### PR TITLE
Initial WMArchive REST service

### DIFF
--- a/src/python/WMCore/WMArchive/Service/Manager.py
+++ b/src/python/WMCore/WMArchive/Service/Manager.py
@@ -12,6 +12,9 @@ of WMArchive project, see
 https://twiki.cern.ch/twiki/bin/viewauth/CMS/WMArchive
 """
 
+# futures
+from __future__ import print_function, division
+
 # system modules
 import os
 import sys

--- a/src/python/WMCore/WMArchive/Service/Manager.py
+++ b/src/python/WMCore/WMArchive/Service/Manager.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+#pylint: disable=
+"""
+File       : Manager.py
+Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
+Description: WMArchiveManager class provides full functionality of
+             the WMArchive service.
+
+TODO: This class will be expanded/modified according to requirements
+of WMArchive project, see
+https://twiki.cern.ch/twiki/bin/viewauth/CMS/WMArchive
+"""
+
+# system modules
+import os
+import sys
+import time
+
+class WMArchiveManager(object):
+    def __init__(self, config=None):
+        """
+        Initialize WMArchive proxy server configuration. The given configuration
+        file will provide details of proxy server, agent information, etc.
+        """
+        self.config = config
+        self._version = "1.0.0"
+
+    def version(self):
+        return self._version
+
+    def encode(self, docs):
+        """
+        Encode given set of documents into appropriate format for long term storage.
+        This method will consume documents in DMWM JSON format.
+        Yield encoded documents to the client.
+        """
+        for doc in docs:
+            doc['ts'] = time.time()
+            # do more transformation
+            yield doc
+
+    def decode(self, docs):
+        """
+        Decode given set of documents into DMWM JSON format.
+        Yield decoded documents to the client.
+        """
+        for doc in docs:
+            yield doc
+
+    def get_ids(self, docs):
+        """
+        Extract ids from given set of documents
+        """
+        for doc in docs:
+            yield doc['uid']
+
+    def write(self, data, chunk_size=None):
+        """
+        Write given data chunk (list of WM documents) into proxy server.
+        The chunk_size default value will be determined by back-end throughput.
+        Return true or false of write operation.
+        """
+        if  isinstance(data, dict):
+            data = [data]
+        if  not isinstance(data, list):
+            raise Exception("WMArchiveManager::write, Invalid data format: %s" % type(data))
+#        ids = self.get_ids(data)
+#        docs = self.encode(data)
+        # write docs into back-end
+        # get doc-ids of written docs
+        return True
+
+    def read(self, query):
+        """
+        Send request to proxy server to read data for given query.
+        Yield list of found documents or None.
+        """
+        # request data from back-end
+
+    def ack(self, docIds):
+        """
+        Send acknowledgement request to proxy server for given set of ids.
+        Return true or false if data is present on back-end server.
+        """
+        # request confirmation about the data from ba

--- a/src/python/WMCore/WMArchive/Service/Methods.py
+++ b/src/python/WMCore/WMArchive/Service/Methods.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+#pylint: disable=
+"""
+File       : Methods.py
+Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
+Description: This module consists of all REST APIs required by WMArchive service
+             Every API is designed as a class with appropriate get/post/put/delete
+             methods, see RESTEntity class for more details.
+"""
+
+# system modules
+import re
+import json
+import cherrypy
+
+# WMCore modules
+import WMCore
+from WMCore.REST.Server import RESTEntity, restcall, rows
+from WMCore.REST.Tools import tools
+from WMCore.REST.Validation import validate_str
+from WMCore.REST.Format import JSONFormat
+
+# WMArchive modules
+from WMCore.WMArchive.Service.Manager import WMArchiveManager
+
+# global regexp
+PAT_EXAMPLE = re.compile(r"^[a-zA-Z]$")
+
+class WMAInfo(RESTEntity):
+    def __init__(self, app, api, config, mount):
+        RESTEntity.__init__(self, app, api, config, mount)
+        self.config = config
+        self.config = config
+        self.mgr = WMArchiveManager(config)
+                
+    def validate(self, apiobj, method, api, param, safe):
+        "Validate user input"
+        if  not param.args or not param.kwargs:
+            return False # this class does not need any parameters
+        return True
+
+    @restcall
+    @tools.expires(secs=-1)
+    def get(self):
+        wmcore_reqmgr_version = WMCore.__version__
+        result = {"WMArchive version": self.mgr.version()}
+        return rows([result])
+
+class WMAGet(RESTEntity):
+    def __init__(self, app, api, config, mount):
+        RESTEntity.__init__(self, app, api, config, mount)
+        self.config = config
+        self.mgr = WMArchiveManager(config)
+    
+    def validate(self, apiobj, method, api, param, safe):
+        """
+        Validate request input data.
+        Has to be implemented, otherwise the service fails to start.
+        If it's not implemented correctly (e.g. just pass), the arguments
+        are not passed in the method at all.
+        
+        """
+        print "VALIDATE", param
+        # here we implement what should be validated
+        validate_str("query", param, safe, PAT_EXAMPLE, optional=True)
+
+    @restcall(formats = [('application/json', JSONFormat())])
+    @tools.expires(secs=-1)
+    def get(self, query):
+        "GET request with given query, all the work is done by WMArchiveManager"
+        docs = self.mgr.read(query)
+        return docs
+
+class WMAPost(RESTEntity):
+    def __init__(self, app, api, config, mount):
+        RESTEntity.__init__(self, app, api, config, mount)
+        self.config = config
+        self.mgr = WMArchiveManager(config)
+
+    def validate(self, apiobj, method, api, param, safe):
+        "Validate user input"
+        if  not param.args or not param.kwargs:
+            return False # this class does not need any parameters
+        return True
+
+    @restcall(formats = [('application/json', JSONFormat())])
+    @tools.expires(secs=-1)
+    def post(self):
+        "POST request with given data, all the work is done by WMArchiveManager"
+        data = {}
+        try :
+            data = json.load(cherrypy.request.body)
+            status = self.mgr.write(data)
+        except Exception as exp:
+            raise cherrypy.HTTPError(str(exp))

--- a/src/python/WMCore/WMArchive/Service/Methods.py
+++ b/src/python/WMCore/WMArchive/Service/Methods.py
@@ -8,6 +8,8 @@ Description: This module consists of all REST APIs required by WMArchive service
              Every API is designed as a class with appropriate get/post/put/delete
              methods, see RESTEntity class for more details.
 """
+# futures
+from __future__ import print_function, division
 
 # system modules
 import re
@@ -61,7 +63,6 @@ class WMAGet(RESTEntity):
         are not passed in the method at all.
         
         """
-        print "VALIDATE", param
         # here we implement what should be validated
         validate_str("query", param, safe, PAT_EXAMPLE, optional=True)
 

--- a/src/python/WMCore/WMArchive/Service/RestApiHub.py
+++ b/src/python/WMCore/WMArchive/Service/RestApiHub.py
@@ -1,0 +1,34 @@
+"""
+Module defines REST API methods and their handles.
+Implementation of handles is in corresponding modules, not here.
+
+"""
+
+import cherrypy
+
+from WMCore.Configuration import Configuration
+from WMCore.REST.Server import RESTApi
+from WMCore.REST.Format import RawFormat
+
+from WMCore.WMArchive.Service.Methods import WMAInfo, WMAPost, WMAGet
+
+class RestApiHub(RESTApi):
+    """
+    Server object for REST data access API.
+    """
+    def __init__(self, app, config, mount):
+        """
+        :arg app: reference to application object; passed to all entities.
+        :arg config: reference to configuration; passed to all entities.
+        :arg str mount: API URL mount point; passed to all entities."""
+        
+        RESTApi.__init__(self, app, config, mount)
+        
+        cherrypy.log("WMArchive entire configuration:\n%s" % Configuration.getInstance())    
+        cherrypy.log("WMArchive REST hub configuration subset:\n%s" % config)
+        
+        self._add({
+            "info": WMAInfo(app, self, config, mount),
+            "write": WMAPost(app, self, config, mount),
+            "fetch": WMAGet(app, self, config, mount),
+                  })

--- a/src/python/WMCore/WMArchive/Service/RestApiHub.py
+++ b/src/python/WMCore/WMArchive/Service/RestApiHub.py
@@ -1,15 +1,22 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+#pylint: disable=
 """
-Module defines REST API methods and their handles.
-Implementation of handles is in corresponding modules, not here.
-
+File       : RestApiHub.py
+Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
+Description: REST API module for WMARchive
 """
 
+# futures
+from __future__ import print_function, division
+
+# cherrypy modules
 import cherrypy
 
+# WMCore modules
 from WMCore.Configuration import Configuration
 from WMCore.REST.Server import RESTApi
 from WMCore.REST.Format import RawFormat
-
 from WMCore.WMArchive.Service.Methods import WMAInfo, WMAPost, WMAGet
 
 class RestApiHub(RESTApi):

--- a/src/python/WMCore/WMArchive/Service/__init__.py
+++ b/src/python/WMCore/WMArchive/Service/__init__.py
@@ -1,0 +1,2 @@
+# futures
+from __future__ import print_function, division

--- a/src/python/WMCore/WMArchive/Web/WMArchiveService.py
+++ b/src/python/WMCore/WMArchive/Web/WMArchiveService.py
@@ -4,8 +4,8 @@
 """
 web server.
 """
-
-__author__ = "Valentin Kuznetsov"
+# futures
+from __future__ import print_function, division
 
 # system modules
 import os

--- a/src/python/WMCore/WMArchive/Web/WMArchiveService.py
+++ b/src/python/WMCore/WMArchive/Web/WMArchiveService.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+#-*- coding: ISO-8859-1 -*-
+
+"""
+web server.
+"""
+
+__author__ = "Valentin Kuznetsov"
+
+# system modules
+import os
+import sys
+import time
+import json
+
+# cherrypy modules
+from cherrypy import tools
+from cherrypy import config as cherryconf
+
+# WMCore modules
+from WMCore.REST.Main import RESTMain
+
+class WMArchiveService(object):
+    """
+    WMArchive web service class
+    """
+    def __init__(self, app, config, mount):
+        # Update CherryPy configuration
+        mime_types  = ['text/css']
+        mime_types += ['application/javascript', 'text/javascript',
+                       'application/x-javascript', 'text/x-javascript']
+        cherryconf.update({'tools.encode.on': True,
+                           'tools.gzip.on': True,
+                           'tools.gzip.mime_types': mime_types,
+                          })
+
+        # initialize rest API
+        statedir = '/tmp'
+        app = RESTMain(config, statedir) # REST application
+        mount = '/rest' # mount point for cherrypy service
+        api = RestApiHub(app, config.mgr, mount)

--- a/src/python/WMCore/WMArchive/Web/__init__.py
+++ b/src/python/WMCore/WMArchive/Web/__init__.py
@@ -1,0 +1,2 @@
+# futures
+from __future__ import print_function, division

--- a/src/python/WMCore/WMArchive/__init__.py
+++ b/src/python/WMCore/WMArchive/__init__.py
@@ -1,0 +1,2 @@
+# futures
+from __future__ import print_function, division


### PR DESCRIPTION
Please take initial implementation of WMArchive REST service (proxy server). Here is its configuration file:

```
import socket
from WMCore.Configuration import Configuration
from os import path

HOST = socket.gethostname().lower()
ROOTDIR = __file__.rsplit('/', 3)[0]
config = Configuration()

main = config.section_("main")
srv = main.section_("server")
srv.thread_pool = 30
main.application = "wmarchive"
main.port = 8246 # main application port it listens on
#main.index = "ui"
main.index = "data"
# Defaults to allow any CMS authenticated user. Write APIs should require
# additional roles in SiteDB (i.e. "Admin" role for the "ReqMgr" group)
#main.authz_defaults = {"role": None, "group": None, "site": None}

#sec = main.section_("tools").section_("cms_auth")
#sec.key_file = "%s/auth/wmcore-auth/header-auth-key" % ROOTDIR
#sec.key_file = "/Users/vk/CMS/DMWM/GIT/WMCore/auth-key"

# this is where the application will be mounted, where the REST API
# is reachable and this features in CMS web frontend rewrite rules
app = config.section_(main.application) # string containing "reqmgr2"
app.admin = "cms-service-webtools@cern.ch"
app.description = "CMS data operations WMArchive."
app.title = "CMS Request Manager (WMArchive)"

views = config.section_("views")

# practical to have this kind of configuration values not in
# service related RPM (difficult/impossible to change in CMS web
# deployment) but in the deployment configuration for the service

# redirector for the REST API implemented handlers
data = views.section_("data")
data.object = "WMCore.WMArchive.Service.RestApiHub.RestApiHub"
```

and (assuming all environment is set) it can be run as following:

```
wmc-httpd -r -d /tmp -l wma.log ./wmarch_config.py
```
