### PR TITLE
implement alternative fileset closing policy

### DIFF
--- a/src/python/WMCore/WMBS/CreateWMBSBase.py
+++ b/src/python/WMCore/WMBS/CreateWMBSBase.py
@@ -153,6 +153,7 @@ class CreateWMBSBase(DBCreator):
              task         VARCHAR(550) NOT NULL,
              type         VARCHAR(255),
              owner        INTEGER      NOT NULL,
+             alt_fs_close INT(1)       NOT NULL,
              injected     INT(1)       DEFAULT 0,
              UNIQUE(name, task),
              FOREIGN KEY(owner)    REFERENCES wmbs_users(id)

--- a/src/python/WMCore/WMBS/MySQL/Fileset/ListClosable.py
+++ b/src/python/WMCore/WMBS/MySQL/Fileset/ListClosable.py
@@ -19,7 +19,7 @@ class ListClosable(DBFormatter):
                     wmbs_workflow_output.workflow_id = wmbs_parent_subscription.workflow
                   INNER JOIN wmbs_workflow ON
                     wmbs_parent_subscription.workflow = wmbs_workflow.id AND
-                    wmbs_workflow.injected = 1
+                    ( wmbs_workflow.injected = 1 OR wmbs_workflow.alt_fs_close = 1 )
                   LEFT OUTER JOIN (SELECT subscription, COUNT(DISTINCT fileid) AS total_files
                               FROM wmbs_sub_files_acquired GROUP BY subscription) files_acquired ON
                     wmbs_parent_subscription.id = files_acquired.subscription

--- a/src/python/WMCore/WMBS/MySQL/Workflow/New.py
+++ b/src/python/WMCore/WMBS/MySQL/Workflow/New.py
@@ -11,12 +11,12 @@ class New(DBFormatter):
     """
     Create a workflow ready for subscriptions
     """
-    sql = """insert into wmbs_workflow (spec, owner, name, task, type)
-                values (:spec, :owner, :name, :task, :type)"""
+    sql = """insert into wmbs_workflow (spec, owner, name, task, type, alt_fs_close)
+                values (:spec, :owner, :name, :task, :type, :alt_fs_close)"""
 
     def execute(self, spec = None, owner = None, name = None, task = None,
-                wfType = None, conn = None, transaction = False):
+                wfType = None, alt_fs_close = False, conn = None, transaction = False):
         binds = {"spec": spec, "owner": owner, "name": name, "task": task,
-                 "type": wfType}
+                 "type": wfType, "alt_fs_close": int(alt_fs_close)}
         self.dbi.processData(self.sql, binds, conn = conn, transaction = transaction)
         return

--- a/src/python/WMCore/WMBS/Oracle/Create.py
+++ b/src/python/WMCore/WMBS/Oracle/Create.py
@@ -233,6 +233,7 @@ class Create(CreateWMBSBase):
                task  VARCHAR(500) NOT NULL,
                type  VARCHAR(255),
                owner INTEGER      NOT NULL,
+               alt_fs_close INTEGER NOT NULL,
                injected INTEGER   DEFAULT 0
                ) %s""" % tablespaceTable
 

--- a/src/python/WMCore/WMBS/Oracle/Workflow/New.py
+++ b/src/python/WMCore/WMBS/Oracle/Workflow/New.py
@@ -8,5 +8,5 @@ Oracle implementation of NewWorkflow
 from WMCore.WMBS.MySQL.Workflow.New import New as NewWorkflowMySQL
 
 class New(NewWorkflowMySQL):
-    sql = """insert into wmbs_workflow (id, spec, owner, name, task, type)
-             values (wmbs_workflow_SEQ.nextval, :spec, :owner, :name, :task, :type)"""
+    sql = """insert into wmbs_workflow (id, spec, owner, name, task, type, alt_fs_close)
+             values (wmbs_workflow_SEQ.nextval, :spec, :owner, :name, :task, :type, :alt_fs_close)"""

--- a/src/python/WMCore/WMBS/Workflow.py
+++ b/src/python/WMCore/WMBS/Workflow.py
@@ -36,7 +36,7 @@ class Workflow(WMBSBase, WMWorkflow):
     def __init__(self, spec = None, owner = "unknown", dn = "unknown",
                  group = "unknown", owner_vogroup = "DEFAULT",
                  owner_vorole = "DEFAULT", name = None, task = None,
-                 wfType = None, id = -1):
+                 wfType = None, id = -1, alternativeFilesetClose = False):
         WMBSBase.__init__(self)
         WMWorkflow.__init__(self, spec = spec, owner = owner, dn = dn,
                             group = group, owner_vogroup = owner_vogroup,
@@ -47,6 +47,7 @@ class Workflow(WMBSBase, WMWorkflow):
             self.dn = owner
 
         self.id = id
+        self.alternativeFilesetClose = alternativeFilesetClose
         return
 
     def exists(self):
@@ -116,6 +117,7 @@ class Workflow(WMBSBase, WMWorkflow):
         action = self.daofactory(classname = "Workflow.New")
         action.execute(spec = self.spec, owner = userid, name = self.name,
                        task = self.task, wfType = self.wfType,
+                       alt_fs_close = self.alternativeFilesetClose,
                        conn = self.getDBConn(),
                        transaction = self.existingTransaction())
 

--- a/src/python/WMCore/WorkQueue/WMBSHelper.py
+++ b/src/python/WMCore/WorkQueue/WMBSHelper.py
@@ -257,7 +257,7 @@ class WMBSHelper(WMConnectionBase):
 
         return outputFilesetName
 
-    def createSubscription(self, task, fileset):
+    def createSubscription(self, task, fileset, alternativeFilesetClose = False):
         """
         _createSubscription_
 
@@ -274,7 +274,8 @@ class WMBSHelper(WMConnectionBase):
                             owner_vogroup = self.wmSpec.getOwner().get("vogroup", "DEFAULT"),
                             owner_vorole = self.wmSpec.getOwner().get("vorole", "DEFAULT"),
                             name = self.wmSpec.name(), task = task.getPathName(),
-                            wfType = self.wmSpec.getDashboardActivity())
+                            wfType = self.wmSpec.getDashboardActivity(),
+                            alternativeFilesetClose = alternativeFilesetClose)
         workflow.create()
         subscription = Subscription(fileset = fileset, workflow = workflow,
                                     split_algo = task.jobSplittingAlgorithm(),
@@ -316,7 +317,7 @@ class WMBSHelper(WMConnectionBase):
                             if primaryDataset != None:
                                 self.mergeOutputMapping[mergedOutputFileset.id] = primaryDataset
 
-                        self.createSubscription(childTask, outputFileset)
+                        self.createSubscription(childTask, outputFileset, alternativeFilesetClose)
 
                 if mergedOutputFileset == None:
                     workflow.addOutput(outputModuleName, outputFileset,


### PR DESCRIPTION
Normally the JobArchiver will only start closing filesets if
the corresponding workflow has been marked as injected. Implement
an alternative policy where fileset closing ignores the injection
status of the workflow and only depends on whether the top level
fileset is closed or not. This is for workflows where the
chain of subscriptions only goes down, that is, we do not have
multiple different top level filesets and subscriptions feeding
into the same lower level fileset/subscription.
