### PR TITLE
Do not update workload cache couch doc with assignment dict parameters

### DIFF
--- a/src/python/WMCore/ReqMgr/Service/Request.py
+++ b/src/python/WMCore/ReqMgr/Service/Request.py
@@ -489,7 +489,11 @@ class Request(RESTEntity):
         # legacy update schema to support ops script
         loadRequestSchema(workload, request_args)
 
-        report = self.reqmgr_db_service.updateRequestProperty(workload.name(), request_args, dn)
+        # Do not update dict values to reqmgr2 workload cache, it's not properly formated.
+        # More info in the PR: #7343
+        reqArgsNoDict = {k: v for k, v in request_args.iteritems() if not isinstance(v, dict)}
+
+        report = self.reqmgr_db_service.updateRequestProperty(workload.name(), reqArgsNoDict, dn)
         workload.saveCouch(self.config.couch_host, self.config.couch_reqmgr_db)
         return report
 


### PR DESCRIPTION
Fixes #6906 
Fixes #6881

The idea is to skip dict values like AcquisitionEra, ProcessingString, ProcessingVersion, MaxRss and MaxVSize from the reqmgr2 db update, e.g.:
https://cmsweb-testbed.cern.ch/couchdb/_utils/document.html?reqmgr_workload_cache/amaltaro_TaskChainZTT_DeterPU_HG1611_Validation_161028_163752_4462

as you can see, `AcquisitionEra` was updated to a dict object value. If we, at any moment, need to clone this request, it would fail the create validation because that parameter is supposed to be a string.

@ticoann please review. Tested in my VM.