### PR TITLE
Fix a couple Lexicon checks for dataset naming

### DIFF
--- a/src/python/WMCore/Lexicon.py
+++ b/src/python/WMCore/Lexicon.py
@@ -195,10 +195,8 @@ def procdataset(candidate):
     Check for processed dataset name.
     letters, numbers, dashes, underscores.
     """
-    if candidate == '' or not candidate:
-        return candidate
-    if candidate.startswith('None'):
-        raise AssertionError("Acquisition era cannot be None.")
+    if not candidate or candidate.startswith('None'):
+        raise AssertionError("ProcDataset cannot be empty or start with None.")
 
     commonCheck = check(r"%s" % PROCESSED_DS['re'], candidate, PROCESSED_DS['maxLength'])
     prodCheck = check(PROCDATASET_RE, candidate)
@@ -242,8 +240,8 @@ def acqname(candidate):
     Check for acquisition name.
     letters, numbers, underscores.
     """
-    if candidate == '' or not candidate:
-        return candidate
+    if not candidate:
+        raise AssertionError("AcqEra cannot be empty or None.")
     return check(r'[a-zA-Z][a-zA-Z0-9_]*$', candidate)
 
 

--- a/test/python/WMCore_t/Lexicon_t.py
+++ b/test/python/WMCore_t/Lexicon_t.py
@@ -115,6 +115,8 @@ class LexiconTest(unittest.TestCase):
         self.assertRaises(AssertionError, procdataset, 'Drop Table')
         self.assertRaises(AssertionError, procdataset, 'Alter Table')
         self.assertRaises(AssertionError, procdataset, 'CMSSW_3_0_0_pre3_IDEAL_30X_v1')
+        self.assertRaises(AssertionError, procdataset, '')
+        self.assertRaises(AssertionError, procdataset, None)
         longStr = 'a' * 100 + "-" + 'b' * 96 + "-v1"
         self.assertRaises(AssertionError, procdataset, longStr)
 
@@ -183,16 +185,32 @@ class LexiconTest(unittest.TestCase):
         self.assertTrue(procversion('88'))
         return
 
-    def testAcqName(self):
-        """
-        _testAcqName_
 
-        Test the acquisitionEra name verification
+    def testGoodAcqName(self):
+        """
+        _testGoodAcqName_
+
+        Test some valid AcquisitionEra names
+        """
+        self.assertTrue(acqname('a22'))
+        self.assertTrue(acqname('aForReals'))
+        self.assertTrue(acqname('Run1016B'))
+        self.assertTrue(acqname('CMSSW_8_0_16_patch1'))
+        return
+
+    def testBadAcqName(self):
+        """
+        _testBadAcqName_
+
+        Test some invalid AcquisitionEra names
         """
         self.assertRaises(AssertionError, acqname, '*Nothing')
         self.assertRaises(AssertionError, acqname, '1version')
-        self.assertTrue(acqname('a22'))
-        self.assertTrue(acqname('aForReals'))
+        self.assertRaises(AssertionError, acqname, '_version')
+        self.assertRaises(AssertionError, acqname, 'AcqEra Spaced')
+        self.assertRaises(AssertionError, acqname, '')
+        self.assertRaises(AssertionError, acqname, None)
+        self.assertRaises(AssertionError, acqname, 'Run2016B-Terrible')
         return
 
     def testGoodSearchstr(self):


### PR DESCRIPTION
Not really a review, but it fixes https://github.com/dmwm/WMCore/issues/7121

Interesting that pylint cannot recognize the Lexicon functions imported with `import *`...
@ticoann please review and I suggest we put it in testbed this week
@yuyiguo @mmascher @emaszs @hufnagel FYI
