### PR TITLE
Improve Scram runtime wrapper: allow to use an arbitrary file (even stdo...

### DIFF
--- a/src/python/WMCore/WMRuntime/Tools/Scram.py
+++ b/src/python/WMCore/WMRuntime/Tools/Scram.py
@@ -228,12 +228,13 @@ class Scram:
         executeIn = runtimeDir
         if runtimeDir == None:
             executeIn = self.projectArea
-        if not os.path.exists(logName):
+        #if the caller passed a filename and not a filehandle and if the logfile does not exist then create one
+        if isinstance(logName, basestring) and not os.path.exists(logName):
             f = open(logName, 'w')
             f.write('Log for recording SCRAM command-line output\n')
             f.write('-------------------------------------------\n')
             f.close()
-        logFile = open(logName, 'a')
+        logFile = open(logName, 'a') if isinstance(logName, basestring) else logName
         proc = subprocess.Popen(["env - /bin/bash"], shell=True, cwd=executeIn,
                                 stdout=logFile,
                                 stderr=logFile,
@@ -270,7 +271,9 @@ class Scram:
         self.stdout, self.stderr = proc.communicate()
         self.code = proc.returncode
         self.lastExecuted = command
-        logFile.close()
+        #close the logfile if one has been created from the name. Let the caller close it if he passed a file object.
+        if isinstance(logName, basestring):
+            logFile.close()
         return self.code
 
 


### PR DESCRIPTION
...ut)

The main motivation for doing this is that right now we are unable to get the output of the command we are invoking. The only way to get it with popen.communicate is tu use stdout=PIPE (which you could pass as logname argument)
