### PR TITLE
Allow overrides on the Primary dataset

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/MonteCarloFromGEN.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/MonteCarloFromGEN.py
@@ -72,8 +72,11 @@ class MonteCarloFromGENWorkloadFactory(StdBase):
         Not that there will be LogCollect tasks created for each processing
         task and Cleanup tasks created for each merge task.
         """
-        (self.inputPrimaryDataset, self.inputProcessedDataset,
+        (inputPrimaryDataset, self.inputProcessedDataset,
          self.inputDataTier) = self.inputDataset[1:].split("/")
+
+        if self.inputPrimaryDataset is None:
+            self.inputPrimaryDataset = inputPrimaryDataset
 
         workload = self.createWorkload()
         workload.setDashboardActivity("lheproduction")
@@ -93,7 +96,6 @@ class MonteCarloFromGENWorkloadFactory(StdBase):
 
         procMergeTasks = {}
         for outputModuleName in outputMods.keys():
-            outputModuleInfo = outputMods[outputModuleName]
             mergeTask = self.addMergeTask(procTask, self.procJobSplitAlgo,
                                           outputModuleName)
             procMergeTasks[outputModuleName] = mergeTask
@@ -118,6 +120,9 @@ class MonteCarloFromGENWorkloadFactory(StdBase):
         self.inputDataset = arguments["InputDataset"]
         self.frameworkVersion = arguments["CMSSWVersion"]
         self.globalTag = arguments["GlobalTag"]
+
+        # Optional override arguments
+        self.inputPrimaryDataset = arguments.get("PrimaryDataset")
 
         # The CouchURL and name of the ConfigCache database must be passed in
         # by the ReqMgr or whatever is creating this workflow.

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/MonteCarloFromGEN_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/MonteCarloFromGEN_t.py
@@ -80,9 +80,14 @@ class MonteCarloFromGENTest(unittest.TestCase):
         arguments = getTestArguments()
         arguments["ConfigCacheID"] = self.injectConfig()
         arguments["CouchDBName"] = "mclhe_t"
+        arguments["PrimaryDataset"] = "WaitThisIsNotMinimumBias"
         testWorkload = monteCarloFromGENWorkload("TestWorkload", arguments)
         testWorkload.setSpecUrl("somespec")
         testWorkload.setOwnerDetails("sfoulkes@fnal.gov", "DMWM")
+
+        self.assertEqual(len(testWorkload.listOutputDatasets()), 2)
+        self.assertTrue("/WaitThisIsNotMinimumBias/WMAgentCommissioning10-FilterRECO-v2/RECO" in testWorkload.listOutputDatasets())
+        self.assertTrue("/WaitThisIsNotMinimumBias/WMAgentCommissioning10-FilterALCARECO-v2/ALCARECO" in testWorkload.listOutputDatasets())
 
         testWMBSHelper = WMBSHelper(testWorkload, "MonteCarloFromGEN", "SomeBlock", cachepath = self.testDir)
         testWMBSHelper.createTopLevelFileset()


### PR DESCRIPTION
Only for MonteCarloFromGEN workflows, when
PrimaryDataset is specified the output will use this instead
of the input primary dataset.

Fixes #4615
