### PR TITLE
Allow runtime environment to resize the cores in the job.

### DIFF
--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -16,7 +16,7 @@ import pickle
 from WMCore.WMRuntime.ScriptInterface import ScriptInterface
 from WMCore.Storage.TrivialFileCatalog import TrivialFileCatalog
 from PSetTweaks.PSetTweak import PSetTweak
-from PSetTweaks.WMTweak import applyTweak
+from PSetTweaks.WMTweak import applyTweak, resizeResources
 from PSetTweaks.WMTweak import makeOutputTweak, makeJobTweak, makeTaskTweak
 from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig
 from WMCore.Wrappers.JsonWrapper import JSONDecoder
@@ -664,8 +664,13 @@ class SetupCMSSWPset(ScriptInterface):
         self.fixupProcess()
 
         try:
-            if int(self.step.data.application.multicore.numberOfCores) > 1:
-                numCores = int(self.step.data.application.multicore.numberOfCores)
+            origCores = int(self.step.data.application.multicore.numberOfCores)
+            resources = {'cores': origCores}
+            resizeResources(resources)
+            numCores = resources['cores']
+            # When we are using multiple cores - or the pset might have
+            # a default of greater than 1 - we must override the provided pset.
+            if (numCores > 1) or (origCores > 1):
                 options = getattr(self.process, "options", None)
                 if options == None:
                     self.process.options = cms.untracked.PSet()

--- a/src/python/WMCore/WMRuntime/Tools/Scram.py
+++ b/src/python/WMCore/WMRuntime/Tools/Scram.py
@@ -268,6 +268,10 @@ class Scram:
             self.procWriter(proc, 'export VO_CMS_SW_DIR=%s/cmssoft/cms\n'%os.environ['OSG_APP'])
         if os.environ.get('CMS_PATH', None) != None:
             self.procWriter(proc, 'export CMS_PATH=%s\n'%os.environ['CMS_PATH'])
+        if os.environ.get('_CONDOR_JOB_AD'):
+            self.procWriter(proc, 'export _CONDOR_JOB_AD=%s\n'%os.environ['_CONDOR_JOB_AD'])
+        if os.environ.get('_CONDOR_MACHINE_AD'):
+            self.procWriter(proc, 'export _CONDOR_MACHINE_AD=%s\n'%os.environ['_CONDOR_MACHINE_AD'])
 
         if hackLdLibPath:
             self.procWriter(proc, self.library_path)


### PR DESCRIPTION
This allows WMRuntime to resize the number of threads in the pset
_if_ the job is in the condor runtime environment (`_CONDOR_MACHINE_AD`
env var is set and the slot's ad is in the referenced file), the
`Cpus` attribute is set to an integer, and `WMCore_ResizeJob` is set to
`true`.

So, by default this does nothing.  However, Ops can then explicitly
enable job resizing (and setting `RequestCpus` and `RequestMemory`
appropriately to reflect this) for a given workflow or subtask in
condor.  Since I suspect we'll need to experiment a bit with the
correct values for `RequestMemory` / `RequestCpus`, I don't currently
change those in the `CondorPlugin`.

This just gives us the flexibility to explore the phase space.

Cases of the `resizeCores` function tested by hand:
- When `_CONDOR_MACHINE_AD` env var is missing.
- When machine ad is unparseable.
- When resize job attribute is missing, true, or false.
- Non-parseable values for `Cpus` or `WMCore_ResizeJob`
- `Cpus` is greater than, equal to, or less than numCores
