### PR TITLE
due to the conflict signal handling

### DIFF
--- a/bin/wmc-httpd
+++ b/bin/wmc-httpd
@@ -1,4 +1,3 @@
 #!/usr/bin/env python
 from WMCore.REST.Main import main
-import Utils.Signals
 main()


### PR DESCRIPTION
https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/REST/Main.py#L444

Probably it is OK to add multiple call backs for a given signal. But for now removing this.
@vkuznet, Valentin, what do suggest? 
