### PR TITLE
add option for EventAwareLumiBase to observe a 47h wall time estimate cap

### DIFF
--- a/src/python/WMCore/DataStructs/Job.py
+++ b/src/python/WMCore/DataStructs/Job.py
@@ -136,21 +136,40 @@ class Job(WMObject, dict):
         Add to the current resource estimates, if None then initialize them
         to the given value. Each value can be set independently.
         """
-        # Update time
-        if self["estimatedJobTime"] is None:
+        if not self["estimatedJobTime"]:
             self["estimatedJobTime"] = jobTime
-        elif jobTime is not None:
+        elif jobTime:
             self["estimatedJobTime"] += jobTime
-        # Update memory
-        if self["estimatedMemoryUsage"] is None:
+
+        if not self["estimatedMemoryUsage"]:
             self["estimatedMemoryUsage"] = memory
-        elif memory is not None:
+        elif memory:
             self["estimatedMemoryUsage"] += memory
-        # Update disk
-        if self["estimatedDiskUsage"] is None:
+
+        if not self["estimatedDiskUsage"]:
             self["estimatedDiskUsage"] = disk
-        elif disk is not None:
+        elif disk:
             self["estimatedDiskUsage"] += disk
+
+        return
+
+    def capResourceEstimates(self, jobTime = None, memory = None, disk = None):
+        """
+        _capResourceEstimates_
+
+        Checks the current resource estimates and caps them
+        at the provided values if higher.
+        """
+        if self["estimatedJobTime"] and jobTime and jobTime < self["estimatedJobTime"]:
+            self["estimatedJobTime"] = jobTime
+
+        if self["estimatedMemoryUsage"] and memory and memory < self["estimatedMemoryUsage"]:
+            self["estimatedMemoryUsage"] = memory
+
+        if self["estimatedDiskUsage"] and disk and disk < self["estimatedDiskUsage"]:
+            self["estimatedDiskUsage"] = disk
+
+        return
 
     def getBaggage(self):
         """

--- a/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
+++ b/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
@@ -52,6 +52,8 @@ class EventAwareLumiBased(JobFactory):
         lumis           = kwargs.get('lumis', None)
         timePerEvent, sizePerEvent, memoryRequirement = \
                     self.getPerformanceParameters(kwargs.get('performance', {}))
+        capJobTime      = kwargs.get('capJobTime', None)
+        capJobDisk      = kwargs.get('capJobDisk', None)
         deterministicPileup = kwargs.get('deterministicPileup', False)
         eventsPerLumiInDataset = 0
 
@@ -212,6 +214,8 @@ class EventAwareLumiBased(JobFactory):
                                 runAddedTime = eventsAdded * timePerEvent
                                 runAddedSize = eventsAdded * sizePerEvent
                                 self.currentJob.addResourceEstimates(jobTime = runAddedTime, disk = runAddedSize)
+                                if capJobTime or capJobDisk:
+                                    self.currentJob.capResourceEstimates(jobTime = capJobTime, disk = capJobDisk)
                                 firstLumi = None
                                 lastLumi = None
                             continue
@@ -224,6 +228,8 @@ class EventAwareLumiBased(JobFactory):
                             runAddedTime = eventsAdded * timePerEvent
                             runAddedSize = eventsAdded * sizePerEvent
                             self.currentJob.addResourceEstimates(jobTime = runAddedTime, disk = runAddedSize)
+                            if capJobTime or capJobDisk:
+                                self.currentJob.capResourceEstimates(jobTime = capJobTime, disk = capJobDisk)
                             firstLumi = None
                             lastLumi = None
 
@@ -243,6 +249,8 @@ class EventAwareLumiBased(JobFactory):
                                 runAddedTime = eventsAdded * timePerEvent
                                 runAddedSize = eventsAdded * sizePerEvent
                                 self.currentJob.addResourceEstimates(jobTime = runAddedTime, disk = runAddedSize)
+                                if capJobTime or capJobDisk:
+                                    self.currentJob.capResourceEstimates(jobTime = capJobTime, disk = capJobDisk)
                             msg = None
                             if failNextJob:
                                 msg = "File %s has too many events (%d) in %d lumi(s)" % (f['lfn'],
@@ -296,6 +304,8 @@ class EventAwareLumiBased(JobFactory):
                         runAddedTime = eventsAdded * timePerEvent
                         runAddedSize = eventsAdded * sizePerEvent
                         self.currentJob.addResourceEstimates(jobTime = runAddedTime, disk = runAddedSize)
+                        if capJobTime or capJobDisk:
+                            self.currentJob.capResourceEstimates(jobTime = capJobTime, disk = capJobDisk)
                         firstLumi = None
                         lastLumi = None
 

--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -260,6 +260,11 @@ class PromptRecoWorkloadFactory(StdBase):
             self.procJobSplitArgs["events_per_job"] = self.eventsPerJob
             if self.procJobSplitAlgo == "EventAwareLumiBased":
                 self.procJobSplitArgs["max_events_per_lumi"] = 100000
+                self.procJobSplitArgs["capJobTime"] = 47*3600
+                if self.multicore:
+                    self.procJobSplitArgs["capJobDisk"] = max(self.multicoreNCores*20000000, 80000000)
+                else:
+                    self.procJobSplitArgs["capJobDisk"] = 80000000
         elif self.procJobSplitAlgo == "LumiBased":
             self.procJobSplitArgs["lumis_per_job"] = self.lumisPerJob
         elif self.procJobSplitAlgo == "FileBased":


### PR DESCRIPTION
The Tier0 has very unreliable timePerEvent and sizePerEvent estimates as running conditions can change greatly, leading to huge differences within the same dataset from run to run. To not create jobs that can never run, cap the wall time and disk estimates.
