### PR TITLE
Fix down_component for agentInfo view

### DIFF
--- a/src/couchapps/WMStats/_attachments/js/DataStruct/WMStats.Agents.js
+++ b/src/couchapps/WMStats/_attachments/js/DataStruct/WMStats.Agents.js
@@ -33,7 +33,7 @@ WMStats.Agents = function (couchData) {
                 agentData.agentNumber.error += 1;
                 report = {status: "error", 
                           message: "Data is not updated: AnalyticsDataCollector Down"};
-            } else if (agentInfo.down_components.length > 0) {
+            } else if (agentInfo.down_components && agentInfo.down_components.length > 0) {
 				agentData.agentNumber.error += 1;
                 report = {status: "error",
                           message:"Components or Thread down"};

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
@@ -902,7 +902,7 @@ WMStats.Agents = function (couchData) {
                 agentData.agentNumber.error += 1;
                 report = {status: "error", 
                           message: "Data is not updated: AnalyticsDataCollector Down"};
-            } else if (agentInfo.down_components.length > 0) {
+            } else if (agentInfo.down_components && agentInfo.down_components.length > 0) {
 				agentData.agentNumber.error += 1;
                 report = {status: "error",
                           message:"Components or Thread down"};

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
@@ -902,7 +902,7 @@ WMStats.Agents = function (couchData) {
                 agentData.agentNumber.error += 1;
                 report = {status: "error", 
                           message: "Data is not updated: AnalyticsDataCollector Down"};
-            } else if (agentInfo.down_components.length > 0) {
+            } else if (agentInfo.down_components && agentInfo.down_components.length > 0) {
 				agentData.agentNumber.error += 1;
                 report = {status: "error",
                           message:"Components or Thread down"};

--- a/src/python/WMCore/Services/WMStats/WMStatsWriter.py
+++ b/src/python/WMCore/Services/WMStats/WMStatsWriter.py
@@ -44,6 +44,7 @@ def convertToServiceCouchDoc(wqInfo, wqURL):
     wqDoc.update(wqInfo)
     wqDoc['_id'] = wqURL
     wqDoc['agent_url'] = wqURL
+    wqDoc['agent_team'] = ""
     wqDoc['timestamp'] = int(time.time())
     wqDoc['type'] = "agent_info"
     

--- a/src/python/WMCore/Services/WMStats/WMStatsWriter.py
+++ b/src/python/WMCore/Services/WMStats/WMStatsWriter.py
@@ -45,7 +45,6 @@ def convertToServiceCouchDoc(wqInfo, wqURL):
     wqDoc['_id'] = wqURL
     wqDoc['agent_url'] = wqURL
     wqDoc['timestamp'] = int(time.time())
-    wqDoc['down_components'] = []
     wqDoc['type'] = "agent_info"
     
     return wqDoc


### PR DESCRIPTION
Seangchan, thanks for spotting this issue.
In principle "down_components" has no usage for global workqueue. Though we could extend it - eventually - to also report possible problems with the threads.

If you prefer to keep this key around, then we just close this PR. Otherwise this would fix the problem.