### PR TITLE
Refines how to trap os._exit in testing mode

### DIFF
--- a/setup_test.py
+++ b/setup_test.py
@@ -287,7 +287,25 @@ if can_nose:
                          '!workerNodeTest,!integration,!performance,!__integration__,!__performance__',
                          '--stop', self.testingRoot],
                          paths = testPath)
-
+                    
+            threadCount = len(threading.enumerate())
+            if threadCount > 1:
+                sys.stderr.write("There are %s threads running. Cherrypy may be acting up.\n" % threadCount)
+                import cherrypy
+                cherrypy.engine.exit()
+                sys.stderr.write("Asked cherrypy politely to commit suicide\n")
+            threadCount = len(threading.enumerate())
+            if threadCount > 1:
+                sys.stderr.write("Cherrypy's being stubborn and there's still %s threads. Grabbing a gun...\n" % threadCount)
+                import cherrypy
+                class MyCherryPyApplication(object):
+                    def default(self):
+                        sys.exit()
+                    default.exposed = True
+                cherrypy.quickstart(MyCherryPyApplication())
+                sys.stderr.write("There's %s threads now. That's all we can do..." % len(threading.enumerate()))
+            print "Testing complete, there are now %s threads" % len(threading.enumerate())
+            
             if retval:
                 sys.exit( 0 )
             else:

--- a/setup_test.py
+++ b/setup_test.py
@@ -95,12 +95,15 @@ if can_nose:
         will replace os._exit() and throw an exception instead
         """
         if hasattr( threading.local(), "isMain" ) and threading.local().isMain:
-            # only trap the main thread
-            print "*******EXIT WAS TRAPPED**********"
-            raise RuntimeError, "os._exit() was called, we trapped it for testing"
-        else:
-            # subthreads can behave the same
-            os.DMWM_REAL_EXIT( code )
+            # The main thread should raise an exception
+            sys.stderr.write("*******EXIT WAS TRAPPED**********\n")
+            raise RuntimeError, "os._exit() was called in the main thread"
+        else:        
+            # os._exit on child threads should just blow away the thread
+            raise SystemExit, "os._exit() was called in a child thread. " +\
+                              "Protecting the interpreter and trapping it"
+        
+
 
     class DetailedOutputter(Plugin):
         name = "detailed"


### PR DESCRIPTION
Obnoxiously, cherrypy throws os._exit if a worker thread hits an error like the socket is already bound. That's, of course, bad for testing because os._exit blows away the interpreter which keeps nose from doing things like continuing to the next test or writing the xml file out. But, if you don't kill the thread, then the process will have spare children hanging out, which will make the interpreter never exit. This patch detects if worker threads are stuck and will start killing them with prejudice.

The obnoxious thing it's sorta racy to trigger this cherrypy stuff, so I'm not 100% it worked, but I ran it like 5 times and it didn't hang, so, I guess that's good enough :/
