### PR TITLE
Remove logging lines hitting couch

### DIFF
--- a/src/couchapps/WorkQueue/lists/workRestrictions.js
+++ b/src/couchapps/WorkQueue/lists/workRestrictions.js
@@ -67,8 +67,6 @@ function(head, req) {
         }
 
         for (var site in resources) {
-			log(site);
-			log(ele);
             // skip if in blacklist
             if (ele["SiteBlacklist"].indexOf(site) !== -1) {
                 continue;


### PR DESCRIPTION
There was this stupid guy nicknamed amaltaro that forgot these 2 logging lines in the code. Thanks to that brilliant mind, couchdb logs were increasing 100GB per day..

@ticoann please add it to Today's testbed tag

PS.: Diego removed these two lines in vocms0140 and vocms0131 already.
