### PR TITLE
Truncate output module name before sending it over to DBS

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/DBSBufferBlock.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSBufferBlock.py
@@ -491,7 +491,13 @@ class DBSBufferBlock:
             firstkey, subkey = nestedKey.split('.', 1)
             if firstkey in block and subkey in block[firstkey]:
                 del block[firstkey][subkey]
-                
+
+        # DBS limits the output_module_label at 45 chars
+        for key in ('dataset_conf_list', 'file_conf_list'):
+            for conf in block.get(key, []):
+                if len(conf.get('output_module_label', '')) > 45:
+                    conf['output_module_label'] = conf['output_module_label'][0:30] +\
+                                                  "..." + conf['output_module_label'][-10:]
         return block
                     
     def setPendingAndCloseBlock(self):


### PR DESCRIPTION
Tier0 is failing to inject one specific kind of block into DBS and the reason for that comes from the long (>45 chars) string used for the `output_module_label`, which in the end responds with a 500 Internal Server Error.

@ericvaandering this patch will truncate the output module as we discussed in the office yesterday.
@hufnagel may have a comment on it as well.
