### PR TITLE
Make condor removal more efficient; improve error message

### DIFF
--- a/src/python/WMCore/BossAir/BossAirAPI.py
+++ b/src/python/WMCore/BossAir/BossAirAPI.py
@@ -683,10 +683,10 @@ class BossAirAPI(WMConnectionBase):
                         # Build a better job message
                         if killMsg:
                             reportedMsg = killMsg
-                            reportedMsg += '\n Job last known status was: %s' % job.get('globalState', 'Unknown')
+                            reportedMsg += '\n Job last known status was: %s' % job.get('status', 'Unknown')
                         else:
                             reportedMsg = WM_JOB_ERROR_CODES[errorCode]
-                            reportedMsg += '\n Job last known status was: %s' % job.get('globalState', 'Unknown')
+                            reportedMsg += '\n Job last known status was: %s' % job.get('status', 'Unknown')
                         errorReport.addError("JobKilled", errorCode, "JobKilled", reportedMsg)
                         try:
                             errorReport.save(filename=reportName)

--- a/src/python/WMCore/BossAir/StatusPoller.py
+++ b/src/python/WMCore/BossAir/StatusPoller.py
@@ -48,7 +48,7 @@ class StatusPoller(BaseWorkerThread):
         # With no timeouts, nothing ever happens
         # Otherwise we expect a dictionary with the keys representing
         # the states and the values the timeouts.
-        self.timeouts = getattr(config.JobStatusLite, 'stateTimeouts', {})
+        self.timeouts = getattr(config.JobStatusLite, 'stateTimeouts')
 
         # init alert system
         self.initAlerts(compName="StatusPoller")
@@ -95,8 +95,8 @@ class StatusPoller(BaseWorkerThread):
             # Then we have no jobs
             return
 
-        if self.timeouts == {}:
-            # Then we've set outself to have no timeouts
+        if not self.timeouts:
+            # Then we've set ourselves to have no timeouts
             # Get out and stay out
             return
 
@@ -111,11 +111,11 @@ class StatusPoller(BaseWorkerThread):
             if statusTime == 0:
                 logging.error("Not killing job %i, the status time was zero", job['id'])
                 continue
-            if timeout != None and statusTime != None:
+            if timeout and statusTime:
                 if time.time() - float(statusTime) > float(timeout):
                     # Then the job needs to be killed.
-                    logging.info("Killing job %i because it has exceeded timeout for status %s", job['id'], globalState)
-                    job['status'] = 'Timeout'
+                    logging.info("Killing job %i because it has exceeded timeout for status '%s'", job['id'], globalState)
+                    job['status'] = globalState
                     jobsToKill.append(job)
 
         # We need to show that the jobs are in state timeout


### PR DESCRIPTION
As suggested by @bbockelm , this should make the condor_rm much more efficient.
From my tests, 'status' seems to be the key really holding the last known condor status.

I still need to test it.
