### PR TITLE
Robust comparison and use for DBS

### DIFF
--- a/src/python/Utils/ExtendedUnitTestCase.py
+++ b/src/python/Utils/ExtendedUnitTestCase.py
@@ -1,0 +1,58 @@
+#! /usr/bin/env python
+"""
+Unit testing base class with our extensions
+"""
+
+from __future__ import (division, print_function)
+
+import copy
+import unittest
+
+
+class ExtendedUnitTestCase(unittest.TestCase):
+    """
+    Class that can be imported to switch to 'mock'ed versions of
+    services.
+    """
+
+    def assertContentsEqual(self, expected_obj, actual_obj, msg=None):
+        """
+        A nested object comparison without regard for the ordering of contents. It asserts that
+        expected_obj and actual_obj contain the same elements and that their sub-elements are the same.
+        However, all sequences are allowed to contain the same elements, but in different orders.
+        """
+
+        def traverse_dict(dictionary):
+            for key, value in dictionary.iteritems():
+                if isinstance(value, dict):
+                    traverse_dict(value)
+                elif isinstance(value, list):
+                    traverse_list(value)
+            return
+
+        def traverse_list(theList):
+            for value in theList:
+                if isinstance(value, dict):
+                    traverse_dict(value)
+                elif isinstance(value, list):
+                    traverse_list(value)
+            theList.sort()
+            return
+
+        if type(expected_obj) != type(actual_obj):
+            self.fail(msg="The two objects are different type and cannot be compared: %s and %s" % (
+            type(expected_obj), type(actual_obj)))
+
+        expected = copy.deepcopy(expected_obj)
+        actual = copy.deepcopy(actual_obj)
+
+        if isinstance(expected, dict):
+            traverse_dict(expected)
+            traverse_dict(actual)
+        elif isinstance(expected, list):
+            traverse_list(expected)
+            traverse_list(actual)
+        else:
+            self.fail(msg="The two objects are different type (%s) and cannot be compared." % type(expected_obj))
+
+        return self.assertEqual(expected, actual)

--- a/test/python/Utils_t/ExtendedUnitTestCase_t.py
+++ b/test/python/Utils_t/ExtendedUnitTestCase_t.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+"""
+Test of assertContentsEqual for ExtendedUnitTestCase
+"""
+
+from __future__ import division, print_function
+
+import copy
+import unittest
+
+from Utils.ExtendedUnitTestCase import ExtendedUnitTestCase
+
+
+class ExtendedUnitTestCaseTest(ExtendedUnitTestCase):
+    """
+    Test of assertContentsEqual for ExtendedUnitTestCase
+    """
+
+    def testNestedListComparison(self):
+        """
+        Test the nested comparison method. Deeply nested lists are compared by content, not order
+         (assertItemsEqual in python 2.7, assertCountEqual in python3)
+        """
+
+        initialList = [{'a': [1, 2, 3, 4], 'b': ['a', 'b', 'c', 'd'], 'c': 'd'},
+                       {'e': {'c': [1, 2, 3]}}]
+        copyList = copy.deepcopy(initialList)
+        sameList = [{'e': {'c': [3, 2, 1]}},
+                    {'a': [3, 1, 2, 4], 'b': ['b', 'a', 'c', 'd'], 'c': 'd'}]
+        diffList1 = [{'a': [1, 2, 3, 5], 'b': ['a', 'b', 'c', 'e'], 'c': 'd'}, {'e': {'c': [1, 2, 3]}}]
+        diffList2 = [{'a': [1, 2, 3, 4], 'b': ['a', 'b', 'c', 'd'], 'c': 'd'}, {'e': {'c': [3, 1, 3]}}]
+
+        self.assertNotEqual(initialList, sameList)
+        self.assertContentsEqual(initialList, sameList)
+        self.assertNotEqual(initialList, sameList)  # Make sure they are still not equal (were not modified)
+        self.assertEqual(initialList, copyList)
+
+        with self.assertRaises(AssertionError):
+            self.assertContentsEqual(initialList, diffList1)
+        with self.assertRaises(AssertionError):
+            self.assertContentsEqual(initialList, diffList2)
+
+    def testNestedDictComparison(self):
+        """
+        Test the nested comparison method. Deeply nested lists are compared by content, not order
+         (assertItemsEqual in python 2.7, assertCountEqual in python3)
+        """
+
+        initialDict = {'a': [1, 2, 3, 4],
+                       'b': ['a', 'b', 'c', 'd'],
+                       'c': 'd',
+                       'e': {'c': [1, 2, 3]}}
+        copyDict = copy.deepcopy(initialDict)
+        sameDict = {'a': [3, 1, 4, 2],
+                    'b': ['a', 'b', 'd', 'c'],
+                    'c': 'd',
+                    'e': {'c': [3, 2, 1]}}
+        diffDict1 = {'a': [3, 1, 4, 2],
+                     'b': ['a', 'b', 'd', 'c'],
+                     'c': 'd',
+                     'e': {'c': 'f'}}
+        diffDict2 = {'a': [1, 2, 3, 4],
+                     'b': ['a', 'b', 'c', 'd'],
+                     'c': 'd',
+                     'e': {'c': [3, 2, 3]}}
+
+        self.assertNotEqual(initialDict, sameDict)
+        self.assertContentsEqual(initialDict, sameDict)
+        self.assertNotEqual(initialDict, sameDict)  # Make sure they are still not equal (were not modified)
+        self.assertEqual(initialDict, copyDict)
+
+        with self.assertRaises(AssertionError):
+            self.assertContentsEqual(initialDict, diffDict1)
+        with self.assertRaises(AssertionError):
+            self.assertContentsEqual(initialDict, diffDict2)
+
+    def testWrongTypes(self):
+        """
+        Test that comparison fails with different types
+        """
+
+        d = {}
+        l = []
+        s = ()
+
+        with self.assertRaises(AssertionError):
+            self.assertContentsEqual(d, l)
+        with self.assertRaises(AssertionError):
+            self.assertContentsEqual(l, s)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/WMQuality_t/Emulators_t/DBSClient_t/MockDbsApi_t.py
+++ b/test/python/WMQuality_t/Emulators_t/DBSClient_t/MockDbsApi_t.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-from __future__ import division
+from __future__ import (division, print_function)
+
 import unittest
-from WMQuality.Emulators.DBSClient.MockDbsApi import MockDbsApi
+
 from dbs.apis.dbsClient import DbsApi
+
+from Utils.ExtendedUnitTestCase import ExtendedUnitTestCase
+from WMQuality.Emulators.DBSClient.MockDbsApi import MockDbsApi
 
 # a small dataset that should always exist
 DATASET = '/HighPileUp/Run2011A-v1/RAW'
@@ -12,7 +15,7 @@ BLOCK = '/HighPileUp/Run2011A-v1/RAW#fabf118a-cbbf-11e0-80a9-003048caaace'
 FILE_NAMES = [u'/store/data/Commissioning2015/Cosmics/RAW/v1/000/238/545/00000/C47FDF25-2ECF-E411-A8E2-02163E011839.root']
 
 
-class MockDbsApiTest(unittest.TestCase):
+class MockDbsApiTest(ExtendedUnitTestCase):
     """
     Class that can be imported to switch to 'mock'ed versions of
     services.
@@ -32,36 +35,35 @@ class MockDbsApiTest(unittest.TestCase):
         """
         Tests members from DBSApi
         """
-        
+
         block_with_parent = '/Cosmics/Commissioning2015-PromptReco-v1/RECO#004ac3ba-d09e-11e4-afad-001e67ac06a0'
-        #List of members from DBSApi
-        members = {'listDataTiers':{},
-                'listDatasets':{'data_tier_name':'RAW', 'primary_ds_name':'Jet'},
-                'listFileLumis':{'block_name':BLOCK, 'validFileOnly':1},
-                # 'listFileLumiArray':{'logical_file_name': FILE_NAMES},
-                'listFileParents':{'block_name':block_with_parent},
-                'listPrimaryDatasets':{'primary_ds_name':'Jet*'},
-                'listRuns':{'dataset':DATASET},
-                'listFileArray':{'dataset':DATASET},
-                'listFileArray':{'dataset':DATASET, 'detail':True, 'validFileOnly':1},
-                'listFileSummaries':{'dataset':DATASET, 'validFileOnly':1},
-                'listBlocks':{'dataset':DATASET, 'detail':True},
-                'listBlockParents':{'block_name' : block_with_parent},
-               }
-        
+        # List of members from DBSApi
+        members = {'listDataTiers': {},
+                   'listDatasets': {'data_tier_name': 'RAW', 'primary_ds_name': 'Jet'},
+                   'listFileLumis': {'block_name': BLOCK, 'validFileOnly': 1},
+                   # 'listFileLumiArray':{'logical_file_name': FILE_NAMES},
+                   'listFileParents': {'block_name': block_with_parent},
+                   'listPrimaryDatasets': {'primary_ds_name': 'Jet*'},
+                   'listRuns': {'dataset': DATASET},
+                   'listFileArray': {'dataset': DATASET},
+                   'listFileArray': {'dataset': DATASET, 'detail': True, 'validFileOnly': 1},
+                   'listFileSummaries': {'dataset': DATASET, 'validFileOnly': 1},
+                   'listBlocks': {'dataset': DATASET, 'detail': True},
+                   'listBlockParents': {'block_name': block_with_parent},
+                   }
+
         for member in members.keys():
-            #Get from  mock DBS
+            # Get from  mock DBS
             args = []
             kwargs = members[member]
 
             real = getattr(self.realDBS, member)(*args, **kwargs)
             mock = getattr(self.mockDBS, member)(*args, **kwargs)
-            
-            #assert the result
-            self.assertEqual(sorted(real), sorted(mock), "Identity check on member %s failed" % member)
+
+            self.assertContentsEqual(real, mock, "Identity check on member %s failed" % member)
 
         return
 
+
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
I wrote a new kind of unit test assert() to check lists of dictionaries of lists (all the way down) or dictionaries as a starting point. The difference is all the lists are sorted at each point.

This is better for dealing with DBS data since depending on the day of the week, the list of lumis, etc, come out in random order. So it should fix this intermittent error with the test of the DBS mock emulator.
