### PR TITLE
Never return None from MemoryCacheStruct

### DIFF
--- a/src/python/WMCore/Cache/GenericDataCache.py
+++ b/src/python/WMCore/Cache/GenericDataCache.py
@@ -3,15 +3,17 @@ import time
 import traceback
 import logging
 
+
 class MemoryCacheStruct(object):
     """
     WARNING: This can be used in multi thread by registering on GenericDataCache
     But this cache is not thread saft.
     """
+
     def __init__(self, expire, func, initCacheValue=None, kwargs=None):
         """
         expire is the seconds which cache will be refreshed when cache is older than the expire.
-        func is the fuction which cache data is retrived
+        func is the fuction which cache data is retrieved
         kwargs are func arguments for cache data
         """
         self.data = initCacheValue
@@ -20,28 +22,28 @@ class MemoryCacheStruct(object):
         if kwargs == None:
             kwargs = {}
         self.kwargs = kwargs
-        self.lastUpdated  = -1
-        
+        self.lastUpdated = -1
+
     def isDataExpired(self):
         if self.lastUpdated == -1:
             return True
         if (int(time.time()) - self.lastUpdated) > self.expire:
             return True
         return False
-    
+
     def getData(self, noFail=True):
         if self.isDataExpired():
             try:
                 self.data = self.func(**self.kwargs)
                 self.lastUpdate = int(time.time())
-            except Exception as ex:
+            except Exception:
                 if noFail:
                     logging.error(traceback.format_exc())
                 else:
                     raise
         return self.data
 
-        
+
 class CacheExistException(Exception):
     def __init__(self, cacheName):
         Exception.__init__(self, cacheName)
@@ -51,6 +53,7 @@ class CacheExistException(Exception):
     def __str__(self):
         return "%s: %s" % (self.msg, self.error)
 
+
 class CacheWithWrongStructException(Exception):
     def __init__(self, cacheName):
         Exception.__init__(self, cacheName)
@@ -59,11 +62,11 @@ class CacheWithWrongStructException(Exception):
 
     def __str__(self):
         return "%s: %s" % (self.msg, self.error)
-                    
+
+
 class GenericDataCache(object):
-    
     _dataCache = {}
-    
+
     @staticmethod
     def getCacheData(cacheName):
         return GenericDataCache._dataCache[cacheName]

--- a/src/python/WMCore/Cache/GenericDataCache.py
+++ b/src/python/WMCore/Cache/GenericDataCache.py
@@ -8,13 +8,13 @@ class MemoryCacheStruct(object):
     WARNING: This can be used in multi thread by registering on GenericDataCache
     But this cache is not thread saft.
     """
-    def __init__(self, expire, func, kwargs=None):
+    def __init__(self, expire, func, initCacheValue=None, kwargs=None):
         """
-        expire is the seconds which cache will be refreshed when cache is order than the expire.
+        expire is the seconds which cache will be refreshed when cache is older than the expire.
         func is the fuction which cache data is retrived
         kwargs are func arguments for cache data
         """
-        self.data = None
+        self.data = initCacheValue
         self.expire = expire
         self.func = func
         if kwargs == None:

--- a/src/python/WMCore/Services/ReqMgr/ReqMgr.py
+++ b/src/python/WMCore/Services/ReqMgr/ReqMgr.py
@@ -211,7 +211,6 @@ class ReqMgr(Service):
         # imports here to avoid the dependency not using this function
         from WMCore.Cache.GenericDataCache import MemoryCacheStruct
 
-        # TODO remove "aborted-completed status when state transition happens in reqmgr2
         maskStates = ["aborted", "force-complete"]
-        return MemoryCacheStruct(expire=0, func=self.getRequestByStatus,
+        return MemoryCacheStruct(expire=0, func=self.getRequestByStatus, initCacheValue=[],
                                  kwargs={'statusList': maskStates, "detail": False})

--- a/test/python/WMCore_t/Cache_t/GenericDataCache_t.py
+++ b/test/python/WMCore_t/Cache_t/GenericDataCache_t.py
@@ -10,6 +10,11 @@ import time
 from WMCore.Cache.GenericDataCache import GenericDataCache, CacheExistException, \
                           CacheWithWrongStructException, MemoryCacheStruct
 
+
+class Foo(object):
+    pass
+
+
 class GenericDataCacheTest(unittest.TestCase):
 
     def testBasic(self):
@@ -18,9 +23,10 @@ class GenericDataCacheTest(unittest.TestCase):
 
         Basic stuff.
         """
-        mc = MemoryCacheStruct(1, lambda x: int(time.time()), {'x':1})
+        mc = MemoryCacheStruct(1, lambda x: int(time.time()), kwargs={'x':1})
+        self.assertIsNone(mc.data)
         self.assertEqual(mc.lastUpdated, -1)
-        
+
         GenericDataCache.registerCache("test", mc)
         with self.assertRaises(CacheExistException):
             GenericDataCache.registerCache("test", mc)
@@ -32,8 +38,30 @@ class GenericDataCacheTest(unittest.TestCase):
         after = mc2.getData()
         self.assertFalse(before == after)
         self.assertFalse(mc2.lastUpdate == -1)
-        
+
         return
+
+    def testBasicInit(self):
+        """
+        _testBasicInit_
+
+        Test init values
+        """
+        mc = MemoryCacheStruct(0, lambda x: x, initCacheValue=Foo())
+        self.assertIsInstance(mc.data, Foo)
+
+        mc1 = MemoryCacheStruct(0, lambda x: sum(x), [], kwargs={'x': [1, 2]})
+        self.assertEqual(mc1.data, [])
+        after = mc1.getData()
+        self.assertEqual(after, 3)
+
+        mc2 = MemoryCacheStruct(0, lambda x: x, {}, kwargs={'x': {'one':1, 'two':2}})
+        self.assertEqual(mc2.data, {})
+        after = mc2.getData()
+        self.assertItemsEqual(after.keys(), ['one', 'two'])
+
+        return
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
We can either change the default value (as done here) or have a check for None in all parts of the code that use this cache struct as an iterable. I think it's much cleaner this one, and this cache should always cache some sort of iterable object.

Just to give some background, this caused all the agents to break (JobSubmitter) during the cmsweb upgrade, since it can return None in case of exception not raised:
https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/Cache/GenericDataCache.py#L38

this was the traceback:
```
2017-02-07 11:34:27,369:139733011392256:INFO:Harness:>>>Terminating worker threads
2017-02-07 11:34:27,380:139733011392256:ERROR:BaseWorkerThread:Error in event loop (2): <WMComponent.JobSubmitter.JobSubmitterPoller.JobSubmitterPoller instance at 0x7f16292a4cf8> JobSubmitterPollerException
Message: Fatal error in JobSubmitter:
argument of type 'NoneType' is not iterable


        ModuleName : WMComponent.JobSubmitter.JobSubmitterPoller
        MethodName : algorithm
        ClassInstance : None
        FileName : /data/srv/wmagent/v1.0.21.patch1/sw/slc6_amd64_gcc493/cms/wmagent/1.0.21.patch1/lib/python2.7/site-packages/WMComponent/JobSubmitter/JobSubmitterPoller.py
        ClassName : None
        LineNumber : 707
        ErrorNr : 0

Traceback: 
  File "/data/srv/wmagent/v1.0.21.patch1/sw/slc6_amd64_gcc493/cms/wmagent/1.0.21.patch1/lib/python2.7/site-packages/WMComponent/JobSubmitter/JobSubmitterPoller.py", line 691, in algorithm
    self.refreshCache()

  File "/data/srv/wmagent/v1.0.21.patch1/sw/slc6_amd64_gcc493/cms/wmagent/1.0.21.patch1/lib/python2.7/site-packages/WMComponent/JobSubmitter/JobSubmitterPoller.py", line 249, in refreshCache
    if (newJob['request_name'] in abortedAndForceCompleteRequests) and \


Backtrace:
  File "/data/srv/wmagent/v1.0.21.patch1/sw/slc6_amd64_gcc493/cms/wmagent/1.0.21.patch1/lib/python2.7/site-packages/WMCore/WorkerThreads/BaseWorkerThread.py", line 206, in __call__
    raise ex

2017-02-07 11:34:27,380:139733011392256:INFO:BaseWorkerThread:Worker thread <WMComponent.JobSubmitter.JobSubmitterPoller.JobSubmitterPoller instance at 0x7f16292a4cf8> terminated
```