### PR TITLE
validate MC site whitelist

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/Resubmission.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Resubmission.py
@@ -7,7 +7,7 @@ with limited input for error recovery.
 """
 
 from Utils.Utilities import makeList
-from WMCore.Lexicon import couchurl, identifier
+from WMCore.Lexicon import couchurl, identifier, cmsname
 from WMCore.WMSpec.WMWorkload import WMWorkloadHelper
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
 
@@ -63,6 +63,8 @@ class ResubmissionWorkloadFactory(StdBase):
                     "ACDCDatabase" : {"default" : "acdcserver", "validate" : identifier,
                                       "attr" : "acdcDatabase"},
                     "CollectionName" : {"default" : None, "null" : True},
-                    "IgnoredOutputModules" : {"default" : [], "type" : makeList}}
+                    "IgnoredOutputModules" : {"default" : [], "type" : makeList},
+                    "SiteWhitelist": {"default": [], "type": makeList,
+                                      "validate": lambda x: all([cmsname(y) for y in x])}}
         StdBase.setDefaultArgumentsProperty(specArgs)
         return specArgs

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -1149,6 +1149,8 @@ class StdBase(object):
                 schema[arg] = "reqmgr_config_cache_t"
             elif arg == "ScramArch":
                 schema[arg] = "slc6_amd64_gcc491"
+            elif arg == "SiteWhitelist":
+                schema[arg] = ['T2_XX_SiteA', 'T2_XX_SiteB', 'T2_XX_SiteC']
             elif not workloadDefinition[arg]["optional"]:
                 if workloadDefinition[arg]["type"] == str:
                     if arg == "InputDataset":

--- a/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
@@ -57,6 +57,9 @@ class StartPolicyInterface(PolicyInterface):
             except Exception as ex:  # can throw many errors e.g. AttributeError, AssertionError etc.
                 error = WorkQueueWMSpecError(self.wmspec, "Site whitelist validation error: %s" % str(ex))
                 raise error
+        else:
+            error = WorkQueueWMSpecError(self.wmspec, "Site whitelist validation error: Empty site whitelist")
+            raise error
 
         if self.initialTask.siteBlacklist():
             if isinstance(self.initialTask.siteBlacklist(), basestring):
@@ -121,6 +124,7 @@ class StartPolicyInterface(PolicyInterface):
         for data, sites in ele['Inputs'].items():
             if not sites:
                 raise WorkQueueWMSpecError(self.wmspec, 'Input data has no locations "%s"' % data)
+
         # catch infinite splitting loops
         if len(self.workQueueElements) > self.args.get('maxRequestSize', 1e8):
             raise WorkQueueWMSpecError(self.wmspec, 'Too many elements (%d)' % self.args.get('MaxRequestElements', 1e8))

--- a/src/python/WMQuality/Emulators/WMSpecGenerator/Samples/MultiTaskProcessingWorkload.py
+++ b/src/python/WMQuality/Emulators/WMSpecGenerator/Samples/MultiTaskProcessingWorkload.py
@@ -5,10 +5,8 @@ _Tier1ReRecoWorkload_
 
 
 """
-import os, pickle, sys, shutil
 from WMCore.WMSpec.WMWorkload import newWorkload
-from WMCore.WMSpec.WMStep import makeWMStep
-from WMCore.WMSpec.Steps.StepFactory import getStepTypeHelper
+
 
 DBSURL = "https://cmsweb.cern.ch/dbs/prod/global/DBSReader"
 
@@ -63,8 +61,8 @@ def createWorkload(name="MultiTaskProcessing"):
         dataTier = "RECO")
 
     #Add a stageOut step
-    skimStageOutHelper = skimStageOut.getTypeHelper()
-    skimLogArchHelper  = skimLogArch.getTypeHelper()
+    #skimStageOutHelper = skimStageOut.getTypeHelper()
+    #skimLogArchHelper  = skimLogArch.getTypeHelper()
 
 
     rereco.addGenerator("BasicNaming")
@@ -81,6 +79,7 @@ def createWorkload(name="MultiTaskProcessing"):
     skimLogArch.setStepType("LogArchive")
     rereco.applyTemplates()
     rereco.setSplittingAlgorithm("FileBased", files_per_job = 1)
+    rereco.setSiteWhitelist(["T2_XX_SiteA", "T2_XX_SiteB", "T2_XX_SiteC"])
     rereco.addInputDataset(
         primary = "Cosmics",
         processed = "ComissioningHI-PromptReco-v1",
@@ -111,9 +110,10 @@ def createWorkload(name="MultiTaskProcessing"):
         dataTier = "RECO")
 
     #Add a stageOut step
-    skimStageOutHelper = skimStageOut.getTypeHelper()
-    skimLogArchHelper  = skimLogArch.getTypeHelper()
+    #skimStageOutHelper = skimStageOut.getTypeHelper()
+    #skimLogArchHelper  = skimLogArch.getTypeHelper()
 
 
     rereco.addGenerator("BasicNaming")
+    workload.setSiteWhitelist(["T2_XX_SiteA", "T2_XX_SiteB", "T2_XX_SiteC"])
     return workload

--- a/src/python/WMQuality/Emulators/WMSpecGenerator/WMSpecGenerator.py
+++ b/src/python/WMQuality/Emulators/WMSpecGenerator/WMSpecGenerator.py
@@ -17,8 +17,7 @@ from .Samples.BasicProcessingWorkload \
     import createWorkload as BasicProcessingWorkload
 from WMCore.Cache.WMConfigCache import ConfigCache
 
-#from Samples.MultiTaskProcessingWorkload import createWorkload as MultiTaskProcessingWorkload
-#from Samples.MultiTaskProductionWorkload import createWorkload as MultiTaskProductionWorkload
+
 mcArgs = getMCArgs()
 
 class WMSpecGenerator(object):
@@ -66,6 +65,7 @@ class WMSpecGenerator(object):
         args = ReRecoWorkloadFactory.getTestArguments()
         args.update(additionalArgs)
         args["ConfigCacheID"] = createConfig(args["CouchDBName"])
+        args["SiteWhitelist"] = ['T2_XX_SiteA', 'T2_XX_SiteB', 'T2_XX_SiteC']
         factory = ReRecoWorkloadFactory()
         spec =  factory.factoryWorkloadConstruction(specName, args)
         if inputDataset != None:
@@ -84,7 +84,7 @@ class WMSpecGenerator(object):
         specs = {}
         for i in range(size):
             specName = specNameBase + "_%s" % i
-            sepc, specUrl = self.createProductionSpec(specName)
+            _, specUrl = self.createProductionSpec(specName)
             specs[specName] = specUrl
         return specs
 

--- a/test/python/WMCore_t/WMSpec_t/samples/BasicProductionWorkload.py
+++ b/test/python/WMCore_t/WMSpec_t/samples/BasicProductionWorkload.py
@@ -19,6 +19,7 @@ workload = newWorkload("BasicProduction")
 workload.setOwner("WMTest")
 workload.setStartPolicy('MonteCarlo', **{'SliceType': 'NumberOfEvents', 'SliceSize': 100})
 workload.setEndPolicy('SingleShot')
+workload.setSiteWhitelist(["T2_XX_SiteA", "T2_XX_SiteB", "T2_XX_SiteC"])
 #  //
 # // set up the production task
 #//
@@ -27,6 +28,7 @@ production.addProduction(totalevents = 1000)
 #WARNING: this is arbitrary task type (wmbs schema only supprot "Processing", "Merge", "Harvest") - maybe add "MCProduction"
 production.setTaskType("Merge")
 production.setSplittingAlgorithm("EventBased", events_per_job = 100)
+production.setSiteWhitelist(["T2_XX_SiteA", "T2_XX_SiteB", "T2_XX_SiteC"])
 prodCmssw = production.makeStep("cmsRun1")
 prodCmssw.setStepType("CMSSW")
 prodStageOut = prodCmssw.addStep("stageOut1")

--- a/test/python/WMCore_t/WMSpec_t/samples/MultiMergeProductionWorkload.py
+++ b/test/python/WMCore_t/WMSpec_t/samples/MultiMergeProductionWorkload.py
@@ -20,6 +20,7 @@ workload = newWorkload("MultiOutputs")
 workload.setOwner("WMTest")
 workload.setStartPolicy('MonteCarlo')
 workload.setEndPolicy('SingleShot')
+workload.setSiteWhitelist(["T2_XX_SiteA", "T2_XX_SiteB", "T2_XX_SiteC"])
 
 #  //
 # // set up the production task

--- a/test/python/WMCore_t/WMSpec_t/samples/MultiTaskProcessingWorkload.py
+++ b/test/python/WMCore_t/WMSpec_t/samples/MultiTaskProcessingWorkload.py
@@ -88,7 +88,6 @@ rereco.addInputDataset(
     processed = "ComissioningHI-PromptReco-v1",
     tier = "RECO",
     dbsurl = DBSURL)
-
 #  //
 # // rereco cmssw step
 #//
@@ -118,3 +117,5 @@ skimLogArchHelper  = skimLogArch.getTypeHelper()
 
 
 rereco.addGenerator("BasicNaming")
+
+workload.setSiteWhitelist(["T2_XX_SiteA", "T2_XX_SiteB", "T2_XX_SiteC"])

--- a/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Dataset_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Dataset_t.py
@@ -49,6 +49,7 @@ class DatasetTestCase(EmulatedUnitTestCase):
         dqmHarvArgs["DQMConfigCacheID"] = createConfig(dqmHarvArgs["CouchDBName"])
         factory = DQMHarvestWorkloadFactory()
         DQMHarvWorkload = factory.factoryWorkloadConstruction('DQMHarvestTest', dqmHarvArgs)
+        DQMHarvWorkload.setSiteWhitelist(["T2_XX_SiteA", "T2_XX_SiteB", "T2_XX_SiteC"])
         splitArgs = DQMHarvWorkload.startPolicyParameters()
         inputDataset = getFirstTask(DQMHarvWorkload).getInputDatasetPath()
 
@@ -73,6 +74,7 @@ class DatasetTestCase(EmulatedUnitTestCase):
         dqmHarvArgs["RunWhitelist"] = [181358, 181417, 180992, 181151]
         factory = DQMHarvestWorkloadFactory()
         DQMHarvWorkload = factory.factoryWorkloadConstruction('DQMHarvestTest', dqmHarvArgs)
+        DQMHarvWorkload.setSiteWhitelist(["T2_XX_SiteA", "T2_XX_SiteB", "T2_XX_SiteC"])
         splitArgs = DQMHarvWorkload.startPolicyParameters()
         inputDataset = getFirstTask(DQMHarvWorkload).getInputDatasetPath()
 
@@ -97,6 +99,7 @@ class DatasetTestCase(EmulatedUnitTestCase):
         dqmHarvArgs["LumiList"] = {"181358": [[71, 80], [95, 110]], "181151": [[1, 20]]}
         factory = DQMHarvestWorkloadFactory()
         DQMHarvWorkload = factory.factoryWorkloadConstruction('DQMHarvestTest', dqmHarvArgs)
+        DQMHarvWorkload.setSiteWhitelist(["T2_XX_SiteA", "T2_XX_SiteB", "T2_XX_SiteC"])
         splitArgs = DQMHarvWorkload.startPolicyParameters()
         inputDataset = getFirstTask(DQMHarvWorkload).getInputDatasetPath()
 
@@ -121,6 +124,7 @@ class DatasetTestCase(EmulatedUnitTestCase):
         dqmHarvArgs["DQMHarvestUnit"] = 'multiRun'
         factory = DQMHarvestWorkloadFactory()
         DQMHarvWorkload = factory.factoryWorkloadConstruction('DQMHarvestTest', dqmHarvArgs)
+        DQMHarvWorkload.setSiteWhitelist(["T2_XX_SiteA", "T2_XX_SiteB", "T2_XX_SiteC"])
         splitArgs = DQMHarvWorkload.startPolicyParameters()
         inputDataset = getFirstTask(DQMHarvWorkload).getInputDatasetPath()
 
@@ -185,6 +189,7 @@ class DatasetTestCase(EmulatedUnitTestCase):
         factory = ReRecoWorkloadFactory()
         Tier1ReRecoWorkload = factory.factoryWorkloadConstruction('ReRecoWorkload', rerecoArgs)
         Tier1ReRecoWorkload.setStartPolicy('Dataset', **splitArgs)
+        Tier1ReRecoWorkload.setSiteWhitelist(["T2_XX_SiteA", "T2_XX_SiteB", "T2_XX_SiteC"])
         for task in Tier1ReRecoWorkload.taskIterator():
             units, _ = Dataset(**splitArgs)(Tier1ReRecoWorkload, task)
             self.assertEqual(1, len(units))
@@ -227,7 +232,7 @@ class DatasetTestCase(EmulatedUnitTestCase):
         dqmHarvArgs["DQMConfigCacheID"] = createConfig(dqmHarvArgs["CouchDBName"])
         factory = DQMHarvestWorkloadFactory()
         DQMHarvWorkload = factory.factoryWorkloadConstruction('DQMHarvestTest', dqmHarvArgs)
-
+        DQMHarvWorkload.setSiteWhitelist(["T2_XX_SiteA", "T2_XX_SiteB", "T2_XX_SiteC"])
         splitArgs = DQMHarvWorkload.startPolicyParameters()
 
         for task in DQMHarvWorkload.taskIterator():
@@ -240,18 +245,21 @@ class DatasetTestCase(EmulatedUnitTestCase):
         dqmHarvArgs["DQMConfigCacheID"] = createConfig(dqmHarvArgs["CouchDBName"])
         factory = DQMHarvestWorkloadFactory()
         DQMHarvWorkload = factory.factoryWorkloadConstruction('NoInputDatasetTest', dqmHarvArgs)
+        DQMHarvWorkload.setSiteWhitelist(["T2_XX_SiteA", "T2_XX_SiteB", "T2_XX_SiteC"])
         getFirstTask(DQMHarvWorkload).data.input.dataset = None
         for task in DQMHarvWorkload.taskIterator():
             self.assertRaises(WorkQueueWMSpecError, Dataset(), DQMHarvWorkload, task)
 
         # invalid dataset name
         DQMHarvWorkload = factory.factoryWorkloadConstruction('InvalidInputDatasetTest', dqmHarvArgs)
+        DQMHarvWorkload.setSiteWhitelist(["T2_XX_SiteA", "T2_XX_SiteB", "T2_XX_SiteC"])
         getFirstTask(DQMHarvWorkload).data.input.dataset.name = '/MinimumBias/FAKE-Filter-v1/RECO'
         for task in DQMHarvWorkload.taskIterator():
             self.assertRaises(DBSReaderError, Dataset(), DQMHarvWorkload, task)
 
         # invalid run whitelist
         DQMHarvWorkload = factory.factoryWorkloadConstruction('InvalidRunNumberTest', dqmHarvArgs)
+        DQMHarvWorkload.setSiteWhitelist(["T2_XX_SiteA", "T2_XX_SiteB", "T2_XX_SiteC"])
         DQMHarvWorkload.setRunWhitelist([666])  # not in this dataset
         for task in DQMHarvWorkload.taskIterator():
             self.assertRaises(WorkQueueNoWorkError, Dataset(), DQMHarvWorkload, task)

--- a/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/ResubmitBlock_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/ResubmitBlock_t.py
@@ -271,6 +271,7 @@ class ResubmitBlockTest(EmulatedUnitTestCase):
         """
         self.stuffACDCDatabase()
         acdcWorkload = self.getMergeACDCSpec('ParentlessMergeBySize', {})
+        acdcWorkload.setSiteWhitelist(["T2_XX_SiteA", "T2_XX_SiteB", "T2_XX_SiteC"])
         acdcWorkload.data.request.priority = 10000
         for task in acdcWorkload.taskIterator():
             policy = ResubmitBlock()

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
@@ -343,6 +343,7 @@ class WorkQueueTest(WorkQueueTestCase):
         self.redigiSpec = redigiWorkload('reDigiSpec', self.redigiArgs)
         self.redigiSpec.setSpecUrl(os.path.join(self.workDir,
                                                 'reDigiSpec.spec'))
+        getFirstTask(self.redigiSpec).setSiteWhitelist(['T2_XX_SiteA', 'T2_XX_SiteB', 'T2_XX_SiteC'])
         self.redigiSpec.save(self.redigiSpec.specUrl())
 
     def createResubmitSpec(self, serverUrl, couchDB, parentage=False):
@@ -1006,16 +1007,18 @@ class WorkQueueTest(WorkQueueTestCase):
         mcspec.setSpecUrl(os.path.join(self.workDir, 'testProductionInvalid.spec'))
         mcspec.save(mcspec.specUrl())
         self.assertRaises(WorkQueueWMSpecError, self.queue.queueWork, mcspec.specUrl())
-        getFirstTask(mcspec).setSiteWhitelist([])
+        getFirstTask(mcspec).setSiteWhitelist(['T2_XX_SiteB'])
         self.queue.deleteWorkflows(mcspec.name())
 
         # 0 events
         getFirstTask(mcspec).addProduction(totalEvents=0)
+        getFirstTask(mcspec).setSiteWhitelist(['T2_XX_SiteB'])
         mcspec.save(mcspec.specUrl())
         self.assertRaises(WorkQueueNoWorkError, self.queue.queueWork, mcspec.specUrl())
 
         # no dataset
         processingSpec = rerecoWorkload('testProcessingInvalid', self.rerecoArgs)
+        getFirstTask(processingSpec).setSiteWhitelist(['T2_XX_SiteB'])
         processingSpec.setSpecUrl(os.path.join(self.workDir,
                                                'testProcessingInvalid.spec'))
         processingSpec.save(processingSpec.specUrl())
@@ -1025,6 +1028,7 @@ class WorkQueueTest(WorkQueueTestCase):
 
         # invalid dbs url
         processingSpec = rerecoWorkload('testProcessingInvalid', self.rerecoArgs)
+        getFirstTask(processingSpec).setSiteWhitelist(['T2_XX_SiteB'])
         processingSpec.setSpecUrl(os.path.join(self.workDir,
                                                'testProcessingInvalid.spec'))
         getFirstTask(processingSpec).data.input.dataset.dbsurl = 'wrongprot://dbs.example.com'
@@ -1034,6 +1038,7 @@ class WorkQueueTest(WorkQueueTestCase):
 
         # invalid dataset name
         processingSpec = rerecoWorkload('testProcessingInvalid', self.rerecoArgs)
+        getFirstTask(processingSpec).setSiteWhitelist(['T2_XX_SiteB'])
         processingSpec.setSpecUrl(os.path.join(self.workDir,
                                                'testProcessingInvalid.spec'))
         getFirstTask(processingSpec).data.input.dataset.name = '/MinimumBias/FAKE-Filter-v1/RECO'
@@ -1049,6 +1054,7 @@ class WorkQueueTest(WorkQueueTestCase):
 
         # dataset splitting with invalid run whitelist
         processingSpec = rerecoWorkload('testProcessingInvalid', self.rerecoArgs)
+        getFirstTask(processingSpec).setSiteWhitelist(['T2_XX_SiteB'])
         processingSpec.setSpecUrl(os.path.join(self.workDir,
                                                'testProcessingInvalid.spec'))
         processingSpec.setStartPolicy('Dataset')
@@ -1059,6 +1065,7 @@ class WorkQueueTest(WorkQueueTestCase):
 
         # block splitting with invalid run whitelist
         processingSpec = rerecoWorkload('testProcessingInvalid', self.rerecoArgs)
+        getFirstTask(processingSpec).setSiteWhitelist(['T2_XX_SiteB'])
         processingSpec.setSpecUrl(os.path.join(self.workDir,
                                                'testProcessingInvalid.spec'))
         processingSpec.setStartPolicy('Block')


### PR DESCRIPTION
Fixes #7707
and superseeds #7756

The spec refactoring PR that I'm working on will change the SiteWhitelist definition again, but that's fine.
In addition to that, once we have a proper validation at creation/assignment, we can likely remove most of that duplicated validation under WorkQueue.