### PR TITLE
fix promptreco lfn

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -223,7 +223,9 @@ class PromptRecoWorkloadFactory(StdBase):
         workload.setTaskPropertiesFromWorkload()
 
         # set the LFN bases (normally done by request manager)
-        workload.setLFNBase(self.mergedLFNBase, self.unmergedLFNBase)
+        # also pass runNumber (workload evaluates it)
+        workload.setLFNBase(self.mergedLFNBase, self.unmergedLFNBase,
+                            runNumber = self.runNumber)
 
         return workload
 

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -651,7 +651,7 @@ class WMWorkloadHelper(PersistencyHelper):
                                                         getattr(outputModule, "dataTier"),
                                                         processingString)
 
-                        if runNumber != None:
+                        if runNumber != None and runNumber > 0:
                             runString = str(runNumber).zfill(9)
                             lfnSuffix = "/%s/%s/%s" % (runString[0:3],
                                                        runString[3:6],


### PR DESCRIPTION
Change the PromptReco LFN conventions to use the 3 directory levels based on runnumber.
