### PR TITLE
Adopt group regexp for new pdmvserv task name scheme.

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
@@ -32,7 +32,7 @@ from WMCore.BossAir.Plugins.BasePlugin import BasePlugin, BossAirPluginException
 from WMCore.FwkJobReport.Report        import Report
 from WMCore.Algorithms                 import SubprocessAlgos
 
-GROUP_NAME_RE = re.compile("^[a-zA-Z0-9]+_([A-Z]+)-")
+GROUP_NAME_RE = re.compile("^[a-zA-Z0-9_]+_([A-Z]+)-")
 
 def submitWorker(input, results, timeout = None):
     """

--- a/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
@@ -36,7 +36,7 @@ from WMCore.Algorithms                 import SubprocessAlgos
 import htcondor as condor
 import classad
 
-GROUP_NAME_RE = re.compile("^[a-zA-Z0-9]+_([A-Z]+)-")
+GROUP_NAME_RE = re.compile("^[a-zA-Z0-9_]+_([A-Z]+)-")
 
 def submitWorker(input, results, timeout = None):
     """


### PR DESCRIPTION
@amaltaro this is probably why you didn't hit the `CMSGroups` issue earlier - newer tasks have tweaked the naming scheme.  This appropriately matches those I could find.
