### PR TITLE
ReqMgr Oracle/CouchDB consistency work

### DIFF
--- a/src/python/WMCore/ReqMgr/database_cleanup/README
+++ b/src/python/WMCore/ReqMgr/database_cleanup/README
@@ -3,29 +3,76 @@ with each other, these tools are supposed to help straighten things out
 (dumpers, checkers/comparators, updaters ...).
 
 
-Utilities for:
-    - dumping Oracle ReqMgr database into Python dictionaries
-    - comparison / consistency between ReqMgr Oracle database and CouchDB
-    - ultimate goal is to drop Oracle database from ReqMgr, keeping data only
-        in CouchDB
-    - as of 2013-01-16, ReqMgr Oracle database dump (in Python dictionaries)
-        is slightly under 900MB, approx. half is in the reqmgr_message table
+cd /data
+source /data/current/apps/reqmgr/etc/profile.d/init.sh
 
 Dump the entire Oracle database:
 	python ./oracle_dump.py user/password@server > oracle_dump.py
 
-
 Consistency check of the requests (reqmgr_request table and CouchDB) (on VM):
-cd /data
-source /data/current/apps/reqmgr/etc/profile.d/init.sh
-# dump only reqmgr_request table
-python /data/current/apps/reqmgr/lib/python2.6/site-packages/WMCore/ReqMgr/database_cleanup/oracle_dump.py user/pass@cms_reqmgr reqmgr_request > oracle_dump_request_table.py
-python /data/current/apps/reqmgr/lib/python2.6/site-packages/WMCore/ReqMgr/database_cleanup/oracle_couchdb_comparison.py oracle_dump_request_table.py > comparison.log
+	# dump only reqmgr_request table
+	python /data/current/apps/reqmgr/lib/python2.6/site-packages/WMCore/ReqMgr/database_cleanup/oracle_dump.py user/pass@cms_reqmgr reqmgr_request > oracle_dump_request_table.py
+	python /data/current/apps/reqmgr/lib/python2.6/site-packages/WMCore/ReqMgr/database_cleanup/oracle_couchdb_comparison.py oracle_dump_request_table.py > comparison.log
 
 
 Deleting requests from CouchDB:
-python /data/current/apps/reqmgr/lib/python2.6/site-packages/WMCore/ReqMgr/couchdb_cleanup.py requestlist.txt
+	python /data/current/apps/reqmgr/lib/python2.6/site-packages/WMCore/ReqMgr/database_cleanup/couchdb_cleanup.py requestlist.txt
 
 
 Request values level consistency check/correction:
-python /data/current/apps/reqmgr/lib/python2.6/site-packages/WMCore/ReqMgr/database_cleanup/oracle_couchdb_consistency_checker.py user/pass@cms_reqmgr 2>&1 | tee log
+	python /data/current/apps/reqmgr/lib/python2.6/site-packages/WMCore/ReqMgr/database_cleanup/oracle_couchdb_consistency_checker.py user/pass@cms_reqmgr 2>&1 | tee log
+	
+	
+
+
+
+
+Checking Oracle database from SQLPlus prompt, SQL queries:
+
+# get number of requests, returns all requests in the system:
+select count(REQUEST_NAME) from reqmgr_request;
+
+
+# get number of requests, returns all requests in the system ; 
+# check group information (reqmgr_request-reqmgr_group_association-reqmgr_group association):
+select count(reqmgr_request.REQUEST_NAME) from reqmgr_request, reqmgr_request_type, reqmgr_request_status, reqmgr_group, reqmgr_group_association where reqmgr_request_type.TYPE_ID=reqmgr_request.REQUEST_TYPE and reqmgr_request_status.STATUS_ID=reqmgr_request.REQUEST_STATUS and reqmgr_group.GROUP_ID=reqmgr_group_association.GROUP_ID and reqmgr_group_association.ASSOCIATION_ID=reqmgr_request.REQUESTOR_GROUP_ID;
+select count(reqmgr_group.GROUP_NAME) from reqmgr_request, reqmgr_request_type, reqmgr_request_status, reqmgr_group, reqmgr_group_association where reqmgr_request_type.TYPE_ID=reqmgr_request.REQUEST_TYPE and reqmgr_request_status.STATUS_ID=reqmgr_request.REQUEST_STATUS and reqmgr_group.GROUP_ID=reqmgr_group_association.GROUP_ID and reqmgr_group_association.ASSOCIATION_ID=reqmgr_request.REQUESTOR_GROUP_ID;
+
+
+# get number of requests, returns all requests in the system ;
+# check requestor information (reqmgr_request-reqmgr_group_association-reqmgr_requestor association):
+select count(reqmgr_request.REQUEST_NAME) from reqmgr_request, reqmgr_request_type, reqmgr_request_status, reqmgr_group, reqmgr_group_association, reqmgr_requestor where reqmgr_request_type.TYPE_ID=reqmgr_request.REQUEST_TYPE and reqmgr_request_status.STATUS_ID=reqmgr_request.REQUEST_STATUS and reqmgr_group.GROUP_ID=reqmgr_group_association.GROUP_ID and reqmgr_group_association.ASSOCIATION_ID=reqmgr_request.REQUESTOR_GROUP_ID and reqmgr_request.REQUESTOR_GROUP_ID=reqmgr_group_association.ASSOCIATION_ID and reqmgr_group_association.REQUESTOR_ID=reqmgr_requestor.REQUESTOR_ID;
+select count(reqmgr_requestor.REQUESTOR_HN_NAME) from reqmgr_request, reqmgr_request_type, reqmgr_request_status, reqmgr_group, reqmgr_group_association, reqmgr_requestor where reqmgr_request_type.TYPE_ID=reqmgr_request.REQUEST_TYPE and reqmgr_request_status.STATUS_ID=reqmgr_request.REQUEST_STATUS and reqmgr_group.GROUP_ID=reqmgr_group_association.GROUP_ID and reqmgr_group_association.ASSOCIATION_ID=reqmgr_request.REQUESTOR_GROUP_ID and reqmgr_request.REQUESTOR_GROUP_ID=reqmgr_group_association.ASSOCIATION_ID and reqmgr_group_association.REQUESTOR_ID=reqmgr_requestor.REQUESTOR_ID;
+
+
+# team information (when a request gets assigned):
+# i.e. only requests which have not reached assignment state,
+# i.e. have no association set over reqmgr_request-reqmgr_assignment-reqmgr_teams
+select count(reqmgr_assignment.REQUEST_ID) from reqmgr_assignment;
+# all queries below return the same number of requests
+select count(reqmgr_request.REQUEST_NAME) from reqmgr_request, reqmgr_teams, reqmgr_assignment where reqmgr_request.REQUEST_ID=reqmgr_assignment.REQUEST_ID and reqmgr_assignment.TEAM_ID=reqmgr_teams.TEAM_ID;
+select count(reqmgr_request.REQUEST_NAME) from reqmgr_request, reqmgr_request_type, reqmgr_request_status, reqmgr_group, reqmgr_group_association, reqmgr_requestor, reqmgr_teams, reqmgr_assignment where reqmgr_request_type.TYPE_ID=reqmgr_request.REQUEST_TYPE and reqmgr_request_status.STATUS_ID=reqmgr_request.REQUEST_STATUS and reqmgr_group.GROUP_ID=reqmgr_group_association.GROUP_ID and reqmgr_group_association.ASSOCIATION_ID=reqmgr_request.REQUESTOR_GROUP_ID and reqmgr_request.REQUESTOR_GROUP_ID=reqmgr_group_association.ASSOCIATION_ID and reqmgr_group_association.REQUESTOR_ID=reqmgr_requestor.REQUESTOR_ID and reqmgr_request.REQUEST_ID=reqmgr_assignment.REQUEST_ID and reqmgr_assignment.TEAM_ID=reqmgr_teams.TEAM_ID;
+select count(reqmgr_teams.TEAM_NAME) from reqmgr_request, reqmgr_teams, reqmgr_assignment where reqmgr_request.REQUEST_ID=reqmgr_assignment.REQUEST_ID and reqmgr_assignment.TEAM_ID=reqmgr_teams.TEAM_ID;
+
+
+# software versions
+# does not return all requests in the system, some are missing software information
+select count(reqmgr_request.REQUEST_NAME) from reqmgr_request, reqmgr_software, reqmgr_software_dependency where reqmgr_request.REQUEST_ID=reqmgr_software_dependency.REQUEST_ID and reqmgr_software_dependency.SOFTWARE_ID=reqmgr_software.SOFTWARE_ID;
+
+# campaign
+# returns only 6797 out of current 29506 requests
+select count(reqmgr_request.REQUEST_NAME) from reqmgr_request, reqmgr_campaign, reqmgr_campaign_assoc where reqmgr_request.REQUEST_ID=reqmgr_campaign_assoc.REQUEST_ID and reqmgr_campaign_assoc.CAMPAIGN_ID=reqmgr_campaign.CAMPAIGN_ID;
+
+
+# other data fields:
+reqmgr_request.REQUEST_NAME, 
+reqmgr_request_type.TYPE_NAME, 
+reqmgr_request_status.STATUS_NAME, 
+reqmgr_request.REQUEST_PRIORITY, 
+reqmgr_request.REQUESTOR_GROUP_ID, 
+reqmgr_request.WORKFLOW,  
+reqmgr_request.REQUEST_EVENT_SIZE, 
+reqmgr_request.REQUEST_SIZE_FILES, 
+reqmgr_request.PREP_ID, 
+reqmgr_request.REQUEST_NUM_EVENTS, 
+-reqmgr_group.GROUP_NAME

--- a/src/python/WMCore/ReqMgr/database_cleanup/couch_dump.py
+++ b/src/python/WMCore/ReqMgr/database_cleanup/couch_dump.py
@@ -4,8 +4,8 @@
 Couch dumper.
 
 Dump one or more, comma separated fields from CouchDB datatabase.
-Dumps entire database ids when run without arguments.
-Dumps entire documents when run just with -f (full).
+Dumps entire database documents IDs when run without arguments.
+Dumps entire database, entire documents when run just with -f (full).
 
 """
 
@@ -52,7 +52,7 @@ def main():
         dump()
     elif len(sys.argv) == 2:
         l = sys.argv[1].split(',')
-        dump(l)
+        dump(fields=l)
             
 
 if __name__ == "__main__":

--- a/src/python/WMCore/ReqMgr/database_cleanup/oracle_tables.py
+++ b/src/python/WMCore/ReqMgr/database_cleanup/oracle_tables.py
@@ -21,7 +21,7 @@ reqmgr_oracle_tables_defition = {
     
     "reqmgr_group_association":
         ["ASSOCIATION_ID", "REQUESTOR_ID", "GROUP_ID"],
-    
+
     "reqmgr_teams":
         ["TEAM_ID", "TEAM_NAME"],
     
@@ -34,31 +34,29 @@ reqmgr_oracle_tables_defition = {
     "reqmgr_assignment":
         ["REQUEST_ID", "TEAM_ID", "PRIORITY_MODIFIER"],
     
-    # TODO (may exist on some requests)
     "reqmgr_input_dataset":
         ["DATASET_ID", "REQUEST_ID", "DATASET_NAME", "DATASET_TYPE"],
     
-    # TODO (may exist on some requests)
     "reqmgr_output_dataset":
         ["DATASET_ID", "REQUEST_ID", "DATASET_NAME", "SIZE_PER_EVENT",
          "CUSTODIAL_SITE"],
     
-    # TODO (may exist on some requests)
     "reqmgr_software":
         ["SOFTWARE_ID", "SOFTWARE_NAME", "SCRAM_ARCH"],
     
-    # TODO (may exist on some requests)
     "reqmgr_software_dependency":
         ["REQUEST_ID", "SOFTWARE_ID"],
     
-    # TODO (may exist on some requests)
+    # this information is already stored in wmstats couch database, it's
+    # reqmgr volatile data and will not be put in reqmgr_workload_cache
     "reqmgr_progress_update":
         ["REQUEST_ID", "UPDATE_TIME", "EVENTS_WRITTEN", "EVENTS_MERGED",
         "FILES_WRITTEN", "FILES_MERGED", "ASSOCIATED_DATASET",
         "TIME_PER_EVENT", "SIZE_PER_EVENT", "PERCENT_SUCCESS", 
         "PERCENT_COMPLETE"],
     
-    # TODO
+    # this information is already stored in wmstats couch database, it's
+    # reqmgr volatile data and will not be put in reqmgr_workload_cache
     "reqmgr_message":
         ["REQUEST_ID", "UPDATE_TIME", "MESSAGE"],
     


### PR DESCRIPTION
Second round of Oracle -> CouchDB updates and checks.
ReqMgr CouchDB now consistent where it was achievable.
Dispensable CouchDB request fields not yet removed.
Prepared series of checks, as described in the README
    file, to be run later on again and should be very
    quick to perform.
README file updated with useful Oracle SQL queries checks.
All, table-by-table, steps comprehensively described on the
    #4388 ticket.

For attention: @ticoann
