### PR TITLE
use reqmgr db instread of wmstats

### DIFF
--- a/src/couchapps/WMStats/_attachments/js/Controller/WMStats.ActiveRequestController.js
+++ b/src/couchapps/WMStats/_attachments/js/Controller/WMStats.ActiveRequestController.js
@@ -23,7 +23,7 @@ WMStats.namespace("ActiveRequestController");
         });
 
     $(WMStats.Globals.Event).on(E.JOB_DETAIL_READY, 
-        function(event, data) {
+		function(event, data) {
             vm.JobDetail.data(data);
         });
 
@@ -51,6 +51,21 @@ WMStats.namespace("ActiveRequestController");
     $(WMStats.Globals.Event).on(E.AJAX_LOADING_START, 
         function(event, data) {
             $('#loading_page').show();
+        });
+        
+    $(WMStats.Globals.Event).on(E.SWITCH_DB, 
+        function(event, data) {
+        	var initView, dbSource;
+        	if (WMStats.Globals.INIT_DB === "WMStats") {
+        		initView = 'requestByStatus';
+        	 	dbSource = WMStats.Couch;
+        	} else if (WMStats.Globals.INIT_DB === "ReqMgr") {
+        		initView = 'bystatus';
+        	 	dbSource = WMStats.ReqMgrCouch;
+        	}
+            WMStats.ActiveRequestModel.setInitView(initView);
+            WMStats.ActiveRequestModel.setDBSource(dbSource);
+			WMStats.ActiveRequestModel.retrieveData();
         });
     
 })(jQuery);

--- a/src/couchapps/WMStats/_attachments/js/DataStruct/WMStats.GenericRequests.js
+++ b/src/couchapps/WMStats/_attachments/js/DataStruct/WMStats.GenericRequests.js
@@ -340,6 +340,7 @@ WMStats.GenericRequests.prototype = {
         /*
          * 
          */
+        var doc = WMStats.Globals.convertRequestDocToWMStatsFormat(doc);
         var workflow = doc.workflow;
         var agentURL = doc.agent_url;
         

--- a/src/couchapps/WMStats/_attachments/js/Models/T1/WMStats.ActiveRequestModel.js
+++ b/src/couchapps/WMStats/_attachments/js/Models/T1/WMStats.ActiveRequestModel.js
@@ -1,6 +1,7 @@
 WMStats.namespace("ActiveRequestModel");
 WMStats.ActiveRequestModel = function() {
     var initView = 'requestByStatus'; 
+    //var initView = 'bystatus';
     var options = {'keys': [
                             "new",
                             "assignment-approved",
@@ -23,5 +24,8 @@ WMStats.ActiveRequestModel = function() {
                    'include_docs': true};
     var reqModel = new WMStats._RequestModelBase(initView, options);
     reqModel.setTrigger(WMStats.CustomEvents.REQUESTS_LOADED);
+    // use reqmgrDB source for initial request
+    //reqModel.setDBSource(WMStats.ReqMgrCouch);
+    
     return reqModel;
 }();

--- a/src/couchapps/WMStats/_attachments/js/Models/T1/WMStats.ReqMgrRequestModel.js
+++ b/src/couchapps/WMStats/_attachments/js/Models/T1/WMStats.ReqMgrRequestModel.js
@@ -2,6 +2,6 @@ WMStats.namespace("ReqMgrRequestModel");
 WMStats.ReqMgrRequestModel = new WMStats._ModelBase('jobsByStatusWorkflow', {}, 
                                           WMStats.ReqMgrRequest);
 
-WMStats.ReqMgrRequestModel.setDBSource(WMStats.ReqMgrCouch)
-WMStats.ReqMgrRequestModel.setTrigger(WMStats.CustomEvents.RESUBMISSION_SUMMARY_READY)
+WMStats.ReqMgrRequestModel.setDBSource(WMStats.ReqMgrCouch);
+WMStats.ReqMgrRequestModel.setTrigger(WMStats.CustomEvents.RESUBMISSION_SUMMARY_READY);
 

--- a/src/couchapps/WMStats/_attachments/js/Models/WMStats._RequestModelBase.js
+++ b/src/couchapps/WMStats/_attachments/js/Models/WMStats._RequestModelBase.js
@@ -6,6 +6,7 @@ WMStats._RequestModelBase = function(initView, options) {
     this._options = options || {'include_docs': true};
     this._data = null;
     this._trigger = "requestReady";
+    this._dbSource = WMStats.Couch;
 };
 //Class method
 WMStats._RequestModelBase.keysFromIDs = function(data) {
@@ -41,8 +42,16 @@ WMStats._RequestModelBase.requestAgentUrlKeys = function(requestList, requestAge
 
 WMStats._RequestModelBase.prototype = {
     
+    setInitView: function(initView) {
+        this._initialView  = initView;
+    },
+    
     setTrigger: function(triggerName) {
         this._trigger = triggerName;
+    },
+    
+    setDBSource: function(dbSource) {
+        this._dbSource = dbSource;
     },
     
     // deprecated
@@ -103,11 +112,11 @@ WMStats._RequestModelBase.prototype = {
         if (!options) {options = WMStats.Utils.cloneObj(this._options);}
         var objPtr = this;
         if (viewName == "allDocs") {
-            WMStats.Couch.allDocs(options, function (overviewData) {
+            this._dbSource.allDocs(options, function (overviewData) {
                 objPtr._getLatestRequestIDsAndCreateTable(overviewData, objPtr);
             });
         } else {
-            WMStats.Couch.view(viewName, options,  function (overviewData) {
+            this._dbSource.view(viewName, options,  function (overviewData) {
                 objPtr._getLatestRequestIDsAndCreateTable(overviewData, objPtr);
             });
         }

--- a/src/couchapps/WMStats/_attachments/js/Views/Controls/T1/WMStats.Controls.js
+++ b/src/couchapps/WMStats/_attachments/js/Views/Controls/T1/WMStats.Controls.js
@@ -87,12 +87,12 @@ WMStats.Controls = function($){
     };
     
     function setAllRequestButton(selector) {
-        var requestBottons = 
+        var requestButtons = 
         '<nav id="all_requests" class="button-group">\
             <ul><li><a href="#" class="nav-button"> all requests </a></li></ul>\
         </nav>';
         
-        $(selector).append(requestBottons).addClass("button-group");
+        $(selector).append(requestButtons).addClass("button-group");
         
         $(document).on('click', "#all_requests li a", function(event){
             vm.RequestView.categoryKey("all");
@@ -107,6 +107,30 @@ WMStats.Controls = function($){
                 $(buttonSelector).removeClass("nav-button-selected").addClass("button-unselected");
             }
         });    
+    };
+    
+    
+    function setDBSourcetButton(selector) {
+        var dbSourceButton = 
+        '<nav id="db_source" class="button-group">\
+            <ul><li><a href="#" class="nav-button"> wmstats db </a></li></ul>\
+        </nav>';
+        
+        $(selector).append(dbSourceButton).addClass("button-group");
+        
+        $(document).on('click', "#db_source li a", function(event){
+            var buttonSelector = "#db_source li a";
+            if (WMStats.Globals.INIT_DB === "WMStats") {
+            	WMStats.Globals.INIT_DB = "ReqMgr";
+            	$(buttonSelector).text("reqmgr db");
+        	} else if (WMStats.Globals.INIT_DB === "ReqMgr") {
+        		WMStats.Globals.INIT_DB = "WMStats";
+        		$(buttonSelector).text("wmstats db");
+        	}
+        	jQuery(WMStats.Globals.Event).triggerHandler(WMStats.CustomEvents.SWITCH_DB);
+            event.preventDefault();
+           });
+        
     };
 
     /* set the view tab and control*/
@@ -149,6 +173,7 @@ WMStats.Controls = function($){
         setAllRequestButton: setAllRequestButton,
         setViewSwitchButton: setViewSwitchButton,
         setExternalLink: setExternalLink,
+        setDBSourcetButton: setDBSourcetButton,
         requests: "requests",
         sites: "sites",
         campaign: "campaign",

--- a/src/couchapps/WMStats/_attachments/js/Views/WMStats.View.IndexHTML.js
+++ b/src/couchapps/WMStats/_attachments/js/Views/WMStats.View.IndexHTML.js
@@ -18,7 +18,8 @@ WMStats.View.IndexHTML = function(){
         $('#loading_page').addClass("front").show();
         //applyTemplate();
         WMStats.CommonControls.setLinkTabs("#link_tabs");
-        WMStats.Controls.setExternalLink("#external_link");
+        //WMStats.Controls.setExternalLink("#external_link");
+        WMStats.Controls.setDBSourcetButton("#external_link");
         WMStats.CommonControls.setUTCClock("#clock");
         WMStats.CommonControls.setWorkloadSummarySearch("#search_option_board");
         WMStats.Controls.setFilter("#filter_board");

--- a/src/couchapps/WMStats/_attachments/js/WMStats.Couch.js
+++ b/src/couchapps/WMStats/_attachments/js/WMStats.Couch.js
@@ -74,4 +74,4 @@ WMStats.Couch = WMStats.CouchBase(WMStats.Globals.COUCHDB_NAME, WMStats.Globals.
 WMStats.WorkloadSummaryCouch = WMStats.CouchBase(WMStats.Globals.WORKLOAD_SUMMARY_COUCHDB_NAME,
                                                  WMStats.Globals.WORKLOAD_SUMMARY_COUCHAPP_DESIGN);
 WMStats.ReqMgrCouch = WMStats.CouchBase(WMStats.Globals.REQMGR_COUCHDB_NAME,
-                                                 WMStats.Globals.REQMGR_SUMMARY_COUCHAPP_DESIGN);
+                                                 WMStats.Globals.REQMGR_COUCHAPP_DESIGN);

--- a/src/couchapps/WMStats/_attachments/js/WMStats.Utils.js
+++ b/src/couchapps/WMStats/_attachments/js/WMStats.Utils.js
@@ -42,7 +42,7 @@ WMStats.Utils.updateObj = function (baseObj, additionObj, createFlag, updateFunc
         }
     } 
 };
-    
+
 WMStats.Utils.getOrDefault= function (baseObj, objList, val) {
     
     if (baseObj[objList[0]]) { 
@@ -205,3 +205,12 @@ WMStats.Utils.addToSet = function(array, value) {
         return false;
     }
 };
+
+WMStats.Utils.delay =  (function(){
+  	var timer = 0;
+  	return function(callback, ms){
+    	var ms = ms || 1000;     	// default 1 sec delay 
+    	clearTimeout (timer);
+    	timer = setTimeout(callback, ms);
+  	};
+})();

--- a/src/couchapps/WMStats/_attachments/js/minified/global.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/global.min.js
@@ -7,7 +7,61 @@ WMStats.namespace("Globals");
 
 WMStats.Globals = function($){
     var _dbVariants = {'wmstats': 'tier1', 'tier0_wmstats': 'tier0'};
+    
+    var reqPropertyMap = {
+		   "_id": "_id",
+		   "InputDataset": "inputdataset",
+		   "PrepID": "prep_id",
+		   "Group": "group",
+		   "RequestDate": "request_date",
+		   "Campaign": "campaign",
+		   "RequestName": "workflow",
+		   "RequestorDN": "user_dn",
+		   "Priority": "priority",
+		   "Requestor": "requestor",
+		   "RequestType": "request_type",
+		   "DbsUrl": "dbs_url",
+		   "SoftWareVersions": "cmssw",
+		   "Outputdatasets": "outputdatasets",
+		   "RequestTransition": "request_status", // Status: status,  UpdateTime: update_time
+		   "SiteWhitelist": "site_white_list",
+		   "Teams": "teams",
+		   "TotalEstimatedJobs": "total_jobs",
+		   "TotalInputEvents": "input_events",
+		   "TotalInputLumis": "input_lumis",
+		   "TotalInputFiles": "input_num_files"
+		};
 
+    function convertRequestDocToWMStatsFormat(doc) {
+    	// check document type whether it is reqmgr doc
+    	// this is hacky way to check  - need better checking 
+    	if (doc.RequestName == undefined) {
+    		return doc;
+    	};
+    	
+    	// this is temporary hack to identify missing RequestTransition property
+    	// all the workflows which has missing info need to be manually updated
+    	if (doc.RequestTransition == undefined || doc.RequestTransition.length == 0) {
+    		doc.RequestTransition = [{"Status": "N/A", "UpdateTime": 0}];
+    	}
+    	var wmstatsReq = {};
+    	for (var key in doc) {
+    		if (reqPropertyMap[key]) {
+    			if (key == "RequestTransition") {
+    				wmstatsReq[reqPropertyMap[key]] = [];
+    				for (var index = 0; index < doc[key].length; index++) {
+    					wmstatsReq[reqPropertyMap[key]][index] = {"status": doc[key][index]["Status"], 
+    															  "update_time": doc[key][index]["UpdateTime"]};
+    				}
+    			} else {
+    				wmstatsReq[reqPropertyMap[key]] = doc[key];
+    			}
+    			
+    		}	
+    	}
+    	return wmstatsReq;
+    };
+    
     function getReqDetailPrefix () {
         if (_dbVariants[dbname] == "tier1") {
             return "/reqmgr/view/details/";
@@ -92,6 +146,7 @@ WMStats.Globals = function($){
 		REQMGR_COUCHAPP_DESIGN: "ReqMgr",
         ALERT_COLLECTOR_LINK: getAlertCollectorLink(),
         CONFIG: null, //this will be set when WMStats.Couch.loadConfig is called. just place holder or have default config
+        INIT_DB: "WMStats",
         loadScript: function (url, success) {
                         $.ajax({async: false, url: url, dataType: 'script', success: success});
             },
@@ -103,7 +158,8 @@ WMStats.Globals = function($){
         Event: {}, // name space for Global Custom event
         formatJobLink: formatJobLink,
         getGQLink: getGQLink,
-        getLQLink: getLQLink
+        getLQLink: getLQLink,
+        convertRequestDocToWMStatsFormat: convertRequestDocToWMStatsFormat
        };
 }(jQuery);
 
@@ -132,6 +188,9 @@ WMStats.CustomEvents.RESUBMISSION_SUCCESS = "C_14";
 
 //workload summary page event
 WMStats.CustomEvents.WORKLOAD_SUMMARY_READY = "W_1";
+
+//workload summary page event
+WMStats.CustomEvents.SWITCH_DB = "S_1";
 
 //view model (need to move to proper location)
 WMStats.namespace("ViewModel");
@@ -180,7 +239,7 @@ WMStats.Utils.updateObj = function (baseObj, additionObj, createFlag, updateFunc
         }
     } 
 };
-    
+
 WMStats.Utils.getOrDefault= function (baseObj, objList, val) {
     
     if (baseObj[objList[0]]) { 
@@ -343,6 +402,15 @@ WMStats.Utils.addToSet = function(array, value) {
         return false;
     }
 };
+
+WMStats.Utils.delay =  (function(){
+  	var timer = 0;
+  	return function(callback, ms){
+    	var ms = ms || 1000;     	// default 1 sec delay 
+    	clearTimeout (timer);
+    	timer = setTimeout(callback, ms);
+  	};
+})();
 /*
  * Define Global values for couch db and couch db function
  * this has dependency on jquery.js and jquery.couch.js
@@ -419,7 +487,7 @@ WMStats.Couch = WMStats.CouchBase(WMStats.Globals.COUCHDB_NAME, WMStats.Globals.
 WMStats.WorkloadSummaryCouch = WMStats.CouchBase(WMStats.Globals.WORKLOAD_SUMMARY_COUCHDB_NAME,
                                                  WMStats.Globals.WORKLOAD_SUMMARY_COUCHAPP_DESIGN);
 WMStats.ReqMgrCouch = WMStats.CouchBase(WMStats.Globals.REQMGR_COUCHDB_NAME,
-                                                 WMStats.Globals.REQMGR_SUMMARY_COUCHAPP_DESIGN);// handles ajax call other than couchdb
+                                                 WMStats.Globals.REQMGR_COUCHAPP_DESIGN);// handles ajax call other than couchdb
 WMStats.namespace("Ajax");
 
 WMStats.Ajax = (function($){

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
@@ -377,6 +377,7 @@ WMStats.GenericRequests.prototype = {
         /*
          * 
          */
+        var doc = WMStats.Globals.convertRequestDocToWMStatsFormat(doc);
         var workflow = doc.workflow;
         var agentURL = doc.agent_url;
         
@@ -1684,7 +1685,8 @@ WMStats.View.IndexHTML = function(){
         $('#loading_page').addClass("front").show();
         //applyTemplate();
         WMStats.CommonControls.setLinkTabs("#link_tabs");
-        WMStats.Controls.setExternalLink("#external_link");
+        //WMStats.Controls.setExternalLink("#external_link");
+        WMStats.Controls.setDBSourcetButton("#external_link");
         WMStats.CommonControls.setUTCClock("#clock");
         WMStats.CommonControls.setWorkloadSummarySearch("#search_option_board");
         WMStats.Controls.setFilter("#filter_board");
@@ -3317,6 +3319,7 @@ WMStats._RequestModelBase = function(initView, options) {
     this._options = options || {'include_docs': true};
     this._data = null;
     this._trigger = "requestReady";
+    this._dbSource = WMStats.Couch;
 };
 //Class method
 WMStats._RequestModelBase.keysFromIDs = function(data) {
@@ -3352,8 +3355,16 @@ WMStats._RequestModelBase.requestAgentUrlKeys = function(requestList, requestAge
 
 WMStats._RequestModelBase.prototype = {
     
+    setInitView: function(initView) {
+        this._initialView  = initView;
+    },
+    
     setTrigger: function(triggerName) {
         this._trigger = triggerName;
+    },
+    
+    setDBSource: function(dbSource) {
+        this._dbSource = dbSource;
     },
     
     // deprecated
@@ -3414,11 +3425,11 @@ WMStats._RequestModelBase.prototype = {
         if (!options) {options = WMStats.Utils.cloneObj(this._options);}
         var objPtr = this;
         if (viewName == "allDocs") {
-            WMStats.Couch.allDocs(options, function (overviewData) {
+            this._dbSource.allDocs(options, function (overviewData) {
                 objPtr._getLatestRequestIDsAndCreateTable(overviewData, objPtr);
             });
         } else {
-            WMStats.Couch.view(viewName, options,  function (overviewData) {
+            this._dbSource.view(viewName, options,  function (overviewData) {
                 objPtr._getLatestRequestIDsAndCreateTable(overviewData, objPtr);
             });
         }
@@ -3582,7 +3593,7 @@ WMStats.namespace("ActiveRequestController");
         });
 
     $(WMStats.Globals.Event).on(E.JOB_DETAIL_READY, 
-        function(event, data) {
+		function(event, data) {
             vm.JobDetail.data(data);
         });
 
@@ -3610,6 +3621,21 @@ WMStats.namespace("ActiveRequestController");
     $(WMStats.Globals.Event).on(E.AJAX_LOADING_START, 
         function(event, data) {
             $('#loading_page').show();
+        });
+        
+    $(WMStats.Globals.Event).on(E.SWITCH_DB, 
+        function(event, data) {
+        	var initView, dbSource;
+        	if (WMStats.Globals.INIT_DB === "WMStats") {
+        		initView = 'requestByStatus';
+        	 	dbSource = WMStats.Couch;
+        	} else if (WMStats.Globals.INIT_DB === "ReqMgr") {
+        		initView = 'bystatus';
+        	 	dbSource = WMStats.ReqMgrCouch;
+        	}
+            WMStats.ActiveRequestModel.setInitView(initView);
+            WMStats.ActiveRequestModel.setDBSource(dbSource);
+			WMStats.ActiveRequestModel.retrieveData();
         });
     
 })(jQuery);

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
@@ -377,6 +377,7 @@ WMStats.GenericRequests.prototype = {
         /*
          * 
          */
+        var doc = WMStats.Globals.convertRequestDocToWMStatsFormat(doc);
         var workflow = doc.workflow;
         var agentURL = doc.agent_url;
         
@@ -1833,7 +1834,8 @@ WMStats.View.IndexHTML = function(){
         $('#loading_page').addClass("front").show();
         //applyTemplate();
         WMStats.CommonControls.setLinkTabs("#link_tabs");
-        WMStats.Controls.setExternalLink("#external_link");
+        //WMStats.Controls.setExternalLink("#external_link");
+        WMStats.Controls.setDBSourcetButton("#external_link");
         WMStats.CommonControls.setUTCClock("#clock");
         WMStats.CommonControls.setWorkloadSummarySearch("#search_option_board");
         WMStats.Controls.setFilter("#filter_board");
@@ -2984,12 +2986,12 @@ WMStats.Controls = function($){
     };
     
     function setAllRequestButton(selector) {
-        var requestBottons = 
+        var requestButtons = 
         '<nav id="all_requests" class="button-group">\
             <ul><li><a href="#" class="nav-button"> all requests </a></li></ul>\
         </nav>';
         
-        $(selector).append(requestBottons).addClass("button-group");
+        $(selector).append(requestButtons).addClass("button-group");
         
         $(document).on('click', "#all_requests li a", function(event){
             vm.RequestView.categoryKey("all");
@@ -3004,6 +3006,30 @@ WMStats.Controls = function($){
                 $(buttonSelector).removeClass("nav-button-selected").addClass("button-unselected");
             }
         });    
+    };
+    
+    
+    function setDBSourcetButton(selector) {
+        var dbSourceButton = 
+        '<nav id="db_source" class="button-group">\
+            <ul><li><a href="#" class="nav-button"> wmstats db </a></li></ul>\
+        </nav>';
+        
+        $(selector).append(dbSourceButton).addClass("button-group");
+        
+        $(document).on('click', "#db_source li a", function(event){
+            var buttonSelector = "#db_source li a";
+            if (WMStats.Globals.INIT_DB === "WMStats") {
+            	WMStats.Globals.INIT_DB = "ReqMgr";
+            	$(buttonSelector).text("reqmgr db");
+        	} else if (WMStats.Globals.INIT_DB === "ReqMgr") {
+        		WMStats.Globals.INIT_DB = "WMStats";
+        		$(buttonSelector).text("wmstats db");
+        	}
+        	jQuery(WMStats.Globals.Event).triggerHandler(WMStats.CustomEvents.SWITCH_DB);
+            event.preventDefault();
+           });
+        
     };
 
     /* set the view tab and control*/
@@ -3046,6 +3072,7 @@ WMStats.Controls = function($){
         setAllRequestButton: setAllRequestButton,
         setViewSwitchButton: setViewSwitchButton,
         setExternalLink: setExternalLink,
+        setDBSourcetButton: setDBSourcetButton,
         requests: "requests",
         sites: "sites",
         campaign: "campaign",
@@ -4033,6 +4060,7 @@ WMStats._RequestModelBase = function(initView, options) {
     this._options = options || {'include_docs': true};
     this._data = null;
     this._trigger = "requestReady";
+    this._dbSource = WMStats.Couch;
 };
 //Class method
 WMStats._RequestModelBase.keysFromIDs = function(data) {
@@ -4068,8 +4096,16 @@ WMStats._RequestModelBase.requestAgentUrlKeys = function(requestList, requestAge
 
 WMStats._RequestModelBase.prototype = {
     
+    setInitView: function(initView) {
+        this._initialView  = initView;
+    },
+    
     setTrigger: function(triggerName) {
         this._trigger = triggerName;
+    },
+    
+    setDBSource: function(dbSource) {
+        this._dbSource = dbSource;
     },
     
     // deprecated
@@ -4130,11 +4166,11 @@ WMStats._RequestModelBase.prototype = {
         if (!options) {options = WMStats.Utils.cloneObj(this._options);}
         var objPtr = this;
         if (viewName == "allDocs") {
-            WMStats.Couch.allDocs(options, function (overviewData) {
+            this._dbSource.allDocs(options, function (overviewData) {
                 objPtr._getLatestRequestIDsAndCreateTable(overviewData, objPtr);
             });
         } else {
-            WMStats.Couch.view(viewName, options,  function (overviewData) {
+            this._dbSource.view(viewName, options,  function (overviewData) {
                 objPtr._getLatestRequestIDsAndCreateTable(overviewData, objPtr);
             });
         }
@@ -4219,6 +4255,7 @@ WMStats.HistoryModel.setTrigger(WMStats.CustomEvents.HISTORY_LOADED);
 WMStats.namespace("ActiveRequestModel");
 WMStats.ActiveRequestModel = function() {
     var initView = 'requestByStatus'; 
+    //var initView = 'bystatus';
     var options = {'keys': [
                             "new",
                             "assignment-approved",
@@ -4241,14 +4278,17 @@ WMStats.ActiveRequestModel = function() {
                    'include_docs': true};
     var reqModel = new WMStats._RequestModelBase(initView, options);
     reqModel.setTrigger(WMStats.CustomEvents.REQUESTS_LOADED);
+    // use reqmgrDB source for initial request
+    //reqModel.setDBSource(WMStats.ReqMgrCouch);
+    
     return reqModel;
 }();
 WMStats.namespace("ReqMgrRequestModel");
 WMStats.ReqMgrRequestModel = new WMStats._ModelBase('jobsByStatusWorkflow', {}, 
                                           WMStats.ReqMgrRequest);
 
-WMStats.ReqMgrRequestModel.setDBSource(WMStats.ReqMgrCouch)
-WMStats.ReqMgrRequestModel.setTrigger(WMStats.CustomEvents.RESUBMISSION_SUMMARY_READY)
+WMStats.ReqMgrRequestModel.setDBSource(WMStats.ReqMgrCouch);
+WMStats.ReqMgrRequestModel.setTrigger(WMStats.CustomEvents.RESUBMISSION_SUMMARY_READY);
 
 WMStats.namespace("GenericController");
 
@@ -4313,7 +4353,7 @@ WMStats.namespace("ActiveRequestController");
         });
 
     $(WMStats.Globals.Event).on(E.JOB_DETAIL_READY, 
-        function(event, data) {
+		function(event, data) {
             vm.JobDetail.data(data);
         });
 
@@ -4341,6 +4381,21 @@ WMStats.namespace("ActiveRequestController");
     $(WMStats.Globals.Event).on(E.AJAX_LOADING_START, 
         function(event, data) {
             $('#loading_page').show();
+        });
+        
+    $(WMStats.Globals.Event).on(E.SWITCH_DB, 
+        function(event, data) {
+        	var initView, dbSource;
+        	if (WMStats.Globals.INIT_DB === "WMStats") {
+        		initView = 'requestByStatus';
+        	 	dbSource = WMStats.Couch;
+        	} else if (WMStats.Globals.INIT_DB === "ReqMgr") {
+        		initView = 'bystatus';
+        	 	dbSource = WMStats.ReqMgrCouch;
+        	}
+            WMStats.ActiveRequestModel.setInitView(initView);
+            WMStats.ActiveRequestModel.setDBSource(dbSource);
+			WMStats.ActiveRequestModel.retrieveData();
         });
     
 })(jQuery);


### PR DESCRIPTION
Initial attempt combine reqmgr db and wmstats.
For now there is a button to switch db.
To make this work reqmgr db need to be updated manually. (but only after this get into production - 
reqmgr update function need to be in production)
