### PR TITLE
don't install workloadsummary unless it is test mode

### DIFF
--- a/bin/wmagent-couchapp-init
+++ b/bin/wmagent-couchapp-init
@@ -10,6 +10,7 @@ import sys
 import urllib
 import optparse
 import shutil
+from urlparse import urlsplit
 
 from couchapp.commands import push as couchapppush
 from couchapp.config import Config
@@ -312,9 +313,6 @@ if __name__ == "__main__":
             setupCronCompaction(wmagentConfig.WorkQueueManager.couchurl, wmagentConfig.WorkQueueManager.dbname)
             setupCronCompaction(wmagentConfig.WorkQueueManager.couchurl, wmagentConfig.WorkQueueManager.inboxDatabase)
 
-    if hasattr(wmagentConfig, "WorkloadSummary"):
-        installCouchApp(wmagentConfig.WorkloadSummary.couchurl, wmagentConfig.WorkloadSummary.database, "WorkloadSummary")
-
     if hasattr(wmagentConfig, "AsyncTransfer"):
         basePath = "%s/couchapp" % os.environ['ASYNC_ROOT']
         baseWMCorePath = "%s/data/couchapps" % os.environ['ASYNC_ROOT']
@@ -346,6 +344,15 @@ if __name__ == "__main__":
         installCouchApp(wmagentConfig.reqmgr.couchUrl, wmagentConfig.reqmgr.wmstatDBName, "WMStats")
         if options.cron:
             setupCronCompaction(wmagentConfig.reqmgr.couchUrl, wmagentConfig.reqmgr.workloadDBName)
-
-
+        # this means test mode  in wmagent it won't depoly reqmgr with it in production
+        # set up  workload summary for test
+        if hasattr(wmagentConfig, "WorkloadSummary"):
+            installCouchApp(wmagentConfig.WorkloadSummary.couchurl, wmagentConfig.WorkloadSummary.database, "WorkloadSummary")
+    else:
+        # in case reqmgr is not set but still worklaad Summary need to be initialized (Tier0 test mode case)
+        # hacky way to check - assuming production url always use https protocal
+        if hasattr(wmagentConfig, "WorkloadSummary") and \
+           urlsplit(wmagentConfig.WorkloadSummary.couchurl).scheme == 'http':
+            installCouchApp(wmagentConfig.WorkloadSummary.couchurl, wmagentConfig.WorkloadSummary.database, "WorkloadSummary")
+    
     sys.exit(0)


### PR DESCRIPTION
Before workload summary is couch app is installed by agent in local machine.
But now workload summary is moved to production so we don't need to push apps when agent deployed.
However, when we run all in one test we still need to push workload summary in local. Test mode is defined when reqmgr config is set.
