### PR TITLE
remove an external used that doesn't work with python 2.7

### DIFF
--- a/src/python/WMComponent/JobArchiver/JobArchiverPoller.py
+++ b/src/python/WMComponent/JobArchiver/JobArchiverPoller.py
@@ -12,7 +12,6 @@ import shutil
 import tarfile
 import traceback
 
-from Utils.IterTools import grouper
 from WMComponent.TaskArchiver.TaskArchiverPoller import uploadPublishWorkflow
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 from WMCore.JobStateMachine.ChangeState import ChangeState
@@ -152,7 +151,9 @@ class JobArchiverPoller(BaseWorkerThread):
         logging.info("Found %i finished jobs to archive", len(doneList))
 
         jobCounter = 0
-        for slicedList in grouper(doneList, 10000):
+        chunkSize = 10000
+        for slicedList in [ doneList[i:i+chunkSize] for i in range(0, len(doneList), chunkSize) ]:
+
             self.cleanWorkArea(slicedList)
 
             successList = []


### PR DESCRIPTION
Showed up in my comp_gcc493 T0 version that uses python 2.7. Easy enough to fix as you really don't need that helper function.
