### PR TITLE
new error code for jobstatus lite timeout

### DIFF
--- a/src/python/WMCore/BossAir/StatusPoller.py
+++ b/src/python/WMCore/BossAir/StatusPoller.py
@@ -122,7 +122,7 @@ class StatusPoller(BaseWorkerThread):
         myThread = threading.currentThread()
         myThread.transaction.begin()
         self.bossAir.update(jobs = jobsToKill)
-        self.bossAir.kill(jobs = jobsToKill, killMsg = "Job killed due to timeout")
+        self.bossAir.kill(jobs = jobsToKill, killMsg = "Job killed due to timeout", errorCode = 61304)
         myThread.transaction.commit()
 
 

--- a/src/python/WMCore/WMExceptions.py
+++ b/src/python/WMCore/WMExceptions.py
@@ -53,7 +53,9 @@ WMJobErrorCodes = {50660 :
                    61302 :
                    "The job was killed by the WMAgent because the site it was running at was set to Draining",
                    61303 :
-                   "The job was killed by the WMAgent because the site it was running at was set to Down"}
+                   "The job was killed by the WMAgent because the site it was running at was set to Down",
+                   61304 :
+                   "The job was killed by the WMAgent for using too much wallclock time"}
 
 """
 WMJobPermanentSystemErrors


### PR DESCRIPTION
changed the error code that is used when a job fails due to a jobstatuslite timeout, this will allow us to make these jobs move to jobfailed instead of jobcooloff after try
