### PR TITLE
move setting the processing task memory into StdBase

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/MonteCarlo.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/MonteCarlo.py
@@ -52,10 +52,7 @@ class MonteCarloWorkloadFactory(StdBase):
                                               configCacheUrl = self.configCacheUrl,
                                               seeding = self.seeding,
                                               totalEvents = self.totalEvents,
-                                              eventsPerLumi = self.eventsPerLumi,
-                                              timePerEvent = self.timePerEvent,
-                                              sizePerEvent = self.sizePerEvent,
-                                              memoryReq = self.memory)
+                                              eventsPerLumi = self.eventsPerLumi)
         self.addLogCollectTask(prodTask)
 
         # pile up support

--- a/src/python/WMCore/WMSpec/StdSpecs/MonteCarloFromGEN.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/MonteCarloFromGEN.py
@@ -50,10 +50,7 @@ class MonteCarloFromGENWorkloadFactory(DataProcessing):
                                               splitAlgo = self.procJobSplitAlgo,
                                               splitArgs = self.procJobSplitArgs,
                                               stepType = "CMSSW",
-                                              primarySubType = "Production",
-                                              timePerEvent = self.timePerEvent,
-                                              memoryReq = self.memory,
-                                              sizePerEvent = self.sizePerEvent)
+                                              primarySubType = "Production")
         self.addLogCollectTask(procTask)
 
         for outputModuleName in outputMods.keys():

--- a/src/python/WMCore/WMSpec/StdSpecs/ReDigi.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/ReDigi.py
@@ -221,9 +221,8 @@ class ReDigiWorkloadFactory(DataProcessing):
                                               configCacheUrl = self.configCacheUrl,
                                               configDoc = self.stepOneConfigCacheID,
                                               splitAlgo = self.procJobSplitAlgo,
-                                              splitArgs = self.procJobSplitArgs, stepType = "CMSSW",
-                                              timePerEvent = self.timePerEvent, memoryReq = self.memory,
-                                              sizePerEvent = self.sizePerEvent)
+                                              splitArgs = self.procJobSplitArgs,
+                                              stepType = "CMSSW")
         self.addLogCollectTask(stepOneTask)
 
         if self.keepStepOneOutput and self.keepStepTwoOutput:

--- a/src/python/WMCore/WMSpec/StdSpecs/ReReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/ReReco.py
@@ -54,10 +54,7 @@ class ReRecoWorkloadFactory(DataProcessing):
                                               configDoc = self.configCacheID,
                                               splitAlgo = self.procJobSplitAlgo,
                                               splitArgs = self.procJobSplitArgs,
-                                              stepType = cmsswStepType,
-                                              timePerEvent = self.timePerEvent,
-                                              memoryReq = self.memory,
-                                              sizePerEvent = self.sizePerEvent)
+                                              stepType = cmsswStepType)
         self.addLogCollectTask(procTask)
 
         for outputModuleName in outputMods.keys():

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -281,9 +281,18 @@ class StdBase(object):
             newSplitArgs[str(argName)] = splitArgs[argName]
 
         procTask.setSplittingAlgorithm(splitAlgo, **newSplitArgs)
+
+        if not timePerEvent and self.timePerEvent:
+            timePerEvent = self.timePerEvent
+        if not sizePerEvent and self.sizePerEvent:
+            sizePerEvent = self.sizePerEvent
+        if not memoryReq and self.memory:
+            memoryReq = self.memory
+
         procTask.setJobResourceInformation(timePerEvent = timePerEvent,
                                            sizePerEvent = sizePerEvent,
                                            memoryReq = memoryReq)
+
         procTask.setTaskType(taskType)
         procTask.setProcessingVersion(self.processingVersion)
         procTask.setAcquisitionEra(self.acquisitionEra)

--- a/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
@@ -322,8 +322,10 @@ class TaskChainWorkloadFactory(StdBase):
                                               configCacheUrl = self.configCacheUrl,
                                               splitArgs = splitArguments, stepType = cmsswStepType,
                                               seeding = taskConf['Seeding'], totalEvents = taskConf['RequestNumEvents'],
-                                              forceUnmerged = forceUnmerged, timePerEvent = self.timePerEvent,
-                                              memoryReq = taskConf.get('Memory', None), sizePerEvent = self.sizePerEvent,
+                                              forceUnmerged = forceUnmerged,
+                                              timePerEvent = taskConf.get('TimePerEvent', None),
+                                              sizePerEvent = taskConf.get('SizePerEvent', None),
+                                              memoryReq = taskConf.get('Memory', None),
                                               taskConf = taskConf)
 
         # this need to be called after setpuProcessingTask since it will overwrite some values
@@ -400,9 +402,9 @@ class TaskChainWorkloadFactory(StdBase):
                                               splitArgs = taskConf["SplittingArguments"],
                                               stepType = cmsswStepType,
                                               forceUnmerged = forceUnmerged,
-                                              timePerEvent = self.timePerEvent,
+                                              timePerEvent = taskConf.get('TimePerEvent', None),
+                                              sizePerEvent = taskConf.get('SizePerEvent', None),
                                               memoryReq = taskConf.get("Memory", None),
-                                              sizePerEvent = self.sizePerEvent, 
                                               taskConf = taskConf)
         
         # this need to be called after setpuProcessingTask since it will overwrite some values


### PR DESCRIPTION
The default for memory, timePerEvent and sizePerEvent should actually be used in the base class and not HAVE to be overridden in every single spec.
