### PR TITLE
1.0.16_crab version of Add Dashboard dir to crabtaskworker dependencies

### DIFF
--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -135,7 +135,8 @@ dependencies = {'wmc-rest':{
                 'crabtaskworker':{
                         'packages':['WMCore.WorkQueue', 'WMCore.Credential', 'WMCore.Algorithms+', 'WMCore.WMSpec+',
                                     'WMCore.JobSplitting', 'WMCore.Services.SiteDB+', 'WMCore.Services.DBS+',
-                                    'WMCore.Services.UserFileCache+', 'WMCore.Services.PhEDEx+', 'Utils+'],
+                                    'WMCore.Services.UserFileCache+', 'WMCore.Services.PhEDEx+', 'WMCore.Services.Dashboard+',
+                                    'Utils+'],
                         'modules': ['WMCore.WMBS.File', 'WMCore.WMBS.WMBSBase', 'WMCore.WMBS.__init__'],
                         'systems': ['wmc-database', 'wmc-runtime'],
                         },


### PR DESCRIPTION
Issue discovered during HG1606 validation [*] about a missing module.

PR on master: #6890 

[*] https://github.com/dmwm/CRABServer/issues/5229#issuecomment-221642195
