### PR TITLE
Reload PID information for MySQL,CouchDB servers during polling.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,16 @@
 WMCORE_JENKINS_REPLACEMENT_SOURCE.tar.gz
 .noseids
 *.patch
+
+
+.project
+.pydevproject
+.settings/
+TEST_AREA/
+list-tests-alerts.txt
+list-tests-reqmgr.txt
+run_my_tests.py
+setup.sh
+setup_environment_only.sh
+shutdown.sh
+tester_runner_bash.sh

--- a/src/python/WMComponent/AlertGenerator/Pollers/System.py
+++ b/src/python/WMComponent/AlertGenerator/Pollers/System.py
@@ -33,13 +33,15 @@ class ProcessCPUPoller(object):
         
         """
         try:
+            # raises: psutil.error.AccessDenied, psutil.error.NoSuchProcess
             pollProcess = lambda proc: proc.get_cpu_percent(PeriodPoller.PSUTIL_INTERVAL)
             v = sum([pollProcess(p) for p in processDetail.allProcs])
             return v
-        except (psutil.error.AccessDenied, psutil.error.NoSuchProcess) as ex:
+        except psutil.error.AccessDenied as ex:
             m = ("Can't get CPU usage of %s, reason: %s" %
                  (processDetail.getDetails(), ex))
             raise Exception(m)
+        # psutil.error.NoSuchProcess is handled higher
 
     
 
@@ -61,13 +63,15 @@ class ProcessMemoryPoller(object):
         """
         try:
             # get_memory_info(): returns RSS, VMS tuple (for reference)
+            # raises: psutil.error.AccessDenied, psutil.error.NoSuchProcess
             pollProcess = lambda proc: proc.get_memory_percent()
             v = sum([pollProcess(p) for p in processDetail.allProcs])
             return v
-        except (psutil.error.AccessDenied, psutil.error.NoSuchProcess) as ex:
+        except psutil.error.AccessDenied as ex:
             m = ("Can't get memory usage of %s, reason: %s" %
                  (processDetail.getDetails(), ex))
             raise Exception(m)
+        # psutil.error.NoSuchProcess is handled higher
                 
         
 


### PR DESCRIPTION
If the polled server process gets restarted (happens a lot with CouchDB),
the poller keeps sending alerts 'no such process'. Reload PID info for 
MySQL, CouchDB servers in case NoSuchProcess is detected. NB: restarting
of WMAgent components processes is handled differently.
