### PR TITLE
Auto-discover the latest python release on the worker nodes - python …

### DIFF
--- a/etc/interactivejob.sh
+++ b/etc/interactivejob.sh
@@ -88,7 +88,7 @@ if [ ! -e $JOB_SANDBOX ]; then
     exit 1
 fi
 
- . $VO_CMS_SW_DIR/COMP/slc6_amd64_gcc493/external/python/2.7.6/etc/profile.d/init.sh
+ . $VO_CMS_SW_DIR/COMP/slc6_amd64_gcc493/external/python/2.7.13/etc/profile.d/init.sh
 #
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$VO_CMS_SW_DIR/COMP/$SCRAM_ARCH/external/openssl/1.0.1p/lib
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$VO_CMS_SW_DIR/COMP/$SCRAM_ARCH/external/bz2lib/1.0.6/lib

--- a/test/python/WMComponent_t/JobSubmitter_t/submit.sh
+++ b/test/python/WMComponent_t/JobSubmitter_t/submit.sh
@@ -5,7 +5,7 @@ SANDBOX=$1
 INDEX=$2
 
 ls
-. /uscmst1/prod/sw/cms/slc6_amd64_gcc493/external/python/2.7.6/etc/profile.d/init.sh 
+. /uscmst1/prod/sw/cms/slc6_amd64_gcc493/external/python/2.7.13/etc/profile.d/init.sh 
 . /uscmst1/prod/sw/cms/setup/shrc prod
 # BADPYTHON
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/uscmst1/prod/sw/cms/slc6_amd64_gcc493/external/openssl/1.0.1p/lib:/uscmst1/prod/sw/cms/slc6_amd64_gcc493/external/bz2lib/1.0.6/lib


### PR DESCRIPTION
…2.7.13

Following the migration to python 2.7.13, update the bootstrap code and make it source and use the latest python release available in the COMP respository. Once we move to python 3, it should also adapt the binary to be used as `python3`.