### PR TITLE
workaround for duplicate alcaharvest output in fjr

### DIFF
--- a/src/python/WMCore/FwkJobReport/Report.py
+++ b/src/python/WMCore/FwkJobReport/Report.py
@@ -1049,11 +1049,20 @@ class Report:
             return []
 
         analysisFiles = stepReport.analysis.files
-        result = []
-        for fileNum in range(analysisFiles.fileCount):
-            result.append(getattr(analysisFiles, "file%s" % fileNum))
 
-        return result
+        results = []
+        for fileNum in range(analysisFiles.fileCount):
+            results.append(getattr(analysisFiles, "file%s" % fileNum))
+
+        # filter out duplicates
+        fileNames = []
+        filteredResults = []
+        for result in results:
+            if result.fileName not in fileNames:
+                fileNames.append(result.fileName)
+                filteredResults.append(result)
+
+        return filteredResults
 
 
     def getAllFileRefsFromStep(self, step):


### PR DESCRIPTION
This should never happen (but it has before), but if for some reason there is a difference in processing history for different data in the same run, the AlcaHarvest will write duplicate payload records into the FJR. Ignore all duplicates and only process each file once, no matter how many records there are for it.
