### PR TITLE
Insert input files into dbsbuffer with in_phedex=1

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/DBSBufferFile.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSBufferFile.py
@@ -13,13 +13,17 @@ from WMCore.WMBS.WMBSBase import WMBSBase
 
 
 class DBSBufferFile(WMBSBase, WMFile):
-    def __init__(self, lfn = None, id = -1, size = None,
-                 events = None, checksums = {}, parents = None, locations = None,
-                 status = "NOTUPLOADED", workflowId = None, prep_id = None):
+
+    def __init__(self, lfn=None, id=-1, size=None,
+                 events=None, checksums=None, parents=None, locations=None,
+                 status="NOTUPLOADED", inPhedex=0, workflowId=None, prep_id=None):
+
+        checksums = checksums or {}
         WMBSBase.__init__(self)
         WMFile.__init__(self, lfn = lfn, size = size, events = events,
                         checksums = checksums, parents = parents, merged = True)
         self.setdefault("status", status)
+        self.setdefault("in_phedex", inPhedex)
         self.setdefault("id", id)
         self.setdefault("workflowId", workflowId)
 

--- a/src/python/WMComponent/DBS3Buffer/DBSBufferFile.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSBufferFile.py
@@ -20,8 +20,8 @@ class DBSBufferFile(WMBSBase, WMFile):
 
         checksums = checksums or {}
         WMBSBase.__init__(self)
-        WMFile.__init__(self, lfn = lfn, size = size, events = events,
-                        checksums = checksums, parents = parents, merged = True)
+        WMFile.__init__(self, lfn=lfn, size=size, events=events,
+                        checksums=checksums, parents=parents, merged=True)
         self.setdefault("status", status)
         self.setdefault("in_phedex", inPhedex)
         self.setdefault("id", id)
@@ -41,16 +41,16 @@ class DBSBufferFile(WMBSBase, WMFile):
         self.setdefault("datasetParent", None)
         self.setdefault("prep_id", None)
 
-        if locations == None:
+        if locations is None:
             self.setdefault("newlocations", set())
         else:
             self.setdefault("newlocations", self.makeset(locations))
 
         # The WMBS base class creates a DAO factory for WMBS, we'll need to
         # overwrite that so we can use the factory for DBSBuffer objects.
-        self.daofactory = DAOFactory(package = "WMComponent.DBS3Buffer",
-                                     logger = self.logger,
-                                     dbinterface = self.dbi)
+        self.daofactory = DAOFactory(package="WMComponent.DBS3Buffer",
+                                     logger=self.logger,
+                                     dbinterface=self.dbi)
 
         return
 
@@ -61,9 +61,9 @@ class DBSBufferFile(WMBSBase, WMFile):
         Determine whether or not a file with this LFN exists inside the
         database.  Return the file's ID if it exists, False otherwise.
         """
-        action = self.daofactory(classname = "DBSBufferFiles.Exists")
-        return action.execute(lfn = self["lfn"], conn = self.getDBConn(),
-                              transaction = self.existingTransaction())
+        action = self.daofactory(classname="DBSBufferFiles.Exists")
+        return action.execute(lfn=self["lfn"], conn=self.getDBConn(),
+                              transaction=self.existingTransaction())
 
     def getStatus(self):
         """
@@ -92,7 +92,7 @@ class DBSBufferFile(WMBSBase, WMFile):
         """
         return list(self["runs"])
 
-    def load(self, parentage = 0):
+    def load(self, parentage=0):
         """
         _load_
 
@@ -102,40 +102,41 @@ class DBSBufferFile(WMBSBase, WMFile):
         existingTransaction = self.beginTransaction()
 
         if self["id"] != -1:
-            action = self.daofactory(classname = "DBSBufferFiles.GetByID")
-            result = action.execute(self["id"], conn = self.getDBConn(),
-                                    transaction = self.existingTransaction())
+            action = self.daofactory(classname="DBSBufferFiles.GetByID")
+            result = action.execute(self["id"], conn=self.getDBConn(),
+                                    transaction=self.existingTransaction())
         else:
-            action = self.daofactory(classname = "DBSBufferFiles.GetByLFN")
-            result = action.execute(self["lfn"], conn = self.getDBConn(),
-                                    transaction = self.existingTransaction())
+            action = self.daofactory(classname="DBSBufferFiles.GetByLFN")
+            result = action.execute(self["lfn"], conn=self.getDBConn(),
+                                    transaction=self.existingTransaction())
 
         self.update(result)
 
-        action = self.daofactory(classname = 'DBSBufferFiles.GetChecksum')
-        result = action.execute(fileid = self['id'], conn = self.getDBConn(),
-                                transaction = self.existingTransaction())
+        action = self.daofactory(classname='DBSBufferFiles.GetChecksum')
+        result = action.execute(fileid=self['id'], conn=self.getDBConn(),
+                                transaction=self.existingTransaction())
         self["checksums"] = result
 
-        action = self.daofactory(classname = "DBSBufferFiles.GetRunLumiFile")
-        runs = action.execute(self["lfn"], conn = self.getDBConn(),
-                              transaction = self.existingTransaction())
-        [self.addRun(run=Run(r, *runs[r])) for r in runs.keys()]
+        action = self.daofactory(classname="DBSBufferFiles.GetRunLumiFile")
+        runs = action.execute(self["lfn"], conn=self.getDBConn(),
+                              transaction=self.existingTransaction())
+        for r in runs:
+            self.addRun(run=Run(r, *runs[r]))
 
-        action = self.daofactory(classname = "DBSBufferFiles.GetLocation")
-        self["locations"] = action.execute(self["lfn"], conn = self.getDBConn(),
-                                           transaction = self.existingTransaction())
+        action = self.daofactory(classname="DBSBufferFiles.GetLocation")
+        self["locations"] = action.execute(self["lfn"], conn=self.getDBConn(),
+                                           transaction=self.existingTransaction())
 
         self["newlocations"].clear()
         self["parents"].clear()
 
         if parentage > 0:
-            action = self.daofactory(classname = "DBSBufferFiles.GetParents")
-            lfns = action.execute(self["lfn"], conn = self.getDBConn(),
-                                  transaction = self.existingTransaction())
+            action = self.daofactory(classname="DBSBufferFiles.GetParents")
+            lfns = action.execute(self["lfn"], conn=self.getDBConn(),
+                                  transaction=self.existingTransaction())
             for lfn in lfns:
-                parentFile = DBSBufferFile(lfn = lfn)
-                parentFile.load(parentage = parentage - 1)
+                parentFile = DBSBufferFile(lfn=lfn)
+                parentFile.load(parentage=parentage - 1)
                 self["parents"].add(parentFile)
 
         self.commitTransaction(existingTransaction)
@@ -147,35 +148,35 @@ class DBSBufferFile(WMBSBase, WMFile):
 
         Insert the dataset and algorithm for this file into the DBS Buffer.
         """
-        newAlgoAction = self.daofactory(classname = "NewAlgo")
-        assocAction = self.daofactory(classname = "AlgoDatasetAssoc")
+        newAlgoAction = self.daofactory(classname="NewAlgo")
+        assocAction = self.daofactory(classname="AlgoDatasetAssoc")
 
         existingTransaction = self.beginTransaction()
 
-        newAlgoAction.execute(appName = self["appName"], appVer = self["appVer"],
-                              appFam = self["appFam"], psetHash = self["psetHash"],
-                              configContent = self["configContent"],
-                              conn = self.getDBConn(),
-                              transaction = True)
+        newAlgoAction.execute(appName=self["appName"], appVer=self["appVer"],
+                              appFam=self["appFam"], psetHash=self["psetHash"],
+                              configContent=self["configContent"],
+                              conn=self.getDBConn(),
+                              transaction=True)
 
         dbsbufferDataset = DBSBufferDataset(self["datasetPath"],
-                                            processingVer = self['processingVer'],
-                                            acquisitionEra = self['acquisitionEra'],
-                                            validStatus = self['validStatus'],
-                                            globalTag = self.get('globalTag', None),
-                                            parent = self['datasetParent'],
-                                            prep_id = self['prep_id'])
+                                            processingVer=self['processingVer'],
+                                            acquisitionEra=self['acquisitionEra'],
+                                            validStatus=self['validStatus'],
+                                            globalTag=self.get('globalTag', None),
+                                            parent=self['datasetParent'],
+                                            prep_id=self['prep_id'])
 
         if dbsbufferDataset.exists():
             dbsbufferDataset.updateDataset()
         else:
             dbsbufferDataset.create()
 
-        assocID = assocAction.execute(appName = self["appName"], appVer = self["appVer"],
-                                      appFam = self["appFam"], psetHash = self["psetHash"],
-                                      datasetPath = self["datasetPath"],
-                                      conn = self.getDBConn(),
-                                      transaction = True)
+        assocID = assocAction.execute(appName=self["appName"], appVer=self["appVer"],
+                                      appFam=self["appFam"], psetHash=self["psetHash"],
+                                      datasetPath=self["datasetPath"],
+                                      conn=self.getDBConn(),
+                                      transaction=True)
 
         self.commitTransaction(existingTransaction)
         return assocID
@@ -194,27 +195,27 @@ class DBSBufferFile(WMBSBase, WMFile):
         existingTransaction = self.beginTransaction()
         assocID = self.insertDatasetAlgo()
 
-        addAction = self.daofactory(classname = "DBSBufferFiles.Add")
-        addAction.execute(files = self["lfn"], size = self["size"],
-                          events = self["events"],
-                          datasetAlgo = assocID, status = self["status"],
-                          workflowID = self["workflowId"],
-                          conn = self.getDBConn(),
-                          transaction = self.existingTransaction())
+        addAction = self.daofactory(classname="DBSBufferFiles.Add")
+        addAction.execute(files=self["lfn"], size=self["size"],
+                          events=self["events"],
+                          datasetAlgo=assocID, status=self["status"],
+                          workflowID=self["workflowId"],
+                          conn=self.getDBConn(),
+                          transaction=self.existingTransaction())
 
         if len(self["runs"]) > 0:
             lumiAction = self.daofactory(classname="DBSBufferFiles.AddRunLumi")
-            lumiAction.execute(file = self["lfn"], runs = self["runs"],
-                               conn = self.getDBConn(),
-                               transaction = self.existingTransaction())
+            lumiAction.execute(file=self["lfn"], runs=self["runs"],
+                               conn=self.getDBConn(),
+                               transaction=self.existingTransaction())
 
         self["id"] = self.exists()
         self.updateLocations()
         self.commitTransaction(existingTransaction)
 
         for checksumType in self["checksums"]:
-            self.setCksum(cksum = self["checksums"][checksumType],
-                          cktype = checksumType)
+            self.setCksum(cksum=self["checksums"][checksumType],
+                          cktype=checksumType)
         return
 
     def delete(self):
@@ -223,9 +224,9 @@ class DBSBufferFile(WMBSBase, WMFile):
 
         Remove a file from the DSBuffer database.
         """
-        action = self.daofactory(classname = "DBSBufferFiles.Delete")
-        action.execute(file = self["lfn"], conn = self.getDBConn(),
-                       transaction = self.existingTransaction())
+        action = self.daofactory(classname="DBSBufferFiles.Delete")
+        action.execute(file=self["lfn"], conn=self.getDBConn(),
+                       transaction=self.existingTransaction())
         return
 
     def addChildren(self, lfns):
@@ -234,7 +235,7 @@ class DBSBufferFile(WMBSBase, WMFile):
 
         Set one or more lfns as the child of this file.
         """
-        if type(lfns) != list:
+        if not isinstance(lfns, list):
             lfns = [lfns]
 
         existingTransaction = self.beginTransaction()
@@ -242,10 +243,10 @@ class DBSBufferFile(WMBSBase, WMFile):
         if not self["id"] > 0:
             raise Exception("Parent file doesn't have an id %s" % self["lfn"])
 
-        action = self.daofactory(classname = "DBSBufferFiles.HeritageLFNChild")
-        action.execute(childLFNs = lfns, parentID = self["id"],
-                       conn = self.getDBConn(),
-                       transaction = self.existingTransaction())
+        action = self.daofactory(classname="DBSBufferFiles.HeritageLFNChild")
+        action.execute(childLFNs=lfns, parentID=self["id"],
+                       conn=self.getDBConn(),
+                       transaction=self.existingTransaction())
 
         self.commitTransaction(existingTransaction)
         return
@@ -258,58 +259,58 @@ class DBSBufferFile(WMBSBase, WMFile):
         the buffer then bogus place holder files will be created so that the
         parentage information can be tracked and correctly inserted into DBS.
         """
-        newAlgoAction = self.daofactory(classname = "NewAlgo")
-        newDatasetAction = self.daofactory(classname = "NewDataset")
-        assocAction = self.daofactory(classname = "AlgoDatasetAssoc")
-        existsAction = self.daofactory(classname = "DBSBufferFiles.Exists")
+        newAlgoAction = self.daofactory(classname="NewAlgo")
+        newDatasetAction = self.daofactory(classname="NewDataset")
+        assocAction = self.daofactory(classname="AlgoDatasetAssoc")
+        existsAction = self.daofactory(classname="DBSBufferFiles.Exists")
 
-        uploadFactory = DAOFactory(package = "WMComponent.DBS3Buffer",
-                                   logger = self.logger,
-                                   dbinterface = self.dbi)
-        setDatasetAlgoAction = uploadFactory(classname = "SetDatasetAlgo")
+        uploadFactory = DAOFactory(package="WMComponent.DBS3Buffer",
+                                   logger=self.logger,
+                                   dbinterface=self.dbi)
+        setDatasetAlgoAction = uploadFactory(classname="SetDatasetAlgo")
 
         existingTransaction = self.beginTransaction()
 
         toBeCreated = []
         for parentLFN in parentLFNs:
-            self["parents"].add(DBSBufferFile(lfn = parentLFN))
-            if not existsAction.execute(lfn = parentLFN,
-                                        conn = self.getDBConn(),
-                                        transaction = True):
+            self["parents"].add(DBSBufferFile(lfn=parentLFN))
+            if not existsAction.execute(lfn=parentLFN,
+                                        conn=self.getDBConn(),
+                                        transaction=True):
                 toBeCreated.append(parentLFN)
 
         if len(toBeCreated) > 0:
-            newAlgoAction.execute(appName = "cmsRun", appVer = "UNKNOWN",
-                                  appFam = "UNKNOWN", psetHash = "NOT_SET",
-                                  configContent = "NOT_SET",
-                                  conn = self.getDBConn(),
-                                  transaction = True)
+            newAlgoAction.execute(appName="cmsRun", appVer="UNKNOWN",
+                                  appFam="UNKNOWN", psetHash="NOT_SET",
+                                  configContent="NOT_SET",
+                                  conn=self.getDBConn(),
+                                  transaction=True)
 
-            newDatasetAction.execute(datasetPath = "bogus",
-                                     conn = self.getDBConn(),
-                                     transaction = True)
+            newDatasetAction.execute(datasetPath="bogus",
+                                     conn=self.getDBConn(),
+                                     transaction=True)
 
-            assocID = assocAction.execute(appName = "cmsRun", appVer = "UNKNOWN",
-                                          appFam = "UNKNOWN", psetHash = "NOT_SET",
-                                          datasetPath = "bogus",
-                                          conn = self.getDBConn(),
-                                          transaction = True)
+            assocID = assocAction.execute(appName="cmsRun", appVer="UNKNOWN",
+                                          appFam="UNKNOWN", psetHash="NOT_SET",
+                                          datasetPath="bogus",
+                                          conn=self.getDBConn(),
+                                          transaction=True)
 
-            setDatasetAlgoAction.execute(datasetAlgo = assocID, inDBS = 1,
-                                         conn = self.getDBConn(),
-                                         transaction = True)
+            setDatasetAlgoAction.execute(datasetAlgo=assocID, inDBS=1,
+                                         conn=self.getDBConn(),
+                                         transaction=True)
 
-            addInputFiles = self.daofactory(classname = "DBSBufferFiles.AddIgnore")
+            addInputFiles = self.daofactory(classname="DBSBufferFiles.AddIgnore")
             addInputFiles.execute(lfns=toBeCreated, datasetAlgo=assocID,
                                   status="GLOBAL",
                                   inPhEDEx=1,
                                   conn=self.getDBConn(),
                                   transaction=True)
 
-        action = self.daofactory(classname = "DBSBufferFiles.HeritageLFNParent")
-        action.execute(parentLFNs = parentLFNs, childLFN = self["lfn"],
-                       conn = self.getDBConn(),
-                       transaction = self.existingTransaction())
+        action = self.daofactory(classname="DBSBufferFiles.HeritageLFNParent")
+        action.execute(parentLFNs=parentLFNs, childLFN=self["lfn"],
+                       conn=self.getDBConn(),
+                       transaction=self.existingTransaction())
         self.commitTransaction(existingTransaction)
         return
 
@@ -327,27 +328,27 @@ class DBSBufferFile(WMBSBase, WMFile):
         existingTransaction = self.beginTransaction()
 
         for location in self['newlocations']:
-            insertAction = self.daofactory(classname = "DBSBufferFiles.AddLocation")
-            insertAction.execute(siteName = location,
-                                 conn = self.getDBConn(),
-                                 transaction = self.existingTransaction())
+            insertAction = self.daofactory(classname="DBSBufferFiles.AddLocation")
+            insertAction.execute(siteName=location,
+                                 conn=self.getDBConn(),
+                                 transaction=self.existingTransaction())
 
         binds = []
         for location in self["newlocations"]:
             binds.append({"lfn": self["lfn"],
                           "pnn": location})
 
-        addAction = self.daofactory(classname = "DBSBufferFiles.SetLocationByLFN")
-        addAction.execute(binds = binds,
-                          conn = self.getDBConn(),
-                          transaction = self.existingTransaction())
+        addAction = self.daofactory(classname="DBSBufferFiles.SetLocationByLFN")
+        addAction.execute(binds=binds,
+                          conn=self.getDBConn(),
+                          transaction=self.existingTransaction())
 
         self["locations"].update(self["newlocations"])
         self["newlocations"].clear()
         self.commitTransaction(existingTransaction)
         return
 
-    def setLocation(self, pnn, immediateSave = True):
+    def setLocation(self, pnn, immediateSave=True):
         """
         _setLocation_
 
@@ -366,8 +367,8 @@ class DBSBufferFile(WMBSBase, WMFile):
 
         return
 
-    def setAlgorithm(self, appName = None, appVer = None, appFam = None,
-                     psetHash = None, configContent = None):
+    def setAlgorithm(self, appName=None, appVer=None, appFam=None,
+                     psetHash=None, configContent=None):
         """
         _setAlgorithm_
 
@@ -478,7 +479,7 @@ class DBSBufferFile(WMBSBase, WMFile):
             for parent in parents:
                 temp.extend(parent["parents"])
             parents = temp
-        result.sort()   # ensure SecondaryInputFiles are in order
+        result.sort()  # ensure SecondaryInputFiles are in order
         return [x['lfn'] for x in result]
 
     def addRunSet(self, runSet):
@@ -491,17 +492,18 @@ class DBSBufferFile(WMBSBase, WMFile):
         """
         existingTransaction = self.beginTransaction()
 
-        lumiAction = self.daofactory(classname = "DBSBufferFiles.AddRunLumi")
-        lumiAction.execute(file = self["lfn"], runs = runSet,
-                           conn = self.getDBConn(),
-                           transaction = self.existingTransaction())
+        lumiAction = self.daofactory(classname="DBSBufferFiles.AddRunLumi")
+        lumiAction.execute(file=self["lfn"], runs=runSet,
+                           conn=self.getDBConn(),
+                           transaction=self.existingTransaction())
 
-        action = self.daofactory(classname = "DBSBufferFiles.GetRunLumiFile")
-        runs = action.execute(self["lfn"], conn = self.getDBConn(),
-                              transaction = self.existingTransaction())
+        action = self.daofactory(classname="DBSBufferFiles.GetRunLumiFile")
+        runs = action.execute(self["lfn"], conn=self.getDBConn(),
+                              transaction=self.existingTransaction())
 
         self["runs"].clear()
-        [self.addRun(run=Run(r, *runs[r])) for r in runs.keys()]
+        for r in runs:
+            self.addRun(run=Run(r, *runs[r]))
 
         self.commitTransaction(existingTransaction)
         return
@@ -514,9 +516,9 @@ class DBSBufferFile(WMBSBase, WMFile):
         """
         existingTransaction = self.beginTransaction()
 
-        blockAction = self.daofactory(classname = "DBSBufferFiles.SetBlock")
-        blockAction.execute(self["lfn"], blockName, conn = self.getDBConn(),
-                              transaction = self.existingTransaction())
+        blockAction = self.daofactory(classname="DBSBufferFiles.SetBlock")
+        blockAction.execute(self["lfn"], blockName, conn=self.getDBConn(),
+                            transaction=self.existingTransaction())
 
         self.commitTransaction(existingTransaction)
         return
@@ -532,9 +534,9 @@ class DBSBufferFile(WMBSBase, WMFile):
 
         existingTransaction = self.beginTransaction()
 
-        action = self.daofactory(classname = "DBSBufferFiles.AddChecksum")
-        action.execute(fileid = self['id'], cktype = cktype, cksum = cksum, \
-                       conn = self.getDBConn(), transaction = existingTransaction)
+        action = self.daofactory(classname="DBSBufferFiles.AddChecksum")
+        action.execute(fileid=self['id'], cktype=cktype, cksum=cksum, \
+                       conn=self.getDBConn(), transaction=existingTransaction)
 
         self.commitTransaction(existingTransaction)
 

--- a/src/python/WMComponent/DBS3Buffer/DBSBufferFile.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSBufferFile.py
@@ -44,12 +44,10 @@ class DBSBufferFile(WMBSBase, WMFile):
 
         # The WMBS base class creates a DAO factory for WMBS, we'll need to
         # overwrite that so we can use the factory for DBSBuffer objects.
-        self.daoFactory = DAOFactory(package = "WMComponent.DBS3Buffer",
+        self.daofactory = DAOFactory(package = "WMComponent.DBS3Buffer",
                                      logger = self.logger,
                                      dbinterface = self.dbi)
 
-        #Remove reference to WMBS daofactory to prevent confusion
-        self.daofactory = self.daoFactory
         return
 
     def exists(self):
@@ -59,7 +57,7 @@ class DBSBufferFile(WMBSBase, WMFile):
         Determine whether or not a file with this LFN exists inside the
         database.  Return the file's ID if it exists, False otherwise.
         """
-        action = self.daoFactory(classname = "DBSBufferFiles.Exists")
+        action = self.daofactory(classname = "DBSBufferFiles.Exists")
         return action.execute(lfn = self["lfn"], conn = self.getDBConn(),
                               transaction = self.existingTransaction())
 
@@ -100,27 +98,27 @@ class DBSBufferFile(WMBSBase, WMFile):
         existingTransaction = self.beginTransaction()
 
         if self["id"] != -1:
-            action = self.daoFactory(classname = "DBSBufferFiles.GetByID")
+            action = self.daofactory(classname = "DBSBufferFiles.GetByID")
             result = action.execute(self["id"], conn = self.getDBConn(),
                                     transaction = self.existingTransaction())
         else:
-            action = self.daoFactory(classname = "DBSBufferFiles.GetByLFN")
+            action = self.daofactory(classname = "DBSBufferFiles.GetByLFN")
             result = action.execute(self["lfn"], conn = self.getDBConn(),
                                     transaction = self.existingTransaction())
 
         self.update(result)
 
-        action = self.daoFactory(classname = 'DBSBufferFiles.GetChecksum')
+        action = self.daofactory(classname = 'DBSBufferFiles.GetChecksum')
         result = action.execute(fileid = self['id'], conn = self.getDBConn(),
                                 transaction = self.existingTransaction())
         self["checksums"] = result
 
-        action = self.daoFactory(classname = "DBSBufferFiles.GetRunLumiFile")
+        action = self.daofactory(classname = "DBSBufferFiles.GetRunLumiFile")
         runs = action.execute(self["lfn"], conn = self.getDBConn(),
                               transaction = self.existingTransaction())
         [self.addRun(run=Run(r, *runs[r])) for r in runs.keys()]
 
-        action = self.daoFactory(classname = "DBSBufferFiles.GetLocation")
+        action = self.daofactory(classname = "DBSBufferFiles.GetLocation")
         self["locations"] = action.execute(self["lfn"], conn = self.getDBConn(),
                                            transaction = self.existingTransaction())
 
@@ -128,7 +126,7 @@ class DBSBufferFile(WMBSBase, WMFile):
         self["parents"].clear()
 
         if parentage > 0:
-            action = self.daoFactory(classname = "DBSBufferFiles.GetParents")
+            action = self.daofactory(classname = "DBSBufferFiles.GetParents")
             lfns = action.execute(self["lfn"], conn = self.getDBConn(),
                                   transaction = self.existingTransaction())
             for lfn in lfns:
@@ -145,8 +143,8 @@ class DBSBufferFile(WMBSBase, WMFile):
 
         Insert the dataset and algorithm for this file into the DBS Buffer.
         """
-        newAlgoAction = self.daoFactory(classname = "NewAlgo")
-        assocAction = self.daoFactory(classname = "AlgoDatasetAssoc")
+        newAlgoAction = self.daofactory(classname = "NewAlgo")
+        assocAction = self.daofactory(classname = "AlgoDatasetAssoc")
 
         existingTransaction = self.beginTransaction()
 
@@ -192,7 +190,7 @@ class DBSBufferFile(WMBSBase, WMFile):
         existingTransaction = self.beginTransaction()
         assocID = self.insertDatasetAlgo()
 
-        addAction = self.daoFactory(classname = "DBSBufferFiles.Add")
+        addAction = self.daofactory(classname = "DBSBufferFiles.Add")
         addAction.execute(files = self["lfn"], size = self["size"],
                           events = self["events"],
                           datasetAlgo = assocID, status = self["status"],
@@ -201,7 +199,7 @@ class DBSBufferFile(WMBSBase, WMFile):
                           transaction = self.existingTransaction())
 
         if len(self["runs"]) > 0:
-            lumiAction = self.daoFactory(classname="DBSBufferFiles.AddRunLumi")
+            lumiAction = self.daofactory(classname="DBSBufferFiles.AddRunLumi")
             lumiAction.execute(file = self["lfn"], runs = self["runs"],
                                conn = self.getDBConn(),
                                transaction = self.existingTransaction())
@@ -221,7 +219,7 @@ class DBSBufferFile(WMBSBase, WMFile):
 
         Remove a file from the DSBuffer database.
         """
-        action = self.daoFactory(classname = "DBSBufferFiles.Delete")
+        action = self.daofactory(classname = "DBSBufferFiles.Delete")
         action.execute(file = self["lfn"], conn = self.getDBConn(),
                        transaction = self.existingTransaction())
         return
@@ -240,7 +238,7 @@ class DBSBufferFile(WMBSBase, WMFile):
         if not self["id"] > 0:
             raise Exception("Parent file doesn't have an id %s" % self["lfn"])
 
-        action = self.daoFactory(classname = "DBSBufferFiles.HeritageLFNChild")
+        action = self.daofactory(classname = "DBSBufferFiles.HeritageLFNChild")
         action.execute(childLFNs = lfns, parentID = self["id"],
                        conn = self.getDBConn(),
                        transaction = self.existingTransaction())
@@ -256,10 +254,10 @@ class DBSBufferFile(WMBSBase, WMFile):
         the buffer then bogus place holder files will be created so that the
         parentage information can be tracked and correctly inserted into DBS.
         """
-        newAlgoAction = self.daoFactory(classname = "NewAlgo")
-        newDatasetAction = self.daoFactory(classname = "NewDataset")
-        assocAction = self.daoFactory(classname = "AlgoDatasetAssoc")
-        existsAction = self.daoFactory(classname = "DBSBufferFiles.Exists")
+        newAlgoAction = self.daofactory(classname = "NewAlgo")
+        newDatasetAction = self.daofactory(classname = "NewDataset")
+        assocAction = self.daofactory(classname = "AlgoDatasetAssoc")
+        existsAction = self.daofactory(classname = "DBSBufferFiles.Exists")
 
         uploadFactory = DAOFactory(package = "WMComponent.DBS3Buffer",
                                    logger = self.logger,
@@ -297,13 +295,14 @@ class DBSBufferFile(WMBSBase, WMFile):
                                          conn = self.getDBConn(),
                                          transaction = True)
 
-            action = self.daoFactory(classname = "DBSBufferFiles.AddIgnore")
-            action.execute(lfns = toBeCreated, datasetAlgo = assocID,
-                           status = "GLOBAL",
-                           conn = self.getDBConn(),
-                           transaction = True)
+            addInputFiles = self.daofactory(classname = "DBSBufferFiles.AddIgnore")
+            addInputFiles.execute(lfns=toBeCreated, datasetAlgo=assocID,
+                                  status="GLOBAL",
+                                  inPhEDEx=1,
+                                  conn=self.getDBConn(),
+                                  transaction=True)
 
-        action = self.daoFactory(classname = "DBSBufferFiles.HeritageLFNParent")
+        action = self.daofactory(classname = "DBSBufferFiles.HeritageLFNParent")
         action.execute(parentLFNs = parentLFNs, childLFN = self["lfn"],
                        conn = self.getDBConn(),
                        transaction = self.existingTransaction())
@@ -324,7 +323,7 @@ class DBSBufferFile(WMBSBase, WMFile):
         existingTransaction = self.beginTransaction()
 
         for location in self['newlocations']:
-            insertAction = self.daoFactory(classname = "DBSBufferFiles.AddLocation")
+            insertAction = self.daofactory(classname = "DBSBufferFiles.AddLocation")
             insertAction.execute(siteName = location,
                                  conn = self.getDBConn(),
                                  transaction = self.existingTransaction())
@@ -334,7 +333,7 @@ class DBSBufferFile(WMBSBase, WMFile):
             binds.append({"lfn": self["lfn"],
                           "pnn": location})
 
-        addAction = self.daoFactory(classname = "DBSBufferFiles.SetLocationByLFN")
+        addAction = self.daofactory(classname = "DBSBufferFiles.SetLocationByLFN")
         addAction.execute(binds = binds,
                           conn = self.getDBConn(),
                           transaction = self.existingTransaction())
@@ -488,12 +487,12 @@ class DBSBufferFile(WMBSBase, WMFile):
         """
         existingTransaction = self.beginTransaction()
 
-        lumiAction = self.daoFactory(classname = "DBSBufferFiles.AddRunLumi")
+        lumiAction = self.daofactory(classname = "DBSBufferFiles.AddRunLumi")
         lumiAction.execute(file = self["lfn"], runs = runSet,
                            conn = self.getDBConn(),
                            transaction = self.existingTransaction())
 
-        action = self.daoFactory(classname = "DBSBufferFiles.GetRunLumiFile")
+        action = self.daofactory(classname = "DBSBufferFiles.GetRunLumiFile")
         runs = action.execute(self["lfn"], conn = self.getDBConn(),
                               transaction = self.existingTransaction())
 
@@ -511,7 +510,7 @@ class DBSBufferFile(WMBSBase, WMFile):
         """
         existingTransaction = self.beginTransaction()
 
-        blockAction = self.daoFactory(classname = "DBSBufferFiles.SetBlock")
+        blockAction = self.daofactory(classname = "DBSBufferFiles.SetBlock")
         blockAction.execute(self["lfn"], blockName, conn = self.getDBConn(),
                               transaction = self.existingTransaction())
 
@@ -529,7 +528,7 @@ class DBSBufferFile(WMBSBase, WMFile):
 
         existingTransaction = self.beginTransaction()
 
-        action = self.daoFactory(classname = "DBSBufferFiles.AddChecksum")
+        action = self.daofactory(classname = "DBSBufferFiles.AddChecksum")
         action.execute(fileid = self['id'], cktype = cktype, cksum = cksum, \
                        conn = self.getDBConn(), transaction = existingTransaction)
 

--- a/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/Add.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/Add.py
@@ -11,21 +11,21 @@ from WMCore.Database.DBFormatter import DBFormatter
 
 class Add(DBFormatter):
 
-    sql = """insert into dbsbuffer_file(lfn, filesize, events, dataset_algo, status, workflow)
-                values (:lfn, :filesize, :events, :dataset_algo, :status, :workflow)"""
+    sql = """insert into dbsbuffer_file(lfn, filesize, events, dataset_algo, status, workflow, in_phedex)
+                values (:lfn, :filesize, :events, :dataset_algo, :status, :workflow, :in_phedex)"""
 
-    def getBinds(self, files = None, size = 0, events = 0, cksum = 0,
-                 dataset_algo = 0, status = "NOTUPLOADED", workflowID = None):
+    def getBinds(self, files, size, events, cksum, dataset_algo, status, workflowID, inPhedex):
         # Can't use self.dbi.buildbinds here...
         binds = {}
-        if type(files) == type('string'):
+        if isinstance(files, basestring):
             binds = {'lfn': files,
                      'filesize': size,
                      'events': events,
                      'dataset_algo': dataset_algo,
                      'status' : status,
-                     'workflow': workflowID}
-        elif type(files) == type([]):
+                     'workflow': workflowID,
+                     'in_phedex': inPhedex}
+        elif isinstance(files, list):
         # files is a list of tuples containing lfn, size, events, cksum, dataset, status
             binds = []
             for f in files:
@@ -34,15 +34,16 @@ class Add(DBFormatter):
                               'events': f[2],
                               'dataset_algo': f[3],
                               'status' : f[4],
-                              'workflow': f[5]})
+                              'workflow': f[5],
+                              'in_phedex': f[6]})
         return binds
 
     def execute(self, files = None, size = 0, events = 0, cksum = 0,
-                datasetAlgo = 0, status = "NOTUPLOADED", workflowID = None, conn = None,
-                transaction = False):
-        binds = self.getBinds(files, size, events, cksum, datasetAlgo, status, workflowID = workflowID)
+                datasetAlgo = 0, status = "NOTUPLOADED", workflowID = None,
+                inPhedex=0, conn = None, transaction = False):
+        binds = self.getBinds(files, size, events, cksum, datasetAlgo, status,
+                              workflowID, inPhedex)
 
-        result = self.dbi.processData(self.sql, binds,
-                                      conn = conn, transaction = transaction)
+        self.dbi.processData(self.sql, binds, conn=conn, transaction=transaction)
 
         return

--- a/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/AddIgnore.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/AddIgnore.py
@@ -7,17 +7,18 @@ MySQL implementation of DBSBufferFiles.AddIgnore
 
 from WMCore.Database.DBFormatter import DBFormatter
 
+
 class AddIgnore(DBFormatter):
     sql = """INSERT IGNORE INTO dbsbuffer_file (lfn, dataset_algo, status, in_phedex)
                 VALUES (:lfn, :dataset_algo, :status, :in_phedex)"""
 
     def execute(self, lfns, datasetAlgo, status, inPhEDEx,
-                conn = None, transaction = False):
+                conn=None, transaction=False):
         binds = []
         for lfn in lfns:
             binds.append({"lfn": lfn, "dataset_algo": datasetAlgo,
                           "status": status, "in_phedex": inPhEDEx})
 
-        self.dbi.processData(self.sql, binds, conn = conn,
-                             transaction = transaction)
+        self.dbi.processData(self.sql, binds, conn=conn,
+                             transaction=transaction)
         return

--- a/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/AddIgnore.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/AddIgnore.py
@@ -8,15 +8,15 @@ MySQL implementation of DBSBufferFiles.AddIgnore
 from WMCore.Database.DBFormatter import DBFormatter
 
 class AddIgnore(DBFormatter):
-    sql = """INSERT IGNORE INTO dbsbuffer_file (lfn, dataset_algo, status)
-                VALUES (:lfn, :dataset_algo, :status)"""
+    sql = """INSERT IGNORE INTO dbsbuffer_file (lfn, dataset_algo, status, in_phedex)
+                VALUES (:lfn, :dataset_algo, :status, :in_phedex)"""
 
-    def execute(self, lfns, datasetAlgo, status,
+    def execute(self, lfns, datasetAlgo, status, inPhEDEx,
                 conn = None, transaction = False):
         binds = []
         for lfn in lfns:
             binds.append({"lfn": lfn, "dataset_algo": datasetAlgo,
-                          "status": status})
+                          "status": status, "in_phedex": inPhEDEx})
 
         self.dbi.processData(self.sql, binds, conn = conn,
                              transaction = transaction)

--- a/src/python/WMComponent/DBS3Buffer/Oracle/DBSBufferFiles/Add.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/DBSBufferFiles/Add.py
@@ -14,6 +14,4 @@ class Add(MySQLAdd):
     """
     Oracle implementation of AddFile
     """
-
-    #sql = """insert into dbsbuffer_file(lfn, filesize, events, cksum, dataset, status)
-    #            values (:lfn, :filesize, :events, :cksum, (select ID from dbsbuffer_dataset where Path=:dataset), :status)"""
+    pass

--- a/src/python/WMComponent/DBS3Buffer/Oracle/DBSBufferFiles/AddIgnore.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/DBSBufferFiles/AddIgnore.py
@@ -12,6 +12,6 @@ from WMComponent.DBS3Buffer.MySQL.DBSBufferFiles.AddIgnore import AddIgnore as \
      MySQLAddIgnore
 
 class AddIgnore(MySQLAddIgnore):
-    sql = """INSERT INTO dbsbuffer_file (lfn, dataset_algo, status)
-                SELECT :lfn, :dataset_algo, :status FROM DUAL WHERE NOT EXISTS
+    sql = """INSERT INTO dbsbuffer_file (lfn, dataset_algo, status, in_phedex)
+                SELECT :lfn, :dataset_algo, :status, :in_phedex FROM DUAL WHERE NOT EXISTS
                   (SELECT id FROM dbsbuffer_file WHERE lfn = :lfn)"""

--- a/src/python/WMComponent/DBS3Buffer/Oracle/DBSBufferFiles/AddIgnore.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/DBSBufferFiles/AddIgnore.py
@@ -5,11 +5,9 @@ _AddIgnore_
 MySQL implementation of DBSBufferFiles.AddIgnore
 """
 
-
-
-
 from WMComponent.DBS3Buffer.MySQL.DBSBufferFiles.AddIgnore import AddIgnore as \
-     MySQLAddIgnore
+    MySQLAddIgnore
+
 
 class AddIgnore(MySQLAddIgnore):
     sql = """INSERT INTO dbsbuffer_file (lfn, dataset_algo, status, in_phedex)

--- a/src/python/WMComponent/JobAccountant/AccountantWorker.py
+++ b/src/python/WMComponent/JobAccountant/AccountantWorker.py
@@ -346,7 +346,8 @@ class AccountantWorker(WMConnectionBase):
                                 size = jobReportFile["size"],
                                 events = jobReportFile["events"],
                                 checksums = jobReportFile["checksums"],
-                                status = "NOTUPLOADED")
+                                status = "NOTUPLOADED",
+                                inPhedex=0)
         dbsFile.setAlgorithm(appName = datasetInfo["applicationName"],
                              appVer = datasetInfo["applicationVersion"],
                              appFam = jobReportFile["module_label"],
@@ -653,7 +654,6 @@ class AccountantWorker(WMConnectionBase):
         dbsFileLoc    = []
         dbsCksumBinds = []
         runLumiBinds  = []
-        selfChecksums = None
         jobLocations  = set()
 
         for dbsFile in self.dbsFilesToCreate:
@@ -719,7 +719,7 @@ class AccountantWorker(WMConnectionBase):
             jobLocations.add(jobLocation)
             dbsFileTuples.append((lfn, dbsFile['size'],
                                   dbsFile['events'], assocID,
-                                  dbsFile['status'], workflowID))
+                                  dbsFile['status'], workflowID, dbsFile['in_phedex']))
 
             dbsFileLoc.append({'lfn': lfn, 'pnn' : jobLocation})
             if dbsFile['runs']:

--- a/src/python/WMCore/WorkQueue/WMBSHelper.py
+++ b/src/python/WMCore/WorkQueue/WMBSHelper.py
@@ -516,7 +516,6 @@ class WMBSHelper(WMConnectionBase):
         dbsFileLoc = []
         dbsCksumBinds = []
         locationsToAdd = []
-        selfChecksums = None
 
         # The first thing we need to do is add the datasetAlgo
         # Assume all files in a pass come from one datasetAlgo?
@@ -530,10 +529,11 @@ class WMBSHelper(WMConnectionBase):
             lfn = dbsFile['lfn']
             selfChecksums = dbsFile['checksums']
 
-            newTuple = (lfn, dbsFile['size'],
-                        dbsFile['events'], self.insertedBogusDataset,
-                        dbsFile['status'], self.topLevelTaskDBSBufferId)
+            newTuple = (lfn, dbsFile['size'], dbsFile['events'],
+                        self.insertedBogusDataset, dbsFile['status'],
+                        self.topLevelTaskDBSBufferId, dbsFile['in_phedex'])
 
+            # TODO: we can probably optmize it
             if newTuple not in dbsFileTuples:
                 dbsFileTuples.append(newTuple)
 
@@ -591,7 +591,8 @@ class WMBSHelper(WMConnectionBase):
                                   events=dbsFile["NumberOfEvents"],
                                   checksums=checksums,
                                   locations=locations,
-                                  status="GLOBAL")
+                                  status="GLOBAL",
+                                  inPhedex=1)
         dbsBuffer.setDatasetPath('bogus')
         dbsBuffer.setAlgorithm(appName="cmsRun", appVer="Unknown",
                                appFam="Unknown", psetHash="Unknown",


### PR DESCRIPTION
Fixes #5223 (and possible #5410)

If I correctly understood the code :), these parentLFNs are the input datasets for workflows, that's why we mark them as status=GLOBAL. However, we should mark them in PhEDEx as well to make sure it's not going to bug us during agent draining.

PS.: I just noticed this `addParents` method is not called anywhere in the code...