### PR TITLE
Promote block names to unicode to help mock DBS

### DIFF
--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -631,6 +631,7 @@ class DBS3Reader:
 
 
         """
+        fileBlockName = unicode(fileBlockName)
         if not self.blockExists(fileBlockName):
             msg = "DBSReader.getFileBlock(%s): No matching data"
             raise DBSReaderError(msg % fileBlockName)


### PR DESCRIPTION
Otherwise we have to double the size of the data file for u'block' and 'block'
