### PR TITLE
Allow keeping ReReco outputs unmerged

### DIFF
--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
@@ -556,10 +556,9 @@ def makeRequest(webApi, reqInputArgs, couchUrl, couchDB, wmstatUrl):
     for blocklist in ["BlockWhitelist", "BlockBlacklist"]:
         if blocklist in reqInputArgs:
             reqSchema[blocklist] = parseBlockList(reqInputArgs[blocklist])
-    if "DqmSequences" in reqInputArgs:
-        reqSchema["DqmSequences"] = parseStringListWithoutValidation(reqInputArgs["DqmSequences"])
-    if "IgnoredOutputModules" in reqInputArgs:
-        reqSchema["IgnoredOutputModules"] = parseStringListWithoutValidation(reqInputArgs["IgnoredOutputModules"])
+    for stringList in ["DqmSequences", "IgnoredOutputModules", "TransientOutputModules"]:
+        if stringList in reqInputArgs:
+            reqSchema[stringList] = parseStringListWithoutValidation(reqInputArgs[stringList])
 
     validate(reqSchema)
 

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/ReReco_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/ReReco_t.py
@@ -33,7 +33,7 @@ class ReRecoTest(unittest.TestCase):
         self.testInit.setupCouch("rereco_t", "ConfigCache")
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
-
+        self.testDir = self.testInit.generateWorkDir()
         couchServer = CouchServer(os.environ["COUCHURL"])
         self.configDatabase = couchServer.connectDatabase("rereco_t")
         return
@@ -46,6 +46,7 @@ class ReRecoTest(unittest.TestCase):
         """
         self.testInit.tearDownCouch()
         self.testInit.clearDatabase()
+        self.testInit.delWorkDir()
         return
 
     def injectReRecoConfig(self):
@@ -123,7 +124,7 @@ class ReRecoTest(unittest.TestCase):
                          Merged.mergedLFNBase,
                          '/store/data/WMAgentCommissioning10/MinimumBias/USER/SkimBFilter-ProcString-v2')
 
-        testWMBSHelper = WMBSHelper(testWorkload, "DataProcessing", "SomeBlock")
+        testWMBSHelper = WMBSHelper(testWorkload, "DataProcessing", "SomeBlock", cachepath = self.testDir)
         testWMBSHelper.createTopLevelFileset()
         testWMBSHelper.createSubscription(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
 
@@ -277,6 +278,157 @@ class ReRecoTest(unittest.TestCase):
                          "Error: Wrong subscription type.")
         self.assertEqual(logCollectSub["split_algo"], "MinFileBased",
                          "Error: Wrong split algo.")
+
+        return
+
+    def testReRecoDroppingRECO(self):
+        """
+        _testReRecoDroppingRECO_
+
+        Verify that ReReco workflows can be created and inserted into WMBS
+        correctly.  The ReReco workflow is just a DataProcessing workflow with
+        skims tacked on. This tests run on unmerged RECO output
+        """
+        skimConfig = self.injectSkimConfig()
+        recoConfig = self.injectReRecoConfig()
+        dataProcArguments = getTestArguments()
+        dataProcArguments['ProcessingString']  = 'ProcString'
+        dataProcArguments['ConfigCacheID'] = recoConfig
+        dataProcArguments["SkimConfigs"] = [{"SkimName": "SomeSkim",
+                                             "SkimInput": "RECOoutput",
+                                             "SkimSplitAlgo": "FileBased",
+                                             "SkimSplitArgs": {"files_per_job": 1,
+                                                               "include_parents": True},
+                                             "ConfigCacheID": skimConfig,
+                                             "Scenario": None}]
+        dataProcArguments["CouchURL"] = os.environ["COUCHURL"]
+        dataProcArguments["CouchDBName"] = "rereco_t"
+        dataProcArguments["TransientOutputModules"] = ["RECOoutput"]
+
+        testWorkload = rerecoWorkload("TestWorkload", dataProcArguments)
+        testWorkload.setSpecUrl("somespec")
+        testWorkload.setOwnerDetails("sfoulkes@fnal.gov", "DMWM")
+
+        self.assertEqual(testWorkload.data.tasks.DataProcessing.tree.children.\
+                         SomeSkim.tree.children.SomeSkimMergeSkimB.steps.cmsRun1.output.modules.\
+                         Merged.mergedLFNBase,
+                         '/store/data/WMAgentCommissioning10/MinimumBias/USER/SkimBFilter-ProcString-v2')
+
+        testWMBSHelper = WMBSHelper(testWorkload, "DataProcessing", "SomeBlock", cachepath = self.testDir)
+        testWMBSHelper.createTopLevelFileset()
+        testWMBSHelper.createSubscription(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
+
+        skimWorkflow = Workflow(name = "TestWorkload",
+                                task = "/TestWorkload/DataProcessing/SomeSkim")
+        skimWorkflow.load()
+
+        self.assertEqual(len(skimWorkflow.outputMap.keys()), 3,
+                         "Error: Wrong number of WF outputs.")
+
+        goldenOutputMods = ["SkimA", "SkimB"]
+        for goldenOutputMod in goldenOutputMods:
+            mergedOutput = skimWorkflow.outputMap[goldenOutputMod][0]["merged_output_fileset"]
+            unmergedOutput = skimWorkflow.outputMap[goldenOutputMod][0]["output_fileset"]
+
+            mergedOutput.loadData()
+            unmergedOutput.loadData()
+
+            self.assertEqual(mergedOutput.name, "/TestWorkload/DataProcessing/SomeSkim/SomeSkimMerge%s/merged-Merged" % goldenOutputMod,
+                             "Error: Merged output fileset is wrong: %s" % mergedOutput.name)
+            self.assertEqual(unmergedOutput.name, "/TestWorkload/DataProcessing/SomeSkim/unmerged-%s" % goldenOutputMod,
+                             "Error: Unmerged output fileset is wrong: %s" % unmergedOutput.name)
+
+        logArchOutput = skimWorkflow.outputMap["logArchive"][0]["merged_output_fileset"]
+        unmergedLogArchOutput = skimWorkflow.outputMap["logArchive"][0]["output_fileset"]
+        logArchOutput.loadData()
+        unmergedLogArchOutput.loadData()
+
+        self.assertEqual(logArchOutput.name, "/TestWorkload/DataProcessing/SomeSkim/unmerged-logArchive",
+                         "Error: LogArchive output fileset is wrong.")
+        self.assertEqual(unmergedLogArchOutput.name, "/TestWorkload/DataProcessing/SomeSkim/unmerged-logArchive",
+                         "Error: LogArchive output fileset is wrong.")
+
+        for goldenOutputMod in goldenOutputMods:
+            mergeWorkflow = Workflow(name = "TestWorkload",
+                                     task = "/TestWorkload/DataProcessing/SomeSkim/SomeSkimMerge%s" % goldenOutputMod)
+            mergeWorkflow.load()
+
+            self.assertEqual(len(mergeWorkflow.outputMap.keys()), 2,
+                             "Error: Wrong number of WF outputs.")
+
+            mergedMergeOutput = mergeWorkflow.outputMap["Merged"][0]["merged_output_fileset"]
+            unmergedMergeOutput = mergeWorkflow.outputMap["Merged"][0]["output_fileset"]
+
+            mergedMergeOutput.loadData()
+            unmergedMergeOutput.loadData()
+
+            self.assertEqual(mergedMergeOutput.name, "/TestWorkload/DataProcessing/SomeSkim/SomeSkimMerge%s/merged-Merged" % goldenOutputMod,
+                             "Error: Merged output fileset is wrong.")
+            self.assertEqual(unmergedMergeOutput.name, "/TestWorkload/DataProcessing/SomeSkim/SomeSkimMerge%s/merged-Merged" % goldenOutputMod,
+                             "Error: Unmerged output fileset is wrong.")
+
+            logArchOutput = mergeWorkflow.outputMap["logArchive"][0]["merged_output_fileset"]
+            unmergedLogArchOutput = mergeWorkflow.outputMap["logArchive"][0]["output_fileset"]
+            logArchOutput.loadData()
+            unmergedLogArchOutput.loadData()
+
+            self.assertEqual(logArchOutput.name, "/TestWorkload/DataProcessing/SomeSkim/SomeSkimMerge%s/merged-logArchive" % goldenOutputMod,
+                             "Error: LogArchive output fileset is wrong: %s" % logArchOutput.name)
+            self.assertEqual(unmergedLogArchOutput.name, "/TestWorkload/DataProcessing/SomeSkim/SomeSkimMerge%s/merged-logArchive" % goldenOutputMod,
+                             "Error: LogArchive output fileset is wrong.")
+
+        topLevelFileset = Fileset(name = "/TestWorkload/DataProcessing/unmerged-RECOoutput")
+        topLevelFileset.loadData()
+
+        skimSubscription = Subscription(fileset = topLevelFileset, workflow = skimWorkflow)
+        skimSubscription.loadData()
+
+        self.assertEqual(skimSubscription["type"], "Skim",
+                         "Error: Wrong subscription type.")
+        self.assertEqual(skimSubscription["split_algo"], "FileBased",
+                         "Error: Wrong split algo.")
+
+        for skimOutput in ["A", "B"]:
+            unmerged = Fileset(name = "/TestWorkload/DataProcessing/SomeSkim/unmerged-Skim%s" % skimOutput)
+            unmerged.loadData()
+            mergeWorkflow = Workflow(name = "TestWorkload",
+                                      task = "/TestWorkload/DataProcessing/SomeSkim/SomeSkimMergeSkim%s" % skimOutput)
+            mergeWorkflow.load()
+            mergeSubscription = Subscription(fileset = unmerged, workflow = mergeWorkflow)
+            mergeSubscription.loadData()
+
+            self.assertEqual(mergeSubscription["type"], "Merge",
+                             "Error: Wrong subscription type.")
+            self.assertEqual(mergeSubscription["split_algo"], "ParentlessMergeBySize",
+                             "Error: Wrong split algo.")
+
+        for skimOutput in ["A", "B"]:
+            unmerged = Fileset(name = "/TestWorkload/DataProcessing/SomeSkim/unmerged-Skim%s" % skimOutput)
+            unmerged.loadData()
+            cleanupWorkflow = Workflow(name = "TestWorkload",
+                                      task = "/TestWorkload/DataProcessing/SomeSkim/SomeSkimCleanupUnmergedSkim%s" % skimOutput)
+            cleanupWorkflow.load()
+            cleanupSubscription = Subscription(fileset = unmerged, workflow = cleanupWorkflow)
+            cleanupSubscription.loadData()
+
+            self.assertEqual(cleanupSubscription["type"], "Cleanup",
+                             "Error: Wrong subscription type.")
+            self.assertEqual(cleanupSubscription["split_algo"], "SiblingProcessingBased",
+                             "Error: Wrong split algo.")
+
+        for skimOutput in ["A", "B"]:
+            skimMergeLogCollect = Fileset(name = "/TestWorkload/DataProcessing/SomeSkim/SomeSkimMergeSkim%s/merged-logArchive" % skimOutput)
+            skimMergeLogCollect.loadData()
+            skimMergeLogCollectWorkflow = Workflow(name = "TestWorkload",
+                                                   task = "/TestWorkload/DataProcessing/SomeSkim/SomeSkimMergeSkim%s/SomeSkimSkim%sMergeLogCollect" % (skimOutput, skimOutput))
+            skimMergeLogCollectWorkflow.load()
+            logCollectSub = Subscription(fileset = skimMergeLogCollect, workflow = skimMergeLogCollectWorkflow)
+            logCollectSub.loadData()
+
+            self.assertEqual(logCollectSub["type"], "LogCollect",
+                             "Error: Wrong subscription type.")
+            self.assertEqual(logCollectSub["split_algo"], "MinFileBased",
+                             "Error: Wrong split algo.")
 
         return
 


### PR DESCRIPTION
Add the option to the ReReco spec to keep some output module unmerged
but still run skims on it if necessary, if no skim is defined for it
the output will be produced, stored in unmerged area and cleaned up
afterwards.
