### PR TITLE
Avoid using test in function names

### DIFF
--- a/src/python/WMCore/REST/Test.py
+++ b/src/python/WMCore/REST/Test.py
@@ -63,7 +63,7 @@ def fake_authz_key_file(delete=True):
     t.seek(0)
     return t
 
-def setup_test_server(module_name, class_name, app_name = None, authz_key_file=None, port=8888):
+def setup_dummy_server(module_name, class_name, app_name = None, authz_key_file=None, port=8888):
     """Helper function to set up a :class:`~.RESTMain` server from given
     module and class. Creates a fake server configuration and instantiates
     the server application from it.

--- a/test/python/WMCore_t/REST_t/Api_t.py
+++ b/test/python/WMCore_t/REST_t/Api_t.py
@@ -10,7 +10,7 @@ from cherrypy.test import webtest
 
 # WMCore modules
 from WMCore.REST.Server import RESTApi, RESTEntity, restcall, rows
-from WMCore.REST.Test import setup_test_server, fake_authz_headers
+from WMCore.REST.Test import setup_dummy_server, fake_authz_headers
 from WMCore.REST.Test import fake_authz_key_file
 from WMCore.REST.Validation import validate_num, validate_str
 from WMCore.REST.Error import InvalidObject
@@ -246,7 +246,7 @@ class Tester(webtest.WebCase):
 
 def setup_server():
     srcfile = __file__.split("/")[-1].split(".py")[0]
-    setup_test_server(srcfile, "Root", authz_key_file=FAKE_FILE, port=PORT)
+    setup_dummy_server(srcfile, "Root", authz_key_file=FAKE_FILE, port=PORT)
 
 def load_server(engine):
     setup_server()

--- a/test/python/WMCore_t/REST_t/Daemon_t.py
+++ b/test/python/WMCore_t/REST_t/Daemon_t.py
@@ -8,7 +8,7 @@ from threading import Thread, Condition
 import time, random
 
 # WMCore modules
-from WMCore.REST.Test import setup_test_server, fake_authz_headers
+from WMCore.REST.Test import setup_dummy_server, fake_authz_headers
 from WMCore.REST.Test import fake_authz_key_file
 from WMCore.REST.Server import RESTApi, RESTEntity, restcall
 
@@ -110,7 +110,7 @@ class TaskTest(webtest.WebCase):
 
 def setup_server():
     srcfile = __file__.split("/")[-1].split(".py")[0]
-    setup_test_server(srcfile, "TaskAPI", authz_key_file=FAKE_FILE, port=PORT)
+    setup_dummy_server(srcfile, "TaskAPI", authz_key_file=FAKE_FILE, port=PORT)
 
 def load_server(engine):
     setup_server()

--- a/test/python/WMCore_t/REST_t/Simple_t.py
+++ b/test/python/WMCore_t/REST_t/Simple_t.py
@@ -5,7 +5,7 @@ from cherrypy import expose
 from multiprocessing import Process
 
 # WMCore modules
-from WMCore.REST.Test import setup_test_server, fake_authz_headers
+from WMCore.REST.Test import setup_dummy_server, fake_authz_headers
 from WMCore.REST.Test import fake_authz_key_file
 from WMCore.REST.Tools import tools
 
@@ -57,7 +57,7 @@ class SimpleTest(webtest.WebCase):
 
 def setup_server():
     srcfile = __file__.split("/")[-1].split(".py")[0]
-    setup_test_server(srcfile, "Root", authz_key_file=FAKE_FILE, port=PORT)
+    setup_dummy_server(srcfile, "Root", authz_key_file=FAKE_FILE, port=PORT)
 
 def load_server(engine):
     setup_server()


### PR DESCRIPTION
Fix this unittest failure

```
Simple_t.SimpleTest:test_auth_fail changed from success to error
```

that is popping up in #6094 

Googling a bit, the problem come from the fact that nose uses a regex to search for tests that needs to be executed. Some more info here:
http://stackoverflow.com/questions/16475980/nose-runs-test-on-function-in-setup-when-no-suite-specified

I hope it fixes the problem.
