### PR TITLE
Fix logic for CondorStatusService availability check

### DIFF
--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -604,10 +604,6 @@ class SetupCMSSWPset(ScriptInterface):
                 elif int(result.group(1)) == 7:
                     if int(result.group(2)) >= 6:
                         addCondorStatusService = True
-                    elif int(result.group(2)) == 5 and int(result.group(3)) >= 1:
-                        addCondorStatusService = True
-                    elif int(result.group(2)) == 4 and int(result.group(3)) >= 7:
-                        addCondorStatusService = True
             except ValueError:
                 pass
 


### PR DESCRIPTION
Same PR as for our 1.0.14_crab branch (#6773).

There was an issue discovered during validation that the CondorStatusService is being added incorrectly. Discussion can be found here https://github.com/dmwm/CRABServer/issues/5186#issuecomment-204324695. Since the service is available from CMSSW_7_6_0 onwards (https://github.com/dmwm/CRABServer/issues/5186#issuecomment-204381799), a fix is needed.
