### PR TITLE
Cast list of PU files to string in the PSet tweak

### DIFF
--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -435,7 +435,8 @@ class SetupCMSSWPset(ScriptInterface):
                         if PhEDExNodeName in blockDict["PhEDExNodeNames"]:
                             eventsAvailable += int(blockDict.get('NumberOfEvents', 0))
                             for fileLFN in blockDict["FileList"]:
-                                inputTypeAttrib.fileNames.append(fileLFN['logical_file_name'])
+                                # vstring does not support unicode
+                                inputTypeAttrib.fileNames.append(str(fileLFN['logical_file_name']))
                     if requestedPileupType == 'data':
                         baggage = self.job.getBaggage()
                         if getattr(baggage, 'skipPileupEvents', None) is not None:


### PR DESCRIPTION
Another leftover from the transition to python standard json. The pileupconf.json file is completely unicode, which raises the following problem during runtime:

```
Running on site 'T2_CH_CERN', local PNN: 'T2_CH_CERN'
Pileup JSON configuration file: '/pool/condor/dir_19807/glide_h6JpSZ/execute/dir_12669/job/WMTaskSpace/cmsRun1/pileupconf.json'
Traceback (most recent call last):
  File "/cvmfs/cms.cern.ch/slc6_amd64_gcc481/external/python/2.7.6/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/cvmfs/cms.cern.ch/slc6_amd64_gcc481/external/python/2.7.6/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/pool/condor/dir_19807/glide_h6JpSZ/execute/dir_12669/job/WMCore.zip/WMCore/WMRuntime/ScriptInvoke.py", line 117, in 
RuntimeError: Error invoking script for step WMTaskSpace.cmsRun1
withe Script module: SetupCMSSWPset
wrong type being appended to container vstringDetails:
  File "/pool/condor/dir_19807/glide_h6JpSZ/execute/dir_12669/job/WMCore.zip/WMCore/WMRuntime/ScriptInvoke.py", line 109, in 
  File "/pool/condor/dir_19807/glide_h6JpSZ/execute/dir_12669/job/WMCore.zip/WMCore/WMRuntime/ScriptInvoke.py", line 77, in invoke
  File "/build/sryu/w/tmp/BUILDROOT/b054a51b3dd7e0752cb64ce26a0021aa/build/sryu/w/slc6_amd64_gcc493/cms/wmagent/1.0.19/lib/python2.7/site-packages/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py", line 716, in __call__
    self.handlePileup()
  File "/build/sryu/w/tmp/BUILDROOT/b054a51b3dd7e0752cb64ce26a0021aa/build/sryu/w/slc6_amd64_gcc493/cms/wmagent/1.0.19/lib/python2.7/site-packages/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py", line 397, in handlePileup
    self._processPileupMixingModules(pileupDict, PhEDExNodeName, mixModules, "mc")
  File "/build/sryu/w/tmp/BUILDROOT/b054a51b3dd7e0752cb64ce26a0021aa/build/sryu/w/slc6_amd64_gcc493/cms/wmagent/1.0.19/lib/python2.7/site-packages/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py", line 438, in _processPileupMixingModules
    inputTypeAttrib.fileNames.append(fileLFN['logical_file_name'])
  File "/cvmfs/cms.cern.ch/slc6_amd64_gcc481/cms/cmssw-patch/CMSSW_7_2_0_patch1/python/FWCore/ParameterSet/Mixins.py", line 482, in append
    raise TypeError("wrong type being appended to container "+self._labelIfAny())
```

I already see jobs succeeding with this patch.
@ericvaandering please review
