### PR TITLE
Get rid of --voms cms when doing myproxy-init

### DIFF
--- a/src/python/WMCore/Credential/Proxy.py
+++ b/src/python/WMCore/Credential/Proxy.py
@@ -296,7 +296,7 @@ class Proxy(Credential):
 
             if nokey is True:
                 credname = sha1(self.userDN).hexdigest()
-                myproxyDelegCmd = 'X509_USER_PROXY=%s ; myproxy-init -d -n -s %s -x -R \'%s\' -x -Z \'%s\' --voms cms -l \'%s\' -t 168:00 -c %s' \
+                myproxyDelegCmd = 'X509_USER_PROXY=%s ; myproxy-init -d -n -s %s -x -R \'%s\' -x -Z \'%s\' -l \'%s\' -t 168:00 -c %s' \
                                   % (credential, self.myproxyServer, self.serverDN, self.serverDN, credname, self.myproxyValidity)
             elif serverRenewer and len( self.serverDN.strip() ) > 0:
                 serverCredName = sha1(self.serverDN).hexdigest()


### PR DESCRIPTION
Bugfix request from Brian, the problem seems to be that VOMS will not extension renewal later in the chain if --voms cms is used for myproxy-init:

```
command : source /afs/cern.ch/cms/LCG/LCG-2/UI/cms_ui_env.sh && env X509_USER_PROXY=/data/certs/creds/fc479abdf4599c660226aa7e521e56922b971626 voms-proxy-init -noregen -voms cms:/cms/uscms/Role=cmsuser -out /data/certs/creds/fc479abdf4599c660226aa7e521e56922b971626 -bits 1024 -valid 167:59
 output : Your identity: /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Brian Bockelman/CN=proxy/CN=proxy/CN=proxy
Contacting  voms.cern.ch:15002 [/DC=ch/DC=cern/OU=computers/CN=voms.cern.ch] "cms" Done
Creating proxy  Done
Your proxy is valid until Wed Dec 11 04:22:52 2013

 error:
Warning: cms : your certificate already contains attributes, only a subset of them can be issued.
```
