### PR TITLE
Improve submit.sh logging, exitCodes check

### DIFF
--- a/etc/submit.sh
+++ b/etc/submit.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
+# should be a bit nicer than before
+echo "======== WMAgent bootstrap STARTING at $(TZ=GMT date) ========"
+echo "User id:    $(id)"
+echo "Local time: $(date)"
+echo "Hostname:   $(hostname -f)"
+echo "System:     $(uname -a)"
+echo "Arguments:  $@"
+
+# Saving START_TIME and when job finishes END_TIME.
+WMA_MIN_JOB_RUNTIMESECS=300
+START_TIME=$(date +%s)
 
 # On some sites we know there was some problems with environment cleaning
 # with using 'env -i'. To overcome this issue, whenever we start a job, we have
@@ -10,38 +21,81 @@ sed -e 's/^/export /' startup_environment.sh > tmp_env.sh
 mv tmp_env.sh startup_environment.sh
 export JOBSTARTDIR=$PWD
 
-# should be a bit nicer than before
-echo "WMAgent bootstrap : `date -u` : starting..."
 
-# We need to create the expected output file in advance just in case
-# some problem happens during the job bootstrap
-outputFile="Report.0.pkl Report.1.pkl Report.2.pkl Report.3.pkl"
-if [ -n "$_CONDOR_JOB_AD" ]; then
-    outputFile=`grep ^TransferOutput $_CONDOR_JOB_AD | awk -F'=' '{print $2}' | sed 's/\"//g'`
+# Multiple checks are done:
+# 1) Check submit.sh bootstrap exit code.
+#    If it is not 0 sleep WMA_MIN_JOB_RUNTIMESECS and in case it is 0, force to sleep 5 mins total runtime
+#    If this bootstrap script is exiting non 0 exit code, something is wrong on this WN...
+# 2) If Job exited 0, do not sleep any timeout
+# 3) Otherwise, sleep up to WMA_MIN_JOB_RUNTIMESECS seconds of runtime.
+function finish {
+  exitCode=$?
+  echo "======== WMAgent final job runtime checks STARTING at $(TZ=GMT date) ========"
+  if [ $exitCode -ne 0 ];
+  then
+      if [ $WMA_MIN_JOB_RUNTIMESECS -eq 0 ];
+      then
+          WMA_MIN_JOB_RUNTIMESECS=300
+      fi
+  elif [ $jobrc -eq 0 ];
+  then
+      WMA_MIN_JOB_RUNTIMESECS=0
+  fi
+  END_TIME=$(date +%s)
+  DIFF_TIME=$((END_TIME-START_TIME))
+  echo "$(TZ=GMT date): Job Runtime in seconds: " $DIFF_TIME
+  echo "$(TZ=GMT date): Job bootstrap script exited: " $exitCode
+  echo "$(TZ=GMT date): Job execution exited: " $jobrc
+  if [ $DIFF_TIME -lt $WMA_MIN_JOB_RUNTIMESECS ];
+  then
+    SLEEP_TIME=$((WMA_MIN_JOB_RUNTIMESECS - DIFF_TIME))
+    echo "$(TZ=GMT date): Job runtime is less than $WMA_MIN_JOB_RUNTIMESECS seconds. Sleeping " $SLEEP_TIME
+    sleep $SLEEP_TIME
+  fi
+  echo -e "======== WMAgent final job runtime checks FINISHED at $(TZ=GMT date) ========\n"
+}
+# Trap all exits and execute finish function
+trap finish EXIT
+
+
+if [ "X$_CONDOR_JOB_AD" != "X" ];
+then
+   outputFile=`grep ^TransferOutput $_CONDOR_JOB_AD | awk -F'=' '{print $2}' | sed 's/\"//g'`
+   WMA_SiteName=`grep '^MachineAttrGLIDEIN_CMSSite0 =' $_CONDOR_JOB_AD | tr -d '"' | awk '{print $NF;}'`
+   echo "Site name:  $WMA_SiteName"
+   echo "======== HTCondor jobAds start at $(TZ=GMT date) ========"
+   while read i; do
+       echo "  $i"
+   done < $_CONDOR_JOB_AD | sort
+   echo -e "======== HTCondor jobAds finished at $(TZ=GMT date) ========\n"
 fi
-if [ -z $outputFile ]; then
+
+# We need to create the expected output files in advance just in case
+# some problem happens during the job bootstrap
+if [ -z "$outputFile" ]; then
     outputFile="Report.0.pkl Report.1.pkl Report.2.pkl Report.3.pkl"
 fi
 touch $outputFile
 
-# validate arguments
+
+echo "======== WMAgent validate arguments starting at $(TZ=GMT date) ========"
 if [ -z "$1" ]
 then
-    echo "WMAgent bootstrap : `date -u` : Error: A sandbox must be specified" >&2
+    echo "WMAgent bootstrap: Error: A sandbox must be specified" >&2
     exit 1
 fi
 if [ -z "$2" ]
 then
-    echo "WMAgent bootstrap : `date -u` : Error: An index must be specified" >&2
+    echo "WMAgent bootstrap: Error: An index must be specified" >&2
     exit 1
 fi
-
 # assign arguments
 SANDBOX=$1
 INDEX=$2
-echo "WMAgent bootstrap : `date -u` : arguments validated..."
+echo -e "======== WMAgent validate arguments finished at $(TZ=GMT date) ========\n"
 
-### source the CMSSW stuff using either OSG or LCG style entry env. variables
+
+echo "======== WMAgent CMS environment load starting at $(TZ=GMT date) ========"
 if [ -f "$VO_CMS_SW_DIR"/cmsset_default.sh ]
 then  #   LCG style --
     . $VO_CMS_SW_DIR/cmsset_default.sh
@@ -56,13 +110,15 @@ then  # ok, lets call it CVMFS then
     export CVMFS=/cvmfs/cms.cern.ch
     . $CVMFS/cmsset_default.sh
 else
-    echo "WMAgent bootstrap : `date -u` : Error: VO_CMS_SW_DIR, OSG_APP, CVMFS environment variables were not set and /cvmfs is not present" >&2
-    echo "WMAgent bootstrap : `date -u` : Error: Because of this, we can't load CMSSW. Not good." >&2
+    echo "WMAgent bootstrap: Error: VO_CMS_SW_DIR, OSG_APP, CVMFS environment variables were not set and /cvmfs is not present" >&2
+    echo "WMAgent bootstrap: Error: Because of this, we can't load CMSSW. Not good." >&2
     exit 2
 fi
+echo "WMAgent bootstrap: WMAgent thinks it found the correct CMSSW setup script"
+echo -e "======== WMAgent CMS environment load finished at $(TZ=GMT date) ========\n"
 
-echo "WMAgent bootstrap : `date -u` : WMAgent thinks it found the correct CMSSW setup script"
 
+echo "======== WMAgent Python boostrap starting at $(TZ=GMT date) ========"
 if [ -e "$VO_CMS_SW_DIR"/COMP/slc6_amd64_gcc493/external/python/2.7.6/etc/profile.d/init.sh ]
 then
     . "$VO_CMS_SW_DIR"/COMP/slc6_amd64_gcc493/external/python/2.7.6/etc/profile.d/init.sh
@@ -73,41 +129,48 @@ elif [ -e "$CVMFS"/COMP/slc6_amd64_gcc493/external/python/2.7.6/etc/profile.d/in
 then
     . "$CVMFS"/COMP/slc6_amd64_gcc493/external/python/2.7.6/etc/profile.d/init.sh
 else
-    echo "WMAgent bootstrap : `date -u` : Error: OSG_APP, VO_CMS_SW_DIR, CVMFS, /cvmfs/cms.cern.ch environment does not contain init.sh" >&2
-    echo "WMAgent bootstrap : `date -u` : Error: Because of this, we can't load CMSSW. Not good." >&2
+    echo "WMAgent bootstrap: Error: OSG_APP, VO_CMS_SW_DIR, CVMFS, /cvmfs/cms.cern.ch environment does not contain init.sh" >&2
+    echo "WMAgent bootstrap: Error: Because of this, we can't load CMSSW. Not good." >&2
     exit 4
 fi
 command -v python2 > /dev/null
 rc=$?
 if [[ $rc != 0 ]]
 then
-    echo "WMAgent bootstrap : `date -u` : Error: Python2.6 isn't available on this worker node." >&2
-    echo "WMAgent bootstrap : `date -u` : Error: WMCore/WMAgent REQUIRES python2" >&2
+    echo "WMAgent bootstrap: Error: python2 isn't available on this worker node." >&2
+    echo "WMAgent bootstrap: Error: WMCore/WMAgent REQUIRES python2" >&2
     exit 3	
 else
-    echo "WMAgent bootstrap : `date -u` : found python2 at.."
+    echo "WMAgent bootstrap: found python2 at.."
     echo `which python2`
 fi
+echo -e "======== WMAgent Python boostrap finished at $(TZ=GMT date) ========\n"
 
+
+echo "======== WMAgent Unpack the job starting at $(TZ=GMT date) ========"
 # Should be ready to unpack and run this
-echo "WMAgent bootstrap : `date -u` : is unpacking the job..."
 python2 Unpacker.py --sandbox=$SANDBOX --package=JobPackage.pkl --index=$INDEX
 
 cd job
 export WMAGENTJOBDIR=$PWD
 export PYTHONPATH=$PYTHONPATH:$PWD/WMCore.zip:$PWD
-echo "WMAgent bootstrap : `date -u` :    Hostname: `hostname -f`"
-echo "WMAgent bootstrap : `date -u` :    Username: `id`"
-echo "WMAgent bootstrap : `date -u` : Environemnt:"
-env
-echo "WMAgent bootstrap : `date -u` : WMAgent is now running the job..."
+echo -e "======== WMAgent Unpack the job finished at $(TZ=GMT date) ========\n"
+
+echo "======== Current environment dump starting ========"
+for i in `env`; do
+  echo "  $i"
+done
+echo -e "======== Current environment dump finished ========\n"
+
+echo "======== WMAgent Run the job starting at $(TZ=GMT date) ========"
 python2 Startup.py
 jobrc=$?
-echo "WMAgent bootstrap : `date -u` : WMAgent finished the job, is copying the pickled report"
+echo -e "======== WMAgent Run the job FINISH at $(TZ=GMT date) ========\n"
+
+
+echo "WMAgent bootstrap: WMAgent finished the job, it's copying the pickled report"
 cp WMTaskSpace/Report*.pkl ../
 ls -l WMTaskSpace
 ls -l WMTaskSpace/*
-echo "WMAgent bootstrap : `date -u` : WMAgent is finished. The job had an exit code of $jobrc "
+echo -e "======== WMAgent bootstrap FINISH at $(TZ=GMT date) ========\n"
 exit 0
-
-

--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/Assign.py
@@ -416,7 +416,8 @@ class Assign(WebAPI):
         helper.setBlockCloseSettings(blockCloseMaxWaitTime, blockCloseMaxFiles,
                                      blockCloseMaxEvents, blockCloseMaxSize)
 
-        helper.setMemoryAndCores(kwargs.get("Memory"), kwargs.get("Multicore"))
+        helper.setMemory(kwargs.get("Memory"))
+        helper.setCores(kwargs.get("Multicore"))
         helper.setDashboardActivity(kwargs.get("Dashboard", ""))
         helper.setTaskProperties(kwargs)
 

--- a/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
+++ b/src/python/WMCore/HTTPFrontEnd/RequestManager/ReqMgrWebTools.py
@@ -368,13 +368,6 @@ def buildWorkloadAndCheckIn(webApi, reqSchema, couchUrl, couchDB, wmstatUrl, clo
     
     helper = WMWorkloadHelper(request['WorkloadSpec'])
     
-    #4378 - ACDC (Resubmission) requests should inherit the Campaign ...
-    # for Resubmission request, there already is previous Campaign set
-    # this call would override it with initial request arguments where
-    # it is not specified, so would become ''
-    if not helper.getCampaign():
-        helper.setCampaign(reqSchema["Campaign"])
-    
     # update request as well for wmstats update
     # there is a better way to do this (passing helper to request but make sure all the information is there) 
     request["Campaign"] = helper.getCampaign()

--- a/src/python/WMCore/ReqMgr/DataStructs/Request.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/Request.py
@@ -61,7 +61,7 @@ def initialize_request_args(request, config, clone=False):
         request["CouchDBName"] = config.couch_config_cache_db
 
         request.setdefault("SoftwareVersions", [])
-        if request["CMSSWVersion"] and (request["CMSSWVersion"] not in request["SoftwareVersions"]):
+        if "CMSSWVersion" in request and request["CMSSWVersion"] not in request["SoftwareVersions"]:
             request["SoftwareVersions"].append(request["CMSSWVersion"])
 
         # TODO

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -635,14 +635,29 @@ class WMWorkloadHelper(PersistencyHelper):
 
         return
 
-    def setMemoryAndCores(self, memory=None, cores=None):
+    def setCores(self, cores):
         """
-        _setMemoryAndCores_
+        _setCores_
 
-        Update memory requirements and number of cores for all tasks in the spec
+        Update number of cores for each task in the spec
         """
+        if not cores:
+            return
+
         for task in self.taskIterator():
             task.setNumberOfCores(cores)
+        return
+
+    def setMemory(self, memory):
+        """
+        _setMemory_
+
+        Update memory requirements for each task in the spec
+        """
+        if not memory:
+            return
+
+        for task in self.taskIterator():
             task.setJobResourceInformation(memoryReq=memory)
         return
 
@@ -1760,7 +1775,8 @@ class WMWorkloadHelper(PersistencyHelper):
         if self._checkKeys(kwargs, "Dashboard"):
             self.setDashboardActivity(kwargs["Dashboard"])
 
-        self.setMemoryAndCores(kwargs.get("Memory"), kwargs.get("Multicore"))
+        self.setMemory(kwargs.get("Memory"))
+        self.setCores(kwargs.get("Multicore"))
 
         # TODO: need to define proper task form maybe kwargs['Tasks']?
         self.setTaskProperties(kwargs)


### PR DESCRIPTION
a) Make sure script runtime is not less than set by a scheduler. Also it will force to sleep up to 5mins if this bootstrap script fails, which mainly means something is wrong with this WN or transferring files to it failed for unknown reason. Re-sending other jobs so fast to same worker node lead to same failure most often. if this MIN_JOB_RUNTIME_TIME_SECONDS is not set, will use 0. If Job exited 0 and bootstrap script also 0, it will not sleep any time and will exit.
b) Improve logging and separate what is where... Also to addition print the condor job ad content for debug reasons and also print environment more nicely.
c) output file variable is a string separated with spaces. Each of word is treated as a separate argument, so this shows a failure: `[: -eq: unary operator expected`

So this would be one of the steps for better debugging, one of the items here: https://github.com/dmwm/WMCore/issues/7224
Also I would propose to add a check on 68 & 137 jobrc code and print some system information, like ulimit, disk space, memory usage, but this would overload this pull request.
