### PR TITLE
Validate dashboard activity

### DIFF
--- a/src/python/WMCore/Lexicon.py
+++ b/src/python/WMCore/Lexicon.py
@@ -605,3 +605,12 @@ def primaryDatasetType(candidate):
         return True
     # to sync with the check() exception when it doesn't match
     raise AssertionError("Invalid primary dataset type : %s should be 'mc' or 'data' or 'test'" % candidate)
+
+
+def activity(candidate):
+    dashboardActivities = ['reprocessing', 'production', 'relval', 'tier0', 't0',
+                           'harvesting', 'storeresults', 'integration',
+                           'test', 'analysis']
+    if candidate in dashboardActivities:
+        return True
+    raise AssertionError("Invalid dashboard activity: %s should 'test'" % candidate)

--- a/src/python/WMCore/ReqMgr/Tools/cms.py
+++ b/src/python/WMCore/ReqMgr/Tools/cms.py
@@ -246,3 +246,9 @@ def cms_groups():
     "Return list of CMS data-ops groups"
     groups = ["DATAOPS"]
     return groups
+
+def dashboardActivities():
+    "Return list of dashboard activities"
+    activity = ['reprocessing', 'production', 'relval', 'harvesting',
+                'storeresults', 'integration', 'test']
+    return activity

--- a/src/python/WMCore/ReqMgr/Utils/Validation.py
+++ b/src/python/WMCore/ReqMgr/Utils/Validation.py
@@ -15,7 +15,7 @@ from WMCore.ReqMgr.Auth import getWritePermission
 from WMCore.ReqMgr.DataStructs.Request import initialize_request_args
 from WMCore.ReqMgr.DataStructs.RequestStatus import check_allowed_transition, STATES_ALLOW_ONLY_STATE_TRANSITION
 from WMCore.ReqMgr.DataStructs.RequestError import InvalidStateTransition, InvalidSpecParameterValue
-from WMCore.ReqMgr.Tools.cms import releases, architectures
+from WMCore.ReqMgr.Tools.cms import releases, architectures, dashboardActivities
 from WMCore.Lexicon import procdataset
 
 
@@ -183,6 +183,8 @@ def create_json_template_spec(specArgs):
             value = releases()
         elif key == "ScramArch":
             value = architectures()
+        elif prop == "Dashboard":
+            value = dashboardActivities()
         elif prop.get("optional", True):
             # if optional need to always have default value
             value = prop["default"]

--- a/src/python/WMCore/ReqMgr/Web/ReqMgrService.py
+++ b/src/python/WMCore/ReqMgr/Web/ReqMgrService.py
@@ -26,7 +26,7 @@ from cherrypy import config as cherryconf
 from WMCore.ReqMgr.Web.tools import exposecss, exposejs, TemplatedPage
 from WMCore.ReqMgr.Web.utils import json2table, json2form, genid, checkargs, tstamp, sort, reorder_list
 from WMCore.ReqMgr.Utils.url_utils import getdata
-from WMCore.ReqMgr.Tools.cms import releases, architectures
+from WMCore.ReqMgr.Tools.cms import releases, architectures, dashboardActivities
 from WMCore.ReqMgr.Tools.cms import web_ui_names, sites
 from WMCore.ReqMgr.Tools.cms import lfn_bases, lfn_unmerged_bases
 from WMCore.ReqMgr.Tools.cms import site_white_list, site_black_list
@@ -343,6 +343,7 @@ class ReqMgrService(TemplatedPage):
                      'ProcessingString': '',
                      'MergedLFNBase': lfn_bases(),
                      'UnmergedLFNBase': lfn_unmerged_bases(),
+                     'Dashboard': dashboardActivities(),
                      'Team': self.getTeams()}
         filter_sort = self.templatepage('filter_sort')
         content = self.templatepage('assign', sort=sortby,
@@ -463,6 +464,7 @@ class ReqMgrService(TemplatedPage):
                               'NonCustodialSubType': ['Move', 'Replica'],
                               'MergedLFNBase': lfn_bases(),
                               'UnmergedLFNBase': lfn_unmerged_bases(),
+                              'Dashboard': dashboardActivities(),
                               'Team': self.getTeams()}
             
             for prop in prop_value_map:

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -8,7 +8,8 @@ import logging
 
 from WMCore.Cache.WMConfigCache import ConfigCache, ConfigCacheException
 from WMCore.Configuration import ConfigSection
-from WMCore.Lexicon import lfnBase, identifier, acqname, cmsswversion, cmsname, couchurl, block, procstring
+from WMCore.Lexicon import lfnBase, identifier, acqname, cmsswversion
+from WMCore.Lexicon import cmsname, couchurl, block, procstring, activity
 from WMCore.Services.Dashboard.DashboardReporter import DashboardReporter
 from WMCore.WMSpec.WMSpecErrors import WMSpecFactoryException
 from WMCore.WMSpec.WMWorkload import newWorkload
@@ -1014,7 +1015,7 @@ class StdBase(object):
                      "BlockCloseMaxSize": {"default": 5000000000000, "type": int, "validate": lambda x: x > 0},
 
                      # dashboard activity
-                     "Dashboard": {"default": "", "type": str},
+                     "Dashboard": {"default": "production", "type": str, "validate": activity},
                      # team name
                      "Team": {"default": "", "type": str},
                      "PrepID": {"default": None, "null": True},


### PR DESCRIPTION
Provides a fixed list of dashboard activities in ReqMgr2 UI.
Also added a lexicon validation for its value.

@ticoann please review. If you prefer we can skip this PR for the current cmsweb cycle.

PS.: I just noticed I have to add `harvesting` and `StoreResults` to the lists. Will do so after the meeting.
