### PR TITLE
Completely replace CouchURL by ConfigCacheUrl

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/DQMHarvest.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/DQMHarvest.py
@@ -56,17 +56,14 @@ class DQMHarvestWorkloadFactory(StdBase):
             msg = "DQMConfigCacheID parameter has not been provided in the request"
             raise WMSpecFactoryException(message=msg)
 
-        couchUrl = schema.get("ConfigCacheUrl", None)
         self.validateConfigCacheExists(configID=schema["DQMConfigCacheID"],
-                                       couchURL=couchUrl,
+                                       configCacheUrl=schema['ConfigCacheUrl'],
                                        couchDBName=schema["CouchDBName"],
                                        getOutputModules=False)
 
     @staticmethod
     def getWorkloadArguments():
         baseArgs = StdBase.getWorkloadArguments()
-        reqMgrArgs = StdBase.getWorkloadArgumentsWithReqMgr()
-        baseArgs.update(reqMgrArgs)
         specArgs = {"RequestType": {"default": "DQMHarvest"},
                     "InputDataset": {"default": None, "optional": False,
                                      "validate": dataset},
@@ -150,10 +147,7 @@ class DQMHarvestWorkloadFactory(StdBase):
                                           dqmHarvestUnit=dqmHarvestUnit)
 
         if self.dqmConfigCacheID is not None:
-            if getattr(self, "configCacheUrl", None) is not None:
-                harvestTaskCmsswHelper.setConfigCache(self.configCacheUrl, self.dqmConfigCacheID, self.couchDBName)
-            else:
-                harvestTaskCmsswHelper.setConfigCache(self.couchURL, self.dqmConfigCacheID, self.couchDBName)
+            harvestTaskCmsswHelper.setConfigCache(self.configCacheUrl, self.dqmConfigCacheID, self.couchDBName)
             harvestTaskCmsswHelper.setDatasetName(self.inputDataset)
         else:
             scenarioArgs = {'globalTag': self.globalTag,

--- a/src/python/WMCore/WMSpec/StdSpecs/DataProcessing.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/DataProcessing.py
@@ -38,8 +38,6 @@ class DataProcessing(StdBase):
     @staticmethod
     def getWorkloadArguments():
         baseArgs = StdBase.getWorkloadArguments()
-        reqMgrArgs = StdBase.getWorkloadArgumentsWithReqMgr()
-        baseArgs.update(reqMgrArgs)
         specArgs = {"InputDataset" : {"default" : "/MinimumBias/ComissioningHI-v1/RAW", "type" : str,
                                       "optional" : False, "validate" : dataset,
                                       "attr" : "inputDataset", "null" : False},

--- a/src/python/WMCore/WMSpec/StdSpecs/MonteCarlo.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/MonteCarlo.py
@@ -46,7 +46,6 @@ class MonteCarloWorkloadFactory(StdBase):
         prodTask = workload.newTask("Production")
 
         outputMods = self.setupProcessingTask(prodTask, "Production", None,
-                                              couchURL=self.couchURL,
                                               couchDBName=self.couchDBName,
                                               configDoc=self.configCacheID,
                                               splitAlgo=self.prodJobSplitAlgo,
@@ -61,7 +60,7 @@ class MonteCarloWorkloadFactory(StdBase):
         if self.pileupConfig:
             self.setupPileup(prodTask, self.pileupConfig)
 
-        for outputModuleName in outputMods.keys():
+        for outputModuleName in outputMods:
             self.addMergeTask(prodTask, self.prodJobSplitAlgo,
                               outputModuleName,
                               lfn_counter=self.previousJobCount)
@@ -128,17 +127,14 @@ class MonteCarloWorkloadFactory(StdBase):
         return self.buildWorkload()
 
     def validateSchema(self, schema):
-        couchUrl = schema.get("ConfigCacheUrl", None) or schema["CouchURL"]
         self.validateConfigCacheExists(configID=schema["ConfigCacheID"],
-                                       couchURL=couchUrl,
+                                       configCacheUrl=schema['ConfigCacheUrl'],
                                        couchDBName=schema["CouchDBName"])
         return
 
     @staticmethod
     def getWorkloadArguments():
         baseArgs = StdBase.getWorkloadArguments()
-        reqMgrArgs = StdBase.getWorkloadArgumentsWithReqMgr()
-        baseArgs.update(reqMgrArgs)
         specArgs = {"RequestType": {"default": "MonteCarlo", "optional": True,
                                     "attr": "requestType"},
                     "PrimaryDataset": {"default": "BlackHoleTest", "type": str,

--- a/src/python/WMCore/WMSpec/StdSpecs/MonteCarloFromGEN.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/MonteCarloFromGEN.py
@@ -45,7 +45,6 @@ class MonteCarloFromGENWorkloadFactory(DataProcessing):
 
         outputMods = self.setupProcessingTask(procTask, "Processing",
                                               self.inputDataset,
-                                              couchURL=self.couchURL,
                                               couchDBName=self.couchDBName,
                                               configCacheUrl=self.configCacheUrl,
                                               configDoc=self.configCacheID,
@@ -97,9 +96,8 @@ class MonteCarloFromGENWorkloadFactory(DataProcessing):
         of the ConfigCacheID
         """
         DataProcessing.validateSchema(self, schema)
-        couchUrl = schema.get("ConfigCacheUrl", None) or schema["CouchURL"]
         self.validateConfigCacheExists(configID=schema["ConfigCacheID"],
-                                       couchURL=couchUrl,
+                                       configCacheUrl=schema['ConfigCacheUrl'],
                                        couchDBName=schema["CouchDBName"])
         return
 
@@ -111,9 +109,6 @@ class MonteCarloFromGENWorkloadFactory(DataProcessing):
                     "PrimaryDataset": {"default": None, "type": str,
                                        "optional": True, "validate": primdataset,
                                        "attr": "inputPrimaryDataset", "null": True},
-                    "ConfigCacheUrl": {"default": None, "type": str,
-                                       "optional": True, "validate": None,
-                                       "attr": "configCacheUrl", "null": False},
                     "ConfigCacheID": {"default": None, "type": str,
                                       "optional": False, "validate": None,
                                       "attr": "configCacheID", "null": True},

--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -239,9 +239,7 @@ class PromptRecoWorkloadFactory(StdBase):
 
         baseArgs.update(specArgs)
         # add more optional arguments in case it is created using ReqMgr (not T0 case but should support both)
-        reqMgrArguments = {"CouchURL" : {"default" : "https://cmsweb.cern.ch/couchdb",
-                                         "validate" : couchurl},
-                           "CouchDBName" : {"default" : "reqmgr_config_cache", "type" : str,
+        reqMgrArguments = {"CouchDBName" : {"default" : "reqmgr_config_cache", "type" : str,
                                             "validate" : identifier},
                            "ConfigCacheUrl" : {"default" :"https://cmsweb.cern.ch/couchdb", "validate" : couchurl},
                            "ConfigCacheID" : {"optional": True, "null": True},

--- a/src/python/WMCore/WMSpec/StdSpecs/ReDigi.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/ReDigi.py
@@ -41,8 +41,7 @@ class ReDigiWorkloadFactory(DataProcessing):
         parentCmsswStep = parentMergeTask.getStep("cmsRun1")
         newTask = parentMergeTask.addTask(taskName)
         outputMods = self.setupProcessingTask(newTask, "Processing", inputStep = parentCmsswStep,
-                                              inputModule = "Merged", couchURL = self.couchURL,
-                                              couchDBName = self.couchDBName,
+                                              inputModule = "Merged", couchDBName = self.couchDBName,
                                               configDoc = configCacheID,
                                               configCacheUrl = self.configCacheUrl,
                                               splitAlgo = self.procJobSplitAlgo,
@@ -61,7 +60,6 @@ class ReDigiWorkloadFactory(DataProcessing):
         output between all three steps.
 
         """
-        configCacheUrl = self.configCacheUrl or self.couchURL
         parentCmsswStep = stepOneTask.getStep("cmsRun1")
         parentCmsswStepHelper = parentCmsswStep.getTypeHelper()
         parentCmsswStepHelper.keepOutput(False)
@@ -77,7 +75,7 @@ class ReDigiWorkloadFactory(DataProcessing):
         stepTwoCmsswHelper.cmsswSetup(self.frameworkVersion, softwareEnvironment = "",
                                       scramArch = self.scramArch)
 
-        stepTwoCmsswHelper.setConfigCache(configCacheUrl, self.stepTwoConfigCacheID,
+        stepTwoCmsswHelper.setConfigCache(self.configCacheUrl, self.stepTwoConfigCacheID,
                                           self.couchDBName)
         stepTwoCmsswHelper.keepOutput(False)
 
@@ -89,11 +87,11 @@ class ReDigiWorkloadFactory(DataProcessing):
         stepThreeCmsswHelper.setupChainedProcessing("cmsRun2", self.stepTwoOutputModuleName)
         stepThreeCmsswHelper.cmsswSetup(self.frameworkVersion, softwareEnvironment = "",
                                         scramArch = self.scramArch)
-        stepThreeCmsswHelper.setConfigCache(configCacheUrl, self.stepThreeConfigCacheID,
+        stepThreeCmsswHelper.setConfigCache(self.configCacheUrl, self.stepThreeConfigCacheID,
                                             self.couchDBName)
 
         configOutput = self.determineOutputModules(None, None, self.stepTwoConfigCacheID,
-                                                   configCacheUrl, self.couchDBName)
+                                                   self.couchDBName, self.configCacheUrl)
         for outputModuleName in configOutput.keys():
             outputModule = self.addOutputModule(stepOneTask,
                                                 outputModuleName,
@@ -103,7 +101,7 @@ class ReDigiWorkloadFactory(DataProcessing):
                                                 stepName = "cmsRun2")
 
         configOutput = self.determineOutputModules(None, None, self.stepThreeConfigCacheID,
-                                                   configCacheUrl, self.couchDBName)
+                                                   self.couchDBName, self.configCacheUrl)
         outputMods = {}
         for outputModuleName in configOutput.keys():
             outputModule = self.addOutputModule(stepOneTask,
@@ -159,7 +157,6 @@ class ReDigiWorkloadFactory(DataProcessing):
         do RECO on the RAW.
 
         """
-        configCacheUrl = self.configCacheUrl or self.couchURL
         parentCmsswStep = stepOneTask.getStep("cmsRun1")
         parentCmsswStepHelper = parentCmsswStep.getTypeHelper()
         parentCmsswStepHelper.keepOutput(False)
@@ -174,10 +171,10 @@ class ReDigiWorkloadFactory(DataProcessing):
         stepTwoCmsswHelper.setupChainedProcessing("cmsRun1", self.stepOneOutputModuleName)
         stepTwoCmsswHelper.cmsswSetup(self.frameworkVersion, softwareEnvironment = "",
                                       scramArch = self.scramArch)
-        stepTwoCmsswHelper.setConfigCache(configCacheUrl, self.stepTwoConfigCacheID,
+        stepTwoCmsswHelper.setConfigCache(self.configCacheUrl, self.stepTwoConfigCacheID,
                                           self.couchDBName)
         configOutput = self.determineOutputModules(None, None, self.stepTwoConfigCacheID,
-                                                   configCacheUrl, self.couchDBName)
+                                                   self.couchDBName, self.configCacheUrl)
         outputMods = {}
         for outputModuleName in configOutput.keys():
             outputModule = self.addOutputModule(stepOneTask,
@@ -223,7 +220,7 @@ class ReDigiWorkloadFactory(DataProcessing):
         stepOneTask = workload.newTask("StepOneProc")
 
         outputMods = self.setupProcessingTask(stepOneTask, "Processing", self.inputDataset,
-                                              couchURL = self.couchURL, couchDBName = self.couchDBName,
+                                              couchDBName = self.couchDBName,
                                               configCacheUrl = self.configCacheUrl,
                                               configDoc = self.stepOneConfigCacheID,
                                               splitAlgo = self.procJobSplitAlgo,
@@ -330,19 +327,18 @@ class ReDigiWorkloadFactory(DataProcessing):
         return baseArgs
 
     def validateSchema(self, schema):
-        couchUrl = schema.get("ConfigCacheUrl", None) or schema["CouchURL"]
         self.validateConfigCacheExists(configID = schema["StepOneConfigCacheID"],
-                                       couchURL = couchUrl,
+                                       configCacheUrl = schema['ConfigCacheUrl'],
                                        couchDBName = schema["CouchDBName"])
         if schema.get("StepTwoConfigCacheID") is not None:
             self.validateConfigCacheExists(configID = schema["StepTwoConfigCacheID"],
-                                           couchURL = couchUrl,
+                                           configCacheUrl = schema['ConfigCacheUrl'],
                                            couchDBName = schema["CouchDBName"])
             if schema.get("StepOneOutputModuleName") is None:
                 self.raiseValidationException("StepTwoConfigCacheID is specified but StepOneOutputModuleName isn't")
         if schema.get("StepThreeConfigCacheID") is not None:
             self.validateConfigCacheExists(configID = schema["StepThreeConfigCacheID"],
-                                           couchURL = couchUrl,
+                                           configCacheUrl = schema['ConfigCacheUrl'],
                                            couchDBName = schema["CouchDBName"])
             if schema.get("StepTwoOutputModuleName") is None:
                 self.raiseValidationException("StepThreeConfigCacheID is specified but StepTwoOutputModuleName isn't")

--- a/src/python/WMCore/WMSpec/StdSpecs/ReReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/ReReco.py
@@ -47,7 +47,6 @@ class ReRecoWorkloadFactory(DataProcessing):
 
         outputMods = self.setupProcessingTask(procTask, taskType,
                                               self.inputDataset,
-                                              couchURL = self.couchURL,
                                               couchDBName = self.couchDBName,
                                               configCacheUrl = self.configCacheUrl,
                                               forceUnmerged = forceUnmerged,
@@ -122,7 +121,6 @@ class ReRecoWorkloadFactory(DataProcessing):
             outputMods = self.setupProcessingTask(skimTask, "Skim",
                                                   inputStep = parentCmsswStep,
                                                   inputModule = inputModule,
-                                                  couchURL = self.couchURL,
                                                   couchDBName = self.couchDBName,
                                                   configCacheUrl = self.configCacheUrl,
                                                   configDoc = skimConfig["ConfigCacheID"],
@@ -237,9 +235,8 @@ class ReRecoWorkloadFactory(DataProcessing):
         Check for required fields, and some skim facts
         """
         DataProcessing.validateSchema(self, schema)
-        couchUrl = schema.get("ConfigCacheUrl", None) or schema["CouchURL"]
         mainOutputModules = self.validateConfigCacheExists(configID = schema["ConfigCacheID"],
-                                                           couchURL = couchUrl,
+                                                           configCacheUrl = schema['ConfigCacheUrl'],
                                                            couchDBName = schema["CouchDBName"],
                                                            getOutputModules = True).keys()
 
@@ -257,7 +254,7 @@ class ReRecoWorkloadFactory(DataProcessing):
                 self.raiseValidationException(msg)
 
             self.validateConfigCacheExists(configID = schema["Skim%sConfigCacheID" % skimIndex],
-                                           couchURL = couchUrl,
+                                           configCacheUrl = schema['ConfigCacheUrl'],
                                            couchDBName = schema["CouchDBName"])
             if schema["SkimInput%s" % skimIndex] not in mainOutputModules:
                 error = "Processing config does not have the following output module: %s." % schema["SkimInput%s" % skimIndex]

--- a/src/python/WMCore/WMSpec/StdSpecs/StoreResults.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StoreResults.py
@@ -10,8 +10,6 @@ _StoreResults_
 Standard StoreResults workflow.
 """
 
-import os
-
 from Utils.Utilities import makeList
 from WMCore.Lexicon import dataset, block
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
@@ -96,8 +94,6 @@ class StoreResultsWorkloadFactory(StdBase):
     @staticmethod
     def getWorkloadArguments():
         baseArgs = StdBase.getWorkloadArguments()
-        reqMgrArgs = StdBase.getWorkloadArgumentsWithReqMgr()
-        baseArgs.update(reqMgrArgs)
         specArgs = {"RequestType" : {"default" : "StoreResults", "optional" : True,
                                       "attr" : "requestType"},
                     "InputDataset" : {"default" : None,

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
@@ -248,7 +248,7 @@ class TaskChainTests(unittest.TestCase):
             "ScramArch": "slc6_amd64_gcc530",
             "ProcessingVersion": 1,
             "GlobalTag": "GR10_P_v4::All",
-            "CouchURL": self.testInit.couchUrl,
+            "ConfigCacheUrl": self.testInit.couchUrl,
             "CouchDBName": self.testInit.couchDbName,
             "SiteWhitelist": ["T1_CH_CERN", "T1_US_FNAL"],
             "DashboardHost": "127.0.0.1",
@@ -497,7 +497,7 @@ class TaskChainTests(unittest.TestCase):
         processorDocs = makeProcessingConfigs(self.configDatabase)
         testArguments = TaskChainWorkloadFactory.getTestArguments()
         testArguments.update(createMultiGTArgs())
-        testArguments["CouchURL"] = self.testInit.couchUrl
+        testArguments["ConfigCacheUrl"] = self.testInit.couchUrl
         testArguments["CouchDBName"] = self.testInit.couchDbName
         testArguments["Task1"]["ConfigCacheID"] = processorDocs['DigiHLT']
         testArguments["Task2"]["ConfigCacheID"] = processorDocs['Reco']
@@ -544,7 +544,7 @@ class TaskChainTests(unittest.TestCase):
         testArguments = TaskChainWorkloadFactory.getTestArguments()
         testArguments.update(createMultiGTArgs())
         lumiDict = {"1": [[2, 4], [8, 50]], "2": [[100, 200], [210, 210]]}
-        testArguments["CouchURL"] = self.testInit.couchUrl
+        testArguments["ConfigCacheUrl"] = self.testInit.couchUrl
         testArguments["CouchDBName"] = self.testInit.couchDbName
         testArguments["Task1"]["LumiList"] = lumiDict
         testArguments["Task1"]["ConfigCacheID"] = processorDocs['DigiHLT']
@@ -624,7 +624,7 @@ class TaskChainTests(unittest.TestCase):
         generatorDoc = makeGeneratorConfig(self.configDatabase)
         testArguments = TaskChainWorkloadFactory.getTestArguments()
         arguments = {
-            "CouchURL": self.testInit.couchUrl,
+            "ConfigCacheUrl": self.testInit.couchUrl,
             "CouchDBName": self.testInit.couchDbName,
             "TaskChain": 1,
             "Task1": {
@@ -846,7 +846,7 @@ class TaskChainTests(unittest.TestCase):
             "ScramArch": "slc6_amd64_gcc530",
             "ProcessingVersion": 1,
             "GlobalTag": "GR10_P_v4::All",
-            "CouchURL": self.testInit.couchUrl,
+            "ConfigCacheUrl": self.testInit.couchUrl,
             "CouchDBName": self.testInit.couchDbName,
             "SiteWhitelist": ["T1_CH_CERN", "T1_US_FNAL"],
             "DashboardHost": "127.0.0.1",
@@ -926,9 +926,8 @@ class TaskChainTests(unittest.TestCase):
         arguments['CMSSWVersion'] = 'CMSSW_8_0_17'
         arguments['ScramArch'] = 'slc6_amd64_gcc530'
         del arguments['ConfigCacheID']
-        del arguments['ConfigCacheUrl']
         arguments.update({
-            "CouchURL": self.testInit.couchUrl,
+            "ConfigCacheUrl": self.testInit.couchUrl,
             "CouchDBName": self.testInit.couchDbName,
         })
 


### PR DESCRIPTION
Fixes #7732 

Since this is possible a breaking change, we need to:
a) review/update the CompOps scripts
b) talk to/announce this change to McM
c) talk to/announce this change to RelVal managers

I also had to remove `getWorkloadArgumentsWithReqMgr` and merge those arguments into `getWorkloadARguments`. Then when a spec doesn't want to use them (T0), it should override it. It's also part of the create/assign argument separation that I'm going to work on after this.