### PR TITLE
Convert DBInterface to use generators while dealing with database calls; this eliminates ResultSet class usage (even though I left it); remove thread from ResultSet class anyway

### DIFF
--- a/src/python/WMCore/Database/MySQLCore.py
+++ b/src/python/WMCore/Database/MySQLCore.py
@@ -8,7 +8,6 @@ Handle bind variable parsing for MySQL.
 import copy
 
 from WMCore.Database.DBCore import DBInterface
-from WMCore.Database.ResultSet import ResultSet
 
 def bindVarCompare(a, b):
     """

--- a/src/python/WMCore/Database/ResultSet.py
+++ b/src/python/WMCore/Database/ResultSet.py
@@ -5,12 +5,6 @@ A class to read in a SQLAlchemy result proxy and hold the data, such that the
 SQLAlchemy result sets (aka cursors) can be closed. Make this class look as much
 like the SQLAlchemy class to minimise the impact of adding this class.
 """
-
-
-
-
-import threading
-
 class ResultSet:
     def __init__(self):
         self.data = []
@@ -29,9 +23,6 @@ class ResultSet:
         return self.data
 
     def add(self, resultproxy):
-
-        myThread = threading.currentThread()
-
         if resultproxy.closed:
             return
         else:


### PR DESCRIPTION
Please keep this PR open until comprehensive set of integration tests is done. By default I left current behavior, i.e. return list from processData. But clients can start using generators via explicit option useGenerator=True in processData.
