### PR TITLE
fix task and step chain mask

### DIFF
--- a/src/python/WMCore/ReqMgr/Service/Request.py
+++ b/src/python/WMCore/ReqMgr/Service/Request.py
@@ -263,16 +263,16 @@ class Request(RESTEntity):
             # assume mask_key is list if the condition doesn't meet.
             
             for i in range(num_loop):
-                chain = req_dict["%s%s" % (chain_name, i+1)]
+                chain_key = "%s%s" % (chain_name, i+1)
+                chain = req_dict[chain_key]
                 if mask_key in chain:
-                    chain_key = "%sName" % chain_name
-                    masked_dict[mask_key].append({chain_key: chain[chain_key], mask_key: chain[mask_key]})
+                    masked_dict[mask_key].append({chain_key: chain[mask_key]})
                 else:
                     if isinstance(defaultValue, dict):
                         value = defaultValue.get(chain_key, None)
                     else:
                         value = defaultValue
-                    masked_dict[mask_key].append({chain_key: chain[chain_key], mask_key: chain[mask_key]})
+                    masked_dict[mask_key].append({chain_key: value})
         return
                  
     def _mask_result(self, mask, result):


### PR DESCRIPTION
fixes #7513
Now it returns something like this.

https://reqmgr2-dev.cern.ch/reqmgr2/data/request?name=sryu_TaskChainRunJet2012C_multiRun_reqmgr2_170113_054413_4532&mask=InputDataset&mask=ProcessingString&mask=TaskName

```
{"result": [
 {
  "sryu_TaskChainRunJet2012C_multiRun_reqmgr2_170113_054413_4532": {
    "InputDataset": [
      {
        "Task1": "/JetHT/Run2012C-v1/RAW"
      }, 
      {
        "Task2": null
      }
    ], 
    "ProcessingString": [
      {
        "Task1": "RelVal_TEST_multiRunHarvesting"
      }, 
      {
        "Task2": "RelVal_TEST_multiRunHarvesting"
      }
    ], 
    "TaskName": [
      {
        "Task1": "HLTD"
      }, 
      {
        "Task2": "RECODreHLT"
      }
    ]
  }
}]}
````