### PR TITLE
Update memory and cores requirements during assignment

### DIFF
--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
@@ -413,13 +413,11 @@ class Assign(WebAPI):
         blockCloseMaxFiles = int(kwargs.get("BlockCloseMaxFiles", helper.getBlockCloseMaxFiles()))
         blockCloseMaxEvents = int(kwargs.get("BlockCloseMaxEvents", helper.getBlockCloseMaxEvents()))
         blockCloseMaxSize = int(kwargs.get("BlockCloseMaxSize", helper.getBlockCloseMaxSize()))
-
         helper.setBlockCloseSettings(blockCloseMaxWaitTime, blockCloseMaxFiles,
                                      blockCloseMaxEvents, blockCloseMaxSize)
 
+        helper.setMemoryAndCores(kwargs.get("Memory"), kwargs.get("Multicore"))
         helper.setDashboardActivity(kwargs.get("Dashboard", ""))
-        # set Task properties if they are exist
-        # TODO: need to define the task format (maybe kwargs["tasks"]?)
         helper.setTaskProperties(kwargs)
 
         Utilities.saveWorkload(helper, request['RequestWorkflow'], self.wmstatWriteURL)

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -5,7 +5,6 @@ _WMWorkload_
 Request level processing specification, acts as a container of a set
 of related tasks.
 """
-
 from WMCore.Configuration import ConfigSection
 from WMCore.WMSpec.ConfigSectionTree import findTop
 from WMCore.WMSpec.Persistency import PersistencyHelper
@@ -451,12 +450,10 @@ class WMWorkloadHelper(PersistencyHelper):
         for site in newWhiteList:
             if '*' in site:
                 msg = "Invalid wildcard site %s in site whitelist!" % site
-                # logging.error(msg)
                 raise WMWorkloadException(msg)
         for site in newBlackList:
             if '*' in site:
                 msg = "Invalid wildcard site %s in site blacklist!" % site
-                # logging.error(msg)
                 raise WMWorkloadException(msg)
 
         self.setSiteWhitelist(siteWhitelist=newWhiteList)
@@ -636,6 +633,17 @@ class WMWorkloadHelper(PersistencyHelper):
                         cmsswHelper = stepHelper.getTypeHelper()
                         cmsswHelper.setDatasetName(datasetName)
 
+        return
+
+    def setMemoryAndCores(self, memory=None, cores=None):
+        """
+        _setMemoryAndCores_
+
+        Update memory requirements and number of cores for all tasks in the spec
+        """
+        for task in self.taskIterator():
+            task.setNumberOfCores(cores)
+            task.setJobResourceInformation(memoryReq=memory)
         return
 
     def setAcquisitionEra(self, acquisitionEras):
@@ -1751,6 +1759,8 @@ class WMWorkloadHelper(PersistencyHelper):
 
         if self._checkKeys(kwargs, "Dashboard"):
             self.setDashboardActivity(kwargs["Dashboard"])
+
+        self.setMemoryAndCores(kwargs.get("Memory"), kwargs.get("Multicore"))
 
         # TODO: need to define proper task form maybe kwargs['Tasks']?
         self.setTaskProperties(kwargs)


### PR DESCRIPTION
As we @ticoann @ericvaandering discussed some time ago, these are the required change to make "Multicore" and "Memory" parameters overwritable during assignment.

It's still not clear to me whether we should also update the reqmgr2 couch doc (reqmgr_workload_cache). If we do, then the original values are gone and any clones would use the new values. I'm inclined not to... I think (?)

Initial tests work Ok in my VM, though I still need to check the reqmgr2 part.
