### PR TITLE
make the jobsplitting trustsitelists aware

### DIFF
--- a/test/python/WMComponent_t/JobSubmitter_t/JobSubmitterCaching_t.py
+++ b/test/python/WMComponent_t/JobSubmitter_t/JobSubmitterCaching_t.py
@@ -122,8 +122,7 @@ class JobSubmitterCachingTest(unittest.TestCase):
 
             newJobA = Job(name = "testJobA-%s" % i, files = [newFile])
             newJobA["workflow"] = "wf001"
-            newJobA["siteWhitelist"] = ["T1_US_FNAL"]
-            newJobA["siteBlacklist"] = []
+            newJobA["possiblePSN"] = ["T1_US_FNAL"]
             newJobA["sandbox"] = "%s/somesandbox" % self.testDir
             newJobA["owner"] = "Steve"
 
@@ -141,8 +140,7 @@ class JobSubmitterCachingTest(unittest.TestCase):
 
             newJobB = Job(name = "testJobB-%s" % i, files = [newFile])
             newJobB["workflow"] = "wf001"
-            newJobB["siteWhitelist"] = ["T1_UK_RAL"]
-            newJobB["siteBlacklist"] = []
+            newJobB["possiblePSN"] = ["T1_UK_RAL"]
             newJobB["sandbox"] = "%s/somesandbox" % self.testDir
             newJobB["owner"] = "Steve"
 

--- a/test/python/WMCore_t/JobSplitting_t/JobFactory_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/JobFactory_t.py
@@ -53,8 +53,6 @@ class JobFactoryTest(unittest.TestCase):
                 self.assertEqual(job["task"], "TestTask", "Error: Task is wrong.")
                 self.assertEqual(job["workflow"], "TestWorkflow", "Error: Workflow is wrong.")
                 self.assertEqual(job["owner"], "Steve", "Error: Owner is wrong.")
-                self.assertEqual(job["siteWhitelist"], ["site1"], "Error: Site white list is wrong.")
-                self.assertEqual(job["siteBlacklist"], ["site2"], "Error: Site black list is wrong.")
         return
 
     def testProductionRunNumber(self):

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/EventAwareLumiBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/EventAwareLumiBased_t.py
@@ -49,8 +49,8 @@ class EventAwareLumiBasedTest(unittest.TestCase):
                                 dbinterface = myThread.dbi)
 
         locationAction = daofactory(classname = "Locations.New")
-        locationAction.execute(siteName = 's1', pnn = "T1_US_FNAL_Disk")
-        locationAction.execute(siteName = 's2', pnn = "T2_CH_CERN")
+        locationAction.execute(siteName = "T1_US_FNAL", pnn = "T1_US_FNAL_Disk")
+        locationAction.execute(siteName = "T2_CH_CERN", pnn = "T2_CH_CERN")
 
         self.testWorkflow = Workflow(spec = "spec.xml", owner = "Steve",
                                 name = "wf001", task = "Test")

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/ParentlessMergeBySize_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/ParentlessMergeBySize_t.py
@@ -63,10 +63,7 @@ class ParentlessMergeBySizeTest(unittest.TestCase):
         well as to the output fileset for their jobgroups.
         """
         locationAction = self.daoFactory(classname="Locations.New")
-        locationAction.execute(siteName="s1", pnn="T1_US_FNAL_Disk")
-        locationAction.execute(siteName="s1", pnn="T1_US_FNAL_MSS")
-
-        changeStateDAO = self.daoFactory(classname="Jobs.ChangeState")
+        locationAction.execute(siteName="T1_US_FNAL", pnn="T1_US_FNAL_Disk")
 
         self.mergeFileset = Fileset(name="mergeFileset")
         self.mergeFileset.create()
@@ -192,6 +189,8 @@ class ParentlessMergeBySizeTest(unittest.TestCase):
 
         self.assertEqual(result[0].jobs[0]["estimatedDiskUsage"], 10 + 2 * 100)
 
+        self.assertEqual(result[0].jobs[0]["possiblePSN"], set(["T1_US_FNAL"]))
+
         goldenFiles = ["file1", "file2", "file3", "file4", "fileA", "fileB",
                        "fileC", "fileI", "fileII", "fileIII", "fileIV"]
 
@@ -202,10 +201,8 @@ class ParentlessMergeBySizeTest(unittest.TestCase):
         currentEvent = 0
         for jobFile in jobFiles:
             jobFile.loadData()
-            assert jobFile["lfn"] in goldenFiles, \
-                "Error: Unknown file: %s" % jobFile["lfn"]
-            self.assertTrue(jobFile["locations"] == set(["T1_US_FNAL_Disk", "T1_US_FNAL_MSS"]),
-                            "Error: File is missing a location.")
+            self.assertTrue(jobFile["lfn"] in goldenFiles,
+                            "Error: Unknown file: %s" % jobFile["lfn"])
             goldenFiles.remove(jobFile["lfn"])
 
             fileRun = list(jobFile["runs"])[0].run
@@ -264,6 +261,9 @@ class ParentlessMergeBySizeTest(unittest.TestCase):
         goldenFilesB = ["fileIV"]
 
         for job in result[0].jobs:
+
+            self.assertEqual(job["possiblePSN"], set(["T1_US_FNAL"]))
+
             jobFiles = job.getFiles()
 
             if jobFiles[0]["lfn"] in goldenFilesA:
@@ -277,10 +277,8 @@ class ParentlessMergeBySizeTest(unittest.TestCase):
             currentLumi = 0
             currentEvent = 0
             for jobFile in jobFiles:
-                assert jobFile["lfn"] in goldenFiles, \
-                    "Error: Unknown file in merge jobs."
-                assert jobFile["locations"] == set(["T1_US_FNAL_Disk"]), \
-                    "Error: File is missing a location."
+                self.assertTrue(jobFile["lfn"] in goldenFiles,
+                                "Error: Unknown file: %s" % jobFile["lfn"])
 
                 goldenFiles.remove(jobFile["lfn"])
 
@@ -341,6 +339,9 @@ class ParentlessMergeBySizeTest(unittest.TestCase):
         goldenFilesB = ["fileIII"]
 
         for job in result[0].jobs:
+
+            self.assertEqual(job["possiblePSN"], set(["T1_US_FNAL"]))
+
             jobFiles = job.getFiles()
 
             if jobFiles[0]["lfn"] in goldenFilesA:
@@ -354,10 +355,8 @@ class ParentlessMergeBySizeTest(unittest.TestCase):
             currentLumi = 0
             currentEvent = 0
             for jobFile in jobFiles:
-                assert jobFile["lfn"] in goldenFiles, \
-                    "Error: Unknown file in merge jobs."
-                assert jobFile["locations"] == set(["T1_US_FNAL_Disk"]), \
-                    "Error: File is missing a location: %s" % jobFile["locations"]
+                self.assertTrue(jobFile["lfn"] in goldenFiles,
+                                "Error: Unknown file: %s" % jobFile["lfn"])
 
                 goldenFiles.remove(jobFile["lfn"])
 
@@ -416,13 +415,16 @@ class ParentlessMergeBySizeTest(unittest.TestCase):
         assert len(result[0].jobs) == 2, \
             "Error: Two jobs should have been returned: %s" % len(result[0].jobs)
 
-        goldenFilesA = ["file1", "file2", "file3", "file4", "fileA", "fileB",
-                        "fileC"]
+        goldenFilesA = ["file1", "file2", "file3", "file4",
+                        "fileA", "fileB", "fileC"]
         goldenFilesB = ["fileI", "fileII", "fileIII", "fileIV"]
         goldenFilesA.sort()
         goldenFilesB.sort()
 
         for job in result[0].jobs:
+
+            self.assertEqual(job["possiblePSN"], set(["T1_US_FNAL"]))
+
             currentRun = 0
             currentLumi = 0
             currentEvent = 0
@@ -431,8 +433,6 @@ class ParentlessMergeBySizeTest(unittest.TestCase):
             for jobFile in job.getFiles():
                 jobFile.loadData()
                 jobLFNs.append(jobFile["lfn"])
-                self.assertTrue(jobFile["locations"] == set(["T1_US_FNAL_Disk", "T1_US_FNAL_MSS"]),
-                                "Error: File is missing a location.")
 
                 fileRun = list(jobFile["runs"])[0].run
                 fileLumi = min(list(jobFile["runs"])[0])
@@ -501,6 +501,9 @@ class ParentlessMergeBySizeTest(unittest.TestCase):
         goldenFilesC = ["fileIV"]
 
         for job in result[0].jobs:
+
+            self.assertEqual(job["possiblePSN"], set(["T1_US_FNAL"]))
+
             jobFiles = job.getFiles()
 
             if jobFiles[0]["lfn"] in goldenFilesA:
@@ -518,9 +521,7 @@ class ParentlessMergeBySizeTest(unittest.TestCase):
             currentEvent = 0
             for jobFile in jobFiles:
                 self.assertTrue(jobFile["lfn"] in goldenFiles,
-                                "Error: Unknown file in merge jobs.")
-                self.assertTrue(jobFile["locations"] == set(["T1_US_FNAL_Disk"]),
-                                "Error: File is missing a location.")
+                                "Error: Unknown file: %s" % jobFile["lfn"])
 
                 goldenFiles.remove(jobFile["lfn"])
 
@@ -580,6 +581,9 @@ class ParentlessMergeBySizeTest(unittest.TestCase):
         goldenFilesC = ["fileIII"]
 
         for job in result[0].jobs:
+
+            self.assertEqual(job["possiblePSN"], set(["T1_US_FNAL"]))
+
             jobFiles = job.getFiles()
 
             if jobFiles[0]["lfn"] in goldenFilesA:
@@ -597,9 +601,7 @@ class ParentlessMergeBySizeTest(unittest.TestCase):
             currentEvent = 0
             for jobFile in jobFiles:
                 self.assertTrue(jobFile["lfn"] in goldenFiles,
-                                "Error: Unknown file in merge jobs.")
-                self.assertTrue(jobFile["locations"] == set(["T1_US_FNAL_Disk"]),
-                                "Error: File is missing a location: %s" % jobFile["locations"])
+                                "Error: Unknown file: %s" % jobFile["lfn"])
 
                 goldenFiles.remove(jobFile["lfn"])
 
@@ -641,9 +643,9 @@ class ParentlessMergeBySizeTest(unittest.TestCase):
         self.stuffWMBS()
 
         locationAction = self.daoFactory(classname = "Locations.New")
-        locationAction.execute(siteName = "s3", pnn = "T1_UK_RAL_Disk")
+        locationAction.execute(siteName = "T1_UK_RAL", pnn = "T1_UK_RAL_Disk")
 
-        fileSite2 = File(lfn = "fileSite2", size = 4098, events = 1024,
+        fileSite2 = File(lfn = "fileRAL", size = 4098, events = 1024,
                          first_event = 0, locations = set(["T1_UK_RAL_Disk"]))
         fileSite2.addRun(Run(1, *[46]))
         fileSite2.create()
@@ -664,16 +666,16 @@ class ParentlessMergeBySizeTest(unittest.TestCase):
         assert len(result[0].jobs) == 3, \
             "ERROR: Three jobs should have been returned."
 
+        ralJobs = 0
+        fnalJobs = 0
         for job in result[0].jobs:
-            firstInputFile = job.getFiles()[0]
-            baseLocation = list(firstInputFile["locations"])[0]
+            if job["possiblePSN"] == set(["T1_UK_RAL"]):
+                ralJobs += 1
+            elif job["possiblePSN"] == set(["T1_US_FNAL"]):
+                fnalJobs += 1
 
-            for inputFile in job.getFiles():
-                assert len(inputFile["locations"]) == 1, \
-                    "Error: Wrong number of locations"
-
-                assert list(inputFile["locations"])[0] == baseLocation, \
-                    "Error: Wrong location."
+        self.assertEqual(ralJobs, 1)
+        self.assertEqual(fnalJobs, 2)
 
         return
 

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/WMBSMergeBySize_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/WMBSMergeBySize_t.py
@@ -60,8 +60,8 @@ class WMBSMergeBySize(unittest.TestCase):
         well as to the output fileset for their jobgroups.
         """
         locationAction = self.daoFactory(classname = "Locations.New")
-        locationAction.execute(siteName = "s1", pnn = "T2_CH_CERN")
-        locationAction.execute(siteName = "s1", pnn = "T1_US_FNAL_Disk")
+        locationAction.execute(siteName = "T2_CH_CERN", pnn = "T2_CH_CERN")
+        locationAction.execute(siteName = "T1_US_FNAL", pnn = "T2_CH_CERN")
 
         changeStateDAO = self.daoFactory(classname = "Jobs.ChangeState")
 
@@ -381,6 +381,9 @@ class WMBSMergeBySize(unittest.TestCase):
         goldenFilesB = ["fileI", "fileII", "fileIII", "fileIV"]
 
         for job in result[0].jobs:
+
+            self.assertEqual(job["possiblePSN"], set(["T1_US_FNAL", "T2_CH_CERN"]))
+
             jobFiles = job.getFiles()
 
             if len(jobFiles) == len(goldenFilesA):
@@ -397,8 +400,6 @@ class WMBSMergeBySize(unittest.TestCase):
                 file.loadData()
                 assert file["lfn"] in goldenFiles, \
                        "Error: Unknown file: %s" % file["lfn"]
-                assert file["locations"] == set(["T2_CH_CERN", "T1_US_FNAL_Disk"]), \
-                       "Error: File is missing a location."
                 goldenFiles.remove(file["lfn"])
 
                 fileRun = list(file["runs"])[0].run
@@ -454,6 +455,8 @@ class WMBSMergeBySize(unittest.TestCase):
 
         self.assertEqual(result[0].jobs[0]["estimatedDiskUsage"], 7)
 
+        self.assertEqual(result[0].jobs[0]["possiblePSN"], set(["T1_US_FNAL", "T2_CH_CERN"]))
+
         jobFiles = list(result[0].jobs)[0].getFiles()
 
         goldenFiles = ["file1", "file2", "file3", "file4", "fileA", "fileB",
@@ -468,8 +471,6 @@ class WMBSMergeBySize(unittest.TestCase):
         for file in jobFiles:
             assert file["lfn"] in goldenFiles, \
                    "Error: Unknown file: %s" % file["lfn"]
-            assert file["locations"] == set(["T2_CH_CERN", "T1_US_FNAL_Disk"]), \
-                   "Error: File is missing a location."
             goldenFiles.remove(file["lfn"])
 
             fileRun = list(file["runs"])[0].run
@@ -522,6 +523,8 @@ class WMBSMergeBySize(unittest.TestCase):
         assert len(result[0].jobs) == 3, \
                "ERROR: Three jobs should have been returned."
 
+        self.assertEqual(result[0].jobs[0]["possiblePSN"], set(["T1_US_FNAL", "T2_CH_CERN"]))
+
         goldenFilesA = ["file1", "file2", "file3", "file4"]
         goldenFilesB = ["fileA", "fileB", "fileC"]
         goldenFilesC = ["fileI", "fileII", "fileIII", "fileIV"]
@@ -545,9 +548,6 @@ class WMBSMergeBySize(unittest.TestCase):
             for file in jobFiles:
                 assert file["lfn"] in goldenFiles, \
                        "Error: Unknown file in merge jobs."
-                assert file["locations"] == set(["T2_CH_CERN", "T1_US_FNAL_Disk"]), \
-                       "Error: File is missing a location."
-
                 goldenFiles.remove(file["lfn"])
 
             fileRun = list(file["runs"])[0].run
@@ -611,14 +611,14 @@ class WMBSMergeBySize(unittest.TestCase):
 
         self.assertEqual(result[0].jobs[0]["estimatedDiskUsage"], 7)
 
+        self.assertEqual(result[0].jobs[0]["possiblePSN"], set(["T1_US_FNAL", "T2_CH_CERN"]))
+
         jobFiles = list(result[0].jobs)[0].getFiles()
 
         currentRun = 0
         currentLumi = 0
         currentEvent = 0
         for file in jobFiles:
-            assert file["locations"] == set(["T2_CH_CERN", "T1_US_FNAL_Disk"]), \
-                   "Error: File is missing a location."
 
             if file["lfn"] in goldenFilesA:
                 goldenFilesA.remove(file["lfn"])
@@ -684,6 +684,9 @@ class WMBSMergeBySize(unittest.TestCase):
         goldenFilesC = ["fileI", "fileII", "fileIII", "fileIV"]
 
         for job in result[0].jobs:
+
+            self.assertEqual(job["possiblePSN"], set(["T1_US_FNAL", "T2_CH_CERN"]))
+
             jobFiles = job.getFiles()
 
             if jobFiles[0]["lfn"] in goldenFilesA:
@@ -702,9 +705,6 @@ class WMBSMergeBySize(unittest.TestCase):
             for file in jobFiles:
                 assert file["lfn"] in goldenFiles, \
                        "Error: Unknown file in merge jobs."
-                assert file["locations"] == set(["T2_CH_CERN", "T1_US_FNAL_Disk"]), \
-                       "Error: File is missing a location: %s" % file["locations"]
-
                 goldenFiles.remove(file["lfn"])
 
                 fileRun = list(file["runs"])[0].run
@@ -764,6 +764,8 @@ class WMBSMergeBySize(unittest.TestCase):
 
         self.assertEqual(result[0].jobs[0]["estimatedDiskUsage"], 7)
 
+        self.assertEqual(result[0].jobs[0]["possiblePSN"], set(["T1_US_FNAL", "T2_CH_CERN"]))
+
         goldenFilesA = ["file1", "file2", "file3", "file4"]
         goldenFilesB = ["fileA", "fileB", "fileC"]
         goldenFilesC = ["fileI", "fileII", "fileIII", "fileIV"]
@@ -774,8 +776,6 @@ class WMBSMergeBySize(unittest.TestCase):
         currentLumi = 0
         currentEvent = 0
         for file in jobFiles:
-            assert file["locations"] == set(["T2_CH_CERN", "T1_US_FNAL_Disk"]), \
-                   "Error: File is missing a location."
 
             if file["lfn"] in goldenFilesA:
                 goldenFilesA.remove(file["lfn"])
@@ -825,8 +825,8 @@ class WMBSMergeBySize(unittest.TestCase):
         subscriptions.
         """
         locationAction = self.daoFactory(classname = "Locations.New")
-        locationAction.execute(siteName = "s1", pnn = "T2_CH_CERN")
-        locationAction.execute(siteName = "s1", pnn = "T1_US_FNAL_Disk")
+        locationAction.execute(siteName = "T2_CH_CERN", pnn = "T2_CH_CERN")
+        locationAction.execute(siteName = "T1_US_FNAL", pnn = "T2_CH_CERN")
 
 
         mergeFilesetA = Fileset(name = "mergeFilesetA")
@@ -1038,7 +1038,7 @@ class WMBSMergeBySize(unittest.TestCase):
         self.stuffWMBS()
 
         locationAction = self.daoFactory(classname = "Locations.New")
-        locationAction.execute(siteName = "s2", pnn = "T1_UK_RAL_Disk")
+        locationAction.execute(siteName = "T1_UK_RAL", pnn = "T1_UK_RAL_Disk")
 
         fileSite2 = File(lfn = "fileSite2", size = 4098, events = 1024,
                          first_event = 0, locations = set(["T1_UK_RAL_Disk"]))
@@ -1062,17 +1062,16 @@ class WMBSMergeBySize(unittest.TestCase):
         assert len(result[0].jobs) == 2, \
                "ERROR: Two jobs should have been returned."
 
+        ralJobs = 0
+        fnalcernJobs = 0
         for job in result[0].jobs:
-            firstInputFile = job.getFiles()[0]
-            baseLocation = list(firstInputFile["locations"])[0]
+            if job["possiblePSN"] == set(["T1_UK_RAL"]):
+                ralJobs += 1
+            elif job["possiblePSN"] == set(["T1_US_FNAL", "T2_CH_CERN"]):
+                fnalcernJobs += 1
 
-            for inputFile in job.getFiles():
-                assert inputFile["locations"] == set(["T2_CH_CERN", "T1_US_FNAL_Disk"]) or \
-                       inputFile["locations"] == set(["T1_UK_RAL_Disk"]), \
-                       "Error: Wrong number of locations"
-
-                assert list(inputFile["locations"])[0] == baseLocation, \
-                       "Error: Wrong location."
+        self.assertEqual(ralJobs, 1)
+        self.assertEqual(fnalcernJobs, 1)
 
         return
 


### PR DESCRIPTION
If the TrustSiteLists paramater is set, change the job splitting to only look at sitewhitelists and siteblacklists and not real locations.

Currently running a Tier0 replay (PromptReco at T1) to test the basics.

@ticoann @amaltaro does the change look alright ?
