### PR TITLE
Set SplitOnRun back to true in LumiBased

### DIFF
--- a/src/python/WMCore/JobSplitting/LumiBased.py
+++ b/src/python/WMCore/JobSplitting/LumiBased.py
@@ -82,7 +82,7 @@ class LumiBased(JobFactory):
         splitOnFile     = bool(kwargs.get('halt_job_on_file_boundaries', True))
         ignoreACDC      = bool(kwargs.get('ignore_acdc_except', False))
         collectionName  = kwargs.get('collectionName', None)
-        splitOnRun      = kwargs.get('splitOnRun', False)
+        splitOnRun      = kwargs.get('splitOnRun', True)
         getParents      = kwargs.get('include_parents', False)
         runWhitelist    = kwargs.get('runWhitelist', [])
         runs            = kwargs.get('runs', None)


### PR DESCRIPTION
I learned from Marco Rovere that the DQM step cannot process two runs
in a file (though the harvesting should on a merged file with multiple runs).
Therefore it's not a good idea to not split by default on run, reverting
that change.
