### PR TITLE
import exceptions to WorkQueueManager

### DIFF
--- a/src/python/WMComponent/WorkQueueManager/WorkQueueManagerWMBSFileFeeder.py
+++ b/src/python/WMComponent/WorkQueueManager/WorkQueueManagerWMBSFileFeeder.py
@@ -9,6 +9,7 @@ __all__ = []
 
 import time
 import random
+import exceptions
 
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 from WMCore.WorkQueue.WMBSHelper import freeSlots


### PR DESCRIPTION
@ticoann @hufnagel @amaltaro

This was founded out testing 0.9.95b.patch2 with newest sql alchemy and Oracle database.

```
2014-08-25 14:17:44,927:ERROR:WorkQueueManagerWMBSFileFeeder:Error in wmbs inject loop: No module named exceptions
2014-08-25 14:17:44,927:ERROR:BaseWorkerThread: Thread WorkQueueManagerWMBSFileFeeder:  Transaction reached
                                              end of poll loop. Raise a bug against me. Rollback.
```
