### PR TITLE
Query requests by state in clean acdc thread

### DIFF
--- a/src/python/WMCore/ReqMgr/CherryPyThreads/CouchDBCleanup.py
+++ b/src/python/WMCore/ReqMgr/CherryPyThreads/CouchDBCleanup.py
@@ -9,7 +9,10 @@ from WMCore.Services.RequestDB.RequestDBReader import RequestDBReader
 from WMCore.ReqMgr.CherryPyThreads.CherryPyPeriodicTask import CherryPyPeriodicTask
 
 class CouchDBCleanup(CherryPyPeriodicTask):
-
+    """
+    CherryPy thread to clean up ACDC docs where the original request
+    is in a final state (or announced).
+    """
     def __init__(self, rest, config):
 
         CherryPyPeriodicTask.__init__(self, config)
@@ -24,35 +27,33 @@ class CouchDBCleanup(CherryPyPeriodicTask):
         """
         gather active data statistics
         """
-        
+
         reqDB = RequestDBReader(config.reqmgrdb_url)
 
         from WMCore.ACDC.CouchService import CouchService
         baseURL, acdcDB = splitCouchServiceURL(config.acdc_url)
-        acdcService = CouchService(url = baseURL, database = acdcDB)
+        acdcService = CouchService(url=baseURL, database=acdcDB)
         originalRequests = acdcService.listCollectionNames()
-        
+
         if len(originalRequests) == 0:
             return 
+
+        deleteStates = ["rejected-archived", "aborted-archived", "normal-archived"]
+        results = reqDB.getRequestByStatus(deleteStates) 
+
         # filter requests
-        results = reqDB._getCouchView("byrequest", {"stale": True}, originalRequests)
-        # checkt he status of the requests [announced, rejected-archived, aborted-archived, normal-archived]
-        deleteStates = ["announced", "rejected-archived", "aborted-archived", "normal-archived"]
-        filteredRequests = []
-        for row in results["rows"]:
-            if row["value"][0] in deleteStates:
-                filteredRequests.append(row["key"])
-                
+        filteredRequests = list(set(originalRequests).intersection(results))
+
         total = 0
         for req in filteredRequests:
             try:
                 deleted = acdcService.removeFilesetsByCollectionName(req)
                 if deleted == None:
-                    self.logger.warning("request alread deleted %s" % req)
+                    self.logger.warning("request already deleted %s" % req)
                 else:
                     total += len(deleted)
                     self.logger.info("request %s deleted" % req)
             except:
-                self.logger.error("request deleted failed: will try again %s" % req)
-        self.logger.info("total %s requests deleted" % total)        
+                self.logger.error("fail to delete request: will try again %s" % req)
+        self.logger.info("total %s requests deleted" % total)
         return


### PR DESCRIPTION
Fixes the couchCleanup issue reported by Diego G. today (in testbed).
It was failing to get the couch view (I did not find the reason), however, I changed it to get requests by status (also removed 'announced' from the list, so we keep only final state).

@ticoann please review. I'll test it in my VM now.
