### PR TITLE
tweak the AlcaHarvest payload duplicate removal

### DIFF
--- a/src/python/WMCore/FwkJobReport/Report.py
+++ b/src/python/WMCore/FwkJobReport/Report.py
@@ -1055,11 +1055,12 @@ class Report:
             results.append(getattr(analysisFiles, "file%s" % fileNum))
 
         # filter out duplicates
-        fileNames = []
+        duplicateCheck = []
         filteredResults = []
         for result in results:
-            if result.fileName not in fileNames:
-                fileNames.append(result.fileName)
+            inputtag = getattr(result, 'inputtag', None)
+            if (result.fileName, inputtag) not in duplicateCheck:
+                duplicateCheck.append((result.fileName, inputtag))
                 filteredResults.append(result)
 
         return filteredResults


### PR DESCRIPTION
A protection mechanism for duplicate files is too aggressive and removes all payloads except the first generated by the AlcaHarvesting. The patch fixes it.

Background: AlcaHarvest reports the same analysis file multiple times, once for each payload. We then upload this file multiple times, once for each payload. Hence we cannot just remove duplicates based on file name alone, this patch takes also into account the payload its for.
