### PR TITLE
change Oracle constraints

### DIFF
--- a/src/python/WMCore/WMBS/Oracle/Create.py
+++ b/src/python/WMCore/WMBS/Oracle/Create.py
@@ -242,9 +242,9 @@ class Create(CreateWMBSBase):
           """ALTER TABLE wmbs_workflow ADD
                (CONSTRAINT wmbs_workflow_pk PRIMARY KEY (id) %s)""" % tablespaceIndex
 
-        self.indexes["02_pk_wmbs_workflow"] = \
+        self.indexes["uniquewfname"] = \
           """ALTER TABLE wmbs_workflow ADD
-               (CONSTRAINT wmbs_workflow_unique UNIQUE (name, task) %s)""" % tablespaceIndex
+               (CONSTRAINT uniq_wf_name UNIQUE (name, task) %s)""" % tablespaceIndex
 
         self.indexes["02_fk_wmbs_workflow"] = \
           """ALTER TABLE wmbs_workflow ADD


### PR DESCRIPTION
A new constraint in CreateWMBSBase conflicts with an older constraint in Oracle/Create, resolve this (by renaming the constraint in Oracle/Create to have the same name as the MySQL version). Without this patch the schema cannot be deployed on Oracle. Someone please give it a quick review and report back or merge.
