### PR TITLE
New checksum version for CRABCache

### DIFF
--- a/src/python/WMCore/Services/UserFileCache/UserFileCache.py
+++ b/src/python/WMCore/Services/UserFileCache/UserFileCache.py
@@ -141,9 +141,9 @@ class UserFileCache(Service):
         if excludeList==None: #pylint says [] is a dangerous default value
             excludeList = []
 
-        #The parameter newchecksum tells the crabcace to use the new algorithm. It's there
-        #for guarantee backward compatibility
-        params = [('hashkey', calculateChecksum(fileName, excludeList)), ('newchecksum', '1')]
+        #The parameter newchecksum tells the crabcache to use the new algorithm. It's there
+        #to guarantee backward compatibility.
+        params = [('hashkey', calculateChecksum(fileName, excludeList)), ('newchecksum', '2')]
 
         resString = self["requests"].uploadFile(fileName=fileName, fieldName='inputfile',
                                                 url=self['endpoint'] + 'file',


### PR DESCRIPTION
We've made a small change in the checksum function in crab as a result of a tarball being recycled too often. 

Issue here: https://github.com/dmwm/CRABServer/issues/5153.
1.0.16_crab PR here: https://github.com/dmwm/WMCore/pull/6954
