### PR TITLE
Fix cases where performance parameters are None

### DIFF
--- a/src/python/WMCore/JobSplitting/JobFactory.py
+++ b/src/python/WMCore/JobSplitting/JobFactory.py
@@ -408,7 +408,7 @@ class JobFactory(WMObject):
         It returns a tuple with the following values:
         timePerEvent, sizePerEvent, memoryRequirement
         """
-        timePerEvent = defaultParams.get('timePerEvent', 0)
-        sizePerEvent = defaultParams.get('sizePerEvent', 0)
-        memory = defaultParams.get('memoryRequirement', 0)
+        timePerEvent = defaultParams.get('timePerEvent', None) or 0
+        sizePerEvent = defaultParams.get('sizePerEvent', None) or 0
+        memory = defaultParams.get('memoryRequirement', None) or 0
         return timePerEvent, sizePerEvent, memory

--- a/test/python/WMCore_t/JobSplitting_t/EventBased_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/EventBased_t.py
@@ -61,7 +61,7 @@ class EventBasedTest(unittest.TestCase):
                                                   split_algo = "EventBased",
                                                   type = "Processing")
 
-        self.performanceParams = {'timePerEvent' : 12,
+        self.performanceParams = {'timePerEvent' : None,
                                   'memoryRequirement' : 2300,
                                   'sizePerEvent' : 400}
 


### PR DESCRIPTION
TaskChain requests are bugged in current cmsweb, not
propagating valid values for the performance parameters.

Make sure it doesn't crash the JobCreator.
