### PR TITLE
Improve error handling in Dashboard runtime

### DIFF
--- a/src/python/WMCore/WMRuntime/DashboardInterface.py
+++ b/src/python/WMCore/WMRuntime/DashboardInterface.py
@@ -86,10 +86,15 @@ def _executeCommand(command, timeout):
     thread.start()
     thread.join(timeout)
     if thread.is_alive():
-        process['process'].terminate()
-        thread.join()
-        logging.error('Command: %s timed out, return code: %i'
-                        % (' '.join(command), process['process'].returncode))
+        if process['process']:
+            process['process'].terminate()
+            thread.join()
+            logging.error('Command: %s timed out, return code: %i'
+                          % (' '.join(command), process['process'].returncode))
+        else:
+            # Process was never initiated, there was an error
+            # bail out
+            logging.error('Command : %s could not be executed' % ' '.join(command))
         return None
     else:
         return process['stdout']


### PR DESCRIPTION
If the command to get the user DN in the dashboard code
hangs when opening the pipe an error can occur later
in the code
