### PR TITLE
New set of changes for issue5702

### DIFF
--- a/src/html/ReqMgr/templates/doc.tmpl
+++ b/src/html/ReqMgr/templates/doc.tmpl
@@ -50,7 +50,7 @@ $jsondata
 <script>
 function ChangeRequestStatus() {
     var parameters = \$('change-status-form').serialize(true);
-    ajaxRequest('$base/data/request', parameters);
+    ajaxRequest('$base/put_request', parameters);
 }
 function ActivateTable() {
     var id = document.getElementById('btn-table');

--- a/src/python/WMCore/ReqMgr/Web/ReqMgrService.py
+++ b/src/python/WMCore/ReqMgr/Web/ReqMgrService.py
@@ -389,7 +389,7 @@ class ReqMgrService(TemplatedPage):
         return [r for r in genobjs(jsondict)]
 
     @expose
-    def fetch(self, rid):
+    def fetch(self, rid, **kwds):
         "Fetch document for given id"
         rid = rid.replace('request-', '')
         doc = self.reqmgr.getRequestByNames(rid)
@@ -500,6 +500,19 @@ class ReqMgrService(TemplatedPage):
         return self.abs_page('batches', content)
 
     ### Aux methods ###
+
+    @expose
+    def put_request(self, *args, **kwds):
+        "PUT request callback to reqmgr server, should be used in AJAX"
+        reqname = kwds.get('RequestName', '')
+        status = kwds.get('RequestStatus', '')
+        if  not reqname:
+            msg = 'Unable to update request status, empty request name'
+            raise cherrypy.HTTPError(406, msg)
+        if  not status:
+            msg = 'Unable to update request status, empty status value'
+            raise cherrypy.HTTPError(406, msg)
+        return self.reqmgr.updateRequestStatus(reqname, status)
 
     @expose
     def images(self, *args, **kwargs):


### PR DESCRIPTION
In order to resolve issue5702 (manually update request status) we need to use PUT request for given request name and status. The problem is that underlying prototype library do not handle properly put request, see http://api.prototypejs.org/ajax/ (method description in Common option section) and therefore I'll need to create wrapper server method to invoke put request.
