### PR TITLE
support a connect string passed with global tag

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -121,13 +121,18 @@ class PromptRecoWorkloadFactory(StdBase):
                                   'moduleLabel' : "write_%s" % dataTier } )
 
         recoTask = workload.newTask("Reco")
+
+        scenarioArgs = { 'globalTag' : self.globalTag,
+                         'skims' : self.alcaSkims,
+                         'dqmSeq' : self.dqmSequences,
+                         'outputs' : recoOutputs }
+        if self.globalTagConnect:
+            scenarioArgs['globalTagConnect'] = self.globalTagConnect
+
         recoOutMods = self.setupProcessingTask(recoTask, taskType, self.inputDataset,
                                                scenarioName = self.procScenario,
                                                scenarioFunc = "promptReco",
-                                               scenarioArgs = { 'globalTag' : self.globalTag,
-                                                                'skims' : self.alcaSkims,
-                                                                'dqmSeq' : self.dqmSequences,
-                                                                'outputs' : recoOutputs },
+                                               scenarioArgs = scenarioArgs,
                                                splitAlgo = self.procJobSplitAlgo,
                                                splitArgs = self.procJobSplitArgs,
                                                stepType = cmsswStepType,
@@ -144,14 +149,19 @@ class PromptRecoWorkloadFactory(StdBase):
 
             else:
                 alcaTask = recoTask.addTask("AlcaSkim")
+
+                scenarioArgs = { 'globalTag' : self.globalTag,
+                                 'skims' : self.alcaSkims,
+                                 'primaryDataset' : self.inputPrimaryDataset }
+                if self.globalTagConnect:
+                    scenarioArgs['globalTagConnect'] = self.globalTagConnect
+
                 alcaOutMods = self.setupProcessingTask(alcaTask, taskType,
                                                        inputStep = recoTask.getStep("cmsRun1"),
                                                        inputModule = recoOutLabel,
                                                        scenarioName = self.procScenario,
                                                        scenarioFunc = "alcaSkim",
-                                                       scenarioArgs = { 'globalTag' : self.globalTag,
-                                                                        'skims' : self.alcaSkims,
-                                                                        'primaryDataset' : self.inputPrimaryDataset },
+                                                       scenarioArgs = scenarioArgs,
                                                        splitAlgo = "WMBSMergeBySize",
                                                        splitArgs = {"max_merge_size": self.maxMergeSize,
                                                                     "min_merge_size": self.minMergeSize,
@@ -275,10 +285,10 @@ class PromptRecoWorkloadFactory(StdBase):
     @staticmethod
     def getWorkloadArguments():
         baseArgs = StdBase.getWorkloadArguments()
-        specArgs = {"Scenario" : {"default" : "pp", "type" : str,
+        specArgs = {"Scenario" : {"default" : None, "type" : str,
                                   "optional" : False, "validate" : None,
                                   "attr" : "procScenario", "null" : False},
-                    "GlobalTag" : {"default" : "GR_P_V29::All", "type" : str,
+                    "GlobalTag" : {"default" : None, "type" : str,
                                    "optional" : False, "validate" : None,
                                    "attr" : "globalTag", "null" : False},
                     "WriteTiers" : {"default" : ["RECO", "AOD", "DQM", "ALCARECO"],

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -636,19 +636,17 @@ class StdBase(object):
                 harvestTaskCmsswHelper.setConfigCache(self.couchURL, self.dqmConfigCacheID, self.couchDBName)
             harvestTaskCmsswHelper.setDatasetName(datasetName)
         else:
+            scenarioArgs = { 'globalTag' : self.globalTag,
+                             'datasetName' : datasetName,
+                             'runNumber' : self.runNumber,
+                             'dqmSeq' : self.dqmSequences }
+            if self.globalTagConnect:
+                scenarioArgs['globalTagConnect'] = self.globalTagConnect
             if getattr(parentOutputModule, "dataTier") == "DQMIO":
-                harvestTaskCmsswHelper.setDataProcessingConfig(self.procScenario, "dqmHarvesting",
-                                                               globalTag = self.globalTag,
-                                                               datasetName = datasetName,
-                                                               runNumber = self.runNumber,
-                                                               dqmSeq = self.dqmSequences,
-                                                               newDQMIO = True)
-            else:
-                harvestTaskCmsswHelper.setDataProcessingConfig(self.procScenario, "dqmHarvesting",
-                                                               globalTag = self.globalTag,
-                                                               datasetName = datasetName,
-                                                               runNumber = self.runNumber,
-                                                               dqmSeq = self.dqmSequences)
+                scenarioArgs['newDQMIO'] = True
+            harvestTaskCmsswHelper.setDataProcessingConfig(self.procScenario,
+                                                           "dqmHarvesting",
+                                                           **scenarioArgs)
 
         harvestTaskUploadHelper = harvestTaskUpload.getTypeHelper()
         harvestTaskUploadHelper.setProxyFile(uploadProxy)
@@ -844,6 +842,12 @@ class StdBase(object):
                      "CMSSWVersion" : {"default" : "CMSSW_5_3_7", "validate" : cmsswversion,
                                        "optional" : False, "attr" : "frameworkVersion"},
                      "ScramArch" : {"default" : "slc5_amd64_gcc462", "optional" : False},
+                     "GlobalTag" : {"default" : None, "type" : str,
+                                    "optional" : True, "validate" : None,
+                                    "attr" : "globalTag", "null" : True},
+                     "GlobalTagConnect" : {"default" : None, "type" : str,
+                                           "optional" : True, "validate" : None,
+                                           "attr" : "globalTagConnect", "null" : True},
                      "ProcessingVersion" : {"default" : 0, "attr" : "processingVersion",
                                             "type" : int},
                      "ProcessingString" : {"default" : None, "attr" : "processingString",


### PR DESCRIPTION
Requires changes in StdBase and PromptReco. Should be transparent if no connect string is used.

@ticoann , please review, especially the changes made to StdBase. I added an optional GlobalTag and GlobalTagConnect parameter, as they are referenced on the code (so they should also be defined there). They are optional though, other specs can re-declare them as mandatory (as they already should as the GlobalTag parameter wasn't previously define in StdBase at all).

PS: This is deployed in the production Tier0 since an hour ago.
