### PR TITLE
1.0.14_crab version of CRABTaskworker import fix

### DIFF
--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -135,7 +135,7 @@ dependencies = {'wmc-rest':{
                 'crabtaskworker':{
                         'packages':['WMCore.WorkQueue', 'WMCore.Credential', 'WMCore.Algorithms+', 'WMCore.WMSpec+',
                                     'WMCore.JobSplitting', 'WMCore.Services.SiteDB+', 'WMCore.Services.DBS+',
-                                    'WMCore.Services.UserFileCache+', 'WMCore.Services.PhEDEx+'],
+                                    'WMCore.Services.UserFileCache+', 'WMCore.Services.PhEDEx+', 'Utils+'],
                         'modules': ['WMCore.WMBS.File', 'WMCore.WMBS.WMBSBase', 'WMCore.WMBS.__init__'],
                         'systems': ['wmc-database', 'wmc-runtime'],
                         },


### PR DESCRIPTION
In the last few months a change was made to the WMTask class which added an import `from Utils.IterTools import flattenList`. Since TaskWorker doesn't have this included in it's dependencies, it causes errors. This PR should fix that on the WMCore side.
