### PR TITLE
Allow _ as a variable name and anything that starts with dummy

### DIFF
--- a/standards/.pylintrc
+++ b/standards/.pylintrc
@@ -91,7 +91,7 @@ method-rgx=([a-z][a-zA-Z0-9]*$)|([_]{2}[a-z]+[_]{2}$)|([a-z][a-zA-Z0-9]*_$)
 argument-rgx=[a-z][a-zA-Z0-9]*$
 
 # Regular expression which should only match correct variable names
-variable-rgx=[a-z][a-zA-Z0-9]*$
+variable-rgx=([a-z][a-zA-Z0-9]*$|^_$)
 
 # Regular expression which should only match correct class attr names
 attr-rgx=[a-z][a-zA-Z0-9]*$
@@ -137,7 +137,7 @@ init-import=no
 
 # A regular expression matching the name of dummy variables (i.e. expectedly
 # not used).
-dummy-variables-rgx=^dummy
+dummy-variables-rgx=(^dummy|^_$)
 
 # checks for :
 #     * methods without self as first argument


### PR DESCRIPTION
Fixed up the variable names that are allowed to be unused:

```
_
dummy
dummySomething
```

anything else will trigger a warning. The idea behind `dummySomething` is that you can easily note the return values of a function without using them, perhaps for future use. 
