### PR TITLE
Always override the PSet number of threads

### DIFF
--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -658,16 +658,15 @@ class SetupCMSSWPset(ScriptInterface):
         self.fixupProcess()
 
         try:
-            if int(self.step.data.application.multicore.numberOfCores) > 1:
-                numCores = int(self.step.data.application.multicore.numberOfCores)
-                options = getattr(self.process, "options", None)
-                if options == None:
-                    self.process.options = cms.untracked.PSet()
-                    options = getattr(self.process, "options")
-                options.numberOfThreads = cms.untracked.uint32(numCores)
-                options.numberOfStreams = cms.untracked.uint32(0)        # For now, same as numCores
-        except AttributeError:
-            print("No value for numberOfCores. Not setting")
+            numCores = int(getattr(self.step.data.application.multicore, 'numberOfCores', 1))
+            options = getattr(self.process, "options", None)
+            if options is None:
+                self.process.options = cms.untracked.PSet()
+                options = getattr(self.process, "options")
+            options.numberOfThreads = cms.untracked.uint32(numCores)
+            options.numberOfStreams = cms.untracked.uint32(0)
+        except AttributeError as ex:
+            print("Failed to override numberOfThreads: %s" % str(ex))
 
         psetTweak = getattr(self.step.data.application.command, "psetTweak", None)
         if psetTweak != None:


### PR DESCRIPTION
If requestors upload the PSet config to couch with a hardcoded numberOfThreads AND they do not provide `Multicore` parameter in the schema (or it's 1), then it is not overriden and those jobs will be created with the PSet config.

This makes sure that jobs will run with the correct number of cores, as provided in the schema or setting it to single core.

I'm applying it to cmssrv214, since Dave is running a test over there.
@hufnagel not sure it impacts any of the cores manipulations made by T0
