### PR TITLE
Implement general DQM Harvesting in WMAgent

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/DataProcessing.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/DataProcessing.py
@@ -121,11 +121,6 @@ class DataProcessingWorkloadFactory(StdBase):
         # Get the ProcConfigCacheID
         self.procConfigCacheID = arguments.get("ProcConfigCacheID", None)
 
-        if arguments.has_key("Scenario"):
-            self.procScenario = arguments.get("Scenario", None)
-        else:
-            self.procScenario = arguments.get("ProcScenario", None)
-
         # Optional arguments that default to something reasonable.
         self.dbsUrl = arguments.get("DbsUrl", "http://cmsdbsprod.cern.ch/cms_dbs_prod_global/servlet/DBSServlet")
         self.blockBlacklist = arguments.get("BlockBlacklist", [])

--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -162,10 +162,6 @@ class PromptRecoWorkloadFactory(StdBase):
                                     self.procJobSplitAlgo,
                                     recoOutLabel)
                 recoMergeTasks[recoOutInfo['dataTier']] = mergeTask
-	    	if recoOutInfo['dataTier'] in [ "DQM", "DQMROOT" ]:
-			self.addDQMHarvestTask(mergeTask, "Merged",
-			uploadProxy = self.dqmUploadProxy,
-			doLogCollect = False)
 
             else:
                 alcaTask = recoTask.addTask("AlcaSkim")
@@ -245,16 +241,13 @@ class PromptRecoWorkloadFactory(StdBase):
         # Required parameters that must be specified by the Requestor.
         self.frameworkVersion = arguments['CMSSWVersion']
         self.globalTag = arguments['GlobalTag']
-        self.procScenario = arguments['ProcScenario']
         self.writeTiers = arguments['WriteTiers']
         self.alcaSkims = arguments['AlcaSkims']
-        self.dqmSequences = arguments['DqmSequences']
         self.inputDataset = arguments['InputDataset']
         self.promptSkims = arguments['PromptSkims']
         self.couchURL = arguments['CouchURL']
         self.couchDBName = arguments['CouchDBName']
         self.initCommand = arguments['InitCommand']
-        self.dqmUploadProxy = arguments['DQMUploadProxy']
 
 
         if arguments.has_key('Multicore'):

--- a/src/python/WMCore/WMSpec/StdSpecs/ReReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/ReReco.py
@@ -150,7 +150,7 @@ class ReRecoWorkloadFactory(DataProcessingWorkloadFactory):
                                                     couchURL = schema["CouchURL"],
                                                     couchDBName = schema["CouchDBName"],
                                                     getOutputModules = True)
-        elif not schema.get('ProcScenario', None) and not schema.get('Scenario', None):
+        elif not schema.get('ProcScenario', None):
             self.raiseValidationException(msg = "No Scenario or Config in Processing Request!")
 
         try:

--- a/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
@@ -110,11 +110,11 @@ def validateSubTask(task, firstTask = False):
             raise WMSpecFactoryException(msg)
         
     # configuration checks
-    check = task.has_key("Scenario") or task.has_key("ConfigCacheID")
+    check = task.has_key("ProcScenario") or task.has_key("ConfigCacheID")
     if not check:
         msg = "Task %s has no Scenario or ConfigCacheID, one of these must be provided" % task['TaskName']
         raise WMSpecFactoryException(msg)
-    if task.has_key("Scenario"):
+    if task.has_key("ProcScenario"):
         if not task.has_key("ScenarioMethod"):
             msg = "Scenario Specified for Task %s but no ScenarioMethod provided" % task['TaskName']
             raise WMSpecFactoryException(msg)
@@ -331,16 +331,13 @@ class TaskChainWorkloadFactory(StdBase):
         scenarioArgs = {}
         couchUrl = self.couchURL
         couchDB = self.couchDBName
-        if taskConf.get("Scenario", None) != None:
-            scenario = taskConf['Scenario']
+        if taskConf.get("ProcScenario", None) != None:
+            self.procScenario = taskConf['ProcScenario']
             scenarioFunc = taskConf['ScenarioMethod']
             scenarioArgs = taskConf['ScenarioArguments']
-            couchUrl = None
-            couchDb = None
-            couchConfig = None            
             
         outputMods = self.setupProcessingTask(task, "Processing", inputDataset, inputStep = inpStep, inputModule=inpMod,
-                                            scenarioName = scenario, scenarioFunc = scenarioFunc, scenarioArgs = scenarioArgs,
+                                            scenarioName = self.procScenario, scenarioFunc = scenarioFunc, scenarioArgs = scenarioArgs,
                                             couchURL = couchUrl, couchDBName = couchDB,
                                             configDoc = configCacheID, splitAlgo = splitAlgorithm,
                                             splitArgs = splitArguments, stepType = cmsswStepType)

--- a/src/python/WMCore/WMSpec/StdSpecs/Tier1PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Tier1PromptReco.py
@@ -234,10 +234,8 @@ class Tier1PromptRecoWorkloadFactory(StdBase):
         # Required parameters that must be specified by the Requestor.
         self.frameworkVersion = arguments['CMSSWVersion']
         self.globalTag = arguments['GlobalTag']
-        self.procScenario = arguments['ProcScenario']
         self.writeTiers = arguments['WriteTiers']
         self.alcaSkims = arguments['AlcaSkims']
-        self.dqmSequences = arguments['DqmSequences']
         self.inputDataset = arguments['InputDataset']
         self.promptSkims = arguments['PromptSkims']
         self.couchURL = arguments['CouchURL']

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
@@ -513,7 +513,7 @@ class TaskChainTests(unittest.TestCase):
                 "TaskName" : "Reco",
                 "InputTask" : "DigiHLT",
                 "InputFromOutputModule" : "writeRAWDIGI",
-                "Scenario" : "pp",
+                "ProcScenario" : "pp",
                 "ScenarioMethod" : "promptReco",
                 "ScenarioArguments" : { 'outputs' : [ { 'dataTier' : "RECO",
                                                         'moduleLabel' : "RECOoutput" },
@@ -528,7 +528,7 @@ class TaskChainTests(unittest.TestCase):
                 "TaskName" : "ALCAReco",
                 "InputTask" : "Reco",
                 "InputFromOutputModule" : "ALCARECOoutput",
-                "Scenario" : "pp",
+                "ProcScenario" : "pp",
                 "ScenarioMethod" : "alcaReco",
                 "ScenarioArguments" : { 'outputs' : [ { 'dataTier' : "ALCARECO",
                                                         'moduleLabel' : "ALCARECOoutput" } ] },
@@ -575,13 +575,13 @@ class TaskChainTests(unittest.TestCase):
         reco = self.workload.getTaskByPath("/YankingTheChain/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco")
         recoStep = reco.getStepHelper("cmsRun1")
         recoAppConf = recoStep.data.application.configuration
-        self.assertEqual(recoAppConf.scenario, arguments['Task2']['Scenario'])
+        self.assertEqual(recoAppConf.scenario, arguments['Task2']['ProcScenario'])
         self.assertEqual(recoAppConf.function, arguments['Task2']['ScenarioMethod'])
         
         alca = self.workload.getTaskByPath("/YankingTheChain/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergeALCARECOoutput/ALCAReco")
         alcaStep = alca.getStepHelper("cmsRun1")
         alcaAppConf = alcaStep.data.application.configuration
-        self.assertEqual(alcaAppConf.scenario, arguments['Task3']['Scenario'])
+        self.assertEqual(alcaAppConf.scenario, arguments['Task3']['ProcScenario'])
         self.assertEqual(alcaAppConf.function, arguments['Task3']['ScenarioMethod'])
         
     def testD(self):
@@ -614,7 +614,7 @@ class TaskChainTests(unittest.TestCase):
                 "InputDataset" : "/DoubleElectron/Run2011A-v1/RAW", 
                 "SplittingAlgorithm"  : "LumiBased",
                 "SplittingArguments" : {"lumis_per_job" : 1},
-                "Scenario" : "pp",
+                "ProcScenario" : "pp",
                 "ScenarioMethod" : "promptReco",
                 "ScenarioArguments" : { 'outputs' : [ { 'dataTier' : "RECO",
                                                         'moduleLabel' : "RECOoutput" },
@@ -630,7 +630,7 @@ class TaskChainTests(unittest.TestCase):
                 "TaskName" : "AlcaSkimming",
                 "InputTask" : "PromptReco",
                 "InputFromOutputModule" : "ALCARECOoutput",
-                "Scenario" : "pp",
+                "ProcScenario" : "pp",
                 "ScenarioMethod" : "alcaSkimming",
                 "ScenarioArguments" : { 'outputs' : [ { 'dataTier' : "ALCARECO",
                                                         'moduleLabel' : "ALCARECOoutput" } ],


### PR DESCRIPTION
These are the spec changes.

Changes:
- Disable stageOut in DQM step. We don't want to store the file, it is only for the DQM GUI.
- Integrate the Harvest splitting algorithm in the splitting page in ReqMgr
- If there is a proxy available under X509_USER_PROXY, the Harvest
  splitter will use it and ship it in the job pickle, if CondorPlugin
  finds such proxy then it will set it in the jdl
- The DQM executor now supports 3 possible input proxies:
  - A proxy in the sandbox
  - A proxy in the environment (X509_USER_PROXY)
  - A proxy whose path is defined in self.upload.proxy
- Given that Harvesting works with an scenario then StdBase must support getting an scenario
  even when a ConfigCache is provided, to ensure this then self.procScenario was moved up to
  StdBase and it is obtained from ProcScenario. Any support of Scenario as the key in the input
  arguments was dropped. Also the ReqMgr doesn't delete a scenario when it finds a config cache.
- All merge tasks created using addMergeTask that have DQM output will
  have a DQM Harvest task attached by default (can be changed passing
  doHarvesting = False). This task will use the upload proxy
  in self.dqmUploadProxy, the url in self.dqmUploadUrl and the dqm
  sequences in self.dqmSequences. dqmSequences is now a StdBase attribute.
- Merge for DQM changed a bit, it accepts the same merge size and event parameters
  as the other data tiers but still requires that the merges are not performed
  across run.

Include DQM Harvesting options in the ReqMgr

Modify the create request schema to support the DQM harvesting
for both ReReco and ReDigi workflows

Deactivate run splitting restrictions

Set the splitting algorithms to process and merge
different runs together by default, even for DQM.
