### PR TITLE
removing listBlockLocations by SE

### DIFF
--- a/src/python/WMComponent/DBSUpload/DBSInterface.py
+++ b/src/python/WMComponent/DBSUpload/DBSInterface.py
@@ -555,7 +555,7 @@ class DBSInterface:
                                  seName = block['location'])
 
             block['Path']               = dataset['Path']
-            block['StorageElementList'] = block['location']
+            block['PhEDExNodeList'] = block['location']
 
 
             # Now assemble the files

--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -764,7 +764,7 @@ class DBS3Reader:
                 dbsOnly = True
             else:
                 for blockSites in blocksInfo.values():
-                    locations.update(blockSites)
+                    locations.intersection_update(blockSites)
 
         if dbsOnly:
             try:

--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -547,7 +547,7 @@ class DBS3Reader:
             raise DBSReaderError(msg)
 
 
-    def listFileBlockLocation(self, fileBlockName, dbsOnly = False):
+    def listFileBlockLocation(self, fileBlockNames, dbsOnly = False):
         """
         _listFileBlockLocation_
 

--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -547,7 +547,7 @@ class DBS3Reader:
             raise DBSReaderError(msg)
 
 
-    def listFileBlockLocation(self, fileBlockNames, dbsOnly = False, phedexNodes=True):
+    def listFileBlockLocation(self, fileBlockName, dbsOnly = False):
         """
         _listFileBlockLocation_
 
@@ -567,7 +567,7 @@ class DBS3Reader:
         node_filter = set(['UNKNOWN', None])
         if not dbsOnly:
             try:
-                blocksInfo = self.phedex.getReplicaSEForBlocks(phedexNodes=phedexNodes, block=fileBlockNames, complete='y')
+                blocksInfo = self.phedex.getReplicaSEForBlocks(block=fileBlockNames, complete='y')
             except Exception, ex:
                 msg = "Error while getting block location from PhEDEx for block_name=%s)\n" % fileBlockName
                 msg += "%s\n" % str(ex)
@@ -596,14 +596,7 @@ class DBS3Reader:
                 return list()
 
             for name, node in blocksInfo.iteritems():
-                try:
-                    cmsname(node)
-                except AssertError:
-                    n = self.phedex.getNodeNames(node) if phedexNodes else [node]
-                else:
-                    n = [node] if phedexNodes else [self.phedex.getNodeSE(node)]
-
-                valid_nodes = set(n) - node_filter
+                valid_nodes = set([node]) - node_filter
                 if valid_nodes:  # dont add if only 'UNKNOWN' or None
                     locations[name] = list(valid_nodes)
 
@@ -742,7 +735,7 @@ class DBS3Reader:
         pathname = blocks[-1].get('dataset', None)
         return pathname
 
-    def listDatasetLocation(self, datasetName, dbsOnly = False, phedexNodes=True):
+    def listDatasetLocation(self, datasetName, dbsOnly = False):
         """
         _listDatasetLocation_
 
@@ -754,7 +747,7 @@ class DBS3Reader:
         locations=set()
         if not dbsOnly:
             try:
-                blocksInfo = self.phedex.getReplicaSEForBlocks(phedexNodes=phedexNodes, dataset=[datasetName],complete='y')
+                blocksInfo = self.phedex.getReplicaSEForBlocks(dataset=[datasetName],complete='y')
             except Exception, ex:
                 msg = "Error while getting block location from PhEDEx for dataset=%s)\n" % datasetName
                 msg += "%s\n" % str(ex)
@@ -778,13 +771,7 @@ class DBS3Reader:
                 return list()
 
             for blockInfo in blocksInfo:
-                try:
-                    cmsname(blockInfo['origin_site_name'])
-                except AssertError:
-                    n = self.phedex.getNodeNames(blockInfo['origin_site_name']) if phedexNodes else [blockInfo['origin_site_name']]
-                else:
-                    n = [blockInfo['origin_site_name']] if phedexNodes else [self.phedex.getNodeSE(blockInfo['origin_site_name'])]
-                locations.update(n)
+                locations.update([blockInfo['origin_site_name']])
 
             locations.difference_update(['UNKNOWN', None]) # remove entry when SE name is 'UNKNOWN'
 

--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -348,7 +348,7 @@ class DBS3Reader:
             raise DBSReaderError(msg % (dataset, blockName))
         if locations:
             for block in blocks:
-                block['StorageElementList'] = [{'Name' : x} for x in self.listFileBlockLocation(block['Name'])]
+                block['PhEDExNodeList'] = [{'Name' : x} for x in self.listFileBlockLocation(block['Name'])]
 
         if onlyClosedBlocks:
             return [x for x in blocks if str(x['OpenForWriting']) != "1"]
@@ -547,64 +547,69 @@ class DBS3Reader:
             raise DBSReaderError(msg)
 
 
-    def listFileBlockLocation(self, fileBlockName, dbsOnly = False, phedexNodes=False):
+    def listFileBlockLocation(self, fileBlockNames, dbsOnly = False, phedexNodes=True):
         """
         _listFileBlockLocation_
 
         Get origin_site_name of a block
 
         """
-        blockNames = [fileBlockName] if isinstance(fileBlockName, basestring) else fileBlockName
-        for block in blockNames:
+        
+        singleBlockName = None
+        if isinstance(fileBlockNames, basestring):
+            singleBlockName = fileBlockNames
+            fileBlockNames = [fileBlockNames]
+ 
+        for block in fileBlockNames:
             self.checkBlockName(block)
 
-        blockInfo = {}
+        locations = {}
+        node_filter = set(['UNKNOWN', None])
         if not dbsOnly:
             try:
-                blockInfo = self.phedex.getReplicaSEForBlocks(phedexNodes=phedexNodes, block=blockNames, complete='y')
+                blocksInfo = self.phedex.getReplicaSEForBlocks(phedexNodes=phedexNodes, block=fileBlockNames, complete='y')
             except Exception, ex:
                 msg = "Error while getting block location from PhEDEx for block_name=%s)\n" % fileBlockName
                 msg += "%s\n" % str(ex)
                 raise Exception(msg)
 
-            if not blockInfo or len(blockInfo) != len(blockNames): #if we couldnt get data location from PhEDEx, try to look into origin site location from dbs
+            for name, nodes in blocksInfo.iteritems():
+                valid_nodes = set(nodes) - node_filter
+                if valid_nodes:  # dont add if only 'UNKNOWN' or None then get with dbs
+                    locations[name] = list(valid_nodes)
+
+            fileblockNames = set(fileBlockNames) - set(locations) #get the blocks we did not find information in phedex
+            if fileblockNames:#if we couldnt get data location from PhEDEx, try to look into origin site location from dbs
                 dbsOnly = True
-                blockNames = set(blockNames) - set(blockInfo) #get the blocks we did not find information in phedex
 
         if dbsOnly:
+            blocksInfo = {}
             try:
-                for block in blockNames:
-                    res = self.dbs.listBlockOrigin(block_name = block)
-                    if res:
-                        blockInfo[block] = [res[0]['origin_site_name']]
+                for block in fileBlockNames:
+                    blocksInfo.update( dict(((block, blockInfo[0]['origin_site_name']) for blockInfo in self.dbs.listBlockOrigin(block_name = block) if blockInfo)) )
             except dbsClientException, ex:
-                msg = "Error in DBS3Reader: self.dbs.listBlockOrigin(block_name=%s)\n" % fileBlockName
+                msg = "Error in DBS3Reader: self.dbs.listBlockOrigin(block_name=%s)\n" % fileBlockNames
                 msg += "%s\n" % formatEx3(ex)
                 raise DBSReaderError(msg)
 
-            if not any(blockInfo.values()): # no data location from dbs
+            if not blocksInfo: # no data location from dbs
                 return list()
 
-        #removing duplicates and 'UNKNOWN entries
-        locations = {}
-        node_filter_list = set(['UNKNOWN', None])
-        for name, nodes in blockInfo.iteritems():
-            final_nodes = set()
-            for n in nodes:
-                if n in node_filter_list:
-                    continue
+            for name, node in blocksInfo.iteritems():
                 try:
-                    cmsname(n)
-                except AssertionError: ## is SE
-                    n = self.phedex.getNodeNames(n) if phedexNodes else [n]
-                else:  ## not SE i.e. phedexNode
-                    n = [self.phedex.getNodeSE(n)] if not phedexNodes else [n]
-                final_nodes = final_nodes.union(n)
-            locations[name] = list(final_nodes - node_filter_list)
+                    cmsname(node)
+                except AssertError:
+                    n = self.phedex.getNodeNames(node) if phedexNodes else [node]
+                else:
+                    n = [node] if phedexNodes else [self.phedex.getNodeSE(node)]
+
+                valid_nodes = set(n) - node_filter
+                if valid_nodes:  # dont add if only 'UNKNOWN' or None
+                    locations[name] = list(valid_nodes)
 
         #returning single list if a single block is passed
-        if isinstance(fileBlockName, basestring):
-            locations = locations[fileBlockName]
+        if singleBlockName is not None:
+            return locations[singleBlockName]
 
         return locations
 
@@ -614,7 +619,7 @@ class DBS3Reader:
 
         return a dictionary:
         { blockName: {
-             "StorageElements" : [<se list>],
+             "PhEDExNodeNames" : [<pnn list>],
              "Files" : { LFN : Events },
              }
         }
@@ -626,7 +631,7 @@ class DBS3Reader:
             raise DBSReaderError(msg % fileBlockName)
 
         result = { fileBlockName: {
-            "StorageElements" : self.listFileBlockLocation(fileBlockName),
+            "PhEDExNodeNames" : self.listFileBlockLocation(fileBlockName),
             "Files" : self.listFilesInBlock(fileBlockName),
             "IsOpen" : self.blockIsOpen(fileBlockName),
 
@@ -640,7 +645,7 @@ class DBS3Reader:
 
         return a dictionary:
         { blockName: {
-             "StorageElements" : [<se list>],
+             "PhEDExNodeNames" : [<pnn list>],
              "Files" : dictionaries representing each file
              }
         }
@@ -653,7 +658,7 @@ class DBS3Reader:
             raise DBSReaderError(msg % fileBlockName)
 
         result = { fileBlockName: {
-            "StorageElements" : self.listFileBlockLocation(fileBlockName),
+            "PhEDExNodeNames" : self.listFileBlockLocation(fileBlockName),
             "Files" : self.listFilesInBlockWithParents(fileBlockName),
             "IsOpen" : self.blockIsOpen(fileBlockName),
 
@@ -668,7 +673,7 @@ class DBS3Reader:
         _getFiles_
 
         Returns a dictionary of block names for the dataset where
-        each block constists of a dictionary containing the StorageElements
+        each block constists of a dictionary containing the PhEDExNodeNames
         for that block and the files in that block by LFN mapped to NEvents
 
         """
@@ -687,7 +692,7 @@ class DBS3Reader:
         blocks = self.dbs.listBlockParents(block_name = blockName)
         for block in blocks:
             toreturn = {'Name' : block['parent_block_name']}
-            toreturn['StorageElementList'] = self.listFileBlockLocation(toreturn['Name'])
+            toreturn['PhEDExNodeList'] = self.listFileBlockLocation(toreturn['Name'])
             result.append(toreturn)
         return result
 
@@ -737,7 +742,7 @@ class DBS3Reader:
         pathname = blocks[-1].get('dataset', None)
         return pathname
 
-    def listDatasetLocation(self, datasetName, dbsOnly = False):
+    def listDatasetLocation(self, datasetName, dbsOnly = False, phedexNodes=True):
         """
         _listDatasetLocation_
 
@@ -746,9 +751,10 @@ class DBS3Reader:
         """
         self.checkDatasetPath(datasetName)
 
+        locations=set()
         if not dbsOnly:
             try:
-                blocksInfo = self.phedex.getReplicaSEForBlocks(dataset=[datasetName],complete='y')
+                blocksInfo = self.phedex.getReplicaSEForBlocks(phedexNodes=phedexNodes, dataset=[datasetName],complete='y')
             except Exception, ex:
                 msg = "Error while getting block location from PhEDEx for dataset=%s)\n" % datasetName
                 msg += "%s\n" % str(ex)
@@ -757,9 +763,8 @@ class DBS3Reader:
             if not blocksInfo: # if we couldnt get data location from PhEDEx, try to look into origin site location from dbs
                 dbsOnly = True
             else:
-                locations = set(blocksInfo.values()[0])
                 for blockSites in blocksInfo.values():
-                    locations.intersection_update(blockSites)
+                    locations.update(blockSites)
 
         if dbsOnly:
             try:
@@ -772,11 +777,16 @@ class DBS3Reader:
             if not blocksInfo: # no data location from dbs
                 return list()
 
-            locations = set()
             for blockInfo in blocksInfo:
-                locations.update([blockInfo['origin_site_name']])
+                try:
+                    cmsname(blockInfo['origin_site_name'])
+                except AssertError:
+                    n = self.phedex.getNodeNames(blockInfo['origin_site_name']) if phedexNodes else [blockInfo['origin_site_name']]
+                else:
+                    n = [blockInfo['origin_site_name']] if phedexNodes else [self.phedex.getNodeSE(blockInfo['origin_site_name'])]
+                locations.update(n)
 
-            locations.difference_update(['UNKNOWN']) # remove entry when SE name is 'UNKNOWN'
+            locations.difference_update(['UNKNOWN', None]) # remove entry when SE name is 'UNKNOWN'
 
         return list(locations)
 

--- a/src/python/WMCore/Services/PhEDEx/PhEDEx.py
+++ b/src/python/WMCore/Services/PhEDEx/PhEDEx.py
@@ -475,7 +475,7 @@ class PhEDEx(Service):
                                 injectedFiles.append(fileInfo['lfn'])
         return injectedFiles
     
-    def getReplicaSEForBlocks(self, phedexNodes=False, **kwargs):
+    def getReplicaSEForBlocks(self, phedexNodes=True, **kwargs):
         """
         _blockreplicasSE_
 

--- a/src/python/WMCore/WMBSFeeder/DBS/Feeder.py
+++ b/src/python/WMCore/WMBSFeeder/DBS/Feeder.py
@@ -119,7 +119,7 @@ class Feeder(FeederImpl):
         # process all file blocks
         for fileBlock in blockList:
 
-            seList = blocks[fileBlock]['StorageElements']
+            seList = blocks[fileBlock]['PhEDExNodeNames']
 
             # add files for non blocked SE
             if seList is None or seList == []:

--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -420,7 +420,7 @@ class SetupCMSSWPset(ScriptInterface):
                     eventsAvailable = 0
                     for blockName in sorted(pileupDict[pileupType].keys()):
                         blockDict = pileupDict[pileupType][blockName]
-                        if seLocalName in blockDict["StorageElementNames"]:
+                        if seLocalName in blockDict["PhEDExNodeNames"]:
                             eventsAvailable += int(blockDict.get('NumberOfEvents', 0))
                             for fileLFN in blockDict["FileList"]:
                                 inputTypeAttrib.fileNames.append(str(fileLFN))

--- a/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
+++ b/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
@@ -31,8 +31,8 @@ class PileupFetcher(FetcherInterface):
         the result data structure is a Python dict following dictionary:
             FileList is a list of LFNs
 
-        {"pileupTypeA": {"BlockA": {"FileList": [], "StorageElementNames": []},
-                         "BlockB": {"FileList": [], "StorageElementName": []}, ....}
+        {"pileupTypeA": {"BlockA": {"FileList": [], "PhEDExNodeNames": []},
+                         "BlockB": {"FileList": [], "PhEDExNodeName": []}, ....}
 
         this structure preserves knowledge of where particular files of data
         set are physically (list of SEs) located. DBS only lists sites which
@@ -54,7 +54,7 @@ class PileupFetcher(FetcherInterface):
                 # iterate over and query each block to get list of files
                 for dbsBlockName in blockNames:
                     blockDict[dbsBlockName] = {"FileList": sorted(dbsReader.lfnsInBlock(dbsBlockName)),
-                                               "StorageElementNames": dbsReader.listFileBlockLocation(dbsBlockName),
+                                               "PhEDExNodeNames": dbsReader.listFileBlockLocation(dbsBlockName),
                                                "NumberOfEvents" : dbsReader.getDBSSummaryInfo(block = dbsBlockName)['NumberOfEvents']}
             resultDict[pileupType] = blockDict
         return resultDict

--- a/src/python/WMCore/WorkQueue/DataLocationMapper.py
+++ b/src/python/WMCore/WorkQueue/DataLocationMapper.py
@@ -141,11 +141,11 @@ class DataLocationMapper():
         for item in dataItems:
             try:
                 if datasetSearch:
-                    seNames = dbs.listDatasetLocation(item, dbsOnly = True)
+                    phedexNodeNames = dbs.listDatasetLocation(item, dbsOnly = True)
                 else:
-                    seNames = dbs.listFileBlockLocation(item, dbsOnly = True)
-                for se in seNames:
-                    result[item].update(self.sitedb.seToCMSName(se))
+                    phedexNodeNames = dbs.listFileBlockLocation(item, dbsOnly = True)
+                for pnn in phedexNodeNames:
+                    result[item].update(pnn)
             except Exception, ex:
                 logging.error('Error getting block location from dbs for %s: %s' % (item, str(ex)))
 

--- a/src/python/WMCore/WorkQueue/Policy/Start/Block.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Block.py
@@ -44,7 +44,7 @@ class Block(StartPolicyInterface):
                     if self.initialTask.inputLocationFlag():
                         parentList[dbsBlock["Name"]] = self.sites
                     else:
-                        parentList[dbsBlock["Name"]] = sitesFromStorageEelements(dbsBlock['StorageElementList'])
+                        parentList[dbsBlock["Name"]] = sitesFromStorageEelements(dbsBlock['PhEDExNodeList'])
 
             self.newQueueElement(Inputs = {block['block'] : self.data.get(block['block'], [])},
                                  ParentFlag = parentFlag,
@@ -185,7 +185,7 @@ class Block(StartPolicyInterface):
             if task.inputLocationFlag():
                 self.data[block['block']] = self.sites
             else:
-                self.data[block['block']] = sitesFromStorageEelements(dbs.listFileBlockLocation(block['block']))
+                self.data[block['block']] = dbs.listFileBlockLocation(block['block'])
 
             # TODO: need to decide what to do when location is no find.
             # There could be case for network problem (no connection to dbs, phedex)

--- a/src/python/WMCore/WorkQueue/Policy/Start/Dataset.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Dataset.py
@@ -161,9 +161,9 @@ class Dataset(StartPolicyInterface):
 
             validBlocks.append(block)
             if locations is None:
-                locations = set(sitesFromStorageEelements(dbs.listFileBlockLocation(block['block'])))
+                locations = set(dbs.listFileBlockLocation(block['block']))
             else:
-                locations = locations.intersection(set(sitesFromStorageEelements(dbs.listFileBlockLocation(block['block']))))
+                locations = locations.intersection(dbs.listFileBlockLocation(block['block']))
             
             if self.wmspec.locationDataSourceFlag():
                 locations = locations.union(siteWhiteList)

--- a/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
@@ -198,6 +198,6 @@ class StartPolicyInterface(PolicyInterface):
         for dbsUrl in datasets:
             dbs = self.dbs(dbsUrl)
             for datasetPath in datasets[dbsUrl]:
-                locations = sitesFromStorageEelements(dbs.listDatasetLocation(datasetPath))
+                locations = dbs.listDatasetLocation(datasetPath)
                 result[datasetPath] = locations
         return result

--- a/src/python/WMCore/WorkQueue/WMBSHelper.py
+++ b/src/python/WMCore/WorkQueue/WMBSHelper.py
@@ -439,7 +439,7 @@ class WMBSHelper(WMConnectionBase):
         else:
             self.isDBS = True
             for dbsFile in self.validFiles(block['Files']):
-                self._addDBSFileToWMBSFile(dbsFile, block['StorageElements'])
+                self._addDBSFileToWMBSFile(dbsFile, block['PhEDExNodeNames'])
 
 
         # Add files to WMBS

--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -356,13 +356,12 @@ class WorkQueue(WorkQueueBase):
             block = {}
             block["Files"] = fileLists
             if wmspec.locationDataSourceFlag():
-                seElements = []
-                for cmsSite in match['Inputs'].values()[0]: #TODO: Allow more than one
-                    ses = self.SiteDB.cmsNametoSE(cmsSite)
-                    seElements.extend(ses)
-                seElements = list(set(seElements))
+                PhEDExNodeNames = []
+                for pnn in match['Inputs'].values()[0]: #TODO: Allow more than one
+                    PhEDExNodeNames.extend(pnn)
+                PhEDExNodeNames = list(set(PhEDExNodeNames))
                 for fileInfo in block["Files"]:
-                    fileInfo['locations'] = seElements
+                    fileInfo['locations'] = PhEDExNodeNames
             return blockName, block
         else:
             dbs = get_dbs(match['Dbs'])
@@ -373,12 +372,11 @@ class WorkQueue(WorkQueueBase):
 
             if wmspec.locationDataSourceFlag():
                 blockInfo = dbsBlockDict[blockName]
-                seElements = []
-                for cmsSite in match['Inputs'].values()[0]: #TODO: Allow more than one
-                    ses = self.SiteDB.cmsNametoSE(cmsSite)
-                    seElements.extend(ses)
-                seElements = list(set(seElements))
-                blockInfo['StorageElements'] = seElements
+                PhEDExNodeNames = []
+                for pnn in match['Inputs'].values()[0]: #TODO: Allow more than one
+                    PhEDExNodeNames.extend(pnn)
+                PhEDExNodeNames = list(set(PhEDExNodeNames))
+                blockInfo['PhEDExNodeNames'] = PhEDExNodeNames
         return blockName, dbsBlockDict[blockName]
 
     def _wmbsPreparation(self, match, wmspec, blockName, dbsBlock):

--- a/src/python/WMQuality/Emulators/DBSClient/DBS3Reader.py
+++ b/src/python/WMQuality/Emulators/DBSClient/DBS3Reader.py
@@ -123,7 +123,7 @@ class DBS3Reader:
                 raise DBSReaderError('DbsBadRequest: DBS Server Raised An Error')
         if locations:
             for block in blocks:
-                block['StorageElementList'] = [{'Role' : '', 'Name' : x} for x in \
+                block['PhEDExNodeList'] = [{'Role' : '', 'Name' : x} for x in \
                                                self.listFileBlockLocation(block['Name'])]
         return blocks
 
@@ -168,7 +168,7 @@ class DBS3Reader:
     def getFileBlock(self, block):
         """Return block + locations"""
         result = { block : {
-            "StorageElements" : self.listFileBlockLocation(block),
+            "PhEDExNodeNames" : self.listFileBlockLocation(block),
             "Files" : self.listFilesInBlock(block),
             "IsOpen" : self.dataBlocks._openForWriting(),
             }
@@ -181,7 +181,7 @@ class DBS3Reader:
 
         return a dictionary:
         { blockName: {
-             "StorageElements" : [<se list>],
+             "PhEDExNodeNames" : [<pnn list>],
              "Files" : dictionaries representing each file
              }
         }
@@ -191,7 +191,7 @@ class DBS3Reader:
         """
 
         result = { fileBlockName: {
-            "StorageElements" : self.listFileBlockLocation(fileBlockName),
+            "PhEDExNodeNames" : self.listFileBlockLocation(fileBlockName),
             "Files" : self.listFilesInBlockWithParents(fileBlockName),
             "IsOpen" : self.dataBlocks._openForWriting(),
 
@@ -318,7 +318,7 @@ class DBS3Reader:
 
         result = set()
         for block in blocks:
-            result |= set([x['Name'] for x in block['StorageElementList']])
+            result |= set([x['Name'] for x in block['PhEDExNodeList']])
 
         return list(result)
 

--- a/src/python/WMQuality/Emulators/DBSClient/DBSReader.py
+++ b/src/python/WMQuality/Emulators/DBSClient/DBSReader.py
@@ -63,7 +63,7 @@ class DBSReader:
                 raise DBSReaderError('DbsBadRequest: DBS Server Raised An Error')
         if locations:
             for block in blocks:
-                block['StorageElementList'] = [{'Role' : '', 'Name' : x} for x in \
+                block['PhEDExNodeList'] = [{'Role' : '', 'Name' : x} for x in \
                                                self.listFileBlockLocation(block['Name'])]
         return blocks
 
@@ -108,7 +108,7 @@ class DBSReader:
     def getFileBlock(self, block):
         """Return block + locations"""
         result = { block : {
-            "StorageElements" : self.listFileBlockLocation(block),
+            "PhEDExNodeNames" : self.listFileBlockLocation(block),
             "Files" : self.listFilesInBlock(block),
             "IsOpen" : self.dataBlocks._openForWriting(),
             }
@@ -121,7 +121,7 @@ class DBSReader:
 
         return a dictionary:
         { blockName: {
-             "StorageElements" : [<se list>],
+             "PhEDExNodeNames" : [<pnn list>],
              "Files" : dictionaries representing each file
              }
         }
@@ -131,7 +131,7 @@ class DBSReader:
         """
 
         result = { fileBlockName: {
-            "StorageElements" : self.listFileBlockLocation(fileBlockName),
+            "PhEDExNodeNames" : self.listFileBlockLocation(fileBlockName),
             "Files" : self.listFilesInBlockWithParents(fileBlockName),
             "IsOpen" : self.dataBlocks._openForWriting(),
 
@@ -235,7 +235,7 @@ class DBSReader:
 
         result = set()
         for block in blocks:
-            result |= set([x['Name'] for x in block['StorageElementList']])
+            result |= set([x['Name'] for x in block['PhEDExNodeList']])
 
         return list(result)
 

--- a/src/python/WMQuality/Emulators/DataBlockGenerator/DataBlockGenerator.py
+++ b/src/python/WMQuality/Emulators/DataBlockGenerator/DataBlockGenerator.py
@@ -49,7 +49,7 @@ class DataBlockGenerator(object):
                            'NumberOfFiles' : GlobalParams.numOfFilesPerBlock(),
                            'NumberOfLumis' : GlobalParams.numOfLumisPerBlock(),
                            'Size' : size,
-                           'StorageElementList' : self.getLocation(blockName),
+                           'PhEDExNodeList' : self.getLocation(blockName),
                            'Parents' : ()}
                            )
         return blocks

--- a/src/python/WMQuality/Emulators/DataBlockGenerator/DataBlockGenerator3.py
+++ b/src/python/WMQuality/Emulators/DataBlockGenerator/DataBlockGenerator3.py
@@ -49,7 +49,7 @@ class DataBlockGenerator3(object):
                            'NumberOfFiles' : GlobalParams.numOfFilesPerBlock(),
                            'NumberOfLumis' : GlobalParams.numOfLumisPerBlock(),
                            'Size' : size,
-                           'StorageElementList' : self.getLocation(blockName),
+                           'PhEDExNodeList' : self.getLocation(blockName),
                            'Parents' : ()}
                            )
         return blocks


### PR DESCRIPTION
@ticoann @ericvaandering 
this fixes issue #5264
Cleaning up and removing the ability to listBlockLocations by SE as should all be by PNN now. This obviously has to be merged after we are happy with all the other changes but since it's a quick one I did it now.

Note: I left the ability for the getReplicaSEForBlocks API from the PhEDEx service to return SEs incase it might be needed in the future but this is not used now in the DBS3Reade.
