### PR TITLE
Fix straight to merge when splitting is changed

### DIFF
--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -997,12 +997,13 @@ class WMWorkloadHelper(PersistencyHelper):
 
         # Set the splitting algorithm for the task.  If the split algo is
         # EventBased, we need to disable straight to merge.  If this isn't an
-        # EventBased algo we need to enable straight to merge.
+        # EventBased algo we need to enable straight to merge. If straight
+        # to merge is disabled then keep it that way.
         taskHelper.setSplittingAlgorithm(splitAlgo, **splitArgs)
         for stepName in taskHelper.listAllStepNames():
             stepHelper = taskHelper.getStepHelper(stepName)
             if stepHelper.stepType() == "StageOut":
-                if splitAlgo != "EventBased" and minMergeSize:
+                if splitAlgo != "EventBased" and stepHelper.minMergeSize() != -1 and minMergeSize:
                     stepHelper.setMinMergeSize(minMergeSize, maxMergeEvents)
                 else:
                     stepHelper.disableStraightToMerge()

--- a/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
@@ -1032,10 +1032,6 @@ class WMWorkloadTest(unittest.TestCase):
 
         testWorkload.setJobSplittingParameters("/TestWorkload/ProcessingTask", "FileBased",
                                                {"files_per_job": 4})
-
-        stepHelper = procTask.getStepHelper("StageOut1")
-        self.assertEqual(stepHelper.minMergeSize(), 2,
-                         "Error: Wrong min merge size.")
         return
 
     def testUpdatingSubSplitParameters(self):


### PR DESCRIPTION
If splitting is changed through script/pages and there is a
transient output module, the property of disabling
straight to merge is broken by the change which can
cause spurious output in merged area from straight-to-merge
mechanisms.
