### PR TITLE
Use machine attr for CMS site location in SimpleCondor

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -183,11 +183,11 @@ class SimpleCondorPlugin(BasePlugin):
         logging.debug("Start: Retrieving classAds using Condor Python XQuery")
         try:
             itobj = schedd.xquery("WMAgent_AgentName == %s" % classad.quote(self.agent),
-                                  ['ClusterId', 'ProcId', 'JobStatus', 'MATCH_EXP_JOBGLIDEIN_CMSSite'])
+                                  ['ClusterId', 'ProcId', 'JobStatus', 'MachineAttrGLIDEIN_CMSSite0'])
             for jobAd in itobj:
                 gridId = "%s.%s" % (jobAd['ClusterId'], jobAd['ProcId'])
                 jobStatus = SimpleCondorPlugin.exitCodeMap().get(jobAd.get('JobStatus'), 'Unknown')
-                location = jobAd.get('MATCH_EXP_JOBGLIDEIN_CMSSite', None)
+                location = jobAd.get('MachineAttrGLIDEIN_CMSSite0', None)
                 jobInfo[gridId] = (jobStatus, location)
         except Exception as ex:
             logging.error("Query to condor schedd failed in SimpleCondorPlugin.")
@@ -452,8 +452,6 @@ class SimpleCondorPlugin(BasePlugin):
 
         ad['WMAgent_AgentName'] = self.agent
 
-        ad['JOBGLIDEIN_CMSSite'] = classad.ExprTree('isUndefined(GLIDEIN_CMSSite) ? Unknown : GLIDEIN_CMSSite')
-
         ad['JobLeaseDuration'] = classad.ExprTree('isUndefined(MachineAttrMaxHibernateTime0) ? 1200 : MachineAttrMaxHibernateTime0')
 
         # Required for global pool accounting
@@ -472,7 +470,7 @@ class SimpleCondorPlugin(BasePlugin):
 
         ad['JobMachineAttrs'] = "GLIDEIN_CMSSite"
         ad['JobAdInformationAttrs'] = ("JobStatus,QDate,EnteredCurrentStatus,JobStartDate,DESIRED_Sites,"
-                                       "ExtDESIRED_Sites,WMAgent_JobID,MATCH_EXP_JOBGLIDEIN_CMSSite")
+                                       "ExtDESIRED_Sites,WMAgent_JobID,MachineAttrGLIDEIN_CMSSite0")
 
         # TODO: remove when 8.5.7 is deployed
         paramsToAdd = htcondor.param['SUBMIT_ATTRS'].split() + htcondor.param['SUBMIT_EXPRS'].split()


### PR DESCRIPTION
Problem spotted and reported in:
https://cms-logbook.cern.ch/elog/GlideInWMS/5034

Summary, the `JOBGLIDEIN_CMSSite` expression we set on the submitter plugin is not correct (I don't know why the others are though...) and it causes `MATCH_EXP_JOBGLIDEIN_CMSSite` not to be set at all.

One of the solutions is to use the machine attribute - which is supposed to be more reliable.
For the record, the `0` in the end corresponds to the actual site. E.g., if job gets evicted, then it could have a `1` in the end with the previous site name.

I still have to test it, but comments are welcome (especially from @bbockelm )