### PR TITLE
Allow multiple DQMConfigCacheIDs in TaskChain

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
@@ -208,7 +208,8 @@ class ParameterStorage(object):
                                 'acquisitionEra' : 'AcquisitionEra',
                                 'timePerEvent' : 'TimePerEvent',
                                 'sizePerEvent' : 'SizePerEvent',
-                                'memory' : 'Memory'
+                                'memory' : 'Memory',
+                                'dqmConfigCacheID' : 'DQMConfigCacheID'
                                 }
         return
 


### PR DESCRIPTION
Assume that Task3 and Task2 have DQM output,
then the usage is :

{ "DQMConfigCacheID" : .....,

   "Task2" : {"DQMConfigCacheID" : ....}
}

With this configuration Task3 will use the original DQMConfigCacheID
in the main dictionary but Task2 will use the the DQMConfigCacheID
defined in its own internal configuration.

Fixes #4614
