### PR TITLE
Fix alerts not sent in StatusPoller, wrong usage of getattr, and printed...

### DIFF
--- a/src/python/WMCore/BossAir/StatusPoller.py
+++ b/src/python/WMCore/BossAir/StatusPoller.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 
 """
@@ -66,14 +66,14 @@ class StatusPoller(BaseWorkerThread):
         except WMException, ex:
             if getattr(myThread.transaction, None):
                 myThread.transaction.rollbackForError()
-            self.sendAlert(6, str(ex))
+            self.sendAlert(6, msg = str(ex))
             raise
         except Exception, ex:
             msg =  "Unhandled error in statusPoller"
             msg += str(ex)
-            logging.error(msg)
-            self.sendAlert(6, msg)
-            if getattr(myThread.transaction, None):
+            logging.exception(msg)
+            self.sendAlert(6, msg = msg)
+            if getattr(myThread, 'transaction', None):
                 myThread.transaction.rollbackForError()
             raise StatusPollerException(msg)
 


### PR DESCRIPTION
... the stacktrace of generic Exception.

I know it's bad practice to print the stacktraces with logging.exception(msg), but imho is unavoidable when you catch generic exceptions (which is also bad practice :))
