### PR TITLE
Fix CMSSW diagnostics of segfaults

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/CMSSW.py
@@ -9,10 +9,10 @@ Diagnostic implementation for a CMSSW job
 
 """
 
-import os
 import os.path
 import logging
 from WMCore.WMSpec.Steps.Diagnostic import Diagnostic, DiagnosticHandler
+from WMCore.FwkJobReport.Report import FwkJobReportException
 
 import WMCore.Algorithms.BasicAlgos as BasicAlgos
 
@@ -96,7 +96,11 @@ class CMSDefaultHandler(DiagnosticHandler):
 
         if os.path.exists(jobRepXml):
             # job report XML exists, load the exception information from it
-            executor.report.parse(jobRepXml)
+            try:
+                executor.report.parse(jobRepXml)
+            except FwkJobReportException:
+                # Job report is bad, the parse already puts a 50115 in the file
+                pass
             reportStep = executor.report.retrieveStep(executor.step._internal_name)
             reportStep.status = errCode
 
@@ -154,7 +158,11 @@ class CMSRunHandler(DiagnosticHandler):
 
         if os.path.exists(jobRepXml):
             # job report XML exists, load the exception information from it
-            executor.report.parse(jobRepXml)
+            try:
+                executor.report.parse(jobRepXml)
+            except FwkJobReportException:
+                # Job report is bad, the parse already puts a 50115 in the file
+                pass
             reportStep = executor.report.retrieveStep(executor.step._internal_name)
             reportStep.status = self.code
 
@@ -239,12 +247,12 @@ class EDMExceptionHandler(DiagnosticHandler):
             return
 
         # job report XML exists, load the exception information from it
-        executor.report.parse(jobRepXml)
-
-
-
-
-
+        try:
+            executor.report.parse(jobRepXml)
+        except FwkJobReportException:
+            # Job report is bad, the parse already puts a 50115 in the file
+            # just go on
+            pass
 
         # make sure the report has the error in it
         errSection = getattr(executor.report.report, "errors", None)

--- a/src/python/WMCore/WMSpec/Steps/ExecuteMaster.py
+++ b/src/python/WMCore/WMSpec/Steps/ExecuteMaster.py
@@ -73,6 +73,9 @@ class ExecuteMaster:
                 if not result == None:
                     skipToStep = result
             except WMException, ex:
+                msg = "Encountered error while running ExecuteMaster:\n"
+                msg += str(ex) + "\n"
+                logging.error(msg)
                 self.toTaskDirectory()
                 break
             except Exception, ex:

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/bin/brokenCmsRun.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/bin/brokenCmsRun.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+"""
+brokenCmsRun.py
+
+cmsRun simulator that exits with a non zero exit code.
+
+Created on Feb 26, 2013
+
+@author: dballest
+"""
+
+import sys
+
+if __name__ == '__main__':
+    sys.exit(65)

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/bin/cmsRun.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/bin/cmsRun.py
@@ -24,12 +24,7 @@ class CmsRun:
     """
     def __init__(self, *args):
         self.args = list(args)
-        print self.args
-
-
-
-
-
+        open("BogusFile.txt", "w").close()
 
 if __name__ == '__main__':
     cmsrun = CmsRun(*sys.argv[1:])

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/bin/test.sh
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/bin/test.sh
@@ -1,0 +1,2 @@
+kill -ABRT $$
+


### PR DESCRIPTION
When a SEGFAULT occurs in cmsRun, the process exits with a 134
error code and leaves an empty FrameworkJobReport behind,
the same case as when the cmsRun process receives a SIGKILL or SIGTERM.
The empty FWJR caused the diagnostics handler to crash and therefore
the job didn't do the logArchive step or returned the report pickle,
this patch fixes that and extends the unti tests for the CMSSW executor
with diagnostics.

Fixes #4134
