### PR TITLE
Increase the WQE size for MC policy

### DIFF
--- a/src/python/WMCore/WorkQueue/Policy/Start/MonteCarlo.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/MonteCarlo.py
@@ -27,7 +27,7 @@ class MonteCarlo(StartPolicyInterface):
         self.args.setdefault('SliceSize', 1000)         # events per job
         self.args.setdefault('SubSliceType', 'NumberOfEventsPerLumi')
         self.args.setdefault('SubSliceSize', self.args['SliceSize']) # events per lumi
-        self.args.setdefault('MaxJobsPerElement', 250)  # jobs per WQE
+        self.args.setdefault('MaxJobsPerElement', 1000)  # jobs per WQE
         self.args.setdefault('blowupFactor', 1.0) # Estimate of additional jobs following tasks.
                                                   # Total WQE tasks will be Jobs*(1+blowupFactor)
 


### PR DESCRIPTION
Since we just had problems aborting a monstrous workflow (that brought central couchdb down twice - so far), let's increase the WQE size for MonteCarlo workflows such that we can cut the amount of docs by 4.

@ticoann besides agents acquiring more work than they should, do you foresee any problem with this change?
