### PR TITLE
Three patches backported to wmagent branch

### DIFF
--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -327,11 +327,6 @@ class JobSubmitterPoller(BaseWorkerThread):
                 numberOfCores = getattr(baggage, "numberOfCores", 1)
             loadedJob['numberOfCores'] = numberOfCores
 
-            # check if job should be submitted as highIO job
-            highIOjob = False
-            if newJob['type'] in ["Repack", "Merge", "Cleanup", "LogCollect"]:
-                highIOjob = True
-
             # Create a job dictionary object and put it in the cache (needs to be in sync with RunJob)
             jobInfo = {'id': jobID,
                        'requestName': newJob['request_name'],
@@ -341,7 +336,6 @@ class JobSubmitterPoller(BaseWorkerThread):
                        'priority': newJob['wf_priority'],
                        'taskID': newJob['task_id'],
                        'retry_count': newJob["retry_count"],
-                       'highIOjob': highIOjob,
                        'taskPriority': None,                                # update from the thresholds
                        'custom': {'location': None},                        # update later
                        'packageDir': batchDir,

--- a/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
@@ -947,8 +947,11 @@ class PyCondorPlugin(BasePlugin):
         else:
             jdl.append('+DESIRED_CMSDataLocations = undefined\n')
 
-        # HighIO jobs
-        jdl.append('+Requestioslots = %d\n' % job.get('highIOjob', 0))
+        # HighIO and repack jobs handling
+        highio = 1 if job['taskType'] in ["Merge", "Cleanup", "LogCollect"] else 0
+        repackjob = 1 if job['taskType'] == 'Repack' else 0
+        jdl.append('+Requestioslots = %d\n' % highio)
+        jdl.append('+RequestRepackslots = %d\n' % repackjob)
 
         # Performance and resource estimates
         numberOfCores = job.get('numberOfCores', 1)

--- a/src/python/WMCore/BossAir/RunJob.py
+++ b/src/python/WMCore/BossAir/RunJob.py
@@ -63,7 +63,6 @@ class RunJob(dict):
         self.setdefault('inputDataset', None)
         self.setdefault('inputDatasetLocations', None)
         self.setdefault('allowOpportunistic', False)
-        self.setdefault('highIOjob', False)
 
         return
 

--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -630,24 +630,17 @@ class DBS3Reader(object):
             blocksInfo = {}
             try:
                 for block in fileBlockNames:
+                    blocksInfo.setdefault(block, [])
+                    # there should be only one element with a single origin site string ...
                     for blockInfo in self.dbs.listBlockOrigin(block_name=block):
-                        if blockInfo:
-                            # TODO remove this line when all DBS origin_site_name is converted to PNN
-                            blockInfo['origin_site_name'] = self.siteDB.checkAndConvertSENameToPNN(blockInfo['origin_site_name'])
-                            # upto this
-                            blocksInfo[block] = blockInfo['origin_site_name']
+                        # TODO remove this line when all DBS origin_site_name is converted to PNN
+                        blockInfo['origin_site_name'] = self.siteDB.checkAndConvertSENameToPNN(blockInfo['origin_site_name'])
+                        # upto this
+                        blocksInfo[block].append(blockInfo['origin_site_name'])
             except dbsClientException as ex:
                 msg = "Error in DBS3Reader: self.dbs.listBlockOrigin(block_name=%s)\n" % fileBlockNames
                 msg += "%s\n" % formatEx3(ex)
                 raise DBSReaderError(msg)
-
-            if not blocksInfo:  # no data location from dbs
-                return list()
-
-            for name, node in blocksInfo.iteritems():
-                valid_nodes = set(node) - node_filter
-                if valid_nodes:  # dont add if only 'UNKNOWN' or None
-                    locations[name] = list(valid_nodes)
         else:
             try:
                 blocksInfo = self.phedex.getReplicaPhEDExNodesForBlocks(block=fileBlockNames, complete='y')
@@ -656,10 +649,9 @@ class DBS3Reader(object):
                 msg += "%s\n" % str(ex)
                 raise Exception(msg)
 
-            for name, nodes in blocksInfo.iteritems():
-                valid_nodes = set(nodes) - node_filter
-                if valid_nodes:  # dont add if only 'UNKNOWN' or None then get with dbs
-                    locations[name] = list(valid_nodes)
+        for block in fileBlockNames:
+            valid_nodes = set(blocksInfo.get(block, [])) - node_filter
+            locations[block] = list(valid_nodes)
 
         # returning single list if a single block is passed
         if singleBlockName is not None:

--- a/src/python/WMCore/WorkQueue/Policy/Start/MonteCarlo.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/MonteCarlo.py
@@ -30,6 +30,8 @@ class MonteCarlo(StartPolicyInterface):
         self.args.setdefault('MaxJobsPerElement', 1000)  # jobs per WQE
         self.args.setdefault('blowupFactor', 1.0) # Estimate of additional jobs following tasks.
                                                   # Total WQE tasks will be Jobs*(1+blowupFactor)
+        noInputUpdate = self.initialTask.getTrustSitelists().get('trustlists')
+        noPileupUpdate = self.initialTask.getTrustSitelists().get('trustPUlists')
 
         if not self.mask:
             self.mask = Mask(FirstRun = 1,
@@ -71,6 +73,8 @@ class MonteCarlo(StartPolicyInterface):
                                  NumberOfEvents = nEvents,
                                  Jobs = jobs,
                                  Mask = copy(mask),
+                                 NoInputUpdate=noInputUpdate,
+                                 NoPileupUpdate=noPileupUpdate,
                                  blowupFactor = self.args['blowupFactor'])
 
 


### PR DESCRIPTION
1.0.21_wmagent branch version of
https://github.com/dmwm/WMCore/pull/7378 Allow jobs to request repack slots
https://github.com/dmwm/WMCore/pull/7437 Accept Trust flags for MonteCarlo WQ policy
https://github.com/dmwm/WMCore/pull/7457 Take2 - return empty location if block is not complete anywhere

The later one needs to be pushed to the production agents (already did for vocms0311).