### PR TITLE
make some spec parameters optional

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -299,7 +299,7 @@ class PromptRecoWorkloadFactory(StdBase):
                                   "optional" : False, "validate" : couchurl,
                                   "attr" : "couchURL", "null" : False},
                     "CouchDBName" : {"default" : "promptreco_t", "type" : str,
-                                     "optional" : False, "validate" : identifier,
+                                     "optional" : True, "validate" : identifier,
                                      "attr" : "couchDBName", "null" : False},
                     "ConfigCacheUrl" : {"default" : None, "type" : str,
                                         "optional" : True, "validate" : couchurl,


### PR DESCRIPTION
Make the CouchDBName parameter optional in PromptReco spec.
