### PR TITLE
tag chirp updates from CMSSW - 1.0.14 version

### DIFF
--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -604,15 +604,13 @@ class SetupCMSSWPset(ScriptInterface):
                 elif int(result.group(1)) == 7:
                     if int(result.group(2)) >= 6:
                         addCondorStatusService = True
-                    elif int(result.group(2)) == 5 and int(result.group(3)) >= 1:
-                        addCondorStatusService = True
-                    elif int(result.group(2)) == 4 and int(result.group(3)) >= 7:
-                        addCondorStatusService = True
             except ValueError:
                 pass
 
         if addCondorStatusService:
-            self.process.add_(cms.Service("CondorStatusService"))
+            print("Tag chirp updates from CMSSW with _%s_" % self.step.data._internal_name)
+            self.process.add_(cms.Service("CondorStatusService",
+                                          tag=cms.untracked.string("_%s_" % self.step.data._internal_name)))
 
         return
 

--- a/test/python/WMCore_t/WMRuntime_t/Scripts_t/FWCore/ParameterSet/Config.py
+++ b/test/python/WMCore_t/WMRuntime_t/Scripts_t/FWCore/ParameterSet/Config.py
@@ -127,7 +127,7 @@ def PSet(**attributes):
 
     return newPSet
 
-def Service(serviceName):
+def Service(serviceName, **kwargs):
     """
     _Service_
 


### PR DESCRIPTION
1.0.14 version of #6778 that is needed for AWS tests (and possible for the production agents as well). 
