### PR TITLE
protects when condor returns undefined; properly rollback transaction

### DIFF
--- a/src/python/WMCore/BossAir/BossAirAPI.py
+++ b/src/python/WMCore/BossAir/BossAirAPI.py
@@ -544,22 +544,23 @@ class BossAirAPI(WMConnectionBase):
                 jobsToReturn.extend(localRunning)
                 jobsToChange.extend(localChanges)
                 jobsToComplete.extend(localCompletes)
-                logging.debug("Changing/completing %i/%i jobs in plugin %s.\n" % (len(localChanges),
-                                                                                  len(localCompletes),
-                                                                                  plugin))
+                logging.info("Running/changing/completing %i/%i/%i jobs in plugin %s.\n" % (len(localRunning),
+                                                                                            len(localChanges),
+                                                                                            len(localCompletes),
+                                                                                            plugin))
             except WMException:
                 raise
             except Exception, ex:
-                msg =  "Unhandled Exception while tracking jobs for plugin %s!\n" % plugin
+                msg =  "Unhandled exception while tracking jobs for plugin %s!\n" % plugin
                 msg += str(ex)
                 logging.error(msg)
                 logging.debug("JobsToTrack: %s" % (jobsToTrack[plugin]))
                 raise BossAirException(msg)
 
-        logging.info("About to change %i jobs\n" % len(jobsToChange))
-        logging.debug("JobsToChange: %s" % jobsToChange)
-        logging.info("About to complete %i jobs\n" % len(jobsToComplete))
-        logging.debug("JobsToComplete: %s" % jobsToComplete)
+        logging.info("About to change %i jobs" % len(jobsToChange))
+        logging.debug("JobsToChange: %s\n" % jobsToChange)
+        logging.info("About to complete %i jobs" % len(jobsToComplete))
+        logging.debug("JobsToComplete: %s\n" % jobsToComplete)
 
         self._updateJobs(jobs = jobsToChange)
         self._complete(jobs = jobsToComplete)

--- a/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
@@ -577,7 +577,11 @@ class CondorPlugin(BasePlugin):
                     completeList.append(job)
             else:
                 jobAd     = jobInfo.get(job['jobid'])
-                jobStatus = int(jobAd.get('JobStatus', 0))
+                try:
+                    # sometimes it returns 'undefined' (probably over high load)
+                    jobStatus = int(jobAd.get('JobStatus', 0))
+                except ValueError, ex:
+                    jobStatus = 0  # unknown
                 statName  = 'Unknown'
                 if jobStatus == 1:
                     # Job is Idle, waiting for something to happen
@@ -611,15 +615,24 @@ class CondorPlugin(BasePlugin):
                 #Check if we have a valid status time
                 if not job['status_time']:
                     if job['status'] == 'Running':
-                        job['status_time'] = int(jobAd.get('runningTime', 0))
+                        try:
+                            job['status_time'] = int(jobAd.get('runningTime', 0))
+                        except ValueError, ex:
+                            job['status_time'] = 0
                         # If we transitioned to running then check the site we are running at
                         job['location'] = jobAd.get('runningCMSSite', None)
                         if job['location'] is None:
                             logging.debug('Something is not right here, a job (%s) is running with no CMS site' % str(jobAd))
                     elif job['status'] == 'Idle':
-                        job['status_time'] = int(jobAd.get('submitTime', 0))
+                        try:
+                            job['status_time'] = int(jobAd.get('submitTime', 0))
+                        except ValueError, ex:
+                            job['status_time'] = 0
                     else:
-                        job['status_time'] = int(jobAd.get('stateTime', 0))
+                        try:
+                            job['status_time'] = int(jobAd.get('stateTime', 0))
+                        except ValueError, ex:
+                            job['status_time'] = 0
                     changeList.append(job)
 
                 runningList.append(job)

--- a/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
@@ -582,7 +582,11 @@ class PyCondorPlugin(BasePlugin):
                     completeList.append(job)
             else:
                 jobAd     = jobInfo.get(job['jobid'])
-                jobStatus = int(jobAd.get('JobStatus', 0))
+                try:
+                    # sometimes it returns 'undefined' (probably over high load)
+                    jobStatus = int(jobAd.get('JobStatus', 0))
+                except ValueError, ex:
+                    jobStatus = 0  # unknown
                 statName  = 'Unknown'
                 if jobStatus == 1:
                     # Job is Idle, waiting for something to happen
@@ -616,15 +620,24 @@ class PyCondorPlugin(BasePlugin):
                 #Check if we have a valid status time
                 if not job['status_time']:
                     if job['status'] == 'Running':
-                        job['status_time'] = int(jobAd.get('runningTime', 0))
+                        try:
+                            job['status_time'] = int(jobAd.get('runningTime', 0))
+                        except ValueError, ex:
+                            job['status_time'] = 0
                         # If we transitioned to running then check the site we are running at
                         job['location'] = jobAd.get('runningCMSSite', None)
                         if job['location'] is None:
                             logging.debug('Something is not right here, a job (%s) is running with no CMS site' % str(jobAd))
                     elif job['status'] == 'Idle':
-                        job['status_time'] = int(jobAd.get('submitTime', 0))
+                        try:
+                            job['status_time'] = int(jobAd.get('submitTime', 0))
+                        except ValueError, ex:
+                            job['status_time'] = 0
                     else:
-                        job['status_time'] = int(jobAd.get('stateTime', 0))
+                        try:
+                            job['status_time'] = int(jobAd.get('stateTime', 0))
+                        except ValueError, ex:
+                            job['status_time'] = 0
                     changeList.append(job)
 
                 runningList.append(job)

--- a/src/python/WMCore/BossAir/StatusPoller.py
+++ b/src/python/WMCore/BossAir/StatusPoller.py
@@ -64,7 +64,7 @@ class StatusPoller(BaseWorkerThread):
         try:
             self.checkStatus()
         except WMException, ex:
-            if getattr(myThread.transaction, None):
+            if getattr(myThread, 'transaction', None):
                 myThread.transaction.rollbackForError()
             self.sendAlert(6, msg = str(ex))
             raise


### PR DESCRIPTION
Replaces #5296 PR in a not so intrusive way.
- JobStatusLite won't crash when (py)condor plugin returns 'undefined'
- Properly rollback the transaction

@ticoann please review 
