### PR TITLE
Propagate multicore settings to job plugins and add strings to test code

### DIFF
--- a/src/python/WMComponent/JobCreator/JobCreatorPoller.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorPoller.py
@@ -104,7 +104,8 @@ def runSplitter(jobFactory, splitParams):
 def saveJob(job, workflow, sandbox, wmTask = None, jobNumber = 0,
             owner = None, ownerDN = None,
             ownerGroup = '', ownerRole = '',
-            scramArch = None, swVersion = None, agentNumber = 0 ):
+            scramArch = None, swVersion = None, agentNumber = 0,
+            multicoreEnabled = False, numberOfCores = 1 ):
     """
     _saveJob_
 
@@ -128,6 +129,8 @@ def saveJob(job, workflow, sandbox, wmTask = None, jobNumber = 0,
     job['ownerRole']   = ownerRole
     job['scramArch'] = scramArch
     job['swVersion'] = swVersion
+    job['multicoreEnabled'] = multicoreEnabled
+    job['numberOfCores'] = numberOfCores
     output = open(os.path.join(cacheDir, 'job.pkl'), 'w')
     cPickle.dump(job, output, cPickle.HIGHEST_PROTOCOL)
     output.close()
@@ -157,6 +160,8 @@ def creatorProcess(work, jobCacheDir):
         scramArch    = work.get('scramArch', None)
         swVersion    = work.get('swVersion', None)
         agentNumber  = work.get('agentNumber', 0)
+        numberOfCores = work.get('numberOfCores', 1)
+        multicoreEnabled = work.get('multicoreEnabled', False)
 
         if ownerDN == None:
             ownerDN = owner
@@ -405,7 +410,7 @@ class JobCreatorPoller(BaseWorkerThread):
             myThread = threading.currentThread()
             if getattr(myThread, 'transaction', False) \
                    and getattr(myThread.transaction, 'transaction', False):
-                myThread.transaction.rollback()            
+                myThread.transaction.rollback()
             # Handle temporary connection problems (Temporary)
             if "This Connection is closed" not in str(ex):
                 msg = "Failed to execute JobCreator \n%s\n\n%s" % (ex,traceback.format_exc())
@@ -550,6 +555,12 @@ class JobCreatorPoller(BaseWorkerThread):
                                'ownerDN': wmWorkload.getOwner().get('dn', None),
                                'ownerGroup': wmWorkload.getOwner().get('vogroup', ''),
                                'ownerRole': wmWorkload.getOwner().get('vorole', '')}
+                try:
+                    multicore = wmTask.steps().applicationSection().multicore
+                    processDict.update({'numberOfCores' : multicore.numberOfCores,
+                                        'multicoreEnabled' : multicore.enabled})
+                except AttributeError:
+                    logging.info("Failed to read multicore settings from task %s" % wmTask.getPathName())
 
                 tempSubscription = Subscription(id = wmbsSubscription['id'])
 

--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -394,7 +394,10 @@ class JobSubmitterPoller(BaseWorkerThread):
                        loadedJob.get("estimatedDiskUsage", None),
                        loadedJob.get("estimatedMemoryUsage", None),
                        newJob['task_name'],
-                       frozenset(potentialLocations))
+                       frozenset(potentialLocations),
+                       loadedJob.get("multicoreEnabled", False),
+                       loadedJob.get("numberOfCores", 1),
+                      )
 
             self.jobDataCache[workflowName][jobID] = jobInfo
 
@@ -701,6 +704,8 @@ class JobSubmitterPoller(BaseWorkerThread):
                                'estimatedMemoryUsage' : cachedJob[16],
                                'taskPriority' : self.workflowPrios[workflow],
                                'taskName' : cachedJob[17],
+                               'multicoreEnabled' : cachedJob[19],
+                               'numberOfCores' : cachedJob[20],
                                'potentialSites' : potentialSites}
 
                     # Add to jobsToSubmit

--- a/src/python/WMCore/BossAir/BossAirAPI.py
+++ b/src/python/WMCore/BossAir/BossAirAPI.py
@@ -822,7 +822,7 @@ class BossAirAPI(WMConnectionBase):
                 raise BossAirException(msg)
         return jobkill
 
-            
+
 
 
     def _buildRunningJobsFromRunJobs(self, runJobs):

--- a/src/python/WMCore/BossAir/RunJob.py
+++ b/src/python/WMCore/BossAir/RunJob.py
@@ -29,7 +29,9 @@ class RunJob(dict):
                  scram_arch = None, siteName = None, jobName = None,
                  proxyPath = None, requestName = None, jobTime = None,
                  diskUsage = None, memoryUsage = None, taskPriority = None,
-                 taskName = None, potentialSites = None):
+                 taskName = None, potentialSites = None, multicoreEnabled = False,
+                 numberOfCores = 1,
+                ):
         """
         Just make sure you init the dictionary fields.
 
@@ -66,6 +68,8 @@ class RunJob(dict):
         self.setdefault('estimatedJobTime', jobTime)
         self.setdefault('estimatedDiskUsage', diskUsage)
         self.setdefault('estimatedMemoryUsage', memoryUsage)
+        self.setdefault('multicoreEnabled', multicoreEnabled)
+        self.setdefault('numberOfCores', numberOfCores)
         self.setdefault('taskPriority', taskPriority)
         self.setdefault('taskName', taskName)
         self.setdefault('potentialSites', potentialSites)

--- a/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
+++ b/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
@@ -202,6 +202,8 @@ class JobSubmitterTest(unittest.TestCase):
             testJob["siteBlacklist"] = bl
             testJob["siteWhitelist"] = wl
             testJob['priority'] = 101
+            testJob['multicoreEnabled'] = False
+            testJob['numberOfCores'] = 1
             jobCache = os.path.join(cacheDir, 'Sub_%i' % (sub), 'Job_%i' % (index))
             os.makedirs(jobCache)
             testJob.create(jobGroup)
@@ -253,7 +255,7 @@ class JobSubmitterTest(unittest.TestCase):
                                                          'WMComponent_t/JobSubmitter_t',
                                                          "submit.sh")
 
-        
+
         # JobSubmitter configuration
         config.component_("JobSubmitter")
         config.JobSubmitter.logLevel      = 'DEBUG'
@@ -412,7 +414,7 @@ class JobSubmitterTest(unittest.TestCase):
 
         jobSubmitter.algorithm()
 
-        # Check that jobs are in the right state, 
+        # Check that jobs are in the right state,
         # here we are limited by the pending threshold for the Processing task (45)
         result = getJobsAction.execute(state = 'Created', jobType = "Processing")
         self.assertEqual(len(result), 5)


### PR DESCRIPTION
This patch takes the multicore settings from the task and passes them through the chain down to the job that is sent to the boss air plugin. 
