### PR TITLE
Merge/Processing job file parentage fix

### DIFF
--- a/src/python/WMCore/WMBS/MySQL/Files/SetParentageByMergeJob.py
+++ b/src/python/WMCore/WMBS/MySQL/Files/SetParentageByMergeJob.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-MySQL implementation of File.SetParentageByJob
+MySQL implementation of File.SetParentageByMergeJob
 
 Make the parentage link between a file and all the inputs of a given job
 """
@@ -12,7 +12,7 @@ import logging
 
 from WMCore.Database.DBFormatter import DBFormatter
 
-class SetParentageByJob(DBFormatter):
+class SetParentageByMergeJob(DBFormatter):
     """
     Make the parentage link between a file and all the inputs of a given job
     """
@@ -21,8 +21,16 @@ class SetParentageByJob(DBFormatter):
     sql = """INSERT INTO wmbs_file_parent (child, parent)
              SELECT DISTINCT wmbs_file_details.id, wmbs_job_assoc.fileid
              FROM wmbs_file_details, wmbs_job_assoc
+             INNER JOIN wmbs_job ON
+                 wmbs_job_assoc.job = wmbs_job.id
+             INNER JOIN wmbs_jobgroup ON
+                 wmbs_jobgroup.id = wmbs_job.jobgroup
+             LEFT OUTER JOIN wmbs_sub_files_failed ON
+                 wmbs_jobgroup.subscription = wmbs_sub_files_failed.subscription
+                 AND wmbs_sub_files_failed.fileid = wmbs_job_assoc.fileid
              WHERE wmbs_job_assoc.job  = :jobid
              AND wmbs_file_details.lfn = :child
+             AND wmbs_sub_files_failed.fileid IS NULL
     """
 
 

--- a/src/python/WMCore/WMBS/Oracle/Files/SetParentageByMergeJob.py
+++ b/src/python/WMCore/WMBS/Oracle/Files/SetParentageByMergeJob.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+"""
+Oracle implementation of File.SetParentageByMergeJob
+
+Make the parentage link between a file and all the inputs of a given job
+"""
+
+
+
+
+from WMCore.WMBS.MySQL.Files.SetParentageByMergeJob import SetParentageByMergeJob as MySQLSetParentageByMergeJob
+
+class SetParentageByMergeJob(MySQLSetParentageByMergeJob):
+    pass


### PR DESCRIPTION
Original code brakes the parentage of files from Processing job when one of the job fails. 

This patch will do,
If one of processing job fails from the same job group, it will still set the parentage correctly.
If merge job fails within the same job group. the parentage won't be set the input files on the whole merge job group.
So robust merge can be still sported.
Dirk please review. basic unit test is added. But ops will do through test.
