### PR TITLE
fix LSF submission when overloaded

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/LsfPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/LsfPlugin.py
@@ -192,7 +192,7 @@ class LsfPlugin(BasePlugin):
                     if returncode == 0:
                         # check for correct naming convention in PFN
                         regExpParser = re.compile('Job <([0-9]+)> is submitted to queue')
-                        match = regExpParser.match(stdout)
+                        match = regExpParser.search(stdout)
                         if match != None:
                             job['gridid'] = match.group(1)
                             successfulJobs.append(job)


### PR DESCRIPTION
When LSF is overloaded, the LSF bsub submit command can print out some debug messages to stdout before submitting the job. In these cases the LsfPlugin does not detect that a job has been submitted. Fix this.
