### PR TITLE
Use PhEDEx to locate blocks/dataset instead of dbs

### DIFF
--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -14,6 +14,8 @@ from DBSAPI.dbsApiException import *
 from WMCore.Services.DBS.DBSErrors import DBSReaderError, formatEx
 from WMCore.Services.EmulatorSwitch import emulatorHook
 
+from WMCore.Services.PhEDEx.PhEDEx import PhEDEx
+
 def remapDBS3Keys(data, stringify = False, **others):
     """Fields have been renamed between DBS2 and 3, take fields from DBS3
     and map to DBS2 values
@@ -52,6 +54,9 @@ class DBS3Reader:
             msg = "Error in DBSReader with DbsApi\n"
             msg += "%s\n" % formatEx(ex)
             raise DBSReaderError(msg)
+        
+        # connection to PhEDEx (Use default endpoint url)
+        self.phedex = PhEDEx(responseType = "json") 
 
     def listPrimaryDatasets(self, match = '*'):
         """
@@ -500,7 +505,7 @@ class DBS3Reader:
         return [x['logical_file_name'] for x in files]
 
 
-    def listFileBlockLocation(self, fileBlockName):
+    def listFileBlockLocation(self, fileBlockName, dbsOnly = False):
         """
         _listFileBlockLocation_
 
@@ -508,17 +513,37 @@ class DBS3Reader:
 
         """
         self.checkBlockName(fileBlockName)
-        try:
-            blockInfo = self.dbs.listBlockOrigin(block_name = fileBlockName)
-        except DbsException, ex:
-            msg = "Error in DBSReader: dbsApi.listBlocks(block_name=%s)\n" % fileBlockName
-            msg += "%s\n" % formatEx(ex)
-            raise DBSReaderError(msg)
         
-        # TODO: How to look for different locations than origin site name
-        location = set()
-        location.update([blockInfo[0]['origin_site_name']])
+        if not dbsOnly:
+            try:
+                blockInfo = self.phedex.getReplicaSEForBlocks(block=[fileBlockName],complete='y')
+            except Exception, ex:
+                msg = "Error while getting block location from PhEDEx for block_name=%s)\n" % fileBlockName
+                msg += "%s\n" % str(ex)
+                raise Exception(msg)
+            
+            if not blockInfo: # if we couldnt get data location from PhEDEx, try to look into origin site location from dbs
+                dbsOnly = True
+            else:
+                location = set()
+                location.update(blockInfo[fileBlockName])
         
+        if dbsOnly:
+            try:
+                blockInfo = self.dbs.listBlockOrigin(block_name = fileBlockName)
+            except DbsException, ex:
+                msg = "Error in DBSReader: dbsApi.listBlocks(block_name=%s)\n" % fileBlockName
+                msg += "%s\n" % formatEx(ex)
+                raise DBSReaderError(msg)
+            
+            if not blockInfo: # no data location from dbs
+                return list()
+            
+            location = set()
+            location.update([blockInfo[0]['origin_site_name']])
+            
+            location.difference_update(['UNKNOWN']) # remove entry when SE name is 'UNKNOWN'
+             
         return list(location)
 
     def getFileBlock(self, fileBlockName):
@@ -650,7 +675,7 @@ class DBS3Reader:
         pathname = blocks[-1].get('dataset', None)
         return pathname
 
-    def listDatasetLocation(self, datasetName):
+    def listDatasetLocation(self, datasetName, dbsOnly = False):
         """
         _listDatasetLocation_
 
@@ -658,18 +683,39 @@ class DBS3Reader:
         dataset.
         """
         self.checkDatasetPath(datasetName)
-        try:
-            blocksInfo = self.dbs.listBlockOrigin(dataset = datasetName)
-        except DbsException, ex:
-            msg = "Error in DBSReader: dbsApi.listBlocks(dataset=%s)\n" % datasetName
-            msg += "%s\n" % formatEx(ex)
-            raise DBSReaderError(msg)
         
-        # TODO: How to look for different locations than origin site name        
-        locations = set()
-        for blockInfo in blocksInfo:
-            locations.update([blockInfo['origin_site_name']])
-
+        if not dbsOnly:
+            try:
+                blocksInfo = self.phedex.getReplicaSEForBlocks(dataset=[datasetName],complete='y')
+            except Exception, ex:
+                msg = "Error while getting block location from PhEDEx for dataset=%s)\n" % datasetName
+                msg += "%s\n" % str(ex)
+                raise Exception(msg)
+            
+            if not blocksInfo: # if we couldnt get data location from PhEDEx, try to look into origin site location from dbs
+                dbsOnly = True
+            else:
+                locations = set(blocksInfo.values()[0])
+                for blockSites in blocksInfo.values():
+                    locations.intersection_update(blockSites)
+        
+        if dbsOnly:
+            try:
+                blocksInfo = self.dbs.listBlockOrigin(dataset = datasetName)
+            except DbsException, ex:
+                msg = "Error in DBSReader: dbsApi.listBlocks(dataset=%s)\n" % datasetName
+                msg += "%s\n" % formatEx(ex)
+                raise DBSReaderError(msg)
+            
+            if not blocksInfo: # no data location from dbs
+                return list()
+            
+            locations = set()
+            for blockInfo in blocksInfo:
+                locations.update([blockInfo['origin_site_name']])
+            
+            locations.difference_update(['UNKNOWN']) # remove entry when SE name is 'UNKNOWN'
+        
         return list(locations)
 
     def checkDatasetPath(self, pathName):

--- a/src/python/WMCore/Services/PhEDEx/PhEDEx.py
+++ b/src/python/WMCore/Services/PhEDEx/PhEDEx.py
@@ -438,3 +438,47 @@ class PhEDEx(Service):
                             if fileInfo['lfn'] in blockFileDict[block]:
                                 injectedFiles.append(fileInfo['lfn'])
         return injectedFiles
+    
+    def getReplicaSEForBlocks(self, **kwargs):
+        """
+        _blockreplicasSE_
+
+        Get replicas SE for given blocks
+        kwargs are options passed through to phedex
+
+        dataset        dataset name, can be multiple (*)
+        block          block name, can be multiple (*)
+        node           node name, can be multiple (*)
+        se             storage element name, can be multiple (*)
+        update_since  unix timestamp, only return replicas updated since this
+                time
+        create_since   unix timestamp, only return replicas created since this
+                time
+        complete       y or n, whether or not to require complete or incomplete
+                blocks. Default is to return either
+        subscribed     y or n, filter for subscription. default is to return either.
+        custodial      y or n. filter for custodial responsibility.  default is
+                to return either.
+        group          group name.  default is to return replicas for any group.
+        
+        Returns a dictionary with se names per block
+        """
+
+        callname = 'blockreplicas'
+        response = self._getResult(callname, args = kwargs)
+        
+        blockSE = dict()
+        
+        blocksInfo = response['phedex']['block']
+        if not blocksInfo:
+            return {}
+        
+        for blockInfo in blocksInfo:
+            se = set()
+            for replica in blockInfo['replica']:
+                se.add(replica['se'])
+            blockSE[blockInfo['name']] = list(se)
+        
+        return blockSE
+            
+            

--- a/src/python/WMCore/WorkQueue/DataLocationMapper.py
+++ b/src/python/WMCore/WorkQueue/DataLocationMapper.py
@@ -141,9 +141,9 @@ class DataLocationMapper():
         for item in dataItems:
             try:
                 if datasetSearch:
-                    seNames = dbs.listDatasetLocation(item)
+                    seNames = dbs.listDatasetLocation(item, dbsOnly = True)
                 else:
-                    seNames = dbs.listFileBlockLocation(item)
+                    seNames = dbs.listFileBlockLocation(item, dbsOnly = True)
                 for se in seNames:
                     result[item].update(self.sitedb.seToCMSName(se))
             except Exception, ex:


### PR DESCRIPTION
Fixes #5033 
And overwrites #5034 (fix some typo and Exception handling)
Use DBS when dbsUrl is local
Handles case when origin site name se = 'UNKNOWN' #5012
