### PR TITLE
allow 0 event file for job estimation

### DIFF
--- a/test/python/WMCore_t/Services_t/WorkQueue_t/WorkQueue_t.py
+++ b/test/python/WMCore_t/Services_t/WorkQueue_t/WorkQueue_t.py
@@ -70,12 +70,12 @@ class WorkQueueTest(EmulatedUnitTestCase):
         # This only checks minimum client call not exactly correctness of return
         # values.
         self.assertEqual(wqApi.getTopLevelJobsByRequest(),
-                         [{'total_jobs': 334, 'request_name': specName}])
+                         [{'total_jobs': 339, 'request_name': specName}])
         # work still available, so no childQueue
         self.assertEqual(wqApi.getChildQueuesAndStatus().keys(), [None])
         result = wqApi.getElementsCountAndJobsByWorkflow()
         self.assertEqual(len(result), 1)
-        self.assertEqual(result[specName]['Available']['Jobs'], 334)
+        self.assertEqual(result[specName]['Available']['Jobs'], 339)
 
         self.assertEqual(wqApi.getChildQueuesAndPriority()[None].keys(), [8000])
         self.assertEqual(wqApi.getWMBSUrl(), [])
@@ -151,14 +151,14 @@ class WorkQueueTest(EmulatedUnitTestCase):
         # This only checks minimum client call not exactly correctness of return
         # values.
         self.assertEqual(wqApi.getTopLevelJobsByRequest(),
-                         [{'total_jobs': 334, 'request_name': specName}])
+                         [{'total_jobs': 339, 'request_name': specName}])
         results = wqApi.getJobsByStatusAndPriority()
         self.assertEqual(results.keys(), ['Available'])
         self.assertEqual(results['Available'].keys(), [8000])
-        self.assertTrue(results['Available'][8000]['sum'], 334)
+        self.assertTrue(results['Available'][8000]['sum'], 339)
         result = wqApi.getElementsCountAndJobsByWorkflow()
         self.assertEqual(len(result), 1)
-        self.assertEqual(result[specName]['Available']['Jobs'], 334)
+        self.assertEqual(result[specName]['Available']['Jobs'], 339)
         data = wqApi.db.loadView('WorkQueue', 'elementsDetailByWorkflowAndStatus',
                                  {'startkey': [specName], 'endkey': [specName, {}],
                                   'reduce': False})


### PR DESCRIPTION
replace #7612.  Instead allowing  Jobs == 0 in workqueue elements, set the job 1 when number of events are 0 due to the file has 0 event.
Since there is legit case it shouldn't allow Job == 0 (in MC case)
https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/WorkQueue/Policy/Start/MonteCarlo.py#L113

@amaltaro, Alan please review