### PR TITLE
Workaround for emitting doc null in workqueue

### DIFF
--- a/src/couchapps/WorkQueue/views/elementsByStatus/map.js
+++ b/src/couchapps/WorkQueue/views/elementsByStatus/map.js
@@ -1,8 +1,10 @@
 function(doc, site) {
-    var ele = doc["WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement"];
-    // Can't get multiple keys to work - use one for now
-    //emit([ele["Status"], ele["RequestName"], doc._id, doc.timestamp, ele["ParentQueueId"]],
-    if (ele) {
-        emit(ele["Status"], {'_id' : doc['_id']});
+    if (doc) {
+        var ele = doc["WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement"];
+        // Can't get multiple keys to work - use one for now
+        //emit([ele["Status"], ele["RequestName"], doc._id, doc.timestamp, ele["ParentQueueId"]],
+        if (ele) {
+            emit(ele["Status"], {'_id' : doc['_id']});
+        }
     }
 }


### PR DESCRIPTION
All the production agents were facing issues while pulling work down (for almost 48h) because a row had doc: null, and then it was breaking the list/filter that is used by the agents for data acquisition.

Investigating the production workqueue views, it had 174 row with doc:null, like:
{"id":"039150ae7098cb4749a90123c014d135","key":"Canceled","value":{"_id":"039150ae7098cb4749a90123c014d135"},"doc":null},
{"id":"41122e9339257b37c8e8a719b84fa7fe","key":"CancelRequested","value":{"_id":"41122e9339257b37c8e8a719b84fa7fe"},"doc":null},
{"id":"47ede14085856e62907acffd101b70ee","key":"CancelRequested","value":{"_id":"47ede14085856e62907acffd101b70ee"},"doc":null},
{"id":"d91f4dd62d8088cc0db5d5f974844568","key":"Done","value":{"_id":"d91f4dd62d8088cc0db5d5f974844568"},"doc":null},
{"id":"15c67cd97353c5dfafaf60dcbf74c402","key":"Negotiating","value":{"_id":"15c67cd97353c5dfafaf60dcbf74c402"},"doc":null},
{"id":"5cd8d5183f2b97f4fcf4dbdcae395815","key":"Running","value":{"_id":"5cd8d5183f2b97f4fcf4dbdcae395815"},"doc":null},

which then breaks here:
https://github.com/dmwm/WMCore/blob/master/src/couchapps/WorkQueue/lists/filter.js#L16

Talking to Diego and Bruno, we don't really understand how it can help besides a race condition where the document is still valid while the view is parsing it but before emitting the doc, it gets deleted and so the null value.

Tested in my VM. @ticoann please review. I'm not sure whether it can affect other things.
If you don't like this fix, another option would be fixing the list/filter.js code to simply skip the doc in case it's null, however in this case we would still keep the null doc in the workqueue views.

It's not critical to get this fix in, but if such problem happens during christmas, it stops the whole production from acquiring new work.
