### PR TITLE
ReqMgr request parameter DbsUrl stored in CouchDB

### DIFF
--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
@@ -634,9 +634,15 @@ def requestDetails(requestName):
     schema['AcquisitionEra']  = str(helper.getAcquisitionEra())
     if schema['SoftwareVersions'] == ['DEPRECATED']:
         schema['SoftwareVersions'] = helper.getCMSSWVersions()
-    # DbsUrl is only in couch or the spec, get it from the later
-    schema['DbsUrl'] = str(task.dbsUrl())
+        
+    # get DbsUrl from CouchDB
+    if schema.get("CouchWorkloadDBName", None) and schema.get("CouchURL", None):
+        couchDb = Database(schema["CouchWorkloadDBName"], schema["CouchURL"])
+        couchReq = couchDb.document(requestName)
+        schema["DbsUrl"] = couchReq.get("DbsUrl", None)
+        
     return schema
+
 
 def serveFile(contentType, prefix, *args):
     """Return a workflow from the cache"""

--- a/src/python/WMCore/RequestManager/RequestDB/Interface/Request/GetRequest.py
+++ b/src/python/WMCore/RequestManager/RequestDB/Interface/Request/GetRequest.py
@@ -6,6 +6,7 @@ API to get requests from the DB
 """
 
 
+import logging
 import WMCore.RequestManager.RequestDB.Connection as DBConnect
 import WMCore.RequestManager.RequestDB.Interface.Request.ListRequests as ListRequests
 import WMCore.RequestManager.RequestDB.Interface.Request.ChangeState as ChangeState
@@ -82,8 +83,12 @@ def getRequest(requestId, reverseTypes=None, reverseStatus=None):
     
     # fetch AcquisitionEra from spec, it's not stored in Oracle at all
     import WMCore.HTTPFrontEnd.RequestManager.ReqMgrWebTools as Utilities
-    helper = Utilities.loadWorkload(request)
-    request["AcquisitionEra"] = str(helper.getAcquisitionEra())
+    try:
+        helper = Utilities.loadWorkload(request)
+        request["AcquisitionEra"] = str(helper.getAcquisitionEra())
+    except Exception, ex:
+        logging.error("Could not check workload for %s, reason: %s" %
+                      (request["RequestName"], ex))
     return request
 
 

--- a/src/python/WMCore/RequestManager/RequestMaker/Registry.py
+++ b/src/python/WMCore/RequestManager/RequestMaker/Registry.py
@@ -115,10 +115,9 @@ def buildWorkloadForRequest(typename, schema):
     if schema.get('CMSSWVersion') and schema.get('CMSSWVersion') not in request['SoftwareVersions']:
         request['SoftwareVersions'].append(schema.get('CMSSWVersion'))
 
-    # Usually DbsUrl is not in the schema, and gets a default value in the WMSpec creation
-    # Use the top level task DBSUrl as the DBSUrl for the whole request, store it in CouchDB
-    request['DbsUrl'] = (workload.getTopLevelTask()[0]).dbsUrl()
-
+    if schema.get("DbsUrl", None):
+        request["DbsUrl"] = schema.get("DbsUrl")
+        
     return request
 
 

--- a/test/data/ReqMgr/reqmgr.py
+++ b/test/data/ReqMgr/reqmgr.py
@@ -572,7 +572,7 @@ class ReqMgrClient(RESTClient):
                         "RequestNumEvents"
                         ]
         # request parameters (fields) which are optional
-        optionalArgs = ["PrepID"]
+        optionalArgs = ["PrepID", "DbsUrl"]
                
         couchDbConn, uri = self.getCouchDbConnectionAndUri(config)
         status, data = couchDbConn.httpRequest("GET", uri + "/" + requestName)
@@ -667,7 +667,7 @@ class ReqMgrClient(RESTClient):
         msg = ("Priorities don't match: original request: %s cloned request: %s" %
                (newPriority, clonedRequest["RequestPriority"]))
         assert newPriority == clonedRequest["RequestPriority"], msg
-        msg = ("DBS Url don't match: original request %s cloned request: %s" %
+        msg = ("DbsUrl don't match: original request %s cloned request: %s" %
                (testRequestData["DbsUrl"], clonedRequest["DbsUrl"]))
         assert testRequestData["DbsUrl"] == clonedRequest["DbsUrl"], msg
         


### PR DESCRIPTION
Correction of #4515
e.g. for MonteCarlo workload the DbsUrl was not really stored in CouchDB, even
though it was specified at injection, querying the request was returning None
for DbsUrl. As discussed with @efajardo, DbsUrl argument, once specified,
shall be stored for all types of workflows.

Fixes #4498
Correction of #4380 (DbsUrl should not have been removed, only fixed so that
it's properly stored in CouchDB, as done here now)
