### PR TITLE
Don.t fail WQE units based on their timestamp

### DIFF
--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -56,9 +56,9 @@ def globalQueue(logger=None, dbi=None, **kwargs):
                 'SplittingMapping': {'DatasetBlock':
                                          {'name': 'Block',
                                           'args': {}}
-                                     },
+                                    },
                 'TrackLocationOrSubscription': 'location'
-                }
+               }
     defaults.update(kwargs)
     return WorkQueue(logger, dbi, **defaults)
 
@@ -155,23 +155,23 @@ class WorkQueue(WorkQueueBase):
         self.params['SplittingMapping'].setdefault('DatasetBlock',
                                                    {'name': 'Block',
                                                     'args': {}}
-                                                   )
+                                                  )
         self.params['SplittingMapping'].setdefault('MonteCarlo',
                                                    {'name': 'MonteCarlo',
                                                     'args': {}}
-                                                   )
+                                                  )
         self.params['SplittingMapping'].setdefault('Dataset',
                                                    {'name': 'Dataset',
                                                     'args': {}}
-                                                   )
+                                                  )
         self.params['SplittingMapping'].setdefault('Block',
                                                    {'name': 'Block',
                                                     'args': {}}
-                                                   )
+                                                  )
         self.params['SplittingMapping'].setdefault('ResubmitBlock',
                                                    {'name': 'ResubmitBlock',
                                                     'args': {}}
-                                                   )
+                                                  )
 
         self.params.setdefault('EndPolicySettings', {})
 
@@ -219,7 +219,6 @@ class WorkQueue(WorkQueueBase):
             # This is need for getting post call
             # TODO: Change ReqMgr api to accept post for for retrieving the data and remove this
             self.requestDB = RequestDBReader(self.params['RequestDBURL'])
-
 
         # initialize alerts sending client (self.sendAlert() method)
         # usage: self.sendAlert(levelNum, msg = msg) ; level - integer 1 .. 10
@@ -714,15 +713,15 @@ class WorkQueue(WorkQueueBase):
         result = self.dataLocationMapper()
         self.backend.recordTaskActivity('location_refresh')
         return result
-    
+
     def _printLog(self, msg, printFlag, logLevel):
         if printFlag:
             print(msg)
         else:
             getattr(self.logger, logLevel)(msg)
-            
-    def pullWorkConditionCheck(self, printFlag = False):
-        
+
+    def pullWorkConditionCheck(self, printFlag=False):
+
         if not self.params['ParentQueueCouchUrl']:
             msg = 'Unable to pull work from parent, ParentQueueCouchUrl not provided'
             self._printLog(msg, printFlag, "warning")
@@ -735,7 +734,7 @@ class WorkQueue(WorkQueueBase):
             msg = 'Draining queue: skipping work pull'
             self._printLog(msg, printFlag, "warning")
             return False
-        
+
         left_over = self.parent_queue.getElements('Negotiating', returnIdOnly=True,
                                                   ChildQueueUrl=self.params['QueueURL'])
         if left_over:
@@ -748,11 +747,11 @@ class WorkQueue(WorkQueueBase):
             msg = 'Not pulling more work. Still processing %d previous units' % len(still_processing)
             self._printLog(msg, printFlag, "warning")
             return False
-        
+
         return True
-    
-    def freeResouceCheck(self, resources=None, printFlag=False):    
-        
+
+    def freeResouceCheck(self, resources=None, printFlag=False):
+
         jobCounts = {}
         if not resources:
             # find out available resources from wmbs
@@ -765,19 +764,17 @@ class WorkQueue(WorkQueueBase):
             msg = 'Not pulling more work. No free slots.'
             self._printLog(msg, printFlag, "warning")
             return (False, False)
-        
+
         return (resources, jobCounts)
 
-        
     def getAvailableWorkfromParent(self, resources, jobCounts, printFlag=False):
-        
+
         work, _, _ = self.parent_queue.availableWork(resources, jobCounts, self.params['Teams'])
 
         if not work:
             msg = 'No available work in parent queue.'
             self._printLog(msg, printFlag, "warning")
         return work
-    
 
     def pullWork(self, resources=None):
         """
@@ -788,16 +785,16 @@ class WorkQueue(WorkQueueBase):
         """
         if self.pullWorkConditionCheck() == False:
             return 0
-        
+
         (resources, jobCounts) = self.freeResouceCheck(resources)
         if (resources, jobCounts) == (False, False):
             return 0
-        
+
         self.logger.info("Pull work for sites %s: " % str(resources))
         work = self.getAvailableWorkfromParent(resources, jobCounts)
         if not work:
             return 0
-        
+
         work = self._assignToChildQueue(self.params['QueueURL'], *work)
 
         return len(work)
@@ -863,7 +860,7 @@ class WorkQueue(WorkQueueBase):
                     lastUpdate = float(max(childrenElements, key=lambda x: x.timestamp).timestamp)
                     if (currentTime - max(newDataFoundTime, lastUpdate)) > openRunningTimeout:
                         workflowsToClose.append(element.id)
-                    #if it is successful remove previous error
+                    # if it is successful remove previous error
                     self.logdb.delete(element.id, "error", this_thread=True)
                 else:
                     msg = "ChildElement is empty for element id %s: investigate" % element.id
@@ -1032,19 +1029,19 @@ class WorkQueue(WorkQueueBase):
             totalUnits.extend(units)
 
         return (totalUnits, rejectedWork)
-    
+
     def _getTotalStats(self, units):
         totalToplevelJobs = 0
         totalEvents = 0
         totalLumis = 0
         totalFiles = 0
-        
+
         for unit in units:
             totalToplevelJobs += unit['Jobs']
             totalEvents += unit['NumberOfEvents']
             totalLumis += unit['NumberOfLumis']
             totalFiles += unit['NumberOfFiles']
-        
+
         return {'total_jobs': totalToplevelJobs,
                 'input_events': totalEvents,
                 'input_lumis': totalLumis,
@@ -1072,12 +1069,13 @@ class WorkQueue(WorkQueueBase):
                     self.logger.info('Request "%s" already split - Resuming' % inbound['RequestName'])
                 else:
                     work, rejectedWork = self._splitWork(inbound['WMSpec'], data=inbound['Inputs'],
-                                                                     mask=inbound['Mask'], inbound=inbound,
-                                                                     continuous=continuous)
+                                                         mask=inbound['Mask'], inbound=inbound,
+                                                         continuous=continuous)
 
                     # save inbound work to signal we have completed queueing
-                    newWork = self.backend.insertElements(work, parent=inbound)  # if this fails, rerunning will pick up here
-                    #get statistics for the new work
+                    # if this fails, rerunning will pick up here
+                    newWork = self.backend.insertElements(work, parent=inbound)
+                    # get statistics for the new work
                     totalStats = self._getTotalStats(newWork)
 
                     if not continuous:

--- a/src/python/WMCore/WorkQueue/WorkQueueReqMgrInterface.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueReqMgrInterface.py
@@ -1,72 +1,71 @@
 #!/usr/bin/env python
 """Helper class for RequestManager interaction
 """
+import os
+import time
+import socket
+import traceback
+import threading
+from operator import itemgetter
+from httplib import HTTPException
 
+from WMCore import Lexicon
 from WMCore.Services.RequestManager.RequestManager import RequestManager
 from WMCore.Services.ReqMgr.ReqMgr import ReqMgr
 from WMCore.Services.LogDB.LogDB import LogDB
 from WMCore.ReqMgr.DataStructs.RequestStatus import REQUEST_STATE_LIST
-from WMCore.WorkQueue.WorkQueueExceptions import WorkQueueWMSpecError, WorkQueueNoWorkError
+from WMCore.WorkQueue.WorkQueueExceptions import WorkQueueWMSpecError, WorkQueueNoWorkError, TERMINAL_EXCEPTIONS
 from WMCore.Database.CMSCouch import CouchError
 from WMCore.Database.CouchUtils import CouchConnectionError
-from WMCore import Lexicon
-import os
-import time
-import socket
-from operator import itemgetter
-import traceback
-import threading
-from httplib import HTTPException
-
-from WMCore.WorkQueue.WorkQueueExceptions import TERMINAL_EXCEPTIONS
 
 
-class WorkQueueReqMgrInterface():
+class WorkQueueReqMgrInterface(object):
     """Helper class for ReqMgr interaction"""
+
     def __init__(self, **kwargs):
         if not kwargs.get('logger'):
             import logging
             kwargs['logger'] = logging
         self.logger = kwargs['logger']
-        #TODO: (reqmgr2Only - remove this line when reqmgr is replaced)
+        # TODO: (reqmgr2Only - remove this line when reqmgr is replaced)
         self.reqMgr = RequestManager(kwargs)
-        #this will break all in one test
+        # this will break all in one test
         self.reqMgr2 = ReqMgr(kwargs.get("reqmgr2_endpoint", None))
-        
+
         centralurl = kwargs.get("central_logdb_url", "")
         identifier = kwargs.get("log_reporter", "")
-        
-        # set the thread name before creat the log db. 
+
+        # set the thread name before creat the log db.
         # only sets that when it is not set already
         myThread = threading.currentThread()
         if myThread.getName() == "MainThread":
             myThread.setName(self.__class__.__name__)
-            
+
         self.logdb = LogDB(centralurl, identifier, logger=self.logger)
         self.previous_state = {}
 
     def __call__(self, queue):
         """Synchronize WorkQueue and RequestManager"""
         msg = ''
-        try:    # pull in new work
+        try:  # pull in new work
             work = self.queueNewRequests(queue)
             msg += "New Work: %d\n" % work
         except Exception:
             self.logger.exception("Error caught during RequestManager pull")
 
-        try: # get additional open-running work
+        try:  # get additional open-running work
             extraWork = self.addNewElementsToOpenRequests(queue)
             msg += "Work added: %d\n" % extraWork
         except Exception:
             self.logger.exception("Error caught during RequestManager split")
 
-        try:    # report back to ReqMgr
+        try:  # report back to ReqMgr
             uptodate_elements = self.report(queue)
             msg += "Updated ReqMgr status for: %s\n" % ", ".join([x['RequestName'] for x in uptodate_elements])
         except Exception:
             self.logger.exception("Error caught during RequestManager update")
         else:
-            try:    # Delete finished requests from WorkQueue
+            try:  # Delete finished requests from WorkQueue
                 self.deleteFinishedWork(queue, uptodate_elements)
             except Exception:
                 self.logger.exception("Error caught during work deletion")
@@ -95,20 +94,20 @@ class WorkQueueReqMgrInterface():
             try:
                 try:
                     Lexicon.couchurl(workLoadUrl)
-                except Exception as ex: # can throw many errors e.g. AttributeError, AssertionError etc.
+                except Exception as ex:  # can throw many errors e.g. AttributeError, AssertionError etc.
                     # check its not a local file
                     if not os.path.exists(workLoadUrl):
                         error = WorkQueueWMSpecError(None, "Workflow url validation error: %s" % str(ex))
                         raise error
 
                 self.logger.info("Processing request %s at %s" % (reqName, workLoadUrl))
-                units = queue.queueWork(workLoadUrl, request = reqName, team = team)
+                units = queue.queueWork(workLoadUrl, request=reqName, team=team)
                 self.logdb.delete(reqName, "error", this_thread=True)
             except TERMINAL_EXCEPTIONS as ex:
                 # fatal error - report back to ReqMgr
                 self.logger.error('Permanent failure processing request "%s": %s' % (reqName, str(ex)))
                 self.logger.info("Marking request %s as failed in ReqMgr" % reqName)
-                self.reportRequestStatus(reqName, 'Failed', message = str(ex))
+                self.reportRequestStatus(reqName, 'Failed', message=str(ex))
                 continue
             except (IOError, socket.error, CouchError, CouchConnectionError) as ex:
                 # temporary problem - try again later
@@ -137,19 +136,18 @@ class WorkQueueReqMgrInterface():
             self.logger.info("%s element(s) obtained from RequestManager" % work)
         return work
 
-
     def report(self, queue):
         """Report queue status to ReqMgr."""
         new_state = {}
         uptodate_elements = []
         now = time.time()
 
-        elements = queue.statusInbox(dictKey = "RequestName")
+        elements = queue.statusInbox(dictKey="RequestName")
         if not elements:
             return new_state
 
         for ele in elements:
-            ele = elements[ele][0] # 1 element tuple
+            ele = elements[ele][0]  # 1 element tuple
             try:
                 request = self.reqMgr2.getRequestByNames(ele['RequestName'])
                 if not request:
@@ -166,7 +164,7 @@ class WorkQueueReqMgrInterface():
                     if queue.params.get('reqmgrCompleteGraceTime', -1) > 0:
                         if (now - float(ele.updatetime)) > queue.params['reqmgrCompleteGraceTime']:
                             # have to check all elements are at least running and are old enough
-                            request_elements = queue.statusInbox(WorkflowName = request['RequestName'])
+                            request_elements = queue.statusInbox(WorkflowName=request['RequestName'])
                             if not any([x for x in request_elements if x['Status'] != 'Running' and not x.inEndState()]):
                                 last_update = max([float(x.updatetime) for x in request_elements])
                                 if (now - last_update) > queue.params['reqmgrCompleteGraceTime']:
@@ -174,7 +172,7 @@ class WorkQueueReqMgrInterface():
                                     queue.doneWork(WorkflowName=request['RequestName'])
                                     continue
                     else:
-                        pass # assume workqueue status will catch up later
+                        pass  # assume workqueue status will catch up later
                 elif request['RequestStatus'] in ['aborted', 'force-complete']:
                     queue.cancelWork(WorkflowName=request['RequestName'])
                 # Check consistency of running-open/closed and the element closure status
@@ -187,7 +185,7 @@ class WorkQueueReqMgrInterface():
                     continue
                 elif ele['Status'] not in self._reqMgrToWorkQueueStatus(request['RequestStatus']):
                     self.reportElement(ele)
-                    
+
                 uptodate_elements.append(ele)
             except Exception as ex:
                 msg = 'Error talking to ReqMgr about request "%s": %s'
@@ -200,36 +198,36 @@ class WorkQueueReqMgrInterface():
         """Delete work from queue that is finished in ReqMgr"""
         finished = []
         for element in elements:
-            if self._workQueueToReqMgrStatus(element['Status']) in ('aborted', 'failed', 'completed', 'announced',
-                                                         'epic-FAILED', 'closed-out', 'rejected') \
-                                                         and element.inEndState():
+            if element.inEndState() and self._workQueueToReqMgrStatus(element['Status']) in ('aborted', 'failed', 'completed',
+                                                                                             'announced', 'epic-FAILED',
+                                                                                             'closed-out', 'rejected'):
                 finished.append(element['RequestName'])
         return queue.deleteWorkflows(*finished)
-    
-    def _getRequestsByTeamsAndStatus(self, status, teams = []):
+
+    def _getRequestsByTeamsAndStatus(self, status, teams=[]):
         """
         TODO: now it assumes one team per requests - check whether this assumption is correct
         Check whether we actually use the team for this.
-        Also switch to byteamandstatus couch call instead of 
+        Also switch to byteamandstatus couch call instead of
         """
         requests = self.reqMgr2.getRequestByStatus(status)
-        #Then sort by Team name then sort by Priority
-        #https://docs.python.org/2/howto/sorting.html
+        # Then sort by Team name then sort by Priority
+        # https://docs.python.org/2/howto/sorting.html
         if teams and len(teams) > 0:
             results = {}
             for reqName, value in requests.items():
                 if value["Teams"][0] in teams:
                     results[reqName] = value
-            return results 
+            return results
         else:
-            return requests    
-            
+            return requests
+
     def getAvailableRequests(self, teams):
         """
         Get available requests for the given teams and sort by team and priority
         returns [(team, request_name, request_spec_url)]
         """
-        
+
         tempResults = self._getRequestsByTeamsAndStatus("assigned", teams).values()
         filteredResults = []
         for request in tempResults:
@@ -238,29 +236,29 @@ class WorkQueueReqMgrInterface():
                 self.logdb.delete(request["RequestName"], "error", this_thread=True)
             else:
                 msg = "no team or more than one team (%s) are assigined: %s" % (
-                                    request.get("Teams", None), request["RequestName"])
+                    request.get("Teams", None), request["RequestName"])
                 self.logger.error(msg)
                 self.logdb.post(request["RequestName"], msg, 'error')
-        filteredResults.sort(key = itemgetter('RequestPriority'), reverse = True)
-        filteredResults.sort(key = lambda r: r["Teams"][0])
-        
+        filteredResults.sort(key=itemgetter('RequestPriority'), reverse=True)
+        filteredResults.sort(key=lambda r: r["Teams"][0])
+
         results = [(x["Teams"][0], x["RequestName"], x["RequestWorkflow"]) for x in filteredResults]
-        
+
         return results
 
-    def reportRequestStatus(self, request, status, message = None):
+    def reportRequestStatus(self, request, status, message=None):
         """Change state in RequestManager
            Optionally, take a message to append to the request
         """
         if message:
             self.logdb.post(request, str(message), 'info')
         reqmgrStatus = self._workQueueToReqMgrStatus(status)
-        if reqmgrStatus: # only send known states
+        if reqmgrStatus:  # only send known states
             try:
-                #TODO: try reqmgr1 call if it fails (reqmgr2Only - remove this line when reqmgr is replaced)
+                # TODO: try reqmgr1 call if it fails (reqmgr2Only - remove this line when reqmgr is replaced)
                 self.reqMgr.reportRequestStatus(request, reqmgrStatus)
                 # And replace with this (remove all Exceptins)
-                #self.reqMgr2.updateRequestStatus(request, reqmgrStatus)
+                # self.reqMgr2.updateRequestStatus(request, reqmgrStatus)
             except HTTPException as ex:
                 # If we get an HTTPException of 404 means reqmgr2 request
                 if ex.status == 404:
@@ -275,21 +273,21 @@ class WorkQueueReqMgrInterface():
             except Exception as ex:
                 msg = "%s : fail to update status will try later: %s" % (request, str(ex))
                 self.logdb.post(request, msg, 'warning')
-                raise ex                
+                raise ex
 
-    def markAcquired(self, request, url = None):
+    def markAcquired(self, request, url=None):
         """Mark request acquired"""
         self.reqMgr.putWorkQueue(request, url)
 
     def _workQueueToReqMgrStatus(self, status):
         """Map WorkQueue Status to that reported to ReqMgr"""
-        statusMapping = {'Acquired' : 'acquired',
-                         'Running' : 'running-open',
-                         'Failed' : 'failed',
-                         'Canceled' : 'aborted',
-                         'CancelRequested' : 'aborted',
-                         'Done' : 'completed'
-                         }
+        statusMapping = {'Acquired': 'acquired',
+                         'Running': 'running-open',
+                         'Failed': 'failed',
+                         'Canceled': 'aborted',
+                         'CancelRequested': 'aborted',
+                         'Done': 'completed'
+                        }
         if status in statusMapping:
             # if wq status passed convert to reqmgr status
             return statusMapping[status]
@@ -303,7 +301,7 @@ class WorkQueueReqMgrInterface():
     def _reqMgrToWorkQueueStatus(self, status):
         """Map ReqMgr status to that in a WorkQueue element, it is not a 1-1 relation"""
         statusMapping = {'acquired': ['Acquired'],
-                         'running' : ['Running'],
+                         'running': ['Running'],
                          'running-open': ['Running'],
                          'running-closed': ['Running'],
                          'failed': ['Failed'],
@@ -346,26 +344,26 @@ class WorkQueueReqMgrInterface():
         for reqName in requests:
             try:
                 self.logger.info("Processing request %s" % (reqName))
-                units = queue.addWork(requestName = reqName)
+                units = queue.addWork(requestName=reqName)
                 self.logdb.delete(reqName, 'error', True)
             except (WorkQueueWMSpecError, WorkQueueNoWorkError) as ex:
                 # fatal error - but at least it was split the first time. Log and skip.
-                msg = 'Error adding further work to request "%s". Will try again later' \
-                '\nError: "%s"' % (reqName, str(ex))
+                msg = 'Error adding further work to request "%s". Will try again later' % reqName
+                msg += '\nError: "%s"' % str(ex)
                 self.logger.info(msg)
                 self.logdb.post(reqName, msg, 'error')
                 continue
             except (IOError, socket.error, CouchError, CouchConnectionError) as ex:
                 # temporary problem - try again later
-                msg = 'Error processing request "%s": will try again later.' \
-                '\nError: "%s"' % (reqName, str(ex))
+                msg = 'Error processing request "%s": will try again later.' % reqName
+                msg += '\nError: "%s"' % str(ex)
                 self.logger.info(msg)
                 self.logdb.post(reqName, msg, 'error')
                 continue
             except Exception as ex:
                 # Log exception as it isnt a communication problem
-                msg = 'Error processing request "%s": will try again later.' \
-                '\nSee log for details.\nError: "%s"' % (reqName, str(ex))
+                msg = 'Error processing request "%s": will try again later.' % reqName
+                msg += '\nSee log for details.\nError: "%s"' % str(ex)
                 traceMsg = traceback.format_exc()
                 msg = "%s\n%s" % (msg, traceMsg)
                 self.logger.exception('Unknown error processing %s' % reqName)

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
@@ -1306,18 +1306,6 @@ class WorkQueueTest(WorkQueueTestCase):
         self.assertEqual(len(self.localQueue.statusInbox(Status='Negotiating')), 1)
         self.assertEqual(len(self.localQueue), 1)
 
-    def testFailRequestAfterTimeout(self):
-        """Fail a request if it errors for too long"""
-        # force queue to fail queueing
-        self.queue.params['SplittingMapping'] = 'thisisswrong'
-
-        self.assertRaises(Exception, self.queue.queueWork, self.processingSpec.specUrl())
-        self.assertEqual(self.queue.statusInbox()[0]['Status'], 'Negotiating')
-        # simulate time passing by making timeout negative
-        self.queue.params['QueueRetryTime'] = -100
-        self.assertRaises(Exception, self.queue.queueWork, self.processingSpec.specUrl())
-        self.assertEqual(self.queue.statusInbox()[0]['Status'], 'Failed')
-
     def testSiteStatus(self):
         """Check that we only pull work on sites in Normal status"""
         self.globalQueue.queueWork(self.processingSpec.specUrl())


### PR DESCRIPTION
Initial attempt to fix #7179

Changes are:
- removed the requestname lexicon check. It is/should be done at ReqMgr level
- add more logging and logdb in case exceptions happen during work splitting
- don't fail elements in case they cannot be splitted within `QueueRetryTime`
- If wqe is marked as Failed status, then don't propagate it to the request level

I still have no clue why that wqe was not splitted within 86k secs though...
@ticoann please share any insights you have on this issue.
