### PR TITLE
Fix DatabasePage class to load even without database configuration

### DIFF
--- a/src/python/WMCore/WebTools/DatabasePage.py
+++ b/src/python/WMCore/WebTools/DatabasePage.py
@@ -43,10 +43,13 @@ class DatabasePage(TemplatedPage, DBFormatter):
         exposed that passes the database connection to all the DAO's.
         """
         TemplatedPage.__init__(self, config)
-        dbConfig = ConfigDBMap(config)
-        conn = DBFactory(self, dbConfig.getDBUrl(), dbConfig.getOption()).connect()
-        DBFormatter.__init__(self, self, conn)
-        myThread = threading.currentThread()
-        myThread.transaction = Transaction(conn)
-        myThread.transaction.commit()
+        try:
+            dbConfig = ConfigDBMap(config)
+            conn = DBFactory(self, dbConfig.getDBUrl(), dbConfig.getOption()).connect()
+            DBFormatter.__init__(self, self, conn)
+            myThread = threading.currentThread()
+            myThread.transaction = Transaction(conn)
+            myThread.transaction.commit()
+        except:
+            pass
         return

--- a/src/python/WMCore/WebTools/DatabasePage.py
+++ b/src/python/WMCore/WebTools/DatabasePage.py
@@ -45,11 +45,12 @@ class DatabasePage(TemplatedPage, DBFormatter):
         TemplatedPage.__init__(self, config)
         try:
             dbConfig = ConfigDBMap(config)
+        except AssertionError as ex:
+            print("WARNING: unable to load database configuration from config file, %s" % str(ex))
+        else:
             conn = DBFactory(self, dbConfig.getDBUrl(), dbConfig.getOption()).connect()
             DBFormatter.__init__(self, self, conn)
             myThread = threading.currentThread()
             myThread.transaction = Transaction(conn)
             myThread.transaction.commit()
-        except:
-            pass
         return


### PR DESCRIPTION
This is required for classes which do not need database, i.e. doesn't have database in configuration. For instance, if my class want to implement RESTApi, WebApi but does not need or implement database access, the current system enfornce through inheritance the database parameter presense in configuration file. Otherwise it does not load WebApi class which inherits from DatabasePage. I put DatabasePage config loading in try/except block to allow higher classes to load configuration even without database parameter.
