### PR TITLE
signal.SIGINFO doesn't exist in signal module

### DIFF
--- a/bin/wmc-httpd
+++ b/bin/wmc-httpd
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 from WMCore.REST.Main import main
-import WMCore.Signals
+import Utils.Signals
 main()


### PR DESCRIPTION
For now remove the import. Also import should be import Utils.Signals
