### PR TITLE
Add log instruction in WorkQueueReqMgrInterface

### DIFF
--- a/src/python/WMCore/WorkQueue/WorkQueueReqMgrInterface.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueReqMgrInterface.py
@@ -89,6 +89,7 @@ class WorkQueueReqMgrInterface():
                 # temporary problem - try again later
                 msg = 'Error processing request "%s": will try again later.' \
                 '\nError: "%s"' % (reqName, str(ex))
+                self.logger.info(msg)
                 self.sendMessage(reqName, msg)
                 continue
             except Exception, ex:


### PR DESCRIPTION
Hi, I run into an error and no message was printed in the log. Only an alert was sent, but imho it can be useful to print a message in the log also.
