### PR TITLE
Move Service/SiteDB to SiteDBv2

### DIFF
--- a/src/python/WMCore/Services/Service.py
+++ b/src/python/WMCore/Services/Service.py
@@ -195,7 +195,7 @@ class Service(dict):
         return cachefile
 
     def refreshCache(self, cachefile, url='', inputdata = {}, openfile=True,
-                     encoder = True, decoder = True, verb = 'GET', contentType = None):
+                     encoder = True, decoder = True, verb = 'GET', contentType = None, incoming_headers={}):
         """
         See if the cache has expired. If it has make a new request to the
         service for the input data. Return the cachefile as an open file object.
@@ -207,7 +207,7 @@ class Service(dict):
         cachefile = self.cacheFileName(cachefile, verb, inputdata)
 
         if cache_expired(cachefile):
-            self.getData(cachefile, url, inputdata, {}, encoder, decoder, verb, contentType)
+            self.getData(cachefile, url, inputdata, incoming_headers, encoder, decoder, verb, contentType)
 
         # cachefile may be filename or file object
         if openfile and not isfile(cachefile):
@@ -216,7 +216,8 @@ class Service(dict):
             return cachefile
 
     def forceRefresh(self, cachefile, url='', inputdata = {}, openfile=True,
-                     encoder = True, decoder = True, verb = 'GET', contentType = None):
+                     encoder = True, decoder = True, verb = 'GET',
+                     contentType = None, incoming_headers={}):
         """
         Make a new request to the service for the input data, regardless of the
         cache state. Return the cachefile as an open file object.
@@ -227,8 +228,9 @@ class Service(dict):
         cachefile = self.cacheFileName(cachefile, verb, inputdata)
 
         self['logger'].debug("Forcing cache refresh of %s" % cachefile)
-        self.getData(cachefile, url, inputdata, {'cache-control':'no-cache'},
-                     encoder, decoder, verb, contentType, force_refresh = True)
+        incoming_headers.update({'cache-control':'no-cache'})
+        self.getData(cachefile, url, inputdata, incoming_headers,
+                     encoder, decoder, verb, contentType, force_refresh = True, )
         if openfile and not isfile(cachefile):
             return open(cachefile, 'r')
         else:

--- a/src/python/WMCore/Services/SiteDB/SiteDB.py
+++ b/src/python/WMCore/Services/SiteDB/SiteDB.py
@@ -5,16 +5,22 @@ _SiteDB_
 API for dealing with retrieving information from SiteDB
 
 """
-
-
-
-
 from WMCore.Services.Service import Service
-
-# This should be deprecated in preference to simplejson once SiteDB spits out
-# correct json
-from WMCore.Services.JSONParser.JSONParser import JSONParser
 from WMCore.Services.EmulatorSwitch import emulatorHook
+
+import json
+
+def row2dict(columns, row):
+    """Convert rows to dictionaries with column keys from description"""
+    robj = {}
+    for k,v in zip(columns, row):
+        robj.setdefault(k,v)
+    return robj
+
+def unflattenJSON(data):
+    """Tranform input to unflatten JSON format"""
+    columns = data['desc']['columns']
+    return [row2dict(columns, row) for row in data['result']]
 
 # emulator hook is used to swap the class instance
 # when emulator values are set.
@@ -25,14 +31,12 @@ class SiteDBJSON(Service):
     """
     API for dealing with retrieving information from SiteDB
     """
+    def __init__(self, config={}):
+        config = dict(config)
+        config['endpoint'] = "https://cmsweb.cern.ch/sitedb/data/prod/"
+        Service.__init__(self, config)
 
-    def __init__(self, dict={}):
-        dict['endpoint'] = "https://cmsweb.cern.ch/sitedb/json/index/"
-        self.parser = JSONParser()
-
-        Service.__init__(self, dict)
-
-    def getJSON(self, callname, file = 'result.json', clearCache = False, verb = 'GET', **args):
+    def getJSON(self, callname, file = 'result.json', clearCache = False, verb = 'GET', data={}):
         """
         _getJSON_
 
@@ -43,54 +47,81 @@ class SiteDBJSON(Service):
         """
         result = ''
         if clearCache:
-            self.clearCache(file, args, verb = verb)
+            self.clearCache(cachefile=file, inputdata=data, verb = verb)
         try:
-            f = self.refreshCache(file, callname, args, verb = verb)
+            #Set content_type and accept_type to application/json to get json returned from siteDB.
+            #Default is text/html which will return xml instead
+            #Add accept-encoding to gzip,identity to overwrite httplib default gzip,deflate,
+            #which is not working properly with cmsweb
+            f = self.refreshCache(cachefile=file, url=callname, inputdata=data,
+                                  verb = verb, contentType='application/json',
+                                  incoming_headers={'Accept' : 'application/json',
+                                                    'accept-encoding' : 'gzip,identity'})
             result = f.read()
             f.close()
         except IOError:
             raise RuntimeError("URL not available: %s" % callname )
         try:
-            # When SiteDB sends proper json, we can use simplejson
-            # return json.loads(result)
-            results = self.parser.dictParser(result)
+            results = json.loads(result)
+            results = unflattenJSON(results)
             return results
         except SyntaxError:
             self.clearCache(file, args, verb = verb)
             raise SyntaxError("Problem parsing data. Cachefile cleared. Retrying may work")
 
+    def _people(self, username=None, clearCache=False):
+        if username:
+            file = 'people_%s.json' % (username)
+            people = self.getJSON("people", file=file, clearCache=clearCache, data=dict(match=username))
+        else:
+            file = 'people.json'
+            people = self.getJSON("people", file=file, clearCache=clearCache)
+        return people
+
+    def _sitenames(self, sitename=None, clearCache=False):
+        if sitename:
+            file = 'site-names_%s.json' % (sitename)
+            sitenames = self.getJSON('site-names', file=file, clearCache=clearCache, data=dict(match=sitename))
+        else:
+            file = 'site-names.json'
+            sitenames = self.getJSON('site-names', file=file, clearCache=clearCache)
+        return sitenames
+
+    def _siteresources(self, clearCache=False):
+        file = 'site-resources.json'
+        return self.getJSON('site-resources', file=file)
 
     def dnUserName(self, dn):
         """
         Convert DN to Hypernews name. Clear cache between trys
         in case user just registered or fixed an issue with SiteDB
         """
-        file = 'dnUserName_%s.json' % str(dn.__hash__())
         try:
-            userinfo = self.getJSON("dnUserName", dn=dn, file=file)
-            userName = userinfo['user']
+            userinfo = filter(lambda x: x['dn']==dn, self._people())[0]
+            username = userinfo['username']
         except (KeyError, IndexError):
-            userinfo = self.getJSON("dnUserName", dn=dn,
-                                        file=file, clearCache=True)
-            userName = userinfo['user']
-        return userName
-
+            userinfo = filter(lambda x: x['dn']==dn, self._people())[0]
+            username = userinfo['username']
+        return username
 
     def cmsNametoCE(self, cmsName):
         """
         Convert CMS name to list of CEs
         """
-        file = 'cmsNametoCE_%s.json' % cmsName
-        ceList = self.cmsNametoList(cmsName, 'CE', file=file)
+        sitenames = filter(lambda x: x['type']=='cms' and x['alias']==cmsName, self._sitenames())[0]
+        siteresources = filter(lambda x: x['site_name']==sitenames['site_name'], self._siteresources())
+        ceList = filter(lambda x: x['type']=='CE', siteresources)
+        ceList = map(lambda x: x['fqdn'], ceList)
         return ceList
-
 
     def cmsNametoSE(self, cmsName):
         """
         Convert CMS name to list of SEs
         """
-        file = 'cmsNametoSE_%s.json' % cmsName
-        seList = self.cmsNametoList(cmsName, 'SE', file=file)
+        sitenames = filter(lambda x: x['type']=='cms' and x['alias']==cmsName, self._sitenames())[0]
+        siteresources = filter(lambda x: x['site_name']==sitenames['site_name'], self._siteresources())
+        seList = filter(lambda x: x['type']=='SE', siteresources)
+        seList = map(lambda x: x['fqdn'], seList)
         return seList
 
     def getAllSENames(self):
@@ -100,8 +131,9 @@ class SiteDBJSON(Service):
         Get all SE names from SiteDB
         This is so that we can easily add them to ResourceControl
         """
-        file = 'cmsNametoSE_*.json'
-        seList = self.cmsNametoList('*', 'SE', file=file)
+        siteresources = self._siteresources()
+        seList = filter(lambda x: x['type']=='SE', siteresources)
+        seList = map(lambda x: x['fqdn'], seList)
         return seList
 
     def getAllCMSNames(self):
@@ -111,68 +143,36 @@ class SiteDBJSON(Service):
         Get all the CMSNames from siteDB
         This will allow us to add them in resourceControl at once
         """
-        result = []
-        file = 'SitetoCMSName_*.json'
-        theInfo = self.getJSON("SEtoCMSName", file=file, name='%')
-        for key in theInfo.keys():
-            name = theInfo[key]['name']
-            if not name in result:
-                result.append(name)
-        return result
+        sitenames = self._sitenames()
+        cmsnames = filter(lambda x: x['type']=='cms', sitenames)
+        cmsnames = map(lambda x: x['alias'], cmsnames)
+        return cmsnames
 
     def cmsNametoList(self, cmsName, kind, file):
-        """
-        Convert CMS name to list of CEs or SEs
-        """
-
-        cmsName = cmsName.replace('*','%')
-        cmsName = cmsName.replace('?','_')
-        theInfo = self.getJSON("CMSNameto"+kind, file=file, name=cmsName)
-
-        theList = []
-        for index in theInfo:
-            try:
-                item = theInfo[index]['name']
-                if item:
-                    theList.append(item)
-            except KeyError:
-                pass
-
-        return theList
-
+        if kind=='CE':
+            return cmsNametoCE(cmsName)
+        elif kind=='SE':
+            return cmsNametoSE(cmsName)
+        else:
+            raise NotImplemented('cmsNametoList for kind: %s is not yet implemented' % (kind))
 
     def seToCMSName(self, se):
         """
         Convert SE name to the CMS Site they belong to
         """
-        # Can't understand why this needs to be a list (T1/T2 sharing SE?)
-        file = 'seToCMSName_%s.json' % se
-        try:
-            info = self.getJSON("SEtoCMSName", name=se, file=file)
-            cmsName = info['0']['name']
-        except (KeyError, IndexError):
-            info = self.getJSON("SEtoCMSName", name=se, file=file, clearCache=True)
-            cmsName = info['0']['name']
-        return cmsName
-
+        siteresources = filter(lambda x: x['fqdn']==se, self._siteresources())[0]
+        cmsname = filter(lambda x: x['type']=='cms', self._sitenames(sitename=siteresources['site_name']))[0]['alias']
+        return cmsname
 
     def cmsNametoPhEDExNode(self, cmsName):
         """
         Convert CMS name to list of Phedex Nodes
         """
-        file = 'cmsNametoPhEDExNode_%s.json' % cmsName
-        theInfo = self.getJSON("CMSNametoPhEDExNode", file=file, cms_name=cmsName)
-
-        theList = []
-        for index in theInfo:
-            try:
-                item = theInfo[index]['phedex_node']
-                if item:
-                    theList.append(item)
-            except KeyError:
-                pass
-
-        return theList
+        sitenames = self._sitenames()
+        sitename = filter(lambda x: x['type']=='cms' and x['alias']==cmsName, sitenames)[0]['site_name']
+        phedexnames = filter(lambda x: x['type']=='phedex' and x['site_name']==sitename, sitenames)
+        phedexnames = map(lambda x: x['alias'], phedexnames)
+        return phedexnames
 
 
     def phEDExNodetocmsName(self, node):

--- a/src/python/WMQuality/Emulators/SiteDBClient/SiteDB.py
+++ b/src/python/WMQuality/Emulators/SiteDBClient/SiteDB.py
@@ -6,15 +6,123 @@ Emulating SiteDB
 """
 
 class SiteDBJSON(object):
-
     """
     API for dealing with retrieving information from SiteDB
     """
-    mapping = {'T2_XX_SiteA' : 'a.example.com', 'T2_XX_SiteB' : 'b.example.com'}
+    _people_data = [{'dn' : '/C=UK/O=eScience/OU=Bristol/L=IS/CN=simon metson',
+                     'username' : 'metson'},
+                    {'dn' : "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=liviof/CN=472739/CN=Livio Fano'",
+                     'username' : 'liviof'}]
 
+    _sitenames_data = [{u'site_name': u'FNAL', u'type': u'cms', u'alias': u'T1_US_FNAL'},
+                       {u'site_name': u'FNAL', u'type': u'phedex', u'alias': u'T1_US_FNAL_Buffer'},
+                       {u'site_name': u'FNAL', u'type': u'phedex', u'alias': u'T1_US_FNAL_MSS'},
+                       {u'site_name': u'RAL', u'type': u'cms', u'alias': u'T1_UK_RAL'}]
 
-    def __init__(self, dict={}):
+    _siteresources_data = [{u'type': u'CE', u'site_name': u'RAL', u'fqdn': u'lcgce11.gridpp.rl.ac.uk', u'is_primary': u'n'},
+                           {u'type': u'CE', u'site_name': u'RAL', u'fqdn': u'lcgce10.gridpp.rl.ac.uk', u'is_primary': u'n'},
+                           {u'type': u'SE', u'site_name': u'RAL', u'fqdn': u'srm-cms.gridpp.rl.ac.uk', u'is_primary': u'n'},
+                           {u'type': u'CE', u'site_name': u'RAL', u'fqdn': u'lcgce02.gridpp.rl.ac.uk', u'is_primary': u'n'},
+                           {u'type': u'CE', u'site_name': u'FNAL', u'fqdn': u'cmsosgce2.fnal.gov', u'is_primary': u'n'},
+                           {u'type': u'CE', u'site_name': u'FNAL', u'fqdn': u'cmsosgce4.fnal.gov', u'is_primary': u'n'},
+                           {u'type': u'CE', u'site_name': u'FNAL', u'fqdn': u'cmsosgce.fnal.gov', u'is_primary': u'n'},
+                           {u'type': u'SE', u'site_name': u'FNAL', u'fqdn': u'cmssrm.fnal.gov', u'is_primary': u'n'}]
+
+    def __init__(self, config={}):
         pass
+
+    def _people(self, username=None, clearCache=False):
+        return self._people_data
+
+    def _sitenames(self, sitename=None, clearCache=False):
+        return self._sitenames_data
+
+    def _siteresources(self, clearCache=False):
+        return self._siteresources_data
+
+    def dnUserName(self, dn):
+        """
+        Convert DN to Hypernews name. Clear cache between trys
+        in case user just registered or fixed an issue with SiteDB
+        """
+        try:
+            userinfo = filter(lambda x: x['dn']==dn, self._people())[0]
+            username = userinfo['username']
+        except (KeyError, IndexError):
+            userinfo = filter(lambda x: x['dn']==dn, self._people(clearCache=True))[0]
+            username = userinfo['username']
+        return username
+
+    def cmsNametoCE(self, cmsName):
+        """
+        Convert CMS name to list of CEs
+        """
+        sitenames = filter(lambda x: x['type']=='cms' and x['alias']==cmsName, self._sitenames())[0]
+        siteresources = filter(lambda x: x['site_name']==sitenames['site_name'], self._siteresources())
+        ceList = filter(lambda x: x['type']=='CE', siteresources)
+        ceList = map(lambda x: x['fqdn'], ceList)
+        return ceList
+
+    def cmsNametoSE(self, cmsName):
+        """
+        Convert CMS name to list of SEs
+        """
+        sitenames = filter(lambda x: x['type']=='cms' and x['alias']==cmsName, self._sitenames())[0]
+        siteresources = filter(lambda x: x['site_name']==sitenames['site_name'], self._siteresources())
+        seList = filter(lambda x: x['type']=='SE', siteresources)
+        seList = map(lambda x: x['fqdn'], seList)
+        return seList
+
+    def getAllSENames(self):
+        """
+        _getAllSENames_
+
+        Get all SE names from SiteDB
+        This is so that we can easily add them to ResourceControl
+        """
+        siteresources = self._siteresources()
+        seList = filter(lambda x: x['type']=='SE', siteresources)
+        seList = map(lambda x: x['fqdn'], seList)
+        return seList
+
+    def getAllCMSNames(self):
+        """
+        _getAllCMSNames_
+
+        Get all the CMSNames from siteDB
+        This will allow us to add them in resourceControl at once
+        """
+        sitenames = self._sitenames()
+        cmsnames = filter(lambda x: x['type']=='cms', sitenames)
+        cmsnames = map(lambda x: x['alias'], cmsnames)
+        return cmsnames
+
+    def cmsNametoList(self, cmsName, kind, file):
+        if kind=='CE':
+            return cmsNametoCE(cmsName)
+        elif kind=='SE':
+            return cmsNametoSE(cmsName)
+        else:
+            raise NotImplemented('cmsNametoList for kind: %s is not yet implemented' % (kind))
+
+    def seToCMSName(self, se):
+        """
+        Convert SE name to the CMS Site they belong to
+        """
+        siteresources = filter(lambda x: x['fqdn']==se, self._siteresources())[0]
+        cmsname = filter(lambda x: x['type']=='cms', self._sitenames(sitename=siteresources['site_name']))[0]['alias']
+        return cmsname
+
+    def cmsNametoPhEDExNode(self, cmsName):
+        """
+        Convert CMS name to list of Phedex Nodes
+        """
+        sitenames = self._sitenames()
+        sitename = filter(lambda x: x['type']=='cms' and x['alias']==cmsName, sitenames)[0]['site_name']
+        phedexnames = filter(lambda x: x['type']=='phedex' and x['site_name']==sitename, sitenames)
+        phedexnames = map(lambda x: x['alias'], phedexnames)
+        return phedexnames
+
 
     def phEDExNodetocmsName(self, node):
         """
@@ -26,16 +134,5 @@ class SiteDBJSON(object):
         name = node.replace('_MSS',
                             '').replace('_Buffer',
                                         '').replace('_Export', '')
+
         return name
-
-    def cmsNametoSE(self, name):
-        return self.mapping[name]
-
-    def seToCMSName(self, name):
-        if name == "cmssrm.fnal.gov":
-            return "T1_US_FNAL"
-        return name # for now se == site name
-
-    def getAllCMSNames(self):
-        """Return cms names"""
-        return self.mapping.keys()

--- a/test/python/WMCore_t/Services_t/SiteDB_t/SiteDB_t.py
+++ b/test/python/WMCore_t/Services_t/SiteDB_t/SiteDB_t.py
@@ -46,7 +46,7 @@ class SiteDBTest(unittest.TestCase):
         """
         Tests CmsNametoSE
         """
-        target = ['srm-cms.gridpp.rl.ac.uk', 'srm-cms-disk.gridpp.rl.ac.uk']
+        target = ['srm-cms.gridpp.rl.ac.uk']
         results = self.mySiteDB.cmsNametoSE("T1_UK_RAL")
         self.failUnless(sorted(results) == sorted(target))
 
@@ -62,20 +62,10 @@ class SiteDBTest(unittest.TestCase):
         """
         Tests CmsNametoCE
         """
-        target = ['lcgce09.gridpp.rl.ac.uk', 'lcgce06.gridpp.rl.ac.uk',
-                  'lcgce07.gridpp.rl.ac.uk', 'lcgce07.gridpp.rl.ac.uk']
+        target = ['lcgce11.gridpp.rl.ac.uk', 'lcgce10.gridpp.rl.ac.uk',
+                  'lcgce02.gridpp.rl.ac.uk']
         results = self.mySiteDB.cmsNametoCE("T1_UK_RAL")
         self.failUnless(sorted(results) == sorted(target))
-
-    def testJSONParser(self):
-        """
-        Tests the JSON parser directly
-        """
-        cmsName = "cmsgrid02.hep.wisc.edu"
-        results = self.mySiteDB.getJSON("CEtoCMSName",
-                                  file="CEtoCMSName",
-                                  name=cmsName)
-        self.failUnless(results['0']['name'] == "T2_US_Wisconsin")
 
     def testDNUserName(self):
         """
@@ -103,32 +93,10 @@ class SiteDBTest(unittest.TestCase):
         See if we can retrieve seNames from all sites
         """
 
-        ceNames = self.mySiteDB.getAllSENames()
-        self.assertTrue(len(ceNames) > 1)
-        self.assertTrue('cmssrm.fnal.gov' in ceNames)
+        seNames = self.mySiteDB.getAllSENames()
+        self.assertTrue(len(seNames) > 1)
+        self.assertTrue('cmssrm.fnal.gov' in seNames)
         return
-
-
-    @attr("integration")
-    def testParsingJsonWithApostrophe(self):
-        """
-        Tests parsing a DN json with an apostrophe in
-        """
-        json = """{"dn": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=liviof/CN=472739/CN=Livio Fano'", "user": "liviof"}"""
-        d = self.mySiteDB.parser.dictParser(json)
-        self.assertEquals("/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=liviof/CN=472739/CN=Livio Fano'", d['dn'])
-
-    @attr("integration")
-    def testParsingInvalidJsonWithApostrophe(self):
-        """
-        Tests parsing a DN invalid json (from sitedb v1) with an apostrophe in
-        """
-        json = """{'dn': '/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=liviof/CN=472739/CN=Livio' Fano', 'user': 'liviof'}"""
-        d = self.mySiteDB.parser.dictParser(json)
-        self.assertEquals("/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=liviof/CN=472739/CN=Livio' Fano", d['dn'])
-        json = """{'dn': '/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=liviof/CN=472739/CN=Livio Fano'', 'user': 'liviof'}"""
-        d = self.mySiteDB.parser.dictParser(json)
-        self.assertEquals("/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=liviof/CN=472739/CN=Livio Fano'", d['dn'])
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/WMCore_t/Services_t/SiteDB_t/SiteDB_t.py
+++ b/test/python/WMCore_t/Services_t/SiteDB_t/SiteDB_t.py
@@ -6,6 +6,7 @@ Test case for SiteDB
 import unittest
 
 from WMCore.Services.SiteDB.SiteDB import SiteDBJSON
+from WMCore.Services.EmulatorSwitch import EmulatorHelper
 
 from nose.plugins.attrib import attr
 
@@ -18,7 +19,11 @@ class SiteDBTest(unittest.TestCase):
         """
         Setup for unit tests
         """
+        EmulatorHelper.setEmulators(siteDB = True)
         self.mySiteDB = SiteDBJSON()
+
+    def tearDown(self):
+        EmulatorHelper.resetEmulators()
 
     def testCmsNametoPhEDExNode(self):
         """


### PR DESCRIPTION
Hi,

since the StoreResults service is using the Service/SiteDB.py for one of its components, I have adapted it to the new SiteDBv2. Please, feel free to include this into the WMCore repository by accept the pull request. I have also adapted the corresponding unittests. 

Few comments:
- The JSONParser is not needed anymore, since SiteDBv2 returns proper formatted json. Therefore, I have removed the parser specific unittests.
- I have also changed few of the expected results in the unittests, since the corresponding sites have updated there information.
- I had to change the Service.py as well, since httplib is forcing "accept-encoding: gzip, deflate" in http headers, if it is not set to a different value. This is not working with cmsweb and leads to an decoding problem. Therefore, I have added the possibility to add additional  incoming_headers to the refreshCache and forceRefresh methods of the Service class. The dictionary is passed through to the getData method, that already had the possibility to add additional headers.

Disclaimer: I am not sure, that always used the most efficient way to get the information. Please, feel free to improve the way of retrieving information. ;-)

Cheers,
Manuel 

P.S.: I wonder what is the current status of the Service package, since Service.py did not work out-of-box for me and some unittests failed before?
