### PR TITLE
Do not report stage-out se-name to dashboard - 1.0.19v

### DIFF
--- a/src/python/WMCore/Services/Dashboard/DashboardAPI.py
+++ b/src/python/WMCore/Services/Dashboard/DashboardAPI.py
@@ -259,7 +259,7 @@ def reportFailureToDashboard(exitCode, ad=None, stageOutReport=None):
         dashboardInst.apMonSend(params)
     return exitCode
 
-def stageoutPolicyReport(fileToStage, seName, pnn, command, stageOutType, stageOutExit):
+def stageoutPolicyReport(fileToStage, pnn, command, stageOutType, stageOutExit):
     """
     Prepare Dashboard report about stageout policies
     This dashboard report will be used for reporting to dashboard and visualize local/fallback/direct
@@ -267,7 +267,6 @@ def stageoutPolicyReport(fileToStage, seName, pnn, command, stageOutType, stageO
     """
     tempDict = {}
     tempDict['LFN'] = fileToStage['LFN'] if 'LFN' in fileToStage else None
-    tempDict['SEName'] = seName if seName else fileToStage['SEName'] if 'SEName' in fileToStage else None
     tempDict['PNN'] = pnn if pnn else fileToStage['PNN'] if 'PNN' in fileToStage else None
     tempDict['StageOutCommand'] = command if command else fileToStage['command'] if 'command' in fileToStage else None
     tempDict['StageOutType'] = stageOutType

--- a/src/python/WMCore/Storage/StageOutMgr.py
+++ b/src/python/WMCore/Storage/StageOutMgr.py
@@ -9,18 +9,14 @@ use this class as a basic API
 """
 from __future__ import print_function
 
-import os
 
 from WMCore.WMException import WMException
-
 from WMCore.Storage.StageOutError import StageOutFailure
 from WMCore.Storage.StageOutError import StageOutInitError
 from WMCore.Storage.DeleteMgr import DeleteMgr
 from WMCore.Storage.Registry import retrieveStageOutImpl
 from WMCore.Services.Dashboard.DashboardAPI import stageoutPolicyReport
 
-import WMCore.Storage.Backends
-import WMCore.Storage.Plugins
 
 class StageOutMgr:
     """
@@ -196,22 +192,20 @@ class StageOutMgr:
                 self.completedFiles[fileToStage['LFN']] = fileToStage
 
                 print("===> Stage Out Successful: %s" % fileToStage)
-                fileToStage = stageoutPolicyReport(fileToStage, None, None, None, 'LOCAL', 0)
+                fileToStage = stageoutPolicyReport(fileToStage, None, None, 'LOCAL', 0)
                 return fileToStage
             except WMException as ex:
                 lastException = ex
                 print("===> Local Stage Out Failure for file:")
                 print("======>  %s\n" % fileToStage['LFN'])
-                fileToStage = stageoutPolicyReport(fileToStage, self.siteCfg.localStageOut['se-name'],
-                                                   self.siteCfg.localStageOut['phedex-node'],
+                fileToStage = stageoutPolicyReport(fileToStage, self.siteCfg.localStageOut.get('phedex-node', None),
                                                    self.siteCfg.localStageOut['command'], 'LOCAL', 60311)
             except Exception as ex:
                 lastException = StageOutFailure("Error during local stage out",
                                                 error = str(ex))
                 print("===> Local Stage Out Failure for file:\n")
                 print("======>  %s\n" % fileToStage['LFN'])
-                fileToStage = stageoutPolicyReport(fileToStage, self.siteCfg.localStageOut['se-name'],
-                                                   self.siteCfg.localStageOut['phedex-node'],
+                fileToStage = stageoutPolicyReport(fileToStage, self.siteCfg.localStageOut.get('phedex-node', None),
                                                    self.siteCfg.localStageOut['command'], 'LOCAL', 60311)
 
         #  //
@@ -231,10 +225,10 @@ class StageOutMgr:
                     del self.failed[lfn]
 
                 print("===> Stage Out Successful: %s" % fileToStage)
-                fileToStage = stageoutPolicyReport(fileToStage, None, None, None, 'FALLBACK', 0)
+                fileToStage = stageoutPolicyReport(fileToStage, None, None, 'FALLBACK', 0)
                 return fileToStage
             except Exception as ex:
-                fileToStage = stageoutPolicyReport(fileToStage, fallback['se-name'], fallback['phedex-node'],
+                fileToStage = stageoutPolicyReport(fileToStage, fallback.get('phedex-node', None),
                                                    fallback['command'], 'FALLBACK', 60310)
                 lastException = ex
                 continue
@@ -287,7 +281,6 @@ class StageOutMgr:
         Given the lfn and local stage out params, invoke the local stage out
 
         """
-        pnn = self.siteCfg.localStageOut['phedex-node']
         command = self.siteCfg.localStageOut['command']
         options = self.siteCfg.localStageOut.get('option', None)
         pfn = self.searchTFC(lfn)


### PR DESCRIPTION
I stumbled upon this issue while investigating a wmstats issue.

This se-name code was added in 20 Apr, https://github.com/dmwm/WMCore/pull/6810 and it surprises me that we hit it only now, maybe because this problem happened in the exception block (and some sites still have se-name in their site-local-config).

This is the traceback from the job logs:

```
ERROR:root:Exception occured when executing step
ERROR:root:Exception is 'se-name'
ERROR:root:Traceback:
ERROR:root:Traceback (most recent call last):
  File "/data/srv/wmagent/v1.0.19.patch1/sw/slc6_amd64_gcc493/cms/wmagent/1.0.19.patch1/lib/python2.7/site-packages/WMCore/WMSpec/Steps/ExecuteMaster.py", line 140, in doExecution
    executionObject.execute()
  File "/tmp/22098895.1.cms-sl6/glide_EN6oF7/execute/dir_2659860/job/WMCore.zip/WMCore/WMSpec/Steps/Executors/StageOut.py", line 200, in execute
    manager(fileForTransfer)
  File "/tmp/22098895.1.cms-sl6/glide_EN6oF7/execute/dir_2659860/job/WMCore.zip/WMCore/Storage/StageOutMgr.py", line 205, in __call__
    fileToStage = stageoutPolicyReport(fileToStage, self.siteCfg.localStageOut['se-name'],
KeyError: 'se-name'
```

@ticoann @hufnagel please review, it still needs to be tested
