### PR TITLE
add underlining logDB call from component

### DIFF
--- a/src/python/WMCore/Services/LogDB/LogDB.py
+++ b/src/python/WMCore/Services/LogDB/LogDB.py
@@ -13,6 +13,17 @@ import threading
 from WMCore.Services.LogDB.LogDBBackend import LogDBBackend, clean_entry
 from WMCore.Lexicon import splitCouchServiceURL
 
+
+def getLogDBInstanceFromThread():
+    """This function only gets to call when LogDB is instantiated before hand
+       All the WMComponentWorkers instatntiate LogDB automatically 
+    """
+    myThread = threading.currentThread()
+    if not hasattr(myThread, "logdbClient") or not isinstance(myThread.logdbClient, LogDB):
+        #logdb is not set do nothting
+        return None
+    return myThread.logdbClient
+
 class LogDB(object):
     """
     _LogDB_

--- a/src/python/WMCore/WorkerThreads/BaseWorkerThread.py
+++ b/src/python/WMCore/WorkerThreads/BaseWorkerThread.py
@@ -142,6 +142,15 @@ class BaseWorkerThread:
             # to get the right name
             myThread = threading.currentThread()
 
+            if hasattr(self.component.config, "General") and \
+               hasattr(self.component.config.General, "central_logdb_url") and \
+               hasattr(self.component.config, "Agent"):
+                from WMCore.Services.LogDB.LogDB import LogDB
+                myThread.logdbClient = LogDB(self.component.config.General.central_logdb_url, 
+                                         self.component.config.Agent.hostName, logger=logging)
+            else:
+                myThread.logdbClient = None
+                
             if hasattr(self.component.config, "Agent"):
                 if getattr(self.component.config.Agent, "useHeartbeat", True):
                     self.heartbeatAPI.updateWorkerHeartbeat(myThread.getName())


### PR DESCRIPTION
@amaltaro Alan, please review.

Usuage is like following.

get logDB instance anywhere component thread using following function.
getLogDBInstanceFromThread()

start logging the message.  If it is error, we need to make sure to delete it in next cycle if the error is gone
