### PR TITLE
Handle lumi sections split across multiple input files

### DIFF
--- a/src/python/WMCore/DataStructs/Mask.py
+++ b/src/python/WMCore/DataStructs/Mask.py
@@ -150,6 +150,17 @@ class Mask(dict):
 
         return
 
+    def removeLumiList(self, lumiList):
+        """
+        Remove a lumi list from this data structure
+
+        This requires conversion to LumiList to do the lumi algebra an
+        may be computationally expensive for a large number of lumis.
+        """
+        myLumis = LumiList(compactList=self['runAndLumis'])
+        myLumis = myLumis - lumiList
+        self['runAndLumis'] = myLumis.getCompactList()
+
     def getRunAndLumis(self):
         """
         _getRunAndLumis_

--- a/src/python/WMCore/DataStructs/Mask.py
+++ b/src/python/WMCore/DataStructs/Mask.py
@@ -13,6 +13,7 @@ job in two ways:
 import logging
 
 from WMCore.DataStructs.Run import Run
+from WMCore.DataStructs.LumiList import LumiList
 
 class Mask(dict):
     """

--- a/src/python/WMCore/DataStructs/Mask.py
+++ b/src/python/WMCore/DataStructs/Mask.py
@@ -139,6 +139,10 @@ class Mask(dict):
         TODO: The name of this function is a little misleading. If you pass a list of lumis
               it ignores the content of the list and adds a range based on the max/min in
               the list. Missing lumis in the list are ignored.
+
+        NOTE: If the new run/lumi range overlaps with the pre-existing lumi ranges in the
+              mask, no attempt is made to merge these together.  This can result in a mask
+              with duplicate lumis.
         """
 
         if not type(lumis) == list:


### PR DESCRIPTION
To the best extent possible, try to not split a single lumi across multiple jobs - even in the case where the lumi is split across multiple files.  For a full explanation, see #5181.

Pull request has been tested with CRAB3 on a Run I PD and includes a test case.
