### PR TITLE
Complete/kill everything for an aborted workflow

### DIFF
--- a/src/python/WMCore/JobStateMachine/Transitions.py
+++ b/src/python/WMCore/JobStateMachine/Transitions.py
@@ -14,7 +14,7 @@ class Transitions(dict):
         self.setdefault('new', ['created', 'createfailed', 'killed'])
         self.setdefault('created', ['executing', 'submitfailed', 'createfailed', 'killed'])
         self.setdefault('executing', ['complete', 'jobfailed', 'killed'])
-        self.setdefault('complete', ['jobfailed', 'success'])
+        self.setdefault('complete', ['jobfailed', 'success', 'cleanout'])
         self.setdefault('createfailed', ['createcooloff', 'retrydone', 'killed'])
         self.setdefault('submitfailed', ['submitcooloff', 'retrydone', 'killed'])
         self.setdefault('jobfailed', ['jobcooloff', 'retrydone', 'killed'])
@@ -28,6 +28,7 @@ class Transitions(dict):
         self.setdefault('jobpaused', ['created', 'retrydone', 'killed'])
         self.setdefault('createpaused', ['created', 'retrydone', 'killed'])
         self.setdefault('submitpaused', ['created', 'retrydone', 'killed'])
+        self.setdefault('cleanout', [])
 
     def states(self):
         """

--- a/src/python/WMCore/WMBS/MySQL/Jobs/KillWorkflow.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/KillWorkflow.py
@@ -7,6 +7,7 @@ MySQL implementation of Jobs.KillWorkflow
 
 from WMCore.Database.DBFormatter import DBFormatter
 
+
 class KillWorkflow(DBFormatter):
     """
     _KillWorkflow_
@@ -18,23 +19,19 @@ class KillWorkflow(DBFormatter):
                wmbs_job.retry_count AS retry_count, wmbs_job.name AS name
                     FROM wmbs_workflow
                INNER JOIN wmbs_subscription ON
-                 wmbs_workflow.id = wmbs_subscription.workflow AND
-                 wmbs_subscription.subtype IN
-                  (SELECT id FROM wmbs_sub_types
-                   WHERE name != 'Cleanup' AND name != 'LogCollect')
+                 wmbs_workflow.id = wmbs_subscription.workflow
                INNER JOIN wmbs_jobgroup ON
                  wmbs_subscription.id = wmbs_jobgroup.subscription
                INNER JOIN wmbs_job ON
                  wmbs_jobgroup.id = wmbs_job.jobgroup AND
                  wmbs_job.state IN
                    (SELECT id FROM wmbs_job_state
-                    WHERE name != 'complete' AND name != 'success' AND
-                          name != 'cleanout' AND name != 'exhausted')
+                    WHERE name NOT IN ('success', 'cleanout', 'exhausted')
                INNER JOIN wmbs_job_state ON
                  wmbs_job.state = wmbs_job_state.id
              WHERE wmbs_workflow.name = :workflowname"""
 
-    def execute(self, workflowName, conn = None, transaction = False):
+    def execute(self, workflowName, conn=None, transaction=False):
         results = self.dbi.processData(self.sql, {"workflowname": workflowName},
-                                       conn = conn, transaction = transaction)
+                                       conn=conn, transaction=transaction)
         return self.formatDict(results)

--- a/src/python/WMCore/WMBS/MySQL/Subscriptions/KillWorkflow.py
+++ b/src/python/WMCore/WMBS/MySQL/Subscriptions/KillWorkflow.py
@@ -7,22 +7,19 @@ MySQL implementation of Subscriptions.KillWorkflow
 
 from WMCore.Database.DBFormatter import DBFormatter
 
+
 class KillWorkflow(DBFormatter):
     """
     _KillWorkflow_
 
     Mark all files that are not complete/failed and belong to a particular
-    workflow as complete so they get clean up.  Ignore Cleanup and
-    LogCollect subscriptions as we still want those to run.
+    workflow as complete so they get clean up.
     """
     sql = """INSERT INTO wmbs_sub_files_complete (subscription, fileid)
                SELECT wmbs_subscription.id, wmbs_fileset_files.fileid
                       FROM wmbs_workflow
                  INNER JOIN wmbs_subscription ON
-                   wmbs_workflow.id = wmbs_subscription.workflow AND
-                   wmbs_subscription.subtype IN
-                    (SELECT id FROM wmbs_sub_types
-                     WHERE name != 'Cleanup' AND name != 'LogCollect')
+                   wmbs_workflow.id = wmbs_subscription.workflow
                  INNER JOIN wmbs_fileset_files ON
                    wmbs_subscription.fileset = wmbs_fileset_files.fileset
                  LEFT OUTER JOIN wmbs_sub_files_complete ON
@@ -39,25 +36,19 @@ class KillWorkflow(DBFormatter):
                   (SELECT wmbs_subscription.id FROM wmbs_workflow
                      INNER JOIN wmbs_subscription ON
                        wmbs_workflow.id = wmbs_subscription.workflow AND
-                       wmbs_workflow.name = :workflowname AND
-                       wmbs_subscription.subtype IN
-                         (SELECT id FROM wmbs_sub_types
-                          WHERE name != 'Cleanup' AND name != 'LogCollect'))"""
+                       wmbs_workflow.name = :workflowname)"""
 
     delAva = """DELETE FROM wmbs_sub_files_available WHERE subscription IN
                   (SELECT wmbs_subscription.id FROM wmbs_workflow
                      INNER JOIN wmbs_subscription ON
                        wmbs_workflow.id = wmbs_subscription.workflow AND
-                       wmbs_workflow.name = :workflowname AND
-                       wmbs_subscription.subtype IN
-                         (SELECT id FROM wmbs_sub_types
-                          WHERE name != 'Cleanup' AND name != 'LogCollect'))"""
+                       wmbs_workflow.name = :workflowname)"""
 
-    def execute(self, workflowName, conn = None, transaction = False):
+    def execute(self, workflowName, conn=None, transaction=False):
         self.dbi.processData(self.sql, {"workflowname": workflowName},
-                             conn = conn, transaction = transaction)
+                             conn=conn, transaction=transaction)
         self.dbi.processData(self.delAcq, {"workflowname": workflowName},
-                             conn = conn, transaction = transaction)
+                             conn=conn, transaction=transaction)
         self.dbi.processData(self.delAva, {"workflowname": workflowName},
-                             conn = conn, transaction = transaction)
+                             conn=conn, transaction=transaction)
         return


### PR DESCRIPTION
Well, I noticed only a minute ago that there is a patch being discussed already for this case, @ticoann made #6572 ... :(

I didn't notice killWorkflow() was called for both 'aborted' and 'force-complete' workflows. It would be easier to just kill/complete everything for workflows having this state transition, as well as less error prone. However, I do agree that it may be useful to have `cleanup` and `logcollect` jobs running for `force-completed` workflows, though I don't know whether people would really care if they lose some of these remaining jobs...

@ericvaandering @ticoann what do you guys think? 
