### PR TITLE
FNAL staging: fix mkdir for local staging

### DIFF
--- a/src/python/WMCore/Storage/Backends/FNALImpl.py
+++ b/src/python/WMCore/Storage/Backends/FNALImpl.py
@@ -17,6 +17,8 @@ _CheckExitCodeOption = True
 
 
 def stripPrefixTOUNIX(filePath):
+    if ".fnal.gov/" not in filePath:
+        return filePath
     return filePath.split(".fnal.gov/", 1)[1]
 
 class FNALImpl(StageOutImpl):
@@ -62,8 +64,10 @@ class FNALImpl(StageOutImpl):
         if method == 'srm':
             self.srmImpl.createOutputDirectory(targetPFN)
         else:
-            pfnSplit = stripPrefixTOUNIX(targetPFN)
-            targetdir= os.path.dirname(pfnSplit)
+            if method != 'local':
+                targetPFN = stripPrefixTOUNIX(targetPFN)
+
+            targetdir= os.path.dirname(targetPFN)
             command = "#!/bin/sh\n"
             command += "if [ ! -e \"%s\" ]; then\n" % targetdir
             command += " mkdir -p %s\n" % targetdir

--- a/src/python/WMCore/Storage/StageInMgr.py
+++ b/src/python/WMCore/Storage/StageInMgr.py
@@ -178,7 +178,7 @@ class StageInMgr:
                     msg = "===> Local Stage Out Failure for file:\n"
                     msg += "======>  %s\n" % fileToStage['LFN']
                     msg += str(ex)
-
+                    print msg
             #  //
             # // Still here => override start using the fallback stage outs
             #//  If override is set, then that will be the only fallback available


### PR DESCRIPTION
We only try to strip the method://foo.fnal.gov/ prefix for non-local
PFNs. (We also return the right thing if the prefix method gets called.)

Also, add additional printing for stage out failures.
