### PR TITLE
making logcollect jobs run better

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
@@ -14,16 +14,16 @@ import socket
 
 from WMCore.WMSpec.Steps.WMExecutionFailure import WMExecutionFailure
 
-from WMCore.WMSpec.Steps.Executor           import Executor
-from WMCore.FwkJobReport.Report             import Report
+from WMCore.WMSpec.Steps.Executor import Executor
 
-import WMCore.Storage.FileManager
-import WMCore.Storage.StageOutMgr as StageOutMgr
-import WMCore.Storage.StageInMgr  as StageInMgr
-import WMCore.Storage.DeleteMgr   as DeleteMgr
+from WMCore.Storage.StageOutMgr import StageOutMgr
+from WMCore.Storage.StageInMgr import StageInMgr
+from WMCore.Storage.DeleteMgr import DeleteMgr
+
 from WMCore.Storage.StageOutError import StageOutFailure
 
 from WMCore.Algorithms.Alarm import Alarm, alarmHandler
+
 
 class LogCollect(Executor):
     """
@@ -40,7 +40,7 @@ class LogCollect(Executor):
         Pre execution checks
 
         """
-        #Are we using an emulator?
+        # Are we using an emulator?
         if (emulator != None):
             return emulator.emulatePre( self.step )
 
@@ -52,7 +52,7 @@ class LogCollect(Executor):
         _execute_
 
         """
-        #Are we using emulators again?
+        # Are we using emulators again?
         if (emulator != None):
             return emulator.emulate( self.step, self.job )
 
@@ -66,12 +66,11 @@ class LogCollect(Executor):
         lfnPrefix = overrides.get('lfnPrefix', "srm://srm-cms.cern.ch:8443/srm/managerv2?SFN=/castor/cern.ch/cms")
         lfnBase   = overrides.get('lfnBase',   "/store/user/jsmith")
         userLogs  = overrides.get('userLogs',  False)
-        dontStage = overrides.get('dontStage', False)
 
         stageOutParams = {"command": "srmv2-lcg",
                           "se-name": seName,  "lfn-prefix": lfnPrefix}
         
-        #Okay, we need a stageOut Manager
+        # Okay, we need a stageOut Manager
         useNewStageOutCode = False
         if getattr(self.step, 'newStageout', False) or \
             ('newStageOut' in overrides and overrides.get('newStageOut')):
@@ -79,131 +78,140 @@ class LogCollect(Executor):
         try:
             if not useNewStageOutCode:
                 # old style
-                deleteMgr   = DeleteMgr.DeleteMgr()
-                stageInMgr  = StageInMgr.StageInMgr()
-                stageOutMgr = StageOutMgr.StageOutMgr(**stageOutParams)
+                stageOutMgr = StageOutMgr(**stageOutParams)
+                stageInMgr = StageInMgr()
+                deleteMgr = DeleteMgr()
             else:
-                # new style
-                logging.info("LOGCOLLECT IS USING NEW STAGEOUT CODE")
-                stageOutMgr = WMCore.Storage.FileManager.StageOutMgr(
-                                    retryPauseTime  = self.step.retryDelay,
-                                    numberOfRetries = self.step.retryCount,
-                                    **overrides)
-                stageInMgr = WMCore.Storage.FileManager.StageInMgr(
-                                    retryPauseTime  = self.step.retryDelay,
-                                    numberOfRetries = self.step.retryCount )
-                deleteMgr = WMCore.Storage.FileManager.DeleteMgr(
-                                    retryPauseTime  = self.step.retryDelay,
-                                    numberOfRetries = self.step.retryCount )
-    
-                deleteMgr   = DeleteMgr.DeleteMgr()
-                stageInMgr  = StageInMgr.StageInMgr()
-                stageOutMgr = StageOutMgr.StageOutMgr(**stageOutParams)
+                # new style (is even working ???)
+                #logging.info("LOGCOLLECT IS USING NEW STAGEOUT CODE")
+                #stageOutMgr = StageOutMgr(retryPauseTime  = self.step.retryDelay,
+                #                          numberOfRetries = self.step.retryCount,
+                #                          **overrides)
+                #stageInMgr = StageInMgr(retryPauseTime  = 0,
+                #                        numberOfRetries = 0)
+                #deleteMgr = DeleteMgr(retryPauseTime  = 0,
+                #                      numberOfRetries = 0)
+                stageOutMgr = StageOutMgr(**stageOutParams)
+                stageInMgr = StageInMgr()
+                deleteMgr = DeleteMgr()
         except Exception as ex:
             msg = "Unable to load StageIn/Out/Delete Impl: %s" % str(ex)
             logging.error(msg)
             raise WMExecutionFailure(60312, "MgrImplementationError", msg)
 
-
         # Now we need the logs
-        if not dontStage: # Don't stage or delete files
-            logs = []
-            for file in self.job["input_files"]:
-                logs.append({"LFN": file["lfn"]})
+        logs = []
+        for log in self.job["input_files"]:
+            logs.append({"LFN": log["lfn"]})
 
-            readyFiles = []
-            for file in logs:
-                signal.signal(signal.SIGALRM, alarmHandler)
-                signal.alarm(waitTime)
-                try:
-                    output = stageInMgr(**file)
-                    readyFiles.append(output)
-                    self.report.addInputFile(sourceName = "logArchives",
-                                            lfn = file['LFN'])
-                except Alarm:
-                    msg = "Indefinite hang during stageIn of LogCollect"
-                    logging.error(msg)
-                    self.report.addError(self.stepName, 60407, "LogCollectTimeout", msg)
-                    self.report.persist("Report.pkl")
-                except StageOutFailure as ex:
-                    msg = "Unable to StageIn %s" % file['LFN']
-                    logging.error(msg)
-                    # Don't do anything other then record it
-                    self.report.addSkippedFile(file.get('PFN', None), file['LFN'])
-                except Exception as ex:
-                    raise
+        # create output tar file
+        taskName = self.report.getTaskName().split('/')[-1]
+        host = socket.gethostname().split('.')[0]
+        tarName = '%s-%s-%s-%i-logs.tar' % (self.report.data.workload, taskName, host , self.job["counter"])
+        tarLocation = os.path.join(self.stepSpace.location, tarName)
+        tarFile = tarfile.open(tarLocation, 'w:')
 
-                signal.alarm(0)
+        addedFilesToTar = 0
+        for log in logs:
 
-            if len(readyFiles) == 0:
-                # Then we have no output; all the files failed
-                # Panic!
-                msg = "No logs staged in during LogCollect step"
-                logging.error(msg)
-                raise WMExecutionFailure(60312, "LogCollectError", msg)
-
-            now = datetime.datetime.now()
-            tarPFN = self.createArchive(readyFiles)
-            if userLogs:
-                lfn = "%s/%s/logs/%s" % (lfnBase, self.report.data.workload, os.path.basename(tarPFN))
-            else:
-                lfn = "/store/logs/prod/%i/%.2i/%s/%s/%s" % (now.year, now.month, "WMAgent",
-                                                            self.report.data.workload,
-                                                            os.path.basename(tarPFN))
-
-            tarInfo = {'LFN'    : lfn,
-                    'PFN'    : tarPFN,
-                    'SEName' : None,
-                    'GUID'   : None}
-
+            # stage in logArchive from mass storage
+            # give up after timeout of 10 minutes
             signal.signal(signal.SIGALRM, alarmHandler)
-            signal.alarm(waitTime)
+            signal.alarm(600)
+            logArchive = None
             try:
-                stageOutMgr(tarInfo)
-                self.report.addOutputFile(outputModule = "LogCollect", file = tarInfo)
+                logArchive = stageInMgr(**log)
+                self.report.addInputFile(sourceName = "logArchives", lfn = log['LFN'])
             except Alarm:
-                msg = "Indefinite hang during stageOut of LogCollect"
+                msg = "Indefinite hang during stageIn of LogCollect"
                 logging.error(msg)
-                raise WMExecutionFailure(60409, "LogCollectTimeout", msg)
-            except Exception as ex:
-                msg = "Unable to stage out log archive:\n"
-                msg += str(ex)
-                print "MSG: %s" % msg
-                raise WMExecutionFailure(60408, "LogCollectStageOutError", msg)
+                self.report.addError(self.stepName, 60407, "LogCollectTimeout", msg)
+                self.report.persist("Report.pkl")
+            except StageOutFailure as ex:
+                msg = "Unable to StageIn %s" % log['LFN']
+                logging.error(msg)
+                # Don't do anything other then record it
+                self.report.addSkippedFile(log.get('PFN', None), log['LFN'])
+            except Exception:
+                raise
             signal.alarm(0)
 
-            # If we're still here we didn't die on stageOut
-            for file in self.job["input_files"]:
-                signal.signal(signal.SIGALRM, alarmHandler)
-                signal.alarm(waitTime)
-                try:
-                    fileToDelete = {"LFN": file["lfn"],
-                                    "PFN": None,
-                                    "SEName": None,
-                                    "StageOutCommand": None}
-                    deleteMgr(fileToDelete = fileToDelete)
-                except Alarm:
-                    msg = "Indefinite hang during delete of LogCollect"
-                    logging.error(msg)
-                    raise WMExecutionFailure(60411, "DeleteTimeout", msg)
-                except Exception as ex:
-                    msg = "Unable to delete files:\n"
-                    msg += str(ex)
-                    logging.error(msg)
-                    raise WMExecutionFailure(60410, "DeleteError", msg)
-                signal.alarm(0)
+            if logArchive:
+                addedFilesToTar =+ 1
+                path = logArchive['PFN'].split('/')
+                tarFile.add(name = logArchive["PFN"],
+                            arcname = os.path.join(path[-3],
+                                                   path[-2],
+                                                   os.path.basename(logArchive['PFN'])))
 
+                # delete logArchive from local disk
+                os.remove(logArchive["PFN"])
+
+        tarFile.close()
+
+        if addedFilesToTar == 0:
+            # Then we have no output, all the files failed => fail job
+            msg = "No logs staged in during LogCollect step"
+            logging.error(msg)
+            raise WMExecutionFailure(60312, "LogCollectError", msg)
+
+        # we got this far, delete input
+        for log in logs:
+
+            # delete logArchive from mass storage
+            # give up after timeout of 5 minutes
+            signal.signal(signal.SIGALRM, alarmHandler)
+            signal.alarm(300)
+            try:
+                fileToDelete = {"LFN": log["lfn"],
+                                "PFN": None,
+                                "SEName": None,
+                                "StageOutCommand": None}
+                deleteMgr(fileToDelete = fileToDelete)
+            except Alarm:
+                msg = "Indefinite hang during delete of LogCollect"
+                logging.error(msg)
+            except Exception as ex:
+                msg = "Unable to delete files:\n"
+                msg += str(ex)
+                logging.error(msg)
+            signal.alarm(0)
+
+        now = datetime.datetime.now()
+        if userLogs:
+            lfn = "%s/%s/logs/%s" % (lfnBase, self.report.data.workload, os.path.basename(tarLocation))
+        else:
+            lfn = "/store/logs/prod/%i/%.2i/%s/%s/%s" % (now.year, now.month, "WMAgent",
+                                                         self.report.data.workload,
+                                                         os.path.basename(tarLocation))
+
+        tarInfo = {'LFN'    : lfn,
+                   'PFN'    : tarLocation,
+                   'SEName' : None,
+                   'GUID'   : None}
+
+        signal.signal(signal.SIGALRM, alarmHandler)
+        signal.alarm(waitTime)
+        try:
+            stageOutMgr(tarInfo)
+            self.report.addOutputFile(outputModule = "LogCollect", file = tarInfo)
+        except Alarm:
+            msg = "Indefinite hang during stageOut of LogCollect"
+            logging.error(msg)
+            raise WMExecutionFailure(60409, "LogCollectTimeout", msg)
+        except Exception as ex:
+            msg = "Unable to stage out log archive:\n"
+            msg += str(ex)
+            print "MSG: %s" % msg
+            raise WMExecutionFailure(60408, "LogCollectStageOutError", msg)
+        signal.alarm(0)
 
         # Add to report
         outputRef = getattr(self.report.data, self.stepName)
-        if dontStage:
-            outputRef.output.pfn = 'NotStaged'
-            outputRef.output.location = 'NotStaged'
-            outputRef.output.lfn = 'NotStaged'
-        else:
-            outputRef.output.pfn = tarInfo['PFN']
-            outputRef.output.location = tarInfo['SEName']
-            outputRef.output.lfn = tarInfo['LFN']
+        outputRef.output.pfn = tarInfo['PFN']
+        outputRef.output.location = tarInfo['SEName']
+        outputRef.output.lfn = tarInfo['LFN']
+
         return
 
     def post(self, emulator = None):
@@ -213,30 +221,9 @@ class LogCollect(Executor):
         Post execution checkpointing
 
         """
-        #Another emulator check
+        # Another emulator check
         if (emulator != None):
             return emulator.emulatePost( self.step )
 
         print "Steps.Executors.LogCollect.post called"
         return None
-
-    def createArchive(self, fileList):
-        """
-        _createArchive_
-
-        Creates a tarball archive for log files
-        """
-        taskName = self.report.getTaskName().split('/')[-1]
-        host = socket.gethostname().split('.')[0]
-        tarName         = '%s-%s-%s-%i-logs.tar' % (self.report.data.workload, taskName, host , self.job["counter"])
-        tarBallLocation = os.path.join(self.stepSpace.location, tarName)
-        tarBall         = tarfile.open(tarBallLocation, 'w:')
-        for f in fileList:
-            path = f['PFN'].split('/')
-            tarBall.add(name = f["PFN"],
-                        arcname = os.path.join(path[-3],
-                                               path[-2],
-                                               os.path.basename(f['PFN'])))
-        tarBall.close()
-
-        return tarBallLocation


### PR DESCRIPTION
LogCollect jobs have a gazillion problems. This is fixing some of them.
- try to stage the logArchive in once, with a timeout at 10 minutes, then give up
- do not actually delete them unless they were staged in and added to the tarball
- stage in one file, add it to the tarball and then delete it from local disk and mass storage
- deletion from mass storage is optional, we try it for 5 minutes and then give up (and not fail the job)

This version seems to work, but probabaly needs some work, open questions:
- should I delete all logArchive if any of them can be processed and therefore the LogCollect job succeeds ?
- what about the fixed timeouts for stagein, is it ok to not retry ?
- what about the fixed timeout for deletions, should it be longer (we should never retry deletions, its not worth waiting for it considering this is just unmerged cleanup at that point) ?

This is fixing two immediate problems we have observed in the Tier0:
- LogCollect jobs ran out of local disk because it staged in all files and then build the tarball instead of doing it file by file
- LogCollect job took hours to retry stagein of a non-existent file, for each input file, leading to 10+hour LogCollect jobs that ultimately failed anyways 
