### PR TITLE
Fix simple typo: running was runnig.

### DIFF
--- a/src/python/WMCore/BossAir/MySQL/JobStatusByTaskAndSite.py
+++ b/src/python/WMCore/BossAir/MySQL/JobStatusByTaskAndSite.py
@@ -36,7 +36,7 @@ class JobStatusByTaskAndSite(DBFormatter):
     MONITOR_STATE_MAP = {'Pending': 'submitted_pending', 
                          'Running': 'submitted_running', 
                          'Complete': 'submitted_running',
-                         'Error': 'submitted_runnig'}
+                         'Error': 'submitted_running'}
     
     def mappedStatusFormat(self, results):
         """

--- a/src/python/WMCore/BossAir/MySQL/JobStatusByWorkflowAndSite.py
+++ b/src/python/WMCore/BossAir/MySQL/JobStatusByWorkflowAndSite.py
@@ -36,7 +36,7 @@ class JobStatusByWorkflowAndSite(DBFormatter):
     MONITOR_STATE_MAP = {'Pending': 'submitted_pending', 
                          'Running': 'submitted_running', 
                          'Complete': 'submitted_running',
-                         'Error': 'submitted_runnig'}
+                         'Error': 'submitted_running'}
     
     def mappedStatusFormat(self, results):
         """


### PR DESCRIPTION
Impact on CRABClient which shows both runniNg and runnig jobs.
