### PR TITLE
Include the jobType in all jobs in ChangeState

### DIFF
--- a/src/python/WMCore/JobStateMachine/ChangeState.py
+++ b/src/python/WMCore/JobStateMachine/ChangeState.py
@@ -370,7 +370,8 @@ class ChangeState(WMObject, WMConnectionBase):
         for idx, job in enumerate(jobs):
             if job["couch_record"] == None:
                 jobIDsToCheck.append(job["id"])
-            if job.get("task", None) == None or job.get("workflow", None) == None:
+            if job.get("task", None) == None or job.get("workflow", None) == None \
+                or job.get("taskType", None) == None or job.get("jobType", None) == None:
                 jobTasksToCheck.append(job["id"])
             jobMap[job["id"]] = idx
 
@@ -390,16 +391,10 @@ class ChangeState(WMObject, WMConnectionBase):
                 jobs[idx]["task"] = jobTask["task"]
                 jobs[idx]["workflow"] = jobTask["name"]
                 jobs[idx]["taskType"] = jobTask["type"]
+                jobs[idx]["jobType"]  = jobTask["subtype"]
 
     def completeCreatedJobsInformation(self, jobs, incrementRetry = False):
-        jobIDsToCheck = []
-        jobMap = {}
-        for idx, job in enumerate(jobs):
-            #Check if the job already has a jobType defined, which is likely
-            #only if it comes from the JobCreator component
-            if "jobType" not in job:
-                jobIDsToCheck.append(job["id"])
-                jobMap[job["id"]] = idx
+        for job in jobs:
             #It there's no jobID in the mask then it's not loaded
             if "jobID" not in job["mask"]:
                 #Make sure the daofactory was not stripped
@@ -413,13 +408,3 @@ class ChangeState(WMObject, WMConnectionBase):
             #Increment retry when commanded
             if incrementRetry:
                 job["retry_count"] += 1
-
-        #Let's continue with the jobTypes, get all the types at once and add them
-        #to the jobs
-        if len(jobIDsToCheck) > 0 :
-            jobTypes = self.jobTypeDAO.execute(jobID = jobIDsToCheck,
-                                               conn = self.getDBConn(),
-                                               transaction = self.existingTransaction())
-            for jobType in jobTypes:
-                idx = jobMap[jobType["id"]]
-                jobs[idx]["jobType"] = jobType["type"]

--- a/src/python/WMCore/WMBS/MySQL/Jobs/GetWorkflowTask.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/GetWorkflowTask.py
@@ -9,13 +9,15 @@ from WMCore.Database.DBFormatter import DBFormatter
 
 class GetWorkflowTask(DBFormatter):
     sql = """SELECT wmbs_workflow.name, wmbs_workflow.task, wmbs_job.id,
-             wmbs_workflow.type FROM wmbs_workflow
+             wmbs_workflow.type, wmbs_sub_types.name AS subtype FROM wmbs_workflow
                INNER JOIN wmbs_subscription ON
                  wmbs_workflow.id = wmbs_subscription.workflow
                INNER JOIN wmbs_jobgroup ON
                  wmbs_subscription.id = wmbs_jobgroup.subscription
                INNER JOIN wmbs_job ON
                  wmbs_jobgroup.id = wmbs_job.jobgroup
+               INNER JOIN wmbs_sub_types ON
+                 wmbs_subscription.subtype = wmbs_sub_types.id
              WHERE wmbs_job.id = :jobid"""    
 
     def execute(self, jobIDs, conn = None, transaction = False):


### PR DESCRIPTION
Any job with a fwjr will require the jobType key
to allow the jobsummary to be uploaded to WMStats (If it's not there, there will be a KeyError),
instead of looking for all the places where the job can come
make it central and load it always when missing, it's part
of a frequent query so it's inexpensive.
