### PR TITLE
migrate from phEDExNodetocmsName to PNNtoPSN

### DIFF
--- a/src/python/WMComponent/PhEDExInjector/PhEDExInjectorSubscriber.py
+++ b/src/python/WMComponent/PhEDExInjector/PhEDExInjectorSubscriber.py
@@ -99,14 +99,15 @@ class PhEDExInjectorSubscriber(BaseWorkerThread):
         nodeMappings = self.phedex.getNodeMap()
         for node in nodeMappings["phedex"]["node"]:
 
-            cmsName = self.siteDB.phEDExNodetocmsName(node["name"])
+            cmsNames = self.siteDB.PNNtoPSN(node["name"])
+            
+            for cmsName in cmsNames:
+                if cmsName not in self.cmsToPhedexMap:
+                    self.cmsToPhedexMap[cmsName] = {}
 
-            if cmsName not in self.cmsToPhedexMap:
-                self.cmsToPhedexMap[cmsName] = {}
-
-            logging.info("Loaded PhEDEx node %s for site %s" % (node["name"], cmsName))
-            if node["kind"] not in self.cmsToPhedexMap[cmsName]:
-                self.cmsToPhedexMap[cmsName][node["kind"]] = node["name"]
+                logging.info("Loaded PhEDEx node %s for site %s" % (node["name"], cmsName))
+                if node["kind"] not in self.cmsToPhedexMap[cmsName]:
+                    self.cmsToPhedexMap[cmsName][node["kind"]] = node["name"]
 
             if node["kind"] in [ "MSS", "Disk" ]:
                 self.phedexNodes[node["kind"]].append(node["name"])

--- a/src/python/WMCore/WorkQueue/DataLocationMapper.py
+++ b/src/python/WMCore/WorkQueue/DataLocationMapper.py
@@ -130,7 +130,10 @@ class DataLocationMapper():
 
         # convert from PhEDEx name to cms site name
         for name, nodes in result.items():
-            result[name] = list(set([self.sitedb.phEDExNodetocmsName(x) for x in nodes]))
+            psns = set()
+            for x in nodes:
+                psns.update(self.sitedb.PNNtoPSN(x))
+            result[name] = list(psns)
 
         return result, fullResync
 


### PR DESCRIPTION
@ticoann @ericvaandering 

fix for issue #5341. Note that the new API PNNtoPSN returns a list of possible PSNs where as the phedexNodetocmsName returned a single PSN string. I have therefore just taken the first element in this list. Does this sound reasonable?

please review

--Alex
