### PR TITLE
No longer fetch/feed Resubmission args in WMStats to ReqMgr

### DIFF
--- a/src/couchapps/WMStats/_attachments/js/ViewModels/WMStats.ViewModel.js
+++ b/src/couchapps/WMStats/_attachments/js/ViewModels/WMStats.ViewModel.js
@@ -411,6 +411,7 @@ WMStats.ViewModel = (function (){
         resubmission.formatResubmissionData = function(reqMgrRequest) {
             var summary = {};
             // from resubmission keys
+            summary.RequestType = "Resubmission";
             summary.OriginalRequestName = resubmission.keys().requestName;
             summary.InitialTaskPath = resubmission.keys().task;
             if (resubmission.keys().acdcURL) {
@@ -421,66 +422,17 @@ WMStats.ViewModel = (function (){
             }
             
             var requestInfo = reqMgrRequest.getData();
-            var getPropertyByTask = WMStats.Requests.getPropertyByTask;
-            var getDictPropertyByTask = WMStats.Requests.getDictPropertyByTask;
-            //from passing request info
-            summary.DbsUrl = requestInfo.DbsUrl || "https://cmsweb.cern.ch/dbs/prod/global/DBSReader";
-            summary.Group = requestInfo.Group;
-            summary.RequestPriority = requestInfo.RequestPriority;
+            // passed to wmstats view
             summary.RequestString = WMStats.Utils.acdcRequestSting(summary.OriginalRequestName, requestInfo.Requestor);
-            summary.Dashboard = requestInfo.Dashboard;
-            summary.MergedLFNBase = requestInfo.MergedLFNBase;
+            summary.Campaign = requestInfo.Campaign;
+            summary.RequestPriority = requestInfo.RequestPriority;
+
+            //TODO get the site white list from acdc db. (site might be overflowed)
             // assign more value for acdc assignment
             summary.Team = requestInfo.Teams[0];
-            
-            summary.SizePerEvent = getPropertyByTask(summary.InitialTaskPath, "SizePerEvent", requestInfo);
-            summary.TimePerEvent = getPropertyByTask(summary.InitialTaskPath, "TimePerEvent", requestInfo);
-            summary.CMSSWVersion = getPropertyByTask(summary.InitialTaskPath, "CMSSWVersion", requestInfo);
-            summary.Campaign = requestInfo.Campaign;
-            
-            //TODO get the site white list from acdc db. (site might be overflowed)
-            //also change templete to handle multiple selection
-            //summary.SiteWhitelist = requestInfo.SiteWhitelist.join();
-            //summary.SiteBlacklist = requestInfo.SiteBlacklist.join();
-            summary.AcquisitionEra = getDictPropertyByTask("AcquisitionEra", requestInfo);
-            summary.ProcessingString = getDictPropertyByTask("ProcessingString", requestInfo);
-            summary.ProcessingVersion = getDictPropertyByTask("ProcessingVersion", requestInfo);
-            summary.Multicore = getDictPropertyByTask("Multicore", requestInfo);
-            summary.Memory = getDictPropertyByTask("Memory", requestInfo);
-            summary.PrepID = getDictPropertyByTask("PrepID", requestInfo);
-            summary.MaxRSS = getDictPropertyByTask("MaxRSS", requestInfo);
-            summary.MaxVSize = getDictPropertyByTask("MaxVSize", requestInfo);
-            eventStream = getDictPropertyByTask("EventStreams", requestInfo);
-            if (eventStream !== undefined && eventStream !== null) {
-            	summary.EventStreams = getDictPropertyByTask("EventStreams", requestInfo);
-            };
-            
-            summary.UnmergedLFNBase = requestInfo.UnmergedLFNBase;
-            summary.MinMergeSize = requestInfo.MinMergeSize;
-            summary.MaxMergeSize = requestInfo.MaxMergeSize;
-            summary.MaxMergeEvents = requestInfo.MaxMergeEvents;
-            summary.BlockCloseMaxWaitTime = requestInfo.BlockCloseMaxWaitTime;
-            summary.BlockCloseMaxFiles = requestInfo.BlockCloseMaxFiles;
-            summary.BlockCloseMaxEvents = requestInfo.BlockCloseMaxEvents;
-            summary.BlockCloseMaxSize = requestInfo.BlockCloseMaxSize;
-            summary.SoftTimeout = requestInfo.SoftTimeout;
-            summary.GracePeriod = requestInfo.GracePeriod;
-            summary.CustodialSites = requestInfo.CustodialSites;
-            summary.CustodialSubType = requestInfo.CustodialSubType;
-            summary.NonCustodialSites = requestInfo.NonCustodialSites;
-            summary.NonCustodialSubType = requestInfo.NonCustodialSubType;
-            summary.AutoApproveSubscriptionSites = requestInfo.AutoApproveSubscriptionSites;
-            summary.SubscriptionPriority = requestInfo.SubscriptionPriority;
-            /*
-            //TODO this handles the legacy data need to be removed
-            requestInfo = WMStats.ActiveRequestModel.getData().getData(summary.OriginalRequestName);
-            summary.Group.requestInfo.group
-            */
-            
             summary.TrustPUSitelists = false;
             summary.TrustSitelists = false;
-            summary.RequestType = "Resubmission";
-            
+
             return summary;
         };
         

--- a/src/couchapps/WMStats/_attachments/js/Views/HTMLList/T1/WMStats.ResubmissionList.js
+++ b/src/couchapps/WMStats/_attachments/js/Views/HTMLList/T1/WMStats.ResubmissionList.js
@@ -6,8 +6,8 @@ WMStats.namespace('ResubmissionList');
         htmlstr = '<div class="closingButton">X</div>';
         htmlstr += "<div class='requestDetailBox'>";
         htmlstr += "<ul>";
-        htmlstr += "<li><b>Request String: :</b><input type='text' name='RequestString' size=30 value='" + summary.RequestString + "'/></li>";
-        htmlstr += "<li><b>Original Request Name: :</b>" + summary.OriginalRequestName + "</li>";
+        htmlstr += "<li><b>Request String: </b><input type='text' name='RequestString' size=70 value='" + summary.RequestString + "'/></li>";
+        htmlstr += "<li><b>Original Request Name:</b> " + summary.OriginalRequestName + "</li>";
         htmlstr += "<li><b>Campaign:</b> " + summary.Campaign + "</li>";
         htmlstr += "<li><b>Initial Task Path:</b> " + summary.InitialTaskPath + "</li>";
 
@@ -18,15 +18,7 @@ WMStats.namespace('ResubmissionList');
             htmlstr += "<li><b>ACDC Server URL:</b><input type='text' name='ACDCServer' size=30 /></li>";
             htmlstr += "<li><b>ACDC DB Name:</b><input type='text' name='ACDCDatabase' size=30  value='wmagent_acdc'/></li>";
         }
-        //htmlstr += "<li><b>Requestor:</b><input type='text' name='Requestor' size=30  value='" + summary.Requestor + "'/></li>";
-        htmlstr += "<li><b>Group:</b> " + summary.Group + "</li>";
-        htmlstr += "<li><b>PrepID:</b> " + JSON.stringify(summary.PrepID) + "</li>";
         htmlstr += "<li><b>RequestPriority:</b> " + summary.RequestPriority + "</li>";
-        htmlstr += "<li><b>DBSURL:</b> " + summary.DbsUrl + "</li>";
-        htmlstr += "<li><b>Memory:</b> " + JSON.stringify(summary.Memory) + "</li>";
-        htmlstr += "<li><b>SizePerEven:</b> " + summary.SizePerEvent + "</li>";
-        htmlstr += "<li><b>TimePerEvent:</b> " + summary.TimePerEvent + "</li>";
-        htmlstr += "<li><b>RequestType:</b> " + summary.RequestType + "</li>";
         /*
         htmlstr += "<li><b>Ignored Output Modules:</b> <input type='text' name='ACDCDatabase' size=30/>";
         htmlstr += "<li><b>Alternative Collection Name:</b><input type='text' name='CollectionName' size=40/>";

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
@@ -1891,6 +1891,7 @@ WMStats.ViewModel = (function (){
         resubmission.formatResubmissionData = function(reqMgrRequest) {
             var summary = {};
             // from resubmission keys
+            summary.RequestType = "Resubmission";
             summary.OriginalRequestName = resubmission.keys().requestName;
             summary.InitialTaskPath = resubmission.keys().task;
             if (resubmission.keys().acdcURL) {
@@ -1901,66 +1902,17 @@ WMStats.ViewModel = (function (){
             }
             
             var requestInfo = reqMgrRequest.getData();
-            var getPropertyByTask = WMStats.Requests.getPropertyByTask;
-            var getDictPropertyByTask = WMStats.Requests.getDictPropertyByTask;
-            //from passing request info
-            summary.DbsUrl = requestInfo.DbsUrl || "https://cmsweb.cern.ch/dbs/prod/global/DBSReader";
-            summary.Group = requestInfo.Group;
-            summary.RequestPriority = requestInfo.RequestPriority;
+            // passed to wmstats view
             summary.RequestString = WMStats.Utils.acdcRequestSting(summary.OriginalRequestName, requestInfo.Requestor);
-            summary.Dashboard = requestInfo.Dashboard;
-            summary.MergedLFNBase = requestInfo.MergedLFNBase;
-            // assign more value for acdc assignment
-            summary.Team = requestInfo.Teams[0];
-            
-            summary.SizePerEvent = getPropertyByTask(summary.InitialTaskPath, "SizePerEvent", requestInfo);
-            summary.TimePerEvent = getPropertyByTask(summary.InitialTaskPath, "TimePerEvent", requestInfo);
-            summary.CMSSWVersion = getPropertyByTask(summary.InitialTaskPath, "CMSSWVersion", requestInfo);
             summary.Campaign = requestInfo.Campaign;
-            
+            summary.RequestPriority = requestInfo.RequestPriority;
+
             //TODO get the site white list from acdc db. (site might be overflowed)
-            //also change templete to handle multiple selection
-            //summary.SiteWhitelist = requestInfo.SiteWhitelist.join();
-            //summary.SiteBlacklist = requestInfo.SiteBlacklist.join();
-            summary.AcquisitionEra = getDictPropertyByTask("AcquisitionEra", requestInfo);
-            summary.ProcessingString = getDictPropertyByTask("ProcessingString", requestInfo);
-            summary.ProcessingVersion = getDictPropertyByTask("ProcessingVersion", requestInfo);
-            summary.Multicore = getDictPropertyByTask("Multicore", requestInfo);
-            summary.Memory = getDictPropertyByTask("Memory", requestInfo);
-            summary.PrepID = getDictPropertyByTask("PrepID", requestInfo);
-            summary.MaxRSS = getDictPropertyByTask("MaxRSS", requestInfo);
-            summary.MaxVSize = getDictPropertyByTask("MaxVSize", requestInfo);
-            eventStream = getDictPropertyByTask("EventStreams", requestInfo);
-            if (eventStream !== undefined && eventStream !== null) {
-            	summary.EventStreams = getDictPropertyByTask("EventStreams", requestInfo);
-            };
-            
-            summary.UnmergedLFNBase = requestInfo.UnmergedLFNBase;
-            summary.MinMergeSize = requestInfo.MinMergeSize;
-            summary.MaxMergeSize = requestInfo.MaxMergeSize;
-            summary.MaxMergeEvents = requestInfo.MaxMergeEvents;
-            summary.BlockCloseMaxWaitTime = requestInfo.BlockCloseMaxWaitTime;
-            summary.BlockCloseMaxFiles = requestInfo.BlockCloseMaxFiles;
-            summary.BlockCloseMaxEvents = requestInfo.BlockCloseMaxEvents;
-            summary.BlockCloseMaxSize = requestInfo.BlockCloseMaxSize;
-            summary.SoftTimeout = requestInfo.SoftTimeout;
-            summary.GracePeriod = requestInfo.GracePeriod;
-            summary.CustodialSites = requestInfo.CustodialSites;
-            summary.CustodialSubType = requestInfo.CustodialSubType;
-            summary.NonCustodialSites = requestInfo.NonCustodialSites;
-            summary.NonCustodialSubType = requestInfo.NonCustodialSubType;
-            summary.AutoApproveSubscriptionSites = requestInfo.AutoApproveSubscriptionSites;
-            summary.SubscriptionPriority = requestInfo.SubscriptionPriority;
-            /*
-            //TODO this handles the legacy data need to be removed
-            requestInfo = WMStats.ActiveRequestModel.getData().getData(summary.OriginalRequestName);
-            summary.Group.requestInfo.group
-            */
-            
+            // assignment args
+            summary.Team = requestInfo.Teams[0];
             summary.TrustPUSitelists = false;
             summary.TrustSitelists = false;
-            summary.RequestType = "Resubmission";
-            
+
             return summary;
         };
         

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
@@ -2034,6 +2034,7 @@ WMStats.ViewModel = (function (){
         resubmission.formatResubmissionData = function(reqMgrRequest) {
             var summary = {};
             // from resubmission keys
+            summary.RequestType = "Resubmission";
             summary.OriginalRequestName = resubmission.keys().requestName;
             summary.InitialTaskPath = resubmission.keys().task;
             if (resubmission.keys().acdcURL) {
@@ -2044,66 +2045,17 @@ WMStats.ViewModel = (function (){
             }
             
             var requestInfo = reqMgrRequest.getData();
-            var getPropertyByTask = WMStats.Requests.getPropertyByTask;
-            var getDictPropertyByTask = WMStats.Requests.getDictPropertyByTask;
-            //from passing request info
-            summary.DbsUrl = requestInfo.DbsUrl || "https://cmsweb.cern.ch/dbs/prod/global/DBSReader";
-            summary.Group = requestInfo.Group;
-            summary.RequestPriority = requestInfo.RequestPriority;
+            // passed to wmstats view
             summary.RequestString = WMStats.Utils.acdcRequestSting(summary.OriginalRequestName, requestInfo.Requestor);
-            summary.Dashboard = requestInfo.Dashboard;
-            summary.MergedLFNBase = requestInfo.MergedLFNBase;
-            // assign more value for acdc assignment
-            summary.Team = requestInfo.Teams[0];
-            
-            summary.SizePerEvent = getPropertyByTask(summary.InitialTaskPath, "SizePerEvent", requestInfo);
-            summary.TimePerEvent = getPropertyByTask(summary.InitialTaskPath, "TimePerEvent", requestInfo);
-            summary.CMSSWVersion = getPropertyByTask(summary.InitialTaskPath, "CMSSWVersion", requestInfo);
             summary.Campaign = requestInfo.Campaign;
-            
+            summary.RequestPriority = requestInfo.RequestPriority;
+
             //TODO get the site white list from acdc db. (site might be overflowed)
-            //also change templete to handle multiple selection
-            //summary.SiteWhitelist = requestInfo.SiteWhitelist.join();
-            //summary.SiteBlacklist = requestInfo.SiteBlacklist.join();
-            summary.AcquisitionEra = getDictPropertyByTask("AcquisitionEra", requestInfo);
-            summary.ProcessingString = getDictPropertyByTask("ProcessingString", requestInfo);
-            summary.ProcessingVersion = getDictPropertyByTask("ProcessingVersion", requestInfo);
-            summary.Multicore = getDictPropertyByTask("Multicore", requestInfo);
-            summary.Memory = getDictPropertyByTask("Memory", requestInfo);
-            summary.PrepID = getDictPropertyByTask("PrepID", requestInfo);
-            summary.MaxRSS = getDictPropertyByTask("MaxRSS", requestInfo);
-            summary.MaxVSize = getDictPropertyByTask("MaxVSize", requestInfo);
-            eventStream = getDictPropertyByTask("EventStreams", requestInfo);
-            if (eventStream !== undefined && eventStream !== null) {
-            	summary.EventStreams = getDictPropertyByTask("EventStreams", requestInfo);
-            };
-            
-            summary.UnmergedLFNBase = requestInfo.UnmergedLFNBase;
-            summary.MinMergeSize = requestInfo.MinMergeSize;
-            summary.MaxMergeSize = requestInfo.MaxMergeSize;
-            summary.MaxMergeEvents = requestInfo.MaxMergeEvents;
-            summary.BlockCloseMaxWaitTime = requestInfo.BlockCloseMaxWaitTime;
-            summary.BlockCloseMaxFiles = requestInfo.BlockCloseMaxFiles;
-            summary.BlockCloseMaxEvents = requestInfo.BlockCloseMaxEvents;
-            summary.BlockCloseMaxSize = requestInfo.BlockCloseMaxSize;
-            summary.SoftTimeout = requestInfo.SoftTimeout;
-            summary.GracePeriod = requestInfo.GracePeriod;
-            summary.CustodialSites = requestInfo.CustodialSites;
-            summary.CustodialSubType = requestInfo.CustodialSubType;
-            summary.NonCustodialSites = requestInfo.NonCustodialSites;
-            summary.NonCustodialSubType = requestInfo.NonCustodialSubType;
-            summary.AutoApproveSubscriptionSites = requestInfo.AutoApproveSubscriptionSites;
-            summary.SubscriptionPriority = requestInfo.SubscriptionPriority;
-            /*
-            //TODO this handles the legacy data need to be removed
-            requestInfo = WMStats.ActiveRequestModel.getData().getData(summary.OriginalRequestName);
-            summary.Group.requestInfo.group
-            */
-            
+            // assignment args
+            summary.Team = requestInfo.Teams[0];
             summary.TrustPUSitelists = false;
             summary.TrustSitelists = false;
-            summary.RequestType = "Resubmission";
-            
+
             return summary;
         };
         
@@ -4420,8 +4372,8 @@ WMStats.namespace('ResubmissionList');
         htmlstr = '<div class="closingButton">X</div>';
         htmlstr += "<div class='requestDetailBox'>";
         htmlstr += "<ul>";
-        htmlstr += "<li><b>Request String: :</b><input type='text' name='RequestString' size=30 value='" + summary.RequestString + "'/></li>";
-        htmlstr += "<li><b>Original Request Name: :</b>" + summary.OriginalRequestName + "</li>";
+        htmlstr += "<li><b>Request String: </b><input type='text' name='RequestString' size=70 value='" + summary.RequestString + "'/></li>";
+        htmlstr += "<li><b>Original Request Name:</b> " + summary.OriginalRequestName + "</li>";
         htmlstr += "<li><b>Campaign:</b> " + summary.Campaign + "</li>";
         htmlstr += "<li><b>Initial Task Path:</b> " + summary.InitialTaskPath + "</li>";
 
@@ -4432,14 +4384,7 @@ WMStats.namespace('ResubmissionList');
             htmlstr += "<li><b>ACDC Server URL:</b><input type='text' name='ACDCServer' size=30 /></li>";
             htmlstr += "<li><b>ACDC DB Name:</b><input type='text' name='ACDCDatabase' size=30  value='wmagent_acdc'/></li>";
         }
-        //htmlstr += "<li><b>Requestor:</b><input type='text' name='Requestor' size=30  value='" + summary.Requestor + "'/></li>";
-        htmlstr += "<li><b>Group:</b> " + summary.Group + "</li>";
-        htmlstr += "<li><b>PrepID:</b> " + JSON.stringify(summary.PrepID) + "</li>";
         htmlstr += "<li><b>RequestPriority:</b> " + summary.RequestPriority + "</li>";
-        htmlstr += "<li><b>DBSURL:</b> " + summary.DbsUrl + "</li>";
-        htmlstr += "<li><b>Memory:</b> " + JSON.stringify(summary.Memory) + "</li>";
-        htmlstr += "<li><b>SizePerEven:</b> " + summary.SizePerEvent + "</li>";
-        htmlstr += "<li><b>TimePerEvent:</b> " + summary.TimePerEvent + "</li>";
         htmlstr += "<li><b>RequestType:</b> " + summary.RequestType + "</li>";
         /*
         htmlstr += "<li><b>Ignored Output Modules:</b> <input type='text' name='ACDCDatabase' size=30/>";


### PR DESCRIPTION
Fixes #7872 
Since Resubmission is basically a clone workflow now (we copy the original creation + assignment requests into a new "truncated" request), there is no more need to load this info in WMStats javascript, do some parsing, and posting it to reqmgr. We need only the very basics, all the rest comes from the resubmission handling on ReqMgr.

Still need to be tested. I don't know if any of those were also used for the small pop-up when creating an ACDC via wmstats.