### PR TITLE
support both pycondor and condor plugin

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -51,7 +51,7 @@ agentNumber = 0
 bossAirPlugins = ["CondorPlugin"]
 
 ## Plugin with Condor-Python API ...
-bossAirPlugins = ["PyCondorPlugin"]
+bossAirPlugins = ["PyCondorPlugin", "CondorPlugin"]
 
 # DBS Information.
 localDBSUrl = "https://cmst0dbs.cern.ch:8443/cms_dbs_prod_tier0_writer/servlet/DBSServlet"


### PR DESCRIPTION
Support both CondorPlugin and PyCondorPlugin 
(Which plugin to use is determined by entries in wmbs_location table). 
We need to deprecate CondorPlugin soon though and remove from the code and config.
