### PR TITLE
Improve listFileArray usage; query by block+lumi instead of dataset+lumi

### DIFF
--- a/src/python/WMCore/WorkQueue/Policy/Start/Block.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Block.py
@@ -215,15 +215,18 @@ class Block(StartPolicyInterface):
         lumiMask = task.getLumiMask()
         taskMask = LumiList(compactList = lumiMask)
 
+        # for performance reasons, we first get all the blocknames
+        blocks = dbs.dbs.listBlocks(dataset=datasetPath)
+
         # Find all the files that have runs and lumis we are interested in,
         # fill block lfn part of maskedBlocks
-
         for run, lumis in lumiMask.items():
             files = []
-            for slumis in Lexicon.slicedIterator(lumis, 50):
-                slicedFiles = dbs.dbs.listFileArray(dataset=datasetPath, run_num=run,
-                                       lumi_list=slumis, detail=True)
-                files.extend(slicedFiles)
+            for slumis in Lexicon.slicedIterator(lumis, 1000):
+                for block in blocks:
+                    slicedFiles = dbs.dbs.listFileArray(block_name=block.get('block_name'), run_num=run,
+                                                        lumi_list=slumis, detail=True)
+                    files.extend(slicedFiles)
             for lfn in files:
                 blockName = lfn['block_name']
                 fileName = lfn['logical_file_name']
@@ -233,7 +236,6 @@ class Block(StartPolicyInterface):
                     maskedBlocks[blockName][fileName] = LumiList()
 
         # Fill maskedLumis part of maskedBlocks
-
         for block in maskedBlocks:
             fileLumis = dbs.dbs.listFileLumis(block_name=block, validFileOnly = 1)
             for fileLumi in fileLumis:


### PR DESCRIPTION
Fixes (or partially) https://github.com/dmwm/DBS/issues/505 , at least from the WMCore side.

As previously discussed, querying for dataset + run + lumi_list is a full table scan and very expensive, which quite often times out (5min).

Changing it to, first we get a list of blocknames and then we query for block+run+lumi_list, which is much faster.

The slicing in WMCore seems to be still needed, if we query for 20k lumis (and block), it takes almost 5min sometimes. However, I increased the slicing to 1000 lumis, should be better than 50.

@ticoann DO NOT MERGE yet please. I ran only 1 interactive test and it seems fine, but better test it for real specially if we want Diego to patch/push it to WorkQueue production this week.

@ticoann @yuyiguo please review.
