### PR TITLE
fix aborted and force complete request not killing the jobs

### DIFF
--- a/src/python/WMComponent/TaskArchiver/TaskArchiverPoller.py
+++ b/src/python/WMComponent/TaskArchiver/TaskArchiverPoller.py
@@ -239,8 +239,6 @@ class TaskArchiverPoller(BaseWorkerThread):
                     if workflow in abortedWorkflows:
                         #TODO: remove when reqmgr2-wmstats deployed
                         newState = "aborted-completed"
-                    elif workflow in forceCompleteWorkflows:
-                        newState = "completed"
                     else:
                         newState = None
                         

--- a/src/python/WMComponent/WorkQueueManager/WorkQueueManager.py
+++ b/src/python/WMComponent/WorkQueueManager/WorkQueueManager.py
@@ -53,24 +53,28 @@ class WorkQueueManager(Harness):
 
             # pull work from parent queue
             myThread.workerThreadManager.addWorker(
-                                WorkQueueManagerWorkPoller(queueFromConfig(self.config)),
+                                WorkQueueManagerWorkPoller(queueFromConfig(self.config),
+                                                           self.config),
                                 pollInterval)
 
             # inject acquired work into wmbs
             myThread.workerThreadManager.addWorker(
-                                WorkQueueManagerWMBSFileFeeder(queueFromConfig(self.config)),
+                                WorkQueueManagerWMBSFileFeeder(queueFromConfig(self.config),
+                                                               self.config),
                                 pollInterval)
 
         ### general functions
 
         # Data location updates
         myThread.workerThreadManager.addWorker(
-                                    WorkQueueManagerLocationPoller(queueFromConfig(self.config)),
+                                    WorkQueueManagerLocationPoller(queueFromConfig(self.config),
+                                                                   self.config),
                                     pollInterval)
 
         # Clean finished work & apply end policies
         myThread.workerThreadManager.addWorker(
-                                WorkQueueManagerCleaner(queueFromConfig(self.config)),
+                                WorkQueueManagerCleaner(queueFromConfig(self.config),
+                                                        self.config),
                                 pollInterval)
 
         return

--- a/src/python/WMComponent/WorkQueueManager/WorkQueueManagerCleaner.py
+++ b/src/python/WMComponent/WorkQueueManager/WorkQueueManagerCleaner.py
@@ -9,18 +9,22 @@ __all__ = []
 import time
 import random
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
-
+from WMCore.Services.ReqMgr.ReqMgr import ReqMgr
 
 class WorkQueueManagerCleaner(BaseWorkerThread):
     """
     Cleans expired items, updates element status.
     """
-    def __init__(self, queue):
+    def __init__(self, queue, config):
         """
         Initialise class members
         """
         BaseWorkerThread.__init__(self)
         self.queue = queue
+        self.config = config
+        self.reqmgr2Svc = ReqMgr(self.config.TaskArchiver.ReqMgr2ServiceURL)
+        # state lists which shouldn't be populated in wmbs. (To prevent creating work before WQE status updated)
+        self.abortedAndForceCompleteWorkflowCache = self.reqmgr2Svc.getAbortedAndForceCompleteRequestsFromMemoryCache()
 
     def setup(self, parameters):
         """
@@ -38,6 +42,14 @@ class WorkQueueManagerCleaner(BaseWorkerThread):
         self.queue.logger.info("Start updating & cleaning...")
         try:
             self.queue.performQueueCleanupActions()
+            # this will clean up whatever left over from above clean up. 
+            # also if the wq replication has problem it won't delay the killing jobs in condor
+            # and updating wmbs status
+            abortedAndForceCompleteRequests = self.abortedAndForceCompleteWorkflowCache.getData()
+
+            for wf in abortedAndForceCompleteRequests:
+                self.queue.killWMBSWorkflow(wf)
+                    
         except Exception as ex:
             self.queue.logger.exception("Error cleaning queue: %s" % str(ex))
         self.queue.logger.info("Finished updating & cleaning.")

--- a/src/python/WMComponent/WorkQueueManager/WorkQueueManagerLocationPoller.py
+++ b/src/python/WMComponent/WorkQueueManager/WorkQueueManagerLocationPoller.py
@@ -15,12 +15,13 @@ class WorkQueueManagerLocationPoller(BaseWorkerThread):
     """
     Polls for location updates
     """
-    def __init__(self, queue):
+    def __init__(self, queue, config):
         """
         Initialise class members
         """
         BaseWorkerThread.__init__(self)
         self.queue = queue
+        self.config = config
 
     def setup(self, parameters):
         """

--- a/src/python/WMComponent/WorkQueueManager/WorkQueueManagerWorkPoller.py
+++ b/src/python/WMComponent/WorkQueueManager/WorkQueueManagerWorkPoller.py
@@ -18,12 +18,13 @@ class WorkQueueManagerWorkPoller(BaseWorkerThread):
     """
     Polls for Work
     """
-    def __init__(self, queue):
+    def __init__(self, queue, config):
         """
         Initialise class members
         """
         BaseWorkerThread.__init__(self)
         self.queue = queue
+        self.config = config
 
     def setup(self, parameters):
         """

--- a/src/python/WMCore/Cache/GenericDataCache.py
+++ b/src/python/WMCore/Cache/GenericDataCache.py
@@ -1,5 +1,7 @@
 from __future__ import print_function, division
 import time
+import traceback
+import logging
 
 class MemoryCacheStruct(object):
     """
@@ -27,10 +29,16 @@ class MemoryCacheStruct(object):
             return True
         return False
     
-    def getData(self):
+    def getData(self, noFail=True):
         if self.isDataExpired():
-            self.data = self.func(**self.kwargs)
-            self.lastUpdate = int(time.time())
+            try:
+                self.data = self.func(**self.kwargs)
+                self.lastUpdate = int(time.time())
+            except Exception as ex:
+                if noFail:
+                    logging.error(traceback.format_exc())
+                else:
+                    raise
         return self.data
 
         

--- a/src/python/WMCore/Services/ReqMgr/ReqMgr.py
+++ b/src/python/WMCore/Services/ReqMgr/ReqMgr.py
@@ -52,9 +52,7 @@ class ReqMgr(Service):
             
         data = result['result']    
         if len(data) == 0:
-            return {}
-        elif len(data) == 1:
-            return data[0]
+            return []
         else:
             return data
     
@@ -100,7 +98,7 @@ class ReqMgr(Service):
         callname = 'request?%s' % query
         return self._getResult(callname, verb = "GET")
 
-    def getRequestByStatus(self, statusList):
+    def getRequestByStatus(self, statusList, detail=True):
         """
         _getRequestByStatus_
         
@@ -118,7 +116,7 @@ class ReqMgr(Service):
         TODO: need proper error handling if status is not 200 from orignal reporting.
         """
         
-        query = self._createQuery({'status': statusList})
+        query = self._createQuery({'status': statusList, 'detail': detail})
         callname = 'request?%s' % query
         return  self._getResult(callname, verb = "GET")
         
@@ -215,4 +213,17 @@ class ReqMgr(Service):
         propDict["RequestName"] = request
         return self["requests"].put('request/%s' % request, propDict)[0]['result']
     
+    
+    def getAbortedAndForceCompleteRequestsFromMemoryCache(self):
+        """
+        _getAbortedAndForceCompleteRequestsFromMemoryCache_
+        
+        """
+        # imports here to avoid the dependency not using this function
+        from WMCore.Cache.GenericDataCache import MemoryCacheStruct
+        
+        #TODO remove "aborted-completed status when state transition happens in reqmgr2
+        maskStates = ["aborted", "aborted-completed", "force-complete"]
+        return MemoryCacheStruct(expire=0, func=self.getRequestByStatus, 
+                                            kwargs={'statusList': maskStates, "detail": False})
         

--- a/src/python/WMCore/WorkQueue/WorkQueueBackend.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueBackend.py
@@ -315,7 +315,7 @@ class WorkQueueBackend(object):
             except CouchNotFoundError:
                 pass
 
-    def availableWork(self, thresholds, siteJobCounts, teams=None, wfs=None):
+    def availableWork(self, thresholds, siteJobCounts, teams=None, wfs=None, excludeWorkflows=[]):
         """
         Get work which is available to be run
 
@@ -365,7 +365,9 @@ class WorkQueueBackend(object):
         # priority.
         for i in result:
             element = CouchWorkQueueElement.fromDocument(self.db, i)
-            sortedElements.append(element)
+            # filter out exclude list from abvaling 
+            if element['RequestName'] not in excludeWorkflows:
+                sortedElements.append(element)
             
         # sort elements to get them in priority first and timestamp order
         sortedElements.sort(key=lambda element: element['CreationTime'])

--- a/src/python/WMQuality/Emulators/EmulatorSetup.py
+++ b/src/python/WMQuality/Emulators/EmulatorSetup.py
@@ -46,5 +46,9 @@ def _wmAgentConfig(configFile):
     config.section_("BossAir")
     config.BossAir.pluginNames = ['TestPlugin', 'CondorPlugin']
     config.BossAir.pluginDir   = 'WMCore.BossAir.Plugins'
+    
+    #TaskArchive setup (JobSubmitter needs this)
+    config.component_("TaskArchiver")
+    config.TaskArchiver.ReqMgr2ServiceURL = "https://cmsweb-dev.cern.ch/reqmgr2"
 
     saveConfigurationFile(config, configFile)

--- a/src/python/WMQuality/TestInit.py
+++ b/src/python/WMQuality/TestInit.py
@@ -271,6 +271,7 @@ class TestInit(object):
         config.component_("TaskArchiver")
         config.TaskArchiver.localWMStatsURL = "%s/%s" % (config.JobStateMachine.couchurl, config.JobStateMachine.jobSummaryDBName)
         config.TaskArchiver.ReqMgrSeviceURL = "request manager service url"
+        config.TaskArchiver.ReqMgr2ServiceURL = "https://cmsweb-dev.cern.ch/reqmgr2"
 
         return config
 

--- a/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
+++ b/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
@@ -270,7 +270,11 @@ class JobSubmitterTest(unittest.TestCase):
         config.JobStateMachine.couchurl        = os.getenv('COUCHURL')
         config.JobStateMachine.couchDBName     = "jobsubmitter_t"
         config.JobStateMachine.jobSummaryDBName = 'wmagent_summary_t'
-
+        
+        #TaskArchive setup (JobSubmitter needs this)
+        config.component_("TaskArchiver")
+        config.TaskArchiver.ReqMgr2ServiceURL = "https://cmsweb-dev.cern.ch/reqmgr2"
+        
         # Needed, because this is a test
         os.makedirs(config.JobSubmitter.componentDir)
 


### PR DESCRIPTION
This is not tested and still has some issues.
Here is possible issues (might not be critical though).

1. There is race condition if some workflow is not cleaned up by LQ but it moved to aborted-archived status. (This should be rare but need to be fixed by how we propagate aborted-completed and       *-archived status from multiple agent).
2. Jobs still can be created and submitted between the time user aborted and killing job happens.
    a. currently aborted workflow check is made for wmbs population to prevent further pulling down the work
    b. But we can also add the check in JobCreator and JobSubmitter. (Not sure how much we will gain this - If we need to choose JobSubmitter check will be more effective)

3. killWork can be called concurrently (but it should cause the deadlock on db)

@amaltaro, Alan, don't need to review yet. I will update the code.  
