### PR TITLE
Fix GFAL2 and environment problem

### DIFF
--- a/src/python/WMCore/Storage/Backends/GFAL2Impl.py
+++ b/src/python/WMCore/Storage/Backends/GFAL2Impl.py
@@ -20,10 +20,13 @@ class GFAL2Impl(StageOutImpl):
 
     def __init__(self, stagein=False):
         StageOutImpl.__init__(self, stagein)
-        self.setups = "env -i X509_USER_PROXY=$X509_USER_PROXY; "
-        self.setups += 'date "+%Y-%m-%dT%H:%M:%S";'
-        self.removeCommand = "%s gfal-rm -vvv -t 600 " % self.setups
-        self.copyCommand = "%s gfal-copy -vvv -t 2400 -T 2400 -p " % self.setups
+        # If we want to execute commands in clean shell, we can`t separate them with ';'.
+        # Next commands after separation are executed without env -i and this leads us with 
+        # mixed environment with COMP and system python.
+        # GFAL2 is not build under COMP environment and it had failures with mixed environment.
+        self.setups = "env -i X509_USER_PROXY=$X509_USER_PROXY sh -c '%s'"
+        self.removeCommand = self.setups % 'printenv; date; gfal-rm -vvv -t 600 %s '
+        self.copyCommand = self.setups % 'printenv; date; gfal-copy -vvv -t 2400 -T 2400 -p %(checksum)s %(options)s %(source)s %(destination)s'
 
     def createSourceName(self, protocol, pfn):
         """
@@ -58,11 +61,11 @@ class GFAL2Impl(StageOutImpl):
                Command is interrupted if time expires before it finishes
         """
         if pfn.startswith("file:"):
-            return self.removeCommand + pfn
+            return self.removeCommand % pfn
         elif os.path.isfile(pfn):
             return "/bin/rm -f %s" % os.path.abspath(pfn)
         else:
-            return self.removeCommand + pfn
+            return self.removeCommand % pfn
 
 
     def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
@@ -81,14 +84,15 @@ class GFAL2Impl(StageOutImpl):
 
         useChecksum = (checksums != None and 'adler32' in checksums and not self.stageIn)
 
-        copyCommand = self.copyCommand
+        copyCommandDict = {'checksum': '', 'options': '', 'source': '', 'destination': ''}
         if useChecksum:
-            copyCommand += " -K adler32 "
+            copyCommandDict['checksum'] = "-K adler32"
         if options != None:
-            copyCommand += " %s " % options
-        copyCommand += " %s " % sourcePFN
-        copyCommand += " %s \n" % targetPFN
+            copyCommandDict['options'] = options
+        copyCommandDict['source'] = sourcePFN
+        copyCommandDict['destination'] = targetPFN
 
+        copyCommand = self.copyCommand % copyCommandDict
         result += copyCommand
 
         if _CheckExitCodeOption:
@@ -116,9 +120,9 @@ class GFAL2Impl(StageOutImpl):
         if os.path.isfile(pfnToRemove):
             command = "/bin/rm -f %s" % os.path.abspath(pfnToRemove)
         if pfnToRemove.startswith("file:"):
-            command = self.removeCommand + pfnToRemove
+            command = self.removeCommand % pfnToRemove
         else:
-            command = self.removeCommand + pfnToRemove
+            command = self.removeCommand % pfnToRemove
         self.executeCommand(command)
 
 

--- a/test/python/WMCore_t/Services_t/SiteDB_t/SiteDB_t.py
+++ b/test/python/WMCore_t/Services_t/SiteDB_t/SiteDB_t.py
@@ -45,6 +45,7 @@ class SiteDBTest(unittest.TestCase):
         """
         target = [u'srm-eoscms.cern.ch', u'srm-eoscms.cern.ch', u'storage01.lcg.cscs.ch', u'eoscmsftp.cern.ch']
         results = self.mySiteDB.cmsNametoSE("%T2_CH")
+        print target, results
         self.assertTrue(sorted(results) == sorted(target))
 
     def testSEtoCmsName(self):
@@ -114,7 +115,7 @@ class SiteDBTest(unittest.TestCase):
     
     def testCMSNametoList(self):
         result = self.mySiteDB.cmsNametoList("T1_US*", "SE")
-        self.assertTrue(result == [u'cmssrm.fnal.gov', u'cmssrmdisk.fnal.gov'])
+        self.assertItemsEqual(result, [u'cmssrm.fnal.gov', u'cmssrmdisk.fnal.gov'])
         
 
 if __name__ == '__main__':


### PR DESCRIPTION
semicolon in env -i leads to execute two diff commands with different environment. Fix a bug which was reported in several threads:
https://ggus.eu/index.php?mode=ticket_info&ticket_id=120327
https://hypernews.cern.ch/HyperNews/CMS/get/computing-tools/1478/1/2/1.html

P.S. This affects only WMAgent as CRAB3 branch is not using this pull request yet: https://github.com/dmwm/WMCore/commit/68f64875567501bc83ee63fb6543f84319f85611
