### PR TITLE
force SCRAM version, do not allow scram to pick another

### DIFF
--- a/src/python/WMCore/WMRuntime/Tools/Scram.py
+++ b/src/python/WMCore/WMRuntime/Tools/Scram.py
@@ -139,7 +139,7 @@ class Scram:
         # send commands to the subshell utilising the process writer method
         self.procWriter(proc, "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$VO_CMS_SW_DIR/COMP/slc5_amd64_gcc434/external/openssl/0.9.7m/lib:$VO_CMS_SW_DIR/COMP/slc5_amd64_gcc434/external/bz2lib/1.0.5/lib\n")
         self.procWriter(proc, self.preCommand())
-        self.procWriter(proc, "%s project CMSSW %s\n" % (self.command, self.version))
+        self.procWriter(proc, "%s --arch %s project CMSSW %s\n" % (self.command, self.architecture, self.version))
         self.procWriter(proc, """if [ "$?" -ne "0" ]; then exit 3; fi\n""")
         self.procWriter(proc, "exit 0")
 


### PR DESCRIPTION
As the title says, force scram to only use the scram version that is requested, ie. does not allow to switch to another supported architecture on its own (as it normally would do if the release does not exist for what is set in SCRAM_ARCH).
