### PR TITLE
Let jobs retry when exit code 61102

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -234,7 +234,7 @@ config.ErrorHandler.logLevel = globalLogLevel
 config.ErrorHandler.maxRetries = maxJobRetries
 config.ErrorHandler.pollInterval = 240
 config.ErrorHandler.readFWJR = True
-config.ErrorHandler.failureExitCodes = [50660, 50661, 50664]
+config.ErrorHandler.failureExitCodes = [50660, 50661, 50664, 61102]
 config.ErrorHandler.maxFailTime = 120000
 config.ErrorHandler.maxProcessSize = 30
 

--- a/src/python/WMComponent/ErrorHandler/ErrorHandlerPoller.py
+++ b/src/python/WMComponent/ErrorHandler/ErrorHandlerPoller.py
@@ -44,7 +44,6 @@ from WMCore.JobStateMachine.ChangeState import ChangeState
 from WMCore.ACDC.DataCollectionService  import DataCollectionService
 from WMCore.WMException                 import WMException
 from WMCore.FwkJobReport.Report         import Report
-from WMCore.WMExceptions                import WMJobPermanentSystemErrors
 from WMCore.Database.CouchUtils import CouchConnectionError
 
 class ErrorHandlerException(WMException):
@@ -95,9 +94,6 @@ class ErrorHandlerPoller(BaseWorkerThread):
         # initialize the alert framework (if available - config.Alert present)
         #    self.sendAlert will be then be available
         self.initAlerts(compName = "ErrorHandler")
-
-        # Some exit codes imply an immediate failure, non-configurable
-        self.exitCodes.extend(WMJobPermanentSystemErrors)
 
         return
 

--- a/src/python/WMCore/WMExceptions.py
+++ b/src/python/WMCore/WMExceptions.py
@@ -56,10 +56,3 @@ WMJobErrorCodes = {50660 :
                    "The job was killed by the WMAgent because the site it was running at was set to Down",
                    61304 :
                    "The job was killed by the WMAgent for using too much wallclock time"}
-
-"""
-WMJobPermanentSystemErrors
-List of job errors produced by WMCore that are internal to the application and are used
-to indicate that a job should not be retried since the error is permanent
-"""
-WMJobPermanentSystemErrors = [61102]


### PR DESCRIPTION
The logic of WMJobPermanentSystemErrors is incompatible with the Retry plugin deciding when to fail a job. The list of exit codes that may cause a job to be failed should be at least configurable, not harcoded. In any case, if a site is down, it'll go through retries pretty quickly, so the gain is minimal. With this pull request the behavior for Ops is not changed, but in the Tier0 we can configure the list of exit codes in https://github.com/dmwm/WMCore/blob/master/etc/WMAgentConfig.py#L237 at convenience and nothing else would overwrite it. 
@hufnagel @amaltaro @ticoann 
