### PR TITLE
Add a dumb function to the PhEDEx emulator to make mocked-DBS work

### DIFF
--- a/src/python/WMQuality/Emulators/PhEDExClient/PhEDEx.py
+++ b/src/python/WMQuality/Emulators/PhEDExClient/PhEDEx.py
@@ -373,6 +373,16 @@ class PhEDEx(dict):
                                     "call_time":0.03909, "request_date":"2013-05-15 16:46:05 UTC"}}
         return goldenResponse
 
+    def getReplicaPhEDExNodesForBlocks(self, block=None, dataset=None, complete='y'):
+        """
+        This function is a really dumb emulator that we need to supply so that the mock-based DBS emulator works
+        """
+        replicas = {}
+        if dataset:
+            block = ['%s#1' % dataset]
+        for blockName in block:
+            replicas.update({blockName: ['T1_US_FNAL_Disk']})
+        return replicas
 
     def emulator(self):
         return "PhEDEx emulator ...."


### PR DESCRIPTION
This patch will allow @jha2 to make progress on the DBS emulator work. Eventually we may want to replace the entire Phedex emulator with a mocked version as well.
