### PR TITLE
Destroy databases before running tests.

### DIFF
--- a/test/python/WMCore_t/WorkQueue_t/WMBSHelper_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WMBSHelper_t.py
@@ -54,7 +54,7 @@ class WMBSHelperTest(EmulatedUnitTestCase):
 
         self.testInit = TestInitCouchApp(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testInit.setDatabaseConnection(destroyAllDatabase=True)
         self.testInit.setupCouch("wmbshelper_t/jobs", "JobDump")
         self.testInit.setupCouch("wmbshelper_t/fwjrs", "FWJRDump")
         self.testInit.setupCouch("config_test", "GroupUser", "ConfigCache")

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueueTestCase.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueueTestCase.py
@@ -43,7 +43,7 @@ class WorkQueueTestCase(EmulatedUnitTestCase):
         self.setSchema()
         self.testInit = TestInit('WorkQueueTest')
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testInit.setDatabaseConnection(destroyAllDatabase=True)
         self.testInit.setSchema(customModules = self.schema,
                                 useDefault = False)
         self.testInit.setupCouch(self.queueDB, *self.couchApps)


### PR DESCRIPTION
@ticoann @ericvaandering 

Here is the patch that will destroy the DBs on running the WorkQueue tests. Please can we get this running in Jenkins
