### PR TITLE
Remove the check for the local wmc-dist-patch script.

### DIFF
--- a/bin/wmc-dist-patch
+++ b/bin/wmc-dist-patch
@@ -8,7 +8,6 @@ R=${WMCORE_ROOT-$(dirname $(dirname $0))}
 [ X"$R" = X ] && { echo '$WMCORE_ROOT not set' 1>&2; exit 1; }
 
 [ -x $R/bin/wmc-dist-patch ] || { echo "$R does not appear to be the right place" 1>&2; exit 1; }
-[ -x bin/wmc-dist-patch ] || { echo "$PWD is not a root of a local area" 1>&2; exit 1; }
 
 set -ex
 rm -fr $R/x{lib,bin,python,data,doc}/{*,.??*}


### PR DESCRIPTION
It is not shipped with the wmc-rest based projects source code. It gets included only during RPM build time and therefore we can't nicely use it like the https://cms-http-group.web.cern.ch/cms-http-group/tutorials/environ/rpm-dev.html instructions tell. This check was only there because sitedb used  to have its own dist-patch script.
