### PR TITLE
Add DBS to CRABClient package dependencies

### DIFF
--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -127,7 +127,7 @@ dependencies = {'wmc-rest':{
                         },
                 'crabclient':{
                         'packages': ['WMCore.Wrappers+', 'WMCore.Credential', 'PSetTweaks', 'WMCore.Services.UserFileCache+',
-                                     'WMCore.Services.SiteDB+', 'WMCore.Services.PhEDEx+'],
+                                     'WMCore.Services.SiteDB+', 'WMCore.Services.PhEDEx+', 'WMCore.Services.DBS+'],
                         'systems': ['wmc-base'],
                         'modules': ['WMCore.FwkJobReport.FileInfo', 'WMCore.Services.Requests', 'WMCore.DataStructs.LumiList',
                                     'WMCore.Services.Service', 'WMCore.Services.pycurl_manager', 'WMCore.Services.EmulatorSwitch'],


### PR DESCRIPTION
We're missing the DBSReader module because the prototype re-implementation of crab report queries DBS from the client rather than rely on the server to do the same thing. 

1.0.21_crab branch PR here: https://github.com/dmwm/WMCore/pull/7331
