### PR TITLE
still run log collect and cleanup job when site is in drain state

### DIFF
--- a/src/python/WMCore/WMExceptions.py
+++ b/src/python/WMCore/WMExceptions.py
@@ -41,7 +41,7 @@ WMJobErrorCodes = {50660 :
                    "No sites are available to submit the job because the location of its input(s)"
                    "do not pass the site whitelist/blacklist restrictions",
                    61102 :
-                   "The job can only run at a site that is currently in Aborted state",
+                   "The job can only run at a site that is currently in Down/Aborted state",
                    61103 :
                    "The JobSubmitter component could not load the job pickle",
                    61104 :


### PR DESCRIPTION
This allow site dependent jobs to be submitted while a site is draining in order to avoid loss of information. I added a test also. fixes #4898 
