### PR TITLE
Remove dependencies to the WorkQueueManager config for the Tier0 agent

### DIFF
--- a/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
+++ b/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
@@ -47,7 +47,6 @@ class ResourceControlUpdater(BaseWorkerThread):
         
         # agent teams (for dynamic threshold) and queueParams (drain mode)
         self.teamNames = config.Agent.teamName
-        self.queueParams = config.WorkQueueManager.queueParams
         self.agentsNumByTeam = getattr(config.AgentStatusWatcher, 'defaultAgentsNumByTeam', 5)
                 
         # only SSB sites

--- a/src/python/WMComponent/AnalyticsDataCollector/DataCollectAPI.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/DataCollectAPI.py
@@ -383,7 +383,10 @@ def isDrainMode(config):
     """
     config is loaded WMAgentCofig 
     """
-    return config.WorkQueueManager.queueParams.get('DrainMode', False)
+    if hasattr(self.config, "Tier0Feeder"):
+        return False
+    else:
+        return config.WorkQueueManager.queueParams.get('DrainMode', False)
 
 def initAgentInfo(config):
     


### PR DESCRIPTION
Tier0 agent does not use WorkQueueManager, in order to be able to remove it from the config we need to fix some dependencies on other components over the WorkQueueManager section of the config.
