### PR TITLE
Fix workqueue mc splitting to normally use 1 lumi section per job.

### DIFF
--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -382,7 +382,7 @@ class WMTaskHelper(TreeHelper):
         if hasattr(self.data, "production"):
             if hasattr(self.data.production, "firstLumi"):
                 return self.data.production.firstEvent
-        return None
+        return 1
 
     def getFirstLumi(self):
         """
@@ -393,7 +393,7 @@ class WMTaskHelper(TreeHelper):
         if hasattr(self.data, "production"):
             if hasattr(self.data.production, "firstLumi"):
                 return self.data.production.firstLumi
-        return None
+        return 1
 
     def setSplittingParameters(self, **params):
         """

--- a/src/python/WMCore/WorkQueue/Policy/Start/MonteCarlo.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/MonteCarlo.py
@@ -17,16 +17,17 @@ class MonteCarlo(StartPolicyInterface):
     """Split elements into blocks"""
     def __init__(self, **args):
         StartPolicyInterface.__init__(self, **args)
-        self.args.setdefault('SliceType', 'NumberOfEvents')
-        self.args.setdefault('SliceSize', 1000)         # events per job
-        self.args.setdefault('SubSliceType', 'NumberOfEventsPerLumi')
-        self.args.setdefault('SubSliceSize', 1000) # events per lumi
-        self.args.setdefault('MaxJobsPerElement', 250)  # jobs per WQE
 
 
     def split(self):
         """Apply policy to spec"""
         # if not specified take standard defaults
+        self.args.setdefault('SliceType', 'NumberOfEvents')
+        self.args.setdefault('SliceSize', 1000)         # events per job
+        self.args.setdefault('SubSliceType', 'NumberOfEventsPerLumi')
+        self.args.setdefault('SubSliceSize', self.args['SliceSize']) # events per lumi
+        self.args.setdefault('MaxJobsPerElement', 250)  # jobs per WQE
+
         if not self.mask:
             self.mask = Mask(FirstRun = 1,
                              FirstLumi = self.initialTask.getFirstLumi(),
@@ -34,9 +35,6 @@ class MonteCarlo(StartPolicyInterface):
                              LastRun = 1,
                              LastEvent = self.initialTask.getFirstEvent() +
                                              self.initialTask.totalEvents() - 1)
-        if not self.args['SubSliceType']:
-            self.args['SubSliceType'] = 'NumberOfEventsPerLumi'
-            self.args['SubSliceSize'] = self.args['SliceSize']
         mask = Mask(**self.mask)
 
         #First let's initialize some parameters


### PR DESCRIPTION
Previsouly defaulted to 1000 events per lumi section.

We still need to add something into reqmgr to allow this param to be overridden.

Signed-off-by: stuartw stuart.wakefield@gmail.com
