### PR TITLE
Add threadid to logfile.

### DIFF
--- a/src/python/WMCore/Agent/Harness.py
+++ b/src/python/WMCore/Agent/Harness.py
@@ -136,7 +136,7 @@ class Harness:
             logHandler = RotatingFileHandler(compSect.logFile,
                 "a", 1000000000, 3)
             logMsgFormat = getattr(compSect, "logMsgFormat", \
-                           "%(asctime)s:%(levelname)s:%(module)s:%(message)s")
+                           "%(asctime)s:%(thread)d:%(levelname)s:%(module)s:%(message)s")
             logFormatter = \
                 logging.Formatter(logMsgFormat)
             logHandler.setFormatter(logFormatter)


### PR DESCRIPTION
Without this information, it's fairly difficult to debug multithreaded
daemons (especially if multiple threads invoke the same function).
