### PR TITLE
fix for DBSUploadPoller when the agent is completely empty

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/MySQL/GetCompletedWorkflows.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/GetCompletedWorkflows.py
@@ -18,5 +18,7 @@ class GetCompletedWorkflows(DBFormatter):
         """
         result = self.dbi.processData(self.sql, conn = conn,
                                           transaction = transaction)
-
-        return self.formatDict(result).values()
+        if self.formatDict(result):
+            return self.formatDict(result).values()
+        else:
+            return self.formatDict(result)


### PR DESCRIPTION
This PR fixes an issue with DBSUploadPoller in 0.9.94c, which was crashing this morning just after a fresh deployment and the reason for that was that blockCache is empty when the agent is just deployed. Just in case, this was the error in the logs [1]

@ticoann @lucacopa, please review it.

[1]
2014-03-19 03:40:24,812:ERROR:DBSUploadPoller:Unhandled Exception in DBSUploadPoller!
'list' object has no attribute 'values'Traceback (most recent call last):
  File "/data/srv/wmagent/v0.9.94c/sw/slc5_amd64_gcc461/cms/wmagent/0.9.94c/lib/python2.6/site-packages/WMComponent/DBS3Buffer/DBSUploadPoller.py", line 324, in algorithm
    self.checkCompleted()
  File "/data/srv/wmagent/v0.9.94c/sw/slc5_amd64_gcc461/cms/wmagent/0.9.94c/lib/python2.6/site-packages/WMComponent/DBS3Buffer/DBSUploadPoller.py", line 498, in checkCompleted
    completedWorkflows = self.dbsUtil.getCompletedWorkflows()
  File "/data/srv/wmagent/v0.9.94c/sw/slc5_amd64_gcc461/cms/wmagent/0.9.94c/lib/python2.6/site-packages/WMComponent/DBS3Buffer/DBSBufferUtil.py", line 447, in getCompletedWorkflows
    transaction=self.existingTransaction())
  File "/data/srv/wmagent/v0.9.94c/sw/slc5_amd64_gcc461/cms/wmagent/0.9.94c/lib/python2.6/site-packages/WMComponent/DBS3Buffer/MySQL/GetCompletedWorkflows.py", line 22, in execute
    return self.formatDict(result).values()
AttributeError: 'list' object has no attribute 'values'

2014-03-19 03:40:24,938:ERROR:BaseWorkerThread:Error in worker algorithm (1):
