### PR TITLE
Add other T2_CH_CERN_* to the site lists, assign webpage

### DIFF
--- a/src/python/WMCore/Services/SiteDB/SiteDB.py
+++ b/src/python/WMCore/Services/SiteDB/SiteDB.py
@@ -168,7 +168,8 @@ class SiteDBJSON(Service):
         This will allow us to add them in resourceControl at once
         """
         sitenames = self._sitenames()
-        cmsnames = filter(lambda x: x['type']=='psn', sitenames)
+        # Remove Disk endpoints and add T2_CH_CERN_* flavors
+        cmsnames = filter(lambda x: x['type']=='cms' and not x['alias'].endswith("Disk"), sitenames)
         cmsnames = map(lambda x: x['alias'], cmsnames)
         return cmsnames
     


### PR DESCRIPTION
It will add the T2_CH_CERN_\* flavors to the site white/black list in the assign webpage.
@ticoann please review. I don't expect to have problems adding T1_CH_CERN to the resource control (which also uses this call), but I didn't investigate it deeply.

For clarity, this is the additional list of sites returned by this fix

> > > set(newnames) - set(cmsnames)
> > > set([u'T2_CH_CERN_T0', u'T2_CH_CERN_HLT', u'T3_TH_CHULA', u'T3_BG_UNI_SOFIA', u'T3_US_NEU', u'T0_CH_CERN', u'T2_CH_CERN_Wigner', u'T3_US_BU', u'T3_AS_Parrot', u'T2_CH_CERN_AI', u'T3_UK_GridPP_Cloud', u'T3_EU_Parrot', u'T3_IN_VBU', u'T3_US_ParrotTest', u'T3_US_UB', u'T3_US_Parrot', u'T1_CH_CERN'])
