### PR TITLE
Handle ParentData in ResubmitBlock WQ policy

### DIFF
--- a/src/python/WMCore/WorkQueue/Policy/Start/ResubmitBlock.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/ResubmitBlock.py
@@ -58,12 +58,15 @@ class ResubmitBlock(StartPolicyInterface):
         self.sites = makeLocationsList(siteWhitelist, siteBlacklist)
 
         for block in self.validBlocks(self.initialTask):
+            parentList = {}
+            parentFlag = False
             if self.initialTask.parentProcessingFlag():
                 parentFlag = True
-            else:
-                parentFlag = False
+                parentList[block["Name"]] = block['Sites']
+
             self.newQueueElement(Inputs={block['Name']: block['Sites']},
                                  ParentFlag=parentFlag,
+                                 ParentData=parentList,
                                  NumberOfLumis=block[self.lumiType],
                                  NumberOfFiles=block['NumberOfFiles'],
                                  NumberOfEvents=block['NumberOfEvents'],
@@ -163,4 +166,5 @@ class ResubmitBlock(StartPolicyInterface):
         dbsBlock['ACDC'] = acdcInfo
         if dbsBlock['NumberOfFiles']:
             result.append(dbsBlock)
+
         return result


### PR DESCRIPTION
Fixes #7781 
Apparently we have never set ParentData in ResubmitBlock elements, which surprises me we haven't found this issue before..

Anyways, for each file we upload to the ACDC server, we define a dictionary with its lfn, parents and locations, which means the location uploaded to the server already is the intersection of input + parent, thus we reuse that location here.

Testing it in my VM.