### PR TITLE
skip AFS cache dir in disk space check

### DIFF
--- a/src/python/WMComponent/AlertGenerator/Pollers/System.py
+++ b/src/python/WMComponent/AlertGenerator/Pollers/System.py
@@ -195,6 +195,8 @@ class DiskSpacePoller(BasePoller):
                 if len(arr) < 6: # 6 elements on the partition entry of df output
                     continue
                 percStr, mount = arr[4:6] # see the df output pattern
+                if mount == "/usr/vice/cache": # do not check AFS cache dir
+                    continue
                 perc = int(percStr[:-1]) # without the percent sign
                 for threshold, level in zip(self.thresholds, self.levels):
                     if perc >= threshold:


### PR DESCRIPTION
Get rid of the stupid annoying constant emails about the AFS cache dir being 'out of space". That mount point is automatically managed, it should never be checked.
