### PR TITLE
Fix pylintrc

### DIFF
--- a/standards/.pylintrc
+++ b/standards/.pylintrc
@@ -27,7 +27,7 @@ evaluation='10.0 - ((float(5 * error + warning) / statement) * 10)'
 # evaluation report (R0004).
 comment=no
 # Include message's id in output
-include-ids=no
+include-id=no
 
 [MESSAGES CONTROL]
 # disable F0401 - could not import module


### PR DESCRIPTION
This is needed to change to our newer version of pylint. Why they just remove "s" from a bunch of stuff, I don't know.
