### PR TITLE
Handle workflows without inbox elements in JobArchiver

### DIFF
--- a/src/python/WMComponent/JobArchiver/JobArchiverPoller.py
+++ b/src/python/WMComponent/JobArchiver/JobArchiverPoller.py
@@ -10,14 +10,13 @@ import os
 import os.path
 import shutil
 import tarfile
-import traceback
 
 from Utils.IterTools import grouper
 from WMComponent.TaskArchiver.CleanCouchPoller import uploadPublishWorkflow
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 from WMCore.JobStateMachine.ChangeState import ChangeState
-
 from WMCore.WorkQueue.WorkQueueExceptions import WorkQueueNoMatchingElements
+from WMCore.WorkQueue.WorkQueueUtils import queueFromConfig
 
 from WMCore.WMBS.Job import Job
 from WMCore.DAOFactory import DAOFactory
@@ -74,15 +73,9 @@ class JobArchiverPoller(BaseWorkerThread):
             msg = "Unhandled exception while setting up logDir and/or uploadPublishDir!\n"
             msg += str(ex)
             logging.error(msg)
-            try:
-                logging.debug("Directory: %s", self.logDir)
-                logging.debug("Config: %s", config)
-            except:
-                pass
             raise JobArchiverPollerException(msg)
 
         try:
-            from WMCore.WorkQueue.WorkQueueUtils import queueFromConfig
             self.workQueue = queueFromConfig(self.config)
         except Exception as ex:
             msg = "Could not load workQueue"
@@ -331,8 +324,7 @@ class JobArchiverPoller(BaseWorkerThread):
                 # workflow not known - free to cleanup
                 injected.append(name)
             except Exception as ex:
-                logging.error("Injection status checking failed, investigate: %s", str(ex))
-                logging.debug("Traceback: %s", traceback.format_exc())
+                logging.exception("Injection status checking failed, investigate: %s", str(ex))
 
         # Now, mark as injected those that returned True
         if len(injected) > 0:

--- a/src/python/WMCore/WorkQueue/WorkQueueBackend.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueBackend.py
@@ -509,13 +509,13 @@ class WorkQueueBackend(object):
         options = {'group': True, 'reduce': True}
         if request:
             options.update(key=request)
-        data = self.db.loadView('WorkQueue', 'wmbsInjectStatusByRequest',
-                                options)
+        data = self.db.loadView('WorkQueue', 'wmbsInjectStatusByRequest', options)
         if request:
             if data['rows']:
                 injectionStatus = data['rows'][0]['value']
                 inboxElement = self.getInboxElements(WorkflowName=request)
-                return injectionStatus and not inboxElement[0].get('OpenForNewData', False)
+                requestOpen = inboxElement[0].get('OpenForNewData', False) if inboxElement else False
+                return injectionStatus and not requestOpen
             else:
                 raise WorkQueueNoMatchingElements("%s not found" % request)
         else:
@@ -523,7 +523,8 @@ class WorkQueueBackend(object):
             finalInjectionStatus = []
             for request in injectionStatus.keys():
                 inboxElements = self.getInboxElements(WorkflowName=request)
-                finalInjectionStatus.append({request: injectionStatus[request] and not inboxElement[0].get('OpenForNewData', False)})
+                requestOpen = inboxElement[0].get('OpenForNewData', False) if inboxElement else False
+                finalInjectionStatus.append({request: injectionStatus[request] and not requestOpen})
 
             return finalInjectionStatus
 


### PR DESCRIPTION
I noticed there was a workflow in testbed not moving from aborted to aborted-completed and the reason is taht JobArchiver was failing to check the WMBS injection status (there was no inbox element for that request(?)).

In case the inbox element is gone, then we set this workflow as injected in the agent and get it out of the system.

@ticoann please review
