### PR TITLE
Generate WMArchive report with new key eventsPerLumi

### DIFF
--- a/src/python/WMCore/Services/WMArchive/DataMap.py
+++ b/src/python/WMCore/Services/WMArchive/DataMap.py
@@ -125,7 +125,18 @@ def combineDataset(dataset):
     return dataset
 
 def changeRunStruct(runDict):
-    return [{"runNumber": int(run), "lumis": lumis}  for run, lumis in runDict.items()]
+    runList = []
+    for run, lumis in runDict.iteritems():
+        singleRun = {"runNumber": int(run)}
+        if isinstance(lumis, dict):
+            # In this case, lumis is a dictionary with lumi numbers as the key, event counts as the value
+            singleRun.update({'lumis': [int(lumi) for lumi in lumis.keys()],
+                              'eventsPerLumi': lumis.values()})
+        elif isinstance(lumis, list):
+            singleRun.update({'lumis': lumis})
+        runList.append(singleRun)
+
+    return runList
 
 def _changeToFloat(value):
     if value in ["-nan", "nan", "inf", ""]:

--- a/src/python/WMCore/Services/WMArchive/DataMap.py
+++ b/src/python/WMCore/Services/WMArchive/DataMap.py
@@ -335,8 +335,7 @@ def createFileArray(fwjr, fArray, fArrayRef):
                             fArray[fileType].add(fileName)
                     else: # this should be string
                         fArray[fileType].add(value)
-            else:
-                createFileArray(value, fArray, fArrayRef)
+            createFileArray(value, fArray, fArrayRef)
     elif isinstance(fwjr, list):
         for item in fwjr:
             createFileArray(item, fArray, fArrayRef)
@@ -357,8 +356,7 @@ def changeToFileRef(fwjr, fArray, fArrayRef):
                     else: # this should be string
                         newRef = fArray[fileType].index(value)
                     fwjr[key] = newRef
-            else:
-                changeToFileRef(value, fArray, fArrayRef)
+            changeToFileRef(value, fArray, fArrayRef)
     elif isinstance(fwjr, list):
         for item in fwjr:
             changeToFileRef(item, fArray, fArrayRef)

--- a/test/python/WMCore_t/Services_t/WMArchive_t/DataMap_t.py
+++ b/test/python/WMCore_t/Services_t/WMArchive_t/DataMap_t.py
@@ -52,8 +52,7 @@ SAMPLE_FWJR = {'fallbackFiles': [],
                                                              'prep_id': 'None',
                                                              'processingStr': 'RECOCOSD_TaskChain_Data_pile_up_test',
                                                              'processingVer': 1,
-                                                             'runs': {'160960': [164,
-                                                                                 165]},
+                                                             'runs': {'160960': {'164': 100, '165': 150}},
                                                              'size': 647376,
                                                              'user_dn': None,
                                                              'user_vogroup': 'DEFAULT',
@@ -185,6 +184,8 @@ class DataMap_t(unittest.TestCase):
             if step['name'] == 'cmsRun1':
                 runInfo = step['output'][0]['runs'][0]
         self.assertEqual((run[str(runInfo['runNumber'])]), runInfo['lumis'])
+        # Make sure the first file events per lumis is carried through
+        self.assertEqual(runInfo['eventsPerLumi'], [100, 150])
         fwjrSamples = ["ErrorCodeFail.json",
                        "FailedByAgent.json",
                        "HarvestSuccessFwjr.json",


### PR DESCRIPTION
@ticoann @vkuznet @yuyiguo 

I think this does what we discussed this morning. Add a 2nd line if the data is available. Is this what you need? Do I have to update the schema somewhere too? Would it be better if I filled eventsPerLumi with Nones in we don't have the info rather than leaving the value out of the JSON completely?