### PR TITLE
Adapt TpE since MaxWallClock works now

### DIFF
--- a/test/data/ReqMgr/requests/DMWM/TaskChainRunJet2012C_multiRun.json
+++ b/test/data/ReqMgr/requests/DMWM/TaskChainRunJet2012C_multiRun.json
@@ -18,7 +18,7 @@
         "ScramArch": "slc6_amd64_gcc481",
         "Memory": 2400,
         "SizePerEvent": 1234,
-        "TimePerEvent": 20,
+        "TimePerEvent": 0.8,
         "TaskChain": 2,
         "mergedLFNBase": "/store/mc",
         "unmergedLFNBase": "/store/unmerged",

--- a/test/data/ReqMgr/requests/DMWM/TaskChain_Data.json
+++ b/test/data/ReqMgr/requests/DMWM/TaskChain_Data.json
@@ -17,7 +17,7 @@
     "ScramArch": "slc5_amd64_gcc481",
     "Memory": 2400,
     "SizePerEvent": 1234,
-    "TimePerEvent": 20,
+    "TimePerEvent": 0.8,
     "MergedLFNBase": "/store/relval",
     "Task1": {"InputDataset": "/Cosmics/Run2011A-v1/RAW",
         "RunWhitelist": [160960],

--- a/test/data/ReqMgr/requests/DMWM/TaskChain_MC.json
+++ b/test/data/ReqMgr/requests/DMWM/TaskChain_MC.json
@@ -14,7 +14,7 @@
     "ScramArch": "slc5_amd64_gcc481",
     "Memory": 2400,
     "SizePerEvent": 1234,
-    "TimePerEvent": 20,
+    "TimePerEvent": 0.8,
     "mergedLFNBase": "/store/relval",
     "unmergedLFNBase": "/store/unmerged",
     "Task1": {"AcquisitionEra": "CMSSW_7_0_0_pre11",

--- a/test/data/ReqMgr/requests/DMWM/TaskChain_MC_PU.json
+++ b/test/data/ReqMgr/requests/DMWM/TaskChain_MC_PU.json
@@ -17,7 +17,7 @@
     "ScramArch": "slc5_amd64_gcc481",
     "Memory": 2400,
     "SizePerEvent": 1234,
-    "TimePerEvent": 20,
+    "TimePerEvent": 0.8,
     "mergedLFNBase": "/store/relval",
     "unmergedLFNBase": "/store/unmerged",
     "Task1": {"AcquisitionEra": "CMSSW_7_0_0_pre11",

--- a/test/data/ReqMgr/requests/DMWM/TaskChain_Multicore.json
+++ b/test/data/ReqMgr/requests/DMWM/TaskChain_Multicore.json
@@ -17,7 +17,7 @@
     "ScramArch": "slc6_amd64_gcc491",
     "Memory": 2400,
     "SizePerEvent": 1234,
-    "TimePerEvent": 20,
+    "TimePerEvent": 0.8,
     "MergedLFNBase": "/store/relval",
     "Multicore": 4,
     "Task1": {"InputDataset": "/SingleElectron/Run2012D-v1/RAW",

--- a/test/data/ReqMgr/requests/DMWM/TaskChain_Task_Multicore.json
+++ b/test/data/ReqMgr/requests/DMWM/TaskChain_Task_Multicore.json
@@ -17,7 +17,7 @@
     "ScramArch": "slc6_amd64_gcc491",
     "Memory": 2400,
     "SizePerEvent": 1234,
-    "TimePerEvent": 20,
+    "TimePerEvent": 0.8,
     "MergedLFNBase": "/store/relval",
     "Multicore": 4,
     "Task1": {"InputDataset": "/SingleElectron/Run2012D-v1/RAW",

--- a/test/data/ReqMgr/requests/TaskChainH130GGgluonfusion_PU.json
+++ b/test/data/ReqMgr/requests/TaskChainH130GGgluonfusion_PU.json
@@ -18,7 +18,7 @@
         "ScramArch": "slc5_amd64_gcc481",
         "Memory": 2400,
         "SizePerEvent": 1234,
-        "TimePerEvent": 20,
+        "TimePerEvent": 0.8,
         "TaskChain": 2,
         "mergedLFNBase": "/store/relval",
         "unmergedLFNBase": "/store/unmerged",

--- a/test/data/ReqMgr/requests/TaskChainProdMinBias.json
+++ b/test/data/ReqMgr/requests/TaskChainProdMinBias.json
@@ -15,7 +15,7 @@
         "ScramArch": "slc5_amd64_gcc481",
         "Memory": 2400,
         "SizePerEvent": 1234,
-        "TimePerEvent": 20,
+        "TimePerEvent": 0.8,
         "TaskChain": 3,
         "mergedLFNBase": "/store/relval",
         "unmergedLFNBase": "/store/unmerged",

--- a/test/data/ReqMgr/requests/TaskChainPyquenZeemumuJets_PU.json
+++ b/test/data/ReqMgr/requests/TaskChainPyquenZeemumuJets_PU.json
@@ -18,7 +18,7 @@
         "ScramArch": "slc5_amd64_gcc481",
         "Memory": 2400,
         "SizePerEvent": 1234,
-        "TimePerEvent": 20,
+        "TimePerEvent": 0.8,
         "TaskChain": 3,
         "mergedLFNBase": "/store/relval",
         "unmergedLFNBase": "/store/unmerged",

--- a/test/data/ReqMgr/requests/TaskChainRunTau2012A.json
+++ b/test/data/ReqMgr/requests/TaskChainRunTau2012A.json
@@ -18,7 +18,7 @@
         "ScramArch": "slc5_amd64_gcc481",
         "Memory": 2400,
         "SizePerEvent": 1234,
-        "TimePerEvent": 20,
+        "TimePerEvent": 0.8,
         "TaskChain": 2,
         "MergedLFNBase": "/store/relval",
         "Task1": {"InputDataset": "/Tau/Run2012A-v1/RAW",

--- a/test/data/ReqMgr/requests/TaskChainSingleMuPt100FastSim.json
+++ b/test/data/ReqMgr/requests/TaskChainSingleMuPt100FastSim.json
@@ -18,7 +18,7 @@
         "ScramArch": "slc5_amd64_gcc481",
         "Memory": 2400,
         "SizePerEvent": 1234,
-        "TimePerEvent": 20,
+        "TimePerEvent": 0.8,
         "TaskChain": 1,
         "mergedLFNBase": "/store/relval",
         "unmergedLFNBase": "/store/unmerged",

--- a/test/data/ReqMgr/requests/TaskChainTTbar.json
+++ b/test/data/ReqMgr/requests/TaskChainTTbar.json
@@ -18,7 +18,7 @@
         "ScramArch": "slc5_amd64_gcc481",
         "Memory": 2400,
         "SizePerEvent": 1234,
-        "TimePerEvent": 20,
+        "TimePerEvent": 0.8,
         "TaskChain": 3,
         "mergedLFNBase": "/store/relval",
         "unmergedLFNBase": "/store/unmerged",

--- a/test/data/ReqMgr/requests/TaskChainZJetsLNu_LHE.json
+++ b/test/data/ReqMgr/requests/TaskChainZJetsLNu_LHE.json
@@ -18,7 +18,7 @@
         "ScramArch": "slc5_amd64_gcc481",
         "Memory": 2000,
         "SizePerEvent": 10,
-        "TimePerEvent": 1,
+        "TimePerEvent": 0.5,
         "TaskChain": 1,
         "mergedLFNBase": "/store/relval",
         "unmergedLFNBase": "/store/unmerged",

--- a/test/data/ReqMgr/requests/TaskChainZTT_PU.json
+++ b/test/data/ReqMgr/requests/TaskChainZTT_PU.json
@@ -18,7 +18,7 @@
         "ScramArch": "slc5_amd64_gcc481",
         "Memory": 2400,
         "SizePerEvent": 1234,
-        "TimePerEvent": 20,
+        "TimePerEvent": 0.8,
         "TaskChain": 3,
         "mergedLFNBase": "/store/relval",
         "unmergedLFNBase": "/store/unmerged",


### PR DESCRIPTION
Jobs may get stuck in pending if MaxWallClock goes beyond 48h, so decreasing TpE everywhere where it may happen.
