### PR TITLE
Fix jsonFile var for AgentStatusWatcher

### DIFF
--- a/bin/wmagent-mod-config
+++ b/bin/wmagent-mod-config
@@ -78,12 +78,12 @@ def modifyConfiguration(config, **args):
     for component in config.listComponents_():
         compCfg = getattr(config, component)
         compCfg.componentDir = "%s/%s" % (args['working_dir'], component)
-
         if component == "JobCreator":
             compCfg.jobCacheDir = "%s/%s/JobCache" % (args['working_dir'], component)
-
-        if component == "JobAccountant":
+        elif component == "JobAccountant":
             compCfg.specDir = "%s/%s/SpecCache" % (args['working_dir'], component)
+        elif component == "AgentStatusWatcher":
+            compCfg.jsonFile = "%s/%s/WMA_monitoring.json" % (args['working_dir'], component)
 
     localhost = socket.getfqdn()
     for webapp in config.listWebapps_():

--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -547,7 +547,7 @@ config.AgentStatusWatcher.enabled = True # switch to enable or not this componen
 config.AgentStatusWatcher.agentPollInterval = 300
 config.AgentStatusWatcher.monitorPollInterval = 3  # number of component polling cycles
 config.AgentStatusWatcher.defaultAgentsNumByTeam = 5
-config.AgentStatusWatcher.jsonFile = config.General.workDir + "/AgentStatusWatcher/WMA_monitoring.json"
+config.AgentStatusWatcher.jsonFile = config.AgentStatusWatcher.componentDir + "/WMA_monitoring.json"
 
 config.component_("ArchiveDataReporter")
 config.ArchiveDataReporter.namespace = "WMComponent.ArchiveDataReporter.ArchiveDataReporter"


### PR DESCRIPTION
And this fixes the `jsonFile` variable. I thought it would get populated from WMAgentConfig.py only.
Already tested in a new deployment.

@ticoann feel free to merge it once jenkins are over
