### PR TITLE
Bundle of patches backported to the wmagent branch, patch1

### DIFF
--- a/etc/submit.sh
+++ b/etc/submit.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
+# should be a bit nicer than before
+echo "======== WMAgent bootstrap STARTING at $(TZ=GMT date) ========"
+echo "User id:    $(id)"
+echo "Local time: $(date)"
+echo "Hostname:   $(hostname -f)"
+echo "System:     $(uname -a)"
+echo "Arguments:  $@"
+
+# Saving START_TIME and when job finishes END_TIME.
+WMA_MIN_JOB_RUNTIMESECS=300
+START_TIME=$(date +%s)
 
 # On some sites we know there was some problems with environment cleaning
 # with using 'env -i'. To overcome this issue, whenever we start a job, we have
@@ -10,38 +21,81 @@ sed -e 's/^/export /' startup_environment.sh > tmp_env.sh
 mv tmp_env.sh startup_environment.sh
 export JOBSTARTDIR=$PWD
 
-# should be a bit nicer than before
-echo "WMAgent bootstrap : `date -u` : starting..."
 
-# We need to create the expected output file in advance just in case
-# some problem happens during the job bootstrap
-outputFile="Report.0.pkl Report.1.pkl Report.2.pkl Report.3.pkl"
-if [ -n "$_CONDOR_JOB_AD" ]; then
-    outputFile=`grep ^TransferOutput $_CONDOR_JOB_AD | awk -F'=' '{print $2}' | sed 's/\"//g'`
+# Multiple checks are done:
+# 1) Check submit.sh bootstrap exit code.
+#    If it is not 0 sleep WMA_MIN_JOB_RUNTIMESECS and in case it is 0, force to sleep 5 mins total runtime
+#    If this bootstrap script is exiting non 0 exit code, something is wrong on this WN...
+# 2) If Job exited 0, do not sleep any timeout
+# 3) Otherwise, sleep up to WMA_MIN_JOB_RUNTIMESECS seconds of runtime.
+function finish {
+  exitCode=$?
+  echo "======== WMAgent final job runtime checks STARTING at $(TZ=GMT date) ========"
+  if [ $exitCode -ne 0 ];
+  then
+      if [ $WMA_MIN_JOB_RUNTIMESECS -eq 0 ];
+      then
+          WMA_MIN_JOB_RUNTIMESECS=300
+      fi
+  elif [ $jobrc -eq 0 ];
+  then
+      WMA_MIN_JOB_RUNTIMESECS=0
+  fi
+  END_TIME=$(date +%s)
+  DIFF_TIME=$((END_TIME-START_TIME))
+  echo "$(TZ=GMT date): Job Runtime in seconds: " $DIFF_TIME
+  echo "$(TZ=GMT date): Job bootstrap script exited: " $exitCode
+  echo "$(TZ=GMT date): Job execution exited: " $jobrc
+  if [ $DIFF_TIME -lt $WMA_MIN_JOB_RUNTIMESECS ];
+  then
+    SLEEP_TIME=$((WMA_MIN_JOB_RUNTIMESECS - DIFF_TIME))
+    echo "$(TZ=GMT date): Job runtime is less than $WMA_MIN_JOB_RUNTIMESECS seconds. Sleeping " $SLEEP_TIME
+    sleep $SLEEP_TIME
+  fi
+  echo -e "======== WMAgent final job runtime checks FINISHED at $(TZ=GMT date) ========\n"
+}
+# Trap all exits and execute finish function
+trap finish EXIT
+
+
+if [ "X$_CONDOR_JOB_AD" != "X" ];
+then
+   outputFile=`grep ^TransferOutput $_CONDOR_JOB_AD | awk -F'=' '{print $2}' | sed 's/\"//g'`
+   WMA_SiteName=`grep '^MachineAttrGLIDEIN_CMSSite0 =' $_CONDOR_JOB_AD | tr -d '"' | awk '{print $NF;}'`
+   echo "Site name:  $WMA_SiteName"
+   echo "======== HTCondor jobAds start at $(TZ=GMT date) ========"
+   while read i; do
+       echo "  $i"
+   done < $_CONDOR_JOB_AD | sort
+   echo -e "======== HTCondor jobAds finished at $(TZ=GMT date) ========\n"
 fi
-if [ -z $outputFile ]; then
+
+# We need to create the expected output files in advance just in case
+# some problem happens during the job bootstrap
+if [ -z "$outputFile" ]; then
     outputFile="Report.0.pkl Report.1.pkl Report.2.pkl Report.3.pkl"
 fi
 touch $outputFile
 
-# validate arguments
+
+echo "======== WMAgent validate arguments starting at $(TZ=GMT date) ========"
 if [ -z "$1" ]
 then
-    echo "WMAgent bootstrap : `date -u` : Error: A sandbox must be specified" >&2
+    echo "WMAgent bootstrap: Error: A sandbox must be specified" >&2
     exit 1
 fi
 if [ -z "$2" ]
 then
-    echo "WMAgent bootstrap : `date -u` : Error: An index must be specified" >&2
+    echo "WMAgent bootstrap: Error: An index must be specified" >&2
     exit 1
 fi
-
 # assign arguments
 SANDBOX=$1
 INDEX=$2
-echo "WMAgent bootstrap : `date -u` : arguments validated..."
+echo -e "======== WMAgent validate arguments finished at $(TZ=GMT date) ========\n"
 
-### source the CMSSW stuff using either OSG or LCG style entry env. variables
+
+echo "======== WMAgent CMS environment load starting at $(TZ=GMT date) ========"
 if [ -f "$VO_CMS_SW_DIR"/cmsset_default.sh ]
 then  #   LCG style --
     . $VO_CMS_SW_DIR/cmsset_default.sh
@@ -56,13 +110,15 @@ then  # ok, lets call it CVMFS then
     export CVMFS=/cvmfs/cms.cern.ch
     . $CVMFS/cmsset_default.sh
 else
-    echo "WMAgent bootstrap : `date -u` : Error: VO_CMS_SW_DIR, OSG_APP, CVMFS environment variables were not set and /cvmfs is not present" >&2
-    echo "WMAgent bootstrap : `date -u` : Error: Because of this, we can't load CMSSW. Not good." >&2
+    echo "WMAgent bootstrap: Error: VO_CMS_SW_DIR, OSG_APP, CVMFS environment variables were not set and /cvmfs is not present" >&2
+    echo "WMAgent bootstrap: Error: Because of this, we can't load CMSSW. Not good." >&2
     exit 2
 fi
+echo "WMAgent bootstrap: WMAgent thinks it found the correct CMSSW setup script"
+echo -e "======== WMAgent CMS environment load finished at $(TZ=GMT date) ========\n"
 
-echo "WMAgent bootstrap : `date -u` : WMAgent thinks it found the correct CMSSW setup script"
 
+echo "======== WMAgent Python boostrap starting at $(TZ=GMT date) ========"
 if [ -e "$VO_CMS_SW_DIR"/COMP/slc6_amd64_gcc493/external/python/2.7.6/etc/profile.d/init.sh ]
 then
     . "$VO_CMS_SW_DIR"/COMP/slc6_amd64_gcc493/external/python/2.7.6/etc/profile.d/init.sh
@@ -73,41 +129,48 @@ elif [ -e "$CVMFS"/COMP/slc6_amd64_gcc493/external/python/2.7.6/etc/profile.d/in
 then
     . "$CVMFS"/COMP/slc6_amd64_gcc493/external/python/2.7.6/etc/profile.d/init.sh
 else
-    echo "WMAgent bootstrap : `date -u` : Error: OSG_APP, VO_CMS_SW_DIR, CVMFS, /cvmfs/cms.cern.ch environment does not contain init.sh" >&2
-    echo "WMAgent bootstrap : `date -u` : Error: Because of this, we can't load CMSSW. Not good." >&2
+    echo "WMAgent bootstrap: Error: OSG_APP, VO_CMS_SW_DIR, CVMFS, /cvmfs/cms.cern.ch environment does not contain init.sh" >&2
+    echo "WMAgent bootstrap: Error: Because of this, we can't load CMSSW. Not good." >&2
     exit 4
 fi
 command -v python2 > /dev/null
 rc=$?
 if [[ $rc != 0 ]]
 then
-    echo "WMAgent bootstrap : `date -u` : Error: Python2.6 isn't available on this worker node." >&2
-    echo "WMAgent bootstrap : `date -u` : Error: WMCore/WMAgent REQUIRES python2" >&2
+    echo "WMAgent bootstrap: Error: python2 isn't available on this worker node." >&2
+    echo "WMAgent bootstrap: Error: WMCore/WMAgent REQUIRES python2" >&2
     exit 3	
 else
-    echo "WMAgent bootstrap : `date -u` : found python2 at.."
+    echo "WMAgent bootstrap: found python2 at.."
     echo `which python2`
 fi
+echo -e "======== WMAgent Python boostrap finished at $(TZ=GMT date) ========\n"
 
+
+echo "======== WMAgent Unpack the job starting at $(TZ=GMT date) ========"
 # Should be ready to unpack and run this
-echo "WMAgent bootstrap : `date -u` : is unpacking the job..."
 python2 Unpacker.py --sandbox=$SANDBOX --package=JobPackage.pkl --index=$INDEX
 
 cd job
 export WMAGENTJOBDIR=$PWD
 export PYTHONPATH=$PYTHONPATH:$PWD/WMCore.zip:$PWD
-echo "WMAgent bootstrap : `date -u` :    Hostname: `hostname -f`"
-echo "WMAgent bootstrap : `date -u` :    Username: `id`"
-echo "WMAgent bootstrap : `date -u` : Environemnt:"
-env
-echo "WMAgent bootstrap : `date -u` : WMAgent is now running the job..."
+echo -e "======== WMAgent Unpack the job finished at $(TZ=GMT date) ========\n"
+
+echo "======== Current environment dump starting ========"
+for i in `env`; do
+  echo "  $i"
+done
+echo -e "======== Current environment dump finished ========\n"
+
+echo "======== WMAgent Run the job starting at $(TZ=GMT date) ========"
 python2 Startup.py
 jobrc=$?
-echo "WMAgent bootstrap : `date -u` : WMAgent finished the job, is copying the pickled report"
+echo -e "======== WMAgent Run the job FINISH at $(TZ=GMT date) ========\n"
+
+
+echo "WMAgent bootstrap: WMAgent finished the job, it's copying the pickled report"
 cp WMTaskSpace/Report*.pkl ../
 ls -l WMTaskSpace
 ls -l WMTaskSpace/*
-echo "WMAgent bootstrap : `date -u` : WMAgent is finished. The job had an exit code of $jobrc "
+echo -e "======== WMAgent bootstrap FINISH at $(TZ=GMT date) ========\n"
 exit 0
-
-

--- a/src/couchapps/FWJRDump/views/skippedFileInfoByTask/map.js
+++ b/src/couchapps/FWJRDump/views/skippedFileInfoByTask/map.js
@@ -1,7 +1,7 @@
 function(doc) {
   if (doc['type'] === 'fwjr') {
     if (doc['fwjr'].task == null || doc['fwjr'].skippedFiles.length === 0 || 
-        doc["jobtype"] === "LogCollect") {
+        doc["jobtype"] !== "Merge" || doc["jobstate"] !== "success") {
       return;
     }
     var specName = doc['fwjr'].task.split('/')[1];

--- a/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
@@ -332,7 +332,7 @@ class DBSUploadPoller(BaseWorkerThread):
         # Now load the blocks
         try:
             loadedBlocks = self.dbsUtil.loadBlocks(blocksToLoad)
-            logging.info("Loaded blocks: %s", loadedBlocks)
+            logging.info("Loaded %d blocks.", len(loadedBlocks))
         except WMException:
             raise
         except Exception as ex:
@@ -352,7 +352,7 @@ class DBSUploadPoller(BaseWorkerThread):
             # Now we have to load files...
             try:
                 files = self.dbsUtil.loadFilesByBlock(blockname = blockname)
-                logging.info("Have %i files for block %s", (len(files), blockname))
+                logging.info("Have %i files for block %s", len(files), blockname)
             except WMException:
                 raise
             except Exception as ex:

--- a/src/python/WMComponent/JobAccountant/AccountantWorker.py
+++ b/src/python/WMComponent/JobAccountant/AccountantWorker.py
@@ -512,7 +512,7 @@ class AccountantWorker(WMConnectionBase):
         if jobSuccess:
             logging.info("Job %d , handle successful job", jobID)
         else:
-            logging.error("Job %d , bad jobReport, failing job",  jobID)
+            logging.warning("Job %d , bad jobReport, failing job",  jobID)
 
         # make sure the task name is present in FWJR (recover from WMBS if needed)
         if len(fileList) > 0:

--- a/src/python/WMComponent/TaskArchiver/TaskArchiverPoller.py
+++ b/src/python/WMComponent/TaskArchiver/TaskArchiverPoller.py
@@ -305,7 +305,7 @@ class TaskArchiverPoller(BaseWorkerThread):
                 self.workQueue.doneWork(SubscriptionId = sub)
             except WorkQueueNoMatchingElements:
                 #Subscription wasn't known to WorkQueue, feel free to clean up
-                logging.info("Local WorkQueue knows nothing about this subscription: %s" % sub)
+                logging.debug("Local WorkQueue knows nothing about this subscription: %s" % sub)
                 pass
             except Exception as ex:
                 msg = "Error talking to workqueue: %s\n" % str(ex)

--- a/src/python/WMCore/FwkJobReport/Report.py
+++ b/src/python/WMCore/FwkJobReport/Report.py
@@ -256,7 +256,7 @@ class Report:
             for i in range(errorCount):
                 reportError = getattr(reportStep.errors, "error%i" % i)
                 jsonStep["errors"].append({"type": reportError.type,
-                                           "details": reportError.details,
+                                           "details": unicode(reportError.details, errors='ignore'),
                                            "exitCode": reportError.exitCode})
 
             jsonStep["cleanup"] = {}

--- a/src/python/WMCore/FwkJobReport/XMLParser.py
+++ b/src/python/WMCore/FwkJobReport/XMLParser.py
@@ -4,7 +4,7 @@ _XMLParser_
 
 Read the raw XML output from the cmsRun executable.
 """
-from __future__ import print_function
+from __future__ import print_function, division
 
 
 
@@ -433,8 +433,8 @@ def perfStoreHandler():
         try:
             readTotalMB = storageValues.get("Timing-%s-read-totalMegabytes" % readMethod, 0) \
                           + storageValues.get("Timing-%s-readv-totalMegabytes" % readMethod, 0)
-            readMSecs   = (storageValues.get("Timing-%s-read-totalMsecs" % readMethod, 0)\
-                           + storageValues.get("Timing-%s-readv-totalMsecs" % readMethod, 0))
+            readMSecs   = storageValues.get("Timing-%s-read-totalMsecs" % readMethod, 0) \
+                           + storageValues.get("Timing-%s-readv-totalMsecs" % readMethod, 0)
             totalReads  = storageValues.get("Timing-%s-read-numOperations" % readMethod, 0) \
                           + storageValues.get("Timing-%s-readv-numOperations" % readMethod, 0)
             readMaxMSec = max(storageValues.get("Timing-%s-read-maxMsecs" % readMethod, 0),
@@ -443,14 +443,14 @@ def perfStoreHandler():
                           storageValues.get("Timing-tstoragefile-read-numOperations", 0)
             readCachOps = storageValues.get("Timing-tstoragefile-readViaCache-numSuccessfulOperations", 0)/\
                           storageValues.get("Timing-tstoragefile-read-numOperations", 0)
-            readTotalT  = 1000 * storageValues.get("Timing-tstoragefile-read-totalMSecs", 0)
+            readTotalT  = storageValues.get("Timing-tstoragefile-read-totalMSecs", 0) // 1000
             readNOps    = storageValues.get("Timing-tstoragefile-read-numOperations", 0)
-            writeTime   = storageValues.get("Timing-tstoragefile-write-totalMsecs", 0) * 1000
+            writeTime   = storageValues.get("Timing-tstoragefile-write-totalMsecs", 0) // 1000
             writeTotMB  = storageValues.get("Timing-%s-write-totalMegabytes" % writeMethod, 0) \
                           + storageValues.get("Timing-%s-writev-totalMegabytes" % writeMethod, 0)
 
             if readMSecs > 0:
-                readMBSec = readTotalMB/readMSecs
+                readMBSec = readTotalMB/readMSecs * 1000
             else:
                 readMBSec = 0
             if totalReads > 0:

--- a/src/python/WMCore/Services/WMArchive/DataMap.py
+++ b/src/python/WMCore/Services/WMArchive/DataMap.py
@@ -214,6 +214,12 @@ def convertOutput(outputList):
         if "dataset" in outDict:
             outDict.update(combineDataset(outDict["dataset"]))
             del outDict["dataset"]
+            
+        if "location" in outDict and isinstance(outDict["location"], list):
+            if len(outDict["location"]) > 0:
+                outDict["location"] = outDict["location"][0]
+            else:
+                outDict["location"] = ""
         
         _validateTypeAndSetDefault(outDict, STEP_DEFAULT['output'][0])            
             

--- a/src/python/WMCore/Storage/StageOutMgr.py
+++ b/src/python/WMCore/Storage/StageOutMgr.py
@@ -9,6 +9,10 @@ use this class as a basic API
 """
 from __future__ import print_function
 
+# If we don't import them, they cannot be ever used (bad PyCharm!)
+import WMCore.Storage.Backends
+import WMCore.Storage.Plugins
+
 from WMCore.WMException import WMException
 from WMCore.Storage.StageOutError import StageOutFailure
 from WMCore.Storage.StageOutError import StageOutInitError

--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -658,16 +658,15 @@ class SetupCMSSWPset(ScriptInterface):
         self.fixupProcess()
 
         try:
-            if int(self.step.data.application.multicore.numberOfCores) > 1:
-                numCores = int(self.step.data.application.multicore.numberOfCores)
-                options = getattr(self.process, "options", None)
-                if options == None:
-                    self.process.options = cms.untracked.PSet()
-                    options = getattr(self.process, "options")
-                options.numberOfThreads = cms.untracked.uint32(numCores)
-                options.numberOfStreams = cms.untracked.uint32(0)        # For now, same as numCores
-        except AttributeError:
-            print("No value for numberOfCores. Not setting")
+            numCores = int(getattr(self.step.data.application.multicore, 'numberOfCores', 1))
+            options = getattr(self.process, "options", None)
+            if options is None:
+                self.process.options = cms.untracked.PSet()
+                options = getattr(self.process, "options")
+            options.numberOfThreads = cms.untracked.uint32(numCores)
+            options.numberOfStreams = cms.untracked.uint32(0)
+        except AttributeError as ex:
+            print("Failed to override numberOfThreads: %s" % str(ex))
 
         psetTweak = getattr(self.step.data.application.command, "psetTweak", None)
         if psetTweak != None:

--- a/test/python/WMCore_t/JobSplitting_t/Harvest_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/Harvest_t.py
@@ -26,6 +26,40 @@ from WMQuality.TestInit import TestInit
 from WMQuality.Emulators import EmulatorSetup
 
 
+def createCommonFileset():
+    """
+    Create a simple fileset with 2 files at the same location
+    """
+    multipleFilesFileset = Fileset(name="TestFileset")
+
+    newFile = File("/some/file/test1", size=1000, events=100)
+    newFile.addRun(Run(1, *[1, 3, 4, 5, 6, 7]))
+    newFile.addRun(Run(2, *[1, 2, 4, 5, 6, 7]))
+    newFile.setLocation('T2_CH_CERN')
+    multipleFilesFileset.addFile(newFile)
+
+    newFile = File("/some/file/test2", size=2000, events=200)
+    newFile.addRun(Run(3, *[2, 8]))
+    newFile.addRun(Run(4, *[3, 8]))
+    newFile.setLocation('T2_CH_CERN')
+    multipleFilesFileset.addFile(newFile)
+
+    newFile = File("/some/file/test3", size=3000, events=300)
+    newFile.addRun(Run(5, *[10, 11, 12]))
+    newFile.addRun(Run(6, *[10, 11, 12]))
+    newFile.setLocation('T2_CH_CERN')
+    multipleFilesFileset.addFile(newFile)
+
+    newFile = File("/some/file/test4", size=4000, events=400)
+    newFile.addRun(Run(2, *[3, 8, 9]))
+    newFile.addRun(Run(3, *[3, 4, 5, 6]))
+    newFile.setLocation('T2_CH_CERN')
+    multipleFilesFileset.addFile(newFile)
+
+    multipleFilesFileset.create()
+    return multipleFilesFileset
+
+
 class HarvestTest(unittest.TestCase):
     """
     _HarvestTest_
@@ -57,15 +91,15 @@ class HarvestTest(unittest.TestCase):
         self.changer = ChangeState(config)
 
         myResourceControl = ResourceControl()
-        myResourceControl.insertSite("SomeSite", 10, 20, "SomeSE", "SomeCE")
-        myResourceControl.insertSite("SomeSite", 10, 20, "SomeSE2", "SomeCE")
-        myResourceControl.insertSite("SomeSite2", 10, 20, "SomeSE3", "SomeCE2")
+        myResourceControl.insertSite("T1_US_FNAL", 10, 20, "T1_US_FNAL_Disk", "T1_US_FNAL")
+        myResourceControl.insertSite("T1_US_FNAL", 10, 20, "T3_US_FNALLPC", "T1_US_FNAL")
+        myResourceControl.insertSite("T2_CH_CERN", 10, 20, "T2_CH_CERN", "T2_CH_CERN")
 
         self.fileset1 = Fileset(name = "TestFileset1")
         for fileNum in range(11):
             newFile = File("/some/file/name%d" % fileNum, size = 1000, events = 100)
             newFile.addRun(Run(1,*[1]))
-            newFile.setLocation('SomeSE')
+            newFile.setLocation('T1_US_FNAL_Disk')
             self.fileset1.addFile(newFile)
 
         self.fileset1.create()
@@ -181,7 +215,7 @@ class HarvestTest(unittest.TestCase):
         for fileNum in range(12,24):
             newFile = File("/some/file/name%d" % fileNum, size = 1000, events = 100)
             newFile.addRun(Run(1,*[1]))
-            newFile.setLocation('SomeSE')
+            newFile.setLocation('T1_US_FNAL_Disk')
             self.fileset1.addFile(newFile)
         self.fileset1.commit()
 
@@ -205,7 +239,7 @@ class HarvestTest(unittest.TestCase):
         for fileNum in range(26,36):
             newFile = File("/some/file/name%d" % fileNum, size = 1000, events = 100)
             newFile.addRun(Run(1,*[1]))
-            newFile.setLocation('SomeSE')
+            newFile.setLocation('T1_US_FNAL_Disk')
             self.fileset1.addFile(newFile)
         self.fileset1.commit()
 
@@ -235,14 +269,14 @@ class HarvestTest(unittest.TestCase):
         for fileNum in range(38,48):
             newFile = File("/some/file/name%d" % fileNum, size = 1000, events = 100)
             newFile.addRun(Run(1,*[1]))
-            newFile.setLocation('SomeSE')
+            newFile.setLocation('T1_US_FNAL_Disk')
             self.fileset1.addFile(newFile)
         self.fileset1.commit()
         # Then another location
         for fileNum in range(50,56):
             newFile = File("/some/file/name%d" % fileNum, size = 1000, events = 100)
             newFile.addRun(Run(1,*[1]))
-            newFile.setLocation('SomeSE3')
+            newFile.setLocation('T2_CH_CERN')
             self.fileset1.addFile(newFile)
         self.fileset1.commit()
 
@@ -257,22 +291,22 @@ class HarvestTest(unittest.TestCase):
         firstJobLocation = jobGroups[0].getJobs()[0].getFileLocations()[0]
         secondJobLocation = jobGroups[0].getJobs()[1].getFileLocations()[0]
 
-        self.assertEqual(firstJobLocation, 'SomeSite', "First job location is not SomeSite")
-        self.assertEqual(secondJobLocation, 'SomeSite2', "Second job location is not SomeSite2")
+        self.assertEqual(firstJobLocation, 'T2_CH_CERN')
+        self.assertEqual(secondJobLocation, 'T1_US_FNAL')
 
         self.finishJobs(jobGroups)
 
         for fileNum in range(60,65):
             newFile = File("/some/file/name%d" % fileNum, size = 1000, events = 100)
             newFile.addRun(Run(2,*[2]))
-            newFile.setLocation('SomeSE3')
+            newFile.setLocation('T2_CH_CERN')
             self.fileset1.addFile(newFile)
         self.fileset1.commit()
 
         for fileNum in range(70,75):
             newFile = File("/some/file/name%d" % fileNum, size = 1000, events = 100)
             newFile.addRun(Run(3,*[3]))
-            newFile.setLocation('SomeSE3')
+            newFile.setLocation('T2_CH_CERN')
             self.fileset1.addFile(newFile)
         self.fileset1.commit()
 
@@ -304,12 +338,12 @@ class HarvestTest(unittest.TestCase):
         newFile = File("/some/file/test1", size = 1000, events = 100)
         newFile.addRun(Run(1,*[1,3,4,5,6,7]))
         newFile.addRun(Run(2,*[1,2,4,5,6,7]))
-        newFile.setLocation('SomeSE')
+        newFile.setLocation('T1_US_FNAL_Disk')
         multipleFilesFileset.addFile(newFile)
         newFile = File("/some/file/test2", size = 1000, events = 100)
         newFile.addRun(Run(1,*[2,8]))
         newFile.addRun(Run(2,*[3,8]))
-        newFile.setLocation('SomeSE3')
+        newFile.setLocation('T2_CH_CERN')
         multipleFilesFileset.addFile(newFile)
         multipleFilesFileset.create()
 
@@ -345,7 +379,7 @@ class HarvestTest(unittest.TestCase):
 
         newFile = File("/some/file/test3", size = 1000, events = 100)
         newFile.addRun(Run(1,*range(9,15)))
-        newFile.setLocation('SomeSE3')
+        newFile.setLocation('T2_CH_CERN')
         multipleFilesFileset.addFile(newFile)
         multipleFilesFileset.commit()
 
@@ -399,6 +433,132 @@ class HarvestTest(unittest.TestCase):
             for lumiPair in runs[run]:
                 for lumi in range(lumiPair[0], lumiPair[1] + 1):
                     self.assertTrue((run, lumi) in ll, "All of %s not in %s" % (lumiPair, ll))
+
+    def testMultiRunHarvesting(self):
+        """
+        _testMultiRunHarvesting_
+
+        Provided a fileset with a couple of files and different runs, create a
+        single job for all the runs at a specific location, which also adds a
+        baggage to the job (True) which is later on looked up by SetupCMSSWPSet.
+        """
+        multipleFilesFileset = createCommonFileset()
+        self.assertEqual(multipleFilesFileset.open, True)
+
+        harvestingWorkflow = Workflow(spec="spec.xml",
+                                      owner="amaltaro",
+                                      name="TestWorkflow",
+                                      task="Test")
+        harvestingWorkflow.create()
+
+        harvestSub = Subscription(fileset=multipleFilesFileset,
+                                  workflow=harvestingWorkflow,
+                                  split_algo="Harvest",
+                                  type="Harvesting")
+        harvestSub.create()
+
+        multipleFilesFileset.markOpen(False)
+        self.assertEqual(multipleFilesFileset.open, False, "Fileset should now be closed")
+
+        jobFactory = self.splitterFactory(package="WMCore.WMBS", subscription=harvestSub)
+        jobGroups = jobFactory(dqmHarvestUnit="multiRun")
+        self.assertEqual(len(jobGroups), 1)
+
+        for jobGroup in jobGroups:
+            self.assertEqual(len(jobGroup.jobs), 1)
+            #for job in jobGroup.jobs:
+            #    baggage = job.getBaggage()
+            #    self.assertTrue(getattr(baggage, "multiRun", False), "It's supposed to be a multiRun job")
+
+    def testByRunHarvesting(self):
+        """
+        _testByRunHarvesting_
+        Provided a fileset with a couple of files and 4 different runs, create
+        one single job per run and location.
+        The multiRun baggage should be false in this case.
+        """
+        multipleFilesFileset = createCommonFileset()
+        self.assertEqual(multipleFilesFileset.open, True, "Fileset should be open!")
+
+        harvestingWorkflow = Workflow(spec="spec.xml",
+                                      owner="amaltaro",
+                                      name="TestWorkflow",
+                                      task="Test")
+        harvestingWorkflow.create()
+
+        harvestSub = Subscription(fileset=multipleFilesFileset,
+                                  workflow=harvestingWorkflow,
+                                  split_algo="Harvest",
+                                  type="Harvesting")
+        harvestSub.create()
+
+        multipleFilesFileset.markOpen(False)
+        self.assertEqual(multipleFilesFileset.open, False, "Fileset should now be closed")
+
+        jobFactory = self.splitterFactory(package="WMCore.WMBS", subscription=harvestSub)
+        jobGroups = jobFactory()
+        self.assertEqual(len(jobGroups), 1, "Should have created 1 job group")
+
+        for jobGroup in jobGroups:
+            self.assertEqual(len(jobGroup.jobs), 6, "Should have created 6 jobs")
+            for job in jobGroup.jobs:
+                baggage = job.getBaggage()
+                self.assertFalse(getattr(baggage, "multiRun", False), "It's supposed to be a byRun job")
+
+    def testByRunAndRunWhitelist(self):
+        """
+        _testByRunAndRunWhitelist_
+
+        Create harvesting jobs by run for the runs provided in the RunWhitelist
+        """
+        multipleFilesFileset = createCommonFileset()
+        self.assertEqual(multipleFilesFileset.open, True)
+
+        harvestingWorkflow = Workflow(spec="spec.xml", owner="amaltaro",
+                                      name="TestWorkflow", task="Test")
+        harvestingWorkflow.create()
+
+        harvestSub = Subscription(fileset=multipleFilesFileset, workflow=harvestingWorkflow,
+                                  split_algo="Harvest", type="Harvesting")
+        harvestSub.create()
+
+        multipleFilesFileset.markOpen(False)
+        self.assertEqual(multipleFilesFileset.open, False, "Fileset should now be closed")
+
+        jobFactory = self.splitterFactory(package="WMCore.WMBS", subscription=harvestSub)
+        jobGroups = jobFactory(runWhitelist=[1, 3])
+        self.assertEqual(len(jobGroups), 1, "One jobgroup per location")
+
+        for jobGroup in jobGroups:
+            self.assertEqual(len(jobGroup.jobs), 2)
+
+    def testByRunAndRunBlacklist(self):
+        """
+        _testByRunAndRunWhitelist_
+
+        Create harvesting jobs by run for the runs provided in the RunWhitelist
+        """
+        multipleFilesFileset = createCommonFileset()
+        self.assertEqual(multipleFilesFileset.open, True)
+
+        harvestingWorkflow = Workflow(spec="spec.xml", owner="amaltaro",
+                                      name="TestWorkflow", task="Test")
+        harvestingWorkflow.create()
+
+        harvestSub = Subscription(fileset=multipleFilesFileset, workflow=harvestingWorkflow,
+                                  split_algo="Harvest", type="Harvesting")
+        harvestSub.create()
+
+        multipleFilesFileset.markOpen(False)
+        self.assertEqual(multipleFilesFileset.open, False, "Fileset should now be closed")
+
+        jobFactory = self.splitterFactory(package="WMCore.WMBS", subscription=harvestSub)
+        jobGroups = jobFactory(runWhitelist=[1, 2, 3, 4, 5], runBlacklist=[1, 3])
+        self.assertEqual(len(jobGroups), 1, "One jobgroup per location")
+
+        for jobGroup in jobGroups:
+            self.assertEqual(len(jobGroup.jobs), 3)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The following PRs were cherry-picked:
fixes unit for performance data #7189
Always override the PSet number of threads #7283
only merge and successful job's skipped file will be reported #7286
add location filter to wmarchive format #7288
TaskArchiver - demote annoying logging #7290
Improve submit.sh logging, exitCodes check #7294
temp fix for encoding error #7297
fallback to cvmfs if xrdcp/xrdfs not in path #7240
Import the stage out plugins #7302
Support run whitelist/blacklist in Harvest algo #7287
