### PR TITLE
Accept either string or list of strings for ScramArch at spec level

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -13,7 +13,7 @@ from WMCore.Lexicon import couchurl, block, procstring, activity, procversion
 from WMCore.Services.Dashboard.DashboardReporter import DashboardReporter
 from WMCore.WMSpec.WMSpecErrors import WMSpecFactoryException
 from WMCore.WMSpec.WMWorkload import newWorkload
-from WMCore.WMSpec.WMWorkloadTools import (makeList, makeLumiList, strToBool,
+from WMCore.WMSpec.WMWorkloadTools import (makeList, makeLumiList, makeNonEmptyList, strToBool,
                                            checkDBSURL, validateArgumentsCreate, safeStr)
 from WMCore.ReqMgr.Tools.cms import releases, architectures
 
@@ -962,8 +962,8 @@ class StdBase(object):
                      "AcquisitionEra": {"validate": acqname, "optional": False},
                      "CMSSWVersion": {"validate": lambda x: x in releases(),
                                       "optional": False, "attr": "frameworkVersion"},
-                     "ScramArch": {"validate": lambda x: x in architectures(),
-                                   "optional": False},
+                     "ScramArch": {"validate": lambda x: all([y in architectures() for y in x]),
+                                   "optional": False, "type": makeNonEmptyList},
                      "GlobalTag": {"optional": False, "null": False},
                      "GlobalTagConnect": {"null": True},
                      "ProcessingVersion": {"default": 1, "type": int, "validate": procversion},
@@ -1120,14 +1120,14 @@ class StdBase(object):
                 schema[arg] = os.environ["COUCHURL"]
             elif arg == "CouchDBName":
                 schema[arg] = "reqmgr_config_cache_t"
+            elif arg == "ScramArch":
+                schema[arg] = "slc6_amd64_gcc491"
             elif not workloadDefinition[arg]["optional"]:
                 if workloadDefinition[arg]["type"] == str:
                     if arg == "InputDataset":
                         schema[arg] = "/MinimumBias/ComissioningHI-v1/RAW"
                     elif arg == "CMSSWVersion":
                         schema[arg] = "CMSSW_7_6_2"
-                    elif arg == "ScramArch":
-                        schema[arg] = "slc6_amd64_gcc491"
                     else:
                         schema[arg] = "FAKE"
                 elif workloadDefinition[arg]["type"] == int or workloadDefinition[arg]["type"] == float:

--- a/src/python/WMCore/WMSpec/WMWorkloadTools.py
+++ b/src/python/WMCore/WMSpec/WMWorkloadTools.py
@@ -153,7 +153,8 @@ def _validateArgFunction(argument, value, valFunction):
     if valFunction:
         try:
             if not valFunction(value):
-                raise WMSpecFactoryException("Argument %s, value: %s doesn't pass the validation function." % (argument, value))
+                raise WMSpecFactoryException(
+                    "Argument %s, value: %s doesn't pass the validation function." % (argument, value))
         except Exception as ex:
             # Some validation functions (e.g. Lexicon) will raise errors instead of returning False
             logging.error(str(ex))
@@ -185,11 +186,10 @@ def _validateArgumentOptions(arguments, argumentDefinition, optionKey=None):
 
 
 def _validateInputDataset(arguments):
-    
     inputdataset = arguments.get("InputDataset", None)
     dbsURL = arguments.get("DbsUrl", None)
     if inputdataset != None and dbsURL != None:
-        #import DBS3Reader here, since Runtime code import this module and worker node doesn't have dbs3 client 
+        # import DBS3Reader here, since Runtime code import this module and worker node doesn't have dbs3 client
         from WMCore.Services.DBS.DBS3Reader import DBS3Reader
         from WMCore.Services.DBS.DBSErrors import DBSReaderError
         try:
@@ -209,7 +209,7 @@ def validateInputDatasSetAndParentFlag(arguments):
         else:
             dbsURL = arguments.get("DbsUrl", None)
             if dbsURL != None:
-                #import DBS3Reader here, since Runtime code import this module and worker node doesn't have dbs3 client 
+                # import DBS3Reader here, since Runtime code import this module and worker node doesn't have dbs3 client
                 from WMCore.Services.DBS.DBS3Reader import DBS3Reader
                 result = DBS3Reader(dbsURL).listDatasetParents(inputdataset)
                 if len(result) == 0:
@@ -261,13 +261,15 @@ def validateSiteLists(arguments):
     arguments["SiteBlacklist"] = blackList
     return
 
+
 def validateAutoGenArgument(arguments):
     autoGenArgs = ["TotalInputEvents", "TotalInputFiles", "TotalInputLumis", "TotalEstimatedJobs"]
-    protectedArgs =set(autoGenArgs).intersection(set(arguments.keys()))
+    protectedArgs = set(autoGenArgs).intersection(set(arguments.keys()))
 
     if len(protectedArgs) > 0:
         raise WMSpecFactoryException("Shouldn't set auto generated params %s: remove it" % list(protectedArgs))
     return
+
 
 def validateArgumentsCreate(arguments, argumentDefinition):
     """
@@ -276,7 +278,7 @@ def validateArgumentsCreate(arguments, argumentDefinition):
     Validate a set of arguments against and argument definition
     as defined in StdBase.getWorkloadArguments. It returns
     an error message if the validation went wrong,
-    otherwise returns None, this is used for spec creation 
+    otherwise returns None, this is used for spec creation
     checks the whether argument is optional as well as validation
     """
     validateAutoGenArgument(arguments)
@@ -324,6 +326,7 @@ def setAssignArgumentsWithDefault(arguments, argumentDefinition, checkList):
             arguments[argument] = argumentDefinition[argument]["default"]
     return
 
+
 def setArgumentsWithDefault(arguments, argumentDefinition):
     """
     sets the default value if arguments value is specified as None
@@ -331,13 +334,14 @@ def setArgumentsWithDefault(arguments, argumentDefinition):
     for argument in argumentDefinition:
         if argument not in arguments and "default" in argumentDefinition[argument]:
             arguments[argument] = argumentDefinition[argument]["default"]
-            
+
     # set the Campaign default value to the same as AcquisitionEra if Campaign is not specified
     if not arguments.get("Campaign"):
         if ("AcquisitionEra" in arguments) and isinstance(arguments["AcquisitionEra"], basestring):
             arguments["Campaign"] = arguments["AcquisitionEra"]
-        
+
     return
+
 
 def loadSpecClassByType(specType):
     factoryName = "%sWorkloadFactory" % specType
@@ -352,8 +356,8 @@ def loadSpecByType(specType):
     specClass = loadSpecClassByType(specType)
     return specClass()
 
+
 def checkDBSURL(url):
-    #import DBS3Reader here, since Runtime code import this module and worker node doesn't have dbs3 client 
+    # import DBS3Reader here, since Runtime code import this module and worker node doesn't have dbs3 client
     from WMCore.Services.DBS.DBS3Reader import DBS3Reader
     return DBS3Reader(url).checkDBSServer()
-

--- a/src/python/WMCore/WMSpec/WMWorkloadTools.py
+++ b/src/python/WMCore/WMSpec/WMWorkloadTools.py
@@ -44,6 +44,20 @@ def makeList(stringList):
     raise WMSpecFactoryException("Can't convert to list %s" % stringList)
 
 
+def makeNonEmptyList(stringList):
+    """
+    _makeNonEmptyList_
+
+    Given a string or a list of strings, return a non empty list of strings.
+    Throws an exception in case the final list is empty or input data is not
+    a string or a python list
+    """
+    finalList = makeList(stringList)
+    if not finalList:
+        raise WMSpecFactoryException("Input data cannot be an empty list %s" % stringList)
+    return finalList
+
+
 def strToBool(string):
     """
     _strToBool_

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
@@ -285,7 +285,7 @@ class StepChainTests(unittest.TestCase):
         self.assertEqual(outModsAndDsets['outputDataset'],
                          '/PrimaryDataset-StepChain/AcquisitionEra_StepChain-ProcessingString_StepChain-v1/MINIAODSIM')
         self.assertEqual(task.getSwVersion(), 'CMSSW_7_1_25_patch2')
-        self.assertEqual(task.getScramArch(), 'slc6_amd64_gcc481')
+        self.assertItemsEqual(task.getScramArch(), ['slc6_amd64_gcc481'])
         step = task.getStep("cmsRun1")
         self.assertEqual(step.data.application.configuration.arguments.globalTag, 'GT-Step1')
 

--- a/test/python/WMCore_t/WMSpec_t/WMWorkloadTools_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMWorkloadTools_t.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+"""
+Unittests for WMWorkloadTools functions
+"""
+
+from __future__ import division, print_function
+
+import unittest
+
+from WMCore.WMSpec.WMWorkloadTools import makeList, makeNonEmptyList
+from WMCore.WMSpec.WMSpecErrors import WMSpecFactoryException
+
+
+class WMWorkloadToolsTest(unittest.TestCase):
+    """
+    unittest for WMWorkloadTools functions
+    """
+
+    def testMakeList(self):
+        """
+        Test the makeList function
+        """
+        self.assertEqual(makeList([]), [])
+        self.assertEqual(makeList(""), [])
+        self.assertEqual(makeList(['123']), ['123'])
+        self.assertEqual(makeList([456]), [456])
+        self.assertItemsEqual(makeList(['123', 456, '789']), ['123', 456, '789'])
+
+        self.assertEqual(makeList('123'), ['123'])
+        self.assertEqual(makeList(u'123'), [u'123'])
+        self.assertItemsEqual(makeList('123,456'), ['123', '456'])
+        self.assertItemsEqual(makeList(u'123,456'), [u'123', u'456'])
+        self.assertItemsEqual(makeList('["aa","bb","cc"]'), ['aa', 'bb', 'cc'])
+        self.assertItemsEqual(makeList(u' ["aa", "bb", "cc"] '), ['aa', 'bb', 'cc'])
+
+        self.assertRaises(WMSpecFactoryException, makeList, 123)
+        self.assertRaises(WMSpecFactoryException, makeList, 123.456)
+        self.assertRaises(WMSpecFactoryException, makeList, {1: 123})
+
+    def testMakeNonEmptyList(self):
+        """
+        Test the makeNonEmptyList function.
+        It has exactly the same behaviour as makeList, but throws an exception
+        for empty list or string.
+        """
+        self.assertEqual(makeList(['123']), makeNonEmptyList(['123']))
+        self.assertItemsEqual(makeList(['123', 456, '789']), makeNonEmptyList(['123', 456, '789']))
+
+        self.assertItemsEqual(makeList(u'123,456'), makeNonEmptyList(u'123, 456'))
+        self.assertItemsEqual(makeList('["aa","bb","cc"]'), makeNonEmptyList('["aa", "bb", "cc"]'))
+
+        self.assertRaises(WMSpecFactoryException, makeNonEmptyList, [])
+        self.assertRaises(WMSpecFactoryException, makeNonEmptyList, "")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #7578
Deeper changes at CMSSW level done here https://github.com/dmwm/WMCore/pull/7579

We then validate and convert the user input into a python list of strings (even if user provided only a basic string), otherwise it's a bit more complicated to do the data sanitisation.

Still to be tested.