### PR TITLE
initial ProcessingVersion include

### DIFF
--- a/src/couchapps/ReqMgr/updates/updaterequest.js
+++ b/src/couchapps/ReqMgr/updates/updaterequest.js
@@ -28,29 +28,58 @@ function(doc, req) {
     }
     // req.query is dictionary fields into the 
     // CMSCouch.Database.updateDocument() method, which is a dictionary
-    var newValues = req.query;
+    function isEmpty(obj) {
+	    for(var prop in obj) {
+	        if(obj.hasOwnProperty(prop))
+	            return false;
+	    }
+    	return true;
+	}
+	
+    // req.query is dictionary fields into the 
+    // CMSCouch.Database.updateDocument() method, which is a dictionary
+ 
+    //TODO: only accepts request body for the argument
+    var fromQuery = false;
+    
+    var newValues = {};
+    if  (isEmpty(req.query)) {
+    	newValues = JSON.parse(req.body);
+    } else {
+    	fromQuery = true;
+    	newValues = req.query;
+    }
+    
     for (key in newValues)
     {   
-        if (key == "RequestTransition" ||
-            key == "SiteWhitelist" ||
-            key == "SiteBlacklist" ||
-            key == "BlockWhitelist" ||
-            key == "SoftwareVersions" ||
-            key == "InputDatasetTypes" ||
-            key == "InputDatasets" ||
-            key == "OutputDatasets" ||
-            key == "CustodialSites" ||
-            key == "NoneCustodialSites" ||
-            key == "AutoApproveSubscriptionSites" ||
-            key == "Teams") {
-    		
-    		doc[key] = JSON.parse(newValues[key]);
-    	} else if (key == "Team") {
+    	
+    	if (fromQuery) {
+        	if (key == "RequestTransition" ||
+	            key == "SiteWhitelist" ||
+	            key == "SiteBlacklist" ||
+	            key == "BlockWhitelist" ||
+	            key == "SoftwareVersions" ||
+	            key == "InputDatasetTypes" ||
+	            key == "InputDatasets" ||
+	            key == "OutputDatasets" ||
+	            key == "CustodialSites" ||
+	            key == "NoneCustodialSites" ||
+	            key == "AutoApproveSubscriptionSites" ||
+	            key == "Teams") {
+	    		
+	    		doc[key] = JSON.parse(newValues[key]);
+	    	}
+	    }
+	    
+	    if (key == "Team") {
     		updateTeams(newValues[key]);
+    	//TODO: need to handle TaskChain cases		
+    
     	} else {
     		doc[key] = newValues[key];
     	}
        
+        // If key is RequestStatus, also update the transition
         if (key == "RequestStatus") {
         	updateTransition();
         }

--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
@@ -404,7 +404,15 @@ class Assign(WebAPI):
         couchDb = Database(reqDetails["CouchWorkloadDBName"], reqDetails["CouchURL"])
         couchDb.updateDocument(request["RequestName"], "ReqMgr", "updaterequest",
                                fields={"AcquisitionEra": reqDetails["AcquisitionEra"],
-                                       "Teams": JsonWrapper.JSONEncoder().encode(kwargs["Teams"]),
-                                       "OutputDatasets": JsonWrapper.JSONEncoder().encode(outputDatasets), 
-                                       "SiteWhitelist": JsonWrapper.JSONEncoder().encode(whiteList),
-                                       "SiteBlacklist": JsonWrapper.JSONEncoder().encode(blackList)})
+                                       "ProcessingVersion": reqDetails["ProcessingVersion"],
+                                       "CustodialSites": custodialList, 
+                                       "NonCustodialSites": nonCustodialList, 
+                                       "AutoApproveSubscriptionSites": autoApproveList,
+                                       "SubscriptionPriority": subscriptionPriority,
+                                       "CustodialSubType": custodialType,
+                                       "NonCustodialSubType": nonCustodialType,
+                                       "Teams": kwargs["Teams"],
+                                       "OutputDatasets": outputDatasets, 
+                                       "SiteWhitelist": whiteList,
+                                       "SiteBlacklist": blackList},
+                               useBody = True)

--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
@@ -177,7 +177,7 @@ def changePriority(requestName, priority, wmstatUrl = None):
     # change priority in CouchDB
     couchDb = Database(request["CouchWorkloadDBName"], request["CouchURL"])
     fields = {"RequestPriority": newPrior}
-    couchDb.updateDocument(requestName, "ReqMgr", "updaterequest", fields=fields)
+    couchDb.updateDocument(requestName, "ReqMgr", "updaterequest", fields=fields, useBody = True)
     # push the change to the WorkQueue
     response = ProdManagement.getProdMgr(requestName)
     if response == [] or response[0] is None or response[0] == "":
@@ -430,7 +430,7 @@ def buildWorkloadAndCheckIn(webApi, reqSchema, couchUrl, couchDB, wmstatUrl, clo
     fields = {}
     for key in paramsToUpdate:
         fields[key] = reqDetails[key]
-    couchDb.updateDocument(request["RequestName"], "ReqMgr", "updaterequest", fields=fields) 
+    couchDb.updateDocument(request["RequestName"], "ReqMgr", "updaterequest", fields=fields, useBody=True) 
         
     try:
         wmstatSvc = WMStatsWriter(wmstatUrl)

--- a/src/python/WMCore/ReqMgr/database_cleanup/couchdb_setter.py
+++ b/src/python/WMCore/ReqMgr/database_cleanup/couchdb_setter.py
@@ -31,7 +31,7 @@ def couchdb_setter(db):
         except KeyError:
             print "%s: %s" % (request_name, "n/a")
         print "Setting %s ..." % request_name
-        db.updateDocument(request_name, "ReqMgr", "updaterequest", fields=fields)
+        db.updateDocument(request_name, "ReqMgr", "updaterequest", fields=fields, useBody=True)
     print "Queried %s request documents." % doc_count 
 
 

--- a/src/python/WMCore/ReqMgr/database_cleanup/oracle_couchdb_consistency_checker.py
+++ b/src/python/WMCore/ReqMgr/database_cleanup/oracle_couchdb_consistency_checker.py
@@ -290,7 +290,7 @@ def main():
             print couch_fields_to_correct
             if sys.argv[-1] == "-c":
                 couchdb.updateDocument(req_name, "ReqMgr", "updaterequest",
-                                       fields=couch_fields_to_correct)
+                                       fields=couch_fields_to_correct, useBody=True)
                 print "Couch updated"
         else:
             print "OK"

--- a/src/python/WMCore/RequestManager/RequestDB/Interface/Request/ChangeState.py
+++ b/src/python/WMCore/RequestManager/RequestDB/Interface/Request/ChangeState.py
@@ -91,7 +91,7 @@ def changeRequestStatus(requestName, newState, priority=None, wmstatUrl=None):
     url = couchUrl.replace('/' + couchDbName, '')
     couchDb = Database(couchDbName, url)
     fields = {"RequestStatus": newState}
-    couchDb.updateDocument(requestName, "ReqMgr", "updaterequest", fields=fields) 
+    couchDb.updateDocument(requestName, "ReqMgr", "updaterequest", fields=fields, useBody=True) 
 
     #TODO: should we make this mendatory?
     if wmstatUrl:

--- a/src/python/WMCore/Services/RequestDB/RequestDBWriter.py
+++ b/src/python/WMCore/Services/RequestDB/RequestDBWriter.py
@@ -41,13 +41,7 @@ class RequestDBWriter(RequestDBReader):
                     fields = stats)
 
     def updateRequestProperty(self, request, propDict, dn = None):
-        encodeProperty = {}
-        for key, value in propDict.items():
-            if isinstance(value, list) or isinstance(value, dict):
-                encodeProperty[key] = JSONEncoder().encode(value)
-            else:
-                encodeProperty[key] = value
         if dn:
-            encodeProperty["DN"] = dn
+            propDict["DN"] = dn
         return self.couchDB.updateDocument(request, self.couchapp, "updaterequest",
-                    encodeProperty)
+                    propDict, useBody=True)


### PR DESCRIPTION
fixes #5793.  This can't be patched to agent until cmsweb is updated.
after all the agent are deployed with this included, map.js need to be cleaned up to accept only request body.
1. Fixes #5793 
2. Also adds all the TaskChain params in reqmgr_workload_cache db but only when reqmgr2 api used.

Still need to be tested. Don't merge.
