### PR TITLE
Fix the rest server to work with newer cherrypy versions.

### DIFF
--- a/src/python/WMCore/REST/Format.py
+++ b/src/python/WMCore/REST/Format.py
@@ -1,6 +1,10 @@
 import re, cherrypy, cjson, types, hashlib, xml.sax.saxutils, zlib
 from WMCore.REST.Error import RESTError, ExecutionError, report_rest_error
 from traceback import format_exc
+try:
+  from cherrypy.lib import httputil
+except:
+  from cherrypy.lib import http as httputil
 
 def vary_by(header):
     """Add 'Vary' header for `header`."""
@@ -392,7 +396,7 @@ def _etag_match(status, etagval, match, nomatch):
     # as they need to be handled as request pre-condition, not in the
     # streaming out part here.
     if cherrypy.request.method in ('GET', 'HEAD'):
-        status, reason, msg = cherrypy.lib.http.valid_status(status)
+        status, reason, msg = httputil.valid_status(status)
         if status >= 200 and status <= 299:
             if match and ("*" in match or etagval in match):
                 raise cherrypy.HTTPError(412, "Precondition on ETag %s failed" % etagval)

--- a/src/python/WMCore/REST/Server.py
+++ b/src/python/WMCore/REST/Server.py
@@ -8,6 +8,10 @@ from functools import wraps
 from WMCore.REST.Error import *
 from WMCore.REST.Format import *
 from WMCore.REST.Validation import validate_no_more_input
+try:
+  from cherrypy.lib import httputil
+except:
+  from cherrypy.lib import http as httputil
 
 #: List of HTTP methods for which it's possible to register a REST handler.
 _METHODS = ('GET', 'HEAD', 'POST', 'PUT', 'DELETE')
@@ -294,7 +298,7 @@ class RESTFrontPage:
 
         # Build final response + headers.
         response.headers['Content-Type'] = ctype
-        response.headers['Last-Modified'] = cherrypy.lib.http.HTTPDate(mtime)
+        response.headers['Last-Modified'] = httputil.HTTPDate(mtime)
         response.headers['Cache-Control'] = "public, max-age=%d" % 86400
         response.headers['ETag'] = '"%s"' % hashlib.sha1(result).hexdigest()
         cherrypy.lib.cptools.validate_since()


### PR DESCRIPTION
Could you please pick this patch for the (new) REST server code? it is needed for running CrabCache, Crabserver, ReqMgr2, SiteDB and T0WMADataSvc on SLC6. This was due to api changes coming from the new cherrypy version we are using in the comp_gcc481 slc6 branch.

I've tested it on VMs and it works for both the new (slc6) cherrypy version and the current (slc5) one we use in production machines.
