### PR TITLE
Break run-lumi mapping into smaller slices for DB insertion

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/AddRunLumi.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/AddRunLumi.py
@@ -8,8 +8,8 @@ MySQL implementation of AddRunLumi
 from Utils.IterTools import grouper
 from WMCore.Database.DBFormatter import DBFormatter
 
-class AddRunLumi(DBFormatter):
 
+class AddRunLumi(DBFormatter):
     sql = """insert dbsbuffer_file_runlumi_map (filename, run, lumi)
             select id, :run, :lumi from dbsbuffer_file
             where lfn = :lfn"""
@@ -20,27 +20,26 @@ class AddRunLumi(DBFormatter):
 
         if isinstance(filename, list):
             for entry in filename:
-                binds.extend(self.getBinds(filename = entry['lfn'], runs = entry['runs']))
+                binds.extend(self.getBinds(filename=entry['lfn'], runs=entry['runs']))
             return binds
 
         if isinstance(filename, basestring):
             lfn = filename
-
         elif isinstance(filename, dict):
             lfn = filename('lfn')
         else:
             raise Exception("Type of filename argument is not allowed: %s" \
-                                % type(filename))
+                            % type(filename))
 
         if isinstance(runs, set):
             for run in runs:
                 for lumi in run:
                     binds.append({'lfn': lfn,
-                                    'run': run.run,
-                                    'lumi':lumi})
+                                  'run': run.run,
+                                  'lumi': lumi})
         else:
             raise Exception("Type of runs argument is not allowed: %s" \
-                                % type(runs))
+                            % type(runs))
         return binds
 
     def format(self, result):

--- a/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/AddRunLumi.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/AddRunLumi.py
@@ -5,9 +5,7 @@ _AddRunLumi_
 MySQL implementation of AddRunLumi
 """
 
-
-
-
+from Utils.IterTools import grouper
 from WMCore.Database.DBFormatter import DBFormatter
 
 class AddRunLumi(DBFormatter):
@@ -16,23 +14,23 @@ class AddRunLumi(DBFormatter):
             select id, :run, :lumi from dbsbuffer_file
             where lfn = :lfn"""
 
-    def getBinds(self, file=None, runs=None):
+    def getBinds(self, filename=None, runs=None):
 
         binds = []
 
-        if type(file) == list:
-            for entry in file:
-                binds.extend(self.getBinds(file = entry['lfn'], runs = entry['runs']))
+        if isinstance(filename, list):
+            for entry in filename:
+                binds.extend(self.getBinds(filename = entry['lfn'], runs = entry['runs']))
             return binds
 
-        if type(file) == type('string'):
-            lfn = file
+        if isinstance(filename, basestring):
+            lfn = filename
 
-        elif type(file) == type({}):
-            lfn = file('lfn')
+        elif isinstance(filename, dict):
+            lfn = filename('lfn')
         else:
-            raise Exception("Type of file argument is not allowed: %s" \
-                                % type(file))
+            raise Exception("Type of filename argument is not allowed: %s" \
+                                % type(filename))
 
         if isinstance(runs, set):
             for run in runs:
@@ -48,8 +46,8 @@ class AddRunLumi(DBFormatter):
     def format(self, result):
         return True
 
-    def execute(self, file=None, runs=None, conn = None, transaction = False):
-        binds = self.getBinds(file, runs)
-        result = self.dbi.processData(self.sql, binds,
-                         conn = conn, transaction = transaction)
+    def execute(self, file=None, runs=None, conn=None, transaction=False):
+        for sliceBinds in grouper(self.getBinds(file, runs), 10000):
+            result = self.dbi.processData(self.sql, sliceBinds, conn=conn,
+                                          transaction=transaction)
         return self.format(result)

--- a/src/python/WMCore/WMBS/MySQL/Files/AddRunLumi.py
+++ b/src/python/WMCore/WMBS/MySQL/Files/AddRunLumi.py
@@ -8,8 +8,8 @@ MySQL implementation of AddRunLumi
 from Utils.IterTools import grouper
 from WMCore.Database.DBFormatter import DBFormatter
 
-class AddRunLumi(DBFormatter):
 
+class AddRunLumi(DBFormatter):
     sql = """INSERT IGNORE wmbs_file_runlumi_map (fileid, run, lumi)
             select id, :run, :lumi from wmbs_file_details
             where lfn = :lfn"""
@@ -20,27 +20,26 @@ class AddRunLumi(DBFormatter):
 
         if isinstance(filename, list):
             for entry in filename:
-                binds.extend(self.getBinds(filename = entry['lfn'], runs = entry['runs']))
+                binds.extend(self.getBinds(filename=entry['lfn'], runs=entry['runs']))
             return binds
 
         if isinstance(filename, basestring):
             lfn = filename
-
         elif isinstance(filename, dict):
             lfn = filename('lfn')
         else:
             raise Exception("Type of filename argument is not allowed: %s" \
-                                % type(filename))
+                            % type(filename))
 
         if isinstance(runs, set):
             for run in runs:
                 for lumi in run:
                     binds.append({'lfn': lfn,
-                                    'run': run.run,
-                                    'lumi':lumi})
+                                  'run': run.run,
+                                  'lumi': lumi})
         else:
             raise Exception("Type of runs argument is not allowed: %s" \
-                                % type(runs))
+                            % type(runs))
         return binds
 
     def format(self, result):


### PR DESCRIPTION
Fix an issue with WorkQueueManager where one of its thread (WorkQueueManagerWMBSFileFeeder) stays forever trying to insert the run/lumi mapping rows into the database.

Creating the binds list is quite straight forward (took < 0.5 secs for 500k lumis in my interactive tests). This operation is likely heavier on Oracle because it first has to check whether that row already exists... so setting it to 10k only to be on the safe side (the case it was getting stuck was .5 million).