### PR TITLE
Make a clear distinction between ReqMgr2 and user create arguments

### DIFF
--- a/src/python/WMCore/ReqMgr/DataStructs/Request.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/Request.py
@@ -55,22 +55,19 @@ def initialize_request_args(request, config, clone=False):
                                      "UpdateTime": int(time.time()), "DN": request["RequestorDN"]}]
     request["RequestDate"] = list(time.gmtime()[:6])
 
-    # TODO: generate this automatically from the spec
-    # generate request name using request
-    generateRequestName(request)
-
     if clone:
         # if it is clone parameter should contain requestName
         request["OriginalRequestName"] = request["RequestName"]
-        request["OriginalRequestType"] = request["RequestType"]
     else:
         # update the information from config
         request["CouchURL"] = config.couch_host
         request["CouchWorkloadDBName"] = config.couch_reqmgr_db
         request["CouchDBName"] = config.couch_config_cache_db
 
+    generateRequestName(request)
 
-def initialize_resubmission(request_args, acceptedArgs, reqmgr_db_service):
+
+def initialize_resubmission(request_args, reqmgr_db_service):
     """
     Initialize a Resubmission request by inheriting the original/parent information
     from couch, unless the user has overwritten that argument in the resubmission request.
@@ -82,8 +79,10 @@ def initialize_resubmission(request_args, acceptedArgs, reqmgr_db_service):
     parent_args = {k: v for k, v in parent_args.iteritems() if k not in ARGS_TO_REMOVE_FROM_ORIGINAL_REQUEST}
 
     for arg in parent_args:
-        if arg not in request_args and arg in acceptedArgs:
+        if arg not in request_args:
             request_args[arg] = parent_args[arg]
+    # to be used later on for spec validation
+    request_args["OriginalRequestType"] = parent_args["RequestType"]
 
 
 def generateRequestName(request):

--- a/src/python/WMCore/ReqMgr/Utils/Validation.py
+++ b/src/python/WMCore/ReqMgr/Utils/Validation.py
@@ -134,16 +134,7 @@ def validate_request_create_args(request_args, config, reqmgr_db_service, *args,
     if request_args["RequestType"] == "Resubmission":
         # do not set default values for Resubmission since it will be inherited from parent
         # both create & assign args are accepted for Resubmission creation
-        acceptedArgs = {}
-        if 'OriginalRequestType' in request_args:
-            parentSpecClass = loadSpecClassByType(request_args['OriginalRequestType'])
-            acceptedArgs = parentSpecClass.getWorkloadCreateArgs()
-
-        acceptedArgs.update(specClass.getWorkloadCreateArgs())
-        assignArgs = specClass.getWorkloadAssignArgs()
-        acceptedArgs.update(assignArgs)
-
-        initialize_resubmission(request_args, acceptedArgs, reqmgr_db_service)
+        initialize_resubmission(request_args, reqmgr_db_service)
     else:
         # set default values for the request_args
         setArgumentsWithDefault(request_args, specClass.getWorkloadCreateArgs())

--- a/src/python/WMCore/ReqMgr/Utils/Validation.py
+++ b/src/python/WMCore/ReqMgr/Utils/Validation.py
@@ -95,37 +95,21 @@ def validate_request_update_args(request_args, config, reqmgr_db_service, param)
     # validate the status
     if "RequestStatus" in request_args:
         validate_state_transition(reqmgr_db_service, request_name, request_args["RequestStatus"])
-        # delete request_args since it is not part of spec argument and validation
-        if request_args["RequestStatus"] not in STATES_ALLOW_ONLY_STATE_TRANSITION:
-            args_without_status = {}
-            args_without_status.update(request_args)
-            del args_without_status["RequestStatus"]
-        else:
+        if request_args["RequestStatus"] in STATES_ALLOW_ONLY_STATE_TRANSITION:
             # if state change doesn't allow other transition nothing else to validate
             args_only_status = {}
             args_only_status["RequestStatus"] = request_args["RequestStatus"]
-            if 'cascade' in request_args:
-                args_only_status["cascade"] = request_args["cascade"]
+            args_only_status["cascade"] = request_args.get("cascade", False)
             return workload, args_only_status
-    else:
-        args_without_status = request_args
+        elif request_args["RequestStatus"] == 'assigned':
+            workload.validateArgumentForAssignment(request_args)
 
-    if len(args_without_status) == 1:
-        if 'RequestPriority' in args_without_status:
-            args_without_status['RequestPriority'] = int(args_without_status['RequestPriority'])
-            if (lambda x: (x >= 0 and x < 1e6))(args_without_status['RequestPriority']) is False:
-                raise InvalidSpecParameterValue("RequestPriority must be an integer between 0 and 1e6")
-            if "RequestStatus" in request_args:
-                return workload, request_args
-            else:
-                return workload, args_without_status
-    elif len(args_without_status) > 0 and not workqueue_stat_validation(args_without_status):
-        # validate the arguments against the spec argumentSpecdefinition
-        # TODO: currently only assigned status allows any update other then Status update
-        workload.validateArgumentForAssignment(args_without_status)
+    # TODO: fetch it from the assignment arg definition
+    if 'RequestPriority' in request_args:
+        request_args['RequestPriority'] = int(request_args['RequestPriority'])
+        if (lambda x: (x >= 0 and x < 1e6))(request_args['RequestPriority']) is False:
+            raise InvalidSpecParameterValue("RequestPriority must be an integer between 0 and 1e6")
 
-    # to update request_args with type conversion
-    request_args.update(args_without_status)
     return workload, request_args
 
 

--- a/src/python/WMCore/WMSpec/StdSpecs/Resubmission.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Resubmission.py
@@ -7,13 +7,13 @@ with limited input for error recovery.
 """
 
 from Utils.Utilities import makeList
-from WMCore.Lexicon import couchurl, identifier, cmsname
-from WMCore.WMSpec.StdSpecs.DataProcessing import DataProcessing
+from WMCore.Lexicon import couchurl, identifier, cmsname, dataset
+from WMCore.WMSpec.StdSpecs.StdBase import StdBase
 from WMCore.WMSpec.WMWorkload import WMWorkloadHelper
 from WMCore.WMSpec.WMWorkloadTools import loadSpecClassByType, validateArgumentsCreate
 
 
-class ResubmissionWorkloadFactory(DataProcessing):
+class ResubmissionWorkloadFactory(StdBase):
     """
     _ResubmissionWorkloadFactory_
 
@@ -52,13 +52,12 @@ class ResubmissionWorkloadFactory(DataProcessing):
         return helper
 
     def __call__(self, workloadName, arguments):
-        DataProcessing.__call__(self, workloadName, arguments)
+        StdBase.__call__(self, workloadName, arguments)
         self.originalRequestName = self.initialTaskPath.split('/')[1]
         return self.buildWorkload(arguments)
 
     @staticmethod
     def getWorkloadCreateArgs():
-        baseArgs = DataProcessing.getWorkloadCreateArgs()
         specArgs = {"RequestType" : {"default" : "Resubmission"},
                     "OriginalRequestType": {"null": False},
                     "OriginalRequestName": {"null": False},
@@ -71,11 +70,12 @@ class ResubmissionWorkloadFactory(DataProcessing):
                     "CollectionName": {"default" : None, "null" : True},
                     "IgnoredOutputModules": {"default": [], "type": makeList},
                     "SiteWhitelist": {"default": [], "type": makeList,
-                                      "validate": lambda x: all([cmsname(y) for y in x])}}
+                                      "validate": lambda x: all([cmsname(y) for y in x])},
+                    # it can be Chained or MC requests, so lets make it optional
+                    "InputDataset" : {"optional": True, "validate" : dataset, "null" : True}}
 
-        baseArgs.update(specArgs)
-        DataProcessing.setDefaultArgumentsProperty(baseArgs)
-        return baseArgs
+        StdBase.setDefaultArgumentsProperty(specArgs)
+        return specArgs
 
     def validateSchema(self, schema):
         """

--- a/src/python/WMCore/WMSpec/WMWorkloadTools.py
+++ b/src/python/WMCore/WMSpec/WMWorkloadTools.py
@@ -289,11 +289,16 @@ def validateUnknownArgs(arguments, argumentDefinition):
     unknownArgs = set(arguments) - set(argumentDefinition.keys())
     if unknownArgs:
         # now onto the exceptions...
-        if arguments.get("RequestType") in ["ReReco", "Resubmission"]:
+        if arguments.get("RequestType") == "ReReco":
             unknownArgs = unknownArgs - set([x for x in unknownArgs if x.startswith("Skim")])
-        elif arguments.get("RequestType") in ["StepChain", "Resubmission"]:
+        elif arguments.get("RequestType") == "StepChain":
             unknownArgs = unknownArgs - set([x for x in unknownArgs if x.startswith("Step")])
-        elif arguments.get("RequestType") in ["TaskChain", "Resubmission"]:
+        elif arguments.get("RequestType") == "TaskChain":
+            unknownArgs = unknownArgs - set([x for x in unknownArgs if x.startswith("Task")])
+        elif arguments.get("RequestType") == "Resubmission":
+            # oh well, then we have to skip all possible obscure arguments
+            unknownArgs = unknownArgs - set([x for x in unknownArgs if x.startswith("Skim")])
+            unknownArgs = unknownArgs - set([x for x in unknownArgs if x.startswith("Step")])
             unknownArgs = unknownArgs - set([x for x in unknownArgs if x.startswith("Task")])
 
         if unknownArgs:


### PR DESCRIPTION
@ticoann I'm pretty sure you predicted this confusion... :-(

Besides this distinction, the only changes are:
*) RequestString is not a ReqMgr2 argument, but user has to provide it
*) RequestStatus is mandatory during assignment (maybe there was a reason I set it to optional...)

Once we merge it, we should point the master code to Antanas again.