### PR TITLE
change StdBase to not assume that COUCHURL is in the environment

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -924,6 +924,6 @@ class StdBase(object):
             
             if arg == "CouchURL":
                 import os
-                schema[arg] = os.environ["COUCHURL"]
+                schema[arg] = os.environ.get('COUCHURL', None)
 
         return schema


### PR DESCRIPTION
The getTestArguments() methods assumes that COUCHURL is in the environment, if it's not it causes an Exception that crashes the component calling this method. Fix this to work if COUCHURL is not defined. Tier0 runs into this because we call the getTestArguments() method to initialize the parameter list.

Question though, aren't we supposed to do that, ie. should we always build the parameters list from scratch and getTestArguments() is reserved for unit tests ? Don't see why this should be the case...

The use of the COUCHURL environment variable is very recent, in a commit from last week.
