### PR TITLE
Relax constrain on passed args (when no YUI is used)

### DIFF
--- a/src/python/WMCore/REST/Server.py
+++ b/src/python/WMCore/REST/Server.py
@@ -320,7 +320,7 @@ class RESTFrontPage:
 
         Serves assets as documented in :meth:`_serve`."""
         if len(args) > 1 or (args and args[0] != "yui"):
-            raise HTTPError(404, "No such file")
+            return self._serve(['/'.join(args)])
         paths = request.query_string.split("&")
         if not paths:
             raise HTTPError(404, "No such file")

--- a/src/python/WMCore/REST/Server.py
+++ b/src/python/WMCore/REST/Server.py
@@ -319,8 +319,12 @@ class RESTFrontPage:
         with 'yui/' to make them compatible with the standard combo loading.
 
         Serves assets as documented in :meth:`_serve`."""
+        # The code was originally designed to server YUI content.
+        # Modified to support any content by joining args into single path
+        # on web page it can be /path/static/js/file.js or /path/static/css/file.css
         if len(args) > 1 or (args and args[0] != "yui"):
             return self._serve(['/'.join(args)])
+        # Path arguments must be empty, or consist of a single 'yui' string,
         paths = request.query_string.split("&")
         if not paths:
             raise HTTPError(404, "No such file")


### PR DESCRIPTION
When I worked with WMArchive I found that constraint in REST Service serving static content is too tight. It was done when we used YUI library. Now, I wanted to serve just set of static files, e.g. wmarchive/static/images/img.jpg, etc. and to do so I loose constrain on passed args.
