### PR TITLE
change the default log level

### DIFF
--- a/src/python/WMCore/WMLogging.py
+++ b/src/python/WMCore/WMLogging.py
@@ -41,6 +41,7 @@ def getTimeRotatingLogger(name, logFile, duration = 'midnight'):
     formatter = logging.Formatter("%(asctime)s:%(levelname)s:%(module)s:%(message)s")
     handler.setFormatter(formatter)
     logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
 
     return logger
 


### PR DESCRIPTION
I am not sure what is the causing this, but it seems some of the log (wmstats) has default level WARNING, instead of NOSET. 
According to the documentation it said "root logger"'s default value is WARNING but not sure how it affects the wmstats logging.
https://docs.python.org/2/library/logging.html

The problem was first self.logger.info prints out the log but not the second one.

https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/ReqMgr/CherryPyThreads/StatusChangeTasks.py#L41

https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/WMStats/CherryPyThreads/CleanUpTask.py#L30
