### PR TITLE
Implement general DQM Harvesting in WMAgent

### DIFF
--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -358,7 +358,8 @@ class JobSubmitterPoller(BaseWorkerThread):
                        frozenset(possibleLocations),
                        loadedJob.get("scramArch", None),
                        loadedJob.get("swVersion", None),
-                       loadedJob["name"])
+                       loadedJob["name"],
+                       loadedJob.get("proxyPath", None))
             
             self.jobDataCache[workflowName][jobID] = jobInfo
 
@@ -605,7 +606,8 @@ class JobSubmitterPoller(BaseWorkerThread):
                                'possibleSites': cachedJob[9],
                                'scramArch': cachedJob[10],
                                'swVersion': cachedJob[11],
-                               'name': cachedJob[12]}
+                               'name': cachedJob[12],
+                               'proxyPath': cachedJob[13]}
 
                     # Add to jobsToSubmit
                     jobsToSubmit[package].append(jobDict)

--- a/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
@@ -885,6 +885,9 @@ class CondorPlugin(BasePlugin):
         else:
             jdl.append('+DESIRED_Sites = \"%s\"\n' %(jobCE))
 
+        if job.get('proxyPath', None):
+            jdl.append('x509userproxy = %s\n' % job['proxyPath'])
+
         return jdl
 
     def getCEName(self, jobSite):

--- a/src/python/WMCore/BossAir/RunJob.py
+++ b/src/python/WMCore/BossAir/RunJob.py
@@ -26,7 +26,8 @@ class RunJob(dict):
                  cache_dir = None, status_time = None, packageDir = None,
                  sandbox = None, priority = None, site_cms_name = None,
                  taskType = None, possibleSites = [], sw_version = None,
-                 scram_arch = None, siteName = None, jobName = None ):
+                 scram_arch = None, siteName = None, jobName = None,
+                 proxyPath = None):
         """
         Just make sure you init the dictionary fields.
 
@@ -58,6 +59,7 @@ class RunJob(dict):
         self.setdefault('scramArch', scram_arch)
         self.setdefault('siteName', siteName)
         self.setdefault('name', jobName)
+        self.setdefault('proxyPath', proxyPath)
 
         return
 

--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrBrowser.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrBrowser.py
@@ -153,6 +153,8 @@ class ReqMgrBrowser(WebAPI):
             splitParams["events_per_job"] = int(submittedParams["events_per_job"])
             if submittedParams.has_key("events_per_lumi"):
                 splitParams["events_per_lumi"] = int(submittedParams["events_per_lumi"])
+        elif splittingAlgo == "Harvest":
+            splitParams["periodic_harvest_interval"] = int(submittedParams["periodic_harvest_interval"])
         elif 'Merg' in splittingTask:
             for field in ['min_merge_size', 'max_merge_size', 'max_merge_events']:
                 splitParams[field] = int(submittedParams[field])

--- a/src/python/WMCore/JobSplitting/Harvest.py
+++ b/src/python/WMCore/JobSplitting/Harvest.py
@@ -4,6 +4,7 @@ _Harvest_
 
 """
 import threading
+import os
 
 from WMCore.JobSplitting.JobFactory import JobFactory
 from WMCore.Services.UUID import makeUUID
@@ -85,6 +86,10 @@ class Harvest(JobFactory):
                 self.newJob(name = "%s-%s-%i" % (baseName, harvestType, jobCount))
                 for f in locationDict[location][run]:
                     self.currentJob.addFile(f)
+
+                #Check for proxy and ship it in the job if available
+                if 'X509_USER_PROXY' in os.environ:
+                    self.currentJob['proxyPath'] = os.environ['X509_USER_PROXY']
 
         return
 

--- a/src/python/WMCore/JobSplitting/LumiBased.py
+++ b/src/python/WMCore/JobSplitting/LumiBased.py
@@ -82,7 +82,7 @@ class LumiBased(JobFactory):
         splitOnFile     = bool(kwargs.get('halt_job_on_file_boundaries', True))
         ignoreACDC      = bool(kwargs.get('ignore_acdc_except', False))
         collectionName  = kwargs.get('collectionName', None)
-        splitOnRun      = kwargs.get('splitOnRun', True)
+        splitOnRun      = kwargs.get('splitOnRun', False)
         getParents      = kwargs.get('include_parents', False)
         runWhitelist    = kwargs.get('runWhitelist', [])
 

--- a/src/python/WMCore/WMBS/MySQL/JobSplitting/ReleasePeriodicJob.py
+++ b/src/python/WMCore/WMBS/MySQL/JobSplitting/ReleasePeriodicJob.py
@@ -27,7 +27,7 @@ class ReleasePeriodicJob(DBFormatter):
                       WHEN COUNT(wmbs_sub_files_acquired.subscription) > 0 THEN 0
                       WHEN COUNT(wmbs_job.id) = 0 THEN 1
                       ELSE 0
-                    END CASE
+                    END
              FROM wmbs_subscription
              INNER JOIN wmbs_sub_files_available ON
                wmbs_sub_files_available.subscription = wmbs_subscription.id

--- a/src/python/WMCore/WMSpec/Steps/Templates/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Templates/CMSSW.py
@@ -197,6 +197,35 @@ class CMSSWStepHelper(CoreHelper):
 
         return pickle.loads(self.data.application.configuration.pickledarguments)['globalTag']
 
+    def setDatasetName(self, datasetName):
+        """
+        _setDatasetName_
+
+        Set the dataset name in the pickled arguments
+        """
+        self.data.application.configuration.section_('arguments')
+        self.data.application.configuration.arguments.datasetName = datasetName
+
+        args = {}
+        if hasattr(self.data.application.configuration, "pickledarguments"):
+            args = pickle.loads(self.data.application.configuration.pickledarguments)
+        args['datasetName'] = datasetName
+        self.data.application.configuration.pickledarguments = pickle.dumps(args)
+
+        return
+
+    def getDatasetName(self):
+        """
+        _setDatasetName_
+
+        Retrieve the dataset name from the pickled arguments
+        """
+        if hasattr(self.data.application.configuration, "arguments"):
+            if hasattr(self.data.application.configuration.arguments, "datasetName"):
+                return self.data.application.configuration.arguments.datasetName
+
+        return pickle.loads(self.data.application.configuration.pickledarguments).get('datasetName', None)
+
     def setUserSandbox(self, userSandbox):
         """
         _setUserSandbox_

--- a/src/python/WMCore/WMSpec/Steps/Templates/DQMUpload.py
+++ b/src/python/WMCore/WMSpec/Steps/Templates/DQMUpload.py
@@ -79,7 +79,7 @@ class DQMUpload(Template):
         step.upload.URL = 'https://cmsweb.cern.ch/dqm/dev'
         step.upload.proxy = None
         step.section_("stageOut")
-        step.stageOut.active = True
+        step.stageOut.active = False
         step.stageOut.retryCount = 3
         step.stageOut.retryDelay = 300
         #step.stageOut.waitTime = 1200

--- a/src/templates/WMCore/WebTools/RequestManager/Splitting.tmpl
+++ b/src/templates/WMCore/WebTools/RequestManager/Splitting.tmpl
@@ -179,6 +179,14 @@ function generateProduction(splitAlgo, splitParams) {
   return procStr;
 }
 
+function generateHarvesting(splitAlgo, splitParams) {
+  var procStr = '<input type="hidden" name="splittingAlgo" value="Harvest"></input>\n';
+  procStr += "<table>"
+  procStr += generateInputRow("Periodic harvesting frequency:", "periodic_harvest_interval", splitParams);
+  procStr += "</table>\n";
+  return procStr;
+}
+
 function generateForm(taskName, splitAlgo, splitParams, taskType) {
   var frmStr = '<form name="' + taskName + '" action="../handleSplittingPage" method="POST">\n';
   frmStr += '<input type="hidden" name="requestName" VALUE="$requestName"></input>\n'; 
@@ -195,6 +203,8 @@ function generateForm(taskName, splitAlgo, splitParams, taskType) {
     frmStr += generateSkim(splitAlgo, splitParams);
   } else if (taskType == "Production" || taskType == "MultiProduction") {
     frmStr += generateProduction(splitAlgo, splitParams);
+  } else if (taskType == "Harvesting") {
+    frmStr += generateHarvesting(splitAlgo, splitParams);
   }
 
   frmStr += submitButton(taskName);

--- a/src/templates/WMCore/WebTools/RequestManager/WebRequestSchema.tmpl
+++ b/src/templates/WMCore/WebTools/RequestManager/WebRequestSchema.tmpl
@@ -76,18 +76,34 @@ Memory (Mbytes): <input type="text" name="Memory" size=10 value=2147483648 />
 Size per event (Kbytes): <input type="text" name="SizePerEvent" size=10 value=512000 /><br/>
 #end def
 
+#def dqmOptions
+DQM Sequences: <input type="text" name="DqmSequences" size=40 />
+DQM URL:
+<select name="DQMUploadUrl">
+    <option selected> https://cmsweb.cern.ch/dqm/dev </option>
+    <option> https://cmsweb.cern.ch/dqm/offline </option>
+    <option> https://cmsweb.cern.ch/dqm/relval </option>
+</select><br/>
+
+#end def
+
+#def scenarioBlock
+Scenario:
+  <select name="ProcScenario">
+    <option selected> pp</option>
+    <option>cosmics</option>
+    <option>hcalnzs</option>
+    <option>preprodmc</option>
+    <option>prodmc</option>
+    <option>relvalmc</option>
+    <option>relvalmcfs</option>
+  </select><br/>
+#end def
+
 #def configBlock($radioName, $scenarioName, $cacheName, $type)
 Configuration <br>
-  <input type="radio" name=$radioName value="scenario" /> Scenario
-    <select name="Scenario">
-      <option selected> pp</option>
-      <option>cosmics</option>
-      <option>hcalnzs</option>
-      <option>preprodmc</option>
-      <option>prodmc</option>
-      <option>relvalmc</option>
-      <option>relvalmcfs</option>
-    </select><br/>
+  <input type="radio" name=$radioName value="scenario" /> Scenario <br/>
+  $scenarioBlock
   <input type="radio" name=$radioName value="couchDB" /> $type ConfigCache ID
     <!--<input type="text" name="$cacheName" size=80 />
     <select name=$cacheName>
@@ -99,9 +115,7 @@ Configuration <br>
        <input name="$cacheName" size=80 id="couchinput" type="text">
        <div id="couchcontainer"></div>
     </div>
-  <br/>
-
-Global Tag: <input type="text" name="GlobalTag" size=20 value=""/> &nbsp &nbsp
+Global Tag: <input type="text" name="GlobalTag" size=20 value=""/> &nbsp &nbsp <br>
 #end def
 
 #def campaignBlock
@@ -193,6 +207,7 @@ First lumi: <input type="text" name="FirstLumi" size=10 value=1 /><br/>
 Include Parents: <select name="IncludeParents"><option>True</option><option selected>False</option></select><br/>
             $campaignBlock
             $configBlock("inputMode", "Scenario", "ProcConfigCacheID", "Reco")
+            $dqmOptions
             $ioBlock
             $skimBlock
             $runBlockBlock
@@ -249,6 +264,7 @@ Include Parents: <select name="IncludeParents"><option>True</option><option sele
             $campaignBlock
 Multicore: <input type="text" name="Multicore" size=2 value="" /> <br/>
             $configBlock("inputMode", "Scenario", "ProcConfigCacheID", "Processing")
+            $dqmOptions
             $ioBlock
             $runBlockBlock
             $performanceBlock
@@ -270,6 +286,8 @@ Include Parents: <select name="IncludeParents"><option>True</option><option sele
             $campaignBlock
             $ioBlock
 <br/>
+            $scenarioBlock
+            $dqmOptions
 Step One CacheCache ID: <input type="text" name="StepOneConfigCacheID" size=80 /><br/>
 Step One Output Module Name: <input type="text" name="StepOneOutputModuleName" size=20 /><br/>
 Step Two CacheCache ID: <input type="text" name="StepTwoConfigCacheID" size=80 /><br/>


### PR DESCRIPTION
This is the version without changes to the specs.

Changes:
- Disable stageOut in DQM step. We don't want to store the file, it is only for the DQM GUI.
- Integrate the Harvest splitting algorithm in the splitting page in ReqMgr
- If there is a proxy available under X509_USER_PROXY, the Harvest
  splitter will use it and ship it in the job pickle, if CondorPlugin
  finds such proxy then it will set it in the jdl
- The DQM executor now supports 3 possible input proxies:
  - A proxy in the sandbox
  - A proxy in the environment (X509_USER_PROXY)
  - A proxy whose path is defined in self.upload.proxy
- Given that Harvesting works with an scenario then StdBase must support getting an scenario
  even when a ConfigCache is provided, to ensure this then self.procScenario was moved up to
  StdBase and it is obtained from ProcScenario. Any support of Scenario as the key in the input
  arguments was dropped. Also the ReqMgr doesn't delete a scenario when it finds a config cache.
- All merge tasks created using addMergeTask that have DQM output will
  have a DQM Harvest task attached by default (can be changed passing
  doHarvesting = False). This task will use the upload proxy
  in self.dqmUploadProxy, the url in self.dqmUploadUrl and the dqm
  sequences in self.dqmSequences. dqmSequences is now a StdBase attribute.
- Merge for DQM changed a bit, it accepts the same merge size and event parameters
  as the other data tiers but still requires that the merges are not performed
  across run.

Include DQM Harvesting options in the ReqMgr

Modify the create request schema to support the DQM harvesting
for both ReReco and ReDigi workflows

Deactivate run splitting restrictions

Set the splitting algorithms to process and merge
different runs together by default, even for DQM.
