### PR TITLE
In case inputdataset is not specified

### DIFF
--- a/src/python/WMCore/WMDataMining/Utils.py
+++ b/src/python/WMCore/WMDataMining/Utils.py
@@ -134,7 +134,7 @@ def gatherWMDataMiningStats(wmstatsUrl, reqmgrUrl, wmMiningUrl,
             outputdatasets = requests[wf].get('outputdatasets', [])
 
             # Can be an empty list, full list, empty string, or non-empty string!
-            inputdataset = requests[wf]['inputdataset']
+            inputdataset = requests[wf].get('inputdataset', "")
             if isinstance(inputdataset, (list,)):
                 if inputdataset:
                     inputdataset = inputdataset[0]


### PR DESCRIPTION
Not sure whether this is legitimate case, but seeing errors like from testbed

[29/Mar/2015:05:53:42]  Periodic Thread ERROR **builtins**.KeyError 'inputdataset'
[29/Mar/2015:05:53:42]   Traceback (most recent call last):
[29/Mar/2015:05:53:42]     File "/data/srv/beHG1504c/sw.pre/slc6_amd64_gcc481/cms/reqmgr2/1.0.5.pre7/lib/python2.6/site-packages/WMCore/ReqMgr/CherryPyThreads/CherryPyPeriodicTask.py", line 74, in run
[29/Mar/2015:05:53:42]       self.taskFunc(self.config)
[29/Mar/2015:05:53:42]     File "/data/srv/beHG1504c/sw.pre/slc6_amd64_gcc481/cms/reqmgr2/1.0.5.pre7/lib/python2.6/site-packages/WMCore/ReqMgr/CherryPyThreads/WMDataMining.py", line 30, in gatherActiveDataStats
[29/Mar/2015:05:53:42]       archived = False, log = cherrypy.log)
[29/Mar/2015:05:53:42]     File "/data/srv/beHG1504c/sw.pre/slc6_amd64_gcc481/cms/reqmgr2/1.0.5.pre7/lib/python2.6/site-packages/WMCore/WMDataMining/Utils.py", line 137, in gatherWMDataMiningStats
[29/Mar/2015:05:53:42]       inputdataset = requests[wf]['inputdataset']
[29/Mar/2015:05:53:42]   KeyError: 'inputdataset'
