### PR TITLE
Limit the number of elements acquired per cycle by LQ

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -140,6 +140,7 @@ config.WorkQueueManager.queueParams = {}
 config.WorkQueueManager.queueParams["ParentQueueCouchUrl"] = "https://cmsweb.cern.ch/couchdb/workqueue"
 # this has to be unique for different work queue. This is just place holder
 config.WorkQueueManager.queueParams["QueueURL"] = "http://%s:5984" % (config.Agent.hostName)
+config.WorkQueueManager.queueParams["WorkPerCycle"] = 100  # don't pull more than this number of elements per cycle
 
 config.component_("DBS3Upload")
 config.DBS3Upload.namespace = "WMComponent.DBS3Buffer.DBS3Upload"


### PR DESCRIPTION
Fixes #7509 
It has to be merged after https://github.com/dmwm/WMCore/pull/7546

As Seangchan mentioned in the issue, if higher priority work keeps coming, it will eventually oversubscribe the agent(s). Anyways, that's the behaviour we want to keep.

`availableWork` is a joker method :-) since we use it to:
 1) pull work from the parent queue (GQ)
 2) pull work from the local queue (LQ)
 3) same as 2, but only used for calculating the resources available before calling 1)

@ticoann I tested it in my VM and seems to be working fine. Let me know if I made any mistake or you have suggestions.
