### PR TITLE
Move future statements to the top

### DIFF
--- a/src/python/WMCore/WorkQueue/Policy/Start/MonteCarlo.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/MonteCarlo.py
@@ -3,8 +3,6 @@
 WorkQueue splitting by block
 
 """
-__all__ = []
-
 from __future__ import division
 
 from WMCore.WorkQueue.Policy.Start.StartPolicyInterface import StartPolicyInterface
@@ -12,6 +10,9 @@ from WMCore.WorkQueue.WorkQueueExceptions import WorkQueueWMSpecError, WorkQueue
 from WMCore.DataStructs.Mask import Mask
 from copy import copy
 from math import ceil
+
+__all__ = []
+
 
 class MonteCarlo(StartPolicyInterface):
     """Split elements into blocks"""


### PR DESCRIPTION
This one slipped through (actually I was not aware of it) and are now bugging WorkQueue in testbed.
This is what pep-0236 says, basically:
In addition, all future_statments must appear near the top of the
    module.  The only lines that can appear before a future_statement are:
    + The module docstring (if any).
    + Comments.
    + Blank lines.
    + Other future_statements.
