### PR TITLE
switch repack to lazy-download and multi-core

### DIFF
--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -533,14 +533,12 @@ class SetupCMSSWPset(ScriptInterface):
         """
         _handleRepackSettings_
 
-        Disable lazy-download for repacking (no benefit on streamer files).
+        Repacking small events is super inefficient reading directly from EOS.
         """
         print("Hardcoding read/cache strategies for repack")
         self.process.add_(
             cms.Service("SiteLocalConfigService",
-                        overrideSourceCacheHintDir = cms.untracked.string("storage-only"),
-                        overrideSourceReadHint = cms.untracked.string("read-ahead-buffered"),
-                        overrideSourceTTreeCacheSize = cms.untracked.uint32(20*1024*1024)
+                        overrideSourceCacheHintDir = cms.untracked.string("lazy-download")
                         )
             )
 
@@ -633,7 +631,7 @@ class SetupCMSSWPset(ScriptInterface):
             if funcName == "repack":
                 self.handleRepackSettings()
 
-            if funcName in ["repack", "merge", "alcaHarvesting" ]:
+            if funcName in ["merge", "alcaHarvesting" ]:
                 self.handleSingleCoreOverride()
 
             if socket.getfqdn().endswith("cern.ch"):


### PR DESCRIPTION
Configure repack to use lazy-download (repacking high event rate streams is very slow from EOS) and allow repack to use multi-core in case it already has multiple core slots assigned to it (because of disk space).