### PR TITLE
Inject phedex data by dataset; improve logging

### DIFF
--- a/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
+++ b/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
@@ -121,10 +121,6 @@ class PhEDExInjectorPoller(BaseWorkerThread):
             if node["kind"] in ["MSS", "Disk"]:
                 self.phedexNodes[node["kind"]].append(node["name"])
 
-        # initialize the alert framework (if available - config.Alert present)
-        #    self.sendAlert will be then be available
-        self.initAlerts(compName="PhEDExInjector")
-
         self.blocksToRecover = []
 
         return
@@ -272,7 +268,6 @@ class PhEDExInjectorPoller(BaseWorkerThread):
             if location == None:
                 msg = "Could not map SE %s to PhEDEx node." % siteName
                 logging.error(msg)
-                self.sendAlert(7, msg=msg)
                 continue
 
             for dataset in uninjectedFiles[siteName]:
@@ -316,7 +311,6 @@ class PhEDExInjectorPoller(BaseWorkerThread):
             if "error" in injectRes:
                 msg = "Error injecting data %s: %s" % (injectData, injectRes["error"])
                 logging.error(msg)
-                self.sendAlert(6, msg=msg)
             else:
                 try:
                     self.setStatus.execute(lfnList, 1)
@@ -360,7 +354,6 @@ class PhEDExInjectorPoller(BaseWorkerThread):
             if location == None:
                 msg = "Could not map SE %s to PhEDEx node." % siteName
                 logging.error(msg)
-                self.sendAlert(6, msg=msg)
                 continue
 
             xmlData = self.createInjectionSpec(migratedBlocks[siteName])
@@ -379,7 +372,6 @@ class PhEDExInjectorPoller(BaseWorkerThread):
                 if "error" in injectRes:
                     msg = "Error closing blocks with data %s: %s" % (migratedBlocks[siteName], injectRes["error"])
                     logging.error(msg)
-                    self.sendAlert(6, msg=msg)
                 else:
                     for datasetName in migratedBlocks[siteName]:
                         for blockName in migratedBlocks[siteName][datasetName]:
@@ -562,7 +554,6 @@ class PhEDExInjectorPoller(BaseWorkerThread):
                 msg = "Site %s doesn't appear to be valid to PhEDEx, " % site
                 msg += "skipping subscription: %s" % subInfo['id']
                 logging.error(msg)
-                self.sendAlert(7, msg=msg)
                 continue
 
             # Avoid custodial subscriptions to disk nodes


### PR DESCRIPTION
I've just noticed the logging of the phedex component is not good at all. This PR makes the following changes:
- inject data/block/files in PhEDEx per location+dataset. It will create more http requests, but with less data. Hopefully hitting less timeouts from phedex backend.
- improved logs to help us debugging issues
- removed the alert system

@ticoann please review. I still have to test it and if possible, I'd like to have it in the 1.0.21 release
