### PR TITLE
Create the inactive doc in the old active db 

### DIFF
--- a/src/python/WMCore/Database/CMSCouch.py
+++ b/src/python/WMCore/Database/CMSCouch.py
@@ -573,7 +573,7 @@ class RotatingDatabase(Database):
         self.server = CouchServer(url)
 
         # self is the "active" database
-        Database.__init__(self, self._get_new_name(), url, size)
+        Database.__init__(self, self.basename, url, size)
         # forcibly make sure I exist
         self.server.connectDatabase(self.name)
 


### PR DESCRIPTION
When rotating a database, the inactive doc should be created in the old active db which becomes inactive and not in the actual active one.   
