### PR TITLE
optimizing SiblingSubscriptionsComplete DAO

### DIFF
--- a/src/python/WMCore/WMBS/MySQL/Subscriptions/SiblingSubscriptionsComplete.py
+++ b/src/python/WMCore/WMBS/MySQL/Subscriptions/SiblingSubscriptionsComplete.py
@@ -31,8 +31,8 @@ class SiblingSubscriptionsComplete(DBFormatter):
                    wmbs_subscription.id != :subscription
                  LEFT OUTER JOIN wmbs_sub_files_complete ON
                    wmbs_sub_files_complete.fileid = wmbs_sub_files_available.fileid AND
-                   wmbs_sub_files_complete.subscription = wmbs_subscription.id AND
-                   wmbs_sub_files_complete.subscription != :subscription
+                   wmbs_sub_files_complete.subscription = wmbs_subscription.id
+               WHERE wmbs_sub_files_available.subscription = :subscription
                GROUP BY wmbs_sub_files_available.fileid
                HAVING COUNT(wmbs_subscription.id) = COUNT(wmbs_sub_files_complete.fileid)
              ) available_files


### PR DESCRIPTION
Should optimize the query (it can be an expensive query) by starting
not will all available files but only the files actually in the
input fileset to this cleanup subscription. Really suprised this
actually worked before.
