### PR TITLE
Glide in wms takeover

### DIFF
--- a/src/couchapps/JobDump/updates/locationTransition.js
+++ b/src/couchapps/JobDump/updates/locationTransition.js
@@ -1,0 +1,21 @@
+/**
+ * Implement an update document to update a transition's location
+ * @author dballest
+ */
+function (doc, req) {
+    if (!doc) {
+        return [doc, 'FAIL']
+    };
+
+    var newLocation = req.query['location'];
+
+    var maxKey = 0;
+    for (key in doc.states) {
+        if (maxKey < parseInt(key)) {
+            maxKey = parseInt(key);
+        }
+    }
+
+    doc.states[(maxKey) + ""]['location'] = newLocation
+    return [doc, 'OK'];
+}

--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -637,8 +637,8 @@ class JobSubmitterPoller(BaseWorkerThread):
                     self.sandboxPackage[package] = cachedJob[3]
 
                     possibleSites = cachedJob[8]
-                    random.shuffle(possibleSites)
-                    fakeAssignedSiteName = possibleSites[0]
+                    possibleSiteList = list(possibleSites)
+                    fakeAssignedSiteName = random.choice(possibleSiteList)
 
                     # Create a job dictionary object
                     jobDict = {'id': cachedJob[0],

--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -10,6 +10,7 @@ _JobSubmitterPoller_t_
 Submit jobs for execution.
 """
 
+import random
 import logging
 import threading
 import os.path
@@ -635,10 +636,14 @@ class JobSubmitterPoller(BaseWorkerThread):
                     # Add the sandbox to a global list
                     self.sandboxPackage[package] = cachedJob[3]
 
+                    possibleSites = cachedJob[8]
+                    random.shuffle(possibleSites)
+                    fakeAssignedSiteName = possibleSites[0]
+
                     # Create a job dictionary object
                     jobDict = {'id': cachedJob[0],
                                'retry_count': cachedJob[1],
-                               'custom': {'location': siteName},
+                               'custom': {'location': fakeAssignedSiteName},
                                'cache_dir': cachedJob[4],
                                'packageDir': package,
                                'userdn': cachedJob[5],
@@ -646,7 +651,7 @@ class JobSubmitterPoller(BaseWorkerThread):
                                'userrole': cachedJob[7],
                                'priority': taskPriority,
                                'taskType': taskType,
-                               'possibleSites': cachedJob[8],
+                               'possibleSites': possibleSites,
                                'scramArch': cachedJob[9],
                                'swVersion': cachedJob[10],
                                'name': cachedJob[11],
@@ -660,7 +665,8 @@ class JobSubmitterPoller(BaseWorkerThread):
                     jobsToSubmit[package].append(jobDict)
 
                     # Deal with accounting
-                    nJobsRequired -= 1
+                    if len(possibleSites) == 1:
+                        nJobsRequired -= 1
                     totalPending  += 1
                     taskPending   += 1
 

--- a/src/python/WMCore/BossAir/BossAirAPI.py
+++ b/src/python/WMCore/BossAir/BossAirAPI.py
@@ -22,6 +22,7 @@ import threading
 import logging
 import subprocess
 
+from WMCore.JobStateMachine.ChangeState import ChangeState
 from WMCore.DAOFactory          import DAOFactory
 from WMCore.WMFactory           import WMFactory
 from WMCore.BossAir.RunJob      import RunJob
@@ -73,6 +74,7 @@ class BossAirAPI(WMConnectionBase):
         self.checkProxy = getattr(config.BossAir, 'checkProxy', False)
         self.cert       = getattr(config.BossAir, 'cert', None)
 
+        self.stateMachine = ChangeState(self.config)
 
         # Create a factory to load plugins
         self.pluginFactory = WMFactory("plugins", self.pluginDir)
@@ -80,7 +82,6 @@ class BossAirAPI(WMConnectionBase):
         self.daoFactory = DAOFactory(package = "WMCore.BossAir",
                                      logger = myThread.logger,
                                      dbinterface = myThread.dbi)
-
 
         self.deleteDAO      = self.daoFactory(classname = "DeleteJobs")
         self.stateDAO       = self.daoFactory(classname = "NewState")
@@ -301,6 +302,10 @@ class BossAirAPI(WMConnectionBase):
         self.updateDAO.execute(jobs = jobs, conn = self.getDBConn(),
                                transaction = self.existingTransaction())
 
+        jobsWithLocation = filter(lambda x : x.get('location') is not None, jobs)
+        if jobsWithLocation:
+            self.stateMachine.recordLocationChange(jobsWithLocation)
+
         self.commitTransaction(existingTransaction)
 
         return
@@ -491,7 +496,6 @@ class BossAirAPI(WMConnectionBase):
         """
 
         jobsToChange   = []
-        loadedJobs     = []
         jobsToComplete = []
         jobsToReturn   = []
         returnList     = []

--- a/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
@@ -611,6 +611,10 @@ class CondorPlugin(BasePlugin):
                 if not job['status_time']:
                     if job['status'] == 'Running':
                         job['status_time'] = int(jobAd.get('runningTime', 0))
+                        # If we transitioned to running then check the site we are running at
+                        job['location'] = jobAd.get('runningCMSSite', None)
+                        if job['location'] is None:
+                            logging.debug('Something is not right here, a job (%s) is running with no CMS site' % str(jobAd))
                     elif job['status'] == 'Idle':
                         job['status_time'] = int(jobAd.get('submitTime', 0))
                     else:
@@ -618,8 +622,6 @@ class CondorPlugin(BasePlugin):
                     changeList.append(job)
 
                 runningList.append(job)
-
-
 
         return runningList, changeList, completeList
 
@@ -752,6 +754,7 @@ class CondorPlugin(BasePlugin):
         jdl.append("Log = condor.$(Cluster).$(Process).log\n")
 
         jdl.append("+WMAgent_AgentName = \"%s\"\n" %(self.agent))
+        jdl.append("+JOBGLIDEIN_CMSSite= \"$$([ifThenElse(GLIDEIN_CMSSite is undefined, \\\"Unknown\\\", GLIDEIN_CMSSite)])\"\n")
 
         jdl.extend(self.customizeCommon(jobList))
 
@@ -937,6 +940,7 @@ class CondorPlugin(BasePlugin):
                    '-format', '(stateTime:\%s)  ', 'EnteredCurrentStatus',
                    '-format', '(runningTime:\%s)  ', 'JobStartDate',
                    '-format', '(submitTime:\%s)  ', 'QDate',
+                   '-format', '(runningCMSSite:\%s)  ', 'MATCH_EXP_JOBGLIDEIN_CMSSite',
                    '-format', '(WMAgentID:\%d):::',  'WMAgent_JobID']
 
         pipe = subprocess.Popen(command, stdout = subprocess.PIPE, stderr = subprocess.PIPE, shell = False)

--- a/src/python/WMCore/WMBS/MySQL/Jobs/UpdateLocation.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/UpdateLocation.py
@@ -1,0 +1,35 @@
+"""
+_UpdateLocation_
+
+MySQL implementation of Jobs.UpdateLocation
+
+Created on Apr 17, 2013
+
+@author: dballest
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class UpdateLocation(DBFormatter):
+    """
+    _UpdateLocation_
+
+    Update the location of the job in WMBS, must be a valid
+    site in wmbs_location.
+    """
+
+    sql = """
+          UPDATE wmbs_job
+          SET location = COALESCE((SELECT id FROM wmbs_location WHERE cms_name = :location), location)
+          WHERE id = :jobID
+          """
+
+    def execute(self, jobs, conn = None, transaction = False):
+        binds = []
+        for job in jobs:
+            bind = {'jobID' : job['jobid'],
+                    'location' : job['location']}
+            binds.append(bind)
+        self.dbi.processData(self.sql, binds, conn = conn,
+                             transaction = transaction)
+        return

--- a/src/python/WMCore/WMBS/Oracle/Jobs/UpdateLocation.py
+++ b/src/python/WMCore/WMBS/Oracle/Jobs/UpdateLocation.py
@@ -1,0 +1,14 @@
+"""
+_UpdateLocation_
+
+Oracle implementation of Jobs.UpdateLocation
+
+Created on Apr 18, 2013
+
+@author: dballest
+"""
+
+from WMCore.WMBS.MySQL.Jobs.UpdateLocation import UpdateLocation as MySQLUpdateLocation
+
+class UpdateLocation(MySQLUpdateLocation):
+    pass


### PR DESCRIPTION
Record location changes in WMBS and Couch

```
Whenever a job starts running, check the CMS site
where it started and store in WMBS and the transition
record in the JobDump in CouchDB. This ensures that
WMStats has the proper monitoring information and
runtime errors are attributed to the right site.
```

Disregard thresholds for jobs with multiple possible running sites. For monitoring purposes, report one random site in the possible site list as the 'pending' site.
