### PR TITLE
ACDC chops off one lumi at the end of the masks

### DIFF
--- a/src/python/WMCore/DataStructs/Mask.py
+++ b/src/python/WMCore/DataStructs/Mask.py
@@ -210,7 +210,7 @@ class Mask(dict):
                 if pair[0] == pair[1]:
                     maskLumis.add(pair[0])
                 else:                  
-                    maskLumis = maskLumis.union(range(pair[0], pair[1], 1))
+                    maskLumis = maskLumis.union(range(pair[0], pair[1] + 1, 1))
             
             filteredLumis = set(runDict[runNumber].lumis).intersection(maskLumis)
             if len(filteredLumis) > 0:

--- a/test/python/WMCore_t/DataStructs_t/Mask_t.py
+++ b/test/python/WMCore_t/DataStructs_t/Mask_t.py
@@ -170,13 +170,13 @@ class MaskTest(unittest.TestCase):
         self.assertEqual(len(newRuns), 1)
 
         runs = set()
-        runs.add(Run(1, 2, 148, 166, 185, 195, 203, 212))
+        runs.add(Run(1, 2, 9, 148, 166, 185, 195, 203, 212))
         newRuns = mask.filterRunLumisByMask(runs = runs)
         self.assertEqual(len(newRuns), 1)
 
         run = newRuns.pop()
         self.assertEqual(run.run, 1)
-        self.assertEqual(run.lumis, [2])
+        self.assertEqual(run.lumis, [2,9])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix and add unit test to catch this

Since commit 7e3a9bfca6b60158797b2b003149dbdf002ced0c, the filterRunLumisByMask
is excluding the last lumi in the mask even if it is in the file.

This was breaking the ErrorHandler unit test, AFAIK masks are inclusive.
