### PR TITLE
Get campaign key with default value

### DIFF
--- a/src/python/WMCore/WMDataMining/Utils.py
+++ b/src/python/WMCore/WMDataMining/Utils.py
@@ -16,12 +16,12 @@ from WMCore.Services.McM.McM import McM, McMNoDataError
 from WMCore.Services.WMStats.DataStruct.RequestInfoCollection import RequestInfoCollection
 from WMCore.Services.WMStats.WMStatsReader import WMStatsReader
 
-maxMCMCalls = 250 # Maximum # of entries to retrieve from McM per run
+maxMCMCalls = 250  # Maximum # of entries to retrieve from McM per run
+
 
 def gatherWMDataMiningStats(wmstatsUrl, reqmgrUrl, wmMiningUrl,
                             mcmUrl, mcmCert, mcmKey, tmpDir,
-                            archived = False, log = logging.info):
-
+                            archived=False, log=logging.info):
     server, database = splitCouchServiceURL(wmMiningUrl)
     analyticsServer = CouchServer(server)
     couchdb = analyticsServer.connectDatabase(database)
@@ -38,7 +38,7 @@ def gatherWMDataMiningStats(wmstatsUrl, reqmgrUrl, wmMiningUrl,
         funcName = "Active Requests"
 
     log.info("%s: Getting job information from %s and %s. Please wait." % (
-                  funcName, wmstatsUrl, reqmgrUrl))
+        funcName, wmstatsUrl, reqmgrUrl))
 
     if archived:
         checkStates = ['normal-archived', 'rejected-archived', 'aborted-archived']
@@ -46,7 +46,7 @@ def gatherWMDataMiningStats(wmstatsUrl, reqmgrUrl, wmMiningUrl,
     else:
         checkStates = WMStatsReader.ACTIVE_STATUS
         jobInfoFlag = True
-    requests = WMStats.getRequestByStatus(checkStates, jobInfoFlag = jobInfoFlag, legacyFormat = True)
+    requests = WMStats.getRequestByStatus(checkStates, jobInfoFlag=jobInfoFlag, legacyFormat=True)
 
     requestCollection = RequestInfoCollection(requests)
     result = requestCollection.getJSONData()
@@ -75,18 +75,16 @@ def gatherWMDataMiningStats(wmstatsUrl, reqmgrUrl, wmMiningUrl,
                 runWhiteList = []
                 filterEfficiency = None
                 try:
-                    #log.debug("Looking up %s in ReqMgr" % wf)
+                    # log.debug("Looking up %s in ReqMgr" % wf)
                     rmDoc = reqMgr.document(wf)
                     runWhiteList = rmDoc.get('RunWhiteList', [])
                     filterEfficiency = rmDoc.get('FilterEfficiency', None)
                 except:
-                    pass # ReqMgr no longer has the workflow
-                report[wf].update({'filterEfficiency':filterEfficiency, 'runWhiteList':runWhiteList})
+                    pass  # ReqMgr no longer has the workflow
+                report[wf].update({'filterEfficiency': filterEfficiency, 'runWhiteList': runWhiteList})
 
-            if ('mcmTotalEvents' not in oldCouchDoc or
-                'mcmApprovalTime' not in oldCouchDoc or
-                oldCouchDoc.get('mcmTotalEvents', 'Unknown') == 'Unknown' or
-                oldCouchDoc.get('mcmApprovalTime', 'Unknown') == 'Unknown'):
+            if oldCouchDoc.get('mcmTotalEvents', 'Unknown') == 'Unknown' or \
+                oldCouchDoc.get('mcmApprovalTime', 'Unknown') == 'Unknown':
 
                 prepID = oldCouchDoc.get('prepID', None)
                 if prepID and nMCMCalls <= maxMCMCalls:
@@ -94,41 +92,41 @@ def gatherWMDataMiningStats(wmstatsUrl, reqmgrUrl, wmMiningUrl,
                     # Get information from McM. Don't call too many times, can take a long time
                     nMCMCalls += 1
                     try:
-                        mcmHistory = mcm.getHistory(prepID = prepID)
+                        mcmHistory = mcm.getHistory(prepID=prepID)
                         if 'mcmApprovalTime' not in oldCouchDoc:
-                            report[wf].update({'mcmApprovalTime':'NoMcMData'})
+                            report[wf].update({'mcmApprovalTime': 'NoMcMData'})
                         found = False
                         for entry in mcmHistory:
                             if entry['action'] == 'set status' and entry['step'] == 'announced':
                                 dateString = entry['updater']['submission_date']
                                 dt = datetime.strptime(dateString, '%Y-%m-%d-%H-%M')
-                                report[wf].update({'mcmApprovalTime':time.mktime(dt.timetuple())})
+                                report[wf].update({'mcmApprovalTime': time.mktime(dt.timetuple())})
                                 found = True
                         if not found:
                             log.error("History found but no approval time for %s" % wf)
                     except McMNoDataError:
                         log.error("Setting NoMcMData for %s" % wf)
-                        report[wf].update({'mcmApprovalTime':'NoMcMData'})
+                        report[wf].update({'mcmApprovalTime': 'NoMcMData'})
                     except (RuntimeError, IOError):
                         exc_type, dummy_exc_value, dummy_exc_traceback = sys.exc_info()
                         log.error("%s getting history from McM for PREP ID %s. May be transient and/or SSO problem." %
-                            (exc_type, prepID))
+                                  (exc_type, prepID))
                     except:
                         exc_type, exc_value, exc_traceback = sys.exc_info()
                         log.error("%s getting history from McM for PREP ID %s. Unknown error." %
-                            (exc_type, prepID))
+                                  (exc_type, prepID))
 
                     try:
-                        mcmRequest = mcm.getRequest(prepID = prepID)
+                        mcmRequest = mcm.getRequest(prepID=prepID)
                         report[wf].update({'mcmTotalEvents': mcmRequest.get('total_events', 'NoMcMData')})
                     except (RuntimeError, IOError):
                         exc_type, exc_value, exc_traceback = sys.exc_info()
                         log.error("%s getting request from McM for PREP ID %s. May be transient and/or SSO problem." %
-                            (exc_type, prepID))
+                                  (exc_type, prepID))
                     except:
                         exc_type, exc_value, exc_traceback = sys.exc_info()
                         log.error("%s getting request from McM for PREP ID %s. Unknown error." %
-                            (exc_type, prepID))
+                                  (exc_type, prepID))
 
             # Basic parameters of the workflow
             priority = requests[wf].get('priority', 0)
@@ -141,7 +139,7 @@ def gatherWMDataMiningStats(wmstatsUrl, reqmgrUrl, wmMiningUrl,
             statuses = requests[wf].get('request_status', [])
 
             if not statuses:
-                log.error("Could not find any status from workflow: %s" % wf) # Should not happen but it does.
+                log.error("Could not find any status from workflow: %s" % wf)  # Should not happen but it does.
 
             # Remove a single  task_ from the start of PREP ID if it exists
             if prep_id and prep_id.startswith('task_'):
@@ -164,7 +162,8 @@ def gatherWMDataMiningStats(wmstatsUrl, reqmgrUrl, wmMiningUrl,
                     else:
                         outputTiers.append(ds.split('/')[-1])
             except:
-                log.error("Could not decode outputdatasets: %s" % outputdatasets) # Sometimes is a list of lists, not just a list. Bail
+                log.error(
+                    "Could not decode outputdatasets: %s" % outputdatasets)  # Sometimes is a list of lists, not just a list. Bail
             if inputdataset:
                 inputTier = inputdataset.split('/')[-1]
                 if inputTier in ['GEN']:
@@ -206,9 +205,9 @@ def gatherWMDataMiningStats(wmstatsUrl, reqmgrUrl, wmMiningUrl,
                 events = dsr.get('events', 0)
                 lumis = dsr.get('totalLumis', 0)
                 if targetLumis:
-                    lumiPercent = min(lumiPercent, lumis/targetLumis*100)
+                    lumiPercent = min(lumiPercent, lumis / targetLumis * 100)
                 if targetEvents:
-                    eventPercent = min(eventPercent, events/targetEvents*100)
+                    eventPercent = min(eventPercent, events / targetEvents * 100)
             if eventPercent > 100:
                 eventPercent = 0
             if lumiPercent > 100:
@@ -223,9 +222,9 @@ def gatherWMDataMiningStats(wmstatsUrl, reqmgrUrl, wmMiningUrl,
                 totalJobs += jobs['created']
             try:
                 if totalJobs and not report[wf].get('firstJobTime', None):
-                    report[wf].update({'firstJobTime' : int(time.time())})
+                    report[wf].update({'firstJobTime': int(time.time())})
                 if totalJobs and successJobs == totalJobs and not report[wf].get('lastJobTime', None):
-                    report[wf].update({'lastJobTime' : int(time.time())})
+                    report[wf].update({'lastJobTime': int(time.time())})
             except:
                 pass
 
@@ -264,33 +263,33 @@ def gatherWMDataMiningStats(wmstatsUrl, reqmgrUrl, wmMiningUrl,
             report.setdefault(wf, {})
 
             if approvedTime and not report[wf].get('approvedTime', None):
-                report[wf].update({'approvedTime':approvedTime})
+                report[wf].update({'approvedTime': approvedTime})
             if assignedTime and not report[wf].get('assignedTime', None):
-                report[wf].update({'assignedTime':assignedTime})
+                report[wf].update({'assignedTime': assignedTime})
             if acquireTime and not report[wf].get('acquireTime', None):
-                report[wf].update({'acquireTime':acquireTime})
+                report[wf].update({'acquireTime': acquireTime})
             if closeoutTime and not report[wf].get('closeoutTime', None):
-                report[wf].update({'closeoutTime':closeoutTime})
+                report[wf].update({'closeoutTime': closeoutTime})
             if announcedTime and not report[wf].get('announcedTime', None):
-                report[wf].update({'announcedTime':announcedTime})
+                report[wf].update({'announcedTime': announcedTime})
             if completedTime and not report[wf].get('completedTime', None):
-                report[wf].update({'completedTime':completedTime})
+                report[wf].update({'completedTime': completedTime})
             if newTime and not report[wf].get('newTime', None):
-                report[wf].update({'newTime':newTime})
+                report[wf].update({'newTime': newTime})
             if archivedTime and not report[wf].get('archivedTime', None):
-                report[wf].update({'archivedTime':archivedTime})
+                report[wf].update({'archivedTime': archivedTime})
 
             try:
                 dt = requests[wf]['request_date']
                 requestDate = '%4.4d-%2.2d-%2.2d %2.2d:%2.2d:%2.2d' % tuple(dt)
-                report[wf].update({'requestDate' : requestDate})
+                report[wf].update({'requestDate': requestDate})
             except:
                 pass
 
-            report[wf].update({'priority':priority, 'status':finalStatus, 'type':requestType})
-            report[wf].update({'totalLumis':targetLumis, 'totalEvents':targetEvents, })
-            report[wf].update({'campaign' : campaign, 'prepID' : prep_id, 'outputTier' : outputTier, })
-            report[wf].update({'outputDatasets' : outputdatasets, 'inputDataset' : inputdataset, })
+            report[wf].update({'priority': priority, 'status': finalStatus, 'type': requestType})
+            report[wf].update({'totalLumis': targetLumis, 'totalEvents': targetEvents,})
+            report[wf].update({'campaign': campaign, 'prepID': prep_id, 'outputTier': outputTier,})
+            report[wf].update({'outputDatasets': outputdatasets, 'inputDataset': inputdataset,})
 
             report[wf].setdefault('lumiPercents', {})
             report[wf].setdefault('eventPercents', {})
@@ -310,23 +309,23 @@ def gatherWMDataMiningStats(wmstatsUrl, reqmgrUrl, wmMiningUrl,
                 if eventPercent >= percentage:
                     eventProgress = percentage
 
-            report[wf].update({'eventProgress' : eventProgress, 'lumiProgress' : lumiProgress,  })
+            report[wf].update({'eventProgress': eventProgress, 'lumiProgress': lumiProgress,})
 
             newCouchDoc.update(report[wf])
 
             # Queue the updated document for addition if it's changed.
             if ancientCouchDoc != newCouchDoc:
                 if wfExists:
-                    #log.debug("Workflow updated: %s" % wf)
+                    # log.debug("Workflow updated: %s" % wf)
                     pass
                 else:
-                    #log.debug("Workflow created: %s" % wf)
+                    # log.debug("Workflow created: %s" % wf)
                     pass
 
                 try:
                     newCouchDoc['updateTime'] = int(time.time())
                     report[wf]['updateTime'] = int(time.time())
-                    dummy = json.dumps(newCouchDoc) # Make sure it encodes before trying to queue
+                    dummy = json.dumps(newCouchDoc)  # Make sure it encodes before trying to queue
                     couchdb.queue(newCouchDoc)
                 except:
                     log.error("Failed to queue document:%s \n" % pprint.pprint(newCouchDoc))

--- a/src/python/WMCore/WMDataMining/Utils.py
+++ b/src/python/WMCore/WMDataMining/Utils.py
@@ -131,11 +131,11 @@ def gatherWMDataMiningStats(wmstatsUrl, reqmgrUrl, wmMiningUrl,
                             (exc_type, prepID))
 
             # Basic parameters of the workflow
-            priority = requests[wf]['priority']
-            requestType = requests[wf]['request_type']
+            priority = requests[wf].get('priority', 0)
+            requestType = requests[wf].get('request_type', 'Unknown')
             targetLumis = requests[wf].get('input_lumis', 0)
             targetEvents = requests[wf].get('input_events', 0)
-            campaign = requests[wf]['campaign']
+            campaign = requests[wf].get('campaign', 'Unknown')
             prep_id = requests[wf].get('prep_id', None)
             outputdatasets = requests[wf].get('outputdatasets', [])
             statuses = requests[wf].get('request_status', [])


### PR DESCRIPTION
I noticed the WMDataMining cherrypy thread is failing over and over in testbed with

```
2016-07-05 18:33:08,600:ERROR:CherryPyPeriodicTask:Periodic Thread ERROR __builtins__.KeyError 'campaign'
2016-07-05 18:33:08,600:ERROR:CherryPyPeriodicTask: Traceback (most recent call last):
2016-07-05 18:33:08,601:ERROR:CherryPyPeriodicTask:   File "/data/srv/beHG1607e/sw/slc6_amd64_gcc493/cms/reqmgr2/1.0.18.pre5/lib/python2.7/site-packages/WMCore/ReqMgr/CherryPyThreads/CherryPyPeriodicTask.py", line 78, in run
2016-07-05 18:33:08,601:ERROR:CherryPyPeriodicTask:     self.taskFunc(self.config)
2016-07-05 18:33:08,601:ERROR:CherryPyPeriodicTask:   File "/data/srv/beHG1607e/sw/slc6_amd64_gcc493/cms/reqmgr2/1.0.18.pre5/lib/python2.7/site-packages/WMCore/ReqMgr/CherryPyThreads/WMDataMining.py", line 29, in gatherActiveDataStats
2016-07-05 18:33:08,601:ERROR:CherryPyPeriodicTask:     archived = False, log = self.logger)
2016-07-05 18:33:08,601:ERROR:CherryPyPeriodicTask:   File "/data/srv/beHG1607e/sw/slc6_amd64_gcc493/cms/reqmgr2/1.0.18.pre5/lib/python2.7/site-packages/WMCore/WMDataMining/Utils.py", line 138, in gatherWMDataMiningStats
2016-07-05 18:33:08,601:ERROR:CherryPyPeriodicTask:     campaign = requests[wf]['campaign']
2016-07-05 18:33:08,601:ERROR:CherryPyPeriodicTask: KeyError: 'campaign'
```

this should fix the problem.
@ericvaandering have a look please, especially on the default values I set.
In addition to that, should we cut a new tag for testbed with this fix?
