### PR TITLE
Encode query args for TagCollector

### DIFF
--- a/src/python/WMCore/Services/TagCollector/TagCollector.py
+++ b/src/python/WMCore/Services/TagCollector/TagCollector.py
@@ -4,12 +4,13 @@ from collections import defaultdict
 from WMCore.Services.Service import Service
 from WMCore.Services.TagCollector.XMLUtils import xml_parser
 
+
 class TagCollector(Service):
     """
     Class which provides interface to CMS TagCollector web-service.
     Provides non-deprecated CMSSW releases in all their ScramArchs (not only prod)
     """
-    
+
     def __init__(self, url=None):
         """
         responseType will be either xml or json
@@ -41,8 +42,8 @@ class TagCollector(Service):
         if clearCache:
             self.clearCache(cfile, args, verb)
 
-        f = self.refreshCache(cfile, callname, args, encoder = encoder,
-                              verb = verb, contentType = contentType)
+        f = self.refreshCache(cfile, callname, args, encoder=encoder,
+                              verb=verb, contentType=contentType)
         result = f.read()
         f.close()
 
@@ -65,8 +66,8 @@ class TagCollector(Service):
         "Yield CMS releases known in tag collector"
         arr = []
         for row in self.data():
-            if  arch:
-                if  arch == row['name']:
+            if arch:
+                if arch == row['name']:
                     for item in row['project']:
                         arr.append(item['label'])
             else:
@@ -80,7 +81,7 @@ class TagCollector(Service):
         for row in self.data():
             arr.append(row['name'])
         return list(set(arr))
-    
+
     def releases_by_architecture(self):
         "returns CMS architectures and realease in dictionary format"
         arch_dict = defaultdict(list)

--- a/src/python/WMCore/Services/TagCollector/TagCollector.py
+++ b/src/python/WMCore/Services/TagCollector/TagCollector.py
@@ -14,7 +14,9 @@ class TagCollector(Service):
         """
         responseType will be either xml or json
         """
-        defaultURL = "https://cmssdt.cern.ch/SDT/cgi-bin/ReleasesXML?anytype=1&anyarch=1"
+        defaultURL = "https://cmssdt.cern.ch/SDT/cgi-bin/ReleasesXML"
+        # all releases types and all their archs
+        self.tcArgs = {"anytype": 1, "anyarch": 1}
         params = {}
         params["timeout"] = 300
         params['endpoint'] = url or defaultURL
@@ -32,7 +34,9 @@ class TagCollector(Service):
 
         TODO: Probably want to move this up into Service
         """
-        
+        if not args:
+            args = self.tcArgs
+
         cfile = callname.replace("/", "_")
         if clearCache:
             self.clearCache(cfile, args, verb)
@@ -86,4 +90,3 @@ class TagCollector(Service):
                 releases.add(item['label'])
             arch_dict[row['name']].extend(list(releases))
         return arch_dict
-        

--- a/test/python/WMCore_t/Services_t/TagCollector_t/TagCollector_t.py
+++ b/test/python/WMCore_t/Services_t/TagCollector_t/TagCollector_t.py
@@ -8,8 +8,8 @@ import unittest
 
 from WMCore.Services.TagCollector.TagCollector import TagCollector
 
-class TagCollectorTest(unittest.TestCase):
 
+class TagCollectorTest(unittest.TestCase):
     def setUp(self):
         """
         _setUp_
@@ -28,10 +28,13 @@ class TagCollectorTest(unittest.TestCase):
         realsese_by_arch = self.tagCollecor.releases_by_architecture()
         self.assertIn('CMSSW_7_1_10_patch2', releases)
         self.assertIn('slc6_amd64_gcc493', architectures)
+        self.assertIn('slc7_amd64_gcc620', architectures)
         self.assertEqual(len(architectures), len(realsese_by_arch))
-        self.assertEqual(sorted(self.tagCollecor.releases('slc6_amd64_gcc493')), sorted(realsese_by_arch.get('slc6_amd64_gcc493')))
-        
+        self.assertEqual(sorted(self.tagCollecor.releases('slc6_amd64_gcc493')),
+                         sorted(realsese_by_arch.get('slc6_amd64_gcc493')))
+
         return
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I'm really sorry about that sick PR #7576 . It was so simple that I left the testing for testbed :(
We must encode the query strings otherwise the `anyarch` is not "seen" in the get request.

Waiting for the unittestt to come back. But this time it was tested in my VM.
