### PR TITLE
Convert leftover se_name to pnn

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/Oracle/CreateBlocks.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/CreateBlocks.py
@@ -14,7 +14,7 @@ class CreateBlocks(MySQLCreateBlocks):
              SELECT dbsbuffer_block_seq.nextval,
                     (SELECT id from dbsbuffer_dataset WHERE path = :dataset),
                     :block,
-                    (SELECT id FROM dbsbuffer_location WHERE se_name = :location),
+                    (SELECT id FROM dbsbuffer_location WHERE pnn = :location),
                     :status,
                     :time
              FROM DUAL


### PR DESCRIPTION
John found (thanks!) this problem in a replay, the mysql class was updated but not the oracle one.
