### PR TITLE
Trust pu all tasks

### DIFF
--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -857,14 +857,9 @@ class WMTaskHelper(TreeHelper):
 
         Get the input and pileup flag for 'trust site lists' in the task.
         """
-
         # handle backward compatibility for the request which doesn't contain trustPUlists
-        try:
-            trustPUlists = self.data.constraints.sites.trustPUlists
-        except AttributeError:
-            trustPUlists = False
-        return {'trustlists': self.data.constraints.sites.trustlists,
-                'trustPUlists': trustPUlists}
+        return {'trustlists': getattr(self.data.constraints.sites, 'trustlists', False),
+                'trustPUlists': getattr(self.data.constraints.sites, 'trustPUlists', False)}
 
     def setTrustSitelists(self, trustSitelists, trustPUSitelists):
         """


### PR DESCRIPTION
Fixes #7428

Since the PU flag affects jobs during runtime, we have to make sure all the tasks will carry it (Taskchain case), otherwise the secondary input will fully rely on location.

It needs to be tested.