### PR TITLE
Fix DbsUrl for clones

### DIFF
--- a/src/python/WMCore/RequestManager/RequestMaker/Registry.py
+++ b/src/python/WMCore/RequestManager/RequestMaker/Registry.py
@@ -116,7 +116,9 @@ def buildWorkloadForRequest(typename, schema):
         request['SoftwareVersions'].append(schema.get('CMSSWVersion'))
 
     if schema.get("DbsUrl", None):
-        request["DbsUrl"] = schema.get("DbsUrl")
+        request["DbsUrl"] = schema["DbsUrl"]
+    else:
+        request["DbsUrl"] = (workload.getTopLevelTask()[0]).dbsUrl()
         
     return request
 

--- a/test/python/WMCore_t/RequestManager_t/ReqMgrWorkload_t.py
+++ b/test/python/WMCore_t/RequestManager_t/ReqMgrWorkload_t.py
@@ -187,7 +187,7 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         self.assertEqual(request['CMSSWVersion'], schema['CMSSWVersion'])
         self.assertEqual(request['Group'], groupName)
         self.assertEqual(request['Requestor'], userName)
-        
+        self.assertEqual(request['DbsUrl'], 'http://cmsdbsprod.cern.ch/cms_dbs_prod_global/servlet/DBSServlet')
 
     @attr('integration')
     def testB_Analysis(self):
@@ -267,7 +267,7 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         self.assertEqual(request['CMSSWVersion'], schema['CMSSWVersion'])
         self.assertEqual(request['Group'], groupName)
         self.assertEqual(request['Requestor'], userName)
-
+        self.assertEqual(request['DbsUrl'], 'http://cmsdbsprod.cern.ch/cms_dbs_prod_global/servlet/DBSServlet')
 
     @attr('integration')
     def testD_ReDigi(self):
@@ -285,7 +285,6 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
                                                groupName = groupName,
                                                teamName = teamName)
         schema['RequestType'] = "ReDigi"
-        schema['DbsUrl'] = 'http://cmsdbsprod.cern.ch/cms_dbs_prod_global/servlet/DBSServlet'
         try:
             raises = False
             result = self.jsonSender.put('request/testRequest', schema)
@@ -318,8 +317,7 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         self.assertEqual(request['CMSSWVersion'], schema['CMSSWVersion'])
         self.assertEqual(request['Group'], groupName)
         self.assertEqual(request['Requestor'], userName)
-        self.assertEqual(request['DbsUrl'], schema['DbsUrl'])
-
+        self.assertEqual(request['DbsUrl'], 'http://cmsdbsprod.cern.ch/cms_dbs_prod_global/servlet/DBSServlet')
 
     @attr('integration')
     def testE_StoreResults(self):
@@ -462,7 +460,6 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
                                                groupName = groupName,
                                                teamName = teamName)
         schema['RequestType'] = "MonteCarloFromGEN"
-        schema['DbsUrl'] = 'http://cmsdbsprod.cern.ch/cms_dbs_prod_global/servlet/DBSServlet'
         try:
             raises = False
             result = self.jsonSender.put('request/testRequest', schema)
@@ -495,8 +492,7 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         self.assertEqual(request['CMSSWVersion'], schema['CMSSWVersion'])
         self.assertEqual(request['Group'], groupName)
         self.assertEqual(request['Requestor'], userName)
-        self.assertEqual(request['DbsUrl'], schema['DbsUrl'])
-
+        self.assertEqual(request['DbsUrl'], 'http://cmsdbsprod.cern.ch/cms_dbs_prod_global/servlet/DBSServlet')
 
     def testH_MonteCarlo(self):
         """
@@ -514,6 +510,7 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
                                                groupName = groupName,
                                                teamName = teamName)
         schema['RequestType'] = "MonteCarlo"
+        schema['DbsUrl'] = 'http://cmsdbsprod.cern.ch/cms_dbs_prod_global/servlet/DBSServlet'
 
         # Set some versions
         schema['ProcessingVersion'] = '2012'
@@ -567,7 +564,7 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         self.assertEqual(request['CMSSWVersion'], schema['CMSSWVersion'])
         self.assertEqual(request['Group'], groupName)
         self.assertEqual(request['Requestor'], userName)
-        self.assertEqual(request['DbsUrl'], None)
+        self.assertEqual(request['DbsUrl'], schema['DbsUrl'])
 
 
     def testI_RelValMC(self):
@@ -693,6 +690,7 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         schema['AcquisitionEra']    = 'ae2012'
         schema['FirstEvent'] = 1
         schema['FirstLumi'] = 1
+        schema['DbsUrl'] = 'http://cmsdbsprod.cern.ch/cms_dbs_prod_global/servlet/DBSServlet'
 
         try:
             raises = False
@@ -776,7 +774,7 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         self.assertEqual(request['CMSSWVersion'], schema['CMSSWVersion'])
         self.assertEqual(request['Group'], groupName)
         self.assertEqual(request['Requestor'], userName)
-        self.assertEqual(request['DbsUrl'], None)
+        self.assertEqual(request['DbsUrl'], schema['DbsUrl'])
 
 
 if __name__=='__main__':


### PR DESCRIPTION
Make sure the correct DbsUrl is stored in couch, even if not present in
the schema. However, if a non-null value is in the schema store that one.

The unit tests in WMCore_t.RequestManager_t.ReqMgrWorkload_t test the following cases:
- If no DbsUrl is present in the schema, then the default from the specs is stored in couchDB.
- If DbsUrl is present in the schema, then it is stored in couch regardless of the request type.
- If no DbsUrl is present in the schema, and the workload doesn't provide a default then couchDB stores a null value.

Fixes #4498
