### PR TITLE
Priority handling improvement

### DIFF
--- a/src/couchapps/WorkQueue/lists/workRestrictions.js
+++ b/src/couchapps/WorkQueue/lists/workRestrictions.js
@@ -118,17 +118,9 @@ function(head, req) {
                 send(",");
             }
             send(toJSON(row["doc"])); // need whole document, id etc...
-            var jobs = ele['Jobs'];
-            var slots = resources[site];
-            if (slots - jobs > 0) {
-                resources[site] = slots - jobs;
-            } else {
-                delete resources[site];
-            }
 
             first = false; // from now on prepend "," to output
             break; // we have work, move to next element (break out of site loop)
-
         } // end resources
     } // end rows
 

--- a/src/python/WMComponent/WorkQueueManager/WorkQueueManagerWMBSFileFeeder.py
+++ b/src/python/WMComponent/WorkQueueManager/WorkQueueManagerWMBSFileFeeder.py
@@ -57,13 +57,13 @@ class WorkQueueManagerWMBSFileFeeder(BaseWorkerThread):
         self.queue.logger.info("Getting work and feeding WMBS files")
 
         # need to make sure jobs are created
-        resources = freeSlots(minusRunning = True, allowedStates = ['Normal', 'Draining'],
+        resources, jobCounts = freeSlots(minusRunning = True, allowedStates = ['Normal', 'Draining'],
                               knownCmsSites = cmsSiteNames())
 
         for site in resources:
             self.queue.logger.info("I need %d jobs on site %s" % (resources[site], site))
 
-        self.previousWorkList = self.queue.getWork(resources)
+        self.previousWorkList = self.queue.getWork(resources, jobCounts)
         self.queue.logger.info("%s of units of work acquired for file creation"
                                % len(self.previousWorkList))
         return

--- a/src/python/WMCore/BossAir/RunJob.py
+++ b/src/python/WMCore/BossAir/RunJob.py
@@ -28,7 +28,7 @@ class RunJob(dict):
                  taskType = None, possibleSites = [], sw_version = None,
                  scram_arch = None, siteName = None, jobName = None,
                  proxyPath = None, requestName = None, jobTime = None,
-                 diskUsage = None, memoryUsage = None):
+                 diskUsage = None, memoryUsage = None, taskPriority = None):
         """
         Just make sure you init the dictionary fields.
 
@@ -65,6 +65,7 @@ class RunJob(dict):
         self.setdefault('estimatedJobTime', jobTime)
         self.setdefault('estimatedDiskUsage', diskUsage)
         self.setdefault('estimatedMemoryUsage', memoryUsage)
+        self.setdefault('taskPriority', taskPriority)
 
         return
 

--- a/src/python/WMCore/DataStructs/Workflow.py
+++ b/src/python/WMCore/DataStructs/Workflow.py
@@ -11,7 +11,7 @@ class Workflow(Pickleable):
     def __init__(self, spec = None, owner = "unknown", dn = "unknown",
                  group = "unknown", owner_vogroup = "unknown",
                  owner_vorole = "unknown", name = None, task = None,
-                 wfType = None):
+                 wfType = None, priority = None):
         self.spec = spec
         self.name = name
         # person making the request
@@ -24,6 +24,7 @@ class Workflow(Pickleable):
         self.task = task
         self.wfType = wfType
         self.outputMap = {}
+        self.priority = priority or 0
 
     def addOutput(self, outputIdentifier, outputFileset,
                   mergedOutputFileset = None):

--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
@@ -248,8 +248,7 @@ def changePriority(requestName, priority, wmstatUrl = None):
     # change priority in CouchDB
     couchDb = Database(request["CouchWorkloadDBName"], request["CouchURL"])
     fields = {"RequestPriority": newPrior}
-    couchDb.updateDocument(requestName, "ReqMgr", "updaterequest", fields=fields) 
-    
+    couchDb.updateDocument(requestName, "ReqMgr", "updaterequest", fields=fields)
 
 def abortRequest(requestName):
     """ Changes the state of the request to "aborted", and asks the work queue

--- a/src/python/WMCore/ResourceControl/ResourceControl.py
+++ b/src/python/WMCore/ResourceControl/ResourceControl.py
@@ -156,10 +156,10 @@ class ResourceControl(WMConnectionBase):
         """
         _listThresholdsForCreate_
 
-        This will return a two level dictionary with the first level being
+        This will return a three level dictionary with the first level being
         keyed by site name.  The second level will have the following keys:
           total_slots - Total number of pending slots available at the site
-          pending_jobs - Total number of jobs pending at the site
+          pending_jobs - Total number of jobs pending at the site per priority level, it is a dictionary
         """
         listAction = self.daofactory(classname = "ListThresholdsForCreate")
         return listAction.execute(conn = self.getDBConn(),

--- a/src/python/WMCore/WMBS/CreateWMBSBase.py
+++ b/src/python/WMCore/WMBS/CreateWMBSBase.py
@@ -147,14 +147,15 @@ class CreateWMBSBase(DBCreator):
 
         self.create["07wmbs_workflow"] = \
           """CREATE TABLE wmbs_workflow (
-             id           INTEGER      PRIMARY KEY AUTO_INCREMENT,
-             spec         VARCHAR(550) NOT NULL,
-             name         VARCHAR(255) NOT NULL,
-             task         VARCHAR(550) NOT NULL,
+             id           INTEGER          PRIMARY KEY AUTO_INCREMENT,
+             spec         VARCHAR(550)     NOT NULL,
+             name         VARCHAR(255)     NOT NULL,
+             task         VARCHAR(550)     NOT NULL,
              type         VARCHAR(255),
-             owner        INTEGER      NOT NULL,
-             alt_fs_close INT(1)       NOT NULL,
-             injected     INT(1)       DEFAULT 0,
+             owner        INTEGER          NOT NULL,
+             alt_fs_close INT(1)           NOT NULL,
+             injected     INT(1)           DEFAULT 0,
+             priority     INTEGER UNSIGNED DEFAULT 0,
              UNIQUE(name, task),
              FOREIGN KEY(owner)    REFERENCES wmbs_users(id)
                ON DELETE CASCADE)"""

--- a/src/python/WMCore/WMBS/MySQL/Jobs/ListForSubmitter.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/ListForSubmitter.py
@@ -16,7 +16,8 @@ class ListForSubmitter(DBFormatter):
                     wmbs_sub_types.name AS type, wmbs_job.retry_count AS retry_count,
                     wmbs_subscription.workflow as workflow,
                     wmbs_subscription.last_update as timestamp,
-                    wmbs_workflow.name as request_name
+                    wmbs_workflow.name as request_name,
+                    wmbs_workflow.priority as task_priority
                     FROM wmbs_job
                INNER JOIN wmbs_jobgroup ON
                  wmbs_job.jobgroup = wmbs_jobgroup.id

--- a/src/python/WMCore/WMBS/MySQL/Workflow/LoadFromID.py
+++ b/src/python/WMCore/WMBS/MySQL/Workflow/LoadFromID.py
@@ -12,7 +12,7 @@ class LoadFromID(DBFormatter):
                     wmbs_users.cert_dn as dn, wmbs_users.owner as owner,
                     wmbs_users.grp as grp, wmbs_users.group_name as vogrp,
                     wmbs_users.role_name as vorole, wmbs_workflow.task,
-                    wmbs_workflow.type
+                    wmbs_workflow.type, wmbs_workflow.priority
              FROM wmbs_workflow
              INNER JOIN wmbs_users ON
                wmbs_workflow.owner = wmbs_users.id

--- a/src/python/WMCore/WMBS/MySQL/Workflow/LoadFromName.py
+++ b/src/python/WMCore/WMBS/MySQL/Workflow/LoadFromName.py
@@ -12,7 +12,7 @@ class LoadFromName(DBFormatter):
                     wmbs_users.cert_dn as dn, wmbs_users.owner as owner,
                     wmbs_users.grp as grp, wmbs_users.group_name as vogrp,
                     wmbs_users.role_name as vorole, wmbs_workflow.task,
-                    wmbs_workflow.type
+                    wmbs_workflow.type, wmbs_workflow.priority
              FROM wmbs_workflow
              INNER JOIN wmbs_users ON
                wmbs_workflow.owner = wmbs_users.id

--- a/src/python/WMCore/WMBS/MySQL/Workflow/LoadFromSpecOwner.py
+++ b/src/python/WMCore/WMBS/MySQL/Workflow/LoadFromSpecOwner.py
@@ -12,7 +12,7 @@ class LoadFromSpecOwner(DBFormatter):
                     wmbs_users.cert_dn as dn, wmbs_users.owner as owner,
                     wmbs_users.grp as grp, wmbs_users.group_name as vogrp,
                     wmbs_users.role_name as vorole, wmbs_workflow.task,
-                    wmbs_workflow.type
+                    wmbs_workflow.type, wmbs_workflow.priority
              FROM wmbs_workflow
              INNER JOIN wmbs_users ON
                wmbs_workflow.owner = wmbs_users.id

--- a/src/python/WMCore/WMBS/MySQL/Workflow/New.py
+++ b/src/python/WMCore/WMBS/MySQL/Workflow/New.py
@@ -11,12 +11,13 @@ class New(DBFormatter):
     """
     Create a workflow ready for subscriptions
     """
-    sql = """insert into wmbs_workflow (spec, owner, name, task, type, alt_fs_close)
-                values (:spec, :owner, :name, :task, :type, :alt_fs_close)"""
+    sql = """insert into wmbs_workflow (spec, owner, name, task, type, alt_fs_close, priority)
+                values (:spec, :owner, :name, :task, :type, :alt_fs_close, :priority)"""
 
     def execute(self, spec = None, owner = None, name = None, task = None,
-                wfType = None, alt_fs_close = False, conn = None, transaction = False):
+                wfType = None, alt_fs_close = False, priority = None,
+                conn = None, transaction = False):
         binds = {"spec": spec, "owner": owner, "name": name, "task": task,
-                 "type": wfType, "alt_fs_close": int(alt_fs_close)}
+                 "type": wfType, "alt_fs_close": int(alt_fs_close), "priority" : priority}
         self.dbi.processData(self.sql, binds, conn = conn, transaction = transaction)
         return

--- a/src/python/WMCore/WMBS/Oracle/Create.py
+++ b/src/python/WMCore/WMBS/Oracle/Create.py
@@ -234,7 +234,8 @@ class Create(CreateWMBSBase):
                type  VARCHAR(255),
                owner INTEGER      NOT NULL,
                alt_fs_close INTEGER NOT NULL,
-               injected INTEGER   DEFAULT 0
+               injected INTEGER   DEFAULT 0,
+               priority INTEGER   DEFAULT 0
                ) %s""" % tablespaceTable
 
         self.indexes["01_pk_wmbs_workflow"] = \

--- a/src/python/WMCore/WMBS/Oracle/Workflow/New.py
+++ b/src/python/WMCore/WMBS/Oracle/Workflow/New.py
@@ -8,5 +8,5 @@ Oracle implementation of NewWorkflow
 from WMCore.WMBS.MySQL.Workflow.New import New as NewWorkflowMySQL
 
 class New(NewWorkflowMySQL):
-    sql = """insert into wmbs_workflow (id, spec, owner, name, task, type, alt_fs_close)
-             values (wmbs_workflow_SEQ.nextval, :spec, :owner, :name, :task, :type, :alt_fs_close)"""
+    sql = """insert into wmbs_workflow (id, spec, owner, name, task, type, alt_fs_close, priority)
+             values (wmbs_workflow_SEQ.nextval, :spec, :owner, :name, :task, :type, :alt_fs_close, :priority)"""

--- a/src/python/WMCore/WMBS/Workflow.py
+++ b/src/python/WMCore/WMBS/Workflow.py
@@ -36,12 +36,13 @@ class Workflow(WMBSBase, WMWorkflow):
     def __init__(self, spec = None, owner = "unknown", dn = "unknown",
                  group = "unknown", owner_vogroup = "DEFAULT",
                  owner_vorole = "DEFAULT", name = None, task = None,
-                 wfType = None, id = -1, alternativeFilesetClose = False):
+                 wfType = None, id = -1, alternativeFilesetClose = False,
+                 priority = None):
         WMBSBase.__init__(self)
         WMWorkflow.__init__(self, spec = spec, owner = owner, dn = dn,
                             group = group, owner_vogroup = owner_vogroup,
                             owner_vorole = owner_vorole, name = name,
-                            task = task, wfType = wfType)
+                            task = task, wfType = wfType, priority = priority)
 
         if self.dn == "unknown":
             self.dn = owner
@@ -118,6 +119,7 @@ class Workflow(WMBSBase, WMWorkflow):
         action.execute(spec = self.spec, owner = userid, name = self.name,
                        task = self.task, wfType = self.wfType,
                        alt_fs_close = self.alternativeFilesetClose,
+                       priority = self.priority,
                        conn = self.getDBConn(),
                        transaction = self.existingTransaction())
 
@@ -174,6 +176,7 @@ class Workflow(WMBSBase, WMWorkflow):
         self.vogroup = result["vorole"]
         self.task = result["task"]
         self.wfType = result["type"]
+        self.priority = result["priority"]
 
         action = self.daofactory(classname = "Workflow.LoadOutput")
         results = action.execute(workflow = self.id, conn = self.getDBConn(),

--- a/src/python/WMCore/WorkQueue/DataStructs/WorkQueueElement.py
+++ b/src/python/WMCore/WorkQueue/DataStructs/WorkQueueElement.py
@@ -34,7 +34,7 @@ class WorkQueueElement(dict):
         self.setdefault('PileupData', {})
         #both ParentData and ParentFlag is needed in case there Dataset split,
         # even though ParentFlag is True it will have empty ParentData
-        self.setdefault('ParentData', [])
+        self.setdefault('ParentData', {})
         self.setdefault('ParentFlag', False)
         # 0 jobs are valid where we need to accept all blocks (only dqm etc subscriptions will run)
         self.setdefault('Jobs', None)
@@ -215,6 +215,16 @@ class WorkQueueElement(dict):
         for locations in self['Inputs'].values():
             if site not in locations:
                 return False
+        # Parent data as well
+        if self['ParentFlag']:
+            for locations in self['ParentData'].values():
+                if site not in locations:
+                    return False
+
+        # Pileup data must be checked
+        for locations in self['PileupData'].values():
+            if site not in locations:
+                return False
 
         # workflow restrictions
         if self['SiteWhitelist'] and site not in self['SiteWhitelist']:
@@ -222,3 +232,4 @@ class WorkQueueElement(dict):
         if site in self['SiteBlacklist']:
             return False
         return True
+

--- a/src/python/WMQuality/Emulators/RequestManagerClient/RequestManager.py
+++ b/src/python/WMQuality/Emulators/RequestManagerClient/RequestManager.py
@@ -64,7 +64,8 @@ class RequestManager(dict):
             raise RuntimeError, "unknown request %s" % requestName
 
         request = {'RequestName' : requestName,
-                   'RequestStatus' : self.status[requestName]}
+                   'RequestStatus' : self.status[requestName],
+                   'Priority' : 100}
         if self.progress.has_key(requestName):
             request.update(self.progress[requestName])
         request.setdefault('percent_complete', 0)

--- a/src/python/WMQuality/Emulators/WMAgents/WMAgentTasks.py
+++ b/src/python/WMQuality/Emulators/WMAgents/WMAgentTasks.py
@@ -29,7 +29,7 @@ class WMAgentTasks(BaseWorkerThread):
         """
         """
 
-        data = self.wq.getWork(self.resources)
+        data = self.wq.getWork(self.resources, {})
         print "Data back from workqueue"
         print "%s: %s" % (self.resources, data)
         if len(data) != 0:

--- a/test/python/WMCore_t/ResourceControl_t/ResourceControl_t.py
+++ b/test/python/WMCore_t/ResourceControl_t/ResourceControl_t.py
@@ -237,14 +237,14 @@ class ResourceControlTest(unittest.TestCase):
         self.assertEqual( createThresholds["testSite1"]["total_slots"], 10,
                           "Error: Wrong number of total slots." )
 
-        self.assertEqual( createThresholds["testSite1"]["pending_jobs"], 0,
+        self.assertEqual( createThresholds["testSite1"]["pending_jobs"], {0 : 0},
                           "Error: Wrong number of running jobs: %s" %
                               createThresholds["testSite1"]["pending_jobs"] )
 
         self.assertEqual( createThresholds["testSite2"]["total_slots"], 100,
                           "Error: Wrong number of total slots." )
 
-        self.assertEqual( createThresholds["testSite2"]["pending_jobs"], 0,
+        self.assertEqual( createThresholds["testSite2"]["pending_jobs"], {0 : 0},
                           "Error: Wrong number of running jobs." )
 
         thresholds = myResourceControl.listThresholdsForSubmit()
@@ -395,12 +395,12 @@ class ResourceControlTest(unittest.TestCase):
         # We should have two running jobs with locations at site one,
         # two running jobs without locations at site two, and one running
         # job without a location at site one and two.
-        self.assertEqual( createThresholds["testSite1"]["pending_jobs"], 4,
+        self.assertEqual( createThresholds["testSite1"]["pending_jobs"], {0 : 4},
                "Error: Wrong number of pending jobs for site 1" )
 
         # We should have one running job with a location at site 2 and
         # another running job without a location.
-        self.assertEqual( createThresholds["testSite2"]["pending_jobs"], 2,
+        self.assertEqual( createThresholds["testSite2"]["pending_jobs"], {0 : 2},
                "Error: Wrong number of pending jobs for site 2" )
 
         # We should also have a phedex_name

--- a/test/python/WMCore_t/WMBS_t/Workflow_t.py
+++ b/test/python/WMCore_t/WMBS_t/Workflow_t.py
@@ -143,7 +143,8 @@ class WorkflowTest(unittest.TestCase):
           Workflow.LoadFromSpecOwner
         """
         testWorkflowA = Workflow(spec = "spec.xml", owner = "Simon",
-                                 name = "wf001", task='Test', wfType="ReReco")
+                                 name = "wf001", task='Test', wfType="ReReco",
+                                 priority = 1000)
         testWorkflowA.create()
 
         testWorkflowB = Workflow(name = "wf001", task='Test')
@@ -154,7 +155,8 @@ class WorkflowTest(unittest.TestCase):
                         (testWorkflowA.spec == testWorkflowB.spec) and
                         (testWorkflowA.task == testWorkflowB.task) and
                         (testWorkflowA.wfType == testWorkflowB.wfType) and
-                        (testWorkflowA.owner == testWorkflowB.owner),
+                        (testWorkflowA.owner == testWorkflowB.owner) and
+                        (testWorkflowA.priority == testWorkflowB.priority),
                         "ERROR: Workflow.LoadFromName Failed")
 
         testWorkflowC = Workflow(id = testWorkflowA.id)
@@ -165,7 +167,8 @@ class WorkflowTest(unittest.TestCase):
                         (testWorkflowA.spec == testWorkflowC.spec) and
                         (testWorkflowA.task == testWorkflowC.task) and
                         (testWorkflowA.wfType == testWorkflowC.wfType) and
-                        (testWorkflowA.owner == testWorkflowC.owner),
+                        (testWorkflowA.owner == testWorkflowC.owner) and
+                        (testWorkflowA.priority == testWorkflowB.priority),
                         "ERROR: Workflow.LoadFromID Failed")
 
         testWorkflowD = Workflow(spec = "spec.xml", owner = "Simon", task='Test')
@@ -176,9 +179,9 @@ class WorkflowTest(unittest.TestCase):
                         (testWorkflowA.spec == testWorkflowD.spec) and
                         (testWorkflowA.task == testWorkflowD.task) and
                         (testWorkflowA.wfType == testWorkflowD.wfType) and
-                        (testWorkflowA.owner == testWorkflowD.owner),
+                        (testWorkflowA.owner == testWorkflowD.owner) and
+                        (testWorkflowA.priority == testWorkflowB.priority),
                         "ERROR: Workflow.LoadFromSpecOwner Failed")
-
         testWorkflowA.delete()
         return
 

--- a/test/python/WMCore_t/WorkQueue_t/LocalQueueProfile_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/LocalQueueProfile_t.py
@@ -84,7 +84,7 @@ class LocalWorkQueueProfileTest(WorkQueueTestCase):
         siteJobs = {}
         for site in Globals.SITES:
             siteJobs[site] = 100000
-        self.localQueue.getWork(siteJobs)
+        self.localQueue.getWork(siteJobs, {})
 
 
 if __name__ == "__main__":

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueueBackend_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueueBackend_t.py
@@ -62,13 +62,13 @@ class WorkQueueBackendTest(unittest.TestCase):
                                          Status = 'Available',
                                          Jobs = 10, Priority = 0.1)
         self.backend.insertElements([element])
-        self.backend.availableWork({'place' : 1000})
+        self.backend.availableWork({'place' : 1000}, {})
         # timestamp in elements have second coarseness, 2nd element must
         # have a higher timestamp to force it after the 1st
         time.sleep(1)
         self.backend.insertElements([lowprielement, element2, highprielement])
-        self.backend.availableWork({'place' : 1000})
-        work = self.backend.availableWork({'place' : 1000})
+        self.backend.availableWork({'place' : 1000}, {})
+        work = self.backend.availableWork({'place' : 1000}, {})
         # order should be high to low, with the standard elements in the order
         # they were queueud
         self.assertEqual([x['RequestName'] for x in work[0]],

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueueReqMgrInterface_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueueReqMgrInterface_t.py
@@ -111,6 +111,7 @@ class WorkQueueReqMgrInterfaceTest(WorkQueueTestCase):
         reqMgrInt(globalQ)
         self.assertEqual(len(globalQ), 2)
         self.assertEqual(reqMgr.status[reqMgr.names[0]], 'acquired')
+        self.assertEqual(len(globalQ.backend.getElements(Priority = 100)), 2)
 
         # local queue acquires and runs
         globalQ.updateLocationInfo()


### PR DESCRIPTION
The purpose of this patch is to improve the priority
handling in the ReqMgr/WorkQueue/WMAgent looking forward
to the new global priority feature in HTCondor. It is now
possible for priorities to cross schedd boundaries
and be published to the negotiatior, this is
available in the 7.9.xx series.

The changes are the following:
- Global WorkQueue
  Implement a polling function that checks the currently
  available elements (i.e. not acquired by a local queue)
  and keeps their priority in synchrony with the
  value in the ReqMgr. This allows priority changes
  in requests beyond acquired state to have some effect.
- WMBS schema
  The priority is now added as a column in wmbs_workflow table,
  this priority is filled by the WMBSHelper the first time a workflow
  is injected into WMBS by the WorkQueue. The value used is the one
  available in the spec.
- Local WorkQueue changes
  The scope of these changes is to prevent priority inversion due
  to the different queues available in the WorkQueue/WMAgent/Batch system
  chain. The WorkQueue now considers priority of running/pending jobs
  and queued elements before acquiring and injecting work. This means
  that if all the pending jobs are of lower priority than an incoming
  element then this will not be prevented from being acquired and injected.
  E.g. The WMAgent has 100 jobs in condor, in pending status for site A, from a workflow
  with priority 500. Also in the local queue there is 100 jobs for site A from a workflow
  with priority 500. The element in the local queue is not injected because there are already
  100 jobs of equal priority in the batch system. Now, someone creates and assigns a workflow
  to site A with priority 1000. Then that element will be acquired into the LQ
  and injected in WMBS because the 100 job slots are occupied only by lower priority jobs.
- JobSubmitter
  The JobSubmitter now order the workflows with jobs to submit by priority and timestamp,
  this means that when slots are available the high priority workflows will be submitted
  first (after considering the task priorities). In case of equal priority, then the
  older workflow is submitted first.
- BossAir/CondorPlugin
  The priority of the workflow is now propagated to condor through BossAir, the
  value passed to condor is a linear combination of the sub-task type priority
  and the request priority. This ensures that Merge/LogCollect/Cleanup/Harvest/Skim
  jobs are submitted faster regardless of priority to avoid missing data
  due to temporary files.

This is part of #4509. Authors:

Diego Ballesteros (@dballesteros7)
Brian Bockelman (@bbockelm)
