### PR TITLE
WorkQueue: Handle open blocks.

### DIFF
--- a/src/couchapps/WorkQueue/views/wmbsInjectStatusByRequest/map.js
+++ b/src/couchapps/WorkQueue/views/wmbsInjectStatusByRequest/map.js
@@ -1,7 +1,8 @@
 function(doc) {
     var ele = doc["WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement"];
     if (ele) {
-        if ((ele.Status == 'Running' || ele.Status == 'Done'
+        if (!ele.OpenForNewData &&
+            (ele.Status == 'Running' || ele.Status == 'Done'
              || ele.Status == 'Failed')) {
             emit(ele.RequestName, true);
         } else {

--- a/src/python/WMCore/WorkQueue/DataStructs/WorkQueueElement.py
+++ b/src/python/WMCore/WorkQueue/DataStructs/WorkQueueElement.py
@@ -61,6 +61,8 @@ class WorkQueueElement(dict):
         self.setdefault('NumOfFilesAdded', 0)
         # Mask used to constrain MC run/lumi ranges
         self.setdefault('Mask', None)
+        # is new data being added to the inputs i.e. open block with new files?
+        self.setdefault('OpenForNewData', False)
 
         # set to true when updated from a WorkQueueElementResult
         self.modified = False
@@ -139,7 +141,8 @@ class WorkQueueElement(dict):
 
     def inEndState(self):
         """Have we finished processing"""
-        return self.isComplete() or self.isFailed() or self.isCanceled()
+        # elements only finished once they are no longer open for new data
+        return not self['OpenForNewData'] and (self.isComplete() or self.isFailed() or self.isCanceled())
 
     def isComplete(self):
         return self['Status'] == 'Done'

--- a/src/python/WMCore/WorkQueue/Policy/Start/Block.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Block.py
@@ -42,7 +42,8 @@ class Block(StartPolicyInterface):
                                  NumberOfFiles = int(block['NumberOfFiles']),
                                  NumberOfEvents = int(block['NumberOfEvents']),
                                  Jobs = ceil(float(block[self.args['SliceType']]) /
-                                             float(self.args['SliceSize']))
+                                             float(self.args['SliceSize'])),
+                                 OpenForNewData = True if str(block.get('OpenForWriting')) == '1' else False
                                  )
 
 

--- a/src/python/WMCore/WorkQueue/WMBSHelper.py
+++ b/src/python/WMCore/WorkQueue/WMBSHelper.py
@@ -431,7 +431,7 @@ class WMBSHelper(WMConnectionBase):
         # Add files to DBSBuffer
         self._createFilesInDBSBuffer()
 
-        self.topLevelFileset.markOpen(False)
+        self.topLevelFileset.markOpen(block.get('IsOpen', False))
         return totalFiles
 
     def getMergeOutputMapping(self):

--- a/src/python/WMQuality/Emulators/DBSClient/DBSReader.py
+++ b/src/python/WMQuality/Emulators/DBSClient/DBSReader.py
@@ -76,7 +76,7 @@ class DBSReader:
         result = { block : {
             "StorageElements" : self.listFileBlockLocation(block),
             "Files" : self.listFilesInBlock(block),
-            "IsOpen" : False,
+            "IsOpen" : self.dataBlocks._openForWriting(),
             }
                 }
         return result
@@ -99,7 +99,7 @@ class DBSReader:
         result = { fileBlockName: {
             "StorageElements" : self.listFileBlockLocation(fileBlockName),
             "Files" : self.listFilesInBlockWithParents(fileBlockName),
-            "IsOpen" : False,
+            "IsOpen" : self.dataBlocks._openForWriting(),
 
             }
                    }
@@ -142,6 +142,7 @@ class DBSReader:
 
             result['path'] = dataset
             result['block'] = block
+            result['OpenForWriting'] = '1' if self.dataBlocks._openForWriting() else '0'
 
         if dataset:
             if self.dataBlocks.getBlocks(dataset):

--- a/src/python/WMQuality/Emulators/DataBlockGenerator/DataBlockGenerator.py
+++ b/src/python/WMQuality/Emulators/DataBlockGenerator/DataBlockGenerator.py
@@ -25,9 +25,16 @@ class DataBlockGenerator(object):
                                      'NumberOfFiles' : GlobalParams.numOfFilesPerBlock(),
                                      'NumberOfLumis' : GlobalParams.numOfLumisPerBlock(),
                                      'Size' : size,
-                                     'Parents' : ()}
+                                     'Parents' : (),
+                                     'OpenForWriting' : '1' if self._openForWriting() else '0'}
                                      )
         return blocks
+
+    def _openForWriting(self):
+      """Is block open or closed?
+      Should do this on a block by block basis but so far not needed,
+      just make a global state"""
+      return GlobalParams.blocksOpenForWriting()
 
     def getParentBlock(self, block, numberOfParents = 1):
         blocks = []

--- a/src/python/WMQuality/Emulators/DataBlockGenerator/Globals.py
+++ b/src/python/WMQuality/Emulators/DataBlockGenerator/Globals.py
@@ -41,6 +41,7 @@ class GlobalParams(object):
     _num_of_lumis_per_block = 2
     _num_of_events_per_file = 1000
     _size_of_file = 20000000
+    _blocks_open_for_writing = False
     
     @staticmethod
     def numOfBlocksPerDataset():
@@ -94,7 +95,15 @@ class GlobalParams(object):
     def getRunNumberForBlock(blockName):
         #assumes blockName is contains number after '#'
         return int(blockName.split('#')[-1])
-    
+
+    @staticmethod
+    def setBlocksOpenForWriting(blocksOpenForWriting):
+        GlobalParams._blocks_open_for_writing = blocksOpenForWriting
+
+    @staticmethod
+    def blocksOpenForWriting():
+        return GlobalParams._blocks_open_for_writing
+
     @staticmethod
     def resetParams():
         """
@@ -106,4 +115,5 @@ class GlobalParams(object):
         GlobalParams._num_of_lumis_per_block = 2
         GlobalParams._num_of_events_per_file = 1000
         GlobalParams._size_of_file = 20000000
+        GlobalParams._blocks_open_for_writing = False
         


### PR DESCRIPTION
Fix #3980

Periodically check open blocks for new files and inject into wmbs. Once
block closed in dbs close fileset in wmbs.

Signed-off-by: stuartw stuart.wakefield@gmail.com
