### PR TITLE
Skip PU location if trustSiteList enabled

### DIFF
--- a/src/python/WMCore/WorkQueue/DataLocationMapper.py
+++ b/src/python/WMCore/WorkQueue/DataLocationMapper.py
@@ -246,6 +246,8 @@ class WorkQueueDataLocationMapper(DataLocationMapper):
             for data, locations in dataMapping.items():
                 elements = self.backend.getElementsForPileupData(data)
                 for element in elements:
+                    if element.get('NoLocationUpdate', False):
+                        continue
                     for pData in element['PileupData']:
                         if pData == data:
                             if sorted(locations) != sorted(element['PileupData'][pData]):

--- a/src/python/WMCore/WorkQueue/DataStructs/WorkQueueElement.py
+++ b/src/python/WMCore/WorkQueue/DataStructs/WorkQueueElement.py
@@ -213,6 +213,9 @@ class WorkQueueElement(dict):
     def passesSiteRestriction(self, site):
         """Takes account of white & black list, and input data to work out
         if site can run the work"""
+        # Don't check anything if useSiteListAsLocation/trusSiteLists is enabled
+        if self['NoLocationUpdate']:
+            return True
         # data restrictions - all data must be present at site
         for locations in self['Inputs'].values():
             if site not in locations:


### PR DESCRIPTION
Fix for #5971.
I think we should break up this problem into 2 steps:
1. make sure wq elements get replicated to the agent even when sitewhitelist hasn't the input
2. make sure things work Ok on the agent side.

With this PR, we would basically replicate any wq element containing NoLocationUpdate=True.
This way we can run ReDigi workflows anywhere during the next 2 months, at least. 
What do you guys thinkg @ticoann @ericvaandering @hufnagel ?
