### PR TITLE
rewrite SiblingSubscriptionsComplete DAO

### DIFF
--- a/src/python/WMCore/JobSplitting/SiblingProcessingBased.py
+++ b/src/python/WMCore/JobSplitting/SiblingProcessingBased.py
@@ -34,7 +34,6 @@ class SiblingProcessingBased(JobFactory):
         
         fileAvail = daoFactory(classname = "Subscriptions.SiblingSubscriptionsComplete")
         completeFiles = fileAvail.execute(self.subscription["id"],
-                                          self.subscription["fileset"].id,
                                           conn = myThread.transaction.conn,
                                           transaction = True)
 

--- a/src/python/WMCore/WMBS/MySQL/Subscriptions/SiblingSubscriptionsComplete.py
+++ b/src/python/WMCore/WMBS/MySQL/Subscriptions/SiblingSubscriptionsComplete.py
@@ -8,36 +8,44 @@ MySQL implementation of Subscription.SiblingSubscriptionsComplete
 from WMCore.Database.DBFormatter import DBFormatter
 
 class SiblingSubscriptionsComplete(DBFormatter):
-    # For each file in the input fileset count the number of subscriptions that
-    # have completed the file.  If the number of subscriptions that have
-    # completed the file is the same as the number of subscriptions that
-    # processed the file (not counting this subscription) we can say that
-    # processing of the file is complete and we can preform some other
-    # action on it (usually deletion).
-    sql = """SELECT wmbs_file_details.id, wmbs_file_details.events,
-                    wmbs_file_details.lfn, wls.se_name
-                    FROM wmbs_sub_files_available
-               INNER JOIN wmbs_file_details ON
-                 wmbs_sub_files_available.fileid = wmbs_file_details.id
-               INNER JOIN
-                 (SELECT wmbs_sub_files_complete.fileid AS fileid, COUNT(fileid) AS complete_files
-                    FROM wmbs_sub_files_complete
-                    INNER JOIN wmbs_subscription ON
-                      wmbs_sub_files_complete.subscription = wmbs_subscription.id AND
-                      wmbs_subscription.fileset = :fileset
-                  GROUP BY wmbs_sub_files_complete.fileid) complete_files ON
-                 wmbs_file_details.id = complete_files.fileid
-               INNER JOIN wmbs_file_location ON
-                 wmbs_file_details.id = wmbs_file_location.fileid
-               INNER JOIN wmbs_location_senames wls ON
-                 wmbs_file_location.location = wls.location
-             WHERE complete_files.complete_files =
-               (SELECT COUNT(*) FROM wmbs_subscription
-                WHERE wmbs_subscription.id != :subscription AND
-                      wmbs_subscription.fileset = :fileset)"""
+    """
+    For each file in the input fileset count the number of subscriptions that
+    have completed the file.  If the number of subscriptions that have
+    completed the file is the same as the number of subscriptions that
+    processed the file (not counting this subscription) we can say that
+    processing of the file is complete and we can preform some other
+    action on it (usually deletion).
 
-    def execute(self, subscription, fileset, conn = None, transaction = False):
-        results = self.dbi.processData(self.sql, {"subscription": subscription,
-                                             "fileset": fileset},
+    """
+    sql = """SELECT wmbs_file_details.id,
+                    wmbs_file_details.events,
+                    wmbs_file_details.lfn,
+                    wmbs_location_senames.se_name
+             FROM (
+               SELECT wmbs_sub_files_available.fileid
+               FROM wmbs_sub_files_available
+                 INNER JOIN wmbs_fileset_files ON
+                   wmbs_fileset_files.fileid = wmbs_sub_files_available.fileid
+                 LEFT OUTER JOIN wmbs_subscription ON
+                   wmbs_subscription.fileset = wmbs_fileset_files.fileset AND
+                   wmbs_subscription.id != :subscription
+                 LEFT OUTER JOIN wmbs_sub_files_complete ON
+                   wmbs_sub_files_complete.fileid = wmbs_sub_files_available.fileid AND
+                   wmbs_sub_files_complete.subscription = wmbs_subscription.id AND
+                   wmbs_sub_files_complete.subscription != :subscription
+               GROUP BY wmbs_sub_files_available.fileid
+               HAVING COUNT(wmbs_subscription.id) = COUNT(wmbs_sub_files_complete.fileid)
+             ) available_files
+             INNER JOIN wmbs_file_details ON
+               wmbs_file_details.id = available_files.fileid
+             INNER JOIN wmbs_file_location ON
+               wmbs_file_location.fileid = available_files.fileid
+             INNER JOIN wmbs_location_senames ON
+               wmbs_location_senames.location = wmbs_file_location.location
+             """
+
+    def execute(self, subscription, conn = None, transaction = False):
+
+        results = self.dbi.processData(self.sql, { 'subscription' : subscription },
                                        conn = conn, transaction = transaction)
         return self.formatDict(results)

--- a/src/python/WMCore/WMBS/Oracle/Subscriptions/SiblingSubscriptionsComplete.py
+++ b/src/python/WMCore/WMBS/Oracle/Subscriptions/SiblingSubscriptionsComplete.py
@@ -9,26 +9,4 @@ from WMCore.WMBS.MySQL.Subscriptions.SiblingSubscriptionsComplete import \
     SiblingSubscriptionsComplete as SiblingCompleteMySQL    
 
 class SiblingSubscriptionsComplete(SiblingCompleteMySQL):
-    sql = """SELECT wmbs_file_details.id, wmbs_file_details.events,
-                    wmbs_file_details.lfn, wmbs_location_senames.se_name
-                    FROM wmbs_sub_files_available
-               INNER JOIN wmbs_file_details ON
-                 wmbs_sub_files_available.fileid = wmbs_file_details.id
-               INNER JOIN
-                 (SELECT wmbs_sub_files_complete.fileid AS fileid, COUNT(fileid) AS complete_files
-                    FROM wmbs_sub_files_complete
-                    INNER JOIN wmbs_subscription ON
-                      wmbs_sub_files_complete.subscription = wmbs_subscription.id AND
-                      wmbs_subscription.fileset = :fileset
-                  GROUP BY wmbs_sub_files_complete.fileid) complete_files ON
-                 wmbs_file_details.id = complete_files.fileid
-               INNER JOIN wmbs_file_location ON
-                 wmbs_file_details.id = wmbs_file_location.fileid
-               INNER JOIN wmbs_location ON
-                 wmbs_file_location.location = wmbs_location.id
-               INNER JOIN wmbs_location_senames ON
-                 wmbs_location_senames.location = wmbs_location.id
-             WHERE complete_files.complete_files =
-               (SELECT COUNT(*) FROM wmbs_subscription
-                WHERE wmbs_subscription.id != :subscription AND
-                      wmbs_subscription.fileset = :fileset)"""
+    pass

--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -182,6 +182,11 @@ class SetupCMSSWPset(ScriptInterface):
         
         """
         if funcName == "merge":
+
+            baggage = self.job.getBaggage()
+            if getattr(baggage, "useErrorDataset", False):
+                funcArgs['outputmod_label'] = "MergedError"
+
             try:
                 from Configuration.DataProcessing.Merge import mergeProcess
                 self.process = mergeProcess(**funcArgs)

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/SiblingProcessingBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/SiblingProcessingBased_t.py
@@ -336,7 +336,7 @@ class SiblingProcessingBasedTest(unittest.TestCase):
         allFiles = []
         for i in range(500):
             testFile = File(str(i), size = 1000, events = 100,
-                            locations = set(["somese.cern.ch"]))
+                                  locations = set(["somese.cern.ch"]))
             testFile.create()
             allFiles.append(testFile)
             testFileset.addFile(testFile)
@@ -364,50 +364,7 @@ class SiblingProcessingBasedTest(unittest.TestCase):
                          "Error: Wrong number of job groups returned.")
         self.assertEqual(len(result[0].jobs), 10,
                          "Error: Wrong number of jobs returned.")
-
+                             
         return
-
-    def testFilesWithoutOtherSubscriptions(self):
-        """
-        _testFilesWithoutOtherSubscriptions_
-
-        Test the case where files only in the delete subscription
-        can happen if cleanup of the other subscriptions is fast
-
-        """
-        testWorkflowA = Workflow(spec = "specA.xml", owner = "Steve",
-                                 name = "wfA", task = "Test")
-        testWorkflowA.create()
-
-        testFileset = Fileset(name = "TestFileset")
-        testFileset.create()
-
-        allFiles = []
-        for i in range(500):
-            testFile = File(str(i), size = 1000, events = 100,
-                            locations = set(["somese.cern.ch"]))
-            testFile.create()
-            allFiles.append(testFile)
-            testFileset.addFile(testFile)
-        testFileset.commit()            
-
-        testSubscriptionA = Subscription(fileset = testFileset,
-                                         workflow = testWorkflowA,
-                                         split_algo = "SiblingProcessingBased",
-                                         type = "Processing")
-        testSubscriptionA.create()
-
-        splitter = SplitterFactory()
-        deleteFactoryA = splitter(package = "WMCore.WMBS",
-                                  subscription = testSubscriptionA)
-
-        result = deleteFactoryA(files_per_job = 50)
-        self.assertEqual(len(result), 1,
-                         "Error: Wrong number of job groups returned.")
-        self.assertEqual(len(result[0].jobs), 10,
-                         "Error: Wrong number of jobs returned.")
-
-        return
-
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/SiblingProcessingBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/SiblingProcessingBased_t.py
@@ -336,7 +336,7 @@ class SiblingProcessingBasedTest(unittest.TestCase):
         allFiles = []
         for i in range(500):
             testFile = File(str(i), size = 1000, events = 100,
-                                  locations = set(["somese.cern.ch"]))
+                            locations = set(["somese.cern.ch"]))
             testFile.create()
             allFiles.append(testFile)
             testFileset.addFile(testFile)
@@ -364,7 +364,50 @@ class SiblingProcessingBasedTest(unittest.TestCase):
                          "Error: Wrong number of job groups returned.")
         self.assertEqual(len(result[0].jobs), 10,
                          "Error: Wrong number of jobs returned.")
-                             
+
         return
+
+    def testFilesWithoutOtherSubscriptions(self):
+        """
+        _testFilesWithoutOtherSubscriptions_
+
+        Test the case where files only in the delete subscription
+        can happen if cleanup of the other subscriptions is fast
+
+        """
+        testWorkflowA = Workflow(spec = "specA.xml", owner = "Steve",
+                                 name = "wfA", task = "Test")
+        testWorkflowA.create()
+
+        testFileset = Fileset(name = "TestFileset")
+        testFileset.create()
+
+        allFiles = []
+        for i in range(500):
+            testFile = File(str(i), size = 1000, events = 100,
+                            locations = set(["somese.cern.ch"]))
+            testFile.create()
+            allFiles.append(testFile)
+            testFileset.addFile(testFile)
+        testFileset.commit()            
+
+        testSubscriptionA = Subscription(fileset = testFileset,
+                                         workflow = testWorkflowA,
+                                         split_algo = "SiblingProcessingBased",
+                                         type = "Processing")
+        testSubscriptionA.create()
+
+        splitter = SplitterFactory()
+        deleteFactoryA = splitter(package = "WMCore.WMBS",
+                                  subscription = testSubscriptionA)
+
+        result = deleteFactoryA(files_per_job = 50)
+        self.assertEqual(len(result), 1,
+                         "Error: Wrong number of job groups returned.")
+        self.assertEqual(len(result[0].jobs), 10,
+                         "Error: Wrong number of jobs returned.")
+
+        return
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Data discovery query was broken on Oracle, inefficient on MySQL and didn't cover the "no other subscription on the file" use case. Also reworked the interface to the DAO to only pass the subscription (passing the fileset as well is redundant).
