### PR TITLE
Implement pending jobs per task/site functionality

### DIFF
--- a/bin/wmagent-resource-control
+++ b/bin/wmagent-resource-control
@@ -15,6 +15,30 @@ from WMCore.Configuration import loadConfigurationFile
 from WMCore.ResourceControl.ResourceControl import ResourceControl
 from WMCore.Services.SiteDB.SiteDB import SiteDBJSON
 
+
+def getTaskTypes(tier0 = False):
+    """
+    _getTaskTypes_
+
+    Get the list of task types we are currently using with
+    priorities.
+    """
+    taskTypes = {"Merge" : 5,
+                 "Cleanup" : 5,
+                 "Harvesting" : 5,
+                 "LogCollect" : 3,
+                 "Skim" : 2,
+                 "Production" : 1,
+                 "Processing" : 1,
+                 "Analysis" : 1
+                 }
+
+    if tier0:
+        taskTypes["Repack"] = 4
+        taskTypes["Express"] = 5
+
+    return taskTypes
+
 def createOptionParser():
     """
     _createOptionParser_
@@ -26,6 +50,8 @@ def createOptionParser():
     myOptParser.add_option("-p", "--thresholds", dest = "printThresholds",
                            default = False, action = "store_true",
                            help = "Print out all known thresholds and site information.")
+    myOptParser.add_option("--add-T0", dest = "addT0", default = False, action = "store_true",
+                           help = "Add the CMS Tier-0 site to resource control.")
     myOptParser.add_option("--add-T1s", dest = "addT1s", default = False, action = "store_true",
                            help = "Add all of the CMS T1 sites to resource control.")
     myOptParser.add_option("--add-T2s", dest = "addT2s", default = False, action = "store_true",
@@ -36,9 +62,11 @@ def createOptionParser():
     myOptParser.add_option("--site-name", dest = "siteName",
                            help = "Specify the unique name of the location")
     myOptParser.add_option("--pending-slots", dest = "pendingSlots",
-                           help = "Specify the maximum number of pending slots to use at the site")
+                           help = "Specify the maximum number of pending slots to use at the site or task type")
     myOptParser.add_option("--running-slots", dest = "runningSlots",
-                           help = "Specify the maximum number of running slots to use at the site")
+                           help = "Specify the maximum number of running slots to use at the site or task type")
+    myOptParser.add_option("--apply-to-all-tasks", dest = "allTasks", default = False, action = "store_true",
+                           help = "Apply site running/pending threshold to all task types")
     myOptParser.add_option("--ce-name", dest = "ceName",
                            help = "Specify the CEName for the site")
     myOptParser.add_option("--se-name", dest = "seName",
@@ -47,8 +75,6 @@ def createOptionParser():
                            help = "Specify the name of the site in SiteDB")
     myOptParser.add_option("--task-type", dest = "taskType",
                            help = "Specify the name of the task to add/modify")
-    myOptParser.add_option("--task-slots", dest = "maxSlots",
-                           help = "Specify the maximum number of slots for the task type")
     myOptParser.add_option("--priority", dest = "priority", default = None,
                            help = "Specify the priority of the threshold at the site (higher is better)")
     myOptParser.add_option("--plugin", dest = "plugin",
@@ -84,45 +110,29 @@ def getCMSSiteInfo(pattern):
 
     return nameSEMapping
 
-def addSites(resourceControl, allSites, ceName, plugin, pendingSlots, runningSlots):
+def addSites(resourceControl, allSites, ceName, plugin, pendingSlots, runningSlots, tier0Option = False, cmsName = None):
     """
     _addSites_
 
     Add the given sites to resource control and add tasks as well.
     """
-    if options.pendingSlots == None:
+    if pendingSlots is None:
         pendingSlots = 10
     else:
-        pendingSlots = options.pendingSlots
-    if options.runningSlots == None:
+        pendingSlots = pendingSlots
+    if runningSlots is None:
         runningSlots = 10
     else:
-        runningSlots = options.runningSlots
+        runningSlots = runningSlots
 
     for siteName in allSites.keys():
-        if ceName == None:
-            updateSiteInfo(resourceControl, siteName, pendingSlots, runningSlots,
-                           siteName, allSites[siteName], plugin, siteName)
-        else:
-            updateSiteInfo(resourceControl, siteName, pendingSlots, runningSlots,
-                           ceName, allSites[siteName], plugin, siteName)
+        updateSiteInfo(resourceControl, siteName, pendingSlots, runningSlots,
+                       ceName or siteName, allSites[siteName], plugin, cmsName or siteName)
 
-        updateThresholdInfo(resourceControl, siteName, "Merge", runningSlots,
-                            priority = 5)
-        updateThresholdInfo(resourceControl, siteName, "Cleanup", runningSlots,
-                            priority = 5)
-        updateThresholdInfo(resourceControl, siteName, "Harvesting", runningSlots,
-                            priority = 5)
-        updateThresholdInfo(resourceControl, siteName, "LogCollect", runningSlots,
-                            priority = 3)
-        updateThresholdInfo(resourceControl, siteName, "Skim", runningSlots,
-                            priority = 2)
-        updateThresholdInfo(resourceControl, siteName, "Production", runningSlots,
-                            priority = 1)
-        updateThresholdInfo(resourceControl, siteName, "Processing", runningSlots,
-                            priority = 1)
-        updateThresholdInfo(resourceControl, siteName, "Analysis", runningSlots,
-                            priority = 1)
+        tasksWithPriorities = getTaskTypes(tier0Option)
+        for task in tasksWithPriorities:
+            updateThresholdInfo(resourceControl, siteName, task, runningSlots, pendingSlots,
+                                priority = tasksWithPriorities[task])
 
     return
 
@@ -156,9 +166,10 @@ def printThresholds(resourceControl, desiredSiteName):
                         siteName, runningJobs, pendingJobs, runningSlots, pendingSlots, stateMsg)
 
         for task in siteThresholds['thresholds']:
-            print "  %s - %d running, %d max, priority %s" % \
+            print "  %s - %d running, %d pending, %d max running, %d max pending, priority %s" % \
                   (task['task_type'], task["task_running_jobs"],
-                   task["max_slots"], str(task.get("priority", 1)))
+                   task['task_pending_jobs'], task["max_slots"],
+                   task["pending_slots"], str(task.get("priority", 1)))
             if task["task_running_jobs"] > 0:
                 taskWorkloads = resourceControl.listWorkloadsForTaskSite(task['task_type'], siteName)
                 for t in taskWorkloads:
@@ -168,15 +179,15 @@ def printThresholds(resourceControl, desiredSiteName):
 
 def updateSiteInfo(resourceControl, siteName, pendingSlots = None,
                    runningSlots = None, ceName = None, seName = None,
-                   plugin = None, cmsName = None):
+                   plugin = None, cmsName = None, allTasks = False):
     """
     _updateSiteInfo_
 
     Add a site to the resource control database if it doesn't exist.  Update
     information about sites in the database if it already exists.
     """
-    if resourceControl.listSiteInfo(siteName) == None:
-        if pendingSlots == None or runningSlots == None or ceName == None or seName == None or plugin == None:
+    if resourceControl.listSiteInfo(siteName) is None:
+        if pendingSlots is None or runningSlots is None or ceName is None or seName is None or plugin is None:
             print "You must specify the number of pending or running slots, the SE name, "
             print "the CE name and a plugin when adding a site."
             print ""
@@ -187,19 +198,25 @@ def updateSiteInfo(resourceControl, siteName, pendingSlots = None,
         if type(seName) == type([]):
             for singleSEName in seName:
                 resourceControl.insertSite(siteName = siteName, pendingSlots = int(pendingSlots),
-                                           runningSlots = int(runningSlots), seName = singleSEName, ceName = ceName,
+                                           runningSlots = int(runningSlots),
+                                           seName = singleSEName, ceName = ceName,
                                            plugin = plugin, cmsName = cmsName)
         else:
             resourceControl.insertSite(siteName = siteName, pendingSlots = int(pendingSlots),
                                        runningSlots = int(runningSlots),
                                        seName = seName, ceName = ceName,
                                        plugin = plugin, cmsName = cmsName)
+
         return
 
     if pendingSlots != None or runningSlots != None:
         resourceControl.setJobSlotsForSite(siteName = siteName,
                                            pendingJobSlots = pendingSlots,
                                            runningJobSlots = runningSlots)
+        tasksWithPriorities = getTaskTypes()
+        for task in tasksWithPriorities:
+            updateThresholdInfo(resourceControl, siteName, task, int(runningSlots), int(pendingSlots),
+                                priority = tasksWithPriorities[task])
 
     if seName != None:
         print "It's not possible to change a site's SE name after the site has"
@@ -213,27 +230,28 @@ def updateSiteInfo(resourceControl, siteName, pendingSlots = None,
 
     return
 
-def updateThresholdInfo(resourceControl, siteName, taskType, maxSlots, priority = None):
+def updateThresholdInfo(resourceControl, siteName, taskType, maxSlots = None, pendingSlots = None, priority = None):
     """
     _updateThresholdInfo_
 
     Add or update a task threshold in the database.
     """
-    if resourceControl.listSiteInfo(siteName) == None:
+    if resourceControl.listSiteInfo(siteName) is None:
         print "You must add the site to the database before you can add"
         print "thresholds."
         print ""
         myOptParser.print_help()
         sys.exit(1)
 
-    if maxSlots == None:
-        print "You must provide the maximum number of slots."
+    if maxSlots is None and pendingSlots is None:
+        print "You must provide either pending or running slots for the task."
         print ""
         myOptParser.print_help()
         sys.exit(1)
 
     resourceControl.insertThreshold(siteName = siteName, taskType = taskType,
-                                    maxSlots = int(maxSlots), priority = priority)
+                                    maxSlots = maxSlots, pendingSlots = pendingSlots,
+                                    priority = priority)
     return
 
 def setSiteState(resourceControl, siteName, state):
@@ -259,7 +277,17 @@ if options.printThresholds:
     printThresholds(myResourceControl, options.siteName)
     sys.exit(0)
 else:
-    if options.addT1s == True:
+    if options.addT0 == True:
+        t0Sites = {'CERN' : ['srm-cms.cern.ch', 'srm-eoscms.cern.ch']}
+        cmsName = 'T0_CH_CERN'
+        ceName = 'CERN'
+        plugin = 'LsfPlugin'
+        runningSlots = -1
+        pendingSlots = 500
+        addSites(myResourceControl, t0Sites, ceName or options.ceName, plugin or options.plugin,
+                 pendingSlots or options.pendingSlots, runningSlots or options.runningSlots, True,
+                 cmsName or options.cmsName)
+    elif options.addT1s == True:
         t1Sites = getCMSSiteInfo("T1*")
         addSites(myResourceControl, t1Sites, options.ceName, options.plugin,
                  options.pendingSlots, options.runningSlots)
@@ -271,19 +299,21 @@ else:
         allSites = getCMSSiteInfo("*")
         addSites(myResourceControl, allSites, options.ceName, options.plugin,
                  options.pendingSlots, options.runningSlots)
-    elif options.siteName == None:
+    elif options.siteName is None:
         print "You must specify a site name."
         myOptParser.print_help()
         sys.exit(1)
     elif options.state is not None:
         setSiteState(myResourceControl, options.siteName, options.state)
         sys.exit(0)
-    elif options.taskType == None:
+    elif options.taskType is None:
         updateSiteInfo(myResourceControl, options.siteName, options.pendingSlots,
                        options.runningSlots, options.ceName, options.seName,
-                       options.plugin, options.cmsName)
+                       options.plugin, options.cmsName, options.allTasks)
         sys.exit(0)
     else:
+        taskType = options.taskType.strip().split(',')
         updateThresholdInfo(myResourceControl, options.siteName,
-                            options.taskType, options.maxSlots, priority = options.priority)
+                            taskType, options.pendingSlots,
+                            options.runningSlots, priority = options.priority)
         sys.exit(0)

--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -486,7 +486,9 @@ class JobSubmitterPoller(BaseWorkerThread):
                     # Pull basic info for the threshold
                     taskType            = threshold["task_type"]
                     maxSlots            = threshold["max_slots"]
+                    taskPendingSlots    = threshold["pending_slots"]
                     taskRunning         = threshold["task_running_jobs"]
+                    taskPending         = threshold["task_pending_jobs"]
                 except KeyError, ex:
                     msg =  "Had invalid threshold %s\n" % threshold
                     msg += str(ex)
@@ -524,7 +526,7 @@ class JobSubmitterPoller(BaseWorkerThread):
                 taskCache = self.cachedJobs[siteName][taskType]
 
                 # Calculate number of jobs we need
-                nJobsRequired = totalPendingSlots - totalPending
+                nJobsRequired = min(totalPendingSlots - totalPending, taskPendingSlots - taskPending)
                 breakLoop = False
                 logging.debug("nJobsRequired for task %s: %i" % (taskType, nJobsRequired))
 
@@ -617,6 +619,7 @@ class JobSubmitterPoller(BaseWorkerThread):
                     # Deal with accounting
                     nJobsRequired -= 1
                     totalPending  += 1
+                    taskPending   += 1
 
                     if breakLoop:
                         break

--- a/src/python/WMCore/ResourceControl/MySQL/Create.py
+++ b/src/python/WMCore/ResourceControl/MySQL/Create.py
@@ -25,10 +25,11 @@ class Create(DBCreator):
 
         self.create["rc_threshold"] = """
         CREATE TABLE rc_threshold(
-            site_id     INTEGER NOT NULL,
-            sub_type_id INTEGER NOT NULL,
-            max_slots   INTEGER NOT NULL,
-            priority    INTEGER DEFAULT 1,
+            site_id       INTEGER NOT NULL,
+            sub_type_id   INTEGER NOT NULL,
+            pending_slots INTEGER NOT NULL,
+            max_slots     INTEGER NOT NULL,
+            priority      INTEGER DEFAULT 1,
             FOREIGN KEY (site_id) REFERENCES wmbs_location(id) ON DELETE CASCADE,
             FOREIGN KEY (sub_type_id) REFERENCES wmbs_sub_types(id) ON DELETE CASCADE)"""
 

--- a/src/python/WMCore/ResourceControl/MySQL/InsertThreshold.py
+++ b/src/python/WMCore/ResourceControl/MySQL/InsertThreshold.py
@@ -22,30 +22,39 @@ class InsertThreshold(DBFormatter):
                   site_id = (SELECT id FROM wmbs_location WHERE site_name = :sitename) AND
                   sub_type_id = (SELECT id FROM wmbs_sub_types WHERE name  = :tasktype)"""
 
-    updSQL = """UPDATE rc_threshold SET max_slots = :maxslots, priority = :priority
+    updSQL = """UPDATE rc_threshold SET max_slots = :maxslots, pending_slots = :pendslots, priority = :priority
                 WHERE site_id = (SELECT id FROM wmbs_location WHERE site_name = :sitename) AND
                       sub_type_id = (SELECT id FROM wmbs_sub_types WHERE name  = :tasktype)"""
 
-    addSQL = """INSERT INTO rc_threshold (site_id, sub_type_id, max_slots, priority) VALUES (
+    addSQL = """INSERT INTO rc_threshold (site_id, sub_type_id, max_slots, pending_slots, priority) VALUES (
                  (SELECT id FROM wmbs_location WHERE site_name = :sitename),
                  (SELECT id FROM wmbs_sub_types WHERE name  = :tasktype),
-                 :maxslots, :priority)"""
+                 :maxslots, :pendslots, :priority)"""
 
-    def execute(self, siteName, taskType, maxSlots, priority = None, conn = None,
+    def execute(self, siteName, taskType, maxSlots, pendingSlots, priority = None, conn = None,
                 transaction = False):
         binds = {"sitename": siteName, "tasktype": taskType,
-                 "maxslots": maxSlots, "priority": priority}
+                 "maxslots": maxSlots, "pendslots": pendingSlots,
+                 "priority": priority}
         result = self.dbi.processData(self.selSQL, {"sitename": siteName, "tasktype": taskType},
                                       conn = conn, transaction = transaction)
         result = self.formatDict(result)
 
         if len(result) == 0:
-            if priority == None:
+            if priority is None:
                 binds['priority'] = 1
+            if maxSlots is None:
+                binds['maxslots'] = pendingSlots
+            if pendingSlots is None:
+                binds['pendslots'] = maxSlots
             self.dbi.processData(self.addSQL, binds, conn = conn, transaction = transaction)
         else:
-            if priority == None:
+            if priority is None:
                 binds['priority'] = result[0]['priority']
+            if pendingSlots is None:
+                binds['pendslots'] = result[0]['pending_slots']
+            if maxSlots is None:
+                binds['maxslots'] = result[0]['max_slots']
             self.dbi.processData(self.updSQL, binds, conn = conn, transaction = transaction)
 
         return

--- a/src/python/WMCore/ResourceControl/MySQL/ListThresholds.py
+++ b/src/python/WMCore/ResourceControl/MySQL/ListThresholds.py
@@ -12,7 +12,7 @@ from WMCore.Database.DBFormatter import DBFormatter
 
 class ListThresholds(DBFormatter):
     sql = """SELECT wl.site_name AS site, wst.name AS type,
-                    rc.max_slots FROM rc_threshold rc
+                    rc.max_slots, rc.pending_slots FROM rc_threshold rc
                 INNER JOIN wmbs_location wl ON wl.id = rc.site_id
                 INNER JOIN wmbs_sub_types wst ON wst.id = rc.sub_type_id
                 ORDER By site

--- a/src/python/WMCore/ResourceControl/MySQL/ListThresholdsForSubmit.py
+++ b/src/python/WMCore/ResourceControl/MySQL/ListThresholdsForSubmit.py
@@ -14,6 +14,7 @@ class ListThresholdsForSubmit(DBFormatter):
                     wmbs_location.running_slots,
                     wmbs_location.cms_name AS cms_name,
                     rc_threshold.max_slots,
+                    rc_threshold.pending_slots AS task_pending_slots,
                     wmbs_sub_types.name AS task_type,
                     job_count.job_status,
                     job_count.jobs,
@@ -109,13 +110,16 @@ class ListThresholdsForSubmit(DBFormatter):
             for threshold in formattedResults[siteName]['thresholds']:
                 if threshold['task_type'] == taskType:
                     threshold['task_running_jobs'] += task_running_jobs
+                    threshold['task_pending_jobs'] += task_pending_jobs
                     break
             else:
                 threshold = {}
                 threshold['task_type']               = taskType
                 threshold['max_slots']               = result['max_slots']
+                threshold['pending_slots']           = result['task_pending_slots']
                 threshold['priority']                = result['priority']
                 threshold['task_running_jobs']       = task_running_jobs
+                threshold['task_pending_jobs']       = task_pending_jobs
                 formattedResults[siteName]['thresholds'].append(threshold)
 
 

--- a/src/python/WMCore/ResourceControl/MySQL/ThresholdBySite.py
+++ b/src/python/WMCore/ResourceControl/MySQL/ThresholdBySite.py
@@ -13,6 +13,7 @@ class ThresholdBySite(DBFormatter):
                     wmbs_location.pending_slots,
                     wmbs_location.running_slots,
                     rc_threshold.max_slots,
+                    rc_threshold.pending_slots AS task_pending_slots,
                     wmbs_sub_types.name AS task_type,
                     job_count.running_jobs AS task_running_jobs,
                     job_count.pending_jobs AS task_pending_jobs

--- a/src/python/WMCore/ResourceControl/MySQL/UpdateThresholdsInBulk.py
+++ b/src/python/WMCore/ResourceControl/MySQL/UpdateThresholdsInBulk.py
@@ -14,7 +14,7 @@ class UpdateThresholdsInBulk(DBFormatter):
     """
     _UpdateThresholdsBulk_
     """
-    sql = """UPDATE rc_threshold SET max_slots = :maxslots
+    sql = """UPDATE rc_threshold SET max_slots = :maxslots, pending_slots = :pendslots
                 WHERE site_id = (SELECT id FROM wmbs_location WHERE site_name = :sitename) AND
                       sub_type_id = (SELECT id FROM wmbs_sub_types WHERE name  = :tasktype)"""
 

--- a/src/python/WMCore/ResourceControl/Oracle/Create.py
+++ b/src/python/WMCore/ResourceControl/Oracle/Create.py
@@ -37,6 +37,7 @@ class Create(DBCreator):
         CREATE TABLE rc_threshold(
             site_id INTEGER NOT NULL,
             sub_type_id INTEGER NOT NULL,
+            pending_slots INTEGER NOT NULL,
             max_slots INTEGER NOT NULL,
             priority  INTEGER DEFAULT 1) %s""" % tablespaceTable
 

--- a/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
+++ b/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
@@ -1,230 +1,137 @@
 #!/bin/env python
-
 """
 _JobSubmitter_t_
 
-JobSubmitter unittest
-Submit jobs to condor in various failure modes
-for the agent and see what they do
+JobSubmitter unit-test, uses the MockPlugin to submit and tests
+the different dynamics that occur inside the JobSubmitter.
 """
 
-import unittest
-import threading
-import os
-import os.path
-import time
-import shutil
-import pickle
 import cProfile
+import os
+import pickle
 import pstats
-import copy
-import getpass
-import re
-import cPickle
-
-from subprocess import Popen, PIPE
-
-
-import WMCore.WMBase
-import WMCore.WMInit
-#from WMQuality.TestInit import TestInit
-from WMQuality.TestInitCouchApp import TestInitCouchApp as TestInit
-from WMCore.DAOFactory          import DAOFactory
-from WMCore.WMInit              import getWMBASE
-
-from WMCore.WMBS.File         import File
-from WMCore.WMBS.Fileset      import Fileset
-from WMCore.WMBS.Workflow     import Workflow
-from WMCore.WMBS.Subscription import Subscription
-from WMCore.WMBS.JobGroup     import JobGroup
-from WMCore.WMBS.Job          import Job
-
-
-
-from WMComponent.JobSubmitter.JobSubmitter       import JobSubmitter
-from WMComponent.JobSubmitter.JobSubmitterPoller import JobSubmitterPoller
-
-from WMCore.JobStateMachine.ChangeState import ChangeState
-
-from WMCore.Services.UUID import makeUUID
-
-from WMCore.Agent.Configuration             import loadConfigurationFile, Configuration
-from WMCore.ResourceControl.ResourceControl import ResourceControl
-from WMCore.DataStructs.JobPackage          import JobPackage
-from WMCore.Agent.HeartbeatAPI              import HeartbeatAPI
-
-
-#Workload stuff
-from WMCore.WMSpec.WMWorkload import newWorkload
-from WMCore.WMSpec.WMStep import makeWMStep
-from WMCore.WMSpec.Steps.StepFactory import getStepTypeHelper
-from WMCore.WMSpec.Makers.TaskMaker import TaskMaker
-from WMCore.WMSpec.StdSpecs.ReReco  import rerecoWorkload, getTestArguments
-from WMCore_t.WMSpec_t.TestSpec import testWorkload
+import threading
+import time
+import unittest
 
 from nose.plugins.attrib import attr
-
-def parseJDL(jdlLocation):
-    """
-    _parseJDL_
-
-    Parse a JDL into some sort of meaningful dictionary
-    """
-
-
-    f = open(jdlLocation, 'r')
-    lines = f.readlines()
-    f.close()
-
-
-    listOfJobs = []
-    headerDict = {}
-    jobLines   = []
-
-    index = 0
-
-    for line in lines:
-        # Go through the lines until you hit Queue
-        index += 1
-        splits = line.split(' = ')
-        key = splits[0]
-        value = ' = '.join(splits[1:])
-        value = value.rstrip('\n')
-        headerDict[key] = value
-        if key == "Queue 1\n":
-            # Yes, this is clumsy
-            jobLines = lines[index:]
-            break
-
-    tmpDict = {}
-    index   = 2
-    for jobLine in jobLines:
-        splits = jobLine.split(' = ')
-        key = splits[0]
-        value = ' = '.join(splits[1:])
-        value = value.rstrip('\n')
-        if key == "Queue 1\n":
-            # Then we've hit the next block
-            tmpDict["index"] = index
-            listOfJobs.append(tmpDict)
-            tmpDict = {}
-            index += 1
-        else:
-            tmpDict[key] = value
-
-    if tmpDict != {}:
-        listOfJobs.append(tmpDict)
-
-
-    return listOfJobs, headerDict
-
-
-
-def getCondorRunningJobs(user):
-    """
-    _getCondorRunningJobs_
-
-    Return the number of jobs currently running for a user
-    """
-
-
-    command = ['condor_q', user]
-    pipe = Popen(command, stdout = PIPE, stderr = PIPE, shell = False)
-    stdout, error = pipe.communicate()
-
-    output = stdout.split('\n')[-2]
-
-    nJobs = int(output.split(';')[0].split()[0])
-
-    return nJobs
-
-
-
+from WMComponent.JobSubmitter.JobSubmitterPoller import JobSubmitterPoller
+from WMCore.Agent.Configuration import Configuration
+from WMCore.Agent.HeartbeatAPI import HeartbeatAPI
+from WMCore.DAOFactory import DAOFactory
+from WMCore.JobStateMachine.ChangeState import ChangeState
+from WMCore.ResourceControl.ResourceControl import ResourceControl
+from WMCore.Services.UUID import makeUUID
+from WMCore.WMBase import getTestBase
+from WMCore.WMBS.File import File
+from WMCore.WMBS.Fileset import Fileset
+from WMCore.WMBS.Job import Job
+from WMCore.WMBS.JobGroup import JobGroup
+from WMCore.WMBS.Subscription import Subscription
+from WMCore.WMBS.Workflow import Workflow
+from WMCore.WMSpec.Makers.TaskMaker import TaskMaker
+from WMCore_t.WMSpec_t.TestSpec import testWorkload
+from WMQuality.TestInitCouchApp import TestInitCouchApp as TestInit
 
 class JobSubmitterTest(unittest.TestCase):
     """
-    Test class for the JobSubmitter
+    _JobSubmitterTest_
 
+    Test class for the JobSubmitterPoller
     """
-
-    sites = ['T2_US_Florida', 'T2_US_UCSD', 'T2_TW_Taiwan', 'T1_CH_CERN']
 
     def setUp(self):
         """
+        _setUp_
+
         Standard setup: Now with 100% more couch
         """
-
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection(destroyAllDatabase = True)
-        self.testInit.setSchema(customModules = ["WMCore.WMBS", "WMCore.BossAir", "WMCore.ResourceControl", "WMCore.Agent.Database"],
-                                useDefault = False)
+        self.testInit.setDatabaseConnection()
+        self.testInit.setSchema(customModules = ["WMCore.WMBS", "WMCore.BossAir", "WMCore.ResourceControl", "WMCore.Agent.Database"])
         self.testInit.setupCouch("jobsubmitter_t/jobs", "JobDump")
         self.testInit.setupCouch("jobsubmitter_t/fwjrs", "FWJRDump")
+        self.testInit.setupCouch("wmagent_summary_t", "WMStats")
 
         myThread = threading.currentThread()
         self.daoFactory = DAOFactory(package = "WMCore.WMBS",
                                      logger = myThread.logger,
                                      dbinterface = myThread.dbi)
-
-        locationAction = self.daoFactory(classname = "Locations.New")
-        locationSlots  = self.daoFactory(classname = "Locations.SetJobSlots")
-
-        # We actually need the user name
-        self.user = getpass.getuser()
-
-        self.ceName = '127.0.0.1'
-
-        #Create sites in resourceControl
-        resourceControl = ResourceControl()
-        for site in self.sites:
-            resourceControl.insertSite(siteName = site, seName = 'se.%s' % (site),
-                                       ceName = site, plugin = "CondorPlugin", pendingSlots = 10000,
-                                       runningSlots = 20000, cmsName = site)
-            resourceControl.insertThreshold(siteName = site, taskType = 'Processing', \
-                                            maxSlots = 10000)
-
+        self.baDaoFactory = DAOFactory(package = "WMCore.BossAir",
+                                       logger = myThread.logger,
+                                       dbinterface = myThread.dbi)
 
         self.testDir = self.testInit.generateWorkDir()
 
         # Set heartbeat
         self.componentName = 'JobSubmitter'
-        self.heartbeatAPI  = HeartbeatAPI(self.componentName)
+        self.heartbeatAPI = HeartbeatAPI(self.componentName)
         self.heartbeatAPI.registerComponent()
 
         return
 
     def tearDown(self):
         """
+        _tearDown_
+
         Standard tearDown
-
         """
-        self.testInit.clearDatabase(modules = ["WMCore.WMBS",
-                                               'WMCore.ResourceControl', 'WMCore.BossAir',
-                                               'WMCore.Agent.Database'])
+        self.testInit.clearDatabase()
         self.testInit.delWorkDir()
-
         self.testInit.tearDownCouch()
+        return
+
+    def setResourceThresholds(self, site, **options):
+        """
+        _setResourceThresholds_
+
+        Utility to set resource thresholds
+        """
+        if not options:
+            options = {'state'        : 'Normal',
+                       'runningSlots' : 10,
+                       'pendingSlots' : 5,
+                       'tasks' : ['Processing', 'Merge'],
+                       'Processing' : {'pendingSlots' : 5,
+                                       'runningSlots' : 10},
+                       'Merge' : {'pendingSlots' : 2,
+                                  'runningSlots' : 5,
+                                  'priority' : 5}}
+
+        resourceControl = ResourceControl()
+        resourceControl.insertSite(siteName = site, seName = 'se.%s' % (site),
+                                   ceName = site, plugin = "MockPlugin", pendingSlots = options['pendingSlots'],
+                                   runningSlots = options['runningSlots'], cmsName = site)
+        for task in options['tasks']:
+            resourceControl.insertThreshold(siteName = site, taskType = task,
+                                            maxSlots = options[task]['runningSlots'],
+                                            pendingSlots = options[task]['pendingSlots'],
+                                            priority = options[task].get('priority', 1))
+        if options.get('state'):
+            resourceControl.changeSiteState(site, options.get('state'))
 
         return
 
-
-
-    def createJobGroups(self, nSubs, nJobs, task, workloadSpec, site = None,
-                        bl = [], wl = [], type = 'Processing'):
+    def createJobGroups(self, nSubs, nJobs, task, workloadSpec, site,
+                        bl = [], wl = [], taskType = 'Processing', name = None):
         """
-        Creates a series of jobGroups for submissions
+        _createJobGroups_
 
+        Creates a series of jobGroups for submissions
         """
 
         jobGroupList = []
 
+        if name is None:
+            name = makeUUID()
+
         testWorkflow = Workflow(spec = workloadSpec, owner = "mnorman",
-                                name = makeUUID(), task="basicWorkload/Production")
+                                name = name, task = "basicWorkload/Production")
         testWorkflow.create()
 
         # Create subscriptions
-        for i in range(nSubs):
+        for _ in range(nSubs):
 
             name = makeUUID()
 
@@ -233,13 +140,12 @@ class JobSubmitterTest(unittest.TestCase):
             testFileset.create()
             testSubscription = Subscription(fileset = testFileset,
                                             workflow = testWorkflow,
-                                            type = type,
+                                            type = taskType,
                                             split_algo = "FileBased")
             testSubscription.create()
 
             testJobGroup = JobGroup(subscription = testSubscription)
             testJobGroup.create()
-
 
             # Create jobs
             self.makeNJobs(name = name, task = task,
@@ -249,17 +155,13 @@ class JobSubmitterTest(unittest.TestCase):
                            sub = testSubscription.exists(),
                            site = site, bl = bl, wl = wl)
 
-
-
             testFileset.commit()
             testJobGroup.commit()
             jobGroupList.append(testJobGroup)
 
         return jobGroupList
 
-
-
-    def makeNJobs(self, name, task, nJobs, jobGroup, fileset, sub, site = None, bl = [], wl = []):
+    def makeNJobs(self, name, task, nJobs, jobGroup, fileset, sub, site, bl = [], wl = []):
         """
         _makeNJobs_
 
@@ -273,13 +175,13 @@ class JobSubmitterTest(unittest.TestCase):
         for n in range(nJobs):
             # First make a file
             #site = self.sites[0]
-            testFile = File(lfn = "/singleLfn/%s/%s" %(name, n),
+            testFile = File(lfn = "/singleLfn/%s/%s" % (name, n),
                             size = 1024, events = 10)
-            if site:
-                testFile.setLocation(site)
+            if type(site) == list:
+                for singleSite in site:
+                    testFile.setLocation(singleSite)
             else:
-                for tmpSite in self.sites:
-                    testFile.setLocation('se.%s' % (tmpSite))
+                testFile.setLocation(site)
             testFile.create()
             fileset.addFile(testFile)
 
@@ -289,37 +191,34 @@ class JobSubmitterTest(unittest.TestCase):
         index = 0
         for f in fileset.files:
             index += 1
-            testJob = Job(name = '%s-%i' %(name, index))
+            testJob = Job(name = '%s-%i' % (name, index))
             testJob.addFile(f)
-            testJob["location"]  = f.getLocations()[0]
-            testJob['task']    = task.getPathName()
+            testJob["location"] = f.getLocations()[0]
+            testJob['task'] = task.getPathName()
             testJob['sandbox'] = task.data.input.sandbox
-            testJob['spec']    = os.path.join(self.testDir, 'basicWorkload.pcl')
+            testJob['spec'] = os.path.join(self.testDir, 'basicWorkload.pcl')
             testJob['mask']['FirstEvent'] = 101
             testJob["siteBlacklist"] = bl
             testJob["siteWhitelist"] = wl
-            testJob['priority']      = 101
+            testJob['priority'] = 101
             jobCache = os.path.join(cacheDir, 'Sub_%i' % (sub), 'Job_%i' % (index))
             os.makedirs(jobCache)
             testJob.create(jobGroup)
             testJob['cache_dir'] = jobCache
             testJob.save()
             jobGroup.add(testJob)
-            output = open(os.path.join(jobCache, 'job.pkl'),'w')
+            output = open(os.path.join(jobCache, 'job.pkl'), 'w')
             pickle.dump(testJob, output)
             output.close()
 
         return testJob, testFile
 
-
-    def getConfig(self, configPath = os.path.join(WMCore.WMInit.getWMBASE(), 'src/python/WMComponent/JobSubmitter/DefaultConfig.py')):
+    def getConfig(self):
         """
         _getConfig_
 
         Gets a basic config from default location
         """
-
-        myThread = threading.currentThread()
 
         config = Configuration()
 
@@ -335,57 +234,51 @@ class JobSubmitterTest(unittest.TestCase):
         config.General.workDir = os.getenv("TESTDIR", self.testDir)
 
         #Now the CoreDatabase information
-        #This should be the dialect, dburl, etc
-
         config.section_("CoreDatabase")
         config.CoreDatabase.connectUrl = os.getenv("DATABASE")
         config.CoreDatabase.socket     = os.getenv("DBSOCK")
 
+        # BossAir and MockPlugin configuration
         config.section_("BossAir")
-        config.BossAir.pluginNames = ['TestPlugin', 'CondorPlugin']
+        config.BossAir.pluginNames = ['MockPlugin']
         config.BossAir.pluginDir   = 'WMCore.BossAir.Plugins'
-
+        config.BossAir.multicoreTaskTypes = ['MultiProcessing', 'MultiProduction']
+        config.BossAir.nCondorProcesses = 1
+        config.BossAir.section_("MockPlugin")
+        config.BossAir.MockPlugin.fakeReport = os.path.join(getTestBase(),
+                                                         'WMComponent_t/JobSubmitter_t',
+                                                         "submit.sh")
+        # JobSubmitter configuration
         config.component_("JobSubmitter")
-        config.JobSubmitter.logLevel      = 'INFO'
+        config.JobSubmitter.logLevel      = 'DEBUG'
         config.JobSubmitter.maxThreads    = 1
         config.JobSubmitter.pollInterval  = 10
-        config.JobSubmitter.pluginName    = 'CondorGlobusPlugin'
-        config.JobSubmitter.pluginDir     = 'JobSubmitter.Plugins'
-        config.JobSubmitter.submitNode    = os.getenv("HOSTNAME", 'badtest.fnal.gov')
-        config.JobSubmitter.submitScript  = os.path.join(WMCore.WMBase.getTestBase(),
+        config.JobSubmitter.submitScript  = os.path.join(getTestBase(),
                                                          'WMComponent_t/JobSubmitter_t',
                                                          'submit.sh')
         config.JobSubmitter.componentDir  = os.path.join(self.testDir, 'Components')
         config.JobSubmitter.workerThreads = 2
         config.JobSubmitter.jobsPerWorker = 200
-        config.JobSubmitter.inputFile     = os.path.join(WMCore.WMBase.getTestBase(),
-                                                         'WMComponent_t/JobSubmitter_t',
-                                                         'FrameworkJobReport-4540.xml')
-        config.JobSubmitter.deleteJDLFiles = False
-
 
         #JobStateMachine
         config.component_('JobStateMachine')
         config.JobStateMachine.couchurl        = os.getenv('COUCHURL')
         config.JobStateMachine.couchDBName     = "jobsubmitter_t"
-
+        config.JobStateMachine.jobSummaryDBName = 'wmagent_summary_t'
 
         # Needed, because this is a test
         os.makedirs(config.JobSubmitter.componentDir)
 
-
         return config
 
-    def createTestWorkload(self, workloadName = 'Test', emulator = True):
+    def createTestWorkload(self, workloadName = 'Tier1ReReco'):
         """
         _createTestWorkload_
 
         Creates a test workload for us to run on, hold the basic necessities.
         """
 
-        workload = testWorkload("Tier1ReReco")
-        rereco = workload.getTask("ReReco")
-
+        workload = testWorkload(workloadName)
 
         taskMaker = TaskMaker(workload, os.path.join(self.testDir, 'workloadTest'))
         taskMaker.skipSubscription = True
@@ -393,105 +286,40 @@ class JobSubmitterTest(unittest.TestCase):
 
         return workload
 
-
-    def checkJDL(self, config, cacheDir, submitFile, site = None, indexFlag = False, noIndex = False):
-        """
-        _checkJDL_
-
-        Check the basic JDL setup
-        """
-
-        jobs, head = parseJDL(jdlLocation = os.path.join(config.JobSubmitter.submitDir,
-                                                         submitFile))
-
-        batch = 1
-
-        # Check each job entry in the JDL
-        for job in jobs:
-            # Check each key
-            index = int(job.get('+WMAgent_JobID', 0))
-            self.assertTrue(index != 0)
-
-            argValue = index -1
-            if indexFlag:
-                batch    = index - 1
-
-            inputFileString = '%s, %s, %s' % (os.path.join(self.testDir, 'workloadTest/TestWorkload',
-                                                           'TestWorkload-Sandbox.tar.bz2'),
-                                              os.path.join(self.testDir, 'workloadTest/TestWorkload',
-                                                           'PackageCollection_0/batch_%i-0/JobPackage.pkl' % (batch)),
-                                              os.path.join(WMCore.WMInit.getWMBASE(), 'src/python/WMCore',
-                                                           'WMRuntime/Unpacker.py'))
-            if not noIndex:
-                self.assertEqual(job.get('transfer_input_files', None),
-                                 inputFileString)
-            # Arguments use a list starting from 0
-            self.assertEqual(job.get('arguments', None),
-                             'TestWorkload-Sandbox.tar.bz2 %i' % (index))
-
-            if site:
-                self.assertEqual(job.get('+DESIRED_Sites', None), '\"%s\"' % site)
-
-            # Check the priority
-            self.assertEqual(job.get('priority', None), '101')
-
-        # Now handle the head
-        self.assertEqual(head.get('should_transfer_files', None), 'YES')
-        self.assertEqual(head.get('Log', None), 'condor.$(Cluster).$(Process).log')
-        self.assertEqual(head.get('Error', None), 'condor.$(Cluster).$(Process).err')
-        self.assertEqual(head.get('Output', None), 'condor.$(Cluster).$(Process).out')
-        self.assertEqual(head.get('when_to_transfer_output', None), 'ON_EXIT')
-        self.assertEqual(head.get('Executable', None), config.JobSubmitter.submitScript)
-
-        return
-
-
-
-
-    @attr('integration')
     def testA_BasicTest(self):
         """
-        Use the CondorGlobusPlugin to create a very simple test
-        Check to see that all the jobs were submitted
-        Parse and test the JDL files
-        See what condor says
+        Use the MockPlugin to create a simple test
+        Check to see that all the jobs were "submitted",
+        don't care about thresholds
         """
         workloadName = "basicWorkload"
-
-        myThread = threading.currentThread()
-
         workload = self.createTestWorkload()
-
-        config   = self.getConfig()
-
+        config = self.getConfig()
         changeState = ChangeState(config)
 
-        nSubs = 1
-        nJobs = 10
-        cacheDir = os.path.join(self.testDir, 'CacheDir')
+        nSubs = 2
+        nJobs = 20
+        site = 'T2_US_UCSD'
+
+        self.setResourceThresholds(site, pendingSlots = 50, runningSlots = 100, tasks = ['Processing', 'Merge'],
+                                   Processing = {'pendingSlots' : 50, 'runningSlots' : 100},
+                                   Merge = {'pendingSlots' : 50, 'runningSlots' : 100})
 
         jobGroupList = self.createJobGroups(nSubs = nSubs, nJobs = nJobs,
                                             task = workload.getTask("ReReco"),
-                                            workloadSpec = os.path.join(self.testDir,
-                                                                        'workloadTest',
+                                            workloadSpec = os.path.join(self.testDir, 'workloadTest',
                                                                         workloadName),
-                                            site = 'se.T2_US_UCSD')
+                                            site = 'se.%s' % site)
         for group in jobGroupList:
             changeState.propagate(group.jobs, 'created', 'new')
-
 
         # Do pre-submit check
         getJobsAction = self.daoFactory(classname = "Jobs.GetAllJobs")
         result = getJobsAction.execute(state = 'Created', jobType = "Processing")
         self.assertEqual(len(result), nSubs * nJobs)
 
-        nRunning = getCondorRunningJobs(self.user)
-        self.assertEqual(nRunning, 0, "User currently has %i running jobs.  Test will not continue" % (nRunning))
-
-
         jobSubmitter = JobSubmitterPoller(config = config)
         jobSubmitter.algorithm()
-
 
         # Check that jobs are in the right state
         result = getJobsAction.execute(state = 'Created', jobType = "Processing")
@@ -499,334 +327,357 @@ class JobSubmitterTest(unittest.TestCase):
         result = getJobsAction.execute(state = 'Executing', jobType = "Processing")
         self.assertEqual(len(result), nSubs * nJobs)
 
+        # Check assigned locations
+        getLocationAction = self.daoFactory(classname = "Jobs.GetLocation")
+        for jobId in result:
+            loc = getLocationAction.execute(jobid = jobId)
+            self.assertEqual(loc, [['T2_US_UCSD']])
+
+        # Run another cycle, it shouldn't submit anything. There isn't anything to submit
+        jobSubmitter.algorithm()
+        result = getJobsAction.execute(state = 'Created', jobType = "Processing")
+        self.assertEqual(len(result), 0)
+        result = getJobsAction.execute(state = 'Executing', jobType = "Processing")
+        self.assertEqual(len(result), nSubs * nJobs)
+
+        nSubs = 1
+        nJobs = 10
+
+        # Submit another 10 jobs
+        jobGroupList = self.createJobGroups(nSubs = nSubs, nJobs = nJobs,
+                                            task = workload.getTask("ReReco"),
+                                            workloadSpec = os.path.join(self.testDir, 'workloadTest',
+                                                                        workloadName),
+                                            site = 'se.%s' % site,
+                                            taskType = "Merge")
+        for group in jobGroupList:
+            changeState.propagate(group.jobs, 'created', 'new')
+
+        # Check that the jobs are available for submission and run another cycle
+        result = getJobsAction.execute(state = 'Created', jobType = "Merge")
+        self.assertEqual(len(result), nSubs * nJobs)
+        jobSubmitter.algorithm()
+
+        #Check that the last 10 jobs were submitted as well.
+        result = getJobsAction.execute(state = 'Created', jobType = "Merge")
+        self.assertEqual(len(result), 0)
+        result = getJobsAction.execute(state = 'Executing', jobType = "Merge")
+        self.assertEqual(len(result), nSubs * nJobs)
+
+        return
+
+    def testB_thresholdTest(self):
+        """
+        _testB_thresholdTest_
+
+        Check that the threshold management is working,
+        this requires checks on pending/running jobs globally
+        at a site and per task/site
+        """
+        workloadName = "basicWorkload"
+        workload = self.createTestWorkload()
+        config = self.getConfig()
+        changeState = ChangeState(config)
+
+        nSubs = 5
+        nJobs = 10
+        sites = ['T1_US_FNAL']
+
+        for site in sites:
+            self.setResourceThresholds(site, pendingSlots = 50, runningSlots = 200, tasks = ['Processing', 'Merge'],
+                                       Processing = {'pendingSlots' : 45, 'runningSlots' :-1},
+                                       Merge = {'pendingSlots' : 10, 'runningSlots' : 20, 'priority' : 5})
+
+        # Always initialize the submitter after setting the sites, flaky!
+        jobSubmitter = JobSubmitterPoller(config = config)
+
+        jobGroupList = self.createJobGroups(nSubs = nSubs, nJobs = nJobs,
+                                            task = workload.getTask("ReReco"),
+                                            workloadSpec = os.path.join(self.testDir, 'workloadTest',
+                                                                        workloadName),
+                                            site = 'se.%s' % 'T1_US_FNAL')
+        for group in jobGroupList:
+            changeState.propagate(group.jobs, 'created', 'new')
+
+        # Do pre-submit check
+        getJobsAction = self.daoFactory(classname = "Jobs.GetAllJobs")
+        result = getJobsAction.execute(state = 'Created', jobType = "Processing")
+        self.assertEqual(len(result), nSubs * nJobs)
+
+        jobSubmitter.algorithm()
+
+        # Check that jobs are in the right state, 
+        # here we are limited by the pending threshold for the Processing task (45)
+        result = getJobsAction.execute(state = 'Created', jobType = "Processing")
+        self.assertEqual(len(result), 5)
+        result = getJobsAction.execute(state = 'Executing', jobType = "Processing")
+        self.assertEqual(len(result), 45)
 
         # Check assigned locations
         getLocationAction = self.daoFactory(classname = "Jobs.GetLocation")
-        for id in result:
-            loc = getLocationAction.execute(jobid = id)
-            self.assertEqual(loc, [['T2_US_UCSD']])
+        for jobId in result:
+            loc = getLocationAction.execute(jobid = jobId)
+            self.assertEqual(loc, [['T1_US_FNAL']])
 
-
-        # Check on the JDL
-        submitFile = None
-        for file in os.listdir(config.JobSubmitter.submitDir):
-            if re.search('submit', file):
-                submitFile = file
-        self.assertTrue(submitFile != None)
-        self.checkJDL(config = config, cacheDir = cacheDir,
-                      submitFile = submitFile, site = 'T2_US_UCSD')
-
-
-
-        #if os.path.exists('CacheDir'):
-        #    shutil.rmtree('CacheDir')
-        #shutil.copytree(self.testDir, 'CacheDir')
-
-
-        # Check to make sure we have running jobs
-        nRunning = getCondorRunningJobs(self.user)
-        self.assertEqual(nRunning, nJobs * nSubs)
-
-        # This should do nothing
-        jobGroupList = self.createJobGroups(nSubs = nSubs, nJobs = nJobs,
-                                            task = workload.getTask("ReReco"),
-                                            workloadSpec = os.path.join(self.testDir,
-                                                                        'workloadTest',
-                                                                        workloadName),
-                                            site = 'se.T2_US_UCSD')
-        for group in jobGroupList:
-            changeState.propagate(group.jobs, 'created', 'new')
+        # Run another cycle, it shouldn't submit anything. Jobs are still in pending
         jobSubmitter.algorithm()
+        result = getJobsAction.execute(state = 'Created', jobType = "Processing")
+        self.assertEqual(len(result), 5)
+        result = getJobsAction.execute(state = 'Executing', jobType = "Processing")
+        self.assertEqual(len(result), 45)
 
-        # Now clean-up
-        command = ['condor_rm', self.user]
-        pipe = Popen(command, stdout = PIPE, stderr = PIPE, shell = False)
-        pipe.communicate()
-
-        del jobSubmitter
-
-
-        return
-
-
-    @attr('performance')
-    def testB_TimeLongSubmission(self):
-        """
-        _TimeLongSubmission_
-
-        Submit a lot of jobs and test how long it takes for
-        them to actually be submitted
-        """
-
-
-        return
-
-
-        workloadName = "basicWorkload"
-        myThread     = threading.currentThread()
-        workload     = self.createTestWorkload()
-        config       = self.getConfig()
-        changeState  = ChangeState(config)
-
-        nSubs = 5
-        nJobs = 300
-        cacheDir = os.path.join(self.testDir, 'CacheDir')
-
+        # Now put 10 Merge jobs, only 5 can be submitted, there we hit the global pending threshold for the site
+        nSubs = 1
+        nJobs = 10
         jobGroupList = self.createJobGroups(nSubs = nSubs, nJobs = nJobs,
                                             task = workload.getTask("ReReco"),
-                                            workloadSpec = os.path.join(self.testDir,
-                                                                        'workloadTest',
-                                                                        workloadName))
-
+                                            workloadSpec = os.path.join(self.testDir, 'workloadTest',
+                                                                        workloadName),
+                                            site = 'se.%s' % 'T1_US_FNAL',
+                                            taskType = 'Merge')
         for group in jobGroupList:
             changeState.propagate(group.jobs, 'created', 'new')
 
-        nRunning = getCondorRunningJobs(self.user)
-        self.assertEqual(nRunning, 0, "User currently has %i running jobs.  Test will not continue" % (nRunning))
+        jobSubmitter.algorithm()
+        result = getJobsAction.execute(state = 'Created', jobType = "Merge")
+        self.assertEqual(len(result), 5)
+        result = getJobsAction.execute(state = 'Executing', jobType = "Merge")
+        self.assertEqual(len(result), 5)
+        result = getJobsAction.execute(state = 'Created', jobType = "Processing")
+        self.assertEqual(len(result), 5)
+        result = getJobsAction.execute(state = 'Executing', jobType = "Processing")
+        self.assertEqual(len(result), 45)
 
+        # Now let's test running thresholds
+        # The scenario will be setup as follows: Move all current jobs as running
+        # Create 300 Processing jobs and 300 merge jobs
+        # Run 5 polling cycles, moving all pending jobs to running in between
+        # Result is, merge is left at 25 running 0 pending and processing is left at 215 running 0 pending
+        # Processing has 135 jobs in queue and Merge 285
+        # This tests all threshold dynamics including the prioritization of merge over processing
+        nSubs = 1
+        nJobs = 300
+        jobGroupList = self.createJobGroups(nSubs = nSubs, nJobs = nJobs,
+                                            task = workload.getTask("ReReco"),
+                                            workloadSpec = os.path.join(self.testDir, 'workloadTest',
+                                                                        workloadName),
+                                            site = 'se.%s' % 'T1_US_FNAL')
+        jobGroupList.extend(self.createJobGroups(nSubs = nSubs, nJobs = nJobs,
+                                            task = workload.getTask("ReReco"),
+                                            workloadSpec = os.path.join(self.testDir, 'workloadTest',
+                                                                        workloadName),
+                                            site = 'se.%s' % 'T1_US_FNAL',
+                                            taskType = 'Merge'))
+        for group in jobGroupList:
+            changeState.propagate(group.jobs, 'created', 'new')
 
-        jobSubmitter = JobSubmitterPoller(config = config)
+        getRunJobID = self.baDaoFactory(classname = "LoadByWMBSID")
+        setRunJobStatus = self.baDaoFactory(classname = "SetStatus")
 
-        # Actually run it
-        startTime = time.time()
-        cProfile.runctx("jobSubmitter.algorithm()", globals(), locals(), filename = "testStats.stat")
-        #jobSubmitter.algorithm()
-        stopTime  = time.time()
+        for _ in range(5):
+            result = getJobsAction.execute(state = 'Executing')
+            binds = []
+            for jobId in result:
+                binds.append({'id' : jobId, 'retry_count' : 0})
+            runJobIds = getRunJobID.execute(binds)
+            setRunJobStatus.execute([x['id'] for x in runJobIds], 'Running')
+            jobSubmitter.algorithm()
 
-        if os.path.isdir('CacheDir'):
-            shutil.rmtree('CacheDir')
-        shutil.copytree('%s' %self.testDir, os.path.join(os.getcwd(), 'CacheDir'))
-
-
-        # Check to make sure we have running jobs
-        nRunning = getCondorRunningJobs(self.user)
-        self.assertEqual(nRunning, nJobs * nSubs)
-
-
-        # Now clean-up
-        command = ['condor_rm', self.user]
-        pipe = Popen(command, stdout = PIPE, stderr = PIPE, shell = False)
-        pipe.communicate()
-
-
-        print "Job took %f seconds to complete" %(stopTime - startTime)
-
-
-        p = pstats.Stats('testStats.stat')
-        p.sort_stats('cumulative')
-        p.print_stats()
+        result = getJobsAction.execute(state = 'Executing', jobType = 'Processing')
+        self.assertEqual(len(result), 215)
+        result = getJobsAction.execute(state = 'Created', jobType = 'Processing')
+        self.assertEqual(len(result), 135)
+        result = getJobsAction.execute(state = 'Executing', jobType = 'Merge')
+        self.assertEqual(len(result), 25)
+        result = getJobsAction.execute(state = 'Created', jobType = 'Merge')
+        self.assertEqual(len(result), 285)
 
         return
 
-
-    def testD_CreamCETest(self):
+    def testC_prioritization(self):
         """
-        _CreamCETest_
+        _testC_prioritization_
 
-        This is for submitting to Cream CEs.  Don't use it.
+        Check that jobs are prioritized by job type and by oldest workflow
         """
-
-        return
-
-        nRunning = getCondorRunningJobs(self.user)
-        self.assertEqual(nRunning, 0, "User currently has %i running jobs.  Test will not continue" % (nRunning))
-
-
         workloadName = "basicWorkload"
-
-        myThread = threading.currentThread()
-
         workload = self.createTestWorkload()
-
-        config   = self.getConfig()
-        config.JobSubmitter.pluginName    = 'CreamPlugin'
-
+        config = self.getConfig()
         changeState = ChangeState(config)
 
         nSubs = 1
         nJobs = 10
-        cacheDir = os.path.join(self.testDir, 'CacheDir')
+        sites = ['T1_US_FNAL']
 
-        # Add a new site
-        siteName = "creamSite"
-        ceName = "https://cream-1-fzk.gridka.de:8443/ce-cream/services/CREAM2  pbs cmsXS"
-        #ceName = "127.0.0.1"
-        locationAction = self.daoFactory(classname = "Locations.New")
-        pendingSlots  = self.daoFactory(classname = "Locations.SetPendingSlots")
-        locationAction.execute(siteName = siteName, seName = siteName, ceName = ceName)
-        pendingSlots.execute(siteName = siteName, pendingSlots = 1000)
+        for site in sites:
+            self.setResourceThresholds(site, pendingSlots = 10, runningSlots = -1, tasks = ['Processing', 'Merge'],
+                                       Processing = {'pendingSlots' : 50, 'runningSlots' :-1},
+                                       Merge = {'pendingSlots' : 10, 'runningSlots' :-1, 'priority' : 5})
 
-        resourceControl = ResourceControl()
-        resourceControl.insertSite(siteName = siteName, seName = siteName, ceName = ceName)
-        resourceControl.insertThreshold(siteName = siteName, taskType = 'Processing', \
-                                        maxSlots = 10000)
-
+        # Always initialize the submitter after setting the sites, flaky!
+        jobSubmitter = JobSubmitterPoller(config = config)
 
         jobGroupList = self.createJobGroups(nSubs = nSubs, nJobs = nJobs,
                                             task = workload.getTask("ReReco"),
-                                            workloadSpec = os.path.join(self.testDir,
-                                                                        'workloadTest',
+                                            workloadSpec = os.path.join(self.testDir, 'workloadTest',
                                                                         workloadName),
-                                            site = siteName)
+                                            site = 'se.%s' % 'T1_US_FNAL',
+                                            name = 'OldestWorkflow')
+        jobGroupList.extend(self.createJobGroups(nSubs = nSubs, nJobs = nJobs,
+                                            task = workload.getTask("ReReco"),
+                                            workloadSpec = os.path.join(self.testDir, 'workloadTest',
+                                                                        workloadName),
+                                            site = 'se.%s' % 'T1_US_FNAL',
+                                            taskType = 'Merge'))
         for group in jobGroupList:
             changeState.propagate(group.jobs, 'created', 'new')
 
-
-
-        jobSubmitter = JobSubmitterPoller(config = config)
         jobSubmitter.algorithm()
 
-
-        # Check that jobs are in the right state
+        # Merge goes first
         getJobsAction = self.daoFactory(classname = "Jobs.GetAllJobs")
-        result = getJobsAction.execute(state = 'Created', jobType = "Processing")
+        result = getJobsAction.execute(state = 'Created', jobType = "Merge")
         self.assertEqual(len(result), 0)
+        result = getJobsAction.execute(state = 'Executing', jobType = "Merge")
+        self.assertEqual(len(result), 10)
+        result = getJobsAction.execute(state = 'Created', jobType = "Processing")
+        self.assertEqual(len(result), 10)
         result = getJobsAction.execute(state = 'Executing', jobType = "Processing")
-        self.assertEqual(len(result), nSubs * nJobs)
+        self.assertEqual(len(result), 0)
 
+        # Create a newer workflow processing, and after some new jobs for an old workflow
 
-        # Now clean-up
-        command = ['condor_rm', self.user]
-        pipe = Popen(command, stdout = PIPE, stderr = PIPE, shell = False)
-        pipe.communicate()
+        jobGroupList = self.createJobGroups(nSubs = nSubs, nJobs = nJobs,
+                                            task = workload.getTask("ReReco"),
+                                            workloadSpec = os.path.join(self.testDir, 'workloadTest',
+                                                                        workloadName),
+                                            site = 'se.%s' % 'T1_US_FNAL',
+                                            name = 'NewestWorkflow')
 
-        if os.path.exists('CacheDir'):
-            shutil.rmtree('CacheDir')
-        shutil.copytree(self.testDir, 'CacheDir')
+        jobGroupList.extend(self.createJobGroups(nSubs = nSubs, nJobs = nJobs,
+                                    task = workload.getTask("ReReco"),
+                                    workloadSpec = os.path.join(self.testDir, 'workloadTest',
+                                                                workloadName),
+                                    site = 'se.%s' % 'T1_US_FNAL',
+                                    name = 'OldestWorkflow'))
+
+        for group in jobGroupList:
+            changeState.propagate(group.jobs, 'created', 'new')
+
+        # Move pending jobs to running
+
+        getRunJobID = self.baDaoFactory(classname = "LoadByWMBSID")
+        setRunJobStatus = self.baDaoFactory(classname = "SetStatus")
+
+        for idx in range(2):
+            result = getJobsAction.execute(state = 'Executing')
+            binds = []
+            for jobId in result:
+                binds.append({'id' : jobId, 'retry_count' : 0})
+            runJobIds = getRunJobID.execute(binds)
+            setRunJobStatus.execute([x['id'] for x in runJobIds], 'Running')
+
+            # Run again on created workflows
+            jobSubmitter.algorithm()
+
+            result = getJobsAction.execute(state = 'Created', jobType = "Merge")
+            self.assertEqual(len(result), 0)
+            result = getJobsAction.execute(state = 'Executing', jobType = "Merge")
+            self.assertEqual(len(result), 10)
+            result = getJobsAction.execute(state = 'Created', jobType = "Processing")
+            self.assertEqual(len(result), 30 - (idx + 1) * 10)
+            result = getJobsAction.execute(state = 'Executing', jobType = "Processing")
+            self.assertEqual(len(result), (idx + 1) * 10)
+
+            # Check that older workflow goes first even with newer jobs
+            getWorkflowAction = self.daoFactory(classname = "Jobs.GetWorkflowTask")
+            workflows = getWorkflowAction.execute(result)
+            for workflow in workflows:
+                self.assertEqual(workflow['name'], 'OldestWorkflow')
 
         return
 
-    @attr('integration')
-    def testE_WhiteListBlackList(self):
+    def testD_WhiteListBlackList(self):
         """
-        _WhiteListBlackList_
+        _testD_WhiteListBlackList_
 
         Test the whitelist/blacklist implementation
         Trust the jobCreator to get this in the job right
         """
-        nRunning = getCondorRunningJobs(self.user)
-        self.assertEqual(nRunning, 0, "User currently has %i running jobs.  Test will not continue" % (nRunning))
-
         workloadName = "basicWorkload"
-        myThread     = threading.currentThread()
-        workload     = self.createTestWorkload()
-        config       = self.getConfig()
-        changeState  = ChangeState(config)
+        workload = self.createTestWorkload()
+        config = self.getConfig()
+        changeState = ChangeState(config)
 
         nSubs = 2
         nJobs = 10
-        cacheDir = os.path.join(self.testDir, 'CacheDir')
+
+        sites = ['T2_US_Florida', 'T2_TW_Taiwan', 'T2_CH_CERN', 'T3_CO_Uniandes']
+
+        for site in sites:
+            self.setResourceThresholds(site, pendingSlots = 1000, runningSlots = -1, tasks = ['Processing', 'Merge'],
+                                       Processing = {'pendingSlots' : 5000, 'runningSlots' :-1},
+                                       Merge = {'pendingSlots' : 1000, 'runningSlots' :-1, 'priority' : 5})
 
         jobGroupList = self.createJobGroups(nSubs = nSubs, nJobs = nJobs,
+                                            site = 'se.%s' % sites[-1],
                                             task = workload.getTask("ReReco"),
                                             workloadSpec = os.path.join(self.testDir,
                                                                         'workloadTest',
                                                                         workloadName),
-                                            bl = ['T2_US_Florida', 'T2_TW_Taiwan', 'T1_CH_CERN'])
+                                            bl = sites[:-1])
 
         for group in jobGroupList:
             changeState.propagate(group.jobs, 'created', 'new')
-
-
-
 
         jobSubmitter = JobSubmitterPoller(config = config)
 
         # Actually run it
         jobSubmitter.algorithm()
-
-        if os.path.isdir('CacheDir'):
-            shutil.rmtree('CacheDir')
-        shutil.copytree('%s' %self.testDir, os.path.join(os.getcwd(), 'CacheDir'))
-
-
-        # Check to make sure we have running jobs
-        nRunning = getCondorRunningJobs(self.user)
-        self.assertEqual(nRunning, nJobs * nSubs)
 
         getJobsAction = self.daoFactory(classname = "Jobs.GetAllJobs")
         result = getJobsAction.execute(state = 'Executing', jobType = "Processing")
         self.assertEqual(len(result), nSubs * nJobs)
 
-        # All jobs should be at UCSD
-        submitFile = None
-        for file in os.listdir(config.JobSubmitter.submitDir):
-            if re.search('submit', file):
-                submitFile = file
-        self.assertTrue(submitFile != None)
-        #submitFile = os.listdir(config.JobSubmitter.submitDir)[0]
-        self.checkJDL(config = config, cacheDir = cacheDir,
-                      submitFile = submitFile, site = 'T2_US_UCSD')
-
-
-        # Now clean-up
-        command = ['condor_rm', self.user]
-        pipe = Popen(command, stdout = PIPE, stderr = PIPE, shell = False)
-        pipe.communicate()
-
-
-
-
-
+        # All jobs should be at T3_CO_Uniandes
+        # Check assigned locations
+        getLocationAction = self.daoFactory(classname = "Jobs.GetLocation")
+        locationDict = getLocationAction.execute([{'jobid' : x} for x in result])
+        for entry in locationDict:
+            loc = entry['site_name']
+            self.assertEqual(loc, 'T3_CO_Uniandes')
 
         # Run again and test the whiteList
         jobGroupList = self.createJobGroups(nSubs = nSubs, nJobs = nJobs,
                                             task = workload.getTask("ReReco"),
+                                            site = 'se.%s' % 'T2_CH_CERN',
                                             workloadSpec = os.path.join(self.testDir,
                                                                         'workloadTest',
                                                                         workloadName),
-                                            wl = ['T2_US_UCSD'])
+                                            wl = ['T2_CH_CERN'])
 
         for group in jobGroupList:
             changeState.propagate(group.jobs, 'created', 'new')
 
-        nRunning = getCondorRunningJobs(self.user)
-        self.assertEqual(nRunning, 0, "User currently has %i running jobs.  Test will not continue" % (nRunning))
-
-
-        jobSubmitter = JobSubmitterPoller(config = config)
-
-        # Actually run it
+        # Run it
         jobSubmitter.algorithm()
-
-        if os.path.isdir('CacheDir'):
-            shutil.rmtree('CacheDir')
-        shutil.copytree('%s' %self.testDir, os.path.join(os.getcwd(), 'CacheDir'))
-
-
-        # Check to make sure we have running jobs
-        nRunning = getCondorRunningJobs(self.user)
-        self.assertEqual(nRunning, nJobs * nSubs)
 
         # You'll have jobs from the previous run still in the database
         result = getJobsAction.execute(state = 'Executing', jobType = "Processing")
         self.assertEqual(len(result), nSubs * nJobs * 2)
 
-        # All jobs should be at UCSD
-        submitFile = None
-        for file in os.listdir(config.JobSubmitter.submitDir):
-            if re.search('submit', file):
-                submitFile = file
-        self.assertTrue(submitFile != None)
-        self.checkJDL(config = config, cacheDir = cacheDir,
-                      submitFile = submitFile, site = 'T2_US_UCSD', noIndex = True)
-
-
-        # Now clean-up
-        command = ['condor_rm', self.user]
-        pipe = Popen(command, stdout = PIPE, stderr = PIPE, shell = False)
-        pipe.communicate()
-
-
-
-
-
+        # All jobs should be at CERN or Uniandes
+        locationDict = getLocationAction.execute([{'jobid' : x} for x in result])
+        for entry in locationDict[nSubs * nJobs:]:
+            loc = entry['site_name']
+            self.assertEqual(loc, 'T2_CH_CERN')
 
         # Run again with an invalid whitelist
-        # NOTE: After this point, the original two sets of jobs will be executing
+        # After this point, the original two sets of jobs will be executing
         # The rest of the jobs should move to submitFailed
         jobGroupList = self.createJobGroups(nSubs = nSubs, nJobs = nJobs,
                                             task = workload.getTask("ReReco"),
+                                            site = 'se.%s' % 'T2_CH_CERN',
                                             workloadSpec = os.path.join(self.testDir,
                                                                         'workloadTest',
                                                                         workloadName),
@@ -835,19 +686,7 @@ class JobSubmitterTest(unittest.TestCase):
         for group in jobGroupList:
             changeState.propagate(group.jobs, 'created', 'new')
 
-        nRunning = getCondorRunningJobs(self.user)
-        self.assertEqual(nRunning, 0, "User currently has %i running jobs.  Test will not continue" % (nRunning))
-
-
-        jobSubmitter = JobSubmitterPoller(config = config)
-
-        # Actually run it
         jobSubmitter.algorithm()
-
-
-        # Check to make sure we have running jobs
-        #nRunning = getCondorRunningJobs(self.user)
-        #self.assertEqual(nRunning, 0)
 
         # Jobs should be gone
         getJobsAction = self.daoFactory(classname = "Jobs.GetAllJobs")
@@ -855,217 +694,188 @@ class JobSubmitterTest(unittest.TestCase):
         self.assertEqual(len(result), nSubs * nJobs * 2)
         result = getJobsAction.execute(state = 'SubmitFailed', jobType = "Processing")
         self.assertEqual(len(result), nSubs * nJobs)
-
-
-
-        # Now clean-up
-        command = ['condor_rm', self.user]
-        pipe = Popen(command, stdout = PIPE, stderr = PIPE, shell = False)
-        pipe.communicate()
-
-
-
-
-
 
         # Run again with all sites blacklisted
         jobGroupList = self.createJobGroups(nSubs = nSubs, nJobs = nJobs,
                                             task = workload.getTask("ReReco"),
+                                            site = ['se.%s' % x for x in sites],
                                             workloadSpec = os.path.join(self.testDir,
                                                                         'workloadTest',
                                                                         workloadName),
-                                            bl = self.sites)
+                                            bl = sites)
 
         for group in jobGroupList:
             changeState.propagate(group.jobs, 'created', 'new')
 
-        nRunning = getCondorRunningJobs(self.user)
-        self.assertEqual(nRunning, 0, "User currently has %i running jobs.  Test will not continue" % (nRunning))
-
-
-        jobSubmitter = JobSubmitterPoller(config = config)
-
-        # Actually run it
         jobSubmitter.algorithm()
 
-
-        # Check to make sure we have running jobs
-        nRunning = getCondorRunningJobs(self.user)
-        self.assertEqual(nRunning, 0)
-
-        # Jobs should be gone
+        # Jobs should go to submit failed
         getJobsAction = self.daoFactory(classname = "Jobs.GetAllJobs")
         result = getJobsAction.execute(state = 'Executing', jobType = "Processing")
         self.assertEqual(len(result), nSubs * nJobs * 2)
         result = getJobsAction.execute(state = 'SubmitFailed', jobType = "Processing")
         self.assertEqual(len(result), nSubs * nJobs * 2)
 
-
-
-        # Now clean-up
-        command = ['condor_rm', self.user]
-        pipe = Popen(command, stdout = PIPE, stderr = PIPE, shell = False)
-        pipe.communicate()
-
-        del jobSubmitter
         return
 
-
-    @attr('integration')
-    def testF_OverloadTest(self):
+    def testE_SiteModesTest(self):
         """
-        _OverloadTest_
+        _testE_SiteModesTest_
 
-        Test and see what happens if you put in more jobs
-        Then the sites can handle
+        Test the behavior of the submitter in response to the different
+        states of the sites
         """
-
-        resourceControl = ResourceControl()
-        for site in self.sites:
-            resourceControl.insertThreshold(siteName = site, taskType = 'Silly', \
-                                            maxSlots = 1)
-
-
-
-        nRunning = getCondorRunningJobs(self.user)
-        self.assertEqual(nRunning, 0, "User currently has %i running jobs.  Test will not continue" % (nRunning))
-
         workloadName = "basicWorkload"
-        myThread     = threading.currentThread()
-        workload     = self.createTestWorkload()
-        config       = self.getConfig()
-        changeState  = ChangeState(config)
+        workload = self.createTestWorkload()
+        config = self.getConfig()
+        changeState = ChangeState(config)
 
-        nSubs = 2
-        nJobs = 10
-        cacheDir = os.path.join(self.testDir, 'CacheDir')
+        nSubs = 1
+        nJobs = 20
 
+        sites = ['T2_US_Florida', 'T2_TW_Taiwan', 'T3_CO_Uniandes', 'T1_US_FNAL']
+
+        for site in sites:
+            self.setResourceThresholds(site, pendingSlots = 10, runningSlots = -1, tasks = ['Processing', 'Merge'],
+                                       Processing = {'pendingSlots' : 10, 'runningSlots' :-1},
+                                       Merge = {'pendingSlots' : 10, 'runningSlots' :-1, 'priority' : 5})
+
+        myResourceControl = ResourceControl()
+        myResourceControl.changeSiteState('T2_US_Florida', 'Draining')
+
+        # First test that we prefer Normal over drain, and T1 over T2/T3
         jobGroupList = self.createJobGroups(nSubs = nSubs, nJobs = nJobs,
+                                            site = ['se.%s' % x for x in sites],
                                             task = workload.getTask("ReReco"),
                                             workloadSpec = os.path.join(self.testDir,
                                                                         'workloadTest',
-                                                                        workloadName),
-                                            type = 'Silly')
+                                                                        workloadName))
 
         for group in jobGroupList:
             changeState.propagate(group.jobs, 'created', 'new')
-
-
-
 
         jobSubmitter = JobSubmitterPoller(config = config)
 
         # Actually run it
         jobSubmitter.algorithm()
 
-        # Should be one job for each site
-        nSites = len(self.sites)
-        nRunning = getCondorRunningJobs(self.user)
-        self.assertEqual(nRunning, nSites)
-
-
         getJobsAction = self.daoFactory(classname = "Jobs.GetAllJobs")
-        result = getJobsAction.execute(state = 'Executing', jobType = "Silly")
-        self.assertEqual(len(result), nSites)
-        result = getJobsAction.execute(state = 'Created', jobType = "Silly")
-        self.assertEqual(len(result), nJobs*nSubs - nSites)
+        result = getJobsAction.execute(state = 'Executing', jobType = "Processing")
+        self.assertEqual(len(result), nSubs * nJobs)
 
+        # All jobs should be at either FNAL or Taiwan
+        # Check assigned locations
+        getLocationAction = self.daoFactory(classname = "Jobs.GetLocation")
+        locationDict = getLocationAction.execute([{'jobid' : x} for x in result])
+        for entry in locationDict:
+            loc = entry['site_name']
+            self.assertNotEqual(loc, 'T3_CO_Uniandes')
+            self.assertNotEqual(loc, 'T2_US_Florida')
 
-        # Now clean-up
-        command = ['condor_rm', self.user]
-        pipe = Popen(command, stdout = PIPE, stderr = PIPE, shell = False)
-        pipe.communicate()
-
-        del jobSubmitter
-
-        return
-
-
-    @attr('integration')
-    def testG_IndexErrorTest(self):
-        """
-        _IndexErrorTest_
-
-        Check to see you get proper indexes for the jobPackages
-        if you have more jobs then you normally run at once.
-        """
-        workloadName = "basicWorkload"
-
-        myThread = threading.currentThread()
-
-        workload = self.createTestWorkload()
-
-        config   = self.getConfig()
-        config.JobSubmitter.jobsPerWorker  = 1
-        config.JobSubmitter.collectionSize = 1
-
-        changeState = ChangeState(config)
-
-        nSubs = 1
-        nJobs = 10
-        cacheDir = os.path.join(self.testDir, 'CacheDir')
+        # Now set everything to down, check we don't submit anything
+        for site in sites:
+            myResourceControl.changeSiteState(site, 'Down')
 
         jobGroupList = self.createJobGroups(nSubs = nSubs, nJobs = nJobs,
+                                            site = ['se.%s' % x for x in sites],
+                                            task = workload.getTask("ReReco"),
+                                            workloadSpec = os.path.join(self.testDir,
+                                                                        'workloadTest',
+                                                                        workloadName))
+
+        for group in jobGroupList:
+            changeState.propagate(group.jobs, 'created', 'new')
+
+        jobSubmitter.algorithm()
+
+        # Nothing is submitted despite the empty slots at Uniandes and Florida
+        result = getJobsAction.execute(state = 'Executing', jobType = "Processing")
+        self.assertEqual(len(result), nSubs * nJobs)
+
+        # Now set everything to Finalizing, and create Merge jobs. Those should the be the ones
+        # submitted
+
+        for site in sites:
+            myResourceControl.changeSiteState(site, 'Finalizing')
+
+        nSubsMerge = 1
+        nJobsMerge = 5
+
+        jobGroupList = self.createJobGroups(nSubs = nSubsMerge, nJobs = nJobsMerge,
+                                            site = ['se.%s' % x for x in sites],
                                             task = workload.getTask("ReReco"),
                                             workloadSpec = os.path.join(self.testDir,
                                                                         'workloadTest',
                                                                         workloadName),
-                                            site = 'se.T2_US_UCSD')
+                                            taskType = 'Merge')
+
         for group in jobGroupList:
             changeState.propagate(group.jobs, 'created', 'new')
 
-
-        # Do pre-submit check
-        getJobsAction = self.daoFactory(classname = "Jobs.GetAllJobs")
-        result = getJobsAction.execute(state = 'Created', jobType = "Processing")
-        self.assertEqual(len(result), nSubs * nJobs)
-
-        nRunning = getCondorRunningJobs(self.user)
-        self.assertEqual(nRunning, 0, "User currently has %i running jobs.  Test will not continue" % (nRunning))
-
-
-        jobSubmitter = JobSubmitterPoller(config = config)
         jobSubmitter.algorithm()
 
-
-        if os.path.exists('CacheDir'):
-            shutil.rmtree('CacheDir')
-        shutil.copytree(self.testDir, 'CacheDir')
-
-
-        # Check that jobs are in the right state
-        result = getJobsAction.execute(state = 'Created', jobType = "Processing")
-        self.assertEqual(len(result), 0)
-        result = getJobsAction.execute(state = 'Executing', jobType = "Processing")
+        result = getJobsAction.execute(state = 'Executing', jobType = 'Merge')
+        self.assertEqual(len(result), nSubsMerge * nJobsMerge)
+        result = getJobsAction.execute(state = 'Executing', jobType = 'Processing')
         self.assertEqual(len(result), nSubs * nJobs)
 
-
-        # Check on the JDL
-        submitFile = None
-        for file in os.listdir(config.JobSubmitter.submitDir):
-            if re.search('submit', file):
-                submitFile = file
-        self.assertTrue(submitFile != None)
-        self.checkJDL(config = config, cacheDir = cacheDir,
-                      submitFile = submitFile, site = 'T2_US_UCSD', indexFlag = True)
-
-
-
-        # Check to make sure we have running jobs
-        nRunning = getCondorRunningJobs(self.user)
-        self.assertEqual(nRunning, nJobs * nSubs)
-
-
-
-
-        # Now clean-up
-        command = ['condor_rm', self.user]
-        pipe = Popen(command, stdout = PIPE, stderr = PIPE, shell = False)
-        pipe.communicate()
-
-        del jobSubmitter
         return
 
+    @attr('performance')
+    def testF_PollerProfileTest(self):
+        """
+        _testF_PollerProfileTest_
+
+        Submit a lot of jobs and test how long it takes for
+        them to actually be submitted
+        """
+
+        workloadName = "basicWorkload"
+        workload = self.createTestWorkload()
+        config = self.getConfig()
+        changeState = ChangeState(config)
+
+        nSubs = 100
+        nJobs = 100
+        sites = ['T1_US_FNAL']
+
+        for site in sites:
+            self.setResourceThresholds(site, pendingSlots = 20000, runningSlots = -1, tasks = ['Processing', 'Merge'],
+                                       Processing = {'pendingSlots' : 10000, 'runningSlots' :-1},
+                                       Merge = {'pendingSlots' : 10000, 'runningSlots' :-1, 'priority' : 5})
+
+        # Always initialize the submitter after setting the sites, flaky!
+        jobSubmitter = JobSubmitterPoller(config = config)
+
+        jobGroupList = self.createJobGroups(nSubs = nSubs, nJobs = nJobs,
+                                            task = workload.getTask("ReReco"),
+                                            workloadSpec = os.path.join(self.testDir, 'workloadTest',
+                                                                        workloadName),
+                                            site = 'se.%s' % 'T1_US_FNAL')
+
+        jobGroupList.extend(self.createJobGroups(nSubs = nSubs, nJobs = nJobs,
+                                            task = workload.getTask("ReReco"),
+                                            workloadSpec = os.path.join(self.testDir, 'workloadTest',
+                                                                        workloadName),
+                                            site = 'se.%s' % 'T1_US_FNAL',
+                                            taskType = 'Merge'))
+
+        for group in jobGroupList:
+            changeState.propagate(group.jobs, 'created', 'new')
+
+        # Actually run it
+        startTime = time.time()
+        cProfile.runctx("jobSubmitter.algorithm()", globals(), locals(), filename = "testStats.stat")
+        stopTime = time.time()
+
+
+        print "Job took %f seconds to complete" % (stopTime - startTime)
+
+        p = pstats.Stats('testStats.stat')
+        p.sort_stats('cumulative')
+        p.print_stats()
+
+        return
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/WMCore_t/ResourceControl_t/ResourceControl_t.py
+++ b/test/python/WMCore_t/ResourceControl_t/ResourceControl_t.py
@@ -79,11 +79,11 @@ class ResourceControlTest(unittest.TestCase):
         myResourceControl.insertSite("testSite1", 10, 20, "testSE1", "testCE1")
         myResourceControl.insertSite("testSite2", 100, 200, "testSE2", "testCE2")
 
-        myResourceControl.insertThreshold("testSite1", "Processing", 20)
-        myResourceControl.insertThreshold("testSite1", "Merge", 200)
-        myResourceControl.insertThreshold("testSite1", "Merge", 250)
-        myResourceControl.insertThreshold("testSite2", "Processing", 50)
-        myResourceControl.insertThreshold("testSite2", "Merge", 135)
+        myResourceControl.insertThreshold("testSite1", "Processing", 20, 10)
+        myResourceControl.insertThreshold("testSite1", "Merge", 200, 100)
+        myResourceControl.insertThreshold("testSite1", "Merge", 250, 150)
+        myResourceControl.insertThreshold("testSite2", "Processing", 50, 30)
+        myResourceControl.insertThreshold("testSite2", "Merge", 135, 100)
 
         createThresholds =  myResourceControl.listThresholdsForCreate()
 
@@ -133,70 +133,94 @@ class ResourceControlTest(unittest.TestCase):
             if threshold["task_type"] == "Merge":
                 mergeThreshold1 = threshold
             elif threshold["task_type"] == "Processing":
-                procThreshold1  = threshold
+                procThreshold1 = threshold
         for threshold in site2Thresholds:
             if threshold["task_type"] == "Merge":
                 mergeThreshold2 = threshold
             elif threshold["task_type"] == "Processing":
-                procThreshold2  = threshold
+                procThreshold2 = threshold
 
-        self.assertEqual( len(site1Thresholds), 2,
-                          "Error: Wrong number of task types." )
+        self.assertEqual(len(site1Thresholds), 2,
+                          "Error: Wrong number of task types.")
 
-        self.assertEqual( len(site2Thresholds), 2,
-                          "Error: Wrong number of task types." )
+        self.assertEqual(len(site2Thresholds), 2,
+                          "Error: Wrong number of task types.")
 
-        self.assertNotEqual( procThreshold1,  None )
-        self.assertNotEqual( procThreshold2,  None )
-        self.assertNotEqual( mergeThreshold1, None )
-        self.assertNotEqual( mergeThreshold2, None )
+        self.assertNotEqual(procThreshold1, None)
+        self.assertNotEqual(procThreshold2, None)
+        self.assertNotEqual(mergeThreshold1, None)
+        self.assertNotEqual(mergeThreshold2, None)
 
-        self.assertEqual( site1Info["total_pending_slots"], 10,
-                          "Error: Site thresholds wrong" )
-
-        self.assertEqual( site1Info["total_running_slots"], 20,
-                          "Error: Site thresholds wrong" )
-
-        self.assertEqual( site1Info["total_running_jobs"], 0,
-                          "Error: Site thresholds wrong" )
-
-        self.assertEqual( site1Info["total_pending_jobs"], 0,
-                          "Error: Site thresholds wrong" )
-
-        self.assertEqual( procThreshold1["task_running_jobs"], 0,
-                          "Error: Site thresholds wrong" )
-
-        self.assertEqual( procThreshold1["max_slots"], 20,
-                          "Error: Site thresholds wrong" )
-
-        self.assertEqual( mergeThreshold1["task_running_jobs"], 0,
-                          "Error: Site thresholds wrong" )
-
-        self.assertEqual( mergeThreshold1["max_slots"], 250,
-                          "Error: Site thresholds wrong" )
-
-        self.assertEqual( site2Info["total_pending_slots"], 100,
+        self.assertEqual(site1Info["total_pending_slots"], 10,
                           "Error: Site thresholds wrong")
 
-        self.assertEqual( site2Info["total_running_slots"], 200,
+        self.assertEqual(site1Info["total_running_slots"], 20,
                           "Error: Site thresholds wrong")
 
-        self.assertEqual( site2Info["total_running_jobs"], 0,
+        self.assertEqual(site1Info["total_running_jobs"], 0,
                           "Error: Site thresholds wrong")
 
-        self.assertEqual( site2Info["total_pending_jobs"], 0,
+        self.assertEqual(site1Info["total_pending_jobs"], 0,
                           "Error: Site thresholds wrong")
 
-        self.assertEqual( procThreshold2["task_running_jobs"], 0,
-                          "Error: Site thresholds wrong" )
-
-        self.assertEqual( procThreshold2["max_slots"], 50,
+        self.assertEqual(procThreshold1["task_running_jobs"], 0,
                           "Error: Site thresholds wrong")
 
-        self.assertEqual( mergeThreshold2["task_running_jobs"], 0,
+        self.assertEqual(procThreshold1["task_pending_jobs"], 0,
                           "Error: Site thresholds wrong")
 
-        self.assertEqual( mergeThreshold2["max_slots"], 135,
+        self.assertEqual(procThreshold1["max_slots"], 20,
+                          "Error: Site thresholds wrong")
+
+        self.assertEqual(procThreshold1["pending_slots"], 10,
+                          "Error: Site thresholds wrong")
+
+        self.assertEqual(mergeThreshold1["task_running_jobs"], 0,
+                          "Error: Site thresholds wrong")
+
+        self.assertEqual(mergeThreshold1["task_pending_jobs"], 0,
+                          "Error: Site thresholds wrong")
+
+        self.assertEqual(mergeThreshold1["max_slots"], 250,
+                          "Error: Site thresholds wrong")
+
+        self.assertEqual(mergeThreshold1["pending_slots"], 150,
+                          "Error: Site thresholds wrong")
+
+        self.assertEqual(site2Info["total_pending_slots"], 100,
+                          "Error: Site thresholds wrong")
+
+        self.assertEqual(site2Info["total_running_slots"], 200,
+                          "Error: Site thresholds wrong")
+
+        self.assertEqual(site2Info["total_running_jobs"], 0,
+                          "Error: Site thresholds wrong")
+
+        self.assertEqual(site2Info["total_pending_jobs"], 0,
+                          "Error: Site thresholds wrong")
+
+        self.assertEqual(procThreshold2["task_running_jobs"], 0,
+                          "Error: Site thresholds wrong")
+
+        self.assertEqual(procThreshold2["task_pending_jobs"], 0,
+                          "Error: Site thresholds wrong")
+
+        self.assertEqual(procThreshold2["max_slots"], 50,
+                          "Error: Site thresholds wrong")
+
+        self.assertEqual(procThreshold2["pending_slots"], 30,
+                          "Error: Site thresholds wrong")
+
+        self.assertEqual(mergeThreshold2["task_running_jobs"], 0,
+                          "Error: Site thresholds wrong")
+
+        self.assertEqual(mergeThreshold2["task_pending_jobs"], 0,
+                          "Error: Site thresholds wrong")
+
+        self.assertEqual(mergeThreshold2["max_slots"], 135,
+                          "Error: Site thresholds wrong")
+
+        self.assertEqual(mergeThreshold2["pending_slots"], 100,
                           "Error: Site thresholds wrong")
 
 
@@ -211,10 +235,10 @@ class ResourceControlTest(unittest.TestCase):
         myResourceControl.insertSite("testSite1", 10, 20, "testSE1", "testCE1", "T1_US_FNAL", "LsfPlugin")
         myResourceControl.insertSite("testSite2", 20, 40, "testSE2", "testCE2")
 
-        myResourceControl.insertThreshold("testSite1", "Processing", 20)
-        myResourceControl.insertThreshold("testSite1", "Merge", 200)
-        myResourceControl.insertThreshold("testSite2", "Processing", 50)
-        myResourceControl.insertThreshold("testSite2", "Merge", 135)
+        myResourceControl.insertThreshold("testSite1", "Processing", 20, 10)
+        myResourceControl.insertThreshold("testSite1", "Merge", 200, 100)
+        myResourceControl.insertThreshold("testSite2", "Processing", 50, 25)
+        myResourceControl.insertThreshold("testSite2", "Merge", 135, 65)
 
         testWorkflow = Workflow(spec = makeUUID(), owner = "Steve",
                                 name = makeUUID(), task = "Test")
@@ -394,11 +418,19 @@ class ResourceControlTest(unittest.TestCase):
 
         self.assertEqual(mergeThreshold1["task_running_jobs"], 0,
                          "Error: Wrong number of task running jobs for submit thresholds.")
+        self.assertEqual(mergeThreshold1["task_pending_jobs"], 0,
+                         "Error: Wrong number of task running jobs for submit thresholds.")
         self.assertEqual(procThreshold1["task_running_jobs"], 1,
+                         "Error: Wrong number of task running jobs for submit thresholds.")
+        self.assertEqual(procThreshold1["task_pending_jobs"], 1,
                          "Error: Wrong number of task running jobs for submit thresholds.")
         self.assertEqual(mergeThreshold2["task_running_jobs"], 0,
                          "Error: Wrong number of task running jobs for submit thresholds.")
+        self.assertEqual(mergeThreshold2["task_pending_jobs"], 0,
+                         "Error: Wrong number of task running jobs for submit thresholds.")
         self.assertEqual(procThreshold2["task_running_jobs"], 0,
+                         "Error: Wrong number of task running jobs for submit thresholds.")
+        self.assertEqual(procThreshold2["task_pending_jobs"], 0,
                          "Error: Wrong number of task running jobs for submit thresholds.")
 
         return
@@ -479,8 +511,8 @@ class ResourceControlTest(unittest.TestCase):
 
         myResourceControl = ResourceControl()
         myResourceControl.insertSite("testSite1", 20, 40, "testSE1", "testCE1")
-        myResourceControl.insertThreshold("testSite1", "Processing", 10)
-        myResourceControl.insertThreshold("testSite1", "Merge", 5)
+        myResourceControl.insertThreshold("testSite1", "Processing", 10, 8)
+        myResourceControl.insertThreshold("testSite1", "Merge", 5, 3)
 
         result   = myResourceControl.thresholdBySite(siteName = "testSite1")
         procInfo = {}
@@ -493,9 +525,11 @@ class ResourceControlTest(unittest.TestCase):
         self.assertEqual(procInfo.get('pending_slots', None), 20)
         self.assertEqual(procInfo.get('running_slots', None), 40)
         self.assertEqual(procInfo.get('max_slots', None), 10)
+        self.assertEqual(procInfo.get('task_pending_slots', None), 8)
         self.assertEqual(mergInfo.get('pending_slots', None), 20)
         self.assertEqual(mergInfo.get('running_slots', None), 40)
         self.assertEqual(mergInfo.get('max_slots', None), 5)
+        self.assertEqual(mergInfo.get('task_pending_slots', None), 3)
 
         return
 
@@ -509,8 +543,8 @@ class ResourceControlTest(unittest.TestCase):
 
         myResourceControl = ResourceControl()
         myResourceControl.insertSite("testSite1", 20, 40, "testSE1", "testCE1")
-        myResourceControl.insertThreshold("testSite1", "Processing", 10, priority = 1)
-        myResourceControl.insertThreshold("testSite1", "Merge", 5, priority = 2)
+        myResourceControl.insertThreshold("testSite1", "Processing", 10, 8, priority = 1)
+        myResourceControl.insertThreshold("testSite1", "Merge", 5, 3, priority = 2)
 
         result = myResourceControl.listThresholdsForSubmit()
 
@@ -518,8 +552,8 @@ class ResourceControlTest(unittest.TestCase):
         self.assertEqual(result['testSite1']['thresholds'][1]['task_type'], 'Processing')
 
 
-        myResourceControl.insertThreshold("testSite1", "Processing", 10, priority = 2)
-        myResourceControl.insertThreshold("testSite1", "Merge", 5, priority = 1)
+        myResourceControl.insertThreshold("testSite1", "Processing", 10, 8, priority = 2)
+        myResourceControl.insertThreshold("testSite1", "Merge", 5, 3, priority = 1)
 
         # Should now be in reverse order
         result = myResourceControl.listThresholdsForSubmit()
@@ -527,8 +561,8 @@ class ResourceControlTest(unittest.TestCase):
         self.assertEqual(result['testSite1']['thresholds'][0]['task_type'], 'Processing')
 
         myResourceControl.insertSite("testSite2", 20, 40, "testSE2", "testCE2")
-        myResourceControl.insertThreshold("testSite2", "Processing", 10, priority = 1)
-        myResourceControl.insertThreshold("testSite2", "Merge", 5, priority = 2)
+        myResourceControl.insertThreshold("testSite2", "Processing", 10, 8, priority = 1)
+        myResourceControl.insertThreshold("testSite2", "Merge", 5, 3, priority = 2)
 
         # Should be in proper order for site 2
         result = myResourceControl.listThresholdsForSubmit()
@@ -539,7 +573,7 @@ class ResourceControlTest(unittest.TestCase):
         self.assertEqual(result['testSite1']['thresholds'][1]['task_type'], 'Merge')
         self.assertEqual(result['testSite1']['thresholds'][0]['task_type'], 'Processing')
 
-        myResourceControl.insertThreshold("testSite2", "Merge", 20)
+        myResourceControl.insertThreshold("testSite2", "Merge", 20, 10)
         result = myResourceControl.listThresholdsForSubmit()
         self.assertEqual(result['testSite2']['thresholds'][0]['priority'], 2)
 
@@ -555,7 +589,7 @@ class ResourceControlTest(unittest.TestCase):
         """
         myResourceControl = ResourceControl()
         myResourceControl.insertSite("testSite1", 20, 40, "testSE1", "testCE1")
-        myResourceControl.insertThreshold("testSite1", "Processing", 10, priority = 1)
+        myResourceControl.insertThreshold("testSite1", "Processing", 10, 5, priority = 1)
 
         result = myResourceControl.listThresholdsForCreate()
         self.assertEqual(result['testSite1']['state'], 'Normal', 'Error: Wrong site state')
@@ -631,8 +665,8 @@ class ResourceControlTest(unittest.TestCase):
         Depending on the WMCore.Services.SiteDB interface
         """
         myResourceControl = ResourceControl()
-        taskList = [{'taskType': 'Processing', 'maxSlots': 100, 'priority': 1},
-                    {'taskType': 'Merge', 'maxSlots': 50, 'priority': 2}]
+        taskList = [{'taskType': 'Processing', 'maxSlots': 100, 'pendingSlots' : 80, 'priority': 1},
+                    {'taskType': 'Merge', 'maxSlots': 50, 'pendingSlots' : 30, 'priority': 2}]
 
         myResourceControl.insertAllSEs(siteName = 'test', pendingSlots = 200,
                                        runningSlots = 400,
@@ -649,9 +683,49 @@ class ResourceControlTest(unittest.TestCase):
                 if thresh['task_type'] == 'Processing':
                     self.assertEqual(thresh['priority'], 1)
                     self.assertEqual(thresh['max_slots'], 100)
+                    self.assertEqual(thresh['pending_slots'], 80)
+
                 else:
                     self.assertEqual(thresh['priority'], 2)
                     self.assertEqual(thresh['max_slots'], 50)
+                    self.assertEqual(thresh['pending_slots'], 30)
+        return
+
+    def testInsertT0(self):
+        """
+        _testInsertT0_
+
+        Test to see if we can insert the Tier-0 alone
+        with a single option
+        """
+        self.createConfig()
+
+        resControlPath = os.path.join(WMCore.WMBase.getTestBase(), "../../bin/wmagent-resource-control")
+        env = os.environ
+        env['PYTHONPATH'] = ":".join(sys.path)
+        cmdline = [resControlPath, "--add-T0" ]
+        retval = subprocess.Popen( cmdline,
+                                   stdout = subprocess.PIPE,
+                                   stderr = subprocess.STDOUT,
+                                   env = env)
+        ( _, _ ) = retval.communicate()
+
+        myResourceControl = ResourceControl()
+        result = myResourceControl.listThresholdsForSubmit()
+        self.assertTrue(len(result), 1)
+        self.assertTrue('CERN' in result)
+        for x in result:
+            self.assertEqual(len(result[x]['thresholds']), 10)
+            self.assertEqual(result[x]['total_pending_slots'], 500)
+            self.assertEqual(result[x]['total_running_slots'], -1)
+            for thresh in result[x]['thresholds']:
+                if thresh['task_type'] == 'Processing':
+                    self.assertEqual(thresh['priority'], 1)
+                    self.assertEqual(thresh['max_slots'], -1)
+
+        # Verify that sites with more than one SE were added correctly.
+        cernInfo = myResourceControl.listSiteInfo("CERN")
+        self.assertTrue(len(cernInfo["se_name"]) == 2)
         return
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add a new column to the rc_threshold table, this indicates the number of pending
jobs to keep for an individual task.

Modify all the concerned DAOs and the JobSubmitter.

Rewrote the JobSubmitterPoller unit tests to make them all non-integration,
break the dependecy of having condor available and add tests for the different
mechanics happening in it such as threshold management, site status,
site whitelists/blacklists. Also includes a performance test.

Finally add a special option to setup the Tier-0 thresholds in one line from the
resource control script.
