### PR TITLE
Allow nullauth for WorkloadSummary in local couch

### DIFF
--- a/src/couchapps/WorkloadSummary/validate_doc_update.js
+++ b/src/couchapps/WorkloadSummary/validate_doc_update.js
@@ -4,12 +4,13 @@ function(newDoc, oldDoc, userCtx) {
 
     var validation = require("lib/validate").init(newDoc, oldDoc, userCtx);
 
-    // if the oldDoc is exists and try to update, something is wrong
-    if(oldDoc) {
-        throw {forbidden: "Summary is already exist"};
-    }
+    // Gets whether the user is a global admin
+    // name=null means requests coming from the local replicator, so we must allow
+    // (the cms couch auth does not allow name=null, so it affects only internal requests)
+    var isGlobalAdm = (userCtx.name === null)
+
     // Admins can do anything
-    if (validation.isAdmin()) {
+    if (validation.isAdmin() || isGlobalAdm) {
         return true;
     }
 


### PR DESCRIPTION
Check for null auth and allow it,
also allow the update of existing documents
this is to provide support for multiple agents
and eventually cleanup. The TaskArchiver already takes care
of not doing funny stuff and uploading stuff twice
unless it's necessary.
