### PR TITLE
modify lcg-cp stageout code to support grid UI from cvmfs

### DIFF
--- a/src/python/WMCore/Storage/Backends/LCGImpl.py
+++ b/src/python/WMCore/Storage/Backends/LCGImpl.py
@@ -86,14 +86,35 @@ class LCGImpl(StageOutImpl):
 
         """
         result = "#!/bin/sh\n"
-        result += self.setups
-        result += "lcg-cp -b -D srmv2 --vo cms --srm-timeout 2400 --sendreceive-timeout 2400 --connect-timeout 300 --verbose "
 
+        # check if we should use the grid UI from CVMFS
+        useCVMFS = False
+        if options == "cvmfs":
+            options = None
+            useCVMFS = True
+
+        copyCommand = "lcg-cp -b -D srmv2 --vo cms --srm-timeout 2400 --sendreceive-timeout 2400 --connect-timeout 300 --verbose "
         if options != None:
-            result += " %s " % options
-        result += " %s " % sourcePFN
-        result += " %s \n" % targetPFN
+            copyCommand += " %s " % options
+        copyCommand += " %s " % sourcePFN
+        copyCommand += " %s \n" % targetPFN
 
+        # for CVMFS skip the usual environment setup and use grid.cern.ch instead
+        # also open a sub-shell and remove the cms.cern.ch path elements
+        if useCVMFS:
+            result += "(\n"
+
+            result += "echo Modifying PATH and LD_LIBRARY_PATH to remove /cvmfs/cms.cern.ch elements\n"
+            result += "export PATH=`echo $PATH | sed -e 's+:*/cvmfs/cms.cern.ch/[^:]*++'g`\n"
+            result += "export LD_LIBRARY_PATH=`echo $LD_LIBRARY_PATH | sed -e 's+:*/cvmfs/cms.cern.ch/[^:]*++'g`\n"
+
+            result += "echo Sourcing CVMFS UI setup script\n"
+            result += ". /cvmfs/grid.cern.ch/emi-ui-2.9.0-1_sl5v1/etc/profile.d/setup-cvmfs-ui.sh\n"
+
+            result += copyCommand
+        else:
+            result += self.setups 
+            result += copyCommand
 
         if _CheckExitCodeOption:
             result += """
@@ -169,6 +190,10 @@ class LCGImpl(StageOutImpl):
 
         """ % (remotePFN, checksumCommand, removeCommand, removeCommand)
         result += metadataCheck
+
+        # close sub-shell for CVMFS use case
+        if useCVMFS:
+            result += ")\n"
 
         return result
 


### PR DESCRIPTION
Modify the lcg-cp stageout so that the setting of the option "cvmfs" in SITECONF triggers using the grid UI from grid.cern.ch
