### PR TITLE
Fix TaskChain job splitting when KeepOutput used

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
@@ -356,14 +356,13 @@ class TaskChainWorkloadFactory(StdBase):
             if not inputTaskConf["KeepOutput"] or len(inputTaskConf["TransientOutputModules"]) > 0:
                 inpMod = taskConf["InputFromOutputModule"]
                 # Check if the splitting has to be changed
-                # Lines below commented out to fix #5007 (by Alan M. on 03/Nov/2014 
-                #if inputTaskConf["SplittingAlgo"] == 'EventBased' \
-                #   and (('InputDataset' in inputTaskConf) or ('InputTask' in inputTaskConf)):
-                #    splitAlgorithm = 'WMBSMergeBySize'
-                #    splitArguments = {'max_merge_size'   : self.maxMergeSize,
-                #                      'min_merge_size'   : self.minMergeSize,
-                #                      'max_merge_events' : self.maxMergeEvents,
-                #                      'max_wait_time'    : self.maxWaitTime}
+                if inputTaskConf["SplittingAlgo"] == 'EventBased' \
+                   and (inputTaskConf["InputDataset"] or inputTaskConf["InputTask"]):
+                    splitAlgorithm = 'WMBSMergeBySize'
+                    splitArguments = {'max_merge_size'   : self.maxMergeSize,
+                                      'min_merge_size'   : self.minMergeSize,
+                                      'max_merge_events' : self.maxMergeEvents,
+                                      'max_wait_time'    : self.maxWaitTime}
             else:
                 inpMod = "Merged"
 
@@ -381,8 +380,8 @@ class TaskChainWorkloadFactory(StdBase):
                                               couchDBName = couchDB,
                                               configCacheUrl = self.configCacheUrl,
                                               configDoc = configCacheID,
-                                              splitAlgo = splitAlgorithm,
-                                              splitArgs = splitArguments,
+                                              splitAlgo = taskConf["SplittingAlgo"],
+                                              splitArgs = taskConf["SplittingArguments"],
                                               stepType = cmsswStepType,
                                               forceUnmerged = forceUnmerged,
                                               timePerEvent = self.timePerEvent,


### PR DESCRIPTION
@ticoann , this is what we've discussed on Friday (fix for #5450 and #5007):
1. really fix the if statement (the key was always there, now we check it's not None)
2. do not use WMBSMergeBySize algo for processing task
   I ran another test in my VM and looks good to go. Thanks!
