### PR TITLE
Minor bugfix for the resource control script

### DIFF
--- a/bin/wmagent-resource-control
+++ b/bin/wmagent-resource-control
@@ -314,6 +314,6 @@ else:
     else:
         taskType = options.taskType.strip().split(',')
         updateThresholdInfo(myResourceControl, options.siteName,
-                            taskType, options.pendingSlots,
-                            options.runningSlots, priority = options.priority)
+                            taskType, options.runningSlots,
+                            options.pendingSlots, priority = options.priority)
         sys.exit(0)


### PR DESCRIPTION
The update threshold option had the pending and running
slots for a task swapped.
