### PR TITLE
Gfal2 plugin is too much verbose...

### DIFF
--- a/src/python/WMCore/Storage/Backends/GFAL2Impl.py
+++ b/src/python/WMCore/Storage/Backends/GFAL2Impl.py
@@ -28,8 +28,8 @@ class GFAL2Impl(StageOutImpl):
         # mixed environment with COMP and system python.
         # GFAL2 is not build under COMP environment and it had failures with mixed environment.
         self.setups = "env -i X509_USER_PROXY=$X509_USER_PROXY JOBSTARTDIR=$JOBSTARTDIR bash -c '%s'"
-        self.removeCommand = self.setups % '. $JOBSTARTDIR/startup_environment.sh; printenv; date; gfal-rm -vvv -t 600 %s '
-        self.copyCommand = self.setups % '. $JOBSTARTDIR/startup_environment.sh; printenv; date; gfal-copy -vvv -t 2400 -T 2400 -p %(checksum)s %(options)s %(source)s %(destination)s'
+        self.removeCommand = self.setups % '. $JOBSTARTDIR/startup_environment.sh; date; gfal-rm -t 600 %s '
+        self.copyCommand = self.setups % '. $JOBSTARTDIR/startup_environment.sh; date; gfal-copy -t 2400 -T 2400 -p %(checksum)s %(options)s %(source)s %(destination)s'
 
 
     def createFinalPFN(self, pfn):
@@ -77,7 +77,6 @@ class GFAL2Impl(StageOutImpl):
         handle file remove using gfal-rm
 
         gfal-rm options used:
-          -vvv most verbose mode
           -t   global timeout for the execution of the command.
                Command is interrupted if time expires before it finishes
         """
@@ -93,7 +92,6 @@ class GFAL2Impl(StageOutImpl):
         Build a gfal-copy command
 
         gfal-copy options used:
-          -vvv most verbose mode
           -t   maximum time for the operation to terminate
           -T   global timeout for the transfer operation
           -p   if the destination directory does not exist, create it

--- a/test/python/WMCore_t/Storage_t/Backends_t/GFAL2Impl_t.py
+++ b/test/python/WMCore_t/Storage_t/Backends_t/GFAL2Impl_t.py
@@ -15,9 +15,9 @@ class GFAL2ImplTest(unittest.TestCase):
     def testInit(self):
         testGFAL2Impl = GFAL2Impl()
         removeCommand = "env -i X509_USER_PROXY=$X509_USER_PROXY JOBSTARTDIR=$JOBSTARTDIR bash -c " \
-                        "'. $JOBSTARTDIR/startup_environment.sh; printenv; date; gfal-rm -vvv -t 600 %s '"
+                        "'. $JOBSTARTDIR/startup_environment.sh; date; gfal-rm -t 600 %s '"
         copyCommand = "env -i X509_USER_PROXY=$X509_USER_PROXY JOBSTARTDIR=$JOBSTARTDIR bash -c '" \
-                      ". $JOBSTARTDIR/startup_environment.sh; printenv; date; gfal-copy -vvv -t 2400 -T 2400 " \
+                      ". $JOBSTARTDIR/startup_environment.sh; date; gfal-copy -t 2400 -T 2400 " \
                       "-p %(checksum)s %(options)s %(source)s %(destination)s'"
         self.assertEqual(removeCommand, testGFAL2Impl.removeCommand)
         self.assertEqual(copyCommand, testGFAL2Impl.copyCommand)


### PR DESCRIPTION
Removing printenv, as it will always use job startup environment and also remove -vvv, as it is too much verbose... In case there is an issue on site, this can be turned on through site-local-config option.
