### PR TITLE
Set FRONTIER_ID variable to the requestName

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
@@ -131,9 +131,7 @@ class CMSSW(Executor):
         # set any global environment variables
         #
         try:
-            os.environ['FRONTIER_ID'] = 'wmagent_%i_%s_%s_%s' % (self.job['id'], self.task.name(),
-                                                                 self.job['retry_count'],
-                                                                 cmsswVersion)
+            os.environ['FRONTIER_ID'] = 'wmagent_%s' % (self.report.data.workload)
         except Exception, ex:
             logging.error('Have critical error in setting FRONTIER_ID: %s' % str(ex))
             logging.error('Continuing, as this is not a critical function yet.')


### PR DESCRIPTION
There was a high load on FNAL frontier last week and their logging depends on what WMAgent is setting for the env variable FRONTIER_ID, it turns out it was not easy to map that information with workflows in WMStats.
These changes will now make the request name appear in frontier logs, also Dave D. confirmed there is no problem when the request name is quite long.
I tested this change in a testbed machine and the variable was properly set in the WN:

```
$ less _condor_stderr
INFO:root:Executing CMSSW step
INFO:root: FRONTIER_ID = wmagent_amaltaro_RVCMSSW_7_0_0_pre11QCD_Ht-100To250_TuneZ2star_8TeV_madgraph-tauola_140325_194339_1468
```
