### PR TITLE
Fix cleanup of timestamp cache on the JobSubmitter

### DIFF
--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -464,7 +464,6 @@ class JobSubmitterPoller(BaseWorkerThread):
         """
         jobsToSubmit = {}
         jobsToPrune = {}
-        workflowsToPrune = set()
 
         rcThresholds = self.getThresholds()
 
@@ -567,7 +566,6 @@ class JobSubmitterPoller(BaseWorkerThread):
                         # Remove the entry in the cache for the workflow if it is empty.
                         if len(self.cachedJobs[siteName][taskType][workflow]) == 0:
                             del self.cachedJobs[siteName][taskType][workflow]
-                            workflowsToPrune.add(workflow)
                         if self.jobDataCache.has_key(workflow) and len(self.jobDataCache[workflow].keys()) == 0:
                             del self.jobDataCache[workflow]
 
@@ -633,15 +631,19 @@ class JobSubmitterPoller(BaseWorkerThread):
                         break
 
         # Remove the jobs that we're going to submit from the cache.
+        allWorkflows = set()
         for siteName in self.cachedJobs.keys():
             for taskType in self.cachedJobs[siteName].keys():
                 for workflow in self.cachedJobs[siteName][taskType].keys():
+                    allWorkflows.add(workflow)
                     if workflow in jobsToPrune.keys():
                         self.cachedJobs[siteName][taskType][workflow] -= jobsToPrune[workflow]
 
         # Remove workflows from the timestamp dictionary which are not anymore in the cache
-        for workflow in workflowsToPrune:
-            del self.workflowTimestamps[workflow]
+        workflowsWithTimestamp = self.workflowTimestamps.keys()
+        for workflow in workflowsWithTimestamp:
+            if workflow not in allWorkflows:
+                del self.workflowTimestamps[workflow]
 
         logging.info("Have %s packages to submit." % len(jobsToSubmit))
         logging.info("Done assigning site locations.")


### PR DESCRIPTION
Last patch for the JobSubmitter ordering has a bug when cleaning up the memory cache on workflow timestamps, fix this here.
