### PR TITLE
Add CMS_JobType into the JDL.

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
@@ -1012,8 +1012,8 @@ class CondorPlugin(BasePlugin):
         if job.get('taskName', None):
             jdl.append('+WMAgent_SubTaskName = "%s"\n' % job['taskName'])
 
-        if job.get('subTaskType', None):
-            jdl.append('+WMAgent_SubTaskType = "%s"\n' % job['taskType'])
+        if job.get('taskType', None):
+            jdl.append('+CMS_JobType = "%s"\n' % job['taskType'])
 
         # Performance estimates
         if job.get('estimatedJobTime', None):

--- a/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
@@ -1050,8 +1050,8 @@ class PyCondorPlugin(BasePlugin):
         if job.get('taskName', None):
             jdl.append('+WMAgent_SubTaskName = "%s"\n' % job['taskName'])
 
-        if job.get('subTaskType', None):
-            jdl.append('+WMAgent_SubTaskType = "%s"\n' % job['taskType'])
+        if job.get('taskType', None):
+            jdl.append('+CMS_JobType = "%s"\n' % job['taskType'])
 
         # Performance estimates
         if job.get('estimatedJobTime', None):


### PR DESCRIPTION
 Can be for reprioritization by HTCondor or enforcing global resource control in GlideinWMS.

Fixes #5748 
