### PR TITLE
fix local job couch view due transition change

### DIFF
--- a/src/couchapps/JobDump/views/failedJobsByWorkflowName/map.js
+++ b/src/couchapps/JobDump/views/failedJobsByWorkflowName/map.js
@@ -1,4 +1,5 @@
 function(doc) {
+  /* this doesn't include killed jobs */
   function stateSort(a, b) {
     if (a['timestamp'] > b['timestamp']) {
       return 1;
@@ -18,18 +19,13 @@ function(doc) {
     stateList.sort(stateSort);
     lastTransition = stateList.pop();
 
-    if (lastTransition['oldstate'] == 'jobfailed' &&
-        lastTransition['newstate'] == 'exhausted') {
-      emit([doc['workflow'], doc['task']], doc['jobid']);
-    } else if (lastTransition['oldstate'] == 'submitfailed' &&
-               lastTransition['newstate'] == 'exhausted') {
-      emit([doc['workflow'], doc['task']], doc['jobid']);
-    } else if (lastTransition['oldstate'] == 'createfailed' &&
-               lastTransition['newstate'] == 'exhausted') {
+    if (lastTransition['newstate'] == 'exhausted') {
       emit([doc['workflow'], doc['task']], doc['jobid']);
     } else if (lastTransition['oldstate'] == 'exhausted' &&
                lastTransition['newstate'] == 'cleanout') {
       emit([doc['workflow'], doc['task']], doc['jobid']);
+    } else if (lastTransition['newstate'] == 'retrydone') {
+      emit([doc['workflow'], doc['task']], doc['jobid']);	
     }
   }
 }

--- a/src/couchapps/JobDump/views/hourlyStatusBySiteName/map.js
+++ b/src/couchapps/JobDump/views/hourlyStatusBySiteName/map.js
@@ -1,4 +1,7 @@
 function(doc) {
+  /* this is used for WMBSService and OLD GlobalMonitor.
+   * need to be deplicated
+   */
   function stateSort(a, b) {
     if (a['timestamp'] > b['timestamp']) {
       return 1;
@@ -26,40 +29,28 @@ function(doc) {
     }
 
     var lastHour = lastTransition['timestamp'] - (lastTransition['timestamp'] % 3600);
-
-    if(lastTransition['oldstate'] == 'jobfailed' &&
-              lastTransition['newstate'] == 'jobcooloff') {
+    
+    // cooloff state
+    if (lastTransition['newstate'] == 'jobcooloff') {
       emit([lastHour, lastLocation, 'cooloff'], doc['jobid']);
-    } else if (lastTransition['oldstate'] == 'complete' &&
-               lastTransition['newstate'] == 'success') {
+    } 
+    // success state
+    else if (lastTransition['newstate'] == 'success') {
       emit([lastHour, lastLocation, 'success'], doc['jobid']);
-    } else if (lastTransition['oldstate'] == 'jobfailed' &&
-               lastTransition['newstate'] == 'exhausted') {
-      emit([lastHour, lastLocation, 'failure'], doc['jobid']);
-    } else if (lastTransition['oldstate'] == 'submitfailed' &&
-               lastTransition['newstate'] == 'exhausted') {
-      emit([lastHour, lastLocation, 'failure'], doc['jobid']);
-    } else if (lastTransition['oldstate'] == 'createfailed' &&
-               lastTransition['newstate'] == 'exhausted') {
-      emit([lastHour, lastLocation, 'failure'], doc['jobid']);
-    } else if (lastTransition['oldstate'] == 'new' &&
-               lastTransition['newstate'] == 'killed') {
-      emit([lastHour, lastLocation, 'failure'], doc['jobid']);
-    } else if (lastTransition['oldstate'] == 'created' &&
-               lastTransition['newstate'] == 'killed') {
-      emit([lastHour, lastLocation, 'failure'], doc['jobid']);
-    } else if (lastTransition['oldstate'] == 'executing' &&
-               lastTransition['newstate'] == 'killed') {
-      emit([lastHour, lastLocation, 'failure'], doc['jobid']);
-    } else if (lastTransition['oldstate'] == 'killed' &&
-               lastTransition['newstate'] == 'killed') {
+	} else if (lastTransition['oldstate'] == 'success' &&
+               lastTransition['newstate'] == 'cleanout') {
+      emit([lastHour, lastLocation, 'success'], doc['jobid']);
+    } 
+    // failure state
+    else if (lastTransition['newstate'] == 'exhausted') {
       emit([lastHour, lastLocation, 'failure'], doc['jobid']);
     } else if (lastTransition['oldstate'] == 'exhausted' &&
                lastTransition['newstate'] == 'cleanout') {
       emit([lastHour, lastLocation, 'failure'], doc['jobid']);
-    } else if (lastTransition['oldstate'] == 'success' &&
-               lastTransition['newstate'] == 'cleanout') {
-      emit([lastHour, lastLocation, 'success'], doc['jobid']);
+    } else if (lastTransition['newstate'] == 'retrydone') {
+      emit([lastHour, lastLocation, 'failure'], doc['jobid']);
+    } else if (lastTransition['newstate'] == 'killed') {
+      emit([lastHour, lastLocation, 'failure'], doc['jobid']);
     }
   }
 }

--- a/src/couchapps/JobDump/views/jobStateBySite/map.js
+++ b/src/couchapps/JobDump/views/jobStateBySite/map.js
@@ -8,7 +8,7 @@ function(doc) {
         //emit(doc['states'][0].location, 1)
         var i; //index
         for (i in doc['states']) {
-            tempSite = doc['states'][i].location
+            tempSite = doc['states'][i].location;
             if (tempSite != "Agent") {
                 site = tempSite;
             }
@@ -26,9 +26,11 @@ function(doc) {
                     else {
                         state = oldstate;
                     }
+                } else if (state == "retrydone") {
+                	state = "jobfailed";
                 }
-                emit([site, state], 1)
+                emit([site, state], 1);
             }
         }
     }
-}
+};

--- a/src/couchapps/JobDump/views/statusBySiteName/map.js
+++ b/src/couchapps/JobDump/views/statusBySiteName/map.js
@@ -25,32 +25,15 @@ function(doc) {
       }
     }
 
-    if(lastTransition['oldstate'] == 'jobfailed' &&
-              lastTransition['newstate'] == 'jobcooloff') {
+    if(lastTransition['newstate'] == 'jobcooloff') {
       emit([lastLocation, 'cooloff'], doc['jobid']);
-    } else if (lastTransition['oldstate'] == 'complete' &&
-               lastTransition['newstate'] == 'success') {
+    } else if (lastTransition['newstate'] == 'success') {
       emit([lastLocation, 'success'], doc['jobid']);
-    } else if (lastTransition['oldstate'] == 'jobfailed' &&
-               lastTransition['newstate'] == 'exhausted') {
+    } else if (lastTransition['newstate'] == 'retrydone') {
       emit([lastLocation, 'failure'], doc['jobid']);
-    } else if (lastTransition['oldstate'] == 'submitfailed' &&
-               lastTransition['newstate'] == 'exhausted') {
+    } else if (lastTransition['newstate'] == 'exhausted') {
       emit([lastLocation, 'failure'], doc['jobid']);
-    } else if (lastTransition['oldstate'] == 'createfailed' &&
-               lastTransition['newstate'] == 'exhausted') {
-      emit([lastLocation, 'failure'], doc['jobid']);
-    } else if (lastTransition['oldstate'] == 'new' &&
-               lastTransition['newstate'] == 'killed') {
-      emit([lastLocation, 'failure'], doc['jobid']);
-    } else if (lastTransition['oldstate'] == 'created' &&
-               lastTransition['newstate'] == 'killed') {
-      emit([lastLocation, 'failure'], doc['jobid']);
-    } else if (lastTransition['oldstate'] == 'executing' &&
-               lastTransition['newstate'] == 'killed') {
-      emit([lastLocation, 'failure'], doc['jobid']);
-    } else if (lastTransition['oldstate'] == 'killed' &&
-               lastTransition['newstate'] == 'killed') {
+    } else if (lastTransition['newstate'] == 'killed') {
       emit([lastLocation, 'failure'], doc['jobid']);
     } else if (lastTransition['oldstate'] == 'exhausted' &&
                lastTransition['newstate'] == 'cleanout') {

--- a/src/couchapps/JobDump/views/statusByWorkflowName/map.js
+++ b/src/couchapps/JobDump/views/statusByWorkflowName/map.js
@@ -34,36 +34,16 @@ function(doc) {
               lastTransition['newstate'] == 'created') {
       emit([doc['workflow'], doc['task'], doc['jobid']],
             {'jobid': doc['jobid'], 'state': 'pending', 'task': doc['task']});
-    } else if (lastTransition['oldstate'] == 'complete' &&
-               lastTransition['newstate'] == 'success') {
+    } else if (lastTransition['newstate'] == 'success') {
       emit([doc['workflow'], doc['task'], doc['jobid']],
             {'jobid': doc['jobid'], 'state': 'success', 'task': doc['task']});
-    } else if (lastTransition['oldstate'] == 'jobfailed' &&
-               lastTransition['newstate'] == 'exhausted') {
+    } else if (lastTransition['newstate'] == 'retrydone') {
       emit([doc['workflow'], doc['task'], doc['jobid']],
             {'jobid': doc['jobid'], 'state': 'failure', 'task': doc['task']});
-    } else if (lastTransition['oldstate'] == 'submitfailed' &&
-               lastTransition['newstate'] == 'exhausted') {
+    } else if (lastTransition['newstate'] == 'exhausted') {
       emit([doc['workflow'], doc['task'], doc['jobid']],
             {'jobid': doc['jobid'], 'state': 'failure', 'task': doc['task']});
-    } else if (lastTransition['oldstate'] == 'createfailed' &&
-               lastTransition['newstate'] == 'exhausted') {
-      emit([doc['workflow'], doc['task'], doc['jobid']],
-            {'jobid': doc['jobid'], 'state': 'failure', 'task': doc['task']});
-    } else if (lastTransition['oldstate'] == 'new' &&
-               lastTransition['newstate'] == 'killed') {
-      emit([doc['workflow'], doc['task'], doc['jobid']],
-            {'jobid': doc['jobid'], 'state': 'failure', 'task': doc['task']});
-    } else if (lastTransition['oldstate'] == 'created' &&
-               lastTransition['newstate'] == 'killed') {
-      emit([doc['workflow'], doc['task'], doc['jobid']],
-            {'jobid': doc['jobid'], 'state': 'failure', 'task': doc['task']});
-    } else if (lastTransition['oldstate'] == 'executing' &&
-               lastTransition['newstate'] == 'killed') {
-      emit([doc['workflow'], doc['task'], doc['jobid']],
-            {'jobid': doc['jobid'], 'state': 'failure', 'task': doc['task']});
-    } else if (lastTransition['oldstate'] == 'killed' &&
-               lastTransition['newstate'] == 'killed') {
+    } else if (lastTransition['newstate'] == 'killed') {
       emit([doc['workflow'], doc['task'], doc['jobid']],
             {'jobid': doc['jobid'], 'state': 'failure', 'task': doc['task']});
     } else if (lastTransition['oldstate'] == 'exhausted' &&


### PR DESCRIPTION
Job couch view need to be corrected due to the job transition changes from
https://github.com/dmwm/WMCore/commit/86ee49a7842d3a13fb23002e630e2c0dcfee6101#diff-116f4e994bd8276572516a098b601300

@hufnagel please review.
Also I have question about the transition itself. Are the following valid transition, should it done by agent or by user

createpaused -> retrydone
sumbitpaused -> retrydone
jobpaused -> retrydone

Is there any other place needs to be changed with job state transition change?
This fetch needs further testing
Thanks,
