### PR TITLE
Fix certificate verification issue during harvesting

### DIFF
--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -35,7 +35,8 @@ dependencies = {'wmc-rest':{
                         'systems':['wmc-base']
                         },
                 'wmc-runtime':{
-                        'packages': ['WMCore.WMRuntime+', 'WMCore.WMSpec+', 'PSetTweaks', 'WMCore.FwkJobReport', 'WMCore.Storage+'],
+                        'packages': ['WMCore.WMRuntime+', 'WMCore.WMSpec+', 'PSetTweaks',
+                                     'WMCore.FwkJobReport', 'WMCore.Storage+', 'WMCore.Services.HTTPS'],
                         'modules' : ['WMCore.Algorithms.ParseXMLFile'],
                         'systems':['wmc-base']
                         },

--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -4,164 +4,165 @@ Manage dependancies by declaring systems here.
 A system can depend on packages or other systems.
 If a package ends with a + include all subpackages.
 """
-dependencies = {'wmc-rest':{
-                        'bin': ['wmc-dist-patch', 'wmc-dist-unpatch', 'wmc-httpd'],
-                        'packages' : ['WMCore.REST'],
-                        'modules': ['WMCore.Configuration'],
-                        'systems':['wmc-base']
-                        },
-                'wmc-wmarchive':{
-                        'bin': ['wmc-dist-patch', 'wmc-dist-unpatch', 'wmc-httpd'],
-                        'packages' : ['WMCore.REST', 'WMCore.Services.StompAMQ'],
-                        'modules': ['WMCore.Configuration'],
-                        'systems':['wmc-base']
-                        },
-                'wmc-base':{
-                        'bin': ['wmc-dist-patch', 'wmc-dist-unpatch'],
-                        'packages' : ['Utils', 'WMCore.DataStructs', 'WMCore.Cache'],
-                        'modules': ['WMCore.WMFactory', 'WMCore.WMException', 'WMCore.Configuration',
-                                    'WMCore.WMExceptions', 'WMCore.WMFactory', 'WMCore.Lexicon',
-                                    'WMCore.WMBase', 'WMCore.WMLogging', 'WMCore.Algorithms.Permissions'],
-                        },
-                'wmc-component':{
-                        'packages': ['WMCore.MsgService', 'WMCore.WorkerThreads', 'WMCore.Alerts+', 'WMCore.ThreadPool'],
-                        'modules': ['WMComponent.__init__'],
-                        'systems': ['wmc-base']
-                        },
-                'wmc-database':{
-                        'packages': ['WMCore.Wrappers+', 'WMCore.GroupUser', 'WMCore.DataStructs', 'WMCore.Database',
-                                    'WMCore.Algorithms', 'WMCore.Services'],
-                        'modules': ['WMCore.WMConnectionBase', 'WMCore.DAOFactory', 'WMCore.WMInit'],
-                        'systems':['wmc-base']
-                        },
-                'wmc-runtime':{
-                        'packages': ['WMCore.WMRuntime+', 'WMCore.WMSpec+', 'PSetTweaks',
-                                     'WMCore.FwkJobReport', 'WMCore.Storage+', 'WMCore.Services.HTTPS'],
-                        'modules' : ['WMCore.Algorithms.ParseXMLFile'],
-                        'systems':['wmc-base']
-                        },
-                'wmc-web':{
-                        'packages': ['WMCore.WebTools', 'WMCore.Agent+', 'WMCore.WorkerThreads', 'WMCore.Alerts+'],
-                        'systems':['wmc-database', 'wmc-base'],
-                        'statics': ['src/javascript/WMCore/WebTools',
-                                'src/javascript/external/yui',
-                                'src/css/WMCore/WebTools',
-                                'src/css/WMCore/WebTools/Masthead',
-                                'src/css/external/yui',
-                                'src/templates/WMCore/WebTools',
-                                'src/templates/WMCore/WebTools/Masthead',]
-                        },
-                'reqmgr2':{
-                        'packages': ['WMCore.ReqMgr+',
-                                     'WMCore.WMDataMining+',
-                                     'WMCore.Services+',
-                                     'WMCore.ACDC'
-                                    ],
-                        'systems': ['wmc-rest', 'wmc-runtime', 'wmc-database'],
-                        'statics': ['src/couchapps/ReqMgr+',
-                                    'src/couchapps/ReqMgrAux+',
-                                    'src/couchapps/ConfigCache+',
-                                    'src/couchapps/WMStats+',
-                                    'src/couchapps/WMDataMining+',
-                                    'src/html/ReqMgr+'
-                                   ],
-                          },
-                'workqueue':{
-                        'packages': ['WMCore.GlobalWorkQueue+', 'WMCore.WorkQueue+',
-                                     'WMCore.Wrappers+', 'WMCore.Services+',
-                                     'WMCore.WMSpec', 'WMCore.WMSpec.Steps', 'WMCore.WMSpec.Steps.Templates',
-                                     'WMCore.ACDC', 'WMCore.GroupUser', 'WMCore.Alerts'],
-                        'modules' : ['WMCore.Algorithms.__init__', 'WMCore.Algorithms.Permissions',
-                                     'WMCore.Algorithms.MiscAlgos', 'WMCore.Algorithms.ParseXMLFile',
-                                     'WMCore.Database.__init__', 'WMCore.Database.CMSCouch',
-                                     'WMCore.Database.CouchUtils',
-                                     'WMCore.ReqMgr.__init__', 'WMCore.ReqMgr.DataStructs.__init__',
-                                     'WMCore.ReqMgr.DataStructs.RequestStatus',
-                                     'WMCore.ReqMgr.DataStructs.RequestType'],
-                        'systems': ['wmc-rest', 'wmc-database'],
-                        'statics': ['src/couchapps/WorkQueue+'],
-                        },
-                'wmagent':{
-                        'packages': ['WMCore.Agent+', 'WMCore.Algorithms+',
-                                    'WMCore.JobStateMachine', 'WMComponent+',
-                                    'WMCore.ThreadPool',
-                                    'WMCore.BossAir+', 'WMCore.Credential',
-                                    'WMCore.JobSplitting+', 'WMCore.ProcessPool',
-                                    'WMCore.Services+', 'WMCore.WMSpec+',
-                                    'WMCore.WMBS+', 'WMCore.ResourceControl+'],
-                        'systems':['wmc-web', 'wmc-database', 'workqueue', 'wmc-runtime'],
-                        'statics': ['src/javascript/WMCore/WebTools/Agent',
-                                    'src/javascript/WMCore/WebTools/WMBS',
-                                    'src/javascript/external/graphael',
-                                    'src/templates/WMCore/WebTools/WMBS'],
-                        },
-                'asyncstageout':{
-                        'packages': ['WMCore.Agent+', 'WMCore.Storage+',
-                                     'WMCore.Credential', 'WMCore.WorkerThreads',
-                                     'WMCore.ACDC', 'WMCore.Alerts+',
-                                     'WMCore.Services+'],
-                        'modules': ['WMQuality.TestInitCouchApp', 'WMCore.Services.Service',
-                                    'WMCore.Services.pycurl_manager', 'WMComponent.__init__'],
-                        'systems': ['wmc-database'],
-                        'statics': ['src/couchapps/Agent+'],
-                        },
-                'crabcache':{
-                        'packages': ['WMCore.Wrappers+', 'WMCore.Services.UserFileCache+'],
-                        'systems': ['wmc-rest'],
-                        'modules': ['WMCore.Services.Requests', 'WMCore.Services.Service',
-                                    'WMCore.Services.pycurl_manager', ],
-                        },
-                'crabserver':{
-                        'packages': ['WMCore.Credential', 'WMCore.Services+',
-                                     'WMCore.WMSpec+', 'WMCore.ACDC'],
-                        'modules' : ['WMCore.DataStructs.LumiList'],
-                        'systems' : ['wmc-rest', 'wmc-database'],
-                        },
-                'crabclient':{
-                        'packages': ['WMCore.Wrappers+', 'WMCore.Credential', 'PSetTweaks', 'WMCore.Services.UserFileCache+',
-                                     'WMCore.Services.SiteDB+', 'WMCore.Services.PhEDEx+', 'WMCore.Services.DBS+'],
-                        'systems': ['wmc-base'],
-                        'modules': ['WMCore.FwkJobReport.FileInfo', 'WMCore.Services.Requests', 'WMCore.DataStructs.LumiList',
-                                    'WMCore.Services.Service', 'WMCore.Services.pycurl_manager',],
-                        },
-                'crabtaskworker':{
-                        'packages':['WMCore.WorkQueue', 'WMCore.Credential', 'WMCore.Algorithms+', 'WMCore.WMSpec+',
-                                    'WMCore.JobSplitting', 'WMCore.Services.SiteDB+', 'WMCore.Services.DBS+',
-                                    'WMCore.Services.UserFileCache+', 'WMCore.Services.PhEDEx+', 'WMCore.Services.Dashboard+',
-                                    'Utils+'],
-                        'modules': ['WMCore.WMBS.File', 'WMCore.WMBS.WMBSBase', 'WMCore.WMBS.__init__'],
-                        'systems': ['wmc-database', 'wmc-runtime'],
-                        },
-                'wmclient':{
-                        'systems': ['wmc-runtime', 'wmc-database']
-                        },
-                'reqmon':{
-                        'packages': ['WMCore.WMStats+', 'WMCore.WMDataMining+',
-                                     'WMCore.Services+', 'WMCore.Wrappers+',
-                                     'WMCore.ReqMgr.DataStructs+'
-                                    ],
-                        'modules' : ['WMCore.Database.__init__', 'WMCore.Database.CMSCouch',
-                                     'WMCore.Database.CouchUtils', 'WMCore.ReqMgr.__init__'],
-                        'systems': ['wmc-base', 'wmc-rest'],
-                        'statics': ['src/couchapps/WMStats+',
-                                    'src/couchapps/WMStatsErl+',
-                                    'src/couchapps/WorkloadSummary+',
-                                    'src/couchapps/T0Request+',
-                                    'src/couchapps/LogDB+',
-                                    'src/html/WMStats+'],
-                        },
-                'alertscollector':
-                {
-                        'statics': ['src/couchapps/AlertsCollector+'],
-                },
-                'acdcserver': {
-                        'packages': ['WMCore.ACDC', 'WMCore.GroupUser', 'WMCore.DataStructs',
-                                     'WMCore.Wrappers+', 'WMCore.Database'],
-                        'modules' : ['WMCore.Configuration',
-                                     'WMCore.Algorithms.ParseXMLFile', 'WMCore.Algorithms.Permissions',
-                                     'WMCore.Lexicon', 'WMCore.WMException', 'WMCore.Services.Requests',
-                                     'WMCore.Services.pycurl_manager'],
-                       'statics' : ['src/couchapps/ACDC+',
-                                    'src/couchapps/GroupUser+']
-                       }
-               }
+dependencies = {
+    'wmc-rest': {
+        'bin': ['wmc-dist-patch', 'wmc-dist-unpatch', 'wmc-httpd'],
+        'packages': ['WMCore.REST'],
+        'modules': ['WMCore.Configuration'],
+        'systems': ['wmc-base']
+    },
+    'wmc-wmarchive': {
+        'bin': ['wmc-dist-patch', 'wmc-dist-unpatch', 'wmc-httpd'],
+        'packages': ['WMCore.REST', 'WMCore.Services.StompAMQ'],
+        'modules': ['WMCore.Configuration'],
+        'systems': ['wmc-base']
+    },
+    'wmc-base': {
+        'bin': ['wmc-dist-patch', 'wmc-dist-unpatch'],
+        'packages': ['Utils', 'WMCore.DataStructs', 'WMCore.Cache'],
+        'modules': ['WMCore.WMFactory', 'WMCore.WMException', 'WMCore.Configuration',
+                    'WMCore.WMExceptions', 'WMCore.WMFactory', 'WMCore.Lexicon',
+                    'WMCore.WMBase', 'WMCore.WMLogging', 'WMCore.Algorithms.Permissions'],
+    },
+    'wmc-component': {
+        'packages': ['WMCore.MsgService', 'WMCore.WorkerThreads', 'WMCore.Alerts+', 'WMCore.ThreadPool'],
+        'modules': ['WMComponent.__init__'],
+        'systems': ['wmc-base']
+    },
+    'wmc-database': {
+        'packages': ['WMCore.Wrappers+', 'WMCore.GroupUser', 'WMCore.DataStructs', 'WMCore.Database',
+                     'WMCore.Algorithms', 'WMCore.Services'],
+        'modules': ['WMCore.WMConnectionBase', 'WMCore.DAOFactory', 'WMCore.WMInit'],
+        'systems': ['wmc-base']
+    },
+    'wmc-runtime': {
+        'packages': ['WMCore.WMRuntime+', 'WMCore.WMSpec+', 'PSetTweaks',
+                     'WMCore.FwkJobReport', 'WMCore.Storage+', 'WMCore.Services.HTTPS'],
+        'modules': ['WMCore.Algorithms.ParseXMLFile'],
+        'systems': ['wmc-base']
+    },
+    'wmc-web': {
+        'packages': ['WMCore.WebTools', 'WMCore.Agent+', 'WMCore.WorkerThreads', 'WMCore.Alerts+'],
+        'systems': ['wmc-database', 'wmc-base'],
+        'statics': ['src/javascript/WMCore/WebTools',
+                    'src/javascript/external/yui',
+                    'src/css/WMCore/WebTools',
+                    'src/css/WMCore/WebTools/Masthead',
+                    'src/css/external/yui',
+                    'src/templates/WMCore/WebTools',
+                    'src/templates/WMCore/WebTools/Masthead', ]
+    },
+    'reqmgr2': {
+        'packages': ['WMCore.ReqMgr+',
+                     'WMCore.WMDataMining+',
+                     'WMCore.Services+',
+                     'WMCore.ACDC'
+                     ],
+        'systems': ['wmc-rest', 'wmc-runtime', 'wmc-database'],
+        'statics': ['src/couchapps/ReqMgr+',
+                    'src/couchapps/ReqMgrAux+',
+                    'src/couchapps/ConfigCache+',
+                    'src/couchapps/WMStats+',
+                    'src/couchapps/WMDataMining+',
+                    'src/html/ReqMgr+'
+                    ],
+    },
+    'workqueue': {
+        'packages': ['WMCore.GlobalWorkQueue+', 'WMCore.WorkQueue+',
+                     'WMCore.Wrappers+', 'WMCore.Services+',
+                     'WMCore.WMSpec', 'WMCore.WMSpec.Steps', 'WMCore.WMSpec.Steps.Templates',
+                     'WMCore.ACDC', 'WMCore.GroupUser', 'WMCore.Alerts'],
+        'modules': ['WMCore.Algorithms.__init__', 'WMCore.Algorithms.Permissions',
+                    'WMCore.Algorithms.MiscAlgos', 'WMCore.Algorithms.ParseXMLFile',
+                    'WMCore.Database.__init__', 'WMCore.Database.CMSCouch',
+                    'WMCore.Database.CouchUtils',
+                    'WMCore.ReqMgr.__init__', 'WMCore.ReqMgr.DataStructs.__init__',
+                    'WMCore.ReqMgr.DataStructs.RequestStatus',
+                    'WMCore.ReqMgr.DataStructs.RequestType'],
+        'systems': ['wmc-rest', 'wmc-database'],
+        'statics': ['src/couchapps/WorkQueue+'],
+    },
+    'wmagent': {
+        'packages': ['WMCore.Agent+', 'WMCore.Algorithms+',
+                     'WMCore.JobStateMachine', 'WMComponent+',
+                     'WMCore.ThreadPool',
+                     'WMCore.BossAir+', 'WMCore.Credential',
+                     'WMCore.JobSplitting+', 'WMCore.ProcessPool',
+                     'WMCore.Services+', 'WMCore.WMSpec+',
+                     'WMCore.WMBS+', 'WMCore.ResourceControl+'],
+        'systems': ['wmc-web', 'wmc-database', 'workqueue', 'wmc-runtime'],
+        'statics': ['src/javascript/WMCore/WebTools/Agent',
+                    'src/javascript/WMCore/WebTools/WMBS',
+                    'src/javascript/external/graphael',
+                    'src/templates/WMCore/WebTools/WMBS'],
+    },
+    'asyncstageout': {
+        'packages': ['WMCore.Agent+', 'WMCore.Storage+',
+                     'WMCore.Credential', 'WMCore.WorkerThreads',
+                     'WMCore.ACDC', 'WMCore.Alerts+',
+                     'WMCore.Services+'],
+        'modules': ['WMQuality.TestInitCouchApp', 'WMCore.Services.Service',
+                    'WMCore.Services.pycurl_manager', 'WMComponent.__init__'],
+        'systems': ['wmc-database'],
+        'statics': ['src/couchapps/Agent+'],
+    },
+    'crabcache': {
+        'packages': ['WMCore.Wrappers+', 'WMCore.Services.UserFileCache+'],
+        'systems': ['wmc-rest'],
+        'modules': ['WMCore.Services.Requests', 'WMCore.Services.Service',
+                    'WMCore.Services.pycurl_manager', ],
+    },
+    'crabserver': {
+        'packages': ['WMCore.Credential', 'WMCore.Services+',
+                     'WMCore.WMSpec+', 'WMCore.ACDC'],
+        'modules': ['WMCore.DataStructs.LumiList'],
+        'systems': ['wmc-rest', 'wmc-database'],
+    },
+    'crabclient': {
+        'packages': ['WMCore.Wrappers+', 'WMCore.Credential', 'PSetTweaks', 'WMCore.Services.UserFileCache+',
+                     'WMCore.Services.SiteDB+', 'WMCore.Services.PhEDEx+', 'WMCore.Services.DBS+'],
+        'systems': ['wmc-base'],
+        'modules': ['WMCore.FwkJobReport.FileInfo', 'WMCore.Services.Requests', 'WMCore.DataStructs.LumiList',
+                    'WMCore.Services.Service', 'WMCore.Services.pycurl_manager', ],
+    },
+    'crabtaskworker': {
+        'packages': ['WMCore.WorkQueue', 'WMCore.Credential', 'WMCore.Algorithms+', 'WMCore.WMSpec+',
+                     'WMCore.JobSplitting', 'WMCore.Services.SiteDB+', 'WMCore.Services.DBS+',
+                     'WMCore.Services.UserFileCache+', 'WMCore.Services.PhEDEx+', 'WMCore.Services.Dashboard+',
+                     'Utils+'],
+        'modules': ['WMCore.WMBS.File', 'WMCore.WMBS.WMBSBase', 'WMCore.WMBS.__init__'],
+        'systems': ['wmc-database', 'wmc-runtime'],
+    },
+    'wmclient': {
+        'systems': ['wmc-runtime', 'wmc-database']
+    },
+    'reqmon': {
+        'packages': ['WMCore.WMStats+', 'WMCore.WMDataMining+',
+                     'WMCore.Services+', 'WMCore.Wrappers+',
+                     'WMCore.ReqMgr.DataStructs+'
+                     ],
+        'modules': ['WMCore.Database.__init__', 'WMCore.Database.CMSCouch',
+                    'WMCore.Database.CouchUtils', 'WMCore.ReqMgr.__init__'],
+        'systems': ['wmc-base', 'wmc-rest'],
+        'statics': ['src/couchapps/WMStats+',
+                    'src/couchapps/WMStatsErl+',
+                    'src/couchapps/WorkloadSummary+',
+                    'src/couchapps/T0Request+',
+                    'src/couchapps/LogDB+',
+                    'src/html/WMStats+'],
+    },
+    'alertscollector':
+        {
+            'statics': ['src/couchapps/AlertsCollector+'],
+        },
+    'acdcserver': {
+        'packages': ['WMCore.ACDC', 'WMCore.GroupUser', 'WMCore.DataStructs',
+                     'WMCore.Wrappers+', 'WMCore.Database'],
+        'modules': ['WMCore.Configuration',
+                    'WMCore.Algorithms.ParseXMLFile', 'WMCore.Algorithms.Permissions',
+                    'WMCore.Lexicon', 'WMCore.WMException', 'WMCore.Services.Requests',
+                    'WMCore.Services.pycurl_manager'],
+        'statics': ['src/couchapps/ACDC+',
+                    'src/couchapps/GroupUser+']
+    }
+}

--- a/src/python/WMCore/Services/HTTPS/HTTPSAuthHandler.py
+++ b/src/python/WMCore/Services/HTTPS/HTTPSAuthHandler.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 """
-Basic interface to HTTPS requests using ssl object managers, for python > 2.7.9.
+Basic interface to HTTPS requests using ssl object managers, for python >= 2.7.9.
 See usage example in:
 src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
 """
-from __future__ import print_function
+from __future__ import print_function, division
 import logging
 import urllib2
 import httplib
@@ -26,9 +26,9 @@ class HTTPSAuthHandler(urllib2.HTTPSHandler):
 
             self.logger.info("Found %d default trusted CA certificates.", len(self.ctx.get_ca_certs()))
             ### DEBUG start ###
-            for ca in self.ctx.get_ca_certs():
-                if 'CERN' in str(ca['subject']):
-                    print("  %s" % str(ca['subject']))
+            #for ca in self.ctx.get_ca_certs():
+            #    if 'CERN' in str(ca['subject']):
+            #        print("  %s" % str(ca['subject']))
             ### DEBUG end ###
             self.logger.info("SSL context manager created with the following settings:")
             self.logger.info("  check_hostname : %s", self.ctx.check_hostname)  # default to True

--- a/src/python/WMCore/Services/HTTPS/HTTPSAuthHandler.py
+++ b/src/python/WMCore/Services/HTTPS/HTTPSAuthHandler.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+"""
+Basic interface to HTTPS requests using ssl object managers, for python > 2.7.9.
+See usage example in:
+src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
+"""
+from __future__ import print_function
+import logging
+import urllib2
+import httplib
+import ssl
+
+
+class HTTPSAuthHandler(urllib2.HTTPSHandler):
+    """
+    HTTPS authentication class to provide a ssl context with the certificates.
+    """
+    def __init__(self, key=None, cert=None, capath='/etc/grid-security/certificates/', level=0):
+        self.logger = logging.getLogger(__name__)
+        if cert:
+            # then create a default ssl context manager to carry the credentials.
+            # It also loads the default CA certificates
+            self.ctx = ssl.create_default_context()
+            self.ctx.load_cert_chain(cert, keyfile=key)
+            self.ctx.load_verify_locations(None, capath)
+
+            self.logger.info("Found %d default trusted CA certificates.", len(self.ctx.get_ca_certs()))
+            ### DEBUG start ###
+            for ca in self.ctx.get_ca_certs():
+                if 'CERN' in str(ca['subject']):
+                    print("  %s" % str(ca['subject']))
+            ### DEBUG end ###
+            self.logger.info("SSL context manager created with the following settings:")
+            self.logger.info("  check_hostname : %s", self.ctx.check_hostname)  # default to True
+            self.logger.info("  options : %s", self.ctx.options)  # default to 2197947391
+            self.logger.info("  protocol : %s", self.ctx.protocol)  # default to 2 (PROTOCOL_SSLv23)
+            self.logger.info("  verify_flags : %s", self.ctx.verify_flags)  # default to 0 (VERIFY_DEFAULT)
+            self.logger.info("  verify_mode : %s", self.ctx.verify_mode)  # default to 2 (CERT_REQUIRED)
+            urllib2.HTTPSHandler.__init__(self, debuglevel=level, context=self.ctx)
+        else:
+            self.logger.info("Certificate not provided for HTTPSHandler")
+            urllib2.HTTPSHandler.__init__(self, debuglevel=level)
+
+    def get_connection(self, host, **kwargs):
+        if self.ctx:
+            return httplib.HTTPSConnection(host, context=self.ctx, **kwargs)
+        return httplib.HTTPSConnection(host)
+
+    def https_open(self, req):
+        """
+        Overwrite the default https_open.
+        """
+        self.logger.debug("%s method to %s", req.get_method(), req.get_full_url())
+        self.logger.debug("  with the following headers: %s", req.headers)
+        return self.do_open(self.get_connection, req)

--- a/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
@@ -6,28 +6,20 @@ Implementation of an Executor for a DQMUpload step
 
 """
 from __future__ import print_function
+
 import os
 import sys
-import httplib
-import urllib2
 import logging
-import traceback
-
+import urllib2
 from cStringIO import StringIO
-from mimetypes import guess_type
-from gzip import GzipFile
 from functools import reduce
-
-# Compatibility with python2.3 or earlier
-HTTPS = httplib.HTTPS
-if sys.version_info[:3] >= (2, 4, 0):
-    HTTPS = httplib.HTTPSConnection
-
+from gzip import GzipFile
 from hashlib import md5
+from mimetypes import guess_type
 
-from WMCore.WMSpec.Steps.Executor import Executor
 from WMCore.FwkJobReport.Report import Report
-
+from WMCore.Services.HTTPS.HTTPSAuthHandler import HTTPSAuthHandler
+from WMCore.WMSpec.Steps.Executor import Executor
 from WMCore.WMSpec.Steps.WMExecutionFailure import WMExecutionFailure
 
 
@@ -50,7 +42,7 @@ class DQMUpload(Executor):
         if emulator != None:
             return emulator.emulatePre(self.step)
 
-        print("Steps.Executors.DQMUpload.pre called")
+        logging.info("Steps.Executors.DQMUpload.pre called")
         return None
 
     def execute(self, emulator=None):
@@ -118,7 +110,7 @@ class DQMUpload(Executor):
         if emulator != None:
             return emulator.emulatePost(self.step)
 
-        print("Steps.Executors.DQMUpload.post called")
+        logging.info("Steps.Executors.DQMUpload.post called")
         return None
 
 
@@ -171,14 +163,13 @@ class DQMUpload(Executor):
             msg += 'Message: %s\n' % ex.hdrs.get("Dqm-Status-Message", None)
             msg += 'Detail: %s\n' % ex.hdrs.get("Dqm-Status-Detail", None)
             msg += 'Error: %s\n' % str(ex)
-            logging.error(msg)
+            logging.exception(msg)
             raise WMExecutionFailure(70318, "DQMUploadFailure", msg)
         except Exception as ex:
             msg = 'HTTP upload failed with response:\n'
             msg += 'Problem unknown.\n'
             msg += 'Error: %s\n' % str(ex)
-            msg += 'Traceback: %s\n' % traceback.format_exc()
-            logging.error(msg)
+            logging.exception(msg)
             raise WMExecutionFailure(70318, "DQMUploadFailure", msg)
 
         return
@@ -228,33 +219,32 @@ class DQMUpload(Executor):
 
         Perform a file upload to the dqm server using HTTPS auth with the
         service proxy provided
-
         """
-        uploadProxy = self.step.upload.proxy or os.environ.get('X509_USER_PROXY', None)
-
-        class HTTPSCertAuth(HTTPS):
-            def __init__(self, host, *args, **kwargs):
-                HTTPS.__init__(self, host, key_file=uploadProxy, cert_file=uploadProxy, **kwargs)
-
-        class HTTPSCertAuthenticate(urllib2.AbstractHTTPHandler):
-            def default_open(self, req):
-                return self.do_open(HTTPSCertAuth, req)
-
         ident = "WMAgent python/%d.%d.%d" % sys.version_info[:3]
+        uploadProxy = self.step.upload.proxy or os.environ.get('X509_USER_PROXY', None)
+        logging.info("Using proxy file: %s", uploadProxy)
+        logging.info("Using CA certificate path: %s", os.environ.get('X509_CERT_DIR'))
 
         msg = "HTTP POST upload arguments:\n"
         for arg in args:
             msg += "  ==> %s: %s\n" % (arg, args[arg])
         logging.info(msg)
 
+        handler = HTTPSAuthHandler(key=uploadProxy, cert=uploadProxy)
+        opener = urllib2.OpenerDirector()
+        opener.add_handler(handler)
+
+        # setup the request object
         datareq = urllib2.Request(url + '/data/put')
         datareq.add_header('Accept-encoding', 'gzip')
         datareq.add_header('User-agent', ident)
         self.marshall(args, {'file' : filename}, datareq)
+
         if 'https://' in url:
-            result = urllib2.build_opener(HTTPSCertAuthenticate()).open(datareq)
+            result = opener.open(datareq)
         else:
-            result = urllib2.build_opener(urllib2.ProxyHandler({})).open(datareq)
+            opener.add_handler(urllib2.ProxyHandler({}))
+            result = opener.open(datareq)
 
         data = result.read()
         if result.headers.get('Content-encoding', '') == 'gzip':

--- a/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
@@ -38,8 +38,8 @@ class DQMUpload(Executor):
         Pre execution checks
 
         """
-        #Are we using an emulator?
-        if emulator != None:
+        # Are we using an emulator?
+        if emulator is not None:
             return emulator.emulatePre(self.step)
 
         logging.info("Steps.Executors.DQMUpload.pre called")
@@ -50,22 +50,22 @@ class DQMUpload(Executor):
         _execute_
 
         """
-        #Are we using emulators again?
-        if emulator != None:
+        # Are we using emulators again?
+        if emulator is not None:
             return emulator.emulate(self.step, self.job)
 
         if self.step.upload.proxy:
             try:
                 self.stepSpace.getFromSandbox(self.step.upload.proxy)
             except Exception as ex:
-                #Let it go, it wasn't in the sandbox. Then it must be
-                #somewhere else
+                # Let it go, it wasn't in the sandbox. Then it must be
+                # somewhere else
                 del ex
 
         # Search through steps for analysis files
         for step in self.stepSpace.taskSpace.stepSpaces():
             if step == self.stepName:
-                #Don't try to parse your own report; it's not there yet
+                # Don't try to parse your own report; it's not there yet
                 continue
             stepLocation = os.path.join(self.stepSpace.taskSpace.location, step)
             logging.info("Beginning report processing for step %s", step)
@@ -107,12 +107,11 @@ class DQMUpload(Executor):
 
         """
         # Another emulator check
-        if emulator != None:
+        if emulator is not None:
             return emulator.emulatePost(self.step)
 
         logging.info("Steps.Executors.DQMUpload.post called")
         return None
-
 
     #
     # for the latest DQM upload code see https://github.com/rovere/dqmgui/blob/master/bin/visDQMUpload
@@ -129,9 +128,11 @@ class DQMUpload(Executor):
 
         # Preparing a checksum
         blockSize = 0x10000
+
         def upd(m, data):
             m.update(data)
             return m
+
         fd = open(filename, 'rb')
         try:
             contents = iter(lambda: fd.read(blockSize), '')
@@ -140,7 +141,7 @@ class DQMUpload(Executor):
             fd.close()
 
         args['checksum'] = 'md5:%s' % m.hexdigest()
-        #args['checksum'] = 'md5:%s' % md5.new(filename).read()).hexdigest()
+        # args['checksum'] = 'md5:%s' % md5.new(filename).read()).hexdigest()
         args['size'] = os.path.getsize(filename)
 
         msg = "HTTP Upload is about to start:\n"
@@ -238,7 +239,7 @@ class DQMUpload(Executor):
         datareq = urllib2.Request(url + '/data/put')
         datareq.add_header('Accept-encoding', 'gzip')
         datareq.add_header('User-agent', ident)
-        self.marshall(args, {'file' : filename}, datareq)
+        self.marshall(args, {'file': filename}, datareq)
 
         if 'https://' in url:
             result = opener.open(datareq)


### PR DESCRIPTION
Fixes #7821 

Some explanation can be seen in the issue itself, but in short there were breaking changes between python 2.7.6 and 2.7.13 and one has to provide a ssl context object manager instead of the certfile and the keyfile args. It has to be given to both urllib2 and httplib classes, and so it `capath` argument, which must be loaded from `/etc/grid-sercurity/certificates`.

As suggested by Valentin, I took this DBS code:
https://github.com/dmwm/DBS/blob/master/Server/Python/src/dbs/utils/dbsHTTPSAuthHandler.py
and made it a WMCore class under Services.

BTW, apparently logger writes to condor_stderr by default. We should override it to go to stdout, but that's for the future.