### PR TITLE
Set numberOfCores for all tasks in a ReDigi

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/ReDigi.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/ReDigi.py
@@ -115,6 +115,11 @@ class ReDigiWorkloadFactory(DataProcessing):
             outputMods[outputModuleName] = outputModule
 
         self.addMergeTasks(stepOneTask, "cmsRun3", outputMods)
+
+        if self.multicore:
+            stepTwoCmsswHelper.setNumberOfCores(self.multicore)
+            stepThreeCmsswHelper.setNumberOfCores(self.multicore)
+
         return
 
     def setupDependentProcessing(self, stepOneTask, outputMods):
@@ -185,6 +190,8 @@ class ReDigiWorkloadFactory(DataProcessing):
             outputMods[outputModuleName] = outputModule
 
         mergeTasks = self.addMergeTasks(stepOneTask, "cmsRun2", outputMods)
+        if self.multicore:
+            stepTwoCmsswHelper.setNumberOfCores(self.multicore)
 
         if self.stepThreeConfigCacheID is None:
             return
@@ -284,57 +291,41 @@ class ReDigiWorkloadFactory(DataProcessing):
     @staticmethod
     def getWorkloadArguments():
         baseArgs = DataProcessing.getWorkloadArguments()
-        specArgs = {"RequestType" : {"default" : "ReDigi", "optional" : True,
-                                      "attr" : "requestType"},
+        specArgs = {"RequestType" : {"default" : "ReDigi", "optional" : True},
                     "StepOneOutputModuleName" : {"default" : None, "type" : str,
-                                                 "optional" : True, "validate" : None,
-                                                 "attr" : "stepOneOutputModuleName", "null" : True},
+                                                 "optional" : True, "null" : True},
                     "StepTwoOutputModuleName" : {"default" : None, "type" : str,
-                                                 "optional" : True, "validate" : None,
-                                                 "attr" : "stepTwoOutputModuleName", "null" : True},
+                                                 "optional" : True, "null" : True},
                     "ConfigCacheID": {"default" : None, "optional": True, "null": True},
                     "StepOneConfigCacheID" : {"default" : None, "type" : str,
-                                              "optional" : False, "validate" : None,
-                                              "attr" : "stepOneConfigCacheID", "null" : True},
+                                              "optional" : False, "null" : True},
                     "StepTwoConfigCacheID" : {"default" : None, "type" : str,
-                                              "optional" : True, "validate" : None,
-                                              "attr" : "stepTwoConfigCacheID", "null" : True},
+                                              "optional" : True, "null" : True},
                     "StepThreeConfigCacheID" : {"default" : None, "type" : str,
-                                                "optional" : True, "validate" : None,
-                                                "attr" : "stepThreeConfigCacheID", "null" : True},
+                                                "optional" : True, "null" : True},
                     "KeepStepOneOutput" : {"default" : True, "type" : strToBool,
-                                           "optional" : True, "validate" : None,
-                                           "attr" : "keepStepOneOutput", "null" : False},
+                                           "optional" : True, "null" : False},
                     "KeepStepTwoOutput" : {"default" : True, "type" : strToBool,
-                                           "optional" : True, "validate" : None,
-                                           "attr" : "keepStepTwoOutput", "null" : False},
-                    "StepTwoTimePerEvent" : {"default" : 1, "type" : float,
-                                             "optional" : True, "validate" : lambda x : x > 0,
-                                             "attr" : "stepTwoTimePerEvent", "null" : False},
-                    "StepThreeTimePerEvent" : {"default" : 1, "type" : float,
-                                               "optional" : True, "validate" : lambda x : x > 0,
-                                               "attr" : "stepThreeTimePerEvent", "null" : False},
-                    "StepTwoSizePerEvent" : {"default" : None, "type" : float,
-                                             "optional" : True, "validate" : lambda x : x > 0,
-                                             "attr" : "stepTwoSizePerEvent", "null" : True},
-                    "StepThreeSizePerEvent" : {"default" : None, "type" : float,
-                                               "optional" : True, "validate" : lambda x : x > 0,
-                                               "attr" : "stepThreeSizePerEvent", "null" : True},
-                    "StepTwoMemory" : {"default" : None, "type" : float,
-                                       "optional" : True, "validate" : lambda x : x > 0,
-                                       "attr" : "stepTwoMemory", "null" : True},
-                    "StepThreeMemory" : {"default" : None, "type" : float,
-                                         "optional" : True, "validate" : lambda x : x > 0,
-                                         "attr" : "stepThreeMemory", "null" : True},
-                    "MCPileup" : {"default" : None, "type" : str,
+                                           "optional" : True, "null" : False},
+                    "StepTwoTimePerEvent" : {"type" : float, "optional" : True, "null" : True,
+                                             "validate" : lambda x : x > 0},
+                    "StepThreeTimePerEvent" : {"type" : float, "optional" : True, "null" : True,
+                                               "validate" : lambda x : x > 0},
+                    "StepTwoSizePerEvent" : {"default" : None, "type" : float, "null" : True,
+                                             "optional" : True, "validate" : lambda x : x > 0},
+                    "StepThreeSizePerEvent" : {"default" : None, "type" : float, "null" : True,
+                                               "optional" : True, "validate" : lambda x : x > 0},
+                    "StepTwoMemory" : {"default" : None, "type" : float, "null" : True,
+                                       "optional" : True, "validate" : lambda x : x > 0},
+                    "StepThreeMemory" : {"default" : None, "type" : float, "null" : True,
+                                         "optional" : True, "validate" : lambda x : x > 0},
+                    "MCPileup" : {"default" : None, "type" : str, "null" : True,
                                   "optional" : True, "validate" : dataset,
                                   "attr" : "mcPileup", "null" : True},
-                    "DataPileup" : {"default" : None, "type" : str,
-                                    "optional" : True, "validate" : dataset,
-                                    "attr" : "dataPileup", "null" : True},
+                    "DataPileup" : {"default" : None, "type" : str, "null" : True,
+                                    "optional" : True, "validate" : dataset},
                     "DeterministicPileup" : {"default" : False, "type" : strToBool,
-                                             "optional" : True, "validate" : None,
-                                             "attr" : "deterministicPileup", "null" : False}}
+                                             "optional" : True, "null" : False}}
         baseArgs.update(specArgs)
         DataProcessing.setDefaultArgumentsProperty(baseArgs)
         return baseArgs

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -43,7 +43,6 @@ class StdBase(object):
 
         # Internal parameters
         self.workloadName = None
-        self.multicoreNCores = None
         self.schema = None
         self.config_cache = {}
 
@@ -74,11 +73,6 @@ class StdBase(object):
                     self.schema[arg] = defaultValue
             except Exception as ex:
                 raise WMSpecFactoryException("parameter %s: %s" % (arg, str(ex)))
-
-        # Definition of parameters that depend on the value of others
-        if hasattr(self, "multicore") and self.multicore:
-            self.multicoreNCores = self.multicore
-            self.multicore = True
 
         return
 
@@ -369,10 +363,10 @@ class StdBase(object):
         procTaskCmsswHelper = procTaskCmssw.getTypeHelper()
         procTaskStageHelper = procTaskStageOut.getTypeHelper()
 
-        if self.multicore and useMulticore:
-            # if multicore, poke in the number of cores setting
-            procTaskCmsswHelper.setNumberOfCores(self.multicoreNCores)
-
+        if 'Multicore' in taskConf and taskConf['Multicore'] > 0:  # used for StepChain overrides
+            procTaskCmsswHelper.setNumberOfCores(taskConf['Multicore'])
+        else:
+            procTaskCmsswHelper.setNumberOfCores(self.multicore)
         procTaskCmsswHelper.setUserSandbox(userSandbox)
         procTaskCmsswHelper.setUserFiles(userFiles)
         procTaskCmsswHelper.setGlobalTag(globalTag)

--- a/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
@@ -253,9 +253,6 @@ class TaskChainWorkloadFactory(StdBase):
             self.runBlacklist = taskConf["RunBlacklist"]
             self.runWhitelist = taskConf["RunWhitelist"]
 
-            if taskConf['Multicore']:
-                self.multicoreNCores = taskConf['Multicore']
-
             parentTask = None
             if parent in self.mergeMapping:
                 parentTask = self.mergeMapping[parent][parentTaskModule(taskConf)]


### PR DESCRIPTION
Fixes #7393
Fixes #7394

Summary of this PR:
* minor change on how we handle multicore at spec level
* fixed multicore settings for ReDigi spec (cmsRun2 was never set)
* fixed multicore settings for StepChain (was set only for cmsRun1)
* fixed *TimePerEvent default values in ReDigi

I tested different settings of StepChain, TaskChain and ReDigi and they work Ok. I still have to run further tests and make some unit tests for all these specs.