### PR TITLE
Fix print regressions

### DIFF
--- a/test/python/WMCore_t/Services_t/SiteDB_t/SiteDB_t.py
+++ b/test/python/WMCore_t/Services_t/SiteDB_t/SiteDB_t.py
@@ -2,6 +2,7 @@
 """
 Test case for SiteDB
 """
+from __future__ import print_function
 
 import unittest
 
@@ -45,7 +46,7 @@ class SiteDBTest(unittest.TestCase):
         """
         target = [u'srm-eoscms.cern.ch', u'srm-eoscms.cern.ch', u'storage01.lcg.cscs.ch', u'eoscmsftp.cern.ch']
         results = self.mySiteDB.cmsNametoSE("%T2_CH")
-        print target, results
+        print(target, results)
         self.assertTrue(sorted(results) == sorted(target))
 
     def testSEtoCmsName(self):

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
@@ -4,6 +4,7 @@ _WorkQueue_t_
 
 WorkQueue tests
 """
+from __future__ import print_function
 
 import os
 import threading
@@ -949,7 +950,7 @@ class WorkQueueTest(WorkQueueTestCase):
         self.assertEqual(len(self.globalQueue.statusInbox(status='Canceled')), 1)
         syncQueues(self.localQueue)
         # local cancelded
-        print self.localQueue.status()
+        print(self.localQueue.status())
         #self.assertEqual(len(self.localQueue.status(status='Canceled')), 1)
         # clear global
         self.globalQueue.deleteWorkflows(self.processingSpec.name())


### PR DESCRIPTION
Had a couple of regressions of our rules on print function vs. statement. I will try to adjust Jenkins to find these.
