### PR TITLE
support multiple URL for DQM GUI upload

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
@@ -160,13 +160,14 @@ class DQMUpload(Executor):
         logging.info(msg)
 
         try:
-            (headers, data) = self.upload(self.step.upload.URL, args, filename)
-            msg = 'HTTP upload finished succesfully with response:\n'
-            msg += 'Status code: %s\n' % headers.get("Dqm-Status-Code", None)
-            msg += 'Message: %s\n' % headers.get("Dqm-Status-Message", None)
-            msg += 'Detail: %s\n' % headers.get("Dqm-Status-Detail", None)
-            msg += 'Data: %s\n' % str(data)
-            logging.info(msg)
+            for uploadURL in self.step.upload.URL.split(';'):
+                (headers, data) = self.upload(uploadURL, args, filename)
+                msg = 'HTTP upload finished succesfully with response:\n'
+                msg += 'Status code: %s\n' % headers.get("Dqm-Status-Code", None)
+                msg += 'Message: %s\n' % headers.get("Dqm-Status-Message", None)
+                msg += 'Detail: %s\n' % headers.get("Dqm-Status-Detail", None)
+                msg += 'Data: %s\n' % str(data)
+                logging.info(msg)
         except urllib2.HTTPError, ex:
             msg = 'HTTP upload failed with response:\n'
             msg += 'Status code: %s\n' % ex.hdrs.get("Dqm-Status-Code", None)


### PR DESCRIPTION
Allows to pass multiple DQM GUI server ulrs to the DQMUpload step, this will be needed temporarily for Tier0 operations as the DQM GUI server is migrated to new hardware. For validation purposes the DQM team wants to run the old and new servers in parallel for a while.

Change is simple enough and doesn't cause overheads or problems for the single server use case, hence the request to merge this into the main code base.
