### PR TITLE
Fix byteamandstatus view for ReqMgr

### DIFF
--- a/src/couchapps/ReqMgr/views/byteamandstatus/map.js
+++ b/src/couchapps/ReqMgr/views/byteamandstatus/map.js
@@ -1,5 +1,5 @@
 function(doc) {
-	if (doc.Team) {
-		emit([doc.Team, doc.RequestStatus], null);
+	if (doc.Teams) {
+		emit([doc.Teams[0], doc.RequestStatus], null);
 	}
 }


### PR DESCRIPTION
It seems the key changed to plural somewhere in 2012 or 2013, that's why we have around 30k requests in production (out of ~90k). Since requests are assigned to a single team, I'm taking only the first element of the array.
@ticoann please review (no rush, we can push it in in the next cycle)
