### PR TITLE
Condor classAd doesn.t like unicode

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -470,7 +470,6 @@ class SimpleCondorPlugin(BasePlugin):
         for param in params_to_add:
             if (param not in ad) and (param in htcondor.param) and (param not in params_to_skip):
                 ad[param] = classad.ExprTree(htcondor.param[param])
-        ad = convertFromUnicodeToStr(ad)
         return ad
 
     def getProcAds(self, jobList):
@@ -482,7 +481,7 @@ class SimpleCondorPlugin(BasePlugin):
         """
         classAds = []
         for job in jobList:
-            ad = classad.ClassAd()
+            ad = {}
 
             ad['Iwd'] = job['cache_dir']
             ad['TransferInput'] = "%s,%s/%s,%s" % (job['sandbox'], job['packageDir'],
@@ -565,6 +564,9 @@ class SimpleCondorPlugin(BasePlugin):
                 ad['REQUIRED_OS'] = "any"
             
             ad = convertFromUnicodeToStr(ad)
-            classAds.append((ad,1))
+            condorAd = classad.ClassAd()
+            for k, v in ad.iteritems():
+                condorAd[k] = v
+            classAds.append((condorAd, 1))
 
         return classAds


### PR DESCRIPTION
I had a couple of issues in my first test with this plugin:
1. python args not matching the c++ signature in the `convertFromUnicodeToStr` func, see [1] for more details
2. cannot set any classad parameter with a unicode value, see [2]. Python3 will default to unicode utf-8, so I wonder whether condor should be able to treat these cases, @bbockelm ?

So my initial proposal here was to make a python dict object with the classAds and only in the end we cast any unicode to ascii string. 

I'm happy to further discuss and improve it though, I just needed to get my tests ongoing.

[1]
```
2016-11-14 16:49:04,965:139808333096704:INFO:JobSubmitterPoller:Done assigning site locations.
2016-11-14 16:49:04,991:139808333096704:ERROR:BossAirAPI:Unhandled exception while submitting jobs to plugin: SimpleCondorPlugin
Python argument types in
    ClassAd.__init__(ClassAd, list)
did not match C++ signature:
    __init__(_object*, boost::python::dict)
    __init__(_object*, std::string)
    __init__(_object*)
2016-11-14 16:49:05,067:139808333096704:ERROR:BaseWorkerThread:Error in worker algorithm (1):
Backtrace:
  <WMComponent.JobSubmitter.JobSubmitterPoller.JobSubmitterPoller instance at 0x7f27ab43a4d0> BossAirException
Message: Unhandled exception while submitting jobs to plugin: SimpleCondorPlugin
Python argument types in
    ClassAd.__init__(ClassAd, list)
did not match C++ signature:
    __init__(_object*, boost::python::dict)
    __init__(_object*, std::string)
    __init__(_object*)
        ModuleName : WMCore.BossAir.BossAirAPI
        MethodName : submit
        ClassInstance : None
        FileName : /data/srv/wmagent/v1.0.22.pre10/sw/slc6_amd64_gcc493/cms/wmagent/1.0.22.pre10/lib/python2.7/site-packages/WMCore/BossAir/BossAirAPI.py
        ClassName : None
        LineNumber : 433
        ErrorNr : 0

Traceback: 
  File "/data/srv/wmagent/v1.0.22.pre10/sw/slc6_amd64_gcc493/cms/wmagent/1.0.22.pre10/lib/python2.7/site-packages/WMCore/BossAir/BossAirAPI.py", line 420, in submit
    info=info)

  File "/data/srv/wmagent/v1.0.22.pre10/sw/slc6_amd64_gcc493/cms/wmagent/1.0.22.pre10/lib/python2.7/site-packages/WMCore/BossAir/Plugins/SimpleCondorPlugin.py", line 144, in submit
    cluster_ad = self.getClusterAd()

  File "/data/srv/wmagent/v1.0.22.pre10/sw/slc6_amd64_gcc493/cms/wmagent/1.0.22.pre10/lib/python2.7/site-packages/WMCore/BossAir/Plugins/SimpleCondorPlugin.py", line 486, in getClusterAd
    ad = convertFromUnicodeToStr(ad)

  File "/data/srv/wmagent/v1.0.22.pre10/sw/slc6_amd64_gcc493/cms/wmagent/1.0.22.pre10/lib/python2.7/site-packages/Utils/IterTools.py", line 51, in convertFromUnicodeToStr
    return type(data)(map(convertFromUnicodeToStr, data))

  File "/data/srv/wmagent/v1.0.22.pre10/sw/slc6_amd64_gcc493/cms/wmagent/1.0.22.pre10/lib/python2.7/site-packages/WMCore/WorkerThreads/BaseWorkerThread.py", line 179, in __call__
    self.algorithm(parameters)
  File "/data/srv/wmagent/v1.0.22.pre10/sw/slc6_amd64_gcc493/cms/wmagent/1.0.22.pre10/lib/python2.7/site-packages/WMComponent/JobSubmitter/JobSubmitterPoller.py", line 673, in algorithm
    self.submitJobs(jobsToSubmit=jobsToSubmit)
  File "/data/srv/wmagent/v1.0.22.pre10/sw/slc6_amd64_gcc493/cms/wmagent/1.0.22.pre10/lib/python2.7/site-packages/WMComponent/JobSubmitter/JobSubmitterPoller.py", line 623, in submitJobs
    successList, failList = self.bossAir.submit(jobs=jobList)
  File "/data/srv/wmagent/v1.0.22.pre10/sw/slc6_amd64_gcc493/cms/wmagent/1.0.22.pre10/lib/python2.7/site-packages/WMCore/BossAir/BossAirAPI.py", line 433, in submit
    raise BossAirException(msg)
```

[2]
```
2016-11-14 17:39:08,855:139754476111616:INFO:JobSubmitterPoller:Done assigning site locations.
2016-11-14 17:39:08,888:139754476111616:ERROR:BossAirAPI:Unhandled exception while submitting jobs to plugin: SimpleCondorPlugin
No registered converter was able to produce a C++ rvalue of type std::string from this Python object of type unicode
2016-11-14 17:39:08,939:139754476111616:ERROR:BaseWorkerThread:Error in worker algorithm (1):
Backtrace:
  <WMComponent.JobSubmitter.JobSubmitterPoller.JobSubmitterPoller instance at 0x7f1b21263710> BossAirException
Message: Unhandled exception while submitting jobs to plugin: SimpleCondorPlugin
No registered converter was able to produce a C++ rvalue of type std::string from this Python object of type unicode
        ModuleName : WMCore.BossAir.BossAirAPI
        MethodName : submit
        ClassInstance : None
        FileName : /data/srv/wmagent/v1.0.22.pre10/sw/slc6_amd64_gcc493/cms/wmagent/1.0.22.pre10/lib/python2.7/site-packages/WMCore/BossAir/BossAirAPI.py
        ClassName : None
        LineNumber : 433
        ErrorNr : 0

Traceback: 
  File "/data/srv/wmagent/v1.0.22.pre10/sw/slc6_amd64_gcc493/cms/wmagent/1.0.22.pre10/lib/python2.7/site-packages/WMCore/BossAir/BossAirAPI.py", line 420, in submit
    info=info)

  File "/data/srv/wmagent/v1.0.22.pre10/sw/slc6_amd64_gcc493/cms/wmagent/1.0.22.pre10/lib/python2.7/site-packages/WMCore/BossAir/Plugins/SimpleCondorPlugin.py", line 145, in submit
    proc_ads = self.getProcAds(jobsReady)

  File "/data/srv/wmagent/v1.0.22.pre10/sw/slc6_amd64_gcc493/cms/wmagent/1.0.22.pre10/lib/python2.7/site-packages/WMCore/BossAir/Plugins/SimpleCondorPlugin.py", line 513, in getProcAds
    ad['DESIRED_Sites'] = sites

  File "/data/srv/wmagent/v1.0.22.pre10/sw/slc6_amd64_gcc493/cms/wmagent/1.0.22.pre10/lib/python2.7/site-packages/WMCore/WorkerThreads/BaseWorkerThread.py", line 179, in __call__
    self.algorithm(parameters)
  File "/data/srv/wmagent/v1.0.22.pre10/sw/slc6_amd64_gcc493/cms/wmagent/1.0.22.pre10/lib/python2.7/site-packages/WMComponent/JobSubmitter/JobSubmitterPoller.py", line 673, in algorithm
    self.submitJobs(jobsToSubmit=jobsToSubmit)
  File "/data/srv/wmagent/v1.0.22.pre10/sw/slc6_amd64_gcc493/cms/wmagent/1.0.22.pre10/lib/python2.7/site-packages/WMComponent/JobSubmitter/JobSubmitterPoller.py", line 623, in submitJobs
    successList, failList = self.bossAir.submit(jobs=jobList)
  File "/data/srv/wmagent/v1.0.22.pre10/sw/slc6_amd64_gcc493/cms/wmagent/1.0.22.pre10/lib/python2.7/site-packages/WMCore/BossAir/BossAirAPI.py", line 433, in submit
    raise BossAirException(msg)
```