### PR TITLE
Bugfix in WMStats update document

### DIFF
--- a/src/couchapps/WMStats/updates/requestStatus.js
+++ b/src/couchapps/WMStats/updates/requestStatus.js
@@ -17,9 +17,9 @@ function (doc, req) {
                 if ((statusObj.status != "closed-out") && (statusObj.status != "normal-archived")) {
                     legalTransition = false;
                 }
-            } else if ((lastState == "aborted-completed") && (statusObj.status != "abort-archived")) {
+            } else if ((lastState == "aborted-completed") && (statusObj.status != "aborted-archived")) {
                 legalTransition = false;
-            } else if ((lastState == "normal-archived") || (lastState == "abort-archived")) {
+            } else if ((lastState == "normal-archived") || (lastState == "aborted-archived")) {
                 legalTransition = false;
             }
             if (legalTransition) {


### PR DESCRIPTION
The last status for aborted requests is aborted-archived. Fix a typo in the update function.
