### PR TITLE
Fix issue with None in parameter validation

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -67,7 +67,10 @@ class StdBase(object):
         argumentDefinition = self.getWorkloadArguments()
         for arg in argumentDefinition:
             if arg in arguments:
-                setattr(self, argumentDefinition[arg]["attr"], argumentDefinition[arg]["type"](arguments[arg]))
+                if arguments[arg] is None:
+                    setattr(self, argumentDefinition[arg]["attr"], arguments[arg])
+                else:
+                    setattr(self, argumentDefinition[arg]["attr"], argumentDefinition[arg]["type"](arguments[arg]))
             elif argumentDefinition[arg]["optional"]:
                 setattr(self, argumentDefinition[arg]["attr"], argumentDefinition[arg]["default"])
 


### PR DESCRIPTION
If the value for an argument is None and the argument definition allows None
as value then the attribute must be stored without the type cast to preserve
the None value.
