### PR TITLE
ReqMgr2 - status, types APIs

### DIFF
--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -67,14 +67,14 @@ dependencies = {'wmc-rest':{
                                     'src/couchapps/WMStats+'],
                         },
                 'reqmgr2':{
-                        'packages': ['WMCore.reqmgr+',
+                        'packages': ['WMCore.ReqMgr+',
                                     ],
                         'systems': ['wmc-rest', 'wmc-runtime', 'wmc-database'],
                         'statics': ['src/couchapps/ReqMgr+',
                                     'src/couchapps/ReqMgrAux+',
                                     'src/couchapps/ConfigCache+',
                                     'src/couchapps/WMStats+',
-                                    'src/html/reqmgr+',
+                                    'src/html/ReqMgr+',
                                    ],
                           },
                 'workqueue':{

--- a/src/html/ReqMgr/index.html
+++ b/src/html/ReqMgr/index.html
@@ -1,19 +1,23 @@
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-US" lang="en-US">
 <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+    <meta name="keywords" content="CMS, RequestManager, ReqMgr" />
+
 	<link href="@MOUNT@/static?html/ReqMgr/style/style.css" media="all" rel="Stylesheet" type="text/css"/>	
 	
 	<script src="@MOUNT@/static?html/ReqMgr/javascript/utils.js"></script>
 	<script src="@MOUNT@/static?html/ReqMgr/javascript/config.js"></script>
     <script src="@MOUNT@/static?html/ReqMgr/javascript/requestsview.js"></script>
        
-   	<title>CMS Request Manager (ReqMgr)</title>
+   	<title>ReqMgr</title>
 </head>
 
 <body>
 	<div class="template">
 	
 		<div id="sitetitle">
-			CMS Request Manager (ReqMgr)
+            CMS RequestManager
 		</div>
 		
 		<div id="navigation">

--- a/src/html/ReqMgr/javascript/requestsview.js
+++ b/src/html/ReqMgr/javascript/requestsview.js
@@ -13,8 +13,8 @@
 var requestsView = 
 {
 	mainAppUrl: "/reqmgr2",
-    closedCellInnerHTML: "&nbsp;<img src=\"/reqmgr2/ui/static/?html/ReqMgr/img/details_closed.gif\"</img>&nbsp;",
-    openCellInnerHTML: "&nbsp;<img src=\"/reqmgr2/ui/static/?html/ReqMgr/img/details_open.gif\"</img>",				
+    closedCellInnerHTML: "&nbsp;<img src=\"/reqmgr2/static/?html/ReqMgr/img/details_closed.gif\"</img>&nbsp;",
+    openCellInnerHTML: "&nbsp;<img src=\"/reqmgr2/static/?html/ReqMgr/img/details_open.gif\"</img>",				
     
     /* 
      * main page building & display
@@ -176,7 +176,7 @@ var requestsView =
      */
 	update: function()
 	{
-    	var url = requestsView.mainAppUrl + "/request";
+    	var url = requestsView.mainAppUrl + "/data/request";
 	    var options = {"method": "GET", "reloadPage": false};	    
 	    var data = {};
 	    utils.makeHttpRequest(url, requestsView.processRequestsData, data, options);

--- a/src/html/ReqMgr/style/style.css
+++ b/src/html/ReqMgr/style/style.css
@@ -1,7 +1,7 @@
 body
 {
 	font-family: Verdana, Arial, Helvetica, sans-serif;
-	background-image:url('/reqmgr2/ui/static/?html/ReqMgr/img/gradientfromtop.gif');
+	background-image:url('/reqmgr2/static/?html/ReqMgr/img/gradientfromtop.gif');
 	background-repeat:repeat-x;	
 }
 
@@ -63,7 +63,7 @@ div.loadmorebottom
 
 div.loadmorebottomloading
 {
-	background-image:url('/reqmgr2/ui/static/?html/ReqMgr/img/loading-small.gif');
+	background-image:url('/reqmgr2/static/?html/ReqMgr/img/loading-small.gif');
 	background-repeat:no-repeat;
 	background-position:center; 
 }
@@ -78,7 +78,7 @@ div.loadmorebottomloading
     top:0px;
     left:0px;
     display:block;
-    background:transparent url('/reqmgr2/ui/static/?html/ReqMgr/img/shadow.gif') repeat;
+    background:transparent url('/reqmgr2/static/?html/ReqMgr/img/shadow.gif') repeat;
 }
 
 

--- a/src/python/WMCore/ReqMgr/Service/Auxiliary.py
+++ b/src/python/WMCore/ReqMgr/Service/Auxiliary.py
@@ -22,6 +22,7 @@ from WMCore.REST.Validation import validate_str
 import WMCore.ReqMgr.Service.RegExp as rx
 
 
+
 class HelloWorld(RESTEntity):
     
     def validate(self, apiobj, method, api, param, safe):
@@ -58,7 +59,6 @@ class ReqMgrBaseRestEntity(RESTEntity):
         self.config = config
         RESTEntity.__init__(self, app, api, config, mount)
     
-
 
 
 class Info(ReqMgrBaseRestEntity):
@@ -213,7 +213,7 @@ class Team(ReqMgrBaseRestEntity):
     "teams" is used as id of the document, but the document
         itself has to be JSON: we use {"teams": [list, of, group, names]
         
-    When request goes through assignment state, it gets assigned
+    When request goes through assignment status, it gets assigned
     to a team.
     Where a request gets run is controlled by SiteBlack/White list.
         
@@ -375,10 +375,10 @@ def update_software(config_file):
     """
     config = loadConfigurationFile(config_file)
     # source of the data
-    tag_collector_url = config.views.restapihub.tag_collector_url
+    tag_collector_url = config.views.data.tag_collector_url
     # store the data into CouchDB auxiliary database under "software" document
-    couch_host = config.views.restapihub.couch_host
-    reqmgr_aux_db = config.views.restapihub.couch_reqmgr_aux_db
+    couch_host = config.views.data.couch_host
+    reqmgr_aux_db = config.views.data.couch_reqmgr_aux_db
     
     # get data from tag collector
     all_archs_and_versions = _get_all_scramarchs_and_versions(tag_collector_url)
@@ -399,8 +399,13 @@ def update_software(config_file):
     
     # now compare recent data from tag collector and what we already have stored
     if all_archs_and_versions != sw_already_stored:
-        logging.warn("ScramArch/CMSSW releases changed, updating software document ...")
+        logging.debug("ScramArch/CMSSW releases changed, updating software document ...")
         doc = Document(id="software", inputDict=all_archs_and_versions)
         couchdb.commitOne(doc)
-    else:
-        logging.warn("No change in ScramArch/CMSSW releases, no update.")
+        # TODO
+        # remove this, only to observe differences during update attempts
+        #msg = ("Really changed? Compare:\n"
+        #       "sw_already_stored:\n%s\n"
+        #       "all_archs_and_versions (returned from TC):\n%s\n" %
+        #       (sw_already_stored, all_archs_and_versions))
+        #print msg

--- a/src/python/WMCore/ReqMgr/Service/Request.py
+++ b/src/python/WMCore/ReqMgr/Service/Request.py
@@ -14,6 +14,9 @@ from WMCore.REST.Validation import validate_str
 from WMCore.ReqMgr.Service.Auxiliary import ReqMgrBaseRestEntity
 import WMCore.ReqMgr.Service.RegExp as rx
 
+from RequestStatus import REQUEST_STATUS_LIST, REQUEST_STATUS_TRANSITION
+from RequestType import REQUEST_TYPES
+
 
 class Request(ReqMgrBaseRestEntity):
     def __init__(self, app, api, config, mount, db_handler):
@@ -43,7 +46,7 @@ class Request(ReqMgrBaseRestEntity):
             return rows([request_doc])
         else:
             options = {"descending": True}
-            if not all:
+            if all == "false":
                 past_days = self.config.default_view_requests_since_num_days
                 current_date = list(time.gmtime()[:6])
                 from_date = datetime(*current_date) - timedelta(days=past_days)
@@ -52,3 +55,42 @@ class Request(ReqMgrBaseRestEntity):
                                                 "ReqMgr", "bydate",
                                                 options=options)
             return rows([request_docs])
+        
+        
+        
+class RequestStatus(RESTEntity):
+    def __init__(self, app, api, config, mount):
+        RESTEntity.__init__(self, app, api, config, mount)
+
+
+    def validate(self, apiobj, method, api, param, safe):
+        validate_str("transition", param, safe, rx.RX_BOOL_FLAG, optional=True)
+    
+    
+    @restcall
+    def get(self, transition):
+        """
+        Return list of allowed request status.
+        If transition, return exhaustive list with all request status
+        and their defined transitions.
+        
+        """
+        if transition == "true":
+            return rows(REQUEST_STATUS_TRANSITION)
+        else:
+            return rows(REQUEST_STATUS_LIST)
+    
+    
+    
+class RequestType(RESTEntity):
+    def __init__(self, app, api, config, mount):
+        RESTEntity.__init__(self, app, api, config, mount)
+    
+    
+    def validate(self, apiobj, method, api, param, safe):
+        pass
+    
+    
+    @restcall
+    def get(self):
+        return rows(REQUEST_TYPES)

--- a/src/python/WMCore/ReqMgr/Service/RequestStatus.py
+++ b/src/python/WMCore/ReqMgr/Service/RequestStatus.py
@@ -1,0 +1,108 @@
+"""
+Definition of valid status values for a request and valid status transitions.
+
+"""
+
+# make this list to ensure insertion order here
+REQUEST_STATUS_TRANSITION = [
+    {"new": ["new",
+             "testing-approved",
+             "assignment-approved",
+             "rejected",
+             "failed",
+             "aborted"]
+    },
+    {"testing-approved": ["testing-approved",
+                          "testing",
+                          "test-failed",
+                          "aborted"]
+    },
+    {"testing": ["testing",
+                 "tested",
+                 "test-failed",
+                 "aborted"]
+    },
+    {"tested": ["tested",
+                "assignment-approved",
+                "failed",
+                "rejected",
+                "aborted"]
+    },
+    {"test-failed": ["test-failed",
+                     "testing-approved",
+                     "rejected",
+                     "aborted"]
+    },
+    {"assignment-approved": ["assignment-approved",
+                             "assigned",
+                             "rejected",
+                             "aborted"]
+    },
+    {"assigned": ["assigned",
+                  "negotiating",
+                  "acquired",
+                  "aborted",
+                  "rejected",
+                  "failed"]
+    },
+    {"negotiating": ["acquired",
+                     "assigned",
+                     "rejected",
+                     "aborted",
+                     "failed",
+                     "negotiating"]
+    },
+    {"acquired": ["running-open",
+                  "failed",
+                  "completed",
+                  "acquired",
+                  "aborted"]
+    },
+    {"running": ["completed",
+                 "aborted",
+                 "failed"]
+    },
+    {"running-open": ["running-closed",
+                      "aborted",
+                      "failed"]
+    },
+    {"running-closed": ["completed",
+                        "aborted",
+                        "failed"]
+    },
+    {"failed": ["failed",
+                "testing-approved",
+                "assigned"]
+    },
+    {"completed": ["completed",
+                   "closed-out",
+                   "rejected"]
+    },
+    {"closed-out": ["announced"]
+    },
+    {"announced": ["normal-archived"]
+    },
+    {"aborted": ["aborted",
+                 "testing-approved",
+                 "assigned",
+                 "rejected",
+                 "failed",
+                 "aborted-completed"]
+    },
+    {"aborted-completed": ["aborted-archived"]
+    },
+    {"rejected": ["rejected",
+                  "rejected-archived"]
+    },
+    # final status
+    {"normal-archived": []
+    },
+    {"aborted-archived": []
+    },
+    {"rejected-archived": []
+    },
+]
+
+# each item from STATUS_TRANSITION is a dictionary with 1 item, the key
+# is name of the status
+REQUEST_STATUS_LIST = [s.keys()[0] for s in REQUEST_STATUS_TRANSITION]

--- a/src/python/WMCore/ReqMgr/Service/RequestType.py
+++ b/src/python/WMCore/ReqMgr/Service/RequestType.py
@@ -1,0 +1,18 @@
+"""
+List of valid request types.
+
+"""
+
+REQUEST_TYPES = [
+    "MonteCarlo",
+    "RelValMC",
+    "ReReco",
+    "StoreResults",
+    "DataProcessing",
+    "Resubmission",
+    "ReDigi",
+    "MonteCarloFromGEN",
+    "TaskChain",
+    "PrivateMC",
+    "LHEStepZero",
+]

--- a/src/python/WMCore/ReqMgr/Service/RestApiHub.py
+++ b/src/python/WMCore/ReqMgr/Service/RestApiHub.py
@@ -17,7 +17,8 @@ from WMCore.ReqMgr.Service.Auxiliary import Group
 from WMCore.ReqMgr.Service.Auxiliary import Team
 from WMCore.ReqMgr.Service.Auxiliary import Software
 from WMCore.ReqMgr.Service.Request import Request
-
+from WMCore.ReqMgr.Service.Request import RequestStatus
+from WMCore.ReqMgr.Service.Request import RequestType
 
 
 
@@ -47,5 +48,7 @@ class RestApiHub(RESTApi):
                "request": Request(app, self, config, mount, db_handler),
                "group": Group(app, self, config, mount, db_handler),
                "team": Team(app, self, config, mount, db_handler),
-               "sw": Software(app, self, config, mount, db_handler),
+               "software": Software(app, self, config, mount, db_handler),
+               "status": RequestStatus(app, self, config, mount),
+               "type": RequestType(app, self, config, mount),
               })

--- a/src/python/WMCore/ReqMgr/database_cleanup/README
+++ b/src/python/WMCore/ReqMgr/database_cleanup/README
@@ -46,7 +46,7 @@ select count(reqmgr_requestor.REQUESTOR_HN_NAME) from reqmgr_request, reqmgr_req
 
 
 # team information (when a request gets assigned):
-# i.e. only requests which have not reached assignment state,
+# i.e. only requests which have not reached assignment status,
 # i.e. have no association set over reqmgr_request-reqmgr_assignment-reqmgr_teams
 select count(reqmgr_assignment.REQUEST_ID) from reqmgr_assignment;
 # all queries below return the same number of requests

--- a/src/python/WMCore/ReqMgr/database_cleanup/oracle_couchdb_consistency_checker.py
+++ b/src/python/WMCore/ReqMgr/database_cleanup/oracle_couchdb_consistency_checker.py
@@ -66,7 +66,7 @@ MAPPING=(
          {"oracle": "REQUESTOR_DN_NAME", "couch": "RequestorDN"},
          
          # team
-         # applies only to requests which reached assignment state
+         # applies only to requests which reached assignment status
          # WARNING:
          # by including teams, not all requests will be returned in
          # the query to compare/update the above data fields


### PR DESCRIPTION
-request status (clean up from ReqMgr1), providing API
-request types, providing API
-making update software cronjob silent
-changing REST API endpoint definitions
-adding tests into the ReqMgr2 client script
-fixed some remaining dependency issues from CamelCase
 modules renaming

Fixes #4323
