### PR TITLE
fix a PhEDExInjector deadlock problem

### DIFF
--- a/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
+++ b/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
@@ -245,11 +245,7 @@ class PhEDExInjectorPoller(BaseWorkerThread):
 
         actual PhEDEx call for file injection
         """
-        myThread = threading.currentThread()
-
         xmlData = self.createInjectionSpec(injectData)
-
-        myThread.transaction.begin()
 
         try:
             injectRes = self.phedex.injectBlocks(location, xmlData)
@@ -279,11 +275,7 @@ class PhEDExInjectorPoller(BaseWorkerThread):
             logging.error(msg)
             self.sendAlert(6, msg = msg)
         else:
-            self.setStatus.execute(lfnList, 1,
-                                   conn = myThread.transaction.conn,
-                                   transaction = myThread.transaction)
-
-        myThread.transaction.commit()
+            self.setStatus.execute(lfnList, 1, transaction = False)
 
         return
 


### PR DESCRIPTION
Should fix an occasional Oracle deadlock crash.

Transaction included too much unrelated code and isn't needed in any case.
