### PR TITLE
slice the multi lfns and lumis for dbs call

### DIFF
--- a/src/python/WMCore/Lexicon.py
+++ b/src/python/WMCore/Lexicon.py
@@ -566,3 +566,19 @@ def primaryDatasetType(candidate):
         return True
     # to sync with the check() exception when it doesn't match
     raise AssertionError("Invalid primary dataset type : %s should be 'mc' or 'data' or 'test'" % candidate)
+
+def slicedIterator(sourceList, sliceSize):
+    """
+    :param: sourceList: list which need to be sliced
+    :type: list
+    :param: sliceSize: size of the slice
+    :type: int
+    :return: iterator of the sliced list 
+    """
+    start = 0
+    end = 0
+
+    while len(sourceList) > end:
+        end = start + sliceSize
+        yield sourceList[start: end]
+        start = end

--- a/src/python/WMCore/WorkQueue/Policy/Start/Block.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Block.py
@@ -219,8 +219,11 @@ class Block(StartPolicyInterface):
         # fill block lfn part of maskedBlocks
 
         for run, lumis in lumiMask.items():
-            files = dbs.dbs.listFileArray(dataset=datasetPath, run_num=run,
-                                      lumi_list=lumis, detail=True)
+            files = []
+            for slumis in Lexicon.slicedIterator(lumis, 50):
+                slicedFiles = dbs.dbs.listFileArray(dataset=datasetPath, run_num=run,
+                                       lumi_list=slumis, detail=True)
+                files.extend(slicedFiles)
             for file in files:
                 blockName = file['block_name']
                 fileName = file['logical_file_name']


### PR DESCRIPTION
This is temporary solution, remove this when DBS api handles long list of parameters.
