### PR TITLE
Remove the need for a prompt when setting up unit tests

### DIFF
--- a/test/deploy/deploy_unittest.sh
+++ b/test/deploy/deploy_unittest.sh
@@ -78,6 +78,5 @@ else
     source ./env_unittest.sh
     $manage start-services
 
-    echo "--- when prompted type 'passwd' (without ')"
-    mysql -u unittestagent -p --sock $INSTALL_DIR/current/install/mysql/logs/mysql.sock --exec "create database wmcore_unittest"
+    mysql -u unittestagent --password=passwd --sock $INSTALL_DIR/current/install/mysql/logs/mysql.sock --exec "create database wmcore_unittest"
 fi


### PR DESCRIPTION
This change allows the script to run without any input from the user and, in turn, lets me set up a docker container ready to run tests. Please merge (or I will if @ticoann is on vacation)
