### PR TITLE
Remove running state from ReqMgr2 UI

### DIFF
--- a/src/python/WMCore/ReqMgr/DataStructs/RequestStatus.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/RequestStatus.py
@@ -22,9 +22,6 @@ REQUEST_STATE_TRANSITION = {
                  "acquired",
                  "aborted"],
                              
-    "running": ["completed",
-                "aborted"], # manual transition
-                             
     "running-open": ["running-closed",
                      "aborted"], # manual transition
                              
@@ -63,7 +60,6 @@ ACTIVE_STATUS = ["new",
                  "assignment-approved",
                  "assigned",
                  "acquired",
-                 "running",
                  "running-open",
                  "running-closed",
                  "failed",
@@ -92,7 +88,6 @@ ALLOWED_ACTIONS_FOR_STATUS = {
                                         "AutoApproveSubscriptionSites", "SubscriptionPriority"],
                  "assigned": ["RequestPriority"],
                  "acquired": ["RequestPriority"],
-                 "running": ["RequestPriority"],
                  "running-open": ["RequestPriority"],
                  "running-closed": ["RequestPriority"],
                  "failed": [],

--- a/src/python/WMCore/ReqMgr/DataStructs/RequestStatus.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/RequestStatus.py
@@ -7,54 +7,54 @@ Definition of valid status values for a request and valid status transitions.
 REQUEST_START_STATE = "new"
 REQUEST_STATE_TRANSITION = {
     REQUEST_START_STATE: [REQUEST_START_STATE,
-            "assignment-approved",
-            "rejected"],
-    
-    "assignment-approved": ["assigned", #manual transition
-                            "rejected"], #manual transition
-                             
+                          "assignment-approved",
+                          "rejected"],
+
+    "assignment-approved": ["assigned",  # manual transition
+                            "rejected"],  # manual transition
+
     "assigned": ["acquired",
-                 "aborted", # manual transition
+                 "aborted",  # manual transition
                  "failed"],
-                                                          
+
     "acquired": ["running-open",
                  "completed",
                  "acquired",
                  "aborted"],
-                             
+
     "running-open": ["running-closed",
-                     "aborted"], # manual transition
-                             
-    "running-closed": ["force-complete", # manual transition
+                     "aborted"],  # manual transition
+
+    "running-closed": ["force-complete",  # manual transition
                        "completed",
-                       "aborted"], # manual transition
-    
-    "force-complete" : ["completed"],
-                             
+                       "aborted"],  # manual transition
+
+    "force-complete": ["completed"],
+
     "failed": ["rejected",  # manual transition
-               "assigned"], # manual transition
-                             
+               "assigned"],  # manual transition
+
     "completed": ["completed",
                   "closed-out",
-                  "rejected"], # manual transition
-                             
-    "closed-out": ["announced", "rejected"], # manual transition
-    
+                  "rejected"],  # manual transition
+
+    "closed-out": ["announced", "rejected"],  # manual transition
+
     "announced": ["rejected", "normal-archived"],
-    
+
     "aborted": ["aborted-completed"],
-                             
+
     "aborted-completed": ["aborted-archived"],
-    
+
     "rejected": ["rejected-archived"],
-                             
+
     # final status
     "normal-archived": ["rejected-archived"],
-    
+
     "aborted-archived": [],
-    
+
     "rejected-archived": []
-    }
+}
 
 ACTIVE_STATUS = ["new",
                  "assignment-approved",
@@ -74,34 +74,34 @@ ACTIVE_STATUS = ["new",
 # if the state is not defined here (new) allows all the property to get
 # states in the key is the source states (need to define source states instead of destination states for GUI update) 
 ALLOWED_ACTIONS_FOR_STATUS = {
-                 "new": ["RequestPriority"],
-                 "assignment-approved":["RequestPriority", "Team", "SiteWhitelist", "SiteBlacklist",
-                                        "AcquisitionEra", "ProcessingString", "ProcessingVersion", 
-                                        "Dashboard", "MergedLFNBase", "MaxRSS", "TrustSitelists", 
-                                        "UnmergedLFNBase", "MinMergeSize", "MaxMergeSize",
-                                        "MaxMergeEvents", "MaxVSize", 
-                                        "BlockCloseMaxWaitTime", 
-                                        "BlockCloseMaxFiles", "BlockCloseMaxEvents", "BlockCloseMaxSize",
-                                        "SoftTimeout", "GracePeriod",
-                                        "TrustPUSitelists", "CustodialSites", "CustodialSubType", 
-                                        "NonCustodialSites", "NonCustodialSubType", 
-                                        "AutoApproveSubscriptionSites", "SubscriptionPriority"],
-                 "assigned": ["RequestPriority"],
-                 "acquired": ["RequestPriority"],
-                 "running-open": ["RequestPriority"],
-                 "running-closed": ["RequestPriority"],
-                 "failed": [],
-                 "force-complete": [],
-                 "completed": [],
-                 "closed-out": [],
-                 "announced": [],
-                 "aborted": [],
-                 "aborted-completed": [],
-                 "rejected": [],
-                 "normal-archived": [],
-                 "aborted-archived": [],
-                 "rejected-archived": [],
-                }
+    "new": ["RequestPriority"],
+    "assignment-approved": ["RequestPriority", "Team", "SiteWhitelist", "SiteBlacklist",
+                            "AcquisitionEra", "ProcessingString", "ProcessingVersion",
+                            "Dashboard", "MergedLFNBase", "MaxRSS", "TrustSitelists",
+                            "UnmergedLFNBase", "MinMergeSize", "MaxMergeSize",
+                            "MaxMergeEvents", "MaxVSize",
+                            "BlockCloseMaxWaitTime",
+                            "BlockCloseMaxFiles", "BlockCloseMaxEvents", "BlockCloseMaxSize",
+                            "SoftTimeout", "GracePeriod",
+                            "TrustPUSitelists", "CustodialSites", "CustodialSubType",
+                            "NonCustodialSites", "NonCustodialSubType",
+                            "AutoApproveSubscriptionSites", "SubscriptionPriority"],
+    "assigned": ["RequestPriority"],
+    "acquired": ["RequestPriority"],
+    "running-open": ["RequestPriority"],
+    "running-closed": ["RequestPriority"],
+    "failed": [],
+    "force-complete": [],
+    "completed": [],
+    "closed-out": [],
+    "announced": [],
+    "aborted": [],
+    "aborted-completed": [],
+    "rejected": [],
+    "normal-archived": [],
+    "aborted-archived": [],
+    "rejected-archived": [],
+}
 
 # list of destiantion states which doesn't allow any additional arguement update
 STATES_ALLOW_ONLY_STATE_TRANSITION = [key for key, val in ALLOWED_ACTIONS_FOR_STATUS.iteritems() if len(val) == 0]
@@ -109,14 +109,16 @@ STATES_ALLOW_ONLY_STATE_TRANSITION = [key for key, val in ALLOWED_ACTIONS_FOR_ST
 # is name of the status
 REQUEST_STATE_LIST = REQUEST_STATE_TRANSITION.keys()
 
+
 def check_allowed_transition(preState, postState):
     stateList = REQUEST_STATE_TRANSITION.get(preState, [])
     if postState in stateList:
         return True
     else:
         return False
-    
-def get_modifiable_properties(status = None):
+
+
+def get_modifiable_properties(status=None):
     """
     returns mondifiable property list by status.
     if status is not defined return dictionarly of all the status and property list
@@ -126,6 +128,7 @@ def get_modifiable_properties(status = None):
         return ALLOWED_ACTIONS_FOR_STATUS.get(status, 'all_attributes')
     else:
         return ALLOWED_ACTIONS_FOR_STATUS
+
 
 def get_protected_properties():
     """


### PR DESCRIPTION
It has been a long time (~2 years?) since we had the last `running` workflow in the system. I suggest to just remove it then.

@ticoann please review.
