### PR TITLE
1.0.16_crab version of Merge Justas' patch for untarring with python 2.6 for older releases

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
@@ -371,7 +371,14 @@ if [ -n "$USER_TARBALL" ] ; then
     EXIT_STATUS=$?
     if [ $EXIT_STATUS -ne 0 ]; then
        echo "***\nCouldn't untar sandbox with python2: $EXIT_STATUS\n";
-       exit 74;
+       echo "***\nWill try with python2.6 as it is might be old CMSSW release!"
+       python2.6 -m WMCore.WMRuntime.Scripts.UnpackUserTarball $USER_TARBALL $USER_FILES
+       EXIT_STATUS=$?
+       if [ $EXIT_STATUS -ne 0 ]; then
+          echo "***\nCouldn't untar sandbox with python2: $EXIT_STATUS\n";
+          echo "***\nThat was last try... failing..."
+          exit 74;
+       fi
     fi
 fi
 echo "Completed SCRAM project"


### PR DESCRIPTION
Patch for an issue discovered a few releases ago about untarring the sandbox with older CMSSW versions, for example CMSSW_5_3_31 [*]. This was fixed on a previous WMCore CRAB branch but no master PR was created.

Master PR here: #6897

After the merge please also create a new tag for the 1.0.16_crab branch. Thanks.

[*] https://github.com/dmwm/CRABServer/issues/5229#issuecomment-221912050
