### PR TITLE
Create the output file expected by condor to be transferred back

### DIFF
--- a/etc/submit.sh
+++ b/etc/submit.sh
@@ -10,11 +10,19 @@ sed -e 's/^/export /' startup_environment.sh > tmp_env.sh
 mv tmp_env.sh startup_environment.sh
 export JOBSTARTDIR=$PWD
 
-
-touch Report.pkl
-
 # should be a bit nicer than before
 echo "WMAgent bootstrap : `date -u` : starting..."
+
+# We need to create the expected output file in advance just in case
+# some problem happens during the job bootstrap
+outputFile="Report.0.pkl Report.1.pkl Report.2.pkl Report.3.pkl"
+if [ -n "$_CONDOR_JOB_AD" ]; then
+    outputFile=`grep ^TransferOutput $_CONDOR_JOB_AD | awk -F'=' '{print $2}' | sed 's/\"//g'`
+fi
+if [ -z $outputFile ]; then
+    outputFile="Report.0.pkl Report.1.pkl Report.2.pkl Report.3.pkl"
+fi
+touch $outputFile
 
 # validate arguments
 if [ -z "$1" ]


### PR DESCRIPTION
Fixes #6923

Read the job classAd in order to figure out which exactly is the expected output file. Otherwise, just falls back to those 4 file names.

I did a few tests, but if you can review @ericvaandering @hufnagel @juztas @vlimant 
