### PR TITLE
Add support for the splitting page in reqmgr.py

### DIFF
--- a/test/data/ReqMgr/requests/MonteCarlo.json
+++ b/test/data/ReqMgr/requests/MonteCarlo.json
@@ -27,6 +27,16 @@
 		"FirstLumi": 1
 	}, 
 
+"changeSplitting":
+    {
+        "Production" :
+            {
+                "SplittingAlgo" : "EventBased",
+                "events_per_job" : 1400,
+                "include_parents" : "False"
+            }
+    },
+
 "assignRequest":
 	{
 		"SiteWhitelist": "SiteWhitelist-OVERRIDE-ME",

--- a/test/data/ReqMgr/requests/MonteCarloFromGEN.json
+++ b/test/data/ReqMgr/requests/MonteCarloFromGEN.json
@@ -25,7 +25,17 @@
         "BlockBlacklist": [],
         "OpenRunningTimeout" : 0
 	}, 
-	
+
+"changeSplitting":
+    {
+        "MonteCarloFromGEN" :
+            {
+                "SplittingAlgo" : "LumiBased",
+                "lumis_per_job" : 1400,
+                "include_parents" : "False",
+                "halt_job_on_file_boundaries" : "True"
+             }
+    },
 
 "assignRequest":
 	{

--- a/test/data/ReqMgr/requests/ReDigi.json
+++ b/test/data/ReqMgr/requests/ReDigi.json
@@ -34,7 +34,17 @@
         "OpenRunningTimeout" : 0
 	},
 
-	
+"changeSplitting":
+    {
+        "StepOneProc" :
+            {
+                "SplittingAlgo" : "LumiBased",
+                "lumis_per_job" : 8,
+                "halt_job_on_file_boundaries" : "True",
+                "include_parents" : "False"
+            }
+    },
+
 "assignRequest":
 	{
 		"SiteWhitelist": "SiteWhitelist-OVERRIDE-ME",

--- a/test/data/ReqMgr/requests/ReReco.json
+++ b/test/data/ReqMgr/requests/ReReco.json
@@ -29,8 +29,20 @@
         "SkimInput1": "RECOoutput",
         "Skim1ConfigCacheID": "7559cf7a427be20436483f82fd109301",
         "OpenRunningTimeout" : 0
-	},
-		
+    },
+
+"changeSplitting":
+    {
+        "DataProcessing" :
+            {
+                "SplittingAlgo" : "EventAwareLumiBased",
+                "avg_events_per_job" : 1400,
+                "max_events_per_lumi" : 20000,
+                "halt_job_on_file_boundaries_event_aware" : "True",
+                "include_parents" : "False"
+            }
+    },
+
 "assignRequest":
 	{
 		"SiteWhitelist": "SiteWhitelist-OVERRIDE-ME",

--- a/test/data/ReqMgr/requests/TaskChain.json
+++ b/test/data/ReqMgr/requests/TaskChain.json
@@ -33,7 +33,16 @@
         "mergedLFNBase": "/store/relval",
         "unmergedLFNBase": "/store/unmerged"
     },
-        
+
+"changeSplitting":
+    {
+        "SingleMuPt100FS" :
+            {
+                "SplittingAlgo" : "EventBased",
+                "events_per_job" : 3500
+            }
+    },
+
 "assignRequest":
     {
         "SiteWhitelist": "SiteWhitelist-OVERRIDE-ME",

--- a/test/data/ReqMgr/requests/TaskChainMultiTask.json
+++ b/test/data/ReqMgr/requests/TaskChainMultiTask.json
@@ -49,7 +49,16 @@
         "mergedLFNBase": "/store/relval",
         "unmergedLFNBase": "/store/unmerged"
     },
-        
+
+"changeSplitting":
+    {
+        "SingleMuPt100FS" :
+            {
+                "SplittingAlgo" : "EventBased",
+                "events_per_job" : 3500
+            }
+    },
+
 "assignRequest":
     {
         "SiteWhitelist": "SiteWhitelist-OVERRIDE-ME",


### PR DESCRIPTION
Add basic support for changing the splitting
with the reqmgr.py script, it is available
through another section in the JSON files.

Also incorporate splitting change in the
allTests procedure.

@zdenekmaxa can you review please?
