### PR TITLE
Fix unit tests breakage due to Specs_t

### DIFF
--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Analysis_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Analysis_t.py
@@ -35,6 +35,7 @@ class AnalysisTest(unittest.TestCase):
 
         couchServer = CouchServer(os.environ["COUCHURL"])
         self.configDatabase = couchServer.connectDatabase("analysis_t")
+        self.testDir = self.testInit.generateWorkDir()
         return
 
     def injectAnalysisConfig(self):
@@ -70,6 +71,7 @@ class AnalysisTest(unittest.TestCase):
         """
         self.testInit.tearDownCouch()
         self.testInit.clearDatabase()
+        self.testInit.delWorkDir()
         return
 
 
@@ -88,7 +90,7 @@ class AnalysisTest(unittest.TestCase):
         testWorkload.setSpecUrl("somespec")
         testWorkload.setOwnerDetails("marco.mascheroni@cern.ch", "DMWM")
 
-        testWMBSHelper = WMBSHelper(testWorkload, "Analysis", "SomeBlock")
+        testWMBSHelper = WMBSHelper(testWorkload, "Analysis", "SomeBlock", cachepath = self.testDir)
         testWMBSHelper.createTopLevelFileset()
         testWMBSHelper.createSubscription(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
         procWorkflow = Workflow(name = "TestWorkload",

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/MonteCarloFromGEN_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/MonteCarloFromGEN_t.py
@@ -35,6 +35,7 @@ class MonteCarloFromGENTest(unittest.TestCase):
 
         couchServer = CouchServer(os.environ["COUCHURL"])
         self.configDatabase = couchServer.connectDatabase("mclhe_t")
+        self.testDir = self.testInit.generateWorkDir()
         return
 
     def tearDown(self):
@@ -44,6 +45,8 @@ class MonteCarloFromGENTest(unittest.TestCase):
         Clear out the database.
         """
         self.testInit.clearDatabase()
+        self.testInit.tearDownCouch()
+        self.testInit.delWorkDir()
         return
 
     def injectConfig(self):
@@ -81,7 +84,7 @@ class MonteCarloFromGENTest(unittest.TestCase):
         testWorkload.setSpecUrl("somespec")
         testWorkload.setOwnerDetails("sfoulkes@fnal.gov", "DMWM")
 
-        testWMBSHelper = WMBSHelper(testWorkload, "MonteCarloFromGEN", "SomeBlock")
+        testWMBSHelper = WMBSHelper(testWorkload, "MonteCarloFromGEN", "SomeBlock", cachepath = self.testDir)
         testWMBSHelper.createTopLevelFileset()
         testWMBSHelper.createSubscription(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
 

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/PrivateMC_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/PrivateMC_t.py
@@ -33,6 +33,7 @@ class PrivateMCTest(unittest.TestCase):
 
         couchServer = CouchServer(os.environ["COUCHURL"])
         self.configDatabase = couchServer.connectDatabase("privatemc_t")
+        self.testDir = self.testInit.generateWorkDir()
         return
 
     def injectAnalysisConfig(self):
@@ -63,6 +64,7 @@ class PrivateMCTest(unittest.TestCase):
         """
         self.testInit.tearDownCouch()
         self.testInit.clearDatabase()
+        self.testInit.delWorkDir()
         return
 
     def testPrivateMC(self):
@@ -80,7 +82,7 @@ class PrivateMCTest(unittest.TestCase):
         testWorkload.setSpecUrl("somespec")
         testWorkload.setOwnerDetails("marco.mascheroni@cern.ch", "DMWM")
 
-        testWMBSHelper = WMBSHelper(testWorkload, "PrivateMC", "SomeBlock")
+        testWMBSHelper = WMBSHelper(testWorkload, "PrivateMC", "SomeBlock", cachepath = self.testDir)
         testWMBSHelper.createTopLevelFileset()
         testWMBSHelper.createSubscription(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
         procWorkflow = Workflow(name = "TestWorkload",

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/PromptReco_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/PromptReco_t.py
@@ -37,6 +37,7 @@ class PromptRecoTest(unittest.TestCase):
                                 useDefault = False)
         couchServer = CouchServer(os.environ["COUCHURL"])
         self.configDatabase = couchServer.connectDatabase("promptreco_t")
+        self.testDir = self.testInit.generateWorkDir()
         return
 
     def tearDown(self):
@@ -47,6 +48,7 @@ class PromptRecoTest(unittest.TestCase):
         """
         self.testInit.tearDownCouch()
         self.testInit.clearDatabase()
+        self.testInit.delWorkDir()
         return
 
     def setupPromptSkimConfigObject(self):
@@ -75,7 +77,7 @@ class PromptRecoTest(unittest.TestCase):
         testWorkload.setSpecUrl("somespec")
         testWorkload.setOwnerDetails("dballest@fnal.gov", "T0")
 
-        testWMBSHelper = WMBSHelper(testWorkload, "Reco", "SomeBlock")
+        testWMBSHelper = WMBSHelper(testWorkload, "Reco", "SomeBlock", cachepath = self.testDir)
         testWMBSHelper.createTopLevelFileset()
         testWMBSHelper.createSubscription(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
 
@@ -405,7 +407,7 @@ class PromptRecoTest(unittest.TestCase):
         testWorkload.setSpecUrl("somespec")
         testWorkload.setOwnerDetails("dballest@fnal.gov", "T0")
 
-        testWMBSHelper = WMBSHelper(testWorkload, "Reco", "SomeBlock")
+        testWMBSHelper = WMBSHelper(testWorkload, "Reco", "SomeBlock", cachepath = self.testDir)
         testWMBSHelper.createTopLevelFileset()
         testWMBSHelper.createSubscription(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
 

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/RelValMC_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/RelValMC_t.py
@@ -14,6 +14,7 @@ from WMCore.WMBS.Workflow import Workflow
 from WMCore.WorkQueue.WMBSHelper import WMBSHelper
 from WMQuality.TestInitCouchApp import TestInitCouchApp
 from WMCore.Database.CMSCouch import CouchServer, Document
+from WMCore.Services.EmulatorSwitch import EmulatorHelper
 
 
 class RelValMCTest(unittest.TestCase):
@@ -28,9 +29,10 @@ class RelValMCTest(unittest.TestCase):
         self.testInit.setupCouch("relvalmc_t", "ConfigCache")
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
+        self.testDir = self.testInit.generateWorkDir()
         couchServer = CouchServer(os.environ["COUCHURL"])
         self.configDatabase = couchServer.connectDatabase("relvalmc_t")
-
+        EmulatorHelper.setEmulators(dbs = True)
 
     def tearDown(self):
         """
@@ -39,7 +41,9 @@ class RelValMCTest(unittest.TestCase):
         """
         self.testInit.tearDownCouch()
         self.testInit.clearDatabase()
-
+        self.testInit.delWorkDir()
+        EmulatorHelper.resetEmulators()
+        return
 
     def _getConfigBase(self):
         """
@@ -421,7 +425,7 @@ class RelValMCTest(unittest.TestCase):
         testWorkload.setSpecUrl("somespec")
         testWorkload.setOwnerDetails("sfoulkes@fnal.gov", "DWMWM")
 
-        testWMBSHelper = WMBSHelper(testWorkload, "Generation", "SomeBlock")
+        testWMBSHelper = WMBSHelper(testWorkload, "Generation", "SomeBlock", cachepath = self.testDir)
         testWMBSHelper.createTopLevelFileset()
         testWMBSHelper.createSubscription(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
 
@@ -456,7 +460,7 @@ class RelValMCTest(unittest.TestCase):
         testWorkload.setSpecUrl("somespec")
         testWorkload.setOwnerDetails("sfoulkes@fnal.gov", "DWMWM")
 
-        testWMBSHelper = WMBSHelper(testWorkload, "Generation", "SomeBlock")
+        testWMBSHelper = WMBSHelper(testWorkload, "Generation", "SomeBlock", cachepath = self.testDir)
         testWMBSHelper.createTopLevelFileset()
         testWMBSHelper.createSubscription(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
 

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StoreResults_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StoreResults_t.py
@@ -30,6 +30,7 @@ class StoreResultsTest(unittest.TestCase):
         self.testInit.setDatabaseConnection()
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
+        self.testDir = self.testInit.generateWorkDir()
         return
 
     def tearDown(self):
@@ -39,6 +40,7 @@ class StoreResultsTest(unittest.TestCase):
         Clear out the database.
         """
         self.testInit.clearDatabase()
+        self.testInit.delWorkDir()
         return
 
     def testStoreResults(self):
@@ -54,7 +56,7 @@ class StoreResultsTest(unittest.TestCase):
         testWorkload.setSpecUrl("somespec")
         testWorkload.setOwnerDetails("ewv@fnal.gov", "DMWM")
 
-        testWMBSHelper = WMBSHelper(testWorkload, "StoreResults", "SomeBlock")
+        testWMBSHelper = WMBSHelper(testWorkload, "StoreResults", "SomeBlock", cachepath = self.testDir)
         testWMBSHelper.createTopLevelFileset()
         testWMBSHelper.createSubscription(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
 


### PR DESCRIPTION
Make sure that all unit tests in Specs_t use the temp directory
to store sandboxes and emulators for DBS

Fixes #4363
