### PR TITLE
Don.t crash JobUpdater if http fails with connection refused

### DIFF
--- a/src/python/WMComponent/JobUpdater/JobUpdaterPoller.py
+++ b/src/python/WMComponent/JobUpdater/JobUpdaterPoller.py
@@ -11,7 +11,7 @@ Created on Apr 16, 2013
 
 import logging
 import threading
-import traceback
+
 from WMCore.BossAir.BossAirAPI import BossAirAPI
 from WMCore.DAOFactory import DAOFactory
 from WMCore.Services.ReqMgr.ReqMgr import ReqMgr
@@ -92,12 +92,12 @@ class JobUpdaterPoller(BaseWorkerThread):
             msg += str(ex)
             logging.exception(msg)
         except Exception as ex:
-            msg = "Caught unexpected exception in JobUpdater\n"
-            msg += str(ex)
-            msg += str(traceback.format_exc())
-            msg += "\n\n"
-            logging.error(msg)
-            raise JobUpdaterException(msg)
+            if 'Connection refused' in str(ex):
+                logging.warn("Failed to sync priorities. Trying in the next cycle")
+            else:
+                msg = "Caught unexpected exception in JobUpdater: %s\n" % str(ex)
+                logging.exception(msg)
+                raise JobUpdaterException(msg)
         
     def synchronizeJobPriority(self):
         """


### PR DESCRIPTION
It mainly happens on agents with an unstable couch server. Here is an example traceback [1]
I've applied this patch to vocms0116, since this component is going down once/twice a day.

@ticoann please review but don't merge yet please

[1]
```
2016-11-22 22:29:49,738:139871564584704:ERROR:JobUpdaterPoller:Caught unexpected exception in JobUpdater
[Errno 111] Connection refusedTraceback (most recent call last):
  File "/data/srv/wmagent/v1.0.21.patch2/sw/slc6_amd64_gcc493/cms/wmagent/1.0.21.patch2/lib/python2.7/site-packages/WMComponent/JobUpdater/JobUpdaterPoller.py", line 82, in algorithm
    self.synchronizeJobPriority()
  File "/data/srv/wmagent/v1.0.21.patch2/sw/slc6_amd64_gcc493/cms/wmagent/1.0.21.patch2/lib/python2.7/site-packages/WMComponent/JobUpdater/JobUpdaterPoller.py", line 114, in synchronizeJobPriority
    workflowsToCheck = [x for x in self.workqueue.getAvailableWorkflows()]
  File "/data/srv/wmagent/v1.0.21.patch2/sw/slc6_amd64_gcc493/cms/wmagent/1.0.21.patch2/lib/python2.7/site-packages/WMCore/Services/WorkQueue/WorkQueue.py", line 117, in getAvailableWorkflows
    {'reduce' : False, 'stale': 'update_after'})
  File "/data/srv/wmagent/v1.0.21.patch2/sw/slc6_amd64_gcc493/cms/wmagent/1.0.21.patch2/lib/python2.7/site-packages/WMCore/Database/CMSCouch.py", line 488, in loadView
    (self.name, design, view), encodedOptions)
  File "/data/srv/wmagent/v1.0.21.patch2/sw/slc6_amd64_gcc493/cms/wmagent/1.0.21.patch2/lib/python2.7/site-packages/WMCore/Services/Requests.py", line 104, in get
    encode, decode, contentType)
  File "/data/srv/wmagent/v1.0.21.patch2/sw/slc6_amd64_gcc493/cms/wmagent/1.0.21.patch2/lib/python2.7/site-packages/WMCore/Database/CMSCouch.py", line 120, in makeRequest
    encode, decode, contentType)
  File "/data/srv/wmagent/v1.0.21.patch2/sw/slc6_amd64_gcc493/cms/wmagent/1.0.21.patch2/lib/python2.7/site-packages/WMCore/Services/Requests.py", line 140, in makeRequest
    encoder, decoder, contentType)
  File "/data/srv/wmagent/v1.0.21.patch2/sw/slc6_amd64_gcc493/cms/wmagent/1.0.21.patch2/lib/python2.7/site-packages/WMCore/Services/Requests.py", line 251, in makeRequest_httplib
    body=encoded_data, headers=headers)
  File "/data/srv/wmagent/v1.0.21.patch2/sw/slc6_amd64_gcc493/external/py2-httplib2/0.7.1-comp3/lib/python2.7/site-packages/httplib2/__init__.py", line 1436, in request
    (response, content) = self._request(conn, authority, uri, request_uri, method, body, headers, redirections, cachekey)
  File "/data/srv/wmagent/v1.0.21.patch2/sw/slc6_amd64_gcc493/external/py2-httplib2/0.7.1-comp3/lib/python2.7/site-packages/httplib2/__init__.py", line 1188, in _request
    (response, content) = self._conn_request(conn, request_uri, method, body, headers)
  File "/data/srv/wmagent/v1.0.21.patch2/sw/slc6_amd64_gcc493/external/py2-httplib2/0.7.1-comp3/lib/python2.7/site-packages/httplib2/__init__.py", line 1123, in _conn_request
    conn.connect()
  File "/data/srv/wmagent/v1.0.21.patch2/sw/slc6_amd64_gcc493/external/py2-httplib2/0.7.1-comp3/lib/python2.7/site-packages/httplib2/__init__.py", line 796, in connect
    raise socket.error, msg
error: [Errno 111] Connection refused
```