### PR TITLE
Enable double harvesting upload in the json templates

### DIFF
--- a/test/data/ReqMgr/requests/DMWM/DQMHarvesting.json
+++ b/test/data/ReqMgr/requests/DMWM/DQMHarvesting.json
@@ -7,7 +7,7 @@
     "CMSSWVersion": "CMSSW_7_3_1_patch1",
     "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb",
     "DbsUrl": "https://cmsweb.cern.ch/dbs/prod/global/DBSReader",
-    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev;https://cmsweb.cern.ch/dqm/dev",
+    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev;https://cmsweb.cern.ch/dqm/relval-test",
     "DQMConfigCacheID": "e554f238a2ee8bb969248a343f6195d1",
     "DQMHarvestUnit": "byRun",
     "InputDataset": "/MinimumBias/CMSSW_7_3_1_patch1-GR_R_73_V0A_RelVal_run2010A-v1/DQMIO",

--- a/test/data/ReqMgr/requests/DMWM/TaskChain_Data.json
+++ b/test/data/ReqMgr/requests/DMWM/TaskChain_Data.json
@@ -7,7 +7,7 @@
     "CMSSWVersion": "CMSSW_7_0_0_pre11",
     "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb",
     "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader",
-    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev",
+    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev;https://cmsweb.cern.ch/dqm/relval-test",
     "EnableHarvesting": "True",
     "DQMConfigCacheID": "5f4811e9ccd63d563cd62572350e588b",
     "GlobalTag": "GR_R_62_V3::All",

--- a/test/data/ReqMgr/requests/Integration/TaskChainH130GGgluonfusion_PU.json
+++ b/test/data/ReqMgr/requests/Integration/TaskChainH130GGgluonfusion_PU.json
@@ -6,7 +6,7 @@
     "Campaign": "Campaign-OVERRIDE-ME",
     "ConfigCacheUrl": "https://cmsweb-testbed.cern.ch/couchdb",
     "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader",
-    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev",
+    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev;https://cmsweb.cern.ch/dqm/relval-test",
     "DQMConfigCacheID": "564b9ff125f090d3385206a0b492bddf",
     "EnableHarvesting": "True",
     "GlobalTag": "START70_V4::All",

--- a/test/data/ReqMgr/requests/Integration/TaskChainPyquenZeemumuJets_PU.json
+++ b/test/data/ReqMgr/requests/Integration/TaskChainPyquenZeemumuJets_PU.json
@@ -6,7 +6,7 @@
     "Campaign": "Campaign-OVERRIDE-ME",
     "ConfigCacheUrl": "https://cmsweb-testbed.cern.ch/couchdb",
     "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader",
-    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev",
+    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev;https://cmsweb.cern.ch/dqm/relval-test",
     "DQMConfigCacheID": "564b9ff125f090d3385206a0b48e6746",
     "EnableHarvesting": "True",
     "GlobalTag": "STARTHI70_V5::All",

--- a/test/data/ReqMgr/requests/Integration/TaskChainRunJet2012C_multiRun.json
+++ b/test/data/ReqMgr/requests/Integration/TaskChainRunJet2012C_multiRun.json
@@ -7,7 +7,7 @@
     "CMSSWVersion": "CMSSW_7_2_0",
     "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb",
     "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader",
-    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev",
+    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev;https://cmsweb.cern.ch/dqm/relval-test",
     "EnableHarvesting": "True",
     "DQMConfigCacheID": "cf0f08f510b46c89e73b3c1c3624d5d4",
     "DQMHarvestUnit": "multiRun",

--- a/test/data/ReqMgr/requests/Integration/TaskChainSingleMuPt100FastSim.json
+++ b/test/data/ReqMgr/requests/Integration/TaskChainSingleMuPt100FastSim.json
@@ -6,7 +6,7 @@
     "Campaign": "Campaign-OVERRIDE-ME",
     "ConfigCacheUrl": "https://cmsweb-testbed.cern.ch/couchdb",
     "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader",
-    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev",
+    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev;https://cmsweb.cern.ch/dqm/relval-test",
     "DQMConfigCacheID": "6abb3e122e8727528767e45494098be1",
     "EnableHarvesting": "True",
     "GlobalTag": "START70_V4::All",

--- a/test/data/ReqMgr/requests/Integration/TaskChainTTbar.json
+++ b/test/data/ReqMgr/requests/Integration/TaskChainTTbar.json
@@ -6,7 +6,7 @@
     "Campaign": "Campaign-OVERRIDE-ME",
     "ConfigCacheUrl": "https://cmsweb-testbed.cern.ch/couchdb",
     "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader",
-    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev",
+    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev;https://cmsweb.cern.ch/dqm/relval-test",
     "DQMConfigCacheID": "6abb3e122e8727528767e4549409f17f",
     "EnableHarvesting": "True",
     "GlobalTag": "START70_V4::All",

--- a/test/data/ReqMgr/requests/Integration/TaskChainZJetsLNu_LHE.json
+++ b/test/data/ReqMgr/requests/Integration/TaskChainZJetsLNu_LHE.json
@@ -6,7 +6,7 @@
     "Campaign": "Campaign-OVERRIDE-ME",
     "ConfigCacheUrl": "https://cmsweb-testbed.cern.ch/couchdb",
     "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader",
-    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev",
+    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev;https://cmsweb.cern.ch/dqm/relval-test",
     "DQMConfigCacheID": "6abb3e122e8727528767e45494098be1",
     "EnableHarvesting": "True",
     "GlobalTag": "START70_V4::All",

--- a/test/data/ReqMgr/requests/Integration/TaskChainZTT_PU.json
+++ b/test/data/ReqMgr/requests/Integration/TaskChainZTT_PU.json
@@ -7,7 +7,7 @@
     "CMSSWVersion": "CMSSW_7_0_0_pre11",
     "ConfigCacheUrl": "https://cmsweb-testbed.cern.ch/couchdb",
     "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader",
-    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev",
+    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev;https://cmsweb.cern.ch/dqm/relval-test",
     "DQMConfigCacheID": "564b9ff125f090d3385206a0b48e41ac",
     "EnableHarvesting": "True",
     "GlobalTag": "START70_V4::All",

--- a/test/data/ReqMgr/requests/Integration/TaskChain_Data_LumiMask.json
+++ b/test/data/ReqMgr/requests/Integration/TaskChain_Data_LumiMask.json
@@ -7,7 +7,7 @@
     "CMSSWVersion": "CMSSW_7_0_0_pre11",
     "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb",
     "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader",
-    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev",
+    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev;https://cmsweb.cern.ch/dqm/relval-test",
     "EnableHarvesting": "True",
     "DQMConfigCacheID": "5f4811e9ccd63d563cd62572350e588b",
     "GlobalTag": "GR_R_62_V3::All",

--- a/test/data/ReqMgr/requests/Integration/TaskChain_Task_Multicore.json
+++ b/test/data/ReqMgr/requests/Integration/TaskChain_Task_Multicore.json
@@ -7,7 +7,7 @@
     "CMSSWVersion": "CMSSW_7_4_0_pre8",
     "ConfigCacheUrl": "https://cmsweb-testbed.cern.ch/couchdb",
     "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader",
-    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev",
+    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev;https://cmsweb.cern.ch/dqm/relval-test",
     "EnableHarvesting": "True",
     "DQMConfigCacheID": "0d6d2c921e3ce552e8f513db7f91d75f",
     "GlobalTag": "GR_R_74_V8A",


### PR DESCRIPTION
Broen asked me to start uploading root files for both servers (including a new dedicated relval node) such that they can better validate and have reliable testing in the new Guis.
