### PR TITLE
Disallow sched_status to be null in the db schema

### DIFF
--- a/src/python/WMCore/BossAir/BossAirAPI.py
+++ b/src/python/WMCore/BossAir/BossAirAPI.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
-#pylint: disable=E1103, E1101, C0103
-#E1103: Use DB objects attached to thread
-#E1101: Create config sections
-#C0103: Internal methods start with _
+# pylint: disable=E1103, E1101, C0103
+# E1103: Use DB objects attached to thread
+# E1101: Create config sections
+# C0103: Internal methods start with _
 """
 _BossAirAPI_
 
@@ -22,13 +22,13 @@ import logging
 import subprocess
 
 from WMCore.JobStateMachine.ChangeState import ChangeState
-from WMCore.DAOFactory          import DAOFactory
-from WMCore.WMFactory           import WMFactory
-from WMCore.BossAir.RunJob      import RunJob
-from WMCore.WMConnectionBase    import WMConnectionBase
-from WMCore.WMException         import WMException
+from WMCore.DAOFactory import DAOFactory
+from WMCore.WMFactory import WMFactory
+from WMCore.BossAir.RunJob import RunJob
+from WMCore.WMConnectionBase import WMConnectionBase
+from WMCore.WMException import WMException
 from WMCore.FwkJobReport.Report import Report
-from WMCore.WMExceptions        import WM_JOB_ERROR_CODES
+from WMCore.WMExceptions import WM_JOB_ERROR_CODES
 
 
 class BossAirException(WMException):
@@ -44,8 +44,6 @@ class BossAirAPI(WMConnectionBase):
 
     The API layer for the BossAir prototype
     """
-
-
 
     def __init__(self, config, noSetup=False):
         """
@@ -98,9 +96,7 @@ class BossAirAPI(WMConnectionBase):
 
         return
 
-
-
-    def loadPlugin(self, noSetup = False):
+    def loadPlugin(self, noSetup=False):
         """
         _loadPlugin_
 
@@ -115,10 +111,8 @@ class BossAirAPI(WMConnectionBase):
             for state in self.plugins[name].states:
                 states.add(state)
 
-        states = list(states)
-
-        if not self.newState in states:
-            states.append(self.newState)
+        if self.newState not in states:
+            states.add(self.newState)
 
         if not noSetup:
             # Add states only if we're not
@@ -129,7 +123,6 @@ class BossAirAPI(WMConnectionBase):
 
         return
 
-
     def addStates(self, states):
         """
         _addStates_
@@ -138,12 +131,10 @@ class BossAirAPI(WMConnectionBase):
         """
         existingTransaction = self.beginTransaction()
 
-
         self.stateDAO.execute(states=states, conn=self.getDBConn(),
                               transaction=self.existingTransaction())
 
         self.commitTransaction(existingTransaction)
-
 
         return
 
@@ -167,7 +158,6 @@ class BossAirAPI(WMConnectionBase):
                 runJob['status'] = self.newState
             jobsToCreate.append(runJob)
 
-
         # Next insert them into the database
         self.newJobDAO.execute(jobs=jobsToCreate, conn=self.getDBConn(),
                                transaction=self.existingTransaction())
@@ -175,7 +165,6 @@ class BossAirAPI(WMConnectionBase):
         self.commitTransaction(existingTransaction)
 
         return
-
 
     def _listRunJobs(self, active=True):
         """
@@ -198,7 +187,6 @@ class BossAirAPI(WMConnectionBase):
             runJobs.append(rj)
 
         return runJobs
-
 
     def _loadByStatus(self, status, complete='1'):
         """
@@ -224,7 +212,6 @@ class BossAirAPI(WMConnectionBase):
             statusJobs.append(rj)
 
         return statusJobs
-
 
     def _loadByID(self, jobs):
         """
@@ -257,11 +244,10 @@ class BossAirAPI(WMConnectionBase):
 
         existingTransaction = self.beginTransaction()
 
-
         self.updateDAO.execute(jobs=jobs, conn=self.getDBConn(),
                                transaction=self.existingTransaction())
 
-        jobsWithLocation = filter(lambda x: x.get('location') is not None, jobs)
+        jobsWithLocation = [job for job in jobs if job.get('location') is not None]
         if jobsWithLocation:
             self.stateMachine.recordLocationChange(jobsWithLocation)
 
@@ -289,7 +275,6 @@ class BossAirAPI(WMConnectionBase):
 
         self.commitTransaction(existingTransaction)
 
-
         return
 
     def loadByWMBS(self, wmbsJobs):
@@ -311,7 +296,7 @@ class BossAirAPI(WMConnectionBase):
             rj.update(job)
             loadedJobs.append(rj)
 
-        if not len(loadedJobs) == len(wmbsJobs):
+        if len(loadedJobs) != len(wmbsJobs):
             logging.error("Mismatch in WMBS load: Some requested jobs not found!")
             idList = [x['jobid'] for x in loadedJobs]
             for job in wmbsJobs:
@@ -346,8 +331,6 @@ class BossAirAPI(WMConnectionBase):
 
         return
 
-
-
     def submit(self, jobs, info=None):
         """
         _submit_
@@ -379,18 +362,18 @@ class BossAirAPI(WMConnectionBase):
             runJobs.append(rj)
             # Can't add to the cache in submit()
             # It's NOT the same bossAir instance
-            #self.jobs.append(rj)
+            # self.jobs.append(rj)
 
         # Now figure out which plugin we need
         pluginDict = {}
         for job in runJobs:
             plugin = job['plugin']
-            if not plugin in pluginDict.keys():
+            if plugin not in pluginDict.keys():
                 pluginDict[plugin] = []
             pluginDict[plugin].append(job)
 
         for plugin in pluginDict.keys():
-            if not plugin in self.plugins.keys():
+            if plugin not in self.plugins.keys():
                 # Then we have a non-existant plugin
                 msg = "CRITICAL ERROR: Non-existant plugin!\n"
                 msg += "Given a plugin %s that we don't have access to.\n" % (plugin)
@@ -432,8 +415,6 @@ class BossAirAPI(WMConnectionBase):
 
         return successJobs, failureJobs
 
-
-
     def track(self, runJobIDs=None, wmbsIDs=None):
         """
         _track_
@@ -456,11 +437,11 @@ class BossAirAPI(WMConnectionBase):
 
         if runJobIDs:
             for job in runningJobs:
-                if not job['id'] in runJobIDs:
+                if job['id'] not in runJobIDs:
                     runningJobs.remove(job)
         if wmbsIDs:
             for job in runningJobs:
-                if not job['jobid'] in wmbsIDs:
+                if job['jobid'] not in wmbsIDs:
                     runningJobs.remove(job)
 
         if len(runningJobs) < 1:
@@ -475,12 +456,12 @@ class BossAirAPI(WMConnectionBase):
 
         for runningJob in loadedJobs:
             plugin = runningJob['plugin']
-            if not plugin in jobsToTrack.keys():
+            if plugin not in jobsToTrack.keys():
                 jobsToTrack[plugin] = []
             jobsToTrack[plugin].append(runningJob)
 
         for plugin in jobsToTrack.keys():
-            if not plugin in self.plugins.keys():
+            if plugin not in self.plugins.keys():
                 msg = "Jobs tracking with non-existant plugin %s\n" % (plugin)
                 msg += "They were submitted but can't be tracked?\n"
                 msg += "That's too strange to continue\n"
@@ -494,7 +475,8 @@ class BossAirAPI(WMConnectionBase):
                 jobsToReturn.extend(localRunning)
                 jobsToChange.extend(localChanges)
                 jobsToComplete.extend(localCompletes)
-                logging.info("Executing/changing/completing %i/%i/%i jobs in plugin %s.", len(localRunning), len(localChanges), len(localCompletes), plugin)
+                logging.info("Executing/changing/completing %i/%i/%i jobs in plugin %s.", len(localRunning),
+                             len(localChanges), len(localCompletes), plugin)
             except WMException:
                 raise
             except Exception as ex:
@@ -511,7 +493,6 @@ class BossAirAPI(WMConnectionBase):
 
         self._updateJobs(jobs=jobsToChange)
         self._complete(jobs=jobsToComplete)
-
 
         # We should have a globalState variable for changed jobs
         # from the plugin
@@ -537,7 +518,7 @@ class BossAirAPI(WMConnectionBase):
         jobsToComplete = {}
 
         for job in jobs:
-            if not job['plugin'] in jobsToComplete.keys():
+            if job['plugin'] not in jobsToComplete.keys():
                 jobsToComplete[job['plugin']] = []
             jobsToComplete[job['plugin']].append(job)
 
@@ -560,7 +541,6 @@ class BossAirAPI(WMConnectionBase):
 
         return
 
-
     def _completeKill(self, jobs):
         """
         __completeKill_
@@ -580,7 +560,6 @@ class BossAirAPI(WMConnectionBase):
 
         return
 
-
     def getComplete(self):
         """
         _getComplete_
@@ -599,7 +578,6 @@ class BossAirAPI(WMConnectionBase):
 
         return completeJobs
 
-
     def removeComplete(self, jobs):
         """
         _removeComplete_
@@ -615,8 +593,6 @@ class BossAirAPI(WMConnectionBase):
         self._deleteJobs(jobs=jobsToRemove)
 
         return
-
-
 
     def kill(self, jobs, workflowName=None, killMsg=None, errorCode=71300):
         """
@@ -643,12 +619,12 @@ class BossAirAPI(WMConnectionBase):
 
         for runningJob in loadedJobs:
             plugin = runningJob['plugin']
-            if not plugin in jobsToKill.keys():
+            if plugin not in jobsToKill.keys():
                 jobsToKill[plugin] = []
             jobsToKill[plugin].append(runningJob)
 
         for plugin in jobsToKill.keys():
-            if not plugin in self.plugins.keys():
+            if plugin not in self.plugins.keys():
                 msg = "Jobs tracking with non-existant plugin %s\n" % (plugin)
                 msg += "They were submitted but can't be tracked?\n"
                 msg += "That's too strange to continue\n"
@@ -664,7 +640,7 @@ class BossAirAPI(WMConnectionBase):
                         pluginInst.kill(jobs=jobsToKill[plugin])
                     # Register the killed jobs
                     for job in jobsToKill[plugin]:
-                        if job.get('cache_dir', None) == None or job.get('retry_count', None) == None:
+                        if job.get('cache_dir') is None or job.get('retry_count') is None:
                             continue
                         # Try to save an error report as the jobFWJR
                         if not os.path.isdir(job['cache_dir']):
@@ -701,7 +677,6 @@ class BossAirAPI(WMConnectionBase):
                     self._completeKill(jobs=jobsToKill[plugin])
         return
 
-
     def update(self, jobs):
         """
         _update_
@@ -715,8 +690,6 @@ class BossAirAPI(WMConnectionBase):
         self._updateJobs(jobs=runJobs)
 
         return
-
-
 
     def monitor(self, commonState=True):
         """
@@ -795,12 +768,11 @@ class BossAirAPI(WMConnectionBase):
             for key in runJob.keys():
                 # Fill one from the other
                 # runJob, being most recent, should be on top
-                if runJob[key] == None:
+                if runJob[key] is None:
                     runJob[key] = loadJob.get(key, None)
             finalJobs.append(runJob)
 
         return finalJobs
-
 
     def _buildRunningJobs(self, wmbsJobs):
         """
@@ -824,7 +796,7 @@ class BossAirAPI(WMConnectionBase):
                     rj.buildFromJob(wmbsJob)
                     rj['id'] = runJob['id']
                     for key in rj.keys():
-                        if rj[key] == None:
+                        if rj[key] is None:
                             rj[key] = runJob.get(key, None)
                     finalJobs.append(rj)
                     break
@@ -832,8 +804,8 @@ class BossAirAPI(WMConnectionBase):
             # It means that although we sent for it, we couldn't find it.
             # Possibly means that the job just isn't in there yet.
             # Make a note of it, then do nothing
-            logging.debug("Could not successfully load a runJob for wmbsJob %i:%i\n", wmbsJob['id'], wmbsJob['retry_count'])
+            logging.debug("Could not successfully load a runJob for wmbsJob %i:%i\n", wmbsJob['id'],
+                          wmbsJob['retry_count'])
             logging.debug("WMBS Job: %s\n", wmbsJob)
-
 
         return finalJobs

--- a/src/python/WMCore/BossAir/MySQL/Create.py
+++ b/src/python/WMCore/BossAir/MySQL/Create.py
@@ -8,10 +8,8 @@ from __future__ import print_function
 import threading
 
 from WMCore.Database.DBCreator import DBCreator
-
 from WMCore.WMException import WMException
-from WMCore.WMExceptions import WMEXCEPTION
-from WMCore.JobStateMachine.ChangeState import Transitions
+
 
 class Create(DBCreator):
     """
@@ -19,7 +17,7 @@ class Create(DBCreator):
 
     """
 
-    def __init__(self, logger = None, dbi = None, params = None):
+    def __init__(self, logger=None, dbi=None, params=None):
         """
         _init_
 
@@ -27,9 +25,9 @@ class Create(DBCreator):
         """
         myThread = threading.currentThread()
 
-        if logger == None:
+        if logger is None:
             logger = myThread.logger
-        if dbi == None:
+        if dbi is None:
             dbi = myThread.dbi
 
         tablespaceIndex = ""
@@ -41,59 +39,56 @@ class Create(DBCreator):
 
         self.requiredTables = ["01bl_status", "02bl_runjob"]
 
-
         self.create['01bl_status'] = \
-        """CREATE TABLE bl_status
-            (
-            id            INT  auto_increment,
-            name          VARCHAR(255),
-            PRIMARY KEY (id),
-            UNIQUE (name)
-            )
-            ENGINE = InnoDB DEFAULT CHARSET=latin1;
-        """
-
+            """CREATE TABLE bl_status
+                (
+                id            INT  auto_increment,
+                name          VARCHAR(255),
+                PRIMARY KEY (id),
+                UNIQUE (name)
+                )
+                ENGINE = InnoDB DEFAULT CHARSET=latin1;
+            """
 
         self.create['02bl_runjob'] = \
-        """CREATE TABLE bl_runjob
-           (
-           id            INT   auto_increment,
-           wmbs_id       INT,
-           grid_id       VARCHAR(255),
-           bulk_id       VARCHAR(255),
-           status        CHAR(1)   DEFAULT '1',
-           sched_status  INT NOT NULL,
-           retry_count   INT,
-           status_time   INT,
-           location      INT,
-           user_id       INT,
-           PRIMARY KEY (id),
-           FOREIGN KEY (wmbs_id) REFERENCES wmbs_job(id) ON DELETE CASCADE,
-           FOREIGN KEY (sched_status) REFERENCES bl_status(id),
-           FOREIGN KEY (user_id) REFERENCES wmbs_users(id) ON DELETE CASCADE,
-           FOREIGN KEY (location) REFERENCES wmbs_location(id) ON DELETE CASCADE,
-           UNIQUE (retry_count, wmbs_id)
-           )
-           ENGINE = InnoDB DEFAULT CHARSET=latin1;
+            """CREATE TABLE bl_runjob
+               (
+               id            INT   auto_increment,
+               wmbs_id       INT,
+               grid_id       VARCHAR(255),
+               bulk_id       VARCHAR(255),
+               status        CHAR(1)   DEFAULT '1',
+               sched_status  INT NOT NULL,
+               retry_count   INT,
+               status_time   INT,
+               location      INT,
+               user_id       INT,
+               PRIMARY KEY (id),
+               FOREIGN KEY (wmbs_id) REFERENCES wmbs_job(id) ON DELETE CASCADE,
+               FOREIGN KEY (sched_status) REFERENCES bl_status(id),
+               FOREIGN KEY (user_id) REFERENCES wmbs_users(id) ON DELETE CASCADE,
+               FOREIGN KEY (location) REFERENCES wmbs_location(id) ON DELETE CASCADE,
+               UNIQUE (retry_count, wmbs_id)
+               )
+               ENGINE = InnoDB DEFAULT CHARSET=latin1;
 
-        """
+            """
 
         self.constraints["01_idx_bl_runjob"] = \
-          """CREATE INDEX idx_bl_runjob_wmbs ON bl_runjob(wmbs_id) %s""" % tablespaceIndex
+            """CREATE INDEX idx_bl_runjob_wmbs ON bl_runjob(wmbs_id) %s""" % tablespaceIndex
 
         self.constraints["02_idx_bl_runjob"] = \
-          """CREATE INDEX idx_bl_runjob_status ON bl_runjob(sched_status) %s""" % tablespaceIndex
+            """CREATE INDEX idx_bl_runjob_status ON bl_runjob(sched_status) %s""" % tablespaceIndex
 
         self.constraints["03_idx_bl_runjob"] = \
-          """CREATE INDEX idx_bl_runjob_users ON bl_runjob(user_id) %s""" % tablespaceIndex
+            """CREATE INDEX idx_bl_runjob_users ON bl_runjob(user_id) %s""" % tablespaceIndex
 
         self.constraints["04_idx_bl_runjob"] = \
-          """CREATE INDEX idx_bl_runjob_location ON bl_runjob(location) %s""" % tablespaceIndex
+            """CREATE INDEX idx_bl_runjob_location ON bl_runjob(location) %s""" % tablespaceIndex
 
         return
 
-
-    def execute(self, conn = None, transaction = None):
+    def execute(self, conn=None, transaction=None):
         """
         _execute_
 

--- a/src/python/WMCore/BossAir/MySQL/Create.py
+++ b/src/python/WMCore/BossAir/MySQL/Create.py
@@ -62,7 +62,7 @@ class Create(DBCreator):
            grid_id       VARCHAR(255),
            bulk_id       VARCHAR(255),
            status        CHAR(1)   DEFAULT '1',
-           sched_status  INT,
+           sched_status  INT NOT NULL,
            retry_count   INT,
            status_time   INT,
            location      INT,

--- a/src/python/WMCore/BossAir/Oracle/Create.py
+++ b/src/python/WMCore/BossAir/Oracle/Create.py
@@ -77,7 +77,7 @@ class Create(DBCreator):
            grid_id       VARCHAR(255),
            bulk_id       VARCHAR(255),
            status        CHAR(1)   DEFAULT '1',
-           sched_status  INTEGER,
+           sched_status  INTEGER NOT NULL,
            retry_count   INTEGER,
            status_time   INTEGER,
            location      INTEGER,

--- a/src/python/WMCore/BossAir/Oracle/Create.py
+++ b/src/python/WMCore/BossAir/Oracle/Create.py
@@ -8,44 +8,38 @@ from __future__ import print_function
 import threading
 
 from WMCore.Database.DBCreator import DBCreator
-
 from WMCore.WMException import WMException
-from WMCore.WMExceptions import WMEXCEPTION
-from WMCore.JobStateMachine.ChangeState import Transitions
+
 
 class Create(DBCreator):
     """
     This should create the BossAir schema; since they don't do it.
 
     """
-    sequence_tables = [ 'bl_runjob', 'bl_status' ]
+    sequence_tables = ['bl_runjob', 'bl_status']
 
-    def __init__(self, logger = None, dbi = None, params = None):
+    def __init__(self, logger=None, dbi=None, params=None):
         """
         _init_
 
         Call the DBCreator constructor and create the list of required tables.
         """
 
-
-
         myThread = threading.currentThread()
 
-        if logger == None:
+        if logger is None:
             logger = myThread.logger
-        if dbi == None:
+        if dbi is None:
             dbi = myThread.dbi
-
 
         DBCreator.__init__(self, logger, dbi)
 
         tablespaceTable = ""
         tablespaceIndex = ""
 
-        self.create          = {}
-        self.constraints     = {}
-        self.indexes         = {}
-
+        self.create = {}
+        self.constraints = {}
+        self.indexes = {}
 
         if params:
             if "tablespace_table" in params:
@@ -53,44 +47,40 @@ class Create(DBCreator):
             if "tablespace_index" in params:
                 tablespaceIndex = "USING INDEX TABLESPACE %s" % params["tablespace_index"]
 
-
-
         self.requiredTables = ["01bl_status", "02bl_runjob"]
 
         self.sequence_tables = []
         self.sequence_tables.append("bl_status")
         self.sequence_tables.append("bl_runjob")
 
-
         self.create['01bl_status'] = \
-        """CREATE TABLE bl_status (
-            id            INTEGER  NOT NULL,
-            name          VARCHAR(255)
-            ) %s  """ % (tablespaceTable)
-
+            """CREATE TABLE bl_status (
+                id            INTEGER  NOT NULL,
+                name          VARCHAR(255)
+                ) %s  """ % (tablespaceTable)
 
         self.create['02bl_runjob'] = \
-        """CREATE TABLE bl_runjob
-           (
-           id            INTEGER NOT NULL,
-           wmbs_id       INTEGER,
-           grid_id       VARCHAR(255),
-           bulk_id       VARCHAR(255),
-           status        CHAR(1)   DEFAULT '1',
-           sched_status  INTEGER NOT NULL,
-           retry_count   INTEGER,
-           status_time   INTEGER,
-           location      INTEGER,
-           user_id       INTEGER
-           ) %s  """ % (tablespaceTable)
+            """CREATE TABLE bl_runjob
+               (
+               id            INTEGER NOT NULL,
+               wmbs_id       INTEGER,
+               grid_id       VARCHAR(255),
+               bulk_id       VARCHAR(255),
+               status        CHAR(1)   DEFAULT '1',
+               sched_status  INTEGER NOT NULL,
+               retry_count   INTEGER,
+               status_time   INTEGER,
+               location      INTEGER,
+               user_id       INTEGER
+               ) %s  """ % (tablespaceTable)
 
         self.indexes["01_pk_bl_status"] = \
-          """ALTER TABLE bl_status ADD
-               (CONSTRAINT bl_status_pk PRIMARY KEY (id) %s)""" % tablespaceIndex
+            """ALTER TABLE bl_status ADD
+                 (CONSTRAINT bl_status_pk PRIMARY KEY (id) %s)""" % tablespaceIndex
 
         self.indexes["02_pk_bl_runjob"] = \
-          """ALTER TABLE bl_runjob ADD
-               (CONSTRAINT bl_runjob_pk PRIMARY KEY (id) %s)""" % tablespaceIndex
+            """ALTER TABLE bl_runjob ADD
+                 (CONSTRAINT bl_runjob_pk PRIMARY KEY (id) %s)""" % tablespaceIndex
 
         self.constraints["01_fk_bl_runjob"] = \
             """ALTER TABLE bl_runjob ADD
@@ -98,7 +88,7 @@ class Create(DBCreator):
                REFERENCES wmbs_job(id) ON DELETE CASCADE)"""
 
         self.constraints["01_idx_bl_runjob"] = \
-          """CREATE INDEX idx_bl_runjob_wmbs ON bl_runjob(wmbs_id) %s""" % tablespaceIndex
+            """CREATE INDEX idx_bl_runjob_wmbs ON bl_runjob(wmbs_id) %s""" % tablespaceIndex
 
         self.constraints["02_fk_bl_runjob"] = \
             """ALTER TABLE bl_runjob ADD
@@ -106,7 +96,7 @@ class Create(DBCreator):
                REFERENCES bl_status(id) ON DELETE CASCADE)"""
 
         self.constraints["02_idx_bl_runjob"] = \
-          """CREATE INDEX idx_bl_runjob_status ON bl_runjob(sched_status) %s""" % tablespaceIndex
+            """CREATE INDEX idx_bl_runjob_status ON bl_runjob(sched_status) %s""" % tablespaceIndex
 
         self.constraints["03_fk_bl_runjob"] = \
             """ALTER TABLE bl_runjob ADD
@@ -114,7 +104,7 @@ class Create(DBCreator):
                REFERENCES wmbs_users(id) ON DELETE CASCADE)"""
 
         self.constraints["03_idx_bl_runjob"] = \
-          """CREATE INDEX idx_bl_runjob_users ON bl_runjob(user_id) %s""" % tablespaceIndex
+            """CREATE INDEX idx_bl_runjob_users ON bl_runjob(user_id) %s""" % tablespaceIndex
 
         self.constraints["04_fk_bl_runjob"] = \
             """ALTER TABLE bl_runjob ADD
@@ -122,21 +112,18 @@ class Create(DBCreator):
                REFERENCES wmbs_location(id) ON DELETE CASCADE)"""
 
         self.constraints["04_idx_bl_runjob"] = \
-          """CREATE INDEX idx_bl_runjob_location ON bl_runjob(location) %s""" % tablespaceIndex
-
+            """CREATE INDEX idx_bl_runjob_location ON bl_runjob(location) %s""" % tablespaceIndex
 
         j = 50
         for i in self.sequence_tables:
             seqname = '%s_SEQ' % i
             self.create["%s%s" % (j, seqname)] = \
-              "CREATE SEQUENCE %s start with 1 increment by 1 nomaxvalue cache 100" \
-              % seqname
-
+                "CREATE SEQUENCE %s start with 1 increment by 1 nomaxvalue cache 100" \
+                % seqname
 
         return
 
-
-    def execute(self, conn = None, transaction = None):
+    def execute(self, conn=None, transaction=None):
         """
         _execute_
 

--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -15,8 +15,8 @@ import time
 import classad
 import htcondor
 
-import WMCore.Algorithms.BasicAlgos as BasicAlgos
 from Utils.IteratorTools import convertFromUnicodeToStr, grouper
+import WMCore.Algorithms.BasicAlgos as BasicAlgos
 from WMCore.BossAir.Plugins.BasePlugin import BasePlugin
 from WMCore.Credential.Proxy import Proxy
 from WMCore.DAOFactory import DAOFactory
@@ -348,16 +348,16 @@ class SimpleCondorPlugin(BasePlugin):
                     extDesiredList.remove(siteName)
 
                 # now put it back in the string format expected by condor
-                desiredList = ",".join(desiredList)
-                extDesiredList = ",".join(extDesiredList)
+                desiredListStr = ",".join(desiredList)
+                extDesiredListStr = ",".join(extDesiredList)
 
                 try:
                     sd.edit('DESIRED_Sites =?= %s && ExtDESIRED_Sites =?= %s' % (classad.quote(siteStrings[0]),
                                                                                  classad.quote(siteStrings[1])),
-                            "DESIRED_Sites", classad.quote(str(desiredList)))
+                            "DESIRED_Sites", classad.quote(str(desiredListStr)))
                     sd.edit('DESIRED_Sites =?= %s && ExtDESIRED_Sites =?= %s' % (classad.quote(siteStrings[0]),
                                                                                  classad.quote(siteStrings[1])),
-                            "ExtDESIRED_Sites", classad.quote(str(extDesiredList)))
+                            "ExtDESIRED_Sites", classad.quote(str(extDesiredListStr)))
                 except RuntimeError as ex:
                     msg = 'Failed to condor edit job sites. Could be that no jobs were in condor anymore: %s' % str(ex)
                     logging.warning(msg)
@@ -576,7 +576,7 @@ class SimpleCondorPlugin(BasePlugin):
             # If the job is running, then we should report the matched CPUs in RequestCpus - but only if there are sane
             # values.  Otherwise, we just report the original CPU request
             ad['JobCpus'] = classad.ExprTree('((JobStatus =!= 1) && (JobStatus =!= 5) && !isUndefined(MATCH_EXP_JOB_GLIDEIN_Cpus) '
-                                              '&& (int(MATCH_EXP_JOB_GLIDEIN_Cpus) isnt error)) ? int(MATCH_EXP_JOB_GLIDEIN_Cpus) : OriginalCpus')
+                                             '&& (int(MATCH_EXP_JOB_GLIDEIN_Cpus) isnt error)) ? int(MATCH_EXP_JOB_GLIDEIN_Cpus) : OriginalCpus')
 
             # Cpus is taken from the machine ad - hence it is only defined when we are doing negotiation.
             # Otherwise, we use either the cores in the running job (if available) or the original cores.

--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -36,6 +36,7 @@ class SimpleCondorPlugin(BasePlugin):
         """
         For a given condor status mapped, return a global state used by the agent
         NOTE: these keys are populated into bl_status table.
+        NOTE2: Timeout must be present in all future plugins (New is recommended too)
         """
         stateMap = {'New': 'Pending',
                     'Idle': 'Pending',
@@ -45,6 +46,7 @@ class SimpleCondorPlugin(BasePlugin):
                     'Held': 'Error',
                     'TransferOutput': 'Running',
                     'Suspended': 'Error',
+                    'Timeout': 'Error',
                     'Unknown': 'Error'}
 
         return stateMap


### PR DESCRIPTION
Fixes #7670 , which is basically that Timeout line in SimpleCondorPlugin.
However, I also removed the begin/end transaction from all get/select methods in BossAir.
In addition to that, we better have this protection in that table for the future plugins to come :)

@ticoann please review after unittests are finished (I still have to test it btw)
