### PR TITLE
Fix bug with updating the logArch location

### DIFF
--- a/src/couchapps/WMStats/updates/jobLogArchiveLocation.js
+++ b/src/couchapps/WMStats/updates/jobLogArchiveLocation.js
@@ -1,4 +1,8 @@
 function (doc, req) {
+  if (!doc) {
+    doc = {};
+    doc._id = req.id;
+  };
   if (doc.logArchiveLFN === undefined) {
       doc.logArchiveLFN = {};
   };


### PR DESCRIPTION
Sometimes the WMStats document doesn't exist
when trying to associate a logArchive location
this caused the update function to crash. Fix it.
