### PR TITLE
Fix default task value for Multicore

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
@@ -643,7 +643,7 @@ class TaskChainWorkloadFactory(StdBase):
                     "PrepID": {"default": None, "type": str,
                                "optional": True, "validate": None,
                                "attr": "prepID", "null": True},
-                    "Multicore": {"default": 1, "type": int,
+                    "Multicore": {"default": 0, "type": int,
                                   "validate": lambda x: x > 0},
                    }
         StdBase.setDefaultArgumentsProperty(specArgs)


### PR DESCRIPTION
Fixes #7350

It's a legit case, the test caught a bug that was going into production (thanks Seangchan!)

This fixes the problem, but it shouldn't be passing the validation function... which leads me to think we've never had a proper validation at task level. I'm debugging it further.