### PR TITLE
First draft at tracking blow-up factor.

### DIFF
--- a/src/python/WMCore/WorkQueue/Policy/Start/MonteCarlo.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/MonteCarlo.py
@@ -71,7 +71,7 @@ class MonteCarlo(StartPolicyInterface):
                                  NumberOfEvents = nEvents,
                                  Jobs = jobs,
                                  Mask = copy(mask),
-                                 BlowupFactor = self.args['BlowupFactor']))
+                                 BlowupFactor = self.args['BlowupFactor'])
 
 
             if mask['LastEvent'] > (2**32 - 1):

--- a/src/python/WMCore/WorkQueue/Policy/Start/MonteCarlo.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/MonteCarlo.py
@@ -28,6 +28,8 @@ class MonteCarlo(StartPolicyInterface):
         self.args.setdefault('SubSliceType', 'NumberOfEventsPerLumi')
         self.args.setdefault('SubSliceSize', self.args['SliceSize']) # events per lumi
         self.args.setdefault('MaxJobsPerElement', 250)  # jobs per WQE
+        self.args.setdefault('BlowupFactor', 0.0) # Estimate of additional jobs following tasks.
+                                                  # Total WQE tasks will be Jobs*(1+BlowupFactor)
 
         if not self.mask:
             self.mask = Mask(FirstRun = 1,
@@ -68,7 +70,9 @@ class MonteCarlo(StartPolicyInterface):
                                  NumberOfLumis = nLumis,
                                  NumberOfEvents = nEvents,
                                  Jobs = jobs,
-                                 Mask = copy(mask))
+                                 Mask = copy(mask),
+                                 BlowupFactor = self.args['BlowupFactor']))
+
 
             if mask['LastEvent'] > (2**32 - 1):
                 #This is getting tricky, to ensure consecutive

--- a/src/python/WMCore/WorkQueue/WorkQueueBackend.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueBackend.py
@@ -385,7 +385,7 @@ class WorkQueueBackend(object):
                 elements.append(element)
                 if site not in siteJobCounts:
                     siteJobCounts[site] = {}
-                siteJobCounts[site][prio] = siteJobCounts[site].setdefault(prio, 0) + element['Jobs']
+                siteJobCounts[site][prio] = siteJobCounts[site].setdefault(prio, 0) + element['Jobs']*(1+element.get('BlowupFactor', 0.0))
             else:
                 self.logger.info("No possible site for %s" % element)
         # sort elements to get them in priority first and timestamp order


### PR DESCRIPTION
We take blow-up factor to be the number of additional jobs in a
task chain after the jobs in the first task.  The latter steps in
the task chain should affect what is acquired for work now - esp
as the blow-up factor may be >100 in the cases of LHE.

This approach is not foolproof, I think.  WQE's already in WMBS
may only count the jobs currently in WMBS still.  If nothing else,
this will slow the acquisition of such workflows to the point where
they are load-balanced across agents.  Not clear that it would
prevent an agent from taking on too much work if it's a single-agent
team.
