### PR TITLE
Bugfix for harvesting tasktype

### DIFF
--- a/bin/wmagent-resource-control
+++ b/bin/wmagent-resource-control
@@ -111,6 +111,8 @@ def addSites(resourceControl, allSites, ceName, plugin, pendingSlots, runningSlo
                             priority = 5)
         updateThresholdInfo(resourceControl, siteName, "Cleanup", runningSlots,
                             priority = 5)
+        updateThresholdInfo(resourceControl, siteName, "Harvesting", runningSlots,
+                            priority = 5)
         updateThresholdInfo(resourceControl, siteName, "LogCollect", runningSlots,
                             priority = 3)
         updateThresholdInfo(resourceControl, siteName, "Skim", runningSlots,

--- a/test/python/WMCore_t/JobSplitting_t/Harvest_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/Harvest_t.py
@@ -76,7 +76,7 @@ class HarvestTest(unittest.TestCase):
         self.subscription1  = Subscription(fileset = self.fileset1,
                                            workflow = workflow1,
                                            split_algo = "Harvest",
-                                           type = "Harvest")
+                                           type = "Harvesting")
 
         self.subscription1.create()
 


### PR DESCRIPTION
Add it to the defaults in wmagent-resource-control
Also fix a reference in the Harvest algo unittest

Fixes #4069
