### PR TITLE
Remove exception in tearDown, get further with pileup fetcher

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
+++ b/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
@@ -82,13 +82,16 @@ class PileupFetcher(FetcherInterface):
             resultDict[pileupType] = blockDict
         return resultDict
 
-
-    def _createPileupConfigFile(self, helper, fakeSites):
+    def _createPileupConfigFile(self, helper, fakeSites=None):
         """
         Stores pileup JSON configuration file in the working
         directory / sandbox.
 
         """
+
+        if fakeSites is None:
+            fakeSites = []
+
         stepPath = "%s/%s" % (self.workingDirectory(), helper.name())
         fileName = "%s/%s" % (stepPath, "pileupconf.json")
         if os.path.isfile(fileName) and os.path.getsize(fileName) > 0:

--- a/test/python/WMCore_t/WMRuntime_t/Scripts_t/SetupCMSSWPset_t.py
+++ b/test/python/WMCore_t/WMRuntime_t/Scripts_t/SetupCMSSWPset_t.py
@@ -8,24 +8,23 @@ Tests for the PSet configuration code.
 
 import imp
 import unittest
-import pickle
 import os
 import sys
+
 import nose
 
 from WMCore.DataStructs.File import File
 from WMCore.DataStructs.Job import Job
 from WMCore.Configuration import ConfigSection
 from WMCore.Storage.TrivialFileCatalog import loadTFC
-
 from WMCore.WMSpec.WMStep import WMStep
 from WMCore.WMSpec.Steps.Templates.CMSSW import CMSSWStepHelper
 from WMCore.WMSpec.Steps import StepFactory
 from WMCore.WMSpec.Steps.Fetchers.PileupFetcher import PileupFetcher
 from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig
-
 from WMQuality.TestInit import TestInit
 import WMCore.WMBase
+
 
 class SetupCMSSWPsetTest(unittest.TestCase):
     def setUp(self):
@@ -36,9 +35,9 @@ class SetupCMSSWPsetTest(unittest.TestCase):
                                         "WMCore_t/WMRuntime_t/Scripts_t"))
 
     def tearDown(self):
-        sys.path.remove(os.path.join(WMCore.WMBase.getTestBase(),
-                                     "WMCore_t/WMRuntime_t/Scripts_t"))
-        del sys.modules["WMTaskSpace"]
+        sys.path.remove(os.path.join(WMCore.WMBase.getTestBase(), "WMCore_t/WMRuntime_t/Scripts_t"))
+        if 'WMTaskSpace' in sys.modules:
+            del sys.modules["WMTaskSpace"]
         self.testInit.delWorkDir()
         os.unsetenv("WMAGENT_SITE_CONFIG_OVERRIDE")
 
@@ -266,7 +265,7 @@ class SetupCMSSWPsetTest(unittest.TestCase):
         # pileup configuration file, need to create it in self.testDir
         fetcher = PileupFetcher()
         fetcher.setWorkingDirectory(self.testDir)
-        fetcher._createPileupConfigFile(setupScript.step)
+        fetcher._createPileupConfigFile(setupScript.step, fakeSites=['T1_US_FNAL'])
 
         setupScript()
 


### PR DESCRIPTION
This fixes an exception in the teardown method which may allow other tests to run. It changes where an exception gets thrown in the test it intends to fix, now at the point where it tries to find a logger for the current thread.
