### PR TITLE
Bugfix for file information

### DIFF
--- a/src/python/WMCore/WMBS/MySQL/Files/Update.py
+++ b/src/python/WMCore/WMBS/MySQL/Files/Update.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+"""
+_Update_
+
+MySQL implementation of Files.Update
+
+Created on Feb 25, 2013
+
+@author: dballest
+"""
+
+from WMCore.WMBS.MySQL.Files.Add import Add
+
+class Update(Add):
+    """
+    _Update_
+
+    Update the wmbs_file_details information
+    for a file
+    """
+
+    sql = """UPDATE wmbs_file_details
+                SET filesize = :filesize,
+                    events = :events,
+                    first_event = :first_event,
+                    merged = :merged
+                WHERE lfn = :lfn
+          """
+
+    def execute(self, files = None, size = 0, events = 0, cksum = 0,
+                first_event = 0, merged = False, conn = None,
+                transaction = False):
+        binds = self.getBinds(files, size, events, cksum, first_event,
+                              merged)
+        self.dbi.processData(self.sql, binds,
+                         conn = conn, transaction = transaction)
+        return

--- a/src/python/WMCore/WMBS/Oracle/Files/Update.py
+++ b/src/python/WMCore/WMBS/Oracle/Files/Update.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+"""
+_Update_
+
+Oracle implementation of Files.Update
+
+Created on Feb 25, 2013
+
+@author: dballest
+"""
+
+from WMCore.WMBS.MySQL.Files.Update import Update as MySQLUpdate
+
+class Update(MySQLUpdate):
+    pass

--- a/test/python/WMCore_t/WMBS_t/File_t.py
+++ b/test/python/WMCore_t/WMBS_t/File_t.py
@@ -7,13 +7,8 @@ Unit tests for the WMBS File class.
 
 import unittest
 import logging
-import os
-import commands
 import threading
-import random
 
-from WMCore.Database.DBCore    import DBInterface
-from WMCore.Database.DBFactory import DBFactory
 from WMCore.DAOFactory         import DAOFactory
 from WMCore.WMBS.File          import File, addFilesToWMBSInBulk
 from WMCore.WMBS.Fileset       import Fileset
@@ -21,7 +16,6 @@ from WMCore.WMBS.Workflow      import Workflow
 from WMCore.WMBS.Subscription  import Subscription
 from WMCore.WMBS.JobGroup      import JobGroup
 from WMCore.WMBS.Job           import Job
-from WMCore.WMFactory          import WMFactory
 from WMQuality.TestInit        import TestInit
 from WMCore.DataStructs.Run    import Run
 from WMCore.DataStructs.File   import File as WMFile
@@ -1221,10 +1215,6 @@ class FileTest(unittest.TestCase):
         self.assertEqual(locations, ['se1.fnal.gov'])
 
         return
-
-
-
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
In some occasions the TaskArchiver fails to delete some file records
correctly from WMBS and some records are left with the default
values in wmbs_file_details. If a second workflow comes with the same
input files it may find zero events files in WMBS which causes
problems in the splitting algo like EventAwareLumiBased. Fix
this by updating the file information in WMBS when trying to add a new file
that is already there. This rarely happens so there is no real cost.
