### PR TITLE
set secondary job priority, fixes #5688

### DIFF
--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -410,7 +410,8 @@ class JobSubmitterPoller(BaseWorkerThread):
                        newJob['task_name'],
                        frozenset(potentialLocations),
                        loadedJob.get("numberOfCores", 1),
-                      )
+                       newJob['task_id']
+                       )
 
             self.jobDataCache[workflowName][jobID] = jobInfo
 
@@ -718,6 +719,7 @@ class JobSubmitterPoller(BaseWorkerThread):
                                'taskPriority' : self.workflowPrios[workflow],
                                'taskName' : cachedJob[17],
                                'numberOfCores' : cachedJob[19],
+                               'taskID' : cachedJob[20],
                                'potentialSites' : potentialSites}
 
                     # Add to jobsToSubmit

--- a/src/python/WMCore/BossAir/BossAirAPI.py
+++ b/src/python/WMCore/BossAir/BossAirAPI.py
@@ -413,10 +413,8 @@ class BossAirAPI(WMConnectionBase):
         successJobs  = []
         failureJobs  = []
 
-
         #TODO: Add plugin and user to input via JobSubmitter
         # IMPORTANT IMPORTANT IMPORTANT
-
 
         # Put job into RunJob format
         runJobs = []

--- a/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
@@ -970,6 +970,9 @@ class CondorPlugin(BasePlugin):
 
             jdl.append("priority = %i\n" % (task_priority + prio*self.maxTaskPriority))
 
+            jdl.append("+PostJobPrio1 = -%d\n" % len(job.get('potentialSites', [])))
+            jdl.append("+PostJobPrio2 = -%d\n" % job['taskID'])
+
             jdl.append("+WMAgent_JobID = %s\n" % job['jobid'])
 
             jdl.append("Queue 1\n")

--- a/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
@@ -1004,6 +1004,9 @@ class PyCondorPlugin(BasePlugin):
 
             jdl.append("priority = %i\n" % (task_priority + prio*self.maxTaskPriority))
 
+            jdl.append("+PostJobPrio1 = -%d\n" % len(job.get('potentialSites', [])))
+            jdl.append("+PostJobPrio2 = -%d\n" % job['taskID'])
+
             jdl.append("+WMAgent_JobID = %s\n" % job['jobid'])
             jdl.append("job_machine_attrs = GLIDEIN_CMSSite\n")
 

--- a/src/python/WMCore/BossAir/RunJob.py
+++ b/src/python/WMCore/BossAir/RunJob.py
@@ -29,7 +29,8 @@ class RunJob(dict):
                  scram_arch = None, siteName = None, jobName = None,
                  proxyPath = None, requestName = None, jobTime = None,
                  diskUsage = None, memoryUsage = None, taskPriority = None,
-                 taskName = None, potentialSites = None, numberOfCores = 1,
+                 taskName = None, taskID = None, potentialSites = None,
+                 numberOfCores = 1,
                 ):
         """
         Just make sure you init the dictionary fields.
@@ -70,6 +71,7 @@ class RunJob(dict):
         self.setdefault('numberOfCores', numberOfCores)
         self.setdefault('taskPriority', taskPriority)
         self.setdefault('taskName', taskName)
+        self.setdefault('taskID', taskID)
         self.setdefault('potentialSites', potentialSites)
 
         return

--- a/src/python/WMCore/WMBS/MySQL/Jobs/ListForSubmitter.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/ListForSubmitter.py
@@ -17,6 +17,7 @@ class ListForSubmitter(DBFormatter):
                     wmbs_subscription.workflow as workflow,
                     wmbs_subscription.last_update as timestamp,
                     wmbs_workflow.name as request_name,
+                    wmbs_workflow.id as task_id,
                     wmbs_workflow.priority as task_priority,
                     wmbs_workflow.task as task_name
                     FROM wmbs_job


### PR DESCRIPTION
This sets a secondary job priority to the negative number of sites the job can run at and a tertiary priority to the negative task id. Look at #5688 for a long discussion on this topic.
