### PR TITLE
FNAL staging: do not invoke mkdir for xrootd

### DIFF
--- a/src/python/WMCore/Storage/Backends/FNALImpl.py
+++ b/src/python/WMCore/Storage/Backends/FNALImpl.py
@@ -47,7 +47,7 @@ class FNALImpl(StageOutImpl):
             method = 'xrdcp'
         if PFN.startswith("srm://"):
             method = 'srm'
-        print "Using method %s for PFN %s", (method, PFN)
+        print "Using method %s for PFN %s" % (method, PFN)
         return method
 
 
@@ -61,12 +61,11 @@ class FNALImpl(StageOutImpl):
         """
         method = self.storageMethod(targetPFN)
 
-        if method == 'srm':
+        if method == 'xrdcp': # xrdcp autocreates parent directories
+            return
+        elif method == 'srm':
             self.srmImpl.createOutputDirectory(targetPFN)
-        else:
-            if method != 'local':
-                targetPFN = stripPrefixTOUNIX(targetPFN)
-
+        elif method == 'local':
             targetdir= os.path.dirname(targetPFN)
             command = "#!/bin/sh\n"
             command += "if [ ! -e \"%s\" ]; then\n" % targetdir


### PR DESCRIPTION
xrdcp auto-creates parent directories, so we don't need any
logic in CreateOutputDirectory for xrootd.

The previous version worked only if the filesystem was also mounted
locally -- that was OK for production which has /lustre/unmerged mounted,
but not for CRAB3 and /store/temp)
