### PR TITLE
Alert emails from address set to noreply. Process pollers fix on disappared child processes.

### DIFF
--- a/bin/wmagent-mod-config
+++ b/bin/wmagent-mod-config
@@ -189,9 +189,9 @@ def modifyConfiguration(config, **args):
         if hasattr(config.AlertProcessor.soft.sinks, "file"):
             config.AlertProcessor.soft.sinks.file.outputfile = os.path.join(args['working_dir'], "AlertsFileSinkSoft.json")
         if hasattr(config.AlertProcessor.critical.sinks, "email"):
-            config.AlertProcessor.critical.sinks.email.fromAddr = "wmagent@%s" % localhost
+            config.AlertProcessor.critical.sinks.email.fromAddr = "noreply@cern.ch"
         if hasattr(config.AlertProcessor.soft.sinks, "email"):
-            config.AlertProcessor.soft.sinks.email.fromAddr = "wmagent@%s" % localhost
+            config.AlertProcessor.soft.sinks.email.fromAddr = "noreply@cern.ch"
     if  hasattr(config, "AlertGenerator"):
         if hasattr(config.AlertGenerator, "couchDbSizePoller"):
             config.AlertGenerator.couchDbSizePoller.couchURL = args["couch_url"]

--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -338,7 +338,12 @@ config.AlertProcessor.critical.sinks.section_("email")
 # from must be a valid domain, at least when the destination address
 # was @cern.ch: it said email is queued but was never delivered,
 # may not always be the case though
-config.AlertProcessor.critical.sinks.email.fromAddr = "wmagent@%s" % serverHostName
+# noreply@ will ensure that on an undeliverable email (e.g.
+# for queueing too long to be delivered), the CERN exchange server
+# generates a NDL (non-deliverable report) which again is
+# undeliverable since the wmagent machine doesn't run any email service,
+# with noreply@ it goes to /dev/null 
+config.AlertProcessor.critical.sinks.email.fromAddr = "noreply@cern.ch"
 config.AlertProcessor.critical.sinks.email.toAddr = ["wmagentalerts@gmail.com"] # add more in the list
 config.AlertProcessor.critical.sinks.email.smtpServer = "cernmx.cern.ch"
 config.AlertProcessor.critical.sinks.email.smtpUser = None
@@ -347,7 +352,7 @@ config.AlertProcessor.soft.sinks.section_("email")
 # from must be a valid domain, at least when the destination address
 # was @cern.ch: it said email is queued but was never delivered,
 # may not always be the case though
-config.AlertProcessor.soft.sinks.email.fromAddr = "wmagent@%s" % serverHostName
+config.AlertProcessor.soft.sinks.email.fromAddr = "noreply@cern.ch"
 config.AlertProcessor.soft.sinks.email.toAddr = ["wmagentalerts@gmail.com"] # add more in the list
 config.AlertProcessor.soft.sinks.email.smtpServer = "cernmx.cern.ch"
 config.AlertProcessor.soft.sinks.email.smtpUser = None
@@ -444,7 +449,8 @@ config.AlertGenerator.section_("couchErrorsPoller")
 config.AlertGenerator.couchErrorsPoller.couchURL = couchURL
 config.AlertGenerator.couchErrorsPoller.soft = 100 # [number of error occurrences]
 config.AlertGenerator.couchErrorsPoller.critical = 200 # [number of error occurrences]
-config.AlertGenerator.couchErrorsPoller.observables = (404, 403, 500) # HTTP status codes to watch over
+# remove 404 for the moment, there is way too many of them and no interest generated
+config.AlertGenerator.couchErrorsPoller.observables = (403, 500) # HTTP status codes to watch over
 config.AlertGenerator.couchErrorsPoller.pollInterval = 600 # [second]
 
 # mysql*Poller sections were made optional and are defined in the

--- a/src/python/WMComponent/AlertGenerator/Pollers/Couch.py
+++ b/src/python/WMComponent/AlertGenerator/Pollers/Couch.py
@@ -7,7 +7,6 @@ Module for all CouchDb related polling.
 import os
 import logging
 import types
-import time
 import psutil
 
 from WMCore.Database.CMSCouch import CouchServer
@@ -103,8 +102,8 @@ class CouchPoller(PeriodPoller):
             try:
                 PeriodPoller.check(self, self._dbProcessDetail, self._measurements)
             except psutil.error.NoSuchProcess as ex:
-                logging.error(ex)
-                logging.error("Updating info about the polled process ...")
+                logging.warn(ex)
+                logging.warn("Updating info about the polled process ...")
                 self._setUp()
 
 
@@ -253,8 +252,8 @@ class CouchErrorsPoller(BasePoller):
                                        occurrences = occurrences, 
                                        threshold = threshold)
                         a = Alert(**self.preAlert)
+                        a.setTimestamp()
                         a["Source"] = self.__class__.__name__
-                        a["Timestamp"] = time.time()
                         a["Details"] = details
                         a["Level"] = level
                         logging.debug("Sending an alert (%s): %s" % (self.__class__.__name__, a))

--- a/src/python/WMComponent/AlertGenerator/Pollers/MySQL.py
+++ b/src/python/WMComponent/AlertGenerator/Pollers/MySQL.py
@@ -80,8 +80,8 @@ class MySQLPoller(PeriodPoller):
             try:
                 PeriodPoller.check(self, self._dbProcessDetail, self._measurements)
             except psutil.error.NoSuchProcess as ex:
-                logging.error(ex)
-                logging.error("Updating info about the polled process ...")
+                logging.warn(ex)
+                logging.warn("Updating info about the polled process ...")
                 self._setUp()
                 
 

--- a/src/python/WMComponent/AlertGenerator/Pollers/System.py
+++ b/src/python/WMComponent/AlertGenerator/Pollers/System.py
@@ -6,7 +6,6 @@ utilisation by particular processes, etc.
 """
 
 import logging
-import time
 import subprocess
 
 import psutil
@@ -202,8 +201,8 @@ class DiskSpacePoller(BasePoller):
                         details = dict(mountPoint = mount, usage = "%s%%" % perc,
                                        threshold = "%s%%" % threshold)
                         a = Alert(**self.preAlert)
+                        a.setTimestamp()
                         a["Source"] = self.__class__.__name__
-                        a["Timestamp"] = time.time()
                         a["Details"] = details
                         a["Level"] = level
                         logging.debug("Sending an alert (%s): %s" % (self.__class__.__name__, a))
@@ -295,8 +294,8 @@ class DirectorySizePoller(BasePoller):
                 details = dict(databasedir = self._dbDirectory, usage = usageStr,
                                threshold = threshold)
                 a = Alert(**self.preAlert)
+                a.setTimestamp()
                 a["Source"] = self._myName
-                a["Timestamp"] = time.time()
                 a["Details"] = details
                 a["Level"] = level                
                 logging.debug("Sending an alert (%s): %s" % (self.__class__.__name__, a))

--- a/src/python/WMCore/Alerts/API.py
+++ b/src/python/WMCore/Alerts/API.py
@@ -10,7 +10,6 @@ of actual messages.
 """
 
 
-import time
 import logging
 
 from WMCore.Configuration import Configuration
@@ -93,7 +92,7 @@ def getSendAlert(sender, preAlert):
     def sendAlertFunc(level, **args):
         if sender:
             alert = Alert(**preAlert)
-            alert["Timestamp"] = time.time()
+            alert.setTimestamp()
             alert["Level"] = level
             alert["Details"] = args
             sender(alert)

--- a/src/python/WMCore/Alerts/Alert.py
+++ b/src/python/WMCore/Alerts/Alert.py
@@ -4,6 +4,8 @@ Representation of management messages within the Alert framework.
 
 """
 
+import time
+
 
 class Alert(dict):
     """
@@ -14,7 +16,10 @@ class Alert(dict):
     TEMPLATE = (u"Alert: Component: %(Component)s, Source: %(Source)s, "
                 "Type: %(Type)s, Level: %(Level)s, Workload: %(Workload)s, "
                 "HostName %(HostName)s, AgentName: %(AgentName)s, "
-                "Timestamp: %(Timestamp)s, Details: %(Details)s")
+                "Timestamp: %(Timestamp)s, TimestampDecoded: %(TimestampDecoded)s, "
+                "Details: %(Details)s")
+    
+    TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S"
 
     
     def __init__(self, **args):
@@ -26,6 +31,9 @@ class Alert(dict):
         self.setdefault("Component", None)
         self.setdefault("Details", {})
         self.setdefault("Timestamp", None)
+        # this is slightly redundant but it's convenient e.g. on an alert email
+        # to see when the alert was generated without decoding the Timestamp
+        self.setdefault("TimestampDecoded", None)
         # add a few values which are read from the configuration (Agent section)
         # (here are the first letters capitalised)
         self.setdefault("HostName", None)
@@ -36,6 +44,17 @@ class Alert(dict):
 
 
     level = property(lambda x: x.get("Level"))
+    
+    
+    def setTimestamp(self):
+        """
+        Set time stamp attributes of a newly created alert instance.
+        
+        """
+        t = time.time()
+        timeStruct = time.gmtime(t) # convert time object to time struct
+        self["Timestamp"] = t
+        self["TimestampDecoded"] = time.strftime(self.TIMESTAMP_FORMAT, timeStruct)
     
     
     def toMsg(self):

--- a/test/python/WMComponent_t/AlertGenerator_t/Pollers_t/Base_t.py
+++ b/test/python/WMComponent_t/AlertGenerator_t/Pollers_t/Base_t.py
@@ -116,6 +116,7 @@ class BaseTest(unittest.TestCase):
         self.assertEqual(d["pid"], pid)
         self.assertEqual(d["component"], name)
         self.assertEqual(d["numChildrenProcesses"], numChildren)
+        pd.refresh()
                 
         
     def testMeasurementsBasic(self):

--- a/test/python/WMCore_t/Alerts_t/Alert_t.py
+++ b/test/python/WMCore_t/Alerts_t/Alert_t.py
@@ -1,4 +1,5 @@
 import unittest
+import time
 
 from WMCore.Alerts.Alert import Alert
 from WMCore.Alerts.Alert import RegisterMsg, UnregisterMsg, ShutdownMsg
@@ -23,6 +24,7 @@ class AlertTest(unittest.TestCase):
         self.assertEqual(a["Component"], None)
         self.assertEqual(a["Details"], {})
         self.assertEqual(a["Timestamp"], None)
+        self.assertEqual(a["TimestampDecoded"], None)
         
         details = dict(detail = "detail")
         a = Alert(Level = 5, Source = "src", Type = "type", Workload = "work",
@@ -36,6 +38,17 @@ class AlertTest(unittest.TestCase):
         self.assertEqual(a["Timestamp"], "time")
         a.toMsg()
         
+        
+    def testSetTimestamp(self):
+        a = Alert()
+        self.assertEqual(a["Timestamp"], None)
+        self.assertEqual(a["TimestampDecoded"], None)        
+        a.setTimestamp()
+        self.assertTrue(isinstance(a["Timestamp"], float))
+        tsd = a["TimestampDecoded"]
+        tsdTested = time.strftime(a.TIMESTAMP_FORMAT, time.gmtime(a["Timestamp"]))
+        self.assertEqual(tsd, tsdTested)
+                
         
     def testRegisterMsg(self):
         msg = RegisterMsg("mylabel")


### PR DESCRIPTION
Alert emails from address set to noreply@cern.ch (undeliverable email report sent to /dev/null). 
Process pollers refresh list of child processes each poll interval. Alerts no longer generated on disappeared processes (can easily be re-enabled).
