### PR TITLE
Removed User, Group, Base request priorities

### DIFF
--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/Admin.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/Admin.py
@@ -1,5 +1,15 @@
-#!/usr/bin/env python
-""" Main Module for browsing and modifying requests """
+"""
+Main Module for browsing and modifying requests.
+
+NOTE (2013-03-21):
+Individual user and group priorities removed. There are still
+APIs down here for modified those, which will probably just ignore
+input priority values. All these will not be ported to ReqMgr2.
+Leaving it here for now.
+
+"""
+
+
 import WMCore.RequestManager.RequestDB.Interface.User.Registration as Registration
 import WMCore.RequestManager.RequestDB.Interface.Admin.SoftwareManagement as SoftwareAdmin
 import WMCore.RequestManager.RequestDB.Interface.Admin.ProdManagement as ProdManagement

--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrBrowser.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrBrowser.py
@@ -49,7 +49,7 @@ class ReqMgrBrowser(WebAPI):
         # Take a guess
         self.templatedir = config.templates
         self.fields = ['RequestName', 'Group', 'Requestor', 'RequestType',
-                       'ReqMgrRequestBasePriority', 'RequestStatus', 'Complete', 'Success']
+                       "RequestPriority", 'RequestStatus', 'Complete', 'Success']
         self.calculatedFields = {'Written': 'percentWritten', 'Merged':'percentMerged',
                                  'Complete':'percentComplete', 'Success' : 'percentSuccess'}
         # entries in the table that show up as HTML links for that entry
@@ -65,8 +65,6 @@ class ReqMgrBrowser(WebAPI):
             'Site Whitelist', 'Site Blacklist']
 
         self.adminMode = True
-        # don't allow mass editing.  Make people click one at a time.
-        #self.adminFields = {'RequestStatus':'statusMenu', 'ReqMgrRequestBasePriority':'Utilities.priorityMenu'}
         self.adminFields = {}
         self.couchUrl = config.couchUrl
         self.configDBName = config.configDBName
@@ -194,7 +192,7 @@ class ReqMgrBrowser(WebAPI):
         except AssertionError:
             raise cherrypy.HTTPError(404, "Cannot load request %s" % requestName)
         adminHtml = statusMenu(requestName, request['RequestStatus']) \
-                  + ' Priority ' + Utilities.priorityMenu(request)
+                  + ' Priority: ' + Utilities.priorityMenu(request)
         return self.templatepage("Request", requestName=requestName,
                                 detailsFields=self.detailsFields,
                                 requestSchema=request,
@@ -327,7 +325,6 @@ class ReqMgrBrowser(WebAPI):
         return "%i%%" % pct
 
     @cherrypy.expose
-    #@cherrypy.tools.secmodv2() security issue fix
     @cherrypy.tools.secmodv2(role=Utilities.security_roles(), group = Utilities.security_groups())    
     def doAdmin(self, **kwargs):
         """  format of kwargs is {'requestname:status' : 'approved', 'requestname:priority' : '2'} """
@@ -340,7 +337,7 @@ class ReqMgrBrowser(WebAPI):
                 priority = kwargs[requestName+':priority']
                 if priority != '':
                     Utilities.changePriority(requestName, priority, self.wmstatWriteURL)
-                    message += "Changed priority for %s to %s\n" % (requestName, priority)
+                    message += "Changed priority for %s to %s.\n" % (requestName, priority)
                 if status != "":
                     Utilities.changeStatus(requestName, status, self.wmstatWriteURL)
                     message += "Changed status for %s to %s\n" % (requestName, status)
@@ -351,7 +348,6 @@ class ReqMgrBrowser(WebAPI):
 
 
     @cherrypy.expose
-    #@cherrypy.tools.secmodv2() security issue fix
     @cherrypy.tools.secmodv2(role=Utilities.security_roles(), group = Utilities.security_groups())
     # FIXME needs to check if authorized, or original user
     def modifyWorkload(self, requestName, workload,

--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrRESTModel.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrRESTModel.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 ReqMgrRESTModel
 
@@ -10,6 +8,7 @@ DB interfaces they execute.
 
 https://twiki.cern.ch/twiki/bin/viewauth/CMS/ReqMgrSystemDesign
 """
+
 import sys
 import math
 import cherrypy
@@ -130,14 +129,6 @@ class ReqMgrRESTModel(RESTModel):
                                 'files_merged', 'percent_written',
                                 'percent_success', 'dataset'],
                         secured=True, validation = [self.validateUpdates])
-        self._addMethod('POST', 'user', self.postUser,
-                        args = ['user', 'priority'],
-                        secured=True, security_params=self.security_params,
-                        validation = [self.isalnum, self.intpriority])
-        self._addMethod('POST',  'group', self.postGroup,
-                        args = ['group', 'priority'],
-                        secured=True, security_params=self.security_params,
-                        validation = [self.isalnum, self.intpriority])
         self._addMethod('DELETE', 'request', self.deleteRequest,
                         args = ['requestName'],
                         secured=True, security_params=self.security_params,
@@ -624,15 +615,6 @@ class ReqMgrRESTModel(RESTModel):
             if k in index:
                 index[k] = float(index[k])
         return index
-
-    def postUser(self, user, priority):
-        """ Change the user's priority """
-        return UserManagement.setPriority(user, priority)
-
-    def postGroup(self, group, priority):
-        """ Change the group's priority """
-        return GroupManagement.setPriority(group, priority)
-
 
     # had no permission control before, security issue fix
     @cherrypy.tools.secmodv2(role=Utilities.security_roles(), group = Utilities.security_groups())

--- a/src/python/WMCore/RequestManager/DataStructs/Request.py
+++ b/src/python/WMCore/RequestManager/DataStructs/Request.py
@@ -22,7 +22,6 @@ class Request(dict):
         # // ReqMgr specifics
         #//
         self.setdefault("ReqMgrRequestID", None)
-        self.setdefault("ReqMgrRequestBasePriority", None)
 
         #  //
         # // Requestor and group information

--- a/src/python/WMCore/RequestManager/RequestDB/Interface/ProdSystem/ProdMgrRetrieve.py
+++ b/src/python/WMCore/RequestManager/RequestDB/Interface/ProdSystem/ProdMgrRetrieve.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 _ProdMgrRetrieve_
 
@@ -39,7 +38,6 @@ def acceptRequest(requestId):
 
     """
     ChangeStatus.changeRequestIDStatus(requestId, "acquired")
-    return
 
 
 
@@ -52,7 +50,6 @@ def getRequest(requestId):
     Includes
     - All basic request information from DB
     - Teams the request has been assigned to
-    - Priority per assigned team
     - URL to download the workflow spec from
 
     TODO: Add download URL for the workflow spec.
@@ -63,10 +60,5 @@ def getRequest(requestId):
 
     request = GetRequest.getRequest(requestId)
     assigned = GetRequest.getRequestAssignments(requestId)
-
-    for team in assigned:
-        team['TeamPriority'] += request['RequestPriority']
     request['Assignments'] = assigned
-
-
     return request

--- a/src/python/WMCore/RequestManager/RequestDB/Interface/Request/ChangeState.py
+++ b/src/python/WMCore/RequestManager/RequestDB/Interface/Request/ChangeState.py
@@ -49,14 +49,12 @@ def changeRequestIDStatus(requestId, newState, priority = None):
         priorityChange = factory(classname = "Request.Priority")
         priorityChange.execute(requestId, priority)
 
-    return
 
 def changeRequestPriority(requestName, priority):
     factory = DBConnect.getConnection()
     reqId = getRequestID(factory, requestName)
     priorityChange = factory(classname = "Request.Priority")
     priorityChange.execute(reqId, priority)
-    return
 
 
 def changeRequestStatus(requestName, newState, priority=None, wmstatUrl=None):
@@ -101,7 +99,7 @@ def changeRequestStatus(requestName, newState, priority=None, wmstatUrl=None):
         wmstatSvc.updateRequestStatus(requestName, newState)
     
 
-def assignRequest(requestName, teamName, priorityModifier = 0, prodMgr = None, wmstatUrl = None):
+def assignRequest(requestName, teamName, prodMgr = None, wmstatUrl = None):
     """
     _assignRequest_
 
@@ -112,9 +110,6 @@ def assignRequest(requestName, teamName, priorityModifier = 0, prodMgr = None, w
     - Changes the status to assigned
     - Creates an association to the team provided
     - Optionally associates the request to a prod mgr instance
-    - Optionally sets the priority modifier for the team (allows same request to be
-      shared between two teams with different priorities
-
 
     """
 
@@ -132,7 +127,7 @@ def assignRequest(requestName, teamName, priorityModifier = 0, prodMgr = None, w
         wmstatSvc.updateTeam(requestName, teamName)
 
     assigner = factory(classname = "Assignment.New")
-    assigner.execute(reqId, teamId, priorityModifier)
+    assigner.execute(reqId, teamId)
 
     changeRequestStatus(requestName, 'assigned', priority = None, wmstatUrl = wmstatUrl)
 
@@ -140,7 +135,6 @@ def assignRequest(requestName, teamName, priorityModifier = 0, prodMgr = None, w
         addPM = factory(classname = "Progress.ProdMgr")
         addPM.execute(reqId, prodMgr)
 
-    return
 
 def deleteAssignment(requestName):
     """
@@ -167,7 +161,6 @@ def updateRequest(requestName, paramDict):
     factory = DBConnect.getConnection()
     reqId = getRequestID(factory, requestName)
     factory(classname = "Progress.Update").execute(reqId, **paramDict)
-    return
 
 
 def getProgress(requestName):
@@ -188,4 +181,3 @@ def putMessage(requestName, message):
     #return factory(classname = "Progress.Message").execute(reqId, message)
     message = message[:999]
     factory(classname = "Progress.Message").execute(reqId, message)
-    return

--- a/src/python/WMCore/RequestManager/RequestDB/Interface/Request/GetRequest.py
+++ b/src/python/WMCore/RequestManager/RequestDB/Interface/Request/GetRequest.py
@@ -53,7 +53,6 @@ def getRequest(requestId, reverseTypes=None, reverseStatus=None):
     request["RequestType"] = reverseTypes[reqData['request_type']]
     request["RequestStatus"] = reverseStatus[reqData['request_status']]
     request["RequestPriority"] = reqData['request_priority']
-    request["ReqMgrRequestBasePriority"] = reqData['request_priority']
     request["RequestWorkflow"] = reqData['workflow']
     request["RequestNumEvents"] = reqData['request_num_events']
     request["RequestSizeFiles"] = reqData['request_size_files']
@@ -61,16 +60,8 @@ def getRequest(requestId, reverseTypes=None, reverseStatus=None):
 
     request["Group"] = groupData['group_name']
     request["ReqMgrGroupID"] = groupData['group_id']
-    request["ReqMgrGroupBasePriority"] = \
-                        groupData['group_base_priority']
     request["Requestor"] = userData['requestor_hn_name']
     request["ReqMgrRequestorID"] = userData['requestor_id']
-    request["ReqMgrRequestorBasePriority"] = \
-                                userData['requestor_base_priority']
-    request["RequestPriority"] = \
-      request['RequestPriority'] + groupData['group_base_priority']
-    request["RequestPriority"] = \
-      request['RequestPriority'] + userData['requestor_base_priority']
 
     updates = ChangeState.getProgress(requestName)
     request['percent_complete'], request['percent_success'] = percentages(updates)

--- a/src/python/WMCore/RequestManager/RequestDB/Interface/Request/MakeRequest.py
+++ b/src/python/WMCore/RequestManager/RequestDB/Interface/Request/MakeRequest.py
@@ -16,7 +16,7 @@ import WMCore.RequestManager.RequestDB.Connection as DBConnect
 
 
 def createRequest(hnUser, groupName, requestName, requestType, workflowName,
-                  prep_id, reqBasePriority):
+                  prep_id, requestPriority):
     """
     _createRequest_
 
@@ -82,8 +82,7 @@ def createRequest(hnUser, groupName, requestName, requestType, workflowName,
             association_id = groups[groupName],
             workflow = workflowName,
             prep_id = prep_id,
-            reqBasePriority = reqBasePriority
-            )
+            requestPriority = requestPriority)
     except Exception, ex:
         msg = "Unable to create request named %s\n" % requestName
         msg += str(ex)

--- a/src/python/WMCore/RequestManager/RequestDB/MySQL/Assignment/GetByRequest.py
+++ b/src/python/WMCore/RequestManager/RequestDB/MySQL/Assignment/GetByRequest.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 _GetByRequest_
 
@@ -25,7 +24,7 @@ class GetByRequest(DBFormatter):
 
         """
         self.sql = """
-        SELECT assign.team_id, assign.priority_modifier, team.team_name
+        SELECT assign.team_id, team.team_name
           FROM reqmgr_assignment assign
             JOIN reqmgr_teams team ON assign.team_id = team.team_id
           WHERE assign.request_id = :requestId"""
@@ -35,8 +34,7 @@ class GetByRequest(DBFormatter):
 
         output = []
         [ output.append({
-            "TeamName" : x[2],
+            "TeamName" : x[1],
             "TeamID"   : x[0],
-            "TeamPriority" : x[1],
             }) for x in self.format(result)]
         return output

--- a/src/python/WMCore/RequestManager/RequestDB/MySQL/Assignment/New.py
+++ b/src/python/WMCore/RequestManager/RequestDB/MySQL/Assignment/New.py
@@ -1,14 +1,9 @@
-#!/usr/bin/env python
 """
 _Assignment.New_
 
 Create a new assignment between a team and a request
 
 """
-
-
-
-
 
 from WMCore.Database.DBFormatter import DBFormatter
 
@@ -19,8 +14,7 @@ class New(DBFormatter):
     Create a new assignment from a request to a production team
 
     """
-    def execute(self, requestId, teamId, priorityMod,
-                conn = None, trans = False):
+    def execute(self, requestId, teamId,conn = None, trans = False):
         """
         _execute_
 
@@ -28,11 +22,10 @@ class New(DBFormatter):
 
         """
         self.sql = "INSERT INTO reqmgr_assignment "
-        self.sql += "(request_id, team_id, priority_modifier ) "
-        self.sql += "VALUES (:requestId, :teamId, :priorityMod)"
+        self.sql += "(request_id, team_id) "
+        self.sql += "VALUES (:requestId, :teamId)"
 
-        binds = {"requestId":requestId, "teamId":teamId, "priorityMod":int(priorityMod)}
+        binds = {"requestId":requestId, "teamId":teamId}
 
-        result = self.dbi.processData(self.sql, binds,
-                                      conn = conn, transaction = trans)
-        return
+        result = self.dbi.processData(self.sql, binds, conn = conn, 
+                 transaction = trans)

--- a/src/python/WMCore/RequestManager/RequestDB/MySQL/Create.py
+++ b/src/python/WMCore/RequestManager/RequestDB/MySQL/Create.py
@@ -1,8 +1,12 @@
-#!/usr/bin/env python
 """
 _ReqMgr.RequestDB.MySQL_
 
 MySQL Compatibility layer for Request Manager DB
+Create all tables for ReqMgr in MySQL
+
+Priorities changed: only reqmgr_request:request_priority is
+really considered, all other priority values are ignored.
+
 """
 
 

--- a/src/python/WMCore/RequestManager/RequestDB/MySQL/Request/New.py
+++ b/src/python/WMCore/RequestManager/RequestDB/MySQL/Request/New.py
@@ -58,7 +58,7 @@ class New(DBFormatter):
             msg = "workflow not provided to Request.New.execute"
             raise RuntimeError, msg
 
-        priority = request.get("reqBasePriority", None)
+        priority = request.get("requestPriority", None)
         priority = priority if priority else 0
         
         prep_id = request.get("prep_id", None)

--- a/src/python/WMCore/RequestManager/RequestDB/Oracle/Create.py
+++ b/src/python/WMCore/RequestManager/RequestDB/Oracle/Create.py
@@ -1,8 +1,13 @@
-#!/usr/bin/env python
 """
-_ReqMgr.RequestDB.MySQL_
+_ReqMgr.RequestDB.Oracle_
 
-MySQL Compatibility layer for Request Manager DB
+Oracle Compatibility layer for Request Manager DB
+Create all tables for ReqMgr in Oracle
+
+
+Priorities changed: only reqmgr_request:request_priority is
+really considered, all other priority values are ignored.
+
 """
 
 

--- a/src/python/WMCore/RequestManager/RequestDB/Oracle/Request/New.py
+++ b/src/python/WMCore/RequestManager/RequestDB/Oracle/Request/New.py
@@ -57,7 +57,7 @@ class New(DBFormatter):
             raise RuntimeError, msg
 
         prep_id = request.get("prep_id", None)
-        priority = request.get("reqBasePriority", None)
+        priority = request.get("requestPriority", None)
         priority = priority if priority else 0
 
         self.sql = """

--- a/src/python/WMCore/RequestManager/RequestMaker/CheckIn.py
+++ b/src/python/WMCore/RequestManager/RequestMaker/CheckIn.py
@@ -91,7 +91,7 @@ def checkIn(request, requestType = 'None'):
         request['RequestType'],
         request['RequestWorkflow'],
         request.get('PrepID', None),
-        request.get('ReqMgrRequestBasePriority', None)
+        request.get('RequestPriority', None)
     )
     except Exception, ex:
         msg = "Error creating new request:\n"

--- a/test/data/ReqMgr/reqmgr.py
+++ b/test/data/ReqMgr/reqmgr.py
@@ -480,13 +480,9 @@ class ReqMgrClient(RESTClient):
         # should be checked if the request parameter actually exists in
         # in both databases ... later this explicit list should be removed
         # and check will be done on automatic inspection and later it will
-        # be removed altogether and Oracled dropped ...
+        # be removed altogether and Oracle dropped ...
         # implement this check automatically without listing request arguments
         # TODO 2:
-        # related to the current priority mess, they usually don't agree:
-        #    ReqMgrRequestBasePriority
-        #    RequestPriority
-        # TODO 3:
         # double list: OutputDatasets (ticket already filed ...)
         # Oracle:InputDatasetTypes: '{u'/QCD_HT-1000ToInf_TuneZ2star_8TeV-madgraph-pythia6/Summer12-START50_V13-v1/GEN': u'source'}' != CouchDB:InputDatasetTypes: '{}'
         # Oracle:RequestNumEvents: '0' != CouchDB:RequestNumEvents: 'None'
@@ -580,19 +576,16 @@ class ReqMgrClient(RESTClient):
             config.requestNames.append(self.createRequest(config, restApi = False))
             self.assignRequests(config)
     
-        # test priority changing (final priority will be sum of the current
-        # and new, so have to first find out the current)
+        # test priority changing. setting priority is absolute now,
+        # the sent value becomes the final priority, there is no composition
         # config.requestNames must be set
-        testRequestData = self.queryRequests(config, toQuery=testRequestName)[0]
-        currPriority = testRequestData["RequestPriority"]
-        newPriority = 10
-        totalPriority = currPriority + newPriority
+        newPriority = 11212
         self.changePriority(testRequestName, newPriority)
         testRequestData = self.queryRequests(config, toQuery=testRequestName)[0]
         # test state (should be "assigned"
         msg = "Status should be 'assigned', is '%s'" % testRequestData["RequestStatus"]
         assert testRequestData["RequestStatus"] == "assigned", msg
-        assert testRequestData["RequestPriority"] == totalPriority, "New RequestPriority does not match!"
+        assert testRequestData["RequestPriority"] == newPriority, "New RequestPriority does not match!"
         
         # take testRequestName for Oracle, CouchDB consistency check
         # this request had status, priority modified, so it also tests whether
@@ -606,8 +599,8 @@ class ReqMgrClient(RESTClient):
         # now test that the cloned request has correct priority
         clonedRequest = self.queryRequests(config, toQuery=clonedRequestName)[0]
         msg = ("Priorities don't match: original request: %s cloned request: %s" %
-               (totalPriority, clonedRequest["RequestPriority"]))
-        assert totalPriority == clonedRequest["RequestPriority"], msg
+               (newPriority, clonedRequest["RequestPriority"]))
+        assert newPriority == clonedRequest["RequestPriority"], msg
         
         # test Resubmission request, only if we have MonteCarlo request template in input
         if config.requestArgs["createRequest"]["RequestType"] == "MonteCarlo":

--- a/test/data/ReqMgr/requests/MonteCarlo.json
+++ b/test/data/ReqMgr/requests/MonteCarlo.json
@@ -5,7 +5,7 @@
 		"GlobalTag": "START311_V2::All",
 		"Campaign": "Campaign-OVERRIDE-ME",
 		"RequestString": "RequestString-OVERRIDE-ME",
-		"RequestPriority": 100,
+		"RequestPriority": 1000,
 		"TimePerEvent": 40,
 		"FilterEfficiency": 0.0361,
 		"ScramArch": "slc5_amd64_gcc434",

--- a/test/data/ReqMgr/requests/MonteCarloFromGEN.json
+++ b/test/data/ReqMgr/requests/MonteCarloFromGEN.json
@@ -5,7 +5,7 @@
 		"GlobalTag": "START50_V13::All",
 		"Campaign": "Campaign-OVERRIDE-ME",
 		"RequestString": "RequestString-OVERRIDE-ME",
-		"RequestPriority": 100,
+		"RequestPriority": 1000,
 		"TimePerEvent": 60,
 		"FilterEfficiency": 0.28,
 		"ScramArch": "slc5_amd64_gcc462",

--- a/test/data/ReqMgr/requests/ReDigi.json
+++ b/test/data/ReqMgr/requests/ReDigi.json
@@ -5,7 +5,7 @@
 		"GlobalTag": "START53_V7A::All",
 		"Campaign": "Campaign-OVERRIDE-ME",		
 		"RequestString": "RequestString-OVERRIDE-ME",
-		"RequestPriority": 100,
+		"RequestPriority": 1000,
 		"TimePerEvent": 17.5,
 		"ScramArch": "slc5_amd64_gcc462",
 		"RequestType": "ReDigi",

--- a/test/data/ReqMgr/requests/ReReco.json
+++ b/test/data/ReqMgr/requests/ReReco.json
@@ -5,7 +5,7 @@
 		"GlobalTag": "FT_R_44_V11::All",
 		"Campaign": "Campaign-OVERRIDE-ME",		
 		"RequestString": "RequestString-OVERRIDE-ME",
-		"RequestPriority": 100,
+		"RequestPriority": 1000,
 		"TimePerEvent": 60,
 		"ScramArch": "slc5_amd64_gcc434",
 		"RequestType": "ReReco",

--- a/test/data/ReqMgr/requests/TaskChain.json
+++ b/test/data/ReqMgr/requests/TaskChain.json
@@ -13,6 +13,7 @@
         "Memory": 2400,
         "ProcessingVersion": 1,
         "RequestString": "RV610_TEST_SingleMuPt100",
+        "RequestPriority": 1000,
         "RequestType": "TaskChain",
         "Requestor": "Requestor-OVERRIDE-ME",
         "ScramArch": "slc5_amd64_gcc472",

--- a/test/data/ReqMgr/requests/TaskChainMultiTask.json
+++ b/test/data/ReqMgr/requests/TaskChainMultiTask.json
@@ -13,6 +13,7 @@
         "Memory": 2400,
         "ProcessingVersion": 1,
         "RequestString": "RV610_TEST_SingleMuPt100",
+        "RequestPriority": 1000,
         "RequestType": "TaskChain",
         "Requestor": "Requestor-OVERRIDE-ME",
         "ScramArch": "slc5_amd64_gcc472",

--- a/test/python/WMCore_t/RequestManager_t/ReqMgrPriority_t.py
+++ b/test/python/WMCore_t/RequestManager_t/ReqMgrPriority_t.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 RequestManager unittest
 
@@ -118,15 +116,11 @@ class ReqMgrPriorityTest(RESTBaseUnitTest):
         workload = self.loadWorkload(requestName = requestName)
         self.assertEqual(workload.priority(), 0)
 
-        # Reset user, group priorities to 0
-        self.jsonSender.post('user/%s?priority=0' % userName)
-        self.jsonSender.post('group/%s?priority=0' % groupName)
-
         # Set priority == 5
         priority = 5
         self.jsonSender.put('request/%s?priority=%s' % (requestName, priority))
         request = self.jsonSender.get('request/%s' % requestName)[0]
-        self.assertEqual(request['ReqMgrRequestBasePriority'], priority)
+        self.assertEqual(request['RequestPriority'], priority)
         workload = self.loadWorkload(requestName = requestName)
         self.assertEqual(workload.priority(), priority)
 
@@ -134,7 +128,7 @@ class ReqMgrPriorityTest(RESTBaseUnitTest):
         priority = 100
         self.jsonSender.put('request/%s?priority=%s' % (requestName, priority))
         request = self.jsonSender.get('request/%s' % requestName)[0]
-        self.assertEqual(request['ReqMgrRequestBasePriority'], priority)
+        self.assertEqual(request['RequestPriority'], priority)
         workload = self.loadWorkload(requestName = requestName)
         self.assertEqual(workload.priority(), priority)
 
@@ -142,7 +136,7 @@ class ReqMgrPriorityTest(RESTBaseUnitTest):
         priority = -1
         self.jsonSender.put('request/%s?priority=%s' % (requestName, priority))
         request = self.jsonSender.get('request/%s' % requestName)[0]
-        self.assertEqual(request['ReqMgrRequestBasePriority'], priority)
+        self.assertEqual(request['RequestPriority'], priority)
         workload = self.loadWorkload(requestName = requestName)
         self.assertEqual(workload.priority(), priority)
 
@@ -161,7 +155,7 @@ class ReqMgrPriorityTest(RESTBaseUnitTest):
         priority = 99
         self.jsonSender.put('request/%s?priority=%s' % (requestName, priority))
         request = self.jsonSender.get('request/%s' % requestName)[0]
-        self.assertEqual(request['ReqMgrRequestBasePriority'], priority)
+        self.assertEqual(request['RequestPriority'], priority)
         workload = self.loadWorkload(requestName = requestName)
         self.assertEqual(workload.priority(), priority)
     
@@ -205,78 +199,6 @@ class ReqMgrPriorityTest(RESTBaseUnitTest):
             print ex.result
             self.assertTrue("Priority must have abs() less then MAXINT!" in ex.result)
         self.assertTrue(raises)
-
-        # Now try to violate the limits put on the requestPriority
-        # This test no longer works because the system is in insecure mode.  I think we
-        # need to figure out how to make it work in insecure mode, but I don't have
-        # any ideas.
-        
-        #raises = False
-        #try:
-        #    priority = 9999
-        #    self.jsonSender.put('request/%s?priority=%s' % (requestName, priority))
-        #except HTTPException, ex:
-        #    raises = True
-        #    self.assertEqual(ex.status, 400)
-        #    print ex.result
-        #    self.assertTrue("Request priority must have abs() less then 100" in ex.result)
-        #self.assertTrue(raises)
-
-
-    def testC_UserGroupRequestPriority(self):
-        """
-        _UserGroupRequestPriority_
-
-        Set the priorities of the user, the group, and the request
-        
-        """
-        userName     = 'Taizong'
-        groupName    = 'Li'
-        teamName     = 'Tang'
-        schema       = utils.getAndSetupSchema(self,
-                                               userName = userName,
-                                               groupName = groupName,
-                                               teamName = teamName)
-        result = self.jsonSender.put('request/testRequest', schema)
-        self.assertEqual(result[1], 200)
-        requestName = result[0]['RequestName']
-
-        workload = self.loadWorkload(requestName = requestName)
-        self.assertEqual(workload.priority(), 0)
-
-        # Reset user, group priorities to 0
-        self.jsonSender.post('user/%s?priority=0' % userName)
-        self.jsonSender.post('group/%s?priority=0' % groupName)
-
-        # Set priority == 5
-        priority = 5
-        self.jsonSender.put('request/%s?priority=%s' % (requestName, priority))
-        request = self.jsonSender.get('request/%s' % requestName)[0]
-        self.assertEqual(request['ReqMgrRequestBasePriority'], priority)
-        workload = self.loadWorkload(requestName = requestName)
-        self.assertEqual(workload.priority(), priority)
-
-        self.jsonSender.post('user/%s?priority=6' % userName)
-        self.jsonSender.put('request/%s?priority=%s' % (requestName, priority))
-        request = self.jsonSender.get('request/%s' % requestName)[0]
-        self.assertEqual(request['ReqMgrRequestBasePriority'], priority)
-        workload = self.loadWorkload(requestName = requestName)
-        self.assertEqual(workload.priority(), priority + 6)
-
-        self.jsonSender.post('group/%s?priority=7' % groupName)
-        self.jsonSender.put('request/%s?priority=%s' % (requestName, priority))
-        request = self.jsonSender.get('request/%s' % requestName)[0]
-        self.assertEqual(request['ReqMgrRequestBasePriority'], priority)
-        workload = self.loadWorkload(requestName = requestName)
-        self.assertEqual(workload.priority(), priority + 6 + 7)
-
-        self.jsonSender.post('user/%s?priority=0' % userName)
-        self.jsonSender.put('request/%s?priority=%s' % (requestName, priority))
-        request = self.jsonSender.get('request/%s' % requestName)[0]
-        self.assertEqual(request['ReqMgrRequestBasePriority'], priority)
-        workload = self.loadWorkload(requestName = requestName)
-        self.assertEqual(workload.priority(), priority + 7)
-
 
 
 if __name__=='__main__':

--- a/test/python/WMCore_t/RequestManager_t/ReqMgrWorkload_t.py
+++ b/test/python/WMCore_t/RequestManager_t/ReqMgrWorkload_t.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 RequestManager Workload unittest
 

--- a/test/python/WMCore_t/RequestManager_t/ReqMgr_t.py
+++ b/test/python/WMCore_t/RequestManager_t/ReqMgr_t.py
@@ -221,15 +221,9 @@ class ReqMgrTest(RESTBaseUnitTest):
         me = self.jsonSender.get('user/me')[0]
         self.assertTrue(requestName in me['requests'])
         self.assertEqual(self.jsonSender.put('request/%s?priority=5' % requestName)[1], 200)
-        self.assertEqual(self.jsonSender.post('user/me?priority=6')[1], 200)
-        self.assertEqual(self.jsonSender.post('group/PeopleLikeMe?priority=7')[1], 200)
 
-        # default priority of group and user of 1
         request = self.jsonSender.get('request/%s' % requestName)[0]
-        self.assertEqual(request['ReqMgrRequestBasePriority'], 5)
-        self.assertEqual(request['ReqMgrRequestorBasePriority'], 6)
-        self.assertEqual(request['ReqMgrGroupBasePriority'], 7)
-        self.assertEqual(request['RequestPriority'], 5+6+7)
+        self.assertEqual(request['RequestPriority'], 5)
 
         # Check LFN Bases
         self.assertEqual(request['UnmergedLFNBase'], '/store/unmerged')
@@ -703,7 +697,7 @@ class ReqMgrTest(RESTBaseUnitTest):
         origRequest = response[0]
         self.assertEquals(origRequest["AcquisitionEra"], acquisitionEra)
         # test that the priority was correctly set in the brand-new request
-        self.assertEquals(origRequest["ReqMgrRequestBasePriority"], priority)
+        self.assertEquals(origRequest["RequestPriority"], priority)
         
         # test cloning not existing request
         self.assertRaises(HTTPException, self.jsonSender.put, "clone/%s" % "NotExistingRequestName")


### PR DESCRIPTION
Removes handling of
    ReqMgrGroupBasePriority
    ReqMgrRequestBasePriority
    ReqMgrRequestorBasePriority

Oracle tables values are still there and Oracle database wasn't and won't be
altered, but above values are not used anymore in the code. Only a single
inject and request parameter 'RequestPriority' is now used. It's value is
updated absolutely, not by offset as it probably was the previous intention
(as agreed via IM by @efajardo).

Value of reqmgr_assignment:priority_modifier from database definition - also
ignored, as well as a bunch of priority related database table columns, as
said above, except for reqmgr_request:request_priority value. This always
agrees with CouchDB "RequestPriority" document field.

unittests and reqmgr.py --allTests OK

Fixes #4465
