### PR TITLE
remove event limits for merges

### DIFF
--- a/src/python/WMCore/JobSplitting/ParentlessMergeBySize.py
+++ b/src/python/WMCore/JobSplitting/ParentlessMergeBySize.py
@@ -169,7 +169,7 @@ class ParentlessMergeBySize(JobFactory):
 
         self.maxMergeSize    = int(kwargs.get("max_merge_size", 1000000000))
         self.minMergeSize    = int(kwargs.get("min_merge_size", 1048576))
-        self.maxMergeEvents  = int(kwargs.get("max_merge_events", 50000))
+        self.maxMergeEvents  = int(kwargs.get("max_merge_events", 100000000))
         self.mergeAcrossRuns = kwargs.get("merge_across_runs", True)
         self.maxWaitTime     = kwargs.get("max_wait_time", 12 * 3600)
 

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -946,7 +946,7 @@ class StdBase(object):
                                       "validate": lambda x: x > 0},
                      "MaxWaitTime": {"default": 24 * 3600, "type": int,
                                      "validate": lambda x: x > 0},
-                     "MaxMergeEvents": {"default": 100000, "type": int,
+                     "MaxMergeEvents": {"default": 100000000, "type": int,
                                         "validate": lambda x: x > 0},
                      "ValidStatus": {"default": "PRODUCTION"},
                      "DbsUrl": {"default": "https://cmsweb.cern.ch/dbs/prod/global/DBSReader",

--- a/test/python/WMComponent_t/JobCreator_t/JobCreator_t.py
+++ b/test/python/WMComponent_t/JobCreator_t/JobCreator_t.py
@@ -524,11 +524,11 @@ class JobCreatorTest(unittest.TestCase):
                       first_event = 1024, locations = set(["somese.cern.ch"]))
         fileII.addRun(Run(2, *[46]))
         fileII.create()
-        fileIII = File(lfn = "fileIII", size = 1024, events = 102400,
+        fileIII = File(lfn = "fileIII", size = 1024, events = 1024,
                        first_event = 2048, locations = set(["somese.cern.ch"]))
         fileIII.addRun(Run(2, *[46]))
         fileIII.create()
-        fileIV = File(lfn = "fileIV", size = 102400, events = 1024,
+        fileIV = File(lfn = "fileIV", size = 1024 * 1000 * 1000, events = 1024,
                       first_event = 3072, locations = set(["somese.cern.ch"]))
         fileIV.addRun(Run(2, *[46]))
         fileIV.create()
@@ -549,11 +549,8 @@ class JobCreatorTest(unittest.TestCase):
         """
         _TestNonProxySplitting_
 
-        Test and see if we can split things without
-        a proxy.
+        Test and see if we can split things without a proxy.
         """
-
-
 
         myThread = threading.currentThread()
 
@@ -563,19 +560,11 @@ class JobCreatorTest(unittest.TestCase):
         name         = makeUUID()
         workloadName = 'TestWorkload'
 
-
         workload = self.createWorkload(workloadName = workloadName)
-
-        # Change the file splitting algo
-        procTask = workload.getTask("ReReco")
-        procTask.setSplittingAlgorithm("ParentlessMergeBySize", min_merge_size = 1, max_merge_size = 100000,
-                            max_merge_events = 200000)
 
         workloadPath = os.path.join(self.testDir, 'workloadTest', 'TestWorkload', 'WMSandbox', 'WMWorkload.pkl')
 
-
         self.stuffWMBS(workflowURL = workloadPath, name = name)
-
 
         testJobCreator = JobCreatorPoller(config = config)
 
@@ -583,6 +572,7 @@ class JobCreatorTest(unittest.TestCase):
 
         getJobsAction = self.daoFactory(classname = "Jobs.GetAllJobs")
         result = getJobsAction.execute(state = 'Created', jobType = "Processing")
+
         self.assertEqual(len(result), 1)
 
         result = getJobsAction.execute(state = 'Created', jobType = "Merge")


### PR DESCRIPTION
Don't want to remove the code completely, but setting the default to 100M events is effectively doing the same thing.
