### PR TITLE
Add AllowOpportunistic flag to job classAd

### DIFF
--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -380,7 +380,8 @@ class JobSubmitterPoller(BaseWorkerThread):
                        loadedJob.get("numberOfCores", 1),
                        newJob['task_id'],
                        loadedJob.get('inputDataset', None),
-                       loadedJob.get('inputDatasetLocations', None)
+                       loadedJob.get('inputDatasetLocations', None),
+                       loadedJob.get('allowOpportunistic', False)
                        )
 
             self.jobDataCache[workflowName][jobID] = jobInfo
@@ -693,7 +694,8 @@ class JobSubmitterPoller(BaseWorkerThread):
                                'numberOfCores' : cachedJob[19],
                                'taskID' : cachedJob[20],
                                'inputDataset' : cachedJob[21],
-                               'inputDatasetLocations' : cachedJob[22]
+                               'inputDatasetLocations' : cachedJob[22],
+                               'allowOpportunistic' : cachedJob[23]
                                }
 
                     # Add to jobsToSubmit

--- a/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
@@ -1031,6 +1031,9 @@ class CondorPlugin(BasePlugin):
         if job.get('taskType', None):
             jdl.append('+CMS_JobType = "%s"\n' % job['taskType'])
 
+        # Handling for AWS, cloud and opportunistic resources
+        jdl.append('+AllowOpportunistic = %s\n' % job.get('allowOpportunistic', False))
+
         # dataset info
         if job.get('inputDataset', None):
             jdl.append('+DESIRED_CMSDataset = "%s"\n' % job['inputDataset'])

--- a/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
@@ -981,6 +981,9 @@ class PyCondorPlugin(BasePlugin):
         if job.get('taskType', None):
             jdl.append('+CMS_JobType = "%s"\n' % job['taskType'])
 
+        # Handling for AWS, cloud and opportunistic resources
+        jdl.append('+AllowOpportunistic = %s\n' % job.get('allowOpportunistic', False))
+
         # dataset info
         if job.get('inputDataset', None):
             jdl.append('+DESIRED_CMSDataset = "%s"\n' % job['inputDataset'])

--- a/src/python/WMCore/BossAir/RunJob.py
+++ b/src/python/WMCore/BossAir/RunJob.py
@@ -19,62 +19,50 @@ class RunJob(dict):
     the necessary fields.
     """
 
-    def __init__(self, id = None, jobid = -1, gridid = None,
-                 bulkid = None, retry_count = 0, status = None,
-                 location = None, userdn = None, usergroup = '',
-                 userrole = '', plugin = None,
-                 cache_dir = None, status_time = None, packageDir = None,
-                 sandbox = None, priority = None, site_cms_name = None,
-                 taskType = None, possibleSites = None, sw_version = None,
-                 scram_arch = None, siteName = None, jobName = None,
-                 proxyPath = None, requestName = None, jobTime = None,
-                 diskUsage = None, memoryUsage = None, taskPriority = None,
-                 taskName = None, taskID = None, potentialSites = None,
-                 numberOfCores = 1, inputDataset = None, inputDatasetLocations = None
-                ):
+    def __init__(self, jobid = -1):
         """
         Just make sure you init the dictionary fields.
 
-        If the field has no value, leave it as NONE so we can
+        If the field has no value, leave it as None so we can
         overwrite it later.
-
         """
 
-        self.setdefault('id', id)
+        self.setdefault('id', None)
         self.setdefault('jobid', jobid)
-        self.setdefault('gridid', gridid)
-        self.setdefault('bulkid', bulkid)
-        self.setdefault('retry_count', retry_count)
-        self.setdefault('status', status)
-        self.setdefault('location', location)
-        self.setdefault('site_cms_name', site_cms_name)
-        self.setdefault('userdn', userdn)
-        self.setdefault('usergroup', usergroup)
-        self.setdefault('userrole', userrole)
-        self.setdefault('plugin', plugin)
-        self.setdefault('cache_dir', cache_dir)
-        self.setdefault('status_time', status_time)
-        self.setdefault('packageDir', packageDir)
-        self.setdefault('sandbox', sandbox)
-        self.setdefault('priority', priority)
-        self.setdefault('taskType', taskType)
-        self.setdefault('possibleSites', possibleSites)
-        self.setdefault('swVersion', sw_version)
-        self.setdefault('scramArch', scram_arch)
-        self.setdefault('siteName', siteName)
-        self.setdefault('name', jobName)
-        self.setdefault('proxyPath', proxyPath)
-        self.setdefault('requestName', requestName)
-        self.setdefault('estimatedJobTime', jobTime)
-        self.setdefault('estimatedDiskUsage', diskUsage)
-        self.setdefault('estimatedMemoryUsage', memoryUsage)
-        self.setdefault('numberOfCores', numberOfCores)
-        self.setdefault('taskPriority', taskPriority)
-        self.setdefault('taskName', taskName)
-        self.setdefault('taskID', taskID)
-        self.setdefault('potentialSites', potentialSites)
-        self.setdefault('inputDataset', inputDataset)
-        self.setdefault('inputDatasetLocations', inputDatasetLocations)
+        self.setdefault('gridid', None)
+        self.setdefault('bulkid', None)
+        self.setdefault('retry_count', 0)
+        self.setdefault('status', None)
+        self.setdefault('location', None)
+        self.setdefault('site_cms_name', None)
+        self.setdefault('userdn', None)
+        self.setdefault('usergroup', '')
+        self.setdefault('userrole', '')
+        self.setdefault('plugin', None)
+        self.setdefault('cache_dir', None)
+        self.setdefault('status_time', None)
+        self.setdefault('packageDir', None)
+        self.setdefault('sandbox', None)
+        self.setdefault('priority', None)
+        self.setdefault('taskType', None)
+        self.setdefault('possibleSites', None)
+        self.setdefault('swVersion', None)
+        self.setdefault('scramArch', None)
+        self.setdefault('siteName', None)
+        self.setdefault('name', None)
+        self.setdefault('proxyPath', None)
+        self.setdefault('requestName', None)
+        self.setdefault('estimatedJobTime', None)
+        self.setdefault('estimatedDiskUsage', None)
+        self.setdefault('estimatedMemoryUsage', None)
+        self.setdefault('numberOfCores', 1)
+        self.setdefault('taskPriority', None)
+        self.setdefault('taskName', None)
+        self.setdefault('taskID', None)
+        self.setdefault('potentialSites', None)
+        self.setdefault('inputDataset', None)
+        self.setdefault('inputDatasetLocations', None)
+        self.setdefault('allowOpportunistic', False)
 
         return
 

--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
@@ -369,9 +369,8 @@ class Assign(WebAPI):
                                           kwargs.get("GracePeriod", None))
 
         # Check whether we should check location for the data
-        useAAA = strToBool(kwargs.get("useSiteListAsLocation", False))
-        if useAAA:
-            helper.setLocationDataSourceFlag(flag=useAAA)
+        helper.setLocationDataSourceFlag(flag=strToBool(kwargs.get("useSiteListAsLocation", False)))
+        helper.setAllowOpportunistic(allowOpport=strToBool(kwargs.get("allowOpportunistic", False)))
 
         # Set phedex subscription information
         custodialList = kwargs.get("CustodialSites", [])

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -230,6 +230,7 @@ class StdBase(object):
         workload.setCampaign(self.campaign)
         workload.setRequestType(self.requestType)
         workload.setPrepID(self.prepID)
+        workload.setAllowOpportunistic(self.allowOpportunistic)
         return workload
 
     def setupProcessingTask(self, procTask, taskType, inputDataset = None, inputStep = None,
@@ -933,7 +934,6 @@ class StdBase(object):
                                          "validate" : lambda x: all([block(y) for y in x])},
                      "BlockWhitelist" : {"default" : [], "type" : makeList, 
                                          "validate" : lambda x: all([block(y) for y in x])},
-                     "TrustSitelists" : {"default" : False, "type" : strToBool},
                      "UnmergedLFNBase" : {"default" : "/store/unmerged"},
                      "MergedLFNBase" : {"default" : "/store/data"},
                      "MinMergeSize" : {"default" : 2 * 1024 * 1024 * 1024, "type" : int,
@@ -970,12 +970,15 @@ class StdBase(object):
                      "IncludeParents" : {"default" : False,  "type" : strToBool},
                      "Multicore" : {"default" : 1, "null" : True,
                                     "validate" : lambda x : x == "auto" or (int(x) > 0)},
+                     # data location management
+                     "TrustSitelists" : {"default" : False, "type" : strToBool},
+                     "UseSiteListAsLocation" : {"default" : False, "type" : bool},
+                     "AllowOpportunistic" : {"default" : False, "type" : bool},
                      #from assignment: performance monitoring data
                      "MaxRSS" : {"default" : 2411724, "type" : int, "validate" : lambda x : x > 0},
                      "MaxVSize" : {"default" : 20411724, "type" : int, "validate" : lambda x : x > 0},
                      "SoftTimeout" : {"default" : 129600, "type" : int, "validate" : lambda x : x > 0},
                      "GracePeriod" : {"default" : 300, "type" : int, "validate" : lambda x : x > 0},
-                     "UseSiteListAsLocation" : {"default" : False, "type" : bool},
                      
                      # Set phedex subscription information
                      "CustodialSites" : {"default" : [], "type" : makeList, "assign_optional": True,
@@ -993,7 +996,7 @@ class StdBase(object):
                      "NonCustodialSubType" : {"default" : "Replica", "type" : str, "assign_optional": True,
                                               "validate" : lambda x: x in ["Move", "Replica"]},
                      
-                     # Block closing informaiont
+                     # Block closing information
                      "BlockCloseMaxWaitTime" : {"default" : 66400, "type" : int, "validate" : lambda x : x > 0},
                      "BlockCloseMaxFiles" : {"default" : 500, "type" : int, "validate" : lambda x : x > 0},
                      "BlockCloseMaxEvents" : {"default" : 25000000, "type" : int, "validate" : lambda x : x > 0},

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -9,7 +9,7 @@ of related tasks.
 from WMCore.Configuration import ConfigSection
 from WMCore.WMSpec.ConfigSectionTree import findTop
 from WMCore.WMSpec.Persistency import PersistencyHelper
-from WMCore.WMSpec.WMWorkloadTools import validateArgumentsUpdate, \
+from WMCore.WMSpec.WMWorkloadTools import validateArgumentsUpdate, strToBool, \
                         loadSpecClassByType, setAssignArgumentsWithDefault
 from WMCore.WMSpec.WMTask import WMTask, WMTaskHelper
 from WMCore.Lexicon import sanitizeURL
@@ -795,6 +795,23 @@ class WMWorkloadHelper(PersistencyHelper):
         """
 
         return getattr(self.data.properties, 'validStatus', None)
+
+    def setAllowOpportunistic(self, allowOpport):
+        """
+        _setAllowOpportunistic_
+
+        Set a flag which enables the workflow to run in cloud resources.
+        """
+        self.data.properties.allowOpportunistic = allowOpport
+        return
+
+    def getAllowOpportunistic(self):
+        """
+        _getAllowOpportunistic_
+
+        Retrieve AllowOpportunitisc flag for the workflow
+        """
+        return getattr(self.data.properties, 'allowOpportunistic', None)
 
     def setPrepID(self, prepID):
         """
@@ -1721,10 +1738,11 @@ class WMWorkloadHelper(PersistencyHelper):
 
         # Check whether we should check location for the data
         if self._checkKeys(kwargs, "useSiteListAsLocation"):
-            self.setLocationDataSourceFlag(flag = kwargs["useSiteListAsLocation"])
+            self.setLocationDataSourceFlag(flag = strToBool(kwargs["useSiteListAsLocation"]))
+        if self._checkKeys(kwargs, "allowOpportunistic"):
+            self.setAllowOpportunistic(allowOpport = strToBool(kwargs["allowOpportunistic"]))
 
         # Set phedex subscription information
-
         if self._checkKeys(kwargs, phedexParams):
             self.setSubscriptionInformationWildCards(wildcardDict = wildcardSites,
                                         custodialSites = kwargs["CustodialSites"],

--- a/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
+++ b/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
@@ -789,7 +789,7 @@ class JobSubmitterTest(unittest.TestCase):
 
         # Actually run it
         startTime = time.time()
-        cProfile.runctx("jobSubmitter.algorithm()", globals(), locals(), filename = "testStats.stat")
+        cProfile.runctx("JobSubmitterPoller(config=config).algorithm()", globals(), locals(), filename="testStats.stat")
         stopTime = time.time()
 
         print "Job took %f seconds to complete" % (stopTime - startTime)

--- a/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
@@ -1818,5 +1818,20 @@ class WMWorkloadTest(unittest.TestCase):
         self.assertEqual(sorted(taskList), sorted(expectedTasks))
         return
 
+    def testAllowOpportunistic(self):
+        """
+        _testAllowOpportunistic_
+
+        Verify that the allowOpportunistic flag can be read and set.
+        """
+        testWorkload = WMWorkloadHelper(WMWorkload("TestWorkload"))
+        self.assertFalse(testWorkload.getAllowOpportunistic(), "Should be None, I did not set you yet.")
+        testWorkload.setAllowOpportunistic(True)
+        self.assertTrue(testWorkload.getAllowOpportunistic(), "Bad job!! You should be True")
+        testWorkload.setAllowOpportunistic(False)
+        self.assertFalse(testWorkload.getAllowOpportunistic(), "Bad job!! You should be False")
+        return
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #5994
This flag (allowOpportunistic) can be set during workflow assignment, which will make it down to the job classAd and then sites (initially T1_US_FNAL) can use that in order to forward jobs to another kind of resources.

Passes my initial test, though more testing/pylint/unittests are needed (if in time for testbed tomorrow).
@ticoann @hufnagel please review
