### PR TITLE
only add document if the job doc exists

### DIFF
--- a/src/couchapps/WMStats/updates/jobLogArchiveLocation.js
+++ b/src/couchapps/WMStats/updates/jobLogArchiveLocation.js
@@ -1,7 +1,6 @@
 function (doc, req) {
   if (!doc) {
-    doc = {};
-    doc._id = req.id;
+    return [null, 'ERROR'];
   };
   if (doc.logArchiveLFN === undefined) {
       doc.logArchiveLFN = {};


### PR DESCRIPTION
@amaltaro, Alan please review.  This will remove all the Junk document from wmstats.
We were pushing the association for all successful jobs.
