### PR TITLE
fix clone request function when priority changes

### DIFF
--- a/src/python/WMCore/RequestManager/RequestDB/Interface/Request/MakeRequest.py
+++ b/src/python/WMCore/RequestManager/RequestDB/Interface/Request/MakeRequest.py
@@ -15,7 +15,7 @@ import WMCore.RequestManager.RequestDB.Connection as DBConnect
 
 
 
-def createRequest(hnUser, groupName, requestName, requestType, workflowName, prep_id):
+def createRequest(hnUser, groupName, requestName, requestType, workflowName, prep_id, priority):
     """
     _createRequest_
 
@@ -80,7 +80,8 @@ def createRequest(hnUser, groupName, requestName, requestType, workflowName, pre
             request_status = statusMap['new'],
             association_id = groups[groupName],
             workflow = workflowName,
-            prep_id = prep_id
+            prep_id = prep_id,
+            request_priority = priority,
             )
     except Exception, ex:
         msg = "Unable to create request named %s\n" % requestName

--- a/src/python/WMCore/RequestManager/RequestDB/MySQL/Request/New.py
+++ b/src/python/WMCore/RequestManager/RequestDB/MySQL/Request/New.py
@@ -59,6 +59,8 @@ class New(DBFormatter):
             raise RuntimeError, msg
 
         priority = request.get("request_priority", 0)
+        if (priority == None):
+            priority = 0
         prep_id = request.get("prep_id", None)
 
         self.sql = """

--- a/src/python/WMCore/RequestManager/RequestMaker/CheckIn.py
+++ b/src/python/WMCore/RequestManager/RequestMaker/CheckIn.py
@@ -90,7 +90,8 @@ def checkIn(request, requestType = 'None'):
         requestName,
         request['RequestType'],
         request['RequestWorkflow'],
-        request.get('PrepID', None)
+        request.get('PrepID', None),
+        request.get('ReqMgrRequestBasePriority')
     )
     except Exception, ex:
         msg = "Error creating new request:\n"


### PR DESCRIPTION
@zdenekmaxa I found where it cause the problem. I attached your unittest in the fix.
Please review. (This will only handle request priority) It seems there are other priorities, (group and requestor), I am not sure that can be modified by user after it is created. In that case those need to be updated as well. 
Zdenek, please review.  
