### PR TITLE
remove reqmgr dependency for reqmgr2

### DIFF
--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -69,8 +69,7 @@ dependencies = {'wmc-rest':{
                                     'src/couchapps/WMStats+'],
                         },
                 'reqmgr2':{
-                        'packages': ['WMCore.RequestManager+',
-                                     'WMCore.ReqMgr+',
+                        'packages': ['WMCore.ReqMgr+',
                                      'WMCore.WMDataMining+',
                                      'WMCore.Services+',
                                      'WMCore.ACDC'

--- a/src/python/WMCore/ReqMgr/Utils/Validation.py
+++ b/src/python/WMCore/ReqMgr/Utils/Validation.py
@@ -72,15 +72,15 @@ def validate_request_create_args(request_args, config, *args, **kwargs):
     """
     
     initialize_request_args(request_args, config)
-    print "xxxxx"
-    from pprint import pprint
-    pprint(request_args)
     #check the permission for creating the request
     permission = getWritePermission(request_args)
     authz_match(permission['role'], permission['group'])
     
     # get the spec type and validate arguments
     spec = loadSpecByType(request_args["RequestType"])
+    if request_args["RequestType"] == "Resubmission":
+        request_args["OriginalRequestCouchURL"] = '%s/%s' % (config.couch_host, 
+                                                             config.couch_reqmgr_db)
     workload = spec.factoryWorkloadConstruction(request_args["RequestName"], 
                                                 request_args)
     return workload, request_args


### PR DESCRIPTION
But sitll supports reqmgr call which need to be removed when reqmgr1 retires
