### PR TITLE
remove non-functional phedex inject override

### DIFF
--- a/src/python/WMComponent/PhEDExInjector/Database/MySQL/GetUninjectedFiles.py
+++ b/src/python/WMComponent/PhEDExInjector/Database/MySQL/GetUninjectedFiles.py
@@ -5,8 +5,6 @@ _GetUninjectedFiles_
 Retrieve a list of files that have been injected into DBS but not PhEDEx.
 Format the output so that it can easily be injected into PhEDEx.
 
-The location of a file for PhEDEx can be overridden by the spec with the field
-overrides.phedexInjectionSite = 'T0_CH_CERN_Buffer'
 """
 
 from WMCore.Database.DBFormatter import DBFormatter

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -1304,28 +1304,6 @@ class WMWorkloadHelper(PersistencyHelper):
         """
         return self.data.section_('overrides')
 
-    def getPhEDExInjectionOverride(self):
-        """
-        _getPhEDExInjectionOverride_
-
-        Get the site to where the files from
-        this workload should be registered to (if any)
-        """
-        if hasattr(self.data, 'overrides'):
-            return getattr(self.data.overrides, 'injectionSite', None)
-        return None
-
-    def setPhEDExInjectionOverride(self, site):
-        """
-        _setPhEDExInjectionOverride_
-
-        Set a site where the files from this workload
-        should be registered to in PhEDEx
-        """
-        overrideSection = self.data.section_('overrides')
-        overrideSection.injectionSite = site
-        return
-
     def setBlockCloseSettings(self, blockCloseMaxWaitTime,
                               blockCloseMaxFiles, blockCloseMaxEvents,
                               blockCloseMaxSize):

--- a/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
@@ -245,22 +245,6 @@ class WMWorkloadTest(unittest.TestCase):
 
         return
 
-    def testF_Overrides(self):
-        """
-        _testF_Overrides_
-
-        Check the values attached to the workload general overrides
-        """
-        name = "ASmartString"
-
-        workload = WMWorkloadHelper(WMWorkload("TestWorkload"))
-        workload.setPhEDExInjectionOverride(name)
-
-        self.assertEqual(workload.getPhEDExInjectionOverride(), name)
-        self.assertEqual(workload.getWorkloadOverrides().injectionSite, name)
-
-        return
-
     def testDbsUrl(self):
         """
         _testDbsUrl_


### PR DESCRIPTION
Set and get methods are useless because the underlying functionality has been removed long ago.
