### PR TITLE
Forbids auto-approval to MSS endpoint

### DIFF
--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
@@ -356,6 +356,9 @@ class Assign(WebAPI):
         custodialList = kwargs.get("CustodialSites", [])
         nonCustodialList = kwargs.get("NonCustodialSites", [])
         autoApproveList = kwargs.get("AutoApproveSubscriptionSites", [])
+        for site in autoApproveList:
+            if site.endswith('_MSS'):
+                raise cherrypy.HTTPError(400, "Auto-approval to MSS endpoint not allowed %s" % autoApproveList)
         subscriptionPriority = kwargs.get("SubscriptionPriority", "Low")
         if subscriptionPriority not in ["Low", "Normal", "High"]:
             raise cherrypy.HTTPError(400, "Invalid subscription priority %s" % subscriptionPriority)


### PR DESCRIPTION
Don't accept assignment if user provides a MSS endpoint in the "AutoApproveSubscriptionSites" list.
Will take effect only when we deploy a new ReqMgr...
@ticoann , please take a look.
