### PR TITLE
add block level subscription to PhEDEx from wmagent blocks (DO NOT MERGE)

### DIFF
--- a/src/python/WMCore/Services/PhEDEx/DataStructs/SubscriptionList.py
+++ b/src/python/WMCore/Services/PhEDEx/DataStructs/SubscriptionList.py
@@ -24,8 +24,9 @@ class PhEDExSubscription(object):
     PhEDEx subscription data service
     """
     def __init__(self, datasetPathList, nodeList, group,
-                 level = 'dataset', priority = 'normal', move = 'n', static = 'n',
-                 custodial = 'n', request_only = 'y', blocks = None, subscriptionId = -1):
+                 level='dataset', priority='normal', move='n', static='n',
+                 custodial='n', request_only ='y', no_mail='n', 
+                 blocks=None, subscriptionId = -1):
         """
         Initialize PhEDEx subscription with default value
         """
@@ -44,6 +45,7 @@ class PhEDExSubscription(object):
         self.group = group
         self.custodial = custodial.lower()
         self.request_only = request_only.lower()
+        self.no_mail = no_mail.lower()
         self.requesterID = None
         self.status = "New"
 

--- a/src/python/WMCore/Services/PhEDEx/PhEDEx.py
+++ b/src/python/WMCore/Services/PhEDEx/PhEDEx.py
@@ -103,6 +103,7 @@ class PhEDEx(Service):
         args['custodial'] = subscription.custodial
         args['group'] = subscription.group
         args['request_only'] = subscription.request_only
+        args['no_mail'] = subscription.no_mail
 
         return self._getResult(callname, args = args, verb = "POST")
 


### PR DESCRIPTION
fixes #5945 

This is initial patch for the review.
As far as I know about the issue, we will make block level subscription when block is injected. (After discussing with Nicolo, I changed to make subscription when block is closed so it can have less duplicate subscription called)

If one of the call fails (either injecting/closing the block or subscribing the block) both will be retried in next cycle)

Here are things still need to be clarified and need to be done. 
1. Should this (block level subscription) be optional for Tier0?
2. Still need to add unittest and test it.
3. When PNN patch is merged this need to be changed to get the correct location
