### PR TITLE
don't make unecessary dbs call for pileup data

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
+++ b/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
@@ -66,6 +66,14 @@ class PileupFetcher(FetcherInterface):
         directory / sandbox.
 
         """
+        
+        stepPath = "%s/%s" % (self.workingDirectory(), helper.name())
+        fileName = "%s/%s" % (stepPath, "pileupconf.json")
+        if os.path.isfile(fileName) and os.path.getsize(fileName) > 0:
+            # if file already exist don't make a new dbs call and overwrite the file.
+            # just return
+            return
+            
         encoder = JSONEncoder()
         # this should have been set in CMSSWStepHelper along with
         # the pileup configuration
@@ -78,7 +86,6 @@ class PileupFetcher(FetcherInterface):
         # create JSON and save into a file
         json = encoder.encode(configDict)
 
-        stepPath = "%s/%s" % (self.workingDirectory(), helper.name())
         if not os.path.exists(stepPath):
             os.mkdir(stepPath)
         try:


### PR DESCRIPTION
This patch contains 3 things.
1. Increase QueueDepth default value to 1.
2. Don't stop the subscription creation if one of the workflow (block) fails to create. send the error messge to LogDB.
3. Don't make the duplicate dbs call for pile up dataset  only one per step not every block. 
