### PR TITLE
Bugfix for Global Workqueue

### DIFF
--- a/src/python/WMCore/Services/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/Services/WorkQueue/WorkQueue.py
@@ -95,7 +95,11 @@ class WorkQueue(object):
             return
         import urllib
         uri = "/" + self.db.name + "/_design/WorkQueue/_update/in-place/"
-        data = {"updates" : json.dumps(updatedParams)}
+        optionsArg = {}
+        if "options" in updatedParams:
+            optionsArg.update(updatedParams.pop("options"))
+        data = {"updates" : json.dumps(updatedParams),
+                "options" : json.dumps(optionsArg)}
         for ele in elementIds:
             thisuri = uri + ele + "?" + urllib.urlencode(data)
             answer = self.db.makeRequest(uri = thisuri, type = 'PUT')

--- a/src/python/WMCore/WorkQueue/Policy/Start/Block.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Block.py
@@ -111,10 +111,8 @@ class Block(StartPolicyInterface):
         for blockName in blocks:
             # check block restrictions
             if blockWhiteList and blockName not in blockWhiteList:
-                self.rejectedWork.append(blockName)
                 continue
             if blockName in blockBlackList:
-                self.rejectedWork.append(blockName)
                 continue
             if blockName in self.blockBlackListModifier:
                 # Don't duplicate blocks rejected before or blocks that were included and therefore are now in the blacklist

--- a/src/python/WMCore/WorkQueue/WorkQueueBackend.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueBackend.py
@@ -259,7 +259,11 @@ class WorkQueueBackend(object):
         if not elementIds:
             return
         uri = "/" + self.db.name + "/_design/WorkQueue/_update/in-place/"
-        data = {"updates" : json.dumps(updatedParams)}
+        optionsArg = {}
+        if "options" in updatedParams:
+            optionsArg.update(updatedParams.pop("options"))
+        data = {"updates" : json.dumps(updatedParams),
+                "options" : json.dumps(optionsArg)}
         for ele in elementIds:
             thisuri = uri + ele + "?" + urllib.urlencode(data)
             self.db.makeRequest(uri = thisuri, type = 'PUT')
@@ -269,7 +273,11 @@ class WorkQueueBackend(object):
     def updateInboxElements(self, *elementIds, **updatedParams):
         """Update given inbox element's (identified by id) with new parameters"""
         uri = "/" + self.inbox.name + "/_design/WorkQueue/_update/in-place/"
-        data = {"updates" : json.dumps(updatedParams)}
+        optionsArg = {}
+        if "options" in updatedParams:
+            optionsArg.update(updatedParams.pop("options"))
+        data = {"updates" : json.dumps(updatedParams),
+                "options" : json.dumps(optionsArg)}
         for ele in elementIds:
             thisuri = uri + ele + "?" + urllib.urlencode(data)
             self.inbox.makeRequest(uri = thisuri, type = 'PUT')

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
@@ -642,6 +642,18 @@ class WorkQueueTest(WorkQueueTestCase):
         syncQueues(self.localQueue)
         self.assertEqual(len(self.localQueue.getWork(slots)), 3)
 
+    def testSplittingLargeInputs(self):
+        """
+        _testSplittingLargeInputs_
+
+        Check that we can split large inputs and store the processed inputs
+        in the inbox element correctly.
+        """
+        GlobalParams.setNumOfBlocksPerDataset(500)
+        self.globalQueue.queueWork(self.processingSpec.specUrl())
+        inboxElement = self.globalQueue.backend.getInboxElements(elementIDs = [self.processingSpec.name()])
+        self.assertEqual(len(inboxElement[0]['ProcessedInputs']), GlobalParams.numOfBlocksPerDataset())
+        return
 
     def testGlobalBlockSplitting(self):
         """Block splitting at global level"""


### PR DESCRIPTION
When splitting a large dataset (>100 blocks) the workqueue can blow up and leave
the requests in funny states. This comes from the latest additions triggering
the max size of an URI in an update call to couch.

We need this ASAP in testbed.
