### PR TITLE
Smart lumi splitting

### DIFF
--- a/src/python/WMComponent/ErrorHandler/ErrorHandlerPoller.py
+++ b/src/python/WMComponent/ErrorHandler/ErrorHandlerPoller.py
@@ -128,18 +128,15 @@ class ErrorHandlerPoller(BaseWorkerThread):
         # Retries < max retry count
         for ajob in jobs:
             # Retries < max retry count
-            if ajob['retry_count'] < self.maxRetries:
+            if ajob['retry_count'] < self.maxRetries and jobType != 'create':
                 cooloffPre.append(ajob)
-            # Check if Retries >= max retry count
-            elif ajob['retry_count'] >= self.maxRetries:
+            # Check if Retries >= max retry count or it is a createfailed job
+            elif ajob['retry_count'] >= self.maxRetries or jobType == 'create':
                 exhaustJobs.append(ajob)
                 msg = "Exhausting job %i" % ajob['id']
                 logging.error(msg)
                 self.sendAlert(4, msg = msg)
                 logging.debug("JobInfo: %s" % ajob)
-            else:
-                logging.debug("Job %i had %s retries remaining" \
-                              % (ajob['id'], str(ajob['retry_count'])))
 
         if self.readFWJR:
             # Then we have to check each FWJR for exit status

--- a/src/python/WMComponent/JobCreator/JobCreatorPoller.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorPoller.py
@@ -697,11 +697,13 @@ class JobCreatorPoller(BaseWorkerThread):
         Mark jobGroup as ready in changeState
         """
         try:
+            createFailedJobs = filter(lambda x : x.get('failedOnCreation', False), wmbsJobGroup.jobs)
             self.changeState.propagate(wmbsJobGroup.jobs, 'created', 'new')
+            self.changeState.propagate(createFailedJobs, 'createfailed', 'created')
         except WMException:
             raise
         except Exception, ex:
-            msg =  "Unhandled exception while calling changeState.\n"
+            msg = "Unhandled exception while calling changeState.\n"
             msg += str(ex)
             logging.error(msg)
             self.sendAlert(6, msg = msg)

--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrBrowser.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrBrowser.py
@@ -148,7 +148,14 @@ class ReqMgrBrowser(WebAPI):
             if str(submittedParams["halt_job_on_file_boundaries"]) == "True":
                 splitParams["halt_job_on_file_boundaries"] = True
             else:
-                splitParams["halt_job_on_file_boundaries"] = False                
+                splitParams["halt_job_on_file_boundaries"] = False
+        elif splittingAlgo == "EventAwareLumiBased":
+            splitParams["events_per_job"] = int(submittedParams["avg_events_per_job"])
+            splitParams["max_events_per_lumi"] = int(submittedParams["max_events_per_lumi"])
+            if str(submittedParams["halt_job_on_file_boundaries"]) == "True":
+                splitParams["halt_job_on_file_boundaries"] = True
+            else:
+                splitParams["halt_job_on_file_boundaries"] = False
         elif splittingAlgo == "EventBased":
             splitParams["events_per_job"] = int(submittedParams["events_per_job"])
             if submittedParams.has_key("events_per_lumi"):

--- a/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
+++ b/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python
+"""
+_EventAwareLumiBased_
+
+Lumi based splitting algorithm that will chop a fileset into
+a set of jobs based on lumi sections, failing jobs with too many
+events in a lumi and adapting the number of lumis per job
+according to the average number of events per lumi in the files.
+
+Created on Sep 25, 2012
+
+@author: dballest
+"""
+
+import logging
+import operator
+import traceback
+import math
+
+from WMCore.DataStructs.Run         import Run
+from WMCore.JobSplitting.JobFactory import JobFactory
+from WMCore.JobSplitting.LumiBased  import isGoodLumi, isGoodRun
+from WMCore.WMBS.File               import File
+from WMCore.WMSpec.WMTask           import buildLumiMask
+
+class EventAwareLumiBased(JobFactory):
+    """
+    Split jobs by lumis taking into account events per lumi
+    """
+
+    locations = []
+
+
+    def algorithm(self, *args, **kwargs):
+        """
+        _algorithm_
+
+        Split files into a number of lumis per job
+        Allow a flag to determine if we split files between jobs
+        """
+
+        avgEventsPerJob = int(kwargs.get('events_per_job', 5000))
+        eventLimit      = int(kwargs.get('max_events_per_lumi', 20000))
+        splitOnFile     = bool(kwargs.get('halt_job_on_file_boundaries', True))
+        ignoreACDC      = bool(kwargs.get('ignore_acdc_except', False))
+        collectionName  = kwargs.get('collectionName', None)
+        splitOnRun      = kwargs.get('splitOnRun', True)
+        getParents      = kwargs.get('include_parents', False)
+        runWhitelist    = kwargs.get('runWhitelist', [])
+        runs            = kwargs.get('runs', None)
+        lumis           = kwargs.get('lumis', None)
+
+        goodRunList = {}
+        if runs and lumis:
+            goodRunList = buildLumiMask(runs, lumis)
+
+        # If we have runLumi info, we need to load it from couch
+        if collectionName:
+            try:
+                from WMCore.ACDC.DataCollectionService import DataCollectionService
+                couchURL       = kwargs.get('couchURL')
+                couchDB        = kwargs.get('couchDB')
+                filesetName    = kwargs.get('filesetName')
+                collectionName = kwargs.get('collectionName')
+                owner          = kwargs.get('owner')
+                group          = kwargs.get('group')
+
+                logging.info('Creating jobs for ACDC fileset %s' % filesetName)
+                dcs = DataCollectionService(couchURL, couchDB)
+                goodRunList = dcs.getLumiWhitelist(collectionName, filesetName, owner, group)
+            except Exception, ex:
+                msg =  "Exception while trying to load goodRunList\n"
+                if ignoreACDC:
+                    msg +=  "Ditching goodRunList\n"
+                    msg += str(ex)
+                    msg += str(traceback.format_exc())
+                    logging.error(msg)
+                    goodRunList = {}
+                else:
+                    msg +=  "Refusing to create any jobs.\n"
+                    msg += str(ex)
+                    msg += str(traceback.format_exc())
+                    logging.error(msg)
+                    return
+
+        lDict = self.sortByLocation()
+        locationDict = {}
+
+        # First we need to load the data
+        if self.package == 'WMCore.WMBS':
+            loadRunLumi = self.daoFactory(classname = "Files.GetBulkRunLumi")
+
+        for key in lDict.keys():
+            newlist = []
+            # First we need to load the data
+            if self.package == 'WMCore.WMBS':
+                fileLumis = loadRunLumi.execute(files = lDict[key])
+                for f in lDict[key]:
+                    lumiDict = fileLumis.get(f['id'], {})
+                    for run in lumiDict.keys():
+                        f.addRun(run = Run(run, *lumiDict[run]))
+
+            for f in lDict[key]:
+                if len(f['runs']) == 0:
+                    continue
+                f['runs'] = sorted(f['runs'])
+                f['lumiCount'] = 0
+                for run in f['runs']:
+                    run.lumis.sort()
+                    f['lumiCount'] += len(run.lumis)
+                f['lowestRun'] = f['runs'][0]
+
+                #Do average event per lumi calculation
+                if f['lumiCount']:
+                    f['avgEvtsPerLumi'] = float(f['events'])/f['lumiCount']
+                else:
+                    #No lumis in the file, ignore it
+                    continue
+                newlist.append(f)
+
+
+            locationDict[key] = sorted(newlist, key=operator.itemgetter('lowestRun'))
+
+        totalJobs      = 0
+        lastLumi       = None
+        firstLumi      = None
+        lastRun        = None
+        lumisInJob     = 0
+        currentJobAvgEventCount = 0
+        for location in locationDict:
+
+            # For each location, we need a new jobGroup
+            self.newGroup()
+            stopJob = True
+            for f in locationDict[location]:
+
+                if getParents:
+                    parentLFNs = self.findParent(lfn = f['lfn'])
+                    for lfn in parentLFNs:
+                        parent = File(lfn = lfn)
+                        f['parents'].add(parent)
+
+                updateSplitOnJobStop = False
+                failNextJob          = False
+                #If the number of events per lumi is higher than the limit
+                #and it's only one lumi then ditch that lumi
+                if f['avgEvtsPerLumi'] > eventLimit and f['lumiCount'] == 1:
+                    failNextJob = True
+                    stopJob = True
+                elif splitOnFile:
+                    # Then we have to split on every boundary
+                    stopJob = True
+                    #Check the average number of events per lumi in this file
+                    #Adapt the lumis per job to match the target conditions
+                    if f['avgEvtsPerLumi']:
+                        #If there are events in the file
+                        ratio = float(avgEventsPerJob) / f['avgEvtsPerLumi']
+                        lumisPerJob = max(int(math.floor(ratio)), 1)
+                    else:
+                        #Zero event file, then the ratio goes to infinity. Computers don't like that
+                        lumisPerJob = f['lumiCount']
+                else:
+                    #Analyze how many events does this job already has
+                    #Check how many we want as target, include as many lumi sections as possible
+                    updateSplitOnJobStop = True
+                    eventsRemaining = max(avgEventsPerJob - currentJobAvgEventCount, 0)
+                    if f['avgEvtsPerLumi']:
+                        lumisAllowed = int(math.floor(float(eventsRemaining) / f['avgEvtsPerLumi']))
+                    else:
+                        lumisAllowed = f['lumiCount']
+                    lumisPerJob = max(lumisInJob + lumisAllowed, 1)
+
+                for run in f['runs']:
+                    if not isGoodRun(goodRunList = goodRunList, run = run.run):
+                        # Then skip this one
+                        continue
+                    if len(runWhitelist) > 0 and not run.run in runWhitelist:
+                        # Skip due to run whitelist
+                        continue
+                    firstLumi = None
+
+                    if splitOnRun and run.run != lastRun:
+                        # Then we need to kill this job and get a new one
+                        stopJob = True
+
+                    # Now loop over the lumis
+                    for lumi in run:
+                        if not isGoodLumi(goodRunList, run = run.run, lumi = lumi):
+                            # Kill the chain of good lumis
+                            # Skip this lumi
+                            if firstLumi != None and firstLumi != lumi:
+                                self.currentJob['mask'].addRunAndLumis(run = run.run,
+                                                                       lumis = [firstLumi, lastLumi])
+                                firstLumi = None
+                                lastLumi = None
+                            continue
+
+                        # You have to kill the lumi chain if they're not continuous
+                        if lastLumi and not lumi == lastLumi + 1:
+                            self.currentJob['mask'].addRunAndLumis(run = run.run,
+                                                                   lumis = [firstLumi, lastLumi])
+                            firstLumi = None
+                            lastLumi = None
+
+                        if firstLumi == None:
+                            # Set the first lumi in the run
+                            firstLumi = lumi
+
+                        # If we're full, end the job
+                        if lumisInJob == lumisPerJob:
+                            stopJob = True
+                        # Actually do the new job creation
+                        if stopJob:
+                            if firstLumi != None and lastLumi != None and lastRun != None:
+                                self.currentJob['mask'].addRunAndLumis(run = lastRun,
+                                                                       lumis = [firstLumi, lastLumi])
+                            self.newJob(name = self.getJobName(length = totalJobs), failedJob = failNextJob)
+                            failNextJob = False
+                            firstLumi = lumi
+                            lumisInJob = 0
+                            currentJobAvgEventCount = 0
+                            totalJobs += 1
+
+                            # Add the file to new jobs
+                            self.currentJob.addFile(f)
+
+                            if updateSplitOnJobStop:
+                                #Then we were carrying from a previous file
+                                #Reset calculations for this file
+                                updateSplitOnJobStop = False
+                                if f['avgEvtsPerLumi']:
+                                    ratio = float(avgEventsPerJob) / f['avgEvtsPerLumi']
+                                    lumisPerJob = max(int(math.floor(ratio)), 1)
+                                else:
+                                    lumisPerJob = f['lumiCount']
+
+                        lumisInJob += 1
+                        lastLumi = lumi
+                        stopJob = False
+                        lastRun = run.run
+
+                        if self.currentJob and not f in self.currentJob['input_files']:
+                            self.currentJob.addFile(f)
+
+                    if firstLumi != None and lastLumi != None:
+                        # Add this run to the mask
+                        self.currentJob['mask'].addRunAndLumis(run = run.run,
+                                                               lumis = [firstLumi, lastLumi])
+                        firstLumi = None
+                        lastLumi = None
+
+                if not splitOnFile:
+                    currentJobAvgEventCount += f['avgEvtsPerLumi'] * min(lumisInJob, f['lumiCount'])
+
+        return

--- a/src/python/WMCore/JobSplitting/JobFactory.py
+++ b/src/python/WMCore/JobSplitting/JobFactory.py
@@ -113,7 +113,7 @@ class JobFactory(WMObject):
         map(lambda x: x.startGroup(self.currentGroup), self.generators)
 
 
-    def newJob(self, name=None, files=None):
+    def newJob(self, name=None, files=None, failedJob=False):
         """
         Instantiate a new Job onject, apply all the generators to it
         """
@@ -129,7 +129,11 @@ class JobFactory(WMObject):
         # All production jobs must be run 1
         if self.subscription["type"] == "Production":
             self.currentJob["mask"].setMaxAndSkipRuns(0, 1)
-                        
+
+        # Some jobs are not meant to be submitted, ever
+        if failedJob:
+            self.currentJob["failedOnCreation"] = True
+
         self.nJobs += 1
         for gen in self.generators:
             gen(self.currentJob)

--- a/src/python/WMCore/JobStateMachine/Transitions.py
+++ b/src/python/WMCore/JobStateMachine/Transitions.py
@@ -12,20 +12,20 @@ class Transitions(dict):
     def __init__(self):
         self.setdefault('none', ['new'])
         self.setdefault('new', ['created', 'createfailed', 'killed'])
-        self.setdefault('created', ['executing', 'submitfailed', 'killed'])
+        self.setdefault('created', ['executing', 'submitfailed', 'createfailed', 'killed'])
         self.setdefault('executing', ['complete', 'jobfailed', 'killed'])
         self.setdefault('complete', ['jobfailed', 'success'])
         self.setdefault('createfailed', ['createcooloff', 'exhausted', 'killed'])
         self.setdefault('submitfailed', ['submitcooloff', 'exhausted', 'killed'])
         self.setdefault('jobfailed', ['jobcooloff', 'exhausted', 'killed'])
-        self.setdefault('createcooloff', ['new', 'killed', 'createpaused'])
+        self.setdefault('createcooloff', ['created', 'killed', 'createpaused'])
         self.setdefault('submitcooloff', ['created', 'killed', 'submitpaused'])
         self.setdefault('jobcooloff', ['created', 'jobpaused', 'killed'])
         self.setdefault('success', ['cleanout'])
         self.setdefault('exhausted', ['cleanout'])
         self.setdefault('killed', ['cleanout', 'killed'])
         self.setdefault('jobpaused', ['created', 'killed'])
-        self.setdefault('createpaused', ['new', 'killed'])
+        self.setdefault('createpaused', ['created', 'killed'])
         self.setdefault('submitpaused', ['created', 'killed'])
 
     def states(self):

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -881,7 +881,8 @@ class WMWorkloadHelper(PersistencyHelper):
         SplitAlgoToStartPolicy = {"FileBased": ["NumberOfFiles"],
                                   "EventBased": ["NumberOfEvents",
                                                  "NumberOfEventsPerLumi"],
-                                  "LumiBased": ["NumberOfLumis"]}
+                                  "LumiBased": ["NumberOfLumis"],
+                                  "EventAwareLumiBased" : ["NumberOfEvents"]}
         SplitAlgoToArgMap = {"NumberOfFiles": "files_per_job",
                              "NumberOfEvents": "events_per_job",
                              "NumberOfLumis": "lumis_per_job",

--- a/src/templates/WMCore/WebTools/RequestManager/Splitting.tmpl
+++ b/src/templates/WMCore/WebTools/RequestManager/Splitting.tmpl
@@ -93,7 +93,27 @@ function generateProcessing(splitAlgo, splitParams) {
   } else {
     procStr += "<option>True</option><option select>False</option>\n";
   }
- 
+
+  procStr += "</select></input></td></tr>\n";
+  procStr += '<tr><td><input type="radio" name="splittingAlgo" value="EventAwareLumiBased"';
+
+  if (splitAlgo == "EventAwareLumiBased") {
+    procStr += " checked";
+  }
+  procStr += ">Event Aware Lumi Based</input></td>\n";
+  procStr += generateInput("Optimal events per job:", "avg_events_per_job", splitParams);
+  procStr += generateInput("Max events in single lumi:", "max_events_per_lumi", splitParams);
+  procStr += '<td>Split files between jobs: <select name="halt_job_on_file_boundaries">';
+  if ("halt_job_on_file_boundaries" in splitParams) {
+    if (splitParams["halt_job_on_file_boundaries"] == true) {
+      procStr += "<option selected>True</option><option>False</option>\n";
+    } else {
+      procStr += "<option>True</option><option selected>False</option>\n";
+    }
+  } else {
+    procStr += "<option>True</option><option select>False</option>\n";
+  }
+
   procStr += "</select></input></td></tr>\n";
   procStr += '<tr><td><input type="radio" name="splittingAlgo" value="EventBased"';
 

--- a/test/python/WMComponent_t/ErrorHandler_t/ErrorHandler_t.py
+++ b/test/python/WMComponent_t/ErrorHandler_t/ErrorHandler_t.py
@@ -234,7 +234,8 @@ class ErrorHandlerTest(unittest.TestCase):
         
         config = self.getConfig()
         changer = ChangeState(config)
-        changer.propagate(testJobGroup.jobs, 'createfailed', 'new')
+        changer.propagate(testJobGroup.jobs, 'created', 'new')
+        changer.propagate(testJobGroup.jobs, 'createfailed', 'created')
 
         idList = self.getJobs.execute(state = 'CreateFailed')
         self.assertEqual(len(idList), self.nJobs)
@@ -246,18 +247,7 @@ class ErrorHandlerTest(unittest.TestCase):
         idList = self.getJobs.execute(state = 'CreateFailed')
         self.assertEqual(len(idList), 0)
 
-        idList = self.getJobs.execute(state = 'CreateCooloff')
-        self.assertEqual(len(idList), self.nJobs)
-
-        changer.propagate(testJobGroup.jobs, 'new', 'CreateCooloff')
-        changer.propagate(testJobGroup.jobs, 'createfailed', 'new')
-
-        # Now exhaust them
-        for job in testJobGroup.jobs:
-            job['retry_count'] = 6
-            job.save()
-        testErrorHandler.algorithm(None)
-
+        #These should go directly to exhausted
         idList = self.getJobs.execute(state = 'Exhausted')
         self.assertEqual(len(idList), self.nJobs)
 

--- a/test/python/WMCore_t/JobSplitting_t/EventAwareLumiBased_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/EventAwareLumiBased_t.py
@@ -1,0 +1,416 @@
+"""
+_EventAwareLumiBased_t_
+
+Lumi based splitting test with awareness of events per lumi.
+It must pass the same tests as the LumiBased algorithm, plus
+specific ones for this algorithm.
+
+Created on Sep 25, 2012
+
+@author: dballest
+"""
+
+import unittest
+
+from WMCore.DataStructs.File import File
+from WMCore.DataStructs.Fileset import Fileset
+from WMCore.DataStructs.Subscription import Subscription
+from WMCore.DataStructs.Workflow import Workflow
+from WMCore.DataStructs.Run import Run
+
+from WMCore.JobSplitting.SplitterFactory import SplitterFactory
+from WMCore.Services.UUID import makeUUID
+
+class EventAwareLumiBasedTest(unittest.TestCase):
+    """
+    _EventAwareLumiBasedTest_
+
+    Test event based job splitting.
+    """
+
+
+    def setUp(self):
+        """
+        _setUp_
+
+        Create two subscriptions: One that contains a single file and one that
+        contains multiple files.
+        """
+
+        self.testWorkflow = Workflow()
+
+        return
+
+    def tearDown(self):
+        """
+        _tearDown_
+
+        Nothing to do...
+        """
+        pass
+
+
+    def createSubscription(self, nFiles, lumisPerFile, twoSites = False, nEventsPerFile = 100):
+        """
+        _createSubscription_
+
+        Create a subscription for testing
+        """
+
+        baseName = makeUUID()
+
+        testFileset = Fileset(name = baseName)
+        for i in range(nFiles):
+            newFile = self.createFile('%s_%i' % (baseName, i), nEventsPerFile,
+                                      i, lumisPerFile, 'blenheim')
+            testFileset.addFile(newFile)
+        if twoSites:
+            for i in range(nFiles):
+                newFile = self.createFile('%s_%i_2' % (baseName, i), nEventsPerFile,
+                                          i, lumisPerFile, 'malpaquet')
+                testFileset.addFile(newFile)
+
+
+        testSubscription = Subscription(fileset = testFileset,
+                                         workflow = self.testWorkflow,
+                                         split_algo = "EventAwareLumiBased",
+                                         type = "Processing")
+
+        return testSubscription
+
+    def createFile(self, lfn, events, run, lumis, location):
+        """
+        _createFile_
+
+        Create a file for testing
+        """
+        newFile = File(lfn = lfn, size = 1000,
+                       events = events)
+        lumiList = []
+        for lumi in range(lumis):
+            lumiList.append((run * lumis) + lumi)
+        newFile.addRun(Run(run, *lumiList))
+        newFile.setLocation(location)
+        return newFile
+
+    def testA_FileSplitting(self):
+        """
+        _FileSplitting_
+
+        Test that things work if we split files between jobs
+        """
+        splitter = SplitterFactory()
+
+        oneSetSubscription = self.createSubscription(nFiles = 10, lumisPerFile = 1)
+        jobFactory = splitter(package = "WMCore.DataStructs",
+                              subscription = oneSetSubscription)
+
+
+        jobGroups = jobFactory(halt_job_on_file_boundaries = True,
+                               events_per_job = 100)
+        self.assertEqual(len(jobGroups), 1)
+        self.assertEqual(len(jobGroups[0].jobs), 10)
+        for job in jobGroups[0].jobs:
+            self.assertTrue(len(job['input_files']), 1)
+
+
+
+
+        twoLumiFiles = self.createSubscription(nFiles = 5, lumisPerFile = 2)
+        jobFactory = splitter(package = "WMCore.DataStructs",
+                              subscription = twoLumiFiles)
+        jobGroups = jobFactory(halt_job_on_file_boundaries = True,
+                               events_per_job = 50)
+        self.assertEqual(len(jobGroups), 1)
+        self.assertEqual(len(jobGroups[0].jobs), 10)
+        for job in jobGroups[0].jobs:
+            self.assertEqual(len(job['input_files']), 1)
+
+
+
+        wholeLumiFiles = self.createSubscription(nFiles = 5, lumisPerFile = 3)
+        jobFactory = splitter(package = "WMCore.DataStructs",
+                              subscription = wholeLumiFiles)
+        jobGroups = jobFactory(halt_job_on_file_boundaries = True,
+                               events_per_job = 67)
+        self.assertEqual(len(jobGroups), 1)
+        # 10 because we split on run boundaries
+        self.assertEqual(len(jobGroups[0].jobs), 10)
+        jobList = jobGroups[0].jobs
+        for job in jobList:
+            # Have should have one file, half two
+            self.assertTrue(len(job['input_files']) in [1, 2])
+
+
+        mask0 = jobList[0]['mask'].getRunAndLumis()
+        self.assertEqual(mask0, {0L: [[0L, 1L]]})
+        mask1 = jobList[1]['mask'].getRunAndLumis()
+        self.assertEqual(mask1, {0L: [[2L, 2L]]})
+        mask2 = jobList[2]['mask'].getRunAndLumis()
+        self.assertEqual(mask2, {1L: [[3L, 4L]]})
+        mask3 = jobList[3]['mask'].getRunAndLumis()
+        self.assertEqual(mask3, {1L: [[5L, 5L]]})
+
+        self.assertEqual(jobList[0]['mask'].getRunAndLumis(), {0L: [[0L, 1L]]})
+
+        # Do it with multiple sites
+        twoSiteSubscription = self.createSubscription(nFiles = 5, lumisPerFile = 2, twoSites = True)
+        jobFactory = splitter(package = "WMCore.DataStructs",
+                              subscription = twoSiteSubscription)
+        jobGroups = jobFactory(halt_job_on_file_boundaries = True,
+                               events_per_job = 50)
+        self.assertEqual(len(jobGroups), 2)
+        self.assertEqual(len(jobGroups[0].jobs), 10)
+        for job in jobGroups[0].jobs:
+            self.assertEqual(len(job['input_files']), 1)
+
+
+
+    def testB_NoRunNoFileSplitting(self):
+        """
+        _NoRunNoFileSplitting_
+
+        Test the splitting algorithm in the odder fringe
+        cases that might be required.
+        """
+        splitter = SplitterFactory()
+        testSubscription = self.createSubscription(nFiles = 5, lumisPerFile = 5, twoSites = False)
+        jobFactory = splitter(package = "WMCore.DataStructs",
+                              subscription = testSubscription)
+
+        jobGroups = jobFactory(halt_job_on_file_boundaries = False,
+                               splitOnRun = False,
+                               events_per_job = 60)
+
+        self.assertEqual(len(jobGroups), 1)
+        jobs = jobGroups[0].jobs
+        self.assertEqual(len(jobs), 9)
+
+        # The first job should have three lumis from one run
+        # The second three lumis from two different runs
+        self.assertEqual(jobs[0]['mask'].getRunAndLumis(), {0L: [[0L, 2L]]})
+        self.assertEqual(jobs[1]['mask'].getRunAndLumis(), {0L: [[3L, 4L]], 1L: [[5L, 5L]]})
+
+        # Assert that this works differently with file splitting on and run splitting on
+        testSubscription = self.createSubscription(nFiles = 5, lumisPerFile = 5, twoSites = False)
+        jobFactory = splitter(package = "WMCore.DataStructs",
+                              subscription = testSubscription)
+        jobGroups = jobFactory(halt_job_on_file_boundaries = True,
+                               splitOnRun = True,
+                               events_per_job = 60)
+        self.assertEqual(len(jobGroups), 1)
+        jobs = jobGroups[0].jobs
+        self.assertEqual(len(jobs), 10)
+
+        # In this case it should slice things up so that each job only has one run
+        # in it.
+        self.assertEqual(jobs[0]['mask'].getRunAndLumis(), {0L: [[0L, 2L]]})
+        self.assertEqual(jobs[1]['mask'].getRunAndLumis(), {0L: [[3L, 4L]]})
+        return
+
+    def testC_FileSplitNoHardLimit(self):
+        """
+        _testC_FileSplitNoHardLimit_
+
+        Simplest use case, there is only a self limit of events per job which
+        the algorithm must adapt to on a file by file basis. At most
+        one file per job so we don't have to pass information between files.
+        """
+        splitter = SplitterFactory()
+
+        #Create 5 files with 7 lumi per file and 100 events per lumi on average.
+        testSubscription = self.createSubscription(nFiles = 5, lumisPerFile = 7, twoSites = False,
+                                                   nEventsPerFile = 700)
+        jobFactory = splitter(package = "WMCore.DataStructs",
+                              subscription = testSubscription)
+
+        #First test, the optimal settings are 360 events per job
+        #As we have files with 100 events per lumi, this will configure the splitting to
+        #3.6 lumis per job, which rounds to 3, the algorithm always approximates to the lower integer.
+        jobGroups = jobFactory(halt_job_on_file_boundaries = True,
+                               splitOnRun = True,
+                               events_per_job = 360)
+        self.assertEqual(len(jobGroups), 1, "There should be only one job group")
+        jobs = jobGroups[0].jobs
+        self.assertEqual(len(jobs), 15, "There should be 15 jobs")
+
+        #Now set the average to 200 events per job
+        #This results in the algorithm reducing the lumis per job to 2
+        jobGroups = jobFactory(halt_job_on_file_boundaries = True,
+                               splitOnRun = True,
+                               events_per_job = 200)
+        self.assertEqual(len(jobGroups), 1, "There should be only one job group")
+        jobs = jobGroups[0].jobs
+        self.assertEqual(len(jobs), 20, "There should be 20 jobs")
+
+        #Check extremes, process a zero event files with lumis. It must be processed in one job
+        testSubscription = self.createSubscription(nFiles = 5, lumisPerFile = 100, twoSites = False,
+                                                   nEventsPerFile = 0)
+        jobFactory = splitter(package = "WMCore.DataStructs",
+                              subscription = testSubscription)
+        jobGroups = jobFactory(halt_job_on_file_boundaries = True,
+                               events_per_job = 5000)
+        self.assertEqual(len(jobGroups), 1, "There should be only one job group")
+        jobs = jobGroups[0].jobs
+        self.assertEqual(len(jobs), 5, "There should be 5 jobs")
+
+        #Process files with 10k events per lumi, fallback to one lumi per job. We can't do better
+        testSubscription = self.createSubscription(nFiles = 5, lumisPerFile = 5, twoSites = False,
+                                                   nEventsPerFile = 50000)
+        jobFactory = splitter(package = "WMCore.DataStructs",
+                              subscription = testSubscription)
+        jobGroups = jobFactory(halt_job_on_file_boundaries = True,
+                               splitOnRun = True,
+                               events_per_job = 5000)
+        self.assertEqual(len(jobGroups), 1, "There should be only one job group")
+        jobs = jobGroups[0].jobs
+        self.assertEqual(len(jobs), 25, "There should be 5 jobs")
+
+
+    def testD_NoFileSplitNoHardLimit(self):
+        """
+        _testD_NoFileSplitNoHardLimit_
+
+        In this case we don't split on file boundaries, check different combination of files
+        make sure we make the most of the splitting, e.g. include many zero event files in
+        a single job.
+        """
+        splitter = SplitterFactory()
+
+        #Create 100 files with 7 lumi per file and 0 events per lumi on average.
+        testSubscription = self.createSubscription(nFiles = 100, lumisPerFile = 7, twoSites = False,
+                                                   nEventsPerFile = 0)
+        jobFactory = splitter(package = "WMCore.DataStructs",
+                              subscription = testSubscription)
+
+        #First test, the optimal settings are 360 events per job
+        #As we have files with 0 events per lumi, this will configure the splitting to
+        #a single job containing all files
+        jobGroups = jobFactory(halt_job_on_file_boundaries = False,
+                               splitOnRun = False,
+                               events_per_job = 360)
+        self.assertEqual(len(jobGroups), 1, "There should be only one job group")
+        jobs = jobGroups[0].jobs
+        self.assertEqual(len(jobs), 1, "There should be 1 job")
+        self.assertEqual(len(jobs[0]['input_files']), 100, "All 100 files must be in the job")
+
+        #Create 7 files, each one with different lumi/event distributions
+        testFileset = Fileset(name = "FilesetA")
+        testFileA = self.createFile("/this/is/file1", 250, 0, 5, "blenheim")
+        testFileB = self.createFile("/this/is/file2", 600, 1, 1, "blenheim")
+        testFileC = self.createFile("/this/is/file3", 1200, 2, 2, "blenheim")
+        testFileD = self.createFile("/this/is/file4", 100, 3, 1, "blenheim")
+        testFileE = self.createFile("/this/is/file5", 30, 4, 1, "blenheim")
+        testFileF = self.createFile("/this/is/file6", 10, 5, 1, "blenheim")
+        testFileG = self.createFile("/this/is/file7", 151, 6, 3, "blenheim")
+        testFileset.addFile(testFileA)
+        testFileset.addFile(testFileB)
+        testFileset.addFile(testFileC)
+        testFileset.addFile(testFileD)
+        testFileset.addFile(testFileE)
+        testFileset.addFile(testFileF)
+        testFileset.addFile(testFileG)
+
+        testSubscription = Subscription(fileset = testFileset,
+                                        workflow = self.testWorkflow,
+                                        split_algo = "EventAwareLumiBased",
+                                        type = "Processing")
+
+        jobFactory = splitter(package = "WMCore.DataStructs",
+                              subscription = testSubscription)
+        #Optimal settings are: jobs with 150 events per job
+        #This means, the first file must be splitted in 3 lumis per job which would leave room
+        #for another lumi in the second job, but the second file has a lumi too big for that
+        #The 3rd job only contains the second file, the fourth and fifth job split the third file
+        jobGroups = jobFactory(halt_job_on_file_boundaries = False,
+                               splitOnRun = False,
+                               events_per_job = 150)
+
+        self.assertEqual(len(jobGroups), 1, "There should be only one job group")
+        jobs = jobGroups[0].jobs
+        self.assertEqual(len(jobs), 8, "Eight jobs must be in the jobgroup")
+        self.assertEqual(jobs[0]["mask"].getRunAndLumis(), {0L : [[0L, 2L]]}, "Wrong mask for the first job")
+        self.assertEqual(jobs[1]["mask"].getRunAndLumis(), {0L : [[3L, 4L]]}, "Wrong mask for the second job")
+        self.assertEqual(jobs[2]["mask"].getRunAndLumis(), {1L : [[1L, 1L]]}, "Wrong mask for the third job")
+        self.assertEqual(jobs[3]["mask"].getRunAndLumis(), {2L : [[4L, 4L]]}, "Wrong mask for the fourth job")
+        self.assertEqual(jobs[4]["mask"].getRunAndLumis(), {2L : [[5L, 5L]]}, "Wrong mask for the fifth job")
+        self.assertEqual(jobs[5]["mask"].getRunAndLumis(),
+                         {3L : [[3L, 3L]], 4L : [[4L, 4L]], 5L : [[5L, 5L]]}, "Wrong mask for the sixth job")
+        self.assertEqual(jobs[6]["mask"].getRunAndLumis(), {6L : [[18L, 19L]]}, "Wrong mask for the seventh job")
+        self.assertEqual(jobs[7]["mask"].getRunAndLumis(), {6L : [[20L, 20L]]}, "Wrong mask for the seventh job")
+        #Test interactions of this algorithm with splitOnRun = True
+        #Make 2 files, one with 3 runs and a second one with the last run of the first
+        fileA = File(lfn = "/this/is/file1", size = 1000,
+                       events = 2400)
+        lumiListA = []
+        lumiListB = []
+        lumiListC = []
+        for lumi in range(8):
+            lumiListA.append(1 + lumi)
+            lumiListB.append(1 + lumi)
+            lumiListC.append(1 + lumi)
+        fileA.addRun(Run(1, *lumiListA))
+        fileA.addRun(Run(2, *lumiListA))
+        fileA.addRun(Run(3, *lumiListA))
+        fileA.setLocation("malpaquet")
+
+        fileB = self.createFile('/this/is/file2', 200, 3, 5, "malpaquet")
+
+        testFileset = Fileset(name = 'FilesetB')
+        testFileset.addFile(fileA)
+        testFileset.addFile(fileB)
+        testSubscription = Subscription(fileset = testFileset,
+                                        workflow = self.testWorkflow,
+                                        split_algo = "EventAwareLumiBased",
+                                        type = "Processing")
+
+        jobFactory = splitter(package = "WMCore.DataStructs",
+                              subscription = testSubscription)
+        #The settings for this splitting are 700 events per job
+        jobGroups = jobFactory(splitOnRun = True,
+                               halt_job_on_file_boundaries = False,
+                               events_per_job = 700)
+        self.assertEqual(len(jobGroups), 1, "There should be only one job group")
+        jobs = jobGroups[0].jobs
+        self.assertEqual(len(jobs), 6, "Six jobs must be in the jobgroup")
+
+    def testE_HardLimitSpltting(self):
+        """
+        _testE_HardLimitSplitting_
+
+        Test that we can specify a event limit, the
+        algorithm shall take single lumi files with more events than the limit
+        and mark them for failure
+        """
+        splitter = SplitterFactory()
+
+        #Create 3 files, the one in the middle is a "bad" file
+        testFileset = Fileset(name = "FilesetA")
+        testFileA = self.createFile("/this/is/file1", 1000, 0, 5, "blenheim")
+        testFileB = self.createFile("/this/is/file2", 1000, 1, 1, "blenheim")
+        testFileC = self.createFile("/this/is/file3", 1000, 2, 2, "blenheim")
+        testFileset.addFile(testFileA)
+        testFileset.addFile(testFileB)
+        testFileset.addFile(testFileC)
+
+        testSubscription = Subscription(fileset = testFileset,
+                                        workflow = self.testWorkflow,
+                                        split_algo = "EventAwareLumiBased",
+                                        type = "Processing")
+        jobFactory = splitter(package = "WMCore.DataStructs",
+                              subscription = testSubscription)
+        #Settings are to split on job boundaries, to fail sing lumis with more than 800 events
+        #and to put 550 events per job
+        jobGroups = jobFactory(halt_job_on_file_boundaries = True,
+                               splitOnRun = True,
+                               events_per_job = 550,
+                               max_events_per_lumi = 800)
+
+        self.assertEqual(len(jobGroups), 1, "There should be only one job group")
+        jobs = jobGroups[0].jobs
+        self.assertEqual(len(jobs), 6, "Six jobs must be in the jobgroup")
+        self.assertTrue(jobs[3]['failedOnCreation'], "The job processing the second file should me marked for failure")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/EventAwareLumiBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/EventAwareLumiBased_t.py
@@ -1,0 +1,338 @@
+"""
+WMBS version of the EventAwareLumiBased splitting
+algorithm unittest
+
+Created on Oct 2, 2012
+
+@author: dballest
+"""
+
+import unittest
+import threading
+
+from WMCore.WMBS.File import File
+from WMCore.WMBS.Fileset import Fileset
+from WMCore.WMBS.Subscription import Subscription
+from WMCore.WMBS.Workflow import Workflow
+
+from WMCore.DataStructs.Run import Run
+
+from WMCore.DAOFactory import DAOFactory
+from WMCore.JobSplitting.SplitterFactory import SplitterFactory
+from WMCore.Services.UUID import makeUUID
+from WMQuality.TestInit import TestInit
+
+class EventAwareLumiBasedTest(unittest.TestCase):
+    """
+    _EventAwareLumiBasedTest_
+
+    Test event based job splitting.
+    """
+
+
+    def setUp(self):
+        """
+        _setUp_
+
+        Create two subscriptions: One that contains a single file and one that
+        contains multiple files.
+        """
+
+        self.testInit = TestInit(__file__)
+        self.testInit.setLogging()
+        self.testInit.setDatabaseConnection()
+        self.testInit.setSchema(customModules = ["WMCore.WMBS"],
+                                useDefault = False)
+
+        myThread = threading.currentThread()
+        daofactory = DAOFactory(package = "WMCore.WMBS",
+                                logger = myThread.logger,
+                                dbinterface = myThread.dbi)
+
+        locationAction = daofactory(classname = "Locations.New")
+        locationAction.execute(siteName = 's1', seName = "somese.cern.ch")
+        locationAction.execute(siteName = 's2', seName = "otherse.cern.ch")
+
+        self.testWorkflow = Workflow(spec = "spec.xml", owner = "Steve",
+                                name = "wf001", task = "Test")
+        self.testWorkflow.create()
+
+        return
+
+    def tearDown(self):
+        """
+        _tearDown_
+
+        Clear out WMBS.
+        """
+        self.testInit.clearDatabase()
+        return
+
+
+
+    def createSubscription(self, nFiles, lumisPerFile, twoSites = False, nEventsPerFile = 100):
+        """
+        _createSubscription_
+
+        Create a subscription for testing
+        """
+
+        baseName = makeUUID()
+
+        testFileset = Fileset(name = baseName)
+        testFileset.create()
+        for i in range(nFiles):
+            newFile = self.createFile('%s_%i' % (baseName, i), nEventsPerFile,
+                                      i, lumisPerFile, 'somese.cern.ch')
+            newFile.create()
+            testFileset.addFile(newFile)
+        if twoSites:
+            for i in range(nFiles):
+                newFile = self.createFile('%s_%i_2' % (baseName, i), nEventsPerFile,
+                                          i, lumisPerFile, 'otherse.cern.ch')
+                newFile.create()
+                testFileset.addFile(newFile)
+        testFileset.commit()
+
+        testSubscription = Subscription(fileset = testFileset,
+                                         workflow = self.testWorkflow,
+                                         split_algo = "EventAwareLumiBased",
+                                         type = "Processing")
+        testSubscription.create()
+
+        return testSubscription
+
+    def createFile(self, lfn, events, run, lumis, location):
+        """
+        _createFile_
+
+        Create a file for testing
+        """
+        newFile = File(lfn = lfn, size = 1000,
+                       events = events)
+        lumiList = []
+        for lumi in range(lumis):
+            lumiList.append((run * lumis) + lumi)
+        newFile.addRun(Run(run, *lumiList))
+        newFile.setLocation(location)
+        return newFile
+
+    def testA_FileSplitNoHardLimit(self):
+        """
+        _testA_FileSplitNoHardLimit_
+
+        Simplest use case, there is only a self limit of events per job which
+        the algorithm must adapt to on a file by file basis. At most
+        one file per job so we don't have to pass information between files.
+        """
+        splitter = SplitterFactory()
+
+        #Create 5 files with 7 lumi per file and 100 events per lumi on average.
+        testSubscription = self.createSubscription(nFiles = 5, lumisPerFile = 7, twoSites = False,
+                                                   nEventsPerFile = 700)
+        jobFactory = splitter(package = "WMCore.WMBS",
+                              subscription = testSubscription)
+
+        #First test, the optimal settings are 360 events per job
+        #As we have files with 100 events per lumi, this will configure the splitting to
+        #3.6 lumis per job, which rounds to 3, the algorithm always approximates to the lower integer.
+        jobGroups = jobFactory(halt_job_on_file_boundaries = True,
+                               splitOnRun = True,
+                               events_per_job = 360)
+        self.assertEqual(len(jobGroups), 1, "There should be only one job group")
+        jobs = jobGroups[0].jobs
+        self.assertEqual(len(jobs), 15, "There should be 15 jobs")
+
+        testSubscription = self.createSubscription(nFiles = 5, lumisPerFile = 7, twoSites = False,
+                                                   nEventsPerFile = 700)
+        jobFactory = splitter(package = "WMCore.WMBS",
+                              subscription = testSubscription)
+        #Now set the average to 200 events per job
+        #This results in the algorithm reducing the lumis per job to 2
+        jobGroups = jobFactory(halt_job_on_file_boundaries = True,
+                               splitOnRun = True,
+                               events_per_job = 200)
+        self.assertEqual(len(jobGroups), 1, "There should be only one job group")
+        jobs = jobGroups[0].jobs
+        self.assertEqual(len(jobs), 20, "There should be 20 jobs")
+
+        #Check extremes, process a zero event files with lumis. It must be processed in one job
+        testSubscription = self.createSubscription(nFiles = 5, lumisPerFile = 100, twoSites = False,
+                                                   nEventsPerFile = 0)
+        jobFactory = splitter(package = "WMCore.WMBS",
+                              subscription = testSubscription)
+        jobGroups = jobFactory(halt_job_on_file_boundaries = True,
+                               events_per_job = 5000)
+        self.assertEqual(len(jobGroups), 1, "There should be only one job group")
+        jobs = jobGroups[0].jobs
+        self.assertEqual(len(jobs), 5, "There should be 5 jobs")
+
+        #Process files with 10k events per lumi, fallback to one lumi per job. We can't do better
+        testSubscription = self.createSubscription(nFiles = 5, lumisPerFile = 5, twoSites = False,
+                                                   nEventsPerFile = 50000)
+        jobFactory = splitter(package = "WMCore.WMBS",
+                              subscription = testSubscription)
+        jobGroups = jobFactory(halt_job_on_file_boundaries = True,
+                               splitOnRun = True,
+                               events_per_job = 5000)
+        self.assertEqual(len(jobGroups), 1, "There should be only one job group")
+        jobs = jobGroups[0].jobs
+        self.assertEqual(len(jobs), 25, "There should be 5 jobs")
+
+
+    def testB_NoFileSplitNoHardLimit(self):
+        """
+        _testB_NoFileSplitNoHardLimit_
+
+        In this case we don't split on file boundaries, check different combination of files
+        make sure we make the most of the splitting, e.g. include many zero event files in
+        a single job.
+        """
+        splitter = SplitterFactory()
+
+        #Create 100 files with 7 lumi per file and 0 events per lumi on average.
+        testSubscription = self.createSubscription(nFiles = 100, lumisPerFile = 7, twoSites = False,
+                                                   nEventsPerFile = 0)
+        jobFactory = splitter(package = "WMCore.WMBS",
+                              subscription = testSubscription)
+
+        #First test, the optimal settings are 360 events per job
+        #As we have files with 0 events per lumi, this will configure the splitting to
+        #a single job containing all files
+        jobGroups = jobFactory(halt_job_on_file_boundaries = False,
+                               splitOnRun = False,
+                               events_per_job = 360)
+        self.assertEqual(len(jobGroups), 1, "There should be only one job group")
+        jobs = jobGroups[0].jobs
+        self.assertEqual(len(jobs), 1, "There should be 1 job")
+        self.assertEqual(len(jobs[0]['input_files']), 100, "All 100 files must be in the job")
+
+        #Create 7 files, each one with different lumi/event distributions
+        testFileset = Fileset(name = "FilesetA")
+        testFileset.create()
+        testFileA = self.createFile("/this/is/file1", 250, 0, 5, "otherse.cern.ch")
+        testFileB = self.createFile("/this/is/file2", 600, 1, 1, "otherse.cern.ch")
+        testFileC = self.createFile("/this/is/file3", 1200, 2, 2, "otherse.cern.ch")
+        testFileD = self.createFile("/this/is/file4", 100, 3, 1, "otherse.cern.ch")
+        testFileE = self.createFile("/this/is/file5", 30, 4, 1, "otherse.cern.ch")
+        testFileF = self.createFile("/this/is/file6", 10, 5, 1, "otherse.cern.ch")
+        testFileG = self.createFile("/this/is/file7", 151, 6, 3, "otherse.cern.ch")
+        testFileset.addFile(testFileA)
+        testFileset.addFile(testFileB)
+        testFileset.addFile(testFileC)
+        testFileset.addFile(testFileD)
+        testFileset.addFile(testFileE)
+        testFileset.addFile(testFileF)
+        testFileset.addFile(testFileG)
+        testFileset.commit()
+
+        testSubscription = Subscription(fileset = testFileset,
+                                        workflow = self.testWorkflow,
+                                        split_algo = "EventAwareLumiBased",
+                                        type = "Processing")
+        testSubscription.create()
+
+        jobFactory = splitter(package = "WMCore.WMBS",
+                              subscription = testSubscription)
+        #Optimal settings are: jobs with 150 events per job
+        #This means, the first file must be splitted in 3 lumis per job which would leave room
+        #for another lumi in the second job, but the second file has a lumi too big for that
+        #The 3rd job only contains the second file, the fourth and fifth job split the third file
+        jobGroups = jobFactory(halt_job_on_file_boundaries = False,
+                               splitOnRun = False,
+                               events_per_job = 150)
+
+        self.assertEqual(len(jobGroups), 1, "There should be only one job group")
+        jobs = jobGroups[0].jobs
+        self.assertEqual(len(jobs), 8, "Eight jobs must be in the jobgroup")
+        self.assertEqual(jobs[0]["mask"].getRunAndLumis(), {0L : [[0L, 2L]]}, "Wrong mask for the first job")
+        self.assertEqual(jobs[1]["mask"].getRunAndLumis(), {0L : [[3L, 4L]]}, "Wrong mask for the second job")
+        self.assertEqual(jobs[2]["mask"].getRunAndLumis(), {1L : [[1L, 1L]]}, "Wrong mask for the third job")
+        self.assertEqual(jobs[3]["mask"].getRunAndLumis(), {2L : [[4L, 4L]]}, "Wrong mask for the fourth job")
+        self.assertEqual(jobs[4]["mask"].getRunAndLumis(), {2L : [[5L, 5L]]}, "Wrong mask for the fifth job")
+        self.assertEqual(jobs[5]["mask"].getRunAndLumis(),
+                         {3L : [[3L, 3L]], 4L : [[4L, 4L]], 5L : [[5L, 5L]]}, "Wrong mask for the sixth job")
+        self.assertEqual(jobs[6]["mask"].getRunAndLumis(), {6L : [[18L, 19L]]}, "Wrong mask for the seventh job")
+        self.assertEqual(jobs[7]["mask"].getRunAndLumis(), {6L : [[20L, 20L]]}, "Wrong mask for the seventh job")
+        #Test interactions of this algorithm with splitOnRun = True
+        #Make 2 files, one with 3 runs and a second one with the last run of the first
+        fileA = File(lfn = "/this/is/file1a", size = 1000,
+                       events = 2400)
+        lumiListA = []
+        lumiListB = []
+        lumiListC = []
+        for lumi in range(8):
+            lumiListA.append(1 + lumi)
+            lumiListB.append(1 + lumi)
+            lumiListC.append(1 + lumi)
+        fileA.addRun(Run(1, *lumiListA))
+        fileA.addRun(Run(2, *lumiListA))
+        fileA.addRun(Run(3, *lumiListA))
+        fileA.setLocation("somese.cern.ch")
+
+        fileB = self.createFile('/this/is/file2a', 200, 3, 5, "somese.cern.ch")
+
+        testFileset = Fileset(name = 'FilesetB')
+        testFileset.create()
+        testFileset.addFile(fileA)
+        testFileset.addFile(fileB)
+        testFileset.commit()
+        testSubscription = Subscription(fileset = testFileset,
+                                        workflow = self.testWorkflow,
+                                        split_algo = "EventAwareLumiBased",
+                                        type = "Processing")
+        testSubscription.create()
+
+        jobFactory = splitter(package = "WMCore.WMBS",
+                              subscription = testSubscription)
+        #The settings for this splitting are 700 events per job
+        jobGroups = jobFactory(splitOnRun = True,
+                               halt_job_on_file_boundaries = False,
+                               events_per_job = 700)
+        self.assertEqual(len(jobGroups), 1, "There should be only one job group")
+        jobs = jobGroups[0].jobs
+        self.assertEqual(len(jobs), 6, "Six jobs must be in the jobgroup")
+
+    def testC_HardLimitSpltting(self):
+        """
+        _testC_HardLimitSplitting_
+
+        Test that we can specify a event limit, the
+        algorithm shall take single lumi files with more events than the limit
+        and mark them for failure
+        """
+        splitter = SplitterFactory()
+
+        #Create 3 files, the one in the middle is a "bad" file
+        testFileset = Fileset(name = "FilesetA")
+        testFileset.create()
+        testFileA = self.createFile("/this/is/file1", 1000, 0, 5, "somese.cern.ch")
+        testFileB = self.createFile("/this/is/file2", 1000, 1, 1, "somese.cern.ch")
+        testFileC = self.createFile("/this/is/file3", 1000, 2, 2, "somese.cern.ch")
+        testFileset.addFile(testFileA)
+        testFileset.addFile(testFileB)
+        testFileset.addFile(testFileC)
+        testFileset.commit()
+
+        testSubscription = Subscription(fileset = testFileset,
+                                        workflow = self.testWorkflow,
+                                        split_algo = "EventAwareLumiBased",
+                                        type = "Processing")
+        testSubscription.create()
+        jobFactory = splitter(package = "WMCore.WMBS",
+                              subscription = testSubscription)
+        #Settings are to split on job boundaries, to fail sing lumis with more than 800 events
+        #and to put 550 events per job
+        jobGroups = jobFactory(halt_job_on_file_boundaries = True,
+                               splitOnRun = True,
+                               events_per_job = 550,
+                               max_events_per_lumi = 800)
+
+        self.assertEqual(len(jobGroups), 1, "There should be only one job group")
+        jobs = jobGroups[0].jobs
+        self.assertEqual(len(jobs), 6, "Six jobs must be in the jobgroup")
+        self.assertTrue(jobs[3]['failedOnCreation'], "The job processing the second file should me marked for failure")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The purpose of this algorithm is to dynamically split jobs by lumis
trying to make the jobs have a target number of events which is
ultimately the unit that determines job running time, disk space used
and memory constraints.
However this differentiates from the EventBased algorithm since
it doesn't split indiviual lumis, the basic unit for the splitting is the
lumi and every job is guaranteed to have at least one full lumi, this implies
that the number of events in a job will never be the exact target
but on average all jobs have about that number.
Also this includes the option to define a hard limit on the events
a job can process, if a file has a single lumi and more events
that such limit that job is created and marked as bad. This means
that this job will be moved from created to createdfailed by the
JobCreator.

The ErrorHandler is now configured to immediatly exhaust createfailed
jobs. The reason is that the createfailed state didn't make much sense,
the transitions defined it to go from createfailed to cooloff and then to
new. But a job that is in createfailed, had to actually be created otherwise
it wouldn't exist in WMBS. I changed the transitions to allow from created to createfailed and changed the transitions from createdcooloff/paused to new
for created instead which seems to be the logical step, since jobs in "new" state are not picked up by any piece of code.
However for now the createcooloff state is unreachable as the ErrorHandler will always take createfailed and send them to exhausted.

The algorithm takes the following inputs:
- events_per_job : This is the main parameter and defines the target events we want in each job. The algorithm will split lumis according to average events per lumi in each file
- max_events_per_lumi: Hard limit that defines jobs to fail when there are too many events in a lumi
- halt_on_file_boundaries, splitOnRun, etc..: Usual LumiBased algorithm parameters

There are two commits here:
- First is all client-side and adds the support for the algorithm
- Second is reqmgr-side which allows to set the splitting to requests

This will need extensive testing if we want to use it instead of usual LumiBased, I already ran a live workflow plus unit tests and so far so good. 
