### PR TITLE
Load default assignment values in the Gui

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -1058,7 +1058,7 @@ class StdBase(object):
         arguments = {"RequestPriority": {"type": int, "attr": "priority",
                                          "validate": lambda x: (x >= 0 and x < 1e6)},
                      "RequestStatus": {"assign_optional": False, "validate": lambda x: x == 'assigned'},
-                     "Team": {"type": safeStr, "assign_optional": False,
+                     "Team": {"default": "", "type": safeStr, "assign_optional": False,
                               "validate": lambda x: len(x) > 0},
                      "AcquisitionEra": {"validate": acqname, "assign_optional": True},
                      "ProcessingString": {"validate": procstring, "assign_optional": True},


### PR DESCRIPTION
Fixes #7840
It replaces #7843 , I still want to fix the assign page as well.
If assignment values are not present in the request, then fetch the default ones from the assignment dictionary definition.
Also set Team attribute default value to `''` such that we don't see a None value in the web UI.

Valentin, besides the import, there was an issue with the prop override that was done too late. It has to be done before filtering out and handling the visible attr. 

@vkuznet please review, basic tests look good.