### PR TITLE
implement smart retry handler

### DIFF
--- a/src/python/WMComponent/RetryManager/PlugIns/ProcessingAlgo.py
+++ b/src/python/WMComponent/RetryManager/PlugIns/ProcessingAlgo.py
@@ -2,28 +2,30 @@
 
 
 """
-_LinearAlgo_
+_ProcessingAlgo_
 
-Straight lines to the end
+'Smart' retry handler algorithm
 """
 import os.path
 import logging
+import shutil
+import cPickle
+import threading
+import time
 
-from WMCore.FwkJobReport.Report                     import Report
+from WMCore.DAOFactory import DAOFactory
+
+from WMCore.JobStateMachine.ChangeState import ChangeState
+
 from WMComponent.RetryManager.PlugIns.RetryAlgoBase import RetryAlgoBase
+
 
 class ProcessingAlgo(RetryAlgoBase):
     """
     _ProcessingAlgo_
 
-    Test jobs for two specific error conditions:
+    'Smart' retry handler
 
-    If job has an exit code within a list of exit codes, only retry once
-      set by ProcessingAlgoOneMoreErrorCodes
-    If a job ran for over 24 hours, only retry once
-      set by ProcessingAlgoMaxRuntime
-
-    This is done by setting the retry_count to be what we think is the maxRetry count - 1
     """
 
     def __init__(self, config):
@@ -31,18 +33,17 @@ class ProcessingAlgo(RetryAlgoBase):
         # Init basics
         RetryAlgoBase.__init__(self, config)
 
-        self.maxRetries = 3
+        myThread = threading.currentThread()
 
-        self.maxRunTime = self.getAlgoParam('default', 'MaxRunTime', 24 * 3600)
-        self.exitCodes  = self.getAlgoParam('default', 'OneMoreErrorCodes', [])
+        daoFactory = DAOFactory(package = "WMCore.WMBS",
+                                logger = myThread.logger,
+                                dbinterface = myThread.dbi)
+        
+        self.getWorkflowsInjectedDAO = daoFactory(classname = "JobGroup.GetWorkflowInjected")
+        self.getJobGroupUpdateTimeDAO = daoFactory(classname = "JobGroup.GetJobGroupUpdateTime")
+        self.getSubscriptionJobCountsDAO = daoFactory(classname = "JobGroup.GetSubscriptionJobCounts")
 
-        # Try to get the actual number of max retries, but don't mind
-        # if this is a test implementation without the full config
-        try:
-            self.maxRetries = self.config.ErrorHandler.maxRetries
-        except:
-            logging.debug("No ErrorHandler component passed to RetryManager.ProcessingAlgo - hope this is a test.")
-            pass
+        self.changeState = ChangeState(self.config)
 
         return
 
@@ -51,49 +52,232 @@ class ProcessingAlgo(RetryAlgoBase):
         Actual function that does the work
 
         """
+        #
+        # base coolOffTime (coolOffTime dict in configuration) in seconds
+        #
+        baseCoolOffTimeDict = self.getAlgoParam(job['jobType'])
+        baseCoolOffTime = baseCoolOffTimeDict.get(cooloffType.lower(), 3600)
 
-        if cooloffType == 'create' or cooloffType == 'submit':
-            # Can't really do anything with these: resubmit
-            return True
+        #
+        # the first retry for jobcooloff type jobs is usually shorter
+        # default 1800 seconds or baseCoolOffTime, whatever is shorter
+        # allowed is anything from 1 to baseCoolOffTime seconds
+        #
+        firstRetryCoolOffTime = self.getAlgoParam(job['jobType'], param = 'firstRetryCoolOffTime', defaultReturn = min(1800, baseCoolOffTime))
+        if firstRetryCoolOffTime not in range(1, baseCoolOffTime + 1):
+            logging.error("ERROR firstRetryCoolOffTime has to be an integer between 1 and %d, setting it to %d" % (baseCoolOffTime + 1, min(1800, baseCoolOffTime))) 
+            firstRetryCoolOffTime = min(1800, baseCoolOffTime)
 
-        # Run this to get the errors in the actual job
+        #
+        # growth of the coolOffTime with each retry (in percent of baseCoolOffTime)
+        #
+        #   coolOffTime = (1 + retry_count * coolOffTimeGrowth / 100) * baseCoolOffTime
+        #
+        # default is 100%, allowed are 0% to 200%
+        #
+        coolOffTimeGrowth = self.getAlgoParam(job['jobType'], param = 'coolOffTimeGrowth', defaultReturn = 100)
+        if coolOffTimeGrowth not in range(201):
+            logging.error("ERROR coolOffTimeGrowth has to be an integer between 0 and 200, setting it to 100") 
+            coolOffTimeGrowth = 100
+
+        #
+        # maximum allowed cooloff time in seconds
+        #
+        # default is 12 hours or twice the baseCoolOffTime, whatever is longer
+        # allowed is anything from baseCoolOffTime to either 24 hours or three times baseCoolOffTime (whatever is longer)
+        #
+        maxCoolOffTime = self.getAlgoParam(job['jobType'], param = 'maxCoolOffTime', defaultReturn = max(12*3600, 2 * baseCoolOffTime))
+        if maxCoolOffTime not in range(baseCoolOffTime, max(24*3600, 3 * baseCoolOffTime)):
+            logging.error("ERROR maxCoolOffTime has to be an integer between %d and %d, setting it to %d" %
+                          (baseCoolOffTime, max(24*3600, 3 * baseCoolOffTime), max(12*3600, 2 * baseCoolOffTime)))
+            maxCoolOffTime = max(12*3600, 2 * baseCoolOffTime)
+
+        #
+        # number of retries we always do, even in closeout
+        # also the retries during which we can modify the site blacklist
+        #
+        # default is 4, allowed are 1 to 99
+        #
+        guaranteedRetries = self.getAlgoParam(job['jobType'], param = 'guaranteedRetries', defaultReturn = 4)
+        if guaranteedRetries not in range(1,100):
+            logging.error("ERROR guaranteedRetries has to be an integer between 1 and 99, setting it to 4")
+            guaranteedRetries = 4
+
+        #
+        # completion percentage for subscription that triggers closeout
+        #
+        # default is 95% , allowed are 50% to 100% 
+        #
+        closeoutPercentage = self.getAlgoParam(job['jobType'], param = 'closeoutPercentage', defaultReturn = 95)
+        if closeoutPercentage not in range(50,101):
+            logging.error("ERROR closeoutPercentage has to be an integer between 50 and 100, setting it to 95")
+            closeoutPercentage = 95
+
+        #
+        # maximum amout of time a job can be retried in hours
+        #  (only applies if workflow is injected)
+        #
+        # default is 72 hours, allowed are between 24 and 168 hours
+        #
+        maxRetryTime = self.getAlgoParam(job['jobType'], param = 'maxRetryTime', defaultReturn = 72)
+        if maxRetryTime not in range(2, 169):
+            logging.error("ERROR maxRetryTime has to be an integer between 2 and 168, setting it to 72")
+            maxRetryTime = 72
+
+        #
+        # minimum amount of time in hours a workflow should be retried before being allowed to fail out
+        #  (only applies if workflow is injected)
+        #
+        # default is 1 hour, allowed are between 1 and 168 hours
+        #
+        minRetryTime = self.getAlgoParam(job['jobType'], param = 'minRetryTime', defaultReturn = 1)
+        if minRetryTime not in range(1, 169):
+            logging.error("ERROR minRetryTime has to be an integer between 1 and 169, setting it to 1")
+            minRetryTime = 1
+        if minRetryTime > maxRetryTime:
+            logging.error("ERROR minRetryTime can't be larger than maxRetryTime, setting it to maxRetryTime")
+            minRetryTime = maxRetryTime
+
+        #
+        # stop immediately for create failures
+        #
+        if cooloffType == 'create':
+            self.stopRetrying(job)
+            return False
+
+        #
+        # calculate timeout
+        #
+        if job['retry_count'] == 0:
+            timeout = firstRetryCoolOffTime
+        elif job['retry_count'] in range(guaranteedRetries):
+            timeout = min((1 + ( job['retry_count'] - 1) * coolOffTimeGrowth / 100) * baseCoolOffTime, maxCoolOffTime)
+        else:
+            timeout = maxCoolOffTime
+
+        #
+        # don't modify the site blacklist for submit failures
+        #
+        if cooloffType == 'submit':
+            if job['retry_count'] >= guaranteedRetries:
+                if self.inCloseout(job, minRetryTime, maxRetryTime, closeoutPercentage):
+                    self.stopRetrying(job)
+                    return False
+            return self.retryWithTimeout(job, timeout)
+
+        #
+        # different behavior for different retries
+        #
+        if job['retry_count'] in range(guaranteedRetries):
+            if self.retryWithTimeout(job, timeout):
+                self.modifySiteBlacklist(job, False)
+                return True
+            else:
+                return False
+        else:
+            if self.inCloseout(job, minRetryTime, maxRetryTime, closeoutPercentage):
+                    self.stopRetrying(job)
+                    return False
+            elif self.retryWithTimeout(job, maxCoolOffTime):
+                self.modifySiteBlacklist(job, True)
+                return True
+            else:
+                return False
+
+    def inCloseout(self, job, minRetryTime, maxRetryTime, closeoutPercentage):
+        """
+        Helper function that determines if the workflow
+        associated with the jobgroup is in closeout
+
+        """
+        if self.getWorkflowsInjectedDAO.execute(jobgroup = job['jobgroup']):
+            updateTime = self.getJobGroupUpdateTimeDAO.execute(jobgroup = job['jobgroup'])
+            totalRetryTime = self.timestamp() - updateTime
+            if totalRetryTime < minRetryTime * 3600:
+                logging.info("DEBUG minRetryTime not reached yet, continue")
+                return False
+            elif totalRetryTime > maxRetryTime * 3600:
+                logging.info("DEBUG maxRetryTime reached, stop")
+                return True
+            else:
+                (allJobs, completeJobs) = self.getSubscriptionJobCountsDAO.execute(jobgroup = job['jobgroup'])
+                logging.info("DEBUG finally hitting closeout")
+                return ( completeJobs*100 / allJobs >= closeoutPercentage )
+        else:
+            return False
+
+    def modifySiteBlacklist(self, job, resetFlag):
+        """
+        Helper function that modifies the site blacklist
+        based on current failure locations
+
+        """
+        pickledJobPath = os.path.join(job['cache_dir'], "job.pkl")
+        pickledJobPathBackup = os.path.join(job['cache_dir'], "job.pkl.backup")
+
+        # This should never happen, don't do anything
+        if not os.path.isfile(pickledJobPath):
+            return
+
+        if job['retry_count'] == 0:
+            logging.info("DEBUG backup pickled job file for job %s" % job['id'])
+            shutil.copy2(pickledJobPath, pickledJobPathBackup)
+        elif resetFlag:
+            if os.path.isfile(pickledJobPathBackup):
+                logging.info("DEBUG restore/move pickled job file backup for job %s" % job['id'])
+                shutil.move(pickledJobPathBackup, pickledJobPath)
+            return
+        else:
+            if not os.path.isfile(pickledJobPathBackup):
+                logging.info("DEBUG no pickled job file backup for job %s" % job['id'])
+                return
+
         try:
-            report     = Report()
-            reportPath = os.path.join(job['cache_dir'], "Report.%i.pkl" % job['retry_count'])
-            report.load(reportPath)
-        except:
-            # If we're here, then the FWJR doesn't exist.
-            # Give up, run it again
-            return True
+            jobHandle = open(pickledJobPath, "r")
+            loadedJob = cPickle.load(jobHandle)
+            jobHandle.close()
+        except Exception, ex:
+            # just silently ignore
+            return
 
-        # Set oneMore flag to be False
-        oneMore = False
+        logging.info("DEBUG siteWhiteList %s for job %s" % (loadedJob['siteWhitelist'], job['id']))
+        logging.info("DEBUG siteBlackList %s for job %s" % (loadedJob['siteBlacklist'], job['id']))
 
-        # Find startTime, stopTime
-        times = report.getFirstStartLastStop()
-        startTime = times['startTime']
-        stopTime  = times['stopTime']
+        tempList = []
+        for site in loadedJob['siteWhitelist']:
+            if site not in loadedJob['siteBlacklist']:
+                tempList.append(site)
 
-        if startTime == None or stopTime == None:
-            # Well, then we have a problem.
-            # There is something very wrong with this job, nevertheless we don't know what it is.
-            # Rerun, and hope the times get written the next time around.
-            logging.error("No start, stop times for steps")
-            return True
+        logging.info("DEBUG tempList %s for job %s" % (tempList, job['id']))
 
-        if stopTime - startTime > self.maxRunTime:
-            logging.error("Job only allowed to run one more time due to ProcessingAlgo.maxRunTime")
-            oneMore = True
+        if len(tempList) > 1:
+            if job['location'] in tempList:
+                loadedJob['siteBlacklist'].append(job['location'])
+                try:
+                    jobHandle = open(pickledJobPath, "w")
+                    cPickle.dump(loadedJob, jobHandle)
+                    jobHandle.close()
+                except Exception, ex:
+                    # could have corrupted job file, use backup
+                    logging.info("DEBUG restore/copy pickled job file backup for job %s" % job['id'])
+                    shutil.copy2(pickledJobPathBackup, pickledJobPath)
+        else:
+            logging.info("DEBUG restore/move pickled job file backup for job %s" % job['id'])
+            shutil.move(pickledJobPathBackup, pickledJobPath)
 
-        if report.getExitCode() in self.exitCodes:
-            logging.error("Job only allowed to run one more time due to ProcessingAlgo.exitCodes")
-            oneMore = True
+        return
 
+    def retryWithTimeout(self, job, timeout):
+        """
+        Helper function that retries job after fixed timeout
 
-        # Reset the retry time
-        if oneMore:
-            job['retry_count'] = max(self.maxRetries - 1, job['retry_count'])
-            job.save()
-            # Hope this gets passed back by reference
+        """
+        return self.timestamp() - job['state_time'] > timeout
 
-        return True
+    def stopRetrying(self, job):
+        """
+        Helper function to stop retrying
+
+        """
+        self.changeState.propagate(job, "retrydone", job['state'])
+        return

--- a/src/python/WMCore/WMBS/MySQL/JobGroup/GetJobGroupUpdateTime.py
+++ b/src/python/WMCore/WMBS/MySQL/JobGroup/GetJobGroupUpdateTime.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+"""
+_GetJobGroupUpdateTime_
+
+MySQL implementation of JobGroup.GetSubscriptionJobCounts
+"""
+
+
+
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class GetJobGroupUpdateTime(DBFormatter):
+
+    sql = """SELECT last_update
+             FROM wmbs_jobgroup
+             WHERE id = :JOBGROUP
+             """
+
+    def execute(self, jobgroup, conn = None, transaction = False):
+
+        results = self.dbi.processData(self.sql, { "JOBGROUP" : jobgroup },
+                                       conn = conn, transaction = transaction)[0].fetchall()
+
+        return results[0][0]

--- a/src/python/WMCore/WMBS/MySQL/JobGroup/GetSubscriptionJobCounts.py
+++ b/src/python/WMCore/WMBS/MySQL/JobGroup/GetSubscriptionJobCounts.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+"""
+_GetSubscriptionJobCounts_
+
+MySQL implementation of JobGroup.GetSubscriptionJobCounts
+"""
+
+
+
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class GetSubscriptionJobCounts(DBFormatter):
+
+    sql = """SELECT COUNT(wmbs_job.id),
+                    COUNT(wmbs_job_state.id)
+             FROM wmbs_subscription
+             INNER JOIN wmbs_jobgroup ON
+               wmbs_jobgroup.subscription = wmbs_subscription.id
+             INNER JOIN wmbs_job ON
+               wmbs_job.jobgroup = wmbs_jobgroup.id
+             LEFT OUTER JOIN wmbs_job_state ON
+               wmbs_job_state.id = wmbs_job.state AND
+               wmbs_job_state.name = 'cleanout'
+             WHERE wmbs_subscription.id =
+               (SELECT subscription FROM wmbs_jobgroup WHERE id = :JOBGROUP)
+             """
+
+    def execute(self, jobgroup, conn = None, transaction = False):
+
+        results = self.dbi.processData(self.sql, { "JOBGROUP" : jobgroup },
+                                       conn = conn, transaction = transaction)[0].fetchall()
+
+        return (results[0][0], results[0][1])

--- a/src/python/WMCore/WMBS/MySQL/JobGroup/GetWorkflowInjected.py
+++ b/src/python/WMCore/WMBS/MySQL/JobGroup/GetWorkflowInjected.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+"""
+_GetWorkflowInjected_
+
+MySQL implementation of JobGroup.GetWorkflowInjected
+"""
+
+
+
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class GetWorkflowInjected(DBFormatter):
+
+    sql = """SELECT injected
+             FROM wmbs_workflow
+             WHERE id = (SELECT workflow FROM wmbs_subscription
+                         WHERE id = (SELECT subscription FROM wmbs_jobgroup
+                                     WHERE id = :JOBGROUP))
+             """
+
+    def execute(self, jobgroup, conn = None, transaction = False):
+
+        results = self.dbi.processData(self.sql, { "JOBGROUP" : jobgroup },
+                                       conn = conn, transaction = transaction)[0].fetchall()
+
+        return bool(results[0][0])

--- a/src/python/WMCore/WMBS/Oracle/JobGroup/GetJobGroupUpdateTime.py
+++ b/src/python/WMCore/WMBS/Oracle/JobGroup/GetJobGroupUpdateTime.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+"""
+_GetJobGroupUpdateTime_
+
+Oracle implementation of JobGroup.GetJobGroupUpdateTime
+"""
+
+
+
+
+from WMCore.WMBS.MySQL.JobGroup.GetJobGroupUpdateTime import GetJobGroupUpdateTime as MySQLGetJobGroupUpdateTime
+
+class GetJobGroupUpdateTime(MySQLGetJobGroupUpdateTime):
+    pass

--- a/src/python/WMCore/WMBS/Oracle/JobGroup/GetSubscriptionJobCounts.py
+++ b/src/python/WMCore/WMBS/Oracle/JobGroup/GetSubscriptionJobCounts.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+"""
+_GetSubscriptionJobCounts_
+
+Oracle implementation of JobGroup.GetSubscriptionJobCounts
+"""
+
+
+
+
+from WMCore.WMBS.MySQL.JobGroup.GetSubscriptionJobCounts import GetSubscriptionJobCounts as MySQLGetSubscriptionJobCounts
+
+class GetSubscriptionJobCounts(MySQLGetSubscriptionJobCounts):
+    pass

--- a/src/python/WMCore/WMBS/Oracle/JobGroup/GetWorkflowInjected.py
+++ b/src/python/WMCore/WMBS/Oracle/JobGroup/GetWorkflowInjected.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+"""
+_GetWorkflowInjected_
+
+Oracle implementation of JobGroup.GetWorkflowInjected
+"""
+
+
+
+
+from WMCore.WMBS.MySQL.JobGroup.GetWorkflowInjected import GetWorkflowInjected as MySQLGetWorkflowInjected
+
+class GetWorkflowInjected(MySQLGetWorkflowInjected):
+    pass


### PR DESCRIPTION
Adds a "smart" retry handler (using the so far unused ProcessingAlgo) and adds a few extra DAOs used by the new retry handler. This will need some extensive tests before it can be merged. Any testing also requires the workqueue modification in #4753.
