### PR TITLE
fix scenario argument default value (workqueue unittest fix)

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -90,6 +90,9 @@ class StdBase(object):
         Determine the output module names and associated metadata for the
         given config.
         """
+        # set default scenarioArgs to empty dictionary if it is None.
+        scenarioArgs = scenarioArgs or {}
+        
         outputModules = {}
         if configDoc != None and configDoc != "":
             url = configCacheUrl or couchURL
@@ -237,6 +240,9 @@ class StdBase(object):
 
         The seeding and totalEvents parameters are only used for production jobs.
         """
+        # set default scenarioArgs to empty dictionary if it is None
+        scenarioArgs = scenarioArgs or {}
+        
         self.addDashboardMonitoring(procTask)
         procTaskCmssw = procTask.makeStep("cmsRun1")
         procTaskCmssw.setStepType(stepType)

--- a/src/python/WMQuality/Emulators/WMSpecGenerator/Samples/TestMonteCarloWorkload.py
+++ b/src/python/WMQuality/Emulators/WMSpecGenerator/Samples/TestMonteCarloWorkload.py
@@ -16,8 +16,8 @@ class TestMonteCarloFactory(MonteCarloWorkloadFactory):
     """Override bits that talk to cmsssw"""
     def __call__(self, workflowName, args):
         workload = MonteCarloWorkloadFactory.__call__(self, workflowName, args)
-        delattr(workload.taskIterator().next().steps().data.application.configuration,
-                'configCacheUrl')
+        #delattr(workload.taskIterator().next().steps().data.application.configuration,
+        #        'configCacheUrl')
         return workload
 
     def determineOutputModules(self, *args, **kwargs):


### PR DESCRIPTION
scenario arguments default value should be {} not None which cause the problem when default is used
This fixes wq unittest. 

There are other problem due to multiple sample spec is used for different test. Created separate issue for that.
https://github.com/dmwm/WMCore/issues/4760 
