### PR TITLE
Take nCores into account for automatic event job splitting

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/DataProcessing.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/DataProcessing.py
@@ -5,7 +5,7 @@ _DataProcessing_
 Base module for workflows with input.
 """
 
-from WMCore.Lexicon import dataset, couchurl, identifier, block
+from WMCore.Lexicon import dataset, block
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
 from WMCore.WMSpec.WMWorkloadTools import makeList
 
@@ -21,10 +21,11 @@ class DataProcessing(StdBase):
         StdBase.__call__(self, workloadName, arguments)
 
         # Handle the default of the various splitting algorithms
-        self.procJobSplitArgs = {"include_parents" : self.includeParents}
+        self.procJobSplitArgs = {"include_parents": self.includeParents}
+        nCores = int(getattr(self, 'multicoreNCores', 1))
         if self.procJobSplitAlgo == "EventBased" or self.procJobSplitAlgo == "EventAwareLumiBased":
             if self.eventsPerJob is None:
-                self.eventsPerJob = int((8.0 * 3600.0) / self.timePerEvent)
+                self.eventsPerJob = int(nCores * (8.0 * 3600.0) / self.timePerEvent)
             self.procJobSplitArgs["events_per_job"] = self.eventsPerJob
             if self.procJobSplitAlgo == "EventAwareLumiBased":
                 self.procJobSplitArgs["max_events_per_lumi"] = 20000

--- a/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
@@ -486,6 +486,7 @@ class TaskChainWorkloadFactory(StdBase):
             if argument in taskConf:
                 taskConf[argument] = baseArguments[argument]["type"](taskConf[argument])
 
+        nCores = int(taskConf.get('Multicore', 1))
         if generator:
             taskConf["SplittingAlgo"] = "EventBased"
             # Adjust totalEvents according to the filter efficiency
@@ -495,12 +496,12 @@ class TaskChainWorkloadFactory(StdBase):
                                        taskConf.get("FilterEfficiency")
 
         if taskConf["EventsPerJob"] is None:
-            taskConf["EventsPerJob"] = int((8.0 * 3600.0) / taskConf.get("TimePerEvent", self.timePerEvent))
+            taskConf["EventsPerJob"] = int(nCores * (8.0 * 3600.0) / taskConf.get("TimePerEvent", self.timePerEvent))
         if taskConf["EventsPerLumi"] is None:
             taskConf["EventsPerLumi"] = taskConf["EventsPerJob"]
 
         taskConf["SplittingArguments"] = {}
-        if taskConf["SplittingAlgo"] == "EventBased" or taskConf["SplittingAlgo"] == "EventAwareLumiBased":
+        if taskConf["SplittingAlgo"] in ["EventBased", "EventAwareLumiBased"]:
             taskConf["SplittingArguments"]["events_per_job"] = taskConf["EventsPerJob"]
             if taskConf["SplittingAlgo"] == "EventAwareLumiBased":
                 taskConf["SplittingArguments"]["max_events_per_lumi"] = 20000


### PR DESCRIPTION
Fixes #6448 (?)
This issue popped up just before Xmas break, which was discussed here to some extent:
https://hypernews.cern.ch/HyperNews/CMS/get/comp-ops/2704/2/2/1/2/1/1/1/1/1/2/1/1/1/1/2.html

The main issue was the definition of TimePerEvent, which apparently McM considers to be something like: (Time it took to process them) / (N events processed). E.g. it took 60secs to process 10 evts (for 4 cores), that would give us an average of 6s per event.

As Brian mentioned, TimePerEvent should be the time each event takes to process, but we do N events at a time. E.g. 6s per event would give us: 4 \* 60 / 6 = 40 evts in total.

The idea is that we make it consistent, of course.
@ericvaandering @ticoann what do you think? Maybe we can quickly discuss it during the meeting.
