### PR TITLE
Second round of ReqMgr CouchDB values fixes.

### DIFF
--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrRESTModel.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrRESTModel.py
@@ -47,7 +47,9 @@ deprecatedRequestArgs = ["ReqMgrGroupID",
                          "ReqMgrRequestorID",
                          "ReqMgrRequestBasePriority",
                          "RequestWorkflow",
-                         "WorkflowSpec"]
+                         "WorkflowSpec",
+                         "RequestSizeEvents",
+                         "RequestEventSize"]
 
 
 class ReqMgrRESTModel(RESTModel):
@@ -517,17 +519,11 @@ class ReqMgrRESTModel(RESTModel):
                 # since we cloned the request, all the attributes
                 # manipulation in Utilities.makeRequest() should not be necessary
                 # the cloned request shall be identical but following arguments
-                toRemove = ("RequestName",
+                toRemove = ["RequestName",
                             "RequestDate",
-                            "timeStamp",
-                            "RequestWorkflow",
-                            # these request arguments were deprecated
-                            # removed them in case of cloning old requests
-                            "ReqMgrGroupID",
-                            "ReqMgrRequestID",
-                            "ReqMgrRequestorID",
-                            "ReqMgrRequestBasePriority",
-                            "WorkflowSpec")
+                            "timeStamp"]
+                toRemove.extend(deprecatedRequestArgs)
+                            
                 for remove in toRemove:
                     try:
                         del requestOrigDict[remove]

--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
@@ -511,7 +511,17 @@ def buildWorkloadAndCheckIn(webApi, reqSchema, couchUrl, couchDB, wmstatUrl, clo
     paramsToUpdate = ["RequestStatus",
                       "RequestSizeFiles",
                       "AcquisitionEra",
-                      "RequestWorkflow"]
+                      "RequestWorkflow",
+                      "RequestType",
+                      "RequestStatus",
+                      "RequestPriority",
+                      "Requestor",
+                      "Group",
+                      "SizePerEvent",
+                      "PrepID",
+                      "RequestNumEvents",
+                      ]
+    
     couchDb = Database(reqDetails["CouchWorkloadDBName"], reqDetails["CouchURL"])
     fields = {}
     for key in paramsToUpdate:

--- a/src/python/WMCore/ReqMgr/database_cleanup/oracle_couchdb_consistency_checker.py
+++ b/src/python/WMCore/ReqMgr/database_cleanup/oracle_couchdb_consistency_checker.py
@@ -139,12 +139,16 @@ def main():
     map_names = [{"oracle": "REQUEST_NAME", "couch": "RequestName"},
                  {"oracle": "REQUEST_TYPE", "couch": "RequestType"},
                  {"oracle": "REQUEST_STATUS", "couch": "RequestStatus"},
-                 {"oracle": "REQUEST_PRIORITY", "couch": "RequestPriority"}]
-    # fields exist in newer couchdb documents but may still be None/Null
-    # RequestSizeEvents
-    # RequestSizeFiles
-    # PrepID
-    # RequestNumEvents
+                 {"oracle": "REQUEST_PRIORITY", "couch": "RequestPriority"},
+                 {"oracle": "WORKFLOW", "couch": "RequestWorkflow"},
+                 {"oracle": "REQUEST_EVENT_SIZE", "couch": "SizePerEvent"},
+                 {"oracle": "REQUEST_SIZE_FILES", "couch": "RequestSizeFiles"},
+                 {"oracle": "PREP_ID", "couch": "PrepID"},
+                 {"oracle": "REQUEST_NUM_EVENTS", "couch": "RequestNumEvents"},
+                 ]
+    
+    # some fields exist in newer couchdb documents but may still be None/Null
+
     counter = 0
     for oracle_req in get_oracle_data(oradb, "reqmgr_request",
                                       reqmgr_request_table_def):
@@ -181,7 +185,10 @@ def main():
                      "ReqMgrRequestID",
                      "ReqMgrRequestBasePriority",
                      "ReqMgrRequestorID",
-                     "Workflowspec"]
+                     "Workflowspec",
+                     "RequestSizeEvents",
+                     "RequestEventSize"]
+        
         print "Couch fields to remove, values: ..."
         for removable in to_remove:
             try:

--- a/src/python/WMCore/RequestManager/DataStructs/Request.py
+++ b/src/python/WMCore/RequestManager/DataStructs/Request.py
@@ -21,3 +21,5 @@ class Request(dict):
         self.setdefault("SoftwareVersions", [])
         self.setdefault("InputDatasets", [])
         self.setdefault("InputDatasetTypes", {})
+        self.setdefault("SizePerEvent", 0)
+        self.setdefault("PrepID", None)

--- a/src/python/WMCore/RequestManager/DataStructs/RequestSchema.py
+++ b/src/python/WMCore/RequestManager/DataStructs/RequestSchema.py
@@ -1,21 +1,6 @@
-#!/usr/bin/env python
-"""
-_RequestMakerInterface_
-
-
-Interface Definition for a RequestMaker implementation.
-
-A RequestMaker Implementation should do the following.
-
-- Instantiate with no args via a factory method
-- Be callable on a RequestMakerSchema implementation
-- Build WorkflowSpec instances
-- Embed each WorkflowSpec in a RequestSpec instance
-- Return a list of RequestSpec instances generated from the schema
-
-"""
 import WMCore.Lexicon
 import time
+
 
 class RequestSchema(dict):
     """
@@ -39,6 +24,7 @@ class RequestSchema(dict):
         self.setdefault("Requestor", None)
         self.setdefault("ScramArch", "slc5_amd64_gcc434")
         self.setdefault("RequestDate", list(time.gmtime()[:6]))
+        self.setdefault("SizePerEvent", 0)
         self.basicFields = self.keys()
         self.validateFields = []
 

--- a/src/python/WMCore/RequestManager/RequestDB/Interface/Request/GetRequest.py
+++ b/src/python/WMCore/RequestManager/RequestDB/Interface/Request/GetRequest.py
@@ -54,10 +54,15 @@ def getRequest(requestId, reverseTypes=None, reverseStatus=None):
     request["RequestWorkflow"] = reqData['workflow']
     request["RequestNumEvents"] = reqData['request_num_events']
     request["RequestSizeFiles"] = reqData['request_size_files']
-    request["RequestEventSize"] = reqData['request_event_size']
-
+    # there used to be RequestEventSize argument, but then SizePerEvent
+    # got introduce and got adopted so this is replacing it, presenting
+    # this nomenclature inconsistency on Oracle level
+    request["SizePerEvent"] = reqData['request_event_size']
+    request["PrepID"] = reqData['prep_id']
+    
     request["Group"] = groupData['group_name']
     request["Requestor"] = userData['requestor_hn_name']
+     
 
     updates = ChangeState.getProgress(requestName)
     request['percent_complete'], request['percent_success'] = percentages(updates)

--- a/src/python/WMCore/RequestManager/RequestDB/Interface/Request/MakeRequest.py
+++ b/src/python/WMCore/RequestManager/RequestDB/Interface/Request/MakeRequest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+
 """
 _MakeRequest_
 
@@ -7,10 +7,6 @@ API for creating a new request in the database
 """
 
 
-
-
-
-import logging
 import WMCore.RequestManager.RequestDB.Connection as DBConnect
 
 
@@ -193,5 +189,3 @@ def updateRequestSize(requestName, reqEventsSize, reqFilesSize = None, reqSizeOf
 
     updateSize = factory(classname = "Request.Size")
     updateSize.execute(reqId, reqEventsSize, reqFilesSize, reqSizeOfEvent)
-
-    return

--- a/src/python/WMCore/RequestManager/RequestMaker/CheckIn.py
+++ b/src/python/WMCore/RequestManager/RequestMaker/CheckIn.py
@@ -141,8 +141,8 @@ def checkIn(request, requestType = 'None'):
     if request["RequestNumEvents"] != None:
         MakeRequest.updateRequestSize(requestName, request["RequestNumEvents"],
                                       request.get("RequestSizeFiles", 0),
-                                      request.get("RequestEventSize", 0)
-                                      )
+                                      request.get("SizePerEvent", 0))
+        
     campaign = request.get("Campaign", "")
     if campaign != "" and campaign != None:
         Campaign.associateCampaign(campaign, reqId)

--- a/test/python/WMCore_t/RequestManager_t/ReqMgr_t.py
+++ b/test/python/WMCore_t/RequestManager_t/ReqMgr_t.py
@@ -196,7 +196,7 @@ class ReqMgrTest(RESTBaseUnitTest):
         """
         schema = utils.getAndSetupSchema(self)
         schema['RequestNumEvents'] = 100
-        schema['RequestEventSize'] = 101
+        schema['SizePerEvent'] = 101
         self.doRequest(schema)
 
 
@@ -232,7 +232,7 @@ class ReqMgrTest(RESTBaseUnitTest):
 
         # Check Num events
         self.assertEqual(request['RequestNumEvents'], 100)
-        self.assertEqual(request['RequestEventSize'], 101)
+        self.assertEqual(request['SizePerEvent'], 101)
 
         # only certain transitions allowed
         #self.assertEqual(self.jsonSender.put('request/%s?status=running' % requestName)[1], 400)


### PR DESCRIPTION
RequestSizeEvents - in majority of couch requests not defined, no references
    in the code (probably was at some point), should be removed from all Couch
    requests ; deprecated, injection fails will fail now if specified
RequestEventSize - deprecated, injection fails will fail now if specified,
    should be removed from all old Couch requests
SizePerEvent - must exist, parameter is mandatory, from Oracle is taken from
    reqmgr_request:REQUEST_EVENT_SIZE (mess that the above probably existed
    when someone was introducing SizePerEvent)
RequestSizeFiles - made mandatory, handled properly so that values are stored
    in Couch, on old requests values should be loaded from
    reqmgr_request:REQUEST_SIZE_FILES
RequestNumEvents - made mandatory, handled properly so that values are stored
    in Couch, on old requests values should be loaded from
    reqmgr_request:REQUEST_NUM_EVENTS
PrepID - made optional, properly stored in Couch, on old requests values
    should be loaded from reqmgr_request:PREP_ID

All unittests updated. reqmgr.py now contains checks for the above.
Database Oracle -> CouchDB migration/consistency scripts should implement the
above when migrating values.
