### PR TITLE
fix phedex injection for dbs3

### DIFF
--- a/src/python/WMComponent/PhEDExInjector/Database/MySQL/GetUninjectedFiles.py
+++ b/src/python/WMComponent/PhEDExInjector/Database/MySQL/GetUninjectedFiles.py
@@ -35,7 +35,8 @@ class GetUninjectedFiles(DBFormatter):
                INNER JOIN dbsbuffer_location ON
                  dbsbuffer_file_location.location = dbsbuffer_location.id
              WHERE dbsbuffer_file.in_phedex = 0 AND
-               (dbsbuffer_file.status = 'LOCAL' OR dbsbuffer_file.status = 'GLOBAL')"""
+               (dbsbuffer_file.status = 'LOCAL' OR dbsbuffer_file.status = 'GLOBAL' OR
+                dbsbuffer_file.status = 'InDBS')"""
 
     def format(self, result):
         """

--- a/src/python/WMComponent/PhEDExInjector/Database/MySQL/GetUnsubscribedBlocks.py
+++ b/src/python/WMComponent/PhEDExInjector/Database/MySQL/GetUnsubscribedBlocks.py
@@ -39,7 +39,7 @@ class GetUnsubscribedBlocks(DBFormatter):
                  dbsbuffer_file.workflow = dbsbuffer_workflow.id
                LEFT OUTER JOIN wmbs_workflow ON
                  wmbs_workflow.name = dbsbuffer_workflow.name
-             WHERE dbsbuffer_file.status = 'GLOBAL' AND
+             WHERE (dbsbuffer_file.status = 'GLOBAL' OR dbsbuffer_file.status = 'InDBS') AND
                    dbsbuffer_file.in_phedex = 1 AND
                    dbsbuffer_dataset.path != 'bogus' AND
                    wmbs_workflow.id is NULL AND

--- a/src/python/WMComponent/PhEDExInjector/Database/MySQL/GetUnsubscribedDatasets.py
+++ b/src/python/WMComponent/PhEDExInjector/Database/MySQL/GetUnsubscribedDatasets.py
@@ -29,7 +29,7 @@ class GetUnsubscribedDatasets(DBFormatter):
                INNER JOIN dbsbuffer_file ON
                  dbsbuffer_algo_dataset_assoc.id = dbsbuffer_file.dataset_algo
              WHERE dbsbuffer_dataset_subscription.subscribed = 0 AND
-                   dbsbuffer_file.status = 'GLOBAL' AND
+                   (dbsbuffer_file.status = 'GLOBAL' OR dbsbuffer_file.status = 'InDBS') AND
                    dbsbuffer_file.in_phedex = 1 AND
                    dbsbuffer_dataset.path != 'bogus'"""
 


### PR DESCRIPTION
This patch will fix the problem that PhEDEx injection won't happen when DBS3 alone mode is enabled.
It is tested on cmssrv94 but one thing still need to be tested is it still need to be working when DBS2 upload is running. 
@ericvaandering  please review. but please don't merge until DBS2 test is confirmed.
