### PR TITLE
Fix for resource control updater when SSB Metrics are down

### DIFF
--- a/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
+++ b/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
@@ -87,6 +87,10 @@ class ResourceControlUpdater(BaseWorkerThread):
             logging.debug("Starting algorithm, getting site info from SSB")
             stateBySite, slotsCPU, slotsIO = self.getInfoFromSSB()
             
+            if not stateBySite or not slotsCPU or not slotsIO:
+                logging.error("One or more of the SSB metrics is down. Please contact the Dashboard team.")
+                return
+            
             logging.debug("Setting status and thresholds for all sites, site pending: %s%%, task pending: %s%%" % 
                           (str(self.pendingSlotsSitePercent), str(self.pendingSlotsTaskPercent))) 
             


### PR DESCRIPTION
When one or more of the metrics of SSB is down/not available, thresholds and site status shouldn't be updated until the problem in Dashboard get fixed.
