### PR TITLE
Store site lists in the proper list format

### DIFF
--- a/src/python/WMCore/WMSpec/WMWorkloadTools.py
+++ b/src/python/WMCore/WMSpec/WMWorkloadTools.py
@@ -217,6 +217,9 @@ def validateSiteLists(arguments):
     if len(res):
         msg = "Validation failed: The same site cannot be white and blacklisted: %s" % list(res)
         raise WMSpecFactoryException(msg)
+    # store the properly formatted values (list instead of string)
+    arguments["SiteWhitelist"] = whiteList
+    arguments["SiteBlacklist"] = blackList
     return
 
 


### PR DESCRIPTION
It seems ReqMgr2 accepts (and stores) site lists in a string format (as provided), which then cause issues later on while casting it to a list. Elog:
https://cms-logbook.cern.ch/elog/Workflow+processing/25185

```
>>> a = "T1_DE_KIT"
>>> for site in a:
...   site
... 
'T'
'1'
'_'
'D'
'E'
'_'
'K'
'I'
'T'
>>> 
```

@ticoann please review. I just injected a test workflow and it was properly cast to a list in the workload doc
I'll make sure Andrew L. has this fix on his assignment script until we get it into production
