### PR TITLE
Make sure file:// is added before source/dest pfn in gfal2 plugin

### DIFF
--- a/src/python/WMCore/Storage/Backends/GFAL2Impl.py
+++ b/src/python/WMCore/Storage/Backends/GFAL2Impl.py
@@ -31,17 +31,35 @@ class GFAL2Impl(StageOutImpl):
         self.removeCommand = self.setups % '. $JOBSTARTDIR/startup_environment.sh; printenv; date; gfal-rm -vvv -t 600 %s '
         self.copyCommand = self.setups % '. $JOBSTARTDIR/startup_environment.sh; printenv; date; gfal-copy -vvv -t 2400 -T 2400 -p %(checksum)s %(options)s %(source)s %(destination)s'
 
-    def createSourceName(self, protocol, pfn):
+
+    def createFinalPFN(self, pfn):
         """
-        _createSourceName_
-        GFAL2 uses file:/// urls
+        _createFinalPFN_
+        GFAL2 requires file:/// for any direction transfers
         """
         if pfn.startswith('file:'):
             return pfn
         elif os.path.isfile(pfn):
             return "file://%s" % os.path.abspath(pfn)
-        else:
-            return pfn
+        elif pfn.startswith('/'):
+            return "file://%s" % os.path.abspath(pfn)
+        return pfn
+
+
+    def createSourceName(self, protocol, pfn):
+        """
+        _createSourceName_
+        GFAL2 uses file:/// urls
+        """
+        return self.createFinalPFN(pfn)
+
+
+    def createTargetName(self, protocol, pfn):
+        """
+        _createTargetName_
+        GFAL2 uses file:// urls
+        """
+        return self.createFinalPFN(pfn)
 
 
     def createOutputDirectory(self, targetPFN):
@@ -63,12 +81,10 @@ class GFAL2Impl(StageOutImpl):
           -t   global timeout for the execution of the command.
                Command is interrupted if time expires before it finishes
         """
-        if pfn.startswith("file:"):
-            return self.removeCommand % pfn
-        elif os.path.isfile(pfn):
+        if os.path.isfile(pfn):
             return "/bin/rm -f %s" % os.path.abspath(pfn)
         else:
-            return self.removeCommand % pfn
+            return self.removeCommand % self.createFinalPFN(pfn)
 
 
     def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
@@ -99,8 +115,8 @@ class GFAL2Impl(StageOutImpl):
 
         copyCommandDict['options'] = ' '.join(unknown)
 
-        copyCommandDict['source'] = sourcePFN
-        copyCommandDict['destination'] = targetPFN
+        copyCommandDict['source'] = self.createFinalPFN(sourcePFN)
+        copyCommandDict['destination'] = self.createFinalPFN(targetPFN)
 
         copyCommand = self.copyCommand % copyCommandDict
         result += copyCommand
@@ -129,10 +145,8 @@ class GFAL2Impl(StageOutImpl):
         command = ""
         if os.path.isfile(pfnToRemove):
             command = "/bin/rm -f %s" % os.path.abspath(pfnToRemove)
-        if pfnToRemove.startswith("file:"):
-            command = self.removeCommand % pfnToRemove
         else:
-            command = self.removeCommand % pfnToRemove
+            command = self.removeCommand % self.createFinalPFN(pfnToRemove)
         self.executeCommand(command)
 
 


### PR DESCRIPTION
Created a new function createFinalPFN, which will take care of preparing pfn and appending file:// if needed 
a) Also added a check if pfn starts with '/' and in that case append file:// any function createStageOutCommand or createRemoveCommand or removeFile uses new function for preparing pfn. 
In any case if WMA or CRAB or whatever would call this Stageout plugin without correct pfns, it enforces pfn modification by calling createFinalPFN function.
Some details here: https://github.com/dmwm/WMCore/pull/6980
