### PR TITLE
When we build wmcore, we strip out test testing tree. This leaves things 

### DIFF
--- a/src/python/WMCore/WMBase.py
+++ b/src/python/WMCore/WMBase.py
@@ -18,3 +18,11 @@ def getWMBASE():
     else:
         return os.path.normpath(os.path.join(os.path.dirname(__file__), '..'))        
 
+def getWMTESTBASE():
+    """ returns the root of WMCore test tree """
+    import WMCore_t
+    if WMCore_t.__file__.find("test/python") != -1:
+        return os.path.normpath(os.path.join(os.path.dirname(WMCore_t.__file__), '..', '..','..'))
+    else:
+        return os.path.normpath(os.path.join(os.path.dirname(WMCore_t.__file__), '..'))        
+

--- a/src/python/WMCore/WMInit.py
+++ b/src/python/WMCore/WMInit.py
@@ -17,7 +17,7 @@ from WMCore.Database.DBFactory import DBFactory
 from WMCore.Database.Transaction import Transaction
 from WMCore.WMFactory import WMFactory
 from WMCore.Configuration import loadConfigurationFile
-from WMCore.WMBase import getWMBASE
+from WMCore.WMBase import getWMBASE, getWMTESTBASE
 
 import os.path
 import sys

--- a/test/python/WMComponent_t/DashboardReporter_t/DashboardReporter_t.py
+++ b/test/python/WMComponent_t/DashboardReporter_t/DashboardReporter_t.py
@@ -227,7 +227,7 @@ class DashboardReporterTest(unittest.TestCase):
         jobGroup = self.createTestJobGroup()
         config   = self.getConfig()
 
-        xmlPath = os.path.join(WMCore.WMInit.getWMBASE(),
+        xmlPath = os.path.join(WMCore.WMInit.getWMTESTBASE(),
                                "test/python/WMCore_t/FwkJobReport_t/PerformanceReport.xml")
         myReport = Report("cmsRun1")
         myReport.parse(xmlPath)

--- a/test/python/WMComponent_t/FeederManager_t/FeederManager_t.py
+++ b/test/python/WMComponent_t/FeederManager_t/FeederManager_t.py
@@ -58,7 +58,7 @@ class FeederManagerTest(unittest.TestCase):
         Get defaults FeederManager parameters
         """
         return self.testInit.getConfiguration(
-                    os.path.join(WMCore.WMInit.getWMBASE(), \
+                    os.path.join(WMCore.WMInit.getWMTESTBASE(), \
             'src/python/WMComponent/FeederManager/DefaultConfig.py'))
 
 

--- a/test/python/WMComponent_t/JobAccountant_t/JobAccountant_t.py
+++ b/test/python/WMComponent_t/JobAccountant_t/JobAccountant_t.py
@@ -154,7 +154,7 @@ class JobAccountantTest(unittest.TestCase):
         testJob["state"] = "complete"
         self.stateChangeAction.execute(jobs = [testJob])
 
-        fwjrPath = os.path.join(WMCore.WMInit.getWMBASE(),
+        fwjrPath = os.path.join(WMCore.WMInit.getWMTESTBASE(),
                                 "test/python/WMComponent_t/JobAccountant_t/fwjrs", fwjrName)
         self.setFWJRAction.execute(jobID = testJob["id"], fwjrPath = fwjrPath)
         return
@@ -318,7 +318,7 @@ class JobAccountantTest(unittest.TestCase):
                                        conn = myThread.transaction.conn,
                                        transaction = True)
 
-        fwjrBasePath = WMCore.WMInit.getWMBASE() + "/test/python/WMComponent_t/JobAccountant_t/fwjrs/"
+        fwjrBasePath = WMCore.WMInit.getWMTESTBASE() + "/test/python/WMComponent_t/JobAccountant_t/fwjrs/"
         self.setFWJRAction.execute(jobID = self.testJobA["id"],
                                    fwjrPath = fwjrBasePath + "SplitSuccessA.pkl",
                                    conn = myThread.transaction.conn,
@@ -578,7 +578,7 @@ class JobAccountantTest(unittest.TestCase):
         accountant.setup()
         accountant.algorithm()
 
-        fwjrBasePath = WMCore.WMInit.getWMBASE() + "/test/python/WMComponent_t/JobAccountant_t/fwjrs/"
+        fwjrBasePath = WMCore.WMInit.getWMTESTBASE() + "/test/python/WMComponent_t/JobAccountant_t/fwjrs/"
         jobReport = Report()
         jobReport.unpersist(fwjrBasePath + "SplitSuccessA.pkl")
         self.verifyFileMetaData(self.testJobA["id"], jobReport.getAllFilesFromStep("cmsRun1"), site = "srm-cms.cern.ch")
@@ -740,7 +740,7 @@ class JobAccountantTest(unittest.TestCase):
         self.stateChangeAction.execute(jobs = [self.testJob])
 
         self.setFWJRAction.execute(self.testJob["id"],
-                                   os.path.join(WMCore.WMInit.getWMBASE(),
+                                   os.path.join(WMCore.WMInit.getWMTESTBASE(),
                                                 "test/python/WMComponent_t/JobAccountant_t/fwjrs",
                                                 "MergedSkimSuccess.pkl"))
         return
@@ -760,7 +760,7 @@ class JobAccountantTest(unittest.TestCase):
         accountant.algorithm()
 
         jobReport = Report()
-        jobReport.unpersist(os.path.join(WMCore.WMInit.getWMBASE(),
+        jobReport.unpersist(os.path.join(WMCore.WMInit.getWMTESTBASE(),
                                          "test/python/WMComponent_t/JobAccountant_t/fwjrs",
                                          "MergedSkimSuccess.pkl"))
         self.verifyFileMetaData(self.testJob["id"], jobReport.getAllFilesFromStep("cmsRun1"), site = "srm-cms.cern.ch")
@@ -912,12 +912,12 @@ class JobAccountantTest(unittest.TestCase):
 
         if noLumi:
             self.setFWJRAction.execute(jobID = self.testJob["id"],
-                                       fwjrPath = os.path.join(WMCore.WMInit.getWMBASE(),
+                                       fwjrPath = os.path.join(WMCore.WMInit.getWMTESTBASE(),
                                                                "test/python/WMComponent_t/JobAccountant_t/fwjrs",
                                                                "MergeSuccessNoLumi.pkl"))
         else:
             self.setFWJRAction.execute(jobID = self.testJob["id"],
-                                       fwjrPath = os.path.join(WMCore.WMInit.getWMBASE(),
+                                       fwjrPath = os.path.join(WMCore.WMInit.getWMTESTBASE(),
                                                                "test/python/WMComponent_t/JobAccountant_t/fwjrs",
                                                                "MergeSuccess.pkl"))            
         return
@@ -936,7 +936,7 @@ class JobAccountantTest(unittest.TestCase):
         accountant.algorithm()
 
         jobReport = Report()
-        jobReport.unpersist(os.path.join(WMCore.WMInit.getWMBASE(),
+        jobReport.unpersist(os.path.join(WMCore.WMInit.getWMTESTBASE(),
                                          "test/python/WMComponent_t/JobAccountant_t/fwjrs",
                                          "MergeSuccess.pkl"))
         self.verifyFileMetaData(self.testJob["id"], jobReport.getAllFilesFromStep("cmsRun1"))
@@ -982,7 +982,7 @@ class JobAccountantTest(unittest.TestCase):
         accountant.algorithm()
 
         jobReport = Report()
-        jobReport.unpersist(os.path.join(WMCore.WMInit.getWMBASE(),
+        jobReport.unpersist(os.path.join(WMCore.WMInit.getWMTESTBASE(),
                                          "test/python/WMComponent_t/JobAccountant_t/fwjrs",
                                          "MergeSuccessNoLumi.pkl"))
         self.verifyFileMetaData(self.testJob["id"], jobReport.getAllFilesFromStep("cmsRun1"))
@@ -1028,7 +1028,7 @@ class JobAccountantTest(unittest.TestCase):
         accountant.algorithm()
 
         jobReport = Report()
-        jobReport.unpersist(os.path.join(WMCore.WMInit.getWMBASE(),
+        jobReport.unpersist(os.path.join(WMCore.WMInit.getWMTESTBASE(),
                                          "test/python/WMComponent_t/JobAccountant_t/fwjrs",
                                          "MergeSuccess.pkl"))
         self.verifyFileMetaData(self.testJob["id"], jobReport.getAllFilesFromStep("cmsRun1"))
@@ -1072,7 +1072,7 @@ class JobAccountantTest(unittest.TestCase):
         accountant.algorithm()
 
         jobReport = Report()
-        jobReport.unpersist(os.path.join(WMCore.WMInit.getWMBASE(),
+        jobReport.unpersist(os.path.join(WMCore.WMInit.getWMTESTBASE(),
                                          "test/python/WMComponent_t/JobAccountant_t/fwjrs",
                                          "MergeSuccessNoFiles.pkl"))
         self.verifyJobSuccess(self.testJob["id"])
@@ -1147,7 +1147,7 @@ class JobAccountantTest(unittest.TestCase):
             testJob.addFile(newFile)
             testJob.associateFiles()
 
-            fwjrPath = os.path.join(WMCore.WMInit.getWMBASE(),
+            fwjrPath = os.path.join(WMCore.WMInit.getWMTESTBASE(),
                                     "test/python/WMComponent_t/JobAccountant_t/fwjrs",
                                     "LoadTest%02d.pkl" % i)
             
@@ -1202,7 +1202,7 @@ class JobAccountantTest(unittest.TestCase):
 
         # We just need to make two jobs process the same report so that we get a
         # duplicate LFN error.
-        fwjrPath = os.path.join(WMCore.WMInit.getWMBASE(),
+        fwjrPath = os.path.join(WMCore.WMInit.getWMTESTBASE(),
                                 "test/python/WMComponent_t/JobAccountant_t/fwjrs",
                                 "LoadTest07.pkl")
         self.setFWJRAction.execute(jobID = 10, fwjrPath = fwjrPath)
@@ -1355,7 +1355,7 @@ class JobAccountantTest(unittest.TestCase):
         self.stateChangeAction.execute(jobs = [self.testJob])
 
         self.setFWJRAction.execute(jobID = self.testJob["id"],
-                                   fwjrPath = os.path.join(WMCore.WMInit.getWMBASE(),
+                                   fwjrPath = os.path.join(WMCore.WMInit.getWMTESTBASE(),
                                                 "test/python/WMComponent_t/JobAccountant_t/fwjrs",
                                                 "MergeSuccess.pkl"))
         return
@@ -1376,7 +1376,7 @@ class JobAccountantTest(unittest.TestCase):
         myThread = threading.currentThread()
 
         jobReport = Report()
-        jobReport.unpersist(os.path.join(WMCore.WMInit.getWMBASE(),
+        jobReport.unpersist(os.path.join(WMCore.WMInit.getWMTESTBASE(),
                                          "test/python/WMComponent_t/JobAccountant_t/fwjrs",
                                          "MergeSuccess.pkl"))
         self.verifyFileMetaData(self.testJob["id"], jobReport.getAllFilesFromStep("cmsRun1"))
@@ -1475,7 +1475,7 @@ class JobAccountantTest(unittest.TestCase):
                 testJob.addFile(newFile)
 
             testJob.associateFiles()
-            fwjrPath = os.path.join(WMCore.WMInit.getWMBASE(),
+            fwjrPath = os.path.join(WMCore.WMInit.getWMTESTBASE(),
                                     "test/python/WMComponent_t/JobAccountant_t/fwjrs",
                                     "HeritageTest%02d.pkl" % i)
             
@@ -1612,7 +1612,7 @@ class JobAccountantTest(unittest.TestCase):
         self.stateChangeAction.execute(jobs = [self.testJob])
 
         self.setFWJRAction.execute(self.testJob["id"],
-                                   os.path.join(WMCore.WMInit.getWMBASE(),
+                                   os.path.join(WMCore.WMInit.getWMTESTBASE(),
                                                 "test/python/WMComponent_t/JobAccountant_t/fwjrs",
                                                 "MergedSkimSuccess.pkl"))
         return
@@ -1632,7 +1632,7 @@ class JobAccountantTest(unittest.TestCase):
         accountant.algorithm()
 
         jobReport = Report()
-        jobReport.unpersist(os.path.join(WMCore.WMInit.getWMBASE(),
+        jobReport.unpersist(os.path.join(WMCore.WMInit.getWMTESTBASE(),
                                          "test/python/WMComponent_t/JobAccountant_t/fwjrs",
                                          "MergedSkimSuccess.pkl"))
         self.verifyFileMetaData(self.testJob["id"], jobReport.getAllFilesFromStep("cmsRun1"), site = "srm-cms.cern.ch")

--- a/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
+++ b/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
@@ -25,7 +25,7 @@ import WMCore.WMInit
 #from WMQuality.TestInit import TestInit
 from WMQuality.TestInitCouchApp import TestInitCouchApp as TestInit
 from WMCore.DAOFactory          import DAOFactory
-from WMCore.WMInit              import getWMBASE
+from WMCore.WMInit              import getWMTESTBASE
 
 from WMCore.WMBS.File         import File
 from WMCore.WMBS.Fileset      import Fileset
@@ -309,7 +309,7 @@ class JobSubmitterTest(unittest.TestCase):
         return testJob, testFile
         
 
-    def getConfig(self, configPath = os.path.join(WMCore.WMInit.getWMBASE(), 'src/python/WMComponent/JobSubmitter/DefaultConfig.py')):
+    def getConfig(self, configPath = os.path.join(WMCore.WMInit.getWMTESTBASE(), 'src/python/WMComponent/JobSubmitter/DefaultConfig.py')):
         """
         _getConfig_
 
@@ -349,13 +349,13 @@ class JobSubmitterTest(unittest.TestCase):
         config.JobSubmitter.pluginName    = 'CondorGlobusPlugin'
         config.JobSubmitter.pluginDir     = 'JobSubmitter.Plugins'
         config.JobSubmitter.submitNode    = os.getenv("HOSTNAME", 'badtest.fnal.gov')
-        config.JobSubmitter.submitScript  = os.path.join(WMCore.WMInit.getWMBASE(),
+        config.JobSubmitter.submitScript  = os.path.join(WMCore.WMInit.getWMTESTBASE(),
                                                          'test/python/WMComponent_t/JobSubmitter_t',
                                                          'submit.sh')
         config.JobSubmitter.componentDir  = os.path.join(self.testDir, 'Components')
         config.JobSubmitter.workerThreads = 2
         config.JobSubmitter.jobsPerWorker = 200
-        config.JobSubmitter.inputFile     = os.path.join(WMCore.WMInit.getWMBASE(),
+        config.JobSubmitter.inputFile     = os.path.join(WMCore.WMInit.getWMTESTBASE(),
                                                          'test/python/WMComponent_t/JobSubmitter_t',
                                                          'FrameworkJobReport-4540.xml')
         config.JobSubmitter.deleteJDLFiles = False
@@ -420,7 +420,7 @@ class JobSubmitterTest(unittest.TestCase):
             
             inputFileString = '%s, %s, %s' % (os.path.join(self.testDir, 'workloadTest/TestWorkload', 'TestWorkload-Sandbox.tar.bz2'),
                                               os.path.join(self.testDir, 'workloadTest/TestWorkload', 'batch_%i-0/JobPackage.pkl' % (batch)),
-                                              os.path.join(WMCore.WMInit.getWMBASE(), 'src/python/WMCore', 'WMRuntime/Unpacker.py'))
+                                              os.path.join(WMCore.WMInit.getWMTESTBASE(), 'src/python/WMCore', 'WMRuntime/Unpacker.py'))
             if not noIndex:
                 self.assertEqual(job.get('transfer_input_files', None),
                                  inputFileString)

--- a/test/python/WMComponent_t/JobTracker_t/JobTracker_t.py
+++ b/test/python/WMComponent_t/JobTracker_t/JobTracker_t.py
@@ -216,7 +216,7 @@ class JobTrackerTest(unittest.TestCase):
         config.JobSubmitter.submitDir     = os.path.join(self.testDir, 'submit')
         config.JobSubmitter.submitNode    = os.getenv("HOSTNAME", 'badtest.fnal.gov')
         #config.JobSubmitter.submitScript  = os.path.join(os.getcwd(), 'submit.sh')
-        config.JobSubmitter.submitScript  = os.path.join(WMCore.WMInit.getWMBASE(),
+        config.JobSubmitter.submitScript  = os.path.join(WMCore.WMInit.getWMTESTBASE(),
                                                          'test/python/WMComponent_t/JobSubmitter_t',
                                                          'submit.sh')
         config.JobSubmitter.componentDir  = os.path.join(os.getcwd(), 'Components')

--- a/test/python/WMComponent_t/RetryManager_t/RetryManager_t.py
+++ b/test/python/WMComponent_t/RetryManager_t/RetryManager_t.py
@@ -95,7 +95,7 @@ class RetryManagerTest(unittest.TestCase):
         # Path to plugin directory
         config.RetryManager.pluginPath   = 'WMComponent.RetryManager.PlugIns'
         #config.RetryManager.pluginName   = ''
-        config.RetryManager.WMCoreBase   = WMCore.WMInit.getWMBASE()
+        config.RetryManager.WMCoreBase   = WMCore.WMInit.getWMTESTBASE()
         config.RetryManager.componentDir = os.path.join(os.getcwd(), 'Components')
 
 

--- a/test/python/WMComponent_t/TaskArchiver_t/TaskArchiver_t.py
+++ b/test/python/WMComponent_t/TaskArchiver_t/TaskArchiver_t.py
@@ -224,14 +224,14 @@ class TaskArchiverTest(unittest.TestCase):
         report1 = Report()
         report2 = Report()
         if error:
-            path1 = os.path.join(WMCore.WMInit.getWMBASE(),
+            path1 = os.path.join(WMCore.WMInit.getWMTESTBASE(),
                                  "test/python/WMComponent_t/JobAccountant_t/fwjrs", "badBackfillJobReport.pkl")
             path2 = path1
         else:
-            path1 = os.path.join(WMCore.WMInit.getWMBASE(),
+            path1 = os.path.join(WMCore.WMInit.getWMTESTBASE(),
                                  'test/python/WMComponent_t/TaskArchiver_t/fwjrs',
                                  'mergeReport1.pkl')
-            path2 = os.path.join(WMCore.WMInit.getWMBASE(),
+            path2 = os.path.join(WMCore.WMInit.getWMTESTBASE(),
                                  'test/python/WMComponent_t/TaskArchiver_t/fwjrs',
                                  'mergeReport2.pkl')
         report1.load(filename = path1)

--- a/test/python/WMComponent_t/WorkQueueManager_t/WorkQueueManager_t.py
+++ b/test/python/WMComponent_t/WorkQueueManager_t/WorkQueueManager_t.py
@@ -60,7 +60,7 @@ class WorkQueueManagerTest(WorkQueueTestCase):
 
         General config file
         """
-        #configPath=os.path.join(WMCore.WMInit.getWMBASE(), \
+        #configPath=os.path.join(WMCore.WMInit.getWMTESTBASE(), \
         #                        'src/python/WMComponent/WorkQueueManager/DefaultConfig.py')):
 
 

--- a/test/python/WMComponent_t/WorkflowManager_t/WorkflowManager_t.py
+++ b/test/python/WMComponent_t/WorkflowManager_t/WorkflowManager_t.py
@@ -66,7 +66,7 @@ class WorkflowManagerTest(unittest.TestCase):
         """
 
         return self.testInit.getConfiguration(
-                    os.path.join(WMCore.WMInit.getWMBASE(), \
+                    os.path.join(WMCore.WMInit.getWMTESTBASE(), \
            'src/python/WMComponent/WorkflowManager/DefaultConfig.py'))
 
 

--- a/test/python/WMCore_t/WMBase_t.py
+++ b/test/python/WMCore_t/WMBase_t.py
@@ -9,7 +9,7 @@ Copyright (c) 2011 Fermilab. All rights reserved.
 
 import unittest
 
-from WMCore.WMBase import getWMBASE
+from WMCore.WMBase import getWMBASE, getWMTESTBASE
 
 class WMBaseTest(unittest.TestCase):
 
@@ -20,6 +20,14 @@ class WMBaseTest(unittest.TestCase):
             getWMBASE()
         except Exception, ex:
             self.fail("Failed to call getWMBASE")
+
+    def testB(self):
+        
+        try:
+            print "test base is %s" % getWMTESTBASE()
+        except Exception, ex:
+            self.fail("Failed to call getWMTESTBASE")
+
 
     
 if __name__ == '__main__':


### PR DESCRIPTION
When we build wmcore, we strip out test testing tree. This leaves things that try to pull supplemental files (like FJR, default configs) in a weird state because they look at site-packages (where WMCore is installed) and not in the test tree. This adds a new funciont, getWMTESTBASE(), which points to the testing tree, to make unittests work again)
