### PR TITLE
increases column sizes for TaskChain stuff

### DIFF
--- a/src/python/WMCore/WMBS/CreateWMBSBase.py
+++ b/src/python/WMCore/WMBS/CreateWMBSBase.py
@@ -66,7 +66,7 @@ class CreateWMBSBase(DBCreator):
         self.create["01wmbs_fileset"] = \
           """CREATE TABLE wmbs_fileset (
              id          INTEGER      PRIMARY KEY AUTO_INCREMENT,
-             name        VARCHAR(500) NOT NULL,
+             name        VARCHAR(700) NOT NULL,
              open        INT(1)       NOT NULL DEFAULT 0,
              last_update INTEGER      NOT NULL,
              UNIQUE (name))"""
@@ -74,7 +74,7 @@ class CreateWMBSBase(DBCreator):
         self.create["02wmbs_file_details"] = \
           """CREATE TABLE wmbs_file_details (
              id           INTEGER      PRIMARY KEY AUTO_INCREMENT,
-             lfn          VARCHAR(500) NOT NULL,
+             lfn          VARCHAR(700) NOT NULL,
              filesize     BIGINT,
              events       INTEGER,
              first_event  BIGINT       NOT NULL DEFAULT 0,
@@ -285,8 +285,8 @@ class CreateWMBSBase(DBCreator):
              couch_record VARCHAR(255),
              location     INTEGER,
              outcome      INTEGER       DEFAULT 0,
-             cache_dir    VARCHAR(700)  DEFAULT 'None',
-             fwjr_path    VARCHAR(700),
+             cache_dir    VARCHAR(800)  DEFAULT 'None',
+             fwjr_path    VARCHAR(800),
              FOREIGN KEY (jobgroup)
              REFERENCES wmbs_jobgroup(id) ON DELETE CASCADE,
              FOREIGN KEY (state) REFERENCES wmbs_job_state(id),

--- a/src/python/WMCore/WMBS/MySQL/Create.py
+++ b/src/python/WMCore/WMBS/MySQL/Create.py
@@ -28,7 +28,7 @@ class Create(CreateWMBSBase):
         self.create["01wmbs_fileset"] = \
           """CREATE TABLE wmbs_fileset (
              id          INTEGER      PRIMARY KEY AUTO_INCREMENT,
-             name        VARCHAR(512) NOT NULL,
+             name        VARCHAR(700) NOT NULL,
              open        INT(1)       NOT NULL DEFAULT 0,
              last_update INT(11)      NOT NULL,
              UNIQUE (name))"""

--- a/src/python/WMCore/WMBS/Oracle/Create.py
+++ b/src/python/WMCore/WMBS/Oracle/Create.py
@@ -51,7 +51,7 @@ class Create(CreateWMBSBase):
         self.create["01wmbs_fileset"] = \
           """CREATE TABLE wmbs_fileset (
                id          INTEGER      NOT NULL,
-               name        VARCHAR(500) NOT NULL,
+               name        VARCHAR(700) NOT NULL,
                open        CHAR(1)      CHECK (open IN ('0', '1' )) NOT NULL,
                last_update INTEGER      NOT NULL
                ) %s""" % tablespaceTable
@@ -67,7 +67,7 @@ class Create(CreateWMBSBase):
         self.create["02wmbs_file_details"] = \
           """CREATE TABLE wmbs_file_details (
                id          INTEGER NOT NULL,
-               lfn         VARCHAR(500) NOT NULL,
+               lfn         VARCHAR(700) NOT NULL,
                filesize    INTEGER,
                events      INTEGER,
                first_event INTEGER      DEFAULT 0,
@@ -517,8 +517,8 @@ class Create(CreateWMBSBase):
                couch_record VARCHAR(255),
                location     INTEGER,
                outcome      INTEGER       DEFAULT 0,
-               cache_dir    VARCHAR(700)  DEFAULT 'None',
-               fwjr_path    VARCHAR(700)
+               cache_dir    VARCHAR(800)  DEFAULT 'None',
+               fwjr_path    VARCHAR(800)
                ) %s""" % tablespaceTable
 
         self.indexes["01_pk_wmbs_job"] = \


### PR DESCRIPTION
Increasing a bit the column size in a few tables. Usually TaskChain hits these constraints because they have several chained tasks and the TaskName can be basically anything with any size. Issue reported here:
https://cms-logbook.cern.ch/elog/Workflow+processing/17624
