### PR TITLE
Bugfix for the JobSubmitter

### DIFF
--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -422,8 +422,8 @@ class JobSubmitterPoller(BaseWorkerThread):
                 self.cmsNames[cmsName] = []
             if not siteName in self.cmsNames[cmsName]:
                 self.cmsNames[cmsName].append(siteName)
-            if state != "Normal" and cmsName not in self.drainSites:
-                self.drainSites.append(cmsName)
+            if state != "Normal" and siteName not in self.drainSites:
+                self.drainSites.append(siteName)
 
             for seName in rcThresholds[siteName]["se_names"]:
                 if not seName in self.siteKeys.keys():


### PR DESCRIPTION
It was storing cmsNames in the drain site list instead of siteNames, it doesn't cause problems as most of the time the site name is equal to the cms name except when it's not.
