### PR TITLE
Properly validate processed dataset

### DIFF
--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
@@ -292,6 +292,17 @@ class Assign(WebAPI):
         helper.setProcessingVersion(kwargs["ProcessingVersion"])
         helper.setAcquisitionEra(kwargs["AcquisitionEra"])
         helper.setProcessingString(kwargs.get("ProcessingString", None))
+
+        # Now verify the output datasets
+        outputDatasets = helper.listOutputDatasets()
+        for dataset in outputDatasets:
+            tokens = dataset.split("/")
+            procds = tokens[2]
+            try:
+                WMCore.Lexicon.procdataset(procds)
+            except AssertionError:
+                raise cherrypy.HTTPError(400, "Bad output dataset name, check the processed dataset.")
+
         #FIXME not validated
         helper.setLFNBase(kwargs["MergedLFNBase"], kwargs["UnmergedLFNBase"])
         helper.setMergeParameters(int(kwargs.get("MinMergeSize", 2147483648)),

--- a/src/python/WMCore/Lexicon.py
+++ b/src/python/WMCore/Lexicon.py
@@ -148,7 +148,7 @@ def procversion(candidate):
 
 def procstring(candidate):
     """ Identifier """
-    return identifier(candidate)
+    return check(r'[a-zA-Z0-9_]{1,100}$', candidate)
 
 def acqname(candidate):
     """


### PR DESCRIPTION
On assignment, verify that the processed datasets meet
the Lexicon definition, also change the verification on the
procstring to make sure it doesn't include dashes.
