### PR TITLE
Priority handling improvement

### DIFF
--- a/bin/wmagent-resource-control
+++ b/bin/wmagent-resource-control
@@ -25,19 +25,18 @@ def getTaskTypes(tier0 = False):
     Get the list of task types we are currently using with
     priorities.
     """
-    taskTypes = {"Merge" : 5,
-                 "Cleanup" : 5,
-                 "Harvesting" : 5,
-                 "LogCollect" : 3,
-                 "Skim" : 2,
-                 "Production" : 1,
-                 "Processing" : 1,
-                 "Analysis" : 1
-                 }
+    taskTypes = ["Merge",
+                 "Cleanup",
+                 "Harvesting",
+                 "LogCollect",
+                 "Skim",
+                 "Production",
+                 "Processing",
+                 "Analysis"]
 
     if tier0:
-        taskTypes["Repack"] = 4
-        taskTypes["Express"] = 5
+        taskTypes.append("Repack")
+        taskTypes.append("Express")
 
     return taskTypes
 
@@ -78,7 +77,7 @@ def createOptionParser():
     myOptParser.add_option("--task-type", dest = "taskType",
                            help = "Specify the name of the task to add/modify")
     myOptParser.add_option("--priority", dest = "priority", default = None,
-                           help = "Specify the priority of the threshold at the site (higher is better)")
+                           help = "Specify the priority of the task across all sites (higher is better)")
     myOptParser.add_option("--plugin", dest = "plugin",
                            help = "Specify submit plugin to use for specific site")
     myOptParser.add_option("--drain", dest = "state", action="store_const",
@@ -134,10 +133,9 @@ def addSites(resourceControl, allSites, ceName, plugin, pendingSlots, runningSlo
         updateSiteInfo(resourceControl, siteName, pendingSlots, runningSlots,
                        ceName or siteName, allSites[siteName], plugin, cmsName or siteName)
 
-        tasksWithPriorities = getTaskTypes(tier0Option)
-        for task in tasksWithPriorities:
-            updateThresholdInfo(resourceControl, siteName, task, runningSlots, pendingSlots,
-                                priority = tasksWithPriorities[task])
+        tasks = getTaskTypes(tier0Option)
+        for task in tasks:
+            updateThresholdInfo(resourceControl, siteName, task, runningSlots, pendingSlots)
 
     return
 
@@ -220,8 +218,7 @@ def updateSiteInfo(resourceControl, siteName, pendingSlots = None,
         if allTasks:
             tasksWithPriorities = getTaskTypes()
             for task in tasksWithPriorities:
-                updateThresholdInfo(resourceControl, siteName, task, runningSlots, pendingSlots,
-                                    priority = tasksWithPriorities[task])
+                updateThresholdInfo(resourceControl, siteName, task, runningSlots, pendingSlots)
 
     if seName != None:
         print "It's not possible to change a site's SE name after the site has"
@@ -235,7 +232,7 @@ def updateSiteInfo(resourceControl, siteName, pendingSlots = None,
 
     return
 
-def updateThresholdInfo(resourceControl, siteName, taskType, maxSlots = None, pendingSlots = None, priority = None):
+def updateThresholdInfo(resourceControl, siteName, taskType, maxSlots = None, pendingSlots = None):
     """
     _updateThresholdInfo_
 
@@ -253,8 +250,21 @@ def updateThresholdInfo(resourceControl, siteName, taskType, maxSlots = None, pe
         sys.exit(1)
 
     resourceControl.insertThreshold(siteName = siteName, taskType = taskType,
-                                    maxSlots = maxSlots, pendingSlots = pendingSlots,
-                                    priority = priority)
+                                    maxSlots = maxSlots, pendingSlots = pendingSlots)
+    return
+
+def updateTaskPriority(resourceControl, taskType, priority):
+    """
+    _updateTaskPriority_
+
+    Update the priority of a task in the database, if task
+    doesn't exist then add it.
+    """
+    if taskType is None:
+        print "Sub-task type must be specified when changing priority."
+        myOptParser.print_help()
+        sys.exit(1)
+    resourceControl.changeTaskPriority(taskType, priority)
     return
 
 def setSiteState(resourceControl, siteName, state):
@@ -284,7 +294,9 @@ if options.printThresholds:
     printThresholds(myResourceControl, options.siteName)
     sys.exit(0)
 else:
-    if options.addT0 == True:
+    if options.priority:
+        updateTaskPriority(myResourceControl, options.taskType, options.priority)
+    elif options.addT0 == True:
         t0Sites = {'CERN' : ['srm-cms.cern.ch', 'srm-eoscms.cern.ch']}
         cmsName = 'T0_CH_CERN'
         ceName = 'CERN'
@@ -325,5 +337,5 @@ else:
         taskType = options.taskType.strip().split(',')
         updateThresholdInfo(myResourceControl, options.siteName,
                             taskType, options.runningSlots,
-                            options.pendingSlots, priority = options.priority)
+                            options.pendingSlots)
         sys.exit(0)

--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -193,6 +193,13 @@ config.JobStatusLite.logLevel = globalLogLevel
 config.JobStatusLite.pollInterval = 60
 config.JobStatusLite.stateTimeouts = {"Error": 1800, "Running": 169200, "Pending": 360000}
 
+config.component_("JobUpdater")
+config.JobUpdater.namespace = "WMComponent.JobUpdater.JobUpdater"
+config.JobUpdater.componentDir = config.General.workDir + "/JobUpdater"
+config.JobUpdater.logLevel = globalLogLevel
+config.JobUpdater.pollInterval = 120
+config.JobUpdater.reqMgrUrl = 'https://cmsweb.cern.ch/reqmgr/reqMgr'
+
 config.component_("ErrorHandler")
 config.ErrorHandler.namespace = "WMComponent.ErrorHandler.ErrorHandler"
 config.ErrorHandler.componentDir  = config.General.workDir + "/ErrorHandler"

--- a/src/couchapps/WorkQueue/lists/workRestrictions.js
+++ b/src/couchapps/WorkQueue/lists/workRestrictions.js
@@ -118,17 +118,9 @@ function(head, req) {
                 send(",");
             }
             send(toJSON(row["doc"])); // need whole document, id etc...
-            var jobs = ele['Jobs'];
-            var slots = resources[site];
-            if (slots - jobs > 0) {
-                resources[site] = slots - jobs;
-            } else {
-                delete resources[site];
-            }
 
             first = false; // from now on prepend "," to output
             break; // we have work, move to next element (break out of site loop)
-
         } // end resources
     } // end rows
 

--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -81,6 +81,7 @@ class JobSubmitterPoller(BaseWorkerThread):
 
         # Additions for caching-based JobSubmitter
         self.workflowTimestamps = {}
+        self.workflowPrios      = {}
         self.cachedJobIDs       = set()
         self.cachedJobs         = {}
         self.jobDataCache       = {}
@@ -124,6 +125,7 @@ class JobSubmitterPoller(BaseWorkerThread):
         self.setLocationAction = self.daoFactory(classname = "Jobs.SetLocation")
         self.locationAction = self.daoFactory(classname = "Locations.GetSiteInfo")
         self.setFWJRPathAction = self.daoFactory(classname = "Jobs.SetFWJRPath")
+        self.listWorkflows = self.daoFactory(classname = "Workflow.ListForSubmitter")
 
         # Keep a record of the thresholds in memory
         self.currentRcThresholds = {}
@@ -245,6 +247,12 @@ class JobSubmitterPoller(BaseWorkerThread):
         badJobs = dict([(x, []) for x in range(61101,61104)])
         dbJobs = set()
 
+        logging.info("Refreshing priority cache...")
+        workflows = self.listWorkflows.execute()
+        workflows = filter(lambda x: x['name'] in self.workflowPrios, workflows)
+        for workflow in workflows:
+            self.workflowPrios[workflow['name']] = workflow['priority']
+
         logging.info("Querying WMBS for jobs to be submitted...")
         newJobs = self.listJobsAction.execute()
         logging.info("Found %s new jobs to be submitted." % len(newJobs))
@@ -342,12 +350,15 @@ class JobSubmitterPoller(BaseWorkerThread):
                 locTypeCache = self.cachedJobs[possibleLocation][newJob["type"]]
                 workflowName = newJob['workflow']
                 timestamp    = newJob['timestamp']
+                prio         = newJob['task_priority']
                 if not locTypeCache.has_key(workflowName):
                     locTypeCache[workflowName] = set()
                 if not self.jobDataCache.has_key(workflowName):
                     self.jobDataCache[workflowName] = {}
                 if not workflowName in self.workflowTimestamps:
                     self.workflowTimestamps[workflowName] = timestamp
+                if workflowName not in self.workflowPrios:
+                    self.workflowPrios[workflowName] = prio
 
                 locTypeCache[workflowName].add(jobID)
 
@@ -368,7 +379,8 @@ class JobSubmitterPoller(BaseWorkerThread):
                        newJob['request_name'],
                        loadedJob.get("estimatedJobTime", None),
                        loadedJob.get("estimatedDiskUsage", None),
-                       loadedJob.get("estimatedMemoryUsage", None))
+                       loadedJob.get("estimatedMemoryUsage", None),
+                       newJob['task_name'])
 
             self.jobDataCache[workflowName][jobID] = jobInfo
 
@@ -577,9 +589,19 @@ class JobSubmitterPoller(BaseWorkerThread):
                     cachedJobWorkflow = None
 
                     workflows = taskCache.keys()
-                    # Sorting by timestamp on the subscription
-                    sortingKey = lambda x : self.workflowTimestamps[x]
-                    workflows.sort(key = sortingKey)
+                    # Sorting by prio and timestamp on the subscription
+                    def sortingCmp(x, y):
+                        if (x not in self.workflowTimestamps) or (y not in self.workflowTimestamps):
+                            return -1
+                        if (x not in self.workflowPrios) or (y not in self.workflowPrios):
+                            return -1
+                        if self.workflowPrios[x] > self.workflowPrios[y]:
+                            return -1
+                        elif self.workflowPrios[x] == self.workflowPrios[y]:
+                            return cmp(self.workflowTimestamps[x], self.workflowTimestamps[y])
+                        else:
+                            return 1
+                    workflows.sort(cmp = sortingCmp)
 
                     for workflow in workflows:
                         # Run a while loop until you get a job
@@ -654,7 +676,9 @@ class JobSubmitterPoller(BaseWorkerThread):
                                'requestName': cachedJob[13],
                                'estimatedJobTime' : cachedJob[14],
                                'estimatedDiskUsage' : cachedJob[15],
-                               'estimatedMemoryUsage' : cachedJob[16]}
+                               'estimatedMemoryUsage' : cachedJob[16],
+                               'taskPriority' : self.workflowPrios[workflow],
+                               'taskName' : cachedJob[17]}
 
                     # Add to jobsToSubmit
                     jobsToSubmit[package].append(jobDict)
@@ -681,6 +705,11 @@ class JobSubmitterPoller(BaseWorkerThread):
         for workflow in workflowsWithTimestamp:
             if workflow not in allWorkflows:
                 del self.workflowTimestamps[workflow]
+
+        workflowsWithPrios = self.workflowPrios.keys()
+        for workflow in workflowsWithPrios:
+            if workflow not in allWorkflows:
+                del self.workflowPrios[workflow]
 
         logging.info("Have %s packages to submit." % len(jobsToSubmit))
         logging.info("Done assigning site locations.")

--- a/src/python/WMComponent/JobUpdater/JobUpdater.py
+++ b/src/python/WMComponent/JobUpdater/JobUpdater.py
@@ -1,0 +1,48 @@
+"""
+__JobUpdater__
+
+Check and calculate changes in job information and
+updates the records of pending jobs in the batch
+system
+
+Created on Apr 16, 2013
+
+@author: dballest
+"""
+
+import logging
+import threading
+
+from WMComponent.JobUpdater.JobUpdaterPoller import JobUpdaterPoller
+
+from WMCore.Agent.Harness import Harness
+
+class JobUpdater(Harness):
+    """
+    Component class for the JobUpdater module,
+    runs a single worker, the JobUpdaterPoller
+    """
+
+    def __init__(self, config):
+        """
+        __init__
+
+        Initialize the Harness
+        """
+        Harness.__init__(self, config)
+
+    def preInitialization(self):
+        """
+        _preInitialization_
+
+        Sets up the worker thread
+        """
+        logging.info("JobTracker.preInitialization")
+
+        myThread = threading.currentThread()
+
+        pollInterval = self.config.JobUpdater.pollInterval
+        logging.info("Setting poll interval to %s seconds" % pollInterval)
+        myThread.workerThreadManager.addWorker(JobUpdaterPoller(self.config), pollInterval)
+
+        return

--- a/src/python/WMComponent/JobUpdater/JobUpdaterPoller.py
+++ b/src/python/WMComponent/JobUpdater/JobUpdaterPoller.py
@@ -1,0 +1,121 @@
+"""
+__JobUpdaterPoller__
+
+Poller module for the JobUpdater, takes care of the
+actual updating work.
+
+Created on Apr 16, 2013
+
+@author: dballest
+"""
+
+import logging
+import threading
+
+from WMCore.BossAir.BossAirAPI import BossAirAPI
+from WMCore.DAOFactory import DAOFactory
+from WMCore.Services.RequestManager.RequestManager import RequestManager
+from WMCore.Services.WorkQueue.WorkQueue import WorkQueue
+from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
+from WMCore.WMException import WMException
+
+class JobUpdaterException(WMException):
+    """
+    _JobUpdaterException_
+
+    A job updater exception-handling class for the JobUpdaterPoller
+    """
+    pass
+
+class JobUpdaterPoller(BaseWorkerThread):
+    """
+    _JobUpdaterPoller_
+
+    Poller class for the JobUpdater
+    """
+
+    def __init__(self, config):
+        """
+        __init__
+        """
+        BaseWorkerThread.__init__(self)
+        self.config = config
+
+        self.bossAir = BossAirAPI(config = self.config)
+        self.reqmgr = RequestManager({'endpoint' : self.config.JobUpdater.reqMgrUrl})
+        self.workqueue = WorkQueue(self.config.WorkQueueManager.couchurl,
+                                   self.config.WorkQueueManager.dbname)
+
+        myThread = threading.currentThread()
+
+        self.daoFactory = DAOFactory(package = "WMCore.WMBS",
+                                     logger = myThread.logger,
+                                     dbinterface = myThread.dbi)
+
+        self.listWorkflowsDAO = self.daoFactory(classname = "Workflow.ListForJobUpdater")
+        self.updateWorkflowPrioDAO = self.daoFactory(classname = "Workflow.UpdatePriority")
+        self.executingJobsDAO = self.daoFactory(classname = "Jobs.GetNumberOfJobsForWorkflowTaskStatus")
+
+
+    def setup(self, parameters = None):
+        """
+        _setup_
+        """
+        pass
+
+    def terminate(self, parameters = None):
+        """
+        _terminate_
+
+        Terminate gracefully.
+        """
+        pass
+
+    def algorithm(self, parameters = None):
+        """
+        _algorithm_
+        """
+        logging.info("Synchronizing priorities with ReqMgr...")
+        self.synchronizeJobPriority()
+
+    def synchronizeJobPriority(self):
+        """
+        _synchronizeJobPriority_
+
+        Check WMBS and WorkQueue for active workflows and compare with the
+        ReqMgr for priority changes. If a priority change occurs
+        then update the job priority in the batch system and
+        the elements in the local queue that have not been injected yet.
+        """
+        # Update the priority of workflows that are not in WMBS and just in local queue
+        priorityCache = {}
+        workflowsToUpdate = {}
+        workflowsToCheck = [x for x in self.workqueue.getAvailableWorkflows()]
+        for workflow, priority in workflowsToCheck:
+            if workflow not in priorityCache:
+                priorityCache[workflow] = self.reqmgr.getRequest(workflow)['RequestPriority']
+            if priority != priorityCache[workflow]:
+                workflowsToUpdate[workflow] = priorityCache[workflow]
+        for workflow in workflowsToUpdate:
+            self.workqueue.updatePriority(workflow, workflowsToUpdate[workflow])
+
+        # Check the workflows in WMBS
+        priorityCache = {}
+        workflowsToUpdateWMBS = {}
+        workflowsToCheck = self.listWorkflowsDAO.execute()
+        for workflowEntry in workflowsToCheck:
+            workflow = workflowEntry['name']
+            if workflow not in priorityCache:
+                priorityCache[workflow] = self.reqmgr.getRequest(workflow)['RequestPriority']
+            requestPriority = priorityCache[workflow]
+            if requestPriority != workflowEntry['workflow_priority']:
+                # Update the workqueue priority for the Available elements
+                self.workqueue.updatePriority(workflow, priorityCache[workflow])
+                # Check if there are executing jobs for this particular task
+                if self.executingJobsDAO.execute(workflow, workflowEntry['task']) > 0:
+                    self.bossAir.updateJobInformation(workflow, workflowEntry['task'],
+                                                      requestPriority = priorityCache[workflow],
+                                                      taskPriority = workflowEntry['task_priority'])
+                workflowsToUpdateWMBS[workflow] = priorityCache[workflow]
+        if workflowsToUpdateWMBS:
+            self.updateWorkflowPrioDAO.execute(workflowsToUpdateWMBS)

--- a/src/python/WMComponent/WorkQueueManager/WorkQueueManagerWMBSFileFeeder.py
+++ b/src/python/WMComponent/WorkQueueManager/WorkQueueManagerWMBSFileFeeder.py
@@ -57,13 +57,13 @@ class WorkQueueManagerWMBSFileFeeder(BaseWorkerThread):
         self.queue.logger.info("Getting work and feeding WMBS files")
 
         # need to make sure jobs are created
-        resources = freeSlots(minusRunning = True, allowedStates = ['Normal', 'Draining'],
+        resources, jobCounts = freeSlots(minusRunning = True, allowedStates = ['Normal', 'Draining'],
                               knownCmsSites = cmsSiteNames())
 
         for site in resources:
             self.queue.logger.info("I need %d jobs on site %s" % (resources[site], site))
 
-        self.previousWorkList = self.queue.getWork(resources)
+        self.previousWorkList = self.queue.getWork(resources, jobCounts)
         self.queue.logger.info("%s of units of work acquired for file creation"
                                % len(self.previousWorkList))
         return

--- a/src/python/WMCore/BossAir/BossAirAPI.py
+++ b/src/python/WMCore/BossAir/BossAirAPI.py
@@ -774,6 +774,26 @@ class BossAirAPI(WMConnectionBase):
 
         return results
 
+    def updateJobInformation(self, workflow, task, **kwargs):
+        """
+        _updateJobInformation_
+
+        Update the information of jobs in a particular workflow and task,
+        the data will be updated according the keyword arguments which
+        will be interpreted by the individual plugins accordingly.
+        """
+        for plugin in self.plugins.keys():
+            try:
+                pluginInst = self.plugins[plugin]
+                pluginInst.updateJobInformation(workflow, task, **kwargs)
+            except WMException:
+                raise
+            except Exception, ex:
+                msg =  "Unhandled exception while calling update method for plugin %s\n" % plugin
+                msg += str(ex)
+                logging.error(msg)
+                raise BossAirException(msg)
+        return
 
     def _buildRunningJobsFromRunJobs(self, runJobs):
         """

--- a/src/python/WMCore/BossAir/Plugins/BasePlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/BasePlugin.py
@@ -96,3 +96,13 @@ class BasePlugin:
 
 
         return
+
+    def updateJobInformation(self, workflow, task, **kwargs):
+        """
+        _updateJobInformation_
+
+        Update information on pending jobs
+        where supported, the values are updated
+        are passed through the kwargs
+        """
+        pass

--- a/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
@@ -17,6 +17,7 @@ import traceback
 import subprocess
 import multiprocessing
 import glob
+import shlex
 
 import WMCore.Algorithms.BasicAlgos as BasicAlgos
 
@@ -187,7 +188,8 @@ class CondorPlugin(BasePlugin):
         self.submitWMSMode = getattr(config.BossAir, 'submitWMSMode', False)
         self.errorThreshold= getattr(config.BossAir, 'submitErrorThreshold', 10)
         self.errorCount    = 0
-
+        self.defaultTaskPriority = getattr(config.BossAir, 'defaultTaskPriority', 0)
+        self.maxTaskPriority     = getattr(config.BossAir, 'maxTaskPriority', 1e7)
 
         # Build ourselves a pool
         self.pool     = []
@@ -720,9 +722,38 @@ class CondorPlugin(BasePlugin):
 
         return
 
+    def updateJobInformation(self, workflow, task, **kwargs):
+        """
+        _updateJobInformation_
 
+        Update job information for all jobs in the workflow and task,
+        the change will take effect if the job is Idle or becomes idle.
 
-
+        The currently supported changes are only priority for which both the task (taskPriority)
+        and workflow priority (requestPriority) must be provided.
+        """
+        if 'taskPriority' in kwargs and 'requestPriority' in kwargs:
+            # Do a priority update
+            priority = (int(kwargs['requestPriority']) + int(kwargs['taskPriority'])*self.maxTaskPriority)
+            command = 'condor_qedit -constraint \'WMAgent_SubTaskName == "%s" && WMAgent_RequestName == "%s"\' ' %(task, workflow)
+            command += 'JobPrio %s' % priority
+            command = shlex.split(command)
+            proc = subprocess.Popen(command, stderr = subprocess.PIPE,
+                                    stdout = subprocess.PIPE)
+            _, stderr = proc.communicate()
+            if proc.returncode != 0:
+                # Check if there are actually jobs to update
+                command = 'condor_q -constraint \'WMAgent_SubTaskName == "%s" && WMAgent_RequestName == "%s"\' ' %(task, workflow)
+                command += '-format \'WMAgentID:\%d:::\' WMAgent_JobID'
+                command = shlex.split(command)
+                proc = subprocess.Popen(command, stderr = subprocess.PIPE,
+                                        stdout = subprocess.PIPE)
+                stdout, _ = proc.communicate()
+                if stdout != '':
+                    msg = 'HTCondor edit failed with exit code %d\n'% proc.returncode
+                    msg += 'Error was: %s' % stderr
+                    raise BossAirPluginException(msg)
+        return
 
     # Start with submit functions
 
@@ -846,10 +877,19 @@ class CondorPlugin(BasePlugin):
             jdl.append("transfer_output_files = Report.%i.pkl\n" % (job["retry_count"]))
 
             # Add priority if necessary
+            task_priority = job.get("taskPriority", self.defaultTaskPriority)
+            try:
+                task_priority = int(task_priority)
+            except:
+                logging.error("Priority for task not castable to an int")
+                logging.error("Not setting priority")
+                logging.debug("Priority: %s" % task_priority)
+                task_priority = 0
+
+            prio = 0
             if job.get('priority', None) != None:
                 try:
                     prio = int(job['priority'])
-                    jdl.append("priority = %i\n" % prio)
                 except ValueError:
                     logging.error("Priority for job %i not castable to an int\n" % job['id'])
                     logging.error("Not setting priority")
@@ -858,6 +898,8 @@ class CondorPlugin(BasePlugin):
                     logging.error("Got unhandled exception while setting priority for job %i\n" % job['id'])
                     logging.error(str(ex))
                     logging.error("Not setting priority")
+
+            jdl.append("priority = %i\n" % (task_priority + prio*self.maxTaskPriority))
 
             jdl.append("+WMAgent_JobID = %s\n" % job['jobid'])
 
@@ -893,6 +935,12 @@ class CondorPlugin(BasePlugin):
         if job.get('requestName', None):
             jdl.append('+WMAgent_RequestName = "%s"\n' % job['requestName'])
 
+        if job.get('taskName', None):
+            jdl.append('+WMAgent_SubTaskName = "%s"\n' % job['taskName'])
+
+        if job.get('subTaskType', None):
+            jdl.append('+WMAgent_SubTaskType = "%s"\n' % job['taskType'])
+
         # Performance estimates
         if job.get('estimatedJobTime', None):
             jdl.append('+MaxWallTimeMins = %d\n' % int(job['estimatedJobTime']/60.0))
@@ -915,19 +963,12 @@ class CondorPlugin(BasePlugin):
             self.locationDict[jobSite] = siteInfo[0].get('ce_name', None)
         return self.locationDict[jobSite]
 
-
-
-
-
     def getClassAds(self):
         """
         _getClassAds_
 
         Grab classAds from condor_q using xml parsing
         """
-
-        constraint = "\"WMAgent_JobID =!= UNDEFINED\""
-
 
         jobInfo = {}
 
@@ -940,7 +981,7 @@ class CondorPlugin(BasePlugin):
                    '-format', '(WMAgentID:\%d):::',  'WMAgent_JobID']
 
         pipe = subprocess.Popen(command, stdout = subprocess.PIPE, stderr = subprocess.PIPE, shell = False)
-        stdout, stderr = pipe.communicate()
+        stdout, _ = pipe.communicate()
         classAdsRaw = stdout.split(':::')
 
         if not pipe.returncode == 0:
@@ -948,7 +989,6 @@ class CondorPlugin(BasePlugin):
             logging.error("condor_q returned non-zero value %s" % str(pipe.returncode))
             logging.error("Skipping classAd processing this round")
             return None
-
 
         if classAdsRaw == '':
             # We have no jobs
@@ -979,6 +1019,5 @@ class CondorPlugin(BasePlugin):
                 jobInfo[int(tmpDict['WMAgentID'])] = tmpDict
 
         logging.info("Retrieved %i classAds" % len(jobInfo))
-
 
         return jobInfo

--- a/src/python/WMCore/BossAir/RunJob.py
+++ b/src/python/WMCore/BossAir/RunJob.py
@@ -28,7 +28,8 @@ class RunJob(dict):
                  taskType = None, possibleSites = [], sw_version = None,
                  scram_arch = None, siteName = None, jobName = None,
                  proxyPath = None, requestName = None, jobTime = None,
-                 diskUsage = None, memoryUsage = None):
+                 diskUsage = None, memoryUsage = None, taskPriority = None,
+                 taskName = None):
         """
         Just make sure you init the dictionary fields.
 
@@ -65,6 +66,8 @@ class RunJob(dict):
         self.setdefault('estimatedJobTime', jobTime)
         self.setdefault('estimatedDiskUsage', diskUsage)
         self.setdefault('estimatedMemoryUsage', memoryUsage)
+        self.setdefault('taskPriority', taskPriority)
+        self.setdefault('taskName', taskName)
 
         return
 

--- a/src/python/WMCore/DataStructs/Workflow.py
+++ b/src/python/WMCore/DataStructs/Workflow.py
@@ -11,7 +11,7 @@ class Workflow(Pickleable):
     def __init__(self, spec = None, owner = "unknown", dn = "unknown",
                  group = "unknown", owner_vogroup = "unknown",
                  owner_vorole = "unknown", name = None, task = None,
-                 wfType = None):
+                 wfType = None, priority = None):
         self.spec = spec
         self.name = name
         # person making the request
@@ -24,6 +24,7 @@ class Workflow(Pickleable):
         self.task = task
         self.wfType = wfType
         self.outputMap = {}
+        self.priority = priority or 0
 
     def addOutput(self, outputIdentifier, outputFileset,
                   mergedOutputFileset = None):

--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
@@ -248,8 +248,15 @@ def changePriority(requestName, priority, wmstatUrl = None):
     # change priority in CouchDB
     couchDb = Database(request["CouchWorkloadDBName"], request["CouchURL"])
     fields = {"RequestPriority": newPrior}
-    couchDb.updateDocument(requestName, "ReqMgr", "updaterequest", fields=fields) 
-    
+    couchDb.updateDocument(requestName, "ReqMgr", "updaterequest", fields=fields)
+    # push the change to the WorkQueue
+    response = ProdManagement.getProdMgr(requestName)
+    if response == [] or response[0] is None or response[0] == "":
+        # Request must not be assigned yet, we are safe here
+        return
+    workqueue = WorkQueue.WorkQueue(response[0])
+    workqueue.updatePriority(requestName, priority)
+    return
 
 def abortRequest(requestName):
     """ Changes the state of the request to "aborted", and asks the work queue

--- a/src/python/WMCore/ResourceControl/MySQL/Create.py
+++ b/src/python/WMCore/ResourceControl/MySQL/Create.py
@@ -29,7 +29,6 @@ class Create(DBCreator):
             sub_type_id   INTEGER NOT NULL,
             pending_slots INTEGER NOT NULL,
             max_slots     INTEGER NOT NULL,
-            priority      INTEGER DEFAULT 1,
             FOREIGN KEY (site_id) REFERENCES wmbs_location(id) ON DELETE CASCADE,
             FOREIGN KEY (sub_type_id) REFERENCES wmbs_sub_types(id) ON DELETE CASCADE)"""
 

--- a/src/python/WMCore/ResourceControl/MySQL/InsertThreshold.py
+++ b/src/python/WMCore/ResourceControl/MySQL/InsertThreshold.py
@@ -22,35 +22,30 @@ class InsertThreshold(DBFormatter):
                   site_id = (SELECT id FROM wmbs_location WHERE site_name = :sitename) AND
                   sub_type_id = (SELECT id FROM wmbs_sub_types WHERE name  = :tasktype)"""
 
-    updSQL = """UPDATE rc_threshold SET max_slots = :maxslots, pending_slots = :pendslots, priority = :priority
+    updSQL = """UPDATE rc_threshold SET max_slots = :maxslots, pending_slots = :pendslots
                 WHERE site_id = (SELECT id FROM wmbs_location WHERE site_name = :sitename) AND
                       sub_type_id = (SELECT id FROM wmbs_sub_types WHERE name  = :tasktype)"""
 
-    addSQL = """INSERT INTO rc_threshold (site_id, sub_type_id, max_slots, pending_slots, priority) VALUES (
+    addSQL = """INSERT INTO rc_threshold (site_id, sub_type_id, max_slots, pending_slots) VALUES (
                  (SELECT id FROM wmbs_location WHERE site_name = :sitename),
                  (SELECT id FROM wmbs_sub_types WHERE name  = :tasktype),
-                 :maxslots, :pendslots, :priority)"""
+                 :maxslots, :pendslots)"""
 
-    def execute(self, siteName, taskType, maxSlots, pendingSlots, priority = None, conn = None,
+    def execute(self, siteName, taskType, maxSlots, pendingSlots, conn = None,
                 transaction = False):
         binds = {"sitename": siteName, "tasktype": taskType,
-                 "maxslots": maxSlots, "pendslots": pendingSlots,
-                 "priority": priority}
+                 "maxslots": maxSlots, "pendslots": pendingSlots}
         result = self.dbi.processData(self.selSQL, {"sitename": siteName, "tasktype": taskType},
                                       conn = conn, transaction = transaction)
         result = self.formatDict(result)
 
         if len(result) == 0:
-            if priority is None:
-                binds['priority'] = 1
             if maxSlots is None:
                 binds['maxslots'] = pendingSlots
             if pendingSlots is None:
                 binds['pendslots'] = maxSlots
             self.dbi.processData(self.addSQL, binds, conn = conn, transaction = transaction)
         else:
-            if priority is None:
-                binds['priority'] = result[0]['priority']
             if pendingSlots is None:
                 binds['pendslots'] = result[0]['pending_slots']
             if maxSlots is None:

--- a/src/python/WMCore/ResourceControl/MySQL/ListThresholdsForSubmit.py
+++ b/src/python/WMCore/ResourceControl/MySQL/ListThresholdsForSubmit.py
@@ -18,7 +18,7 @@ class ListThresholdsForSubmit(DBFormatter):
                     wmbs_sub_types.name AS task_type,
                     job_count.job_status,
                     job_count.jobs,
-                    rc_threshold.priority,
+                    wmbs_sub_types.priority,
                     wmbs_location_state.name AS state,
                     wmbs_location.plugin AS plugin
                     FROM wmbs_location
@@ -50,7 +50,7 @@ class ListThresholdsForSubmit(DBFormatter):
                            bl_status.name) job_count ON
                   wmbs_location.id = job_count.location AND
                   wmbs_sub_types.id = job_count.subtype
-               ORDER BY rc_threshold.priority DESC"""
+               ORDER BY wmbs_sub_types.priority DESC"""
     seSql = """SELECT wl.site_name AS site_name,
                       wls.se_name
                FROM wmbs_location wl

--- a/src/python/WMCore/ResourceControl/Oracle/Create.py
+++ b/src/python/WMCore/ResourceControl/Oracle/Create.py
@@ -38,8 +38,7 @@ class Create(DBCreator):
             site_id INTEGER NOT NULL,
             sub_type_id INTEGER NOT NULL,
             pending_slots INTEGER NOT NULL,
-            max_slots INTEGER NOT NULL,
-            priority  INTEGER DEFAULT 1) %s""" % tablespaceTable
+            max_slots INTEGER NOT NULL) %s""" % tablespaceTable
 
         self.constraints["rc_threshold_fk1"] = \
           """ALTER TABLE rc_threshold ADD

--- a/src/python/WMCore/Services/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/Services/WorkQueue/WorkQueue.py
@@ -1,6 +1,7 @@
 from WMCore.Database.CMSCouch import CouchServer, CouchNotFoundError
 from WMCore.Wrappers import JsonWrapper as json
 from WMCore.Lexicon import splitCouchServiceURL
+from WMCore.WMSpec.WMWorkload import WMWorkloadHelper
 
 # TODO: this could be derived from the Service class to use client side caching
 class WorkQueue(object):
@@ -13,6 +14,7 @@ class WorkQueue(object):
         # if dbName not given assume we have to split
         if not dbName:
             couchURL, dbName = splitCouchServiceURL(couchURL)
+        self.hostWithAuth = couchURL
         self.server = CouchServer(couchURL)
         self.db = self.server.connectDatabase(dbName, create = False)
 
@@ -105,6 +107,15 @@ class WorkQueue(object):
             answer = self.db.makeRequest(uri = thisuri, type = 'PUT')
         return
 
+    def getAvailableWorkflows(self):
+        """Get the workflows that have all their elements
+           available in the workqueue"""
+        data = self.db.loadView('WorkQueue', 'elementsDetailByWorkflowAndStatus',
+                                {'reduce' : False})
+        availableSet = set((x['value']['RequestName'], x['value']['Priority']) for x in data.get('rows', []) if x['key'][1] == 'Available')
+        notAvailableSet = set((x['value']['RequestName'], x['value']['Priority']) for x in data.get('rows', []) if x['key'][1] != 'Available')
+        return availableSet - notAvailableSet
+
     def cancelWorkflow(self, wf):
         """Cancel a workflow"""
         nonCancelableElements = ['Done', 'Canceled', 'Failed']
@@ -113,3 +124,22 @@ class WorkQueue(object):
                                  'reduce' : False})
         elements = [x['id'] for x in data.get('rows', []) if x['key'][1] not in nonCancelableElements]
         return self.updateElements(*elements, Status = 'CancelRequested')
+
+    def updatePriority(self, wf, priority):
+        """Update priority of a workflow, this implies
+           updating the spec and the priority of the Available elements"""
+        # Update elements in Available status
+        data = self.db.loadView('WorkQueue', 'elementsDetailByWorkflowAndStatus',
+                                {'startkey' : [wf], 'endkey' : [wf, {}],
+                                 'reduce' : False})
+        elementsToUpdate = [x['id'] for x in data.get('rows', []) if x['key'][1] == 'Available']
+        if elementsToUpdate:
+            self.updateElements(*elementsToUpdate, Priority = priority)
+        # Update the spec, if it exists
+        if self.db.documentExists(wf):
+            wmspec = WMWorkloadHelper()
+            wmspec.load(self.db['host'] + "/%s/%s/spec" % (self.db.name, wf))
+            wmspec.setPriority(priority)
+            dummy_values = {'name' : wmspec.name()}
+            wmspec.saveCouch(self.hostWithAuth, self.db.name, dummy_values)
+        return

--- a/src/python/WMCore/WMBS/CreateWMBSBase.py
+++ b/src/python/WMCore/WMBS/CreateWMBSBase.py
@@ -147,14 +147,15 @@ class CreateWMBSBase(DBCreator):
 
         self.create["07wmbs_workflow"] = \
           """CREATE TABLE wmbs_workflow (
-             id           INTEGER      PRIMARY KEY AUTO_INCREMENT,
-             spec         VARCHAR(550) NOT NULL,
-             name         VARCHAR(255) NOT NULL,
-             task         VARCHAR(550) NOT NULL,
+             id           INTEGER          PRIMARY KEY AUTO_INCREMENT,
+             spec         VARCHAR(550)     NOT NULL,
+             name         VARCHAR(255)     NOT NULL,
+             task         VARCHAR(550)     NOT NULL,
              type         VARCHAR(255),
-             owner        INTEGER      NOT NULL,
-             alt_fs_close INT(1)       NOT NULL,
-             injected     INT(1)       DEFAULT 0,
+             owner        INTEGER          NOT NULL,
+             alt_fs_close INT(1)           NOT NULL,
+             injected     INT(1)           DEFAULT 0,
+             priority     INTEGER UNSIGNED DEFAULT 0,
              UNIQUE(name, task),
              FOREIGN KEY(owner)    REFERENCES wmbs_users(id)
                ON DELETE CASCADE)"""
@@ -177,6 +178,7 @@ class CreateWMBSBase(DBCreator):
           """CREATE TABLE wmbs_sub_types (
                id   INTEGER      PRIMARY KEY AUTO_INCREMENT,
                name VARCHAR(255) NOT NULL,
+               priority INTEGER DEFAULT 0,
                UNIQUE(name))"""
 
         self.create["09wmbs_subscription"] = \
@@ -435,13 +437,13 @@ class CreateWMBSBase(DBCreator):
                 (jobState)
             self.inserts["job_state_%s" % jobState] = jobStateQuery
 
-        self.subTypes = ["Processing", "Merge", "Harvesting", "Cleanup",
-                         "LogCollect", "Skim", "Analysis", "Production",
-                         "MultiProcessing", "MultiProduction"]
-        for i in range(len(self.subTypes)):
-            subTypeQuery = """INSERT INTO wmbs_sub_types (name)
-                                VALUES ('%s')""" % (self.subTypes[i])
-            self.inserts["wmbs_sub_types_%s" % self.subTypes[i]] = subTypeQuery
+        self.subTypes = [("Processing", 0), ("Merge", 5), ("Harvesting", 3), ("Cleanup", 5),
+                         ("LogCollect", 3), ("Skim", 3), ("Analysis", 0), ("Production", 0),
+                         ("MultiProcessing", 0), ("MultiProduction", 0)]
+        for pair in self.subTypes:
+            subTypeQuery = """INSERT INTO wmbs_sub_types (name, priority)
+                                VALUES ('%s', %d)""" % (pair[0], pair[1])
+            self.inserts["wmbs_sub_types_%s" % pair[0]] = subTypeQuery
 
         locationStates = ["Normal", "Down", "Draining", "Aborted"]
 

--- a/src/python/WMCore/WMBS/MySQL/Jobs/GetNumberOfJobsForWorkflowTaskStatus.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/GetNumberOfJobsForWorkflowTaskStatus.py
@@ -1,0 +1,41 @@
+"""
+_GetNumberOfJobsForWorkflowTaskStatus_
+
+MySQL implementation of GetNumberOfJobsForWorkflowTaskStatus
+
+Created on Apr 17, 2013
+
+@author: dballest
+"""
+__all__ = []
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class GetNumberOfJobsForWorkflowTaskStatus(DBFormatter):
+    """
+    Get the number of jobs for a workflow/task combination
+    in a given job status.
+    """
+
+    sql = """SELECT COUNT(*) FROM wmbs_job
+             INNER JOIN wmbs_jobgroup ON wmbs_job.jobgroup = wmbs_jobgroup.id
+             INNER JOIN wmbs_subscription ON wmbs_subscription.id = wmbs_jobgroup.subscription
+             INNER JOIN wmbs_workflow ON wmbs_subscription.workflow = wmbs_workflow.id
+             WHERE wmbs_workflow.name = :workflow AND
+                   wmbs_workflow.task = :task AND
+                   wmbs_job.state = (SELECT id FROM wmbs_job_state WHERE name = :status)
+               """
+
+    def execute(self, workflow, task, status = 'executing', conn = None, transaction = False):
+        """
+        _execute_
+
+        Execute the SQL and return the number of jobs
+        """
+
+        binds = {'workflow': workflow, 'task' : task, 'status' : status}
+
+        result = self.dbi.processData(self.sql, binds,
+                                      conn = conn, transaction = transaction)
+
+        return self.format(result)[0][0]

--- a/src/python/WMCore/WMBS/MySQL/Jobs/ListForSubmitter.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/ListForSubmitter.py
@@ -16,7 +16,9 @@ class ListForSubmitter(DBFormatter):
                     wmbs_sub_types.name AS type, wmbs_job.retry_count AS retry_count,
                     wmbs_subscription.workflow as workflow,
                     wmbs_subscription.last_update as timestamp,
-                    wmbs_workflow.name as request_name
+                    wmbs_workflow.name as request_name,
+                    wmbs_workflow.priority as task_priority,
+                    wmbs_workflow.task as task_name
                     FROM wmbs_job
                INNER JOIN wmbs_jobgroup ON
                  wmbs_job.jobgroup = wmbs_jobgroup.id

--- a/src/python/WMCore/WMBS/MySQL/Subscriptions/InsertType.py
+++ b/src/python/WMCore/WMBS/MySQL/Subscriptions/InsertType.py
@@ -14,8 +14,16 @@ class InsertType(DBFormatter):
     sql = """INSERT INTO wmbs_sub_types (name)
                SELECT :name AS name FROM DUAL WHERE NOT EXISTS
                 (SELECT name FROM wmbs_sub_types WHERE name = :name)"""
+    
+    sqlUpdate = """UPDATE wmbs_sub_types SET priority = :priority
+                   WHERE name = :name"""
 
-    def execute(self, subType, conn = None, transaction = False):
+    def execute(self, subType, priority = None,
+                conn = None, transaction = False):
         self.dbi.processData(self.sql, {"name": subType}, conn = conn,
                              transaction = transaction)
+        if priority is not None:
+            self.dbi.processData(self.sqlUpdate, {"name" : subType,
+                                                  "priority" : priority},
+                                 conn = conn, transaction = transaction)
         return

--- a/src/python/WMCore/WMBS/MySQL/Workflow/ListForJobUpdater.py
+++ b/src/python/WMCore/WMBS/MySQL/Workflow/ListForJobUpdater.py
@@ -1,0 +1,33 @@
+"""
+__ListForJobUpdater__
+
+MySQL implementation of ListForJobUpdater
+
+Created on Apr 16, 2013
+
+@author: dballest
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class ListForJobUpdater(DBFormatter):
+    """
+    _ListForJobUpdater_
+
+    List the available workflows and tasks in WMBS with the workflow
+    priority and the sub task priority
+    """
+    sql = """SELECT wmbs_workflow.name, wmbs_workflow.task,
+                    wmbs_workflow.priority AS workflow_priority,
+                    wmbs_sub_types.priority AS task_priority
+             FROM wmbs_workflow
+             INNER JOIN wmbs_subscription ON
+               wmbs_workflow.id = wmbs_subscription.workflow
+             INNER JOIN wmbs_sub_types ON
+               wmbs_subscription.subtype = wmbs_sub_types.id
+             GROUP BY wmbs_workflow.name, wmbs_workflow.task"""
+
+    def execute(self, conn = None, transaction = False):
+        result = self.dbi.processData(self.sql,
+                                      conn = conn, transaction = transaction)
+        return self.formatDict(result)

--- a/src/python/WMCore/WMBS/MySQL/Workflow/ListForSubmitter.py
+++ b/src/python/WMCore/WMBS/MySQL/Workflow/ListForSubmitter.py
@@ -1,0 +1,28 @@
+"""
+__ListForSubmitter__
+
+MySQL implementation of ListForSubmitter
+
+Created on Apr 17, 2013
+
+@author: dballest
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class ListForSubmitter(DBFormatter):
+    """
+    _ListForSubmitter_
+
+    List the available workflows in WMBS with the workflow
+    priority
+    """
+    sql = """SELECT wmbs_workflow.name,
+                    wmbs_workflow.priority
+             FROM wmbs_workflow
+             GROUP BY wmbs_workflow.name"""
+
+    def execute(self, conn = None, transaction = False):
+        result = self.dbi.processData(self.sql,
+                                      conn = conn, transaction = transaction)
+        return self.formatDict(result)

--- a/src/python/WMCore/WMBS/MySQL/Workflow/LoadFromID.py
+++ b/src/python/WMCore/WMBS/MySQL/Workflow/LoadFromID.py
@@ -12,7 +12,7 @@ class LoadFromID(DBFormatter):
                     wmbs_users.cert_dn as dn, wmbs_users.owner as owner,
                     wmbs_users.grp as grp, wmbs_users.group_name as vogrp,
                     wmbs_users.role_name as vorole, wmbs_workflow.task,
-                    wmbs_workflow.type
+                    wmbs_workflow.type, wmbs_workflow.priority
              FROM wmbs_workflow
              INNER JOIN wmbs_users ON
                wmbs_workflow.owner = wmbs_users.id

--- a/src/python/WMCore/WMBS/MySQL/Workflow/LoadFromName.py
+++ b/src/python/WMCore/WMBS/MySQL/Workflow/LoadFromName.py
@@ -12,7 +12,7 @@ class LoadFromName(DBFormatter):
                     wmbs_users.cert_dn as dn, wmbs_users.owner as owner,
                     wmbs_users.grp as grp, wmbs_users.group_name as vogrp,
                     wmbs_users.role_name as vorole, wmbs_workflow.task,
-                    wmbs_workflow.type
+                    wmbs_workflow.type, wmbs_workflow.priority
              FROM wmbs_workflow
              INNER JOIN wmbs_users ON
                wmbs_workflow.owner = wmbs_users.id

--- a/src/python/WMCore/WMBS/MySQL/Workflow/LoadFromSpecOwner.py
+++ b/src/python/WMCore/WMBS/MySQL/Workflow/LoadFromSpecOwner.py
@@ -12,7 +12,7 @@ class LoadFromSpecOwner(DBFormatter):
                     wmbs_users.cert_dn as dn, wmbs_users.owner as owner,
                     wmbs_users.grp as grp, wmbs_users.group_name as vogrp,
                     wmbs_users.role_name as vorole, wmbs_workflow.task,
-                    wmbs_workflow.type
+                    wmbs_workflow.type, wmbs_workflow.priority
              FROM wmbs_workflow
              INNER JOIN wmbs_users ON
                wmbs_workflow.owner = wmbs_users.id

--- a/src/python/WMCore/WMBS/MySQL/Workflow/New.py
+++ b/src/python/WMCore/WMBS/MySQL/Workflow/New.py
@@ -11,12 +11,13 @@ class New(DBFormatter):
     """
     Create a workflow ready for subscriptions
     """
-    sql = """insert into wmbs_workflow (spec, owner, name, task, type, alt_fs_close)
-                values (:spec, :owner, :name, :task, :type, :alt_fs_close)"""
+    sql = """insert into wmbs_workflow (spec, owner, name, task, type, alt_fs_close, priority)
+                values (:spec, :owner, :name, :task, :type, :alt_fs_close, :priority)"""
 
     def execute(self, spec = None, owner = None, name = None, task = None,
-                wfType = None, alt_fs_close = False, conn = None, transaction = False):
+                wfType = None, alt_fs_close = False, priority = None,
+                conn = None, transaction = False):
         binds = {"spec": spec, "owner": owner, "name": name, "task": task,
-                 "type": wfType, "alt_fs_close": int(alt_fs_close)}
+                 "type": wfType, "alt_fs_close": int(alt_fs_close), "priority" : priority}
         self.dbi.processData(self.sql, binds, conn = conn, transaction = transaction)
         return

--- a/src/python/WMCore/WMBS/MySQL/Workflow/UpdatePriority.py
+++ b/src/python/WMCore/WMBS/MySQL/Workflow/UpdatePriority.py
@@ -1,0 +1,31 @@
+"""
+__UpdatePriority__
+
+MySQL implementation of UpdatePriority
+
+Created on Apr 16, 2013
+
+@author: dballest
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class UpdatePriority(DBFormatter):
+    """
+    _UpdatePriority_
+
+    Update the priority of the workflows given
+    the name.
+    """
+    sql = """UPDATE wmbs_workflow SET priority = :priority
+             WHERE wmbs_workflow.name = :name"""
+
+    def execute(self, workflowsToUpdate,
+                conn = None, transaction = False):
+        binds = []
+        for workflow in workflowsToUpdate:
+            bind = {'name' : workflow,
+                    'priority' : workflowsToUpdate[workflow]}
+            binds.append(bind)
+        self.dbi.processData(self.sql, binds,
+                             conn = conn, transaction = transaction)

--- a/src/python/WMCore/WMBS/Oracle/Create.py
+++ b/src/python/WMCore/WMBS/Oracle/Create.py
@@ -234,7 +234,8 @@ class Create(CreateWMBSBase):
                type  VARCHAR(255),
                owner INTEGER      NOT NULL,
                alt_fs_close INTEGER NOT NULL,
-               injected INTEGER   DEFAULT 0
+               injected INTEGER   DEFAULT 0,
+               priority INTEGER   DEFAULT 0
                ) %s""" % tablespaceTable
 
         self.indexes["01_pk_wmbs_workflow"] = \
@@ -285,7 +286,8 @@ class Create(CreateWMBSBase):
         self.create["08wmbs_sub_types"] = \
           """CREATE TABLE wmbs_sub_types (
                id   INTEGER      NOT NULL,
-               name VARCHAR(255) NOT NULL
+               name VARCHAR(255) NOT NULL,
+               priority INTEGER DEFAULT 0
                ) %s""" % tablespaceTable
 
         self.indexes["01_pk_wmbs_sub_types"] = \
@@ -656,13 +658,13 @@ class Create(CreateWMBSBase):
                                (wmbs_job_state_SEQ.nextval, '%s')""" % jobState
             self.inserts["job_state_%s" % jobState] = jobStateQuery
 
-        self.subTypes = ["Processing", "Merge", "Harvesting", "Cleanup",
-                         "LogCollect", "Skim", "Analysis", "Production",
-                         "MultiProcessing", "MultiProduction"]
-        for i in range(len(self.subTypes)):
-            subTypeQuery = """INSERT INTO wmbs_sub_types (id, name)
-                              VALUES (wmbs_sub_types_SEQ.nextval, '%s')""" % (self.subTypes[i])
-            self.inserts["wmbs_sub_types_%s" % self.subTypes[i]] = subTypeQuery
+        self.subTypes = [("Processing", 0), ("Merge", 5), ("Harvesting", 3), ("Cleanup", 5),
+                         ("LogCollect", 3), ("Skim", 3), ("Analysis", 0), ("Production", 0),
+                         ("MultiProcessing", 0), ("MultiProduction", 0)]
+        for pair in self.subTypes:
+            subTypeQuery = """INSERT INTO wmbs_sub_types (id, name, priority)
+                              VALUES (wmbs_sub_types_SEQ.nextval, '%s', %d)""" % (pair[0], pair[1])
+            self.inserts["wmbs_sub_types_%s" % pair[0]] = subTypeQuery
 
         locationStates = ["Normal", "Down", "Draining", "Aborted"]
 

--- a/src/python/WMCore/WMBS/Oracle/Jobs/GetNumberOfJobsForWorkflowTaskStatus.py
+++ b/src/python/WMCore/WMBS/Oracle/Jobs/GetNumberOfJobsForWorkflowTaskStatus.py
@@ -1,0 +1,16 @@
+"""
+_GetNumberOfJobsForWorkflowTaskStatus_
+
+Oracle implementation of GetNumberOfJobsForWorkflowTaskStatus
+
+Created on Apr 17, 2013
+
+@author: dballest
+"""
+__all__ = []
+
+from WMCore.WMBS.MySQL.Jobs.GetNumberOfJobsForWorkflowTaskStatus import GetNumberOfJobsForWorkflowTaskStatus \
+    as MySQLGetNumberOfJobsForWorkflowTaskStatus
+
+class GetNumberOfJobsForWorkflowTaskStatus(MySQLGetNumberOfJobsForWorkflowTaskStatus):
+    pass

--- a/src/python/WMCore/WMBS/Oracle/Workflow/ListForJobUpdater.py
+++ b/src/python/WMCore/WMBS/Oracle/Workflow/ListForJobUpdater.py
@@ -1,0 +1,14 @@
+"""
+__ListForJobUpdater__
+
+Oracle implementation of ListForJobUpdater
+
+Created on Apr 16, 2013
+
+@author: dballest
+"""
+
+from WMCore.WMBS.MySQL.Workflow.ListForJobUpdater import ListForJobUpdater as MySQLListForJobUpdater
+
+class ListForJobUpdater(MySQLListForJobUpdater):
+    pass

--- a/src/python/WMCore/WMBS/Oracle/Workflow/ListForSubmitter.py
+++ b/src/python/WMCore/WMBS/Oracle/Workflow/ListForSubmitter.py
@@ -1,0 +1,14 @@
+"""
+__ListForSubmitter__
+
+Oracle implementation of ListForSubmitter
+
+Created on Apr 17, 2013
+
+@author: dballest
+"""
+
+from WMCore.WMBS.MySQL.Workflow.ListForSubmitter import ListForSubmitter as MySQLListForSubmitter
+
+class ListForSubmitter(MySQLListForSubmitter):
+    pass

--- a/src/python/WMCore/WMBS/Oracle/Workflow/New.py
+++ b/src/python/WMCore/WMBS/Oracle/Workflow/New.py
@@ -8,5 +8,5 @@ Oracle implementation of NewWorkflow
 from WMCore.WMBS.MySQL.Workflow.New import New as NewWorkflowMySQL
 
 class New(NewWorkflowMySQL):
-    sql = """insert into wmbs_workflow (id, spec, owner, name, task, type, alt_fs_close)
-             values (wmbs_workflow_SEQ.nextval, :spec, :owner, :name, :task, :type, :alt_fs_close)"""
+    sql = """insert into wmbs_workflow (id, spec, owner, name, task, type, alt_fs_close, priority)
+             values (wmbs_workflow_SEQ.nextval, :spec, :owner, :name, :task, :type, :alt_fs_close, :priority)"""

--- a/src/python/WMCore/WMBS/Oracle/Workflow/UpdatePriority.py
+++ b/src/python/WMCore/WMBS/Oracle/Workflow/UpdatePriority.py
@@ -1,0 +1,14 @@
+"""
+__UpdatePriority__
+
+Oracle implementation of UpdatePriority
+
+Created on Apr 16, 2013
+
+@author: dballest
+"""
+
+from WMCore.WMBS.MySQL.Workflow.UpdatePriority import UpdatePriority as MySQLUpdatePriority
+
+class UpdatePriority(MySQLUpdatePriority):
+    pass

--- a/src/python/WMCore/WMBS/Workflow.py
+++ b/src/python/WMCore/WMBS/Workflow.py
@@ -36,12 +36,13 @@ class Workflow(WMBSBase, WMWorkflow):
     def __init__(self, spec = None, owner = "unknown", dn = "unknown",
                  group = "unknown", owner_vogroup = "DEFAULT",
                  owner_vorole = "DEFAULT", name = None, task = None,
-                 wfType = None, id = -1, alternativeFilesetClose = False):
+                 wfType = None, id = -1, alternativeFilesetClose = False,
+                 priority = None):
         WMBSBase.__init__(self)
         WMWorkflow.__init__(self, spec = spec, owner = owner, dn = dn,
                             group = group, owner_vogroup = owner_vogroup,
                             owner_vorole = owner_vorole, name = name,
-                            task = task, wfType = wfType)
+                            task = task, wfType = wfType, priority = priority)
 
         if self.dn == "unknown":
             self.dn = owner
@@ -118,6 +119,7 @@ class Workflow(WMBSBase, WMWorkflow):
         action.execute(spec = self.spec, owner = userid, name = self.name,
                        task = self.task, wfType = self.wfType,
                        alt_fs_close = self.alternativeFilesetClose,
+                       priority = self.priority,
                        conn = self.getDBConn(),
                        transaction = self.existingTransaction())
 
@@ -174,6 +176,7 @@ class Workflow(WMBSBase, WMWorkflow):
         self.vogroup = result["vorole"]
         self.task = result["task"]
         self.wfType = result["type"]
+        self.priority = result["priority"]
 
         action = self.daofactory(classname = "Workflow.LoadOutput")
         results = action.execute(workflow = self.id, conn = self.getDBConn(),

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -187,6 +187,13 @@ class WMWorkloadHelper(PersistencyHelper):
         """
         self.data.sandbox = sandboxPath
 
+    def setPriority(self, priority):
+        """
+        _setPriority_
+
+        Set the priority for the workload
+        """
+        self.data.request.priority = int(priority)
 
     def priority(self):
         """

--- a/src/python/WMCore/WorkQueue/DataStructs/WorkQueueElement.py
+++ b/src/python/WMCore/WorkQueue/DataStructs/WorkQueueElement.py
@@ -34,7 +34,7 @@ class WorkQueueElement(dict):
         self.setdefault('PileupData', {})
         #both ParentData and ParentFlag is needed in case there Dataset split,
         # even though ParentFlag is True it will have empty ParentData
-        self.setdefault('ParentData', [])
+        self.setdefault('ParentData', {})
         self.setdefault('ParentFlag', False)
         # 0 jobs are valid where we need to accept all blocks (only dqm etc subscriptions will run)
         self.setdefault('Jobs', None)
@@ -215,6 +215,16 @@ class WorkQueueElement(dict):
         for locations in self['Inputs'].values():
             if site not in locations:
                 return False
+        # Parent data as well
+        if self['ParentFlag']:
+            for locations in self['ParentData'].values():
+                if site not in locations:
+                    return False
+
+        # Pileup data must be checked
+        for locations in self['PileupData'].values():
+            if site not in locations:
+                return False
 
         # workflow restrictions
         if self['SiteWhitelist'] and site not in self['SiteWhitelist']:
@@ -222,3 +232,4 @@ class WorkQueueElement(dict):
         if site in self['SiteBlacklist']:
             return False
         return True
+

--- a/src/python/WMCore/WorkQueue/WorkQueueReqMgrInterface.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueReqMgrInterface.py
@@ -38,7 +38,7 @@ class WorkQueueReqMgrInterface():
 
         try:    # report back to ReqMgr
             uptodate_elements = self.report(queue)
-            msg += "Updated ReqMgr status for: %s" % ", ".join([x['RequestName'] for x in uptodate_elements])
+            msg += "Updated ReqMgr status for: %s\n" % ", ".join([x['RequestName'] for x in uptodate_elements])
         except:
             self.logger.exception("Error caught during RequestManager update")
         else:
@@ -46,8 +46,8 @@ class WorkQueueReqMgrInterface():
                 self.deleteFinishedWork(queue, uptodate_elements)
             except:
                 self.logger.exception("Error caught during work deletion")
-            else:
-                queue.backend.recordTaskActivity('reqmgr_sync', msg)
+
+        queue.backend.recordTaskActivity('reqmgr_sync', msg)
 
     def queueNewRequests(self, queue):
         """Get requests from regMgr and queue to workqueue"""

--- a/src/python/WMQuality/Emulators/RequestManagerClient/RequestManager.py
+++ b/src/python/WMQuality/Emulators/RequestManagerClient/RequestManager.py
@@ -64,7 +64,8 @@ class RequestManager(dict):
             raise RuntimeError, "unknown request %s" % requestName
 
         request = {'RequestName' : requestName,
-                   'RequestStatus' : self.status[requestName]}
+                   'RequestStatus' : self.status[requestName],
+                   'RequestPriority' : 100}
         if self.progress.has_key(requestName):
             request.update(self.progress[requestName])
         request.setdefault('percent_complete', 0)

--- a/src/python/WMQuality/Emulators/WMAgents/WMAgentTasks.py
+++ b/src/python/WMQuality/Emulators/WMAgents/WMAgentTasks.py
@@ -29,7 +29,7 @@ class WMAgentTasks(BaseWorkerThread):
         """
         """
 
-        data = self.wq.getWork(self.resources)
+        data = self.wq.getWork(self.resources, {})
         print "Data back from workqueue"
         print "%s: %s" % (self.resources, data)
         if len(data) != 0:

--- a/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
+++ b/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
@@ -96,8 +96,7 @@ class JobSubmitterTest(unittest.TestCase):
                        'Processing' : {'pendingSlots' : 5,
                                        'runningSlots' : 10},
                        'Merge' : {'pendingSlots' : 2,
-                                  'runningSlots' : 5,
-                                  'priority' : 5}}
+                                  'runningSlots' : 5}}
 
         resourceControl = ResourceControl()
         resourceControl.insertSite(siteName = site, seName = 'se.%s' % (site),
@@ -106,8 +105,7 @@ class JobSubmitterTest(unittest.TestCase):
         for task in options['tasks']:
             resourceControl.insertThreshold(siteName = site, taskType = task,
                                             maxSlots = options[task]['runningSlots'],
-                                            pendingSlots = options[task]['pendingSlots'],
-                                            priority = options[task].get('priority', 1))
+                                            pendingSlots = options[task]['pendingSlots'])
         if options.get('state'):
             resourceControl.changeSiteState(site, options.get('state'))
 

--- a/test/python/WMComponent_t/JobUpdater_t/JobUpdater_t.py
+++ b/test/python/WMComponent_t/JobUpdater_t/JobUpdater_t.py
@@ -1,0 +1,134 @@
+"""
+__JobUpdater_t__
+
+Test module for the JobUpdater component
+Created on Apr 16, 2013
+
+@author: dballest
+"""
+
+import os
+import unittest
+import logging
+import threading
+
+from WMComponent.JobUpdater.JobUpdaterPoller import JobUpdaterPoller
+from WMCore.Configuration import Configuration
+from WMCore.DAOFactory import DAOFactory
+from WMCore.Services.EmulatorSwitch import EmulatorHelper
+from WMCore.WMBase import getTestBase
+from WMCore.WMBS.Fileset import Fileset
+from WMCore.WMBS.Subscription import Subscription
+from WMCore.WMBS.Workflow import Workflow
+from WMQuality.TestInitCouchApp import TestInitCouchApp as TestInit
+
+class JobUpdaterTest(unittest.TestCase):
+    """
+    _JobUpdaterTest_
+
+    Test class for the JobUpdater
+    """
+
+    def setUp(self):
+        """
+        _setUp_
+
+        Set up test environment
+        """
+        self.testInit = TestInit(__file__)
+        self.testInit.setLogging()
+        self.testInit.setDatabaseConnection()
+        self.testInit.setSchema(customModules = ["WMCore.WMBS",
+                                                 "WMCore.BossAir"],
+                                useDefault = False)
+        self.testInit.setupCouch('workqueue_t', 'WorkQueue')
+        self.testInit.setupCouch('workqueue_inbox_t', 'WorkQueue')
+        self.testDir = self.testInit.generateWorkDir(deleteOnDestruction = False)
+        EmulatorHelper.setEmulators(phedex = True, dbs = True,
+                                    siteDB = True, requestMgr = True)
+
+        myThread = threading.currentThread()
+        self.daoFactory = DAOFactory(package = "WMCore.WMBS",
+                                     logger = logging,
+                                     dbinterface = myThread.dbi)
+        self.listWorkflows = self.daoFactory(classname = "Workflow.ListForSubmitter")
+
+    def tearDown(self):
+        """
+        _tearDown_
+
+        Tear down the databases
+        """
+        self.testInit.clearDatabase()
+        self.testInit.tearDownCouch()
+        self.testInit.delWorkDir()
+        EmulatorHelper.resetEmulators()
+
+    def getConfig(self):
+        """
+        _getConfig_
+
+        Get a test configuration for
+        the JobUpdater tests
+        """
+        config = Configuration()
+
+        config.section_('Agent')
+        config.Agent.agentName = 'testAgent'
+
+        config.section_('CoreDatabase')
+        config.CoreDatabase.connectUrl = os.environ['DATABASE']
+        config.CoreDatabase.socket = os.getenv('DBSOCK')
+
+        # JobTracker
+        config.component_('JobUpdater')
+        config.JobUpdater.reqMgrUrl = 'https://cmsweb-dev.cern.ch/reqmgr/reqMgr'
+
+        # BossAir
+        config.section_('BossAir')
+        config.BossAir.pluginNames = ['MockPlugin']
+        config.BossAir.pluginDir = 'WMCore.BossAir.Plugins'
+        config.BossAir.multicoreTaskTypes = ['MultiProcessing', 'MultiProduction']
+        config.BossAir.nCondorProcesses = 1
+        config.BossAir.section_('MockPlugin')
+        config.BossAir.MockPlugin.fakeReport = os.path.join(getTestBase(),
+                                                         'WMComponent_t/JobAccountant_t/fwjrs',
+                                                         'MergedSkimSuccess.pkl')
+
+        # WorkQueue
+        config.component_('WorkQueueManager')
+        config.WorkQueueManager.couchurl = os.environ['COUCHURL']
+        config.WorkQueueManager.dbname = 'workqueue_t'
+        config.WorkQueueManager.inboxDatabase = 'workqueue_inbox_t'
+
+        return config
+
+    def stuffWMBS(self):
+        """
+        _stuffWMBS_
+
+        Stuff WMBS with workflows
+        """
+        workflow = Workflow(spec = 'spec.xml', name = 'ReRecoTest_v0Emulator',
+                            task = '/ReRecoTest_v0Emulator/Test', priority = 10)
+        workflow.create()
+        inputFileset = Fileset(name = 'TestFileset')
+        inputFileset.create()
+        subscription = Subscription(inputFileset, workflow)
+        subscription.create()
+
+    def test_BasicTest(self):
+        """
+        _BasicTest_
+
+        Basic sanity check
+        """
+        self.stuffWMBS()
+        poller = JobUpdaterPoller(self.getConfig())
+        poller.reqmgr.getAssignment(self)
+        result = self.listWorkflows.execute()
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['priority'], 10)
+        poller.algorithm()
+        result = self.listWorkflows.execute()
+        self.assertEqual(result[0]['priority'], 100)

--- a/test/python/WMCore_t/WMBS_t/Monitoring_t.py
+++ b/test/python/WMCore_t/WMBS_t/Monitoring_t.py
@@ -81,10 +81,9 @@ class MonitoringTest(unittest.TestCase):
         listSubTypes = self.daoFactory(classname = "Monitoring.ListSubTypes")
         subTypes = listSubTypes.execute()
 
-        schemaTypes = CreateWMBSBase().subTypes
+        schemaTypes = [x[0] for x in CreateWMBSBase().subTypes]
         assert len(subTypes) == len(schemaTypes), \
                "Error: Number of subscription types don't match."
-
         for subType in subTypes:
             assert subType in schemaTypes, \
                    "Error: Missing subscription type: %s" % subType

--- a/test/python/WMCore_t/WMBS_t/Workflow_t.py
+++ b/test/python/WMCore_t/WMBS_t/Workflow_t.py
@@ -143,7 +143,8 @@ class WorkflowTest(unittest.TestCase):
           Workflow.LoadFromSpecOwner
         """
         testWorkflowA = Workflow(spec = "spec.xml", owner = "Simon",
-                                 name = "wf001", task='Test', wfType="ReReco")
+                                 name = "wf001", task='Test', wfType="ReReco",
+                                 priority = 1000)
         testWorkflowA.create()
 
         testWorkflowB = Workflow(name = "wf001", task='Test')
@@ -154,7 +155,8 @@ class WorkflowTest(unittest.TestCase):
                         (testWorkflowA.spec == testWorkflowB.spec) and
                         (testWorkflowA.task == testWorkflowB.task) and
                         (testWorkflowA.wfType == testWorkflowB.wfType) and
-                        (testWorkflowA.owner == testWorkflowB.owner),
+                        (testWorkflowA.owner == testWorkflowB.owner) and
+                        (testWorkflowA.priority == testWorkflowB.priority),
                         "ERROR: Workflow.LoadFromName Failed")
 
         testWorkflowC = Workflow(id = testWorkflowA.id)
@@ -165,7 +167,8 @@ class WorkflowTest(unittest.TestCase):
                         (testWorkflowA.spec == testWorkflowC.spec) and
                         (testWorkflowA.task == testWorkflowC.task) and
                         (testWorkflowA.wfType == testWorkflowC.wfType) and
-                        (testWorkflowA.owner == testWorkflowC.owner),
+                        (testWorkflowA.owner == testWorkflowC.owner) and
+                        (testWorkflowA.priority == testWorkflowB.priority),
                         "ERROR: Workflow.LoadFromID Failed")
 
         testWorkflowD = Workflow(spec = "spec.xml", owner = "Simon", task='Test')
@@ -176,9 +179,9 @@ class WorkflowTest(unittest.TestCase):
                         (testWorkflowA.spec == testWorkflowD.spec) and
                         (testWorkflowA.task == testWorkflowD.task) and
                         (testWorkflowA.wfType == testWorkflowD.wfType) and
-                        (testWorkflowA.owner == testWorkflowD.owner),
+                        (testWorkflowA.owner == testWorkflowD.owner) and
+                        (testWorkflowA.priority == testWorkflowB.priority),
                         "ERROR: Workflow.LoadFromSpecOwner Failed")
-
         testWorkflowA.delete()
         return
 

--- a/test/python/WMCore_t/WorkQueue_t/LocalQueueProfile_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/LocalQueueProfile_t.py
@@ -84,7 +84,7 @@ class LocalWorkQueueProfileTest(WorkQueueTestCase):
         siteJobs = {}
         for site in Globals.SITES:
             siteJobs[site] = 100000
-        self.localQueue.getWork(siteJobs)
+        self.localQueue.getWork(siteJobs, {})
 
 
 if __name__ == "__main__":

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueueBackend_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueueBackend_t.py
@@ -62,13 +62,13 @@ class WorkQueueBackendTest(unittest.TestCase):
                                          Status = 'Available',
                                          Jobs = 10, Priority = 0.1)
         self.backend.insertElements([element])
-        self.backend.availableWork({'place' : 1000})
+        self.backend.availableWork({'place' : 1000}, {})
         # timestamp in elements have second coarseness, 2nd element must
         # have a higher timestamp to force it after the 1st
         time.sleep(1)
         self.backend.insertElements([lowprielement, element2, highprielement])
-        self.backend.availableWork({'place' : 1000})
-        work = self.backend.availableWork({'place' : 1000})
+        self.backend.availableWork({'place' : 1000}, {})
+        work = self.backend.availableWork({'place' : 1000}, {})
         # order should be high to low, with the standard elements in the order
         # they were queueud
         self.assertEqual([x['RequestName'] for x in work[0]],


### PR DESCRIPTION
The purpose of this patch is to improve the priority
handling in the ReqMgr/WorkQueue/WMAgent looking forward
to the new global priority feature in HTCondor. It is now
possible for priorities to cross schedd boundaries
and be published to the negotiatior, this is
available in the 7.9.xx series.

The changes are the following:
- ReqMgr
  Push priority changes to the WorkQueue by updating
  the available elements in the global queue and the spec.
  This effectively updates the priority value for any
  future split in the local queues and in any new global
  element created.
- WMBS schema
  The priority is now added as a column in wmbs_workflow table,
  this priority is filled by the WMBSHelper the first time a workflow
  is injected into WMBS by the WorkQueue. The value used is the one
  available in the spec.
- Local WorkQueue changes
  The scope of these changes is to prevent priority inversion due
  to the different queues available in the WorkQueue/WMAgent/Batch system
  chain. The WorkQueue now considers priority of running/pending jobs
  and queued elements before acquiring and injecting work. This means
  that if all the pending jobs are of lower priority than an incoming
  element then this will not be prevented from being acquired and injected.
  E.g. The WMAgent has 100 jobs in condor, in pending status for site A, from a workflow
  with priority 500. Also in the local queue there is 100 jobs for site A from a workflow
  with priority 500. The element in the local queue is not injected because there are already
  100 jobs of equal priority in the batch system. Now, someone creates and assigns a workflow
  to site A with priority 1000. Then that element will be acquired into the LQ
  and injected in WMBS because the 100 job slots are occupied only by lower priority jobs.
- JobSubmitter
  The JobSubmitter now order the workflows with jobs to submit by priority and timestamp,
  this means that when slots are available the high priority workflows will be submitted
  first (after considering the task priorities). In case of equal priority, then the
  older workflow is submitted first.
- BossAir/CondorPlugin
  The priority of the workflow is now propagated to condor through BossAir, the
  value passed to condor is a linear combination of the sub-task type priority
  and the request priority. This ensures that Merge/LogCollect/Cleanup/Harvest/Skim
  jobs are submitted faster regardless of priority to avoid missing data
  due to temporary files.
  Also the sub task path and the sub task type (e.g. Processing) is passed
  to the condor JDL as this allows more efficients updates later.
- Resource control
  Make sub-task type priorities equal for all sites,
  the granularity creates more inconveniences down the road
  and currently there is no use case for them.
  Simplifies the priority system in submission.
- JobUpdater (New component)
  
  The JobUpdater is a new component which makes sure that
  the information in the jobs already submitted to the batch
  system are up to date. At the moment this only
  concern the value of priority through the CondorPlugin.
  
  Additionally in the case of priority, it also ensures that
  the value is in synch with WMBS and the available elements
  in the Local Queue.

Fixes #4509.

Authors:

Diego Ballesteros (@dballesteros7)
Brian Bockelman (@bbockelm)
