### PR TITLE
Multiple DQMGui Urls; Keep JobCreator running if Oracle connection is…

### DIFF
--- a/src/python/WMComponent/JobCreator/JobCreatorPoller.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorPoller.py
@@ -411,12 +411,12 @@ class JobCreatorPoller(BaseWorkerThread):
                    and getattr(myThread.transaction, 'transaction', False):
                 myThread.transaction.rollback()
             # Handle temporary connection problems (Temporary)
-            if "This Connection is closed" not in str(ex):
+            if "(InterfaceError) not connected" in str(ex):
+                logging.error('There was a connection problem during the JobCreator algorithm, I will try again next cycle')
+            else:
                 msg = "Failed to execute JobCreator \n%s\n\n%s" % (ex,traceback.format_exc())
                 logging.error(msg)
                 raise JobCreatorException(msg)
-            else:
-                logging.error('There was a connection problem during the JobCreator algorithm, I will try again next cycle')
 
     def terminate(self, params):
         """

--- a/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
@@ -160,13 +160,14 @@ class DQMUpload(Executor):
         logging.info(msg)
 
         try:
-            (headers, data) = self.upload(self.step.upload.URL, args, filename)
-            msg = 'HTTP upload finished succesfully with response:\n'
-            msg += 'Status code: %s\n' % headers.get("Dqm-Status-Code", None)
-            msg += 'Message: %s\n' % headers.get("Dqm-Status-Message", None)
-            msg += 'Detail: %s\n' % headers.get("Dqm-Status-Detail", None)
-            msg += 'Data: %s\n' % str(data)
-            logging.info(msg)
+            for uploadURL in self.step.upload.URL.split(';'):
+                (headers, data) = self.upload(uploadURL, args, filename)
+                msg = 'HTTP upload finished succesfully with response:\n'
+                msg += 'Status code: %s\n' % headers.get("Dqm-Status-Code", None)
+                msg += 'Message: %s\n' % headers.get("Dqm-Status-Message", None)
+                msg += 'Detail: %s\n' % headers.get("Dqm-Status-Detail", None)
+                msg += 'Data: %s\n' % str(data)
+                logging.info(msg)
         except urllib2.HTTPError, ex:
             msg = 'HTTP upload failed with response:\n'
             msg += 'Status code: %s\n' % ex.hdrs.get("Dqm-Status-Code", None)


### PR DESCRIPTION
… lost
Backporting 2 fixes:
- #5807 to support uploading root files to more than one DQMGui (needed for the DQMGui server commissioning). IMO we should make it a list, but anyways this fix will vanish in a couple of months...
- #5952 not to crash JobCreator when oracle connection is lost

@ticoann please don't merge this yet. I want to run it for a few days in testbed first.
