### PR TITLE
Refactor SiteDB into two parts to make it easy to mock

### DIFF
--- a/src/python/WMCore/Services/SiteDB/SiteDBAPI.py
+++ b/src/python/WMCore/Services/SiteDB/SiteDBAPI.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+"""
+_SiteDBAPI_
+
+API for retrieving information from SiteDB
+
+"""
+
+import json
+
+from WMCore.Services.Service import Service
+
+def unflattenJSON(data):
+    """Tranform input to unflatten JSON format"""
+    columns = data['desc']['columns']
+    return [row2dict(columns, row) for row in data['result']]
+
+def row2dict(columns, row):
+    """Convert rows to dictionaries with column keys from description"""
+    robj = {}
+    for k,v in zip(columns, row):
+        robj.setdefault(k,v)
+    return robj
+
+
+
+class SiteDBAPI(Service):
+    """
+    Class to define just the data interaction layer with SiteDB
+    """
+
+    def __init__(self, config={}):
+        config = dict(config)
+        config['endpoint'] = "https://cmsweb.cern.ch/sitedb/data/prod/"
+        Service.__init__(self, config)
+
+    def getJSON(self, callname, filename='result.json', clearCache=False, verb='GET', data={}):
+        """
+        _getJSON_
+
+        retrieve JSON formatted information given the service name and the
+        argument dictionaries
+
+        TODO: Probably want to move this up into Service
+        """
+        print ("Using real SiteDB getJSON")
+        result = ''
+        if clearCache:
+            self.clearCache(cachefile=filename, inputdata=data, verb=verb)
+        try:
+            # Set content_type and accept_type to application/json to get json returned from siteDB.
+            # Default is text/html which will return xml instead
+            # Add accept-encoding to gzip,identity to overwrite httplib default gzip,deflate,
+            # which is not working properly with cmsweb
+            f = self.refreshCache(cachefile=filename, url=callname, inputdata=data,
+                                  verb=verb, contentType='application/json',
+                                  incoming_headers={'Accept': 'application/json',
+                                                    'accept-encoding': 'gzip,identity'})
+            result = f.read()
+            f.close()
+        except IOError:
+            raise RuntimeError("URL not available: %s" % callname)
+        try:
+            results = json.loads(result)
+            results = unflattenJSON(results)
+            return results
+        except SyntaxError:
+            self.clearCache(filename, inputdata=data, verb=verb)
+            raise SyntaxError("Problem parsing data. Cachefile cleared. Retrying may work")


### PR DESCRIPTION
This is a change that will be part of @jha2 's branch for mocking SiteDB, so don't merge this. However you can look at it. The point is to split SiteDB into two parts. One which actually talks to SiteDB and the other which parses the dictionaries it returns. This makes it possible to use mock to just replace the lower level and leave the upper level alone.

@ticoann and @amaltaro , please feel free to review/comment.
