### PR TITLE
Fix location update for Pileup on Generation

### DIFF
--- a/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
@@ -96,12 +96,19 @@ class StartPolicyInterface(PolicyInterface):
             raise error
 
     def newQueueElement(self, **args):
+        # DBS Url may not be available in the initial task
+        # but in the pileup data (MC pileup)
+        dbsUrl = self.initialTask.dbsUrl()
+        if dbsUrl is None and self.pileupData:
+            # Get the first DBS found
+            dbsUrl = self.wmspec.listPileupDatasets().keys()[0]
+
         args.setdefault('Status', 'Available')
         args.setdefault('WMSpec', self.wmspec)
         args.setdefault('Task', self.initialTask)
         args.setdefault('RequestName', self.wmspec.name())
         args.setdefault('TaskName', self.initialTask.name())
-        args.setdefault('Dbs', self.initialTask.dbsUrl())
+        args.setdefault('Dbs', dbsUrl)
         args.setdefault('SiteWhitelist', self.initialTask.siteWhitelist())
         args.setdefault('SiteBlacklist', self.initialTask.siteBlacklist())
         args.setdefault('EndPolicy', self.wmspec.endPolicyParameters())

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
@@ -1525,12 +1525,14 @@ class WorkQueueTest(WorkQueueTestCase):
         self.assertEqual(len(self.localQueue.getWork({'T2_XX_SiteA' : 1}, {})), 1)
         self.assertEqual(len(self.localQueue), 0)
 
-    def testPileupOnProdution(self):
+    def testPileupOnProduction(self):
         """Test that we can split properly a Production workflow with pileup"""
         specfile = self.productionPileupSpec.specUrl()
         # Sanity check on queueWork only
         self.assertEqual(1, self.globalQueue.queueWork(specfile))
         self.assertEqual(1, len(self.globalQueue))
+        self.assertEqual(len(self.globalQueue.backend.getActivePileupData()),1)
+        self.assertNotEqual(self.globalQueue.backend.getActivePileupData()[0]['dbs_url'], None)
 
     def testPrioritiesWorkPolling(self):
         """Test how the priorities and current jobs in the queue affect the workqueue behavior


### PR DESCRIPTION
When the top level task is a Production task with no DBS Url,
the location updater crashes since there is no DBS to do the
location update. Fix that by including a DBS url in the workqueue
element even if not present in the top level task, it will use one from
the pileup datasets.
