### PR TITLE
Fix workqueue mc splitting for large (2^32) requests

### DIFF
--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -373,27 +373,29 @@ class WMTaskHelper(TreeHelper):
         setattr(self.data.production, "firstEvent", firstEvent)
         setattr(self.data.production, "firstLumi", firstLumi)
 
-    def getFirstEvent(self):
+    def getFirstEvent(self, default = None):
         """
         _getFirstEvent_
 
         Get first event to produce for the task
+        Return default if not in spec
         """
         if hasattr(self.data, "production"):
-            if hasattr(self.data.production, "firstLumi"):
+            if hasattr(self.data.production, "firstEvent"):
                 return self.data.production.firstEvent
-        return None
+        return default
 
-    def getFirstLumi(self):
+    def getFirstLumi(self, default = None):
         """
         _getFirstLumi_
 
         Get first lumi to produce for the task
+        Return default if not in spec
         """
         if hasattr(self.data, "production"):
             if hasattr(self.data.production, "firstLumi"):
                 return self.data.production.firstLumi
-        return None
+        return default
 
     def setSplittingParameters(self, **params):
         """


### PR DESCRIPTION
The current code doesn't handle a workflow which doesn't have FirstEvent/Lumi set fix that.

Also fix lumi section counting which produced activity like:
2012-07-20 17:41:40,138:INFO:WMBSHelper:"etorassa_BPH-Summer12-00029_batch137_v1__120711_211903_6758" Injecting production 1:60001:150000000001 - 1:685000:150625000000 (run:lumi:event) into wmbs
2012-07-20 17:46:52,732:INFO:WMBSHelper:"etorassa_BPH-Summer12-00029_batch137_v1__120711_211903_6758" Injecting production 1:60001:150000000001 - 1:685000:150625000000 (run:lumi:event) into wmbs

Diego, I modified a fair bit of the code here. Does it look ok to you?

Until we add a new param to the workqueue splitting code during request generation this will default to 1 lumi per job (this replaces the previous default of 1000 events per lumi).
