### PR TITLE
fix WorkQueue_t test

### DIFF
--- a/src/python/WMCore/WMSpec/WMWorkloadTools.py
+++ b/src/python/WMCore/WMSpec/WMWorkloadTools.py
@@ -61,7 +61,7 @@ def strToBool(string):
 def _verifyDBSCall(dbsURL, uri):
     try:
         #from WMCore.Services.DBS.DBS3Reader import DBS3Reader
-        #DBS3Reader(dbsUrl).dbs.serverinfo()
+        #DBS3Reader(dbsURL).dbs.serverinfo()
         from WMCore.Services.Requests import JSONRequests
         jsonSender = JSONRequests(dbsURL)
         result = jsonSender.get("/%s" % uri)

--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -725,7 +725,7 @@ class WorkQueue(WorkQueueBase):
         self.backend.recordTaskActivity('location_refresh')
         return result
 
-    def pullWork(self, resources=None, continuousReplication=True):
+    def pullWork(self, resources=None):
         """
         Pull work from another WorkQueue to be processed
 
@@ -880,6 +880,7 @@ class WorkQueue(WorkQueueBase):
         for key, value in requestsInfo.items():
             if (value["RequestStatus"] == None) or (value["RequestStatus"] in deletableStates):
                 deleteRequests.append(key)
+            
         return self.backend.deleteWQElementsByWorkflow(deleteRequests)
 
     def performSyncAndCancelAction(self, skipWMBS):

--- a/src/python/WMQuality/Emulators/SiteDBClient/SiteDB.py
+++ b/src/python/WMQuality/Emulators/SiteDBClient/SiteDB.py
@@ -65,6 +65,9 @@ class SiteDBJSON(object):
                             {u'phedex_name': u'T1_UK_RAL_Disk',  u'psn_name': u'T1_UK_RAL',  u'site_name': u'RAL-LCG2-DISK'},
                             {u'phedex_name': u'T1_US_FNAL_Disk',  u'psn_name': u'T1_US_FNAL',  u'site_name': u'USCMS-FNAL-WC1-DISK'},
                             {u'phedex_name': u'T2_UK_London_IC',  u'psn_name': u'T2_UK_London_IC',  u'site_name': u'UKI-LT2-IC-HEP'},
+                            {u'phedex_name': u'T2_XX_SiteA_MSS',  u'psn_name': u'T2_XX_SiteA',  u'site_name': u'XX_T2_XX_SiteA'},
+                            {u'phedex_name': u'T2_XX_SiteB_MSS',  u'psn_name': u'T2_XX_SiteB',  u'site_name': u'XX_T2_XX_SiteB'},
+                            {u'phedex_name': u'T2_XX_SiteC_MSS',  u'psn_name': u'T2_XX_SiteC',  u'site_name': u'XX_T2_XX_SiteC'},
                            ]
 
     def __init__(self, config={}):

--- a/test/python/WMCore_t/Services_t/WorkQueue_t/WorkQueue_t.py
+++ b/test/python/WMCore_t/Services_t/WorkQueue_t/WorkQueue_t.py
@@ -102,7 +102,7 @@ class WorkQueueTest(unittest.TestCase):
         storedElements = globalQ.backend.getElementsForWorkflow(specName)
         for element in storedElements:
             self.assertEqual(element['Priority'], 100)
-        self.assertTrue(localQ.pullWork({'T2_XX_SiteA' : 10}, continuousReplication = False) > 0)
+        self.assertTrue(localQ.pullWork({'T2_XX_SiteA' : 10}) > 0)
         localQ.processInboundWork(continuous = False)
         storedElements = localQ.backend.getElementsForWorkflow(specName)
         for element in storedElements:

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueueTestCase.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueueTestCase.py
@@ -38,6 +38,7 @@ class WorkQueueTestCase(unittest.TestCase):
         self.localQInboxDB2 = 'workqueue_t_local2_inbox'
         self.configCacheDB = 'workqueue_t_config_cache'
         self.logDBName = 'logdb_t'
+        self.requestDBName = 'workqueue_t_reqmgr_workload_cache'
         
         self.setSchema()
         self.testInit = TestInit('WorkQueueTest')
@@ -55,14 +56,17 @@ class WorkQueueTestCase(unittest.TestCase):
         self.testInit.setupCouch(self.localQInboxDB2, *self.couchApps)
         self.testInit.setupCouch(self.configCacheDB, 'ConfigCache')
         self.testInit.setupCouch(self.logDBName, 'LogDB')
+        self.testInit.setupCouch(self.requestDBName, 'ReqMgr')
         
 
         couchServer = CouchServer(os.environ.get("COUCHURL"))
         self.configCacheDBInstance = couchServer.connectDatabase(self.configCacheDB)
         
         self.localCouchMonitor = CouchMonitor(os.environ.get("COUCHURL"))
-    
+        self.localCouchMonitor.deleteReplicatorDocs()
+
         self.workDir = self.testInit.generateWorkDir()
+
         return
 
     def tearDown(self):
@@ -71,7 +75,7 @@ class WorkQueueTestCase(unittest.TestCase):
 
         Drop all the WMBS tables.
         """
-        #self.localCouchMonitor.deleteReplicatorDocs()
+        self.localCouchMonitor.deleteReplicatorDocs()
         self.testInit.tearDownCouch()
         self.testInit.clearDatabase()
         self.testInit.delWorkDir()


### PR DESCRIPTION
1. fixes unittests caused by changing behavior of cancel and done. - WQ elements are not deleted until request status is end status.
2. fixes unittest caused by PNN, PSN transition patch
3. fixes unittest caused by replication is no done before the following call is made.

Still need to emulate DBS - currently it calls production dbs for spec validation which can fail if the server is not available.
Also need to emulate ReqMgr2 call to test performCleanupAction correctly.
To makes sure replication is finished on time, add the time.sleep(2). Not completely sure that is optimal number to wait.

All the tests in local are passed at least
