### PR TITLE
Implement deterministic pileup support

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
+++ b/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
@@ -53,8 +53,9 @@ class PileupFetcher(FetcherInterface):
                 # DBS listBlocks returns list of DbsFileBlock objects for each dataset,
                 # iterate over and query each block to get list of files
                 for dbsBlockName in blockNames:
-                    blockDict[dbsBlockName] = {"FileList": dbsReader.lfnsInBlock(dbsBlockName),
-                                               "StorageElementNames": dbsReader.listFileBlockLocation(dbsBlockName)}
+                    blockDict[dbsBlockName] = {"FileList": sorted(dbsReader.lfnsInBlock(dbsBlockName)),
+                                               "StorageElementNames": dbsReader.listFileBlockLocation(dbsBlockName),
+                                               "NumberOfEvents" : dbsReader.getDBSSummaryInfo(block = dbsBlockName)['NumberOfEvents']}
             resultDict[pileupType] = blockDict
         return resultDict
 
@@ -70,7 +71,6 @@ class PileupFetcher(FetcherInterface):
         # the pileup configuration
         url = helper.data.dbsUrl
 
-        from WMCore.Services.DBS.DBSReader import DBSReader
         dbsReader = DBSReader(url)
 
         configDict = self._queryDbsAndGetPileupConfig(helper, dbsReader)


### PR DESCRIPTION
The EventAwareLumiBased and LumiBased splitting algorithms
will keep count of the number of jobs when deterministic
pileup is required, this allows the PSet to be tweaked
to use sequential pileup and skip the events already
used from the pileup dataset.
