### PR TITLE
Collect local workqueue info in AgentStatusWatcher

### DIFF
--- a/src/python/Utils/Utilities.py
+++ b/src/python/Utils/Utilities.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 from __future__ import division, print_function
+import time
 
 
 def makeList(stringList):
@@ -58,3 +59,22 @@ def safeStr(string):
     if not isinstance(string, (tuple, list, set, dict)):
         return str(string)
     raise ValueError("We're not supposed to convert %s to string." % string)
+
+
+def timeit(func):
+    """
+    source: https://www.andreas-jung.com/contents/a-python-decorator-for-measuring-the-execution-time-of-methods
+
+    Decorator function to measure how long a method/function takes to run
+    It returns a tuple with:
+      * wall clock time spent
+      * returned result of the function
+      * the function name
+    """
+    def wrapper(*arg, **kw):
+        t1 = time.time()
+        res = func(*arg, **kw)
+        t2 = time.time()
+        return (t2 - t1), res, func.__name__
+
+    return wrapper


### PR DESCRIPTION
Basic monitoring for local workqueue database.

I've also added a timeit decorator function that we can start using in the code for timing a method/function execution (unfortunately I squashed it with the real code change here).