### PR TITLE
Split trust location flag for input and for pileup data

### DIFF
--- a/src/couchapps/WorkQueue/lists/workRestrictions.js
+++ b/src/couchapps/WorkQueue/lists/workRestrictions.js
@@ -12,7 +12,7 @@ function(head, req) {
         send(toJSON({}));
         return;
     }
-  
+
     try {
         var resources = JSON.parse(req.query.resources);
     } catch (ex) {
@@ -29,6 +29,7 @@ function(head, req) {
             return;
         }
     }
+
     var wfs = [];
     if (req.query.wfs) {
         try {
@@ -65,31 +66,69 @@ function(head, req) {
             continue;
         }
 
-        // Don't check anything if trustSitelists is enabled
-        if (ele['NoLocationUpdate']) {
-            // subtract element jobs from site resources
-            if (first !== true) {
-                send(",");
-            }
-            send(toJSON(row["doc"])); // need whole document, id etc...
-            first = false; // from now on prepend "," to output
-            continue; // we have work, move to the next element
-        }
-
         for (var site in resources) {
-
+			log(site);
+			log(ele);
             // skip if in blacklist
-            if (ele["SiteBlacklist"].indexOf(site) != -1) {
+            if (ele["SiteBlacklist"].indexOf(site) !== -1) {
                 continue;
             }
+
             //skip if not in whitelist
             if (ele["SiteWhitelist"].length != 0 && ele["SiteWhitelist"].indexOf(site) === -1) {
                 continue;
             }
+
+            // Don't check anything if trustSitelists AND trustPUSitelists is enabled
+            if (ele['NoLocationUpdate'] && ele["SiteWhitelist"].indexOf(site) !== -1) {
+                if (first !== true) {
+                    send(",");
+                }
+                send(toJSON(row["doc"])); // need whole document, id etc...
+                first = false; // from now on prepend "," to output
+                break; // we have work, move to the next element
+            }
+
+            // Input data location restrictions
+            // don't check input data location if trustSitelists is enabled
+            var noInputSite = false;
+            if (ele["NoInputUpdate"] === true) {
+                noInputSite = false;
+            } else if (ele["Inputs"]) {
+                for (block in ele['Inputs']) {
+                    if (ele['Inputs'][block].indexOf(site) === -1) {
+                        noInputSite = true;
+                        break;
+                    }
+                }
+            }
+            if (noInputSite) {
+                continue;
+            }
+
+            // Pileup data location restrictions, all pileup datasets must be at the site
+            // don't check pileup data location if trustPUSitelists
+            var noPileupSite = false;
+            if (ele["NoPileupUpdate"] === true) {
+                noPileupSite = false;
+            } else if (ele["PileupData"]) {
+                for(dataset in ele["PileupData"]) {
+                    if(ele["PileupData"][dataset].indexOf(site) === -1) {
+                        noPileupSite = true;
+                        break;
+                    }
+                }
+            }
+            if (noPileupSite){
+                continue;
+            }
+
             //skip if parent processing flag is set and parent block is not in the site.
             //all the parent block has to be in the same site
-            noParentSite = false;
-            if (ele["ParentFlag"]) {
+            var noParentSite = false;
+            if (ele["NoInputUpdate"] === true) {
+                noParentSite = false;
+            } else if (ele["ParentFlag"]) {
                 for (block in ele["ParentData"]) {
                     if (ele["ParentData"][block].indexOf(site) === -1) {
                         noParentSite = true;
@@ -101,34 +140,6 @@ function(head, req) {
                 continue;
             }
 
-            // Check the pile up data, all pileup datasets must be at the site to be valid
-            noPileupSite = false;
-            if(ele["PileupData"]){
-                for(dataset in ele["PileupData"]){
-                    if(ele["PileupData"][dataset].indexOf(site) === -1){
-                        noPileupSite = true;
-                        break;
-                    }
-                }
-            }
-            if(noPileupSite){
-                continue;
-            }
-
-            // input data restrictions
-            var hasData = true;
-            for (var data in ele['Inputs']) {
-                var locations = ele['Inputs'][data];
-                if (locations.indexOf(site) === -1) {
-                    hasData = false; // data not at site, skip
-                    break;
-                }
-            }
-            if (hasData === false) {
-                continue; // skip to next site
-            }
-
-            // subtract element jobs from site resources
             if (first !== true) {
                 send(",");
             }

--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
@@ -370,7 +370,8 @@ class Assign(WebAPI):
                                           kwargs.get("GracePeriod", None))
 
         # Check whether we should check location for the data
-        helper.setTrustLocationFlag(flag=strToBool(kwargs.get("TrustSitelists", False)))
+        helper.setTrustLocationFlag(inputFlag=strToBool(kwargs.get("TrustSitelists", False)),
+                                    pileupFlag=strToBool(kwargs.get("TrustPUSitelists", False)))
         helper.setAllowOpportunistic(allowOpport=strToBool(kwargs.get("AllowOpportunistic", False)))
 
         # Set phedex subscription information
@@ -448,5 +449,6 @@ class Assign(WebAPI):
                                        "UnmergedLFNBase": kwargs["UnmergedLFNBase"],
                                        "Dashboard": kwargs.get("Dashboard", ""),
                                        "TrustSitelists": kwargs.get("TrustSitelists", False),
+                                       "TrustPUSitelists": kwargs.get("TrustPUSitelists", False),
                                        "AllowOpportunistic": kwargs.get("AllowOpportunistic", False)},
                                useBody=True)

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -300,7 +300,7 @@ class StdBase(object):
         if applySiteLists:
             procTask.setSiteWhitelist(self.siteWhitelist)
             procTask.setSiteBlacklist(self.siteBlacklist)
-            procTask.setTrustSitelists(self.trustSitelists)
+            procTask.setTrustSitelists(self.trustSitelists, self.trustPUSitelists)
 
         newSplitArgs = {}
         for argName in splitArgs.keys():
@@ -988,6 +988,7 @@ class StdBase(object):
                                    "validate": lambda x: x == "auto" or (int(x) > 0)},
                      # data location management
                      "TrustSitelists": {"default": False, "type": bool},
+                     "TrustPUSitelists": {"default": False, "type": bool},
                      "AllowOpportunistic": {"default": False, "type": bool},
                      # from assignment: performance monitoring data
                      "MaxRSS": {"default": 2411724, "type": int, "validate": lambda x: x > 0},

--- a/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
+++ b/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
@@ -143,7 +143,7 @@ class PileupFetcher(FetcherInterface):
     def _updatePileupPNNs(self, stepHelper, fakeSites):
         """
         Update the workflow copy of the cached pileup file with PNNs
-        forced by TrustSitelists flag
+        forced by TrustPUSitelists flag
         """
         fileName = self._getStepFilePath(stepHelper)
         fakePNNs = mapSitetoPNN(fakeSites)
@@ -210,7 +210,7 @@ class PileupFetcher(FetcherInterface):
             fakeSites = []
 
         if self._isCacheValid(helper):
-            # we need to update the new sandbox json file in case TrustSitelists is on
+            # we need to update the new sandbox json file in case TrustPUSitelists is on
             if fakeSites:
                 self._updatePileupPNNs(helper, fakeSites)
 
@@ -243,8 +243,8 @@ class PileupFetcher(FetcherInterface):
         """
         fakeSites = []
 
-        # check whether we need to pretend PU data location
-        if wmTask.getTrustSitelists():
+        # check whether we need to overlook the PU data location
+        if wmTask.getTrustSitelists().get('trustPUlists'):
             fakeSites = makeLocationsList(wmTask.siteWhitelist(), wmTask.siteBlacklist())
 
         for step in wmTask.steps().nodeIterator():

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -522,7 +522,7 @@ class WMTaskHelper(TreeHelper):
                 del splittingParams['performance']
         splittingParams["siteWhitelist"] = self.siteWhitelist()
         splittingParams["siteBlacklist"] = self.siteBlacklist()
-        splittingParams["trustSitelists"] = self.getTrustSitelists()
+        splittingParams["trustSitelists"] = self.getTrustSitelists().get('trustlists')
 
         if "runWhitelist" not in splittingParams.keys() and self.inputRunWhitelist() != None:
             splittingParams["runWhitelist"] = self.inputRunWhitelist()
@@ -855,17 +855,19 @@ class WMTaskHelper(TreeHelper):
         """
         _getTrustSitelists_
 
-        Accessor for the 'trust site lists' flag for the task.
+        Get the input and pileup flag for 'trust site lists' in the task.
         """
-        return self.data.constraints.sites.trustlists
+        return {'trustlists': self.data.constraints.sites.trustlists,
+                'trustPUlists': self.data.constraints.sites.trustPUlists}
 
-    def setTrustSitelists(self, trustSitelists):
+    def setTrustSitelists(self, trustSitelists, trustPUSitelists):
         """
         _setTrustSitelists_
 
-        Set the 'trust site lists' flag for the task.
+        Set the input and the pileup flags for 'trust site lists' in the task.
         """
         self.data.constraints.sites.trustlists = trustSitelists
+        self.data.constraints.sites.trustPUlists = trustPUSitelists
         return
 
     def listOutputDatasetsAndModules(self):
@@ -1589,6 +1591,7 @@ class WMTask(ConfigSectionTree):
         self.constraints.sites.whitelist = []
         self.constraints.sites.blacklist = []
         self.constraints.sites.trustlists = False
+        self.constraints.sites.trustPUlists = False
         self.subscriptions.outputModules = []
         self.input.section_("WMBS")
 

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -1613,29 +1613,28 @@ class WMWorkloadHelper(PersistencyHelper):
             result.extend(t.getConfigCacheIDs())
         return result
 
-    def setTrustLocationFlag(self, flag=False):
+    def setTrustLocationFlag(self, inputFlag=False, pileupFlag=False):
         """
         _setTrustLocationFlag_
 
-        Set the flag in the top level tasks
-        indicating that site lists should be
-        used as location data
+        Set the input and the pileup flags in the top level tasks
+        indicating that site lists should be used as location data
         """
         for task in self.getTopLevelTask():
-            task.setTrustSitelists(flag)
+            task.setTrustSitelists(inputFlag, pileupFlag)
         return
 
     def getTrustLocationFlag(self):
         """
         _getTrustLocationFlag_
 
-        Get the flag in the top level tasks
-        that indicates whether the site lists
-        should be trusted as the location for data
+        Get a tuple with the inputFlag and the pileupFlag values from
+        the top level tasks that indicates whether the site lists should
+        be trusted as the location for input data or pileup data (or both)
         """
         for task in self.getTopLevelTask():
             return task.getTrustSitelists()
-        return False
+        return {'trustlists': False, 'trustPUlists': False}
 
     def validateArgumentForAssignment(self, schema):
         specClass = loadSpecClassByType(self.requestType())
@@ -1670,7 +1669,7 @@ class WMWorkloadHelper(PersistencyHelper):
         args are validated before update.
         assignment is common for all different types spec.
         """
-        siteParams = ["SiteWhitelist", "SiteBlacklist", "TrustSitelists"]
+        siteParams = ["SiteWhitelist", "SiteBlacklist", "TrustSitelists", "TrustPUSitelists"]
         lfnParams = ["MergedLFNBase", "UnmergedLFNBase"]
         mergeParams = ["MinMergeSize", "MaxMergeSize", "MaxMergeEvents"]
         performanceParams = ["MaxRSS", "MaxVSize", "SoftTimeout", "GracePeriod"]
@@ -1698,7 +1697,8 @@ class WMWorkloadHelper(PersistencyHelper):
             self.setSiteWildcardsLists(siteWhitelist=kwargs["SiteWhitelist"],
                                        siteBlacklist=kwargs["SiteBlacklist"],
                                        wildcardDict=wildcardSites)
-            self.setTrustLocationFlag(flag=strToBool(kwargs["TrustSitelists"]))
+            self.setTrustLocationFlag(inputFlag=strToBool(kwargs["TrustSitelists"]),
+                                      pileupFlag=strToBool(kwargs["TrustPUSitelists"]))
 
         # FIXME not validated
         if self._checkKeys(kwargs, lfnParams):

--- a/src/python/WMCore/WorkQueue/DataLocationMapper.py
+++ b/src/python/WMCore/WorkQueue/DataLocationMapper.py
@@ -201,6 +201,8 @@ class WorkQueueDataLocationMapper(DataLocationMapper):
                 for element in elements:
                     if element.get('NoLocationUpdate', False):
                         continue
+                    if element.get('NoInputUpdate', False):
+                        continue
                     if sorted(locations) != sorted(element['Inputs'][data]):
                         if fullResync:
                             self.logger.info(data + ': Setting locations to: ' + ', '.join(locations))
@@ -229,6 +231,8 @@ class WorkQueueDataLocationMapper(DataLocationMapper):
                 elements = self.backend.getElementsForParentData(data)
                 for element in elements:
                     if element.get('NoLocationUpdate', False):
+                        continue
+                    if element.get('NoInputUpdate', False):
                         continue
                     for pData in element['ParentData']:
                         if pData == data:
@@ -259,6 +263,8 @@ class WorkQueueDataLocationMapper(DataLocationMapper):
                 elements = self.backend.getElementsForPileupData(data)
                 for element in elements:
                     if element.get('NoLocationUpdate', False):
+                        continue
+                    if element.get('NoPileupUpdate', False):
                         continue
                     for pData in element['PileupData']:
                         if pData == data:

--- a/src/python/WMCore/WorkQueue/DataLocationMapper.py
+++ b/src/python/WMCore/WorkQueue/DataLocationMapper.py
@@ -8,8 +8,8 @@ import logging
 from WMCore.WorkQueue.WorkQueueUtils import get_dbs
 from WMCore.WorkQueue.DataStructs.ACDCBlock import ACDCBlock
 
-#TODO: Combine with existing dls so DBSreader can do this kind of thing transparently
-#TODO: Known Issue: Can't have same item in multiple dbs's at the same time.
+# TODO: Combine with existing dls so DBSreader can do this kind of thing transparently
+# TODO: Known Issue: Can't have same item in multiple dbs's at the same time.
 
 
 # round update times. Avoid cache misses from too precise time's
@@ -22,7 +22,7 @@ def isGlobalDBS(dbs):
         # try to determine from name - save a trip to server
         # fragile but if this url changes many other things will break also...
         from urlparse import urlparse
-        url = urlparse(dbs.dbs.getServerUrl()) #DBSApi has url not DBSReader
+        url = urlparse(dbs.dbs.getServerUrl())  # DBSApi has url not DBSReader
         if url.hostname.startswith('cmsweb.cern.ch') and url.path.startswith('/dbs/prod/global'):
             return True
         info = dbs.dbs.getServerInfo()
@@ -32,7 +32,7 @@ def isGlobalDBS(dbs):
     except Exception as ex:
         # determin whether this is dbs3
         dbs.dbs.serverinfo()
-        
+
         # hacky way to check whether it is global or local dbs.
         # issue is created, when it is resolved. use serverinfo() for that.
         # https://github.com/dmwm/DBS/issues/355
@@ -42,7 +42,8 @@ def isGlobalDBS(dbs):
         else:
             return False
 
-def timeFloor(number, interval = UPDATE_INTERVAL_COARSENESS):
+
+def timeFloor(number, interval=UPDATE_INTERVAL_COARSENESS):
     """Get numerical floor of time to given interval"""
     from math import floor
     return floor(number / interval) * interval
@@ -55,8 +56,9 @@ def isDataset(inputData):
     return True
 
 
-class DataLocationMapper():
+class DataLocationMapper(object):
     """Map data to locations for WorkQueue"""
+
     def __init__(self, **kwargs):
         self.params = kwargs
         self.params.setdefault('locationFrom', 'subscription')
@@ -70,16 +72,16 @@ class DataLocationMapper():
 
         validLocationFrom = ('subscription', 'location')
         if self.params['locationFrom'] not in validLocationFrom:
-            raise ValueError("Invalid value for locationFrom '%s' valid values %s" % (self.params['locationFrom'], validLocationFrom))
+            msg = "Invalid value for locationFrom '%s' valid values %s" % (self.params['locationFrom'], validLocationFrom)
+            raise ValueError(msg)
 
         if self.params.get('phedex'):
             self.phedex = self.params['phedex']
         if self.params.get('sitedb'):
             self.sitedb = self.params['sitedb']
 
-
-    def __call__(self, dataItems, fullResync = False, dbses = {},
-                 datasetSearch = False):
+    def __call__(self, dataItems, fullResync=False, dbses={},
+                 datasetSearch=False):
         result = {}
 
         # do a full resync every fullRefreshInterval interval
@@ -94,7 +96,7 @@ class DataLocationMapper():
             if isGlobalDBS(dbs):
                 output, fullResync = self.locationsFromPhEDEx(dataItems, fullResync,
                                                               datasetSearch)
-                
+
             else:
                 output, fullResync = self.locationsFromDBS(dbs, dataItems,
                                                            datasetSearch)
@@ -103,9 +105,8 @@ class DataLocationMapper():
             self.lastFullResync = now
 
         return result, fullResync
-    
-    def locationsFromPhEDEx(self, dataItems, fullResync = False,
-                            datasetSearch = False):
+
+    def locationsFromPhEDEx(self, dataItems, fullResync=False, datasetSearch=False):
         """Get data location from phedex"""
         if self.params['locationFrom'] == 'subscription':
             # subscription api doesn't support partial update
@@ -122,9 +123,9 @@ class DataLocationMapper():
             for dataItem in dataItems:
                 try:
                     if datasetSearch or isDataset(dataItem):
-                        response = self.phedex.getReplicaInfoForBlocks(dataset = [dataItem], **args)['phedex']
+                        response = self.phedex.getReplicaInfoForBlocks(dataset=[dataItem], **args)['phedex']
                     else:
-                        response = self.phedex.getReplicaInfoForBlocks(block = [dataItem], **args)['phedex']
+                        response = self.phedex.getReplicaInfoForBlocks(block=[dataItem], **args)['phedex']
                     for block in response['block']:
                         nodes = [replica['node'] for replica in block['replica']]
                         if datasetSearch or isDataset(dataItem):
@@ -145,15 +146,15 @@ class DataLocationMapper():
         return result, fullResync
 
     def locationsFromDBS(self, dbs, dataItems,
-                         datasetSearch = False):
+                         datasetSearch=False):
         """Get data location from dbs"""
         result = defaultdict(set)
         for dataItem in dataItems:
             try:
                 if datasetSearch or isDataset(dataItem):
-                    phedexNodeNames = dbs.listDatasetLocation(dataItem, dbsOnly = True)
+                    phedexNodeNames = dbs.listDatasetLocation(dataItem, dbsOnly=True)
                 else:
-                    phedexNodeNames = dbs.listFileBlockLocation(dataItem, dbsOnly = True)
+                    phedexNodeNames = dbs.listFileBlockLocation(dataItem, dbsOnly=True)
                 for pnn in phedexNodeNames:
                     result[dataItem].update(pnn)
             except Exception as ex:
@@ -165,8 +166,7 @@ class DataLocationMapper():
             psns.update(self.sitedb.PNNstoPSNs(nodes))
             result[name] = list(psns)
 
-        return result, True # partial dbs updates not supported
-
+        return result, True  # partial dbs updates not supported
 
     def organiseByDbs(self, dataItems):
         """Sort items by dbs instances - return dict with DBSReader as key & data items as values"""
@@ -182,12 +182,13 @@ class DataLocationMapper():
 
 class WorkQueueDataLocationMapper(DataLocationMapper):
     """WorkQueue data location functionality"""
+
     def __init__(self, logger, backend, **kwargs):
         self.backend = backend
         self.logger = logger
         DataLocationMapper.__init__(self, **kwargs)
 
-    def __call__(self, fullResync = False):
+    def __call__(self, fullResync=False):
         dataItems = self.backend.getActiveData()
 
         # fullResync incorrect with multiple dbs's - fix!!!
@@ -216,9 +217,10 @@ class WorkQueueDataLocationMapper(DataLocationMapper):
         numOfParentLocations = self.updateParentLocation(fullResync)
         numOfPileupLocations = self.updatePileupLocation(fullResync)
 
-        return len(dataLocations) + numOfParentLocations + numOfPileupLocations # probably not quite what we want, but will indicate whether some mappings were added or not
+        # probably not quite what we want, but will indicate whether some mappings were added or not
+        return len(dataLocations) + numOfParentLocations + numOfPileupLocations
 
-    def updateParentLocation(self, fullResync = False):
+    def updateParentLocation(self, fullResync=False):
         dataItems = self.backend.getActiveParentData()
 
         # fullResync incorrect with multiple dbs's - fix!!!
@@ -249,12 +251,12 @@ class WorkQueueDataLocationMapper(DataLocationMapper):
 
         return len(dataLocations)
 
-    def updatePileupLocation(self, fullResync = False):
+    def updatePileupLocation(self, fullResync=False):
         dataItems = self.backend.getActivePileupData()
 
         # fullResync incorrect with multiple dbs's - fix!!!
         dataLocations, fullResync = DataLocationMapper.__call__(self, dataItems, fullResync,
-                                                                datasetSearch = True)
+                                                                datasetSearch=True)
 
         # elements with multiple changed data items will fail fix this, or move to store data outside element
         for dataMapping in dataLocations.values():

--- a/src/python/WMCore/WorkQueue/DataStructs/WorkQueueElement.py
+++ b/src/python/WMCore/WorkQueue/DataStructs/WorkQueueElement.py
@@ -6,12 +6,13 @@ A dictionary based object meant to represent a WorkQueue element
 
 from hashlib import md5
 
-
 STATES = ('Available', 'Negotiating', 'Acquired', 'Running',
-            'Done', 'Failed', 'CancelRequested', 'Canceled')
+          'Done', 'Failed', 'CancelRequested', 'Canceled')
+
 
 class WorkQueueElement(dict):
     """Class to represent a WorkQueue element"""
+
     def __init__(self, **kwargs):
         dict.__init__(self)
 
@@ -32,7 +33,7 @@ class WorkQueueElement(dict):
         # Some workflows require additional datasets for PileUp
         # Track their locations
         self.setdefault('PileupData', {})
-        #both ParentData and ParentFlag is needed in case there Dataset split,
+        # both ParentData and ParentFlag is needed in case there Dataset split,
         # even though ParentFlag is True it will have empty ParentData
         self.setdefault('ParentData', {})
         self.setdefault('ParentFlag', False)
@@ -72,7 +73,7 @@ class WorkQueueElement(dict):
         # When was the last time we found new data (not the same as when new data was split), e.g. An open block was found
         self.setdefault('TimestampFoundNewData', 0)
         # TODO: being deprecated as of 29/03/2016. Trust initial input and pileup location or not
-        #self.setdefault('NoLocationUpdate', False)
+        # self.setdefault('NoLocationUpdate', False)
         # Trust initial input dataset location only or not
         self.setdefault('NoInputUpdate', False)
         # Trust initial pileup dataset location only or not
@@ -84,18 +85,19 @@ class WorkQueueElement(dict):
 
     def __to_json__(self, thunker):
         """Strip unthunkable"""
-        #result = WorkQueueElement(thunker_encoded_json = True,
-        result = dict(thunker_encoded_json = True,
-                      type = 'WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement')
+        # result = WorkQueueElement(thunker_encoded_json = True,
+        result = dict(thunker_encoded_json=True,
+                      type='WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement')
         result['WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement'] = {}
         result['WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement'].update(self)
-        result['WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement'].pop('Subscription', None) # Do we need this or can we not store this at all?
+        # Do we need this 'Subscription' or can we not store this at all?
+        result['WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement'].pop('Subscription', None)
         result['WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement'].pop('WMSpec', None)
-#        if self.get('Id'):
-#            result['_id'] = result['WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement'].pop('Id')
-#        if self.get('_rev'):
-#            result['_rev'] = result['WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement'].pop('_rev')
-        #result['Mask'] = thunker._thunk(result['Mask'])
+        #        if self.get('Id'):
+        #            result['_id'] = result['WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement'].pop('Id')
+        #        if self.get('_rev'):
+        #            result['_rev'] = result['WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement'].pop('_rev')
+        # result['Mask'] = thunker._thunk(result['Mask'])
         return result
 
     @property
@@ -122,18 +124,18 @@ class WorkQueueElement(dict):
             return self._id
         # Assume md5 is good enough for now
         hash = md5()
-        spacer = ';' # character not present in any field
+        spacer = ';'  # character not present in any field
         hash.update(self['RequestName'] + spacer)
         # Task will be None in global inbox
         hash.update(repr(self['TaskName']) + spacer)
         hash.update(",".join(sorted(self['Inputs'].keys())) + spacer)
         # Check repr is reproducible - should be
         if self['Mask']:
-            hash.update(",".join(["%s=%s" % (x,y) for x,y in self['Mask'].items()]) + spacer)
+            hash.update(",".join(["%s=%s" % (x, y) for x, y in self['Mask'].items()]) + spacer)
         else:
             hash.update("None" + spacer)
         # Check ACDC is deterministic and all params relevant
-        hash.update(",".join(["%s=%s" % (x,y) for x,y in self['ACDC'].items()]) + spacer)
+        hash.update(",".join(["%s=%s" % (x, y) for x, y in self['ACDC'].items()]) + spacer)
         hash.update(repr(self['Dbs']) + spacer)
         self._id = hash.hexdigest()
         return self._id
@@ -147,16 +149,17 @@ class WorkQueueElement(dict):
         """"""
         self.update(jsondata)
         return self
-#        self.update(jsondata['WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement'])
-#        self.pop('type', None)
-#        self.pop('thunker_encoded_json', None)
-##        self['Id'] = jsondata['_id']
-#        self['_rev'] = jsondata['_rev'] # what to do here???
-#        return self
+
+    #        self.update(jsondata['WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement'])
+    #        self.pop('type', None)
+    #        self.pop('thunker_encoded_json', None)
+    ##        self['Id'] = jsondata['_id']
+    #        self['_rev'] = jsondata['_rev'] # what to do here???
+    #        return self
 
     def inEndState(self):
         """Have we finished processing"""
-        return (self.isComplete() or self.isFailed() or self.isCanceled())
+        return self.isComplete() or self.isFailed() or self.isCanceled()
 
     def isComplete(self):
         return self['Status'] == 'Done'
@@ -181,10 +184,10 @@ class WorkQueueElement(dict):
 
     def updateFromSubscription(self, wmbsStatus):
         """Get subscription status"""
-        mapping = {'EventsWritten' : 'events_written',
-                   'FilesProcessed' : 'files_processed',
-                   'PercentComplete' : 'percent_complete',
-                   'PercentSuccess' : 'percent_success'}
+        mapping = {'EventsWritten': 'events_written',
+                   'FilesProcessed': 'files_processed',
+                   'PercentComplete': 'percent_complete',
+                   'PercentSuccess': 'percent_success'}
         for ourkey, wmbskey in mapping.items():
             if wmbskey in wmbsStatus and self[ourkey] != wmbsStatus[wmbskey]:
                 self['Modified'] = True
@@ -201,7 +204,7 @@ class WorkQueueElement(dict):
             if self[val] == progressReport[val]:
                 continue
             # ignore new state if it is lower than the current state
-            if val == 'Status' and self[val] and not STATES.index(progressReport[val]) > STATES.index(self[val]):
+            if val == 'Status' and self[val] and STATES.index(progressReport[val]) <= STATES.index(self[val]):
                 continue
 
             self[val] = progressReport[val]
@@ -210,9 +213,9 @@ class WorkQueueElement(dict):
 
     def statusMetrics(self):
         """Returns the status & performance metrics"""
-        return dict(Status = self['Status'],
-                    PercentComplete = self['PercentComplete'],
-                    PercentSuccess = self['PercentSuccess'])
+        return dict(Status=self['Status'],
+                    PercentComplete=self['PercentComplete'],
+                    PercentSuccess=self['PercentSuccess'])
 
     def passesSiteRestriction(self, site):
         """Takes account of white & black list, and input data to work out
@@ -245,7 +248,7 @@ class WorkQueueElement(dict):
                     return False
 
         return True
-    
+
     def intersectionWithEmptySet(self, a, b):
         """
         interaction of 2 sets but if one of the set is empty returns union
@@ -256,22 +259,25 @@ class WorkQueueElement(dict):
             return a & b
 
     def possibleSites(self):
-        
+
         if self.get('NoLocationUpdate'):
             return self['SiteWhitelist']
-        
+
         possibleSites = set()
-        
+
         if self['SiteWhitelist']:
             possibleSites = self.intersectionWithEmptySet(possibleSites, set(self['SiteWhitelist']))
-        
+
         if self['Inputs'] and self['NoInputUpdate'] is False:
-            possibleSites = self.intersectionWithEmptySet(possibleSites, set([y for x in self['Inputs'].values() for y in x]))
-        
+            possibleSites = self.intersectionWithEmptySet(possibleSites,
+                                                          set([y for x in self['Inputs'].values() for y in x]))
+
         if self['ParentFlag'] and self['NoInputUpdate'] is False:
-            possibleSites = self.intersectionWithEmptySet(possibleSites, set([y for x in self['ParentData'].values() for y in x]))
+            possibleSites = self.intersectionWithEmptySet(possibleSites,
+                                                          set([y for x in self['ParentData'].values() for y in x]))
 
         if self['PileupData'] and self['NoPileupUpdate'] is False:
-            possibleSites = self.intersectionWithEmptySet(possibleSites, set([y for x in self['PileupData'].values() for y in x]))
+            possibleSites = self.intersectionWithEmptySet(possibleSites,
+                                                          set([y for x in self['PileupData'].values() for y in x]))
 
         return list(possibleSites)

--- a/src/python/WMCore/WorkQueue/Policy/Start/Block.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Block.py
@@ -40,12 +40,12 @@ class Block(StartPolicyInterface):
             if self.initialTask.parentProcessingFlag():
                 parentFlag = True
                 for dbsBlock in dbs.listBlockParents(block["block"]):
-                    if self.initialTask.getTrustSitelists():
+                    if self.initialTask.getTrustSitelists().get('trustlists'):
                         parentList[dbsBlock["Name"]] = self.sites
                     else:
                         parentList[dbsBlock["Name"]] = self.siteDB.PNNstoPSNs(dbsBlock['PhEDExNodeList'])
 
-            self.newQueueElement(Inputs = {block['block'] : self.data.get(block['block'], [])},
+            self.newQueueElement(Inputs = {block['block']: self.data.get(block['block'], [])},
                                  ParentFlag = parentFlag,
                                  ParentData = parentList,
                                  NumberOfLumis = int(block[self.lumiType]),
@@ -54,7 +54,8 @@ class Block(StartPolicyInterface):
                                  Jobs = ceil(float(block[self.args['SliceType']]) /
                                              float(self.args['SliceSize'])),
                                  OpenForNewData = True if str(block.get('OpenForWriting')) == '1' else False,
-                                 NoLocationUpdate = self.initialTask.getTrustSitelists()
+                                 NoInputUpdate = self.initialTask.getTrustSitelists().get('trustlists'),
+                                 NoPileupUpdate = self.initialTask.getTrustSitelists().get('trustPUlists')
                                  )
 
 
@@ -76,8 +77,7 @@ class Block(StartPolicyInterface):
         runBlackList = task.inputRunBlacklist()
         if task.getLumiMask(): #if we have a lumi mask get only the relevant blocks
             maskedBlocks = self.getMaskedBlocks(task, dbs, datasetPath)
-        if task.getTrustSitelists():
-            # Then get the locations from the site whitelist/blacklist + SiteDB
+        if task.getTrustSitelists().get('trustlists'):
             siteWhitelist = task.siteWhitelist()
             siteBlacklist = task.siteBlacklist()
             self.sites = makeLocationsList(siteWhitelist, siteBlacklist)
@@ -181,7 +181,7 @@ class Block(StartPolicyInterface):
                     block['NumberOfFiles'] = acceptedFileCount
                     block['NumberOfEvents'] = acceptedEventCount
             # save locations
-            if task.getTrustSitelists():
+            if task.getTrustSitelists().get('trustlists'):
                 self.data[block['block']] = self.sites
             else:
                 self.data[block['block']] = self.siteDB.PNNstoPSNs(dbs.listFileBlockLocation(block['block']))

--- a/src/python/WMCore/WorkQueue/Policy/Start/Dataset.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Dataset.py
@@ -69,7 +69,8 @@ class Dataset(StartPolicyInterface):
                              NumberOfFiles=numFiles,
                              NumberOfEvents=numEvents,
                              Jobs=ceil(float(work) / float(self.args['SliceSize'])),
-                             NoLocationUpdate=self.initialTask.getTrustSitelists()
+                             NoInputUpdate=self.initialTask.getTrustSitelists().get('trustlists'),
+                             NoPileupUpdate=self.initialTask.getTrustSitelists().get('trustPUlists')
                             )
 
     def validate(self):
@@ -90,7 +91,7 @@ class Dataset(StartPolicyInterface):
         runWhiteList = task.inputRunWhitelist()
         runBlackList = task.inputRunBlacklist()
 
-        if task.getTrustSitelists():
+        if task.getTrustSitelists().get('trustlists'):
             siteWhitelist = task.siteWhitelist()
             siteBlacklist = task.siteBlacklist()
             self.sites = makeLocationsList(siteWhitelist, siteBlacklist)
@@ -169,7 +170,7 @@ class Dataset(StartPolicyInterface):
                 locations = locations.intersection(dbs.listFileBlockLocation(block['block']))
 
         # all needed blocks present at these sites
-        if self.wmspec.getTrustLocationFlag():
+        if self.wmspec.getTrustLocationFlag().get('trustlists'):
             self.data[datasetPath] = self.sites
         elif locations:
             self.data[datasetPath] = list(set(self.siteDB.PNNstoPSNs(locations)))

--- a/src/python/WMCore/WorkQueue/Policy/Start/ResubmitBlock.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/ResubmitBlock.py
@@ -105,7 +105,7 @@ class ResubmitBlock(StartPolicyInterface):
             dbsBlock['NumberOfEvents'] = block['events']
             dbsBlock['NumberOfLumis'] = block['lumis']
             dbsBlock['ACDC'] = acdcInfo
-            if task.getTrustSitelists():
+            if task.getTrustSitelists().get('trustlists'):
                 dbsBlock["Sites"] = self.sites
             else:
                 # TODO remove this line when all DBS origin_site_name is converted to PNN
@@ -140,7 +140,7 @@ class ResubmitBlock(StartPolicyInterface):
             dbsBlock['NumberOfFiles'] = block['files']
             dbsBlock['NumberOfEvents'] = block['events']
             dbsBlock['NumberOfLumis'] = block['lumis']
-            if task.getTrustSitelists():
+            if task.getTrustSitelists().get('trustlists'):
                 dbsBlock["Sites"] = self.sites
             else:
                 # TODO remove this line when all DBS origin_site_name is converted to PNN
@@ -166,7 +166,7 @@ class ResubmitBlock(StartPolicyInterface):
         dbsBlock['NumberOfFiles'] = acdcBlock['files']
         dbsBlock['NumberOfEvents'] = acdcBlock['events']
         dbsBlock['NumberOfLumis'] = acdcBlock['lumis']
-        if task.getTrustSitelists():
+        if task.getTrustSitelists().get('trustlists'):
             dbsBlock["Sites"] = self.sites
         else:
             # TODO remove this line when all DBS origin_site_name is converted to PNN

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/DQMHarvest_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/DQMHarvest_t.py
@@ -125,7 +125,7 @@ class DQMHarvestTests(unittest.TestCase):
         self.assertEqual(task.getPathName(), "/TestWorkload/EndOfRunDQMHarvest")
         self.assertEqual(task.taskType(), "Harvesting", "Wrong task type")
         self.assertEqual(task.jobSplittingAlgorithm(), "Harvest", "Wrong job splitting algo")
-        self.assertFalse(task.getTrustSitelists(), "Wrong input location flag")
+        self.assertFalse(task.getTrustSitelists().get('trustlists'), "Wrong input location flag")
         self.assertEqual(sorted(task.inputRunWhitelist()),
                          [138923, 138924, 138934, 138937, 139788, 139789,
                           139790, 144011, 144083, 144084, 144086])

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
@@ -297,7 +297,7 @@ class StepChainTests(unittest.TestCase):
         self.assertTrue(splitParams['performance']['sizePerEvent'] > 1233)
         self.assertTrue(splitParams['performance']['memoryRequirement'] == 2400)
 
-        self.assertFalse(task.getTrustSitelists(), "Wrong input location flag")
+        self.assertFalse(task.getTrustSitelists().get('trustlists'), "Wrong input location flag")
         self.assertFalse(task.inputRunWhitelist(), "Wrong run white list")
 
         # test workload step stuff

--- a/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
@@ -1844,11 +1844,20 @@ class WMWorkloadTest(unittest.TestCase):
         """
         testWorkload = self.makeTestWorkload()[0]
 
-        self.assertFalse(testWorkload.getTrustLocationFlag(), "Should be False, I did not set you yet.")
-        testWorkload.setTrustLocationFlag(flag=True)
-        self.assertTrue(testWorkload.getTrustLocationFlag(), "Bad job!! You should be True now")
-        testWorkload.setTrustLocationFlag(flag=False)
-        self.assertFalse(testWorkload.getTrustLocationFlag(), "Bad job!! You should be False again")
+        self.assertFalse(testWorkload.getTrustLocationFlag().get('trustlists'), "Should be False, I did not set you yet.")
+        self.assertFalse(testWorkload.getTrustLocationFlag().get('trustPUlists'), "Should be False, I did not set you yet.")
+        testWorkload.setTrustLocationFlag(inputFlag=True, pileupFlag=True)
+        self.assertTrue(testWorkload.getTrustLocationFlag().get('trustlists'), "Bad job!! You should be True now")
+        self.assertTrue(testWorkload.getTrustLocationFlag().get('trustPUlists'), "Bad job!! You should be True now")
+        testWorkload.setTrustLocationFlag(inputFlag=False, pileupFlag=False)
+        self.assertFalse(testWorkload.getTrustLocationFlag().get('trustlists'), "Bad job!! You should be False now")
+        self.assertFalse(testWorkload.getTrustLocationFlag().get('trustPUlists'), "Bad job!! You should be False now")
+        testWorkload.setTrustLocationFlag(inputFlag=False, pileupFlag=True)
+        self.assertFalse(testWorkload.getTrustLocationFlag().get('trustlists'), "Bad job!! You should still be False")
+        self.assertTrue(testWorkload.getTrustLocationFlag().get('trustPUlists'), "Bad job!! You should be True once again")
+        testWorkload.setTrustLocationFlag(inputFlag=True, pileupFlag=False)
+        self.assertTrue(testWorkload.getTrustLocationFlag().get('trustlists'), "Bad job!! You should be True once again")
+        self.assertFalse(testWorkload.getTrustLocationFlag().get('trustPUlists'), "Bad job!! You should be False again")
         return
 
 


### PR DESCRIPTION
Disclaimer: it's a non working version :)

A summary of this patch is:
- get rid of the 'NoLocationUpdate' WQE parameter
- added a new 'NoInputUpdate' WQE parameter, set by "TrustSitelists" flag to bypass only the input dataset
- added a new 'NoPileupUpdate' WQE parameter, set by "TrustPUSitelists" flag to bypass only the pileup dataset

I had a few typos in the javascript code, that was fixed and doesn't break WQ anymore, however, when I set a) only the PU flag or b) when I set both, somehow blocks don't get replicated from GQ to LQ.

@ticoann if you spend time looking at this, check only the workRestrictions.js and DataStructs/WorkQueueElement.py. Otherwise, I'll sort it out on Tuesday.
