### PR TITLE
Fix duplicate logCollect tar name

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
@@ -5,11 +5,12 @@ _Step.Executor.LogCollect_
 Implementation of an Executor for a StageOut step.
 """
 
-import os.path
+import os
 import logging
 import signal
 import tarfile
 import datetime
+import socket
 
 from WMCore.WMSpec.Steps.WMExecutionFailure import WMExecutionFailure
 
@@ -226,7 +227,8 @@ class LogCollect(Executor):
         Creates a tarball archive for log files
         """
         taskName = self.report.getTaskName().split('/')[-1]
-        tarName         = '%s-%s-%i-logs.tar' % (self.report.data.workload, taskName, self.job["counter"])
+        host = socket.gethostname().split('.')[0]
+        tarName         = '%s-%s-%s-%i-logs.tar' % (self.report.data.workload, taskName, host , self.job["counter"])
         tarBallLocation = os.path.join(self.stepSpace.location, tarName)
         tarBall         = tarfile.open(tarBallLocation, 'w:')
         for f in fileList:


### PR DESCRIPTION
Going through some log archives stored at castor with @juanfmx2, we found that we have been creating duplicate names for log archives when a workflow run in more than 1 agent. 
The problem is that the tar archive name is like: workflow_name-task_name-counter-log.tar
So if 2 agents are running the same log collect task for a given workflow, we end up re-writing the log archives at castor :( as the agent don't know about each other counter.
This is one example:
http://vocms235.cern.ch:5984/wmagent_jobdump%2Fjobs/_design/JobDump/_show/jobSummary/425246
http://vocms216.cern.ch:5984/wmagent_jobdump%2Fjobs/_design/JobDump/_show/jobSummary/948384
@ticoann we could add the hostname in the tar archive name, and it should avoid the same problem again. Does it makes sense?
