### PR TITLE
Allow PrimaryDataset default to be None for MCFromGEN

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/MonteCarloFromGEN.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/MonteCarloFromGEN.py
@@ -110,7 +110,7 @@ class MonteCarloFromGENWorkloadFactory(DataProcessing):
                                     "attr": "requestType"},
                     "PrimaryDataset": {"default": None, "type": str,
                                        "optional": True, "validate": primdataset,
-                                       "attr": "inputPrimaryDataset", "null": False},
+                                       "attr": "inputPrimaryDataset", "null": True},
                     "ConfigCacheUrl": {"default": None, "type": str,
                                        "optional": True, "validate": None,
                                        "attr": "configCacheUrl", "null": False},


### PR DESCRIPTION
Fixes #7410 

@ticoann please review. Tested in my VM.

The next step (to be eventually done) would be to not save - in the workload_cache doc - parameters with None value.