### PR TITLE
Remove origin_site_name conversion from SE to PNN

### DIFF
--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -15,7 +15,6 @@ from RestClient.ErrorHandling.RestClientExceptions import HTTPError
 from Utils.IterTools import grouper
 from WMCore.Services.DBS.DBSErrors import DBSReaderError, formatEx3
 from WMCore.Services.PhEDEx.PhEDEx import PhEDEx
-from WMCore.Services.SiteDB.SiteDB import SiteDBJSON as SiteDB
 
 
 def remapDBS3Keys(data, stringify=False, **others):
@@ -65,7 +64,6 @@ class DBS3Reader(object):
 
         # connection to PhEDEx (Use default endpoint url)
         self.phedex = PhEDEx(responseType="json")
-        self.siteDB = SiteDB()
 
     def _getLumiList(self, blockName=None, lfns=None, validFileOnly=1):
         """
@@ -633,9 +631,6 @@ class DBS3Reader(object):
                     blocksInfo.setdefault(block, [])
                     # there should be only one element with a single origin site string ...
                     for blockInfo in self.dbs.listBlockOrigin(block_name=block):
-                        # TODO remove this line when all DBS origin_site_name is converted to PNN
-                        blockInfo['origin_site_name'] = self.siteDB.checkAndConvertSENameToPNN(blockInfo['origin_site_name'])
-                        # upto this
                         blocksInfo[block].append(blockInfo['origin_site_name'])
             except dbsClientException as ex:
                 msg = "Error in DBS3Reader: self.dbs.listBlockOrigin(block_name=%s)\n" % fileBlockNames
@@ -812,9 +807,6 @@ class DBS3Reader(object):
                 return list()
 
             for blockInfo in blocksInfo:
-                # TODO remove this line when all DBS origin_site_name is converted to PNN
-                blockInfo['origin_site_name'] = self.siteDB.checkAndConvertSENameToPNN(blockInfo['origin_site_name'])
-                # upto this
                 locations.update(blockInfo['origin_site_name'])
 
             locations.difference_update(['UNKNOWN', None])  # remove entry when SE name is 'UNKNOWN'

--- a/src/python/WMCore/Services/SiteDB/SiteDB.py
+++ b/src/python/WMCore/Services/SiteDB/SiteDB.py
@@ -272,19 +272,3 @@ class SiteDBJSON(SiteDBAPI):
                 continue
             mapping.setdefault(entry['psn_name'], set()).add(entry['phedex_name'])
         return mapping
-    #TODO remove this when all DBS origin_site_name is converted to PNN
-    def checkAndConvertSENameToPNN(self, seNameOrPNN):
-        """
-        check whether argument is sename
-        if it is convert to PNN
-        if not just return argument
-        """
-        if isinstance(seNameOrPNN, basestring):
-            seNameOrPNN = [seNameOrPNN]
-        newList = []
-        for se in seNameOrPNN:
-            if not pnn_regex.match(se):
-                newList.extend(self.seToPNNs(se))
-            else:
-                newList.append(se)
-        return newList

--- a/src/python/WMCore/WorkQueue/Policy/Start/ResubmitBlock.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/ResubmitBlock.py
@@ -110,9 +110,6 @@ class ResubmitBlock(StartPolicyInterface):
             if task.getTrustSitelists().get('trustlists'):
                 dbsBlock["Sites"] = self.sites
             else:
-                # TODO remove this line when all DBS origin_site_name is converted to PNN
-                block["locations"] = self.siteDB.checkAndConvertSENameToPNN(block["locations"])
-                # upto this
                 dbsBlock["Sites"] = self.siteDB.PNNstoPSNs(block["locations"])
             validBlocks.append(dbsBlock)
         else:
@@ -145,9 +142,6 @@ class ResubmitBlock(StartPolicyInterface):
             if task.getTrustSitelists().get('trustlists'):
                 dbsBlock["Sites"] = self.sites
             else:
-                # TODO remove this line when all DBS origin_site_name is converted to PNN
-                block["locations"] = self.siteDB.checkAndConvertSENameToPNN(block["locations"])
-                # upto this
                 dbsBlock["Sites"] = self.siteDB.PNNstoPSNs(block["locations"])
             dbsBlock['ACDC'] = acdcInfo
             if dbsBlock['NumberOfFiles']:
@@ -171,9 +165,6 @@ class ResubmitBlock(StartPolicyInterface):
         if task.getTrustSitelists().get('trustlists'):
             dbsBlock["Sites"] = self.sites
         else:
-            # TODO remove this line when all DBS origin_site_name is converted to PNN
-            acdcBlock["locations"] = self.siteDB.checkAndConvertSENameToPNN(acdcBlock["locations"])
-            # upto this
             dbsBlock["Sites"] = self.siteDB.PNNstoPSNs(acdcBlock["locations"])
         dbsBlock['ACDC'] = acdcInfo
         if dbsBlock['NumberOfFiles']:

--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -416,10 +416,6 @@ class WorkQueue(WorkQueueBase):
                                            splitedBlockName['NumOfFiles'],
                                            user=wmspec.getOwner().get("name"),
                                            group=wmspec.getOwner().get("group"))
-            # since we may still be recovering ACDCs with SE location,
-            # we have to convert them to PNN before adding to wmbs
-            for elem in fileLists:
-                elem['locations'] = self.SiteDB.checkAndConvertSENameToPNN(elem['locations'])
 
             block = {}
             block["Files"] = fileLists

--- a/src/python/WMQuality/Emulators/SiteDBClient/SiteDB.py
+++ b/src/python/WMQuality/Emulators/SiteDBClient/SiteDB.py
@@ -5,11 +5,7 @@ _SiteDBClient_
 Emulating SiteDB
 """
 import re
-"""
-TODO remove this when all DBS origin_site_name is converted to PNN
-Being used in checkAndConvertSENameToPNN
 
-"""
 pnn_regex = re.compile(r'^T[0-3%]((_[A-Z]{2}(_[A-Za-z0-9]+)*)?)')
 
 class SiteDBJSON(object):
@@ -316,18 +312,4 @@ class SiteDBJSON(object):
                 continue
             mapping.setdefault(entry['psn_name'], set()).add(entry['phedex_name'])
         return mapping
-    def checkAndConvertSENameToPNN(self, seNameOrPNN):
-        """
-        check whether argument is sename
-        if it is convert to PNN
-        if not just return argument
-        """
-        if isinstance(seNameOrPNN, basestring):
-            seNameOrPNN = [seNameOrPNN]
-        newList = []
-        for se in seNameOrPNN:
-            if not pnn_regex.match(se):
-                newList.extend(self.seToPNNs(se))
-            else:
-                newList.append(se)
-        return newList
+

--- a/test/python/WMCore_t/Services_t/SiteDB_t/SiteDB_t.py
+++ b/test/python/WMCore_t/Services_t/SiteDB_t/SiteDB_t.py
@@ -15,7 +15,7 @@ class SiteDBTest(EmulatedUnitTestCase):
     Unit tests for SiteScreening module
     """
 
-    def  __init__(self, methodName='runTest'):
+    def __init__(self, methodName='runTest'):
         super(SiteDBTest, self).__init__(methodName=methodName)
 
     def setUp(self):
@@ -112,28 +112,6 @@ class SiteDBTest(EmulatedUnitTestCase):
         """
         result = self.mySiteDB.cmsNametoList("T1_US*", "SE")
         self.assertItemsEqual(result, [u'cmsdcadisk01.fnal.gov'])
-
-    def testCheckAndConvertSENameToPNN(self):
-        """
-        Test the conversion of SE name to PNN for single
-        and multiple sites/PNNs using checkAndConvertSENameToPNN
-        """
-
-        fnalSE = u'cmsdcadisk01.fnal.gov'
-        purdueSE = u'srm.rcac.purdue.edu'
-        fnalPNNs = [u'T1_US_FNAL_Buffer', u'T1_US_FNAL_MSS', u'T1_US_FNAL_Disk']
-        purduePNN = [u'T2_US_Purdue']
-
-        pnnList = fnalPNNs + purduePNN
-        seList = [fnalSE, purdueSE]
-
-        self.assertItemsEqual(self.mySiteDB.checkAndConvertSENameToPNN(fnalSE), fnalPNNs)
-        self.assertItemsEqual(self.mySiteDB.checkAndConvertSENameToPNN([fnalSE]), fnalPNNs)
-        self.assertItemsEqual(self.mySiteDB.checkAndConvertSENameToPNN(purdueSE), purduePNN)
-        self.assertItemsEqual(self.mySiteDB.checkAndConvertSENameToPNN([purdueSE]), purduePNN)
-        self.assertItemsEqual(self.mySiteDB.checkAndConvertSENameToPNN(seList), purduePNN + fnalPNNs)
-        self.assertItemsEqual(self.mySiteDB.checkAndConvertSENameToPNN(pnnList), pnnList)
-        return
 
     def testPNNstoPSNs(self):
         """


### PR DESCRIPTION
As double-checked with Yuyi, `origin_site_name` reports the PNN instead of SE name for quite a while now. Thus I'm making these changes now before we forget it again.

Needs to be tested in VM and agent.
To be merged *after* #7457