### PR TITLE
fix JobCreator crashes due to loosing Oracle connection v2

### DIFF
--- a/src/python/WMComponent/JobCreator/JobCreatorPoller.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorPoller.py
@@ -411,7 +411,7 @@ class JobCreatorPoller(BaseWorkerThread):
                    and getattr(myThread.transaction, 'transaction', False):
                 myThread.transaction.rollback()
             # Handle temporary connection problems (Temporary)
-            if "InterfaceError: not connected" in str(ex):
+            if "(InterfaceError) not connected" in str(ex):
                 logging.error('There was a connection problem during the JobCreator algorithm, I will try again next cycle')
             else:
                 msg = "Failed to execute JobCreator \n%s\n\n%s" % (ex,traceback.format_exc())


### PR DESCRIPTION
Second version, copy&paste error, exception matching string was slightly wrong.
