### PR TITLE
handle when PhEDEx return se null

### DIFF
--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -548,9 +548,13 @@ class DBS3Reader:
 
         #removing duplicates and 'UNKNOWN entries
         locations = {}
+        node_filter_list = set(['UNKNOWN', None])
         for name, nodes in blockInfo.iteritems():
             final_nodes = set()
+            
             for n in nodes:
+                if n in node_filter_list:
+                    continue
                 try:
                     cmsname(n)
                 except AssertionError: ## is SE
@@ -559,8 +563,8 @@ class DBS3Reader:
                 else:  ## not SE i.e. phedexNode
                     if not phedexNodes: 
                         n = [self.phedex.getNodeSE(n)] ## convert to SE
-                final_nodes.add(n)
-            locations[name] = list( set(final_nodes) - set(['UNKNOWN']) )
+                final_nodes = final_nodes.union(n)
+            locations[name] = list(final_nodes - node_filter_list)
 
         #returning single list if a single block is passed
         if isinstance(fileBlockName, basestring):


### PR DESCRIPTION
Need to find out why PhEDEx returns se null.

https://cmsweb.cern.ch/phedex/datasvc/json/prod/blockreplicas?block=/ZJetsToNuNu_HT-400to600_Tune4C_13TeV-madgraph-tauola/Spring14dr-PU20bx25_POSTLS170_V5-v1/AODSIM%23136ecc80-0582-11e4-9e28-003048f02c8a
