### PR TITLE
WorkQueue fixes

### DIFF
--- a/src/couchapps/WorkQueue/filters/queueFilter.js
+++ b/src/couchapps/WorkQueue/filters/queueFilter.js
@@ -1,10 +1,16 @@
 function(doc, req) {
-  if (doc._deleted){
-    return true;
-  }
-	if (doc.type && doc.type === "WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement") {
-		var ele = doc["WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement"];
-		return (ele['ChildQueueUrl'] === req.query.childUrl && ele['ParentQueueUrl'] === req.query.parentUrl)
-	}
-	return false;
+    if (doc.type && doc.type === "WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement"){
+        var ele = doc["WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement"];
+        return (ele['ChildQueueUrl'] === req.query.childUrl && ele['ParentQueueUrl'] === req.query.parentUrl);
+    }
+    if (doc._deleted){
+        // TEMPORARY: Don't replicate specs
+        // Need to clean cmsweb databases properly
+        if (doc._attachments){
+            return false;
+        }
+        return true;
+    }
+
+    return false
 }

--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -781,6 +781,9 @@ class WorkQueue(WorkQueueBase):
             self.logger.warning('Backend busy or down: skipping cleanup tasks')
             return
 
+        if self.params['LocalQueueFlag']:
+            self.backend.checkReplicationStatus() # Check any replication error and fix it.
+
         self.backend.pullFromParent() # Check we are upto date with inbound changes
         if self.params['LocalQueueFlag']:
             self.backend.fixConflicts() # before doing anything fix any conflicts


### PR DESCRIPTION
Check that replication is alive in the WorkQueue, kill if it is
in error state so that it can be restarted.

Also make a temporal fix to the WorkQueue replication filter
since we have _deleted documents with data in cmsweb which we don't
want to shuffle around.
