### PR TITLE
Extend LHEStepZero support

### DIFF
--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrBrowser.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrBrowser.py
@@ -172,6 +172,11 @@ class ReqMgrBrowser(WebAPI):
             splitParams["events_per_job"] = int(submittedParams["events_per_job"])
             if submittedParams.has_key("events_per_lumi"):
                 splitParams["events_per_lumi"] = int(submittedParams["events_per_lumi"])
+            if "lheInputFiles" in submittedParams:
+                if str(submittedParams["lheInputFiles"]) == "True":
+                    splitParams["lheInputFiles"] = True
+                else:
+                    splitParams["lheInputFiles"] = False
         elif splittingAlgo == "Harvest":
             splitParams["periodic_harvest_interval"] = int(submittedParams["periodic_harvest_interval"])
         elif 'Merg' in splittingTask:

--- a/src/python/WMCore/JobSplitting/EventBased.py
+++ b/src/python/WMCore/JobSplitting/EventBased.py
@@ -28,6 +28,7 @@ class EventBased(JobFactory):
         eventsPerJob = int(kwargs.get("events_per_job", 100))
         eventsPerLumi = int(kwargs.get("events_per_lumi", eventsPerJob))
         getParents   = kwargs.get("include_parents", False)
+        lheInput = kwargs.get("lheInputFiles", False)
         collectionName  = kwargs.get('collectionName', None)
         timePerEvent, sizePerEvent, memoryRequirement = \
                     self.getPerformanceParameters(kwargs.get('performance', {}))
@@ -122,7 +123,8 @@ class EventBased(JobFactory):
                     if acdcFileList:
                         if f['lfn'] in [x['lfn'] for x in acdcFileList]:
                             self.createACDCJobs(f, acdcFileList,
-                                                timePerEvent, sizePerEvent, memoryRequirement)
+                                                timePerEvent, sizePerEvent, memoryRequirement,
+                                                lheInput)
                         continue
                     #This assumes there's only one run which is the case for MC
                     lumis = runs[0].lumis
@@ -133,6 +135,7 @@ class EventBased(JobFactory):
                         while totalEvents < eventsInFile:
                             self.newJob(name = self.getJobName(length=totalJobs))
                             self.currentJob.addFile(f)
+                            self.currentJob.addBaggageParameter("lheInputFiles",lheInput)
                             lumisPerJob = int(ceil(float(eventsPerJob)
                                                 / eventsPerLumi))
                             #Limit the number of events to a unsigned 32bit int
@@ -180,7 +183,8 @@ class EventBased(JobFactory):
                         totalJobs += 1
 
     def createACDCJobs(self, fakeFile, acdcFileInfo,
-                       timePerEvent, sizePerEvent, memoryRequirement):
+                       timePerEvent, sizePerEvent, memoryRequirement,
+                       lheInputOption):
         """
         _createACDCJobs_
 
@@ -191,6 +195,7 @@ class EventBased(JobFactory):
         for acdcFile in acdcFileInfo:
             if fakeFile['lfn'] == acdcFile['lfn']:
                 self.newJob(name = self.getJobName(length = totalJobs))
+                self.currentJob.addBaggageParameter("lheInputFiles", lheInputOption)
                 self.currentJob.addFile(fakeFile)
                 self.currentJob["mask"].setMaxAndSkipEvents(acdcFile["events"],
                                                             acdcFile["first_event"])

--- a/src/python/WMCore/WMSpec/StdSpecs/LHEStepZero.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/LHEStepZero.py
@@ -39,6 +39,7 @@ class LHEStepZeroWorkloadFactory(MonteCarloWorkloadFactory):
 
     def __init__(self):
         MonteCarloWorkloadFactory.__init__(self)
+        self.lheInputFiles = False
 
     def __call__(self, workloadName, arguments):
         """
@@ -51,6 +52,9 @@ class LHEStepZeroWorkloadFactory(MonteCarloWorkloadFactory):
         filterEfficiency = float(arguments.get('FilterEfficiency', 1.0))
         totalTime        = int(arguments.get('TotalTime', 9 * 3600))
         self.totalEvents = int(int(arguments['RequestNumEvents']) / filterEfficiency)
+        if arguments.get("LheInputFiles", False) == True \
+             or arguments.get("LheInputFiles", False) == "True":
+            self.lheInputFiles = True
 
         # These are mostly place holders because the job splitting algo and
         # parameters will be updated after the workflow has been created.
@@ -59,6 +63,7 @@ class LHEStepZeroWorkloadFactory(MonteCarloWorkloadFactory):
         self.prodJobSplitArgs  = arguments.setdefault("ProdJobSplitArgs",
                                                {"events_per_job": eventsPerJob,
                                                 "events_per_lumi": arguments['EventsPerLumi']})
+        self.prodJobSplitArgs.setdefault("lheInputFiles", self.lheInputFiles)
         mcWorkload = MonteCarloWorkloadFactory.__call__(self, workloadName, arguments)
         mcWorkload.setBlockCloseSettings(mcWorkload.getBlockCloseMaxWaitTime(), 5,
                                          250000000, mcWorkload.getBlockCloseMaxSize())

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -440,6 +440,11 @@ class WMTaskHelper(TreeHelper):
           merge_across_runs
           runWhitelist
 
+        Preserve parameters which can be set up at request creation and if not
+        specified should remain unchanged, at the moment these are:
+            include_parents
+            lheInputFiles
+
         Also preserve the performance section.
         """
         setACDCParams = {}
@@ -449,6 +454,11 @@ class WMTaskHelper(TreeHelper):
             if hasattr(self.data.input.splitting, paramName):
                 setACDCParams[paramName] = getattr(self.data.input.splitting,
                                                    paramName)
+        preservedParams = {}
+        for paramName in ["lheInputFiles", "include_parents"]:
+            if hasattr(self.data.input.splitting, paramName):
+                preservedParams[paramName] = getattr(self.data.input.splitting,
+                                                     paramName)
         performanceConfig = getattr(self.data.input.splitting, "performance", None)
         
         delattr(self.data.input, "splitting")
@@ -456,6 +466,7 @@ class WMTaskHelper(TreeHelper):
         self.data.input.splitting.section_("performance")
 
         setattr(self.data.input.splitting, "algorithm", algoName)
+        self.setSplittingParameters(**preservedParams)
         self.setSplittingParameters(**params)
         self.setSplittingParameters(**setACDCParams)
         if performanceConfig is not None:

--- a/src/templates/WMCore/WebTools/RequestManager/Splitting.tmpl
+++ b/src/templates/WMCore/WebTools/RequestManager/Splitting.tmpl
@@ -200,6 +200,15 @@ function generateProduction(splitAlgo, splitParams) {
   if ("events_per_lumi" in splitParams) {
     procStr += generateInputRow("Events per lumi:", "events_per_lumi", splitParams);
   }
+  if ("lheInputFiles" in splitParams) {
+    procStr += '<tr><td>Processing LHE files?: <select name="lheInputFiles">';
+      if (splitParams["lheInputFiles"] == true) {
+        procStr += "<option selected>True</option><option>False</option>\n";
+      } else {
+        procStr += "<option>True</option><option selected>False</option>\n";
+      }
+      procStr += '</td></tr>\n'
+  }
   procStr += "</table>\n";
   return procStr;
 }

--- a/test/python/WMCore_t/JobSplitting_t/EventBased_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/EventBased_t.py
@@ -427,6 +427,7 @@ class EventBasedTest(unittest.TestCase):
         jobFactory = splitter(singleMCSubscription)
 
         jobGroups = jobFactory(events_per_job = 99,
+                               lheInputFiles = True,
                                performance = self.performanceParams)
         self.assertEqual(len(jobGroups), 1,
                          "Error: JobFactory did not return one JobGroup")
@@ -444,6 +445,7 @@ class EventBasedTest(unittest.TestCase):
             self.assertTrue(firstJobCondition or secondJobCondition,
                             "Job mask: %s didn't pass neither of the conditions"
                             % job["mask"])
+            self.assertTrue(job.getBaggage().lheInputFiles)
 
 
     def testMC50EventSplit(self):
@@ -477,6 +479,8 @@ class EventBasedTest(unittest.TestCase):
             self.assertTrue(firstJobCondition or secondJobCondition,
                             "Job mask: %s didn't pass neither of the conditions"
                             % job["mask"])
+            self.assertFalse(job.getBaggage().lheInputFiles)
+
         return
 
     def testMCShiftedEventSplit(self):


### PR DESCRIPTION
Include a new option that indicates if we are processing
lhe input files instead of forking a generator in cmsRun,
this way the input source options are set correctly
to read n events per job.

Fixes #2090
