### PR TITLE
Fix unittest deployment for the new pkgtools

### DIFF
--- a/test/deploy/deploy_unittest.sh
+++ b/test/deploy/deploy_unittest.sh
@@ -13,7 +13,7 @@
 # for running the test check the tutorial, https://github.com/dmwm/WMCore/wiki/Setup-wmcore-unittest
 ###
 DMWM_ARCH=slc6_amd64_gcc493
-REPURL=http://cmsrep.cern.ch/cmssw/repos/comp/$DMWM_ARCH/latest
+VERSION=$(curl -s "http://cmsrep.cern.ch/cgi-bin/repos/comp/$DMWM_ARCH?C=M;O=D" | grep -oP "(?<=>cms\+wmagent-dev\+).*(?=-1-1)" | head -1)
 
 REPOSITORY=dmwm
 BRANCH=
@@ -50,20 +50,6 @@ update_src() {
     )
 }
 
-get_current_version() {
-    url=$1
-    while json=$(curl -sf $url/RPMS.json)
-    do
-        if v=$(echo "$json" | grep -m 1 wmagent-dev)
-        then
-            VERSION=$(echo $v | cut -d + -f 3 | cut -d \" -f 1)
-            return 0
-        fi
-        url=$url/parent
-    done
-    return 11
-}
-
 while [ $# -gt 0 ]
 do
     case "$1" in
@@ -75,15 +61,6 @@ do
     esac
     shift
 done
-
-if [ -z $VERSION ]
-then
-    if ! get_current_version $REPURL
-    then
-        echo "ERROR: Failed to identify wmagent-dev current version."
-        exit 11
-    fi
-fi
 
 if [ $UPDATE = "true" ]
 then


### PR DESCRIPTION
This PR fixes deploy_unittest.sh to work with the new structure of cmsrep.
The problem is reported on issue #7261.
