### PR TITLE
Fix TaskChain assignment without the optional args

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
@@ -345,14 +345,14 @@ class TaskChainWorkloadFactory(StdBase):
                                               memoryReq=taskConf.get('Memory', None),
                                               taskConf=taskConf)
 
-        # this need to be called after setpuProcessingTask since it will overwrite some values
-        self._updateCommonParams(task, taskConf)
-
         self.addLogCollectTask(task, 'LogCollectFor%s' % task.name())
 
         # Do the output module merged/unmerged association
         self.setUpMergeTasks(task, outputMods, splitAlgorithm,
                              keepOutput, transientModules)
+
+        # this need to be called after setpuProcessingTask since it will overwrite some values
+        self._updateCommonParams(task, taskConf)
 
         return
 
@@ -424,14 +424,14 @@ class TaskChainWorkloadFactory(StdBase):
                                               memoryReq=taskConf.get("Memory", None),
                                               taskConf=taskConf)
 
-        # this need to be called after setpuProcessingTask since it will overwrite some values
-        self._updateCommonParams(task, taskConf)
-
         self.addLogCollectTask(task, 'LogCollectFor%s' % task.name())
         self.setUpMergeTasks(task, outputMods, splitAlgorithm,
                              keepOutput, transientModules)
 
         self.inputPrimaryDataset = currentPrimaryDataset
+
+        # this need to be called after setpuProcessingTask since it will overwrite some values
+        self._updateCommonParams(task, taskConf)
 
         return
 


### PR DESCRIPTION
Goes along with #7322

The problem this PR is addressing is related to the assignment of workflows without the AcqEra/ProcStr/ProcVer key/values, which was failing because the Merge tasks didn't have the correct settings set.

@ticoann please review. I just started testing it, but the issues seems solved now.
