### PR TITLE
New file to deal with summary db

### DIFF
--- a/bin/wmagent-couchapp-init
+++ b/bin/wmagent-couchapp-init
@@ -73,16 +73,19 @@ def installWorkQueueCouchApp(couchUrl, couchDBName):
     finally:
         shutil.rmtree(tempDir, ignore_errors = True)
 
-def createCronEntires(crontabLines):
+def createCronEntries(crontabLines):
     tempDir = tempfile.mkdtemp()
-    os.system("crontab -l > %s/crontab" % tempDir)
-    cronTab = open("%s/crontab" % tempDir, "a")
-    [cronTab.write(line) for line in crontabLines]
-    cronTab.close()
-    os.system("crontab %s/crontab" % tempDir)
-    os.remove("%s/crontab" % tempDir)
+    cname = '%s/crontab' % tempDir
+    os.system("crontab -l > %s" % cname)
+    entries = [l.replace('\n', '').strip() for l in open(cname, 'r').readlines()]
+    with open(cname, 'a') as astream:
+        for line in crontabLines:
+            line = line.strip()
+            if  line not in entries:
+                astream.write(line + '\n')
+    os.system("crontab %s" % cname)
+    os.remove(cname)
     os.rmdir(tempDir)
-
 
 def setupCron(couchUrl, couchDBName):
     """
@@ -107,28 +110,19 @@ def setupCron(couchUrl, couchDBName):
     compactCmd = "echo %s | sed -e 's|\\\\||g' | xargs curl -s -H 'Content-Type: application/json' -X POST > /dev/null"
 
     crontabLines = []
-    crontabLines.append("* * * * * %s\n" % (indexCmd % indexJobsUrl))
-    crontabLines.append("* * * * * %s\n" % (indexCmd % indexFwjrUrl))
-    crontabLines.append("0 0 * * * %s\n" % (compactCmd % compactViewUrl))
-    crontabLines.append("0 0 * * * %s\n" % (compactCmd % compactDBUrl))
-    createCronEntires(crontabLines)
+    crontabLines.append("* * * * * %s" % (indexCmd % indexJobsUrl))
+    crontabLines.append("* * * * * %s" % (indexCmd % indexFwjrUrl))
+    crontabLines.append("0 0 * * * %s" % (compactCmd % compactViewUrl))
+    crontabLines.append("0 0 * * * %s" % (compactCmd % compactDBUrl))
+    createCronEntries(crontabLines)
 
 
 def setupCronCompaction(couchUrl, couchDbName):
     """Add a simple couch compaction"""
     compactUrl = "%s/%s/_compact" % (couchUrl, couchDbName)
     compactCmd = "curl -s -H 'Content-Type: application/json' -X POST '%s' > /dev/null"
-
-    tempDir = tempfile.mkdtemp()
-    os.system("crontab -l > %s/crontab" % tempDir)
-    cronTab = open("%s/crontab" % tempDir, "a")
-    cronTab.write("0 1 * * * %s\n" % (compactCmd % compactUrl))
-    cronTab.close()
-
-    os.system("crontab %s/crontab" % tempDir)
-    os.remove("%s/crontab" % tempDir)
-    os.rmdir(tempDir)
-
+    cronLine = "0 1 * * * %s" % (compactCmd % compactUrl)
+    createCronEntries([cronLine])
 
 files_needed_from_yui = [
 'build/animation/animation-min.js',
@@ -296,6 +290,7 @@ if __name__ == "__main__":
         installCouchApp(wmagentConfig.JobStateMachine.couchurl, fwjrDumpName, "FWJRDump")
         installCouchApp(wmagentConfig.JobStateMachine.couchurl, jobDumpName, "JobDump")
         installCouchApp(wmagentConfig.JobStateMachine.couchurl, wmagentConfig.JobStateMachine.jobSummaryDBName, "WMStats")
+        installCouchApp(wmagentConfig.JobStateMachine.couchurl, wmagentConfig.JobStateMachine.summaryStatsDBName, "SummaryStats")
         if options.cron:
             setupCron(wmagentConfig.JobStateMachine.couchurl,
                       wmagentConfig.JobStateMachine.couchDBName)

--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -32,6 +32,7 @@ databaseSocket = "/opt/MySQL-5.1/var/lib/mysql/mysql.sock"
 couchURL = "http://USERNAME:PASSWORD@COUCHSERVER:5984"
 jobDumpDBName = "wmagent_jobdump"
 jobSummaryDBName = "wmagent_summary"
+summaryStatsDBName = "stat_summary"
 acdcDBName = "acdcserver"
 workqueueDBName = 'workqueue'
 workqueueInboxDbName = 'workqueue_inbox'
@@ -87,6 +88,7 @@ config.section_("JobStateMachine")
 config.JobStateMachine.couchurl = couchURL
 config.JobStateMachine.couchDBName = jobDumpDBName
 config.JobStateMachine.jobSummaryDBName = jobSummaryDBName
+config.JobStateMachine.summaryStatsDBName = summaryStatsDBName
 
 config.section_("ACDC")
 config.ACDC.couchurl = "https://cmsweb.cern.ch/couchdb"

--- a/src/couchapps/SummaryStats/_id
+++ b/src/couchapps/SummaryStats/_id
@@ -1,0 +1,1 @@
+_design/SummaryStats

--- a/src/couchapps/SummaryStats/couchapp.json
+++ b/src/couchapps/SummaryStats/couchapp.json
@@ -1,0 +1,4 @@
+{
+    "name": "SummaryStats",
+    "description": "JobSummary db for agenet for feeding the data to wmstats"
+}

--- a/src/couchapps/SummaryStats/language
+++ b/src/couchapps/SummaryStats/language
@@ -1,0 +1,1 @@
+javascript

--- a/src/couchapps/SummaryStats/updates/genericUpdate.js
+++ b/src/couchapps/SummaryStats/updates/genericUpdate.js
@@ -1,0 +1,23 @@
+function (doc, req) {
+	
+	// create doc if it is not exist. 
+    if (doc === null) {
+        // _id needs to be specified
+        var newDoc = JSON.parse(req.body);
+        if (newDoc._id) {
+            //TODO: add the validation
+        	doc = newDoc;
+        	return [doc, 'OK: inserted'];
+        } else{
+        	return [null, "Error: _id need to be specified " + newDoc];
+        };   
+    } else {
+        var fields = JSON.parse(req.body); 
+    	for (var key in fields) {
+    		if (key !== "_id") {
+	        	doc[key] = fields[key];
+	       	}
+	    }
+	    return [doc, 'OK: updated'];
+    };  
+}; 

--- a/src/python/WMComponent/AnalyticsDataCollector/AnalyticsPoller.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/AnalyticsPoller.py
@@ -44,7 +44,9 @@ class AnalyticsPoller(BaseWorkerThread):
         self.localQueue = WorkQueueService(self.config.AnalyticsDataCollector.localQueueURL)
 
         # set the connection for local couchDB call
-        self.localCouchDB = LocalCouchDBData(self.config.AnalyticsDataCollector.localCouchURL, self.summaryLevel)
+        self.localCouchDB = LocalCouchDBData(self.config.AnalyticsDataCollector.localCouchURL, 
+                                             self.config.JobStateMachine.summaryStatsDBName,
+                                             self.summaryLevel)
 
         # interface to WMBS/BossAir db
         myThread = threading.currentThread()
@@ -73,8 +75,10 @@ class AnalyticsPoller(BaseWorkerThread):
             #fwjr per request info
             logging.info("Getting FWJRJob Couch Data ...")
 
-            #fwjrInfoFromCouch = self.localCouchDB.getEventSummaryByWorkflow()
-            fwjrInfoFromCouch = self.localCouchDB.getJobPerformanceByTaskAndSite()
+            #TODO: commented out for now if summary db works correctly, remove completed.
+            #fwjrInfoFromCouch = self.localCouchDB.getJobPerformanceByTaskAndSite()
+            
+            fwjrInfoFromCouch = self.localCouchDB.getJobPerformanceByTaskAndSiteFromSummaryDB()
             
             logging.info("Getting Batch Job Data ...")
             batchJobInfo = self.wmagentDB.getBatchJobInfo()

--- a/src/python/WMComponent/AnalyticsDataCollector/DataCollectAPI.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/DataCollectAPI.py
@@ -22,12 +22,14 @@ from WMComponent.AnalyticsDataCollector.DataCollectorEmulatorSwitch import emula
 @emulatorHook
 class LocalCouchDBData():
 
-    def __init__(self, couchURL, summaryLevel):
+    def __init__(self, couchURL, statSummaryDB, summaryLevel):
         # set the connection for local couchDB call
         self.couchURL = couchURL
         self.couchURLBase, self.dbName = splitCouchServiceURL(couchURL)
         self.jobCouchDB = CouchServer(self.couchURLBase).connectDatabase(self.dbName + "/jobs", False)
         self.fwjrsCouchDB = CouchServer(self.couchURLBase).connectDatabase(self.dbName + "/fwjrs", False)
+        #TODO: remove the hard coded name (wma_summarydb)
+        self.summaryStatsDB = CouchServer(self.couchURLBase).connectDatabase(statSummaryDB, False)
         self.summaryLevel = summaryLevel
 
     def getJobSummaryByWorkflowAndSite(self):
@@ -152,6 +154,16 @@ class LocalCouchDBData():
                 
         return data
     
+    def getJobPerformanceByTaskAndSiteFromSummaryDB(self):
+        
+        options = {"include_docs": True}
+        results = self.summaryStatsDB.allDocs(options)
+        data = {}
+        for row in results['rows']:
+            if not row['id'].startswith("_"):
+                data[row['id']] = {}
+                data[row['id']]['tasks'] = row['doc']['tasks']
+        return data
     
     def getEventSummaryByWorkflow(self):
         """

--- a/src/python/WMCore/Database/CMSCouch.py
+++ b/src/python/WMCore/Database/CMSCouch.py
@@ -311,7 +311,6 @@ class Database(CouchDBRequests):
         else:
             updateUri = '/%s/_design/%s/_update/%s/%s' % \
                 (self.name, design, update_func, doc_id)
-    
             return self.put(uri=updateUri, data=fields, decode=False)
 
     def documentExists(self, id, rev = None):
@@ -333,7 +332,7 @@ class Database(CouchDBRequests):
         """
         doc = self.document(id, rev)
         doc.delete()
-        self.commitOne(doc)
+        return self.commitOne(doc)
 
     def compact(self, views=[], blocking=False, blocking_poll=5, callback=False):
         """
@@ -866,6 +865,10 @@ class CouchServer(CouchDBRequests):
                 check_name(destination)
             else:
                 check_server_url(destination)
+        if not destination.startswith("http"):
+            destination = '%s/%s' % (self.url, destination)
+        if not source.startswith("http"):
+            source = '%s/%s' % (self.url, source)
         data={"source":source,"target":destination}
         #There must be a nicer way to do this, but I've not had coffee yet...
         if continuous: data["continuous"] = continuous

--- a/src/python/WMCore/JobStateMachine/SummaryDB.py
+++ b/src/python/WMCore/JobStateMachine/SummaryDB.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+#pylint: disable=
+"""
+File       : SummaryDB.py
+Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
+Description: Set of modules/functions to update WMAgent SummaryDB.
+"""
+
+# system modules
+import logging
+from pprint import pformat
+from WMCore.Database.CMSCouch import CouchNotFoundError
+
+def fwjr_parser(doc):
+    """
+    Parse FWJR document and yeild the following structure:
+    {"id": "requestName",
+        "tasks": {
+            "taskName1": {
+                "sites": {
+                    "siteName1":  {
+                        "wrappedTotalJobTime": 1612,
+                        "cmsRunCPUPerformance": 
+                           {"totalJobCPU": 20, "totalJobTime": 42, "totalEventCPU": 4},
+                        "inputEvents": 0,
+                        "dataset": {}
+                    }
+                    "siteName2":  {
+                        "wrappedTotalJobTime": 1612,
+                        "cmsRunCPUPerformance": {"totalJobCPU": 20, "totalJobTime": 42, "totalEventCPU": 4},
+                        "inputEvents": 0,
+                        "dataset": {
+                             "/a/b/c": {"size": 50, "events": 10, "totalLumis": 100},
+                             "/a1/b1/c1": {"size": 50, "events": 10, "totalLumis": 100}
+                        },
+                    }
+                },
+            }
+            "taskName2" : {}
+        }
+    }
+    """
+    # flag for the data collection, in some case fwjr doesn't contains the data needed
+    # In that case it shouldn't crash but move on.
+    dataCollectedFlag = False
+
+    if  'fwjr' in doc:
+        fwjr = doc['fwjr']
+        if  not isinstance(fwjr, dict):
+            fwjr = fwjr.__to_json__(None)
+    else:
+        raise Exception('Document does not contain FWJR part')
+    
+    if not fwjr.has_key('task'):
+        return dataCollectedFlag
+    
+    task_name = fwjr['task']
+    try:
+        req_name = task_name.split('/')[1]
+    except:
+        raise Exception('Cannot get request name from task_name "%s"' % task_name)
+    
+    # if one of the step has error except logArchive step don't collect the data 
+    for stepName in fwjr['steps']:
+        if not stepName.startswith('logArch') and fwjr['steps'][stepName]['status'] != 0:
+            return dataCollectedFlag
+
+    sdict = {} # all sites summary
+    steps = fwjr['steps']
+    wrappedTotalJobTime = 0
+    pdict = dict(totalJobCPU=0, totalJobTime=0, totalEventCPU=0)
+    ddict = {}
+    for key, val in steps.items():
+        wrappedTotalJobTime += val['stop'] - val['start']
+        site_name = val['site']
+        site_summary = dict(wrappedTotalJobTime=wrappedTotalJobTime,
+                            inputEvents=0, dataset=ddict,
+                            cmsRunCPUPerformance=pdict)
+        if  key.startswith('cmsRun'):
+            perf = val['performance']
+            pdict['totalJobCPU'] += float(perf['cpu']['TotalJobCPU'])
+            pdict['totalJobTime'] += float(perf['cpu']['TotalJobTime'])
+            pdict['totalEventCPU'] += float(perf['cpu']['TotalEventCPU'])
+            
+            odict = val['output']
+            for kkk, vvv in odict.items():
+                for row in vvv:
+                    if  row.get('merged', False):
+                        prim = row['dataset']['primaryDataset']
+                        proc = row['dataset']['primaryDataset']
+                        tier = row['dataset']['primaryDataset']
+                        dataset = '/'.join([prim, proc, tier])
+                        totalLumis = sum([len(r) for r in row['runs'].values()])
+                        dataset_summary = \
+                                dict(size=row['size'], events=row['events'], totalLumis=totalLumis)
+                        ddict[dataset] = dataset_summary
+            if  ddict: # if we got dataset summary
+                site_summary.update({'dataset': ddict})
+
+            idict = val.get('input', {})
+            if  idict:
+                source = idict.get('source', {})
+                if  isinstance(source, list):
+                    for item in source:
+                        site_summary['inputEvents'] += item.get('events', 0)
+                else:
+                    site_summary['inputEvents'] += source.get('events', 0)
+        sdict[site_name] = site_summary
+        dataCollectedFlag = True
+    
+    if dataCollectedFlag:
+        # prepare final data structure
+        sum_doc = dict(_id=req_name, tasks={task_name: dict(sites=sdict)})
+        return sum_doc
+    else:
+        return dataCollectedFlag
+
+def merge_docs(doc1, doc2):
+    "Merge two summary documents use dict in place strategy"
+    for key in ['_id', '_rev']:
+        if  key in doc1:
+            del doc1[key]
+        if  key in doc2:
+            del doc2[key]
+    for key, val in doc1.items():
+        if  key not in doc2:
+            return False
+        if isinstance(val, dict):
+            if  not merge_docs(doc1[key], doc2[key]):
+                return False
+        else:
+            doc1[key] += doc2[key]
+    return True
+
+def update_tasks(old_tasks, new_tasks):
+    "Update tasks dictionaries"
+    for task, tval in new_tasks.items():
+        if  task in old_tasks:
+            for site, sval in tval['sites'].items():
+                if  site in old_tasks[task]['sites']:
+                    old_sdict = old_tasks[task]['sites'][site]
+                    new_sdict = sval
+                    status = merge_docs(old_sdict, new_sdict)
+                    if  not status:
+                        logging.error("Error merge_docs:\n%s\n%s\n" % (pformat(old_sdict),
+                                                                     pformat(new_sdict)))
+                else:
+                    old_tasks[task]['sites'].update({site:sval})
+        else:
+            old_tasks.update({task: tval})
+    return old_tasks
+
+def updateSummaryDB(sumdb, document):
+    "Update summary DB with given document"
+    # parse input doc and create summary doc
+    sum_doc = fwjr_parser(document)
+    # check if DB has FWJR statistics
+    if sum_doc == False: 
+        return False
+    
+    try:
+        doc = sumdb.document(sum_doc['_id'])
+        old_tasks = doc['tasks']
+    except CouchNotFoundError:
+        old_tasks = {}
+    
+    tasks = update_tasks(old_tasks, sum_doc['tasks'])
+        
+    try:
+        combinedDoc = {'_id': sum_doc['_id'], 'tasks': tasks}
+        resp = sumdb.updateDocument(sum_doc['_id'], "SummaryStats", 
+                                    "genericUpdate", 
+                                    fields = combinedDoc,
+                                    useBody = True)
+        #TODO: check response whether update successfull or not
+        return True
+    except Exception, ex:
+        import traceback
+        logging.error("Error fetching summary doc %s: %s" % (
+                                    sum_doc['_id'], traceback.format_exc()))
+        return False

--- a/src/python/WMQuality/Emulators/EmulatorSetup.py
+++ b/src/python/WMQuality/Emulators/EmulatorSetup.py
@@ -28,6 +28,7 @@ def _wmAgentConfig(configFile):
     config.JobStateMachine.couchurl = os.getenv("COUCHURL")
     config.JobStateMachine.couchDBName = os.getenv("COUCHDB")
     config.JobStateMachine.jobSummaryDBName = "wmagent_summary_test"
+    config.JobStateMachine.summaryStatsDBName = "stat_summary_test"
     
     config.section_("Agent")
     # User specific parameter

--- a/src/python/WMQuality/TestInit.py
+++ b/src/python/WMQuality/TestInit.py
@@ -275,7 +275,9 @@ class TestInit:
         
         config.component_("JobStateMachine")
         config.JobStateMachine.couchurl = couchurl
+        config.JobStateMachine.couchDBName = "wmagent_job_test"
         config.JobStateMachine.jobSummaryDBName = "job_summary"
+        config.JobStateMachine.summaryStatsDBName = "stat_summary_test"
         
         config.component_("JobAccountant")
         config.JobAccountant.pollInterval = 60

--- a/test/python/WMCore_t/JobStateMachine_t/ChangeState_t.py
+++ b/test/python/WMCore_t/JobStateMachine_t/ChangeState_t.py
@@ -60,6 +60,7 @@ class TestChangeState(unittest.TestCase):
         couchurl = os.getenv("COUCHURL")
         self.couchServer = CouchServer(dburl = couchurl)
         self.config = self.testInit.getConfiguration()
+        self.taskName = "/TestWorkflow/Task"
         return
 
     def tearDown(self):
@@ -102,7 +103,7 @@ class TestChangeState(unittest.TestCase):
         locationAction.execute("site1", seName = "somese.cern.ch")
 
         testWorkflow = Workflow(spec = "spec.xml", owner = "Steve",
-                                name = "wf001", task = "Test")
+                                name = "wf001", task = self.taskName)
         testWorkflow.create()
         testFileset = Fileset(name = "TestFileset")
         testFileset.create()
@@ -240,7 +241,7 @@ class TestChangeState(unittest.TestCase):
         locationAction.execute("site1", seName = "somese.cern.ch")
 
         testWorkflow = Workflow(spec = "spec.xml", owner = "Steve",
-                                name = "wf001", task = "Test")
+                                name = "wf001", task = self.taskName)
         testWorkflow.create()
         testFileset = Fileset(name = "TestFileset")
         testFileset.create()
@@ -285,7 +286,7 @@ class TestChangeState(unittest.TestCase):
         locationAction.execute("site1", seName = "somese.cern.ch")
 
         testWorkflow = Workflow(spec = "spec.xml", owner = "Steve",
-                                name = "wf001", task = "Test")
+                                name = "wf001", task = self.taskName)
         testWorkflow.create()
         testFileset = Fileset(name = "TestFileset")
         testFileset.create()
@@ -355,7 +356,7 @@ class TestChangeState(unittest.TestCase):
         locationAction.execute("site1", seName = "somese.cern.ch")
 
         testWorkflow = Workflow(spec = "spec.xml", owner = "Steve",
-                                name = "wf001", task = "Test")
+                                name = "wf001", task = self.taskName)
         testWorkflow.create()
         testFileset = Fileset(name = "TestFileset")
         testFileset.create()
@@ -428,7 +429,7 @@ class TestChangeState(unittest.TestCase):
         locationAction.execute("site1", seName = "somese.cern.ch")
 
         testWorkflow = Workflow(spec = "spec.xml", owner = "Steve",
-                                name = "wf001", task = "Test")
+                                name = "wf001", task = self.taskName)
         testWorkflow.create()
         testFileset = Fileset(name = "TestFileset")
         testFileset.create()
@@ -508,7 +509,7 @@ class TestChangeState(unittest.TestCase):
         locationAction.execute("site1", seName = "somese.cern.ch")
 
         testWorkflow = Workflow(spec = "spec.xml", owner = "Steve",
-                                name = "wf001", task = "Test")
+                                name = "wf001", task = self.taskName)
         testWorkflow.create()
         testFileset = Fileset(name = "TestFileset")
         testFileset.create()
@@ -571,7 +572,7 @@ class TestChangeState(unittest.TestCase):
         locationAction.execute("site1", seName = "somese.cern.ch")
 
         testWorkflow = Workflow(spec = "spec.xml", owner = "Steve",
-                                name = "wf001", task = "Test")
+                                name = "wf001", task = self.taskName)
         testWorkflow.create()
         testFileset = Fileset(name = "TestFileset")
         testFileset.create()
@@ -645,7 +646,7 @@ class TestChangeState(unittest.TestCase):
         locationAction.execute("site1", seName = "somese.cern.ch")
 
         testWorkflow = Workflow(spec = "spec.xml", owner = "Steve",
-                                name = "wf001", task = "Test")
+                                name = "wf001", task = self.taskName)
         testWorkflow.create()
         testFileset = Fileset(name = "TestFileset")
         testFileset.create()
@@ -719,7 +720,7 @@ class TestChangeState(unittest.TestCase):
         locationAction.execute("site1", seName = "somese.cern.ch")
 
         testWorkflow = Workflow(spec = "spec.xml", owner = "Steve",
-                                name = "wf001", task = "Test")
+                                name = "wf001", task = self.taskName)
         testWorkflow.create()
         testFileset = Fileset(name = "TestFileset")
         testFileset.create()
@@ -756,9 +757,9 @@ class TestChangeState(unittest.TestCase):
         testJobA["fwjr"] = myReport
         change.propagate([testJobA], 'jobfailed', 'executing')
 
-        changeStateDB = self.couchServer.connectDatabase(dbname = "job_summary")
+        changeStateDB = self.couchServer.connectDatabase(dbname = self.config.JobStateMachine.jobSummaryDBName)
         allDocs = changeStateDB.document("_all_docs")
-
+        
         self.assertEqual(len(allDocs["rows"]), 2,
                          "Error: Wrong number of documents")
 
@@ -791,7 +792,7 @@ class TestChangeState(unittest.TestCase):
         locationAction.execute("site1", seName = "somese.cern.ch")
 
         testWorkflow = Workflow(spec = "spec.xml", owner = "Steve",
-                                name = "wf001", task = "Test")
+                                name = "wf001", task = self.taskName)
         testWorkflow.create()
         testFileset = Fileset(name = "TestFileset")
         testFileset.create()
@@ -831,7 +832,7 @@ class TestChangeState(unittest.TestCase):
         jobDoc = jobdatabase.document("1")
         fwjrDoc = fwjrdatabase.document("1-0")
         self.assertEqual(jobDoc["workflow"], "wf001", "Wrong workflow in couch job document")
-        self.assertEqual(fwjrDoc["fwjr"]["task"], "Test", "Wrong task in fwjr couch document")
+        self.assertEqual(fwjrDoc["fwjr"]["task"], self.taskName, "Wrong task in fwjr couch document")
 
         testJobA.delete()
 
@@ -839,7 +840,7 @@ class TestChangeState(unittest.TestCase):
         myThread.dbi.processData("ALTER TABLE wmbs_job AUTO_INCREMENT = 1")
 
         testWorkflow = Workflow(spec = "spec.xml", owner = "Steve",
-                                name = "wf002", task = "Test2")
+                                name = "wf002", task = "/TestWorkflow/Test2")
         testWorkflow.create()
         testFileset = Fileset(name = "TestFilesetB")
         testFileset.create()
@@ -868,7 +869,7 @@ class TestChangeState(unittest.TestCase):
         jobDoc = jobdatabase.document("1")
         fwjrDoc = fwjrdatabase.document("1-0")
         self.assertEqual(jobDoc["workflow"], "wf002", "Job document was not overwritten")
-        self.assertEqual(fwjrDoc["fwjr"]["task"], "Test2", "FWJR document was not overwritten")
+        self.assertEqual(fwjrDoc["fwjr"]["task"], "/TestWorkflow/Test2", "FWJR document was not overwritten")
 
         return
 
@@ -886,7 +887,7 @@ class TestChangeState(unittest.TestCase):
         locationAction.execute("site2", seName = "somese2.cern.ch")
 
         testWorkflow = Workflow(spec = "spec.xml", owner = "Steve",
-                                name = "wf001", task = "Test")
+                                name = "wf001", task = self.taskName)
         testWorkflow.create()
         testFileset = Fileset(name = "TestFileset")
         testFileset.create()

--- a/test/python/WMCore_t/JobStateMachine_t/Couchapp_t.py
+++ b/test/python/WMCore_t/JobStateMachine_t/Couchapp_t.py
@@ -41,19 +41,21 @@ class CouchappTest(unittest.TestCase):
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
         self.databaseName = "couchapp_t_0"
-        self.testInit.setupCouch(self.databaseName, "WorkloadSummary")
-        self.testInit.setupCouch("%s/jobs" % self.databaseName, "JobDump")
-        self.testInit.setupCouch("%s/fwjrs" % self.databaseName, "FWJRDump")
+        
 
         # Setup config for couch connections
         config = self.testInit.getConfiguration()
-        config.section_("JobStateMachine")
-        config.JobStateMachine.couchDBName  = self.databaseName
-
+        
+        self.testInit.setupCouch(self.databaseName, "WorkloadSummary")
+        self.testInit.setupCouch("%s/jobs" % config.JobStateMachine.couchDBName, "JobDump")
+        self.testInit.setupCouch("%s/fwjrs" % config.JobStateMachine.couchDBName, "FWJRDump")
+        self.testInit.setupCouch(config.JobStateMachine.summaryStatsDBName, "SummaryStats")
+                                 
         # Create couch server and connect to databases
         self.couchdb      = CouchServer(config.JobStateMachine.couchurl)
         self.jobsdatabase = self.couchdb.connectDatabase("%s/jobs" % config.JobStateMachine.couchDBName)
         self.fwjrdatabase = self.couchdb.connectDatabase("%s/fwjrs" % config.JobStateMachine.couchDBName)
+        self.statsumdatabase = self.couchdb.connectDatabase(config.JobStateMachine.summaryStatsDBName)
 
         # Create changeState
         self.changeState = ChangeState(config)
@@ -67,6 +69,7 @@ class CouchappTest(unittest.TestCase):
     def tearDown(self):
 
         self.testInit.clearDatabase(modules = ["WMCore.WMBS"])
+        self.testInit.tearDownCouch()
         self.testInit.delWorkDir()
         #self.testInit.tearDownCouch()
         return


### PR DESCRIPTION
fixes #5099 (from Valentin)
Add updateSummaryDB int job state machine

Add wma_summarydb; fix issue with creating multiple crontab entries each time we initialize agent

Use full URL names for source/destination when setup replication

Add SummaryStats app

Replace key_id with request name (as Seangchan suggested); removed md5hash

Be generic and pass job document into summary

Protect code from unfilled attributes
