### PR TITLE
Changes to migrate from prototype to jQuery library

### DIFF
--- a/src/html/ReqMgr/javascript/ajax_utils.js
+++ b/src/html/ReqMgr/javascript/ajax_utils.js
@@ -63,6 +63,7 @@ function ajaxRequest(path, parameters, verb) {
         type: verb || 'POST',
         // headers: {"X-HTTP-Method-Override": "PUT"}, // X-HTTP-Method-Override set to PUT.
         dataType: "json",
+        cache: false,
         beforeSend: function() {
             var doc = document.getElementById('confirmation');
             doc.innerHTML='Your request has been submitted';
@@ -72,20 +73,21 @@ function ajaxRequest(path, parameters, verb) {
     request.done(function(data) {
         $('response').html(data);
     });
-    request.fail(function(xhr, msg) {
+    request.fail(function(xhr, msg, err) {
         var doc = document.getElementById('confirmation');
-        doc.innerHTML='ERROR! Your request has been failed with status code '+xhr.status+' and error message '+msg;
+        doc.innerHTML='ERROR! Your request has been failed with status code '+xhr.status+' and '+msg+' '+err;
         doc.className='tools-alert tools-alert-red confirmation fadeout shadow';
-        setTimeout(cleanConfirmation, 5000);
+        var headers = xhr.getAllResponseHeaders();
+        errorMessage(headers);
     });
-    request.always(function (xhr, msg) {
+    request.always(function (xhr, msg, err) {
         var doc = document.getElementById('confirmation');
         if  (xhr.status==200 || xhr.status==201) {
             doc.innerHTML='SUCCESS! Your request has been processed with status code '+xhr.status;
             doc.className='tools-alert tools-alert-green confirmation fadeout shadow';
             setTimeout(cleanConfirmation, 5000);
         } else {
-            doc.innerHTML='WARNING! Your request has been processed with status code '+xhr.status+' and error message'+msg;
+            doc.innerHTML='WARNING! Your request has been processed with status code '+xhr.status+' and '+msg+' '+err;
             doc.className='tools-alert tools-alert-yellow confirmation fadeout shadow';
             var headers = xhr.getAllResponseHeaders();
             errorMessage(headers);

--- a/src/html/ReqMgr/javascript/ajax_utils.js
+++ b/src/html/ReqMgr/javascript/ajax_utils.js
@@ -72,20 +72,20 @@ function ajaxRequest(path, parameters, verb) {
     request.done(function(data) {
         $('response').html(data);
     });
-    request.fail(function(xhr, status) {
+    request.fail(function(xhr, msg) {
         var doc = document.getElementById('confirmation');
-        doc.innerHTML='ERROR! Your request has been failed';
+        doc.innerHTML='ERROR! Your request has been failed with status code '+xhr.status+' and error message '+msg;
         doc.className='tools-alert tools-alert-red confirmation fadeout shadow';
         setTimeout(cleanConfirmation, 5000);
     });
-    request.always(function (xhr, status) {
+    request.always(function (xhr, msg) {
         var doc = document.getElementById('confirmation');
-        if  (status==200 || status==201) {
-            doc.innerHTML='SUCCESS! Your request has been processed with status '+status;
+        if  (xhr.status==200 || xhr.status==201) {
+            doc.innerHTML='SUCCESS! Your request has been processed with status code '+xhr.status;
             doc.className='tools-alert tools-alert-green confirmation fadeout shadow';
             setTimeout(cleanConfirmation, 5000);
         } else {
-            doc.innerHTML='WARNING! Your request has been processed with status '+status;
+            doc.innerHTML='WARNING! Your request has been processed with status code '+xhr.status+' and error message'+msg;
             doc.className='tools-alert tools-alert-yellow confirmation fadeout shadow';
             var headers = xhr.getAllResponseHeaders();
             errorMessage(headers);

--- a/src/html/ReqMgr/javascript/ajax_utils.js
+++ b/src/html/ReqMgr/javascript/ajax_utils.js
@@ -80,14 +80,17 @@ function ajaxRequest(path, parameters, verb) {
         var headers = xhr.getAllResponseHeaders();
         errorMessage(headers);
     });
-    request.always(function (xhr, msg, err) {
+    request.always(function (arg1, msg, arg2) {
+        // from jQuery docs: http://api.jquery.com/jquery.ajax/
+        // for successful events the input parameters are (data, msg, xhr)
+        // for failed events the input parameters are (xhr, msg, err)
         var doc = document.getElementById('confirmation');
-        if  (xhr.status==200 || xhr.status==201) {
-            doc.innerHTML='SUCCESS! Your request has been processed with status code '+xhr.status;
+        if  (arg2.status==200 || arg2.status==201 || msg=='success') {
+            doc.innerHTML='SUCCESS! Your request has been processed with code '+arg2.status;
             doc.className='tools-alert tools-alert-green confirmation fadeout shadow';
             setTimeout(cleanConfirmation, 5000);
         } else {
-            doc.innerHTML='WARNING! Your request has been processed with status code '+xhr.status+' and '+msg+' '+err;
+            doc.innerHTML='WARNING! Your request has been processed with status code '+arg1.status+' and '+msg+' '+arg2;
             doc.className='tools-alert tools-alert-yellow confirmation fadeout shadow';
             var headers = xhr.getAllResponseHeaders();
             errorMessage(headers);

--- a/src/html/ReqMgr/javascript/ajax_utils.js
+++ b/src/html/ReqMgr/javascript/ajax_utils.js
@@ -22,7 +22,7 @@ function errorMessage(err) {
     doc.innerHTML=html;
     doc.className='width-50 tools-alert tools-alert-red confirmation shadow';
 }
-function ajaxRequest(path, parameters) {
+function ajaxRequestPrototype(path, parameters) {
     // path is an URI binded to certain server method
     // parameters is dict of parameters passed to the server function
     new Ajax.Updater('response', path,
@@ -52,5 +52,43 @@ function ajaxRequest(path, parameters) {
               errorMessage(headers);
           }
       }
+    });
+}
+function ajaxRequest(path, parameters, verb) {
+    // path is an URI binded to certain server method
+    // parameters is dict of parameters passed to the server function
+    var request = $.ajax({
+        url: path,
+        data: parameters,
+        type: verb || 'POST',
+        // headers: {"X-HTTP-Method-Override": "PUT"}, // X-HTTP-Method-Override set to PUT.
+        dataType: "json",
+        beforeSend: function() {
+            var doc = document.getElementById('confirmation');
+            doc.innerHTML='Your request has been submitted';
+            doc.className='tools-alert tools-alert-blue confirmation fadeout shadow';
+        }
+    });
+    request.done(function(data) {
+        $('response').html(data);
+    });
+    request.fail(function(xhr, status) {
+        var doc = document.getElementById('confirmation');
+        doc.innerHTML='ERROR! Your request has been failed';
+        doc.className='tools-alert tools-alert-red confirmation fadeout shadow';
+        setTimeout(cleanConfirmation, 5000);
+    });
+    request.always(function (xhr, status) {
+        var doc = document.getElementById('confirmation');
+        if  (status==200 || status==201) {
+            doc.innerHTML='SUCCESS! Your request has been processed with status '+status;
+            doc.className='tools-alert tools-alert-green confirmation fadeout shadow';
+            setTimeout(cleanConfirmation, 5000);
+        } else {
+            doc.innerHTML='WARNING! Your request has been processed with status '+status;
+            doc.className='tools-alert tools-alert-yellow confirmation fadeout shadow';
+            var headers = xhr.getAllResponseHeaders();
+            errorMessage(headers);
+        }
     });
 }

--- a/src/html/ReqMgr/templates/assign.tmpl
+++ b/src/html/ReqMgr/templates/assign.tmpl
@@ -190,9 +190,9 @@ function ProcessRequests(new_status) {
     }
     if (ids.length>0) {
         // capture form id="assign-settings"
-        var parameters = \$('assign-settings').serialize(true);
+        var parameters = \$('#assign-settings').serialize();
         // capture form id="assign-misc-settings"
-        var misc_args = \$('assign-misc-settings').serialize(true);
+        var misc_args = \$('#assign-misc-settings').serialize();
         // merge misc_args with parameters
         for (var attr in misc_args) { parameters[attr] = misc_args[attr]; }
         parameters.ids = ids;

--- a/src/html/ReqMgr/templates/batch.tmpl
+++ b/src/html/ReqMgr/templates/batch.tmpl
@@ -65,7 +65,7 @@ $attributes
 function CreateBatch(formtag) {
     var parameters = {};
     if (formtag=='batch-form') {
-        parameters = \$('batch-form').serialize(true);
+        parameters = \$('#batch-form').serialize();
     }
     ajaxRequest('$base/data/request', parameters);
 }

--- a/src/html/ReqMgr/templates/create.tmpl
+++ b/src/html/ReqMgr/templates/create.tmpl
@@ -81,7 +81,7 @@ $jsondata
 function CreateRequest(formtag) {
     var parameters = {};
     if (formtag=='table-form') {
-        parameters = \$('table-form').serialize(true);
+        parameters = \$('#table-form').serialize();
     } else if (formtag=='json-form') {
         var doc = document.getElementById('jsondict');
         var data = doc.value;

--- a/src/html/ReqMgr/templates/doc.tmpl
+++ b/src/html/ReqMgr/templates/doc.tmpl
@@ -49,8 +49,8 @@ $jsondata
 
 <script>
 function ChangeRequestStatus() {
-    var parameters = \$('change-status-form').serialize(true);
-    ajaxRequest('$base/put_request', parameters);
+    var parameters = \$('#change-status-form').serialize();
+    ajaxRequest('$base/data/request', parameters, 'PUT');
 }
 function ActivateTable() {
     var id = document.getElementById('btn-table');

--- a/src/html/ReqMgr/templates/doc.tmpl
+++ b/src/html/ReqMgr/templates/doc.tmpl
@@ -11,7 +11,6 @@
     </nav>
 </header>
 <hr/>
-<form id="change-status-form" name="change-status-form" method="post">
 <header class="group">
 <nav class="navbar navbar-right">
 <ul>
@@ -29,7 +28,6 @@ Status: <b>$status</b> to
 </li>
 </nav>
 </header>
-</form>
 
 <div name="edit-table" id="edit-table">
 $table
@@ -49,7 +47,7 @@ $jsondata
 
 <script>
 function ChangeRequestStatus() {
-    var parameters = \$('#change-status-form').serialize();
+    var parameters = {'RequestStatus':\$('#RequestStatus').val()};
     ajaxRequest('$base/data/request', parameters, 'PUT');
 }
 function ActivateTable() {

--- a/src/html/ReqMgr/templates/doc.tmpl
+++ b/src/html/ReqMgr/templates/doc.tmpl
@@ -48,7 +48,7 @@ $jsondata
 <script>
 function ChangeRequestStatus() {
     var parameters = {'RequestStatus':\$('#RequestStatus').val()};
-    ajaxRequest('$base/data/request', parameters, 'PUT');
+    ajaxRequest('$base/data/request/$name', parameters, 'PUT');
 }
 function ActivateTable() {
     var id = document.getElementById('btn-table');

--- a/src/html/ReqMgr/templates/main.tmpl
+++ b/src/html/ReqMgr/templates/main.tmpl
@@ -4,7 +4,9 @@
     <title>ReqMgr Prototype</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script src="$base/js/?f=utils.js&amp;f=prototype.js&amp;f=ajax_utils.js&amp;f=md5.js"></script>
+    <script src="$base/js/?f=utils.js&amp;f=ajax_utils.js&amp;f=md5.js"></script>
+    <script src="//code.jquery.com/jquery-1.11.2.min.js"></script>
+    <script src="//code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
     <link rel="stylesheet" href="$base/css/?f=kube.min.css&amp;f=main.css" />
 </head>
 <body class="kubepage">


### PR DESCRIPTION
I modified ajaxRequest to use jQuery syntax, for other templates it was required to use hash tag of placeholder. And, for jQuery libs I used CDN links, once it will be included in release we can switch to use local library.
