### PR TITLE
Display docstrings in RESTAPI documentation

### DIFF
--- a/src/python/WMCore/WebTools/RESTModel.py
+++ b/src/python/WMCore/WebTools/RESTModel.py
@@ -5,7 +5,7 @@
 """
 Rest Model abstract implementation
 """
-
+from functools import wraps
 from WMCore.Lexicon import check
 from WMCore.WebTools.WebAPI import WebAPI
 from cherrypy import request, HTTPError
@@ -169,6 +169,7 @@ class RESTModel(WebAPI):
 
         if not self.methods.has_key(verb):
             self.methods[verb] = {}
+        @wraps(function)
         def wrapper(*input_args, **input_kwargs):
             if secured:
                 # set up security


### PR DESCRIPTION
Hi,

according to the cheetah template for the RESTAPI documentation, docstrings of exposed methods should be displayed in the auto-generated documentation page. Currently that feature is not working properly, because _addMethod contains a wrapper function around the original method, thus the docstrings of the original method are lost. One can re-enable the feature by using the wraps decorator from functools. DBS was ask to improve the documentation in https://svnweb.cern.ch/trac/CMSDMWM/ticket/4009 and we would to use that feature of WebTools.

Could you review and merge that patch, please?

Thanks,
Manuel
