### PR TITLE
Fix T0 ProcessingString regex

### DIFF
--- a/src/python/WMCore/Lexicon.py
+++ b/src/python/WMCore/Lexicon.py
@@ -253,10 +253,10 @@ def procstringT0(candidate):
     """
     if isinstance(candidate, dict):
         for candi in candidate.values():
-            check(r'[a-zA-Z0-9_]{1,100}$', candi)
+            check(r'^$|[a-zA-Z0-9_]{1,100}$', candi)
         return True
     else:
-        return check(r'[a-zA-Z0-9_]{1,100}$', candidate)
+        return check(r'^$|[a-zA-Z0-9_]{1,100}$', candidate)
 
 
 def acqname(candidate):

--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -167,7 +167,7 @@ class PromptRecoWorkloadFactory(StdBase):
                     "GlobalTag" : {"default" : None, "type" : str,
                                    "optional" : False, "validate" : None,
                                    "attr" : "globalTag", "null" : False},
-                    "ProcessingString": {"default": "", "validate": procstringT0, "assign_optional": False},
+                    "ProcessingString": {"default": "", "validate": procstringT0},
                     "WriteTiers" : {"default" : ["RECO", "AOD", "DQM", "ALCARECO"],
                                     "type" : makeList, "optional" : False,
                                     "validate" : None,


### PR DESCRIPTION
ProcString can be an empty string for T0, this regex should accept that.
It also fixes these two tests
```  WMComponent_t.AnalyticsDataCollector_t.Plugins_t.Tier0Plugin_t.Tier0PluginTest:testC_PromptRecoStates changed from success to error
    WMCore_t.WMSpec_t.StdSpecs_t.PromptReco_t.PromptRecoTest:testPromptReco changed from success to error
```
that failed in #7375 

I tested it interactively and online, but @ticoann , please review because my regex skills are not good :)