### PR TITLE
Handle requests without prep_id

### DIFF
--- a/src/python/WMCore/WMDataMining/Utils.py
+++ b/src/python/WMCore/WMDataMining/Utils.py
@@ -145,7 +145,7 @@ def gatherWMDataMiningStats(wmstatsUrl, reqmgrUrl, wmMiningUrl,
                 log.error("Could not find any status from workflow: %s" % wf) # Should not happen but it does.
 
             # Remove a single  task_ from the start of PREP ID if it exists
-            if prep_id.startswith('task_'):
+            if prep_id and prep_id.startswith('task_'):
                 prep_id.replace('task_', '', 1)
 
             # Can be an empty list, full list, empty string, or non-empty string!


### PR DESCRIPTION
Diego G. reported a problem with WMDataMining in testbed. From the traceback, it seems to fail when a request does not have Prep_Id, it should fix that issue

@ericvaandering please review. I could not test it in my VM because it fails to generate a SSO cookie (?)
otherwise I'll wipe my VM in make a fresh installation this evening just to make sure there won't be another bug after this one.
