### PR TITLE
Fix for multiRun harvesting job creation

### DIFF
--- a/src/python/WMCore/JobSplitting/Harvest.py
+++ b/src/python/WMCore/JobSplitting/Harvest.py
@@ -93,6 +93,11 @@ class Harvest(JobFactory):
         return
     
     def createJobByRun(self, locationDict, location, baseName, harvestType, runDict, endOfRun):
+        """
+        _createJobByRun_
+
+        Creates one job per run for all files available at the same location.
+        """
 
         for run in locationDict[location].keys():
             # Should create at least one job for every location/run, putting this here will do
@@ -107,23 +112,49 @@ class Harvest(JobFactory):
 
             if endOfRun:
                 self.currentJob.addBaggageParameter("runIsComplete", True)
+            self.mergeLumiRange(self.currentJob['mask']['runAndLumis'])
         return
     
     def createMultiRunJob(self, locationDict, location, baseName, harvestType, runDict, endOfRun):
+        """
+        _createMultiRunJob_
+
+        Creates a single harvesting job for all files and runs available
+        at the same location.
+        """
         
         self.jobCount += 1
         self.newJob(name = "%s-%s-Harvest-%i" % (baseName, harvestType, self.jobCount))
-        for run in locationDict[location].keys():
+        for run in locationDict[location]:
             for f in locationDict[location][run]:
                 for fileRun in runDict[f['lfn']]:
                     if fileRun.run == run:
                         self.currentJob['mask'].addRun(fileRun)
                         break
-                self.currentJob.addFile(f)
+                if f not in self.currentJob['input_files']:
+                    self.currentJob.addFile(f)
+
         if endOfRun:
             self.currentJob.addBaggageParameter("runIsComplete", True)
+        self.mergeLumiRange(self.currentJob['mask']['runAndLumis'])
         return
-                
+
+    def mergeLumiRange(self, runLumis):
+        """
+        _mergeLumiRange_
+
+        Merges the interesection of lumi ranges.
+        """
+        for run, lumis in runLumis.iteritems():
+            lumis.sort(key=lambda sublist: sublist[0])
+            fixedLumis = [lumis[0]]
+            for lumi in lumis:
+                if (fixedLumis[-1][1] +1) >= lumi[0]:
+                    fixedLumis[-1][1] = lumi[1]
+                else:
+                    fixedLumis.append(lumi)
+            self.currentJob['mask']['runAndLumis'][run] = fixedLumis
+
     def algorithm(self, *args, **kwargs):
         """
         _algorithm_


### PR DESCRIPTION
Fixes #5848 
Basically:
 a) do not add duplicate lfn into the job configuration
 b) merge the intersection of lumi ranges (see issue for details)

Tested in testbed and it works fine for both byRun and multiRun harvesting.
@ticoann please review. @hufnagel may want to take a look.
