### PR TITLE
support multiple PromptCalibprod

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -117,7 +117,7 @@ class StdBase(object):
             elif scenarioFunc == "alcaSkim":
                 for alcaSkim in scenarioArgs.get('skims',[]):
                     moduleLabel = "ALCARECOStream%s" % alcaSkim
-                    if alcaSkim == "PromptCalibProd":
+                    if alcaSkim.startswith("PromptCalibProd"):
                         dataTier = "ALCAPROMPT"
                     else:
                         dataTier = "ALCARECO"


### PR DESCRIPTION
With the proposed PCL on ExpressCosmics we need the ability to configure different PromptCalibProd\* producers for different stream.
