### PR TITLE
Record and propagate events information per lumi to DBS

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/DBSBufferBlock.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSBufferBlock.py
@@ -141,7 +141,11 @@ class DBSBufferBlock:
         lumiList = []
         for run in dbsFile.getRuns():
             for lumi in run.lumis:
-                lumiList.append({'lumi_section_num': lumi, 'run_num': run.run})
+                dbsLumiDict = {'lumi_section_num': lumi, 'run_num': run.run}
+                if run.getEventsByLumi(lumi) is not None:
+                    # if events is not None update event for dbs upload
+                    dbsLumiDict['event_count'] = run.getEventsByLumi(lumi)
+                lumiList.append(dbsLumiDict)
         fileDict['file_lumi_list'] = lumiList
 
         # Append to the files list
@@ -461,6 +465,7 @@ class DBSBufferBlock:
     def convertToDBSBlock(self):
         """
         convert to DBSBlock structure to upload to dbs
+        TODO: check file lumi event and validate event is not null
         """
         block = {}
 

--- a/src/python/WMComponent/DBS3Buffer/DBSBufferUtil.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSBufferUtil.py
@@ -147,7 +147,7 @@ class DBSBufferUtil(WMConnectionBase):
                 # Then we have to replace it with a real run
                 for r in dbsfile['runInfo'].keys():
                     run = Run(runNumber = r)
-                    run.extend(dbsfile['runInfo'][r])
+                    run.extendLumis(dbsfile['runInfo'][r])
                     dbsfile.addRun(run)
                 del dbsfile['runInfo']
             if 'parentLFNs' in dbsfile.keys():
@@ -182,7 +182,7 @@ class DBSBufferUtil(WMConnectionBase):
                 # Then we have to replace it with a real run
                 for r in dbsfile['runInfo'].keys():
                     run = Run(runNumber = r)
-                    run.extend(dbsfile['runInfo'][r])
+                    run.extendLumis(dbsfile['runInfo'][r])
                     dbsfile.addRun(run)
                 del dbsfile['runInfo']
             if 'parentLFNs' in dbsfile.keys():

--- a/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/AddRunLumi.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/AddRunLumi.py
@@ -10,8 +10,8 @@ from WMCore.Database.DBFormatter import DBFormatter
 
 
 class AddRunLumi(DBFormatter):
-    sql = """insert dbsbuffer_file_runlumi_map (filename, run, lumi)
-            select id, :run, :lumi from dbsbuffer_file
+    sql = """insert dbsbuffer_file_runlumi_map (filename, run, lumi, num_events)
+            select id, :run, :lumi, :num_events from dbsbuffer_file
             where lfn = :lfn"""
 
     def getBinds(self, filename=None, runs=None):
@@ -36,7 +36,8 @@ class AddRunLumi(DBFormatter):
                 for lumi in run:
                     binds.append({'lfn': lfn,
                                   'run': run.run,
-                                  'lumi': lumi})
+                                  'lumi': lumi,
+                                  'num_events': run.getEventsByLumi(lumi)})
         else:
             raise Exception("Type of runs argument is not allowed: %s" \
                             % type(runs))

--- a/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/GetRunLumiFile.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/GetRunLumiFile.py
@@ -11,7 +11,7 @@ MySQL implementation of GetRunLumiFile
 from WMCore.Database.DBFormatter import DBFormatter
 
 class GetRunLumiFile(DBFormatter):
-    sql = """select flr.run as run, flr.lumi as lumi
+    sql = """select flr.run as run, flr.lumi as lumi, flr.num_events as num_events
                 from dbsbuffer_file_runlumi_map flr
                         where flr.filename in (select id from dbsbuffer_file where lfn=:lfn)"""
 
@@ -30,7 +30,7 @@ class GetRunLumiFile(DBFormatter):
             for i in r.fetchall():
                 if i[0] not in run_lumis.keys():
                     run_lumis[i[0]]=[]
-                run_lumis[i[0]].append(i[1])
+                run_lumis[i[0]].append((i[1], i[2]))
 
         return run_lumis
 

--- a/src/python/WMComponent/DBS3Buffer/MySQL/LoadDBSFilesByDAS.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/LoadDBSFilesByDAS.py
@@ -60,7 +60,7 @@ class LoadDBSFilesByDAS(DBFormatter):
                            WHERE fcs.fileid = :fileid"""
 
 
-    getRunLumiSQL = """SELECT flr.run AS run, flr.lumi AS lumi, dbsbuffer_file.id AS id
+    getRunLumiSQL = """SELECT flr.run AS run, flr.lumi AS lumi, flr.num_events AS num_events, dbsbuffer_file.id AS id
                           FROM dbsbuffer_file_runlumi_map flr
                           INNER JOIN dbsbuffer_file ON dbsbuffer_file.id = flr.filename
                           WHERE dbsbuffer_file.id = :fileid"""
@@ -181,8 +181,7 @@ class LoadDBSFilesByDAS(DBFormatter):
                 interimDictionary[entry['id']] = {}
             if entry['run'] not in interimDictionary[entry['id']].keys():
                 interimDictionary[entry['id']][entry['run']] = []
-            interimDictionary[entry['id']][entry['run']].append(entry['lumi'])
-
+            interimDictionary[entry['id']][entry['run']].append((entry['lumi'], entry["num_events"]))
 
         finalList = []
         for entry in interimDictionary.keys():

--- a/src/python/WMComponent/DBS3Buffer/Oracle/DBSBufferFiles/AddRunLumi.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/DBSBufferFiles/AddRunLumi.py
@@ -9,6 +9,6 @@ from WMComponent.DBS3Buffer.MySQL.DBSBufferFiles.AddRunLumi import AddRunLumi as
 
 class AddRunLumi(MySQLAddRunLumi):
 
-    sql = """INSERT INTO dbsbuffer_file_runlumi_map (filename, run, lumi)
-            select id, :run, :lumi from dbsbuffer_file
+    sql = """INSERT INTO dbsbuffer_file_runlumi_map (filename, run, lumi, num_events)
+            select id, :run, :lumi, :num_events from dbsbuffer_file
             where lfn = :lfn"""

--- a/src/python/WMComponent/JobAccountant/AccountantWorker.py
+++ b/src/python/WMComponent/JobAccountant/AccountantWorker.py
@@ -369,12 +369,7 @@ class AccountantWorker(WMConnectionBase):
         #TODO need to find where to get the prep id
         dbsFile.setPrepID(prep_id = jobReportFile.get('prep_id', None))
         dbsFile['task'] = task
-
-        for run in jobReportFile["runs"]:
-            newRun = Run(runNumber = run.run)
-            newRun.extend(run.lumis)
-            dbsFile.addRun(newRun)
-
+        dbsFile['runs'] = jobReportFile['runs']
 
         dbsFile.setLocation(pnn = list(jobReportFile["locations"])[0], immediateSave = False)
         self.dbsFilesToCreate.append(dbsFile)

--- a/src/python/WMCore/ACDC/DataCollectionService.py
+++ b/src/python/WMCore/ACDC/DataCollectionService.py
@@ -252,7 +252,7 @@ class DataCollectionService(CouchService):
                            locations=set(fileInfo["locations"]), merged=fileInfo["merged"])
             for run in fileInfo["runs"]:
                 newRun = Run(run["run_number"])
-                newRun.extend(run["lumis"])
+                newRun.extendLumis(run["lumis"])
                 newFile.addRun(newRun)
 
             chunkFiles.append(newFile)

--- a/src/python/WMCore/DataStructs/Mask.py
+++ b/src/python/WMCore/DataStructs/Mask.py
@@ -200,7 +200,7 @@ class Mask(dict):
         runDict = {}
         for r in runs:
             if r.run in runDict:
-                runDict[r.run].lumis.extend(r.lumis)
+                runDict[r.run].extendLumis(r.lumis)
             else:
                 runDict[r.run] = r
 
@@ -219,6 +219,7 @@ class Mask(dict):
 
             filteredLumis = set(runDict[runNumber].lumis).intersection(maskLumis)
             if len(filteredLumis) > 0:
-                newRuns.add(Run(runNumber, *list(filteredLumis)))
+                filteredLumiEvents = [(lumi, runDict[runNumber].getEventsByLumi(lumi)) for lumi in filteredLumis]
+                newRuns.add(Run(runNumber, *filteredLumiEvents))
 
         return newRuns

--- a/src/python/WMCore/DataStructs/Run.py
+++ b/src/python/WMCore/DataStructs/Run.py
@@ -176,6 +176,12 @@ class Run(WMObject):
         else:  # Just given lumis, not events
             if lumi not in self.eventsPerLumi:  # Don't overwrite existing events
                 self.eventsPerLumi[lumi] = None
+    
+    def getEventsByLumi(self, lumi):
+        """
+        getter to select event counts by given lumi
+        """
+        return self.eventsPerLumi.get(lumi)
 
     def json(self):
         """

--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -92,7 +92,10 @@ class DBS3Reader(object):
             item = {}
             item["RunNumber"] = lumisItem['run_num']
             item['LumiSectionNumber'] = lumisItem['lumi_section_num']
+            if lumisItem.get('event_count', None) is not None:
+                item['EventCount'] = lumisItem['event_count']
             lumiDict[lumisItem['logical_file_name']].append(item)
+            # TODO: add key for lumi and event pair.
         return lumiDict
 
     def checkDBSServer(self):

--- a/src/python/WMCore/WMBS/File.py
+++ b/src/python/WMCore/WMBS/File.py
@@ -9,7 +9,6 @@ A simple object representing a file in WMBS.
 
 
 import threading
-import time
 import logging
 
 from WMCore.DataStructs.File import File as WMFile

--- a/src/python/WMCore/WMBS/MySQL/Files/AddRunLumi.py
+++ b/src/python/WMCore/WMBS/MySQL/Files/AddRunLumi.py
@@ -10,8 +10,8 @@ from WMCore.Database.DBFormatter import DBFormatter
 
 
 class AddRunLumi(DBFormatter):
-    sql = """INSERT IGNORE wmbs_file_runlumi_map (fileid, run, lumi)
-            select id, :run, :lumi from wmbs_file_details
+    sql = """INSERT IGNORE wmbs_file_runlumi_map (fileid, run, lumi, num_events)
+            select id, :run, :lumi, :num_events from wmbs_file_details
             where lfn = :lfn"""
 
     def getBinds(self, filename=None, runs=None):
@@ -36,7 +36,8 @@ class AddRunLumi(DBFormatter):
                 for lumi in run:
                     binds.append({'lfn': lfn,
                                   'run': run.run,
-                                  'lumi': lumi})
+                                  'lumi': lumi,
+                                  'num_events': run.getEventsByLumi(lumi)})
         else:
             raise Exception("Type of runs argument is not allowed: %s" \
                             % type(runs))

--- a/src/python/WMCore/WMBS/MySQL/Files/GetRunLumiFile.py
+++ b/src/python/WMCore/WMBS/MySQL/Files/GetRunLumiFile.py
@@ -11,7 +11,8 @@ MySQL implementation of GetRunLumiFile
 from WMCore.Database.DBFormatter import DBFormatter
 
 class GetRunLumiFile(DBFormatter):
-    sql = """SELECT flr.run AS run, flr.lumi AS lumi FROM wmbs_file_runlumi_map flr
+    sql = """SELECT flr.run AS run, flr.lumi AS lumi, flr.num_events as num_events
+               FROM wmbs_file_runlumi_map flr
                INNER JOIN wmbs_file_details wfd ON wfd.id = flr.fileid
                WHERE wfd.lfn = :lfn"""
 
@@ -30,7 +31,7 @@ class GetRunLumiFile(DBFormatter):
             for i in r.fetchall():
                 if i[0] not in run_lumis.keys():
                     run_lumis[i[0]]=[]
-                run_lumis[i[0]].append(i[1])
+                run_lumis[i[0]].append((i[1], i[2]))
                 r.close()
         return run_lumis
 

--- a/src/python/WMCore/WMBS/MySQL/Jobs/LoadForErrorHandler.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/LoadForErrorHandler.py
@@ -53,7 +53,7 @@ class LoadForErrorHandler(DBFormatter):
                      INNER JOIN wmbs_file_details parent ON parent.id = wfp.parent
                      WHERE wfp.child = :fileid """
 
-    runLumiSQL = """SELECT fileid, run, lumi FROM wmbs_file_runlumi_map
+    runLumiSQL = """SELECT fileid, run, lumi, num_events FROM wmbs_file_runlumi_map
                      WHERE fileid = :fileid"""
 
 
@@ -136,11 +136,9 @@ class LoadForErrorHandler(DBFormatter):
                     for l in lumiDict[f['id']]:
                         run  = l['run']
                         lumi = l['lumi']
-                        try:
-                            fileRuns[run].append(lumi)
-                        except KeyError:
-                            fileRuns[run] = []
-                            fileRuns[run].append(lumi)
+                        numEvents = l['num_events']
+                        fileRuns.setdefault(run, [])
+                        fileRuns[run].append((lumi, numEvents))
 
                 for r in fileRuns.keys():
                     newRun = Run(runNumber = r)

--- a/src/python/WMCore/WMBS/Oracle/Files/AddRunLumi.py
+++ b/src/python/WMCore/WMBS/Oracle/Files/AddRunLumi.py
@@ -12,8 +12,8 @@ class AddRunLumi(AddRunLumiMySQL):
     To Check: might not need to overwrite if modifiy MySQL.Files.AddRunLumi.sql
     a bit to work with both
     """
-    sql = """INSERT INTO wmbs_file_runlumi_map (fileid, run, lumi)
-                SELECT wfd.id, :run, :lumi FROM wmbs_file_details wfd WHERE lfn = :lfn
+    sql = """INSERT INTO wmbs_file_runlumi_map (fileid, run, lumi, num_events)
+                SELECT wfd.id, :run, :lumi, :num_events FROM wmbs_file_details wfd WHERE lfn = :lfn
                   AND NOT EXISTS (SELECT fileid FROM wmbs_file_runlumi_map wfrm2
                                    WHERE wfrm2.fileid = wfd.id
                                    AND wfrm2.run = :run

--- a/src/python/WMCore/WorkQueue/WMBSHelper.py
+++ b/src/python/WMCore/WorkQueue/WMBSHelper.py
@@ -183,7 +183,6 @@ class WMBSHelper(WMConnectionBase):
 
         # DAOs from WMBS for file commit
         self.setParentage = self.daofactory(classname="Files.SetParentage")
-        self.setFileRunLumi = self.daofactory(classname="Files.AddRunLumi")
         self.setFileLocation = self.daofactory(classname="Files.SetLocationForWorkQueue")
         self.setFileAddChecksum = self.daofactory(classname="Files.AddChecksumByLFN")
         self.addFileAction = self.daofactory(classname="Files.Add")
@@ -612,6 +611,7 @@ class WMBSHelper(WMConnectionBase):
            This is not True in general case, but workquue should only select work only
            where child and parent files are in the same location
         """
+        # TODO get dbsFile with lumi event information
         wmbsParents = []
         dbsFile.setdefault("ParentList", [])
         for parent in dbsFile["ParentList"]:
@@ -634,9 +634,13 @@ class WMBSHelper(WMConnectionBase):
 
         for lumi in dbsFile['LumiList']:
             if isinstance(lumi['LumiSectionNumber'], list):
-                run = Run(lumi['RunNumber'], *lumi['LumiSectionNumber'])
+                lumiSecList = (list(zip(lumi['LumiSectionNumber'], lumi['EventCount']))
+                               if 'EventCount' in lumi else lumi['LumiSectionNumber'])
+                run = Run(lumi['RunNumber'], lumiSecList)
             else:
-                run = Run(lumi['RunNumber'], lumi['LumiSectionNumber'])
+                lumiSecTuple = ((lumi['LumiSectionNumber'], lumi['EventCount'])
+                               if 'EventCount' in lumi else lumi['LumiSectionNumber'])
+                run = Run(lumi['RunNumber'], lumiSecTuple)
             wmbsFile.addRun(run)
 
         self._addToDBSBuffer(dbsFile, checksums, storageElements)


### PR DESCRIPTION
fixes #7712
Initial attempt to handle event per lumi. Patch contains.

0. schema change on wmbs - already in master (https://github.com/dmwm/WMCore/pull/7779)
1. reading from DBS with event information (dbsapi.listFileLumis - should return events information, check with Yuyi about the format) - done
2. reading from FWJR with event information - already in master branch (https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/FwkJobReport/Report.py#L89)
3. Update the query to insert event information from 1., 2. - included in this patch
4. Read events information from updated *_runlumi_map table with correct format - included in this patch
5. writing to dbs. (using dbsApi.insertBulkBlock call) - done
6. Writing to ACDC - done (current agent code might be broken.)
7. Read from ACDC -  done

