### PR TITLE
Drop bad encoded chars from the parsed logs

### DIFF
--- a/src/python/WMCore/Algorithms/BasicAlgos.py
+++ b/src/python/WMCore/Algorithms/BasicAlgos.py
@@ -6,7 +6,7 @@ _BasicAlgos_
 Python implementations of basic Linux functionality
 
 """
-
+import io
 import os
 import stat
 import time
@@ -59,9 +59,8 @@ def tail(filename, nLines = 20):
     A version of tail
     Adapted from code on http://stackoverflow.com/questions/136168/get-last-n-lines-of-a-file-with-python-similar-to-tail
     """
-
-
-    f = open(filename, 'r')
+    # make sure only valid utf8 encoded chars will be passed along
+    f = io.open(filename, 'r', encoding='utf8', errors='ignore')
 
     assert nLines >= 0
     pos, lines = nLines+1, []
@@ -75,10 +74,11 @@ def tail(filename, nLines = 20):
             lines = list(f)
         pos *= 2
 
-
     f.close()
 
-    return lines[-nLines:]
+    text = "".join(lines[-nLines:])
+
+    return text
 
 
 def getFileInfo(filename):

--- a/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/CondorPlugin.py
@@ -684,7 +684,7 @@ class CondorPlugin(BasePlugin):
             if errLog != None and os.path.isfile(errLog):
                 logTail = BasicAlgos.tail(errLog, 50)
                 logOutput += 'Adding end of condor.log to error message:\n'
-                logOutput += '\n'.join(logTail)
+                logOutput += logTail
             if not os.path.isdir(job['cache_dir']):
                 msg =  "Serious Error in Completing condor job with id %s!\n" % job.get('id', 'unknown')
                 msg += "Could not find jobCache directory - directory deleted under job: %s\n" % job['cache_dir']

--- a/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
@@ -141,7 +141,7 @@ def parseCondorLogs(logfile, extension):
     if errLog is not None and os.path.isfile(errLog):
         logTail = BasicAlgos.tail(errLog, 50)
         logOut += 'Adding end of condor.%s to error message:\n' % extension
-        logOut += ''.join(logTail)
+        logOut += logTail
         logOut += '\n\n'
     return logOut
 

--- a/src/python/WMCore/JobStateMachine/ChangeState.py
+++ b/src/python/WMCore/JobStateMachine/ChangeState.py
@@ -159,18 +159,22 @@ class ChangeState(WMObject, WMConnectionBase):
         # 3. Make the state transition
         self.persist(jobs, newstate, oldstate)
 
-        # 4. Document the state transition in couch
-        try:
-            self.recordInCouch(jobs, newstate, oldstate, updatesummary)
-        except Exception as ex:
-            logging.error("Error updating job in couch: %s" % str(ex))
-            logging.error(traceback.format_exc())
-
-        # 5. Report the job transition to the dashboard
+        # 4. Report the job transition to the dashboard
         try:
             self.reportToDashboard(jobs, newstate, oldstate)
         except Exception as ex:
             logging.error("Error reporting to the dashboard: %s" % str(ex))
+            logging.error(traceback.format_exc())
+
+        # 5. Document the state transition in couch
+        try:
+            self.recordInCouch(jobs, newstate, oldstate, updatesummary)
+        except UnicodeDecodeError as ex:
+            msg = "A critical error happened! Report it to developers. Error: %s" % str(ex)
+            logging.exception(msg)
+            raise
+        except Exception as ex:
+            logging.error("Error updating job in couch: %s" % str(ex))
             logging.error(traceback.format_exc())
 
         return

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/CMSSW.py
@@ -74,7 +74,7 @@ class Exit50513(DiagnosticHandler):
         if os.path.exists(errLog):
             logTail = BasicAlgos.tail(errLog, DEFAULT_TAIL_LINES_FROM_LOG)
             msg += '\n Adding last %s lines of SCRAM error log:\n' % DEFAULT_TAIL_LINES_FROM_LOG
-            msg += "".join(logTail)
+            msg += logTail
 
         executor.report.addError(executor.step._internal_name,
                                  50513, "SCRAMScriptFailure", msg)
@@ -125,11 +125,11 @@ class CMSDefaultHandler(DiagnosticHandler):
         if os.path.exists(errLog):
             logTail = BasicAlgos.tail(errLog, DEFAULT_TAIL_LINES_FROM_LOG)
             msg += '\n Adding last %s lines of CMSSW stderr:\n' % DEFAULT_TAIL_LINES_FROM_LOG
-            msg += "".join(logTail)
+            msg += logTail
         if os.path.exists(outLog):
             logTail = BasicAlgos.tail(outLog, DEFAULT_TAIL_LINES_FROM_LOG)
             msg += '\n Adding last %s lines of CMSSW stdout:\n' % DEFAULT_TAIL_LINES_FROM_LOG
-            msg += "".join(logTail)
+            msg += logTail
 
         # If it exists, grab the SCRAM log
         errLog = os.path.join(os.path.dirname(jobRepXml),
@@ -138,7 +138,7 @@ class CMSDefaultHandler(DiagnosticHandler):
         if os.path.exists(errLog):
             logTail = BasicAlgos.tail(errLog, 25)
             msg += '\n Adding last ten lines of SCRAM error log:\n'
-            msg += "".join(logTail)
+            msg += logTail
 
         # make sure the report has the error in it
         dummy = getattr(executor.report.report, "errors", None)  # Seems to do nothing
@@ -185,11 +185,11 @@ class CMSRunHandler(DiagnosticHandler):
         if os.path.exists(errLog):
             logTail = BasicAlgos.tail(errLog, DEFAULT_TAIL_LINES_FROM_LOG)
             msg += '\n Adding last %s lines of CMSSW stderr:\n' % DEFAULT_TAIL_LINES_FROM_LOG
-            msg += "".join(logTail)
+            msg += logTail
         if os.path.exists(outLog):
             logTail = BasicAlgos.tail(outLog, DEFAULT_TAIL_LINES_FROM_LOG)
             msg += '\n Adding last %s lines of CMSSW stdout:\n' % DEFAULT_TAIL_LINES_FROM_LOG
-            msg += "".join(logTail)
+            msg += logTail
 
         # make sure the report has the error in it
         errSection = getattr(executor.report.report, "errors", None)
@@ -235,7 +235,7 @@ class EDMExceptionHandler(DiagnosticHandler):
         if os.path.exists(errLog):
             logTail = BasicAlgos.tail(errLog, 10)
             addOn += '\nAdding last ten lines of CMSSW stderr:\n'
-            addOn += "".join(logTail)
+            addOn += logTail
         else:
             logging.error("No stderr from CMSSW")
             logging.error(os.listdir(os.path.basename(jobRepXml)))
@@ -243,7 +243,7 @@ class EDMExceptionHandler(DiagnosticHandler):
         if os.path.exists(outLog):
             logTail = BasicAlgos.tail(outLog, DEFAULT_TAIL_LINES_FROM_LOG)
             msg = '\n Adding last %s lines of CMSSW stdout:\n' % DEFAULT_TAIL_LINES_FROM_LOG
-            msg += "".join(logTail)
+            msg += logTail
 
         # Add the error we were sent
         ex = args.get('ExceptionInstance', None)

--- a/test/python/WMCore_t/Algorithms_t/BasicAlgos_t.py
+++ b/test/python/WMCore_t/Algorithms_t/BasicAlgos_t.py
@@ -7,11 +7,8 @@ Test class for Basic Algorithms
 
 import os
 import os.path
-import hashlib
 import unittest
-import tempfile
 
-#from WMCore.Algorithms.BasicAlgos import *
 import WMCore.Algorithms.BasicAlgos as BasicAlgos
 from WMQuality.TestInitCouchApp import TestInitCouchApp
 
@@ -19,8 +16,6 @@ from WMQuality.TestInitCouchApp import TestInitCouchApp
 class testBasicAlgos(unittest.TestCase):
     """
     Test to see whether we can do Linux
-
-
     """
 
     def setUp(self):
@@ -33,7 +28,6 @@ class testBasicAlgos(unittest.TestCase):
 
         return
 
-
     def tearDown(self):
         """
         Do nothing
@@ -43,8 +37,6 @@ class testBasicAlgos(unittest.TestCase):
 
         return
 
-
-
     def test_tail(self):
         """
         _tail_
@@ -52,29 +44,19 @@ class testBasicAlgos(unittest.TestCase):
         Can we tail a file?
         """
 
-
-
         a = "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl\nm\nn\no\np\n"
 
         f = open('tmpfile.tmp', 'w')
         f.write(a)
         f.close()
 
+        self.assertEqual(BasicAlgos.tail('tmpfile.tmp', 10), "g\nh\ni\nj\nk\nl\nm\nn\no\np\n")
 
-
-        self.assertEqual(BasicAlgos.tail('tmpfile.tmp', 10),
-                         ['g\n', 'h\n', 'i\n', 'j\n', 'k\n',
-                          'l\n', 'm\n', 'n\n', 'o\n', 'p\n'])
-
-        self.assertEqual(BasicAlgos.tail('tmpfile.tmp', 2),
-                         ['o\n', 'p\n'])
-
+        self.assertEqual(BasicAlgos.tail('tmpfile.tmp', 2), "o\np\n")
 
         os.remove('tmpfile.tmp')
 
-
         return
-
 
     def test_fileInfo(self):
         """
@@ -89,7 +71,7 @@ class testBasicAlgos(unittest.TestCase):
         f.write(silly)
         f.close()
 
-        info = BasicAlgos.getFileInfo(filename = filename)
+        info = BasicAlgos.getFileInfo(filename=filename)
         self.assertEqual(info['Name'], filename)
         self.assertEqual(info['Size'], 34)
         return


### PR DESCRIPTION
Fixes #7295 and possibly replaces #7297

Sorry, Seangchan. It seems my brain was not responsive in the last Friday, because I was sure this patch was applied to one of the agents and did _not_ work... 
I applied it to vocms0308 and it's working just fine for the last 4h. 

How about we make it the permanent fix for this issue? The `io`module seems to be the default interface in python 3 as well, for files/stream handling.

@ticoann please review
