### PR TITLE
use the adler32 checksum in gfal2 stageout

### DIFF
--- a/src/python/WMCore/Storage/Backends/GFAL2Impl.py
+++ b/src/python/WMCore/Storage/Backends/GFAL2Impl.py
@@ -103,6 +103,8 @@ class GFAL2Impl(StageOutImpl):
 
         copyCommandDict = {'checksum': '', 'options': '', 'source': '', 'destination': ''}
 
+        useChecksum = (checksums is not None and 'adler32' in checksums and not self.stageIn)
+
         if not options:
             options = ''
 
@@ -111,7 +113,11 @@ class GFAL2Impl(StageOutImpl):
         args, unknown = parser.parse_known_args(options.split())
 
         if not args.nochecksum:
-            copyCommandDict['checksum'] = "-K adler32"
+            if useChecksum:
+                checksums['adler32'] = "%08x" % int(checksums['adler32'], 16)
+                copyCommandDict['checksum'] = "-K adler32:%s" % checksums['adler32']
+            else:
+                copyCommandDict['checksum'] = "-K adler32"
 
         copyCommandDict['options'] = ' '.join(unknown)
 


### PR DESCRIPTION
Our runtime code calculate the adler32 checksum before calling the stageout code. Actually use the checksum in the gfal2 stageout (like we already do for xrdcp stageout).

I have no way to test this myself, syntax rules are based on the xrdcp stageout, which supports the same argument in the same fashion.

@amaltaro , please review and test as convenient
