### PR TITLE
Stop submission at pending threshold

### DIFF
--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -713,8 +713,7 @@ class JobSubmitterPoller(BaseWorkerThread):
                         breakLoop, exitLoop = True, True
 
                     # Deal with accounting
-                    if len(possibleSites) == 1:
-                        nJobsRequired -= 1
+                    nJobsRequired -= 1
                     totalPending  += 1
                     taskPending   += 1
 


### PR DESCRIPTION
Now that we mark all submitted jobs as pending at the site we're currently looping over, make sure we don't submit past the threshold.
