### PR TITLE
Use the correct priority var between JobSubmitter and RunJob

### DIFF
--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -329,13 +329,13 @@ class JobSubmitterPoller(BaseWorkerThread):
             if newJob['type'] in ["Repack", "Merge", "Cleanup", "LogCollect"]:
                 highIOjob = True
 
-            # Create a job dictionary object and put it in the cache
+            # Create a job dictionary object and put it in the cache (needs to be in sync with RunJob)
             jobInfo = {'id': jobID,
                        'requestName': newJob['request_name'],
                        'taskName': newJob['task_name'],
                        'taskType': newJob['type'],
                        'cache_dir': newJob["cache_dir"],
-                       'requestPriority': newJob['wf_priority'],
+                       'priority': newJob['wf_priority'],
                        'taskID': newJob['task_id'],
                        'retry_count': newJob["retry_count"],
                        'highIOjob': highIOjob,
@@ -588,7 +588,6 @@ class JobSubmitterPoller(BaseWorkerThread):
 
             sandbox = self.sandboxPackage[package]
             jobs = jobsToSubmit.get(package, [])
-
             for job in jobs:
                 job['location'], job['plugin'], job['site_cms_name'] = self.getSiteInfo(job['custom']['location'])
                 job['sandbox'] = sandbox

--- a/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
@@ -862,7 +862,7 @@ class PyCondorPlugin(BasePlugin):
 
             # Set job priority from the request and task priority
             task_priority = int(job.get("taskPriority", self.defaultTaskPriority))
-            prio = int(job.get('requestPriority', 0))
+            prio = int(job.get('priority', 0))
             jdl.append("priority = %i\n" % (prio + task_priority * self.maxTaskPriority))
 
             jdl.append("+PostJobPrio1 = -%d\n" % len(job.get('potentialSites', [])))


### PR DESCRIPTION
To bear in mind that the job object built at JobSubmitter level is not exactly what we pass downstream do PyCondor plugin. Instead, we build a RunJob object from the "JobSubmitter job object".

Tested in testbed and it looks good.
@ticoann please review
