### PR TITLE
Fix status_time type for oracle DAO

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
@@ -607,14 +607,14 @@ class CondorPlugin(BasePlugin):
                     job['status']      = statName
                     job['status_time'] = 0
 
-               #Check if we have a valid status time
+                #Check if we have a valid status time
                 if not job['status_time']:
                     if job['status'] == 'Running':
-                        job['status_time'] = jobAd.get('runningTime', 0)
+                        job['status_time'] = int(jobAd.get('runningTime', 0))
                     elif job['status'] == 'Idle':
-                        job['status_time'] = jobAd.get('submitTime', 0)
+                        job['status_time'] = int(jobAd.get('submitTime', 0))
                     else:
-                        job['status_time'] = jobAd.get('stateTime', 0)
+                        job['status_time'] = int(jobAd.get('stateTime', 0))
                     changeList.append(job)
 
                 runningList.append(job)


### PR DESCRIPTION
Oracle optimization require a constant type on the binds
when calling a query many times. Ensure this from the CondorPlugin
track method.

Fixes #4297
