### PR TITLE
Cascade close-out

### DIFF
--- a/src/couchapps/ReqMgr/views/childresubmissionrequests/map.js
+++ b/src/couchapps/ReqMgr/views/childresubmissionrequests/map.js
@@ -1,0 +1,10 @@
+/**
+ * Given a request name obtain the Resubmission requests where request is the input
+ * collection.
+ * @author Diego Ballesteros
+ */
+function(doc){
+    if(doc["OriginalRequestName"]){
+        emit(doc["OriginalRequestName"], null);
+    }
+}

--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
@@ -677,3 +677,20 @@ def associateCampaign(campaign, requestName, couchURL, couchDBName):
     helper = loadWorkload(request)
     helper.setCampaign(campaign = campaign)
     helper.saveCouch(couchUrl = couchURL, couchDBName = couchDBName)
+
+def retrieveResubmissionChildren(requestName, couchUrl, couchDBName):
+    """
+    _retrieveResubmissionChildren_
+
+    Construct a list of request names which are the resubmission
+    offspring from a request. This is a recursive
+    call with a single requestName as input.
+    The result only includes the children and not the original request.
+    """
+    childrenRequestNames = []
+    reqmgrDb = Database(couchDBName, couchUrl)
+    result = reqmgrDb.loadView('ReqMgr', 'childresubmissionrequests', keys = [requestName])['rows']
+    for child in result:
+        childrenRequestNames.append(child['id'])
+        childrenRequestNames.extend(retrieveResubmissionChildren(child['id'], couchUrl, couchDBName))
+    return childrenRequestNames

--- a/test/python/WMCore_t/RequestManager_t/ReqMgrWorkload_t.py
+++ b/test/python/WMCore_t/RequestManager_t/ReqMgrWorkload_t.py
@@ -676,8 +676,13 @@ class ReqMgrWorkloadTest(RESTBaseUnitTest):
         result = self.jsonSender.put('request/testRequest', schema)
         resubmitName = result[0]['RequestName']
         result = self.jsonSender.get('request/%s' % resubmitName)
-        request = result[0]
-        
+
+        couchServer = CouchServer(self.testInit.couchUrl)
+        reqmgrCouch = couchServer.connectDatabase(self.couchDBName)
+        result = reqmgrCouch.loadView('ReqMgr', 'childresubmissionrequests', {}, [requestName])['rows']
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['key'], requestName)
+        self.assertEqual(result[0]['id'], resubmitName)
 
     def testK_LHEStepZero(self):
         """

--- a/test/python/WMCore_t/RequestManager_t/ReqMgr_t.py
+++ b/test/python/WMCore_t/RequestManager_t/ReqMgr_t.py
@@ -740,5 +740,49 @@ class ReqMgrTest(RESTBaseUnitTest):
             self.assertRaises(HTTPException, self.jsonSender.put, "request", schema)
             
 
+    def testL_CascadeCloseOutAnnnouncement(self):
+        myThread = threading.currentThread()
+        userName     = 'Taizong'
+        groupName    = 'Li'
+        teamName     = 'Tang'
+        schema       = utils.getAndSetupSchema(self,
+                                               userName = userName,
+                                               groupName = groupName,
+                                               teamName = teamName)
+        result = self.jsonSender.put("request", schema)[0]
+        originalRequest = result['RequestName']
+        depth = 2
+        nReq = 3
+        requests = [originalRequest]
+        def createChildrenRequest(parentRequest, i, nReq):
+            createdRequests = []
+            resubSchema = utils.getResubmissionSchema(parentRequest, "/%s/DataProcessing" % parentRequest,
+                                                      groupName, userName)
+            result = self.jsonSender.put("request", resubSchema)[0]
+            requestName = result['RequestName']
+            createdRequests.append(requestName)
+            if i:
+                for _ in range(nReq):
+                    createdRequests.extend(createChildrenRequest(requestName, i - 1, nReq))
+            return createdRequests
+        requests.extend(createChildrenRequest(originalRequest, depth, nReq))
+        for request in requests:
+            self.changeStatusAndCheck(request, 'assignment-approved')
+        for request in requests:
+            self.jsonSender.put("assignment?team=%s&requestName=%s" % (teamName, request))
+        for status in ['acquired',
+                       'running-open', 'running-closed',
+                       'completed']:
+            for request in requests:
+                self.changeStatusAndCheck(request, status)
+        self.jsonSender.post('closeout?requestName=%s&cascade=True' % originalRequest)
+        for request in requests:
+            result = self.jsonSender.get('request/%s' % request)
+            self.assertEqual(result[0]['RequestStatus'], 'closed-out')
+        self.jsonSender.post('announce?requestName=%s&cascade=True' % originalRequest)
+        for request in requests:
+            result = self.jsonSender.get('request/%s' % request)
+            self.assertEqual(result[0]['RequestStatus'], 'announced')
+
 if __name__=='__main__':
     unittest.main()

--- a/test/python/WMCore_t/RequestManager_t/utils.py
+++ b/test/python/WMCore_t/RequestManager_t/utils.py
@@ -38,3 +38,19 @@ def getSchema(groupName = 'PeopleLikeMe', userName = 'me'):
     schema['Memory'] = 3000
     schema['SizePerEvent'] = 512
     return schema
+
+def getResubmissionSchema(originalRequest, initialTask,
+                          groupName = 'PeopleLikeMe', userName = 'me'):
+    schema = {}
+    schema['RequestName'] = 'TestResubmission'
+    schema['RequestType'] = 'Resubmission'
+    schema['Requestor'] = '%s' % userName
+    schema['Group'] = '%s' % groupName
+    schema['TimePerEvent'] = '12'
+    schema['Memory'] = 3000
+    schema['SizePerEvent'] = 512
+    schema['OriginalRequestName'] = originalRequest
+    schema['InitialTaskPath'] = initialTask
+    schema['ACDCServer'] = os.environ['COUCHURL']
+    schema['ACDCDatabase'] = 'bogus'
+    return schema


### PR DESCRIPTION
Implement the option to close-out/announce requests and cascade the
status change to all resubmission children for the request.

For this there is a new view which allows the ReqMgr service
to construct the resubmission tree starting from a "original" request.

Usage:

<reqmgrHost>/reqMgr/closeout?requestName=<rootRequest>&cascade=True
<reqmgrHost>/reqMgr/announce?requestName=<rootRequest>&cascade=True
Fixes #4477
