### PR TITLE
add schema section on workload. (many ops script depend on that)

### DIFF
--- a/src/python/WMCore/ReqMgr/Service/RequestAdditionalInfo.py
+++ b/src/python/WMCore/ReqMgr/Service/RequestAdditionalInfo.py
@@ -203,7 +203,9 @@ class WorkloadSplitting(RESTEntity):
                 raise cherrypy.HTTPError(404, "Cannot find workload: % "+ name)
             
             helper.setJobSplittingParameters(splittingTask, splittingAlgo, splitParams)
-        
-        url = "%s/%s" % (self.reqdb_url, name)
-        result = helper.saveCouchUrl(url)    
+            
+            # Not sure why it needs to updated per each task but if following lines are outside the loop
+            # it doesn't work
+            url = "%s/%s" % (self.reqdb_url, name)
+            result = helper.saveCouchUrl(url)    
         return result


### PR DESCRIPTION
fixes #6624

Many DataOps script uses schema section from workload ( which was removed  since schema is stored in couch, but there are too many script relying on this, so added schema in reqmgr workload.)

This could me removed once DataOps script is ported
