### PR TITLE
Bugfix for JobSubmitterPoller

### DIFF
--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -323,6 +323,7 @@ class JobSubmitterPoller(BaseWorkerThread):
                 possibleLocations = non_draining_sites
 
             if len(possibleLocations) == 0:
+                newJob['name'] = loadedJob['name']
                 badJobs.append(newJob)
                 continue
 


### PR DESCRIPTION
JobSubmitterPoller passes an incomplete object to the JSM if the job
has no valid sites. This fix adds the necessary field (name) to the job
if it ends up down that code path
