### PR TITLE
reduce RECO merges by allowing PromptReco to stageout to merged

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -61,8 +61,7 @@ class PromptRecoWorkloadFactory(StdBase):
                                                scenarioArgs = scenarioArgs,
                                                splitAlgo = self.procJobSplitAlgo,
                                                splitArgs = self.procJobSplitArgs,
-                                               stepType = cmsswStepType,
-                                               forceUnmerged = True)
+                                               stepType = cmsswStepType)
         if self.doLogCollect:
             self.addLogCollectTask(recoTask)
 


### PR DESCRIPTION
Sigh. Really thought I had removed this earlier. This was needed when we were still doing event splitting in PromptReco, now it just completely blows up the number of (and data volume) we pipe through RECO merges.
