### PR TITLE
Remove access to unittest internal variable which is breaking 2.7

### DIFF
--- a/test/python/WMCore_t/Services_t/Service_t.py
+++ b/test/python/WMCore_t/Services_t/Service_t.py
@@ -82,10 +82,7 @@ class ServiceTest(unittest.TestCase):
 
 
     def tearDown(self):
-        testname = self.id().split('.')[-1]
-        #shutil.rmtree(self.cache_path, ignore_errors = True)
         self.testInit.delWorkDir()
-
         # There was old code here to see if the test passed and send a message to
         # self.logger.info It broke in 2.7, so if needed find a supported way to do it
         return
@@ -294,7 +291,7 @@ class ServiceTest(unittest.TestCase):
         cherrypy.engine.start()
         FORMAT = '%(message)s'
         logging.basicConfig(format=FORMAT)
-        logger = logging.getLogger('john')
+        dummyLogger = logging.getLogger('john')
         test_dict = {'logger': self.logger,'endpoint':'http://127.0.0.1:%i/truncated' % self.port,
                      'usestalecache': True}
         myService = Service(test_dict)
@@ -312,7 +309,7 @@ class ServiceTest(unittest.TestCase):
         cherrypy.engine.start()
         FORMAT = '%(message)s'
         logging.basicConfig(format=FORMAT)
-        logger = logging.getLogger('john')
+        dummyLogger = logging.getLogger('john')
         test_dict = {'logger': self.logger,'endpoint':'http://127.0.0.1:%i/slow' % self.port,
                      'usestalecache': True}
         myService = Service(test_dict)
@@ -330,7 +327,7 @@ class ServiceTest(unittest.TestCase):
         """
         FORMAT = '%(message)s'
         logging.basicConfig(format=FORMAT)
-        logger = logging.getLogger('john')
+        dummyLogger = logging.getLogger('john')
         test_dict = {'logger': self.logger,'endpoint':'http://127.0.0.1:%i/badstatus' % self.port,
                      'usestalecache': True}
         myService = Service(test_dict)
@@ -354,7 +351,7 @@ class ServiceTest(unittest.TestCase):
         cherrypy.engine.start()
         FORMAT = '%(message)s'
         logging.basicConfig(format=FORMAT)
-        logger = logging.getLogger('john')
+        dummyLogger = logging.getLogger('john')
         test_dict = {'logger': self.logger,'endpoint':'http://127.0.0.1:%i/reg1/regular' % self.port,
                      'usestalecache': True, "cacheduration": 0.005}
         myService = Service(test_dict)

--- a/test/python/WMCore_t/Services_t/Service_t.py
+++ b/test/python/WMCore_t/Services_t/Service_t.py
@@ -86,10 +86,9 @@ class ServiceTest(unittest.TestCase):
         #shutil.rmtree(self.cache_path, ignore_errors = True)
         self.testInit.delWorkDir()
 
-        if self._exc_info()[0] == None:
-            self.logger.info('test "%s" passed' % testname)
-        else:
-            self.logger.info('test "%s" failed' % testname)
+        # There was old code here to see if the test passed and send a message to
+        # self.logger.info It broke in 2.7, so if needed find a supported way to do it
+        return
 
     def testClear(self):
         """

--- a/test/python/WMCore_t/WMLogging_t.py
+++ b/test/python/WMCore_t/WMLogging_t.py
@@ -21,10 +21,8 @@ class WMLoggingTest(unittest.TestCase):
         self.db = self.server.connectDatabase(self.dbname)
 
     def tearDown(self):
-        if self._exc_info()[0] == None:
-            # This test has passed, clean up after it
-            testname = self.id().split('.')[-1]
-            self.server.deleteDatabase(self.dbname)
+        # This used to test self._exc_info to only run on success. Broke in 2.7. Removed.
+        self.server.deleteDatabase(self.dbname)
 
     def testLog(self):
         """

--- a/test/python/WMCore_t/WMLogging_t.py
+++ b/test/python/WMCore_t/WMLogging_t.py
@@ -35,7 +35,7 @@ class WMLoggingTest(unittest.TestCase):
         handler.setFormatter(formatter)
         my_logger.addHandler(handler)
 
-        for i in range(10):
+        for _ in range(10):
             my_logger.debug('This is probably all noise.')
             my_logger.info('Jackdaws love my big sphinx of quartz.')
             my_logger.error('HOLLY CRAP!')


### PR DESCRIPTION
This should fix all the new errors that popped up with python 2.7 unit tests.
