### PR TITLE
Global Workqueue thread for monitoring

### DIFF
--- a/src/python/WMCore/GlobalWorkQueue/CherryPyThreads/MonitoringTask.py
+++ b/src/python/WMCore/GlobalWorkQueue/CherryPyThreads/MonitoringTask.py
@@ -1,0 +1,49 @@
+from __future__ import (division, print_function)
+
+from Utils.CherryPyPeriodicTask import CherryPyPeriodicTask
+from WMCore.WorkQueue.WorkQueue import globalQueue
+from WMCore.Services.WMStats.WMStatsWriter import WMStatsWriter, convertToServiceCouchDoc
+
+
+class MonitoringTask(CherryPyPeriodicTask):
+    def __init__(self, rest, config):
+        CherryPyPeriodicTask.__init__(self, config)
+        self.centralWMStats = WMStatsWriter(config.queueParams['WMStatsCouchUrl'])
+
+    def setConcurrentTasks(self, config):
+        """
+        sets the list of function reference for concurrent tasks
+        """
+        self.concurrentTasks = [{'func': self.monitorGlobalQueue, 'duration': config.monitDuration}]
+
+    def monitorGlobalQueue(self, config):
+        """
+        Collect some statistics for Global Workqueue and upload it to WMStats. They are:
+        - by status: count of elements and total number of estimated jobs
+        - by status: count of elements and sum of jobs by *priority*.
+        - by agent: count of elements and sum of jobs by *status*
+        - by agent: count of elements and sum of jobs by *priority*
+        - by status: unique (distributed) and possible (total assigned) number
+          of jobs and elements per *site*, taking into account data locality
+        - by status: unique (distributed) and possible (total assigned) number
+          of jobs and elements per *site*, regardless data locality (using AAA)
+
+        TODO: these still need to be done
+        * for Available workqueue elements:
+         - WQE without a common site list (that does not pass the work restrictions)
+         - WQE older than 7 days (or whatever number we decide)
+         - WQE that create > 30k jobs (or whatever number we decide)
+        * for Acquired workqueue elements
+         - WQE older than 7 days (or whatever the number is)
+        """
+        self.logger.info("Collecting GlobalWorkqueue statistics...")
+
+        # retrieve whole docs for these status in order to create site metrics
+        status = ['Available', 'Negotiating', 'Acquired']
+        globalQ = globalQueue(**config.queueParams)
+        results = globalQ.monitorWorkQueue(status)
+
+        wqSummaryDoc = convertToServiceCouchDoc(results, config.queueParams['log_reporter'])
+        self.centralWMStats.updateAgentInfo(wqSummaryDoc)
+
+        return

--- a/src/python/WMCore/Services/WMStats/WMStatsWriter.py
+++ b/src/python/WMCore/Services/WMStats/WMStatsWriter.py
@@ -36,6 +36,19 @@ def monitorDocFromRequestSchema(schema):
     return doc
 
 
+def convertToServiceCouchDoc(wqInfo, wqURL):
+    """
+    Convert services generic info into a proper couch doc.
+    """
+    wqDoc = {}
+    wqDoc.update(wqInfo)
+    wqDoc['_id'] = wqURL
+    wqDoc['agent_url'] = wqURL
+    wqDoc['timestamp'] = int(time.time())
+    wqDoc['type'] = "agent_info"
+    return wqDoc
+
+
 class WMStatsWriter(WMStatsReader):
 
     def __init__(self, couchURL, appName="WMStats", reqdbURL=None, reqdbCouchApp="ReqMgr"):


### PR DESCRIPTION
It has to be merged *after* #7530

Initial version of the WorkQueue cherrypy thread for monitoring global queue (I still have to remove my logging :)) 

It gather most of the information described in the agent wiki page:
https://github.com/dmwm/WMCore/wiki/WMAgent-monitoring

number 4 (4. Central Global Queue...).

BTW, besides what was already suggested to the WorkQueue deployment changes, we have also to add the following to the workqueue config.py file:
```
    # workqueue monitoring thread
    monitTask = extentions.section_("monitTask")
    monitTask.object = "WMCore.GlobalWorkQueue.CherryPyThreads.MonitoringTask.MonitoringTask"
    setWorkQueueCommonConfig(monitTask)
    monitTask.monitDuration = 60 * 30 # every 30 minutes
    monitTask.log_file = '%s/logs/workqueue/monitTask-%s.log' % (__file__.rsplit('/', 4)[0], time.strftime("%Y%m%d"))
```