### PR TITLE
add capability for highio jobs

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -259,11 +259,11 @@ config.JobArchiver.namespace = "WMComponent.JobArchiver.JobArchiver"
 config.JobArchiver.componentDir  = config.General.workDir + "/JobArchiver"
 config.JobArchiver.pollInterval = 240
 config.JobArchiver.logLevel = globalLogLevel
+config.JobArchiver.numberOfJobsToCluster = 1000
 # This is now OPTIONAL, it defaults to the componentDir
 # HOWEVER: Is is HIGHLY recommended that you do NOT run this on the same
 # disk as the JobCreator
 #config.JobArchiver.logDir = config.General.workDir + "/JobArchives"
-config.JobArchiver.numberOfJobsToCluster = 1000
 
 config.component_("TaskArchiver")
 config.TaskArchiver.namespace = "WMComponent.TaskArchiver.TaskArchiver"
@@ -554,8 +554,3 @@ config.ArchiveDataReporter.pollInterval = 300
 config.ArchiveDataReporter.WMArchiverURL = None
 config.ArchiveDataReporter.numDocsRetrievePerPolling = 1000 # number of documents needed to be polled each time
 config.ArchiveDataReporter.numDocsUploadPerCall = 200 # number of documents upload each time in bulk to WMArchive
-# This is now OPTIONAL, it defaults to the componentDir
-# HOWEVER: Is is HIGHLY recommended that you do NOT run this on the same
-# disk as the JobCreator
-#config.JobArchiver.logDir = config.General.workDir + "/JobArchives"
-config.JobArchiver.numberOfJobsToCluster = 1000

--- a/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
@@ -385,72 +385,75 @@ class PyCondorPlugin(BasePlugin):
         # unordered list of jobs with random sandboxes.
         # We intend to sort them by sandbox.
 
-        # We also need to do a secondary sort by number of cores
-        # because we can have jobs with different number of cores
-        # and the same sandbox and they cannot be submitted together.
+        # Do a secondary sort for numberOfCores and also for
+        # highIO jobs, they need to be submitted separately.
 
         submitDict = {}
         nSubmits = 0
         for job in jobs:
             sandbox = job['sandbox']
-            numberOfCores = job.get('numberOfCores', 1)
-            if not sandbox in submitDict.keys():
+            numberOfCores = job['numberOfCores']
+            highIOjob = job['highIOjob']
+            if sandbox not in submitDict.keys():
                 submitDict[sandbox] = {}
-            if not numberOfCores in submitDict[sandbox]:
-                submitDict[sandbox][numberOfCores] = []
-            submitDict[sandbox][numberOfCores].append(job)
+            if numberOfCores not in submitDict[sandbox]:
+                submitDict[sandbox][numberOfCores] = {}
+            if highIOjob not in submitDict[sandbox][numberOfCores]:
+                submitDict[sandbox][numberOfCores][highIOjob] = []
+
+            submitDict[sandbox][numberOfCores][highIOjob].append(job)
 
 
         # Now submit the bastards
         queueError = False
         for sandbox in submitDict.keys():
             for numberOfCores in submitDict[sandbox].keys():
-                jobList = submitDict[sandbox][numberOfCores]
-                if queueError:
-                    # If the queue has failed, then we must not process
-                    # any more jobs this cycle.
-                    break
-                for jobsReady in grouper(jobList, self.jobsPerWorker):
-                    idList = [x['id'] for x in jobsReady]
-                    jdlList = self.makeSubmit(jobList=jobsReady)
-                    if not jdlList:
-                        # Then we got nothing
-                        logging.error("No JDL file made!")
-                        return {'NoResult': [0]}
-                    jdlFile = "%s/submit_%i_%i.jdl" % (self.submitDir, os.getpid(), idList[0])
-                    with open(jdlFile, 'w') as handle:
-                        handle.writelines(jdlList)
-                    jdlFiles.append(jdlFile)
-
-                    # Now submit them
-                    logging.info("About to submit %i jobs", len(jobsReady))
-                    if self.glexecPath:
-                        command = 'CS=`which condor_submit`; '
-                        if self.glexecWrapScript:
-                            command += 'export GLEXEC_ENV=`%s 2>/dev/null`; ' % self.glexecWrapScript
-                        command += 'export GLEXEC_CLIENT_CERT=%s; ' % self.glexecProxyFile
-                        command += 'export GLEXEC_SOURCE_PROXY=%s; ' % self.glexecProxyFile
-                        command += 'export X509_USER_PROXY=%s; ' % self.glexecProxyFile
-                        command += 'export GLEXEC_TARGET_PROXY=%s; ' % self.jdlProxyFile
-                        if self.glexecUnwrapScript:
-                            command += '%s %s -- $CS %s' % (self.glexecPath, self.glexecUnwrapScript, jdlFile)
-                        else:
-                            command += '%s $CS %s' % (self.glexecPath, jdlFile)
-                    else:
-                        command = "condor_submit %s" % jdlFile
-
-                    try:
-                        self.inputQueue.put({'command': command, 'idList': idList})
-                    except AssertionError as ex:
-                        msg = "Critical error: input pipeline probably closed.\n"
-                        msg += str(ex)
-                        msg += "Error Procedure: Something critical has happened in the worker process\n"
-                        msg += "We will now proceed to pull all useful data from the queue (if it exists)\n"
-                        msg += "Then refresh the worker pool\n"
-                        logging.error(msg)
-                        queueError = True
+                for jobList in submitDict[sandbox][numberOfCores].values():
+                    if queueError:
+                        # If the queue has failed, then we must not process
+                        # any more jobs this cycle.
                         break
-                    nSubmits += 1
+                    for jobsReady in grouper(jobList, self.jobsPerWorker):
+                        idList = [x['id'] for x in jobsReady]
+                        jdlList = self.makeSubmit(jobList=jobsReady)
+                        if not jdlList:
+                            # Then we got nothing
+                            logging.error("No JDL file made!")
+                            return {'NoResult': [0]}
+                        jdlFile = "%s/submit_%i_%i.jdl" % (self.submitDir, os.getpid(), idList[0])
+                        with open(jdlFile, 'w') as handle:
+                            handle.writelines(jdlList)
+                        jdlFiles.append(jdlFile)
+
+                        # Now submit them
+                        logging.info("About to submit %i jobs", len(jobsReady))
+                        if self.glexecPath:
+                            command = 'CS=`which condor_submit`; '
+                            if self.glexecWrapScript:
+                                command += 'export GLEXEC_ENV=`%s 2>/dev/null`; ' % self.glexecWrapScript
+                            command += 'export GLEXEC_CLIENT_CERT=%s; ' % self.glexecProxyFile
+                            command += 'export GLEXEC_SOURCE_PROXY=%s; ' % self.glexecProxyFile
+                            command += 'export X509_USER_PROXY=%s; ' % self.glexecProxyFile
+                            command += 'export GLEXEC_TARGET_PROXY=%s; ' % self.jdlProxyFile
+                            if self.glexecUnwrapScript:
+                                command += '%s %s -- $CS %s' % (self.glexecPath, self.glexecUnwrapScript, jdlFile)
+                            else:
+                                command += '%s $CS %s' % (self.glexecPath, jdlFile)
+                        else:
+                            command = "condor_submit %s" % jdlFile
+
+                        try:
+                            self.inputQueue.put({'command': command, 'idList': idList})
+                        except AssertionError as ex:
+                            msg = "Critical error: input pipeline probably closed.\n"
+                            msg += str(ex)
+                            msg += "Error Procedure: Something critical has happened in the worker process\n"
+                            msg += "We will now proceed to pull all useful data from the queue (if it exists)\n"
+                            msg += "Then refresh the worker pool\n"
+                            logging.error(msg)
+                            queueError = True
+                            break
+                        nSubmits += 1
 
         # Now we should have sent all jobs to be submitted
         # Going to do the rest of it now
@@ -969,6 +972,11 @@ class PyCondorPlugin(BasePlugin):
             jdl.append('+DESIRED_CMSDataset = "%s"\n' % job['inputDataset'])
         if job.get('inputDatasetLocations'):
             jdl.append('+DESIRED_CMSDataLocations = "%s"\n' % ','.join(job['inputDatasetLocations']))
+
+        # HighIO jobs
+        highIOjob = job.get('highIOjob')
+        if highIOjob:
+            jdl.append('+Requestioslots = 1\n')
 
         # Performance estimates
         if job.get('estimatedJobTime'):

--- a/src/python/WMCore/BossAir/RunJob.py
+++ b/src/python/WMCore/BossAir/RunJob.py
@@ -63,6 +63,7 @@ class RunJob(dict):
         self.setdefault('inputDataset', None)
         self.setdefault('inputDatasetLocations', None)
         self.setdefault('allowOpportunistic', False)
+        self.setdefault('highIOjob', False)
 
         return
 


### PR DESCRIPTION
Switch merge, cleanup and logcollect jobs to highio jobs. By default this is off, but it can be enabled for a select list of sites in the JobSubmitter config. I want to include this for T0_CH_CERN by default as all Tier0 and WMAgent operations there should make use of highIOjobs. What's the best way to do this ?
Add it in WMCore/etc/WMAgentConfig.py ?

@ticoann any advice ?
