### PR TITLE
Update groups:roles authorized

### DIFF
--- a/src/couchapps/LogDB/validate_doc_update.js
+++ b/src/couchapps/LogDB/validate_doc_update.js
@@ -40,7 +40,6 @@ function(newDoc, oldDoc, userCtx) {
    // The following rule aplies for all operation types
    var allowed = isGlobalAdm || matchesRole("admin", "group:reqmgr")
                              || matchesRole("web-service", "group:facops")
-                             || matchesRole("production-manager","group:dataops")
                              || matchesRole("t0-operator","group:dataops")
                              || matchesRole("production-operator", "group:dataops");
    

--- a/src/couchapps/ReqMgr/validate_doc_update.js
+++ b/src/couchapps/ReqMgr/validate_doc_update.js
@@ -39,7 +39,9 @@ function(newDoc, oldDoc, userCtx) {
 
    // The following rule aplies for all operation types
    var allowed = isGlobalAdm || matchesRole("admin", "group:reqmgr")
+                             || matchesRole("data-manager", "group:reqmgr")
                              || matchesRole("web-service", "group:facops")
+                             || matchesRole("production-operator", "group:dataops")
                              || matchesRole("production-operator", "group:dataops");
    
    // Throw if user not validated

--- a/src/couchapps/WMStats/validate_doc_update.js
+++ b/src/couchapps/WMStats/validate_doc_update.js
@@ -41,10 +41,9 @@ function(newDoc, oldDoc, userCtx) {
    // Authorization rules for Myapp DB
 
    // The following rule aplies for all operation types
-   var allowed = isGlobalAdm || matchesRole("production-operator","group:dataops")
-                             || matchesRole("production-manager","group:dataops")
+   var allowed = isGlobalAdm || matchesRole("web-service","group:facops")
                              || matchesRole("t0-operator","group:dataops")
-                             || matchesRole("web-service","group:facops");
+                             || matchesRole("production-operator","group:dataops");
 
    // Throw if user not validated
    if(!allowed) {

--- a/src/couchapps/WorkQueue/validate_doc_update.js
+++ b/src/couchapps/WorkQueue/validate_doc_update.js
@@ -15,7 +15,6 @@ function(newDoc, oldDoc, userCtx) {
     // Either Developer or DataOps Operator/Manager required
     if (validation.hasGroupRole("dataops", "developer") ||
         validation.hasGroupRole("dataops", "production-operator") ||
-        validation.hasGroupRole("dataops", "production-manager") ||
         validation.hasGroupRole("facops", "web-service")) {
         return true;
     }

--- a/src/couchapps/WorkloadSummary/validate_doc_update.js
+++ b/src/couchapps/WorkloadSummary/validate_doc_update.js
@@ -16,8 +16,7 @@ function(newDoc, oldDoc, userCtx) {
 
     // Either Developer or DataOps Operator/Manager required
     if (validation.hasGroupRole("dataops", "developer") ||
-        validation.hasGroupRole("dataops", "production-operator") ||
-        validation.hasGroupRole("dataops", "production-manager")) {
+        validation.hasGroupRole("dataops", "production-operator") {
         return true;
     }
 


### PR DESCRIPTION
Not sure we really care about these changes, since it's six of one and half a dozen of the other :-)

I removed dataops:production-manager role, since nobody has such role in SiteDB right now.
and added reqmgr:data-manager with the goal to start moving PPD/PdmV folks into this group instead of giving them reqmgr:admin role. Right now they seem to have exactly the same privileges, but at least we can start better organizing people in sitedb.

@ticoann what do you think? No hurry, it's not urgent
