### PR TITLE
ReqMgr2 request validation fixed

### DIFF
--- a/src/python/WMCore/ReqMgr/DataStructs/Request.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/Request.py
@@ -4,17 +4,17 @@ define just 1 class. Derived from Python dict and implementing
 necessary conversion and validation extra methods possibly needed.
     
 TODO/NOTE:
-not sure what 'inputMode' request input argument is good for ... investigate
-
-TODO/NOTE:
-InputDataset vs InputDatasets - do we need both of these?    
-
+    'inputMode' should be removed by now (2013-07)
+    
+    since arguments validation #4705, arguments which are later
+        validated during spec instantiation and which are not
+        present in the request injection request, can't be defined
+        here because their None value is not allowed in the spec.
+        This is the case for e.g. DbsUrl, AcquisitionEra
+        This module should probably define only absolutely
+        necessary request parameters and not any optional ones.
+    
 """
-
-import WMCore.Lexicon
-
-from RequestType import REQUEST_TYPES 
-
 
 
 class RequestDataError(Exception):
@@ -61,7 +61,6 @@ class Request(dict):
         self.setdefault("RequestPriority", None)
         self.setdefault("RequestNumEvents", None)
         self.setdefault("RequestSizeFiles", None)
-        self.setdefault("AcquisitionEra", None)
         self.setdefault("Group", None)
         self.setdefault("OutputDatasets", [])
         # particular CMSSW version to run on
@@ -72,7 +71,6 @@ class Request(dict):
         self.setdefault("InputDatasetTypes", {})
         self.setdefault("SizePerEvent", 0)
         self.setdefault("PrepID", None)
-        self.setdefault("DbsUrl", None)
         self.setdefault("ScramArch", None)
         self.setdefault("GlobalTag", None)
         self.setdefault("ConfigCacheID", None)

--- a/src/python/WMCore/ReqMgr/Service/Request.py
+++ b/src/python/WMCore/ReqMgr/Service/Request.py
@@ -100,7 +100,8 @@ class Request(RESTEntity):
         if status and team:
             request_info.append(self.get_reqmgr_view("byteamandstatus", option, team, "list"))
         if name:
-            request_info.append(self._getReuestsByNames(name))
+            request_doc = self.reqmgr_db.document(name)
+            request_info.append(rows([request_doc]))
         if prep_id:
             request_info.append(self.get_reqmgr_view("byprepid", option, prep_id, "list"))
         if inputdataset:
@@ -142,22 +143,15 @@ class Request(RESTEntity):
         
     
     def get_reqmgr_view(self, view, options, keys, format):
-        
-        return self._get_couch_view(self.reqmgr_db, "ReqMgr", view, options, keys, format)
+        return self._get_couch_view(self.reqmgr_db, "ReqMgr", view,
+                                    options, keys, format)
     
     
     def get_wmstats_view(self, view, options, keys, format):
-        
-        return self._get_couch_view(self.wmstatsCouch, "WMStats", view, options, keys, format)
+        return self._get_couch_view(self.wmstatsCouch, "WMStats", view,
+                                    options, keys, format)
        
-    
-    def _get_request_by_names(self, names, stale="update_after"):
-        """
-        TODO: names can be regular expression or list of names
-        """
-        request_doc = self.reqmgr_db.document(self.db_name, names)
-        return rows([request_doc])
-        
+            
     def _combine_request(self, request_info, requestAgentUrl, cache):
         keys = {}
         requestAgentUrlList = []

--- a/test/data/ReqMgr/aux.json
+++ b/test/data/ReqMgr/aux.json
@@ -1,2 +1,0 @@
-{"_id": "software",  "slc5_amd64_gcc434": ["CMSSW_4_1_8", "CMSSW_6_2_0_pre5slc6"], 
- "slc5_amd64_gcc462": ["CMSSW_5_1_3", "CMSSW_5_2_0_pre6", "CMSSW_5_2_0_pre6DQM"]}

--- a/test/data/ReqMgr/reqmgr-all-tests.sh
+++ b/test/data/ReqMgr/reqmgr-all-tests.sh
@@ -1,10 +1,19 @@
-py test/data/ReqMgr/reqmgr.py -u https://localhost:2000 -f ./test/data/ReqMgr/requests/MonteCarlo.json  --json '{"createRequest": {"Requestor": "maxa"}, "assignRequest": {"Team": "dmwm", "AcquisitionEra": "AcquisitionEraTest"}}' --allTests && \
-py test/data/ReqMgr/reqmgr.py -u https://localhost:2000 -f ./test/data/ReqMgr/requests/MonteCarloFromGEN.json  --json '{"createRequest": {"Requestor": "maxa", "InputDataset": "/QCD_HT-1000ToInf_TuneZ2star_8TeV-madgraph-pythia6/Summer12-START50_V13-v1/GEN"}, "assignRequest": {"Team": "dmwm", "AcquisitionEra": "AcquisitionEraTest"}}' --allTests && \
-py test/data/ReqMgr/reqmgr.py -u https://localhost:2000 -f ./test/data/ReqMgr/requests/ReDigi.json  --json '{"createRequest": {"Requestor": "maxa", "InputDataset": "/WprimeToENu_M-3000_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v1/GEN-SIM"}, "assignRequest": {"Team": "dmwm", "AcquisitionEra": "AcquisitionEraTest"}}' --allTests && \
-py test/data/ReqMgr/reqmgr.py -u https://localhost:2000 -f ./test/data/ReqMgr/requests/ReReco.json  --json '{"createRequest": {"Requestor": "maxa", "InputDataset": "/BTag/Run2011B-v1/RAW"}, "assignRequest": {"Team": "dmwm", "AcquisitionEra": "AcquisitionEraTest"}}' --allTests && \
-py test/data/ReqMgr/reqmgr.py -u https://localhost:2000 -f ./test/data/ReqMgr/requests/TaskChain.json --json '{"createRequest": {"Requestor": "maxa"}, "assignRequest": {"Team": "dmwm", "AcquisitionEra": "AcquisitionEraTest"}}' --allTests && \
-py test/data/ReqMgr/reqmgr.py -u https://localhost:2000 -f ./test/data/ReqMgr/requests/TaskChainMultiDQM.json --json '{"createRequest": {"Requestor": "maxa"}, "assignRequest": {"Team": "dmwm"}}' --allTests && \
-py test/data/ReqMgr/reqmgr.py -u https://localhost:2000 -f ./test/data/ReqMgr/requests/TaskChainMultiTask.json --json '{"createRequest": {"Requestor": "maxa"}, "assignRequest": {"Team": "dmwm"}}' --allTests && \
-py test/data/ReqMgr/reqmgr.py -u https://localhost:2000 -f ./test/data/ReqMgr/requests/TaskChainPileupScratch.json --json '{"createRequest": {"Requestor": "maxa"}, "assignRequest": {"Team": "dmwm"}}' --allTests && \
-py test/data/ReqMgr/reqmgr.py -u https://localhost:2000 -f ./test/data/ReqMgr/requests/TaskChainProdTTbar.json --json '{"createRequest": {"Requestor": "maxa"}, "assignRequest": {"Team": "dmwm"}}' --allTests && \
-py test/data/ReqMgr/reqmgr.py -u https://localhost:2000 -f ./test/data/ReqMgr/requests/TaskChainRunMET2012A.json --json '{"createRequest": {"Requestor": "maxa"}, "assignRequest": {"Team": "dmwm"}}' --allTests
+# needs 1 argument - ReqMgr URL:
+#	http://localhost:8687 when running on localhost
+#	https://localhost:2000 when running against ReqMgr on VM via ssh tunnel
+if [ "x$1" == "x" ] ; then
+	echo "Missing ReqMgr URL (e.g. http://localhost:8687)"
+	exit 1
+fi
+
+REQMGR_URL=$1
+py test/data/ReqMgr/reqmgr.py -u $REQMGR_URL -f ./test/data/ReqMgr/requests/MonteCarlo.json  --json '{"createRequest": {"Requestor": "maxa"}, "assignRequest": {"Team": "dmwm", "AcquisitionEra": "AcquisitionEraTest"}}' --allTests && \
+py test/data/ReqMgr/reqmgr.py -u $REQMGR_URL -f ./test/data/ReqMgr/requests/MonteCarloFromGEN.json  --json '{"createRequest": {"Requestor": "maxa", "InputDataset": "/QCD_HT-1000ToInf_TuneZ2star_8TeV-madgraph-pythia6/Summer12-START50_V13-v1/GEN"}, "assignRequest": {"Team": "dmwm", "AcquisitionEra": "AcquisitionEraTest"}}' --allTests && \
+py test/data/ReqMgr/reqmgr.py -u $REQMGR_URL -f ./test/data/ReqMgr/requests/ReDigi.json  --json '{"createRequest": {"Requestor": "maxa", "InputDataset": "/WprimeToENu_M-3000_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v1/GEN-SIM"}, "assignRequest": {"Team": "dmwm", "AcquisitionEra": "AcquisitionEraTest"}}' --allTests && \
+py test/data/ReqMgr/reqmgr.py -u $REQMGR_URL -f ./test/data/ReqMgr/requests/ReReco.json  --json '{"createRequest": {"Requestor": "maxa", "InputDataset": "/BTag/Run2011B-v1/RAW"}, "assignRequest": {"Team": "dmwm", "AcquisitionEra": "AcquisitionEraTest"}}' --allTests && \
+py test/data/ReqMgr/reqmgr.py -u $REQMGR_URL -f ./test/data/ReqMgr/requests/TaskChain.json --json '{"createRequest": {"Requestor": "maxa"}, "assignRequest": {"Team": "dmwm", "AcquisitionEra": "AcquisitionEraTest"}}' --allTests && \
+py test/data/ReqMgr/reqmgr.py -u $REQMGR_URL -f ./test/data/ReqMgr/requests/TaskChainMultiDQM.json --json '{"createRequest": {"Requestor": "maxa"}, "assignRequest": {"Team": "dmwm"}}' --allTests && \
+py test/data/ReqMgr/reqmgr.py -u $REQMGR_URL -f ./test/data/ReqMgr/requests/TaskChainMultiTask.json --json '{"createRequest": {"Requestor": "maxa"}, "assignRequest": {"Team": "dmwm"}}' --allTests && \
+py test/data/ReqMgr/reqmgr.py -u $REQMGR_URL -f ./test/data/ReqMgr/requests/TaskChainPileupScratch.json --json '{"createRequest": {"Requestor": "maxa"}, "assignRequest": {"Team": "dmwm"}}' --allTests && \
+py test/data/ReqMgr/reqmgr.py -u $REQMGR_URL -f ./test/data/ReqMgr/requests/TaskChainProdTTbar.json --json '{"createRequest": {"Requestor": "maxa"}, "assignRequest": {"Team": "dmwm"}}' --allTests && \
+py test/data/ReqMgr/reqmgr.py -u $REQMGR_URL -f ./test/data/ReqMgr/requests/TaskChainRunMET2012A.json --json '{"createRequest": {"Requestor": "maxa"}, "assignRequest": {"Team": "dmwm"}}' --allTests

--- a/test/data/ReqMgr/reqmgr2-all-tests.sh
+++ b/test/data/ReqMgr/reqmgr2-all-tests.sh
@@ -1,0 +1,20 @@
+# needs 1 argument - ReqMgr URL:
+#	http://localhost:8246 when running on localhost
+#	https://localhost:2000 when running against ReqMgr on VM via ssh tunnel
+
+if [ "x$1" == "x" ] ; then
+	echo "Missing ReqMgr URL (e.g. http://localhost:8246)"
+	exit 1
+fi
+
+REQMGR_URL=$1
+py test/data/ReqMgr/reqmgr2.py -u $REQMGR_URL -f ./test/data/ReqMgr/requests/MonteCarlo.json --all_tests && \
+py test/data/ReqMgr/reqmgr2.py -u $REQMGR_URL -f ./test/data/ReqMgr/requests/MonteCarloFromGEN.json --json '{"createRequest": {"InputDataset": "/QCD_HT-1000ToInf_TuneZ2star_8TeV-madgraph-pythia6/Summer12-START50_V13-v1/GEN"}}' --all_tests && \
+py test/data/ReqMgr/reqmgr2.py -u $REQMGR_URL -f ./test/data/ReqMgr/requests/ReDigi.json --json '{"createRequest": {"InputDataset": "/WprimeToENu_M-3000_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v1/GEN-SIM"}}' --all_tests && \ 
+py test/data/ReqMgr/reqmgr2.py -u $REQMGR_URL -f ./test/data/ReqMgr/requests/ReReco.json --json '{"createRequest": {"InputDataset": "/BTag/Run2011B-v1/RAW"}}' --all_tests && \
+py test/data/ReqMgr/reqmgr2.py -u $REQMGR_URL -f ./test/data/ReqMgr/requests/TaskChain.json --all_tests && \
+py test/data/ReqMgr/reqmgr2.py -u $REQMGR_URL -f ./test/data/ReqMgr/requests/TaskChainMultiDQM.json --all_tests && \
+py test/data/ReqMgr/reqmgr2.py -u $REQMGR_URL -f ./test/data/ReqMgr/requests/TaskChainMultiTask.json --all_tests && \
+py test/data/ReqMgr/reqmgr2.py -u $REQMGR_URL -f ./test/data/ReqMgr/requests/TaskChainPileupScratch.json --all_tests && \
+py test/data/ReqMgr/reqmgr2.py -u $REQMGR_URL -f ./test/data/ReqMgr/requests/TaskChainProdTTbar.json --all_tests && \
+py test/data/ReqMgr/reqmgr2.py -u $REQMGR_URL -f ./test/data/ReqMgr/requests/TaskChainRunMET2012A.json --all_tests

--- a/test/data/ReqMgr/reqmgr2.py
+++ b/test/data/ReqMgr/reqmgr2.py
@@ -174,7 +174,7 @@ class ReqMgrClient(RESTClient):
         if requests_to_query:
             for request_name in requests_to_query:
                 logging.info("Querying '%s' request ..." % request_name)
-                urn = self.urn_prefix + "/request?request_name=%s" % request_name
+                urn = self.urn_prefix + "/request?name=%s" % request_name
                 status, data = self.http_request("GET", urn)
                 if status != 200:
                     print data
@@ -186,6 +186,7 @@ class ReqMgrClient(RESTClient):
             # returns data on requests in the same order as in the config.request_names
             return requests_data
         else:
+            raise RuntimeError("Implementation not completed, work on GET method underway.")
             logging.info("Querying all requests ...")
             urn = self.urn_prefix + "/request?all=true"
             status, data = self.http_request("GET", urn)
@@ -224,13 +225,7 @@ class ReqMgrClient(RESTClient):
         assert team not in data, "%s should be deleted from %s" % (team, data)
         
         data = self._caller_checker("/software", "GET")
-        
-        data = self._caller_checker("/request", "GET")
-        data = self._caller_checker("/request?all=false", "GET")
-        data = self._caller_checker("/request?all=true", "GET")
-        req_name = data[0]["rows"][0]["id"] # is RequestName
-        self._caller_checker("/request?request_name=%s" % req_name, "GET")
-        
+                
         data = self._caller_checker("/status", "GET")
         assert len(data) > 0, "%s should be non-empty list." % data
         # test some request status
@@ -249,8 +244,14 @@ class ReqMgrClient(RESTClient):
         data = self._caller_checker("/type", "GET")
         assert len(data) > 0, "%s should be non-empty list." % data
         
-        self.create_request(config)
+        # request tests
+        new_request_name = self.create_request(config) 
         
+        data = self._caller_checker("/request?name=%s" % new_request_name, "GET")
+        request = data[0]
+        assert request["RequestName"] == new_request_name  
+        assert request["RequestStatus"] == "new"
+                        
         print "\nall_tests succeeded."
         
     

--- a/test/python/WMCore_t/ReqMgr_t/Service_t/ReqMgr_t.py
+++ b/test/python/WMCore_t/ReqMgr_t/Service_t/ReqMgr_t.py
@@ -20,6 +20,8 @@ def insertDataToCouch(couchUrl, couchDBName, data):
     doc = database.commit(data)
     return doc
 
+
+
 class ReqMgrTest(RESTBaseUnitTestWithDBBackend):
     """
     Test WorkQueue Service client
@@ -29,43 +31,41 @@ class ReqMgrTest(RESTBaseUnitTestWithDBBackend):
 
     This checks whether DS call makes without error and return the results.
     Not the correctness of functions. That will be tested in different module.
+    
     """
-
     def setUp(self):
-        """
-        setUP global values
-        """
-        appport = 19888
-        #config = Config(appport, os.getenv("COUCHURL"), False);
         self.setConfig(config)
         self.setCouchDBs([(config.views.data.couch_reqmgr_db, "ReqMgr"), 
                           (config.views.data.couch_reqmgr_aux_db, None)])
         self.setSchemaModules([])
         RESTBaseUnitTestWithDBBackend.setUp(self)
-        
+
+        # put into ReqMgr auxiliary database under "software" document scram/cmsms
+        # which we'll need a little for request injection                
         #Warning: this assumes the same structure in jenkins wmcore_root/test
         requestPath = os.path.join(getWMBASE(), "test", "data", "ReqMgr", "requests")
-        #requestPath = os.path.join("..", "..", "..", "..", "data", "ReqMgr", "requests")
         mcFile = open(os.path.join(requestPath, "MonteCarlo.json"), 'r')
         self.mcArgs = JsonWrapper.load(mcFile)["createRequest"]
-        
         cmsswDoc = {"_id": "software"}
         cmsswDoc[self.mcArgs["ScramArch"]] =  []
         cmsswDoc[self.mcArgs["ScramArch"]].append(self.mcArgs["CMSSWVersion"])
         insertDataToCouch(os.getenv("COUCHURL"), config.views.data.couch_reqmgr_aux_db, cmsswDoc)        
         
+        
     def tearDown(self):
         RESTBaseUnitTestWithDBBackend.tearDown(self)
 
-    def testRequest(self):
-        
+
+    def testRequest(self):        
         self.jsonSender.post('data/request', self.mcArgs)
         #TODO: need to make stale option disabled to have the correct record
         result = self.jsonSender.get('data/request?status=new&status=assigned&_nostale=true')[0]['result']
-        print result
+        # TODO
+        # the above call should return request values. assert some of them
+        # against self.mcArgs
         self.jsonSender.get('data/request?prep_id=%s&_nostale=true' % self.mcArgs["PrepID"])[0]['result']
-        print result
+        
+        
         
 if __name__ == '__main__':
-
     unittest.main()


### PR DESCRIPTION
-unittests passing
-reqmgr.py client script --all_tests passing
-ReqMgr2 convenience bash wrapper script added

@ticoann, please see the client script testing of ReqMgr2

dballesteros7 - I have removed default None definition of request arguments which caused problems later in spec validation ff they remained None (i.e. when they were not overwritten by user input arguments). I think more of those should eventually be removed from ReqMgr/DataStructs/Request.py but now everything passes - creating 10 various requests by the client script based on all available request templates.
