### PR TITLE
Allow the execution of arbitrary scramPreScripts in the CMSSW executor

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
@@ -211,10 +211,9 @@ class CMSSW(Executor):
         logging.info("RUNNING SCRAM SCRIPTS")
         for script in self.step.runtime.scramPreScripts:
             #invoke scripts with scram()
-            invokeCommand = "%s -m WMCore.WMRuntime.ScriptInvoke %s %s \n" % (
-                sys.executable,
-                stepModule,
-                script)
+            invokeCommand = self.step.runtime.invokeCommand if hasattr(self.step.runtime, 'invokeCommand') else\
+                                "%s -m WMCore.WMRuntime.ScriptInvoke %s" % (sys.executable, stepModule)
+            invokeCommand += " %s \n" % script
             logging.info("    Invoking command: %s" % invokeCommand)
             retCode = scram(invokeCommand)
             if retCode > 0:


### PR DESCRIPTION
This is something needed by the crab3-gwms testbed where we do not want to pass by the WMCore default script invoker (WMCore.WMRuntime.ScriptInvoke) to execute a pre script.
