### PR TITLE
Fix Condor JDL

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
@@ -889,7 +889,7 @@ class CondorPlugin(BasePlugin):
             jdl.append('x509userproxy = %s\n' % job['proxyPath'])
 
         if job.get('requestName', None):
-            jdl.append('+WMAgent_RequestName = %s\n' % job['requestName'])
+            jdl.append('+WMAgent_RequestName = "%s"\n' % job['requestName'])
 
         return jdl
 


### PR DESCRIPTION
Newer condor versions enforce quotes around strings, anyway all those attributes should have the quotes.
