### PR TITLE
1.0.21_crab version of Changes needed for automatic splitting in CRAB3

### DIFF
--- a/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
+++ b/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
@@ -40,6 +40,7 @@ class EventAwareLumiBased(JobFactory):
         """
 
         avgEventsPerJob = int(kwargs.get('events_per_job', 5000))
+        jobLimit        = int(kwargs.get('job_limit', 0))
         eventLimit      = int(kwargs.get('max_events_per_lumi', 20000))
         totalEvents     = int(kwargs.get('total_events', 0))
         splitOnFile     = bool(kwargs.get('halt_job_on_file_boundaries', True))
@@ -264,6 +265,9 @@ class EventAwareLumiBased(JobFactory):
                             lumisInJobInFile = 0
                             currentJobAvgEventCount = 0
                             totalJobs += 1
+                            if jobLimit and totalJobs > jobLimit:
+                                msg = "Job limit of {0} jobs exceeded.".format(jobLimit)
+                                raise RuntimeError(msg)
 
                             # Add the file to new jobs
                             self.currentJob.addFile(f)

--- a/src/python/WMCore/Services/Dashboard/DashboardAPI.py
+++ b/src/python/WMCore/Services/Dashboard/DashboardAPI.py
@@ -254,7 +254,7 @@ def reportFailureToDashboard(exitCode, ad=None, stageOutReport=None):
         return exitCode
     params = {
         'MonitorID': ad['CRAB_ReqName'],
-        'MonitorJobID': '%d_https://glidein.cern.ch/%d/%s_%d' % (ad['CRAB_Id'], ad['CRAB_Id'],
+        'MonitorJobID': '%s_https://glidein.cern.ch/%s/%s_%s' % (ad['CRAB_Id'], ad['CRAB_Id'],
                                                                  ad['CRAB_ReqName'].replace("_", ":"), ad['CRAB_Retry']),
         'JobExitCode': exitCode
     }

--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -726,6 +726,11 @@ class SetupCMSSWPset(ScriptInterface):
             self.process.source.numberEventsInLuminosityBlock = \
                 cms.untracked.uint32(self.step.data.application.configuration.eventsPerLumi)
 
+        # limit run time if desired
+        if hasattr(self.step.data.application.configuration, "maxSecondsUntilRampdown"):
+            self.process.maxSecondsUntilRampdown = cms.untracked.PSet(
+                    input = cms.untracked.int32(self.step.data.application.configuration.maxSecondsUntilRampdown))
+
         # accept an overridden TFC from the step
         if hasattr(self.step.data.application,'overrideCatalog'):
             print("Found a TFC override: %s" % self.step.data.application.overrideCatalog)


### PR DESCRIPTION
* Allow to specify maximum runtime.

  Adjusts maxSecondsUntilRampdown as desired.  Pertains to dmwm/CRABServer#4690.

* Adjust to string formatting in dashboard to accept all CRAB_IDs
* Fail job splitting if a total job count limit is exceeded.

  Only raises an exception when a limit is set.  This is in preparation for
  an automated splitting mode for CRAB3, where splitting parameters may yield
  a lot of jobs and cause excessive load on the schedd.

Master PR here: https://github.com/dmwm/WMCore/pull/7083