### PR TITLE
Parse out/err files instead of condor.log

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
@@ -128,6 +128,24 @@ def parseError(error):
     return errorCondition, errorMsg
 
 
+def parseCondorLogs(logfile, extension):
+    """
+    Retrieve the last X lines of the log file
+    """
+    errLog = None
+    logOut = ''
+
+    logPaths = glob.glob(logfile)
+    if len(logPaths):
+        errLog = max(logPaths, key=lambda path: os.stat(path).st_mtime)
+    if errLog is not None and os.path.isfile(errLog):
+        logTail = BasicAlgos.tail(errLog, 50)
+        logOut += 'Adding end of condor.%s to error message:\n' % extension
+        logOut += ''.join(logTail)
+        logOut += '\n\n'
+    return logOut
+
+
 class PyCondorPlugin(BasePlugin):
     """
     _PyCondorPlugin_
@@ -603,16 +621,8 @@ class PyCondorPlugin(BasePlugin):
             logOutput = 'Could not find jobReport\n'
             # But we don't know exactly the condor id, so it will append
             # the last lines of the latest condor log in cache_dir
-            # TODO: Alan - how about we look at the .out or .err file instead of the .log?
-            genLogPath = os.path.join(job['cache_dir'], 'condor.*.*.log')
-            logPaths = glob.glob(genLogPath)
-            errLog = None
-            if len(logPaths):
-                errLog = max(logPaths, key=lambda path: os.stat(path).st_mtime)
-            if errLog is not None and os.path.isfile(errLog):
-                logTail = BasicAlgos.tail(errLog, 50)
-                logOutput += 'Adding end of condor.log to error message:\n'
-                logOutput += '\n'.join(logTail)
+            logOutput = parseCondorLogs(os.path.join(job['cache_dir'], 'condor.*.*.err'), 'err')
+            logOutput += parseCondorLogs(os.path.join(job['cache_dir'], 'condor.*.*.out'), 'out')
 
             condorReport = Report()
             if not os.path.isdir(job['cache_dir']):


### PR DESCRIPTION
I finally found a concrete example that supports reading the tail of the `.out` and .`err` instead of the condor `.log` file.

I hit the same `99303 NoJobReport` exit code in testbed and looking at the condor log files:
- log extension: besides some condor classAds, it has no clear error message
- out extension: in general "good" output from the submit.sh, like

```
WMAgent bootstrap : Tue Oct  4 10:38:21 UTC 2016 : starting...
WMAgent bootstrap : Tue Oct  4 10:38:21 UTC 2016 : arguments validated...
```
- err extension: errors from the submit.sh, like

```
WMAgent bootstrap : Tue Oct  4 10:38:21 UTC 2016 : Error: VO_CMS_SW_DIR, OSG_APP, CVMFS environment variables were not set and /cvmfs is not present
WMAgent bootstrap : Tue Oct  4 10:38:21 UTC 2016 : Error: Because of this, we can't load CMSSW. Not good.
```

Thus, I suggest we pick 50/50, some out and some err lines, just to be on the safe side.
I still have to test it (and be lucky to see it happening again)

@ticoann should we pick only the last 25lines of each file instead? or 50 lines is Ok for each?
@hufnagel you may update the new plugin you're working on.
