### PR TITLE
Change CustodialSubType dafault to Replica instead of Move

### DIFF
--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
@@ -362,7 +362,7 @@ class Assign(WebAPI):
         subscriptionPriority = kwargs.get("SubscriptionPriority", "Low")
         if subscriptionPriority not in ["Low", "Normal", "High"]:
             raise cherrypy.HTTPError(400, "Invalid subscription priority %s" % subscriptionPriority)
-        custodialType = kwargs.get("CustodialSubType", "Move")
+        custodialType = kwargs.get("CustodialSubType", "Replica")
         if custodialType not in ["Move", "Replica"]:
             raise cherrypy.HTTPError(400, "Invalid custodial subscription type %s" % custodialType)
         nonCustodialType = kwargs.get("NonCustodialSubType", "Replica")

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -949,7 +949,7 @@ class StdBase(object):
                      "SubscriptionPriority" : {"default" : "Low", "assign_optional": True,
                                                "validate" : lambda x: x in ["Low", "Normal", "High"]},
                      # should be Move Replica  
-                     "CustodialSubType" : {"default" : "Move", "type" : str, "assign_optional": True,
+                     "CustodialSubType" : {"default" : "Replica", "type" : str, "assign_optional": True,
                                            "validate" : lambda x: x in ["Move", "Replica"]},
                      "NonCustodialSubType" : {"default" : "Replica", "type" : str, "assign_optional": True,
                                               "validate" : lambda x: x in ["Move", "Replica"]},

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -870,7 +870,7 @@ class WMTaskHelper(TreeHelper):
         return outputDatasets
 
     def setSubscriptionInformation(self, custodialSites = None, nonCustodialSites = None,
-                                         autoApproveSites = None, custodialSubType = "Move",
+                                         autoApproveSites = None, custodialSubType = "Replica",
                                          nonCustodialSubType = "Replica", priority = "Low",
                                          primaryDataset = None, dataTier = None):
         """
@@ -915,7 +915,7 @@ class WMTaskHelper(TreeHelper):
                 outputModuleSection.custodialSites = []
                 outputModuleSection.nonCustodialSites = []
                 outputModuleSection.autoApproveSites = []
-                outputModuleSection.custodialSubType = "Move"
+                outputModuleSection.custodialSubType = "Replica"
                 outputModuleSection.nonCustodialSubType = "Replica"
                 outputModuleSection.priority = "Low"
 
@@ -976,7 +976,7 @@ class WMTaskHelper(TreeHelper):
                                        "AutoApproveSites" : outputModuleSection.autoApproveSites,
                                        "Priority" : outputModuleSection.priority,
                                        # Specs assigned before HG1303 don't have the CustodialSubtype
-                                       "CustodialSubType" : getattr(outputModuleSection, "custodialSubType", "Move"),
+                                       "CustodialSubType" : getattr(outputModuleSection, "custodialSubType", "Replica"),
                                        "NonCustodialSubType" : getattr(outputModuleSection, "nonCustodialSubType", "Replica")}
         return subInformation
 

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -1216,7 +1216,7 @@ class WMWorkloadHelper(PersistencyHelper):
 
     def setSubscriptionInformationWildCards(self, wildcardDict, custodialSites = None,
                                             nonCustodialSites = None, autoApproveSites = None,
-                                            custodialSubType = "Move", nonCustodialSubType = "Replica",
+                                            custodialSubType = "Replica", nonCustodialSubType = "Replica",
                                             priority = "Low", primaryDataset = None, dataTier = None):
         """
         _setSubscriptonInformationWildCards_
@@ -1261,7 +1261,7 @@ class WMWorkloadHelper(PersistencyHelper):
 
     def setSubscriptionInformation(self, initialTask = None, custodialSites = None,
                                    nonCustodialSites = None, autoApproveSites = None,
-                                   custodialSubType = "Move", nonCustodialSubType = "Replica",
+                                   custodialSubType = "Replica", nonCustodialSubType = "Replica",
                                    priority = "Low", primaryDataset = None, dataTier = None):
         """
         _setSubscriptionInformation_

--- a/src/templates/WMCore/WebTools/RequestManager/Assign.tmpl
+++ b/src/templates/WMCore/WebTools/RequestManager/Assign.tmpl
@@ -105,8 +105,8 @@ Subscription Priority:
 </select>
 Custodial Subscription Type:
 <select name="CustodialSubType">
-<option selected>Move</option>
-<option>Replica</option>
+<option selected>Replica</option>
+<option>Move</option>
 </select>
 Noncustodial Subscription Type:
 <select name="NonCustodialSubType">


### PR DESCRIPTION
Workflow team was sometimes not setting this argument, and then it was defaulting to Move and making a mess for multi-steps/multi-tasks workflows.

@ticoann review. In principle we skip it only for the other cycle (unless we need to fix something still this week :-))
