### PR TITLE
have TaskArchiver accept missing working directory

### DIFF
--- a/src/python/WMComponent/TaskArchiver/TaskArchiverPoller.py
+++ b/src/python/WMComponent/TaskArchiver/TaskArchiverPoller.py
@@ -359,13 +359,18 @@ class TaskArchiverPoller(BaseWorkerThread):
                 workDir, taskDir = getMasterName(startDir = self.jobCacheDir,
                                                  workflow = workflow)
                 logging.info("About to delete work directory %s" % taskDir)
-                if os.path.isdir(taskDir):
-                    # Remove the taskDir, because we're done
-                    shutil.rmtree(taskDir)
+                if os.path.exists(taskDir):
+                    if os.path.isdir(taskDir):
+                        shutil.rmtree(taskDir)
+                    else:
+                        # What we think of as a working directory is not a directory
+                        # This should never happen and there is no way we can recover
+                        # from this here. Bail out now and have someone look at things. 
+                        msg = "Work directory is not a directory, this should never happen: %s" % taskDir
+                        raise TaskArchiverPollerException(msg)
                 else:
                     msg = "Attempted to delete work directory but it was already gone: %s" % taskDir
-                    logging.error(msg)
-                    self.sendAlert(1, msg = msg)
+                    logging.debug(msg)
 
                 # Now check if the workflow is done
                 if not workflow.countWorkflowsBySpec() == 0:


### PR DESCRIPTION
Currently, the TaskArchiver will print an error message and send
an alert if it cannot delete the working directory for a task due
to that working directory not existing.

If the input for a task never gets any events, the task itself is
never initialized by the JobCreator and therefor it's working
directory is never created in the first place. This is normal
for these cases and not an error.

Downgrade the error message to a debug message and remove the alert.

While modifying this code anyways, make the consistency check more
specific: If the working directory does not exist, handle it in
the described way. If it exists, but is not a directory, bail out
with an exception because at that point something is screwed up.
