### PR TITLE
remove absolute paths for xrdcp binaries

### DIFF
--- a/src/python/WMCore/Storage/Backends/FNALImpl.py
+++ b/src/python/WMCore/Storage/Backends/FNALImpl.py
@@ -121,7 +121,7 @@ class FNALImpl(StageOutImpl):
 
             # always overwrite the output
 
-            result = "/usr/bin/xrdcp-old -d 0 -f "
+            result = "xrdcp-old -d 0 -f "
             if options != None:
                 result += " %s " % options
             result += " %s " % sourcePFN


### PR DESCRIPTION
They aren't needed and they make the FNAL stageout plugin unusable on some opportunistic sites.
