### PR TITLE
Fix 792 800

### DIFF
--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/LumiBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/LumiBased_t.py
@@ -17,13 +17,13 @@ from WMCore.WMBS.Job import Job
 from WMCore.WMBS.Subscription import Subscription
 from WMCore.WMBS.Workflow import Workflow
 from WMCore.DataStructs.Run import Run
-
 from WMCore.DAOFactory import DAOFactory
 from WMCore.JobSplitting.SplitterFactory import SplitterFactory
 from WMCore.Services.UUID import makeUUID
 from WMQuality.TestInitCouchApp import TestInitCouchApp as TestInit
 from WMCore.ACDC.DataCollectionService import DataCollectionService
 from WMCore.WMSpec.WMWorkload import newWorkload
+
 
 def getJob(workload):
     """
@@ -38,6 +38,7 @@ def getJob(workload):
     job["owner"] = "evansde77"
     job["group"] = "DMWM"
     return job
+
 
 class LumiBasedTest(unittest.TestCase):
     """
@@ -58,26 +59,22 @@ class LumiBasedTest(unittest.TestCase):
         self.testInit.setLogging()
         self.testInit.setDatabaseConnection()
         # self.testInit.clearDatabase(modules = ['WMCore.WMBS'])
-        self.testInit.setSchema(customModules = ["WMCore.WMBS"],
-                                useDefault = False)
+        self.testInit.setSchema(customModules=["WMCore.WMBS"], useDefault=False)
         self.testInit.setupCouch("lumi_t", "GroupUser", "ACDC")
 
         myThread = threading.currentThread()
-        daofactory = DAOFactory(package = "WMCore.WMBS",
-                                logger = myThread.logger,
-                                dbinterface = myThread.dbi)
+        daofactory = DAOFactory(package="WMCore.WMBS", logger=myThread.logger, dbinterface=myThread.dbi)
 
-        locationAction = daofactory(classname = "Locations.New")
-        locationAction.execute(siteName = 's1', seName = "somese.cern.ch")
-        locationAction.execute(siteName = 's2', seName = "otherse.cern.ch")
+        locationAction = daofactory(classname="Locations.New")
+        locationAction.execute(siteName='s1', seName="somese.cern.ch")
+        locationAction.execute(siteName='s2', seName="otherse.cern.ch")
 
-        self.testWorkflow = Workflow(spec = "spec.xml", owner = "mnorman",
-                                     name = "wf001", task = "Test")
+        self.testWorkflow = Workflow(spec="spec.xml", owner="mnorman", name="wf001", task="Test")
         self.testWorkflow.create()
 
-        self.performanceParams = {'timePerEvent' : 12,
-                                  'memoryRequirement' : 2300,
-                                  'sizePerEvent' : 400}
+        self.performanceParams = {'timePerEvent': 12,
+                                  'memoryRequirement': 2300,
+                                  'sizePerEvent': 400}
 
         return
 
@@ -90,8 +87,7 @@ class LumiBasedTest(unittest.TestCase):
         self.testInit.tearDownCouch()
         return
 
-
-    def createSubscription(self, nFiles, lumisPerFile, twoSites = False, rand = False):
+    def createSubscription(self, nFiles, lumisPerFile, twoSites=False, rand=False):
         """
         _createSubscription_
 
@@ -100,14 +96,14 @@ class LumiBasedTest(unittest.TestCase):
 
         baseName = makeUUID()
 
-        testFileset = Fileset(name = baseName)
+        testFileset = Fileset(name=baseName)
         testFileset.create()
-        parentFile = File('%s_parent' % (baseName), size = 1000, events = 100,
-                          locations = set(["somese.cern.ch"]))
+        parentFile = File('%s_parent' % baseName, size=1000, events=100,
+                          locations=set(["somese.cern.ch"]))
         parentFile.create()
         for i in range(nFiles):
-            newFile = File(lfn = '%s_%i' % (baseName, i), size = 1000,
-                           events = 100, locations = "somese.cern.ch")
+            newFile = File(lfn='%s_%i' % (baseName, i), size=1000,
+                           events=100, locations="somese.cern.ch")
             lumis = []
             for lumi in range(lumisPerFile):
                 if rand:
@@ -120,8 +116,8 @@ class LumiBasedTest(unittest.TestCase):
             testFileset.addFile(newFile)
         if twoSites:
             for i in range(nFiles):
-                newFile = File(lfn = '%s_%i_2' % (baseName, i), size = 1000,
-                               events = 100, locations = "otherse.cern.ch")
+                newFile = File(lfn='%s_%i_2' % (baseName, i), size=1000,
+                               events=100, locations="otherse.cern.ch")
                 lumis = []
                 for lumi in range(lumisPerFile):
                     if rand:
@@ -134,17 +130,11 @@ class LumiBasedTest(unittest.TestCase):
                 testFileset.addFile(newFile)
         testFileset.commit()
 
-
-        testSubscription = Subscription(fileset = testFileset,
-                                         workflow = self.testWorkflow,
-                                         split_algo = "LumiBased",
-                                         type = "Processing")
+        testSubscription = Subscription(fileset=testFileset, workflow=self.testWorkflow,
+                                        split_algo="LumiBased", type="Processing")
         testSubscription.create()
 
         return testSubscription
-
-
-
 
     def testA_FileSplitting(self):
         """
@@ -154,14 +144,10 @@ class LumiBasedTest(unittest.TestCase):
         """
         splitter = SplitterFactory()
 
-        oneSetSubscription = self.createSubscription(nFiles = 10, lumisPerFile = 1)
-        jobFactory = splitter(package = "WMCore.WMBS",
-                              subscription = oneSetSubscription)
+        oneSetSubscription = self.createSubscription(nFiles=10, lumisPerFile=1)
+        jobFactory = splitter(package="WMCore.WMBS", subscription=oneSetSubscription)
 
-
-        jobGroups = jobFactory(lumis_per_job = 3,
-                               halt_job_on_file_boundaries = True,
-                               performance = self.performanceParams)
+        jobGroups = jobFactory(lumis_per_job=3, halt_job_on_file_boundaries=True, performance=self.performanceParams)
         self.assertEqual(len(jobGroups), 1)
         self.assertEqual(len(jobGroups[0].jobs), 10)
         for job in jobGroups[0].jobs:
@@ -170,12 +156,9 @@ class LumiBasedTest(unittest.TestCase):
             self.assertEqual(job['estimatedDiskUsage'], 100 * 400)
             self.assertEqual(job['estimatedMemoryUsage'], 2300)
 
-        twoLumiFiles = self.createSubscription(nFiles = 5, lumisPerFile = 2)
-        jobFactory = splitter(package = "WMCore.WMBS",
-                              subscription = twoLumiFiles)
-        jobGroups = jobFactory(lumis_per_job = 1,
-                               halt_job_on_file_boundaries = True,
-                               performance = self.performanceParams)
+        twoLumiFiles = self.createSubscription(nFiles=5, lumisPerFile=2)
+        jobFactory = splitter(package="WMCore.WMBS", subscription=twoLumiFiles)
+        jobGroups = jobFactory(lumis_per_job=1, halt_job_on_file_boundaries=True, performance=self.performanceParams)
         self.assertEqual(len(jobGroups), 1)
         self.assertEqual(len(jobGroups[0].jobs), 10)
         for job in jobGroups[0].jobs:
@@ -184,28 +167,23 @@ class LumiBasedTest(unittest.TestCase):
             self.assertEqual(job['estimatedDiskUsage'], 50 * 400)
             self.assertEqual(job['estimatedMemoryUsage'], 2300)
 
-
-        wholeLumiFiles = self.createSubscription(nFiles = 5, lumisPerFile = 3)
-        jobFactory = splitter(package = "WMCore.WMBS",
-                              subscription = wholeLumiFiles)
-        jobGroups = jobFactory(lumis_per_job = 2,
-                               halt_job_on_file_boundaries = True,
-                               performance = self.performanceParams)
+        wholeLumiFiles = self.createSubscription(nFiles=5, lumisPerFile=3)
+        jobFactory = splitter(package="WMCore.WMBS", subscription=wholeLumiFiles)
+        jobGroups = jobFactory(lumis_per_job=2, halt_job_on_file_boundaries=True, performance=self.performanceParams)
         self.assertEqual(len(jobGroups), 1)
         # 10 because we split on run boundaries
         self.assertEqual(len(jobGroups[0].jobs), 10)
         jobList = jobGroups[0].jobs
-        for idx, job in enumerate(jobList, start = 1):
+        for idx, job in enumerate(jobList, start=1):
             # Have should have one file, half two
             self.assertEqual(len(job['input_files']), 1)
             if idx % 2 == 0:
-                self.assertEqual(job['estimatedJobTime'], (1.0 * round(100/3)) * 12)
-                self.assertEqual(job['estimatedDiskUsage'], (1.0 * round(100/3)) * 400)
+                self.assertEqual(job['estimatedJobTime'], (1.0 * round(100 / 3)) * 12)
+                self.assertEqual(job['estimatedDiskUsage'], (1.0 * round(100 / 3)) * 400)
             else:
-                self.assertEqual(job['estimatedJobTime'], (2.0 * round(100/3)) * 12)
-                self.assertEqual(job['estimatedDiskUsage'], (2.0 * round(100/3)) * 400)
+                self.assertEqual(job['estimatedJobTime'], (2.0 * round(100 / 3)) * 12)
+                self.assertEqual(job['estimatedDiskUsage'], (2.0 * round(100 / 3)) * 400)
             self.assertEqual(job['estimatedMemoryUsage'], 2300)
-
 
         mask0 = jobList[0]['mask'].getRunAndLumis()
         self.assertEqual(mask0, {0: [[0, 1]]})
@@ -216,17 +194,17 @@ class LumiBasedTest(unittest.TestCase):
         mask3 = jobList[3]['mask'].getRunAndLumis()
         self.assertEqual(mask3, {1: [[102, 102]]})
 
-        j0 = Job(id = jobList[0]['id'])
+        j0 = Job(id=jobList[0]['id'])
         j0.loadData()
         self.assertEqual(j0['mask'].getRunAndLumis(), {0: [[0, 1]]})
 
         # Do it with multiple sites
-        twoSiteSubscription = self.createSubscription(nFiles = 5, lumisPerFile = 2, twoSites = True)
-        jobFactory = splitter(package = "WMCore.WMBS",
-                              subscription = twoSiteSubscription)
-        jobGroups = jobFactory(lumis_per_job = 1,
-                               halt_job_on_file_boundaries = True,
-                               performance = self.performanceParams)
+        twoSiteSubscription = self.createSubscription(nFiles=5, lumisPerFile=2, twoSites=True)
+        jobFactory = splitter(package="WMCore.WMBS",
+                              subscription=twoSiteSubscription)
+        jobGroups = jobFactory(lumis_per_job=1,
+                               halt_job_on_file_boundaries=True,
+                               performance=self.performanceParams)
         self.assertEqual(len(jobGroups), 2)
         self.assertEqual(len(jobGroups[0].jobs), 10)
         for job in jobGroups[0].jobs:
@@ -243,14 +221,14 @@ class LumiBasedTest(unittest.TestCase):
         cases that might be required.
         """
         splitter = SplitterFactory()
-        testSubscription = self.createSubscription(nFiles = 5, lumisPerFile = 5, twoSites = False)
-        jobFactory = splitter(package = "WMCore.WMBS",
-                              subscription = testSubscription)
+        testSubscription = self.createSubscription(nFiles=5, lumisPerFile=5, twoSites=False)
+        jobFactory = splitter(package="WMCore.WMBS",
+                              subscription=testSubscription)
 
-        jobGroups = jobFactory(lumis_per_job = 3,
-                               halt_job_on_file_boundaries = False,
-                               splitOnRun = False,
-                               performance = self.performanceParams)
+        jobGroups = jobFactory(lumis_per_job=3,
+                               halt_job_on_file_boundaries=False,
+                               splitOnRun=False,
+                               performance=self.performanceParams)
 
         self.assertEqual(len(jobGroups), 1)
         jobs = jobGroups[0].jobs
@@ -269,18 +247,18 @@ class LumiBasedTest(unittest.TestCase):
 
 
         # And it should still be the same when you load it out of the database
-        j1 = Job(id = jobs[1]['id'])
+        j1 = Job(id=jobs[1]['id'])
         j1.loadData()
         self.assertEqual(j1['mask'].getRunAndLumis(), {0: [[3, 4]], 1: [[100, 100]]})
 
         # Assert that this works differently with file splitting on and run splitting on
-        testSubscription = self.createSubscription(nFiles = 5, lumisPerFile = 5, twoSites = False)
-        jobFactory = splitter(package = "WMCore.WMBS",
-                              subscription = testSubscription)
-        jobGroups = jobFactory(lumis_per_job = 3,
-                               halt_job_on_file_boundaries = True,
-                               splitOnRun = True,
-                               performance = self.performanceParams)
+        testSubscription = self.createSubscription(nFiles=5, lumisPerFile=5, twoSites=False)
+        jobFactory = splitter(package="WMCore.WMBS",
+                              subscription=testSubscription)
+        jobGroups = jobFactory(lumis_per_job=3,
+                               halt_job_on_file_boundaries=True,
+                               splitOnRun=True,
+                               performance=self.performanceParams)
         self.assertEqual(len(jobGroups), 1)
         jobs = jobGroups[0].jobs
         self.assertEqual(len(jobs), 10)
@@ -290,21 +268,20 @@ class LumiBasedTest(unittest.TestCase):
         self.assertEqual(jobs[0]['mask'].getRunAndLumis(), {0: [[0, 2]]})
         self.assertEqual(jobs[1]['mask'].getRunAndLumis(), {0: [[3, 4]]})
 
-
-        testSubscription = self.createSubscription(nFiles = 5, lumisPerFile = 4, twoSites = False)
-        jobFactory = splitter(package = "WMCore.WMBS",
-                              subscription = testSubscription)
-        jobGroups = jobFactory(lumis_per_job = 10,
-                               halt_job_on_file_boundaries = False,
-                               splitOnRun = False,
-                               performance = self.performanceParams)
+        testSubscription = self.createSubscription(nFiles=5, lumisPerFile=4, twoSites=False)
+        jobFactory = splitter(package="WMCore.WMBS",
+                              subscription=testSubscription)
+        jobGroups = jobFactory(lumis_per_job=10,
+                               halt_job_on_file_boundaries=False,
+                               splitOnRun=False,
+                               performance=self.performanceParams)
         self.assertEqual(len(jobGroups), 1)
         jobs = jobGroups[0].jobs
         self.assertEqual(len(jobs), 2)
         self.assertEqual(jobs[0]['mask']['runAndLumis'], {0: [[0, 3]], 1: [[100, 103]], 2: [[200, 201]]})
         self.assertEqual(jobs[1]['mask']['runAndLumis'], {2: [[202, 203]], 3: [[300, 303]], 4: [[400, 403]]})
 
-        j = Job(id = jobs[0]['id'])
+        j = Job(id=jobs[0]['id'])
         j.loadData()
         self.assertEqual(len(j['input_files']), 3)
         for f in j['input_files']:
@@ -320,28 +297,27 @@ class LumiBasedTest(unittest.TestCase):
         workload = newWorkload("ACDCTest")
         reco = workload.newTask("reco")
         skim1 = reco.addTask("skim1")
-        workload.setOwnerDetails(name = "evansde77", group = "DMWM")
+        workload.setOwnerDetails(name="evansde77", group="DMWM")
 
         # first task uses the input dataset
-        reco.addInputDataset(primary = "PRIMARY", processed = "processed-v1", tier = "TIER1")
+        reco.addInputDataset(primary="PRIMARY", processed="processed-v1", tier="TIER1")
         cmsRunReco = reco.makeStep("cmsRun1")
         cmsRunReco.setStepType("CMSSW")
         reco.applyTemplates()
         cmsRunRecoHelper = cmsRunReco.getTypeHelper()
         cmsRunRecoHelper.addOutputModule("outputRECO",
-                                        primaryDataset = "PRIMARY",
-                                        processedDataset = "processed-v2",
-                                        dataTier = "TIER2",
-                                        lfnBase = "/store/dunkindonuts",
-                                        mergedLFNBase = "/store/kfc")
+                                         primaryDataset="PRIMARY",
+                                         processedDataset="processed-v2",
+                                         dataTier="TIER2",
+                                         lfnBase="/store/dunkindonuts",
+                                         mergedLFNBase="/store/kfc")
         # second step uses an input reference
         cmsRunSkim = skim1.makeStep("cmsRun2")
         cmsRunSkim.setStepType("CMSSW")
         skim1.applyTemplates()
-        skim1.setInputReference(cmsRunReco, outputModule = "outputRECO")
+        skim1.setInputReference(cmsRunReco, outputModule="outputRECO")
 
         return workload
-
 
     def testC_ACDCTest(self):
         """
@@ -351,61 +327,61 @@ class LumiBasedTest(unittest.TestCase):
         and process it correctly.
         """
         workload = self.createTestWorkload()
-        dcs = DataCollectionService(url = self.testInit.couchUrl, database = self.testInit.couchDbName)
+        dcs = DataCollectionService(url=self.testInit.couchUrl, database=self.testInit.couchDbName)
 
-        testFileA = File(lfn = makeUUID(), size = 1024, events = 1024, locations = "somese.cern.ch")
+        testFileA = File(lfn=makeUUID(), size=1024, events=1024, locations="somese.cern.ch")
         testFileA.addRun(Run(1, 1, 2))
         testFileA.create()
-        testFileB = File(lfn = makeUUID(), size = 1024, events = 1024, locations = "somese.cern.ch")
+        testFileB = File(lfn=makeUUID(), size=1024, events=1024, locations="somese.cern.ch")
         testFileB.addRun(Run(1, 3))
         testFileB.create()
         testJobA = getJob(workload)
         testJobA.addFile(testFileA)
         testJobA.addFile(testFileB)
 
-        testFileC = File(lfn = makeUUID(), size = 1024, events = 1024, locations = "somese.cern.ch")
+        testFileC = File(lfn=makeUUID(), size=1024, events=1024, locations="somese.cern.ch")
         testFileC.addRun(Run(1, 4, 6))
         testFileC.create()
         testJobB = getJob(workload)
         testJobB.addFile(testFileC)
 
-        testFileD = File(lfn = makeUUID(), size = 1024, events = 1024, locations = "somese.cern.ch")
+        testFileD = File(lfn=makeUUID(), size=1024, events=1024, locations="somese.cern.ch")
         testFileD.addRun(Run(1, 7))
         testFileD.create()
         testJobC = getJob(workload)
         testJobC.addFile(testFileD)
 
-        testFileE = File(lfn = makeUUID(), size = 1024, events = 1024, locations = "somese.cern.ch")
+        testFileE = File(lfn=makeUUID(), size=1024, events=1024, locations="somese.cern.ch")
         testFileE.addRun(Run(1, 11, 12))
         testFileE.create()
         testJobD = getJob(workload)
         testJobD.addFile(testFileE)
 
-        testFileF = File(lfn = makeUUID(), size = 1024, events = 1024, locations = "somese.cern.ch")
+        testFileF = File(lfn=makeUUID(), size=1024, events=1024, locations="somese.cern.ch")
         testFileF.addRun(Run(2, 5, 6, 7))
         testFileF.create()
         testJobE = getJob(workload)
         testJobE.addFile(testFileF)
 
-        testFileG = File(lfn = makeUUID(), size = 1024, events = 1024, locations = "somese.cern.ch")
+        testFileG = File(lfn=makeUUID(), size=1024, events=1024, locations="somese.cern.ch")
         testFileG.addRun(Run(2, 10, 11, 12))
         testFileG.create()
         testJobF = getJob(workload)
         testJobF.addFile(testFileG)
 
-        testFileH = File(lfn = makeUUID(), size = 1024, events = 1024, locations = "somese.cern.ch")
+        testFileH = File(lfn=makeUUID(), size=1024, events=1024, locations="somese.cern.ch")
         testFileH.addRun(Run(2, 15))
         testFileH.create()
         testJobG = getJob(workload)
         testJobG.addFile(testFileH)
 
-        testFileI = File(lfn = makeUUID(), size = 1024, events = 1024, locations = "somese.cern.ch")
+        testFileI = File(lfn=makeUUID(), size=1024, events=1024, locations="somese.cern.ch")
         testFileI.addRun(Run(3, 20))
         testFileI.create()
         testJobH = getJob(workload)
         testJobH.addFile(testFileI)
 
-        testFileJ = File(lfn = makeUUID(), size = 1024, events = 1024, locations = "somese.cern.ch")
+        testFileJ = File(lfn=makeUUID(), size=1024, events=1024, locations="somese.cern.ch")
         testFileJ.addRun(Run(1, 9))
         testFileJ.create()
         testJobI = getJob(workload)
@@ -418,7 +394,7 @@ class LumiBasedTest(unittest.TestCase):
 
         baseName = makeUUID()
 
-        testFileset = Fileset(name = baseName)
+        testFileset = Fileset(name=baseName)
         testFileset.create()
         testFileset.addFile(testFileA)
         testFileset.addFile(testFileB)
@@ -432,33 +408,31 @@ class LumiBasedTest(unittest.TestCase):
         testFileset.addFile(testFileJ)
         testFileset.commit()
 
-        testSubscription = Subscription(fileset = testFileset,
-                                         workflow = self.testWorkflow,
-                                         split_algo = "LumiBased",
-                                         type = "Processing")
+        testSubscription = Subscription(fileset=testFileset,
+                                        workflow=self.testWorkflow,
+                                        split_algo="LumiBased",
+                                        type="Processing")
         testSubscription.create()
 
         splitter = SplitterFactory()
-        jobFactory = splitter(package = "WMCore.WMBS",
-                              subscription = testSubscription)
+        jobFactory = splitter(package="WMCore.WMBS",
+                              subscription=testSubscription)
 
-        jobGroups = jobFactory(lumis_per_job = 100,
-                               halt_job_on_file_boundaries = False,
-                               splitOnRun = True,
-                               collectionName = workload.name(),
-                               filesetName = workload.getTask("reco").getPathName(),
-                               owner = "evansde77",
-                               group = "DMWM",
-                               couchURL = self.testInit.couchUrl,
-                               couchDB = self.testInit.couchDbName,
-                               performance = self.performanceParams)
-
+        jobGroups = jobFactory(lumis_per_job=100,
+                               halt_job_on_file_boundaries=False,
+                               splitOnRun=True,
+                               collectionName=workload.name(),
+                               filesetName=workload.getTask("reco").getPathName(),
+                               owner="evansde77",
+                               group="DMWM",
+                               couchURL=self.testInit.couchUrl,
+                               couchDB=self.testInit.couchDbName,
+                               performance=self.performanceParams)
 
         self.assertEqual(jobGroups[0].jobs[0]['mask'].getRunAndLumis(), {1: [[1, 2], [3, 3], [11, 12]]})
         self.assertEqual(jobGroups[0].jobs[1]['mask'].getRunAndLumis(), {3: [[20, 20]]})
 
         return
-
 
     def testD_NonContinuousLumis(self):
         """
@@ -467,15 +441,14 @@ class LumiBasedTest(unittest.TestCase):
         Test and see if LumiBased can work when the lumis are non continuous
         """
 
-
         baseName = makeUUID()
         nFiles = 10
 
-        testFileset = Fileset(name = baseName)
+        testFileset = Fileset(name=baseName)
         testFileset.create()
         for i in range(nFiles):
-            newFile = File(lfn = '%s_%i' % (baseName, i), size = 1000,
-                           events = 100, locations = "somese.cern.ch")
+            newFile = File(lfn='%s_%i' % (baseName, i), size=1000,
+                           events=100, locations="somese.cern.ch")
             # Set to two non-continuous lumi numbers
             lumis = [100 + i, 200 + i]
             newFile.addRun(Run(i, *lumis))
@@ -484,21 +457,20 @@ class LumiBasedTest(unittest.TestCase):
 
         testFileset.commit()
 
-
-        testSubscription = Subscription(fileset = testFileset,
-                                         workflow = self.testWorkflow,
-                                         split_algo = "LumiBased",
-                                         type = "Processing")
+        testSubscription = Subscription(fileset=testFileset,
+                                        workflow=self.testWorkflow,
+                                        split_algo="LumiBased",
+                                        type="Processing")
         testSubscription.create()
 
         splitter = SplitterFactory()
-        jobFactory = splitter(package = "WMCore.WMBS",
-                              subscription = testSubscription)
+        jobFactory = splitter(package="WMCore.WMBS",
+                              subscription=testSubscription)
 
-        jobGroups = jobFactory(lumis_per_job = 2,
-                               halt_job_on_file_boundaries = False,
-                               splitOnRun = False,
-                               performance = self.performanceParams)
+        jobGroups = jobFactory(lumis_per_job=2,
+                               halt_job_on_file_boundaries=False,
+                               splitOnRun=False,
+                               performance=self.performanceParams)
 
         self.assertEqual(len(jobGroups), 1)
         jobs = jobGroups[0].jobs
@@ -517,9 +489,7 @@ class LumiBasedTest(unittest.TestCase):
             self.assertEqual(j['estimatedDiskUsage'], 100 * 400)
             self.assertEqual(j['estimatedMemoryUsage'], 2300)
 
-
         return
-
 
     def testE_getParents(self):
         """
@@ -528,17 +498,16 @@ class LumiBasedTest(unittest.TestCase):
         Test the TwoFileBased version of this code
         """
 
-
         splitter = SplitterFactory()
 
-        oneSetSubscription = self.createSubscription(nFiles = 10, lumisPerFile = 1)
-        jobFactory = splitter(package = "WMCore.WMBS",
-                              subscription = oneSetSubscription)
+        oneSetSubscription = self.createSubscription(nFiles=10, lumisPerFile=1)
+        jobFactory = splitter(package="WMCore.WMBS",
+                              subscription=oneSetSubscription)
 
-        jobGroups = jobFactory(lumis_per_job = 3,
-                               split_files_between_job = True,
-                               include_parents = True,
-                               performance = self.performanceParams)
+        jobGroups = jobFactory(lumis_per_job=3,
+                               split_files_between_job=True,
+                               include_parents=True,
+                               performance=self.performanceParams)
         self.assertEqual(len(jobGroups), 1)
         self.assertEqual(len(jobGroups[0].jobs), 10)
         for job in jobGroups[0].jobs:
@@ -558,17 +527,16 @@ class LumiBasedTest(unittest.TestCase):
         the GoodRunlist where it would make sense.
         """
 
-
         splitter = SplitterFactory()
 
-        oneSetSubscription = self.createSubscription(nFiles = 10, lumisPerFile = 1)
-        jobFactory = splitter(package = "WMCore.WMBS",
-                              subscription = oneSetSubscription)
+        oneSetSubscription = self.createSubscription(nFiles=10, lumisPerFile=1)
+        jobFactory = splitter(package="WMCore.WMBS",
+                              subscription=oneSetSubscription)
 
-        jobGroups = jobFactory(lumis_per_job = 10,
-                               split_files_between_job = True,
-                               runWhitelist = [1],
-                               performance = self.performanceParams)
+        jobGroups = jobFactory(lumis_per_job=10,
+                               split_files_between_job=True,
+                               runWhitelist=[1],
+                               performance=self.performanceParams)
 
         self.assertEqual(len(jobGroups), 1)
         self.assertEqual(len(jobGroups[0].jobs), 1)
@@ -576,6 +544,7 @@ class LumiBasedTest(unittest.TestCase):
         self.assertEqual(len(jobGroups[0].jobs[0]['input_files'][0]['runs']), 1)
         self.assertEqual(jobGroups[0].jobs[0]['input_files'][0]['runs'][0].run, 1)
         return
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/LumiBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/LumiBased_t.py
@@ -5,6 +5,8 @@ _LumiBased_t
 Test lumi based splitting.
 """
 
+from __future__ import division
+
 import threading
 import unittest
 import random
@@ -197,11 +199,11 @@ class LumiBasedTest(unittest.TestCase):
             # Have should have one file, half two
             self.assertEqual(len(job['input_files']), 1)
             if idx % 2 == 0:
-                self.assertEqual(job['estimatedJobTime'], (1.0 * 100 / 3) * 12)
-                self.assertEqual(job['estimatedDiskUsage'], (1.0 * 100 / 3) * 400)
+                self.assertEqual(job['estimatedJobTime'], (1.0 * round(100/3)) * 12)
+                self.assertEqual(job['estimatedDiskUsage'], (1.0 * round(100/3)) * 400)
             else:
-                self.assertEqual(job['estimatedJobTime'], (2.0 * 100 / 3) * 12)
-                self.assertEqual(job['estimatedDiskUsage'], (2.0 * 100 / 3) * 400)
+                self.assertEqual(job['estimatedJobTime'], (2.0 * round(100/3)) * 12)
+                self.assertEqual(job['estimatedDiskUsage'], (2.0 * round(100/3)) * 400)
             self.assertEqual(job['estimatedMemoryUsage'], 2300)
 
 


### PR DESCRIPTION
Fix one of the tests which is caused by rounding in LumiBased splitting. Maybe would have been better to fix the rounding of events/lumi, but in the real word it won't matter.

1st commit is actual changes, second is reformatting to PEP-8 (automatically for the most part with PyCharm)
