### PR TITLE
Dictionary with all the create arguments for each request type

### DIFF
--- a/doc/createSpecs/DQMHarvest_createSpec.json
+++ b/doc/createSpecs/DQMHarvest_createSpec.json
@@ -1,0 +1,302 @@
+{
+    "AcquisitionEra": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "BlockBlacklist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "BlockWhitelist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "CMSSWVersion": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "Campaign": {
+        "default": "", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "Comments": {
+        "default": "", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ConfigCacheID": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ConfigCacheUrl": {
+        "default": "https://cmsweb.cern.ch/couchdb", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMConfigCacheID": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMHarvestUnit": {
+        "default": "byRun", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMSequences": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "DQMUploadProxy": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMUploadUrl": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "DashboardHost": {
+        "default": "cms-jobmon.cern.ch", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DashboardPort": {
+        "default": 8884, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "DbsUrl": {
+        "default": "https://cmsweb.cern.ch/dbs/prod/global/DBSReader", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DeleteFromSource": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "EnableHarvesting": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "EnableNewStageout": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "EventStreams": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "EventsPerJob": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "FilesPerJob": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "GlobalTag": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "GlobalTagConnect": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "Group": {
+        "default": "DATAOPS", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "IncludeParents": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "InputDataset": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "LumiList": {
+        "default": {}, 
+        "optional": true, 
+        "type": "<function makeLumiList at 0x7f65d9b55410>"
+    }, 
+    "LumisPerJob": {
+        "default": 8, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "MaxMergeEvents": {
+        "default": 100000000, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "MaxMergeSize": {
+        "default": 4294967296, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "MaxWaitTime": {
+        "default": 86400, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "Memory": {
+        "default": 2300.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "MergedLFNBase": {
+        "default": "/store/data", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "MinMergeSize": {
+        "default": 2147483648, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "Multicore": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "OpenRunningTimeout": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "OverrideCatalog": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "PeriodicHarvestInterval": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "PrepID": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "PrimaryDataset": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ProcessingString": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "ProcessingVersion": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "RequestPriority": {
+        "default": 8000, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "RequestString": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "RequestType": {
+        "default": "DQMHarvest", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "RobustMerge": {
+        "default": true, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "RunBlacklist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "RunNumber": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "RunWhitelist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "Scenario": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ScramArch": {
+        "default": null, 
+        "optional": false, 
+        "type": "<function makeNonEmptyList at 0x7f65da26a9b0>"
+    }, 
+    "SizePerEvent": {
+        "default": 512.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "SplittingAlgo": {
+        "default": "EventAwareLumiBased", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "SubRequestType": {
+        "default": "", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "TimePerEvent": {
+        "default": 12.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "UnmergedLFNBase": {
+        "default": "/store/unmerged", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ValidStatus": {
+        "default": "PRODUCTION", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "VoGroup": {
+        "default": "unknown", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "VoRole": {
+        "default": "unknown", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }
+}

--- a/doc/createSpecs/MonteCarloFromGEN_createSpec.json
+++ b/doc/createSpecs/MonteCarloFromGEN_createSpec.json
@@ -1,0 +1,317 @@
+{
+    "AcquisitionEra": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "BlockBlacklist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "BlockWhitelist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "CMSSWVersion": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "Campaign": {
+        "default": "", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "Comments": {
+        "default": "", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ConfigCacheID": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "ConfigCacheUrl": {
+        "default": "https://cmsweb.cern.ch/couchdb", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMConfigCacheID": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMHarvestUnit": {
+        "default": "byRun", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMSequences": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "DQMUploadProxy": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMUploadUrl": {
+        "default": "https://cmsweb.cern.ch/dqm/dev", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DashboardHost": {
+        "default": "cms-jobmon.cern.ch", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DashboardPort": {
+        "default": 8884, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "DataPileup": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DbsUrl": {
+        "default": "https://cmsweb.cern.ch/dbs/prod/global/DBSReader", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DeleteFromSource": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "DeterministicPileup": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "EnableHarvesting": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "EnableNewStageout": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "EventStreams": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "EventsPerJob": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "FilesPerJob": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "GlobalTag": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "GlobalTagConnect": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "Group": {
+        "default": "DATAOPS", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "IncludeParents": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "InputDataset": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "LumiList": {
+        "default": {}, 
+        "optional": true, 
+        "type": "<function makeLumiList at 0x7f65d9b55410>"
+    }, 
+    "LumisPerJob": {
+        "default": 8, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "MCPileup": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "MaxMergeEvents": {
+        "default": 100000000, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "MaxMergeSize": {
+        "default": 4294967296, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "MaxWaitTime": {
+        "default": 86400, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "Memory": {
+        "default": 2300.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "MergedLFNBase": {
+        "default": "/store/data", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "MinMergeSize": {
+        "default": 2147483648, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "Multicore": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "OpenRunningTimeout": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "OverrideCatalog": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "PeriodicHarvestInterval": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "PrepID": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "PrimaryDataset": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ProcessingString": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "ProcessingVersion": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "RequestPriority": {
+        "default": 8000, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "RequestString": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "RequestType": {
+        "default": "MonteCarloFromGEN", 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "RobustMerge": {
+        "default": true, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "RunBlacklist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "RunNumber": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "RunWhitelist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "Scenario": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ScramArch": {
+        "default": null, 
+        "optional": false, 
+        "type": "<function makeNonEmptyList at 0x7f65da26a9b0>"
+    }, 
+    "SizePerEvent": {
+        "default": 512.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "SplittingAlgo": {
+        "default": "EventAwareLumiBased", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "SubRequestType": {
+        "default": "", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "TimePerEvent": {
+        "default": 12.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "UnmergedLFNBase": {
+        "default": "/store/unmerged", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ValidStatus": {
+        "default": "PRODUCTION", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "VoGroup": {
+        "default": "unknown", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "VoRole": {
+        "default": "unknown", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }
+}

--- a/doc/createSpecs/MonteCarlo_createSpec.json
+++ b/doc/createSpecs/MonteCarlo_createSpec.json
@@ -1,0 +1,312 @@
+{
+    "AcquisitionEra": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "CMSSWVersion": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "Campaign": {
+        "default": "", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "Comments": {
+        "default": "", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ConfigCacheID": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "ConfigCacheUrl": {
+        "default": "https://cmsweb.cern.ch/couchdb", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMConfigCacheID": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMHarvestUnit": {
+        "default": "byRun", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMSequences": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "DQMUploadProxy": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMUploadUrl": {
+        "default": "https://cmsweb.cern.ch/dqm/dev", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DashboardHost": {
+        "default": "cms-jobmon.cern.ch", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DashboardPort": {
+        "default": 8884, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "DataPileup": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DbsUrl": {
+        "default": "https://cmsweb.cern.ch/dbs/prod/global/DBSReader", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DeleteFromSource": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "DeterministicPileup": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "EnableHarvesting": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "EnableNewStageout": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "EventStreams": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "EventsPerJob": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "EventsPerLumi": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "FilterEfficiency": {
+        "default": 1.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "FirstEvent": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "FirstLumi": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "GlobalTag": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "GlobalTagConnect": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "Group": {
+        "default": "DATAOPS", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "IncludeParents": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "LheInputFiles": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "LumiList": {
+        "default": {}, 
+        "optional": true, 
+        "type": "<function makeLumiList at 0x7f65d9b55410>"
+    }, 
+    "MCPileup": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "MaxMergeEvents": {
+        "default": 100000000, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "MaxMergeSize": {
+        "default": 4294967296, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "MaxWaitTime": {
+        "default": 86400, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "Memory": {
+        "default": 2300.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "MergedLFNBase": {
+        "default": "/store/data", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "MinMergeSize": {
+        "default": 2147483648, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "Multicore": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "OpenRunningTimeout": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "OverrideCatalog": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "PeriodicHarvestInterval": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "PrepID": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "PrimaryDataset": {
+        "default": "BlackHoleTest", 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "ProcessingString": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "ProcessingVersion": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "RequestNumEvents": {
+        "default": 1000, 
+        "optional": false, 
+        "type": "<type 'int'>"
+    }, 
+    "RequestPriority": {
+        "default": 8000, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "RequestString": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "RequestType": {
+        "default": "MonteCarlo", 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "RobustMerge": {
+        "default": true, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "RunNumber": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "ScramArch": {
+        "default": null, 
+        "optional": false, 
+        "type": "<function makeNonEmptyList at 0x7f65da26a9b0>"
+    }, 
+    "Seeding": {
+        "default": "AutomaticSeeding", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "SizePerEvent": {
+        "default": 512.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "SplittingAlgo": {
+        "default": "EventBased", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "SubRequestType": {
+        "default": "", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "TimePerEvent": {
+        "default": 12.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "UnmergedLFNBase": {
+        "default": "/store/unmerged", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ValidStatus": {
+        "default": "PRODUCTION", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "VoGroup": {
+        "default": "unknown", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "VoRole": {
+        "default": "unknown", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }
+}

--- a/doc/createSpecs/ReDigi_createSpec.json
+++ b/doc/createSpecs/ReDigi_createSpec.json
@@ -1,0 +1,382 @@
+{
+    "AcquisitionEra": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "BlockBlacklist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "BlockWhitelist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "CMSSWVersion": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "Campaign": {
+        "default": "", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "Comments": {
+        "default": "", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ConfigCacheID": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ConfigCacheUrl": {
+        "default": "https://cmsweb.cern.ch/couchdb", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMConfigCacheID": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMHarvestUnit": {
+        "default": "byRun", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMSequences": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "DQMUploadProxy": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMUploadUrl": {
+        "default": "https://cmsweb.cern.ch/dqm/dev", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DashboardHost": {
+        "default": "cms-jobmon.cern.ch", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DashboardPort": {
+        "default": 8884, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "DataPileup": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DbsUrl": {
+        "default": "https://cmsweb.cern.ch/dbs/prod/global/DBSReader", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DeleteFromSource": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "DeterministicPileup": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "EnableHarvesting": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "EnableNewStageout": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "EventStreams": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "EventsPerJob": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "FilesPerJob": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "GlobalTag": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "GlobalTagConnect": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "Group": {
+        "default": "DATAOPS", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "IncludeParents": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "InputDataset": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "KeepStepOneOutput": {
+        "default": true, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "KeepStepTwoOutput": {
+        "default": true, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "LumiList": {
+        "default": {}, 
+        "optional": true, 
+        "type": "<function makeLumiList at 0x7f65d9b55410>"
+    }, 
+    "LumisPerJob": {
+        "default": 8, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "MCPileup": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "MaxMergeEvents": {
+        "default": 100000000, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "MaxMergeSize": {
+        "default": 4294967296, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "MaxWaitTime": {
+        "default": 86400, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "Memory": {
+        "default": 2300.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "MergedLFNBase": {
+        "default": "/store/data", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "MinMergeSize": {
+        "default": 2147483648, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "Multicore": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "OpenRunningTimeout": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "OverrideCatalog": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "PeriodicHarvestInterval": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "PrepID": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "PrimaryDataset": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ProcessingString": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "ProcessingVersion": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "RequestPriority": {
+        "default": 8000, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "RequestString": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "RequestType": {
+        "default": "ReDigi", 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "RobustMerge": {
+        "default": true, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "RunBlacklist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "RunNumber": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "RunWhitelist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "Scenario": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ScramArch": {
+        "default": null, 
+        "optional": false, 
+        "type": "<function makeNonEmptyList at 0x7f65da26a9b0>"
+    }, 
+    "SizePerEvent": {
+        "default": 512.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "SplittingAlgo": {
+        "default": "EventAwareLumiBased", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "StepOneConfigCacheID": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "StepOneOutputModuleName": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "StepThreeConfigCacheID": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "StepThreeMemory": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "StepThreeSizePerEvent": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "StepThreeTimePerEvent": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "StepTwoConfigCacheID": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "StepTwoMemory": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "StepTwoOutputModuleName": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "StepTwoSizePerEvent": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "StepTwoTimePerEvent": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "SubRequestType": {
+        "default": "", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "TimePerEvent": {
+        "default": 12.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "UnmergedLFNBase": {
+        "default": "/store/unmerged", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ValidStatus": {
+        "default": "PRODUCTION", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "VoGroup": {
+        "default": "unknown", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "VoRole": {
+        "default": "unknown", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }
+}

--- a/doc/createSpecs/ReReco_createSpec.json
+++ b/doc/createSpecs/ReReco_createSpec.json
@@ -1,0 +1,357 @@
+{
+    "AcquisitionEra": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "BlockBlacklist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "BlockWhitelist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "CMSSWVersion": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "Campaign": {
+        "default": "", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "Comments": {
+        "default": "", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ConfigCacheID": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "ConfigCacheUrl": {
+        "default": "https://cmsweb.cern.ch/couchdb", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMConfigCacheID": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMHarvestUnit": {
+        "default": "byRun", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMSequences": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "DQMUploadProxy": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMUploadUrl": {
+        "default": "https://cmsweb.cern.ch/dqm/dev", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DashboardHost": {
+        "default": "cms-jobmon.cern.ch", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DashboardPort": {
+        "default": 8884, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "DbsUrl": {
+        "default": "https://cmsweb.cern.ch/dbs/prod/global/DBSReader", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DeleteFromSource": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "EnableHarvesting": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "EnableNewStageout": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "EventStreams": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "EventsPerJob": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "FilesPerJob": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "GlobalTag": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "GlobalTagConnect": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "Group": {
+        "default": "DATAOPS", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "IncludeParents": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "InputDataset": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "LumiList": {
+        "default": {}, 
+        "optional": true, 
+        "type": "<function makeLumiList at 0x7f65d9b55410>"
+    }, 
+    "LumisPerJob": {
+        "default": 8, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "MaxMergeEvents": {
+        "default": 100000000, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "MaxMergeSize": {
+        "default": 4294967296, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "MaxWaitTime": {
+        "default": 86400, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "Memory": {
+        "default": 2300.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "MergedLFNBase": {
+        "default": "/store/data", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "MinMergeSize": {
+        "default": 2147483648, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "Multicore": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "OpenRunningTimeout": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "OverrideCatalog": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "PeriodicHarvestInterval": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "PrepID": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "PrimaryDataset": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ProcessingString": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "ProcessingVersion": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "RequestPriority": {
+        "default": 8000, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "RequestString": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "RequestType": {
+        "default": "ReReco", 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "RobustMerge": {
+        "default": true, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "RunBlacklist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "RunNumber": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "RunWhitelist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "Scenario": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ScramArch": {
+        "default": null, 
+        "optional": false, 
+        "type": "<function makeNonEmptyList at 0x7f65da26a9b0>"
+    }, 
+    "SizePerEvent": {
+        "default": 512.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "Skim1ConfigCacheID": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "SkimEventsPerJob1": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "SkimFilesPerJob1": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "SkimInput1": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "SkimLumisPerJob1": {
+        "default": 8, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "SkimMemory1": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "SkimName1": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "SkimSizePerEvent1": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "SkimSplittingAlgo1": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "SkimTimePerEvent1": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "SplittingAlgo": {
+        "default": "EventAwareLumiBased", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "SubRequestType": {
+        "default": "", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "TimePerEvent": {
+        "default": 12.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "TransientOutputModules": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "UnmergedLFNBase": {
+        "default": "/store/unmerged", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ValidStatus": {
+        "default": "PRODUCTION", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "VoGroup": {
+        "default": "unknown", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "VoRole": {
+        "default": "unknown", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }
+}

--- a/doc/createSpecs/StepChain_createSpec.json
+++ b/doc/createSpecs/StepChain_createSpec.json
@@ -1,0 +1,272 @@
+{
+    "AcquisitionEra": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "CMSSWVersion": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "Campaign": {
+        "default": "", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "Comments": {
+        "default": "", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ConfigCacheID": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ConfigCacheUrl": {
+        "default": "https://cmsweb.cern.ch/couchdb", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMConfigCacheID": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMHarvestUnit": {
+        "default": "byRun", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMSequences": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "DQMUploadProxy": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMUploadUrl": {
+        "default": "https://cmsweb.cern.ch/dqm/dev", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DashboardHost": {
+        "default": "cms-jobmon.cern.ch", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DashboardPort": {
+        "default": 8884, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "DbsUrl": {
+        "default": "https://cmsweb.cern.ch/dbs/prod/global/DBSReader", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DeleteFromSource": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "EnableHarvesting": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "EnableNewStageout": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "EventStreams": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "FirstEvent": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "FirstLumi": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "GlobalTag": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "GlobalTagConnect": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "Group": {
+        "default": "DATAOPS", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "IncludeParents": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "LumiList": {
+        "default": {}, 
+        "optional": true, 
+        "type": "<function makeLumiList at 0x7f65d9b55410>"
+    }, 
+    "MaxMergeEvents": {
+        "default": 100000000, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "MaxMergeSize": {
+        "default": 4294967296, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "MaxWaitTime": {
+        "default": 86400, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "Memory": {
+        "default": 2300.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "MergedLFNBase": {
+        "default": "/store/data", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "MinMergeSize": {
+        "default": 2147483648, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "Multicore": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "OpenRunningTimeout": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "OverrideCatalog": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "PeriodicHarvestInterval": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "PrepID": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "PrimaryDataset": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ProcessingString": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "ProcessingVersion": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "RequestPriority": {
+        "default": 8000, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "RequestString": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "RequestType": {
+        "default": "StepChain", 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "RobustMerge": {
+        "default": true, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "RunNumber": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "ScramArch": {
+        "default": null, 
+        "optional": false, 
+        "type": "<function makeNonEmptyList at 0x7f65da26a9b0>"
+    }, 
+    "SizePerEvent": {
+        "default": 512.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "Step1": {
+        "default": {}, 
+        "optional": false, 
+        "type": "<type 'dict'>"
+    }, 
+    "StepChain": {
+        "default": 1, 
+        "optional": false, 
+        "type": "<type 'int'>"
+    }, 
+    "SubRequestType": {
+        "default": "", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "TimePerEvent": {
+        "default": 12.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "UnmergedLFNBase": {
+        "default": "/store/unmerged", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ValidStatus": {
+        "default": "PRODUCTION", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "VoGroup": {
+        "default": "unknown", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "VoRole": {
+        "default": "unknown", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }
+}

--- a/doc/createSpecs/StepChain_create_Step_GeneratorSpec.json
+++ b/doc/createSpecs/StepChain_create_Step_GeneratorSpec.json
@@ -1,0 +1,172 @@
+{
+    "AcquisitionEra": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "BlockBlacklist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "BlockWhitelist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "CMSSWVersion": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "Campaign": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ConfigCacheID": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "DataPileup": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "EventStreams": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "EventsPerJob": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "EventsPerLumi": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "FilesPerJob": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "FilterEfficiency": {
+        "default": 1.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "GlobalTag": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "InputDataset": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "InputFromOutputModule": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "InputStep": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "KeepOutput": {
+        "default": true, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "LheInputFiles": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "LumiList": {
+        "default": {}, 
+        "optional": true, 
+        "type": "<function makeLumiList at 0x7f65d9b55410>"
+    }, 
+    "LumisPerJob": {
+        "default": 8, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "MCPileup": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "Memory": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "Multicore": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "PrepID": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "PrimaryDataset": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ProcessingString": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ProcessingVersion": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "RequestNumEvents": {
+        "default": 1000, 
+        "optional": false, 
+        "type": "<type 'int'>"
+    }, 
+    "RunBlacklist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "RunWhitelist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "ScramArch": {
+        "default": null, 
+        "optional": true, 
+        "type": "<function makeNonEmptyList at 0x7f65da26a9b0>"
+    }, 
+    "Seeding": {
+        "default": "AutomaticSeeding", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "SplittingAlgo": {
+        "default": "EventAwareLumiBased", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "StepName": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }
+}

--- a/doc/createSpecs/StepChain_create_Step_ProcessingSpec.json
+++ b/doc/createSpecs/StepChain_create_Step_ProcessingSpec.json
@@ -1,0 +1,172 @@
+{
+    "AcquisitionEra": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "BlockBlacklist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "BlockWhitelist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "CMSSWVersion": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "Campaign": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ConfigCacheID": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "DataPileup": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "EventStreams": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "EventsPerJob": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "EventsPerLumi": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "FilesPerJob": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "FilterEfficiency": {
+        "default": 1.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "GlobalTag": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "InputDataset": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "InputFromOutputModule": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "InputStep": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "KeepOutput": {
+        "default": true, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "LheInputFiles": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "LumiList": {
+        "default": {}, 
+        "optional": true, 
+        "type": "<function makeLumiList at 0x7f65d9b55410>"
+    }, 
+    "LumisPerJob": {
+        "default": 8, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "MCPileup": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "Memory": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "Multicore": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "PrepID": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "PrimaryDataset": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ProcessingString": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ProcessingVersion": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "RequestNumEvents": {
+        "default": 1000, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "RunBlacklist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "RunWhitelist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "ScramArch": {
+        "default": null, 
+        "optional": true, 
+        "type": "<function makeNonEmptyList at 0x7f65da26a9b0>"
+    }, 
+    "Seeding": {
+        "default": "AutomaticSeeding", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "SplittingAlgo": {
+        "default": "EventAwareLumiBased", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "StepName": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }
+}

--- a/doc/createSpecs/StoreResults_createSpec.json
+++ b/doc/createSpecs/StoreResults_createSpec.json
@@ -1,0 +1,282 @@
+{
+    "AcquisitionEra": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "BlockBlacklist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "BlockWhitelist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "CMSSWVersion": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "Campaign": {
+        "default": "", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "CmsPath": {
+        "default": "/tmp", 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "Comments": {
+        "default": "", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ConfigCacheID": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "ConfigCacheUrl": {
+        "default": "https://cmsweb.cern.ch/couchdb", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMConfigCacheID": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMHarvestUnit": {
+        "default": "byRun", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMSequences": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "DQMUploadProxy": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMUploadUrl": {
+        "default": "https://cmsweb.cern.ch/dqm/dev", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DashboardHost": {
+        "default": "cms-jobmon.cern.ch", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DashboardPort": {
+        "default": 8884, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "DataTier": {
+        "default": "USER", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DbsUrl": {
+        "default": "https://cmsweb.cern.ch/dbs/prod/global/DBSReader", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DeleteFromSource": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "EnableHarvesting": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "EnableNewStageout": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "EventStreams": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "GlobalTag": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "GlobalTagConnect": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "Group": {
+        "default": "DATAOPS", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "IncludeParents": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "InputDataset": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "LumiList": {
+        "default": {}, 
+        "optional": true, 
+        "type": "<function makeLumiList at 0x7f65d9b55410>"
+    }, 
+    "MaxMergeEvents": {
+        "default": 100000000, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "MaxMergeSize": {
+        "default": 4294967296, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "MaxWaitTime": {
+        "default": 86400, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "Memory": {
+        "default": 2300.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "MergedLFNBase": {
+        "default": "/store/results", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "MinMergeSize": {
+        "default": 2147483648, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "Multicore": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "OpenRunningTimeout": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "OverrideCatalog": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "PeriodicHarvestInterval": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "PrepID": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ProcessingString": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "ProcessingVersion": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "RequestPriority": {
+        "default": 8000, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "RequestString": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "RequestType": {
+        "default": "StoreResults", 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "RobustMerge": {
+        "default": true, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "RunBlacklist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "RunNumber": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "RunWhitelist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "ScramArch": {
+        "default": null, 
+        "optional": false, 
+        "type": "<function makeNonEmptyList at 0x7f65da26a9b0>"
+    }, 
+    "SizePerEvent": {
+        "default": 512.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "SubRequestType": {
+        "default": "", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "TimePerEvent": {
+        "default": 12.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "UnmergedLFNBase": {
+        "default": "/store/unmerged", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ValidStatus": {
+        "default": "PRODUCTION", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "VoGroup": {
+        "default": "unknown", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "VoRole": {
+        "default": "unknown", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }
+}

--- a/doc/createSpecs/TaskChain_createSpec.json
+++ b/doc/createSpecs/TaskChain_createSpec.json
@@ -1,0 +1,272 @@
+{
+    "AcquisitionEra": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "CMSSWVersion": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "Campaign": {
+        "default": "", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "Comments": {
+        "default": "", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ConfigCacheID": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ConfigCacheUrl": {
+        "default": "https://cmsweb.cern.ch/couchdb", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMConfigCacheID": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMHarvestUnit": {
+        "default": "byRun", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMSequences": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "DQMUploadProxy": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DQMUploadUrl": {
+        "default": "https://cmsweb.cern.ch/dqm/dev", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DashboardHost": {
+        "default": "cms-jobmon.cern.ch", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DashboardPort": {
+        "default": 8884, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "DbsUrl": {
+        "default": "https://cmsweb.cern.ch/dbs/prod/global/DBSReader", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DeleteFromSource": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "EnableHarvesting": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "EnableNewStageout": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "EventStreams": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "FirstEvent": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "FirstLumi": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "GlobalTag": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "GlobalTagConnect": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "Group": {
+        "default": "DATAOPS", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "IgnoredOutputModules": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "IncludeParents": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "LumiList": {
+        "default": {}, 
+        "optional": true, 
+        "type": "<function makeLumiList at 0x7f65d9b55410>"
+    }, 
+    "MaxMergeEvents": {
+        "default": 100000000, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "MaxMergeSize": {
+        "default": 4294967296, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "MaxWaitTime": {
+        "default": 86400, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "Memory": {
+        "default": 2300.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "MergedLFNBase": {
+        "default": "/store/data", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "MinMergeSize": {
+        "default": 2147483648, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "Multicore": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "OpenRunningTimeout": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "OverrideCatalog": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "PeriodicHarvestInterval": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "PrepID": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ProcessingString": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "ProcessingVersion": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "RequestPriority": {
+        "default": 8000, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "RequestString": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "RequestType": {
+        "default": "TaskChain", 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "RobustMerge": {
+        "default": true, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "RunNumber": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "ScramArch": {
+        "default": null, 
+        "optional": false, 
+        "type": "<function makeNonEmptyList at 0x7f65da26a9b0>"
+    }, 
+    "SizePerEvent": {
+        "default": 512.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "SubRequestType": {
+        "default": "", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "Task1": {
+        "default": {}, 
+        "optional": false, 
+        "type": "<type 'dict'>"
+    }, 
+    "TaskChain": {
+        "default": 1, 
+        "optional": false, 
+        "type": "<type 'int'>"
+    }, 
+    "TimePerEvent": {
+        "default": 12.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "UnmergedLFNBase": {
+        "default": "/store/unmerged", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ValidStatus": {
+        "default": "PRODUCTION", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "VoGroup": {
+        "default": "unknown", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "VoRole": {
+        "default": "unknown", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }
+}

--- a/doc/createSpecs/TaskChain_create_Task_GeneratorSpec.json
+++ b/doc/createSpecs/TaskChain_create_Task_GeneratorSpec.json
@@ -1,0 +1,192 @@
+{
+    "AcquisitionEra": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "BlockBlacklist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "BlockWhitelist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "CMSSWVersion": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "Campaign": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ConfigCacheID": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "DataPileup": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DeterministicPileup": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "EventStreams": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "EventsPerJob": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "EventsPerLumi": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "FilesPerJob": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "FilterEfficiency": {
+        "default": 1.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "GlobalTag": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "InputDataset": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "InputFromOutputModule": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "InputTask": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "KeepOutput": {
+        "default": true, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "LheInputFiles": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "LumiList": {
+        "default": {}, 
+        "optional": true, 
+        "type": "<function makeLumiList at 0x7f65d9b55410>"
+    }, 
+    "LumisPerJob": {
+        "default": 8, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "MCPileup": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "Memory": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "Multicore": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "PrepID": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "PrimaryDataset": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "ProcessingString": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ProcessingVersion": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "RequestNumEvents": {
+        "default": 1000, 
+        "optional": false, 
+        "type": "<type 'int'>"
+    }, 
+    "RunBlacklist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "RunWhitelist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "ScramArch": {
+        "default": null, 
+        "optional": true, 
+        "type": "<function makeNonEmptyList at 0x7f65da26a9b0>"
+    }, 
+    "Seeding": {
+        "default": "AutomaticSeeding", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "SizePerEvent": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "SplittingAlgo": {
+        "default": "EventAwareLumiBased", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "TaskName": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "TimePerEvent": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "TransientOutputModules": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }
+}

--- a/doc/createSpecs/TaskChain_create_Task_ProcessingSpec.json
+++ b/doc/createSpecs/TaskChain_create_Task_ProcessingSpec.json
@@ -1,0 +1,192 @@
+{
+    "AcquisitionEra": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "BlockBlacklist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "BlockWhitelist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "CMSSWVersion": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "Campaign": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ConfigCacheID": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "DataPileup": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "DeterministicPileup": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "EventStreams": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "EventsPerJob": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "EventsPerLumi": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "FilesPerJob": {
+        "default": 1, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "FilterEfficiency": {
+        "default": 1.0, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "GlobalTag": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "InputDataset": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "InputFromOutputModule": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "InputTask": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "KeepOutput": {
+        "default": true, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "LheInputFiles": {
+        "default": false, 
+        "optional": true, 
+        "type": "<function strToBool at 0x7f65da26aa28>"
+    }, 
+    "LumiList": {
+        "default": {}, 
+        "optional": true, 
+        "type": "<function makeLumiList at 0x7f65d9b55410>"
+    }, 
+    "LumisPerJob": {
+        "default": 8, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "MCPileup": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "Memory": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "Multicore": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "PrepID": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "PrimaryDataset": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ProcessingString": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "ProcessingVersion": {
+        "default": 0, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "RequestNumEvents": {
+        "default": 1000, 
+        "optional": true, 
+        "type": "<type 'int'>"
+    }, 
+    "RunBlacklist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "RunWhitelist": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }, 
+    "ScramArch": {
+        "default": null, 
+        "optional": true, 
+        "type": "<function makeNonEmptyList at 0x7f65da26a9b0>"
+    }, 
+    "Seeding": {
+        "default": "AutomaticSeeding", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "SizePerEvent": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "SplittingAlgo": {
+        "default": "EventAwareLumiBased", 
+        "optional": true, 
+        "type": "<type 'str'>"
+    }, 
+    "TaskName": {
+        "default": null, 
+        "optional": false, 
+        "type": "<type 'str'>"
+    }, 
+    "TimePerEvent": {
+        "default": null, 
+        "optional": true, 
+        "type": "<type 'float'>"
+    }, 
+    "TransientOutputModules": {
+        "default": [], 
+        "optional": true, 
+        "type": "<function makeList at 0x7f65da26a938>"
+    }
+}


### PR DESCRIPTION
Json file containing all the request arguments supported by each request type (including a few important fields of their definition).
There is also a json for StepChain and TaskChain inner chain (for both generator and non-generator case).
ReReco Skim stuff is a bit complicated too :(

I built these json with this script:
https://github.com/amaltaro/ProductionTools/blob/master/makeRequestSpecs.py

@ericvaandering @ticoann I'm not sure whether there is a better location for these files. Let me know if that's the case.