### PR TITLE
Add option to not clean the env in Scram.py

### DIFF
--- a/src/python/WMCore/WMRuntime/Tools/Scram.py
+++ b/src/python/WMCore/WMRuntime/Tools/Scram.py
@@ -218,7 +218,7 @@ class Scram:
 
 
     def __call__(self, command, hackLdLibPath = True,
-                 logName = "scramOutput.log", runtimeDir = None):
+                 logName = "scramOutput.log", runtimeDir = None, cleanEnv = True):
         """
         _operator(command)_
 
@@ -241,7 +241,10 @@ class Scram:
             f.write('-------------------------------------------\n')
             f.close()
         logFile = open(logName, 'a') if isinstance(logName, basestring) else logName
-        proc = subprocess.Popen(["env - /bin/bash"], shell=True, cwd=executeIn,
+        bashcmd = "/bin/bash"
+        if cleanEnv:
+            bashcmd = "env - " + bashcmd
+        proc = subprocess.Popen([bashcmd], shell=True, cwd=executeIn,
                                 stdout=logFile,
                                 stderr=logFile,
                                 stdin=subprocess.PIPE,


### PR DESCRIPTION
The scriptExe functionality of CRAB3 is using this library
(Scram.py), but it would be nice to avoid cleaning the environment so that
variables like X509_USER_PROXY can be used for example.
Notice that the CMSSW.py executors also does not clean the env for
cmsRun.
