### PR TITLE
Add sites to input dataset when trustSiteList is enabled

### DIFF
--- a/src/python/WMCore/WorkQueue/Policy/Start/Dataset.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Dataset.py
@@ -90,6 +90,7 @@ class Dataset(StartPolicyInterface):
         blockBlackList = task.inputBlockBlacklist()
         runWhiteList = task.inputRunWhitelist()
         runBlackList = task.inputRunBlacklist()
+        siteWhiteList = task.siteWhitelist()
 
         for blockName in dbs.listFileBlocks(datasetPath):
             block = dbs.getDBSSummaryInfo(datasetPath, block = blockName)
@@ -163,6 +164,9 @@ class Dataset(StartPolicyInterface):
                 locations = set(sitesFromStorageEelements(dbs.listFileBlockLocation(block['block'])))
             else:
                 locations = locations.intersection(set(sitesFromStorageEelements(dbs.listFileBlockLocation(block['block']))))
+            
+            if self.wmspec.locationDataSourceFlag():
+                locations = locations.union(siteWhiteList)
 
         # all needed blocks present at these sites
         if locations:


### PR DESCRIPTION
This adds the site whitelist locations to the input dataset locations when a WorkQueueElement is created at the GWQ level, when xrootd is enabled (trustSiteList=True). Otherwise WorkQueueElement is not pulled to wmagent. I realized of this working with data stored at cmseos.fnal.gov (T3_US_FNALLPC), even if I enable xrootd and set T1_US_FNAL in the site whitelist, the agent never pull work.
