### PR TITLE
Nicely handle CouchConnectionError exception in JobAccountant

### DIFF
--- a/src/python/WMComponent/JobAccountant/JobAccountantPoller.py
+++ b/src/python/WMComponent/JobAccountant/JobAccountantPoller.py
@@ -5,17 +5,16 @@ _JobAccountantPoller_
 Poll WMBS for complete jobs and process their framework job reports.
 """
 
-import time
 import threading
 import logging
 
 from Utils.IteratorTools import grouper
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
-from WMCore.Agent.Harness import Harness
 from WMCore.Database.CouchUtils import CouchConnectionError
 from WMCore.DAOFactory import DAOFactory
 from WMComponent.JobAccountant.AccountantWorker import AccountantWorker
 from WMCore.WMException import WMException
+
 
 class JobAccountantPollerException(WMException):
     """
@@ -26,43 +25,39 @@ class JobAccountantPollerException(WMException):
     from the worker).
     """
 
+
 class JobAccountantPoller(BaseWorkerThread):
     def __init__(self, config):
         BaseWorkerThread.__init__(self)
         self.config = config
         self.accountantWorkSize = getattr(self.config.JobAccountant, 'accountantWorkSize', 100)
-        # initialize the alert framework (if available - config.Alert present)
-        #    self.sendAlert will be then be available
-        self.initAlerts(compName = "JobAccountant")
 
         return
 
-    def setup(self, parameters = None):
+    def setup(self, parameters=None):
         """
         _setup_
 
         Instantiate the requisite number of accountant workers and create a
         processpool with them.  Also instantiate all the DAOs that we will use.
         """
-        #self.accountantWorker = AccountantWorker(couchURL = self.config.JobStateMachine.couchurl,
-        #                                         couchDBName = self.config.JobStateMachine.couchDBName)
-        self.accountantWorker = AccountantWorker(config = self.config)
+        self.accountantWorker = AccountantWorker(config=self.config)
 
         myThread = threading.currentThread()
-        daoFactory = DAOFactory(package = "WMCore.WMBS", logger = myThread.logger,
-                                dbinterface = myThread.dbi)
-        self.getJobsAction = daoFactory(classname = "Jobs.GetFWJRByState")
+        daoFactory = DAOFactory(package="WMCore.WMBS", logger=myThread.logger,
+                                dbinterface=myThread.dbi)
+        self.getJobsAction = daoFactory(classname="Jobs.GetFWJRByState")
         return
 
-    def algorithm(self, parameters = None):
+    def algorithm(self, parameters=None):
         """
         _algorithm_
 
         Poll WMBS for jobs in the 'Complete' state and then pass them to the
         accountant worker.
         """
-        completeJobs = self.getJobsAction.execute(state = "complete")
-        logging.info("Found %d completed jobs" % len(completeJobs))
+        completeJobs = self.getJobsAction.execute(state="complete")
+        logging.info("Found %d completed jobs", len(completeJobs))
 
         if len(completeJobs) == 0:
             logging.debug("No work to do; exiting")
@@ -79,7 +74,7 @@ class JobAccountantPoller(BaseWorkerThread):
             except CouchConnectionError as ex:
                 msg = "Caught CouchConnectionError exception. Waiting until the next polling cycle.\n"
                 msg += str(ex)
-                logging.exception(msg)
+                logging.error(msg)
                 myThread = threading.currentThread()
                 if getattr(myThread, 'transaction', None) is not None:
                     myThread.transaction.rollback()
@@ -89,8 +84,7 @@ class JobAccountantPoller(BaseWorkerThread):
                     myThread.transaction.rollback()
                 msg = "Hit general exception in JobAccountantPoller while using worker.\n"
                 msg += str(ex)
-                logging.error(msg)
-                self.sendAlert(6, msg = msg)
+                logging.exception(msg)
                 raise JobAccountantPollerException(msg)
 
         return


### PR DESCRIPTION
Most of the agents went down over the weekend (including nodes in testbed as well) with the following traceback [1].

With this patch, the agent will rollback DB changes and retry in the next polling cycle.

[1]
```
2017-03-19 01:52:36,496:139792240887552:INFO:AccountantWorker:About to commit all DBSBuffer Heritage information
2017-03-19 01:52:36,496:139792240887552:INFO:AccountantWorker:0
2017-03-19 01:54:12,951:139792240887552:ERROR:JobAccountantPoller:Hit general exception in JobAccountantPoller while using worker.
Exception instantiating couch services for :
 url = https://cmsweb-testbed.cern.ch/couchdb
 database = acdcserver
 Exception: 
2017-03-19 01:54:14,926:139792240887552:ERROR:BaseWorkerThread:Error in worker algorithm (1):
Backtrace:
  <WMComponent.JobAccountant.JobAccountantPoller.JobAccountantPoller instance at 0x7f23ec2dd0e0> JobAccountantPollerException
Message: Hit general exception in JobAccountantPoller while using worker.
Exception instantiating couch services for :
 url = https://cmsweb-testbed.cern.ch/couchdb
 database = acdcserver
 Exception: 
	ModuleName : WMComponent.JobAccountant.JobAccountantPoller
	MethodName : algorithm
	ClassInstance : None
	FileName : /data/srv/wmagent/v1.1.0.patch2/sw/slc6_amd64_gcc493/cms/wmagent/1.1.0.patch2/lib/python2.7/site-packages/WMComponent/JobAccountant/JobAccountantPoller.py
	ClassName : None
	LineNumber : 88
	ErrorNr : 0

Traceback: 
  File "/data/srv/wmagent/v1.1.0.patch2/sw/slc6_amd64_gcc493/cms/wmagent/1.1.0.patch2/lib/python2.7/site-packages/WMComponent/JobAccountant/JobAccountantPoller.py", line 73, in algorithm
    self.accountantWorker(jobsSlice)

  File "/data/srv/wmagent/v1.1.0.patch2/sw/slc6_amd64_gcc493/cms/wmagent/1.1.0.patch2/lib/python2.7/site-packages/WMComponent/JobAccountant/AccountantWorker.py", line 309, in __call__
    self.handleSkippedFiles()

  File "/data/srv/wmagent/v1.1.0.patch2/sw/slc6_amd64_gcc493/cms/wmagent/1.1.0.patch2/lib/python2.7/site-packages/WMComponent/JobAccountant/AccountantWorker.py", line 952, in handleSkippedFiles
    self.dataCollection.failedJobs(jobList, useMask = False)

  File "/data/srv/wmagent/v1.1.0.patch2/sw/slc6_amd64_gcc493/cms/wmagent/1.1.0.patch2/lib/python2.7/site-packages/WMCore/Database/CouchUtils.py", line 53, in wrapper
    return funcRef(x, *args, **opts)

  File "/data/srv/wmagent/v1.1.0.patch2/sw/slc6_amd64_gcc493/cms/wmagent/1.1.0.patch2/lib/python2.7/site-packages/WMCore/ACDC/DataCollectionService.py", line 101, in failedJobs
    fileset.add(files = job['input_files'])

  File "/data/srv/wmagent/v1.1.0.patch2/sw/slc6_amd64_gcc493/cms/wmagent/1.1.0.patch2/lib/python2.7/site-packages/WMCore/Database/CouchUtils.py", line 52, in wrapper
    initialiseCouch(x)

  File "/data/srv/wmagent/v1.1.0.patch2/sw/slc6_amd64_gcc493/cms/wmagent/1.1.0.patch2/lib/python2.7/site-packages/WMCore/Database/CouchUtils.py", line 42, in initialiseCouch
    raise CouchConnectionError(msg)

  File "/data/srv/wmagent/v1.1.0.patch2/sw/slc6_amd64_gcc493/cms/wmagent/1.1.0.patch2/lib/python2.7/site-packages/WMCore/WorkerThreads/BaseWorkerThread.py", line 179, in __call__
    self.algorithm(parameters)
  File "/data/srv/wmagent/v1.1.0.patch2/sw/slc6_amd64_gcc493/cms/wmagent/1.1.0.patch2/lib/python2.7/site-packages/WMComponent/JobAccountant/JobAccountantPoller.py", line 88, in algorithm
    raise JobAccountantPollerException(msg)

2017-03-19 01:54:14,926:139792240887552:INFO:Harness:>>>Terminating worker threads
2017-03-19 01:54:15,105:139792240887552:ERROR:BaseWorkerThread:Error in event loop (2): <WMComponent.JobAccountant.JobAccountantPoller.JobAccountantPoller instance at 0x7f23ec2dd0e0> JobAccountantPollerException
Message: Hit general exception in JobAccountantPoller while using worker.
Exception instantiating couch services for :
 url = https://cmsweb-testbed.cern.ch/couchdb
 database = acdcserver
 Exception: 
	ModuleName : WMComponent.JobAccountant.JobAccountantPoller
	MethodName : algorithm
	ClassInstance : None
	FileName : /data/srv/wmagent/v1.1.0.patch2/sw/slc6_amd64_gcc493/cms/wmagent/1.1.0.patch2/lib/python2.7/site-packages/WMComponent/JobAccountant/JobAccountantPoller.py
	ClassName : None
	LineNumber : 88
	ErrorNr : 0

Traceback: 
  File "/data/srv/wmagent/v1.1.0.patch2/sw/slc6_amd64_gcc493/cms/wmagent/1.1.0.patch2/lib/python2.7/site-packages/WMComponent/JobAccountant/JobAccountantPoller.py", line 73, in algorithm
    self.accountantWorker(jobsSlice)

  File "/data/srv/wmagent/v1.1.0.patch2/sw/slc6_amd64_gcc493/cms/wmagent/1.1.0.patch2/lib/python2.7/site-packages/WMComponent/JobAccountant/AccountantWorker.py", line 309, in __call__
    self.handleSkippedFiles()

  File "/data/srv/wmagent/v1.1.0.patch2/sw/slc6_amd64_gcc493/cms/wmagent/1.1.0.patch2/lib/python2.7/site-packages/WMComponent/JobAccountant/AccountantWorker.py", line 952, in handleSkippedFiles
    self.dataCollection.failedJobs(jobList, useMask = False)

  File "/data/srv/wmagent/v1.1.0.patch2/sw/slc6_amd64_gcc493/cms/wmagent/1.1.0.patch2/lib/python2.7/site-packages/WMCore/Database/CouchUtils.py", line 53, in wrapper
    return funcRef(x, *args, **opts)

  File "/data/srv/wmagent/v1.1.0.patch2/sw/slc6_amd64_gcc493/cms/wmagent/1.1.0.patch2/lib/python2.7/site-packages/WMCore/ACDC/DataCollectionService.py", line 101, in failedJobs
    fileset.add(files = job['input_files'])

  File "/data/srv/wmagent/v1.1.0.patch2/sw/slc6_amd64_gcc493/cms/wmagent/1.1.0.patch2/lib/python2.7/site-packages/WMCore/Database/CouchUtils.py", line 52, in wrapper
    initialiseCouch(x)

  File "/data/srv/wmagent/v1.1.0.patch2/sw/slc6_amd64_gcc493/cms/wmagent/1.1.0.patch2/lib/python2.7/site-packages/WMCore/Database/CouchUtils.py", line 42, in initialiseCouch
    raise CouchConnectionError(msg)


Backtrace:
  File "/data/srv/wmagent/v1.1.0.patch2/sw/slc6_amd64_gcc493/cms/wmagent/1.1.0.patch2/lib/python2.7/site-packages/WMCore/WorkerThreads/BaseWorkerThread.py", line 205, in __call__
    raise ex

2017-03-19 01:54:15,105:139792240887552:INFO:BaseWorkerThread:Worker thread <WMComponent.JobAccountant.JobAccountantPoller.JobAccountantPoller instance at 0x7f23ec2dd0e0> terminated
cmst1@vocms0159:/data/srv/wmagent/current $ 
```