### PR TITLE
added --no-disk option for RC; removed duplicated SEs

### DIFF
--- a/bin/wmagent-resource-control
+++ b/bin/wmagent-resource-control
@@ -90,6 +90,8 @@ def createOptionParser():
                            const = 'Normal', help = "Normal operation for the site.")
     myOptParser.add_option("--emulator", dest = "emulator", default= False, action = "store_true",
                            help = "Use SiteDB emulator for unittests")
+    myOptParser.add_option("--no-disk", dest = "noDisk", default = False, action = "store_true",
+                           help = "Do not add T1s _Disk endpoint to resource control.")
 
     return myOptParser
 
@@ -111,6 +113,12 @@ def getCMSSiteInfo(pattern):
                 nameSEMapping[cmsName].append(seName)
             else:
                 nameSEMapping[cmsName] = [seName]
+
+    if options.noDisk:
+        nameSEMapping = dict((k, list(set(v))) for k, v in nameSEMapping.iteritems()
+                        if not k.endswith("_Disk"))
+    else:
+        nameSEMapping = dict((k, list(set(v))) for k, v in nameSEMapping.iteritems())
 
     return nameSEMapping
 


### PR DESCRIPTION
@ticoann
This patch provides/fixes two issues:
 a) it adds a new parameter to the wmagent-resource-control (--no-disk) which will drop the _Disk endpoint, so it's not going to be added into the RC database
 b) it also removes duplicated SEs in the same key (cmsName)

It was well tested this morning, while I was deploying a testbed agent.
