### PR TITLE
Make filesize BIGINT in MySQL

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/MySQL/Create.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/Create.py
@@ -83,7 +83,7 @@ class Create(DBCreator):
                  block_close_max_wait_time    INTEGER,
                  block_close_max_files        INTEGER,
                  block_close_max_events       INTEGER,
-                 block_close_max_size         INTEGER,
+                 block_close_max_size         BIGINT,
                  completed                    INTEGER       DEFAULT 0,
                  PRIMARY KEY (id),
                  CONSTRAINT uq_dbs_wor UNIQUE (name, task)
@@ -93,7 +93,7 @@ class Create(DBCreator):
             """CREATE TABLE dbsbuffer_file (
                  id                    INTEGER      AUTO_INCREMENT,
                  lfn                   VARCHAR(500) NOT NULL,
-                 filesize              INTEGER,
+                 filesize              BIGINT,
                  events                INTEGER,
                  dataset_algo          INTEGER      NOT NULL,
                  block_id              INTEGER,

--- a/test/python/WMComponent_t/DBS3Buffer_t/DBSBufferFile_t.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/DBSBufferFile_t.py
@@ -267,6 +267,27 @@ class DBSBufferFileTest(unittest.TestCase):
         testFileA.delete()
         return
 
+    def testFilesize(self):
+        """
+        _testFilesize_
+
+        Test storing and loading the file information from dbsbuffer_file.
+        Make sure filesize can be bigger than 32 bits
+        """
+        checksums = {"adler32": "adler32", "cksum": "cksum"}
+        testFileA = DBSBufferFile(lfn = "/this/is/a/lfn", size = 3221225472, events = 1500000,
+                                  checksums = checksums)
+        testFileA.setAlgorithm(appName = "cmsRun", appVer = "CMSSW_7_6_0",
+                               appFam = "RECO", psetHash = "GIBBERISH",
+                               configContent = "MOREGIBBERISH")
+        testFileA.setDatasetPath("/Cosmics/CRUZET09-PromptReco-v1/RECO")
+        testFileA.create()
+
+        testFileB = DBSBufferFile(lfn = testFileA["lfn"])
+        testFileB.load()
+        self.assertEqual(testFileB["size"], 3221225472, "Error: the filesize should be 3GB")
+        self.assertEqual(testFileB["events"], 1500000, "Error: the number of events should be 1.5M")
+
     def testAddChild(self):
         """
         _testAddChild_


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/6435 and changes need to be pushed to all new agents already deployed.

@ticoann ping me on gtalk when you see this PR please, I'll wait for your ack :)

PS.: I noticed we have also changed several columns (in oracle) from number(11) to integer. Integer - in oracle - is the same as number(38), which means the database space taken is increased and probably the performance is affected. Maybe we should set to integer only what we're sure of, otherwise keep the old and good working lengths.
