### PR TITLE
Convert MCFakeFile lfn from unicode to string

### DIFF
--- a/src/python/WMCore/WorkQueue/WMBSHelper.py
+++ b/src/python/WMCore/WorkQueue/WMBSHelper.py
@@ -365,7 +365,7 @@ class WMBSHelper(WMConnectionBase):
                 self.logger.error('Error getting storage element for "%s": %s' % (site, str(ex)))
         if not locations:
             raise RuntimeError, "No locations to inject Monte Carlo work to, unable to proceed"
-        mcFakeFileName = "MCFakeFile-%s" % self.topLevelFileset.name
+        mcFakeFileName = ("MCFakeFile-%s" % self.topLevelFileset.name).encode('ascii', 'ignore')
         wmbsFile = File(lfn = mcFakeFileName,
                         first_event = self.mask['FirstEvent'],
                         last_event = self.mask['LastEvent'],


### PR DESCRIPTION
As reported on this elog:
https://cms-logbook.cern.ch/elog/Workflow+processing/17434

WorkQueueManager is complaining in all the MC agents (but not reproc). 
Since the try/except block encapsulates lots of calls, the debugging was a bit tricky but in the end it maps to this call
https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/WMBS/File.py#L619
which makes this SQL call
https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/WMBS/MySQL/Files/AddRunLumi.py#L27

Maybe this convertion should be done in the latter file instead?
