### PR TITLE
Set empty default in the UI select boxes

### DIFF
--- a/src/python/WMCore/ReqMgr/Web/utils.py
+++ b/src/python/WMCore/ReqMgr/Web/utils.py
@@ -100,8 +100,12 @@ def json2table(jsondata, web_ui_map, visible_attrs=None, selected={}):
                     values = val
                 else:
                     values = sorted(val)
+
                 if  key in ['CMSSWVersion', 'ScramArch']:
                     values.reverse()
+                # when there is no value to be selected
+                if key in selected and not selected[key]:
+                    sel += "<option selected disabled>--select an option--</option>"
                 for item in values:
                     if key in selected and item in selected[key]:
                         sel += "<option value=\"%s\" selected=\"selected\">%s</option>" % (item, item)

--- a/src/python/WMCore/WMSpec/WMWorkloadTools.py
+++ b/src/python/WMCore/WMSpec/WMWorkloadTools.py
@@ -163,8 +163,6 @@ def _validateArgumentOptions(arguments, argumentDefinition, optionKey=None):
         # specific case when user GUI returns empty string for optional arguments
         elif arg not in arguments:
             continue
-        elif optional and arguments[arg] == "":
-            del arguments[arg]
         elif isinstance(arguments[arg], dict):
             arguments[arg] = _validateArgumentDict(arg, arguments[arg], argValue)
         else:


### PR DESCRIPTION
Superseeds #7312
Fixes #7284
Fixes #7373 

And that's why `makeList` was not casting an empty string to an empty list, because it was actually being skipped.

@ticoann please review. I tested it in my VM with a couple workflows and it looks good