### PR TITLE
Remove phedexnodetocmsname

### DIFF
--- a/src/python/WMComponent/PhEDExInjector/PhEDExInjectorSubscriber.py
+++ b/src/python/WMComponent/PhEDExInjector/PhEDExInjectorSubscriber.py
@@ -99,14 +99,15 @@ class PhEDExInjectorSubscriber(BaseWorkerThread):
         nodeMappings = self.phedex.getNodeMap()
         for node in nodeMappings["phedex"]["node"]:
 
-            cmsName = self.siteDB.phEDExNodetocmsName(node["name"])
+            cmsNames = self.siteDB.PNNtoPSN(node["name"])
+            
+            for cmsName in cmsNames:
+                if cmsName not in self.cmsToPhedexMap:
+                    self.cmsToPhedexMap[cmsName] = {}
 
-            if cmsName not in self.cmsToPhedexMap:
-                self.cmsToPhedexMap[cmsName] = {}
-
-            logging.info("Loaded PhEDEx node %s for site %s" % (node["name"], cmsName))
-            if node["kind"] not in self.cmsToPhedexMap[cmsName]:
-                self.cmsToPhedexMap[cmsName][node["kind"]] = node["name"]
+                logging.info("Loaded PhEDEx node %s for site %s" % (node["name"], cmsName))
+                if node["kind"] not in self.cmsToPhedexMap[cmsName]:
+                    self.cmsToPhedexMap[cmsName][node["kind"]] = node["name"]
 
             if node["kind"] in [ "MSS", "Disk" ]:
                 self.phedexNodes[node["kind"]].append(node["name"])

--- a/src/python/WMCore/Services/SiteDB/SiteDB.py
+++ b/src/python/WMCore/Services/SiteDB/SiteDB.py
@@ -235,29 +235,6 @@ class SiteDBJSON(Service):
         return phedexnames
 
 
-    def phEDExNodetocmsName(self, node):
-        """
-        Convert PhEDEx node name to cms site
-        """
-        # api doesn't work at the moment - so reverse engineer
-        # first strip special endings and check with cmsNametoPhEDExNode
-        # if this fails (to my knowledge no node does fail) do a full lookup
-        name = node.replace('_MSS',
-                            '').replace('_Disk',
-                                '').replace('_Buffer',
-                                    '').replace('_Export', '')
-
-        return name
-        # Disable cross-check until following bug fixed.
-        # https://savannah.cern.ch/bugs/index.php?67044
-#        if node in self.cmsNametoPhEDExNode(name):
-#            return name
-#
-#        # As far as i can tell there is no way to get a full listing, would
-#        # need to call CMSNametoPhEDExNode?cms_name= but can't find a way to do
-#        # that. So simply raise an error
-#        raise ValueError, "Unable to find CMS name for \'%s\'" % node
-
     def PNNtoPSN(self, pnn):
         """
         Convert PhEDEx node name to Processing Site Name(s)

--- a/src/python/WMCore/WorkQueue/DataLocationMapper.py
+++ b/src/python/WMCore/WorkQueue/DataLocationMapper.py
@@ -130,7 +130,10 @@ class DataLocationMapper():
 
         # convert from PhEDEx name to cms site name
         for name, nodes in result.items():
-            result[name] = list(set([self.sitedb.phEDExNodetocmsName(x) for x in nodes]))
+            psns = set()
+            for x in nodes:
+                psns.update(self.sitedb.PNNtoPSN(x))
+            result[name] = list(psns)
 
         return result, fullResync
 

--- a/src/python/WMQuality/Emulators/SiteDBClient/SiteDB.py
+++ b/src/python/WMQuality/Emulators/SiteDBClient/SiteDB.py
@@ -210,19 +210,6 @@ class SiteDBJSON(object):
         phedexnames = map(lambda x: x['alias'], phedexnames)
         return phedexnames
 
-    def phEDExNodetocmsName(self, node):
-        """
-        Convert PhEDEx node name to cms site
-        """
-        # api doesn't work at the moment - so reverse engineer
-        # first strip special endings and check with cmsNametoPhEDExNode
-        # if this fails (to my knowledge no node does fail) do a full lookup
-        name = node.replace('_MSS',
-                            '').replace('_Buffer',
-                                        '').replace('_Export', '')
-
-        return name
-
     def PNNtoPSN(self, pnn):
         """
         Emulator to convert PhEDEx node name to Processing Site Name(s)

--- a/test/data/ReqMgr/RequestQuery.py
+++ b/test/data/ReqMgr/RequestQuery.py
@@ -10,7 +10,7 @@ providing information for the bookeeping database
 """
 import os, re, traceback
 from dbs.apis.dbsClient import DbsApi
-from WMCore.Services.PhEDEx.PhEDEx import PhEDEx 
+from WMCore.Services.SiteDB.SiteDB import SiteDBJSON
 from mechanize import Browser
 from bs4 import BeautifulSoup
 
@@ -30,7 +30,7 @@ class RequestQuery:
         self.config = config
         
         # Initialise connections
-        self.phedex = PhEDEx({"endpoint":"https://cmsweb.cern.ch/phedex/datasvc/json/prod/"}, "json")
+        self.mySiteDB = SiteDBJSON()
         self.dbsPhys01 = DbsApi(url = dbs_base_url+"phys01/DBSReader/")
         self.dbsPhys02 = DbsApi(url = dbs_base_url+"phys02/DBSReader/")
         self.dbsPhys03 = DbsApi(url = dbs_base_url+"phys03/DBSReader/")
@@ -198,20 +198,6 @@ class RequestQuery:
                 siteNames.append(node['name']) 
         
         return siteNames, seList
-    
-    def phEDExNodetocmsName(self, nodeList):
-        """
-        Convert PhEDEx node name list to cms names list 
-        """
-        names = []
-        for node in nodeList:
-            name = node.replace('_MSS',
-                                '').replace('_Disk',
-                                    '').replace('_Buffer',
-                                        '').replace('_Export', '')
-            if name not in names:
-                names.append(name)
-        return names
     
     def setGlobalTagFromOrigin(self, dbs_url,input_dataset):
         """
@@ -439,8 +425,8 @@ class RequestQuery:
                 
                 # Get dataset site info:
                 phedex_map, se_names = self.getDatasetOriginSites(dbs_url,input_dataset)
-                sites = self.phEDExNodetocmsName(phedex_map)
-                
+                sites = set([self.mySiteDB.PNNtoPSN(node) for node in phedex_map])
+
                 infoDict = {}
                 # Build store results json
                 # First add all the defaults values

--- a/test/python/WMCore_t/Services_t/SiteDB_t/SiteDB_t.py
+++ b/test/python/WMCore_t/Services_t/SiteDB_t/SiteDB_t.py
@@ -33,20 +33,6 @@ class SiteDBTest(unittest.TestCase):
         results = self.mySiteDB.cmsNametoPhEDExNode("T1_US_FNAL")
         self.failUnless(sorted(results) == sorted(target))
 
-    def testPhEDExNodetocmsName(self):
-        """
-        Tests PhEDExNodetocmsName
-        """
-        result = self.mySiteDB.phEDExNodetocmsName('T1_US_FNAL_MSS')
-        self.failUnless(result == 'T1_US_FNAL')
-        result = self.mySiteDB.phEDExNodetocmsName('T1_US_FNAL_Buffer')
-        self.failUnless(result == 'T1_US_FNAL')
-        result = self.mySiteDB.phEDExNodetocmsName('T2_UK_London_IC')
-        self.failUnless(result == 'T2_UK_London_IC')
-        # don't check this anymore, see comment in phEDExNodetocmsName function
-        #self.assertRaises(ValueError, self.mySiteDB.phEDExNodetocmsName,
-        #                  'T9_DOESNT_EXIST_Buffer')
-
     def testCmsNametoSE(self):
         """
         Tests CmsNametoSE


### PR DESCRIPTION
fixes issue #5360.

This patch builds on #5359 which migrates the WMCore to using sitedb PNNtoPSN. This patch should therefore probably be applied after #5359 as it removes all trace of phedexNodetocmsName from the code base and migrates the unittest that was using it (RequestQuery.py) to the new PNNtoPSN api.
