### PR TITLE
Fix Reduce function for outputByWorkflowName

### DIFF
--- a/src/couchapps/FWJRDump/views/outputByWorkflowName/reduce.js
+++ b/src/couchapps/FWJRDump/views/outputByWorkflowName/reduce.js
@@ -1,6 +1,7 @@
 function (key, values, rereduce) {
-  var output = {'size': 0, 'events': 0, 'count': 0, 'dataset': null, 'tasks': {}};
+  var output = {'size': 0, 'events': 0, 'count': 0, 'dataset': null, 'tasks': []};
 
+  var storedTasks = {}
   for (var someValue in values) {
     output['dataset'] = values[someValue]['dataset'];
     output['size'] += values[someValue]['size'];
@@ -14,12 +15,19 @@ function (key, values, rereduce) {
     }
 
     if (rereduce) {
-      for (var task in values[someValue]['tasks']) {
-          output['tasks'][task] = true
+      for (var i = 0; i < values[someValue]['tasks'].length; i++) {
+        var task = values[someValue]['tasks'][i]
+        if (!(task in storedTasks)){
+          output['tasks'].push(task)
+          storedTasks[task] = true
+        }
       }
     }
     else {
-      output['tasks'][values[someValue]['task']] = true
+      if (!(values[someValue]['task'] in storedTasks)){
+        storedTasks[values[someValue]['task']] = true
+        output['tasks'].push(values[someValue]['task'])
+      }
     }
   }
 

--- a/src/python/WMComponent/TaskArchiver/TaskArchiverPoller.py
+++ b/src/python/WMComponent/TaskArchiver/TaskArchiverPoller.py
@@ -563,7 +563,7 @@ class TaskArchiverPoller(BaseWorkerThread):
             workflowData['output'][dataset]['nFiles'] = entry['count']
             workflowData['output'][dataset]['size']   = entry['size']
             workflowData['output'][dataset]['events'] = entry['events']
-            workflowData['output'][dataset]['tasks']  = entry['tasks'].keys()
+            workflowData['output'][dataset]['tasks']  = entry['tasks']
 
 
         # Loop over all failed jobs

--- a/test/python/WMComponent_t/TaskArchiver_t/TaskArchiver_t.py
+++ b/test/python/WMComponent_t/TaskArchiver_t/TaskArchiver_t.py
@@ -476,7 +476,7 @@ class TaskArchiverTest(unittest.TestCase):
 
         # Check the output
         self.assertEqual(workloadSummary['output'].keys(), ['/Electron/MorePenguins-v0/RECO'])
-        self.assertEqual(workloadSummary['output']['/Electron/MorePenguins-v0/RECO']['tasks'],
+        self.assertEqual(sorted(workloadSummary['output']['/Electron/MorePenguins-v0/RECO']['tasks']),
                         ['/TestWorkload/ReReco', '/TestWorkload/ReReco/LogCollect'])
         # Check performance
         # Check histograms


### PR DESCRIPTION
It was generating a growing object in the output,
although it would only grow to size 2 at any given time.
Couchdb reduce_limit check throws an overflow
error on this function, changing the type to an array
fixes the problem. Added an object variable
that only lives in the reduce function to
keep track of duplicates.

Changed the TaskArchiver accordingly.

I'm applying it to cmssrv94 for the integration tests.
