### PR TITLE
Assign test_authz_key in unit test

### DIFF
--- a/test/python/WMCore_t/REST_t/Api_t.py
+++ b/test/python/WMCore_t/REST_t/Api_t.py
@@ -225,7 +225,7 @@ class Tester(helper.CPWebCase):
 
 def setup_server():
     srcfile = __file__.split("/")[-1].split(".py")[0]
-    setup_test_server(srcfile, "Root")
+    _, T.test_authz_key = setup_test_server(srcfile, "Root")
     #cpconfig.update({"log.screen": True})
 
 if __name__ == '__main__':


### PR DESCRIPTION
This recipe may fix some of the failed unit tests.
