### PR TITLE
remove port from agent url

### DIFF
--- a/bin/wmagent-unregister-wmstats
+++ b/bin/wmagent-unregister-wmstats
@@ -16,11 +16,11 @@ if __name__ == "__main__":
     wmagentConfig = loadConfigurationFile(os.environ["WMAGENT_CONFIG"])
     
     parser = OptionParser()
-    parser.set_usage("wmagent-unregister-wmstats [agent_url:port]")
+    parser.set_usage("wmagent-unregister-wmstats [agent_url]")
     
     (options, args) = parser.parse_args()
     if not args:
-        agentUrl = ("%s:%s" % (wmagentConfig.Agent.hostName, wmagentConfig.WMBSService.Webtools.port))
+        agentUrl = ("%s" % wmagentConfig.Agent.hostName)
     else:
         agentUrl = args[0]
     

--- a/src/python/WMComponent/AnalyticsDataCollector/DataCollectAPI.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/DataCollectAPI.py
@@ -445,7 +445,7 @@ def initAgentInfo(config):
     agentInfo['agent_team'] = config.Agent.teamName
     agentInfo['agent'] = config.Agent.agentName
     # temporarly add port for the split test
-    agentInfo['agent_url'] = ("%s:%s" % (config.Agent.hostName, config.WMBSService.Webtools.port))
+    agentInfo['agent_url'] = "%s" % config.Agent.hostName
     return agentInfo
 
 


### PR DESCRIPTION
This was initially added that assuming there could be multiple agents are running in the same machine. Which is not the case so far. Removing it to remove the dependency from WMBSService component.