### PR TITLE
Add per-request switch for stageout

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -89,6 +89,7 @@ class StdBase(object):
         self.dqmSequences = None
         self.procScenario = None
         self.enableHarvesting = True
+        self.enableNewStageout = False
         return
 
     def __call__(self, workloadName, arguments):
@@ -134,6 +135,7 @@ class StdBase(object):
         self.dqmSequences = arguments.get("DqmSequences", [])
         self.procScenario = arguments.get("ProcScenario", None)
         self.enableHarvesting = arguments.get("EnableHarvesting", True)
+        self.enableNewStageout = arguments.get("EnableNewStageout", False)
 
         if arguments.get("IncludeParents", False) == "True":
             self.includeParents = True
@@ -312,8 +314,11 @@ class StdBase(object):
         procTaskStageOut.setUserDN(userDN)
         procTaskStageOut.setAsyncDest(asyncDest)
         procTaskStageOut.setUserRoleAndGroup(owner_vogroup, owner_vorole)
+        procTaskStageOut.setNewStageoutOverride(self.enableNewStageout)
         procTaskLogArch = procTaskCmssw.addStep("logArch1")
         procTaskLogArch.setStepType("LogArchive")
+        procTaskLogArch.setNewStageoutOverride(self.enableNewStageout)
+        
         procTask.applyTemplates()
         procTask.setTaskPriority(self.priority)
 
@@ -506,6 +511,7 @@ class StdBase(object):
         self.addDashboardMonitoring(logCollectTask)
         logCollectStep = logCollectTask.makeStep("logCollect1")
         logCollectStep.setStepType("LogCollect")
+        logCollectStep.setNewStageoutOverride(self.enableNewStageout)
         logCollectTask.applyTemplates()
         logCollectTask.setSplittingAlgorithm("MinFileBased", files_per_job = filesPerJob)
         logCollectTask.setTaskType("LogCollect")
@@ -529,8 +535,12 @@ class StdBase(object):
 
         mergeTaskStageOut = mergeTaskCmssw.addStep("stageOut1")
         mergeTaskStageOut.setStepType("StageOut")
+        mergeTaskStageOut.setNewStageoutOverride(self.enableNewStageout)
+
         mergeTaskLogArch = mergeTaskCmssw.addStep("logArch1")
         mergeTaskLogArch.setStepType("LogArchive")
+        mergeTaskLogArch.setNewStageoutOverride(self.enableNewStageout)
+
 
         mergeTask.setTaskLogBaseLFN(self.unmergedLFNBase)
         if doLogCollect:

--- a/src/python/WMCore/WMSpec/Steps/Executors/LogArchive.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/LogArchive.py
@@ -85,7 +85,8 @@ class LogArchive(Executor):
 
         #Okay, we need a stageOut Manager
         useNewStageOutCode = False
-        if overrides.has_key('newStageOut') and overrides.get('newStageOut'):
+        if self.step.getNewStageoutOverride() or \
+            (overrides.has_key('newStageOut') and overrides.get('newStageOut')):
             useNewStageOutCode = True
         if not useNewStageOutCode:
             # old style

--- a/src/python/WMCore/WMSpec/Steps/Executors/StageOut.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/StageOut.py
@@ -78,7 +78,8 @@ class StageOut(Executor):
 
         # switch between old stageOut behavior and new, fancy stage out behavior
         useNewStageOutCode = False
-        if overrides.has_key('newStageOut') and overrides.get('newStageOut'):
+        if self.step.getNewStageoutOverride() or \
+            (overrides.has_key('newStageOut') and overrides.get('newStageOut')):
             useNewStageOutCode = True
 
 

--- a/src/python/WMCore/WMSpec/WMStep.py
+++ b/src/python/WMCore/WMSpec/WMStep.py
@@ -165,6 +165,21 @@ class WMStepHelper(TreeHelper):
 
         self.data.output.ignoredModules = moduleList
         return
+    
+    def setNewStageoutOverride(self, newValue):
+        """
+        A toggle for steps to use old or new stageout code
+        """
+        self.data.newStageout = newValue
+    
+    def getNewStageoutOverride(self):
+        """
+        A toggle for steps to use old or new stageout code
+        """
+        if hasattr(self.data, 'newStageout'):
+            return self.data.newStageout
+        else:
+            return False
 
     def getIgnoredOutputModules(self):
         """


### PR DESCRIPTION
The old switch is hardcoded per-agent. This makes it so you can set
EnableNewStageout to cause StageOut, LogArchive, LogCollect to use the
new values
