### PR TITLE
Accept sites state when adding sites

### DIFF
--- a/bin/deploy-wmagent.sh
+++ b/bin/deploy-wmagent.sh
@@ -300,11 +300,11 @@ echo "*** Populating resource-control ***"
 cd $MANAGE
 if [[ "$TEAMNAME" == relval* || "$TEAMNAME" == *testbed* ]]; then
   echo "Adding only T1 and T2 sites to resource-control..."
-  ./manage execute-agent wmagent-resource-control --add-T1s --plugin=CondorPlugin --pending-slots=50 --running-slots=50
-  ./manage execute-agent wmagent-resource-control --add-T2s --plugin=CondorPlugin --pending-slots=50 --running-slots=50
+  ./manage execute-agent wmagent-resource-control --add-T1s --plugin=CondorPlugin --pending-slots=50 --running-slots=50 --down
+  ./manage execute-agent wmagent-resource-control --add-T2s --plugin=CondorPlugin --pending-slots=50 --running-slots=50 --down
 else
   echo "Adding ALL sites to resource-control..."
-  ./manage execute-agent wmagent-resource-control --add-all-sites --plugin=CondorPlugin --pending-slots=50 --running-slots=50
+  ./manage execute-agent wmagent-resource-control --add-all-sites --plugin=CondorPlugin --pending-slots=50 --running-slots=50 --down
 fi
 echo "Done!" && echo
 

--- a/bin/wmagent-resource-control
+++ b/bin/wmagent-resource-control
@@ -123,18 +123,18 @@ def getCMSSiteInfo(pattern):
     return nameSEMapping
 
 def addSites(resourceControl, allSites, ceName, plugin, pendingSlots, runningSlots,
-             tier0Option = False, cmsName = None):
+             tier0Option = False, cmsName = None, state=None):
     """
     _addSites_
 
     Add the given sites to resource control and add tasks as well.
     """
     if pendingSlots is None:
-        pendingSlots = 10
+        pendingSlots = 25
     else:
         pendingSlots = pendingSlots
     if runningSlots is None:
-        runningSlots = 10
+        runningSlots = 25
     else:
         runningSlots = runningSlots
 
@@ -145,6 +145,10 @@ def addSites(resourceControl, allSites, ceName, plugin, pendingSlots, runningSlo
         tasks = getTaskTypes(tier0Option)
         for task in tasks:
             updateThresholdInfo(resourceControl, siteName, task, runningSlots, pendingSlots)
+
+    if state:
+        for siteName in allSites.keys():
+            setSiteState(resourceControl, siteName, state)
 
     return
 
@@ -318,15 +322,15 @@ else:
     elif options.addT1s == True:
         t1Sites = getCMSSiteInfo("T1*")
         addSites(myResourceControl, t1Sites, options.ceName, options.plugin,
-                 options.pendingSlots, options.runningSlots)
+                 options.pendingSlots, options.runningSlots, state=options.state)
     elif options.addT2s == True:
         t2Sites = getCMSSiteInfo("T2*")
         addSites(myResourceControl, t2Sites, options.ceName, options.plugin,
-                 options.pendingSlots, options.runningSlots)
+                 options.pendingSlots, options.runningSlots, state=options.state)
     elif options.addAllSites == True:
         allSites = getCMSSiteInfo("*")
         addSites(myResourceControl, allSites, options.ceName, options.plugin,
-                 options.pendingSlots, options.runningSlots)
+                 options.pendingSlots, options.runningSlots, state=options.state)
     elif options.siteName is None:
         print "You must specify a site name."
         myOptParser.print_help()


### PR DESCRIPTION
Ops wants to start with sites in Down state and then rely on SSB to switch them to Normal.
This way we can keep onlySSB=False, such that it does not shutdown sites if SSB gets in trouble.

Tested in my VM. @ticoann I'll check and create patches missing for 1.0.8 branch and then we go for a new tag
