### PR TITLE
make FindDASToUpload Oracle DAO functional, fixes #3770

### DIFF
--- a/src/python/WMComponent/DBSUpload/Database/MySQL/FindDASToUpload.py
+++ b/src/python/WMComponent/DBSUpload/Database/MySQL/FindDASToUpload.py
@@ -5,7 +5,6 @@ This code should load the necessary information regarding
 dataset-algo combinations from the DBSBuffer.
 
 """
-import logging
 from WMCore.Database.DBFormatter import DBFormatter
 
 
@@ -14,22 +13,30 @@ class FindDASToUpload(DBFormatter):
     Find Uploadable DAS
 
     """
-
-    querySQL = """SELECT DISTINCT dbsfile.dataset_algo AS dasid FROM dbsbuffer_file dbsfile
-                     WHERE dbsfile.status = 'NOTUPLOADED'"""
-
-
-    sql = """SELECT das.dataset_id AS dataset, ds.Path as Path, das.algo_id as Algo, das.in_dbs as in_dbs,
-               das.id AS das_id,
-               ds.valid_status AS valid_status,
-               ds.global_tag AS global_tag,
-               ds.parent AS parent
+    sql = """SELECT das.dataset_id AS dataset,
+                    ds.Path as Path,
+                    das.algo_id as Algo,
+                    das.in_dbs as in_dbs,
+                    das.id AS das_id,
+                    ds.valid_status AS valid_status,
+                    ds.global_tag AS global_tag,
+                    ds.parent AS parent
              FROM dbsbuffer_algo_dataset_assoc das
-             INNER JOIN dbsbuffer_dataset ds ON ds.id = das.dataset_id
-             WHERE das.id = :das
-             AND UPPER(ds.Path) NOT LIKE 'BOGUS'
+             INNER JOIN dbsbuffer_dataset ds ON
+               ds.id = das.dataset_id
+             INNER JOIN dbsbuffer_file dbsfile ON
+               dbsfile.dataset_algo = das.id AND
+               dbsfile.status = 'NOTUPLOADED'
+             WHERE UPPER(ds.Path) NOT LIKE 'BOGUS'
+             GROUP BY das.dataset_id,
+                      ds.Path,
+                      das.algo_id,
+                      das.in_dbs,
+                      das.id,
+                      ds.valid_status,
+                      ds.global_tag,
+                      ds.parent
              """
-
 
     def makeDAS(self, results):
         ret=[]
@@ -62,18 +69,7 @@ class FindDASToUpload(DBFormatter):
 
     def execute(self, conn=None, transaction = False):
 
-        binds  = {}
-        query  = self.dbi.processData(self.querySQL, binds,
-                                      conn = conn, transaction = transaction)
-        qDict  = self.formatDict(query)
-        idList = []
-        for i in qDict:
-            idList.append({'das': i['dasid']})
-
-        if len(idList) < 1:
-            return []
-
-        result = self.dbi.processData(self.sql, idList, 
-                         conn = conn, transaction = transaction)
+        result = self.dbi.processData(self.sql, binds = {}, conn = conn,
+                                      transaction = transaction)
         
         return self.makeDAS(self.formatDict(result))

--- a/src/python/WMComponent/DBSUpload/Database/Oracle/FindDASToUpload.py
+++ b/src/python/WMComponent/DBSUpload/Database/Oracle/FindDASToUpload.py
@@ -4,41 +4,10 @@
 This code should load the necessary information regarding
 dataset-algo combinations from the DBSBuffer.
 
-Oracle version
-
 """
-
-
-
-
 from WMComponent.DBSUpload.Database.MySQL.FindDASToUpload import FindDASToUpload as MySQLFindDASToUpload
 
 
 class FindDASToUpload(MySQLFindDASToUpload):
-    """
-    Find Uploadable DAS
+    pass
 
-    """
-
-
-    sql = """SELECT das1.dataset_id AS dataset, ds1.Path as Path, das1.algo_id as Algo, das1.in_dbs as in_dbs,
-               das1.id AS das_id,
-               da1.app_name AS ApplicationName, 
-               da1.app_ver AS ApplicationVersion, 
-               da1.app_fam AS ApplicationFamily, 
-               da1.PSet_Hash as PSetHash,
-               da1.Config_Content as PSetContent,
-               da1.in_dbs AS algo_in_dbs,
-               ds1.valid_status AS valid_status
-             FROM dbsbuffer_algo_dataset_assoc das1
-             INNER JOIN dbsbuffer_algo da1 ON da1.id = das1.algo_id
-             INNER JOIN dbsbuffer_dataset ds1 ON ds1.id = das1.dataset_id
-             WHERE das1.id IN
-             (SELECT DISTINCT das.id
-             FROM dbsbuffer_algo_dataset_assoc das
-             INNER JOIN dbsbuffer_dataset ds2 ON ds2.id = das.dataset_id
-             WHERE EXISTS (SELECT id FROM dbsbuffer_file dbsfile
-                            WHERE dbsfile.dataset_algo = das.id
-                            AND dbsfile.status = 'NOTUPLOADED')
-             AND UPPER(ds2.Path) NOT LIKE 'BOGUS')
-             """


### PR DESCRIPTION
Instead of just fixing the Oracle DAO and resolving the functional differences between the Oracle and MySQL version, I wiped the Oracle version and changed/improved the MySQL version to work with both MySQL and Oracle.

There is no unit test that uses this DAO, but running the component in an Oracle WMAgent does not crash anymore.

Please review and merge
