### PR TITLE
stop endless spamming cpu alarms

### DIFF
--- a/src/python/WMComponent/AlertGenerator/Pollers/System.py
+++ b/src/python/WMComponent/AlertGenerator/Pollers/System.py
@@ -32,7 +32,7 @@ class ProcessCPUPoller(object):
         """
         try:
             # raises: psutil.error.AccessDenied, psutil.error.NoSuchProcess
-            pollProcess = lambda proc: proc.get_cpu_percent(PeriodPoller.PSUTIL_INTERVAL)
+            pollProcess = lambda proc: proc.cpu_percent(PeriodPoller.PSUTIL_INTERVAL)
             v = sum([pollProcess(p) for p in processDetail.allProcs])
             return v
         except AccessDenied as ex:


### PR DESCRIPTION
Seems like the psutil.Process object has no get_cpu_percent method in the python version that we ship with WMAgent (and the Tier0). Not sure if this is a recent change or of this was always broken, but this fixes it. Without it the AlertGenerator goes nuts, sending a cpu alert every polling cycle.
