### PR TITLE
Fix location for Dataset policy

### DIFF
--- a/src/python/WMCore/WorkQueue/Policy/Start/Dataset.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Dataset.py
@@ -165,11 +165,10 @@ class Dataset(StartPolicyInterface):
             else:
                 locations = locations.intersection(dbs.listFileBlockLocation(block['block']))
 
-            locations = set(self.siteDB.PNNstoPSNs(locations))
-            if self.wmspec.locationDataSourceFlag():
-                locations = locations.union(siteWhiteList)
-
         # all needed blocks present at these sites
-        if locations:
-            self.data[datasetPath] = list(locations)
+        if self.wmspec.locationDataSourceFlag():
+            self.data[datasetPath] = locations.union(siteWhiteList)
+        elif locations:
+            self.data[datasetPath] = set(self.siteDB.PNNstoPSNs(locations))
+
         return validBlocks


### PR DESCRIPTION
Convert to PSN only after getting locations intersection of ALL blocks.
Still testing in my VM, but seems to be just fine.

@ticoann wait for the jenkins and merge it for tomorrow's testbed please.
