### PR TITLE
Set jobs killed by JobStatusLite to Timeout status

### DIFF
--- a/src/python/WMComponent/JobTracker/JobTrackerPoller.py
+++ b/src/python/WMComponent/JobTracker/JobTrackerPoller.py
@@ -4,8 +4,6 @@ The actual jobTracker algorithm
 """
 __all__ = []
 
-
-
 import threading
 import logging
 import os
@@ -13,16 +11,12 @@ import os.path
 
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 
-from WMCore.WMBS.Job          import Job
-from WMCore.DAOFactory        import DAOFactory
-from WMCore.WMFactory         import WMFactory
-from WMCore.WMException       import WMException
-
-from WMCore.FwkJobReport.Report      import Report
-
+from WMCore.DAOFactory import DAOFactory
+from WMCore.WMException import WMException
+from WMCore.FwkJobReport.Report import Report
 from WMCore.JobStateMachine.ChangeState import ChangeState
+from WMCore.BossAir.BossAirAPI import BossAirAPI
 
-from WMCore.BossAir.BossAirAPI          import BossAirAPI
 
 class JobTrackerException(WMException):
     """
@@ -31,6 +25,7 @@ class JobTrackerException(WMException):
     A job tracker exception-handling class for the JobTracker
     """
 
+
 class JobTrackerPoller(BaseWorkerThread):
     """
     _JobTrackerPoller_
@@ -38,7 +33,6 @@ class JobTrackerPoller(BaseWorkerThread):
     Polls the BossAir database for complete jobs
     Handles completed jobs
     """
-
 
     def __init__(self, config):
         """
@@ -50,30 +44,25 @@ class JobTrackerPoller(BaseWorkerThread):
 
         myThread = threading.currentThread()
 
+        self.changeState = ChangeState(self.config)
+        self.bossAir = BossAirAPI(config=config)
+        self.daoFactory = DAOFactory(package="WMCore.WMBS",
+                                     logger=myThread.logger,
+                                     dbinterface=myThread.dbi)
 
-        self.changeState   = ChangeState(self.config)
-        self.bossAir       = BossAirAPI(config = config)
-        self.daoFactory    = DAOFactory(package = "WMCore.WMBS",
-                                        logger = myThread.logger,
-                                        dbinterface = myThread.dbi)
-
-        self.jobListAction = self.daoFactory(classname = "Jobs.GetAllJobs")
+        self.jobListAction = self.daoFactory(classname="Jobs.GetAllJobs")
 
         # initialize the alert framework (if available)
-        self.initAlerts(compName = "JobTracker")
+        self.initAlerts(compName="JobTracker")
 
-
-    def setup(self, parameters = None):
+    def setup(self, parameters=None):
         """
         Load DB objects required for queries
         """
 
         return
 
-
-
-
-    def terminate(self, params = None):
+    def terminate(self, params=None):
         """
         _terminate_
 
@@ -83,10 +72,7 @@ class JobTrackerPoller(BaseWorkerThread):
         self.algorithm(params)
         return
 
-
-
-
-    def algorithm(self, parameters = None):
+    def algorithm(self, parameters=None):
         """
         Performs the archiveJobs method, looking for each type of failure
         And deal with it as desired.
@@ -98,14 +84,14 @@ class JobTrackerPoller(BaseWorkerThread):
         except WMException as ex:
             if getattr(myThread, 'transaction', None):
                 myThread.transaction.rollback()
-            self.sendAlert(6, msg = str(ex))
+            self.sendAlert(6, msg=str(ex))
             raise
         except Exception as ex:
-            msg =  "Unknown exception in JobTracker!\n"
+            msg = "Unknown exception in JobTracker!\n"
             msg += str(ex)
             if getattr(myThread, 'transaction', None):
                 myThread.transaction.rollback()
-            self.sendAlert(6, msg = msg)
+            self.sendAlert(6, msg=msg)
             logging.error(msg)
             raise JobTrackerException(msg)
 
@@ -121,7 +107,7 @@ class JobTrackerPoller(BaseWorkerThread):
         passedJobs = []
         failedJobs = []
 
-        jobList = self.jobListAction.execute(state = "executing")
+        jobList = self.jobListAction.execute(state="executing")
         logging.info("Have list of %i executing jobs in WMBS", len(jobList))
 
         if not jobList:
@@ -141,13 +127,11 @@ class JobTrackerPoller(BaseWorkerThread):
             else:
                 passedJobs.append(job)
 
-
         # Assume all these jobs "passed" if they aren't in timeout
         self.passJobs(passedJobs)
         self.failJobs(failedJobs)
 
         return
-
 
     def failJobs(self, failedJobs):
         """
@@ -163,10 +147,8 @@ class JobTrackerPoller(BaseWorkerThread):
 
         myThread = threading.currentThread()
 
-
         # Load DAOs
-        setFWJRAction = self.daoFactory(classname = "Jobs.SetFWJRPath")
-        loadAction    = self.daoFactory(classname = "Jobs.LoadFromID")
+        setFWJRAction = self.daoFactory(classname="Jobs.SetFWJRPath")
 
         jrBinds = []
 
@@ -174,15 +156,15 @@ class JobTrackerPoller(BaseWorkerThread):
             jrPath = os.path.join(job.getCache(),
                                   'Report.%i.pkl' % (job['retry_count']))
             jrBinds.append({'jobid': job['id'], 'fwjrpath': jrPath})
-            #Make sure the job object goes packed with fwjr_path so it
-            #can be persisted in couch
+            # Make sure the job object goes packed with fwjr_path so it
+            # can be persisted in couch
 
             fwjr = Report()
             try:
                 fwjr.load(jrPath)
             except Exception:
-                #Something went wrong reading the pickle
-                logging.error("The pickle in %s could not be loaded, generating a new one" % jrPath)
+                # Something went wrong reading the pickle
+                logging.error("The pickle in %s could not be loaded, generating a new one", jrPath)
                 fwjr = Report()
                 msg = "The job failed due to a timeout, unfortunately the original job report was lost"
                 fwjr.addError("NoJobReport", 99303, "NoJobReport", msg)
@@ -191,12 +173,11 @@ class JobTrackerPoller(BaseWorkerThread):
 
         # Set all paths at once
         myThread.transaction.begin()
-        setFWJRAction.execute(binds = jrBinds)
+        setFWJRAction.execute(binds=jrBinds)
 
         self.changeState.propagate(failedJobs, 'jobfailed', 'executing')
-        logging.info("Failed %i jobs" % (len(failedJobs)))
+        logging.info("Failed %i jobs", len(failedJobs))
         myThread.transaction.commit()
-
 
         return
 
@@ -210,11 +191,10 @@ class JobTrackerPoller(BaseWorkerThread):
         if len(passedJobs) == 0:
             return
 
-        #Mark 'em as complete
-        loadAction    = self.daoFactory(classname = "Jobs.LoadFromID")
-        setFWJRAction = self.daoFactory(classname = "Jobs.SetFWJRPath")
+        # Mark 'em as complete
+        setFWJRAction = self.daoFactory(classname="Jobs.SetFWJRPath")
 
-        jrBinds    = []
+        jrBinds = []
         for job in passedJobs:
             jrPath = os.path.join(job.getCache(),
                                   'Report.%i.pkl' % (job['retry_count']))
@@ -222,11 +202,11 @@ class JobTrackerPoller(BaseWorkerThread):
 
         myThread = threading.currentThread()
         myThread.transaction.begin()
-        setFWJRAction.execute(binds = jrBinds, conn = myThread.transaction.conn,
-                              transaction = True)
+        setFWJRAction.execute(binds=jrBinds, conn=myThread.transaction.conn,
+                              transaction=True)
         myThread.transaction.commit()
 
         self.changeState.propagate(passedJobs, 'complete', 'executing')
         logging.debug("Propagating jobs in jobTracker")
-        logging.info("Passed %i jobs" % len(passedJobs))
+        logging.info("Passed %i jobs", len(passedJobs))
         return

--- a/src/python/WMCore/BossAir/BossAirAPI.py
+++ b/src/python/WMCore/BossAir/BossAirAPI.py
@@ -185,20 +185,19 @@ class BossAirAPI(WMConnectionBase):
         """
 
         existingTransaction = self.beginTransaction()
-
         if active:
             runJobDicts = self.runningJobDAO.execute(conn=self.getDBConn(),
                                                      transaction=self.existingTransaction())
         else:
             runJobDicts = self.completeJobDAO.execute(conn=self.getDBConn(),
                                                       transaction=self.existingTransaction())
+        self.commitTransaction(existingTransaction)
+
         runJobs = []
         for jDict in runJobDicts:
             rj = RunJob()
             rj.update(jDict)
             runJobs.append(rj)
-
-        self.commitTransaction(existingTransaction)
 
         return runJobs
 
@@ -683,10 +682,10 @@ class BossAirAPI(WMConnectionBase):
                         # Build a better job message
                         if killMsg:
                             reportedMsg = killMsg
-                            reportedMsg += '\n Job last known status was: %s' % job.get('status', 'Unknown')
+                            reportedMsg += '\n Job last known status was: %s' % job.get('globalState', 'Unknown')
                         else:
                             reportedMsg = WM_JOB_ERROR_CODES[errorCode]
-                            reportedMsg += '\n Job last known status was: %s' % job.get('status', 'Unknown')
+                            reportedMsg += '\n Job last known status was: %s' % job.get('globalState', 'Unknown')
                         errorReport.addError("JobKilled", errorCode, "JobKilled", reportedMsg)
                         try:
                             errorReport.save(filename=reportName)

--- a/src/python/WMCore/BossAir/StatusPoller.py
+++ b/src/python/WMCore/BossAir/StatusPoller.py
@@ -113,9 +113,9 @@ class StatusPoller(BaseWorkerThread):
                 continue
             if timeout and statusTime:
                 if time.time() - float(statusTime) > float(timeout):
-                    # Then the job needs to be killed.
+                    # Timeout status is used by JobTracker to fail jobs in WMBS database
                     logging.info("Killing job %i because it has exceeded timeout for status '%s'", job['id'], globalState)
-                    job['status'] = globalState
+                    job['status'] = 'Timeout'
                     jobsToKill.append(job)
 
         # We need to show that the jobs are in state timeout


### PR DESCRIPTION
@ticoann I knew it was my fault :-( I had no idea this Timeout sched_status was being used by the JobTracker for failing jobs in WMBS... bug injected with https://github.com/dmwm/WMCore/commit/523d1881990ea8d1bf94348b841a025875445d58

Please review and then I'll push it to the agents (initially trying submit2)
