### PR TITLE
Ensure jobs are submitted, oldest workflow first

### DIFF
--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -83,19 +83,20 @@ class JobSubmitterPoller(BaseWorkerThread):
         self.bossAir = BossAirAPI(config = self.config)
 
         # Additions for caching-based JobSubmitter
-        self.cachedJobIDs   = set()
-        self.cachedJobs     = {}
-        self.jobDataCache   = {}
-        self.jobsToPackage  = {}
-        self.sandboxPackage = {}
-        self.siteKeys       = {}
-        self.locationDict   = {}
-        self.cmsNames       = {}
-        self.drainSites     = []
-        self.sortedSites    = []
-        self.packageSize    = getattr(self.config.JobSubmitter, 'packageSize', 500)
-        self.collSize       = getattr(self.config.JobSubmitter, 'collectionSize',
-                                      self.packageSize * 1000)
+        self.workflowTimestamps = {}
+        self.cachedJobIDs       = set()
+        self.cachedJobs         = {}
+        self.jobDataCache       = {}
+        self.jobsToPackage      = {}
+        self.sandboxPackage     = {}
+        self.siteKeys           = {}
+        self.locationDict       = {}
+        self.cmsNames           = {}
+        self.drainSites         = []
+        self.sortedSites        = []
+        self.packageSize        = getattr(self.config.JobSubmitter, 'packageSize', 500)
+        self.collSize           = getattr(self.config.JobSubmitter, 'collectionSize',
+                                          self.packageSize * 1000)
 
         # initialize the alert framework (if available)
         self.initAlerts(compName = "JobSubmitter")
@@ -338,10 +339,13 @@ class JobSubmitterPoller(BaseWorkerThread):
 
                 locTypeCache = self.cachedJobs[possibleLocation][newJob["type"]]
                 workflowName = newJob['workflow']
+                timestamp    = newJob['timestamp']
                 if not locTypeCache.has_key(workflowName):
                     locTypeCache[workflowName] = set()
                 if not self.jobDataCache.has_key(workflowName):
                     self.jobDataCache[workflowName] = {}
+                if not workflowName in self.workflowTimestamps:
+                    self.workflowTimestamps[workflowName] = timestamp
 
                 locTypeCache[workflowName].add(jobID)
 
@@ -460,6 +464,7 @@ class JobSubmitterPoller(BaseWorkerThread):
         """
         jobsToSubmit = {}
         jobsToPrune = {}
+        workflowsToPrune = set()
 
         rcThresholds = self.getThresholds()
 
@@ -539,7 +544,9 @@ class JobSubmitterPoller(BaseWorkerThread):
                     cachedJobWorkflow = None
 
                     workflows = taskCache.keys()
-                    workflows.sort()
+                    # Sorting by timestamp on the subscription
+                    sortingKey = lambda x : self.workflowTimestamps[x]
+                    workflows.sort(key = sortingKey)
 
                     for workflow in workflows:
                         # Run a while loop until you get a job
@@ -560,6 +567,7 @@ class JobSubmitterPoller(BaseWorkerThread):
                         # Remove the entry in the cache for the workflow if it is empty.
                         if len(self.cachedJobs[siteName][taskType][workflow]) == 0:
                             del self.cachedJobs[siteName][taskType][workflow]
+                            workflowsToPrune.add(workflow)
                         if self.jobDataCache.has_key(workflow) and len(self.jobDataCache[workflow].keys()) == 0:
                             del self.jobDataCache[workflow]
 
@@ -630,6 +638,10 @@ class JobSubmitterPoller(BaseWorkerThread):
                 for workflow in self.cachedJobs[siteName][taskType].keys():
                     if workflow in jobsToPrune.keys():
                         self.cachedJobs[siteName][taskType][workflow] -= jobsToPrune[workflow]
+
+        # Remove workflows from the timestamp dictionary which are not anymore in the cache
+        for workflow in workflowsToPrune:
+            del self.workflowTimestamps[workflow]
 
         logging.info("Have %s packages to submit." % len(jobsToSubmit))
         logging.info("Done assigning site locations.")

--- a/src/python/WMCore/WMBS/MySQL/Jobs/ListForSubmitter.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/ListForSubmitter.py
@@ -15,6 +15,7 @@ class ListForSubmitter(DBFormatter):
                     wmbs_job.cache_dir AS cache_dir,
                     wmbs_sub_types.name AS type, wmbs_job.retry_count AS retry_count,
                     wmbs_subscription.workflow as workflow,
+                    wmbs_subscription.last_update as timestamp,
                     wmbs_workflow.name as request_name
                     FROM wmbs_job
                INNER JOIN wmbs_jobgroup ON


### PR DESCRIPTION
In Oracle we don't have guarantee of strictly increasing
indexes for the workflows and the JobSubmitter relies
on this to order the workflows and submit older workflows first.
Change the sort to use the timestamp in the last_update column
from the subscriptions.
