### PR TITLE
custodial and non-custodial phedex groups for subscriptions

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/MySQL/NewSubscription.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/NewSubscription.py
@@ -25,9 +25,11 @@ class NewSubscription(DBFormatter):
     def _createPhEDExSubBinds(self, datasetID, subscriptionInfo, custodialFlag):
         
         # DeleteFromSource is not supported for move subscriptions
+        phedex_group = None
         delete_blocks = None
         if custodialFlag:
             sites = subscriptionInfo['CustodialSites']
+            phedex_group = subscriptionInfo['CustodialGroup']
             if subscriptionInfo['CustodialSubType'] == 'Move':
                 isMove = 1
             else:
@@ -36,6 +38,7 @@ class NewSubscription(DBFormatter):
                     delete_blocks = 1
         else:
             sites = subscriptionInfo['NonCustodialSites']
+            phedex_group = subscriptionInfo['NonCustodialGroup']
             if subscriptionInfo['NonCustodialSubType'] == 'Move':
                 isMove = 1
             else:
@@ -51,7 +54,7 @@ class NewSubscription(DBFormatter):
                            'auto_approve' : 1 if site in subscriptionInfo['AutoApproveSites'] else 0,
                            'move' : isMove,
                            'priority' : subscriptionInfo['Priority'],
-                           'phedex_group' : subscriptionInfo.get('PhEDExGroup', None),
+                           'phedex_group' : phedex_group,
                            'delete_blocks' : delete_blocks} )
         return binds
     

--- a/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
+++ b/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
@@ -46,7 +46,6 @@ class PhEDExInjectorPoller(BaseWorkerThread):
         self.config = config
         self.phedex = phedex
         self.dbsUrl = config.DBSInterface.globalDBSUrl
-        self.group = getattr(config.PhEDExInjector, "group", "DataOps")
 
         # This will be used to map SE names which are stored in the DBSBuffer to
         # PhEDEx node names.  The first key will be the "kind" which consists

--- a/src/python/WMComponent/PhEDExInjector/PhEDExInjectorSubscriber.py
+++ b/src/python/WMComponent/PhEDExInjector/PhEDExInjectorSubscriber.py
@@ -55,7 +55,6 @@ class PhEDExInjectorSubscriber(BaseWorkerThread):
         BaseWorkerThread.__init__(self)
         self.phedex = phedex
         self.dbsUrl = config.DBSInterface.globalDBSUrl
-        self.group = getattr(config.PhEDExInjector, "group", "DataOps")
 
         self.phedexNodes = {'MSS':[], 'Disk':[]}
         for node in nodeMappings["phedex"]["node"]:
@@ -267,11 +266,7 @@ class PhEDExInjectorSubscriber(BaseWorkerThread):
             elif site.startswith("T1"):
                 subInfo['request_only'] = 'y'
 
-            group = subInfo['phedex_group']
-            if not group:
-                group = self.group
-
-            phedexSub = PhEDExSubscription(subInfo['path'], site, group,
+            phedexSub = PhEDExSubscription(subInfo['path'], site, subInfo['phedex_group'],
                                            priority = subInfo['priority'],
                                            move = subInfo['move'],
                                            custodial = subInfo['custodial'],

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -999,7 +999,7 @@ class StdBase(object):
                                             "validate" : lambda x: all([cmsname(y) for y in x])},
                      "AutoApproveSubscriptionSites" : {"default" : [], "type" : makeList, "assign_optional": True, 
                                                        "validate" : lambda x: all([cmsname(y) for y in x])},
-                     # should be Low, Normal, High
+                     # should be Low, Normal or High
                      "SubscriptionPriority" : {"default" : "Low", "assign_optional": True,
                                                "validate" : lambda x: x in ["Low", "Normal", "High"]},
                      # should be Move Replica  
@@ -1007,6 +1007,13 @@ class StdBase(object):
                                            "validate" : lambda x: x in ["Move", "Replica"]},
                      "NonCustodialSubType" : {"default" : "Replica", "type" : str, "assign_optional": True,
                                               "validate" : lambda x: x in ["Move", "Replica"]},
+
+                     # should be a valid PhEDEx group
+                     "CustodialGroup" : {"default" : "DataOps", "type" : str, "assign_optional": True },
+                     "NonCustodialGroup" : {"default" : "DataOps", "type" : str, "assign_optional": True },
+
+                     # should be True or False
+                     "DeleteFromSource" : {"default" : False, "type" : bool},
                      
                      # Block closing information
                      "BlockCloseMaxWaitTime" : {"default" : 66400, "type" : int, "validate" : lambda x : x > 0},

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -892,10 +892,11 @@ class WMTaskHelper(TreeHelper):
         return outputDatasets
 
     def setSubscriptionInformation(self, custodialSites = None, nonCustodialSites = None,
-                                   autoApproveSites = None, custodialSubType = "Replica",
-                                   nonCustodialSubType = "Replica", priority = "Low",
-                                   primaryDataset = None, dataTier = None,
-                                   phedexGroup = None, deleteFromSource = False):
+                                   autoApproveSites = None,
+                                   custodialSubType = "Replica", nonCustodialSubType = "Replica",
+                                   custodialGroup = "DataOps", nonCustodialGroup = "DataOps",
+                                   priority = "Low", primaryDataset = None,
+                                   dataTier = None, deleteFromSource = False):
         """
         _setSubscriptionsInformation_
 
@@ -940,8 +941,9 @@ class WMTaskHelper(TreeHelper):
                 outputModuleSection.autoApproveSites = []
                 outputModuleSection.custodialSubType = "Replica"
                 outputModuleSection.nonCustodialSubType = "Replica"
+                outputModuleSection.custodialGroup = "DataOps"
+                outputModuleSection.nonCustodialGroup = "DataOps"
                 outputModuleSection.priority = "Low"
-                outputModuleSection.phedexGroup = None
                 outputModuleSection.deleteFromSource = False
 
             outputModuleSection = getattr(self.data.subscriptions, outputModule)
@@ -952,10 +954,11 @@ class WMTaskHelper(TreeHelper):
             if autoApproveSites  is not None:
                 outputModuleSection.autoApproveSites = autoApproveSites
             outputModuleSection.priority = priority
-            outputModuleSection.phedexGroup = phedexGroup
             outputModuleSection.deleteFromSource = deleteFromSource
             outputModuleSection.custodialSubType = custodialSubType
             outputModuleSection.nonCustodialSubType = nonCustodialSubType
+            outputModuleSection.custodialGroup = custodialGroup
+            outputModuleSection.nonCustodialGroup = nonCustodialGroup
 
         return
 
@@ -986,7 +989,7 @@ class WMTaskHelper(TreeHelper):
                       NonCustodialSites : [],
                       AutoApproveSites : [],
                       Priority : "Low",
-                      CustodialSubType : "Move",
+                      CustodialSubType : "Replica",
                       NonCustodialSubType : "Replica"
                      }
         }
@@ -1002,8 +1005,9 @@ class WMTaskHelper(TreeHelper):
                                        "NonCustodialSites" : outputModuleSection.nonCustodialSites,
                                        "AutoApproveSites" : outputModuleSection.autoApproveSites,
                                        "Priority" : outputModuleSection.priority,
-                                       # PhEDExGroup and DeleteFromSource are optional
-                                       "PhEDExGroup" : getattr(outputModuleSection, "phedexGroup", False),
+                                       # These might not be present in all specs
+                                       "CustodialGroup" : getattr(outputModuleSection, "custodialGroup", "DataOps"),
+                                       "NonCustodialGroup" : getattr(outputModuleSection, "nonCustodialGroup", "DataOps"),
                                        "DeleteFromSource" : getattr(outputModuleSection, "deleteFromSource", False),
                                        # Specs assigned before HG1303 don't have the CustodialSubtype
                                        "CustodialSubType" : getattr(outputModuleSection, "custodialSubType", "Replica"),

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -1154,10 +1154,11 @@ class WMWorkloadHelper(PersistencyHelper):
     def setSubscriptionInformationWildCards(self, wildcardDict, custodialSites = None,
                                             nonCustodialSites = None, autoApproveSites = None,
                                             custodialSubType = "Replica", nonCustodialSubType = "Replica",
-                                            priority = "Low", primaryDataset = None, dataTier = None,
-                                            phedexGroup = None, deleteFromSource = False):
+                                            custodialGroup = "DataOps", nonCustodialGroup = "DataOps",
+                                            priority = "Low", primaryDataset = None,
+                                            dataTier = None, deleteFromSource = False):
         """
-        _setSubscriptonInformationWildCards_
+        _setSubscriptionInformationWildCards_
 
         Set the given subscription information for all datasets
         in the workload that match the given primary dataset (if any), site lists can have wildcards.
@@ -1193,17 +1194,19 @@ class WMWorkloadHelper(PersistencyHelper):
                                         autoApproveSites = newAutoApproveList,
                                         custodialSubType = custodialSubType,
                                         nonCustodialSubType = nonCustodialSubType,
+                                        custodialGroup = custodialGroup,
+                                        nonCustodialGroup = nonCustodialGroup,
                                         priority = priority,
                                         primaryDataset = primaryDataset,
                                         dataTier = dataTier,
-                                        phedexGroup = phedexGroup,
                                         deleteFromSource = deleteFromSource)
 
     def setSubscriptionInformation(self, initialTask = None, custodialSites = None,
                                    nonCustodialSites = None, autoApproveSites = None,
                                    custodialSubType = "Replica", nonCustodialSubType = "Replica",
-                                   priority = "Low", primaryDataset = None, dataTier = None,
-                                   phedexGroup = None, deleteFromSource = False):
+                                   custodialGroup = "DataOps", nonCustodialGroup = "DataOps",
+                                   priority = "Low", primaryDataset = None,
+                                   dataTier = None, deleteFromSource = False):
         """
         _setSubscriptionInformation_
 
@@ -1225,15 +1228,18 @@ class WMWorkloadHelper(PersistencyHelper):
 
         for task in taskIterator:
             task.setSubscriptionInformation(custodialSites, nonCustodialSites,
-                                            autoApproveSites, custodialSubType,
-                                            nonCustodialSubType, priority,
-                                            primaryDataset, dataTier,
-                                            phedexGroup, deleteFromSource)
-            self.setSubscriptionInformation(task, custodialSites, nonCustodialSites,
-                                            autoApproveSites, custodialSubType,
-                                            nonCustodialSubType, priority,
-                                            primaryDataset, dataTier,
-                                            phedexGroup, deleteFromSource)
+                                            autoApproveSites,
+                                            custodialSubType, nonCustodialSubType,
+                                            custodialGroup, nonCustodialGroup,
+                                            priority, primaryDataset,
+                                            dataTier, deleteFromSource)
+            self.setSubscriptionInformation(task,
+                                            custodialSites, nonCustodialSites,
+                                            autoApproveSites,
+                                            custodialSubType, nonCustodialSubType,
+                                            custodialGroup, nonCustodialGroup,
+                                            priority, primaryDataset,
+                                            dataTier, deleteFromSource)
 
         return
 
@@ -1276,14 +1282,16 @@ class WMWorkloadHelper(PersistencyHelper):
                                                                               subInfo[dataset]["AutoApproveSites"])
                     subInfo[dataset]["Priority"]          = solvePrioConflicts(taskSubInfo[dataset]["Priority"],
                                                                                subInfo[dataset]["Priority"])
-                    subInfo[dataset]["PhEDExGroup"] = solveGroupConflicts(taskSubInfo[dataset]["PhEDExGroup"],
-                                                                          subInfo[dataset]["PhEDExGroup"])
                     subInfo[dataset]["DeleteFromSource"] = solveDelConflicts(taskSubInfo[dataset]["DeleteFromSource"],
                                                                                subInfo[dataset]["DeleteFromSource"])
                     subInfo[dataset]["CustodialSubType"] = solveTypeConflicts(taskSubInfo[dataset]["CustodialSubType"],
                                                                               subInfo[dataset]["CustodialSubType"])
                     subInfo[dataset]["NonCustodialSubType"] = solveTypeConflicts(taskSubInfo[dataset]["NonCustodialSubType"],
                                                                                  subInfo[dataset]["NonCustodialSubType"])
+                    subInfo[dataset]["CustodialGroup"] = solveGroupConflicts(taskSubInfo[dataset]["CustodialGroup"],
+                                                                             subInfo[dataset]["CustodialGroup"])
+                    subInfo[dataset]["NonCustodialGroup"] = solveGroupConflicts(taskSubInfo[dataset]["NonCustodialGroup"],
+                                                                                subInfo[dataset]["NonCustodialGroup"])
                 else:
                     subInfo[dataset] = taskSubInfo[dataset]
                 subInfo[dataset]["CustodialSites"] = list(set(subInfo[dataset]["CustodialSites"]) - set(subInfo[dataset]["NonCustodialSites"]))
@@ -1688,8 +1696,10 @@ class WMWorkloadHelper(PersistencyHelper):
         mergeParams = ["MinMergeSize", "MaxMergeSize", "MaxMergeEvents"]
         performanceParams = ["MaxRSS", "MaxVSize", "SoftTimeout", "GracePeriod"]
         phedexParams = ["CustodialSites", "NonCustodialSites",
-                        "AutoApproveSubscriptionSites", "CustodialSubType",
-                        "NonCustodialSubType", "SubscriptionPriority"]
+                        "AutoApproveSubscriptionSites",
+                        "CustodialSubType", "NonCustodialSubType",
+                        "CustodialGroup", "NonCustodialGroup",
+                        "SubscriptionPriority", "DeleteFromSource"]
         blockCloseParams = ["BlockCloseMaxWaitTime", "BlockCloseMaxFiles",
                             "BlockCloseMaxEvents", "BlockCloseMaxSize"]
 

--- a/test/python/WMCore_t/WMSpec_t/WMTask_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMTask_t.py
@@ -468,27 +468,38 @@ class WMTaskTest(unittest.TestCase):
 
         self.assertEqual(testTask.getSubscriptionInformation(), {}, "There should not be any subscription info")
 
-        testTask.setSubscriptionInformation(["mercury"], ["mars", "earth"],
-                                            ["earth"], "Replica", "Move", "High",
-                                            "OneParticle")
+        testTask.setSubscriptionInformation(custodialSites = ["mercury"],
+                                            nonCustodialSites = ["mars", "earth"],
+                                            autoApproveSites = ["earth"],
+                                            custodialSubType = "Replica",
+                                            nonCustodialSubType = "Move",
+                                            custodialGroup = "DataOps",
+                                            nonCustodialGroup = "AnalysisOps",
+                                            priority = "Normal",
+                                            deleteFromSource = True,
+                                            primaryDataset = "OneParticle")
         subInfo = testTask.getSubscriptionInformation()
 
         outputRecoSubInfo = {"CustodialSites" : ["mercury"],
                              "NonCustodialSites" : ["mars", "earth"],
                              "AutoApproveSites" : ["earth"],
-                             "Priority" : "High",
                              "CustodialSubType" : "Replica",
                              "NonCustodialSubType" : "Move",
-                             "PhEDExGroup" : None,
-                             "DeleteFromSource" : False}
-        
+                             "CustodialGroup" : "DataOps",
+                             "NonCustodialGroup" : "AnalysisOps",
+                             "Priority" : "Normal",
+                             "DeleteFromSource" : True}
+
         self.assertEqual(subInfo["/OneParticle/DawnOfAnEra-v1/RECO"],
                          outputRecoSubInfo, "The RECO subscription information is wrong")
         self.assertTrue("/OneParticle/DawnOfAnEra-v1/AOD" in subInfo, "The AOD subscription information is wrong")
         self.assertFalse("/TwoParticles/DawnOfAnEra-v1/DQM" in subInfo, "The DQM subscription information is wrong")
 
-        testTask.setSubscriptionInformation(["jupiter"], primaryDataset = "TwoParticles")
+        testTask.setSubscriptionInformation(custodialSites = ["jupiter"],
+                                            primaryDataset = "TwoParticles")
+
         subInfo = testTask.getSubscriptionInformation()
+
         self.assertEqual(subInfo["/OneParticle/DawnOfAnEra-v1/RECO"],
                          outputRecoSubInfo, "The RECO subscription information is wrong")
         self.assertTrue("/OneParticle/DawnOfAnEra-v1/AOD" in subInfo, "The AOD subscription information is wrong")
@@ -496,7 +507,9 @@ class WMTaskTest(unittest.TestCase):
 
         recoutOutputModule = cmsswHelper.getOutputModule("outputRECO")
         setattr(recoutOutputModule, "primaryDataset", "ThreeParticles")
+
         testTask.updateSubscriptionDataset("outputRECO", recoutOutputModule)
+
         subInfo = testTask.getSubscriptionInformation()
         self.assertEqual(subInfo["/ThreeParticles/DawnOfAnEra-v1/RECO"],
                         outputRecoSubInfo, "The RECO subscription information is wrong")


### PR DESCRIPTION
The Tier0 makes multiple subscriptions for some datasets, one to MSS and one to Disk. These subscriptions should use different PhEDEx groups, which isn't currently possible. Add this feature by allowing to configure different PhEDEx groups for custodial and nonCustodial subscriptions.
