### PR TITLE
create a working xrdcp stageout plugin, fixes #6989

### DIFF
--- a/src/python/WMCore/Storage/Backends/FNALImpl.py
+++ b/src/python/WMCore/Storage/Backends/FNALImpl.py
@@ -8,7 +8,7 @@ Implementation of StageOutImpl interface for FNAL
 from __future__ import print_function
 import os
 from WMCore.Storage.Registry import registerStageOutImpl
-from WMCore.Storage.StageOutImpl import StageOutImpl, splitPFN
+from WMCore.Storage.StageOutImpl import StageOutImpl
 from WMCore.Storage.Backends.LCGImpl import LCGImpl
 
 _CheckExitCodeOption = True
@@ -153,7 +153,7 @@ class FNALImpl(StageOutImpl):
         method = self.storageMethod(pfnToRemove)
 
         if method == 'xrdcp':
-            (_, host, path, _) = splitPFN(pfnToRemove)
+            (_, host, path, _) = self.splitPFN(pfnToRemove)
             command = "xrd %s rm %s" % (host, path)
             print("Executing: %s" % command)
             self.executeCommand(command)

--- a/src/python/WMCore/Storage/Backends/RFCPCERNImpl.py
+++ b/src/python/WMCore/Storage/Backends/RFCPCERNImpl.py
@@ -11,7 +11,7 @@ import os
 import re
 
 from WMCore.Storage.Registry import registerStageOutImpl
-from WMCore.Storage.StageOutImpl import StageOutImpl, splitPFN
+from WMCore.Storage.StageOutImpl import StageOutImpl
 from WMCore.Storage.StageOutError import StageOutError
 
 from WMCore.Storage.Execute import execute
@@ -149,7 +149,7 @@ class RFCPCERNImpl(StageOutImpl):
 
         if isRemoteEOS:
 
-            (_, host, path, _) = splitPFN(remotePFN)
+            (_, host, path, _) = self.splitPFN(remotePFN)
 
             result += "REMOTE_SIZE=`xrd '%s' stat '%s' | sed -r 's/.* Size: ([0-9]+) .*/\\1/'`\n" % (host, path)
             result += "echo \"Remote File Size is: $REMOTE_SIZE\"\n"
@@ -185,7 +185,7 @@ class RFCPCERNImpl(StageOutImpl):
         Alternate between EOS, CASTOR and local.
         """
         if self.isEOS(pfn):
-            (_, host, path, _) = splitPFN(pfn)
+            (_, host, path, _) = self.splitPFN(pfn)
             return "xrd %s rm %s" % (host, path)
         try:
             simplePFN = self.parseCastorPath(pfn)
@@ -203,7 +203,7 @@ class RFCPCERNImpl(StageOutImpl):
         """
         if self.isEOS(pfnToRemove):
 
-            (_, host, path, _) = splitPFN(pfnToRemove)
+            (_, host, path, _) = self.splitPFN(pfnToRemove)
             command = "xrd %s rm %s" % (host, path)
 
         else:
@@ -321,7 +321,7 @@ class RFCPCERNImpl(StageOutImpl):
         Check if the PFN is for EOS
 
         """
-        (protocol, host, _, _) = splitPFN(pfn)
+        (protocol, host, _, _) = self.splitPFN(pfn)
         if protocol == "root" and not host.startswith("castor"):
             return True
         else:

--- a/src/python/WMCore/Storage/Backends/XRDCPImpl.py
+++ b/src/python/WMCore/Storage/Backends/XRDCPImpl.py
@@ -2,63 +2,132 @@
 """
 _XRDCPImpl_
 
-Implementation of StageOutImpl interface for RFIO in Castor-2
+Implementation of StageOutImpl interface for xrdcp
+
+Generic, will/should work with any site.
 
 """
 from __future__ import print_function
 import os
+import argparse
+
 from WMCore.Storage.Registry import registerStageOutImpl
 from WMCore.Storage.StageOutImpl import StageOutImpl
+from WMCore.Storage.StageOutError import StageOutError
 
-from WMCore.Storage.Execute import runCommand
+from WMCore.Storage.Execute import execute
 
 
 class XRDCPImpl(StageOutImpl):
     """
     _XRDCPImpl_
 
-    Implement interface for rfcp command
-
     """
 
-    run = staticmethod(runCommand)
+    def __init__(self, stagein=False):
+        StageOutImpl.__init__(self, stagein)
+        self.numRetries = 5
+        self.retryPause = 300
 
     def createSourceName(self, protocol, pfn):
         """
         _createSourceName_
 
-         uses pfn
-
         """
-        return "%s" % pfn
+        return pfn
 
-    def createStageOutCommand(self, sourcePFN, targetPFN, options = None, checksums = None):
+    def createOutputDirectory(self, targetPFN):
+        """
+        _createOutputDirectory_
+
+        not needed since xrdcp does it automatically
+        """
+        return
+
+    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
         """
         _createStageOutCommand_
 
-        Build an xrdcp command
+        Build the actual xrdcp stageout command
+
+        If adler32 checksum is provided, use it for the transfer
+        xrdcp options used:
+          --force : re-creates a file if it's already present
+          --nopbar : does not display the progress bar
 
         """
-        original_size = os.stat(sourcePFN)[6]
-        print("Local File Size is: %s" % original_size)
-        result = ". /afs/cern.ch/user/c/cmsprod/scratch1/releases/CMSSW_1_8_0_pre0/src/runtime.sh ; xrdcp -d 3"
-        if options != None:
-            result += " %s " % options
-        result += " %s " % sourcePFN
-        result += " root://lxgate39.cern.ch/%s " % targetPFN
-        result += "; DEST_SIZE=`rfstat %s | grep Size | cut -f2 -d:` ; if [ $DEST_SIZE ] && [ '%s' == $DEST_SIZE ]; then exit 0; else echo \"Error: Size Mismatch between local and SE\"; exit 60311 ; fi " % (targetPFN,original_size)
-        return result
+        if not options:
+            options = ''
 
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--cerncastor', action='store_true')
+        args, unknown = parser.parse_known_args(options.split())
+
+        copyCommandOptions = ' '.join(unknown)
+
+        copyCommand = ""
+
+        if self.stageIn:
+            remotePFN, localPFN = sourcePFN, targetPFN
+        else:
+            remotePFN, localPFN = targetPFN, sourcePFN
+            copyCommand += "LOCAL_SIZE=`stat -c%%s \"%s\"`\n" % localPFN
+            copyCommand += "echo \"Local File Size is: $LOCAL_SIZE\"\n"
+            if args.cerncastor:
+                targetPFN += "?svcClass=t0cms"
+
+        useChecksum = (checksums != None and 'adler32' in checksums and not self.stageIn)
+
+        copyCommand += "xrdcp --force --nopbar "
+
+        if copyCommandOptions:
+            copyCommand += "%s " % copyCommandOptions
+
+        if useChecksum:
+            checksums['adler32'] = "%08x" % int(checksums['adler32'], 16)
+            copyCommand += "--cksum adler32:%s " % checksums['adler32']
+
+        copyCommand += " \"%s\" " % sourcePFN
+        copyCommand += " \"%s\" \n" % targetPFN
+
+        if self.stageIn:
+            copyCommand += "LOCAL_SIZE=`stat -c%%s \"%s\"`\n" % localPFN
+            copyCommand += "echo \"Local File Size is: $LOCAL_SIZE\"\n"
+
+        (_, host, path, _) = self.splitPFN(remotePFN)
+
+        if self.stageIn:
+            removeCommand = ""
+        else:
+            removeCommand = "xrdfs %s rm %s" % (host, path)
+
+        copyCommand += "REMOTE_SIZE=`xrdfs '%s' stat '%s' | grep Size | sed -r 's/.*Size:[ ]*([0-9]+).*/\\1/'`\n" % (host, path)
+        copyCommand += "echo \"Remote File Size is: $REMOTE_SIZE\"\n"
+
+        if useChecksum:
+
+            copyCommand += "echo \"Local File Checksum is: %s\"\n" % checksums['adler32']
+            copyCommand += "REMOTE_XS=`xrdfs '%s' query checksum '%s' | grep adler32 | sed -r 's/.*adler32[ ]*([0-9a-fA-F]{8}).*/\\1/'`\n" % (host, path)
+            copyCommand += "echo \"Remote File Checksum is: $REMOTE_XS\"\n"
+
+            copyCommand += "if [ $REMOTE_SIZE ] && [ $REMOTE_XS ] && [ $LOCAL_SIZE == $REMOTE_SIZE ] && [ '%s' == $REMOTE_XS ]; then exit 0; " % checksums['adler32']
+            copyCommand += "else echo \"Error: Size or Checksum Mismatch between local and SE\"; %s ; exit 60311 ; fi" % removeCommand
+
+        else:
+
+            copyCommand += "if [ $REMOTE_SIZE ] && [ $LOCAL_SIZE == $REMOTE_SIZE ]; then exit 0; "
+            copyCommand += "else echo \"Error: Size Mismatch between local and SE\"; %s ; exit 60311 ; fi" % removeCommand
+
+        return copyCommand
 
     def removeFile(self, pfnToRemove):
         """
         _removeFile_
 
-        CleanUp pfn provided: specific for Castor-2
-
         """
-        command = "stager_rm -M %s ; nsrm %s" %(pfnToRemove,pfnToRemove)
-        self.executeCommand(command)
-
+        (_, host, path, _) = self.splitPFN(pfnToRemove)
+        command = "xrdfs %s rm %s" % (host, path)
+        execute(command)
+        return
 
 registerStageOutImpl("xrdcp", XRDCPImpl)

--- a/src/python/WMCore/Storage/StageOutImpl.py
+++ b/src/python/WMCore/Storage/StageOutImpl.py
@@ -13,43 +13,6 @@ from WMCore.Storage.Execute import runCommand
 from WMCore.Storage.StageOutError import StageOutError
 
 
-def splitPFN(pfn):
-    """
-     _splitPFN_
-
-    Generic function to split the PFN in smaller pieces, such as:
-    { <protocol>, <host>, <path>, <opaque> }
-    """
-    protocol = pfn.split(':')[0]
-    host = pfn.split('/')[2]
-    thisList = pfn.replace('%s://%s/' % (protocol, host), '').split('?')
-    path = thisList[0]
-    opaque = ""
-    # If we have any opaque info keep it
-    if len(thisList) == 2:
-        opaque = "?%s" % thisList[1]
-
-    # check for the path to actually be in the opaque information
-    if opaque.startswith("?path="):
-        elements = opaque.split('&')
-        path = elements[0].replace('?path=', '')
-        buildingOpaque = '?'
-        for element in elements[1:]:
-            buildingOpaque += element
-            buildingOpaque += '&'
-        opaque = buildingOpaque.rstrip('&')
-    elif opaque.find("&path=") != -1:
-        elements = opaque.split('&')
-        buildingOpaque = elements[0]
-        for element in elements[1:]:
-            if element.startswith('path='):
-                path = element.replace('path=', '')
-            else:
-                buildingOpaque += '&' + element
-        opaque = buildingOpaque
-    return protocol, host, path, opaque
-
-
 class StageOutImpl(object):
     """
     _StageOutImpl_
@@ -69,6 +32,43 @@ class StageOutImpl(object):
         self.numRetries = 3
         self.retryPause = 600
         self.stageIn = stagein
+
+    @staticmethod
+    def splitPFN(pfn):
+        """
+        _splitPFN_
+
+        Generic function to split the PFN in smaller pieces, such as:
+        { <protocol>, <host>, <path>, <opaque> }
+        """
+        protocol = pfn.split(':')[0]
+        host = pfn.split('/')[2]
+        thisList = pfn.replace('%s://%s/' % (protocol, host), '').split('?')
+        path = thisList[0]
+        opaque = ""
+        # If we have any opaque info keep it
+        if len(thisList) == 2:
+            opaque = "?%s" % thisList[1]
+
+        # check for the path to actually be in the opaque information
+        if opaque.startswith("?path="):
+            elements = opaque.split('&')
+            path = elements[0].replace('?path=', '')
+            buildingOpaque = '?'
+            for element in elements[1:]:
+                buildingOpaque += element
+                buildingOpaque += '&'
+            opaque = buildingOpaque.rstrip('&')
+        elif opaque.find("&path=") != -1:
+            elements = opaque.split('&')
+            buildingOpaque = elements[0]
+            for element in elements[1:]:
+                if element.startswith('path='):
+                    path = element.replace('path=', '')
+                else:
+                    buildingOpaque += '&' + element
+            opaque = buildingOpaque
+        return protocol, host, path, opaque
 
     def executeCommand(self, command):
         """

--- a/src/python/WMCore/Storage/StageOutMgr.py
+++ b/src/python/WMCore/Storage/StageOutMgr.py
@@ -245,7 +245,7 @@ class StageOutMgr:
                 fileToStage = stageoutPolicyReport(fileToStage, None, None, None, 'FALLBACK', 0)
                 return fileToStage
             except Exception as ex:
-                fileToStage = stageoutPolicyReport(fileToStage, fallback['se-name'], fallback['PNN'],
+                fileToStage = stageoutPolicyReport(fileToStage, fallback['se-name'], fallback['phedex-node'],
                                                    fallback['command'], 'FALLBACK', 60310)
                 lastException = ex
                 continue

--- a/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
@@ -73,27 +73,21 @@ class LogCollect(Executor):
         # Set wait to over an hour
         waitTime = overrides.get('waitTime', 3600 + (self.step.retryDelay * self.step.retryCount))
 
-        # Pull out StageOutMgr Overrides
-        # switch between old stageOut behavior and new, fancy stage out behavior
-        useNewStageOutCode = False
-        if 'newStageOut' in overrides and overrides.get('newStageOut'):
-            useNewStageOutCode = True
-
         # hardcode CERN Castor T0_CH_CERN_MSS stageout parameters
         castorStageOutParams = {}
-        castorStageOutParams['command'] = overrides.get('command', "srmv2-lcg")
-        castorStageOutParams['option'] = overrides.get('option', "")
+        castorStageOutParams['command'] = overrides.get('command', "xrdcp")
+        castorStageOutParams['option'] = overrides.get('option', "--cerncastor")
         castorStageOutParams['se-name'] = overrides.get('se-name', "srm-cms.cern.ch")
         castorStageOutParams['phedex-node'] = overrides.get('phedex-node', "T2_CH_CERN")
-        castorStageOutParams['lfn-prefix'] = overrides.get('lfn-prefix', "srm://srm-cms.cern.ch:8443/srm/managerv2?SFN=/castor/cern.ch/cms")
+        castorStageOutParams['lfn-prefix'] = overrides.get('lfn-prefix', "root://castorcms.cern.ch//castor/cern.ch/cms")
 
         # hardcode CERN EOS T2_CH_CERN stageout parameters
         eosStageOutParams = {}
-        eosStageOutParams['command'] = overrides.get('command', "srmv2-lcg")
+        eosStageOutParams['command'] = overrides.get('command', "xrdcp")
         eosStageOutParams['option'] = overrides.get('option', "")
         eosStageOutParams['se-name'] = overrides.get('se-name', "srm-eoscms.cern.ch")
         eosStageOutParams['phedex-node'] = overrides.get('phedex-node', "T2_CH_CERN")
-        eosStageOutParams['lfn-prefix'] = overrides.get('lfn-prefix', "srm://srm-eoscms.cern.ch:8443/srm/v2/server?SFN=/eos/cms")
+        eosStageOutParams['lfn-prefix'] = overrides.get('lfn-prefix', "root://eoscms.cern.ch//eos/cms")
 
         # are we using the new stageout method ?
         useNewStageOutCode = False
@@ -102,25 +96,10 @@ class LogCollect(Executor):
             useNewStageOutCode = True
 
         try:
-            if useNewStageOutCode:
-                # is this even working ???
-                #logging.info("LOGCOLLECT IS USING NEW STAGEOUT CODE")
-                #stageOutMgr = StageOutMgr(retryPauseTime  = self.step.retryDelay,
-                #                          numberOfRetries = self.step.retryCount,
-                #                          **overrides)
-                #stageInMgr = StageInMgr(retryPauseTime  = 0,
-                #                        numberOfRetries = 0)
-                #deleteMgr = DeleteMgr(retryPauseTime  = 0,
-                #                      numberOfRetries = 0)
-                castorStageOutMgr = StageOutMgr(**castorStageOutParams)
-                eosStageOutMgr = StageOutMgr(**eosStageOutParams)
-                stageInMgr = StageInMgr()
-                deleteMgr = DeleteMgr()
-            else:
-                castorStageOutMgr = StageOutMgr(**castorStageOutParams)
-                eosStageOutMgr = StageOutMgr(**eosStageOutParams)
-                stageInMgr = StageInMgr()
-                deleteMgr = DeleteMgr()
+            castorStageOutMgr = StageOutMgr(**castorStageOutParams)
+            eosStageOutMgr = StageOutMgr(**eosStageOutParams)
+            stageInMgr = StageInMgr()
+            deleteMgr = DeleteMgr()
         except Exception as ex:
             msg = "Unable to load StageOut/Delete Impl: %s" % str(ex)
             logging.error(msg)


### PR DESCRIPTION
Create a basic xrdcp stageout plugin. Use it for LogCollect stageout to EOS and Castor (the latter needs special options). Also fix a bug in the StageOutMgr exception handling. In addition convert the top-level splitPFN function in StageOutImpl into a static class method (had problems with the top-level function).

@amaltaro , @ticoann , please review.

Patch has been tested (both for general stageout with some hacking and for LogCollect), although only at CERN (only resources I have easy access to). Would need to be tested elsewhere too (especially Fermilab since I modified the splitPFN call in their stageout plugin).

Still leaving the wrong PNN for the castor stageout in, we can look at that later.
