### PR TITLE
Reorganize imports

### DIFF
--- a/src/python/WMCore/ReqMgr/Tools/cms.py
+++ b/src/python/WMCore/ReqMgr/Tools/cms.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python
-#-*- coding: utf-8 -*-
-#pylint: disable=
+# encoding: utf-8
+
 """
 File       : cms.py
 Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
 Description: CMS modules
 """
+
 from __future__ import (division, print_function)
 
-# system modules
 from WMCore.Cache.GenericDataCache import MemoryCacheStruct
-# CMS modules
 from WMCore.ReqMgr.DataStructs.RequestStatus import REQUEST_STATE_LIST, REQUEST_STATE_TRANSITION
 from WMCore.Services.SiteDB.SiteDB import SiteDBJSON
 from WMCore.Services.TagCollector.TagCollector import TagCollector

--- a/src/python/WMCore/Services/TagCollector/XMLUtils.py
+++ b/src/python/WMCore/Services/TagCollector/XMLUtils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-#-*- coding: utf-8 -*-
-#pylint: disable=
+# encoding: utf-8
+
 """
 File       : XMLUtils.py
 Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
@@ -8,9 +8,9 @@ Description: Set of utilities for RequestManager code
 """
 
 from __future__ import (division, print_function)
-# system modules
-import re
+
 import cStringIO as StringIO
+import re
 import xml.etree.cElementTree as ET
 
 int_number_pattern = re.compile(r'(^[0-9-]$|^[0-9-][0-9]*$)')

--- a/src/python/WMQuality/Emulators/DBSClient/MockDbsApi.py
+++ b/src/python/WMQuality/Emulators/DBSClient/MockDbsApi.py
@@ -1,4 +1,5 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
+
 """
 Version of dbsClient.dbsApi intended to be used with mock or unittest.mock
 """

--- a/src/python/WMQuality/Emulators/PhEDExClient/MockPhEDExApi.py
+++ b/src/python/WMQuality/Emulators/PhEDExClient/MockPhEDExApi.py
@@ -1,4 +1,5 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
+
 """
 Version of Services/PhEDEx intended to be used with mock or unittest.mock
 Parts of this code are cribbed directly from


### PR DESCRIPTION
Each of these files original format surrounding imports, docstrings, and comments caused the futurize program to put new imports in the wrong place breaking the code. 