### PR TITLE
Inherit only valid arguments for Resubmission and validate them in th…

### DIFF
--- a/src/python/WMCore/ReqMgr/DataStructs/Request.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/Request.py
@@ -64,24 +64,6 @@ def initialize_request_args(request, config):
     generateRequestName(request)
 
 
-def initialize_resubmission(request_args, reqmgr_db_service):
-    """
-    Initialize a Resubmission request by inheriting the original/parent information
-    from couch, unless the user has overwritten that argument in the resubmission request.
-    Any arguments that are not expected either at creation or assignment level, will get
-    removed.
-    """
-    requests = reqmgr_db_service.getRequestByNames(request_args["OriginalRequestName"])
-    parent_args = requests.values()[0]
-    parent_args = {k: v for k, v in parent_args.iteritems() if k not in ARGS_TO_REMOVE_FROM_ORIGINAL_REQUEST}
-
-    for arg in parent_args:
-        if arg not in request_args:
-            request_args[arg] = parent_args[arg]
-    # to be used later on for spec validation
-    request_args["OriginalRequestType"] = parent_args["RequestType"]
-
-
 def _replace_cloned_args(clone_args, user_args):
     """
     replace original arguments with user argument.

--- a/src/python/WMCore/ReqMgr/DataStructs/Request.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/Request.py
@@ -16,9 +16,12 @@ TODO/NOTE:
 
 """
 from __future__ import print_function, division
-import time
+
 import re
+import time
+
 import cherrypy
+
 from WMCore.ReqMgr.DataStructs.RequestStatus import REQUEST_START_STATE, ACTIVE_STATUS_FILTER
 
 # TODO: I wish we can, one day, remove this stuff and have a decent resubmission handling... :)

--- a/src/python/WMCore/ReqMgr/Utils/Validation.py
+++ b/src/python/WMCore/ReqMgr/Utils/Validation.py
@@ -3,21 +3,22 @@ ReqMgr request handling.
 
 """
 from __future__ import print_function
-import json
-import time
-import logging
 
-from WMCore.WMSpec.WMWorkload import WMWorkloadHelper
-from WMCore.WMSpec.WMWorkloadTools import loadSpecClassByType, setArgumentsWithDefault
+import json
+import logging
+import time
+
+from WMCore.Lexicon import procdataset
 from WMCore.REST.Auth import authz_match
-from WMCore.WMFactory import WMFactory
-from WMCore.Services.DBS.DBS3Reader import DBS3Reader as DBSReader
 from WMCore.ReqMgr.Auth import getWritePermission
 from WMCore.ReqMgr.DataStructs.Request import initialize_request_args, initialize_clone
-from WMCore.ReqMgr.DataStructs.RequestStatus import check_allowed_transition, STATES_ALLOW_ONLY_STATE_TRANSITION
 from WMCore.ReqMgr.DataStructs.RequestError import InvalidStateTransition, InvalidSpecParameterValue
+from WMCore.ReqMgr.DataStructs.RequestStatus import check_allowed_transition, STATES_ALLOW_ONLY_STATE_TRANSITION
 from WMCore.ReqMgr.Tools.cms import releases, architectures, dashboardActivities
-from WMCore.Lexicon import procdataset
+from WMCore.Services.DBS.DBS3Reader import DBS3Reader as DBSReader
+from WMCore.WMFactory import WMFactory
+from WMCore.WMSpec.WMWorkload import WMWorkloadHelper
+from WMCore.WMSpec.WMWorkloadTools import loadSpecClassByType, setArgumentsWithDefault
 
 
 def loadRequestSchema(workload, requestSchema):
@@ -138,7 +139,7 @@ def validate_request_create_args(request_args, config, reqmgr_db_service, *args,
         setArgumentsWithDefault(request_args, specClass.getWorkloadCreateArgs())
         spec = specClass()
         workload = spec.factoryWorkloadConstruction(request_args["RequestName"],
-                                                request_args)
+                                                    request_args)
 
     return workload, request_args
 

--- a/src/python/WMCore/ReqMgr/Utils/Validation.py
+++ b/src/python/WMCore/ReqMgr/Utils/Validation.py
@@ -13,7 +13,7 @@ from WMCore.REST.Auth import authz_match
 from WMCore.WMFactory import WMFactory
 from WMCore.Services.DBS.DBS3Reader import DBS3Reader as DBSReader
 from WMCore.ReqMgr.Auth import getWritePermission
-from WMCore.ReqMgr.DataStructs.Request import initialize_request_args, initialize_resubmission, initialize_clone
+from WMCore.ReqMgr.DataStructs.Request import initialize_request_args, initialize_clone
 from WMCore.ReqMgr.DataStructs.RequestStatus import check_allowed_transition, STATES_ALLOW_ONLY_STATE_TRANSITION
 from WMCore.ReqMgr.DataStructs.RequestError import InvalidStateTransition, InvalidSpecParameterValue
 from WMCore.ReqMgr.Tools.cms import releases, architectures, dashboardActivities
@@ -122,25 +122,22 @@ def validate_request_create_args(request_args, config, reqmgr_db_service, *args,
     3. convert data from body to arguments (spec instance, argument with default setting)
     TODO: raise right kind of error with clear message
     """
-
-    initialize_request_args(request_args, config)
-    # check the permission for creating the request
-    permission = getWritePermission(request_args)
-    authz_match(permission['role'], permission['group'])
-
-    # load the correct class to in order to validate the arguments
-    specClass = loadSpecClassByType(request_args["RequestType"])
-
     if request_args["RequestType"] == "Resubmission":
         # do not set default values for Resubmission since it will be inherited from parent
         # both create & assign args are accepted for Resubmission creation
-        initialize_resubmission(request_args, reqmgr_db_service)
+        workload, request_args = validate_clone_create_args(request_args, config, reqmgr_db_service)
     else:
+        initialize_request_args(request_args, config)
+        # check the permission for creating the request
+        permission = getWritePermission(request_args)
+        authz_match(permission['role'], permission['group'])
+
+        # load the correct class in order to validate the arguments
+        specClass = loadSpecClassByType(request_args["RequestType"])
         # set default values for the request_args
         setArgumentsWithDefault(request_args, specClass.getWorkloadCreateArgs())
-
-    spec = specClass()
-    workload = spec.factoryWorkloadConstruction(request_args["RequestName"],
+        spec = specClass()
+        workload = spec.factoryWorkloadConstruction(request_args["RequestName"],
                                                 request_args)
 
     return workload, request_args
@@ -150,25 +147,41 @@ def validate_clone_create_args(request_args, config, reqmgr_db_service, *args, *
     """
     Load the spec arguments definition (and chain definition, if needed) and inherit
     all arguments defined in the specs.
+    Special handle if a Resubmission request is being cloned or resubmitted, since we
+    cannot validate such request because we don't know its real origin
     *arg and **kwargs are only for the interface
     """
     response = reqmgr_db_service.getRequestByNames(request_args.pop("OriginalRequestName"))
     originalArgs = response.values()[0]
 
-    # load arguments definition from the proper spec factory
-    specClass = loadSpecClassByType(originalArgs["RequestType"])
-    if originalArgs["RequestType"] in ('StepChain', 'TaskChain'):
-        chainArgs = specClass.getChainCreateArgs()
+    chainArgs = None
+    createArgs = {}
+    # load arguments definition from the proper/original spec factory
+    parentClass = loadSpecClassByType(originalArgs["RequestType"])
+    if originalArgs["RequestType"] == 'Resubmission':
+        # then we are cloning/resubmitting an ACDC. We cannot validate it,
+        # simply copy the whole original dictionary over and we accept all args
+        request_args['OriginalRequestType'] = originalArgs["RequestType"]
+        createArgs = originalArgs
     else:
-        chainArgs = None
+        # are we cloning or resubmitting another request type?
+        if request_args.get('RequestType') == 'Resubmission':
+            request_args['OriginalRequestType'] = originalArgs["RequestType"]
+            # then load assignment arguments as well
+            createArgs = parentClass.getWorkloadAssignArgs()
+        if originalArgs["RequestType"] in ('StepChain', 'TaskChain'):
+            chainArgs = parentClass.getChainCreateArgs()
+        createArgs.update(parentClass.getWorkloadCreateArgs())
+
     cloned_args = initialize_clone(request_args, originalArgs,
-                                   specClass.getWorkloadCreateArgs(), chainArgs)
+                                   createArgs, chainArgs)
 
     initialize_request_args(cloned_args, config)
 
     permission = getWritePermission(cloned_args)
     authz_match(permission['role'], permission['group'])
 
+    specClass = loadSpecClassByType(request_args["RequestType"])
     spec = specClass()
     workload = spec.factoryWorkloadConstruction(cloned_args["RequestName"], cloned_args)
 

--- a/src/python/WMCore/WMSpec/StdSpecs/Resubmission.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Resubmission.py
@@ -58,21 +58,21 @@ class ResubmissionWorkloadFactory(StdBase):
 
     @staticmethod
     def getWorkloadCreateArgs():
-        specArgs = {"RequestType" : {"default" : "Resubmission"},
+        specArgs = {"RequestType": {"default": "Resubmission"},
                     "OriginalRequestType": {"null": False},
                     "OriginalRequestName": {"null": False},
-                    "InitialTaskPath" : {"default" : "/SomeRequest/Task1", "optional": False,
-                                         "validate": lambda x: len(x.split('/')) > 2},
-                    "ACDCServer" : {"default" : "https://cmsweb.cern.ch/couchdb", "validate" : couchurl,
-                                    "attr" : "acdcServer"},
-                    "ACDCDatabase" : {"default" : "acdcserver", "validate" : identifier,
-                                      "attr" : "acdcDatabase"},
-                    "CollectionName": {"default" : None, "null" : True},
+                    "InitialTaskPath": {"default": "/SomeRequest/Task1", "optional": False,
+                                        "validate": lambda x: len(x.split('/')) > 2},
+                    "ACDCServer": {"default": "https://cmsweb.cern.ch/couchdb", "validate": couchurl,
+                                   "attr": "acdcServer"},
+                    "ACDCDatabase": {"default": "acdcserver", "validate": identifier,
+                                     "attr": "acdcDatabase"},
+                    "CollectionName": {"default": None, "null": True},
                     "IgnoredOutputModules": {"default": [], "type": makeList},
                     "SiteWhitelist": {"default": [], "type": makeList,
                                       "validate": lambda x: all([cmsname(y) for y in x])},
                     # it can be Chained or MC requests, so lets make it optional
-                    "InputDataset" : {"optional": True, "validate" : dataset, "null" : True}}
+                    "InputDataset": {"optional": True, "validate": dataset, "null": True}}
 
         StdBase.setDefaultArgumentsProperty(specArgs)
         return specArgs

--- a/src/python/WMCore/WMSpec/StdSpecs/Resubmission.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Resubmission.py
@@ -82,17 +82,15 @@ class ResubmissionWorkloadFactory(StdBase):
         Since we skip the master validation for Resubmission specs, we better have
         some specific validation
         """
-        argumentDefinition = {}
-        if 'OriginalRequestType' in schema:
-            parentSpecClass = loadSpecClassByType(schema['OriginalRequestType'])
-            argumentDefinition = parentSpecClass.getWorkloadCreateArgs()
+        if schema.get('OriginalRequestType') == 'Resubmission':
+            # we cannot validate such schema
+            return
 
+        # load assignment + creation + resubmission creation args definition
+        argumentDefinition = self.getWorkloadAssignArgs()
+        parentSpecClass = loadSpecClassByType(schema['OriginalRequestType'])
+        argumentDefinition.update(parentSpecClass.getWorkloadCreateArgs())
         argumentDefinition.update(self.getWorkloadCreateArgs())
-        # RequestStatus has different validate function, at this point we must use
-        # the creation one. Thus just save it to update the final arg definition
-        createStatus = {'RequestStatus': dict(argumentDefinition['RequestStatus'])}
-        argumentDefinition.update(self.getWorkloadAssignArgs())
-        argumentDefinition.update(createStatus)
 
         try:
             validateArgumentsCreate(schema, argumentDefinition)

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -840,11 +840,8 @@ class StdBase(object):
 
         Named this way so that nobody else will try to use this name.
         """
-        if arguments.get("RequestType") == "Resubmission":
-            # We're skipping the Resubmission validation for now
-            # clone is already validated, the user args only, so skip it too
-            # self.validateSchema(schema=arguments)
-            pass
+        if arguments.get('RequestType') == 'Resubmission':
+            self.validateSchema(schema=arguments)
         else:
             self.masterValidation(schema=arguments)
             self.validateSchema(schema=arguments)

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -471,7 +471,8 @@ class StdBase(object):
             taskName = taskConf["StepName"]
         acqEra = taskConf.get('AcquisitionEra') or self._getDictionaryParams(self.acquisitionEra, taskName)
         procString = taskConf.get('ProcessingString') or self._getDictionaryParams(self.processingString, taskName)
-        procVersion = taskConf.get('ProcessingVersion') or self._getDictionaryParams(self.processingVersion, taskName,1)
+        procVersion = taskConf.get('ProcessingVersion') or self._getDictionaryParams(self.processingVersion,
+                                                                                     taskName, 1)
 
         processedDataset = "%s-" % acqEra
         if haveFilterName:


### PR DESCRIPTION
Fixes #7842 

Changes are:
* copy only supported args from the original request (including task/step dicts)
* validate all the arguments at Resubmission class level only (validateSchema)
* don't validate anything if ACDCing (and cloning) a Resubmission workflow, simply copy it over.