### PR TITLE
fix problem in sub type insert DAO

### DIFF
--- a/src/python/WMCore/WMBS/MySQL/Subscriptions/InsertType.py
+++ b/src/python/WMCore/WMBS/MySQL/Subscriptions/InsertType.py
@@ -16,6 +16,14 @@ class InsertType(DBFormatter):
                 (SELECT name FROM wmbs_sub_types WHERE name = :name)"""
 
     def execute(self, subType, conn = None, transaction = False):
-        self.dbi.processData(self.sql, {"name": subType}, conn = conn,
+
+        if type(subType) == type([]):
+            binds = []
+            for t in subType:
+                binds.append( { 'name' : t } )
+        else:
+            binds = { 'name' : subTypes }
+
+        self.dbi.processData(self.sql, binds, conn = conn,
                              transaction = transaction)
         return


### PR DESCRIPTION
Seems MySQL can take a bind variable of the type { "BINDPARAM" : [ value1, value2] }. Oracle can not. Change it to the common [ { "BINDPARAM" : value1 }, { "BINDPARAM" : value2 } ] which is supported by both MySQL and Oracle.
