### PR TITLE
Remove instances of import md5 which is deprecated

### DIFF
--- a/src/python/WMCore/Cache/WMConfigCache.py
+++ b/src/python/WMCore/Cache/WMConfigCache.py
@@ -6,23 +6,16 @@ Being in itself a wrapped class around a config cache
 """
 
 
-import urllib
+import hashlib
 import logging
 import traceback
-
-
-try:
-    import hashlib
-except:
-    import md5 as hashlib
+import urllib
 
 from WMCore.Database.CMSCouch import CouchServer, Document
 from WMCore.DataStructs.WMObject import WMObject
 
 from WMCore.WMException import WMException
 from WMCore.Database.CMSCouch import CouchNotFoundError
-
-
 from WMCore.GroupUser.Group import Group
 from WMCore.GroupUser.User  import makeUser
 

--- a/src/python/WMCore/WMBSFeeder/Fake/Feeder.py
+++ b/src/python/WMCore/WMBSFeeder/Fake/Feeder.py
@@ -9,12 +9,13 @@ Always returns new/unique files.
 __all__ = []
 
 
+import random
+import time
 
-from WMCore.DataStructs.WMObject import WMObject
+from hashlib import md5
+
 from WMCore.DataStructs.File import File
 from WMCore.WMBSFeeder.FeederImpl import FeederImpl
-
-import time, random, md5
 
 def uuid( *args ):
     """
@@ -29,7 +30,7 @@ def uuid( *args ):
         # if we can't get a network address, just imagine one
         a = random.random()*100000000000000000L
     data = str(t)+' '+str(r)+' '+str(a)+' '+str(args)
-    data = md5.md5(data).hexdigest()
+    data = md5(data).hexdigest()
     return data
 
 

--- a/src/python/WMCore/WMBSFeeder/Fake/UpdatingFeeder.py
+++ b/src/python/WMCore/WMBSFeeder/Fake/UpdatingFeeder.py
@@ -9,12 +9,13 @@ Returns existing files, with updated locations.
 __all__ = []
 
 
+import random
+import time
+from hashlib import md5
 
-from WMCore.DataStructs.WMObject import WMObject
 from WMCore.DataStructs.File import File
 from WMCore.WMBSFeeder.FeederImpl import FeederImpl
 
-import time, random, md5
 
 def uuid( *args ):
     """
@@ -29,7 +30,7 @@ def uuid( *args ):
         # if we can't get a network address, just imagine one
         a = random.random()*100000000000000000L
     data = str(t)+' '+str(r)+' '+str(a)+' '+str(args)
-    data = md5.md5(data).hexdigest()
+    data = md5(data).hexdigest()
     return data
 
 

--- a/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
@@ -21,11 +21,7 @@ HTTPS = httplib.HTTPS
 if sys.version_info[:3] >= (2, 4, 0):
     HTTPS = httplib.HTTPSConnection
 
-# Compatibility with python2.4 or earlier
-try:
-    from hashlib import md5
-except ImportError:
-    from md5 import md5
+from hashlib import md5
 
 from WMCore.WMSpec.Steps.Executor import Executor
 from WMCore.FwkJobReport.Report import Report


### PR DESCRIPTION
Gets rid of an import that has been deprecated since python 2.6
