### PR TITLE
Catch empty lumi runs

### DIFF
--- a/src/python/WMCore/FwkJobReport/Report.py
+++ b/src/python/WMCore/FwkJobReport/Report.py
@@ -1324,8 +1324,14 @@ class Report:
         error = None
         files = self.getAllFilesFromStep(step = stepName)
         for f in files:
-            if not f.get('runs', {}):
+            if not f.get('runs', None):
                 error = f.get('lfn', None)
+            else:
+                for run in f['runs']:
+                    lumis = run.lumis
+                    if not lumis:
+                        error = f.get('lfn', None)
+                        break
         if error:
             msg = '%s, file was %s' % (WMJobErrorCodes[60452], error)
             self.addError(stepName, 60452, "NoRunLumiInformation", msg)

--- a/test/python/WMCore_t/FwkJobReport_t/Report_t.py
+++ b/test/python/WMCore_t/FwkJobReport_t/Report_t.py
@@ -747,9 +747,7 @@ cms::Exception caught in EventProcessor and rethrown
                         "Error: Report XML doesn't have the module for the test, invalid test")
 
         originalOutputModules = len(originalReport.retrieveStep("cmsRun1").outputModules)
-        print originalReport.data
         originalReport.deleteOutputModuleForStep("cmsRun1", "outputALCARECORECO")
-        print originalReport.data
         self.assertFalse(originalReport.getOutputModule("cmsRun1", "outputALCARECORECO"),
                         "Error: The output module persists after deletion")
         self.assertEqual(len(originalReport.retrieveStep("cmsRun1").outputModules), originalOutputModules - 1,


### PR DESCRIPTION
Improve on 851acb4d94fc20d07d15b6aa3fe94d82c43aa2ed to catch
the cases where the runs dictionary is not empty but the lumi lists
are empty for a run in the report.
