### PR TITLE
Explicitly add FQAN for X509 user proxy for job submission

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -113,6 +113,7 @@ class SimpleCondorPlugin(BasePlugin):
         proxy = Proxy({'logger': myThread.logger})
         self.x509userproxy = proxy.getProxyFilename()
         self.x509userproxysubject = proxy.getSubject()
+        self.x509userproxyfqan = proxy.getAttributeFromProxy(self.x509userproxy)
 
         return
 
@@ -466,6 +467,7 @@ class SimpleCondorPlugin(BasePlugin):
 
         ad['x509userproxy'] = self.x509userproxy
         ad['x509userproxysubject'] = self.x509userproxysubject
+        ad['x509userproxyfirstfqan'] = self.x509userproxyfqan
 
         ad['Rank'] = 0.0
         ad['TransferIn'] = False


### PR DESCRIPTION
There is a random behaviour going on on the global pool where some jobs don't have this `x509userproxyfirstfqan` ad defined, which causes problems at RALPP.

Diego and I failed to find the issue and/or a pattern to what's going on. So the solution is to explicitly set it in the submitter plugin. Still to be tested