### PR TITLE
Newline after CMSGroups classAd

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
@@ -1028,7 +1028,7 @@ class CondorPlugin(BasePlugin):
             jdl.append('+WMAgent_RequestName = "%s"\n' % job['requestName'])
             m = GROUP_NAME_RE.match(job['requestName'])
             if m:
-                jdl.append('+CMSGroups = "%s"' % m.groups()[0])
+                jdl.append('+CMSGroups = "%s"\n' % m.groups()[0])
 
 
         if job.get('taskName', None):

--- a/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
@@ -978,7 +978,7 @@ class PyCondorPlugin(BasePlugin):
             jdl.append('+WMAgent_RequestName = "%s"\n' % job['requestName'])
             m = GROUP_NAME_RE.match(job['requestName'])
             if m:
-                jdl.append('+CMSGroups = %s' % classad.quote(m.groups()[0]))
+                jdl.append('+CMSGroups = %s\n' % classad.quote(m.groups()[0]))
 
         if job.get('taskName', None):
             jdl.append('+WMAgent_SubTaskName = "%s"\n' % job['taskName'])


### PR DESCRIPTION
My bad I did not catch this bug in testbed, the problem is that my test workflows don't have a group and so they never matched that regexp. Pushing it to the newest production agents right now.
