### PR TITLE
Fix cascade status update on reqmgr2

### DIFF
--- a/src/python/WMCore/ReqMgr/Service/Request.py
+++ b/src/python/WMCore/ReqMgr/Service/Request.py
@@ -444,8 +444,7 @@ class Request(RESTEntity):
             # request_args should contain only 4 keys 'total_jobs', 'input_lumis', 'input_events', 'input_num_files'}
             report = self.reqmgr_db_service.updateRequestStats(workload.name(), request_args)
         else:
-            InvalidSpecParameterValue(
-                 "can't update value without state transition: %s" % request_args)
+            raise InvalidSpecParameterValue("can't update value without state transition: %s" % request_args)
         
         return report
 

--- a/src/python/WMCore/ReqMgr/Utils/Validation.py
+++ b/src/python/WMCore/ReqMgr/Utils/Validation.py
@@ -100,14 +100,18 @@ def validate_request_update_args(request_args, config, reqmgr_db_service, param)
     else:
         args_without_status = request_args
 
-    if len(args_without_status) == 1 and 'RequestPriority' in args_without_status:
-        try:
-            args_without_status['RequestPriority'] = int(args_without_status['RequestPriority'])
-            if args_without_status['RequestPriority'] < 0 or args_without_status['RequestPriority'] >= 1e6:
-                raise TypeError
-        except TypeError:
-            raise InvalidSpecParameterValue("RequestPriority must be an integer between 0 and 1e6")
-        return workload, args_without_status
+    if len(args_without_status) == 1:
+        if 'RequestPriority' in args_without_status:
+            try:
+                args_without_status['RequestPriority'] = int(args_without_status['RequestPriority'])
+                if args_without_status['RequestPriority'] < 0 or args_without_status['RequestPriority'] >= 1e6:
+                    raise TypeError
+            except TypeError:
+                raise InvalidSpecParameterValue("RequestPriority must be an integer between 0 and 1e6")
+            return workload, args_without_status
+        elif 'cascade' in args_without_status:
+            # status was already validated
+            return workload, request_args
     elif len(args_without_status) > 0 and not workqueue_stat_validation(args_without_status):
         # validate the arguments against the spec argumentSpecdefinition
         #TODO: currently only assigned status allows any update other then Status update


### PR DESCRIPTION
It fixes the status update for closed-out and announced (using cascade option).
Just did a small test in my VM and it worked, though my environment is a bit messy now :)

The problems is that workqueue_stat_validation(args_without_status) was returning False.

@ticoann feel free to also test it in your VM if you can, otherwise I will take another look a bit later in the day.
