### PR TITLE
switch for disabling (or not) AgentStatusWatcher

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -524,3 +524,4 @@ config.AgentStatusWatcher.runningRepackPercent = 10 # [percent] Only used for ti
 config.AgentStatusWatcher.t1SitesCores = 30 # [percent] Only used for tier0 agent
 config.AgentStatusWatcher.forcedSiteList = [] # [site list] List sites to force Resource Control
 config.AgentStatusWatcher.onlySSB = True # Set thresholds for sites only in SSB (Force all other to zero/down)
+config.AgentStatusWatcher.enabled = True # switch to enable or not this component

--- a/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
+++ b/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
@@ -55,6 +55,9 @@ class ResourceControlUpdater(BaseWorkerThread):
         # tier mode
         self.tier0Mode = hasattr(config, "Tier0Feeder")
         self.t1SitesCores = config.AgentStatusWatcher.t1SitesCores
+
+        # switch this component on/off
+        self.enabled = getattr(config.AgentStatusWatcher, 'enabled', True)
         
     def setup(self, parameters):
         """
@@ -81,10 +84,13 @@ class ResourceControlUpdater(BaseWorkerThread):
             3. Set site status and set therholds for each valid site
         Sites from SSB are validated with PhEDEx node names
         """
+        # set variables every polling cycle
+        self.setVariables(self.config)
+        if not self.enabled:
+            logging.info("This component is not enabled in the configuration. Doing nothing.")
+            return
+
         try:
-            # set variables every polling cycle
-            self.setVariables(self.config)
-            
             # Get sites in Resource Control
             currentSites = self.resourceControl.listCurrentSites()
             


### PR DESCRIPTION
For cases where we do not want AgentStatusWatcher messing up with the thresholds and site status, we can set that flag and then the component will just .. do nothing :-) (but will still run)
