### PR TITLE
Report out # of cores to dashboard on job start, not just job end, 10…

### DIFF
--- a/src/python/WMCore/WMRuntime/DashboardInterface.py
+++ b/src/python/WMCore/WMRuntime/DashboardInterface.py
@@ -207,6 +207,13 @@ class DashboardInfo():
         data['StatusValueReason'] = 'Job started execution in the WN'
         data['StatusDestination'] = getSyncCE()
 
+        # Inspect the tasks steps and figure out how many cores we will use
+        maxCores = 1
+        for stepName in self.task.listAllStepNames():
+            sh = self.task.getStepHelper(stepName)
+            maxCores = max(maxCores, sh.getNumberOfCores())
+        data['NCores'] = maxCores
+
         self.publish(data = data)
 
         return data

--- a/test/python/WMCore_t/WMRuntime_t/DashboardInterface_t.py
+++ b/test/python/WMCore_t/WMRuntime_t/DashboardInterface_t.py
@@ -208,12 +208,16 @@ class DashboardInterfaceTest(unittest.TestCase):
         dbInfo   = DashboardInfo(job = job, task = task)
         dbInfo.addDestination('127.0.0.1', 8884)
 
+        # Modify the first step
+        step = task.getStep(stepName = "cmsRun1")
+        step.getTypeHelper().setMulticoreCores(8)
+
         # Check jobStart information
         data = dbInfo.jobStart()
+        self.assertEqual(data['NCores'], 8)
 
         # Do the first step
         step = task.getStep(stepName = "cmsRun1")
-        step.getTypeHelper().setMulticoreCores(8)
 
         # Do the step start
         data = dbInfo.stepStart(step = step.data)


### PR DESCRIPTION
1.0.5 version of #5751 
