### PR TITLE
Clean up databases and couch DBs with addCleanup instead of tearDown

### DIFF
--- a/src/python/WMQuality/TestInit.py
+++ b/src/python/WMQuality/TestInit.py
@@ -20,6 +20,8 @@ import tempfile
 import threading
 import traceback
 
+from _mysql_exceptions import OperationalError
+
 from WMCore.Agent.Configuration import Configuration
 from WMCore.Agent.Configuration import loadConfigurationFile
 from WMCore.WMException import WMException
@@ -155,7 +157,11 @@ class TestInit(object):
 
         # Have to check whether or not database is empty
         # If the database is not empty when we go to set the schema, abort!
-        result = self.init.checkDatabaseContents()
+        try:
+            result = self.init.checkDatabaseContents()
+        except OperationalError:
+            logging.debug("Error checking DB contents, assume DB does not exist")
+            return
         if len(result) > 0:
             msg = "Database not empty, cannot set schema !\n"
             msg += str(result)

--- a/test/python/WMCore_t/WorkQueue_t/WMBSHelper_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WMBSHelper_t.py
@@ -54,7 +54,7 @@ class WMBSHelperTest(EmulatedUnitTestCase):
 
         self.testInit = TestInitCouchApp(__file__)
         self.testInit.setLogging()
-        self.testInit.setDatabaseConnection()
+        self.testInit.setDatabaseConnection(destroyAllDatabase=True)
         self.testInit.setupCouch("wmbshelper_t/jobs", "JobDump")
         self.testInit.setupCouch("wmbshelper_t/fwjrs", "FWJRDump")
         self.testInit.setupCouch("config_test", "GroupUser", "ConfigCache")

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
@@ -300,7 +300,7 @@ class WorkQueueTest(WorkQueueTestCase):
 
     def tearDown(self):
         """tearDown"""
-        WorkQueueTestCase.tearDown(self)
+        super(WorkQueueTest, self).tearDown()
         #Delete WMBSAgent config file
         EmulatorSetup.deleteConfig(self.configFile)
         EmulatorHelper.resetEmulators()


### PR DESCRIPTION
Wondering if this has anything to do with the WorkQueue problem @alexanderrichards has been looking at.
