### PR TITLE
add option to disable xrdcp write recovery

### DIFF
--- a/src/python/WMCore/Storage/Backends/XRDCPImpl.py
+++ b/src/python/WMCore/Storage/Backends/XRDCPImpl.py
@@ -62,6 +62,7 @@ class XRDCPImpl(StageOutImpl):
         parser = argparse.ArgumentParser()
         parser.add_argument('--cerncastor', action='store_true')
         parser.add_argument('--old', action='store_true')
+        parser.add_argument('--disablewriterecovery', action='store_true')
         args, unknown = parser.parse_known_args(options.split())
 
         copyCommandOptions = ' '.join(unknown)
@@ -110,6 +111,9 @@ class XRDCPImpl(StageOutImpl):
                 if all(os.path.isfile(initFile) for initFile in initFiles):
                     for initFile in initFiles:
                         copyCommand += "source %s\n" % initFile
+
+        if args.disablewriterecovery and not args.cerncastor:
+            copyCommand += "env XRD_WRITERECOVERY=0 "
 
         copyCommand += "%s --force --nopbar " % xrdcpExec
 

--- a/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
@@ -79,7 +79,7 @@ class LogCollect(Executor):
         # hardcode CERN EOS T2_CH_CERN stageout parameters
         eosStageOutParams = {}
         eosStageOutParams['command'] = overrides.get('command', "xrdcp")
-        eosStageOutParams['option'] = overrides.get('option', "")
+        eosStageOutParams['option'] = overrides.get('option', "--disablewriterecovery")
         eosStageOutParams['phedex-node'] = overrides.get('phedex-node', "T2_CH_CERN")
         eosStageOutParams['lfn-prefix'] = overrides.get('lfn-prefix', "root://eoscms.cern.ch//eos/cms")
 


### PR DESCRIPTION
Seems EOS has a write recovery feature that does really bad things sometimes (xrdcp exit code 0 only to delete the file later). Add an option to disable this, turn on that option for LogCollect stageout to EOS (but not Castor). For normal stageout this then needs to be activated in the SITECONF.

There is ongoing discussion on this, so I expect some revisions will be needed, just wanted to get it out here for others to see and comment on.