### PR TITLE
Retrieve all non-deprecated CMSSW releases in all ScramArchs available

### DIFF
--- a/src/python/WMCore/Services/TagCollector/TagCollector.py
+++ b/src/python/WMCore/Services/TagCollector/TagCollector.py
@@ -7,14 +7,14 @@ from WMCore.Services.TagCollector.XMLUtils import xml_parser
 class TagCollector(Service):
     """
     Class which provides interface to CMS TagCollector web-service.
-    Provides both Production and Development releases (anytype=1)
+    Provides non-deprecated CMSSW releases in all their ScramArchs (not only prod)
     """
     
     def __init__(self, url=None):
         """
         responseType will be either xml or json
         """
-        defaultURL = "https://cmssdt.cern.ch/SDT/cgi-bin/ReleasesXML?anytype=1"
+        defaultURL = "https://cmssdt.cern.ch/SDT/cgi-bin/ReleasesXML?anytype=1&anyarch=1"
         params = {}
         params["timeout"] = 300
         params['endpoint'] = url or defaultURL


### PR DESCRIPTION
Shahzad has just created this arch option (anyarch) and now we can retrieve a CMSSW release in all its ScramArch (before it was showing only the production one).

This is needed if we want to run slc7_* workflows.