### PR TITLE
Fix pileup dataset location tracking

### DIFF
--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -1102,10 +1102,10 @@ class WMWorkloadHelper(PersistencyHelper):
         """
         _listPileUpDataset_
 
-        Returns a list of all the required pile-up datasets
-        in this workload
+        Returns a dictionary with all the required pile-up datasets
+        in this workload and their associated dbs url as the key
         """
-        pileupDatasets = []
+        pileupDatasets = {}
 
         if initialTask:
             taskIterator = initialTask.childTaskIterator()
@@ -1119,13 +1119,16 @@ class WMWorkloadHelper(PersistencyHelper):
                        stepHelper.stepType() == "MulticoreCMSSW":
                     pileupSection = stepHelper.getPileup()
                     if pileupSection is None: continue
+                    dbsUrl = stepHelper.data.dbsUrl
+                    if dbsUrl not in pileupDatasets:
+                        pileupDatasets[dbsUrl] = set()
                     for pileupType in pileupSection.listSections_():
                         datasets = getattr(getattr(stepHelper.data.pileup, pileupType), "dataset")
-                        pileupDatasets.extend(datasets)
+                        pileupDatasets[dbsUrl].update(datasets)
 
-            pileupDatasets.extend(self.listPileupDatasets(task))
+            pileupDatasets.update(self.listPileupDatasets(task))
 
-        return list(set(pileupDatasets))
+        return pileupDatasets
 
     def listOutputProducingTasks(self, initialTask = None):
         """

--- a/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
@@ -1722,8 +1722,10 @@ class WMWorkloadTest(unittest.TestCase):
 
         procTask3CmsswHelper = procTask3Cmssw.getTypeHelper()
         procTask3CmsswHelper.setupPileup(mcPileupConfig, 'dbslocation')
-        self.assertEqual(sorted(testWorkload.listPileupDatasets()), sorted(["/some/minbias/data",
-                                                                            "/some/minbias/mc"]))
+        self.assertTrue('dbslocation' in testWorkload.listPileupDatasets())
+        self.assertEqual(len(testWorkload.listPileupDatasets()), 1)
+        self.assertEqual(testWorkload.listPileupDatasets()['dbslocation'], set(["/some/minbias/data",
+                                                                                "/some/minbias/mc"]))
 
     def testBlockCloseSettings(self):
         """

--- a/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Block_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Block_t.py
@@ -406,7 +406,8 @@ class BlockTestCase(unittest.TestCase):
         Tier1ReRecoWorkload = rerecoWorkload('ReRecoWorkload', rerecoArgs)
         for task in Tier1ReRecoWorkload.taskIterator():
             policyInstance(Tier1ReRecoWorkload, task)
-            outputs = policyInstance.getDatasetLocations(Tier1ReRecoWorkload.listOutputDatasets())
+            outputs = policyInstance.getDatasetLocations({'http://cmsdbsprod.cern.ch/cms_dbs_prod_global/servlet/DBSServlet' :
+                                                          Tier1ReRecoWorkload.listOutputDatasets()})
             for dataset in outputs:
                 self.assertEqual(sorted(outputs[dataset]), ['T2_XX_SiteA', 'T2_XX_SiteB'])
         return


### PR DESCRIPTION
On workflows where the first task is production, the
dbsUrl is not available in the top level task. Therefore
the WorkQueue was choking when trying to get the locations
since it couldn't find a dbsUrl.

Change it to properly use the dbsUrl that is shipped in the stephelper
information with the pileup datasets.

@ericvaandering We need this in the current cmsweb-testbed cycle, can you please commit and tag it and request a WorkQueue redeployment with it? Ops is ready to validate the bugfix this week.
