### PR TITLE
prevent exceptions printout in TempDirectory

### DIFF
--- a/src/python/WMCore/Services/Requests.py
+++ b/src/python/WMCore/Services/Requests.py
@@ -577,5 +577,5 @@ class TempDirectory(object):
         try:
             # it'll likely fail, but give it a try
             shutil.rmtree(self.dir, ignore_errors=True)
-        except (IOError, OSError):
+        except Exception:
             pass


### PR DESCRIPTION
Restore protections. The exception caught here has nothing to do with the actual call, it happens because the system is in shutdown and there is no shutil module available anymore. Therefore do not restrict the exceptions catch, it needs to catch everything.