### PR TITLE
ReqMgr1, 2 - StoreResults injection

### DIFF
--- a/test/data/ReqMgr/requests/StoreResults.json
+++ b/test/data/ReqMgr/requests/StoreResults.json
@@ -1,0 +1,24 @@
+{ 
+"createRequest":
+	{		 
+		"RequestType": "StoreResults",
+        "UnmergedLFNBase": "/store/temp/WMAgent/unmerged",
+        "MergedLFNBase": "/store/results",
+        "MinMergeSize": 1073741824,
+        "MaxMergeSize": 3221225472,
+        "MaxMergeEvents": 100000,
+        "DataTier": "USER",
+        "InputDataset": "/MinimumBias/Run2010A-Dec22ReReco_v1/USER",
+        "CMSSWVersion": "CMSSW_4_1_8",
+        "ScramArch": "slc5_amd64_gcc434",
+        "ProcessingVersion": 1,
+        "GlobalTag": "GR10_P_v4::All",
+        "Scenario": "pp",
+        "TimePerEvent": 40,
+        "Memory": 2394,
+        "Group": "DATAOPS",
+        "DbsUrl": "http://cmsdbsprod.cern.ch/cms_dbs_prod_global/servlet/DBSServlet",
+        "AcquisitionEra": "AcquisitionEra-OVERRIDE-ME",
+        "CmsPath": "/uscmst1/prod/sw/cms"               
+	} 
+}


### PR DESCRIPTION
Create StoreResults.json request template capable of injecting
into both ReqMgr1,2. Some requisite values e.g. CmsPath do not
seem to be accessed in the spec implementation.
Also, definition of splitting parameters changed compared to
how StdSpects/StoreResults.py defines them. So currently,
this new StoreResults request would be treated in ReqMgr exactly
the same way like other request types, no special checks or
assignment conditions, roles, etc exist yet. This is for ReqMgr2.

For attention @ticoann, @ericvaandering. Could not find Dan.
