### PR TITLE
RelValMC further clean up

### DIFF
--- a/src/python/WMCore/ReqMgr/Service/RequestType.py
+++ b/src/python/WMCore/ReqMgr/Service/RequestType.py
@@ -5,7 +5,6 @@ List of valid request types.
 
 REQUEST_TYPES = [
     "MonteCarlo",
-    "RelValMC",
     "ReReco",
     "StoreResults",
     "DataProcessing",

--- a/src/templates/WMCore/WebTools/RequestManager/WebRequestSchema.tmpl
+++ b/src/templates/WMCore/WebTools/RequestManager/WebRequestSchema.tmpl
@@ -100,8 +100,6 @@ Scenario:
     <option>hcalnzs</option>
     <option>preprodmc</option>
     <option>prodmc</option>
-    <option>relvalmc</option>
-    <option>relvalmcfs</option>
   </select><br/>
 #end def
 


### PR DESCRIPTION
RelValMC workload was removed in #4687, this patch cleans up remaining
relevant, now unnecessary, references.
