### PR TITLE
Update deprecated cherrypy key

### DIFF
--- a/src/python/WMCore/REST/Main.py
+++ b/src/python/WMCore/REST/Main.py
@@ -180,7 +180,7 @@ class RESTMain:
         cpconfig.update({'tools.proxy.on': True})
         cpconfig.update({'tools.proxy.base': local_base})
         cpconfig.update({'tools.time.on': True})
-        cpconfig.update({'engine.autoreload_on': False})
+        cpconfig.update({'engine.autoreload.on': False})
         cpconfig.update({'request.show_tracebacks': False})
         cpconfig.update({'request.methods_with_bodies': ("POST", "PUT", "DELETE")})
         thread.stack_size(getattr(self.srvconfig, 'thread_stack_size', 128*1024))

--- a/src/python/WMCore/WebTools/Root.py
+++ b/src/python/WMCore/WebTools/Root.py
@@ -202,7 +202,7 @@ class Root(Harness):
         if cherrypy.config["server.environment"] == "production":
             # If we're production these should be set regardless
             cherrypy.config["request.show_tracebacks"] = False
-            cherrypy.config["engine.autoreload_on"] = False
+            cherrypy.config["engine.autoreload.on"] = False
             # In production mode only allow errors at WARNING or greater to the log
             err_lvl = max((configDict.get("error_log_level", logging.WARNING), logging.WARNING))
             acc_lvl = max((configDict.get("access_log_level", logging.INFO), logging.INFO))
@@ -213,7 +213,7 @@ class Root(Harness):
             print('THIS BETTER NOT BE A PRODUCTION SERVER')
             print()
             cherrypy.config["request.show_tracebacks"] = configDict.get("show_tracebacks", False)
-            cherrypy.config["engine.autoreload_on"] = configDict.get("autoreload", False)
+            cherrypy.config["engine.autoreload.on"] = configDict.get("autoreload", False)
             # Allow debug output
             cherrypy.log.error_log.setLevel(configDict.get("error_log_level", logging.DEBUG))
             cherrypy.log.access_log.setLevel(configDict.get("access_log_level", logging.DEBUG))


### PR DESCRIPTION
`ENGINE WARNING: Use of engine.autoreload_on is deprecated and will be removed in a future version. Use engine.autoreload.on instead.`

So updating it now.
