### PR TITLE
Avoid re-running performance killed jobs

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -200,6 +200,7 @@ config.ErrorHandler.logLevel = globalLogLevel
 config.ErrorHandler.maxRetries = maxJobRetries
 config.ErrorHandler.pollInterval = 240
 config.ErrorHandler.readFWJR = True
+config.ErrorHandler.failureExitCodes = [50660, 50661, 50664]
 
 config.component_("RetryManager")
 config.RetryManager.namespace = "WMComponent.RetryManager.RetryManager"

--- a/src/python/WMComponent/ErrorHandler/ErrorHandlerPoller.py
+++ b/src/python/WMComponent/ErrorHandler/ErrorHandlerPoller.py
@@ -224,15 +224,15 @@ class ErrorHandlerPoller(BaseWorkerThread):
                     exhaustJobs.append(job)
                     continue
 
-                if report.getExitCode() in self.exitCodes:
-                    msg = "Job %i exhausted due to exitCode %s" % (job['id'], report.getExitCode())
+                if len([x for x in report.getExitCodes() if x in self.exitCodes]):
+                    msg = "Job %i exhausted due to a bad exit code (%s)" % (job['id'], str(report.getExitCodes()))
                     logging.error(msg)
                     self.sendAlert(4, msg = msg)
                     exhaustJobs.append(job)
                     continue
 
-                if report.getExitCode() in self.passCodes:
-                    msg = "Job %i restarted immediately due to exitCode %i" % (job['id'], report.getExitCode())
+                if len([x for x in report.getExitCodes() if x in self.passCodes]):
+                    msg = "Job %i restarted immediately due to an exit code (%s)" % (job['id'], str(report.getExitCodes()))
                     passJobs.append(job)
                     continue
 

--- a/src/python/WMCore/FwkJobReport/Report.py
+++ b/src/python/WMCore/FwkJobReport/Report.py
@@ -275,6 +275,33 @@ class Report:
         """
         return getattr(self.data, 'siteName', {})
 
+    def getExitCodes(self):
+        """
+        _getExitCodes_
+
+        Return a list of all non-zero exit codes in the report
+        """
+        returnCodes = set()
+        for stepName in self.listSteps():
+            returnCodes.update(self.getStepExitCodes(stepName = stepName))
+        return returnCodes
+
+    def getStepExitCodes(self, stepName):
+        """
+        _getStepExitCodes_
+
+        Returns a list of all non-zero exit codes in the step
+        """
+        returnCodes = set()
+        reportStep = self.retrieveStep(stepName)
+        errorCount = getattr(reportStep.errors, "errorCount", 0)
+        for i in range(errorCount):
+            reportError = getattr(reportStep.errors, "error%i" % i)
+            if getattr(reportError, 'exitCode', None):
+                returnCodes.add(int(reportError.exitCode))
+
+        return returnCodes
+
     def getExitCode(self):
         """
         _getExitCode_

--- a/src/python/WMCore/WMExceptions.py
+++ b/src/python/WMCore/WMExceptions.py
@@ -22,10 +22,16 @@ WMEXCEPTION = {'WMCore-1' : 'Not allowed to instantiate ',
 
 """
 WMJobErrorCodes
-List of job error codes present in WMCOre, some of them coming from CMSSW, and a description
+List of job error codes present in WMCore, some of them coming from CMSSW, and a description
 of the error it represents.
 """
-WMJobErrorCodes = {60452 :
+WMJobErrorCodes = {50660 :
+                        "Application terminated by wrapper for using too much RSS",
+                    50661 :
+                        "Application terminated by wrapper for using too much VSZ",
+                    50664 :
+                        "Application terminated by wrapper for using too much wallclock time",
+                    60452 :
                         "No run and lumi information in a file produced by cmsRun",
                     61101 :
                         "No sites are available to submit the job because the location of its input(s)"


### PR DESCRIPTION
Improve the exit code handling in the ErrorHandler,
retrieve a list instead of a single random non-zero exit code.
Compare the list against the exit and pass list.
Change the exit codes for performance kills to make them identifiable,
include them in the default configurable list or exit codes.

Fixes #4473
