### PR TITLE
add option for Tier0 specific LFNs

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -222,6 +222,9 @@ class PromptRecoWorkloadFactory(StdBase):
         # sets acquisitionEra, processingVersion, processingString
         workload.setTaskPropertiesFromWorkload()
 
+        # set the LFN bases (normally done by request manager)
+        workload.setLFNBase(self.mergedLFNBase, self.unmergedLFNBase)
+
         return workload
 
     def __call__(self, workloadName, arguments):

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -602,7 +602,7 @@ class WMWorkloadHelper(PersistencyHelper):
 
         return
 
-    def updateLFNsAndDatasets(self, initialTask = None):
+    def updateLFNsAndDatasets(self, initialTask = None, runNumber = None):
         """
         _updateLFNsAndDatasets_
 
@@ -650,6 +650,15 @@ class WMWorkloadHelper(PersistencyHelper):
                                                         getattr(outputModule, "primaryDataset"),
                                                         getattr(outputModule, "dataTier"),
                                                         processingString)
+
+                        if runNumber != None:
+                            runString = str(runNumber).zfill(9)
+                            lfnSuffix = "/%s/%s/%s" % (runString[0:3],
+                                                       runString[3:6],
+                                                       runString[6:9])
+                            unmergedLFN += lfnSuffix
+                            mergedLFN += lfnSuffix
+
                         lfnBase(unmergedLFN)
                         lfnBase(mergedLFN)
                         setattr(outputModule, "processedDataset", processedDataset)
@@ -672,7 +681,7 @@ class WMWorkloadHelper(PersistencyHelper):
                             setattr(outputModule, "mergedLFNBase", mergedLFN)
 
             task.setTaskLogBaseLFN(self.data.properties.unmergedLFNBase)
-            self.updateLFNsAndDatasets(task)
+            self.updateLFNsAndDatasets(task, runNumber = runNumber)
 
         return
 
@@ -863,7 +872,7 @@ class WMWorkloadHelper(PersistencyHelper):
         """
         return getattr(self.data.properties, 'campaign', None)
 
-    def setLFNBase(self, mergedLFNBase, unmergedLFNBase):
+    def setLFNBase(self, mergedLFNBase, unmergedLFNBase, runNumber = None):
         """
         _setLFNBase_
 
@@ -872,7 +881,7 @@ class WMWorkloadHelper(PersistencyHelper):
         """
         self.data.properties.mergedLFNBase = mergedLFNBase
         self.data.properties.unmergedLFNBase = unmergedLFNBase
-        self.updateLFNsAndDatasets()
+        self.updateLFNsAndDatasets(runNumber = runNumber)
         return
 
     def setMergeParameters(self, minSize, maxSize, maxEvents,


### PR DESCRIPTION
Tier0 LFNs end with three directory levels based on the run number. Also make an extra call in the PromptReco Spec to fix the lfns (as that call is normally done from the RequestManager and the Tier0 doesn't have that).

Other than the old Tier0, this change will mean that PromptReco LFNs will not have the three directory levels based on the run number. For now that's ok, will open a discussion if this should be changed.
