### PR TITLE
fix to import HTTPException

### DIFF
--- a/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
+++ b/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
@@ -8,6 +8,7 @@ Poll the DBSBuffer database and inject files as they are created.
 import threading
 import logging
 import traceback
+from httplib import HTTPException
 
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 


### PR DESCRIPTION
PhEDExInjector crashed because of the missing module. Weird that we haven't encountered this long time.
@ericvaandering  please review.
