### PR TITLE
Fix deletion of couch documents

### DIFF
--- a/src/couchapps/WMStats/validate_doc_update.js
+++ b/src/couchapps/WMStats/validate_doc_update.js
@@ -4,6 +4,10 @@ function(newDoc, oldDoc, userCtx) {
    var docOp = oldDoc ? (newDoc._deleted === true ? DOCOPS.delet : DOCOPS.modif)
                       : DOCOPS.creat;
 
+   if (newDoc._deleted === true && !oldDoc) {
+     throw({forbidden: 'Do not create deleted docs'});
+   }
+
    // Function to get the user list of site/groups for the given role
    var getRole = function(role) {
       var roles = userCtx.roles;

--- a/src/couchapps/WorkQueue/filters/childQueueFilter.js
+++ b/src/couchapps/WorkQueue/filters/childQueueFilter.js
@@ -1,4 +1,7 @@
 function(doc, req) {
+  if (doc._deleted){
+    return true;
+  }
 	if (doc.type && doc.type === "WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement") {
 		var ele = doc["WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement"];
 		if (ele['ChildQueueUrl'] === req.query.queueUrl) {

--- a/src/couchapps/WorkQueue/filters/queueFilter.js
+++ b/src/couchapps/WorkQueue/filters/queueFilter.js
@@ -1,4 +1,7 @@
 function(doc, req) {
+  if (doc._deleted){
+    return true;
+  }
 	if (doc.type && doc.type === "WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement") {
 		var ele = doc["WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement"];
 		return (ele['ChildQueueUrl'] === req.query.childUrl && ele['ParentQueueUrl'] === req.query.parentUrl)

--- a/src/couchapps/WorkQueue/validate_doc_update.js
+++ b/src/couchapps/WorkQueue/validate_doc_update.js
@@ -1,6 +1,9 @@
 function(newDoc, oldDoc, userCtx) {
-    // We only care if the user is someone with the correct permissions
-    // there is no difference between creating a new doc or updating an old one
+    // Check permissions and filter out replication of _deleted docs
+
+    if (newDoc._deleted === true && !oldDoc) {
+      throw({forbidden: 'Do not create deleted docs'});
+    }
 
     var validation = require("lib/validate").init(newDoc, oldDoc, userCtx);
 

--- a/src/python/WMCore/Database/CMSCouch.py
+++ b/src/python/WMCore/Database/CMSCouch.py
@@ -51,7 +51,11 @@ class Document(dict):
         Mark the document as deleted
         """
         # https://issues.apache.org/jira/browse/COUCHDB-1141
-        self = { '_id' : self['_id'], '_rev' : self['_rev'], '_deleted' : True }
+        deletedDict = { '_id' : self['_id'], '_rev' : self['_rev'], '_deleted' : True }
+        self.update(deletedDict)
+        for key in self.keys():
+            if key not in deletedDict:
+                del self[key]
 
     def __to_json__(self, thunker):
         """


### PR DESCRIPTION
Delete the fields in the document before commiting with _deleted = True,
make sure that WorkQueue replication replicates the deletion but avoids
creating deleted documents from other queues. Ensure the same in
WMStats.
