### PR TITLE
Fetch proxy validity in AgentStatusPoller and send this info to wmstats

### DIFF
--- a/src/couchapps/WMStats/_attachments/js/DataStruct/WMStats.Agents.js
+++ b/src/couchapps/WMStats/_attachments/js/DataStruct/WMStats.Agents.js
@@ -35,9 +35,17 @@ WMStats.Agents = function (couchData) {
                 report.status = "drain";
                 report.message += "Draining Agent; ";
             }
+
+            if (agentInfo.proxy_warning && agentInfo.status === "warning") {
+                report.status = agentInfo.status;
+                report.message += "Proxy expiration warning; ";
+            } else if (agentInfo.proxy_warning && agentInfo.status === "error") {
+                agentData.agentNumber.error += 1;
+                report.status = agentInfo.status;
+                report.message += "Proxy expiration error; ";
+            }
             
             // warning case
-            
             if (agentInfo.couch_process_warning) {
                 agentData.agentNumber.error += 1;
                 report.status = "error";

--- a/src/couchapps/WMStats/_attachments/js/Views/HTMLList/WMStats.AgentDetailList.js
+++ b/src/couchapps/WMStats/_attachments/js/Views/HTMLList/WMStats.AgentDetailList.js
@@ -32,8 +32,9 @@ WMStats.namespace("AgentDetailList");
         htmlstr += "<div class='" + msgType + " agent_detail_box'>";
         htmlstr += "<ul>";
         if (agentInfo) {
-            htmlstr += "<li><b>agent:</b> " + agentInfo.agent_url + "</li>";
-            htmlstr += "<li><b>agent last updated:</b> " + WMStats.Utils.utcClock(new Date(agentInfo.timestamp * 1000)) +" : " + 
+            agentVersion = '  (' + agentInfo.agent_version + ')'
+            htmlstr += "<li><b>agent:</b> " + agentInfo.agent_url + agentVersion + "</li>";
+            htmlstr += "<li><b>agent last updated:</b> " + WMStats.Utils.utcClock(new Date(agentInfo.timestamp * 1000)) +" : " +
                               agentInfo.alert.agent_update  + "</li>";
             htmlstr += "<li><b>data last updated:</b> " + agentInfo.alert.data_update  + "</li>";
             htmlstr += "<li><b>status:</b> " + agentInfo.alert.message + "</li>";

--- a/src/couchapps/WMStats/_attachments/js/Views/HTMLList/WMStats.AgentDetailList.js
+++ b/src/couchapps/WMStats/_attachments/js/Views/HTMLList/WMStats.AgentDetailList.js
@@ -52,7 +52,11 @@ WMStats.namespace("AgentDetailList");
             htmlstr += diskFullFormat(diskInfo);
             htmlstr +="</li>";
            };
-           
+
+        if (agentInfo.proxy_warning) {
+            htmlstr += "<li><b>proxy warning:</b> " + agentInfo.proxy_warning + "</li>";
+           };
+
         var dataError = agentInfo.data_error;
         if (dataError && dataError !== 'ok') {
             htmlstr += "<li><b>data collect error:</b> ";

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
@@ -905,8 +905,16 @@ WMStats.Agents = function (couchData) {
                 report.message += "Draining Agent; ";
             }
             
+            if (agentInfo.proxy_warning && agentInfo.status === "warning") {
+                report.status = agentInfo.status;
+                report.message += "Proxy expiration warning; ";
+            } else if (agentInfo.proxy_warning && agentInfo.status === "error") {
+                agentData.agentNumber.error += 1;
+                report.status = agentInfo.status;
+                report.message += "Proxy expiration error; ";
+            }
+
             // warning case
-            
             if (agentInfo.couch_process_warning) {
                 agentData.agentNumber.error += 1;
                 report.status = "error";
@@ -2862,7 +2870,11 @@ WMStats.namespace("AgentDetailList");
             htmlstr += diskFullFormat(diskInfo);
             htmlstr +="</li>";
            };
-           
+
+        if (agentInfo.proxy_warning) {
+            htmlstr += "<li><b>proxy warning:</b> " + agentInfo.proxy_warning + "</li>";
+           };
+
         var dataError = agentInfo.data_error;
         if (dataError && dataError !== 'ok') {
             htmlstr += "<li><b>data collect error:</b> ";

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
@@ -2850,8 +2850,9 @@ WMStats.namespace("AgentDetailList");
         htmlstr += "<div class='" + msgType + " agent_detail_box'>";
         htmlstr += "<ul>";
         if (agentInfo) {
-            htmlstr += "<li><b>agent:</b> " + agentInfo.agent_url + "</li>";
-            htmlstr += "<li><b>agent last updated:</b> " + WMStats.Utils.utcClock(new Date(agentInfo.timestamp * 1000)) +" : " + 
+            agentVersion = '  (' + agentInfo.agent_version + ')'
+            htmlstr += "<li><b>agent:</b> " + agentInfo.agent_url + agentVersion + "</li>";
+            htmlstr += "<li><b>agent last updated:</b> " + WMStats.Utils.utcClock(new Date(agentInfo.timestamp * 1000)) +" : " +
                               agentInfo.alert.agent_update  + "</li>";
             htmlstr += "<li><b>data last updated:</b> " + agentInfo.alert.data_update  + "</li>";
             htmlstr += "<li><b>status:</b> " + agentInfo.alert.message + "</li>";

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
@@ -904,9 +904,17 @@ WMStats.Agents = function (couchData) {
                 report.status = "drain";
                 report.message += "Draining Agent; ";
             }
-            
+
+            if (agentInfo.proxy_warning && agentInfo.status === "warning") {
+                report.status = agentInfo.status;
+                report.message += "Proxy expiration warning; ";
+            } else if (agentInfo.proxy_warning && agentInfo.status === "error") {
+                agentData.agentNumber.error += 1;
+                report.status = agentInfo.status;
+                report.message += "Proxy expiration error; ";
+            }
+
             // warning case
-            
             if (agentInfo.couch_process_warning) {
                 agentData.agentNumber.error += 1;
                 report.status = "error";
@@ -3005,7 +3013,11 @@ WMStats.namespace("AgentDetailList");
             htmlstr += diskFullFormat(diskInfo);
             htmlstr +="</li>";
            };
-           
+
+        if (agentInfo.proxy_warning) {
+            htmlstr += "<li><b>proxy warning:</b> " + agentInfo.proxy_warning + "</li>";
+           };
+
         var dataError = agentInfo.data_error;
         if (dataError && dataError !== 'ok') {
             htmlstr += "<li><b>data collect error:</b> ";

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
@@ -2993,8 +2993,9 @@ WMStats.namespace("AgentDetailList");
         htmlstr += "<div class='" + msgType + " agent_detail_box'>";
         htmlstr += "<ul>";
         if (agentInfo) {
-            htmlstr += "<li><b>agent:</b> " + agentInfo.agent_url + "</li>";
-            htmlstr += "<li><b>agent last updated:</b> " + WMStats.Utils.utcClock(new Date(agentInfo.timestamp * 1000)) +" : " + 
+            agentVersion = '  (' + agentInfo.agent_version + ')'
+            htmlstr += "<li><b>agent:</b> " + agentInfo.agent_url + agentVersion + "</li>";
+            htmlstr += "<li><b>agent last updated:</b> " + WMStats.Utils.utcClock(new Date(agentInfo.timestamp * 1000)) +" : " +
                               agentInfo.alert.agent_update  + "</li>";
             htmlstr += "<li><b>data last updated:</b> " + agentInfo.alert.data_update  + "</li>";
             htmlstr += "<li><b>status:</b> " + agentInfo.alert.message + "</li>";

--- a/src/python/WMComponent/AnalyticsDataCollector/DataCollectAPI.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/DataCollectAPI.py
@@ -7,6 +7,7 @@ import time
 import subprocess
 import logging
 
+import WMCore
 from WMCore.Agent.Daemon.Details import Details
 from WMCore.Database.CMSCouch import CouchServer
 from WMCore.DAOFactory import DAOFactory
@@ -443,6 +444,7 @@ def isDrainMode(config):
 def initAgentInfo(config):
     agentInfo = {}
     agentInfo['agent_team'] = config.Agent.teamName
+    agentInfo['agent_version'] = WMCore.__version__
     agentInfo['agent'] = config.Agent.agentName
     # temporarly add port for the split test
     agentInfo['agent_url'] = "%s" % config.Agent.hostName


### PR DESCRIPTION
Superseeds #7349

Code for fetching the lifetime of the user proxy on the agents and creating warning or error message in wmstats.
I also added the agent version to the wmstats view, it'll make our life easier when checking what is up and running and their versions.