### PR TITLE
fix dbs url used by PhEDEx

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -52,7 +52,7 @@ bossAirPlugins = ["CondorPlugin"]
 # DBS Information.
 localDBSUrl = "https://cmst0dbs.cern.ch:8443/cms_dbs_prod_tier0_writer/servlet/DBSServlet"
 localDBSVersion = "DBS_2_0_8"
-globalDBSUrl = "https://cmsdbsprod.cern.ch:8443/cms_dbs_prod_global_writer/servlet/DBSServlet"
+globalDBSUrl = "https://cmsweb.cern.ch/dbs/prod/global/DBSReader"
 globalDBSVersion = "DBS_2_0_8"
 
 # Job retry information.  This includes the number of times a job will tried and


### PR DESCRIPTION
This is temporary fix, the url should be coming from secrete file instead hard coded in config.
However, #4949 need to be done first. Issue is created #4969
