### PR TITLE
Return correct value from checkbox checked

### DIFF
--- a/src/templates/WMCore/WebTools/RequestManager/Assign.tmpl
+++ b/src/templates/WMCore/WebTools/RequestManager/Assign.tmpl
@@ -77,7 +77,7 @@ Site Blacklist:
        <option>$site</option>
    #end for
 </select></br>
-<input type="checkbox" name="useSiteListAsLocation"/>Use site whitelist/blacklist for data location (allows use of xrootd capabilities)<br/>
+<input type="checkbox" name="useSiteListAsLocation" value="True"/>Use site whitelist/blacklist for data location (allows use of xrootd capabilities)<br/>
 <h4> PhEDEx Subscriptions </h4>
 Custodial Sites:
 <select name="CustodialSites" multiple size=10>


### PR DESCRIPTION
Current production (and testbed, I guess) ReqMgr raises a 500 if useSiteListAsLocation is checked.
Tested in my VM. @ticoann please review. It needs to get in the current testbed cycle.

Merge but don't create a tag yet, I still have to fix site lists.
