### PR TITLE
Bugfix for validation of well-formed dqmHarvest

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -717,8 +717,13 @@ class StdBase(object):
         if self.enableHarvesting:
             for task in workload.getAllTasks():
                 if task.taskType() == "Harvesting":
-                    if not self.procScenario:
-                        self.raiseValidationException(msg = "A DQM harvesting task was found, you must specify a scenario")
+                    for stepName in task.listAllStepNames():
+                        step = task.getStep(stepName)
+                        if step.stepType() != "CMSSW":
+                            continue
+                        cmsswHelper = task.getTypeHelper(stepName)
+                        if not cmsswHelper.getScenario():
+                            self.raiseValidationException(msg = "A DQM harvesting task was found, you must specify a scenario")
 
         return
 

--- a/src/python/WMCore/WMSpec/Steps/Templates/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Templates/CMSSW.py
@@ -216,7 +216,7 @@ class CMSSWStepHelper(CoreHelper):
 
     def getDatasetName(self):
         """
-        _setDatasetName_
+        _getDatasetName_
 
         Retrieve the dataset name from the pickled arguments
         """
@@ -225,6 +225,17 @@ class CMSSWStepHelper(CoreHelper):
                 return self.data.application.configuration.arguments.datasetName
 
         return pickle.loads(self.data.application.configuration.pickledarguments).get('datasetName', None)
+
+    def getScenario(self):
+        """
+        _getScenario_
+
+        Retrieve the scenario from the pickled arguments, if any
+        """
+        if hasattr(self.data.application.configuration, "scenario"):
+            return self.data.application.configuration.scenario
+
+        return None
 
     def setUserSandbox(self, userSandbox):
         """


### PR DESCRIPTION
Validation depends on having a self.procScenario in stdBase
this holds in all cases but ACDC workflows, this bug
prevents from creating ACDC workflows of requests
with DQM harvesting included through the webinterface (it is still
possible through script by passing a dummy 'scenario' parameter).

This patch changes the validation to check the steps in the harvesting task
and make sure the scenario was defined, this covers all workflows including
ACDC.
