### PR TITLE
Fix ASW when there is no site IO/CPU slots info

### DIFF
--- a/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
+++ b/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
@@ -133,11 +133,11 @@ class ResourceControlUpdater(BaseWorkerThread):
             for site in listSites:
                 if site in currentSites:
                     sitestate = stateBySite.get(site,'Normal')
-                    if not slotsCPU[site] or not slotsIO[site]:
+                    if site not in slotsCPU or site not in slotsIO:
                         pluginResponse = self.updateSiteInfo(site, sitestate, 0, 0, agentsNum)
                         if not pluginResponse: 
                             continue
-                        logging.error('Setting site %s to %s, forcing CPUBound: 0, IOBound: 0 due to missing information in SSB' % 
+                        logging.warn('Setting site %s to %s, forcing CPUBound: 0, IOBound: 0 due to missing information in SSB' % 
                                  (site, sitestate))
                         continue
                     


### PR DESCRIPTION
As reported here:
https://cms-logbook.cern.ch/elog/Workflow+processing/18376

when there is no CPU/IO slots info for a specific site, AgentStatusWatcher was raising an exception.

This patch fixes it, but in the near future I guess it would be better not to touch resource-control when there is no such information in SSB.
