### PR TITLE
Create indexes to wmbs_job and fix column lengths

### DIFF
--- a/src/python/WMCore/BossAir/MySQL/Create.py
+++ b/src/python/WMCore/BossAir/MySQL/Create.py
@@ -31,6 +31,11 @@ class Create(DBCreator):
         if dbi == None:
             dbi = myThread.dbi
 
+        tablespaceIndex = ""
+        if params:
+            if params.has_key("tablespace_index"):
+                tablespaceIndex = "USING INDEX TABLESPACE %s" % params["tablespace_index"]
+
         DBCreator.__init__(self, logger, dbi)
 
         self.requiredTables = ["01bl_status", "02bl_runjob"]
@@ -72,6 +77,17 @@ class Create(DBCreator):
 
         """
 
+        self.constraints["01_idx_bl_runjob"] = \
+          """CREATE INDEX idx_bl_runjob_wmbs ON bl_runjob(wmbs_id) %s""" % tablespaceIndex
+
+        self.constraints["02_idx_bl_runjob"] = \
+          """CREATE INDEX idx_bl_runjob_status ON bl_runjob(sched_status) %s""" % tablespaceIndex
+
+        self.constraints["03_idx_bl_runjob"] = \
+          """CREATE INDEX idx_bl_runjob_users ON bl_runjob(user_id) %s""" % tablespaceIndex
+
+        self.constraints["04_idx_bl_runjob"] = \
+          """CREATE INDEX idx_bl_runjob_location ON bl_runjob(location) %s""" % tablespaceIndex
 
         return
 

--- a/src/python/WMCore/BossAir/Oracle/Create.py
+++ b/src/python/WMCore/BossAir/Oracle/Create.py
@@ -83,39 +83,45 @@ class Create(DBCreator):
            user_id       INTEGER
            ) %s  """ % (tablespaceTable)
 
-
-        self.indexes["02_pk_bl_runjob"] = \
-          """ALTER TABLE bl_runjob ADD
-               (CONSTRAINT bl_runjob_pk PRIMARY KEY (id) %s)""" % tablespaceIndex
-
-
         self.indexes["01_pk_bl_status"] = \
           """ALTER TABLE bl_status ADD
                (CONSTRAINT bl_status_pk PRIMARY KEY (id) %s)""" % tablespaceIndex
 
+        self.indexes["02_pk_bl_runjob"] = \
+          """ALTER TABLE bl_runjob ADD
+               (CONSTRAINT bl_runjob_pk PRIMARY KEY (id) %s)""" % tablespaceIndex
 
         self.constraints["01_fk_bl_runjob"] = \
             """ALTER TABLE bl_runjob ADD
                (CONSTRAINT bl_runjob_fk1 FOREIGN KEY(wmbs_id)
                REFERENCES wmbs_job(id) ON DELETE CASCADE)"""
 
+        self.constraints["01_idx_bl_runjob"] = \
+          """CREATE INDEX idx_bl_runjob_wmbs ON bl_runjob(wmbs_id) %s""" % tablespaceIndex
 
         self.constraints["02_fk_bl_runjob"] = \
             """ALTER TABLE bl_runjob ADD
                (CONSTRAINT bl_runjob_fk2 FOREIGN KEY(sched_status)
                REFERENCES bl_status(id) ON DELETE CASCADE)"""
 
+        self.constraints["02_idx_bl_runjob"] = \
+          """CREATE INDEX idx_bl_runjob_status ON bl_runjob(sched_status) %s""" % tablespaceIndex
 
         self.constraints["03_fk_bl_runjob"] = \
             """ALTER TABLE bl_runjob ADD
                (CONSTRAINT bl_runjob_fk3 FOREIGN KEY(user_id)
                REFERENCES wmbs_users(id) ON DELETE CASCADE)"""
 
+        self.constraints["03_idx_bl_runjob"] = \
+          """CREATE INDEX idx_bl_runjob_users ON bl_runjob(user_id) %s""" % tablespaceIndex
+
         self.constraints["04_fk_bl_runjob"] = \
             """ALTER TABLE bl_runjob ADD
                (CONSTRAINT bl_runjob_fk4 FOREIGN KEY(location)
                REFERENCES wmbs_location(id) ON DELETE CASCADE)"""
 
+        self.constraints["04_idx_bl_runjob"] = \
+          """CREATE INDEX idx_bl_runjob_location ON bl_runjob(location) %s""" % tablespaceIndex
 
 
         j = 50

--- a/src/python/WMCore/WMBS/CreateWMBSBase.py
+++ b/src/python/WMCore/WMBS/CreateWMBSBase.py
@@ -285,8 +285,8 @@ class CreateWMBSBase(DBCreator):
              couch_record VARCHAR(255),
              location     INTEGER,
              outcome      INTEGER       DEFAULT 0,
-             cache_dir    VARCHAR(800)  DEFAULT 'None',
-             fwjr_path    VARCHAR(800),
+             cache_dir    VARCHAR(767)  DEFAULT 'None',
+             fwjr_path    VARCHAR(767),
              FOREIGN KEY (jobgroup)
              REFERENCES wmbs_jobgroup(id) ON DELETE CASCADE,
              FOREIGN KEY (state) REFERENCES wmbs_job_state(id),

--- a/src/python/WMCore/WMBS/Oracle/Create.py
+++ b/src/python/WMCore/WMBS/Oracle/Create.py
@@ -517,8 +517,8 @@ class Create(CreateWMBSBase):
                couch_record VARCHAR(255),
                location     INTEGER,
                outcome      INTEGER       DEFAULT 0,
-               cache_dir    VARCHAR(800)  DEFAULT 'None',
-               fwjr_path    VARCHAR(800)
+               cache_dir    VARCHAR(767)  DEFAULT 'None',
+               fwjr_path    VARCHAR(767)
                ) %s""" % tablespaceTable
 
         self.indexes["01_pk_wmbs_job"] = \


### PR DESCRIPTION
Fixes a couple of issues:
 1) column length for unique constraint cannot be > 767. Fix for #5465 
 2) partial fix for #5213 by adding 4 indexes to 4 fk in bl_runjob table (applied Yuyi's fix). 
The deadlock still happens, but _should_ be less often now.

I've just deployed a MariaDB backend agent and the deployment went fine and the 4 indexes are there [1]
Since my knowledge in DB is quite weak :-(, I may be missing something.
 @yuyiguo @hufnagel can you please review?

```
[1]
MariaDB [wmagent]> show index from bl_runjob;
+-----------+------------+------------------------+--------------+--------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
| Table     | Non_unique | Key_name               | Seq_in_index | Column_name  | Collation | Cardinality | Sub_part | Packed | Null | Index_type | Comment | Index_comment |
+-----------+------------+------------------------+--------------+--------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
| bl_runjob |          0 | PRIMARY                |            1 | id           | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
| bl_runjob |          0 | retry_count            |            1 | retry_count  | A         |           0 |     NULL | NULL   | YES  | BTREE      |         |               |
| bl_runjob |          0 | retry_count            |            2 | wmbs_id      | A         |           0 |     NULL | NULL   | YES  | BTREE      |         |               |
| bl_runjob |          1 | idx_bl_runjob_wmbs     |            1 | wmbs_id      | A         |           0 |     NULL | NULL   | YES  | BTREE      |         |               |
| bl_runjob |          1 | idx_bl_runjob_location |            1 | location     | A         |           0 |     NULL | NULL   | YES  | BTREE      |         |               |
| bl_runjob |          1 | idx_bl_runjob_status   |            1 | sched_status | A         |           0 |     NULL | NULL   | YES  | BTREE      |         |               |
| bl_runjob |          1 | idx_bl_runjob_users    |            1 | user_id      | A         |           0 |     NULL | NULL   | YES  | BTREE      |         |               |
+-----------+------------+------------------------+--------------+--------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
```
