### PR TITLE
Use dummy PNNs for PSNs without a PNN

### DIFF
--- a/src/python/WMCore/Services/SiteDB/SiteDB.py
+++ b/src/python/WMCore/Services/SiteDB/SiteDB.py
@@ -311,7 +311,7 @@ class SiteDBJSON(Service):
             pnns.update(pnn_list)
         return list(pnns)
 
-    def PSNtoPNNMap(self, psn_pattern=''):
+    def PSNtoPNNMap(self, psn_pattern='', include_dummies=True):
         if not isinstance(psn_pattern, str):
             raise TypeError('psn_pattern arg must be of type str')
 
@@ -321,6 +321,12 @@ class SiteDBJSON(Service):
             if not psn_pattern.match(entry['psn_name']):
                 continue
             mapping.setdefault(entry['psn_name'], set()).add(entry['phedex_name'])
+
+        if include_dummies:
+            no_pnn_psn_names = set([psn for psn in self.getAllCMSNames()
+                                    if psn_pattern.match(psn)])
+            no_pnn_psn_names.difference_update(mapping.iterkeys())
+            mapping.update((k, set([k+'_Dummy'])) for k in no_pnn_psn_names)
         return mapping
     
     #TODO remove this when all DBS origin_site_name is converted to PNN


### PR DESCRIPTION
This pull request resolves https://github.com/dmwm/WMCore/issues/6433 by adding into the resources table sites that have no PNN with a dummy entry of 'Site_Dummy'
