### PR TITLE
Block close settings per request

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -54,9 +54,6 @@ localDBSUrl = "https://cmst0dbs.cern.ch:8443/cms_dbs_prod_tier0_writer/servlet/D
 localDBSVersion = "DBS_2_0_8"
 globalDBSUrl = "https://cmsdbsprod.cern.ch:8443/cms_dbs_prod_global_writer/servlet/DBSServlet"
 globalDBSVersion = "DBS_2_0_8"
-dbsMaxBlockSize = 5000000000000
-dbsMaxBlockFiles = 500
-dbsBlockTimeout = 86400
 
 # Job retry information.  This includes the number of times a job will tried and
 # how long it will sit in cool off.
@@ -137,9 +134,6 @@ config.DBSInterface.DBSUrl = globalDBSUrl
 config.DBSInterface.DBSVersion = localDBSVersion
 config.DBSInterface.globalDBSUrl = globalDBSUrl
 config.DBSInterface.globalDBSVersion = globalDBSVersion
-config.DBSInterface.DBSBlockMaxSize = dbsMaxBlockSize
-config.DBSInterface.DBSBlockMaxFiles = dbsMaxBlockFiles
-config.DBSInterface.DBSBlockMaxTime = dbsBlockTimeout
 config.DBSInterface.MaxFilesToCommit = 200
 config.DBSInterface.doGlobalMigration = False
 

--- a/setup_test.py
+++ b/setup_test.py
@@ -99,7 +99,10 @@ if can_nose:
             # The main thread should raise an exception
             sys.stderr.write("*******EXIT WAS TRAPPED**********\n")
             raise RuntimeError, "os._exit() was called in the main thread"
-        else:        
+        elif "DONT_TRAP_EXIT" in os.environ:
+            # We trust this component to run real exits
+            os.DMWM_REAL_EXIT(code)
+        else:
             # os._exit on child threads should just blow away the thread
             raise SystemExit, "os._exit() was called in a child thread. " +\
                               "Protecting the interpreter and trapping it"

--- a/src/python/WMComponent/DBS3Buffer/DBSBufferFile.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSBufferFile.py
@@ -22,12 +22,13 @@ from WMCore.WMBS.WMBSBase import WMBSBase
 class DBSBufferFile(WMBSBase, WMFile):
     def __init__(self, lfn = None, id = -1, size = None,
                  events = None, checksums = {}, parents = None, locations = None,
-                 status = "NOTUPLOADED"):
+                 status = "NOTUPLOADED", workflowId = None):
         WMBSBase.__init__(self)
         WMFile.__init__(self, lfn = lfn, size = size, events = events,
                         checksums = checksums, parents = parents, merged = True)
         self.setdefault("status", status)
         self.setdefault("id", id)
+        self.setdefault("workflowId", workflowId)
 
         # Parameters for the algorithm
         self.setdefault("appName", None)
@@ -200,6 +201,7 @@ class DBSBufferFile(WMBSBase, WMFile):
         addAction.execute(files = self["lfn"], size = self["size"],
                           events = self["events"],
                           datasetAlgo = assocID, status = self["status"],
+                          workflowID = self["workflowId"],
                           conn = self.getDBConn(),
                           transaction = self.existingTransaction())
 

--- a/src/python/WMComponent/DBS3Buffer/MySQL/Create.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/Create.py
@@ -65,10 +65,14 @@ class Create(DBCreator):
 
         self.create["03dbsbuffer_workflow"] = \
           """CREATE TABLE dbsbuffer_workflow (
-               id           INTEGER PRIMARY KEY AUTO_INCREMENT,
-               name         VARCHAR(255),
-               task         VARCHAR(255),
-               spec         VARCHAR(255),
+               id                           INTEGER PRIMARY KEY AUTO_INCREMENT,
+               name                         VARCHAR(255),
+               task                         VARCHAR(255),
+               spec                         VARCHAR(255),
+               block_close_max_wait_time    INTEGER UNSIGNED,
+               block_close_max_files        INTEGER UNSIGNED,
+               block_close_max_events       INTEGER UNSIGNED,
+               block_close_max_size         BIGINT UNSIGNED,
                UNIQUE(name, task)) ENGINE = InnoDB"""
 
         self.create["04dbsbuffer_file"] = \

--- a/src/python/WMComponent/DBS3Buffer/MySQL/InsertWorkflow.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/InsertWorkflow.py
@@ -14,32 +14,42 @@ class InsertWorkflow(DBFormatter):
     Insert a workflow using the name and task
     """
 
-    sql = "INSERT IGNORE INTO dbsbuffer_workflow (name, task) VALUES (:name, :task)"
+    sql = """INSERT IGNORE INTO dbsbuffer_workflow (name, task, spec,
+                                                    block_close_max_wait_time,
+                                                    block_close_max_files,
+                                                    block_close_max_events,
+                                                    block_close_max_size)
+                VALUES (:name, :task, :spec,
+                        :blockMaxCloseTime,
+                        :blockMaxFiles,
+                        :blockMaxEvents,
+                        :blockMaxSize)"""
 
     existsSQL = "SELECT id FROM dbsbuffer_workflow WHERE name = :name AND task = :task"
 
-    updateSQL = "UPDATE dbsbuffer_workflow SET spec = :spec WHERE id = :id"
 
-
-    def execute(self, requestName, taskPath, specPath = None, conn = None, transaction = False):
+    def execute(self, requestName, taskPath,
+                blockMaxCloseTime, blockMaxFiles,
+                blockMaxEvents, blockMaxSize,
+                specPath = None,
+                conn = None, transaction = False):
         """
         _execute_
 
         Insert a simple workflow into the dbsbuffer_workflow table
         """
-        binds = {'name': requestName, 'task': taskPath}
+        binds = {'name': requestName, 'task': taskPath, 'spec' : specPath,
+                 'blockMaxCloseTime' : blockMaxCloseTime,
+                 'blockMaxFiles' : blockMaxFiles,
+                 'blockMaxEvents' : blockMaxEvents,
+                 'blockMaxSize' : blockMaxSize}
 
         self.dbi.processData(self.sql, binds, conn = conn,
                              transaction = transaction)
 
+        binds = {'name': requestName, 'task': taskPath}
+
         result = self.dbi.processData(self.existsSQL, binds, conn = conn,
                                       transaction = transaction)
         workflowId = self.formatDict(result)[0]['id']
-
-        if specPath:
-            # We got a specPath, update it in the database
-            binds = {'spec' : specPath, 'id' : workflowId}
-            self.dbi.processData(self.updateSQL, binds, conn = conn,
-                                 transaction = transaction)
-
         return workflowId

--- a/src/python/WMComponent/DBS3Buffer/MySQL/LoadBlocks.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/LoadBlocks.py
@@ -5,16 +5,11 @@ _LoadBlocks_
 MySQL implementation of LoadBlocks
 """
 
-
-
-
 from WMCore.Database.DBFormatter import DBFormatter
 
 class LoadBlocks(DBFormatter):
     sql = """SELECT DISTINCT dbb.blockname as blockname, dbb.create_time as create_time,
                 dbb.status AS status, dbb.status3 AS status3,
-                (SELECT COUNT(*) FROM dbsbuffer_file dbf WHERE dbf.block_id = dbb.id) AS nFiles,
-                (SELECT SUM(dbf2.filesize) FROM dbsbuffer_file dbf2 WHERE dbf2.block_id = dbb.id) AS blocksize,
                 dbl.se_name AS location, dbf3.dataset_algo AS das
               FROM dbsbuffer_block dbb
               INNER JOIN dbsbuffer_file dbf3 ON
@@ -30,8 +25,6 @@ class LoadBlocks(DBFormatter):
             final = {}
             final['block_name']       = tmp['blockname']
             final['creation_date']    = tmp['create_time']
-            #final['file_count']       = tmp['nfiles']
-            #final['block_size']       = int(tmp['blocksize'])
             final['origin_site_name'] = tmp['location']
             final['DatasetAlgo']      = tmp['das']
 

--- a/src/python/WMComponent/DBS3Buffer/MySQL/LoadDBSFilesByDAS.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/LoadDBSFilesByDAS.py
@@ -20,7 +20,11 @@ class LoadDBSFilesByDAS(DBFormatter):
                     dbsbuffer_algo.app_name AS app_name, dbsbuffer_algo.app_ver AS app_ver,
                     dbsbuffer_algo.app_fam AS app_fam, dbsbuffer_algo.pset_hash AS pset_hash,
                     dbsbuffer_algo.config_content, dbsbuffer_dataset.path AS dataset_path,
-                    dbsbuffer_dataset.global_tag AS global_tag
+                    dbsbuffer_dataset.global_tag AS global_tag,
+                    dbsbuffer_workflow.block_close_max_wait_time,
+                    dbsbuffer_workflow.block_close_max_files,
+                    dbsbuffer_workflow.block_close_max_events,
+                    dbsbuffer_workflow.block_close_max_size
              FROM dbsbuffer_file files
              INNER JOIN dbsbuffer_algo_dataset_assoc ON
                files.dataset_algo = dbsbuffer_algo_dataset_assoc.id
@@ -28,6 +32,8 @@ class LoadDBSFilesByDAS(DBFormatter):
                dbsbuffer_algo_dataset_assoc.algo_id = dbsbuffer_algo.id
              INNER JOIN dbsbuffer_dataset ON
                dbsbuffer_algo_dataset_assoc.dataset_id = dbsbuffer_dataset.id
+             INNER JOIN dbsbuffer_workflow ON
+               dbsbuffer_workflow.id = files.workflow
              WHERE dbsbuffer_algo_dataset_assoc.id = :das
              AND files.status = :status
              AND NOT EXISTS (SELECT parent FROM dbsbuffer_file_parent dbfp

--- a/src/python/WMComponent/DBS3Buffer/MySQL/LoadFilesByBlock.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/LoadFilesByBlock.py
@@ -21,7 +21,11 @@ class LoadFilesByBlock(MySQLLoadDBSFilesByDAS):
                     dbsbuffer_algo.config_content, dbsbuffer_dataset.path AS dataset_path,
                     dbsbuffer_dataset.acquisition_era AS acquisition_era,
                     dbsbuffer_dataset.processing_ver AS processing_ver,
-                    dbsbuffer_dataset.global_tag AS global_tag
+                    dbsbuffer_dataset.global_tag AS global_tag,
+                    dbsbuffer_workflow.block_close_max_wait_time,
+                    dbsbuffer_workflow.block_close_max_files,
+                    dbsbuffer_workflow.block_close_max_events,
+                    dbsbuffer_workflow.block_close_max_size
              FROM dbsbuffer_file files
              INNER JOIN dbsbuffer_algo_dataset_assoc ON
                files.dataset_algo = dbsbuffer_algo_dataset_assoc.id
@@ -29,6 +33,8 @@ class LoadFilesByBlock(MySQLLoadDBSFilesByDAS):
                dbsbuffer_algo_dataset_assoc.algo_id = dbsbuffer_algo.id
              INNER JOIN dbsbuffer_dataset ON
                dbsbuffer_algo_dataset_assoc.dataset_id = dbsbuffer_dataset.id
+             INNER JOIN dbsbuffer_workflow ON
+               dbsbuffer_workflow.id = files.workflow
              WHERE files.block_id = (SELECT id FROM dbsbuffer_block WHERE blockname = :block)
              ORDER BY files.id"""
 

--- a/src/python/WMComponent/DBS3Buffer/MySQL/UpdateSpec.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/UpdateSpec.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+"""
+_InsertSpec_
+
+MySQL implementation of DBSBuffer3.UpdateSpec
+
+Created on Mar 11, 2013
+
+@author: dballest
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class UpdateSpec(DBFormatter):
+    """
+    _UpdateSpec_
+
+    Insert a spec using the name and task to a pre-existing record in dbsbuffer_workflow
+    """
+
+    existsSQL = "SELECT id FROM dbsbuffer_workflow WHERE name = :name AND task = :task"
+
+    updateSQL = "UPDATE dbsbuffer_workflow SET spec = :spec WHERE id = :id"
+
+    def execute(self, requestName, taskPath,
+                specPath, conn = None, transaction = False):
+        """
+        _execute_
+
+        Update a workflow in the dbsbuffer_workflow table
+        """
+        binds = {'name': requestName, 'task': taskPath}
+
+        result = self.dbi.processData(self.existsSQL, binds, conn = conn,
+                                      transaction = transaction)
+        formattedResult = self.formatDict(result)
+
+        if not formattedResult:
+            return None
+
+        workflowId = formattedResult[0]['id']
+
+        if specPath is not None:
+            binds = {'spec' : specPath, 'id' : workflowId}
+            self.dbi.processData(self.updateSQL, binds, conn = conn,
+                                 transaction = transaction)
+
+        return workflowId

--- a/src/python/WMComponent/DBS3Buffer/Oracle/Create.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/Create.py
@@ -227,10 +227,15 @@ class Create(DBCreator):
 
         self.create["13dbsbuffer_workflow"] = \
           """CREATE TABLE dbsbuffer_workflow (
-               id           INTEGER,
-               name         VARCHAR2(255),
-               task         VARCHAR2(255),
-               spec         VARCHAR2(255)) %s """ % tablespaceTable
+               id                           INTEGER,
+               name                         VARCHAR2(255),
+               task                         VARCHAR2(255),
+               spec                         VARCHAR2(255),
+               block_close_max_wait_time    NUMBER(11),
+               block_close_max_files        NUMBER(11),
+               block_close_max_events       NUMBER(11),
+               block_close_max_size         NUMBER(11),
+               ) %s """ % tablespaceTable
 
         self.create["10dbsbuffer_workflow_seq"] = \
           """CREATE SEQUENCE dbsbuffer_workflow_seq
@@ -345,10 +350,10 @@ class Create(DBCreator):
           """ALTER TABLE dbsbuffer_workflow ADD
                (CONSTRAINT dbsbuffer_workflow_uq UNIQUE (name, task) %s)""" % tablespaceIndex
 
-        #self.constraints["01_fk_dbsbuffer_file"] = \
-        #  """ALTER TABLE dbsbuffer_file ADD
-        #       (CONSTRAINT dbsbuffer_file  FOREIGN KEY (workflow)  REFERENCES dbsbuffer_workflow(id)
-        #         ON DELETE CASCADE)"""
+        self.constraints["01_fk_dbsbuffer_file"] = \
+          """ALTER TABLE dbsbuffer_file ADD
+               (CONSTRAINT dbsbuffer_file  FOREIGN KEY (workflow)  REFERENCES dbsbuffer_workflow(id)
+                 ON DELETE CASCADE)"""
 
         checksumTypes = ['cksum', 'adler32', 'md5']
         for i in checksumTypes:

--- a/src/python/WMComponent/DBS3Buffer/Oracle/InsertWorkflow.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/InsertWorkflow.py
@@ -15,10 +15,19 @@ class InsertWorkflow(MySQLInsertWorkflow):
     """
 
     sql = """INSERT INTO dbsbuffer_workflow
-             (id, name, task)
+                (id, name, task, spec,
+                block_close_max_wait_time,
+                block_close_max_files,
+                block_close_max_events,
+                block_close_max_size)
              SELECT dbsbuffer_workflow_seq.nextval,
                     :name,
-                    :task
+                    :task,
+                    :spec,
+                    :blockMaxCloseTime,
+                    :blockMaxFiles,
+                    :blockMaxEvents,
+                    :blockMaxSize
              FROM DUAL
              WHERE NOT EXISTS (
                SELECT id

--- a/src/python/WMComponent/DBS3Buffer/Oracle/UpdateSpec.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/UpdateSpec.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+"""
+_InsertSpec_
+
+Oracle implementation of DBSBuffer3.UpdateSpec
+
+Created on Mar 11, 2013
+
+@author: dballest
+"""
+
+from WMComponent.DBS3Buffer.MySQL.UpdateSpec import UpdateSpec as MySQLUpdateSpec
+
+class UpdateSpec(MySQLUpdateSpec):
+    pass

--- a/src/python/WMComponent/DBSUpload/DBSInterface.py
+++ b/src/python/WMComponent/DBSUpload/DBSInterface.py
@@ -487,9 +487,6 @@ class DBSInterface:
         self.version           = self.config.DBSVersion
         self.globalDBSUrl      = None
         self.committedRuns     = collections.deque(maxlen = 1000)
-        self.maxBlockFiles     = self.config.DBSBlockMaxFiles
-        self.maxBlockTime      = self.config.DBSBlockMaxTime
-        self.maxBlockSize      = self.config.DBSBlockMaxSize
         self.maxFilesToCommit  = self.config.MaxFilesToCommit
         self.doGlobalMigration = getattr(self.config, 'doGlobalMigration', True)
 

--- a/src/python/WMComponent/DBSUpload/Database/MySQL/LoadBlocks.py
+++ b/src/python/WMComponent/DBSUpload/Database/MySQL/LoadBlocks.py
@@ -11,13 +11,15 @@ MySQL implementation of DBSBufferFiles.GetBlock
 from WMCore.Database.DBFormatter import DBFormatter
 
 class LoadBlocks(DBFormatter):
-    sql = """SELECT DISTINCT db1.blockname as blockname, db1.create_time as create_time, db1.status AS open,
-                 db1.id AS id, dada.id AS das
+    sql = """SELECT db1.blockname as blockname, db1.create_time as create_time, db1.status AS open,
+                 db1.id AS id, dada.id AS das, dbw.block_close_max_wait_time
                FROM dbsbuffer_block db1
                INNER JOIN dbsbuffer_file df1 ON df1.block_id = db1.id
                INNER JOIN dbsbuffer_algo_dataset_assoc dada ON dada.id = df1.dataset_algo
+               INNER JOIN dbsbuffer_workflow dbw ON df1.workflow = dbw.id
                WHERE db1.status = 'Open'
                OR db1.status = 'Pending'
+               GROUP BY db1.blockname
              """
 
     def execute(self, conn = None, transaction = False):

--- a/src/python/WMComponent/DBSUpload/Database/MySQL/LoadBlocksByDAS.py
+++ b/src/python/WMComponent/DBSUpload/Database/MySQL/LoadBlocksByDAS.py
@@ -11,16 +11,20 @@ MySQL implementation of LoadBlocksByDAS
 from WMCore.Database.DBFormatter import DBFormatter
 
 class LoadBlocksByDAS(DBFormatter):
-    sql = """SELECT DISTINCT dbb.blockname as blockname, dbb.create_time as create_time,
+    sql = """SELECT dbb.blockname as blockname, dbb.create_time as create_time,
                 (SELECT COUNT(*) FROM dbsbuffer_file dbf WHERE dbf.block_id = dbb.id) AS nFiles,
                 (SELECT SUM(dbf2.filesize) FROM dbsbuffer_file dbf2 WHERE dbf2.block_id = dbb.id) AS blocksize,
-                dbl.se_name AS location, dbb.id AS id
+                (SELECT SUM(dbf4.events) FROM dbsbuffer_file dbf4 WHERE dbf4.block_id = dbb.id) AS blockevents,
+                dbl.se_name AS location, dbb.id AS id,
+                dbw.block_close_max_wait_time, dbw.block_close_max_files,
+                dbw.block_close_max_events, dbw.block_close_max_size
                 FROM dbsbuffer_block dbb
                 INNER JOIN dbsbuffer_file dbf3 ON dbf3.block_id = dbb.id
                 INNER JOIN dbsbuffer_location dbl ON dbl.id = dbb.location
+                INNER JOIN dbsbuffer_workflow dbw ON dbw.id = dbf3.workflow
                 WHERE dbb.status = 'Open'
-                AND dbf3.dataset_algo = :das"""
-
+                AND dbf3.dataset_algo = :das
+                GROUP BY dbb.blockname"""
 
     def format(self, result):
         tmpList = self.formatDict(result)
@@ -32,10 +36,15 @@ class LoadBlocksByDAS(DBFormatter):
             final['CreationDate']  = tmp['create_time']
             final['NumberOfFiles'] = tmp['nfiles']
             final['BlockSize']     = tmp['blocksize']
+            final['NumberOfEvents'] = tmp['blockevents']
             final['location']      = tmp['location']
             final['newFiles']      = []
             final['insertedFiles'] = []
             final['open']          = 1
+            final['MaxCloseTime'] = tmp['block_close_max_wait_time']
+            final['MaxCloseEvents'] = tmp['block_close_max_events']
+            final['MaxCloseFiles'] = tmp['block_close_max_files']
+            final['MaxCloseSize'] = tmp['block_close_max_size']
             blockList.append(final)
 
         return blockList

--- a/src/python/WMComponent/DBSUpload/Database/MySQL/LoadDBSFilesByDAS.py
+++ b/src/python/WMComponent/DBSUpload/Database/MySQL/LoadDBSFilesByDAS.py
@@ -5,11 +5,6 @@ _LoadDBSFilesByDAS_
 MySQL implementation of LoadDBSFilesByDAS
 """
 
-
-
-
-import logging
-
 from WMCore.Database.DBFormatter import DBFormatter
 
 class LoadDBSFilesByDAS(DBFormatter):
@@ -19,7 +14,11 @@ class LoadDBSFilesByDAS(DBFormatter):
                     files.block_id AS block_id,
                     dbsbuffer_algo.app_name AS app_name, dbsbuffer_algo.app_ver AS app_ver,
                     dbsbuffer_algo.app_fam AS app_fam, dbsbuffer_algo.pset_hash AS pset_hash,
-                    dbsbuffer_algo.config_content, dbsbuffer_dataset.path AS dataset_path
+                    dbsbuffer_algo.config_content, dbsbuffer_dataset.path AS dataset_path,
+                    dbsbuffer_workflow.block_close_max_wait_time,
+                    dbsbuffer_workflow.block_close_max_files,
+                    dbsbuffer_workflow.block_close_max_events,
+                    dbsbuffer_workflow.block_close_max_size
              FROM dbsbuffer_file files
              INNER JOIN dbsbuffer_algo_dataset_assoc ON
                files.dataset_algo = dbsbuffer_algo_dataset_assoc.id
@@ -27,6 +26,8 @@ class LoadDBSFilesByDAS(DBFormatter):
                dbsbuffer_algo_dataset_assoc.algo_id = dbsbuffer_algo.id
              INNER JOIN dbsbuffer_dataset ON
                dbsbuffer_algo_dataset_assoc.dataset_id = dbsbuffer_dataset.id
+             INNER JOIN dbsbuffer_workflow ON
+               dbsbuffer_workflow.id = files.workflow
              LEFT OUTER JOIN dbsbuffer_block dbb ON dbb.id = files.block_id
              WHERE dbsbuffer_algo_dataset_assoc.id = :das
              AND files.status = 'NOTUPLOADED'

--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
@@ -123,6 +123,10 @@ class Assign(WebAPI):
         if helper.getProcessingString():
             procString = helper.getProcessingString()
         dashboardActivity = helper.getDashboardActivity()
+        blockCloseMaxWaitTime = helper.getBlockCloseMaxWaitTime()
+        blockCloseMaxFiles = helper.getBlockCloseMaxFiles()
+        blockCloseMaxEvents = helper.getBlockCloseMaxEvents()
+        blockCloseMaxSize = helper.getBlockCloseMaxSize()
 
         (reqMergedBase, reqUnmergedBase) = helper.getLFNBases()
 
@@ -135,7 +139,11 @@ class Assign(WebAPI):
                                  acqEra = acqEra, procVer = procVer,
                                  procString = procString,
                                  dashboardActivity = dashboardActivity,
-                                 badRequests = [])
+                                 badRequests = [],
+                                 blockCloseMaxWaitTime = blockCloseMaxWaitTime,
+                                 blockCloseMaxFiles = blockCloseMaxFiles,
+                                 blockCloseMaxSize = blockCloseMaxSize,
+                                 blockCloseMaxEvents = blockCloseMaxEvents)
 
     @cherrypy.expose
     @cherrypy.tools.secmodv2(role=ReqMgrAuth.assign_roles)
@@ -153,6 +161,10 @@ class Assign(WebAPI):
         goodRequests = []
         reqMergedBase = None
         reqUnmergedBase = None
+        blockCloseMaxWaitTime = 66400
+        blockCloseMaxFiles = 500
+        blockCloseMaxEvents = 250000000
+        blockCloseMaxSize = 5000000000000
         for request in allRequests:
             # make sure there's a workload attached
             try:
@@ -171,6 +183,10 @@ class Assign(WebAPI):
                             procVer = helper.getProcessingVersion()
                         if helper.getProcessingString() != None:
                             procString = helper.getProcessingString()
+                        blockCloseMaxWaitTime = helper.getBlockCloseMaxWaitTime()
+                        blockCloseMaxFiles = helper.getBlockCloseMaxFiles()
+                        blockCloseMaxEvents = helper.getBlockCloseMaxEvents()
+                        blockCloseMaxSize = helper.getBlockCloseMaxSize()
                         (reqMergedBase, reqUnmergedBase) = helper.getLFNBases()
                         dashboardActivity = helper.getDashboardActivity()
                         goodRequests.append(request)
@@ -189,7 +205,11 @@ class Assign(WebAPI):
                                  acqEra = acqEra, procVer = procVer,
                                  procString = procString,
                                  dashboardActivity = dashboardActivity,
-                                 badRequests = badRequestNames)
+                                 badRequests = badRequestNames,
+                                 blockCloseMaxWaitTime = blockCloseMaxWaitTime,
+                                 blockCloseMaxFiles = blockCloseMaxFiles,
+                                 blockCloseMaxSize = blockCloseMaxSize,
+                                 blockCloseMaxEvents = blockCloseMaxEvents)
 
     @cherrypy.expose
     #@cherrypy.tools.secmodv2(role=ReqMgrAuth.assign_roles) security issue fix
@@ -292,6 +312,16 @@ class Assign(WebAPI):
                                                    autoApproveSites = autoApproveList,
                                                    custodialSubType = subscriptionType,
                                                    priority = subscriptionPriority)
+
+        # Block closing information
+        blockCloseMaxWaitTime = int(kwargs.get("BlockCloseMaxWaitTime", helper.getBlockCloseMaxWaitTime()))
+        blockCloseMaxFiles = int(kwargs.get("BlockCloseMaxFiles", helper.getBlockCloseMaxFiles()))
+        blockCloseMaxEvents = int(kwargs.get("BlockCloseMaxEvents", helper.getBlockCloseMaxEvents()))
+        blockCloseMaxSize = int(kwargs.get("BlockCloseMaxSize", helper.getBlockCloseMaxSize()))
+
+        helper.setBlockCloseSettings(blockCloseMaxWaitTime, blockCloseMaxFiles,
+                                     blockCloseMaxEvents, blockCloseMaxSize)
+
         helper.setDashboardActivity(kwargs.get("dashboard", ""))
         Utilities.saveWorkload(helper, request['RequestWorkflow'], self.wmstatWriteURL)
         

--- a/src/python/WMCore/WMSpec/StdSpecs/LHEStepZero.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/LHEStepZero.py
@@ -59,7 +59,11 @@ class LHEStepZeroWorkloadFactory(MonteCarloWorkloadFactory):
         self.prodJobSplitArgs  = arguments.setdefault("ProdJobSplitArgs",
                                                {"events_per_job": eventsPerJob,
                                                 "events_per_lumi": arguments['EventsPerLumi']})
-        return MonteCarloWorkloadFactory.__call__(self, workloadName, arguments)
+        mcWorkload = MonteCarloWorkloadFactory.__call__(self, workloadName, arguments)
+        mcWorkload.setBlockCloseSettings(mcWorkload.getBlockCloseMaxWaitTime(), 5,
+                                         250000000, mcWorkload.getBlockCloseMaxSize())
+
+        return mcWorkload
 
     def validateSchema(self, schema):
         """

--- a/src/python/WMCore/WMSpec/StdSpecs/MonteCarlo.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/MonteCarlo.py
@@ -98,6 +98,11 @@ class MonteCarloWorkloadFactory(StdBase):
             self.addMergeTask(prodTask, self.prodJobSplitAlgo,
                               outputModuleName, lfn_counter = self.previousJobCount)
 
+        workload.setBlockCloseSettings(workload.getBlockCloseMaxWaitTime(),
+                                       workload.getBlockCloseMaxFiles(),
+                                       25000000,
+                                       workload.getBlockCloseMaxSize())
+
         return workload
 
 

--- a/src/python/WMCore/WMSpec/StdSpecs/MonteCarloFromGEN.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/MonteCarloFromGEN.py
@@ -97,6 +97,11 @@ class MonteCarloFromGENWorkloadFactory(StdBase):
                                           outputModuleName)
             procMergeTasks[outputModuleName] = mergeTask
 
+        workload.setBlockCloseSettings(workload.getBlockCloseMaxWaitTime(),
+                                       workload.getBlockCloseMaxFiles(),
+                                       25000000,
+                                       workload.getBlockCloseMaxSize())
+
         return workload
     
 

--- a/src/python/WMQuality/Emulators/DBSClient/DBS2Interface.py
+++ b/src/python/WMQuality/Emulators/DBSClient/DBS2Interface.py
@@ -1,0 +1,210 @@
+"""
+_DBS2Interface_
+
+Module containing a mock class to run unittests on the DBS2 uploader
+
+Created on Mar 12, 2013
+
+@author: dballest
+"""
+
+from WMComponent.DBSUpload.DBSErrors import DBSInterfaceError
+
+class DBS2Interface():
+    """
+    _DBS2Interface_
+
+    Provide a mock interface for DBS2 that can be used to test the full DBS2 uploader
+    without the actual upload or the need of a real DBS2 instance.
+    """
+    def __init__(self, config):
+        """
+        __init__
+
+        Initialize the storage of fake DBS data
+        """
+        self.dbs = 'FakeButNotNone'
+        self.algoList = []
+        self.processedDatasetList = []
+        self.primaryDatasetList = []
+        self.blocks = {}
+
+    def runDBSBuffer(self, algo, dataset, blocks, override = False):
+        """
+        _runDBSBuffer_
+
+        Run the entire fake DBSBuffer chain
+        """
+        # First create the dataset
+        processed = self.insertDatasetAlgo(algo = algo, dataset = dataset,
+                                           override = override)
+
+        # Next create blocks
+        affBlocks = self.createAndInsertBlocks(dataset = dataset,
+                                               procDataset = processed,
+                                               blocks = blocks)
+
+        return affBlocks
+
+    def insertDatasetAlgo(self, algo, dataset, override = False):
+        """
+        _insertDatasetAlgo_
+
+        Insert a dataset-algo combination in fake DBS2
+        """
+        dbsRef = None
+        if override or not algo['InDBS']:
+            # Then put the algo in DBS by referencing local DBS
+            dbsRef = self.dbs
+
+        # Create a DBS Algo
+        dbsAlgo = self._createAlgorithm(apiRef = dbsRef,
+                                          appName = algo['ApplicationName'],
+                                          appVer = algo['ApplicationVersion'],
+                                          appFam = algo['ApplicationFamily'],
+                                          PSetHash = algo['PSetHash'],
+                                          PSetContent = algo['PSetContent'])
+
+        if dataset['PrimaryDataset'].lower() == 'bogus':
+            # Do not commit bogus datasets!
+            return None
+
+        dbsRef = self.dbs
+        if dataset.get('DASInDBS', None):
+            # Then this whole thing is already in DBS
+            dbsRef = None
+
+        primary = self._createPrimaryDataset(apiRef = dbsRef,
+                                             primaryName = dataset['PrimaryDataset'])
+
+        processed = self._createProcessedDataset(apiRef = dbsRef,
+                                                 algorithm = dbsAlgo,
+                                                 primary = primary,
+                                                 processedName = dataset['ProcessedDataset'],
+                                                 dataTier = dataset['DataTier'],
+                                                 status = dataset['status'],
+                                                 globalTag = dataset['globalTag'],
+                                                 parent = dataset['parent'])
+
+        return processed
+
+    def createAndInsertBlocks(self, dataset, procDataset, blocks):
+        """
+        _createAndInsertBlocks_
+
+        Create all the blocks, account for the number of files, events and size only.
+        """
+        affectedBlocks = []
+
+        for block in blocks:
+            # Create each block one at a time and insert its files
+
+            # First create the block
+            self._createUncheckedBlock(apiRef = self.dbs, name = block['Name'],
+                                       datasetPath = dataset['Path'],
+                                       seName = block['location'])
+
+            block['Path'] = dataset['Path']
+            block['StorageElementList'] = block['location']
+
+            # Now assemble the files
+            block['readyFiles'] = block['newFiles']
+            flag = False
+            if block['open'] == 'Pending':
+                flag = True
+
+            finBlock = self.insertFilesAndCloseBlocks(block = block, close = flag)
+            affectedBlocks.append(finBlock)
+        return affectedBlocks
+
+    def insertFilesAndCloseBlocks(self, block, close = False):
+        """
+        _insertFilesAndCloseBlocks_
+
+        Insert files into blocks and close them.
+        This does all the actual work of closing a block, first
+        inserting the file info, then actually closing if you have
+        toggled the 'close' flag. All in the fake DBS.
+        """
+        # Insert all the files added to the block in this round
+        blockRef = self.blocks[block['Name']]
+        for fileInfo in block.get('readyFiles', []):
+            blockRef['events'] += fileInfo['events']
+            blockRef['size'] += fileInfo['size']
+            blockRef['nFiles'] += 1
+
+        # Close the block if requested
+        if close:
+            blockRef['OpenForWriting'] = '0'
+            block['OpenForWriting'] = '0'
+            block['open'] = 0
+
+        return block
+
+    def _createAlgorithm(self, apiRef, appName, appVer, appFam,
+                         PSetHash = None, PSetContent = None):
+        """
+        _createAlgorithm_
+
+        Create an algo object in fake DBS2
+        """
+        algoObject = {'exe' : appName,
+                      'version' : appVer,
+                      'family' : appFam,
+                      'hash' : PSetHash,
+                      'content' : PSetContent}
+        if apiRef:
+            self.algoList.append(algoObject)
+        return algoObject
+
+    def _createPrimaryDataset(self, primaryName, primaryDatasetType = 'mc', apiRef = None):
+        """
+        _createPrimaryDataset_
+
+        Create an primds object in fake DBS2
+        """
+        primDsObject = {'name' : primaryName,
+                        'type' : primaryDatasetType}
+        if apiRef:
+            self.primaryDatasetList.append(primDsObject)
+        return primDsObject
+
+    def _createProcessedDataset(self, algorithm, apiRef, primary, processedName, dataTier,
+                                group = "NoGroup", status = "VALID",
+                                globalTag = '', parent = None):
+        """
+        _createProcessedDataset_
+
+        Create an procds object in fake DBS2
+        """
+        if algorithm not in self.algoList:
+            raise DBSInterfaceError("No algo object inserted before associated processed dataset")
+        if primary not in self.primaryDatasetList:
+            raise DBSInterfaceError("No primds object inserted before associated processed dataset")
+        procDsObject = {'name' : processedName,
+                        'tier' : dataTier,
+                        'group' : group,
+                        'status' : status,
+                        'tag' : globalTag,
+                        'parent' : parent}
+        if apiRef:
+            self.processedDatasetList.append(procDsObject)
+        return procDsObject
+
+    def _createUncheckedBlock(self, apiRef, name, datasetPath, seName):
+        """
+        _createUncheckedBlock_
+
+        Create blocks object if not existent and store them in the DBSInterface memory
+        """
+        blockObject = {'name' : name,
+                       'datasetPath' : datasetPath,
+                       'storage_elements' : [seName],
+                       'events' : 0,
+                       'nFiles' : 0,
+                       'size' : 0,
+                       'OpenForWriting' : '1'}
+        if name not in self.blocks:
+            self.blocks[name] = blockObject
+
+        return self.blocks[name]

--- a/src/python/WMQuality/Emulators/DBSClient/DBS3API.py
+++ b/src/python/WMQuality/Emulators/DBSClient/DBS3API.py
@@ -1,0 +1,47 @@
+"""
+_DBS3API_
+
+Mock DBS3 api for testing the DBS3 uploader
+
+Created on Mar 13, 2013
+
+@author: dballest
+"""
+
+import json
+import os
+
+class DbsApi():
+    """
+    _DbsApi_
+
+    Replacement DbsApi implementing the required
+    functions for the DBS3 upload poller.
+    """
+    def __init__(self, url):
+        """
+        _init_
+
+        Store the url where this dbs is "located"
+        """
+        self.dbsPath = url
+
+    def insertBulkBlock(self, blockDump):
+        """
+        _insertBulkBlock_
+
+        Insert a block into fake DBS, only insert the block specific information
+        and no file information in the file given in the dbsPath
+        """
+
+        currentInfo = []
+        if os.path.getsize(self.dbsPath):
+            inFileHandle = open(self.dbsPath, 'r')
+            currentInfo = json.load(inFileHandle)
+            inFileHandle.close()
+        outFileHandle = open(self.dbsPath, 'w')
+        currentInfo.append(blockDump['block'])
+        json.dump(currentInfo, outFileHandle)
+        outFileHandle.close()
+
+        return

--- a/src/templates/WMCore/WebTools/RequestManager/Assign.tmpl
+++ b/src/templates/WMCore/WebTools/RequestManager/Assign.tmpl
@@ -136,7 +136,15 @@ Memory limits: RSS (KiBytes) <input type="text" name="maxRSS" value=2411724 size
 VSS (KiBytes)<input type="text" name="maxVSize" value=2411724 size=10/><br/>
 Wallclock limits: Timeout (Seconds) <input type="text" name="SoftTimeout" value=129600 size=10/>
 GracePeriod (Seconds)<input type="text" name="GracePeriod" value=300 size=10/><br/>
-
+Block Closing Settings: Block timeout (Seconds) <input type="text" name="BlockCloseMaxWaitTime" value=$blockCloseMaxWaitTime size=10/>
+Max number of files <input type="text" name="BlockCloseMaxFiles" value=$blockCloseMaxFiles size=10/><br/>
+<!-- Indentation -->
+&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp
+&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp
+&nbsp&nbsp&nbsp
+<!-- Indentation -->
+Max number of events <input type="text" name="BlockCloseMaxEvents" value=$blockCloseMaxEvents size=10/>
+Max block size (Bytes) <input type="text" name="BlockCloseMaxSize" value=$blockCloseMaxSize size=10/><br/>
 Acquisition Era: <input type="text" name="AcquisitionEra" size=20 value="$acqEra" /><br/>
 Processing Version:  <input type="text" name="ProcessingVersion"  size=10 value="$procVer" /><br/>
 Processing String: <input type="text" name="ProcessingString" size=20 value="$procString" /><br/>

--- a/test/data/ReqMgr/requests/MonteCarlo.json
+++ b/test/data/ReqMgr/requests/MonteCarlo.json
@@ -59,6 +59,10 @@
         "NonCustodialSites": [],
         "AutoApproveSubscriptionSites": [],
         "SubscriptionPriority": "Low",
-        "CustodialSubType" : "Move"
+        "CustodialSubType" : "Move",
+        "BlockCloseMaxWaitTime" : 66400,
+        "BlockCloseMaxFiles" : 500,
+        "BlockCloseMaxEvents" : 25000000,
+        "BlockCloseMaxSize" : 5000000000000
 	}
 }

--- a/test/data/ReqMgr/requests/MonteCarloFromGEN.json
+++ b/test/data/ReqMgr/requests/MonteCarloFromGEN.json
@@ -59,6 +59,10 @@
         "NonCustodialSites": [],
         "AutoApproveSubscriptionSites": [],
         "SubscriptionPriority": "Low",
-        "CustodialSubType" : "Move"
+        "CustodialSubType" : "Move",
+        "BlockCloseMaxWaitTime" : 66400,
+        "BlockCloseMaxFiles" : 500,
+        "BlockCloseMaxEvents" : 25000000,
+        "BlockCloseMaxSize" : 5000000000000
 	}
 }

--- a/test/data/ReqMgr/requests/ReDigi.json
+++ b/test/data/ReqMgr/requests/ReDigi.json
@@ -67,6 +67,10 @@
         "NonCustodialSites": [],
         "AutoApproveSubscriptionSites": [],
         "SubscriptionPriority": "Low",
-        "CustodialSubType" : "Move"
+        "CustodialSubType" : "Move",
+        "BlockCloseMaxWaitTime" : 66400,
+        "BlockCloseMaxFiles" : 500,
+        "BlockCloseMaxEvents" : 250000000,
+        "BlockCloseMaxSize" : 5000000000000
 	}
 }

--- a/test/data/ReqMgr/requests/ReReco.json
+++ b/test/data/ReqMgr/requests/ReReco.json
@@ -65,6 +65,10 @@
         "NonCustodialSites": [],
         "AutoApproveSubscriptionSites": [],
         "SubscriptionPriority": "Low",
-        "CustodialSubType" : "Move"
+        "CustodialSubType" : "Move",
+        "BlockCloseMaxWaitTime" : 66400,
+        "BlockCloseMaxFiles" : 500,
+        "BlockCloseMaxEvents" : 250000000,
+        "BlockCloseMaxSize" : 5000000000000
 	}
 }

--- a/test/data/ReqMgr/requests/TaskChain.json
+++ b/test/data/ReqMgr/requests/TaskChain.json
@@ -66,6 +66,10 @@
         "NonCustodialSites": [],
         "AutoApproveSubscriptionSites": [],
         "SubscriptionPriority": "Low",
-        "CustodialSubType" : "Move"
+        "CustodialSubType" : "Move",
+        "BlockCloseMaxWaitTime" : 66400,
+        "BlockCloseMaxFiles" : 500,
+        "BlockCloseMaxEvents" : 250000000,
+        "BlockCloseMaxSize" : 5000000000000
     }
 }

--- a/test/data/ReqMgr/requests/TaskChainMultiTask.json
+++ b/test/data/ReqMgr/requests/TaskChainMultiTask.json
@@ -86,6 +86,10 @@
         "NonCustodialSites": [],
         "AutoApproveSubscriptionSites": [],
         "SubscriptionPriority": "Low",
-        "CustodialSubType" : "Move"
+        "CustodialSubType" : "Move",
+        "BlockCloseMaxWaitTime" : 66400,
+        "BlockCloseMaxFiles" : 500,
+        "BlockCloseMaxEvents" : 250000000,
+        "BlockCloseMaxSize" : 5000000000000
     }
 }

--- a/test/python/WMComponent_t/DBS3Buffer_t/DBSBufferFile_t.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/DBSBufferFile_t.py
@@ -6,11 +6,9 @@ Unit tests for the DBSBufferFile class.
 """
 
 import unittest
-import os
 import threading
 
 from WMCore.DAOFactory import DAOFactory
-from WMCore.WMFactory  import WMFactory
 
 from WMQuality.TestInit import TestInit
 from WMCore.DataStructs.Run import Run
@@ -28,7 +26,7 @@ class DBSBufferFileTest(unittest.TestCase):
         """
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection(destroyAllDatabase = True)
+        self.testInit.setDatabaseConnection()
         self.testInit.setSchema(customModules = ["WMComponent.DBS3Buffer"],
                                 useDefault = False)
 

--- a/test/python/WMComponent_t/DBS3Buffer_t/__init__.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/__init__.py
@@ -1,0 +1,5 @@
+"""
+Created on Mar 13, 2013
+
+@author: dballest
+"""

--- a/test/python/WMComponent_t/DBS3Buffer_t/scaleTest.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/scaleTest.py
@@ -187,10 +187,10 @@ if __name__ == "__main__":
 
     """
 
-    scaleTester = scaleTestFiller()
-
-    while True:
-        print "Ready to begin scale testing"
-        scaleTester()
-        print "Done running for now, sleeping temporarily"
-        time.sleep(random.randint(10, 60))
+    if False: # Enable test at your own risk
+        scaleTester = scaleTestFiller()
+        while True:
+            print "Ready to begin scale testing"
+            scaleTester()
+            print "Done running for now, sleeping temporarily"
+            time.sleep(random.randint(10, 60))

--- a/test/python/WMComponent_t/JobAccountant_t/JobAccountant_t.py
+++ b/test/python/WMComponent_t/JobAccountant_t/JobAccountant_t.py
@@ -5,14 +5,11 @@ _JobAccountant_t_
 Unit tests for the WMAgent JobAccountant component.
 """
 
-import logging
 import os.path
 import threading
 import unittest
 import time
 import copy
-import random
-import tempfile
 
 import WMCore.WMBase
 from WMCore.FwkJobReport.Report import Report
@@ -27,6 +24,7 @@ from WMCore.WMBS.Job          import Job
 from WMCore.WMBS.File         import File
 from WMCore.WMBS.JobGroup     import JobGroup
 from WMCore.WMBS.Fileset      import Fileset
+from WMCore.WMSpec.WMWorkload import newWorkload
 
 from WMCore.DataStructs.Run   import Run
 
@@ -675,9 +673,9 @@ class JobAccountantTest(unittest.TestCase):
         self.cleanupFileset = Fileset(name = "Cleanup")
         self.cleanupFileset.create()
 
-        falseSpec = os.path.join(WMCore.WMBase.getTestBase(),
-                                 "WMComponent_t/JobAccountant_t/fwjrs",
-                                 "MergedSkimSuccess.pkl")
+        dummyWorkload = newWorkload("Steves")
+        dummyWorkload.save(os.path.join(self.testDir, 'initialSpecPath.pkl'))
+        falseSpec = os.path.join(self.testDir, 'initialSpecPath.pkl')
 
         self.testWorkflow = Workflow(spec = falseSpec, owner = "Steve",
                                      name = "TestWF", task = "TestTopTask")
@@ -820,9 +818,9 @@ class JobAccountantTest(unittest.TestCase):
         self.mergedAodOutputFileset = Fileset(name = "MergedAOD")
         self.mergedAodOutputFileset.create()
 
-        falseSpec = os.path.join(WMCore.WMBase.getTestBase(),
-                                 "WMComponent_t/JobAccountant_t/fwjrs",
-                                 "MergeSuccess.pkl")
+        dummyWorkload = newWorkload("Steves")
+        dummyWorkload.save(os.path.join(self.testDir, 'initialSpecPath.pkl'))
+        falseSpec = os.path.join(self.testDir, 'initialSpecPath.pkl')
         self.testWorkflow = Workflow(spec = "wf001.xml", owner = "Steve",
                                      name = "Steves", task = "/Steves/Stupid/ProcessingTask")
         self.testWorkflow.create()

--- a/test/python/WMComponent_t/PhEDExInjector_t/PhEDExInjectorPoller_t.py
+++ b/test/python/WMComponent_t/PhEDExInjector_t/PhEDExInjectorPoller_t.py
@@ -93,8 +93,10 @@ class PhEDExInjectorPollerTest(unittest.TestCase):
                                    logger = myThread.logger,
                                    dbinterface = myThread.dbi)
         insertWorkflow = buffer3Factory(classname = "InsertWorkflow")
-        insertWorkflow.execute("BogusRequest", "BogusTask", os.path.join(getTestBase(),
-                                                                         "WMComponent_t/PhEDExInjector_t/specs/%s" % spec))
+        insertWorkflow.execute("BogusRequest", "BogusTask",
+                               0,0,0,0,
+                               os.path.join(getTestBase(),
+                               "WMComponent_t/PhEDExInjector_t/specs/%s" % spec))
 
         checksums = {"adler32": "1234", "cksum": "5678"}
         testFileA = DBSBufferFile(lfn = makeUUID(), size = 1024, events = 10,

--- a/test/python/WMComponent_t/PhEDExInjector_t/PhEDExInjectorSubscriber_t.py
+++ b/test/python/WMComponent_t/PhEDExInjector_t/PhEDExInjectorSubscriber_t.py
@@ -109,8 +109,10 @@ class PhEDExInjectorSubscriberTest(unittest.TestCase):
                                    logger = myThread.logger,
                                    dbinterface = myThread.dbi)
         insertWorkflow = buffer3Factory(classname = "InsertWorkflow")
-        insertWorkflow.execute("BogusRequest", "BogusTask", os.path.join(getTestBase(),
-                                                                         "WMComponent_t/PhEDExInjector_t/specs/TestWorkload.pkl"))
+        insertWorkflow.execute("BogusRequest", "BogusTask",
+                               0,0,0,0,
+                               os.path.join(getTestBase(),
+                                            "WMComponent_t/PhEDExInjector_t/specs/TestWorkload.pkl"))
 
         checksums = {"adler32": "1234", "cksum": "5678"}
         testFileA = DBSBufferFile(lfn = makeUUID(), size = 1024, events = 10,

--- a/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
@@ -1715,5 +1715,29 @@ class WMWorkloadTest(unittest.TestCase):
         self.assertEqual(sorted(testWorkload.listPileupDatasets()), sorted(["/some/minbias/data",
                                                                             "/some/minbias/mc"]))
 
+    def testBlockCloseSettings(self):
+        """
+        _testBlockCloseSettings_
+
+        Check the setters and getters for the block closing
+        parameters
+        """
+
+        testWorkload = self.makeTestWorkload()[0]
+        testWorkload.setBlockCloseSettings(1,2,3,4)
+        self.assertEqual(testWorkload.getBlockCloseMaxWaitTime(), 1)
+        self.assertEqual(testWorkload.getBlockCloseMaxFiles(), 2)
+        self.assertEqual(testWorkload.getBlockCloseMaxEvents(), 3)
+        self.assertEqual(testWorkload.getBlockCloseMaxSize(), 4)
+        return
+
+    def testListOutputProducingTasks(self):
+        testWorkload = self.makeTestWorkload()[0]
+        taskList = testWorkload.listOutputProducingTasks()
+        expectedTasks = ['/TestWorkload/ProcessingTask', '/TestWorkload/ProcessingTask/MergeTask',
+                         '/TestWorkload/ProcessingTask/MergeTask/SkimTask']
+        self.assertEqual(sorted(taskList), sorted(expectedTasks))
+        return
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Move the settings that determine when to close a produced block in
DBS to the request level instead of an agent-wide parameter.

These settings are:
- BlockCloseMaxWaitTime: Maximum time that a block will be left open since its creation.
- BlockCloseMaxFiles: Maximum number of files in a block, when reached the block is closed.
- BlockCloseMaxEvents: Maximum number of events in a block, when reached the block is closed.
- BlockCloseMaxSize: Maximum size of a block, when reached the block is closed.

Breakdown of the changes:
- At the RequestManager and workload definition level:
  - The WMWorkload contains the 4 block closing settings in the properties section (top level).
  - These are set to sensible defaults that are also modified per request type. E.g. LHEStepZero workloads have 5 files per block only.
  - The values can be modified through the assign page, these parameters are optional. The identifiers of the parameters were given above.
- At the local workqueue level:
  - The WMBSHelper now installs all tasks that will potentially produce merge output in the dbsbuffer workflow table, this includes the block closing settings.
- DBSBuffer3 schema changes:
  - The dbsbuffer_workflow table now contains 4 columns, one for each setting.
  - The InsertWorkflow DAO is updated to require the settings with any workflow injection
  - A new UpdateSpec DAO is provided to updated the spec path in the dbsbuffer_workflow table
- JobAccountant changes:
  - Since the workflows are injected at the WorkQueue level then workflows are not injected by default when files arrive,
    however if no workflow is found, the JobAccountant can still take care of this (so far the only use for this is unit testing).
- DBSUpload and DBSBuffer changes (2 & 3)
  - Every file record used in the DBSUpload pollers now contains the block closing settings
  - New blocks take the block closing settings from the first file they add and then use it to check when the block should be closed
  - Any component setting has been removed
- Unit tests
  - New emulator for the DBSInterface module for DBS2, this can be used to test the full dbsUploader without having a valid DBS instance
  - New mock API for the DBS3 Api, this can be used to the test the full dbsUploader (DBS3) without having a valid DBS instance
  - Extend unit tests for the dbsUploader to test new settings per workflow in DBS2 and DBS3

@sfoulkes, please review. 
