### PR TITLE
Include performance estimates in Condor JDLs

### DIFF
--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -365,7 +365,10 @@ class JobSubmitterPoller(BaseWorkerThread):
                        loadedJob.get("swVersion", None),
                        loadedJob["name"],
                        loadedJob.get("proxyPath", None),
-                       newJob['request_name'])
+                       newJob['request_name'],
+                       loadedJob.get("estimatedJobTime", None),
+                       loadedJob.get("estimatedDiskUsage", None),
+                       loadedJob.get("estimatedMemoryUsage", None))
 
             self.jobDataCache[workflowName][jobID] = jobInfo
 
@@ -648,7 +651,10 @@ class JobSubmitterPoller(BaseWorkerThread):
                                'swVersion': cachedJob[10],
                                'name': cachedJob[11],
                                'proxyPath': cachedJob[12],
-                               'requestName': cachedJob[13]}
+                               'requestName': cachedJob[13],
+                               'estimatedJobTime' : cachedJob[14],
+                               'estimatedDiskUsage' : cachedJob[15],
+                               'estimatedMemoryUsage' : cachedJob[16]}
 
                     # Add to jobsToSubmit
                     jobsToSubmit[package].append(jobDict)

--- a/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
@@ -893,6 +893,14 @@ class CondorPlugin(BasePlugin):
         if job.get('requestName', None):
             jdl.append('+WMAgent_RequestName = "%s"\n' % job['requestName'])
 
+        # Performance estimates
+        if job.get('estimatedJobTime', None):
+            jdl.append('+MaxWallTimeMins = %d\n' % int(job['estimatedJobTime']/60.0))
+        if job.get('estimatedMemoryUsage', None):
+            jdl.append('request_memory = %d\n' % int(job['estimatedMemoryUsage']))
+        if job.get('estimatedDiskUsage', None):
+            jdl.append('request_disk = %d\n' % int(job['estimatedDiskUsage']))
+
         return jdl
 
     def getCEName(self, jobSite):

--- a/src/python/WMCore/BossAir/RunJob.py
+++ b/src/python/WMCore/BossAir/RunJob.py
@@ -27,7 +27,8 @@ class RunJob(dict):
                  sandbox = None, priority = None, site_cms_name = None,
                  taskType = None, possibleSites = [], sw_version = None,
                  scram_arch = None, siteName = None, jobName = None,
-                 proxyPath = None, requestName = None):
+                 proxyPath = None, requestName = None, jobTime = None,
+                 diskUsage = None, memoryUsage = None):
         """
         Just make sure you init the dictionary fields.
 
@@ -61,6 +62,9 @@ class RunJob(dict):
         self.setdefault('name', jobName)
         self.setdefault('proxyPath', proxyPath)
         self.setdefault('requestName', requestName)
+        self.setdefault('estimatedJobTime', jobTime)
+        self.setdefault('estimatedDiskUsage', diskUsage)
+        self.setdefault('estimatedMemoryUsage', memoryUsage)
 
         return
 

--- a/src/python/WMCore/DataStructs/Job.py
+++ b/src/python/WMCore/DataStructs/Job.py
@@ -49,6 +49,9 @@ class Job(WMObject, dict):
         self["fwjr_path"] = None
         self["workflow"] = None
         self["owner"] = None
+        self["estimatedJobTime"] = None
+        self["estimatedMemoryUsage"] = None
+        self["estimatedDiskUsage"] = None
         return
 
     #  //
@@ -125,6 +128,29 @@ class Job(WMObject, dict):
         """
         self["outcome"] = jobOutcome
         return
+
+    def addResourceEstimates(self, jobTime = None, memory = None, disk = None):
+        """
+        _addResourceEstimates_
+
+        Add to the current resource estimates, if None then initialize them
+        to the given value. Each value can be set independently.
+        """
+        # Update time
+        if self["estimatedJobTime"] is None:
+            self["estimatedJobTime"] = jobTime
+        elif jobTime is not None:
+            self["estimatedJobTime"] += jobTime
+        # Update memory
+        if self["estimatedMemoryUsage"] is None:
+            self["estimatedMemoryUsage"] = memory
+        elif memory is not None:
+            self["estimatedMemoryUsage"] += memory
+        # Update disk
+        if self["estimatedDiskUsage"] is None:
+            self["estimatedDiskUsage"] = disk
+        elif disk is not None:
+            self["estimatedDiskUsage"] += disk
 
     def getBaggage(self):
         """

--- a/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
+++ b/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
@@ -49,6 +49,8 @@ class EventAwareLumiBased(JobFactory):
         runWhitelist    = kwargs.get('runWhitelist', [])
         runs            = kwargs.get('runs', None)
         lumis           = kwargs.get('lumis', None)
+        timePerEvent, sizePerEvent, memoryRequirement = \
+                    self.getPerformanceParameters(kwargs.get('performance', {}))
 
         goodRunList = {}
         if runs and lumis:
@@ -192,6 +194,10 @@ class EventAwareLumiBased(JobFactory):
                             if firstLumi != None and firstLumi != lumi:
                                 self.currentJob['mask'].addRunAndLumis(run = run.run,
                                                                        lumis = [firstLumi, lastLumi])
+                                eventsAdded = ((lastLumi - firstLumi + 1) * f['avgEvtsPerLumi'])
+                                runAddedTime = eventsAdded * timePerEvent
+                                runAddedSize = eventsAdded * sizePerEvent
+                                self.currentJob.addResourceEstimates(jobTime = runAddedTime, disk = runAddedSize)
                                 firstLumi = None
                                 lastLumi = None
                             continue
@@ -200,6 +206,10 @@ class EventAwareLumiBased(JobFactory):
                         if lastLumi and not lumi == lastLumi + 1:
                             self.currentJob['mask'].addRunAndLumis(run = run.run,
                                                                    lumis = [firstLumi, lastLumi])
+                            eventsAdded = ((lastLumi - firstLumi + 1) * f['avgEvtsPerLumi'])
+                            runAddedTime = eventsAdded * timePerEvent
+                            runAddedSize = eventsAdded * sizePerEvent
+                            self.currentJob.addResourceEstimates(jobTime = runAddedTime, disk = runAddedSize)
                             firstLumi = None
                             lastLumi = None
 
@@ -215,6 +225,10 @@ class EventAwareLumiBased(JobFactory):
                             if firstLumi != None and lastLumi != None and lastRun != None:
                                 self.currentJob['mask'].addRunAndLumis(run = lastRun,
                                                                        lumis = [firstLumi, lastLumi])
+                                eventsAdded = ((lastLumi - firstLumi + 1) * f['avgEvtsPerLumi'])
+                                runAddedTime = eventsAdded * timePerEvent
+                                runAddedSize = eventsAdded * sizePerEvent
+                                self.currentJob.addResourceEstimates(jobTime = runAddedTime, disk = runAddedSize)
                             msg = None
                             if failNextJob:
                                 msg = "File %s has too many events (%d) in %d lumi(s)" % (f['lfn'],
@@ -222,6 +236,7 @@ class EventAwareLumiBased(JobFactory):
                                                                                           f['lumiCount'])
                             self.newJob(name = self.getJobName(length = totalJobs), failedJob = failNextJob,
                                         failedReason = msg)
+                            self.currentJob.addResourceEstimates(memory = memoryRequirement)
                             failNextJob = False
                             firstLumi = lumi
                             lumisInJob = 0
@@ -253,6 +268,10 @@ class EventAwareLumiBased(JobFactory):
                         # Add this run to the mask
                         self.currentJob['mask'].addRunAndLumis(run = run.run,
                                                                lumis = [firstLumi, lastLumi])
+                        eventsAdded = ((lastLumi - firstLumi + 1) * f['avgEvtsPerLumi'])
+                        runAddedTime = eventsAdded * timePerEvent
+                        runAddedSize = eventsAdded * sizePerEvent
+                        self.currentJob.addResourceEstimates(jobTime = runAddedTime, disk = runAddedSize)
                         firstLumi = None
                         lastLumi = None
 

--- a/src/python/WMCore/JobSplitting/JobFactory.py
+++ b/src/python/WMCore/JobSplitting/JobFactory.py
@@ -395,3 +395,20 @@ class JobFactory(WMObject):
                     newParents.add(parent)
 
         return newParents
+
+    def getPerformanceParameters(self, defaultParams):
+        """
+        _getPerformanceParameters_
+
+        This generic JobFactory function allows all splitters to easily
+        retrieve the parameters to specify the resource requirements for
+        the created jobs.
+        # TODO: Check couchDB for performance on the current task
+                and if not available it falls back to the default params.
+        It returns a tuple with the following values:
+        timePerEvent, sizePerEvent, memoryRequirement
+        """
+        timePerEvent = defaultParams.get('timePerEvent', 0)
+        sizePerEvent = defaultParams.get('sizePerEvent', 0)
+        memory = defaultParams.get('memoryRequirement', 0)
+        return timePerEvent, sizePerEvent, memory

--- a/src/python/WMCore/JobSplitting/MinFileBased.py
+++ b/src/python/WMCore/JobSplitting/MinFileBased.py
@@ -9,14 +9,6 @@ number of files, it will not create any jobs UNLESS the
 fileset is closed.
 """
 
-
-
-
-import threading
-import sys
-import logging
-import gc
-
 from WMCore.JobSplitting.JobFactory import JobFactory
 from WMCore.WMBS.File               import File
 

--- a/src/python/WMCore/JobSplitting/ParentlessMergeBySize.py
+++ b/src/python/WMCore/JobSplitting/ParentlessMergeBySize.py
@@ -89,6 +89,7 @@ class ParentlessMergeBySize(JobFactory):
             newFile["locations"] = set([file["se_name"]])
             newFile.addRun(Run(file["file_run"], file["file_lumi"]))
             self.currentJob.addFile(newFile)
+            self.currentJob.addResourceEstimates(disk = float(file["file_size"])/1024)
 
     def defineMergeJobs(self, mergeableFiles):
         """

--- a/src/python/WMCore/JobSplitting/WMBSMergeBySize.py
+++ b/src/python/WMCore/JobSplitting/WMBSMergeBySize.py
@@ -61,7 +61,7 @@ def sortedFilesFromMergeUnits(mergeUnits):
 
         for file in mergeUnit["files"]:
             newFile = File(id = file["file_id"], lfn = file["file_lfn"],
-                           events = file["file_events"])
+                           events = file["file_events"], size = file["file_size"])
 
             # The WMBS data structure puts locations that are passed in through
             # the constructor in the "newlocations" attribute.  We want these to
@@ -147,6 +147,7 @@ class WMBSMergeBySize(JobFactory):
         sortedFiles = sortedFilesFromMergeUnits(mergeUnits)
 
         for file in sortedFiles:
+            self.currentJob.addResourceEstimates(disk = float(file["size"])/1024)
             self.currentJob.addFile(file)
 
     def defineMergeJobs(self, mergeUnits):

--- a/test/python/WMCore_t/JobSplitting_t/EventAwareLumiBased_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/EventAwareLumiBased_t.py
@@ -38,6 +38,9 @@ class EventAwareLumiBasedTest(unittest.TestCase):
         """
 
         self.testWorkflow = Workflow()
+        self.performanceParams = {'timePerEvent' : 12,
+                                  'memoryRequirement' : 2300,
+                                  'sizePerEvent' : 400}
 
         return
 
@@ -107,7 +110,8 @@ class EventAwareLumiBasedTest(unittest.TestCase):
 
 
         jobGroups = jobFactory(halt_job_on_file_boundaries = True,
-                               events_per_job = 100)
+                               events_per_job = 100,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1)
         self.assertEqual(len(jobGroups[0].jobs), 10)
         for job in jobGroups[0].jobs:
@@ -120,7 +124,8 @@ class EventAwareLumiBasedTest(unittest.TestCase):
         jobFactory = splitter(package = "WMCore.DataStructs",
                               subscription = twoLumiFiles)
         jobGroups = jobFactory(halt_job_on_file_boundaries = True,
-                               events_per_job = 50)
+                               events_per_job = 50,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1)
         self.assertEqual(len(jobGroups[0].jobs), 10)
         for job in jobGroups[0].jobs:
@@ -132,7 +137,8 @@ class EventAwareLumiBasedTest(unittest.TestCase):
         jobFactory = splitter(package = "WMCore.DataStructs",
                               subscription = wholeLumiFiles)
         jobGroups = jobFactory(halt_job_on_file_boundaries = True,
-                               events_per_job = 67)
+                               events_per_job = 67,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1)
         # 10 because we split on run boundaries
         self.assertEqual(len(jobGroups[0].jobs), 10)
@@ -158,7 +164,8 @@ class EventAwareLumiBasedTest(unittest.TestCase):
         jobFactory = splitter(package = "WMCore.DataStructs",
                               subscription = twoSiteSubscription)
         jobGroups = jobFactory(halt_job_on_file_boundaries = True,
-                               events_per_job = 50)
+                               events_per_job = 50,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 2)
         self.assertEqual(len(jobGroups[0].jobs), 10)
         for job in jobGroups[0].jobs:
@@ -180,7 +187,8 @@ class EventAwareLumiBasedTest(unittest.TestCase):
 
         jobGroups = jobFactory(halt_job_on_file_boundaries = False,
                                splitOnRun = False,
-                               events_per_job = 60)
+                               events_per_job = 60,
+                               performance = self.performanceParams)
 
         self.assertEqual(len(jobGroups), 1)
         jobs = jobGroups[0].jobs
@@ -197,7 +205,8 @@ class EventAwareLumiBasedTest(unittest.TestCase):
                               subscription = testSubscription)
         jobGroups = jobFactory(halt_job_on_file_boundaries = True,
                                splitOnRun = True,
-                               events_per_job = 60)
+                               events_per_job = 60,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1)
         jobs = jobGroups[0].jobs
         self.assertEqual(len(jobs), 10)
@@ -229,7 +238,8 @@ class EventAwareLumiBasedTest(unittest.TestCase):
         #3.6 lumis per job, which rounds to 3, the algorithm always approximates to the lower integer.
         jobGroups = jobFactory(halt_job_on_file_boundaries = True,
                                splitOnRun = True,
-                               events_per_job = 360)
+                               events_per_job = 360,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1, "There should be only one job group")
         jobs = jobGroups[0].jobs
         self.assertEqual(len(jobs), 15, "There should be 15 jobs")
@@ -238,7 +248,8 @@ class EventAwareLumiBasedTest(unittest.TestCase):
         #This results in the algorithm reducing the lumis per job to 2
         jobGroups = jobFactory(halt_job_on_file_boundaries = True,
                                splitOnRun = True,
-                               events_per_job = 200)
+                               events_per_job = 200,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1, "There should be only one job group")
         jobs = jobGroups[0].jobs
         self.assertEqual(len(jobs), 20, "There should be 20 jobs")
@@ -249,7 +260,8 @@ class EventAwareLumiBasedTest(unittest.TestCase):
         jobFactory = splitter(package = "WMCore.DataStructs",
                               subscription = testSubscription)
         jobGroups = jobFactory(halt_job_on_file_boundaries = True,
-                               events_per_job = 5000)
+                               events_per_job = 5000,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1, "There should be only one job group")
         jobs = jobGroups[0].jobs
         self.assertEqual(len(jobs), 5, "There should be 5 jobs")
@@ -261,7 +273,8 @@ class EventAwareLumiBasedTest(unittest.TestCase):
                               subscription = testSubscription)
         jobGroups = jobFactory(halt_job_on_file_boundaries = True,
                                splitOnRun = True,
-                               events_per_job = 5000)
+                               events_per_job = 5000,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1, "There should be only one job group")
         jobs = jobGroups[0].jobs
         self.assertEqual(len(jobs), 25, "There should be 5 jobs")
@@ -288,7 +301,8 @@ class EventAwareLumiBasedTest(unittest.TestCase):
         #a single job containing all files
         jobGroups = jobFactory(halt_job_on_file_boundaries = False,
                                splitOnRun = False,
-                               events_per_job = 360)
+                               events_per_job = 360,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1, "There should be only one job group")
         jobs = jobGroups[0].jobs
         self.assertEqual(len(jobs), 1, "There should be 1 job")
@@ -324,7 +338,8 @@ class EventAwareLumiBasedTest(unittest.TestCase):
         #The 3rd job only contains the second file, the fourth and fifth job split the third file
         jobGroups = jobFactory(halt_job_on_file_boundaries = False,
                                splitOnRun = False,
-                               events_per_job = 150)
+                               events_per_job = 150,
+                               performance = self.performanceParams)
 
         self.assertEqual(len(jobGroups), 1, "There should be only one job group")
         jobs = jobGroups[0].jobs
@@ -369,7 +384,8 @@ class EventAwareLumiBasedTest(unittest.TestCase):
         #The settings for this splitting are 700 events per job
         jobGroups = jobFactory(splitOnRun = True,
                                halt_job_on_file_boundaries = False,
-                               events_per_job = 700)
+                               events_per_job = 700,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1, "There should be only one job group")
         jobs = jobGroups[0].jobs
         self.assertEqual(len(jobs), 6, "Six jobs must be in the jobgroup")
@@ -404,7 +420,8 @@ class EventAwareLumiBasedTest(unittest.TestCase):
         jobGroups = jobFactory(halt_job_on_file_boundaries = True,
                                splitOnRun = True,
                                events_per_job = 550,
-                               max_events_per_lumi = 800)
+                               max_events_per_lumi = 800,
+                               performance = self.performanceParams)
 
         self.assertEqual(len(jobGroups), 1, "There should be only one job group")
         jobs = jobGroups[0].jobs
@@ -444,7 +461,8 @@ class EventAwareLumiBasedTest(unittest.TestCase):
         jobGroups = jobFactory(halt_job_on_file_boundaries = True,
                                splitOnRun = True,
                                events_per_job = 550,
-                               max_events_per_lumi = 800)
+                               max_events_per_lumi = 800,
+                               performance = self.performanceParams)
 
         self.assertEqual(len(jobGroups), 1, "There should be only one job group")
         jobs = jobGroups[0].jobs

--- a/test/python/WMCore_t/JobSplitting_t/EventBased_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/EventBased_t.py
@@ -61,6 +61,10 @@ class EventBasedTest(unittest.TestCase):
                                                   split_algo = "EventBased",
                                                   type = "Processing")
 
+        self.performanceParams = {'timePerEvent' : 12,
+                                  'memoryRequirement' : 2300,
+                                  'sizePerEvent' : 400}
+
         return
 
     def tearDown(self):
@@ -97,7 +101,8 @@ class EventBasedTest(unittest.TestCase):
         """
         splitter = SplitterFactory()
         jobFactory = splitter(self.emptyFileSubscription)
-        jobGroups = jobFactory(events_per_job = 100)
+        jobGroups = jobFactory(events_per_job = 100,
+                               performance = self.performanceParams)
 
         self.assertEqual(len(jobGroups), 1,
                          "ERROR: JobFactory didn't return one JobGroup")
@@ -121,7 +126,8 @@ class EventBasedTest(unittest.TestCase):
         """
         splitter = SplitterFactory()
         jobFactory = splitter(self.singleFileSubscription)
-        jobGroups = jobFactory(events_per_job = 100)
+        jobGroups = jobFactory(events_per_job = 100,
+                               performance = self.performanceParams)
 
         assert len(jobGroups) == 1, \
                "ERROR: JobFactory didn't return one JobGroup."
@@ -152,7 +158,8 @@ class EventBasedTest(unittest.TestCase):
         splitter = SplitterFactory()
         jobFactory = splitter(self.singleFileSubscription)
 
-        jobGroups = jobFactory(events_per_job = 1000)
+        jobGroups = jobFactory(events_per_job = 1000,
+                               performance = self.performanceParams)
 
         assert len(jobGroups) == 1, \
                "ERROR: JobFactory didn't return one JobGroup."
@@ -184,7 +191,8 @@ class EventBasedTest(unittest.TestCase):
         splitter = SplitterFactory()
         jobFactory = splitter(self.singleFileSubscription)
 
-        jobGroups = jobFactory(events_per_job = 50)
+        jobGroups = jobFactory(events_per_job = 50,
+                               performance = self.performanceParams)
 
         assert len(jobGroups) == 1, \
                "ERROR: JobFactory didn't return one JobGroup."
@@ -219,7 +227,8 @@ class EventBasedTest(unittest.TestCase):
         splitter = SplitterFactory()
         jobFactory = splitter(self.singleFileSubscription)
 
-        jobGroups = jobFactory(events_per_job = 99)
+        jobGroups = jobFactory(events_per_job = 99,
+                               performance = self.performanceParams)
 
         assert len(jobGroups) == 1, \
                "ERROR: JobFactory didn't return one JobGroup."
@@ -254,7 +263,8 @@ class EventBasedTest(unittest.TestCase):
         splitter = SplitterFactory()
         jobFactory = splitter(self.multipleFileSubscription)
 
-        jobGroups = jobFactory(events_per_job = 100)
+        jobGroups = jobFactory(events_per_job = 100,
+                               performance = self.performanceParams)
 
         assert len(jobGroups) == 1, \
                "ERROR: JobFactory didn't return one JobGroup."
@@ -285,7 +295,8 @@ class EventBasedTest(unittest.TestCase):
         splitter = SplitterFactory()
         jobFactory = splitter(self.multipleFileSubscription)
 
-        jobGroups = jobFactory(events_per_job = 50)
+        jobGroups = jobFactory(events_per_job = 50,
+                               performance = self.performanceParams)
 
         assert len(jobGroups) == 1, \
                "ERROR: JobFactory didn't return one JobGroup."
@@ -316,7 +327,8 @@ class EventBasedTest(unittest.TestCase):
         splitter = SplitterFactory()
         jobFactory = splitter(self.multipleFileSubscription)
 
-        jobGroups = jobFactory(events_per_job = 150)
+        jobGroups = jobFactory(events_per_job = 150,
+                               performance = self.performanceParams)
 
         assert len(jobGroups) == 1, \
                "ERROR: JobFactory didn't return one JobGroup."
@@ -345,7 +357,8 @@ class EventBasedTest(unittest.TestCase):
         splitter = SplitterFactory()
         jobFactory = splitter(singleMCSubscription)
 
-        jobGroups = jobFactory(events_per_job = 100)
+        jobGroups = jobFactory(events_per_job = 100,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1,
                          "Error: JobFactory did not return one JobGroup")
         self.assertEqual(len(jobGroups[0].jobs), 1,
@@ -379,7 +392,8 @@ class EventBasedTest(unittest.TestCase):
         splitter = SplitterFactory()
         jobFactory = splitter(singleMCSubscription)
 
-        jobGroups = jobFactory(events_per_job = 1000)
+        jobGroups = jobFactory(events_per_job = 1000,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1,
                          "Error: JobFactory did not return one JobGroup")
         self.assertEqual(len(jobGroups[0].jobs), 1,
@@ -412,7 +426,8 @@ class EventBasedTest(unittest.TestCase):
         splitter = SplitterFactory()
         jobFactory = splitter(singleMCSubscription)
 
-        jobGroups = jobFactory(events_per_job = 99)
+        jobGroups = jobFactory(events_per_job = 99,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1,
                          "Error: JobFactory did not return one JobGroup")
         self.assertEqual(len(jobGroups[0].jobs), 2,
@@ -444,7 +459,8 @@ class EventBasedTest(unittest.TestCase):
         splitter = SplitterFactory()
         jobFactory = splitter(singleMCSubscription)
 
-        jobGroups = jobFactory(events_per_job = 50)
+        jobGroups = jobFactory(events_per_job = 50,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1,
                          "Error: JobFactory did not return one JobGroup")
         self.assertEqual(len(jobGroups[0].jobs), 2,
@@ -476,7 +492,8 @@ class EventBasedTest(unittest.TestCase):
         splitter = SplitterFactory()
         jobFactory = splitter(singleMCSubscription)
 
-        jobGroups = jobFactory(events_per_job = 600)
+        jobGroups = jobFactory(events_per_job = 600,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1,
                          "Error: JobFactory did not return one JobGroup")
         self.assertEqual(len(jobGroups[0].jobs), 1,
@@ -495,7 +512,8 @@ class EventBasedTest(unittest.TestCase):
                                                        lastEvent = 800)
         splitter = SplitterFactory()
         jobFactory = splitter(singleMCSubscription)
-        jobGroups = jobFactory(events_per_job = 6000)
+        jobGroups = jobFactory(events_per_job = 6000,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1,
                          "Error: JobFactory did not return one JobGroup")
         self.assertEqual(len(jobGroups[0].jobs), 1,
@@ -514,7 +532,8 @@ class EventBasedTest(unittest.TestCase):
                                                        lastEvent = 800)
         splitter = SplitterFactory()
         jobFactory = splitter(singleMCSubscription)
-        jobGroups = jobFactory(events_per_job = 599)
+        jobGroups = jobFactory(events_per_job = 599,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1,
                          "Error: JobFactory did not return one JobGroup")
         self.assertEqual(len(jobGroups[0].jobs), 2,
@@ -537,7 +556,8 @@ class EventBasedTest(unittest.TestCase):
                                                        lastEvent = 800)
         splitter = SplitterFactory()
         jobFactory = splitter(singleMCSubscription)
-        jobGroups = jobFactory(events_per_job = 300)
+        jobGroups = jobFactory(events_per_job = 300,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1,
                          "Error: JobFactory did not return one JobGroup")
         self.assertEqual(len(jobGroups[0].jobs), 2,
@@ -568,7 +588,8 @@ class EventBasedTest(unittest.TestCase):
         splitter = SplitterFactory()
         jobFactory = splitter(singleMCSubscription)
 
-        jobGroups = jobFactory(events_per_job = 100)
+        jobGroups = jobFactory(events_per_job = 100,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1,
                          "Error: JobFactory did not return one JobGroup")
         self.assertEqual(len(jobGroups[0].jobs), 1,
@@ -586,7 +607,8 @@ class EventBasedTest(unittest.TestCase):
                                                        lastLumi = 345)
         splitter = SplitterFactory()
         jobFactory = splitter(singleMCSubscription)
-        jobGroups = jobFactory(events_per_job = 1000)
+        jobGroups = jobFactory(events_per_job = 1000,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1,
                          "Error: JobFactory did not return one JobGroup")
         self.assertEqual(len(jobGroups[0].jobs), 1,
@@ -604,7 +626,8 @@ class EventBasedTest(unittest.TestCase):
                                                        lastLumi = 345)
         splitter = SplitterFactory()
         jobFactory = splitter(singleMCSubscription)
-        jobGroups = jobFactory(events_per_job = 99)
+        jobGroups = jobFactory(events_per_job = 99,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1,
                          "Error: JobFactory did not return one JobGroup")
         self.assertEqual(len(jobGroups[0].jobs), 2,
@@ -626,7 +649,8 @@ class EventBasedTest(unittest.TestCase):
                                                        lastLumi = 345)
         splitter = SplitterFactory()
         jobFactory = splitter(singleMCSubscription)
-        jobGroups = jobFactory(events_per_job = 50)
+        jobGroups = jobFactory(events_per_job = 50,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1,
                          "Error: JobFactory did not return one JobGroup")
         self.assertEqual(len(jobGroups[0].jobs), 2,
@@ -660,7 +684,8 @@ class EventBasedTest(unittest.TestCase):
         splitter = SplitterFactory()
         jobFactory = splitter(singleMCSubscription)
 
-        jobGroups = jobFactory(events_per_job = 100, events_per_lumi = 10)
+        jobGroups = jobFactory(events_per_job = 100, events_per_lumi = 10,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1,
                          "Error: JobFactory did not return one JobGroup")
         self.assertEqual(len(jobGroups[0].jobs), 2,
@@ -684,7 +709,8 @@ class EventBasedTest(unittest.TestCase):
         splitter = SplitterFactory()
         jobFactory = splitter(singleMCSubscription)
 
-        jobGroups = jobFactory(events_per_job = 111, events_per_lumi = 10)
+        jobGroups = jobFactory(events_per_job = 111, events_per_lumi = 10,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1,
                          "Error: JobFactory did not return one JobGroup")
         self.assertEqual(len(jobGroups[0].jobs), 2,
@@ -717,7 +743,8 @@ class EventBasedTest(unittest.TestCase):
         jobFactory = splitter(singleMCSubscription)
 
         jobGroups = jobFactory(events_per_job = 2**32 - 1,
-                               events_per_lumi = 2**32 - 1)
+                               events_per_lumi = 2**32 - 1,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1,
                          "Error: JobFactory did not return one JobGroup")
         self.assertEqual(len(jobGroups[0].jobs), 2,
@@ -742,7 +769,8 @@ class EventBasedTest(unittest.TestCase):
         splitter = SplitterFactory()
         jobFactory = splitter(singleMCSubscription)
 
-        jobGroups = jobFactory(events_per_job = 2**31, events_per_lumi = 2**32)
+        jobGroups = jobFactory(events_per_job = 2**31, events_per_lumi = 2**32,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1,
                          "Error: JobFactory did not return one JobGroup")
         self.assertEqual(len(jobGroups[0].jobs), 2,
@@ -768,7 +796,8 @@ class EventBasedTest(unittest.TestCase):
         splitter = SplitterFactory()
         jobFactory = splitter(singleMCSubscription)
 
-        jobGroups = jobFactory(events_per_job = 2**32, events_per_lumi = 2**32)
+        jobGroups = jobFactory(events_per_job = 2**32, events_per_lumi = 2**32,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1,
                          "Error: JobFactory did not return one JobGroup")
         self.assertEqual(len(jobGroups[0].jobs), 1,
@@ -790,7 +819,8 @@ class EventBasedTest(unittest.TestCase):
         splitter = SplitterFactory()
         jobFactory = splitter(singleMCSubscription)
 
-        jobGroups = jobFactory(events_per_job = 3, events_per_lumi = 1)
+        jobGroups = jobFactory(events_per_job = 3, events_per_lumi = 1,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1,
                          "Error: JobFactory did not return one JobGroup")
         self.assertEqual(len(jobGroups[0].jobs), 1,
@@ -812,7 +842,8 @@ class EventBasedTest(unittest.TestCase):
         splitter = SplitterFactory()
         jobFactory = splitter(singleMCSubscription)
 
-        jobGroups = jobFactory(events_per_job = 60, events_per_lumi = 10)
+        jobGroups = jobFactory(events_per_job = 60, events_per_lumi = 10,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1,
                          "Error: JobFactory did not return one JobGroup")
         self.assertEqual(len(jobGroups[0].jobs), 1,
@@ -834,7 +865,8 @@ class EventBasedTest(unittest.TestCase):
         splitter = SplitterFactory()
         jobFactory = splitter(singleMCSubscription)
 
-        jobGroups = jobFactory(events_per_job = 30, events_per_lumi = 10)
+        jobGroups = jobFactory(events_per_job = 30, events_per_lumi = 10,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1,
                          "Error: JobFactory did not return one JobGroup")
         self.assertEqual(len(jobGroups[0].jobs), 2,

--- a/test/python/WMCore_t/JobSplitting_t/FileBased_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/FileBased_t.py
@@ -59,6 +59,10 @@ class FileBasedTest(unittest.TestCase):
         #self.multipleFileSubscription.create()
         #self.singleFileSubscription.create()
 
+        self.performanceParams = {'timePerEvent' : 12,
+                                  'memoryRequirement' : 2300,
+                                  'sizePerEvent' : 400}
+
         return
 
     def tearDown(self):
@@ -79,7 +83,8 @@ class FileBasedTest(unittest.TestCase):
         splitter = SplitterFactory()
         jobFactory = splitter(self.singleFileSubscription)
 
-        jobGroups = jobFactory(files_per_job = 1)
+        jobGroups = jobFactory(files_per_job = 1,
+                               performance = self.performanceParams)
 
         assert len(jobGroups) == 1, \
                "ERROR: JobFactory didn't return one JobGroup."
@@ -104,7 +109,8 @@ class FileBasedTest(unittest.TestCase):
         splitter = SplitterFactory()
         jobFactory = splitter(self.singleFileSubscription)
 
-        jobGroups = jobFactory(files_per_job = 10)
+        jobGroups = jobFactory(files_per_job = 10,
+                               performance = self.performanceParams)
 
         assert len(jobGroups) == 1, \
                "ERROR: JobFactory didn't return one JobGroup."
@@ -129,7 +135,8 @@ class FileBasedTest(unittest.TestCase):
         splitter = SplitterFactory()
         jobFactory = splitter(self.multipleFileSubscription)
 
-        jobGroups = jobFactory(files_per_job = 2)
+        jobGroups = jobFactory(files_per_job = 2,
+                               performance = self.performanceParams)
 
         assert len(jobGroups) == 1, \
                "ERROR: JobFactory didn't return one JobGroup."
@@ -160,7 +167,8 @@ class FileBasedTest(unittest.TestCase):
         splitter = SplitterFactory()
         jobFactory = splitter(self.multipleFileSubscription)
 
-        jobGroups = jobFactory(files_per_job = 3)
+        jobGroups = jobFactory(files_per_job = 3,
+                               performance = self.performanceParams)
 
         self.assertEqual(len(jobGroups), 1)
 

--- a/test/python/WMCore_t/JobSplitting_t/LumiBased_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/LumiBased_t.py
@@ -34,6 +34,9 @@ class LumiBasedTest(unittest.TestCase):
         """
 
         self.testWorkflow = Workflow()
+        self.performanceParams = {'timePerEvent' : 12,
+                                  'memoryRequirement' : 2300,
+                                  'sizePerEvent' : 400}
 
         return
 
@@ -98,7 +101,8 @@ class LumiBasedTest(unittest.TestCase):
 
 
         jobGroups = jobFactory(lumis_per_job = 3,
-                               halt_job_on_file_boundaries = True)
+                               halt_job_on_file_boundaries = True,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1)
         self.assertEqual(len(jobGroups[0].jobs), 10)
         for job in jobGroups[0].jobs:
@@ -111,7 +115,8 @@ class LumiBasedTest(unittest.TestCase):
         jobFactory = splitter(package = "WMCore.DataStructs",
                               subscription = twoLumiFiles)
         jobGroups = jobFactory(lumis_per_job = 1,
-                               halt_job_on_file_boundaries = True)
+                               halt_job_on_file_boundaries = True,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1)
         self.assertEqual(len(jobGroups[0].jobs), 10)
         for job in jobGroups[0].jobs:
@@ -123,7 +128,8 @@ class LumiBasedTest(unittest.TestCase):
         jobFactory = splitter(package = "WMCore.DataStructs",
                               subscription = wholeLumiFiles)
         jobGroups = jobFactory(lumis_per_job = 2,
-                               halt_job_on_file_boundaries = True)
+                               halt_job_on_file_boundaries = True,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1)
         # 10 because we split on run boundaries
         self.assertEqual(len(jobGroups[0].jobs), 10)
@@ -149,7 +155,8 @@ class LumiBasedTest(unittest.TestCase):
         jobFactory = splitter(package = "WMCore.DataStructs",
                               subscription = twoSiteSubscription)
         jobGroups = jobFactory(lumis_per_job = 1,
-                               halt_job_on_file_boundaries = True)
+                               halt_job_on_file_boundaries = True,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 2)
         self.assertEqual(len(jobGroups[0].jobs), 10)
         for job in jobGroups[0].jobs:
@@ -171,7 +178,8 @@ class LumiBasedTest(unittest.TestCase):
 
         jobGroups = jobFactory(lumis_per_job = 3,
                                halt_job_on_file_boundaries = False,
-                               splitOnRun = False)
+                               splitOnRun = False,
+                               performance = self.performanceParams)
 
         self.assertEqual(len(jobGroups), 1)
         jobs = jobGroups[0].jobs
@@ -192,7 +200,8 @@ class LumiBasedTest(unittest.TestCase):
                               subscription = testSubscription)
         jobGroups = jobFactory(lumis_per_job = 3,
                                halt_job_on_file_boundaries = True,
-                               splitOnRun = True)
+                               splitOnRun = True,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1)
         jobs = jobGroups[0].jobs
         self.assertEqual(len(jobs), 10)

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/EventAwareLumiBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/EventAwareLumiBased_t.py
@@ -57,6 +57,10 @@ class EventAwareLumiBasedTest(unittest.TestCase):
                                 name = "wf001", task = "Test")
         self.testWorkflow.create()
 
+        self.performanceParams = {'timePerEvent' : 12,
+                                  'memoryRequirement' : 2300,
+                                  'sizePerEvent' : 400}
+
         return
 
     def tearDown(self):
@@ -127,57 +131,87 @@ class EventAwareLumiBasedTest(unittest.TestCase):
         """
         splitter = SplitterFactory()
 
-        #Create 5 files with 7 lumi per file and 100 events per lumi on average.
+        # Create 5 files with 7 lumi per file and 100 events per lumi on average.
         testSubscription = self.createSubscription(nFiles = 5, lumisPerFile = 7, twoSites = False,
                                                    nEventsPerFile = 700)
         jobFactory = splitter(package = "WMCore.WMBS",
                               subscription = testSubscription)
 
-        #First test, the optimal settings are 360 events per job
-        #As we have files with 100 events per lumi, this will configure the splitting to
-        #3.6 lumis per job, which rounds to 3, the algorithm always approximates to the lower integer.
+        # First test, the optimal settings are 360 events per job
+        # As we have files with 100 events per lumi, this will configure the splitting to
+        # 3.6 lumis per job, which rounds to 3, the algorithm always approximates to the lower integer.
         jobGroups = jobFactory(halt_job_on_file_boundaries = True,
                                splitOnRun = True,
-                               events_per_job = 360)
+                               events_per_job = 360,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1, "There should be only one job group")
         jobs = jobGroups[0].jobs
         self.assertEqual(len(jobs), 15, "There should be 15 jobs")
+        for idx, job in enumerate(jobs, start = 1):
+            # Jobs may have 1 lumi or 2 check performance figures accordingly
+            self.assertEqual(job['estimatedMemoryUsage'], 2300)
+            if idx % 3 == 0:
+                self.assertEqual(job['estimatedDiskUsage'], 100 * 400)
+                self.assertEqual(job['estimatedJobTime'], 100 * 12)
+            else:
+                self.assertEqual(job['estimatedDiskUsage'], 3 * 100 * 400)
+                self.assertEqual(job['estimatedJobTime'], 3 * 100 * 12)
 
         testSubscription = self.createSubscription(nFiles = 5, lumisPerFile = 7, twoSites = False,
                                                    nEventsPerFile = 700)
         jobFactory = splitter(package = "WMCore.WMBS",
                               subscription = testSubscription)
-        #Now set the average to 200 events per job
-        #This results in the algorithm reducing the lumis per job to 2
+        # Now set the average to 200 events per job
+        # This results in the algorithm reducing the lumis per job to 2
         jobGroups = jobFactory(halt_job_on_file_boundaries = True,
                                splitOnRun = True,
-                               events_per_job = 200)
+                               events_per_job = 200,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1, "There should be only one job group")
         jobs = jobGroups[0].jobs
         self.assertEqual(len(jobs), 20, "There should be 20 jobs")
+        for idx, job in enumerate(jobs, start = 1):
+            # Jobs may have 1 lumi or 2 check performance figures accordingly
+            self.assertEqual(job['estimatedMemoryUsage'], 2300)
+            if idx % 4 == 0:
+                self.assertEqual(job['estimatedDiskUsage'], 100 * 400)
+                self.assertEqual(job['estimatedJobTime'], 100 * 12)
+            else:
+                self.assertEqual(job['estimatedDiskUsage'], 2 * 100 * 400)
+                self.assertEqual(job['estimatedJobTime'], 2 * 100 * 12)
 
-        #Check extremes, process a zero event files with lumis. It must be processed in one job
+        # Check extremes, process a zero event files with lumis. It must be processed in one job
         testSubscription = self.createSubscription(nFiles = 5, lumisPerFile = 100, twoSites = False,
                                                    nEventsPerFile = 0)
         jobFactory = splitter(package = "WMCore.WMBS",
                               subscription = testSubscription)
         jobGroups = jobFactory(halt_job_on_file_boundaries = True,
-                               events_per_job = 5000)
+                               events_per_job = 5000,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1, "There should be only one job group")
         jobs = jobGroups[0].jobs
         self.assertEqual(len(jobs), 5, "There should be 5 jobs")
+        for job in jobs:
+            self.assertEqual(job['estimatedMemoryUsage'], 2300)
+            self.assertEqual(job['estimatedDiskUsage'], 0)
+            self.assertEqual(job['estimatedJobTime'], 0)
 
-        #Process files with 10k events per lumi, fallback to one lumi per job. We can't do better
+        # Process files with 10k events per lumi, fallback to one lumi per job. We can't do better
         testSubscription = self.createSubscription(nFiles = 5, lumisPerFile = 5, twoSites = False,
                                                    nEventsPerFile = 50000)
         jobFactory = splitter(package = "WMCore.WMBS",
                               subscription = testSubscription)
         jobGroups = jobFactory(halt_job_on_file_boundaries = True,
                                splitOnRun = True,
-                               events_per_job = 5000)
+                               events_per_job = 5000,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1, "There should be only one job group")
         jobs = jobGroups[0].jobs
         self.assertEqual(len(jobs), 25, "There should be 5 jobs")
+        for job in jobs:
+            self.assertEqual(job['estimatedMemoryUsage'], 2300)
+            self.assertEqual(job['estimatedDiskUsage'], 10000 * 400)
+            self.assertEqual(job['estimatedJobTime'], 10000 * 12)
 
 
     def testB_NoFileSplitNoHardLimit(self):
@@ -190,24 +224,28 @@ class EventAwareLumiBasedTest(unittest.TestCase):
         """
         splitter = SplitterFactory()
 
-        #Create 100 files with 7 lumi per file and 0 events per lumi on average.
+        # Create 100 files with 7 lumi per file and 0 events per lumi on average.
         testSubscription = self.createSubscription(nFiles = 100, lumisPerFile = 7, twoSites = False,
                                                    nEventsPerFile = 0)
         jobFactory = splitter(package = "WMCore.WMBS",
                               subscription = testSubscription)
 
-        #First test, the optimal settings are 360 events per job
-        #As we have files with 0 events per lumi, this will configure the splitting to
-        #a single job containing all files
+        # First test, the optimal settings are 360 events per job
+        # As we have files with 0 events per lumi, this will configure the splitting to
+        # a single job containing all files
         jobGroups = jobFactory(halt_job_on_file_boundaries = False,
                                splitOnRun = False,
-                               events_per_job = 360)
+                               events_per_job = 360,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1, "There should be only one job group")
         jobs = jobGroups[0].jobs
         self.assertEqual(len(jobs), 1, "There should be 1 job")
         self.assertEqual(len(jobs[0]['input_files']), 100, "All 100 files must be in the job")
+        self.assertEqual(jobs[0]['estimatedMemoryUsage'], 2300)
+        self.assertEqual(jobs[0]['estimatedDiskUsage'], 0)
+        self.assertEqual(jobs[0]['estimatedJobTime'], 0)
 
-        #Create 7 files, each one with different lumi/event distributions
+        # Create 7 files, each one with different lumi/event distributions
         testFileset = Fileset(name = "FilesetA")
         testFileset.create()
         testFileA = self.createFile("/this/is/file1", 250, 0, 5, "otherse.cern.ch")
@@ -234,28 +272,47 @@ class EventAwareLumiBasedTest(unittest.TestCase):
 
         jobFactory = splitter(package = "WMCore.WMBS",
                               subscription = testSubscription)
-        #Optimal settings are: jobs with 150 events per job
-        #This means, the first file must be splitted in 3 lumis per job which would leave room
-        #for another lumi in the second job, but the second file has a lumi too big for that
-        #The 3rd job only contains the second file, the fourth and fifth job split the third file
+        # Optimal settings are: jobs with 150 events per job
+        # This means, the first file must be splitted in 3 lumis per job which would leave room
+        # for another lumi in the second job, but the second file has a lumi too big for that
+        # The 3rd job only contains the second file, the fourth and fifth job split the third file
         jobGroups = jobFactory(halt_job_on_file_boundaries = False,
                                splitOnRun = False,
-                               events_per_job = 150)
+                               events_per_job = 150,
+                               performance = self.performanceParams)
 
         self.assertEqual(len(jobGroups), 1, "There should be only one job group")
         jobs = jobGroups[0].jobs
         self.assertEqual(len(jobs), 8, "Eight jobs must be in the jobgroup")
         self.assertEqual(jobs[0]["mask"].getRunAndLumis(), {0L : [[0L, 2L]]}, "Wrong mask for the first job")
+        self.assertEqual(jobs[0]["estimatedJobTime"], 150 * 12)
+        self.assertEqual(jobs[0]["estimatedDiskUsage"], 150 * 400)
         self.assertEqual(jobs[1]["mask"].getRunAndLumis(), {0L : [[3L, 4L]]}, "Wrong mask for the second job")
+        self.assertEqual(jobs[1]["estimatedJobTime"], 100 * 12)
+        self.assertEqual(jobs[1]["estimatedDiskUsage"], 100 * 400)
         self.assertEqual(jobs[2]["mask"].getRunAndLumis(), {1L : [[1L, 1L]]}, "Wrong mask for the third job")
+        self.assertEqual(jobs[2]["estimatedJobTime"], 600 * 12)
+        self.assertEqual(jobs[2]["estimatedDiskUsage"], 600 * 400)
         self.assertEqual(jobs[3]["mask"].getRunAndLumis(), {2L : [[4L, 4L]]}, "Wrong mask for the fourth job")
+        self.assertEqual(jobs[3]["estimatedJobTime"], 600 * 12)
+        self.assertEqual(jobs[3]["estimatedDiskUsage"], 600 * 400)
         self.assertEqual(jobs[4]["mask"].getRunAndLumis(), {2L : [[5L, 5L]]}, "Wrong mask for the fifth job")
+        self.assertEqual(jobs[4]["estimatedJobTime"], 600 * 12)
+        self.assertEqual(jobs[4]["estimatedDiskUsage"], 600 * 400)
         self.assertEqual(jobs[5]["mask"].getRunAndLumis(),
                          {3L : [[3L, 3L]], 4L : [[4L, 4L]], 5L : [[5L, 5L]]}, "Wrong mask for the sixth job")
+        self.assertEqual(jobs[5]["estimatedJobTime"], 140 * 12)
+        self.assertEqual(jobs[5]["estimatedDiskUsage"], 140 * 400)
         self.assertEqual(jobs[6]["mask"].getRunAndLumis(), {6L : [[18L, 19L]]}, "Wrong mask for the seventh job")
+        self.assertEqual(jobs[6]["estimatedJobTime"], (151.0 * 2 / 3) * 12)
+        self.assertEqual(jobs[6]["estimatedDiskUsage"], (151.0 * 2 / 3) * 400)
         self.assertEqual(jobs[7]["mask"].getRunAndLumis(), {6L : [[20L, 20L]]}, "Wrong mask for the seventh job")
-        #Test interactions of this algorithm with splitOnRun = True
-        #Make 2 files, one with 3 runs and a second one with the last run of the first
+        self.assertEqual(jobs[7]["estimatedJobTime"], (151.0 / 3) * 12)
+        self.assertEqual(jobs[7]["estimatedDiskUsage"], (151.0 / 3) * 400)
+        for job in jobs:
+            self.assertEqual(job["estimatedMemoryUsage"], 2300)
+        # Test interactions of this algorithm with splitOnRun = True
+        # Make 2 files, one with 3 runs and a second one with the last run of the first
         fileA = File(lfn = "/this/is/file1a", size = 1000,
                        events = 2400)
         lumiListA = []
@@ -285,15 +342,29 @@ class EventAwareLumiBasedTest(unittest.TestCase):
 
         jobFactory = splitter(package = "WMCore.WMBS",
                               subscription = testSubscription)
-        #The settings for this splitting are 700 events per job
+        # The settings for this splitting are 700 events per job
         jobGroups = jobFactory(splitOnRun = True,
                                halt_job_on_file_boundaries = False,
-                               events_per_job = 700)
+                               events_per_job = 700,
+                               performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1, "There should be only one job group")
         jobs = jobGroups[0].jobs
         self.assertEqual(len(jobs), 6, "Six jobs must be in the jobgroup")
+        self.assertEqual(jobs[0]["estimatedJobTime"], 700 * 12)
+        self.assertEqual(jobs[0]["estimatedDiskUsage"], 700 * 400)
+        self.assertEqual(jobs[1]["estimatedJobTime"], 100 * 12)
+        self.assertEqual(jobs[1]["estimatedDiskUsage"], 100 * 400)
+        self.assertEqual(jobs[2]["estimatedJobTime"], 700 * 12)
+        self.assertEqual(jobs[2]["estimatedDiskUsage"], 700 * 400)
+        self.assertEqual(jobs[3]["estimatedJobTime"], 100 * 12)
+        self.assertEqual(jobs[3]["estimatedDiskUsage"], 100 * 400)
+        self.assertEqual(jobs[4]["estimatedJobTime"], 700 * 12)
+        self.assertEqual(jobs[4]["estimatedDiskUsage"], 700 * 400)
+        self.assertEqual(jobs[5]["estimatedJobTime"], 300 * 12)
+        self.assertEqual(jobs[5]["estimatedDiskUsage"], 300 * 400)
 
-    def testC_HardLimitSpltting(self):
+
+    def testC_HardLimitSplitting(self):
         """
         _testC_HardLimitSplitting_
 
@@ -303,7 +374,7 @@ class EventAwareLumiBasedTest(unittest.TestCase):
         """
         splitter = SplitterFactory()
 
-        #Create 3 files, the one in the middle is a "bad" file
+        # Create 3 files, the one in the middle is a "bad" file
         testFileset = Fileset(name = "FilesetA")
         testFileset.create()
         testFileA = self.createFile("/this/is/file1", 1000, 0, 5, "somese.cern.ch")
@@ -321,12 +392,13 @@ class EventAwareLumiBasedTest(unittest.TestCase):
         testSubscription.create()
         jobFactory = splitter(package = "WMCore.WMBS",
                               subscription = testSubscription)
-        #Settings are to split on job boundaries, to fail sing lumis with more than 800 events
-        #and to put 550 events per job
+        # Settings are to split on job boundaries, to fail sing lumis with more than 800 events
+        # and to put 550 events per job
         jobGroups = jobFactory(halt_job_on_file_boundaries = True,
                                splitOnRun = True,
                                events_per_job = 550,
-                               max_events_per_lumi = 800)
+                               max_events_per_lumi = 800,
+                               performance = self.performanceParams)
 
         self.assertEqual(len(jobGroups), 1, "There should be only one job group")
         jobs = jobGroups[0].jobs
@@ -344,7 +416,7 @@ class EventAwareLumiBasedTest(unittest.TestCase):
         """
         splitter = SplitterFactory()
 
-        #Create 3 single-big-lumi files
+        # Create 3 single-big-lumi files
         testFileset = Fileset(name = "FilesetA")
         testFileset.create()
         testFileA = self.createFile("/this/is/file1", 1000, 0, 1, "somese.cern.ch")
@@ -362,17 +434,18 @@ class EventAwareLumiBasedTest(unittest.TestCase):
         testSubscription.create()
         jobFactory = splitter(package = "WMCore.WMBS",
                               subscription = testSubscription)
-        #Settings are to split on job boundaries, to fail sing lumis with more than 800 events
-        #and to put 550 events per job
+        # Settings are to split on job boundaries, to fail sing lumis with more than 800 events
+        # and to put 550 events per job
         jobGroups = jobFactory(halt_job_on_file_boundaries = True,
                                splitOnRun = True,
                                events_per_job = 550,
-                               max_events_per_lumi = 800)
+                               max_events_per_lumi = 800,
+                               performance = self.performanceParams)
 
         self.assertEqual(len(jobGroups), 1, "There should be only one job group")
         jobs = jobGroups[0].jobs
         self.assertEqual(len(jobs), 3, "Three jobs must be in the jobgroup")
-        for i in range(1,4):
+        for i in range(1, 4):
             self.assertTrue(jobs[i - 1]['failedOnCreation'], "The job processing the second file should me marked for failure")
             self.assertEqual(jobs[i - 1]['failedReason'], "File /this/is/file%d has too many events (1000) in 1 lumi(s)" % i,
                           "The reason for the failure is not accurate")

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/ParentlessMergeBySize_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/ParentlessMergeBySize_t.py
@@ -6,22 +6,17 @@ Unit tests for parentless WMBS merging.
 """
 
 import unittest
-import os
 import threading
 
 from WMCore.WMBS.File import File
 from WMCore.WMBS.Fileset import Fileset
-from WMCore.WMBS.Job import Job
-from WMCore.WMBS.JobGroup import JobGroup
 from WMCore.WMBS.Subscription import Subscription
 from WMCore.WMBS.Workflow import Workflow
 
 from WMCore.DataStructs.Run import Run
 
 from WMCore.DAOFactory import DAOFactory
-from WMCore.WMFactory import WMFactory
 from WMCore.JobSplitting.SplitterFactory import SplitterFactory
-from WMCore.Services.UUID import makeUUID
 from WMQuality.TestInit import TestInit
 
 class ParentlessMergeBySizeTest(unittest.TestCase):
@@ -190,6 +185,8 @@ class ParentlessMergeBySizeTest(unittest.TestCase):
         assert len(result[0].jobs) == 1, \
                "Error: One job should have been returned: %s" % len(result[0].jobs)
 
+        self.assertEqual(result[0].jobs[0]["estimatedDiskUsage"], 10 + 100)
+
         goldenFiles = ["file1", "file2", "file3", "file4", "fileA", "fileB",
                       "fileC", "fileI", "fileII", "fileIII", "fileIV"]
 
@@ -265,8 +262,10 @@ class ParentlessMergeBySizeTest(unittest.TestCase):
             jobFiles = job.getFiles()
 
             if jobFiles[0]["lfn"] in goldenFilesA:
+                self.assertEqual(job["estimatedDiskUsage"], 10)
                 goldenFiles = goldenFilesA
             elif jobFiles[0]["lfn"] in goldenFilesB:
+                self.assertEqual(job["estimatedDiskUsage"], 100)
                 goldenFiles = goldenFilesB
 
             currentRun = 0
@@ -340,8 +339,10 @@ class ParentlessMergeBySizeTest(unittest.TestCase):
             jobFiles = job.getFiles()
 
             if jobFiles[0]["lfn"] in goldenFilesA:
+                self.assertEqual(job["estimatedDiskUsage"], 9 + 100)
                 goldenFiles = goldenFilesA
             elif jobFiles[0]["lfn"] in goldenFilesB:
+                self.assertEqual(job["estimatedDiskUsage"], 1)
                 goldenFiles = goldenFilesB
 
             currentRun = 0
@@ -455,8 +456,10 @@ class ParentlessMergeBySizeTest(unittest.TestCase):
 
             jobLFNs.sort()
             if jobLFNs == goldenFilesA:
+                self.assertEqual(job["estimatedDiskUsage"], 7)
                 goldenFilesA = []
             else:
+                self.assertEqual(job["estimatedDiskUsage"], 3 + 100)
                 self.assertEqual(jobLFNs, goldenFilesB,
                                  "Error: LFNs do not match.")
                 goldenFilesB = []
@@ -496,10 +499,13 @@ class ParentlessMergeBySizeTest(unittest.TestCase):
             jobFiles = job.getFiles()
 
             if jobFiles[0]["lfn"] in goldenFilesA:
+                self.assertEqual(job["estimatedDiskUsage"], 7)
                 goldenFiles = goldenFilesA
             elif jobFiles[0]["lfn"] in goldenFilesB:
+                self.assertEqual(job["estimatedDiskUsage"], 3)
                 goldenFiles = goldenFilesB
             else:
+                self.assertEqual(job["estimatedDiskUsage"], 100)
                 goldenFiles = goldenFilesC
 
             currentRun = 0
@@ -572,10 +578,13 @@ class ParentlessMergeBySizeTest(unittest.TestCase):
             jobFiles = job.getFiles()
 
             if jobFiles[0]["lfn"] in goldenFilesA:
+                self.assertEqual(job["estimatedDiskUsage"], 7)
                 goldenFiles = goldenFilesA
             elif jobFiles[0]["lfn"] in goldenFilesB:
+                self.assertEqual(job["estimatedDiskUsage"], 2 + 100)
                 goldenFiles = goldenFilesB
             else:
+                self.assertEqual(job["estimatedDiskUsage"], 1)
                 goldenFiles = goldenFilesC
 
             currentRun = 0

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/WMBSMergeBySize_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/WMBSMergeBySize_t.py
@@ -6,7 +6,6 @@ Unit tests for generic WMBS merging.
 """
 
 import unittest
-import os
 import threading
 
 from WMCore.WMBS.File import File
@@ -19,9 +18,7 @@ from WMCore.WMBS.Workflow import Workflow
 from WMCore.DataStructs.Run import Run
 
 from WMCore.DAOFactory import DAOFactory
-from WMCore.WMFactory import WMFactory
 from WMCore.JobSplitting.SplitterFactory import SplitterFactory
-from WMCore.Services.UUID import makeUUID
 from WMQuality.TestInit import TestInit
 
 class WMBSMergeBySize(unittest.TestCase):
@@ -387,8 +384,10 @@ class WMBSMergeBySize(unittest.TestCase):
             jobFiles = job.getFiles()
 
             if len(jobFiles) == len(goldenFilesA):
+                self.assertEqual(job["estimatedDiskUsage"], 7)
                 goldenFiles = goldenFilesA
             else:
+                self.assertEqual(job["estimatedDiskUsage"], 4)
                 goldenFiles = goldenFilesB
 
             currentRun = 0
@@ -452,6 +451,8 @@ class WMBSMergeBySize(unittest.TestCase):
 
         assert len(result[0].jobs) == 1, \
                "ERROR: One job should have been returned."
+
+        self.assertEqual(result[0].jobs[0]["estimatedDiskUsage"], 7)
 
         jobFiles = list(result[0].jobs)[0].getFiles()
 
@@ -529,10 +530,13 @@ class WMBSMergeBySize(unittest.TestCase):
             jobFiles = job.getFiles()
 
             if jobFiles[0]["lfn"] in goldenFilesA:
+                self.assertEqual(job["estimatedDiskUsage"], 4)
                 goldenFiles = goldenFilesA
             elif jobFiles[0]["lfn"] in goldenFilesB:
+                self.assertEqual(job["estimatedDiskUsage"], 3)
                 goldenFiles = goldenFilesB
             else:
+                self.assertEqual(job["estimatedDiskUsage"], 4)
                 goldenFiles = goldenFilesC
 
             currentRun = 0
@@ -604,6 +608,8 @@ class WMBSMergeBySize(unittest.TestCase):
         goldenFilesA = ["file1", "file2", "file3", "file4"]
         goldenFilesB = ["fileA", "fileB", "fileC"]
         goldenFilesC = ["fileI", "fileII", "fileIII", "fileIV"]
+
+        self.assertEqual(result[0].jobs[0]["estimatedDiskUsage"], 7)
 
         jobFiles = list(result[0].jobs)[0].getFiles()
 
@@ -681,10 +687,13 @@ class WMBSMergeBySize(unittest.TestCase):
             jobFiles = job.getFiles()
 
             if jobFiles[0]["lfn"] in goldenFilesA:
+                self.assertEqual(job["estimatedDiskUsage"], 4)
                 goldenFiles = goldenFilesA
             elif jobFiles[0]["lfn"] in goldenFilesB:
+                self.assertEqual(job["estimatedDiskUsage"], 3)
                 goldenFiles = goldenFilesB
             else:
+                self.assertEqual(job["estimatedDiskUsage"], 4)
                 goldenFiles = goldenFilesC
 
             currentRun = 0
@@ -752,6 +761,8 @@ class WMBSMergeBySize(unittest.TestCase):
 
         assert len(result[0].jobs) == 1, \
                "ERROR: One job should have been returned."
+
+        self.assertEqual(result[0].jobs[0]["estimatedDiskUsage"], 7)
 
         goldenFilesA = ["file1", "file2", "file3", "file4"]
         goldenFilesB = ["fileA", "fileB", "fileC"]


### PR DESCRIPTION
On the way to better provisioning, some of the splitters are able
to "predict" how long a job will take based on time per event estimates,
how much disk it will require based on estimates of output size per event
and how much memory the job will require. This information is included in
the condor JDLs in the following values:

+MaxWallTimeMins : Time in minutes, used already by CRAB2, coordinating with the FE admins if central production is already set to use it.
request_memory : Standard condor attribute to request memory during the matchmaking. It's in MB
request_disk : Standard condor attribute to request disk space during the matchmaking. It's in KB

The list of algorithms which support estimates follows:

EventAwareLumiBased, EventBased, LumiBased, FileBased: Provides estimates for all 3 values, this covers all Processing/Production/Skim tasks.
WMBSMergeBySize, ParentlessMergeBySize: Provide very accurate estimates for the disk space. This covers all merge tasks.

The tasks which provide no estimates are:

Harvest, Cleanup, LogCollect : All these tasks are very fast and with very little requirements.
We may tailor some defaults for them in the future.

The initial idea included changing the estimates for time per event, size per event
and memory dynamically using couchDB information. However after giving some thought
I realized that with the current schema this is not useful and can be harmful. The case
is when the second block is split after only fast jobs have run, these will have
low time per event and memory usage which will trigger bad pilots for future jobs
and won't allow for correction.

The estimates will be only reliable in a model where we first fully process at least a block
before splitting the rest of the workload. This would give some guarantee that the sample
used for the performance information is somewhat representative.

Fixes #4472
