### PR TITLE
Set status_time when jobs get submitted in BossAir

### DIFF
--- a/src/python/WMCore/BossAir/MySQL/NewJobs.py
+++ b/src/python/WMCore/BossAir/MySQL/NewJobs.py
@@ -5,7 +5,7 @@ _NewJobs_
 MySQL implementation for creating a new job
 """
 
-
+import time
 from WMCore.Database.DBFormatter import DBFormatter
 
 class NewJobs(DBFormatter):
@@ -16,12 +16,14 @@ class NewJobs(DBFormatter):
     """
 
 
-    sql = """INSERT IGNORE INTO bl_runjob (wmbs_id, grid_id, bulk_id, sched_status, retry_count, user_id, location)
+    sql = """INSERT IGNORE INTO bl_runjob (wmbs_id, grid_id, bulk_id, sched_status,
+                 retry_count, user_id, location, status_time)
                VALUES (:jobid, :gridid, :bulkid,
                  (SELECT id FROM bl_status WHERE name = :status),
                  :retry_count,
                  (SELECT id FROM wmbs_users WHERE cert_dn = :userdn AND group_name = :usergroup AND role_name = :userrole),
-                 (SELECT id FROM wmbs_location WHERE site_name = :location)
+                 (SELECT id FROM wmbs_location WHERE site_name = :location),
+                 :status_time
           )"""
 
 
@@ -37,12 +39,13 @@ class NewJobs(DBFormatter):
         if len(jobs) == 0:
             return
 
+        statusTime = int(time.time())
         binds = []
         for job in jobs:
             binds.append({'jobid': job['jobid'], 'gridid': job.get('gridid', None), 'bulkid': job.get('bulkid', None),
                           'status': job.get('status', None), 'retry_count': job['retry_count'], 'userdn': job['userdn'],
                           'usergroup': job['usergroup'], 'userrole': job['userrole'],
-                          'location': job.get('siteName')})
+                          'location': job.get('siteName'), 'status_time': statusTime})
 
         result = self.dbi.processData(self.sql, binds, conn = conn,
                                       transaction = transaction)

--- a/src/python/WMCore/BossAir/MySQL/NewJobs.py
+++ b/src/python/WMCore/BossAir/MySQL/NewJobs.py
@@ -6,7 +6,9 @@ MySQL implementation for creating a new job
 """
 
 import time
+
 from WMCore.Database.DBFormatter import DBFormatter
+
 
 class NewJobs(DBFormatter):
     """

--- a/src/python/WMCore/BossAir/Oracle/NewJobs.py
+++ b/src/python/WMCore/BossAir/Oracle/NewJobs.py
@@ -5,8 +5,8 @@ _NewJobs_
 Oracle implementation for creating a new job
 """
 
-
 from WMCore.BossAir.MySQL.NewJobs import NewJobs as MySQLNewJobs
+
 
 class NewJobs(MySQLNewJobs):
     """
@@ -14,7 +14,6 @@ class NewJobs(MySQLNewJobs):
 
     Insert new jobs into bl_runjob
     """
-
 
     sql = """INSERT INTO bl_runjob (id, wmbs_id, grid_id, bulk_id, sched_status,
                  retry_count, user_id, location, status_time)

--- a/src/python/WMCore/BossAir/Oracle/NewJobs.py
+++ b/src/python/WMCore/BossAir/Oracle/NewJobs.py
@@ -16,12 +16,14 @@ class NewJobs(MySQLNewJobs):
     """
 
 
-    sql = """INSERT INTO bl_runjob (id, wmbs_id, grid_id, bulk_id, sched_status, retry_count, user_id, location)
+    sql = """INSERT INTO bl_runjob (id, wmbs_id, grid_id, bulk_id, sched_status,
+                 retry_count, user_id, location, status_time)
                SELECT bl_runjob_SEQ.nextval, :jobid, :gridid, :bulkid,
                  (SELECT id FROM bl_status WHERE name = :status),
                  :retry_count,
                  (SELECT id FROM wmbs_users WHERE cert_dn = :userdn AND group_name = :usergroup AND role_name = :userrole),
-                 (SELECT id FROM wmbs_location WHERE site_name = :location)
+                 (SELECT id FROM wmbs_location WHERE site_name = :location),
+                 :status_time
                FROM dual
                WHERE NOT EXISTS (SELECT id FROM bl_runjob WHERE wmbs_id = :jobid
                                    AND retry_count = :retry_count)"""


### PR DESCRIPTION
Fixes #7849 (well, the held jobs still need to be addressed).

Problem being the lack of `status_time` on newly created jobs in BossAir (which happens after calling condor submit). I still need to test to make sure that was the only reason. Weird that we've found it only now though...