### PR TITLE
optimize sibgling subscription DAO

### DIFF
--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/SiblingProcessingBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/SiblingProcessingBased_t.py
@@ -43,7 +43,6 @@ class SiblingProcessingBasedTest(unittest.TestCase):
 
         locationAction = daofactory(classname = "Locations.New")
         locationAction.execute("site1", seName = "somese.cern.ch")
-        locationAction.execute("site1", seName = "somese3.cern.ch")
         locationAction.execute("site2", seName = "somese2.cern.ch")
 
         self.testFilesetA = Fileset(name = "FilesetA")

--- a/test/python/WMCore_t/WorkQueue_t/WMBSHelper_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WMBSHelper_t.py
@@ -439,7 +439,7 @@ class WMBSHelperTest(unittest.TestCase):
         cleanupTask = procTask.addTask("CleanupTask")
         cleanupTask.setInputReference(procTaskCMSSW, outputModule = "OutputA")
         cleanupTask.setTaskType("Merge")
-        cleanupTask.setSplittingAlgorithm("SiblingProcessingBase", files_per_job = 50)
+        cleanupTask.setSplittingAlgorithm("SiblingProcessingBased", files_per_job = 50)
         cleanupTaskCMSSW = cleanupTask.makeStep("cmsRun1")
         cleanupTaskCMSSW.setStepType("CMSSW")
         cleanupTaskCMSSWHelper = cleanupTaskCMSSW.getTypeHelper()


### PR DESCRIPTION
Optimize the sibling complete DAO query to not join against the huge wmbs_fileset_files table and only against wmbs_fileset. Also works if the other subscription are cleaned up before (even though this should not happen anymore).
