### PR TITLE
Add TransientOutputModules to TaskChain

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/DataProcessing.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/DataProcessing.py
@@ -53,6 +53,7 @@ class DataProcessingWorkloadFactory(StdBase):
 
         # Define attributes used by this spec
         self.openRunningTimeout = None
+        self.transientModules = []
 
         return
 

--- a/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
@@ -377,6 +377,8 @@ class TaskChainWorkloadFactory(StdBase):
         splitAlgorithm = taskConf.get('SplittingAlgorithm', 'EventBased')
         splitArguments = taskConf.get('SplittingArguments', {'events_per_job': int((24*3600)/float(self.timePerEvent))})
         keepOutput = taskConf.get('KeepOutput', True)
+        transientModules = taskConf.get('TransientOutputModules', [])
+        forceUnmerged = (not keepOutput) or (len(transientModules) > 0)
 
         self.inputPrimaryDataset = taskConf['PrimaryDataset']
         outputMods = self.setupProcessingTask(task, "Production",
@@ -385,28 +387,22 @@ class TaskChainWorkloadFactory(StdBase):
                                               configCacheUrl = self.configCacheUrl,
                                               splitArgs = splitArguments, stepType = cmsswStepType,
                                               seeding = taskConf['Seeding'], totalEvents = taskConf['RequestNumEvents'],
-                                              forceUnmerged = not keepOutput)
+                                              forceUnmerged = forceUnmerged)
 
+        # Set up any pileup
         if 'MCPileup' in taskConf or 'DataPileup' in taskConf:
             parsePileupConfig(taskConf)
         if taskConf.get('PileupConfig', None):
             self.setupPileup(task, taskConf['PileupConfig'])
 
         self.addLogCollectTask(task, 'LogCollectFor%s' % task.name())
-        if keepOutput:
-            procMergeTasks = {}
-            for outputModuleName in outputMods.keys():
-                mergeTask = self.addMergeTask(task, taskConf['SplittingAlgorithm'],
-                                              outputModuleName)
-                procMergeTasks[str(outputModuleName)] = mergeTask
-            self.mergeMapping[task.name()] = procMergeTasks
-        else:
-            procTasks = {}
-            for outputModuleName in outputMods:
-                self.addCleanupTask(task, outputModuleName)
-                procTasks[outputModuleName] = task
-            self.mergeMapping[task.name()] = procTasks
-        
+
+        # Do the output module merged/unmerged association
+        self.setUpMergeTasks(task, outputMods, splitAlgorithm,
+                             keepOutput, transientModules)
+
+        return
+
     @ParameterStorage
     def setupTask(self, task, taskConf):
         """
@@ -421,6 +417,8 @@ class TaskChainWorkloadFactory(StdBase):
         splitAlgorithm = taskConf.get('SplittingAlgorithm', 'LumiBased')
         splitArguments = taskConf.get('SplittingArguments', {'lumis_per_job': 8})
         keepOutput     = taskConf.get('KeepOutput', True)
+        transientModules = taskConf.get('TransientOutputModules', [])
+        forceUnmerged = (not keepOutput) or (len(transientModules) > 0)
 
         # in case the initial task is a processing task, we have an input dataset, otherwise
         # we look up the parent task and step
@@ -437,7 +435,7 @@ class TaskChainWorkloadFactory(StdBase):
             inputTaskConf = self.taskMapping[inputTask]
             parentTaskForMod = self.mergeMapping[inputTask][taskConf['InputFromOutputModule']]
             inpStep = parentTaskForMod.getStep("cmsRun1")
-            if not inputTaskConf.get('KeepOutput', True):
+            if not inputTaskConf.get('KeepOutput', True) or len(inputTaskConf.get('TransientOutputModules', [])) > 0:
                 inpMod = taskConf['InputFromOutputModule']
                 # Check if the splitting has to be changed
                 if inputTaskConf.get('SplittingAlgorithm', 'LumiBased') == 'EventBased' \
@@ -469,7 +467,7 @@ class TaskChainWorkloadFactory(StdBase):
                                               configCacheUrl = self.configCacheUrl,
                                               configDoc = configCacheID, splitAlgo = splitAlgorithm,
                                               splitArgs = splitArguments, stepType = cmsswStepType,
-                                              forceUnmerged = not keepOutput)
+                                              forceUnmerged = forceUnmerged)
 
 
         if 'MCPileup' in taskConf or 'DataPileup' in taskConf:
@@ -478,21 +476,41 @@ class TaskChainWorkloadFactory(StdBase):
             self.setupPileup(task, taskConf['PileupConfig'])
 
         self.addLogCollectTask(task, 'LogCollectFor%s' % task.name())
-        if keepOutput:
-            procMergeTasks = {}
-            for outputModuleName in outputMods.keys():
-                mergeTask = self.addMergeTask(task, splitAlgorithm,
-                                              outputModuleName)
-                procMergeTasks[str(outputModuleName)] = mergeTask
-            self.mergeMapping[task.name()] = procMergeTasks
-        else:
-            procTasks = {}
-            for outputModuleName in outputMods:
-                self.addCleanupTask(task, outputModuleName)
-                procTasks[outputModuleName] = task
-            self.mergeMapping[task.name()] = procTasks
+        self.setUpMergeTasks(task, outputMods, splitAlgorithm,
+                             keepOutput, transientModules)
 
         self.inputPrimaryDataset = currentPrimaryDataset
+
+        return
+
+    def setUpMergeTasks(self, parentTask, outputModules, splittingAlgo,
+                        keepOutput, transientOutputModules):
+        """
+        _setUpMergeTasks_
+
+        Set up the required merged tasks according to the following parameters:
+        - KeepOutput : All output modules not in the transient list are merged.
+        - TransientOutputModules : These output modules won't be merged.
+        If not merged then only a cleanup task is created.
+        """
+        modulesToMerge = []
+        unmergedModules = outputModules.keys()
+        if keepOutput:
+            unmergedModules = filter(lambda x : x in transientOutputModules, outputModules.keys())
+            modulesToMerge = filter(lambda x : x not in transientOutputModules, outputModules.keys())
+
+        procMergeTasks = {}
+        for outputModuleName in modulesToMerge:
+            mergeTask = self.addMergeTask(parentTask, splittingAlgo,
+                                          outputModuleName)
+            procMergeTasks[str(outputModuleName)] = mergeTask
+        self.mergeMapping[parentTask.name()] = procMergeTasks
+
+        procTasks = {}
+        for outputModuleName in unmergedModules:
+            self.addCleanupTask(parentTask, outputModuleName)
+            procTasks[outputModuleName] = parentTask
+        self.mergeMapping[parentTask.name()].update(procTasks)
 
         return
 
@@ -513,6 +531,7 @@ class TaskChainWorkloadFactory(StdBase):
             msg = "No tasks present in taskChain!"
             self.raiseValidationException(msg = msg)
 
+        transientMapping = {}
         for i in range(1, numTasks+1):
             taskName = "Task%s" % i
             if not schema.has_key(taskName):
@@ -543,7 +562,19 @@ class TaskChainWorkloadFactory(StdBase):
                                                couchDBName = schema["CouchDBName"],
                                                getOutputModules = True)
 
+            # Validate the chaining of transient output modules, need to make a copy of the lists
+            transientMapping[task['TaskName']] = [x for x in task.get('TransientOutputModules', [])]
 
+            if i > 1:
+                inputTransientModules = transientMapping[task['InputTask']]
+                if task['InputFromOutputModule'] in inputTransientModules:
+                    inputTransientModules.remove(task['InputFromOutputModule'])
+
+        for task in transientMapping:
+            if transientMapping[task]:
+                msg = "A transient module is not processed by a subsequent task.\n"
+                msg += "This is a malformed task chain workload"
+                self.raiseValidationException(msg)
 
 def taskChainWorkload(workloadName, arguments):
     """


### PR DESCRIPTION
Same functionality as in ReReco, some modules can be kept unmerged if
necessary in order to reduce the output but allow subsequent processing.

The parameter per task is TransientOutputModules, also KeepOutput is still
valid and can be used to wipe all the output in the task to unmerged. If
KeepOutput is False then TransientOutputModules doesn't have any effect.

Fixes #4474
