### PR TITLE
Fix EventBased algorithm dropping zero event lumis

### DIFF
--- a/src/python/WMCore/DataStructs/Mask.py
+++ b/src/python/WMCore/DataStructs/Mask.py
@@ -41,8 +41,11 @@ class Mask(dict):
         Set FirstEvent & LastEvent fields as max & skip events
 
         """
+
         self['FirstEvent'] = skipEvents
-        self['LastEvent']  = skipEvents + maxEvents
+        if maxEvents is not None:
+            self['LastEvent']  = skipEvents + maxEvents
+
         return
 
     def setMaxAndSkipLumis(self, maxLumis, skipLumi):

--- a/src/python/WMCore/JobSplitting/EventBased.py
+++ b/src/python/WMCore/JobSplitting/EventBased.py
@@ -72,15 +72,13 @@ class EventBased(JobFactory):
                             if eventsPerJob + currentEvent < eventsInFile:
                                 self.currentJob["mask"].setMaxAndSkipEvents(eventsPerJob, currentEvent)
                             else:
-                                self.currentJob["mask"].setMaxAndSkipEvents(eventsInFile - currentEvent,
+                                self.currentJob["mask"].setMaxAndSkipEvents(None,
                                                                             currentEvent)
                             currentEvent += eventsPerJob
                             totalJobs    += 1
                     else:
                         self.newJob(name = self.getJobName(length=totalJobs))
                         self.currentJob.addFile(f)
-                        if f["events"]:
-                            self.currentJob["mask"].setMaxAndSkipEvents(f["events"], 0)
                         totalJobs += 1
                 else:
                     #This assumes there's only one run which is the case for MC

--- a/test/python/WMCore_t/JobSplitting_t/EventBased_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/EventBased_t.py
@@ -135,7 +135,7 @@ class EventBasedTest(unittest.TestCase):
         assert job.getFiles(type = "lfn") == ["/some/file/name"], \
                "ERROR: Job contains unknown files."
 
-        assert job["mask"].getMaxEvents() == 100, \
+        assert job["mask"].getMaxEvents() is None, \
                "ERROR: Job's max events is incorrect."
 
         assert job["mask"]["FirstEvent"] == 0, \
@@ -166,10 +166,10 @@ class EventBasedTest(unittest.TestCase):
         assert job.getFiles(type = "lfn") == ["/some/file/name"], \
                "ERROR: Job contains unknown files."
 
-        assert job["mask"].getMaxEvents() == 100, \
+        assert job["mask"].getMaxEvents() is None, \
                "ERROR: Job's max events is incorrect."
 
-        assert job["mask"]["FirstEvent"] == 0, \
+        assert job["mask"]["FirstEvent"] is None, \
                "ERROR: Job's first event is incorrect."
 
         return
@@ -198,7 +198,7 @@ class EventBasedTest(unittest.TestCase):
             assert job.getFiles(type = "lfn") == ["/some/file/name"], \
                    "ERROR: Job contains unknown files."
 
-            assert job["mask"].getMaxEvents() == 50, \
+            assert job["mask"].getMaxEvents() == 50 or job["mask"].getMaxEvents() is None, \
                    "ERROR: Job's max events is incorrect."
 
             assert job["mask"]["FirstEvent"] in [0, 50], \
@@ -233,7 +233,7 @@ class EventBasedTest(unittest.TestCase):
             assert job.getFiles(type = "lfn") == ["/some/file/name"], \
                    "ERROR: Job contains unknown files."
 
-            self.assertTrue(job["mask"].getMaxEvents() == 99 or job['mask'].getMaxEvents() == 1,
+            self.assertTrue(job["mask"].getMaxEvents() == 99 or job['mask'].getMaxEvents() is None,
                             "ERROR: Job's max events is incorrect.")
 
             assert job["mask"]["FirstEvent"] in [0, 99], \
@@ -267,7 +267,7 @@ class EventBasedTest(unittest.TestCase):
             assert len(job.getFiles(type = "lfn")) == 1, \
                    "ERROR: Job contains too many files."
 
-            assert job["mask"].getMaxEvents() == 100, \
+            assert job["mask"].getMaxEvents() is None, \
                    "ERROR: Job's max events is incorrect."
 
             assert job["mask"]["FirstEvent"] == 0, \
@@ -298,7 +298,7 @@ class EventBasedTest(unittest.TestCase):
             assert len(job.getFiles(type = "lfn")) == 1, \
                    "ERROR: Job contains too many files."
 
-            assert job["mask"].getMaxEvents() == 50, \
+            assert job["mask"].getMaxEvents() == 50 or job["mask"].getMaxEvents() is None, \
                    "ERROR: Job's max events is incorrect."
 
             assert job["mask"]["FirstEvent"] in [0, 50], \
@@ -329,10 +329,10 @@ class EventBasedTest(unittest.TestCase):
             assert len(job.getFiles(type = "lfn")) == 1, \
                    "ERROR: Job contains too many files."
 
-            assert job["mask"].getMaxEvents() == 100, \
+            assert job["mask"].getMaxEvents() is None, \
                    "ERROR: Job's max events is incorrect."
 
-            assert job["mask"]["FirstEvent"] == 0, \
+            assert job["mask"]["FirstEvent"] is None, \
                    "ERROR: Job's first event is incorrect."
     def testMCExactEvents(self):
         """


### PR DESCRIPTION
The current mask definition performed by the EventBased splitting
algorithm on non-mc input files can lead to missing lumis in the output.
This occurs when an input file has zero events in the last lumis, because
the cmsRun process will stop once it has reached the max events and won't process
those eventless lumis. To fix this, avoid passing the maxEvents parameter
when configuring the mask of the last job in a file, the skipEvents parameter
will suffice and the job will run over the remainder of the file.

Many assertions changed in the unit tests, since we change from having
always a max events to having it only on intermediate jobs in a file.
