### PR TITLE
Removed GroupUser couchapp from ReqMgr unittests

### DIFF
--- a/test/python/WMCore_t/RequestManager_t/Admin_t.py
+++ b/test/python/WMCore_t/RequestManager_t/Admin_t.py
@@ -1,9 +1,6 @@
-#!/usr/bin/env python
-
 """
-Admin_t
-
 Test for code in the RequestDB/Admin section
+
 """
 import os
 import unittest
@@ -20,8 +17,6 @@ from WMCore_t.RequestManager_t import utils
 
 class AdminTest(RESTBaseUnitTest):
     """
-    _AdminTest_
-
     Test for the lower-level DB code in the admin section
     
     """
@@ -33,8 +28,7 @@ class AdminTest(RESTBaseUnitTest):
         """
         self.couchDBName = "reqmgr_t_0"
         RESTBaseUnitTest.setUp(self)
-        self.testInit.setupCouch("%s" % self.couchDBName,
-                                 "GroupUser", "ConfigCache", "ReqMgr")
+        self.testInit.setupCouch("%s" % self.couchDBName, "ConfigCache", "ReqMgr")
         reqMgrHost = self.config.getServerUrl()
         self.jsonSender = JSONRequests(reqMgrHost)
 

--- a/test/python/WMCore_t/RequestManager_t/Assign_t.py
+++ b/test/python/WMCore_t/RequestManager_t/Assign_t.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
-
 """
+
 RequestManager unittest
 
 Tests the functions of the REST API
@@ -28,11 +27,6 @@ from WMCore_t.RequestManager_t.ReqMgr_t import RequestManagerConfig
 
 
 class AssignTest(RESTBaseUnitTest):
-    """
-    _AssignTest_
-
-    """
-
     def setUp(self):
         """
         setUP global values
@@ -41,8 +35,7 @@ class AssignTest(RESTBaseUnitTest):
         """
         self.couchDBName = "reqmgr_t_0"
         RESTBaseUnitTest.setUp(self, initRoot = False)
-        self.testInit.setupCouch("%s" % self.couchDBName,
-                                 "GroupUser", "ConfigCache", "ReqMgr")
+        self.testInit.setupCouch("%s" % self.couchDBName, "ConfigCache", "ReqMgr")
         reqMgrHost = self.config.getServerUrl()
         self.jsonSender = JSONRequests(reqMgrHost)
         

--- a/test/python/WMCore_t/RequestManager_t/ReqMgrPriority_t.py
+++ b/test/python/WMCore_t/RequestManager_t/ReqMgrPriority_t.py
@@ -24,8 +24,6 @@ from WMCore_t.RequestManager_t import utils
 
 class ReqMgrPriorityTest(RESTBaseUnitTest):
     """
-    _ReqMgrPriorityTest_
-
     Basic test for setting the priority in ReqMgr Services
     
     """
@@ -37,11 +35,9 @@ class ReqMgrPriorityTest(RESTBaseUnitTest):
         """
         self.couchDBName = "reqmgr_t_0"
         RESTBaseUnitTest.setUp(self)
-        self.testInit.setupCouch("%s" % self.couchDBName,
-                                 "GroupUser", "ConfigCache", "ReqMgr")
-        self.testInit.setupCouch("%s_wmstats" % self.couchDBName,
-                                 "WMStats")
-        reqMgrHost      = self.config.getServerUrl()
+        self.testInit.setupCouch("%s" % self.couchDBName, "ConfigCache", "ReqMgr")
+        self.testInit.setupCouch("%s_wmstats" % self.couchDBName, "WMStats")
+        reqMgrHost = self.config.getServerUrl()
         self.jsonSender = JSONRequests(reqMgrHost)
         
 

--- a/test/python/WMCore_t/RequestManager_t/ReqMgrWebTools_t.py
+++ b/test/python/WMCore_t/RequestManager_t/ReqMgrWebTools_t.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 Unittest for ReqMgr utilities
 
@@ -11,8 +9,6 @@ from WMCore.HTTPFrontEnd.RequestManager import ReqMgrWebTools
 
 class ReqMgrWebToolsTest(unittest.TestCase):
     """
-    _ReqMgrWebTools_
-
     Test class for the ReqMgr utility functions
 
     This ONLY tests things that don't touch the DB

--- a/test/python/WMCore_t/RequestManager_t/ReqMgrWorkload_t.py
+++ b/test/python/WMCore_t/RequestManager_t/ReqMgrWorkload_t.py
@@ -28,8 +28,6 @@ from WMCore_t.RequestManager_t import utils
 
 class ReqMgrWorkloadTest(RESTBaseUnitTest):
     """
-    _ReqMgrWorkloadTest_
-
     Test that sets up and checks the validations of the various main WMSpec.StdSpecs
     This is mostly a simple set of tests which can be very repetitive.
     
@@ -39,13 +37,12 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         """
         setUP global values
         Database setUp is done in base class
+        
         """
         self.couchDBName = "reqmgr_t_0"
         RESTBaseUnitTest.setUp(self)
-        self.testInit.setupCouch("%s" % self.couchDBName,
-                                 "GroupUser", "ConfigCache", "ReqMgr")
-        self.testInit.setupCouch("%s_wmstats" % self.couchDBName,
-                                 "WMStats")
+        self.testInit.setupCouch("%s" % self.couchDBName, "ConfigCache", "ReqMgr")
+        self.testInit.setupCouch("%s_wmstats" % self.couchDBName, "WMStats")
         reqMgrHost = self.config.getServerUrl()
         self.jsonSender = JSONRequests(reqMgrHost)
 
@@ -787,6 +784,7 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         self.assertEqual(request['SizePerEvent'], 512)
         self.assertEqual(request['RequestNumEvents'], 100)
         self.assertEqual(request['RequestSizeFiles'], 0)
+
 
 if __name__=='__main__':
     unittest.main()

--- a/test/python/WMCore_t/RequestManager_t/ReqMgr_t.py
+++ b/test/python/WMCore_t/RequestManager_t/ReqMgr_t.py
@@ -71,8 +71,6 @@ class RequestManagerConfig(DefaultConfig):
         
 class ReqMgrTest(RESTBaseUnitTest):
     """
-    _ReqMgrTest_
-
     Basic test for the ReqMgr services.
     Setup is done off-screen in RESTBaseUnitTest - this makes
     things confusing
@@ -86,8 +84,7 @@ class ReqMgrTest(RESTBaseUnitTest):
         """
         self.couchDBName = "reqmgr_t_0"
         RESTBaseUnitTest.setUp(self)
-        self.testInit.setupCouch("%s" % self.couchDBName,
-                                 "GroupUser", "ConfigCache", "ReqMgr")
+        self.testInit.setupCouch("%s" % self.couchDBName, "ConfigCache", "ReqMgr")
         self.testInit.setupCouch("%s_wmstats" % self.couchDBName,
                                  "WMStats")
         reqMgrHost = self.config.getServerUrl()


### PR DESCRIPTION
ReqMgr unittests pushing GroupUser couchapp was not necessary, removed. The
couchapp is not used in ReqMgr at all.
