### PR TITLE
make multicore in setupProcessingTask optional

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -111,8 +111,6 @@ class PromptRecoWorkloadFactory(StdBase):
 
         cmsswStepType = "CMSSW"
         taskType = "Processing"
-        if self.multicore:
-            taskType = "MultiProcessing"
 
         recoOutputs = []
         for dataTier in self.writeTiers:
@@ -156,7 +154,8 @@ class PromptRecoWorkloadFactory(StdBase):
                                                        splitArgs = {"max_merge_size": self.maxMergeSize,
                                                                     "min_merge_size": self.minMergeSize,
                                                                     "max_merge_events": self.maxMergeEvents},
-                                                       stepType = cmsswStepType)
+                                                       stepType = cmsswStepType,
+                                                       useMulticore = False)
                 if self.doLogCollect:
                     self.addLogCollectTask(alcaTask, taskName = "AlcaSkimLogCollect")
                 self.addCleanupTask(recoTask, recoOutLabel)
@@ -210,7 +209,7 @@ class PromptRecoWorkloadFactory(StdBase):
                                                   couchURL = self.couchURL, couchDBName = self.couchDBName,
                                                   configCacheUrl = self.configCacheUrl,
                                                   configDoc = configCacheID, splitAlgo = self.skimJobSplitAlgo,
-                                                  splitArgs = self.skimJobSplitArgs)
+                                                  splitArgs = self.skimJobSplitArgs, useMulticore = False)
             if self.doLogCollect:
                 self.addLogCollectTask(skimTask, taskName = "%sLogCollect" % promptSkim.SkimName)
 

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -220,7 +220,7 @@ class StdBase(object):
                             userSandbox = None, userFiles = [], primarySubType = None,
                             forceMerged = False, forceUnmerged = False,
                             configCacheUrl = None, timePerEvent = None, memoryReq = None,
-                            sizePerEvent = None):
+                            sizePerEvent = None, useMulticore = True):
         """
         _setupProcessingTask_
 
@@ -300,7 +300,7 @@ class StdBase(object):
         procTaskCmsswHelper = procTaskCmssw.getTypeHelper()
         procTaskStageHelper = procTaskStageOut.getTypeHelper()
 
-        if self.multicore:
+        if self.multicore and useMulticore:
             # if multicore, poke in the number of cores setting
             procTaskCmsswHelper.setMulticoreCores(self.multicoreNCores)
 


### PR DESCRIPTION
Just because a request should use multicore does not mean that all setupProcessingTask created tasks should really use multiple cores. Make it optional, to be overridden by the caller. Also adjust the PromptReco spec to only use multicore for the reconstruction step.

Please note, but default all setupProcessingTask created tasks will still use the standard multicore settings, so the default behavior does not change. If we want to turn it off for certain steps, we need to adjust the spec files (as is done here for PromptReco).
