### PR TITLE
Add CRAB2 lfns to Lexicon.py

### DIFF
--- a/src/python/WMCore/Lexicon.py
+++ b/src/python/WMCore/Lexicon.py
@@ -191,6 +191,7 @@ def lfn(candidate):
     regexp1 = '/([a-z]+)/([a-z0-9]+)/([a-zA-Z0-9\-_]+)/([a-zA-Z0-9\-_]+)/([A-Z\-_]+)/([a-zA-Z0-9\-_]+)((/[0-9]+){3}){0,1}/([0-9]+)/([a-zA-Z0-9\-_]+).root'
     regexp2 = '/([a-z]+)/([a-z0-9]+)/([a-z0-9]+)/([a-zA-Z0-9\-_]+)/([a-zA-Z0-9\-_]+)/([A-Z\-_]+)/([a-zA-Z0-9\-_]+)((/[0-9]+){3}){0,1}/([0-9]+)/([a-zA-Z0-9\-_]+).root'
     regexp3 = '/store/(temp/)*(user|group)/%(hnName)s/%(primDS)s/%(secondary)s/%(version)s/%(counter)s/%(root)s' % lfnParts
+    regexp4 = '/store/(temp/)*(user|group)/%(hnName)s/%(primDS)s/(%(subdir)s/)+%(root)s' % lfnParts
 
     oldStyleTier0LFN = '/store/data/%(era)s/%(primDS)s/%(tier)s/%(version)s/%(counter)s/%(counter)s/%(counter)s/%(root)s' % lfnParts
     tier0LFN = '/store/(backfill/[0-9]/){0,1}(t0temp/){0,1}(data|express|hidata)/%(era)s/%(primDS)s/%(tier)s/%(version)s/%(counter)s/%(counter)s/%(counter)s(/%(counter)s)?/%(root)s' % lfnParts
@@ -211,6 +212,11 @@ def lfn(candidate):
 
     try:
         return check(regexp3, candidate)
+    except AssertionError:
+        pass
+
+    try:
+        return check(regexp4, candidate)
     except AssertionError:
         pass
 

--- a/test/python/WMCore_t/Lexicon_t.py
+++ b/test/python/WMCore_t/Lexicon_t.py
@@ -324,6 +324,10 @@ class LexiconTest(unittest.TestCase):
         lfn(lfnA)
         lfnA = '/store/results/qcd/QCD_Pt80/StoreResults-Summer09-MC_31X_V3_7TeV-Jet30U-JetAODSkim-0a98be42532eba1f0545cc9b086ec3c3/QCD_Pt80/USER/StoreResults-Summer09-MC_31X_V3_7TeV-Jet30U-JetAODSkim-0a98be42532eba1f0545cc9b086ec3c3/0000/C44630AC-C0C7-DE11-AD4E-0019B9CAC0F8.root'
         lfn(lfnA)
+        lfnA = '/store/user/fanzago/RelValZMM/FanzagoTutGrid/f30a6bb13f516198b2814e83414acca1/outfile_10_2_tw4.root'
+        lfn(lfnA)
+        lfnA = '/store/group/higgs/SDMu9_Zmumu/Zmumu/OctX_HZZ3lepSkim_SDMu9/1eb161a436e69f7af28d18145e4ce909/3lepSkim_SDMu9_1.root'
+        lfn(lfnA)
 
         # All these cases should fail
         lfnA = '/storeA/temp/lustre/acquisition_10-A/MuElectron-10_100/RAW-RECO/vX-1/1000/a_X-2.root'
@@ -368,8 +372,6 @@ class LexiconTest(unittest.TestCase):
         lfnA = '/store/temp/acquisition_10-A/MuElectron-10_100/RAW-RECO/vX-1/1000/a_X;-2.root'
         self.assertRaises(AssertionError, lfn, lfnA)
 
-        lfnA = '/store/temp/user/ewv/Higgs-123/PrivateSample/USER/v1/a_X-2.root'
-        self.assertRaises(AssertionError, lfn, lfnA)
         lfnA = '/store/temp/user/ewv/Higgs;123/PrivateSample/v1/a_X-2.root'
         self.assertRaises(AssertionError, lfn, lfnA)
         lfnA = '/store/temp/user/ewv/Higgs-123/Private;Sample/v1/a_X-2.root'


### PR DESCRIPTION
Hi,

according to the email threads about this topic, I have now implemented Eric's suggestion for the CRAB 2 lfn regular expression. Hope that was the consensus?

``` python
regexp4 = '/store/(temp/)*(user|group)/%(hnName)s/%(primDS)s/(%(subdir)s/)+%(root)s' % lfnParts
```

@ericvaandering: Could you review and merge that pull request, please?

Thanks,
Manuel
