### PR TITLE
fix force complete to completed update

### DIFF
--- a/src/python/WMComponent/TaskArchiver/TaskArchiverPoller.py
+++ b/src/python/WMComponent/TaskArchiver/TaskArchiverPoller.py
@@ -217,8 +217,6 @@ class TaskArchiverPoller(BaseWorkerThread):
             #abortedWorkflows = self.reqmgrCouchDBWriter.getRequestByStatus(["aborted"], format = "dict");
             abortedWorkflows = self.centralCouchDBWriter.getRequestByStatus(["aborted"])
             logging.info("There are %d requests in 'aborted' status in central couch." % len(abortedWorkflows))
-            forceCompleteWorkflows = self.centralCouchDBWriter.getRequestByStatus(["force-complete"])
-            logging.info("List of 'force-complete' workflows in central couch: %s" % forceCompleteWorkflows)
             
         except Exception as ex:
             centralCouchAlive = False
@@ -243,8 +241,6 @@ class TaskArchiverPoller(BaseWorkerThread):
                     if workflow in abortedWorkflows:
                         #TODO: remove when reqmgr2-wmstats deployed
                         newState = "aborted-completed"
-                    elif workflow in forceCompleteWorkflows:
-                        newState = "completed"
                     else:
                         newState = None
                         

--- a/src/python/WMCore/WorkQueue/WorkQueueReqMgrInterface.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueReqMgrInterface.py
@@ -202,9 +202,8 @@ class WorkQueueReqMgrInterface():
         """Delete work from queue that is finished in ReqMgr"""
         finished = []
         for element in elements:
-            if self._workQueueToReqMgrStatus(element['Status']) in ('aborted', 'failed', 'completed', 'announced',
-                                                         'epic-FAILED', 'closed-out', 'rejected') \
-                                                         and element.inEndState():
+            if self._workQueueToReqMgrStatus(element['Status']) in ('failed', 'completed', 
+                                                'announced', 'closed-out', 'rejected') and element.inEndState():
                 finished.append(element['RequestName'])
         return queue.deleteWorkflows(*finished)
     


### PR DESCRIPTION
rely on workqueue element status update for force-complete to completed transition.

This way it will prevent workflow moves completed status prematurely moved to completed status when the request is running in multiple agent. 
