### PR TITLE
fix cp stageout to always create 775 directories

### DIFF
--- a/src/python/WMCore/Storage/Backends/CPImpl.py
+++ b/src/python/WMCore/Storage/Backends/CPImpl.py
@@ -52,7 +52,7 @@ class CPImpl(StageOutImpl):
             pass
 
         if checkdirexitCode:
-            mkdircmd = "/bin/mkdir -m 775 -p %s" % targetdir
+            mkdircmd = "umask 002 ; /bin/mkdir -p %s" % targetdir
             print "=> creating the dir : %s" %mkdircmd
             try:
                 self.run(mkdircmd)


### PR DESCRIPTION
The cp stageout plugin creates all the needed new directories,
but if they are multiple levels deep, only the last one will
get the desired permission bits of 775. Fix that so that all
newly created directories have the same 775 permissions.
