### PR TITLE
Limit the number of jobs JobSubmitter can submit per cycle

### DIFF
--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -76,6 +76,7 @@ class JobSubmitterPoller(BaseWorkerThread):
 
         self.changeState = ChangeState(self.config)
         self.repollCount = getattr(self.config.JobSubmitter, 'repollCount', 10000)
+        self.maxJobsPerPoll = int(getattr(self.config.JobSubmitter, 'maxJobsPerPoll', 1000))
 
         # BossAir
         self.bossAir = BossAirAPI(config = self.config)
@@ -537,8 +538,12 @@ class JobSubmitterPoller(BaseWorkerThread):
         """
         jobsToSubmit = {}
         jobsToPrune = {}
+        jobsCount = 0
+        exitLoop = False 
 
         for siteName in self.sortedSites:
+            if exitLoop:
+                break
 
             totalPending = None
             if siteName not in self.cachedJobs:
@@ -557,6 +562,8 @@ class JobSubmitterPoller(BaseWorkerThread):
                 logging.error(msg)
                 continue
             for threshold in self.currentRcThresholds[siteName].get('thresholds', []):
+                if exitLoop:
+                    break
                 try:
                     # Pull basic info for the threshold
                     taskType            = threshold["task_type"]
@@ -710,6 +717,9 @@ class JobSubmitterPoller(BaseWorkerThread):
 
                     # Add to jobsToSubmit
                     jobsToSubmit[package].append(jobDict)
+                    jobsCount += 1
+                    if jobsCount >= self.maxJobsPerPoll:
+                        breakLoop, exitLoop = True, True
 
                     # Deal with accounting
                     if len(possibleSites) == 1:
@@ -755,6 +765,10 @@ class JobSubmitterPoller(BaseWorkerThread):
         jobList   = []
         idList    = []
 
+        if len(jobsToSubmit) == 0:
+            logging.debug("There are no packages to submit.")
+            return
+
         for package in jobsToSubmit.keys():
 
             sandbox = self.sandboxPackage[package]
@@ -775,17 +789,22 @@ class JobSubmitterPoller(BaseWorkerThread):
 
         # Run the actual underlying submit code using bossAir
         successList, failList = self.bossAir.submit(jobs = jobList)
+        logging.info("Jobs that succeeded/failed submission: %d/%d." % (len(successList),len(failList)))
 
         # Propagate states in the WMBS database
+        logging.debug("Propagating success state to WMBS.")
         self.changeState.propagate(successList, 'executing', 'created')
+        logging.debug("Propagating fail state to WMBS.")
         self.changeState.propagate(failList, 'submitfailed', 'created')
 
         # At the end we mark the locations of the jobs
         # This applies even to failed jobs, since the location
         # could be part of the failure reason.
+        logging.debug("Updating job location...")
         self.setLocationAction.execute(bulkList = idList, conn = myThread.transaction.conn,
                                        transaction = True)
         myThread.transaction.commit()
+        logging.info("Transaction cycle successfully completed.")
 
         return
 


### PR DESCRIPTION
For cases the agent pulls a lot of work (>20k jobs in one cycle), JobSubmitter is taking a long time
to go through it's cycle of:
- determining possible site locations
- submitting them with the condor plugin
- updating WMBS database
  which in the end was not marking jobs as 'executing' in WMBS and bringing inconsistencies to the job tracking.

The idea with this patch is to limit each JobSubmitter cycle to 1k jobs maximum.
