### PR TITLE
Add AccountingGroup to job classAds

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -50,8 +50,9 @@ agentNumber = 0
 # List of BossAir plugins that this agent will use.
 bossAirPlugins = ["CondorPlugin"]
 
-## Plugin with Condor-Python API ...
-bossAirPlugins = ["PyCondorPlugin", "CondorPlugin"]
+# Required for global pool accounting
+glideInAcctGroup = "production"
+glideInAcctGroupUser = "cmsdataops"
 
 # DBS Information.
 localDBSUrl = "https://cmst0dbs.cern.ch:8443/cms_dbs_prod_tier0_writer/servlet/DBSServlet"
@@ -107,6 +108,8 @@ config.BossAir.pluginNames = bossAirPlugins
 config.BossAir.nCondorProcesses = 1
 config.BossAir.multicoreTaskTypes = ["MultiProcessing", "MultiProduction"]
 config.BossAir.submitWMSMode = True
+config.BossAir.acctGroup = glideInAcctGroup
+config.BossAir.acctGroupUser = glideInAcctGroupUser
 
 config.section_("CoreDatabase")
 config.CoreDatabase.connectUrl = databaseUrl

--- a/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
@@ -190,6 +190,10 @@ class CondorPlugin(BasePlugin):
         self.defaultTaskPriority = getattr(config.BossAir, 'defaultTaskPriority', 0)
         self.maxTaskPriority     = getattr(config.BossAir, 'maxTaskPriority', 1e7)
 
+        # Required for global pool accounting
+        self.acctGroup = getattr(config.BossAir, 'acctGroup', "production")
+        self.acctGroupUser = getattr(config.BossAir, 'acctGroupUser', "cmsdataops")
+
         # Build ourselves a pool
         self.pool     = []
         self.input    = None
@@ -849,6 +853,11 @@ class CondorPlugin(BasePlugin):
 
         jdl.append("+WMAgent_AgentName = \"%s\"\n" %(self.agent))
         jdl.append("+JOBGLIDEIN_CMSSite= \"$$([ifThenElse(GLIDEIN_CMSSite is undefined, \\\"Unknown\\\", GLIDEIN_CMSSite)])\"\n")
+
+        # Required for global pool accounting
+        jdl.append("+AcctGroup = \"%s\"\n" % (self.acctGroup))
+        jdl.append("+AcctGroupUser = \"%s\"\n" %(self.acctGroupUser))
+        jdl.append("+AccountingGroup = \"%s.%s\"\n" %(self.acctGroup, self.acctGroupUser))
 
         jdl.extend(self.customizeCommon(jobList))
 

--- a/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
@@ -198,6 +198,10 @@ class PyCondorPlugin(BasePlugin):
         self.defaultTaskPriority = getattr(config.BossAir, 'defaultTaskPriority', 0)
         self.maxTaskPriority     = getattr(config.BossAir, 'maxTaskPriority', 1e7)
 
+        # Required for global pool accounting
+        self.acctGroup = getattr(config.BossAir, 'acctGroup', "production")
+        self.acctGroupUser = getattr(config.BossAir, 'acctGroupUser', "cmsdataops")
+
         # Build ourselves a pool
         self.pool     = []
         self.input    = None
@@ -883,6 +887,11 @@ class PyCondorPlugin(BasePlugin):
 
         jdl.append("+WMAgent_AgentName = \"%s\"\n" %(self.agent))
         jdl.append("+JOBGLIDEIN_CMSSite= \"$$([ifThenElse(GLIDEIN_CMSSite is undefined, \\\"Unknown\\\", GLIDEIN_CMSSite)])\"\n")
+
+        # Required for global pool accounting
+        jdl.append("+AcctGroup = \"%s\"\n" % (self.acctGroup))
+        jdl.append("+AcctGroupUser = \"%s\"\n" %(self.acctGroupUser))
+        jdl.append("+AccountingGroup = \"%s.%s\"\n" %(self.acctGroup, self.acctGroupUser))
         
         jdl.extend(self.customizeCommon(jobList))
 


### PR DESCRIPTION
@Farrukh-Aftab tells me it's needed for proper job accounting in global pool (between CERN and FNAL agents).
I still need to test it, @ticoann don't merge yet please.
