### PR TITLE
Don't create fileset for IgnoredOutputModules

### DIFF
--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -270,8 +270,19 @@ class WMTaskHelper(TreeHelper):
         outputModules = []
         for stepName in self.listAllStepNames():
             outputModules.append(self.getOutputModulesForStep(stepName))
-
         return outputModules
+
+    def getIgnoredOutputModulesForTask(self):
+        """
+        _getIgnoredOutputModulesForTask_
+
+        Retrieve the ignored output modules in the given task.
+        """
+        ignoredOutputModules = []
+        for stepName in self.listAllStepNames():
+            stepHelper = self.getStepHelper(stepName)
+            ignoredOutputModules.extend(stepHelper.getIgnoredOutputModules())
+        return ignoredOutputModules
 
     def getOutputModulesForStep(self, stepName):
         """

--- a/src/python/WMCore/WorkQueue/WMBSHelper.py
+++ b/src/python/WMCore/WorkQueue/WMBSHelper.py
@@ -309,8 +309,12 @@ class WMBSHelper(WMConnectionBase):
             logging.info("Child subscription created: %s" % subscription["id"])
 
         outputModules = task.getOutputModulesForTask()
+        ignoredOutputModules = task.getIgnoredOutputModulesForTask()
         for outputModule in outputModules:
             for outputModuleName in outputModule.listSections_():
+                if outputModuleName in ignoredOutputModules:
+                    logging.info("IgnoredOutputModule set for %s, skipping fileset creation.", outputModuleName)
+                    continue
                 outputFileset = Fileset(self.outputFilesetName(task, outputModuleName))
                 outputFileset.create()
                 outputFileset.markOpen(True)

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
@@ -346,6 +346,8 @@ class TaskChainTests(unittest.TestCase):
         workflow.load()
 
         outputMods = outputModuleList(task)
+        ignoredOutputMods = task.getIgnoredOutputModulesForTask()
+        outputMods = set(outputMods) - set(ignoredOutputMods)
         self.assertEqual(len(workflow.outputMap.keys()), len(outputMods),
                          "Error: Wrong number of WF outputs")
 


### PR DESCRIPTION
Fixes #6395
It's needed for the resubmission workflows (rereco recoveries) where we set IgnoredOutputModules in the schema to avoid producing/staging some tiers. Without this patch, JobAccountant fails jobs since the expected outputmodules is != than the one returned in the Report.pkl.

I tested these changes on the agent side and seems to be working ok. I still want to test in a clean environment though
