### PR TITLE
fixes unit for performance data

### DIFF
--- a/src/python/WMCore/FwkJobReport/XMLParser.py
+++ b/src/python/WMCore/FwkJobReport/XMLParser.py
@@ -4,7 +4,7 @@ _XMLParser_
 
 Read the raw XML output from the cmsRun executable.
 """
-from __future__ import print_function
+from __future__ import print_function, division
 
 
 
@@ -433,8 +433,8 @@ def perfStoreHandler():
         try:
             readTotalMB = storageValues.get("Timing-%s-read-totalMegabytes" % readMethod, 0) \
                           + storageValues.get("Timing-%s-readv-totalMegabytes" % readMethod, 0)
-            readMSecs   = (storageValues.get("Timing-%s-read-totalMsecs" % readMethod, 0)\
-                           + storageValues.get("Timing-%s-readv-totalMsecs" % readMethod, 0))
+            readMSecs   = storageValues.get("Timing-%s-read-totalMsecs" % readMethod, 0) \
+                           + storageValues.get("Timing-%s-readv-totalMsecs" % readMethod, 0)
             totalReads  = storageValues.get("Timing-%s-read-numOperations" % readMethod, 0) \
                           + storageValues.get("Timing-%s-readv-numOperations" % readMethod, 0)
             readMaxMSec = max(storageValues.get("Timing-%s-read-maxMsecs" % readMethod, 0),
@@ -443,14 +443,14 @@ def perfStoreHandler():
                           storageValues.get("Timing-tstoragefile-read-numOperations", 0)
             readCachOps = storageValues.get("Timing-tstoragefile-readViaCache-numSuccessfulOperations", 0)/\
                           storageValues.get("Timing-tstoragefile-read-numOperations", 0)
-            readTotalT  = 1000 * storageValues.get("Timing-tstoragefile-read-totalMSecs", 0)
+            readTotalT  = storageValues.get("Timing-tstoragefile-read-totalMSecs", 0) // 1000
             readNOps    = storageValues.get("Timing-tstoragefile-read-numOperations", 0)
-            writeTime   = storageValues.get("Timing-tstoragefile-write-totalMsecs", 0) * 1000
+            writeTime   = storageValues.get("Timing-tstoragefile-write-totalMsecs", 0) // 1000
             writeTotMB  = storageValues.get("Timing-%s-write-totalMegabytes" % writeMethod, 0) \
                           + storageValues.get("Timing-%s-writev-totalMegabytes" % writeMethod, 0)
 
             if readMSecs > 0:
-                readMBSec = readTotalMB/readMSecs
+                readMBSec = readTotalMB/readMSecs * 1000
             else:
                 readMBSec = 0
             if totalReads > 0:

--- a/test/python/WMCore_t/FwkJobReport_t/Report_t.py
+++ b/test/python/WMCore_t/FwkJobReport_t/Report_t.py
@@ -462,7 +462,7 @@ cms::Exception caught in EventProcessor and rethrown
         self.assertEqual(perf.memory.PeakValueRss, '492.293')
         self.assertEqual(perf.cpu.TotalJobCPU, '9.16361')
         self.assertEqual(perf.storage.writeTotalMB, 5.22226)
-        self.assertEqual(perf.storage.writeTotalSecs, 60317.4)
+        self.assertEqual(perf.storage.writeTotalSecs, 0) #actual value is 0.06
         self.assertEqual(perf.storage.readPercentageOps, 0.98585512216030857)
 
         return


### PR DESCRIPTION
fixes #7185 
@yuyiguo, @juztas, @amaltaro please review.
I change other units  from msec to sec. However this implies the keyword changes in fwjr data.

readMaxMSec -> readMaxSec

I am not sure whether this will break anything or it is too big of a unit. If anyone concerned I can change back to MSec.  
