### PR TITLE
fix some issues in the fwj report

### DIFF
--- a/src/python/WMCore/FwkJobReport/Report.py
+++ b/src/python/WMCore/FwkJobReport/Report.py
@@ -323,7 +323,7 @@ class Report:
         handle.close()
         return
 
-    def unpersist(self, filename):
+    def unpersist(self, filename, reportname = None):
         """
         _unpersist_
 
@@ -332,6 +332,11 @@ class Report:
         handle = open(filename, 'r')
         self.data = cPickle.load(handle)
         handle.close()
+
+        # old self.report (if it existed) became unattached
+        if reportname:
+            self.report = getattr(self.data, reportname)
+
         return
 
     def addOutputModule(self, moduleName):
@@ -467,8 +472,6 @@ class Report:
         # All right, the rest should be JSONalizable python primitives
         for entry in keyList:
             setattr(fileRef, entry, attrs[entry])
-
-
 
         return fileRef
 

--- a/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
@@ -130,8 +130,8 @@ class DQMUpload(Executor):
                 continue
 
             # First, get everything from a file and 'unpersist' it
-            stepReport = Report(step)
-            stepReport.unpersist(reportLocation)
+            stepReport = Report()
+            stepReport.unpersist(reportLocation, step)
 
             # Don't upload nor stage out files from bad steps.
             if not stepReport.stepSuccessful(step):

--- a/src/python/WMCore/WMSpec/Steps/Executors/StageOut.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/StageOut.py
@@ -125,8 +125,8 @@ class StageOut(Executor):
                               % (step, stepLocation))
                 continue
             # First, get everything from a file and 'unpersist' it
-            stepReport = Report(step)
-            stepReport.unpersist(reportLocation)
+            stepReport = Report()
+            stepReport.unpersist(reportLocation, step)
             taskID = getattr(stepReport.data, 'id', None)
 
             # Don't stage out files from bad steps.

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -830,8 +830,8 @@ class WMTaskHelper(TreeHelper):
         for taskStep in taskSteps:
             reportPath = os.path.join(jobLocation, taskStep, "Report.pkl")
             if os.path.isfile(reportPath):
-                stepReport = Report.Report(taskStep)
-                stepReport.unpersist(reportPath)
+                stepReport = Report.Report()
+                stepReport.unpersist(reportPath, taskStep)
                 finalReport.setStep(taskStep, stepReport.retrieveStep(taskStep))
             else:
                 # Then we have a missing report

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/StageOut_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/StageOut_t.py
@@ -215,7 +215,7 @@ class otherStageOutTest(unittest.TestCase):
 
     @attr('integration')
     def testCPBackendStageOutAgainstReportNew(self):
-        myReport = Report('cmsRun1')
+        myReport = Report()
         myReport.unpersist(os.path.join( self.testDir, 'UnitTests','WMTaskSpace', 'cmsRun1' , 'Report.pkl'))
         myReport.data.cmsRun1.status = 0
         myReport.persist(os.path.join( self.testDir,'UnitTests', 'WMTaskSpace', 'cmsRun1' , 'Report.pkl'))
@@ -230,7 +230,7 @@ class otherStageOutTest(unittest.TestCase):
 
     @attr('integration')
     def testCPBackendStageOutAgainstReportFailedStepNew(self):
-        myReport = Report('cmsRun1')
+        myReport = Report()
         myReport.unpersist(os.path.join( self.testDir, 'UnitTests','WMTaskSpace', 'cmsRun1' , 'Report.pkl'))
         myReport.data.cmsRun1.status = 1
         myReport.persist(os.path.join( self.testDir,'UnitTests', 'WMTaskSpace', 'cmsRun1' , 'Report.pkl'))
@@ -247,7 +247,7 @@ class otherStageOutTest(unittest.TestCase):
     @attr('integration')
     def testCPBackendStageOutAgainstReportOld(self):
         
-        myReport = Report('cmsRun1')
+        myReport = Report()
         myReport.unpersist(os.path.join( self.testDir,'UnitTests', 'WMTaskSpace', 'cmsRun1' , 'Report.pkl'))
         myReport.data.cmsRun1.status = 0
         myReport.persist(os.path.join( self.testDir,'UnitTests', 'WMTaskSpace', 'cmsRun1' , 'Report.pkl'))
@@ -262,7 +262,7 @@ class otherStageOutTest(unittest.TestCase):
 
     @attr('integration') 
     def testCPBackendStageOutAgainstReportFailedStepOld(self):
-        myReport = Report('cmsRun1')
+        myReport = Report()
         myReport.unpersist(os.path.join( self.testDir,'UnitTests', 'WMTaskSpace', 'cmsRun1' , 'Report.pkl'))
         myReport.data.cmsRun1.status = 1
         myReport.persist(os.path.join( self.testDir, 'UnitTests','WMTaskSpace', 'cmsRun1' , 'Report.pkl'))
@@ -280,7 +280,7 @@ class otherStageOutTest(unittest.TestCase):
     def testOnWorkerNodes(self):
         raise RuntimeError
         # Stage a file out, stage it back in, check it, delete it
-        myReport = Report('cmsRun1')
+        myReport = Report()
         myReport.unpersist(os.path.join( self.testDir,'UnitTests', 'WMTaskSpace', 'cmsRun1' , 'Report.pkl'))
         myReport.data.cmsRun1.status = 1
         del myReport.data.cmsRun1.output
@@ -305,7 +305,7 @@ class otherStageOutTest(unittest.TestCase):
         print "stageout done"
         
         # pull in the report with the stage out info
-        myReport = Report('cmsRun1')
+        myReport = Report()
         myReport.unpersist(os.path.join( self.testDir,'UnitTests', 'WMTaskSpace', 'cmsRun1' , 'Report.pkl'))
         print "Got the stage out data back"
         print myReport.data


### PR DESCRIPTION
When calling the constructor of the Report class with
a step name, it adds the step and initializes self.report
to point at the data for that step. Some other methods
to modify the report then work off self.report.

When unpersisting the report (ie. loading data from
a file and overwriting the internal data), self.report
will now no longer point at the internal data structures.
The modification methods will still work, they just
modify some data that is no longer attached to the
class and will not be written out when the report is
persistet again.

Fix this by allowing to pass a step name to the unpersist
methos, it then initializes self.report to point at the
data for that step after loading the file. Also fix a
few places where the Report class is used to not pass
a stepname to the constructor if it's not used.
