### PR TITLE
Fix WMBSMergeBySize causing duplicates

### DIFF
--- a/src/python/WMCore/JobSplitting/WMBSMergeBySize.py
+++ b/src/python/WMCore/JobSplitting/WMBSMergeBySize.py
@@ -67,7 +67,7 @@ def sortedFilesFromMergeUnits(mergeUnits):
             # the constructor in the "newlocations" attribute.  We want these to
             # be in the "locations" attribute so that they get picked up by the
             # job submitter.
-            newFile["locations"] = set([file["se_name"]])
+            newFile["locations"] = set(file["se_name"])
             newFile.addRun(Run(file["file_run"], file["file_lumi"]))
             sortedFiles.append(newFile)
 
@@ -97,6 +97,7 @@ class WMBSMergeBySize(JobFactory):
 
         for mergeableFile in mergeableFiles:
             newMergeFile = {}
+
             for key in mergeableFile.keys():
                 newMergeFile[key] = mergeableFile[key]
 

--- a/src/python/WMCore/WMBS/MySQL/Subscriptions/GetFilesForMerge.py
+++ b/src/python/WMCore/WMBS/MySQL/Subscriptions/GetFilesForMerge.py
@@ -78,4 +78,15 @@ class GetFilesForMerge(DBFormatter):
     def execute(self, subscription = None, conn = None, transaction = False):
         results = self.dbi.processData(self.sql, {"p_1": subscription}, conn = conn,
                                       transaction = transaction)
-        return self.formatDict(results)
+
+        ungroupedResult = self.formatDict(results)
+        result = {}
+        for entry in ungroupedResult:
+            if entry['file_lfn'] not in result:
+                entry['se_name'] = set([entry['se_name']])
+                result[entry['file_lfn']] = entry
+            else:
+                result[entry['file_lfn']]['se_name'].add(entry['se_name'])
+        for entry in result:
+            result[entry]['se_name'] = frozenset(result[entry]['se_name'])
+        return result.values()

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/WMBSMergeBySize_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/WMBSMergeBySize_t.py
@@ -64,6 +64,7 @@ class WMBSMergeBySize(unittest.TestCase):
         """
         locationAction = self.daoFactory(classname = "Locations.New")
         locationAction.execute(siteName = "s1", seName = "somese.cern.ch")
+        locationAction.execute(siteName = "s1", seName = "somese2.cern.ch")
 
         changeStateDAO = self.daoFactory(classname = "Jobs.ChangeState")
 
@@ -397,7 +398,7 @@ class WMBSMergeBySize(unittest.TestCase):
                 file.loadData()
                 assert file["lfn"] in goldenFiles, \
                        "Error: Unknown file: %s" % file["lfn"]
-                assert file["locations"] == set(["somese.cern.ch"]), \
+                assert file["locations"] == set(["somese.cern.ch", "somese2.cern.ch"]), \
                        "Error: File is missing a location."
                 goldenFiles.remove(file["lfn"])
 
@@ -466,7 +467,7 @@ class WMBSMergeBySize(unittest.TestCase):
         for file in jobFiles:
             assert file["lfn"] in goldenFiles, \
                    "Error: Unknown file: %s" % file["lfn"]
-            assert file["locations"] == set(["somese.cern.ch"]), \
+            assert file["locations"] == set(["somese.cern.ch", "somese2.cern.ch"]), \
                    "Error: File is missing a location."
             goldenFiles.remove(file["lfn"])
 
@@ -540,7 +541,7 @@ class WMBSMergeBySize(unittest.TestCase):
             for file in jobFiles:
                 assert file["lfn"] in goldenFiles, \
                        "Error: Unknown file in merge jobs."
-                assert file["locations"] == set(["somese.cern.ch"]), \
+                assert file["locations"] == set(["somese.cern.ch", "somese2.cern.ch"]), \
                        "Error: File is missing a location."
 
                 goldenFiles.remove(file["lfn"])
@@ -610,7 +611,7 @@ class WMBSMergeBySize(unittest.TestCase):
         currentLumi = 0
         currentEvent = 0
         for file in jobFiles:
-            assert file["locations"] == set(["somese.cern.ch"]), \
+            assert file["locations"] == set(["somese.cern.ch", "somese2.cern.ch"]), \
                    "Error: File is missing a location."
 
             if file["lfn"] in goldenFilesA:
@@ -692,7 +693,7 @@ class WMBSMergeBySize(unittest.TestCase):
             for file in jobFiles:
                 assert file["lfn"] in goldenFiles, \
                        "Error: Unknown file in merge jobs."
-                assert file["locations"] == set(["somese.cern.ch"]), \
+                assert file["locations"] == set(["somese.cern.ch", "somese2.cern.ch"]), \
                        "Error: File is missing a location: %s" % file["locations"]
 
                 goldenFiles.remove(file["lfn"])
@@ -762,7 +763,7 @@ class WMBSMergeBySize(unittest.TestCase):
         currentLumi = 0
         currentEvent = 0
         for file in jobFiles:
-            assert file["locations"] == set(["somese.cern.ch"]), \
+            assert file["locations"] == set(["somese.cern.ch", "somese2.cern.ch"]), \
                    "Error: File is missing a location."
 
             if file["lfn"] in goldenFilesA:
@@ -814,6 +815,8 @@ class WMBSMergeBySize(unittest.TestCase):
         """
         locationAction = self.daoFactory(classname = "Locations.New")
         locationAction.execute(siteName = "s1", seName = "somese.cern.ch")
+        locationAction.execute(siteName = "s1", seName = "somese2.cern.ch")
+
 
         mergeFilesetA = Fileset(name = "mergeFilesetA")
         mergeFilesetB = Fileset(name = "mergeFilesetB")
@@ -1024,10 +1027,10 @@ class WMBSMergeBySize(unittest.TestCase):
         self.stuffWMBS()
 
         locationAction = self.daoFactory(classname = "Locations.New")
-        locationAction.execute(siteName = "s2", seName = "somese2.cern.ch")
+        locationAction.execute(siteName = "s2", seName = "somese3.cern.ch")
 
         fileSite2 = File(lfn = "fileSite2", size = 4098, events = 1024,
-                         first_event = 0, locations = set(["somese2.cern.ch"]))
+                         first_event = 0, locations = set(["somese3.cern.ch"]))
         fileSite2.addRun(Run(1, *[46]))
         fileSite2.create()
         fileSite2.addParent(self.parentFileSite2["lfn"])
@@ -1053,7 +1056,8 @@ class WMBSMergeBySize(unittest.TestCase):
             baseLocation = list(firstInputFile["locations"])[0]
 
             for inputFile in job.getFiles():
-                assert len(inputFile["locations"]) == 1, \
+                assert inputFile["locations"] == set(["somese.cern.ch", "somese2.cern.ch"]) or \
+                       inputFile["locations"] == set(["somese3.cern.ch"]), \
                        "Error: Wrong number of locations"
 
                 assert list(inputFile["locations"])[0] == baseLocation, \


### PR DESCRIPTION
This occurs when a site has multiple SEs, fix
changes the discovery query to return a file only once
with a tuple of the possible SEs.

@sfoulkes please review, same problem as in f222ab2f2ccf82a6f8539d78c4590cb2171a6e92. Here the fix is different to mantain the parent file boundaries. Unit tests were modified to fail without the fixes.
