### PR TITLE
Add view for StoreResults datasets only

### DIFF
--- a/src/couchapps/WMDataMining/views/storeresults_summary/map.js
+++ b/src/couchapps/WMDataMining/views/storeresults_summary/map.js
@@ -1,0 +1,5 @@
+function(doc) {
+  if (doc.type == 'StoreResults') {
+    emit([doc.updateTime, doc._id], [doc.campaign, doc.outputTier, doc.type, doc.status, doc.priority, doc.totalEvents, doc.eventProgress, doc.newTime, doc.inputDataset, doc.outputDatasets, doc.filterEfficiency, doc.runWhiteList]);
+  }
+}


### PR DESCRIPTION
This should go on cmsweb for the production release. Code is nearly identical to what is there now for other views and has been running on cmssrv101 for weeks.
