### PR TITLE
allow to configure group ownership for a subscription

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/MySQL/Create.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/Create.py
@@ -48,6 +48,7 @@ class Create(DBCreator):
                  move                   INTEGER      DEFAULT 0,
                  priority               VARCHAR(10)  DEFAULT 'Low',
                  subscribed             INTEGER      DEFAULT 0,
+                 phedex_group           VARCHAR(100),
                  delete_blocks          INTEGER,
                  PRIMARY KEY (id),
                  CONSTRAINT uq_dbs_dat_sub UNIQUE (dataset_id, site, custodial, auto_approve, move, priority)

--- a/src/python/WMComponent/DBS3Buffer/MySQL/NewSubscription.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/NewSubscription.py
@@ -18,8 +18,8 @@ class NewSubscription(DBFormatter):
     """
 
     sql = """INSERT IGNORE INTO dbsbuffer_dataset_subscription
-            (dataset_id, site, custodial, auto_approve, move, priority, subscribed, delete_blocks)
-            VALUES (:id, :site, :custodial, :auto_approve, :move, :priority, 0, :delete_blocks)
+            (dataset_id, site, custodial, auto_approve, move, priority, subscribed, phedex_group, delete_blocks)
+            VALUES (:id, :site, :custodial, :auto_approve, :move, :priority, 0, :phedex_group, :delete_blocks)
           """
 
     def _createPhEDExSubBinds(self, datasetID, subscriptionInfo, custodialFlag):
@@ -42,17 +42,17 @@ class NewSubscription(DBFormatter):
                 isMove = 0
                 if subscriptionInfo.get('DeleteFromSource', False):
                     delete_blocks = 1
-                    
+
         binds = []
         for site in sites:
-            subInfo = {'id' : datasetID,
-                       'site' : site,
-                       'custodial' : custodialFlag,
-                       'auto_approve' : 1 if site in subscriptionInfo['AutoApproveSites'] else 0,
-                       'move' : isMove,
-                       'priority' : subscriptionInfo['Priority'],
-                       'delete_blocks' : delete_blocks}
-            binds.append(subInfo)
+            binds.append( {'id' : datasetID,
+                           'site' : site,
+                           'custodial' : custodialFlag,
+                           'auto_approve' : 1 if site in subscriptionInfo['AutoApproveSites'] else 0,
+                           'move' : isMove,
+                           'priority' : subscriptionInfo['Priority'],
+                           'phedex_group' : subscriptionInfo.get('PhEDExGroup', None),
+                           'delete_blocks' : delete_blocks} )
         return binds
     
     def execute(self, datasetID, subscriptionInfo,

--- a/src/python/WMComponent/DBS3Buffer/Oracle/Create.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/Create.py
@@ -47,6 +47,7 @@ class Create(DBCreator):
                  move               INTEGER      DEFAULT 0,
                  priority           VARCHAR(10)  DEFAULT 'Low',
                  subscribed         INTEGER      DEFAULT 0,
+                 phedex_group       VARCHAR(100),
                  delete_blocks      INTEGER,
                  PRIMARY KEY (id),
                  CONSTRAINT uq_dbs_dat_sub UNIQUE (dataset_id, site, custodial, auto_approve, move, priority)

--- a/src/python/WMComponent/DBS3Buffer/Oracle/NewSubscription.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/NewSubscription.py
@@ -18,9 +18,9 @@ class NewSubscription(MySQLNewSubscription):
     """
 
     sql = """INSERT INTO dbsbuffer_dataset_subscription
-             (id, dataset_id, site, custodial, auto_approve, move, priority, subscribed, delete_blocks)
+             (id, dataset_id, site, custodial, auto_approve, move, priority, subscribed, phedex_group, delete_blocks)
              SELECT dbsbuffer_dataset_sub_seq.nextval, :id, :site, :custodial, :auto_approve,
-                    :move, :priority, 0, :delete_blocks
+                    :move, :priority, 0, :phedex_group, :delete_blocks
              FROM DUAL
              WHERE NOT EXISTS
                ( SELECT *

--- a/src/python/WMComponent/PhEDExInjector/Database/MySQL/GetUnsubscribedDatasets.py
+++ b/src/python/WMComponent/PhEDExInjector/Database/MySQL/GetUnsubscribedDatasets.py
@@ -20,7 +20,8 @@ class GetUnsubscribedDatasets(DBFormatter):
                              dbsbuffer_dataset_subscription.custodial,
                              dbsbuffer_dataset_subscription.auto_approve,
                              dbsbuffer_dataset_subscription.move,
-                             dbsbuffer_dataset_subscription.priority
+                             dbsbuffer_dataset_subscription.priority,
+                             dbsbuffer_dataset_subscription.phedex_group
                FROM dbsbuffer_dataset_subscription
                INNER JOIN dbsbuffer_dataset ON
                    dbsbuffer_dataset.id = dbsbuffer_dataset_subscription.dataset_id

--- a/src/python/WMComponent/PhEDExInjector/PhEDExInjectorSubscriber.py
+++ b/src/python/WMComponent/PhEDExInjector/PhEDExInjectorSubscriber.py
@@ -266,11 +266,17 @@ class PhEDExInjectorSubscriber(BaseWorkerThread):
             # Avoid auto approval in T1 sites
             elif site.startswith("T1"):
                 subInfo['request_only'] = 'y'
-            
-            phedexSub = PhEDExSubscription(subInfo['path'], site,
-                                           self.group, priority = subInfo['priority'],
-                                           move = subInfo['move'], custodial = subInfo['custodial'],
-                                           request_only = subInfo['request_only'], subscriptionId = subInfo['id'])
+
+            group = subInfo['phedex_group']
+            if not group:
+                group = self.group
+
+            phedexSub = PhEDExSubscription(subInfo['path'], site, group,
+                                           priority = subInfo['priority'],
+                                           move = subInfo['move'],
+                                           custodial = subInfo['custodial'],
+                                           request_only = subInfo['request_only'],
+                                           subscriptionId = subInfo['id'])
 
             # Check if the subscription is a duplicate
             if phedexSub.matchesExistingSubscription(self.phedex) or \

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -882,10 +882,10 @@ class WMTaskHelper(TreeHelper):
         return outputDatasets
 
     def setSubscriptionInformation(self, custodialSites = None, nonCustodialSites = None,
-                                         autoApproveSites = None, custodialSubType = "Replica",
-                                         nonCustodialSubType = "Replica", priority = "Low",
-                                         primaryDataset = None, dataTier = None,
-                                         deleteFromSource = False):
+                                   autoApproveSites = None, custodialSubType = "Replica",
+                                   nonCustodialSubType = "Replica", priority = "Low",
+                                   primaryDataset = None, dataTier = None,
+                                   phedexGroup = None, deleteFromSource = False):
         """
         _setSubscriptionsInformation_
 
@@ -931,6 +931,7 @@ class WMTaskHelper(TreeHelper):
                 outputModuleSection.custodialSubType = "Replica"
                 outputModuleSection.nonCustodialSubType = "Replica"
                 outputModuleSection.priority = "Low"
+                outputModuleSection.phedexGroup = None
                 outputModuleSection.deleteFromSource = False
 
             outputModuleSection = getattr(self.data.subscriptions, outputModule)
@@ -941,6 +942,7 @@ class WMTaskHelper(TreeHelper):
             if autoApproveSites  is not None:
                 outputModuleSection.autoApproveSites = autoApproveSites
             outputModuleSection.priority = priority
+            outputModuleSection.phedexGroup = phedexGroup
             outputModuleSection.deleteFromSource = deleteFromSource
             outputModuleSection.custodialSubType = custodialSubType
             outputModuleSection.nonCustodialSubType = nonCustodialSubType
@@ -990,7 +992,8 @@ class WMTaskHelper(TreeHelper):
                                        "NonCustodialSites" : outputModuleSection.nonCustodialSites,
                                        "AutoApproveSites" : outputModuleSection.autoApproveSites,
                                        "Priority" : outputModuleSection.priority,
-                                       # DeleteFromSource is optional
+                                       # PhEDExGroup and DeleteFromSource are optional
+                                       "PhEDExGroup" : getattr(outputModuleSection, "phedexGroup", False),
                                        "DeleteFromSource" : getattr(outputModuleSection, "deleteFromSource", False),
                                        # Specs assigned before HG1303 don't have the CustodialSubtype
                                        "CustodialSubType" : getattr(outputModuleSection, "custodialSubType", "Replica"),

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -1155,7 +1155,7 @@ class WMWorkloadHelper(PersistencyHelper):
                                             nonCustodialSites = None, autoApproveSites = None,
                                             custodialSubType = "Replica", nonCustodialSubType = "Replica",
                                             priority = "Low", primaryDataset = None, dataTier = None,
-                                            deleteFromSource = False):
+                                            phedexGroup = None, deleteFromSource = False):
         """
         _setSubscriptonInformationWildCards_
 
@@ -1196,13 +1196,14 @@ class WMWorkloadHelper(PersistencyHelper):
                                         priority = priority,
                                         primaryDataset = primaryDataset,
                                         dataTier = dataTier,
+                                        phedexGroup = phedexGroup,
                                         deleteFromSource = deleteFromSource)
 
     def setSubscriptionInformation(self, initialTask = None, custodialSites = None,
                                    nonCustodialSites = None, autoApproveSites = None,
                                    custodialSubType = "Replica", nonCustodialSubType = "Replica",
                                    priority = "Low", primaryDataset = None, dataTier = None,
-                                   deleteFromSource = False):
+                                   phedexGroup = None, deleteFromSource = False):
         """
         _setSubscriptionInformation_
 
@@ -1227,12 +1228,12 @@ class WMWorkloadHelper(PersistencyHelper):
                                             autoApproveSites, custodialSubType,
                                             nonCustodialSubType, priority,
                                             primaryDataset, dataTier,
-                                            deleteFromSource)
+                                            phedexGroup, deleteFromSource)
             self.setSubscriptionInformation(task, custodialSites, nonCustodialSites,
                                             autoApproveSites, custodialSubType,
                                             nonCustodialSubType, priority,
                                             primaryDataset, dataTier,
-                                            deleteFromSource)
+                                            phedexGroup, deleteFromSource)
 
         return
 
@@ -1252,13 +1253,8 @@ class WMWorkloadHelper(PersistencyHelper):
         solvePrioConflicts = lambda x, y: y if x == "High" or y == "Low" else x
         # Choose replica over move
         solveTypeConflicts = lambda x, y: y if x == "Move" else x
-
-
-
-
-
-
-
+        # Choose the 'smallest' group (based on string comparison)
+        solveGroupConflicts = lambda x, y: y if x > y else x
         # Always choose a logical AND
         solveDelConflicts = lambda x, y : x and y
 
@@ -1280,6 +1276,8 @@ class WMWorkloadHelper(PersistencyHelper):
                                                                               subInfo[dataset]["AutoApproveSites"])
                     subInfo[dataset]["Priority"]          = solvePrioConflicts(taskSubInfo[dataset]["Priority"],
                                                                                subInfo[dataset]["Priority"])
+                    subInfo[dataset]["PhEDExGroup"] = solveGroupConflicts(taskSubInfo[dataset]["PhEDExGroup"],
+                                                                          subInfo[dataset]["PhEDExGroup"])
                     subInfo[dataset]["DeleteFromSource"] = solveDelConflicts(taskSubInfo[dataset]["DeleteFromSource"],
                                                                                subInfo[dataset]["DeleteFromSource"])
                     subInfo[dataset]["CustodialSubType"] = solveTypeConflicts(taskSubInfo[dataset]["CustodialSubType"],

--- a/test/python/WMCore_t/WMSpec_t/WMTask_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMTask_t.py
@@ -479,6 +479,7 @@ class WMTaskTest(unittest.TestCase):
                              "Priority" : "High",
                              "CustodialSubType" : "Replica",
                              "NonCustodialSubType" : "Move",
+                             "PhEDExGroup" : None,
                              "DeleteFromSource" : False}
         
         self.assertEqual(subInfo["/OneParticle/DawnOfAnEra-v1/RECO"],


### PR DESCRIPTION
In the subscription information record allow to configure a phedex group override. If not specified it defaults to None which triggers using the default component parameters (so DataOps).

So far this is only used by the Tier0, if desired for WMAgent we would need to make this configurable from RequestManager and pass the information down to where subscriptions are setup.
