### PR TITLE
Allow jobs to request repack slots

### DIFF
--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -327,11 +327,6 @@ class JobSubmitterPoller(BaseWorkerThread):
                 numberOfCores = getattr(baggage, "numberOfCores", 1)
             loadedJob['numberOfCores'] = numberOfCores
 
-            # check if job should be submitted as highIO job
-            highIOjob = False
-            if newJob['type'] in ["Repack", "Merge", "Cleanup", "LogCollect"]:
-                highIOjob = True
-
             # Create a job dictionary object and put it in the cache (needs to be in sync with RunJob)
             jobInfo = {'id': jobID,
                        'requestName': newJob['request_name'],
@@ -341,7 +336,6 @@ class JobSubmitterPoller(BaseWorkerThread):
                        'priority': newJob['wf_priority'],
                        'taskID': newJob['task_id'],
                        'retry_count': newJob["retry_count"],
-                       'highIOjob': highIOjob,
                        'taskPriority': None,                                # update from the thresholds
                        'custom': {'location': None},                        # update later
                        'packageDir': batchDir,

--- a/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
@@ -921,8 +921,11 @@ class PyCondorPlugin(BasePlugin):
         else:
             jdl.append('+DESIRED_CMSDataLocations = undefined\n')
 
-        # HighIO jobs
-        jdl.append('+Requestioslots = %d\n' % job.get('highIOjob', 0))
+        # HighIO and repack jobs handling
+        highio = 1 if job['taskType'] in ["Merge", "Cleanup", "LogCollect"] else 0
+        repackjob = 1 if job['taskType'] == 'Repack' else 0
+        jdl.append('+Requestioslots = %d\n' % highio)
+        jdl.append('+RequestRepackslots = %d\n' % repackjob)
 
         # Performance and resource estimates
         numberOfCores = job.get('numberOfCores', 1)

--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -526,8 +526,9 @@ class SimpleCondorPlugin(BasePlugin):
             else:
                 ad['DESIRED_CMSDataLocations'] = classad.Value.Undefined
 
-            # HighIO jobs
-            ad['Requestioslots'] = int(job.get('highIOjob', False))
+            # HighIO and repack jobs
+            ad['Requestioslots'] = 1 if job['taskType'] in ["Merge", "Cleanup", "LogCollect"] else 0
+            ad['RequestRepackslots'] = 1 if job['taskType'] == 'Repack' else 0
 
             # Performance and resource estimates
             numberOfCores = job.get('numberOfCores', 1)

--- a/src/python/WMCore/BossAir/RunJob.py
+++ b/src/python/WMCore/BossAir/RunJob.py
@@ -63,7 +63,6 @@ class RunJob(dict):
         self.setdefault('inputDataset', None)
         self.setdefault('inputDatasetLocations', None)
         self.setdefault('allowOpportunistic', False)
-        self.setdefault('highIOjob', False)
 
         return
 


### PR DESCRIPTION
Fixes #7372

Since it relies only on the job type, I added this logic only to the plugins instead of adding it to the RunJob object structure. We could actually do the same thing with the highio flag IMO.

@johnhcasallasl please review and test it in a replay