### PR TITLE
don't call getElementsForParent if not necessary

### DIFF
--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -1073,10 +1073,10 @@ class WorkQueue(WorkQueueBase):
         if not inbound_work:
             inbound_work = self.backend.getElementsForSplitting()
         for inbound in inbound_work:
-            # Check we haven't already split the work, unless it's continuous processing
-            work = self.backend.getElementsForParent(inbound)
             try:
-                if work and not continuous:
+                # Check we haven't already split the work, unless it's continuous processing
+                work = not continuous and self.backend.getElementsForParent(inbound)
+                if work:
                     self.logger.info('Request "%s" already split - Resuming' % inbound['RequestName'])
                 else:
                     work, rejectedWork = self._splitWork(inbound['WMSpec'], data=inbound['Inputs'],


### PR DESCRIPTION
as it explained in the title. reduce the unnecessary call when following gets called.
 
https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/WorkQueue/WorkQueue.py#L660
