### PR TITLE
dbsurl validation

### DIFF
--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -55,6 +55,7 @@ dependencies = {'wmc-rest':{
                                      'WMCore.Services.Dashboard',
                                      'WMCore.Services.WMStats',
                                      'WMCore.Services.SiteDB+',
+                                     'WMCore.Services.DBS+',
                                      'WMCore.ACDC'],
 
                         'systems':['wmc-web', 'wmc-runtime'],
@@ -70,6 +71,7 @@ dependencies = {'wmc-rest':{
                         'packages': ['WMCore.ReqMgr+',
                                      'WMCore.WMDataMining+',
                                      'WMCore.Services.Dashboard+',
+                                     'WMCore.Services.DBS+',
                                      'WMCore.Services.WMStats+'
                                     ],
                         'systems': ['wmc-rest', 'wmc-runtime', 'wmc-database'],

--- a/src/python/WMCore/Services/DBS/DBSReader.py
+++ b/src/python/WMCore/Services/DBS/DBSReader.py
@@ -10,31 +10,12 @@ import urlparse
 from WMCore.Services.DBS.DBSErrors import DBSReaderError
 from WMCore.Services.EmulatorSwitch import emulatorHook
 
-# make assumption that same host won't be used for both
-# this check should catch most deployed servers
-DBS2HOST = 'cmsdbsprod.cern.ch'
-DBS3HOST = 'cmsweb.cern.ch'
 
 @emulatorHook
 def DBSReader(endpoint, **kwargs):
     """Function to find and instantiate desired DBSReader object"""
-    endpoint_components = urlparse.urlparse(endpoint)
-
-    if endpoint_components.hostname == DBS3HOST:
-        return _getDBS3Reader(endpoint, **kwargs)
-    elif endpoint_components.hostname == DBS2HOST:
-        return _getDBS2Reader(endpoint, **kwargs)
-
+    
     msg = ''
-    # try with a dbs2 instance, if that fails try dbs3
-    try:
-        dbs = _getDBS2Reader(endpoint, **kwargs)
-        # if this doesn't throw endpoint is dbs2
-        dbs.dbs.getServerInfo()
-        return dbs
-    except Exception, ex:
-        msg += 'Instantiating DBS2Reader failed with %s\n' % str(ex)
-
     try:
         dbs = _getDBS3Reader(endpoint, **kwargs)
         # if this doesn't throw endpoint is dbs3
@@ -44,9 +25,6 @@ def DBSReader(endpoint, **kwargs):
         msg += 'Instantiating DBS3Reader failed with %s\n' % str(ex)
     raise DBSReaderError("Can't contact DBS at %s, got errors %s" % (endpoint, msg))
 
-def _getDBS2Reader(endpoint, **kwargs):
-    from WMCore.Services.DBS.DBS2Reader import DBS2Reader as DBSReader
-    return DBSReader(endpoint, **kwargs)
 
 def _getDBS3Reader(endpoint, **kwargs):
     from WMCore.Services.DBS.DBS3Reader import DBS3Reader as DBSReader

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -12,7 +12,7 @@ from WMCore.Lexicon import lfnBase, identifier, acqname, cmsswversion, cmsname
 from WMCore.Services.Dashboard.DashboardReporter import DashboardReporter
 from WMCore.WMException import WMException
 from WMCore.WMSpec.WMWorkload import newWorkload
-from WMCore.WMSpec.WMWorkloadTools import makeList, makeLumiList, strToBool, validateArguments
+from WMCore.WMSpec.WMWorkloadTools import makeList, makeLumiList, strToBool, validateArguments, checkDBSUrl
 
 analysisTaskTypes = ['Analysis', 'PrivateMC']
 
@@ -868,7 +868,8 @@ class StdBase(object):
                      "MaxMergeEvents" : {"default" : 100000, "type" : int,
                                          "validate" : lambda x : x > 0},
                      "ValidStatus" : {"default" : "PRODUCTION"},
-                     "DbsUrl" : {"default" : "https://cmsweb.cern.ch/dbs/prod/global/DBSReader"},
+                     "DbsUrl" : {"default" : "https://cmsweb.cern.ch/dbs/prod/global/DBSReader",
+                                 "null" : True, "validate" : checkDBSUrl},
                      "DashboardHost" : {"default" : "cms-wmagent-job.cern.ch"},
                      "DashboardPort" : {"default" : 8884, "type" : int,
                                         "validate" : lambda x : x > 0},


### PR DESCRIPTION
check the dbs url in the spec. If dbs are not available request creation will fail. It might not be desirable behavior but for correct checking we can't just use lexicon or patterns.
