### PR TITLE
do not enforce data type for producer nEvents

### DIFF
--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -486,8 +486,7 @@ class SetupCMSSWPset(ScriptInterface):
         producers.update(self.process.producers)
         for producer in producers:
             if hasattr(producers[producer], "nEvents"):
-                producers[producer].nEvents = cms.uint32(
-                                        self.process.maxEvents.input.value())
+                producers[producer].nEvents = self.process.maxEvents.input.value()
 
     def handleDQMFileSaver(self):
         """


### PR DESCRIPTION
Stop forcing nEvents type for LHEProducer. Should fix the issues discussed in this HN
https://hypernews.cern.ch/HyperNews/CMS/get/wmDevelopment/642.html

@ticoann , is this also called when a configcacheID is injected into couch? If so, I need to
test it tomorrow.
