### PR TITLE
use pycurl as default

### DIFF
--- a/src/python/WMCore/Services/Requests.py
+++ b/src/python/WMCore/Services/Requests.py
@@ -60,7 +60,12 @@ class Requests(dict):
         if  not idict:
             idict = {}
         dict.__init__(self, idict)
-        self.pycurl = idict.get('pycurl', None)
+        try:
+            import pycurl
+            self.pycurl = True
+        except ImportError:
+            logging.debug("Not using pycurl")
+            self.pycurl = False
         self.capath = idict.get('capath', None)
         if self.pycurl:
             self.reqmgr = RequestHandler()


### PR DESCRIPTION
It seem WMAgent is not using pycurl as default (httplib2 is used). Change to pycurl call.
However, pycurl doesn't seems to be working smothly all the call fails.

Please don't merge yet

Traceback (most recent call last):
  File "/Users/sryu/WorkArea2/WMCore/test/python/WMCore_t/Services_t/ReqMgr_t/ReqMgr_t.py", line 62, in setUp
    RESTBaseUnitTestWithDBBackend.setUp(self)
  File "/Users/sryu/WorkArea2/WMCore/src/python/WMQuality/REST/RESTBaseUnitTestWithDBBackend.py", line 53, in setUp
    self.testInit.setupCouch(dbName, couchApp)
  File "/Users/sryu/WorkArea2/WMCore/src/python/WMQuality/TestInitCouchApp.py", line 98, in setupCouch
    self.couch.create(dropExistingDb=self.dropExistingDb)
  File "/Users/sryu/WorkArea2/WMCore/src/python/WMQuality/TestInitCouchApp.py", line 49, in create
    self.couchServer.createDatabase(self.dbName)
  File "/Users/sryu/WorkArea2/WMCore/src/python/WMCore/Database/CMSCouch.py", line 876, in createDatabase
    self.put("/%s" % urllib.quote_plus(dbname))
  File "/Users/sryu/WorkArea2/WMCore/src/python/WMCore/Services/Requests.py", line 130, in put
    encode, decode, contentType)
  File "/Users/sryu/WorkArea2/WMCore/src/python/WMCore/Database/CMSCouch.py", line 113, in makeRequest
    encode, decode,contentType)
  File "/Users/sryu/WorkArea2/WMCore/src/python/WMCore/Services/Requests.py", line 147, in makeRequest
    encoder, decoder, contentType)
  File "/Users/sryu/WorkArea2/WMCore/src/python/WMCore/Services/Requests.py", line 172, in makeRequest_pycurl
    verb=verb, ckey=ckey, cert=cert, capath=capath, decode=decoder)
  File "/Users/sryu/WorkArea2/WMCore/src/python/WMCore/Services/pycurl_manager.py", line 149, in request
    ckey, cert, capath, verbose, verb, doseq, cainfo)
  File "/Users/sryu/WorkArea2/WMCore/src/python/WMCore/Services/pycurl_manager.py", line 91, in set_opts
    curl.setopt(pycurl.POSTFIELDS, params)
TypeError: invalid arguments to setopt
