### PR TITLE
Adding os-level alarm to testing code

### DIFF
--- a/setup_test.py
+++ b/setup_test.py
@@ -163,10 +163,10 @@ if can_nose:
                          ('testingRoot=',
                          None,
                          "Primarily used by buildbot. Gives the path to the root of the test tree (i.e. the directory with WMCore_t)"),
-                        ('testMinimumIndex=',
+                         ('testMinimumIndex=',
                          None,
                          "The minimum ID to be executed (advanced use)"),
-                        ('testMaximumIndex=',
+                         ('testMaximumIndex=',
                          None,
                          "The maximum ID to be executed (advanced use)")
                          ]
@@ -319,7 +319,7 @@ if can_nose:
             # if we got here, then sys.exit got cancelled by the alarm...
             sys.stderr.write("Failed to exit after 30 secs...something hung\n")
             sys.stderr.write("Forcing process to die")
-            os.DMWM_REAL_EXIT
+            os.DMWM_REAL_EXIT()
 
             
 else:


### PR DESCRIPTION
cherrypy.engine.exit depends on the code inside the worker threads responding in a regular amount of time. That's hopeless. Fortunately, nosetests.xml is already written, so we can just slay the process if it takes too long. This adds a signal handler and an alarm to forcibly slay python if it takes more than 60 seconds to shut down.
