### PR TITLE
Ignore output modules in ACDC requests

### DIFF
--- a/src/python/WMCore/FwkJobReport/Report.py
+++ b/src/python/WMCore/FwkJobReport/Report.py
@@ -984,6 +984,28 @@ class Report:
 
         return
 
+    def deleteOutputModuleForStep(self, stepName, moduleName):
+        """
+        _deleteOutputModuleForStep_
+
+        Delete any reference to the given output module in the step report
+        that includes deleting any output file it produced
+        """
+        stepReport = self.retrieveStep(step = stepName)
+
+        if not stepReport:
+            return
+
+        listOfModules = getattr(stepReport, 'outputModules', [])
+
+        if moduleName not in listOfModules:
+            return
+
+        delattr(stepReport.output, moduleName)
+        listOfModules.remove(moduleName)
+
+        return
+
     def setStepStartTime(self, stepName):
         """
         _setStepStatus_

--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
@@ -107,11 +107,17 @@ def parseBlockList(l):
 
     return result
 
-def parseDqmSequences(l):
-    """ Changes a string into a list of strings """
+def parseStringListWithoutValidation(l):
+    """
+    _parseStringListWithoutValidation
+
+    Changes a string into a list of  generic strings,
+    this doesn't validate the strings in the list
+    against the Lexicon
+    """
     result = None
     if isinstance(l, list):
-       result = l
+        result = l
     elif isinstance(l, basestring):
         toks = l.lstrip(' [').rstrip(' ]').split(',')
         if toks == ['']:
@@ -119,7 +125,7 @@ def parseDqmSequences(l):
         # only one set of quotes
         result = [str(tok.strip(' \'"')) for tok in toks]
     else:
-        raise cherrypy.HTTPError(400, "Bad DQM sequences list of type " + type(l).__name__)
+        raise cherrypy.HTTPError(400, "Bad list of type " + type(l).__name__)
     return result
 
 def parseSite(kw, name):
@@ -480,7 +486,10 @@ def makeRequest(kwargs, couchUrl, couchDB, wmstatUrl):
         if blocklist in kwargs:
             schema[blocklist] = parseBlockList(kwargs[blocklist])
     if "DqmSequences" in kwargs:
-            schema["DqmSequences"] = parseDqmSequences(kwargs["DqmSequences"])
+        schema["DqmSequences"] = parseStringListWithoutValidation(kwargs["DqmSequences"])
+    if "IgnoredOutputModules" in kwargs:
+        schema["IgnoredOutputModules"] = parseStringListWithoutValidation(kwargs["IgnoredOutputModules"])
+
     validate(schema)
 
     # Get the DN

--- a/src/python/WMCore/WMSpec/ConfigSectionTree.py
+++ b/src/python/WMCore/WMSpec/ConfigSectionTree.py
@@ -153,6 +153,17 @@ def addTopNode(currentNode, newNode):
     newNode.tree.parent = nodeName(currentNode)
     return
 
+def deleteNode(topNode, childName):
+    """
+    _deleteNode_
+
+    Given a node within the tree, delete the child
+    with the given name if it exists
+    """
+    if hasattr(topNode.tree.children, childName):
+        delattr(topNode.tree.children, childName)
+        topNode.tree.childNames.remove(childName)
+
 def getNode(node, nodeNameToGet):
     """
     _getNode_
@@ -297,7 +308,17 @@ class TreeHelper:
         """
         if isinstance(newNode, TreeHelper):
             return addTopNode(self.data, newNode.data)
-        return addTopNode(self.data, newNode)        
+        return addTopNode(self.data, newNode)
+
+    def deleteNode(self, nodeName):
+        """
+        _deleteNode
+
+        Delete a child node given its name,
+        if it doesn't exists then do nothing
+        """
+        deleteNode(self.data, nodeName)
+        return
 
     def allNodeNames(self):
         """get list of all known node names in the tree containing this node"""

--- a/src/python/WMCore/WMSpec/StdSpecs/Resubmission.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Resubmission.py
@@ -27,8 +27,8 @@ class ResubmissionWorkloadFactory(StdBase):
         helper = loadWorkload(originalRequest)
         helper.truncate(arguments["RequestName"], arguments["InitialTaskPath"],
                         arguments["ACDCServer"], arguments["ACDCDatabase"])
+        helper.ignoreOutputModules(arguments.get("IgnoredOutputModules", []))
         return helper
-
 
     def validateSchema(self, schema):
         """

--- a/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
@@ -323,6 +323,10 @@ class CMSSW(Executor):
 
         if self.step.output.keep != True:
             self.report.killOutput()
+        else:
+            #Check that we only keep the desired output
+            for module in stepHelper.getIgnoredOutputModules():
+                self.report.deleteOutputModuleForStep(stepName = self.stepName, moduleName = module)
 
         # Add stageout LFN to existing TFileService files
         reportAnalysisFiles = self.report.getAnalysisFilesFromStep(self.stepName)

--- a/src/python/WMCore/WMSpec/WMStep.py
+++ b/src/python/WMCore/WMSpec/WMStep.py
@@ -155,6 +155,29 @@ class WMStepHelper(TreeHelper):
 
         return None
 
+    def setIgnoredOutputModules(self, moduleList):
+        """
+        _setIgnoredOutputModules_
+
+        Set a list of output modules to be ignored,
+        only CMSSW steps will use this
+        """
+
+        self.data.output.ignoredModules = moduleList
+        return
+
+    def getIgnoredOutputModules(self):
+        """
+        _ignoreOutputModules_
+
+        Get a list of output modules to be ignored,
+        if the attribute is not set then return an empty list
+        """
+
+        if hasattr(self.data.output, 'ignoredModules'):
+            return self.data.output.ignoredModules
+        return []
+
     def getUserSandboxes(self):
         if hasattr(self.data, 'user'):
             if hasattr(self.data.user, 'inputSandboxes'):

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -1184,6 +1184,14 @@ class WMTaskHelper(TreeHelper):
 
         return {}
     
+    def deleteChild(self, childName):
+        """
+        _deleteChild_
+
+        Remove the child task from the tree, if it exists
+        """
+        self.deleteNode(childName)
+
 class WMTask(ConfigSectionTree):
     """
     _WMTask_

--- a/src/templates/WMCore/WebTools/RequestManager/WebRequestSchema.tmpl
+++ b/src/templates/WMCore/WebTools/RequestManager/WebRequestSchema.tmpl
@@ -280,6 +280,7 @@ Original Request Name: <input type="text" name="OriginalRequestName" size=30/> <
 Initial Task Path: <input type="text" name="InitialTaskPath" size=30/><br/>
 ACDC Server URL: <input type="text" name="ACDCServer" size=30/><br/>
 ACDC Database Name: <input type="text" name="ACDCDatabase" size=30/><br/>
+Ignored Output Modules: <input type="text" name="IgnoredOutputModules" size=40/><br/>
             $performanceBlock
             $trailerBlock("Resubmission")
         </div>

--- a/test/python/WMCore_t/FwkJobReport_t/Report_t.py
+++ b/test/python/WMCore_t/FwkJobReport_t/Report_t.py
@@ -706,6 +706,29 @@ cms::Exception caught in EventProcessor and rethrown
         self.assertEqual(report.data.cmsRun1.testVar, 'test01')
         
         return
-    
+
+    def testDeleteOutputModule(self):
+        """
+        _testDeleteOutputModule_
+
+        If asked delete an output module, if it doesn't
+        exist then do nothing
+        """
+        originalReport = Report("cmsRun1")
+        originalReport.parse(self.xmlPath)
+
+        self.assertTrue(originalReport.getOutputModule("cmsRun1", "outputALCARECORECO"),
+                        "Error: Report XML doesn't have the module for the test, invalid test")
+
+        originalOutputModules = len(originalReport.retrieveStep("cmsRun1").outputModules)
+        print originalReport.data
+        originalReport.deleteOutputModuleForStep("cmsRun1", "outputALCARECORECO")
+        print originalReport.data
+        self.assertFalse(originalReport.getOutputModule("cmsRun1", "outputALCARECORECO"),
+                        "Error: The output module persists after deletion")
+        self.assertEqual(len(originalReport.retrieveStep("cmsRun1").outputModules), originalOutputModules - 1,
+                         "Error: The number of output modules is incorrect after deletion")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/WMCore_t/WMSpec_t/WMTask_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMTask_t.py
@@ -392,7 +392,7 @@ class WMTaskTest(unittest.TestCase):
         testTask.setPrimarySubType(subType = "subType")
         self.assertEqual(testTask.getPrimarySubType(), "subType")
         return
-    
+
     def testBuildLumiMask(self):
         from WMCore.WMSpec.WMTask import buildLumiMask
         runs=['3','4']
@@ -463,6 +463,30 @@ class WMTaskTest(unittest.TestCase):
         self.assertEqual(subInfo["/ThreeParticles/DawnOfAnEra-v1/RECO"],
                         outputRecoSubInfo, "The RECO subscription information is wrong")
         self.assertFalse("/OneParticle/DawnOfAnEra-v1/RECO" in subInfo, "The RECO subscription information is wrong")
+
+    def testDeleteChild(self):
+        """
+        _testDeleteChild_
+
+        Test that we can remove all reference from a child
+        and other children are left intact
+        """
+
+        task1 = makeWMTask("task1")
+
+        task2a = task1.addTask("task2a")
+        task2b = task1.addTask("task2b")
+        task2c = task1.addTask("task2c")
+
+        task1.deleteChild("task2a")
+        childrenNumber = 0
+        for childTask in task1.childTaskIterator():
+            if childTask.name() == task2a.name():
+                self.fail("Error: It was possible to find the deleted child")
+            childrenNumber += 1
+        self.assertEqual(childrenNumber, 2, "Error: Wrong number of children tasks")
+
+        return
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
ACDC requests can specify a list of output modules which will be ignored
when running th ACDC. It works as follows:
- Any task that uses one of the output modules in the ignore list as input is removed from the workload, that means that task and its children are gone
- Tasks that produce output modules in the lists store the list of "bad" output modules in the CMSSW step information
- CMSSW steps don't add information about the files belonging to modules in the bad output modules list to the Report pickle, so those files don't get staged out

Fixes #3976
