### PR TITLE
Integrate DQM harvesting in the WMAgent workflows

### DIFF
--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -357,7 +357,8 @@ class JobSubmitterPoller(BaseWorkerThread):
                        frozenset(possibleLocations),
                        loadedJob.get("scramArch", None),
                        loadedJob.get("swVersion", None),
-                       loadedJob["name"])
+                       loadedJob["name"],
+                       loadedJob.get("proxyPath", None))
             
             self.jobDataCache[workflowName][jobID] = jobInfo
 
@@ -604,7 +605,8 @@ class JobSubmitterPoller(BaseWorkerThread):
                                'possibleSites': cachedJob[9],
                                'scramArch': cachedJob[10],
                                'swVersion': cachedJob[11],
-                               'name': cachedJob[12]}
+                               'name': cachedJob[12],
+                               'proxyPath': cachedJob[13]}
 
                     # Add to jobsToSubmit
                     jobsToSubmit[package].append(jobDict)

--- a/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
@@ -885,6 +885,9 @@ class CondorPlugin(BasePlugin):
         else:
             jdl.append('+DESIRED_Sites = \"%s\"\n' %(jobCE))
 
+        if job.get('proxyPath', None):
+            jdl.append('x509userproxy = %s\n' % job['proxyPath'])
+
         return jdl
 
     def getCEName(self, jobSite):

--- a/src/python/WMCore/BossAir/RunJob.py
+++ b/src/python/WMCore/BossAir/RunJob.py
@@ -26,7 +26,8 @@ class RunJob(dict):
                  cache_dir = None, status_time = None, packageDir = None,
                  sandbox = None, priority = None, site_cms_name = None,
                  taskType = None, possibleSites = [], sw_version = None,
-                 scram_arch = None, siteName = None, jobName = None ):
+                 scram_arch = None, siteName = None, jobName = None,
+                 proxyPath = None):
         """
         Just make sure you init the dictionary fields.
 
@@ -58,6 +59,7 @@ class RunJob(dict):
         self.setdefault('scramArch', scram_arch)
         self.setdefault('siteName', siteName)
         self.setdefault('name', jobName)
+        self.setdefault('proxyPath', proxyPath)
 
         return
 

--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrBrowser.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrBrowser.py
@@ -153,6 +153,8 @@ class ReqMgrBrowser(WebAPI):
             splitParams["events_per_job"] = int(submittedParams["events_per_job"])
             if submittedParams.has_key("events_per_lumi"):
                 splitParams["events_per_lumi"] = int(submittedParams["events_per_lumi"])
+        elif splittingAlgo == "Harvest":
+            splitParams["periodic_harvest_interval"] = int(submittedParams["periodic_harvest_interval"])
         elif 'Merg' in splittingTask:
             for field in ['min_merge_size', 'max_merge_size', 'max_merge_events']:
                 splitParams[field] = int(submittedParams[field])

--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
@@ -379,7 +379,7 @@ def unidecode(data):
 def validate(schema):
     schema.validate()
     for field in ['RequestName', 'Requestor', 'RequestString',
-        'Campaign', 'Scenario', 'ProcConfigCacheID', 'inputMode',
+        'Campaign', 'ProcScenario', 'ProcConfigCacheID', 'inputMode',
         'CouchDBName', 'Group']:
         value = schema.get(field, '')
         if value and value != '':
@@ -423,14 +423,11 @@ def makeRequest(kwargs, couchUrl, couchDB, wmstatUrl):
     else:
         schema['RequestName'] = "%s_%s_%s" % (schema['Requestor'], currentTime, secondFraction)
     schema["Campaign"] = kwargs.get("Campaign", "")
-    if 'Scenario' in kwargs and 'ProcConfigCacheID' in kwargs:
+    if 'ProcScenario' in kwargs and 'ProcConfigCacheID' in kwargs:
         # Use input mode to delete the unused one
         inputMode = kwargs['inputMode']
-        inputValues = {'scenario':'Scenario',
-                       'couchDB':'ProdConfigCacheID'}
-        for n, v in inputValues.iteritems():
-            if n != inputMode:
-                schema[v] = ""
+        if inputMode == 'scenario':
+            del schema['ProcConfigCacheID']
 
     if kwargs.has_key("InputDataset"):
         schema["InputDatasets"] = [kwargs["InputDataset"]]

--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
@@ -107,6 +107,21 @@ def parseBlockList(l):
 
     return result
 
+def parseDqmSequences(l):
+    """ Changes a string into a list of strings """
+    result = None
+    if isinstance(l, list):
+       result = l
+    elif isinstance(l, basestring):
+        toks = l.lstrip(' [').rstrip(' ]').split(',')
+        if toks == ['']:
+            return []
+        # only one set of quotes
+        result = [str(tok.strip(' \'"')) for tok in toks]
+    else:
+        raise cherrypy.HTTPError(400, "Bad DQM sequences list of type " + type(l).__name__)
+    return result
+
 def parseSite(kw, name):
     """ puts site whitelist & blacklists into nice format"""
     value = kw.get(name, [])
@@ -461,6 +476,8 @@ def makeRequest(kwargs, couchUrl, couchDB, wmstatUrl):
     for blocklist in ["BlockWhitelist", "BlockBlacklist"]:
         if blocklist in kwargs:
             schema[blocklist] = parseBlockList(kwargs[blocklist])
+    if "DqmSequences" in kwargs:
+            schema["DqmSequences"] = parseDqmSequences(kwargs["DqmSequences"])
     validate(schema)
 
     # Get the DN

--- a/src/python/WMCore/JobSplitting/Harvest.py
+++ b/src/python/WMCore/JobSplitting/Harvest.py
@@ -4,6 +4,7 @@ _Harvest_
 
 """
 import threading
+import os
 
 from WMCore.JobSplitting.JobFactory import JobFactory
 from WMCore.Services.UUID import makeUUID
@@ -85,6 +86,10 @@ class Harvest(JobFactory):
                 self.newJob(name = "%s-%s-%i" % (baseName, harvestType, jobCount))
                 for f in locationDict[location][run]:
                     self.currentJob.addFile(f)
+
+                #Check for proxy and ship it in the job if available
+                if 'X509_USER_PROXY' in os.environ:
+                    self.currentJob['proxyPath'] = os.environ['X509_USER_PROXY']
 
         return
 

--- a/src/python/WMCore/JobSplitting/LumiBased.py
+++ b/src/python/WMCore/JobSplitting/LumiBased.py
@@ -82,7 +82,7 @@ class LumiBased(JobFactory):
         splitOnFile     = bool(kwargs.get('halt_job_on_file_boundaries', True))
         ignoreACDC      = bool(kwargs.get('ignore_acdc_except', False))
         collectionName  = kwargs.get('collectionName', None)
-        splitOnRun      = kwargs.get('splitOnRun', True)
+        splitOnRun      = kwargs.get('splitOnRun', False)
         getParents      = kwargs.get('include_parents', False)
         runWhitelist    = kwargs.get('runWhitelist', [])
 

--- a/src/python/WMCore/WMBS/MySQL/JobSplitting/ReleasePeriodicJob.py
+++ b/src/python/WMCore/WMBS/MySQL/JobSplitting/ReleasePeriodicJob.py
@@ -27,7 +27,7 @@ class ReleasePeriodicJob(DBFormatter):
                       WHEN COUNT(wmbs_sub_files_acquired.subscription) > 0 THEN 0
                       WHEN COUNT(wmbs_job.id) = 0 THEN 1
                       ELSE 0
-                    END CASE
+                    END
              FROM wmbs_subscription
              INNER JOIN wmbs_sub_files_available ON
                wmbs_sub_files_available.subscription = wmbs_subscription.id

--- a/src/python/WMCore/WMSpec/StdSpecs/DataProcessing.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/DataProcessing.py
@@ -121,11 +121,6 @@ class DataProcessingWorkloadFactory(StdBase):
         # Get the ProcConfigCacheID
         self.procConfigCacheID = arguments.get("ProcConfigCacheID", None)
 
-        if arguments.has_key("Scenario"):
-            self.procScenario = arguments.get("Scenario", None)
-        else:
-            self.procScenario = arguments.get("ProcScenario", None)
-
         # Optional arguments that default to something reasonable.
         self.dbsUrl = arguments.get("DbsUrl", "http://cmsdbsprod.cern.ch/cms_dbs_prod_global/servlet/DBSServlet")
         self.blockBlacklist = arguments.get("BlockBlacklist", [])

--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -162,10 +162,6 @@ class PromptRecoWorkloadFactory(StdBase):
                                     self.procJobSplitAlgo,
                                     recoOutLabel)
                 recoMergeTasks[recoOutInfo['dataTier']] = mergeTask
-	    	if recoOutInfo['dataTier'] in [ "DQM", "DQMROOT" ]:
-			self.addDQMHarvestTask(mergeTask, "Merged",
-			uploadProxy = self.dqmUploadProxy,
-			doLogCollect = False)
 
             else:
                 alcaTask = recoTask.addTask("AlcaSkim")
@@ -245,16 +241,13 @@ class PromptRecoWorkloadFactory(StdBase):
         # Required parameters that must be specified by the Requestor.
         self.frameworkVersion = arguments['CMSSWVersion']
         self.globalTag = arguments['GlobalTag']
-        self.procScenario = arguments['ProcScenario']
         self.writeTiers = arguments['WriteTiers']
         self.alcaSkims = arguments['AlcaSkims']
-        self.dqmSequences = arguments['DqmSequences']
         self.inputDataset = arguments['InputDataset']
         self.promptSkims = arguments['PromptSkims']
         self.couchURL = arguments['CouchURL']
         self.couchDBName = arguments['CouchDBName']
         self.initCommand = arguments['InitCommand']
-        self.dqmUploadProxy = arguments['DQMUploadProxy']
 
 
         if arguments.has_key('Multicore'):

--- a/src/python/WMCore/WMSpec/StdSpecs/ReReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/ReReco.py
@@ -150,7 +150,7 @@ class ReRecoWorkloadFactory(DataProcessingWorkloadFactory):
                                                     couchURL = schema["CouchURL"],
                                                     couchDBName = schema["CouchDBName"],
                                                     getOutputModules = True)
-        elif not schema.get('ProcScenario', None) and not schema.get('Scenario', None):
+        elif not schema.get('ProcScenario', None):
             self.raiseValidationException(msg = "No Scenario or Config in Processing Request!")
 
         try:

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -83,6 +83,11 @@ class StdBase(object):
         self.timePerEvent = 60
         self.memory = 2000
         self.sizePerEvent = 512
+        self.periodicHarvestingInterval = 0
+        self.dqmUploadProxy = None
+        self.dqmUploadUrl = None
+        self.dqmSequences = None
+        self.procScenario = None
         return
 
     def __call__(self, workloadName, arguments):
@@ -122,6 +127,11 @@ class StdBase(object):
         self.timePerEvent = int(arguments.get("TimePerEvent", 60))
         self.memory = int(arguments.get("Memory", 2000))
         self.sizePerEvent = int(arguments.get("SizePerEvent", 512))
+        self.periodicHarvestingInterval = int(arguments.get("PeriodicHarvest", 0))
+        self.dqmUploadProxy = arguments.get("DQMUploadProxy", None)
+        self.dqmUploadUrl = arguments.get("DQMUploadUrl", "https://cmsweb.cern.ch/dqm/dev")
+        self.dqmSequences = arguments.get("DqmSequences", [])
+        self.procScenario = arguments.get("ProcScenario", None)
 
         if arguments.get("IncludeParents", False) == "True":
             self.includeParents = True
@@ -499,7 +509,8 @@ class StdBase(object):
         return logCollectTask
 
     def addMergeTask(self, parentTask, parentTaskSplitting, parentOutputModuleName,
-                     parentStepName = "cmsRun1", doLogCollect = True):
+                     parentStepName = "cmsRun1", doLogCollect = True,
+                     doHarvesting = True):
         """
         _addMergeTask_
 
@@ -542,15 +553,13 @@ class StdBase(object):
         mergeTaskCmsswHelper.setOverrideCatalog(self.overrideCatalog)
 
         if getattr(parentOutputModule, "dataTier") in ["DQM", "DQMROOT"]:
-            # DQM wants everything to be a single file per run, so we'll merge
-            # accordingly.  We'll set the max_wait_time to two weeks as files
-            # tend to be garbage collected after that. Also effectively disable
-            # size thresholds for DQM merges (they do not apply).
+            # DQM wants everything to be a single run per file, so we'll merge
+            # accordingly.
             mergeTask.setSplittingAlgorithm(splitAlgo,
-                                            max_merge_size = 21000000000,
-                                            min_merge_size = 20000000000,
-                                            max_merge_events = 21000000000,
-                                            max_wait_time = 14 * 24 * 3600,
+                                            max_merge_size = self.maxMergeSize,
+                                            min_merge_size = self.minMergeSize,
+                                            max_merge_events = self.maxMergeEvents,
+                                            max_wait_time = self.maxWaitTime,
                                             merge_across_runs = False,
                                             siteWhitelist = self.siteWhitelist,
                                             siteBlacklist = self.siteBlacklist)
@@ -564,7 +573,8 @@ class StdBase(object):
                                             siteBlacklist = self.siteBlacklist)
 
         if getattr(parentOutputModule, "dataTier") == "DQMROOT":
-            mergeTaskCmsswHelper.setDataProcessingConfig("do_not_use", "merge", newDQMIO = True)
+            mergeTaskCmsswHelper.setDataProcessingConfig("do_not_use", "merge",
+                                                         newDQMIO = True)
         else:
             mergeTaskCmsswHelper.setDataProcessingConfig("do_not_use", "merge")
 
@@ -575,6 +585,9 @@ class StdBase(object):
                              forceMerged = True)
 
         self.addCleanupTask(parentTask, parentOutputModuleName)
+        if doHarvesting and getattr(parentOutputModule, "dataTier") in ["DQMROOT", "DQM"]:
+            self.addDQMHarvestTask(mergeTask, "Merged", self.dqmUploadProxy,
+                                   self.periodicHarvestingInterval)
         return mergeTask
 
     def addCleanupTask(self, parentTask, parentOutputModuleName):
@@ -619,7 +632,7 @@ class StdBase(object):
         if doLogCollect:
             self.addLogCollectTask(harvestTask, taskName = "%s%sDQMHarvestLogCollect" % (parentTask.name(), parentOutputModuleName))
 
-        harvestTask.setTaskType("Processing")
+        harvestTask.setTaskType("Harvesting")
         harvestTask.applyTemplates()
         harvestTask.setTaskPriority(self.priority + 5)
 
@@ -648,6 +661,7 @@ class StdBase(object):
                                                                                         getattr(parentOutputModule, "processedDataset"),
                                                                                         getattr(parentOutputModule, "dataTier")),
                                                            runNumber = self.runNumber,
+                                                           dqmSeq = self.dqmSequences,
                                                            newDQMIO = True)
         else:
             harvestTaskCmsswHelper.setDataProcessingConfig(self.procScenario, "dqmHarvesting",
@@ -655,11 +669,12 @@ class StdBase(object):
                                                            datasetName = "/%s/%s/%s" % (getattr(parentOutputModule, "primaryDataset"),
                                                                                         getattr(parentOutputModule, "processedDataset"),
                                                                                         getattr(parentOutputModule, "dataTier")),
-                                                           runNumber = self.runNumber)
-        if uploadProxy: 
-            harvestTaskUploadHelper = harvestTaskUpload.getTypeHelper()
-            harvestTaskUploadHelper.setProxyFile(uploadProxy)
+                                                           runNumber = self.runNumber,
+                                                           dqmSeq = self.dqmSequences)
 
+        harvestTaskUploadHelper = harvestTaskUpload.getTypeHelper()
+        harvestTaskUploadHelper.setProxyFile(uploadProxy)
+        harvestTaskUploadHelper.setServerURL(self.dqmUploadUrl)
         return
 
     def setupPileup(self, task, pileupConfig):
@@ -698,8 +713,16 @@ class StdBase(object):
         put it.
 
         If something breaks, raise a WMSpecFactoryException.  A message
-        in that excpetion will be transferred to an HTTP Error later on.
+        in that exception will be transferred to an HTTP Error later on.
         """
+
+        #Check the workload for harvesting task, if there is a
+        #harvesting task then a self.procScenario must be defined
+        for task in workload.getAllTasks():
+            if task.taskType() == "Harvesting":
+                if not self.procScenario:
+                    self.raiseValidationException(msg = "A DQM harvesting task was found, you must specify a scenario")
+
         return
 
     def factoryWorkloadConstruction(self, workloadName, arguments):

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -552,25 +552,13 @@ class StdBase(object):
         mergeTaskCmsswHelper.setGlobalTag(self.globalTag)
         mergeTaskCmsswHelper.setOverrideCatalog(self.overrideCatalog)
 
-        if getattr(parentOutputModule, "dataTier") in ["DQM", "DQMROOT"]:
-            # DQM wants everything to be a single run per file, so we'll merge
-            # accordingly.
-            mergeTask.setSplittingAlgorithm(splitAlgo,
-                                            max_merge_size = self.maxMergeSize,
-                                            min_merge_size = self.minMergeSize,
-                                            max_merge_events = self.maxMergeEvents,
-                                            max_wait_time = self.maxWaitTime,
-                                            merge_across_runs = False,
-                                            siteWhitelist = self.siteWhitelist,
-                                            siteBlacklist = self.siteBlacklist)
-        else:
-            mergeTask.setSplittingAlgorithm(splitAlgo,
-                                            max_merge_size = self.maxMergeSize,
-                                            min_merge_size = self.minMergeSize,
-                                            max_merge_events = self.maxMergeEvents,
-                                            max_wait_time = self.maxWaitTime,
-                                            siteWhitelist = self.siteWhitelist,
-                                            siteBlacklist = self.siteBlacklist)
+        mergeTask.setSplittingAlgorithm(splitAlgo,
+                                        max_merge_size = self.maxMergeSize,
+                                        min_merge_size = self.minMergeSize,
+                                        max_merge_events = self.maxMergeEvents,
+                                        max_wait_time = self.maxWaitTime,
+                                        siteWhitelist = self.siteWhitelist,
+                                        siteBlacklist = self.siteBlacklist)
 
         if getattr(parentOutputModule, "dataTier") == "DQMROOT":
             mergeTaskCmsswHelper.setDataProcessingConfig("do_not_use", "merge",

--- a/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
@@ -110,11 +110,11 @@ def validateSubTask(task, firstTask = False):
             raise WMSpecFactoryException(msg)
         
     # configuration checks
-    check = task.has_key("Scenario") or task.has_key("ConfigCacheID")
+    check = task.has_key("ProcScenario") or task.has_key("ConfigCacheID")
     if not check:
         msg = "Task %s has no Scenario or ConfigCacheID, one of these must be provided" % task['TaskName']
         raise WMSpecFactoryException(msg)
-    if task.has_key("Scenario"):
+    if task.has_key("ProcScenario"):
         if not task.has_key("ScenarioMethod"):
             msg = "Scenario Specified for Task %s but no ScenarioMethod provided" % task['TaskName']
             raise WMSpecFactoryException(msg)
@@ -331,16 +331,13 @@ class TaskChainWorkloadFactory(StdBase):
         scenarioArgs = {}
         couchUrl = self.couchURL
         couchDB = self.couchDBName
-        if taskConf.get("Scenario", None) != None:
-            scenario = taskConf['Scenario']
+        if taskConf.get("ProcScenario", None) != None:
+            self.procScenario = taskConf['ProcScenario']
             scenarioFunc = taskConf['ScenarioMethod']
             scenarioArgs = taskConf['ScenarioArguments']
-            couchUrl = None
-            couchDb = None
-            couchConfig = None            
             
         outputMods = self.setupProcessingTask(task, "Processing", inputDataset, inputStep = inpStep, inputModule=inpMod,
-                                            scenarioName = scenario, scenarioFunc = scenarioFunc, scenarioArgs = scenarioArgs,
+                                            scenarioName = self.procScenario, scenarioFunc = scenarioFunc, scenarioArgs = scenarioArgs,
                                             couchURL = couchUrl, couchDBName = couchDB,
                                             configDoc = configCacheID, splitAlgo = splitAlgorithm,
                                             splitArgs = splitArguments, stepType = cmsswStepType)

--- a/src/python/WMCore/WMSpec/StdSpecs/Tier1PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Tier1PromptReco.py
@@ -234,10 +234,8 @@ class Tier1PromptRecoWorkloadFactory(StdBase):
         # Required parameters that must be specified by the Requestor.
         self.frameworkVersion = arguments['CMSSWVersion']
         self.globalTag = arguments['GlobalTag']
-        self.procScenario = arguments['ProcScenario']
         self.writeTiers = arguments['WriteTiers']
         self.alcaSkims = arguments['AlcaSkims']
-        self.dqmSequences = arguments['DqmSequences']
         self.inputDataset = arguments['InputDataset']
         self.promptSkims = arguments['PromptSkims']
         self.couchURL = arguments['CouchURL']

--- a/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
@@ -106,22 +106,14 @@ class DQMUpload(Executor):
         if self.step.upload.active:
             logging.info("DQM Upload is ACTIVE.")
 
-            # FIXME : samir : This doesnt help in the T0 case. In the general (GlideIn case) we have another 
-            # Ways to implement it which are easier but this will be the last resort.
- 
-            # Pulling the proxy from the input sandbox
-            # After this, the proxy will be in the local directory
-            # The command bellow throws an exception if the sandbox
-            # does not have the proxy file
-            #try:
-            #    self.stepSpace.getFromSandbox(self.step.upload.proxy)
-            #except Exception, ex:
-            #    msg = "Could not find proxy file in input sandbox:"
-            #    msg += str(ex) + "\n"
-            #    msg += traceback.format_exc()
-            #    logging.error(msg)
-            #    raise WMExecutionFailure(60318, "DQMUploadFailure", msg)
-     
+            if self.step.upload.proxy:
+                try:
+                   self.stepSpace.getFromSandbox(self.step.upload.proxy)
+                except Exception, ex:
+                    #Let it go, it wasn't in the sandbox. Then it must be
+                    #somewhere else
+                    pass
+
         # Now, let's work...
 
         # Search through steps for analysis files
@@ -291,7 +283,7 @@ class DQMUpload(Executor):
 
         args['checksum'] = 'md5:' + m.hexdigest()
         args['size'] = str(os.stat(file)[6])
-        proxyLoc = self.step.upload.proxy
+        proxyLoc = os.environ.get('X509_USER_PROXY', None) or self.step.upload.proxy
 
         class HTTPSCertAuth(HTTPS):
             def __init__(self, host, timeout):
@@ -319,17 +311,23 @@ class DQMUpload(Executor):
             msg += "  ==> %s: %s\n" % (arg, args[arg])
         logging.info(msg)
 
-        authreq = urllib2.Request(args['url'] + '/digest')
-        authreq.add_header('User-agent', ident)
-        result = urllib2.build_opener(HTTPSCertAuthenticate()).open(authreq)
-        cookie = result.headers.get('Set-Cookie')
-        if not cookie:
+        try:
+            authreq = urllib2.Request(args['url'] + '/digest')
+            authreq.add_header('User-agent', ident)
+            result = urllib2.build_opener(HTTPSCertAuthenticate()).open(authreq)
+            cookie = result.headers.get('Set-Cookie')
+            if not cookie:
+                raise RuntimeError
+        except Exception, ex:
             msg = "Unable to authenticate to DQM Server:\n"
-            msg += "%s\n" % self.args['url']
+            msg += "%s\n" % args['url']
             msg += "With Proxy from:\n"
             msg += "%s\n" % proxyLoc
+            msg += "Exception: %s\n" % str(ex)
+            msg += traceback.format_exc()
             logging.error(msg)
-            raise RuntimeError, msg
+            raise WMExecutionFailure(60318, "DQMUploadFailure", msg)
+
         cookie = cookie.split(";")[0]
 
         # open a connection and upload the file

--- a/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
@@ -283,7 +283,7 @@ class DQMUpload(Executor):
 
         args['checksum'] = 'md5:' + m.hexdigest()
         args['size'] = str(os.stat(file)[6])
-        proxyLoc = os.environ.get('X509_USER_PROXY', None) or self.step.upload.proxy
+        proxyLoc = self.step.upload.proxy or os.environ.get('X509_USER_PROXY', None)
 
         class HTTPSCertAuth(HTTPS):
             def __init__(self, host, timeout):

--- a/src/python/WMCore/WMSpec/Steps/Templates/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Templates/CMSSW.py
@@ -197,6 +197,35 @@ class CMSSWStepHelper(CoreHelper):
 
         return pickle.loads(self.data.application.configuration.pickledarguments)['globalTag']
 
+    def setDatasetName(self, datasetName):
+        """
+        _setDatasetName_
+
+        Set the dataset name in the pickled arguments
+        """
+        self.data.application.configuration.section_('arguments')
+        self.data.application.configuration.arguments.datasetName = datasetName
+
+        args = {}
+        if hasattr(self.data.application.configuration, "pickledarguments"):
+            args = pickle.loads(self.data.application.configuration.pickledarguments)
+        args['datasetName'] = datasetName
+        self.data.application.configuration.pickledarguments = pickle.dumps(args)
+
+        return
+
+    def getDatasetName(self):
+        """
+        _setDatasetName_
+
+        Retrieve the dataset name from the pickled arguments
+        """
+        if hasattr(self.data.application.configuration, "arguments"):
+            if hasattr(self.data.application.configuration.arguments, "datasetName"):
+                return self.data.application.configuration.arguments.datasetName
+
+        return pickle.loads(self.data.application.configuration.pickledarguments).get('datasetName', None)
+
     def setUserSandbox(self, userSandbox):
         """
         _setUserSandbox_

--- a/src/python/WMCore/WMSpec/Steps/Templates/DQMUpload.py
+++ b/src/python/WMCore/WMSpec/Steps/Templates/DQMUpload.py
@@ -79,7 +79,7 @@ class DQMUpload(Template):
         step.upload.URL = 'https://cmsweb.cern.ch/dqm/dev'
         step.upload.proxy = None
         step.section_("stageOut")
-        step.stageOut.active = True
+        step.stageOut.active = False
         step.stageOut.retryCount = 3
         step.stageOut.retryDelay = 300
         #step.stageOut.waitTime = 1200

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -855,22 +855,14 @@ class WMWorkloadHelper(PersistencyHelper):
             taskIterator = self.taskIterator()
 
         for task in taskIterator:
-            foundDQMOutput = False
             for stepName in task.listAllStepNames():
                 stepHelper = task.getStepHelper(stepName)
                 if stepHelper.stepType() == "StageOut" and stepHelper.minMergeSize() != -1:
                     stepHelper.setMinMergeSize(minSize, maxEvents)
-                if stepHelper.stepType() == "CMSSW" or \
-                       stepHelper.stepType() == "MulticoreCMSSW":
-                    for outputModuleName in stepHelper.listOutputModules():
-                        outputModule = stepHelper.getOutputModule(outputModuleName)
-                        if outputModule.dataTier == "DQM":
-                            foundDQMOutput = True
                 
             if task.taskType() == "Merge":
                 task.setSplittingParameters(min_merge_size = minSize,
                                             max_merge_size = maxSize,
-                                            merge_across_runs = not foundDQMOutput,
                                             max_merge_events = maxEvents)
 
             self.setMergeParameters(minSize, maxSize, maxEvents, task)

--- a/src/templates/WMCore/WebTools/RequestManager/Splitting.tmpl
+++ b/src/templates/WMCore/WebTools/RequestManager/Splitting.tmpl
@@ -179,6 +179,14 @@ function generateProduction(splitAlgo, splitParams) {
   return procStr;
 }
 
+function generateHarvesting(splitAlgo, splitParams) {
+  var procStr = '<input type="hidden" name="splittingAlgo" value="Harvest"></input>\n';
+  procStr += "<table>"
+  procStr += generateInputRow("Periodic harvesting frequency:", "periodic_harvest_interval", splitParams);
+  procStr += "</table>\n";
+  return procStr;
+}
+
 function generateForm(taskName, splitAlgo, splitParams, taskType) {
   var frmStr = '<form name="' + taskName + '" action="../handleSplittingPage" method="POST">\n';
   frmStr += '<input type="hidden" name="requestName" VALUE="$requestName"></input>\n'; 
@@ -195,6 +203,8 @@ function generateForm(taskName, splitAlgo, splitParams, taskType) {
     frmStr += generateSkim(splitAlgo, splitParams);
   } else if (taskType == "Production" || taskType == "MultiProduction") {
     frmStr += generateProduction(splitAlgo, splitParams);
+  } else if (taskType == "Harvesting") {
+    frmStr += generateHarvesting(splitAlgo, splitParams);
   }
 
   frmStr += submitButton(taskName);

--- a/src/templates/WMCore/WebTools/RequestManager/WebRequestSchema.tmpl
+++ b/src/templates/WMCore/WebTools/RequestManager/WebRequestSchema.tmpl
@@ -76,8 +76,19 @@ Memory (Mbytes): <input type="text" name="Memory" size=10 value=2147483648 />
 Size per event (Kbytes): <input type="text" name="SizePerEvent" size=10 value=512000 /><br/>
 #end def
 
-#def configBlock($radioName, $scenarioName, $cacheName, $type)
-Configuration <br>
+#def dqmOptions
+DQM Sequences: <input type="text" name="DqmSequences" size=40 />
+DQM URL:
+<select name="DQMUploadUrl">
+    <option selected> https://cmsweb.cern.ch/dqm/dev </option>
+    <option> https://cmsweb.cern.ch/dqm/offline </option>
+    <option> https://cmsweb.cern.ch/dqm/relval </option>
+</select><br/>
+
+#end def
+
+#def scenarioBlock
+Scenario:
   <select name="ProcScenario">
     <option selected> pp</option>
     <option>cosmics</option>
@@ -87,7 +98,12 @@ Configuration <br>
     <option>relvalmc</option>
     <option>relvalmcfs</option>
   </select><br/>
-  <input type="radio" name=$radioName value="scenario" /> Scenario
+#end def
+
+#def configBlock($radioName, $scenarioName, $cacheName, $type)
+Configuration <br>
+  <input type="radio" name=$radioName value="scenario" /> Scenario <br/>
+  $scenarioBlock
   <input type="radio" name=$radioName value="couchDB" /> $type ConfigCache ID
     <!--<input type="text" name="$cacheName" size=80 />
     <select name=$cacheName>
@@ -99,9 +115,7 @@ Configuration <br>
        <input name="$cacheName" size=80 id="couchinput" type="text">
        <div id="couchcontainer"></div>
     </div>
-  <br/>
-
-Global Tag: <input type="text" name="GlobalTag" size=20 value=""/> &nbsp &nbsp
+Global Tag: <input type="text" name="GlobalTag" size=20 value=""/> &nbsp &nbsp <br>
 #end def
 
 #def campaignBlock
@@ -193,6 +207,7 @@ First lumi: <input type="text" name="FirstLumi" size=10 value=1 /><br/>
 Include Parents: <select name="IncludeParents"><option>True</option><option selected>False</option></select><br/>
             $campaignBlock
             $configBlock("inputMode", "Scenario", "ProcConfigCacheID", "Reco")
+            $dqmOptions
             $ioBlock
             $skimBlock
             $runBlockBlock
@@ -249,6 +264,7 @@ Include Parents: <select name="IncludeParents"><option>True</option><option sele
             $campaignBlock
 Multicore: <input type="text" name="Multicore" size=2 value="" /> <br/>
             $configBlock("inputMode", "Scenario", "ProcConfigCacheID", "Processing")
+            $dqmOptions
             $ioBlock
             $runBlockBlock
             $performanceBlock
@@ -270,6 +286,8 @@ Include Parents: <select name="IncludeParents"><option>True</option><option sele
             $campaignBlock
             $ioBlock
 <br/>
+            $scenarioBlock
+            $dqmOptions
 Step One CacheCache ID: <input type="text" name="StepOneConfigCacheID" size=80 /><br/>
 Step One Output Module Name: <input type="text" name="StepOneOutputModuleName" size=20 /><br/>
 Step Two CacheCache ID: <input type="text" name="StepTwoConfigCacheID" size=80 /><br/>

--- a/src/templates/WMCore/WebTools/RequestManager/WebRequestSchema.tmpl
+++ b/src/templates/WMCore/WebTools/RequestManager/WebRequestSchema.tmpl
@@ -78,16 +78,16 @@ Size per event (Kbytes): <input type="text" name="SizePerEvent" size=10 value=51
 
 #def configBlock($radioName, $scenarioName, $cacheName, $type)
 Configuration <br>
+  <select name="ProcScenario">
+    <option selected> pp</option>
+    <option>cosmics</option>
+    <option>hcalnzs</option>
+    <option>preprodmc</option>
+    <option>prodmc</option>
+    <option>relvalmc</option>
+    <option>relvalmcfs</option>
+  </select><br/>
   <input type="radio" name=$radioName value="scenario" /> Scenario
-    <select name="Scenario">
-      <option selected> pp</option>
-      <option>cosmics</option>
-      <option>hcalnzs</option>
-      <option>preprodmc</option>
-      <option>prodmc</option>
-      <option>relvalmc</option>
-      <option>relvalmcfs</option>
-    </select><br/>
   <input type="radio" name=$radioName value="couchDB" /> $type ConfigCache ID
     <!--<input type="text" name="$cacheName" size=80 />
     <select name=$cacheName>

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
@@ -513,7 +513,7 @@ class TaskChainTests(unittest.TestCase):
                 "TaskName" : "Reco",
                 "InputTask" : "DigiHLT",
                 "InputFromOutputModule" : "writeRAWDIGI",
-                "Scenario" : "pp",
+                "ProcScenario" : "pp",
                 "ScenarioMethod" : "promptReco",
                 "ScenarioArguments" : { 'outputs' : [ { 'dataTier' : "RECO",
                                                         'moduleLabel' : "RECOoutput" },
@@ -528,7 +528,7 @@ class TaskChainTests(unittest.TestCase):
                 "TaskName" : "ALCAReco",
                 "InputTask" : "Reco",
                 "InputFromOutputModule" : "ALCARECOoutput",
-                "Scenario" : "pp",
+                "ProcScenario" : "pp",
                 "ScenarioMethod" : "alcaReco",
                 "ScenarioArguments" : { 'outputs' : [ { 'dataTier' : "ALCARECO",
                                                         'moduleLabel' : "ALCARECOoutput" } ] },
@@ -575,13 +575,13 @@ class TaskChainTests(unittest.TestCase):
         reco = self.workload.getTaskByPath("/YankingTheChain/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco")
         recoStep = reco.getStepHelper("cmsRun1")
         recoAppConf = recoStep.data.application.configuration
-        self.assertEqual(recoAppConf.scenario, arguments['Task2']['Scenario'])
+        self.assertEqual(recoAppConf.scenario, arguments['Task2']['ProcScenario'])
         self.assertEqual(recoAppConf.function, arguments['Task2']['ScenarioMethod'])
         
         alca = self.workload.getTaskByPath("/YankingTheChain/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergeALCARECOoutput/ALCAReco")
         alcaStep = alca.getStepHelper("cmsRun1")
         alcaAppConf = alcaStep.data.application.configuration
-        self.assertEqual(alcaAppConf.scenario, arguments['Task3']['Scenario'])
+        self.assertEqual(alcaAppConf.scenario, arguments['Task3']['ProcScenario'])
         self.assertEqual(alcaAppConf.function, arguments['Task3']['ScenarioMethod'])
         
     def testD(self):
@@ -614,7 +614,7 @@ class TaskChainTests(unittest.TestCase):
                 "InputDataset" : "/DoubleElectron/Run2011A-v1/RAW", 
                 "SplittingAlgorithm"  : "LumiBased",
                 "SplittingArguments" : {"lumis_per_job" : 1},
-                "Scenario" : "pp",
+                "ProcScenario" : "pp",
                 "ScenarioMethod" : "promptReco",
                 "ScenarioArguments" : { 'outputs' : [ { 'dataTier' : "RECO",
                                                         'moduleLabel' : "RECOoutput" },
@@ -630,7 +630,7 @@ class TaskChainTests(unittest.TestCase):
                 "TaskName" : "AlcaSkimming",
                 "InputTask" : "PromptReco",
                 "InputFromOutputModule" : "ALCARECOoutput",
-                "Scenario" : "pp",
+                "ProcScenario" : "pp",
                 "ScenarioMethod" : "alcaSkimming",
                 "ScenarioArguments" : { 'outputs' : [ { 'dataTier' : "ALCARECO",
                                                         'moduleLabel' : "ALCARECOoutput" } ],

--- a/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
@@ -274,8 +274,7 @@ class WMWorkloadTest(unittest.TestCase):
         mergeDQMTask.setInputReference(procTaskCMSSW, outputModule = "outputDQM")
         mergeDQMTask.setTaskType("Merge")
         mergeDQMTask.setSplittingAlgorithm("WMBSMergeBySize", max_merge_size = 4,
-                                           max_merge_events = 4, min_merge_size = 4,
-                                           merge_across_runs = False)
+                                           max_merge_events = 4, min_merge_size = 4)
         mergeDQMTaskCMSSW = mergeDQMTask.makeStep("cmsRun1")
         mergeDQMTaskCMSSW.setStepType("CMSSW")
         mergeDQMTaskStageOut = mergeDQMTaskCMSSW.addStep("StageOut1")
@@ -321,7 +320,7 @@ class WMWorkloadTest(unittest.TestCase):
                          "Error: Site black list was updated.")
 
         mergeSplitParams = mergeTask.jobSplittingParameters()
-        self.assertEqual(len(mergeSplitParams.keys()), 7,
+        self.assertEqual(len(mergeSplitParams.keys()), 6,
                          "Error: Wrong number of params for merge task.")
         self.assertEqual(mergeSplitParams["algorithm"], "WMBSMergeBySize",
                          "Error: Wrong job splitting algo for merge task.")
@@ -331,15 +330,13 @@ class WMWorkloadTest(unittest.TestCase):
                          "Error: Wrong max merge size.")
         self.assertEqual(mergeSplitParams["max_merge_events"], 1000,
                          "Error: Wrong max merge events.")
-        self.assertEqual(mergeSplitParams["merge_across_runs"], True,
-                         "Error: Wrong merge across runs.")
         self.assertEqual(mergeSplitParams["siteWhitelist"], [],
                          "Error: Site white list was updated.")
         self.assertEqual(mergeSplitParams["siteBlacklist"], [],
                          "Error: Site black list was updated.")
 
         mergeDQMSplitParams = mergeDQMTask.jobSplittingParameters()
-        self.assertEqual(len(mergeDQMSplitParams.keys()), 7,
+        self.assertEqual(len(mergeDQMSplitParams.keys()), 6,
                          "Error: Wrong number of params for merge task.")
         self.assertEqual(mergeDQMSplitParams["algorithm"], "WMBSMergeBySize",
                          "Error: Wrong job splitting algo for merge task.")
@@ -349,8 +346,6 @@ class WMWorkloadTest(unittest.TestCase):
                          "Error: Wrong max merge size.")
         self.assertEqual(mergeDQMSplitParams["max_merge_events"], 1000,
                          "Error: Wrong max merge events.")
-        self.assertEqual(mergeDQMSplitParams["merge_across_runs"], False,
-                         "Error: Wrong merge across runs.")
         self.assertEqual(mergeDQMSplitParams["siteWhitelist"], [],
                          "Error: Site white list was updated.")
         self.assertEqual(mergeDQMSplitParams["siteBlacklist"], [],


### PR DESCRIPTION
Please review.

Changes:
- Disable stageOut in DQM step. We don't want to store the file, it is only for the DQM GUI.
- Integrate the Harvest splitting algorithm in the splitting page in ReqMgr
- If there is a proxy available under X509_USER_PROXY, the Harvest
  splitter will use it and ship the path in the job pickle, if CondorPlugin
  finds such proxy then it will set it in the jdl
- The DQM executor now supports 3 possible input proxies:
  - A proxy in the sandbox
  - A proxy in the environment (X509_USER_PROXY)
  - A proxy which path is defined in self.upload.proxy
- Given that Harvesting works with an scenario then StdBase must support getting an scenario
  even when a ConfigCache is provided, to ensure this then self.procScenario was moved up to
  StdBase and it is obtained from ProcScenario. Any support of 'Scenario' as the key in the input
  arguments was dropped. Also the ReqMgr doesn't delete a scenario when it finds a config cache.
- All merge tasks created using addMergeTask that have DQM output will
  have a DQM Harvest task attached by default (can be changed passing
  doHarvesting = False). This task will use the upload proxy
  in self.dqmUploadProxy, the url in self.dqmUploadUrl and the dqm
  sequences in self.dqmSequences. dqmSequences is now a StdBase attribute.
- Merge for DQM changed a bit, it accepts the same merge size and event parameters
  as the other data tiers but still requires that the merges are not performed
  across run.

What is missing:
- Support in harvesting for multiple runs per file
- Support for putting more blocks in the workqueue after a workflow has been created, this is needed for Tier1PromptReco/PromptSkimming to work under the rare cases of late blocks.
