### PR TITLE
Accept plain list of lumis

### DIFF
--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -1322,8 +1322,11 @@ class WMTaskHelper(TreeHelper):
         for run, runLumis in lumiMask.items():
             runs.append(int(run))
             lumiList = []
-            for lumi in runLumis:
-                lumiList.extend([str(l) for l in lumi])
+            # check whether it's a plain or nested list
+            if isinstance(runLumis[0], int):
+                lumiList.extend([str(l) for l in runLumis])
+            else:
+                lumiList.extend([str(l) for lumi in runLumis for l in lumi])
             lumis.append(','.join(lumiList))
 
         self.data.input.splitting.runs = runs

--- a/test/data/ReqMgr/requests/Integration/MonteCarloFromGEN_LumiMask.json
+++ b/test/data/ReqMgr/requests/Integration/MonteCarloFromGEN_LumiMask.json
@@ -1,7 +1,7 @@
 { 
 "createRequest":
 {         
-    "Comments": "MonteCarloFromGEN with LumiMask, 1 run and 42l in total. Half an hour opened",
+    "Comments": "MonteCarloFromGEN with LumiMask, 1 run and 15l in total. Half an hour opened",
     "Campaign": "Campaign-OVERRIDE-ME",
     "RequestString": "RequestString-OVERRIDE-ME",
     "CMSSWVersion": "CMSSW_5_3_19",
@@ -22,7 +22,7 @@
     "Group": "DATAOPS",
     "TotalTime": 28800,
     "TimePerEvent": 16.879,
-    "LumiList": {"1": [[1, 10], [25,45], [90,100]]},
+    "LumiList": {"1": [1, 2, 3, 4, 25, 26, 27, 28, 29, 30, 90, 91, 92, 93, 94]},
     "Memory": 2300,
     "LumisPerJob": 1,
     "SizePerEvent": 1154,


### PR DESCRIPTION
On the same topic as #6241 , I just noticed we can not workaround that issue by providing a plain list of lumis since it's broken in production :-(

I also noticed we are not properly setting splitting.lumis (a few lines below) when it's a list of lists, since we don't expand it. Since things work fine since the beginning, I assume it's not a problem, otherwise let me know and I can update it.

Request injection works on my VM, however I still want to completely run one workflow.
