### PR TITLE
Fix sizePerEvent for MC

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/MonteCarlo.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/MonteCarlo.py
@@ -128,6 +128,8 @@ class MonteCarloWorkloadFactory(StdBase):
         self.totalEvents = int(int(arguments["RequestNumEvents"]) / filterEfficiency)
         self.firstEvent  = int(arguments.get("FirstEvent", 1))
         self.firstLumi   = int(arguments.get("FirstLumi", 1))
+        # We don't write out every event in MC, adjust the size per event accordingly
+        self.sizePerEvent = self.sizePerEvent * filterEfficiency
 
         # pileup configuration for the first generation task
         self.pileupConfig = arguments.get("PileupConfig", None)


### PR DESCRIPTION
MC requests may have very low filter efficiency
so the estimates for disk space will be too high
since the current calculation assumes the definition of:

"Size per event is the size of one event in the output"

However, a more proper definition would be:
- "Size per event is the contribution to the output size for every event in the
  input, if there is no input (i.e. production) then it is the size of every
  event in the output"

Under this definition we must adjust the sizePerEvent according to the efficiency
value in MonteCarlo/LHEStepZero but for all the other processing requests
we expect size per event values according to the above definition (e.g. in
the skims, the skim efficiency should be considered in the sizeperEvent).

@ericvaandering @zdenekmaxa This is a small bugfix and it would be beneficial to include in the current deployment but not urgent. Please do it at your convenience, only affects ReqMgr.
