### PR TITLE
Store correctly the SizePerEvent and friends

### DIFF
--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
@@ -634,7 +634,10 @@ def requestDetails(requestName):
     schema['AcquisitionEra']  = str(helper.getAcquisitionEra())
     if schema['SoftwareVersions'] == ['DEPRECATED']:
         schema['SoftwareVersions'] = helper.getCMSSWVersions()
-        
+
+    # Check in the CouchWorkloadDBName if not present
+    schema.setdefault("CouchWorkloadDBName", "reqmgr_workload_cache")
+
     # get DbsUrl from CouchDB
     if schema.get("CouchWorkloadDBName", None) and schema.get("CouchURL", None):
         couchDb = Database(schema["CouchWorkloadDBName"], schema["CouchURL"])

--- a/src/python/WMCore/RequestManager/RequestDB/Interface/Request/MakeRequest.py
+++ b/src/python/WMCore/RequestManager/RequestDB/Interface/Request/MakeRequest.py
@@ -168,12 +168,13 @@ def associateSoftware(requestName, softwareName):
 
 
 
-def updateRequestSize(requestName, reqEventsSize, reqFilesSize = None, reqSizeOfEvent = None):
+def updateRequestSize(requestName, reqEventsSize,
+                      reqFilesSize, reqSizeOfEvent):
     """
     _updateRequestSize_
 
     Update the size of the request in events to be generated/read
-    and optionally  the number of files to be read for processing
+    and the number of files to be read for processing
     requests
 
     """

--- a/src/python/WMCore/RequestManager/RequestDB/MySQL/Request/Size.py
+++ b/src/python/WMCore/RequestManager/RequestDB/MySQL/Request/Size.py
@@ -17,24 +17,30 @@ class Size(DBFormatter):
     Update the event and file size values for a request
 
     """
-    def execute(self, requestId, eventSize, fileSize = None,
-                sizeOfEvent = None, conn = None, trans = False):
+    def execute(self, requestId, eventSize, fileSize,
+                sizeOfEvent, conn = None, trans = False):
         """
         _execute_
 
         Update the event and file sizes for the request Id provided
         """
 
+        if eventSize is None:
+            eventSize = 0
+        if fileSize is None:
+            fileSize = 0
+        if sizeOfEvent is None:
+            sizeOfEvent = 0
 
-        self.sql = "UPDATE reqmgr_request SET request_num_events=:event_size"
-        binds = {"event_size": int(eventSize), "request_id": requestId}
-        if fileSize != None:
-            self.sql += ",request_size_files=:file_size"
-            binds["file_size"] = int(fileSize)
-        if sizeOfEvent != None:
-            self.sql += ",request_event_size = :size_of_event"
-            binds['size_of_event'] = int(sizeOfEvent)
-        self.sql += " WHERE request_id=:request_id"
+        self.sql = """UPDATE reqmgr_request SET request_num_events = :event_size,
+                        request_size_files = :file_size,
+                        request_event_size = :size_of_event
+                        WHERE request_id = :request_id
+                    """
+        binds = {"event_size": int(eventSize), "request_id": requestId,
+                 "file_size" : int(fileSize),
+                 "size_of_event" : int(sizeOfEvent)}
+
         result = self.dbi.processData(self.sql, binds,
                                       conn = conn, transaction = trans)
         return self.format(result)

--- a/src/python/WMCore/RequestManager/RequestMaker/CheckIn.py
+++ b/src/python/WMCore/RequestManager/RequestMaker/CheckIn.py
@@ -138,10 +138,9 @@ def checkIn(request, requestType = 'None'):
     except Exception, ex:
         _raiseCheckInError(request, ex, "Unable to associate software for this request")
 
-    if request["RequestNumEvents"] != None:
-        MakeRequest.updateRequestSize(requestName, request["RequestNumEvents"],
-                                      request.get("RequestSizeFiles", 0),
-                                      request.get("SizePerEvent", 0))
+    MakeRequest.updateRequestSize(requestName, request.get("RequestNumEvents", 0),
+                                  request.get("RequestSizeFiles", 0),
+                                  request.get("SizePerEvent", 0))
         
     campaign = request.get("Campaign", "")
     if campaign != "" and campaign != None:

--- a/test/python/WMCore_t/RequestManager_t/ReqMgrWorkload_t.py
+++ b/test/python/WMCore_t/RequestManager_t/ReqMgrWorkload_t.py
@@ -318,6 +318,9 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         self.assertEqual(request['Group'], groupName)
         self.assertEqual(request['Requestor'], userName)
         self.assertEqual(request['DbsUrl'], 'http://cmsdbsprod.cern.ch/cms_dbs_prod_global/servlet/DBSServlet')
+        self.assertEqual(request['SizePerEvent'], 512)
+        self.assertEqual(request['RequestNumEvents'], 0)
+        self.assertEqual(request['RequestSizeFiles'], 0)
 
     @attr('integration')
     def testE_StoreResults(self):
@@ -493,6 +496,10 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         self.assertEqual(request['Group'], groupName)
         self.assertEqual(request['Requestor'], userName)
         self.assertEqual(request['DbsUrl'], 'http://cmsdbsprod.cern.ch/cms_dbs_prod_global/servlet/DBSServlet')
+        self.assertEqual(request['SizePerEvent'], 512)
+        self.assertEqual(request['RequestNumEvents'], 0)
+        self.assertEqual(request['RequestSizeFiles'], 0)
+
 
     def testH_MonteCarlo(self):
         """
@@ -565,7 +572,9 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         self.assertEqual(request['Group'], groupName)
         self.assertEqual(request['Requestor'], userName)
         self.assertEqual(request['DbsUrl'], schema['DbsUrl'])
-
+        self.assertEqual(request['SizePerEvent'], 512)
+        self.assertEqual(request['RequestNumEvents'], 100)
+        self.assertEqual(request['RequestSizeFiles'], 0)
 
     def testI_RelValMC(self):
         """
@@ -775,7 +784,9 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         self.assertEqual(request['Group'], groupName)
         self.assertEqual(request['Requestor'], userName)
         self.assertEqual(request['DbsUrl'], schema['DbsUrl'])
-
+        self.assertEqual(request['SizePerEvent'], 512)
+        self.assertEqual(request['RequestNumEvents'], 100)
+        self.assertEqual(request['RequestSizeFiles'], 0)
 
 if __name__=='__main__':
     unittest.main()


### PR DESCRIPTION
Make sure that SizePerEvent is stored correctly in CouchDB and Oracle
if present, it goes in hand with RequestSizeFiles and RequestNumEvents
but these two are not really present in any request schema
so they will be always zero, only SizePerEvent is mandatory.

Also fix the clone and assign of requests pre-upgrade.
