### PR TITLE
Make team name required during assignment; proper validation

### DIFF
--- a/src/python/WMCore/ReqMgr/Service/Request.py
+++ b/src/python/WMCore/ReqMgr/Service/Request.py
@@ -463,9 +463,8 @@ class Request(RESTEntity):
         
     def _handleAssignmentStateTransition(self, workload, request_args, dn):
         
-        req_status = request_args["RequestStatus"]
-        if req_status == "assigned" and not request_args.get('Team', '').strip():
-            raise InvalidSpecParameterValue("Team must be set during workflow assignment: %s" % request_args)
+        if request_args.get('Team', '').strip() == '':
+            raise InvalidSpecParameterValue("A Team name must be set during workflow assignment")
             
         if ('SoftTimeout' in request_args) and ('GracePeriod' in request_args):
             request_args['SoftTimeout'] = int(request_args['SoftTimeout'])

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -13,7 +13,8 @@ from WMCore.Lexicon import couchurl, block, procstring, activity, procversion
 from WMCore.Services.Dashboard.DashboardReporter import DashboardReporter
 from WMCore.WMSpec.WMSpecErrors import WMSpecFactoryException
 from WMCore.WMSpec.WMWorkload import newWorkload
-from WMCore.WMSpec.WMWorkloadTools import makeList, makeLumiList, strToBool, checkDBSURL, validateArgumentsCreate
+from WMCore.WMSpec.WMWorkloadTools import (makeList, makeLumiList, strToBool,
+                                           checkDBSURL, validateArgumentsCreate, safeStr)
 
 
 class StdBase(object):
@@ -1017,7 +1018,7 @@ class StdBase(object):
                      # dashboard activity
                      "Dashboard": {"default": "production", "type": str, "validate": activity},
                      # team name
-                     "Team": {"default": "", "type": str},
+                     "Team": {"default": "", "type": safeStr, "assign_optional": False},
                      "PrepID": {"default": None, "null": True},
                      "RobustMerge": {"default": True, "type": bool}
                     }

--- a/src/python/WMCore/WMSpec/WMWorkloadTools.py
+++ b/src/python/WMCore/WMSpec/WMWorkloadTools.py
@@ -62,6 +62,17 @@ def strToBool(string):
         raise WMSpecFactoryException("Can't convert to bool: %s" % string)
 
 
+def safeStr(string):
+    """
+    _safeStr_
+
+    WMCore defined type used to more safely cast simple data types to string
+    """
+    if not isinstance(string, (tuple, list, set, dict)):
+        return str(string)
+    raise WMSpecFactoryException("We're not supposed to convert %s to string." % string)
+
+
 def parsePileupConfig(mcPileup, dataPileup):
     """
     _parsePileupConfig_


### PR DESCRIPTION
Fixes #6917

Make sure a single team name (string) is set during the workflow assignment.