### PR TITLE
Add option to disable xrdcp write recovery

### DIFF
--- a/src/python/WMCore/Storage/Backends/XRDCPImpl.py
+++ b/src/python/WMCore/Storage/Backends/XRDCPImpl.py
@@ -60,10 +60,13 @@ class XRDCPImpl(StageOutImpl):
             options = ''
 
         parser = argparse.ArgumentParser()
-        parser.add_argument('--cerncastor', action='store_true')
-        parser.add_argument('--old', action='store_true')
+        parser.add_argument('--wma-cerncastor', action='store_true')
+        parser.add_argument('--wma-old', action='store_true')
+        parser.add_argument('--wma-disablewriterecovery', action='store_true')
         args, unknown = parser.parse_known_args(options.split())
 
+        # strip out WMAgent specific options
+        unknown = [option for option in unknown if not option.startswith('--wma-')]
         copyCommandOptions = ' '.join(unknown)
 
         copyCommand = ""
@@ -74,13 +77,13 @@ class XRDCPImpl(StageOutImpl):
             remotePFN, localPFN = targetPFN, sourcePFN
             copyCommand += "LOCAL_SIZE=`stat -c%%s \"%s\"`\n" % localPFN
             copyCommand += "echo \"Local File Size is: $LOCAL_SIZE\"\n"
-            if args.cerncastor:
+            if args.wma_cerncastor:
                 targetPFN += "?svcClass=t0cms"
 
         useChecksum = (checksums != None and 'adler32' in checksums and not self.stageIn)
 
         xrdcpExec = "xrdcp"
-        if args.old:
+        if args.wma_old:
             xrdcpExec = "xrdcp-old"
 
         # check if xrdcp(-old) and xrdfs are in path
@@ -110,6 +113,9 @@ class XRDCPImpl(StageOutImpl):
                 if all(os.path.isfile(initFile) for initFile in initFiles):
                     for initFile in initFiles:
                         copyCommand += "source %s\n" % initFile
+
+        if args.wma_disablewriterecovery:
+            copyCommand += "env XRD_WRITERECOVERY=0 "
 
         copyCommand += "%s --force --nopbar " % xrdcpExec
 

--- a/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
@@ -72,14 +72,14 @@ class LogCollect(Executor):
         # hardcode CERN Castor T0_CH_CERN_MSS stageout parameters
         castorStageOutParams = {}
         castorStageOutParams['command'] = overrides.get('command', "xrdcp")
-        castorStageOutParams['option'] = overrides.get('option', "--cerncastor")
+        castorStageOutParams['option'] = overrides.get('option', "--wma-cerncastor")
         castorStageOutParams['phedex-node'] = overrides.get('phedex-node', "T2_CH_CERN")
         castorStageOutParams['lfn-prefix'] = overrides.get('lfn-prefix', "root://castorcms.cern.ch//castor/cern.ch/cms")
 
         # hardcode CERN EOS T2_CH_CERN stageout parameters
         eosStageOutParams = {}
         eosStageOutParams['command'] = overrides.get('command', "xrdcp")
-        eosStageOutParams['option'] = overrides.get('option', "")
+        eosStageOutParams['option'] = overrides.get('option', "--wma-disablewriterecovery")
         eosStageOutParams['phedex-node'] = overrides.get('phedex-node', "T2_CH_CERN")
         eosStageOutParams['lfn-prefix'] = overrides.get('lfn-prefix', "root://eoscms.cern.ch//eos/cms")
 

--- a/test/python/WMCore_t/Storage_t/Backends_t/XRDCPImpl_t.py
+++ b/test/python/WMCore_t/Storage_t/Backends_t/XRDCPImpl_t.py
@@ -36,26 +36,26 @@ class XRDCPImplTest(unittest.TestCase):
     def testCreateStageOutCommand_optionsNoStageInNoChecksum(self, mock_splitPFN):
         mock_splitPFN.return_value = (None, "host", "path", None)
         self.XRDCPImpl.stageIn = False
-        results = self.XRDCPImpl.createStageOutCommand("sourcePFN", "targetPFN", options="--cerncastor")
+        results = self.XRDCPImpl.createStageOutCommand("sourcePFN", "targetPFN", options="--wma-cerncastor")
         expectedResults = self.createStageOutCommandResults(False, "sourcePFN", "targetPFN", "sourcePFN",
-                                                            "--cerncastor", False, False, "host", "path")
+                                                            "--wma-cerncastor", False, False, "host", "path")
         self.assertEqual(expectedResults, results)
 
     @mock.patch('WMCore.Storage.Backends.XRDCPImpl.XRDCPImpl.splitPFN')
     def testCreateStageOutCommand_optionsUnknowsNoStageInNoChecksum(self, mock_splitPFN):
         mock_splitPFN.return_value = (None, "host", "path", None)
         self.XRDCPImpl.stageIn = False
-        results = self.XRDCPImpl.createStageOutCommand("sourcePFN", "targetPFN", options="--cerncastor --test")
+        results = self.XRDCPImpl.createStageOutCommand("sourcePFN", "targetPFN", options="--wma-cerncastor --test")
         expectedResults = self.createStageOutCommandResults(False, "sourcePFN", "targetPFN", "sourcePFN",
-                                                            "--cerncastor", "--test", False, "host", "path")
+                                                            "--wma-cerncastor", "--test", False, "host", "path")
         self.assertEqual(expectedResults, results)
 
     @mock.patch('WMCore.Storage.Backends.XRDCPImpl.XRDCPImpl.splitPFN')
     def testCreateStageOutCommand_optionsUnknowsStageInNoChecksum(self, mock_splitPFN):
         mock_splitPFN.return_value = (None, "host", "path", None)
         self.XRDCPImpl.stageIn = True
-        results = self.XRDCPImpl.createStageOutCommand("sourcePFN", "targetPFN", options="--cerncastor --test")
-        expectedResults = self.createStageOutCommandResults(True, "sourcePFN", "targetPFN", "targetPFN", "--cerncastor",
+        results = self.XRDCPImpl.createStageOutCommand("sourcePFN", "targetPFN", options="--wma-cerncastor --test")
+        expectedResults = self.createStageOutCommandResults(True, "sourcePFN", "targetPFN", "targetPFN", "--wma-cerncastor",
                                                             "--test", False, "host", "path")
         self.assertEqual(expectedResults, results)
 
@@ -63,9 +63,9 @@ class XRDCPImplTest(unittest.TestCase):
     def testCreateStageOutCommand_optionsUnknowsStageInChecksum(self, mock_splitPFN):
         mock_splitPFN.return_value = (None, "host", "path", None)
         self.XRDCPImpl.stageIn = True
-        results = self.XRDCPImpl.createStageOutCommand("sourcePFN", "targetPFN", options="--cerncastor --test",
+        results = self.XRDCPImpl.createStageOutCommand("sourcePFN", "targetPFN", options="--wma-cerncastor --test",
                                                        checksums=["adler32"])
-        expectedResults = self.createStageOutCommandResults(True, "sourcePFN", "targetPFN", "targetPFN", "--cerncastor",
+        expectedResults = self.createStageOutCommandResults(True, "sourcePFN", "targetPFN", "targetPFN", "--wma-cerncastor",
                                                             "--test", False, "host", "path")
         self.assertEqual(expectedResults, results)
 
@@ -73,10 +73,10 @@ class XRDCPImplTest(unittest.TestCase):
     def testCreateStageOutCommand_optionsNoStageInChecksum(self, mock_splitPFN):
         mock_splitPFN.return_value = (None, "host", "path", None)
         self.XRDCPImpl.stageIn = False
-        results = self.XRDCPImpl.createStageOutCommand("sourcePFN", "targetPFN", options="--cerncastor --test",
+        results = self.XRDCPImpl.createStageOutCommand("sourcePFN", "targetPFN", options="--wma-cerncastor --test",
                                                        checksums={'adler32': "32"})
         expectedResults = self.createStageOutCommandResults(False, "sourcePFN", "targetPFN", "sourcePFN",
-                                                            "--cerncastor", "--test", "00000032", "host", "path")
+                                                            "--wma-cerncastor", "--test", "00000032", "host", "path")
         self.assertEqual(expectedResults, results)
 
     def createStageOutCommandResults(self, stageIn, sourcePFN, targetPFN, localPFN, copyCommandOptions, unknow,


### PR DESCRIPTION
Possible replaces #7868
Changes are:
* support a new wmagent-specific argument to disable XRD_WRITERECOVERY (workaround for a problem at T2_CH_CERN)
* rename wmagent-specific stage out arguments
* make sure not to add those arguments (options) to the actual stage out command
* remove support for xrdcp-old 