### PR TITLE
Update crab taskworker dependencies to include PhEDEx client API.

### DIFF
--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -129,7 +129,8 @@ dependencies = {'wmc-rest':{
                         },
                 'crabtaskworker':{
                         'packages':['WMCore..WorkQueue', 'WMCore.Credential', 'WMCore.Algorithms+', 'WMCore.WMSpec+',
-                                     'WMCore.JobSplitting', 'WMCore.Services.SiteDB+', 'WMCore.Services.DBS+', 'WMCore.Services.UserFileCache+'],
+                                    'WMCore.JobSplitting', 'WMCore.Services.SiteDB+', 'WMCore.Services.DBS+', 'WMCore.Services.UserFileCache+',
+                                    'WMCore.Services.PhEDEx+',],
                         'modules': ['WMCore.WMBS.File', 'WMCore.WMBS.WMBSBase', 'WMCore.WMBS.__init__'],
                         'systems': ['wmc-database'],
                         },


### PR DESCRIPTION
CRAB3's TaskWorker runtime needs to be able to invoke PhEDEx API calls to resolve LFNs into PFNs.
