### PR TITLE
Fix timeout kills in LSF plugin

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/LsfPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/LsfPlugin.py
@@ -46,7 +46,8 @@ class LsfPlugin(BasePlugin):
                      'DONE': 'Complete',
                      'EXIT': 'Error',
                      'UNKWN': 'Error',
-                     'ZOMBI': 'Error'}
+                     'ZOMBI': 'Error',
+                     'Timeout' : 'Error'}
 
         return stateDict
 


### PR DESCRIPTION
Add the Timeout state to the LSF plugin
state map, needed when a job is killed by timeout
