### PR TITLE
Distributed filesystems are awesome

### DIFF
--- a/src/python/WMCore/Storage/Backends/FNALImpl.py
+++ b/src/python/WMCore/Storage/Backends/FNALImpl.py
@@ -255,7 +255,7 @@ fi
                 result += " %s " % options
             result += " %s " % sourcePFN
             result += " %s " % targetPFN
-            result += "; sync; DEST_SIZE=`/bin/ls -l %s | /bin/awk '{print $5}'` ; if [ $DEST_SIZE ] && [ '%s' == $DEST_SIZE ]; then exit 0; else echo \"Error: Size Mismatch between local and SE\"; exit 60311 ; fi " % (targetPFN,original_size)
+            result += "&& sync && DEST_SIZE=`/bin/ls -l %s | /bin/awk '{print $5}'` && if [ $DEST_SIZE ] && [ '%s' == $DEST_SIZE ]; then exit 0; else echo \"Error: Size Mismatch between local and SE\"; exit 60311 ; fi " % (targetPFN,original_size)
             return result
 
 


### PR DESCRIPTION
I think Lustre might be failing in a way where /bin/cp exits with non-zero status, but a /bin/ls gives the correct file size.  (The file actually fails halfway through a copy and is truncated, but the local node doesn't know that yet).

By replacing ; with &&, a non-zero exit status will propagate.
