### PR TITLE
Allow JobSubmitter to go over max running limits in the case of

### DIFF
--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -564,13 +564,13 @@ class JobSubmitterPoller(BaseWorkerThread):
                 if state == 'Down':
                     continue
 
-                #If the number of running exceeded the running slots in the
-                #site then get out
-                if totalRunningSlots >= 0 and totalRunning >= totalRunningSlots:
-                    continue
-
-                #If the task is running more than allowed then get out
-                if maxSlots >= 0 and taskRunning >= maxSlots:
+                # If the task is running more than allowed then get out.
+                # As we have extensive site whitelists, we can't control the number of pending
+                # jobs per site - hence, we cannot actually control the number of running jobs per
+                # site.  Accordingly, we allow ourselves to ignore the running limits for what are
+                # considered CPU-intensive jobs.
+                if (taskType not in ["Production", "Processing"]) and (maxSlots >= 0) \
+                        and (taskRunning >= maxSlots):
                     continue
 
                 # Ignore this threshold if we've cleaned out the site


### PR DESCRIPTION
Production / Processing jobs.

This limit has not been effective for as long as we have had multi-site
whitelists.  However, it has been able to cause priority-inversions in
practice.

We keep the concept of a threshold for IO-intensive jobs and for
purposes of pulling work into the agent.

@amaltaro @ticoann - this corresponds to the thread I started on CompOps
@hufnagel - please think about how this might affect the T0.  That's less-familiar territory to me.
