### PR TITLE
add query for checking draining status

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/MySQL/CheckDrainStatus.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/CheckDrainStatus.py
@@ -1,0 +1,46 @@
+from __future__ import print_function, division
+from WMCore.Database.DBFormatter import DBFormatter
+
+class CheckDrainStatus(DBFormatter):
+    """
+    _CheckDrainStatus_
+    
+    1. checks all the workflows are completed status (within the agent)
+    2. checks all the blocks are closed
+    3. checks all the files are injected to PhEDEx
+    4. checks all the files are uploaded to DBS
+
+    TODO: need to check archived statsus
+    """
+    completedSQL = "SELECT count(*) FROM dbsbuffer_workflow WHERE completed = 0"
+    
+    blockClosedSQL = "SELECT count(*) FROM dbsbuffer_block where status != 'Closed'"
+
+    phedexSQL = "SELECT count(*) FROM dbsbuffer_file WHERE in_phedex = 0"
+    
+    dbsSQL = "SELECT count(*) FROM dbsbuffer_file WHERE status != 'InDBS'"
+
+    def _executeQuery(self, sql, keyName, conn = None, transaction = False):
+        result = self.dbi.processData(self.sql, conn = conn, transaction = transaction)
+        count = self.format(result)[0]
+        return {keyName: count}
+        
+    def execute(self, conn = None, transaction = False):
+        result = {}
+        # number of workflows
+        completeStatus = self._executeQuery(self.completedSQL, "NotCompleted", conn, transaction)
+        result.update(completeStatus)
+        
+        # number of blocks
+        closedStatus = self._executeQuery(self.completedSQL, "NotClosed", conn, transaction)
+        result.update(closedStatus)
+        
+        # number of files
+        phedexStatus = self._executeQuery(self.completedSQL, "NotInPhEDEx", conn, transaction)
+        result.update(phedexStatus)
+        
+        # number of files
+        dbsStatus = self._executeQuery(self.completedSQL, "NotInDBS", conn, transaction)
+        result.update(dbsStatus)
+
+        return result

--- a/src/python/WMComponent/DBS3Buffer/Oracle/CheckDrainStatus.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/CheckDrainStatus.py
@@ -1,0 +1,10 @@
+from __future__ import print_function, division
+from WMComponent.DBS3Buffer.MySQL.CheckDrainStatus \
+    import CheckDrainStatus as MySQLCheckDrainStatus
+
+class CheckDrainStatus(MySQLCheckDrainStatus):
+    """
+    _CheckDrainStatus_
+
+    """
+    pass


### PR DESCRIPTION
@goughes, Erik, this is initial check for draining status. (shouldn't be merged - just start point the Erik and work on)

when agent is set to drain.

1. In AgentStatusWatcher, check the drain status and run this query to whether everything is read to go. (all the count has to be 0)
2. report this to wmstats (and email). 

There need to be a check for stuck workflows (jobs won't be run), Alan will tell what condition to check. (This should run before above check)

We can discuss in more detail but start with this patch. Also could you create the unittest for it.