### PR TITLE
Allow -fake- Campaign arg at chain level

### DIFF
--- a/src/python/WMCore/Lexicon.py
+++ b/src/python/WMCore/Lexicon.py
@@ -270,6 +270,14 @@ def acqname(candidate):
     else:
         return check(r'[a-zA-Z][a-zA-Z0-9_]*$', candidate)
 
+def campaign(candidate):
+    """
+    Check for Campaign name.
+    letters, numbers, underscores and dashes are allowed, up to 60 chars.
+    """
+    if not candidate:
+        return True
+    return check(r'^[a-zA-Z0-9-_]{1,60}$', candidate)
 
 def primdataset(candidate):
     """

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -10,7 +10,7 @@ from Utils.Utilities import makeList, makeNonEmptyList, strToBool, safeStr
 from WMCore.Cache.WMConfigCache import ConfigCache, ConfigCacheException
 from WMCore.Configuration import ConfigSection
 from WMCore.Lexicon import couchurl, procstring, activity, procversion, primdataset
-from WMCore.Lexicon import lfnBase, identifier, acqname, cmsname, dataset, block
+from WMCore.Lexicon import lfnBase, identifier, acqname, cmsname, dataset, block, campaign
 from WMCore.ReqMgr.DataStructs.RequestStatus import REQUEST_START_STATE
 from WMCore.ReqMgr.Tools.cms import releases, architectures
 from WMCore.Services.Dashboard.DashboardReporter import DashboardReporter
@@ -994,7 +994,7 @@ class StdBase(object):
         arguments = {"RequestType": {"default": "StdBase", "optional": False},
                      "RequestString": {"optional": False, "null": False},
                      # default value will be AcquisitionEra except when AcquistionEra is dict
-                     "Campaign": {"default": "", "optional": True},
+                     "Campaign": {"default": "", "optional": True, "validate": campaign},
                      "CMSSWVersion": {"validate": lambda x: x in releases(),
                                       "optional": False, "attr": "frameworkVersion"},
                      "ScramArch": {"validate": lambda x: all([y in architectures() for y in x]),
@@ -1166,6 +1166,8 @@ class StdBase(object):
         at the docstring for getWorkloadCreateArgs.
         """
         arguments = {'AcquisitionEra': {'optional': True, 'validate': acqname},
+                     # Campaign at chain level has no meaning but for CompOps/McM bookkeeping
+                     "Campaign": {"optional": True, "validate": campaign},
                      'BlockBlacklist': {'default': [], 'null': False, 'optional': True, 'type': makeList,
                                         'validate': lambda x: all([block(y) for y in x])},
                      'BlockWhitelist': {'default': [], 'null': False, 'optional': True, 'type': makeList,

--- a/test/python/WMCore_t/Lexicon_t.py
+++ b/test/python/WMCore_t/Lexicon_t.py
@@ -213,6 +213,34 @@ class LexiconTest(unittest.TestCase):
         self.assertRaises(AssertionError, acqname, 'Run2016B-Terrible')
         return
 
+    def testGoodCampaign(self):
+        """
+        _testGoodCampaign_
+
+        Test some valid Campaign names
+        """
+        self.assertTrue(campaign(''))
+        self.assertTrue(campaign(None))
+        self.assertTrue(campaign('a22'))
+        self.assertTrue(campaign('aForReals'))
+        self.assertTrue(campaign('Run1016B'))
+        self.assertTrue(campaign('CMSSW_9_1_0_pre2__UPSG_Tracker_PU200-1492810586'))
+        return
+
+    def testBadCampaign(self):
+        """
+        _testBadCampaign_
+
+        Test some invalid Campaign names
+        """
+        self.assertRaises(AssertionError, campaign, '*Nothing')
+        self.assertRaises(AssertionError, campaign, 'B@dCampaign')
+        self.assertRaises(AssertionError, campaign, '\version')
+        self.assertRaises(AssertionError, campaign, '/bad-campaign')
+        self.assertRaises(AssertionError, campaign, 'spaced campaign')
+        self.assertRaises(AssertionError, campaign, 'a_very_very_very__very__very__very_long_campaign_with_62_chars')
+        return
+
     def testGoodSearchstr(self):
         # Check that valid searchstr work
         assert searchstr('/store/mc/Fall08/BBJets250to500-madgraph/*'), 'valid search string not validated'


### PR DESCRIPTION
As requested by @vlimant and @anorkus, allow `Campaign` to be set at task/step level as well, during creation time. It has no meaning in the WMCore code, it's still a request argument and the system will only use the top level argument.