### PR TITLE
Include REST API for missing lumis in the summary

### DIFF
--- a/src/couchapps/FWJRDump/views/outputByWorkflowName/map.js
+++ b/src/couchapps/FWJRDump/views/outputByWorkflowName/map.js
@@ -5,7 +5,7 @@ function(doc) {
     }
 
     var specName = doc['fwjr'].task.split('/')[1]
-
+    var task = doc['fwjr'].task
     var cmsRunFound = false;
     for (var stepName in doc['fwjr']['steps']) {
       if (doc['fwjr']['steps'][stepName].status != 0) {
@@ -25,7 +25,8 @@ function(doc) {
                               '/' + outputFile['dataset']['dataTier'];
             emit([specName, datasetPath], {'size': outputFile['size'],
                                            'events': outputFile['events'],
-                                           'dataset': datasetPath});
+                                           'dataset': datasetPath,
+                                           'task': task});
           }
         }
       }

--- a/src/couchapps/FWJRDump/views/outputByWorkflowName/reduce.js
+++ b/src/couchapps/FWJRDump/views/outputByWorkflowName/reduce.js
@@ -1,5 +1,5 @@
 function (key, values, rereduce) {
-  var output = {'size': 0, 'events': 0, 'count': 0, 'dataset': null};
+  var output = {'size': 0, 'events': 0, 'count': 0, 'dataset': null, 'tasks': {}};
 
   for (var someValue in values) {
     output['dataset'] = values[someValue]['dataset'];
@@ -11,6 +11,15 @@ function (key, values, rereduce) {
     }
     else {
       output['count'] += 1;
+    }
+
+    if (rereduce) {
+      for (var task in values[someValue]['tasks']) {
+          output['tasks'][task] = true
+      }
+    }
+    else {
+      output['tasks'][values[someValue]['task']] = true
     }
   }
 

--- a/src/couchapps/WorkloadSummary/shows/lumiMissingByWorkflow.js
+++ b/src/couchapps/WorkloadSummary/shows/lumiMissingByWorkflow.js
@@ -1,0 +1,100 @@
+function(doc, req) {
+
+  // No document found, return a nice Four Oh Four
+  if (doc === null){
+    return {"code"   : 404,
+            "body"   : "Workflow name doesn't exist.",
+            "headers": { "Content-Type": "text/html"}};
+  }
+
+  // They may want just the lost lumi in an output dataset
+  var searchKey = req.query.outputDataset;
+
+  // Initialize the result
+  var result = new Object;
+
+  // Go through the errors
+  for(var task in doc.errors){
+    var resultKeys = [];
+    // Check if we have output dataset - task mapping information
+    for (var outputDataset in doc.output){
+      var outputInfo = doc.output[outputDataset];
+      if("tasks" in outputInfo){
+        if(outputInfo.tasks.indexOf(task) != -1){
+          resultKeys.push(outputDataset);
+        }
+      }
+    }
+
+    // If we only have task for the errors, then that will be the key
+    if(resultKeys.length === 0){
+      resultKeys.push(task);
+    }
+    // Now record the lumi lost from all the errors
+    var lumiLost = new Object;
+    for (var step in doc.errors[task]){
+      for (var exitCode in doc.errors[task][step]){
+        for (var run in doc.errors[task][step][exitCode]["runs"]){
+          if (!(run in lumiLost)){
+            lumiLost[run] = new Object;
+          }
+          for(var i = 0; i < doc.errors[task][step][exitCode]["runs"][run].length; i++){
+            singleLumi = doc.errors[task][step][exitCode]["runs"][run][i]
+            lumiLost[run][singleLumi] = true;
+          }
+        }
+      }
+    }
+    // Add the lumi lost to the appropiate dataset or task
+    // As always avoid duplicates by using Objects instead of Arrays
+    for (var i = 0; i < resultKeys.length; i++){
+      var individualKey = resultKeys[i];
+      if (!(individualKey in result)){
+        result[individualKey] = new Object;
+      }
+      for (var run in lumiLost){
+        if (!(run in result[individualKey])){
+          result[individualKey][run] = new Object;
+        }
+        for (var singleLumi in lumiLost[run]){
+          result[individualKey][run][singleLumi] = true;
+        }
+      }
+    }
+  }
+
+  // We finished gathering all the lumis, generate a user-friendly
+  // structure like {OutputDataset : {run : [lumi,lumi]} }
+  var jsonResult = new Object;
+  for (var indexingKey in result){
+    if (searchKey != null && searchKey != indexingKey) continue;
+    jsonResult[indexingKey] = new Object;
+    for (var run in result[indexingKey]){
+      jsonResult[indexingKey][run] = [];
+      var allLumis = []
+      for (var singleLumi in result[indexingKey][run]){
+        allLumis.push(parseInt(singleLumi));
+      }
+      allLumis.sort(function(a,b){return a-b});
+      if (allLumis.length === 0) continue;
+      var lastLumi = allLumis[0]
+      var lumiBlock = [lastLumi]
+      for (var i = 1; i < allLumis.length; i++){
+        var currentLumi = allLumis[i]
+        if (currentLumi !== (lastLumi + 1)){
+          lumiBlock[1] = lastLumi
+          jsonResult[indexingKey][run].push(lumiBlock)
+          lumiBlock = [currentLumi]
+        }
+        lastLumi = currentLumi
+      }
+     lumiBlock[1] = lastLumi
+     jsonResult[indexingKey][run].push(lumiBlock)
+    }
+  }
+
+  provides("json", function(){
+    send(JSON.stringify(jsonResult));
+  });
+
+}

--- a/src/python/WMComponent/TaskArchiver/TaskArchiverPoller.py
+++ b/src/python/WMComponent/TaskArchiver/TaskArchiverPoller.py
@@ -554,6 +554,7 @@ class TaskArchiverPoller(BaseWorkerThread):
             workflowData['output'][dataset]['nFiles'] = entry['count']
             workflowData['output'][dataset]['size']   = entry['size']
             workflowData['output'][dataset]['events'] = entry['events']
+            workflowData['output'][dataset]['tasks']  = entry['tasks'].keys()
 
 
         # Loop over all failed jobs

--- a/test/python/WMComponent_t/TaskArchiver_t/TaskArchiver_t.py
+++ b/test/python/WMComponent_t/TaskArchiver_t/TaskArchiver_t.py
@@ -472,6 +472,10 @@ class TaskArchiverTest(unittest.TestCase):
         # Check the output
         self.assertEqual(workloadSummary['output'].keys(), ['/Electron/MorePenguins-v0/RECO',
                                                             '/Electron/MorePenguins-v0/ALCARECO'])
+        self.assertEqual(workloadSummary['output']['/Electron/MorePenguins-v0/RECO']['tasks'],
+                        ['/TestWorkload/ReReco', '/TestWorkload/ReReco/LogCollect'])
+        self.assertEqual(workloadSummary['output']['/Electron/MorePenguins-v0/ALCARECO']['tasks'],
+                        ['/TestWorkload/ReReco', '/TestWorkload/ReReco/LogCollect'])
 
         # Check performance
         # Check histograms
@@ -542,6 +546,7 @@ class TaskArchiverTest(unittest.TestCase):
         self.assertTrue(workloadSummary['errors']['/TestWorkload/ReReco']['cmsRun1'].has_key('99999'))
         self.assertEquals(workloadSummary['errors']['/TestWorkload/ReReco']['cmsRun1']['99999']['runs'], {'10' : [12312]},
                           "Wrong lumi information in the summary for failed jobs")
+
         return
 
     def atestC_Profile(self):


### PR DESCRIPTION
Add a show function which works as a REST API
to get the missing lumis for a completed workflow from
the workload summary.

URL is ugly at the moment:

/_design/WorkloadSummary/_show/lumiMissingByWorkflow/<workflowName>?outputDataset=<string>

The outputDataset parameter is optional and is used to filter the output. The format of the output
is:

{outputDataset:string : { run:string : [ [startLumi:int, endLumi:init], ...] , ... }, ...}

Note that for summaries produced by agents without the TaskArchiver changes in this patch, the outputDataset won't
be returned as a key, instead it will be the task where the lumis were lost.

Fixes #4216

To be included in December CMSWEB deployment.
