### PR TITLE
keyerror %d_ExeWCTime in DashboardInterface

### DIFF
--- a/src/python/WMCore/WMRuntime/DashboardInterface.py
+++ b/src/python/WMCore/WMRuntime/DashboardInterface.py
@@ -335,8 +335,8 @@ class DashboardInfo():
                                                         'TotalJobCPU', 0)
                 self.WrapperCPUTime += float(data['%d_ExeCPUTime'
                                                         % self.stepCount])
-
-        self.WrapperWCTime += data['%d_ExeWCTime' % self.stepCount]
+        if str('%d_ExeWCTime' % self.stepCount) in data.keys():
+            self.WrapperWCTime += data['%d_ExeWCTime' % self.stepCount]
         self.lastStep = helper.name()
 
         self.publish(data = data)


### PR DESCRIPTION
I have seen this printed for a long long time already... Lets fix it.

```
ERROR:root:Traceback (most recent call last):
  File "/condor/condor/dir_3852736/glide_yXLdYX/execute/dir_165130/job/WMCore.zip/WMCore/WMRuntime/Monitors/DashboardMonitor.py", line 135, in stepEnd
    stepReport = stepReport)
  File "/condor/condor/dir_3852736/glide_yXLdYX/execute/dir_165130/job/WMCore.zip/WMCore/WMRuntime/DashboardInterface.py", line 339, in stepEnd
    self.WrapperWCTime += data['%d_ExeWCTime' % self.stepCount]
KeyError: '2_ExeWCTime'
```
