### PR TITLE
support dqm and alca harvesting on AI nodes without AFS

### DIFF
--- a/src/python/WMCore/JobSplitting/Harvest.py
+++ b/src/python/WMCore/JobSplitting/Harvest.py
@@ -94,10 +94,6 @@ class Harvest(JobFactory):
                             break
                     self.currentJob.addFile(f)
 
-                #Check for proxy and ship it in the job if available
-                if 'X509_USER_PROXY' in os.environ:
-                    self.currentJob['proxyPath'] = os.environ['X509_USER_PROXY']
-
                 if endOfRun:
                     self.currentJob.addBaggageParameter("runIsComplete", True)
 

--- a/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
@@ -264,4 +264,5 @@ class DQMUpload(Executor):
         data = result.read()
         if result.headers.get('Content-encoding', '') == 'gzip':
             data = GzipFile(fileobj=StringIO(data)).read ()
+
         return (result.headers, data)


### PR DESCRIPTION
DQM Harvesting in the Tier0 relied on passing a proxy via AFS. On CERN AI resources AFS is no longer available. Make sure using the proxy that comes from the glidein system is supported. Also remove uploading intermediate files from the Alca Harvesting to AFS, use EOS for that now.
