### PR TITLE
Define Task1/Step1 in the getWorkloadCreateArgs

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
@@ -346,6 +346,7 @@ class StepChainWorkloadFactory(StdBase):
     def getWorkloadCreateArgs():
         baseArgs = StdBase.getWorkloadCreateArgs()
         specArgs = {"RequestType": {"default": "StepChain", "optional": False},
+                    "Step1": {"default": {}, "optional": False, "type": dict},
                     # ConfigCacheID is not used in the main dict for StepChain
                     "ConfigCacheID": {"optional": True, "null": True},
                     "PrimaryDataset": {"null": True, "validate": primdataset},

--- a/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
@@ -506,6 +506,7 @@ class TaskChainWorkloadFactory(StdBase):
     def getWorkloadCreateArgs():
         baseArgs = StdBase.getWorkloadCreateArgs()
         specArgs = {"RequestType": {"default": "TaskChain", "optional": False},
+                    "Task1": {"default": {}, "optional": False, "type": dict},
                     # ConfigCacheID is not used in the main dict for TaskChain
                     "ConfigCacheID": {"optional": True, "null": True},
                     "IgnoredOutputModules": {"default": [], "type": makeList, "null": False},

--- a/src/python/WMCore/WMSpec/WMWorkloadTools.py
+++ b/src/python/WMCore/WMSpec/WMWorkloadTools.py
@@ -74,8 +74,9 @@ def _validateArgumentDict(argument, argValue, argumentDefinition):
 
     for val in argValue.values():
         try:
-            # sigh.. LumiList has a peculiar type validation
-            if argument == 'LumiList':
+            # sigh.. LumiList has a peculiar type validation.
+            # Task/Step is validated later in the schema
+            if argument in ['LumiList', 'Step1', 'Task1']:
                 val = argumentDefinition["type"](argValue)
                 break
             val = argumentDefinition["type"](val)


### PR DESCRIPTION
At least the first task/step must be always present. So we better add it to the creation args specification. Validation of those inner dicts is done a bit later in the chain.