### PR TITLE
Write the configuration as a pickle in binary mode

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Templates/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Templates/CMSSW.py
@@ -381,6 +381,7 @@ class CMSSW(Template):
         step.application.section_("command")
         step.application.command.executable = "cmsRun"
         step.application.command.configuration = "PSet.py"
+        step.application.command.configurationPickle = "PSet.pkl"
         step.application.command.configurationHash = None
         step.application.command.psetTweak = None
         step.application.command.arguments = ""

--- a/test/python/WMCore_t/WMRuntime_t/Scripts_t/SetupCMSSWMulticore_t.py
+++ b/test/python/WMCore_t/WMRuntime_t/Scripts_t/SetupCMSSWMulticore_t.py
@@ -52,6 +52,29 @@ class SetupCMSSWPsetTest(unittest.TestCase):
         newStep.application.multicore.numberOfCores = "auto"
         return newStepHelper
 
+    def loadProcessFromPSet(self):
+        """
+        _loadProcessFromPSet_
+
+        This requires changing the working directory,
+        do so in a safe manner to encapsulate the change to this method only
+        """
+
+        currentPath = os.getcwd()
+        loadedProcess = None
+        try:
+            if not os.path.isdir(self.testDir):
+                raise
+            os.chdir(self.testDir)
+            testFile = "PSet.py"
+            pset = imp.load_source('process', testFile)
+            loadedProcess = pset.process
+        except Exception, ex:
+            self.fail("An exception was caught while trying to load the PSet, %s" % str(ex))
+        finally:
+            os.chdir(currentPath)
+
+        return loadedProcess
 
     def testBuildPset(self):
         """
@@ -68,10 +91,8 @@ class SetupCMSSWPsetTest(unittest.TestCase):
         setupScript.files = {'file1': {'events':1000}}
         setupScript.buildPSet()
 
-        testFile = os.path.join(self.testDir, "PSet.py")
-        pset = imp.load_source('process', testFile)
+        fixedPSet = self.loadProcessFromPSet()
 
-        fixedPSet = pset.process
         self.assertTrue(int(fixedPSet.options.multiProcesses.maxChildProcesses.value) > 0)
         self.assertTrue(int(fixedPSet.options.multiProcesses.maxSequentialEventsPerChild.value) > 0)
 

--- a/test/python/WMCore_t/WMRuntime_t/Scripts_t/SetupCMSSWPset_t.py
+++ b/test/python/WMCore_t/WMRuntime_t/Scripts_t/SetupCMSSWPset_t.py
@@ -73,6 +73,29 @@ class SetupCMSSWPsetTest(unittest.TestCase):
                             parents = set([File(lfn = "/some/parent/two")])))
         return newJob
 
+    def loadProcessFromPSet(self):
+        """
+        _loadProcessFromPSet_
+
+        This requires changing the working directory,
+        do so in a safe manner to encapsulate the change to this method only
+        """
+
+        currentPath = os.getcwd()
+        loadedProcess = None
+        try:
+            if not os.path.isdir(self.testDir):
+                raise
+            os.chdir(self.testDir)
+            testFile = "PSet.py"
+            pset = imp.load_source('process', testFile)
+            loadedProcess = pset.process
+        except Exception, ex:
+            self.fail("An exception was caught while trying to load the PSet, %s" % str(ex))
+        finally:
+            os.chdir(currentPath)
+
+        return loadedProcess
 
     def testPSetFixup(self):
         """
@@ -89,9 +112,7 @@ class SetupCMSSWPsetTest(unittest.TestCase):
         setupScript.job = self.createTestJob()
         setupScript()
 
-        testFile = os.path.join(self.testDir, "PSet.py")
-        pset = imp.load_source('process', testFile)
-        fixedPSet = pset.process
+        fixedPSet = self.loadProcessFromPSet()
 
         self.assertEqual(len(fixedPSet.source.fileNames.value), 2,
                          "Error: Wrong number of files.")
@@ -123,9 +144,7 @@ class SetupCMSSWPsetTest(unittest.TestCase):
         setupScript.job = self.createTestJob()
         setupScript()
 
-        testFile = os.path.join(self.testDir, "PSet.py")
-        pset = imp.load_source('process', testFile)
-        fixedPSet = pset.process
+        fixedPSet = self.loadProcessFromPSet()
 
         self.assertEqual(len(fixedPSet.source.fileNames.value), 2,
                          "Error: Wrong number of files.")


### PR DESCRIPTION
Make a suitable PSet that loads the binary pickle and stores it as
the process for the cmsRun command

Fixes #4104
