### PR TITLE
1.0.14_crab version of Fix logic for CondorStatusService availability check

### DIFF
--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -604,10 +604,6 @@ class SetupCMSSWPset(ScriptInterface):
                 elif int(result.group(1)) == 7:
                     if int(result.group(2)) >= 6:
                         addCondorStatusService = True
-                    elif int(result.group(2)) == 5 and int(result.group(3)) >= 1:
-                        addCondorStatusService = True
-                    elif int(result.group(2)) == 4 and int(result.group(3)) >= 7:
-                        addCondorStatusService = True
             except ValueError:
                 pass
 

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
@@ -948,7 +948,6 @@ class WorkQueueTest(WorkQueueTestCase):
         self.assertEqual(len(self.globalQueue.statusInbox(status='Canceled')), 1)
         syncQueues(self.localQueue)
         # local cancelded
-        print self.localQueue.status()
         #self.assertEqual(len(self.localQueue.status(status='Canceled')), 1)
         # clear global
         self.globalQueue.deleteWorkflows(self.processingSpec.name())


### PR DESCRIPTION
There was an issue discovered during validation that the CondorStatusService is being added incorrectly. Discussion can be found here https://github.com/dmwm/CRABServer/issues/5186#issuecomment-204324695. Since the service is available from CMSSW_7_6_0 onwards (https://github.com/dmwm/CRABServer/issues/5186#issuecomment-204381799), a fix is needed. After the merge we would also like a new tag, 1.0.14_crab_5 for our branch.
