### PR TITLE
fix priority update for workqueue from reqmgr/reqmgr2

### DIFF
--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
@@ -179,11 +179,8 @@ def changePriority(requestName, priority, wmstatUrl = None):
     fields = {"RequestPriority": newPrior}
     couchDb.updateDocument(requestName, "ReqMgr", "updaterequest", fields=fields, useBody = True)
     # push the change to the WorkQueue
-    response = ProdManagement.getProdMgr(requestName)
-    if response == [] or response[0] is None or response[0] == "":
-        # Request must not be assigned yet, we are safe here
-        return
-    workqueue = WorkQueue.WorkQueue(response[0])
+    gqURL = "%s/workqueue" % request["CouchURL"]
+    workqueue = WorkQueue.WorkQueue(gqURL)
     workqueue.updatePriority(requestName, priority)
     return
 

--- a/src/python/WMCore/ReqMgr/Service/Request.py
+++ b/src/python/WMCore/ReqMgr/Service/Request.py
@@ -394,6 +394,9 @@ class Request(RESTEntity):
         if ('SoftTimeout' in request_args) and ('GracePeriod' in request_args): 
             request_args['HardTimeout'] = request_args['SoftTimeout'] + request_args['GracePeriod']
         
+        if 'RequestPriority' in request_args:
+            self.gq_service.updatePriority(workload.name(), request_args['RequestPriority'])
+        
         if "total_jobs" in request_args:
             # only GQ update this stats
             # request_args should contain only 4 keys 'total_jobs', 'input_lumis', 'input_events', 'input_num_files'}

--- a/src/python/WMCore/Services/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/Services/WorkQueue/WorkQueue.py
@@ -133,7 +133,7 @@ class WorkQueue(object):
         data = self.db.loadView('WorkQueue', 'elementsDetailByWorkflowAndStatus',
                                 {'startkey' : [wf], 'endkey' : [wf, {}],
                                  'reduce' : False})
-        elementsToUpdate = [x['id'] for x in data.get('rows', []) if x['key'][1] == 'Available']
+        elementsToUpdate = [x['id'] for x in data.get('rows', [])]
         if elementsToUpdate:
             self.updateElements(*elementsToUpdate, Priority = priority)
         # Update the spec, if it exists
@@ -160,7 +160,7 @@ class WorkQueue(object):
         """
         deleted = 0
         dbs = [self.db, self.inboxDB]
-        if type(workflowNames) != list:
+        if not isinstance(workflowNames, list):
             workflowNames = [workflowNames]
         
         if len(workflowNames) == 0:


### PR DESCRIPTION
fixes #6310, @amaltaro, Alan it seem reqmgr update workqueue priority when it changes its priority. Only reqmgr2 doesn't do that. It might happen that if update fails it doesn't retry, though. (The case you pointed). Don't merge yet. running the test now.
