### PR TITLE
Add temporary access to request information including lastest job.

### DIFF
--- a/src/python/WMCore/ReqMgr/Service/RestApiHub.py
+++ b/src/python/WMCore/ReqMgr/Service/RestApiHub.py
@@ -20,6 +20,7 @@ from WMCore.ReqMgr.Service.Auxiliary import Software
 from WMCore.ReqMgr.Service.Request import Request
 from WMCore.ReqMgr.Service.Request import RequestStatus
 from WMCore.ReqMgr.Service.Request import RequestType
+from WMCore.ReqMgr.Service.WMStatsInfo import WMStatsInfo
 
 
 
@@ -52,4 +53,5 @@ class RestApiHub(RESTApi):
                    "status": RequestStatus(app, self, config, mount),
                    "type": RequestType(app, self, config, mount),
                    "spec_template": RequestSpec(self, app, config, mount),
+                   "wmstats_info":WMStatsInfo(self, app, config, mount)
                   })

--- a/src/python/WMCore/ReqMgr/Service/WMStatsInfo.py
+++ b/src/python/WMCore/ReqMgr/Service/WMStatsInfo.py
@@ -1,0 +1,43 @@
+"""
+Hello world example using WMCore.REST handling framework.
+Info class giving information about ReqMgr database.
+Teams, Groups, Software versions handling for ReqMgr.
+
+"""
+
+import logging
+import cherrypy
+
+from WMCore.REST.Server import RESTEntity, restcall, rows
+from WMCore.REST.Tools import tools
+from WMCore.Services.WMStats.WMStatsReader import WMStatsReader
+
+from WMCore.REST.Format import JSONFormat
+
+class WMStatsInfo(RESTEntity):
+    """
+    This class need to move under WMStats server when wmstats server created
+    """
+    def __init__(self, app, api, config, mount):
+        # main CouchDB database where requests/workloads are stored
+        RESTEntity.__init__(self, app, api, config, mount)
+        wmstats_url = "%s/%s" % (self.config.couch_host, self.config.couch_wmstats_db)
+        reqdb_url = "%s/%s" % (self.config.couch_host, self.config.couch_reqmgr_db)
+        self.wmstats = WMStatsReader(wmstats_url, reqdb_url, reqdbCouchApp = "ReqMgr")           
+        
+    def validate(self, apiobj, method, api, param, safe):
+        args_length = len(param.args)
+        if args_length == 1:
+            safe.args.append(param.args[0])
+            param.args.pop()   
+        return            
+
+    
+    @restcall(formats = [('application/json', JSONFormat())])
+    @tools.expires(secs=-1)
+    def get(self, request_name):
+        result = self.wmstats.getRequestSummaryWithJobInfo(request_name)
+        return rows([result])
+    
+
+

--- a/src/python/WMCore/Services/WMStats/WMStatsReader.py
+++ b/src/python/WMCore/Services/WMStats/WMStatsReader.py
@@ -304,3 +304,13 @@ class WMStatsReader():
             self._updateRequestInfoWithJobInfo(requestInfo)
         return requestInfo
     
+    def getRequestSummaryWithJobInfo(self, requestName):
+        """
+        get request info with job status
+        """
+        requestInfo = self.reqDB.getRequestByNames(requestName)
+        self._updateRequestInfoWithJobInfo(requestInfo)
+        return requestInfo
+        
+        
+    

--- a/test/python/WMCore_t/Services_t/WMStats_t/WMStats_t.py
+++ b/test/python/WMCore_t/Services_t/WMStats_t/WMStats_t.py
@@ -105,6 +105,9 @@ class WMStatsTest(unittest.TestCase):
         requests = self.wmstatsReader.getRequestByStatus(["failed"])
         self.assertEquals(requests.keys(), [schema[0]['RequestName']])
         
+        requests = self.wmstatsReader.getRequestSummaryWithJobInfo(schema[0]['RequestName'])
+        self.assertEquals(requests.keys(), [schema[0]['RequestName']])
+        
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
intermediate step towards #5681 This this grant temporary access to the api through reqmgr2 api. But this need to move to wmstats api when server cherrrypy backend is created.
