### PR TITLE
Fix Block policy accounting of lumis

### DIFF
--- a/src/python/WMCore/Services/DBS/DBS2Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS2Reader.py
@@ -121,6 +121,35 @@ class DBS2Reader:
 
         return [x["RunNumber"] for x in results]
 
+    def listRunLumis(self, dataset = None, block = None):
+        """
+        It gets a list of DBSRun objects and returns the number of lumisections per run
+        DbsRun (RunNumber,
+                NumberOfEvents,
+                NumberOfLumiSections,
+                TotalLuminosity,
+                StoreNumber,
+                StartOfRungetLong,
+                EndOfRun,
+                CreationDate,
+                CreatedBy,
+                LastModificationDate,
+                LastModifiedBy
+                )
+        """
+        try:
+            if block:
+                results = self.dbs.listRuns(block = block)
+            else:
+                results = self.dbs.listRuns(dataset = dataset)
+        except DbsException, ex:
+            msg = "Error in DBSReader.listRuns(%s, %s)\n" % (dataset, block)
+            msg += "%s\n" % formatEx(ex)
+            raise DBSReaderError(msg)
+
+        return dict((x["RunNumber"], x["NumberOfLumiSections"])
+                    for x in results)
+
     def listProcessedDatasets(self, primary, dataTier = None):
         """
         _listProcessedDatasets_

--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -140,6 +140,35 @@ class DBS3Reader:
         [runs.extend(x['run_num']) for x in results]
         return runs
 
+    def listRunLumis(self, dataset = None, block = None):
+        """
+        It gets a list of DBSRun objects and returns the number of lumisections per run
+        DbsRun (RunNumber,
+                NumberOfEvents,
+                NumberOfLumiSections,
+                TotalLuminosity,
+                StoreNumber,
+                StartOfRungetLong,
+                EndOfRun,
+                CreationDate,
+                CreatedBy,
+                LastModificationDate,
+                LastModifiedBy
+                )
+        """
+        try:
+            if block:
+                results = self.dbs.listRuns(block = block)
+            else:
+                results = self.dbs.listRuns(dataset = dataset)
+        except DbsException, ex:
+            msg = "Error in DBSReader.listRuns(%s, %s)\n" % (dataset, block)
+            msg += "%s\n" % formatEx(ex)
+            raise DBSReaderError(msg)
+
+        return dict((x["run_num"], x["num_lumi"])
+                    for x in results)
+
     def listProcessedDatasets(self, primary, dataTier = '*'):
         """
         _listProcessedDatasets_

--- a/src/python/WMCore/WorkQueue/Policy/Start/Dataset.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Dataset.py
@@ -102,9 +102,9 @@ class Dataset(StartPolicyInterface):
 
             # check run restrictions
             if runWhiteList or runBlackList:
-                # listRuns returns a run number per lumi section
-                full_lumi_list = dbs.listRuns(block = block['block'])
-                runs = set(full_lumi_list)
+                # listRunLumis returns a dictionary with the lumi sections per run
+                runLumis = dbs.listRunLumis(block = block['block'])
+                runs = set(runLumis.keys())
 
                 # apply blacklist
                 runs = runs.difference(runBlackList)
@@ -118,11 +118,18 @@ class Dataset(StartPolicyInterface):
                 # recalculate effective size of block
                 # make a guess for new event/file numbers from ratio
                 # of accepted lumi sections (otherwise have to pull file info)
-                accepted_lumis = [x for x in full_lumi_list if x in runs]
-                ratio_accepted = 1. * len(accepted_lumis) / len(full_lumi_list)
-                block[self.lumiType] = len(accepted_lumis)
-                block['NumberOfFiles'] = float(block['NumberOfFiles']) * ratio_accepted
-                block['NumberOfEvents'] = float(block['NumberOfEvents']) * ratio_accepted
+                acceptedLumiCount = 0
+                fullLumiCount = 0
+                acceptedLumiCount = 0
+                fullLumiCount = 0
+                for run in runLumis:
+                    if run in runs:
+                        acceptedLumiCount += runLumis[run]
+                    fullLumiCount += runLumis[run]
+                ratioAccepted = float(acceptedLumiCount) / fullLumiCount
+                block[self.lumiType] = acceptedLumiCount
+                block['NumberOfFiles'] = int(float(block['NumberOfFiles']) * ratioAccepted)
+                block['NumberOfEvents'] = int(float(block['NumberOfEvents']) * ratioAccepted)
 
             validBlocks.append(block)
             if locations is None:

--- a/src/python/WMQuality/Emulators/DataBlockGenerator/Globals.py
+++ b/src/python/WMQuality/Emulators/DataBlockGenerator/Globals.py
@@ -61,6 +61,7 @@ class GlobalParams(object):
 
     @staticmethod
     def numOfLumisPerBlock():
+        #It's really the number of lumis per file
         return GlobalParams._num_of_lumis_per_block
 
     @staticmethod

--- a/test/python/WMCore_t/Services_t/DBS_t/DBSReader_t.py
+++ b/test/python/WMCore_t/Services_t/DBS_t/DBSReader_t.py
@@ -67,6 +67,17 @@ class DBSReaderTest(unittest.TestCase):
         self.assertEqual([173657], runs)
 
     @attr("integration")
+    def testlistRunLumis(self):
+        """listRunLumis returns known runs and lumicounts"""
+        self.dbs = DBSReader(self.endpoint)
+        runs = self.dbs.listRunLumis(dataset = DATASET)
+        self.assertEqual(46, len(runs))
+        self.assertTrue(173692 in runs)
+        self.assertEqual(runs[173692], 2782)
+        runs = self.dbs.listRuns(dataset = DATASET, block = BLOCK)
+        self.assertEqual({173657 : 94}, runs)
+
+    @attr("integration")
     def testListProcessedDatasets(self):
         """listProcessedDatasets returns known processed datasets"""
         self.dbs = DBSReader(self.endpoint)

--- a/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Block_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Block_t.py
@@ -215,9 +215,9 @@ class BlockTestCase(unittest.TestCase):
     def testRunWhitelist(self):
         """ReReco lumi split with Run whitelist"""
         # get files with multiple runs
-        Globals.GlobalParams.setNumOfRunsPerFile(2)
+        Globals.GlobalParams.setNumOfRunsPerFile(8)
         # a large number of lumis to ensure we get multiple runs
-        Globals.GlobalParams.setNumOfLumisPerBlock(10)
+        Globals.GlobalParams.setNumOfLumisPerBlock(20)
         splitArgs = dict(SliceType = 'NumberOfLumis', SliceSize = 1)
 
         Tier1ReRecoWorkload = rerecoWorkload('ReRecoWorkload', rerecoArgs)
@@ -238,8 +238,10 @@ class BlockTestCase(unittest.TestCase):
             wq_jobs = 0
             for unit in units:
                 wq_jobs += unit['Jobs']
-                runs = dbs[inputDataset.dbsurl].listRuns(block = unit['Inputs'].keys()[0])
-                jobs += len([x for x in runs if x in getFirstTask(Tier1ReRecoWorkload).inputRunWhitelist()])
+                runLumis = dbs[inputDataset.dbsurl].listRunLumis(block = unit['Inputs'].keys()[0])
+                for run in runLumis:
+                    if run in getFirstTask(Tier1ReRecoWorkload).inputRunWhitelist():
+                        jobs += runLumis[run]
             self.assertEqual(int(jobs / splitArgs['SliceSize'] ) , int(wq_jobs))
 
     def testInvalidSpecs(self):

--- a/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Dataset_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Dataset_t.py
@@ -239,8 +239,10 @@ class DatasetTestCase(unittest.TestCase):
             wq_jobs = 0
             for unit in units:
                 wq_jobs += unit['Jobs']
-                runs = dbs[inputDataset.dbsurl].listRuns(unit['Inputs'].keys()[0])
-                jobs += len([x for x in runs if x in getFirstTask(Tier1ReRecoWorkload).inputRunWhitelist()])
+                runLumis = dbs[inputDataset.dbsurl].listRunLumis(dataset = unit['Inputs'].keys()[0])
+                for run in runLumis:
+                    if run in getFirstTask(Tier1ReRecoWorkload).inputRunWhitelist():
+                        jobs += runLumis[run]
             self.assertEqual(int(jobs / splitArgs['SliceSize'] ) , int(wq_jobs))
 
     def testInvalidSpecs(self):


### PR DESCRIPTION
When a run white/blacklist is present, the accounting of lumis is screwed up
and it only reports a number of lumis equal to the number of runs accepted in a block.

Unfortunately, DBS doesn't return block level information on runs and lumis
when calling the listRuns function. So the solution is the following:
- Check first with listRuns and apply run black and whitelist.
- If there is a single run in the block, and the block passed then no need to recalculate lumis.
- However if the block has more than one run, and the list of blocks in the run was affected
  by the run white/blacklist then recalculate the event/file/lumi counts by pulling full file
  information from DBS. This is expensive but we expect the case to be rarely present.

Note that in the dataset splitting it's not necessary to do all this since we can assume safely that a run doesn't cross dataset boundaries.

Tested it with a PromptSkim dataset (the most mixed up run/block distribution we produce :) ), it checks out against my manual calculations from DBS data.

@sfoulkes can you please review it?
