### PR TITLE
fix typo in sandbox creation code

### DIFF
--- a/src/python/WMCore/WMRuntime/SandboxCreator.py
+++ b/src/python/WMCore/WMRuntime/SandboxCreator.py
@@ -176,7 +176,7 @@ class SandboxCreator:
             tarContent.append((psetTweaksPath, '/PSetTweaks'))
             
             utilsPath = Utils.__path__[0]
-            tarContent.append((psetTweaksPath, '/Utils'))
+            tarContent.append((utilsPath, '/Utils'))
 
         for sb in userSandboxes:
             splitResult = urlparse.urlsplit(sb)


### PR DESCRIPTION
Added the PSetTweaks directory twice and didn't added the Utils directory at all. Fixed it.
