### PR TITLE
allow to set number of cores in job splitting

### DIFF
--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -389,6 +389,14 @@ class JobSubmitterPoller(BaseWorkerThread):
 
                 locTypeCache[workflowName].add(jobID)
 
+            # allow job baggage to override numberOfCores
+            #       => used for repacking to get more slots/disk
+            numberOfCores = loadedJob.get('numberOfCores', 1)
+            if numberOfCores == 1:
+                baggage = loadedJob.getBaggage()
+                numberOfCores = getattr(baggage, "numberOfCores", 1)
+            loadedJob['numberOfCores'] = numberOfCores
+
             # Now that we're out of that loop, put the job data in the cache
             jobInfo = (jobID,
                        newJob["retry_count"],


### PR DESCRIPTION
For now this is only used for repack where very large input files will trigger a request to run a job with multiple cores to be able to use multiple 20GB disk slots.

Only supported for jobs that are originally single core.
