### PR TITLE
temporary fix for FirstRun/LastRun wrong data type

### DIFF
--- a/src/python/WMCore/WMBS/Mask.py
+++ b/src/python/WMCore/WMBS/Mask.py
@@ -63,8 +63,8 @@ class Mask(WMBSBase, WMMask):
                 tmpMask['inclusivemask']  = self['inclusivemask']
                 tmpMask['FirstEvent'] = self['FirstEvent']
                 tmpMask['LastEvent']  = self['LastEvent']
-                tmpMask['FirstRun']   = run
-                tmpMask['LastRun']    = run
+                tmpMask['FirstRun']   = int(run)
+                tmpMask['LastRun']    = int(run)
                 tmpMask['FirstLumi']  = lumiPair[0]
                 tmpMask['LastLumi']   = lumiPair[1]
                 maskList.append(tmpMask)


### PR DESCRIPTION
It's a temporary fix for what has been discussed in this elog:
https://cms-logbook.cern.ch/elog/Workflow+processing/17619

In summary, we try to insert data into the database with different data type (int and str) for the same column, and that causes an exception. I still need to find why and where exactly the run numbers are being cast to str.
Maybe give me a couple of days to figure out that...
It's now in  in the RelVal agent and one of the testbed ones.
