### PR TITLE
Import the stage out plugins

### DIFF
--- a/src/python/WMCore/Storage/StageOutMgr.py
+++ b/src/python/WMCore/Storage/StageOutMgr.py
@@ -9,6 +9,10 @@ use this class as a basic API
 """
 from __future__ import print_function
 
+# If we don't import them, they cannot be ever used (bad PyCharm!)
+import WMCore.Storage.Backends
+import WMCore.Storage.Plugins
+
 from WMCore.WMException import WMException
 from WMCore.Storage.StageOutError import StageOutFailure
 from WMCore.Storage.StageOutError import StageOutInitError


### PR DESCRIPTION
Looking again at the error logs - for the new agent - we can see it's not a problem with xrdcp in the path, but instead with the plugins that were never registered in Registry class. Well, of course the xrdcp is an issue as well, but this is getting addressed somewhere else.

@emaszs I guess you need it for the *21 CRAB branch as well, no?
