### PR TITLE
Don't validate Resubmission specs

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -843,11 +843,7 @@ class StdBase(object):
         if 'OriginalRequestName' not in arguments:
             self.masterValidation(schema=arguments)
             self.validateSchema(schema=arguments)
-        elif arguments.get("RequestType") == "Resubmission":
-            # Don't validate schema for cloned workflow
-            # But Resubmission workflow has to be validated
-            self.validateSchema(schema=arguments)
-        
+
         workload = self.__call__(workloadName=workloadName, arguments=arguments)
         self.validateWorkload(workload)
 


### PR DESCRIPTION
Fixes #7835 (if you allow me to call it a fix :))

@ticoann this is the fix I suggest to be pushed into cmsweb as a critical patch release.
Then we can properly implement and test Resubmission creation/validation for the next cycle.
What do you think? If you agree, we can ask the HTTP team to push it to testbed even today and to production tomorrow morning.