### PR TITLE
add support to call condor_chirp at runtime

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Executor.py
+++ b/src/python/WMCore/WMSpec/Steps/Executor.py
@@ -7,7 +7,10 @@ Interface definition for a step executor
 
 """
 
+import os
 import sys
+import json
+import subprocess
 
 from WMCore.FwkJobReport.Report import Report
 from WMCore.WMSpec.WMStep import WMStepHelper
@@ -25,7 +28,6 @@ def getStepSpace(stepName):
     you use it
 
     """
-
     modName = "WMTaskSpace"
     if modName in sys.modules.keys():
         taskspace = sys.modules[modName]
@@ -47,7 +49,6 @@ def getStepSpace(stepName):
         msg += str(ex)
         raise RuntimeError(msg)
     return stepSpace
-
 
 
 class Executor:
@@ -104,11 +105,6 @@ class Executor:
             self.emulator.initialise(self)
             self.emulationMode = True
 
-
-
-
-
-
         return
 
 
@@ -123,7 +119,6 @@ class Executor:
         return
 
 
-
     def pre(self, emulator = None):
         """
         _pre_
@@ -136,6 +131,7 @@ class Executor:
 
         """
         return None
+
 
     def execute(self, emulator = None):
         """
@@ -163,3 +159,26 @@ class Executor:
 
         """
         return None
+
+
+    def setCondorChirpAttrDelayed(self, key, value):
+        """
+        _setCondorChirpAttrDelayed_
+
+        Util to call condor_chirp and publish the key/value pair
+
+        """
+        # construct condor_chirp binary location from CONDOR_CONFIG
+        condor_chirp_bin = None
+        condor_config = os.getenv('CONDOR_CONFIG', None)
+        if condor_config:
+            condor_config_dir = os.path.dirname(condor_config)
+            condor_chirp_bin = os.path.join(condor_config_dir, 'main/condor/libexec/condor_chirp')
+            if not os.path.isfile(condor_chirp_bin):
+                condor_chirp_bin = None
+
+        if condor_chirp_bin:
+            args = [ condor_chirp_bin, 'set_job_attr_delayed', key, json.dumps(value) ]
+            returncode = subprocess.call(args)
+
+        return

--- a/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
@@ -224,6 +224,9 @@ class CMSSW(Executor):
         else:
             returncode = subprocess.call(args, stdout = stdoutHandle, stderr = stderrHandle)
 
+        self.setCondorChirpAttrDelayed('Chirp_WMCore_cmsRun_ExitCode', returncode)
+        self.setCondorChirpAttrDelayed('Chirp_WMCore_%s_ExitCode' % self.stepName, returncode)
+
         stdoutHandle.close()
         stderrHandle.close()
 


### PR DESCRIPTION
We want to publish certain information (as key/value pairs) into HTCondor during the runtime of a job. Add support to do so in the Executor base classe, so this can be called from different step types. Also implement publishing the cmsRun exit code.

We probably want to test this first before merging. I tested that it doesn't impact agent functionality, but haven't check that it actually does what it is supposed to do.
