### PR TITLE
Fix formatter method to handle generator type

### DIFF
--- a/src/python/WMCore/WebTools/RESTFormatter.py
+++ b/src/python/WMCore/WebTools/RESTFormatter.py
@@ -64,6 +64,8 @@ class RESTFormatter(TemplatedPage):
     def to_string(self, data):
         if isinstance(data, GeneratorType):
             data = [i for i in data]
+        if isinstance(data, dict) or isinstance(data, list):
+            return json.dumps(data)
         return str(data)
 
     def format(self, data, datatype, expires):

--- a/src/python/WMCore/WebTools/RESTFormatter.py
+++ b/src/python/WMCore/WebTools/RESTFormatter.py
@@ -48,16 +48,22 @@ class RESTFormatter(TemplatedPage):
         return JsonWrapper.dumps(data)
 
     def xml(self, data):
+        if isinstance(data, GeneratorType):
+            data = [i for i in data]
         return self.templatepage('XML', data = data,
                                 config = self.config,
                                 path = request.path_info)
 
     def atom(self, data):
+        if isinstance(data, GeneratorType):
+            data = [i for i in data]
         return self.templatepage('Atom', data = data,
                                 config = self.config,
                                 path = request.path_info)
 
     def to_string(self, data):
+        if isinstance(data, GeneratorType):
+            data = [i for i in data]
         return str(data)
 
     def format(self, data, datatype, expires):

--- a/src/python/WMCore/WebTools/RESTFormatter.py
+++ b/src/python/WMCore/WebTools/RESTFormatter.py
@@ -63,7 +63,7 @@ class RESTFormatter(TemplatedPage):
 
     def to_string(self, data):
         if isinstance(data, GeneratorType):
-            data = [i for i in data]
+            return self.json(data)
         if isinstance(data, dict) or isinstance(data, list):
             return json.dumps(data)
         return str(data)

--- a/src/python/WMQuality/WebTools/RESTClientAPI.py
+++ b/src/python/WMQuality/WebTools/RESTClientAPI.py
@@ -68,8 +68,9 @@ def methodTest(verb, url, request_input={}, accept='text/json', contentType = No
 
     keyMap = {'code': code, 'data': data, 'type': content_type, 'response': response}
     for key, value in output.items():
-        assert keyMap[key] == value, \
-            'Got a return %s != %s (got %s) (data %s)' % (key, value, keyMap[key], data)
+        msg = 'Got a return %s != %s (got %s, type %s) (data %s, type %s)' \
+                % (keyMap[key], value, keyMap[key], type(keyMap[key]), data, type(data))
+        assert keyMap[key] == value, msg
 
     expires = response.getheader('Expires')
     if expireTime != 0:


### PR DESCRIPTION
This PR is crucial for DBS when clients request data using default Accept/Content-type. If generator is passed current code does not care, while it should iterate over generator in order to fetch the actual data from generator.
