### PR TITLE
Remove duplicate logic.

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
@@ -270,10 +270,10 @@ class PyCondorPlugin(BasePlugin):
         if self.serverCert and self.serverKey and self.myproxySrv:
             self.proxy = self.setupMyProxy()
 
-        # Build a request string
-        self.reqStr = ('(OpSys == "LINUX" ) && (Arch == "INTEL" || Arch == "X86_64") '
-                       '&& stringListMember(GLIDEIN_CMSSite, DESIRED_Sites) '
-                       '&& ((REQUIRED_OS=="any") || stringListMember(GLIDEIN_REQUIRED_OS, REQUIRED_OS))')
+        # See notes about this in SimpleCondorPlugin.  TODO(bbockelm): remove once HLT is upgraded.
+        self.reqStr = ('(REQUIRED_OS=?="any") || '
+                       '(GLIDEIN_REQUIRED_OS=?="any") || '
+                       'stringListMember(GLIDEIN_REQUIRED_OS, REQUIRED_OS)')
         if hasattr(config.BossAir, 'condorRequirementsString'):
             self.reqStr = config.BossAir.condorRequirementsString
 
@@ -769,7 +769,8 @@ class PyCondorPlugin(BasePlugin):
         #    avoid condorg submission errors from > 256 character pathnames
 
         jdl.append("universe = vanilla\n")
-        jdl.append("requirements = %s\n" % self.reqStr)
+        if self.reqStr:
+            jdl.append("requirements = %s\n" % self.reqStr)
 
         jdl.append("should_transfer_files = YES\n")
         jdl.append("when_to_transfer_output = ON_EXIT\n")

--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -102,10 +102,13 @@ class SimpleCondorPlugin(BasePlugin):
         self.acctGroup = getattr(config.BossAir, 'acctGroup', "production")
         self.acctGroupUser = getattr(config.BossAir, 'acctGroupUser', "cmsdataops")
 
-        # Build a requirement string
-        self.reqStr = ('stringListMember(GLIDEIN_CMSSite, DESIRED_Sites) '
-                       '&& ((REQUIRED_OS=?="any") || stringListMember(GLIDEIN_REQUIRED_OS, REQUIRED_OS))'
-                       '&& (TARGET.Cpus >= RequestCpus)')
+        # Build a requirement string.  All CMS resources match DESIRED_Sites on the START
+        # expression side; however, there are currently some resources (T2_CH_CERN_HLT)
+        # that are missing the REQUIRED_OS logic.  Hence, we duplicate it here.
+        # TODO(bbockelm): Remove reqStr once HLT has upgraded.
+        self.reqStr = ('((REQUIRED_OS=?="any") || '
+                       '(GLIDEIN_REQUIRED_OS =?= "any") || '
+                       'stringListMember(GLIDEIN_REQUIRED_OS, REQUIRED_OS))')
         if hasattr(config.BossAir, 'condorRequirementsString'):
             self.reqStr = config.BossAir.condorRequirementsString
 
@@ -441,7 +444,8 @@ class SimpleCondorPlugin(BasePlugin):
         ad = classad.ClassAd()
 
         # ad['universe'] = "vanilla"
-        ad['Requirements'] = classad.ExprTree(self.reqStr)
+        if self.reqStr:
+            ad['Requirements'] = classad.ExprTree(self.reqStr)
         ad['ShouldTransferFiles'] = "YES"
         ad['WhenToTransferOutput'] = "ON_EXIT"
         ad['UserLogUseXML'] = True


### PR DESCRIPTION
Except for `REQUIRED_OS`, the same Requirements logic is currently in both HTCondor `startd`s and WMAgent.  Remove the logic from the agent so we can make changes from a single place.

For `REQUIRED_OS`, we keep the logic but:
- Left a TODO to remove it once `T2_CH_CERN_HLT` has made the corresponding
  change.
- Add support for `GLIDEIN_REQUIRED_OS="any"` (for pilots that use singularity).

@ericvaandering @hufnagel @amaltaro - please note, as you've been doing `REQUIRED_OS` work recently.