### PR TITLE
deleting jobsummary from wmagent summary  when request is announced

### DIFF
--- a/src/couchapps/WMStats/views/jobsByStatusWorkflow/map.js
+++ b/src/couchapps/WMStats/views/jobsByStatusWorkflow/map.js
@@ -9,6 +9,7 @@ function(doc) {
         }
     }
     listErrors.sort();
-    emit([doc.workflow, doc.task, doc.state, doc.exitcode, doc.site, listErrors], null);
+    emit([doc.workflow, doc.task, doc.state, doc.exitcode, doc.site, listErrors], 
+         {'id': doc['_id'], 'rev': doc['_rev']});
   }
 }

--- a/src/python/WMCore/Services/WMStats/WMStatsReader.py
+++ b/src/python/WMCore/Services/WMStats/WMStatsReader.py
@@ -17,15 +17,21 @@ class WMStatsReader():
         self.couchServer = CouchServer(self.couchURL)
         self.couchDB = CouchServer(self.couchURL).connectDatabase(self.dbName, False)
 
-    def workflowsByStatus(self, statusList):
+    def workflowsByStatus(self, statusList, format = "list"):
         keys = statusList
         options = {"stale": "update_after"}
         result = self.couchDB.loadView("WMStats", "requestByStatus", options, keys)
-        workflowList = []
-        for item in result["rows"]:
-            workflowList.append(item["id"])
-        return workflowList
 
-    def replicate(self, target):
-        self.couchServer.replicate(self.dbName, target,
-                                   continuous = True)
+        if format == "dict":
+            workflowDict = {}
+            for item in result["rows"]:
+                workflowDict[item["id"]] = None
+            return workflowDict
+        else:
+            workflowList = []
+            for item in result["rows"]:
+                workflowList.append(item["id"])
+            return workflowList
+
+    def getDBInstance(self):
+        return self.couchDB

--- a/src/python/WMCore/Services/WMStats/WMStatsWriter.py
+++ b/src/python/WMCore/Services/WMStats/WMStatsWriter.py
@@ -3,6 +3,7 @@ import logging
 from WMCore.Database.CMSCouch import CouchServer
 from WMCore.Lexicon import splitCouchServiceURL, sanitizeURL
 from WMCore.Wrappers.JsonWrapper import JSONEncoder
+from WMCore.Services.WMStats.WMStatsReader import WMStatsReader
 
 def monitorDocFromRequestSchema(schema):
     """
@@ -33,7 +34,7 @@ def monitorDocFromRequestSchema(schema):
     return doc
 
 
-class WMStatsWriter():
+class WMStatsWriter(WMStatsReader):
 
     def __init__(self, couchURL, dbName = None):
         # set the connection for local couchDB call
@@ -142,5 +143,9 @@ class WMStatsWriter():
             return "nothing"
 
     def replicate(self, target):
-        self.couchServer.replicate(self.dbName, target, continuous = True,
+        return self.couchServer.replicate(self.dbName, target, continuous = True,
                                    filter = 'WMStats/repfilter', useReplicator = True)
+    
+    def getDBInstance(self):
+        return self.couchDB
+


### PR DESCRIPTION
This will delete job summary data which is announced or aborted.
1. It will pull check the status of workflow and retrieve announced. and aborted-completed workflow.
2. It will compare with local db and only workflow is exist in the local db, it will update workflow status in central db.

This will have problem of race condition if workflow is splited between agent. So need to provide additional solution in that case. Currently we don't have that case.

Steve please review
