### PR TITLE
Fix request archival logic

### DIFF
--- a/src/python/WMCore/ReqMgr/DataStructs/Request.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/Request.py
@@ -183,10 +183,8 @@ class RequestInfo(object):
         for key, value in filterDict.iteritems():
             # special case checks where key is not exist in Request's Doc.
             # It is used whether AgentJobInfo is deleted or not for announced status
-            if value == "NO_KEY" and key not in self.data:
+            if value == "NO_KEY":
                 continue
-            elif value == "NO_KEY" and key in self.data:
-                return False
 
             if isinstance(value, dict):
                 # TODO: need to handle dictionary comparison


### PR DESCRIPTION
That's why we have some workflows (either in my VM and testbed) not moving to archived.

I was going to say that I don't understand why we need to pass the `AgentJobInfo` as input condition
https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/ReqMgr/CherryPyThreads/StatusChangeTasks.py#L90

but I think the answer is that the agent may still be running logCollect/Cleanup, thus we don't want to archive it. 

@ticoann is that the case?

If so, then this one should be getting archived:
https://cmsweb-testbed.cern.ch/wmstatsserver/data/filtered_requests?RequestStatus=announced&mask=RequestTransition&mask=AgentJobInfo

since all the subscriptions are finished.
