### PR TITLE
Change PU file list behavior during WMRuntime/TrustPUSitelists

### DIFF
--- a/src/python/WMCore/JobSplitting/JobFactory.py
+++ b/src/python/WMCore/JobSplitting/JobFactory.py
@@ -71,6 +71,7 @@ class JobFactory(WMObject):
         self.siteWhitelist = kwargs.get("siteWhitelist", [])
         self.siteBlacklist = kwargs.get("siteBlacklist", [])
         self.trustSitelists = kwargs.get("trustSitelists", False)
+        self.trustPUSitelists = kwargs.get("trustPUSitelists", False)
 
         # Every time we restart, re-zero the jobs
         self.nJobs = 0
@@ -136,6 +137,10 @@ class JobFactory(WMObject):
         if failedJob:
             self.currentJob["failedOnCreation"] = True
             self.currentJob["failedReason"] = failedReason
+
+        # Decides how the pileup data will be handled in runtime
+        if self.trustPUSitelists:
+            self.currentJob.addBaggageParameter("trustPUSitelists", self.trustPUSitelists)
 
         self.nJobs += 1
         for gen in self.generators:

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -512,6 +512,7 @@ class WMTaskHelper(TreeHelper):
         splittingParams["siteWhitelist"] = self.siteWhitelist()
         splittingParams["siteBlacklist"] = self.siteBlacklist()
         splittingParams["trustSitelists"] = self.getTrustSitelists().get('trustlists')
+        splittingParams["trustPUSitelists"] = self.getTrustSitelists().get('trustPUlists')
 
         if "runWhitelist" not in splittingParams.keys() and self.inputRunWhitelist() != None:
             splittingParams["runWhitelist"] = self.inputRunWhitelist()

--- a/test/python/WMCore_t/DataStructs_t/Job_t.py
+++ b/test/python/WMCore_t/DataStructs_t/Job_t.py
@@ -150,19 +150,16 @@ class JobTest(unittest.TestCase):
         """
         test that setting/accessing the Job Baggage ConfigSection works
         """
-        setattr(self.dummyJob.baggage, "baggageContents", {"key":"value"})
+        self.dummyJob.addBaggageParameter("baggageContents", True)
+        self.dummyJob.addBaggageParameter("trustPUSitelists", False)
+        self.dummyJob.addBaggageParameter("skipPileupEvents", 20000)
 
+        baggage = self.dummyJob.getBaggage()
+        self.assertTrue(getattr(baggage, "baggageContents"))
+        self.assertFalse(getattr(baggage, "trustPUSitelists"))
+        self.assertEqual(getattr(baggage, "skipPileupEvents"), 20000)
+        self.assertFalse(hasattr(baggage, "IDontExist"))
 
-        try:
-            baggage = self.dummyJob.getBaggage()
-        except Exception as ex:
-            msg = "Error calling Job.getBaggage()\n"
-            msg += str(ex)
-            self.fail(msg)
-
-
-
-        self.assertTrue(hasattr(baggage, "baggageContents"))
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/WMCore_t/WMSpec_t/WMTask_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMTask_t.py
@@ -175,10 +175,10 @@ class WMTaskTest(unittest.TestCase):
                "Error: Wrong job splitting algorithm name.")
 
         algoParams = testTask.jobSplittingParameters(performance = False)
-        self.assertEqual(len(algoParams), 9,
+        self.assertEqual(len(algoParams), 10,
                          "Error: Wrong number of algo parameters.")
         algoParams = testTask.jobSplittingParameters()
-        self.assertEqual(len(algoParams), 10,
+        self.assertEqual(len(algoParams), 11,
                          "Error: Wrong number of algo parameters.")
 
         self.assertTrue("algorithm" in algoParams,
@@ -214,6 +214,37 @@ class WMTaskTest(unittest.TestCase):
                          "Error: Wrong memory requirement")
         self.assertEqual(algoParams["performance"]["sizePerEvent"], 512,
                          "Error: Wrong size per event")
+
+        return
+
+    def testTrustSitelists(self):
+        """
+        _testTrustSitelists_
+
+        Verify that we can set/get the proper TrustSitelists and TrustPUSitelists
+        flag.
+        Also make sure they are retrievable through job splitting parameters.
+        """
+        testTask = makeWMTask("TestTask")
+        testTask.setJobResourceInformation(timePerEvent=50, memoryReq=4000,
+                                           sizePerEvent=10)
+        splitArgs = testTask.jobSplittingParameters(performance=False)
+        self.assertFalse(splitArgs['trustSitelists'])
+        self.assertFalse(splitArgs['trustPUSitelists'])
+
+        testTask.setTrustSitelists(True, True)
+        trustlists = testTask.getTrustSitelists()
+        self.assertTrue(trustlists['trustlists'])
+        self.assertTrue(trustlists['trustPUlists'])
+
+        splitArgs = testTask.jobSplittingParameters(performance=False)
+        self.assertTrue(splitArgs['trustSitelists'])
+        self.assertTrue(splitArgs['trustPUSitelists'])
+
+        testTask.setTrustSitelists(False, False)
+        trustlists = testTask.getTrustSitelists()
+        self.assertFalse(trustlists['trustlists'])
+        self.assertFalse(trustlists['trustPUlists'])
 
         return
 

--- a/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
@@ -392,7 +392,7 @@ class WMWorkloadTest(unittest.TestCase):
         testWorkload.setMergeParameters(minSize=10, maxSize=100, maxEvents=1000)
 
         procSplitParams = procTask.jobSplittingParameters(performance=False)
-        self.assertEqual(len(procSplitParams.keys()), 5,
+        self.assertEqual(len(procSplitParams.keys()), 6,
                          "Error: Wrong number of params for proc task.")
         self.assertEqual(procSplitParams["algorithm"], "FileBased",
                          "Error: Wrong job splitting algo for proc task.")
@@ -404,7 +404,7 @@ class WMWorkloadTest(unittest.TestCase):
                          "Error: Site black list was updated.")
 
         skimSplitParams = skimTask.jobSplittingParameters(performance=False)
-        self.assertEqual(len(skimSplitParams.keys()), 6,
+        self.assertEqual(len(skimSplitParams.keys()), 7,
                          "Error: Wrong number of params for skim task.")
         self.assertEqual(skimSplitParams["algorithm"], "FileBased",
                          "Error: Wrong job splitting algo for skim task.")
@@ -418,7 +418,7 @@ class WMWorkloadTest(unittest.TestCase):
                          "Error: Site black list was updated.")
 
         mergeSplitParams = mergeTask.jobSplittingParameters(performance=False)
-        self.assertEqual(len(mergeSplitParams.keys()), 7,
+        self.assertEqual(len(mergeSplitParams.keys()), 8,
                          "Error: Wrong number of params for merge task.")
         self.assertEqual(mergeSplitParams["algorithm"], "WMBSMergeBySize",
                          "Error: Wrong job splitting algo for merge task.")
@@ -434,7 +434,7 @@ class WMWorkloadTest(unittest.TestCase):
                          "Error: Site black list was updated.")
 
         mergeDQMSplitParams = mergeDQMTask.jobSplittingParameters(performance=False)
-        self.assertEqual(len(mergeDQMSplitParams.keys()), 7,
+        self.assertEqual(len(mergeDQMSplitParams.keys()), 8,
                          "Error: Wrong number of params for merge task.")
         self.assertEqual(mergeDQMSplitParams["algorithm"], "WMBSMergeBySize",
                          "Error: Wrong job splitting algo for merge task.")
@@ -1027,7 +1027,7 @@ class WMWorkloadTest(unittest.TestCase):
         self.assertFalse("SubSliceSize" in testWorkload.startPolicyParameters(),
                          "Error: Shouldn't have sub-slice size.")
         procSplitParams = procTask.jobSplittingParameters(performance=False)
-        self.assertEqual(len(procSplitParams.keys()), 6,
+        self.assertEqual(len(procSplitParams.keys()), 7,
                          "Error: Wrong number of params for proc task.")
         self.assertEqual(procSplitParams["algorithm"], "FileBased",
                          "Error: Wrong job splitting algo for proc task.")
@@ -1045,7 +1045,7 @@ class WMWorkloadTest(unittest.TestCase):
                          "Error: Wrong min merge size: %s" % stepHelper.minMergeSize())
 
         skimSplitParams = skimTask.jobSplittingParameters(performance=False)
-        self.assertEqual(len(skimSplitParams.keys()), 7,
+        self.assertEqual(len(skimSplitParams.keys()), 8,
                          "Error: Wrong number of params for skim task.")
         self.assertEqual(skimSplitParams["algorithm"], "RunBased",
                          "Error: Wrong job splitting algo for skim task.")
@@ -1061,7 +1061,7 @@ class WMWorkloadTest(unittest.TestCase):
                          "Error: Site black list was updated.")
 
         mergeSplitParams = mergeTask.jobSplittingParameters(performance=False)
-        self.assertEqual(len(mergeSplitParams.keys()), 7,
+        self.assertEqual(len(mergeSplitParams.keys()), 8,
                          "Error: Wrong number of params for merge task.")
         self.assertEqual(mergeSplitParams["algorithm"], "ParentlessMergeBySize",
                          "Error: Wrong job splitting algo for merge task.")
@@ -1091,7 +1091,7 @@ class WMWorkloadTest(unittest.TestCase):
                          "Error: Wrong min merge size.")
 
         mergeSplitParams = mergeTask.jobSplittingParameters(performance=False)
-        self.assertEqual(len(mergeSplitParams.keys()), 7,
+        self.assertEqual(len(mergeSplitParams.keys()), 8,
                          "Error: Wrong number of params for merge task.")
         self.assertEqual(mergeSplitParams["algorithm"], "WMBSMergeBySize",
                          "Error: Wrong job splitting algo for merge task.")
@@ -1167,7 +1167,7 @@ class WMWorkloadTest(unittest.TestCase):
         self.assertEqual(testWorkload.startPolicyParameters()["SubSliceSize"],
                          15, "Error: Wrong sub-slice size.")
         prodSplitParams = prodTask.jobSplittingParameters(performance=False)
-        self.assertEqual(len(prodSplitParams.keys()), 6,
+        self.assertEqual(len(prodSplitParams.keys()), 7,
                          "Error: Wrong number of params for proc task.")
         self.assertEqual(prodSplitParams["algorithm"], "EventBased",
                          "Error: Wrong job splitting algo for proc task.")
@@ -1189,7 +1189,7 @@ class WMWorkloadTest(unittest.TestCase):
                          "Error: Wrong min merge size: %s" % stepHelper.minMergeSize())
 
         mergeSplitParams = mergeTask.jobSplittingParameters(performance=False)
-        self.assertEqual(len(mergeSplitParams.keys()), 7,
+        self.assertEqual(len(mergeSplitParams.keys()), 8,
                          "Error: Wrong number of params for merge task.")
         self.assertEqual(mergeSplitParams["algorithm"], "ParentlessMergeBySize",
                          "Error: Wrong job splitting algo for merge task.")
@@ -1247,15 +1247,17 @@ class WMWorkloadTest(unittest.TestCase):
         self.assertEqual(results["/TestWorkload/ProcessingTask"], {"files_per_job": 2,
                                                                    "algorithm": "FileBased",
                                                                    'trustSitelists': False,
+                                                                   'trustPUSitelists': False,
                                                                    "type": "Processing"},
                          "Error: Wrong splitting parameters: %s" % results["/TestWorkload/ProcessingTask"])
+
         self.assertEqual(results["/TestWorkload/ProcessingTask/MergeTask/SkimTask"],
                          {"max_files": 21, "algorithm": "RunBased", "some_other_param": "value",
-                          'trustSitelists': False, "type": "Skim"},
+                          'trustSitelists': False, 'trustPUSitelists': False, "type": "Skim"},
                          "Error: Wrong splitting parameters.")
         self.assertEqual(results["/TestWorkload/ProcessingTask/MergeTask"],
-                         {"algorithm": "ParentlessMergeBySize", "max_merge_size": 2,
-                          "max_merge_events": 2, "min_merge_size": 2, 'trustSitelists': False, "type": "Merge"},
+                         {"algorithm": "ParentlessMergeBySize", "max_merge_size": 2, "max_merge_events": 2,
+                          "min_merge_size": 2, 'trustSitelists': False, 'trustPUSitelists': False, "type": "Merge"},
                          "Error: Wrong splitting parameters.")
 
         return


### PR DESCRIPTION
Fixes #7387

Summary of the changes and the expected behaviour is as follows:
* pileup json file contains only real data/location, no more fake pnns.
* `TrustPUSitelists` changes the behaviour of two things, when set to `True`.
  - used for bypassing GQ to LQ replication.
  - makes sure **all** the PU files are added to the PSet as secondary input, no matter the site and/or data location
* if job lands on a site that contains only 1 PU block out of 100, the PSet will have only files that belong to that block (unles Trust flag was set to True) 
* Needless to say, if the PU dataset is wiped out from the storage by DDM (or anything else), ALL the jobs will read the PU data via AAA (depending on the workflow, it can cause a very bad impact on the grid resources (AAA, storage)) 

I'm not testing it before I get a confirmation whether this is the desired behaviour or not.
So @ticoann @hufnagel @vlimant @ericvaandering please share your thoughts (Dirk, only short comments please :), otherwise it's impossible to have a productive follow up)