### PR TITLE
Fix queries for Oracle compatibility

### DIFF
--- a/src/python/WMComponent/DBSUpload/Database/MySQL/LoadBlocksByDAS.py
+++ b/src/python/WMComponent/DBSUpload/Database/MySQL/LoadBlocksByDAS.py
@@ -23,14 +23,17 @@ class LoadBlocksByDAS(DBFormatter):
                 INNER JOIN dbsbuffer_location dbl ON dbl.id = dbb.location
                 INNER JOIN dbsbuffer_workflow dbw ON dbw.id = dbf3.workflow
                 WHERE dbb.status = 'Open'
-                AND dbf3.dataset_algo = :das
-                GROUP BY dbb.blockname"""
+                AND dbf3.dataset_algo = :das"""
 
     def format(self, result):
         tmpList = self.formatDict(result)
         blockList = []
+        blockNames = set()
         for tmp in tmpList:
             final = {}
+            if tmp['blockname'] in blockNames:
+                # Block with different settings, ignore
+                continue
             final['ID']            = tmp['id']
             final['Name']          = tmp['blockname']
             final['CreationDate']  = tmp['create_time']
@@ -46,6 +49,7 @@ class LoadBlocksByDAS(DBFormatter):
             final['MaxCloseFiles'] = tmp['block_close_max_files']
             final['MaxCloseSize'] = tmp['block_close_max_size']
             blockList.append(final)
+            blockNames.add(tmp['blockname'])
 
         return blockList
 


### PR DESCRIPTION
They were using a MySQL only feature in the group by
to prevent duplicates. Do the duplicate filtering
after the database query to keep a single compatible query.

This is a bugfix for 0.9.59 and onwards.
