### PR TITLE
Clean-up database usage in unittests, major upgrade do not merge

### DIFF
--- a/setup_test.py
+++ b/setup_test.py
@@ -139,7 +139,9 @@ if can_nose:
         # if you set this to true, I will really delete your database
         #  after every test
         # WARNING WARNING WARNING
-        user_options = [\
+        user_options = [('reallyDeleteMyDatabaseAfterEveryTest=',
+                         None,
+                         'If you set this I WILL DELETE YOUR DATABASE AFTER EVERY TEST. DO NOT RUN ON A PRODUCTION SYSTEM'),
                          ('buildBotMode=',
                           None,
                           'Are we running inside buildbot?'),

--- a/setup_test.py
+++ b/setup_test.py
@@ -139,9 +139,7 @@ if can_nose:
         # if you set this to true, I will really delete your database
         #  after every test
         # WARNING WARNING WARNING
-        user_options = [('reallyDeleteMyDatabaseAfterEveryTest=',
-                         None,
-                         'If you set this I WILL DELETE YOUR DATABASE AFTER EVERY TEST. DO NOT RUN ON A PRODUCTION SYSTEM'),
+        user_options = [\
                          ('buildBotMode=',
                           None,
                           'Are we running inside buildbot?'),
@@ -258,13 +256,6 @@ if can_nose:
             else:
                 quickTestArg = []
                 
-            if self.reallyDeleteMyDatabaseAfterEveryTest:
-                print "#### WE ARE DELETING YOUR DATABASE. 3 SECONDS TO CANCEL ####"
-                print "#### buildbotmode is %s" % self.buildBotMode
-                sys.stdout.flush()
-                import WMQuality.TestInit
-                WMQuality.TestInit.deleteDatabaseAfterEveryTest( "I'm Serious" )
-                time.sleep(4)
             if self.workerNodeTestsOnly:
                 args = [__file__,'--with-xunit', '-m', '(_t.py$)|(_t$)|(^test)','-a','workerNodeTest',self.testingRoot]
                 args.extend( quickTestArg )

--- a/src/python/WMComponent/DBS3Buffer/MySQL/Create.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/Create.py
@@ -25,12 +25,12 @@ class Create(DBCreator):
               """CREATE TABLE dbsbuffer_dataset
                         (
                            id              BIGINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
-                           path            VARCHAR(500) COLLATE latin1_general_cs UNIQUE NOT NULL,
+                           path            VARCHAR(255) COLLATE latin1_general_cs UNIQUE NOT NULL,
                            processing_ver  VARCHAR(255),
                            acquisition_era VARCHAR(255),
                            valid_status    VARCHAR(20),
                            global_tag      VARCHAR(255),
-                           parent          VARCHAR(500),
+                           parent          VARCHAR(255),
                            prep_id         VARCHAR(255)
                         ) ENGINE=InnoDB"""
 
@@ -58,7 +58,7 @@ class Create(DBCreator):
                            app_name varchar(100),
                            app_ver  varchar(100),
                            app_fam  varchar(100),
-                           pset_hash varchar(700),
+                           pset_hash varchar(255),
                            config_content LONGTEXT,
                            in_dbs int, 
                            UNIQUE (app_name, app_ver, app_fam, pset_hash)
@@ -80,8 +80,8 @@ class Create(DBCreator):
         self.create["03dbsbuffer_workflow"] = \
           """CREATE TABLE dbsbuffer_workflow (
                id                           INTEGER PRIMARY KEY AUTO_INCREMENT,
-               name                         VARCHAR(700),
-               task                         VARCHAR(700),
+               name                         VARCHAR(255),
+               task                         VARCHAR(255),
                block_close_max_wait_time    INTEGER UNSIGNED,
                block_close_max_files        INTEGER UNSIGNED,
                block_close_max_events       INTEGER UNSIGNED,
@@ -93,7 +93,7 @@ class Create(DBCreator):
         self.create["04dbsbuffer_file"] = \
           """CREATE TABLE dbsbuffer_file (
              id           INTEGER      PRIMARY KEY AUTO_INCREMENT,
-             lfn          VARCHAR(500) NOT NULL,
+             lfn          VARCHAR(255) NOT NULL,
              filesize     BIGINT,
              events       INTEGER,
              dataset_algo BIGINT UNSIGNED   NOT NULL,

--- a/src/python/WMComponent/DBS3Buffer/MySQL/InsertWorkflow.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/InsertWorkflow.py
@@ -31,7 +31,7 @@ class InsertWorkflow(DBFormatter):
     def execute(self, requestName, taskPath,
                 blockMaxCloseTime, blockMaxFiles,
                 blockMaxEvents, blockMaxSize,
-                conn = None, transaction = False):
+                conn = None, transaction = True):
         """
         _execute_
 
@@ -43,7 +43,7 @@ class InsertWorkflow(DBFormatter):
                  'blockMaxEvents' : blockMaxEvents,
                  'blockMaxSize' : blockMaxSize}
 
-        self.dbi.processData(self.sql, binds, conn = conn,
+        result = self.dbi.processData(self.sql, binds, conn = conn,
                              transaction = transaction)
 
         binds = {'name': requestName, 'task': taskPath}

--- a/src/python/WMCore/Database/DBFormatter.py
+++ b/src/python/WMCore/Database/DBFormatter.py
@@ -38,6 +38,18 @@ class DBFormatter(WMObject):
         t = datetime.datetime.now()
         return self.convertdatetime(t)
 
+# VK this is example of format method re-factoring if
+# we'll use ResultSetExampleDictConverter class
+#    def format(self, result):
+#        """
+#        Some standard formatting, put all records into a list
+#        """
+#        out = []
+#        for res in result:
+#            for row in res.fetchall():
+#                out.append(row)
+#            res.close()
+#        return out
     def format(self, result):
         """
         Some standard formatting, put all records into a list
@@ -61,6 +73,15 @@ class DBFormatter(WMObject):
             for i in r.fetchone():
                 out.append(i)
         return out
+
+# VK this is example of formatDict method re-factoring if
+# we'll use ResultSetExampleDictConverter class
+#    def formatDict(self, result):
+#        out = []
+#        for row in result:
+#            for item in row.fetchall():
+#                out.append(item)
+#        return out
 
     def formatDict(self, result):
         """
@@ -86,6 +107,16 @@ class DBFormatter(WMObject):
 
         return dictOut
 
+# VK this is example of formatOneDict method re-factoring if
+# we'll use ResultSetExampleDictConverter class
+#    def formatOneDict(self, result):
+#        """
+#        Return a dictionary representing the first record
+#        """
+#        if (len(result) == 0):
+#            return {}
+#        return result[0]
+
     def formatOneDict(self, result):
         """
         Return a dictionary representing the first record
@@ -109,7 +140,7 @@ class DBFormatter(WMObject):
         Use fetchmany(size = default arraysize = 50)
 
         """
-	if type(cursor.keys) == types.MethodType:
+        if type(cursor.keys) == types.MethodType:
             keys = [x.lower() for x in cursor.keys()]
         else:
             keys = [x.lower() for x in cursor.keys]

--- a/src/python/WMCore/Database/MySQL/Create.py
+++ b/src/python/WMCore/Database/MySQL/Create.py
@@ -1,0 +1,30 @@
+"""
+_Create_
+
+Implementation of Create for MySQL
+
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class Create(DBFormatter):
+
+    def execute(self, dbName, conn = None):
+        """Execute create statement"""
+        # check among list of database if dbName is present
+        sql = """SHOW DATABASES"""
+        results = self.dbi.processData(sql, {}, conn = conn)
+        found = False
+        for row in self.formatDict(results):
+            if row['database'] == dbName:
+                found = True
+                break
+        if  not found:
+            try:
+                sql = """CREATE DATABASE %s""" % dbName
+                self.dbi.processData(sql, {}, conn = conn)
+            except Exception as exp:
+                print("Create database: %s" % str(exp))
+                raise exp
+        sql = """USE %s""" % dbName
+        self.dbi.processData(sql, {}, conn = conn)

--- a/src/python/WMCore/Database/MySQLCore.py
+++ b/src/python/WMCore/Database/MySQLCore.py
@@ -39,6 +39,10 @@ def stringLengthCompare(a, b):
         return 1
 
 class MySQLInterface(DBInterface):
+
+    def __init__(self, logger, engine):
+        DBInterface.__init__(self, logger, engine)
+
     def substitute(self, origSQL, origBindsList):
         """
         _substitute_

--- a/src/python/WMCore/Database/ResultSet.py
+++ b/src/python/WMCore/Database/ResultSet.py
@@ -6,15 +6,90 @@ SQLAlchemy result sets (aka cursors) can be closed. Make this class look as much
 like the SQLAlchemy class to minimise the impact of adding this class.
 """
 
-
-
-
-import threading
+import sqlalchemy
 
 class ResultSet:
-    def __init__(self):
+    """
+    Class to read SQLAlchemy result proxy objects and convert it into
+    python data structure. The class should provide iterable interface
+    and hold fetched keys.
+    """
+    def __init__(self, resultproxy):
+        self.data = [] # values of query
+        self.keys = set()
+        if not resultproxy.closed:
+            data = []
+            try:
+                data = resultproxy.fetchall()
+            except sqlalchemy.exc.ResourceClosedError:
+                pass
+            except Exception as exp:
+                msg = 'ResultSet, failed to fetch resultproxy object, %s type=%s' \
+                        % (str(exp), type(exp))
+                raise Exception(msg)
+            for r in data:
+                if  not self.keys:
+                    self.keys = r.keys()
+                self.data.append(r.values())
+            resultproxy.close()
+
+    def __len__(self):
+        "Length method"
+        return len(self.data)
+
+    def __iter__(self):
+        "Iterator method"
+        return iter(self.data)
+
+    def close(self):
+        "Immitate close of resultproxy object"
+        return
+
+    def fetchone(self):
+        "Immitate fetchone method of resultproxy object"
+        if len(self.data) > 0:
+            return self.data[0]
+        else:
+            return []
+
+    def fetchall(self):
+        "Immitate fetchmany method of resultproxy object"
+        return self.data
+
+### Valentin, I left this class as an example
+### how to convert resultproxy set directly into stream of dictionaries
+### So far this job is delegated to DBFormatter formatDict/formatDictOne
+### methods, but it must be done earlier at DB level.
+class ResultSetExampleDictConverter:
+    def __init__(self, resultproxy):
         self.data = []
-        self.keys = []
+        self.keys = set()
+        if not resultproxy.closed:
+            data = []
+            try:
+                data = resultproxy.fetchall()
+            except sqlalchemy.exc.ResourceClosedError:
+                pass
+            except Exception as exp:
+                msg = 'ResultSet, failed to fetch resultproxy object, %s type=%s' \
+                        % (str(exp), type(exp))
+                raise Exception(msg)
+            for r in data:
+                if  not self.keys:
+                    self.keys = r.keys()
+                rec = {}
+                for pair in r.items():
+                    # convert each pair into dict, a pair comes from db
+                    # as (key, value). We also lower key names since ORACLE has capitalize them
+                    rec.update({pair[0].lower(): pair[1]})
+                self.data.append(rec)
+            resultproxy.close()
+
+    def __len__(self):
+        return len(self.data)
+
+    def __iter__(self):
+        return iter(self.data)
 
     def close(self):
         return
@@ -27,17 +102,3 @@ class ResultSet:
 
     def fetchall(self):
         return self.data
-
-    def add(self, resultproxy):
-
-        myThread = threading.currentThread()
-
-        if resultproxy.closed:
-            return
-        else:
-            for r in resultproxy:
-                if len(self.keys) == 0:
-                    self.keys.extend(r.keys())
-                self.data.append(r)
-
-        return

--- a/src/python/WMCore/Services/DBS/DBSReader.py
+++ b/src/python/WMCore/Services/DBS/DBSReader.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python
 """
 _DBSReader_
-
 Readonly DBS Interface
-
 """
 import urlparse
 
 from WMCore.Services.DBS.DBSErrors import DBSReaderError
 from WMCore.Services.EmulatorSwitch import emulatorHook
-from WMCore.Services.DBS.DBS3Reader import DBS3Reader
+
 
 @emulatorHook
 def DBSReader(endpoint, **kwargs):
@@ -17,13 +15,17 @@ def DBSReader(endpoint, **kwargs):
     
     msg = ''
     try:
-        dbs = DBS3Reader(endpoint, **kwargs)
+        dbs = _getDBS3Reader(endpoint, **kwargs)
         # if this doesn't throw endpoint is dbs3
         dbs.dbs.serverinfo()
         return dbs
     except Exception as ex:
         msg += 'Instantiating DBS3Reader failed with %s\n' % str(ex)
-    raise DBSReaderError("Can't contact DBS at %s, kwargs %s, got errors %s" \
-            % (endpoint, kwargs, msg))
+    raise DBSReaderError("Can't contact DBS at %s, got errors %s" % (endpoint, msg))
+
+
+def _getDBS3Reader(endpoint, **kwargs):
+    from WMCore.Services.DBS.DBS3Reader import DBS3Reader as DBSReader
+    return DBSReader(endpoint, **kwargs)
 
 __all__ = [DBSReader]

--- a/src/python/WMCore/Services/DBS/DBSReader.py
+++ b/src/python/WMCore/Services/DBS/DBSReader.py
@@ -9,7 +9,7 @@ import urlparse
 
 from WMCore.Services.DBS.DBSErrors import DBSReaderError
 from WMCore.Services.EmulatorSwitch import emulatorHook
-
+from WMCore.Services.DBS.DBS3Reader import DBS3Reader
 
 @emulatorHook
 def DBSReader(endpoint, **kwargs):
@@ -17,17 +17,13 @@ def DBSReader(endpoint, **kwargs):
     
     msg = ''
     try:
-        dbs = _getDBS3Reader(endpoint, **kwargs)
+        dbs = DBS3Reader(endpoint, **kwargs)
         # if this doesn't throw endpoint is dbs3
         dbs.dbs.serverinfo()
         return dbs
     except Exception as ex:
         msg += 'Instantiating DBS3Reader failed with %s\n' % str(ex)
-    raise DBSReaderError("Can't contact DBS at %s, got errors %s" % (endpoint, msg))
-
-
-def _getDBS3Reader(endpoint, **kwargs):
-    from WMCore.Services.DBS.DBS3Reader import DBS3Reader as DBSReader
-    return DBSReader(endpoint, **kwargs)
+    raise DBSReaderError("Can't contact DBS at %s, kwargs %s, got errors %s" \
+            % (endpoint, kwargs, msg))
 
 __all__ = [DBSReader]

--- a/src/python/WMCore/WMBS/CreateWMBSBase.py
+++ b/src/python/WMCore/WMBS/CreateWMBSBase.py
@@ -66,7 +66,7 @@ class CreateWMBSBase(DBCreator):
         self.create["01wmbs_fileset"] = \
           """CREATE TABLE wmbs_fileset (
              id          INTEGER      PRIMARY KEY AUTO_INCREMENT,
-             name        VARCHAR(700) NOT NULL,
+             name        VARCHAR(255) NOT NULL,
              open        INT(1)       NOT NULL DEFAULT 0,
              last_update INTEGER      NOT NULL,
              UNIQUE (name))"""
@@ -74,7 +74,7 @@ class CreateWMBSBase(DBCreator):
         self.create["02wmbs_file_details"] = \
           """CREATE TABLE wmbs_file_details (
              id           INTEGER      PRIMARY KEY AUTO_INCREMENT,
-             lfn          VARCHAR(700) NOT NULL,
+             lfn          VARCHAR(255) NOT NULL,
              filesize     BIGINT,
              events       INTEGER,
              first_event  BIGINT       NOT NULL DEFAULT 0,
@@ -148,9 +148,9 @@ class CreateWMBSBase(DBCreator):
         self.create["07wmbs_workflow"] = \
           """CREATE TABLE wmbs_workflow (
              id           INTEGER          PRIMARY KEY AUTO_INCREMENT,
-             spec         VARCHAR(700)     NOT NULL,
-             name         VARCHAR(700)     NOT NULL,
-             task         VARCHAR(700)     NOT NULL,
+             spec         VARCHAR(70)     NOT NULL,
+             name         VARCHAR(70)     NOT NULL,
+             task         VARCHAR(70)     NOT NULL,
              type         VARCHAR(255),
              owner        INTEGER          NOT NULL,
              alt_fs_close INT(1)           NOT NULL,
@@ -278,15 +278,15 @@ class CreateWMBSBase(DBCreator):
           """CREATE TABLE wmbs_job (
              id           INTEGER       PRIMARY KEY AUTO_INCREMENT,
              jobgroup     INTEGER       NOT NULL,
-             name         VARCHAR(255),
+             name         VARCHAR(70),
              state        INTEGER       NOT NULL,
              state_time   INTEGER       NOT NULL,
              retry_count  INTEGER       DEFAULT 0,
              couch_record VARCHAR(255),
              location     INTEGER,
              outcome      INTEGER       DEFAULT 0,
-             cache_dir    VARCHAR(767)  DEFAULT 'None',
-             fwjr_path    VARCHAR(767),
+             cache_dir    VARCHAR(70)  DEFAULT 'None',
+             fwjr_path    VARCHAR(70),
              FOREIGN KEY (jobgroup)
              REFERENCES wmbs_jobgroup(id) ON DELETE CASCADE,
              FOREIGN KEY (state) REFERENCES wmbs_job_state(id),

--- a/src/python/WMCore/WMBS/MySQL/Create.py
+++ b/src/python/WMCore/WMBS/MySQL/Create.py
@@ -28,7 +28,7 @@ class Create(CreateWMBSBase):
         self.create["01wmbs_fileset"] = \
           """CREATE TABLE wmbs_fileset (
              id          INTEGER      PRIMARY KEY AUTO_INCREMENT,
-             name        VARCHAR(700) NOT NULL,
+             name        VARCHAR(255) NOT NULL,
              open        INT(1)       NOT NULL DEFAULT 0,
              last_update INT(11)      NOT NULL,
              UNIQUE (name))"""

--- a/src/python/WMCore/WMBS/MySQL/Fileset/Exists.py
+++ b/src/python/WMCore/WMBS/MySQL/Fileset/Exists.py
@@ -17,7 +17,7 @@ class Exists(DBFormatter):
     def format(self, result):
         result = DBFormatter.format(self, result)
         if len(result) == 0:
-            return False
+            return None
         else:
             return int(result[0][0])
 

--- a/src/python/WMCore/WMBS/MySQL/Fileset/LoadFromName.py
+++ b/src/python/WMCore/WMBS/MySQL/Fileset/LoadFromName.py
@@ -23,7 +23,10 @@ class LoadFromName(DBFormatter):
         DBFormatter's formatDict() method changes all attributes to be
         strings.
         """
-        formattedResult = DBFormatter.formatDict(self, result)[0]
+        res = DBFormatter.formatDict(self, result)
+        if not res:
+            return res
+        formattedResult = res[0]
         formattedResult["id"] = int(formattedResult["id"])
         formattedResult["last_update"] = int(formattedResult["last_update"])
 

--- a/src/python/WMQuality/REST/RESTBaseUnitTestWithDBBackend.py
+++ b/src/python/WMQuality/REST/RESTBaseUnitTestWithDBBackend.py
@@ -32,6 +32,7 @@ class RESTBaseUnitTestWithDBBackend(unittest.TestCase):
                     
             
         """
+        self.testDB = 'unittest_%s' % self.__class__.__name__
         if self.schemaModules or self.couchDBs:
             from WMQuality.TestInitCouchApp import TestInitCouchApp
             self.testInit = TestInitCouchApp(__file__)
@@ -39,6 +40,8 @@ class RESTBaseUnitTestWithDBBackend(unittest.TestCase):
             
             if self.schemaModules:
                 self.testInit.setDatabaseConnection()
+                self.testInit.destroyDatabase(self.testDB) # wipe-out previous db
+                self.testInit.createDatabase(self.testDB) # create new db
                 self.testInit.setSchema(customModules = self.schemaModules,
                                         useDefault = False)
                 # Now pull the dbURL from the factory
@@ -72,7 +75,7 @@ class RESTBaseUnitTestWithDBBackend(unittest.TestCase):
             self.test_authz_key = None
 
         if self.schemaModules:
-            self.testInit.clearDatabase()
+            self.testInit.destroyDatabase(self.testDB)
         
         if self.couchDBs:
             self.testInit.tearDownCouch()

--- a/src/python/WMQuality/WebTools/RESTBaseUnitTest.py
+++ b/src/python/WMQuality/WebTools/RESTBaseUnitTest.py
@@ -14,6 +14,7 @@ from WMCore.WebTools.Root import Root
 class RESTBaseUnitTest(unittest.TestCase):
 
     def setUp(self, initRoot = True):
+        self.testDB = 'unittest_%s' % self.__class__.__name__
         # default set
         self.schemaModules = []
 
@@ -24,7 +25,9 @@ class RESTBaseUnitTest(unittest.TestCase):
             from WMQuality.TestInitCouchApp import TestInitCouchApp
             self.testInit = TestInitCouchApp(__file__)
             self.testInit.setLogging() # logLevel = logging.SQLDEBUG
-            self.testInit.setDatabaseConnection( destroyAllDatabase = True )
+            self.testInit.setDatabaseConnection()
+            self.testInit.destroyDatabase(self.testDB) # wipe-out previous db
+            self.testInit.createDatabase(self.testDB) # create new db
             self.testInit.setSchema(customModules = self.schemaModules,
                                     useDefault = False)
             # Now pull the dbURL from the factory
@@ -84,7 +87,7 @@ class RESTBaseUnitTest(unittest.TestCase):
             cherrypy.engine.subscribe('start', cherrypy.checker)
 
         if self.schemaModules:
-            self.testInit.clearDatabase()
+            self.testInit.destroyDatabase(self.testDB)
         self.config = None
         return
 

--- a/test/python/WMComponent_t/AnalyticsDataCollector_t/Plugins_t/Tier0Plugin_t.py
+++ b/test/python/WMComponent_t/AnalyticsDataCollector_t/Plugins_t/Tier0Plugin_t.py
@@ -35,7 +35,8 @@ class Tier0PluginTest(unittest.TestCase):
         Setup the test environment
         """
         self.testInit = TestInit(__file__)
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(["WMCore.WMBS"])
         self.requestCouchDB = 'wmstats_plugin_t'
         self.testInit.setupCouch(self.requestCouchDB, 'T0Request')
@@ -57,7 +58,7 @@ class Tier0PluginTest(unittest.TestCase):
         Clear databases and delete files
         """
         self.testInit.tearDownCouch()
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
         self.testInit.delWorkDir()
 
         return

--- a/test/python/WMComponent_t/DBS3Buffer_t/DBSBufferDataset_t.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/DBSBufferDataset_t.py
@@ -26,13 +26,14 @@ class DBSBufferDatasetTest(unittest.TestCase):
     """
     def setUp(self):
         self.testInit = TestInit(__file__)
+        self.testDB = 'unittest_%s' % self.__class__.__name__
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMComponent.DBS3Buffer"],
                                 useDefault = False)
 
     def tearDown(self):
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
 
     def testBasic(self):
         """

--- a/test/python/WMComponent_t/DBS3Buffer_t/DBSBufferFile_t.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/DBSBufferFile_t.py
@@ -27,7 +27,8 @@ class DBSBufferFileTest(unittest.TestCase):
         """
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMComponent.DBS3Buffer"],
                                 useDefault = False)
 
@@ -51,7 +52,7 @@ class DBSBufferFileTest(unittest.TestCase):
 
         Drop all the DBSBuffer tables.
         """
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
 
     def testCreateDeleteExists(self):
         """

--- a/test/python/WMComponent_t/DBS3Buffer_t/DBSUpload_t.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/DBSUpload_t.py
@@ -46,10 +46,10 @@ class DBSUploadTest(unittest.TestCase):
         setUp function for unittest
 
         """
-
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMComponent.DBS3Buffer"],
                                 useDefault = False)
         self.testDir = self.testInit.generateWorkDir(deleteOnDestruction = False)
@@ -78,7 +78,7 @@ class DBSUploadTest(unittest.TestCase):
 
         tearDown function for unittest
         """
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
         self.testInit.delWorkDir()
         EmulatorSetup.deleteConfig(self.configFile)
 

--- a/test/python/WMComponent_t/DBSUpload_t/DBSUploadPoller_t.py
+++ b/test/python/WMComponent_t/DBSUpload_t/DBSUploadPoller_t.py
@@ -54,9 +54,10 @@ class DBSUploadTest(unittest.TestCase):
         self.configURL    = "RANDOM;;URL;;NAME"
         self.configString = "This is a random string"
 
+        self.testDB = 'unittest_%s' % self.__class__.__name__
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules =
                                 ["WMComponent.DBS3Buffer",
                                  'WMCore.Agent.Database'],
@@ -105,7 +106,7 @@ class DBSUploadTest(unittest.TestCase):
         tearDown function for unittest
         """
 
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
         self.testInit.tearDownCouch()
         self.testInit.delWorkDir()
         return

--- a/test/python/WMComponent_t/ErrorHandler_t/ErrorHandler_t.py
+++ b/test/python/WMComponent_t/ErrorHandler_t/ErrorHandler_t.py
@@ -49,7 +49,8 @@ class ErrorHandlerTest(unittest.TestCase):
 
         self.testInit = TestInitCouchApp(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection(destroyAllDatabase = True)
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
         self.testInit.setupCouch("errorhandler_t", "GroupUser", "ACDC")
@@ -70,17 +71,15 @@ class ErrorHandlerTest(unittest.TestCase):
         self.dataCS = DataCollectionService(url = self.testInit.couchUrl,
                                             database = "errorhandler_t")
 
-        return
 
     def tearDown(self):
         """
         Database deletion
         """
-        self.testInit.clearDatabase()
         self.testInit.delWorkDir()
+        self.testInit.destroyDatabase(self.testDB)
         self.testInit.tearDownCouch()
         EmulatorSetup.deleteConfig(self.configFile)
-        return
 
     def getConfig(self):
         """

--- a/test/python/WMComponent_t/JobAccountant_t/JobAccountant_t.py
+++ b/test/python/WMComponent_t/JobAccountant_t/JobAccountant_t.py
@@ -50,7 +50,8 @@ class JobAccountantTest(unittest.TestCase):
         """
         self.testInit = TestInitCouchApp(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setupCouch("jobaccountant_t", "JobDump")
         self.testInit.setupCouch("jobaccountant_acdc_t", "ACDC", "GroupUser")
         self.testInit.setupCouch("jobaccountant_wmstats_t", "WMStats")
@@ -85,7 +86,6 @@ class JobAccountantTest(unittest.TestCase):
         dbsLocationAction.execute(siteName = "srm-cms.cern.ch")
 
         self.testDir = self.testInit.generateWorkDir()
-        return
 
     def tearDown(self):
         """
@@ -93,10 +93,9 @@ class JobAccountantTest(unittest.TestCase):
 
         Clear out the WMBS and DBSBuffer database schemas.
         """
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
         self.testInit.tearDownCouch()
         self.testInit.delWorkDir()
-        return
 
     def createConfig(self):
         """

--- a/test/python/WMComponent_t/JobArchiver_t/JobArchiver_t.py
+++ b/test/python/WMComponent_t/JobArchiver_t/JobArchiver_t.py
@@ -65,8 +65,8 @@ class JobArchiverTest(unittest.TestCase):
 
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
-        #self.tearDown()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
         self.testInit.setupCouch("jobarchiver_t_0/jobs", "JobDump")
@@ -94,7 +94,7 @@ class JobArchiverTest(unittest.TestCase):
         Database deletion
         """
         EmulatorHelper.resetEmulators()
-        self.testInit.clearDatabase(modules = ["WMCore.WMBS"])
+        self.testInit.destroyDatabase(self.testDB, modules = ["WMCore.WMBS"])
         self.testInit.tearDownCouch()
         self.testInit.delWorkDir()
         EmulatorSetup.deleteConfig(self.configFile)

--- a/test/python/WMComponent_t/JobCreator_t/JobCreator_t.py
+++ b/test/python/WMComponent_t/JobCreator_t/JobCreator_t.py
@@ -63,8 +63,8 @@ class JobCreatorTest(unittest.TestCase):
 
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
-        #self.tearDown()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ['WMCore.WMBS',
                                                  'WMCore.ResourceControl',
                                                  'WMCore.Agent.Database'], useDefault = False)
@@ -115,7 +115,8 @@ class JobCreatorTest(unittest.TestCase):
 
         myThread = threading.currentThread()
 
-        self.testInit.clearDatabase(modules = ['WMCore.WMBS', 'WMCore.ResourceControl',
+        self.testInit.destroyDatabase(self.testDB, 
+                modules = ['WMCore.WMBS', 'WMCore.ResourceControl',
                                                'WMCore.Agent.Database'])
 
         self.testInit.delWorkDir()

--- a/test/python/WMComponent_t/JobSubmitter_t/JobSubmitterCaching_t.py
+++ b/test/python/WMComponent_t/JobSubmitter_t/JobSubmitterCaching_t.py
@@ -34,7 +34,8 @@ class JobSubmitterCachingTest(unittest.TestCase):
         """
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS", "WMCore.BossAir",
                                                  "WMCore.ResourceControl"],
                                 useDefault = False)
@@ -58,7 +59,7 @@ class JobSubmitterCachingTest(unittest.TestCase):
 
         Tear everything down.
         """
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
         self.testInit.delWorkDir()
         self.testInit.tearDownCouch()
         EmulatorSetup.deleteConfig(self.configFile)

--- a/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
+++ b/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
@@ -49,7 +49,8 @@ class JobSubmitterTest(unittest.TestCase):
         """
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS", "WMCore.BossAir", "WMCore.ResourceControl", "WMCore.Agent.Database"])
         self.testInit.setupCouch("jobsubmitter_t/jobs", "JobDump")
         self.testInit.setupCouch("jobsubmitter_t/fwjrs", "FWJRDump")
@@ -79,7 +80,7 @@ class JobSubmitterTest(unittest.TestCase):
 
         Standard tearDown
         """
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
         self.testInit.delWorkDir()
         self.testInit.tearDownCouch()
         EmulatorSetup.deleteConfig(self.configFile)

--- a/test/python/WMComponent_t/JobTracker_t/JobTracker_t.py
+++ b/test/python/WMComponent_t/JobTracker_t/JobTracker_t.py
@@ -136,8 +136,8 @@ class JobTrackerTest(unittest.TestCase):
 
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
-        #self.testInit.clearDatabase(modules = ["WMCore.WMBS", "WMCore.BossAir", "WMCore.ResourceControl"])
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS", "WMCore.BossAir", "WMCore.ResourceControl"],
                                 useDefault = False)
         self.testInit.setupCouch("jobtracker_t/jobs", "JobDump")
@@ -174,7 +174,8 @@ class JobTrackerTest(unittest.TestCase):
         """
         Database deletion
         """
-        self.testInit.clearDatabase(modules = ["WMCore.WMBS", "WMCore.BossAir", "WMCore.ResourceControl"])
+        self.testInit.destroyDatabase(self.testDB,
+                modules = ["WMCore.WMBS", "WMCore.BossAir", "WMCore.ResourceControl"])
         self.testInit.delWorkDir()
         self.testInit.tearDownCouch()
         EmulatorSetup.deleteConfig(self.configFile)

--- a/test/python/WMComponent_t/JobUpdater_t/JobUpdater_t.py
+++ b/test/python/WMComponent_t/JobUpdater_t/JobUpdater_t.py
@@ -38,7 +38,8 @@ class JobUpdaterTest(unittest.TestCase):
         """
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS",
                                                  "WMCore.BossAir"],
                                 useDefault = False)
@@ -61,7 +62,7 @@ class JobUpdaterTest(unittest.TestCase):
 
         Tear down the databases
         """
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
         self.testInit.tearDownCouch()
         self.testInit.delWorkDir()
         EmulatorHelper.resetEmulators()

--- a/test/python/WMComponent_t/PhEDExInjector_t/PhEDExInjectorPoller_t.py
+++ b/test/python/WMComponent_t/PhEDExInjector_t/PhEDExInjectorPoller_t.py
@@ -45,8 +45,8 @@ class PhEDExInjectorPollerTest(unittest.TestCase):
 
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection(destroyAllDatabase = True)
-
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMComponent.DBS3Buffer"],
                                 useDefault = False)
 
@@ -73,7 +73,7 @@ class PhEDExInjectorPollerTest(unittest.TestCase):
 
         Delete the database.
         """
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
 
     def stuffDatabase(self, spec = "TestWorkload.pkl"):
         """

--- a/test/python/WMComponent_t/PhEDExInjector_t/PhEDExInjectorSubscriber_t.py
+++ b/test/python/WMComponent_t/PhEDExInjector_t/PhEDExInjectorSubscriber_t.py
@@ -52,8 +52,8 @@ class PhEDExInjectorSubscriberTest(unittest.TestCase):
 
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
-
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMComponent.DBS3Buffer",
                                                  "WMCore.WMBS"],
                                 useDefault = False)
@@ -63,15 +63,13 @@ class PhEDExInjectorSubscriberTest(unittest.TestCase):
         self.testDatasetA = "/BogusPrimary/Run2012Z-PromptReco-v1/RECO"
         self.testDatasetB = "/BogusPrimary/CRUZET11-v1/RAW"
 
-        return
-
     def tearDown(self):
         """
         _tearDown_
 
         Delete the database.
         """
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
         EmulatorHelper.resetEmulators()
 
     def createConfig(self):

--- a/test/python/WMComponent_t/RetryManager_t/RetryManager_t.py
+++ b/test/python/WMComponent_t/RetryManager_t/RetryManager_t.py
@@ -50,7 +50,8 @@ class RetryManagerTest(unittest.TestCase):
 
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
         self.testInit.setupCouch("retry_manager_t/jobs", "JobDump")
@@ -65,17 +66,15 @@ class RetryManagerTest(unittest.TestCase):
         self.testDir = self.testInit.generateWorkDir()
         self.configFile = EmulatorSetup.setupWMAgentConfig()
         self.nJobs = 10
-        return
 
     def tearDown(self):
         """
         Database deletion
         """
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
         self.testInit.delWorkDir()
         self.testInit.tearDownCouch()
         EmulatorSetup.deleteConfig(self.configFile)
-        return
 
     def getConfig(self):
         """

--- a/test/python/WMComponent_t/TaskArchiver_t/TaskArchiver_t.py
+++ b/test/python/WMComponent_t/TaskArchiver_t/TaskArchiver_t.py
@@ -67,7 +67,8 @@ class TaskArchiverTest(unittest.TestCase):
 
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection(destroyAllDatabase = True)
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS", "WMComponent.DBS3Buffer"],
                                 useDefault = False)
         self.databaseName = "taskarchiver_t_0"
@@ -100,21 +101,18 @@ class TaskArchiverTest(unittest.TestCase):
         self.uploadPublishInfo = False
         self.uploadPublishDir  = None
 
-        return
-
     def tearDown(self):
         """
         Database deletion
         """
         myThread = threading.currentThread()
 
-        self.testInit.clearDatabase(modules = ["WMCore.WMBS"])
+        self.testInit.destroyDatabase(self.testDB, modules = ["WMCore.WMBS"])
         self.testInit.delWorkDir()
         self.testInit.tearDownCouch()
         if self.alertsReceiver:
             self.alertsReceiver.shutdown()
             self.alertsReceiver = None
-        return
 
     def getConfig(self):
         """

--- a/test/python/WMCore_t/ACDC_t/DataCollectionService_t.py
+++ b/test/python/WMCore_t/ACDC_t/DataCollectionService_t.py
@@ -26,12 +26,9 @@ class DataCollectionService_t(unittest.TestCase):
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
         self.testInit.setupCouch("wmcore-acdc-datacollectionsvc", "GroupUser", "ACDC")
-        return
 
     def tearDown(self):
         self.testInit.tearDownCouch()
-        self.testInit.clearDatabase()
-        return
 
     def testChunking(self):
         """

--- a/test/python/WMCore_t/Agent_t/Daemon_t.py
+++ b/test/python/WMCore_t/Agent_t/Daemon_t.py
@@ -39,14 +39,15 @@ class DaemonTest(unittest.TestCase):
         "make a logger instance and create tables"
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.tempDir = tempfile.mkdtemp()
 
     def tearDown(self):
         """
         Deletion of the databases
         """
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
         shutil.rmtree( self.tempDir, True )
 
     def testA(self):

--- a/test/python/WMCore_t/Agent_t/Harness_t.py
+++ b/test/python/WMCore_t/Agent_t/Harness_t.py
@@ -39,14 +39,15 @@ class HarnessTest(unittest.TestCase):
         """
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema()
 
     def tearDown(self):
         """
         Delete database
         """
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
 
     def testB(self):
         raise nose.SkipTest

--- a/test/python/WMCore_t/Agent_t/Heartbeat_t.py
+++ b/test/python/WMCore_t/Agent_t/Heartbeat_t.py
@@ -25,7 +25,8 @@ class HeartbeatTest(unittest.TestCase):
 
         self.testInit = TestInit(__file__)
         self.testInit.setLogging() # logLevel = logging.SQLDEBUG
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.Agent.Database"],
                                 useDefault = False)
         self.heartbeat = HeartbeatAPI("testComponent")
@@ -37,7 +38,7 @@ class HeartbeatTest(unittest.TestCase):
         Drop all the Heartbeat tables.
         """
 
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
 
     def testHeartbeat(self):
         testComponent = HeartbeatAPI("testComponent")

--- a/test/python/WMCore_t/BossAir_t/BossAir_t.py
+++ b/test/python/WMCore_t/BossAir_t/BossAir_t.py
@@ -87,8 +87,8 @@ class BossAirTest(unittest.TestCase):
 
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
-        self.tearDown()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS", "WMCore.BossAir", "WMCore.ResourceControl", "WMCore.Agent.Database"],
                                 useDefault = False)
         self.testInit.setupCouch("bossair_t/jobs", "JobDump")
@@ -147,15 +147,10 @@ class BossAirTest(unittest.TestCase):
         """
         Database deletion
         """
-        #self.testInit.clearDatabase(modules = ["WMCore.WMBS", "WMCore.BossAir", "WMCore.ResourceControl", "WMCore.Agent.Database"])
-
+        self.testInit.destroyDatabase(self.testDB,
+                modules = ["WMCore.WMBS", "WMCore.BossAir", "WMCore.ResourceControl", "WMCore.Agent.Database"])
         self.testInit.delWorkDir()
-
         self.testInit.tearDownCouch()
-
-        return
-
-
 
     def getConfig(self):
         """

--- a/test/python/WMCore_t/BossAir_t/RunJob_t.py
+++ b/test/python/WMCore_t/BossAir_t/RunJob_t.py
@@ -39,8 +39,8 @@ class RunJobTest(unittest.TestCase):
 
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
-        #self.tearDown()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS", "WMCore.BossAir", "WMCore.ResourceControl", "WMCore.Agent.Database"],
                                 useDefault = False)
 
@@ -67,12 +67,9 @@ class RunJobTest(unittest.TestCase):
         """
         Database deletion
         """
-        self.testInit.clearDatabase(modules = ["WMCore.WMBS", "WMCore.BossAir", "WMCore.ResourceControl", "WMCore.Agent.Database"])
-
+        self.testInit.destroyDatabase(self.testDB,
+                modules = ["WMCore.WMBS", "WMCore.BossAir", "WMCore.ResourceControl", "WMCore.Agent.Database"])
         self.testInit.delWorkDir()
-
-        return
-
 
     def createJobs(self, nJobs):
         """

--- a/test/python/WMCore_t/Database_t/DBCore_t.py
+++ b/test/python/WMCore_t/Database_t/DBCore_t.py
@@ -18,18 +18,16 @@ class DBCoreTest(unittest.TestCase):
     def setUp(self):
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMQuality.TestDB"],
                                 useDefault = False)
-
-        return
 
     def tearDown(self):
         """
         Delete the databases
         """
-        self.testInit.clearDatabase()
-        return
+        self.testInit.destroyDatabase(self.testDB)
 
     def testBuildBinds(self):
         """

--- a/test/python/WMCore_t/Database_t/DBFormatter_t.py
+++ b/test/python/WMCore_t/Database_t/DBFormatter_t.py
@@ -36,7 +36,8 @@ class DBFormatterTest(unittest.TestCase):
 
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema()
 
         myThread = threading.currentThread()
@@ -61,8 +62,6 @@ insert into test (bind1, bind2) values (:bind1, :bind2) """
         myThread.transaction.processData(myThread.insert, myThread.insert_binds)
         myThread.transaction.commit()
 
-        return
-
     def tearDown(self):
         """
         Delete the databases
@@ -71,7 +70,7 @@ insert into test (bind1, bind2) values (:bind1, :bind2) """
         myThread.transaction = Transaction(myThread.dbi)
         myThread.transaction.processData("drop table test")
         myThread.transaction.commit()
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
 
     @attr("integration")
     def testBFormatting(self):

--- a/test/python/WMCore_t/Database_t/ResultSet_t.py
+++ b/test/python/WMCore_t/Database_t/ResultSet_t.py
@@ -31,23 +31,19 @@ class ResultSetTest(unittest.TestCase):
 
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMQuality.TestDB"],
                                    useDefault = False)
 
         self.myThread = threading.currentThread()
-
-        return
 
     def tearDown(self):
         """
         Delete the ResultSet test class
 
         """
-        self.testInit.clearDatabase()
-        return
-
-
+        self.testInit.destroyDatabase(self.testDB)
 
     def testFullResultSet(self):
         """

--- a/test/python/WMCore_t/FwkJobReport_t/ReportIntegration_t.py
+++ b/test/python/WMCore_t/FwkJobReport_t/ReportIntegration_t.py
@@ -40,7 +40,8 @@ class ReportIntegrationTest(unittest.TestCase):
         """
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMComponent.DBS3Buffer",
                                                  "WMCore.WMBS"],
                                 useDefault = False)
@@ -119,7 +120,6 @@ class ReportIntegrationTest(unittest.TestCase):
         self.stateChangeAction.execute(jobs = [self.testJob])
 
         self.tempDir = tempfile.mkdtemp()
-        return
 
     def tearDown(self):
         """
@@ -127,7 +127,7 @@ class ReportIntegrationTest(unittest.TestCase):
 
         Clear out the database and the pickled report file.
         """
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
 
         try:
             os.remove(os.path.join(self.tempDir, "ProcReport.pkl"))
@@ -139,8 +139,6 @@ class ReportIntegrationTest(unittest.TestCase):
             os.rmdir(self.tempDir)
         except Exception as ex:
             pass
-
-        return
 
     def createConfig(self, workerThreads):
         """

--- a/test/python/WMCore_t/FwkJobReport_t/Report_t.py
+++ b/test/python/WMCore_t/FwkJobReport_t/Report_t.py
@@ -30,7 +30,7 @@ class ReportTest(unittest.TestCase):
         """
         self.testInit = TestInitCouchApp(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection(destroyAllDatabase = True)
+        self.testInit.setDatabaseConnection()
         self.testInit.setupCouch("report_t/fwjrs", "FWJRDump")
 
         self.xmlPath = os.path.join(getTestBase(),
@@ -49,7 +49,6 @@ class ReportTest(unittest.TestCase):
                                                    "WMCore_t/FwkJobReport_t/CMSSWPileup.xml")
 
         self.testDir = self.testInit.generateWorkDir()
-        return
 
     def tearDown(self):
         """
@@ -58,9 +57,7 @@ class ReportTest(unittest.TestCase):
         Cleanup the databases.
         """
         self.testInit.tearDownCouch()
-        self.testInit.clearDatabase()
         self.testInit.delWorkDir()
-        return
 
     def verifyInputData(self, report):
         """

--- a/test/python/WMCore_t/JobSplitting_t/Harvest_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/Harvest_t.py
@@ -40,8 +40,8 @@ class HarvestTest(unittest.TestCase):
         """
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
-
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS"])
 
         self.splitterFactory = SplitterFactory(package = "WMCore.JobSplitting")
@@ -81,17 +81,13 @@ class HarvestTest(unittest.TestCase):
         self.subscription1.create()
         self.configFile = EmulatorSetup.setupWMAgentConfig()
 
-        return
-
     def tearDown(self):
         """
         _tearDown_
 
         """
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
         EmulatorSetup.deleteConfig(self.configFile)
-
-        return
 
     def getConfig(self):
         """

--- a/test/python/WMCore_t/JobStateMachine_t/ChangeState_t.py
+++ b/test/python/WMCore_t/JobStateMachine_t/ChangeState_t.py
@@ -44,7 +44,8 @@ class TestChangeState(unittest.TestCase):
         self.transitions = Transitions()
         self.testInit = TestInitCouchApp(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setupCouch("changestate_t/jobs", "JobDump")
         self.testInit.setupCouch("changestate_t/fwjrs", "FWJRDump")
         self.testInit.setupCouch("job_summary", "WMStats")
@@ -61,7 +62,6 @@ class TestChangeState(unittest.TestCase):
         self.couchServer = CouchServer(dburl = couchurl)
         self.config = self.testInit.getConfiguration()
         self.taskName = "/TestWorkflow/Task"
-        return
 
     def tearDown(self):
         """
@@ -69,9 +69,8 @@ class TestChangeState(unittest.TestCase):
 
         Cleanup the databases.
         """
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
         self.testInit.tearDownCouch()
-        return
 
     def testCheck(self):
         """

--- a/test/python/WMCore_t/JobStateMachine_t/Couchapp_t.py
+++ b/test/python/WMCore_t/JobStateMachine_t/Couchapp_t.py
@@ -37,7 +37,8 @@ class CouchappTest(unittest.TestCase):
 
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
         self.databaseName = "couchapp_t_0"
@@ -64,16 +65,12 @@ class CouchappTest(unittest.TestCase):
         # Create testDir
         self.testDir = self.testInit.generateWorkDir()
 
-        return
-
     def tearDown(self):
 
-        self.testInit.clearDatabase(modules = ["WMCore.WMBS"])
+        self.testInit.destroyDatabase(self.testDB, modules = ["WMCore.WMBS"])
         self.testInit.tearDownCouch()
         self.testInit.delWorkDir()
         #self.testInit.tearDownCouch()
-        return
-
 
     def createWorkload(self, workloadName = 'Test', emulator = True):
         """

--- a/test/python/WMCore_t/Misc_t/Config_t.py
+++ b/test/python/WMCore_t/Misc_t/Config_t.py
@@ -50,7 +50,8 @@ class ConfigTest(unittest.TestCase):
         """
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection(destroyAllDatabase = True)
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS",
                                                  "WMComponent.DBSBuffer.Database",
                                                  'WMCore.ResourceControl',
@@ -73,7 +74,7 @@ class ConfigTest(unittest.TestCase):
 
         Tear things down and go home
         """
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
         self.testInit.tearDownCouch()
         return
 

--- a/test/python/WMCore_t/Misc_t/WMAgent_t.py
+++ b/test/python/WMCore_t/Misc_t/WMAgent_t.py
@@ -108,7 +108,8 @@ class WMAgentTest(unittest.TestCase):
 
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS",'WMCore.MsgService',
                                                  'WMCore.ResourceControl', 'WMCore.ThreadPool',
                                                  'WMCore.Agent.Database'],
@@ -148,26 +149,15 @@ class WMAgentTest(unittest.TestCase):
 
         self.configFile = EmulatorSetup.setupWMAgentConfig()
 
-        return
-
-
     def tearDown(self):
         """
         _tearDown_
 
         Tear down everything and go home.
         """
-
-        self.testInit.clearDatabase()
-
+        self.testInit.destroyDatabase(self.testDB)
         self.testInit.delWorkDir()
-        
         EmulatorSetup.deleteConfig(self.configFile)
-
-        return
-
-
-
 
     def createTestWorkload(self, workloadName = 'Test', emulator = True):
         """

--- a/test/python/WMCore_t/ProcessPool_t/ProcessPool_t.py
+++ b/test/python/WMCore_t/ProcessPool_t/ProcessPool_t.py
@@ -18,18 +18,17 @@ class ProcessPoolTest(unittest.TestCase):
         """
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection(destroyAllDatabase = True)
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.Agent.Database"],
                                 useDefault = False)
-        return
 
     def tearDown(self):
         """
         _tearDown_
 
         """
-        self.testInit.clearDatabase()
-        return
+        self.testInit.destroyDatabase(self.testDB)
 
     def testA_ProcessPool(self):
         """

--- a/test/python/WMCore_t/REST_t/Api_t.py
+++ b/test/python/WMCore_t/REST_t/Api_t.py
@@ -255,12 +255,12 @@ def load_server(engine):
 
 def start_server(engine):
     webtest.WebCase.PORT = PORT
-    cherrypy.log.screen = True
+#    cherrypy.log.screen = True
     engine.start()
     engine.block()
 
 def stop_server(proc, engine):
-    cherrypy.log.screen = True
+#    cherrypy.log.screen = True
     engine.stop()
     proc.terminate()
 

--- a/test/python/WMCore_t/REST_t/Daemon_t.py
+++ b/test/python/WMCore_t/REST_t/Daemon_t.py
@@ -120,12 +120,12 @@ def load_server(engine):
 
 def start_server(engine):
     webtest.WebCase.PORT = PORT
-    cherrypy.log.screen = True
+#    cherrypy.log.screen = True
     engine.start()
     engine.block()
 
 def stop_server(proc, engine):
-    cherrypy.log.screen = True
+#    cherrypy.log.screen = True
     engine.stop()
     proc.terminate()
 

--- a/test/python/WMCore_t/REST_t/Simple_t.py
+++ b/test/python/WMCore_t/REST_t/Simple_t.py
@@ -68,12 +68,12 @@ def load_server(engine):
 
 def start_server(engine):
     webtest.WebCase.PORT = PORT
-    cherrypy.log.screen = True
+#    cherrypy.log.screen = True
     engine.start()
     engine.block()
 
 def stop_server(proc, engine):
-    cherrypy.log.screen = True
+#    cherrypy.log.screen = True
     engine.stop()
     proc.terminate()
 

--- a/test/python/WMCore_t/ResourceControl_t/ResourceControl_t.py
+++ b/test/python/WMCore_t/ResourceControl_t/ResourceControl_t.py
@@ -40,7 +40,8 @@ class ResourceControlTest(unittest.TestCase):
 
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS",
                                                  "WMCore.ResourceControl",
                                                  "WMCore.BossAir"],
@@ -61,7 +62,6 @@ class ResourceControlTest(unittest.TestCase):
         self.insertState.execute(states)
 
         self.tempDir = self.testInit.generateWorkDir()
-        return
 
     def tearDown(self):
         """
@@ -70,8 +70,7 @@ class ResourceControlTest(unittest.TestCase):
         Clear the schema.
         """
         EmulatorHelper.resetEmulators()
-        self.testInit.clearDatabase()
-        return
+        self.testInit.destroyDatabase(self.testDB)
 
     def createJobs(self):
         """

--- a/test/python/WMCore_t/Services_t/Service_t.py
+++ b/test/python/WMCore_t/Services_t/Service_t.py
@@ -88,11 +88,6 @@ class ServiceTest(unittest.TestCase):
         #shutil.rmtree(self.cache_path, ignore_errors = True)
         self.testInit.delWorkDir()
 
-        if self._exc_info()[0] == None:
-            self.logger.info('test "%s" passed' % testname)
-        else:
-            self.logger.info('test "%s" failed' % testname)
-
     def testClear(self):
         """
         Populate the cache, and then check that it's deleted

--- a/test/python/WMCore_t/ThreadPool_t/ThreadPool_t.py
+++ b/test/python/WMCore_t/ThreadPool_t/ThreadPool_t.py
@@ -39,10 +39,9 @@ class ThreadPoolTest(unittest.TestCase):
 
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema()
-
-
 
     def tearDown(self):
         """
@@ -50,7 +49,7 @@ class ThreadPoolTest(unittest.TestCase):
         """
         # FIXME: this might not work if your not using socket.
 
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
 
     def testA(self):
         """

--- a/test/python/WMCore_t/WMBS_t/CursorLeak_t.py
+++ b/test/python/WMCore_t/WMBS_t/CursorLeak_t.py
@@ -38,7 +38,8 @@ class CursorLeakTest(unittest.TestCase):
 
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
 
@@ -51,15 +52,13 @@ class CursorLeakTest(unittest.TestCase):
         locationAction.execute(siteName = "se1.cern.ch")
         locationAction.execute(siteName = "se1.fnal.gov")
 
-        return
-
     def tearDown(self):
         """
         _tearDown_
 
         Drop all the WMBS tables.
         """
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
 
     def testCursor(self):
         """

--- a/test/python/WMCore_t/WMBS_t/File_t.py
+++ b/test/python/WMCore_t/WMBS_t/File_t.py
@@ -32,7 +32,8 @@ class FileTest(unittest.TestCase):
 
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
 
@@ -45,16 +46,13 @@ class FileTest(unittest.TestCase):
         locationAction.execute(siteName = "site1", seName = "se1.cern.ch")
         locationAction.execute(siteName = "site2", seName = "se1.fnal.gov")
 
-        return
-
     def tearDown(self):
         """
         _tearDown_
 
         Drop all the WMBS tables.
         """
-        self.testInit.clearDatabase()
-        return
+        self.testInit.destroyDatabase(self.testDB)
 
     def testCreateDeleteExists(self):
         """

--- a/test/python/WMCore_t/WMBS_t/Fileset_t.py
+++ b/test/python/WMCore_t/WMBS_t/Fileset_t.py
@@ -35,7 +35,8 @@ class FilesetTest(unittest.TestCase):
         """
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
 
@@ -46,7 +47,6 @@ class FilesetTest(unittest.TestCase):
 
         locationAction = self.daofactory(classname = "Locations.New")
         locationAction.execute(siteName = "site1", seName = "goodse.cern.ch")
-        return
 
     def tearDown(self):
         """
@@ -54,7 +54,7 @@ class FilesetTest(unittest.TestCase):
 
         Drop all the WMBS tables.
         """
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
 
     def testCreateDeleteExists(self):
         """

--- a/test/python/WMCore_t/WMBS_t/JobGroup_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobGroup_t.py
@@ -44,7 +44,8 @@ class JobGroupTest(unittest.TestCase):
 
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
 
@@ -65,7 +66,7 @@ class JobGroupTest(unittest.TestCase):
 
         Drop all the WMBS tables.
         """
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
 
     def createTestJobGroup(self, commitFlag = True):
         """

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/EventAwareLumiBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/EventAwareLumiBased_t.py
@@ -40,7 +40,8 @@ class EventAwareLumiBasedTest(unittest.TestCase):
 
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
 
@@ -61,18 +62,13 @@ class EventAwareLumiBasedTest(unittest.TestCase):
                                   'memoryRequirement' : 2300,
                                   'sizePerEvent' : 400}
 
-        return
-
     def tearDown(self):
         """
         _tearDown_
 
         Clear out WMBS.
         """
-        self.testInit.clearDatabase()
-        return
-
-
+        self.testInit.destroyDatabase(self.testDB)
 
     def createSubscription(self, nFiles, lumisPerFile, twoSites = False, nEventsPerFile = 100):
         """

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/EventBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/EventBased_t.py
@@ -48,17 +48,13 @@ class EventBasedTest(unittest.TestCase):
                                   'memoryRequirement' : 2300,
                                   'sizePerEvent' : 400}
 
-        return
-
     def tearDown(self):
         """
         _tearDown_
 
         Clear out WMBS.
         """
-        self.testInit.clearDatabase()
         self.testInit.tearDownCouch()
-        return
 
     def populateWMBS(self):
         """

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/FileBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/FileBased_t.py
@@ -42,7 +42,8 @@ class FileBasedTest(unittest.TestCase):
         """
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
 
@@ -115,7 +116,6 @@ class FileBasedTest(unittest.TestCase):
         self.performanceParams = {'timePerEvent' : 12,
                                   'memoryRequirement' : 2300,
                                   'sizePerEvent' : 400}
-        return
 
     def tearDown(self):
         """
@@ -123,8 +123,7 @@ class FileBasedTest(unittest.TestCase):
 
         Clear out WMBS.
         """
-        self.testInit.clearDatabase()
-        return
+        self.testInit.destroyDatabase(self.testDB)
 
     def createLargeFileBlock(self):
         """

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/FixedDelay_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/FixedDelay_t.py
@@ -33,7 +33,8 @@ class FixedDelayTest(unittest.TestCase):
         """
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
 
@@ -104,7 +105,6 @@ class FixedDelayTest(unittest.TestCase):
         self.singleFileSubscription.create()
         self.multipleLumiSubscription.create()
         self.singleLumiSubscription.create()
-        return
 
     def tearDown(self):
         """
@@ -112,8 +112,7 @@ class FixedDelayTest(unittest.TestCase):
 
         Nothing to do...
         """
-        self.testInit.clearDatabase()
-        return
+        self.testInit.destroyDatabase(self.testDB)
 
     def testNone(self):
         """

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/LumiBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/LumiBased_t.py
@@ -57,8 +57,8 @@ class LumiBasedTest(unittest.TestCase):
 
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
-        # self.testInit.clearDatabase(modules = ['WMCore.WMBS'])
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules=["WMCore.WMBS"], useDefault=False)
         self.testInit.setupCouch("lumi_t", "GroupUser", "ACDC")
 
@@ -76,16 +76,13 @@ class LumiBasedTest(unittest.TestCase):
                                   'memoryRequirement': 2300,
                                   'sizePerEvent': 400}
 
-        return
-
     def tearDown(self):
         """
         _tearDown_
 
         """
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
         self.testInit.tearDownCouch()
-        return
 
     def createSubscription(self, nFiles, lumisPerFile, twoSites=False, rand=False):
         """

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/MinFileBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/MinFileBased_t.py
@@ -41,7 +41,8 @@ class FileBasedTest(unittest.TestCase):
         """
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
 
@@ -56,18 +57,13 @@ class FileBasedTest(unittest.TestCase):
             locationAction.execute(siteName = "site%i" % site,
                                    seName = "site%i.cern.ch" % site)
 
-        return
-
     def tearDown(self):
         """
         _tearDown_
 
         Clear out WMBS.
         """
-        self.testInit.clearDatabase(modules = ["WMCore.WMBS"])
-
-        return
-
+        self.testInit.destroyDatabase(self.testDB, modules = ["WMCore.WMBS"])
 
     def createTestSubscription(self, nFiles, nSites = 1, closeFileset = False):
         """

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/ParentlessMergeBySize_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/ParentlessMergeBySize_t.py
@@ -33,7 +33,8 @@ class ParentlessMergeBySizeTest(unittest.TestCase):
         """
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules=["WMCore.WMBS"],
                                 useDefault=False)
 
@@ -41,7 +42,6 @@ class ParentlessMergeBySizeTest(unittest.TestCase):
         self.daoFactory = DAOFactory(package="WMCore.WMBS",
                                      logger=myThread.logger,
                                      dbinterface=myThread.dbi)
-        return
 
     def tearDown(self):
         """
@@ -49,8 +49,7 @@ class ParentlessMergeBySizeTest(unittest.TestCase):
 
         Clear out WMBS.
         """
-        self.testInit.clearDatabase()
-        return
+        self.testInit.destroyDatabase(self.testDB)
 
     def stuffWMBS(self):
         """

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/RunBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/RunBased_t.py
@@ -44,7 +44,8 @@ class EventBasedTest(unittest.TestCase):
 
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
 
@@ -131,17 +132,13 @@ class EventBasedTest(unittest.TestCase):
         self.singleRunSubscription.create()
         self.singleRunMultipleLumiSubscription.create()
 
-
-        return
-
     def tearDown(self):
         """
         _tearDown_
 
         Tear down WMBS architechture.
         """
-        self.testInit.clearDatabase()
-        return
+        self.testInit.destroyDatabase(self.testDB)
 
     def testExactRuns(self):
         """

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/SiblingProcessingBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/SiblingProcessingBased_t.py
@@ -32,7 +32,8 @@ class SiblingProcessingBasedTest(unittest.TestCase):
         """
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
 
@@ -128,7 +129,6 @@ class SiblingProcessingBasedTest(unittest.TestCase):
                                                 split_algo = "SiblingProcessingBased",
                                                 type = "Cleanup")
         self.deleteSubscriptionB.create()
-        return
 
     def tearDown(self):
         """
@@ -136,8 +136,7 @@ class SiblingProcessingBasedTest(unittest.TestCase):
 
         Clear out WMBS.
         """
-        self.testInit.clearDatabase()
-        return
+        self.testInit.destroyDatabase(self.testDB)
 
     def testSiblingProcessing(self):
         """

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/SizeBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/SizeBased_t.py
@@ -37,7 +37,8 @@ class SizeBasedTest(unittest.TestCase):
         """
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
 
@@ -100,7 +101,6 @@ class SizeBasedTest(unittest.TestCase):
                                                      split_algo = "SizeBased",
                                                      type = "Processing")
         self.multipleSiteSubscription.create()
-        return
 
     def tearDown(self):
         """
@@ -108,8 +108,7 @@ class SizeBasedTest(unittest.TestCase):
 
         Clear out WMBS.
         """
-        self.testInit.clearDatabase()
-        return
+        self.testInit.destroyDatabase(self.testDB)
 
     def testExactEvents(self):
         """

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/SplitFileBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/SplitFileBased_t.py
@@ -39,7 +39,8 @@ class SplitFileBasedTest(unittest.TestCase):
         """
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
 
@@ -48,16 +49,13 @@ class SplitFileBasedTest(unittest.TestCase):
                                      logger = myThread.logger,
                                      dbinterface = myThread.dbi)
 
-        return
-
     def tearDown(self):
         """
         _tearDown_
 
         Clear out WMBS.
         """
-        self.testInit.clearDatabase()
-        return
+        self.testInit.destroyDatabase(self.testDB)
 
     def stuffWMBS(self):
         """

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/WMBSMergeBySize_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/WMBSMergeBySize_t.py
@@ -30,7 +30,8 @@ class WMBSMergeBySize(unittest.TestCase):
         """
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
 
@@ -38,7 +39,6 @@ class WMBSMergeBySize(unittest.TestCase):
         self.daoFactory = DAOFactory(package = "WMCore.WMBS",
                                      logger = myThread.logger,
                                      dbinterface = myThread.dbi)
-        return
 
     def tearDown(self):
         """
@@ -46,8 +46,7 @@ class WMBSMergeBySize(unittest.TestCase):
 
         Clear out WMBS.
         """
-        self.testInit.clearDatabase()
-        return
+        self.testInit.destroyDatabase(self.testDB)
 
     def stuffWMBS(self, injected = True):
         """

--- a/test/python/WMCore_t/WMBS_t/Job_t.py
+++ b/test/python/WMCore_t/WMBS_t/Job_t.py
@@ -40,7 +40,8 @@ class JobTest(unittest.TestCase):
         """
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
 
@@ -53,15 +54,13 @@ class JobTest(unittest.TestCase):
         locationNew.execute(siteName = "test.site.ch", seName = "setest.site.ch")
         locationNew.execute(siteName = "test2.site.ch", seName = "setest2.site.ch")
 
-        return
-
     def tearDown(self):
         """
         _tearDown_
 
         Drop all the WMBS tables.
         """
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
 
     def createTestJob(self, subscriptionType = "Merge"):
         """

--- a/test/python/WMCore_t/WMBS_t/Locations_t.py
+++ b/test/python/WMCore_t/WMBS_t/Locations_t.py
@@ -24,10 +24,10 @@ class LocationsTest(unittest.TestCase):
         """
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
-        return
 
     def tearDown(self):
         """
@@ -35,8 +35,7 @@ class LocationsTest(unittest.TestCase):
 
         Drop all the WMBS tables.
         """
-        self.testInit.clearDatabase()
-        return
+        self.testInit.destroyDatabase(self.testDB)
 
     def testCreateDeleteList(self):
         """

--- a/test/python/WMCore_t/WMBS_t/Monitoring_t.py
+++ b/test/python/WMCore_t/WMBS_t/Monitoring_t.py
@@ -34,7 +34,8 @@ class MonitoringTest(unittest.TestCase):
         """
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
 
@@ -42,7 +43,6 @@ class MonitoringTest(unittest.TestCase):
         self.daoFactory = DAOFactory(package="WMCore.WMBS",
                                      logger = myThread.logger,
                                      dbinterface = myThread.dbi)
-        return
 
     def tearDown(self):
         """
@@ -50,8 +50,7 @@ class MonitoringTest(unittest.TestCase):
 
         Drop all the WMBS tables.
         """
-        self.testInit.clearDatabase()
-        return
+        self.testInit.destroyDatabase(self.testDB)
 
     def testListJobStates(self):
         """

--- a/test/python/WMCore_t/WMBS_t/Subscription_t.py
+++ b/test/python/WMCore_t/WMBS_t/Subscription_t.py
@@ -35,7 +35,8 @@ class SubscriptionTest(unittest.TestCase):
         """
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
 
@@ -52,15 +53,13 @@ class SubscriptionTest(unittest.TestCase):
         stateDAO = self.daofactory(classname = "Jobs.GetStateID")
         self.stateID = stateDAO.execute('cleanout')
 
-        return
-
     def tearDown(self):
         """
         _tearDown_
 
         Drop all the WMBS tables.
         """
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
 
     def createSubscriptionWithFileABC(self):
         """

--- a/test/python/WMCore_t/WMBS_t/Workflow_t.py
+++ b/test/python/WMCore_t/WMBS_t/Workflow_t.py
@@ -26,10 +26,10 @@ class WorkflowTest(unittest.TestCase):
         """
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
-        return
 
     def tearDown(self):
         """
@@ -37,8 +37,7 @@ class WorkflowTest(unittest.TestCase):
 
         Drop all the WMBS tables.
         """
-        self.testInit.clearDatabase()
-        return
+        self.testInit.destroyDatabase(self.testDB)
 
     def testCreateDeleteExists(self):
         """

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Analysis_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Analysis_t.py
@@ -36,7 +36,6 @@ class AnalysisTest(unittest.TestCase):
         couchServer = CouchServer(os.environ["COUCHURL"])
         self.configDatabase = couchServer.connectDatabase("analysis_t")
         self.testDir = self.testInit.generateWorkDir()
-        return
 
     def injectAnalysisConfig(self):
         """
@@ -70,10 +69,7 @@ class AnalysisTest(unittest.TestCase):
         Clear out the database.
         """
         self.testInit.tearDownCouch()
-        self.testInit.clearDatabase()
         self.testInit.delWorkDir()
-        return
-
 
     def testAnalysis(self):
         """

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/DQMHarvest_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/DQMHarvest_t.py
@@ -45,8 +45,6 @@ class DQMHarvestTests(unittest.TestCase):
         self.workload = None
         self.jsonTemplate = getTestFile('data/ReqMgr/requests/DMWM/DQMHarvesting.json')
 
-        return
-
     def tearDown(self):
         """
         _tearDown_
@@ -54,9 +52,7 @@ class DQMHarvestTests(unittest.TestCase):
         Clear out the database.
         """
         self.testInit.tearDownCouch()
-        self.testInit.clearDatabase()
         self.testInit.delWorkDir()
-        return
 
     def injectDQMHarvestConfig(self):
         """

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/MonteCarloFromGEN_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/MonteCarloFromGEN_t.py
@@ -42,7 +42,6 @@ class MonteCarloFromGENTest(unittest.TestCase):
 
         Clear out the database.
         """
-        self.testInit.clearDatabase()
         self.testInit.tearDownCouch()
         self.testInit.delWorkDir()
         return

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/MonteCarlo_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/MonteCarlo_t.py
@@ -46,7 +46,6 @@ class MonteCarloTest(unittest.TestCase):
         Clear out the database.
         """
         self.testInit.tearDownCouch()
-        self.testInit.clearDatabase()
         self.testInit.delWorkDir()
         EmulatorHelper.resetEmulators()
         return

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/PrivateMC_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/PrivateMC_t.py
@@ -63,7 +63,6 @@ class PrivateMCTest(unittest.TestCase):
         Clear out the database.
         """
         self.testInit.tearDownCouch()
-        self.testInit.clearDatabase()
         self.testInit.delWorkDir()
         return
 

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/PromptReco_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/PromptReco_t.py
@@ -47,7 +47,6 @@ class PromptRecoTest(unittest.TestCase):
         Clear out the database.
         """
         self.testInit.tearDownCouch()
-        self.testInit.clearDatabase()
         self.testInit.delWorkDir()
         return
 

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/ReDigi_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/ReDigi_t.py
@@ -98,7 +98,6 @@ class ReDigiTest(unittest.TestCase):
         Clear out the database.
         """
         self.testInit.tearDownCouch()
-        self.testInit.clearDatabase()
         self.testInit.delWorkDir()
         EmulatorHelper.resetEmulators()
         return

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/ReReco_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/ReReco_t.py
@@ -42,7 +42,6 @@ class ReRecoTest(unittest.TestCase):
         Clear out the database.
         """
         self.testInit.tearDownCouch()
-        self.testInit.clearDatabase()
         self.testInit.delWorkDir()
         return
 

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
@@ -132,7 +132,6 @@ class StepChainTests(unittest.TestCase):
         Clear out the database.
         """
         self.testInit.tearDownCouch()
-        self.testInit.clearDatabase()
         self.testInit.delWorkDir()
         return
 

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StoreResults_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StoreResults_t.py
@@ -23,11 +23,11 @@ class StoreResultsTest(unittest.TestCase):
         """
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
         self.testDir = self.testInit.generateWorkDir()
-        return
 
     def tearDown(self):
         """
@@ -35,9 +35,8 @@ class StoreResultsTest(unittest.TestCase):
 
         Clear out the database.
         """
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
         self.testInit.delWorkDir()
-        return
 
     def testStoreResults(self):
         """

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
@@ -151,7 +151,8 @@ class TaskChainTests(unittest.TestCase):
         """
         self.testInit = TestInitCouchApp(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setupCouch("taskchain_t", "ConfigCache")
         self.testInit.setSchema(customModules = ["WMCore.WMBS"],
                                 useDefault = False)
@@ -162,8 +163,6 @@ class TaskChainTests(unittest.TestCase):
         self.workload = None
 
         self.differentNCores = getTestFile('data/ReqMgr/requests/Integration/TaskChain_Task_Multicore.json')
-        return
-
 
     def tearDown(self):
         """
@@ -172,10 +171,9 @@ class TaskChainTests(unittest.TestCase):
         Clear out the database.
 
         """
+        self.testInit.destroyDatabase(self.testDB)
         self.testInit.tearDownCouch()
-        self.testInit.clearDatabase()
         self.testInit.delWorkDir()
-        return
 
     def testGeneratorWorkflow(self):
         """

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Fetchers_t/PileupFetcher_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Fetchers_t/PileupFetcher_t.py
@@ -43,7 +43,6 @@ class PileupFetcherTest(unittest.TestCase):
         Clear out the database.
         """
         self.testInit.tearDownCouch()
-        self.testInit.clearDatabase()
         self.testInit.delWorkDir()
         EmulatorHelper.resetEmulators()
 

--- a/test/python/WMCore_t/WorkQueue_t/WMBSHelper_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WMBSHelper_t.py
@@ -77,7 +77,6 @@ class WMBSHelperTest(unittest.TestCase):
         self.daoFactory = DAOFactory(package = "WMCore.WMBS",
                                      logger = threading.currentThread().logger,
                                      dbinterface = threading.currentThread().dbi)
-        return
 
     def tearDown(self):
         """
@@ -85,10 +84,8 @@ class WMBSHelperTest(unittest.TestCase):
 
         Clear out the database.
         """
-        self.testInit.clearDatabase()
         self.testInit.tearDownCouch()
         self.testInit.delWorkDir()
-        return
 
     def setupForKillTest(self, baAPI = None):
         """

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueueTestCase.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueueTestCase.py
@@ -42,7 +42,8 @@ class WorkQueueTestCase(unittest.TestCase):
         self.setSchema()
         self.testInit = TestInit('WorkQueueTest')
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testDB = 'unittest_%s' % self.__class__.__name__
+        self.testInit.prepareDatabase(self.testDB)
         self.testInit.setSchema(customModules = self.schema,
                                 useDefault = False)
         self.testInit.setupCouch(self.queueDB, *self.couchApps)
@@ -73,5 +74,5 @@ class WorkQueueTestCase(unittest.TestCase):
         """
         #self.localCouchMonitor.deleteReplicatorDocs()
         self.testInit.tearDownCouch()
-        self.testInit.clearDatabase()
+        self.testInit.destroyDatabase(self.testDB)
         self.testInit.delWorkDir()


### PR DESCRIPTION
Major upgrade: remove reallyDeleteMyDatabaseAfterEveryTest bot option and replace it with setUp/tearDown approach to setup/delete unittest databases for every unit test; re-factor DBCore class to use generators and be compatible with WMCore functionality; re-factor ResultSet to keep data instead of resultproxy objects; close all resultproxy objects once data is read from them; change logic of processData to use transaction (it as reversed); adjust all unit tests to create its own database for their test purposes
