### PR TITLE
Enable tier0 status for the resource control updater

### DIFF
--- a/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
+++ b/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
@@ -240,10 +240,11 @@ class ResourceControlUpdater(BaseWorkerThread):
                 if not status: 
                     logging.error('Site %s does not have status in SSB' % voname) 
                     continue
-                if not self.getState(str(status)):
+                new_status = self.getState(str(status))
+                if not new_status:
                     logging.error("Unkwown status '%s' for site %s, please check SSB" % (str(status), voname))
                     continue
-                statusBySite[voname] = self.getState(str(status))
+                statusBySite[voname] = new_status
             else:
                 logging.error('I have a duplicated status entry in SSB for %s' % voname) 
         return statusBySite
@@ -258,6 +259,12 @@ class ResourceControlUpdater(BaseWorkerThread):
             return "Normal"
         elif stateFromSSB == "drain":
             return "Draining"
+        elif stateFromSSB == "tier0":
+            logging.debug('There is a site in tier0 status (Tier0Mode is %s)' % self.tier0Mode )
+            if self.tier0Mode: 
+                return "Normal"
+            else:
+                return "Draining"
         elif stateFromSSB == "down":
             return "Down"
         elif stateFromSSB == "skip":


### PR DESCRIPTION
ResourceControlUpdater will accept the 'tier0' status. That status means that a site will only be used by the agent if the agent is a tier0 instance.
