### PR TITLE
Include RequestName in the Condor JDL

### DIFF
--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -117,7 +117,7 @@ class JobSubmitterPoller(BaseWorkerThread):
                 logging.debug("Config: %s" % config)
             except:
                 pass
-            raise JobSubmitterException(msg)
+            raise JobSubmitterPollerException(msg)
 
 
         # Now the DAOs
@@ -359,7 +359,8 @@ class JobSubmitterPoller(BaseWorkerThread):
                        loadedJob.get("scramArch", None),
                        loadedJob.get("swVersion", None),
                        loadedJob["name"],
-                       loadedJob.get("proxyPath", None))
+                       loadedJob.get("proxyPath", None),
+                       newJob['request_name'])
             
             self.jobDataCache[workflowName][jobID] = jobInfo
 
@@ -607,7 +608,8 @@ class JobSubmitterPoller(BaseWorkerThread):
                                'scramArch': cachedJob[10],
                                'swVersion': cachedJob[11],
                                'name': cachedJob[12],
-                               'proxyPath': cachedJob[13]}
+                               'proxyPath': cachedJob[13],
+                               'requestName': cachedJob[14]}
 
                     # Add to jobsToSubmit
                     jobsToSubmit[package].append(jobDict)
@@ -638,8 +640,6 @@ class JobSubmitterPoller(BaseWorkerThread):
         Actually do the submission of the jobs
         """
 
-        agentName = self.config.Agent.agentName
-        lenWork   = 0
         jobList   = []
         idList    = []
 

--- a/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
@@ -888,6 +888,9 @@ class CondorPlugin(BasePlugin):
         if job.get('proxyPath', None):
             jdl.append('x509userproxy = %s\n' % job['proxyPath'])
 
+        if job.get('requestName', None):
+            jdl.append('+WMAgent_RequestName = %s\n' % job['requestName'])
+
         return jdl
 
     def getCEName(self, jobSite):

--- a/src/python/WMCore/BossAir/RunJob.py
+++ b/src/python/WMCore/BossAir/RunJob.py
@@ -27,7 +27,7 @@ class RunJob(dict):
                  sandbox = None, priority = None, site_cms_name = None,
                  taskType = None, possibleSites = [], sw_version = None,
                  scram_arch = None, siteName = None, jobName = None,
-                 proxyPath = None):
+                 proxyPath = None, requestName = None):
         """
         Just make sure you init the dictionary fields.
 
@@ -60,6 +60,7 @@ class RunJob(dict):
         self.setdefault('siteName', siteName)
         self.setdefault('name', jobName)
         self.setdefault('proxyPath', proxyPath)
+        self.setdefault('requestName', requestName)
 
         return
 

--- a/src/python/WMCore/WMBS/MySQL/Jobs/ListForSubmitter.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/ListForSubmitter.py
@@ -14,7 +14,8 @@ class ListForSubmitter(DBFormatter):
     sql = """SELECT wmbs_job.id AS id, wmbs_job.name AS name,
                     wmbs_job.cache_dir AS cache_dir,
                     wmbs_sub_types.name AS type, wmbs_job.retry_count AS retry_count,
-                    wmbs_subscription.workflow as workflow
+                    wmbs_subscription.workflow as workflow,
+                    wmbs_workflow.name as request_name
                     FROM wmbs_job
                INNER JOIN wmbs_jobgroup ON
                  wmbs_job.jobgroup = wmbs_jobgroup.id
@@ -24,6 +25,8 @@ class ListForSubmitter(DBFormatter):
                  wmbs_subscription.subtype = wmbs_sub_types.id
                INNER JOIN wmbs_job_state ON
                  wmbs_job.state = wmbs_job_state.id
+               INNER JOIN wmbs_workflow ON
+                 wmbs_subscription.workflow = wmbs_workflow.id
              WHERE wmbs_job_state.name = 'created'"""
 
     def execute(self, conn = None, transaction = False):


### PR DESCRIPTION
Changes:
- Modify the ListForSubmitter DAO to fetch the workflow name
- Pass the request name in the RunJob objects
- Include the line +WMAgent_RequestName in the condor JDL

Fixes #3970
