### PR TITLE
Fixing giant log files/memory leaks

### DIFF
--- a/src/python/WMCore/Storage/StageInMgr.py
+++ b/src/python/WMCore/Storage/StageInMgr.py
@@ -252,38 +252,11 @@ class StageInMgr:
         except Exception, ex:
             msg = "Failure for local stage in:\n"
             msg += str(ex)
-            try:
-                import traceback
-                msg += traceback.format_exc()
-            except AttributeError, ex:
-                msg += "Traceback unavailable\n"
             raise StageOutFailure(msg, Command = command, Protocol = protocol,
                                   LFN = lfn, InputPFN = localPfn,
                                   TargetPFN = pfn)
 
         return localPfn
-
-
-
-#    def reportStageOutFailure(self, stageOutExcep):
-#        """
-#        _reportStageOutFailure_
-#
-#        When a stage out failure occurs, report it to the input
-#        framework job report.
-#
-#        - *stageOutExcep* : Instance of on of the StageOutError derived classes
-#
-#        """
-#        errStatus = stageOutExcep.data["ErrorCode"]
-#        errType = stageOutExcep.data["ErrorType"]
-#        desc = stageOutExcep.message
-#
-#        errReport = self.inputReport.addError(errStatus, errType)
-#        errReport['Description'] = desc
-#        return
-
-
 
 
     def searchTFC(self, lfn):

--- a/src/python/WMCore/Storage/StageOutImpl.py
+++ b/src/python/WMCore/Storage/StageOutImpl.py
@@ -183,8 +183,7 @@ class StageOutImpl:
         #  //
         # // Create the command to be used.
         #//
-        command = self.createStageOutCommand(
-            sourcePFN, targetPFN, options)
+        command = self.createStageOutCommand(sourcePFN, targetPFN, options)
 
         #  //
         # // Run the command

--- a/src/python/WMCore/WMException.py
+++ b/src/python/WMCore/WMException.py
@@ -6,15 +6,12 @@ General Exception class for WM modules
 
 """
 
-
-
-
-
-
 import exceptions
 import inspect
 import logging
 import traceback
+import sys
+
 
 class WMException(exceptions.Exception):
     """
@@ -50,34 +47,44 @@ class WMException(exceptions.Exception):
         #  //
         # // Automatically determine the module name
         #//  if not set
-        if self['ModuleName'] == None:
-            frame = inspect.currentframe()
-            lastframe = inspect.getouterframes(frame)[1][0]
-            excepModule = inspect.getmodule(lastframe)
-            if excepModule != None:
-                modName = excepModule.__name__
-                self['ModuleName'] = modName
-
+        if self.data['ModuleName'] == None:
+            try:
+                frame = inspect.currentframe()
+                lastframe = inspect.getouterframes(frame)[1][0]
+                excepModule = inspect.getmodule(lastframe)
+                if excepModule != None:
+                    modName = excepModule.__name__
+                    self.data['ModuleName'] = modName
+            finally:
+                frame = None
 
         #  //
         # // Find out where the exception came from
         #//
-        stack = inspect.stack(1)[1]
-        self['FileName'] = stack[1]
-        self['LineNumber'] = stack[2]
-        self['MethodName'] = stack[3]
+        try:
+            stack = inspect.stack(1)[1]
+            self.data['FileName'] = stack[1]
+            self.data['LineNumber'] = stack[2]
+            self.data['MethodName'] = stack[3]
+        finally:
+            stack = None
 
         #  //
         # // ClassName if ClassInstance is passed
         #//
-        if self['ClassInstance'] != None:
-            self['ClassName'] = \
-              self['ClassInstance'].__class__.__name__
+        try:
+            if self.data['ClassInstance'] != None:
+                self.data['ClassName'] = \
+                      self.data['ClassInstance'].__class__.__name__
+        except:
+            pass
 
 
         # Determine the traceback at time of __init__
-        self.traceback = str(traceback.format_exc())
-
+        try:
+            self.traceback = "\n".join(traceback.format_tb(sys.exc_info()[2]))
+        except:
+            self.traceback = "WMException error: Couldn't get traceback\n"
 
     def __getitem__(self, key):
         """


### PR DESCRIPTION
WMException was printing traceback.format_exc(), which spits out all the
information for an exception. In the case of nested exceptions, this
would cause the size of the error message would grow geometrically.
Also, WMException was looking for member variables it didn't have, so it
would end up failing in **init** (classy)

kudos to @dballesteros7 for finding that one and making it reproducible
