### PR TITLE
add self-healing to corrupted FWJR

### DIFF
--- a/src/python/WMCore/WMBS/MySQL/Jobs/GetFWJRTaskName.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/GetFWJRTaskName.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+"""
+_GetFWJRTaskName_
+
+MySQL implementation of Jobs.GetFWJRTaskName
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+import logging
+
+class GetFWJRTaskName(DBFormatter):
+    """
+    _GetFWJRTaskName_
+
+    Retrieve the taskName and the fwjr_path to heal corrupted FWJRs
+    seen by the JobAccountant. See #5421.
+    """
+    sql = """
+          SELECT wj.fwjr_path, ww.task FROM wmbs_workflow ww
+            INNER JOIN wmbs_subscription ws ON ws.workflow = ww.id
+            INNER JOIN wmbs_jobgroup wjg ON wjg.subscription = ws.id
+            INNER JOIN wmbs_job wj ON wj.jobgroup = wjg.id
+            WHERE wj.id = :jobId"""
+
+    def format(self, results):
+        """
+        _format_
+
+        """
+        result = DBFormatter.format(self, results)
+
+        return {"fwjr_path": result[0][0], "taskName": result[0][1]}
+
+    def execute(self, jobId, conn = None, transaction = False):
+        result = self.dbi.processData(self.sql, {"jobId": jobId}, conn = conn,
+                                      transaction = transaction)
+
+        return self.format(result)

--- a/src/python/WMCore/WMBS/Oracle/Jobs/GetFWJRTaskName.py
+++ b/src/python/WMCore/WMBS/Oracle/Jobs/GetFWJRTaskName.py
@@ -1,0 +1,15 @@
+s
+#!/usr/bin/env python
+"""
+_GetFWJRTaskName_
+
+Oracle implementation of Jobs.GetFWJRTaskName
+"""
+
+from WMCore.WMBS.MySQL.Jobs.GetFWJRTaskName import GetFWJRTaskName as MySQLGetFWJRTaskName
+
+class GetFWJRTaskName(MySQLGetFWJRTaskName):
+    """
+    Identical to MySQL version.
+    """
+    pass


### PR DESCRIPTION
now the component should be able to self-recover FWJRs that are missing the taskName.
This has been tested in testbed.
@ticoann , please review and let me know if this is not the proper way to fix this issue
If you are happy :-), then I'll forward port it to master.
