### PR TITLE
transaction logic fix

### DIFF
--- a/src/python/WMCore/Database/DBCore.py
+++ b/src/python/WMCore/Database/DBCore.py
@@ -6,7 +6,7 @@ Core Database APIs
 
 
 """
-
+import traceback
 from WMCore.DataStructs.WMObject import WMObject
 from WMCore.Database.ResultSet import ResultSet
 from copy import copy
@@ -57,13 +57,19 @@ class DBInterface(WMObject):
 
         returns a list of sqlalchemy.engine.base.ResultProxy objects
         """
-        if b == None:
-            resultProxy = connection.execute(s)
-        else:
-            resultProxy = connection.execute(s, b)
-        yield resultProxy
+        try:
+            if b == None:
+                resultProxy = connection.execute(s)
+            else:
+                resultProxy = connection.execute(s, b)
+        except:
+            traceback.print_exc()
+            resultProxy = None
+        if resultProxy:
+            yield resultProxy
         if not returnCursor:
-            resultProxy.close()
+            if resultProxy and hasattr(resultProxy, "close"):
+                resultProxy.close()
 
     def executemanybinds(self, s=None, b=None, connection=None,
                          returnCursor=False):
@@ -96,8 +102,13 @@ class DBInterface(WMObject):
                     yield resultproxy
                     resultproxy.close()
             return
-        result = connection.execute(s, b)
-        yield result
+        try:
+            result = connection.execute(s, b)
+        except:
+            traceback.print_exc()
+            result = None
+        if result:
+            yield result
 
     def connection(self):
         """

--- a/src/python/WMCore/Database/DBCore.py
+++ b/src/python/WMCore/Database/DBCore.py
@@ -7,8 +7,6 @@ Core Database APIs
 
 """
 
-
-
 from WMCore.DataStructs.WMObject import WMObject
 from WMCore.Database.ResultSet import ResultSet
 from copy import copy
@@ -29,21 +27,21 @@ class DBInterface(WMObject):
         Support executemany()
     """
 
-    logger = None
-    engine = None
-
     def __init__(self, logger, engine):
+        super(DBInterface, self).__init__(self)
         self.logger = logger
         self.logger.info ("Instantiating base WM DBInterface")
         self.engine = engine
         self.maxBindsPerQuery = 500
 
-    def buildbinds(self, sequence, thename, therest=[{}]):
+    def buildbinds(self, sequence, thename, therest=None):
         """
         Build a list of binds. Can be used recursively, e.g.:
         buildbinds(file, 'file', buildbinds(sename, 'location'), {'lumi':123})
         TODO: replace with an appropriate map function
         """
+        if  not therest:
+            therest = [{}]
         binds = []
         for r in sequence:
             for i in self.makelist(therest):
@@ -63,14 +61,9 @@ class DBInterface(WMObject):
             resultProxy = connection.execute(s)
         else:
             resultProxy = connection.execute(s, b)
-
-        if returnCursor:
-            return resultProxy
-
-        result = ResultSet()
-        result.add(resultProxy)
-        resultProxy.close()
-        return result
+        yield resultProxy
+        if not returnCursor:
+            resultProxy.close()
 
     def executemanybinds(self, s=None, b=None, connection=None,
                          returnCursor=False):
@@ -92,27 +85,19 @@ class DBInterface(WMObject):
 
         s = s.strip()
         if s.lower().endswith('select', 0, 6):
-            """
-            Trying to select many
-            """
+            # Trying to select many
             if returnCursor:
-                result = []
                 for bind in b:
-                    result.append(connection.execute(s, bind))
+                    result = connection.execute(s, bind)
+                    yield result
             else:
-                result = ResultSet()
                 for bind in b:
                     resultproxy = connection.execute(s, bind)
-                    result.add(resultproxy)
+                    yield resultproxy
                     resultproxy.close()
-
-            return self.makelist(result)
-
-        """
-        Now inserting or updating many
-        """
+            return
         result = connection.execute(s, b)
-        return self.makelist(result)
+        yield result
 
     def connection(self):
         """
@@ -120,85 +105,95 @@ class DBInterface(WMObject):
         """
         return self.engine.connect()
 
+    def processData(self, sqlstmt, binds=None, conn=None,
+                    transaction=True, returnCursor=False):
+        """Wrapper around _processData generator"""
+        if  not binds:
+            binds = {}
+        connection = conn if conn else self.connection()
+#        print("### processData engine obj=%s, engine=%s, sql=%s, binds=%s, conn=%s, trainsaction=%s" \
+#                % (hex(id(self.engine)), self.engine.__dict__['engine'], sqlstmt, binds, conn, transaction))
+        gen = self._processData(sqlstmt, binds, connection, transaction, returnCursor)
+        rset = ResultSet()
+        for resultproxy in gen:
+            rset.add(resultproxy)
+        if not conn:
+            connection.close()
+        return [rset]
 
-    def processData(self, sqlstmt, binds={}, conn=None,
-                    transaction=False, returnCursor=False):
+    def _processData(self, sqlstmt, binds=None, connection=None,
+                    transaction=True, returnCursor=False):
         """
         set conn if you already have an active connection to reuse
         set transaction = True if you already have an active transaction
 
         """
-        connection = None
-        try:
-            if not conn:
-                connection = self.connection()
-            else:
-                connection = conn
+        if  not binds:
+            binds = {}
+        # Can take either a single statement or a list of statements and binds
+        sqlstmt = self.makelist(sqlstmt)
+        binds = self.makelist(binds)
+        if len(sqlstmt) > 0 and (len(binds) == 0 or (binds[0] == {} or binds[0] == None)):
+            if transaction:
+                trans = connection.begin()
 
-            result = []
-            # Can take either a single statement or a list of statements and binds
-            sqlstmt = self.makelist(sqlstmt)
-            binds = self.makelist(binds)
-            if len(sqlstmt) > 0 and (len(binds) == 0 or (binds[0] == {} or binds[0] == None)):
-                # Should only be run by create statements
-                if not transaction:
-                    #WMCore.WMLogging.sqldebug("transaction created in DBInterface")
-                    trans = connection.begin()
+            for i in sqlstmt:
+                gen = self.executebinds(i, connection=connection,
+                                      returnCursor=returnCursor)
+                for rec in gen:
+                    yield rec
 
-                for i in sqlstmt:
-                    r = self.executebinds(i, connection=connection,
-                                          returnCursor=returnCursor)
-                    result.append(r)
+            if transaction:
+                trans.commit()
+        elif len(binds) > len(sqlstmt) and len(sqlstmt) == 1:
+            #Run single SQL statement for a list of binds - use execute_many()
+            if transaction:
+                trans = connection.begin()
+            while(len(binds) > self.maxBindsPerQuery):
+                gen = self._processData(sqlstmt, binds[:self.maxBindsPerQuery],
+                                               connection=connection, transaction=True,
+                                               returnCursor=returnCursor)
+                for rec in gen:
+                    yield rec
+                binds = binds[self.maxBindsPerQuery:]
 
-                if not transaction:
-                    trans.commit()
-            elif len(binds) > len(sqlstmt) and len(sqlstmt) == 1:
-                #Run single SQL statement for a list of binds - use execute_many()
-                if not transaction:
-                    trans = connection.begin()
-                while(len(binds) > self.maxBindsPerQuery):
-                    result.extend(self.processData(sqlstmt, binds[:self.maxBindsPerQuery],
-                                                   conn=connection, transaction=True,
-                                                   returnCursor=returnCursor))
-                    binds = binds[self.maxBindsPerQuery:]
+            for i in sqlstmt:
+                gen = self.executemanybinds(i, binds, connection=connection,
+                                                    returnCursor=returnCursor)
+                for rec in gen:
+                    yield rec
 
-                for i in sqlstmt:
-                    result.extend(self.executemanybinds(i, binds, connection=connection,
-                                                        returnCursor=returnCursor))
-                if not transaction:
-                    trans.commit()
-            elif len(binds) == len(sqlstmt):
-                # Run a list of SQL for a list of binds
-                if not transaction:
-                    trans = connection.begin()
+            if transaction:
+                trans.commit()
+        elif len(binds) == len(sqlstmt):
+            # Run a list of SQL for a list of binds
+            if transaction:
+                trans = connection.begin()
 
-                for i, s in enumerate(sqlstmt):
-                    b = binds[i]
+            for i, s in enumerate(sqlstmt):
+                b = binds[i]
 
-                    r = self.executebinds(s, b, connection=connection,
-                                          returnCursor=returnCursor)
-                    result.append(r)
+                gen = self.executebinds(s, b, connection=connection,
+                                      returnCursor=returnCursor)
+                for rec in gen:
+                    yield rec
 
-                if not transaction:
-                    trans.commit()
-            else:
-                self.logger.exception(
-                    "DBInterface.processData Nothing executed, problem with your arguments")
-                self.logger.exception(
-                    "DBInterface.processData SQL = %s" % sqlstmt)
-                WMCore.WMLogging.sqldebug('DBInterface.processData  sql is %s items long' % len(sqlstmt))
-                WMCore.WMLogging.sqldebug('DBInterface.processData  binds are %s items long' % len(binds))
-                assert_value = False
-                if len(binds) == len(sqlstmt):
-                    assert_value = True
-                WMCore.WMLogging.sqldebug('DBInterface.processData are binds and sql same length? : %s' % (assert_value))
-                WMCore.WMLogging.sqldebug('sql: %s\n binds: %s\n, connection:%s\n, transaction:%s\n' %
-                                           (sqlstmt, binds, connection, transaction))
-                WMCore.WMLogging.sqldebug('type check:\nsql: %s\n binds: %s\n, connection:%s\n, transaction:%s\n' %
-                                           (type(sqlstmt), type(binds), type(connection), type(transaction)))
-                raise Exception("""DBInterface.processData Nothing executed, problem with your arguments
-                Probably mismatched sizes for sql (%i) and binds (%i)""" % (len(sqlstmt), len(binds)))
-        finally:
-            if not conn and connection != None:
-                connection.close() # Return connection to the pool
-        return result
+            if transaction:
+                trans.commit()
+        else:
+            self.logger.exception(
+                "DBInterface.processData Nothing executed, problem with your arguments")
+            self.logger.exception(
+                "DBInterface.processData SQL = %s" % sqlstmt)
+            WMCore.WMLogging.sqldebug('DBInterface.processData  sql is %s items long' % len(sqlstmt))
+            WMCore.WMLogging.sqldebug('DBInterface.processData  binds are %s items long' % len(binds))
+            assert_value = False
+            if len(binds) == len(sqlstmt):
+                assert_value = True
+            WMCore.WMLogging.sqldebug('DBInterface.processData are binds and sql same length? : %s' % (assert_value))
+            WMCore.WMLogging.sqldebug('sql: %s\n binds: %s\n, connection:%s\n, transaction:%s\n' %
+                                       (sqlstmt, binds, connection, transaction))
+            WMCore.WMLogging.sqldebug('type check:\nsql: %s\n binds: %s\n, connection:%s\n, transaction:%s\n' %
+                                       (type(sqlstmt), type(binds), type(connection), type(transaction)))
+            raise Exception("""DBInterface.processData Nothing executed, problem with your arguments
+            Probably mismatched sizes for sql (%i) and binds (%i)""" % (len(sqlstmt), len(binds)))

--- a/src/python/WMCore/Database/DBFormatter.py
+++ b/src/python/WMCore/Database/DBFormatter.py
@@ -46,7 +46,7 @@ class DBFormatter(WMObject):
         for r in result:
             for i in r.fetchall():
                 row = []
-                for j in i:
+                for j in i.values():
                     row.append(j)
                 out.append(row)
             r.close()
@@ -68,22 +68,8 @@ class DBFormatter(WMObject):
         """
         dictOut = []
         for r in result:
-            descriptions = r.keys
             for i in r.fetchall():
-                #WARNING: this can generate errors for some stupid reason
-                # in both oracle and mysql.
-                entry = {}
-                for index in xrange(0,len(descriptions)):
-                    # WARNING: Oracle returns table names in CAP!
-                    if type(i[index]) == unicode:
-                        entry[str(descriptions[index].lower())] = str(i[index])
-                    else:
-                        entry[str(descriptions[index].lower())] = i[index]
-
-                dictOut.append(entry)
-
-            r.close()
-
+                dictOut.append(i)
         return dictOut
 
     def formatOneDict(self, result):
@@ -94,12 +80,7 @@ class DBFormatter(WMObject):
             return {}
 
         r = result[0]
-        description = map(lambda x: str(x).lower(), r.keys)
-        if len(r.data) < 1:
-            return {}
-
-        return dict(list(zip(description, r.fetchone())))
-
+        return r.fetchone()
 
     def formatCursor(self, cursor, size=10):
         """
@@ -109,7 +90,7 @@ class DBFormatter(WMObject):
         Use fetchmany(size = default arraysize = 50)
 
         """
-	if type(cursor.keys) == types.MethodType:
+        if isinstance(cursor.keys, types.MethodType):
             keys = [x.lower() for x in cursor.keys()]
         else:
             keys = [x.lower() for x in cursor.keys]

--- a/src/python/WMCore/Database/ResultSet.py
+++ b/src/python/WMCore/Database/ResultSet.py
@@ -1,43 +1,175 @@
 """
 _ResultSet_
-
 A class to read in a SQLAlchemy result proxy and hold the data, such that the
 SQLAlchemy result sets (aka cursors) can be closed. Make this class look as much
 like the SQLAlchemy class to minimise the impact of adding this class.
 """
+from __future__ import print_function, division
+import sqlalchemy
+import operator
 
+class ResultRow(object):
+    """Class which immitates sqlalchemy result row object which is basically a dict
+    which allows iteration and values access"""
+    def __init__(self, row, sqlKeys):
+        self._data = row
+        self._keys = [k for k in sqlKeys if k in row.keys()]
+    def keys(self):
+        """Imitate dict keys method"""
+        return self._keys
+    def values(self):
+        """Imitate dict values method"""
+        return [self._data[k] for k in self._keys]
+    def __getitem__(self, key):
+        """Imitate dict getitem method, i.e. access object by bracket"""
+        if isinstance(key, int):
+            return self._data[self._keys[key]]
+        if isinstance(key, basestring):
+            return self._data.get(key, '')
+    def __setitem__(self, key, value):
+        """Imitate dict setitem method"""
+        if  key not in self._keys:
+            self._keys.append(key)
+        self._data[key] = value
+    def __delitem__(self, key):
+        """Imitate dict delitem method"""
+        try:
+            self._keys.remove(key)
+        except ValueError:
+            pass
+        del self._data[key]
+    def update(self, rec):
+        """Imitate dict update method"""
+        self._keys += [k for k in rec.keys() if k not in self._keys]
+        self._data.update(rec)
+    def get(self, key, default=None):
+        """Imitate dict get method"""
+        return self._data.get(key, default)
+    def items(self):
+        """Imitate dict items method"""
+        return [pair for pair in self.iteritems()]
+    def iteritems(self):
+        """Imitate dict iteritems method"""
+        for key in self._keys:
+            yield (key, self.get(key))
+    def __len__(self):
+        return len(self._data.values())
+    def __str__(self):
+        """Imitate dict str method"""
+        return str(self._data)
+    def __repr__(self):
+        """Imitate dict repr method"""
+        return repr(self._data)
 
+    def _op(self, other, op):
+        """Helper function to perform given operation over other part"""
+        if isinstance(other, dict):
+            return op(self._data, other)
+        if other:
+            return op(self._data, other._data)
+        return op(self._data, other)
 
+    def __lt__(self, other):
+        """Comparison lt operator implementation"""
+        return self._op(other, operator.lt)
 
-import threading
+    def __le__(self, other):
+        """Comparison le operator implementation"""
+        return self._op(other, operator.le)
+
+    def __ge__(self, other):
+        """Comparison ge operator implementation"""
+        return self._op(other, operator.ge)
+
+    def __gt__(self, other):
+        """Comparison gt operator implementation"""
+        return self._op(other, operator.gt)
+
+    def __eq__(self, other):
+        """Comparison eq operator implementation"""
+        return self._op(other, operator.eq)
+
+    def __ne__(self, other):
+        """Comparison ne operator implementation"""
+        return self._op(other, operator.ne)
 
 class ResultSet:
-    def __init__(self):
-        self.data = []
-        self.keys = []
+    """
+    Class to read SQLAlchemy result proxy objects and convert it into
+    python data structure. The class should provide iterable interface
+    and hold fetched keys.
+    """
+    def __init__(self, resultproxy=None):
+        self.keys, self.data = parse(resultproxy)
+        self.pos = 0 # current position of records to be retrieved
+
+    def __len__(self):
+        """Length method"""
+        return len(self.data)
+
+    def __iter__(self):
+        """Iterator method"""
+        return iter(self.data)
 
     def close(self):
+        """Imitate close of resultproxy object"""
         return
 
     def fetchone(self):
+        """Imitate fetchone method of resultproxy object"""
         if len(self.data) > 0:
             return self.data[0]
         else:
             return []
 
     def fetchall(self):
+        """Imitate fetchall method of resultproxy object"""
         return self.data
 
+    def fetchmany(self, size=None):
+        """Imitate fetchmany method of resultproxy object"""
+        if  size == None: # all data
+            return self.data
+        if self.pos == 0 and size > len(self.data): # we've been asked for all data
+            return self.data
+        if self.pos+size > len(self.data):
+            raise StopIteration
+        data = self.data[self.pos:self.pos+size]
+        self.pos = self.pos+size
+        return data
+
     def add(self, resultproxy):
+        """Add new resultproxy object into result set"""
+        keys, data = parse(resultproxy)
+        if self.keys:
+            if keys != self.keys:
+                msg = "WARNING, ResultRow:add, result proxy keys mismatch, %s=!%s" % (keys, self.keys)
+                print(msg)
+                self.keys = [k for k in keys if k not in self.keys]
+        else:
+            self.keys = keys
+        for rec in data:
+            self.data.append(rec)
 
-        myThread = threading.currentThread()
-
-        if resultproxy.closed:
-            return
-        elif resultproxy.returns_rows:
-            for r in resultproxy:
-                if len(self.keys) == 0:
-                    self.keys.extend(r.keys())
-                self.data.append(r)
-
-        return
+def parse(resultproxy):
+    """Helper function to parse SQLAlchemy resultproxy object"""
+    values = []
+    keys = []
+    if resultproxy and not resultproxy.closed:
+        data = []
+        try:
+            data = resultproxy.fetchall()
+        except sqlalchemy.exc.ResourceClosedError:
+            pass
+        except Exception as exp:
+            msg = 'ResultSet, failed to fetch resultproxy object, %s type=%s' \
+                    % (str(exp), type(exp))
+            print(msg) # need to get something when run within threads
+            raise Exception(msg)
+        for r in data:
+            if  not keys:
+                keys = [i.lower() for i in r.keys()]
+            rec = ResultRow(dict(zip(keys, r.values())), keys)
+            values.append(rec)
+        resultproxy.close()
+    return keys, values

--- a/test/python/WMCore_t/BossAir_t/RunJob_t.py
+++ b/test/python/WMCore_t/BossAir_t/RunJob_t.py
@@ -140,7 +140,7 @@ class RunJobTest(unittest.TestCase):
         statusDAO.execute(states = ['New', 'Gone', 'Dead'])
 
         result = myThread.dbi.processData("SELECT name FROM bl_status")[0].fetchall()
-        self.assertEqual(result, [('Dead',), ('Gone',), ('New',)])
+        self.assertEqual([tuple(r.values()) for r in result], [('Dead',), ('Gone',), ('New',)])
 
 
         newJobDAO = self.daoFactory(classname = "NewJobs")
@@ -148,7 +148,7 @@ class RunJobTest(unittest.TestCase):
 
 
         result = myThread.dbi.processData("SELECT wmbs_id FROM bl_runjob")[0].fetchall()
-        self.assertEqual(result,
+        self.assertEqual([tuple(r.values()) for r in result],
                          [(1,), (2,), (3,), (4,), (5,), (6,), (7,), (8,), (9,), (10,)])
 
 

--- a/test/python/WMCore_t/WMBS_t/File_t.py
+++ b/test/python/WMCore_t/WMBS_t/File_t.py
@@ -280,27 +280,17 @@ class FileTest(unittest.TestCase):
         assert testFileA == testFileC, \
                "ERROR: File load by ID didn't work"
 
-        assert type(testFileB["id"]) == int, \
-               "ERROR: File id is not an integer type."
-        assert type(testFileB["size"]) == int, \
-               "ERROR: File size is not an integer type."
-        assert type(testFileB["events"]) == int, \
-               "ERROR: File events is not an integer type."
-        assert type(testFileB["checksums"]) == dict, \
+        for attr in ["id", "size", "events", "first_event"]:
+            cond = isinstance(testFileB[attr], int) or isinstance(testFileB[attr], long)
+            msg = "ERROR: File %s is not an integer type" % attr
+            assert cond == True, "ERROR: File id is not an integer type."
+        assert isinstance(testFileB["checksums"], dict), \
                "ERROR: File cksum is not a string type."
-        assert type(testFileB["first_event"]) == int, \
-               "ERROR: File first_event is not an integer type."
 
-        assert type(testFileC["id"]) == int, \
-               "ERROR: File id is not an integer type."
-        assert type(testFileC["size"]) == int, \
-               "ERROR: File size is not an integer type."
-        assert type(testFileC["events"]) == int, \
-               "ERROR: File events is not an integer type."
-        assert type(testFileC["checksums"]) == dict, \
-               "ERROR: File cksum is not an string type."
-        assert type(testFileC["first_event"]) == int, \
-               "ERROR: File first_event is not an integer type."
+        for attr in ["id", "size", "events", "first_event"]:
+            cond = isinstance(testFileC[attr], int) or isinstance(testFileC[attr], long)
+            msg = "ERROR: File %s is not an integer type" % attr
+            assert cond == True, "ERROR: File id is not an integer type."
 
         self.assertEqual(testFileC['checksums'], {'cksum': '101'})
 


### PR DESCRIPTION
This was reverted due to the following errors in Tier0

Reverting back due to the errors found in Tier0 test.
Here is Dirk's finding.

Noticed two failures:

1) select queries break if two column names are identical

https://github.com/dmwm/T0/blob/master/src/python/T0/WMBS/Oracle/RunConfig/GetStreamDatasetTriggers.py

As you see, the two columns selected have the same name, but in
different tables. This didn't work anymore, it somehow got confused by
the identical names and returned (column2,column2) instead of
(column1,column2).

2) array inserts seems to sometimes drop some binds

https://github.com/dmwm/T0/blob/master/src/python/T0/WMBS/Oracle/RunConfig/InsertLumiSection.py

Passed lumis 1 to 100 (same run), it always skips inserting lumi 46.

Probably would fail in other places too, these are the two things I
noticed (and which killed the Tier0 tests).

Cheers

   Dirk
