### PR TITLE
clean up dbs3 configuration code

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -94,7 +94,7 @@ config.section_("General")
 config.General.workDir = workDirectory
 config.General.logdb_name = logDBName
 config.General.logdb_url = "%s/%s" % (couchURL, config.General.logdb_name)
-config.General.central_logdb_url = "need to get from secrete file"
+config.General.central_logdb_url = "need to get from secrets file"
 
 config.section_("JobStateMachine")
 config.JobStateMachine.couchurl = couchURL
@@ -147,8 +147,7 @@ config.DBS3Upload.logLevel = globalLogLevel
 config.DBS3Upload.workerThreads = 1
 config.DBS3Upload.pollInterval = 100
 #"https://cmsweb.cern.ch/dbs/prod/global/DBSWriter" - production one
-config.DBS3Upload.dbsUrl = "OVER_WRITE_BY_SECETES" 
-config.DBS3Upload.dbs3UploadOnly = False
+config.DBS3Upload.dbsUrl = "OVERWRITE_BY_SECRETS"
 config.DBS3Upload.primaryDatasetType = "mc"
 
 config.section_("DBSInterface")

--- a/src/python/WMComponent/DBS3Buffer/DBSBufferUtil.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSBufferUtil.py
@@ -204,7 +204,7 @@ class DBSBufferUtil(WMConnectionBase):
 
 
 
-    def findOpenBlocks(self, dbs3OnlyUpload = False):
+    def findOpenBlocks(self):
         """
         _findOpenBlocks_
 
@@ -214,7 +214,7 @@ class DBSBufferUtil(WMConnectionBase):
         existingTransaction = self.beginTransaction()
 
         openBlocks = self.daoFactory(classname = "GetOpenBlocks")
-        result = openBlocks.execute(dbs3OnlyUpload, conn = self.getDBConn(),
+        result = openBlocks.execute(conn = self.getDBConn(),
                                     transaction=self.existingTransaction())
 
         self.commitTransaction(existingTransaction)
@@ -245,7 +245,7 @@ class DBSBufferUtil(WMConnectionBase):
 
 
 
-    def loadBlocks(self, blocknames, dbs3UploadOnly):
+    def loadBlocks(self, blocknames):
         """
         _loadBlocks_
 
@@ -261,7 +261,7 @@ class DBSBufferUtil(WMConnectionBase):
         existingTransaction = self.beginTransaction()
 
         findBlocks = self.daoFactory(classname = "LoadBlocks")
-        result     = findBlocks.execute(blocknames, dbs3UploadOnly,
+        result     = findBlocks.execute(blocknames,
                                         conn = self.getDBConn(),
                                         transaction=self.existingTransaction())
 
@@ -315,7 +315,7 @@ class DBSBufferUtil(WMConnectionBase):
         return dbsFiles
 
 
-    def updateBlocks(self, blocks, dbs3UploadOnly = False):
+    def updateBlocks(self, blocks):
         """
         _updateBlocks_
 
@@ -329,7 +329,7 @@ class DBSBufferUtil(WMConnectionBase):
         existingTransaction = self.beginTransaction()
 
         updateBlock = self.daoFactory(classname = "UpdateBlocks")
-        updateBlock.execute(blocks, dbs3UploadOnly, conn = self.getDBConn(),
+        updateBlock.execute(blocks, conn = self.getDBConn(),
                             transaction=self.existingTransaction())
         self.commitTransaction(existingTransaction)
         return

--- a/src/python/WMComponent/DBS3Buffer/MySQL/Create.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/Create.py
@@ -150,7 +150,6 @@ class Create(DBCreator):
              location     INTEGER      NOT NULL,
              create_time  INTEGER,
              status       VARCHAR(20),
-             status3      VARCHAR(20) DEFAULT 'Pending',
              deleted      INTEGER DEFAULT 0,
              FOREIGN KEY (dataset_id) REFERENCES dbsbuffer_dataset(id)
                ON DELETE CASCADE,

--- a/src/python/WMComponent/DBS3Buffer/MySQL/GetOpenBlocks.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/GetOpenBlocks.py
@@ -24,34 +24,9 @@ class GetOpenBlocks(DBFormatter):
                     GROUP BY dbsbuffer_block.id) pending_parents ON
                    dbsbuffer_block.id = pending_parents.block_id
              WHERE dbsbuffer_block.status = 'Open' OR dbsbuffer_block.status = 'Pending' AND
-                   (pending_parents.parent_count IS NULL or pending_parents.parent_count = 0)"""    
+                   (pending_parents.parent_count IS NULL or pending_parents.parent_count = 0)"""
 
-    # Find only blocks that have been closed and uploaded to DBS2 but are still
-    # waiting to be uploaded to DBS3.
-    sql3 = """SELECT dbsbuffer_block.blockname AS blockname, dbsbuffer_block.create_time AS create_time,
-                     pending_parents.parent_count FROM dbsbuffer_block
-                LEFT OUTER JOIN
-                  (SELECT dbsbuffer_block.id AS block_id, COUNT(dbsbuffer_block.id) AS parent_count FROM dbsbuffer_block
-                     INNER JOIN dbsbuffer_file ON
-                       dbsbuffer_block.id = dbsbuffer_file.block_id
-                     LEFT OUTER JOIN dbsbuffer_file_parent ON
-                       dbsbuffer_file.id = dbsbuffer_file_parent.child
-                     LEFT OUTER JOIN dbsbuffer_file dbsbuffer_file_parent_detail ON
-                        dbsbuffer_file_parent.parent = dbsbuffer_file_parent_detail.id
-                     LEFT OUTER JOIN dbsbuffer_block dbsbuffer_block_parent ON
-                       dbsbuffer_file_parent_detail.block_id = dbsbuffer_block_parent.id
-                     WHERE dbsbuffer_block_parent.status3 = 'Pending'
-                     GROUP BY dbsbuffer_block.id) pending_parents ON
-                    dbsbuffer_block.id = pending_parents.block_id
-              WHERE (dbsbuffer_block.status = 'Closed' OR dbsbuffer_block.status = 'InGlobalDBS') AND
-                    (dbsbuffer_block.status3 = 'Pending' OR dbsbuffer_block.status3 = 'Open') AND
-                    (pending_parents.parent_count IS NULL or pending_parents.parent_count = 0)"""
-
-    def execute(self, dbs3OnlyUpload, conn = None, transaction = False):
-        if dbs3OnlyUpload:
-            result = self.dbi.processData(self.sql3, {}, conn = conn,
-                                          transaction = transaction)
-        else:
-            result = self.dbi.processData(self.sql, {}, conn = conn,
+    def execute(self, conn = None, transaction = False):
+        result = self.dbi.processData(self.sql, {}, conn = conn,
                                           transaction = transaction)            
         return self.formatDict(result)

--- a/src/python/WMComponent/DBS3Buffer/MySQL/LoadBlocks.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/LoadBlocks.py
@@ -9,7 +9,7 @@ from WMCore.Database.DBFormatter import DBFormatter
 
 class LoadBlocks(DBFormatter):
     sql = """SELECT DISTINCT dbb.blockname as blockname, dbb.create_time as create_time,
-                dbb.status AS status, dbb.status3 AS status3,
+                dbb.status AS status,
                 dbl.se_name AS location, dbf3.dataset_algo AS das,
                 dbw.name AS workflow
               FROM dbsbuffer_block dbb
@@ -21,7 +21,7 @@ class LoadBlocks(DBFormatter):
                 dbw.id = dbf3.workflow
               WHERE dbb.blockname = :blockname"""
 
-    def format(self, result, dbs3UploadOnly):
+    def format(self, result):
         tmpList = self.formatDict(result)
         blockList = []
         for tmp in tmpList:
@@ -31,17 +31,13 @@ class LoadBlocks(DBFormatter):
             final['origin_site_name'] = tmp['location']
             final['DatasetAlgo']      = tmp['das']
             final['workflow']      = tmp['workflow']
-            
-            if dbs3UploadOnly:
-                final['status'] = tmp['status3']
-            else:
-                final['status'] = tmp['status']
+            final['status'] = tmp['status']
                 
             blockList.append(final)
 
         return blockList
 
-    def execute(self, blocknames, dbs3UploadOnly, conn = None, transaction = False):
+    def execute(self, blocknames, conn = None, transaction = False):
         """
         Take a list of blocknames and use them to load
         the blocks.
@@ -51,4 +47,4 @@ class LoadBlocks(DBFormatter):
             binds.append({'blockname': name})
         result = self.dbi.processData(self.sql, binds, conn = conn,
                                       transaction = transaction)
-        return self.format(result, dbs3UploadOnly)
+        return self.format(result)

--- a/src/python/WMComponent/DBS3Buffer/MySQL/UpdateBlocks.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/UpdateBlocks.py
@@ -12,21 +12,13 @@ class UpdateBlocks(DBFormatter):
                 (SELECT dbl.id FROM dbsbuffer_location dbl WHERE dbl.se_name = :location)
                 WHERE blockname = :block"""
 
-    sql3  = """UPDATE dbsbuffer_block SET status3 = :status WHERE blockname = :block"""
-
-    def execute(self, blocks, dbs3UploadOnly = False, conn = None, transaction = False):
+    def execute(self, blocks, conn = None, transaction = False):
         bindVars = []
 
-        if dbs3UploadOnly:
-            for block in blocks:
-                bindVars.append({"block": block.getName(), "status": block.status})
-            self.dbi.processData(self.sql3, bindVars, conn = conn,
-                                 transaction = transaction)
-        else:
-            for block in blocks:
-                bindVars.append({"block": block.getName(), "location": block.getLocation(),
-                                 "status": block.status, "time": block.getStartTime()})            
-            self.dbi.processData(self.sql, bindVars, conn = conn,
+        for block in blocks:
+            bindVars.append({"block": block.getName(), "location": block.getLocation(),
+                             "status": block.status, "time": block.getStartTime()})            
+        self.dbi.processData(self.sql, bindVars, conn = conn,
                                  transaction = transaction)            
 
         return

--- a/src/python/WMComponent/DBS3Buffer/Oracle/Create.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/Create.py
@@ -213,7 +213,6 @@ class Create(DBCreator):
           location    INTEGER      NOT NULL,
           create_time INTEGER,
           status      VARCHAR(20),
-          status3     VARCHAR(20) DEFAULT 'Pending',
           deleted     INTEGER DEFAULT 0
           )%s""" % tablespaceTable
 

--- a/src/python/WMComponent/PhEDExInjector/Database/MySQL/GetMigratedBlocks.py
+++ b/src/python/WMComponent/PhEDExInjector/Database/MySQL/GetMigratedBlocks.py
@@ -28,7 +28,7 @@ class GetMigratedBlocks(DBFormatter):
                  dbsbuffer_file.dataset_algo = dbsbuffer_algo_dataset_assoc.id
                INNER JOIN dbsbuffer_dataset ON
                  dbsbuffer_algo_dataset_assoc.dataset_id = dbsbuffer_dataset.id
-             WHERE dbsbuffer_block.status = 'InGlobalDBS' OR dbsbuffer_block.status = 'InDBS'
+             WHERE dbsbuffer_block.status = 'InDBS'
              AND NOT EXISTS (SELECT dbf.id FROM dbsbuffer_file dbf
                               WHERE dbf.block_id = dbsbuffer_block.id
                               AND dbf.in_phedex = 0)"""

--- a/test/python/WMComponent_t/DBS3Buffer_t/DBSUpload_t.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/DBSUpload_t.py
@@ -84,7 +84,7 @@ class DBSUploadTest(unittest.TestCase):
 
         return
 
-    def getConfig(self, dbs3UploadOnly = False):
+    def getConfig(self):
         """
         _getConfig_
 
@@ -118,7 +118,6 @@ class DBSUploadTest(unittest.TestCase):
         config.DBS3Upload.nProcesses       = 1
         config.DBS3Upload.dbsWaitTime      = 0.1
         config.DBS3Upload.datasetType      = "VALID"
-        config.DBS3Upload.dbs3UploadOnly   = dbs3UploadOnly
         return config
 
     def createParentFiles(self, acqEra, nFiles = 10,
@@ -390,7 +389,6 @@ class DBSUploadTest(unittest.TestCase):
         Verify that the dual upload mode works correctly.
         """
         self.dbsApi = DbsApi(url = self.dbsUrl)
-        config = self.getConfig(dbs3UploadOnly = True)
         dbsUploader = DBSUploadPoller(config = config)
         dbsUtil = DBSBufferUtil()
 


### PR DESCRIPTION
This still need to be tested. This patch removed some codes for the more clarity of the code.
1. dbs3UploadOnly option and code using it. (It is always False now and never True).
2. status3 is removed from dbsbuffer_block schema(not used anymore)
3. InGlobalDBS status is removed, 'InDBS' is what is used now.

DBS block transition follows. 
Open (block is created in agent) -> Pending (block is closed in agent) -> InDBS (closed block is uploaded in dbs3) -> Closed (block is closed in PhEDEx) (PhEDEx injection started before block is closed)

Still need to do 
DBSBuffer and DBSUpload package need to be removed as well as unittest code, Fix the unittest for PhEDExInjector which still uses DBSBuffer
