### PR TITLE
Fix another possible glitch in the Tier-0 plugin

### DIFF
--- a/src/couchapps/WMStats/updates/requestStatus.js
+++ b/src/couchapps/WMStats/updates/requestStatus.js
@@ -19,6 +19,8 @@ function (doc, req) {
                 }
             } else if ((lastState == "aborted-completed") && (statusObj.status != "abort-archived")) {
                 legalTransition = false;
+            } else if ((lastState == "normal-archived") || (lastState == "abort-archived")) {
+                legalTransition = false;
             }
             if (legalTransition) {
                 doc.request_status.push(statusObj);


### PR DESCRIPTION
normal-archived and aborted-archived are final status and therefore
no transition from them should be admitted.

@ticoann, please review
