### PR TITLE
Add timestamp to stageout; remove ls retries; minor changes

### DIFF
--- a/src/python/WMCore/Storage/StageOutImpl.py
+++ b/src/python/WMCore/Storage/StageOutImpl.py
@@ -11,6 +11,7 @@ import os
 from WMCore.Storage.Execute import runCommand
 from WMCore.Storage.StageOutError import StageOutError
 
+
 class StageOutImpl:
     """
     _StageOutImpl_
@@ -44,14 +45,13 @@ class StageOutImpl:
             msg = "%s : Command exited with status: %s\n" % (time.strftime("%Y-%m-%dT%H:%M:%S"), exitCode)
             print msg
         except Exception as ex:
-            raise StageOutError(str(ex), Command = command, ExitCode = 60311)
+            raise StageOutError(str(ex), Command=command, ExitCode=60311)
         if exitCode:
             msg = "%s : Command exited non-zero" % time.strftime("%Y-%m-%dT%H:%M:%S")
             print "ERROR: Exception During Stage Out:\n"
             print msg
-            raise StageOutError(msg, Command = command, ExitCode = exitCode)
+            raise StageOutError(msg, Command=command, ExitCode=exitCode)
         return
-
 
     def createSourceName(self, protocol, pfn):
         """
@@ -63,7 +63,6 @@ class StageOutImpl:
 
         """
         raise NotImplementedError("StageOutImpl.createSourceName")
-
 
     def createTargetName(self, protocol, pfn):
         """
@@ -80,7 +79,6 @@ class StageOutImpl:
         """
         return self.createSourceName(protocol, pfn)
 
-
     def createOutputDirectory(self, targetPFN):
         """
         _createOutputDirectory_
@@ -92,8 +90,7 @@ class StageOutImpl:
         """
         pass
 
-
-    def createStageOutCommand(self, sourcePFN, targetPFN, options = None, checksums = None):
+    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
         """
         _createStageOutCommand_
 
@@ -102,7 +99,6 @@ class StageOutImpl:
 
         """
         raise NotImplementedError("StageOutImpl.createStageOutCommand")
-
 
     def removeFile(self, pfnToRemove):
         """
@@ -116,7 +112,6 @@ class StageOutImpl:
         """
         raise NotImplementedError("StageOutImpl.removeFile")
 
-
     def createRemoveFileCommand(self, pfn):
         """
         return the command to delete a file after a failed copy
@@ -128,8 +123,7 @@ class StageOutImpl:
         else:
             return ""
 
-
-    def __call__(self, protocol, inputPFN, targetPFN, options = None, checksums = None):
+    def __call__(self, protocol, inputPFN, targetPFN, options=None, checksums=None):
         """
         _Operator()_
 
@@ -140,7 +134,7 @@ class StageOutImpl:
         """
         #  //
         # // Generate the source PFN from the plain PFN if needed
-        #//
+        # //
         sourcePFN = self.createSourceName(protocol, inputPFN)
 
         # destination may also need PFN changed
@@ -149,10 +143,10 @@ class StageOutImpl:
 
         #  //
         # // Create the output directory if implemented
-        #//
+        # //
         for retryCount in range(1, self.numRetries + 1):
             try:
-                print "%s : Creating output directory." % time.strftime("%Y-%m-%dT%H:%M:%S")
+                print "%s : Creating output directory..." % time.strftime("%Y-%m-%dT%H:%M:%S")
                 self.createOutputDirectory(targetPFN)
                 break
             except StageOutError as ex:
@@ -160,24 +154,24 @@ class StageOutImpl:
                 msg += "Automatically retrying in %s secs\n " % self.retryPause
                 msg += "Error details:\n%s\n" % str(ex)
                 print msg
-                if retryCount == self.numRetries :
+                if retryCount == self.numRetries:
                     #  //
                     # // last retry, propagate exception
-                    #//
+                    # //
                     raise ex
                 time.sleep(self.retryPause)
 
-        #  //
+        # //
         # // Create the command to be used.
-        #//
+        # //
         command = self.createStageOutCommand(sourcePFN, targetPFN, options, checksums)
         #  //
         # // Run the command
-        #//
+        # //
 
         for retryCount in range(1, self.numRetries + 1):
             try:
-                print "%s : Attempting to stage out." % time.strftime("%Y-%m-%dT%H:%M:%S")
+                print "%s : Running the stage out..." % time.strftime("%Y-%m-%dT%H:%M:%S")
                 self.executeCommand(command)
                 break
             except StageOutError as ex:
@@ -185,10 +179,10 @@ class StageOutImpl:
                 msg += "Automatically retrying in %s secs\n " % self.retryPause
                 msg += "Error details:\n%s\n" % str(ex)
                 print msg
-                if retryCount == self.numRetries :
+                if retryCount == self.numRetries:
                     #  //
                     # // last retry, propagate exception
-                    #//
+                    # //
                     raise ex
                 time.sleep(self.retryPause)
 


### PR DESCRIPTION
As reported in the CompOps (and personally by @bbockelm), when a dcache server is under high load the lcg-ls retries may make things even more unstable. So I removed those 10 retries we had before per each lcg-cp attempt.

Timestamp was also added to the stage out code such that it makes our life a bit easier to debug any thing there.

Directory creation was evaluating to True all the time, so I simply removed the code checking for that (and error codes).

Finally, lcg-cp logs will be spit to the _condor_stdout now, even when it's successful.

@hufnagel please have a look.
I successfully ran several tests, but I put a few more changes in this commit that needs one more test at least.
