### PR TITLE
fix env when docker container is used

### DIFF
--- a/test/deploy/env_unittest.sh
+++ b/test/deploy/env_unittest.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+export USER=`whoami`
 export BASE_DIR=$PWD
 export TEST_DIR=$BASE_DIR/wmcore_unittest
 export TEST_SRC=$TEST_DIR/WMCore/src


### PR DESCRIPTION
When docker container is used for the unittest, USER env variable is not set automatically.
That cause some unittest to fail when dbs client is used.