### PR TITLE
Fix WorkQueueElement location/restriction methods

### DIFF
--- a/src/couchapps/WorkQueue/lists/workRestrictions.js
+++ b/src/couchapps/WorkQueue/lists/workRestrictions.js
@@ -73,7 +73,7 @@ function(head, req) {
             }
 
             //skip if not in whitelist
-            if (ele["SiteWhitelist"].length != 0 && ele["SiteWhitelist"].indexOf(site) === -1) {
+            if (ele["SiteWhitelist"].indexOf(site) === -1) {
                 continue;
             }
 

--- a/src/python/WMCore/WorkQueue/DataLocationMapper.py
+++ b/src/python/WMCore/WorkQueue/DataLocationMapper.py
@@ -198,7 +198,7 @@ class WorkQueueDataLocationMapper(DataLocationMapper):
         for dbs, dataMapping in dataLocations.items():
             modified = []
             for data, locations in dataMapping.items():
-                elements = self.backend.getElementsForData(dbs, data)
+                elements = self.backend.getElementsForData(data)
                 for element in elements:
                     if element.get('NoInputUpdate', False):
                         continue

--- a/src/python/WMCore/WorkQueue/WorkQueueBackend.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueBackend.py
@@ -524,7 +524,7 @@ class WorkQueueBackend(object):
             injectionStatus = dict((x['key'], x['value']) for x in data.get('rows', []))
             finalInjectionStatus = []
             for request in injectionStatus.keys():
-                inboxElements = self.getInboxElements(WorkflowName=request)
+                inboxElement = self.getInboxElements(WorkflowName=request)
                 requestOpen = inboxElement[0].get('OpenForNewData', False) if inboxElement else False
                 finalInjectionStatus.append({request: injectionStatus[request] and not requestOpen})
 

--- a/src/python/WMCore/WorkQueue/WorkQueueBackend.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueBackend.py
@@ -189,27 +189,28 @@ class WorkQueueBackend(object):
 
         if elementIDs:
             if elementFilters or status or returnIdOnly:
-                raise ValueError("Can't specify extra filters (or return id's) when using element id's with getElements()")
+                raise ValueError(
+                    "Can't specify extra filters (or return id's) when using element id's with getElements()")
             elements = [CouchWorkQueueElement(db, i).load() for i in elementIDs]
         else:
             options = {'include_docs': True, 'filter': elementFilters, 'idOnly': returnIdOnly, 'reduce': False}
             # filter on workflow or status if possible
-            filter = 'elementsByWorkflow'
+            filterName = 'elementsByWorkflow'
             if WorkflowName:
                 key.append(WorkflowName)
             elif status:
-                filter = 'elementsByStatus'
+                filterName = 'elementsByStatus'
                 key.append(status)
             elif elementFilters.get('SubscriptionId'):
                 key.append(elementFilters['SubscriptionId'])
-                filter = 'elementsBySubscription'
+                filterName = 'elementsBySubscription'
             # add given params to filters
             if status:
                 options['filter']['Status'] = status
             if WorkflowName:
                 options['filter']['RequestName'] = WorkflowName
 
-            view = db.loadList('WorkQueue', 'filter', filter, options, key)
+            view = db.loadList('WorkQueue', 'filter', filterName, options, key)
             view = json.loads(view)
             if returnIdOnly:
                 return view
@@ -300,7 +301,7 @@ class WorkQueueBackend(object):
             i.delete()
             specs[i['RequestName']] = None
         answer = elements[0]._couch.commit()
-        result, failures = formatReply(answer, *elements)
+        _, failures = formatReply(answer, *elements)
         msg = 'Couch error deleting element: "%s", error "%s", reason "%s"'
         for failed in failures:
             # only count delete as failed if document still exists
@@ -315,7 +316,7 @@ class WorkQueueBackend(object):
             except CouchNotFoundError:
                 pass
 
-    def availableWork(self, thresholds, siteJobCounts, teams=None, wfs=None, excludeWorkflows=[]):
+    def availableWork(self, thresholds, siteJobCounts, teams=None, wfs=None, excludeWorkflows=None):
         """
         Get work which is available to be run
 
@@ -328,6 +329,7 @@ class WorkQueueBackend(object):
         """
         self.logger.info("Getting available work from %s/%s" %
                          (sanitizeURL(self.server.url)['url'], self.db.name))
+        excludeWorkflows = excludeWorkflows or []
         elements = []
         sortedElements = []
 
@@ -365,14 +367,14 @@ class WorkQueueBackend(object):
         # priority.
         for i in result:
             element = CouchWorkQueueElement.fromDocument(self.db, i)
-            # filter out exclude list from abvaling 
+            # filter out exclude list from abvaling
             if element['RequestName'] not in excludeWorkflows:
                 sortedElements.append(element)
-            
+
         # sort elements to get them in priority first and timestamp order
         sortedElements.sort(key=lambda element: element['CreationTime'])
-        sortedElements.sort(key = lambda x: x['Priority'], reverse = True)
-         
+        sortedElements.sort(key=lambda x: x['Priority'], reverse=True)
+
         for element in sortedElements:
             prio = element['Priority']
 
@@ -382,7 +384,6 @@ class WorkQueueBackend(object):
             for site in sites:
                 if element.passesSiteRestriction(site):
                     # Count the number of jobs currently running of greater priority
-                    prio = element['Priority']
                     curJobCount = sum(map(lambda x: x[1] if x[0] >= prio else 0, siteJobCounts.get(site, {}).items()))
                     self.logger.debug("Job Count: %s, site: %s threshods: %s" % (curJobCount, site, thresholds[site]))
                     if curJobCount < thresholds[site]:
@@ -419,7 +420,7 @@ class WorkQueueBackend(object):
         return [{'dbs_url': x['key'][0],
                  'name': x['key'][1]} for x in data.get('rows', [])]
 
-    def getElementsForData(self, dbs, data):
+    def getElementsForData(self, data):
         """Get active elements for this dbs & data combo"""
         elements = self.db.loadView('WorkQueue', 'elementsByData', {'key': data, 'include_docs': True})
         return [CouchWorkQueueElement.fromDocument(self.db,

--- a/test/python/WMCore_t/WorkQueue_t/DataStructs_t/WorkQueueElement_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/DataStructs_t/WorkQueueElement_t.py
@@ -22,7 +22,6 @@ ParentQueueId = [None, '1', 2]
 Acdcs = [{}, {'Something' : 'Somewhat'}]
 
 
-
 class WorkQueueElementTest(unittest.TestCase):
 
     def testId(self):
@@ -72,6 +71,205 @@ class WorkQueueElementTest(unittest.TestCase):
         ele.id = 'something_new'
         self.assertEqual('something_new', ele.id)
         self.assertNotEqual(before_id, ele.id)
+
+    def testPassesSiteRestriction(self):
+        """
+        Workqueue element site restriction check (same as workRestrictions)
+        """
+        # test element ala MonteCarlo
+        ele = WorkQueueElement(SiteWhitelist=["T1_IT_CNAF", "T2_DE_DESY"], SiteBlacklist=["T1_US_FNAL"])
+        self.assertFalse(ele.passesSiteRestriction("T1_US_FNAL"))
+        self.assertFalse(ele.passesSiteRestriction("T2_CH_CERN"))
+        self.assertTrue(ele.passesSiteRestriction("T1_IT_CNAF"))
+
+        # test element with input dataset
+        ele['Inputs'] = {"/MY/BLOCK/NAME#73e99a52": []}
+        self.assertFalse(ele.passesSiteRestriction("T1_US_FNAL"))
+        self.assertFalse(ele.passesSiteRestriction("T2_CH_CERN"))
+        self.assertFalse(ele.passesSiteRestriction("T1_IT_CNAF"))
+        self.assertFalse(ele.passesSiteRestriction("T2_DE_DESY"))
+        ele['Inputs'] = {"/MY/BLOCK/NAME#73e99a52": ["T1_US_FNAL", "T2_DE_DESY"]}
+        self.assertFalse(ele.passesSiteRestriction("T1_US_FNAL"))
+        self.assertFalse(ele.passesSiteRestriction("T1_IT_CNAF"))
+        self.assertTrue(ele.passesSiteRestriction("T2_DE_DESY"))
+
+        # test element with input and parent dataset
+        ele['Inputs'] = {"/MY/BLOCK/NAME#73e99a52": []}
+        ele['ParentFlag'] = True
+        ele['ParentData'] = {"/MY/BLOCK2/NAME#002590494c06": []}
+        self.assertFalse(ele.passesSiteRestriction("T1_US_FNAL"))
+        self.assertFalse(ele.passesSiteRestriction("T2_CH_CERN"))
+        self.assertFalse(ele.passesSiteRestriction("T1_IT_CNAF"))
+        self.assertFalse(ele.passesSiteRestriction("T2_DE_DESY"))
+        ele['Inputs'] = {"/MY/BLOCK/NAME#73e99a52": ["T1_US_FNAL", "T2_DE_DESY"]}
+        self.assertFalse(ele.passesSiteRestriction("T1_US_FNAL"))
+        self.assertFalse(ele.passesSiteRestriction("T2_DE_DESY"))
+        ele['Inputs'] = {"/MY/BLOCK/NAME#73e99a52": ["T1_US_FNAL", "T2_DE_DESY"]}
+        ele['ParentData'] = {"/MY/BLOCK2/NAME#002590494c06": ["T1_IT_CNAF", "T2_CH_CERN", "T2_DE_DESY"]}
+        self.assertFalse(ele.passesSiteRestriction("T1_US_FNAL"))
+        self.assertFalse(ele.passesSiteRestriction("T1_IT_CNAF"))
+        self.assertTrue(ele.passesSiteRestriction("T2_DE_DESY"))
+
+        # test element with input, parent and pileup dataset
+        ele['PileupData'] = {"/MY/DATASET/NAME": []}
+        self.assertFalse(ele.passesSiteRestriction("T1_US_FNAL"))
+        self.assertFalse(ele.passesSiteRestriction("T2_CH_CERN"))
+        self.assertFalse(ele.passesSiteRestriction("T1_IT_CNAF"))
+        self.assertFalse(ele.passesSiteRestriction("T2_DE_DESY"))
+        ele['PileupData'] = {"/MY/DATASET/NAME": ["T2_US_Nebraska", "T1_IT_CNAF"]}
+        self.assertFalse(ele.passesSiteRestriction("T1_IT_CNAF"))
+        ele['Inputs'] = {"/MY/BLOCK/NAME#73e99a52": ["T1_US_FNAL", "T1_IT_CNAF", "T2_DE_DESY"]}
+        self.assertFalse(ele.passesSiteRestriction("T1_US_FNAL"))
+        self.assertTrue(ele.passesSiteRestriction("T1_IT_CNAF"))
+        self.assertFalse(ele.passesSiteRestriction("T2_DE_DESY"))
+
+    def testPassesSiteRestrictionLocationFlags(self):
+        """
+        Workqueue element site restriction check (same as workRestrictions)
+        """
+        # test element ala MonteCarlo
+        ele = WorkQueueElement(SiteWhitelist=["T1_IT_CNAF", "T2_DE_DESY"], SiteBlacklist=["T1_US_FNAL"])
+        self.assertFalse(ele.passesSiteRestriction("T1_US_FNAL"))
+        self.assertFalse(ele.passesSiteRestriction("T2_CH_CERN"))
+        self.assertTrue(ele.passesSiteRestriction("T1_IT_CNAF"))
+
+        # test element with input dataset
+        ele['Inputs'] = {"/MY/BLOCK/NAME#73e99a52": []}
+        ele['NoInputUpdate'] = True
+        self.assertFalse(ele.passesSiteRestriction("T1_US_FNAL"))
+        self.assertFalse(ele.passesSiteRestriction("T2_CH_CERN"))
+        self.assertTrue(ele.passesSiteRestriction("T1_IT_CNAF"))
+        self.assertTrue(ele.passesSiteRestriction("T2_DE_DESY"))
+        ele['Inputs'] = {"/MY/BLOCK/NAME#73e99a52": ["T1_US_FNAL", "T2_DE_DESY"]}
+        self.assertFalse(ele.passesSiteRestriction("T1_US_FNAL"))
+        self.assertTrue(ele.passesSiteRestriction("T1_IT_CNAF"))
+        self.assertTrue(ele.passesSiteRestriction("T2_DE_DESY"))
+
+        # test element with input and parent dataset
+        ele['Inputs'] = {"/MY/BLOCK/NAME#73e99a52": []}
+        ele['ParentFlag'] = True
+        ele['ParentData'] = {"/MY/BLOCK2/NAME#002590494c06": []}
+        self.assertFalse(ele.passesSiteRestriction("T1_US_FNAL"))
+        self.assertFalse(ele.passesSiteRestriction("T2_CH_CERN"))
+        self.assertTrue(ele.passesSiteRestriction("T1_IT_CNAF"))
+        self.assertTrue(ele.passesSiteRestriction("T2_DE_DESY"))
+        ele['Inputs'] = {"/MY/BLOCK/NAME#73e99a52": ["T1_US_FNAL", "T2_DE_DESY"]}
+        self.assertFalse(ele.passesSiteRestriction("T1_US_FNAL"))
+        self.assertTrue(ele.passesSiteRestriction("T2_DE_DESY"))
+        ele['Inputs'] = {"/MY/BLOCK/NAME#73e99a52": ["T1_US_FNAL", "T2_DE_DESY"]}
+        ele['ParentData'] = {"/MY/BLOCK2/NAME#002590494c06": ["T1_IT_CNAF", "T2_CH_CERN", "T2_DE_DESY"]}
+        self.assertFalse(ele.passesSiteRestriction("T1_US_FNAL"))
+        self.assertTrue(ele.passesSiteRestriction("T1_IT_CNAF"))
+        self.assertTrue(ele.passesSiteRestriction("T2_DE_DESY"))
+
+        # test element with input, parent and pileup dataset
+        ele['PileupData'] = {"/MY/DATASET/NAME": []}
+        ele['NoPileupUpdate'] = True
+        self.assertFalse(ele.passesSiteRestriction("T1_US_FNAL"))
+        self.assertFalse(ele.passesSiteRestriction("T2_CH_CERN"))
+        self.assertTrue(ele.passesSiteRestriction("T1_IT_CNAF"))
+        self.assertTrue(ele.passesSiteRestriction("T2_DE_DESY"))
+        ele['PileupData'] = {"/MY/DATASET/NAME": ["T2_US_Nebraska", "T1_IT_CNAF"]}
+        self.assertFalse(ele.passesSiteRestriction("T2_US_Nebraska"))
+        ele['Inputs'] = {"/MY/BLOCK/NAME#73e99a52": ["T1_US_FNAL", "T1_IT_CNAF", "T2_DE_DESY"]}
+        self.assertFalse(ele.passesSiteRestriction("T1_US_FNAL"))
+        self.assertTrue(ele.passesSiteRestriction("T1_IT_CNAF"))
+        self.assertTrue(ele.passesSiteRestriction("T2_DE_DESY"))
+        # only the pileup flag enabled now
+        ele['NoInputUpdate'] = False
+        ele['PileupData'] = {"/MY/DATASET/NAME": []}
+        self.assertFalse(ele.passesSiteRestriction("T1_US_FNAL"))
+        self.assertFalse(ele.passesSiteRestriction("T2_CH_CERN"))
+        self.assertTrue(ele.passesSiteRestriction("T1_IT_CNAF"))
+        self.assertTrue(ele.passesSiteRestriction("T2_DE_DESY"))
+
+    def testPossibleSites(self):
+        """
+        Workqueue element data location check (same as workRestrictions)
+        """
+        # test element ala MonteCarlo
+        ele = WorkQueueElement(SiteWhitelist=["T1_IT_CNAF", "T2_DE_DESY"])
+        self.assertEqual(ele.possibleSites(), ["T1_IT_CNAF", "T2_DE_DESY"])
+
+        # test element with InputDataset but no location
+        ele['Inputs'] = {"/MY/BLOCK/NAME#73e99a52": []}
+        self.assertEqual(ele.possibleSites(), [])
+        # test element with InputDataset and no match location
+        ele['Inputs'] = {"/MY/BLOCK/NAME#73e99a52": ["T1_US_FNAL", "T2_CH_CERN"]}
+        self.assertEqual(ele.possibleSites(), [])
+        # test element with InputDataset and valid location
+        ele['Inputs'] = {"/MY/BLOCK/NAME#73e99a52": ["T1_US_FNAL", "T2_CH_CERN", "T2_DE_DESY"]}
+        self.assertEqual(ele.possibleSites(), ["T2_DE_DESY"])
+
+        # test element with InputDataset and ParentData with no location
+        ele['Inputs'] = {"/MY/BLOCK/NAME#73e99a52": ["T1_US_FNAL", "T2_CH_CERN", "T2_DE_DESY"]}
+        ele['ParentFlag'] = True
+        ele['ParentData'] = {"/MY/BLOCK2/NAME#002590494c06": []}
+        self.assertEqual(ele.possibleSites(), [])
+        # test element with InputDataset and ParentData with no match location
+        ele['ParentData'] = {"/MY/BLOCK2/NAME#002590494c06": ["T1_IT_CNAF"]}
+        self.assertEqual(ele.possibleSites(), [])
+        # test element with InputDataset and ParentData with valid location
+        ele['ParentData'] = {"/MY/BLOCK2/NAME#002590494c06": ["T1_US_FNAL", "T2_DE_DESY"]}
+        self.assertEqual(ele.possibleSites(), ["T2_DE_DESY"])
+
+        # test element with InputDataset, PileupData and ParentData with no location
+        ele['Inputs'] = {"/MY/BLOCK/NAME#73e99a52": ["T1_US_FNAL", "T2_CH_CERN", "T2_DE_DESY"]}
+        ele['ParentData'] = {"/MY/BLOCK2/NAME#002590494c06": ["T2_DE_DESY"]}
+        ele['PileupData'] = {"/MY/DATASET/NAME": []}
+        self.assertEqual(ele.possibleSites(), [])
+        # test element with InputDataset, PileupData and ParentData with no match location
+        ele['PileupData'] = {"/MY/DATASET/NAME": ["T1_IT_CNAF", "T2_CH_CERN"]}
+        self.assertEqual(ele.possibleSites(), [])
+        # test element with InputDataset, PileupData and ParentData with valid location
+        ele['PileupData'] = {"/MY/DATASET/NAME": ["T1_IT_CNAF", "T2_DE_DESY"]}
+        self.assertEqual(ele.possibleSites(), ["T2_DE_DESY"])
+
+    def testPossibleSitesLocationFlags(self):
+        """
+        Workqueue element data location check, using the input and PU data location flags
+        """
+        ele = WorkQueueElement(SiteWhitelist=["T1_IT_CNAF", "T2_DE_DESY"])
+
+        # test element with InputDataset and no location, but input flag on
+        ele['Inputs'] = {"/MY/BLOCK/NAME#73e99a52": []}
+        ele['NoInputUpdate'] = True
+        self.assertEqual(ele.possibleSites(), ["T1_IT_CNAF", "T2_DE_DESY"])
+        # test element with InputDataset and one match, but input flag on
+        ele['Inputs'] = {"/MY/BLOCK/NAME#73e99a52": ["T1_IT_CNAF", "T2_CH_CERN"]}
+        self.assertEqual(ele.possibleSites(), ["T1_IT_CNAF", "T2_DE_DESY"])
+        # test element with InputDataset and one match, but pu flag on
+        ele['NoInputUpdate'] = False
+        ele['NoPileupUpdate'] = True
+        self.assertEqual(ele.possibleSites(), ["T1_IT_CNAF"])
+        # test element with InputDataset and one match, but both flags on
+        ele['NoInputUpdate'] = True
+        self.assertEqual(ele.possibleSites(), ["T1_IT_CNAF", "T2_DE_DESY"])
+
+        # test element with InputDataset and ParentData and no location, but both flags on
+        ele['ParentFlag'] = True
+        ele['ParentData'] = {"/MY/BLOCK2/NAME#002590494c06": []}
+        self.assertEqual(ele.possibleSites(), ["T1_IT_CNAF", "T2_DE_DESY"])
+        # test element with InputDataset and ParentData and no location, but input flag on
+        ele['NoPileupUpdate'] = False
+        self.assertEqual(ele.possibleSites(), ["T1_IT_CNAF", "T2_DE_DESY"])
+        # test element with InputDataset and ParentData and no location, but pileup flag on
+        ele['NoInputUpdate'] = False
+        ele['NoPileupUpdate'] = True
+        self.assertEqual(ele.possibleSites(), [])
+
+        # test element with InputDataset, PileupData and ParentData with no location, but pileup flag on
+        ele['Inputs'] = {"/MY/BLOCK/NAME#73e99a52": ["T1_US_FNAL", "T2_CH_CERN", "T2_DE_DESY"]}
+        ele['ParentData'] = {"/MY/BLOCK2/NAME#002590494c06": ["T2_DE_DESY"]}
+        ele['PileupData'] = {"/MY/DATASET/NAME": []}
+        self.assertEqual(ele.possibleSites(), ["T2_DE_DESY"])
+        # test element with InputDataset, PileupData and ParentData with no location, but both flags on
+        ele['NoInputUpdate'] = True
+        self.assertEqual(ele.possibleSites(), ["T1_IT_CNAF", "T2_DE_DESY"])
+        # test element with InputDataset, PileupData and ParentData with no location, but input flag on
+        ele['NoPileupUpdate'] = False
+        self.assertEqual(ele.possibleSites(), [])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/WMCore_t/WorkQueue_t/DataStructs_t/WorkQueueElement_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/DataStructs_t/WorkQueueElement_t.py
@@ -10,23 +10,22 @@ from WMCore.WorkQueue.DataStructs.WorkQueueElement import WorkQueueElement
 
 RequestNames = ['test', 'test2', '', 'abcdefg']
 TaskNames = [None, '', 'task1', 'task2', 'abcdfg']
-Inputs = [{}, {'/dataset/RAW' : ['sitea']},
-          {'/dataset/RAW' : ['sitea'], '/dataset/RECO' : ['sitea', 'siteb']}]
-Masks = [None, {'FirstEvent' : 1}, {'FirstEvent' : 1, 'LastEvent' : 10},
-         {'FirstEvent' : 5, 'LastLumi' : 10}]
+Inputs = [{}, {'/dataset/RAW': ['sitea']},
+          {'/dataset/RAW': ['sitea'], '/dataset/RECO': ['sitea', 'siteb']}]
+Masks = [None, {'FirstEvent': 1}, {'FirstEvent': 1, 'LastEvent': 10},
+         {'FirstEvent': 5, 'LastLumi': 10}]
 Dbses = [None, 'https://example.com/dbs', 'http://example.com/another_dbs']
 Progress = Priority = [x for x in range(0, 100, 10)]
 Teams = [None, '', 'bob', 'A-Team']
 ParentQueueUrl = [None, '', 'https://something']
 ParentQueueId = [None, '1', 2]
-Acdcs = [{}, {'Something' : 'Somewhat'}]
+Acdcs = [{}, {'Something': 'Somewhat'}]
 
 
 class WorkQueueElementTest(unittest.TestCase):
-
     def testId(self):
         """Id calculated correctly"""
-        ele = WorkQueueElement(RequestName = 'test')
+        ele = WorkQueueElement(RequestName='test')
         self.assertEqual(ele.id, '8b2e394154f6464f4b2aaf086a45f8c2')
 
     def testIdUnique(self):
@@ -36,37 +35,37 @@ class WorkQueueElementTest(unittest.TestCase):
         # verify each id is unique
         for params in itertools.product(RequestNames, TaskNames, Inputs,
                                         Masks, Dbses, Acdcs):
-            ele = WorkQueueElement(RequestName = params[0], TaskName = params[1],
-                                   Inputs = params[2], Mask = params[3],
-                                   Dbs = params[4], ACDC = params[5]
-                                   )
+            ele = WorkQueueElement(RequestName=params[0], TaskName=params[1],
+                                   Inputs=params[2], Mask=params[3],
+                                   Dbs=params[4], ACDC=params[5]
+                                  )
             self.assertFalse(ele.id in ids)
             ids[ele.id] = None
 
     def testIdIgnoresIrrelevant(self):
         """Id calculation ignores irrelavant variables"""
-        ele = WorkQueueElement(RequestName = 'testIdIgnoresIrrelevant')
+        ele = WorkQueueElement(RequestName='testIdIgnoresIrrelevant')
         this_id = ele.id
         for params2 in itertools.product(Progress, Priority, Teams,
                                          ParentQueueUrl, ParentQueueId):
-            ele = WorkQueueElement(RequestName = 'testIdIgnoresIrrelevant',
-                                   PercentSuccess = params2[0],
-                                   Priority = params2[1], TeamName = params2[2],
-                                   ParentQueueUrl = params2[3], ParentQueueId = params2[4],
-                                   )
+            ele = WorkQueueElement(RequestName='testIdIgnoresIrrelevant',
+                                   PercentSuccess=params2[0],
+                                   Priority=params2[1], TeamName=params2[2],
+                                   ParentQueueUrl=params2[3], ParentQueueId=params2[4],
+                                  )
             # id not changed by changing irrelvant parameters
             self.assertEqual(ele.id, this_id)
 
     def testIdImmutable(self):
         """Id fixed once calculated"""
-        ele = WorkQueueElement(RequestName = 'testIdImmutable')
+        ele = WorkQueueElement(RequestName='testIdImmutable')
         before_id = ele.id
         ele['RequestName'] = 'somethingElse'
         self.assertEqual(before_id, ele.id)
 
     def testSetId(self):
         """Can override id generation"""
-        ele = WorkQueueElement(RequestName = 'testIdImmutable')
+        ele = WorkQueueElement(RequestName='testIdImmutable')
         before_id = ele.id
         ele.id = 'something_new'
         self.assertEqual('something_new', ele.id)

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueueBackend_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueueBackend_t.py
@@ -6,7 +6,6 @@
 import unittest
 import time
 from WMQuality.TestInitCouchApp import TestInitCouchApp as TestInit
-
 from WMCore.WorkQueue.WorkQueueBackend import WorkQueueBackend
 from WMCore.WorkQueue.DataStructs.CouchWorkQueueElement import CouchWorkQueueElement
 from WMCore.WorkQueue.DataStructs.WorkQueueElement import WorkQueueElement
@@ -15,13 +14,15 @@ from WMCore.WMSpec.StdSpecs.ReReco import ReRecoWorkloadFactory
 from WMQuality.Emulators.WMSpecGenerator.WMSpecGenerator import createConfig
 
 rerecoArgs = ReRecoWorkloadFactory.getTestArguments()
+
+
 def rerecoWorkload(workloadName, arguments):
     factory = ReRecoWorkloadFactory()
     wmspec = factory.factoryWorkloadConstruction(workloadName, arguments)
     return wmspec
 
-class WorkQueueBackendTest(unittest.TestCase):
 
+class WorkQueueBackendTest(unittest.TestCase):
     def setUp(self):
         self.testInit = TestInit('CouchWorkQueueTest')
         self.testInit.setLogging()
@@ -29,13 +30,12 @@ class WorkQueueBackendTest(unittest.TestCase):
         self.testInit.setupCouch('wq_backend_test', 'WorkQueue')
         self.testInit.setupCouch('wq_backend_test_parent', 'WorkQueue')
         self.couch_db = self.testInit.couch.couchServer.connectDatabase('wq_backend_test')
-        self.backend = WorkQueueBackend(db_url = self.testInit.couchUrl,
-                                        db_name = 'wq_backend_test',
-                                        inbox_name = 'wq_backend_test_inbox',
-                                        parentQueue = '%s/%s' % (self.testInit.couchUrl, 'wq_backend_test_parent'))
+        self.backend = WorkQueueBackend(db_url=self.testInit.couchUrl,
+                                        db_name='wq_backend_test',
+                                        inbox_name='wq_backend_test_inbox',
+                                        parentQueue='%s/%s' % (self.testInit.couchUrl, 'wq_backend_test_parent'))
         rerecoArgs["ConfigCacheID"] = createConfig(rerecoArgs["CouchDBName"])
         self.processingSpec = rerecoWorkload('testProcessing', rerecoArgs)
-
 
     def tearDown(self):
         """
@@ -46,62 +46,69 @@ class WorkQueueBackendTest(unittest.TestCase):
 
     def testPriority(self):
         """Element priority and ordering handled correctly"""
-        element = WorkQueueElement(RequestName = 'backend_test',
-                                   WMSpec = self.processingSpec,
-                                   Status = 'Available',
-                                   Jobs = 10, Priority = 1)
-        highprielement = WorkQueueElement(RequestName = 'backend_test_high',
-                                          WMSpec = self.processingSpec,
-                                          Status = 'Available', Jobs = 10,
-                                          Priority = 100)
-        element2 = WorkQueueElement(RequestName = 'backend_test_2',
-                                    WMSpec = self.processingSpec,
-                                    Status = 'Available',
-                                    Jobs = 10, Priority = 1)
-        element3 = WorkQueueElement(RequestName = 'backend_test_3',
-                                    WMSpec = self.processingSpec,
-                                    Status = 'Available',
-                                    Jobs = 10, Priority = 1)
-        lowprielement = WorkQueueElement(RequestName = 'backend_test_low',
-                                         WMSpec = self.processingSpec,
-                                         Status = 'Available',
-                                         Jobs = 10, Priority = 0.1)
+        element = WorkQueueElement(RequestName='backend_test',
+                                   WMSpec=self.processingSpec,
+                                   Status='Available',
+                                   SiteWhitelist=["place"],
+                                   Jobs=10, Priority=1)
+        highprielement = WorkQueueElement(RequestName='backend_test_high',
+                                          WMSpec=self.processingSpec,
+                                          Status='Available', Jobs=10,
+                                          SiteWhitelist=["place"],
+                                          Priority=100)
+        element2 = WorkQueueElement(RequestName='backend_test_2',
+                                    WMSpec=self.processingSpec,
+                                    Status='Available',
+                                    SiteWhitelist=["place"],
+                                    Jobs=10, Priority=1)
+        element3 = WorkQueueElement(RequestName='backend_test_3',
+                                    WMSpec=self.processingSpec,
+                                    Status='Available',
+                                    SiteWhitelist=["place"],
+                                    Jobs=10, Priority=1)
+        lowprielement = WorkQueueElement(RequestName='backend_test_low',
+                                         WMSpec=self.processingSpec,
+                                         Status='Available',
+                                         SiteWhitelist=["place"],
+                                         Jobs=10, Priority=0.1)
         self.backend.insertElements([element])
-        self.backend.availableWork({'place' : 1000}, {})
+        self.backend.availableWork({'place': 1000}, {})
         # timestamp in elements have second coarseness, 2nd element must
         # have a higher timestamp to force it after the 1st
         time.sleep(1)
         self.backend.insertElements([lowprielement, element2, highprielement])
-        self.backend.availableWork({'place' : 1000}, {})
+        self.backend.availableWork({'place': 1000}, {})
         time.sleep(1)
         self.backend.insertElements([element3])
-        work = self.backend.availableWork({'place' : 1000}, {})
+        work = self.backend.availableWork({'place': 1000}, {})
         # order should be high to low, with the standard elements in the order
         # they were queueud
         self.assertEqual([x['RequestName'] for x in work[0]],
-                         ['backend_test_high', 'backend_test', 'backend_test_2', 
-                          'backend_test_3','backend_test_low'])
-
+                         ['backend_test_high', 'backend_test', 'backend_test_2',
+                          'backend_test_3', 'backend_test_low'])
 
     def testDuplicateInsertion(self):
         """Try to insert elements multiple times"""
         element1 = CouchWorkQueueElement(self.couch_db,
-                                         elementParams = {'RequestName' : 'backend_test',
-                                                          'WMSpec' : self.processingSpec,
-                                                          'Status' : 'Available',
-                                                          'Jobs' : 10,
-                                                          'Inputs' : {self.processingSpec.listInputDatasets()[0] + '#1' : []}})
+                                         elementParams={'RequestName': 'backend_test',
+                                                        'WMSpec': self.processingSpec,
+                                                        'Status': 'Available',
+                                                        'Jobs': 10,
+                                                        'Inputs': {
+                                                            self.processingSpec.listInputDatasets()[0] + '#1': []}})
         element2 = CouchWorkQueueElement(self.couch_db,
-                                         elementParams = {'RequestName' : 'backend_test',
-                                                          'WMSpec' : self.processingSpec,
-                                                          'Status' : 'Available',
-                                                          'Jobs' : 20,
-                                                          'Inputs' : {self.processingSpec.listInputDatasets()[0] + '#2' : []}})
+                                         elementParams={'RequestName': 'backend_test',
+                                                        'WMSpec': self.processingSpec,
+                                                        'Status': 'Available',
+                                                        'Jobs': 20,
+                                                        'Inputs': {
+                                                            self.processingSpec.listInputDatasets()[0] + '#2': []}})
         self.backend.insertElements([element1, element2])
         self.backend.insertElements([element1, element2])
         # check no duplicates and no conflicts
-        self.assertEqual(len(self.backend.db.allDocs()['rows']), 4) # design doc + workflow + 2 elements
+        self.assertEqual(len(self.backend.db.allDocs()['rows']), 4)  # design doc + workflow + 2 elements
         self.assertEqual(self.backend.db.loadView('WorkQueue', 'conflicts')['total_rows'], 0)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Mostly fixed issues in `possibleSites()` method and make tons of tests for that method and the site passing restriction method.
Ideally we should have the same tests for https://github.com/dmwm/WMCore/blob/master/src/couchapps/WorkQueue/lists/workRestrictions.js , eventually :-)