### PR TITLE
Update WQ to handle PhEDExNodeNames; fixed remote read

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
+++ b/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
@@ -24,7 +24,7 @@ def mapSitetoSE(sites):
     fakeSEs = []
     rControl = ResourceControl()
     for site in sites:
-        fakeSEs.extend(rControl.listSiteInfo(site)['se_name'])
+        fakeSEs.extend(rControl.listSiteInfo(site)['pnn'])
     return fakeSEs
 
 class PileupFetcher(FetcherInterface):

--- a/src/python/WMCore/WorkQueue/DataLocationMapper.py
+++ b/src/python/WMCore/WorkQueue/DataLocationMapper.py
@@ -47,6 +47,14 @@ def timeFloor(number, interval = UPDATE_INTERVAL_COARSENESS):
     from math import floor
     return floor(number / interval) * interval
 
+
+def isDataset(inputData):
+    """Check whether we're handling a block or a dataset"""
+    if '#' in inputData.split('/')[-1]:
+        return False
+    return True
+
+
 class DataLocationMapper():
     """Map data to locations for WorkQueue"""
     def __init__(self, **kwargs):
@@ -113,13 +121,13 @@ class DataLocationMapper():
                 args['update_since'] = timeFloor(self.lastLocationUpdate, self.params['updateIntervalCoarseness'])
             for dataItem in dataItems:
                 try:
-                    if datasetSearch:
+                    if datasetSearch or isDataset(dataItem):
                         response = self.phedex.getReplicaInfoForBlocks(dataset = [dataItem], **args)['phedex']
                     else:
                         response = self.phedex.getReplicaInfoForBlocks(block = [dataItem], **args)['phedex']
                     for block in response['block']:
-                        nodes = [se['node'] for se in block['replica']]
-                        if datasetSearch:
+                        nodes = [replica['node'] for replica in block['replica']]
+                        if datasetSearch or isDataset(dataItem):
                             result[dataItem].update(nodes)
                         else:
                             result[block['name']].update(nodes)
@@ -143,7 +151,7 @@ class DataLocationMapper():
         result = defaultdict(set)
         for item in dataItems:
             try:
-                if datasetSearch:
+                if datasetSearch or isDataset(dataItem):
                     phedexNodeNames = dbs.listDatasetLocation(item, dbsOnly = True)
                 else:
                     phedexNodeNames = dbs.listFileBlockLocation(item, dbsOnly = True)

--- a/src/python/WMCore/WorkQueue/WMBSHelper.py
+++ b/src/python/WMCore/WorkQueue/WMBSHelper.py
@@ -737,10 +737,13 @@ class WMBSHelper(WMConnectionBase):
                 continue
 
             # Create a LumiList from the WMBS info
-            lumis = []
+            runLumis = {}
             for x in f['LumiList']:
-                lumis.append([str(x['RunNumber']), x['LumiSectionNumber']])
-            fileLumiList = LumiList(lumis=lumis)
+                if x['RunNumber'] in runLumis:
+                    runLumis[x['RunNumber']].extend(x['LumiSectionNumber'])
+                else:
+                    runLumis[x['RunNumber']] = x['LumiSectionNumber']
+            fileLumiList = LumiList(runsAndLumis=runLumis)
 
             if lumiMask:
                 if fileLumiList & lumiMask:  # At least one lumi from file is in lumiMask

--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -387,18 +387,17 @@ class WorkQueue(WorkQueueBase):
         for blockName in blocks:
             tmpDsetDict.update(dbs.getFileBlock(blockName))
 
-        dbsDatasetDict = {'Files': [], 'IsOpen': False, 'StorageElements': []}
+        dbsDatasetDict = {'Files': [], 'IsOpen': False, 'PhEDExNodeNames': []}
         dbsDatasetDict['Files'] = [f for block in tmpDsetDict.values() for f in block['Files']]
-        dbsDatasetDict['StorageElements'].extend(
-            [f for block in tmpDsetDict.values() for f in block['StorageElements']])
-        dbsDatasetDict['StorageElements'] = list(set(dbsDatasetDict['StorageElements']))
+        dbsDatasetDict['PhEDExNodeNames'].extend(
+            [f for block in tmpDsetDict.values() for f in block['PhEDExNodeNames']])
+        dbsDatasetDict['PhEDExNodeNames'] = list(set(dbsDatasetDict['PhEDExNodeNames']))
 
         if wmspec.locationDataSourceFlag():
-            seElements = []
-            for cmsSite in match['Inputs'].values()[0]:
-                ses = self.SiteDB.cmsNametoSE(cmsSite)
-                seElements.extend(ses)
-            dbsDatasetDict['StorageElements'] = list(set(seElements))
+            PhEDExNodeNames = []
+            for pnn in match['Inputs'].values()[0]:
+                PhEDExNodeNames.append(pnn)
+            dbsDatasetDict['PhEDExNodeNames'] = list(set(PhEDExNodeNames))
         return datasetName, dbsDatasetDict
 
     def _getDBSBlock(self, match, wmspec):
@@ -418,10 +417,10 @@ class WorkQueue(WorkQueueBase):
             block = {}
             block["Files"] = fileLists
             if wmspec.locationDataSourceFlag():
-                PhEDExNodeNames = set()
+                PhEDExNodeNames = []
                 for pnn in match['Inputs'].values()[0]:  # TODO: Allow more than one
-                    PhEDExNodeNames.update(pnn)
-                PhEDExNodeNames = list(PhEDExNodeNames)
+                    PhEDExNodeNames.append(pnn)
+                PhEDExNodeNames = list(set(PhEDExNodeNames))
                 for fileInfo in block["Files"]:
                     fileInfo['locations'] = PhEDExNodeNames
             return blockName, block
@@ -434,10 +433,10 @@ class WorkQueue(WorkQueueBase):
 
             if wmspec.locationDataSourceFlag():
                 blockInfo = dbsBlockDict[blockName]
-                PhEDExNodeNames = set()
+                PhEDExNodeNames = []
                 for pnn in match['Inputs'].values()[0]:  # TODO: Allow more than one
-                    PhEDExNodeNames.update(pnn)
-                PhEDExNodeNames = list(PhEDExNodeNames)
+                    PhEDExNodeNames.append(pnn)
+                PhEDExNodeNames = list(set(PhEDExNodeNames))
                 blockInfo['PhEDExNodeNames'] = PhEDExNodeNames
         return blockName, dbsBlockDict[blockName]
 

--- a/src/python/WMQuality/Emulators/DBSClient/DBSReader.py
+++ b/src/python/WMQuality/Emulators/DBSClient/DBSReader.py
@@ -180,15 +180,14 @@ class DBSReader:
         return None
 
 
-
     def getDBSSummaryInfo(self, dataset=None, block=None):
-
         """Dataset summary"""
+
         def getLumisectionsInBlock(b):
-            lumis = set()
+            lumis = 0
             for file in self.dataBlocks.getFiles(b):
                 for x in file['LumiList']:
-                    lumis.add(x['LumiSectionNumber'])
+                    lumis =+ len(x['LumiSectionNumber'])
             return lumis
 
         result = {}
@@ -197,7 +196,7 @@ class DBSReader:
                                 for x in self.dataBlocks.getFiles(block)]))
             result['NumberOfFiles'] = str(len(self.dataBlocks.getFiles(block)))
 
-            result['NumberOfLumis'] = str(len(getLumisectionsInBlock(block)))
+            result['NumberOfLumis'] = str(getLumisectionsInBlock(block))
 
             result['path'] = dataset
             result['block'] = block
@@ -209,11 +208,11 @@ class DBSReader:
                                     for x in self.dataBlocks.getBlocks(dataset)]))
                 result['NumberOfFiles'] = str(sum([x['NumberOfFiles']
                                     for x in self.dataBlocks.getBlocks(dataset)]))
-                lumis = set()
+                lumis = 0
                 for b in self.dataBlocks.getBlocks(dataset):
-                    lumis = lumis.union(getLumisectionsInBlock(b['Name']))
+                    lumis += b['NumberOfLumis']
 
-                result['NumberOfLumis'] = str(len(lumis))
+                result['NumberOfLumis'] = str(lumis)
                 result['path'] = dataset
 
         # Weird error handling follows, this is what dbs does

--- a/src/python/WMQuality/Emulators/DataBlockGenerator/DataBlockGenerator.py
+++ b/src/python/WMQuality/Emulators/DataBlockGenerator/DataBlockGenerator.py
@@ -86,9 +86,8 @@ class DataBlockGenerator(object):
                           'ParentList': [],
                           # assign run and lumi numbers in appropriate range: note run numbers
                           #  for successive blocks may overlap if numOfRunsPerFile() > 1
-                          'LumiList': [{'RunNumber': int(round((1. * lumi * (GlobalParams.numOfRunsPerFile() - 1) / GlobalParams.numOfLumisPerBlock()) + run)),     #random.randint(run, run + GlobalParams.numOfRunsPerFile() -1),
-                                        'LumiSectionNumber': run*(GlobalParams.numOfLumisPerBlock()) + lumi -1}
-                                       for lumi in range(GlobalParams.numOfLumisPerBlock())]
+                          'LumiList': [{'RunNumber': GlobalParams.numOfRunsPerFile(),
+                                        'LumiSectionNumber': range(1, GlobalParams.numOfLumisPerBlock()+1)}]
                           }
         defaultDBSFile.update(dbsFile)
         return defaultDBSFile

--- a/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Dataset_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Dataset_t.py
@@ -144,10 +144,10 @@ class DatasetTestCase(unittest.TestCase):
         units, _ = Dataset(**self.splitArgs)(blacklistBlockWorkload, task)
         self.assertEqual(len(units), 1)
         self.assertEqual(units[0]['Inputs'].keys(), [dataset])
-        self.assertEqual(units[0]['Jobs'], 2.0)
-        self.assertEqual(4, units[0]['NumberOfLumis'])
-        self.assertEqual(10, units[0]['NumberOfFiles'])
-        self.assertEqual(10000, units[0]['NumberOfEvents'])
+        self.assertEqual(units[0]['Jobs'], 4.0)
+        self.assertEqual(8, units[0]['NumberOfLumis'])
+        self.assertEqual(20, units[0]['NumberOfFiles'])
+        self.assertEqual(20000, units[0]['NumberOfEvents'])
 
         rerecoArgs3 = {}
         rerecoArgs3.update(rerecoArgs)
@@ -175,10 +175,10 @@ class DatasetTestCase(unittest.TestCase):
         units, _ = Dataset(**self.splitArgs)(blacklistBlockWorkload, task)
         self.assertEqual(len(units), 1)
         self.assertEqual(units[0]['Inputs'].keys(), [dataset])
-        self.assertEqual(units[0]['Jobs'], 2.0)
-        self.assertEqual(4, units[0]['NumberOfLumis'])
-        self.assertEqual(10, units[0]['NumberOfFiles'])
-        self.assertEqual(10000, units[0]['NumberOfEvents'])
+        self.assertEqual(units[0]['Jobs'], 4.0)
+        self.assertEqual(8, units[0]['NumberOfLumis'])
+        self.assertEqual(20, units[0]['NumberOfFiles'])
+        self.assertEqual(20000, units[0]['NumberOfEvents'])
 
         # Run Mixed Whitelist
         rerecoArgs3 = {}
@@ -259,11 +259,10 @@ class DatasetTestCase(unittest.TestCase):
             for unit in units:
                 wq_jobs += unit['Jobs']
                 runLumis = dbs[inputDataset.dbsurl].listRunLumis(dataset=unit['Inputs'].keys()[0])
-                print "runLumis", runLumis
                 for run in runLumis:
                     if run in getFirstTask(Tier1ReRecoWorkload).inputRunWhitelist():
                         self.assertEqual(runLumis[run], None)  # This is what it is with DBS3 unless we calculate it
-            self.assertEqual(75, int(wq_jobs))
+            self.assertEqual(40, int(wq_jobs))
 
     def testInvalidSpecs(self):
         """Specs with no work"""

--- a/test/python/WMCore_t/WorkQueue_t/WMBSHelper_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WMBSHelper_t.py
@@ -822,7 +822,7 @@ class WMBSHelperTest(unittest.TestCase):
     def testReRecoWhiteRunRestriction(self):
         block = self.dataset + "#2"
         # Run Whitelist
-        self.topLevelTask.setInputRunWhitelist([2])
+        self.topLevelTask.setInputRunWhitelist([1])
         wmbs = self.createWMBSHelperWithTopTask(self.wmspec, block)
         files = wmbs.validFiles(self.dbs.getFileBlock(block)[block]['Files'])
         self.assertEqual(len(files), GlobalParams.numOfFilesPerBlock())


### PR DESCRIPTION
Fixes 2 things. 
1. My last fix for DQMHarvest :(, since I followed the SE convention instead of PNNs
2. setting to read data remotely would fail since updating a set with string will break the string down in chars and update the set with each elements

Do NOT merge yet please, needs further test. 
