### PR TITLE
Fixes for DBS3 duplicate insertions

### DIFF
--- a/src/python/WMQuality/Emulators/DBSClient/DBS3API.py
+++ b/src/python/WMQuality/Emulators/DBSClient/DBS3API.py
@@ -11,6 +11,8 @@ Created on Mar 13, 2013
 import json
 import os
 
+from random import random
+
 class DbsApi():
     """
     _DbsApi_
@@ -31,7 +33,8 @@ class DbsApi():
         _insertBulkBlock_
 
         Insert a block into fake DBS, only insert the block specific information
-        and no file information in the file given in the dbsPath
+        and no file information in the file given in the dbsPath.
+        There is 20% chance of a proxy error!
         """
 
         currentInfo = []
@@ -40,8 +43,30 @@ class DbsApi():
             currentInfo = json.load(inFileHandle)
             inFileHandle.close()
         outFileHandle = open(self.dbsPath, 'w')
+        for block in currentInfo:
+            if block["block"]["block_name"] == blockDump["block"]["block_name"]:
+                raise Exception("Block %s already exists" % blockDump["block"]["block_name"])
         currentInfo.append(blockDump)
         json.dump(currentInfo, outFileHandle)
         outFileHandle.close()
 
+        randomNumber = random()
+        if randomNumber < 0.2:
+            raise Exception("Proxy Error, this is a mock proxy error.")
+
         return
+
+    def listBlocks(self, block_name):
+        """
+        _listBlocks_
+
+        Return the requested block information if it exists.
+        """
+        if os.path.getsize(self.dbsPath):
+            inFileHandle = open(self.dbsPath, 'r')
+            currentInfo = json.load(inFileHandle)
+            inFileHandle.close()
+            for block in currentInfo:
+                if block["block"]["block_name"] == block_name:
+                    return [block["block"]]
+        return []

--- a/test/python/WMComponent_t/DBS3Buffer_t/DBSUpload_t.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/DBSUpload_t.py
@@ -471,6 +471,7 @@ class DBSUploadTest(unittest.TestCase):
             # create all the blocks and upload one with less than 150 events.
             # On the second iteration the second block is uploaded.
             dbsUploader.algorithm()
+            dbsUploader.checkBlocks()
             openBlocks = dbsUtil.findOpenBlocks()
             self.assertEqual(len(openBlocks), 1)
             globalFiles = myThread.dbi.processData("SELECT id FROM dbsbuffer_file WHERE status = 'InDBS'")[0].fetchall()
@@ -489,6 +490,7 @@ class DBSUploadTest(unittest.TestCase):
                 self.assertTrue('close_settings' not in block)
             time.sleep(3)
             dbsUploader.algorithm()
+            dbsUploader.checkBlocks()
             openBlocks = dbsUtil.findOpenBlocks()
             self.assertEqual(len(openBlocks), 0)
             fakeDBS = open(self.dbsUrl, 'r')
@@ -513,7 +515,7 @@ class DBSUploadTest(unittest.TestCase):
                                    workflowName = workflowName,
                                    taskPath = taskPath)
             dbsUploader.algorithm()
-    
+            dbsUploader.checkBlocks()
             openBlocks = dbsUtil.findOpenBlocks()
             self.assertEqual(len(openBlocks), 1)
             fakeDBS = open(self.dbsUrl, 'r')
@@ -534,7 +536,7 @@ class DBSUploadTest(unittest.TestCase):
                                    workflowName = workflowName,
                                    taskPath = taskPath)
             dbsUploader.algorithm()
-    
+            dbsUploader.checkBlocks()
             openBlocks = dbsUtil.findOpenBlocks()
             self.assertEqual(len(openBlocks), 0)
             fakeDBS = open(self.dbsUrl, 'r')
@@ -562,8 +564,10 @@ class DBSUploadTest(unittest.TestCase):
                                    workflowName = workflowName,
                                    taskPath = taskPath)
             dbsUploader.algorithm()
+            dbsUploader.checkBlocks()
             time.sleep(2)
             dbsUploader.algorithm()
+            dbsUploader.checkBlocks()
     
             self.assertEqual(len(openBlocks), 0)
             fakeDBS = open(self.dbsUrl, 'r')


### PR DESCRIPTION
1. Update DBS3 error message catch for duplicate insertions
2. Implement a check on Proxy Errors where the uploaded will check in the next polling cycle
   if the blocks were really inserted or not, the polling cycle delay should suffice
   for the block to appear in DBS3 if they were really inserted which is usually
   the case with DBS3 Proxy errors. If they are found as injected then mark them in DBS3Buffer.

Fixes #4673
