### PR TITLE
Added Pileup support to MCFromGEN

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/MonteCarlo.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/MonteCarlo.py
@@ -16,6 +16,7 @@ from WMCore.Lexicon import primdataset, dataset
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
 from WMCore.WMSpec.WMWorkloadTools import strToBool, parsePileupConfig
 
+
 class MonteCarloWorkloadFactory(StdBase):
     """
     _MonteCarloWorkloadFactory_
@@ -44,15 +45,15 @@ class MonteCarloWorkloadFactory(StdBase):
         prodTask = workload.newTask("Production")
 
         outputMods = self.setupProcessingTask(prodTask, "Production", None,
-                                              couchURL = self.couchURL,
-                                              couchDBName = self.couchDBName,
-                                              configDoc = self.configCacheID,
-                                              splitAlgo = self.prodJobSplitAlgo,
-                                              splitArgs = self.prodJobSplitArgs,
-                                              configCacheUrl = self.configCacheUrl,
-                                              seeding = self.seeding,
-                                              totalEvents = self.totalEvents,
-                                              eventsPerLumi = self.eventsPerLumi)
+                                              couchURL=self.couchURL,
+                                              couchDBName=self.couchDBName,
+                                              configDoc=self.configCacheID,
+                                              splitAlgo=self.prodJobSplitAlgo,
+                                              splitArgs=self.prodJobSplitArgs,
+                                              configCacheUrl=self.configCacheUrl,
+                                              seeding=self.seeding,
+                                              totalEvents=self.totalEvents,
+                                              eventsPerLumi=self.eventsPerLumi)
         self.addLogCollectTask(prodTask)
 
         # pile up support
@@ -62,7 +63,7 @@ class MonteCarloWorkloadFactory(StdBase):
         for outputModuleName in outputMods.keys():
             self.addMergeTask(prodTask, self.prodJobSplitAlgo,
                               outputModuleName,
-                              lfn_counter = self.previousJobCount)
+                              lfn_counter=self.previousJobCount)
 
         maxFiles = workload.getBlockCloseMaxFiles()
         if self.eventsPerLumi != self.eventsPerJob:
@@ -82,7 +83,7 @@ class MonteCarloWorkloadFactory(StdBase):
         # set the LFN bases (normally done by request manager)
         # also pass runNumber (workload evaluates it)
         workload.setLFNBase(self.mergedLFNBase, self.unmergedLFNBase,
-                            runNumber = self.runNumber)
+                            runNumber=self.runNumber)
 
         return workload
 
@@ -108,8 +109,8 @@ class MonteCarloWorkloadFactory(StdBase):
         if self.eventsPerLumi is None:
             self.eventsPerLumi = self.eventsPerJob
         self.prodJobSplitArgs = {"events_per_job": self.eventsPerJob,
-                                  "events_per_lumi" : self.eventsPerLumi,
-                                  "lheInputFiles" : self.lheInputFiles}
+                                 "events_per_lumi": self.eventsPerLumi,
+                                 "lheInputFiles": self.lheInputFiles}
 
         # Transform the pileup as required by the CMSSW step
         self.pileupConfig = parsePileupConfig(self.mcPileup, self.dataPileup)
@@ -127,9 +128,9 @@ class MonteCarloWorkloadFactory(StdBase):
 
     def validateSchema(self, schema):
         couchUrl = schema.get("ConfigCacheUrl", None) or schema["CouchURL"]
-        self.validateConfigCacheExists(configID = schema["ConfigCacheID"],
-                                       couchURL = couchUrl,
-                                       couchDBName = schema["CouchDBName"])
+        self.validateConfigCacheExists(configID=schema["ConfigCacheID"],
+                                       couchURL=couchUrl,
+                                       couchDBName=schema["CouchDBName"])
         return
 
     @staticmethod
@@ -137,49 +138,48 @@ class MonteCarloWorkloadFactory(StdBase):
         baseArgs = StdBase.getWorkloadArguments()
         reqMgrArgs = StdBase.getWorkloadArgumentsWithReqMgr()
         baseArgs.update(reqMgrArgs)
-        specArgs = {"RequestType" : {"default" : "MonteCarlo", "optional" : True,
-                                      "attr" : "requestType"},
-                    "PrimaryDataset" : {"default" : "BlackHoleTest", "type" : str,
-                                        "optional" : False, "validate" : primdataset,
-                                        "attr" : "inputPrimaryDataset", "null" : False},
-                    "Seeding" : {"default" : "AutomaticSeeding", "type" : str,
-                                 "optional" : True, "validate" : lambda x : x in ["ReproducibleSeeding",
-                                                                                  "AutomaticSeeding"],
-                                 "attr" : "seeding", "null" : False},
-                    "GlobalTag" : {"default" : "GT_MC_V1:All", "type" : str,
-                                   "optional" : False, "validate" : None,
-                                   "attr" : "globalTag", "null" : False},
-                    "FilterEfficiency" : {"default" : 1.0, "type" : float,
-                                          "optional" : True, "validate" : lambda x : x > 0.0,
-                                          "attr" : "filterEfficiency", "null" : False},
-                    "RequestNumEvents" : {"default" : 1000, "type" : int,
-                                          "optional" : False, "validate" : lambda x : x > 0,
-                                          "attr" : "requestNumEvents", "null" : False},
-                    "FirstEvent" : {"default" : 1, "type" : int,
-                                    "optional" : True, "validate" : lambda x : x > 0,
-                                    "attr" : "firstEvent", "null" : False},
-                    "FirstLumi" : {"default" : 1, "type" : int,
-                                    "optional" : True, "validate" : lambda x : x > 0,
-                                    "attr" : "firstLumi", "null" : False},
-                    "MCPileup" : {"default" : None, "type" : str,
-                                  "optional" : True, "validate" : dataset,
-                                  "attr" : "mcPileup", "null" : False},
-                    "DataPileup" : {"default" : None, "type" : str,
-                                    "optional" : True, "validate" : dataset,
-                                    "attr" : "dataPileup", "null" : False},
-                    "DeterministicPileup" : {"default" : False, "type" : strToBool,
-                                             "optional" : True, "validate" : None,
-                                             "attr" : "deterministicPileup", "null" : False},
-                    "EventsPerJob" : {"default" : None, "type" : int,
-                                      "optional" : True, "validate" : lambda x : x > 0,
-                                      "attr" : "eventsPerJob", "null" : True},
-                    "EventsPerLumi" : {"default" : None, "type" : int,
-                                       "optional" : True, "validate" : lambda x : x > 0,
-                                       "attr" : "eventsPerLumi", "null" : True},
-                    "LheInputFiles" : {"default" : False, "type" : strToBool,
-                                       "optional" : True, "validate" : None,
-                                       "attr" : "lheInputFiles", "null" : False}
-                    }
+        specArgs = {"RequestType": {"default": "MonteCarlo", "optional": True,
+                                    "attr": "requestType"},
+                    "PrimaryDataset": {"default": "BlackHoleTest", "type": str,
+                                       "optional": False, "validate": primdataset,
+                                       "attr": "inputPrimaryDataset", "null": False},
+                    "Seeding": {"default": "AutomaticSeeding", "type": str,
+                                "optional": True, "validate": lambda x: x in ["ReproducibleSeeding", "AutomaticSeeding"],
+                                "attr": "seeding", "null": False},
+                    "GlobalTag": {"default": "GT_MC_V1:All", "type": str,
+                                  "optional": False, "validate": None,
+                                  "attr": "globalTag", "null": False},
+                    "FilterEfficiency": {"default": 1.0, "type": float,
+                                         "optional": True, "validate": lambda x: x > 0.0,
+                                         "attr": "filterEfficiency", "null": False},
+                    "RequestNumEvents": {"default": 1000, "type": int,
+                                         "optional": False, "validate": lambda x: x > 0,
+                                         "attr": "requestNumEvents", "null": False},
+                    "FirstEvent": {"default": 1, "type": int,
+                                   "optional": True, "validate": lambda x: x > 0,
+                                   "attr": "firstEvent", "null": False},
+                    "FirstLumi": {"default": 1, "type": int,
+                                  "optional": True, "validate": lambda x: x > 0,
+                                  "attr": "firstLumi", "null": False},
+                    "MCPileup": {"default": None, "type": str,
+                                 "optional": True, "validate": dataset,
+                                 "attr": "mcPileup", "null": False},
+                    "DataPileup": {"default": None, "type": str,
+                                   "optional": True, "validate": dataset,
+                                   "attr": "dataPileup", "null": False},
+                    "DeterministicPileup": {"default": False, "type": strToBool,
+                                            "optional": True, "validate": None,
+                                            "attr": "deterministicPileup", "null": False},
+                    "EventsPerJob": {"default": None, "type": int,
+                                     "optional": True, "validate": lambda x: x > 0,
+                                     "attr": "eventsPerJob", "null": True},
+                    "EventsPerLumi": {"default": None, "type": int,
+                                      "optional": True, "validate": lambda x: x > 0,
+                                      "attr": "eventsPerLumi", "null": True},
+                    "LheInputFiles": {"default": False, "type": strToBool,
+                                      "optional": True, "validate": None,
+                                      "attr": "lheInputFiles", "null": False}
+                   }
         baseArgs.update(specArgs)
         StdBase.setDefaultArgumentsProperty(baseArgs)
         return baseArgs

--- a/src/python/WMCore/WMSpec/StdSpecs/MonteCarlo.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/MonteCarlo.py
@@ -12,7 +12,7 @@ fetches from DBS the information about pileup input.
 """
 
 import math
-from WMCore.Lexicon import primdataset, couchurl, identifier, dataset
+from WMCore.Lexicon import primdataset, dataset
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
 from WMCore.WMSpec.WMWorkloadTools import strToBool, parsePileupConfig
 
@@ -113,6 +113,8 @@ class MonteCarloWorkloadFactory(StdBase):
 
         # Transform the pileup as required by the CMSSW step
         self.pileupConfig = parsePileupConfig(self.mcPileup, self.dataPileup)
+        # Adjust the pileup splitting
+        self.prodJobSplitArgs.setdefault("deterministicPileup", self.deterministicPileup)
 
         # Production can be extending statistics,
         # need to move the initial lfn counter
@@ -165,6 +167,9 @@ class MonteCarloWorkloadFactory(StdBase):
                     "DataPileup" : {"default" : None, "type" : str,
                                     "optional" : True, "validate" : dataset,
                                     "attr" : "dataPileup", "null" : False},
+                    "DeterministicPileup" : {"default" : False, "type" : strToBool,
+                                             "optional" : True, "validate" : None,
+                                             "attr" : "deterministicPileup", "null" : False},
                     "EventsPerJob" : {"default" : None, "type" : int,
                                       "optional" : True, "validate" : lambda x : x > 0,
                                       "attr" : "eventsPerJob", "null" : True},

--- a/src/python/WMCore/WMSpec/StdSpecs/MonteCarloFromGEN.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/MonteCarloFromGEN.py
@@ -40,19 +40,19 @@ class MonteCarloFromGENWorkloadFactory(DataProcessing):
         self.reportWorkflowToDashboard(workload.getDashboardActivity())
         workload.setWorkQueueSplitPolicy("Block", self.procJobSplitAlgo,
                                          self.procJobSplitArgs,
-                                         OpenRunningTimeout = self.openRunningTimeout)
+                                         OpenRunningTimeout=self.openRunningTimeout)
         procTask = workload.newTask("MonteCarloFromGEN")
 
         outputMods = self.setupProcessingTask(procTask, "Processing",
                                               self.inputDataset,
-                                              couchURL = self.couchURL,
-                                              couchDBName = self.couchDBName,
-                                              configCacheUrl = self.configCacheUrl,
-                                              configDoc = self.configCacheID,
-                                              splitAlgo = self.procJobSplitAlgo,
-                                              splitArgs = self.procJobSplitArgs,
-                                              stepType = "CMSSW",
-                                              primarySubType = "Production")
+                                              couchURL=self.couchURL,
+                                              couchDBName=self.couchDBName,
+                                              configCacheUrl=self.configCacheUrl,
+                                              configDoc=self.configCacheID,
+                                              splitAlgo=self.procJobSplitAlgo,
+                                              splitArgs=self.procJobSplitArgs,
+                                              stepType="CMSSW",
+                                              primarySubType="Production")
         self.addLogCollectTask(procTask)
 
         # pile up support
@@ -70,7 +70,7 @@ class MonteCarloFromGENWorkloadFactory(DataProcessing):
         # set the LFN bases (normally done by request manager)
         # also pass runNumber (workload evaluates it)
         workload.setLFNBase(self.mergedLFNBase, self.unmergedLFNBase,
-                            runNumber = self.runNumber)
+                            runNumber=self.runNumber)
 
         return workload
 
@@ -98,34 +98,34 @@ class MonteCarloFromGENWorkloadFactory(DataProcessing):
         """
         DataProcessing.validateSchema(self, schema)
         couchUrl = schema.get("ConfigCacheUrl", None) or schema["CouchURL"]
-        self.validateConfigCacheExists(configID = schema["ConfigCacheID"],
-                                       couchURL = couchUrl,
-                                       couchDBName = schema["CouchDBName"])
+        self.validateConfigCacheExists(configID=schema["ConfigCacheID"],
+                                       couchURL=couchUrl,
+                                       couchDBName=schema["CouchDBName"])
         return
 
     @staticmethod
     def getWorkloadArguments():
         baseArgs = DataProcessing.getWorkloadArguments()
-        specArgs = {"RequestType" : {"default" : "MonteCarloFromGEN", "optional" : True,
-                                      "attr" : "requestType"},
-                    "PrimaryDataset" : {"default" : None, "type" : str,
-                                        "optional" : True, "validate" : primdataset,
-                                        "attr" : "inputPrimaryDataset", "null" : False},
-                    "ConfigCacheUrl" : {"default" : None, "type" : str,
-                                        "optional" : True, "validate" : None,
-                                        "attr" : "configCacheUrl", "null" : False},
-                    "ConfigCacheID" : {"default" : None, "type" : str,
-                                       "optional" : False, "validate" : None,
-                                       "attr" : "configCacheID", "null" : False},
-                    "MCPileup" : {"default" : None, "type" : str,
-                                  "optional" : True, "validate" : dataset,
-                                  "attr" : "mcPileup", "null" : False},
-                    "DataPileup" : {"default" : None, "type" : str,
-                                    "optional" : True, "validate" : dataset,
-                                    "attr" : "dataPileup", "null" : False},
-                    "DeterministicPileup" : {"default" : False, "type" : strToBool,
-                                             "optional" : True, "validate" : None,
-                                             "attr" : "deterministicPileup", "null" : False}}
+        specArgs = {"RequestType": {"default": "MonteCarloFromGEN", "optional": True,
+                                    "attr": "requestType"},
+                    "PrimaryDataset": {"default": None, "type": str,
+                                       "optional": True, "validate": primdataset,
+                                       "attr": "inputPrimaryDataset", "null": False},
+                    "ConfigCacheUrl": {"default": None, "type": str,
+                                       "optional": True, "validate": None,
+                                       "attr": "configCacheUrl", "null": False},
+                    "ConfigCacheID": {"default": None, "type": str,
+                                      "optional": False, "validate": None,
+                                      "attr": "configCacheID", "null": False},
+                    "MCPileup": {"default": None, "type": str,
+                                 "optional": True, "validate": dataset,
+                                 "attr": "mcPileup", "null": False},
+                    "DataPileup": {"default": None, "type": str,
+                                   "optional": True, "validate": dataset,
+                                   "attr": "dataPileup", "null": False},
+                    "DeterministicPileup": {"default": False, "type": strToBool,
+                                            "optional": True, "validate": None,
+                                            "attr": "deterministicPileup", "null": False}}
         baseArgs.update(specArgs)
         DataProcessing.setDefaultArgumentsProperty(baseArgs)
         return baseArgs

--- a/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
@@ -497,6 +497,9 @@ class TaskChainWorkloadFactory(StdBase):
             taskConf["SplittingArguments"]["files_per_job"] = taskConf["FilesPerJob"]
 
         taskConf["PileupConfig"] = parsePileupConfig(taskConf["MCPileup"], taskConf["DataPileup"])
+        # Adjust the pileup splitting
+        taskConf["SplittingArguments"].setdefault("deterministicPileup", taskConf['DeterministicPileup'])
+
         return
 
     @staticmethod
@@ -575,6 +578,9 @@ class TaskChainWorkloadFactory(StdBase):
                     "DataPileup" : {"default" : None, "type" : str,
                                     "optional" : True, "validate" : dataset,
                                     "null" : False},
+                    "DeterministicPileup" : {"default" : False, "type" : strToBool,
+                                             "optional" : True, "validate" : None,
+                                             "attr" : "deterministicPileup", "null" : False},
                     "InputDataset" : {"default" : None, "type" : str,
                                       "optional" : generator or not firstTask, "validate" : dataset,
                                       "null" : False},

--- a/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
@@ -87,8 +87,8 @@ Example initial processing task
 
 from WMCore.Lexicon import identifier, couchurl, block, primdataset, dataset
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
-from WMCore.WMSpec.WMWorkloadTools import makeList, strToBool,\
-     validateArgumentsCreate, validateArgumentsNoOptionalCheck, parsePileupConfig
+from WMCore.WMSpec.WMWorkloadTools import makeList, strToBool, \
+    validateArgumentsCreate, validateArgumentsNoOptionalCheck, parsePileupConfig
 
 #
 # simple utils for data mining the request dictionary
@@ -122,17 +122,17 @@ class ParameterStorage(object):
         in StdBase to the argument key in the task dictionaries
         """
         self.func = func
-        self.validParameters = {'globalTag' : 'GlobalTag',
-                                'frameworkVersion' : 'CMSSWVersion',
-                                'scramArch' : 'ScramArch',
-                                'processingVersion' : 'ProcessingVersion',
-                                'processingString' : 'ProcessingString',
-                                'acquisitionEra' : 'AcquisitionEra',
-                                'timePerEvent' : 'TimePerEvent',
-                                'sizePerEvent' : 'SizePerEvent',
-                                'memory' : 'Memory',
-                                'dqmConfigCacheID' : 'DQMConfigCacheID'
-                                }
+        self.validParameters = {'globalTag': 'GlobalTag',
+                                'frameworkVersion': 'CMSSWVersion',
+                                'scramArch': 'ScramArch',
+                                'processingVersion': 'ProcessingVersion',
+                                'processingString': 'ProcessingString',
+                                'acquisitionEra': 'AcquisitionEra',
+                                'timePerEvent': 'TimePerEvent',
+                                'sizePerEvent': 'SizePerEvent',
+                                'memory': 'Memory',
+                                'dqmConfigCacheID': 'DQMConfigCacheID'
+                               }
         return
 
     def __get__(self, instance, owner):
@@ -156,7 +156,7 @@ class ParameterStorage(object):
         self.storeParameters()
         self.alterParameters(taskConf)
         self.func(self.obj, task, taskConf)
-        self.restoreParameters(taskConf)
+        self.restoreParameters()
         self.resetParameters()
         return
 
@@ -183,7 +183,7 @@ class ParameterStorage(object):
                 setattr(self.obj, param, taskValue)
         return
 
-    def restoreParameters(self, taskConf):
+    def restoreParameters(self):
         """
         _restoreParameters_
 
@@ -203,6 +203,7 @@ class ParameterStorage(object):
         for param in self.validParameters:
             setattr(self, param, None)
         return
+
 
 class TaskChainWorkloadFactory(StdBase):
     def __init__(self):
@@ -224,7 +225,7 @@ class TaskChainWorkloadFactory(StdBase):
             originalTaskConf = arguments["Task%d" % i]
             taskConf = {}
             # Make a shallow copy of the taskConf
-            for k,v in originalTaskConf.items():
+            for k, v in originalTaskConf.items():
                 taskConf[k] = v
             parent = taskConf.get("InputTask", None)
 
@@ -233,16 +234,16 @@ class TaskChainWorkloadFactory(StdBase):
             # Set task-specific global parameters
             self.blockBlacklist = taskConf["BlockBlacklist"]
             self.blockWhitelist = taskConf["BlockWhitelist"]
-            self.runBlacklist   = taskConf["RunBlacklist"]
-            self.runWhitelist   = taskConf["RunWhitelist"]
-            
+            self.runBlacklist = taskConf["RunBlacklist"]
+            self.runWhitelist = taskConf["RunWhitelist"]
+
             if taskConf['Multicore'] and taskConf['Multicore'] != 'None':
                 self.multicoreNCores = int(taskConf['Multicore'])
 
             parentTask = None
             if parent in self.mergeMapping:
                 parentTask = self.mergeMapping[parent][parentTaskModule(taskConf)]
-                
+
             task = self.makeTask(taskConf, parentTask)
 
             if i == 1:
@@ -257,7 +258,7 @@ class TaskChainWorkloadFactory(StdBase):
                 else:
                     # process an existing dataset
                     self.workload.setWorkQueueSplitPolicy("Block", taskConf['SplittingAlgo'],
-                                                     taskConf['SplittingArguments'])
+                                                          taskConf['SplittingArguments'])
                     self.setupTask(task, taskConf)
                 self.reportWorkflowToDashboard(self.workload.getDashboardActivity())
             else:
@@ -269,8 +270,7 @@ class TaskChainWorkloadFactory(StdBase):
 
         return self.workload
 
-
-    def makeTask(self, taskConf, parentTask = None):
+    def makeTask(self, taskConf, parentTask=None):
         """
         _makeTask_
 
@@ -286,8 +286,8 @@ class TaskChainWorkloadFactory(StdBase):
         return task
 
     def _updateCommonParams(self, task, taskConf):
-    # sets the prepID  all the properties need to be set by
-            # self.workload.setTaskPropertiesFromWorkload manually for the task
+        # sets the prepID  all the properties need to be set by
+        # self.workload.setTaskPropertiesFromWorkload manually for the task
         task.setPrepID(taskConf.get("PrepID", self.workload.getPrepID()))
         task.setAcquisitionEra(taskConf.get("AcquisitionEra", self.workload.acquisitionEra))
         task.setProcessingString(taskConf.get("ProcessingString", self.workload.processingString))
@@ -295,11 +295,10 @@ class TaskChainWorkloadFactory(StdBase):
         lumiMask = taskConf.get("LumiList", self.workload.lumiList)
         if lumiMask:
             task.setLumiMask(lumiMask)
-        
+
         if taskConf["PileupConfig"]:
             self.setupPileup(task, taskConf['PileupConfig'])
-        
-        
+
     @ParameterStorage
     def setupGeneratorTask(self, task, taskConf):
         """
@@ -317,20 +316,20 @@ class TaskChainWorkloadFactory(StdBase):
 
         self.inputPrimaryDataset = taskConf['PrimaryDataset']
         outputMods = self.setupProcessingTask(task, "Production",
-                                              couchURL = self.couchURL, couchDBName = self.couchDBName,
-                                              configDoc = configCacheID, splitAlgo = splitAlgorithm,
-                                              configCacheUrl = self.configCacheUrl,
-                                              splitArgs = splitArguments, stepType = cmsswStepType,
-                                              seeding = taskConf['Seeding'], totalEvents = taskConf['RequestNumEvents'],
-                                              forceUnmerged = forceUnmerged,
-                                              timePerEvent = taskConf.get('TimePerEvent', None),
-                                              sizePerEvent = taskConf.get('SizePerEvent', None),
-                                              memoryReq = taskConf.get('Memory', None),
-                                              taskConf = taskConf)
+                                              couchURL=self.couchURL, couchDBName=self.couchDBName,
+                                              configDoc=configCacheID, splitAlgo=splitAlgorithm,
+                                              configCacheUrl=self.configCacheUrl,
+                                              splitArgs=splitArguments, stepType=cmsswStepType,
+                                              seeding=taskConf['Seeding'], totalEvents=taskConf['RequestNumEvents'],
+                                              forceUnmerged=forceUnmerged,
+                                              timePerEvent=taskConf.get('TimePerEvent', None),
+                                              sizePerEvent=taskConf.get('SizePerEvent', None),
+                                              memoryReq=taskConf.get('Memory', None),
+                                              taskConf=taskConf)
 
         # this need to be called after setpuProcessingTask since it will overwrite some values
         self._updateCommonParams(task, taskConf)
-        
+
         self.addLogCollectTask(task, 'LogCollectFor%s' % task.name())
 
         # Do the output module merged/unmerged association
@@ -338,7 +337,7 @@ class TaskChainWorkloadFactory(StdBase):
                              keepOutput, transientModules)
 
         return
-        
+
     @ParameterStorage
     def setupTask(self, task, taskConf):
         """
@@ -348,11 +347,11 @@ class TaskChainWorkloadFactory(StdBase):
         and set the parents appropriately to handle a processing task
         """
 
-        cmsswStepType  = "CMSSW"
-        configCacheID  = taskConf["ConfigCacheID"]
+        cmsswStepType = "CMSSW"
+        configCacheID = taskConf["ConfigCacheID"]
         splitAlgorithm = taskConf["SplittingAlgo"]
         splitArguments = taskConf["SplittingArguments"]
-        keepOutput     = taskConf["KeepOutput"]
+        keepOutput = taskConf["KeepOutput"]
         transientModules = taskConf["TransientOutputModules"]
         forceUnmerged = (not keepOutput) or (len(transientModules) > 0)
 
@@ -375,12 +374,12 @@ class TaskChainWorkloadFactory(StdBase):
                 inpMod = taskConf["InputFromOutputModule"]
                 # Check if the splitting has to be changed
                 if inputTaskConf["SplittingAlgo"] == 'EventBased' \
-                   and (inputTaskConf["InputDataset"] or inputTaskConf["InputTask"]):
+                        and (inputTaskConf["InputDataset"] or inputTaskConf["InputTask"]):
                     splitAlgorithm = 'WMBSMergeBySize'
-                    splitArguments = {'max_merge_size'   : self.maxMergeSize,
-                                      'min_merge_size'   : self.minMergeSize,
-                                      'max_merge_events' : self.maxMergeEvents,
-                                      'max_wait_time'    : self.maxWaitTime}
+                    splitArguments = {'max_merge_size': self.maxMergeSize,
+                                      'min_merge_size': self.minMergeSize,
+                                      'max_merge_events': self.maxMergeEvents,
+                                      'max_wait_time': self.maxWaitTime}
             else:
                 inpMod = "Merged"
 
@@ -392,24 +391,24 @@ class TaskChainWorkloadFactory(StdBase):
         couchDB = self.couchDBName
         outputMods = self.setupProcessingTask(task, "Processing",
                                               inputDataset,
-                                              inputStep = inpStep,
-                                              inputModule = inpMod,
-                                              couchURL = couchUrl,
-                                              couchDBName = couchDB,
-                                              configCacheUrl = self.configCacheUrl,
-                                              configDoc = configCacheID,
-                                              splitAlgo = taskConf["SplittingAlgo"],
-                                              splitArgs = taskConf["SplittingArguments"],
-                                              stepType = cmsswStepType,
-                                              forceUnmerged = forceUnmerged,
-                                              timePerEvent = taskConf.get('TimePerEvent', None),
-                                              sizePerEvent = taskConf.get('SizePerEvent', None),
-                                              memoryReq = taskConf.get("Memory", None),
-                                              taskConf = taskConf)
-        
+                                              inputStep=inpStep,
+                                              inputModule=inpMod,
+                                              couchURL=couchUrl,
+                                              couchDBName=couchDB,
+                                              configCacheUrl=self.configCacheUrl,
+                                              configDoc=configCacheID,
+                                              splitAlgo=taskConf["SplittingAlgo"],
+                                              splitArgs=splitArguments,
+                                              stepType=cmsswStepType,
+                                              forceUnmerged=forceUnmerged,
+                                              timePerEvent=taskConf.get('TimePerEvent', None),
+                                              sizePerEvent=taskConf.get('SizePerEvent', None),
+                                              memoryReq=taskConf.get("Memory", None),
+                                              taskConf=taskConf)
+
         # this need to be called after setpuProcessingTask since it will overwrite some values
         self._updateCommonParams(task, taskConf)
-        
+
         self.addLogCollectTask(task, 'LogCollectFor%s' % task.name())
         self.setUpMergeTasks(task, outputMods, splitAlgorithm,
                              keepOutput, transientModules)
@@ -417,8 +416,7 @@ class TaskChainWorkloadFactory(StdBase):
         self.inputPrimaryDataset = currentPrimaryDataset
 
         return
-    
-        
+
     def setUpMergeTasks(self, parentTask, outputModules, splittingAlgo,
                         keepOutput, transientOutputModules):
         """
@@ -432,8 +430,8 @@ class TaskChainWorkloadFactory(StdBase):
         modulesToMerge = []
         unmergedModules = outputModules.keys()
         if keepOutput:
-            unmergedModules = filter(lambda x : x in transientOutputModules, outputModules.keys())
-            modulesToMerge = filter(lambda x : x not in transientOutputModules, outputModules.keys())
+            unmergedModules = filter(lambda x: x in transientOutputModules, outputModules.keys())
+            modulesToMerge = filter(lambda x: x not in transientOutputModules, outputModules.keys())
 
         procMergeTasks = {}
         for outputModuleName in modulesToMerge:
@@ -451,7 +449,7 @@ class TaskChainWorkloadFactory(StdBase):
         return
 
     def modifyTaskConfiguration(self, taskConf,
-                                firstTask = False, generator = False):
+                                firstTask=False, generator=False):
         """
         _modifyTaskConfiguration_
 
@@ -479,7 +477,7 @@ class TaskChainWorkloadFactory(StdBase):
                                        taskConf.get("FilterEfficiency")
 
         if taskConf["EventsPerJob"] is None:
-            taskConf["EventsPerJob"] = int((8.0 * 3600.0)/(taskConf.get("TimePerEvent", self.timePerEvent)))
+            taskConf["EventsPerJob"] = int((8.0 * 3600.0) / (taskConf.get("TimePerEvent", self.timePerEvent)))
         if taskConf["EventsPerLumi"] is None:
             taskConf["EventsPerLumi"] = taskConf["EventsPerJob"]
 
@@ -507,39 +505,39 @@ class TaskChainWorkloadFactory(StdBase):
         baseArgs = StdBase.getWorkloadArguments()
         reqMgrArgs = StdBase.getWorkloadArgumentsWithReqMgr()
         baseArgs.update(reqMgrArgs)
-        specArgs = {"RequestType" : {"default" : "TaskChain", "optional" : False,
-                                      "attr" : "requestType"},
-                    "GlobalTag" : {"default" : "GT_TC_V1", "type" : str,
-                                   "optional" : False, "validate" : None,
-                                   "attr" : "globalTag", "null" : False},
-                    "CouchURL" : {"default" : "http://localhost:5984", "type" : str,
-                                  "optional" : False, "validate" : couchurl,
-                                  "attr" : "couchURL", "null" : False},
-                    "CouchDBName" : {"default" : "dp_configcache", "type" : str,
-                                     "optional" : False, "validate" : identifier,
-                                     "attr" : "couchDBName", "null" : False},
-                    "ConfigCacheUrl" : {"default" : None, "type" : str,
-                                        "optional" : True, "validate" : None,
-                                        "attr" : "configCacheUrl", "null" : True},
-                    "IgnoredOutputModules" : {"default" : [], "type" : makeList,
-                                              "optional" : True, "validate" : None,
-                                              "attr" : "ignoredOutputModules", "null" : False},
-                    "TaskChain" : {"default" : 1, "type" : int,
-                                   "optional" : False, "validate" : lambda x : x > 0,
-                                   "attr" : "taskChain", "null" : False},
-                    "FirstEvent" : {"default" : 1, "type" : int,
-                                    "optional" : True, "validate" : lambda x : x > 0,
-                                    "attr" : "firstEvent", "null" : False},
-                    "FirstLumi" : {"default" : 1, "type" : int,
-                                    "optional" : True, "validate" : lambda x : x > 0,
-                                    "attr" : "firstLumi", "null" : False}
-                    }
+        specArgs = {"RequestType": {"default": "TaskChain", "optional": False,
+                                    "attr": "requestType"},
+                    "GlobalTag": {"default": "GT_TC_V1", "type": str,
+                                  "optional": False, "validate": None,
+                                  "attr": "globalTag", "null": False},
+                    "CouchURL": {"default": "http://localhost:5984", "type": str,
+                                 "optional": False, "validate": couchurl,
+                                 "attr": "couchURL", "null": False},
+                    "CouchDBName": {"default": "dp_configcache", "type": str,
+                                    "optional": False, "validate": identifier,
+                                    "attr": "couchDBName", "null": False},
+                    "ConfigCacheUrl": {"default": None, "type": str,
+                                       "optional": True, "validate": None,
+                                       "attr": "configCacheUrl", "null": True},
+                    "IgnoredOutputModules": {"default": [], "type": makeList,
+                                             "optional": True, "validate": None,
+                                             "attr": "ignoredOutputModules", "null": False},
+                    "TaskChain": {"default": 1, "type": int,
+                                  "optional": False, "validate": lambda x: x > 0,
+                                  "attr": "taskChain", "null": False},
+                    "FirstEvent": {"default": 1, "type": int,
+                                   "optional": True, "validate": lambda x: x > 0,
+                                   "attr": "firstEvent", "null": False},
+                    "FirstLumi": {"default": 1, "type": int,
+                                  "optional": True, "validate": lambda x: x > 0,
+                                  "attr": "firstLumi", "null": False}
+                   }
         baseArgs.update(specArgs)
         StdBase.setDefaultArgumentsProperty(baseArgs)
         return baseArgs
 
     @staticmethod
-    def getTaskArguments(firstTask = False, generator = False):
+    def getTaskArguments(firstTask=False, generator=False):
         """
         _getTaskArguments_
 
@@ -548,89 +546,90 @@ class TaskChainWorkloadFactory(StdBase):
         defined in StdBase.getWorkloadArguments and those do not appear here
         since they are all optional. Here only new arguments are listed.
         """
-        specArgs = {"TaskName" : {"default" : None, "type" : str,
-                                  "optional" : False, "validate" : None,
-                                  "null" : False},
-                    "ConfigCacheUrl" : {"default" : "https://cmsweb.cern.ch/couchdb", "type" : str,
-                                        "optional" : False, "validate" : None,
-                                        "attr" : "configCacheUrl", "null" : False},
-                    "ConfigCacheID" : {"default" : None, "type" : str,
-                                       "optional" : False, "validate" : None,
-                                       "null" : False},
-                    "KeepOutput" : {"default" : True, "type" : strToBool,
-                                    "optional" : True, "validate" : None,
-                                    "null" : False},
-                    "TransientOutputModules" : {"default" : [], "type" : makeList,
-                                                "optional" : True, "validate" : None,
-                                                "null" : False},
-                    "PrimaryDataset" : {"default" : None, "type" : str,
-                                        "optional" : not generator, "validate" : primdataset,
-                                        "null" : False},
-                    "Seeding" : {"default" : "AutomaticSeeding", "type" : str,
-                                 "optional" : True, "validate" : lambda x : x in ["ReproducibleSeeding", "AutomaticSeeding"],
-                                 "null" : False},
-                    "RequestNumEvents" : {"default" : 1000, "type" : int,
-                                          "optional" : not generator, "validate" : lambda x : x > 0,
-                                          "null" : False},
-                    "MCPileup" : {"default" : None, "type" : str,
-                                  "optional" : True, "validate" : dataset,
-                                  "null" : False},
-                    "DataPileup" : {"default" : None, "type" : str,
-                                    "optional" : True, "validate" : dataset,
-                                    "null" : False},
-                    "DeterministicPileup" : {"default" : False, "type" : strToBool,
-                                             "optional" : True, "validate" : None,
-                                             "attr" : "deterministicPileup", "null" : False},
-                    "InputDataset" : {"default" : None, "type" : str,
-                                      "optional" : generator or not firstTask, "validate" : dataset,
-                                      "null" : False},
-                    "InputTask" : {"default" : None, "type" : str,
-                                   "optional" : firstTask, "validate" : None,
-                                   "null" : False},
-                    "InputFromOutputModule" : {"default" : None, "type" : str,
-                                               "optional" : firstTask, "validate" : None,
-                                               "null" : False},
-                    "BlockBlacklist" : {"default" : [], "type" : makeList,
-                                        "optional" : True, "validate" : lambda x: all([block(y) for y in x]),
-                                        "null" : False},
-                    "BlockWhitelist" : {"default" : [], "type" : makeList,
-                                        "optional" : True, "validate" : lambda x: all([block(y) for y in x]),
-                                        "null" : False},
-                    "RunBlacklist" : {"default" : [], "type" : makeList,
-                                      "optional" : True, "validate" : lambda x: all([int(y) > 0 for y in x]),
-                                      "null" : False},
-                    "RunWhitelist" : {"default" : [], "type" : makeList,
-                                      "optional" : True, "validate" : lambda x: all([int(y) > 0 for y in x]),
-                                      "null" : False},
-                    "SplittingAlgo" : {"default" : "EventAwareLumiBased", "type" : str,
-                                       "optional" : True, "validate" : lambda x: x in ["EventBased", "LumiBased",
-                                                                                       "EventAwareLumiBased", "FileBased"],
-                                       "null" : False},
-                    "EventsPerJob" : {"default" : None, "type" : int,
-                                      "optional" : True, "validate" : lambda x : x > 0,
-                                      "null" : False},
-                    "LumisPerJob" : {"default" : 8, "type" : int,
-                                     "optional" : True, "validate" : lambda x : x > 0,
-                                     "null" : False},
-                    "FilesPerJob" : {"default" : 1, "type" : int,
-                                     "optional" : True, "validate" : lambda x : x > 0,
-                                     "null" : False},
-                    "EventsPerLumi" : {"default" : None, "type" : int,
-                                       "optional" : True, "validate" : lambda x : x > 0,
-                                       "attr" : "eventsPerLumi", "null" : True},
-                    "FilterEfficiency" : {"default" : 1.0, "type" : float,
-                                          "optional" : True, "validate" : lambda x : x > 0.0,
-                                          "attr" : "filterEfficiency", "null" : False},
-                    "LheInputFiles" : {"default" : False, "type" : strToBool,
-                                       "optional" : True, "validate" : None,
-                                       "attr" : "lheInputFiles", "null" : False},
-                    "PrepID": {"default" : None, "type": str,
-                               "optional" : True, "validate" : None,
-                                "attr" : "prepID",  "null" : True},
-                    "Multicore" : {"default" : None, "type" : int,
-                                     "optional" : True, "validate" : lambda x : x > 0,
-                                     "null" : False},
-                    }
+        specArgs = {"TaskName": {"default": None, "type": str,
+                                 "optional": False, "validate": None,
+                                 "null": False},
+                    "ConfigCacheUrl": {"default": "https://cmsweb.cern.ch/couchdb", "type": str,
+                                       "optional": False, "validate": None,
+                                       "attr": "configCacheUrl", "null": False},
+                    "ConfigCacheID": {"default": None, "type": str,
+                                      "optional": False, "validate": None,
+                                      "null": False},
+                    "KeepOutput": {"default": True, "type": strToBool,
+                                   "optional": True, "validate": None,
+                                   "null": False},
+                    "TransientOutputModules": {"default": [], "type": makeList,
+                                               "optional": True, "validate": None,
+                                               "null": False},
+                    "PrimaryDataset": {"default": None, "type": str,
+                                       "optional": not generator, "validate": primdataset,
+                                       "null": False},
+                    "Seeding": {"default": "AutomaticSeeding", "type": str,
+                                "optional": True,
+                                "validate": lambda x: x in ["ReproducibleSeeding", "AutomaticSeeding"],
+                                "null": False},
+                    "RequestNumEvents": {"default": 1000, "type": int,
+                                         "optional": not generator, "validate": lambda x: x > 0,
+                                         "null": False},
+                    "MCPileup": {"default": None, "type": str,
+                                 "optional": True, "validate": dataset,
+                                 "null": False},
+                    "DataPileup": {"default": None, "type": str,
+                                   "optional": True, "validate": dataset,
+                                   "null": False},
+                    "DeterministicPileup": {"default": False, "type": strToBool,
+                                            "optional": True, "validate": None,
+                                            "attr": "deterministicPileup", "null": False},
+                    "InputDataset": {"default": None, "type": str,
+                                     "optional": generator or not firstTask, "validate": dataset,
+                                     "null": False},
+                    "InputTask": {"default": None, "type": str,
+                                  "optional": firstTask, "validate": None,
+                                  "null": False},
+                    "InputFromOutputModule": {"default": None, "type": str,
+                                              "optional": firstTask, "validate": None,
+                                              "null": False},
+                    "BlockBlacklist": {"default": [], "type": makeList,
+                                       "optional": True, "validate": lambda x: all([block(y) for y in x]),
+                                       "null": False},
+                    "BlockWhitelist": {"default": [], "type": makeList,
+                                       "optional": True, "validate": lambda x: all([block(y) for y in x]),
+                                       "null": False},
+                    "RunBlacklist": {"default": [], "type": makeList,
+                                     "optional": True, "validate": lambda x: all([int(y) > 0 for y in x]),
+                                     "null": False},
+                    "RunWhitelist": {"default": [], "type": makeList,
+                                     "optional": True, "validate": lambda x: all([int(y) > 0 for y in x]),
+                                     "null": False},
+                    "SplittingAlgo": {"default": "EventAwareLumiBased", "type": str,
+                                      "optional": True, "validate": lambda x: x in ["EventBased", "LumiBased",
+                                                                                    "EventAwareLumiBased", "FileBased"],
+                                      "null": False},
+                    "EventsPerJob": {"default": None, "type": int,
+                                     "optional": True, "validate": lambda x: x > 0,
+                                     "null": False},
+                    "LumisPerJob": {"default": 8, "type": int,
+                                    "optional": True, "validate": lambda x: x > 0,
+                                    "null": False},
+                    "FilesPerJob": {"default": 1, "type": int,
+                                    "optional": True, "validate": lambda x: x > 0,
+                                    "null": False},
+                    "EventsPerLumi": {"default": None, "type": int,
+                                      "optional": True, "validate": lambda x: x > 0,
+                                      "attr": "eventsPerLumi", "null": True},
+                    "FilterEfficiency": {"default": 1.0, "type": float,
+                                         "optional": True, "validate": lambda x: x > 0.0,
+                                         "attr": "filterEfficiency", "null": False},
+                    "LheInputFiles": {"default": False, "type": strToBool,
+                                      "optional": True, "validate": None,
+                                      "attr": "lheInputFiles", "null": False},
+                    "PrepID": {"default": None, "type": str,
+                               "optional": True, "validate": None,
+                               "attr": "prepID", "null": True},
+                    "Multicore": {"default": None, "type": int,
+                                  "optional": True, "validate": lambda x: x > 0,
+                                  "null": False},
+                   }
         StdBase.setDefaultArgumentsProperty(specArgs)
         return specArgs
 
@@ -647,14 +646,14 @@ class TaskChainWorkloadFactory(StdBase):
             taskName = "Task%s" % i
             if taskName not in schema:
                 msg = "No Task%s entry present in request" % i
-                self.raiseValidationException(msg = msg)
+                self.raiseValidationException(msg=msg)
 
             task = schema[taskName]
             # We can't handle non-dictionary tasks
-            if type(task) != dict:
-                msg =  "Non-dictionary input for task in TaskChain.\n"
+            if not isinstance(task, dict):
+                msg = "Non-dictionary input for task in TaskChain.\n"
                 msg += "Could be an indicator of JSON error.\n"
-                self.raiseValidationException(msg = msg)
+                self.raiseValidationException(msg=msg)
 
             # Generic task parameter validation
             self.validateTask(task, self.getTaskArguments(i == 1, i == 1 and 'InputDataset' not in task))
@@ -662,10 +661,10 @@ class TaskChainWorkloadFactory(StdBase):
             # Validate the existence of the configCache
             if task["ConfigCacheID"]:
                 configCacheUrl = schema.get("ConfigCacheUrl", None) or schema["CouchURL"]
-                self.validateConfigCacheExists(configID = task['ConfigCacheID'],
-                                               couchURL = configCacheUrl,
-                                               couchDBName = schema["CouchDBName"],
-                                               getOutputModules = True)
+                self.validateConfigCacheExists(configID=task['ConfigCacheID'],
+                                               couchURL=configCacheUrl,
+                                               couchDBName=schema["CouchDBName"],
+                                               getOutputModules=True)
 
             # Validate the chaining of transient output modules, need to make a copy of the lists
             transientMapping[task['TaskName']] = [x for x in task.get('TransientOutputModules', [])]
@@ -691,16 +690,15 @@ class TaskChainWorkloadFactory(StdBase):
         msg = validateArgumentsCreate(taskConf, taskArgumentDefinition)
         if msg is not None:
             self.raiseValidationException(msg)
-            
+
         # Also retrieve the "main" arguments which may be overriden in the task
         # Change them all to optional for validation
         baseArgs = self.getWorkloadArguments()
         validateArgumentsNoOptionalCheck(taskConf, baseArgs)
-        
+
         for arg in baseArgs:
             baseArgs[arg]["optional"] = True
         msg = validateArgumentsCreate(taskConf, baseArgs)
         if msg is not None:
             self.raiseValidationException(msg)
         return
-

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/MonteCarlo_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/MonteCarlo_t.py
@@ -281,6 +281,7 @@ class MonteCarloTest(unittest.TestCase):
         # Add pileup inputs
         defaultArguments["MCPileup"] = "/some/cosmics/dataset1"
         defaultArguments["DataPileup"] = "/some/minbias/dataset1"
+        defaultArguments["DeterministicPileup"] = True
 
         factory = MonteCarloWorkloadFactory()
         testWorkload = factory.factoryWorkloadConstruction("TestWorkload", defaultArguments)
@@ -296,6 +297,8 @@ class MonteCarloTest(unittest.TestCase):
         self.assertEqual(pileupData.data.dataset, ["/some/minbias/dataset1"])
         self.assertEqual(pileupData.mc.dataset, ["/some/cosmics/dataset1"])
 
+        splitting = productionTask.jobSplittingParameters()
+        self.assertTrue(splitting["deterministicPileup"])
         return
 
     def testMCWithLHE(self):
@@ -328,6 +331,7 @@ class MonteCarloTest(unittest.TestCase):
         self.assertEqual(splitting["events_per_job"], 200)
         self.assertEqual(splitting["events_per_lumi"], 50)
         self.assertEqual(splitting["lheInputFiles"], True)
+        self.assertFalse(splitting["deterministicPileup"])
 
         return
 

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
@@ -646,6 +646,78 @@ class TaskChainTests(unittest.TestCase):
 
         return
 
+    def testPileupTaskChain(self):
+        """
+        Test for multithreaded task chains where each step
+        may run with a different number of cores
+        """
+        processorDocs = makeProcessingConfigs(self.configDatabase)
+
+        testArguments = TaskChainWorkloadFactory.getTestArguments()
+        arguments = {
+            "AcquisitionEra": "ReleaseValidation",
+            "Requestor": "alan.malta@cern.ch",
+            "CMSSWVersion": "CMSSW_3_5_8",
+            "ScramArch": "slc5_ia32_gcc434",
+            "ProcessingVersion": 1,
+            "GlobalTag": "GR10_P_v4::All",
+            "CouchURL": self.testInit.couchUrl,
+            "CouchDBName": self.testInit.couchDbName,
+            "SiteWhitelist" : ["T1_CH_CERN", "T1_US_FNAL"],
+            "DashboardHost": "127.0.0.1",
+            "DashboardPort": 8884,
+            "TaskChain" : 2,
+            "Task1" :{
+                "InputDataset" : "/cosmics/whatever-input-v1/GEN-SIM",
+                "TaskName" : "DIGI",
+                "ConfigCacheID" : processorDocs['DigiHLT'],
+                "SplittingAlgo" : "LumiBased",
+                "LumisPerJob": 4,
+                "MCPileup": "/some/cosmics-mc-v1/GEN-SIM",
+                "DeterministicPileup": True,
+                "CMSSWVersion" : "CMSSW_5_2_6",
+                "GlobalTag" : "GR_39_P_V5:All",
+                "PrimaryDataset" : "PURelValTTBar",
+                "AcquisitionEra": "CMSSW_5_2_6",
+                "ProcessingString": "ProcStr_Task1"
+            },
+            "Task2" : {
+                "TaskName" : "RECO",
+                "InputTask" : "DIGI",
+                "InputFromOutputModule" : "writeRAWDIGI",
+                "ConfigCacheID" : processorDocs['Reco'],
+                "DataPileup": "/some/minbias-data-v1/GEN-SIM",
+                "SplittingAlgo" : "LumiBased",
+                "LumisPerJob": 2,
+                "GlobalTag": "GR_R_62_V3::All",
+                "AcquisitionEra": "CMSSW_5_2_7",
+                "ProcessingString": "ProcStr_Task2"
+            },
+        }
+        
+        testArguments.update(arguments)
+        arguments = testArguments
+
+        factory = TaskChainWorkloadFactory()
+        self.workload = factory.factoryWorkloadConstruction("PullingTheChain", arguments)
+
+        firstTask = self.workload.getTaskByPath("/PullingTheChain/DIGI")
+        cmsRunStep = firstTask.getStep("cmsRun1").getTypeHelper()
+        pileupData = cmsRunStep.getPileup()
+        self.assertFalse(hasattr(pileupData, "data"))
+        self.assertEqual(pileupData.mc.dataset, ["/some/cosmics-mc-v1/GEN-SIM"])
+        splitting = firstTask.jobSplittingParameters()
+        self.assertTrue(splitting["deterministicPileup"])
+
+        secondTask = self.workload.getTaskByPath("/PullingTheChain/DIGI/DIGIMergewriteRAWDIGI/RECO")
+        cmsRunStep = secondTask.getStep("cmsRun1").getTypeHelper()
+        pileupData = cmsRunStep.getPileup()
+        self.assertFalse(hasattr(pileupData, "mc"))
+        self.assertEqual(pileupData.data.dataset, ["/some/minbias-data-v1/GEN-SIM"])
+        splitting = secondTask.jobSplittingParameters()
+        self.assertFalse(splitting["deterministicPileup"])
+
+
     def buildMultithreadedTaskChain(self, filename):
         """    d
         Build a TaskChain from several sources and customization


### PR DESCRIPTION
Fixes #6219 which was already available in MonteCarlo but not in MonteCarloFromGEN.

I also added the deterministicPileup capability to these 2 specs and TaskChain.

@ticoann do NOT merge it yet. I ran basic tests in my VM and workload gets properly filled, I just need to check a couple other things (and unittests + pylint).

TODO: I noticed EventBased splitting is not capable to handle it yet.. I will create another issue to get it fixed there as well.
