### PR TITLE
Send multiple job report to dashboard with the same object

### DIFF
--- a/src/python/WMCore/Services/Dashboard/DashboardReporter.py
+++ b/src/python/WMCore/Services/Dashboard/DashboardReporter.py
@@ -10,7 +10,19 @@ import logging
 from WMCore import __version__
 from WMCore.WMException                     import WMException
 from WMCore.DataStructs.WMObject import WMObject
-from WMCore.Services.Dashboard.DashboardAPI import apmonSend, apmonFree, DEFAULT_PARAMS
+from WMCore.Services.Dashboard.DashboardAPI import DashboardAPI
+
+
+# xdrlib cannot handle unicode strings
+def unicodeToStr(value):
+    if not isinstance(value, basestring):
+        return 'unknown'
+    try:
+        return str(value)
+    except UnicodeEncodeError:
+        #This contains some unicode outside ascii range
+        return 'unknown'
+
 
 class DashboardReporterException(WMException):
     """
@@ -35,18 +47,17 @@ class DashboardReporter(WMObject):
         #Have to default this to the local host otherwise a lot of unit tests
         #die
         if hasattr(config, 'DashboardReporter'):
-            self.destHost = getattr(self.config.DashboardReporter, 'dashboardHost',
-                               '127.0.0.1')
-            self.destPort = getattr(self.config.DashboardReporter, 'dashboardPort',
-                               8884)
+            self.destHost = getattr(self.config.DashboardReporter, 'dashboardHost', '127.0.0.1')
+            self.destPort = getattr(self.config.DashboardReporter, 'dashboardPort', 8884)
         else:
             self.destHost = '127.0.0.1'
             self.destPort = 8884
 
-        self.serverreport = {str(self.destHost + ':' + str(self.destPort)) : DEFAULT_PARAMS}
-
         self.taskPrefix = 'wmagent_'
         self.tsFormat = '%Y-%m-%d %H:%M:%S'
+
+        self.dashboardUrl = '%s:%s' % (self.destHost, str(self.destPort))
+        self.dashboard = DashboardAPI(logr=logging, server=self.dashboardUrl)
 
     def handleCreated(self, jobs):
         """
@@ -67,38 +78,22 @@ class DashboardReporter(WMObject):
         to the description of the addTask method
         """
         logging.info ("Handling %d created jobs" % len(jobs))
-        logging.debug ("Handling created jobs: %s" % jobs)
 
+        jobParams = []
         for job in jobs:
             logging.debug("Sending info for job %s" % str(job))
 
+            jobid = '%s_%i' % (job['name'], job['retry_count'])
             package = {}
-            package['MessageType']      = 'JobMeta'
-            package['taskId']           = self.taskPrefix + \
-                                               job['workflow']
-            package['jobId']            = '%s_%i' % (job['name'],
-                                                    job['retry_count'])
-            package['TaskType']         = job['taskType']
-            package['JobType']          = job['jobType']
-            package['NEventsToProcess'] = job.get('nEventsToProc',
-                                                    'NotAvailable')
+            package['MessageType'] = 'JobMeta'
+            package['jobId'] = unicodeToStr(jobid)
+            package['taskId'] = unicodeToStr(self.taskPrefix + job['workflow'])
+            package['TaskType'] = job['taskType']
+            package['JobType'] = job['jobType']
+            package['NEventsToProcess'] = job.get('nEventsToProc', 'NotAvailable')
+            jobParams.append(package)
 
-            logging.debug("Sending: %s" % str(package))
-            result = apmonSend(taskid = package['taskId'],
-                               jobid = package['jobId'],
-                               params = package,
-                               logr = logging,
-                               apmonServer = self.serverreport)
-            if result != 0:
-                msg = "Error %i sending info for submitted job %s via UDP\n" \
-                      % (result, job['name'])
-                msg += "Ignoring"
-                logging.error(msg)
-                logging.debug("Package sent: %s\n" % package)
-                logging.debug("Host info: host %s, port %s" \
-                              % (self.destHost,
-                                 self.destPort))
-            apmonFree()
+        self.dashboard.apMonSend(jobParams)
 
         return
 
@@ -119,111 +114,83 @@ class DashboardReporter(WMObject):
             *fwjr -> Post processing step information
         """
         logging.info("Handling %d jobs" % len(jobs))
-        logging.debug("Handling jobs: %s" % jobs)
 
+        jobParams = []
         for job in jobs:
             logging.debug("Sending info for job %s" % str(job))
 
+            jobid = '%s_%i' % (job['name'], job['retry_count'])
             package = {}
-            package['MessageType']       = 'JobStatus'
-            package['jobId']             = '%s_%i' % (job['name'],
-                                                    job['retry_count'])
-            package['taskId']            = self.taskPrefix + job['workflow']
-            package['StatusValue']       = statusValue
+            package['MessageType'] = 'JobStatus'
+            package['jobId'] = unicodeToStr(jobid)
+            package['taskId'] = unicodeToStr(self.taskPrefix + job['workflow'])
+            package['StatusValue'] = statusValue
             package['StatusValueReason'] = statusMessage
-            package['StatusEnterTime']   = time.strftime(self.tsFormat,
-                                        time.gmtime())
-            package['StatusDestination'] = job.get('location',
-                                                   'NotAvailable')
-
+            package['StatusEnterTime'] = time.strftime(self.tsFormat, time.gmtime())
+            package['StatusDestination'] = job.get('location', 'NotAvailable')
             if job.get('plugin', None):
-                package['scheduler']     = job['plugin'][:-6]
+                package['scheduler'] = job['plugin'][:-6]
+            jobParams.append(package)
 
-            logging.debug("Sending: %s" % str(package))
-            result = apmonSend(taskid = package['taskId'],
-                               jobid = package['jobId'],
-                               params = package,
-                               logr = logging,
-                               apmonServer = self.serverreport)
+        self.dashboard.apMonSend(jobParams)
 
-            if result != 0:
-                msg =  "Error %i sending info for submitted job %s via UDP\n" \
-                        % (result, job['name'])
-                msg += "Ignoring"
-                logging.error(msg)
-                logging.debug("Package sent: %s\n" % package)
-                logging.debug("Host info: host %s, port %s" \
-                              % (self.destHost,
-                                 self.destPort))
-            apmonFree()
-
-            if 'fwjr' in job:
-                self.handleSteps(job)
+        # send step information, if available
+        self.handleSteps(jobs)
 
         return
 
-    def handleSteps(self, job):
+    def handleSteps(self, jobs):
         """
         _handleSteps_
 
         Handle the post-processing step information
         """
-        if job['fwjr'] == None:
-            return
+        jobParams = []
+        for job in jobs:
+            if job['fwjr'] is None:
+                return
 
-        steps = job['fwjr'].listSteps()
-        for stepName in steps:
-            step = job['fwjr'].retrieveStep(stepName)
-            if not hasattr(step, 'counter'):
-                continue
+            steps = job['fwjr'].listSteps()
+            for stepName in steps:
+                step = job['fwjr'].retrieveStep(stepName)
+                if not hasattr(step, 'counter'):
+                    continue
 
-            counter = step.counter
+                counter = step.counter
 
-            package = {}
+                package = {}
+                package.update(self.getPerformanceInformation(step))
+                package.update(self.getEventInformation(stepName, job['fwjr']))
 
-            package.update(self.getPerformanceInformation(step))
-            package.update(self.getEventInformation(stepName, job['fwjr']))
+                # Input files should just be appended onto inputFiles instead of given a step #
+                # per https://hypernews.cern.ch/HyperNews/CMS/get/comp-monitoring/326.html
+                inputFilePackage = self.getInputFilesInformation(step)
+                if inputFilePackage:
+                    if 'inputFiles' in package:
+                        package['inputFiles'] += ';' +  inputFilePackage['inputFiles']
+                    else:
+                        package.update(self.getInputFilesInformation(step))
 
-            # Input files should just be appended onto inputFiles instead of given a step #
-            # per https://hypernews.cern.ch/HyperNews/CMS/get/comp-monitoring/326.html
-            inputFilePackage = self.getInputFilesInformation(step)
-            if inputFilePackage:
-                if 'inputFiles' in package:
-                    package['inputFiles'] += ';' +  inputFilePackage['inputFiles']
-                else:
-                    package.update(self.getInputFilesInformation(step))
+                trimmedPackage = {}
+                for key in package:
+                    if key in ['inputFiles', 'Basename', 'inputBlocks']:
+                        trimmedPackage[key] = package[key]
+                    elif package[key] is not None:
+                        trimmedPackage['%d_%s' % (counter, key)] = package[key]
+                package = trimmedPackage
 
-            trimmedPackage = {}
-            for key in package:
-                if key in ['inputFiles', 'Basename', 'inputBlocks']:
-                    trimmedPackage[key] = package[key]
-                elif package[key] != None:
-                    trimmedPackage['%d_%s' % (counter, key)] = package[key]
-            package = trimmedPackage
+                if not package:
+                    continue
 
-            if not package:
-                continue
+                jobid = '%s_%i' % (job['name'], job['retry_count'])
+                package['jobId'] = unicodeToStr(jobid)
+                package['taskId'] = unicodeToStr(self.taskPrefix + job['workflow'])
+                package['%d_stepName' % counter] = stepName
 
-            package['jobId']    = '%s_%i' % (job['name'], job['retry_count'])
-            package['taskId']   = self.taskPrefix + job['workflow']
-            package['%d_stepName' % counter] = stepName
+                logging.debug("Sending step info: %s" % str(package))
+                jobParams.append(package)
 
-
-            logging.debug("Sending step info: %s" % str(package))
-            result = apmonSend(taskid = package['taskId'],
-                               jobid = package['jobId'], params = package,
-                               logr = logging, apmonServer = self.serverreport)
-
-            if result != 0:
-                msg =  "Error %i sending info for completed job %s via UDP\n" \
-                        % (result, job['name'])
-                msg += "Ignoring"
-                logging.error(msg)
-                logging.debug("Package sent: %s\n" % package)
-                logging.debug("Host info: host %s, port %s" \
-                              % (self.destHost,
-                                 self.destPort))
-            apmonFree()
+            self.dashboard.apMonSend(package)
 
         return
 
@@ -430,17 +397,4 @@ class DashboardReporter(WMObject):
 
         logging.info("Sending %s info" % taskName)
         logging.debug("Sending task info: %s" % str(package))
-        result = apmonSend(taskid = package['TaskName'],
-                           jobid = package['JobName'], params = package,
-                           logr = logging, apmonServer = self.serverreport)
-
-        if result != 0:
-            msg =  "Error %i sending info for new task %s via UDP\n" % (result,
-                                                                        taskName)
-            msg += "Ignoring"
-            logging.error(msg)
-            logging.debug("Package sent: %s\n" % package)
-            logging.debug("Host info: host %s, port %s" \
-                          % (self.destHost,
-                             self.destPort))
-        apmonFree()
+        self.dashboard.apMonSend(package)

--- a/src/python/WMCore/Services/Dashboard/apmon.py
+++ b/src/python/WMCore/Services/Dashboard/apmon.py
@@ -289,10 +289,14 @@ class ApMon(object):
             if clusterName is None or clusterName == "":
                 clusterName = self.__defaultUserCluster
             else:
+                if isinstance(clusterName, int):
+                    clusterName = str(clusterName)
                 self.__defaultUserCluster = clusterName
             if nodeName is None:
                 nodeName = self.__defaultUserNode
             else:
+                if isinstance(nodeName, int):
+                    nodeName = str(nodeName)
                 self.__defaultUserNode = nodeName
             if len(self.destinations) == 0:
                 self.logger.log(Logger.WARNING, "Not sending parameters since no destination is defined.")
@@ -457,9 +461,15 @@ class ApMon(object):
 
     def initializedOK(self):
         """
-        Retruns true if there is no destination where the parameters to be sent.
+        Returns true if there are destination(s) configured.
         """
         return len(self.destinations) > 0
+
+    def freedOK(self):
+        """
+        Returns true if all ApMon resources were properly freed.
+        """
+        return self.__freed
 
     def setLogLevel(self, strLevel):
         """

--- a/src/python/WMCore/WMRuntime/DashboardInterface.py
+++ b/src/python/WMCore/WMRuntime/DashboardInterface.py
@@ -166,7 +166,7 @@ class DashboardInfo():
         #Dashboard server interface info
         self.publisher    = None
         self.destinations = {}
-        self.server       = None
+        self.server       = dashboardUrl
 
         #Job ids
         self.taskName = unicodeToStr('wmagent_%s' % self.workload.name())
@@ -186,10 +186,6 @@ class DashboardInfo():
 
         #Utility
         self.tsFormat = '%Y-%m-%d %H:%M:%S'
-
-        # API to talk to apmon
-        self.dashboard = DashboardAPI(server=dashboardUrl)
-        self.server = self.dashboard.server
 
         return
 
@@ -412,6 +408,8 @@ class DashboardInfo():
         instance.
         """
         logging.info("About to send UDP package to dashboard: %s" % data)
-        logging.info("Using address %s" % self.server)
-        self.dashboard.apMonSend(data)
+        with DashboardAPI(server=self.server) as dashboard:
+            logging.info("Using address %s" % dashboard.server)
+            dashboard.apMonSend(data)
+
         return

--- a/src/python/WMCore/WMRuntime/DashboardInterface.py
+++ b/src/python/WMCore/WMRuntime/DashboardInterface.py
@@ -11,8 +11,8 @@ import re
 
 from WMCore.WMSpec.WMStep     import WMStepHelper
 from WMCore.WMSpec.WMWorkload import getWorkloadFromTask
-from WMCore.WMRuntime.Tools.Plugins.ApMonLite.ApMonDestMgr import ApMonDestMgr
-from WMCore.Services.Dashboard.DashboardAPI import apmonSend, apmonFree
+from WMCore.Services.Dashboard.DashboardAPI import DashboardAPI
+from WMCore.Services.Dashboard.DashboardReporter import unicodeToStr
 from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig, SiteConfigError
 
 def getSyncCE(default = socket.gethostname()):
@@ -152,7 +152,7 @@ class DashboardInfo():
 
     """
 
-    def __init__(self, task, job):
+    def __init__(self, task, job, dashboardUrl=None):
         """
         Init some stuff
 
@@ -169,8 +169,8 @@ class DashboardInfo():
         self.server       = None
 
         #Job ids
-        self.taskName = 'wmagent_%s' % self.workload.name()
-        self.jobName  = '%s_%i' % (job['name'], job['retry_count'])
+        self.taskName = unicodeToStr('wmagent_%s' % self.workload.name())
+        self.jobName  = unicodeToStr('%s_%i' % (job['name'], job['retry_count']))
 
         #Step counter
         self.stepCount = 0
@@ -186,6 +186,10 @@ class DashboardInfo():
 
         #Utility
         self.tsFormat = '%Y-%m-%d %H:%M:%S'
+
+        # API to talk to apmon
+        self.dashboard = DashboardAPI(server=dashboardUrl)
+        self.server = self.dashboard.server
 
         return
 
@@ -399,56 +403,15 @@ class DashboardInfo():
 
         return
 
-    def addDestination(self, host, port):
-        """
-        _addDestination_
-
-        Add a publishing destination to the Publisher
-        """
-
-        if self.publisher == None:
-            self._InitPublisher()
-        self.destinations[host] = port
-        self.publisher.newDestination(host, port)
-        self.server = ['%s:%s' % (host, port)]
-
-    def publish(self, data, redundancy = 1):
+    def publish(self, data):
         """
         _publish_
 
         Publish information in this object to the Dashboard
         using the ApMon interface and the destinations stored in this
         instance.
-
-        redunancy is the amount to times to publish this information
-
         """
-
         logging.info("About to send UDP package to dashboard: %s" % data)
         logging.info("Using address %s" % self.server)
-        apmonSend(taskid = self.taskName, jobid = self.jobName, params = data,
-                  logr = logging, apmonServer = self.server)
-        apmonFree()
-        return
-
-    def _InitPublisher(self):
-        """
-        _InitPublisher_
-
-        *private*
-
-        Initialise the ApMonDestMgr instance, verifying that the task and
-        job attributes are set
-
-        """
-        if self.taskName == None:
-            msg = "Error: You must set the task id before adding \n"
-            msg += "destinations or publishing data"
-            raise RuntimeError(msg)
-        if self.jobName == None:
-            msg = "Error: You must set the job id before adding \n"
-            msg += "destinations or publishing data"
-            raise RuntimeError(msg)
-        self.publisher = ApMonDestMgr(clusterName = self.taskName,
-                                      nodeName = self.jobName)
+        self.dashboard.apMonSend(data)
         return

--- a/src/python/WMCore/WMRuntime/Monitors/DashboardMonitor.py
+++ b/src/python/WMCore/WMRuntime/Monitors/DashboardMonitor.py
@@ -76,14 +76,9 @@ class DashboardMonitor(WMRuntimeMonitor):
 
         destHost = args.get('destinationHost', None)
         destPort = args.get('destinationPort', None)
+        dashboardUrl = '%s:%s' % (destHost, str(destPort))
 
-        self.dashboardInfo = DashboardInfo(task = task, job = job)
-
-        if destHost and destPort:
-            logging.info("About to set destination to %s:%s" % (destHost, destPort))
-            self.dashboardInfo.addDestination(host = destHost,
-                                              port = destPort)
-
+        self.dashboardInfo = DashboardInfo(task=task, job=job, dashboardUrl=dashboardUrl)
 
     def jobStart(self, task):
         """

--- a/test/python/WMCore_t/Services_t/Dashboard_t/DashboardAPI_t.py
+++ b/test/python/WMCore_t/Services_t/Dashboard_t/DashboardAPI_t.py
@@ -16,10 +16,8 @@ import time
 
 from WMCore.WMBase import getTestBase
 from WMCore.Services.Dashboard.Logger import Logger
-from WMCore.Services.Dashboard.DashboardAPI import DashboardAPI
-from WMCore.Services.Dashboard.DashboardAPI import apmonFree, apmonSend, parseAd
-from WMCore.Services.Dashboard.DashboardAPI import APMONINSTANCE, APMONINIT, APMONCONF
-from WMCore.Services.Dashboard.DashboardAPI import reportFailureToDashboard, logger, getApmonInstance
+from WMCore.Services.Dashboard.DashboardAPI import DashboardAPI, parseAd, \
+    reportFailureToDashboard, logger
 
 
 class DashboardAPITest(unittest.TestCase):
@@ -34,22 +32,23 @@ class DashboardAPITest(unittest.TestCase):
 
         Just test initialization of apmon Instance
         """
-        print("Apmon Configuration %s" % APMONCONF)
-        apmon = getApmonInstance(apmonServer=APMONCONF)
-        self.assertTrue(apmon.initializedOK())
+        dashboard = DashboardAPI()
+        apmonInst = dashboard.getApMonInstance()
+        self.assertTrue(apmonInst.initializedOK())
         # Free up apmon instance and check if it was successfull
-        apmonFree()
-        self.assertFalse(APMONINIT)
-        self.assertEqual(None, APMONINSTANCE)
+        apmonInst.free()
+        self.assertEqual(None, apmonInst)
 
     def testApmonSend(self):
         """
         _testApmonSend_
 
-        Just test simple apmonSend with fake data
+        We cannot really test any results, but let's just send some data
         """
-        # We just sent fake data which is not monitored by dashboard.
-        self.assertEqual(0, apmonSend("TaskID", "Job1", {"CPUUsage": 100, "MemUsage": 1}))
+        package = {'jobId': 'abcd-1234_0', 'MessageType': 'JobStatus',
+                   'taskId': 'wmagent_alan', 'StatusValue': 'submitted'}
+        dashboard = DashboardAPI()
+        dashboard.apMonSend(package)
 
     def testLogger(self):
         """

--- a/test/python/WMCore_t/WMRuntime_t/DashboardInterface_t.py
+++ b/test/python/WMCore_t/WMRuntime_t/DashboardInterface_t.py
@@ -133,8 +133,7 @@ class DashboardInterfaceTest(unittest.TestCase):
         self.setupJobEnvironment(name = name)
 
         # Instantiate DBInfo
-        dbInfo   = DashboardInfo(job = job, task = task)
-        dbInfo.addDestination('127.0.0.1', 8884)
+        dbInfo   = DashboardInfo(job=job, task=task, dashboardUrl='127.0.0.1:8884')
 
         # Check jobStart information
         data = dbInfo.jobStart()
@@ -205,8 +204,7 @@ class DashboardInterfaceTest(unittest.TestCase):
         self.setupJobEnvironment(name = name)
 
         # Instantiate DBInfo
-        dbInfo   = DashboardInfo(job = job, task = task)
-        dbInfo.addDestination('127.0.0.1', 8884)
+        dbInfo   = DashboardInfo(job=job, task=task, dashboardUrl='127.0.0.1:8884')
 
         # Modify the first step
         step = task.getStep(stepName = "cmsRun1")
@@ -254,8 +252,7 @@ class DashboardInterfaceTest(unittest.TestCase):
         self.setupJobEnvironment(name = name)
 
         # Instantiate DBInfo
-        dbInfo   = DashboardInfo(job = job, task = task)
-        dbInfo.addDestination('127.0.0.1', 8884)
+        dbInfo   = DashboardInfo(job=job, task=task, dashboardUrl='127.0.0.1:8884')
 
         # Check jobStart information
         data = dbInfo.jobStart()
@@ -310,8 +307,7 @@ class DashboardInterfaceTest(unittest.TestCase):
         self.setupJobEnvironment(name = name)
 
         # Instantiate DBInfo
-        dbInfo   = DashboardInfo(job = job, task = task)
-        dbInfo.addDestination('127.0.0.1', 8884)
+        dbInfo   = DashboardInfo(job=job, task=task, dashboardUrl='127.0.0.1:8884')
 
         # Check jobStart information
         data = dbInfo.jobStart()


### PR DESCRIPTION
I found out some agents spending several minutes to send information to dashboard. One of them was actually even failing to resolve the name into an ip address from time to time (since we get a new instance for each report).

This patch solves that problem by passing a list of jobs to report to the same method that retrieves the apmon instance. I also tried to get rid of some of those standalone functions and make it all in the `DashboardAPI`  class (so I had to update the WMRuntime report as well).

I still want to a) make it report a group of jobs in `handleSteps` instead of one by one, b) run a larger test to make sure it behaves Ok and c) test the ReqMgr report

@ticoann @ericvaandering please review
@mmascher @juztas @emaszs I noticed there is a 'copy' of the apmon code in the CRABServer repo. Is CRAB completing relying on the WMCore code for the dashboard report. There are several different functions/reports here that I don't really know if they are used at all (certainly not by WMAgent)
