### PR TITLE
Split DQMHarvest in dataset instead of blocks

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/DQMHarvest.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/DQMHarvest.py
@@ -22,10 +22,7 @@ class DQMHarvestWorkloadFactory(StdBase):
         self.workload.setDashboardActivity("harvesting")
         self.reportWorkflowToDashboard(self.workload.getDashboardActivity())
 
-        self.workload.setWorkQueueSplitPolicy("DatasetBlock", "FileBased", {"files_per_job": 99999} )
-
-        # TODO maybe it can be removed since LFNBase shouldn't be needed here
-        self.workload.setLFNBase(self.mergedLFNBase, self.unmergedLFNBase)
+        self.workload.setWorkQueueSplitPolicy("Dataset", "FileBased", {"files_per_job": 99999} )
 
         # also creates the logCollect job by default
         self.addDQMHarvestTask(uploadProxy = self.dqmUploadProxy,

--- a/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
@@ -108,6 +108,7 @@ class StartPolicyInterface(PolicyInterface):
         args.setdefault('Dbs', dbsUrl)
         args.setdefault('SiteWhitelist', self.initialTask.siteWhitelist())
         args.setdefault('SiteBlacklist', self.initialTask.siteBlacklist())
+        args.setdefault('StartPolicy', self.wmspec.startPolicy())
         args.setdefault('EndPolicy', self.wmspec.endPolicyParameters())
         args.setdefault('Priority', self.wmspec.priority())
         args.setdefault('PileupData', self.pileupData)

--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -350,7 +350,10 @@ class WorkQueue(WorkQueueBase):
                 else:
                     wmspec = wmspecCache[match['RequestName']]
 
-                if match['Inputs']:
+                if match['StartPolicy'] == 'Dataset':
+                    # actually returns dataset name and dataset info
+                    blockName, dbsBlock = self._getDBSDataset(match, wmspec)
+                elif match['Inputs']:
                     blockName, dbsBlock = self._getDBSBlock(match, wmspec)
                 
                 try:
@@ -374,6 +377,29 @@ class WorkQueue(WorkQueueBase):
         del wmspecCache # remove cache explicitly
         self.logger.info('Injected %s units into WMBS' % len(results))
         return results
+
+    def _getDBSDataset(self, match, wmspec):
+        """Get DBS info for this dataset"""
+        tmpDsetDict = {}
+        dbs = get_dbs(match['Dbs'])
+        datasetName = match['Inputs'].keys()[0]
+
+        blocks = dbs.listFileBlocks(datasetName, onlyClosedBlocks = True)
+        for blockName in blocks:
+            tmpDsetDict.update(dbs.getFileBlock(blockName))
+
+        dbsDatasetDict = {'Files': [], 'IsOpen': False, 'StorageElements': []}
+        dbsDatasetDict['Files'] = [f for block in tmpDsetDict.values() for f in block['Files']]
+        dbsDatasetDict['StorageElements'].extend([f for block in tmpDsetDict.values() for f in block['StorageElements']])
+        dbsDatasetDict['StorageElements'] = list(set(dbsDatasetDict['StorageElements']))
+
+        if wmspec.locationDataSourceFlag():
+            seElements = []
+            for cmsSite in match['Inputs'].values()[0]:
+                ses = self.SiteDB.cmsNametoSE(cmsSite)
+                seElements.extend(ses)
+            dbsDatasetDict['StorageElements'] = list(set(seElements))
+        return datasetName, dbsDatasetDict
 
     def _getDBSBlock(self, match, wmspec):
         """Get DBS info for this block"""
@@ -419,8 +445,7 @@ class WorkQueue(WorkQueueBase):
         return blockName, dbsBlockDict[blockName]
 
     def _wmbsPreparation(self, match, wmspec, blockName, dbsBlock):
-        """Inject data into wmbs and create subscription.
-        """
+        """Inject data into wmbs and create subscription."""
         from WMCore.WorkQueue.WMBSHelper import WMBSHelper
         self.logger.info("Adding WMBS subscription for %s" % match['RequestName'])
 
@@ -449,7 +474,7 @@ class WorkQueue(WorkQueueBase):
         for ele in elements:
             if not ele.isRunning() or not ele['SubscriptionId'] or not ele:
                 continue
-            if not ele['Inputs'] or not ele['OpenForNewData']:
+            if not ele['Inputs'] or not ele['OpenForNewData'] or ele['StartPolicy'] == 'Dataset':
                 continue
             if not wmspec:
                 wmspec = self.backend.getWMSpec(ele['RequestName'])

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/DQMHarvest_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/DQMHarvest_t.py
@@ -111,7 +111,7 @@ class DQMHarvestTests(unittest.TestCase):
         self.assertEqual(sorted(testWorkload.lumiList.values()),
                          [[[5, 10], [15, 20], [25, 30]], [[25, 75],
                          [125, 175], [275, 325]], [[50, 100], [110, 125]]])
-        self.assertEqual(testWorkload.data.policies.start.policyName, "DatasetBlock")
+        self.assertEqual(testWorkload.data.policies.start.policyName, "Dataset")
 
         # test workload tasks and steps
         tasks = testWorkload.listAllTaskNames()


### PR DESCRIPTION
Fixes #6217 in 1.0.9_wmagent branch. The problem is that WorkQueueManager was creating one element (and fileset) per block, so for datasets with > 1 blocks, we were not harvesting full stats in the same job.

FOY, both cmsweb and agent needs to be patched, though not urgent.
I still have to create the master version.
