### PR TITLE
don't pass sitelists to merge jobsplitter

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -529,8 +529,6 @@ class StdBase(object):
                                         min_merge_size = self.minMergeSize,
                                         max_merge_events = self.maxMergeEvents,
                                         max_wait_time = self.maxWaitTime,
-                                        siteWhitelist = self.siteWhitelist,
-                                        siteBlacklist = self.siteBlacklist,
                                         initial_lfn_counter = lfn_counter)
 
         if getattr(parentOutputModule, "dataTier") == "DQMIO":


### PR DESCRIPTION
Merge jobs at the moment inherit the sitelists of their workflow (as they get passed in via the job splitting parameters). This is a) unnecessary and b) causes problems for opportunistic resources where the top task of the workflow runs at site A and merging should be run at site B. Essentially, with the current code, you cannot just run the top task of the workflow at site A, you would have to allow it to run at both site A and B.
