### PR TITLE
Adding phedex-node to localStageOut report.

### DIFF
--- a/src/python/WMCore/Storage/SiteLocalConfig.py
+++ b/src/python/WMCore/Storage/SiteLocalConfig.py
@@ -274,6 +274,8 @@ def processLocalStageOut():
                 localReport['option'] = subnode.attrs.get('value', None)
             elif subnode.name == 'catalog':
                 localReport['catalog'] = subnode.attrs.get('url', None)
+            elif subnode.name == 'phedex-node':
+                localReport['phedex-node'] = subnode.attrs.get('value', None)
         report['localStageOut'] = localReport
 
 @coroutine

--- a/test/python/WMCore_t/Storage_t/SiteLocalConfig_t.py
+++ b/test/python/WMCore_t/Storage_t/SiteLocalConfig_t.py
@@ -11,8 +11,11 @@ import unittest
 from WMQuality.TestInit import TestInit
 from WMCore.WMBase import getTestBase
 
-from WMCore.Storage.SiteLocalConfig import SiteLocalConfig
+from WMCore.Storage.SiteLocalConfig import SiteLocalConfig, SiteConfigError
 from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig
+from WMCore.Services.PhEDEx.PhEDEx import PhEDEx
+
+from nose.plugins.attrib import attr
 
 class SiteLocalConfigTest(unittest.TestCase):
     def setUp(self):
@@ -156,6 +159,38 @@ class SiteLocalConfigTest(unittest.TestCase):
                          "Error: Wrong site name.")
 
 
+    @attr("integration")
+    def testSlcPhedexNodesEqualPhedexApiNodes(self):
+        """
+        For each site, verify that the stageout node specified in
+        site-local-config.xml is the same as the one returned by the PhEDEx api.
+        """
+        os.environ["CMS_PATH"] = "/cvmfs/cms.cern.ch"
+
+        phedex = PhEDEx()
+        nodes = phedex.getNodeMap()["phedex"]["node"]
+
+        # Make a dict for translating the se names into regular site names.
+        node_map = {}
+        for node in nodes:
+            node_map[str(node[u"se"])] = str(node[str(u"name")])
+        
+        for d in os.listdir("/cvmfs/cms.cern.ch/SITECONF/"):
+            # Only T0_, T1_... folders are needed
+            if d[0] == "T":
+                os.environ['WMAGENT_SITE_CONFIG_OVERRIDE'] ='/cvmfs/cms.cern.ch/SITECONF/%s/JobConfig/site-local-config.xml' % (d)
+                try:
+                    slc = loadSiteLocalConfig()
+                except SiteConfigError as e:
+                    print e.args[0]
+                phedexNode = slc.localStageOut.get("phedex-node")
+                # If slc is correct, perform check
+                if "se-name" in slc.localStageOut and slc.localStageOut["se-name"] in node_map and phedexNode != None:
+                    self.assertEqual(phedexNode, node_map[slc.localStageOut["se-name"]], \
+                            "Error: Node specified in SLC (%s) doesn't match node returned by PhEDEx api (%s)." \
+                            % (phedexNode, node_map[slc.localStageOut["se-name"]]))
+                    
+        return 
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
We need to have the phedex-node value of site-local-config.xml in order to avoid querying PhEDEx if possible. This is the issue: https://github.com/dmwm/CRABServer/issues/4895.

Also added an integration test to see if site-local-configs actually match what PhEDEx is providing. 
