### PR TITLE
Add Signals dependency

### DIFF
--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -12,8 +12,8 @@ dependencies = {'wmc-rest':{
                         },
                 'wmc-base':{
                         'bin': ['wmc-dist-patch', 'wmc-dist-unpatch'],
-                        'packages' : ['WMCore.DataStructs'],
-                        'modules': ['Utils+', 'WMCore.WMFactory', 'WMCore.WMException', 'WMCore.Configuration',
+                        'packages' : ['WMCore.DataStructs','Utils.IterTools'],
+                        'modules': ['WMCore.WMFactory', 'WMCore.WMException', 'WMCore.Configuration',
                                     'WMCore.WMExceptions', 'WMCore.WMFactory', 'WMCore.Lexicon',
                                     'WMCore.WMBase', 'WMCore.WMLogging', 'WMCore.Algorithms.Permissions'],
                         },

--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -52,7 +52,7 @@ dependencies = {'wmc-rest':{
                                      'WMCore.Services.RequestManager',
                                      'WMCore.Services+',
                                      'WMCore.ACDC'],
-
+                        'modules': ['WMCore.Signals'],
                         'systems':['wmc-web', 'wmc-runtime'],
                         'statics': ['src/templates/WMCore/WebTools/RequestManager',
                                     'src/html/GlobalMonitor',
@@ -69,6 +69,7 @@ dependencies = {'wmc-rest':{
                                      'WMCore.ACDC'
                                     ],
                         'systems': ['wmc-rest', 'wmc-runtime', 'wmc-database'],
+                        'modules': ['WMCore.Signals'],
                         'statics': ['src/couchapps/ReqMgr+',
                                     'src/couchapps/ReqMgrAux+',
                                     'src/couchapps/ConfigCache+',
@@ -153,7 +154,8 @@ dependencies = {'wmc-rest':{
                                      'WMCore.Database.CouchUtils',
                                      'WMCore.ReqMgr.__init__', 'WMCore.ReqMgr.DataStructs.__init__',
                                      'WMCore.ReqMgr.DataStructs.RequestStatus',
-                                     'WMCore.ReqMgr.DataStructs.RequestType'],
+                                     'WMCore.ReqMgr.DataStructs.RequestType',
+                                     'WMCore.Signals'],
                         'systems': ['wmc-base', 'wmc-rest'],
                         'statics': ['src/couchapps/WMStats+',
                                     'src/couchapps/WMStatsErl+',


### PR DESCRIPTION
I just have problems deploying services in my VM
ImportError: No module named Signals
and I don't see this module under the services path.

First time I change this file, but I believe this is the right fix.
@ticoann please review
