### PR TITLE
Fixes automatic testing of TaskChain requests

### DIFF
--- a/test/data/ReqMgr/requests/TaskChain.json
+++ b/test/data/ReqMgr/requests/TaskChain.json
@@ -4,7 +4,6 @@
         "AcquisitionEra": "6_1_0-TEST_Testbed-base",
         "CMSSWVersion": "CMSSW_6_1_0",
         "Campaign": "Testbed_TEST",
-        "CouchURL": "https://cmsweb-testbed.cern.ch/couchdb",
         "ConfigCacheUrl": "https://cmsweb-testbed.cern.ch/couchdb",
         "DQMConfigCacheID": "de444dec82fa4d973e6b94c27a3aaa8d",
         "DQMUploadUrl": "https://cmsweb.cern.ch/dqm/dev",

--- a/test/data/ReqMgr/requests/TaskChainMultiTask.json
+++ b/test/data/ReqMgr/requests/TaskChainMultiTask.json
@@ -4,7 +4,6 @@
         "AcquisitionEra": "6_1_0-TEST_Testbed-base",
         "CMSSWVersion": "CMSSW_6_1_0",
         "Campaign": "Testbed_TEST",
-        "CouchURL": "https://cmsweb-testbed.cern.ch/couchdb",
         "ConfigCacheUrl": "https://cmsweb-testbed.cern.ch/couchdb",
         "DQMConfigCacheID": "de444dec82fa4d973e6b94c27a3aaa8d",
         "DQMUploadUrl": "https://cmsweb.cern.ch/dqm/dev",


### PR DESCRIPTION
TaskChain requests JSON template files had CouchURL argument defined. Which
overrides ConfigCacheUrl. This could have possibly worked only on the defined
host which was testbed, but failed with CouchInternalError otherwise.
