### PR TITLE
Allow different PrepID in StepChains

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -436,6 +436,10 @@ class StdBase(object):
 
             procTaskCmsswHelper.setDataProcessingConfig(scenarioName, scenarioFunc,
                                                         **scenarioArgs)
+        # only in the very end, in order to get it in for the children tasks as well
+        prepID = taskConf.get("PrepID") or self.prepID
+        procTask.setPrepID(prepID)
+
         return outputModules
 
     def _getDictionaryParams(self, prop, key, default=None):
@@ -662,6 +666,11 @@ class StdBase(object):
                                    periodic_harvest_interval=self.periodicHarvestInterval,
                                    doLogCollect=doLogCollect,
                                    dqmHarvestUnit=self.dqmHarvestUnit)
+
+        # only in the very end, in order to get it in for the children tasks as well
+        prepID = taskConf.get("PrepID") or parentTask.getPrepID()
+        mergeTask.setPrepID(prepID)
+
         return mergeTask
 
     def addCleanupTask(self, parentTask, parentOutputModuleName, forceTaskName=None):
@@ -684,6 +693,10 @@ class StdBase(object):
         cleanupStep = cleanupTask.makeStep("cleanupUnmerged%s" % parentOutputModuleName)
         cleanupStep.setStepType("DeleteFiles")
         cleanupTask.applyTemplates()
+
+        # TODO: for StepChain, it will still use the Step1 PrepID. It has to be fixed
+        cleanupTask.setPrepID(parentTask.getPrepID())
+
         return
 
     def addDQMHarvestTask(self, parentTask, parentOutputModuleName, uploadProxy=None,


### PR DESCRIPTION
It was setting PrepID - though using the workload level only - before my recent changes accepting Step level assignment. With those changes, it was not even setting that :(

This should fix this issue for good and properly set different PrepIDs if they were set inside a Step dict. 

There is one fix though for Cleanup task, which right now inherits PrepID from the production/processing job. I'll have to add the same `taskConf` parameter over there, I just don't want to do this at this stage of the validation.

I'll start running a few workflows soon, to make sure it doesn't break anything else.