### PR TITLE
dbsbuffer changes to work around race condition between dbs and phedex updates

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
@@ -89,7 +89,7 @@ def uploadWorker(workInput, results, dbsUrl):
     """
 
     # Init DBS Stuff
-    logging.debug("Creating dbsAPI with address %s" % dbsUrl)
+    logging.debug("Creating dbsAPI with address %s", dbsUrl)
     dbsApi = DbsApi(url = dbsUrl)
 
 
@@ -112,7 +112,7 @@ def uploadWorker(workInput, results, dbsUrl):
 
         # Do stuff with DBS
         try:
-            logging.debug("About to call insert block with block: %s" % block)
+            logging.debug("About to call insert block with block: %s", block)
             dbsApi.insertBulkBlock(blockDump = block)
             results.put({'name': name, 'success': "uploaded"})
         except Exception as ex:
@@ -120,9 +120,9 @@ def uploadWorker(workInput, results, dbsUrl):
             if 'Block %s already exists' % name in exString:
                 # Then this is probably a duplicate
                 # Ignore this for now
-                logging.error("Had duplicate entry for block %s. Ignoring for now." % name)
-                logging.debug("Exception: %s" % exString)
-                logging.debug("Traceback: %s" % str(traceback.format_exc()))
+                logging.error("Had duplicate entry for block %s. Ignoring for now.", name)
+                logging.debug("Exception: %s", exString)
+                logging.debug("Traceback: %s", str(traceback.format_exc()))
                 results.put({'name': name, 'success': "uploaded"})
             elif 'Proxy Error' in exString:
                 # This is probably a successfully inserton that went bad.
@@ -136,7 +136,7 @@ def uploadWorker(workInput, results, dbsUrl):
                 msg += exString
                 logging.error(msg)
                 logging.error(str(traceback.format_exc()))
-                logging.debug("block: %s \n" % block)
+                logging.debug("block: %s \n", block)
                 results.put({'name': name, 'success': "error", 'error': msg})
 
     return
@@ -320,8 +320,8 @@ class DBSUploadPoller(BaseWorkerThread):
         Find all blocks; make sure they're in the cache
         """
         openBlocks = self.dbsUtil.findOpenBlocks()
-        logging.info("Found %d open blocks." % len(openBlocks))
-        logging.debug("These are the openblocks: %s" % openBlocks)
+        logging.info("Found %d open blocks.", len(openBlocks))
+        logging.debug("These are the openblocks: %s", openBlocks)
 
         # Load them if we don't have them
         blocksToLoad = []
@@ -332,14 +332,14 @@ class DBSUploadPoller(BaseWorkerThread):
         # Now load the blocks
         try:
             loadedBlocks = self.dbsUtil.loadBlocks(blocksToLoad)
-            logging.info("Loaded blocks: %s" % loadedBlocks)
+            logging.info("Loaded blocks: %s", loadedBlocks)
         except WMException:
             raise
         except Exception as ex:
             msg =  "Unhandled exception while loading blocks.\n"
             msg += str(ex)
             logging.error(msg)
-            logging.debug("Blocks to load: %s\n" % blocksToLoad)
+            logging.debug("Blocks to load: %s\n", blocksToLoad)
             raise DBSUploadException(msg)
 
         for blockInfo in loadedBlocks:
@@ -352,14 +352,14 @@ class DBSUploadPoller(BaseWorkerThread):
             # Now we have to load files...
             try:
                 files = self.dbsUtil.loadFilesByBlock(blockname = blockname)
-                logging.info("Have %i files for block %s" % (len(files), blockname))
+                logging.info("Have %i files for block %s", (len(files), blockname))
             except WMException:
                 raise
             except Exception as ex:
                 msg =  "Unhandled exception while loading files for existing blocks.\n"
                 msg += str(ex)
                 logging.error(msg)
-                logging.debug("Blocks being loaded: %s\n" % blockname)
+                logging.debug("Blocks being loaded: %s\n", blockname)
                 raise DBSUploadException(msg)
 
             # Add the loaded files to the block
@@ -394,7 +394,7 @@ class DBSUploadPoller(BaseWorkerThread):
                 msg =  "Unhandled exception while loading uploadable files for DatasetPath.\n"
                 msg += str(ex)
                 logging.error(msg)
-                logging.debug("DatasetPath being loaded: %s\n" % datasetpath)
+                logging.debug("DatasetPath being loaded: %s\n", datasetpath)
                 raise DBSUploadException(msg)
 
             # Sort the files and blocks by location
@@ -581,8 +581,8 @@ class DBSUploadPoller(BaseWorkerThread):
                 msg =  "Unhandled exception while writing new blocks into DBSBuffer\n"
                 msg += str(ex)
                 logging.error(msg)
-                logging.debug("Blocks for DBSBuffer: %s\n" % createInDBSBuffer)
-                logging.debug("Blocks for Update: %s\n" % updateInDBSBuffer)
+                logging.debug("Blocks for DBSBuffer: %s\n", createInDBSBuffer)
+                logging.debug("Blocks for Update: %s\n", updateInDBSBuffer)
                 raise DBSUploadException(msg)
             else:
                 myThread.transaction.commit()
@@ -608,7 +608,7 @@ class DBSUploadPoller(BaseWorkerThread):
                 msg =  "Unhandled exception while setting blocks in files.\n"
                 msg += str(ex)
                 logging.error(msg)
-                logging.debug("Files to Update: %s\n" % self.filesToUpdate)
+                logging.debug("Files to Update: %s\n", self.filesToUpdate)
                 raise DBSUploadException(msg)
             else:
                 myThread.transaction.commit()
@@ -627,11 +627,11 @@ class DBSUploadPoller(BaseWorkerThread):
                                  datasetType  = self.datasetType,
                                  physicsGroup = dbsFile.get('physicsGroup', None),
                                  prep_id = dbsFile.get('prep_id', None))
-            logging.debug("Found block %s in blocks" % block.getName())
+            logging.debug("Found block %s in blocks", block.getName())
             block.setPhysicsGroup(group = self.physicsGroup)
             
             encodedBlock = block.convertToDBSBlock()
-            logging.info("About to insert block %s" % block.getName())
+            logging.info("About to insert block %s", block.getName())
             self.workInput.put({'name': block.getName(), 'block': encodedBlock})
             self.blockCount += 1
             if self.produceCopy:
@@ -704,7 +704,7 @@ class DBSUploadPoller(BaseWorkerThread):
                 block = result["name"]
                 self.blocksToCheck.append(block)
             else:
-                logging.error("Error found in multiprocess during process of block %s" % result.get('name'))
+                logging.error("Error found in multiprocess during process of block %s", result.get('name'))
                 logging.error(result['error'])
                 # Continue to the next block
                 # Block will remain in pending status until it is transferred
@@ -718,16 +718,29 @@ class DBSUploadPoller(BaseWorkerThread):
                 updateBlocksDAO.execute(blocks = loadedBlocks,
                                         conn = myThread.transaction.conn,
                                         transaction = True)
-            except WMException:
-                myThread.transaction.rollback()
-                raise
             except Exception as ex:
                 myThread.transaction.rollback()
-                msg =  "Unhandled exception while finished closed blocks in DBSBuffer\n"
-                msg += str(ex)
-                logging.error(msg)
-                logging.debug("Blocks for Update: %s\n" % loadedBlocks)
-                raise DBSUploadException(msg)
+                # possible deadlock with PhEDExInjector, retry once after 10s
+                logging.warning("Oracle exception, possible deadlock due to race condition, retry after 10s sleep")
+                time.sleep(10)
+                try:
+                    myThread.transaction.begin()
+                    updateFilesDAO.execute(blocks = loadedBlocks, status = "InDBS",
+                                           conn = myThread.transaction.conn,
+                                           transaction = True)
+                    updateBlocksDAO.execute(blocks = loadedBlocks,
+                                            conn = myThread.transaction.conn,
+                                            transaction = True)
+                except Exception as ex:
+                    myThread.transaction.rollback()
+                    msg =  "Unhandled exception while finished closed blocks in DBSBuffer\n"
+                    msg += str(ex)
+                    logging.error(msg)
+                    logging.debug("Blocks for Update: %s\n", loadedBlocks)
+                    raise DBSUploadException(msg)
+                else:
+                    myThread.transaction.commit()
+
             else:
                 myThread.transaction.commit()
 
@@ -759,7 +772,7 @@ class DBSUploadPoller(BaseWorkerThread):
 
         # See if there is anything to check
         for block in self.blocksToCheck:
-            logging.debug("Checking block existence: %s" % block)
+            logging.debug("Checking block existence: %s", block)
             # Check in DBS if the block was really inserted
             try:
                 result = self.dbsApi.listBlocks(block_name = block)
@@ -794,7 +807,7 @@ class DBSUploadPoller(BaseWorkerThread):
                 msg =  "Unhandled exception while finished closed blocks in DBSBuffer\n"
                 msg += str(ex)
                 logging.error(msg)
-                logging.debug("Blocks for Update: %s\n" % blocksUploaded)
+                logging.debug("Blocks for Update: %s\n", blocksUploaded)
                 raise DBSUploadException(msg)
             else:
                 myThread.transaction.commit()

--- a/src/python/WMComponent/DBS3Buffer/MySQL/Create.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/Create.py
@@ -21,160 +21,289 @@ class Create(DBCreator):
 
         DBCreator.__init__(self, myThread.logger, myThread.dbi)
 
-        self.create["01dbsbuffer_dataset"] = \
-              """CREATE TABLE dbsbuffer_dataset
-                        (
-                           id              BIGINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
-                           path            VARCHAR(500) COLLATE latin1_general_cs UNIQUE NOT NULL,
-                           processing_ver  VARCHAR(255),
-                           acquisition_era VARCHAR(255),
-                           valid_status    VARCHAR(20),
-                           global_tag      VARCHAR(255),
-                           parent          VARCHAR(500),
-                           prep_id         VARCHAR(255)
-                        ) ENGINE=InnoDB"""
+        #
+        # Tables, functions, procedures and sequences
+        #
+        self.create[len(self.create)] = \
+            """CREATE TABLE dbsbuffer_dataset (
+                 id              INTEGER      AUTO_INCREMENT,
+                 path            VARCHAR(500) COLLATE latin1_general_cs NOT NULL,
+                 processing_ver  VARCHAR(255),
+                 acquisition_era VARCHAR(255),
+                 valid_status    VARCHAR(20),
+                 global_tag      VARCHAR(255),
+                 parent          VARCHAR(500),
+                 prep_id         VARCHAR(255),
+                 PRIMARY KEY (id),
+                 CONSTRAINT uq_dbs_dat UNIQUE (path)
+               ) ENGINE=InnoDB"""
 
-        self.create["02dbsbuffer_dataset_subscription"] = \
-            """CREATE TABLE dbsbuffer_dataset_subscription
-                (
-                    id                     INTEGER PRIMARY KEY AUTO_INCREMENT,
-                    dataset_id             BIGINT UNSIGNED NOT NULL,
-                    site                   VARCHAR(100) NOT NULL,
-                    custodial              INTEGER DEFAULT 0,
-                    auto_approve           INTEGER DEFAULT 0,
-                    move                   INTEGER DEFAULT 0,
-                    priority               VARCHAR(10) DEFAULT 'Low',
-                    subscribed             INTEGER DEFAULT 0,
-                    delete_blocks          INTEGER,
-                    FOREIGN KEY (dataset_id) REFERENCES dbsbuffer_dataset(id)
-                        ON DELETE CASCADE,
-                    UNIQUE (dataset_id, site, custodial, auto_approve, move, priority)
-                ) ENGINE=InnoDB"""
+        self.create[len(self.create)] = \
+            """CREATE TABLE dbsbuffer_dataset_subscription (
+                 id                     INTEGER      AUTO_INCREMENT,
+                 dataset_id             INTEGER      NOT NULL,
+                 site                   VARCHAR(100) NOT NULL,
+                 custodial              INTEGER      DEFAULT 0,
+                 auto_approve           INTEGER      DEFAULT 0,
+                 move                   INTEGER      DEFAULT 0,
+                 priority               VARCHAR(10)  DEFAULT 'Low',
+                 subscribed             INTEGER      DEFAULT 0,
+                 delete_blocks          INTEGER,
+                 PRIMARY KEY (id),
+                 CONSTRAINT uq_dbs_dat_sub UNIQUE (dataset_id, site, custodial, auto_approve, move, priority)
+               ) ENGINE=InnoDB"""
 
-        self.create["02dbsbuffer_algo"] = \
-              """CREATE TABLE dbsbuffer_algo
-                        (
-                           id     BIGINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
-                           app_name varchar(100),
-                           app_ver  varchar(100),
-                           app_fam  varchar(100),
-                           pset_hash varchar(700),
-                           config_content LONGTEXT,
-                           in_dbs int, 
-                           UNIQUE (app_name, app_ver, app_fam, pset_hash)
-                        ) ENGINE=InnoDB"""
+        self.create[len(self.create)] = \
+            """CREATE TABLE dbsbuffer_algo (
+                 id             INTEGER       AUTO_INCREMENT,
+                 app_name       VARCHAR(100),
+                 app_ver        VARCHAR(100),
+                 app_fam        VARCHAR(100),
+                 pset_hash      VARCHAR(700),
+                 config_content LONGTEXT,
+                 in_dbs         INTEGER,
+                 PRIMARY KEY (id),
+                 CONSTRAINT uq_dbs_alg UNIQUE (app_name, app_ver, app_fam, pset_hash)
+               ) ENGINE=InnoDB"""
 
-        self.create["03dbsbuffer_algo_dataset_assoc"] = \
-              """CREATE TABLE dbsbuffer_algo_dataset_assoc
-                        (
-                           id BIGINT UNSIGNED PRIMARY KEY NOT NULL AUTO_INCREMENT,
-                           algo_id BIGINT UNSIGNED,
-                           dataset_id BIGINT UNSIGNED,
-                           in_dbs INTEGER DEFAULT 0, 
-                           FOREIGN KEY (algo_id) REFERENCES dbsbuffer_algo(id)
-                             ON DELETE CASCADE,
-                           FOREIGN KEY (dataset_id) REFERENCES dbsbuffer_dataset(id)
-                             ON DELETE CASCADE
-                        ) ENGINE = InnoDB"""
+        self.create[len(self.create)] = \
+              """CREATE TABLE dbsbuffer_algo_dataset_assoc (
+                   id         INTEGER AUTO_INCREMENT,
+                   algo_id    INTEGER NOT NULL,
+                   dataset_id INTEGER NOT NULL,
+                   in_dbs     INTEGER DEFAULT 0,
+                   PRIMARY KEY (id)
+                 ) ENGINE = InnoDB"""
 
-        self.create["03dbsbuffer_workflow"] = \
-          """CREATE TABLE dbsbuffer_workflow (
-               id                           INTEGER PRIMARY KEY AUTO_INCREMENT,
-               name                         VARCHAR(700),
-               task                         VARCHAR(700),
-               block_close_max_wait_time    INTEGER UNSIGNED,
-               block_close_max_files        INTEGER UNSIGNED,
-               block_close_max_events       INTEGER UNSIGNED,
-               block_close_max_size         BIGINT UNSIGNED,
-               completed                    INTEGER DEFAULT 0,
-               UNIQUE (name, task)
+        self.create[len(self.create)] = \
+            """CREATE TABLE dbsbuffer_workflow (
+                 id                           INTEGER       AUTO_INCREMENT,
+                 name                         VARCHAR(700),
+                 task                         VARCHAR(700),
+                 block_close_max_wait_time    INTEGER,
+                 block_close_max_files        INTEGER,
+                 block_close_max_events       INTEGER,
+                 block_close_max_size         INTEGER,
+                 completed                    INTEGER       DEFAULT 0,
+                 PRIMARY KEY (id),
+                 CONSTRAINT uq_dbs_wor UNIQUE (name, task)
                ) ENGINE = InnoDB"""
 
-        self.create["04dbsbuffer_file"] = \
-          """CREATE TABLE dbsbuffer_file (
-             id           INTEGER      PRIMARY KEY AUTO_INCREMENT,
-             lfn          VARCHAR(500) NOT NULL,
-             filesize     BIGINT,
-             events       INTEGER,
-             dataset_algo BIGINT UNSIGNED   NOT NULL,
-             block_id     BIGINT UNSIGNED,
-             status       VARCHAR(20),
-             in_phedex    INTEGER DEFAULT 0,
-             workflow     INTEGER,
-             LastModificationDate  BIGINT,
-             FOREIGN KEY (workflow) references dbsbuffer_workflow(id)
-               ON DELETE CASCADE,
-             UNIQUE(lfn)) ENGINE=InnoDB"""
+        self.create[len(self.create)] = \
+            """CREATE TABLE dbsbuffer_file (
+                 id                    INTEGER      AUTO_INCREMENT,
+                 lfn                   VARCHAR(500) NOT NULL,
+                 filesize              INTEGER,
+                 events                INTEGER,
+                 dataset_algo          INTEGER      NOT NULL,
+                 block_id              INTEGER,
+                 status                VARCHAR(20),
+                 in_phedex             INTEGER      DEFAULT 0,
+                 workflow              INTEGER,
+                 LastModificationDate  INTEGER,
+                 PRIMARY KEY (id),
+                 CONSTRAINT uq_dbs_fil UNIQUE (lfn)
+               ) ENGINE=InnoDB"""
 
-        self.create["06dbsbuffer_file_parent"] = \
-          """CREATE TABLE dbsbuffer_file_parent (
-             child  INTEGER NOT NULL,
-             parent INTEGER NOT NULL,
-             FOREIGN KEY (child)  references dbsbuffer_file(id)
-               ON DELETE CASCADE,
-             FOREIGN KEY (parent) references dbsbuffer_file(id),
-             UNIQUE(child, parent)) ENGINE=InnoDB"""
+        self.create[len(self.create)] = \
+            """CREATE TABLE dbsbuffer_file_parent (
+                 child  INTEGER NOT NULL,
+                 parent INTEGER NOT NULL,
+                 CONSTRAINT pk_dbs_fil_par PRIMARY KEY (child, parent)
+               ) ENGINE=InnoDB
+               """
 
-        self.constraints["01_pk_dbsbuffer_file_parent"] = \
-          """ALTER TABLE dbsbuffer_file_parent ADD
-               (CONSTRAINT dbsbuffer_file_parent_pk PRIMARY KEY (child, parent))"""
+        self.create[len(self.create)] = \
+            """CREATE TABLE dbsbuffer_file_runlumi_map (
+                 filename    INTEGER NOT NULL,
+                 run         INTEGER NOT NULL,
+                 lumi        INTEGER NOT NULL
+               ) ENGINE=InnoDB"""
 
-        self.create["07dbsbuffer_file_runlumi_map"] = \
-          """CREATE TABLE dbsbuffer_file_runlumi_map (
-             filename    INTEGER NOT NULL,
-             run         INTEGER NOT NULL,
-             lumi        INTEGER NOT NULL,
-             FOREIGN KEY (filename) references dbsbuffer_file(id)
-               ON DELETE CASCADE)ENGINE=InnoDB"""
+        self.create[len(self.create)] = \
+            """CREATE TABLE dbsbuffer_location (
+                 id       INTEGER      AUTO_INCREMENT,
+                 se_name  VARCHAR(255) NOT NULL,
+                 PRIMARY KEY (id),
+                 CONSTRAINT uq_dbs_loc UNIQUE (se_name)
+               ) ENGINE=InnoDB"""
 
-        self.create["08dbsbuffer_location"] = \
-          """CREATE TABLE dbsbuffer_location (
-             id      INTEGER      PRIMARY KEY AUTO_INCREMENT,
-             se_name VARCHAR(255) NOT NULL,
-             UNIQUE(se_name))ENGINE=InnoDB"""
+        self.create[len(self.create)] = \
+            """CREATE TABLE dbsbuffer_file_location (
+                 filename INTEGER NOT NULL,
+                 location INTEGER NOT NULL,
+                 CONSTRAINT pk_dbs_fil_loc PRIMARY KEY (filename, location)
+               ) ENGINE=InnoDB"""
 
-        self.create["09dbsbuffer_file_location"] = \
-          """CREATE TABLE dbsbuffer_file_location (
-             filename INTEGER NOT NULL,
-             location INTEGER NOT NULL,
-             FOREIGN KEY (filename) references dbsbuffer_file(id)
-               ON DELETE CASCADE,
-             UNIQUE(filename, location)) ENGINE=InnoDB"""
+        self.create[len(self.create)] = \
+            """CREATE TABLE dbsbuffer_block (
+                 id           INTEGER      AUTO_INCREMENT,
+                 dataset_id   INTEGER      NOT NULL,
+                 blockname    VARCHAR(250) NOT NULL,
+                 location     INTEGER      NOT NULL,
+                 create_time  INTEGER,
+                 status       VARCHAR(20),
+                 deleted      INTEGER      DEFAULT 0,
+                 PRIMARY KEY (id),
+                 CONSTRAINT uq_dbs_blo UNIQUE (blockname, location)
+               ) ENGINE=InnoDB"""
 
-        self.create["10dbsbuffer_block"] = \
-          """CREATE TABLE dbsbuffer_block (
-             id           INTEGER      PRIMARY KEY AUTO_INCREMENT,
-             dataset_id   BIGINT UNSIGNED NOT NULL,
-             blockname    VARCHAR(250) NOT NULL,
-             location     INTEGER      NOT NULL,
-             create_time  INTEGER,
-             status       VARCHAR(20),
-             deleted      INTEGER DEFAULT 0,
-             FOREIGN KEY (location) REFERENCES dbsbuffer_location(id)
-               ON DELETE CASCADE,
-             FOREIGN KEY (dataset_id) REFERENCES dbsbuffer_dataset(id)
-               ON DELETE CASCADE,
-             UNIQUE(blockname, location))ENGINE=InnoDB"""
+        self.create[len(self.create)] = \
+            """CREATE TABLE dbsbuffer_checksum_type (
+                 id   INTEGER      AUTO_INCREMENT,
+                 type VARCHAR(255),
+                 PRIMARY KEY (id)
+               ) ENGINE=InnoDB"""
 
-        self.create["11dbsbuffer_checksum_type"] = \
-          """CREATE TABLE dbsbuffer_checksum_type (
-              id            INTEGER      PRIMARY KEY AUTO_INCREMENT,
-              type          VARCHAR(255) ) ENGINE=InnoDB"""
+        self.create[len(self.create)] = \
+            """CREATE TABLE dbsbuffer_file_checksums (
+                 fileid  INTEGER,
+                 typeid  INTEGER,
+                 cksum   VARCHAR(100),
+                 CONSTRAINT pk_dbs_fil_che PRIMARY KEY (fileid, typeid)
+               ) ENGINE=InnoDB"""
 
+        #
+        # Indexes
+        #
+        self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_dbs_fil_che_1 ON dbsbuffer_file_checksums (typeid)"""
 
-        self.create["12dbsbuffer_file_checksums"] = \
-          """CREATE TABLE dbsbuffer_file_checksums (
-              fileid        INTEGER,
-              typeid        INTEGER,
-              cksum         VARCHAR(100),
-              UNIQUE (fileid, typeid),
-              FOREIGN KEY (typeid) REFERENCES dbsbuffer_checksum_type(id)
-                ON DELETE CASCADE,
-              FOREIGN KEY (fileid) REFERENCES dbsbuffer_file(id)
-                ON DELETE CASCADE) ENGINE=InnoDB"""
+        self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_dbs_fil_che_2 ON dbsbuffer_file_checksums (fileid)"""
+
+        self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_dbs_dat_sub_1 ON dbsbuffer_dataset_subscription (dataset_id)"""
+
+        self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_dbs_fil_par_1 ON dbsbuffer_file_parent (child)"""
+
+        self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_dbs_fil_par_2 ON dbsbuffer_file_parent (parent)"""
+
+        self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_dbs_blo_1 ON dbsbuffer_block (location)"""
+
+        self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_dbs_blo_2 ON dbsbuffer_block (dataset_id)"""
+
+        self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_dbs_alg_ass_1 ON dbsbuffer_algo_dataset_assoc (dataset_id)"""
+
+        self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_dbs_alg_ass_2 ON dbsbuffer_algo_dataset_assoc (algo_id)"""
+
+        self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_dbs_fil_run_1 ON dbsbuffer_file_runlumi_map (filename)"""
+
+        self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_dbs_fil_loc_1 ON dbsbuffer_file_location (location)"""
+
+        self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_dbs_fil_loc_2 ON dbsbuffer_file_location (filename)"""
+
+        self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_dbs_fil_1 ON dbsbuffer_file (workflow)"""
+
+        #
+        # Constraints
+        #
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE dbsbuffer_file_checksums
+                 ADD CONSTRAINT fk_file_checksums_typeid
+                 FOREIGN KEY (typeid)
+                 REFERENCES dbsbuffer_checksum_type(id)
+                 ON DELETE CASCADE"""
+
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE dbsbuffer_file_checksums
+                 ADD CONSTRAINT fk_file_checksums_fileid
+                 FOREIGN KEY (fileid)
+                 REFERENCES dbsbuffer_file(id)
+                 ON DELETE CASCADE"""
+
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE dbsbuffer_dataset_subscription
+                 ADD CONSTRAINT fk_dsetsubscription_datasetid
+                 FOREIGN KEY (dataset_id)
+                 REFERENCES dbsbuffer_dataset(id)
+                 ON DELETE CASCADE"""
+
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE dbsbuffer_file_parent
+                 ADD CONSTRAINT fk_file_parent_child
+                 FOREIGN KEY (child)
+                 REFERENCES dbsbuffer_file(id)
+                 ON DELETE CASCADE"""
+
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE dbsbuffer_file_parent
+                 ADD CONSTRAINT fk_file_parent_parent
+                 FOREIGN KEY (parent)
+                 REFERENCES dbsbuffer_file(id)
+                 ON DELETE CASCADE"""
+
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE dbsbuffer_block
+                 ADD CONSTRAINT fk_block_location
+                 FOREIGN KEY (location)
+                 REFERENCES dbsbuffer_location(id)
+                 ON DELETE CASCADE"""
+
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE dbsbuffer_block
+                 ADD CONSTRAINT fk_block_dataset_id
+                 FOREIGN KEY (dataset_id)
+                 REFERENCES dbsbuffer_dataset(id)
+                 ON DELETE CASCADE"""
+
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE dbsbuffer_algo_dataset_assoc
+                 ADD CONSTRAINT fk_algodset_assoc_dataset_id
+                 FOREIGN KEY (dataset_id)
+                 REFERENCES dbsbuffer_dataset(id)
+                 ON DELETE CASCADE"""
+
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE dbsbuffer_algo_dataset_assoc
+                 ADD CONSTRAINT fk_algodset_assoc_algo_id
+                 FOREIGN KEY (algo_id)
+                 REFERENCES dbsbuffer_algo(id)
+                 ON DELETE CASCADE"""
+
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE dbsbuffer_file_runlumi_map
+                 ADD CONSTRAINT fk_file_runlumi_filename
+                 FOREIGN KEY (filename)
+                 REFERENCES dbsbuffer_file(id)
+                 ON DELETE CASCADE"""
+
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE dbsbuffer_file_location
+                 ADD CONSTRAINT fk_file_location_location
+                 FOREIGN KEY (location)
+                 REFERENCES dbsbuffer_location(id)
+                 ON DELETE CASCADE"""
+
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE dbsbuffer_file_location
+                 ADD CONSTRAINT fk_file_location_filename
+                 FOREIGN KEY (filename)
+                 REFERENCES dbsbuffer_file(id)
+                 ON DELETE CASCADE"""
+
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE dbsbuffer_file
+                 ADD CONSTRAINT fk_file_workflow
+                 FOREIGN KEY (workflow)
+                 REFERENCES dbsbuffer_workflow(id)
+                 ON DELETE CASCADE"""
+
 
         checksumTypes = ['cksum', 'adler32', 'md5']
         for i in checksumTypes:
-            checksumTypeQuery = """INSERT INTO dbsbuffer_checksum_type (type) VALUES ('%s')
-            """ % (i)
+            checksumTypeQuery = """INSERT INTO dbsbuffer_checksum_type
+                                   (type)
+                                   VALUES ('%s')
+                                   """ % (i)
             self.inserts["wmbs_checksum_type_%s" % (i)] = checksumTypeQuery

--- a/src/python/WMComponent/DBS3Buffer/MySQL/CreateBlocks.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/CreateBlocks.py
@@ -10,17 +10,17 @@ from WMCore.Database.DBFormatter import DBFormatter
 
 class CreateBlocks(DBFormatter):
 
-    def execute(self, blocks, conn = None, transaction = False):
+    sql = """INSERT INTO dbsbuffer_block
+             (dataset_id, blockname, location, status, create_time)
+             SELECT (SELECT id from dbsbuffer_dataset WHERE path = :dataset),
+                    :block,
+                    (SELECT id FROM dbsbuffer_location WHERE se_name = :location),
+                    :status,
+                    :time
+             FROM DUAL
+             """
 
-        sql = """INSERT INTO dbsbuffer_block
-                 (dataset_id, blockname, location, status, create_time)
-                 SELECT (SELECT id from dbsbuffer_dataset WHERE path = :dataset),
-                        :block,
-                        (SELECT id FROM dbsbuffer_location WHERE se_name = :location),
-                        :status,
-                        :time
-                 FROM DUAL
-                 """
+    def execute(self, blocks, conn = None, transaction = False):
 
         bindVars = []
 
@@ -32,7 +32,7 @@ class CreateBlocks(DBFormatter):
                                'status' : block.status,
                                'time' : block.getStartTime() } )
 
-        self.dbi.processData(sql, bindVars, conn = conn,
+        self.dbi.processData(self.sql, bindVars, conn = conn,
                              transaction = transaction)
 
         return

--- a/src/python/WMComponent/DBS3Buffer/MySQL/NewAlgo.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/NewAlgo.py
@@ -11,19 +11,11 @@ MySQL implementation of DBSBuffer.NewAlgo
 from WMCore.Database.DBFormatter import DBFormatter
 
 class NewAlgo(DBFormatter):
-    """
-    _NewAlgo_
 
-    Check for existence of algo, then add if not exists
-    """
-    existsSQL = """SELECT id FROM dbsbuffer_algo WHERE app_name = :app_name AND
-                     app_ver = :app_ver AND app_fam = :app_fam AND
-                     pset_hash = :pset_hash FOR UPDATE"""
-
-    sql = """INSERT IGNORE INTO dbsbuffer_algo (app_name, app_ver, app_fam, pset_hash,
-                                         config_content, in_dbs)
-               VALUES (:app_name, :app_ver, :app_fam, :pset_hash,
-                 :config_content, 0)"""
+    sql = """INSERT IGNORE INTO dbsbuffer_algo
+             (app_name, app_ver, app_fam, pset_hash, config_content, in_dbs)
+             VALUES (:app_name, :app_ver, :app_fam, :pset_hash, :config_content, 0)
+             """
 
     def execute(self, appName, appVer, appFam, psetHash = None,
                 configContent = None, conn = None, transaction = False):
@@ -35,12 +27,7 @@ class NewAlgo(DBFormatter):
         binds = {"app_name": appName, "app_ver": appVer, "app_fam": appFam,
                  "pset_hash": psetHash, "config_content": configContent}
 
-        result = self.dbi.processData(self.existsSQL, binds, conn = conn,
-                                      transaction = transaction)
-        result = self.format(result)
-
-        if len(result) == 0:
-            self.dbi.processData(self.sql, binds, conn = conn,
-                                 transaction = transaction)
+        self.dbi.processData(self.sql, binds, conn = conn,
+                             transaction = transaction)
 
         return

--- a/src/python/WMComponent/DBS3Buffer/Oracle/AlgoDatasetAssoc.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/AlgoDatasetAssoc.py
@@ -5,15 +5,25 @@ _AlgoDatasetAssoc_
 Associate an algorithm with a dataset in DBSBuffer.
 """
 
-
-
-
 from WMComponent.DBSBuffer.Database.MySQL.AlgoDatasetAssoc import AlgoDatasetAssoc as MySQLAlgoDatasetAssoc
 
 class AlgoDatasetAssoc(MySQLAlgoDatasetAssoc):
-    """
-    _AlgoDatasetAssoc_
 
-    Associate an algorithm with a dataset in DBSBuffer.
-    """
-    pass
+    sql = """INSERT INTO dbsbuffer_algo_dataset_assoc
+             (id, algo_id, dataset_id)
+             SELECT dbsbuffer_algdset_assoc_seq.nextval,
+                    (SELECT id FROM dbsbuffer_algo
+                     WHERE app_name = :app_name AND app_ver = :app_ver
+                     AND app_fam = :app_fam AND pset_hash = :pset_hash),
+                    (SELECT id FROM dbsbuffer_dataset WHERE path = :path)
+             FROM DUAL
+             WHERE NOT EXISTS
+               ( SELECT *
+                 FROM dbsbuffer_algo_dataset_assoc
+                 WHERE algo_id =
+                   (SELECT id FROM dbsbuffer_algo
+                    WHERE app_name = :app_name AND app_ver = :app_ver
+                    AND app_fam = :app_fam AND pset_hash = :pset_hash)
+                 AND dataset_id =
+                   (SELECT id FROM dbsbuffer_dataset WHERE path = :path) )
+             """

--- a/src/python/WMComponent/DBS3Buffer/Oracle/Create.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/Create.py
@@ -20,395 +20,352 @@ class Create(DBCreator):
         myThread = threading.currentThread()
         DBCreator.__init__(self, myThread.logger, myThread.dbi)
 
-        tablespaceTable = ""
-        tablespaceIndex = ""
-
-        if params:
-            if "tablespace_table" in params:
-                tablespaceTable = "TABLESPACE %s" % params["tablespace_table"]
-            if "tablespace_index" in params:
-                tablespaceIndex = "USING INDEX TABLESPACE %s" % params["tablespace_index"]
-
-        self.create["01dbsbuffer_dataset"] = \
-          """CREATE TABLE dbsbuffer_dataset
-               (
-                 id                NUMBER(11)     NOT NULL,
+        #
+        # Tables, functions, procedures and sequences
+        #
+        self.create[len(self.create)] = \
+            """CREATE TABLE dbsbuffer_dataset (
+                 id                INTEGER        NOT NULL,
                  path              VARCHAR2(500)  NOT NULL,
                  processing_ver    VARCHAR2(255),
                  acquisition_era   VARCHAR2(255),
                  valid_status      VARCHAR2(20),
                  global_tag        VARCHAR2(255),
                  parent            VARCHAR2(500),
-                 prep_id         VARCHAR(255)
+                 prep_id           VARCHAR(255),
+                 PRIMARY KEY (id),
+                 CONSTRAINT uq_dbs_dat UNIQUE (path)
                )"""
 
-        self.create["01dbsbuffer_dataset_seq"] = \
-          """CREATE SEQUENCE dbsbuffer_dataset_seq
-               start with 1
-               increment by 1
-               nomaxvalue"""
+        self.create[len(self.create)] = \
+            """CREATE TABLE dbsbuffer_dataset_subscription (
+                 id                 INTEGER      NOT NULL,
+                 dataset_id         INTEGER      NOT NULL,
+                 site               VARCHAR(100) NOT NULL,
+                 custodial          INTEGER      DEFAULT 0,
+                 auto_approve       INTEGER      DEFAULT 0,
+                 move               INTEGER      DEFAULT 0,
+                 priority           VARCHAR(10)  DEFAULT 'Low',
+                 subscribed         INTEGER      DEFAULT 0,
+                 delete_blocks      INTEGER,
+                 PRIMARY KEY (id),
+                 CONSTRAINT uq_dbs_dat_sub UNIQUE (dataset_id, site, custodial, auto_approve, move, priority)
+               )"""
 
-        self.create["01dbsbuffer_dataset_trg"] = \
-          """CREATE TRIGGER dbsbuffer_dataset_trg
-               BEFORE INSERT ON dbsbuffer_dataset
-               FOR EACH ROW
-                 BEGIN
-                   SELECT dbsbuffer_dataset_seq.nextval INTO :NEW.ID FROM dual;
-                 END;"""
-
-        self.create["02dbsbuffer_dataset_subscription"] = \
-            """CREATE TABLE dbsbuffer_dataset_subscription
-                (
-                    id                 NUMBER(11) NOT NULL,
-                    dataset_id         NUMBER(11) NOT NULL,
-                    site               VARCHAR(100) NOT NULL,
-                    custodial          INT DEFAULT 0,
-                    auto_approve       INT DEFAULT 0,
-                    move               INT DEFAULT 0,
-                    priority           VARCHAR(10) DEFAULT 'Low',
-                    subscribed         INT DEFAULT 0,
-                    delete_blocks      INT
-                )"""
-
-        self.create["02dbsbuffer_dataset_subscription_seq"] = \
-          """CREATE SEQUENCE dbsbuffer_dataset_sub_seq
-               start with 1
-               increment by 1
-               nomaxvalue"""
-
-        self.create["02dbsbuffer_dataset_subscription_trg"] = \
-          """CREATE TRIGGER dbsbuffer_dataset_sub_trg
-               BEFORE INSERT ON dbsbuffer_dataset_subscription
-               FOR EACH ROW
-                 BEGIN
-                   SELECT dbsbuffer_dataset_sub_seq.nextval INTO :NEW.ID FROM dual;
-                 END;"""
-
-        self.create["02dbsbuffer_algo"] = \
-          """CREATE TABLE dbsbuffer_algo
-               (
-                 id        NUMBER(11) NOT NULL,
-                 app_name  varchar2(100),
-                 app_ver   varchar2(100),
-                 app_fam   varchar2(100),
-                 pset_hash varchar2(700),
+        self.create[len(self.create)] = \
+            """CREATE TABLE dbsbuffer_algo (
+                 id             INTEGER        NOT NULL,
+                 app_name       VARCHAR2(100),
+                 app_ver        VARCHAR2(100),
+                 app_fam        VARCHAR2(100),
+                 pset_hash      VARCHAR2(700),
                  config_content CLOB,
-                 in_dbs    NUMBER(11)
-               )%s""" % tablespaceTable
+                 in_dbs         INTEGER,
+                 PRIMARY KEY (id),
+                 CONSTRAINT uq_dbs_alg UNIQUE (app_name, app_ver, app_fam, pset_hash)
+               )"""
 
-        self.create["02dbsbuffer_algo_seq"] = \
-          """CREATE SEQUENCE dbsbuffer_algo_seq
-               start with 1
-               increment by 1
-               nomaxvalue"""
-
-        self.create["02dbsbuffer_algo_trg"] = \
-          """CREATE TRIGGER dbsbuffer_algo_trg
-               BEFORE INSERT ON dbsbuffer_algo
-               FOR EACH ROW
-                 BEGIN
-                   SELECT dbsbuffer_algo_seq.nextval INTO :new.ID FROM dual;
-                 END; """
-
-        self.create["03dbsbuffer_algo_dataset_assoc"] = \
-          """CREATE TABLE dbsbuffer_algo_dataset_assoc
-               (
-                 id         INTEGER NOT NULL,
+        self.create[len(self.create)] = \
+            """CREATE TABLE dbsbuffer_algo_dataset_assoc (
+                 id         INTEGER,
                  algo_id    INTEGER NOT NULL,
                  dataset_id INTEGER NOT NULL,
-                 in_dbs     INTEGER DEFAULT 0
-               )%s""" % tablespaceTable
+                 in_dbs     INTEGER DEFAULT 0,
+                 PRIMARY KEY (id)
+               )"""
 
-        self.create["03dbsbuffer_algo_dataset_assoc_seq"] = \
-          """CREATE SEQUENCE dbsbuffer_algdset_assoc_seq
-               start with 1
-               increment by 1
-               nomaxvalue"""
+        self.create[len(self.create)] = \
+            """CREATE TABLE dbsbuffer_workflow (
+                 id                           INTEGER,
+                 name                         VARCHAR2(700),
+                 task                         VARCHAR2(700),
+                 block_close_max_wait_time    INTEGER,
+                 block_close_max_files        INTEGER,
+                 block_close_max_events       INTEGER,
+                 block_close_max_size         INTEGER,
+                 completed                    INTEGER        DEFAULT 0,
+                 PRIMARY KEY (id),
+                 CONSTRAINT uq_dbs_wor UNIQUE (name, task)
+               )"""
 
-        self.create["03dbsbuffer_algo_dataset_assoc_trg"] = \
-          """CREATE TRIGGER dbsbuffer_algdset_assoc_trg
-               BEFORE INSERT ON dbsbuffer_algo_dataset_assoc
-               FOR EACH ROW
-                BEGIN
-                  SELECT dbsbuffer_algdset_assoc_seq.nextval INTO :new.id FROM dual;
-                END;"""
-
-        self.create["04dbsbuffer_file"] = \
-          """CREATE TABLE dbsbuffer_file
-               (
-                 id                    NUMBER(11) NOT NULL,
+        self.create[len(self.create)] = \
+            """CREATE TABLE dbsbuffer_file (
+                 id                    INTEGER,
                  lfn                   VARCHAR2(500) NOT NULL,
-                 filesize              NUMBER(11),
+                 filesize              INTEGER,
                  events                INTEGER,
-                 cksum                 NUMBER(11),
-                 dataset_algo          NUMBER(11)    NOT NULL,
+                 cksum                 INTEGER,
+                 dataset_algo          INTEGER       NOT NULL,
                  status                VARCHAR2(20),
-                 in_phedex             INTEGER DEFAULT 0,
-                 block_id              NUMBER(11),
+                 in_phedex             INTEGER       DEFAULT 0,
+                 block_id              INTEGER,
                  workflow              INTEGER,
-                 LastModificationDate  NUMBER(11)
-               )%s""" % tablespaceTable
+                 LastModificationDate  INTEGER,
+                 PRIMARY KEY (id),
+                 CONSTRAINT uq_dbs_fil UNIQUE (lfn)
+               )"""
 
-        self.create["04dbsbuffer_file_seq"] = \
-          """CREATE SEQUENCE dbsbuffer_file_seq
-               start with 1
-               increment by 1
-               nomaxvalue"""
-
-        self.create["04dbsbuffer_file_trg"] = \
-          """CREATE TRIGGER dbsbuffer_file_trg
-               BEFORE INSERT ON dbsbuffer_file
-               FOR EACH ROW
-                BEGIN
-                  SELECT dbsbuffer_file_seq.nextval INTO :new.id FROM dual;
-                END;"""
-
-        self.create["05dbsbuffer_file_parent"] = \
-          """CREATE TABLE dbsbuffer_file_parent
-               (
+        self.create[len(self.create)] = \
+            """CREATE TABLE dbsbuffer_file_parent (
                  child  NUMBER(11) NOT NULL,
-                 parent NUMBER(11) NOT NULL
-               )%s""" % tablespaceTable
+                 parent NUMBER(11) NOT NULL,
+                 CONSTRAINT pk_dbs_fil_par PRIMARY KEY (child, parent)
+               )"""
 
-        self.create["06dbsbuffer_file_runlumi_map"] = \
-          """CREATE TABLE dbsbuffer_file_runlumi_map
-               (
+        self.create[len(self.create)] = \
+            """CREATE TABLE dbsbuffer_file_runlumi_map (
                  filename  INTEGER NOT NULL,
                  run       INTEGER NOT NULL,
                  lumi      INTEGER NOT NULL
-               )%s""" % tablespaceTable
+               )"""
 
-        self.create["07dbsbuffer_location"] = \
-          """CREATE TABLE dbsbuffer_location
-               (
-                 id      INTEGER NOT NULL,
-                 se_name VARCHAR2(255) NOT NULL
-               )%s""" % tablespaceTable
+        self.create[len(self.create)] = \
+            """CREATE TABLE dbsbuffer_location (
+                 id       INTEGER,
+                 se_name  VARCHAR2(255) NOT NULL,
+                 PRIMARY KEY (id),
+                 CONSTRAINT uq_dbs_loc UNIQUE (se_name)
+               )"""
 
-        self.create["07dbsbuffer_location_seq"] = \
-          """CREATE SEQUENCE dbsbuffer_location_seq
-               start with 1
-               increment by 1
-               nomaxvalue"""
-
-        self.create["07dbsbuffer_location_trg"] = \
-          """CREATE TRIGGER dbsbuffer_location_trg
-             BEFORE INSERT ON dbsbuffer_location
-             FOR EACH ROW
-               BEGIN
-                 SELECT dbsbuffer_location_seq.nextval INTO :new.id FROM dual;
-               END;"""
-
-        self.create["08dbsbuffer_file_location"] = \
-          """CREATE TABLE dbsbuffer_file_location
-               (
+        self.create[len(self.create)] = \
+            """CREATE TABLE dbsbuffer_file_location (
                  filename   INTEGER NOT NULL,
-                 location   INTEGER NOT NULL
-               )%s""" % tablespaceTable
+                 location   INTEGER NOT NULL,
+                 CONSTRAINT pk_dbs_fil_loc PRIMARY KEY (filename, location)
+               )"""
 
-        self.create["10dbsbuffer_block"] = \
-          """CREATE TABLE dbsbuffer_block (
-          id          INTEGER NOT NULL,
-          dataset_id  INTEGER      NOT NULL,
-          blockname   VARCHAR(250) NOT NULL,
-          location    INTEGER      NOT NULL,
-          create_time INTEGER,
-          status      VARCHAR(20),
-          deleted     INTEGER DEFAULT 0
-          )%s""" % tablespaceTable
+        self.create[len(self.create)] = \
+            """CREATE TABLE dbsbuffer_block (
+                 id          INTEGER,
+                 dataset_id  INTEGER      NOT NULL,
+                 blockname   VARCHAR(250) NOT NULL,
+                 location    INTEGER      NOT NULL,
+                 create_time INTEGER,
+                 status      VARCHAR(20),
+                 deleted     INTEGER      DEFAULT 0,
+                 PRIMARY KEY (id),
+                 CONSTRAINT uq_dbs_blo UNIQUE (blockname, location)
+               )"""
 
-        self.create["10dbsbuffer_block_seq"] = \
-          """CREATE SEQUENCE dbsbuffer_block_seq
-          start with 1
-          increment by 1
-          nomaxvalue"""
+        self.create[len(self.create)] = \
+            """CREATE TABLE dbsbuffer_checksum_type (
+                 id    INTEGER,
+                 type  VARCHAR(255),
+                 PRIMARY KEY (id)
+               )"""
 
-        self.create["10dbsbuffer_block_trg"] = \
-          """CREATE TRIGGER dbsbuffer_block_trg
-          BEFORE INSERT ON dbsbuffer_block
-          FOR EACH ROW
-          BEGIN
-            SELECT dbsbuffer_block_seq.nextval INTO :new.id FROM dual;
-          END;"""
+        self.create[len(self.create)] = \
+            """CREATE TABLE dbsbuffer_file_checksums (
+                 fileid  INTEGER,
+                 typeid  INTEGER,
+                 cksum   VARCHAR2(100),
+                 CONSTRAINT pk_dbs_fil_che PRIMARY KEY (fileid, typeid)
+               )"""
 
-        self.create["11dbsbuffer_checksum_type"] = \
-          """CREATE TABLE dbsbuffer_checksum_type (
-              id            INTEGER,
-              type          VARCHAR(255)
-              ) %s""" % tablespaceTable
+        self.create[len(self.create)] = \
+            """CREATE SEQUENCE dbsbuffer_dataset_seq
+                 START WITH 1
+                 INCREMENT BY 1
+                 NOMAXVALUE"""
 
-        self.create["10dbsbuffer_checksum_type_seq"] = \
-          """CREATE SEQUENCE dbsbuffer_checksum_type_seq
-          start with 1
-          increment by 1
-          nomaxvalue"""
+        self.create[len(self.create)] = \
+            """CREATE SEQUENCE dbsbuffer_dataset_sub_seq
+                 START WITH 1
+                 INCREMENT BY 1
+                 NOMAXVALUE"""
 
-        self.create["12dbsbuffer_file_checksums"] = \
-          """CREATE TABLE dbsbuffer_file_checksums (
-              fileid        INTEGER,
-              typeid        INTEGER,
-              cksum         VARCHAR2(100)
-              ) %s""" % tablespaceTable
+        self.create[len(self.create)] = \
+            """CREATE SEQUENCE dbsbuffer_algo_seq
+                 START WITH 1
+                 INCREMENT BY 1
+                 NOMAXVALUE"""
 
-        self.create["13dbsbuffer_workflow"] = \
-          """CREATE TABLE dbsbuffer_workflow (
-               id                           INTEGER,
-               name                         VARCHAR2(700),
-               task                         VARCHAR2(700),
-               block_close_max_wait_time    INTEGER,
-               block_close_max_files        INTEGER,
-               block_close_max_events       INTEGER,
-               block_close_max_size         INTEGER,
-               completed                    INTEGER DEFAULT 0
-               ) %s """ % tablespaceTable
+        self.create[len(self.create)] = \
+            """CREATE SEQUENCE dbsbuffer_algdset_assoc_seq
+                 START WITH 1
+                 INCREMENT BY 1
+                 NOMAXVALUE"""
 
-        self.create["10dbsbuffer_workflow_seq"] = \
-          """CREATE SEQUENCE dbsbuffer_workflow_seq
-          start with 1
-          increment by 1
-          nomaxvalue"""
+        self.create[len(self.create)] = \
+            """CREATE SEQUENCE dbsbuffer_file_seq
+                 START WITH 1
+                 INCREMENT BY 1
+                 NOMAXVALUE"""
 
-        self.indexes["01_pk_dbsbuffer_checksum_type"] = \
-          """ALTER TABLE dbsbuffer_checksum_type ADD
-               (CONSTRAINT dbsbuffer_checksum_type_pk PRIMARY KEY (id) %s)""" % tablespaceIndex
+        self.create[len(self.create)] = \
+            """CREATE SEQUENCE dbsbuffer_location_seq
+                 START WITH 1
+                 INCREMENT BY 1
+                 NOMAXVALUE"""
 
-        self.indexes["01_uq_dbsbuffer_file_checksums"] = \
-          """ALTER TABLE dbsbuffer_file_checksums ADD
-               (CONSTRAINT dbsbuffer_file_checksums_uq UNIQUE (fileid, typeid) %s)""" % tablespaceIndex
+        self.create[len(self.create)] = \
+            """CREATE SEQUENCE dbsbuffer_block_seq
+                 START WITH 1
+                 INCREMENT BY 1
+                 NOMAXVALUE"""
 
-        self.constraints["01_fk_dbsbuffer_file_checksums"] = \
-          """ALTER TABLE dbsbuffer_file_checksums ADD
-               (CONSTRAINT fk_file_checksums_typeid FOREIGN KEY (typeid)
-                REFERENCES dbsbuffer_checksum_type(id) ON DELETE CASCADE)"""
+        self.create[len(self.create)] = \
+            """CREATE SEQUENCE dbsbuffer_checksum_type_seq
+                 START WITH 1
+                 INCREMENT BY 1
+                 NOMAXVALUE"""
 
-        self.constraints["02_fk_dbsbuffer_file_checksums"] = \
-          """ALTER TABLE dbsbuffer_file_checksums ADD
-               (CONSTRAINT fk_file_checksums_fileid FOREIGN KEY (fileid)
-                REFERENCES dbsbuffer_file(id) ON DELETE CASCADE)"""
+        self.create[len(self.create)] = \
+            """CREATE SEQUENCE dbsbuffer_workflow_seq
+                 START WITH 1
+                 INCREMENT BY 1
+                 NOMAXVALUE"""
 
-        self.indexes["01_pk_dbsbuffer_dataset"] = \
-          """ALTER TABLE dbsbuffer_dataset ADD
-               (CONSTRAINT dbsbuffer_dataset_pk PRIMARY KEY (id) %s)""" % tablespaceIndex
 
-        self.indexes["01_uq_dbsbuffer_dataset"] = \
-          """ALTER TABLE dbsbuffer_dataset ADD
-               (CONSTRAINT dbsbuffer_dataset_uq UNIQUE (Path) %s)""" % tablespaceIndex
+        self.create[len(self.create)] = \
+            """CREATE TRIGGER dbsbuffer_file_trg
+                 BEFORE INSERT ON dbsbuffer_file
+                 FOR EACH ROW
+                  BEGIN
+                    SELECT dbsbuffer_file_seq.nextval INTO :new.id FROM dual;
+                  END;"""
 
-        self.indexes["01_pk_dbsbuffer_dataset_subscription"] = \
-          """ALTER TABLE dbsbuffer_dataset_subscription ADD
-               (CONSTRAINT dbsbuffer_dataset_sub_pk PRIMARY KEY (id) %s)""" % tablespaceIndex
+        #
+        # Indexes
+        #
+        self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_dbs_fil_che_1 ON dbsbuffer_file_checksums (typeid)"""
 
-        self.indexes["01_uq_dbsbuffer_dataset_subscription"] = \
-          """ALTER TABLE dbsbuffer_dataset_subscription ADD
-               (CONSTRAINT dbsbuffer_dataset_sub_uq UNIQUE (dataset_id, site,
-                custodial, auto_approve, move, priority) %s)""" % tablespaceIndex
+        self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_dbs_fil_che_2 ON dbsbuffer_file_checksums (fileid)"""
 
-        self.constraints["01_fk_dbsbuffer_dataset_subscription"] = \
-          """ALTER TABLE dbsbuffer_dataset_subscription ADD
-               (CONSTRAINT fk_dsetsubscription_datasetid  FOREIGN KEY (dataset_id)
-                REFERENCES dbsbuffer_dataset(id) ON DELETE CASCADE)"""
+        self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_dbs_dat_sub_1 ON dbsbuffer_dataset_subscription (dataset_id)"""
 
-        self.indexes["01_pk_dbsbuffer_algo"] = \
-          """ALTER TABLE dbsbuffer_algo ADD
-               (CONSTRAINT dbsbuffer_algo_pk PRIMARY KEY (id) %s)""" % tablespaceIndex
+        self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_dbs_fil_par_1 ON dbsbuffer_file_parent (child)"""
 
-        self.indexes["01_uq_dbsbuffer_algo"] = \
-          """ALTER TABLE dbsbuffer_algo ADD
-               (CONSTRAINT dbsbuffer_algo_uq UNIQUE (app_name, app_ver,
-                app_fam, pset_hash) %s)""" % tablespaceIndex
+        self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_dbs_fil_par_2 ON dbsbuffer_file_parent (parent)"""
 
-        self.indexes["01_pk_dbsbuffer_file_parent"] = \
-          """ALTER TABLE dbsbuffer_file_parent ADD
-               (CONSTRAINT dbsbuffer_file_parent_pk PRIMARY KEY (child, parent) %s)""" % tablespaceIndex
+        self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_dbs_blo_1 ON dbsbuffer_block (location)"""
 
-        self.constraints["01_fk_dbsbuffer_file_parent"] = \
-          """ALTER TABLE dbsbuffer_file_parent ADD
-               (CONSTRAINT fk_file_parent_child FOREIGN KEY (child)
-                REFERENCES dbsbuffer_file(id) ON DELETE CASCADE)"""
+        self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_dbs_blo_2 ON dbsbuffer_block (dataset_id)"""
 
-        self.constraints["02_fk_dbsbuffer_file_parent"] = \
-          """ALTER TABLE dbsbuffer_file_parent ADD
-               (CONSTRAINT fk_file_parent_parent FOREIGN KEY (parent)
-                REFERENCES dbsbuffer_file(id) ON DELETE CASCADE)"""
+        self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_dbs_alg_ass_1 ON dbsbuffer_algo_dataset_assoc (dataset_id)"""
 
-        self.indexes["01_pk_dbsbuffer_location"] = \
-          """ALTER TABLE dbsbuffer_location ADD
-               (CONSTRAINT dbsbuffer_location_pk PRIMARY KEY (id) %s)""" % tablespaceIndex
+        self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_dbs_alg_ass_2 ON dbsbuffer_algo_dataset_assoc (algo_id)"""
 
-        self.indexes["01_uq_dbsbuffer_location"] = \
-          """ALTER TABLE dbsbuffer_location ADD
-               (CONSTRAINT dbsbuffer_location_uq UNIQUE (se_name) %s)""" % tablespaceIndex
+        self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_dbs_fil_run_1 ON dbsbuffer_file_runlumi_map (filename)"""
 
-        self.indexes["01_pk_dbsbuffer_block"] = \
-          """ALTER TABLE dbsbuffer_block ADD
-               (CONSTRAINT dbsbuffer_block_pk PRIMARY KEY (id) %s)""" % tablespaceIndex
+        self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_dbs_fil_loc_1 ON dbsbuffer_file_location (location)"""
 
-        self.indexes["01_uq_dbsbuffer_block"] = \
-          """ALTER TABLE dbsbuffer_block ADD
-               (CONSTRAINT dbsbuffer_block_uq UNIQUE (blockname, location) %s)""" % tablespaceIndex
+        self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_dbs_fil_loc_2 ON dbsbuffer_file_location (filename)"""
 
-        self.constraints["01_fk_dbsbuffer_block"] = \
-          """ALTER TABLE dbsbuffer_block ADD
-               (CONSTRAINT fk_block_location FOREIGN KEY (location)
-                 REFERENCES dbsbuffer_location(id) ON DELETE CASCADE)"""
+        self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_dbs_fil_1 ON dbsbuffer_file (workflow)"""
 
-        self.constraints["02_fk_dbsbuffer_block"] = \
-          """ALTER TABLE dbsbuffer_block ADD
-               (CONSTRAINT fk_block_dataset_id FOREIGN KEY (dataset_id)
-                REFERENCES dbsbuffer_dataset(id) ON DELETE CASCADE)"""
+        #
+        # Constraints
+        #
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE dbsbuffer_file_checksums
+                 ADD CONSTRAINT fk_file_checksums_typeid
+                 FOREIGN KEY (typeid)
+                 REFERENCES dbsbuffer_checksum_type(id)
+                 ON DELETE CASCADE"""
 
-        self.indexes["01_pk_dbsbuffer_algodset_assoc"] = \
-          """ALTER TABLE dbsbuffer_algo_dataset_assoc ADD
-               (CONSTRAINT dbsbuffer_algodset_assoc_pk PRIMARY KEY (id) %s)""" % tablespaceIndex
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE dbsbuffer_file_checksums
+                 ADD CONSTRAINT fk_file_checksums_fileid
+                 FOREIGN KEY (fileid)
+                 REFERENCES dbsbuffer_file(id)
+                 ON DELETE CASCADE"""
 
-        self.constraints["01_fk_dbsbuffer_algodset_assoc"] = \
-          """ALTER TABLE dbsbuffer_algo_dataset_assoc ADD
-               (CONSTRAINT fk_algodset_assoc_dataset_id FOREIGN KEY (dataset_id)
-                REFERENCES dbsbuffer_dataset(id) ON DELETE CASCADE)"""
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE dbsbuffer_dataset_subscription
+                 ADD CONSTRAINT fk_dsetsubscription_datasetid
+                 FOREIGN KEY (dataset_id)
+                 REFERENCES dbsbuffer_dataset(id)
+                 ON DELETE CASCADE"""
 
-        self.constraints["02_fk_dbsbuffer_algodset_assoc"] = \
-          """ALTER TABLE dbsbuffer_algo_dataset_assoc ADD
-               (CONSTRAINT fk_algodset_assoc_algo_id FOREIGN KEY (algo_id)
-                REFERENCES dbsbuffer_algo(id) ON DELETE CASCADE)"""
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE dbsbuffer_file_parent
+                 ADD CONSTRAINT fk_file_parent_child
+                 FOREIGN KEY (child)
+                 REFERENCES dbsbuffer_file(id)
+                 ON DELETE CASCADE"""
 
-        self.constraints["01_fk_dbsbuffer_file_runlumi"] = \
-          """ALTER TABLE dbsbuffer_file_runlumi_map ADD
-               (CONSTRAINT fk_file_runlumi_filename FOREIGN KEY (filename)
-                REFERENCES dbsbuffer_file(id) ON DELETE CASCADE)"""
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE dbsbuffer_file_parent
+                 ADD CONSTRAINT fk_file_parent_parent
+                 FOREIGN KEY (parent)
+                 REFERENCES dbsbuffer_file(id)
+                 ON DELETE CASCADE"""
 
-        self.constraints["01_fk_dbsbuffer_file_location"] = \
-          """ALTER TABLE dbsbuffer_file_location ADD
-               (CONSTRAINT fk_file_location_location FOREIGN KEY (location)
-                REFERENCES dbsbuffer_location(id) ON DELETE CASCADE)"""
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE dbsbuffer_block
+                 ADD CONSTRAINT fk_block_location
+                 FOREIGN KEY (location)
+                 REFERENCES dbsbuffer_location(id)
+                 ON DELETE CASCADE"""
 
-        self.constraints["02_fk_dbsbuffer_file_location"] = \
-          """ALTER TABLE dbsbuffer_file_location ADD
-               (CONSTRAINT fk_file_location_filename FOREIGN KEY (filename)
-                REFERENCES dbsbuffer_file(id) ON DELETE CASCADE)"""
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE dbsbuffer_block
+                 ADD CONSTRAINT fk_block_dataset_id
+                 FOREIGN KEY (dataset_id)
+                 REFERENCES dbsbuffer_dataset(id)
+                 ON DELETE CASCADE"""
 
-        self.indexes["01_pk_dbsbuffer_workflow"] = \
-          """ALTER TABLE dbsbuffer_workflow ADD
-               (CONSTRAINT dbsbuffer_workflow_pk PRIMARY KEY (id) %s)""" % tablespaceIndex
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE dbsbuffer_algo_dataset_assoc
+                 ADD CONSTRAINT fk_algodset_assoc_dataset_id
+                 FOREIGN KEY (dataset_id)
+                 REFERENCES dbsbuffer_dataset(id)
+                 ON DELETE CASCADE"""
 
-        self.indexes["01_uq_dbsbuffer_workflow"] = \
-          """ALTER TABLE dbsbuffer_workflow ADD
-               (CONSTRAINT dbsbuffer_workflow_uq UNIQUE (name, task) %s)""" % tablespaceIndex
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE dbsbuffer_algo_dataset_assoc
+                 ADD CONSTRAINT fk_algodset_assoc_algo_id
+                 FOREIGN KEY (algo_id)
+                 REFERENCES dbsbuffer_algo(id)
+                 ON DELETE CASCADE"""
 
-        self.indexes["01_pk_dbsbuffer_file"] = \
-          """ALTER TABLE dbsbuffer_file ADD
-               (CONSTRAINT dbsbuffer_file_pk PRIMARY KEY (id) %s)""" % tablespaceIndex
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE dbsbuffer_file_runlumi_map
+                 ADD CONSTRAINT fk_file_runlumi_filename
+                 FOREIGN KEY (filename)
+                 REFERENCES dbsbuffer_file(id)
+                 ON DELETE CASCADE"""
 
-        self.constraints["01_fk_dbsbuffer_file"] = \
-          """ALTER TABLE dbsbuffer_file ADD
-               (CONSTRAINT fk_file_workflow FOREIGN KEY (workflow)
-                REFERENCES dbsbuffer_workflow(id) ON DELETE CASCADE)"""
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE dbsbuffer_file_location
+                 ADD CONSTRAINT fk_file_location_location
+                 FOREIGN KEY (location)
+                 REFERENCES dbsbuffer_location(id)
+                 ON DELETE CASCADE"""
 
-        self.indexes["01_uq_dbsbuffer_file"] = \
-          """ALTER TABLE dbsbuffer_file ADD
-               (CONSTRAINT dbsbuffer_file_unique UNIQUE (lfn) %s)""" % tablespaceIndex
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE dbsbuffer_file_location
+                 ADD CONSTRAINT fk_file_location_filename
+                 FOREIGN KEY (filename)
+                 REFERENCES dbsbuffer_file(id)
+                 ON DELETE CASCADE"""
+
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE dbsbuffer_file
+                 ADD CONSTRAINT fk_file_workflow
+                 FOREIGN KEY (workflow)
+                 REFERENCES dbsbuffer_workflow(id)
+                 ON DELETE CASCADE"""
+
 
         checksumTypes = ['cksum', 'adler32', 'md5']
         for i in checksumTypes:
-            checksumTypeQuery = """INSERT INTO dbsbuffer_checksum_type (id, type) VALUES (dbsbuffer_checksum_type_seq.nextval, '%s')
-            """ % (i)
+            checksumTypeQuery = """INSERT INTO dbsbuffer_checksum_type
+                                   (id, type)
+                                   VALUES (dbsbuffer_checksum_type_seq.nextval, '%s')
+                                   """ % (i)
             self.inserts["wmbs_checksum_type_%s" % (i)] = checksumTypeQuery

--- a/src/python/WMComponent/DBS3Buffer/Oracle/CreateBlocks.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/CreateBlocks.py
@@ -3,10 +3,19 @@
 _DBS3Buffer.CreateBlocks_
 
 Create new block in dbsbuffer_block
-
 """
 
 from WMComponent.DBS3Buffer.MySQL.CreateBlocks import CreateBlocks as MySQLCreateBlocks
 
 class CreateBlocks(MySQLCreateBlocks):
-    pass
+
+    sql = """INSERT INTO dbsbuffer_block
+             (id, dataset_id, blockname, location, status, create_time)
+             SELECT dbsbuffer_block_seq.nextval,
+                    (SELECT id from dbsbuffer_dataset WHERE path = :dataset),
+                    :block,
+                    (SELECT id FROM dbsbuffer_location WHERE se_name = :location),
+                    :status,
+                    :time
+             FROM DUAL
+             """

--- a/src/python/WMComponent/DBS3Buffer/Oracle/DBSBufferFiles/AddLocation.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/DBSBufferFiles/AddLocation.py
@@ -5,12 +5,16 @@ _AddLocation_
 Oracle implementation of DBSBufferFiles.AddLocation
 """
 
-from WMCore.Database.DBFormatter import DBFormatter
-
-from WMComponent.DBS3Buffer.MySQL.DBSBufferFiles.AddLocation import AddLocation as \
-     MySQLAddLocation
+from WMComponent.DBS3Buffer.MySQL.DBSBufferFiles.AddLocation import AddLocation as MySQLAddLocation
 
 class AddLocation(MySQLAddLocation):
-    sql = """INSERT INTO dbsbuffer_location (se_name)
-               SELECT :location AS se_name FROM DUAL WHERE NOT EXISTS
-                (SELECT se_name FROM dbsbuffer_location WHERE se_name = :location)"""
+
+    sql = """INSERT INTO dbsbuffer_location
+             (id, se_name)
+             SELECT dbsbuffer_location_seq.nextval, :location
+             FROM DUAL
+             WHERE NOT EXISTS
+               ( SELECT *
+                 FROM dbsbuffer_location
+                 WHERE se_name = :location )
+             """

--- a/src/python/WMComponent/DBS3Buffer/Oracle/NewAlgo.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/NewAlgo.py
@@ -5,42 +5,21 @@ _NewAlgo_
 Oracle implementation of DBSBuffer.NewAlgo
 """
 
+from WMComponent.DBS3Buffer.MySQL.NewAlgo import NewAlgo as MySQLNewAlgo
 
+class NewAlgo(MySQLNewAlgo):
 
+    sql = """INSERT INTO dbsbuffer_algo
+             (id, app_name, app_ver, app_fam, pset_hash, config_content, in_dbs)
+             SELECT dbsbuffer_algo_seq.nextval, :app_name, :app_ver, :app_fam,
+                    :pset_hash, :config_content, 0
+             FROM DUAL
+             WHERE NOT EXISTS
+               ( SELECT *
+                 FROM dbsbuffer_algo
+                 WHERE app_name = :app_name
+                 AND app_ver = :app_ver
+                 AND app_fam = :app_fam
+                 AND pset_hash = :pset_hash )
+             """
 
-import logging
-
-from WMCore.Database.DBFormatter import DBFormatter
-
-class NewAlgo(DBFormatter):
-    """
-    _NewAlgo_
-
-    Add a new algorithm to the DBSBuffer.  This will do nothing if an algorithm
-    with the given parameters already exists.
-    """
-    sql = """INSERT INTO dbsbuffer_algo (app_name, app_ver, app_fam, pset_hash,
-                                         config_content, in_dbs)
-               SELECT :app_name, :app_ver, :app_fam, :pset_hash,
-                 :config_content, 0 FROM DUAL WHERE NOT EXISTS
-                   (SELECT * FROM dbsbuffer_algo WHERE app_name = :app_name AND
-                      app_ver = :app_ver AND app_fam = :app_fam AND
-                      pset_hash = :pset_hash)"""
-
-    def execute(self, appName = None, appVer = None, appFam = None,
-                psetHash = None, configContent = None, conn = None,
-                transaction = False):
-        binds = {"app_name": appName, "app_ver": appVer, "app_fam": appFam,
-                 "pset_hash": psetHash, "config_content": configContent}
-
-        try:
-            self.dbi.processData(self.sql, binds, conn = conn,
-                                 transaction = transaction)
-        except Exception as ex:
-            if "orig" in dir(ex) and type(ex.orig) != tuple:
-                if str(ex.orig).find("ORA-00001: unique constraint") != -1 and \
-                   str(ex.orig).find("DBSBUFFER_ALGO_UNIQUE") != -1:
-                    return
-            raise ex
-
-        return

--- a/src/python/WMComponent/DBS3Buffer/Oracle/NewDataset.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/NewDataset.py
@@ -12,6 +12,13 @@ from WMComponent.DBS3Buffer.MySQL.NewDataset import NewDataset as MySQLNewDatase
 
 class NewDataset(MySQLNewDataset):
 
-    sql = """INSERT INTO dbsbuffer_dataset (path, processing_ver, acquisition_era, valid_status, global_tag, parent, prep_id)
-               SELECT :path, :processing_ver, :acquisition_era, :valid_status, :global_tag, :parent, :prep_id FROM DUAL
-               WHERE NOT EXISTS (SELECT path FROM dbsbuffer_dataset WHERE path = :path)"""
+    sql = """INSERT INTO dbsbuffer_dataset
+             (id, path, processing_ver, acquisition_era, valid_status, global_tag, parent, prep_id)
+             SELECT dbsbuffer_dataset_seq.nextval, :path, :processing_ver, :acquisition_era,
+                    :valid_status, :global_tag, :parent, :prep_id
+             FROM DUAL
+             WHERE NOT EXISTS
+               ( SELECT *
+                 FROM dbsbuffer_dataset
+                 WHERE path = :path )
+             """

--- a/src/python/WMComponent/DBS3Buffer/Oracle/NewSubscription.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/NewSubscription.py
@@ -18,9 +18,17 @@ class NewSubscription(MySQLNewSubscription):
     """
 
     sql = """INSERT INTO dbsbuffer_dataset_subscription
-            (dataset_id, site, custodial, auto_approve, move, priority, subscribed, delete_blocks)
-            SELECT :id, :site, :custodial, :auto_approve, :move, :priority, 0, :delete_blocks FROM DUAL
-            WHERE NOT EXISTS (SELECT * from dbsbuffer_dataset_subscription
-                WHERE dataset_id = :id AND site = :site AND custodial = :custodial
-                AND auto_approve = :auto_approve AND move = :move AND priority = :priority)
-          """
+             (id, dataset_id, site, custodial, auto_approve, move, priority, subscribed, delete_blocks)
+             SELECT dbsbuffer_dataset_sub_seq.nextval, :id, :site, :custodial, :auto_approve,
+                    :move, :priority, 0, :delete_blocks
+             FROM DUAL
+             WHERE NOT EXISTS
+               ( SELECT *
+                 FROM dbsbuffer_dataset_subscription
+                 WHERE dataset_id = :id
+                 AND site = :site
+                 AND custodial = :custodial
+                 AND auto_approve = :auto_approve
+                 AND move = :move
+                 AND priority = :priority )
+             """

--- a/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
+++ b/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
@@ -274,8 +274,9 @@ class PhEDExInjectorPoller(BaseWorkerThread):
             try:
                 self.setStatus.execute(lfnList, 1, transaction = False)
             except Exception:
-                # possible race conditions, retry once after 1s
-                time.sleep(1)
+                # possible deadlock with DBS3Upload, retry once after 5s
+                logging.warning("Oracle exception, possible deadlock due to race condition, retry after 5s sleep")
+                time.sleep(5)
                 self.setStatus.execute(lfnList, 1, transaction = False)
 
         return


### PR DESCRIPTION
Both PhEDExInjector and DBS3Buffer components update dbsbuffer_file records. They do it in a way that the two updates can deadlock each other. General slow performance of dbsbuffer related code makes this quite likely to happen, therefor rework and simplify the schema (add some indexes, remove triggers, general cleanup).

No functional changes and the cleanup and indexes are only done on Oracle for now as some of it is very Oracle specific. We could sync the MySQL version later if so desired.

Also put in recovery logic to at least retry once in each component if deadlock occurs.
