### PR TITLE
add role and group so agent can update the status

### DIFF
--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
@@ -208,13 +208,13 @@ def ownsRequest(request):
     return cherrypy.request.user['login'] == request['Requestor']
 
 def security_roles():
-    return ['Developer', 'Admin',  'Data Manager', 'developer', 'admin', 'data-manager']
+    return ['developer', 'admin', 'data-manager', 'production-operator']
 
 def security_groups():
     """
     A list of groups which have security access
     """
-    return ['ReqMgr', 'reqmgr']
+    return ['reqmgr', "dataops"]
 
 def privileged():
     """ whether this user has roles that overlap with security_roles """


### PR DESCRIPTION
From  the bug below. It seem it is not allowed that agent change request status in reqmgr.

2014-06-09 19:30:26,851:WARNING:Service:The cachefile /data/srv/wmagent/v0.9.91/install/wmagent/TaskArchiver/.wmcore_cache/.wmcore_cache_31961/requests/cmsweb.cern.ch/7106221298909341352_PUT_request does not exist and the service at https://cmsweb.cern.ch/reqmgr/rest/request is unavailable - it returned 403 because Forbidden
 with result: {"exception": 403, "message": "Failed to change status: Cannot change status from normal-archived to normal-archived.  Allowed values are []", "type": “HTTPError"
