### PR TITLE
set default config cache name sync with production name

### DIFF
--- a/bin/wmagent-mod-config
+++ b/bin/wmagent-mod-config
@@ -183,7 +183,6 @@ def modifyConfiguration(config, **args):
         config.reqmgr.Webtools.host = args["reqmgr_hostname"]
         config.reqmgr.Webtools.port = int(args["reqmgr_port"])
         config.reqmgr.couchUrl = args["couch_url"]
-        config.reqmgr.configDBName = "wmagent_configcache"
         config.reqmgr.views.active.create.requestor = "cmsdataops"
         config.reqmgr.admin = "gutsche@fnal.gov"
         config.reqmgr.views.active.reqMgr.model.couchUrl = args["couch_url"]

--- a/etc/ReqMgrConfig.py
+++ b/etc/ReqMgrConfig.py
@@ -37,7 +37,7 @@ userEmail = "OPERATOR EMAIL"
 # database.  The JobDump couchapp needs to be installed into the jobdump
 # database.
 couchURL = "http://USERNAMEPASSWORD@COUCHSERVER:5984"
-configCacheDBName = "wmagent_configcache"
+configCacheDBName = "reqmgr_config_cache"
 reqMgrDBName = "reqmgrdb"
 wmstatDBName = "wmstats"
 

--- a/src/python/WMCore/WMSpec/StdSpecs/Analysis.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Analysis.py
@@ -162,7 +162,7 @@ class AnalysisWorkloadFactory(StdBase):
                     "CouchURL" : {"default" : "http://localhost:5984", "type" : str,
                                   "optional" : False, "validate" : couchurl,
                                   "attr" : "couchURL", "null" : False},
-                    "CouchDBName" : {"default" : "wmagent_configcache", "type" : str,
+                    "CouchDBName" : {"default" : "analysis_reqmgr_config_cache", "type" : str,
                                      "optional" : False, "validate" : identifier,
                                      "attr" : "couchDBName", "null" : False},
                     "AnalysisConfigCacheDoc" : {"default" : None, "type" : str,


### PR DESCRIPTION
set the reqmgr config cache db name the same as production deployment. so in case test need to access cmsweb-testbed config cache, it doesn't need manual config change after deployment.
@ericvaandering, please review
