### PR TITLE
ReqMgr2 software versions update problem fixed

### DIFF
--- a/src/python/WMCore/ReqMgr/Service/Auxiliary.py
+++ b/src/python/WMCore/ReqMgr/Service/Auxiliary.py
@@ -386,14 +386,20 @@ def update_software(config_file):
         return
     
     # now compare recent data from tag collector and what we already have stored
-    if all_archs_and_versions != sw_already_stored:
+    # sorting is necessary
+    if sorted(all_archs_and_versions) != sorted(sw_already_stored):
         logging.debug("ScramArch/CMSSW releases changed, updating software document ...")
         doc = Document(id="software", inputDict=all_archs_and_versions)
         couchdb.commitOne(doc)
+    """
         # TODO
-        # remove this, only to observe differences during update attempts
+        # this is only to observe differences during update attempts
+        # reference: https://github.com/dmwm/WMCore/issues/4715
         #msg = ("Really changed? Compare:\n"
         #       "sw_already_stored:\n%s\n"
         #       "all_archs_and_versions (returned from TC):\n%s\n" %
         #       (sw_already_stored, all_archs_and_versions))
         #print msg
+    else:
+        print "CMSSW versions identical, no database update necessary."
+    """


### PR DESCRIPTION
-the issues comprised from more misconceptions, thus was overall very
    confusing
-first, in order to compare values of dictionaries, these have to be sorted,
    otherwise the order is arbirtary and will -almost- always differ given the
    amount of data of CMSSW versions and ScramArchs
-second, when parsed and JSONified info on CMSSW versions and ScramArchs is
    not logged to stdout (which, since it's a cronjob, gets emailed over) but
    printed into a file straight away, the extra CR, ! or ' ' characters are
    never encountered. Since these characters are really seen in an email sent
    over as the job output, they may be a result of emailing the output or
    simply of some other element different from XML parsing and/or DOM
    building.
    This false idea (as summarised on #4715) was propped up by someone's
    former comment in the code:
        "Somehow we can get extraneous ('\n') text nodes in certain versions
        of Linux"
    this is either something completely different or the same false
    understanding based on the "log output" received in an email.

Although using JSON URL source from tag collector may be advantageous for some
other reasons, XML resource works fine as observed lately in a private VM
setup.

Fixes #4715
