### PR TITLE
Fix data acquisition for TrustSitelists

### DIFF
--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -393,10 +393,6 @@ class WorkQueue(WorkQueueBase):
             [f for block in tmpDsetDict.values() for f in block['PhEDExNodeNames']])
         dbsDatasetDict['PhEDExNodeNames'] = list(set(dbsDatasetDict['PhEDExNodeNames']))
 
-        if wmspec.locationDataSourceFlag():
-            psns = match['Inputs'].values()[0]
-            pnns = self.SiteDB.PSNstoPNNs(psns)
-            dbsDatasetDict['PhEDExNodeNames'] = pnns
         return datasetName, dbsDatasetDict
 
     def _getDBSBlock(self, match, wmspec):
@@ -420,11 +416,6 @@ class WorkQueue(WorkQueueBase):
 
             block = {}
             block["Files"] = fileLists
-            if wmspec.locationDataSourceFlag():
-                psns = match['Inputs'].values()[0]
-                pnns = self.SiteDB.PSNstoPNNs(psns)
-                for fileInfo in block["Files"]:
-                    fileInfo['locations'] = pnns
             return blockName, block
         else:
             dbs = get_dbs(match['Dbs'])
@@ -433,11 +424,6 @@ class WorkQueue(WorkQueueBase):
             else:
                 dbsBlockDict = dbs.getFileBlock(blockName)
 
-            if wmspec.locationDataSourceFlag():
-                blockInfo = dbsBlockDict[blockName]
-                psns = match['Inputs'].values()[0]
-                pnns = self.SiteDB.PSNstoPNNs(psns)
-                blockInfo['PhEDExNodeNames'] = pnns
         return blockName, dbsBlockDict[blockName]
 
     def _wmbsPreparation(self, match, wmspec, blockName, dbsBlock):


### PR DESCRIPTION
DO NOT MERGE yet, please.
When we assign work to opportunistic sites (aka., without PNN), we cannot force file wmbs registration against the site white list (because the mapping to PNN is empty and then it fails to acquire work).

I'm almost sure it will break our current "useSiteListAsLocation" mode, ideally we should merge them and live with a single case.

This parameter cannot be overriden during assignment (only request creation), so I'm going to fix that next within this patch.
