### PR TITLE
Add Multi* tasks to RC database. Fixes #5616

### DIFF
--- a/bin/wmagent-resource-control
+++ b/bin/wmagent-resource-control
@@ -32,6 +32,8 @@ def getTaskTypes(tier0 = False):
                  "Skim",
                  "Production",
                  "Processing",
+                 "MultiProcessing",
+                 "MultiProduction",
                  "Analysis"]
 
     if tier0:

--- a/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
+++ b/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
@@ -313,7 +313,7 @@ class ResourceControlUpdater(BaseWorkerThread):
                                                 runningJobSlots = CPUBound)
         
         # Set thresholds for CPU bound task types
-        cpuTasks = ['Processing', 'Production', 'Analysis']
+        cpuTasks = ['Processing', 'Production', 'MultiProcessing', 'MultiProduction', 'Analysis']
         for task in cpuTasks:
             self.resourceControl.insertThreshold(siteName = siteName, taskType = task,
                                                  maxSlots = CPUBound, pendingSlots = taskCPUPending)


### PR DESCRIPTION
As we recently discovered, not all tasks make it to the resource-control database and we are wrongly setting ReReco jobs as MultiProcessing (which is fixed now in testbed #5618 ).
