### PR TITLE
Remove most instances of deprecated assertEquals

### DIFF
--- a/test/python/WMComponent_t/TaskArchiver_t/TaskArchiver_t.py
+++ b/test/python/WMComponent_t/TaskArchiver_t/TaskArchiver_t.py
@@ -410,7 +410,7 @@ class TaskArchiverTest(unittest.TestCase):
         getUrl = "%sjsonfairy/archive/%s%s/DQM/TimerService/event_byluminosity" % (dqmUrl, run, dataset)
         # Assert if the URL is assembled as expected
         if run == 207214:
-            self.assertEquals('https://cmsweb.cern.ch/dqm/dev/jsonfairy/archive/207214/MinimumBias/Commissioning10-v4/DQM/DQM/TimerService/event_byluminosity',
+            self.assertEqual('https://cmsweb.cern.ch/dqm/dev/jsonfairy/archive/207214/MinimumBias/Commissioning10-v4/DQM/DQM/TimerService/event_byluminosity',
                                getUrl)
         # let's suppose it works..
         testResponseFile = open(os.path.join(getTestBase(),
@@ -457,7 +457,7 @@ class TaskArchiverTest(unittest.TestCase):
         testDashBoardPayload = testDashBoardPayloadFile.read()
         testDashBoardPayloadFile.close()
 
-        self.assertEquals(data, testDashBoardPayload)
+        self.assertEqual(data, testDashBoardPayload)
 
         return True
     
@@ -642,7 +642,7 @@ class TaskArchiverTest(unittest.TestCase):
         failedRunInfo = workloadSummary['errors']['/TestWorkload/ReReco']['cmsRun1']['99999']['runs']
         for key, value in failedRunInfo.items():
             failedRunInfo[key] = list(set(value))
-        self.assertEquals(failedRunInfo, {'10' : [12312]},
+        self.assertEqual(failedRunInfo, {'10' : [12312]},
                           "Wrong lumi information in the summary for failed jobs")
 
         # Check the failures by site histograms
@@ -809,10 +809,10 @@ class TaskArchiverTest(unittest.TestCase):
             if not release :
                 logging.info("no release for %s, bailing out" % workload.name())
 
-        self.assertEquals(release, "test_compops_CMSSW_5_3_6_patch1")
+        self.assertEqual(release, "test_compops_CMSSW_5_3_6_patch1")
         # If all is true, get the run numbers processed by this worklfow
         runList = listRunsWorkflow.execute(workflow = workload.name())
-        self.assertEquals([207214, 207215], runList)
+        self.assertEqual([207214, 207215], runList)
         # GO to DQM GUI, get what you want
         # https://cmsweb.cern.ch/dqm/offline/jsonfairy/archive/211313/PAMuon/HIRun2013-PromptReco-v1/DQM/DQM/TimerService/event
         for dataset in interestingDatasets :

--- a/test/python/WMCore_t/BossAir_t/MockPlugin_t.py
+++ b/test/python/WMCore_t/BossAir_t/MockPlugin_t.py
@@ -48,7 +48,7 @@ class MockPluginTest(unittest.TestCase):
         mp = MockPlugin(config)
 
         #Check that the job has been scheduled
-        self.assertEquals({}, mp.jobsScheduledEnd)
+        self.assertEqual({}, mp.jobsScheduledEnd)
 
         # Don't be racy
         currentTime = datetime.now()
@@ -65,16 +65,16 @@ class MockPluginTest(unittest.TestCase):
                          "Time till Job %s !<= Delta %s" % (timeTillJob, \
                          timedelta(minutes = TEST_JOB_LEN * 120/100 + 1)) )
         #the job is running
-        self.assertEquals( 'Running', res[0][0]['status'])
-        self.assertEquals( 'Running', res[1][0]['status'])
-        self.assertEquals( [], res[2])
+        self.assertEqual( 'Running', res[0][0]['status'])
+        self.assertEqual( 'Running', res[1][0]['status'])
+        self.assertEqual( [], res[2])
 
         #the job is not running anymore
         mp.jobsScheduledEnd[1] = datetime(1900,1,1)
         res = mp.track( jobList )
-        self.assertEquals( [], res[0])
-        self.assertEquals( 'Done', res[1][0]['status'])
-        self.assertEquals( 'Done', res[2][0]['status'])
+        self.assertEqual( [], res[0])
+        self.assertEqual( 'Done', res[1][0]['status'])
+        self.assertEqual( 'Done', res[2][0]['status'])
 
         del mp
 

--- a/test/python/WMCore_t/Configuration_t.py
+++ b/test/python/WMCore_t/Configuration_t.py
@@ -264,7 +264,7 @@ class ConfigurationTest(unittest.TestCase):
         config.section_("testsection")
         self.assertTrue(hasattr(instance, "testsection"))
         config.testsection.var = 10
-        self.assertEquals(instance.testsection.var, 10)
+        self.assertEqual(instance.testsection.var, 10)
 
 
     def testH_ConfigSectionDictionariseInternalChildren(self):

--- a/test/python/WMCore_t/Database_t/CMSCouch_t.py
+++ b/test/python/WMCore_t/Database_t/CMSCouch_t.py
@@ -158,8 +158,8 @@ class CMSCouchTest(unittest.TestCase):
         d['foo'] = 'bar'
         doc_info = self.db.commit(doc=d, timestamp=True)[0]
         d_from_db = self.db.document(doc_info['id'])
-        self.assertEquals(d['foo'], d_from_db['foo'])
-        self.assertEquals(d['timestamp'], d_from_db['timestamp'])
+        self.assertEqual(d['foo'], d_from_db['foo'])
+        self.assertEqual(d['timestamp'], d_from_db['timestamp'])
 
     def testAttachments(self):
         """
@@ -224,15 +224,15 @@ class CMSCouchTest(unittest.TestCase):
         data = repl_db.post('/%s/_temp_view' % repl_db.name, conflict_view)
 
         # Should have one conflict in the repl database
-        self.assertEquals(data['total_rows'], 1)
+        self.assertEqual(data['total_rows'], 1)
         # Should have no conflicts in the source database
-        self.assertEquals(self.db.post('/%s/_temp_view' % self.db.name, conflict_view)['total_rows'], 0)
+        self.assertEqual(self.db.post('/%s/_temp_view' % self.db.name, conflict_view)['total_rows'], 0)
         self.assertTrue(repl_db.documentExists(data['rows'][0]['id'], rev=data['rows'][0]['key'][0]))
 
         repl_db.delete_doc(data['rows'][0]['id'], rev=data['rows'][0]['key'][0])
         data = repl_db.post('/%s/_temp_view' % repl_db.name, conflict_view)
 
-        self.assertEquals(data['total_rows'], 0)
+        self.assertEqual(data['total_rows'], 0)
         self.server.deleteDatabase(repl_db.name)
 
         #update it again
@@ -243,7 +243,7 @@ class CMSCouchTest(unittest.TestCase):
 
         #test that I can pull out an old revision
         doc_v1_test = self.db.document(doc_id, rev=doc_v1['_rev'])
-        self.assertEquals(doc_v1, doc_v1_test)
+        self.assertEqual(doc_v1, doc_v1_test)
 
         #test that I can check a revision exists
         self.assertTrue(self.db.documentExists(doc_id, rev=doc_v2['_rev']))
@@ -318,9 +318,9 @@ class CMSCouchTest(unittest.TestCase):
         self.db.commit(update_ddoc)
         doc = {'foo': 123, 'counter': 0}
         doc_id = self.db.commit(doc)[0]['id']
-        self.assertEquals("bumped it!", self.db.updateDocument(doc_id, 'foo', 'bump-counter'))
+        self.assertEqual("bumped it!", self.db.updateDocument(doc_id, 'foo', 'bump-counter'))
 
-        self.assertEquals(1, self.db.document(doc_id)['counter'])
+        self.assertEqual(1, self.db.document(doc_id)['counter'])
 
 
     def testList(self):

--- a/test/python/WMCore_t/JobSplitting_t/FixedDelay_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/FixedDelay_t.py
@@ -87,19 +87,19 @@ class FixedDelayTest(unittest.TestCase):
         splitter = SplitterFactory()
         jobFactory = splitter(self.singleFileSubscription)
         jobGroups = jobFactory(trigger_time = int(time.time()) * 2)
-        self.assertEquals(jobGroups, [], "Should have returned a null set")
+        self.assertEqual(jobGroups, [], "Should have returned a null set")
 
         jobFactory = splitter(self.multipleFileSubscription)
         jobGroups = jobFactory(trigger_time = int(time.time()) * 2)
-        self.assertEquals(jobGroups, [], "Should have returned a null set")
+        self.assertEqual(jobGroups, [], "Should have returned a null set")
 
         jobFactory = splitter(self.multipleLumiSubscription)
         jobGroups = jobFactory(trigger_time = int(time.time()) * 2)
-        self.assertEquals(jobGroups, [], "Should have returned a null set")
+        self.assertEqual(jobGroups, [], "Should have returned a null set")
 
         jobFactory = splitter(self.singleLumiSubscription)
         jobGroups = jobFactory(trigger_time = int(time.time()) * 2)
-        self.assertEquals(jobGroups, [], "Should have returned a null set")
+        self.assertEqual(jobGroups, [], "Should have returned a null set")
 
         return
 
@@ -127,19 +127,19 @@ class FixedDelayTest(unittest.TestCase):
         self.multipleFileSubscription.getFileset().markOpen(False)
         jobFactory = splitter(self.multipleFileSubscription)
         jobGroups = jobFactory(trigger_time = 1)
-        self.assertEquals(len(jobGroups), 1)
-        self.assertEquals(len(jobGroups[0].jobs),1)
+        self.assertEqual(len(jobGroups), 1)
+        self.assertEqual(len(jobGroups[0].jobs),1)
         myfiles = jobGroups[0].jobs[0].getFiles()
-        self.assertEquals(len(myfiles), 10)
+        self.assertEqual(len(myfiles), 10)
 
         self.multipleLumiSubscription.getFileset().markOpen(False)
         jobFactory = splitter(self.multipleLumiSubscription)
         jobGroups = jobFactory(trigger_time = 1)
-        self.assertEquals(len(jobGroups), 1)
-        self.assertEquals(len(jobGroups[0].jobs),1)
+        self.assertEqual(len(jobGroups), 1)
+        self.assertEqual(len(jobGroups[0].jobs),1)
         myfiles = jobGroups[0].jobs[0].getFiles()
-        self.assertEquals(len(myfiles), 10)
-        #self.assertEquals(jobGroups, [], "Should have returned a null set")
+        self.assertEqual(len(myfiles), 10)
+        #self.assertEqual(jobGroups, [], "Should have returned a null set")
 
         self.singleLumiSubscription.getFileset().markOpen(False)
         jobFactory = splitter(self.singleLumiSubscription)
@@ -150,7 +150,7 @@ class FixedDelayTest(unittest.TestCase):
         assert len(jobGroups[0].jobs) == 1, \
                "ERROR: JobFactory didn't create a single job."
         myfiles = jobGroups[0].jobs[0].getFiles()
-        self.assertEquals(len(myfiles), 10)
+        self.assertEqual(len(myfiles), 10)
 
 
     def testAllAcquired(self):
@@ -163,25 +163,25 @@ class FixedDelayTest(unittest.TestCase):
                            self.singleFileSubscription.availableFiles())
         jobFactory = splitter(self.singleFileSubscription)
         jobGroups = jobFactory(trigger_time = 1)
-        self.assertEquals(jobGroups, [], "Should have returned a null set: %s" % jobGroups)
+        self.assertEqual(jobGroups, [], "Should have returned a null set: %s" % jobGroups)
 
         self.multipleFileSubscription.acquireFiles(
                            self.multipleFileSubscription.availableFiles())
         jobFactory = splitter(self.multipleFileSubscription)
         jobGroups = jobFactory(trigger_time = 1)
-        self.assertEquals(jobGroups, [], "Should have returned a null set")
+        self.assertEqual(jobGroups, [], "Should have returned a null set")
 
         self.multipleLumiSubscription.acquireFiles(
                            self.multipleLumiSubscription.availableFiles())
         jobFactory = splitter(self.multipleLumiSubscription)
         jobGroups = jobFactory(trigger_time = 1)
-        self.assertEquals(jobGroups, [], "Should have returned a null set")
+        self.assertEqual(jobGroups, [], "Should have returned a null set")
 
         self.singleLumiSubscription.acquireFiles(
                            self.singleLumiSubscription.availableFiles())
         jobFactory = splitter(self.singleLumiSubscription)
         jobGroups = jobFactory(trigger_time = 1)
-        self.assertEquals(jobGroups, [], "Should have returned a null set")
+        self.assertEqual(jobGroups, [], "Should have returned a null set")
 
     def testClosedSomeAcquired(self):
         """
@@ -195,18 +195,18 @@ class FixedDelayTest(unittest.TestCase):
                            [self.singleFileSubscription.availableFiles().pop()])
         jobFactory = splitter(self.singleFileSubscription)
         jobGroups = jobFactory(trigger_time = 1)
-        self.assertEquals(jobGroups, [], "Should have returned a null set")
+        self.assertEqual(jobGroups, [], "Should have returned a null set")
 
         self.multipleFileSubscription.getFileset().markOpen(False)
         self.multipleFileSubscription.acquireFiles(
                            [self.multipleFileSubscription.availableFiles().pop()])
         jobFactory = splitter(self.multipleFileSubscription)
         jobGroups = jobFactory(trigger_time = 1)
-        self.assertEquals(len(jobGroups),1, "Should have gotten one jobGroup")
-        self.assertEquals(len(jobGroups[0].jobs), 1, \
+        self.assertEqual(len(jobGroups),1, "Should have gotten one jobGroup")
+        self.assertEqual(len(jobGroups[0].jobs), 1, \
                "JobFactory should have made one job")
         myfiles = jobGroups[0].jobs[0].getFiles()
-        self.assertEquals(len(myfiles), 9, \
+        self.assertEqual(len(myfiles), 9, \
                 "JobFactory should have provides us with 9 files")
 
         self.multipleLumiSubscription.getFileset().markOpen(False)
@@ -214,11 +214,11 @@ class FixedDelayTest(unittest.TestCase):
                            [self.multipleLumiSubscription.availableFiles().pop()])
         jobFactory = splitter(self.multipleLumiSubscription)
         jobGroups = jobFactory(trigger_time = 1)
-        self.assertEquals(len(jobGroups),1, "Should have gotten one jobGroup")
-        self.assertEquals(len(jobGroups[0].jobs), 1, \
+        self.assertEqual(len(jobGroups),1, "Should have gotten one jobGroup")
+        self.assertEqual(len(jobGroups[0].jobs), 1, \
                "JobFactory should have made one job")
         myfiles = jobGroups[0].jobs[0].getFiles()
-        self.assertEquals(len(myfiles), 9, \
+        self.assertEqual(len(myfiles), 9, \
                 "JobFactory should have provides us with 9 files")
 
         self.singleLumiSubscription.getFileset().markOpen(False)
@@ -226,14 +226,14 @@ class FixedDelayTest(unittest.TestCase):
                            [self.singleLumiSubscription.availableFiles().pop()])
         jobFactory = splitter(self.singleLumiSubscription)
         jobGroups = jobFactory(trigger_time = 1)
-        self.assertEquals(len(jobGroups),1, "Should have gotten one jobGroup")
-        self.assertEquals(len(jobGroups[0].jobs), 1, \
+        self.assertEqual(len(jobGroups),1, "Should have gotten one jobGroup")
+        self.assertEqual(len(jobGroups[0].jobs), 1, \
                "JobFactory should have made one job")
         myfiles = jobGroups[0].jobs[0].getFiles()
-        self.assertEquals(len(myfiles), 9, \
+        self.assertEqual(len(myfiles), 9, \
                 "JobFactory should have provides us with 9 files")
 
-        self.assertEquals(len(myfiles), 9)
+        self.assertEqual(len(myfiles), 9)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/WMCore_t/RequestManager_t/ReqMgr_t.py
+++ b/test/python/WMCore_t/RequestManager_t/ReqMgr_t.py
@@ -722,9 +722,9 @@ class ReqMgrTest(RESTBaseUnitTest):
         # shall have the same stuff in
         response = self.jsonSender.get("request/%s" % requestName)
         origRequest = response[0]
-        self.assertEquals(origRequest["AcquisitionEra"], acquisitionEra)
+        self.assertEqual(origRequest["AcquisitionEra"], acquisitionEra)
         # test that the priority was correctly set in the brand-new request
-        self.assertEquals(origRequest["RequestPriority"], priority)
+        self.assertEqual(origRequest["RequestPriority"], priority)
         
         # test cloning not existing request
         self.assertRaises(HTTPException, self.jsonSender.put, "clone/%s" % "NotExistingRequestName")
@@ -739,7 +739,7 @@ class ReqMgrTest(RESTBaseUnitTest):
         for differ in toDiffer:
             self.assertNotEqual(origRequest[differ], clonedRequest[differ])
         # check the desired status of the cloned request
-        self.assertEquals(clonedRequest["RequestStatus"], "assignment-approved",
+        self.assertEqual(clonedRequest["RequestStatus"], "assignment-approved",
                           "Cloned request status should be 'assignment-approved', not '%s'." %
                           clonedRequest["RequestStatus"])
         # don't care about these two (they will likely be the same in the unittest
@@ -750,7 +750,7 @@ class ReqMgrTest(RESTBaseUnitTest):
             del origRequest[differ]
             del clonedRequest[differ]
         # check the request dictionaries
-        self.assertEquals(len(origRequest), len(clonedRequest))
+        self.assertEqual(len(origRequest), len(clonedRequest))
         for k1, k2 in zip(sorted(origRequest.keys()), sorted(clonedRequest.keys())):
             msg = ("Request values: original: %s: %s cloned: %s: %s differ" %
                    (k1, origRequest[k1], k2, clonedRequest[k2]))

--- a/test/python/WMCore_t/ResourceControl_t/ResourceControl_t.py
+++ b/test/python/WMCore_t/ResourceControl_t/ResourceControl_t.py
@@ -780,7 +780,7 @@ class ResourceControlTest(unittest.TestCase):
         (_, _) = retval.communicate()
         myResourceControl = ResourceControl()
         result = myResourceControl.listThresholdsForSubmit()
-        self.assertEquals(len(result), 1)
+        self.assertEqual(len(result), 1)
         self.assertTrue('CERN' in result)
         for x in result:
             self.assertEqual(len(result[x]['thresholds']), 10)

--- a/test/python/WMCore_t/Services_t/RequestDB_t/RequestDB_t.py
+++ b/test/python/WMCore_t/Services_t/RequestDB_t/RequestDB_t.py
@@ -47,35 +47,35 @@ class RequestDBTest(unittest.TestCase):
         schema = generate_reqmgr_schema(3)
         result =  self.requestWriter.insertGenericRequest(schema[0])
 
-        self.assertEquals(len(result), 1, 'insert fail');
+        self.assertEqual(len(result), 1, 'insert fail');
         
-        self.assertEquals(self.requestWriter.updateRequestStatus(schema[0]['RequestName'], "failed"), 'OK', 'update fail')
-        self.assertEquals(self.requestWriter.updateRequestStatus("not_exist_schema", "assigned"),
+        self.assertEqual(self.requestWriter.updateRequestStatus(schema[0]['RequestName'], "failed"), 'OK', 'update fail')
+        self.assertEqual(self.requestWriter.updateRequestStatus("not_exist_schema", "assigned"),
                           'Error: document not found')
         result = self.requestWriter.updateRequestProperty(schema[0]['RequestName'], 
                                                                    {'Teams': ['teamA']})
-        self.assertEquals(self.requestWriter.updateRequestProperty(schema[0]['RequestName'], 
+        self.assertEqual(self.requestWriter.updateRequestProperty(schema[0]['RequestName'], 
                                                                    {'Teams': ['teamA']}), 'OK', 'update fail')
-        self.assertEquals(self.requestWriter.updateRequestProperty("not_exist_schema", {'Teams': 'teamA'}),
+        self.assertEqual(self.requestWriter.updateRequestProperty("not_exist_schema", {'Teams': 'teamA'}),
                           'Error: document not found')
         
         result = self.requestReader.getRequestByNames([schema[0]['RequestName']])
-        self.assertEquals(len(result), 1, "should be 1")
+        self.assertEqual(len(result), 1, "should be 1")
         result = self.requestReader.getRequestByStatus(["failed"], False, 1)
-        self.assertEquals(len(result), 1, "should be 1")
+        self.assertEqual(len(result), 1, "should be 1")
         
         result = self.requestReader.getStatusAndTypeByRequest([schema[0]['RequestName']])
-        self.assertEquals(result[schema[0]['RequestName']][0], 'failed', "should be failed")
+        self.assertEqual(result[schema[0]['RequestName']][0], 'failed', "should be failed")
         
         result =  self.requestWriter.insertGenericRequest(schema[1])
         time.sleep(2)
         result =  self.requestWriter.insertGenericRequest(schema[2])
         endTime = int(time.time()) - 1
         result = self.requestReader.getRequestByStatusAndStartTime("new", False, endTime)
-        self.assertEquals(len(result), 1, "should be 1")
+        self.assertEqual(len(result), 1, "should be 1")
         endTime = int(time.time()) + 1
         result = self.requestReader.getRequestByStatusAndStartTime("new", False, endTime)
-        self.assertEquals(len(result), 2, "should be 2")
+        self.assertEqual(len(result), 2, "should be 2")
       
 
 if __name__ == '__main__':

--- a/test/python/WMCore_t/Services_t/RequestDB_t/T0RequestDB_t.py
+++ b/test/python/WMCore_t/Services_t/RequestDB_t/T0RequestDB_t.py
@@ -43,27 +43,27 @@ class T0RequestDBTest(unittest.TestCase):
         schema = generate_reqmgr_schema()
         result =  self.requestWriter.insertGenericRequest(schema[0])
 
-        self.assertEquals(len(result), 1, 'insert fail');
+        self.assertEqual(len(result), 1, 'insert fail');
         
         result = self.requestWriter.updateRequestStatus(schema[0]['RequestName'], "assigned")
 
-        self.assertEquals(result, 'not allowed state assigned', 'update fail')
-        self.assertEquals(self.requestWriter.updateRequestStatus("not_exist_schema", "new"),
+        self.assertEqual(result, 'not allowed state assigned', 'update fail')
+        self.assertEqual(self.requestWriter.updateRequestStatus("not_exist_schema", "new"),
                           'Error: document not found')
         
         allowedStates = ["Closed", "Merge", "AlcaSkim", "Harvesting",  
                          "Processing Done", "completed"]
         for state in allowedStates:
-            self.assertEquals(self.requestWriter.updateRequestStatus(schema[0]['RequestName'], state),
+            self.assertEqual(self.requestWriter.updateRequestStatus(schema[0]['RequestName'], state),
                           'OK')
         
-        self.assertEquals(self.requestWriter.updateRequestStatus(schema[0]['RequestName'], "Processing Done"),
+        self.assertEqual(self.requestWriter.updateRequestStatus(schema[0]['RequestName'], "Processing Done"),
                           'not allowed transition completed to Processing Done')  
         
-        self.assertEquals(self.requestWriter.updateRequestStatus(schema[0]['RequestName'], "normal-archived"),
+        self.assertEqual(self.requestWriter.updateRequestStatus(schema[0]['RequestName'], "normal-archived"),
                           'OK')  
         result = self.requestWriter.getRequestByStatus(["normal-archived"], False, 1)
-        self.assertEquals(len(result), 1, "should be 1 but %s" % result)
+        self.assertEqual(len(result), 1, "should be 1 but %s" % result)
       
 
 if __name__ == '__main__':

--- a/test/python/WMCore_t/Services_t/Requests_t.py
+++ b/test/python/WMCore_t/Services_t/Requests_t.py
@@ -304,8 +304,8 @@ class testJSONRequests(unittest.TestCase):
     def testSpecialCharacterPasswords(self):
         url = 'http://username:p@ssw:rd@localhost:6666'
         req = JSONRequests(url)
-        self.assertEquals(req['host'], 'http://localhost:6666')
-        self.assertEquals(req.additionalHeaders['Authorization'], 'Basic dXNlcm5hbWU6cEBzc3c6cmQ=')
+        self.assertEqual(req['host'], 'http://localhost:6666')
+        self.assertEqual(req.additionalHeaders['Authorization'], 'Basic dXNlcm5hbWU6cEBzc3c6cmQ=')
 
 class TestRequests(unittest.TestCase):
 

--- a/test/python/WMCore_t/Services_t/Service_t.py
+++ b/test/python/WMCore_t/Services_t/Service_t.py
@@ -221,14 +221,14 @@ class ServiceTest(unittest.TestCase):
 
         self.logger.info('second call to refreshCache - should pass')
         data = service.refreshCache(cache, '/lies').read()
-        self.assertEquals(cacheddata, data)
+        self.assertEqual(cacheddata, data)
 
         # sleep a while so the file expires in the cache
         # FIXME: RACY
         time.sleep(2)
         self.logger.info('third call to refreshCache - should return stale cache')
         data = service.refreshCache(cache, '/lies').read()
-        self.assertEquals(cacheddata, data)
+        self.assertEqual(cacheddata, data)
 
         # sleep a while longer so the cache is dead
         # FIXME: RACY

--- a/test/python/WMCore_t/Services_t/WMStats_t/WMStats_t.py
+++ b/test/python/WMCore_t/Services_t/WMStats_t/WMStats_t.py
@@ -51,29 +51,29 @@ class WMStatsTest(unittest.TestCase):
         schema = generate_reqmgr_schema()
         
         result = self.reqDBWriter.insertGenericRequest(schema[0])
-        self.assertEquals(result[0]['ok'], True, 'insert fail')
+        self.assertEqual(result[0]['ok'], True, 'insert fail')
         
         result = self.reqDBWriter.updateRequestStatus(schema[0]['RequestName'], "failed")
-        self.assertEquals(result, 'OK', 'update fail')
+        self.assertEqual(result, 'OK', 'update fail')
         
         result = self.reqDBWriter.updateRequestStatus("not_exist_schema", "assigned") 
-        self.assertEquals(result,'Error: document not found')
+        self.assertEqual(result,'Error: document not found')
         
         result = self.reqDBWriter.updateRequestProperty(schema[0]['RequestName'], {"Teams": ['teamA']})
-        self.assertEquals(result, 'OK', 'update fail')
+        self.assertEqual(result, 'OK', 'update fail')
         
         result = self.reqDBWriter.updateRequestProperty("not_exist_schema", {"Teams": ['teamA']})                  
-        self.assertEquals(result, 'Error: document not found')
+        self.assertEqual(result, 'Error: document not found')
         
         totalStats = {'TotalEstimatedJobs': 100, 'TotalInputEvents': 1000, 'TotalInputLumis': 1234, 'TotalInputFiles': 5}
         result = self.reqDBWriter.updateRequestProperty(schema[0]['RequestName'], totalStats)
-        self.assertEquals(result, 'OK', 'update fail')
+        self.assertEqual(result, 'OK', 'update fail')
         
         result = self.reqDBWriter.updateRequestProperty(schema[0]['RequestName'], totalStats)
-        self.assertEquals(result, 'OK', 'update fail')
+        self.assertEqual(result, 'OK', 'update fail')
         
         result = self.reqDBWriter.updateRequestProperty("not_exist_schema", totalStats)
-        self.assertEquals(result, 'Error: document not found')
+        self.assertEqual(result, 'Error: document not found')
         
         spec1 = newWorkload(schema[0]['RequestName'])
         production = spec1.newTask("Production")
@@ -83,7 +83,7 @@ class WMStatsTest(unittest.TestCase):
                       'SiteWhitelist': spec1.getTopLevelTask()[0].siteWhitelist(),
                       'OutputDatasets': spec1.listOutputDatasets()}
         result = self.reqDBWriter.updateRequestProperty(spec1.name(), properties)
-        self.assertEquals(result, 'OK', 'update fail')
+        self.assertEqual(result, 'OK', 'update fail')
         
         spec2 = newWorkload("not_exist_schema")
         production = spec2.newTask("Production")
@@ -92,22 +92,22 @@ class WMStatsTest(unittest.TestCase):
                       'SiteWhitelist': spec2.getTopLevelTask()[0].siteWhitelist(),
                       'OutputDatasets': spec2.listOutputDatasets()}
         result = self.reqDBWriter.updateRequestProperty(spec2.name(), properties)
-        self.assertEquals(result, 'Error: document not found')
+        self.assertEqual(result, 'Error: document not found')
 
         requests = self.wmstatsReader.getRequestByStatus(["failed"], jobInfoFlag = False, legacyFormat = True)
-        self.assertEquals(requests.keys(), [schema[0]['RequestName']])
+        self.assertEqual(requests.keys(), [schema[0]['RequestName']])
         
         requestCollection = RequestInfoCollection(requests)
         result = requestCollection.getJSONData()
-        self.assertEquals(result.keys(), [schema[0]['RequestName']])
+        self.assertEqual(result.keys(), [schema[0]['RequestName']])
         
         requests = self.wmstatsReader.getActiveData()
-        self.assertEquals(requests.keys(), [schema[0]['RequestName']])
+        self.assertEqual(requests.keys(), [schema[0]['RequestName']])
         requests = self.wmstatsReader.getRequestByStatus(["failed"])
-        self.assertEquals(requests.keys(), [schema[0]['RequestName']])
+        self.assertEqual(requests.keys(), [schema[0]['RequestName']])
         
         requests = self.wmstatsReader.getRequestSummaryWithJobInfo(schema[0]['RequestName'])
-        self.assertEquals(requests.keys(), [schema[0]['RequestName']])
+        self.assertEqual(requests.keys(), [schema[0]['RequestName']])
         
 
 if __name__ == '__main__':

--- a/test/python/WMCore_t/Services_t/pycurlFileUpload_t.py
+++ b/test/python/WMCore_t/Services_t/pycurlFileUpload_t.py
@@ -38,7 +38,7 @@ class PyCurlRESTServer(RESTBaseUnitTest):
         res = self.requestHandler.uploadFile(fileName, 'http://127.0.0.1:8888/unittests/rest/file/')
         # the file is there now (?)
         self.assertTrue(os.path.isfile(uploadedFilename))
-        self.assertEquals(open(uploadedFilename).read(), open(fileName).read())
+        self.assertEqual(open(uploadedFilename).read(), open(fileName).read())
         # delete the uploaded file
         os.remove(uploadedFilename)
         self.assertTrue('Success' in res)

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/FixedDelay_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/FixedDelay_t.py
@@ -124,19 +124,19 @@ class FixedDelayTest(unittest.TestCase):
         splitter = SplitterFactory()
         jobFactory = splitter(self.singleFileSubscription)
         jobGroups = jobFactory(trigger_time = int(time.time())*2)
-        self.assertEquals(jobGroups, [], "Should have returned a null set")
+        self.assertEqual(jobGroups, [], "Should have returned a null set")
 
         jobFactory = splitter(self.multipleFileSubscription)
         jobGroups = jobFactory(trigger_time = int(time.time())*2)
-        self.assertEquals(jobGroups, [], "Should have returned a null set")
+        self.assertEqual(jobGroups, [], "Should have returned a null set")
 
         jobFactory = splitter(self.multipleLumiSubscription)
         jobGroups = jobFactory(trigger_time = int(time.time())*2)
-        self.assertEquals(jobGroups, [], "Should have returned a null set")
+        self.assertEqual(jobGroups, [], "Should have returned a null set")
 
         jobFactory = splitter(self.singleLumiSubscription)
         jobGroups = jobFactory(trigger_time = int(time.time())*2)
-        self.assertEquals(jobGroups, [], "Should have returned a null set")
+        self.assertEqual(jobGroups, [], "Should have returned a null set")
 
         return
 
@@ -166,19 +166,19 @@ class FixedDelayTest(unittest.TestCase):
         jobFactory = splitter(self.multipleFileSubscription)
         jobGroups = jobFactory(trigger_time = 1)
 
-        self.assertEquals(len(jobGroups), 1)
-        self.assertEquals(len(jobGroups[0].jobs),1)
+        self.assertEqual(len(jobGroups), 1)
+        self.assertEqual(len(jobGroups[0].jobs),1)
         myfiles = jobGroups[0].jobs[0].getFiles()
-        self.assertEquals(len(myfiles), 10)
+        self.assertEqual(len(myfiles), 10)
 
         self.multipleLumiSubscription.getFileset().markOpen(False)
         jobFactory = splitter(self.multipleLumiSubscription)
         jobGroups = jobFactory(trigger_time = 1)
-        self.assertEquals(len(jobGroups), 1)
-        self.assertEquals(len(jobGroups[0].jobs),1)
+        self.assertEqual(len(jobGroups), 1)
+        self.assertEqual(len(jobGroups[0].jobs),1)
         myfiles = jobGroups[0].jobs[0].getFiles()
-        self.assertEquals(len(myfiles), 10)
-        #self.assertEquals(jobGroups, [], "Should have returned a null set")
+        self.assertEqual(len(myfiles), 10)
+        #self.assertEqual(jobGroups, [], "Should have returned a null set")
 
         self.singleLumiSubscription.getFileset().markOpen(False)
         jobFactory = splitter(self.singleLumiSubscription)
@@ -189,7 +189,7 @@ class FixedDelayTest(unittest.TestCase):
         assert len(jobGroups[0].jobs) == 1, \
                "ERROR: JobFactory didn't create a single job."
         myfiles = jobGroups[0].jobs[0].getFiles()
-        self.assertEquals(len(myfiles), 10)
+        self.assertEqual(len(myfiles), 10)
 
 
     def testAllAcquired(self):
@@ -202,25 +202,25 @@ class FixedDelayTest(unittest.TestCase):
                            self.singleFileSubscription.availableFiles())
         jobFactory = splitter(self.singleFileSubscription)
         jobGroups = jobFactory(trigger_time = 1)
-        self.assertEquals(jobGroups, [], "Should have returned a null set")
+        self.assertEqual(jobGroups, [], "Should have returned a null set")
 
         self.multipleFileSubscription.acquireFiles(
                            self.multipleFileSubscription.availableFiles())
         jobFactory = splitter(self.multipleFileSubscription)
         jobGroups = jobFactory(trigger_time = 1)
-        self.assertEquals(jobGroups, [], "Should have returned a null set")
+        self.assertEqual(jobGroups, [], "Should have returned a null set")
 
         self.multipleLumiSubscription.acquireFiles(
                            self.multipleLumiSubscription.availableFiles())
         jobFactory = splitter(self.multipleLumiSubscription)
         jobGroups = jobFactory(trigger_time = 1)
-        self.assertEquals(jobGroups, [], "Should have returned a null set")
+        self.assertEqual(jobGroups, [], "Should have returned a null set")
 
         self.singleLumiSubscription.acquireFiles(
                            self.singleLumiSubscription.availableFiles())
         jobFactory = splitter(self.singleLumiSubscription)
         jobGroups = jobFactory(trigger_time = 1)
-        self.assertEquals(jobGroups, [], "Should have returned a null set")
+        self.assertEqual(jobGroups, [], "Should have returned a null set")
 
     def testClosedSomeAcquired(self):
         """
@@ -235,7 +235,7 @@ class FixedDelayTest(unittest.TestCase):
                            [self.singleFileSubscription.availableFiles().pop()])
         jobFactory = splitter(self.singleFileSubscription)
         jobGroups = jobFactory(trigger_time = 1)
-        self.assertEquals(jobGroups, [], "Should have returned a null set")
+        self.assertEqual(jobGroups, [], "Should have returned a null set")
 
 
 
@@ -244,11 +244,11 @@ class FixedDelayTest(unittest.TestCase):
                            [self.multipleFileSubscription.availableFiles().pop()])
         jobFactory = splitter(package = "WMCore.WMBS", subscription =self.multipleFileSubscription)
         jobGroups = jobFactory(trigger_time = 1)
-        self.assertEquals(len(jobGroups),1, "Should have gotten one jobGroup")
-        self.assertEquals(len(jobGroups[0].jobs), 1, \
+        self.assertEqual(len(jobGroups),1, "Should have gotten one jobGroup")
+        self.assertEqual(len(jobGroups[0].jobs), 1, \
                "JobFactory should have made one job")
         myfiles = jobGroups[0].jobs[0].getFiles()
-        self.assertEquals(len(myfiles), 9, \
+        self.assertEqual(len(myfiles), 9, \
                 "JobFactory should have provides us with 9 files")
 
         self.multipleLumiSubscription.getFileset().markOpen(False)
@@ -256,11 +256,11 @@ class FixedDelayTest(unittest.TestCase):
                            [self.multipleLumiSubscription.availableFiles().pop()])
         jobFactory = splitter(self.multipleLumiSubscription)
         jobGroups = jobFactory(trigger_time = 1)
-        self.assertEquals(len(jobGroups),1, "Should have gotten one jobGroup")
-        self.assertEquals(len(jobGroups[0].jobs), 1, \
+        self.assertEqual(len(jobGroups),1, "Should have gotten one jobGroup")
+        self.assertEqual(len(jobGroups[0].jobs), 1, \
                "JobFactory should have made one job")
         myfiles = jobGroups[0].jobs[0].getFiles()
-        self.assertEquals(len(myfiles), 9, \
+        self.assertEqual(len(myfiles), 9, \
                 "JobFactory should have provides us with 9 files")
 
         self.singleLumiSubscription.getFileset().markOpen(False)
@@ -268,14 +268,14 @@ class FixedDelayTest(unittest.TestCase):
                            [self.singleLumiSubscription.availableFiles().pop()])
         jobFactory = splitter(self.singleLumiSubscription)
         jobGroups = jobFactory(trigger_time = 1)
-        self.assertEquals(len(jobGroups),1, "Should have gotten one jobGroup")
-        self.assertEquals(len(jobGroups[0].jobs), 1, \
+        self.assertEqual(len(jobGroups),1, "Should have gotten one jobGroup")
+        self.assertEqual(len(jobGroups[0].jobs), 1, \
                "JobFactory should have made one job")
         myfiles = jobGroups[0].jobs[0].getFiles()
-        self.assertEquals(len(myfiles), 9, \
+        self.assertEqual(len(myfiles), 9, \
                 "JobFactory should have provides us with 9 files")
 
-        self.assertEquals(len(myfiles), 9)
+        self.assertEqual(len(myfiles), 9)
 
 
 if __name__ == '__main__':

--- a/test/python/WMCore_t/WMBS_t/Job_t.py
+++ b/test/python/WMCore_t/WMBS_t/Job_t.py
@@ -1153,30 +1153,30 @@ class JobTest(unittest.TestCase):
         for inFile in jobAprime['input_files']:
             if inFile['lfn'] == '/this/is/a/lfnA':
                 run = inFile['runs'].pop()
-                self.assertEquals(run.run, 1, 'The run number is wrong')
-                self.assertEquals(run.lumis, [45], 'The lumis are wrong')
+                self.assertEqual(run.run, 1, 'The run number is wrong')
+                self.assertEqual(run.lumis, [45], 'The lumis are wrong')
             else:
                 run = inFile['runs'].pop()
-                self.assertEquals(run.run, 1, 'The run number is wrong')
-                self.assertEquals(run.lumis, [46], 'The lumis are wrong')
+                self.assertEqual(run.run, 1, 'The run number is wrong')
+                self.assertEqual(run.lumis, [46], 'The lumis are wrong')
 
         mask = jobAprime['mask']
-        self.assertEquals(mask['runAndLumis'], {1 : [[45, 45]]}, "Wrong run and lumis in mask")
+        self.assertEqual(mask['runAndLumis'], {1 : [[45, 45]]}, "Wrong run and lumis in mask")
 
         jobBprime = jobs[1]
         for inFile in jobBprime['input_files']:
             if inFile['lfn'] == '/this/is/a/lfnA':
                 run = inFile['runs'].pop()
-                self.assertEquals(run.run, 1, 'The run number is wrong')
-                self.assertEquals(run.lumis, [45], 'The lumis are wrong')
+                self.assertEqual(run.run, 1, 'The run number is wrong')
+                self.assertEqual(run.lumis, [45], 'The lumis are wrong')
             else:
                 run = inFile['runs'].pop()
-                self.assertEquals(run.run, 1, 'The run number is wrong')
-                self.assertEquals(run.lumis, [46], 'The lumis are wrong')
+                self.assertEqual(run.run, 1, 'The run number is wrong')
+                self.assertEqual(run.lumis, [46], 'The lumis are wrong')
         runs = []
         for inputFile in jobBprime['input_files']:
             runs.extend(inputFile.getRuns())
-        self.assertEquals(jobBprime['mask'].filterRunLumisByMask(runs = runs), runs, "Wrong mask in jobB")
+        self.assertEqual(jobBprime['mask'].filterRunLumisByMask(runs = runs), runs, "Wrong mask in jobB")
 
         return
 

--- a/test/python/WMCore_t/WMBS_t/Subscription_t.py
+++ b/test/python/WMCore_t/WMBS_t/Subscription_t.py
@@ -1500,44 +1500,44 @@ class SubscriptionTest(unittest.TestCase):
         testSubscription.create()
 
         availableFiles = testSubscription.filesOfStatus("Available")
-        self.assertEquals(len(availableFiles), 6)
+        self.assertEqual(len(availableFiles), 6)
         availableFiles = testSubscription.filesOfStatus("Available", 0)
-        self.assertEquals(len(availableFiles), 6)
+        self.assertEqual(len(availableFiles), 6)
         availableFiles = testSubscription.filesOfStatus("Available", 3)
-        self.assertEquals(len(availableFiles), 3)
+        self.assertEqual(len(availableFiles), 3)
         availableFiles = testSubscription.filesOfStatus("Available", 7)
-        self.assertEquals(len(availableFiles), 6)
+        self.assertEqual(len(availableFiles), 6)
 
 
         testSubscription.acquireFiles([testFileA, testFileB, testFileC, testFileD])
         availableFiles = testSubscription.filesOfStatus("Available", 6)
-        self.assertEquals(len(availableFiles), 2)
+        self.assertEqual(len(availableFiles), 2)
 
         files = testSubscription.filesOfStatus("Acquired", 0)
-        self.assertEquals(len(files), 4)
+        self.assertEqual(len(files), 4)
         files = testSubscription.filesOfStatus("Acquired", 2)
-        self.assertEquals(len(files), 2)
+        self.assertEqual(len(files), 2)
         files = testSubscription.filesOfStatus("Acquired", 6)
-        self.assertEquals(len(files), 4)
+        self.assertEqual(len(files), 4)
 
 
         testSubscription.completeFiles([testFileB, testFileC])
 
         files = testSubscription.filesOfStatus("Completed", 0)
-        self.assertEquals(len(files), 2)
+        self.assertEqual(len(files), 2)
         files = testSubscription.filesOfStatus("Completed", 1)
-        self.assertEquals(len(files), 1)
+        self.assertEqual(len(files), 1)
         files = testSubscription.filesOfStatus("Completed", 6)
-        self.assertEquals(len(files), 2)
+        self.assertEqual(len(files), 2)
 
         testSubscription.failFiles([testFileA, testFileE])
 
         files = testSubscription.filesOfStatus("Failed", 0)
-        self.assertEquals(len(files), 2)
+        self.assertEqual(len(files), 2)
         files = testSubscription.filesOfStatus("Failed", 1)
-        self.assertEquals(len(files), 1)
+        self.assertEqual(len(files), 1)
         files = testSubscription.filesOfStatus("Failed", 6)
-        self.assertEquals(len(files), 2)
+        self.assertEqual(len(files), 2)
 
 
         testSubscription.delete()
@@ -1742,10 +1742,10 @@ class SubscriptionTest(unittest.TestCase):
         finishedDAO = daoFactory(classname = "Subscriptions.GetFinishedSubscriptions")
         finishedSubs = finishedDAO.execute()
 
-        self.assertEquals(len(finishedSubs), 2,
+        self.assertEqual(len(finishedSubs), 2,
                           "Error: Wrong number of finished subscriptions.")
 
-        self.assertEquals(finishedSubs[0]["id"], testSubscription1["id"],
+        self.assertEqual(finishedSubs[0]["id"], testSubscription1["id"],
                           "Error: Wrong subscription id.")
 
         #Mark all output filesets which are input of another subscription as closed
@@ -1757,7 +1757,7 @@ class SubscriptionTest(unittest.TestCase):
         newFinishedDAO.execute(self.stateID)
         finishedSubs = finishedDAO.execute()
 
-        self.assertEquals(len(finishedSubs), 4,
+        self.assertEqual(len(finishedSubs), 4,
                           "Error: Wrong number of finished subscriptions.")
 
         return

--- a/test/python/WMCore_t/WMBS_t/Subscription_t.py
+++ b/test/python/WMCore_t/WMBS_t/Subscription_t.py
@@ -5,25 +5,21 @@ _Subscription_t_
 Unit tests for the WMBS Subscription class and all it's DAOs.
 """
 
-import unittest
-import logging
-import random
 import threading
 import time
+import unittest
 
 from WMCore.DAOFactory import DAOFactory
-from WMQuality.TestInit import TestInit
-
+from WMCore.DataStructs.Run import Run
+from WMCore.WMBS.CreateWMBSBase import CreateWMBSBase
 from WMCore.WMBS.File import File
 from WMCore.WMBS.Fileset import Fileset
 from WMCore.WMBS.Job import Job
 from WMCore.WMBS.JobGroup import JobGroup
 from WMCore.WMBS.Subscription import Subscription
 from WMCore.WMBS.Workflow import Workflow
+from WMQuality.TestInit import TestInit
 
-from WMCore.DataStructs.Run import Run
-
-from WMCore.WMBS.CreateWMBSBase import CreateWMBSBase
 
 class SubscriptionTest(unittest.TestCase):
     def setUp(self):
@@ -814,32 +810,23 @@ class SubscriptionTest(unittest.TestCase):
         testSubscriptionB.load()
         testSubscriptionC.load()
 
-        assert type(testSubscriptionB["id"]) == int, \
-               "ERROR: Subscription id is not an int."
+        self.assertTrue(isinstance(testSubscriptionB["id"], int),
+                        "ERROR: Subscription id is not an int.")
+        self.assertTrue(isinstance(testSubscriptionB["workflow"].id, int),
+                        "ERROR: Subscription workflow id is not an int.")
+        self.assertTrue(isinstance(testSubscriptionC["workflow"].id, int),
+                        "ERROR: Subscription workflow id is not an int.")
+        self.assertTrue(isinstance(testSubscriptionB["fileset"].id, int),
+                        "ERROR: Subscription fileset id is not an int.")
+        self.assertTrue(isinstance(testSubscriptionC["fileset"].id, int),
+                        "ERROR: Subscription fileset id is not an int.")
 
-        assert type(testSubscriptionC["id"]) == int, \
-               "ERROR: Subscription id is not an int."
-
-        assert type(testSubscriptionB["workflow"].id) == int, \
-               "ERROR: Subscription workflow id is not an int."
-
-        assert type(testSubscriptionC["workflow"].id) == int, \
-               "ERROR: Subscription workflow id is not an int."
-
-        assert type(testSubscriptionB["fileset"].id) == int, \
-               "ERROR: Subscription fileset id is not an int."
-
-        assert type(testSubscriptionC["fileset"].id) == int, \
-               "ERROR: Subscription fileset id is not an int."
-
-        assert testWorkflow.id == testSubscriptionB["workflow"].id, \
-               "ERROR: Subscription load by ID didn't load workflow correctly"
-
-        assert testFileset.id == testSubscriptionB["fileset"].id, \
-               "ERROR: Subscription load by ID didn't load fileset correctly"
-
-        assert testSubscriptionA["id"] == testSubscriptionC["id"], \
-               "ERROR: Subscription didn't load ID correctly."
+        self.assertEqual(testWorkflow.id, testSubscriptionB["workflow"].id,
+                         "ERROR: Subscription load by ID didn't load workflow correctly")
+        self.assertEqual(testFileset.id, testSubscriptionB["fileset"].id,
+                         "ERROR: Subscription load by ID didn't load fileset correctly")
+        self.assertEqual(testSubscriptionA["id"], testSubscriptionC["id"],
+                         "ERROR: Subscription didn't load ID correctly.")
 
         return
 

--- a/test/python/WMCore_t/WMBS_t/Workflow_t.py
+++ b/test/python/WMCore_t/WMBS_t/Workflow_t.py
@@ -498,7 +498,7 @@ class WorkflowTest(unittest.TestCase):
 
         getFinishedDAO = daoFactory(classname = "Workflow.GetFinishedWorkflows")
         result = getFinishedDAO.execute()
-        self.assertEquals(len(result), 0, "A workflow is incorrectly flagged as finished: %s" % str(result))
+        self.assertEqual(len(result), 0, "A workflow is incorrectly flagged as finished: %s" % str(result))
 
         #Mark the first 50 subscriptions as finished
         for idx, sub in enumerate(subscriptions):
@@ -508,7 +508,7 @@ class WorkflowTest(unittest.TestCase):
 
         #No workflow is finished, none of them has all the subscriptions completed
         result = getFinishedDAO.execute()
-        self.assertEquals(len(result), 0, "A workflow is incorrectly flagged as finished: %s" % str(result))
+        self.assertEqual(len(result), 0, "A workflow is incorrectly flagged as finished: %s" % str(result))
 
         #Now finish all workflows in wf{000-5}
         for idx, sub in enumerate(subscriptions):
@@ -518,20 +518,20 @@ class WorkflowTest(unittest.TestCase):
 
         #Check the workflows
         result = getFinishedDAO.execute()
-        self.assertEquals(len(result), 6, "A workflow is incorrectly flagged as finished: %s" % str(result))
+        self.assertEqual(len(result), 6, "A workflow is incorrectly flagged as finished: %s" % str(result))
 
         #Check the overall structure of the workflows
         for wf in result:
             #Sanity checks on the results
             # These are very specific checks and depends heavily on the names of task, spec and workflow
-            self.assertEquals(wf[2:], result[wf]['spec'][2:],
+            self.assertEqual(wf[2:], result[wf]['spec'][2:],
                             "A workflow has the wrong spec-name combination: %s" % str(wf))
             self.assertTrue(int(wf[2:]) < 6,
                             "A workflow is incorrectly flagged as finished: %s" % str(wf))
-            self.assertEquals(len(result[wf]['workflows']), 10,
+            self.assertEqual(len(result[wf]['workflows']), 10,
                               "A workflow has more tasks than it should: %s" % str(result[wf]))
             for task in result[wf]['workflows']:
-                self.assertEquals(len(result[wf]['workflows'][task]), 1,
+                self.assertEqual(len(result[wf]['workflows'][task]), 1,
                                   "A workflow has more subscriptions than it should: %s" % str(result[wf]))
 
         return

--- a/test/python/WMCore_t/WMRuntime_t/SandboxCreator_t.py
+++ b/test/python/WMCore_t/WMRuntime_t/SandboxCreator_t.py
@@ -90,7 +90,7 @@ class SandboxCreator_t(unittest.TestCase):
     def fileExistsTest(self,file,msg = None):
         if (msg == None):
             msg = "Failed file existence test for (%s)" % file
-        self.assertEquals(os.path.exists(file),True,msg)
+        self.assertEqual(os.path.exists(file),True,msg)
 
     def setUp(self):
         # need to take a slice to make a real copy

--- a/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
@@ -928,15 +928,15 @@ class WMWorkloadTest(unittest.TestCase):
         outputDatasets = testWorkload.listOutputDatasets()
         for outputDataset in outputDatasets:
             datasetSub = subInformation[outputDataset]
-            self.assertEquals(datasetSub["CustodialSites"], ["CMSSite_1"],
+            self.assertEqual(datasetSub["CustodialSites"], ["CMSSite_1"],
                               "Wrong custodial sites for %s" % outputDataset)
-            self.assertEquals(datasetSub["NonCustodialSites"], ["CMSSite_2"],
+            self.assertEqual(datasetSub["NonCustodialSites"], ["CMSSite_2"],
                               "Wrong non-custodial sites for %s" % outputDataset)
-            self.assertEquals(datasetSub["AutoApproveSites"], [], "Wrong auto-approve sites for %s" % outputDataset)
-            self.assertEquals(datasetSub["Priority"], "Low", "Wrong priority for %s" % outputDataset)
-            self.assertEquals(datasetSub["CustodialSubType"], "Replica",
+            self.assertEqual(datasetSub["AutoApproveSites"], [], "Wrong auto-approve sites for %s" % outputDataset)
+            self.assertEqual(datasetSub["Priority"], "Low", "Wrong priority for %s" % outputDataset)
+            self.assertEqual(datasetSub["CustodialSubType"], "Replica",
                               "Wrong custodial subscription type for %s" % outputDataset)
-            self.assertEquals(datasetSub["NonCustodialSubType"], "Replica",
+            self.assertEqual(datasetSub["NonCustodialSubType"], "Replica",
                               "Wrong custodial subscription type for %s" % outputDataset)
 
         testWorkload.setSubscriptionInformation(custodialSites=["CMSSite_1", "CMSSite_2"],
@@ -946,16 +946,16 @@ class WMWorkloadTest(unittest.TestCase):
         subInformation = testWorkload.getSubscriptionInformation()
         for outputDataset in outputDatasets:
             datasetSub = subInformation[outputDataset]
-            self.assertEquals(set(datasetSub["CustodialSites"]), set(["CMSSite_1", "CMSSite_2"]),
+            self.assertEqual(set(datasetSub["CustodialSites"]), set(["CMSSite_1", "CMSSite_2"]),
                               "Wrong custodial sites for %s" % outputDataset)
-            self.assertEquals(datasetSub["NonCustodialSites"], ["CMSSite_3"],
+            self.assertEqual(datasetSub["NonCustodialSites"], ["CMSSite_3"],
                               "Wrong non-custodial sites for %s" % outputDataset)
-            self.assertEquals(datasetSub["AutoApproveSites"], ["CMSSite_2"],
+            self.assertEqual(datasetSub["AutoApproveSites"], ["CMSSite_2"],
                               "Wrong auto-approve sites for %s" % outputDataset)
-            self.assertEquals(datasetSub["Priority"], "Normal", "Wrong priority for %s" % outputDataset)
-            self.assertEquals(datasetSub["CustodialSubType"], "Move",
+            self.assertEqual(datasetSub["Priority"], "Normal", "Wrong priority for %s" % outputDataset)
+            self.assertEqual(datasetSub["CustodialSubType"], "Move",
                               "Wrong custodial subscription type for %s" % outputDataset)
-            self.assertEquals(datasetSub["NonCustodialSubType"], "Move",
+            self.assertEqual(datasetSub["NonCustodialSubType"], "Move",
                               "Wrong custodial subscription type for %s" % outputDataset)
         return
 
@@ -1470,7 +1470,7 @@ class WMWorkloadTest(unittest.TestCase):
         self.assertTrue(testWorkload.getTaskByPath("/TestWorkload/ProcessingTask/MergeTask2/SkimTask"),
                         "Error: Skim task is not available")
 
-        self.assertEquals(procTaskCmssw.getIgnoredOutputModules(), ["badOutput"])
+        self.assertEqual(procTaskCmssw.getIgnoredOutputModules(), ["badOutput"])
         return
 
     def testSetCMSSWParams(self):

--- a/test/python/WMCore_t/WebTools_t/REST_t.py
+++ b/test/python/WMCore_t/WebTools_t/REST_t.py
@@ -67,8 +67,8 @@ class RESTTest(RESTBaseUnitTest):
         output={'code':200}
         data, _ = methodTest('GET', url, accept='text/json', output=output)
         data = json.loads(data)
-        self.assertEquals(type(data), list)
-        self.assertEquals(type(data[0]), dict)
+        self.assertEqual(type(data), list)
+        self.assertEqual(type(data[0]), dict)
 
     def testUnsupportedFormat(self):
         # test not accepted type should return 406 error
@@ -148,13 +148,13 @@ class RESTTest(RESTBaseUnitTest):
         urllib_data = urllib.urlopen(url)
         if self.do_production:
             #production mode returns 403 error
-            self.assertEquals(urllib_data.getcode(), 403)
+            self.assertEqual(urllib_data.getcode(), 403)
         else:
             response_data = urllib_data.read()
             response_data = json.loads(response_data)
-            self.assertEquals(response_data['type'], expected_data['type'])
-            self.assertEquals(response_data['message'], expected_data['message'])
-            self.assertEquals(urllib_data.getcode(), 400)
+            self.assertEqual(response_data['type'], expected_data['type'])
+            self.assertEqual(response_data['message'], expected_data['message'])
+            self.assertEqual(urllib_data.getcode(), 400)
 
     def testList(self):
         verb ='GET'
@@ -368,7 +368,7 @@ class RESTTest(RESTBaseUnitTest):
         verb ='PUT'
         url = self.urlbase + 'list1'
         urllib_data = urllib.urlopen(url)
-        self.assertEquals(urllib_data.getcode(), 403)
+        self.assertEqual(urllib_data.getcode(), 403)
 
         # pass proper role
         output={'code':200}

--- a/test/python/WMCore_t/WebTools_t/Root_t.py
+++ b/test/python/WMCore_t/WebTools_t/Root_t.py
@@ -116,7 +116,7 @@ class RootTest():
         server = Root(config)
 
         server.start(blocking=False)
-        self.assertEquals(cpconfig['tools.proxy.base'], test_proxy_base)
+        self.assertEqual(cpconfig['tools.proxy.base'], test_proxy_base)
         server.stop()
 
     def testShortHandProxyBase(self):
@@ -132,7 +132,7 @@ class RootTest():
         server = Root(config)
 
         server.start(blocking=False)
-        self.assertEquals(cpconfig['tools.proxy.base'], test_proxy_base)
+        self.assertEqual(cpconfig['tools.proxy.base'], test_proxy_base)
         server.stop()
 
     def testLongHandChangePort(self):
@@ -148,7 +148,7 @@ class RootTest():
 
         server = Root(config)
         server.start(blocking=False)
-        self.assertEquals(cpconfig['server.socket_port'], test_port)
+        self.assertEqual(cpconfig['server.socket_port'], test_port)
         server.stop()
 
     def testShortHandChangePort(self):
@@ -163,7 +163,7 @@ class RootTest():
 
         server = Root(config)
         server.start(blocking=False)
-        self.assertEquals(cpconfig['server.socket_port'], test_port)
+        self.assertEqual(cpconfig['server.socket_port'], test_port)
         server.stop()
 
     def testShortHandPortOverride(self):
@@ -182,7 +182,7 @@ class RootTest():
 
         server = Root(config)
         server.start(blocking=False)
-        self.assertEquals(cpconfig['server.socket_port'], test_port)
+        self.assertEqual(cpconfig['server.socket_port'], test_port)
         server.stop()
 
     def testSecuritySetting(self):
@@ -202,10 +202,10 @@ class RootTest():
         config.Webtools.environment = "production"
         server = Root(config)
         server.start(blocking=False)
-        self.assertEquals(cpconfig['tools.secmodv2.on'], True)
-        self.assertEquals(cpconfig['tools.secmodv2.role'], testRole)
-        self.assertEquals(cpconfig['tools.secmodv2.group'], testGroup)
-        self.assertEquals(cpconfig['tools.secmodv2.site'], testSite)
+        self.assertEqual(cpconfig['tools.secmodv2.on'], True)
+        self.assertEqual(cpconfig['tools.secmodv2.role'], testRole)
+        self.assertEqual(cpconfig['tools.secmodv2.group'], testGroup)
+        self.assertEqual(cpconfig['tools.secmodv2.site'], testSite)
         server.stop()
 
     def testInstanceInUrl(self):
@@ -239,13 +239,13 @@ class RootTest():
         for instance in config.UnitTests.instances:
             url = 'http://127.0.0.1:%s/unittests/%s/test' % (cpconfig['server.socket_port'], instance)
             html = urllib2.urlopen(url).read()
-            self.assertEquals(html, instance)
+            self.assertEqual(html, instance)
             db_url = '%s/database' % url
             html = urllib2.urlopen(db_url).read()
-            self.assertEquals(html, db_instances.section_(instance).connectUrl)
+            self.assertEqual(html, db_instances.section_(instance).connectUrl)
             sec_url = '%s/security' % url
             html = urllib2.urlopen(sec_url).read()
-            self.assertEquals(html, security_instances.section_(instance).sec_params)
+            self.assertEqual(html, security_instances.section_(instance).sec_params)
         server.stop()
 
     def testUsingFilterTool(self):


### PR DESCRIPTION
assertEquals is deprecated in python 2.7 (and not preferred for ages). There are a few outstanding that I will convert to assertTrue/False
