### PR TITLE
Bugfix/update couchdb delete

### DIFF
--- a/src/python/WMCore/Database/CMSCouch.py
+++ b/src/python/WMCore/Database/CMSCouch.py
@@ -50,7 +50,8 @@ class Document(dict):
         """
         Mark the document as deleted
         """
-        self['_deleted'] = True
+        # https://issues.apache.org/jira/browse/COUCHDB-1141
+        self = { '_id' : self['_id'], '_rev' : self['_rev'], '_deleted' : self['_deleted'] }
 
     def __to_json__(self, thunker):
         """
@@ -206,7 +207,8 @@ class Database(CouchDBRequests):
         Queue up a document for deletion
         """
         assert isinstance(doc, type({})), "document not a dictionary"
-        doc['_deleted'] = True
+        # https://issues.apache.org/jira/browse/COUCHDB-1141
+        doc = { '_id' : doc['_id'], '_rev' : doc['_rev'], '_deleted' : True }
         self.queue(doc)
 
     def commitOne(self, doc, returndocs=False, timestamp = False, viewlist=[]):


### PR DESCRIPTION
A weird hitch in couch's delete semantics is that if you don't use the
DELETE verb (i.e. you commit with _bulk_docs and set _deleted=true), it
stores the whole data in the delete tombstone. See:

https://issues.apache.org/jira/browse/COUCHDB-1141

Since (AFAIK), we don't ever use _deleted_revs=true to look at things,
it means that we have tons of old data sitting around in couch that's
basically invisible. This patch strips the document before comitting it
so the only thing lefts are _id, _rev and _deleted
