### PR TITLE
Get proper data location for StoreResults requests

### DIFF
--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -624,9 +624,12 @@ class DBS3Reader:
 
         return locations
 
-    def getFileBlock(self, fileBlockName):
+    def getFileBlock(self, fileBlockName, dbsOnly=False):
         """
         _getFileBlock_
+
+        dbsOnly flag is mostly meant for StoreResults, since there is no
+        data in TMDB.
 
         return a dictionary:
         { blockName: {
@@ -644,8 +647,8 @@ class DBS3Reader:
             msg = "DBSReader.getFileBlock(%s): No matching data"
             raise DBSReaderError(msg % fileBlockName)
 
-        result = { fileBlockName: {
-            "PhEDExNodeNames" : self.listFileBlockLocation(fileBlockName),
+        result = {fileBlockName: {
+            "PhEDExNodeNames": self.listFileBlockLocation(fileBlockName, dbsOnly),
             "Files" : self.listFilesInBlock(fileBlockName),
             "IsOpen" : self.blockIsOpen(fileBlockName)
                                  }

--- a/src/python/WMCore/WorkQueue/DataLocationMapper.py
+++ b/src/python/WMCore/WorkQueue/DataLocationMapper.py
@@ -155,8 +155,7 @@ class DataLocationMapper(object):
                     phedexNodeNames = dbs.listDatasetLocation(dataItem, dbsOnly=True)
                 else:
                     phedexNodeNames = dbs.listFileBlockLocation(dataItem, dbsOnly=True)
-                for pnn in phedexNodeNames:
-                    result[dataItem].update(pnn)
+                result[dataItem].update(phedexNodeNames)
             except Exception as ex:
                 logging.error('Error getting block location from dbs for %s: %s' % (dataItem, str(ex)))
 

--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -429,6 +429,8 @@ class WorkQueue(WorkQueueBase):
             dbs = get_dbs(match['Dbs'])
             if wmspec.getTask(match['TaskName']).parentProcessingFlag():
                 dbsBlockDict = dbs.getFileBlockWithParents(blockName)
+            elif wmspec.requestType() == 'StoreResults':
+                dbsBlockDict = dbs.getFileBlock(blockName, dbsOnly=True)
             else:
                 dbsBlockDict = dbs.getFileBlock(blockName)
 


### PR DESCRIPTION
Do not use PhEDEx for data location of StoreResults requests, since the input dataset is not available in TMDB. This change should be transparent to anything else.

Paola helped me to test it in testbed and it seems to be working fine.
However, I made a last minute change and I still want to check whether it's Ok.

@ticoann please review
