### PR TITLE
Include the new PSet pickle in the logArchs

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Executors/LogArchive.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/LogArchive.py
@@ -80,7 +80,8 @@ class LogArchive(Executor):
             "FrameworkJobReport",
             "Report.pkl",
             "Report.pcl",
-            "^PSet.py$"
+            "^PSet.py$",
+            "^PSet.pkl$"
             ]
 
         #Okay, we need a stageOut Manager


### PR DESCRIPTION
Since we changed to having a pickle file
with the configuration, the logArchs only have
the .py file which is useless without the pickle.
