### PR TITLE
fix ListForSubmitter DAO to work with Oracle

### DIFF
--- a/src/python/WMCore/WMBS/MySQL/Workflow/ListForSubmitter.py
+++ b/src/python/WMCore/WMBS/MySQL/Workflow/ListForSubmitter.py
@@ -17,8 +17,8 @@ class ListForSubmitter(DBFormatter):
     List the available workflows in WMBS with the workflow
     priority
     """
-    sql = """SELECT wmbs_workflow.name,
-                    wmbs_workflow.priority
+    sql = """SELECT wmbs_workflow.name AS name,
+                    MIN(wmbs_workflow.priority) AS priority
              FROM wmbs_workflow
              GROUP BY wmbs_workflow.name"""
 


### PR DESCRIPTION
The usual very forgiving MySQL syntax that breaks Oracle. Btw, in principle this query can return multiple workflow name, priority combinations for the same workflow name, If this is not desired, the query should be changed to return MIN(wmbs_workflow.priority) or something like it.
