### PR TITLE
Remove imports that no longer exist

### DIFF
--- a/test/python/WMCore_t/REST_t/Api_t.py
+++ b/test/python/WMCore_t/REST_t/Api_t.py
@@ -1,4 +1,4 @@
-from cherrypy.test import test, webtest, helper
+from cherrypy.test import helper
 from cherrypy import expose, response, config as cpconfig
 from WMCore.REST.Server import RESTApi, RESTEntity, restcall, rows
 from WMCore.REST.Test import setup_test_server, fake_authz_headers

--- a/test/python/WMCore_t/REST_t/Daemon_t.py
+++ b/test/python/WMCore_t/REST_t/Daemon_t.py
@@ -1,4 +1,4 @@
-from cherrypy.test import test, webtest, helper
+from cherrypy.test import helper
 from WMCore.REST.Test import setup_test_server, fake_authz_headers
 from WMCore.REST.Server import RESTApi, RESTEntity, restcall
 from cherrypy import expose, engine, process, config as cpconfig

--- a/test/python/WMCore_t/REST_t/Simple_t.py
+++ b/test/python/WMCore_t/REST_t/Simple_t.py
@@ -1,4 +1,4 @@
-from cherrypy.test import test, webtest, helper
+from cherrypy.test import helper
 from WMCore.REST.Test import setup_test_server, fake_authz_headers
 from WMCore.REST.Tools import tools
 import WMCore.REST.Test as T


### PR DESCRIPTION
This won't actually fix any tests. Still trying to work out how to do that with CherryPy in our setup. But these imports disappeared in CherryPy 3.2 and the method of testing changed. So it seems to me you can merge this and then let things fail on something other than the missing import.
