### PR TITLE
Do the SE name => Site name conversion also for failed jobs

### DIFF
--- a/src/python/WMComponent/JobAccountant/AccountantWorker.py
+++ b/src/python/WMComponent/JobAccountant/AccountantWorker.py
@@ -490,6 +490,7 @@ class AccountantWorker(WMConnectionBase):
             for outputFileset in outputFilesets:
                 self.filesetAssoc.append({"lfn": wmbsFile["lfn"], "fileset": outputFileset})
 
+        self._mapLocation(wmbsJob['fwjr'])
         self.listOfJobsToFail.append(wmbsJob)
 
         return


### PR DESCRIPTION
In the AccountantPoller there is a conversion from SE name to Site name done for successful jobs here:

https://github.com/dmwm/WMCore/blob/master/src/python/WMComponent/JobAccountant/AccountantWorker.py#L445

However whis is not done for failed jobs, and this can cause the problem discussed in this thread in the crab3-commissioning list:

https://groups.cern.ch/group/cms-crab3-commissioning/Lists/Archive/Flat.aspx?RootFolder=%2Fgroup%2Fcms-crab3-commissioning%2FLists%2FArchive%2Fcrab3%20Execution%20error&FolderCTID=0x012002000F7D37EA88ECAC4FB5C902B28F041610#{EA7333D6-7BE0-44F7-BA55-6D1C7389E643}

The pull request solve this problem.
