### PR TITLE
cleanup of the use of rowcount

### DIFF
--- a/src/python/WMCore/Database/DBFormatter.py
+++ b/src/python/WMCore/Database/DBFormatter.py
@@ -48,9 +48,7 @@ class DBFormatter(WMObject):
                 for j in i:
                     row.append(j)
                 out.append(row)
-
             r.close()
-
         return out
 
     def formatOne(self, result):
@@ -59,8 +57,6 @@ class DBFormatter(WMObject):
         """
         out = []
         for r in result:
-            if r.rowcount == 0:
-                return []
             for i in r.fetchone():
                 out.append(i)
         return out

--- a/src/python/WMCore/Database/ResultSet.py
+++ b/src/python/WMCore/Database/ResultSet.py
@@ -15,27 +15,22 @@ class ResultSet:
     def __init__(self):
         self.data = []
         self.keys = []
-        self.rowcount = 0
-        #Oracle has no lastrowid, so this is only set if it exists.  See add()
-        self.lastrowid = None
 
     def close(self):
         return
 
     def fetchone(self):
-        return self.data[0]
+        if len(self.data) > 0:
+            return self.data[0]
+        else:
+            return []
 
     def fetchall(self):
         return self.data
 
     def add(self, resultproxy):
+
         myThread = threading.currentThread()
-
-        # The Oracle resultproxy doesn't have lastrowid.
-        if hasattr(resultproxy, 'lastrowid'):
-            self.lastrowid = resultproxy.lastrowid
-
-        self.rowcount += resultproxy.rowcount
 
         if resultproxy.closed:
             return
@@ -44,10 +39,5 @@ class ResultSet:
                 if len(self.keys) == 0:
                     self.keys.extend(r.keys())
                 self.data.append(r)
-
-            # Oracle only sets the rowcount parameter in the result proxy after
-            # we have iterated through all the results.
-            if not hasattr(resultproxy, 'lastrowid'):
-                self.rowcount += resultproxy.rowcount
 
         return

--- a/test/python/WMCore_t/Database_t/ResultSet_t.py
+++ b/test/python/WMCore_t/Database_t/ResultSet_t.py
@@ -76,38 +76,11 @@ class ResultSetTest(unittest.TestCase):
         #import pdb
         #pdb.set_trace()
         testSet.add(testProxy)
-        self.assertEqual(testProxy.rowcount, 4)
-        self.assertEqual(testSet.rowcount, 4)
+
         #Test to make sure fetchone and fetchall both work
         self.assertEqual(str(testSet.fetchone()[0]), 'value1')
         self.assertEqual(str(testSet.fetchall()[-1][1]), 'value2c')
 
-    def testRowCount(self):
-
-        testSet = ResultSet()
-        insertProxy = self.myThread.dbi.connection().execute("insert into test_tablec (column1, column2) values ('a', 'b')")
-        testSet.add(insertProxy)
-        self.assertEqual(testSet.rowcount, 1)
-
-        updateProxy = self.myThread.dbi.connection().execute("update test_tablec set column1 = 'c'")
-        testSet.add(updateProxy)
-        self.assertEqual(testSet.rowcount, 2)
-
-        updateProxy = self.myThread.dbi.connection().execute("update test_tablec set column1 = 'c' where column1 = 'a'")
-        testSet.add(updateProxy)
-        self.assertEqual(testSet.rowcount, 2)
-
-        insertProxy = self.myThread.dbi.connection().execute("insert into test_tablec (column1, column2) values ('a', 'b')")
-        testSet.add(insertProxy)
-        self.assertEqual(testSet.rowcount, 3)
-
-        selectProxy = self.myThread.dbi.connection().execute("select * from test_tablec")
-        testSet.add(selectProxy)
-        self.assertEqual(testSet.rowcount, 5)
-
-        selectProxy = self.myThread.dbi.connection().execute("delete from test_tablec")
-        testSet.add(selectProxy)
-        self.assertEqual(testSet.rowcount, 7)
 
     def test1000Binds(self):
 


### PR DESCRIPTION
The way we handled rowcount for the results of a query was somewhat hacky and didn't work with
newer versions of SqlAlchemy and Oracle. As rowcount was only used in one place in the code and
there was a much cleaner alternative implementation there, I completely removed the rowcount
field and the hacky code from ResultSet.
