### PR TITLE
Make it so all tests run

### DIFF
--- a/setup_test.py
+++ b/setup_test.py
@@ -19,6 +19,8 @@ can_lint = False
 can_coverage = False
 can_nose = False
 
+sys.setrecursionlimit(10000) # Eliminates recursion exceptions with nose
+
 try:
     from pylint.lint import Run
     from pylint.lint import preprocess_options, cb_init_hook
@@ -285,12 +287,12 @@ if can_nose:
                                              '!workerNodeTest,!integration,!performance,!lifecycle,!__integration__,!__performance__,!__lifecycle__',
                                              '--with-coverage','--cover-html','--cover-html-dir=coverageHtml','--cover-erase',
                                              '--cover-package=' + moduleList, '--cover-inclusive',
-                                             self.testingRoot],
+                                             testPath],
                                              paths = testPath)
                 else:
                     retval = self.callNose([__file__,'--with-xunit', '-m', '(_t.py$)|(_t$)|(^test)','-a',
                          '!workerNodeTest,!integration,!performance,!lifecycle,!__integration__,!__performance__,!__lifecycle__',
-                         '--stop', self.testingRoot],
+                         '--stop', testPath],
                          paths = testPath)
                     
             threadCount = len(threading.enumerate())

--- a/test/python/WMCore_t/Database_t/DBFormatter_t.py
+++ b/test/python/WMCore_t/Database_t/DBFormatter_t.py
@@ -71,6 +71,7 @@ insert into test (bind1, bind2) values (:bind1, :bind2) """
         myThread.transaction.commit()
         self.testInit.clearDatabase()
 
+    @attr("integration")
     def testBFormatting(self):
         """
         Test various formats


### PR DESCRIPTION
Changes needed to setup_test.py to get all the tests to run. The one test newly marked integration was taking 8 hours on its own. No idea why. Will open a ticket for that.
