### PR TITLE
Mark flipping tests as integration

### DIFF
--- a/test/python/WMCore_t/WebTools_t/NestedModel_t.py
+++ b/test/python/WMCore_t/WebTools_t/NestedModel_t.py
@@ -1,6 +1,8 @@
 import unittest, logging
 from cherrypy import HTTPError
 
+from nose.plugins.attrib import attr
+
 from WMQuality.WebTools.RESTBaseUnitTest import RESTBaseUnitTest
 from WMQuality.WebTools.RESTClientAPI import methodTest
 from WMQuality.WebTools.RESTServerSetup import DefaultConfig
@@ -51,6 +53,9 @@ class NestedModelTest(RESTBaseUnitTest):
         output={'code':400}
         methodTest(verb, url, output=output)
 
+    # This test is flipping back and forth in Jenkins. Perhaps due to port 8888 not being available.
+    # Disabling for now
+    @attr("integration")
     def testInnerPingError(self):
         verb ='GET'
         url = self.urlbase + 'foo/123/ping'

--- a/test/python/WMCore_t/WebTools_t/RESTFormat_t.py
+++ b/test/python/WMCore_t/WebTools_t/RESTFormat_t.py
@@ -9,17 +9,15 @@ TODO: duplicate all direct call tests to ones that use HTTP
 
 import unittest
 import logging
-import urllib
-import urllib2
 
-from cherrypy import HTTPError
+from nose.plugins.attrib import attr
+
 from WMCore.WebTools.RESTFormatter import RESTFormatter
 from WMCore_t.WebTools_t.DummyRESTModel import DummyRESTModel
 
 from WMQuality.WebTools.RESTBaseUnitTest import RESTBaseUnitTest
 from WMQuality.WebTools.RESTClientAPI import methodTest
 from WMQuality.WebTools.RESTServerSetup import DefaultConfig
-from WMCore.Wrappers import JsonWrapper
 
 class RESTFormatTest(RESTBaseUnitTest):
 
@@ -50,6 +48,9 @@ class RESTFormatTest(RESTBaseUnitTest):
             # test accepted type should return 200 error
             methodTest('GET', url, accept=type, output={'code':200})
 
+    # This test is flipping back and forth in Jenkins. Perhaps due to port 8888 not being available.
+    # Disabling for now
+    @attr("integration")
     def testEncodedInput(self):
         type = 'text/plain'
 

--- a/test/python/WMCore_t/WebTools_t/REST_t.py
+++ b/test/python/WMCore_t/WebTools_t/REST_t.py
@@ -100,6 +100,9 @@ class RESTTest(RESTBaseUnitTest):
 
         methodTest(verb, url, input, output=output)
 
+    # This test is flipping back and forth in Jenkins. Perhaps due to port 8888 not being available.
+    # Disabling for now
+    @attr("integration")
     def testBadVerbEcho(self):
         "echo is only available to GET and POST, so should raise a 501"
         url = self.urlbase + 'echo'
@@ -109,6 +112,9 @@ class RESTTest(RESTBaseUnitTest):
         for verb in ['DELETE']:
             methodTest(verb, url, input, output=output)
 
+    # This test is flipping back and forth in Jenkins. Perhaps due to port 8888 not being available.
+    # Disabling for now
+    @attr("integration")
     def testPing(self):
         verb ='GET'
         url = self.urlbase + 'ping'
@@ -117,6 +123,9 @@ class RESTTest(RESTBaseUnitTest):
 
         methodTest(verb, url, output=output, expireTime=expireTime)
 
+    # This test is flipping back and forth in Jenkins. Perhaps due to port 8888 not being available.
+    # Disabling for now
+    @attr("integration")
     def testBadPing(self):
         verb ='GET'
 
@@ -133,6 +142,9 @@ class RESTTest(RESTBaseUnitTest):
         output={'code':400}
         methodTest(verb, url, output=output)
 
+    # This test is flipping back and forth in Jenkins. Perhaps due to port 8888 not being available.
+    # Disabling for now
+    @attr("integration")
     def testException(self):
         """
         list takes a single integer argument, querying with a string
@@ -162,12 +174,17 @@ class RESTTest(RESTBaseUnitTest):
         for i in result.keys():
             self.assertEqual(result[i], request_input[i], '%s does not match response' % i)
 
-
+    # This test is flipping back and forth in Jenkins. Perhaps due to port 8888 not being available.
+    # Disabling for now
+    @attr("integration")
     def testA(self):
         for t in ['GET', 'POST', 'PUT', 'DELETE', 'UPDATE']:
             response = makeRequest(url=self.urlbase + '/', values={'value':1234})
             assert response[1] == 200, 'Got a return code != 200 (got %s)' % response[1]
 
+    # This test is flipping back and forth in Jenkins. Perhaps due to port 8888 not being available.
+    # Disabling for now
+    @attr("integration")
     def testSanitisePass(self):
         """
         Emulate how CherryPy passes arguments to a method, check that the data
@@ -224,6 +241,9 @@ class RESTTest(RESTBaseUnitTest):
                  '. Got a return code != 200 (got %s)' % response[1] +\
                  '. Returned data: %s' % response[0]
 
+    # This test is flipping back and forth in Jenkins. Perhaps due to port 8888 not being available.
+    # Disabling for now
+    @attr("integration")
     def testSanitiseAssertFail(self):
         """
         No server set up required, the purpose of the test is just
@@ -300,6 +320,9 @@ class RESTTest(RESTBaseUnitTest):
         result =  drm.methods['GET']['data3']['call'](num = 456, thing="TEST")
         self.assertEqual( result['num'] == 456 and result['thing'] ,  "TEST" )
 
+    # This test is flipping back and forth in Jenkins. Perhaps due to port 8888 not being available.
+    # Disabling for now
+    @attr("integration")
     def testDAOBasedHTTP(self):
         """
         Same as testSanitisePass but do it over http and check the returned http
@@ -338,6 +361,9 @@ class RESTTest(RESTBaseUnitTest):
         #Should use encoded and decoded format
         self.assertEqual( response[0] ,  "{'thing': 'abc', 'num': '123'}", "should be {'thing': 'abc', 'num': '123'} but got %s" % response[0] )
 
+    # This test is flipping back and forth in Jenkins. Perhaps due to port 8888 not being available.
+    # Disabling for now
+    @attr("integration")
     def testListTypeArgs(self):
         # 2 positional args (e.g. url/arg1/arg2)
         url = self.urlbase + 'listTypeArgs?aList=1'


### PR DESCRIPTION
At least this should take out some of the tests that insist on flipping back and forth and making noise.
