### PR TITLE
Checking if file exists and always use abspath

### DIFF
--- a/src/python/WMCore/Storage/Backends/LCGImpl.py
+++ b/src/python/WMCore/Storage/Backends/LCGImpl.py
@@ -51,8 +51,8 @@ class LCGImpl(StageOutImpl):
         SRM uses file:/// urls
 
         """
-        if pfn.startswith('/'):
-            return "file:%s" % pfn
+        if os.path.isfile(pfn):
+            return "file:%s" % os.path.abspath(pfn)
         else:
             return pfn
 

--- a/src/python/WMCore/Storage/Backends/SRMFNALImpl.py
+++ b/src/python/WMCore/Storage/Backends/SRMFNALImpl.py
@@ -29,8 +29,8 @@ class SRMImpl(StageOutImpl):
         SRM uses file:/// urls
 
         """
-        if pfn.startswith('/'):
-            return "file:///%s" % pfn
+        if os.path.isfile(pfn):
+            return "file:///%s" % os.path.abspath(pfn)
         else:
             return pfn
 

--- a/src/python/WMCore/Storage/Backends/SRMImpl.py
+++ b/src/python/WMCore/Storage/Backends/SRMImpl.py
@@ -29,8 +29,8 @@ class SRMImpl(StageOutImpl):
         SRM uses file:/// urls
 
         """
-        if pfn.startswith('/'):
-            return "file:///%s" % pfn
+        if os.path.isfile(pfn):
+            return "file:///%s" % os.path.abspath(pfn)
         else:
             return pfn
 

--- a/src/python/WMCore/Storage/Backends/SRMV2Impl.py
+++ b/src/python/WMCore/Storage/Backends/SRMV2Impl.py
@@ -38,8 +38,8 @@ class SRMV2Impl(StageOutImpl):
         SRM uses file:/// urls
 
         """
-        if pfn.startswith('/'):
-            return "file:///%s" % pfn
+        if os.path.isfile(pfn):
+            return "file:///%s" % os.path.abspath(pfn)
         else:
             return pfn
 

--- a/src/python/WMCore/Storage/Plugins/Examples/SRMFNALImpl.py
+++ b/src/python/WMCore/Storage/Plugins/Examples/SRMFNALImpl.py
@@ -34,8 +34,8 @@ class SRMImpl(StageOutImplV2):
         SRM uses file:/// urls
 
         """
-        if pfn.startswith('/'):
-            return "file:///%s" % pfn
+        if os.path.isfile(pfn):
+            return "file:///%s" % os.path.abspath(pfn)
         else:
             return pfn
 
@@ -104,8 +104,8 @@ class SRMImpl(StageOutImplV2):
             self.runCommandWarnOnNonZero(["/bin/rm", "-f", self.createPnfsPath(pfn)])
         elif pfn.startswith("file:"):
             self.runCommandWarnOnNonZero(["/bin/rm", "-f", pfn.replace("file://", "", 1)])
-        elif pfn.startswith('/'):
-            self.runCommandWarnOnNonZero(["/bin/rm", "-f", pfn])
+        elif os.path.isfile(pfn):
+            self.runCommandWarnOnNonZero(["/bin/rm", "-f", os.path.abspath(pfn)])
         else:
             logging.info("Tried to delete, but nothing knew how")
             logging.info("pfn: %s" % pfn)

--- a/src/python/WMCore/Storage/Plugins/Examples/SRMImpl.py
+++ b/src/python/WMCore/Storage/Plugins/Examples/SRMImpl.py
@@ -33,8 +33,8 @@ class SRMImpl(StageOutImplV2):
         SRM uses file:/// urls
 
         """
-        if pfn.startswith('/'):
-            return "file:///%s" % pfn
+        if os.path.isfile(pfn):
+            return "file:///%s" % os.path.abspath(pfn)
         else:
             return pfn
 
@@ -93,8 +93,8 @@ class SRMImpl(StageOutImplV2):
             self.runCommandWarnOnNonZero(["srm-advisory-delete", pfn])
         elif pfn.startswith("file:"):
             self.runCommandWarnOnNonZero(["/bin/rm", "-f", pfn.replace("file://", "", 1)])
-        elif pfn.startswith('/'):
-            self.runCommandWarnOnNonZero(["/bin/rm", "-f", pfn])
+        elif os.path.isfile(pfn)
+            self.runCommandWarnOnNonZero(["/bin/rm", "-f", os.path.abspath(pfn)])
         else:
             logging.info("Tried to delete, but nothing knew how")
             logging.info("pfn: %s" % pfn)

--- a/src/python/WMCore/Storage/Plugins/Examples/SRMV2Impl.py
+++ b/src/python/WMCore/Storage/Plugins/Examples/SRMV2Impl.py
@@ -41,8 +41,8 @@ class SRMV2Impl(StageOutImplV2):
         SRM uses file:/// urls
 
         """
-        if pfn.startswith('/'):
-            return "file:///%s" % pfn
+        if os.path.isfile(pfn):
+            return "file:///%s" % os.path.abspath(pfn)
         else:
             return pfn
 
@@ -96,8 +96,8 @@ class SRMV2Impl(StageOutImplV2):
             self.runCommandWarnOnNonZero(["srmrm", 'pfn'])
         elif pfn.startswith("file:"):
             self.runCommandWarnOnNonZero(["/bin/rm", "-f", pfn.replace("file://", "", 1)])
-        elif pfn.startswith('/'):
-            self.runCommandWarnOnNonZero(["/bin/rm", "-f", pfn])
+        elif os.path.isfile(pfn):
+            self.runCommandWarnOnNonZero(["/bin/rm", "-f", os.path.abspath(pfn)])
         else:
             logging.info("Tried to delete, but nothing knew how")
             logging.info("pfn: %s" % pfn)

--- a/src/python/WMCore/Storage/StageOutImpl.py
+++ b/src/python/WMCore/Storage/StageOutImpl.py
@@ -134,8 +134,8 @@ class StageOutImpl:
         """
         return the command to delete a file after a failed copy
         """
-        if pfn.startswith("/"):
-            return "/bin/rm -f %s" % pfn
+        if os.path.isfile(pfn):
+            return "/bin/rm -f %s" % os.path.abspath(pfn)
         else:
             return ""
 


### PR DESCRIPTION
It should not break any of implemantation, but it needs to be tested in all services which are using it. Here are changes not to check `if pfn.startswith('/')` but to check `if isfile(pfn)`

In any case, if any of these functions will get absolute path or relative path everything should work :

```
>>> import os
>>> file = 'cmsRun-stderr.log'
>>> if os.path.isfile(file):
...     print os.path.abspath(file)
... 
/tmp/condor/execute/dir_20810/glide_Th7adb/execute/dir_25952/cmsRun-stderr.log
>>> file = os.path.abspath('cmsRun-stderr.log')
>>> if os.path.isfile(file):
...     print os.path.abspath(file)
... 
/tmp/condor/execute/dir_20810/glide_Th7adb/execute/dir_25952/cmsRun-stderr.log
```

@ericvaandering, @ticoann, @mmascher can you take a look ?

I will comment in this hypernews with more details soon : https://hypernews.cern.ch/HyperNews/CMS/get/crabDevelopment/2103.html 
