### PR TITLE
Harvest optional proxy

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -164,7 +164,7 @@ class PromptRecoWorkloadFactory(StdBase):
                 recoMergeTasks[recoOutInfo['dataTier']] = mergeTask
 	    	if recoOutInfo['dataTier'] in [ "DQM", "DQMROOT" ]:
 			self.addDQMHarvestTask(mergeTask, "Merged",
-			#uploadProxy = self.dqmUploadProxy,
+			uploadProxy = self.dqmUploadProxy,
 			doLogCollect = False)
 
             else:
@@ -254,6 +254,7 @@ class PromptRecoWorkloadFactory(StdBase):
         self.couchURL = arguments['CouchURL']
         self.couchDBName = arguments['CouchDBName']
         self.initCommand = arguments['InitCommand']
+        self.dqmUploadProxy = arguments['DQMUploadProxy']
 
 
         if arguments.has_key('Multicore'):

--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -162,6 +162,10 @@ class PromptRecoWorkloadFactory(StdBase):
                                     self.procJobSplitAlgo,
                                     recoOutLabel)
                 recoMergeTasks[recoOutInfo['dataTier']] = mergeTask
+	    	if recoOutInfo['dataTier'] in [ "DQM", "DQMROOT" ]:
+			self.addDQMHarvestTask(mergeTask, "Merged",
+			#uploadProxy = self.dqmUploadProxy,
+			doLogCollect = False)
 
             else:
                 alcaTask = recoTask.addTask("AlcaSkim")

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -589,7 +589,7 @@ class StdBase(object):
         return
 
     def addDQMHarvestTask(self, parentTask, parentOutputModuleName,
-                          uploadProxy, periodic_harvest_interval = 0,
+                          uploadProxy = None, periodic_harvest_interval = 0,
                           parentStepName = "cmsRun1", doLogCollect = True):
         """
         _addDQMHarvestTask_
@@ -647,9 +647,9 @@ class StdBase(object):
                                                                                         getattr(parentOutputModule, "processedDataset"),
                                                                                         getattr(parentOutputModule, "dataTier")),
                                                            runNumber = self.runNumber)
-
-        harvestTaskUploadHelper = harvestTaskUpload.getTypeHelper()
-        harvestTaskUploadHelper.setProxyFile(uploadProxy)
+        if uploadProxy: 
+            harvestTaskUploadHelper = harvestTaskUpload.getTypeHelper()
+            harvestTaskUploadHelper.setProxyFile(uploadProxy)
 
         return
 


### PR DESCRIPTION
For some reason this change didn't went in the original patches, I would say it's needed as not all harvest tasks will count on a proxy coming from the configuration.
