### PR TITLE
Validate CMSSW/ScramArch against TagCollector

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -8,13 +8,13 @@ import logging
 
 from WMCore.Cache.WMConfigCache import ConfigCache, ConfigCacheException
 from WMCore.Configuration import ConfigSection
-from WMCore.Lexicon import lfnBase, identifier, acqname, cmsswversion, cmsname
+from WMCore.Lexicon import lfnBase, identifier, acqname, cmsname
 from WMCore.Lexicon import couchurl, block, procstring, activity, procversion
 from WMCore.Services.Dashboard.DashboardReporter import DashboardReporter
 from WMCore.WMSpec.WMSpecErrors import WMSpecFactoryException
 from WMCore.WMSpec.WMWorkload import newWorkload
 from WMCore.WMSpec.WMWorkloadTools import makeList, makeLumiList, strToBool, checkDBSURL, validateArgumentsCreate
-
+from WMCore.ReqMgr.Tools.cms import releases, architectures
 
 class StdBase(object):
     """
@@ -923,9 +923,10 @@ class StdBase(object):
                      "VoRole": {"default": "unknown", "attr": "owner_vorole"},
                      "Campaign": {"optional": False},
                      "AcquisitionEra": {"validate": acqname, "optional": False},
-                     "CMSSWVersion": {"validate": cmsswversion,
+                     "CMSSWVersion": {"validate": lambda x: x in releases(),
                                       "optional": False, "attr": "frameworkVersion"},
-                     "ScramArch": {"default": "slc5_amd64_gcc462", "optional": False},
+                     "ScramArch": {"validate": lambda x: x in architectures(),
+                                   "optional": False},
                      "GlobalTag": {"optional": False, "null": False},
                      "GlobalTagConnect": {"null": True},
                      "ProcessingVersion": {"default": 1, "type": int, "validate": procversion},
@@ -1089,7 +1090,7 @@ class StdBase(object):
                     elif arg == "CMSSWVersion":
                         schema[arg] = "CMSSW_7_6_2"
                     elif arg == "ScramArch":
-                        schema[arg] = "sl6_amd64_gcc491"
+                        schema[arg] = "slc6_amd64_gcc491"
                     else:
                         schema[arg] = "FAKE"
                 elif workloadDefinition[arg]["type"] == int or workloadDefinition[arg]["type"] == float:

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
@@ -238,10 +238,14 @@ class StepChainTests(unittest.TestCase):
         request = json.load(open(self.jsonTemplate))
         testArguments = request['createRequest']
         testArguments.update({
+            "CMSSWVersion": "CMSSW_8_0_17",
+            "ScramArch": "slc6_amd64_gcc530",
             "CouchURL": os.environ["COUCHURL"],
             "ConfigCacheUrl": os.environ["COUCHURL"],
             "CouchDBName": "stepchain_t"
         })
+        testArguments["Step1"]["ScramArch"] = "slc6_amd64_gcc493"
+        testArguments['Step1']["CMSSWVersion"] = "CMSSW_8_0_1"
         configDocs = injectStepChainConfigMC(self.configDatabase)
         for s in ['Step1', 'Step2', 'Step3']:
             testArguments[s]['ConfigCacheID'] = configDocs[s]
@@ -266,7 +270,7 @@ class StepChainTests(unittest.TestCase):
         self.assertEqual(testWorkload.getProcessingString(), "START70_V4")
         self.assertEqual(testWorkload.getProcessingVersion(), 1)
         self.assertEqual(testWorkload.getPrepID(), "Step-00")
-        self.assertEqual(sorted(testWorkload.getCMSSWVersions()), ['CMSSW_7_0_0_pre11', 'CMSSW_7_0_0_pre12'])
+        self.assertEqual(sorted(testWorkload.getCMSSWVersions()), ['CMSSW_8_0_1', 'CMSSW_8_0_17'])
 
         # test workload attributes
         self.assertEqual(testWorkload.processingString, "START70_V4")
@@ -312,8 +316,8 @@ class StepChainTests(unittest.TestCase):
         self.assertTrue('/RelValProdMinBias/CMSSW_7_0_0_pre11-FilterA-START70_V4-v1/GEN-SIM' in outDsets)
         self.assertTrue('/RelValProdMinBias/CMSSW_7_0_0_pre11-FilterD-START70_V4-v1/AODSIM' in outDsets)
         self.assertTrue('/RelValProdMinBias/CMSSW_7_0_0_pre11-FilterC-START70_V4-v1/GEN-SIM-RECO' in outDsets)
-        self.assertEqual(task.getSwVersion(), 'CMSSW_7_0_0_pre12')
-        self.assertEqual(task.getScramArch(), 'slc5_amd64_gcc481')
+        self.assertEqual(task.getSwVersion(), testArguments['Step1']["CMSSWVersion"])
+        self.assertEqual(task.getScramArch(), testArguments['Step1']["ScramArch"])
 
         step = task.getStep("cmsRun1")
         self.assertFalse(step.data.tree.parent)
@@ -323,8 +327,8 @@ class StepChainTests(unittest.TestCase):
         self.assertEqual(step.data.output.modules.RAWSIMoutput.dataTier, 'GEN-SIM')
         self.assertTrue(step.data.output.keep)
         self.assertEqual(sorted(step.data.tree.childNames), ['cmsRun2', 'logArch1', 'stageOut1'])
-        self.assertEqual(step.data.application.setup.cmsswVersion, 'CMSSW_7_0_0_pre12')
-        self.assertEqual(step.data.application.setup.scramArch, 'slc5_amd64_gcc481')
+        self.assertEqual(step.data.application.setup.cmsswVersion, testArguments['Step1']["CMSSWVersion"])
+        self.assertEqual(step.data.application.setup.scramArch, testArguments['Step1']["ScramArch"])
         self.assertEqual(step.data.application.configuration.arguments.globalTag, 'START70_V4::All')
 
         step = task.getStep("cmsRun2")
@@ -335,8 +339,8 @@ class StepChainTests(unittest.TestCase):
         self.assertEqual(step.data.output.modules.RAWSIMoutput.dataTier, 'GEN-SIM-RAW')
         self.assertFalse(step.data.output.keep)
         self.assertEqual(step.data.tree.childNames, ["cmsRun3"])
-        self.assertEqual(step.data.application.setup.cmsswVersion, 'CMSSW_7_0_0_pre11')
-        self.assertEqual(step.data.application.setup.scramArch, 'slc5_amd64_gcc481')
+        self.assertEqual(step.data.application.setup.cmsswVersion, testArguments["CMSSWVersion"])
+        self.assertEqual(step.data.application.setup.scramArch, testArguments["ScramArch"])
         self.assertEqual(step.data.application.configuration.arguments.globalTag, 'START70_V4::All')
 
         step = task.getStep("cmsRun3")
@@ -349,8 +353,8 @@ class StepChainTests(unittest.TestCase):
         self.assertEqual(step.data.output.modules.AODSIMoutput.dataTier, 'AODSIM')
         self.assertTrue(step.data.output.keep)
         self.assertFalse(step.data.tree.childNames)
-        self.assertEqual(step.data.application.setup.cmsswVersion, 'CMSSW_7_0_0_pre11')
-        self.assertEqual(step.data.application.setup.scramArch, 'slc5_amd64_gcc481')
+        self.assertEqual(step.data.application.setup.cmsswVersion, testArguments["CMSSWVersion"])
+        self.assertEqual(step.data.application.setup.scramArch, testArguments["ScramArch"])
         self.assertEqual(step.data.application.configuration.arguments.globalTag, 'START70_V4::All')
 
         return
@@ -362,6 +366,16 @@ class StepChainTests(unittest.TestCase):
         factory = StepChainWorkloadFactory()
         request = json.load(open(self.jsonTemplate))
         testArguments = request['createRequest']
+        testArguments.update({
+            "CMSSWVersion": "CMSSW_8_0_17",
+            "ScramArch": "slc6_amd64_gcc530",
+            "CouchURL": os.environ["COUCHURL"],
+            "ConfigCacheUrl": os.environ["COUCHURL"],
+            "CouchDBName": "stepchain_t"
+        })
+        testArguments["Step1"]["ScramArch"] = "slc6_amd64_gcc493"
+        testArguments['Step1']["CMSSWVersion"] = "CMSSW_8_0_1"
+
         # Create a new DIGI step in Step3 and shift Step3 to Step4
         testArguments['Step4'] = copy(testArguments['Step3'])
         testArguments['Step3'] = {"GlobalTag": "START70_V4::All",
@@ -369,9 +383,6 @@ class StepChainTests(unittest.TestCase):
                                   "InputStep": "ProdMinBias",
                                   "StepName": "DIGIPROD2"}
         testArguments['StepChain'] = 4
-        testArguments.update({"CouchURL": os.environ["COUCHURL"],
-                              "ConfigCacheUrl": os.environ["COUCHURL"],
-                              "CouchDBName": "stepchain_t"})
         configDocs = injectStepChainConfigMC(self.configDatabase)
         for s in ['Step1', 'Step2', 'Step3', 'Step4']:
             testArguments[s]['ConfigCacheID'] = configDocs[s]

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
@@ -193,8 +193,8 @@ class TaskChainTests(unittest.TestCase):
         arguments = {
             "AcquisitionEra": "ReleaseValidation",
             "Requestor": "sfoulkes@fnal.gov",
-            "CMSSWVersion": "CMSSW_3_5_8",
-            "ScramArch": "slc5_ia32_gcc434",
+            "CMSSWVersion": "CMSSW_8_0_17",
+            "ScramArch": "slc6_amd64_gcc530",
             "ProcessingVersion": 1,
             "GlobalTag": "GR10_P_v4::All",
             "CouchURL": self.testInit.couchUrl,
@@ -218,7 +218,7 @@ class TaskChainTests(unittest.TestCase):
                 "InputFromOutputModule" : "writeGENSIM",
                 "ConfigCacheID" : processorDocs['DigiHLT'],
                 "SplittingAlgo" : "LumiBased",
-                "CMSSWVersion" : "CMSSW_5_2_6",
+                "CMSSWVersion" : "CMSSW_8_0_18",
                 "GlobalTag" : "GR_39_P_V5:All",
                 "PrimaryDataset" : "PURelValTTBar",
                 "KeepOutput" : False
@@ -229,7 +229,7 @@ class TaskChainTests(unittest.TestCase):
                 "InputFromOutputModule" : "writeGENSIM",
                 "ConfigCacheID" : processorDocs['DigiHLT'],
                 "SplittingAlgo" : "EventBased",
-                "CMSSWVersion" : "CMSSW_5_2_7",
+                "CMSSWVersion" : "CMSSW_8_0_18",
                 "GlobalTag" : "GR_40_P_V5:All",
                 "AcquisitionEra" : "ReleaseValidationNewConditions",
                 "ProcessingVersion" : 3,
@@ -452,8 +452,8 @@ class TaskChainTests(unittest.TestCase):
         arguments = {
             "AcquisitionEra": "ReleaseValidation",
             "Requestor": "sfoulkes@fnal.gov",
-            "CMSSWVersion": "CMSSW_3_5_8",
-            "ScramArch": "slc5_ia32_gcc434",
+            "CMSSWVersion": "CMSSW_8_0_17",
+            "ScramArch": "slc6_amd64_gcc530",
             "ProcessingVersion": 1,
             "GlobalTag": "DefaultGlobalTag",
             "CouchURL": self.testInit.couchUrl,
@@ -475,8 +475,8 @@ class TaskChainTests(unittest.TestCase):
                 "InputFromOutputModule" : "writeRAWDIGI",
                 "ConfigCacheID" : processorDocs['Reco'],
                 "GlobalTag" : "GlobalTagForReco",
-                "CMSSWVersion" : "CMSSW_3_1_2",
-                "ScramArch" : "CompatibleRECOArch",
+                "CMSSWVersion" : "CMSSW_8_0_18",
+                "ScramArch" : "slc6_amd64_gcc530",
                 "PrimaryDataset" : "ZeroBias",
                 "SplittingAlgo"  : "EventAwareLumiBased",
             },
@@ -486,8 +486,8 @@ class TaskChainTests(unittest.TestCase):
                 "InputFromOutputModule" : "writeALCA",
                 "ConfigCacheID" : processorDocs['ALCAReco'],
                 "GlobalTag" : "GlobalTagForALCAReco",
-                "CMSSWVersion" : "CMSSW_3_1_3",
-                "ScramArch" : "CompatibleALCAArch",
+                "CMSSWVersion" : "CMSSW_8_0_19",
+                "ScramArch" : "slc6_amd64_gcc530",
                 "SplittingAlgo"  : "EventAwareLumiBased",
             },
             "Task4" : {
@@ -641,8 +641,8 @@ class TaskChainTests(unittest.TestCase):
         arguments = {
             "AcquisitionEra": "ReleaseValidation",
             "Requestor": "alan.malta@cern.ch",
-            "CMSSWVersion": "CMSSW_3_5_8",
-            "ScramArch": "slc5_ia32_gcc434",
+            "CMSSWVersion": "CMSSW_8_0_17",
+            "ScramArch": "slc6_amd64_gcc530",
             "ProcessingVersion": 1,
             "GlobalTag": "GR10_P_v4::All",
             "CouchURL": self.testInit.couchUrl,
@@ -659,7 +659,8 @@ class TaskChainTests(unittest.TestCase):
                 "LumisPerJob": 4,
                 "MCPileup": "/some/cosmics-mc-v1/GEN-SIM",
                 "DeterministicPileup": True,
-                "CMSSWVersion" : "CMSSW_5_2_6",
+                "CMSSWVersion" : "CMSSW_8_0_1",
+                "ScramArch": "slc6_amd64_gcc493",
                 "GlobalTag" : "GR_39_P_V5:All",
                 "PrimaryDataset" : "PURelValTTBar",
                 "AcquisitionEra": "CMSSW_5_2_6",
@@ -703,7 +704,7 @@ class TaskChainTests(unittest.TestCase):
 
 
     def buildMultithreadedTaskChain(self, filename):
-        """    d
+        """
         Build a TaskChain from several sources and customization
         """
 
@@ -717,16 +718,13 @@ class TaskChainTests(unittest.TestCase):
         arguments = testArguments
 
         # ... continuing with the request
-        for key in ['CMSSWVersion', 'ScramArch', 'GlobalTag', 'ProcessingVersion',
-                    'Multicore', 'Memory',
+        for key in ['GlobalTag', 'ProcessingVersion', 'Multicore', 'Memory',
                     'TaskChain', 'Task1', 'Task2', 'Task3']:
             arguments.update({key : request['createRequest'][key]})
 
-        for key in ['SiteBlacklist']:
-            arguments.update({key : request['assignRequest'][key]})
-
         # ... then some local overrides
-
+        arguments['CMSSWVersion'] = 'CMSSW_8_0_17'
+        arguments['ScramArch'] = 'slc6_amd64_gcc530'
         del arguments['ConfigCacheID']
         del arguments['ConfigCacheUrl']
         arguments.update({


### PR DESCRIPTION
Fixes #4918

I think we were using the default ScramArch value for tests. If it breaks too many things, then we can just drop this PR and fix it in the future :)