### PR TITLE
SimpleCondorPlugin job submission Unicode problems

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -483,7 +483,7 @@ class SimpleCondorPlugin(BasePlugin):
         for param in params_to_add:
             if (param not in ad) and (param in htcondor.param) and (param not in params_to_skip):
                 ad[param] = classad.ExprTree(htcondor.param[param])
-        ad = convertFromUnicodeToStr(ad)
+        #ad = convertFromUnicodeToStr(ad)
         return ad
 
     def getProcAds(self, jobList):
@@ -578,7 +578,7 @@ class SimpleCondorPlugin(BasePlugin):
             else:
                 ad['REQUIRED_OS'] = "any"
             
-            ad = convertFromUnicodeToStr(ad)
+            #ad = convertFromUnicodeToStr(ad)
             classAds.append((ad,1))
 
         return classAds


### PR DESCRIPTION
@ticoann unicode conversion code doesn't work for me, I get job submission errors:

Python argument types in
    ClassAd.__init__(ClassAd, list)
did not match C++ signature:
    __init__(_object*, boost::python::dict)
    __init__(_object*, std::string)
    __init__(_object*)

Don't want to merge it like this, but lets discuss what needs to be done in the PR and I'll modify.
