### PR TITLE
Add support in Reqmgr for deterministic pileup

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/ReDigi.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/ReDigi.py
@@ -343,6 +343,8 @@ class ReDigiWorkloadFactory(StdBase):
 
         # Pileup configuration for the first generation task
         self.pileupConfig = arguments.get("PileupConfig", None)
+        # If the pileup is data pileup, we may want deterministic pileup
+        self.deterministicPileup = arguments.get("DeterministicPileup", False)
 
         # Optional arguments that default to something reasonable.
         self.blockBlacklist = arguments.get("BlockBlacklist", [])
@@ -357,6 +359,7 @@ class ReDigiWorkloadFactory(StdBase):
         self.procJobSplitArgs = arguments.get("StdJobSplitArgs",
                                               {"lumis_per_job": 8,
                                                "include_parents": self.includeParents})
+        self.procJobSplitArgs.setdefault("deterministicPileup", self.deterministicPileup)
         return self.buildWorkload()
 
     def validateSchema(self, schema):

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -455,7 +455,7 @@ class WMTaskHelper(TreeHelper):
                 setACDCParams[paramName] = getattr(self.data.input.splitting,
                                                    paramName)
         preservedParams = {}
-        for paramName in ["lheInputFiles", "include_parents"]:
+        for paramName in ["lheInputFiles", "include_parents", "deterministicPileup"]:
             if hasattr(self.data.input.splitting, paramName):
                 preservedParams[paramName] = getattr(self.data.input.splitting,
                                                      paramName)


### PR DESCRIPTION
It just adds a new parameter to the splitting
algorithms in ReDigi. The actual support will come
in a WMAgent patch that is still under testing.
