### PR TITLE
CRAB3 is failing untar for older cmssw releases

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
@@ -357,15 +357,22 @@ export SCRAM_ARCH=$SCRAM_ARCHIT
 echo "Retrieving SCRAM project..."
 # do the actual executing
 $SCRAM_COMMAND project $SCRAM_PROJECT $CMSSW_VERSION
-if [ $? -ne 0 ]; then echo "Scram failed"; exit 71; fi
+EXIT_STATUS=$?
+if [ $EXIT_STATUS -ne 0 ]; then echo "Scram failed with exit code: $EXIT_STATUS"; exit 71; fi
 cd $CMSSW_VERSION
-if [ $? -ne 0 ]; then echo "***\nCouldn't chdir: $?\n"; exit 72; fi
+EXIT_STATUS=$?
+if [ $EXIT_STATUS -ne 0 ]; then echo "***\nCouldn't chdir: $EXIT_STATUS\n"; exit 72; fi
 
 eval `$SCRAM_COMMAND runtime -sh`
-if [ $? -ne 0 ]; then echo "***\nCouldn't get scram runtime: $?\n*"; exit 73; fi
+EXIT_STATUS=$?
+if [ $EXIT_STATUS -ne 0 ]; then echo "***\nCouldn't get scram runtime: $EXIT_STATUS\n*"; exit 73; fi
 if [ -n "$USER_TARBALL" ] ; then
     python2 -m WMCore.WMRuntime.Scripts.UnpackUserTarball $USER_TARBALL $USER_FILES
-    if [ $? -ne 0 ]; then echo "***\nCouldn't untar sandbox: $?\n"; exit 74; fi
+    EXIT_STATUS=$?
+    if [ $EXIT_STATUS -ne 0 ]; then
+       echo "***\nCouldn't untar sandbox with python2: $EXIT_STATUS\n";
+       exit 74;
+    fi
 fi
 echo "Completed SCRAM project"
 cd ..


### PR DESCRIPTION
Before we were using python2.6 and now with this enforcement to python2 makes it worse and fails with old releases (as example tested with CMSSW_5_3_22)
