### PR TITLE
Configure T1 disk sites overrride

### DIFF
--- a/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
+++ b/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
@@ -55,6 +55,9 @@ class PhEDExInjectorPoller(BaseWorkerThread):
         self.seMap = {}
         self.nodeNames = []
 
+        self.diskSites = getattr(config.PhEDExInjector, "diskSites", ["storm-fe-cms.cr.cnaf.infn.it",
+                                                                      "srm-cms-disk.gridpp.rl.ac.uk"])
+
         # initialize the alert framework (if available - config.Alert present)
         #    self.sendAlert will be then be available
         self.initAlerts(compName = "PhEDExInjector")
@@ -147,15 +150,26 @@ class PhEDExInjectorPoller(BaseWorkerThread):
             if siteName in self.nodeNames:
                 location = siteName
             else:
-                if self.seMap.has_key("Buffer") and \
-                       self.seMap["Buffer"].has_key(siteName):
-                    location = self.seMap["Buffer"][siteName]
-                elif self.seMap.has_key("MSS") and \
-                         self.seMap["MSS"].has_key(siteName):
-                    location = self.seMap["MSS"][siteName]
-                elif self.seMap.has_key("Disk") and \
-                         self.seMap["Disk"].has_key(siteName):
-                    location = self.seMap["Disk"][siteName]
+                if siteName in self.diskSites:
+                    if self.seMap.has_key("Disk") and \
+                           self.seMap["Disk"].has_key(siteName):
+                        location = self.seMap["Disk"][siteName]
+                    elif self.seMap.has_key("Buffer") and \
+                             self.seMap["Buffer"].has_key(siteName):
+                        location = self.seMap["Buffer"][siteName]
+                    elif self.seMap.has_key("MSS") and \
+                             self.seMap["MSS"].has_key(siteName):
+                        location = self.seMap["MSS"][siteName]
+                else:
+                    if self.seMap.has_key("Buffer") and \
+                           self.seMap["Buffer"].has_key(siteName):
+                        location = self.seMap["Buffer"][siteName]
+                    elif self.seMap.has_key("MSS") and \
+                             self.seMap["MSS"].has_key(siteName):
+                        location = self.seMap["MSS"][siteName]
+                    elif self.seMap.has_key("Disk") and \
+                             self.seMap["Disk"].has_key(siteName):
+                        location = self.seMap["Disk"][siteName]
 
             if location == None:
                 msg = "Could not map SE %s to PhEDEx node." % siteName


### PR DESCRIPTION
Allow a configurable list of SEs where the Disk node
should have priority over the Buffer, this is used
by T1 sites where the Disk instance is commissioned
and uses the same SE endpoint as the Buffer instance.

It defaults to the SE of CNAF and the Disk SE of RAL. It can be configured
as:

config.PhEDExInjector.diskSites = ["storm-fe-cms.cr.cnaf.infn.it","srm-cms-disk.gridpp.rl.ac.uk"]
