### PR TITLE
Read only existent logs in PyCondor plugin - 1.0.14 version

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
@@ -1073,8 +1073,10 @@ class PyCondorPlugin(BasePlugin):
         ### This should select the latest log file in the cache_dir
         fmtime = 0
         logFile = None
+        jobLogInfo = {}
         if not os.path.exists(job['cache_dir']):
-            logging.debug('%s does not EXIST.', job['cache_dir'])
+            logging.info('%s does not exist.', job['cache_dir'])
+            return jobLogInfo
 
         for joblog in os.listdir(job['cache_dir']):
             if fnmatch.fnmatch(joblog, 'condor.*.*.log'):
@@ -1084,7 +1086,6 @@ class PyCondorPlugin(BasePlugin):
                     fmtime = _tmpfmtime
                     logFile = _tmplogFile
 
-        jobLogInfo = {}
         try:
             logging.debug("Opening condor job log file: %s", logFile)
             logfileobj = open(logFile, "r")


### PR DESCRIPTION
Since my previous patch was very stupid https://github.com/dmwm/WMCore/commit/0cef26d4e7e8d7652b00fd21675ae119cb466dde#diff-9b070481bcf1072545075872a49c7968R1077

fixing the issue for real now.
