### PR TITLE
Support a many-to-many CMS site to SE relation

### DIFF
--- a/bin/wmagent-resource-control
+++ b/bin/wmagent-resource-control
@@ -106,11 +106,12 @@ def getCMSSiteInfo(pattern):
 
     siteDB = SiteDBJSON()
     for seName in siteDB.cmsNametoList(pattern, "SE", "result.json"):
-        cmsName = siteDB.seToCMSName(seName)
-        if nameSEMapping.has_key(cmsName):
-            nameSEMapping[cmsName].append(seName)
-        else:
-            nameSEMapping[cmsName] = [seName]
+        cmsNames = siteDB.seToCMSName(seName)
+        for cmsName in cmsNames:
+            if cmsName in nameSEMapping:
+                nameSEMapping[cmsName].append(seName)
+            else:
+                nameSEMapping[cmsName] = [seName]
 
     return nameSEMapping
 

--- a/src/python/WMCore/WorkQueue/DataLocationMapper.py
+++ b/src/python/WMCore/WorkQueue/DataLocationMapper.py
@@ -142,7 +142,8 @@ class DataLocationMapper():
                     seNames = dbs.listDatasetLocation(item)
                 else:
                     seNames = dbs.listFileBlockLocation(item)
-                result[item].update([self.sitedb.seToCMSName(x) for x in seNames])
+                for se in seNames:
+                    result[item].update(self.sitedb.seToCMSName(se))
             except Exception, ex:
                 logging.error('Erro getting block location from dbs for %s: %s' % (item, str(ex)))
 

--- a/src/python/WMCore/WorkQueue/WorkQueueUtils.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueUtils.py
@@ -47,11 +47,11 @@ def sitesFromStorageEelements(ses):
     result = set()
     for se in ses:
         try:
-            site = __sitedb.seToCMSName(se)
+            sites = __sitedb.seToCMSName(se)
         except:
             print "Unable to get site name for %s" % se
         else:
-            result.add(site)
+            result.update(sites)
     return list(result)
 
 __cmsSiteNames = []

--- a/test/python/WMCore_t/Services_t/SiteDB_t/SiteDB_t.py
+++ b/test/python/WMCore_t/Services_t/SiteDB_t/SiteDB_t.py
@@ -59,8 +59,11 @@ class SiteDBTest(unittest.TestCase):
         """
         Tests CmsNametoSE
         """
-        target = 'T1_US_FNAL'
+        target = ['T1_US_FNAL']
         results = self.mySiteDB.seToCMSName("cmssrm.fnal.gov")
+        self.failUnless(results == target)
+        target = sorted(['T2_CH_CERN', 'T2_CH_CERN_HLT'])
+        results = sorted(self.mySiteDB.seToCMSName("srm-eoscms.cern.ch"))
         self.failUnless(results == target)
 
     def testCmsNametoCE(self):
@@ -76,8 +79,8 @@ class SiteDBTest(unittest.TestCase):
         """
         Tests DN to Username lookup
         """
-        testDn = "/C=UK/O=eScience/OU=Bristol/L=IS/CN=simon metson"
-        testUserName = "metson"
+        testDn = "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=gutsche/CN=582680/CN=Oliver Gutsche"
+        testUserName = "gutsche"
         userName = self.mySiteDB.dnUserName(dn=testDn)
         self.failUnless(testUserName == userName)
 


### PR DESCRIPTION
Make sure that data is read properly from siteDB when building
lists of sites from a SE, taking into account that a se can be
shared by many CMS sites.

Update the test emulator such that the unit test works when
disabling the emulator in it.
