### PR TITLE
srmcp requires to create directory before copy. Fixes #6149

### DIFF
--- a/src/python/WMCore/Storage/Backends/SRMV2Impl.py
+++ b/src/python/WMCore/Storage/Backends/SRMV2Impl.py
@@ -55,7 +55,6 @@ class SRMV2Impl(StageOutImpl):
 
         """
         targetdir = os.path.dirname(targetPFN)
-
         if self.stageIn:
             # stage in to local directory - should exist but you never know
             if not os.path.exists(targetdir):
@@ -122,6 +121,7 @@ class SRMV2Impl(StageOutImpl):
         Build an srmcp command
 
         """
+        self.createOutputDirectory(targetPFN)
         result = "#!/bin/sh\n"
         result += "REPORT_FILE=`pwd`/srm.report.$$\n"
         result += "srmcp -2 -report=$REPORT_FILE -retry_num=0"


### PR DESCRIPTION
tested with pdb and copied site-local-config of caltech. So seems is never calling this function, so now before copying file it will try to check if all needed directories exists.

Test code:

```
touch /tmp/justas.txt
voms-proxy-init -voms cms

python >>
import os
import WMCore.Storage.StageOutMgr as StageOutMgr
from WMCore.Storage.Registry import retrieveStageOutImpl



local_stageout_mgr = StageOutMgr.StageOutMgr()
impl = retrieveStageOutImpl("srmv2")
local_stageout_mgr.numberOfRetries = 1
local_stageout_mgr.retryPauseTime = 1

file_for_transfer = {'LFN': '/tmp/justas.txt', 'PFN': '/store/temp/user/jbalcas/justas.txt'}
local_stageout_mgr(file_for_transfer)
```
