### PR TITLE
Allow to get non-valid files from DBS in listDatasetFileDetails.

### DIFF
--- a/src/python/WMCore/JobSplitting/JobFactory.py
+++ b/src/python/WMCore/JobSplitting/JobFactory.py
@@ -205,8 +205,8 @@ class JobFactory(WMObject):
             fileset = self.loadFiles(size = self.limit)
             logging.debug("Loaded %i files" % (len(fileset)))
         else:
-            fileset = self.subscription.availableFiles(limit = self.limit, doingJobSplitting = True)
             logging.debug("About to load files by DAO")
+            fileset = self.subscription.availableFiles(limit = self.limit, doingJobSplitting = True)
 
         for file in fileset:
             locSet = frozenset(file['locations'])


### PR DESCRIPTION
This pull is because in CRAB we only care about files status in DBS and not about dataset status.

When the function listDatasetFileDetails was introduced by @bbockelm it was retrieving the details for all files in the dataset, no matter the dataset/files status. CRAB is then filtering the valid files. Then the "validFileOnly" flag was introduced here and hardcoded to 1. The problem with this is that in this case one gets the valid files only if the dataset status itself is VALID or PRODUCTION, but for any other dataset status one gets no files. And this is not what we want in CRAB. For example, if the dataset is in status INVALID or DEPRECATED, but there are some files in valid status, we want to be able to retrieve them. 

So I am introducing in this pull (first commit) the possibility to set validFileOnly = 0. In CRAB we then take care to filter the valid files. 

I tested the first commit with CRAB on a private dataset (/GenericTTbar/atanasi-140429_131619_crab_AprilTest_3000jbsOf3hrs-95e5dc29a1ac0766eb8514eb5d4ff77a/USER at phys03) that I set to INVALID and left 1 file in valid status (I used the procedure documented in https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideCrabForPublication#Invalidate_a_dataset_in_DBS) calling listDatasetFileDetails with validFileOnly = 0. I got all the files in the dataset as I wanted, but I was not getting the lumis. I tried then changing listFileLumis->listFileLumiArray (and therefore getting the lumis per file instaed of per block and btw doing the same for the parents) and I was able to get the lumis. So this is what I changed in the second commit.
