### PR TITLE
Fix stage out deleting unwanted files

### DIFF
--- a/src/python/WMCore/Storage/Backends/LCGImpl.py
+++ b/src/python/WMCore/Storage/Backends/LCGImpl.py
@@ -124,12 +124,10 @@ class LCGImpl(StageOutImpl):
             echo "lcg-cp exit status: $EXIT_STATUS"
             if [[ $EXIT_STATUS != 0 ]]; then
                echo "Non-zero lcg-cp Exit status!!!"
-               echo "Cleaning up failed file:"
-                %s
-               exit 60311
+               exit $EXIT_STATUS
             fi
 
-            """ % self.createRemoveFileCommand(targetPFN)
+            """
 
         if self.stageIn:
             remotePFN, localPFN = sourcePFN, targetPFN.replace("file:", "", 1)
@@ -139,8 +137,6 @@ class LCGImpl(StageOutImpl):
         result += "FILE_SIZE=`stat -c %s"
         result += " %s `\n" % localPFN
         result += "echo \"Local File Size is: $FILE_SIZE\"\n"
-
-        removeCommand = self.createRemoveFileCommand(targetPFN)
 
         useChecksum = (checksums != None and 'adler32' in checksums and not self.stageIn)
 
@@ -153,14 +149,12 @@ class LCGImpl(StageOutImpl):
                         exit 0
                     else
                         echo "Error: Checksum Mismatch between local and SE"
-                        echo "Cleaning up failed file"
-                        %s
                         exit 60311
                     fi
                 else
                     exit 0
                 fi
-            """ % (localAdler32, removeCommand)
+            """ % localAdler32
         else:
             checksumCommand = "exit 0"
 
@@ -168,7 +162,7 @@ class LCGImpl(StageOutImpl):
         """
         for ((a=1; a <= 10 ; a++))
         do
-           LCG_OUTPUT=`lcg-ls -l -b -D srmv2 %s 2>/dev/null`
+           LCG_OUTPUT=`lcg-ls -l -b -D srmv2 --srm-timeout 1800 %s 2>/dev/null`
            SRM_SIZE=`echo "$LCG_OUTPUT" | awk 'NR==1{print $5}'`
            SRM_CHECKSUM=`echo "$LCG_OUTPUT" | sed -nr 's/^.*\s([a-f0-9]{8})\s*\([aA][dD][lL][eE][rR]32\)\s*$/\\1/p'`
            echo "Remote Size is $SRM_SIZE"
@@ -178,19 +172,15 @@ class LCGImpl(StageOutImpl):
                  %s
               else
                  echo "Error: Size Mismatch between local and SE"
-                 echo "Cleaning up failed file:"
-                 %s
                  exit 60311
               fi
            else
               sleep 2
            fi
         done
-        echo "Cleaning up failed file:"
-        %s
         exit 60311
 
-        """ % (remotePFN, checksumCommand, removeCommand, removeCommand)
+        """ % (remotePFN, checksumCommand)
         result += metadataCheck
 
         # close sub-shell for CVMFS use case
@@ -207,7 +197,7 @@ class LCGImpl(StageOutImpl):
         CleanUp pfn provided
 
         """
-        command = "%s lcg-del -b -l -D srmv2 --vo cms %s" % (self.setups, pfnToRemove)
+        command = "%s lcg-del -b -l -D srmv2 --srm-timeout 1800 --vo cms %s" % (self.setups, pfnToRemove)
         self.executeCommand(command)
 
 

--- a/src/python/WMCore/Storage/Backends/LCGImpl.py
+++ b/src/python/WMCore/Storage/Backends/LCGImpl.py
@@ -5,11 +5,9 @@ _LCGImpl_
 Implementation of StageOutImpl interface for lcg-cp
 
 """
-import os, re
+import os
 from WMCore.Storage.Registry import registerStageOutImpl
 from WMCore.Storage.StageOutImpl import StageOutImpl
-from WMCore.Storage.StageOutError import StageOutError
-
 from WMCore.Storage.Execute import runCommandWithOutput as runCommand
 
 _CheckExitCodeOption = True
@@ -115,7 +113,7 @@ class LCGImpl(StageOutImpl):
 
             result += copyCommand
         else:
-            result += self.setups 
+            result += self.setups
             result += copyCommand
 
         if _CheckExitCodeOption:

--- a/src/python/WMCore/Storage/StageOutImpl.py
+++ b/src/python/WMCore/Storage/StageOutImpl.py
@@ -9,9 +9,9 @@ inherit this object and implement the methods accordingly
 import time
 import os
 from WMCore.Storage.Execute import runCommand
-from WMCore.Storage.StageOutError import StageOutError, StageOutInvalidPath
+from WMCore.Storage.StageOutError import StageOutError
 
-class StageOutImpl:
+class StageOutImpl(object):
     """
     _StageOutImpl_
 

--- a/src/python/WMCore/Storage/StageOutImpl.py
+++ b/src/python/WMCore/Storage/StageOutImpl.py
@@ -30,17 +30,6 @@ class StageOutImpl:
         self.numRetries = 3
         self.retryPause = 600
         self.stageIn = stagein
-        # tuple of exit codes of copy when dest directory does not exist
-        self.directoryErrorCodes = tuple()
-
-
-    def deferDirectoryCreation(self):
-        """
-        Can we defer directory creation, hoping it exists,
-        only to create on a given error condition
-        """
-        return len(self.directoryErrorCodes) != 0
-
 
     def executeCommand(self, command):
         """
@@ -52,16 +41,13 @@ class StageOutImpl:
         """
         try:
             exitCode = runCommand(command)
-            msg = "Command exited with status: %s" % (exitCode)
-            print msg
         except Exception as ex:
             raise StageOutError(str(ex), Command = command, ExitCode = 60311)
-        if exitCode in self.directoryErrorCodes:
-            raise StageOutInvalidPath()
-        elif exitCode:
+
+        print "Command exited with status: %s" % exitCode
+        if exitCode:
             msg = "Command exited non-zero"
-            print "ERROR: Exception During Stage Out:\n"
-            print msg
+            print "ERROR: Exception during Stage Out:\n%s" % msg
             raise StageOutError(msg, Command = command, ExitCode = exitCode)
         return
 
@@ -149,7 +135,6 @@ class StageOutImpl:
         This operator does the actual stage out by invoking the overridden
         plugin methods of the derived object.
 
-
         """
         #  //
         # // Generate the source PFN from the plain PFN if needed
@@ -161,53 +146,32 @@ class StageOutImpl:
         targetPFN = self.createTargetName(protocol, targetPFN)
 
         #  //
-        # // Create the output directory if implemented
-        #//
-        for retryCount in range(1, self.numRetries + 1):
-            try:
-                # if we can detect directory problems later
-                # defer directory creation till then, only applies to stageOut
-                if not self.deferDirectoryCreation() or self.stageIn:
-                    self.createOutputDirectory(targetPFN)
-                break
-
-            except StageOutError as ex:
-                msg = "Attempted directory creation for stageout %s failed\n" % retryCount
-                msg += "Automatically retrying in %s secs\n " % self.retryPause
-                msg += "Error details:\n%s\n" % str(ex)
-                if retryCount == self.numRetries :
-                    #  //
-                    # // last retry, propagate exception
-                    #//
-                    raise ex
-                time.sleep(self.retryPause)
-
-        #  //
         # // Create the command to be used.
         #//
         command = self.createStageOutCommand(sourcePFN, targetPFN, options, checksums)
+        print "ALAN StageOutImpl command created %s" % command
+        print "ALAN StageOutImpl checksums created %s" % checksums
         #  //
         # // Run the command
         #//
         for retryCount in range(1, self.numRetries + 1):
             try:
-
                 try:
                     self.executeCommand(command)
-                except StageOutInvalidPath as ex:
-                    # plugin indicated directory missing,create and retry
-                    msg = "Copy failure indicates directory does not exist.\n"
-                    msg += "Create now"
+                except StageOutError as ex:
+                    msg = "Possible there is a directory missing.\n"
+                    msg += "Creating it now ..."
                     print msg
                     self.createOutputDirectory(targetPFN)
                     self.executeCommand(command)
                 return
 
             except StageOutError as ex:
+                print "ALAN StageOutImpl command raised StageOutError"
                 msg = "Attempted stage out %s failed\n" % retryCount
                 msg += "Automatically retrying in %s secs\n " % self.retryPause
                 msg += "Error details:\n%s\n" % str(ex)
-                if retryCount == self.numRetries :
+                if retryCount == self.numRetries:
                     #  //
                     # // last retry, propagate exception
                     #//

--- a/src/python/WMCore/Storage/StageOutMgr.py
+++ b/src/python/WMCore/Storage/StageOutMgr.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+#pylint: disable=E0702
+# E0702: known bug in pylint about raising NoneType
+
 """
 _StageOutMgr_
 
@@ -7,8 +10,6 @@ Util class to provide stage out functionality as an interface object.
 Based of RuntimeStageOut.StageOutManager, that should probably eventually
 use this class as a basic API
 """
-
-import os
 
 from WMCore.WMException import WMException
 
@@ -20,7 +21,7 @@ from WMCore.Storage.Registry import retrieveStageOutImpl
 import WMCore.Storage.Backends
 import WMCore.Storage.Plugins
 
-class StageOutMgr:
+class StageOutMgr(object):
     """
     _StageOutMgr_
 
@@ -223,7 +224,8 @@ class StageOutMgr:
                 lastException = ex
                 continue
 
-        raise lastException
+        if lastException:
+            raise lastException
 
     def fallbackStageOut(self, lfn, localPfn, fbParams, checksums):
         """
@@ -271,7 +273,6 @@ class StageOutMgr:
         Given the lfn and local stage out params, invoke the local stage out
 
         """
-        seName = self.siteCfg.localStageOut['se-name']
         command = self.siteCfg.localStageOut['command']
         options = self.siteCfg.localStageOut.get('option', None)
         pfn = self.searchTFC(lfn)

--- a/src/python/WMCore/Storage/StageOutMgr.py
+++ b/src/python/WMCore/Storage/StageOutMgr.py
@@ -71,7 +71,6 @@ class StageOutMgr:
         else:
             self.initialiseSiteConf()
 
-        self.failed = {}
         self.completedFiles = {}
         return
 
@@ -217,8 +216,6 @@ class StageOutMgr:
                 fileToStage['StageOutCommand'] = fallback['command']
                 print "attempting fallback"
                 self.completedFiles[fileToStage['LFN']] = fileToStage
-                if lfn in self.failed:
-                    del self.failed[lfn]
 
                 print "===> Stage Out Successful: %s" % fileToStage
                 return fileToStage

--- a/src/python/WMCore/WMExceptions.py
+++ b/src/python/WMCore/WMExceptions.py
@@ -31,6 +31,18 @@ WM_JOB_ERROR_CODES = {50660:
                       "Application terminated by wrapper for using too much VSize",
                       50664:
                       "Application terminated by wrapper for using too much wallclock time",
+                      60401:
+                      "Failed to directly merge file by file size constraint",
+                      60402:
+                      "Failed to directly merge file by number of events constraint",
+                      60403:
+                      "Stage out operation took too long and timed out",
+                      60404:
+                      "Stage out operation failed unexpectedly",
+                      60405:
+                      "LogArchive transfer took too long and timed out",
+                      60406:
+                      "LogArchive transfer failed unexpectedly",
                       60450:
                       "No output files present in the report",
                       60451:

--- a/src/python/WMCore/WMSpec/Steps/Executors/LogArchive.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/LogArchive.py
@@ -15,6 +15,7 @@ import signal
 import traceback
 
 from WMCore.WMException import WMException
+from WMCore.WMExceptions import WM_JOB_ERROR_CODES
 
 from WMCore.Algorithms.Alarm import Alarm, alarmHandler
 
@@ -140,18 +141,17 @@ class LogArchive(Executor):
                           "checksums": {'adler32': adler32, 'cksum' : cksum}}
             self.report.addOutputFile(outputModule = "logArchive", file = reportFile)
         except Alarm:
-            msg = "Indefinite hang during stageOut of logArchive"
-            logging.error(msg)
-            self.report.addError(self.stepName, 60404, "LogArchiveTimeout", msg)
+            logging.error(WM_JOB_ERROR_CODES[60405])
+            self.report.addError(self.stepName, 60405, "LogArchiveTimeout", WM_JOB_ERROR_CODES[60405])
             self.report.persist("Report.pkl")
-            raise WMExecutionFailure(60404, "LogArchiveTimeout", msg)
+            raise WMExecutionFailure(60405, "LogArchiveTimeout", WM_JOB_ERROR_CODES[60405])
         except WMException as ex:
-            self.report.addError(self.stepName, 60307, "LogArchiveFailure", str(ex))
+            self.report.addError(self.stepName, 60406, "LogArchiveFailure", str(ex))
             self.report.setStepStatus(self.stepName, 0)
             self.report.persist("Report.pkl")
             raise ex
         except Exception as ex:
-            self.report.addError(self.stepName, 60405, "LogArchiveFailure", str(ex))
+            self.report.addError(self.stepName, 60406, "LogArchiveFailure", str(ex))
             self.report.setStepStatus(self.stepName, 0)
             self.report.persist("Report.pkl")
             msg = "Failure in transferring logArchive tarball\n"

--- a/src/python/WMCore/WMSpec/Steps/Executors/StageOut.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/StageOut.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
-#pylint: disable=E1101, W6501, W0142
+#pylint: disable=E1101, W0142
 # E1101:  Doesn't recognize section_() as defining objects
-# W6501:  String formatting in log output
 # W0142:  Dave likes himself some ** magic
 
 """
@@ -22,7 +21,6 @@ from WMCore.WMExceptions          import WM_JOB_ERROR_CODES
 
 import WMCore.Storage.StageOutMgr as StageOutMgr
 import WMCore.Storage.FileManager
-import WMCore.Storage.DeleteMgr   as DeleteMgr
 
 from WMCore.Lexicon               import lfn     as lfnRegEx
 from WMCore.Lexicon               import userLfn as userLfnRegEx
@@ -126,7 +124,6 @@ class StageOut(Executor):
             # First, get everything from a file and 'unpersist' it
             stepReport = Report()
             stepReport.unpersist(reportLocation, step)
-            taskID = getattr(stepReport.data, 'id', None)
 
             # Don't stage out files from bad steps.
             if not stepReport.stepSuccessful(step):

--- a/src/python/WMCore/WMSpec/Steps/Executors/StageOut.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/StageOut.py
@@ -16,15 +16,16 @@ import os.path
 import logging
 import signal
 
-from WMCore.WMSpec.Steps.Executor           import Executor
-from WMCore.FwkJobReport.Report             import Report
+from WMCore.WMSpec.Steps.Executor import Executor
+from WMCore.FwkJobReport.Report   import Report
+from WMCore.WMExceptions          import WM_JOB_ERROR_CODES
 
 import WMCore.Storage.StageOutMgr as StageOutMgr
 import WMCore.Storage.FileManager
 import WMCore.Storage.DeleteMgr   as DeleteMgr
 
-from WMCore.Lexicon                  import lfn     as lfnRegEx
-from WMCore.Lexicon                  import userLfn as userLfnRegEx
+from WMCore.Lexicon               import lfn     as lfnRegEx
+from WMCore.Lexicon               import userLfn as userLfnRegEx
 
 from WMCore.Algorithms.Alarm import Alarm, alarmHandler
 
@@ -64,17 +65,14 @@ class StageOut(Executor):
         if (emulator != None):
             return emulator.emulate( self.step, self.job )
 
-
+        # Pull out StageOutMgr Overrides
         overrides = {}
         if hasattr(self.step, 'override'):
             overrides = self.step.override.dictionary_()
-
-        # Set wait to over an hour
-        waitTime = overrides.get('waitTime', 3600 + (self.step.retryDelay * self.step.retryCount))
-
         logging.info("StageOut override is: %s " % self.step)
 
-        # Pull out StageOutMgr Overrides
+        # total wait time for this wrapper before timing out the whole operation
+        waitTime = overrides.get('waitTime', 3600 + (self.step.retryDelay * self.step.retryCount))
 
         # switch between old stageOut behavior and new, fancy stage out behavior
         useNewStageOutCode = False
@@ -94,12 +92,7 @@ class StageOut(Executor):
 
         # naw man, this is real
         # iterate over all the incoming files
-        if not useNewStageOutCode:
-            # old style
-            manager = StageOutMgr.StageOutMgr(**stageOutCall)
-            manager.numberOfRetries = self.step.retryCount
-            manager.retryPauseTime  = self.step.retryDelay
-        else:
+        if useNewStageOutCode:
             # new style
             logging.critical("STAGEOUT IS USING NEW STAGEOUT CODE")
             print "STAGEOUT IS USING NEW STAGEOUT CODE"
@@ -107,6 +100,11 @@ class StageOut(Executor):
                                 retryPauseTime  = self.step.retryDelay,
                                 numberOfRetries = self.step.retryCount,
                                 **stageOutCall)
+        else:
+            # old style
+            manager = StageOutMgr.StageOutMgr(**stageOutCall)
+            manager.numberOfRetries = self.step.retryCount
+            manager.retryPauseTime  = self.step.retryDelay
 
         # We need to find a list of steps in our task
         # And eventually a list of jobReports for out steps
@@ -170,13 +168,11 @@ class StageOut(Executor):
                             manager.cleanSuccessfulStageOuts()
                             stepReport.addError(self.stepName, 60401,
                                                 "DirectToMergeFailure", str(ex))
-                    elif getattr(self.step.output, 'maxMergeEvents', None) != None\
-                             and getattr(file, 'events', None) != None\
+                    elif getattr(self.step.output, 'maxMergeEvents', None) \
+                             and getattr(file, 'events', None) \
                              and not getattr(file, 'merged', False):
-                        # Then direct-to-merge due to events if
-                        # the file is large enough:
                         if file.events >= self.step.output.maxMergeEvents:
-                            # straight to merge
+                            # Then direct-to-merge since it has enough events
                             try:
                                 file = self.handleLFNForMerge(mergefile = file, step = step)
                             except Exception as ex:
@@ -211,16 +207,19 @@ class StageOut(Executor):
                     file.StageOutCommand = fileForTransfer['StageOutCommand']
                     file.location        = fileForTransfer['SEName']
                     file.OutputPFN       = fileForTransfer['PFN']
+                    print "ALAN StageOut calling manager succeeded"
                 except Alarm:
-                    msg = "Indefinite hang during stageOut of logArchive"
-                    logging.error(msg)
+                    print "ALAN StageOut manager raised Alarm"
+                    logging.error(WM_JOB_ERROR_CODES[60403])
                     manager.cleanSuccessfulStageOuts()
                     stepReport.addError(self.stepName, 60403,
-                                        "StageOutTimeout", msg)
+                                        "StageOutTimeout", WM_JOB_ERROR_CODES[60403])
+                    stepReport.setStepStatus(self.stepName, 1)
                     stepReport.persist("Report.pkl")
                 except Exception as ex:
+                    print "ALAN StageOut manager raised Exception"
                     manager.cleanSuccessfulStageOuts()
-                    stepReport.addError(self.stepName, 60307,
+                    stepReport.addError(self.stepName, 60404,
                                         "StageOutFailure", str(ex))
                     stepReport.setStepStatus(self.stepName, 1)
                     stepReport.persist("Report.pkl")
@@ -228,17 +227,12 @@ class StageOut(Executor):
 
                 signal.alarm(0)
 
-
-
-            # Am DONE with report
-            # Persist it
+            # DONE iterating over files and with the report
             stepReport.persist(reportLocation)
 
-
-
-        #Done with all steps, and should have a list of
-        #stagedOut files in fileForTransfer
-        logging.info("Transferred %i files" %(len(filesTransferred)))
+        # DONE with all stepsDone with all steps
+        # should have a list of stagedOut files in filesTransferred
+        logging.info("Transferred %i files" % (len(filesTransferred)))
         return
 
 


### PR DESCRIPTION
Attempt to fix (or mitigate) #6273 

I could not find any flaw in the code, then as discussed with Seangchan, I'm removing as much as possible file deletion commands. In summary:
- files cleanup (when failures happen) will be done mainly at top level (cleanSuccessfulStageOuts call)
- since other stage out implementation don't care for file size and checksum, I also removed it from LCGImp such that we rely solely on the exit status of lcg-cp command.
- removed deferDirectoryCreation since it was always returning False
- trying to place all wmagent exit codes in a single place

I discussed this with @hufnagel today and he does not like the removal of additional checks. However there is not much we can do here since logs are not available after the workflow is archived. Moreover, I don't expect lcg-cp returning exit status 0 when transfer faces problems (!= file size or checksum).

Pylint cleanup (and my ALAN logs) were left for a bit later. For now only sharing this code for comments/review. 
