### PR TITLE
fix JobCreator connection fail to Oracle database

### DIFF
--- a/src/python/WMComponent/JobCreator/JobCreatorPoller.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorPoller.py
@@ -411,12 +411,12 @@ class JobCreatorPoller(BaseWorkerThread):
                    and getattr(myThread.transaction, 'transaction', False):
                 myThread.transaction.rollback()
             # Handle temporary connection problems (Temporary)
-            if "This Connection is closed" not in str(ex):
+            if "InterfaceError: not connected" in str(ex):
+                logging.error('There was a connection problem during the JobCreator algorithm, I will try again next cycle')
+            else:
                 msg = "Failed to execute JobCreator \n%s\n\n%s" % (ex,traceback.format_exc())
                 logging.error(msg)
                 raise JobCreatorException(msg)
-            else:
-                logging.error('There was a connection problem during the JobCreator algorithm, I will try again next cycle')
 
     def terminate(self, params):
         """


### PR DESCRIPTION
JobCreator sometimes looses the connection to the Oracle database. There is a workaround for it, but this didn't trigger anymore, probabaly because the error message changed with the new sqlalchemy version.
