### PR TITLE
handle block deletion for blocks without any replica

### DIFF
--- a/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
+++ b/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
@@ -479,20 +479,21 @@ class PhEDExInjectorPoller(BaseWorkerThread):
                 except:
                     logging.error("Couldn't get block info from PhEDEx, retry next cycle")
                 else:
+                    nodes = set()
                     for entry in blockInfo:
                         if entry['name'] == blockName:
                             nodes = set([x['node'] for x in entry['replica']])
-                            if location not in nodes:
-                                logging.debug("Block %s not present on %s, mark as deleted", blockName, location)
-                                binds = {'DELETED': 1, 'BLOCKNAME': blockName}
-                                self.markBlocksDeleted.execute(binds)
-                            elif sites.issubset(nodes):
-                                logging.debug("Deleting block %s from %s since it is fully transfered", blockName, location)
-                                if location not in deletableEntries:
-                                    deletableEntries[location] = {}
-                                if dataset not in deletableEntries[location]:
-                                    deletableEntries[location][dataset] = set()
-                                    deletableEntries[location][dataset].add(blockName)
+                    if location not in nodes:
+                        logging.debug("Block %s not present on %s, mark as deleted", blockName, location)
+                        binds = {'DELETED': 1, 'BLOCKNAME': blockName}
+                        self.markBlocksDeleted.execute(binds)
+                    elif sites.issubset(nodes):
+                        logging.debug("Deleting block %s from %s since it is fully transfered", blockName, location)
+                        if location not in deletableEntries:
+                            deletableEntries[location] = {}
+                            if dataset not in deletableEntries[location]:
+                                deletableEntries[location][dataset] = set()
+                                deletableEntries[location][dataset].add(blockName)
 
         binds = []
         for blockName in skippableBlocks:


### PR DESCRIPTION
Make sure that blocks without any replica are correctly processed (they should be marked deleted too).

@ticoann , this is deployed in the prod Tier0 and working and only affects the Tier0, so should get merged (after the jenkins check). I really would like to have this in the pre5 tag as well.
