### PR TITLE
Don't sort list each iteration in FileBased splitting

### DIFF
--- a/src/python/WMCore/JobSplitting/FileBased.py
+++ b/src/python/WMCore/JobSplitting/FileBased.py
@@ -61,7 +61,7 @@ class FileBased(JobFactory):
                     ## Do average event per lumi calculation.
                     f['avgEvtsPerLumi'] = round(float(f['events']) / f['lumiCount'])
                 newlist.append(f)
-                locationDict[key] = sorted(newlist, key = lambda f: f['lfn'])
+            locationDict[key] = sorted(newlist, key = lambda f: f['lfn'])
 
         ## Make a list with all the files, sorting them by LFN. Remove from the list all
         ## the files filtered out by the lumi-mask (if there is one).


### PR DESCRIPTION
Looks like I've discovered a minor bug which has a big performance impact for the CRAB TaskWorker component when processing large datasets (one dataset which has 160k files hangs a child process for hours). AFAICT, it makes no sense to sort the lfn list after each lfn addition.