### PR TITLE
ignore location for job submission and only use sitewhitelist/siteblacklist

### DIFF
--- a/src/python/WMCore/JobSplitting/JobFactory.py
+++ b/src/python/WMCore/JobSplitting/JobFactory.py
@@ -65,8 +65,9 @@ class JobFactory(WMObject):
         self.currentGroup = None
         self.currentJob = None
 
-        self.siteBlacklist = kwargs.get("siteBlacklist", [])
         self.siteWhitelist = kwargs.get("siteWhitelist", [])
+        self.siteBlacklist = kwargs.get("siteBlacklist", [])
+        self.trustSitelists = kwargs.get("trustSitelists", False)
 
         # Every time we restart, re-zero the jobs
         self.nJobs = 0
@@ -123,8 +124,15 @@ class JobFactory(WMObject):
         self.currentJob["jobType"] = self.subscription["type"]
         self.currentJob["taskType"] = self.subscription.workflowType()
         self.currentJob["owner"] = self.subscription.owner()
-        self.currentJob["siteBlacklist"] = self.siteBlacklist
-        self.currentJob["siteWhitelist"] = self.siteWhitelist
+
+        # only put into job object if relevant
+        # JobSubmitter can deal with absence
+        if len(self.siteBlacklist) > 0:
+            self.currentJob["siteBlacklist"] = self.siteBlacklist
+        if len(self.siteWhitelist) > 0:
+            self.currentJob["siteWhitelist"] = self.siteWhitelist
+        if self.trustSitelists:
+            self.currentJob["trustSitelists"] = self.trustSitelists
 
         # All production jobs must be run 1
         if self.subscription["type"] == "Production":

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -220,7 +220,7 @@ class StdBase(object):
                             userSandbox = None, userFiles = [], primarySubType = None,
                             forceMerged = False, forceUnmerged = False,
                             configCacheUrl = None, timePerEvent = None, memoryReq = None,
-                            sizePerEvent = None, useMulticore = True):
+                            sizePerEvent = None, useMulticore = True, applySiteLists = True):
         """
         _setupProcessingTask_
 
@@ -261,8 +261,11 @@ class StdBase(object):
         procTask.applyTemplates()
 
         procTask.setTaskLogBaseLFN(self.unmergedLFNBase)
-        procTask.setSiteWhitelist(self.siteWhitelist)
-        procTask.setSiteBlacklist(self.siteBlacklist)
+
+        if applySiteLists:
+            procTask.setSiteWhitelist(self.siteWhitelist)
+            procTask.setSiteBlacklist(self.siteBlacklist)
+            procTask.setTrustSitelists(self.trustSitelists)
 
         newSplitArgs = {}
         for argName in splitArgs.keys():
@@ -493,8 +496,8 @@ class StdBase(object):
         mergeTaskLogArch.setStepType("LogArchive")
         mergeTaskLogArch.setNewStageoutOverride(self.enableNewStageout)
 
-
         mergeTask.setTaskLogBaseLFN(self.unmergedLFNBase)
+
         if doLogCollect:
             self.addLogCollectTask(mergeTask, taskName = "%s%sMergeLogCollect" % (parentTask.name(), parentOutputModuleName))
 
@@ -855,6 +858,7 @@ class StdBase(object):
                                         "validate" : lambda x: all([cmsname(y) for y in x])},
                      "SiteWhitelist" : {"default" : [], "type" : makeList,
                                         "validate" : lambda x: all([cmsname(y) for y in x])},
+                     "TrustSitelists" : {"default" : False, "type" : strToBool},
                      "UnmergedLFNBase" : {"default" : "/store/unmerged"},
                      "MergedLFNBase" : {"default" : "/store/data"},
                      "MinMergeSize" : {"default" : 2 * 1024 * 1024 * 1024, "type" : int,

--- a/src/python/WMCore/WMSpec/StdSpecs/StoreResults.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StoreResults.py
@@ -50,9 +50,11 @@ class StoreResultsWorkloadFactory(StdBase):
         
         mergeTaskLogArch = mergeTaskCmssw.addStep("logArch1")
         mergeTaskLogArch.setStepType("LogArchive")
-        
-        self.addLogCollectTask(mergeTask,
-                               taskName = "StoreResultsLogCollect")
+
+        mergeTask.setSiteWhitelist(self.siteWhitelist)
+        mergeTask.setSiteBlacklist(self.siteBlacklist)
+
+        self.addLogCollectTask(mergeTask, taskName = "StoreResultsLogCollect")
         
         mergeTask.setTaskType("Merge")
         mergeTask.applyTemplates()
@@ -70,9 +72,7 @@ class StoreResultsWorkloadFactory(StdBase):
         mergeTask.setSplittingAlgorithm(splitAlgo,
                                         max_merge_size = self.maxMergeSize,
                                         min_merge_size = self.minMergeSize,
-                                        max_merge_events = self.maxMergeEvents,
-                                        siteWhitelist = self.siteWhitelist,
-                                        siteBlacklist = self.siteBlacklist)
+                                        max_merge_events = self.maxMergeEvents)
         
         mergeTaskCmsswHelper = mergeTaskCmssw.getTypeHelper()
         mergeTaskCmsswHelper.cmsswSetup(self.frameworkVersion, softwareEnvironment = "",

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -501,6 +501,7 @@ class WMTaskHelper(TreeHelper):
                 del splittingParams['performance']
         splittingParams["siteWhitelist"] = self.siteWhitelist()
         splittingParams["siteBlacklist"] = self.siteBlacklist()
+        splittingParams["trustSitelists"] = self.trustSitelists()
 
         if "runWhitelist" not in splittingParams.keys() and self.inputRunWhitelist() != None:
             splittingParams["runWhitelist"] = self.inputRunWhitelist()
@@ -805,7 +806,7 @@ class WMTaskHelper(TreeHelper):
         """
         _setSiteWhitelist_
 
-        Set the set white list for this task.
+        Set the set white list for the task.
         """
         self.data.constraints.sites.whitelist = siteWhitelist
         return
@@ -822,9 +823,26 @@ class WMTaskHelper(TreeHelper):
         """
         _setSiteBlacklist_
 
-        Set the site black list for this task.
+        Set the site black list for the task.
         """
         self.data.constraints.sites.blacklist = siteBlacklist
+        return
+
+    def trustSitelists(self):
+        """
+        _trustSitelists_
+
+        Accessor for the 'trust site lists' flag for the task.
+        """
+        return self.data.constraints.sites.trustlists
+
+    def setTrustSitelists(self, trustSitelists):
+        """
+        _setTrustSitelists_
+
+        Set the 'trus site lists' flag for the task.
+        """
+        self.data.constraints.sites.trustlists = trustSitelists
         return
 
     def listOutputDatasetsAndModules(self):
@@ -1313,6 +1331,7 @@ class WMTask(ConfigSectionTree):
         self.constraints.section_("sites")
         self.constraints.sites.whitelist = []
         self.constraints.sites.blacklist = []
+        self.constraints.sites.trustlists = False
         self.subscriptions.outputModules = []
         self.input.section_("WMBS")
 


### PR DESCRIPTION
Add a new parameter TrustSitelists in StdBase that is propagated to the process task jobsplitter (just like the sitewhitelist and siteblacklist). From there it makes it into the job object and is picked up by the JobSubmitter, where it forces use of the site lists without taking data location into account.

Also remove the site lists from merge jobs and make applying the site lists to processing tasks optional (later tasks in a task chain might not want to use them).
