### PR TITLE
ReqMgr unittests fixes, removing hardcoded CMSSW version in tests

### DIFF
--- a/test/python/WMCore_t/RequestManager_t/Admin_t.py
+++ b/test/python/WMCore_t/RequestManager_t/Admin_t.py
@@ -8,12 +8,14 @@ Test for code in the RequestDB/Admin section
 import os
 import unittest
 
-from WMCore.Services.Requests            import JSONRequests
-from WMQuality.WebTools.RESTBaseUnitTest import RESTBaseUnitTest
-from WMCore_t.RequestManager_t.ReqMgr_t  import RequestManagerConfig, getRequestSchema
 
+from WMCore.Services.Requests import JSONRequests
 from WMCore.RequestManager.RequestDB.Interface.Admin import SoftwareManagement
-from WMCore.HTTPFrontEnd.RequestManager              import ReqMgrWebTools
+from WMCore.HTTPFrontEnd.RequestManager import ReqMgrWebTools
+
+from WMQuality.WebTools.RESTBaseUnitTest import RESTBaseUnitTest
+from WMCore_t.RequestManager_t.ReqMgr_t  import RequestManagerConfig
+from WMCore_t.RequestManager_t import utils
 
 
 class AdminTest(RESTBaseUnitTest):
@@ -21,22 +23,21 @@ class AdminTest(RESTBaseUnitTest):
     _AdminTest_
 
     Test for the lower-level DB code in the admin section
+    
     """
-
     def setUp(self):
         """
         setUP global values
         Database setUp is done in base class
+        
         """
         self.couchDBName = "reqmgr_t_0"
         RESTBaseUnitTest.setUp(self)
         self.testInit.setupCouch("%s" % self.couchDBName,
                                  "GroupUser", "ConfigCache")
-
-        reqMgrHost      = self.config.getServerUrl()
+        reqMgrHost = self.config.getServerUrl()
         self.jsonSender = JSONRequests(reqMgrHost)
 
-        return
 
     def initialize(self):
         self.config = RequestManagerConfig(
@@ -46,26 +47,26 @@ class AdminTest(RESTBaseUnitTest):
         self.config.setupCouchDatabase(dbName = self.couchDBName)
         self.config.setPort(12888)
         self.schemaModules = ["WMCore.RequestManager.RequestDB"]
-        return
+
 
     def tearDown(self):
         """
         _tearDown_
 
         Basic tear down of database
+        
         """
-
         RESTBaseUnitTest.tearDown(self)
         self.testInit.tearDownCouch()
-        return
+    
 
     def testA_SoftwareManagement(self):
         """
         _SoftwareManagement_
 
         Test the SoftwareManagement code
+        
         """
-
         self.assertEqual(SoftwareManagement.listSoftware(), {})
         softwareVersions = ReqMgrWebTools.allScramArchsAndVersions()
         ReqMgrWebTools.updateScramArchsAndCMSSWVersions()
@@ -81,6 +82,8 @@ class AdminTest(RESTBaseUnitTest):
             SoftwareManagement.updateSoftware(softwareNames = [], scramArch = scramArch)
         self.assertEqual(SoftwareManagement.listSoftware(), {})
 
+        # import has to be here, otherwise getting:
+        # AttributeError: 'Toolbox' object has no attribute 'secmodv2' from the Admin module
         from WMCore.HTTPFrontEnd.RequestManager import Admin
         setattr(self.config, 'database', self.testInit.coreConfig.CoreDatabase)
         self.config.section_('templates')
@@ -89,7 +92,8 @@ class AdminTest(RESTBaseUnitTest):
 
         ReqMgrWebTools.updateScramArchsAndCMSSWVersions()
         self.assertTrue('slc5_amd64_gcc434' in admin.scramArchs())
-        return
+        
+        
 
 if __name__=='__main__':
     unittest.main()

--- a/test/python/WMCore_t/RequestManager_t/ReqMgrWebTools_t.py
+++ b/test/python/WMCore_t/RequestManager_t/ReqMgrWebTools_t.py
@@ -6,7 +6,8 @@ Unittest for ReqMgr utilities
 """
 
 import unittest
-from WMCore.HTTPFrontEnd.RequestManager import ReqMgrWebTools
+from WMCore.HTTPFrontEnd.RequestManager import ReqMgrWebTools 
+
 
 class ReqMgrWebToolsTest(unittest.TestCase):
     """
@@ -15,6 +16,7 @@ class ReqMgrWebToolsTest(unittest.TestCase):
     Test class for the ReqMgr utility functions
 
     This ONLY tests things that don't touch the DB
+    
     """
 
     def setUp(self):
@@ -22,17 +24,21 @@ class ReqMgrWebToolsTest(unittest.TestCase):
         _setUp_
 
         Do nothing
+        
         """
-        return
+        pass
+
 
     def tearDown(self):
         """
         _tearDown_
 
         Do nothing
+        
         """
-        return
-
+        pass
+    
+    
     def testA_ParseRunList(self):
         l0 = ''
         l1 = ' [1,  2,  3 ] '
@@ -45,18 +51,20 @@ class ReqMgrWebToolsTest(unittest.TestCase):
         self.assertEqual(ReqMgrWebTools.parseRunList(l2), [1,2,3])
         self.assertEqual(ReqMgrWebTools.parseRunList(l3), [1,2,3])
         self.assertEqual(ReqMgrWebTools.parseRunList(l4), [1,2,3])
-
+  
+  
     def testB_ParseBlockList(self):
         l3 = '  ["/test/test/test#Barack", "  /test/test/test#Sarah  ",/test/test/test#George]'
         self.assertEqual(ReqMgrWebTools.parseBlockList(l3), ['/test/test/test#Barack',
                                                              '/test/test/test#Sarah',
                                                              '/test/test/test#George'])
-        return
+
 
     def testC_RemovePassword(self):
         url = 'http://sarah:maverick@whitehouse.gov:1600/birthcertificates/trig'
         cleanedUrl = ReqMgrWebTools.removePasswordFromUrl(url)
         self.assertEqual(cleanedUrl, 'http://whitehouse.gov:1600/birthcertificates/trig')
+        
 
     def testD_AllSoftwareVersions(self):
         """
@@ -65,14 +73,13 @@ class ReqMgrWebToolsTest(unittest.TestCase):
         This test is a bit weird because it just checks to make sure you're getting versions
         with CMSSW in the name.  I don't want to do specifics because software versions
         change all the time.
+        
         """
-
         result = ReqMgrWebTools.allSoftwareVersions()
         self.assertTrue(len(result) > 0)
         for ver in result:
             self.assertTrue('CMSSW' in ver)
 
-        return
 
 
 if __name__=='__main__':

--- a/test/python/WMCore_t/RequestManager_t/ReqMgrWorkload_t.py
+++ b/test/python/WMCore_t/RequestManager_t/ReqMgrWorkload_t.py
@@ -4,6 +4,7 @@
 RequestManager Workload unittest
 
 Tests our ability to create requests of every major type
+
 """
 
 import os
@@ -12,20 +13,19 @@ import json
 import shutil
 import urllib
 import unittest
+from httplib import HTTPException
 
-from httplib                  import HTTPException
-from WMCore.Services.Requests import JSONRequests
-
-from WMQuality.WebTools.RESTBaseUnitTest import RESTBaseUnitTest
-from WMCore.WMSpec.StdSpecs.ReReco       import getTestArguments
-from WMCore.WMSpec.WMWorkload            import WMWorkloadHelper
-from WMCore.Cache.WMConfigCache          import ConfigCache, ConfigCacheException
-from WMCore.Database.CMSCouch            import CouchServer
-
-import WMCore.WMSpec.StdSpecs.ReReco as ReReco
 from nose.plugins.attrib import attr
 
-from WMCore_t.RequestManager_t.ReqMgr_t import RequestManagerConfig, getRequestSchema
+from WMCore.Services.Requests import JSONRequests
+from WMQuality.WebTools.RESTBaseUnitTest import RESTBaseUnitTest
+from WMCore.WMSpec.WMWorkload import WMWorkloadHelper
+from WMCore.Cache.WMConfigCache import ConfigCache, ConfigCacheException
+from WMCore.Database.CMSCouch import CouchServer
+
+from WMCore_t.RequestManager_t.ReqMgr_t import RequestManagerConfig
+from WMCore_t.WMSpec_t.StdSpecs_t.TaskChain_t import makeGeneratorConfig, makeProcessingConfigs
+from WMCore_t.RequestManager_t import utils
 
 
 class ReqMgrWorkloadTest(RESTBaseUnitTest):
@@ -34,6 +34,7 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
 
     Test that sets up and checks the validations of the various main WMSpec.StdSpecs
     This is mostly a simple set of tests which can be very repetitive.
+    
     """
 
     def setUp(self):
@@ -47,11 +48,9 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
                                  "GroupUser", "ConfigCache")
         self.testInit.setupCouch("%s_wmstats" % self.couchDBName,
                                  "WMStats")
-
-        reqMgrHost      = self.config.getServerUrl()
+        reqMgrHost = self.config.getServerUrl()
         self.jsonSender = JSONRequests(reqMgrHost)
 
-        return
 
     def initialize(self):
         self.config = RequestManagerConfig(
@@ -61,36 +60,34 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         self.config.setupCouchDatabase(dbName = self.couchDBName)
         self.config.setPort(12888)
         self.schemaModules = ["WMCore.RequestManager.RequestDB"]
-        return
+
 
     def tearDown(self):
         """
         _tearDown_
 
         Basic tear down of database
+        
         """
-
         RESTBaseUnitTest.tearDown(self)
         self.testInit.tearDownCouch()
-        return
+
 
     def createConfig(self, bad = False):
         """
         _createConfig_
 
         Create a config of some sort that we can load out of ConfigCache
+        
         """
-
         PSetTweak = {'process': {'outputModules_': ['ThisIsAName'],
                                  'ThisIsAName': {'dataset': {'dataTier': 'RECO',
                                                              'filterName': 'Filter'}}}}
-
         BadTweak  = {'process': {'outputModules_': ['ThisIsAName1', 'ThisIsAName2'],
                                  'ThisIsAName1': {'dataset': {'dataTier': 'RECO',
                                                              'filterName': 'Filter'}},
                                  'ThisIsAName2': {'dataset': {'dataTier': 'RECO',
                                                              'filterName': 'Filter'}}}}
-
         configCache = ConfigCache(os.environ["COUCHURL"], couchDBName = self.couchDBName)
         configCache.createUserGroup(groupname = "testGroup", username = 'testOps')
         if bad:
@@ -98,52 +95,22 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         else:
             configCache.setPSetTweaks(PSetTweak = PSetTweak)
         configCache.save()
-
         return configCache.getCouchID()
 
-    def setupSchema(self, groupName = 'PeopleLikeMe',
-                    userName = 'me', teamName = 'White Sox',
-                    CMSSWVersion = 'CMSSW_3_5_8',
-                    typename = 'ReReco', setupDB = True,
-                    scramArch = 'slc5_ia32_gcc434'):
-        """
-        _setupSchema_
-
-        Set up a test schema so that we can run a test request.
-        Standardization!
-        """
-        if setupDB:
-            self.jsonSender.put('user/%s?email=me@my.com' % userName)
-            self.jsonSender.put('group/%s' % groupName)
-            try:
-                self.jsonSender.put('group/%s/%s' % (groupName, userName))
-            except:
-                # Done this already
-                pass
-            self.jsonSender.put(urllib.quote('team/%s' % teamName))
-            self.jsonSender.put('version/%s/%s' % (CMSSWVersion, scramArch))
-
-        schema = ReReco.getTestArguments()
-        schema['RequestName'] = 'TestReReco'
-        schema['RequestType'] = typename
-        schema['CmsPath'] = "/uscmst1/prod/sw/cms"
-        schema['Requestor'] = '%s' % userName
-        schema['Group'] = '%s' % groupName
-
-        return schema
 
     def loadWorkload(self, requestName):
         """
         _loadWorkload_
 
         Load the workload from couch after we've saved it there.
+        
         """
-
         workload = WMWorkloadHelper()
         url      = '%s/%s/%s/spec' % (os.environ['COUCHURL'], self.couchDBName,
                                       requestName)
         workload.load(url)
         return workload
+    
 
     @attr('integration')
     def testA_makeReRecoWorkload(self):
@@ -151,21 +118,15 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         _makeReRecoWorkload_
 
         Check that you can make a basic ReReco workload
+        
         """
-
         userName     = 'Taizong'
         groupName    = 'Li'
         teamName     = 'Tang'
-        CMSSWVersion = 'CMSSW_3_5_8'
-
-
-        # Okay, we can make one.  Shouldn't surprise us.  Let's try
-        # and make a bad one.
-        schema       = self.setupSchema(userName = userName,
-                                        groupName = groupName,
-                                        teamName = teamName,
-                                        CMSSWVersion = CMSSWVersion,
-                                        setupDB = True)
+        schema = utils.getAndSetupSchema(self,
+                                         userName = userName,
+                                         groupName = groupName,
+                                         teamName = teamName)
         del schema['GlobalTag']
         raises = False
         try:
@@ -176,12 +137,7 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
             self.assertTrue("Missing required field GlobalTag in workload validation" in ex.result)
         self.assertTrue(raises)
 
-
-        schema       = self.setupSchema(userName = userName,
-                                        groupName = groupName,
-                                        teamName = teamName,
-                                        CMSSWVersion = CMSSWVersion,
-                                        setupDB = False)
+        schema = utils.getSchema(groupName = groupName,  userName = userName)
         schema['InputDataset'] = '/Nothing'
         raises = False
         try:
@@ -192,11 +148,7 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
             self.assertTrue("Bad value for InputDataset" in ex.result)
         self.assertTrue(raises)
 
-        schema       = self.setupSchema(userName = userName,
-                                        groupName = groupName,
-                                        teamName = teamName,
-                                        CMSSWVersion = CMSSWVersion,
-                                        setupDB = False)
+        schema = utils.getSchema(groupName = groupName,  userName = userName)
         raises = False
         del schema['ProcScenario']
         try:
@@ -207,14 +159,8 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
             self.assertTrue("No Scenario or Config in Processing Request!" in ex.result)
         self.assertTrue(raises)
 
-
-        schema       = self.setupSchema(userName = userName,
-                                        groupName = groupName,
-                                        teamName = teamName,
-                                        CMSSWVersion = CMSSWVersion,
-                                        setupDB = False)
-
         configID = self.createConfig(bad = True)
+        schema = utils.getSchema(groupName = groupName,  userName = userName)
         schema["ProcConfigCacheID"] = configID
         schema["CouchDBName"] = self.couchDBName
         schema["CouchURL"]    = os.environ.get("COUCHURL")
@@ -225,14 +171,11 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         except HTTPException, ex:
             raises = True
             self.assertEqual(ex.status, 400)
-            self.assertTrue("Error in Workload Validation: Duplicate dataTier/filterName combination" in ex.result)
+            self.assertTrue("Error in Workload Validation: "
+                            "Duplicate dataTier/filterName combination" in ex.result)
         self.assertTrue(raises)
 
-        schema       = self.setupSchema(userName = userName,
-                                        groupName = groupName,
-                                        teamName = teamName,
-                                        CMSSWVersion = CMSSWVersion,
-                                        setupDB = False)
+        schema = utils.getSchema(groupName = groupName,  userName = userName)
         try:
             result = self.jsonSender.put('request/testRequest', schema)
         except Exception,ex:
@@ -240,14 +183,12 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
 
         self.assertEqual(result[1], 200)
         requestName = result[0]['RequestName']
-
         result = self.jsonSender.get('request/%s' % requestName)
         request = result[0]
-        self.assertEqual(request['CMSSWVersion'], CMSSWVersion)
+        self.assertEqual(request['CMSSWVersion'], schema['CMSSWVersion'])
         self.assertEqual(request['Group'], groupName)
         self.assertEqual(request['Requestor'], userName)
-
-        return
+        
 
     @attr('integration')
     def testB_Analysis(self):
@@ -255,25 +196,23 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         _Analysis_
 
         Test Analysis workflows
+        
         """
-
         userName     = 'Taizong'
         groupName    = 'Li'
         teamName     = 'Tang'
-        CMSSWVersion = 'CMSSW_3_5_8'
-        schema       = self.setupSchema(userName = userName,
-                                        groupName = groupName,
-                                        teamName = teamName,
-                                        CMSSWVersion = CMSSWVersion,
-                                        typename = "Analysis")
-
+        schema = utils.getAndSetupSchema(self,
+                                         userName = userName,
+                                         groupName = groupName,
+                                         teamName = teamName)
+        schema['RequestType'] = "Analysis"
+        
         try:
             raises = False
             result = self.jsonSender.put('request/testRequest', schema)
         except HTTPException, ex:
             raises = True
             self.assertEqual(ex.status, 400)
-            pass
         self.assertTrue(raises)
 
         # Put the right things in the schema
@@ -288,7 +227,6 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         #self.assertEqual(request['CMSSWVersion'], CMSSWVersion)
         #self.assertEqual(request['Group'], groupName)
         #self.assertEqual(request['Requestor'], userName)
-        return
 
 
     @attr('integration')
@@ -297,18 +235,17 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         _DataProcessing_
 
         Test DataProcessing workflows
+        
         """
-
         userName     = 'Taizong'
         groupName    = 'Li'
         teamName     = 'Tang'
-        CMSSWVersion = 'CMSSW_3_5_8'
-        schema       = self.setupSchema(userName = userName,
-                                        groupName = groupName,
-                                        teamName = teamName,
-                                        CMSSWVersion = CMSSWVersion,
-                                        typename = "DataProcessing")
-
+        schema       = utils.getAndSetupSchema(self,
+                                               userName = userName,
+                                               groupName = groupName,
+                                               teamName = teamName)
+        schema['RequestType'] = "DataProcessing"
+        
         del schema['ProcScenario']
         try:
             raises = False
@@ -317,7 +254,6 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
             raises = True
             self.assertEqual(ex.status, 400)
             self.assertTrue("No Scenario or Config in Processing Request!" in ex.result)
-            pass
         self.assertTrue(raises)
 
         # Now we have to make ourselves a configCache
@@ -327,13 +263,13 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         schema["CouchURL"]    = os.environ.get("COUCHURL")
         result = self.jsonSender.put('request/testRequest', schema)
         requestName = result[0]['RequestName']
-
+        
         result = self.jsonSender.get('request/%s' % requestName)
         request = result[0]
-        self.assertEqual(request['CMSSWVersion'], CMSSWVersion)
+        self.assertEqual(request['CMSSWVersion'], schema['CMSSWVersion'])
         self.assertEqual(request['Group'], groupName)
         self.assertEqual(request['Requestor'], userName)
-        return
+
 
     @attr('integration')
     def testD_ReDigi(self):
@@ -341,17 +277,16 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         _ReDigi_
 
         Test ReDigi workflows
+        
         """
-
         userName     = 'Taizong'
         groupName    = 'Li'
         teamName     = 'Tang'
-        CMSSWVersion = 'CMSSW_3_5_8'
-        schema       = self.setupSchema(userName = userName,
-                                        groupName = groupName,
-                                        teamName = teamName,
-                                        CMSSWVersion = CMSSWVersion,
-                                        typename = "ReDigi")
+        schema       = utils.getAndSetupSchema(self,
+                                               userName = userName,
+                                               groupName = groupName,
+                                               teamName = teamName)
+        schema['RequestType'] = "ReDigi"
 
         try:
             raises = False
@@ -360,7 +295,6 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
             raises = True
             self.assertEqual(ex.status, 400)
             self.assertTrue("Missing required field StepOneConfigCacheID in workload validation" in ex.result)
-            pass
         self.assertTrue(raises)
 
         schema["StepOneConfigCacheID"] = "fakeID"
@@ -373,21 +307,19 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
             raises = True
             self.assertEqual(ex.status, 400)
             self.assertTrue("Failure to load ConfigCache while validating workload" in ex.result)
-            pass
         self.assertTrue(raises)
 
         configID = self.createConfig()
         schema["StepOneConfigCacheID"] = configID
         result = self.jsonSender.put('request/testRequest', schema)
         requestName = result[0]['RequestName']
-
+        
         result = self.jsonSender.get('request/%s' % requestName)
         request = result[0]
-        self.assertEqual(request['CMSSWVersion'], CMSSWVersion)
+        self.assertEqual(request['CMSSWVersion'], schema['CMSSWVersion'])
         self.assertEqual(request['Group'], groupName)
         self.assertEqual(request['Requestor'], userName)
 
-        return
 
     @attr('integration')
     def testE_StoreResults(self):
@@ -400,13 +332,12 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         userName     = 'Taizong'
         groupName    = 'Li'
         teamName     = 'Tang'
-        CMSSWVersion = 'CMSSW_3_5_8'
-        schema       = self.setupSchema(userName = userName,
-                                        groupName = groupName,
-                                        teamName = teamName,
-                                        CMSSWVersion = CMSSWVersion,
-                                        typename = "StoreResults")
-
+        schema       = utils.getAndSetupSchema(self,
+                                               userName = userName,
+                                               groupName = groupName,
+                                               teamName = teamName)
+        schema['RequestType'] = "StoreResults"
+        
         try:
             raises = False
             result = self.jsonSender.put('request/testRequest', schema)
@@ -414,7 +345,6 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
             raises = True
             self.assertEqual(ex.status, 400)
             self.assertTrue("Missing required field DbsUrl in workload validation" in ex.result)
-            pass
         self.assertTrue(raises)
 
         schema['DbsUrl']            = 'http://fake.dbs.url/dbs'
@@ -425,10 +355,10 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
 
         result = self.jsonSender.get('request/%s' % requestName)
         request = result[0]
-        self.assertEqual(request['CMSSWVersion'], CMSSWVersion)
+        self.assertEqual(request['CMSSWVersion'], schema['CMSSWVersion'])
         self.assertEqual(request['Group'], groupName)
         self.assertEqual(request['Requestor'], userName)
-        return
+        
 
     @attr('integration')
     def testF_TaskChain(self):
@@ -441,98 +371,77 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         NOTE: This test is so complicated that all I do is
         take code from TaskChain_t and make sure it still
         produces and actual request
+        
         """
-
-        from WMCore_t.WMSpec_t.StdSpecs_t.TaskChain_t import makeGeneratorConfig, makeProcessingConfigs
         couchServer = CouchServer(os.environ["COUCHURL"])
-        configDatabase = couchServer.connectDatabase(self.couchDBName)
+        configDatabase = couchServer.connectDatabase(self.couchDBName)  
         generatorDoc = makeGeneratorConfig(configDatabase)
         processorDocs = makeProcessingConfigs(configDatabase)
-
-        schema = {
-            "AcquisitionEra": "ReleaseValidation",
-            "Requestor": "sfoulkes@fnal.gov",
-            "CMSSWVersion": "CMSSW_3_5_8",
-            "ScramArch": "slc5_ia32_gcc434",
-            "ProcessingVersion": 1,
-            "GlobalTag": "GR10_P_v4::All",
-            "CouchURL": os.environ["COUCHURL"],
-            "CouchDBName": self.couchDBName,
-            "SiteWhitelist" : ["T1_CH_CERN", "T1_US_FNAL"],
-            "TaskChain" : 5,
-            "Task1" :{
-                "TaskName" : "GenSim",
-                "ConfigCacheID" : generatorDoc,
-                "SplittingAlgorithm"  : "EventBased",
-                "SplittingArguments" : {"events_per_job" : 250},
-                "RequestNumEvents" : 10000,
-                "Seeding" : "Automatic",
-                "PrimaryDataset" : "RelValTTBar",
-            },
-            "Task2" : {
-                "TaskName" : "DigiHLT",
-                "InputTask" : "GenSim",
-                "InputFromOutputModule" : "writeGENSIM",
-                "ConfigCacheID" : processorDocs['DigiHLT'],
-                "SplittingAlgorithm" : "FileBased",
-                "SplittingArguments" : {"files_per_job" : 1 },
-            },
-            "Task3" : {
-                "TaskName" : "Reco",
-                "InputTask" : "DigiHLT",
-                "InputFromOutputModule" : "writeRAWDIGI",
-                "ConfigCacheID" : processorDocs['Reco'],
-                "SplittingAlgorithm" : "FileBased",
-                "SplittingArguments" : {"files_per_job" : 1 },
-            },
-            "Task4" : {
-                "TaskName" : "ALCAReco",
-                "InputTask" : "Reco",
-                "InputFromOutputModule" : "writeALCA",
-                "ConfigCacheID" : processorDocs['ALCAReco'],
-                "SplittingAlgorithm" : "FileBased",
-                "SplittingArguments" : {"files_per_job" : 1 },
-
-            },
-            "Task5" : {
-                "TaskName" : "Skims",
-                "InputTask" : "Reco",
-                "InputFromOutputModule" : "writeRECO",
-                "ConfigCacheID" : processorDocs['Skims'],
-                "SplittingAlgorithm" : "FileBased",
-                "SplittingArguments" : {"files_per_job" : 10 },
-            }
-
-        }
-
+        
         userName     = 'Taizong'
         groupName    = 'Li'
         teamName     = 'Tang'
-        CMSSWVersion = 'CMSSW_3_5_8'
-        args         = self.setupSchema(userName = userName,
-                                        groupName = groupName,
-                                        teamName = teamName,
-                                        CMSSWVersion = CMSSWVersion,
-                                        typename = "TaskChain")
-
+        schema = utils.getSchema(userName = userName)
+        schema["CouchURL"] = os.environ["COUCHURL"]
+        schema["CouchDBName"] = self.couchDBName
+        schema["SiteWhitelist"] = ["T1_CH_CERN", "T1_US_FNAL"]
+        schema["TaskChain"] = 5
+        chains = {"Task1" : {"TaskName" : "GenSim",
+                             "ConfigCacheID" : generatorDoc,
+                              "SplittingAlgorithm"  : "EventBased",
+                              "SplittingArguments" : {"events_per_job" : 250},
+                              "RequestNumEvents" : 10000,
+                              "Seeding" : "Automatic",
+                              "PrimaryDataset" : "RelValTTBar"},
+                  "Task2" : {"TaskName" : "DigiHLT",
+                             "InputTask" : "GenSim",
+                             "InputFromOutputModule" : "writeGENSIM",
+                             "ConfigCacheID" : processorDocs['DigiHLT'],
+                             "SplittingAlgorithm" : "FileBased",
+                             "SplittingArguments" : {"files_per_job" : 1 } },
+                  "Task3" : {"TaskName" : "Reco",
+                             "InputTask" : "DigiHLT",
+                             "InputFromOutputModule" : "writeRAWDIGI",
+                             "ConfigCacheID" : processorDocs['Reco'],
+                             "SplittingAlgorithm" : "FileBased",
+                             "SplittingArguments" : {"files_per_job" : 1 } },
+                  "Task4" : {"TaskName" : "ALCAReco",
+                             "InputTask" : "Reco",
+                             "InputFromOutputModule" : "writeALCA",
+                             "ConfigCacheID" : processorDocs['ALCAReco'],
+                             "SplittingAlgorithm" : "FileBased",
+                             "SplittingArguments" : {"files_per_job" : 1 } },
+                  "Task5" : {"TaskName" : "Skims",
+                             "InputTask" : "Reco",
+                             "InputFromOutputModule" : "writeRECO",
+                             "ConfigCacheID" : processorDocs['Skims'],
+                             "SplittingAlgorithm" : "FileBased",
+                             "SplittingArguments" : {"files_per_job" : 10 } } }
+        schema.update(chains)
+        args = utils.getAndSetupSchema(self,
+                                       userName = userName,
+                                       groupName = groupName,
+                                       teamName = teamName)
         schema.update(args)
+        
+        # this is necessary and after all updates to the schema are made,
+        # otherwise this item will get overwritten
+        schema['RequestType'] = "TaskChain"
         schema["CouchDBName"] = self.couchDBName
         schema["CouchURL"]    = os.environ.get("COUCHURL")
-
+        
         result = self.jsonSender.put('request/testRequest', schema)
+        
         requestName = result[0]['RequestName']
-
         result = self.jsonSender.get('request/%s' % requestName)
         request = result[0]
-        self.assertEqual(request['CMSSWVersion'], CMSSWVersion)
+        self.assertEqual(request['CMSSWVersion'], schema['CMSSWVersion'])
         self.assertEqual(request['Group'], groupName)
         self.assertEqual(request['Requestor'], userName)
 
         workload = self.loadWorkload(requestName)
         self.assertEqual(workload.data.request.schema.Task1.SplittingArguments,
                          {'events_per_job': 250})
-
-        return
 
 
     @attr('integration')
@@ -541,18 +450,17 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         _MonteCarloFromGEN_
 
         Test MonteCarloFromGEN workflows
+        
         """
-
         userName     = 'Taizong'
         groupName    = 'Li'
         teamName     = 'Tang'
-        CMSSWVersion = 'CMSSW_3_5_8'
-        schema       = self.setupSchema(userName = userName,
-                                        groupName = groupName,
-                                        teamName = teamName,
-                                        CMSSWVersion = CMSSWVersion,
-                                        typename = "MonteCarloFromGEN")
-
+        schema       = utils.getAndSetupSchema(self,
+                                               userName = userName,
+                                               groupName = groupName,
+                                               teamName = teamName)
+        schema['RequestType'] = "MonteCarloFromGEN"
+        
         try:
             raises = False
             result = self.jsonSender.put('request/testRequest', schema)
@@ -560,7 +468,6 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
             raises = True
             self.assertEqual(ex.status, 400)
             self.assertTrue("Missing required field ProcConfigCacheID in workload validation" in ex.result)
-            pass
         self.assertTrue(raises)
 
         schema["ProcConfigCacheID"] = "fakeID"
@@ -573,38 +480,36 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
             raises = True
             self.assertEqual(ex.status, 400)
             self.assertTrue("Failure to load ConfigCache while validating workload" in ex.result)
-            pass
         self.assertTrue(raises)
 
         configID = self.createConfig()
         schema["ProcConfigCacheID"] = configID
         result = self.jsonSender.put('request/testRequest', schema)
         requestName = result[0]['RequestName']
-
+        
         result = self.jsonSender.get('request/%s' % requestName)
         request = result[0]
-        self.assertEqual(request['CMSSWVersion'], CMSSWVersion)
+        self.assertEqual(request['CMSSWVersion'], schema['CMSSWVersion'])
         self.assertEqual(request['Group'], groupName)
         self.assertEqual(request['Requestor'], userName)
 
-        return
 
     def testH_MonteCarlo(self):
         """
         _MonteCarlo_
 
         Test MonteCarlo workflows
+        
         """
 
         userName     = 'Taizong'
         groupName    = 'Li'
         teamName     = 'Tang'
-        CMSSWVersion = 'CMSSW_3_5_8'
-        schema       = self.setupSchema(userName = userName,
-                                        groupName = groupName,
-                                        teamName = teamName,
-                                        CMSSWVersion = CMSSWVersion,
-                                        typename = "MonteCarlo")
+        schema       = utils.getAndSetupSchema(self,
+                                               userName = userName,
+                                               groupName = groupName,
+                                               teamName = teamName)
+        schema['RequestType'] = "MonteCarlo"
 
         # Set some versions
         schema['ProcessingVersion'] = '2012'
@@ -619,7 +524,6 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
             raises = True
             self.assertEqual(ex.status, 400)
             self.assertTrue("Missing required field ProcConfigCacheID in workload validation" in ex.result)
-            pass
         self.assertTrue(raises)
 
         schema["ProcConfigCacheID"] = "fakeID"
@@ -634,7 +538,6 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
             raises = True
             self.assertEqual(ex.status, 400)
             self.assertTrue("Failure to load ConfigCache while validating workload" in ex.result)
-            pass
         self.assertTrue(raises)
 
         configID = self.createConfig()
@@ -648,20 +551,17 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
             raises = True
             self.assertEqual(ex.status, 400)
             self.assertTrue("Negative filter efficiency for MC workflow" in ex.result)
-            pass
         self.assertTrue(raises)
 
         schema["FilterEfficiency"] = 1.0
         result = self.jsonSender.put('request/testRequest', schema)
         requestName = result[0]['RequestName']
-
+        
         result = self.jsonSender.get('request/%s' % requestName)
         request = result[0]
-        self.assertEqual(request['CMSSWVersion'], CMSSWVersion)
+        self.assertEqual(request['CMSSWVersion'], schema['CMSSWVersion'])
         self.assertEqual(request['Group'], groupName)
         self.assertEqual(request['Requestor'], userName)
-
-        return
 
 
     def testI_RelValMC(self):
@@ -669,18 +569,16 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         _RelValMC_
 
         Test RelValMC workflows
+        
         """
-
         userName     = 'Taizong'
         groupName    = 'Li'
         teamName     = 'Tang'
-        CMSSWVersion = 'CMSSW_3_5_8'
-        schema       = self.setupSchema(userName = userName,
-                                        groupName = groupName,
-                                        teamName = teamName,
-                                        CMSSWVersion = CMSSWVersion,
-                                        typename = "RelValMC")
-
+        schema       = utils.getAndSetupSchema(self,
+                                               userName = userName,
+                                               groupName = groupName,
+                                               teamName = teamName)
+        schema['RequestType'] = "RelValMC"
         try:
             raises = False
             result = self.jsonSender.put('request/testRequest', schema)
@@ -688,7 +586,6 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
             raises = True
             self.assertEqual(ex.status, 400)
             self.assertTrue("Missing required field PrimaryDataset in workload validation" in ex.result)
-            pass
         self.assertTrue(raises)
 
         schema["GenConfigCacheID"]        = "fakeID"
@@ -708,7 +605,6 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
             raises = True
             self.assertEqual(ex.status, 400)
             self.assertTrue("Failure to load ConfigCache while validating workload" in ex.result)
-            pass
 
         configID = self.createConfig()
         schema["GenConfigCacheID"]     = configID
@@ -719,41 +615,34 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
 
         result = self.jsonSender.get('request/%s' % requestName)
         request = result[0]
-        self.assertEqual(request['CMSSWVersion'], CMSSWVersion)
+        self.assertEqual(request['CMSSWVersion'], schema['CMSSWVersion'])
         self.assertEqual(request['Group'], groupName)
         self.assertEqual(request['Requestor'], userName)
 
-
-        return
 
     def testJ_Resubmission(self):
         """
         _Resubmission_
 
         Test Resubmission
-        Use an utterly bogus CMSSWVersion since it shouldn't check that anyway
+        
         """
-
         userName     = 'Taizong'
         groupName    = 'Li'
         teamName     = 'Tang'
-        CMSSWVersion = 'CMSSW_3_5_8'
-        schema       = self.setupSchema(userName = userName,
-                                        groupName = groupName,
-                                        teamName = teamName,
-                                        CMSSWVersion = CMSSWVersion,
-                                        typename = "DataProcessing")
+        schema       = utils.getAndSetupSchema(self,
+                                               userName = userName,
+                                               groupName = groupName,
+                                               teamName = teamName)
+        schema['RequestType'] = "DataProcessing"
         schema['ProdScenario'] = 'pp'
         result = self.jsonSender.put('request/testRequest', schema)
         requestName = result[0]['RequestName']
 
-        schema       = self.setupSchema(userName = userName,
-                                        groupName = groupName,
-                                        teamName = teamName,
-                                        CMSSWVersion = 'CMSSW_1_0_0',
-                                        typename = "Resubmission")
-
-
+        # user, group schema already set up
+        schema = utils.getSchema(groupName = groupName, userName = userName)
+        schema['RequestType'] = "Resubmission"
+        
         try:
             raises = False
             result = self.jsonSender.put('request/testRequest', schema)
@@ -761,7 +650,6 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
             raises = True
             self.assertEqual(ex.status, 400)
             self.assertTrue("Missing required field OriginalRequestName" in ex.result)
-            pass
         self.assertTrue(raises)
 
         schema["OriginalRequestName"] = requestName
@@ -774,26 +662,23 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         resubmitName = result[0]['RequestName']
         result = self.jsonSender.get('request/%s' % resubmitName)
         request = result[0]
-
-        return
+        
 
     def testK_LHEStepZero(self):
         """
         _LHEStepZero_
 
         Test LHEStepZero workflows
+        
         """
-
         userName     = 'Taizong'
         groupName    = 'Li'
         teamName     = 'Tang'
-        CMSSWVersion = 'CMSSW_3_5_8'
-        schema       = self.setupSchema(userName = userName,
-                                        groupName = groupName,
-                                        teamName = teamName,
-                                        CMSSWVersion = CMSSWVersion,
-                                        typename = "LHEStepZero")
-
+        schema       = utils.getAndSetupSchema(self,
+                                               userName = userName,
+                                               groupName = groupName,
+                                               teamName = teamName)
+        schema['RequestType'] = "LHEStepZero"
         # Set some versions
         schema['ProcessingVersion'] = '2012'
         schema['AcquisitionEra']    = 'ae2012'
@@ -807,7 +692,6 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
             raises = True
             self.assertEqual(ex.status, 400)
             self.assertTrue("Missing required field ProcConfigCacheID in workload validation" in ex.result)
-            pass
         self.assertTrue(raises)
 
         schema["ProcConfigCacheID"] = "fakeID"
@@ -822,7 +706,6 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
             raises = True
             self.assertEqual(ex.status, 400)
             self.assertTrue("Failure to load ConfigCache while validating workload" in ex.result)
-            pass
         self.assertTrue(raises)
 
         configID = self.createConfig()
@@ -836,7 +719,6 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
             raises = True
             self.assertEqual(ex.status, 400)
             self.assertTrue("Negative filter efficiency for MC workflow" in ex.result)
-            pass
         self.assertTrue(raises)
 
         schema["FilterEfficiency"] = 1.0
@@ -848,7 +730,6 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
             raises = True
             self.assertEqual(ex.status, 400)
             self.assertTrue("No events per lumi information was entered" in ex.result)
-            pass
         self.assertTrue(raises)
 
         schema["EventsPerLumi"] = "-10"
@@ -860,7 +741,6 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
             raises = True
             self.assertEqual(ex.status, 400)
             self.assertTrue("The events per lumi input from the user is invalid, only positive numbers allowed" in ex.result)
-            pass
         self.assertTrue(raises)
 
         schema["EventsPerLumi"] = "101"
@@ -872,7 +752,6 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
             raises = True
             self.assertEqual(ex.status, 400)
             self.assertTrue("More events per lumi than total events requested" in ex.result)
-            pass
         self.assertTrue(raises)
 
         schema["EventsPerLumi"] = "20"
@@ -881,11 +760,10 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
 
         result = self.jsonSender.get('request/%s' % requestName)
         request = result[0]
-        self.assertEqual(request['CMSSWVersion'], CMSSWVersion)
+        self.assertEqual(request['CMSSWVersion'], schema['CMSSWVersion'])
         self.assertEqual(request['Group'], groupName)
         self.assertEqual(request['Requestor'], userName)
 
-        return
 
 
 if __name__=='__main__':

--- a/test/python/WMCore_t/RequestManager_t/utils.py
+++ b/test/python/WMCore_t/RequestManager_t/utils.py
@@ -1,47 +1,40 @@
 """
 Common module for helper methods, Classes for RequestManager related unittests.
 
-"""
+""" 
 
 import os
+import urllib
 
+import WMCore.WMSpec.StdSpecs.ReReco as ReReco
 
-
-def getFakeRequest(requestType):
+    
+def getAndSetupSchema(testInstance, groupName = 'PeopleLikeMe',
+                      userName = 'me', teamName = 'White Sox'):
     """
-    Return testing request dictionary.
-    Leave now for reference, but it doens't seem to be used from anywhere ...
-
+    Set up a test schema so that we can run a test request.
+    The function is shared among RequestManager unittests.
+    testInstance is a caller - instances of the current unittest class.
+    
     """
-    requestName = 'Test' + requestType
-    couchUrl = os.environ.get("COUCHURL", None)
-    return {
-        'ProdConfigCacheID' : 'f821abc0fd7ee5c5a7c34f3b96c995dc',
-         # MC
-        'ProdConfigCacheID' : 'f700c7fff9bac224f2d89ef9e419d363' ,
-        'CouchURL' : couchUrl,
-        'CouchUrl' : couchUrl,
-        'CouchDBName' : "wmagent_config_cache",
-        'RequestName' : requestName,
-        'RequestType' : requestType,
-        "Requestor" : "me",
-        "Group" : "PeopleLikeMe",
-        "RequestSizeEvents" : 100,
-        "InputDatasets" : '/PRIM/PROC/TIER',
-        "InputDataset" : '/PRIM/PROC/TIER',
-        "PrimaryDataset" : '/PRIM/PROC/TIER',
-        "PileupDatasets" : [],
-        "CMSSWVersion" : 'CMSSW_3_5_8',
-        "ProcessingVersion" : 'CMSSW_3_5_8',
-        'FinalDestination' : 'somewhere',
-        'GlobalTag' : 'V1::All',
-        'LFNCategory' : '/store/data',
-        'AcquisitionEra' : 'Now',
-        'OutputTiers' : ['RECO', 'AOD'],
-        'DBSURL' : 'www.theonion.com',
-        'ScramArch' : 'slc5_ia32_gcc434',
-        "SkimInput" : "output",
-        "SkimConfig1"  : '36f2fd377a5ac1c4149f5dd535271a10',
-        "CmsPath" : "/uscmst1/prod/sw/cms",
-        "Emulator" : False
-    }
+    schema = getSchema(groupName = groupName, userName = userName)
+    testInstance.jsonSender.put('user/%s?email=me@my.com' % userName)
+    testInstance.jsonSender.put('group/%s' % groupName)
+    testInstance.jsonSender.put('group/%s/%s' % (groupName, userName))
+    testInstance.jsonSender.put(urllib.quote('team/%s' % teamName))
+    testInstance.jsonSender.put('version/%s/%s' % (schema["CMSSWVersion"], schema["ScramArch"]))
+    return schema
+
+
+def getSchema(groupName = 'PeopleLikeMe', userName = 'me'):
+    schema = ReReco.getTestArguments()
+    schema['RequestName'] = 'TestReReco'
+    schema['RequestType'] = 'ReReco'
+    schema['CmsPath'] = "/uscmst1/prod/sw/cms"
+    schema['Requestor'] = '%s' % userName
+    schema['Group'] = '%s' % groupName
+    schema['CustodialSite'] = 'US_T1_FNAL'
+    schema['TimePerEvent'] = '12'
+    schema['Memory'] = 3000
+    schema['SizePerEvent'] = 512
+    return schema

--- a/test/python/WMCore_t/Services_t/RequestManager_t/RequestManager_t.py
+++ b/test/python/WMCore_t/Services_t/RequestManager_t/RequestManager_t.py
@@ -3,44 +3,43 @@ import unittest
 import tempfile
 import shutil
 import logging
-
 from nose.plugins.attrib import attr
 
 from WMCore.Services.Requests import JSONRequests
-from WMCore.Services.RequestManager.RequestManager import RequestManager \
-     as RequestManagerDS
+from WMCore.Services.RequestManager.RequestManager import RequestManager as RequestManagerDS
 
 from WMQuality.WebTools.RESTBaseUnitTest import RESTBaseUnitTest
 from WMQuality.WebTools.RESTServerSetup import DefaultConfig
-import WMCore.WMSpec.StdSpecs.ReReco as ReReco
 
 from WMCore_t.RequestManager_t.ReqMgr_t import RequestManagerConfig
+from WMCore_t.RequestManager_t import utils
 
 
-
+    
 class RequestManagerTest(RESTBaseUnitTest):
     """
     Test RequestMgr Service client
     It will start RequestMgr RESTService
-    Server DB is whatever env is set
-
+    Server DB is whatever env is set     
+    
     This checks whether DS call makes without error and return the results.
     This test only test service call returns without error.
     The correctness of each function is tested in test/python/RequestManager_t/RequestMgr_t.py
+    
     """
-
     def initialize(self):
         self.couchDBName = "reqmgr_t_0"
         self.config = RequestManagerConfig(
                 'WMCore.HTTPFrontEnd.RequestManager.ReqMgrRESTModel')
         dbUrl = os.environ.get("DATABASE", None)
-        self.config.setDBUrl(dbUrl)
+        self.config.setDBUrl(dbUrl)        
         self.config.setFormatter('WMCore.WebTools.RESTFormatter')
         self.config.setupRequestConfig()
         self.config.setupCouchDatabase(dbName = self.couchDBName)
         self.config.setPort(8888)
         self.schemaModules = ["WMCore.RequestManager.RequestDB"]
-
+                
+        
     def setUp(self):
         RESTBaseUnitTest.setUp(self)
         self.testInit.setupCouch("%s" % self.couchDBName, "GroupUser", "ConfigCache")
@@ -52,27 +51,21 @@ class RequestManagerTest(RESTBaseUnitTest):
         self.params['endpoint'] = self.config.getServerUrl()
         self.reqService = RequestManagerDS(self.params)
         self.jsonSender = JSONRequests(self.config.getServerUrl())
-        self.jsonSender.put('user/me?email=me@my.com')
-        self.jsonSender.put('group/PeopleLikeMe')
-        self.jsonSender.put('group/PeopleLikeMe/me')
-        self.jsonSender.put('version/CMSSW_3_5_8/slc5_ia32_gcc434')
 
-        schema = ReReco.getTestArguments()
-        schema['RequestName'] = 'TestReReco'
-        schema['RequestType'] = 'ReReco'
-        schema['CmsPath'] = "/uscmst1/prod/sw/cms"
-        schema['Requestor'] = '%s' % "me"
-        schema['Group'] = '%s' % "PeopleLikeMe"
-        schema['BlockWhitelist'] = ['/dataset/dataset/dataset#alpha']
-        schema['BlockBlacklist'] = ['/dataset/dataset/dataset#beta']
-        schema['Campaign'] = 'MyTestCampaign'
+        userName     = 'Taizong'
+        groupName    = 'Li'
+        teamName     = 'Tang'
+        schema = utils.getAndSetupSchema(self,
+                                         userName = userName,
+                                         groupName = groupName,
+                                         teamName = teamName)                
         try:
-            r = self.jsonSender.put('request/' + schema['RequestName'], schema)
+            r = self.jsonSender.put('request/' + schema['RequestName'], schema)                             
         except Exception, ex:
             print "Exception during set up, reason: %s" % ex
             return
         self.requestName = r[0]['RequestName'] 
-    
+        
     
     def tearDown(self):
         self.config.deleteWorkloadCache()
@@ -83,35 +76,35 @@ class RequestManagerTest(RESTBaseUnitTest):
     @attr("integration")
     def testA_RequestManagerService(self):
         requestName = self.requestName
-
+        
         request = self.reqService.getRequest(requestName)
         # minimal test : it's return type  and the some value inside
         self.assertEqual(type(request), dict)
         self.assertTrue(len(request) > 0)
-
+        
         # Test putTeam
         self.reqService.putTeam("team_usa")
         self.assertTrue('team_usa' in self.jsonSender.get('team')[0])
-
+        
         self.jsonSender.put('assignment/%s/%s' % ("team_usa", requestName))
-
+        
         request = self.reqService.getAssignment(teamName = "team_usa")
         self.assertEqual(type(request), list)
         self.assertTrue(len(request) > 0)
-
+       
         request = self.reqService.getAssignment(request = requestName)
         self.assertEqual(type(request), list)
         self.assertTrue(len(request) > 0)
-
+        
         self.reqService.sendMessage(requestName,"error")
         self.reqService.putWorkQueue(requestName, "http://test_url")
         self.reqService.reportRequestProgress(requestName)
         self.reqService.reportRequestProgress(requestName,
                         percent_complete = 100, percent_success = 90)
-
+        
         self.reqService.reportRequestStatus(requestName, "running")
 
-
-
+        
+        
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- fixing ReqMgr unittests failing due to changed default version of CMSSW in the ReReco module
- removing all hardcoded CMSSW version strings from the ReqMgr unittests
- general clean up
- first step towards having workflow arguments defined at as many places as possible
