### PR TITLE
Adding subsciption info to GET request result

### DIFF
--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrRESTModel.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrRESTModel.py
@@ -41,7 +41,7 @@ import WMCore.RequestManager.RequestDB.Interface.Request.Campaign           as C
 # request arguments which are deprecated at injection (2013-03-26)
 # 'RequestWorkflow' is an exception that is it deprecated at injection
 # but is created and stored in CouchDB, others not
-# have this global so that it can easily be access from unitteest
+# have this global so that it can easily be access from unittest
 deprecatedRequestArgs = ["ReqMgrGroupID",
                          "ReqMgrRequestID",
                          "ReqMgrRequestorID",

--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
@@ -640,6 +640,7 @@ def requestDetails(requestName):
     # take the stuff from the DB preferentially
     schema.update(request)
     task = helper.getTopLevelTask()[0]
+    
     schema['Site Whitelist']  = task.siteWhitelist()
     schema['Site Blacklist']  = task.siteBlacklist()
     schema['MergedLFNBase']   = str(helper.getMergedLFNBase())
@@ -658,6 +659,8 @@ def requestDetails(requestName):
         couchReq = couchDb.document(requestName)
         schema["DbsUrl"] = couchReq.get("DbsUrl", None)
         
+    # https://github.com/dmwm/WMCore/issues/4588
+    schema["SubscriptionInformation"] = helper.getSubscriptionInformation()
     return schema
 
 


### PR DESCRIPTION
This small modification adds subscription information to the GET REST API call
so information like CustodialSites is listed in the form that is returned from
the workload helper.

Fixes #4588
