### PR TITLE
cleanup use of sqlalchemy exceptions

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/Oracle/NewAlgo.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/NewAlgo.py
@@ -10,7 +10,6 @@ Oracle implementation of DBSBuffer.NewAlgo
 
 import logging
 
-from sqlalchemy.exceptions import IntegrityError
 from WMCore.Database.DBFormatter import DBFormatter
 
 class NewAlgo(DBFormatter):

--- a/src/python/WMComponent/DBSBuffer/Database/Oracle/NewAlgo.py
+++ b/src/python/WMComponent/DBSBuffer/Database/Oracle/NewAlgo.py
@@ -10,7 +10,6 @@ Oracle implementation of DBSBuffer.NewAlgo
 
 import logging
 
-from sqlalchemy.exceptions import IntegrityError
 from WMCore.Database.DBFormatter import DBFormatter
 
 class NewAlgo(DBFormatter):


### PR DESCRIPTION
The imports aren't used at all and will cause problems with new SqlAlchemy versions as sqlalchemy.exceptions doesn't exist anymore.
