### PR TITLE
Add {un}mergedLFNBase to the workload cache

### DIFF
--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
@@ -444,6 +444,8 @@ class Assign(WebAPI):
                                        "OutputDatasets": outputDatasets,
                                        "SiteWhitelist": whiteList,
                                        "SiteBlacklist": blackList,
+                                       "MergedLFNBase": kwargs["MergedLFNBase"],
+                                       "UnmergedLFNBase": kwargs["UnmergedLFNBase"],
                                        "Dashboard": kwargs.get("Dashboard", ""),
                                        "TrustSitelists": kwargs.get("TrustSitelists", False),
                                        "AllowOpportunistic": kwargs.get("AllowOpportunistic", False)},


### PR DESCRIPTION
It seems this info is available in workload_cache docs only when it's provided during request creation.
If it's not, but only during assignment, then we don't get these key/value pairs in the cache doc.

It will always be available from now on, forever ;)

@ticoann please review. I just did a test in my VM and it works. Let us push this to current testbed please.
