### PR TITLE
fix bug in dbs workflow completion query (crashes TaskArchiver)

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/MySQL/UpdateWorkflowsToCompleted.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/UpdateWorkflowsToCompleted.py
@@ -13,18 +13,19 @@ class UpdateWorkflowsToCompleted(DBFormatter):
     """
 
     sql = """UPDATE dbsbuffer_workflow
-             SET completed = 1 WHERE name = :name
-          """
+             SET completed = 1
+             WHERE name = :WORKFLOW
+             """
 
-    def execute(self, workflowNames, conn = None, transaction = False):
+    def execute(self, workflows, conn = None, transaction = False):
         """
         _execute_
 
         Run the query
         """
         binds = []
-        for name in workflowNames:
-            bind = {"name" : name}
+        for workflow in workflows:
+            binds.append( { "WORKFLOW" : workflow } )
 
         self.dbi.processData(self.sql, binds,
                              conn = conn, transaction = transaction)


### PR DESCRIPTION
Bug was in constructing the bind parameters, they were always left empty. Couldn't resist also making some other cosmetic changes :-)
