### PR TITLE
add special subscription support for skims

### DIFF
--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -897,6 +897,7 @@ class WMTaskHelper(TreeHelper):
                                    custodialSubType = "Replica", nonCustodialSubType = "Replica",
                                    custodialGroup = "DataOps", nonCustodialGroup = "DataOps",
                                    priority = "Low", primaryDataset = None,
+                                   useSkim = False, isSkim = False,
                                    dataTier = None, deleteFromSource = False):
         """
         _setSubscriptionsInformation_
@@ -926,9 +927,18 @@ class WMTaskHelper(TreeHelper):
             outputDataset = entry["outputDataset"]
             outputModule = entry["outputModule"]
 
-            primDs = outputDataset.split('/')[1]
-            tier = outputDataset.split('/')[3]
+            dsSplit = outputDataset.split('/')
+
+            primDs = dsSplit[1]
+
+            procDsSplit = dsSplit[2].split('-')
+            skim = ( len(procDsSplit) == 4 )
+
+            tier = dsSplit[3]
+
             if primaryDataset and primDs != primaryDataset:
+                continue
+            if useSkim and isSkim != skim:
                 continue
             if dataTier and tier != dataTier:
                 continue

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -1150,6 +1150,7 @@ class WMWorkloadHelper(PersistencyHelper):
                                             custodialSubType="Replica", nonCustodialSubType="Replica",
                                             custodialGroup="DataOps", nonCustodialGroup="DataOps",
                                             priority="Low", primaryDataset=None,
+                                            useSkim = False, isSkim = False,
                                             dataTier=None, deleteFromSource=False):
         """
         _setSubscriptionInformationWildCards_
@@ -1192,6 +1193,8 @@ class WMWorkloadHelper(PersistencyHelper):
                                         nonCustodialGroup=nonCustodialGroup,
                                         priority=priority,
                                         primaryDataset=primaryDataset,
+                                        useSkim=useSkim,
+                                        isSkim=isSkim,
                                         dataTier=dataTier,
                                         deleteFromSource=deleteFromSource)
 
@@ -1200,6 +1203,7 @@ class WMWorkloadHelper(PersistencyHelper):
                                    custodialSubType="Replica", nonCustodialSubType="Replica",
                                    custodialGroup="DataOps", nonCustodialGroup="DataOps",
                                    priority="Low", primaryDataset=None,
+                                   useSkim = False, isSkim = False,
                                    dataTier=None, deleteFromSource=False):
         """
         _setSubscriptionInformation_
@@ -1226,6 +1230,7 @@ class WMWorkloadHelper(PersistencyHelper):
                                             custodialSubType, nonCustodialSubType,
                                             custodialGroup, nonCustodialGroup,
                                             priority, primaryDataset,
+                                            useSkim, isSkim,
                                             dataTier, deleteFromSource)
             self.setSubscriptionInformation(task,
                                             custodialSites, nonCustodialSites,
@@ -1233,6 +1238,7 @@ class WMWorkloadHelper(PersistencyHelper):
                                             custodialSubType, nonCustodialSubType,
                                             custodialGroup, nonCustodialGroup,
                                             priority, primaryDataset,
+                                            useSkim, isSkim,
                                             dataTier, deleteFromSource)
 
         return


### PR DESCRIPTION
When defining the subscriptions for workflow output, allow to define different subscriptions for skims. Needed by Tier0. Basically, skims can have the same data tier as regular workflow output but need different subscriptions. As such, the usual selection by primary dataset and data tier isn't enough.

@ticoann please review
