### PR TITLE
Allow arbitrary collection name on ACDC request

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/Resubmission.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Resubmission.py
@@ -26,7 +26,8 @@ class ResubmissionWorkloadFactory(StdBase):
         originalRequest = GetRequest.getRequestByName(requestName)
         helper = loadWorkload(originalRequest)
         helper.truncate(arguments["RequestName"], arguments["InitialTaskPath"],
-                        arguments["ACDCServer"], arguments["ACDCDatabase"])
+                        arguments["ACDCServer"], arguments["ACDCDatabase"],
+                        arguments.get("CollectionName"))
         helper.ignoreOutputModules(arguments.get("IgnoredOutputModules", []))
         return helper
 

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -1188,22 +1188,27 @@ class WMWorkloadHelper(PersistencyHelper):
         pass
 
     def truncate(self, newWorkloadName, initialTaskPath, serverUrl,
-                 databaseName):
+                 databaseName, collectionName = None):
         """
         _truncate_
 
         Truncate a workflow so that it can be used for resubmission.  This will
         rename the workflow and set the task in the intitialTaskPath parameter
         to be the top level task.  This modifies the workflow in place.
+        The input collection name can be specified otherwise it will default to
+        the old workload name.
         """
+        if not collectionName:
+            collectionName = self.name()
+
         allTaskPaths = self.listAllTaskPathNames()
         newTopLevelTask = self.getTaskByPath(initialTaskPath)
-        newTopLevelTask.addInputACDC(serverUrl, databaseName, self.name(),
+        newTopLevelTask.addInputACDC(serverUrl, databaseName, collectionName,
                                      initialTaskPath)
         newTopLevelTask.setInputStep(None)
         workloadOwner = self.getOwner()
         self.setInitialJobCount(self.getInitialJobCount() + 10000000)
-        newTopLevelTask.setSplittingParameters(collectionName = self.name(),
+        newTopLevelTask.setSplittingParameters(collectionName = collectionName,
                                                filesetName = initialTaskPath,
                                                couchURL = serverUrl,
                                                couchDB = databaseName,

--- a/src/templates/WMCore/WebTools/RequestManager/WebRequestSchema.tmpl
+++ b/src/templates/WMCore/WebTools/RequestManager/WebRequestSchema.tmpl
@@ -281,6 +281,7 @@ Initial Task Path: <input type="text" name="InitialTaskPath" size=30/><br/>
 ACDC Server URL: <input type="text" name="ACDCServer" size=30/><br/>
 ACDC Database Name: <input type="text" name="ACDCDatabase" size=30/><br/>
 Ignored Output Modules: <input type="text" name="IgnoredOutputModules" size=40/><br/>
+Alternative Collection Name: <input type="text" name="CollectionName" size=40/><br/>
             $performanceBlock
             $trailerBlock("Resubmission")
         </div>

--- a/test/python/WMCore_t/RequestManager_t/ReqMgrWorkload_t.py
+++ b/test/python/WMCore_t/RequestManager_t/ReqMgrWorkload_t.py
@@ -659,6 +659,7 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         schema["InitialTaskPath"]     = '/%s/DataProcessing' % requestName
         schema["ACDCServer"]          = os.environ.get("COUCHURL")
         schema["ACDCDatabase"]        = self.couchDBName
+        schema["CollectionName"]      = "SomeOtherName"
 
         # Here we just make sure that real result goes through
         result = self.jsonSender.put('request/testRequest', schema)


### PR DESCRIPTION
A CollectionName parameter can be specified in the request arguments
if not specified the  collection name defaults to the old request name
as it has done so far.

See an example workload: https://cmsoguatworld.cern.ch/reqmgr/view/showWorkload?requestName=dballest_TestACDC_arbritrary_2_121102_174323_6616

Internally the workload has a different collectionName in the splitting and acdc attributes of the input section.
