### PR TITLE
Return empty location if block is not complete anywhere

### DIFF
--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -646,8 +646,7 @@ class DBS3Reader(object):
 
             for name, node in blocksInfo.iteritems():
                 valid_nodes = set(node) - node_filter
-                if valid_nodes:  # dont add if only 'UNKNOWN' or None
-                    locations[name] = list(valid_nodes)
+                locations[name] = list(valid_nodes)
         else:
             try:
                 blocksInfo = self.phedex.getReplicaPhEDExNodesForBlocks(block=fileBlockNames, complete='y')
@@ -658,11 +657,10 @@ class DBS3Reader(object):
 
             for name, nodes in blocksInfo.iteritems():
                 valid_nodes = set(nodes) - node_filter
-                if valid_nodes:  # dont add if only 'UNKNOWN' or None then get with dbs
-                    locations[name] = list(valid_nodes)
+                locations[name] = list(valid_nodes)
 
         # returning single list if a single block is passed
-        if singleBlockName is not None:
+        if singleBlockName:
             return locations[singleBlockName]
 
         return locations


### PR DESCRIPTION
Partially fixes #7446

Make sure to always return a list of block locations (even if block is still not completed anywhere).
TBD how to handle blocks with only invalid files.
