### PR TITLE
Fixes ACDC documents retrieval. LumiBased splitting at least

### DIFF
--- a/src/python/WMCore/ACDC/DataCollectionService.py
+++ b/src/python/WMCore/ACDC/DataCollectionService.py
@@ -96,14 +96,12 @@ class DataCollectionService(CouchService):
         keys = [[group, user, collectionName, filesetName]]
         results = self.couchdb.loadView("ACDC", "owner_coll_fileset_docs", option, keys)
         
-        filesetFiles = {}
+        filesInfo = []
         for row in results["rows"]:
             files = row["doc"].get("files", False)
-            if (files):
-                filesetFiles.update(files)
-        
-        filesInfo = filesetFiles.values()
-        
+            if files:
+                filesInfo.extend(files.values())
+
         # second lfn sort
         filesInfo.sort(key = lambda x: x["lfn"])
         #primary location sort (python preserve sort result) 


### PR DESCRIPTION
What a tough bug to track...
Should fix #5665 , since we were updating the same key (when > 1 failures in the same input file).
Tested interactively only, I still need to test the whole chain, so don't merge yet.
