### PR TITLE
Make maxRetries flexible between job types

### DIFF
--- a/src/python/WMCore/WMBS/MySQL/Jobs/LoadFromIDWithType.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/LoadFromIDWithType.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+"""
+_LoadFromIDWithType_
+
+MySQL implementation of LoadFromIDWithType
+
+Created on Oct 3, 2012
+
+@author: dballest
+"""
+
+from WMCore.WMBS.MySQL.Jobs.LoadFromID import LoadFromID
+
+class LoadFromIDWithType(LoadFromID):
+    """
+    _LoadFromIDWithType_
+
+    Load jobs by ID but include the type
+    of the subscription they belong to
+    """
+
+    sql = """SELECT wmbs_job.id, jobgroup, wmbs_job.name AS name,
+                    wmbs_job_state.name AS state, state_time, retry_count,
+                    couch_record,  cache_dir, wmbs_location.site_name AS location,
+                    outcome AS bool_outcome, fwjr_path AS fwjr_path,
+                    wmbs_sub_types.name AS type
+             FROM wmbs_job
+               LEFT OUTER JOIN wmbs_location ON
+                 wmbs_job.location = wmbs_location.id
+               LEFT OUTER JOIN wmbs_job_state ON
+                 wmbs_job.state = wmbs_job_state.id
+             INNER JOIN wmbs_jobgroup ON wmbs_jobgroup.id = wmbs_job.jobgroup
+             INNER JOIN wmbs_subscription ON wmbs_subscription.id = wmbs_jobgroup.subscription
+             INNER JOIN wmbs_sub_types ON wmbs_sub_types.id = wmbs_subscription.subtype
+             WHERE wmbs_job.id = :jobid"""

--- a/src/python/WMCore/WMBS/Oracle/Jobs/LoadFromIDWithType.py
+++ b/src/python/WMCore/WMBS/Oracle/Jobs/LoadFromIDWithType.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+"""
+_LoadFromIDWithType_
+
+Oracle implementation of LoadFromIDWithType
+
+Created on Oct 3, 2012
+
+@author: dballest
+"""
+
+from WMCore.WMBS.MySQL.Jobs.LoadFromIDWithType import LoadFromIDWithType as MySQLLoadFromIDWithType
+
+class LoadFromIDWithType(MySQLLoadFromIDWithType):
+    pass


### PR DESCRIPTION
In #3961 the retry manager was modified to work differently on each
type of job, however there is one parameter which affect retries but
it is in the ErrorHandler.

This should be as flexible as the RetryManager parameters
