### PR TITLE
Fix status validation in reqmgr2

### DIFF
--- a/src/python/WMCore/ReqMgr/Service/Request.py
+++ b/src/python/WMCore/ReqMgr/Service/Request.py
@@ -20,41 +20,41 @@ from WMCore.ReqMgr.DataStructs.Request import initialize_request_args
 from WMCore.ReqMgr.DataStructs.RequestStatus import REQUEST_STATE_LIST
 from WMCore.ReqMgr.DataStructs.RequestStatus import REQUEST_STATE_TRANSITION
 from WMCore.ReqMgr.DataStructs.RequestType import REQUEST_TYPES
-from WMCore.ReqMgr.DataStructs.RequestError import  InvalidSpecParameterValue
-from WMCore.ReqMgr.Utils.Validation import validate_request_create_args, \
-               validate_request_update_args
+from WMCore.ReqMgr.DataStructs.RequestError import InvalidSpecParameterValue
+from WMCore.ReqMgr.Utils.Validation import validate_request_create_args, validate_request_update_args
 
 from WMCore.Services.RequestDB.RequestDBWriter import RequestDBWriter
 from WMCore.Services.WorkQueue.WorkQueue import WorkQueue
+
 
 class Request(RESTEntity):
     def __init__(self, app, api, config, mount):
         # main CouchDB database where requests/workloads are stored
         RESTEntity.__init__(self, app, api, config, mount)
         self.reqmgr_db = api.db_handler.get_db(config.couch_reqmgr_db)
-        self.reqmgr_db_service = RequestDBWriter(self.reqmgr_db, couchapp = "ReqMgr")
-        # this need for the post validtiaon 
+        self.reqmgr_db_service = RequestDBWriter(self.reqmgr_db, couchapp="ReqMgr")
+        # this need for the post validtiaon
         self.reqmgr_aux_db = api.db_handler.get_db(config.couch_reqmgr_aux_db)
         self.gq_service = WorkQueue(config.couch_host, config.couch_workqueue_db)
-        
+
     def _requestArgMapFromBrowser(self, request_args):
         """
         This is specific mapping function data from browser
-        
-        TO: give a key word so it doesn't have to loop though in general
+
+        TODO: give a key word so it doesn't have to loop though in general
         """
         docs = []
         for doc in request_args:
             for key in doc.keys():
-                if  key.startswith('request'):
+                if key.startswith('request'):
                     rid = key.split('request-')[-1]
-                    if  rid != 'all':
+                    if rid != 'all':
                         docs.append(rid)
                     del doc[key]
         return docs
-    
+
     def _validateGET(self, param, safe):
-        #TODO: need proper validation but for now pass everything
+        # TODO: need proper validation but for now pass everything
         args_length = len(param.args)
         if args_length == 1:
             safe.kwargs["name"] = param.args[0]
@@ -66,18 +66,19 @@ class Request(RESTEntity):
         if "status" in param.kwargs:
             for status in param.kwargs["status"]:
                 if status.endswith("-archived"):
-                    raise InvalidSpecParameterValue("Can't retrieve bulk archived status requests, use other search arguments")
+                    raise InvalidSpecParameterValue(
+                        "Can't retrieve bulk archived status requests, use other search arguments")
 
         for prop in param.kwargs:
             safe.kwargs[prop] = param.kwargs[prop]
-        
+
         for prop in safe.kwargs:
             del param.kwargs[prop]
-        
+
         return
-    
-    def _validateRequestBase(self, param, safe, valFunc, requestName = None):
-        
+
+    def _validateRequestBase(self, param, safe, valFunc, requestName=None):
+
         data = cherrypy.request.body.read()
         if data:
             request_args = JsonWrapper.loads(data)
@@ -85,47 +86,46 @@ class Request(RESTEntity):
                 request_args["RequestName"] = requestName
             if isinstance(request_args, dict):
                 request_args = [request_args]
-                
+
         else:
             # actually this is error case
-            #cherrypy.log(str(param.kwargs))
+            # cherrypy.log(str(param.kwargs))
             request_args = {}
             for prop in param.kwargs:
                 request_args[prop] = param.kwargs[prop]
-                
+
             for prop in request_args:
-                del param.kwargs[prop] 
+                del param.kwargs[prop]
             if requestName:
                 request_args["RequestName"] = requestName
             request_args = [request_args]
-        
-        
+
         safe.kwargs['workload_pair_list'] = []
         if isinstance(request_args, dict):
             request_args = [request_args]
         for args in request_args:
             workload, r_args = valFunc(args, self.config, self.reqmgr_db_service, param)
             safe.kwargs['workload_pair_list'].append((workload, r_args))
-    
+
     def _get_request_names(self, ids):
         "Extract request names from given documents"
-        #cherrypy.log("request names %s" % ids)
+        # cherrypy.log("request names %s" % ids)
         doc = {}
-        if  isinstance(ids, list):
+        if isinstance(ids, list):
             for rid in ids:
                 doc[rid] = 'on'
         elif isinstance(ids, basestring):
             doc[ids] = 'on'
-            
+
         docs = []
         for key in doc.keys():
-            if  key.startswith('request'):
+            if key.startswith('request'):
                 rid = key.split('request-')[-1]
-                if  rid != 'all':
+                if rid != 'all':
                     docs.append(rid)
                 del doc[key]
         return docs
-    
+
     def _getMultiRequestArgs(self, multiRequestForm):
         request_args = {}
         for prop in multiRequestForm:
@@ -134,62 +134,61 @@ class Request(RESTEntity):
             elif prop == "new_status":
                 request_args["RequestStatus"] = multiRequestForm[prop]
             # remove this
-            #elif prop in ["CustodialSites", "AutoApproveSubscriptionSites"]:
+            # elif prop in ["CustodialSites", "AutoApproveSubscriptionSites"]:
             #    request_args[prop] = [multiRequestForm[prop]]
             else:
                 request_args[prop] = multiRequestForm[prop]
         return request_names, request_args
-        
+
     def _validateMultiRequests(self, param, safe, valFunc):
-        
+
         data = cherrypy.request.body.read()
         if data:
             request_names, request_args = self._getMultiRequestArgs(JsonWrapper.loads(data))
         else:
             # actually this is error case
-            #cherrypy.log(str(param.kwargs))
+            # cherrypy.log(str(param.kwargs))
             request_names, request_args = self._getMultiRequestArgs(param.kwargs)
-            
+
             for prop in request_args:
                 if prop == "RequestStatus":
                     del param.kwargs["new_status"]
                 else:
                     del param.kwargs[prop]
-            
+
             del param.kwargs["ids"]
-            
-            #remove this
-            #tmp = []
-            #for prop in param.kwargs:
+
+            # remove this
+            # tmp = []
+            # for prop in param.kwargs:
             #    tmp.append(prop)
-            #for prop in tmp:
+            # for prop in tmp:
             #    del param.kwargs[prop]
-        
+
         safe.kwargs['workload_pair_list'] = []
 
         for request_name in request_names:
             request_args["RequestName"] = request_name
             workload, r_args = valFunc(request_args, self.config, self.reqmgr_db_service, param)
             safe.kwargs['workload_pair_list'].append((workload, r_args))
-            
+
         safe.kwargs["multi_update_flag"] = True
-        
-        
+
     def _getRequestNamesFromBody(self, param, safe, valFunc):
-        
+
         request_names = JsonWrapper.loads(cherrypy.request.body.read())
         safe.kwargs['workload_pair_list'] = request_names
         safe.kwargs["multi_names_flag"] = True
-            
+
     def validate(self, apiobj, method, api, param, safe):
         # to make validate successful
         # move the validated argument to safe
         # make param empty
-        # other wise raise the error 
+        # other wise raise the error
         try:
             if method in ['GET']:
                 self._validateGET(param, safe)
-                    
+
             if method == 'PUT':
                 args_length = len(param.args)
                 if args_length == 1:
@@ -198,29 +197,29 @@ class Request(RESTEntity):
                 else:
                     requestName = None
                 self._validateRequestBase(param, safe, validate_request_update_args, requestName)
-                #TO: handle multiple clone
-#                 if len(param.args) == 2:
-#                     #validate clone case
-#                     if param.args[0] == "clone":
-#                         param.args.pop()
-#                         return None, request_args
-                    
+                # TO: handle multiple clone
+            #                 if len(param.args) == 2:
+            #                     #validate clone case
+            #                     if param.args[0] == "clone":
+            #                         param.args.pop()
+            #                         return None, request_args
+
             if method == 'POST':
                 args_length = len(param.args)
                 if args_length == 1 and param.args[0] == "multi_update":
-                    #special case for multi update from browser.
+                    # special case for multi update from browser.
                     param.args.pop()
                     self._validateMultiRequests(param, safe, validate_request_update_args)
                 elif args_length == 1 and param.args[0] == "bynames":
-                    #special case for multi update from browser.
+                    # special case for multi update from browser.
                     param.args.pop()
                     self._getRequestNamesFromBody(param, safe, validate_request_update_args)
                 else:
-                    self._validateRequestBase(param, safe, validate_request_create_args)    
+                    self._validateRequestBase(param, safe, validate_request_create_args)
         except InvalidSpecParameterValue as ex:
             raise ex
         except Exception as ex:
-            #TODO add proper error message instead of trace back
+            # TODO add proper error message instead of trace back
             msg = traceback.format_exc()
             cherrypy.log("Error: %s" % msg)
             if hasattr(ex, "message"):
@@ -231,33 +230,32 @@ class Request(RESTEntity):
             else:
                 msg = str(ex)
             raise InvalidSpecParameterValue(msg)
-    
+
     def initialize_clone(self, request_name):
         requests = self.reqmgr_db_service.getRequestByNames(request_name)
         clone_args = requests.values()[0]
         # overwrite the name and time stamp.
         initialize_request_args(clone_args, self.config, clone=True)
         # timestamp status update
-        
+
         spec = loadSpecByType(clone_args["RequestType"])
-        workload = spec.factoryWorkloadConstruction(clone_args["RequestName"], 
+        workload = spec.factoryWorkloadConstruction(clone_args["RequestName"],
                                                     clone_args)
         return (workload, clone_args)
-    
 
-    @restcall(formats = [('application/json', JSONFormat())])
+    @restcall(formats=[('application/json', JSONFormat())])
     def get(self, **kwargs):
         """
         Returns request info depending on the conditions set by kwargs
         Currently defined kwargs are following.
         statusList, requestNames, requestType, prepID, inputDataset, outputDataset, dateRange
         If jobInfo is True, returns jobInfomation about the request as well.
-            
+
         TODO:
         stuff like this has to filtered out from result of this call:
             _attachments: {u'spec': {u'stub': True, u'length': 51712, u'revpos': 2, u'content_type': u'application/json'}}
             _id: maxa_RequestString-OVERRIDE-ME_130621_174227_9225
-            _rev: 4-c6ceb2737793aaeac3f1cdf591593da4        
+            _rev: 4-c6ceb2737793aaeac3f1cdf591593da4
 
         """
         if len(kwargs) == 0:
@@ -265,7 +263,7 @@ class Request(RESTEntity):
             options = {"descending": True, 'include_docs': True, 'limit': 200}
             request_docs = self.reqmgr_db.loadView("ReqMgr", "bystatus", options)
             return rows([request_docs])
-            
+
         # list of status
         status = kwargs.get("status", False)
         # list of request names
@@ -289,15 +287,17 @@ class Request(RESTEntity):
         _nostale = kwargs.get("_nostale", False)
         if _nostale:
             self.reqmgr_db_service._setNoStale()
-            
-        request_info =[]
-        
+
+        request_info = []
+
         if status and not team and not request_type:
-            request_info.append(self.reqmgr_db_service.getRequestByCouchView("bystatus" , option, status))
+            request_info.append(self.reqmgr_db_service.getRequestByCouchView("bystatus", option, status))
         if status and team:
-            request_info.append(self.reqmgr_db_service.getRequestByCouchView("byteamandstatus", option, [[team, status]]))
+            request_info.append(
+                self.reqmgr_db_service.getRequestByCouchView("byteamandstatus", option, [[team, status]]))
         if status and request_type:
-            request_info.append(self.reqmgr_db_service.getRequestByCouchView("requestsbystatusandtype", option, [[status, request_type]]))
+            request_info.append(self.reqmgr_db_service.getRequestByCouchView("requestsbystatusandtype", option,
+                                                                             [[status, request_type]]))
         if name:
             request_info.append(self.reqmgr_db_service.getRequestByNames(name))
         if prep_id:
@@ -316,12 +316,12 @@ class Request(RESTEntity):
             request_info.append(self.reqmgr_db_service.getRequestByCouchView("bymcpileup", option, mc_pileup))
         if data_pileup:
             request_info.append(self.reqmgr_db_service.getRequestByCouchView("bydatapileup", option, data_pileup))
-        #get interaction of the request
-        result = self._intersection_of_request_info(request_info);
+        # get interaction of the request
+        result = self._intersection_of_request_info(request_info)
         if len(result) == 0:
             return []
         return rows([result])
-        
+
     def _intersection_of_request_info(self, request_info):
         requests = {}
         if len(request_info) < 1:
@@ -330,55 +330,56 @@ class Request(RESTEntity):
         request_key_set = set(request_info[0].keys())
         for info in request_info:
             request_key_set = set(request_key_set) & set(info.keys())
-        #TODO: need to assume some data maight not contains include docs
+        # TODO: need to assume some data maight not contains include docs
         for request_name in request_key_set:
             requests[request_name] = request_info[0][request_name]
-        return requests    
-        
-    #TODO move this out of this class
+        return requests
+
+        # TODO move this out of this class
+
     def filterCouchInfo(self, couchInfo):
         for key in ['_rev', '_attachments']:
-            if  key in couchInfo:
+            if key in couchInfo:
                 del couchInfo[key]
-                
+
     def _combine_request(self, request_info, requestAgentUrl, cache):
         keys = {}
         requestAgentUrlList = []
         for row in requestAgentUrl["rows"]:
             request = row["key"][0]
-            if not keys[request]: 
+            if not keys[request]:
                 keys[request] = []
             keys[request].append(row["key"][1])
 
-        for request in request_info: 
-            for agentUrl in keys[request]: 
-                requestAgentUrlList.append([request, agentUrl]);
+        for request in request_info:
+            for agentUrl in keys[request]:
+                requestAgentUrlList.append([request, agentUrl])
 
-        return requestAgentUrlList;
-    
+        return requestAgentUrlList
+
     def _retrieveResubmissionChildren(self, request_name):
-        
-        result = self.reqmgr_db.loadView('ReqMgr', 'childresubmissionrequests', keys = [request_name])['rows']
+
+        result = self.reqmgr_db.loadView('ReqMgr', 'childresubmissionrequests', keys=[request_name])['rows']
         childrenRequestNames = []
         for child in result:
             childrenRequestNames.append(child['id'])
             childrenRequestNames.extend(self._retrieveResubmissionChildren(child['id']))
         return childrenRequestNames
-    
+
     def _updateRequest(self, workload, request_args):
-                       
+
         if workload == None:
             (workload, request_args) = self.initialize_clone(request_args["OriginalRequestName"])
             return self.post(workload, request_args)
-        
+
         dn = cherrypy.request.user.get("dn", "unknown")
-        
-        if ('SoftTimeout' in request_args) and ('GracePeriod' in request_args): 
+
+        if ('SoftTimeout' in request_args) and ('GracePeriod' in request_args):
             request_args['HardTimeout'] = request_args['SoftTimeout'] + request_args['GracePeriod']
-        
+
         if 'RequestPriority' in request_args:
             self.gq_service.updatePriority(workload.name(), request_args['RequestPriority'])
-        
+
         if "total_jobs" in request_args:
             # only GQ update this stats
             # request_args should contain only 4 keys 'total_jobs', 'input_lumis', 'input_events', 'input_num_files'}
@@ -386,7 +387,7 @@ class Request(RESTEntity):
         # if is not just updating status
         else:
             req_status = request_args.get("RequestStatus", None)
-            
+
             if len(request_args) >= 1 and req_status == None:
                 try:
                     workload.updateArguments(request_args)
@@ -394,36 +395,36 @@ class Request(RESTEntity):
                     msg = traceback.format_exc()
                     cherrypy.log("Error for request args %s: %s" % (request_args, msg))
                     raise InvalidSpecParameterValue(str(ex))
-                    
+
                 # trailing / is needed for the savecouchUrl function
                 workload.saveCouch(self.config.couch_host, self.config.couch_reqmgr_db)
-            
+
             elif (req_status in ["closed-out"  "announced"]) and request_args.get("cascade", False):
                 cascade_list = self._retrieveResubmissionChildren(workload.name)
                 for req_name in cascade_list:
                     report = self.reqmgr_db_service.updateRequestStatus(req_name, req_status)
-            
+
             # If it is aborted or force-complete transition call workqueue to cancel the request
             else:
                 if req_status == "aborted" or req_status == "force-complete":
                     self.gq_service.cancelWorkflow(workload.name())
                 report = self.reqmgr_db_service.updateRequestProperty(workload.name(), request_args, dn)
-        
+
         if report == 'OK':
             return {workload.name(): "OK"}
         else:
             return {workload.name(): "ERROR"}
-    
-    @restcall(formats = [('application/json', JSONFormat())])
+
+    @restcall(formats=[('application/json', JSONFormat())])
     def put(self, workload_pair_list):
         "workloadPairList is a list of tuple containing (workload, requeat_args)"
         report = []
         for workload, request_args in workload_pair_list:
             result = self._updateRequest(workload, request_args)
             report.append(result)
-        return report 
-    
-    @restcall(formats = [('application/json', JSONFormat())])
+        return report
+
+    @restcall(formats=[('application/json', JSONFormat())])
     def delete(self, request_name):
         cherrypy.log("INFO: Deleting request document '%s' ..." % request_name)
         try:
@@ -431,71 +432,68 @@ class Request(RESTEntity):
         except CouchError as ex:
             msg = "ERROR: Delete failed."
             cherrypy.log(msg + " Reason: %s" % ex)
-            raise cherrypy.HTTPError(404, msg)        
-        # TODO
+            raise cherrypy.HTTPError(404, msg)
+            # TODO
         # delete should also happen on WMStats
         cherrypy.log("INFO: Delete '%s' done." % request_name)
-        
+
     def _update_additional_request_args(self, workload, request_args):
         """
         add to request_args properties which is not initially set from user.
-        This data will put in to couchdb. 
+        This data will put in to couchdb.
         Update request_args here if additional information need to be put in couchdb
         """
-        request_args['RequestWorkflow'] = sanitizeURL("%s/%s/%s/spec" % (request_args["CouchURL"], 
-                                            request_args["CouchWorkloadDBName"], workload.name()))['url']
-        
+        request_args['RequestWorkflow'] = sanitizeURL("%s/%s/%s/spec" % (request_args["CouchURL"],
+                                                                         request_args["CouchWorkloadDBName"],
+                                                                         workload.name()))['url']
+
         # Add the output datasets if necessary
-        # for some bizarre reason OutpuDatasets is list of lists    
+        # for some bizarre reason OutpuDatasets is list of lists
         request_args['OutputDatasets'] = workload.listOutputDatasets()
-        
-        #TODO: remove this after reqmgr2 replice reqmgr (reqmgr2Only)
+
+        # TODO: remove this after reqmgr2 replice reqmgr (reqmgr2Only)
         request_args['ReqMgr2Only'] = True
         return
-    
-    @restcall(formats = [('application/json', JSONFormat())])
-    def post(self, workload_pair_list, multi_update_flag = False, multi_names_flag = False):
+
+    @restcall(formats=[('application/json', JSONFormat())])
+    def post(self, workload_pair_list, multi_update_flag=False, multi_names_flag=False):
         """
-        Create and update couchDB with  a new request. 
-        request argument is passed from validation 
+        Create and update couchDB with  a new request.
+        request argument is passed from validation
         (validation convert cherrypy.request.body data to argument)
-                        
+
         TODO:
         this method will have some parts factored out so that e.g. clone call
         can share functionality.
-        
+
         NOTES:
-        1) do not strip spaces, #4705 will fails upon injection with spaces ; 
+        1) do not strip spaces, #4705 will fails upon injection with spaces;
             currently the chain relies on a number of things coming in #4705
-        
         2) reqInputArgs = Utilities.unidecode(JsonWrapper.loads(body))
             (from ReqMgrRESTModel.putRequest)
-                
         """
-        
+
         # storing the request document into Couch
-        
+
         if multi_update_flag:
             return self.put(workload_pair_list)
         if multi_names_flag:
-            return self.get(name = workload_pair_list)
-            
+            return self.get(name=workload_pair_list)
+
         out = []
         for workload, request_args in workload_pair_list:
-            
             self._update_additional_request_args(workload, request_args)
-            
+
             cherrypy.log("INFO: Create request, input args: %s ..." % request_args)
             workload.saveCouch(request_args["CouchURL"], request_args["CouchWorkloadDBName"],
-                                              metadata=request_args)
-            out.append({'request':workload.name()})
+                               metadata=request_args)
+            out.append({'request': workload.name()})
         return out
-        
+
 
 class RequestStatus(RESTEntity):
     def __init__(self, app, api, config, mount):
         RESTEntity.__init__(self, app, api, config, mount)
-
 
     def validate(self, apiobj, method, api, param, safe):
         validate_str("transition", param, safe, rx.RX_BOOL_FLAG, optional=True)
@@ -504,32 +502,27 @@ class RequestStatus(RESTEntity):
             safe.kwargs["transiton"] = param.args[0]
             param.args.pop()
             return
-        
-    
-    @restcall(formats = [('application/json', JSONFormat())])
+
+    @restcall(formats=[('application/json', JSONFormat())])
     def get(self, transition):
         """
         Return list of allowed request status.
         If transition, return exhaustive list with all request status
         and their defined transitions.
-        
         """
         if transition == "true":
             return rows([REQUEST_STATE_TRANSITION])
         else:
             return rows(REQUEST_STATE_LIST)
-    
-    
-    
+
+
 class RequestType(RESTEntity):
     def __init__(self, app, api, config, mount):
         RESTEntity.__init__(self, app, api, config, mount)
-    
-    
+
     def validate(self, apiobj, method, api, param, safe):
         pass
-    
-    
+
     @restcall
     def get(self):
         return rows(REQUEST_TYPES)


### PR DESCRIPTION
Fix request api validation when > 1 status is provided.

Pylint was also complaining about
E:363,36: Instance of 'Request' has no 'wmstatsCouch' member (no-member)

Since nothing else in the code uses that method (and I actually don't think wmstats method belong to this class), I simply removed it. @ticoann let me know if we need to fix and add it back.
