### PR TITLE
Clone only creation arguments and validate them

### DIFF
--- a/src/python/WMCore/ReqMgr/DataStructs/Request.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/Request.py
@@ -31,6 +31,7 @@ ARGS_TO_REMOVE_FROM_ORIGINAL_REQUEST = \
      'Teams', 'TotalEstimatedJobs', 'TotalInputEvents', 'TotalInputFiles', 'TotalInputLumis',
      'TransientOutputModules', 'TrustPUSitelists', 'TrustSitelists', 'VoRole', '_id', '_rev']
 
+
 def initialize_request_args(request, config):
     """
     Request data class request is a dictionary representing
@@ -80,6 +81,7 @@ def initialize_resubmission(request_args, reqmgr_db_service):
     # to be used later on for spec validation
     request_args["OriginalRequestType"] = parent_args["RequestType"]
 
+
 def _replace_cloned_args(clone_args, user_args):
     """
     replace original arguments with user argument.
@@ -127,6 +129,7 @@ def initialize_clone(requestArgs, originalArgs, argsDefinition, chainDefinition=
 
     return cloneArgs
 
+
 def generateRequestName(request):
     currentTime = time.strftime('%y%m%d_%H%M%S', time.localtime(time.time()))
     seconds = int(10000 * (time.time() % 1.0))
@@ -134,8 +137,8 @@ def generateRequestName(request):
     request["RequestName"] = "%s_%s" % (request["Requestor"], request.get("RequestString"))
     request["RequestName"] += "_%s_%s" % (currentTime, seconds)
 
-def protectedLFNs(requestInfo):
 
+def protectedLFNs(requestInfo):
     reqData = RequestInfo(requestInfo)
     result = []
     if reqData.andFilterCheck(ACTIVE_STATUS_FILTER):
@@ -144,14 +147,16 @@ def protectedLFNs(requestInfo):
         for out in outs:
             dsn, ps, tier = out.split('/')[1:]
             acq, rest = ps.split('-', 1)
-            dirPath = '/'.join([ base, acq, dsn, tier, rest])
+            dirPath = '/'.join([base, acq, dsn, tier, rest])
             result.append(dirPath)
     return result
+
 
 class RequestInfo(object):
     """
     Wrapper class for Request data
     """
+
     def __init__(self, requestData):
         self.data = requestData
 
@@ -258,4 +263,3 @@ class RequestInfo(object):
         # cannot determin whether AgentJobInfo is cleaned or not when 'AgentJobInfo' Key doesn't exist
         # Maybe JobInformation is not included but since it requested by above status assumed it returns True
         return True
-

--- a/src/python/WMCore/ReqMgr/DataStructs/Request.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/Request.py
@@ -17,6 +17,7 @@ TODO/NOTE:
 """
 from __future__ import print_function, division
 import time
+import re
 import cherrypy
 from WMCore.ReqMgr.DataStructs.RequestStatus import REQUEST_START_STATE, ACTIVE_STATUS_FILTER
 
@@ -83,26 +84,48 @@ def _replace_cloned_args(clone_args, user_args):
     """
     replace original arguments with user argument.
     If the value is dictionary format, overwrite only with specified arguments.
-    If the original arguemnt has simple value and user passes dictionary, completely replace to dictionary
+    If the original argument has simple value and user passes dictionary, completely replace to dictionary
+    XXX this means LumiList won't remove other runs, only updates runs overwritten
     """
     for prop in user_args:
         if isinstance(user_args[prop], dict) and isinstance(clone_args.get(prop), dict):
             _replace_cloned_args(clone_args.get(prop, {}), user_args[prop])
-        else:     
+        else:
             clone_args[prop] = user_args[prop]
     return
-    
-def initialize_clone(request_args, reqmgr_db_service):
-    """
-    Initialize a Clone arguments by inheriting and overwriting argument from OriginalRequest
-    """
-    requests = reqmgr_db_service.getRequestByNames(request_args["OriginalRequestName"])
-    clone_args = requests.values()[0]
-    # TODO: need to validate new overwrite request_args here since it will skip the clone_args validtaiton
-    _replace_cloned_args(clone_args, request_args)
-    clone_args = {k: v for k, v in clone_args.iteritems() if k not in ARGS_TO_REMOVE_FROM_ORIGINAL_REQUEST}
 
-    return clone_args
+
+def initialize_clone(requestArgs, originalArgs, argsDefinition, chainDefinition=None):
+    """
+    Initialize arguments for a clone request by inheriting and overwriting argument
+    from OriginalRequest.
+
+    :param requestArgs: user-provided dictionary with override arguments
+    :param originalArgs: original arguments retrieved for the workflow being cloned
+    :param argsDefinition: arguments definition according to the workflow type being cloned
+    :param chainDefinition: a dictionary containing the chain argument definition, for
+    StepChain and TaskChain
+    :return: dictionary with original args filtered out, as per the spec definition. And on
+     top of that, user arguments added/replaced in the dictionary.
+    """
+    chainPattern = r'(Task|Step)\d{1,2}'
+    cloneArgs = {}
+    for topKey, topValue in originalArgs.iteritems():
+        if topKey in argsDefinition:
+            cloneArgs[topKey] = topValue
+        elif topKey.startswith(("Skim", "Step", "Task")):
+            # accept floating args from ReReco, StepChain and TaskChain
+            if re.match(chainPattern, topKey):
+                for innerKey in topValue:
+                    if innerKey not in chainDefinition:
+                        # remove internal keys that are not in the spec
+                        topValue.pop(innerKey, None)
+            cloneArgs[topKey] = topValue
+
+    # apply user override arguments at the end, such that it's validated at spec level
+    _replace_cloned_args(cloneArgs, requestArgs)
+
+    return cloneArgs
 
 def generateRequestName(request):
     currentTime = time.strftime('%y%m%d_%H%M%S', time.localtime(time.time()))

--- a/src/python/WMCore/ReqMgr/Utils/Validation.py
+++ b/src/python/WMCore/ReqMgr/Utils/Validation.py
@@ -145,6 +145,7 @@ def validate_request_create_args(request_args, config, reqmgr_db_service, *args,
 
     return workload, request_args
 
+
 def validate_clone_create_args(request_args, config, reqmgr_db_service, *args, **kwargs):
     """
     Load the spec arguments definition (and chain definition, if needed) and inherit

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -109,7 +109,7 @@ class StdBase(object):
                    'PAMinBias': 'RAW-RECO',
                    'PAZEE': 'RAW-RECO',
                    'PAZMM': 'RAW-RECO'
-                  }
+                   }
         return skimMap
 
     def determineOutputModules(self, scenarioFunc=None, scenarioArgs=None,
@@ -124,7 +124,7 @@ class StdBase(object):
         scenarioArgs = scenarioArgs or {}
 
         outputModules = {}
-        if configDoc != None and configDoc != "":
+        if configDoc is not None and configDoc != "":
             if (configCacheUrl, couchDBName) in self.config_cache:
                 configCache = self.config_cache[(configCacheUrl, couchDBName)]
             else:
@@ -309,7 +309,7 @@ class StdBase(object):
         procTask.setTaskLogBaseLFN(self.unmergedLFNBase)
 
         # FIXME (Alan on 27/Mar/17): can we remove it? (I guess T0 needs it...?)
-        #if applySiteLists:
+        # if applySiteLists:
         #    procTask.setSiteWhitelist(self.siteWhitelist)
         #    procTask.setSiteBlacklist(self.siteBlacklist)
         #    procTask.setTrustSitelists(self.trustSitelists, self.trustPUSitelists)
@@ -352,13 +352,13 @@ class StdBase(object):
                                        taskConf.get("SoftTimeout", None),
                                        taskConf.get("GracePeriod", None))
 
-        if taskType in ["Production", 'PrivateMC'] and totalEvents != None:
+        if taskType in ["Production", 'PrivateMC'] and totalEvents is not None:
             procTask.addGenerator(seeding)
             procTask.addProduction(totalEvents=totalEvents)
             procTask.setFirstEventAndLumi(firstEvent=self.firstEvent,
                                           firstLumi=self.firstLumi)
         else:
-            if inputDataset != None:
+            if inputDataset is not None:
                 (primary, processed, tier) = self.inputDataset[1:].split("/")
                 procTask.addInputDataset(name=self.inputDataset, primary=primary,
                                          processed=processed, tier=tier, dbsurl=self.dbsUrl,
@@ -366,7 +366,7 @@ class StdBase(object):
                                          block_whitelist=self.blockWhitelist,
                                          run_blacklist=self.runBlacklist,
                                          run_whitelist=self.runWhitelist)
-            elif inputStep != None and inputModule != None:
+            elif inputStep is not None and inputModule is not None:
                 procTask.setInputReference(inputStep, outputModule=inputModule)
 
         if primarySubType:
@@ -420,7 +420,7 @@ class StdBase(object):
                                                 forceMerged=forceMerged, forceUnmerged=forceUnmerged, taskConf=taskConf)
             outputModules[outputModuleName] = outputModule
 
-        if configDoc != None and configDoc != "":
+        if configDoc is not None and configDoc != "":
             procTaskCmsswHelper.setConfigCache(configCacheUrl, configDoc, couchDBName)
         else:
             # delete dataset information from scenarioArgs
@@ -462,16 +462,16 @@ class StdBase(object):
         dataset name is desired
         """
         taskConf = taskConf or {}
-        haveFilterName = (filterName != None and filterName != "")
-        haveProcString = (self.processingString != None and self.processingString != "")
-        haveRunNumber = (self.runNumber != None and self.runNumber > 0)
+        haveFilterName = (filterName is not None and filterName != "")
+        haveProcString = (self.processingString is not None and self.processingString != "")
+        haveRunNumber = (self.runNumber is not None and self.runNumber > 0)
 
         taskName = parentTask.name()
         if self.requestType == "StepChain" and "StepName" in taskConf:
             taskName = taskConf["StepName"]
         acqEra = taskConf.get('AcquisitionEra') or self._getDictionaryParams(self.acquisitionEra, taskName)
         procString = taskConf.get('ProcessingString') or self._getDictionaryParams(self.processingString, taskName)
-        procVersion = taskConf.get('ProcessingVersion') or self._getDictionaryParams(self.processingVersion, taskName, 1)
+        procVersion = taskConf.get('ProcessingVersion') or self._getDictionaryParams(self.processingVersion, taskName,1)
 
         processedDataset = "%s-" % acqEra
         if haveFilterName:
@@ -1023,7 +1023,7 @@ class StdBase(object):
                      "MergedLFNBase": {"default": "/store/data"},
                      "UnmergedLFNBase": {"default": "/store/unmerged"},
                      "DeleteFromSource": {"default": False, "type": strToBool},
-                    }
+                     }
 
         # these arguments are internally set by ReqMgr2 and should not be provided by the user
         reqmgrArgs = {"Requestor": {"attr": "owner", "optional": False},
@@ -1035,7 +1035,7 @@ class StdBase(object):
                       "CouchURL": {"default": "https://cmsweb.cern.ch/couchdb", "validate": couchurl},
                       "CouchDBName": {"default": "reqmgr_config_cache", "type": str, "validate": identifier},
                       "CouchWorkloadDBName": {"default": "reqmgr_workload_cache", "validate": identifier}
-                     }
+                      }
 
         arguments.update(reqmgrArgs)
         # Set defaults for the argument specification
@@ -1114,7 +1114,7 @@ class StdBase(object):
                      "BlockCloseMaxSize": {"default": 5000000000000, "type": int, "validate": lambda x: x > 0},
                      # dashboard activity
                      "Dashboard": {"default": "production", "type": str, "validate": activity}
-                    }
+                     }
         # Set defaults for the argument specification
         StdBase.setDefaultArgumentsProperty(arguments)
 

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -840,7 +840,12 @@ class StdBase(object):
 
         Named this way so that nobody else will try to use this name.
         """
-        if 'OriginalRequestName' not in arguments:
+        if arguments.get("RequestType") == "Resubmission":
+            # We're skipping the Resubmission validation for now
+            # clone is already validated, the user args only, so skip it too
+            # self.validateSchema(schema=arguments)
+            pass
+        else:
             self.masterValidation(schema=arguments)
             self.validateSchema(schema=arguments)
 

--- a/test/python/WMCore_t/ReqMgr_t/DataStructs_t/Request_t.py
+++ b/test/python/WMCore_t/ReqMgr_t/DataStructs_t/Request_t.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python
+"""
+Unittests for IteratorTools functions
+"""
+
+from __future__ import division, print_function
+
+import unittest
+from copy import deepcopy
+
+from WMCore.ReqMgr.DataStructs.Request import initialize_clone
+from WMCore.WMSpec.StdSpecs.MonteCarlo import MonteCarloWorkloadFactory
+from WMCore.WMSpec.StdSpecs.StepChain import StepChainWorkloadFactory
+from WMCore.WMSpec.StdSpecs.TaskChain import TaskChainWorkloadFactory
+from WMCore.WMSpec.WMSpecErrors import WMSpecFactoryException
+
+### Spec arguments definition with only key and its default value
+MC_ARGS = MonteCarloWorkloadFactory.getWorkloadCreateArgs()
+STEPCHAIN_ARGS = StepChainWorkloadFactory.getWorkloadCreateArgs()
+TASKCHAIN_ARGS = TaskChainWorkloadFactory.getWorkloadCreateArgs()
+# inner Task/Step definition
+STEP_ARGS = StepChainWorkloadFactory.getChainCreateArgs()
+TASK_ARGS = TaskChainWorkloadFactory.getChainCreateArgs()
+
+### Some original request dicts (ones to be cloned from)
+mcOriginalArgs = {'Memory': 1234, 'TimePerEvent': 1.2, 'RequestType': 'MonteCarlo', "LheInputFiles": True,
+                  "ScramArch": ["slc6_amd64_gcc481"], "RequestName": "test_mc"}
+stepChainOriginalArgs = {'Memory': 1234, 'TimePerEvent': 1.2, 'RequestType': 'StepChain',
+                         "ScramArch": ["slc6_amd64_gcc481"], "RequestName": "test_stepchain",
+                         "Step1": {"ConfigCacheID": "blah", "GlobalTag": "PHYS18", "BlockWhitelist": ["A", "B"]},
+                         "Step2": {"AcquisitionEra": "ACQERA", "ProcessingVersion": 3, "LumisPerJob": 10},
+                         "StepChain": 2, "ConfigCacheID": None}
+taskChainOriginalArgs = {'PrepID': None, 'Campaign': "MainTask", 'RequestType': 'TaskChain',
+                         "ScramArch": ["slc6_amd64_gcc481", "slc7_amd64_gcc630"], "RequestName": "test_taskchain",
+                         "Task1": {"ConfigCacheID": "blah", "InputDataset": "/1/2/RAW", "BlockWhitelist": ["A", "B"],
+                                   "LumiList": {"202205": [[1, 10], [20, 25]], "202209": [[1, 3], [5, 5], [6, 9]]}},
+                         "Task2": {"AcquisitionEra": "ACQERA", "KeepOutput": False, "ProcessingVersion": 3,
+                                   "LumisPerJob": 10},
+                         "Task3": {"InputTask": "task111", "TaskName": "blah", "LumisPerJob": 10},
+                         "TaskChain": 3, "DQMConfigCacheID": 'unidunite'}
+
+
+def updateDict(dictObj1, dictObj2):
+    """
+    Util for updating the dictObj1 with the context of dictObj2 and return the final dict
+    """
+    dictObj1.update(dictObj2)
+    return dictObj1
+
+
+class RequestTests(unittest.TestCase):
+    """
+    unittest for ReqMgr DataStructs Request functions.
+    """
+
+    def testInvalidKeys_initialize_clone(self):
+        """
+        Test some undefined/assignment user arguments in initialize_clone
+        """
+        # test with unknown key
+        requestArgs = {'Multicore': 1, 'WRONG': 'Alan', 'ReqMgr2Only': False}
+        originalArgs = deepcopy(mcOriginalArgs)
+        cloneArgs = initialize_clone(requestArgs, originalArgs, MC_ARGS)
+        with self.assertRaises(WMSpecFactoryException):
+            MonteCarloWorkloadFactory().factoryWorkloadConstruction(cloneArgs["RequestName"], cloneArgs)
+
+        # test with assignment key
+        requestArgs = {'Multicore': 1, 'TrustSitelists': False, 'ReqMgr2Only': False}
+        originalArgs = deepcopy(mcOriginalArgs)
+        cloneArgs = initialize_clone(requestArgs, originalArgs, MC_ARGS)
+        with self.assertRaises(WMSpecFactoryException):
+            MonteCarloWorkloadFactory().factoryWorkloadConstruction(cloneArgs["RequestName"], cloneArgs)
+
+        # test mix of StepChain and TaskChain args (it passes the initial filter but raises factory exception)
+        requestArgs = {'SubRequestType': "RelVal", "Step2": {"LumisPerJob": 5, "Campaign": "Step2Camp"}}
+        originalArgs = deepcopy(taskChainOriginalArgs)
+        cloneArgs = initialize_clone(requestArgs, originalArgs, TASKCHAIN_ARGS, TASK_ARGS)
+        with self.assertRaises(WMSpecFactoryException):
+            TaskChainWorkloadFactory().factoryWorkloadConstruction(cloneArgs["RequestName"], cloneArgs)
+
+    def testMC_initialize_clone(self):
+        """
+        Test the basics of initialize_clone. 
+        """
+        # test overwrite of original values
+        requestArgs = {'Multicore': 1, 'ScramArch': 'slc6_amd64_gcc481', 'LheInputFiles': False}
+        originalArgs = deepcopy(mcOriginalArgs)
+        cloneArgs = initialize_clone(requestArgs, originalArgs, MC_ARGS)
+        mcArgs = deepcopy(mcOriginalArgs)
+        self.assertDictEqual(cloneArgs, updateDict(mcArgs, requestArgs))
+
+        # test overwrite of values that are not in the original request
+        requestArgs = {'DQMUploadProxy': 'test_file', 'RequestNumEvents': 1, 'DQMSequences': ['a', 'b']}
+        originalArgs = deepcopy(mcOriginalArgs)
+        cloneArgs = initialize_clone(requestArgs, originalArgs, MC_ARGS)
+        mcArgs = deepcopy(mcOriginalArgs)
+        self.assertDictEqual(cloneArgs, updateDict(mcArgs, requestArgs))
+
+        # check whether invalid keys in the original request are dumped
+        requestArgs = {'RequestNumEvents': 1, 'DQMSequences': []}
+        originalArgs = deepcopy(mcOriginalArgs)
+        originalArgs.update(badJob='whatever', WMCore={'YouFool': True})
+        cloneArgs = initialize_clone(requestArgs, originalArgs, MC_ARGS)
+        mcArgs = deepcopy(mcOriginalArgs)
+        self.assertDictEqual(cloneArgs, updateDict(mcArgs, requestArgs))
+
+    def testSC_initialize_clone(self):
+        """
+        Test initialize_clone handling StepChains
+        """
+        # test overwrite of original values
+        requestArgs = {'TimePerEvent': 12.34, 'ConfigCacheID': 'couchid', 'StepChain': 20}
+        originalArgs = deepcopy(stepChainOriginalArgs)
+        cloneArgs = initialize_clone(requestArgs, originalArgs, STEPCHAIN_ARGS, STEP_ARGS)
+        scArgs = deepcopy(stepChainOriginalArgs)
+        self.assertDictEqual(cloneArgs, updateDict(scArgs, requestArgs))
+
+        # test overwrite of values that are not in the original request
+        requestArgs = {'DQMUploadProxy': 'test_file', 'RequestNumEvents': 1, 'DQMSequences': ['a', 'b']}
+        originalArgs = deepcopy(stepChainOriginalArgs)
+        cloneArgs = initialize_clone(requestArgs, originalArgs, STEPCHAIN_ARGS, STEP_ARGS)
+        scArgs = deepcopy(stepChainOriginalArgs)
+        self.assertDictEqual(cloneArgs, updateDict(scArgs, requestArgs))
+
+        # check whether invalid keys in the original request are dumped
+        requestArgs = {'RequestNumEvents': 1, 'DQMSequences': []}
+        originalArgs = deepcopy(stepChainOriginalArgs)
+        originalArgs.update(Chain='whatever', WMCore={'YouFool': True})
+        cloneArgs = initialize_clone(requestArgs, originalArgs, STEPCHAIN_ARGS, STEP_ARGS)
+        scArgs = deepcopy(stepChainOriginalArgs)
+        self.assertDictEqual(cloneArgs, updateDict(scArgs, requestArgs))
+
+        # test overwrite of inner Step dictionaries
+        requestArgs = {'SubRequestType': "RelVal", "Step2": {"LumisPerJob": 5, "Campaign": "Step2Camp"},
+                       "Step1": {"BlockWhitelist": ["C"]}}
+        originalArgs = deepcopy(stepChainOriginalArgs)
+        cloneArgs = initialize_clone(requestArgs, originalArgs, STEPCHAIN_ARGS, STEP_ARGS)
+        scArgs = deepcopy(stepChainOriginalArgs)
+        # setting by hand, I assume I better not use the code that is being tested here :-)
+        updateDict(scArgs, requestArgs)
+        scArgs['Step1'] = {"ConfigCacheID": "blah", "GlobalTag": "PHYS18", "BlockWhitelist": ["C"]}
+        scArgs['Step2'] = {"AcquisitionEra": "ACQERA", "ProcessingVersion": 3, "LumisPerJob": 5,
+                           "Campaign": "Step2Camp"}
+        self.assertDictEqual(cloneArgs, scArgs)
+
+    def testTC_initialize_clone(self):
+        """
+        Test initialize_clone handling TaskChains
+        """
+        # test overwrite of original values
+        requestArgs = {'ScramArch': "slc6_amd64_gcc630", 'DQMConfigCacheID': None, 'TaskChain': 20}
+        originalArgs = deepcopy(taskChainOriginalArgs)
+        cloneArgs = initialize_clone(requestArgs, originalArgs, TASKCHAIN_ARGS, TASK_ARGS)
+        tcArgs = deepcopy(taskChainOriginalArgs)
+        self.assertDictEqual(cloneArgs, updateDict(tcArgs, requestArgs))
+
+        # test overwrite of values that are not in the original request
+        requestArgs = {'Task4': {"InputTask": "task222", "TransientOutputModules": ["RAW", "AOD"]},
+                       'ConfigCacheID': None, 'EventStreams': 8}
+        originalArgs = deepcopy(taskChainOriginalArgs)
+        cloneArgs = initialize_clone(requestArgs, originalArgs, TASKCHAIN_ARGS, TASK_ARGS)
+        tcArgs = deepcopy(taskChainOriginalArgs)
+        self.assertDictEqual(cloneArgs, updateDict(tcArgs, requestArgs))
+
+        # check whether invalid keys in the original request are dumped
+        requestArgs = {'RequestPriority': 1, 'DQMSequences': [], "AcquisitionEra": {"T1": "a", "T2": "b"}}
+        originalArgs = deepcopy(taskChainOriginalArgs)
+        originalArgs.update(ioInput='whatever', WMCore={'YouFool': True}, TotalJobs=123)
+        cloneArgs = initialize_clone(requestArgs, originalArgs, TASKCHAIN_ARGS, TASK_ARGS)
+        tcArgs = deepcopy(taskChainOriginalArgs)
+        self.assertDictEqual(cloneArgs, updateDict(tcArgs, requestArgs))
+
+        # test overwrite of inner Task dictionaries
+        requestArgs = {"Task1": {"LumisPerJob": 1, "LumiList": {"202209": [[3, 5]]}},
+                       "Task3": {"TaskName": "newBlah", "TransientOutputModules": []},
+                       "PrepID": "prepBlah"}
+        originalArgs = deepcopy(taskChainOriginalArgs)
+        cloneArgs = initialize_clone(requestArgs, originalArgs, TASKCHAIN_ARGS, TASK_ARGS)
+        tcArgs = deepcopy(taskChainOriginalArgs)
+        # setting by hand, I assume I better not use the code that is being tested here :-)
+        updateDict(tcArgs, requestArgs)
+        tcArgs['Task1'] = {"ConfigCacheID": "blah", "InputDataset": "/1/2/RAW", "BlockWhitelist": ["A", "B"],
+                           "LumisPerJob": 1, "LumiList": {"202205": [[1, 10], [20, 25]], "202209": [[3, 5]]}}
+        tcArgs['Task3'] = {"InputTask": "task111", "TaskName": "newBlah", "LumisPerJob": 10,
+                           "TransientOutputModules": []}
+        self.assertDictEqual(cloneArgs, tcArgs)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/7846
@ticoann Seangchan, this is what I had in mind for cloning the creation arguments only. Which then can go through standard request creation validation as well.

The drawback is the fact that we validate all arguments again. Which is not that bad in cases we had a cmsweb upgrade that changed the data format/validate function for some of them :)
Second improvement to be done would be checking permissions before cloning the args, though we have basically 0 cases where the user cannot create a request.

If you think it would be good to have it in this testbed, let me know and I'll try to validate tomorrow and ask Lina for a new upgrade. Otherwise we can discuss and improve it for the next cycle. 