### PR TITLE
delete WMStats document locally

### DIFF
--- a/src/python/WMCore/WorkQueue/DataStructs/WorkQueueElement.py
+++ b/src/python/WMCore/WorkQueue/DataStructs/WorkQueueElement.py
@@ -213,8 +213,10 @@ class WorkQueueElement(dict):
     def passesSiteRestriction(self, site):
         """Takes account of white & black list, and input data to work out
         if site can run the work"""
-        # Don't check anything if useSiteListAsLocation/trusSiteLists is enabled
-        if self['NoLocationUpdate']:
+        # Don't check anything if trustSitelists is enabled and SiteWhitelist is empty or site is 
+        # is site whitelist
+        if self['NoLocationUpdate'] and \
+           (not self['SiteWhitelist'] or site in self['SiteWhitelist']):
             return True
         # data restrictions - all data must be present at site
         for locations in self['Inputs'].values():


### PR DESCRIPTION
Since production wmstats is update to clean up db using thread, this needs to be patched in production agents. (Sorry I forgot to add this earlier)
@amaltaro Alan, please review. 
