### PR TITLE
ReqMgr - removing wrong DBS URL from configuration

### DIFF
--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrConfiguration.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrConfiguration.py
@@ -17,7 +17,6 @@ def reqMgrConfig(
     proxyBase = None,
     couchurl = os.getenv("COUCHURL"),
     sitedb = 'https://cmsweb.cern.ch/sitedb/json/index/CEtoCMSName?name',
-    dbs3 = 'http://vocms09.cern.ch:8989/dbs',
     yuiroot = "/reqmgr/yuiserver/yui",
     configCouchDB = 'reqmgr_config_cache',
     workloadCouchDB = 'reqmgr_workload_cache',
@@ -73,7 +72,6 @@ def reqMgrConfig(
     config.reqmgr.wmstatDBName = wmstatCouchDB
     config.reqmgr.security_roles = ['Admin', 'Developer', 'Data Manager', 'developer', 'admin', 'data-manager']
     config.reqmgr.yuiroot = yuiroot
-    config.reqmgr.dbs3=dbs3
 
     views = config.reqmgr.section_('views')
     active = views.section_('active')

--- a/src/templates/WMCore/WebTools/RequestManager/WebRequestSchema.tmpl
+++ b/src/templates/WMCore/WebTools/RequestManager/WebRequestSchema.tmpl
@@ -136,11 +136,9 @@ Open Running Timeout: <input type="text" name="OpenRunningTimeout" size=10 value
 DBS: <!--input type="text" name="dbs" value="http://cmsdbsprod.cern.ch/cms_dbs_prod_global/servlet/DBSServlet" size=80/><br/-->
 <select name="DbsUrl">
 		<option>http://cmsdbsprod.cern.ch/cms_dbs_prod_global/servlet/DBSServlet</option>
-                <option>http://cmsdbsprod.cern.ch/cms_dbs_ph_analysis_01/servlet/DBSServlet</option>
-                <option>http://cmsdbsprod.cern.ch/cms_dbs_ph_analysis_02/servlet/DBSServlet</option>
+        <option>http://cmsdbsprod.cern.ch/cms_dbs_ph_analysis_01/servlet/DBSServlet</option>
+        <option>http://cmsdbsprod.cern.ch/cms_dbs_ph_analysis_02/servlet/DBSServlet</option>
 		<option>https://cmsweb-dev.cern.ch/dbs/prod/global/DBSWriter</option>
-		<option>https://dbs3-dev01.cern.ch/dbs/prod/global/DBSWriter</option>
-		<option>http://cms-xen40.fnal.gov:8787/dbs/prod/global/DBSWriter</option>
 </select><br>
 #end def
 


### PR DESCRIPTION
ReqMgr configuration defined:
dbs3 = 'http://vocms09.cern.ch:8989/dbs'
which is wrong. Was removed along with related code in the Announce module.
The results of handleAnnounce call here are at least questionable, pending Ops
feedback it may be removed altogether.
