### PR TITLE
Use CMSSW python2.6 instead of the comp one

### DIFF
--- a/etc/submit.sh
+++ b/etc/submit.sh
@@ -5,38 +5,39 @@ touch Report.pkl
 # should be a bit nicer than before
 echo "WMAgent bootstrap : `date -u` : starting..."
 
-
 # validate arguments
-
-if [ -z "$1" ];then
+if [ -z "$1" ]
+then
     echo "WMAgent bootstrap : `date -u` : Error: A sandbox must be specified" >&2
     exit 1
 fi
-
-if [ -z "$2" ];then
+if [ -z "$2" ]
+then
     echo "WMAgent bootstrap : `date -u` : Error: An index must be specified" >&2
     exit 1
 fi
 
 # assign arguments
-
 SANDBOX=$1
 INDEX=$2
 echo "WMAgent bootstrap : `date -u` : arguments validated..."
 
 ### source the CMSSW stuff using either OSG or LCG style entry env. variables
-###    (incantations per oli's instructions)
-
-if [ -f "$VO_CMS_SW_DIR"/cmsset_default.sh ];then  #   LCG style --
+if [ -f "$VO_CMS_SW_DIR"/cmsset_default.sh ]
+then  #   LCG style --
     . $VO_CMS_SW_DIR/cmsset_default.sh
-elif [ -f "$OSG_APP"/cmssoft/cms/cmsset_default.sh ];then  #   OSG style --
+elif [ -f "$OSG_APP"/cmssoft/cms/cmsset_default.sh ]
+then  #   OSG style --
     . $OSG_APP/cmssoft/cms/cmsset_default.sh CMSSW_3_3_2
-elif [ -f "$CVMFS"/cms.cern.ch/cmsset_default.sh ];then
+elif [ -f "$CVMFS"/cms.cern.ch/cmsset_default.sh ]
+then
     . $CVMFS/cms.cern.ch/cmsset_default.sh
-elif [ -f /cvmfs/cms.cern.ch/cmsset_default.sh ];then
-    . /cvmfs/cms.cern.ch/cmsset_default.sh
+elif [ -f /cvmfs/cms.cern.ch/cmsset_default.sh ]
+then  # ok, lets call it CVMFS then
+    export CVMFS=/cvmfs/cms.cern.ch
+    . $CVMFS/cmsset_default.sh
 else
-    echo "WMAgent bootstrap : `date -u` : Error: OSG_APP, VO_CMS_SW_DIR, CVMFS environment variables were not set and /cvmfs is not present" >&2
+    echo "WMAgent bootstrap : `date -u` : Error: VO_CMS_SW_DIR, OSG_APP, CVMFS environment variables were not set and /cvmfs is not present" >&2
     echo "WMAgent bootstrap : `date -u` : Error: Because of this, we can't load CMSSW. Not good." >&2
     exit 2
 fi
@@ -45,12 +46,13 @@ echo "WMAgent bootstrap : `date -u` : WMAgent thinks it found the correct CMSSW 
 
 if [ -e "$VO_CMS_SW_DIR"/COMP/slc6_amd64_gcc481/external/python/2.6.8-comp9/etc/profile.d/init.sh ]
 then
-        . "$VO_CMS_SW_DIR"/COMP/slc6_amd64_gcc481/external/python/2.6.8-comp9/etc/profile.d/init.sh
-	export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:"$VO_CMS_SW_DIR"/COMP/slc6_amd64_gcc481/external/openssl/1.0.1p/lib:"$VO_CMS_SW_DIR"/COMP/slc6_amd64_gcc481/external/bz2lib/1.0.6/lib
+    . "$VO_CMS_SW_DIR"/COMP/slc6_amd64_gcc481/external/python/2.6.8-comp9/etc/profile.d/init.sh
 elif [ -e "$OSG_APP"/cmssoft/cms/COMP/slc6_amd64_gcc481/external/python/2.6.8-comp9/etc/profile.d/init.sh ]
 then
-	. "$OSG_APP"/cmssoft/cms/COMP/slc6_amd64_gcc481/external/python/2.6.8-comp9/etc/profile.d/init.sh
-	export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:"$OSG_APP"/cmssoft/cms/COMP/slc6_amd64_gcc481/external/openssl/1.0.1p/lib:"$OSG_APP"/cmssoft/cms/COMP/slc6_amd64_gcc481/external/bz2lib/1.0.6/lib
+    . "$OSG_APP"/cmssoft/cms/COMP/slc6_amd64_gcc481/external/python/2.6.8-comp9/etc/profile.d/init.sh
+elif [ -e "$CVMFS"/COMP/slc6_amd64_gcc481/external/python/2.6.8-comp9/etc/profile.d/init.sh ]
+then
+    . "$CVMFS"/COMP/slc6_amd64_gcc481/external/python/2.6.8-comp9/etc/profile.d/init.sh
 else
     echo "WMAgent bootstrap : `date -u` : Error: OSG_APP, VO_CMS_SW_DIR, CVMFS, /cvmfs/cms.cern.ch environment does not contain init.sh" >&2
     echo "WMAgent bootstrap : `date -u` : Error: Because of this, we can't load CMSSW. Not good." >&2
@@ -60,12 +62,12 @@ command -v python2.6 > /dev/null
 rc=$?
 if [[ $rc != 0 ]]
 then
-	echo "WMAgent bootstrap : `date -u` : Error: Python2.6 isn't available on this worker node." >&2
-	echo "WMAgent bootstrap : `date -u` : Error: WMCore/WMAgent REQUIRES python2.6" >&2
-	exit 3	
+    echo "WMAgent bootstrap : `date -u` : Error: Python2.6 isn't available on this worker node." >&2
+    echo "WMAgent bootstrap : `date -u` : Error: WMCore/WMAgent REQUIRES python2.6" >&2
+    exit 3	
 else
-	echo "WMAgent bootstrap : `date -u` : found python2.6 at.."
-	echo `which python2.6`
+    echo "WMAgent bootstrap : `date -u` : found python2.6 at.."
+    echo `which python2.6`
 fi
 
 # Should be ready to unpack and run this

--- a/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
@@ -170,7 +170,7 @@ class CMSSW(Executor):
                 stdin=subprocess.PIPE,
                 )
             # BADPYTHON
-            scriptProcess.stdin.write("export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$VO_CMS_SW_DIR/COMP/slc5_amd64_gcc434/external/openssl/0.9.7m/lib:$VO_CMS_SW_DIR/COMP/slc5_amd64_gcc434/external/bz2lib/1.0.5/lib\n")
+            scriptProcess.stdin.write("export LD_LIBRARY_PATH=$LD_LIBRARY_PATH\n")
             invokeCommand = "%s -m WMCore.WMRuntime.ScriptInvoke %s %s \n" % (
                 sys.executable,
                 stepModule,
@@ -197,7 +197,6 @@ class CMSSW(Executor):
             invokeCommand = self.step.runtime.invokeCommand if hasattr(self.step.runtime, 'invokeCommand') else\
                                 "%s -m WMCore.WMRuntime.ScriptInvoke %s" % (sys.executable, stepModule)
             invokeCommand += " %s \n" % script
-            logging.info("    Invoking command: %s" % invokeCommand)
             retCode = scram(invokeCommand, runtimeDir=runtimeDir)
             if retCode > 0:
                 msg = "Error running command\n%s\n" % invokeCommand


### PR DESCRIPTION
No way to make the pre scram script work with the comp python. I ran several tests interactively and I could import urandom, pythonpath and ld_library_path always had the proper path.

Following @hufnagel suggestion, I changed the python used to run SetupCMSSWPSet (and cmsRun) to the one under the release dir.

@ticoann please don't merge yet. I want to run all our test workflows with these changes. Later on I'll update this PR with pylint fixes.
