### PR TITLE
pycurl_manager is no longer decoding the body of HTTP responses

### DIFF
--- a/src/python/WMCore/Services/UserFileCache/UserFileCache.py
+++ b/src/python/WMCore/Services/UserFileCache/UserFileCache.py
@@ -54,7 +54,6 @@ class UserFileCache(Service):
         return json.loads(resString)['result'][0]
 
     def removeFile(self, haskey):
-
         result=self['requests'].makeRequest(uri = 'info', data = {'subresource':'fileremove', 'hashkey': haskey})
         return result[0]['result'][0]
 

--- a/src/python/WMCore/Services/pycurl_manager.py
+++ b/src/python/WMCore/Services/pycurl_manager.py
@@ -138,7 +138,7 @@ class RequestHandler(object):
                         % (str(exc), type(data))
                 logging.warning(msg)
                 return data
-            return data
+            return res
         else:
             return data
 

--- a/test/python/WMCore_t/Services_t/UserFileCache_t/UserFileCache_t.py
+++ b/test/python/WMCore_t/Services_t/UserFileCache_t/UserFileCache_t.py
@@ -31,16 +31,20 @@ class UserFileCacheTest(unittest.TestCase):
         self.assertRaises(IOError, self.ufc.checksum, **{'fileName': 'does_not_exist'})
         return
 
+
     def testUploadDownload(self):
         if 'UFCURL' in os.environ:
             currdir = getTestBase()
             upfile = path.join(currdir, 'WMCore_t/Services_t/UserFileCache_t/test_file.tgz') #file to upload
             upfileLog = path.join(currdir, 'WMCore_t/Services_t/UserFileCache_t/uplog.txt') #file to upload
-            ufc = UserFileCache({'endpoint':os.environ['UFCURL']})
+            ufc = UserFileCache({'endpoint':os.environ['UFCURL'], 'pycurl': True})
 
             #hashkey upload/download
             res = ufc.upload(upfile)
             ufc.download(res['hashkey'], output='pippo_publish_down.tgz')
+
+            #hashkey deletion
+            ufc.removeFile(res['hashkey'])
 
             #log upload/download
             res = ufc.uploadLog(upfileLog)


### PR DESCRIPTION
The bug was found by @jmarra13 during the validation of the crab3 September release (https://github.com/dmwm/CRABServer/issues/4954#issuecomment-136322439)
