### PR TITLE
fix the acdc clean up call

### DIFF
--- a/src/python/WMCore/ACDC/CouchService.py
+++ b/src/python/WMCore/ACDC/CouchService.py
@@ -113,7 +113,7 @@ class CouchService(Service):
         Remove all the collections matching certain collection
         name.
         """
-        result = self.couchdb.loadView("ACDC", "byCollectionName", keys = [collectionName])
+        result = self.couchdb.loadView("ACDC", "byCollectionName", options={"reduce": False}, keys=[collectionName])
         for entry in result["rows"]:
             self.couchdb.queueDelete(entry["value"])
         return self.couchdb.commit()


### PR DESCRIPTION
I am not sure why default value for reduce is not False. (I think it was False before maybe after couch new version upgrade it has changed).
We need to check other views whether view assumes reduce is False.

Manually cleaning acdc db now so this patch is not critical to be undated but if other bug need to be fixed include in the new request. 

@amaltaro, Alan, please review.
