### PR TITLE
Implement checksums in LCGImpl backend module

### DIFF
--- a/src/python/WMCore/Storage/StageOutImpl.py
+++ b/src/python/WMCore/Storage/StageOutImpl.py
@@ -140,7 +140,7 @@ class StageOutImpl:
             return ""
 
 
-    def __call__(self, protocol, inputPFN, targetPFN, options = None):
+    def __call__(self, protocol, inputPFN, targetPFN, options = None, checksums = None):
         """
         _Operator()_
 
@@ -183,8 +183,7 @@ class StageOutImpl:
         #  //
         # // Create the command to be used.
         #//
-        command = self.createStageOutCommand(sourcePFN, targetPFN, options)
-
+        command = self.createStageOutCommand(sourcePFN, targetPFN, options, checksums)
         #  //
         # // Run the command
         #//

--- a/src/python/WMCore/Storage/StageOutMgr.py
+++ b/src/python/WMCore/Storage/StageOutMgr.py
@@ -184,7 +184,7 @@ class StageOutMgr:
         if not self.override:
             print "===> Attempting Local Stage Out."
             try:
-                pfn = self.localStageOut(lfn, fileToStage['PFN'])
+                pfn = self.localStageOut(lfn, fileToStage['PFN'], fileToStage.get('Checksums'))
                 fileToStage['PFN'] = pfn
                 fileToStage['SEName'] = self.siteCfg.localStageOut['se-name']
                 fileToStage['StageOutCommand'] = self.siteCfg.localStageOut['command']
@@ -209,7 +209,7 @@ class StageOutMgr:
         for fallback in self.fallbacks:
             try:
                 pfn = self.fallbackStageOut(lfn, fileToStage['PFN'],
-                                            fallback)
+                                            fallback, fileToStage.get('Checksums'))
                 fileToStage['PFN'] = pfn
                 fileToStage['SEName'] = fallback['se-name']
                 fileToStage['StageOutCommand'] = fallback['command']
@@ -226,7 +226,7 @@ class StageOutMgr:
 
         raise lastException
 
-    def fallbackStageOut(self, lfn, localPfn, fbParams):
+    def fallbackStageOut(self, lfn, localPfn, fbParams, checksums):
         """
         _fallbackStageOut_
 
@@ -255,7 +255,7 @@ class StageOutMgr:
         impl.retryPause = self.retryPauseTime
 
         try:
-            impl(fbParams['command'], localPfn, pfn, fbParams.get("option", None))
+            impl(fbParams['command'], localPfn, pfn, fbParams.get("option", None), checksums)
         except Exception, ex:
             msg = "Failure for fallback stage out:\n"
             msg += str(ex)
@@ -265,7 +265,7 @@ class StageOutMgr:
 
         return pfn
 
-    def localStageOut(self, lfn, localPfn):
+    def localStageOut(self, lfn, localPfn, checksums):
         """
         _localStageOut_
 
@@ -294,7 +294,7 @@ class StageOutMgr:
         impl.retryPause = self.retryPauseTime
 
         try:
-            impl(protocol, localPfn, pfn, options)
+            impl(protocol, localPfn, pfn, options, checksums)
         except Exception, ex:
             msg = "Failure for local stage out:\n"
             msg += str(ex)

--- a/src/python/WMCore/WMSpec/Steps/Executors/StageOut.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/StageOut.py
@@ -199,7 +199,8 @@ class StageOut(Executor):
                 fileForTransfer = {'LFN': lfn,
                                    'PFN': getattr(file, 'pfn'),
                                    'SEName' : None,
-                                   'StageOutCommand': None}
+                                   'StageOutCommand': None,
+                                   'Checksums' : getattr(file, 'checksums', None)}
                 signal.signal(signal.SIGALRM, alarmHandler)
                 signal.alarm(waitTime)
                 try:


### PR DESCRIPTION
Add support for verifying the adler32 checksum when available
through the lcg-ls -l command. Also add general support
for passing the locally calculated checksums of the files
to the StageOutImpl objects, this will enable the checksum
verification in the rfcp-CERN backend plugin as well.

For the LCGImpl plugin the checksum is obtained as follows:

```
echo "$LCG_OUTPUT" | sed -nr 's/^.*\s([a-f0-9]{8})\s*\([aA][dD][lL][eE][rR]32\)\s*$/\\1/p'

Where LCG_OUTPUT=`lcg-ls -l -b -D srmv2 <SURL> 2>/dev/null`
```

The expected format of LCG_OUTPUT is a multi-line string where one of the lines has the following format:
- Checksum: <8-hex character string> (ADLER32)

Or
- Checksum: <8-hex character string> (adler32)

If this line is not present then it is assumed that the checksum is not supported and the check is skipped,
but if a checksum is present then it will be compared and will fail with exit code 63011 if it doesn't match.
Error code is the same as for size mismatch.

Fixes #4185

Tested on all 4 T1s using the srmv2-lcg stageout command, and therefore the LCGImpl backend module, works even in CNAF which doesn't give a checksum yet.
