### PR TITLE
Implement ACDC cleanup operations in ReqMgr

### DIFF
--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -53,7 +53,8 @@ dependencies = {'wmc-rest':{
                                      'WMCore.Services.WMBS',
                                      'WMCore.Services.WMAgent',
                                      'WMCore.Services.Dashboard',
-                                     'WMCore.Services.WMStats'],
+                                     'WMCore.Services.WMStats',
+                                     'WMCore.ACDC'],
 
                         'systems':['wmc-web', 'wmc-runtime'],
                         'statics': ['src/templates/WMCore/WebTools/RequestManager',

--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/Announce.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/Announce.py
@@ -16,6 +16,7 @@ class Announce(BulkOperations):
     def __init__(self, config):
         BulkOperations.__init__(self, config)
         self.wmstatWriteURL = "%s/%s" % (config.couchUrl.rstrip('/'), config.wmstatDBName)
+        self.acdcURL = "%s/%s" % (config.couchUrl.rstrip('/'), config.acdcDBName)
         self.searchFields = ["RequestName", "RequestType"]
 
     @cherrypy.expose
@@ -46,7 +47,8 @@ class Announce(BulkOperations):
         badDatasets = []
         for requestName in requests:
             WMCore.Lexicon.identifier(requestName)
-            ChangeState.changeRequestStatus(requestName, 'announced', wmstatUrl = self.wmstatWriteURL)
+            Utilities.changeStatus(requestName, 'announced', wmstatUrl = self.wmstatWriteURL,
+                                   acdcUrl = self.acdcURL)
             datasets.extend(Utilities.getOutputForRequest(requestName))
         for dataset in datasets:
             # was needed for the DBS call to wrong DBS URL

--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrBrowser.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrBrowser.py
@@ -71,6 +71,7 @@ class ReqMgrBrowser(WebAPI):
         self.workloadDBName = config.workloadDBName
         self.yuiroot = config.yuiroot
         self.wmstatWriteURL = "%s/%s" % (self.couchUrl.rstrip('/'), config.wmstatDBName)
+        self.acdcURL = "%s/%s" % (self.couchUrl.rstrip('/'), config.acdcDBName)
         cherrypy.engine.subscribe('start_thread', self.initThread)
 
     def initThread(self, thread_index):
@@ -354,7 +355,7 @@ class ReqMgrBrowser(WebAPI):
                     Utilities.changePriority(requestName, priority, self.wmstatWriteURL)
                     message += "Changed priority for %s to %s.\n" % (requestName, priority)
                 if status != "":
-                    Utilities.changeStatus(requestName, status, self.wmstatWriteURL)
+                    Utilities.changeStatus(requestName, status, self.wmstatWriteURL, self.acdcURL)
                     message += "Changed status for %s to %s\n" % (requestName, status)
                     if status == "assigned":
                         # make a page to choose teams

--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrConfiguration.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrConfiguration.py
@@ -22,6 +22,7 @@ def reqMgrConfig(
     workloadCouchDB = 'reqmgr_workload_cache',
     workloadSummaryCouchDB = "workloadsummary",
     wmstatCouchDB = "wmstats",
+    acdcCouchDB = "acdcserver",
     connectURL = None,
     startup = "Root.py",
     addMonitor = True):
@@ -70,6 +71,7 @@ def reqMgrConfig(
     config.reqmgr.configDBName = configCouchDB
     config.reqmgr.workloadDBName = workloadCouchDB
     config.reqmgr.wmstatDBName = wmstatCouchDB
+    config.reqmgr.acdcDBName = acdcCouchDB
     config.reqmgr.security_roles = ['Admin', 'Developer', 'Data Manager', 'developer', 'admin', 'data-manager']
     config.reqmgr.yuiroot = yuiroot
 

--- a/test/python/WMCore_t/RequestManager_t/ReqMgrPriority_t.py
+++ b/test/python/WMCore_t/RequestManager_t/ReqMgrPriority_t.py
@@ -37,6 +37,7 @@ class ReqMgrPriorityTest(RESTBaseUnitTest):
         RESTBaseUnitTest.setUp(self)
         self.testInit.setupCouch("%s" % self.couchDBName, "ConfigCache", "ReqMgr")
         self.testInit.setupCouch("%s_wmstats" % self.couchDBName, "WMStats")
+        self.testInit.setupCouch("%s_acdc" % self.couchDBName, "ACDC")
         reqMgrHost = self.config.getServerUrl()
         self.jsonSender = JSONRequests(reqMgrHost)
         


### PR DESCRIPTION
Include the ACDC database in the ReqMgr configuration
and cleanup collections from it when a request is moved
to announced.

@zdenekmaxa If the ACDC server is deployed this should be included for ReqMgr.
