### PR TITLE
ReqMgr2 - CouchDB request docs null fields

### DIFF
--- a/src/couchapps/ReqMgr/updates/updaterequest.js
+++ b/src/couchapps/ReqMgr/updates/updaterequest.js
@@ -1,0 +1,14 @@
+// update function
+// input: valueKey (what to change), value - new value
+function(doc, req)
+{
+	log(req);
+	// req.query is dictionary fields into the 
+	// CMSCouch.Database.updateDocument() method, which is a dictionary
+	var newValues = req.query;
+	for (key in newValues)
+	{
+		doc[key] = newValues[key];  
+	}
+    return [doc, "OK"]	
+}

--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrRESTModel.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrRESTModel.py
@@ -451,6 +451,8 @@ class ReqMgrRESTModel(RESTModel):
             body = cherrypy.request.body.read()
             reqInputArgs = Utilities.unidecode(JsonWrapper.loads(body))
             reqInputArgs.setdefault('CouchURL', Utilities.removePasswordFromUrl(self.couchUrl))
+            reqInputArgs.setdefault('CouchWorkloadDBName', self.workloadDBName)
+            # wrong naming ... but it's all over the place, it's the config cache DB name
             reqInputArgs.setdefault('CouchDBName', self.configDBName)
             try:
                 self.info("Creating a request for: '%s'\n\tworkloadDB: '%s'\n\twmstatUrl: "

--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/WebRequestSchema.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/WebRequestSchema.py
@@ -106,7 +106,9 @@ class WebRequestSchema(WebAPI):
     @cherrypy.tools.secmodv2()
     def makeSchema(self, **schema):
         schema.setdefault('CouchURL', Utilities.removePasswordFromUrl(self.couchUrl))
+        # wrong naming ... but it's all over the place, it's the config cache DB name
         schema.setdefault('CouchDBName', self.configDBName)
+        schema.setdefault('CouchWorkloadDBName', self.workloadDBName)
 
         decodedSchema = {}
         for key in schema.keys():

--- a/src/python/WMCore/RequestManager/DataStructs/Request.py
+++ b/src/python/WMCore/RequestManager/DataStructs/Request.py
@@ -1,19 +1,10 @@
-#!/usr/bin/env python
 """
-_Request_
-
 Data Object representing a request
-
 
 """
 
 
 class Request(dict):
-    """
-    _Request_
-
-
-    """
     def __init__(self):
         dict.__init__(self)
         #  //
@@ -23,7 +14,6 @@ class Request(dict):
         self.setdefault("RequestType", None)
         self.setdefault("RequestStatus", None)
         self.setdefault("RequestPriority", None)
-        self.setdefault("RequestWorkflow", None)
         self.setdefault("RequestNumEvents", None)
         self.setdefault("RequestSizeFiles", None)
         self.setdefault("AcquisitionEra", None)
@@ -53,11 +43,3 @@ class Request(dict):
         self.setdefault("SoftwareVersions", [])
         self.setdefault("InputDatasets", [])
         self.setdefault("InputDatasetTypes", {})
-
-
-        #  //
-        # // Workflow information
-        #//
-        self.setdefault("WorkflowSpec", None)
-        # DBS information
-        self.setdefault("DbsUrl", None)

--- a/src/python/WMCore/RequestManager/RequestDB/Interface/Request/GetRequest.py
+++ b/src/python/WMCore/RequestManager/RequestDB/Interface/Request/GetRequest.py
@@ -114,14 +114,6 @@ def percentages(updates):
             percent_success = update['percent_success']
     return percent_complete, percent_success
 
-def getRequestDetails(requestName):
-    """ Return a dict with the intimate details of the request """
-    requestId = requestID(requestName)
-    request = getRequest(requestId)
-    request['Assignments'] = getAssignmentsByName(requestName)
-    request['RequestMessages'] = ChangeState.getMessages(requestName)
-    request['RequestUpdates'] = ChangeState.getProgress(requestName)
-    return request
 
 def getRequests():
     """ This only fills the details needed to make succint browser tables,

--- a/src/python/WMCore/RequestManager/RequestMaker/Registry.py
+++ b/src/python/WMCore/RequestManager/RequestMaker/Registry.py
@@ -114,8 +114,6 @@ def buildWorkloadForRequest(typename, schema):
     #    this is not now screwed up
     if schema.get('CMSSWVersion') and schema.get('CMSSWVersion') not in request['SoftwareVersions']:
         request['SoftwareVersions'].append(schema.get('CMSSWVersion'))
-    # assume only one dbs for all the task
-    request['DbsUrl'] = (workload.getTopLevelTask()[0]).dbsUrl()
     return request
 
 

--- a/test/python/WMCore_t/RequestManager_t/Admin_t.py
+++ b/test/python/WMCore_t/RequestManager_t/Admin_t.py
@@ -34,7 +34,7 @@ class AdminTest(RESTBaseUnitTest):
         self.couchDBName = "reqmgr_t_0"
         RESTBaseUnitTest.setUp(self)
         self.testInit.setupCouch("%s" % self.couchDBName,
-                                 "GroupUser", "ConfigCache")
+                                 "GroupUser", "ConfigCache", "ReqMgr")
         reqMgrHost = self.config.getServerUrl()
         self.jsonSender = JSONRequests(reqMgrHost)
 

--- a/test/python/WMCore_t/RequestManager_t/Assign_t.py
+++ b/test/python/WMCore_t/RequestManager_t/Assign_t.py
@@ -42,7 +42,7 @@ class AssignTest(RESTBaseUnitTest):
         self.couchDBName = "reqmgr_t_0"
         RESTBaseUnitTest.setUp(self, initRoot = False)
         self.testInit.setupCouch("%s" % self.couchDBName,
-                                 "GroupUser", "ConfigCache")
+                                 "GroupUser", "ConfigCache", "ReqMgr")
         reqMgrHost = self.config.getServerUrl()
         self.jsonSender = JSONRequests(reqMgrHost)
         

--- a/test/python/WMCore_t/RequestManager_t/ReqMgrPriority_t.py
+++ b/test/python/WMCore_t/RequestManager_t/ReqMgrPriority_t.py
@@ -40,7 +40,7 @@ class ReqMgrPriorityTest(RESTBaseUnitTest):
         self.couchDBName = "reqmgr_t_0"
         RESTBaseUnitTest.setUp(self)
         self.testInit.setupCouch("%s" % self.couchDBName,
-                                 "GroupUser", "ConfigCache")
+                                 "GroupUser", "ConfigCache", "ReqMgr")
         self.testInit.setupCouch("%s_wmstats" % self.couchDBName,
                                  "WMStats")
         reqMgrHost      = self.config.getServerUrl()

--- a/test/python/WMCore_t/RequestManager_t/ReqMgrWorkload_t.py
+++ b/test/python/WMCore_t/RequestManager_t/ReqMgrWorkload_t.py
@@ -45,7 +45,7 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         self.couchDBName = "reqmgr_t_0"
         RESTBaseUnitTest.setUp(self)
         self.testInit.setupCouch("%s" % self.couchDBName,
-                                 "GroupUser", "ConfigCache")
+                                 "GroupUser", "ConfigCache", "ReqMgr")
         self.testInit.setupCouch("%s_wmstats" % self.couchDBName,
                                  "WMStats")
         reqMgrHost = self.config.getServerUrl()

--- a/test/python/WMCore_t/RequestManager_t/ReqMgr_t.py
+++ b/test/python/WMCore_t/RequestManager_t/ReqMgr_t.py
@@ -89,7 +89,7 @@ class ReqMgrTest(RESTBaseUnitTest):
         self.couchDBName = "reqmgr_t_0"
         RESTBaseUnitTest.setUp(self)
         self.testInit.setupCouch("%s" % self.couchDBName,
-                                 "GroupUser", "ConfigCache")
+                                 "GroupUser", "ConfigCache", "ReqMgr")
         self.testInit.setupCouch("%s_wmstats" % self.couchDBName,
                                  "WMStats")
         reqMgrHost = self.config.getServerUrl()

--- a/test/python/WMCore_t/Services_t/RequestManager_t/RequestManager_t.py
+++ b/test/python/WMCore_t/Services_t/RequestManager_t/RequestManager_t.py
@@ -42,7 +42,7 @@ class RequestManagerTest(RESTBaseUnitTest):
         
     def setUp(self):
         RESTBaseUnitTest.setUp(self)
-        self.testInit.setupCouch("%s" % self.couchDBName, "GroupUser", "ConfigCache")
+        self.testInit.setupCouch("%s" % self.couchDBName, "GroupUser", "ConfigCache", "ReqMgr")
         self.testInit.setupCouch("%s_wmstats" % self.couchDBName, "WMStats")
         # logging stuff from TestInit is broken, setting myself
         l = logging.getLogger()


### PR DESCRIPTION
- some fields removed from CouchDB (useless)
- majority of other CouchDB fields is not properly set and updated (e.g.
  Status or Priority as changed on the request)
- reqmgr.py --allTests checks Oracle, CouchDB consistency, at least partly now

Fixes #4380
