### PR TITLE
Improvements for agent monitoring: agent, wmbs, couch...

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -545,7 +545,9 @@ config.AgentStatusWatcher.forceSiteDown = [] # List of sites to be forced to Dow
 config.AgentStatusWatcher.onlySSB = True # Set thresholds for sites only in SSB (Force all other to zero/down)
 config.AgentStatusWatcher.enabled = True # switch to enable or not this component
 config.AgentStatusWatcher.agentPollInterval = 300
+config.AgentStatusWatcher.monitorPollInterval = 3  # number of component polling cycles
 config.AgentStatusWatcher.defaultAgentsNumByTeam = 5
+config.AgentStatusWatcher.jsonFile = config.General.workDir + "/AgentStatusWatcher/WMA_monitoring.json"
 
 config.component_("ArchiveDataReporter")
 config.ArchiveDataReporter.namespace = "WMComponent.ArchiveDataReporter.ArchiveDataReporter"

--- a/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
+++ b/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
@@ -1,5 +1,9 @@
 """
-Perform cleanup actions
+Perform general agent monitoring, like:
+ 1. Status of the agent processes
+ 2. Status of the agent threads
+ 3. Couchdb replication status (and status of its database)
+ 4. Disk usage status
 """
 __all__ = []
 
@@ -9,6 +13,7 @@ import threading
 import logging
 import time
 import traceback
+import json
 from WMCore.Lexicon import sanitizeURL
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 from WMCore.Database.CMSCouch import CouchMonitor
@@ -31,7 +36,11 @@ class AgentStatusPoller(BaseWorkerThread):
         self.config = config
         # need to get campaign, user, owner info
         self.agentInfo = initAgentInfo(self.config)
-        self.summaryLevel = (config.AnalyticsDataCollector.summaryLevel).lower()
+        self.summaryLevel = config.AnalyticsDataCollector.summaryLevel
+        self.jsonFile = config.AgentStatusWatcher.jsonFile
+        # counter for deep agent monitoring. Every 15min (3 cycles of the component)
+        self.monitorCounter = 0
+        self.monitorInterval = getattr(config.AgentStatusWatcher, 'monitorPollInterval', 3)
     
     def setUpCouchDBReplication(self):
         
@@ -58,9 +67,8 @@ class AgentStatusPoller(BaseWorkerThread):
                                         'filter': wqfilter, 'query_params': query_params})       
             self.replicatorDocs.append({'source': sanitizeURL(localQInboxURL)['url'], 'target': parentQURL, 
                                         'filter': wqfilter, 'query_params': query_params})
-        
-        
-    # delete or replicator docs befor setting up
+
+        # delete old replicator docs before setting up
         self.localCouchMonitor.deleteReplicatorDocs()
         
         for rp in self.replicatorDocs:
@@ -91,18 +99,18 @@ class AgentStatusPoller(BaseWorkerThread):
         get information from wmbs, workqueue and local couch
         """
         try:
-            logging.info("Getting Agent info ...")
             agentInfo = self.collectAgentInfo()
-            
             #set the uploadTime - should be the same for all docs
             uploadTime = int(time.time())
-            
             self.uploadAgentInfoToCentralWMStats(agentInfo, uploadTime)
-            
-            logging.info("Agent components down:\n %s" % agentInfo['down_components'])
-            logging.info("Agent in drain mode:\n %s \nsleep for next WMStats alarm updating cycle"
-                          % agentInfo['drain_mode'])
-            
+
+            if self.monitorCounter % self.monitorInterval == 0:
+                monitoring = self.collectWMBSInfo()
+                monitoring['components'] = agentInfo['down_components']
+                monitoring['timestamp'] = int(time.time())
+                with open(self.jsonFile, 'w') as outFile:
+                    json.dump(monitoring, outFile, indent=2)
+            self.monitorCounter += 1
         except Exception as ex:
             logging.error("Error occurred, will retry later:")
             logging.error(str(ex))
@@ -111,42 +119,47 @@ class AgentStatusPoller(BaseWorkerThread):
      
     def collectCouchDBInfo(self):
         
-        couchInfo = {'status': 'ok', 'error_message': ""}
+        couchInfo = {'name': 'CouchServer', 'status': 'ok', 'error_message': ""}
         
         if self.skipReplicationCheck:
             # skipping the check this round set if False so it can be checked next round.
             self.skipReplicationCheck = False
             return couchInfo
-        
-        msg = ""
+
         for rp in self.replicatorDocs:
             cInfo = self.localCouchMonitor.checkCouchServerStatus(rp['source'], 
                                                         rp['target'], checkUpdateSeq = False)
             if cInfo['status'] != 'ok':
                 couchInfo['status'] = 'error'
+                couchInfo['error_message'] = cInfo['error_message']
         
-        couchInfo['error_message'] = msg
         return couchInfo
         
     def collectAgentInfo(self):
-        
+        """
+        Monitors the general health of the agent, as:
+          1. status of the agent processes
+          2. status of the agent threads based on the database info
+          3. couchdb active tasks and its replications
+          4. check the disk usage
+          5. check the number of couch processes
+
+        :return: a dict with all the info collected
+        """
+        logging.info("Getting agent info ...")
         agentInfo = self.wmagentDB.getComponentStatus(self.config)
         agentInfo.update(self.agentInfo)
         
         if isDrainMode(self.config):
             logging.info("Agent is in DrainMode")
             agentInfo['drain_mode'] = True
-            agentInfo['status'] = "warning"
-        
         else:
             agentInfo['drain_mode'] = False
         
         couchInfo = self.collectCouchDBInfo()
-        
-        if (couchInfo['status'] != 'ok'):
-            agentInfo['down_components'].append("CouchServer")
+        if couchInfo['status'] != 'ok':
+            agentInfo['down_components'].append(couchInfo['name'])
             agentInfo['status'] = couchInfo['status']
-            couchInfo['name'] = "CouchServer"
             agentInfo['down_component_detail'].append(couchInfo)
         
         
@@ -155,12 +168,14 @@ class AgentStatusPoller(BaseWorkerThread):
         diskUseThreshold = float(self.config.AnalyticsDataCollector.diskUseThreshold)
         agentInfo['disk_warning'] = []
         for disk in diskUseList:
-            if float(disk['percent'].strip('%')) >= diskUseThreshold and disk['mounted'] not in self.config.AnalyticsDataCollector.ignoreDisk:
+            if float(disk['percent'].strip('%')) >= diskUseThreshold and \
+                            disk['mounted'] not in self.config.AnalyticsDataCollector.ignoreDisk:
                 agentInfo['disk_warning'].append(disk)
         
         # Couch process warning
         couchProc = numberCouchProcess()
-        couchProcessThreshold = float(self.config.AnalyticsDataCollector.couchProcessThreshold)
+        logging.info("CouchDB is running with %d processes", couchProc)
+        couchProcessThreshold = self.config.AnalyticsDataCollector.couchProcessThreshold
         if couchProc >= couchProcessThreshold:
             agentInfo['couch_process_warning'] = couchProc
         else:
@@ -168,20 +183,21 @@ class AgentStatusPoller(BaseWorkerThread):
         
         # This adds the last time and message when data was updated to agentInfo
         lastDataUpload = DataUploadTime.getInfo(self)
-        if lastDataUpload['data_last_update']!=0:
+        if lastDataUpload['data_last_update']:
             agentInfo['data_last_update'] = lastDataUpload['data_last_update']
-        if lastDataUpload['data_error']!="":
+        if lastDataUpload['data_error']:
             agentInfo['data_error'] = lastDataUpload['data_error']
         
         # Change status if there is data_error, couch process maxed out or disk full problems.
-        if agentInfo['status'] == 'ok':
-            if agentInfo['disk_warning'] != []:
-                agentInfo['status'] = "warning"
+        if agentInfo['status'] == 'ok' and (agentInfo['drain_mode'] or agentInfo['disk_warning']):
+            agentInfo['status'] = "warning"
                 
         if agentInfo['status'] == 'ok' or agentInfo['status'] == 'warning':
-            if ('data_error' in agentInfo and agentInfo['data_error'] != 'ok') or \
-               ('couch_process_warning' in agentInfo and agentInfo['couch_process_warning'] != 0):
+            if agentInfo.get('data_error', 'ok') != 'ok' or agentInfo.get('couch_process_warning', 0):
                 agentInfo['status'] = "error"
+
+        if agentInfo['down_components']:
+            logging.info("List of agent components down: %s" % agentInfo['down_components'])
 
         return agentInfo
 
@@ -190,3 +206,29 @@ class AgentStatusPoller(BaseWorkerThread):
         agentDocs = convertToAgentCouchDoc(agentInfo, self.config.ACDC, uploadTime)
         self.centralWMStatsCouchDB.updateAgentInfo(agentDocs)
 
+    def collectWMBSInfo(self):
+        """
+        Fetches WMBS job information.
+        In addition to WMBS, also collects RunJob info from BossAir
+        :return: dict with the number of jobs in each status
+        """
+        results = {}
+        logging.info("Getting wmbs job info ...")
+        # first retrieve the site thresholds
+        results['thresholds'] = self.wmagentDB.getJobSlotInfo()
+        logging.info("Running and pending site thresholds: %s", results['thresholds'])
+
+        # now fetch the amount of jobs in each state and the amount of created
+        # jobs grouped by task
+        results.update(self.wmagentDB.getAgentMonitoring())
+        logging.info("Total number of jobs in WMBS sorted by status: %s", results['wmbsCountByState'])
+        logging.info("Total number of 'created' jobs in WMBS sorted by type: %s", results['wmbsCreatedTypeCount'])
+        logging.info("Total number of 'executing' jobs in WMBS sorted by type: %s", results['wmbsExecutingTypeCount'])
+
+        logging.info("Total number of active jobs in BossAir sorted by status: %s", results['activeRunJobByStatus'])
+        logging.info("Total number of complete jobs in BossAir sorted by status: %s", results['completeRunJobByStatus'])
+
+        logging.info("Available slots thresholds to pull work from GQ to LQ: %s", results['thresholdsGQ2LQ'])
+        logging.info("List of jobs pending for each site, sorted by priority: %s", results['sitePendCountByPrio'])
+
+        return results

--- a/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
+++ b/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
@@ -182,7 +182,7 @@ class AgentStatusPoller(BaseWorkerThread):
             agentInfo['couch_process_warning'] = 0
         
         # This adds the last time and message when data was updated to agentInfo
-        lastDataUpload = DataUploadTime.getInfo(self)
+        lastDataUpload = DataUploadTime.getInfo()
         if lastDataUpload['data_last_update']:
             agentInfo['data_last_update'] = lastDataUpload['data_last_update']
         if lastDataUpload['data_error']:

--- a/src/python/WMComponent/AnalyticsDataCollector/AnalyticsPoller.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/AnalyticsPoller.py
@@ -128,10 +128,10 @@ class AnalyticsPoller(BaseWorkerThread):
 
             self.localSummaryCouchDB.uploadData(requestDocs)
             logging.info("Request data upload success\n %s request, \nsleep for next cycle" % len(requestDocs))
-            DataUploadTime.setInfo(self, uploadTime, "ok")
+            DataUploadTime.setInfo(uploadTime, "ok")
             
         except Exception as ex:
             logging.error("Error occurred, will retry later:")
             logging.error(str(ex))
-            DataUploadTime.setInfo(self, False, str(ex))
+            DataUploadTime.setInfo(False, str(ex))
             logging.error("Trace back: \n%s" % traceback.format_exc())

--- a/src/python/WMCore/Agent/Daemon/Details.py
+++ b/src/python/WMCore/Agent/Daemon/Details.py
@@ -75,10 +75,9 @@ class Details(dict):
         _isAlive_
 
         Is the process still running?
-
-        Dumb check on /proc/pid existing. Anyone know a better way?
-
         """
+        # FIXME ps -T -p 1946167 -o euser,pid,ppid,lwp,nlwp,stat,start
+        # it prints the user, process and its threads, number of threads, etc
         se, so, rc = run('ps -p %s' % self['ProcessID'])
         if rc != 0:
             return False

--- a/src/python/WMCore/Agent/Daemon/Details.py
+++ b/src/python/WMCore/Agent/Daemon/Details.py
@@ -10,30 +10,28 @@ Also, provides utils to shutdown the daemon process
 """
 from __future__ import print_function
 
-
-
-
-
 import os
 import subprocess
 import shutil
 import time
-#FIXME: needs to be replaced with persistent backend.
+# FIXME: needs to be replaced with persistent backend.
 from xml.dom.minidom import parse
+
 
 def run(command):
     proc = subprocess.Popen(
-            ["/bin/bash"], shell=True, cwd=os.environ['PWD'],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            stdin=subprocess.PIPE,
-            )
+        ["/bin/bash"], shell=True, cwd=os.environ['PWD'],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        stdin=subprocess.PIPE,
+    )
 
     proc.stdin.write(command)
-    stdout, stderr =  proc.communicate()
+    stdout, stderr = proc.communicate()
     rc = proc.returncode
 
     return stdout, stderr, rc
+
 
 class Details(dict):
     """
@@ -47,11 +45,11 @@ class Details(dict):
     This util takes that file, reads its fields into a dictionary.
 
     """
+
     def __init__(self, daemonXmlFile):
         dict.__init__(self)
         self.load(daemonXmlFile)
         self.daemonXmlFile = daemonXmlFile
-
 
     def load(self, xmlFile):
         """
@@ -76,14 +74,14 @@ class Details(dict):
 
         Is the process still running?
         """
-        # FIXME ps -T -p 1946167 -o euser,pid,ppid,lwp,nlwp,stat,start
+        # Reference: ps -T -p 1946167 -o euser,pid,ppid,lwp,nlwp,stat,start
         # it prints the user, process and its threads, number of threads, etc
-        se, so, rc = run('ps -p %s' % self['ProcessID'])
+        dummyse, dummyso, rc = run('ps -p %s' % self['ProcessID'])
         if rc != 0:
             return False
         return True
 
-    def kill(self, signal = 15):
+    def kill(self, signal=15):
         """
         _kill_
 
@@ -95,7 +93,7 @@ class Details(dict):
         self.removeAndBackupDaemonFile()
         return
 
-    def killWithPrejudice(self, signal = 15):
+    def killWithPrejudice(self, signal=15):
         """
         _killWithPredjudice_
 
@@ -104,7 +102,7 @@ class Details(dict):
 
         """
         os.killpg(self['ProcessGroupID'], signal)
-        for count in range(0, 3):
+        for dummycount in range(0, 3):
             time.sleep(1)
             if not self.isAlive():
                 self.removeAndBackupDaemonFile()
@@ -119,11 +117,11 @@ class Details(dict):
         Removes the daemon file (after a kill) and backs it up
         for post mortem.
         """
-        path, file = os.path.split(self.daemonXmlFile)
+        path, dFile = os.path.split(self.daemonXmlFile)
         timeStamp = time.strftime("%d-%M-%Y")
-        newFile = "%s.BAK.%s" %(file, str(timeStamp))
+        newFile = "%s.BAK.%s" % (dFile, str(timeStamp))
         newLocation = os.path.join(path, newFile)
         try:
             shutil.move(self.daemonXmlFile, newLocation)
         except Exception as ex:
-            print('Move failed. Remove manual: '+str(ex))
+            print('Move failed. Remove manual: ' + str(ex))

--- a/src/python/WMCore/Database/CMSCouch.py
+++ b/src/python/WMCore/Database/CMSCouch.py
@@ -217,7 +217,7 @@ class Database(CouchDBRequests):
             self.commit(viewlist=viewlist, callback=callback)
         self._queue.append(doc)
 
-    def queueDelete(self, doc, viewlist=[]):
+    def queueDelete(self, doc):
         """
         Queue up a document for deletion
         """
@@ -226,7 +226,7 @@ class Database(CouchDBRequests):
         doc = {'_id': doc['_id'], '_rev': doc['_rev'], '_deleted': True}
         self.queue(doc)
 
-    def commitOne(self, doc, returndocs=False, timestamp=False, viewlist=[]):
+    def commitOne(self, doc, timestamp=False, viewlist=[]):
         """
         Helper function for when you know you only want to insert one doc
         additionally keeps from having to rewrite ConfigCache to handle the
@@ -246,9 +246,8 @@ class Database(CouchDBRequests):
     def commit(self, doc=None, returndocs=False, timestamp=False,
                viewlist=[], callback=None, **data):
         """
-        Add doc and/or the contents of self._queue to the database. If
-        returndocs is true, return document objects representing what has been
-        committed. If timestamp is true timestamp all documents with a unix style
+        Add doc and/or the contents of self._queue to the database.
+        If timestamp is true timestamp all documents with a unix style
         timestamp - this will be the timestamp of when the commit was called, it
         will not override an existing timestamp field.  If timestamp is a string
         that string will be used as the label for the timestamp.
@@ -1085,8 +1084,8 @@ class CouchMonitor(object):
                     else:
                         logging.error("""replication failed from %s to %s 
                                          couch server needs to be manually restarted""" % (
-                                      replaceToSantizeURL(source),
-                                      replaceToSantizeURL(target)))
+                            replaceToSantizeURL(source),
+                            replaceToSantizeURL(target)))
                     filteredDocs.append(doc)
         return filteredDocs
 
@@ -1147,13 +1146,12 @@ class CouchMonitor(object):
             logging.error(msg)
             return {'status': 'down', 'error_message': str(ex)}
 
-        
     def checkReplicationStatus(self, activeStatus, dbInfo, source, target, checkUpdateSeq):
         """
         adhoc way to check the replication
         """
         # monitor the last update on replications according to 5 min + checkpoint_interval
-        secsUpdateOn = 5 * 60 + activeStatus['checkpoint_interval']/1000
+        secsUpdateOn = 5 * 60 + activeStatus['checkpoint_interval'] / 1000
         lastUpdate = activeStatus["updated_on"]
         updateNum = int(activeStatus["source_seq"])
         previousUpdateNum = self.getPreviousUpdateSequence(source, target)
@@ -1170,7 +1168,7 @@ class CouchMonitor(object):
                 return True
             else:
                 logging.warning("Replication from %s to %s has not been updated for more than %d minutes", source,
-                                                                                                           target,
-                                                                                                           secsUpdateOn)
+                                target,
+                                secsUpdateOn)
                 return False
         return False

--- a/src/python/WMCore/Database/CMSCouch.py
+++ b/src/python/WMCore/Database/CMSCouch.py
@@ -16,6 +16,7 @@ import re
 import hashlib
 import base64
 import logging
+import traceback
 from httplib import HTTPException
 from datetime import datetime
 
@@ -1117,6 +1118,9 @@ class CouchMonitor(object):
         return couchInfo
 
     def checkCouchServerStatus(self, source, target, checkUpdateSeq):
+        """
+        Check the status of a specific replication task
+        """
         try:
             if checkUpdateSeq:
                 dbInfo = self.couchServer.get("/%s" % source)
@@ -1124,47 +1128,49 @@ class CouchMonitor(object):
                 dbInfo = None
             activeTasks = self.couchServer.get("/_active_tasks")
             replicationFlag = False
-            passwdStrippedURL = target.split("@")[-1]
+            passwdStrippedTarget = target.split("@")[-1]
 
             for activeStatus in activeTasks:
                 if activeStatus["type"].lower() == "replication":
-                    if passwdStrippedURL in activeStatus.get("target", ""):
-                        replicationFlag = self.checkReplicationStatus(activeStatus,
-                                                                      dbInfo, source, target, checkUpdateSeq)
+                    if passwdStrippedTarget in activeStatus.get("target", ""):
+                        replicationFlag = self.checkReplicationStatus(activeStatus, dbInfo, source,
+                                                                      passwdStrippedTarget, checkUpdateSeq)
                         break
 
             if replicationFlag:
                 return {'status': 'ok'}
             else:
-                return {'status': 'error', 'error_message': "replication stopped"}
+                msg = "Replication stopped from %s to %s.\n" % (source, passwdStrippedTarget)
+                return {'status': 'error', 'error_message': msg}
         except Exception as ex:
-            import traceback
             msg = traceback.format_exc()
             logging.error(msg)
             return {'status': 'down', 'error_message': str(ex)}
 
-    def checkReplicationStatus(self, activeStatus, dbInfo, source, target,
-                               checkUpdateSeq):
+        
+    def checkReplicationStatus(self, activeStatus, dbInfo, source, target, checkUpdateSeq):
         """
-        adhog way to check the replication
+        adhoc way to check the replication
         """
-
-        logging.info("checking the replication status")
-        # if activeStatus["started_on"]:
-        #   logging.info("Starting status: ok")
-        #    return True
+        # monitor the last update on replications according to 5 min + checkpoint_interval
+        secsUpdateOn = 5 * 60 + activeStatus['checkpoint_interval']/1000
+        lastUpdate = activeStatus["updated_on"]
+        updateNum = int(activeStatus["source_seq"])
         previousUpdateNum = self.getPreviousUpdateSequence(source, target)
 
-        if activeStatus["updated_on"]:
-            updateNum = int(activeStatus["source_seq"])
-            self.setPreviousUpdateSequence(source, target, updateNum)
-            if not checkUpdateSeq:
-                logging.warning("Need to check replication from %s to %s", replaceToSantizeURL(source),
-                                                                           replaceToSantizeURL(target))
-                return True
-            elif updateNum == dbInfo["update_seq"] or updateNum > previousUpdateNum:
-                logging.info("update up-to-date: ok")
+        self.setPreviousUpdateSequence(source, target, updateNum)
+        if checkUpdateSeq:
+            if updateNum == dbInfo["update_seq"] or updateNum > previousUpdateNum:
                 return True
             else:
+                logging.warning("'update_seq for replication from %s to %s is falling behind", source, target)
+                return False
+        else:
+            if int(time.time()) - lastUpdate < secsUpdateOn:
+                return True
+            else:
+                logging.warning("Replication from %s to %s has not been updated for more than %d minutes", source,
+                                                                                                           target,
+                                                                                                           secsUpdateOn)
                 return False
         return False

--- a/src/python/WMCore/WMBS/MySQL/Locations/GetJobSlotsByCMSName.py
+++ b/src/python/WMCore/WMBS/MySQL/Locations/GetJobSlotsByCMSName.py
@@ -3,7 +3,6 @@
 _GetJobSlotsByCMSName_
 """
 
-
 from WMCore.Database.DBFormatter import DBFormatter
 
 
@@ -33,7 +32,6 @@ class GetJobSlotsByCMSName(DBFormatter):
 
         return dictResult
 
-    def execute(self, conn=None, transaction=False):
-
+    def execute(self, conn=None, transaction=False, returnCursor=False):
         results = self.dbi.processData(self.sql, conn=conn, transaction=transaction)
         return self.formatDict(results)

--- a/src/python/WMCore/WMBS/MySQL/Locations/GetJobSlotsByCMSName.py
+++ b/src/python/WMCore/WMBS/MySQL/Locations/GetJobSlotsByCMSName.py
@@ -1,25 +1,39 @@
 #!/usr/bin/env python
 """
 _GetJobSlotsByCMSName_
-
-MySQL implementation of Locations.GetSiteInfo
 """
-
-__all__ = []
-
 
 
 from WMCore.Database.DBFormatter import DBFormatter
 
+
 class GetJobSlotsByCMSName(DBFormatter):
     """
-    get number of jobSlots by cms name
+    Get site running and pending thresholds grouped by CMS name
     """
 
-    sql = "SELECT cms_name, SUM(job_slots) AS job_slots FROM wmbs_location GROUP BY cms_name"
+    sql = """
+        SELECT cms_name, wmbs_location_state.name as state, pending_slots, running_slots
+            FROM wmbs_location
+            INNER JOIN wmbs_location_state ON wmbs_location.state = wmbs_location_state.id
+        """
 
+    def formatDict(self, results):
+        """
+        _formatDict_
 
-    def execute(self, conn = None, transaction = False):
+        Format the results in a dict keyed by the cms_name
+        """
+        formattedResults = DBFormatter.formatDict(self, results)
 
-        results = self.dbi.processData(self.sql, conn = conn, transaction = transaction)
+        dictResult = {}
+        for item in formattedResults:
+            site = item.pop('cms_name')
+            dictResult[site] = item
+
+        return dictResult
+
+    def execute(self, conn=None, transaction=False):
+
+        results = self.dbi.processData(self.sql, conn=conn, transaction=transaction)
         return self.formatDict(results)

--- a/src/python/WMCore/WMBS/MySQL/Monitoring/JobCountByState.py
+++ b/src/python/WMCore/WMBS/MySQL/Monitoring/JobCountByState.py
@@ -28,12 +28,12 @@ class JobCountByState(DBFormatter):
 
         return dictResult
 
-    def execute(self, conn=None, transaction=False):
+    def execute(self, conn=None, transaction=False, returnCursor=False):
         """
         _execute_
 
         Execute the SQL.
         """
-        result = self.dbi.processData(self.sql, conn = conn, transaction = transaction)
+        result = self.dbi.processData(self.sql, conn=conn, transaction=transaction)
 
         return self.formatDict(result)

--- a/src/python/WMCore/WMBS/MySQL/Monitoring/JobCountByState.py
+++ b/src/python/WMCore/WMBS/MySQL/Monitoring/JobCountByState.py
@@ -4,14 +4,36 @@ _JobsByState_
 
 Monitoring DAO classes for Jobs in WMBS
 """
-__all__ = []
+
+from WMCore.Database.DBFormatter import DBFormatter
 
 
-
-from WMCore.WMBS.MySQL.Monitoring.DefaultFormatter import DefaultFormatter
-
-class JobCountByState(DefaultFormatter):
+class JobCountByState(DBFormatter):
     sql = """SELECT count(wmbs_job.state) AS job_count, wmbs_job_state.name AS job_state
              FROM wmbs_job
              INNER JOIN wmbs_job_state ON wmbs_job.state=wmbs_job_state.id
              GROUP BY wmbs_job_state.name"""
+
+    def formatDict(self, results):
+        """
+        _formatDict_
+
+        Format the results in a dict keyed by the state name
+        """
+        formattedResults = DBFormatter.formatDict(self, results)
+
+        dictResult = {}
+        for formattedResult in formattedResults:
+            dictResult[formattedResult['job_state']] = int(formattedResult['job_count'])
+
+        return dictResult
+
+    def execute(self, conn=None, transaction=False):
+        """
+        _execute_
+
+        Execute the SQL.
+        """
+        result = self.dbi.processData(self.sql, conn = conn, transaction = transaction)
+
+        return self.formatDict(result)

--- a/src/python/WMCore/WMBS/MySQL/Monitoring/JobTypeCountByState.py
+++ b/src/python/WMCore/WMBS/MySQL/Monitoring/JobTypeCountByState.py
@@ -3,7 +3,7 @@ _JobTypeCountByState_
 
 Monitoring DAO classes for Jobs in WMBS
 """
-
+from __future__ import print_function, division
 
 from WMCore.Database.DBFormatter import DBFormatter
 

--- a/src/python/WMCore/WMBS/MySQL/Monitoring/JobTypeCountByState.py
+++ b/src/python/WMCore/WMBS/MySQL/Monitoring/JobTypeCountByState.py
@@ -1,0 +1,39 @@
+"""
+_JobTypeCountByState_
+
+Monitoring DAO classes for Jobs in WMBS
+"""
+
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+
+class JobTypeCountByState(DBFormatter):
+    sql = """
+          SELECT wmbs_sub_types.name AS job_type, COUNT(*) AS count FROM wmbs_job
+            INNER JOIN wmbs_jobgroup ON wmbs_job.jobgroup = wmbs_jobgroup.id
+            INNER JOIN wmbs_subscription ON wmbs_jobgroup.subscription = wmbs_subscription.id
+            INNER JOIN wmbs_sub_types ON wmbs_subscription.subtype = wmbs_sub_types.id
+            WHERE wmbs_job.state = (SELECT id FROM wmbs_job_state WHERE name = :state)
+            GROUP BY wmbs_subscription.subtype, wmbs_sub_types.name
+          """
+
+    def formatDict(self, results):
+        """
+        _formatDict_
+
+        Format the results in a dict keyed by the state name
+        """
+        formattedResults = DBFormatter.formatDict(self, results)
+
+        dictResult = {}
+        for formattedResult in formattedResults:
+            dictResult[formattedResult['job_type']] = int(formattedResult['count'])
+
+        return dictResult
+
+    def execute(self, state, conn=None, transaction=False):
+        binds = {'state': state}
+        result = self.dbi.processData(self.sql, binds, conn=conn, transaction=transaction)
+
+        return self.formatDict(result)

--- a/src/python/WMCore/WMBS/MySQL/Monitoring/RunJobByStatus.py
+++ b/src/python/WMCore/WMBS/MySQL/Monitoring/RunJobByStatus.py
@@ -1,0 +1,43 @@
+"""
+_RunJobByStatus_
+
+Monitoring DAO classes for Jobs in BossAir database
+"""
+
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+
+class RunJobByStatus(DBFormatter):
+    sql = """
+          SELECT bl_status.name AS sched_status, count(*) AS count
+            FROM bl_runjob
+            INNER JOIN bl_status ON bl_runjob.sched_status = bl_status.id
+            LEFT OUTER JOIN wmbs_users ON wmbs_users.id = bl_runjob.user_id
+            INNER JOIN wmbs_job ON wmbs_job.id = bl_runjob.wmbs_id
+            WHERE bl_runjob.status = :status GROUP BY bl_status.name
+          """
+
+    def formatDict(self, results):
+        """
+        _formatDict_
+
+        Format the results in a dict keyed by the state name
+        """
+        formattedResults = DBFormatter.formatDict(self, results)
+
+        dictResult = {}
+        for formattedResult in formattedResults:
+            dictResult[formattedResult['sched_status']] = int(formattedResult['count'])
+
+        return dictResult
+
+    def execute(self, active=True, conn=None, transaction=False):
+        if active:
+            binds = {'status': 1}
+        else:
+            binds = {'status': 0}
+
+        result = self.dbi.processData(self.sql, binds, conn=conn, transaction=transaction)
+
+        return self.formatDict(result)

--- a/src/python/WMCore/WMBS/MySQL/Monitoring/RunJobByStatus.py
+++ b/src/python/WMCore/WMBS/MySQL/Monitoring/RunJobByStatus.py
@@ -3,7 +3,7 @@ _RunJobByStatus_
 
 Monitoring DAO classes for Jobs in BossAir database
 """
-
+from __future__ import print_function, division
 
 from WMCore.Database.DBFormatter import DBFormatter
 

--- a/src/python/WMCore/WMBS/Oracle/Locations/GetJobSlotsByCMSName.py
+++ b/src/python/WMCore/WMBS/Oracle/Locations/GetJobSlotsByCMSName.py
@@ -9,6 +9,4 @@ from WMCore.WMBS.MySQL.Locations.GetJobSlotsByCMSName \
     import GetJobSlotsByCMSName as MySQLGetJobSlotsByCMSName
 
 class GetJobSlotsByCMSName(MySQLGetJobSlotsByCMSName):
-    """
-    Identical to MySQL version
-    """
+    pass

--- a/src/python/WMCore/WMBS/Oracle/Monitoring/JobTypeCountByState.py
+++ b/src/python/WMCore/WMBS/Oracle/Monitoring/JobTypeCountByState.py
@@ -3,6 +3,7 @@ _JobTypeCountByState_
 
 Oracle implementation of Monitoring.JobTypeCountByState
 """
+from __future__ import print_function, division
 
 from WMCore.WMBS.MySQL.Monitoring.JobTypeCountByState import JobTypeCountByState as MySQLJobTypeCountByState
 

--- a/src/python/WMCore/WMBS/Oracle/Monitoring/JobTypeCountByState.py
+++ b/src/python/WMCore/WMBS/Oracle/Monitoring/JobTypeCountByState.py
@@ -1,0 +1,10 @@
+"""
+_JobTypeCountByState_
+
+Oracle implementation of Monitoring.JobTypeCountByState
+"""
+
+from WMCore.WMBS.MySQL.Monitoring.JobTypeCountByState import JobTypeCountByState as MySQLJobTypeCountByState
+
+class ListByStateAndLocation(MySQLJobTypeCountByState):
+    pass

--- a/src/python/WMCore/WMBS/Oracle/Monitoring/RunJobByStatus.py
+++ b/src/python/WMCore/WMBS/Oracle/Monitoring/RunJobByStatus.py
@@ -1,0 +1,10 @@
+"""
+_RunJobByStatus_
+
+Oracle implementation of Monitoring.RunJobByStatus
+"""
+
+from WMCore.WMBS.MySQL.Monitoring.RunJobByStatus import RunJobByStatus as MySQLRunJobByStatus
+
+class RunJobByStatus(MySQLRunJobByStatus):
+    pass

--- a/src/python/WMCore/WMBS/Oracle/Monitoring/RunJobByStatus.py
+++ b/src/python/WMCore/WMBS/Oracle/Monitoring/RunJobByStatus.py
@@ -3,6 +3,7 @@ _RunJobByStatus_
 
 Oracle implementation of Monitoring.RunJobByStatus
 """
+from __future__ import print_function, division
 
 from WMCore.WMBS.MySQL.Monitoring.RunJobByStatus import RunJobByStatus as MySQLRunJobByStatus
 

--- a/test/python/WMCore_t/Database_t/CMSCouch_t.py
+++ b/test/python/WMCore_t/Database_t/CMSCouch_t.py
@@ -38,10 +38,10 @@ class CMSCouchTest(unittest.TestCase):
     def testCommitOne(self):
         # Can I commit one dict
         doc = {'foo':123, 'bar':456}
-        id = self.db.commitOne(doc, returndocs=True)[0]['id']
+        id = self.db.commitOne(doc)[0]['id']
         # What about a Document
         doc = Document(inputDict = doc)
-        id = self.db.commitOne(doc, returndocs=True)[0]['id']
+        id = self.db.commitOne(doc)[0]['id']
 
     def testCommitOneWithQueue(self):
         """
@@ -54,14 +54,14 @@ class CMSCouchTest(unittest.TestCase):
             self.db.queue(doc)
         # Commit one Document
         doc = Document(inputDict = doc)
-        id = self.db.commitOne(doc, returndocs=True)[0]['id']
+        id = self.db.commitOne(doc)[0]['id']
         self.assertEqual(1, len(self.db.allDocs()['rows']))
         self.db.commit()
         self.assertEqual(6, len(self.db.allDocs()['rows']))
 
     def testTimeStamping(self):
         doc = {'foo':123, 'bar':456}
-        id = self.db.commitOne(doc, timestamp=True, returndocs=True)[0]['id']
+        id = self.db.commitOne(doc, timestamp=True)[0]['id']
         doc = self.db.document(id)
         self.assertTrue('timestamp' in doc.keys())
 
@@ -104,7 +104,7 @@ class CMSCouchTest(unittest.TestCase):
     def testReplicate(self):
         repl_db = self.server.connectDatabase(self.db.name + 'repl')
 
-        doc_id = self.db.commitOne({'foo':123}, timestamp=True, returndocs=True)[0]['id']
+        doc_id = self.db.commitOne({'foo':123}, timestamp=True)[0]['id']
         doc_v1 = self.db.document(doc_id)
 
         #replicate
@@ -165,7 +165,7 @@ class CMSCouchTest(unittest.TestCase):
         """
         Test uploading attachments with and without checksumming
         """
-        doc = self.db.commitOne({'foo':'bar'}, timestamp=True, returndocs=True)[0]
+        doc = self.db.commitOne({'foo':'bar'}, timestamp=True)[0]
         attachment1 = "Hello"
         attachment2 = "How are you today?"
         attachment3 = "I'm very well, thanks for asking"
@@ -202,7 +202,7 @@ class CMSCouchTest(unittest.TestCase):
         self.db = self.server.connectDatabase(self.db.name)
         repl_db = self.server.connectDatabase(self.db.name + 'repl')
 
-        doc_id = self.db.commitOne({'foo':123}, timestamp=True, returndocs=True)[0]['id']
+        doc_id = self.db.commitOne({'foo':123}, timestamp=True)[0]['id']
         doc_v1 = self.db.document(doc_id)
 
         #replicate
@@ -210,7 +210,7 @@ class CMSCouchTest(unittest.TestCase):
 
         doc_v2 = self.db.document(doc_id)
         doc_v2['bar'] = 456
-        doc_id_rev2 = self.db.commitOne(doc_v2, returndocs=True)[0]
+        doc_id_rev2 = self.db.commitOne(doc_v2)[0]
         doc_v2 = self.db.document(doc_id)
 
         #now update the replica
@@ -238,7 +238,7 @@ class CMSCouchTest(unittest.TestCase):
         #update it again
         doc_v3 = self.db.document(doc_id)
         doc_v3['baz'] = 789
-        doc_id_rev3 = self.db.commitOne(doc_v3, returndocs=True)[0]
+        doc_id_rev3 = self.db.commitOne(doc_v3)[0]
         doc_v3 = self.db.document(doc_id)
 
         #test that I can pull out an old revision


### PR DESCRIPTION
Seangchan, as we discussed in the meeting. These are the changes I've been working on for the agent monitoring, it also fixes an issue with the replication code that I don't remember anymore :-D

This patch, as it is, is going to run the "deep agent monitoring" every 3 cycles of the AgentStatusPoller (which runs every 5min). Right now it dumps this information into a json file every 15min (completely overwrites the previous data) AND prints those info in the log file (better if we need to debug something, while we don't have a time series of the json data). In case you want to have a look at the logs, check vocms0231 out.

In summary, these are the points monitored so far (from the wiki):
- number of jobs in WMBS in each state.
- number of jobs in WMBS in 'created' status, sorted by job type
- number of jobs in WMBS in 'executing' status, sorted by job type (should be equal to the numbers of jobs in condor)
- BONUS: would be sorting by job priority and site as well
- thesholds for data acquisition from GQ to LQ
- thresholds for job submission (WMBS to condor global pool) (general site thresholds only)
- total running and pending thresholds for each site in Drain or Normal status (and their status)

Things to be done in a very short future:
- thresholds for job creation (LQ to WMBS)
- and perhaps tasks thresholds per site

@ticoann can you review it please? I ran a bunch of tests and some more running today in vocms0231, everything looks good so far
@stiegerb FYI
