### PR TITLE
fix tier0 case and typo

### DIFF
--- a/src/python/WMCore/WMSpec/WMWorkloadTools.py
+++ b/src/python/WMCore/WMSpec/WMWorkloadTools.py
@@ -143,9 +143,9 @@ def _validateArgumentOptions(arguments, argumentDefinition, optionKey):
 
 def _validateInputDataset(arguments):
     inputdataset = arguments.get("InputDataset", None)
-    if inputdataset != None:
-        dbsURL = arguments.get("DbsUrl", None)
-        result = _varifyDBSCall(dbsURL, "datasets?&dataset_access_type=*&dataset=%s" % inputdataset)
+    dbsURL = arguments.get("DbsUrl", None)
+    if inputdataset != None and dbsURL != None:
+        result = _verifyDBSCall(dbsURL, "datasets?&dataset_access_type=*&dataset=%s" % inputdataset)
         if len(result) == 0:
             msg = "Inputdataset %s doesn't exist on %s" % (inputdataset, dbsURL)
             raise WMSpecFactoryException(msg)
@@ -159,10 +159,11 @@ def validateInputDatasSetAndParentFlag(arguments):
             raise WMSpecFactoryException(msg)
         else:
             dbsURL = arguments.get("DbsUrl", None)
-            result = _varifyDBSCall(dbsURL, "datasetparents?dataset=%s" % inputdataset)
-            if len(result) == 0:
-                msg = "Validation failed: IncludeParent flag is True but inputdataset %s doesn't have parents" % (inputdataset)
-                raise WMSpecFactoryException(msg)
+            if dbsURL != None:
+                result = _verifyDBSCall(dbsURL, "datasetparents?dataset=%s" % inputdataset)
+                if len(result) == 0:
+                    msg = "Validation failed: IncludeParent flag is True but inputdataset %s doesn't have parents" % (inputdataset)
+                    raise WMSpecFactoryException(msg)
     else:
         _validateInputDataset(arguments)
     return

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StdBase_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StdBase_t.py
@@ -74,6 +74,11 @@ class StdBaseTest(unittest.TestCase):
         arguments["IncludeParents"] = False
         arguments["InputDataset"] = "/Cosmics/Commissioning2015-6Mar2015-v1/RECO"
         stdBaseInstance.factoryWorkloadConstruction("TestWorkload", arguments)
+        
+        arguments["IncludeParents"] = False
+        arguments["InputDataset"] = "/Cosmics/ABS/RAW" 
+        arguments["DbsUrl"] = None
+        stdBaseInstance.factoryWorkloadConstruction("TestWorkload", arguments)
         return 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Tier0 can't check dbs for its inputdataset validation.  fixes typo as well.
