### PR TITLE
Make SiteWhitelist mandatory during assignment; remove site wildcards…

### DIFF
--- a/src/python/WMCore/Lexicon.py
+++ b/src/python/WMCore/Lexicon.py
@@ -127,15 +127,12 @@ def jobrange(candidate):
 
 def cmsname(candidate):
     """
-    Check candidate as a (partial) CMS name. Should pass:
-        T2
-        T2_UK
-        T2_UK_SGrid
-        T2_UK_SGrid_Bristol
+    Candidate must pass the CMS name pattern. Thus:
+     * good candidates: T2_UK_SGrid or T2_UK_SGrid_Bristol
+     * bad candidates: T2, T2_UK
     """
-    # remove any trailing _'s
     candidate = candidate.rstrip('_')
-    return check("^T[0-3%]((_[A-Z]{2}(_[A-Za-z0-9]+)*)?)$", candidate)
+    return check("^T[0-3]_[A-Z]{2}((_[A-Za-z0-9]+)+)$", candidate)
 
 
 def countrycode(candidate):

--- a/src/python/WMCore/ReqMgr/Service/Request.py
+++ b/src/python/WMCore/ReqMgr/Service/Request.py
@@ -463,9 +463,11 @@ class Request(RESTEntity):
         
     def _handleAssignmentStateTransition(self, workload, request_args, dn):
         
-        if request_args.get('Team', '').strip() == '':
+        if 'Team' not in request_args or not request_args['Team'].strip():
             raise InvalidSpecParameterValue("A Team name must be set during workflow assignment")
-            
+        if 'SiteWhitelist' not in request_args or not request_args['SiteWhitelist']:
+            raise InvalidSpecParameterValue("A non-empty SiteWhitelist must be set at assignment")
+
         if ('SoftTimeout' in request_args) and ('GracePeriod' in request_args):
             request_args['SoftTimeout'] = int(request_args['SoftTimeout'])
             #TODO: not sure why GracePeriod when passed from web ingerface but convert here

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -431,69 +431,13 @@ class WMWorkloadHelper(PersistencyHelper):
         self.data.tasks.tasklist.remove(taskName)
         return
 
-    def setSiteWildcardsLists(self, siteWhitelist, siteBlacklist, wildcardDict):
-        """
-        _setSiteWildcardsLists_
-
-        Given a whitelist and a blacklist that contain wildcards, and a
-        list of wildcards, assign the whitelist and the blacklist so that
-        they have the proper sites and not the wildcard symbols.
-
-        Expects a wildcardDict containing all available wildcard symbols as keys
-        and the list of sites corresponding to those keys as values.
-
-        e.g.
-        {'T2*': ['T2_US_UCSD', 'T2_US_UNL', 'T2_US_CIT'],
-        'US*': ['T1_US_FNAL', 'T2_US_UCSD', 'T2_US_UNL', 'T2_US_CIT'],
-        'T1*': ['T1_US_FNAL', 'T1_CH_CERN', 'T1_UK_RAL']}
-        """
-        newWhiteList = self.removeWildcardsFromList(siteList=siteWhitelist, wildcardDict=wildcardDict)
-        newBlackList = self.removeWildcardsFromList(siteList=siteBlacklist, wildcardDict=wildcardDict)
-
-        for site in newWhiteList:
-            if '*' in site:
-                msg = "Invalid wildcard site %s in site whitelist!" % site
-                raise WMWorkloadException(msg)
-        for site in newBlackList:
-            if '*' in site:
-                msg = "Invalid wildcard site %s in site blacklist!" % site
-                raise WMWorkloadException(msg)
-
-        self.setSiteWhitelist(siteWhitelist=newWhiteList)
-        self.setSiteBlacklist(siteBlacklist=newBlackList)
-
-        return
-
-    def removeWildcardsFromList(self, siteList, wildcardDict={}):
-        """
-        _removeWildcardsFromList_
-
-        Given a list of sites, remove any of the wildcards
-        that are in site.wildcards and replace them with the
-        sites that you picked out of SiteDB.
-        """
-
-        deleteKeys = []
-        for s in siteList:
-            if s in wildcardDict.keys():
-                deleteKeys.append(s)
-
-        for s in deleteKeys:
-            keyList = wildcardDict[s]
-            for site in keyList:
-                if site not in siteList:
-                    siteList.append(site)
-            siteList.remove(s)
-
-        return siteList
-
     def setSiteWhitelist(self, siteWhitelist):
         """
         _setSiteWhitelist_
 
         Set the site white list for the top level tasks in the workload.
         """
-        if not isinstance(siteWhitelist, type([])):
+        if not isinstance(siteWhitelist, list):
             siteWhitelist = [siteWhitelist]
 
         taskIterator = self.taskIterator()
@@ -1173,59 +1117,6 @@ class WMWorkloadHelper(PersistencyHelper):
 
         return taskList
 
-    def setSubscriptionInformationWildCards(self, wildcardDict, custodialSites=None,
-                                            nonCustodialSites=None, autoApproveSites=None,
-                                            custodialSubType="Replica", nonCustodialSubType="Replica",
-                                            custodialGroup="DataOps", nonCustodialGroup="DataOps",
-                                            priority="Low", primaryDataset=None,
-                                            useSkim = False, isSkim = False,
-                                            dataTier=None, deleteFromSource=False):
-        """
-        _setSubscriptionInformationWildCards_
-
-        Set the given subscription information for all datasets
-        in the workload that match the given primary dataset (if any), site lists can have wildcards.
-        See WMWorkload.WMWorkloadHelper.setSiteWildcardsLists for details on the wildcardDict
-        """
-
-        if custodialSites and not isinstance(custodialSites, type([])):
-            custodialSites = [custodialSites]
-        if nonCustodialSites and not isinstance(nonCustodialSites, type([])):
-            nonCustodialSites = [nonCustodialSites]
-        if autoApproveSites and not isinstance(autoApproveSites, type([])):
-            autoApproveSites = [autoApproveSites]
-
-        newCustodialList = self.removeWildcardsFromList(siteList=custodialSites, wildcardDict=wildcardDict)
-        newNonCustodialList = self.removeWildcardsFromList(siteList=nonCustodialSites, wildcardDict=wildcardDict)
-        newAutoApproveList = self.removeWildcardsFromList(siteList=autoApproveSites, wildcardDict=wildcardDict)
-
-        for site in newCustodialList:
-            if '*' in site:
-                msg = "Invalid wildcard site %s in custodial site list!" % site
-                raise WMWorkloadException(msg)
-        for site in newNonCustodialList:
-            if '*' in site:
-                msg = "Invalid wildcard site %s in non custodial site list!" % site
-                raise WMWorkloadException(msg)
-        for site in newAutoApproveList:
-            if '*' in site:
-                msg = "Invalid wildcard site %s in auto approval site list!" % site
-                raise WMWorkloadException(msg)
-
-        self.setSubscriptionInformation(custodialSites=newCustodialList,
-                                        nonCustodialSites=newNonCustodialList,
-                                        autoApproveSites=newAutoApproveList,
-                                        custodialSubType=custodialSubType,
-                                        nonCustodialSubType=nonCustodialSubType,
-                                        custodialGroup=custodialGroup,
-                                        nonCustodialGroup=nonCustodialGroup,
-                                        priority=priority,
-                                        primaryDataset=primaryDataset,
-                                        useSkim=useSkim,
-                                        isSkim=isSkim,
-                                        dataTier=dataTier,
-                                        deleteFromSource=deleteFromSource)
-
     def setSubscriptionInformation(self, initialTask=None, custodialSites=None,
                                    nonCustodialSites=None, autoApproveSites=None,
                                    custodialSubType="Replica", nonCustodialSubType="Replica",
@@ -1240,11 +1131,11 @@ class WMWorkloadHelper(PersistencyHelper):
         in the workload that match the given primaryDataset (if any)
         """
 
-        if custodialSites and not isinstance(custodialSites, type([])):
+        if custodialSites and not isinstance(custodialSites, list):
             custodialSites = [custodialSites]
-        if nonCustodialSites and not isinstance(nonCustodialSites, type([])):
+        if nonCustodialSites and not isinstance(nonCustodialSites, list):
             nonCustodialSites = [nonCustodialSites]
-        if autoApproveSites and not isinstance(autoApproveSites, type([])):
+        if autoApproveSites and not isinstance(autoApproveSites, list):
             autoApproveSites = [autoApproveSites]
 
         if initialTask:
@@ -1699,7 +1590,7 @@ class WMWorkloadHelper(PersistencyHelper):
             # TODO raise proper exception
             raise Exception("not all the key is specified %s" % keys)
 
-    def updateArguments(self, kwargs, wildcardSites={}):
+    def updateArguments(self, kwargs):
         """
         set up all the argument related to assigning request.
         args are validated before update.
@@ -1730,9 +1621,8 @@ class WMWorkloadHelper(PersistencyHelper):
         setAssignArgumentsWithDefault(kwargs, argumentDefinition, assignParams)
 
         if self._checkKeys(kwargs, siteParams):
-            self.setSiteWildcardsLists(siteWhitelist=kwargs["SiteWhitelist"],
-                                       siteBlacklist=kwargs["SiteBlacklist"],
-                                       wildcardDict=wildcardSites)
+            self.setSiteWhitelist(kwargs["SiteWhitelist"])
+            self.setSiteBlacklist(kwargs["SiteBlacklist"])
             self.setTrustLocationFlag(inputFlag=strToBool(kwargs["TrustSitelists"]),
                                       pileupFlag=strToBool(kwargs["TrustPUSitelists"]))
 
@@ -1767,16 +1657,15 @@ class WMWorkloadHelper(PersistencyHelper):
 
         # Set phedex subscription information
         if self._checkKeys(kwargs, phedexParams):
-            self.setSubscriptionInformationWildCards(wildcardDict=wildcardSites,
-                                                     custodialSites=kwargs["CustodialSites"],
-                                                     nonCustodialSites=kwargs["NonCustodialSites"],
-                                                     autoApproveSites=kwargs["AutoApproveSubscriptionSites"],
-                                                     custodialSubType=kwargs["CustodialSubType"],
-                                                     nonCustodialSubType=kwargs["NonCustodialSubType"],
-                                                     custodialGroup=kwargs["CustodialGroup"],
-                                                     nonCustodialGroup=kwargs["NonCustodialGroup"],
-                                                     priority=kwargs["SubscriptionPriority"],
-                                                     deleteFromSource=kwargs["DeleteFromSource"])
+            self.setSubscriptionInformation(custodialSites=kwargs["CustodialSites"],
+                                            nonCustodialSites=kwargs["NonCustodialSites"],
+                                            autoApproveSites=kwargs["AutoApproveSubscriptionSites"],
+                                            custodialSubType=kwargs["CustodialSubType"],
+                                            nonCustodialSubType=kwargs["NonCustodialSubType"],
+                                            custodialGroup=kwargs["CustodialGroup"],
+                                            nonCustodialGroup=kwargs["NonCustodialGroup"],
+                                            priority=kwargs["SubscriptionPriority"],
+                                            deleteFromSource=kwargs["DeleteFromSource"])
 
         # Block closing information
         if self._checkKeys(kwargs, blockCloseParams):

--- a/test/python/WMCore_t/Lexicon_t.py
+++ b/test/python/WMCore_t/Lexicon_t.py
@@ -6,10 +6,10 @@ General test of Lexicon
 
 """
 
-import logging
 import unittest
 
 from WMCore.Lexicon import *
+
 
 class LexiconTest(unittest.TestCase):
     def testDBSUser(self):
@@ -25,7 +25,7 @@ class LexiconTest(unittest.TestCase):
         u9 = '/O=GermanGrid/OU=RWTH/CN=Maarten Thomas'
         u10 = 'cmsdataops@cmssrv44.fnal.gov'
         u11 = '/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=ceballos/CN=488892/CN=Guillelmo Gomez Ceballos'
-        for test_u in [u1, u2, u3, u4, u5, u6, u7,u8,u9, u10,u11]:
+        for test_u in [u1, u2, u3, u4, u5, u6, u7, u8, u9, u10, u11]:
             assert DBSUser(test_u), 'valid search not validated'
 
         u10 = 'Fred Bloggs'
@@ -45,7 +45,7 @@ class LexiconTest(unittest.TestCase):
         ds7 = '/Higgs/*/*'
         ds8 = '/*/blah-v2/*'
         ds9 = '/QCD_EMenriched_Pt30to80/Summer08_IDEAL_V11_redigi_v2/GEN-SIM-RAW'
-        ds10 ='/*'
+        ds10 = '/*'
         ds11 = '/*QCD'
         ds12 = '/QCD*/Summer*'
         ds13 = '/QCD_EMenriched_Pt30to80/Summer08_IDEAL_V11_redigi_v2/GEN-SIM-*'
@@ -94,10 +94,10 @@ class LexiconTest(unittest.TestCase):
 
         for test_ds in [ds1, ds2, ds3, ds4, ds5]:
             self.assertRaises(AssertionError, searchblock, test_ds)
-            
+
     def testPublishdatasetname(self):
         assert publishdatasetname('pog-Summer09-MC_31X_V3_SD_ZeroBias-v1_Full_v0CandProducerPAT'), \
-                  'valid publishdatasetname not validated'
+            'valid publishdatasetname not validated'
         # shouldn't contain .
         self.assertRaises(AssertionError, publishdatasetname, 'withdot.pre3_IDEAL_30X_v1')
 
@@ -109,7 +109,7 @@ class LexiconTest(unittest.TestCase):
         assert procdataset('CMSSW_3_0_0_pre3_IDEAL_30X-my_filter-my_string-v1'), 'valid procdataset not validated'
         longStr = 'a' * 99 + "-" + 'b' * 96 + "-v1"
         assert procdataset(longStr), 'valid procdataset %s length fail' % len(longStr)
-        
+
     def testBadProcdataset(self):
         # Check that invalid Procdataset raise an exception
         self.assertRaises(AssertionError, procdataset, 'Drop Table')
@@ -126,7 +126,7 @@ class LexiconTest(unittest.TestCase):
                   'StoreResults-Summer12_DR53X-PU_S10_START53_V7A-v1_TLBSM_53x_v3_bugfix_v1-99bd99199697666ff01397dad5652e9e']
         for ds in dsList:
             self.assertTrue(userprocdataset(ds))
-        longStr = 'a' * 99 + '-' + 'b' * 66 + '-' +'c'* 32
+        longStr = 'a' * 99 + '-' + 'b' * 66 + '-' + 'c' * 32
         assert userprocdataset(longStr), 'valid userdataset %s length fail' % len(longStr)
 
     def testBadUserProcDataset(self):
@@ -135,8 +135,8 @@ class LexiconTest(unittest.TestCase):
                   'tracker-pog-Summer09-MC_31X_V3_SD_ZeroBias-v1_Full_v0#CandProducerPAT-6b5c47aa1f79fc09d5b81a20702e3621']
         for ds in dsList:
             self.assertRaises(AssertionError, userprocdataset, ds)
-        #201 length
-        longStr = 'a' * 100 + '-' + 'b' * 66 + '-' +'c'* 32
+        # 201 length
+        longStr = 'a' * 100 + '-' + 'b' * 66 + '-' + 'c' * 32
         self.assertRaises(AssertionError, userprocdataset, longStr)
 
     def testGoodPrimdataset(self):
@@ -146,32 +146,33 @@ class LexiconTest(unittest.TestCase):
         assert primdataset('RelVal160pre14SingleMuMinusPt10'), 'valid primdataset not validated'
         longStr = 'a' * 99
         assert primdataset(longStr), 'valid primdataset %s length failed' % len(longStr)
-        
+
     def testBadPrimdataset(self):
         # Check that invalid Primdataset raise an exception
         self.assertRaises(AssertionError, primdataset, 'Drop Table')
         self.assertRaises(AssertionError, primdataset, 'Alter Table')
         longStr = 'a' * 100
         self.assertRaises(AssertionError, primdataset, longStr)
-        
+
     def testGoodBlock(self):
-        
-        bList = ["/ZPrimeToTTJets_M500GeV_W5GeV_TuneZ2star_8TeV-madgraph-tauola/StoreResults-Summer12_DR53X-PU_S10_START53_V7A-v1_TLBSM_53x_v3_bugfix_v1-99bd99199697666ff01397dad5652e9e/USER#620a38a9-29ba-4af4-b650-e2ba07d133f3",
-                 "/DoubleMu/aburgmei-Run2012A_22Jan2013_v1_RHembedded_trans1_tau121_ptelec1_17elec2_8_v4-f456bdbb960236e5c696adfe9b04eaae/USER#1f1eee22-cdee-0f1b-271b-77a7f559e7dd"]
+
+        bList = [
+            "/ZPrimeToTTJets_M500GeV_W5GeV_TuneZ2star_8TeV-madgraph-tauola/StoreResults-Summer12_DR53X-PU_S10_START53_V7A-v1_TLBSM_53x_v3_bugfix_v1-99bd99199697666ff01397dad5652e9e/USER#620a38a9-29ba-4af4-b650-e2ba07d133f3",
+            "/DoubleMu/aburgmei-Run2012A_22Jan2013_v1_RHembedded_trans1_tau121_ptelec1_17elec2_8_v4-f456bdbb960236e5c696adfe9b04eaae/USER#1f1eee22-cdee-0f1b-271b-77a7f559e7dd"]
         for bk in bList:
             assert block(bk), "validation failed"
         longStr = "/" + 'a' * 99 + "/" + 'a' * 199 + "/" + 'A' * 99 + "#" + 'a' * 99
         assert block(longStr), 'valid block %s length failed' % len(longStr)
 
     def testBadBlock(self):
-        
+
         bList = ["/ZPrimeToTTJets/StoreResults-Summer12_DR53X-P",
                  "/DoubleMu/aburgme/USER1f1eee22-cdee-0f1b-271b-77a7f559e7dd"]
         for bk in bList:
             self.assertRaises(AssertionError, block, bk)
         longStr = "/" + 'a' * 100 + "/" + 'a' * 200 + "/" + 'a' * 99 + "#" + 'a' * 99
         self.assertRaises(AssertionError, block, longStr)
-        
+
     def testProcVersion(self):
         """
         _testProcVersion_
@@ -184,7 +185,6 @@ class LexiconTest(unittest.TestCase):
         self.assertTrue(procversion('1'))
         self.assertTrue(procversion('88'))
         return
-
 
     def testGoodAcqName(self):
         """
@@ -216,7 +216,8 @@ class LexiconTest(unittest.TestCase):
     def testGoodSearchstr(self):
         # Check that valid searchstr work
         assert searchstr('/store/mc/Fall08/BBJets250to500-madgraph/*'), 'valid search string not validated'
-        assert searchstr('/QCD_EMenriched_Pt30to80/Summer08_IDEAL_V11_redigi_v2/GEN-SIM-RAW#cfc0a501-e845-4576-af8a-f811165d82d9'), 'valid search string not validated'
+        assert searchstr(
+            '/QCD_EMenriched_Pt30to80/Summer08_IDEAL_V11_redigi_v2/GEN-SIM-RAW#cfc0a501-e845-4576-af8a-f811165d82d9'), 'valid search string not validated'
         assert searchstr('STREAMER'), 'valid search string not validated'
 
     def testBadSearchstr(self):
@@ -271,11 +272,7 @@ class LexiconTest(unittest.TestCase):
         assert cmsname('T0_CH_CERN'), 'valid CMS name not validated'
         assert cmsname('T2_UK_SGrid_Bristol'), 'valid CMS name not validated'
         assert cmsname('T2_FR_CCIN2P3'), 'valid CMS name not validated'
-
-    def testPartialCMSName(self):
-        # Check that partial names work
-        for i in ['T%', 'T2','T2_', 'T2_UK', 'T2_UK_', 'T2_UK_SGrid', 'T2_UK_SGrid_']:
-            assert cmsname(i), 'partial CMS name (%s) not validated' % i
+        assert cmsname('T3_US_FNAL_LPC_Cloud'), 'valid CMS name not validated'
 
     def testBadCMSName(self):
         # Check that invalid names raise an exception
@@ -284,7 +281,7 @@ class LexiconTest(unittest.TestCase):
         self.assertRaises(AssertionError, cmsname, 'T2_UK_SGrid_Bris-tol')
         self.assertRaises(AssertionError, cmsname, 'D2_UK_SGrid_Bristol')
         self.assertRaises(AssertionError, cmsname, 'T2asjkjhadshjkdashjkasdkjhdas')
-        #self.assertRaises(AssertionError, cmsname, 'T2_UK')
+        self.assertRaises(AssertionError, cmsname, 'T2_UK')
 
     def testGoodIdentifier(self):
         for ok in ['__wil.1.am__', '.']:
@@ -322,7 +319,7 @@ class LexiconTest(unittest.TestCase):
                    'http://luke:skywalker@localhost:7654/some_db/some_doc',
                    'https://cmsreqmgr.cern.ch/couchdb/db1/doc',
                    'http://1.2.3.4:5184/somedb/some_dir/doc',
-                   'http://iam.anexternal.host:5184/somedb/some_doc/some_doc' ]:
+                   'http://iam.anexternal.host:5184/somedb/some_doc/some_doc']:
             assert couchurl(ok)
 
     def testBadCouchUrl(self):
@@ -385,7 +382,7 @@ class LexiconTest(unittest.TestCase):
         lfnA = '/store/unmerged/data/Run2010A/Cosmics/RECO/v4/000/143/316/0000/F65F4AFE-14AC-DF11-B3BE-00215E21F32E.root'
         lfn(lfnA)
         lfnA = '/store/himc/Run2010A/Cosmics/RECO/v4/000/143/316/0000/F65F4AFE-14AC-DF11-B3BE-00215E21F32E.root'
-        lfn(lfnA)        
+        lfn(lfnA)
         lfnA = '/store/backfill/1/data/Run2010A/Cosmics/RECO/v4/000/143/316/0000/F65F4AFE-14AC-DF11-B3BE-00215E21F32E.root'
         lfn(lfnA)
         lfnA = '/store/backfill/1/t0temp/data/Run2010A/Cosmics/RECO/v4/000/143/316/0000/F65F4AFE-14AC-DF11-B3BE-00215E21F32E.root'
@@ -417,7 +414,6 @@ class LexiconTest(unittest.TestCase):
         lfnA = '/store/lhe/10860/mysecondary/0001/LQToUE_BetaHalf_vector_YM-MLQ300LG0KG0.lhe.xz'
         lfn(lfnA)
 
-
         # All these cases should fail
         lfnA = '/storeA/temp/lustre/acquisition_10-A/MuElectron-10_100/RAW-RECO/vX-1/1000/a_X-2.root'
         self.assertRaises(AssertionError, lfn, lfnA)
@@ -441,7 +437,6 @@ class LexiconTest(unittest.TestCase):
         self.assertRaises(AssertionError, lfn, lfnA)
         lfnA = '/store/temp/lustre/acquisition_10-A/MuElectron-10_100/RAW-RECO/vX-1/000/Iamralph/000/1000/a_X-2.root'
         self.assertRaises(AssertionError, lfn, lfnA)
-
 
         # All these cases should fail
         lfnA = '/storeA/temp/acquisition_10-A/MuElectron-10_100/RAW-RECO/vX-1/1000/a_X-2.root'
@@ -523,7 +518,6 @@ class LexiconTest(unittest.TestCase):
         lfnA = '/store/temp/lustre/acquisition_10-A/MuElectron-10_100/RAW-RECO/vX;-1'
         self.assertRaises(AssertionError, lfn, lfnA)
 
-
         lfnA = '/Store/temp/acquisition_10-A/MuElectron-10_100/RAW-RECO/vX-1'
         self.assertRaises(AssertionError, lfn, lfnA)
         lfnA = '/store/Temp/acquisition_10-A/MuElectron-10_100/RAW-RECO/vX-1'
@@ -538,7 +532,6 @@ class LexiconTest(unittest.TestCase):
         self.assertRaises(AssertionError, lfn, lfnA)
 
         return
-
 
     def testUserLFN(self):
         """
@@ -569,7 +562,6 @@ class LexiconTest(unittest.TestCase):
         userLfnBase(lfnA)
 
         return
-
 
     def testLFNParser(self):
         """
@@ -685,7 +677,7 @@ class LexiconTest(unittest.TestCase):
         host = "test.com"
         user = "abc"
         passwd = "^cba$"
-        port  = "9999"
+        port = "9999"
         url = "%s://%s:%s@%s:%s" % (proto, user, passwd, host, port)
         urlDict = sanitizeURL(url)
         self.assertEqual(urlDict['url'], "%s://%s:%s" % (proto, host, port))
@@ -739,7 +731,6 @@ class LexiconTest(unittest.TestCase):
         sanitizedError = "DB failure: %s" % (dbUrl2)
         self.assertEqual(replaceToSantizeURL(errorMsg), sanitizedError)
 
-
     def testSplitCouchServiceURL(self):
 
         urlSplit = splitCouchServiceURL("https://cmsweb-dev.cern.ch:8888/workqueue")
@@ -769,7 +760,7 @@ class LexiconTest(unittest.TestCase):
         """
         Test the validateUrl function for some use case of DBS 3
         """
-        #Good http(s) urls
+        # Good http(s) urls
         for url in ['https://cmsweb.cern.ch/dbs/prod/global/DBSReader',
                     'https://mydbs.mydomain.de:8443',
                     'http://localhost',
@@ -780,22 +771,23 @@ class LexiconTest(unittest.TestCase):
                     'http://[2001:0db8:85a3:08d3:1319:8a2e:0370:7344]:8443/']:
             validateUrl(url)
 
-        #Bad http(s) urls
+        # Bad http(s) urls
         for url in ['ftp://dangerous.download.this',
                     'https:/notvalid.url',
                     'http://-NiceTry',
                     'https://NiceTry; DROP Table;--',
                     'http://123123104122',
                     'http://.www.google.com',
-                    'http://[2001:0db8:85a3:08d3:1319:8a2z:0370:7344]/',]:
+                    'http://[2001:0db8:85a3:08d3:1319:8a2z:0370:7344]/', ]:
             self.assertRaises(AssertionError, validateUrl, url)
-            
+
     def testPrimaryDatasetType(self):
         self.assertRaises(AssertionError, primaryDatasetType, "MC")
         self.assertTrue(primaryDatasetType("mc"), "mc should be allowed")
         self.assertTrue(primaryDatasetType("data"), "data should be allowed")
         self.assertTrue(primaryDatasetType("cosmic"), "data should be allowed")
         self.assertTrue(primaryDatasetType("test"), "test should be allowed")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
@@ -8,7 +8,7 @@ Unittest for WMWorkload class
 import os
 import unittest
 
-from WMCore.WMSpec.WMWorkload import WMWorkload, WMWorkloadHelper, WMWorkloadException
+from WMCore.WMSpec.WMWorkload import WMWorkload, WMWorkloadHelper
 from WMCore.WMSpec.WMTask import WMTask, WMTaskHelper
 from WMCore.WMSpec.WMSpecErrors import WMSpecFactoryException
 import WMCore_t.WMSpec_t.TestWorkloads as TestSpecs
@@ -200,10 +200,7 @@ class WMWorkloadTest(unittest.TestCase):
         workload2 = WMWorkloadHelper(WMWorkload("workload2"))
         workload2.load(self.persistFile)
 
-        self.assertEqual(
-            workload.listAllTaskNames(),
-            workload2.listAllTaskNames()
-        )
+        self.assertEqual(workload.listAllTaskNames(), workload2.listAllTaskNames())
         # probably need to flesh this out a bit more
 
     def testD_Owner(self):
@@ -873,21 +870,21 @@ class WMWorkloadTest(unittest.TestCase):
         acquisitionEra = testWorkload.getAcquisitionEra()
         processingString = testWorkload.getProcessingString()
 
-        self.assertEqual(processingVersion, {'ProcessingTask': 2, 'SkimTask': 3}, 
+        self.assertEqual(processingVersion, {'ProcessingTask': 2, 'SkimTask': 3},
                          "Error: Wrong top level processing version")
-        self.assertEqual(acquisitionEra, {'ProcessingTask': 'TestAcqEra', 'SkimTask': 'TestAcqEraSkim'}, 
+        self.assertEqual(acquisitionEra, {'ProcessingTask': 'TestAcqEra', 'SkimTask': 'TestAcqEraSkim'},
                          "Error: Wrong top level acquisition era")
-        self.assertEqual(processingString, {'ProcessingTask': 'Test', 'SkimTask': 'SkimTest'}, 
+        self.assertEqual(processingString, {'ProcessingTask': 'Test', 'SkimTask': 'SkimTest'},
                          "Error: Wront top level processing string")
-        
+
         processingVersion = testWorkload.getProcessingVersion('ProcessingTask')
         acquisitionEra = testWorkload.getAcquisitionEra('SkimTask')
         processingString = testWorkload.getProcessingString('ProcessingTask')
-        
+
         self.assertEqual(processingVersion, 2, "Error: Wrong top level processing version")
-        self.assertEqual(acquisitionEra,'TestAcqEraSkim', "Error: Wrong top level acquisition era")
+        self.assertEqual(acquisitionEra, 'TestAcqEraSkim', "Error: Wrong top level acquisition era")
         self.assertEqual(processingString, 'Test', "Error: Wront top level processing string")
-        
+
         return
 
     def testSetSubscriptionInformation(self):
@@ -906,15 +903,15 @@ class WMWorkloadTest(unittest.TestCase):
         for outputDataset in outputDatasets:
             datasetSub = subInformation[outputDataset]
             self.assertEqual(datasetSub["CustodialSites"], ["CMSSite_1"],
-                              "Wrong custodial sites for %s" % outputDataset)
+                             "Wrong custodial sites for %s" % outputDataset)
             self.assertEqual(datasetSub["NonCustodialSites"], ["CMSSite_2"],
-                              "Wrong non-custodial sites for %s" % outputDataset)
+                             "Wrong non-custodial sites for %s" % outputDataset)
             self.assertEqual(datasetSub["AutoApproveSites"], [], "Wrong auto-approve sites for %s" % outputDataset)
             self.assertEqual(datasetSub["Priority"], "Low", "Wrong priority for %s" % outputDataset)
             self.assertEqual(datasetSub["CustodialSubType"], "Replica",
-                              "Wrong custodial subscription type for %s" % outputDataset)
+                             "Wrong custodial subscription type for %s" % outputDataset)
             self.assertEqual(datasetSub["NonCustodialSubType"], "Replica",
-                              "Wrong custodial subscription type for %s" % outputDataset)
+                             "Wrong custodial subscription type for %s" % outputDataset)
 
         testWorkload.setSubscriptionInformation(custodialSites=["CMSSite_1", "CMSSite_2"],
                                                 nonCustodialSites=["CMSSite_3"],
@@ -924,16 +921,16 @@ class WMWorkloadTest(unittest.TestCase):
         for outputDataset in outputDatasets:
             datasetSub = subInformation[outputDataset]
             self.assertEqual(set(datasetSub["CustodialSites"]), set(["CMSSite_1", "CMSSite_2"]),
-                              "Wrong custodial sites for %s" % outputDataset)
+                             "Wrong custodial sites for %s" % outputDataset)
             self.assertEqual(datasetSub["NonCustodialSites"], ["CMSSite_3"],
-                              "Wrong non-custodial sites for %s" % outputDataset)
+                             "Wrong non-custodial sites for %s" % outputDataset)
             self.assertEqual(datasetSub["AutoApproveSites"], ["CMSSite_2"],
-                              "Wrong auto-approve sites for %s" % outputDataset)
+                             "Wrong auto-approve sites for %s" % outputDataset)
             self.assertEqual(datasetSub["Priority"], "Normal", "Wrong priority for %s" % outputDataset)
             self.assertEqual(datasetSub["CustodialSubType"], "Move",
-                              "Wrong custodial subscription type for %s" % outputDataset)
+                             "Wrong custodial subscription type for %s" % outputDataset)
             self.assertEqual(datasetSub["NonCustodialSubType"], "Move",
-                              "Wrong custodial subscription type for %s" % outputDataset)
+                             "Wrong custodial subscription type for %s" % outputDataset)
         return
 
     def testValidatePhEDExSubscription(self):
@@ -1502,8 +1499,8 @@ class WMWorkloadTest(unittest.TestCase):
         skimTask.setSplittingAlgorithm("FileBased", files_per_job=1)
         skimTask.applyTemplates()
 
-        testWorkload.setCMSSWParams(cmsswVersion="CMSSW_1_1_1", globalTag=
-                                    "GLOBALTAG", scramArch="SomeSCRAMArch")
+        testWorkload.setCMSSWParams(cmsswVersion="CMSSW_1_1_1", globalTag="GLOBALTAG",
+                                    scramArch="SomeSCRAMArch")
 
         def verifyParams(initialTask=None):
             """
@@ -1612,80 +1609,6 @@ class WMWorkloadTest(unittest.TestCase):
         self.assertTrue(hasattr(testWorkload.data.tasks.ProcessingTask.tree.children.MergeTask, 'watchdog'))
         return
 
-    def test_parseSiteWildcards(self):
-        """
-        _parseSiteWildcards_
-
-        Parse the methods by which we add wildcards to the site
-        whitelist/blacklist
-        """
-
-        testWorkload = WMWorkloadHelper(WMWorkload("TestWorkload"))
-        procTask = testWorkload.newTask("ProcessingTask")
-        procTask.setTaskType("Processing")
-
-        siteList = ['T1_US_FNAL', 'T1_CH_CERN', 'T1_UK_RAL',
-                    'T2_US_UCSD', 'T2_US_UNL', 'T2_US_CIT']
-        wildcardSites = {'T2*': ['T2_US_UCSD', 'T2_US_UNL', 'T2_US_CIT'],
-                         'US*': ['T1_US_FNAL', 'T2_US_UCSD', 'T2_US_UNL', 'T2_US_CIT'],
-                         'T1*': ['T1_US_FNAL', 'T1_CH_CERN', 'T1_UK_RAL']}
-
-        # Test full set
-        testWorkload.setSiteWildcardsLists(siteWhitelist=['US*', 'T1*'],
-                                           siteBlacklist=[],
-                                           wildcardDict=wildcardSites)
-        self.assertEqual(testWorkload.data.tasks.ProcessingTask.constraints.sites.whitelist.sort(),
-                         siteList.sort())
-
-        # Test one subset
-        testWorkload.setSiteWildcardsLists(siteWhitelist=['US*'],
-                                           siteBlacklist=[],
-                                           wildcardDict=wildcardSites)
-        self.assertEqual(testWorkload.data.tasks.ProcessingTask.constraints.sites.whitelist.sort(),
-                         ['T1_US_FNAL', 'T2_US_UCSD', 'T2_US_UNL', 'T2_US_CIT'].sort())
-
-        # Test one subset plus one site
-        testWorkload.setSiteWildcardsLists(siteWhitelist=['US*', 'T1_UK_RAL'],
-                                           siteBlacklist=[],
-                                           wildcardDict=wildcardSites)
-        self.assertEqual(testWorkload.data.tasks.ProcessingTask.constraints.sites.whitelist.sort(),
-                         ['T1_US_FNAL', 'T2_US_UCSD', 'T2_US_UNL', 'T2_US_CIT', 'T1_UK_RAL'].sort())
-
-        # Repeat above with blacklist
-        # Test full set
-        testWorkload.setSiteWildcardsLists(siteBlacklist=['US*', 'T1*'],
-                                           siteWhitelist=[],
-                                           wildcardDict=wildcardSites)
-        self.assertEqual(testWorkload.data.tasks.ProcessingTask.constraints.sites.blacklist.sort(),
-                         siteList.sort())
-
-        # Test one subset
-        testWorkload.setSiteWildcardsLists(siteBlacklist=['US*'],
-                                           siteWhitelist=[],
-                                           wildcardDict=wildcardSites)
-        self.assertEqual(testWorkload.data.tasks.ProcessingTask.constraints.sites.blacklist.sort(),
-                         ['T1_US_FNAL', 'T2_US_UCSD', 'T2_US_UNL', 'T2_US_CIT'].sort())
-
-        # Test one subset plus one site
-        testWorkload.setSiteWildcardsLists(siteBlacklist=['US*', 'T1_UK_RAL'],
-                                           siteWhitelist=[],
-                                           wildcardDict=wildcardSites)
-        self.assertEqual(testWorkload.data.tasks.ProcessingTask.constraints.sites.blacklist.sort(),
-                         ['T1_US_FNAL', 'T2_US_UCSD', 'T2_US_UNL', 'T2_US_CIT', 'T1_UK_RAL'].sort())
-
-
-        # Test an invalid
-        raises = False
-        try:
-            testWorkload.setSiteWildcardsLists(siteBlacklist=['T3*'],
-                                               siteWhitelist=[],
-                                               wildcardDict=wildcardSites)
-        except WMWorkloadException as ex:
-            raises = True
-            self.assertTrue("Invalid wildcard site T3* in site blacklist!" in str(ex))
-        self.assertTrue(raises)
-        return
-
     def test_getCMSSWVersion(self):
         """
         _getCMSSWVersion_
@@ -1700,8 +1623,8 @@ class WMWorkloadTest(unittest.TestCase):
         procTaskCmssw.setStepType("CMSSW")
         procTask.applyTemplates()
 
-        testWorkload.setCMSSWParams(cmsswVersion="CMSSW_1_1_1", globalTag=
-                                    "GLOBALTAG", scramArch="SomeSCRAMArch")
+        testWorkload.setCMSSWParams(cmsswVersion="CMSSW_1_1_1", globalTag="GLOBALTAG",
+                                    scramArch="SomeSCRAMArch")
 
         self.assertEqual(testWorkload.getCMSSWVersions(), ["CMSSW_1_1_1"])
         return
@@ -1839,8 +1762,10 @@ class WMWorkloadTest(unittest.TestCase):
         """
         testWorkload = self.makeTestWorkload()[0]
 
-        self.assertFalse(testWorkload.getTrustLocationFlag().get('trustlists'), "Should be False, I did not set you yet.")
-        self.assertFalse(testWorkload.getTrustLocationFlag().get('trustPUlists'), "Should be False, I did not set you yet.")
+        self.assertFalse(testWorkload.getTrustLocationFlag().get('trustlists'),
+                         "Should be False, I did not set you yet.")
+        self.assertFalse(testWorkload.getTrustLocationFlag().get('trustPUlists'),
+                         "Should be False, I did not set you yet.")
         testWorkload.setTrustLocationFlag(inputFlag=True, pileupFlag=True)
         self.assertTrue(testWorkload.getTrustLocationFlag().get('trustlists'), "Bad job!! You should be True now")
         self.assertTrue(testWorkload.getTrustLocationFlag().get('trustPUlists'), "Bad job!! You should be True now")
@@ -1849,9 +1774,11 @@ class WMWorkloadTest(unittest.TestCase):
         self.assertFalse(testWorkload.getTrustLocationFlag().get('trustPUlists'), "Bad job!! You should be False now")
         testWorkload.setTrustLocationFlag(inputFlag=False, pileupFlag=True)
         self.assertFalse(testWorkload.getTrustLocationFlag().get('trustlists'), "Bad job!! You should still be False")
-        self.assertTrue(testWorkload.getTrustLocationFlag().get('trustPUlists'), "Bad job!! You should be True once again")
+        self.assertTrue(testWorkload.getTrustLocationFlag().get('trustPUlists'),
+                        "Bad job!! You should be True once again")
         testWorkload.setTrustLocationFlag(inputFlag=True, pileupFlag=False)
-        self.assertTrue(testWorkload.getTrustLocationFlag().get('trustlists'), "Bad job!! You should be True once again")
+        self.assertTrue(testWorkload.getTrustLocationFlag().get('trustlists'),
+                        "Bad job!! You should be True once again")
         self.assertFalse(testWorkload.getTrustLocationFlag().get('trustPUlists'), "Bad job!! You should be False again")
         return
 


### PR DESCRIPTION
…; updated cmsname Lexicon

Fixes #7535

Ideally, the validation should go under WMWorkloadTools, but I can't see how to distinguish creation from assignment and make it work with that special data type and the validate function. Seangchan, if you agree, I'd say we leave that up to the moment that we really separate creation from assignment arguments :-)

It passes all the basic tests.