### PR TITLE
add CondorStatusService

### DIFF
--- a/test/python/WMCore_t/WMRuntime_t/Scripts_t/SetupCMSSWPset_t.py
+++ b/test/python/WMCore_t/WMRuntime_t/Scripts_t/SetupCMSSWPset_t.py
@@ -104,6 +104,10 @@ class SetupCMSSWPsetTest(unittest.TestCase):
 
         """
         from WMCore.WMRuntime.Scripts.SetupCMSSWPset import SetupCMSSWPset
+
+        if os.environ.get('CMSSW_VERSION', None):
+            del os.environ['CMSSW_VERSION']
+
         setupScript = SetupCMSSWPset()
         setupScript.step = self.createTestStep()
         setupScript.stepSpace = ConfigSection(name = "stepSpace")
@@ -135,6 +139,9 @@ class SetupCMSSWPsetTest(unittest.TestCase):
 
         """
         from WMCore.WMRuntime.Scripts.SetupCMSSWPset import SetupCMSSWPset
+
+        os.environ['CMSSW_VERSION'] = "CMSSW_7_4_0"
+
         setupScript = SetupCMSSWPset()
         setupScript.step = self.createTestStep()
         setupScript.step.setEventsPerLumi(500)
@@ -169,6 +176,9 @@ class SetupCMSSWPsetTest(unittest.TestCase):
 
         """
         from WMCore.WMRuntime.Scripts.SetupCMSSWPset import SetupCMSSWPset
+
+        os.environ['CMSSW_VERSION'] = "CMSSW_7_6_0"
+
         setupScript = SetupCMSSWPset()
         setupScript.step = self.createTestStep()
         setupScript.stepSpace = ConfigSection(name = "stepSpace")


### PR DESCRIPTION
Requested by Brian, already in use for CRAB3. As far as I understand it makes CMSSW publish job progress information to Condor, that information can then be remotely queried.

Also exercised in Tier0 tests, no issues observed.

If desired I can factor this out into its own method, functionally wouldn't be any different though.

@ericvaandering and @ticoann , please review.
