### PR TITLE
Allow to use callables as configuration params

### DIFF
--- a/test/python/WMCore_t/Configuration_t.py
+++ b/test/python/WMCore_t/Configuration_t.py
@@ -7,10 +7,50 @@ import os
 
 from WMCore.Configuration import ConfigSection
 from WMCore.Configuration import Configuration
+from WMCore.Configuration import ConfigurationEx
 from WMCore.Configuration import loadConfigurationFile
 from WMCore.Configuration import saveConfigurationFile
 
-from WMQuality.TestInitCouchApp import TestInitCouchApp as TestInit
+from WMQuality.TestInit import TestInit
+
+
+class ConfigurationExTest(unittest.TestCase):
+    """
+    test case for Configuration object
+
+    """
+    def setUp(self):
+        """set up"""
+        self.testInit = TestInit(__file__)
+        self.testDir  = self.testInit.generateWorkDir()
+        self.functionSave = "%s/WMCore_Agent_Configuration_t_function.py" % self.testDir
+
+
+    def tearDown(self):
+        """clean up"""
+        self.testInit.delWorkDir()
+
+
+    def testCallableConfigParams(self):
+        """ctor"""
+        def f():
+            return True
+
+        config = Configuration()
+        config.section_("SectionF")
+        #creating field for the following test
+        config.SectionF.aFunction = ''
+        #Cannot set a function for plain Configuration objects
+        #config.SectionF.__setattr__('aFunction', f)
+        self.assertRaises(RuntimeError, config.SectionF.__setattr__, config.SectionF.aFunction, f)
+
+        config = ConfigurationEx()
+        config.section_("SectionF")
+        #No failures with configurationEx
+        config.SectionF.aFunction = f
+
+        #However ConfigurationEx instances cannot be saved
+        self.assertRaises(RuntimeError, saveConfigurationFile, config, self.functionSave)
 
 
 class ConfigurationTest(unittest.TestCase):
@@ -119,7 +159,7 @@ class ConfigurationTest(unittest.TestCase):
         self.assertRaises(
             RuntimeError, setattr,
             config.Section2, "BadDict", badDict)
-        
+
         goodDict = { "dict" : {}, "list": [], "tuple" : () }
         config.Section2.GoodDict = goodDict
 

--- a/test/python/WMCore_t/Configuration_t.py
+++ b/test/python/WMCore_t/Configuration_t.py
@@ -3,7 +3,6 @@
 
 
 import unittest
-import os
 
 from WMCore.Configuration import ConfigSection
 from WMCore.Configuration import Configuration
@@ -75,7 +74,7 @@ class ConfigurationTest(unittest.TestCase):
     def testA(self):
         """ctor"""
         try:
-            config = Configuration()
+            dummyConfig = Configuration()
         except Exception as ex:
             msg = "Failed to instantiate Configuration\n"
             msg += str(ex)
@@ -246,19 +245,19 @@ class ConfigurationTest(unittest.TestCase):
                 sect.document_("This is Parameter%s" %i,
                                "Parameter%s" %i)
 
-        stringSave = str(config)
-        documentSave = config.documentedString_()
-        commentSave = config.commentedString_()
+        dummyStringSave = str(config)
+        dummyDocumentSave = config.documentedString_()
+        dummyCommentSave = config.commentedString_()
 
         saveConfigurationFile(config, self.normalSave)
         saveConfigurationFile(config, self.docSave, document = True)
         saveConfigurationFile(config, self.commentSave, comment = True)
 
-        plainConfig = loadConfigurationFile(self.normalSave)
+        dummyPlainConfig = loadConfigurationFile(self.normalSave)
 
-        docConfig = loadConfigurationFile(self.docSave)
+        dummyDocConfig = loadConfigurationFile(self.docSave)
 
-        commentConfig = loadConfigurationFile(self.commentSave)
+        dummyCommentConfig = loadConfigurationFile(self.commentSave)
 
         #print commentConfig.commentedString_()
         #print docConfig.documentedString_()

--- a/test/python/WMCore_t/FwkJobReport_t/Report_t.py
+++ b/test/python/WMCore_t/FwkJobReport_t/Report_t.py
@@ -680,7 +680,7 @@ cms::Exception caught in EventProcessor and rethrown
 
         myReport.save(path1)
         info = BasicAlgos.getFileInfo(filename=path1)
-        self.assertEqual(info['Size'], 7101)
+        sizeBefore = info['Size']
 
         inputFiles = myReport.getAllInputFiles()
         self.assertEqual(len(inputFiles), 1)
@@ -689,7 +689,9 @@ cms::Exception caught in EventProcessor and rethrown
 
         myReport.save(path2)
         info = BasicAlgos.getFileInfo(filename=path2)
-        self.assertEqual(info['Size'], 6210)
+        sizeAfter = info['Size']
+
+        self.assertGreater(sizeBefore, sizeAfter)
 
         return
 


### PR DESCRIPTION
That's a very useful feature imho that exploits the true potential of having a configuration in python.

In particular I would like to have as a parameter of CRAB the function we use to pick up the schedd depending on parameters like memory usage, running jobs etc.
