### PR TITLE
Changes to support dynamic templates

### DIFF
--- a/src/html/ReqMgr/templates/create.tmpl
+++ b/src/html/ReqMgr/templates/create.tmpl
@@ -2,14 +2,12 @@
 <hr/>
 <header class="group">
     <nav class="navbar navbar-left">
-        <ul>
-        <li id="ReReco" class="menu-item"><a href="$base/create?form=ReReco">ReReco</a></li>
-        <li id="MonteCarlo" class="menu-item"><a href="$base/create?form=MonteCarlo">MonteCarlo</a></li>
-        <li id="StoreResults" class="menu-item"><a href="$base/create?form=StoreResults">StoreResults</a></li>
-        <li id="DataProcessing" class="menu-item"><a href="$base/create?form=DataProcessing">DataProcessing</a></li>
-        <li id="Resubmission" class="menu-item"><a href="$base/create?form=Resubmission">Resubmission</a></li>
-        <li id="ReDigi" class="menu-item"><a href="$base/create?form=ReDigi">ReDigi</a></li>
-        </ul>
+        Workflow template:
+        <select onchange="loadSpec(this)">
+        #for spec in $specs
+        <option value="$spec">$spec</option>
+        #end for
+        </select>
     </nav>
     <nav class="navbar navbar-right">
         <ul>
@@ -107,9 +105,8 @@ function ActivateJSON() {
     id.className="btn btn-small";
     ShowTag('edit-json');HideTag('edit-table');
 }
-function ShowForm(tag) {
-    var id=document.getElementById(tag);
-    id.className='menu-item active underline'
+function loadSpec(tag) {
+    var url="$base/create?form="+tag.value;
+    load(url);
 }
-ShowForm('$name')
 </script>

--- a/src/python/WMCore/ReqMgr/Utils/Validation.py
+++ b/src/python/WMCore/ReqMgr/Utils/Validation.py
@@ -128,8 +128,8 @@ def create_json_template_spec(specArgs):
         template[key] = value
     return template
 
-def get_request_template_from_type(request_type):
-    pluginFactory = WMFactory("specArgs", "WMSpec.StdSpecs")
+def get_request_template_from_type(request_type, loc="WMSpec.StdSpecs"):
+    pluginFactory = WMFactory("specArgs", loc)
     alteredClassName = "%sWorkloadFactory" % request_type
     spec = pluginFactory.loadObject(classname = request_type, alteredClassName = alteredClassName)
     specArgs = spec.getWorkloadArguments()

--- a/src/python/WMCore/ReqMgr/Web/ReqMgrService.py
+++ b/src/python/WMCore/ReqMgr/Web/ReqMgrService.py
@@ -118,12 +118,10 @@ def request_attr(doc, attrs=None):
 def spec_list(root, spec_path):
     "Return list of specs from given root directory"
     specs = []
-    print "root", root, spec_path
     for fname in os.listdir(root):
         if  not fname.endswith('.py') or fname == '__init__.py':
             continue
         sname = fname.split('.')[0]
-        print "local load", sname, spec_path
         pluginFactory = WMFactory("specArgs", spec_path)
         alteredClassName = "%sWorkloadFactory" % sname
         try:
@@ -132,7 +130,6 @@ def spec_list(root, spec_path):
             print str(err)
             continue
         specs.append(sname)
-    print "\n### specs", specs
     return specs
 
 class ReqMgrService(TemplatedPage):


### PR DESCRIPTION
I implemented support for dynamic templates loading (ticket #5696). The standard templates are loaded from default WMSpec.StdSpecs module, while local ones will be loaded from Specs module within RM_SPECPATH location. During deployment phase someone will need to setup RM_SPECPATH to location of local (dynamic) templates. This directory should have Specs sub-dir with **init**.py file (Specs module). The RM_SPECPATH needs to be added to PYTHONPATH. After that any file which will be dropped into $RM_SPECPATH/Specs will be dynamically loaded into list of specs supported on reqmgr2 interface. The Specs should coded in similar way as WMSpec/StdSpecs modules, i.e. it is python code which contains <Spec>WorkloadFactory class which must perform full validation of the spec according to WMSpec requirements. For tests I used ReDigi.py module, rename it and drop into $RM_SPECPATH/Specs area. Then it appears on reqmgr2 web UI. I also modified reqmgr2 UI to use drop-down menu (instead of ul list) to better handle long list of templates.
