### PR TITLE
Additional condor classAd for HLT usage

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
@@ -871,6 +871,9 @@ class PyCondorPlugin(BasePlugin):
             jdl.append("+WMAgent_JobID = %s\n" % job['jobid'])
             jdl.append("job_machine_attrs = GLIDEIN_CMSSite\n")
 
+            # As discussed with Farrukh on Sept 6, this knob is needed for HLT usage
+            jdl.append("+JobLeaseDuration = isUndefined(MachineAttrMaxHibernateTime0) ? 1200 : MachineAttrMaxHibernateTime0\n")
+
             ### print all the variables needed for us to rely on condor userlog
             jdl.append("job_ad_information_attrs = JobStatus,QDate,EnteredCurrentStatus,JobStartDate,DESIRED_Sites,ExtDESIRED_Sites,WMAgent_JobID,MATCH_EXP_JOBGLIDEIN_CMSSite\n")
 


### PR DESCRIPTION
One of the condor tweaks for better usage of the HLT resources. Farrukh knows more details, but what we discussed is that it can be applied upstream to all the agents and it will only make difference when jobs land on HLT worker nodes. So it has no side effects.

We have this patch already in place for the HLT agent (vocms0116).

@Farrukh-Aftab, do I get it right that before we starting running production in HLT, all the agents have to have this patch?
