### PR TITLE
add support for Alca Harvesting

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -173,7 +173,11 @@ class StdBase(object):
             elif scenarioFunc == "alcaSkim":
                 for alcaSkim in scenarioArgs.get('skims',[]):
                     moduleLabel = "ALCARECOStream%s" % alcaSkim
-                    outputModules[moduleLabel] = { 'dataTier' : "ALCARECO",
+                    if alcaSkim == "PromptCalibProd":
+                        dataTier = "ALCAPROMPT"
+                    else:
+                        dataTier = "ALCARECO"
+                    outputModules[moduleLabel] = { 'dataTier' : dataTier,
                                                    'primaryDataset' : scenarioArgs.get('primaryDataset'),
                                                    'filterName' : alcaSkim }
 

--- a/src/python/WMCore/WMSpec/Steps/Builders/AlcaHarvest.py
+++ b/src/python/WMCore/WMSpec/Steps/Builders/AlcaHarvest.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""
+_AlcaHarvest_
+
+Builder implementation for AlcaHarvest
+
+"""
+from WMCore.WMSpec.Steps.Builder import Builder
+from WMCore.WMSpec.ConfigSectionTree import nodeName
+
+
+class AlcaHarvest(Builder):
+    """
+    _AlcaHarvest_
+
+    Build a working area for a AlcaHarvest step
+
+    """
+
+    def build(self, step, workingDir, **args):
+        """
+        _build_
+
+        implement build interface for DQMUpload Step
+
+        """
+        stepName = nodeName(step)
+        stepWorkingArea = "%s/%s" % (workingDir, stepName)
+        self.installWorkingArea(step, stepWorkingArea)
+        print "Builders.AlcaHarvest.build called on %s" % stepName

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/AlcaHarvest.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/AlcaHarvest.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+"""
+_AlcaHarvest_
+
+Diagnostic implementation for a AlcaHarvest job
+
+
+"""
+
+import os
+
+from WMCore.WMSpec.Steps.Diagnostic import Diagnostic, DiagnosticHandler
+
+
+class Exit60319(DiagnosticHandler):
+    def __call__(self, errCode, executor, **args):
+        msg = "Failed to copy AlcaHarvest condition file to target directory."
+        executor.report.addError(executor.step._internal_name,
+                                 60319, "AlcaHarvestFailure", msg)
+
+
+class AHExceptionHandler(DiagnosticHandler):
+    """
+    _AHExceptionHandler_
+
+    Generic handler for the AlcaHarvest step
+
+    I have no idea what this should do
+
+    """
+    def __call__(self, errCode, executor, **args):
+        """
+        _operator()_
+
+        Twiddle thumbs, contemplate navel, toss coin
+
+        """
+        jobRepXml = os.path.join(executor.step.builder.workingDir,
+                                 executor.step.output.jobReport)
+
+        if not os.path.exists(jobRepXml):
+            # no report => Error
+            msg = "No Job Report Found: %s" % jobRepXml
+            executor.report.addError(50115, "MissingJobReport", msg)
+            return
+        
+        # job report XML exists, load the exception information from it
+        executor.report.parse(jobRepXml)
+        
+        # make sure the report has the error in it
+        errSection = getattr(executor.report.report, "errors", None)
+        if errSection == None:
+            msg = "Job Report contains no error report, but AlcaHarvest exited non-zero: %s" % errCode
+            executor.report.addError(50116, "MissingErrorReport", msg)
+        else:
+            #check exit code in report is non zero
+            if executor.report.report.status == 0:
+                msg = "Job Report contains no error report, but AlcaHarvest exited non-zero: %s" % errCode
+                executor.report.addError(50116, "MissingErrorReport", msg)
+        return
+
+class AlcaHarvest(Diagnostic):
+
+    def __init__(self):
+        Diagnostic.__init__(self)
+        self.handlers[60319] = Exit60319()
+
+        catchAll = AHExceptionHandler()
+        [self.handlers.__setitem__(x, catchAll) for x in range(0, 255) if not self.handlers.has_key(x)]

--- a/src/python/WMCore/WMSpec/Steps/Emulators/AlcaHarvest.py
+++ b/src/python/WMCore/WMSpec/Steps/Emulators/AlcaHarvest.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+"""
+_AlcaHarvest_
+
+Basic Emulator for AlcaHarvest Step
+
+"""
+
+from WMCore.WMSpec.Steps.Emulator import Emulator
+
+class AlcaHarvest(Emulator):
+    """
+    _AlcaHarvest_
+
+    Emulate the execution of a AlcaHarvest Step
+
+    """
+    def pre(self):
+        """
+        _pre_
+
+        Emulate pre AlcaHarvest
+
+        """
+        return None
+
+    def execute(self):
+        """
+        _execute_
+
+        Emulate AlcaHarvest execution
+
+        """
+        self.step.section_("execution")
+        self.step.execution.exitStatus = 0
+        self.step.section_("emulation")
+        self.step.emulation.emulatedBy = str(self.__class__.__name__)
+
+        print "Emulating AlcaHarvest Step"
+
+
+    def post(self):
+        """
+        _post_
+
+        Emulate post AlcaHarvest
+
+        """
+        return None

--- a/src/python/WMCore/WMSpec/Steps/Executors/AlcaHarvest.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/AlcaHarvest.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python
+"""
+_Step.Executor.AlcaHarvest_
+
+Implementation of an Executor for a AlcaHarvest step
+
+"""
+import os
+import sys
+import stat
+import shutil
+import tarfile
+import logging
+
+from WMCore.WMSpec.Steps.Executor import Executor
+from WMCore.FwkJobReport.Report import Report
+from WMCore.Services.UUID import makeUUID
+
+from WMCore.WMSpec.Steps.WMExecutionFailure import WMExecutionFailure
+
+
+class AlcaHarvest(Executor):
+    """
+    _AlcaHarvest_
+
+    Execute a AlcaHarvest Step
+
+    """
+    def pre(self, emulator = None):
+        """
+        _pre_
+
+        Pre execution checks
+
+        """
+        #Are we using an emulator?
+        if emulator != None:
+            return emulator.emulatePre(self.step)
+
+        print "Steps.Executors.AlcaHarvest.pre called"
+        return None
+
+    def execute(self, emulator = None):
+        """
+        _execute_
+
+        """
+        #Are we using emulators again?
+        if emulator != None:
+            return emulator.emulate(self.step, self.job)
+
+        # Search through steps for analysis files
+        for step in self.stepSpace.taskSpace.stepSpaces():
+            if step == self.stepName:
+                #Don't try to parse your own report; it's not there yet
+                continue
+            stepLocation = os.path.join(self.stepSpace.taskSpace.location, step)
+            logging.info("Beginning report processing for step %s" % step)
+            reportLocation = os.path.join(stepLocation, 'Report.pkl')
+            if not os.path.isfile(reportLocation):
+                logging.error("Cannot find report for step %s in space %s" \
+                              % (step, stepLocation))
+                continue
+
+            # First, get everything from a file and 'unpersist' it
+            stepReport = Report()
+            stepReport.unpersist(reportLocation, step)
+
+            # Don't upload nor stage out files from bad steps.
+            if not stepReport.stepSuccessful(step):
+                continue
+
+            # Pulling out the analysis files from each step
+            analysisFiles = stepReport.getAnalysisFilesFromStep(step)
+
+            # are we in validation mode ?
+            dropboxValidation = False
+
+            # make sure all conditions from this job get the same uuid
+            uuid = makeUUID()
+
+            files2copy = []
+
+            # Working on analysis files
+            for analysisFile in analysisFiles:
+                # only deal with sqlite files
+                if analysisFile.FileClass == "ALCA":
+
+                    sqlitefile = analysisFile.fileName.replace('sqlite_file:', '', 1)
+
+                    filenamePrefix = "Run%d@%s@%s" % (self.step.condition.runNumber,
+                                                      analysisFile.tag, uuid)
+                    filenameDB = filenamePrefix + ".db"
+                    filenameTXT = filenamePrefix + ".txt"
+                    filenameTAR = filenamePrefix + ".tar.bz2"
+
+                    shutil.copy2(os.path.join(stepLocation, sqlitefile), filenameDB)
+
+                    # if we run in validation mode, upload to different destination
+                    if dropboxValidation != "False":
+                        analysisFile.destDB = analysisFile.destDBValidation
+
+                    textoutput = "destDB %s\n" % analysisFile.destDB
+                    textoutput += "tag %s\n" % analysisFile.tag
+                    textoutput += "inputtag %s\n" % analysisFile.inputtag
+                    textoutput += "since\n"
+                    textoutput += "Timetype %s\n" % analysisFile.Timetype
+                    textoutput += "IOVCheck %s\n" % getattr(analysisFile, 'IOVCheck', "offline")
+                    textoutput += "DuplicateTagHLT %s\n" % getattr(analysisFile, 'DuplicateTagHLT', "")
+                    textoutput += "DuplicateTagEXPRESS %s\n"  % getattr(analysisFile, 'DuplicateTagEXPRESS', "")
+                    textoutput += "DuplicateTagPROMPT %s\n" % analysisFile.DuplicateTagPROMPT
+                    textoutput += "Source %s\n" % getattr(analysisFile, 'Source', "")
+                    textoutput += "Fileclass ALCA\n"
+
+                    fout = open(filenameTXT, "w")
+                    fout.write(textoutput)
+                    fout.close()
+
+                    os.chmod(filenameDB, stat.S_IREAD | stat.S_IWRITE | stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH | stat.S_IWOTH)
+                    os.chmod(filenameTXT, stat.S_IREAD | stat.S_IWRITE | stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH | stat.S_IWOTH)
+
+                    if dropboxValidation == "False":
+
+                        fout = tarfile.open(filenameTAR, "w:bz2")
+                        fout.add(filenameDB)
+                        fout.add(filenameTXT)
+                        fout.close()
+
+                        os.chmod(filenameTAR, stat.S_IREAD | stat.S_IWRITE | stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH | stat.S_IWOTH)
+
+                        files2copy.append(filenameTAR)
+
+                    else:
+
+                        files2copy.append(filenameDB)
+                        files2copy.append(filenameTXT)
+
+            # check and create target directory
+            if not os.path.isdir(self.step.condition.dir):
+                msg = 'Conditions copy failed with response:\n'
+                msg += 'The target dir %s does not exist or is not a directory\n'
+                logging.error(msg)
+                raise WMExecutionFailure(60319, "AlcaHarvestFailure", msg)
+
+            # copy files out and fake the job report
+            logging.info("Copy out conditions files to %s" % self.step.condition.dir)
+            for file2copy in files2copy:
+
+                logging.info("==> copy %s" % file2copy) 
+
+                targetFile = os.path.join(self.step.condition.dir, file2copy)
+
+                try:
+                    shutil.copy2(file2copy, targetFile)
+                except Exception, ex:
+                    msg = 'Conditions copy failed with response:\n'
+                    msg += 'Error: %s\n' % str(ex)
+                    logging.error(msg)
+                    raise WMExecutionFailure(60319, "AlcaHarvestFailure", msg)
+
+                # add fake output file to job report
+                stepReport.addOutputFile(self.step.condition.outLabel,
+                                         file = { 'lfn' : targetFile,
+                                                  'pfn' : targetFile })
+
+            # Am DONE with report
+            # Persist it
+            stepReport.persist(reportLocation)
+
+        return
+    
+    def post(self, emulator = None):
+        """
+        _post_
+
+        Post execution checkpointing
+
+        """
+        # Another emulator check
+        if emulator is not None:
+            return emulator.emulatePost(self.step)
+        
+        print "Steps.Executors.AlcaHarvest.post called"
+        return None

--- a/src/python/WMCore/WMSpec/Steps/Templates/AlcaHarvest.py
+++ b/src/python/WMCore/WMSpec/Steps/Templates/AlcaHarvest.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+"""
+_AlcaHarvest_
+
+Template for a AlcaHarvest Step
+
+"""
+
+from WMCore.WMSpec.Steps.Template import Template
+from WMCore.WMSpec.Steps.Template import CoreHelper
+from WMCore.WMSpec.ConfigSectionTree import nodeName
+
+
+class AlcaHarvestStepHelper(CoreHelper):
+    """
+    _AlcaHarvestStepHelper_
+
+    Add API calls and helper methods to the basic WMStepHelper to specialise
+    for AlcaHarvest tasks
+
+    """
+    def setRunNumber(self, runNumber):
+        """
+        Sets the run number, used to create a
+        run specific subdir for the output
+        """
+        self.data.condition.runNumber = runNumber
+
+    def setConditionOutputLabel(self, outLabel):
+        """
+        Sets the output label for the fake
+        output model containing the sqlite files
+        """
+        self.data.condition.outLabel = outLabel
+
+    def setConditionDir(self, dir):
+        """
+        Sets the directory for condition file copy,
+        assumed to be a POSIX accessible path (AFS)
+        """
+        self.data.condition.dir = dir
+
+
+class AlcaHarvest(Template):
+    """
+    _AlcaHarvest_
+
+    Tools for creating a template AlcaHarvest Step
+
+    """
+
+    def install(self, step):
+        stepname = nodeName(step)
+        step.stepType = "AlcaHarvest"
+        step.section_("condition")
+        step.condition.runNumber = None
+        step.condition.outLabel = None
+        step.condition.dir = None
+
+    def helper(self, step):
+        """
+        _helper_
+
+        Wrap the WMStep provided in the CMSSW helper class that
+        includes the ability to add and manipulate the details
+        of a CMSSW workflow step
+
+        """
+        return AlcaHarvestStepHelper(step)
+
+
+


### PR DESCRIPTION
Add AlcaHarvest step which goes through the analysis files
the CMSSW job wrote out and checks for sqlite condition files.
If it finds any, it does create metadata text files and copies
each condition file and it's corresponding metadata text file
to a special directory (POSIX path) and then adds both files
to the FJR under a fake output module.

Also make a change in StdBase to support output from
AlcaSkimming with data tier 'ALCAPROMPT'. This is needed
to support AlcaHarvesting.
