### PR TITLE
Fix ACDC for production

### DIFF
--- a/src/python/WMCore/ACDC/DataCollectionService.py
+++ b/src/python/WMCore/ACDC/DataCollectionService.py
@@ -228,6 +228,33 @@ class DataCollectionService(CouchService):
         return chunkFiles
 
     @CouchUtils.connectToCouch
+    def getProductionACDCInfo(self, collectionID, taskName, user = "cmsdataops",
+                        group = "cmsdataops"):
+        """
+        _getFileInfo_
+
+        Query ACDC for all of the files in the given collection and task.
+        Return an entry for each file with lumis and event info.
+        Format is:
+        [{'lfn' : 'someLfn',
+          'runs' : { run0 : [lumi0,lumi1], },
+          'events' :}]
+        """
+        results = self.couchdb.loadView("ACDC", "owner_coll_fileset_files",
+                                        {"startkey": [group, user,
+                                                      collectionID, taskName],
+                                         "endkey": [group, user,
+                                                    collectionID, taskName, {}]}, [])
+        acdcInfo = []
+        for result in results["rows"]:
+            fileInfo = {"lfn" : result["value"]["lfn"],
+                        "first_event" : result["value"]["first_event"],
+                        "lumis" : result["value"]["runs"][0]["lumis"],
+                        "events" : result["value"]["events"]}
+            acdcInfo.append(fileInfo)
+        return acdcInfo
+
+    @CouchUtils.connectToCouch
     def getLumiWhitelist(self, collectionID, taskName, user = "cmsdataops",
                          group = "cmsdataops"):
         """

--- a/src/python/WMCore/JobSplitting/EventBased.py
+++ b/src/python/WMCore/JobSplitting/EventBased.py
@@ -6,11 +6,13 @@ Event based splitting algorithm that will chop a fileset into
 a set of jobs based on event counts
 """
 
+import logging
+import traceback
+from math import ceil
 
 from WMCore.JobSplitting.JobFactory import JobFactory
-from WMCore.WMBS.File               import File
+from WMCore.WMBS.File import File
 from WMCore.DataStructs.Run import Run
-from math import ceil
 
 class EventBased(JobFactory):
     """
@@ -26,7 +28,30 @@ class EventBased(JobFactory):
         eventsPerJob = int(kwargs.get("events_per_job", 100))
         eventsPerLumi = int(kwargs.get("events_per_lumi", eventsPerJob))
         getParents   = kwargs.get("include_parents", False)
+        collectionName  = kwargs.get('collectionName', None)
 
+        acdcFileList = []
+
+        # If we have runLumi info, we need to load it from couch
+        if collectionName:
+            try:
+                from WMCore.ACDC.DataCollectionService import DataCollectionService
+                couchURL       = kwargs.get('couchURL')
+                couchDB        = kwargs.get('couchDB')
+                filesetName    = kwargs.get('filesetName')
+                collectionName = kwargs.get('collectionName')
+                owner          = kwargs.get('owner')
+                group          = kwargs.get('group')
+                logging.info('Creating jobs for ACDC fileset %s' % filesetName)
+                dcs = DataCollectionService(couchURL, couchDB)
+                acdcFileList = dcs.getProductionACDCInfo(collectionName, filesetName, owner, group)
+            except Exception, ex:
+                msg =  "Exception while trying to load goodRunList\n"
+                msg +=  "Refusing to create any jobs.\n"
+                msg += str(ex)
+                msg += str(traceback.format_exc())
+                logging.error(msg)
+                return
 
         totalJobs    = 0
 
@@ -81,6 +106,10 @@ class EventBased(JobFactory):
                         self.currentJob.addFile(f)
                         totalJobs += 1
                 else:
+                    if acdcFileList:
+                        if f['lfn'] in [x['lfn'] for x in acdcFileList]:
+                            self.createACDCJobs(f, acdcFileList)
+                        continue
                     #This assumes there's only one run which is the case for MC
                     lumis = runs[0].lumis
                     (firstLumi, lastLumi) = (min(lumis), max(lumis))
@@ -123,3 +152,22 @@ class EventBased(JobFactory):
                         self.currentJob["mask"].setMaxAndSkipLumis(lastLumi -
                                                         currentLumi + 1, currentLumi)
                         totalJobs += 1
+
+    def createACDCJobs(self, fakeFile, acdcFileInfo):
+        """
+        _createACDCJobs_
+
+        Create ACDC production jobs, this are treated differentely
+        since it is an exact copy of the failed jobs.
+        """
+        totalJobs = 0
+        for acdcFile in acdcFileInfo:
+            if fakeFile['lfn'] == acdcFile['lfn']:
+                self.newJob(name = self.getJobName(length = totalJobs))
+                self.currentJob.addFile(fakeFile)
+                self.currentJob["mask"].setMaxAndSkipEvents(acdcFile["events"],
+                                                            acdcFile["first_event"])
+                self.currentJob["mask"].setMaxAndSkipLumis(len(acdcFile["lumis"]) - 1,
+                                                           acdcFile["lumis"][0])
+                totalJobs += 1
+        return

--- a/src/python/WMCore/WorkQueue/Policy/Start/ResubmitBlock.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/ResubmitBlock.py
@@ -41,7 +41,8 @@ class ResubmitBlock(StartPolicyInterface):
                             'ParentlessMergeBySize' : self.singleChunk,
                             'MinFileBased' : self.singleChunk,
                             'LumiBased' : self.singleChunk,
-                            'EventAwareLumiBased' : self.singleChunk}
+                            'EventAwareLumiBased' : self.singleChunk,
+                            'EventBased' : self.singleChunk}
         self.unsupportedAlgos = ['WMBSMergeBySize', 'SiblingProcessingBased']
         self.defaultAlgo = self.fixedSizeChunk
 

--- a/test/python/WMCore_t/JobSplitting_t/EventBased_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/EventBased_t.py
@@ -9,7 +9,6 @@ import unittest
 
 from WMCore.DataStructs.File import File
 from WMCore.DataStructs.Fileset import Fileset
-from WMCore.DataStructs.Job import Job
 from WMCore.DataStructs.Subscription import Subscription
 from WMCore.DataStructs.Workflow import Workflow
 from WMCore.DataStructs.Run import Run

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/EventBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/EventBased_t.py
@@ -6,22 +6,19 @@ Event based splitting test.
 """
 
 import unittest
-import os
 import threading
+import os
 
-from WMCore.WMBS.File import File
-from WMCore.WMBS.Fileset import Fileset
-from WMCore.WMBS.Job import Job
-from WMCore.WMBS.Subscription import Subscription
-from WMCore.WMBS.Workflow import Workflow
-
-from WMCore.DataStructs.Run import Run
-
+from WMCore.Database.CMSCouch import CouchServer
 from WMCore.DAOFactory import DAOFactory
-from WMCore.WMFactory import WMFactory
+from WMCore.DataStructs.Run import Run
 from WMCore.JobSplitting.SplitterFactory import SplitterFactory
 from WMCore.Services.UUID import makeUUID
-from WMQuality.TestInit import TestInit
+from WMCore.WMBS.File import File
+from WMCore.WMBS.Fileset import Fileset
+from WMCore.WMBS.Subscription import Subscription
+from WMCore.WMBS.Workflow import Workflow
+from WMQuality.TestInitCouchApp import TestInitCouchApp
 
 class EventBasedTest(unittest.TestCase):
     """
@@ -36,12 +33,36 @@ class EventBasedTest(unittest.TestCase):
         Create two subscriptions: One that contains a single file and one that
         contains multiple files.
         """
-        self.testInit = TestInit(__file__)
+        self.testInit = TestInitCouchApp(__file__)
         self.testInit.setLogging()
         self.testInit.setDatabaseConnection()
+        self.couchUrl = os.environ["COUCHURL"]
+        self.couchDBName = "acdc_event_based_t"
+        self.testInit.setupCouch(self.couchDBName, "GroupUser", "ACDC")
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
+        couchSever = CouchServer(dburl = self.couchUrl)
+        self.couchDB = couchSever.connectDatabase(self.couchDBName)
+        self.populateWMBS()
 
+        return
+
+    def tearDown(self):
+        """
+        _tearDown_
+
+        Clear out WMBS.
+        """
+        self.testInit.clearDatabase()
+        self.testInit.tearDownCouch()
+        return
+
+    def populateWMBS(self):
+        """
+        _populateWMBS_
+
+        Create files and subscriptions in WMBS
+        """
         myThread = threading.currentThread()
         daofactory = DAOFactory(package = "WMCore.WMBS",
                                 logger = myThread.logger,
@@ -50,13 +71,14 @@ class EventBasedTest(unittest.TestCase):
         locationAction = daofactory(classname = "Locations.New")
         locationAction.execute(siteName = 's1', seName = "somese.cern.ch")
         locationAction.execute(siteName = 's2', seName = "otherse.cern.ch")
+        self.validLocations = ["somese.cern.ch", "otherse.cern.ch"]
 
         self.multipleFileFileset = Fileset(name = "TestFileset1")
         self.multipleFileFileset.create()
         parentFile = File('/parent/lfn/', size = 1000, events = 100,
                           locations = set(["somese.cern.ch"]))
         parentFile.create()
-        for i in range(10):
+        for _ in range(10):
             newFile = File(makeUUID(), size = 1000, events = 100,
                            locations = set(["somese.cern.ch"]))
             newFile.create()
@@ -75,20 +97,20 @@ class EventBasedTest(unittest.TestCase):
 
         self.multipleSiteFileset = Fileset(name = "TestFileset3")
         self.multipleSiteFileset.create()
-        for i in range(5):
+        for _ in range(5):
             newFile = File(makeUUID(), size = 1000, events = 100)
             newFile.setLocation("somese.cern.ch")
             newFile.create()
             self.multipleSiteFileset.addFile(newFile)
-        for i in range(5):
+        for _ in range(5):
             newFile = File(makeUUID(), size = 1000, events = 100)
-            newFile.setLocation(["somese.cern.ch","otherse.cern.ch"])
+            newFile.setLocation(["somese.cern.ch", "otherse.cern.ch"])
             newFile.create()
             self.multipleSiteFileset.addFile(newFile)
         self.multipleSiteFileset.commit()
 
         testWorkflow = Workflow(spec = "spec.xml", owner = "Steve",
-                                name = "wf001", task="Test")
+                                name = "wf001", task = "Test")
         testWorkflow.create()
         self.multipleFileSubscription = Subscription(fileset = self.multipleFileFileset,
                                                      workflow = testWorkflow,
@@ -105,24 +127,56 @@ class EventBasedTest(unittest.TestCase):
                                                      split_algo = "EventBased",
                                                      type = "Processing")
         self.multipleSiteSubscription.create()
+
         return
 
-    def tearDown(self):
+    def populateACDCCouch(self, numFiles = 2, lumisPerJob = 35,
+                          eventsPerJob = 20000):
         """
-        _tearDown_
+        _populateACDCCouch_
 
-        Clear out WMBS.
+        Create production files in couchDB to test the creation
+        of ACDC jobs for the EventBased algorithm
         """
-        self.testInit.clearDatabase()
+        # Define some constants
+        workflowName = "ACDC_TestEventBased"
+        filesetName = "/%s/Production" % workflowName
+        owner = "dballest@fnal.gov"
+        group = "unknown"
+
+        lumisPerFile = lumisPerJob * 250
+        for i in range(numFiles):
+            for j in range(250):
+                lfn = "MCFakeFile-some-hash-%s" % str(i).zfill(5)
+                acdcFile = File(lfn = lfn, size = 100, events = eventsPerJob, locations = self.validLocations,
+                                merged = False, first_event = 1)
+                run = Run(1, *range(1 + (i * lumisPerFile) + j * lumisPerJob,
+                                    (j + 1) * lumisPerJob + (i * lumisPerFile) + 2))
+                acdcFile.addRun(run)
+                acdcDoc = {"collection_name" : workflowName,
+                           "collection_type" : "ACDC.CollectionTypes.DataCollection",
+                           "files" : {lfn : acdcFile},
+                           "fileset_name" : filesetName,
+                           "owner" : {"user": owner,
+                                      "group" : group}}
+                self.couchDB.queue(acdcDoc)
+
+        self.couchDB.commit()
         return
 
     def generateFakeMCFile(self, numEvents = 100, firstEvent = 1,
                            lastEvent = 100, firstLumi = 1, lastLumi = 10,
                            index = 1):
-        #MC comes with only one MCFakeFile
-        singleMCFileset = Fileset(name = "MCTestFileset %i" % index)
+        """
+        _generateFakeMCFile_
+
+        Generates a fake MC file for testing production EventBased
+        creation of jobs
+        """
+        # MC comes with only one MCFakeFile
+        singleMCFileset = Fileset(name = "MCTestFileset-%i" % index)
         singleMCFileset.create()
-        newFile = File("MCFakeFileTest %i" % index, size = 1000,
+        newFile = File("MCFakeFile-some-hash-%s" % str(index).zfill(5), size = 1000,
                        events = numEvents,
                        locations = set(["somese.cern.ch"]))
         newFile.addRun(Run(1, *range(firstLumi, lastLumi + 1)))
@@ -132,7 +186,7 @@ class EventBasedTest(unittest.TestCase):
         singleMCFileset.addFile(newFile)
         singleMCFileset.commit()
         testWorkflow = Workflow(spec = "spec.xml", owner = "Steve",
-                                name = "wf001", task="Test")
+                                name = "wf001", task = "Test")
         testWorkflow.create()
 
         singleMCFileSubscription = Subscription(fileset = singleMCFileset,
@@ -409,6 +463,37 @@ class EventBasedTest(unittest.TestCase):
 
         return
 
+    def testACDCProduction(self):
+        """
+        _testACDCProduction_
+
+        Test the ability of the EventBased algorithm of creating
+        jobs from ACDC correctly
+        """
+        self.populateACDCCouch()
+        mcSubscription = self.generateFakeMCFile(20000, 1, 20001, 1, 8750, 0)
+        splitter = SplitterFactory()
+        jobFactory = splitter(package = "WMCore.WMBS",
+                              subscription = mcSubscription)
+
+        jobGroups = jobFactory(events_per_job = 50, collectionName = "ACDC_TestEventBased",
+                               couchURL = self.couchUrl, couchDB = self.couchDBName,
+                               filesetName = "/ACDC_TestEventBased/Production",
+                               owner = "dballest@fnal.gov", group = "unknown")
+
+        self.assertEqual(1, len(jobGroups))
+        jobGroup = jobGroups[0]
+        self.assertEqual(250, len(jobGroup.jobs))
+
+        for job in jobGroup.jobs:
+            self.assertEqual(1, len(job["input_files"]))
+            self.assertEqual("MCFakeFile-some-hash-00000", job["input_files"][0]["lfn"])
+            mask = job["mask"]
+            self.assertEqual(35, mask["LastLumi"] - mask["FirstLumi"])
+            self.assertEqual(20000, mask["LastEvent"] - mask["FirstEvent"])
+            self.assertFalse(mask["runAndLumis"])
+
+        return
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Improve the EventBased splitting algorithm to support ACDC for production
workflows (MonteCarlo and LHEStepZero only). It implements a limited
ACDC where the jobs will be reproduced exactly as the last time. For recovery
of statistics it is suggested to use the statistics extension feature instead.

Fixes #4399
