### PR TITLE
Only change jobPrio when it has a diff prio

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
@@ -803,16 +803,17 @@ class CondorPlugin(BasePlugin):
         if 'taskPriority' in kwargs and 'requestPriority' in kwargs:
             # Do a priority update
             priority = (int(kwargs['requestPriority']) + int(kwargs['taskPriority'] * self.maxTaskPriority))
-            command = 'condor_qedit -constraint \'WMAgent_SubTaskName == "%s" && WMAgent_RequestName == "%s"\' ' %(task, workflow)
-            command += 'JobPrio %d' % priority
+            command = 'condor_qedit -constraint \'WMAgent_SubTaskName == "%s" && WMAgent_RequestName == "%s" ' %(task, workflow)
+            command += '&& (JobPrio != %d)\' JobPrio %d' % (priority, priority)
             command = shlex.split(command)
             proc = subprocess.Popen(command, stderr = subprocess.PIPE,
                                     stdout = subprocess.PIPE)
             _, stderr = proc.communicate()
             if proc.returncode != 0:
                 # Check if there are actually jobs to update
-                command = 'condor_q -constraint \'WMAgent_SubTaskName == "%s" && WMAgent_RequestName == "%s"\' ' %(task, workflow)
-                command += '-format \'WMAgentID:\%d:::\' WMAgent_JobID'
+                command = 'condor_q -constraint \'WMAgent_SubTaskName == "%s" && WMAgent_RequestName == "%s"' %(task, workflow)
+                command += ' && (JobPrio != %d)\'' % priority
+                command += ' -format \'WMAgentID:\%d:::\' WMAgent_JobID'               
                 command = shlex.split(command)
                 proc = subprocess.Popen(command, stderr = subprocess.PIPE,
                                         stdout = subprocess.PIPE)

--- a/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
@@ -850,8 +850,8 @@ class PyCondorPlugin(BasePlugin):
             # Do a priority update
             priority = (int(kwargs['requestPriority']) + int(kwargs['taskPriority'] * self.maxTaskPriority))
             try:
-                sd.edit('WMAgent_JobID =!= "UNDEFINED" && WMAgent_SubTaskName == %s && WMAgent_RequestName == %s'% (classad.quote(str(task)),classad.quote(str(workflow))),
-                        "JobPrio", classad.Literal(int(priority)))
+                sd.edit('WMAgent_JobID =!= "UNDEFINED" && WMAgent_SubTaskName == %s && WMAgent_RequestName == %s && JobPrio != %d' %
+                        (classad.quote(str(task)),classad.quote(str(workflow)),classad.Literal(int(priority))), "JobPrio", classad.Literal(int(priority)))
             except:
                 msg = "Couldn\'t edit classAd to change job Priority for WMAgent_SubTaskName=%s, WMAgent_RequestName=%s " % (classad.quote(str(task)), classad.quote(str(workflow)))
                 logging.debug(msg)


### PR DESCRIPTION
Quick patch provided by Brian. @bbockelm @ticoann iplease review. We need to push it to production asap.

There is still one thing we have to fix, it seems we first submit jobs to condor queue and only then we change its prio (creating one condor_qedit more). But this will have to wait.
