### PR TITLE
fix Tier0 DBS2 upload problems

### DIFF
--- a/src/python/WMComponent/DBSUpload/DBSUploadPoller.py
+++ b/src/python/WMComponent/DBSUpload/DBSUploadPoller.py
@@ -62,22 +62,25 @@ def createDatasetFromInfo(info):
     Create a dataset object from basic information
 
     """
-    dataset = {'ID':               info.get('Dataset'),
-               'Path':             info.get('Path'),
-               'ProcessedDataset': info.get('ProcessedDataset'),
-               'PrimaryDataset':   info.get('PrimaryDataset'),
-               'DataTier':         info.get('DataTier'),
-               'Algo':             info.get('Algo'),
-               'AlgoInDBS':        info.get('AlgoInDBS', None),
-               'DASInDBS':         info.get('DASInDBS', None),
-               'status':           info.get('ValidStatus', 'PRODUCTION'),
-               'globalTag':        info.get('GlobalTag', ''),
-               'parent':           info.get('Parent', '')
+    dataset = {'ID':               info['Dataset'],
+               'Path':             info['Path'],
+               'ProcessedDataset': info['ProcessedDataset'],
+               'PrimaryDataset':   info['PrimaryDataset'],
+               'DataTier':         info['DataTier'],
+               'Algo':             info['Algo'],
+               'AlgoInDBS':        info['AlgoInDBS'],
+               'DASInDBS':         info['DASInDBS'],
+               'status':           info['ValidStatus'],
+               'globalTag':        info['GlobalTag'],
+               'parent':           info['Parent']
                }
-    if dataset['globalTag'] == None:
-        dataset['globalTag'] = ''
+
     if dataset['status'] == None:
         dataset['status'] = 'PRODUCTION'
+
+    if dataset['globalTag'] == None:
+        dataset['globalTag'] = ''
+
     return dataset
 
 def createAlgoFromInfo(info):
@@ -86,12 +89,12 @@ def createAlgoFromInfo(info):
 
     """
     
-    algo = {'ApplicationName':    info.get('ApplicationName'),
-            'ApplicationFamily':  info.get('ApplicationFamily'),
-            'ApplicationVersion': info.get('ApplicationVersion'),
-            'PSetHash':           info.get('PSetHash'),
+    algo = {'ApplicationName':    info['ApplicationName'],
+            'ApplicationFamily':  info['ApplicationFamily'],
+            'ApplicationVersion': info['ApplicationVersion'],
+            'PSetHash':           info['PSetHash'],
             'PSetContent':        None,
-            'InDBS':              info.get('AlgoInDBS', None)
+            'InDBS':              info['AlgoInDBS']
             }
 
     configString = info.get('PSetContent')

--- a/src/python/WMComponent/DBSUpload/Database/MySQL/FindDASToUpload.py
+++ b/src/python/WMComponent/DBSUpload/Database/MySQL/FindDASToUpload.py
@@ -44,24 +44,32 @@ class FindDASToUpload(DBFormatter):
             if r == {}:
                 continue
             entry={}
-            entry['Path']=r['path']
+
             entry['DAS_ID'] = long(r['das_id'])
+
             if not r['algo'] == None:
                 entry['Algo'] = int(r['algo'])
             else:
                 entry['Algo'] = None
+
             if not r['in_dbs'] == None:
                 entry['DASInDBS'] = int(r['in_dbs'])
             else:
                 entry['DASInDBS'] = None
+
+            # insert for upstream users
+            entry['AlgoInDBS'] = None
+
             path = r['path']
+            entry['Path']               = r['path']
             entry['PrimaryDataset']     = path.split('/')[1]
             entry['ProcessedDataset']   = path.split('/')[2]
             entry['DataTier']           = path.split('/')[3]
             entry['Dataset']            = r['dataset']
             entry['ValidStatus']        = r['valid_status']
-            entry['GlobalTag']          = r.get('global_tag', '')
-            entry['Parent']             = r.get('parent', '')
+            entry['GlobalTag']          = r['global_tag']
+            entry['Parent']             = r['parent']
+
             ret.append(entry)
 
         return ret

--- a/src/python/WMComponent/DBSUpload/Database/MySQL/LoadInfoFromDAS.py
+++ b/src/python/WMComponent/DBSUpload/Database/MySQL/LoadInfoFromDAS.py
@@ -15,17 +15,20 @@ class LoadInfoFromDAS(FindDASToUpload):
     """
 
 
-    sql = """SELECT DISTINCT das.dataset_id AS dataset, ds.Path as Path, das.algo_id as Algo, das.in_dbs as in_dbs,
-               das.id AS das_id,
-               da.app_name AS ApplicationName, 
-               da.app_ver AS ApplicationVersion, 
-               da.app_fam AS ApplicationFamily, 
-               da.PSet_Hash as PSetHash,
-               da.Config_Content as PSetContent,
-               da.in_dbs AS algo_in_dbs,
-               ds.valid_status AS valid_status,
-               ds.global_tag AS global_tag,
-               ds.parent AS parent
+    sql = """SELECT das.dataset_id AS dataset,
+                    ds.Path as Path,
+                    das.algo_id as Algo,
+                    das.in_dbs as in_dbs,
+                    das.id AS das_id,
+                    da.app_name AS ApplicationName, 
+                    da.app_ver AS ApplicationVersion, 
+                    da.app_fam AS ApplicationFamily, 
+                    da.PSet_Hash as PSetHash,
+                    da.Config_Content as PSetContent,
+                    da.in_dbs AS algo_in_dbs,
+                    ds.valid_status AS valid_status,
+                    ds.global_tag AS global_tag,
+                    ds.parent AS parent
              FROM dbsbuffer_algo_dataset_assoc das
              INNER JOIN dbsbuffer_dataset ds ON ds.id = das.dataset_id
              INNER JOIN dbsbuffer_algo da ON da.id = das.algo_id
@@ -38,21 +41,26 @@ class LoadInfoFromDAS(FindDASToUpload):
             if r == {}:
                 continue
             entry={}
-            entry['Path']=r['path']
+
             entry['DAS_ID'] = long(r['das_id'])
+
             if not r['algo'] == None:
                 entry['Algo'] = int(r['algo'])
             else:
                 entry['Algo'] = None
+
             if not r['algo_in_dbs'] == None:
                 entry['AlgoInDBS'] = int(r['algo_in_dbs'])
             else:
                 entry['AlgoInDBS'] = None
+
             if not r['in_dbs'] == None:
                 entry['DASInDBS'] = int(r['in_dbs'])
             else:
                 entry['DASInDBS'] = None
+
             path = r['path']
+            entry['Path']               = path
             entry['PrimaryDataset']     = path.split('/')[1]
             entry['ProcessedDataset']   = path.split('/')[2]
             entry['DataTier']           = path.split('/')[3]
@@ -63,8 +71,9 @@ class LoadInfoFromDAS(FindDASToUpload):
             entry['PSetContent']        = r['psetcontent']
             entry['Dataset']            = r['dataset']
             entry['ValidStatus']        = r['valid_status']
-            entry['GlobalTag']          = r.get('global_tag', '')
-            entry['Parent']             = r.get('parent', '')
+            entry['GlobalTag']          = r['global_tag']
+            entry['Parent']             = r['parent']
+
             ret.append(entry)
 
         return ret

--- a/src/python/WMComponent/DBSUpload/Database/Oracle/LoadInfoFromDAS.py
+++ b/src/python/WMComponent/DBSUpload/Database/Oracle/LoadInfoFromDAS.py
@@ -8,24 +8,4 @@ Load the DAS info from the DAS ID
 from WMComponent.DBSUpload.Database.MySQL.LoadInfoFromDAS import LoadInfoFromDAS as MySQLLoadInfoFromDAS
 
 class LoadInfoFromDAS(MySQLLoadInfoFromDAS):
-    """
-    Oracle version
-
-
-    """
-
-
-    sql = """SELECT das1.dataset_id AS dataset, ds1.Path as Path, das1.algo_id as Algo, das1.in_dbs as in_dbs,
-               das1.id AS das_id,
-               da1.app_name AS ApplicationName, 
-               da1.app_ver AS ApplicationVersion, 
-               da1.app_fam AS ApplicationFamily, 
-               da1.PSet_Hash as PSetHash,
-               da1.Config_Content as PSetContent,
-               da1.in_dbs AS algo_in_dbs,
-               ds1.valid_status AS valid_status
-             FROM dbsbuffer_algo_dataset_assoc das1
-             INNER JOIN dbsbuffer_algo da1 ON da1.id = das1.algo_id
-             INNER JOIN dbsbuffer_dataset ds1 ON ds1.id = das1.dataset_id
-             WHERE das1.id = :id
-             """
+    pass


### PR DESCRIPTION
Fixes a crash in DBSUpload when running the agent with Oracle backend. Direct cause of the crash was an out-of-date Oracle DAO (versus the MySQL version). The Oracle version didn't return some needed information, which triggered a code path that substituted some defaults that later caused an error in calling a DBS2 API.

Fixed the out-of-date DAO (removed it, it falls back to the MySQL version now), removed an unneeded (and potentially wrong) DISTINCT keyword from the MySQL DAO and removed all defaults for values that should be initialized and returned by the DAO.
