### PR TITLE
Reduce default couchdb queue size for ChangeState

### DIFF
--- a/src/python/WMCore/JobStateMachine/ChangeState.py
+++ b/src/python/WMCore/JobStateMachine/ChangeState.py
@@ -35,9 +35,9 @@ class ChangeState(WMObject, WMConnectionBase):
 
         try:
             self.couchdb = CouchServer(self.config.JobStateMachine.couchurl)
-            self.jobsdatabase = self.couchdb.connectDatabase("%s/jobs" % self.dbname)
-            self.fwjrdatabase = self.couchdb.connectDatabase("%s/fwjrs" % self.dbname)
-            self.jsumdatabase = self.couchdb.connectDatabase( getattr(self.config.JobStateMachine, 'jobSummaryDBName') )
+            self.jobsdatabase = self.couchdb.connectDatabase("%s/jobs" % self.dbname, size = 250)
+            self.fwjrdatabase = self.couchdb.connectDatabase("%s/fwjrs" % self.dbname, size = 250)
+            self.jsumdatabase = self.couchdb.connectDatabase( getattr(self.config.JobStateMachine, 'jobSummaryDBName'), size = 250 )
         except Exception, ex:
             logging.error("Error connecting to couch: %s" % str(ex))
             self.jobsdatabase = None


### PR DESCRIPTION
1000 seems to be too much in the busiest machine (e.g. vocms96)

This should help with #4078, however there is another side of the story with committing documents to couch. I'll comment there.
