### PR TITLE
Split job work for JobArchiver

### DIFF
--- a/src/python/WMComponent/JobArchiver/JobArchiverPoller.py
+++ b/src/python/WMComponent/JobArchiver/JobArchiverPoller.py
@@ -1,35 +1,29 @@
 #!/usr/bin/env python
-#pylint: disable=W6501
-# W6501: pass information to logging using string arguments
 """
 The actual jobArchiver algorithm
 """
 __all__ = []
 
-
-
 import threading
-import json
 import logging
 import os
 import os.path
 import shutil
 import tarfile
 import traceback
-import time
 
 from WMComponent.TaskArchiver.TaskArchiverPoller import uploadPublishWorkflow
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
-from WMCore.JobStateMachine.ChangeState    import ChangeState
+from WMCore.JobStateMachine.ChangeState import ChangeState
 
 from WMCore.WorkQueue.WorkQueueExceptions import WorkQueueNoMatchingElements
 
-from WMCore.WMBS.Job          import Job
-from WMCore.DAOFactory        import DAOFactory
-from WMCore.WMBS.Fileset      import Fileset
-from WMCore.WMException       import WMException
-from WMCore.WMBS.Workflow     import Workflow
-from WMCore                   import Lexicon
+from WMCore.WMBS.Job import Job
+from WMCore.DAOFactory import DAOFactory
+from WMCore.WMBS.Fileset import Fileset
+from WMCore.WMException import WMException
+from WMCore.WMBS.Workflow import Workflow
+from WMCore import Lexicon
 
 
 class JobArchiverPollerException(WMException):
@@ -39,23 +33,25 @@ class JobArchiverPollerException(WMException):
     The Exception handler for the job archiver.
     """
 
+
 class JobArchiverPoller(BaseWorkerThread):
     """
     Polls for Error Conditions, handles them
     """
+
     def __init__(self, config):
         """
         Initialise class members
         """
         BaseWorkerThread.__init__(self)
-        self.config      = config
+        self.config = config
         self.changeState = ChangeState(self.config)
 
-        myThread        = threading.currentThread()
-        self.daoFactory = DAOFactory(package = "WMCore.WMBS",
-                                     logger = myThread.logger,
-                                     dbinterface = myThread.dbi)
-        self.loadAction = self.daoFactory(classname = "Jobs.LoadFromIDWithWorkflow")
+        myThread = threading.currentThread()
+        self.daoFactory = DAOFactory(package="WMCore.WMBS",
+                                     logger=myThread.logger,
+                                     dbinterface=myThread.dbi)
+        self.loadAction = self.daoFactory(classname="Jobs.LoadFromIDWithWorkflow")
 
 
         # Variables
@@ -63,11 +59,11 @@ class JobArchiverPoller(BaseWorkerThread):
                                              "numberOfJobsToCluster", 1000)
 
         # initialize the alert framework (if available)
-        self.initAlerts(compName = "JobArchiver")
+        self.initAlerts(compName="JobArchiver")
 
         try:
             self.uploadPublishDir = getattr(self.config.JobArchiver, 'uploadPublishDir',
-                                  os.path.join(config.JobArchiver.componentDir, 'publishDir'))
+                                            os.path.join(config.JobArchiver.componentDir, 'publishDir'))
             self.logDir = getattr(config.JobArchiver, 'logDir',
                                   os.path.join(config.JobArchiver.componentDir, 'logDir'))
             if not os.path.isdir(self.logDir):
@@ -75,13 +71,13 @@ class JobArchiverPoller(BaseWorkerThread):
             if not os.path.isdir(self.uploadPublishDir):
                 os.makedirs(self.uploadPublishDir)
         except Exception as ex:
-            msg =  "Unhandled exception while setting up logDir and/or uploadPublishDir!\n"
+            msg = "Unhandled exception while setting up logDir and/or uploadPublishDir!\n"
             msg += str(ex)
             logging.error(msg)
-            self.sendAlert(6, msg = msg)
+            self.sendAlert(6, msg=msg)
             try:
-                logging.debug("Directory: %s" % self.logDir)
-                logging.debug("Config: %s" % config)
+                logging.debug("Directory: %s", self.logDir)
+                logging.debug("Config: %s", config)
             except:
                 pass
             raise JobArchiverPollerException(msg)
@@ -90,10 +86,10 @@ class JobArchiverPoller(BaseWorkerThread):
             from WMCore.WorkQueue.WorkQueueUtils import queueFromConfig
             self.workQueue = queueFromConfig(self.config)
         except Exception as ex:
-            msg =  "Could not load workQueue"
+            msg = "Could not load workQueue"
             msg += str(ex)
             logging.error(msg)
-            #raise JobArchiverPollerException(msg)
+            # raise JobArchiverPollerException(msg)
 
         self.uploadPublishInfo = getattr(self.config.JobArchiver, 'uploadPublishInfo', False)
         self.userFileCacheURL = getattr(self.config.JobArchiver, 'userFileCacheURL', None)
@@ -102,14 +98,11 @@ class JobArchiverPoller(BaseWorkerThread):
 
         return
 
-
-
     def setup(self, parameters):
         """
         Load DB objects required for queries
         """
         return
-
 
     def terminate(self, params):
         """
@@ -121,8 +114,7 @@ class JobArchiverPoller(BaseWorkerThread):
         self.algorithm(params)
         return
 
-
-    def algorithm(self, parameters = None):
+    def algorithm(self, parameters=None):
         """
         Performs the archiveJobs method, looking for each type of failure
         And deal with it as desired.
@@ -133,8 +125,8 @@ class JobArchiverPoller(BaseWorkerThread):
             self.markInjected()
         except WMException:
             myThread = threading.currentThread()
-            if getattr(myThread, 'transaction', None) != None\
-                   and getattr(myThread.transaction, 'transaction', None) != None:
+            if getattr(myThread, 'transaction', None) != None \
+                    and getattr(myThread.transaction, 'transaction', None) != None:
                 myThread.transaction.rollback()
             raise
         except Exception as ex:
@@ -142,13 +134,12 @@ class JobArchiverPoller(BaseWorkerThread):
             msg = "Caught exception in JobArchiver\n"
             msg += str(ex)
             msg += "\n\n"
-            if getattr(myThread, 'transaction', None) != None\
-                   and getattr(myThread.transaction, 'transaction', None) != None:
+            if getattr(myThread, 'transaction', None) != None \
+                    and getattr(myThread.transaction, 'transaction', None) != None:
                 myThread.transaction.rollback()
             raise JobArchiverPollerException(msg)
 
         return
-
 
     def archiveJobs(self):
         """
@@ -157,16 +148,16 @@ class JobArchiverPoller(BaseWorkerThread):
         archiveJobs will handle the master task of looking for finished jobs,
         and running the code that cleans them out.
         """
-        doneList  = self.findFinishedJobs()
-        logging.info("Found %i finished jobs to archive" % len(doneList))
+        doneList = self.findFinishedJobs()
+        logging.info("Found %i finished jobs to archive", len(doneList))
 
         jobCounter = 0
         for slicedList in Lexicon.slicedIterator(doneList, 10000):
             self.cleanWorkArea(slicedList)
 
             successList = []
-            failList    = []
-            killList    = []
+            failList = []
+            killList = []
             for job in slicedList:
                 if job["outcome"] == "success":
                     successList.append(job)
@@ -188,7 +179,6 @@ class JobArchiverPoller(BaseWorkerThread):
             jobCounter += len(slicedList)
             logging.info("Successfully archived %d jobs out of %d.", jobCounter, len(doneList))
 
-
     def findFinishedJobs(self):
         """
         _findFinishedJobs_
@@ -197,10 +187,10 @@ class JobArchiverPoller(BaseWorkerThread):
         """
         jobList = []
 
-        jobListAction = self.daoFactory(classname = "Jobs.GetAllJobs")
-        jobList1 = jobListAction.execute(state = "success")
-        jobList2 = jobListAction.execute(state = "exhausted")
-        jobList3 = jobListAction.execute(state = "killed")
+        jobListAction = self.daoFactory(classname="Jobs.GetAllJobs")
+        jobList1 = jobListAction.execute(state="success")
+        jobList2 = jobListAction.execute(state="exhausted")
+        jobList3 = jobListAction.execute(state="killed")
 
         jobList.extend(jobList1)
         jobList.extend(jobList2)
@@ -215,23 +205,20 @@ class JobArchiverPoller(BaseWorkerThread):
         for jobID in jobList:
             binds.append({"jobid": jobID})
 
+        results = self.loadAction.execute(jobID=binds)
 
-        results = self.loadAction.execute(jobID = binds)
-
-        if not type(results) == list:
+        if not isinstance(results, list):
             results = [results]
 
         doneList = []
 
         for entry in results:
             # One job per entry
-            tmpJob = Job(id = entry['id'])
+            tmpJob = Job(id=entry['id'])
             tmpJob.update(entry)
             doneList.append(tmpJob)
 
-
         return doneList
-
 
     def cleanWorkArea(self, doneList):
         """
@@ -242,7 +229,7 @@ class JobArchiverPoller(BaseWorkerThread):
         """
 
         for job in doneList:
-            #print "About to clean cache for job %i" % (job['id'])
+            # print "About to clean cache for job %i" % (job['id'])
             self.cleanJobCache(job)
 
         return
@@ -260,7 +247,7 @@ class JobArchiverPoller(BaseWorkerThread):
         if not cacheDir or not os.path.isdir(cacheDir):
             msg = "Could not find jobCacheDir %s" % (cacheDir)
             logging.error(msg)
-            self.sendAlert(1, msg = msg)
+            self.sendAlert(1, msg=msg)
             return
 
         cacheDirList = os.listdir(cacheDir)
@@ -273,56 +260,55 @@ class JobArchiverPoller(BaseWorkerThread):
         try:
             # Label all directories by workflow
             # Workflow better have a first character
-            workflow       = job['workflow']
+            workflow = job['workflow']
             firstCharacter = workflow[0]
             jobFolder = 'JobCluster_%i' \
-                        % (int(job['id']/self.numberOfJobsToCluster))
-            logDir =  os.path.join(self.logDir, firstCharacter,
-                                   workflow, jobFolder)
+                        % (int(job['id'] / self.numberOfJobsToCluster))
+            logDir = os.path.join(self.logDir, firstCharacter,
+                                  workflow, jobFolder)
             if not os.path.exists(logDir):
                 os.makedirs(logDir)
         except Exception as ex:
-            msg =  "Exception while trying to make output logDir\n"
+            msg = "Exception while trying to make output logDir\n"
             msg += str("logDir: %s\n" % (logDir))
             msg += str(ex)
             logging.error(msg)
-            self.sendAlert(6, msg = msg)
+            self.sendAlert(6, msg=msg)
             raise JobArchiverPollerException(msg)
 
         # Otherwise we have something in there
         try:
             tarName = 'Job_%i.tar.bz2' % (job['id'])
-            tarball = tarfile.open(name = os.path.join(logDir, tarName),
-                                   mode = 'w:bz2')
+            tarball = tarfile.open(name=os.path.join(logDir, tarName),
+                                   mode='w:bz2')
             for fileName in cacheDirList:
                 fullFile = os.path.join(cacheDir, fileName)
                 try:
-                    tarball.add(name = fullFile,
-                                arcname = 'Job_%i/%s' %(job['id'], fileName))
+                    tarball.add(name=fullFile,
+                                arcname='Job_%i/%s' % (job['id'], fileName))
                 except IOError:
-                    logging.error('Cannot read %s, skipping' % fullFile)
+                    logging.error('Cannot read %s, skipping', fullFile)
             tarball.close()
         except Exception as ex:
-            msg =  "Exception while opening and adding to a tarfile\n"
+            msg = "Exception while opening and adding to a tarfile\n"
             msg += "Tarfile: %s\n" % os.path.join(logDir, tarName)
             msg += str(ex)
             logging.error(msg)
-            self.sendAlert(6, msg = msg)
-            logging.debug("cacheDirList: %s" % (cacheDirList))
+            self.sendAlert(6, msg=msg)
+            logging.debug("cacheDirList: %s", cacheDirList)
             raise JobArchiverPollerException(msg)
 
         try:
             shutil.rmtree('%s' % (cacheDir), ignore_errors=True)
         except Exception as ex:
-            msg =  "Error while removing the old cache dir.\n"
+            msg = "Error while removing the old cache dir.\n"
             msg += "CacheDir: %s\n" % cacheDir
             msg += str(ex)
             logging.error(msg)
-            self.sendAlert(6, msg = msg)
+            self.sendAlert(6, msg=msg)
             raise JobArchiverPollerException(msg)
 
         return
-
 
     def markInjected(self):
         """
@@ -336,27 +322,27 @@ class JobArchiverPoller(BaseWorkerThread):
             return
 
         myThread = threading.currentThread()
-        getAction  = self.daoFactory(classname = "Workflow.GetInjectedWorkflows")
-        markAction = self.daoFactory(classname = "Workflow.MarkInjectedWorkflows")
+        getAction = self.daoFactory(classname="Workflow.GetInjectedWorkflows")
+        markAction = self.daoFactory(classname="Workflow.MarkInjectedWorkflows")
         result = getAction.execute()
 
         # Check each result to see if it is injected:
         injected = []
         for name in result:
             try:
-                if self.workQueue.getWMBSInjectionStatus(workflowName = name):
+                if self.workQueue.getWMBSInjectionStatus(workflowName=name):
                     injected.append(name)
             except WorkQueueNoMatchingElements:
                 # workflow not known - free to cleanup
                 injected.append(name)
             except Exception as ex:
-                logging.error("Injection status checking failed, investigate: %s" % str(ex))
-                logging.debug("Traceback: %s" % traceback.format_exc())
+                logging.error("Injection status checking failed, investigate: %s", str(ex))
+                logging.debug("Traceback: %s", traceback.format_exc())
 
         # Now, mark as injected those that returned True
         if len(injected) > 0:
             myThread.transaction.begin()
-            markAction.execute(names = injected, injected = True)
+            markAction.execute(names=injected, injected=True)
             myThread.transaction.commit()
         return
 
@@ -369,14 +355,14 @@ class JobArchiverPoller(BaseWorkerThread):
         myThread = threading.currentThread()
         myThread.transaction.begin()
 
-        closableFilesetDAO = self.daoFactory(classname = "Fileset.ListClosable")
+        closableFilesetDAO = self.daoFactory(classname="Fileset.ListClosable")
         closableFilesets = closableFilesetDAO.execute()
 
         for closableFileset in closableFilesets:
-            openFileset = Fileset(id = closableFileset)
+            openFileset = Fileset(id=closableFileset)
             openFileset.load()
 
-            logging.debug("Closing fileset %s" % openFileset.name)
+            logging.debug("Closing fileset %s", openFileset.name)
             openFileset.markOpen(False)
 
         myThread.transaction.commit()
@@ -392,7 +378,7 @@ class JobArchiverPoller(BaseWorkerThread):
             try:
                 uploadPublishWorkflow(self.config, wf, ufcEndpoint=self.userFileCacheURL, workDir=self.uploadPublishDir)
             except Exception as ex:
-                logging.error('Upload failed for workflow, task: %s, %s' % (workflow, task))
+                logging.error('Upload failed for workflow, task: %s, %s', workflow, task)
                 logging.error(str(ex))
 
         return


### PR DESCRIPTION
fixes #6449
As reported by Brian here
https://cms-logbook.cern.ch/elog/Workflow+processing/22541

we can split the job state change in JobArchiver, especially for cases where a super big workflow is aborted and the component has to go through lots of jobs.

@ticoann please review, still needs to be tested in testbed.
