### PR TITLE
This fixes a bug in the condor plugin

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
@@ -720,10 +720,11 @@ class CondorPlugin(BasePlugin):
             if not jobAd :
                 logging.error("No jobAd received for jobID %i"%jobID)
             else :
+                desiredSites = jobAd.get('DESIRED_Sites').split(', ')
+                extDesiredSites = jobAd.get('ExtDESIRED_Sites').split(', ')
                 if excludeSite :
-                    if siteName in jobAd.get('DESIRED_Sites') and siteName in jobAd.get('ExtDESIRED_Sites') :
-                        usi = jobAd.get('DESIRED_Sites').split(', ')
-                        print len(usi)
+                    if siteName in desiredSites and siteName in extDesiredSites:
+                        usi = desiredSites
                         if len(usi) > 1 :
                             usi.remove(siteName)
                             usi = usi.__str__().lstrip('[').rstrip(']')
@@ -737,8 +738,8 @@ class CondorPlugin(BasePlugin):
                     else :
                         logging.error("Cannot find siteName %s in the sitelist" % siteName)
                 else :
-                    if siteName in jobAd.get('ExtDESIRED_Sites') and siteName not in jobAd.get('DESIRED_Sites') :
-                        usi = jobAd.get('DESIRED_Sites').split(', ')
+                    if siteName in desiredSites and siteName not in extDesiredSites:
+                        usi = desiredSites
                         usi.append(siteName)
                         usi = usi.__str__().lstrip('[').rstrip(']')
                         usi = filter(lambda c: c not in "\'", usi)


### PR DESCRIPTION
I am afraid there is another problem in the condor plugin, today tier0 jobs got massively killed with no error messages... when I checked, there was a problem in the logic at: 
https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/BossAir/Plugins/CondorPlugin.py#L724

The problem is that when jobAd.get('DESIRED_Sites') returns 'T2_CH_CERN_T0', the check in that line for  'T2_CH_CERN' is True because it checks for the string itself. Then when T2_CH_CERN is set to down is actually killing all the jobs for T2_CH_CERN_T0 !!! 

This patch should avoid this problem in the future.
