### PR TITLE
switch logcollect stagein to use edmCopyUtil, fixes #6740

### DIFF
--- a/src/python/WMCore/WMBS/CreateWMBSBase.py
+++ b/src/python/WMCore/WMBS/CreateWMBSBase.py
@@ -9,7 +9,6 @@ import threading
 from WMCore.Database.DBCreator import DBCreator
 
 from WMCore.WMException import WMException
-from WMCore.WMExceptions import WMEXCEPTION
 from WMCore.JobStateMachine.Transitions import Transitions
 
 class CreateWMBSBase(DBCreator):
@@ -26,11 +25,8 @@ class CreateWMBSBase(DBCreator):
         if dbi == None:
             dbi = myThread.dbi
 
-        tablespaceTable = ""
         tablespaceIndex = ""
         if params:
-            if "tablespace_table" in params:
-                tablespaceTable = "TABLESPACE %s" % params["tablespace_table"]
             if "tablespace_index" in params:
                 tablespaceIndex = "USING INDEX TABLESPACE %s" % params["tablespace_index"]
 
@@ -115,12 +111,12 @@ class CreateWMBSBase(DBCreator):
           """CREATE TABLE wmbs_location (
              id          INTEGER      PRIMARY KEY AUTO_INCREMENT,
              site_name   VARCHAR(255) NOT NULL,
+             state       INTEGER NOT NULL,
              cms_name    VARCHAR(255),
              ce_name     VARCHAR(255),
              running_slots   INTEGER,
              pending_slots   INTEGER,
              plugin      VARCHAR(255),
-             state       INTEGER NOT NULL,
              UNIQUE(site_name),
              FOREIGN KEY (state) REFERENCES wmbs_location_state(id))"""
 

--- a/src/python/WMCore/WMBS/Oracle/Create.py
+++ b/src/python/WMCore/WMBS/Oracle/Create.py
@@ -159,12 +159,12 @@ class Create(CreateWMBSBase):
           """CREATE TABLE wmbs_location (
                id          INTEGER      NOT NULL,
                site_name   VARCHAR(255) NOT NULL,
+               state       INTEGER      NOT NULL,
                cms_name    VARCHAR(255),
                ce_name     VARCHAR(255),
                running_slots   INTEGER,
                pending_slots   INTEGER,
-               plugin      VARCHAR(255),
-               state       INTEGER NOT NULL
+               plugin      VARCHAR(255)
                ) %s""" % tablespaceTable
 
         self.indexes["01_pk_wmbs_location"] = \
@@ -683,5 +683,5 @@ class Create(CreateWMBSBase):
         for i in self.sequence_tables:
             seqname = '%s_SEQ' % i
             self.create["%s%s" % (j, seqname)] = \
-      "CREATE SEQUENCE %s start with 1 increment by 1 nomaxvalue cache 100" \
-                    % seqname
+                """CREATE SEQUENCE %s start with 1 increment by 1 nomaxvalue cache 100""" \
+                % seqname

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -375,7 +375,8 @@ class StdBase(object):
         else:
             procTaskStageHelper.setMinMergeSize(self.minMergeSize, self.maxMergeEvents)
 
-        procTaskCmsswHelper.cmsswSetup(cmsswVersion, softwareEnvironment="",
+        procTaskCmsswHelper.cmsswSetup(cmsswVersion,
+                                       softwareEnvironment="",
                                        scramArch=scramArch)
 
         if "events_per_lumi" in newSplitArgs:
@@ -527,6 +528,12 @@ class StdBase(object):
 
         parentTaskLogArch = parentTask.getStep("logArch1")
         logCollectTask.setInputReference(parentTaskLogArch, outputModule="logArchive")
+
+        logCollectStepHelper = logCollectStep.getTypeHelper()
+        logCollectStepHelper.cmsswSetup(self.frameworkVersion,
+                                        softwareEnvironment="",
+                                        scramArch=self.scramArch)
+
         return logCollectTask
 
     def addMergeTask(self, parentTask, parentTaskSplitting, parentOutputModuleName,
@@ -575,7 +582,8 @@ class StdBase(object):
         mergeTaskCmsswHelper = mergeTaskCmssw.getTypeHelper()
         mergeTaskStageHelper = mergeTaskStageOut.getTypeHelper()
 
-        mergeTaskCmsswHelper.cmsswSetup(self.frameworkVersion, softwareEnvironment="",
+        mergeTaskCmsswHelper.cmsswSetup(self.frameworkVersion,
+                                        softwareEnvironment="",
                                         scramArch=self.scramArch)
 
         mergeTaskCmsswHelper.setErrorDestinationStep(stepName=mergeTaskLogArch.name())
@@ -672,7 +680,8 @@ class StdBase(object):
         harvestTask.applyTemplates()
 
         harvestTaskCmsswHelper = harvestTaskCmssw.getTypeHelper()
-        harvestTaskCmsswHelper.cmsswSetup(self.frameworkVersion, softwareEnvironment="",
+        harvestTaskCmsswHelper.cmsswSetup(self.frameworkVersion,
+                                          softwareEnvironment="",
                                           scramArch=self.scramArch)
 
         harvestTaskCmsswHelper.setErrorDestinationStep(stepName=harvestTaskLogArch.name())

--- a/src/python/WMCore/WMSpec/Steps/Templates/LogCollect.py
+++ b/src/python/WMCore/WMSpec/Steps/Templates/LogCollect.py
@@ -40,6 +40,23 @@ class LogCollectStepHelper(CoreHelper):
         Adds an out location to put a tarball of all logs
         """
 
+    def cmsswSetup(self, cmsswVersion, **options):
+        """
+        _cmsswSetup_
+        Provide setup details for CMSSW.
+        cmsswVersion - required - version of CMSSW to use
+        Optional:
+        scramCommand - defaults to scramv1
+        scramProject - defaults to CMSSW
+        scramArch    - optional scram architecture, defaults to None
+        buildArch    - optional scram build architecture, defaults to None
+        softwareEnvironment - setup command to bootstrap scram,defaults to None
+        """
+        self.data.application.setup.cmsswVersion = cmsswVersion
+        for k,v in options.items():
+            setattr(self.data.application.setup, k, v)
+        return
+
 
 class LogCollect(Template):
     """
@@ -56,7 +73,13 @@ class LogCollect(Template):
         step.logcount = 0
         step.retryCount = 3
         step.retryDelay = 300
-
+        step.application.section_("setup")
+        step.application.setup.scramCommand = "scramv1"
+        step.application.setup.scramProject = "CMSSW"
+        step.application.setup.cmsswVersion = None
+        step.application.setup.scramArch = None
+        step.application.setup.buildArch = None
+        step.application.setup.softwareEnvironment = None
 
     def helper(self, step):
         """


### PR DESCRIPTION
Most obvious change is to not use the stagin method defined in site-local-config to copy logArchives to the local node, but edmCopyUtil. This requires setting up a Scram environment and calling edmCopyUtil via scram (and also some proxy forwarding). There is a hardcoded dependency on CMSSW_8_0_8, but since all we do here is copy logArchives to local disk, this should work as long as we don't retire CMSSW_8_0_8. Well, and as long as the chosen slc6_amd64_gcc493 architecture can run on all of our hardware.

At the moment edmCopyUtil is called for 10 files at a time, so if any of the 10 files can't be read, all 10 files are skipped.

I also fixed a bunch of design flaws and bugs in the previous code:

Input file deletion didn't work (at all) due to a wrong dictionary keyword, fixed that.

Input file deletion should only be done after LogCollect stageout and after job is considered successful.

The skipped files were added to the job report without an LFN, leading to error messages in the JobAccountant.

Reporting LogCollect output was done in a weird way. We reported the output file that was staged to Castor, but with an EOS location and immediately after the mandatory Castor stageout succeeded (and even if the optional EOS stageout failed). Changed that to only report the EOS stageout, since that is optional, you can have a LogCollect job that succeeds but doesn't report any output since the EOS stageout failed. Which is correct IMO if you care about output actually present on EOS.
