### PR TITLE
Add the "New" state to the LSF plugin map

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/LsfPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/LsfPlugin.py
@@ -36,7 +36,8 @@ class LsfPlugin(BasePlugin):
         For a given name, return a global state
 
         """
-        stateDict = {'PEND': 'Pending',
+        stateDict = {'New':  'Pending',
+                     'PEND': 'Pending',
                      'PSUSP': 'Pending',
                      'WAIT': 'Pending',
                      'RUN': 'Running',


### PR DESCRIPTION
Even though the initial state of BossAir can be configured
as PEND for agents with the LSF plugin configured, if
we want an agent that uses both condor and LSF plugins that option
would not work anymore. Therefore the LSF plugin
should map the New state to Pending as well.
