### PR TITLE
Fix lumis list to store unique values

### DIFF
--- a/src/python/WMCore/DataStructs/Mask.py
+++ b/src/python/WMCore/DataStructs/Mask.py
@@ -107,10 +107,10 @@ class Mask(dict):
 
         Add a run object
         """
-        run.lumis.sort()
-        firstLumi = run.lumis[0]
-        lastLumi  = run.lumis[0]
-        for lumi in run.lumis:
+        lumis = sorted(list(run.lumis))
+        firstLumi = lumis[0]
+        lastLumi  = lumis[0]
+        for lumi in lumis:
             if lumi <= lastLumi + 1:
                 lastLumi = lumi
             else:
@@ -144,7 +144,7 @@ class Mask(dict):
               with duplicate lumis.
         """
 
-        if not type(lumis) == list:
+        if not isinstance(lumis, list):
             lumis = list(lumis)
 
         if not run in self['runAndLumis'].keys():

--- a/src/python/WMCore/DataStructs/Run.py
+++ b/src/python/WMCore/DataStructs/Run.py
@@ -21,8 +21,18 @@ class Run(WMObject):
     def __init__(self, runNumber = None, *newLumis):
         WMObject.__init__(self)
         self.run = runNumber
-        self.lumis = []
-        self.lumis.extend(newLumis)
+        self._lumis = []
+        self._lumis.extend(newLumis)
+
+    def __setattr__(self, name, value):
+        if name == "lumis":
+            self._lumis = value
+        else:
+            super(Run, self).__setattr__(name, value)
+
+    @property
+    def lumis(self):
+        return list(set(self._lumis))
 
     def __str__(self):
         return "Run%s:%s" % (self.run, list(self.lumis))
@@ -40,7 +50,7 @@ class Run(WMObject):
 
 
     def extend(self, items):
-        self.lumis.extend(items)
+        self._lumis.extend(items)
         return
 
     def __cmp__(self, rhs):

--- a/src/python/WMCore/DataStructs/Run.py
+++ b/src/python/WMCore/DataStructs/Run.py
@@ -32,7 +32,7 @@ class Run(WMObject):
 
     @property
     def lumis(self):
-        return list(set(self._lumis))
+        return sorted(list(set(self._lumis)))
 
     def __str__(self):
         return "Run%s:%s" % (self.run, list(self.lumis))
@@ -75,7 +75,7 @@ class Run(WMObject):
 
         #newRun = Run(self.run, *self)
         #[ newRun.append(x) for x in rhs if x not in newRun ]
-        [ self.lumis.append(x) for x in rhs.lumis if x not in self.lumis ]
+        [ self._lumis.append(x) for x in rhs.lumis if x not in self._lumis ]
 
         return self
     def __iter__(self):

--- a/src/python/WMCore/FwkJobReport/XMLParser.py
+++ b/src/python/WMCore/FwkJobReport/XMLParser.py
@@ -233,7 +233,7 @@ def runHandler():
                           if "ID" in lumi.attrs]
 
                 runInfo = Run(runNumber = runId)
-                runInfo.lumis.extend(lumis)
+                runInfo._lumis.extend(lumis)
 
                 Report.addRunInfoToFile(fileSection, runInfo)
 

--- a/test/python/WMCore_t/JobSplitting_t/EventAwareLumiBased_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/EventAwareLumiBased_t.py
@@ -664,12 +664,12 @@ class EventAwareLumiBasedTest(unittest.TestCase):
         for runObj in files[0]['runs']:
             if runObj.run != 0:
                 continue
-            runObj.lumis.append(42)
+            runObj._lumis.append(42)
         for runObj in files[1]['runs']:
             if runObj.run != 1:
                 continue
             runObj.run = 0
-            runObj.lumis.append(42)
+            runObj._lumis.append(42)
         files[1]['locations'] = set(['blenheim'])
         jobFactory = splitter(package = "WMCore.DataStructs",
                               subscription = testSubscription)
@@ -707,10 +707,10 @@ class EventAwareLumiBasedTest(unittest.TestCase):
         for runObj in files[0]['runs']:
             if runObj.run != 0:
                 continue
-            runObj.lumis.append(42)
+            runObj._lumis.append(42)
         for runObj in files[1]['runs']:
             runObj.run = 0
-            runObj.lumis = [42]
+            runObj._lumis = [42]
         files[1]['locations'] = set(['blenheim'])
         jobFactory = splitter(package = "WMCore.DataStructs",
                               subscription = testSubscription)


### PR DESCRIPTION
While testing #6284 I came across several unit tests which failed due to improper logic of Run DataStructure. The Run class stores lumis in a list. But comparison function does not account for identical lumi sections. Therefore unittests such as DBSBufferFile_t, Job_t had several failures when I switched to usage of generators in WMCore. I think that caused because nobody check uniqueness of results from SQL (or SQL didnt' require unique values). When generators are in place they don't care about results and if no one specify unique SQL clause explicitly we may end-up with duplicates. The proposed changes takes care of internal data structure without any outside modification. I added property lumis, which always return unique list, while internal lumis are still stored in list. Once this fix was applied aforementioned unit tests with generator usage in WMCore were completed ok.
