### PR TITLE
Avoid the error: un(deep)copyable object of type <type 'thread.lock'>

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/gLitePlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/gLitePlugin.py
@@ -15,7 +15,7 @@ import tempfile
 import os
 import time
 import types
-from copy import deepcopy
+from copy import copy
 
 from WMCore.Wrappers import JsonWrapper as json
 from WMCore.Credential.Proxy           import Proxy
@@ -1433,7 +1433,7 @@ class gLitePlugin(BasePlugin):
         """
 
         logging.debug("Retrieving proxy for %s" % userdn)
-        config = deepcopy(self.defaultDelegation)
+        config = copy(self.defaultDelegation)
         config['userDN'] = userdn
         config['group'] = group
         config['role'] = role


### PR DESCRIPTION
The deepcopy of the self.defaultDelegation object (in gLitePlugin.py line 1437) fails because there is a logger object which cannot be deep-copied.
