### PR TITLE
Automatically remove jobs in Held status after 10min

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -461,6 +461,10 @@ class SimpleCondorPlugin(BasePlugin):
 
         ad['JobLeaseDuration'] = classad.ExprTree('isUndefined(MachineAttrMaxHibernateTime0) ? 1200 : MachineAttrMaxHibernateTime0')
 
+        ad['PeriodicRemove'] = classad.ExprTree('( JobStatus =?= 5 ) && ( time() - EnteredCurrentStatus > 10 * 60 )')
+        removeReasonExpr = 'PeriodicRemove ? "Job automatically removed for being in Held status" : ""'
+        ad['PeriodicRemoveReason'] = classad.ExprTree(removeReasonExpr)
+
         # Required for global pool accounting
         ad['AcctGroup'] = self.acctGroup
         ad['AcctGroupUser'] = self.acctGroupUser


### PR DESCRIPTION
Fixes #7881

Since it's simpler than I thought, why not to fix it right now :)
I'm not sure we actually need the remove reason, since the job was already taken care by the agent, but anyways it won't hurt.