### PR TITLE
Refactor LogDB to use one back-end and use deterministic ids

### DIFF
--- a/src/couchapps/LogDB/views/tstamp/map.js
+++ b/src/couchapps/LogDB/views/tstamp/map.js
@@ -1,5 +1,7 @@
 function(doc) {
-    if (doc.ts) {
-        emit(doc.ts, null);
+    if(doc.comments) {
+        for(i=0;i<doc.comments.length;i++) {
+            emit(doc.comments[i].ts, null);
+        }
     }
 }

--- a/src/python/WMCore/Services/LogDB/LogDB.py
+++ b/src/python/WMCore/Services/LogDB/LogDB.py
@@ -6,6 +6,7 @@ https://github.com/dmwm/WMCore/issues/5705
 
 # standard modules
 import os
+import re
 import logging
 import threading
 
@@ -20,7 +21,7 @@ class LogDB(object):
 
     LogDB object - interface to LogDB functionality.
     """
-    def __init__(self, url, identifier, centralurl=None, logger=None, **kwds):
+    def __init__(self, url, identifier, logger=None, **kwds):
         self.logger = logger if logger else logging.getLogger()
         if  not url or not identifier:
             raise RuntimeError("Attempt to init LogDB with url='%s', identifier='%s'"\
@@ -30,26 +31,26 @@ class LogDB(object):
             self.thread_name = kwds.pop('thread_name')
         except KeyError:
             self.thread_name = threading.currentThread().getName()
-        self.agent = 1 if centralurl else 0
-        self.localurl = url
-        self.centralurl = centralurl
-        couch_url, db_name = splitCouchServiceURL(self.localurl)
-        self.backend = LogDBBackend(couch_url, db_name, identifier, self.thread_name, self.agent, **kwds)
-        self.central = None
-        if  centralurl:
-            couch_url, db_name = splitCouchServiceURL(self.centralurl)
-            self.central = LogDBBackend(couch_url, db_name, identifier, self.thread_name, self.agent, **kwds)
+        self.url = url
+        self.user_pat = re.compile(r'^/[a-zA-Z][a-zA-Z0-9/\=\s()\']*\=[a-zA-Z0-9/\=\.\-_/#:\s\']*$')
+        self.agent = 0 if self.user_pat.match(self.identifier) else 1
+        couch_url, db_name = splitCouchServiceURL(self.url)
+        self.backend = LogDBBackend(couch_url, db_name, identifier, \
+                self.thread_name, agent=self.agent, **kwds)
         self.logger.info(self)
 
     def __repr__(self):
         "Return representation for class"
-        return "<LogDB(local=%s, central=%s, agent=%s)>" \
-                % (self.localurl, self.centralurl, self.agent)
+        return "<LogDB(url=%s, identifier=%s, agent=%1)>" \
+                % (self.url, self.identifier, self.agent)
 
     def post(self, request, msg, mtype="comment"):
         """Post new entry into LogDB for given request"""
         try:
-            res = self.backend.post(request, msg, mtype)
+            if  self.user_pat.match(self.identifier):
+                res = self.backend.user_update(request, msg, mtype)
+            else:
+                res = self.backend.agent_update(request, msg, mtype)
         except Exception as exc:
             self.logger.error("LogDBBackend post API failed, error=%s" % str(exc))
             res = 'post-error'
@@ -58,9 +59,16 @@ class LogDB(object):
 
     def get(self, request, mtype="comment"):
         """Retrieve all entries from LogDB for given request"""
+        res = []
         try:
-            res = [clean_entry(r['doc']) for r in \
-                    self.backend.get(request, mtype).get('rows', [])]
+            for row in self.backend.get(request, mtype).get('rows', []):
+                request = row['doc']['request']
+                identifier = row['doc']['identifier']
+                thr = row['doc']['thr']
+                mtype = row['doc']['type']
+                for rec in row['doc']['comments']:
+                    rec.update({'request':request, 'identifier':identifier, 'thr': thr, 'type':mtype})
+                    res.append(rec)
         except Exception as exc:
             self.logger.error("LogDBBackend get API failed, error=%s" % str(exc))
             res = 'get-error'
@@ -90,51 +98,10 @@ class LogDB(object):
         self.logger.debug("LogDB delete request, res=%s", res)
         return res
 
-    def summary(self, request):
-        """Generate summary document for given request"""
-        try:
-            res = self.backend.summary(request)
-        except Exception as exc:
-            self.logger.error("LogDBBackend summary API failed, error=%s" % str(exc))
-            res = 'summary-error'
-        self.logger.debug("LogDB summary request, res=%s", res)
-        return res
-
-    def upload2central(self, request):
-        """
-        Upload local LogDB docs corresponding to given request
-        into central LogDB database
-        """
-        if  not self.central:
-            if  self.logger:
-                self.logger.debug("LogDB upload2central does nothing, no central setup")
-            return -1
-        try:
-            docs = self.backend.summary(request)
-            for doc in docs:
-                try:
-                    exist_doc = self.central.db.document(doc["_id"])
-                    doc["_rev"] = exist_doc["_rev"]
-                except CouchNotFoundError:
-                    self.logger.debug("initial update for %s" % doc["_id"])
-                
-                self.central.db.queue(doc)
-            res = self.central.db.commit()
-        except Exception as exc:
-            self.logger.error("LogDBBackend summary API failed, error=%s" % str(exc))
-            res = 'summary-error'
-        self.logger.debug("LogDB upload2central request, res=%s", res)
-        return res
-
     def cleanup(self, thr, backend='local'):
         """Clean-up back-end LogDB"""
         try:
-            if  backend=='local':
-                self.backend.cleanup(thr)
-            elif backend=='central':
-                self.central.cleanup(thr)
-            else:
-                raise RuntimeError()
+            self.backend.cleanup(thr)
         except Exception as exc:
             self.logger.error('LogDBBackend cleanup API failed, backend=%s, error=%s' \
                     % (backend, str(exc)))

--- a/src/python/WMCore/Services/LogDB/LogDBReport.py
+++ b/src/python/WMCore/Services/LogDB/LogDBReport.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+#pylint: disable=
+"""
+File       : LogDBReport.py
+Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
+Description: LogDB report class to represent LogDB messages
+"""
+
+# system modules
+import os
+import sys
+
+class LogDBReport(object):
+    """LogDBReport class to represent LogDB messages"""
+    def __init__(self, logdb):
+        self.logdb = logdb
+
+    def docs(self, request):
+        """Fetch LogDB messages for given request"""
+        if  request == 'all':
+            docs = self.logdb.get_all_requests()
+        else:
+            docs = self.logdb.get(request)
+        return docs
+        
+    def orderby(self, docs, order):
+        """Order LogDB messages by given type"""
+        odict = {}
+        for item in docs:
+            odict[item['ts']] = item
+        keys = sorted(odict.keys())
+        keys.reverse()
+        out = []
+        for key in keys:
+            out.append(odict[key])
+        return out
+
+    def to_json(self, request, order='ts'):
+        """Represent given messages in JSON data-format for given set of requests"""
+        docs = self.orderby(self.docs(request), order)
+        return docs
+
+    def to_txt(self, request, order='ts', sep=' '):
+        """Represent given messages in ASCII text format for given set of requests"""
+        docs = self.orderby(self.docs(request), order)
+        keys = docs[0].keys()
+        out = sep.join(keys) + '\n'
+        for doc in docs:
+            values = []
+            for key in keys:
+                values.append('%s' % doc[key])
+            out += sep.join(values) + '\n'
+        return out
+
+    def to_html(self, request, order='ts'):
+        """Represent given messages in ASCII text format for given set of requests"""
+        out = '<table id="logdb-report">\n'
+        for doc in self.to_txt(request, order, sep='</td><td>').split('\n'):
+            if  doc:
+                out += '<tr><td>'+doc+'</td></tr>\n'
+        out += '</table>'
+        return out
+
+    def to_stdout(self, request, order='ts'):
+        """Yield to stdout LogDB messages for given request/type"""
+        msg = '\nReport for %s' % request
+        print msg, '\n', '-'*len(msg)
+        docs = self.orderby(self.docs(request), order)
+        times = []
+        messages = []
+        mtypes = []
+        for doc in docs:
+            times.append(str(doc['ts']))
+            messages.append(doc['msg'])
+            mtypes.append(doc['type'])
+        tstpad = max([len(t) for t in times])
+        msgpad = max([len(m) for m in messages])
+        mtppad = max([len(m) for m in mtypes])
+        out = []
+        for idx in range(len(times)):
+            tcol = '%s%s' % (times[idx], ' '*(tstpad-len(times[idx])))
+            mcol = '%s%s' % (messages[idx], ' '*(msgpad-len(messages[idx])))
+            ecol = '%s%s' % (mtypes[idx], ' '*(mtppad-len(mtypes[idx])))
+            print "%s %s %s" % (tcol, mcol, ecol)


### PR DESCRIPTION
This PR includes code to use single back-end for LogDB. It relies on the following deterministic id schema: for agent based requests the id is generated as request-agent-thread-type, while for user based comments id is generated as request-userdn-thread-type. All documents have standard structure: `{_id:id, data:[{msg:msg, ts:123, type:mtype}, ...]}`. The `data` part is always a list which allows to have consistent structure for messages. The agent-based messages are updated in place, while user based one are growing. The LogDB post API uses LogDBBackend user_update and agent_update APIs based on LogDB identifier (which either set for agent or uses userdn). We'll create LogDB object for every user request. The data in LogDB are minimized to have only msg/ts/mtype dict, while LogDB get API decompose id into request/agent/thread/type and update retrieved documents accordingly such that end-user get the following structure: `{request:bla, identifier:bla, thr: bla, msg:bla, ts:123, mtype:bla}`. I also provided first draft of LogDBReport class. All unit tests are adjusted accordingly.
