### PR TITLE
more fine-grained options to force unmerged and use them in PromptReco

### DIFF
--- a/src/python/WMCore/FwkJobReport/Report.py
+++ b/src/python/WMCore/FwkJobReport/Report.py
@@ -1052,29 +1052,33 @@ class Report:
 
         return filteredResults
 
-
     def getAllFileRefsFromStep(self, step):
         """
         _getAllFileRefsFromStep_
 
-        Retrieve a list of all files produced in a step.  The files will be in
-        the form of references to the ConfigSection objects in the acutal
-        report.
+        Retrieve all files produced in a step.  Return it as a dictionary keyed
+        of the output module since the stageout code has some output module
+        specific settings (force unmerged output).
+
+        The files will be in the form of references to the ConfigSection
+        objects in the acutal report.
         """
         stepReport = self.retrieveStep(step=step)
         if not stepReport:
-            return []
+            return {}
 
         outputModules = getattr(stepReport, "outputModules", [])
-        fileRefs = []
+        fileRefs = {}
         for outputModule in outputModules:
+
+            fileRefs.setdefault(outputModule, [])
+
             outputModuleRef = self.getOutputModule(step=step, outputModule=outputModule)
 
             for i in range(outputModuleRef.files.fileCount):
-                fileRefs.append(getattr(outputModuleRef.files, "file%i" % i))
+                fileRefs[outputModule].append(getattr(outputModuleRef.files, "file%i" % i))
 
-        analysisFiles = self.getAnalysisFilesFromStep(step)
-        fileRefs.extend(analysisFiles)
+        fileRefs['analysis'] = self.getAnalysisFilesFromStep(step)
 
         return fileRefs
 
@@ -1236,9 +1240,10 @@ class Report:
 
         fileRefs = []
         for step in self.data.steps:
-            tmpRefs = self.getAllFileRefsFromStep(step=step)
-            if len(tmpRefs) > 0:
-                fileRefs.extend(tmpRefs)
+            fileDict = self.getAllFileRefsFromStep(step=step)
+            for tmpRefs in fileDict.values():
+                if len(tmpRefs) > 0:
+                    fileRefs.extend(tmpRefs)
 
         return fileRefs
 

--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -62,7 +62,8 @@ class PromptRecoWorkloadFactory(StdBase):
                                                splitAlgo = self.procJobSplitAlgo,
                                                splitArgs = self.procJobSplitArgs,
                                                stepType = cmsswStepType,
-                                               forceUnmerged = True)
+                                               forceUnmerged = ["write_ALCARECO"] if 'ALCARECO' in self.writeTiers else False)
+
         if self.doLogCollect:
             self.addLogCollectTask(recoTask)
 

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -379,12 +379,14 @@ class StdBase(object):
         procTaskCmsswHelper.setOverrideCatalog(self.overrideCatalog)
         procTaskCmsswHelper.setErrorDestinationStep(stepName=procTaskLogArch.name())
 
-        if forceMerged:
+        if forceMerged and isinstance(forceMerged, bool):
             procTaskStageHelper.setMinMergeSize(0, 0)
-        elif forceUnmerged:
+        elif forceUnmerged and isinstance(forceUnmerged, bool):
             procTaskStageHelper.disableStraightToMerge()
         else:
             procTaskStageHelper.setMinMergeSize(self.minMergeSize, self.maxMergeEvents)
+            if forceUnmerged and isinstance(forceUnmerged, list):
+                procTaskStageHelper.disableStraightToMergeForOutputModules(forceUnmerged)
 
         procTaskCmsswHelper.cmsswSetup(cmsswVersion,
                                        softwareEnvironment="",

--- a/src/python/WMCore/WMSpec/Steps/Templates/StageOut.py
+++ b/src/python/WMCore/WMSpec/Steps/Templates/StageOut.py
@@ -45,7 +45,15 @@ class StageOutStepHelper(CoreHelper):
         """
         if hasattr(self.data.output, "minMergeSize"):
             delattr(self.data.output, "minMergeSize")
+        return
 
+    def disableStraightToMergeForOutputModules(self, outputModules):
+        """
+        _disableStraightToMergeForOutputModules_
+
+        Disable straight to merge only for these output modules.
+        """
+        self.data.output.forceUnmergedOutputs = outputModules
         return
 
     def setMinMergeSize(self, minMergeSize, maxMergeEvents):

--- a/test/python/WMCore_t/FwkJobReport_t/ReportIntegration_t.py
+++ b/test/python/WMCore_t/FwkJobReport_t/ReportIntegration_t.py
@@ -299,9 +299,10 @@ class ReportIntegrationTest(unittest.TestCase):
         myReport.parse(self.procPath)
 
         # Fake some metadata that should be added by the stageout scripts.
-        for fileRef in myReport.getAllFileRefsFromStep("cmsRun1"):
-            fileRef.size = 1024
-            fileRef.location = "cmssrm.fnal.gov"
+        for fileRefs in myReport.getAllFileRefsFromStep("cmsRun1").values():
+            for fileRef in fileRefs:
+                fileRef.size = 1024
+                fileRef.location = "cmssrm.fnal.gov"
 
         fwjrPath = os.path.join(self.tempDir, "ProcReport.pkl")
         cmsRunStep = myReport.retrieveStep("cmsRun1")
@@ -341,12 +342,13 @@ class ReportIntegrationTest(unittest.TestCase):
         myReport.parse(self.mergePath)
 
         # Fake some metadata that should be added by the stageout scripts.
-        for fileRef in myReport.getAllFileRefsFromStep("mergeReco"):
-            fileRef.size = 1024
-            fileRef.location = "cmssrm.fnal.gov"
-            fileRef.dataset = {"applicationName": "cmsRun", "applicationVersion": "CMSSW_3_4_2_patch1",
-                               "primaryDataset": "MinimumBias", "processedDataset": "Rereco-v1",
-                               "dataTier": "RECO"}
+        for fileRefs in myReport.getAllFileRefsFromStep("mergeReco").values():
+            for fileRef in fileRefs:
+                fileRef.size = 1024
+                fileRef.location = "cmssrm.fnal.gov"
+                fileRef.dataset = {"applicationName": "cmsRun", "applicationVersion": "CMSSW_3_4_2_patch1",
+                                   "primaryDataset": "MinimumBias", "processedDataset": "Rereco-v1",
+                                   "dataTier": "RECO"}
 
         fwjrPath = os.path.join(self.tempDir, "MergeReport.pkl")
         myReport.setTaskName('/MergeWF/None')

--- a/test/python/WMCore_t/FwkJobReport_t/Report_t.py
+++ b/test/python/WMCore_t/FwkJobReport_t/Report_t.py
@@ -600,18 +600,19 @@ cms::Exception caught in EventProcessor and rethrown
         # Now see what happens if the adler32 is set to None
         myReport2 = Report("cmsRun1")
         myReport2.parse(self.xmlPath)
-        fRefs = myReport2.getAllFileRefsFromStep(step="cmsRun1")
-        for fRef in fRefs:
-            fRef.checksums = {'adler32': None}
+        for fRefs in myReport2.getAllFileRefsFromStep(step="cmsRun1").values():
+            for fRef in fRefs:
+                fRef.checksums = {'adler32': None}
+
         myReport2.checkForAdlerChecksum(stepName="cmsRun1")
         self.assertFalse(myReport2.stepSuccessful(stepName="cmsRun1"))
         self.assertEqual(myReport2.getExitCode(), 60451)
 
         myReport3 = Report("cmsRun1")
         myReport3.parse(self.xmlPath)
-        fRefs = myReport3.getAllFileRefsFromStep(step="cmsRun1")
-        for fRef in fRefs:
-            fRef.checksums = {'adler32': 100}
+        for fRefs in myReport3.getAllFileRefsFromStep(step="cmsRun1").values():
+            for fRef in fRefs:
+                fRef.checksums = {'adler32': 100}
 
         myReport3.checkForAdlerChecksum(stepName="cmsRun1")
         self.assertTrue(myReport3.getExitCode() != 60451)
@@ -636,9 +637,9 @@ cms::Exception caught in EventProcessor and rethrown
         # Remove the lumi information on purpose
         myReport2 = Report("cmsRun1")
         myReport2.parse(self.xmlPath)
-        fRefs = myReport2.getAllFileRefsFromStep(step="cmsRun1")
-        for fRef in fRefs:
-            fRef.runs = ConfigSection()
+        for fRefs in myReport2.getAllFileRefsFromStep(step="cmsRun1").values():
+            for fRef in fRefs:
+                fRef.runs = ConfigSection()
         myReport2.checkForRunLumiInformation(stepName="cmsRun1")
         self.assertFalse(myReport2.stepSuccessful(stepName="cmsRun1"))
         self.assertEqual(myReport2.getExitCode(), 70452)


### PR DESCRIPTION
Allowing to override all outputs to either merged or unmerged is not enough. Add a way to go with the default (straight to merge enabled for all outputs) but force specific output modules to always write unmerged. Use this to force PromptReco to write ALCARECO output always unmerged.

@ticoann @amaltaro please review. I think this will need some intense testing since it touches the guts of the system. AFAIK WMAgent doesn't use this functionality though, so we have time for testing. Tier0 testing and deployment can follow a different schedule.
