### PR TITLE
Properly set AcqEra for any task level - TaskChain

### DIFF
--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -1349,6 +1349,13 @@ class WMTaskHelper(TreeHelper):
         """
         if isinstance(era, dict):
             taskEra = era.get(self.name(), parentAcquisitionEra)
+            if taskEra is None:
+                # We cannot properly set AcqEra for ACDC of TaskChain Merge
+                # failures, so we should look up for a similar taskname in
+                # the acqera dict passed from the requestor
+                for taskname in era:
+                    if taskname in self.name():
+                        taskEra = era[taskname]
         else:
             taskEra = era
 


### PR DESCRIPTION
Fixes #6941

Makes AcqEra parameter mandatory for assignment in reqmgr (it already is, I hope, in reqmgr2).
About the assign_optional validation, I could not find anything validating it in ReqMgr. Should we call this validation function being used by reqmgr2:
https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/WMSpec/WMWorkloadTools.py#L241
?

For ACDCs of TaskChain Merge jobs, we sometimes don't have the Processing task in the workflow, meaning AcqEra key/value would not find that TaskName. I added a workaround such that Merge tasks will inherit the value from its parent according to one string contains another.

@ticoann I still have to test it, but feel free to make comments :)
