### PR TITLE
Make unique file entries for ACDC MCFakeFiles

### DIFF
--- a/test/python/WMCore_t/ACDC_t/DataCollectionService_t.py
+++ b/test/python/WMCore_t/ACDC_t/DataCollectionService_t.py
@@ -9,9 +9,8 @@ Copyright (c) 2010 Fermilab. All rights reserved.
 
 import unittest
 
-
 from WMQuality.TestInitCouchApp import TestInitCouchApp
-from WMCore.ACDC.DataCollectionService import DataCollectionService
+from WMCore.ACDC.DataCollectionService import DataCollectionService, mergeFakeFiles
 from WMCore.WMBS.Job import Job
 from WMCore.DataStructs.File import File
 from WMCore.DataStructs.Run import Run
@@ -294,6 +293,87 @@ class DataCollectionService_t(unittest.TestCase):
         self.assertEqual(whiteList["3"], [[20, 20]],
                          "Error: Whitelist for run 3 is wrong.")
         return
+
+    def notestMergeFakeFiles(self):
+        """
+        _testMergeFakeFiles_
+
+        Verify that we can merge MCFakeFiles together when a fileset contains
+        several failures for the same input fake file.
+        """
+        originalFiles = [{'checksums': {},
+                          'events': 500000,
+                          'first_event': 1,
+                          'id': 40,
+                          'last_event': 0,
+                          'lfn': 'MCFakeFile-File1',
+                          'locations': ['T1_DE_KIT_Disk'],
+                          'merged': '0',
+                          'parents': [],
+                          'runs': [{'lumis': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], 'run_number': 1}],
+                          'size': 0},
+                         {'checksums': {},
+                          'events': 500000,
+                          'first_event': 1000001,
+                          'id': 40,
+                          'last_event': 0,
+                          'lfn': 'MCFakeFile-File2',
+                          'locations': ['T1_DE_KIT_Disk'],
+                          'merged': '0',
+                          'parents': [],
+                          'runs': [{'lumis': [21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31],
+                                    'run_number': 1}],
+                          'size': 0},
+                         {'checksums': {},
+                          'events': 500000,
+                          'first_event': 2000001,
+                          'id': 40,
+                          'last_event': 0,
+                          'lfn': 'MCFakeFile-File1',
+                          'locations': ['T1_DE_KIT_Disk'],
+                          'merged': '0',
+                          'parents': [],
+                          'runs': [{'lumis': [41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51],
+                                    'run_number': 1}],
+                          'size': 0},
+                         {'checksums': {},
+                          'events': 500000,
+                          'first_event': 7000001,
+                          'id': 40,
+                          'last_event': 0,
+                          'lfn': 'MCFakeFile-File3',
+                          'locations': ['T1_DE_KIT_Disk'],
+                          'merged': '0',
+                          'parents': [],
+                          'runs': [{'lumis': [81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91],
+                                    'run_number': 1}],
+                          'size': 0},
+                         {'checksums': {},
+                          'events': 500000,
+                          'first_event': 4000001,
+                          'id': 40,
+                          'last_event': 0,
+                          'lfn': 'MCFakeFile-File3',
+                          'locations': ['T1_DE_KIT_Disk'],
+                          'merged': '0',
+                          'parents': [],
+                          'runs': [{'lumis': [51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61],
+                                    'run_number': 1}],
+                          'size': 0}]
+
+        mergedFiles = mergeFakeFiles(originalFiles)
+        self.assertEqual(len(mergedFiles), 3, "Error: wrong number of files.")
+
+        totalEvents = 0
+        for job in mergedFiles:
+            totalEvents += job['events']
+        self.assertEqual(totalEvents, 2500000, "Error: wrong number of total events.")
+
+        for job in mergedFiles:
+            if job['lfn'] == 'MCFakeFile-File1':
+                lumiList= job['runs'][0]['lumis']
+        self.assertEqual(len(lumiList), 22)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
It seems several acdc entries (jobs) using the same MCFakeFile causes an Oracle IntegrityError

```
2015-08-03 07:25:55,051:ERROR:WorkQueue:jbadillo_ACDC_SUS-RunIIWinter15pLHE-00011_00010_v0_STEP0ATCERN_150708_150727_7499, /acdc/jbadillo_ACDC_SUS-RunIIWinter15pLHE-00011_00010_v0_STEP0ATCERN_150708_150727_7499/:pdmvserv_SUS-RunIIWinter15pLHE-00011_00010_v0_STEP0ATCERN_150704_201230_7297:Production/0/26 creating subscription failed in LQ: (IntegrityError) (1062, "Duplicate entry 'MCFakeFile-pdmvserv_SUS-RunIIWinter15pLHE-00011_00010_v0_STEP0AT' for key 'lfn'") 'insert into dbsbuffer_file(lfn, filesize, events, dataset_algo, status, workflow)\n                values (%s, %s, %s, %s, %s, %s)' [('MCFakeFile-pdmvserv_SUS-RunIIWinter15pLHE-00011_00010_v0_STEP0ATCERN_150704_201230_7297-Production-b9ea0183968f67ba39db2a964f0565e6', 0, 500000, 1L, 'GLOBAL', 19221L), ('MCFakeFile-pdmvserv_SUS-RunIIWinter15pLHE-00011_00010_v0_STEP0ATCERN_150704_201230_7297-Production-b9ea0183968f67ba39db2a964f0565e6', 0, 200000, 1L, 'GLOBAL', 19221L)]
```

cmssrv217 was raising this exception for a couple of weeks.
I have applied this patch there (agent is basically drained) and then WorkQueue went through.

@ticoann please do not merge it yet, I need to go deeper here to make sure it's not going to bug down in the chain (I guess job creation for acdc is retrieved from couch, not from oracle, so in principle we should be safe here)...
