### PR TITLE
Tier0 PromptReco does not support LogCollect

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -579,8 +579,10 @@ class StdBase(object):
 
         self.addCleanupTask(parentTask, parentOutputModuleName)
         if self.enableHarvesting and getattr(parentOutputModule, "dataTier") in ["DQMROOT", "DQM"]:
-            self.addDQMHarvestTask(mergeTask, "Merged", self.dqmUploadProxy,
-                                   self.periodicHarvestingInterval)
+            self.addDQMHarvestTask(mergeTask, "Merged",
+                                   uploadProxy = self.dqmUploadProxy,
+                                   periodic_harvest_interval= self.periodicHarvestingInterval,
+                                   doLogCollect = doLogCollect)
         return mergeTask
 
     def addCleanupTask(self, parentTask, parentOutputModuleName):


### PR DESCRIPTION
Changes to the PromptReco Spec to evaluate the DoLogCollect spec parametere and use it to configure with or without logCollect tasks (default is logCollect enabled).
