### PR TITLE
Fix broken DBS3Buffer creation in Oracle

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/Oracle/Create.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/Create.py
@@ -234,7 +234,7 @@ class Create(DBCreator):
                block_close_max_wait_time    NUMBER(11),
                block_close_max_files        NUMBER(11),
                block_close_max_events       NUMBER(11),
-               block_close_max_size         NUMBER(11),
+               block_close_max_size         NUMBER(11)
                ) %s """ % tablespaceTable
 
         self.create["10dbsbuffer_workflow_seq"] = \


### PR DESCRIPTION
It was broken in 0.9.58, just a typo.

We need a new tag for WMAgent since 0.9.58 can't be deployed with an Oracle backend due to this bug. @sfoulkes, can you make one ASAP please?
