### PR TITLE
Fix bug in WMBSHelper when no subs are present

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/MySQL/NewSubscription.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/NewSubscription.py
@@ -50,6 +50,9 @@ class NewSubscription(DBFormatter):
                        'priority' : subscriptionInfo['Priority']}
             binds.append(subInfo)
 
+        if not binds:
+            return
+
         self.dbi.processData(self.sql,
-                                      binds = binds, conn = conn,
-                                      transaction = transaction)
+                             binds = binds, conn = conn,
+                             transaction = transaction)

--- a/test/python/WMCore_t/WorkQueue_t/WMBSHelper_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WMBSHelper_t.py
@@ -472,6 +472,7 @@ class WMBSHelperTest(unittest.TestCase):
                                             lfnBase = "bogusUnmerged",
                                             mergedLFNBase = "bogusMerged",
                                             filterName = None)
+
         return testWorkload
 
     def setupMCWMSpec(self):
@@ -493,6 +494,9 @@ class WMBSHelperTest(unittest.TestCase):
     def createWMSpec(self, name = 'ReRecoWorkload'):
         wmspec = rerecoWorkload(name, rerecoArgs)
         wmspec.setSpecUrl("/path/to/workload")
+        wmspec.setSubscriptionInformation(custodialSites = [],
+                                          nonCustodialSites = [], autoApproveSites = [],
+                                          priority = "Low", custodialSubType = "Move")
         return wmspec
 
     def createMCWMSpec(self, name = 'MonteCarloWorkload'):


### PR DESCRIPTION
If no PhEDEx subscriptions are present, the WMBSHelper
crashes when injecting the subscriptions into WMBS.

Fix this and change the unittest to trigger the error without
the fix.
