### PR TITLE
do both adler32 and crc checksum calculation in one file read

### DIFF
--- a/src/couchapps/WMStats/_attachments/js/Views/HTMLList/WMStats.JobDetailList.js
+++ b/src/couchapps/WMStats/_attachments/js/Views/HTMLList/WMStats.JobDetailList.js
@@ -124,8 +124,7 @@ WMStats.namespace('JobDetailList');
                     htmlstr += jobDoc.output[i].location[j] + " ";
                 }*/
                 htmlstr += "</li>";
-                htmlstr += "<li><b>checksums: adler32:</b> " + jobDoc.output[i].checksums.adler32 + 
-                            ",<b>  cksum:</b> " + jobDoc.output[i].checksums.cksum + "</li>";
+                htmlstr += "<li><b>checksums: adler32:</b> " + jobDoc.output[i].checksums.adler32 + "</li>";
                 htmlstr += "<li><b>size:</b> " + jobDoc.output[i].size + "</li>";
                 htmlstr += "</ul>";
                 htmlstr += "</ul>";

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
@@ -2401,8 +2401,7 @@ WMStats.namespace('JobDetailList');
                     htmlstr += jobDoc.output[i].location[j] + " ";
                 }*/
                 htmlstr += "</li>";
-                htmlstr += "<li><b>checksums: adler32:</b> " + jobDoc.output[i].checksums.adler32 + 
-                            ",<b>  cksum:</b> " + jobDoc.output[i].checksums.cksum + "</li>";
+                htmlstr += "<li><b>checksums: adler32:</b> " + jobDoc.output[i].checksums.adler32 + "</li>";
                 htmlstr += "<li><b>size:</b> " + jobDoc.output[i].size + "</li>";
                 htmlstr += "</ul>";
                 htmlstr += "</ul>";

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
@@ -2493,8 +2493,7 @@ WMStats.namespace('JobDetailList');
                     htmlstr += jobDoc.output[i].location[j] + " ";
                 }*/
                 htmlstr += "</li>";
-                htmlstr += "<li><b>checksums: adler32:</b> " + jobDoc.output[i].checksums.adler32 + 
-                            ",<b>  cksum:</b> " + jobDoc.output[i].checksums.cksum + "</li>";
+                htmlstr += "<li><b>checksums: adler32:</b> " + jobDoc.output[i].checksums.adler32 + "</li>";
                 htmlstr += "<li><b>size:</b> " + jobDoc.output[i].size + "</li>";
                 htmlstr += "</ul>";
                 htmlstr += "</ul>";

--- a/src/python/WMComponent/DBS3Buffer/DBSBufferBlock.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSBufferBlock.py
@@ -125,8 +125,6 @@ class DBSBlock:
         fileDict['logical_file_name']      = dbsFile['lfn']
         fileDict['file_size']              = dbsFile['size']
         fileDict['event_count']            = dbsFile['events']
-        fileDict['adler32'] = "NOTSET"
-        fileDict['md5'] = "NOTSET"
         fileDict['last_modified_by'] = "WMAgent"
         fileDict['last_modification_date'] = int(time.time())
         fileDict['auto_cross_section'] = 0.0

--- a/src/python/WMCore/Algorithms/BasicAlgos.py
+++ b/src/python/WMCore/Algorithms/BasicAlgos.py
@@ -10,7 +10,46 @@ Python implementations of basic Linux functionality
 import os
 import stat
 import time
-import hashlib
+import zlib
+import subprocess
+
+def calculateChecksums(filename):
+    """
+    _calculateChecksums_
+
+    Get the adler32 and crc32 checksums of a file. Return None on error
+
+    Process line by line and adjust for known signed vs. unsigned issues
+      http://docs.python.org/library/zlib.html
+
+    The cksum UNIX command line tool implements a CRC32 checksum that is
+    different than any of the python algorithms, therefore open cksum
+    in a subprocess and feed it the same chunks of data that are used
+    to calculate the adler32 checksum.
+
+    """
+    adler32Checksum = 1 # adler32 of an empty string
+    cksumProcess = subprocess.Popen("cksum", stdin = subprocess.PIPE, stdout = subprocess.PIPE)
+
+    # the lambda basically creates an iterator function with zero
+    # arguments that steps through the file in 4096 byte chunks
+    with open(filename, 'rb') as f:
+        for chunk in iter((lambda:f.read(4096)),''):
+            adler32Checksum = zlib.adler32(chunk, adler32Checksum)
+            cksumProcess.stdin.write(chunk)
+
+    cksumProcess.stdin.close()
+    cksumProcess.wait()
+
+    cksumStdout = cksumProcess.stdout.read().split()
+    cksumProcess.stdout.close()
+
+    # consistency check on the cksum output
+    filesize = os.stat(filename)[stat.ST_SIZE]
+    if len(cksumStdout) != 2 or int(cksumStdout[1]) != filesize:
+        raise RuntimeError("Something went wrong with the cksum calculation !")
+
+    return ("%x" % (adler32Checksum & 0xffffffff), "%s" % cksumStdout[0])
 
 
 def tail(filename, nLines = 20):
@@ -42,29 +81,6 @@ def tail(filename, nLines = 20):
     return lines[-nLines:]
 
 
-
-def getMD5(filename, size = 8192):
-    """
-    _md5_
-
-    Get the md5 checksum of a particular file
-    """
-
-    h = hashlib.md5()
-    f = open(filename, 'r')
-
-    # Read the file
-    while True:
-        bit = f.read(size)
-        if len(bit) == 0:
-            # EOF
-            break
-        h.update(bit)
-
-    f.close()
-    return h.hexdigest()
-
-
 def getFileInfo(filename):
     """
     _getFileInfo_
@@ -75,7 +91,7 @@ def getFileInfo(filename):
     filestats = os.stat(filename)
 
     fileInfo = {'Name': filename,
-                'Size': filestats [stat.ST_SIZE],
+                'Size': filestats[stat.ST_SIZE],
                 'LastModification': time.strftime("%m/%d/%Y %I:%M:%S %p",time.localtime(filestats[stat.ST_MTIME])),
                 'LastAccess': time.strftime("%m/%d/%Y %I:%M:%S %p",time.localtime(filestats[stat.ST_ATIME]))}
     return fileInfo

--- a/src/python/WMCore/FwkJobReport/FileInfo.py
+++ b/src/python/WMCore/FwkJobReport/FileInfo.py
@@ -10,62 +10,11 @@ Not in the Framework XML
 """
 
 
-
-
-
-
-
 import os
 import os.path
-import subprocess
 import logging
 
-
-def readAdler32(filename):
-    """
-    _readAdler32_
-
-    Get the adler32 checksum of a file. Return None on error
-
-    Process line by line and adjust for known signed vs. unsigned issues
-      http://docs.python.org/library/zlib.html
-
-    """
-    try:
-        from zlib import adler32
-        sum = 1L
-        f = open(filename, 'rb')
-        while True:
-            line = f.readline(4096) #limit so binary files don't blow up
-            if not line:
-                break
-            sum = adler32(line, sum)
-        f.close()
-        return '%x' % (sum & 0xffffffffL) # +ve values and convert to hex
-    except StandardError as e:
-        print('Error computing Adler32 checksum of %s. %s' % (filename, str(e)))
-
-
-
-def readCksum(filename):
-    """
-    _readCksum_
-
-    Run a cksum command on a file an return the checksum value
-
-    """
-    ckproc = subprocess.Popen(['cksum', filename],
-                              stdout = subprocess.PIPE,
-                              stderr = subprocess.PIPE)
-    ckproc.wait()
-    result = ckproc.stdout.readlines()
-
-    result = result[0]  # Get the only list element
-    result = result.strip() # Get rid of crappy characters
-    cksum = result.split()[0] # Take the first one
-    return cksum
-
-
+from WMCore.Algorithms.BasicAlgos import calculateChecksums
 
 class FileInfo:
     """
@@ -125,14 +74,10 @@ class FileInfo:
 
 
         """
-
-        # Get checksums
-        adler32 = readAdler32(filename = filename)
-        cksum   = readCksum(filename = filename)
-
+        # Get checksum
+        (adler32, cksum) = calculateChecksums(filename)
 
         # Get info from spec
-
         output = getattr(step.output.modules, outputModule)
         disableGUID      = getattr(output, 'disableGUID', False)
         fixedLFN         = getattr(output, 'fixedLFN', False)
@@ -142,7 +87,6 @@ class FileInfo:
 
         # Get other file information
         size = os.stat(filename)[6]
-
 
         #Get info from file
         mergedLFNBase    = getattr(fileReport, 'MergedLFNBase', None)

--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -236,7 +236,6 @@ class DBS3Reader:
               'Parents': [],
               'Checksum': '22218315',
               'Adler32': 'a41a1446',
-              'Md5': 'NOTSET',
               'FileSize': 286021145
             }
 

--- a/test/python/WMCore_t/Algorithms_t/BasicAlgos_t.py
+++ b/test/python/WMCore_t/Algorithms_t/BasicAlgos_t.py
@@ -75,25 +75,6 @@ class testBasicAlgos(unittest.TestCase):
 
         return
 
-    def test_MD5(self):
-        """
-        _MD5_
-
-        Check if we can create an MD5 checksum
-        """
-
-        silly = "This is a rather ridiculous string"
-        filename = os.path.join(self.testDir, 'md5test.test')
-
-        f = open(filename, 'w')
-        f.write(silly)
-        f.close()
-
-        self.assertEqual(BasicAlgos.getMD5(filename = filename),
-                         hashlib.md5(silly).hexdigest())
-
-        os.remove(filename)
-        return
 
     def test_fileInfo(self):
         """


### PR DESCRIPTION
To improve performance and reduce disk IO on the worker node calculate the adler32 and crc checksums in one file read.
