### PR TITLE
Add /store/mc/* to qualified lfn names. YG

### DIFF
--- a/src/python/WMCore/Lexicon.py
+++ b/src/python/WMCore/Lexicon.py
@@ -195,6 +195,8 @@ def lfn(candidate):
     oldStyleTier0LFN = '/store/data/%(era)s/%(primDS)s/%(tier)s/%(version)s/%(counter)s/%(counter)s/%(counter)s/%(root)s' % lfnParts
     tier0LFN = '/store/(backfill/[0-9]/){0,1}(t0temp/){0,1}(data|express|hidata)/%(era)s/%(primDS)s/%(tier)s/%(version)s/%(counter)s/%(counter)s/%(counter)s/%(counter)s/%(root)s' % lfnParts
 
+    storeMcLFN = '/store/mc/([a-zA-Z0-9\-_]+)/([a-zA-Z0-9\-_]+)/([a-zA-Z0-9\-_]+)/([a-zA-Z0-9\-_]+)(/([a-zA-Z0-9\-_]+))*/([a-zA-Z0-9\-_]+).root'
+
     storeResultsLFN = '/store/results/%(physics_group)s/%(primDS)s/%(secondary)s/%(primDS)s/%(tier)s/%(secondary)s/%(counter)s/%(root)s' % lfnParts
 
     try:
@@ -219,6 +221,11 @@ def lfn(candidate):
 
     try:
         return check(oldStyleTier0LFN, candidate)
+    except AssertionError:
+        pass
+
+    try:
+        return check(storeMcLFN, candidate)
     except AssertionError:
         return check(storeResultsLFN, candidate)
 

--- a/test/python/WMCore_t/Lexicon_t.py
+++ b/test/python/WMCore_t/Lexicon_t.py
@@ -278,6 +278,10 @@ class LexiconTest(unittest.TestCase):
 
         Test the LFN checker in several modes, including user LFNs
         """
+        lfnA = '/store/mc/Fall10/DYToMuMu_M-20_TuneZ2_7TeV-pythia6/AODSIM/START38_V12-v1/0003/C0F3344F-6EC8-DF11-8ED6-E41F13181020.root'
+        lfn(lfnA)
+        lfnA = '/store/mc/2008/2/21/FastSim-CSA07Electron-1203615548/0009/B6E531DD-99E1-DC11-9FEC-001617E30D4A.root'
+        lfn(lfnA)
         lfnA = '/store/temp/user/ewv/Higgs-123/PrivateSample/v1/1000/a_X-2.root'
         lfn(lfnA)
         lfnA = '/store/temp/user/cinquilli.nocern/Higgs-123/PrivateSample/v1/1000/a_X-2.root'
@@ -369,6 +373,8 @@ class LexiconTest(unittest.TestCase):
         lfnA = '/store/temp/user/ewv/Higgs-123/Private;Sample/v1/a_X-2.root'
         self.assertRaises(AssertionError, lfn, lfnA)
         lfnA = '/store/temp/user/ewv/Higgs-123/PrivateSample/v1;/a_X-2.root'
+        self.assertRaises(AssertionError, lfn, lfnA)
+        lfnA = '/store/mc/2008/2/FastSim-CSA07Electron-1203615548/B6E531DD-99E1-DC11-9FEC-001617E30D4A.root'
         self.assertRaises(AssertionError, lfn, lfnA)
 
         lfnA = '/store/Results/qcd/QCD_Pt80/StoreResults-Summer09-MC_31X_V3_7TeV-Jet30U-JetAODSkim-0a98be42532eba1f0545cc9b086ec3c3/QCD_Pt80/USER/StoreResults-Summer09-MC_31X_V3_7TeV-Jet30U-JetAODSkim-0a98be42532eba1f0545cc9b086ec3c3/0000/C44630AC-C0C7-DE11-AD4E-0019B9CAC0F8.root'


### PR DESCRIPTION
Please add this new Lexicon.py in upcoming CMSWEB release. The current Lexicon.py does not include a valid check for /store/mc/\* lfns so some of the dataOps scripts are broken due to lfn cannot pass validation.
Thanks,
yuyi
