### PR TITLE
Fix error display in workload summary

### DIFF
--- a/src/couchapps/WorkloadSummary/_attachments/js/dataMap/errorData.js
+++ b/src/couchapps/WorkloadSummary/_attachments/js/dataMap/errorData.js
@@ -28,6 +28,7 @@ errorSummary = function(errors) {
                 codeSummary.runLumis = getRunLumiRange(errors[task][step][code].runs)
                 codeSummary.input = errors[task][step][code].input;
                 summary[task][step][i] = codeSummary;
+                i++;
                 /*
                 summary[task].totalJobs += codeSummary.jobs;
                 summary[task].totalFiles += codeSummary.input.length;


### PR DESCRIPTION
Display all errors correctly

Example: https://dballesteros.iriscouch.com/workloadsummary_testdisplay/_design/WorkloadSummary/_show/histogramByWorkflow/an_id

Fixes #4217
