### PR TITLE
fix read settings for repack jobs

### DIFF
--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -540,6 +540,17 @@ class SetupCMSSWPset(ScriptInterface):
 
         self.fixupProcess()
 
+        # repack is only run at CERN and has a streaming format as input that should never use lazy-download
+        if funcName == "repack":
+            print "Hardcoding read/cache strategies for repack"
+            self.process.add_(
+                cms.Service("SiteLocalConfigService",
+                            overrideSourceCacheHintDir = cms.untracked.string("storage-only"),
+                            overrideSourceReadHint = cms.untracked.string("read-ahead-buffered"),
+                            overrideSourceTTreeCacheSize = cms.untracked.uint32(20*1024*1024)
+                            )
+                )
+
         try:
             if int(self.step.data.application.multicore.numberOfCores) > 1:
                 numCores = int(self.step.data.application.multicore.numberOfCores)


### PR DESCRIPTION
Repack jobs have as input a streaming format. There is some ambiguity on the CERN site read settings (lazy-download or not), hard code an override for the repack read settings.
