### PR TITLE
Fixed job OS requirement in the JDL

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
@@ -234,7 +234,7 @@ class CondorPlugin(BasePlugin):
             self.proxy = self.setupMyProxy()
 
         # Build a request string
-        self.reqStr = "(Memory >= 1 && OpSys == \"LINUX\" ) && (Arch == \"INTEL\" || Arch == \"X86_64\") && stringListMember(GLIDEIN_CMSSite, DESIRED_Sites) && (GLIDEIN_REQUIRED_OS==REQUIRED_OS)"
+        self.reqStr = "(Memory >= 1 && OpSys == \"LINUX\" ) && (Arch == \"INTEL\" || Arch == \"X86_64\") && stringListMember(GLIDEIN_CMSSite, DESIRED_Sites) && ((REQUIRED_OS==\"any\") || (GLIDEIN_REQUIRED_OS==REQUIRED_OS))"
         if hasattr(config.BossAir, 'condorRequirementsString'):
             self.reqStr = config.BossAir.condorRequirementsString
 
@@ -1002,7 +1002,7 @@ class CondorPlugin(BasePlugin):
             jdl.append('request_disk = %d\n' % int(job['estimatedDiskUsage']))
 
         #Add OS requirements for jobs
-        if job.get('scramArch') is not None and job.get('scramArch').startswith("sl6_") :
+        if job.get('scramArch') is not None and job.get('scramArch').startswith("slc6_") :
             jdl.append('+REQUIRED_OS = "rhel6"\n')
         else : 
             jdl.append('+REQUIRED_OS = "any"\n')


### PR DESCRIPTION
When a job has the attribute
REQUIRED_OS="any"
the condition GLIDEIN_REQUIRED_OS==REQUIRED_OS in the job requirements expression never matches the job to a glidein at the collector/negotiator because no glidein has
GLIDEIN_REQUIRED_OS="any"
I changed the expresion so that the above comparison is made only when the job has some other value of the attribute like REQUIRED_OS="rhel6". Without the change jobs never run.

The condition on the scramarch when the CondorPlugin sets the REQUIRED_OS="rhel6" requirement in the JDL is also fixed.

We discovered the problem and tested the patch while validating WMagent 0.9.79
