### PR TITLE
Support Step level dataset args in StepChain

### DIFF
--- a/test/data/ReqMgr/requests/Integration/StepChain_Tasks.json
+++ b/test/data/ReqMgr/requests/Integration/StepChain_Tasks.json
@@ -1,0 +1,92 @@
+{
+    "assignRequest": {
+        "AcquisitionEra": {
+            "GENSIM": "AcquisitionEra-OVERRIDE-ME", 
+            "DIGI": "AcquisitionEra-OVERRIDE-ME", 
+            "RECO": "AcquisitionEra-OVERRIDE-ME"
+        }, 
+        "ProcessingString": {
+            "GENSIM": "ProcessingString-OVERRIDE-ME", 
+            "DIGI": "ProcessingString-OVERRIDE-ME", 
+            "RECO": "ProcessingString-OVERRIDE-ME"
+        }, 
+        "Dashboard": "Dashboard-OVERRIDE-ME",
+        "GracePeriod": 300, 
+        "MaxRSS": 2300000, 
+        "MaxVSize": 40000000, 
+        "MergedLFNBase": "/store/backfill/1", 
+        "SiteBlacklist": [], 
+        "SiteWhitelist": [
+            "SiteWhitelist-OVERRIDE-ME"
+        ], 
+        "SoftTimeout": 129600, 
+        "Team": "Team-OVERRIDE-ME", 
+        "UnmergedLFNBase": "/store/unmerged"
+    }, 
+    "createRequest": {
+        "AcquisitionEra": "Integ_Test", 
+        "CMSSWVersion": "CMSSW_8_0_21", 
+        "Campaign": "Campaign-OVERRIDE-ME", 
+        "Comments": ["No input data; PU in Step2; Automatic splitting 200 EpJ, 2 LpJ; Main dict with double scram for slc6",
+                     "Step1 using diff 7_1_25_patch2/gcc481; Step2 with 8_0_21 single slc6 scram; Step3 with 8_0_21 and top level scram"],
+        "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb", 
+        "CouchDBName": "reqmgr_config_cache", 
+        "DbsUrl": "https://cmsweb.cern.ch/dbs/prod/global/DBSReader/", 
+        "GlobalTag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+        "Group": "DATAOPS",
+        "Memory": 2300, 
+        "Multicore": 1, 
+        "PrepID": "TEST-TEST-HIG-RunIISummer15wmLHEGS-00744", 
+        "PrimaryDataset": "DYJetsToLL_Pt-50To100_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8", 
+        "ProcessingString": "StepChain_MC_GenSimDigiReco_TEST_WMCore", 
+        "ProcessingVersion": 20, 
+        "RequestPriority": 316000, 
+        "RequestString": "RequestString-OVERRIDE-ME", 
+        "RequestType": "StepChain", 
+        "Requestor": "amaltaro", 
+        "ScramArch": ["slc6_amd64_gcc481", "slc6_amd64_gcc530"], 
+        "SizePerEvent": 250, 
+        "Step1": {
+            "AcquisitionEra": "Integ_TestStep1", 
+            "ProcessingString": "StepChain_MC_Step1_TEST_WMCore", 
+            "CMSSWVersion": "CMSSW_7_1_25_patch2", 
+            "ConfigCacheID": "526ca0745cd309b7cfef9f23b3d43acb", 
+            "EventsPerLumi": 100, 
+            "GlobalTag": "MCRUN2_71_V1::All", 
+            "PrepID": "TEST-Step1-RunIISummer15wmLHEGS-00744", 
+            "RequestNumEvents": 20000, 
+            "ScramArch": ["slc6_amd64_gcc481"], 
+            "Seeding": "AutomaticSeeding", 
+            "SplittingAlgo": "EventBased", 
+            "StepName": "GENSIM"
+        }, 
+        "Step2": {
+            "AcquisitionEra": "Integ_TestStep2", 
+            "ProcessingString": "StepChain_MC_Step2_TEST_WMCore", 
+            "CMSSWVersion": "CMSSW_8_0_21", 
+            "ConfigCacheID": "f7e311f2c6b5a0884faea133990edcbf", 
+            "GlobalTag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6", 
+            "InputFromOutputModule": "RAWSIMoutput", 
+            "InputStep": "GENSIM", 
+            "MCPileup": "/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW", 
+            "PrepID": "TEST-Step2-RunIISummer15wmLHEGS-00744", 
+            "ScramArch": ["slc6_amd64_gcc530"], 
+            "SplittingAlgo": "EventAwareLumiBased", 
+            "StepName": "DIGI"
+        }, 
+        "Step3": {
+            "AcquisitionEra": "Integ_TestStep3", 
+            "ProcessingString": "StepChain_MC_Step3_TEST_WMCore", 
+            "ConfigCacheID": "f7e311f2c6b5a0884faea133990f66cc",
+            "GlobalTag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6", 
+            "InputFromOutputModule": "PREMIXRAWoutput", 
+            "InputStep": "DIGI", 
+            "KeepOutput": true, 
+            "PrepID": "TEST-Step3-RunIISummer15wmLHEGS-00744", 
+            "SplittingAlgo": "EventAwareLumiBased",
+            "StepName": "RECO"
+        }, 
+        "StepChain": 3, 
+        "TimePerEvent": 144
+    }
+}


### PR DESCRIPTION
Fixes #7155

Properly builds a StepChain request taking into consideration the Step level settings (AcqEra/ProcStr/ProcVer).
In case those values are overwritten during assignment, the code is ready to nicely handle and update those properties at step (and output module) level.

BTW, most of these changes should be transparent to anything but StepChain requests.

TODO: I still have to remove all my loggings.
TODO2: make sure the tests will work just fine. Spec-wise, changes seem Ok.
TODO3: squash the first 3 commits