### PR TITLE
Port assignment validation code to ReqMgr2

### DIFF
--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
@@ -320,7 +320,7 @@ class Assign(WebAPI):
                 for value in kwargs[field].values():
                     self.validate(value, field)
             else:
-                self.validate(kwargs.get(field, origValue))
+                self.validate(kwargs.get(field, origValue), field)
 
         # Set white list and black list
         whiteList = kwargs.get("SiteWhitelist", [])

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -1765,7 +1765,7 @@ class WMWorkloadHelper(PersistencyHelper):
         # TODO: need to define proper task form maybe kwargs['Tasks']?
         self.setTaskProperties(kwargs)
 
-        return kwargs
+        return
 
     def loadSpecFromCouch(self, couchurl, requestName):
         """


### PR DESCRIPTION
While investigating #7075, I stumbled upon a few flaws that are fixed here, they are:
- fixed a validation issue in Assign.py
- ported the output datasets lexicon validation to ReqMgr2
- ported the datatiers validation to ReqMgr2
- fixed the validation of assignment dict arguments in ReqMgr2
- BUT, did not fix the AcqEra issue as reported in that issue :-(

@ticoann please review but don't merge please, I still have to test it.  
