### PR TITLE
backport WMStats views cleanup and replacement of calls

### DIFF
--- a/src/python/WMComponent/TaskArchiver/CleanCouchPoller.py
+++ b/src/python/WMComponent/TaskArchiver/CleanCouchPoller.py
@@ -12,8 +12,11 @@ from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 from WMCore.Services.WMStats.WMStatsWriter import WMStatsWriter
 from WMCore.Services.WMStats.WMStatsReader import WMStatsReader
 from WMCore.Services.RequestManager.RequestManager import RequestManager
+from WMCore.Services.RequestDB.RequestDBWriter import RequestDBWriter
+from WMCore.Services.RequestDB.RequestDBReader import RequestDBReader
 from WMCore.Database.CMSCouch import CouchServer
 from WMCore.Lexicon import sanitizeURL
+from WMCore.Database.CMSCouch import CouchNotFoundError
 
 class CleanCouchPoller(BaseWorkerThread):
     """
@@ -38,17 +41,25 @@ class CleanCouchPoller(BaseWorkerThread):
         """
         # set the connection for local couchDB call
         self.useReqMgrForCompletionCheck   = getattr(self.config.TaskArchiver, 'useReqMgrForCompletionCheck', True)
+        self.archiveDelayHours   = getattr(self.config.TaskArchiver, 'archiveDelayHours', 0)
         self.wmstatsCouchDB = WMStatsWriter(self.config.TaskArchiver.localWMStatsURL)
-        self.centralCouchDBReader = WMStatsReader(self.config.TaskArchiver.centralWMStatsURL)
+        
+        #TODO: we might need to use local db for Tier0
+        self.centralRequestDBReader = RequestDBReader(self.config.AnalyticsDataCollector.centralRequestDBURL, 
+                                                   couchapp = self.config.AnalyticsDataCollector.RequestCouchApp)
         
         if self.useReqMgrForCompletionCheck:
-            self.deletableStates = ["announced"]
-            self.centralCouchDBWriter = WMStatsWriter(self.config.TaskArchiver.centralWMStatsURL)
+            self.deletableState = "announced"
+            self.centralRequestDBWriter = RequestDBWriter(self.config.AnalyticsDataCollector.centralRequestDBURL, 
+                                                   couchapp = self.config.AnalyticsDataCollector.RequestCouchApp)
+            #TODO: remove this for reqmgr2
             self.reqmgrSvc = RequestManager({'endpoint': self.config.TaskArchiver.ReqMgrServiceURL})
         else:
             # Tier0 case
-            self.deletableStates = ["completed"]
-            self.centralCouchDBWriter = self.wmstatsCouchDB
+            self.deletableState = "completed"
+            # use local for update
+            self.centralRequestDBWriter = RequestDBWriter(self.config.AnalyticsDataCollector.localT0RequestDBURL, 
+                                                   couchapp = self.config.AnalyticsDataCollector.RequestCouchApp)
         
         jobDBurl = sanitizeURL(self.config.JobStateMachine.couchurl)['url']
         jobDBName = self.config.JobStateMachine.couchDBName
@@ -69,18 +80,19 @@ class CleanCouchPoller(BaseWorkerThread):
             logging.info("%s docs deleted" % report)
             logging.info("getting complete and announced requests")
             
-            deletableWorkflows = self.centralCouchDBReader.workflowsByStatus(self.deletableStates)
-            
+            endTime = int(time.time()) - self.archiveDelayHours * 3600
+            deletableWorkflows = self.centralRequestDBReader.getRequestByStatusAndStartTime(self.deletableState, 
+                                                                                            False, endTime)
             logging.info("Ready to archive normal %s workflows" % len(deletableWorkflows))
             numUpdated = self.archiveWorkflows(deletableWorkflows, "normal-archived")
             logging.info("archive normal %s workflows" % numUpdated)
             
-            abortedWorkflows = self.centralCouchDBReader.workflowsByStatus(["aborted-completed"])
+            abortedWorkflows = self.centralRequestDBReader.getRequestByStatus(["aborted-completed"])
             logging.info("Ready to archive aborted %s workflows" % len(abortedWorkflows))
             numUpdated = self.archiveWorkflows(abortedWorkflows, "aborted-archived")
             logging.info("archive aborted %s workflows" % numUpdated)
             
-            rejectedWorkflows = self.centralCouchDBReader.workflowsByStatus(["rejected"])
+            rejectedWorkflows = self.centralRequestDBReader.getRequestByStatus(["rejected"])
             logging.info("Ready to archive rejected %s workflows" % len(rejectedWorkflows))
             numUpdated = self.archiveWorkflows(rejectedWorkflows, "rejected-archived")
             logging.info("archive rejected %s workflows" % numUpdated)
@@ -93,12 +105,14 @@ class CleanCouchPoller(BaseWorkerThread):
         updated = 0
         for workflowName in workflows:
             if self.cleanAllLocalCouchDB(workflowName):
-                self.centralCouchDBWriter.updateRequestStatus(workflowName, archiveState)
-                # update reqmgr workload document
                 if self.useReqMgrForCompletionCheck:
+                    #TODO: for reqmgr2 uncomment this
+                    # self.centralRequestDBWriter.updateRequestStatus(workflowName, archiveState)
                     self.reqmgrSvc.updateRequestStatus(workflowName, archiveState);
                     updated += 1 
                     logging.debug("status updated to %s %s" % (archiveState, workflowName))
+                else:
+                    self.centralRequestDBWriter.updateRequestStatus(workflowName, archiveState)
         return updated
     
     def deleteWorkflowFromJobCouch(self, workflowName, db):
@@ -125,7 +139,10 @@ class CleanCouchPoller(BaseWorkerThread):
             view = "jobsByStatusWorkflow"
         
         if view == None:
-            committed = couchDB.delete_doc(workflowName)
+            try:
+                committed = couchDB.delete_doc(workflowName)
+            except CouchNotFoundError, ex:
+                return {'status': 'warning', 'message': "%s: %s" % (workflowName, str(ex))}
         else:
             options = {"startkey": [workflowName], "endkey": [workflowName, {}], "reduce": False}
             try:

--- a/src/python/WMCore/Services/RequestDB/RequestDBReader.py
+++ b/src/python/WMCore/Services/RequestDB/RequestDBReader.py
@@ -1,0 +1,163 @@
+import time
+import logging
+from WMCore.Database.CMSCouch import CouchServer, Database
+from WMCore.Lexicon import splitCouchServiceURL, sanitizeURL
+from WMCore.Wrappers.JsonWrapper import JSONEncoder
+
+class RequestDBReader():
+
+    def __init__(self, couchURL, couchapp = "ReqMgr"):
+        couchURL = sanitizeURL(couchURL)['url']
+        # set the connection for local couchDB call
+        self._commonInit(couchURL, couchapp)
+        
+    def _commonInit(self, couchURL, couchapp):
+        """
+        setting up comon variables for inherited class.
+        inherited class should call this in their init function
+        """
+        if isinstance(couchURL, Database):
+            self.couchDB = couchURL
+            self.couchURL = self.couchDB['host']
+            self.dbName = self.couchDB.name
+            self.couchServer = CouchServer(self.couchURL)
+        else:    
+            self.couchURL, self.dbName = splitCouchServiceURL(couchURL)
+            self.couchServer = CouchServer(self.couchURL)
+            self.couchDB = self.couchServer.connectDatabase(self.dbName, False)
+        self.couchapp = couchapp
+        self.defaultStale = {"stale": "update_after"}
+        
+    
+    def setDefaultStaleOptions(self, options):
+        if not options:
+            options = {}  
+        if not options.has_key('stale'):
+            options.update(self.defaultStale)
+        return options
+    
+    def _setNoStale(self):
+        """
+        Use this only for the unittest
+        """        
+        self.defaultStale = {}
+        
+    def _getCouchView(self, view, options, keys = []):
+        
+        options = self.setDefaultStaleOptions(options)
+            
+        if keys and isinstance(keys, basestring):
+            keys = [keys]
+        return self.couchDB.loadView(self.couchapp, view, options, keys)
+    
+    
+    def _filterCouchInfo(self, couchInfo):
+        # remove the couch specific information
+        for key in ['_rev', '_attachments']:
+            if  key in couchInfo:
+                del couchInfo[key]
+        return
+    
+                
+    def _formatCouchData(self, data, key = "id", detail = True, filterCouch = True):
+        result = {}
+        for row in data['rows']:
+            if row.has_key('error'):
+                continue
+            if row.has_key("doc"):
+                if filterCouch:
+                    self._filterCouchInfo(row["doc"])
+                result[row[key]] = row["doc"]
+            else:
+                result[row[key]] = None
+        if detail:
+            return result
+        else:
+            return result.keys()
+            
+    def _getRequestByNames(self, requestNames, detail):
+        """
+        'status': list of the status
+        """
+        options = {}
+        options["include_docs"] = detail
+        result = self.couchDB.allDocs(options, requestNames)
+        return result
+        
+    def _getRequestByStatus(self, statusList, detail, limit, skip):
+        """
+        'status': list of the status
+        """
+        options = {}
+        options["include_docs"] = detail
+
+        if limit != None:
+            options["limit"] = limit
+        if skip != None:
+            options["skip"] = skip
+        keys = statusList
+        return self._getCouchView("bystatus", options, keys)
+    
+    def _getRequestByStatusAndStartTime(self, status, detail, endTime):
+        """
+        'status': is the status of the workflow
+        'startTime': unix timestamp for start time
+        """
+        options = {}
+        options["include_docs"] = detail
+        options["startkey"] = [status, 0]
+        options["endkey"] = [status, endTime]
+        options["descending"] = False
+
+        return self._getCouchView("bystatusandtime", options)
+  
+    def _getAllDocsByIDs(self, ids, include_docs = True):
+        """
+        keys is [id, ....]
+        returns document
+        """
+        if len(ids) == 0:
+            return []
+        options = {}
+        options["include_docs"] =  include_docs
+        result = self.couchDB.allDocs(options, ids)
+        
+        return result
+    
+    def getDBInstance(self):
+        return self.couchDB
+    
+    
+    def getRequestByNames(self, requestNames, detail = True):
+        if isinstance(requestNames, basestring):
+            requestNames = [requestNames]
+        if len(requestNames) == 0:
+            return {}
+        data = self._getRequestByNames(requestNames, detail = detail)
+
+        requestInfo = self._formatCouchData(data, detail = detail)
+        return requestInfo
+    
+    def getRequestByStatus(self, statusList, detail = False, limit = None, skip = None):
+        
+        data = self._getRequestByStatus(statusList, detail, limit, skip)
+        requestInfo = self._formatCouchData(data, detail = detail)
+
+        return requestInfo
+    
+    def getRequestByStatusAndStartTime(self, status, detail = False, endTime = 0):
+        
+        if endTime == 0:
+            data = self._getRequestByStatus([status], detail, limit = None, skip = None)
+        else:
+            data = self._getRequestByStatusAndStartTime(status, detail, endTime)
+            
+        requestInfo = self._formatCouchData(data, detail = detail)
+
+        return requestInfo
+    
+    def getRequestByCouchView(self, view, options, keys = []):
+        options.setdefault("include_docs", True)
+        data = self._getCouchView(view, options, keys)
+        requestInfo = self._formatCouchData(data)
+        return requestInfo

--- a/src/python/WMCore/Services/RequestDB/RequestDBWriter.py
+++ b/src/python/WMCore/Services/RequestDB/RequestDBWriter.py
@@ -1,0 +1,43 @@
+from WMCore.Wrappers.JsonWrapper import JSONEncoder
+from WMCore.Services.RequestDB.RequestDBReader import RequestDBReader
+from WMCore.Database.CMSCouch import Document
+
+class RequestDBWriter(RequestDBReader):
+
+    def __init__(self, couchURL, couchapp = "ReqMgr"):
+        # set the connection for local couchDB call
+        # inherited from WMStatsReader
+        self._commonInit(couchURL, couchapp)
+        self._propertyNeedToBeEncoded = ["RequestTransition",
+                                         "SiteWhitelist",
+                                         "SiteBlacklist",
+                                         "BlockWhitelist",
+                                         "SoftwareVersions",
+                                         "InputDatasetTypes",
+                                         "InputDatasets",
+                                         "OutputDatasets",
+                                         "Teams"]
+
+    def insertGenericRequest(self, doc):
+        
+        doc = Document(doc["RequestName"], doc) 
+        result = self.couchDB.commitOne(doc)
+        self.updateRequestStatus(doc["RequestName"], "new")
+        return result
+
+    def updateRequestStatus(self, request, status):
+        status = {"RequestStatus": status}
+        return self.couchDB.updateDocument(request, self.couchapp, "updaterequest",
+                    status)
+
+    def updateRequestProperty(self, request, propDict, dn = None):
+        encodeProperty = {}
+        for key, value in propDict.items():
+            if isinstance(value, list) or isinstance(value, dict):
+                encodeProperty[key] = JSONEncoder().encode(value)
+            else:
+                encodeProperty[key] = value
+        if dn:
+            encodeProperty["DN"] = dn
+        return self.couchDB.updateDocument(request, self.couchapp, "updaterequest",
+                    encodeProperty)

--- a/src/python/WMCore/Services/WMStats/WMStatsWriter.py
+++ b/src/python/WMCore/Services/WMStats/WMStatsWriter.py
@@ -40,10 +40,10 @@ def monitorDocFromRequestSchema(schema):
 
 class WMStatsWriter(WMStatsReader):
 
-    def __init__(self, couchURL, dbName = None):
+    def __init__(self, couchURL):
         # set the connection for local couchDB call
         # inherited from WMStatsReader
-        self._commonInit(couchURL, dbName)
+        self._commonInit(couchURL)
 
     def uploadData(self, docs):
         """


### PR DESCRIPTION
Backported version of #5609, otherwise TaskArchiver will be still using old WMStats views.
A couple of changes are also required in the configuration file:

```
config.AnalyticsDataCollector.centralRequestDBURL = 'https://cmsweb-testbed.cern.ch/couchdb/reqmgr_workload_cache'
config.AnalyticsDataCollector.RequestCouchApp = 'ReqMgr'
```

Testing it right now in testbed (vocms0230) with the HG1503 tag.
@ticoann please take a look at it but don't merge yet.
