### PR TITLE
Fix Gfal2 plugin to use proxy and register module

### DIFF
--- a/src/python/WMCore/Storage/Backends/GFAL2Impl.py
+++ b/src/python/WMCore/Storage/Backends/GFAL2Impl.py
@@ -20,7 +20,8 @@ class GFAL2Impl(StageOutImpl):
 
     def __init__(self, stagein=False):
         StageOutImpl.__init__(self, stagein)
-
+        self.removeCommand = "env -i X509_USER_PROXY=$X509_USER_PROXY gfal-rm -vvv %s"
+        self.copyCommand = "env -i X509_USER_PROXY=$X509_USER_PROXY gfal-copy -t 2400 -T 2400 -p -vvv"
 
     def createSourceName(self, protocol, pfn):
         """
@@ -49,11 +50,11 @@ class GFAL2Impl(StageOutImpl):
         handle file remove using gfal-rm
         """
         if pfn.startswith("file:"):
-            return "env -i gfal-rm -vvv %s" % pfn
+            return self.removeCommand % pfn
         elif os.path.isfile(pfn):
             return "/bin/rm -f %s" % os.path.abspath(pfn)
         else:
-            return "env -i gfal-rm -vvv %s" % pfn
+            return self.removeCommand % pfn
 
 
     def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
@@ -65,9 +66,9 @@ class GFAL2Impl(StageOutImpl):
 
         useChecksum = (checksums != None and 'adler32' in checksums and not self.stageIn)
 
-        copyCommand = "env -i gfal-copy -t 2400 -T 2400 -p -vvv "
+        copyCommand = self.copyCommand
         if useChecksum:
-            copyCommand += "-K adler32 "
+            copyCommand += " -K adler32 "
         if options != None:
             copyCommand += " %s " % options
         copyCommand += " %s " % sourcePFN
@@ -100,9 +101,9 @@ class GFAL2Impl(StageOutImpl):
         if os.path.isfile(pfnToRemove):
             command = "/bin/rm -f %s" % os.path.abspath(pfnToRemove)
         if pfnToRemove.startswith("file:"):
-            command = "env -i gfal-rm -vvv %s" % pfnToRemove
+            command = self.removeCommand % pfnToRemove
         else:
-            command = "env -i gfal-rm -vvv %s" % pfnToRemove
+            command = self.removeCommand % pfnToRemove
         self.executeCommand(command)
 
 

--- a/src/python/WMCore/Storage/Backends/__init__.py
+++ b/src/python/WMCore/Storage/Backends/__init__.py
@@ -34,3 +34,4 @@ import HadoopImpl
 import UnittestImpl
 import VandyImpl
 import TestFallbackToOldBackend
+import GFAL2Impl

--- a/src/python/WMCore/Storage/Plugins/GFAL2Impl.py
+++ b/src/python/WMCore/Storage/Plugins/GFAL2Impl.py
@@ -41,7 +41,7 @@ class GFAL2Impl(StageOutImpl2):
         if not options:
             options = ""
 
-        transferCommand = "env -i gfal-copy -t 2400 -T 2400 -p -K adler32 -vvv %s %s %s " %\
+        transferCommand = "env -i X509_USER_PROXY=$X509_USER_PROXY gfal-copy -t 2400 -T 2400 -p -K adler32 -vvv %s %s %s " %\
                             (options, fromPfn2, toPfn2)
 
         logging.info("Staging out with gfal-copy")
@@ -69,6 +69,6 @@ class GFAL2Impl(StageOutImpl2):
         if os.path.isfile(pfn):
             runCommand("/bin/rm -f %s" % pfn)
         elif pfn.startswith("file:"):
-            runCommand("env -i gfal-rm -vvv %s" % pfn)
+            runCommand("env -i X509_USER_PROXY=$X509_USER_PROXY gfal-rm -vvv %s" % pfn)
         else:
             runCommand(StageOutImpl.createRemoveFileCommand(self, pfn))


### PR DESCRIPTION
I have tested this at CERN, but seems with castor and adler32 it always fail with Segmentation fault.
Without adler32 it works as expected, and as far as I understand, CERN will not change to gfal2.
Tapas, I have agent fully set up with this patch, and let me know if you have some time to test.
Everything what was needed for me is to put site-local-config.xml in afs directory and run jobs at CERN. Can you put somewhere modified site-local-config.xml that it is accessible in WN?
Changes which I did to this file are:

```
   <local-stage-out>
     <command value="gfal2"/>
     <option value=""/>
     <catalog url="trivialcatalog_file:/afs/cern.ch/cms/SITECONF/T2_CH_CERN/PhEDEx/storage.xml?protocol=srmv2"/>
```
