### PR TITLE
Update logdb request when blocks are opened in dbs

### DIFF
--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -804,6 +804,8 @@ class WorkQueue(WorkQueueBase):
                     if policyInstance.newDataAvailable(topLevelTask, element):
                         skipElement = True
                         self.backend.updateInboxElements(element.id, TimestampFoundNewData = currentTime)
+                        msg = "There are blocks still open for writing in DBS."
+                        self.logdb.post(element['RequestName'], msg, "warning")
                         break
                 if skipElement:
                     continue


### PR DESCRIPTION
Making life easier when we need to spot why a workflow is stuck in running-open.
