### PR TITLE
Added unique constraint to oracle dbsbuffer_file lfn

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/Oracle/Create.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/Create.py
@@ -317,10 +317,6 @@ class Create(DBCreator):
                (CONSTRAINT dbsbuffer_algo_unique UNIQUE (app_name, app_ver,
                                                          app_fam, pset_hash) %s)""" % tablespaceIndex
 
-        self.indexes["01_pk_dbsbuffer_file"] = \
-          """ALTER TABLE dbsbuffer_file ADD
-               (CONSTRAINT dbsbuffer_file_pk PRIMARY KEY (id) %s)""" % tablespaceIndex
-
         self.indexes["01_pk_dbsbuffer_file_parent"] = \
           """ALTER TABLE dbsbuffer_file_parent ADD
                (CONSTRAINT dbsbuffer_file_parent_pk PRIMARY KEY (child, parent) %s)""" % tablespaceIndex
@@ -398,10 +394,18 @@ class Create(DBCreator):
           """ALTER TABLE dbsbuffer_workflow ADD
                (CONSTRAINT dbsbuffer_workflow_uq UNIQUE (name, task) %s)""" % tablespaceIndex
 
+        self.indexes["01_pk_dbsbuffer_file"] = \
+          """ALTER TABLE dbsbuffer_file ADD
+               (CONSTRAINT dbsbuffer_file_pk PRIMARY KEY (id) %s)""" % tablespaceIndex
+
         self.constraints["01_fk_dbsbuffer_file"] = \
           """ALTER TABLE dbsbuffer_file ADD
-               (CONSTRAINT dbsbuffer_file  FOREIGN KEY (workflow)  REFERENCES dbsbuffer_workflow(id)
+               (CONSTRAINT dbsbuffer_file FOREIGN KEY (workflow) REFERENCES dbsbuffer_workflow(id)
                  ON DELETE CASCADE)"""
+
+        self.indexes["01_uq_dbsbuffer_file"] = \
+          """ALTER TABLE dbsbuffer_file ADD
+               (CONSTRAINT dbsbuffer_file_unique UNIQUE (lfn) %s)""" % tablespaceIndex
 
         checksumTypes = ['cksum', 'adler32', 'md5']
         for i in checksumTypes:


### PR DESCRIPTION
As discussed in this elog
https://cms-logbook.cern.ch/elog/Workflow+processing/21225
this is the simple patch.

However, I noticed quite a bit of inconsistencies between the mysql and oracle db schema. They basically are:
- oracle has much more not null constraints
- oracle missing unique constraint for dbsbuffer_file_parent
- oracle with additional fk for dbsbuffer_block
- oracle with additional fk for dbsbuffer_file_runlumi_map
- mysql missing a pk for dbsbuffer_algo_dataset_assoc
  you can see the whole story here:
  https://github.com/amaltaro/WMCore/commit/6b1379a5a37ff52fe3c6b69ec071bb96d6956e2a

@ticoann what do you think? should we make them consistent? replicate which schema (mysql -> oracle or vice-versa?)? 
Otherwise, someone could make some diagrams and investigate what's really correct :-)
