### PR TITLE
temp fix for logdb delete - current version has realfix

### DIFF
--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -371,7 +371,7 @@ class WorkQueue(WorkQueueBase):
                                                                   wmspec,
                                                                   blockName,
                                                                   dbsBlock)
-                    self.logdb.delete(wmspec.name(), "error", this_thread=True)
+                    #self.logdb.delete(wmspec.name(), "error", this_thread=True)
                 except Exception as ex:
                     msg = "%s, %s: \ncreating subscription failed in LQ: \n%s" % (wmspec.name(), blockName, str(ex))
                     self.logger.error(msg)
@@ -868,7 +868,7 @@ class WorkQueue(WorkQueueBase):
                     if (currentTime - max(newDataFoundTime, lastUpdate)) > openRunningTimeout:
                         workflowsToClose.append(element.id)
                     # if it is successful remove previous error
-                    self.logdb.delete(element.id, "error", this_thread=True)
+                    #self.logdb.delete(element.id, "error", this_thread=True)
                 else:
                     msg = "ChildElement is empty for element id %s: investigate" % element.id
                     self.logdb.post(element.id, msg, "error")


### PR DESCRIPTION
related to #7627

Applied to all the production agent (only 1.0.21 version) and WorkQueueManagers are restarted.