### PR TITLE
Ensure canceled workflows get cleaned up.

### DIFF
--- a/src/couchapps/WorkQueue/views/wmbsInjectStatusByRequest/map.js
+++ b/src/couchapps/WorkQueue/views/wmbsInjectStatusByRequest/map.js
@@ -3,7 +3,7 @@ function(doc) {
     if (ele) {
         if (!ele.OpenForNewData &&
             (ele.Status == 'Running' || ele.Status == 'Done'
-             || ele.Status == 'Failed')) {
+             || ele.Status == 'Failed' || ele.Status == 'Canceled')) {
             emit(ele.RequestName, true);
         } else {
             emit(ele.RequestName, false);

--- a/src/python/WMComponent/JobArchiver/JobArchiverPoller.py
+++ b/src/python/WMComponent/JobArchiver/JobArchiverPoller.py
@@ -22,6 +22,8 @@ from WMComponent.TaskArchiver.TaskArchiverPoller import uploadPublishWorkflow
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 from WMCore.JobStateMachine.ChangeState    import ChangeState
 
+from WMCore.WorkQueue.WorkQueueExceptions import WorkQueueNoMatchingElements
+
 from WMCore.WMBS.Job          import Job
 from WMCore.DAOFactory        import DAOFactory
 from WMCore.WMBS.Fileset      import Fileset
@@ -342,6 +344,9 @@ class JobArchiverPoller(BaseWorkerThread):
             try:
                 if self.workQueue.getWMBSInjectionStatus(workflowName = name):
                     injected.append(name)
+            except WorkQueueNoMatchingElements:
+                # workflow not known - free to cleanup
+                injected.append(name)
             except:
                 # Do nothing if it complains
                 pass

--- a/src/python/WMCore/WorkQueue/WorkQueueBackend.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueBackend.py
@@ -10,6 +10,7 @@ import time
 import urllib
 
 from WMCore.Database.CMSCouch import CouchServer, CouchNotFoundError, Document
+from WMCore.WorkQueue.WorkQueueExceptions import WorkQueueNoMatchingElements
 from WMCore.WorkQueue.DataStructs.CouchWorkQueueElement import CouchWorkQueueElement, fixElementConflicts
 from WMCore.Wrappers import JsonWrapper as json
 from WMCore.WMSpec.WMWorkload import WMWorkloadHelper
@@ -445,6 +446,6 @@ class WorkQueueBackend(object):
             if data['rows']:
                 return data['rows'][0]['value']
             else:
-                raise ValueError("%s not exist in the queue" % request)
+                raise WorkQueueNoMatchingElements("%s not found" % request)
         else:
             return [{x['key']: x['value']} for x in data.get('rows', [])]


### PR DESCRIPTION
Fixes #4160

Fix wmbs injection query to report canceled as injected.
If workflow unknown to workqueue let job archiver clean up.
