### PR TITLE
print out returned content from http errors

### DIFF
--- a/src/python/WMCore/Services/Service.py
+++ b/src/python/WMCore/Services/Service.py
@@ -306,6 +306,8 @@ class Service(dict):
                 if hasattr(he, 'status') and hasattr(he, 'reason'):
                     msg += ' is unavailable - it returned %s because %s\n' % (he.status,
                                                                               he.reason)
+                    if hasattr(he, result):
+                        msg += ' with result: %s\n' % he.result
                 else:
                     msg += ' raised a %s when accessed' % he.__repr__()
                 self['logger'].warning(msg)


### PR DESCRIPTION
When a http server returns an error (400, 500 or whatever status),
it can also return a message explaining why this happens. At the
moment this message is just eaten and not printed out, which makes
communication problems with web services like PHEDEx really
hard to debug. Add a printout.
