### PR TITLE
Changes needed for "Automatic" splitting in CRAB

### DIFF
--- a/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
+++ b/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
@@ -40,6 +40,7 @@ class EventAwareLumiBased(JobFactory):
         """
 
         avgEventsPerJob = int(kwargs.get('events_per_job', 5000))
+        jobLimit        = int(kwargs.get('job_limit', 0))
         eventLimit      = int(kwargs.get('max_events_per_lumi', 20000))
         totalEvents     = int(kwargs.get('total_events', 0))
         splitOnFile     = bool(kwargs.get('halt_job_on_file_boundaries', True))
@@ -264,6 +265,9 @@ class EventAwareLumiBased(JobFactory):
                             lumisInJobInFile = 0
                             currentJobAvgEventCount = 0
                             totalJobs += 1
+                            if jobLimit and totalJobs > jobLimit:
+                                msg = "Job limit of {0} jobs exceeded.".format(jobLimit)
+                                raise RuntimeError(msg)
 
                             # Add the file to new jobs
                             self.currentJob.addFile(f)

--- a/src/python/WMCore/Services/Dashboard/DashboardAPI.py
+++ b/src/python/WMCore/Services/Dashboard/DashboardAPI.py
@@ -254,7 +254,7 @@ def reportFailureToDashboard(exitCode, ad=None, stageOutReport=None):
         return exitCode
     params = {
         'MonitorID': ad['CRAB_ReqName'],
-        'MonitorJobID': '%d_https://glidein.cern.ch/%d/%s_%d' % (ad['CRAB_Id'], ad['CRAB_Id'],
+        'MonitorJobID': '%s_https://glidein.cern.ch/%s/%s_%s' % (ad['CRAB_Id'], ad['CRAB_Id'],
                                                                  ad['CRAB_ReqName'].replace("_", ":"), ad['CRAB_Retry']),
         'JobExitCode': exitCode
     }

--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -725,6 +725,11 @@ class SetupCMSSWPset(ScriptInterface):
             self.process.source.numberEventsInLuminosityBlock = \
                 cms.untracked.uint32(self.step.data.application.configuration.eventsPerLumi)
 
+        # limit run time if desired
+        if hasattr(self.step.data.application.configuration, "maxSecondsUntilRampdown"):
+            self.process.maxSecondsUntilRampdown = cms.untracked.PSet(
+                    input = cms.untracked.int32(self.step.data.application.configuration.maxSecondsUntilRampdown))
+
         # accept an overridden TFC from the step
         if hasattr(self.step.data.application,'overrideCatalog'):
             print("Found a TFC override: %s" % self.step.data.application.overrideCatalog)


### PR DESCRIPTION
These are changes needed for "Automatic" splitting in CRAB. In detail:
1. Allow to specify the runtime limitation parameter `maxSecondsUntilRampdown` in the pset (`CMSSW_7_4_0` and later)
   - this allows us to run a splitting "probe" on the schedd that will return after a specific amount of time
   - allows to cap the runtime of regular jobs to have more of a "task completion time" guarantee (ASO excluded)
2. Adjust the dashboard API to accept non-integer job IDs
   - the "capped" regular jobs have completion jobs with IDs of the form `1-1`, `1-2`,… to complete unprocessed lumis from job `1` etc…
3. Allow to set a hard job limit for splitting, raising an exception when the total number of jobs exceeds this limit
   - the splitting probe runs the splitting algorithm in the the postjob on the schedd. When splitting parameters turn out to be unreasonable, creating more jobs than we ask for will bog down the schedd. Returning with an error state before this happens prevents the postjob from consuming excessive amounts of memory.
