### PR TITLE
Assign test_authz_key in unit test

### DIFF
--- a/test/python/WMCore_t/REST_t/Daemon_t.py
+++ b/test/python/WMCore_t/REST_t/Daemon_t.py
@@ -93,7 +93,7 @@ class TaskTest(helper.CPWebCase):
 def setup_server():
     """Set up this test case."""
     srcfile = __file__.split("/")[-1].split(".py")[0]
-    setup_test_server(srcfile, "TaskAPI")
+    _, T.test_authz_key = setup_test_server(srcfile, "TaskAPI")
     #cpconfig.update({"log.screen": True})
     #print server.config
 

--- a/test/python/WMCore_t/REST_t/Simple_t.py
+++ b/test/python/WMCore_t/REST_t/Simple_t.py
@@ -41,7 +41,7 @@ class SimpleTest(helper.CPWebCase):
 
 def setup_server():
     srcfile = __file__.split("/")[-1].split(".py")[0]
-    setup_test_server(srcfile, "Root")
+    _, T.test_authz_key = setup_test_server(srcfile, "Root")
 
 if __name__ == '__main__':
     setup_server()


### PR DESCRIPTION
Fix other tests who inherit test_authz_key problem.
