### PR TITLE
fix bug in stageout exception handler

### DIFF
--- a/src/python/WMCore/Storage/Execute.py
+++ b/src/python/WMCore/Storage/Execute.py
@@ -146,7 +146,9 @@ def execute(command):
         msg = "Command exited with status: %s" % (exitCode)
         print msg
     except Exception, ex:
+        msg = "Command threw exception"
         print "ERROR: Exception During Stage Out:\n"
+        print msg
         raise StageOutError(msg, Command = command, ExitCode = 60311)
     if exitCode:
         msg = "Command exited non-zero"


### PR DESCRIPTION
In the stageout runtime execution class, if the command being executed throws an exception, we die in the exception handler due to the use of an uninitialized variable.

That prevents the error from being passed up the chain and being properly dealt with in the higher level stageout code.
