### PR TITLE
Fix RESTError method name to show actual error

### DIFF
--- a/src/python/WMCore/REST/Error.py
+++ b/src/python/WMCore/REST/Error.py
@@ -67,7 +67,7 @@ class RESTError(Exception):
         self.info = info
         self.trace = trace
 
-    def __repr__(self):
+    def __str__(self):
         return "%s %s [HTTP %d, APP %d, MSG %s, INFO %s, ERR %s]" \
           % (self.__class__.__name__, self.errid, self.http_code, self.app_code,
              repr(self.message).replace("\n", " ~~ "),


### PR DESCRIPTION
When exception is thrown in REST server is always confusing and misleading, e.g.

```
[08/Dec/2015:13:02:27]  SERVER REST ERROR WMCore.REST.Error.InvalidParameter e12492dc0b4efc857a5578c15c308b22 (Invalid input parameter)
[08/Dec/2015:13:02:27]    Traceback (most recent call last):
[08/Dec/2015:13:02:27]      File "/Users/vk/CMS/DMWM/GIT/WMCore/src/python/WMCore/REST/Server.py", line 697, in default
[08/Dec/2015:13:02:27]        return self._call(RESTArgs(list(args), kwargs))
[08/Dec/2015:13:02:27]      File "/Users/vk/CMS/DMWM/GIT/WMCore/src/python/WMCore/REST/Server.py", line 768, in _call
[08/Dec/2015:13:02:27]        v(apiobj, request.method, api, param, safe)
[08/Dec/2015:13:02:27]      File "/Users/vk/CMS/DMWM/GIT/WMCore/src/python/WMCore/WMArchive/Service/Methods.py", line 66, in validate
[08/Dec/2015:13:02:27]        validate_str("query", param, safe, PAT_EXAMPLE, optional=True)
[08/Dec/2015:13:02:27]      File "/Users/vk/CMS/DMWM/GIT/WMCore/src/python/WMCore/REST/Validation.py", line 122, in validate_str
[08/Dec/2015:13:02:27]        _validate_one(argname, param, safe, _check_str, optional, rx, custom_err)
[08/Dec/2015:13:02:27]      File "/Users/vk/CMS/DMWM/GIT/WMCore/src/python/WMCore/REST/Validation.py", line 85, in _validate_one
[08/Dec/2015:13:02:27]        safe.kwargs[argname] = checker(argname, val, *args)
[08/Dec/2015:13:02:27]      File "/Users/vk/CMS/DMWM/GIT/WMCore/src/python/WMCore/REST/Validation.py", line 39, in _check_str
[08/Dec/2015:13:02:27]        raise InvalidParameter(return_message("Incorrect '%s' parameter" % argname, custom_err))
[08/Dec/2015:13:02:27]    InvalidParameter
```

the problem is that we mis-use method name in RESTError class which prevent class to show actual error, e.g. we must use **str** instead of **repr**. With this fix the aforementioned error will be printed as following:

```
[08/Dec/2015:13:11:14]  SERVER REST ERROR WMCore.REST.Error.InvalidParameter e80fd45ab299e685ee4116abd6289f7e (Invalid input parameter)
[08/Dec/2015:13:11:14]    Traceback (most recent call last):
[08/Dec/2015:13:11:14]      File "/Users/vk/CMS/DMWM/GIT/WMCore/src/python/WMCore/REST/Server.py", line 697, in default
[08/Dec/2015:13:11:14]        return self._call(RESTArgs(list(args), kwargs))
[08/Dec/2015:13:11:14]      File "/Users/vk/CMS/DMWM/GIT/WMCore/src/python/WMCore/REST/Server.py", line 768, in _call
[08/Dec/2015:13:11:14]        v(apiobj, request.method, api, param, safe)
[08/Dec/2015:13:11:14]      File "/Users/vk/CMS/DMWM/GIT/WMCore/src/python/WMCore/WMArchive/Service/Methods.py", line 66, in validate
[08/Dec/2015:13:11:14]        validate_str("query", param, safe, PAT_EXAMPLE, optional=True)
[08/Dec/2015:13:11:14]      File "/Users/vk/CMS/DMWM/GIT/WMCore/src/python/WMCore/REST/Validation.py", line 121, in validate_str
[08/Dec/2015:13:11:14]        _validate_one(argname, param, safe, _check_str, optional, rx, custom_err)
[08/Dec/2015:13:11:14]      File "/Users/vk/CMS/DMWM/GIT/WMCore/src/python/WMCore/REST/Validation.py", line 84, in _validate_one
[08/Dec/2015:13:11:14]        safe.kwargs[argname] = checker(argname, val, *args)
[08/Dec/2015:13:11:14]      File "/Users/vk/CMS/DMWM/GIT/WMCore/src/python/WMCore/REST/Validation.py", line 38, in _check_str
[08/Dec/2015:13:11:14]        raise InvalidParameter(return_message("Incorrect '%s' parameter" % argname, custom_err))
[08/Dec/2015:13:11:14]    InvalidParameter: InvalidParameter e80fd45ab299e685ee4116abd6289f7e [HTTP 400, APP 302, MSG 'Invalid input parameter', INFO "Incorrect 'query' parameter", ERR None]
```

As you can see the difference comes in last line, where now we will have full message about the error, instead of classname who thrown exception.
