### PR TITLE
Add only unique file/location rows into dbsbuffer

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/SetLocation.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/SetLocation.py
@@ -11,7 +11,7 @@ MySQL implementation of DBSBuffer.SetLocation
 from WMCore.Database.DBFormatter import DBFormatter
 
 class SetLocation(DBFormatter):
-    sql = """INSERT INTO dbsbuffer_file_location (filename, location)
+    sql = """INSERT IGNORE INTO dbsbuffer_file_location (filename, location)
                VALUES (:fileid, :locationid)"""
 
     def execute(self, binds, conn = None, transaction = None):

--- a/src/python/WMComponent/DBS3Buffer/Oracle/DBSBufferFiles/SetLocation.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/DBSBufferFiles/SetLocation.py
@@ -12,4 +12,11 @@ from WMComponent.DBS3Buffer.MySQL.DBSBufferFiles.SetLocation import SetLocation 
      MySQLSetLocation
 
 class SetLocation(MySQLSetLocation):
-    pass
+    """
+    Insert unique lfn, location row
+    """
+    sql = """INSERT INTO dbsbuffer_file_location (filename, location)
+               SELECT :fileid, :locationid FROM DUAL WHERE NOT EXISTS
+                 (SELECT filename FROM dbsbuffer_file_location
+                 WHERE filename= :fileid and location= :locationid)
+               """

--- a/src/python/WMComponent/DBS3Buffer/Oracle/DBSBufferFiles/SetLocationByLFN.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/DBSBufferFiles/SetLocationByLFN.py
@@ -16,8 +16,10 @@ class SetLocationByLFN(MySQLSetLocationByLFN):
 
     """
     sql = """INSERT INTO dbsbuffer_file_location (filename, location)
-               SELECT df.id, dl.id
-               FROM dbsbuffer_file df, dbsbuffer_location dl
-               WHERE df.lfn = :lfn
-               AND dl.pnn = :pnn
+               SELECT (SELECT id FROM dbsbuffer_file WHERE lfn= :lfn) AS filename,
+                      (SELECT id FROM dbsbuffer_location WHERE pnn= :pnn) AS location
+               FROM DUAL WHERE NOT EXISTS
+                 (SELECT filename FROM dbsbuffer_file_location
+                   WHERE filename= (SELECT id FROM dbsbuffer_file WHERE lfn= :lfn) AND
+                   location= (SELECT id FROM dbsbuffer_location WHERE pnn= :pnn))
                """


### PR DESCRIPTION
Sigh... why Oracle cannot have the handy and simple `ignore` clause...

This fix is supposed to fix this problem [1]
@hufnagel @yuyiguo can you review it please?
@ticoann I'll apply this patch to the production nodes as soon as I get it reviewed (vocms0309 is complaining about it)

```
[1]
(IntegrityError) ORA-00001: unique constraint (CMS_WMBS_PROD2.PK_DBS_FIL_LOC) violated
 'INSERT INTO dbsbuffer_file_location (filename, location)\n               SELECT df.id, dl.id\n               FROM dbsbuffer_file df, dbsbuffer_location dl\n               WHERE df.lfn = :lfn\n               AND dl.se_name = :sename' [{'sename': 'T3_US_Vanderbilt_EC2', 'lfn': '/store/hidata/HIRun2015/HIHardProbes/RAW/v1/000/262/492/00000/C0B873F9-5393-E511-A0ED-02163E014704.root'}, {'sename': 'T2_US_Vanderbilt', 'lfn': '/store/hidata/HIRun2015/HIHardProbes/RAW/v1/000/262/492/00000/C0B873F9-5393-E511-A0ED-02163E014704.root'}, {'sename': 'T3_US_Vanderbilt_EC2', 'lfn': '/store/hidata/HIRun2015/HIHardProbes/RAW/v1/000/262/494/00000/FA899139-5493-E511-899F-02163E01433B.root'}, {'sename': 'T2_US_Vanderbilt', 'lfn': '/store/hidata/HIRun2015/HIHardProbes/RAW/v1/000/262/494/00000/FA899139-5493-E511-899F-02163E01433B.root'}, {'sename': 'T3_US_Vanderbilt_EC2', 'lfn': '/store/hidata/HIRun2015/HIHardProbes/RAW/v1/000/262/495/00000/4A753A00-5493-E511-8EEC-02163E011B5A.root'}, {'sename': 'T2_US_Vanderbilt', 'lfn': '/store/hidata/HIRun2015/HIHardProbes/RAW/v1/000/262/495/00000/4A753A00-5493-E511-8EEC-02163E011B5A.root'}, {'sename': 'T3_US_Vanderbilt_EC2', 'lfn': '/store/hidata/HIRun2015/HIHardProbes/RAW/v1/000/262/496/00000/C820070A-5493-E511-962B-02163E0134BD.root'}, {'sename': 'T2_US_Vanderbilt', 'lfn': '/store/hidata/HIRun2015/HIHardProbes/RAW/v1/000/262/496/00000/C820070A-5493-E511-962B-02163E0134BD.root'}  ... displaying 10 of 500 total bound parameter sets ...  {'sename': 'T3_US_Vanderbilt_EC2', 'lfn': '/store/hidata/HIRun2015/HIHardProbes/RAW/v1/000/262/768/00000/8C431DDE-9995-E511-87C9-02163E014130.root'}, {'sename': 'T2_US_Vanderbilt', 'lfn': '/store/hidata/HIRun2015/HIHardProbes/RAW/v1/000/262/768/00000/8C431DDE-9995-E511-87C9-02163E014130.root'}]
```
