### PR TITLE
Skip Proxy Error exception in PhEDExInjector

### DIFF
--- a/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
+++ b/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
@@ -175,8 +175,8 @@ class PhEDExInjectorPoller(BaseWorkerThread):
                 self.deleteBlocks()
                 self.subscribeDatasets()
         except HTTPException as ex:
-            if hasattr(ex, "status") and ex.status == 503:
-                # then service is unavailable
+            if hasattr(ex, "status") and ex.status in [502, 503]:
+                # then either proxy error or service is unavailable
                 msg = "Caught HTTPException in PhEDExInjector. Retrying in the next cycle.\n"
                 msg += str(ex)
                 logging.error(msg)


### PR DESCRIPTION
Fixes #7828

"502 Proxy Error" comes back when the http request hits a bad/down backend, see full traceback here [1].

I wonder if the same error/reason can happen in other cases, like a request way too big which the backend cannot respond within the frontend timeout(?) Otherwise it should be safe to push it to all the agents (have pushed in only in vocms026 for now).


[1]
```
2017-05-01 21:50:45,160:140420007802624:INFO:PhEDExInjectorPoller:Starting subscribeDatasets method
2017-05-01 21:52:28,102:140420007802624:WARNING:Service:The cachefile /data/srv/wmagent/v1.1.2.patch3/install/wmagent/PhEDExInjector/.wmcore_cache/.wmcore_cache_31961/requests/cmsweb.cern.ch/-5456226762442263214_GET_subscriptions does not exist and the service at https://cmsweb.cern.ch/phedex/datasvc/json/prod/subscriptions is unavailable - it returned 502 because Proxy Error
 with result: <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>502 Proxy Error</title>
</head><body>
<h1>Proxy Error</h1>
<p>The proxy server received an invalid
response from an upstream server.<br />
The proxy server could not handle the request <em><a href="/auth/complete/phedex/datasvc/json/prod/subscriptions">GET&nbsp;/auth/complete/phedex/datasvc/json/prod/subscriptions</a></em>.<p>
Reason: <strong>Error reading from remote server</strong></p></p>
</body></html>


2017-05-01 21:52:28,105:140420007802624:ERROR:PhEDExInjectorPoller:Caught unexpected HTTPException in PhEDExInjector.
Traceback (most recent call last):
  File "/data/srv/wmagent/v1.1.2.patch3/sw/slc6_amd64_gcc493/cms/wmagent/1.1.2.patch3/lib/python2.7/site-packages/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py", line 176, in algorithm
    self.subscribeDatasets()
  File "/data/srv/wmagent/v1.1.2.patch3/sw/slc6_amd64_gcc493/cms/wmagent/1.1.2.patch3/lib/python2.7/site-packages/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py", line 588, in subscribeDatasets
    if phedexSub.matchesExistingSubscription(self.phedex) or \
  File "/data/srv/wmagent/v1.1.2.patch3/sw/slc6_amd64_gcc493/cms/wmagent/1.1.2.patch3/lib/python2.7/site-packages/WMCore/Services/PhEDEx/DataStructs/SubscriptionList.py", line 206, in matchesExistingSubscription
    node = node)['phedex']['dataset']
  File "/data/srv/wmagent/v1.1.2.patch3/sw/slc6_amd64_gcc493/cms/wmagent/1.1.2.patch3/lib/python2.7/site-packages/WMCore/Services/PhEDEx/PhEDEx.py", line 221, in subscriptions
    return self._getResult(callname, args=kwargs, verb="GET")
  File "/data/srv/wmagent/v1.1.2.patch3/sw/slc6_amd64_gcc493/cms/wmagent/1.1.2.patch3/lib/python2.7/site-packages/WMCore/Services/PhEDEx/PhEDEx.py", line 48, in _getResult
    f = self.refreshCache(file, callname, args, verb=verb)
  File "/data/srv/wmagent/v1.1.2.patch3/sw/slc6_amd64_gcc493/cms/wmagent/1.1.2.patch3/lib/python2.7/site-packages/WMCore/Services/Service.py", line 201, in refreshCache
    self.getData(cachefile, url, inputdata, incoming_headers, encoder, decoder, verb, contentType)
  File "/data/srv/wmagent/v1.1.2.patch3/sw/slc6_amd64_gcc493/cms/wmagent/1.1.2.patch3/lib/python2.7/site-packages/WMCore/Services/Service.py", line 309, in getData
    raise he
HTTPException
2017-05-01 21:52:28,106:140420007802624:ERROR:BaseWorkerThread:Error in worker algorithm (1):
Backtrace:
  <WMComponent.PhEDExInjector.PhEDExInjectorPoller.PhEDExInjectorPoller instance at 0x7fb61cdccb48>   File "/data/srv/wmagent/v1.1.2.patch3/sw/slc6_amd64_gcc493/cms/wmagent/1.1.2.patch3/lib/python2.7/site-packages/WMCore/WorkerThreads/BaseWorkerThread.py", line 179, in __call__
    self.algorithm(parameters)
  File "/data/srv/wmagent/v1.1.2.patch3/sw/slc6_amd64_gcc493/cms/wmagent/1.1.2.patch3/lib/python2.7/site-packages/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py", line 176, in algorithm
    self.subscribeDatasets()
  File "/data/srv/wmagent/v1.1.2.patch3/sw/slc6_amd64_gcc493/cms/wmagent/1.1.2.patch3/lib/python2.7/site-packages/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py", line 588, in subscribeDatasets
    if phedexSub.matchesExistingSubscription(self.phedex) or \
  File "/data/srv/wmagent/v1.1.2.patch3/sw/slc6_amd64_gcc493/cms/wmagent/1.1.2.patch3/lib/python2.7/site-packages/WMCore/Services/PhEDEx/DataStructs/SubscriptionList.py", line 206, in matchesExistingSubscription
    node = node)['phedex']['dataset']
  File "/data/srv/wmagent/v1.1.2.patch3/sw/slc6_amd64_gcc493/cms/wmagent/1.1.2.patch3/lib/python2.7/site-packages/WMCore/Services/PhEDEx/PhEDEx.py", line 221, in subscriptions
    return self._getResult(callname, args=kwargs, verb="GET")
  File "/data/srv/wmagent/v1.1.2.patch3/sw/slc6_amd64_gcc493/cms/wmagent/1.1.2.patch3/lib/python2.7/site-packages/WMCore/Services/PhEDEx/PhEDEx.py", line 48, in _getResult
    f = self.refreshCache(file, callname, args, verb=verb)
  File "/data/srv/wmagent/v1.1.2.patch3/sw/slc6_amd64_gcc493/cms/wmagent/1.1.2.patch3/lib/python2.7/site-packages/WMCore/Services/Service.py", line 201, in refreshCache
    self.getData(cachefile, url, inputdata, incoming_headers, encoder, decoder, verb, contentType)
  File "/data/srv/wmagent/v1.1.2.patch3/sw/slc6_amd64_gcc493/cms/wmagent/1.1.2.patch3/lib/python2.7/site-packages/WMCore/Services/Service.py", line 309, in getData
    raise he

2017-05-01 21:52:28,106:140420007802624:INFO:Harness:>>>Terminating worker threads
2017-05-01 21:52:28,110:140420007802624:ERROR:BaseWorkerThread:Error in event loop (2): <WMComponent.PhEDExInjector.PhEDExInjectorPoller.PhEDExInjectorPoller instance at 0x7fb61cdccb48> 
Backtrace:
  File "/data/srv/wmagent/v1.1.2.patch3/sw/slc6_amd64_gcc493/cms/wmagent/1.1.2.patch3/lib/python2.7/site-packages/WMCore/WorkerThreads/BaseWorkerThread.py", line 205, in __call__
    raise ex

2017-05-01 21:52:28,111:140420007802624:INFO:BaseWorkerThread:Worker thread <WMComponent.PhEDExInjector.PhEDExInjectorPoller.PhEDExInjectorPoller instance at 0x7fb61cdccb48> terminated

```