### PR TITLE
Inherit MaxRSS and Sitelists for ReqMgr2 ACDCs

### DIFF
--- a/src/couchapps/WMStats/_attachments/js/ViewModels/WMStats.ViewModel.js
+++ b/src/couchapps/WMStats/_attachments/js/ViewModels/WMStats.ViewModel.js
@@ -449,6 +449,7 @@ WMStats.ViewModel = (function (){
             summary.MinMergeSize = requestInfo.MinMergeSize;
             summary.MaxMergeSize = requestInfo.MaxMergeSize;
             summary.MaxMergeEvents = requestInfo.MaxMergeEvents;
+            summary.MaxRSS = requestInfo.MaxRSS;
             summary.MaxVSize = requestInfo.MaxVSize;
             summary.BlockCloseMaxWaitTime = requestInfo.BlockCloseMaxWaitTime;
             summary.BlockCloseMaxFiles = requestInfo.BlockCloseMaxFiles;

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
@@ -1907,6 +1907,7 @@ WMStats.ViewModel = (function (){
             summary.MinMergeSize = requestInfo.MinMergeSize;
             summary.MaxMergeSize = requestInfo.MaxMergeSize;
             summary.MaxMergeEvents = requestInfo.MaxMergeEvents;
+            summary.MaxRSS = requestInfo.MaxRSS;
             summary.MaxVSize = requestInfo.MaxVSize;
             summary.BlockCloseMaxWaitTime = requestInfo.BlockCloseMaxWaitTime;
             summary.BlockCloseMaxFiles = requestInfo.BlockCloseMaxFiles;

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
@@ -1999,6 +1999,7 @@ WMStats.ViewModel = (function (){
             summary.MinMergeSize = requestInfo.MinMergeSize;
             summary.MaxMergeSize = requestInfo.MaxMergeSize;
             summary.MaxMergeEvents = requestInfo.MaxMergeEvents;
+            summary.MaxRSS = requestInfo.MaxRSS;
             summary.MaxVSize = requestInfo.MaxVSize;
             summary.BlockCloseMaxWaitTime = requestInfo.BlockCloseMaxWaitTime;
             summary.BlockCloseMaxFiles = requestInfo.BlockCloseMaxFiles;

--- a/src/python/WMCore/ReqMgr/Tools/cms.py
+++ b/src/python/WMCore/ReqMgr/Tools/cms.py
@@ -82,6 +82,20 @@ def sites():
         raise Exception(msg)
     return sites
 
+
+def pnns():
+    """
+    Returns all PhEDEx node names, excluding Buffer endpoints
+    """
+    try:
+        sitedb = SiteDBJSON()
+        pnns = sorted(sitedb.getAllPhEDExNodeNames(excludeBuffer=True))
+    except Exception as exc:
+        msg = "ERROR: Could not retrieve PNNs from SiteDB, reason: %s" % str(exc)
+        raise Exception(msg)
+    return pnns
+
+
 def site_white_list():
     "site white list, default all T1"
     t1_sites = [s for s in sites() if s.startswith('T1_')]
@@ -135,9 +149,7 @@ def web_ui_names():
             "TimePerEvent": "TimePerEvent (seconds)",
             "OpenRunningTimeout": "OpenRunningTimeout (deprecated)",
             "SizePerEvent": "SizePerEvent (KBytes)",
-            "ScramArch": "Architecture",
             "Memory": "Memory (MBytes)",
-            "RequestString": "RequestString (optional)",
             "BlockCloseMaxSize": "BlockCloseMaxSize (Bytes)",
             "SoftTimeout": "SoftTimeout (seconds)",
             }

--- a/src/python/WMCore/ReqMgr/Web/ReqMgrService.py
+++ b/src/python/WMCore/ReqMgr/Web/ReqMgrService.py
@@ -27,7 +27,7 @@ from WMCore.ReqMgr.Web.tools import exposecss, exposejs, TemplatedPage
 from WMCore.ReqMgr.Web.utils import json2table, json2form, genid, checkargs, tstamp, sort, reorder_list
 from WMCore.ReqMgr.Utils.url_utils import getdata
 from WMCore.ReqMgr.Tools.cms import releases, architectures
-from WMCore.ReqMgr.Tools.cms import web_ui_names, sites
+from WMCore.ReqMgr.Tools.cms import web_ui_names, sites, pnns
 from WMCore.ReqMgr.Tools.cms import lfn_bases, lfn_unmerged_bases
 from WMCore.ReqMgr.Tools.cms import site_white_list, site_black_list
 
@@ -322,8 +322,10 @@ class ReqMgrService(TemplatedPage):
         sortby = kwds.get('sort', 'status')
         docs = [r for r in sort(docs, sortby)]
         misc_json = {'RequestPriority': 5000,
-                     'CMSSW Releases': releases(),
-                     'CMSSW architectures': architectures(),
+                     'CMSSWVersion': releases(),
+                     'ScramArch': architectures(),
+                     'SiteWhitelist': sites(),
+                     'SiteBlacklist': sites(),
                      'SubscriptionPriority': ['Low', 'Normal', 'High'],
                      'CustodialSubType': ['Move', 'Replica'],
                      'NonCustodialSubType': ['Move', 'Replica'],
@@ -456,18 +458,23 @@ class ReqMgrService(TemplatedPage):
                 filteredDoc = {}
                 for prop in visible_attrs:
                     filteredDoc[prop] = doc.get(prop, "")
-            
-            prop_value_map = {'CMSSW Releases': releases(),
+
+            listPNNs = pnns()
+            prop_value_map = {'CMSSWVersion': releases(),
+                              'SiteWhitelist': sites(),
+                              'SiteBlacklist': sites(),
                               'SubscriptionPriority': ['Low', 'Normal', 'High'],
+                              'CustodialSites': listPNNs,
                               'CustodialSubType': ['Move', 'Replica'],
+                              'NonCustodialSites': listPNNs,
                               'NonCustodialSubType': ['Move', 'Replica'],
+                              'AutoApproveSubscriptionSites': listPNNs,
                               'MergedLFNBase': lfn_bases(),
                               'UnmergedLFNBase': lfn_unmerged_bases(),
                               'Team': self.getTeams()}
             
             for prop in prop_value_map:
                 if prop in filteredDoc:
-                    # filteredDoc[prop shoulbe str
                     filteredDoc[prop] = reorder_list(prop_value_map[prop], filteredDoc[prop])
                     
             content = self.templatepage('doc', title=title, status=status, name=name, rid=rid,

--- a/src/python/WMCore/ReqMgr/Web/utils.py
+++ b/src/python/WMCore/ReqMgr/Web/utils.py
@@ -90,12 +90,15 @@ def json2table(jsondata, web_ui_map, visible_attrs=None, selected=False):
                         % (key, json.dumps(val))
             else:
                 sel = "<select name=\"%s\">" % key
+                MULTI_SELECTION_KEYS = ['SiteWhitelist', 'SiteBlacklist', 'AutoApproveSubscriptionSites']
+                if key in MULTI_SELECTION_KEYS:
+                    sel = "<select name=\"%s\" multiple>" % key
                 if selected and len(val) > 0:
                     selected_val = val[0]
                 else:
                     selected_val = None
                 values = sorted(val)
-                if  key in ['releases', 'software_releases', 'CMSSWVersion', 'ScramArch']:
+                if  key in ['CMSSWVersion', 'ScramArch']:
                     values.reverse()
                 for item in values:
                     if selected and selected_val == item:
@@ -278,6 +281,8 @@ def reorder_list(org_list, first):
     move the first in front of the list
     if not, add first to the list
     """
+    if first and isinstance(first, list):
+        first = first[0]
     new_list = list(org_list)
     try:
         i = new_list.index(first)
@@ -285,4 +290,3 @@ def reorder_list(org_list, first):
     except ValueError:
         new_list.insert(0, first)
     return new_list
-        


### PR DESCRIPTION
I found some issues in my VM and this PR tries to address them, as:
- `MaxRSS` was not getting inherited for Resubmission wfs;
- when `CustodialSites`, `NonCustodialSites` or `AutoApproveSubscriptionSites` is inherited. The dropdown menu comes already selected and you cannot change that selection (only that option available).
- provides a multiple dropdown menu for `SiteWhitelist` and `SiteBlacklist`, instead of an input text box.

This does not fix the site list inherited for Resubmission though
