### PR TITLE
Allow requests to run at sites without the data

### DIFF
--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
@@ -254,6 +254,11 @@ class Assign(WebAPI):
                                           int(kwargs.get("maxVSize", 2411724)),
                                           int(kwargs.get("SoftTimeout", 171600)),
                                           int(kwargs.get("GracePeriod", 300)))
+
+        # Check whether we should check location for the data
+        if "useSiteListAsLocation" in kwargs:
+            helper.setLocationDataSourceFlag()
+
         # Set phedex subscription information
         custodialList = kwargs.get("CustodialSites", [])
         nonCustodialList = kwargs.get("NonCustodialSites", [])

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -1183,7 +1183,28 @@ class WMTaskHelper(TreeHelper):
             return buildLumiMask(runs, lumis)
 
         return {}
-    
+
+    def setInputLocationFlag(self, flag = True):
+        """
+        _setInputLocationFlag_
+
+        Store a flag that indicates that the site
+        whitelist/blacklist should be used
+        as the location for the input data.
+        Trust it blindly and don't check PhEDEx.
+        """
+        self.data.input.trustSiteLists = True
+
+    def inputLocationFlag(self):
+        """
+        _getInputLocationFlag
+
+        Get the flag which tells
+        whether to use the site lists
+        as data location or not
+        """
+        return getattr(self.data.input, "trustSiteLists", False)
+
     def deleteChild(self, childName):
         """
         _deleteChild_
@@ -1216,6 +1237,7 @@ class WMTask(ConfigSectionTree):
         self.section_("subscriptions")
         self.notifications.targets = []
         self.input.sandbox = None
+        self.input.trustSiteLists = False
         self.input.section_("splitting")
         self.input.splitting.algorithm = None
         self.constraints.section_("sites")

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -1451,9 +1451,29 @@ class WMWorkloadHelper(PersistencyHelper):
             result.extend(t.getConfigCacheIDs())
         return result
 
+    def setLocationDataSourceFlag(self):
+        """
+        _setLocationDataSourceFlag_
 
+        Set the flag in the top level tasks
+        indicating that site lists should be
+        used as location data
+        """
+        for task in self.getTopLevelTask():
+            task.setInputLocationFlag()
+        return
 
+    def locationDataSourceFlag(self):
+        """
+        _locationDataSourceFlag_
 
+        Get the flag in the top level tasks
+        that indicates whether the site lists
+        should be trusted as the location for data
+        """
+        for task in self.getTopLevelTask():
+            return task.inputLocationFlag()
+        return False
 
 class WMWorkload(ConfigSection):
     """

--- a/src/python/WMCore/WorkQueue/DataLocationMapper.py
+++ b/src/python/WMCore/WorkQueue/DataLocationMapper.py
@@ -166,6 +166,8 @@ class WorkQueueDataLocationMapper(DataLocationMapper):
             for data, locations in dataMapping.items():
                 elements = self.backend.getElementsForData(dbs, data)
                 for element in elements:
+                    if element.get('NoLocationUpdate', False):
+                        continue
                     if sorted(locations) != sorted(element['Inputs'][data]):
                         if fullResync:
                             self.logger.info(data + ': Setting locations to: ' + ', '.join(locations))
@@ -192,6 +194,8 @@ class WorkQueueDataLocationMapper(DataLocationMapper):
             for data, locations in dataMapping.items():
                 elements = self.backend.getElementsForParentData(data)
                 for element in elements:
+                    if element.get('NoLocationUpdate', False):
+                        continue
                     for pData in element['ParentData']:
                         if pData == data:
                             if sorted(locations) != sorted(element['ParentData'][pData]):

--- a/src/python/WMCore/WorkQueue/DataStructs/WorkQueueElement.py
+++ b/src/python/WMCore/WorkQueue/DataStructs/WorkQueueElement.py
@@ -63,6 +63,8 @@ class WorkQueueElement(dict):
         self.setdefault('Mask', None)
         # is new data being added to the inputs i.e. open block with new files?
         self.setdefault('OpenForNewData', False)
+        # Should we check the location of the inputs, or trust the initial values?
+        self.setdefault('NoLocationUpdate', False)
 
         # set to true when updated from a WorkQueueElementResult
         self.modified = False

--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -353,6 +353,15 @@ class WorkQueue(WorkQueueBase):
                 dbsBlockDict = dbs.getFileBlockWithParents(blockName)
             else:
                 dbsBlockDict = dbs.getFileBlock(blockName)
+
+            if wmspec.locationDataSourceFlag():
+                blockInfo = dbsBlockDict[blockName]
+                seElements = []
+                for cmsSite in match['Inputs'].values()[0]: #TODO: Allow more than one
+                    ses = self.SiteDB.cmsNametoSE(cmsSite)
+                    seElements.extend(ses)
+                seElements = list(set(seElements))
+                blockInfo['StorageElements'] = seElements
         return blockName, dbsBlockDict[blockName]
 
     def _wmbsPreparation(self, match, wmspec, blockName, dbsBlock):

--- a/src/templates/WMCore/WebTools/RequestManager/Assign.tmpl
+++ b/src/templates/WMCore/WebTools/RequestManager/Assign.tmpl
@@ -76,7 +76,8 @@ Site Blacklist:
    #for $site in $sites:
        <option>$site</option>
    #end for
-</select>
+</select></br>
+<input type="checkbox" name="useSiteListAsLocation"/>Use site whitelist/blacklist for data location (allows use of xrootd capabilities)<br/>
 <h4> PhEDEx Subscriptions </h4>
 Custodial Sites:
 <select name="CustodialSites" multiple size=10>


### PR DESCRIPTION
Include a flag at assignment time that
allows ops to decide if a request should run
in all CMS sites filtered by whitelist/blacklist
instead of where the data is. This assumes Ops knows
what is doing (sites have xrootd to get the data).
