### PR TITLE
properly handle None in JobAccountant

### DIFF
--- a/src/python/WMComponent/JobAccountant/AccountantWorker.py
+++ b/src/python/WMComponent/JobAccountant/AccountantWorker.py
@@ -655,9 +655,10 @@ class AccountantWorker(WMConnectionBase):
                     raise AccountantWorkerException(msg)
 
             # Associate the workflow to the file using the taskPath and the requestName
-            taskPath     = str(dbsFile.get('task'))
+            # TODO: debug why it happens and then drop/recover these cases automatically
+            taskPath = dbsFile.get('task')
             if not taskPath:
-                msg = "Can't do workflow association, this is not acceptable.\n"
+                msg = "Can't do workflow association, report this error to a developer.\n"
                 msg += "DbsFile : %s" % str(dbsFile)
                 raise AccountantWorkerException(msg)
             workflowName = taskPath.split('/')[1]


### PR DESCRIPTION
Handle None as None instead of 'None', so now it raises the correct exception.

As discussed with @ticoann , we are not sure when it happens, so in principle we cannot
simply drop that file. Developer manual intervention is still needed for this case.
Seangchan, review please. If you know how to automatically recover it, please let me know :-)
