### PR TITLE
Track pileup locations

### DIFF
--- a/src/couchapps/WorkQueue/lists/workRestrictions.js
+++ b/src/couchapps/WorkQueue/lists/workRestrictions.js
@@ -86,6 +86,20 @@ function(head, req) {
                 continue;
             }
 
+            // Check the pile up data, all pileup datasets must be at the site to be valid
+            noPileupSite = false;
+            if(ele["PileupData"]){
+                for(dataset in ele["PileupData"]){
+                    if(ele["PileupData"][dataset].indexOf(site) === -1){
+                        noPileupSite = true;
+                        break;
+                    }
+                }
+            }
+            if(noPileupSite){
+                continue;
+            }
+
             // input data restrictions
             var hasData = true;
             for (var data in ele['Inputs']) {

--- a/src/couchapps/WorkQueue/views/activePileupData/map.js
+++ b/src/couchapps/WorkQueue/views/activePileupData/map.js
@@ -1,0 +1,8 @@
+function(doc) {
+  var ele = doc["WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement"];
+  if (ele && ele["Status"] === "Available" && ele["PileupData"]) {
+    for (var i in ele["PileupData"]) {
+        emit([ele["Dbs"], i], null);
+    }
+  }
+}

--- a/src/couchapps/WorkQueue/views/activePileupData/reduce.js
+++ b/src/couchapps/WorkQueue/views/activePileupData/reduce.js
@@ -1,0 +1,2 @@
+function(keys, values) {
+}

--- a/src/couchapps/WorkQueue/views/elementsByPileupData/map.js
+++ b/src/couchapps/WorkQueue/views/elementsByPileupData/map.js
@@ -1,0 +1,8 @@
+function(doc) {
+  var ele = doc["WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement"];
+  if (ele && ele["Status"] === "Available" && ele["PileupData"]) {
+    for (var i in ele["PileupData"]) {
+      emit(i, {'_id' : doc['_id']});
+    }
+  }
+}

--- a/src/python/WMCore/Services/DBS/DBS2Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS2Reader.py
@@ -550,7 +550,26 @@ class DBS2Reader:
             return False
         return True
 
+    def listDatasetLocation(self, dataset):
+        """
+        _listDatasetLocation_
 
+        List the SEs where there is at least a block of the given
+        dataset.
+        """
+        self.checkDatasetPath(dataset)
+        try:
+            blocks = self.dbs.listBlocks(dataset, '*', nosite = False)
+        except DbsException, ex:
+            msg = "Error in DBSReader.listFileBlocks(%s)\n" % dataset
+            msg += "%s\n" % formatEx(ex)
+            raise DBSReaderError(msg)
+
+        result = set()
+        for block in blocks:
+            result |= set([x['Name'] for x in block['StorageElementList']])
+
+        return list(result)
 
     def blockToDatasetPath(self, blockName):
         """

--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -612,6 +612,28 @@ class DBS3Reader:
         pathname = blocks[-1].get('dataset', None)
         return pathname
 
+    def listDatasetLocation(self, dataset):
+        """
+        _listDatasetLocation_
+
+        List the SEs where there is at least a block of the given
+        dataset.
+        """
+        self.checkDatasetPath(dataset)
+        args = {'dataset' : dataset, 'detail' : False}
+        try:
+            blocks = self.dbs.listBlocks(**args)
+        except DbsException, ex:
+            msg = "Error in DBSReader.listFileBlocks(%s)\n" % dataset
+            msg += "%s\n" % formatEx(ex)
+            raise DBSReaderError(msg)
+
+        blockNames = [ x['block_name'] for x in blocks ]
+        locations = set()
+        for blockName in blockNames:
+            locations |= set(self.listFileBlockLocation(blockName))
+
+        return list(locations)
 
     def checkDatasetPath(self, pathName):
         """

--- a/src/python/WMCore/WMSpec/StdSpecs/ReDigi.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/ReDigi.py
@@ -44,7 +44,7 @@ def getTestArguments():
         # or alternatively CouchURL part can be replaced by ConfigCacheUrl,
         # then ConfigCacheUrl + CouchDBName + ConfigCacheID
         "ConfigCacheUrl": None,        
-        "PileupConfig": {"mc": "/some/cosmics/dataset"},        
+        "PileupConfig": {"mc": ["/mixing/pileup/dataset"]},
         
         "DashboardHost": "127.0.0.1",
         "DashboardPort": 8884,

--- a/src/python/WMCore/WorkQueue/DataStructs/WorkQueueElement.py
+++ b/src/python/WMCore/WorkQueue/DataStructs/WorkQueueElement.py
@@ -29,6 +29,9 @@ class WorkQueueElement(dict):
         self.setdefault('Inputs', {})
         self.setdefault('ProcessedInputs', [])
         self.setdefault('RejectedInputs', [])
+        # Some workflows require additional datasets for PileUp
+        # Track their locations
+        self.setdefault('PileupData', {})
         #both ParentData and ParentFlag is needed in case there Dataset split,
         # even though ParentFlag is True it will have empty ParentData
         self.setdefault('ParentData', [])

--- a/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
@@ -30,6 +30,7 @@ class StartPolicyInterface(PolicyInterface):
         self.lumi = None
         self.couchdb = None
         self.rejectedWork = [] # List of inputs that were rejected
+        self.pileupData = {}
 
     def split(self):
         """Apply policy to spec"""
@@ -83,6 +84,15 @@ class StartPolicyInterface(PolicyInterface):
             error = WorkQueueWMSpecError(self.wmspec, "Dataset validation error: %s" % str(ex))
             raise error
 
+        # if pileup is found, check that they are valid datasets
+        try:
+            if self.wmspec.listPileupDatasets():
+                for dataset in self.wmspec.listPileupDatasets():
+                    Lexicon.dataset(dataset)
+        except Exception, ex: # can throw many errors e.g. AttributeError, AssertionError etc.
+            error = WorkQueueWMSpecError(self.wmspec, "Pileup dataset validation error: %s" % str(ex))
+            raise error
+
     def newQueueElement(self, **args):
         args.setdefault('Status', 'Available')
         args.setdefault('WMSpec', self.wmspec)
@@ -94,6 +104,7 @@ class StartPolicyInterface(PolicyInterface):
         args.setdefault('SiteBlacklist', self.initialTask.siteBlacklist())
         args.setdefault('EndPolicy', self.wmspec.endPolicyParameters())
         args.setdefault('Priority', self.wmspec.priority())
+        args.setdefault('PileupData', self.pileupData)
         if not args['Priority']:
             args['Priority'] = 0
         ele = WorkQueueElement(**args)
@@ -115,6 +126,9 @@ class StartPolicyInterface(PolicyInterface):
         self.mask = mask
         self.validate()
         try:
+            pileupDatasets = self.wmspec.listPileupDatasets()
+            if pileupDatasets:
+                self.pileupData = self.getDatasetLocations(pileupDatasets)
             self.split()
         # For known exceptions raise custom error that will fail the workflow.
         except DbsConfigurationError, ex:
@@ -130,7 +144,7 @@ class StartPolicyInterface(PolicyInterface):
             # DbsConnectionError: Database exception,Invalid parameters thrown by Summary api
             if 'DbsBadRequest' in str(ex) or 'Invalid parameters' in str(ex):
                 data = task.data.input.pythonise_() if task.data.input else 'None'
-                msg = """data: %s: mask %s. %s""" % (str(data), str(mask), str(ex))
+                msg = """data: %s, mask: %s, pileup: %s. %s""" % (str(data), str(mask), str(pileupDatasets), str(ex))
                 error = WorkQueueNoWorkError(self.wmspec, msg)
                 raise error
             raise # propagate other dbs errors
@@ -167,3 +181,12 @@ class StartPolicyInterface(PolicyInterface):
             will be included if the inbound element is split (i.e. the new data could be open blocks for the Block policy).
         """
         raise NotImplementedError("This can't be called on a base StartPolicyInterface object")
+
+    def getDatasetLocations(self, datasets):
+        """Returns a dictionary with the location of the datasets according to DBS"""
+        dbs = self.dbs()
+        result = {}
+        for datasetPath in datasets:
+            locations = dbs.listDatasetLocation(datasetPath)
+            result[datasetPath] = locations
+        return result

--- a/src/python/WMCore/WorkQueue/WorkQueueBackend.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueBackend.py
@@ -368,6 +368,12 @@ class WorkQueueBackend(object):
         return [{'dbs_url' : x['key'][0],
                  'name' : x['key'][1]} for x in data.get('rows', [])]
 
+    def getActivePileupData(self):
+        """Get data items we have work in the queue for with pileup"""
+        data = self.db.loadView('WorkQueue', 'activePileupData', {'reduce' : True, 'group' : True})
+        return [{'dbs_url' : x['key'][0],
+                 'name' : x['key'][1]} for x in data.get('rows', [])]
+
     def getElementsForData(self, dbs, data):
         """Get active elements for this dbs & data combo"""
         elements = self.db.loadView('WorkQueue', 'elementsByData', {'key' : data, 'include_docs' : True})
@@ -378,6 +384,13 @@ class WorkQueueBackend(object):
     def getElementsForParentData(self, data):
         """Get active elements for this data """
         elements = self.db.loadView('WorkQueue', 'elementsByParentData', {'key' : data, 'include_docs' : True})
+        return [CouchWorkQueueElement.fromDocument(self.db,
+                                                   x['doc'])
+                for x in elements.get('rows', [])]
+
+    def getElementsForPileupData(self, data):
+        """Get active elements for this data """
+        elements = self.db.loadView('WorkQueue', 'elementsByPileupData', {'key' : data, 'include_docs' : True})
         return [CouchWorkQueueElement.fromDocument(self.db,
                                                    x['doc'])
                 for x in elements.get('rows', [])]

--- a/src/python/WMQuality/Emulators/DBSClient/DBSReader.py
+++ b/src/python/WMQuality/Emulators/DBSClient/DBSReader.py
@@ -223,4 +223,20 @@ class DBSReader:
     def listBlockParents(self, block):
         return self.dataBlocks.getParentBlock(block, 1)
 
+    def listDatasetLocation(self, dataset):
+        """
+        _listDatasetLocation_
+
+        List the SEs where there is at least a block of the given
+        dataset.
+        """
+        blocks = self.getFileBlocksInfo(dataset, onlyClosedBlocks = False,
+                                        blockName = '*', locations = True)
+
+        result = set()
+        for block in blocks:
+            result |= set([x['Name'] for x in block['StorageElementList']])
+
+        return list(result)
+
 # pylint: enable-msg=W0613,R0201

--- a/src/python/WMQuality/Emulators/DataBlockGenerator/Globals.py
+++ b/src/python/WMQuality/Emulators/DataBlockGenerator/Globals.py
@@ -1,4 +1,5 @@
 NOT_EXIST_DATASET = 'thisdoesntexist'
+PILEUP_DATASET = '/mixing/pileup/dataset'
 
 SITES = ['T2_XX_SiteA', 'T2_XX_SiteB', 'T2_XX_SiteC']
 
@@ -10,7 +11,11 @@ def getSites(block):
     if _BLOCK_LOCATIONS.has_key(block):
         return _BLOCK_LOCATIONS[block]
 
-    if block.endswith('#1'):
+    if block.split('#')[0] == PILEUP_DATASET:
+        # Pileup is at a single site
+        sites = ['T2_XX_SiteC']
+        _BLOCK_LOCATIONS[block] = sites
+    elif block.endswith('#1'):
         sites  = ['T2_XX_SiteA']
         _BLOCK_LOCATIONS[block] = sites
     elif block.endswith('#2'):

--- a/src/python/WMQuality/Emulators/PhEDExClient/PhEDEx.py
+++ b/src/python/WMQuality/Emulators/PhEDExClient/PhEDEx.py
@@ -165,6 +165,11 @@ class PhEDEx(dict):
         Where are blocks located
         """
         data = {"phedex":{"request_timestamp":1254762796.13538, "block" : []}}
+        if 'dataset' in args:
+            args['block'] = []
+            for dataset in args['dataset']:
+                args['block'].extend(self.dataBlocks._blockGenerator(dataset))
+            args['block'] = [x['Name'] for x in args['block']]
         for block in args['block']:
             blocks = data['phedex']['block']
             files = self.dataBlocks.getFiles(block)
@@ -251,8 +256,6 @@ class PhEDEx(dict):
           o Input is a block and subscription is a dataset
           o Input is a block and subscription is a block
           o Input is a dataset and subscription is a dataset
-
-        Not supported:
           o Input is a dataset but only block subscriptions exist
         """
         from collections import defaultdict
@@ -283,13 +286,17 @@ class PhEDEx(dict):
 
                 #if we have a block we must check for block level subscription also
                 # combine with original query when can give both dataset and block
-                if item.find('#') > -1 and dset.has_key('block'):
+                if dset.has_key('block'):
                     for block in dset['block']:
+                        nodes = [x['node'] for x in block['subscription']
+                                 if x['suspended'] == 'n']
                         if block['name'] == item:
-                            nodes = [x['node'] for x in block['subscription']
-                                     if x['suspended'] == 'n']
                             result[item].update(nodes)
                             break
+                        elif dset['name'] == item:
+                            result[item].update(nodes)
+                            break
+
         return result
 
 

--- a/src/python/WMQuality/Emulators/SiteDBClient/SiteDB.py
+++ b/src/python/WMQuality/Emulators/SiteDBClient/SiteDB.py
@@ -22,7 +22,7 @@ class SiteDBJSON(object):
                        {u'site_name': u'Nebraska', u'type': u'cms', u'alias': u'T2_US_Nebraska'},
                        {u'site_name': u'T2_XX_SiteA', u'type': u'cms', u'alias': u'T2_XX_SiteA'},
                        {u'site_name': u'T2_XX_SiteB', u'type': u'cms', u'alias': u'T2_XX_SiteB'},
-                       {u'site_name': u'T2_XX_SiteB', u'type': u'cms', u'alias': u'T2_XX_SiteC'}]
+                       {u'site_name': u'T2_XX_SiteC', u'type': u'cms', u'alias': u'T2_XX_SiteC'}]
 
     _siteresources_data = [{u'type': u'CE', u'site_name': u'RAL', u'fqdn': u'lcgce11.gridpp.rl.ac.uk', u'is_primary': u'n'},
                            {u'type': u'CE', u'site_name': u'RAL', u'fqdn': u'lcgce10.gridpp.rl.ac.uk', u'is_primary': u'n'},

--- a/test/python/WMCore_t/Services_t/DBS_t/DBSReader_t.py
+++ b/test/python/WMCore_t/Services_t/DBS_t/DBSReader_t.py
@@ -259,7 +259,5 @@ class DBSReaderTest(unittest.TestCase):
         self.assertEqual(self.dbs.blockToDatasetPath(BLOCK), DATASET)
         self.assertFalse(self.dbs.blockToDatasetPath(BLOCK + 'asas'))
 
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/ReDigi_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/ReDigi_t.py
@@ -20,6 +20,56 @@ from WMQuality.TestInitCouchApp import TestInitCouchApp
 from WMCore.Database.CMSCouch import CouchServer, Document
 from WMCore.Services.EmulatorSwitch import EmulatorHelper
 
+def injectReDigiConfigs(configDatabase, combinedStepOne = False):
+    """
+    _injectReDigiConfigs_
+
+    Create bogus config cache documents for the various steps of the
+    ReDigi workflow.  Return the IDs of the documents.
+    """
+    stepOneConfig = Document()
+    stepOneConfig["info"] = None
+    stepOneConfig["config"] = None
+    stepOneConfig["md5hash"] = "eb1c38cf50e14cf9fc31278a5c8e580f"
+    stepOneConfig["pset_hash"] = "7c856ad35f9f544839d8525ca10259a7"
+    stepOneConfig["owner"] = {"group": "cmsdataops", "user": "sfoulkes"}
+    if combinedStepOne:
+        stepOneConfig["pset_tweak_details"] ={"process": {"outputModules_": ["RECODEBUGoutput", "DQMoutput"],
+                                                          "RECODEBUGoutput": {"dataset": {"filterName": "",
+                                                                                          "dataTier": "RECO-DEBUG-OUTPUT"}},
+                                                          "DQMoutput": {"dataset": {"filterName": "",
+                                                                                    "dataTier": "DQM"}}}}
+    else:
+        stepOneConfig["pset_tweak_details"] ={"process": {"outputModules_": ["RAWDEBUGoutput"],
+                                                          "RAWDEBUGoutput": {"dataset": {"filterName": "",
+                                                                                         "dataTier": "RAW-DEBUG-OUTPUT"}}}}
+
+    stepTwoConfig = Document()
+    stepTwoConfig["info"] = None
+    stepTwoConfig["config"] = None
+    stepTwoConfig["md5hash"] = "eb1c38cf50e14cf9fc31278a5c8e580f"
+    stepTwoConfig["pset_hash"] = "7c856ad35f9f544839d8525ca10259a7"
+    stepTwoConfig["owner"] = {"group": "cmsdataops", "user": "sfoulkes"}
+    stepTwoConfig["pset_tweak_details"] ={"process": {"outputModules_": ["RECODEBUGoutput", "DQMoutput"],
+                                                      "RECODEBUGoutput": {"dataset": {"filterName": "",
+                                                                                      "dataTier": "RECO-DEBUG-OUTPUT"}},
+                                                      "DQMoutput": {"dataset": {"filterName": "",
+                                                                                "dataTier": "DQM"}}}}
+
+    stepThreeConfig = Document()
+    stepThreeConfig["info"] = None
+    stepThreeConfig["config"] = None
+    stepThreeConfig["md5hash"] = "eb1c38cf50e14cf9fc31278a5c8e580f"
+    stepThreeConfig["pset_hash"] = "7c856ad35f9f544839d8525ca10259a7"
+    stepThreeConfig["owner"] = {"group": "cmsdataops", "user": "sfoulkes"}
+    stepThreeConfig["pset_tweak_details"] ={"process": {"outputModules_": ["aodOutputModule"],
+                                                        "aodOutputModule": {"dataset": {"filterName": "",
+                                                                                        "dataTier": "AODSIM"}}}}
+    stepOne = configDatabase.commitOne(stepOneConfig)[0]["id"]
+    stepTwo = configDatabase.commitOne(stepTwoConfig)[0]["id"]
+    stepThree = configDatabase.commitOne(stepThreeConfig)[0]["id"]
+    return (stepOne, stepTwo, stepThree)
+
 class ReDigiTest(unittest.TestCase):
     def setUp(self):
         """
@@ -53,56 +103,6 @@ class ReDigiTest(unittest.TestCase):
         EmulatorHelper.resetEmulators()
         return
 
-    def injectReDigiConfigs(self, combinedStepOne = False):
-        """
-        _injectReDigiConfigs_
-
-        Create bogus config cache documents for the various steps of the
-        ReDigi workflow.  Return the IDs of the documents.
-        """
-        stepOneConfig = Document()
-        stepOneConfig["info"] = None
-        stepOneConfig["config"] = None
-        stepOneConfig["md5hash"] = "eb1c38cf50e14cf9fc31278a5c8e580f"
-        stepOneConfig["pset_hash"] = "7c856ad35f9f544839d8525ca10259a7"
-        stepOneConfig["owner"] = {"group": "cmsdataops", "user": "sfoulkes"}
-        if combinedStepOne:
-            stepOneConfig["pset_tweak_details"] ={"process": {"outputModules_": ["RECODEBUGoutput", "DQMoutput"],
-                                                              "RECODEBUGoutput": {"dataset": {"filterName": "",
-                                                                                              "dataTier": "RECO-DEBUG-OUTPUT"}},
-                                                              "DQMoutput": {"dataset": {"filterName": "",
-                                                                                        "dataTier": "DQM"}}}}
-        else:
-            stepOneConfig["pset_tweak_details"] ={"process": {"outputModules_": ["RAWDEBUGoutput"],
-                                                              "RAWDEBUGoutput": {"dataset": {"filterName": "",
-                                                                                             "dataTier": "RAW-DEBUG-OUTPUT"}}}}
-
-        stepTwoConfig = Document()
-        stepTwoConfig["info"] = None
-        stepTwoConfig["config"] = None
-        stepTwoConfig["md5hash"] = "eb1c38cf50e14cf9fc31278a5c8e580f"
-        stepTwoConfig["pset_hash"] = "7c856ad35f9f544839d8525ca10259a7"
-        stepTwoConfig["owner"] = {"group": "cmsdataops", "user": "sfoulkes"}
-        stepTwoConfig["pset_tweak_details"] ={"process": {"outputModules_": ["RECODEBUGoutput", "DQMoutput"],
-                                                          "RECODEBUGoutput": {"dataset": {"filterName": "",
-                                                                                          "dataTier": "RECO-DEBUG-OUTPUT"}},
-                                                          "DQMoutput": {"dataset": {"filterName": "",
-                                                                                    "dataTier": "DQM"}}}}
-
-        stepThreeConfig = Document()
-        stepThreeConfig["info"] = None
-        stepThreeConfig["config"] = None
-        stepThreeConfig["md5hash"] = "eb1c38cf50e14cf9fc31278a5c8e580f"
-        stepThreeConfig["pset_hash"] = "7c856ad35f9f544839d8525ca10259a7"
-        stepThreeConfig["owner"] = {"group": "cmsdataops", "user": "sfoulkes"}
-        stepThreeConfig["pset_tweak_details"] ={"process": {"outputModules_": ["aodOutputModule"],
-                                                            "aodOutputModule": {"dataset": {"filterName": "",
-                                                                                            "dataTier": "AODSIM"}}}}
-        stepOne = self.configDatabase.commitOne(stepOneConfig)[0]["id"]
-        stepTwo = self.configDatabase.commitOne(stepTwoConfig)[0]["id"]
-        stepThree = self.configDatabase.commitOne(stepThreeConfig)[0]["id"]
-        return (stepOne, stepTwo, stepThree)
-
     def testDependentReDigi(self):
         """
         _testDependentReDigi_
@@ -113,7 +113,7 @@ class ReDigiTest(unittest.TestCase):
         defaultArguments = getTestArguments()
         defaultArguments["CouchURL"] = os.environ["COUCHURL"]
         defaultArguments["CouchDBName"] = "redigi_t"
-        configs = self.injectReDigiConfigs()
+        configs = injectReDigiConfigs(self.configDatabase)
         defaultArguments["StepOneConfigCacheID"] = configs[0]
         defaultArguments["StepTwoConfigCacheID"] = configs[1]
         defaultArguments["StepThreeConfigCacheID"] = configs[2]
@@ -631,7 +631,7 @@ class ReDigiTest(unittest.TestCase):
         defaultArguments = getTestArguments()
         defaultArguments["CouchURL"] = os.environ["COUCHURL"]
         defaultArguments["CouchDBName"] = "redigi_t"
-        configs = self.injectReDigiConfigs()
+        configs = injectReDigiConfigs(self.configDatabase)
         defaultArguments["StepOneConfigCacheID"] = configs[0]
         defaultArguments["StepTwoConfigCacheID"] = configs[1]
         defaultArguments["StepThreeConfigCacheID"] = configs[2]
@@ -669,7 +669,7 @@ class ReDigiTest(unittest.TestCase):
         defaultArguments = getTestArguments()
         defaultArguments["CouchURL"] = os.environ["COUCHURL"]
         defaultArguments["CouchDBName"] = "redigi_t"
-        configs = self.injectReDigiConfigs()
+        configs = injectReDigiConfigs(self.configDatabase)
         defaultArguments["StepOneConfigCacheID"] = configs[0]
         defaultArguments["StepTwoConfigCacheID"] = configs[1]
         defaultArguments["StepThreeConfigCacheID"] = configs[2]
@@ -705,7 +705,7 @@ class ReDigiTest(unittest.TestCase):
         defaultArguments = getTestArguments()
         defaultArguments["CouchURL"] = os.environ["COUCHURL"]
         defaultArguments["CouchDBName"] = "redigi_t"
-        configs = self.injectReDigiConfigs(combinedStepOne = True)
+        configs = injectReDigiConfigs(self.configDatabase, combinedStepOne = True)
         defaultArguments["StepOneConfigCacheID"] = configs[0]
         defaultArguments["StepTwoConfigCacheID"] = configs[2]
         defaultArguments["StepThreeConfigCacheID"] = None
@@ -733,7 +733,7 @@ class ReDigiTest(unittest.TestCase):
         defaultArguments = getTestArguments()
         defaultArguments["CouchURL"] = os.environ["COUCHURL"]
         defaultArguments["CouchDBName"] = "redigi_t"
-        configs = self.injectReDigiConfigs()
+        configs = injectReDigiConfigs(self.configDatabase)
         defaultArguments["StepOneConfigCacheID"] = configs[2]
         defaultArguments["StepTwoConfigCacheID"] = None
         defaultArguments["StepThreeConfigCacheID"] = None

--- a/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
@@ -1674,6 +1674,46 @@ class WMWorkloadTest(unittest.TestCase):
                           'SomeURL/SomeDBName/DocIDThatIsReallyLong2/configFile'])
         return
 
+    def testPileupDatasetList(self):
+        """
+        _testPileupDatasetList_
+
+        Test that we can list all the pile up datasets in a workload including those not
+        in the top level task.
+        """
+        dataPileupConfig = {"data" : ["/some/minbias/data"]}
+        mcPileupConfig = {"data" : ["/some/minbias/data"],
+                          "mc" : ["/some/minbias/mc"]}
+
+        testWorkload = WMWorkloadHelper(WMWorkload("TestWorkload"))
+        procTask = testWorkload.newTask("ProcessingTask")
+        procTask.setSplittingAlgorithm("FileBased", files_per_job = 1)
+        procTask.setTaskType("Processing")
+        procTaskCmssw = procTask.makeStep("cmsRun1")
+        procTaskCmssw.setStepType("CMSSW")
+        procTask.applyTemplates()
+
+        procTaskCmsswHelper = procTaskCmssw.getTypeHelper()
+        procTaskCmsswHelper.setupPileup(dataPileupConfig, 'dbslocation')
+
+        procTask2 = procTask.addTask("ProcessingTask2")
+        procTask2.setSplittingAlgorithm("FileBased", files_per_job = 1)
+        procTask2.setTaskType("Processing")
+        procTask2Cmssw = procTask2.makeStep("cmsRun2")
+        procTask2Cmssw.setStepType("CMSSW")
+        procTask2.applyTemplates()
+
+        procTask3 = procTask2.addTask("ProcessingTask3")
+        procTask3.setSplittingAlgorithm("FileBased", files_per_job = 1)
+        procTask3.setTaskType("Processing")
+        procTask3Cmssw = procTask3.makeStep("cmsRun2")
+        procTask3Cmssw.setStepType("CMSSW")
+        procTask3.applyTemplates()
+
+        procTask3CmsswHelper = procTask3Cmssw.getTypeHelper()
+        procTask3CmsswHelper.setupPileup(mcPileupConfig, 'dbslocation')
+        self.assertEqual(sorted(testWorkload.listPileupDatasets()), sorted(["/some/minbias/data",
+                                                                            "/some/minbias/mc"]))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/WMCore_t/WMSpec_t/samples/MultiTaskProcessingWorkload.py
+++ b/test/python/WMCore_t/WMSpec_t/samples/MultiTaskProcessingWorkload.py
@@ -60,6 +60,10 @@ rerecoCmsswHelper.addOutputModule(
     processedDataset = "Processed",
     dataTier = "RECO")
 
+pileupConfig = {"data" : ["/mixing/pileup/dataset"]}
+rerecoCmsswHelper.setupPileup(pileupConfig,
+                              "http://cmsdbsprod.cern.ch/cms_dbs_prod_global/servlet/DBSServlet")
+
 #Add a stageOut step
 skimStageOutHelper = skimStageOut.getTypeHelper()
 skimLogArchHelper  = skimLogArch.getTypeHelper()

--- a/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Block_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Block_t.py
@@ -394,5 +394,38 @@ class BlockTestCase(unittest.TestCase):
 
         return
 
+    def testDatasetLocation(self):
+        """
+        _testDatasetLocation_
+
+        This is a function of all start policies so only test it here
+        as there is no StartPolicyInterface unit test
+        """
+        policyInstance = Block(**self.splitArgs)
+        # The policy instance must be called first to initialize the values
+        Tier1ReRecoWorkload = rerecoWorkload('ReRecoWorkload', rerecoArgs)
+        for task in Tier1ReRecoWorkload.taskIterator():
+            policyInstance(Tier1ReRecoWorkload, task)
+            outputs = policyInstance.getDatasetLocations(Tier1ReRecoWorkload.listOutputDatasets())
+            for dataset in outputs:
+                self.assertEqual(sorted(outputs[dataset]), ['T2_XX_SiteA', 'T2_XX_SiteB'])
+        return
+
+    def testPileupData(self):
+        """
+        _testPileupData_
+
+        Check that every workqueue element split contains the pile up data
+        if it is present in the workload.
+        """
+        for task in MultiTaskProcessingWorkload.taskIterator():
+            units, _ = Block(**self.splitArgs)(MultiTaskProcessingWorkload, task)
+            self.assertEqual(Globals.GlobalParams.numOfBlocksPerDataset(), len(units))
+            for unit in units:
+                pileupData = unit["PileupData"]
+                self.assertEqual(len(pileupData), 1)
+                self.assertEqual(pileupData.values()[0], ["T2_XX_SiteC"])
+        return
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueueTestCase.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueueTestCase.py
@@ -8,6 +8,8 @@ Unit tests for the WMBS File class.
 import unittest
 import os
 
+from WMCore.Database.CMSCouch import CouchServer
+
 from WMQuality.TestInit import TestInit
 from WMQuality.TestInitCouchApp import TestInitCouchApp as TestInit
 
@@ -33,6 +35,7 @@ class WorkQueueTestCase(unittest.TestCase):
         self.localQInboxDB = 'workqueue_t_local_inbox'
         self.localQDB2 = 'workqueue_t_local2'
         self.localQInboxDB2 = 'workqueue_t_local2_inbox'
+        self.configCacheDB = 'workqueue_t_config_cache'
 
         self.setSchema()
         self.testInit = TestInit('WorkQueueTest')
@@ -48,6 +51,10 @@ class WorkQueueTestCase(unittest.TestCase):
         self.testInit.setupCouch(self.localQInboxDB, *self.couchApps)
         self.testInit.setupCouch(self.localQDB2, *self.couchApps)
         self.testInit.setupCouch(self.localQInboxDB2, *self.couchApps)
+        self.testInit.setupCouch(self.configCacheDB, 'ConfigCache')
+
+        couchServer = CouchServer(os.environ.get("COUCHURL"))
+        self.configCacheDBInstance = couchServer.connectDatabase(self.configCacheDB)
 
         self.workDir = self.testInit.generateWorkDir()
         return

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
@@ -18,6 +18,8 @@ from WMCore.Services.WorkQueue.WorkQueue import WorkQueue as WorkQueueService
 
 from WMCore.WMSpec.StdSpecs.ReReco import rerecoWorkload as rerecoWMSpec, \
                                           getTestArguments as getRerecoArgs
+from WMCore.WMSpec.StdSpecs.ReDigi import reDigiWorkload as redigiWMSpec, \
+                                            getTestArguments as getRedigiArgs
 from WMQuality.Emulators.WMSpecGenerator.Samples.TestMonteCarloWorkload \
     import monteCarloWorkload, getMCArgs
 
@@ -29,6 +31,7 @@ from WMCore.DAOFactory import DAOFactory
 from WMQuality.Emulators import EmulatorSetup
 
 from WMCore_t.WorkQueue_t.WorkQueueTestCase import WorkQueueTestCase
+from WMCore_t.WMSpec_t.StdSpecs_t.ReDigi_t import injectReDigiConfigs
 from WMCore_t.WMSpec_t.samples.MultiTaskProductionWorkload \
                                 import workload as MultiTaskProductionWorkload
 from WMCore.Services.EmulatorSwitch import EmulatorHelper
@@ -49,11 +52,16 @@ parentProcArgs = getRerecoArgs()
 parentProcArgs.update(IncludeParents = "True")
 openRunningProcArgs = getRerecoArgs()
 openRunningProcArgs.update(OpenRunningTimeout = 10)
+redigiArgs = getRedigiArgs()
 
 
 def rerecoWorkload(workloadName, arguments):
     wmspec = rerecoWMSpec(workloadName, arguments)
     #wmspec.setStartPolicy("DatasetBlock")
+    return wmspec
+
+def redigiWorkload(workloadName, arguments):
+    wmspec = redigiWMSpec(workloadName, arguments)
     return wmspec
 
 def getFirstTask(wmspec):
@@ -130,6 +138,9 @@ class WorkQueueTest(WorkQueueTestCase):
                                                      'testOpenRunningSpec.spec'))
         self.openRunningSpec.save(self.openRunningSpec.specUrl())
 
+        # Redigi spec with pile-up
+        # Needs special configCache setup
+        self.createRedigiSpec()
 
         # setup Mock DBS and PhEDEx
         inputDataset = getFirstTask(self.processingSpec).inputDataset()
@@ -211,6 +222,22 @@ class WorkQueueTest(WorkQueueTestCase):
         EmulatorSetup.deleteConfig(self.configFile)
         EmulatorHelper.resetEmulators()
 
+
+    def createRedigiSpec(self):
+        """
+        _createRedigiSpec_
+
+        Create a bogus redigi spec, with configs and all the shiny things
+        """
+        configs = injectReDigiConfigs(self.configCacheDBInstance)
+        redigiArgs["CouchDBName"] = self.configCacheDB
+        redigiArgs["StepOneConfigCacheID"] = configs[0]
+        redigiArgs["StepTwoConfigCacheID"] = configs[1]
+        redigiArgs["StepThreeConfigCacheID"] = configs[2]
+        self.redigiSpec = redigiWorkload('reDigiSpec', redigiArgs)
+        self.redigiSpec.setSpecUrl(os.path.join(self.workDir,
+                                                'reDigiSpec.spec'))
+        self.redigiSpec.save(self.redigiSpec.specUrl())
 
     def createResubmitSpec(self, serverUrl, couchDB, parentage = False):
         """
@@ -1400,6 +1427,43 @@ class WorkQueueTest(WorkQueueTestCase):
         self.assertEqual(0, self.globalQueue.addWork(self.processingSpec.name()))
 
         return
+
+    def testProcessingWithPileup(self):
+        """Test a full WorkQueue cycle in a request with pileup datasets"""
+        specfile = self.redigiSpec.specUrl()
+        # Queue work with initial block count
+        self.assertEqual(GlobalParams.numOfBlocksPerDataset(), self.globalQueue.queueWork(specfile))
+        self.assertEqual(GlobalParams.numOfBlocksPerDataset(), len(self.globalQueue))
+
+        # All blocks are in Site A and B, but the pileup is only at C.
+        # We should not be able to pull the work.
+        self.assertEqual(self.localQueue.pullWork({'T2_XX_SiteA' : 1,
+                                                   'T2_XX_SiteB' : 3,
+                                                   'T2_XX_SiteC' : 4},
+                                                  continuousReplication = False), 0)
+        # The PhEDEx emulator will move the pileup blocks to site A
+        self.globalQueue.updateLocationInfo()
+        self.assertEqual(self.localQueue.pullWork({'T2_XX_SiteB' : 1,
+                                                   'T2_XX_SiteC' : 4},
+                                                  continuousReplication = False), 0)
+
+        # Now try with site A
+        self.assertEqual(self.localQueue.pullWork({'T2_XX_SiteA' : 1},
+                                                  continuousReplication = False), 1)
+        syncQueues(self.localQueue)
+        self.assertEqual(len(self.localQueue), 1)
+        self.assertEqual(len(self.globalQueue), 1)
+
+        # Pull it to WMBS, first try with an impossible site
+        # The pileup was split again in the local queue so site A is not there
+        self.assertEqual(len(self.localQueue.getWork({'T2_XX_SiteA' : 1,
+                                                      'T2_XX_SiteB' : 3,
+                                                      'T2_XX_SiteC' : 4})), 0)
+        Globals.moveBlock({'/mixing/pileup/dataset#1' : ['T2_XX_SiteA', 'T2_XX_SiteC'],
+                           '/mixing/pileup/dataset#2' : ['T2_XX_SiteA', 'T2_XX_SiteC']})
+        self.localQueue.updateLocationInfo()
+        self.assertEqual(len(self.localQueue.getWork({'T2_XX_SiteA' : 1})), 1)
+        self.assertEqual(len(self.localQueue), 0)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The WorkQueue now tracks the location of pileup datasets
in a workload. The handling of these datasets it's similar
to the parent data, it is required that all pileup datasets
are at a site before acquiring the work for that site. However,
since the pileup is set at a dataset-level instead of blocks.
It is required that just a block is at the site for the dataset
to be considered "at the site". If the pileup is not at any
of the valid sites (after white/black lists) then the work
will wait in Available until the datasets/blocks are transferred.

Fixes #3733
