### PR TITLE
Temp fix to get Held jobs removed from condor - old agent

### DIFF
--- a/src/python/WMCore/BossAir/StatusPoller.py
+++ b/src/python/WMCore/BossAir/StatusPoller.py
@@ -113,6 +113,11 @@ class StatusPoller(BaseWorkerThread):
             if statusTime == 0:
                 logging.error("Not killing job %i, the status time was zero", job['id'])
                 continue
+            # FIXME: temporary fix to get held/removed jobs out of condor
+            if globalState == 'Error' and statusTime is None:
+                logging.info("Killing job %i in '%s' state because it has no status_time value", job['id'], globalState)
+                job['status'] = 'Timeout'
+                jobsToKill[globalState].append(job)
             if timeout and statusTime:
                 if time.time() - float(statusTime) > float(timeout):
                     # Timeout status is used by JobTracker to fail jobs in WMBS database


### PR DESCRIPTION
Temporary fix for 1.1.0._wmagent branch only. Not to be merged!

While draining production agents, I've been seeing several jobs in condor status 5 (Held) that are in the pool for several days. Apparently they are not getting removed because `status_time` value in `bl_runjob` is None, thus JobStatusLite never removes them.

I've seen Pending jobs lingering around as well for more than 1M secs.

Now why it's None is another story. I have an old branch where I was working on this job tracking and updates to boss air and wmbs tables. I'll have to revive and resume working on that.
