### PR TITLE
simplify/rewrite dbs3upload

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/MySQL/FindDASToUpload.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/FindDASToUpload.py
@@ -17,75 +17,44 @@ class FindDASToUpload(DBFormatter):
     Find Uploadable DAS
 
     """
-    sql = """SELECT DISTINCT dbsbuffer_algo_dataset_assoc.dataset_id AS dataset,
-                             dbsbuffer_dataset.Path as Path, dbsbuffer_algo_dataset_assoc.algo_id as Algo,
-                             dbsbuffer_algo_dataset_assoc.in_dbs as in_dbs,
-                             dbsbuffer_algo_dataset_assoc.id AS das_id,
-                             dbsbuffer_dataset.acquisition_era AS AcquisitionEra,
-                             dbsbuffer_dataset.processing_ver AS ProcessingVer,
-                             dbsbuffer_dataset.global_tag AS global_tag,
-                             dbsbuffer_dataset.prep_id AS prep_id,
-                             dbsbuffer_algo.app_name AS ApplicationName,
-                             dbsbuffer_algo.app_ver AS ApplicationVersion,
-                             dbsbuffer_algo.app_fam AS ApplicationFamily,
-                             dbsbuffer_algo.PSet_Hash as PSetHash,
-                             dbsbuffer_algo.config_content as PSetContent,
-                             dbsbuffer_algo.in_dbs AS algo_in_dbs
-             FROM dbsbuffer_algo_dataset_assoc
+    sql = """SELECT dbsbuffer_dataset.path AS datasetpath,
+                    dbsbuffer_dataset.acquisition_era AS acquera,
+                    dbsbuffer_dataset.processing_ver AS procver
+             FROM dbsbuffer_file
+             INNER JOIN dbsbuffer_algo_dataset_assoc ON
+               dbsbuffer_algo_dataset_assoc.id = dbsbuffer_file.dataset_algo
              INNER JOIN dbsbuffer_dataset ON
                dbsbuffer_dataset.id = dbsbuffer_algo_dataset_assoc.dataset_id
-             INNER JOIN dbsbuffer_algo ON
-               dbsbuffer_algo.id = dbsbuffer_algo_dataset_assoc.algo_id
-             WHERE EXISTS (SELECT id FROM dbsbuffer_file dbsfile
-                             WHERE dbsfile.dataset_algo = dbsbuffer_algo_dataset_assoc.id
-                             AND dbsfile.status = :status
-                             AND NOT EXISTS (SELECT id FROM dbsbuffer_file dbf2
-                                              INNER JOIN dbsbuffer_file_parent dbfp ON dbf2.id = dbfp.parent
-                                              WHERE dbf2.status = 'NOTUPLOADED'
-                                              AND dbfp.child = dbsfile.id))
+             LEFT OUTER JOIN dbsbuffer_file_parent ON
+               dbsbuffer_file_parent.child = dbsbuffer_file.id
+             LEFT OUTER JOIN dbsbuffer_file parent_file ON
+               parent_file.id = dbsbuffer_file_parent.parent AND
+               parent_file.status = 'NOTUPLOADED'
+             WHERE dbsbuffer_file.status = 'NOTUPLOADED'
+             GROUP BY dbsbuffer_dataset.path,
+                      dbsbuffer_dataset.acquisition_era,
+                      dbsbuffer_dataset.processing_ver
+             HAVING COUNT(parent_file.id) = 0
              """
 
     def makeDAS(self, results):
-        ret=[]
-        for r in results:
-            entry={}
-            entry['Path']=r['path']
-            entry['DAS_ID'] = long(r['das_id'])
-            if not r['algo'] == None:
-                entry['Algo'] = int(r['algo'])
-            else:
-                entry['Algo'] = None
-            if not r['algo_in_dbs'] == None:
-                entry['AlgoInDBS'] = int(r['algo_in_dbs'])
-            else:
-                entry['AlgoInDBS'] = None
-            if not r['in_dbs'] == None:
-                entry['DASInDBS'] = int(r['in_dbs'])
-            else:
-                entry['DASInDBS'] = None
-            path = r['path']
-            entry['PrimaryDataset']     = path.split('/')[1]
-            entry['ProcessedDataset']   = path.split('/')[2]
-            entry['DataTier']           = path.split('/')[3]
-            entry['ApplicationName']    = r['applicationname']
-            entry['ApplicationVersion'] = r['applicationversion']
-            entry['ApplicationFamily']  = r['applicationfamily']
-            entry['PSetHash']           = r['psethash']
-            entry['PSetContent']        = r['psetcontent']
-            entry['Dataset']            = r['dataset']
-            entry['AcquisitionEra']     = r['acquisitionera']
-            if r["processingver"].count("-") == 1:
-                (junk, entry["ProcessingVer"]) = r["processingver"].split("-v")
-            else:
-                entry['ProcessingVer']      = r['processingver']
-                
-            entry['GlobalTag']          = r['global_tag']
-            entry['prep_id']          = r['prep_id']
-            ret.append(entry)
+        """
+        build the data structure we want to return
 
-        return ret
+        """
+        datasetalgos = []
+        for result in results:
+
+            # compatibility statement for old style proc ver (still needed ?)
+            if result['procver'].count("-") == 1:
+                result['procver'] = result['procver'].split("-v")[1]
+
+            datasetalgos.append( { 'DatasetPath' : result['datasetpath'],
+                                   'AcquisitionEra' : result['acquera'],
+                                   'ProcessingVer' : result['procver'] } )
+
+        return datasetalgos
 
     def execute(self, conn = None, transaction = False):
-        result = self.dbi.processData(self.sql, {"status": "NOTUPLOADED"},
-                                      conn = conn, transaction = transaction)
+        result = self.dbi.processData(self.sql, conn = conn, transaction = transaction)
         return self.makeDAS(self.formatDict(result))

--- a/src/python/WMComponent/DBS3Buffer/MySQL/LoadBlocks.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/LoadBlocks.py
@@ -8,32 +8,30 @@ MySQL implementation of LoadBlocks
 from WMCore.Database.DBFormatter import DBFormatter
 
 class LoadBlocks(DBFormatter):
-    sql = """SELECT DISTINCT dbb.blockname as blockname, dbb.create_time as create_time,
-                dbb.status AS status,
-                dbl.se_name AS location, dbf3.dataset_algo AS das,
-                dbw.name AS workflow
-              FROM dbsbuffer_block dbb
-              INNER JOIN dbsbuffer_file dbf3 ON
-                dbf3.block_id = dbb.id
-              INNER JOIN dbsbuffer_location dbl ON
-                dbl.id = dbb.location
-              INNER JOIN dbsbuffer_workflow dbw ON
-                dbw.id = dbf3.workflow
-              WHERE dbb.blockname = :blockname"""
+
+    sql = """SELECT dbsbuffer_block.blockname as blockname,
+                    dbsbuffer_block.create_time as create_time,
+                    dbsbuffer_block.status AS status,
+                    dbsbuffer_dataset.path AS datasetpath,
+                    dbsbuffer_location.se_name AS location
+              FROM dbsbuffer_block
+              INNER JOIN dbsbuffer_dataset ON
+                dbsbuffer_dataset.id = dbsbuffer_block.dataset_id
+              INNER JOIN dbsbuffer_location ON
+                dbsbuffer_location.id = dbsbuffer_block.location
+              WHERE dbsbuffer_block.blockname = :blockname
+              """
 
     def format(self, result):
+
         tmpList = self.formatDict(result)
         blockList = []
         for tmp in tmpList:
-            final = {}
-            final['block_name']       = tmp['blockname']
-            final['creation_date']    = tmp['create_time']
-            final['origin_site_name'] = tmp['location']
-            final['DatasetAlgo']      = tmp['das']
-            final['workflow']      = tmp['workflow']
-            final['status'] = tmp['status']
-                
-            blockList.append(final)
+            blockList.append( { 'block_name' : tmp['blockname'],
+                                'creation_date' : tmp['create_time'],
+                                'origin_site_name' : tmp['location'],
+                                'datasetpath' : tmp['datasetpath'],
+                                'status' : tmp['status'] } )
 
         return blockList
 

--- a/src/python/WMComponent/DBS3Buffer/MySQL/LoadFilesByBlock.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/LoadFilesByBlock.py
@@ -5,17 +5,13 @@ _LoadFilesByBlock_
 MySQL implementation of LoadFilesByBlock
 """
 
-
-
-
-import logging
-
 from WMComponent.DBS3Buffer.MySQL.LoadDBSFilesByDAS import LoadDBSFilesByDAS as MySQLLoadDBSFilesByDAS
 
 class LoadFilesByBlock(MySQLLoadDBSFilesByDAS):
     fileInfoSQL = """SELECT files.id AS id, files.lfn AS lfn, files.filesize AS filesize,
                     files.events AS events,
                     files.status AS status,
+                    dbsbuffer_workflow.name AS workflow,
                     dbsbuffer_algo.app_name AS app_name, dbsbuffer_algo.app_ver AS app_ver,
                     dbsbuffer_algo.app_fam AS app_fam, dbsbuffer_algo.pset_hash AS pset_hash,
                     dbsbuffer_algo.config_content, dbsbuffer_dataset.path AS dataset_path,

--- a/src/python/WMComponent/DBS3Buffer/Oracle/FindDASToUpload.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/FindDASToUpload.py
@@ -1,43 +1,11 @@
 #!/usr/bin/env python
-
 """
-This code should load the necessary information regarding
-dataset-algo combinations from the DBSBuffer.
+_FindDASToUpload_
 
-Oracle version
-
+Oracle version of DBS3Buffer.FindDASToUpload
 """
-
-
-
 
 from WMComponent.DBS3Buffer.MySQL.FindDASToUpload import FindDASToUpload as MySQLFindDASToUpload
 
-
 class FindDASToUpload(MySQLFindDASToUpload):
-    """
-    Find Uploadable DAS
-
-    """
-    sql = """SELECT das.dataset_id AS dataset, ds.Path as Path, das.algo_id as Algo, das.in_dbs as in_dbs,
-               das.id AS das_id,
-               ds.acquisition_era AS AcquisitionEra,
-               ds.processing_ver AS ProcessingVer,
-               ds.global_tag AS global_tag,
-               ds.prep_id AS prep_id,
-               da.app_name AS ApplicationName,
-               da.app_ver AS ApplicationVersion,
-               da.app_fam AS ApplicationFamily,
-               da.PSet_Hash as PSetHash,
-               da.config_content as PSetContent,
-               da.in_dbs AS algo_in_dbs
-             FROM dbsbuffer_algo_dataset_assoc das
-             INNER JOIN dbsbuffer_dataset ds ON ds.id = das.dataset_id
-             INNER JOIN dbsbuffer_algo da ON da.id = das.algo_id
-             WHERE EXISTS (SELECT id FROM dbsbuffer_file dbsfile
-                             WHERE dbsfile.dataset_algo = das.id
-                             AND dbsfile.status = :status
-                             AND NOT EXISTS (SELECT id FROM dbsbuffer_file dbf2
-                                              INNER JOIN dbsbuffer_file_parent dbfp ON dbf2.id = dbfp.parent
-                                              WHERE dbf2.status = 'NOTUPLOADED'
-                                              AND dbfp.child = dbsfile.id))"""
+    pass

--- a/src/python/WMComponent/DBS3Buffer/Oracle/LoadDBSFilesByDAS.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/LoadDBSFilesByDAS.py
@@ -2,19 +2,10 @@
 """
 _LoadDBSFilesByDAS_
 
-Oracle implementation of LoadDBSFilesByDAS
+Oracle implementation of DBS3Buffer.LoadDBSFilesByDAS
 """
-
-
-
-
-import logging
 
 from WMComponent.DBS3Buffer.MySQL.LoadDBSFilesByDAS import LoadDBSFilesByDAS as MySQLLoadDBSFilesByDAS
 
 class LoadDBSFilesByDAS(MySQLLoadDBSFilesByDAS):
-    """
-    _LoadDBSFilesByDAS_
-
-    Oracle implementation, untested
-    """
+    pass

--- a/test/python/WMComponent_t/DBS3Buffer_t/DBSBufferFile_t.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/DBSBufferFile_t.py
@@ -15,7 +15,7 @@ from WMCore.DataStructs.Run import Run
 
 from WMComponent.DBS3Buffer.DBSBufferFile import DBSBufferFile
 from WMComponent.DBS3Buffer.DBSBufferUtil import DBSBufferUtil
-from WMComponent.DBS3Buffer.DBSBufferBlock import DBSBlock
+from WMComponent.DBS3Buffer.DBSBufferBlock import DBSBufferBlock
 
 class DBSBufferFileTest(unittest.TestCase):
     def setUp(self):
@@ -245,24 +245,24 @@ class DBSBufferFileTest(unittest.TestCase):
         testFileC.load()
 
         assert testFileA == testFileB, \
-               "ERROR: File load by LFN didn't work"
+            "ERROR: File load by LFN didn't work"
 
         assert testFileA == testFileC, \
-               "ERROR: File load by ID didn't work"
+            "ERROR: File load by ID didn't work"
 
-        assert type(testFileB["id"]) == int or type(testFileB["id"]) == long, \
-               "ERROR: File id is not an integer type."
-        assert type(testFileB["size"]) == int or type(testFileB["size"]) == long, \
-               "ERROR: File size is not an integer type."
-        assert type(testFileB["events"]) == int or type(testFileB["events"]) == long, \
-               "ERROR: File events is not an integer type."
+        assert isinstance(testFileB["id"], int) or isinstance(testFileB["id"], long), \
+            "ERROR: File id is not an integer type."
+        assert isinstance(testFileB["size"], int) or isinstance(testFileB["size"], long), \
+            "ERROR: File size is not an integer type."
+        assert isinstance(testFileB["events"], int) or isinstance(testFileB["events"], long), \
+            "ERROR: File events is not an integer type."
 
-        assert type(testFileC["id"]) == int or type(testFileC["id"]) == long, \
-               "ERROR: File id is not an integer type."
-        assert type(testFileC["size"]) == int or type(testFileC["size"]) == long, \
-               "ERROR: File size is not an integer type."
-        assert type(testFileC["events"]) == int or type(testFileC["events"]) == long, \
-               "ERROR: File events is not an integer type."
+        assert isinstance(testFileC["id"], int) or isinstance(testFileC["id"], long), \
+            "ERROR: File id is not an integer type."
+        assert isinstance(testFileC["size"], int) or isinstance(testFileC["size"], long), \
+            "ERROR: File size is not an integer type."
+        assert isinstance(testFileC["events"], int) or isinstance(testFileC["events"], long), \
+            "ERROR: File events is not an integer type."
 
         testFileA.delete()
         return
@@ -544,7 +544,7 @@ class DBSBufferFileTest(unittest.TestCase):
         assert (runSet - testFile["runs"]) == set(), \
             "Error: addRunSet is not updating set correctly"
 
-    def testXSetBlock(self):
+    def testSetBlock(self):
         """
         _testSetBlock_
 
@@ -563,9 +563,9 @@ class DBSBufferFileTest(unittest.TestCase):
 
         datasetAction.execute(datasetPath = dataset)
 
-        newBlock = DBSBlock(name = "someblockname",
-                            location = "se1.cern.ch",
-                            das = None, workflow = None)
+        newBlock = DBSBufferBlock(name = "someblockname",
+                                  location = "se1.cern.ch",
+                                  datasetpath = None)
         newBlock.setDataset(dataset, 'data', 'VALID')
 
         createAction.execute(blocks = [newBlock])
@@ -785,9 +785,6 @@ class DBSBufferFileTest(unittest.TestCase):
         _testSetLocationByLFN_
 
         """
-
-        myThread = threading.currentThread()
-
         testFileA = DBSBufferFile(lfn = "/this/is/a/lfn", size = 1024, events = 10)
         testFileA.setAlgorithm(appName = "cmsRun", appVer = "CMSSW_2_1_8",
                                appFam = "RECO", psetHash = "GIBBERISH",
@@ -821,7 +818,6 @@ class DBSBufferFileTest(unittest.TestCase):
         testFileA.setDatasetPath("/Cosmics/CRUZET09-PromptReco-v1/RECO")
         testFileA.create()
 
-        checksums = {"adler32": "adler32", "cksum": "cksum", "md5": "md5"}
         setCksumAction = self.daoFactory(classname = "DBSBufferFiles.AddChecksumByLFN")
         binds = [{'lfn': "/this/is/a/lfn", 'cktype': 'adler32', 'cksum': 201},
                  {'lfn': "/this/is/a/lfn", 'cktype': 'cksum', 'cksum': 101}]
@@ -845,9 +841,6 @@ class DBSBufferFileTest(unittest.TestCase):
 
 
         addToBuffer = DBSBufferUtil()
-
-        bulkLoad = self.daoFactory(classname = "DBSBufferFiles.LoadBulkFilesByID")
-
 
         testFileChildA = DBSBufferFile(lfn = "/this/is/a/child/lfnA", size = 1024,
                                         events = 20)

--- a/test/python/WMComponent_t/DBS3Buffer_t/DBSUpload_t.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/DBSUpload_t.py
@@ -11,14 +11,12 @@ import threading
 import time
 import unittest
 import json
-import logging
 
 from tempfile import mkstemp
 from nose.plugins.attrib import attr
 
 from dbs.apis.dbsClient import DbsApi
 
-from WMCore.Agent.Configuration import Configuration
 from WMCore.DAOFactory      import DAOFactory
 from WMCore.DataStructs.Run import Run
 from WMCore.Services.UUID   import makeUUID
@@ -26,7 +24,7 @@ from WMCore.Services.UUID   import makeUUID
 from WMComponent.DBS3Buffer.DBSBufferDataset import DBSBufferDataset
 from WMComponent.DBS3Buffer.DBSBufferFile import DBSBufferFile
 from WMComponent.DBS3Buffer.DBSBufferUtil import DBSBufferUtil
-from WMComponent.DBS3Buffer.DBSBufferBlock import DBSBlock
+from WMComponent.DBS3Buffer.DBSBufferBlock import DBSBufferBlock
 
 from WMComponent.DBS3Buffer.DBSUploadPoller import DBSUploadPoller
 
@@ -406,10 +404,9 @@ class DBSUploadTest(unittest.TestCase):
         for i in range(4):
             DBSBufferDataset(parentFiles[0]["datasetPath"]).create()
             blockName = parentFiles[0]["datasetPath"] + "#" + makeUUID()
-            dbsBlock = DBSBlock(blockName,
-                                location = "malpaquet",
-                                das =  None,
-                                workflow = None)
+            dbsBlock = DBSBufferBlock(blockName,
+                                      location = "malpaquet",
+                                      datasetpath =  None)
             dbsBlock.status = "Open"                
             dbsBlock.setDataset(parentFiles[0]["datasetPath"], 'data', 'VALID')
             dbsUtil.createBlocks([dbsBlock])
@@ -424,10 +421,9 @@ class DBSUploadTest(unittest.TestCase):
 
         DBSBufferDataset(childFiles[0]["datasetPath"]).create()
         blockName = childFiles[0]["datasetPath"] + "#" + makeUUID()
-        dbsBlock = DBSBlock(blockName,
-                            location = "malpaquet",
-                            das =  None,
-                            workflow = None)
+        dbsBlock = DBSBufferBlock(blockName,
+                                  location = "malpaquet",
+                                  datasetpath =  None)
         dbsBlock.status = "InDBS"
         dbsBlock.setDataset(childFiles[0]["datasetPath"], 'data', 'VALID')
         dbsUtil.createBlocks([dbsBlock])

--- a/test/python/WMComponent_t/PhEDExInjector_t/PhEDExInjectorPoller_t.py
+++ b/test/python/WMComponent_t/PhEDExInjector_t/PhEDExInjectorPoller_t.py
@@ -14,7 +14,7 @@ import logging
 
 from WMComponent.PhEDExInjector.PhEDExInjectorPoller import PhEDExInjectorPoller
 from WMComponent.DBS3Buffer.DBSBufferFile import DBSBufferFile
-from WMComponent.DBS3Buffer.DBSBufferBlock import DBSBlock
+from WMComponent.DBS3Buffer.DBSBufferBlock import DBSBufferBlock
 
 from WMCore.Services.PhEDEx.PhEDEx import PhEDEx
 from WMCore.Services.UUID import makeUUID
@@ -75,7 +75,7 @@ class PhEDExInjectorPollerTest(unittest.TestCase):
         """
         self.testInit.clearDatabase()
 
-    def stuffDatabase(self, spec = "TestWorkload.pkl"):
+    def stuffDatabase(self):
         """
         _stuffDatabase_
 
@@ -165,15 +165,15 @@ class PhEDExInjectorPollerTest(unittest.TestCase):
         self.blockAName = self.testDatasetA + "#" + makeUUID()
         self.blockBName = self.testDatasetB + "#" + makeUUID()
 
-        newBlockA = DBSBlock(name = self.blockAName,
-                             location = "srm-cms.cern.ch",
-                             das = None, workflow = None)
+        newBlockA = DBSBufferBlock(name = self.blockAName,
+                                   location = "srm-cms.cern.ch",
+                                   datasetpath = None)
         newBlockA.setDataset(self.testDatasetA, 'data', 'VALID')
         newBlockA.status = 'Closed'
 
-        newBlockB = DBSBlock(name = self.blockBName,
-                             location = "srm-cms.cern.ch",
-                             das = None, workflow = None)
+        newBlockB = DBSBufferBlock(name = self.blockBName,
+                                   location = "srm-cms.cern.ch",
+                                   datasetpath = None)
         newBlockB.setDataset(self.testDatasetB, 'data', 'VALID')
         newBlockB.status = 'Closed'
 

--- a/test/python/WMComponent_t/PhEDExInjector_t/PhEDExInjectorSubscriber_t.py
+++ b/test/python/WMComponent_t/PhEDExInjector_t/PhEDExInjectorSubscriber_t.py
@@ -11,7 +11,7 @@ import unittest
 
 from WMComponent.DBS3Buffer.DBSBufferDataset import DBSBufferDataset
 from WMComponent.DBS3Buffer.DBSBufferFile import DBSBufferFile
-from WMComponent.DBS3Buffer.DBSBufferBlock import DBSBlock
+from WMComponent.DBS3Buffer.DBSBufferBlock import DBSBufferBlock
 
 from WMComponent.PhEDExInjector.PhEDExInjectorSubscriber import PhEDExInjectorSubscriber
 
@@ -20,10 +20,6 @@ from WMCore.DataStructs.Run import Run
 from WMCore.Services.EmulatorSwitch import EmulatorHelper
 from WMCore.Services.UUID import makeUUID
 from WMCore.WMBase import getTestBase
-from WMCore.WMBS.File import File
-from WMCore.WMBS.Fileset import Fileset
-from WMCore.WMBS.Subscription import Subscription
-from WMCore.WMBS.Workflow import Workflow
 from WMCore.WMSpec.WMWorkload import WMWorkloadHelper
 
 from WMQuality.TestInit import TestInit
@@ -185,15 +181,15 @@ class PhEDExInjectorSubscriberTest(unittest.TestCase):
         self.blockAName = self.testDatasetA + "#" + makeUUID()
         self.blockBName = self.testDatasetB + "#" + makeUUID()
 
-        newBlockA = DBSBlock(name = self.blockAName,
-                             location = "srm-cms.cern.ch",
-                             das = None, workflow = None)
+        newBlockA = DBSBufferBlock(name = self.blockAName,
+                                   location = "srm-cms.cern.ch",
+                                   datasetpath = None)
         newBlockA.setDataset(self.testDatasetA, 'data', 'VALID')
         newBlockA.status = 'Closed'
 
-        newBlockB = DBSBlock(name = self.blockBName,
-                             location = "srm-cms.cern.ch",
-                             das = None, workflow = None)
+        newBlockB = DBSBufferBlock(name = self.blockBName,
+                                   location = "srm-cms.cern.ch",
+                                   datasetpath = None)
         newBlockB.setDataset(self.testDatasetB, 'data', 'VALID')
         newBlockB.status = 'Closed'
 


### PR DESCRIPTION
Current code was not compatible with the Tier0. It somehow worked so far, but never really correctly (mostly causing internal multiplication of work) and with the huge backlog we accumulated due to the few deadlocks and component restarts it completely broke it. I tried to keep the changes minimal. Didn't quite succeed, but this is about as minimal as I can get it.

I needed to remove the workflow parameter from DBSBufferBlock as workflow is not a property of a block. Replaced it with a workflows set, which is filled when files are added to the DBSBufferBlock. Then for block closing I look at whether any of the workflows in a block is completed.

Dataset_algo is also not a property of a block, but it was used as a key for a block cache and to split blocks into smaller groups to process. Removed the whole cache based on dataset_algo as it wasn't needed and replaced the splitting to use datasetpath instead. That actually is a property of a block, but I had to add it to DBSBufferBlock as it wasn't stored.

As I had to touch some queries for these datasetpath and workflow changes anyways, optimized these queries when I saw something obvious. Saw plenty more to be optimized there, but constrained myself...

Reworked the transaction code in DBSBufferUtil, read methods don't need transactions, they just slow things down. Removed them. Left the transactions intact for writes.

Tested this code in a short Tier0 replay, both in live mode and in the mode where DBSUpload component is restarted and has to pick up from open blocks stored in the database. Worked.

Currently running a larger Tier0 replay with Express and Bulk processing and automatic transfers from T0_CH_CERN_Disk to T2_CH_CERN and automatic deletions from T0_CH_CERN_DIsk. If that works too I am going to pull the trigger and deploy this in the production Tier0.
