### PR TITLE
Remove Autoincrement check for MySQL

### DIFF
--- a/src/python/WMComponent/JobCreator/JobCreatorPoller.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorPoller.py
@@ -370,36 +370,6 @@ class JobCreatorPoller(BaseWorkerThread):
 
         self.changeState = ChangeState(self.config)
 
-        # Initiate autoIncrement for MySQL
-        # This is because MySQL stores the autoIncrement in memory and it has
-        # to be resynchronized with couch after a server restart
-        if getattr(myThread, 'dialect', 'None').lower() == 'mysql':
-            incrementDAO     = self.daoFactory(classname = "Jobs.AutoIncrementCheck")
-            couchdb          = CouchServer(config.JobStateMachine.couchurl)
-            jobsdatabase     = couchdb.connectDatabase("%s/jobs" % config.JobStateMachine.couchDBName)
-            try:
-                jobID = jobsdatabase.loadView("JobDump",
-                                              "highestJobID",
-                                              options = {'reduce': False,
-                                                         'limit': 1,
-                                                         'descending': True}
-                                              )['rows'][0]['id']
-                jobID = int(jobID)
-            except IndexError:
-                # In this case, there are no jobs in couch
-                jobID = 0
-            except ValueError:
-                # This is a weird error - there's a document in the couch server
-                # without a job ID as id
-                jobID = 0
-                logging.error("Encountered a document in the JobDump database with an invalid ID!")
-                logging.error("ID: %s" % jobID)
-                pass
-
-            # Now increment the MySQL AutoIncrement
-            logging.info("About to handle MySQL AutoIncrement with jobID %i" % jobID)
-            incrementDAO.execute(input = jobID)
-
         return
 
     def check(self):

--- a/src/python/WMCore/Database/CMSCouch.py
+++ b/src/python/WMCore/Database/CMSCouch.py
@@ -184,19 +184,21 @@ class Database(CouchDBRequests):
                     doc[label] = int(time.time())
         return data
 
-    def queue(self, doc, timestamp = False, viewlist=[]):
+    def queue(self, doc, timestamp = False, viewlist=[], callback = None):
         """
         Queue up a doc for bulk insert. If timestamp = True add a timestamp
         field if one doesn't exist. Use this over commit(timestamp=True) if you
         want to timestamp when a document was added to the queue instead of when
         it was committed
+        If a callback is specified then pass it to the commit function if a
+        commit is triggered
         """
         if timestamp:
             self.timestamp(doc, timestamp)
         #TODO: Thread this off so that it's non blocking...
         if len(self._queue) >= self._queue_size:
             print 'queue larger than %s records, committing' % self._queue_size
-            self.commit(viewlist=viewlist)
+            self.commit(viewlist=viewlist, callback = callback)
         self._queue.append(doc)
 
     def queueDelete(self, doc, viewlist=[]):
@@ -225,7 +227,7 @@ class Database(CouchDBRequests):
         return retval
 
     def commit(self, doc=None, returndocs = False, timestamp = False,
-               viewlist=[], **data):
+               viewlist=[], callback = None, **data):
         """
         Add doc and/or the contents of self._queue to the database. If
         returndocs is true, return document objects representing what has been
@@ -233,6 +235,12 @@ class Database(CouchDBRequests):
         timestamp - this will be the timestamp of when the commit was called, it
         will not override an existing timestamp field.  If timestamp is a string
         that string will be used as the label for the timestamp.
+
+        The callback function will be called with the documents that trigger a
+        conflict when doing the bulk post of the documents in the queue,
+        callback functions must accept the database object, the data posted and a row in the
+        result from the bulk commit. The callback updates the retval with
+        its internal retval
 
         key, value pairs can be used to pass extra parameters to the bulk doc api
         See http://wiki.apache.org/couchdb/HTTP_Bulk_Document_API
@@ -259,6 +267,11 @@ class Database(CouchDBRequests):
         for v in viewlist:
             design, view = v.split('/')
             self.loadView(design, view, {'limit': 0})
+        if callback:
+            for idx, result in enumerate(retval):
+                if result.get('error', None) == 'conflict':
+                    retval[idx] = callback(self, data, result)
+
         return retval
 
     def document(self, id, rev = None):

--- a/src/python/WMCore/JobStateMachine/ChangeState.py
+++ b/src/python/WMCore/JobStateMachine/ChangeState.py
@@ -11,14 +11,50 @@ import traceback
 import re
 
 from WMCore.Database.CMSCouch import CouchServer
-from WMCore.Database.CMSCouch import CouchConflictError, CouchNotFoundError
+from WMCore.Database.CMSCouch import CouchNotFoundError, CouchError
 from WMCore.DataStructs.WMObject import WMObject
 from WMCore.JobStateMachine.Transitions import Transitions
-from WMCore.Services.UUID import makeUUID
 from WMCore.Services.Dashboard.DashboardReporter import DashboardReporter
 from WMCore.WMConnectionBase import WMConnectionBase
 
 CMSSTEP = re.compile(r'^cmsRun[0-9]+$')
+
+def discardConflictingDocument(couchDbInstance, data, result):
+    """
+    _discardConflictingDocument_
+
+    This should be passed to the queue and commit calls of CMSCouch
+    in order to tell it what to do with conflicting documents.
+    In this case we trash the old one and replace with what we were
+    trying to commit, this is available in the data argument.
+    And the result tells us the id of the conflicting document
+    """
+
+    conflictingId = result["id"]
+
+    try:
+        if not couchDbInstance.documentExists(conflictingId):
+            # It doesn't exist, this is odd
+            # Don't try again
+            return result
+
+        # Get the revision to override
+        originalDocRev = couchDbInstance.document(conflictingId)["_rev"]
+
+        # Look for the data to be commited
+        retval = result
+        for doc in data["docs"]:
+            if doc["_id"] == conflictingId:
+                doc["_rev"] = originalDocRev
+                retval = couchDbInstance.commitOne(doc)
+                break
+
+        return retval
+    except CouchError, ex:
+        logging.error("Couldn't resolve conflict when updating document with id %s" % result["id"])
+        logging.error("Error: %s" % str(ex))
+        return result
+
 
 class ChangeState(WMObject, WMConnectionBase):
     """
@@ -185,7 +221,7 @@ class ChangeState(WMObject, WMConnectionBase):
 
                 couchRecordsToUpdate.append({"jobid": job["id"],
                                              "couchid": jobDocument["_id"]})
-                self.jobsdatabase.queue(jobDocument)
+                self.jobsdatabase.queue(jobDocument, callback = discardConflictingDocument)
             else:
                 # We send a PUT request to the stateTransition update handler.
                 # Couch expects the parameters to be passed as arguments to in
@@ -229,7 +265,7 @@ class ChangeState(WMObject, WMConnectionBase):
                                 "retrycount": job["retry_count"],
                                 "fwjr": job["fwjr"].__to_json__(None),
                                 "type": "fwjr"}
-                self.fwjrdatabase.queue(fwjrDocument, timestamp = True)
+                self.fwjrdatabase.queue(fwjrDocument, timestamp = True, callback = discardConflictingDocument)
 
                 jobSummaryId = job["name"]
                 # building a summary of fwjr
@@ -281,8 +317,8 @@ class ChangeState(WMObject, WMConnectionBase):
                                      conn = self.getDBConn(),
                                      transaction = self.existingTransaction())
 
-        self.jobsdatabase.commit()
-        self.fwjrdatabase.commit()
+        self.jobsdatabase.commit(callback = discardConflictingDocument)
+        self.fwjrdatabase.commit(callback = discardConflictingDocument)
         self.jsumdatabase.commit()
         return
 


### PR DESCRIPTION
From the MySQL documentation:

```
InnoDB uses the following algorithm to initialize the auto-increment counter for a table t that contains an AUTO_INCREMENT column named ai_col: After a server startup, for the first insert into a table t, InnoDB executes the equivalent of this statement:

SELECT MAX(ai_col) FROM t FOR UPDATE;
InnoDB increments the value retrieved by the statement and assigns it to the column and to the auto-increment counter for the table. By default, the value is incremented by one.
...
If the table is empty, InnoDB uses the value 1.
```

In case of a server restart we have security that the auto-increment will be preserved to the max job_id present, the only case where removing this check might cause problems
is if the most recent workflow was deleted and so the index in wmbs_job is lower than before and then you restart MySQL before the TaskArchiver/CleanUpPoller cleans couch. But
even then, the old documents in couch would simply be replaced.

The benefit of this change is avoiding errors when the JobCreator is restarted after a couch crash.

Fixes #4005
