### PR TITLE
Allow harvesting tasks to have the trust flags

### DIFF
--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -372,7 +372,7 @@ class WMWorkloadHelper(PersistencyHelper):
         tasks = []
         for n in self.listAllTaskPathNames():
             task = self.getTaskByPath(taskPath=n)
-            if cpuOnly and task.taskType() in ["Merge", "Harvesting", "Cleanup", "LogCollect"]:
+            if cpuOnly and task.taskType() in ["Cleanup", "LogCollect"]:
                 continue
             tasks.append(task)
 

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
@@ -513,7 +513,7 @@ class TaskChainTests(unittest.TestCase):
             flags = task.getTrustSitelists()
             if task.isTopOfTree():
                 self.assertEqual(flags.values(), [True, True])
-            elif task.taskType() in ["Merge", "Harvesting", "Cleanup", "LogCollect"]:
+            elif task.taskType() in ["Cleanup", "LogCollect"]:
                 self.assertEqual(flags.values(), [False, False])
             else:
                 self.assertFalse(flags['trustlists'])


### PR DESCRIPTION
Fixes #7469
Fix a bug I recently injected in #7433 :-(

Summary of their behaviour is:
*) LogCollect and Cleanup tasks don't see these flags at all
*) for other tasks - if it's top of tree - then they see both flags
*) for other tasks - that are NOT top of tree - they see only the PU flag (which is harmless to non Processing tasks)

Use case being a DQMHarvest workflow that you want to read the input dataset through AAA (FYI @vlimant , this is not working in the current production reqmgr).

Second use case, recovering a merge job in a site that had storage problems and is in drain (read the unmerged files remotely)

Sorry about that.