### PR TITLE
added CPU service to PSet configuration

### DIFF
--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -337,9 +337,9 @@ class SetupCMSSWPset(ScriptInterface):
 
         # include the default performance report services
         self.process.add_(PSetConfig.Service("SimpleMemoryCheck"))
+        self.process.add_(PSetConfig.Service("CPU"))
         self.process.add_(PSetConfig.Service("Timing"))
         self.process.Timing.summaryOnly = PSetConfig.untracked(PSetConfig.bool(True))
-
 
     def _handleChainedProcessing(self):
         """
@@ -347,7 +347,6 @@ class SetupCMSSWPset(ScriptInterface):
         output of one step/task (nomenclature ambiguous) to another.
         This method creates particular mapping in a working Trivial
         File Catalog (TFC).
-
         """
         # first, create an instance of TrivialFileCatalog to override
         tfc = TrivialFileCatalog()


### PR DESCRIPTION
As discussed in this HN
https://hypernews.cern.ch/HyperNews/CMS/get/edmFramework/3352/1.html

this is how we populate FJR with basic CPU info. Just tested this in testbed, here is
the outcome example [1].
I'll make another PR for the master branch later on. Thanks

```
[1]
<PerformanceReport>
  <PerformanceSummary Metric="SystemCPU">
    <Metric Name="CPUModels" Value="Quad-Core AMD Opteron(tm) Processor 2389"/>
    <Metric Name="averageCoreSpeed" Value="2637.5"/>
    <Metric Name="totalCPUs" Value="8"/>
  </PerformanceSummary>
</PerformanceReport>
```
