### PR TITLE
work around the fact that dCache only knows ADLER32, not adler32

### DIFF
--- a/src/python/WMCore/Storage/Backends/XRDCPImpl.py
+++ b/src/python/WMCore/Storage/Backends/XRDCPImpl.py
@@ -140,7 +140,7 @@ class XRDCPImpl(StageOutImpl):
         if useChecksum:
 
             copyCommand += "echo \"Local File Checksum is: %s\"\n" % checksums['adler32']
-            copyCommand += "REMOTE_XS=`xrdfs '%s' query checksum '%s' | grep adler32 | sed -r 's/.*adler32[ ]*([0-9a-fA-F]{8}).*/\\1/'`\n" % (host, path)
+            copyCommand += "REMOTE_XS=`xrdfs '%s' query checksum '%s' | grep -i adler32 | sed -r 's/.*[adler|ADLER]32[ ]*([0-9a-fA-F]{8}).*/\\1/'`\n" % (host, path)
             copyCommand += "echo \"Remote File Checksum is: $REMOTE_XS\"\n"
 
             copyCommand += "if [ $REMOTE_SIZE ] && [ $REMOTE_XS ] && [ $LOCAL_SIZE == $REMOTE_SIZE ] && [ '%s' == $REMOTE_XS ]; then exit 0; " % checksums['adler32']

--- a/test/python/WMCore_t/Storage_t/Backends_t/XRDCPImpl_t.py
+++ b/test/python/WMCore_t/Storage_t/Backends_t/XRDCPImpl_t.py
@@ -105,7 +105,7 @@ class XRDCPImplTest(unittest.TestCase):
         copyCommand += "echo \"Remote File Size is: $REMOTE_SIZE\"\n"
         if checksums:
             copyCommand += "echo \"Local File Checksum is: %s\"\n" % checksums
-            copyCommand += "REMOTE_XS=`xrdfs '%s' query checksum '%s' | grep adler32 | sed -r 's/.*adler32[ ]*([0-9a-fA-F]{8}).*/\\1/'`\n" % (
+            copyCommand += "REMOTE_XS=`xrdfs '%s' query checksum '%s' | grep -i adler32 | sed -r 's/.*[adler|ADLER]32[ ]*([0-9a-fA-F]{8}).*/\\1/'`\n" % (
                 host, path)
             copyCommand += "echo \"Remote File Checksum is: $REMOTE_XS\"\n"
 


### PR DESCRIPTION
FNAL dCache only seems to know about ADLER32 checksums, the xrootd client only knows about adler32, neither accepts the other capitalization. The actual xrdcp stageout command still works (it prints a warning that it doesn't know what to do with the passed adler32 checksum), but the post-transfer checksum comparison fails since the regular expression expects an adler32 return and get ADLER32. Fix the regular expression.

In parallel also investigate why dCache gets it wrong, but this patch at least allows the plugin to work against FNAL dCache.