### PR TITLE
Move utilitarian function from WMWorkloadTools to Utils

### DIFF
--- a/src/python/Utils/Utilities.py
+++ b/src/python/Utils/Utilities.py
@@ -1,0 +1,60 @@
+#! /usr/bin/env python
+from __future__ import division, print_function
+
+
+def makeList(stringList):
+    """
+    _makeList_
+
+    Make a python list out of a comma separated list of strings,
+    throws a ValueError if the input is not well formed.
+    If the stringList is already of type list, then return it untouched.
+    """
+    if isinstance(stringList, list):
+        return stringList
+    if isinstance(stringList, basestring):
+        toks = stringList.lstrip(' [').rstrip(' ]').split(',')
+        if toks == ['']:
+            return []
+        return [str(tok.strip(' \'"')) for tok in toks]
+    raise ValueError("Can't convert to list %s" % stringList)
+
+
+def makeNonEmptyList(stringList):
+    """
+    _makeNonEmptyList_
+
+    Given a string or a list of strings, return a non empty list of strings.
+    Throws an exception in case the final list is empty or input data is not
+    a string or a python list
+    """
+    finalList = makeList(stringList)
+    if not finalList:
+        raise ValueError("Input data cannot be an empty list %s" % stringList)
+    return finalList
+
+
+def strToBool(string):
+    """
+    _strToBool_
+
+    Try to convert a string to boolean. i.e. "True" to python True
+    """
+    if string in [False, True]:
+        return string
+    elif string in ["True", "true", "TRUE"]:
+        return True
+    elif string in ["False", "false", "FALSE"]:
+        return False
+    raise ValueError("Can't convert to bool: %s" % string)
+
+
+def safeStr(string):
+    """
+    _safeStr_
+
+    Cast simple data (int, float, basestring) to string.
+    """
+    if not isinstance(string, (tuple, list, set, dict)):
+        return str(string)
+    raise ValueError("We're not supposed to convert %s to string." % string)

--- a/src/python/WMCore/WMSpec/StdSpecs/DQMHarvest.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/DQMHarvest.py
@@ -1,6 +1,6 @@
+from Utils.Utilities import makeList
 from WMCore.Lexicon import dataset, block
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
-from WMCore.WMSpec.WMWorkloadTools import makeList
 from WMCore.WMSpec.WMSpecErrors import WMSpecFactoryException
 
 

--- a/src/python/WMCore/WMSpec/StdSpecs/DataProcessing.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/DataProcessing.py
@@ -4,10 +4,10 @@ _DataProcessing_
 
 Base module for workflows with input.
 """
-
+from Utils.Utilities import makeList
 from WMCore.Lexicon import dataset, block
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
-from WMCore.WMSpec.WMWorkloadTools import makeList
+
 
 class DataProcessing(StdBase):
     """

--- a/src/python/WMCore/WMSpec/StdSpecs/MonteCarlo.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/MonteCarlo.py
@@ -12,9 +12,10 @@ fetches from DBS the information about pileup input.
 """
 
 import math
+from Utils.Utilities import strToBool
 from WMCore.Lexicon import primdataset, dataset
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
-from WMCore.WMSpec.WMWorkloadTools import strToBool, parsePileupConfig
+from WMCore.WMSpec.WMWorkloadTools import parsePileupConfig
 
 
 class MonteCarloWorkloadFactory(StdBase):

--- a/src/python/WMCore/WMSpec/StdSpecs/MonteCarloFromGEN.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/MonteCarloFromGEN.py
@@ -4,10 +4,10 @@ _MonteCarloFromGEN_
 
 Workflow for processing MonteCarlo GEN files.
 """
-
+from Utils.Utilities import strToBool
 from WMCore.Lexicon import primdataset, dataset
 from WMCore.WMSpec.StdSpecs.DataProcessing import DataProcessing
-from WMCore.WMSpec.WMWorkloadTools import strToBool, parsePileupConfig
+from WMCore.WMSpec.WMWorkloadTools import parsePileupConfig
 
 
 class MonteCarloFromGENWorkloadFactory(DataProcessing):

--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -5,9 +5,9 @@ _PromptReco_
 Standard PromptReco workflow.
 """
 
+from Utils.Utilities import makeList, strToBool
 from WMCore.Lexicon import dataset, couchurl, identifier, block, procstringT0
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
-from WMCore.WMSpec.WMWorkloadTools import makeList, strToBool
 
 
 class PromptRecoWorkloadFactory(StdBase):

--- a/src/python/WMCore/WMSpec/StdSpecs/ReReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/ReReco.py
@@ -4,9 +4,9 @@ _ReReco_
 
 Standard ReReco workflow.
 """
-
+from Utils.Utilities import makeList
 from WMCore.WMSpec.StdSpecs.DataProcessing import DataProcessing
-from WMCore.WMSpec.WMWorkloadTools import makeList, validateArgumentsCreate
+from WMCore.WMSpec.WMWorkloadTools import validateArgumentsCreate
 
 class ReRecoWorkloadFactory(DataProcessing):
     """
@@ -168,7 +168,7 @@ class ReRecoWorkloadFactory(DataProcessing):
                 if skimConfig["SkimJobSplitAlgo"] == "EventAwareLumiBased":
                     skimConfig["SkimJobSplitAlgo"]["max_events_per_lumi"] = 20000
             elif skimConfig["SkimJobSplitAlgo"] == "LumiBased":
-                skimConfig["SkimJobSplitArgs"["lumis_per_job"]] = int(arguments.get("SkimLumisPerJob%s" % skimIndex, 8))
+                skimConfig["SkimJobSplitArgs"]["lumis_per_job"] = int(arguments.get("SkimLumisPerJob%s" % skimIndex, 8))
             self.skimConfigs.append(skimConfig)
             skimIndex += 1
 

--- a/src/python/WMCore/WMSpec/StdSpecs/Resubmission.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Resubmission.py
@@ -6,10 +6,10 @@ Resubmission module, this creates truncated workflows
 with limited input for error recovery.
 """
 
+from Utils.Utilities import makeList
 from WMCore.Lexicon import couchurl, identifier
 from WMCore.WMSpec.WMWorkload import WMWorkloadHelper
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
-from WMCore.WMSpec.WMWorkloadTools import makeList
 
 class ResubmissionWorkloadFactory(StdBase):
     """

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -6,6 +6,7 @@ Base class with helper functions for standard WMSpec files.
 """
 import logging
 
+from Utils.Utilities import makeList, makeNonEmptyList, strToBool, safeStr
 from WMCore.Cache.WMConfigCache import ConfigCache, ConfigCacheException
 from WMCore.Configuration import ConfigSection
 from WMCore.Lexicon import lfnBase, identifier, acqname, cmsname
@@ -13,8 +14,7 @@ from WMCore.Lexicon import couchurl, block, procstring, activity, procversion
 from WMCore.Services.Dashboard.DashboardReporter import DashboardReporter
 from WMCore.WMSpec.WMSpecErrors import WMSpecFactoryException
 from WMCore.WMSpec.WMWorkload import newWorkload
-from WMCore.WMSpec.WMWorkloadTools import (makeList, makeLumiList, makeNonEmptyList, strToBool,
-                                           checkDBSURL, validateArgumentsCreate, safeStr)
+from WMCore.WMSpec.WMWorkloadTools import (makeLumiList, checkDBSURL, validateArgumentsCreate)
 from WMCore.ReqMgr.Tools.cms import releases, architectures
 
 

--- a/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
@@ -13,12 +13,11 @@ It also assumes all the intermediate steps output are transient and do not need
 to be staged out and registered in DBS/PhEDEx. Only the last step output will be
 made available.
 """
-
+from Utils.Utilities import makeList, strToBool
 import WMCore.WMSpec.Steps.StepFactory as StepFactory
 from WMCore.Lexicon import identifier, couchurl, block, primdataset, dataset
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
-from WMCore.WMSpec.WMWorkloadTools import makeList, strToBool, \
-    validateArgumentsCreate, validateArgumentsNoOptionalCheck, parsePileupConfig
+from WMCore.WMSpec.WMWorkloadTools import validateArgumentsCreate, validateArgumentsNoOptionalCheck, parsePileupConfig
 
 # simple utils for data mining the request dictionary
 isGenerator = lambda args: not args["Step1"].get("InputDataset", None)

--- a/src/python/WMCore/WMSpec/StdSpecs/StoreResults.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StoreResults.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
-# pylint: disable=W0201, W0142, W0102
+# pylint: disable=W0201, W0102
 # W0201: Steve defines all global vars in __call__
 #   I don't know why, but I'm not getting blamed for it
-# W0142: Dave loves the ** magic
 # W0102: Dangerous default values?  I live on danger!
 #   Allows us to use a dict as a default
 """
@@ -13,9 +12,9 @@ Standard StoreResults workflow.
 
 import os
 
+from Utils.Utilities import makeList
 from WMCore.Lexicon import dataset, block
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
-from WMCore.WMSpec.WMWorkloadTools import makeList
 
 class StoreResultsWorkloadFactory(StdBase):
     """

--- a/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
@@ -86,10 +86,10 @@ Example initial processing task
 """
 from __future__ import division
 
+from Utils.Utilities import makeList, strToBool
 from WMCore.Lexicon import identifier, couchurl, block, primdataset, dataset
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
-from WMCore.WMSpec.WMWorkloadTools import makeList, strToBool, \
-    validateArgumentsCreate, validateArgumentsNoOptionalCheck, parsePileupConfig
+from WMCore.WMSpec.WMWorkloadTools import validateArgumentsCreate, validateArgumentsNoOptionalCheck, parsePileupConfig
 
 #
 # simple utils for data mining the request dictionary

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -5,11 +5,11 @@ _WMWorkload_
 Request level processing specification, acts as a container of a set
 of related tasks.
 """
+from Utils.Utilities import strToBool
 from WMCore.Configuration import ConfigSection
 from WMCore.WMSpec.ConfigSectionTree import findTop
 from WMCore.WMSpec.Persistency import PersistencyHelper
-from WMCore.WMSpec.WMWorkloadTools import validateArgumentsUpdate, strToBool, \
-    loadSpecClassByType, setAssignArgumentsWithDefault
+from WMCore.WMSpec.WMWorkloadTools import validateArgumentsUpdate, loadSpecClassByType, setAssignArgumentsWithDefault
 from WMCore.WMSpec.WMTask import WMTask, WMTaskHelper
 from WMCore.Lexicon import sanitizeURL
 from WMCore.WMException import WMException

--- a/src/python/WMCore/WMSpec/WMWorkloadTools.py
+++ b/src/python/WMCore/WMSpec/WMWorkloadTools.py
@@ -11,6 +11,7 @@ Created on Jun 13, 2013
 import json
 import logging
 
+from Utils.Utilities import makeList, strToBool
 from WMCore.DataStructs.LumiList import LumiList
 from WMCore.WMSpec.WMSpecErrors import WMSpecFactoryException
 
@@ -23,68 +24,6 @@ def makeLumiList(lumiDict):
         return ll.getCompactList()
     except:
         raise WMSpecFactoryException("Could not parse LumiList, %s: %s" % (type(lumiDict), lumiDict))
-
-
-def makeList(stringList):
-    """
-    _makeList_
-
-    Make a python list out of a comma separated list of strings,
-    throws a WMSpecFactoryException if the input is not
-    well formed. If the stringList is already of type list
-    then it is return untouched
-    """
-    if isinstance(stringList, list):
-        return stringList
-    if isinstance(stringList, basestring):
-        toks = stringList.lstrip(' [').rstrip(' ]').split(',')
-        if toks == ['']:
-            return []
-        return [str(tok.strip(' \'"')) for tok in toks]
-    raise WMSpecFactoryException("Can't convert to list %s" % stringList)
-
-
-def makeNonEmptyList(stringList):
-    """
-    _makeNonEmptyList_
-
-    Given a string or a list of strings, return a non empty list of strings.
-    Throws an exception in case the final list is empty or input data is not
-    a string or a python list
-    """
-    finalList = makeList(stringList)
-    if not finalList:
-        raise WMSpecFactoryException("Input data cannot be an empty list %s" % stringList)
-    return finalList
-
-
-def strToBool(string):
-    """
-    _strToBool_
-
-    Convert the string to the matching boolean value:
-    i.e. "True" to python True
-    """
-    if string == False or string == True:
-        return string
-    # Should we make it more human-friendly (i.e. string in ("Yes", "True", "T")?
-    elif string == "True":
-        return True
-    elif string == "False":
-        return False
-    else:
-        raise WMSpecFactoryException("Can't convert to bool: %s" % string)
-
-
-def safeStr(string):
-    """
-    _safeStr_
-
-    WMCore defined type used to more safely cast simple data types to string
-    """
-    if not isinstance(string, (tuple, list, set, dict)):
-        return str(string)
-    raise WMSpecFactoryException("We're not supposed to convert %s to string." % string)
 
 
 def parsePileupConfig(mcPileup, dataPileup):

--- a/test/python/Utils_t/Utilities_t.py
+++ b/test/python/Utils_t/Utilities_t.py
@@ -1,19 +1,18 @@
 #!/usr/bin/env python
 """
-Unittests for WMWorkloadTools functions
+Unittests for Utilities functions
 """
 
 from __future__ import division, print_function
 
 import unittest
 
-from WMCore.WMSpec.WMWorkloadTools import makeList, makeNonEmptyList
-from WMCore.WMSpec.WMSpecErrors import WMSpecFactoryException
+from Utils.Utilities import makeList, makeNonEmptyList, strToBool, safeStr
 
 
 class WMWorkloadToolsTest(unittest.TestCase):
     """
-    unittest for WMWorkloadTools functions
+    unittest for Utilities functions
     """
 
     def testMakeList(self):
@@ -33,9 +32,9 @@ class WMWorkloadToolsTest(unittest.TestCase):
         self.assertItemsEqual(makeList('["aa","bb","cc"]'), ['aa', 'bb', 'cc'])
         self.assertItemsEqual(makeList(u' ["aa", "bb", "cc"] '), ['aa', 'bb', 'cc'])
 
-        self.assertRaises(WMSpecFactoryException, makeList, 123)
-        self.assertRaises(WMSpecFactoryException, makeList, 123.456)
-        self.assertRaises(WMSpecFactoryException, makeList, {1: 123})
+        self.assertRaises(ValueError, makeList, 123)
+        self.assertRaises(ValueError, makeList, 123.456)
+        self.assertRaises(ValueError, makeList, {1: 123})
 
     def testMakeNonEmptyList(self):
         """
@@ -49,8 +48,34 @@ class WMWorkloadToolsTest(unittest.TestCase):
         self.assertItemsEqual(makeList(u'123,456'), makeNonEmptyList(u'123, 456'))
         self.assertItemsEqual(makeList('["aa","bb","cc"]'), makeNonEmptyList('["aa", "bb", "cc"]'))
 
-        self.assertRaises(WMSpecFactoryException, makeNonEmptyList, [])
-        self.assertRaises(WMSpecFactoryException, makeNonEmptyList, "")
+        self.assertRaises(ValueError, makeNonEmptyList, [])
+        self.assertRaises(ValueError, makeNonEmptyList, "")
+
+    def testStrToBool(self):
+        """
+        Test the strToBool function.
+        """
+        for v in [True, "True", "TRUE", "true"]:
+            self.assertTrue(strToBool(v))
+        for v in [False, "False", "FALSE", "false"]:
+            self.assertFalse(strToBool(v))
+
+        for v in ["", "alan", [], [''], {'a': 123}]:
+            self.assertRaises(ValueError, strToBool, v)
+
+    def safeStr(self):
+        """
+        Test the safeStr function.
+        """
+        for v in ['123', u'123', 123]:
+            self.assertEqual(safeStr(v), '123')
+        self.assertEqual(safeStr(123.45), '123.45')
+        self.assertEqual(safeStr(False), 'False')
+        self.assertEqual(safeStr(None), 'None')
+        self.assertEqual(safeStr(""), "")
+
+        for v in [[1, 2], {'x': 123}, set([1])]:
+            self.assertRaises(safeStr(v), '123')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #7633

Moving any generic python functions that don't depend on WMCore code.
I guess we don't want to move functions that are too specific to WMCore (e.g. parsePileupConfig), do we?