### PR TITLE
remove crc checksum calculation, fixes #5632

### DIFF
--- a/src/couchapps/WMStats/_attachments/js/Views/HTMLList/WMStats.JobDetailList.js
+++ b/src/couchapps/WMStats/_attachments/js/Views/HTMLList/WMStats.JobDetailList.js
@@ -124,8 +124,7 @@ WMStats.namespace('JobDetailList');
                     htmlstr += jobDoc.output[i].location[j] + " ";
                 }*/
                 htmlstr += "</li>";
-                htmlstr += "<li><b>checksums: adler32:</b> " + jobDoc.output[i].checksums.adler32 + 
-                            ",<b>  cksum:</b> " + jobDoc.output[i].checksums.cksum + "</li>";
+                htmlstr += "<li><b>checksums: adler32:</b> " + jobDoc.output[i].checksums.adler32 + "</li>";
                 htmlstr += "<li><b>size:</b> " + jobDoc.output[i].size + "</li>";
                 htmlstr += "</ul>";
                 htmlstr += "</ul>";

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
@@ -2401,8 +2401,7 @@ WMStats.namespace('JobDetailList');
                     htmlstr += jobDoc.output[i].location[j] + " ";
                 }*/
                 htmlstr += "</li>";
-                htmlstr += "<li><b>checksums: adler32:</b> " + jobDoc.output[i].checksums.adler32 + 
-                            ",<b>  cksum:</b> " + jobDoc.output[i].checksums.cksum + "</li>";
+                htmlstr += "<li><b>checksums: adler32:</b> " + jobDoc.output[i].checksums.adler32 + "</li>";
                 htmlstr += "<li><b>size:</b> " + jobDoc.output[i].size + "</li>";
                 htmlstr += "</ul>";
                 htmlstr += "</ul>";

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
@@ -2493,8 +2493,7 @@ WMStats.namespace('JobDetailList');
                     htmlstr += jobDoc.output[i].location[j] + " ";
                 }*/
                 htmlstr += "</li>";
-                htmlstr += "<li><b>checksums: adler32:</b> " + jobDoc.output[i].checksums.adler32 + 
-                            ",<b>  cksum:</b> " + jobDoc.output[i].checksums.cksum + "</li>";
+                htmlstr += "<li><b>checksums: adler32:</b> " + jobDoc.output[i].checksums.adler32 + "</li>";
                 htmlstr += "<li><b>size:</b> " + jobDoc.output[i].size + "</li>";
                 htmlstr += "</ul>";
                 htmlstr += "</ul>";

--- a/src/python/WMCore/Algorithms/BasicAlgos.py
+++ b/src/python/WMCore/Algorithms/BasicAlgos.py
@@ -10,7 +10,39 @@ Python implementations of basic Linux functionality
 import os
 import stat
 import time
-import hashlib
+import zlib
+import subprocess
+
+def calculateChecksums(filename):
+    """
+    _calculateChecksums_
+
+    Get the adler32 and crc32 checksums of a file. Return None on error
+
+    Process line by line and adjust for known signed vs. unsigned issues
+      http://docs.python.org/library/zlib.html
+
+    The cksum UNIX command line tool implements a CRC32 checksum that is
+    different than any of the python algorithms, therefore open cksum
+    in a subprocess and feed it the same chunks of data that are used
+    to calculate the adler32 checksum.
+
+    """
+    adler32Checksum = zlib.adler32("")
+
+    cksum = subprocess.Popen("cksum", stdin = subprocess.PIPE, stdout = subprocess.PIPE)
+
+    f = open(filename, 'rb')
+    while True:
+        line = f.readline(4096) #limit so memory use doesn't blow up
+    if not line:
+        break
+    adler32Checksum = zlib.adler32(line, adler32Checksum)
+    cksum.stdin.write(line)
+    f.close()
+    cksum.stdin.close()
+    cksum.wait()
+    return ((adler32Checksum & 0xffffffff), cksum.stdout.read().split()[0])
 
 
 def tail(filename, nLines = 20):
@@ -40,29 +72,6 @@ def tail(filename, nLines = 20):
     f.close()
 
     return lines[-nLines:]
-
-
-
-def getMD5(filename, size = 8192):
-    """
-    _md5_
-
-    Get the md5 checksum of a particular file
-    """
-
-    h = hashlib.md5()
-    f = open(filename, 'r')
-
-    # Read the file
-    while True:
-        bit = f.read(size)
-        if len(bit) == 0:
-            # EOF
-            break
-        h.update(bit)
-
-    f.close()
-    return h.hexdigest()
 
 
 def getFileInfo(filename):

--- a/src/python/WMCore/FwkJobReport/FileInfo.py
+++ b/src/python/WMCore/FwkJobReport/FileInfo.py
@@ -10,61 +10,11 @@ Not in the Framework XML
 """
 
 
-
-
-
-
-
 import os
 import os.path
-import subprocess
 import logging
 
-
-def readAdler32(filename):
-    """
-    _readAdler32_
-
-    Get the adler32 checksum of a file. Return None on error
-
-    Process line by line and adjust for known signed vs. unsigned issues
-      http://docs.python.org/library/zlib.html
-
-    """
-    try:
-        from zlib import adler32
-        sum = 1L
-        f = open(filename, 'rb')
-        while True:
-            line = f.readline(4096) #limit so binary files don't blow up
-            if not line:
-                break
-            sum = adler32(line, sum)
-        f.close()
-        return '%x' % (sum & 0xffffffffL) # +ve values and convert to hex
-    except StandardError, e:
-        print('Error computing Adler32 checksum of %s. %s' % (filename, str(e)))
-
-
-
-def readCksum(filename):
-    """
-    _readCksum_
-
-    Run a cksum command on a file an return the checksum value
-
-    """
-    ckproc = subprocess.Popen(['cksum', filename],
-                              stdout = subprocess.PIPE,
-                              stderr = subprocess.PIPE)
-    ckproc.wait()
-    result = ckproc.stdout.readlines()
-
-    result = result[0]  # Get the only list element
-    result = result.strip() # Get rid of crappy characters
-    cksum = result.split()[0] # Take the first one
-    return cksum
-
+from WMCore.Algorithms.BasicAlgos import calculateChecksums
 
 
 class FileInfo:
@@ -125,14 +75,10 @@ class FileInfo:
 
 
         """
-
-        # Get checksums
-        adler32 = readAdler32(filename = filename)
-        cksum   = readCksum(filename = filename)
-
+        # Get checksum
+        (adler32, cksum) = calculateChecksums(filename)
 
         # Get info from spec
-
         output = getattr(step.output.modules, outputModule)
         disableGUID      = getattr(output, 'disableGUID', False)
         fixedLFN         = getattr(output, 'fixedLFN', False)
@@ -142,7 +88,6 @@ class FileInfo:
 
         # Get other file information
         size = os.stat(filename)[6]
-
 
         #Get info from file
         mergedLFNBase    = getattr(fileReport, 'MergedLFNBase', None)

--- a/src/python/WMCore/WMSpec/Steps/Executors/LogArchive.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/LogArchive.py
@@ -5,9 +5,6 @@ _Step.Executor.LogArchive_
 Implementation of an Executor for a LogArchive step
 """
 
-
-
-
 import os
 import os.path
 import logging
@@ -19,14 +16,16 @@ import traceback
 
 from WMCore.WMException import WMException
 
+from WMCore.Algorithms.Alarm import Alarm, alarmHandler
+
 from WMCore.WMSpec.Steps.Executor           import Executor
 from WMCore.WMSpec.Steps.WMExecutionFailure import WMExecutionFailure
-from WMCore.FwkJobReport.FileInfo           import readAdler32, readCksum
+
+from WMCore.Algorithms.BasicAlgos import calculateChecksums
+
 import WMCore.Storage.StageOutMgr as StageOutMgr
 import WMCore.Storage.FileManager
-import WMCore.Algorithms.BasicAlgos as BasicAlgos
 
-from WMCore.Algorithms.Alarm import Alarm, alarmHandler
 
 lfnGroup = lambda j : str(j.get("counter", 0) / 1000).zfill(4)
 
@@ -134,12 +133,11 @@ class LogArchive(Executor):
         try:
             manager(fileInfo)
             self.report.addOutputModule(moduleName = "logArchive")
+            (adler32, cksum) = calculateChecksums(tarBallLocation)
             reportFile = {"lfn": fileInfo["LFN"], "pfn": fileInfo["PFN"],
                           "location": fileInfo["SEName"], "module_label": "logArchive",
                           "events": 0, "size": 0, "merged": False,
-                          "checksums": {'md5': BasicAlgos.getMD5(tarBallLocation),
-                                        'adler32': readAdler32(tarBallLocation),
-                                        'cksum': readCksum(tarBallLocation)}}
+                          "checksums": {'adler32': adler32}, 'cksum' : cksum}
             self.report.addOutputFile(outputModule = "logArchive", file = reportFile)
         except Alarm:
             msg = "Indefinite hang during stageOut of logArchive"

--- a/test/python/WMCore_t/Algorithms_t/BasicAlgos_t.py
+++ b/test/python/WMCore_t/Algorithms_t/BasicAlgos_t.py
@@ -75,25 +75,6 @@ class testBasicAlgos(unittest.TestCase):
 
         return
 
-    def test_MD5(self):
-        """
-        _MD5_
-
-        Check if we can create an MD5 checksum
-        """
-
-        silly = "This is a rather ridiculous string"
-        filename = os.path.join(self.testDir, 'md5test.test')
-
-        f = open(filename, 'w')
-        f.write(silly)
-        f.close()
-
-        self.assertEqual(BasicAlgos.getMD5(filename = filename),
-                         hashlib.md5(silly).hexdigest())
-
-        os.remove(filename)
-        return
 
     def test_fileInfo(self):
         """


### PR DESCRIPTION
The CRC checksum is not needed by any of our systems, everything uses adler32. Remove it.

Also remove MD5 checksum calculation for logArchives (no idea why that is done) and remove the code and unit test for MD5 checksum calculation as its not used anywhere else.

This does NOT remove all code that supports checksums of a different type than adler32. DBS for instance still supports CRC and MD5 checksums, we just don't set them anymore.
