### PR TITLE
fix jquery.couch.js in firefox

### DIFF
--- a/src/couchapps/couchskel/vendor/couchapp/_attachments/jquery.couch.js
+++ b/src/couchapps/couchskel/vendor/couchapp/_attachments/jquery.couch.js
@@ -78,7 +78,7 @@
           } else if (options.error) {
             options.error(req.status, resp.error, resp.reason);
           } else {
-            alert("An error occurred getting session info: " + resp.reason);
+            throw "An error occurred getting session info: " + resp.reason;
           }
         }
       });
@@ -104,7 +104,7 @@
 
     prepareUserDoc: function(user_doc, new_password) {
       if (typeof hex_sha1 == "undefined") {
-        alert("creating a user doc requires sha1.js to be loaded in the page");
+        throw "creating a user doc requires sha1.js to be loaded in the page";
         return;
       }
       var user_prefix = "org.couchdb.user:";
@@ -136,7 +136,7 @@
           } else if (options.error) {
             options.error(req.status, resp.error, resp.reason);
           } else {
-            alert("An error occurred logging in: " + resp.reason);
+            throw "An error occurred logging in: " + resp.reason;
           }
         }
       });
@@ -156,7 +156,7 @@
           } else if (options.error) {
             options.error(req.status, resp.error, resp.reason);
           } else {
-            alert("An error occurred logging out: " + resp.reason);
+            throw "An error occurred logging out: " + resp.reason;
           }
         }
       });
@@ -169,7 +169,7 @@
         if (doc._id && doc._rev && rawDocs[doc._id] && rawDocs[doc._id].rev == doc._rev) {
           // todo: can we use commonjs require here?
           if (typeof Base64 == "undefined") {
-            alert("please include /_utils/script/base64.js in the page for base64 support");
+            throw "please include /_utils/script/base64.js in the page for base64 support";
             return false;
           } else {
             doc._attachments = doc._attachments || {};
@@ -344,7 +344,7 @@
               }
             });
           } else {
-            alert("Please provide an eachApp function for allApps()");
+           	throw "Please provide an eachApp function for allApps()";
           }
         },
         openDoc: function(docId, options, ajaxOptions) {
@@ -412,7 +412,7 @@
               } else if (options.error) {
                 options.error(req.status, resp.error, resp.reason);
               } else {
-                alert("The document could not be saved: " + resp.reason);
+               	throw "The document could not be saved: " + resp.reason;
               }
             }
           });
@@ -465,7 +465,7 @@
               } else if (options.error) {
                 options.error(req.status, resp.error, resp.reason);
               } else {
-                alert("The document could not be copied: " + resp.reason);
+                throw "The document could not be copied: " + resp.reason;
               }
             }
           });
@@ -655,7 +655,7 @@
           if (options.error) {
             options.error(req.status, req, e);
           } else {
-            alert(errorMessage + ": " + e);
+            throw errorMessage + ": " + e;
           }
           return;
         }
@@ -668,7 +668,7 @@
         } else if (options.error) {
           options.error(req.status, resp && resp.error || errorMessage, resp && resp.reason || "no response");
         } else {
-          alert(errorMessage + ": " + resp.reason);
+          throw errorMessage + ": " + (resp && resp.reason || "no response");
         }
       }
     }, obj), ajaxOptions));


### PR DESCRIPTION
not sure why it happens only in firefox in testbed. in my vm it worked fine. 
The problem was some times resp value gets null after the call.
If I turn on the debugger, it didn't happen either. I have no idea how this happens but it happens in firefox.
This patch should at least stop sending the alert in firefox but only can be test in testbed.

In the code, instead popping the alert message it will throw the errors.
