### PR TITLE
increase default request timeout to 2 min

### DIFF
--- a/src/python/WMCore/Services/Service.py
+++ b/src/python/WMCore/Services/Service.py
@@ -125,7 +125,7 @@ class Service(dict):
         self.setdefault("method", None)
 
         #Set a timeout for the socket
-        self.setdefault("timeout", 30)
+        self.setdefault("timeout", 120)
 
         # then update with the incoming dict
         self.update(cfg_dict)


### PR DESCRIPTION
some calls to request manager from workqueue takes more than 30 second default time out.
which case the errors. This need to be included for workqueue deployment.
@dballesteros7 is there anything else need to be request for workqueue deployment?
