### PR TITLE
Fix xrootd option for ACDC

### DIFF
--- a/src/couchapps/ACDC/views/owner_coll_fileset_files/map.js
+++ b/src/couchapps/ACDC/views/owner_coll_fileset_files/map.js
@@ -1,8 +1,9 @@
 function(doc) {
   for (var lfn in doc.files) {
     filesetFile = doc.files[lfn];
-    filesetFile["locations"].sort();
+    var locationCopy = filesetFile["locations"].slice();
+    locationCopy.sort();
     emit([doc.owner.group, doc.owner.user, doc.collection_name, doc.fileset_name, 
-          filesetFile["locations"], filesetFile["lfn"]], filesetFile);
+          locationCopy, filesetFile["lfn"]], filesetFile);
   }
 }

--- a/src/python/WMCore/WorkQueue/Policy/Start/Block.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Block.py
@@ -11,7 +11,7 @@ from WMCore.WorkQueue.Policy.Start.StartPolicyInterface import StartPolicyInterf
 from copy import deepcopy
 from math import ceil
 from WMCore.WorkQueue.WorkQueueExceptions import WorkQueueWMSpecError
-from WMCore.WorkQueue.WorkQueueUtils import sitesFromStorageEelements, cmsSiteNames
+from WMCore.WorkQueue.WorkQueueUtils import sitesFromStorageEelements, makeLocationsList
 from WMCore import Lexicon
 
 class Block(StartPolicyInterface):
@@ -79,16 +79,7 @@ class Block(StartPolicyInterface):
             # Then get the locations from the site whitelist/blacklist + SiteDB
             siteWhitelist = task.siteWhitelist()
             siteBlacklist = task.siteBlacklist()
-            if siteWhitelist:
-                # Just get the ses matching the whitelists
-                self.sites = siteWhitelist
-            elif siteBlacklist:
-                # Get all CMS sites less the blacklist
-                allSites = cmsSiteNames()
-                self.sites = list(set(allSites) - set (siteBlacklist))
-            else:
-                # Run at any CMS site
-                self.sites = cmsSiteNames()
+            self.sites = makeLocationsList(siteWhitelist, siteBlacklist)
 
         blocks = []
         # Take data inputs or from spec

--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -30,6 +30,7 @@ from WMCore.WorkQueue.WorkQueueExceptions import TERMINAL_EXCEPTIONS
 from WMCore.WorkQueue.WorkQueueExceptions import WorkQueueError
 from WMCore.WorkQueue.WorkQueueUtils import get_dbs
 from WMCore.WorkQueue.WorkQueueUtils import cmsSiteNames
+from WMCore.WorkQueue.WorkQueueUtils import makeLocationsList
 
 from WMCore.WMSpec.WMWorkload import WMWorkloadHelper, getWorkloadFromTask
 from WMCore.ACDC.DataCollectionService import DataCollectionService
@@ -351,6 +352,14 @@ class WorkQueue(WorkQueueBase):
                                            group = wmspec.getOwner().get("group"))
             block = {}
             block["Files"] = fileLists
+            if wmspec.locationDataSourceFlag():
+                seElements = []
+                for cmsSite in match['Inputs'].values()[0]: #TODO: Allow more than one
+                    ses = self.SiteDB.cmsNametoSE(cmsSite)
+                    seElements.extend(ses)
+                seElements = list(set(seElements))
+                for fileInfo in block["Files"]:
+                    fileInfo['locations'] = seElements
             return blockName, block
         else:
             dbs = get_dbs(match['Dbs'])

--- a/src/python/WMCore/WorkQueue/WorkQueueUtils.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueUtils.py
@@ -70,6 +70,22 @@ def cmsSiteNames():
         pass
     return __cmsSiteNames
 
+def makeLocationsList(siteWhitelist, siteBlacklist):
+    """
+    _makeLocationsList_
+
+    Make a location list based on the intersection between a site white list
+    and blacklist, if none specified then all sites are listed.
+    """
+    sites = cmsSiteNames()
+    if siteWhitelist:
+        # Just get the CMS sites matching the whitelists
+        sites = list(set(sites) & set(siteWhitelist))
+    if siteBlacklist:
+        # Get all CMS sites less the blacklist
+        sites = list(set(sites) - set (siteBlacklist))
+    return sites
+
 def queueFromConfig(config):
     """Create a queue from the config object"""
     config = queueConfigFromConfigObject(config)

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
@@ -1020,10 +1020,10 @@ class WorkQueueTest(WorkQueueTestCase):
         spec.save(spec.specUrl())
         self.localQueue.params['Teams'] = ['cmsdataops']
         self.globalQueue.queueWork(spec.specUrl(), "Resubmit_TestWorkload", team = "cmsdataops")
-        self.localQueue.pullWork({"T1_US_FNAL": 100},
-                                 continuousReplication = False)
+        self.assertEqual(self.localQueue.pullWork({"T1_US_FNAL": 100},
+                                                  continuousReplication = False), 1)
         syncQueues(self.localQueue)
-        self.localQueue.getWork({"T1_US_FNAL": 100})
+        self.assertEqual(len(self.localQueue.getWork({"T1_US_FNAL": 100})), 1)
 
     def testResubmissionWithParentsWorkflow(self):
         """Test workflow resubmission with parentage via ACDC"""
@@ -1040,6 +1040,26 @@ class WorkQueueTest(WorkQueueTestCase):
                                  continuousReplication = False)
         syncQueues(self.localQueue)
         self.localQueue.getWork({"T1_US_FNAL": 100})
+
+    def testResubmissionWorkflowSiteWhitelistLocations(self):
+        """ Test an ACDC workflow where we use the site whitelist as locations"""
+        acdcCouchDB = "workqueue_t_acdc"
+        self.testInit.setupCouch(acdcCouchDB, "GroupUser", "ACDC")
+
+        spec = self.createResubmitSpec(self.testInit.couchUrl,
+                                       acdcCouchDB)
+        spec.setSpecUrl(os.path.join(self.workDir, 'resubmissionWorkflow.spec'))
+        spec.setSiteWhitelist('T1_UK_RAL')
+        spec.setLocationDataSourceFlag()
+        spec.save(spec.specUrl())
+        self.localQueue.params['Teams'] = ['cmsdataops']
+        self.globalQueue.queueWork(spec.specUrl(), "Resubmit_TestWorkload", team = "cmsdataops")
+        self.assertEqual(self.localQueue.pullWork({"T1_US_FNAL": 100},
+                                 continuousReplication = False), 0)
+        self.assertEqual(self.localQueue.pullWork({"T1_UK_RAL": 100},
+                                 continuousReplication = False), 1)
+        syncQueues(self.localQueue)
+        self.assertEqual(len(self.localQueue.getWork({"T1_UK_RAL": 100})),1)
 
     def testThrottling(self):
         """Pull work only if all previous work processed in child"""


### PR DESCRIPTION
Allow the trust site whitelist as location option to work for ACDC workflows
the ACDC files will have locations according to the site whitelist and blacklist.

Also improve an ACDC view making it compatible to newer versions of couchDB where
documents can't be modified in a view (it was sorting in place a element of the doc
inside the view).

Fixes #4496
