### PR TITLE
ReqMgr cloned requests priority fix

### DIFF
--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
@@ -237,7 +237,7 @@ class Assign(WebAPI):
                                   int(kwargs.get("MaxMergeEvents", 50000)))
         helper.setupPerformanceMonitoring(int(kwargs.get("maxRSS", 2411724)),
                                           int(kwargs.get("maxVSize", 2411724)),
-                                          int(kwargs.get("SoftTimeout", 171600)),
+                                          int(kwargs.get("SoftTimeout", 167000)),
                                           int(kwargs.get("GracePeriod", 300)))
 
         # Check whether we should check location for the data

--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrRESTModel.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrRESTModel.py
@@ -4,7 +4,7 @@
 ReqMgrRESTModel
 
 This holds the methods for the REST model, all methods which
-will be available via HTTP PUT/GET/POST commands from the iconterface,
+will be available via HTTP PUT/GET/POST commands from the interface,
 the validation, the security for each, and the function calls for the
 DB interfaces they execute.
 
@@ -490,8 +490,9 @@ class ReqMgrRESTModel(RESTModel):
         A new request is generated.
         The cloned request has a newly generated RequestName, new timestamp,
         RequestDate, however -everything- else is copied from the original request.
-        Since Edgar changed his mind, he no longer
-        wants this cloned request be in the 'new' state but in 'assignment-approved'.
+        Addition: since Edgar changed his mind, he no longer
+        wants this cloned request be in the 'new' state but put 
+        straight into 'assignment-approved' state.
         
         """
         request = None
@@ -508,8 +509,11 @@ class ReqMgrRESTModel(RESTModel):
                 toRemove = ("RequestName", "RequestDate", "timeStamp", "ReqMgrRequestID",
                             "RequestWorkflow")
                 for remove in toRemove:
-                    del requestOrigDict[remove]                
+                    del requestOrigDict[remove]
                 newReqSchema.update(requestOrigDict) # clone
+                
+                # problem that priority wasn't preserved went down from here:
+                # via CheckIn.checkIn() -> MakeRequest.createRequest() -> Request.New.py factory
                 request = Utilities.buildWorkloadAndCheckIn(self, newReqSchema,
                                                             self.couchUrl, self.workloadDBName,
                                                             self.wmstatWriteURL, clone=True)

--- a/src/python/WMCore/RequestManager/RequestDB/Interface/Request/ChangeState.py
+++ b/src/python/WMCore/RequestManager/RequestDB/Interface/Request/ChangeState.py
@@ -66,6 +66,9 @@ def changeRequestStatus(requestName, newState, priority = None, wmstatUrl = None
     - *requestName* : name of the request to be modified
     - *newState*    : name of the new status for the request
     - *priority* : optional integer priority
+    
+    Apparently when changing request state (on assignment page),
+    it's possible to change priority at one go. Hence the argument is here.
 
     """
     #TODO: should we make this mendatory?

--- a/src/python/WMCore/RequestManager/RequestDB/Interface/Request/MakeRequest.py
+++ b/src/python/WMCore/RequestManager/RequestDB/Interface/Request/MakeRequest.py
@@ -15,7 +15,8 @@ import WMCore.RequestManager.RequestDB.Connection as DBConnect
 
 
 
-def createRequest(hnUser, groupName, requestName, requestType, workflowName, prep_id):
+def createRequest(hnUser, groupName, requestName, requestType, workflowName,
+                  prep_id, reqBasePriority):
     """
     _createRequest_
 
@@ -80,7 +81,8 @@ def createRequest(hnUser, groupName, requestName, requestType, workflowName, pre
             request_status = statusMap['new'],
             association_id = groups[groupName],
             workflow = workflowName,
-            prep_id = prep_id
+            prep_id = prep_id,
+            reqBasePriority = reqBasePriority
             )
     except Exception, ex:
         msg = "Unable to create request named %s\n" % requestName

--- a/src/python/WMCore/RequestManager/RequestDB/MySQL/Request/New.py
+++ b/src/python/WMCore/RequestManager/RequestDB/MySQL/Request/New.py
@@ -58,7 +58,9 @@ class New(DBFormatter):
             msg = "workflow not provided to Request.New.execute"
             raise RuntimeError, msg
 
-        priority = request.get("request_priority", 0)
+        priority = request.get("reqBasePriority", None)
+        priority = priority if priority else 0
+        
         prep_id = request.get("prep_id", None)
 
         self.sql = """

--- a/src/python/WMCore/RequestManager/RequestDB/Oracle/Request/New.py
+++ b/src/python/WMCore/RequestManager/RequestDB/Oracle/Request/New.py
@@ -56,9 +56,9 @@ class New(DBFormatter):
             msg = "workflow not provided to Request.New.execute"
             raise RuntimeError, msg
 
-
         prep_id = request.get("prep_id", None)
-        priority = request.get("request_priority", 0)
+        priority = request.get("reqBasePriority", None)
+        priority = priority if priority else 0
 
         self.sql = """
         INSERT INTO reqmgr_request (request_name, request_type,

--- a/src/python/WMCore/RequestManager/RequestMaker/CheckIn.py
+++ b/src/python/WMCore/RequestManager/RequestMaker/CheckIn.py
@@ -90,7 +90,8 @@ def checkIn(request, requestType = 'None'):
         requestName,
         request['RequestType'],
         request['RequestWorkflow'],
-        request.get('PrepID', None)
+        request.get('PrepID', None),
+        request.get('ReqMgrRequestBasePriority', None)
     )
     except Exception, ex:
         msg = "Error creating new request:\n"

--- a/src/templates/WMCore/WebTools/RequestManager/Assign.tmpl
+++ b/src/templates/WMCore/WebTools/RequestManager/Assign.tmpl
@@ -125,7 +125,7 @@ Max Merge Size <input type="text" name="MaxMergeSize" value=4294967296 size=10/>
 Max Merge Events <input type="text" name="MaxMergeEvents" value=50000 size=10/><br/>
 Memory limits: RSS (KiBytes) <input type="text" name="maxRSS" value=2411724 size=10/>
 VSS (KiBytes)<input type="text" name="maxVSize" value=2411724 size=10/><br/>
-Wallclock limits: Timeout (Seconds) <input type="text" name="SoftTimeout" value=171600 size=10/>
+Wallclock limits: Timeout (Seconds) <input type="text" name="SoftTimeout" value=167000 size=10/>
 GracePeriod (Seconds)<input type="text" name="GracePeriod" value=300 size=10/><br/>
 
 Acquisition Era: <input type="text" name="AcquisitionEra" size=20 value="$acqEra" /><br/>

--- a/test/data/ReqMgr/requests/MonteCarlo.json
+++ b/test/data/ReqMgr/requests/MonteCarlo.json
@@ -40,7 +40,7 @@
 		"ProcessingVersion": "ProcessingVersion-OVERRIDE-ME",
 		"maxRSS": 4294967296,
 		"maxVSize": 4294967296,
-		"SoftTimeout": 171600,
+		"SoftTimeout": 167000,
 		"GracePeriod": 300,
 		"dashboard": "dashboard-OVERRIDE-ME",
 		"Team": "Team--OVERRIDE-ME",

--- a/test/data/ReqMgr/requests/MonteCarloFromGEN.json
+++ b/test/data/ReqMgr/requests/MonteCarloFromGEN.json
@@ -39,7 +39,7 @@
 		"ProcessingVersion": "ProcessingVersion-OVERRIDE-ME",
 		"maxRSS": 4294967296,
 		"maxVSize": 4294967296,
-		"SoftTimeout": 171600,
+		"SoftTimeout": 167000,
 		"GracePeriod": 300,
 		"dashboard": "dashboard-OVERRIDE-ME",
 		"Team": "Team--OVERRIDE-ME",

--- a/test/data/ReqMgr/requests/ReDigi.json
+++ b/test/data/ReqMgr/requests/ReDigi.json
@@ -47,7 +47,7 @@
 		"ProcessingVersion": "ProcessingVersion-OVERRIDE-ME",
 		"maxRSS": 4294967296,
 		"maxVSize": 4294967296,
-		"SoftTimeout": 171600,
+		"SoftTimeout": 167000,
 		"GracePeriod": 300,
 		"dashboard": "dashboard-OVERRIDE-ME",
 		"Team": "Team--OVERRIDE-ME",

--- a/test/data/ReqMgr/requests/ReReco.json
+++ b/test/data/ReqMgr/requests/ReReco.json
@@ -43,7 +43,7 @@
 		"ProcessingVersion": "ProcessingVersion-OVERRIDE-ME",
 		"maxRSS": 4294967296,
 		"maxVSize": 4294967296,
-		"SoftTimeout": 171600,
+		"SoftTimeout": 167000,
 		"GracePeriod": 300,
 		"dashboard": "dashboard-OVERRIDE-ME",
 		"Team": "Team--OVERRIDE-ME",


### PR DESCRIPTION
When cloning a request which had changed priority, the newly cloned request
priority is on default values. Fixes goes via MakeRequest.createRequest() to
database DAOs Request/New.py
Also reqmgr.py checks the case.

Modified default value SoftTimeout on Ops request.
