### PR TITLE
Review lumiCorrection function in the Lumibased Splitting

### DIFF
--- a/src/python/WMCore/DataStructs/Mask.py
+++ b/src/python/WMCore/DataStructs/Mask.py
@@ -13,7 +13,6 @@ job in two ways:
 import logging
 
 from WMCore.DataStructs.Run import Run
-from WMCore.DataStructs.LumiList import LumiList
 
 class Mask(dict):
     """
@@ -154,17 +153,6 @@ class Mask(dict):
         self['runAndLumis'][run].append([min(lumis), max(lumis)])
 
         return
-
-    def removeLumiList(self, lumiList):
-        """
-        Remove a lumi list from this data structure
-
-        This requires conversion to LumiList to do the lumi algebra an
-        may be computationally expensive for a large number of lumis.
-        """
-        myLumis = LumiList(compactList=self['runAndLumis'])
-        myLumis = myLumis - lumiList
-        self['runAndLumis'] = myLumis.getCompactList()
 
     def getRunAndLumis(self):
         """

--- a/test/python/WMCore_t/JobSplitting_t/LumiBased_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/LumiBased_t.py
@@ -237,7 +237,7 @@ class LumiBasedTest(unittest.TestCase):
 
         jobFactory = splitter(package = "WMCore.DataStructs",
                               subscription = testSubscription)
-        
+
         jobGroups = jobFactory(lumis_per_job = 3,
                                halt_job_on_file_boundaries = False,
                                splitOnRun = False,

--- a/test/python/WMCore_t/JobSplitting_t/LumiBased_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/LumiBased_t.py
@@ -74,7 +74,7 @@ class LumiBasedTest(unittest.TestCase):
                                events = 100)
                 lumis = []
                 for lumi in range(lumisPerFile):
-                    lumis.append((i * 100) + lumi)
+                    lumis.append(5 + 10 * (i * 100) + lumi) #lumis should be different
                 newFile.addRun(Run(i, *lumis))
                 newFile.setLocation('malpaquet')
                 testFileset.addFile(newFile)
@@ -241,7 +241,9 @@ class LumiBasedTest(unittest.TestCase):
         jobGroups = jobFactory(lumis_per_job = 3,
                                halt_job_on_file_boundaries = False,
                                splitOnRun = False,
-                               performance = self.performanceParams)
+                               performance = self.performanceParams,
+                               applyLumiCorrection = True
+                              )
 
         self.assertEqual(len(jobGroups), 1)
         jobs = jobGroups[0].jobs
@@ -250,7 +252,30 @@ class LumiBasedTest(unittest.TestCase):
         self.assertEqual(len(jobs[0]['input_files']), 2)
         self.assertEqual(len(jobs[1]['input_files']), 1)
         self.assertEqual(jobs[0]['mask'].getRunAndLumis(), {0: [[0L, 1L], [42L, 42L]]})
-        self.assertEqual(jobs[1]['mask'].getRunAndLumis(), {'0': [[100L, 101L]]})
+        self.assertEqual(jobs[1]['mask'].getRunAndLumis(), {0: [[100L, 101L]]})
+
+        #Test that we are not removing all the lumis from the jobs anymore
+        removedLumi = self.createSubscription(nFiles = 4, lumisPerFile = 1)
+        #Setting the lumi of job 0 to value 100, as the one of job one
+        runObj = next(iter(removedLumi.getFileset().getFiles()[0]['runs']))
+        runObj.run = 1
+        runObj[0] = 100
+        jobFactory = splitter(package = "WMCore.DataStructs",
+                              subscription = removedLumi)
+        jobGroups = jobFactory(lumis_per_job = 1,
+                               halt_job_on_file_boundaries = True,
+                               performance = self.performanceParams,
+                               applyLumiCorrection = True)
+        # we need to end up with 3 jobs and one job with two input files
+        jobs = jobGroups[0].jobs
+
+        self.assertEqual(len(jobs), 3)
+        self.assertEqual(len(jobs[0]['input_files']), 2)
+        self.assertEqual(len(jobs[1]['input_files']), 1)
+        self.assertEqual(len(jobs[2]['input_files']), 1)
+        self.assertEqual(jobs[0]['mask'].getRunAndLumis(), {1: [[100L, 100L]]})
+        self.assertEqual(jobs[1]['mask'].getRunAndLumis(), {2: [[200L, 200L]]})
+        self.assertEqual(jobs[2]['mask'].getRunAndLumis(), {3: [[300L, 300L]]})
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Do the lumi correction on the fly. Keep track of the already processed
lumis in a dict, and skip them it they were already encountered. Also,
keep track of the input files of the duplicated lumis, and add these input
files to the "original" job.

In the tests I did with my CRAB3 instance on the problematic datasets/splitting parameters, things have improved dramaticly. The previous algorithm was taking hours to complete and not it finishes pretty quickly (< 1 minute).

One other improvement is that if you want 50 lumis per job you will really have 50 lumis per job, while before you were removing lumis and ending up with jobs analyzing less than 50 lumis.

Finally, I have also checked that the issue raised by Andrew Levin (removing all the lumis in one job and ending up analyzing the whole dataset) is not there anymore. I added a unit test for it.

I made the check optional, and I am using the default as False, so unless explicitly enabled WMAgent will not make the check about duplicated lumis.
