### PR TITLE
add support for phedex deletions

### DIFF
--- a/src/python/WMCore/Services/PhEDEx/DataStructs/PhEDExDeletion.py
+++ b/src/python/WMCore/Services/PhEDEx/DataStructs/PhEDExDeletion.py
@@ -1,0 +1,45 @@
+"""
+_PhEDExDeletion_
+
+Data structure which contains the information for the deletion of a dataset/block in PhEDEx.
+
+Created on May 29, 2013
+
+@author: dballest
+"""
+
+class PhEDExDeletion(object):
+    """
+    _PhEDExDeletion_
+
+    Data structure which contains PHEDEx fields for
+    PhEDEx deletion data service
+    """
+
+    def __init__(self, datasetPathList, nodeList,
+                 level = 'dataset', subscriptions = 'n', blocks = None,
+                 comments = 'Deleted automatically by the WMAgent'):
+        """
+        Initialize PhEDEx deletion with default values
+        """
+        if type(datasetPathList) == str:
+            datasetPathList = [datasetPathList]
+        if type(nodeList) == str:
+            nodeList = [nodeList]
+
+        self.datasetPaths = set(datasetPathList)
+        self.nodes = set(nodeList)
+
+        self.level = level.lower()
+        self.subscriptions = subscriptions
+        self.blocks = blocks
+        self.comments = comments
+
+    def getDatasetsAndBlocks(self):
+        """
+        _getDatasetsAndBlocks_
+
+        Get the block structure
+        with datasets and blocks
+        """
+        return self.blocks

--- a/src/python/WMCore/Services/PhEDEx/PhEDEx.py
+++ b/src/python/WMCore/Services/PhEDEx/PhEDEx.py
@@ -34,7 +34,7 @@ class PhEDEx(Service):
         Service.__init__(self, dict)
 
     def _getResult(self, callname, clearCache = False,
-                   args = None, verb="POST"):
+                   args = None, verb = "POST"):
         """
         _getResult_
 
@@ -78,7 +78,7 @@ class PhEDEx(Service):
         args['data'] = xmlData
         args['strict'] = strict
 
-        return self._getResult(callname, args = args, verb="POST")
+        return self._getResult(callname, args = args, verb = "POST")
 
     def subscribe(self, subscription, xmlData):
         """
@@ -104,8 +104,44 @@ class PhEDEx(Service):
         args['group'] = subscription.group
         args['request_only'] = subscription.request_only
 
-        return self._getResult(callname, args = args, verb="POST")
+        return self._getResult(callname, args = args, verb = "POST")
 
+    def delete(self, deletion, xmlData):
+        """
+        _delete_
+
+        xmlData = XMLDrop.makePhEDExXMLForDatasets(dbsUrl, subscription.getDatasetPaths())
+        Deletion is a PhEDEX deletion structure
+        """
+
+        callname = 'delete'
+        args = {}
+
+        args['node'] = []
+        for node in deletion.nodes:
+            args['node'].append(node)
+
+        args['data'] = xmlData
+        args['level'] = deletion.level
+        args['rm_subscriptions'] = deletion.subscriptions
+        args['comments'] = deletion.comments
+
+        return self._getResult(callname, args = args, verb = "POST")
+
+    def updateRequest(self, requestId, decision, nodes):
+        """
+        _updateRequest_
+
+        Update a request approving/disapproving it.
+        """
+        if type(nodes) == str:
+            nodes = [nodes]
+        args = {}
+        args['decision'] = decision.lower()
+        args['request'] = requestId
+        args['node'] = nodes
+
+        return self._getResult('updaterequest', args = args, verb = "POST")
 
     def getReplicaInfoForBlocks(self, **kwargs):
         """
@@ -486,5 +522,3 @@ class PhEDEx(Service):
         if phedexNodes:
             return blockNodes
         return blockSE
-            
-            


### PR DESCRIPTION
The new copy-delete subscription mode will require wmagent to make deletion request, add the neccessary code to do so.

This is just a verbatim copy of the code that Diego implemented a year ago, it worked then. I will add a unit test later when I implement the copy-delete subscription mode, only then will I know in what context this is going to be used.
