### PR TITLE
Added basic http(s) url validation for DBS3

### DIFF
--- a/src/python/WMCore/Lexicon.py
+++ b/src/python/WMCore/Lexicon.py
@@ -266,6 +266,22 @@ def couchurl(candidate):
 def requestName(candidate):
     return check(r'[a-zA-Z0-9\.\-_]{1,150}$', candidate)
 
+def validateUrl(candidate):
+    """
+    Basic input validation for http(s) urls
+    """
+    #regex taken from django https://github.com/django/django/blob/master/django/core/validators.py#L47
+    #Copyright (c) Django Software Foundation and individual contributors
+    protocol = r"^https?://"  # http:// or https://
+    domain = r'?:(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,6}\.?'
+    localhost = r'localhost'
+    ipv4 = r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}'
+    ipv6 = r'\[?[a-fA-F0-9]*:[a-fA-F0-9:]+\]?'
+    port = r'(?::\d+)?'  # optional port
+    path = r'(?:/?|[/?]\S+)$'
+    regex_url = r'%s(%s|%s|%s|%s)%s%s' % (protocol, domain, localhost, ipv4, ipv6, port, path)
+    return check(regex_url, candidate)
+
 def check(regexp, candidate):
     assert re.compile(regexp).match(candidate) != None , \
               "'%s' does not match regular expression %s" % (candidate, regexp)

--- a/test/python/WMCore_t/Lexicon_t.py
+++ b/test/python/WMCore_t/Lexicon_t.py
@@ -260,6 +260,7 @@ class LexiconTest(unittest.TestCase):
     def testBadCouchUrl(self):
         for notok in ['agent86@control.fnal.gov:5984', 'http:/localhost:443', 'http://www.myspace.com']:
             self.assertRaises(AssertionError, couchurl, notok)
+
     def testHNName(self):
         """
         _testHNName_
@@ -660,6 +661,31 @@ class LexiconTest(unittest.TestCase):
         self.assertRaises(AssertionError, globalTag, gTag)
 
         return
+
+    def testUrlValidation(self):
+        """
+        Test the validateUrl function for some use case of DBS 3
+        """
+        #Good http(s) urls
+        for url in ['https://cmsweb.cern.ch/dbs/prod/global/DBSReader',
+                    'https://mydbs.mydomain.de:8443',
+                    'http://localhost',
+                    'http://192.168.1.1',
+                    'https://192.168.1.1:443',
+                    'http://[2001:0db8:85a3:08d3:1319:8a2e:0370:7344]/',
+                    'http://2001:0db8:85a3:08d3:1319:8a2e:0370:7344/',
+                    'http://[2001:0db8:85a3:08d3:1319:8a2e:0370:7344]:8443/']:
+            validateUrl(url)
+
+        #Bad http(s) urls
+        for url in ['ftp://dangerous.download.this',
+                    'https:/notvalid.url',
+                    'http://-NiceTry',
+                    'https://NiceTry; DROP Table;--',
+                    'http://123123104122',
+                    'http://.www.google.com',
+                    'http://[2001:0db8:85a3:08d3:1319:8a2z:0370:7344]/',]:
+            self.assertRaises(AssertionError, validateUrl, url)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Hi,

DBS 3 needs to validate http(s) urls provided by the users. I have implemented a basic url validation based on the validation done in the django framework. A set of test cases have been added as well. Could you review and merge, please?

Thanks,
Manuel
