### PR TITLE
Import fix for CRAB3

### DIFF
--- a/src/python/WMCore/Services/Requests.py
+++ b/src/python/WMCore/Services/Requests.py
@@ -356,6 +356,7 @@ class Requests(dict):
         """
         method getting a secure (HTTPS) connection
         """
+        import httplib2
         key, cert = None, None
         if self['endpoint_components'].scheme == 'https':
             # only add certs to https requests


### PR DESCRIPTION
Similar to #6745, need to import httplib2 because otherwise we don't have it.
