### PR TITLE
remove couchskel link from the script. wmagent.spec 1.131 needs to be used

### DIFF
--- a/bin/wmagent-couchapp-init
+++ b/bin/wmagent-couchapp-init
@@ -72,36 +72,6 @@ def installWorkQueueCouchApp(couchUrl, couchDBName):
     finally:
         shutil.rmtree(tempDir, ignore_errors = True)
 
-def createSymLinkWMStatsExternal():
-    """WMStats has to install jquery libraries to couchapp - handle this here"""
-    
-    def createSymLink(directory):
-        source = os.path.join(couchskel, directory)
-        dest = os.path.join(externalDir, directory)
-        if not os.path.exists(dest):
-            print source
-            print dest
-            os.symlink(source, dest)
-
-    couchskelRoot = os.environ.get('COUCHSKEL_ROOT')
-    if not couchskelRoot:
-        raise RuntimeError, "Can't locate couchskel lib"
-    couchskel = os.path.join(couchskelRoot, 'data','couchapps', 'couchskel','vendor')
-
-    basePath = couchAppRoot('WMStats')
-    # make a temporary directory to create the couchapp structure
-    externalDir = os.path.join(basePath, 'WMStats', 'vendor')
-    try:
-         os.makedirs(externalDir)
-    except OSError, ex:
-        print str(ex)
-        pass
-    
-    createSymLink('jquery')
-    createSymLink('datatables')
-    createSymLink('couchapp')
-
-
 def createCronEntires(crontabLines):
     tempDir = tempfile.mkdtemp()
     os.system("crontab -l > %s/crontab" % tempDir)
@@ -387,7 +357,6 @@ if __name__ == "__main__":
         installCouchApp(wmagentConfig.reqmgr.couchUrl, wmagentConfig.reqmgr.workloadDBName, "ReqMgr")
         # wmstatDBName is set to use specfic client {'wmstats': 'tier1', 'tier0_wmstats': 'tier0', 'analysis_wmstats': 'analysis' }
         # which needs to be changed in wmagent for prompt skiming deployment script
-        createSymLinkWMStatsExternal()
         installCouchApp(wmagentConfig.reqmgr.couchUrl, wmagentConfig.reqmgr.wmstatDBName, "WMStats")
         if options.cron:
             setupCronCompaction(wmagentConfig.reqmgr.couchUrl, wmagentConfig.reqmgr.workloadDBName)


### PR DESCRIPTION
Stuart please review,
Thera are 2 cases wmagent need couchskel. 
1. if wmagent manage script installs all the application (reqmgr, workqueue, wmagent) which I guess won't be supported eventually,
2. wmagent installation for prompt scheme.

There needs to be some deployment script changes made. I think it is better to create new deployment script for those two cases.

FYI
For both cases(No. 1, No. 2), following codes are needed in wmagent deployment script. 

deploy_wmagent_sw()
{
  // wmagent code 
 ......

perl -p -i -e 's/**fill_dbname_here**/wmagent_summary/g' $root/current/apps/reqmon/data/couchapps/WMStats/_attachments/js/loader.js
}

and this code is for No. 2 case.

deploy_wmagent_post()
{
  # Tell couchdb to push the reqmon app on the next restart
  echo "couchapp push $root/current/apps/wmagent/data/couchapps/WMStats" \
       "http://localhost:5984/wmagent_summary" > $root/state/couchdb/stagingarea/wmagent
}
