### PR TITLE
ReqMgr - ProcessingString, ProcessingVersion

### DIFF
--- a/src/python/WMCore/RequestManager/RequestDB/Interface/Request/GetRequest.py
+++ b/src/python/WMCore/RequestManager/RequestDB/Interface/Request/GetRequest.py
@@ -86,9 +86,13 @@ def getRequest(requestId, reverseTypes=None, reverseStatus=None):
     try:
         helper = Utilities.loadWorkload(request)
         request["AcquisitionEra"] = str(helper.getAcquisitionEra())
+        # add ProcessingVersion and ProcessingString in the response (#4561)
+        request["ProcessingVersion"] = str(helper.getProcessingVersion())
+        request["ProcessingString"] = str(helper.getProcessingString())
     except Exception, ex:
         logging.error("Could not check workload for %s, reason: %s" %
                       (request["RequestName"], ex))
+    
     return request
 
 


### PR DESCRIPTION
ProcessingString, ProcessingVersion were missing in the get request response
details. This information is stored only on spec (nor on Oracle or
CouchDB). It may be stored in CouchDB if the request defined this at the
injection time. Added now in the response.
Fixes #4561
