### PR TITLE
Do not crash JobStatusLite when it cannot get a value from the job dict

### DIFF
--- a/src/python/WMCore/BossAir/BossAirAPI.py
+++ b/src/python/WMCore/BossAir/BossAirAPI.py
@@ -544,21 +544,22 @@ class BossAirAPI(WMConnectionBase):
                 jobsToReturn.extend(localRunning)
                 jobsToChange.extend(localChanges)
                 jobsToComplete.extend(localCompletes)
-                logging.debug("Changing/completing %i/%i jobs in plugin %s.\n" % (len(localChanges),
-                                                                                  len(localCompletes),
-                                                                                  plugin))
+                logging.info("Running/changing/completing %i/%i/%i jobs in plugin %s.\n" % (len(localRunning),
+                                                                                            len(localChanges),
+                                                                                            len(localCompletes),
+                                                                                            plugin))
             except WMException:
                 raise
             except Exception, ex:
-                msg =  "Unhandled Exception while tracking jobs for plugin %s!\n" % plugin
+                msg =  "Unhandled exception while tracking jobs for plugin %s!\n" % plugin
                 msg += str(ex)
                 logging.error(msg)
                 logging.debug("JobsToTrack: %s" % (jobsToTrack[plugin]))
                 raise BossAirException(msg)
 
-        logging.info("About to change %i jobs\n" % len(jobsToChange))
+        logging.info("About to change %i jobs" % len(jobsToChange))
         logging.debug("JobsToChange: %s" % jobsToChange)
-        logging.info("About to complete %i jobs\n" % len(jobsToComplete))
+        logging.info("About to complete %i jobs" % len(jobsToComplete))
         logging.debug("JobsToComplete: %s" % jobsToComplete)
 
         self._updateJobs(jobs = jobsToChange)

--- a/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
@@ -578,7 +578,10 @@ class CondorPlugin(BasePlugin):
                     completeList.append(job)
             else:
                 jobAd     = jobInfo.get(job['jobid'])
-                jobStatus = int(jobAd.get('JobStatus', 0))
+                try:
+                    jobStatus = int(jobAd.get('JobStatus', 0))
+                except ValueError, ex:
+                    jobStatus = 0  # unknown
                 statName  = 'Unknown'
                 if jobStatus == 1:
                     # Job is Idle, waiting for something to happen
@@ -599,7 +602,7 @@ class CondorPlugin(BasePlugin):
                     statName = 'Complete'
                 else:
                     # What state are we in?
-                    logging.info("Job in unknown state %i" % jobStatus)
+                    logging.warning("Job in unknown state %i" % jobStatus)
 
                 # Get the global state
                 job['globalState'] = CondorPlugin.stateMap()[statName]
@@ -612,15 +615,24 @@ class CondorPlugin(BasePlugin):
                 #Check if we have a valid status time
                 if not job['status_time']:
                     if job['status'] == 'Running':
-                        job['status_time'] = int(jobAd.get('runningTime', 0))
+                        try:
+                            job['status_time'] = int(jobAd.get('runningTime', 0))
+                        except ValueError, ex:
+                            job['status_time'] = 0
                         # If we transitioned to running then check the site we are running at
                         job['location'] = jobAd.get('runningCMSSite', None)
                         if job['location'] is None:
                             logging.debug('Something is not right here, a job (%s) is running with no CMS site' % str(jobAd))
                     elif job['status'] == 'Idle':
-                        job['status_time'] = int(jobAd.get('submitTime', 0))
+                        try:
+                            job['status_time'] = int(jobAd.get('submitTime', 0))
+                        except ValueError, ex:
+                            job['status_time'] = 0
                     else:
-                        job['status_time'] = int(jobAd.get('stateTime', 0))
+                        try:
+                            job['status_time'] = int(jobAd.get('stateTime', 0))
+                        except ValueError, ex:
+                            job['status_time'] = 0
                     changeList.append(job)
 
                 runningList.append(job)


### PR DESCRIPTION
Ok, after 30min I succeeded squashing 3 commits :-)

@ticoann, this PR is meant to fix the crashes in JobStatusLite seen in vocms235. For some reason this call
https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/BossAir/Plugins/CondorPlugin.py#L615
sometimes returns 'undefined' and so it crashes the component.

It looks like only the jobAd.get() for 'runningTime' has a bad return from time to time. But to be on the safe side, I've enclosed the other calls in try/except too.

Let me know if you have any comments and/or do not like the logging warning mode. Thanks
