### PR TITLE
Add total_events flag in EventAwareLumiBased splitting. Fix counting of average number of events in job per file to include only good lumis. Fixes #5907 #5908

### DIFF
--- a/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
+++ b/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
@@ -152,6 +152,7 @@ class EventAwareLumiBased(JobFactory):
                         parent = File(lfn = lfn)
                         f['parents'].add(parent)
 
+                lumisInJobInFile = 0
                 updateSplitOnJobStop = False
                 failNextJob          = False
                 #If the number of events per lumi is higher than the limit
@@ -252,6 +253,7 @@ class EventAwareLumiBased(JobFactory):
                             failNextJob = False
                             firstLumi = lumi
                             lumisInJob = 0
+                            lumisInJobInFile = 0
                             currentJobAvgEventCount = 0
                             totalJobs += 1
 
@@ -269,6 +271,7 @@ class EventAwareLumiBased(JobFactory):
                                     lumisPerJob = f['lumiCount']
 
                         lumisInJob += 1
+                        lumisInJobInFile += 1
                         lastLumi = lumi
                         stopJob = False
                         lastRun = run.run
@@ -288,6 +291,6 @@ class EventAwareLumiBased(JobFactory):
                         lastLumi = None
 
                 if not splitOnFile:
-                    currentJobAvgEventCount += f['avgEvtsPerLumi'] * min(lumisInJob, f['lumiCount'])
+                    currentJobAvgEventCount += f['avgEvtsPerLumi'] * lumisInJobInFile
 
         return


### PR DESCRIPTION
This pull has two commits, one to fix #5907 and one for #5908 
I tested both commits in a CRAB3 workflow: 150513_172334:atanasi_crab_test_totalUnits_lumimask_7K_30K_with_final_fix_2 (http://glidemon.web.cern.ch/glidemon/jobs.php?taskid=1093519) which used these CRAB configuration parameters:

Data.inputDataset = '/SingleMu/Run2012B-13Jul2012-v1/AOD'
Data.lumiMask = 'https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions12/8TeV/Prompt/Cert_190456-208686_8TeV_PromptReco_Collisions12_JSON.txt'
Data.runRange = '193093-193999'
Data.splitting = 'EventAwareLumiBased'
Data.unitsPerJob = 7000
Data.totalUnits = 30000

The task resulted in 5 jobs. In the post-job logs one can see which lumis and input files were analyzed by each job. Taking from DAS the information of how many lumis and events each file contains, I could get the average number of events per lumi for each file (f['avgEvtsPerLumi']) and then count the average number of events the task had analyzed. The result was 29880.37... So the total units limit from the second commit is working. 
Similarly I could count the average number of events each job has analyzed, and it was:
job 1: 6922
job 2: 6624.95....
job 3: 6746.62....
job 4: 6654.73....
job 5: 2932.07....
summing up the 29880.37.... in total. So one can see that each job analyzed less but almost 7000 average events. In all cases, adding one more lumi to the jobs would have caused to exceed the 7000 limit. I also counted that, without the fix of commit 1, the job 2 analyzes 5004.95.... average events from '193834': [3, 4, 29, 30, 33, 34]; (see http://glidemon.web.cern.ch/glidemon/jobs.php?taskid=1093404). While with the fix of commit 1, job 2 analyzes 6624.95... average events from '193834': [3, 4, 9, 10, 29, 30, 33, 34]; that is, it includes 2 more lumis (9 and 10) from the next input file. These 2 lumis are analyzed in job 3 when the fix of commit 1 is not included.
