### PR TITLE
Allow Memory to be overwritten for Resubmission specs

### DIFF
--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
@@ -416,7 +416,8 @@ class Assign(WebAPI):
         helper.setBlockCloseSettings(blockCloseMaxWaitTime, blockCloseMaxFiles,
                                      blockCloseMaxEvents, blockCloseMaxSize)
 
-        helper.setMemoryAndCores(kwargs.get("Memory"), kwargs.get("Multicore"))
+        helper.setMemory(kwargs.get("Memory"))
+        helper.setCores(kwargs.get("Multicore"))
         helper.setDashboardActivity(kwargs.get("Dashboard", ""))
         helper.setTaskProperties(kwargs)
 

--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
@@ -368,13 +368,6 @@ def buildWorkloadAndCheckIn(webApi, reqSchema, couchUrl, couchDB, wmstatUrl, clo
     
     helper = WMWorkloadHelper(request['WorkloadSpec'])
     
-    #4378 - ACDC (Resubmission) requests should inherit the Campaign ...
-    # for Resubmission request, there already is previous Campaign set
-    # this call would override it with initial request arguments where
-    # it is not specified, so would become ''
-    if not helper.getCampaign():
-        helper.setCampaign(reqSchema["Campaign"])
-    
     # update request as well for wmstats update
     # there is a better way to do this (passing helper to request but make sure all the information is there) 
     request["Campaign"] = helper.getCampaign()

--- a/src/python/WMCore/ReqMgr/DataStructs/Request.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/Request.py
@@ -61,7 +61,7 @@ def initialize_request_args(request, config, clone=False):
         request["CouchDBName"] = config.couch_config_cache_db
 
         request.setdefault("SoftwareVersions", [])
-        if request["CMSSWVersion"] and (request["CMSSWVersion"] not in request["SoftwareVersions"]):
+        if "CMSSWVersion" in request and request["CMSSWVersion"] not in request["SoftwareVersions"]:
             request["SoftwareVersions"].append(request["CMSSWVersion"])
 
         # TODO

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -635,14 +635,29 @@ class WMWorkloadHelper(PersistencyHelper):
 
         return
 
-    def setMemoryAndCores(self, memory=None, cores=None):
+    def setCores(self, cores):
         """
-        _setMemoryAndCores_
+        _setCores_
 
-        Update memory requirements and number of cores for all tasks in the spec
+        Update number of cores for each task in the spec
         """
+        if not cores:
+            return
+
         for task in self.taskIterator():
             task.setNumberOfCores(cores)
+        return
+
+    def setMemory(self, memory):
+        """
+        _setMemory_
+
+        Update memory requirements for each task in the spec
+        """
+        if not memory:
+            return
+
+        for task in self.taskIterator():
             task.setJobResourceInformation(memoryReq=memory)
         return
 
@@ -1760,7 +1775,8 @@ class WMWorkloadHelper(PersistencyHelper):
         if self._checkKeys(kwargs, "Dashboard"):
             self.setDashboardActivity(kwargs["Dashboard"])
 
-        self.setMemoryAndCores(kwargs.get("Memory"), kwargs.get("Multicore"))
+        self.setMemory(kwargs.get("Memory"))
+        self.setCores(kwargs.get("Multicore"))
 
         # TODO: need to define proper task form maybe kwargs['Tasks']?
         self.setTaskProperties(kwargs)


### PR DESCRIPTION
Fixes #7132 and #6907

Changes are:
- allow requestor to override `TimePerEvent`, `Memory` and `RequestPriority` for ACDC workflows (via script, of course).
- when `Multicore` or `Memory` is overriden, just apply that to processing/production tasks

@ticoann please review. First tests look Ok, but I need to clean up my VM and run it again to make sure it's alright for both reqmgr and reqmgr2
