### PR TITLE
add api to get team name

### DIFF
--- a/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
+++ b/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
@@ -121,7 +121,7 @@ class ResourceControlUpdater(BaseWorkerThread):
         """
         agentsByTeam = {}
         try:
-            agentsByTeam = self.centralCouchDBReader.agentsByTeam()
+            agentsByTeam = self.centralCouchDBReader.agentsByTeam(filterDrain=True)
         except Exception as ex:
             logging.error("WMStats is not available or is unresponsive.")
 

--- a/src/python/WMCore/Services/WMStats/WMStatsReader.py
+++ b/src/python/WMCore/Services/WMStats/WMStatsReader.py
@@ -248,19 +248,19 @@ class WMStatsReader(object):
         
         return result
     
-    def agentsByTeam(self, ignoreDrain = True):
+    def agentsByTeam(self, filterDrain=False):
         """
         return a dictionary like {team:#agents,...}
         """
         result = self._getAgentInfo()
         response = dict()
+
         for agentInfo in result["rows"]:
-            
             teams = agentInfo['value']['agent_team'].split(',')
             for team in teams:
-                if team not in response.keys():
-                    response[team] = 0
-            if ignoreDrain:
+                response.setdefault(team, 0)
+                
+            if filterDrain:
                 if not agentInfo['value']['drain_mode']:
                     for team in teams:
                         response[team] += 1

--- a/src/python/WMCore/WMStats/Service/RequestInfo.py
+++ b/src/python/WMCore/WMStats/Service/RequestInfo.py
@@ -62,3 +62,26 @@ class FinishedStatusInfo(RESTEntity):
         result = self.wmstats.isWorkflowCompletedWithLogCollectAndCleanUp(request_name)
         return rows([result])
 
+class TeamInfo(RESTEntity):
+    """
+    This class need to move under WMStats server when wmstats server created
+    """
+    def __init__(self, app, api, config, mount):
+        # main CouchDB database where requests/workloads are stored
+        RESTEntity.__init__(self, app, api, config, mount)
+        wmstats_url = "%s/%s" % (self.config.couch_host, self.config.couch_wmstats_db)
+        self.wmstats = WMStatsReader(wmstats_url)           
+        
+    def validate(self, apiobj, method, api, param, safe):
+        args_length = len(param.args)
+        if args_length == 1:
+            safe.args.append(param.args[0])
+            param.args.pop()   
+        return            
+
+    
+    @restcall(formats = [('application/json', JSONFormat())])
+    @tools.expires(secs=-1)
+    def get(self):
+        result = self.wmstats.agentsByTeam(filterDrain=False)
+        return rows(result.keys())

--- a/src/python/WMCore/WMStats/Service/RestApiHub.py
+++ b/src/python/WMCore/WMStats/Service/RestApiHub.py
@@ -11,7 +11,7 @@ from WMCore.REST.Server import RESTApi
 from WMCore.REST.Format import JSONFormat
 
 from WMCore.WMStats.Service.MetaDataInfo import ServerInfo
-from WMCore.WMStats.Service.RequestInfo import RequestInfo, FinishedStatusInfo
+from WMCore.WMStats.Service.RequestInfo import RequestInfo, FinishedStatusInfo, TeamInfo
 from WMCore.WMStats.Service.ActiveRequestJobInfo import ActiveRequestJobInfo
 
 class RestApiHub(RESTApi):
@@ -32,6 +32,7 @@ class RestApiHub(RESTApi):
         # only allows json format for return value
         self.formats =  [('application/json', JSONFormat())]
         self._add({"info": ServerInfo(app, self, config, mount),
+                   "teams": TeamInfo(app, self, config, mount),
                    "request": RequestInfo(app, self, config, mount),
                    "isfinished": FinishedStatusInfo(app, self, config, mount),
                    "requestcache": ActiveRequestJobInfo(app, self, config, mount)


### PR DESCRIPTION
add list of team names for assigning the request.
team names are only determined by agents registered to wmstats. (Not sure this will cause the problem).
Otherwise we have to have the interface to add the team name like in reqmgr1 
@vkuznet, @amaltaro, Please review
