### PR TITLE
Modify LFN counters in extension workflows

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -515,7 +515,8 @@ class StdBase(object):
         return logCollectTask
 
     def addMergeTask(self, parentTask, parentTaskSplitting, parentOutputModuleName,
-                     parentStepName = "cmsRun1", doLogCollect = True):
+                     parentStepName = "cmsRun1", doLogCollect = True,
+                     lfn_counter = 0):
         """
         _addMergeTask_
 
@@ -563,7 +564,8 @@ class StdBase(object):
                                         max_merge_events = self.maxMergeEvents,
                                         max_wait_time = self.maxWaitTime,
                                         siteWhitelist = self.siteWhitelist,
-                                        siteBlacklist = self.siteBlacklist)
+                                        siteBlacklist = self.siteBlacklist,
+                                        initial_lfn_counter = lfn_counter)
 
         if getattr(parentOutputModule, "dataTier") == "DQMROOT":
             mergeTaskCmsswHelper.setDataProcessingConfig("do_not_use", "merge",

--- a/src/python/WMQuality/Emulators/DBSClient/DBSReader.py
+++ b/src/python/WMQuality/Emulators/DBSClient/DBSReader.py
@@ -3,14 +3,18 @@
     Mocked DBS interface for Start Policy unit tests
 """
 
-from DBSAPI.dbsApi import DbsApi
 from WMCore.Services.DBS.DBSErrors import DBSReaderError
 
 class _MockDBSApi():
     """Mock dbs api"""
     def __init__(self, args):
         # just make sure args value complies with dbs args
-        DbsApi(args)
+        try:
+            from DBSAPI.dbsApi import DbsApi
+            DbsApi(args)
+        except ImportError:
+            # No dbsApi available, carry on
+            pass
         self.args = args
 
     def getServerUrl(self):
@@ -62,6 +66,16 @@ class DBSReader:
                 block['StorageElementList'] = [{'Role' : '', 'Name' : x} for x in \
                                                self.listFileBlockLocation(block['Name'])]
         return blocks
+
+    def lfnsInBlock(self, fileBlockName):
+        """
+        _lfnsInBlock_
+        Get a fake list of LFNs for the block
+        """
+
+        files = self.listFilesInBlock(fileBlockName)
+
+        return [x['LogicalFileName'] for x in files]
 
     def listFileBlocks(self, dataset, onlyClosedBlocks = False,
                        blockName = '*'):

--- a/standards/allowed_failing_tests.txt
+++ b/standards/allowed_failing_tests.txt
@@ -54,8 +54,6 @@ WMCore_t.WMBS_t.JobSplitting_t.ParentlessMergeBySize_t.ParentlessMergeBySizeTest
 WMCore_t.WMBS_t.Job_t.JobTest.testNewestStateChangeDAO
 WMCore_t.WMRuntime_t.Scripts_t.UnpackUserTarball_t.UnpackUserTarballTest.testFileAndURLSandbox
 WMCore_t.WMRuntime_t.Scripts_t.UnpackUserTarball_t.UnpackUserTarballTest.testUrlSandbox
-WMCore_t.WMSpec_t.StdSpecs_t.LHEStepZero_t.MonteCarloTest.testRelValMCWithPileup
-WMCore_t.WMSpec_t.StdSpecs_t.MonteCarlo_t.MonteCarloTest.testRelValMCWithPileup
 WMCore_t.WMSpec_t.StdSpecs_t.PromptReco_t.PromptRecoTest.testPromptReco
 WMCore_t.WMSpec_t.StdSpecs_t.StoreResults_t.StoreResultsTest.testStoreResults
 WMCore_t.WebTools_t.REST_t.RESTTest.testPing

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/LHEStepZero_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/LHEStepZero_t.py
@@ -52,7 +52,7 @@ class LHEStepZeroTest(MonteCarloTest):
         testWorkload.setSpecUrl("somespec")
         testWorkload.setOwnerDetails("sfoulkes@fnal.gov", "DWMWM")
 
-        testWMBSHelper = WMBSHelper(testWorkload, "Production", "SomeBlock")
+        testWMBSHelper = WMBSHelper(testWorkload, "Production", "SomeBlock", cachepath = self.testInit.testDir)
         testWMBSHelper.createTopLevelFileset()
         testWMBSHelper.createSubscription(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
 


### PR DESCRIPTION
Add the initial_lfn_counter parameter to the splitting of the
production and merge tasks in MonteCarlo and LHEStepZero workflows
if the FirstEvent/Lumi is different from 1. The initial_lfn_counter
is calculated as what the last previous job count should have been
based on the current events_per_job and FirstEvent.

Fixes #4151
