### PR TITLE
Do not use nCores for job wall time estimation

### DIFF
--- a/src/python/WMComponent/JobCreator/JobCreatorPoller.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorPoller.py
@@ -108,8 +108,8 @@ def capResourceEstimates(jobGroups, nCores, constraints):
                 j['estimatedJobTime'] = min(j['estimatedJobTime'], constraints['MaxWallTimeSecs'])
                 j['estimatedDiskUsage'] = min(j['estimatedDiskUsage'], constraints['MaxRequestDiskKB'])
             else:
-                # we assume job efficiency as nCores * 0.8 for multicore
-                j['estimatedJobTime'] = min(j['estimatedJobTime']/(nCores * 0.8),
+                # we assume job efficiency as 0.8 for multicore jobs
+                j['estimatedJobTime'] = min(j['estimatedJobTime']/0.8,
                                             constraints['MaxWallTimeSecs'])
                 j['estimatedDiskUsage'] = min(j['estimatedDiskUsage'],
                                               constraints['MaxRequestDiskKB'] * nCores)


### PR DESCRIPTION
At the moment, ReqMgr assumes the TimePerEvent provided for a workflow/task/step takes into account the number of cores. E.g., if we receive {'TimePerEvent': 4, 'Multicore': 8},  then it means one event will take 4 seconds to be processed in an 8 cores job, so the automatic 8h job splitting would set 7200 events per job.
However, when JobCreator is creating these jobs, it assumes _each_ core takes 4seconds to process 1 event, so calculating a ~2h wall time.

Almost sure unit tests need to be fixed...
