### PR TITLE
reqmgr2 auth fix

### DIFF
--- a/src/couchapps/ReqMgr/validate_doc_update.js
+++ b/src/couchapps/ReqMgr/validate_doc_update.js
@@ -41,7 +41,6 @@ function(newDoc, oldDoc, userCtx) {
    var allowed = isGlobalAdm || matchesRole("admin", "group:reqmgr")
                              || matchesRole("data-manager", "group:reqmgr")
                              || matchesRole("web-service", "group:facops")
-                             || matchesRole("production-operator", "group:dataops")
                              || matchesRole("production-operator", "group:dataops");
    
    // Throw if user not validated

--- a/src/python/WMCore/ReqMgr/Auth.py
+++ b/src/python/WMCore/ReqMgr/Auth.py
@@ -2,9 +2,10 @@
 Define Authentiction roles and groups for the access permission for writing the the database
 WMCore.REST.Auth authz_match
 """
-ALL_ROLES = ['developer', 'admin', 'data-manager', 'dataops', 'web-service']
+ALL_ROLES = ['developer', 'admin', 'data-manager', 'production-operator', 'web-service']
 ADMIN_ROLES = ['admin', 'web-service']
 ADMIN_GROUP = ['reqmgr', 'facops']
+#OTHER_GROUP = ['dataops']
 
 DEFAULT_PERMISSION =  {'role': ALL_ROLES,
                       'group': []}


### PR DESCRIPTION
This is need for agent update the status (agent role is production-operator)
However we need to define roles and groups and their permissions. 
