### PR TITLE
change taskarchiver subscription delete order

### DIFF
--- a/src/python/WMCore/WMBS/MySQL/Subscriptions/GetFinishedSubscriptions.py
+++ b/src/python/WMCore/WMBS/MySQL/Subscriptions/GetFinishedSubscriptions.py
@@ -6,44 +6,57 @@ MySQL implementation of Subscription.GetFinishedSubscriptions
 """
 
 import time
-import logging
 
 from WMCore.Database.DBFormatter import DBFormatter
 
 class GetFinishedSubscriptions(DBFormatter):
-    sql = """SELECT DISTINCT wmbs_sub.id FROM wmbs_subscription wmbs_sub
-               INNER JOIN wmbs_fileset ON wmbs_fileset.id = wmbs_sub.fileset
+    """
+
+    Searches for all subscriptions where the fileset is closed,
+    the workflow is injected, there are no available files,
+    no acquired files, no child subscriptions, no jobs that
+    are not in state 'cleanout' and no jobs whose last state
+    change was not been at least a certain time ago
+
+    """
+    sql = """SELECT wmbs_subscription.id
+             FROM wmbs_subscription
+               INNER JOIN wmbs_fileset ON
+                 wmbs_fileset.id = wmbs_subscription.fileset AND
+                 wmbs_fileset.open = 0
                INNER JOIN wmbs_workflow ON
-                 wmbs_sub.workflow = wmbs_workflow.id AND
+                 wmbs_workflow.id = wmbs_subscription.workflow AND
                  wmbs_workflow.injected = 1
-               LEFT OUTER JOIN (SELECT subscription, COUNT(DISTINCT fileid) AS total_files
-                      FROM wmbs_sub_files_acquired GROUP BY subscription) sub_acquired ON
-                      wmbs_sub.id = sub_acquired.subscription
-               LEFT OUTER JOIN (SELECT subscription, COUNT(DISTINCT fileid) AS total_files
-                      FROM wmbs_sub_files_available GROUP BY subscription) sub_available ON
-                      wmbs_sub.id = sub_available.subscription
-               LEFT OUTER JOIN
-                 (SELECT wmbs_subscription.id AS id, COUNT(*) AS total FROM wmbs_subscription
-                    LEFT OUTER JOIN wmbs_workflow_output ON
-                      wmbs_subscription.workflow = wmbs_workflow_output.workflow_id
-                    INNER JOIN wmbs_subscription child_subscriptions ON
-                      wmbs_workflow_output.output_fileset = child_subscriptions.fileset
-                  GROUP BY wmbs_subscription.id) child_subscriptions ON
-                 wmbs_sub.id = child_subscriptions.id     
-               WHERE wmbs_fileset.open = 0 AND child_subscriptions.total IS Null AND
-                     COALESCE(sub_acquired.total_files, 0) = 0 AND
-                     COALESCE(sub_available.total_files, 0) = 0
-               AND (SELECT COUNT(wmbs_job.id) FROM wmbs_job
-                      INNER JOIN wmbs_jobgroup ON wmbs_jobgroup.id = wmbs_job.jobgroup
-                      WHERE wmbs_job.state != (SELECT id FROM wmbs_job_state WHERE name = 'cleanout')
-                      AND wmbs_jobgroup.subscription = wmbs_sub.id) = 0
-               AND (SELECT COUNT(wmbs_job.id) FROM wmbs_job
-                      INNER JOIN wmbs_jobgroup ON wmbs_jobgroup.id = wmbs_job.jobgroup
-                      WHERE :currTime - wmbs_job.state_time < :timeOut
-                      AND wmbs_jobgroup.subscription = wmbs_sub.id) = 0"""
+               LEFT OUTER JOIN wmbs_sub_files_available ON
+                 wmbs_sub_files_available.subscription = wmbs_subscription.id
+               LEFT OUTER JOIN wmbs_sub_files_acquired ON
+                 wmbs_sub_files_acquired.subscription = wmbs_subscription.id
+               LEFT OUTER JOIN wmbs_workflow_output ON
+                 wmbs_workflow_output.workflow_id = wmbs_subscription.workflow
+               LEFT OUTER JOIN wmbs_subscription child_subscription ON
+                 child_subscription.fileset = wmbs_workflow_output.output_fileset
+               LEFT OUTER JOIN wmbs_jobgroup ON
+                 wmbs_jobgroup.subscription = wmbs_subscription.id
+               LEFT OUTER JOIN wmbs_job ON
+                 wmbs_job.jobgroup = wmbs_jobgroup.id AND
+                 wmbs_job.state_time > :currTime - :timeOut
+               LEFT OUTER JOIN wmbs_job_state ON
+                 wmbs_job_state.id = wmbs_job.state AND
+                 wmbs_job_state.name != 'cleanout'
+             GROUP BY wmbs_subscription.id
+             HAVING COUNT(wmbs_sub_files_available.subscription) = 0
+             AND COUNT(wmbs_sub_files_acquired.subscription) = 0
+             AND COUNT(child_subscription.fileset) = 0
+             AND COUNT(wmbs_job_state.id) = 0
+             ORDER BY wmbs_subscription.id DESC
+             """
 
     def execute(self, timeOut = 0, conn = None, transaction = False):
-        binds = {'currTime': int(time.time()), 'timeOut': timeOut}
-        results = self.dbi.processData(self.sql, binds,
-                         conn = conn, transaction = transaction)
+
+        binds = { 'currTime' : int(time.time()),
+                  'timeOut' : timeOut }
+
+        results = self.dbi.processData(self.sql, binds, conn = conn,
+                                       transaction = transaction)
+
         return self.formatDict(results)


### PR DESCRIPTION
Major functional change is changing the order in which subscription
ids are returned from the GetFinishedSubscriptions DAO. If multiple
subscriptions are found in the same query, the ones with the higher
ids are deleted first. This fixes a bug in the Tier0 where a working
directory for subscription 2 was a subdir of the working directory
for subscription 1 and they were deleted out-of-order.

In the process of tracking this down I also rewrote and simplified
the query in the DAO.
