### PR TITLE
Fix for WMBS job mask in oracle

### DIFF
--- a/src/python/WMCore/WMBS/Oracle/Masks/Save.py
+++ b/src/python/WMCore/WMBS/Oracle/Masks/Save.py
@@ -7,33 +7,30 @@ Oracle implementation of Masks.Save
 
 __all__ = []
 
-
-
 from WMCore.WMBS.MySQL.Masks.Save import Save as SaveMasksMySQL
 
+
 class Save(SaveMasksMySQL):
-    sql = """INSERT INTO wmbs_job_mask (job, firstevent, lastevent, firstrun,
-               lastrun, firstlumi, lastlumi, inclusivemask)
-             SELECT :jobid, :firstevent, :lastevent, :firstrun, :lastrun, :firstlumi,
-               :lastlumi, :inclusivemask FROM dual
-             WHERE NOT EXISTS (SELECT job FROM wmbs_job_mask wjm2 WHERE wjm2.firstevent = :firstevent
-                                AND wjm2.lastevent = :lastevent
-                                AND wjm2.firstlumi = :firstlumi
-                                AND wjm2.lastlumi = :lastlumi
-                                AND wjm2.firstrun = :firstrun
-                                AND wjm2.lastrun = :lastrun
-                                AND wjm2.inclusivemask = :inclusivemask)    """
+    sql = """INSERT INTO wmbs_job_mask (job, firstevent, lastevent, firstrun, lastrun, firstlumi, lastlumi, inclusivemask)
+             SELECT :jobid, :firstevent, :lastevent, :firstrun, :lastrun, :firstlumi, :lastlumi, :inclusivemask FROM dual
+             WHERE NOT EXISTS (SELECT * FROM wmbs_job_mask wjm2 WHERE
+                               job = :jobid
+                               AND wjm2.firstevent = :firstevent
+                               AND wjm2.lastevent = :lastevent
+                               AND wjm2.firstlumi = :firstlumi
+                               AND wjm2.lastlumi = :lastlumi
+                               AND wjm2.firstrun = :firstrun
+                               AND wjm2.lastrun = :lastrun
+                               AND wjm2.inclusivemask = :inclusivemask)"""
 
-
-
-    def execute(self, jobid, mask, conn = None, transaction = False):
-        if type(mask) == list:
+    def execute(self, jobid, mask, conn=None, transaction=False):
+        if isinstance(mask, list):
             # Bulk commit
             # Hope you didn't send us a list of empty masks
             binds = []
             for m in mask:
                 inclusiveMask = 'T'
-                if m['inclusivemask'] == False:
+                if m['inclusivemask'] is False:
                     inclusiveMask = 'F'
                 binds.append({"jobid": m['jobID'], 'firstevent': m['FirstEvent'], 'lastevent': m['LastEvent'],
                               'firstrun': m['FirstRun'], 'lastrun': m['LastRun'], 'firstlumi': m['FirstLumi'],
@@ -41,7 +38,7 @@ class Save(SaveMasksMySQL):
         else:
             # Simple one-part mask
             inclusiveMask = 'T'
-            if mask['inclusivemask'] == False:
+            if mask['inclusivemask'] is False:
                 inclusiveMask = 'F'
             binds = {"jobid": jobid, 'firstevent': mask['FirstEvent'], 'lastevent': mask['LastEvent'],
                      'firstrun': mask['FirstRun'], 'lastrun': mask['LastRun'], 'firstlumi': mask['FirstLumi'],
@@ -56,7 +53,6 @@ class Save(SaveMasksMySQL):
                 return
 
         # Actually run the code
-        self.dbi.processData(self.sql, binds, conn = conn,
-                             transaction = transaction)
+        self.dbi.processData(self.sql, binds, conn=conn, transaction=transaction)
 
         return


### PR DESCRIPTION
Fixes #7377
The real fix was just the `job = :jobid` to the select query. This means if there was any other workflow (job) using exactly the same job splitting and having exactly the same job mask, we were not adding a new job for it.

It shouldn't cause too much trouble in production since there is a variety of workflows, but in our tests we recycle workflows, that's why it was spotted.

@ticoann @yuyiguo please review. I'm gonna run one more test with these final changes.