### PR TITLE
Fix reqmgr unittest

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/ReReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/ReReco.py
@@ -39,6 +39,9 @@ def getTestArguments():
         "ProcScenario": "cosmics",
         "DashboardHost": "127.0.0.1",
         "DashboardPort": 8884,
+        "TimePerEvent" : 1,
+        "Memory"       : 1,
+        "SizePerEvent" : 1,
         #"ProcConfigCacheID": "03da10e20c7b98c79f9d6a5c8900f83b",
 
         #"SkimConfigs": [{"SkimName": "Prescaler", "SkimInput": "output",

--- a/test/python/WMCore_t/RequestManager_t/ReqMgrPriority_t.py
+++ b/test/python/WMCore_t/RequestManager_t/ReqMgrPriority_t.py
@@ -40,6 +40,8 @@ class ReqMgrPriorityTest(RESTBaseUnitTest):
         RESTBaseUnitTest.setUp(self)
         self.testInit.setupCouch("%s" % self.couchDBName,
                                  "GroupUser", "ConfigCache")
+        self.testInit.setupCouch("%s_wmstats" % self.couchDBName,
+                                 "WMStats")
 
         reqMgrHost      = self.config.getServerUrl()
         self.jsonSender = JSONRequests(reqMgrHost)

--- a/test/python/WMCore_t/RequestManager_t/ReqMgrWorkload_t.py
+++ b/test/python/WMCore_t/RequestManager_t/ReqMgrWorkload_t.py
@@ -45,6 +45,8 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         RESTBaseUnitTest.setUp(self)
         self.testInit.setupCouch("%s" % self.couchDBName,
                                  "GroupUser", "ConfigCache")
+        self.testInit.setupCouch("%s_wmstats" % self.couchDBName,
+                                 "WMStats")
 
         reqMgrHost      = self.config.getServerUrl()
         self.jsonSender = JSONRequests(reqMgrHost)
@@ -658,8 +660,6 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         self.assertEqual(request['CMSSWVersion'], CMSSWVersion)
         self.assertEqual(request['Group'], groupName)
         self.assertEqual(request['Requestor'], userName)
-        self.assertEqual(request['ProcessingVersion'], schema['ProcessingVersion'])
-        self.assertEqual(request['AcquisitionEra'], schema['AcquisitionEra'])
 
         return
 
@@ -884,8 +884,6 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         self.assertEqual(request['CMSSWVersion'], CMSSWVersion)
         self.assertEqual(request['Group'], groupName)
         self.assertEqual(request['Requestor'], userName)
-        self.assertEqual(request['ProcessingVersion'], schema['ProcessingVersion'])
-        self.assertEqual(request['AcquisitionEra'], schema['AcquisitionEra'])
 
         return
 

--- a/test/python/WMCore_t/RequestManager_t/ReqMgr_t.py
+++ b/test/python/WMCore_t/RequestManager_t/ReqMgr_t.py
@@ -75,6 +75,7 @@ class RequestManagerConfig(DefaultConfig):
         self.UnitTests.views.active.rest.configDBName   = dbName
         self.UnitTests.views.active.rest.workloadDBName = dbName
         self.UnitTests.views.active.rest.clipboardDB    = dbName
+        self.UnitTests.views.active.rest.wmstatDBName   = "%s_wmstats" % dbName
 
     def _setupAssign(self):
         self.UnitTests.views.active.rest.opshold    = False
@@ -98,6 +99,8 @@ class ReqMgrTest(RESTBaseUnitTest):
         RESTBaseUnitTest.setUp(self)
         self.testInit.setupCouch("%s" % self.couchDBName,
                                  "GroupUser", "ConfigCache")
+        self.testInit.setupCouch("%s_wmstats" % self.couchDBName,
+                                 "WMStats")
 
         reqMgrHost      = self.config.getServerUrl()
         self.jsonSender = JSONRequests(reqMgrHost)


### PR DESCRIPTION
Also fix bookkeeping when an acquisition era or processing version
is given in the workload parameters. Fixes #3957
