### PR TITLE
Fix TaskArchiver not cleaning outputs

### DIFF
--- a/src/python/WMComponent/TaskArchiver/TaskArchiverPoller.py
+++ b/src/python/WMComponent/TaskArchiver/TaskArchiverPoller.py
@@ -384,6 +384,7 @@ class TaskArchiverPoller(BaseWorkerThread):
                     subIDs = workflows[workflow]["workflows"][wmbsWorkflow.id]
                     for subID in subIDs:
                         subscription = Subscription(id = subID)
+                        subscription['workflow'] = wmbsWorkflow
                         subscription.load()
                         subscription.deleteEverything()
 

--- a/test/python/WMComponent_t/TaskArchiver_t/TaskArchiver_t.py
+++ b/test/python/WMComponent_t/TaskArchiver_t/TaskArchiver_t.py
@@ -218,6 +218,19 @@ class TaskArchiverTest(unittest.TestCase):
         testWMBSFileset.commit()
         testWMBSFileset.markOpen(0)
 
+        outputWMBSFileset = Fileset(name = '%sOutput' % filesetName)
+        outputWMBSFileset.create()
+        testFileC = File(lfn = "/this/is/a/lfnC" , size = 1024, events = 10)
+        testFileC.addRun(Run(10, *[12312]))
+        testFileC.setLocation('malpaquet')
+        testFileC.create()
+        outputWMBSFileset.addFile(testFileC)
+        outputWMBSFileset.commit()
+        outputWMBSFileset.markOpen(0)
+
+        testWorkflow.addOutput('output', outputWMBSFileset)
+
+
         testSubscription = Subscription(fileset = testWMBSFileset,
                                         workflow = testWorkflow)
         testSubscription.create()


### PR DESCRIPTION
In the last task archiver fixes I missed loading a workflow
when loading the subscription before deleting it which
made the workflow have empty output maps.

Modified the unit test to catch this
