### PR TITLE
Delete a TFC override that uses the old dcap at FNAL

### DIFF
--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -632,15 +632,6 @@ class SetupCMSSWPset(ScriptInterface):
             self.process.source.overrideCatalog = \
                 cms.untracked.string(self.step.data.application.overrideCatalog)
 
-        # If we're running on a FNAL worker node override the TFC so we can
-        # test lustre.
-        hostname = socket.gethostname()
-        if hostname.endswith("fnal.gov"):
-            for inputFile in self.job["input_files"]:
-                if inputFile["lfn"].find("unmerged") != -1:
-                    self.process.source.overrideCatalog = \
-                        cms.untracked.string("trivialcatalog_file:/uscmst1/prod/sw/cms/SITECONF/T1_US_FNAL/PhEDEx/storage-test.xml?protocol=dcap")
-
         configFile = self.step.data.application.command.configuration
         configPickle = getattr(self.step.data.application.command, "configurationPickle", "PSet.pkl")
         workingDir = self.stepSpace.location


### PR DESCRIPTION
We have to test this though. The failure was found on tier0 wmagent jobs, but it really sounds like we should have noticed this problem before... dcap is not used anymore at FNAL since disk tape separation (several months ago). Using the default config for FNAL should be enough. I checked with Catalin and we may need to update the FNAL storage plugin.
