### PR TITLE
Fix listFilesInBlockWithParents since parent lfn is a list

### DIFF
--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -498,7 +498,9 @@ class DBS3Reader:
 
         childByParents = defaultdict(list)
         for f in files:
-            childByParents[f['parent_logical_file_name']].append(f['logical_file_name'])
+            # Probably a child can have more than 1 parent file
+            for fp in f['parent_logical_file_name']:
+                childByParents[fp].append(f['logical_file_name'])
         parentsLFNs = childByParents.keys()
         
         parentFilesDetail = []
@@ -508,7 +510,7 @@ class DBS3Reader:
             parentFilesDetail.extend(self.dbs.listFileArray(logical_file_name = pLFNs, detail = True))
         
         if lumis:
-            parentLumis = self._getLumiList(lfn = parentsLFNs)
+            parentLumis = self._getLumiList(lfns = parentsLFNs)
         
         parentsByLFN = defaultdict(list)
         


### PR DESCRIPTION
There were 2 problems in a row:
1. 'f['parent_logical_file_name']' was a list and so cannot be a dict key
2. then a wrong argument name for _getLumiList
   @ticoann please review, though I'm going to push it to the other agents right now :-D

I will create the same patch for 1.0.5_wmagent and will also create a json template to exercise this includeParents part, my fault not to have gotten it during validation :-(
