### PR TITLE
some PhEDExInjector improvements

### DIFF
--- a/src/python/WMComponent/PhEDExInjector/PhEDExInjector.py
+++ b/src/python/WMComponent/PhEDExInjector/PhEDExInjector.py
@@ -8,9 +8,11 @@ DBS.
 
 import threading
 import logging
+import time
 
 from WMCore.Agent.Harness import Harness
-from WMCore.WMFactory import WMFactory
+
+from WMCore.Services.PhEDEx.PhEDEx import PhEDEx
 
 from WMComponent.PhEDExInjector.PhEDExInjectorPoller import PhEDExInjectorPoller
 from WMComponent.PhEDExInjector.PhEDExInjectorSubscriber import PhEDExInjectorSubscriber
@@ -22,12 +24,27 @@ class PhEDExInjector(Harness):
     def preInitialization(self):
         pollInterval = self.config.PhEDExInjector.pollInterval
         subInterval = self.config.PhEDExInjector.subscribeInterval
-        logging.info("Setting poll interval to %s seconds for inject" % pollInterval)
+        logging.info("Setting poll interval to %s seconds for inject", pollInterval)
 
+        # retrieving the node mappings is fickle and can fail quite often
+        # hence only do it once (with retries) and pass it to the workers
+        phedex = PhEDEx({"endpoint": self.config.PhEDExInjector.phedexurl}, "json")
+        try:
+            nodeMappings = phedex.getNodeMap()
+        except Exception:
+            time.sleep(2)
+            try:
+                nodeMappings = phedex.getNodeMap()
+            except Exception:
+                time.sleep(4)
+                nodeMappings = phedex.getNodeMap()
 
         myThread = threading.currentThread()
-        myThread.workerThreadManager.addWorker(PhEDExInjectorPoller(self.config), pollInterval)
+        myThread.workerThreadManager.addWorker(PhEDExInjectorPoller(self.config, phedex, nodeMappings), pollInterval)
 
         if getattr(self.config.PhEDExInjector, "subscribeDatasets", False):
-            logging.info("Setting poll interval to %s seconds for subscribe" % subInterval)
-            myThread.workerThreadManager.addWorker(PhEDExInjectorSubscriber(self.config), subInterval)
+            # wait a bit for first poll cycle of PhEDExInjectorPoller to complete
+            # hopefully avoids intermingled logs (which can be confusing)
+            time.sleep(2)
+            logging.info("Setting poll interval to %s seconds for subscribe", subInterval)
+            myThread.workerThreadManager.addWorker(PhEDExInjectorSubscriber(self.config, phedex, nodeMappings), subInterval)

--- a/test/python/WMComponent_t/PhEDExInjector_t/PhEDExInjectorSubscriber_t.py
+++ b/test/python/WMComponent_t/PhEDExInjector_t/PhEDExInjectorSubscriber_t.py
@@ -6,12 +6,15 @@ Created on Oct 12, 2012
 """
 
 import os
+import time
 import threading
 import unittest
 
 from WMComponent.DBS3Buffer.DBSBufferDataset import DBSBufferDataset
 from WMComponent.DBS3Buffer.DBSBufferFile import DBSBufferFile
 from WMComponent.DBS3Buffer.DBSBufferBlock import DBSBufferBlock
+
+from WMCore.Services.PhEDEx.PhEDEx import PhEDEx
 
 from WMComponent.PhEDExInjector.PhEDExInjectorSubscriber import PhEDExInjectorSubscriber
 
@@ -251,7 +254,19 @@ class PhEDExInjectorSubscriberTest(unittest.TestCase):
 
         self.stuffDatabase()
         config = self.createConfig()
-        subscriber = PhEDExInjectorSubscriber(config)
+
+        phedex = PhEDEx({"endpoint": config.PhEDExInjector.phedexurl}, "json")
+        try:
+            nodeMappings = phedex.getNodeMap()
+        except Exception:
+            time.sleep(2)
+            try:
+                nodeMappings = phedex.getNodeMap()
+            except Exception:
+                time.sleep(4)
+                nodeMappings = phedex.getNodeMap()
+
+        subscriber = PhEDExInjectorSubscriber(config, phedex, nodeMappings)
         subscriber.setup({})
         subscriber.algorithm({})
 


### PR DESCRIPTION
Two problems addressed in one pull request:

Retrieving the node map fails very often. It doesn't help that both worker thread do this at the same time when they are starting up. Move the retrieval out of the worker threads into the base component and also at least try it 3 times with a few second sleep in between the tries. This also fixes the problem where only one of the worker threads fails in the node map retrieval and the other worker thread keeps "working". Component log looks like the component is working, but it isn't really because half its functionality is dead.

The other issue is frequent Oracle deadlocks in the file status update. Already optimized the transaction handling as much as possible, but it still happens (although less frequent). My suspicion is a race condition between the two worker threads in accessing/modifying the same table/rows in different ways. If this is the case, the proper fix is to get rid of the two worker threads and only use one. Don't want to tackle this now (too big a change and also not sure if there weren't performance reasons why we are using two), but add a single retry after 1s instead. If we are really looking at a race condition that should probably "fix" the problem.
