### PR TITLE
Selective crontab for testbed/dev agent deployment

### DIFF
--- a/bin/deploy-wmagent.sh
+++ b/bin/deploy-wmagent.sh
@@ -24,7 +24,7 @@
 ### Usage:               -n <agent_number> Agent number to be set when more than 1 agent connected to the same team (defaults to 0)
 ### Usage:
 ### Usage: deploy-wmagent.sh -w <wma_version> -c <cmsweb_tag> -t <team_name> [-s <scram_arch>] [-r <repository>] [-n <agent_number>]
-### Usage: Example: sh deploy-wmagent.sh -w 1.0.19.patch2 -c HG1609a -t production -p "7099" -n 2
+### Usage: Example: sh deploy-wmagent.sh -w 1.0.21.patch3 -c HG1610f -t production -p "7399" -n 2
 ### Usage: Example: sh deploy-wmagent.sh -w 1.0.21 -c HG1610f -t testbed-cmssrv214 -s slc6_amd64_gcc493 -r comp=comp.amaltaro
 ### Usage:
  
@@ -323,14 +323,22 @@ echo "Done!" && echo
 
 ### Populating cronjob with utilitarian scripts
 echo "*** Creating cronjobs for them ***"
-( crontab -l 2>/dev/null | grep -Fv ntpdate
-echo "#remove old jobs script"
-echo "10 */4 * * * source /data/admin/wmagent/rmOldJobs.sh &> /tmp/rmJobs.log"
-echo "55 */12 * * * (export X509_USER_CERT=/data/certs/servicecert.pem; export X509_USER_KEY=/data/certs/servicekey.pem; myproxy-get-delegation -v -l amaltaro -t 168 -s 'myproxy.cern.ch' -k $MYPROXY_CREDNAME -n -o /data/certs/mynewproxy.pem && voms-proxy-init -rfc -voms cms:/cms/Role=production -valid 168:00 -noregen -cert /data/certs/mynewproxy.pem -key /data/certs/mynewproxy.pem -out /data/certs/myproxy.pem)"
-echo "58 */12 * * * python /data/admin/wmagent/checkProxy.py --proxy /data/certs/myproxy.pem --time 96 --send-mail True --mail alanmalta@gmail.com,alan.malta@cern.ch"
-echo "#workaround for the ErrorHandler silence issue"
-echo "*/15 * * * *  source /data/admin/wmagent/restartComponent.sh > /dev/null"
-) | crontab -
+if [[ "$TEAMNAME" == *testbed* || "$TEAMNAME" == *dev* ]]; then
+  ( crontab -l 2>/dev/null | grep -Fv ntpdate
+  echo "#remove old jobs script"
+  echo "10 */4 * * * source /data/admin/wmagent/rmOldJobs.sh &> /tmp/rmJobs.log"
+  echo "55 */12 * * * (export X509_USER_CERT=/data/certs/servicecert.pem; export X509_USER_KEY=/data/certs/servicekey.pem; myproxy-get-delegation -v -l amaltaro -t 168 -s 'myproxy.cern.ch' -k $MYPROXY_CREDNAME -n -o /data/certs/mynewproxy.pem && voms-proxy-init -rfc -voms cms:/cms/Role=production -valid 168:00 -noregen -cert /data/certs/mynewproxy.pem -key /data/certs/mynewproxy.pem -out /data/certs/myproxy.pem)"
+  ) | crontab -
+else
+  ( crontab -l 2>/dev/null | grep -Fv ntpdate
+  echo "#remove old jobs script"
+  echo "10 */4 * * * source /data/admin/wmagent/rmOldJobs.sh &> /tmp/rmJobs.log"
+  echo "55 */12 * * * (export X509_USER_CERT=/data/certs/servicecert.pem; export X509_USER_KEY=/data/certs/servicekey.pem; myproxy-get-delegation -v -l amaltaro -t 168 -s 'myproxy.cern.ch' -k $MYPROXY_CREDNAME -n -o /data/certs/mynewproxy.pem && voms-proxy-init -rfc -voms cms:/cms/Role=production -valid 168:00 -noregen -cert /data/certs/mynewproxy.pem -key /data/certs/mynewproxy.pem -out /data/certs/myproxy.pem)"
+  echo "58 */12 * * * python /data/admin/wmagent/checkProxy.py --proxy /data/certs/myproxy.pem --time 96 --send-mail True --mail alanmalta@gmail.com,alan.malta@cern.ch"
+  echo "#workaround for the ErrorHandler silence issue"
+  echo "*/15 * * * *  source /data/admin/wmagent/restartComponent.sh > /dev/null"
+  ) | crontab -
+fi
 echo "Done!" && echo
 
 echo && echo "Deployment finished!! However you still need to:"


### PR DESCRIPTION
Updated deployment command line example.

Skip restartComponent and proxy alarm cronjobs for *testbed* and *dev* agents.