### PR TITLE
Get the correct times out of a report if any

### DIFF
--- a/src/python/WMComponent/ErrorHandler/ErrorHandlerPoller.py
+++ b/src/python/WMComponent/ErrorHandler/ErrorHandlerPoller.py
@@ -159,12 +159,10 @@ class ErrorHandlerPoller(BaseWorkerThread):
                     stopTime  = times['stopTime']
 
                     if startTime == None or stopTime == None:
-                        # Well, then we have a problem.
-                        # There is something very wrong with this job, nevertheless we don't know what it is.
-                        # Rerun, and hope the times get written the next time around.
+                        # We have no information to make a decision, send them to cooloff.
+                        # The RetryManager will take it from here.
                         logging.error("No start, stop times for steps for job %i" % job['id'])
-                        continue
-
+                        cooloffJobs.append(job)
                     elif stopTime - startTime > self.maxFailTime:
                         msg = "Job %i exhausted after running on node for %i seconds" % (job['id'], stopTime - startTime)
                         logging.error(msg)

--- a/src/python/WMCore/FwkJobReport/Report.py
+++ b/src/python/WMCore/FwkJobReport/Report.py
@@ -1057,9 +1057,12 @@ class Report:
 
         for stepName in steps:
             timeStamps = self.getTimes(stepName = stepName)
-            if startTime > timeStamps['startTime']:
+            if timeStamps['startTime'] is None or timeStamps['stopTime'] is None:
+                # Unusable times
+                continue
+            if startTime is None or startTime > timeStamps['startTime']:
                 startTime = timeStamps['startTime']
-            if stopTime < timeStamps['stopTime']:
+            if stopTime is None or stopTime < timeStamps['stopTime']:
                 stopTime = timeStamps['stopTime']
 
         return {'startTime': startTime, 'stopTime': stopTime}


### PR DESCRIPTION
The function to retrieve the start and end time out of a FJR had a
bug where a None time would make it return always a None stopTime.

Fix it and also don't allow the ErrorHandler to get stuck if
the jobs don't have running time information.
