### PR TITLE
Use DBSBufferFile module from DBS3 package

### DIFF
--- a/src/python/WMComponent/DBSUpload/Database/Interface/UploadToDBS.py
+++ b/src/python/WMComponent/DBSUpload/Database/Interface/UploadToDBS.py
@@ -14,7 +14,7 @@ from WMCore.WMFactory        import WMFactory
 from WMCore.DAOFactory       import DAOFactory
 from WMCore.WMConnectionBase import WMConnectionBase
 
-from WMComponent.DBSBuffer.Database.Interface.DBSBufferFile import DBSBufferFile
+from WMComponent.DBS3Buffer.DBSBufferFile import DBSBufferFile
 from WMCore.DataStructs.Run import Run
 
 

--- a/src/python/WMCore/WorkQueue/WMBSHelper.py
+++ b/src/python/WMCore/WorkQueue/WMBSHelper.py
@@ -25,7 +25,7 @@ from WMCore.WMBS.Subscription import Subscription
 from WMCore.WMBS.Job import Job
 from WMCore.WMException import WMException
 from WMCore.DataStructs.Run import Run
-from WMComponent.DBSBuffer.Database.Interface.DBSBufferFile import DBSBufferFile
+from WMComponent.DBS3Buffer.DBSBufferFile import DBSBufferFile
 from WMComponent.DBS3Buffer.DBSBufferDataset import DBSBufferDataset
 from WMCore.DAOFactory import DAOFactory
 from WMCore.WMConnectionBase import WMConnectionBase


### PR DESCRIPTION
WorkQueueManager was failing to completely create request subscriptions and that was also affecting JobAccountant (which I thought were due to the recent sql schema changes). Turns out the problem was happening because it was using dao that did not consider the new schema.

@ticoann this seems to fix the WMAgent issue I saw yesterday. Anyways, better waiting until tomorrow or Monday to merge it.
