### PR TITLE
initial attempt to change fwjr structure (Do not merge!)

### DIFF
--- a/src/python/WMCore/FwkJobReport/Report.py
+++ b/src/python/WMCore/FwkJobReport/Report.py
@@ -156,7 +156,7 @@ class Report:
             raise FwkJobReportException(msg)
 
 
-    def jsonizeFiles(self, reportModule):
+    def jsonizeFiles(self, reportModule, newFormat=False):
         """
         _jsonizeFiles_
 
@@ -175,10 +175,18 @@ class Report:
 
             if jsonFile.get('runs', None):
                 cfgSectionRuns = jsonFile["runs"]
-                jsonFile["runs"] = {}
+                
+                if newFormat:
+                    jsonFile["runs"] = []
+                else:
+                    jsonFile["runs"] = {}
                 for runNumber in cfgSectionRuns.listSections_():
-                    jsonFile["runs"][str(runNumber)] = getattr(cfgSectionRuns,
-                                                               runNumber)
+                    if newFormat:
+                        jsonFile["runs"].append({'runNumber': runNumber, 
+                                                 'value': getattr(cfgSectionRuns, runNumber)})
+                    else:
+                        jsonFile["runs"][str(runNumber)] = getattr(cfgSectionRuns,
+                                                                runNumber)
             jsonFiles.append(jsonFile)
 
         return jsonFiles
@@ -204,7 +212,7 @@ class Report:
 
         return jsonPerformance
 
-    def __to_json__(self, thunker):
+    def __to_json__(self, thunker, newFormat=False):
         """
         __to_json__
 
@@ -233,19 +241,31 @@ class Report:
 
             jsonStep["performance"] = self.jsonizePerformance(reportStep.performance)
 
-            jsonStep["output"] = {}
+            if newFormat:
+                jsonStep["output"] = []
+            else:
+                jsonStep["output"] = {}
             for outputModule in reportStep.outputModules:
                 reportOutputModule = getattr(reportStep.output, outputModule)
-                jsonStep["output"][outputModule] = self.jsonizeFiles(reportOutputModule)
+                if newFormat:
+                    jsonStep["output"].append({'outputModule': outputModule, 
+                                                'value': self.jsonizeFiles(reportOutputModule, newFormat)})
+                else:
+                    jsonStep["output"][outputModule] = self.jsonizeFiles(reportOutputModule, newFormat)
 
             analysisSection = getattr(reportStep, 'analysis', None)
             if analysisSection:
-                jsonStep["output"]['analysis'] = self.jsonizeFiles(analysisSection)
-
+                if newFormat:
+                    jsonStep["output"].append({'outputModule': 'analysis', 
+                                               'value': self.jsonizeFiles(analysisSection, newFormat)})
+                else:
+                    jsonStep["output"]['analysis'] = self.jsonizeFiles(analysisSection, newFormat)
+            
             jsonStep["input"] = {}
             for inputSource in reportStep.input.listSections_():
                 reportInputSource = getattr(reportStep.input, inputSource)
-                jsonStep["input"][inputSource] = self.jsonizeFiles(reportInputSource)
+                # input source is always "source"
+                jsonStep["input"][inputSource] = self.jsonizeFiles(reportInputSource, newFormat)
 
             jsonStep["errors"] = []
             errorCount = getattr(reportStep.errors, "errorCount", 0)

--- a/test/python/WMCore_t/FwkJobReport_t/Report_t.py
+++ b/test/python/WMCore_t/FwkJobReport_t/Report_t.py
@@ -8,6 +8,7 @@ Unit tests for the Report class.
 import unittest
 import os
 import time
+from pprint import pprint
 
 from WMCore.Algorithms import BasicAlgos
 from WMCore.Configuration import ConfigSection
@@ -255,7 +256,7 @@ cms::Exception caught in EventProcessor and rethrown
 
         myReport = Report("cmsRun1")
         myReport.parse(xmlPath)
-
+        
         assert hasattr(myReport.data.cmsRun1, "errors"), \
                "Error: Error section missing."
         assert getattr(myReport.data.cmsRun1.errors, "errorCount") == 1, \
@@ -343,7 +344,7 @@ cms::Exception caught in EventProcessor and rethrown
                                "WMCore_t/FwkJobReport_t/CMSSWProcessingReport.xml")
         myReport = Report("cmsRun1")
         myReport.parse(xmlPath)
-
+                
         jsonReport = myReport.__to_json__(None)
 
         assert "task" in jsonReport.keys(), \
@@ -440,6 +441,7 @@ cms::Exception caught in EventProcessor and rethrown
             self.assertEqual(d['min'], 100)
             self.assertEqual(d['max'], 800)
             self.assertEqual(d['average'], 244)
+            
         return
 
     def testPerformanceSummary(self):
@@ -876,6 +878,21 @@ cms::Exception caught in EventProcessor and rethrown
         self.assertFalse(badReport.stepSuccessful(stepName="cmsRun1"))
         self.assertEqual(badReport.getExitCode(), 60450)
         return
+    
+    def testReport(self):
+        
+        pathList = [self.xmlPath, 
+                    self.skippedFilesxmlPath,
+                    self.skippedAllFilesxmlPath,
+                    self.fallbackXmlPath,
+                    self.twoFileFallbackXmlPath,
+                    self.pileupXmlPath]
+        for path in pathList:
+            myReport = Report("cmsRun1")
+            myReport.parse(path)
+            pprint(myReport.__to_json__(None, True))
+        
+        
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This is initial attempt to switch FWJR format to support archiver (putting in hadoop)
This code won't change the current structure unless newFormat is set to True.
1. Removing arbitrary key value from dictionary. 
   output = {name: value}  -> output = [{'outputModule': name, 'value': value}
   runs = {runNumber: runNumberList} -> runs = [{'runNumber': runNumber, 'value': runNumberList} 
2. for input, left as it is since inputSource is alwas 'source'

It would break the code when newFormat is set to True. - need to be fixed and updated.
Make sure this change wouldn't break any code outside WMCore. Especially CRAB - need to check.
