### PR TITLE
use new prep_id in UpdateDataset DAO

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/MySQL/UpdateDataset.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/UpdateDataset.py
@@ -22,19 +22,21 @@ class UpdateDataset(DBFormatter):
     sql = """UPDATE dbsbuffer_dataset
               SET processing_ver = :procVer, acquisition_era = :acqEra,
                   valid_status = :valid, global_tag = :globalTag,
-                  parent = :parent
+                  parent = :parent, prep_id = :prep_id
               WHERE id = :id
            """
     def execute(self, datasetId,
                 processingVer = None, acquisitionEra = None,
                 validStatus = None, globalTag = None,
-                parent = None, conn = None, transaction = False):
+                parent = None, prep_id = None,
+                conn = None, transaction = False):
 
         bindVars = {"procVer" : processingVer,
                     "acqEra" : acquisitionEra,
                     "valid" : validStatus,
                     "globalTag" : globalTag,
                     "parent" : parent,
+                    "prep_id" : prep_id,
                     "id" : datasetId}
         self.dbi.processData(self.sql, bindVars, conn = conn,
                              transaction = transaction)


### PR DESCRIPTION
Fixing a bug where the new prep_id parameter defined for a dataset is not used in the UpdataDataset DAO.
