### PR TITLE
Corrects format of PU files in the CMSSW MixingModule

### DIFF
--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -423,7 +423,7 @@ class SetupCMSSWPset(ScriptInterface):
                         if seLocalName in blockDict["StorageElementNames"]:
                             eventsAvailable += int(blockDict.get('NumberOfEvents', 0))
                             for fileLFN in blockDict["FileList"]:
-                                inputTypeAttrib.fileNames.append(str(fileLFN))
+                                inputTypeAttrib.fileNames.append(fileLFN['logical_file_name'])
                     if requestedPileupType == 'data':
                         baggage = self.job.getBaggage()
                         if getattr(baggage, 'skipPileupEvents', None) is not None:


### PR DESCRIPTION
Adapting the list of PU fileNames to a correct format, with the latest changes to DBS it was filling this variable with dictionaries like

```
fileNames = cms.untracked.vstring( ("{\'logical_file_name\': \'/store/mc/Summer12/MinBias_TuneZ2star_8TeV-pythia6/GEN-SIM/START50_V13-v3/0002/0E28D15B-9867-E111-A442-00266CF2ABA8.root\'}",
            "{\'logical_file_name\': \'/store/mc/Summer12/MinBias_TuneZ2star_8TeV-pythia6/GEN-SIM/START50_V13-v3/0002/10C4B861-9967-E111-A6B0-0025901D493A.root\'}", ...
```

we need to have a simple string there. This should fix this issue.
Testing it now.
