### PR TITLE
Catch proxy errors

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
@@ -145,6 +145,19 @@ def uploadWorker(input, results, dbsUrl):
                 logging.error("Exception: %s\n" % exString)
                 logging.error("Traceback: %s\n" % str(traceback.format_exc()))
                 results.put({'name': name, 'success': True})
+            elif 'Proxy Error' in exString:
+                # This is probably a successfully inserton that went bad.
+                # Make sure of it!
+                result = dbsApi.listBlocks(block_name = name)
+                for blockResult in result:
+                    if blockResult['block_name'] == name:
+                        results.put({'name': name, 'success': True})
+                        break
+                else:
+                    msg = "Got a proxy error but the block (%s) is not in DBS3 yet." % name
+                    logging.error(msg)
+                    logging.error(str(traceback.format_exc()))
+                    results.put({'name': name, 'success': False, 'error': msg})
             else:
                 msg =  "Error trying to process block %s through DBS.\n" % name
                 msg += exString


### PR DESCRIPTION
If a 502 Proxy Error happens, it is likely that the block was inserted
but the response was not returned in time and it was killed by the
cmsweb frontend. Check if the block is in DBS3 already and if it is
then declare it successful.
