### PR TITLE
Set defaults for some assign fields

### DIFF
--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
@@ -246,12 +246,12 @@ class Assign(WebAPI):
         helper.setAcquisitionEra(kwargs["AcquisitionEra"])
         #FIXME not validated
         helper.setLFNBase(kwargs["MergedLFNBase"], kwargs["UnmergedLFNBase"])
-        helper.setMergeParameters(int(kwargs["MinMergeSize"]),
-                                  int(kwargs["MaxMergeSize"]), 
-                                  int(kwargs["MaxMergeEvents"]))
-        helper.setupPerformanceMonitoring(int(kwargs["maxRSS"]), 
-                                          int(kwargs["maxVSize"]),
-                                          int(kwargs["SoftTimeout"]),
+        helper.setMergeParameters(int(kwargs.get("MinMergeSize", 2147483648)),
+                                  int(kwargs.get("MaxMergeSize", 4294967296)),
+                                  int(kwargs.get("MaxMergeEvents", 50000)))
+        helper.setupPerformanceMonitoring(int(kwargs.get("maxRSS", 2411724)),
+                                          int(kwargs.get("maxVSize", 2411724)),
+                                          int(kwargs.get("SoftTimeout", 171600)),
                                           int(kwargs.get("GracePeriod", 300)))
         helper.setDashboardActivity(kwargs.get("dashboard", ""))
         Utilities.saveWorkload(helper, request['RequestWorkflow'], self.wmstatWriteURL)

--- a/src/python/WMCore/Services/Dashboard/DashboardReporter.py
+++ b/src/python/WMCore/Services/Dashboard/DashboardReporter.py
@@ -340,7 +340,6 @@ class DashboardReporter(WMObject):
         Add a task to the Dashboard, jobs must contain the following information
         about the task:
             application -> CMSSW release
-            nevtJob -> Number of events per job
             tool -> JobSubmission tool (like Condor? or WMAgent)
             JSToolVersion -> 'tool' version
             TaskType -> Type of activity
@@ -351,7 +350,6 @@ class DashboardReporter(WMObject):
         package = {}
         package['MessageType']   = 'TaskMeta'
         package['application']   = task['application']
-        package['nevtJob']       = task['nevtJob']
         package['tool']          = 'WMAgent'
         package['JSToolVersion'] = __version__
         package['TaskType']      = task['TaskType']


### PR DESCRIPTION
Set defaults for non-critical assign fields, these are the same defaults as those displayed in the web interface and comply with CMS policy on node protection.
