### PR TITLE
implement a copy-delete type subscription mode

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/MySQL/NewSubscription.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/NewSubscription.py
@@ -25,7 +25,7 @@ class NewSubscription(DBFormatter):
     def _createPhEDExSubBinds(self, datasetID, subscriptionInfo, custodialFlag):
         
         # DeleteFromSource is not supported for move subscriptions
-        delete_blocks = None 
+        delete_blocks = None
         if custodialFlag:
             sites = subscriptionInfo['CustodialSites']
             if subscriptionInfo['CustodialSubType'] == 'Move':
@@ -40,7 +40,7 @@ class NewSubscription(DBFormatter):
                 isMove = 1
             else:
                 isMove = 0
-                if subscriptionInfo.get('DeleteFromSourceNonCustodial', False):
+                if subscriptionInfo.get('DeleteFromSource', False):
                     delete_blocks = 1
                     
         binds = []

--- a/src/python/WMComponent/PhEDExInjector/Database/MySQL/GetDeletableBlocks.py
+++ b/src/python/WMComponent/PhEDExInjector/Database/MySQL/GetDeletableBlocks.py
@@ -1,0 +1,76 @@
+"""
+_GetDeletableBlocks_
+
+MySQL implementation of PhEDExInjector.GetDeletableBlocks
+
+Retrieve a list of blocks that can be deleted,
+including their location and the sites they
+are subscribed too
+
+"""
+
+from __future__ import print_function
+from __future__ import division
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class GetDeletableBlocks(DBFormatter):
+
+    # Retrieve a list of blocks that can be deleted:
+    #   - workflow for all files in block completed
+    #   - subscription made for dataset is copy+delete
+    #   - subscription has been made in PhEDEx
+    #   - blocks hasn't been deleted yet
+
+    # FIXME: returns SE, should switch to PNN soon
+
+    sql = """SELECT dbsbuffer_block.blockname,
+                    dbsbuffer_location.se_name,
+                    dbsbuffer_dataset.path,
+                    dbsbuffer_dataset_subscription.site
+             FROM dbsbuffer_dataset_subscription
+             INNER JOIN dbsbuffer_dataset ON
+               dbsbuffer_dataset.id = dbsbuffer_dataset_subscription.dataset_id
+             INNER JOIN dbsbuffer_block ON
+               dbsbuffer_block.dataset_id = dbsbuffer_dataset_subscription.dataset_id
+             INNER JOIN dbsbuffer_file ON
+               dbsbuffer_file.block_id = dbsbuffer_block.id
+             INNER JOIN dbsbuffer_workflow ON
+               dbsbuffer_workflow.id = dbsbuffer_file.workflow
+             INNER JOIN dbsbuffer_location ON
+               dbsbuffer_location.id = dbsbuffer_block.location
+             LEFT OUTER JOIN wmbs_workflow ON
+               wmbs_workflow.name = dbsbuffer_workflow.name
+             WHERE dbsbuffer_dataset_subscription.delete_blocks = 1
+             AND dbsbuffer_dataset_subscription.subscribed = 1
+             AND dbsbuffer_block.status = 'Closed'
+             AND dbsbuffer_block.deleted = 0
+             GROUP BY dbsbuffer_block.blockname,
+                      dbsbuffer_location.se_name,
+                      dbsbuffer_dataset.path,
+                      dbsbuffer_dataset_subscription.site
+             HAVING COUNT(*) = SUM(dbsbuffer_workflow.completed)
+             AND COUNT(wmbs_workflow.name) = 0
+             """
+
+    def execute(self, conn = None, transaction = False):
+
+        results = self.dbi.processData(self.sql, conn = conn,
+                                      transaction = transaction)[0].fetchall()
+
+        blockDict = {}
+        for result in results:
+
+            blockName = result[0]
+            location = result[1]
+            dataset = result[2]
+            site = result[3]
+
+            if blockName not in blockDict:
+                blockDict[blockName] = { 'location' : location,
+                                         'dataset' : dataset,
+                                         'sites' : set() }
+
+            blockDict[blockName]['sites'].add(site)
+
+        return blockDict

--- a/src/python/WMComponent/PhEDExInjector/Database/MySQL/MarkBlocksDeleted.py
+++ b/src/python/WMComponent/PhEDExInjector/Database/MySQL/MarkBlocksDeleted.py
@@ -1,0 +1,27 @@
+"""
+_MarkBlocksDeleted_
+
+MySQL implementation of PhEDExInjector.MarkBlocksDeleted
+
+Set deleted status for blocks
+
+"""
+
+from __future__ import print_function
+from __future__ import division
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class MarkBlocksDeleted(DBFormatter):
+
+    sql = """UPDATE dbsbuffer_block
+             SET dbsbuffer_block.deleted = :DELETED
+             WHERE dbsbuffer_block.blockname = :BLOCKNAME
+             """
+
+    def execute(self, binds, conn = None, transaction = False):
+
+        self.dbi.processData(self.sql, binds, conn = conn,
+                             transaction = transaction)
+
+        return

--- a/src/python/WMComponent/PhEDExInjector/Database/Oracle/GetDeletableBlocks.py
+++ b/src/python/WMComponent/PhEDExInjector/Database/Oracle/GetDeletableBlocks.py
@@ -1,0 +1,14 @@
+"""
+_GetDeletableBlocks_
+
+Oracle implementation of PhEDExInjector.GetDeletableBlocks
+
+"""
+
+from __future__ import print_function
+from __future__ import division
+
+from WMComponent.PhEDExInjector.Database.MySQL.GetDeletableBlocks import GetDeletableBlocks as MySQLBase
+
+class GetDeletableBlocks(MySQLBase):
+    pass

--- a/src/python/WMComponent/PhEDExInjector/Database/Oracle/MarkBlocksDeleted.py
+++ b/src/python/WMComponent/PhEDExInjector/Database/Oracle/MarkBlocksDeleted.py
@@ -1,0 +1,14 @@
+"""
+_MarkBlocksDeleted_
+
+Oracle implementation of PhEDExInjector.MarkBlocksDeleted
+
+"""
+
+from __future__ import print_function
+from __future__ import division
+
+from WMComponent.PhEDExInjector.Database.MySQL.MarkBlocksDeleted import MarkBlocksDeleted as MySQLBase
+
+class MarkBlocksDeleted(MySQLBase):
+    pass

--- a/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
+++ b/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
@@ -166,6 +166,8 @@ class PhEDExInjectorPoller(BaseWorkerThread):
 
         Inject any uninjected files in PhEDEx.
         """
+        logging.info("Starting injectFiles method")
+
         myThread = threading.currentThread()
         uninjectedFiles = self.getUninjected.execute()
 
@@ -255,6 +257,8 @@ class PhEDExInjectorPoller(BaseWorkerThread):
 
         Close any blocks that have been migrated to global DBS.
         """
+        logging.info("Starting closeBlocks method")
+
         myThread = threading.currentThread()
         migratedBlocks = self.getMigrated.execute()
 

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -160,7 +160,7 @@ class WMWorkloadHelper(PersistencyHelper):
         self.data.owner.name = name
         self.data.owner.group = "undefined"
 
-        if not type(ownerProperties) == dict:
+        if not isinstance(ownerProperties, dict):
             raise Exception("Someone is trying to setOwner without a dictionary")
 
         for key in ownerProperties.keys():
@@ -177,7 +177,8 @@ class WMWorkloadHelper(PersistencyHelper):
         """
         self.data.owner.name = name
         self.data.owner.group = group
-        if not type(ownerProperties) == dict:
+
+        if not isinstance(ownerProperties, dict):
             raise Exception("Someone is trying to setOwnerDetails without a dictionary")
         for key in ownerProperties.keys():
             setattr(self.data.owner, key, ownerProperties[key])
@@ -497,7 +498,7 @@ class WMWorkloadHelper(PersistencyHelper):
 
         Set the site white list for the top level tasks in the workload.
         """
-        if type(siteWhitelist) != type([]):
+        if not isinstance(siteWhitelist, type([])):
             siteWhitelist = [siteWhitelist]
 
         taskIterator = self.taskIterator()
@@ -513,7 +514,7 @@ class WMWorkloadHelper(PersistencyHelper):
 
         Set the site black list for the top level tasks in the workload.
         """
-        if type(siteBlacklist) != type([]):
+        if not isinstance(siteBlacklist, type([])):
             siteBlacklist = [siteBlacklist]
 
         taskIterator = self.taskIterator()
@@ -530,7 +531,7 @@ class WMWorkloadHelper(PersistencyHelper):
         Set the block white list for all tasks that have an input dataset
         defined.
         """
-        if type(blockWhitelist) != type([]):
+        if not isinstance(blockWhitelist, type([])):
             blockWhitelist = [blockWhitelist]
 
         if initialTask:
@@ -552,7 +553,7 @@ class WMWorkloadHelper(PersistencyHelper):
         Set the block black list for all tasks that have an input dataset
         defined.
         """
-        if type(blockBlacklist) != type([]):
+        if not isinstance(blockBlacklist, type([])):
             blockBlacklist = [blockBlacklist]
 
         if initialTask:
@@ -573,7 +574,7 @@ class WMWorkloadHelper(PersistencyHelper):
 
         Set the run white list for all tasks that have an input dataset defined.
         """
-        if type(runWhitelist) != type([]):
+        if not isinstance(runWhitelist, type([])):
             runWhitelist = [runWhitelist]
 
         if initialTask:
@@ -595,7 +596,7 @@ class WMWorkloadHelper(PersistencyHelper):
 
         Set the run black list for all tasks that have an input dataset defined.
         """
-        if type(runBlacklist) != type([]):
+        if not isinstance(runBlacklist, type([])):
             runBlacklist = [runBlacklist]
 
         if initialTask:
@@ -642,7 +643,7 @@ class WMWorkloadHelper(PersistencyHelper):
 
         return
 
-    def setAcquisitionEra(self, acquisitionEras, parentAcquisitionEra = None):
+    def setAcquisitionEra(self, acquisitionEras):
         """
         _setAcquistionEra_
 
@@ -658,7 +659,7 @@ class WMWorkloadHelper(PersistencyHelper):
         self.acquisitionEra = acquisitionEras
         return
 
-    def setProcessingVersion(self, processingVersions, parentProcessingVersion = 0):
+    def setProcessingVersion(self, processingVersions):
         """
         _setProcessingVersion_
 
@@ -674,7 +675,7 @@ class WMWorkloadHelper(PersistencyHelper):
         self.processingVersion = processingVersions
         return
 
-    def setProcessingString(self, processingStrings, parentProcessingString = None):
+    def setProcessingString(self, processingStrings):
         """
         _setProcessingString_
 
@@ -690,7 +691,7 @@ class WMWorkloadHelper(PersistencyHelper):
         self.processingString = processingStrings
         return
 
-    def setLumiList(self, lumiLists,  parentLumiList = None):
+    def setLumiList(self, lumiLists):
         """
         _setLumiList_
 
@@ -1136,7 +1137,8 @@ class WMWorkloadHelper(PersistencyHelper):
     def setSubscriptionInformationWildCards(self, wildcardDict, custodialSites = None,
                                             nonCustodialSites = None, autoApproveSites = None,
                                             custodialSubType = "Replica", nonCustodialSubType = "Replica",
-                                            priority = "Low", primaryDataset = None, dataTier = None):
+                                            priority = "Low", primaryDataset = None, dataTier = None,
+                                            deleteFromSource = False):
         """
         _setSubscriptonInformationWildCards_
 
@@ -1145,11 +1147,11 @@ class WMWorkloadHelper(PersistencyHelper):
         See WMWorkload.WMWorkloadHelper.setSiteWildcardsLists for details on the wildcardDict
         """
 
-        if custodialSites and type(custodialSites) != type([]):
+        if custodialSites and not isinstance(custodialSites, type([])):
             custodialSites = [custodialSites]
-        if nonCustodialSites and type(nonCustodialSites) != type([]):
+        if nonCustodialSites and not isinstance(nonCustodialSites, type([])):
             nonCustodialSites = [nonCustodialSites]
-        if autoApproveSites and type(autoApproveSites) != type([]):
+        if autoApproveSites and not isinstance(autoApproveSites, type([])):
             autoApproveSites = [autoApproveSites]
 
         newCustodialList = self.removeWildcardsFromList(siteList = custodialSites, wildcardDict = wildcardDict)
@@ -1176,12 +1178,14 @@ class WMWorkloadHelper(PersistencyHelper):
                                         nonCustodialSubType = nonCustodialSubType,
                                         priority = priority,
                                         primaryDataset = primaryDataset,
-                                        dataTier = dataTier)
+                                        dataTier = dataTier,
+                                        deleteFromSource = deleteFromSource)
 
     def setSubscriptionInformation(self, initialTask = None, custodialSites = None,
                                    nonCustodialSites = None, autoApproveSites = None,
                                    custodialSubType = "Replica", nonCustodialSubType = "Replica",
-                                   priority = "Low", primaryDataset = None, dataTier = None):
+                                   priority = "Low", primaryDataset = None, dataTier = None,
+                                   deleteFromSource = False):
         """
         _setSubscriptionInformation_
 
@@ -1189,11 +1193,11 @@ class WMWorkloadHelper(PersistencyHelper):
         in the workload that match the given primaryDataset (if any)
         """
 
-        if custodialSites and type(custodialSites) != type([]):
+        if custodialSites and not isinstance(custodialSites, type([])):
             custodialSites = [custodialSites]
-        if nonCustodialSites and type(nonCustodialSites) != type([]):
+        if nonCustodialSites and not isinstance(nonCustodialSites, type([])):
             nonCustodialSites = [nonCustodialSites]
-        if autoApproveSites and type(autoApproveSites) != type([]):
+        if autoApproveSites and not isinstance(autoApproveSites, type([])):
             autoApproveSites = [autoApproveSites]
 
         if initialTask:
@@ -1205,11 +1209,13 @@ class WMWorkloadHelper(PersistencyHelper):
             task.setSubscriptionInformation(custodialSites, nonCustodialSites,
                                             autoApproveSites, custodialSubType,
                                             nonCustodialSubType, priority,
-                                            primaryDataset, dataTier)
+                                            primaryDataset, dataTier,
+                                            deleteFromSource)
             self.setSubscriptionInformation(task, custodialSites, nonCustodialSites,
                                             autoApproveSites, custodialSubType,
                                             nonCustodialSubType, priority,
-                                            primaryDataset, dataTier)
+                                            primaryDataset, dataTier,
+                                            deleteFromSource)
 
         return
 
@@ -1230,6 +1236,15 @@ class WMWorkloadHelper(PersistencyHelper):
         # Choose replica over move
         solveTypeConflicts = lambda x, y: y if x == "Move" else x
 
+
+
+
+
+
+
+        # Always choose a logical AND
+        solveDelConflicts = lambda x, y : x and y
+
         if initialTask:
             taskIterator = initialTask.childTaskIterator()
             subInfo = initialTask.getSubscriptionInformation()
@@ -1248,6 +1263,8 @@ class WMWorkloadHelper(PersistencyHelper):
                                                                               subInfo[dataset]["AutoApproveSites"])
                     subInfo[dataset]["Priority"]          = solvePrioConflicts(taskSubInfo[dataset]["Priority"],
                                                                                subInfo[dataset]["Priority"])
+                    subInfo[dataset]["DeleteFromSource"] = solveDelConflicts(taskSubInfo[dataset]["DeleteFromSource"],
+                                                                               subInfo[dataset]["DeleteFromSource"])
                     subInfo[dataset]["CustodialSubType"] = solveTypeConflicts(taskSubInfo[dataset]["CustodialSubType"],
                                                                               subInfo[dataset]["CustodialSubType"])
                     subInfo[dataset]["NonCustodialSubType"] = solveTypeConflicts(taskSubInfo[dataset]["NonCustodialSubType"],

--- a/test/python/WMCore_t/WMSpec_t/WMTask_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMTask_t.py
@@ -63,7 +63,7 @@ class WMTaskTest(unittest.TestCase):
         task2a = task1.addTask("task2a")
         task2b = task1.addTask("task2b")
         task2c = task1.addTask("task2c")
-        task3 = task2a.addTask("task3")
+        task2a.addTask("task3")
 
         step1 = makeWMStep("step1")
         step1.addStep("step1a")
@@ -478,7 +478,8 @@ class WMTaskTest(unittest.TestCase):
                              "AutoApproveSites" : ["earth"],
                              "Priority" : "High",
                              "CustodialSubType" : "Replica",
-                             "NonCustodialSubType" : "Move"}
+                             "NonCustodialSubType" : "Move",
+                             "DeleteFromSource" : False}
         
         self.assertEqual(subInfo["/OneParticle/DawnOfAnEra-v1/RECO"],
                          outputRecoSubInfo, "The RECO subscription information is wrong")
@@ -510,14 +511,14 @@ class WMTaskTest(unittest.TestCase):
 
         task1 = makeWMTask("task1")
 
-        task2a = task1.addTask("task2a")
-        task2b = task1.addTask("task2b")
-        task2c = task1.addTask("task2c")
-
+        task1.addTask("task2a")
+        task1.addTask("task2b")
+        task1.addTask("task2c")
         task1.deleteChild("task2a")
+
         childrenNumber = 0
         for childTask in task1.childTaskIterator():
-            if childTask.name() == task2a.name():
+            if childTask.name() == "task2a":
                 self.fail("Error: It was possible to find the deleted child")
             childrenNumber += 1
         self.assertEqual(childrenNumber, 2, "Error: Wrong number of children tasks")


### PR DESCRIPTION
Normally there are only two subscription modes supported, copy or move. This implements a delayed move, consisting of a copy first, followed by a delete from the injection site once the workflow creating the data is done and the block is fully transferred to all sites the WMAgent made a subscription for.

If there is an active (outside the agent) subscription to the injection site, the delete is skipped.
