### PR TITLE
Bugfix DashboardReporter

### DIFF
--- a/src/python/WMCore/Services/Dashboard/DashboardReporter.py
+++ b/src/python/WMCore/Services/Dashboard/DashboardReporter.py
@@ -136,7 +136,7 @@ class DashboardReporter(WMObject):
             package['StatusDestination'] = job.get('location',
                                                    'NotAvailable')
 
-            if 'plugin' in job:
+            if job.get('plugin', None):
                 package['scheduler']     = job['plugin'][:-6]
 
             logging.debug("Sending: %s" % str(package))


### PR DESCRIPTION
The JobTracker fails jobs that come with a None plugin to the ChangeState.
This generates an error in the DashboardReporter.
