### PR TITLE
Do not add Disk endpoints by default, but provide a new option for it; r...

### DIFF
--- a/bin/wmagent-resource-control
+++ b/bin/wmagent-resource-control
@@ -90,6 +90,8 @@ def createOptionParser():
                            const = 'Normal', help = "Normal operation for the site.")
     myOptParser.add_option("--emulator", dest = "emulator", default= False, action = "store_true",
                            help = "Use SiteDB emulator for unittests")
+    myOptParser.add_option("--add-disk", dest = "addDisk", default = True, action = "store_false",
+                           help = "Use it to explicitly add the Disk endpoints together with the other T1s")
 
     return myOptParser
 
@@ -111,6 +113,12 @@ def getCMSSiteInfo(pattern):
                 nameSEMapping[cmsName].append(seName)
             else:
                 nameSEMapping[cmsName] = [seName]
+
+    if options.addDisk:
+        nameSEMapping = dict((k, list(set(v))) for k, v in nameSEMapping.iteritems()
+                        if not k.endswith("_Disk"))
+    else:
+        nameSEMapping = dict((k, list(set(v))) for k, v in nameSEMapping.iteritems())
 
     return nameSEMapping
 


### PR DESCRIPTION
...emoved duplicated SEs

as requested in #5075, the default now is NOT to add the Disk endpoints. It also remove the duplicate SE entries in the same key (cmsName). I tested it in my VM.
