### PR TITLE
add location filter to wmarchive format

### DIFF
--- a/src/python/WMCore/Services/WMArchive/DataMap.py
+++ b/src/python/WMCore/Services/WMArchive/DataMap.py
@@ -214,6 +214,12 @@ def convertOutput(outputList):
         if "dataset" in outDict:
             outDict.update(combineDataset(outDict["dataset"]))
             del outDict["dataset"]
+            
+        if "location" in outDict and isinstance(outDict["location"], list):
+            if len(outDict["location"]) > 0:
+                outDict["location"] = outDict["location"][0]
+            else:
+                outDict["location"] = ""
         
         _validateTypeAndSetDefault(outDict, STEP_DEFAULT['output'][0])            
             


### PR DESCRIPTION
fix what Valentine reported. 
@amaltaro, @vkuznet, Alan, Valentin, please review

```
and look what's wrong with the record you'll see that it is
SCHEMA ERROR PATH: "/steps/output/location" TYPE: "Basic data type" AREC: ["string", "null"] DATA: ["T2_CH_CERN"]

The message should be read as following:
- in a path: steps -> output -> location we have a data ["T2_CH_CERN"], but its
 avro type is either string or null.

If you'll look at our production schema:
https://github.com/dmwm/WMArchive/blob/master/src/python/WMArchive/Schemas/FWJRProduction.py#L60

the steps->output->location should be a string type not a list !!!
```
