### PR TITLE
Alarming improvements

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -499,5 +499,7 @@ config.AnalyticsDataCollector.localQueueURL = "%s/%s" % (config.WorkQueueManager
 config.AnalyticsDataCollector.localWMStatsURL = "%s/%s" % (config.JobStateMachine.couchurl, config.JobStateMachine.jobSummaryDBName)
 config.AnalyticsDataCollector.centralWMStatsURL = "Central WMStats URL"
 config.AnalyticsDataCollector.summaryLevel = "task"
+config.AnalyticsDataCollector.diskUseThreshold = 85
+config.AnalyticsDataCollector.couchProcessThreshold = 25
 config.AnalyticsDataCollector.pluginName = None
 

--- a/src/python/WMComponent/AnalyticsDataCollector/AgentStatusPoller.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/AgentStatusPoller.py
@@ -15,7 +15,8 @@ from WMCore.Services.WorkQueue.WorkQueue import WorkQueue as WorkQueueService
 from WMCore.Services.WMStats.WMStatsWriter import WMStatsWriter
 from WMComponent.AnalyticsDataCollector.DataCollectAPI import LocalCouchDBData, \
      WMAgentDBData, combineAnalyticsData, convertToRequestCouchDoc, \
-     convertToAgentCouchDoc, isDrainMode, initAgentInfo
+     convertToAgentCouchDoc, isDrainMode, initAgentInfo, DataUploadTime, \
+     diskUse, numberCouchProcess
 from WMCore.WMFactory import WMFactory
 
 class AgentStatusPoller(BaseWorkerThread):
@@ -82,19 +83,53 @@ class AgentStatusPoller(BaseWorkerThread):
         agentInfo = self.wmagentDB.getComponentStatus(self.config)
         agentInfo.update(self.agentInfo)
         
+        if isDrainMode(self.config):
+            logging.info("Agent is in DrainMode")
+            agentInfo['drain_mode'] = True
+            agentInfo['status'] = "warning"
+        
+        else:
+            agentInfo['drain_mode'] = False
+        
         if (couchInfo['status'] != 'ok'):
             agentInfo['down_components'].append("CouchServer")
             agentInfo['status'] = couchInfo['status']
             couchInfo['name'] = "CouchServer"
             agentInfo['down_component_detail'].append(couchInfo)
         
-        if isDrainMode(self.config):
-            logging.info("Agent is in DrainMode")
-            agentInfo['drain_mode'] = True
-            agentInfo['status'] = "warning"
+        
+        # Disk space warning   
+        diskUseList = diskUse()
+        diskUseThreshold = float(self.config.AnalyticsDataCollector.diskUseThreshold)
+        agentInfo['disk_warning'] = []
+        for disk in diskUseList:
+            if float(disk['percent'].strip('%')) >= diskUseThreshold:
+                agentInfo['disk_warning'].append(disk)
+        
+        # Couch process warning
+        couchProc = numberCouchProcess()
+        couchProcessThreshold = float(self.config.AnalyticsDataCollector.couchProcessThreshold)
+        if couchProc >= couchProcessThreshold:
+            agentInfo['couch_process_warning'] = couchProc
         else:
-            agentInfo['drain_mode'] = False
-            
+            agentInfo['couch_process_warning'] = 0
+        
+        # This adds the last time and message when data was updated to agentInfo
+        lastDataUpload = DataUploadTime.getInfo(self)
+        if lastDataUpload['data_last_update']!=0:
+            agentInfo['data_last_update'] = lastDataUpload['data_last_update']
+        if lastDataUpload['data_error']!="":
+            agentInfo['data_error'] = lastDataUpload['data_error']
+        
+        # Change status if there is data_error, couch process maxed out or disk full problems.
+        if agentInfo['status'] == 'ok':
+            if agentInfo['disk_warning'] != []:
+                agentInfo['status'] = "warning"
+                
+        if agentInfo['status'] == 'ok' or agentInfo['status'] == 'warning':
+             if agentInfo['data_error'] != 'ok' or agentInfo['couch_process_warning'] != 0:
+                 agentInfo['status'] = "error"
+
         return agentInfo
 
     def uploadAgentInfoToCentralWMStats(self, agentInfo, uploadTime):

--- a/src/python/WMComponent/AnalyticsDataCollector/AnalyticsPoller.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/AnalyticsPoller.py
@@ -15,7 +15,7 @@ from WMCore.Services.WorkQueue.WorkQueue import WorkQueue as WorkQueueService
 from WMCore.Services.WMStats.WMStatsWriter import WMStatsWriter
 from WMComponent.AnalyticsDataCollector.DataCollectAPI import LocalCouchDBData, \
      WMAgentDBData, combineAnalyticsData, convertToRequestCouchDoc, \
-     convertToAgentCouchDoc, isDrainMode, initAgentInfo
+     convertToAgentCouchDoc, isDrainMode, initAgentInfo, DataUploadTime
 from WMCore.WMFactory import WMFactory
 
 class AnalyticsPoller(BaseWorkerThread):
@@ -112,9 +112,10 @@ class AnalyticsPoller(BaseWorkerThread):
 
             self.localSummaryCouchDB.uploadData(requestDocs)
             logging.info("Request data upload success\n %s request, \nsleep for next cycle" % len(requestDocs))
-
+            DataUploadTime.setInfo(self, uploadTime, "ok")
+            
         except Exception, ex:
             logging.error("Error occurred, will retry later:")
             logging.error(str(ex))
+            DataUploadTime.setInfo(self, False, str(ex))
             logging.error("Trace back: \n%s" % traceback.format_exc())
- 


### PR DESCRIPTION
This is the combined patch to fix #4820 and #4786 

This combine patch includes:
- send the last time when data was uploaded
- send the error message if data could not be uploaded, otherwise sends 'ok'
- warning if a disk partition is above 85% full
- warning if couch process are maxed out (25 or above).

@ticoann Sorry, I made too many commits, next time I will do it better
