### PR TITLE
Fix type in DQMHarvest; correct GQ stats accounting

### DIFF
--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -384,7 +384,7 @@ class DBS3Reader(object):
             msg = "DBSReader.listDatasetSummary(%s, %s): No matching data"
             raise DBSReaderError(msg % (dataset, block))
         result = remapDBS3Keys(summary[0], stringify=True)
-        result['path'] = dataset if not block else ''
+        result['path'] = dataset if dataset else ''
         result['block'] = block if block else ''
         return result
 
@@ -417,8 +417,7 @@ class DBS3Reader(object):
 
         return blocks
 
-    def listFileBlocks(self, dataset, onlyClosedBlocks=False,
-                       blockName=None):
+    def listFileBlocks(self, dataset, onlyClosedBlocks=False, blockName=None):
         """
         _listFileBlocks_
 

--- a/src/python/WMCore/WMSpec/StdSpecs/DQMHarvest.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/DQMHarvest.py
@@ -23,7 +23,11 @@ class DQMHarvestWorkloadFactory(StdBase):
         self.workload.setDashboardActivity("harvesting")
         self.reportWorkflowToDashboard(self.workload.getDashboardActivity())
 
-        self.workload.setWorkQueueSplitPolicy("Dataset", "FileBased", {"files_per_job": 99999})
+        splitArgs = {"runs_per_job": 1}
+        if self.dqmHarvestUnit == "multiRun":
+            # then it should result in a single job in the end, very high number of runs
+            splitArgs['runs_per_job'] = 999999
+        self.workload.setWorkQueueSplitPolicy("Dataset", "Harvest", splitArgs)
 
         # also creates the logCollect job by default
         self.addDQMHarvestTask(uploadProxy=self.dqmUploadProxy,
@@ -129,13 +133,14 @@ class DQMHarvestWorkloadFactory(StdBase):
 
         harvestTaskCmsswHelper.setUserLFNBase("/")
 
-        (self.inputPrimaryDataset, self.inputProcessedDataset, self.inputDataTier) = self.inputDataset[1:].split("/")
-        harvestTask.addInputDataset(primary=self.inputPrimaryDataset,
-                                    processed=self.inputProcessedDataset,
-                                    tier=self.inputDataTier,
+        (inputPrimaryDataset, inputProcessedDataset, inputDataTier) = self.inputDataset[1:].split("/")
+        harvestTask.addInputDataset(name=self.inputDataset,
+                                    primary=inputPrimaryDataset,
+                                    processed=inputProcessedDataset,
+                                    tier=inputDataTier,
                                     dbsurl=self.dbsUrl,
                                     block_whitelist=self.blockWhitelist,
-                                    black_blacklist=self.blockBlacklist,
+                                    block_blacklist=self.blockBlacklist,
                                     run_whitelist=self.runWhitelist,
                                     run_blacklist=self.runBlacklist)
 

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -344,8 +344,8 @@ class StdBase(object):
         else:
             if inputDataset != None:
                 (primary, processed, tier) = self.inputDataset[1:].split("/")
-                procTask.addInputDataset(primary=primary, processed=processed,
-                                         tier=tier, dbsurl=self.dbsUrl,
+                procTask.addInputDataset(name=self.inputDataset, primary=primary,
+                                         processed=processed, tier=tier, dbsurl=self.dbsUrl,
                                          block_blacklist=self.blockBlacklist,
                                          block_whitelist=self.blockWhitelist,
                                          run_blacklist=self.runBlacklist,

--- a/src/python/WMCore/WMSpec/StdSpecs/StoreResults.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StoreResults.py
@@ -32,7 +32,7 @@ class StoreResultsWorkloadFactory(StdBase):
         """
         StdBase.__call__(self, workloadName, arguments)
 
-        (self.inputPrimaryDataset, self.inputProcessedDataset, self.inputDataTier) = self.inputDataset[1:].split("/")
+        (inputPrimaryDataset, inputProcessedDataset, inputDataTier) = self.inputDataset[1:].split("/")
 
         workload = self.createWorkload()
         
@@ -59,9 +59,10 @@ class StoreResultsWorkloadFactory(StdBase):
         mergeTask.setTaskType("Merge")
         mergeTask.applyTemplates()
         
-        mergeTask.addInputDataset(primary = self.inputPrimaryDataset,
-                                  processed = self.inputProcessedDataset,
-                                  tier = self.inputDataTier,
+        mergeTask.addInputDataset(name=self.inputDataset,
+                                  primary = inputPrimaryDataset,
+                                  processed = inputProcessedDataset,
+                                  tier = inputDataTier,
                                   dbsurl = self.dbsUrl,
                                   block_blacklist = self.blockBlacklist,
                                   block_whitelist = self.blockWhitelist,
@@ -82,7 +83,7 @@ class StoreResultsWorkloadFactory(StdBase):
         mergeTaskCmsswHelper.setDataProcessingConfig("do_not_use", "merge")
         
         self.addOutputModule(mergeTask, "Merged",
-                             primaryDataset = self.inputPrimaryDataset,
+                             primaryDataset = inputPrimaryDataset,
                              dataTier = self.dataTier,
                              filterName = None,
                              forceMerged = True)

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -933,10 +933,12 @@ class WMWorkloadHelper(PersistencyHelper):
                                   "EventBased": ["NumberOfEvents",
                                                  "NumberOfEventsPerLumi"],
                                   "LumiBased": ["NumberOfLumis"],
+                                  "Harvest": ["NumberOfRuns"],
                                   "EventAwareLumiBased": ["NumberOfEvents"]}
         SplitAlgoToArgMap = {"NumberOfFiles": "files_per_job",
                              "NumberOfEvents": "events_per_job",
                              "NumberOfLumis": "lumis_per_job",
+                             "NumberOfRuns": "runs_per_job",
                              "NumberOfEventsPerLumi": "events_per_lumi"}
         startPolicyArgs = {'SplittingAlgo': splitAlgo}
         startPolicyArgs.update(kwargs)

--- a/src/python/WMCore/WorkQueue/Policy/Start/Block.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Block.py
@@ -8,7 +8,6 @@ __all__ = []
 from math import ceil
 from WMCore.WorkQueue.Policy.Start.StartPolicyInterface import StartPolicyInterface
 from WMCore.Services.SiteDB.SiteDB import SiteDBJSON as SiteDB
-from WMCore.DataStructs.LumiList import LumiList
 from WMCore.WorkQueue.WorkQueueExceptions import WorkQueueWMSpecError
 from WMCore.WorkQueue.WorkQueueUtils import makeLocationsList
 from WMCore import Lexicon
@@ -200,37 +199,7 @@ class Block(StartPolicyInterface):
             validBlocks.append(block)
         return validBlocks
 
-    def getMaskedBlocks(self, task, dbs, datasetPath):
-        """ Get the blocks which pass the lumi mask restrictions. For each block return the list of lumis
-            which were ok (given the lumi mask). The data structure returned is the following:
 
-            {
-                "block1" : {"file1" : LumiList(), "file5" : LumiList(), ...}
-                "block2" : {"file2" : LumiList(), "file7" : LumiList(), ...}
-            }
-
-        """
-        # Get the task mask as a LumiList object to make operations easier
-        maskedBlocks = {}
-        taskMask = task.getLumiMask()
-
-        # for performance reasons, we first get all the blocknames
-        blocks = [x['block_name'] for x in dbs.dbs.listBlocks(dataset=datasetPath)]
-
-        for block in blocks:
-            fileLumis = dbs.dbs.listFileLumis(block_name=block, validFileOnly=1)
-            for fileLumi in fileLumis:
-                lfn = fileLumi['logical_file_name']
-                runNumber = str(fileLumi['run_num'])
-                lumis = fileLumi['lumi_section_num']
-                fileMask = LumiList(runsAndLumis={runNumber: lumis})
-                commonMask = taskMask & fileMask
-                if commonMask:
-                    maskedBlocks.setdefault(block, {})
-                    maskedBlocks[block].setdefault(lfn, LumiList())
-                    maskedBlocks[block][lfn] += commonMask
-
-        return maskedBlocks
 
     def modifyPolicyForWorkAddition(self, inboxElement):
         """

--- a/src/python/WMCore/WorkQueue/Policy/Start/Dataset.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Dataset.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python
 """
-WorkQueue splitting by dataset
+WorkQueue splitting by dataset, it creates one single
+workqueue element per dataset.
 
+This policy is specifically used by DQMHarvest workflows, which requires
+some special handling based on run information. Nonetheless, trying to
+make it generic enough that could be used by other spec types.
 """
 __all__ = []
 
@@ -18,7 +22,7 @@ class Dataset(StartPolicyInterface):
 
     def __init__(self, **args):
         StartPolicyInterface.__init__(self, **args)
-        self.args.setdefault('SliceType', 'NumberOfFiles')
+        self.args.setdefault('SliceType', 'NumberOfRuns')
         self.args.setdefault('SliceSize', 1)
         self.lumiType = "NumberOfLumis"
         self.sites = []
@@ -26,15 +30,12 @@ class Dataset(StartPolicyInterface):
 
     def split(self):
         """Apply policy to spec"""
-        dbs = self.dbs()
-        work = 0
+        work = set() if self.args['SliceType'] == 'NumberOfRuns' else 0
         numFiles = 0
         numEvents = 0
         numLumis = 0
-        inputDataset = self.initialTask.inputDataset()
-        datasetPath = "/%s/%s/%s" % (inputDataset.primary,
-                                     inputDataset.processed,
-                                     inputDataset.tier)
+        datasetPath = self.initialTask.getInputDatasetPath()
+
         # dataset splitting can't have its data selection overridden
         if self.data and self.data.keys() != [datasetPath]:
             raise RuntimeError("Can't provide different data to split with")
@@ -44,31 +45,28 @@ class Dataset(StartPolicyInterface):
             return
 
         for block in blocks:
-            work += float(block[self.args['SliceType']])
+            if self.args['SliceType'] == 'NumberOfRuns':
+                work = work.union(block[self.args['SliceType']])
+            else:
+                work += float(block[self.args['SliceType']])
             numLumis += int(block[self.lumiType])
             numFiles += int(block['NumberOfFiles'])
             numEvents += int(block['NumberOfEvents'])
 
-        dataset = dbs.getDBSSummaryInfo(dataset=datasetPath)
-
-        # If the dataset which is not in dbs is passed, just return.
-        # The exception will be created in upper level
-        # when there is no work created
-        if not dataset:
-            return
+        if self.args['SliceType'] == 'NumberOfRuns':
+            numJobs = ceil(len(work) / float(self.args['SliceSize']))
+        else:
+            numJobs = ceil(float(work) / float(self.args['SliceSize']))
 
         # parentage
         parentFlag = True if self.initialTask.parentProcessingFlag() else False
 
-        if not work:
-            work = dataset[self.args['SliceType']]
-
-        self.newQueueElement(Inputs={dataset['path']: self.data.get(dataset['path'], [])},
+        self.newQueueElement(Inputs={datasetPath: self.data.get(datasetPath, [])},
                              ParentFlag=parentFlag,
                              NumberOfLumis=numLumis,
                              NumberOfFiles=numFiles,
                              NumberOfEvents=numEvents,
-                             Jobs=ceil(float(work) / float(self.args['SliceSize'])),
+                             Jobs=numJobs,
                              NoInputUpdate=self.initialTask.getTrustSitelists().get('trustlists'),
                              NoPileupUpdate=self.initialTask.getTrustSitelists().get('trustPUlists')
                             )
@@ -90,87 +88,94 @@ class Dataset(StartPolicyInterface):
         blockBlackList = task.inputBlockBlacklist()
         runWhiteList = task.inputRunWhitelist()
         runBlackList = task.inputRunBlacklist()
-
-        if task.getTrustSitelists().get('trustlists'):
-            siteWhitelist = task.siteWhitelist()
-            siteBlacklist = task.siteBlacklist()
-            self.sites = makeLocationsList(siteWhitelist, siteBlacklist)
+        lumiMask = task.getLumiMask()
+        if lumiMask:
+            maskedBlocks = self.getMaskedBlocks(task, dbs, datasetPath)
 
         for blockName in dbs.listFileBlocks(datasetPath):
-            block = dbs.getDBSSummaryInfo(datasetPath, block=blockName)
-
             # check block restrictions
-            if blockWhiteList and block['block'] not in blockWhiteList:
+            if blockWhiteList and blockName not in blockWhiteList:
                 continue
-            if block['block'] in blockBlackList:
+            if blockName in blockBlackList:
                 continue
 
+            blockSummary = dbs.getDBSSummaryInfo(block=blockName)
+            if self.args['SliceType'] == 'NumberOfRuns':
+                blockSummary['NumberOfRuns'] = dbs.listRuns(block=blockName)
+
+            if int(blockSummary['NumberOfFiles']) == 0:
+                self.rejectedWork.append(blockName)
+                continue
+
+            # check lumi restrictions
+            if lumiMask:
+                if blockName not in maskedBlocks:
+                    self.rejectedWork.append(blockName)
+                    continue
+
+                acceptedLumiCount = sum([len(maskedBlocks[blockName][lfn].getLumis()) for lfn in maskedBlocks[blockName]])
+                ratioAccepted = 1. * acceptedLumiCount / float(blockSummary['NumberOfLumis'])
+                maskedRuns = [maskedBlocks[blockName][lfn].getRuns() for lfn in maskedBlocks[blockName]]
+                acceptedRuns = set(lumiMask.getRuns()).intersection(set().union(*maskedRuns))
+
+                blockSummary['NumberOfFiles'] = len(maskedBlocks[blockName])
+                blockSummary['NumberOfEvents'] = float(blockSummary['NumberOfEvents']) * ratioAccepted
+                blockSummary[self.lumiType] = acceptedLumiCount
+                blockSummary['NumberOfRuns'] = acceptedRuns
             # check run restrictions
-            if runWhiteList or runBlackList:
-                # listRunLumis returns a dictionary with the lumi sections per run
-                runLumis = dbs.listRunLumis(block=block['block'])
-                runs = set(runLumis.keys())
-                recalculateLumiCounts = False
-                if len(runs) > 1:
-                    # If more than one run in the block
-                    # Then we must calculate the lumi counts after filtering the run list
-                    # This has to be done rarely and requires calling DBS file information
-                    recalculateLumiCounts = True
+            elif runWhiteList or runBlackList:
+                runs = set(dbs.listRuns(block=blockName))
+                # multi run blocks need special account, requires more DBS calls
+                recalculateLumiCounts = True if len(runs) > 1 else False
 
-                # apply blacklist
+                # apply blacklist and whitelist
                 runs = runs.difference(runBlackList)
-                # if whitelist only accept listed runs
                 if runWhiteList:
                     runs = runs.intersection(runWhiteList)
                 # any runs left are ones we will run on, if none ignore block
                 if not runs:
+                    self.rejectedWork.append(blockName)
                     continue
 
                 if recalculateLumiCounts:
-                    # get correct lumi count
-                    # Recalculate effective size of block
-                    # We pull out file info, since we don't do this often
+                    # Recalculate the number of files, lumis and ~events accepted
                     acceptedLumiCount = 0
                     acceptedEventCount = 0
                     acceptedFileCount = 0
-                    fileInfo = dbs.listFilesInBlock(fileBlockName=block['block'])
+                    fileInfo = dbs.listFilesInBlock(fileBlockName=blockName)
+
                     for fileEntry in fileInfo:
                         acceptedFile = False
-                        acceptedFileLumiCount = 0
                         for lumiInfo in fileEntry['LumiList']:
-                            runNumber = lumiInfo['RunNumber']
-                            if runNumber in runs:
+                            if lumiInfo['RunNumber'] in runs:
                                 acceptedFile = True
-                                acceptedFileLumiCount += 1
+                                acceptedLumiCount += len(lumiInfo['LumiSectionNumber'])
                         if acceptedFile:
                             acceptedFileCount += 1
-                            acceptedLumiCount += acceptedFileLumiCount
-                            if len(fileEntry['LumiList']) != acceptedFileLumiCount:
-                                acceptedEventCount += float(acceptedFileLumiCount) * fileEntry['NumberOfEvents'] / len(
-                                    fileEntry['LumiList'])
-                            else:
-                                acceptedEventCount += fileEntry['NumberOfEvents']
+                            acceptedEventCount += fileEntry['NumberOfEvents']
+
                 else:
-                    acceptedLumiCount = block["NumberOfLumis"]
-                    acceptedFileCount = block['NumberOfFiles']
-                    acceptedEventCount = block['NumberOfEvents']
+                    acceptedLumiCount = blockSummary["NumberOfLumis"]
+                    acceptedFileCount = blockSummary['NumberOfFiles']
+                    acceptedEventCount = blockSummary['NumberOfEvents']
 
-                # recalculate effective size of block
-                # make a guess for new event/file numbers from ratio
-                # of accepted lumi sections (otherwise have to pull file info)
+                blockSummary[self.lumiType] = acceptedLumiCount
+                blockSummary['NumberOfFiles'] = acceptedFileCount
+                blockSummary['NumberOfEvents'] = acceptedEventCount
+                blockSummary['NumberOfRuns'] = runs
 
-                block[self.lumiType] = acceptedLumiCount
-                block['NumberOfFiles'] = acceptedFileCount
-                block['NumberOfEvents'] = acceptedEventCount
+            validBlocks.append(blockSummary)
 
-            validBlocks.append(block)
             if locations is None:
-                locations = set(dbs.listFileBlockLocation(block['block']))
+                locations = set(dbs.listFileBlockLocation(blockName))
             else:
-                locations = locations.intersection(dbs.listFileBlockLocation(block['block']))
+                locations = locations.intersection(dbs.listFileBlockLocation(blockName))
 
         # all needed blocks present at these sites
-        if self.wmspec.getTrustLocationFlag().get('trustlists'):
+        if task.getTrustSitelists().get('trustlists'):
+            siteWhitelist = task.siteWhitelist()
+            siteBlacklist = task.siteBlacklist()
+            self.sites = makeLocationsList(siteWhitelist, siteBlacklist)
             self.data[datasetPath] = self.sites
         elif locations:
             self.data[datasetPath] = list(set(self.siteDB.PNNstoPSNs(locations)))

--- a/test/python/WMCore_t/Services_t/DBS_t/DBSReader_t.py
+++ b/test/python/WMCore_t/Services_t/DBS_t/DBSReader_t.py
@@ -161,7 +161,7 @@ class DBSReaderTest(EmulatedUnitTestCase):
         self.assertEqual(dataset['NumberOfLumis'], 7223)
 
         block = self.dbs.getDBSSummaryInfo(DATASET, BLOCK)
-        self.assertEqual(block['path'], '')
+        self.assertEqual(block['path'], DATASET)
         self.assertEqual(block['block'], BLOCK)
         self.assertEqual(block['NumberOfEvents'], 377)
         self.assertEqual(block['NumberOfBlocks'], 1)

--- a/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Block_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Block_t.py
@@ -283,18 +283,9 @@ class BlockTestCase(EmulatedUnitTestCase):
         for task in processingSpec.taskIterator():
             self.assertRaises(DBSReaderError, Block(), processingSpec, task)
 
-        # invalid dataset name
-        # This test is throwing a DBS exception but continuing on:
-        # Message: DbsBadRequest: DBS Server Raised An Error
-        # ModuleName : WMCore.Services.DBS.DBSErrors
-        # MethodName : __init__
-        # ClassInstance : None
-        # FileName : .../WMCore/Services/DBS/DBSErrors.py
-        # ClassName : None
-        # LineNumber : 29
-        # ErrorNr : 1002
+        # dataset non existent
         processingSpec = factory.factoryWorkloadConstruction('testProcessingInvalid', rerecoArgs)
-        getFirstTask(processingSpec).data.input.dataset.primary = NOT_EXIST_DATASET
+        getFirstTask(processingSpec).data.input.dataset.name = "/MinimumBias/FAKE-Filter-v1/RECO"
         for task in processingSpec.taskIterator():
             self.assertRaises(DBSReaderError, Block(), processingSpec, task)
 

--- a/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Dataset_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Dataset_t.py
@@ -4,28 +4,34 @@
 """
 
 import unittest
-
+from WMCore_t.WorkQueue_t.WorkQueue_t import getFirstTask
 from WMCore_t.WMSpec_t.samples.MultiTaskProcessingWorkload \
     import workload as MultiTaskProcessingWorkload
-from WMCore_t.WorkQueue_t.WorkQueue_t import getFirstTask
 
 from WMCore.Services.DBS.DBSErrors import DBSReaderError
-from WMCore.Services.DBS.DBSReader import DBSReader
 from WMCore.WMSpec.StdSpecs.ReReco import ReRecoWorkloadFactory
+from WMCore.WMSpec.StdSpecs.DQMHarvest import DQMHarvestWorkloadFactory
 from WMCore.WorkQueue.Policy.Start.Dataset import Dataset
 from WMCore.WorkQueue.WorkQueueExceptions import (WorkQueueWMSpecError, WorkQueueNoWorkError)
 from WMQuality.Emulators.EmulatedUnitTestCase import EmulatedUnitTestCase
 from WMQuality.Emulators.PhEDExClient.MockPhEDExApi import NOT_EXIST_DATASET
 from WMQuality.Emulators.WMSpecGenerator.WMSpecGenerator import createConfig
 
-rerecoArgs = ReRecoWorkloadFactory.getTestArguments()
-parentProcArgs = ReRecoWorkloadFactory.getTestArguments()
-parentProcArgs.update(IncludeParents="True")
+
+def getRequestArgs():
+    """ Returns default values defined in the spec workload """
+    return DQMHarvestWorkloadFactory.getTestArguments()
+
+
+def getReRecoArgs(parent=False):
+    """ Returns default values defined in the spec workload """
+    rerecoArgs = ReRecoWorkloadFactory.getTestArguments()
+    if parent:
+        rerecoArgs.update(IncludeParents="True")
+    return rerecoArgs
 
 
 class DatasetTestCase(EmulatedUnitTestCase):
-    splitArgs = dict(SliceType='NumberOfFiles', SliceSize=5)
-
     def __init__(self, methodName='runTest'):
         super(DatasetTestCase, self).__init__(methodName=methodName)
 
@@ -35,39 +41,133 @@ class DatasetTestCase(EmulatedUnitTestCase):
     def tearDown(self):
         super(DatasetTestCase, self).tearDown()
 
+    def testDatasetPolicy(self):
+        """
+        Test ordinary NumberOfRuns splitting
+        """
+        dqmHarvArgs = getRequestArgs()
+        dqmHarvArgs["DQMConfigCacheID"] = createConfig(dqmHarvArgs["CouchDBName"])
+        factory = DQMHarvestWorkloadFactory()
+        DQMHarvWorkload = factory.factoryWorkloadConstruction('DQMHarvestTest', dqmHarvArgs)
+        splitArgs = DQMHarvWorkload.startPolicyParameters()
+        inputDataset = getFirstTask(DQMHarvWorkload).getInputDatasetPath()
+
+        for task in DQMHarvWorkload.taskIterator():
+            units, _ = Dataset(**splitArgs)(DQMHarvWorkload, task)
+            self.assertEqual(1, len(units))
+            for unit in units:
+                self.assertEqual(47, unit['Jobs'])
+                self.assertEqual(DQMHarvWorkload, unit['WMSpec'])
+                self.assertEqual(task, unit['Task'])
+                self.assertEqual(unit['Inputs'].keys(), [inputDataset])
+                self.assertEqual(4855, unit['NumberOfLumis'])
+                self.assertEqual(72, unit['NumberOfFiles'])
+                self.assertEqual(743201, unit['NumberOfEvents'])
+
+    def testDatasetRunWhitelist(self):
+        """
+        Test NumberOfRuns splitting with run white list
+        """
+        dqmHarvArgs = getRequestArgs()
+        dqmHarvArgs["DQMConfigCacheID"] = createConfig(dqmHarvArgs["CouchDBName"])
+        dqmHarvArgs["RunWhitelist"] = [181358, 181417, 180992, 181151]
+        factory = DQMHarvestWorkloadFactory()
+        DQMHarvWorkload = factory.factoryWorkloadConstruction('DQMHarvestTest', dqmHarvArgs)
+        splitArgs = DQMHarvWorkload.startPolicyParameters()
+        inputDataset = getFirstTask(DQMHarvWorkload).getInputDatasetPath()
+
+        for task in DQMHarvWorkload.taskIterator():
+            units, _ = Dataset(**splitArgs)(DQMHarvWorkload, task)
+            self.assertEqual(1, len(units))
+            for unit in units:
+                self.assertEqual(4, unit['Jobs'])
+                self.assertEqual(DQMHarvWorkload, unit['WMSpec'])
+                self.assertEqual(task, unit['Task'])
+                self.assertEqual(unit['Inputs'].keys(), [inputDataset])
+                self.assertEqual(217, unit['NumberOfLumis'])
+                self.assertEqual(8, unit['NumberOfFiles'])
+                self.assertEqual(83444, unit['NumberOfEvents'])
+
+    def testDatasetLumiMask(self):
+        """
+        Test NumberOfRuns splitting type with lumi mask
+        """
+        dqmHarvArgs = getRequestArgs()
+        dqmHarvArgs["DQMConfigCacheID"] = createConfig(dqmHarvArgs["CouchDBName"])
+        dqmHarvArgs["LumiList"] = {"181358": [[71, 80], [95, 110]], "181151": [[1, 20]]}
+        factory = DQMHarvestWorkloadFactory()
+        DQMHarvWorkload = factory.factoryWorkloadConstruction('DQMHarvestTest', dqmHarvArgs)
+        splitArgs = DQMHarvWorkload.startPolicyParameters()
+        inputDataset = getFirstTask(DQMHarvWorkload).getInputDatasetPath()
+
+        for task in DQMHarvWorkload.taskIterator():
+            units, _ = Dataset(**splitArgs)(DQMHarvWorkload, task)
+            self.assertEqual(1, len(units))
+            for unit in units:
+                self.assertEqual(2, unit['Jobs'])
+                self.assertEqual(DQMHarvWorkload, unit['WMSpec'])
+                self.assertEqual(task, unit['Task'])
+                self.assertEqual(unit['Inputs'].keys(), [inputDataset])
+                self.assertEqual(46, unit['NumberOfLumis'])
+                self.assertEqual(4, unit['NumberOfFiles'])
+                self.assertEqual(12342, unit['NumberOfEvents'])
+
+    def testDatasetSingleJob(self):
+        """
+        Test NumberOfRuns splitting type with very large SliceSize
+        """
+        dqmHarvArgs = getRequestArgs()
+        dqmHarvArgs["DQMConfigCacheID"] = createConfig(dqmHarvArgs["CouchDBName"])
+        dqmHarvArgs["DQMHarvestUnit"] = 'multiRun'
+        factory = DQMHarvestWorkloadFactory()
+        DQMHarvWorkload = factory.factoryWorkloadConstruction('DQMHarvestTest', dqmHarvArgs)
+        splitArgs = DQMHarvWorkload.startPolicyParameters()
+        inputDataset = getFirstTask(DQMHarvWorkload).getInputDatasetPath()
+
+        for task in DQMHarvWorkload.taskIterator():
+            units, _ = Dataset(**splitArgs)(DQMHarvWorkload, task)
+            self.assertEqual(1, len(units))
+            for unit in units:
+                self.assertEqual(1, unit['Jobs'])
+                self.assertEqual(DQMHarvWorkload, unit['WMSpec'])
+                self.assertEqual(task, unit['Task'])
+                self.assertEqual(unit['Inputs'].keys(), [inputDataset])
+                self.assertEqual(4855, unit['NumberOfLumis'])
+                self.assertEqual(72, unit['NumberOfFiles'])
+                self.assertEqual(743201, unit['NumberOfEvents'])
+
     def testTier1ReRecoWorkload(self):
         """Tier1 Re-reco workflow"""
+        splitArgs = dict(SliceType='NumberOfFiles', SliceSize=5)
+        rerecoArgs = getReRecoArgs()
         rerecoArgs["ConfigCacheID"] = createConfig(rerecoArgs["CouchDBName"])
         factory = ReRecoWorkloadFactory()
         Tier1ReRecoWorkload = factory.factoryWorkloadConstruction('ReRecoWorkload', rerecoArgs)
-        Tier1ReRecoWorkload.setStartPolicy('Dataset', **self.splitArgs)
-        inputDataset = getFirstTask(Tier1ReRecoWorkload).inputDataset()
-        dataset = "/%s/%s/%s" % (inputDataset.primary, inputDataset.processed, inputDataset.tier)
-        dummyDBS = {inputDataset.dbsurl: DBSReader(inputDataset.dbsurl)}
+        Tier1ReRecoWorkload.setStartPolicy('Dataset', **splitArgs)
+        inputDataset = getFirstTask(Tier1ReRecoWorkload).getInputDatasetPath()
         for task in Tier1ReRecoWorkload.taskIterator():
-            units, _ = Dataset(**self.splitArgs)(Tier1ReRecoWorkload, task)
+            units, _ = Dataset(**splitArgs)(Tier1ReRecoWorkload, task)
             self.assertEqual(1, len(units))
             for unit in units:
                 self.assertEqual(15, unit['Jobs'])
                 self.assertEqual(Tier1ReRecoWorkload, unit['WMSpec'])
                 self.assertEqual(task, unit['Task'])
-                self.assertEqual(unit['Inputs'].keys(), [dataset])
+                self.assertEqual(unit['Inputs'].keys(), [inputDataset])
                 self.assertEqual(4855, unit['NumberOfLumis'])
                 self.assertEqual(72, unit['NumberOfFiles'])
                 self.assertEqual(743201, unit['NumberOfEvents'])
 
     def testMultiTaskProcessingWorkload(self):
         """Multi Task Processing Workflow"""
+        splitArgs = dict(SliceType='NumberOfFiles', SliceSize=5)
         datasets = []
         tasks, count = 0, 0
         for task in MultiTaskProcessingWorkload.taskIterator():
             tasks += 1
-            inputDataset = task.inputDataset()
-            datasets.append("/%s/%s/%s" % (inputDataset.primary,
-                                           inputDataset.processed,
-                                           inputDataset.tier))
+            inputDataset = task.getInputDatasetPath()
+            datasets.append(inputDataset)
         for task in MultiTaskProcessingWorkload.taskIterator():
-            units, _ = Dataset(**self.splitArgs)(MultiTaskProcessingWorkload, task)
+            units, _ = Dataset(**splitArgs)(MultiTaskProcessingWorkload, task)
             self.assertEqual(1, len(units))
             for unit in units:
                 self.assertEqual(22, unit['Jobs'])
@@ -77,135 +177,10 @@ class DatasetTestCase(EmulatedUnitTestCase):
             count += 1
         self.assertEqual(tasks, count)
 
-    def testWhiteBlackLists(self):
-        """Block/Run White/Black lists"""
-        rerecoArgs["ConfigCacheID"] = createConfig(rerecoArgs["CouchDBName"])
-        factory = ReRecoWorkloadFactory()
-        Tier1ReRecoWorkload = factory.factoryWorkloadConstruction('ReRecoWorkload', rerecoArgs)
-        Tier1ReRecoWorkload.setStartPolicy('Dataset', **self.splitArgs)
-        inputDataset = getFirstTask(Tier1ReRecoWorkload).inputDataset()
-        dataset = "/%s/%s/%s" % (inputDataset.primary, inputDataset.processed, inputDataset.tier)
-        dummyDBS = {inputDataset.dbsurl: DBSReader(inputDataset.dbsurl)}
-        white_list = "#5c53d062-0bed-11e1-b764-003048caaace"
-        black_list = "#f29b82f0-0c50-11e1-b764-003048caaace"
-        # Block blacklist
-        rerecoArgs2 = {}
-        rerecoArgs2.update(rerecoArgs)
-        rerecoArgs2.update({'BlockBlacklist': [dataset + black_list]})
-        blacklistBlockWorkload = factory.factoryWorkloadConstruction('ReRecoWorkload', rerecoArgs2)
-        blacklistBlockWorkload.setStartPolicy('Dataset', **self.splitArgs)
-        task = getFirstTask(blacklistBlockWorkload)
-        units, _ = Dataset(**self.splitArgs)(blacklistBlockWorkload, task)
-        self.assertEqual(len(units), 1)
-        self.assertEqual(units[0]['Jobs'], 15.0)
-        self.assertEqual(4813, units[0]['NumberOfLumis'])
-        self.assertEqual(71, units[0]['NumberOfFiles'])
-        self.assertEqual(725849, units[0]['NumberOfEvents'])
-
-        # Block Whitelist
-        rerecoArgs2['BlockWhitelist'] = [dataset + white_list]
-        rerecoArgs2['BlockBlacklist'] = []
-
-        blacklistBlockWorkload = factory.factoryWorkloadConstruction('ReRecoWorkload', rerecoArgs2)
-        blacklistBlockWorkload.setStartPolicy('Dataset', **self.splitArgs)
-        task = getFirstTask(blacklistBlockWorkload)
-        units, _ = Dataset(**self.splitArgs)(blacklistBlockWorkload, task)
-
-        self.assertEqual(len(units), 1)
-        self.assertEqual(units[0]['Jobs'], 1.0)
-        self.assertEqual(21, units[0]['NumberOfLumis'])
-        self.assertEqual(1, units[0]['NumberOfFiles'])
-        self.assertEqual(20176, units[0]['NumberOfEvents'])
-        # Block Mixed Whitelist
-        rerecoArgs2['BlockWhitelist'] = [dataset + white_list]
-        rerecoArgs2['BlockBlacklist'] = [dataset + black_list]
-        blacklistBlockWorkload = factory.factoryWorkloadConstruction('ReRecoWorkload', rerecoArgs2)
-        blacklistBlockWorkload.setStartPolicy('Dataset', **self.splitArgs)
-        task = getFirstTask(blacklistBlockWorkload)
-        units, _ = Dataset(**self.splitArgs)(blacklistBlockWorkload, task)
-        self.assertEqual(len(units), 1)
-        self.assertEqual(units[0]['Jobs'], 1.0)
-        self.assertEqual(21, units[0]['NumberOfLumis'])
-        self.assertEqual(1, units[0]['NumberOfFiles'])
-        self.assertEqual(20176, units[0]['NumberOfEvents'])
-
-        # Run Whitelist
-        rerecoArgs3 = {}
-        rerecoArgs3.update(rerecoArgs)
-        rerecoArgs3.update({'RunWhitelist': [181061]})
-        blacklistBlockWorkload = factory.factoryWorkloadConstruction('ReRecoWorkload', rerecoArgs3)
-        blacklistBlockWorkload.setStartPolicy('Dataset', **self.splitArgs)
-        task = getFirstTask(blacklistBlockWorkload)
-        units, _ = Dataset(**self.splitArgs)(blacklistBlockWorkload, task)
-
-        self.assertEqual(len(units), 1)
-        self.assertEqual(units[0]['Inputs'].keys(), [dataset])
-        self.assertEqual(units[0]['Jobs'], 1.0)
-        self.assertEqual(71, units[0]['NumberOfLumis'])
-        self.assertEqual(1, units[0]['NumberOfFiles'])
-        self.assertEqual(5694, units[0]['NumberOfEvents'])
-
-        rerecoArgs3 = {}
-        rerecoArgs3.update(rerecoArgs)
-        rerecoArgs3.update({'RunWhitelist': [181061, 181175]})
-        blacklistBlockWorkload = factory.factoryWorkloadConstruction('ReRecoWorkload', rerecoArgs3)
-        blacklistBlockWorkload.setStartPolicy('Dataset', **self.splitArgs)
-        task = getFirstTask(blacklistBlockWorkload)
-        units, _ = Dataset(**self.splitArgs)(blacklistBlockWorkload, task)
-        self.assertEqual(len(units), 1)
-        self.assertEqual(units[0]['Inputs'].keys(), [dataset])
-        self.assertEqual(units[0]['Jobs'], 1.0)
-        self.assertEqual(250, units[0]['NumberOfLumis'])
-        self.assertEqual(2, units[0]['NumberOfFiles'])
-        self.assertEqual(13766, units[0]['NumberOfEvents'])
-
-        # Run Blacklist
-        rerecoArgs3 = {}
-        rerecoArgs3.update(rerecoArgs)
-        rerecoArgs3.update({'RunBlacklist': [181175]})
-        blacklistBlockWorkload = factory.factoryWorkloadConstruction('ReRecoWorkload', rerecoArgs3)
-        blacklistBlockWorkload.setStartPolicy('Dataset', **self.splitArgs)
-        task = getFirstTask(blacklistBlockWorkload)
-        units, _ = Dataset(**self.splitArgs)(blacklistBlockWorkload, task)
-
-        self.assertEqual(len(units), 1)
-        self.assertEqual(units[0]['Inputs'].keys(), [dataset])
-        self.assertEqual(units[0]['Jobs'], 15.0)
-        self.assertEqual(4676, units[0]['NumberOfLumis'])
-        self.assertEqual(71, units[0]['NumberOfFiles'])
-        self.assertEqual(735129, units[0]['NumberOfEvents'])
-
-        # Run Mixed Whitelist
-        rerecoArgs3 = {}
-        rerecoArgs3.update(rerecoArgs)
-        rerecoArgs3.update({'RunBlacklist': [181175], 'RunWhitelist': [181061]})
-        blacklistBlockWorkload = factory.factoryWorkloadConstruction('ReRecoWorkload', rerecoArgs3)
-        blacklistBlockWorkload.setStartPolicy('Dataset', **self.splitArgs)
-        task = getFirstTask(blacklistBlockWorkload)
-        units, _ = Dataset(**self.splitArgs)(blacklistBlockWorkload, task)
-        self.assertEqual(len(units), 1)
-        self.assertEqual(units[0]['Inputs'].keys(), [dataset])
-        self.assertEqual(units[0]['Jobs'], 1.0)
-        self.assertEqual(71, units[0]['NumberOfLumis'])
-        self.assertEqual(1, units[0]['NumberOfFiles'])
-        self.assertEqual(5694, units[0]['NumberOfEvents'])
-
-    def testDataDirectiveFromQueue(self):
-        """Test data directive from queue"""
-        rerecoArgs["ConfigCacheID"] = createConfig(rerecoArgs["CouchDBName"])
-        factory = ReRecoWorkloadFactory()
-        Tier1ReRecoWorkload = factory.factoryWorkloadConstruction('ReRecoWorkload', rerecoArgs)
-        inputDataset = getFirstTask(Tier1ReRecoWorkload).inputDataset()
-        dataset = "/%s/%s/%s" % (inputDataset.primary, inputDataset.processed, inputDataset.tier)
-        dbs = {inputDataset.dbsurl: DBSReader(inputDataset.dbsurl)}
-        for task in Tier1ReRecoWorkload.taskIterator():
-            Dataset(**self.splitArgs)(Tier1ReRecoWorkload, task, {dataset: []})
-            self.assertRaises(RuntimeError, Dataset(**self.splitArgs), Tier1ReRecoWorkload, task, dbs,
-                              {dataset + '1': []})
-
     def testLumiSplitTier1ReRecoWorkload(self):
         """Tier1 Re-reco workflow split by Lumi"""
         splitArgs = dict(SliceType='NumberOfLumis', SliceSize=2)
+        rerecoArgs = getReRecoArgs()
         rerecoArgs["ConfigCacheID"] = createConfig(rerecoArgs["CouchDBName"])
         factory = ReRecoWorkloadFactory()
         Tier1ReRecoWorkload = factory.factoryWorkloadConstruction('ReRecoWorkload', rerecoArgs)
@@ -216,85 +191,70 @@ class DatasetTestCase(EmulatedUnitTestCase):
             for unit in units:
                 self.assertEqual(2428, unit['Jobs'])
 
-    def testRunWhitelist(self):
-        """
-        ReReco lumi split with Run whitelist
-        This test may not do much of anything anymore since listRunLumis is not in DBS3
-        """
-
-        splitArgs = dict(SliceType='NumberOfLumis', SliceSize=1)
-        rerecoArgs["ConfigCacheID"] = createConfig(rerecoArgs["CouchDBName"])
-        factory = ReRecoWorkloadFactory()
-        Tier1ReRecoWorkload = factory.factoryWorkloadConstruction('ReRecoWorkload', rerecoArgs)
-        Tier1ReRecoWorkload.setRunWhitelist([181061, 181175])
-        Tier1ReRecoWorkload.setStartPolicy('Dataset', **splitArgs)
-        inputDataset = getFirstTask(Tier1ReRecoWorkload).inputDataset()
-        dbs = {inputDataset.dbsurl: DBSReader(inputDataset.dbsurl)}
-        for task in Tier1ReRecoWorkload.taskIterator():
-            units, _ = Dataset(**splitArgs)(Tier1ReRecoWorkload, task)
-            self.assertEqual(1, len(units))
-            # Check number of jobs in element match number for
-            # dataset in run whitelist
-            wq_jobs = 0
-            for unit in units:
-                wq_jobs += unit['Jobs']
-                runLumis = dbs[inputDataset.dbsurl].listRunLumis(dataset=unit['Inputs'].keys()[0])
-                for run in runLumis:
-                    if run in getFirstTask(Tier1ReRecoWorkload).inputRunWhitelist():
-                        # This is what it is with DBS3 unless we calculate it
-                        self.assertEqual(runLumis[run], None)
-            self.assertEqual(250, int(wq_jobs))
-
-    def testInvalidSpecs(self):
-        """Specs with no work"""
-        # no dataset
-        rerecoArgs["ConfigCacheID"] = createConfig(rerecoArgs["CouchDBName"])
-        factory = ReRecoWorkloadFactory()
-        processingSpec = factory.factoryWorkloadConstruction('testProcessingInvalid', rerecoArgs)
-        getFirstTask(processingSpec).data.input.dataset = None
-        for task in processingSpec.taskIterator():
-            self.assertRaises(WorkQueueWMSpecError, Dataset(), processingSpec, task)
-
-        # invalid dataset name
-        processingSpec = factory.factoryWorkloadConstruction('testProcessingInvalid', rerecoArgs)
-        getFirstTask(processingSpec).data.input.dataset.primary = NOT_EXIST_DATASET
-
-        for task in processingSpec.taskIterator():
-            self.assertRaises(DBSReaderError, Dataset(), processingSpec, task)
-
-        # invalid run whitelist
-        processingSpec = factory.factoryWorkloadConstruction('testProcessingInvalid', rerecoArgs)
-        processingSpec.setRunWhitelist([666])  # not in this dataset
-        for task in processingSpec.taskIterator():
-            self.assertRaises(WorkQueueNoWorkError, Dataset(), processingSpec, task)
-
     def testParentProcessing(self):
         """
         test parent processing: should have the same results as rereco test
         with the parent flag and dataset.
         """
-        parentProcArgs["ConfigCacheID"] = createConfig(rerecoArgs["CouchDBName"])
+        splitArgs = dict(SliceType='NumberOfLumis', SliceSize=2)
+        parentProcArgs = getReRecoArgs(parent=True)
+        parentProcArgs["ConfigCacheID"] = createConfig(parentProcArgs["CouchDBName"])
         factory = ReRecoWorkloadFactory()
 
-        # This dataset does have parents. Adding it here to keep the test going. It seems like "dbs" below is never used
+        # This dataset does have parents. Adding it here to keep the test going.
+        # It seems like "dbs" below is never used
         parentProcArgs2 = {}
         parentProcArgs2.update(parentProcArgs)
         parentProcArgs2.update({'InputDataset': '/SingleMu/CMSSW_6_2_0_pre4-PRE_61_V1_RelVal_mu2012A-v1/RECO'})
         parentProcSpec = factory.factoryWorkloadConstruction('testParentProcessing', parentProcArgs2)
-        parentProcSpec.setStartPolicy('Dataset', **self.splitArgs)
-        inputDataset = getFirstTask(parentProcSpec).inputDataset()
-        dataset = "/%s/%s/%s" % (inputDataset.primary, inputDataset.processed, inputDataset.tier)
-        dummyDBS = {inputDataset.dbsurl: DBSReader(inputDataset.dbsurl)}
+        parentProcSpec.setStartPolicy('Dataset', **splitArgs)
+        inputDataset = getFirstTask(parentProcSpec).getInputDatasetPath()
         for task in parentProcSpec.taskIterator():
-            units, _ = Dataset(**self.splitArgs)(parentProcSpec, task)
+            units, _ = Dataset(**splitArgs)(parentProcSpec, task)
             self.assertEqual(1, len(units))
             for unit in units:
-                self.assertEqual(64, unit['Jobs'])
+                self.assertEqual(847, unit['Jobs'])
+                self.assertEqual(1694, unit['NumberOfLumis'])
                 self.assertEqual(parentProcSpec, unit['WMSpec'])
                 self.assertEqual(task, unit['Task'])
-                self.assertEqual(unit['Inputs'].keys(), [dataset])
+                self.assertEqual(unit['Inputs'].keys(), [inputDataset])
                 self.assertEqual(True, unit['ParentFlag'])
                 self.assertEqual(0, len(unit['ParentData']))
+
+    def testDataDirectiveFromQueue(self):
+        """Test data directive from queue"""
+        dqmHarvArgs = getRequestArgs()
+        dqmHarvArgs["DQMConfigCacheID"] = createConfig(dqmHarvArgs["CouchDBName"])
+        factory = DQMHarvestWorkloadFactory()
+        DQMHarvWorkload = factory.factoryWorkloadConstruction('DQMHarvestTest', dqmHarvArgs)
+
+        splitArgs = DQMHarvWorkload.startPolicyParameters()
+
+        for task in DQMHarvWorkload.taskIterator():
+            self.assertRaises(RuntimeError, Dataset(**splitArgs), DQMHarvWorkload, task, {NOT_EXIST_DATASET: []})
+
+    def testInvalidSpecs(self):
+        """Specs with no work"""
+        dqmHarvArgs = getRequestArgs()
+        # no dataset
+        dqmHarvArgs["DQMConfigCacheID"] = createConfig(dqmHarvArgs["CouchDBName"])
+        factory = DQMHarvestWorkloadFactory()
+        DQMHarvWorkload = factory.factoryWorkloadConstruction('NoInputDatasetTest', dqmHarvArgs)
+        getFirstTask(DQMHarvWorkload).data.input.dataset = None
+        for task in DQMHarvWorkload.taskIterator():
+            self.assertRaises(WorkQueueWMSpecError, Dataset(), DQMHarvWorkload, task)
+
+        # invalid dataset name
+        DQMHarvWorkload = factory.factoryWorkloadConstruction('InvalidInputDatasetTest', dqmHarvArgs)
+        getFirstTask(DQMHarvWorkload).data.input.dataset.name = '/MinimumBias/FAKE-Filter-v1/RECO'
+        for task in DQMHarvWorkload.taskIterator():
+            self.assertRaises(DBSReaderError, Dataset(), DQMHarvWorkload, task)
+
+        # invalid run whitelist
+        DQMHarvWorkload = factory.factoryWorkloadConstruction('InvalidRunNumberTest', dqmHarvArgs)
+        DQMHarvWorkload.setRunWhitelist([666])  # not in this dataset
+        for task in DQMHarvWorkload.taskIterator():
+            self.assertRaises(WorkQueueNoWorkError, Dataset(), DQMHarvWorkload, task)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Several minor changes to the DQMHarvest spec:
- fixed typo (black_blacklist)
- use the correct splitting algo for the spec and start policy
- gather correct statistics at GQ level (not for events)
- added dataset name to the WMTask attributes (to avoid using PD,ProcStr,Tier all the time)

DQMHarvesting tests look Ok in my VM, still a wider test missing.
@ticoann please review
