### PR TITLE
Fix TaskChain unit test

### DIFF
--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
@@ -224,8 +224,6 @@ class TaskChainTests(unittest.TestCase):
                 "RequestNumEvents" : 10000,
                 "Seeding" : "Automatic",
                 "PrimaryDataset" : "RelValTTBar",
-                "DataPileup" : "/minbias/some/data",
-                "MCPileup" : "/minbias/some/mc"
             },
             "Task2" : {
                 "TaskName" : "DigiHLT",
@@ -234,8 +232,6 @@ class TaskChainTests(unittest.TestCase):
                 "ConfigCacheID" : processorDocs['DigiHLT'],
                 "SplittingAlgorithm" : "FileBased",
                 "SplittingArguments" : {"files_per_job" : 1 },
-                "DataPileup" : "/minbias/some/data",
-                "MCPileup" : "/minbias/some/mc"
             },
             "Task3" : {
                 "TaskName" : "Reco",


### PR DESCRIPTION
This lines shouldn't have been committed, they were only to check my sanity when adding the pileup support.

Fixes #4114
