### PR TITLE
move Repack and Express Spec from T0

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/Express.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Express.py
@@ -1,0 +1,500 @@
+"""
+_Express_
+
+Express workflow
+
+express processing -> FEVT/RAW/RECO/whatever -> express merge
+                      (supports multiple output with different primary datasets)
+                   -> ALCARECO -> alca skimming / merging -> ALCARECO
+                                                          -> ALCAPROMPT -> end of run alca harvesting -> sqlite -> dropbox upload
+                   -> DQM -> merge -> DQM -> periodic dqm harvesting
+                                          -> end of run dqm harvesting
+"""
+
+from __future__ import division
+
+import WMCore.WMSpec.Steps.StepFactory as StepFactory
+
+from Utils.Utilities import makeList, makeNonEmptyList
+from WMCore.Lexicon import procstringT0
+
+from WMCore.ReqMgr.Tools.cms import releases, architectures
+
+from WMCore.WMSpec.StdSpecs.StdBase import StdBase
+
+
+class ExpressWorkloadFactory(StdBase):
+    """
+    _ExpressWorkloadFactory_
+
+    Stamp out Express workflows.
+    """
+    def __init__(self):
+        StdBase.__init__(self)
+
+        self.inputPrimaryDataset = None
+        self.inputProcessedDataset = None
+
+        return
+
+    def buildWorkload(self):
+        """
+        _buildWorkload_
+
+        Build the workload given all of the input parameters.
+
+        Not that there will be LogCollect tasks created for each processing
+        task and Cleanup tasks created for each merge task.
+
+        """
+        workload = self.createWorkload()
+        workload.setDashboardActivity("tier0")
+        self.reportWorkflowToDashboard(workload.getDashboardActivity())
+
+        cmsswStepType = "CMSSW"
+        taskType = "Processing"
+
+        # complete output configuration
+        for output in self.outputs:
+            output['moduleLabel'] = "write_%s_%s" % (output['primaryDataset'],
+                                                     output['dataTier'])
+
+        # finalize splitting parameters
+        mySplitArgs = self.expressSplitArgs.copy()
+        mySplitArgs['algo_package'] = "T0.JobSplitting"
+
+        expressTask = workload.newTask("Express")
+
+        #
+        # need to split this up into two separate code paths
+        # one is direct reco from the streamer files
+        # the other is conversion and then reco
+        #
+        if self.recoFrameworkVersion == None or self.recoFrameworkVersion == self.frameworkVersion:
+
+            expressRecoStepName = "cmsRun1"
+
+            scenarioArgs = { 'globalTag' : self.globalTag,
+                             'globalTagTransaction' : self.globalTagTransaction,
+                             'skims' : self.alcaSkims,
+                             'dqmSeq' : self.dqmSequences,
+                             'outputs' : self.outputs,
+                             'inputSource' : "DAT" }
+
+            if self.globalTagConnect:
+                scenarioArgs['globalTagConnect'] = self.globalTagConnect
+
+            expressOutMods = self.setupProcessingTask(expressTask, taskType,
+                                                      scenarioName = self.procScenario,
+                                                      scenarioFunc = "expressProcessing",
+                                                      scenarioArgs = scenarioArgs,
+                                                      splitAlgo = "Express",
+                                                      splitArgs = mySplitArgs,
+                                                      stepType = cmsswStepType,
+                                                      forceUnmerged = True)
+        else:
+
+            expressRecoStepName = "cmsRun2"
+
+            conversionOutMods = self.setupProcessingTask(expressTask, taskType,
+                                                         scenarioName = self.procScenario,
+                                                         scenarioFunc = "repack",
+                                                         scenarioArgs = { 'outputs' : [ { 'dataTier' : "RAW",
+                                                                                          'eventContent' : "ALL",
+                                                                                          'primaryDataset' : self.specialDataset,
+                                                                                          'moduleLabel' : "write_RAW" } ] },
+                                                         splitAlgo = "Express",
+                                                         splitArgs = mySplitArgs,
+                                                         stepType = cmsswStepType,
+                                                         forceUnmerged = True)
+
+            # there is only one
+            conversionOutLabel = conversionOutMods.keys()[0]
+
+            # everything coming after should use the reco CMSSW version and Scram Arch
+            self.frameworkVersion = self.recoFrameworkVersion
+            self.scramArch = self.recoScramArch
+
+            # add a second step doing the reconstruction
+            parentCmsswStep = expressTask.getStep("cmsRun1")
+            parentCmsswStepHelper = parentCmsswStep.getTypeHelper()
+            parentCmsswStepHelper.keepOutput(False)
+            stepTwoCmssw = parentCmsswStep.addTopStep("cmsRun2")
+            stepTwoCmssw.setStepType(cmsswStepType)
+
+            template = StepFactory.getStepTemplate(cmsswStepType)
+            template(stepTwoCmssw.data)
+
+            stepTwoCmsswHelper = stepTwoCmssw.getTypeHelper()
+
+            stepTwoCmsswHelper.setNumberOfCores(self.multicore)
+
+            stepTwoCmsswHelper.setGlobalTag(self.globalTag)
+            stepTwoCmsswHelper.setupChainedProcessing("cmsRun1", conversionOutLabel)
+            stepTwoCmsswHelper.cmsswSetup(self.frameworkVersion, softwareEnvironment = "",
+                                          scramArch = self.scramArch)
+
+            scenarioFunc = "expressProcessing"
+            scenarioArgs = { 'globalTag' : self.globalTag,
+                             'globalTagTransaction' : self.globalTagTransaction,
+                             'skims' : self.alcaSkims,
+                             'dqmSeq' : self.dqmSequences,
+                             'outputs' : self.outputs,
+                             'inputSource' : "EDM" }
+
+            if self.globalTagConnect:
+                scenarioArgs['globalTagConnect'] = self.globalTagConnect
+
+            configOutput = self.determineOutputModules(scenarioFunc, scenarioArgs)
+
+            expressOutMods = {}
+            for outputModuleName in configOutput.keys():
+                outputModule = self.addOutputModule(expressTask,
+                                                    outputModuleName,
+                                                    configOutput[outputModuleName]['primaryDataset'],
+                                                    configOutput[outputModuleName]['dataTier'],
+                                                    configOutput[outputModuleName].get('filterName', None),
+                                                    stepName = "cmsRun2", forceUnmerged = True)
+                expressOutMods[outputModuleName] = outputModule
+
+            if 'outputs' in scenarioArgs:
+                for output in scenarioArgs['outputs']:
+                    if 'primaryDataset' in output:
+                        del output['primaryDataset']
+            if 'primaryDataset' in scenarioArgs:
+                del scenarioArgs['primaryDataset']
+
+            stepTwoCmsswHelper.setDataProcessingConfig(self.procScenario,
+                                                       scenarioFunc,
+                                                       **scenarioArgs)
+
+
+        expressTask.setTaskType("Express")
+
+        self.addLogCollectTask(expressTask, taskName = "ExpressLogCollect")
+
+        for expressOutLabel, expressOutInfo in expressOutMods.items():
+
+            if expressOutInfo['dataTier'] == "ALCARECO":
+
+                # finalize splitting parameters
+                mySplitArgs = self.expressMergeSplitArgs.copy()
+                mySplitArgs['algo_package'] = "T0.JobSplitting"
+
+                alcaSkimTask = expressTask.addTask("%sAlcaSkim%s" % (expressTask.name(), expressOutLabel))
+
+                alcaSkimTask.setInputReference(expressTask.getStep(expressRecoStepName),
+                                               outputModule = expressOutLabel)
+
+                alcaTaskConf = {'Multicore': 1,
+                                'EventStreams': 0}
+
+                scenarioArgs = { 'globalTag' : self.globalTag,
+                                 'globalTagTransaction' : self.globalTagTransaction,
+                                 'skims' : self.alcaSkims,
+                                 'primaryDataset' : self.specialDataset }
+
+                if self.globalTagConnect:
+                    scenarioArgs['globalTagConnect'] = self.globalTagConnect
+
+                alcaSkimOutMods = self.setupProcessingTask(alcaSkimTask, taskType,
+                                                           scenarioName = self.procScenario,
+                                                           scenarioFunc = "alcaSkim",
+                                                           scenarioArgs = scenarioArgs,
+                                                           splitAlgo = "ExpressMerge",
+                                                           splitArgs = mySplitArgs,
+                                                           stepType = cmsswStepType,
+                                                           forceMerged = True,
+                                                           taskConf=alcaTaskConf)
+
+                alcaSkimTask.setTaskType("Express")
+
+                self.addLogCollectTask(alcaSkimTask, taskName = "AlcaSkimLogCollect")
+                self.addCleanupTask(expressTask, expressOutLabel)
+
+                for alcaSkimOutLabel, alcaSkimOutInfo in alcaSkimOutMods.items():
+
+                    if alcaSkimOutInfo['dataTier'] == "ALCAPROMPT" and self.alcaHarvestDir != None:
+
+                        harvestTask = self.addAlcaHarvestTask(alcaSkimTask, alcaSkimOutLabel,
+                                                              alcapromptdataset = alcaSkimOutInfo['filterName'],
+                                                              condOutLabel = self.alcaHarvestOutLabel,
+                                                              condUploadDir = self.alcaHarvestDir,
+                                                              uploadProxy = self.dqmUploadProxy,
+                                                              doLogCollect = True)
+
+                        self.addConditionTask(harvestTask, self.alcaHarvestOutLabel)
+
+            else:
+
+                mergeTask = self.addExpressMergeTask(expressTask, expressRecoStepName, expressOutLabel)
+
+                if expressOutInfo['dataTier'] in [ "DQM", "DQMIO" ]:
+
+                    self.addDQMHarvestTask(mergeTask, "Merged",
+                                           uploadProxy = self.dqmUploadProxy,
+                                           periodic_harvest_interval = self.periodicHarvestInterval,
+                                           doLogCollect = True)
+
+        workload.setBlockCloseSettings(self.blockCloseDelay,
+                                       workload.getBlockCloseMaxFiles(),
+                                       workload.getBlockCloseMaxEvents(),
+                                       workload.getBlockCloseMaxSize())
+
+        # setting the parameters which need to be set for all the tasks
+        # sets acquisitionEra, processingVersion, processingString
+        workload.setTaskPropertiesFromWorkload()
+
+        # set the LFN bases (normally done by request manager)
+        # also pass run number to add run based directories
+        workload.setLFNBase(self.mergedLFNBase, self.unmergedLFNBase,
+                            runNumber = self.runNumber)
+
+        return workload
+
+    def addExpressMergeTask(self, parentTask, parentStepName, parentOutputModuleName):
+        """
+        _addExpressMergeTask_
+
+        Create an expressmerge task for files produced by the parent task
+
+        """
+        # finalize splitting parameters
+        mySplitArgs = self.expressMergeSplitArgs.copy()
+        mySplitArgs['algo_package'] = "T0.JobSplitting"
+
+        parentTaskCmssw = parentTask.getStep(parentStepName)
+        parentOutputModule = parentTaskCmssw.getOutputModule(parentOutputModuleName)
+
+        mergeTask = parentTask.addTask("%sMerge%s" % (parentTask.name(), parentOutputModuleName))
+
+        mergeTask.setInputReference(parentTaskCmssw, outputModule = parentOutputModuleName)
+
+        self.addDashboardMonitoring(mergeTask)
+        mergeTaskCmssw = mergeTask.makeStep("cmsRun1")
+        mergeTaskCmssw.setStepType("CMSSW")
+
+        mergeTaskStageOut = mergeTaskCmssw.addStep("stageOut1")
+        mergeTaskStageOut.setStepType("StageOut")
+        mergeTaskLogArch = mergeTaskCmssw.addStep("logArch1")
+        mergeTaskLogArch.setStepType("LogArchive")
+
+        mergeTask.setTaskLogBaseLFN(self.unmergedLFNBase)
+
+        self.addLogCollectTask(mergeTask, taskName = "%s%sMergeLogCollect" % (parentTask.name(), parentOutputModuleName))
+
+        mergeTask.applyTemplates()
+
+        mergeTaskCmsswHelper = mergeTaskCmssw.getTypeHelper()
+
+        mergeTaskCmsswHelper.cmsswSetup(self.frameworkVersion, softwareEnvironment = "",
+                                        scramArch = self.scramArch)
+
+        mergeTaskCmsswHelper.setErrorDestinationStep(stepName = mergeTaskLogArch.name())
+        mergeTaskCmsswHelper.setGlobalTag(self.globalTag)
+        mergeTaskCmsswHelper.setOverrideCatalog(self.overrideCatalog)
+
+        #mergeTaskStageHelper = mergeTaskStageOut.getTypeHelper()
+        #mergeTaskStageHelper.setMinMergeSize(0, 0)
+
+        mergeTask.setTaskType("Merge")
+
+        # DQM is handled differently
+        #  merging does not increase size
+        #                => disable size limits
+        #  only harvest every 15 min
+        #                => higher limits for latency (disabled for now)
+        dataTier = getattr(parentOutputModule, "dataTier")
+        if dataTier in [ "DQM", "DQMIO" ]:
+            mySplitArgs['maxInputSize'] *= 100
+
+        mergeTask.setSplittingAlgorithm("ExpressMerge",
+                                        **mySplitArgs)
+        mergeTaskCmsswHelper.setDataProcessingConfig(self.procScenario, "merge",
+                                                     newDQMIO = (dataTier == "DQMIO"))
+
+        self.addOutputModule(mergeTask, "Merged",
+                             primaryDataset = getattr(parentOutputModule, "primaryDataset"),
+                             dataTier = getattr(parentOutputModule, "dataTier"),
+                             filterName = getattr(parentOutputModule, "filterName"),
+                             forceMerged = True)
+
+        self.addCleanupTask(parentTask, parentOutputModuleName)
+
+        return mergeTask
+
+    def addAlcaHarvestTask(self, parentTask, parentOutputModuleName,
+                           alcapromptdataset, condOutLabel, condUploadDir, uploadProxy,
+                           parentStepName = "cmsRun1", doLogCollect = True):
+        """
+        _addAlcaHarvestTask_
+
+        Create an Alca harvest task to harvest the files produces by the parent task.
+        """
+        # finalize splitting parameters
+        mySplitArgs = {}
+        mySplitArgs['algo_package'] = "T0.JobSplitting"
+        mySplitArgs['runNumber'] = self.runNumber
+        mySplitArgs['alcapromptdataset'] = alcapromptdataset
+        mySplitArgs['timeout'] = self.alcaHarvestTimeout
+
+        harvestTask = parentTask.addTask("%sAlcaHarvest%s" % (parentTask.name(), parentOutputModuleName))
+        self.addDashboardMonitoring(harvestTask)
+        harvestTaskCmssw = harvestTask.makeStep("cmsRun1")
+        harvestTaskCmssw.setStepType("CMSSW")
+
+        harvestTaskCondition = harvestTaskCmssw.addStep("condition1")
+        harvestTaskCondition.setStepType("AlcaHarvest")
+        harvestTaskUpload = harvestTaskCmssw.addStep("upload1")
+        harvestTaskUpload.setStepType("DQMUpload")
+        harvestTaskLogArch = harvestTaskCmssw.addStep("logArch1")
+        harvestTaskLogArch.setStepType("LogArchive")
+
+        harvestTask.setTaskLogBaseLFN(self.unmergedLFNBase)
+        if doLogCollect:
+            self.addLogCollectTask(harvestTask, taskName = "%s%sAlcaHarvestLogCollect" % (parentTask.name(), parentOutputModuleName))
+
+        harvestTask.setTaskType("Harvesting")
+        harvestTask.applyTemplates()
+
+        harvestTaskCmsswHelper = harvestTaskCmssw.getTypeHelper()
+        harvestTaskCmsswHelper.cmsswSetup(self.frameworkVersion, softwareEnvironment = "",
+                                          scramArch = self.scramArch)
+
+        harvestTaskCmsswHelper.setErrorDestinationStep(stepName = harvestTaskLogArch.name())
+        harvestTaskCmsswHelper.setGlobalTag(self.globalTag)
+        harvestTaskCmsswHelper.setOverrideCatalog(self.overrideCatalog)
+
+        harvestTaskCmsswHelper.setUserLFNBase("/")
+
+        parentTaskCmssw = parentTask.getStep(parentStepName)
+        parentOutputModule = parentTaskCmssw.getOutputModule(parentOutputModuleName)
+
+        harvestTask.setInputReference(parentTaskCmssw, outputModule = parentOutputModuleName)
+
+        harvestTask.setSplittingAlgorithm("AlcaHarvest",
+                                          **mySplitArgs)
+
+        scenarioArgs = { 'globalTag' : self.globalTag,
+                         'datasetName' : "/%s/%s/%s" % (getattr(parentOutputModule, "primaryDataset"),
+                                                        getattr(parentOutputModule, "processedDataset"),
+                                                        getattr(parentOutputModule, "dataTier")),
+                         'runNumber' : self.runNumber,
+                         'alcapromptdataset' : alcapromptdataset }
+
+        if self.globalTagConnect:
+            scenarioArgs['globalTagConnect'] = self.globalTagConnect
+
+        harvestTaskCmsswHelper.setDataProcessingConfig(self.procScenario,
+                                                       "alcaHarvesting",
+                                                       **scenarioArgs)
+
+        harvestTaskConditionHelper = harvestTaskCondition.getTypeHelper()
+        harvestTaskConditionHelper.setRunNumber(self.runNumber)
+        harvestTaskConditionHelper.setConditionOutputLabel(condOutLabel)
+        harvestTaskConditionHelper.setConditionDir(condUploadDir)
+
+        self.addOutputModule(harvestTask, condOutLabel,
+                             primaryDataset = getattr(parentOutputModule, "primaryDataset"),
+                             dataTier = getattr(parentOutputModule, "dataTier"),
+                             filterName = getattr(parentOutputModule, "filterName"))
+
+        harvestTaskUploadHelper = harvestTaskUpload.getTypeHelper()
+        harvestTaskUploadHelper.setProxyFile(uploadProxy)
+        harvestTaskUploadHelper.setServerURL(self.dqmUploadUrl)
+
+        return harvestTask
+
+    def addConditionTask(self, parentTask, parentOutputModuleName):
+        """
+        _addConditionTask_
+
+        Does not actually produce any jobs
+        The job splitter is custom and just forwards information
+        into T0AST specific data structures, the actual upload
+        of the conditions to the DropBox is handled in a separate
+        Tier0 component.
+
+        """
+        # finalize splitting parameters
+        mySplitArgs = {}
+        mySplitArgs['algo_package'] = "T0.JobSplitting"
+        mySplitArgs['runNumber'] = self.runNumber
+        mySplitArgs['streamName'] = self.streamName
+
+        parentTaskCmssw = parentTask.getStep("cmsRun1")
+
+        conditionTask = parentTask.addTask("%sCondition%s" % (parentTask.name(), parentOutputModuleName))
+
+        # this is complete bogus, but other code can't deal with a task with no steps
+        conditionTaskBogus = conditionTask.makeStep("bogus")
+        conditionTaskBogus.setStepType("DQMUpload")
+
+        conditionTask.setInputReference(parentTaskCmssw, outputModule = parentOutputModuleName)
+
+        conditionTask.applyTemplates()
+
+        conditionTask.setTaskType("Harvesting")
+
+        conditionTask.setSplittingAlgorithm("Condition",
+                                            **mySplitArgs)
+
+        return
+
+    def __call__(self, workloadName, arguments):
+        """
+        _call_
+
+        Create a Express workload with the given parameters.
+        """
+        StdBase.__call__(self, workloadName, arguments)
+
+        # Required parameters that must be specified by the Requestor.
+        self.outputs = arguments['Outputs']
+
+        # job splitting parameters (also required parameters)
+        self.expressSplitArgs = {}
+        self.expressSplitArgs['maxInputRate'] = arguments['MaxInputRate']
+        self.expressSplitArgs['maxInputEvents'] = arguments['MaxInputEvents']
+        self.expressMergeSplitArgs = {}
+        self.expressMergeSplitArgs['maxInputSize'] = arguments['MaxInputSize']
+        self.expressMergeSplitArgs['maxInputFiles'] = arguments['MaxInputFiles']
+        self.expressMergeSplitArgs['maxLatency'] = arguments['MaxLatency']
+
+        # fixed parameters that are used in various places
+        self.alcaHarvestOutLabel = "Sqlite"
+
+        return self.buildWorkload()
+
+    @staticmethod
+    def getWorkloadCreateArgs():
+        baseArgs = StdBase.getWorkloadCreateArgs()
+        specArgs = {"RequestType": {"default": "Express"},
+                    "ConfigCacheID": {"optional": True, "null": True},
+                    "Scenario": {"optional": False, "attr": "procScenario"},
+                    "RecoCMSSWVersion": {"validate": lambda x: x in releases(),
+                                         "optional": False, "attr": "recoFrameworkVersion"},
+                    "RecoScramArch": {"validate": lambda x: all([y in architectures() for y in x]),
+                                      "optional": False, "type": makeNonEmptyList},
+                    "GlobalTag": {"optional": False},
+                    "GlobalTagTransaction": {"optional": False},
+                    "ProcessingString": {"default": "", "validate": procstringT0},
+                    "StreamName": {"optional": False},
+                    "SpecialDataset": {"optional": False},
+                    "AlcaHarvestTimeout": {"type": int, "optional": False},
+                    "AlcaHarvestDir": {"optional": False, "null": True},
+                    "AlcaSkims": {"type": makeList, "optional": False},
+                    "DQMSequences": {"type": makeList, "attr": "dqmSequences", "optional": False},
+                    "BlockCloseDelay": {"type": int, "optional": False,
+                                        "validate": lambda x : x > 0},
+                    "Outputs": {"type": makeList, "optional": False},
+                    "MaxInputRate": {"type": int, "optional": False},
+                    "MaxInputEvents": {"type": int, "optional": False},
+                    "MaxInputSize": {"type": int, "optional": False},
+                    "MaxInputFiles": {"type": int, "optional": False},
+                    "MaxLatency": {"type": int, "optional": False},
+
+                    }
+        baseArgs.update(specArgs)
+        StdBase.setDefaultArgumentsProperty(baseArgs)
+        return baseArgs

--- a/src/python/WMCore/WMSpec/StdSpecs/Repack.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Repack.py
@@ -1,0 +1,211 @@
+"""
+_Repack_
+
+Repack workflow
+
+repacking -> RAW -> optional merge
+             (supports multiple output with different primary datasets)
+
+"""
+
+from __future__ import division
+
+from Utils.Utilities import makeList
+from WMCore.Lexicon import procstringT0
+
+from WMCore.WMSpec.StdSpecs.StdBase import StdBase
+
+class RepackWorkloadFactory(StdBase):
+    """
+    _RepackWorkloadFactory_
+
+    Stamp out Repack workflows.
+    """
+
+    def __init__(self):
+        StdBase.__init__(self)
+
+        self.inputPrimaryDataset = None
+        self.inputProcessedDataset = None
+
+        return
+
+    def buildWorkload(self):
+        """
+        _buildWorkload_
+
+        Build the workload given all of the input parameters.  At the very least
+        this will create a processing task and merge tasks for all the outputs
+        of the processing task.
+
+        Not that there will be LogCollect tasks created for each processing
+        task and Cleanup tasks created for each merge task.
+
+        """
+        workload = self.createWorkload()
+        workload.setDashboardActivity("tier0")
+        self.reportWorkflowToDashboard(workload.getDashboardActivity())
+
+        cmsswStepType = "CMSSW"
+        taskType = "Processing"
+
+        # complete output configuration
+        for output in self.outputs:
+            output['moduleLabel'] = "write_%s_%s" % (output['primaryDataset'],
+                                                     output['dataTier'])
+
+        # finalize splitting parameters
+        mySplitArgs = self.repackSplitArgs.copy()
+        mySplitArgs['algo_package'] = "T0.JobSplitting"
+
+        repackTask = workload.newTask("Repack")
+        repackOutMods = self.setupProcessingTask(repackTask, taskType,
+                                                 scenarioName = self.procScenario,
+                                                 scenarioFunc = "repack",
+                                                 scenarioArgs = { 'outputs' : self.outputs },
+                                                 splitAlgo = "Repack",
+                                                 splitArgs = mySplitArgs,
+                                                 stepType = cmsswStepType)
+
+        repackTask.setTaskType("Repack")
+
+        self.addLogCollectTask(repackTask)
+
+        for repackOutLabel in repackOutMods.keys():
+            self.addRepackMergeTask(repackTask, repackOutLabel)
+
+        workload.setBlockCloseSettings(self.blockCloseDelay,
+                                       workload.getBlockCloseMaxFiles(),
+                                       workload.getBlockCloseMaxEvents(),
+                                       workload.getBlockCloseMaxSize())
+
+        # setting the parameters which need to be set for all the tasks
+        # sets acquisitionEra, processingVersion, processingString
+        workload.setTaskPropertiesFromWorkload()
+
+        # set the LFN bases (normally done by request manager)
+        # also pass run number to add run based directories
+        workload.setLFNBase(self.mergedLFNBase, self.unmergedLFNBase,
+                            runNumber = self.runNumber)
+
+        return workload
+
+    def addRepackMergeTask(self, parentTask, parentOutputModuleName):
+        """
+        _addRepackMergeTask_
+
+        Create an repackmerge task for files produced by the parent task.
+
+        """
+        mergeTask = parentTask.addTask("%sMerge%s" % (parentTask.name(), parentOutputModuleName))
+        self.addDashboardMonitoring(mergeTask)
+        mergeTaskCmssw = mergeTask.makeStep("cmsRun1")
+        mergeTaskCmssw.setStepType("CMSSW")
+
+        mergeTaskStageOut = mergeTaskCmssw.addStep("stageOut1")
+        mergeTaskStageOut.setStepType("StageOut")
+        mergeTaskLogArch = mergeTaskCmssw.addStep("logArch1")
+        mergeTaskLogArch.setStepType("LogArchive")
+
+        mergeTask.setTaskLogBaseLFN(self.unmergedLFNBase)
+
+        self.addLogCollectTask(mergeTask, taskName = "%s%sMergeLogCollect" % (parentTask.name(), parentOutputModuleName))
+
+        mergeTask.applyTemplates()
+
+        parentTaskCmssw = parentTask.getStep("cmsRun1")
+        parentOutputModule = parentTaskCmssw.getOutputModule(parentOutputModuleName)
+
+        mergeTask.setInputReference(parentTaskCmssw, outputModule = parentOutputModuleName)
+
+        mergeTaskCmsswHelper = mergeTaskCmssw.getTypeHelper()
+
+        mergeTaskCmsswHelper.cmsswSetup(self.frameworkVersion, softwareEnvironment = "",
+                                        scramArch = self.scramArch)
+
+        mergeTaskCmsswHelper.setErrorDestinationStep(stepName = mergeTaskLogArch.name())
+        mergeTaskCmsswHelper.setGlobalTag(self.globalTag)
+        mergeTaskCmsswHelper.setOverrideCatalog(self.overrideCatalog)
+
+        #mergeTaskStageHelper = mergeTaskStageOut.getTypeHelper()
+        #mergeTaskStageHelper.setMinMergeSize(0, 0)
+
+        mergeTask.setTaskType("Merge")
+
+        # finalize splitting parameters
+        mySplitArgs = self.repackMergeSplitArgs.copy()
+        mySplitArgs['algo_package'] = "T0.JobSplitting"
+
+        mergeTask.setSplittingAlgorithm("RepackMerge",
+                                        **mySplitArgs)
+        mergeTaskCmsswHelper.setDataProcessingConfig(self.procScenario, "merge")
+
+        self.addOutputModule(mergeTask, "Merged",
+                             primaryDataset = getattr(parentOutputModule, "primaryDataset"),
+                             dataTier = getattr(parentOutputModule, "dataTier"),
+                             filterName = getattr(parentOutputModule, "filterName"),
+                             forceMerged = True)
+
+        self.addOutputModule(mergeTask, "MergedError",
+                             primaryDataset = getattr(parentOutputModule, "primaryDataset") + "-Error",
+                             dataTier = getattr(parentOutputModule, "dataTier"),
+                             filterName = getattr(parentOutputModule, "filterName"),
+                             forceMerged = True)
+
+        self.addCleanupTask(parentTask, parentOutputModuleName)
+
+        return mergeTask
+
+    def __call__(self, workloadName, arguments):
+        """
+        _call_
+
+        Create a Repack workload with the given parameters.
+        """
+        StdBase.__call__(self, workloadName, arguments)
+
+        # Required parameters that must be specified by the Requestor.
+        self.outputs = arguments['Outputs']
+
+        # job splitting parameters
+        self.repackSplitArgs = {}
+        self.repackSplitArgs['maxSizeSingleLumi'] = arguments['MaxSizeSingleLumi']
+        self.repackSplitArgs['maxSizeMultiLumi'] = arguments['MaxSizeMultiLumi']
+        self.repackSplitArgs['maxInputEvents'] = arguments['MaxInputEvents']
+        self.repackSplitArgs['maxInputFiles'] = arguments['MaxInputFiles']
+        self.repackSplitArgs['maxLatency'] = arguments['MaxLatency']
+        self.repackMergeSplitArgs = {}
+        self.repackMergeSplitArgs['minInputSize'] = arguments['MinInputSize']
+        self.repackMergeSplitArgs['maxInputSize'] = arguments['MaxInputSize']
+        self.repackMergeSplitArgs['maxEdmSize'] = arguments['MaxEdmSize']
+        self.repackMergeSplitArgs['maxOverSize'] = arguments['MaxOverSize']
+        self.repackMergeSplitArgs['maxInputEvents'] = arguments['MaxInputEvents']
+        self.repackMergeSplitArgs['maxInputFiles'] = arguments['MaxInputFiles']
+        self.repackMergeSplitArgs['maxLatency'] = arguments['MaxLatency']
+
+        return self.buildWorkload()
+
+    @staticmethod
+    def getWorkloadCreateArgs():
+        baseArgs = StdBase.getWorkloadCreateArgs()
+        specArgs = {"RequestType": {"default": "Repack"},
+                    "ConfigCacheID": {"optional": True, "null": True},
+                    "Scenario": {"default": "fake", "attr": "procScenario"},
+                    "GlobalTag": {"default": "fake"},
+                    "ProcessingString": {"default": "", "validate": procstringT0},
+                    "BlockCloseDelay": {"type": int, "optional": False,
+                                        "validate": lambda x : x > 0},
+                    "Outputs": {"type": makeList, "optional": False},
+                    "MaxSizeSingleLumi": {"type": int, "optional": False},
+                    "MaxSizeMultiLumi": {"type": int, "optional": False},
+                    "MaxInputEvents": {"type": int, "optional": False},
+                    "MaxInputFiles": {"type": int, "optional": False},
+                    "MaxLatency": {"type": int, "optional": False},
+                    "MinInputSize": {"type": int, "optional": False},
+                    "MaxInputSize": {"type": int, "optional": False},
+                    "MaxEdmSize": {"type": int, "optional": False},
+                    "MaxOverSize": {"type": int, "optional": False},
+                    }
+        baseArgs.update(specArgs)
+        StdBase.setDefaultArgumentsProperty(baseArgs)
+        return baseArgs

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Express_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Express_t.py
@@ -1,0 +1,541 @@
+#!/usr/bin/env python
+"""
+_Express_t_
+
+Unit tests for the Express workflow.
+"""
+
+from __future__ import division
+
+import unittest
+
+from WMCore.WMBS.Fileset import Fileset
+from WMCore.WMBS.Subscription import Subscription
+from WMCore.WMBS.Workflow import Workflow
+
+from WMCore.WorkQueue.WMBSHelper import WMBSHelper
+from WMCore.WMSpec.StdSpecs.Express import ExpressWorkloadFactory
+
+from WMQuality.TestInitCouchApp import TestInitCouchApp
+
+
+class ExpressTest(unittest.TestCase):
+    def setUp(self):
+        """
+        _setUp_
+
+        Initialize the database and couch.
+        """
+        self.testInit = TestInitCouchApp(__file__)
+        self.testInit.setLogging()
+        self.testInit.setDatabaseConnection()
+        self.testInit.setSchema(customModules=["WMCore.WMBS"],
+                                useDefault=False)
+        self.testDir = self.testInit.generateWorkDir()
+        return
+
+    def tearDown(self):
+        """
+        _tearDown_
+
+        Clear out the database.
+        """
+        self.testInit.clearDatabase()
+        self.testInit.delWorkDir()
+        return
+
+    def testExpress(self):
+        """
+        _testExpress_
+
+        Create an Express workflow
+        and verify it installs into WMBS correctly.
+        """
+        testArguments = ExpressWorkloadFactory.getTestArguments()
+        testArguments['ProcessingString'] = "Express"
+        testArguments['ProcessingVersion'] = 9
+        testArguments['Scenario'] = "test_scenario"
+        testArguments['CMSSWVersion'] = "CMSSW_9_0_0"
+        testArguments['ScramArch'] = "slc6_amd64_gcc530"
+        testArguments['RecoCMSSWVersion'] = "CMSSW_9_0_0"
+        testArguments['RecoScramArch'] = "slc6_amd64_gcc530"
+        testArguments['GlobalTag'] = "SomeGlobalTag"
+        testArguments['GlobalTagTransaction'] = "Express_123456"
+        testArguments['GlobalTagConnect'] = "frontier://PromptProd/CMS_CONDITIONS"
+        testArguments['MaxInputRate'] = 23 * 1000
+        testArguments['MaxInputEvents'] = 400
+        testArguments['MaxInputSize'] = 2 * 1024 * 1024 * 1024
+        testArguments['MaxInputFiles'] = 15
+        testArguments['MaxLatency'] = 15 * 23
+        testArguments['AlcaSkims'] = [ "TkAlMinBias", "PromptCalibProd" ]
+        testArguments['DQMSequences'] = [ "@common" ]
+        testArguments['AlcaHarvestTimeout'] = 12 * 3600
+        testArguments['AlcaHarvestDir'] = "/somepath"
+        testArguments['DQMUploadProxy'] = "/somepath/proxy"
+        testArguments['DQMUploadUrl'] = "https://cmsweb.cern.ch/dqm/offline"
+        testArguments['StreamName'] = "Express"
+        testArguments['SpecialDataset'] = "StreamExpress"
+
+        testArguments['RunNumber'] = 123456
+        testArguments['AcquisitionEra'] = "TestAcquisitionEra"
+        testArguments['ValidStatus'] = "VALID"
+
+        testArguments['Outputs'] = []
+        testArguments['Outputs'].append( { 'dataTier' : "FEVT",
+                                           'eventContent' : "FEVT",
+                                           'selectEvents' : ["Path1:HLT,Path2:HLT"],
+                                           'primaryDataset' : "PrimaryDataset1" } )
+        testArguments['Outputs'].append( { 'dataTier' : "ALCARECO",
+                                           'eventContent' : "ALCARECO",
+                                           'primaryDataset' : "StreamExpress" } )
+        testArguments['Outputs'].append( { 'dataTier' : "DQMIO",
+                                           'eventContent' : "DQMIO",
+                                           'primaryDataset' : "StreamExpress" } )
+
+        testArguments['PeriodicHarvestInterval'] = 20 * 60
+                                         
+        factory = ExpressWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
+        testWorkload.setSpecUrl("somespec")
+        testWorkload.setOwnerDetails("Dirk.Hufnagel@cern.ch", "T0")
+
+        testWMBSHelper = WMBSHelper(testWorkload, "Express", cachepath=self.testDir)
+        testWMBSHelper.createTopLevelFileset()
+        testWMBSHelper._createSubscriptionsInWMBS(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
+
+        expressWorkflow = Workflow(name="TestWorkload",
+                                   task="/TestWorkload/Express")
+        expressWorkflow.load()
+        self.assertEqual(len(expressWorkflow.outputMap.keys()), len(testArguments["Outputs"]) + 1,
+                         "Error: Wrong number of WF outputs in the Express WF.")
+
+        goldenOutputMods = ["write_PrimaryDataset1_FEVT", "write_StreamExpress_ALCARECO", "write_StreamExpress_DQMIO"]
+        for goldenOutputMod in goldenOutputMods:
+            mergedOutput = expressWorkflow.outputMap[goldenOutputMod][0]["merged_output_fileset"]
+            unmergedOutput = expressWorkflow.outputMap[goldenOutputMod][0]["output_fileset"]
+            mergedOutput.loadData()
+            unmergedOutput.loadData()
+
+            if goldenOutputMod != "write_StreamExpress_ALCARECO":
+                self.assertEqual(mergedOutput.name, "/TestWorkload/Express/ExpressMerge%s/merged-Merged" % goldenOutputMod,
+                                 "Error: Merged output fileset is wrong: %s" % mergedOutput.name)
+            self.assertEqual(unmergedOutput.name, "/TestWorkload/Express/unmerged-%s" % goldenOutputMod,
+                             "Error: Unmerged output fileset is wrong: %s" % unmergedOutput.name)
+
+        logArchOutput = expressWorkflow.outputMap["logArchive"][0]["merged_output_fileset"]
+        unmergedLogArchOutput = expressWorkflow.outputMap["logArchive"][0]["output_fileset"]
+        logArchOutput.loadData()
+        unmergedLogArchOutput.loadData()
+
+        self.assertEqual(logArchOutput.name, "/TestWorkload/Express/unmerged-logArchive",
+                         "Error: LogArchive output fileset is wrong.")
+        self.assertEqual(unmergedLogArchOutput.name, "/TestWorkload/Express/unmerged-logArchive",
+                         "Error: LogArchive output fileset is wrong.")
+
+        alcaSkimWorkflow = Workflow(name="TestWorkload",
+                                    task="/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO")
+        alcaSkimWorkflow.load()
+        self.assertEqual(len(alcaSkimWorkflow.outputMap.keys()), len(testArguments["AlcaSkims"]) + 1,
+                         "Error: Wrong number of WF outputs in the AlcaSkim WF.")
+
+        goldenOutputMods = []
+        for alcaProd in testArguments["AlcaSkims"]:
+            goldenOutputMods.append("ALCARECOStream%s" % alcaProd)
+
+        for goldenOutputMod in goldenOutputMods:
+            mergedOutput = alcaSkimWorkflow.outputMap[goldenOutputMod][0]["merged_output_fileset"]
+            unmergedOutput = alcaSkimWorkflow.outputMap[goldenOutputMod][0]["output_fileset"]
+            mergedOutput.loadData()
+            unmergedOutput.loadData()
+            self.assertEqual(mergedOutput.name, "/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/unmerged-%s" % goldenOutputMod,
+                             "Error: Merged output fileset is wrong: %s" % mergedOutput.name)
+            self.assertEqual(unmergedOutput.name, "/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/unmerged-%s" % goldenOutputMod,
+                             "Error: Unmerged output fileset is wrong: %s" % unmergedOutput.name)
+
+        logArchOutput = alcaSkimWorkflow.outputMap["logArchive"][0]["merged_output_fileset"]
+        unmergedLogArchOutput = alcaSkimWorkflow.outputMap["logArchive"][0]["output_fileset"]
+        logArchOutput.loadData()
+        unmergedLogArchOutput.loadData()
+
+        self.assertEqual(logArchOutput.name, "/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/unmerged-logArchive",
+                         "Error: LogArchive output fileset is wrong.")
+        self.assertEqual(unmergedLogArchOutput.name, "/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/unmerged-logArchive",
+                         "Error: LogArchive output fileset is wrong.")
+
+        for dqmString in ["ExpressMergewrite_StreamExpress_DQMIOEndOfRunDQMHarvestMerged",
+                          "ExpressMergewrite_StreamExpress_DQMIOPeriodicDQMHarvestMerged"]:
+
+            dqmTask = "/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO/%s" % dqmString
+
+            dqmWorkflow = Workflow(name="TestWorkload",
+                                   task=dqmTask)
+            dqmWorkflow.load()
+        
+            logArchOutput = dqmWorkflow.outputMap["logArchive"][0]["merged_output_fileset"]
+            unmergedLogArchOutput = dqmWorkflow.outputMap["logArchive"][0]["output_fileset"]
+            logArchOutput.loadData()
+            unmergedLogArchOutput.loadData()
+
+            self.assertEqual(logArchOutput.name,
+                             "%s/unmerged-logArchive" % dqmTask,
+                             "Error: LogArchive output fileset is wrong.")
+            self.assertEqual(unmergedLogArchOutput.name,
+                             "%s/unmerged-logArchive" % dqmTask,
+                             "Error: LogArchive output fileset is wrong.")
+
+        goldenOutputMods = ["write_PrimaryDataset1_FEVT", "write_StreamExpress_DQMIO"]
+        for goldenOutputMod in goldenOutputMods:
+            mergeWorkflow = Workflow(name="TestWorkload",
+                                     task="/TestWorkload/Express/ExpressMerge%s" % goldenOutputMod)
+            mergeWorkflow.load()
+
+            self.assertEqual(len(mergeWorkflow.outputMap.keys()), 2,
+                             "Error: Wrong number of WF outputs.")
+
+            mergedMergeOutput = mergeWorkflow.outputMap["Merged"][0]["merged_output_fileset"]
+            unmergedMergeOutput = mergeWorkflow.outputMap["Merged"][0]["output_fileset"]
+
+            mergedMergeOutput.loadData()
+            unmergedMergeOutput.loadData()
+
+            self.assertEqual(mergedMergeOutput.name, "/TestWorkload/Express/ExpressMerge%s/merged-Merged" % goldenOutputMod,
+                             "Error: Merged output fileset is wrong.")
+            self.assertEqual(unmergedMergeOutput.name, "/TestWorkload/Express/ExpressMerge%s/merged-Merged" % goldenOutputMod,
+                             "Error: Unmerged output fileset is wrong.")
+
+            logArchOutput = mergeWorkflow.outputMap["logArchive"][0]["merged_output_fileset"]
+            unmergedLogArchOutput = mergeWorkflow.outputMap["logArchive"][0]["output_fileset"]
+            logArchOutput.loadData()
+            unmergedLogArchOutput.loadData()
+
+            self.assertEqual(logArchOutput.name, "/TestWorkload/Express/ExpressMerge%s/merged-logArchive" % goldenOutputMod,
+                             "Error: LogArchive output fileset is wrong: %s" % logArchOutput.name)
+            self.assertEqual(unmergedLogArchOutput.name, "/TestWorkload/Express/ExpressMerge%s/merged-logArchive" % goldenOutputMod,
+                             "Error: LogArchive output fileset is wrong.")
+
+        topLevelFileset = Fileset(name="TestWorkload-Express")
+        topLevelFileset.loadData()
+
+        expressSubscription = Subscription(fileset=topLevelFileset, workflow=expressWorkflow)
+        expressSubscription.loadData()
+
+        self.assertEqual(expressSubscription["type"], "Express",
+                         "Error: Wrong subscription type.")
+        self.assertEqual(expressSubscription["split_algo"], "Express",
+                         "Error: Wrong split algorithm. %s" % expressSubscription["split_algo"])
+
+        alcaRecoFileset = Fileset(name="/TestWorkload/Express/unmerged-write_StreamExpress_ALCARECO")
+        alcaRecoFileset.loadData()
+
+        alcaSkimSubscription = Subscription(fileset=alcaRecoFileset, workflow=alcaSkimWorkflow)
+        alcaSkimSubscription.loadData()
+
+        self.assertEqual(alcaSkimSubscription["type"], "Express",
+                         "Error: Wrong subscription type.")
+        self.assertEqual(alcaSkimSubscription["split_algo"], "ExpressMerge",
+                         "Error: Wrong split algorithm. %s" % alcaSkimSubscription["split_algo"])
+
+        mergedDQMFileset = Fileset(name="/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO/merged-Merged")
+        mergedDQMFileset.loadData()
+
+        dqmSubscription = Subscription(fileset=mergedDQMFileset, workflow=dqmWorkflow)
+        dqmSubscription.loadData()
+
+        self.assertEqual(dqmSubscription["type"], "Harvesting",
+                         "Error: Wrong subscription type.")
+        self.assertEqual(dqmSubscription["split_algo"], "Harvest",
+                         "Error: Wrong split algo.")
+
+        unmergedOutputs = ["write_PrimaryDataset1_FEVT", "write_StreamExpress_DQMIO"]
+        for unmergedOutput in unmergedOutputs:
+            unmergedDataTier = Fileset(name="/TestWorkload/Express/unmerged-%s" % unmergedOutput)
+            unmergedDataTier.loadData()
+            dataTierMergeWorkflow = Workflow(name="TestWorkload",
+                                             task="/TestWorkload/Express/ExpressMerge%s" % unmergedOutput)
+            dataTierMergeWorkflow.load()
+            mergeSubscription = Subscription(fileset=unmergedDataTier, workflow=dataTierMergeWorkflow)
+            mergeSubscription.loadData()
+
+            self.assertEqual(mergeSubscription["type"], "Merge",
+                             "Error: Wrong subscription type.")
+            self.assertEqual(mergeSubscription["split_algo"], "ExpressMerge",
+                             "Error: Wrong split algorithm. %s" % mergeSubscription["split_algo"])
+
+        goldenOutputMods = ["write_PrimaryDataset1_FEVT", "write_StreamExpress_ALCARECO", "write_StreamExpress_DQMIO"]
+        for goldenOutputMod in goldenOutputMods:
+            unmergedFileset = Fileset(name="/TestWorkload/Express/unmerged-%s" % goldenOutputMod)
+            unmergedFileset.loadData()
+            cleanupWorkflow = Workflow(name="TestWorkload",
+                                       task="/TestWorkload/Express/ExpressCleanupUnmerged%s" % goldenOutputMod)
+            cleanupWorkflow.load()
+            cleanupSubscription = Subscription(fileset=unmergedFileset, workflow=cleanupWorkflow)
+            cleanupSubscription.loadData()
+
+            self.assertEqual(cleanupSubscription["type"], "Cleanup",
+                             "Error: Wrong subscription type.")
+            self.assertEqual(cleanupSubscription["split_algo"], "SiblingProcessingBased",
+                             "Error: Wrong subscription type.")
+
+        expressLogCollect = Fileset(name="/TestWorkload/Express/unmerged-logArchive")
+        expressLogCollect.loadData()
+        expressLogCollectWorkflow = Workflow(name="TestWorkload",
+                                             task="/TestWorkload/Express/ExpressLogCollect")
+        expressLogCollectWorkflow.load()
+        logCollectSub = Subscription(fileset=expressLogCollect, workflow=expressLogCollectWorkflow)
+        logCollectSub.loadData()
+
+        self.assertEqual(logCollectSub["type"], "LogCollect",
+                         "Error: Wrong subscription type.")
+        self.assertEqual(logCollectSub["split_algo"], "MinFileBased",
+                         "Error: Wrong split algorithm.")
+
+        alcaSkimLogCollect = Fileset(name="/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/unmerged-logArchive")
+        alcaSkimLogCollect.loadData()
+        alcaSkimLogCollectWorkflow = Workflow(name="TestWorkload",
+                                              task="/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/AlcaSkimLogCollect")
+        alcaSkimLogCollectWorkflow.load()
+        logCollectSub = Subscription(fileset=alcaSkimLogCollect, workflow=alcaSkimLogCollectWorkflow)
+        logCollectSub.loadData()
+
+        self.assertEqual(logCollectSub["type"], "LogCollect",
+                         "Error: Wrong subscription type.")
+        self.assertEqual(logCollectSub["split_algo"], "MinFileBased",
+                         "Error: Wrong split algorithm.")
+
+        goldenOutputMods = ["write_PrimaryDataset1_FEVT", "write_StreamExpress_DQMIO"]
+        for goldenOutputMod in goldenOutputMods:
+            expressMergeLogCollect = Fileset(name="/TestWorkload/Express/ExpressMerge%s/merged-logArchive" % goldenOutputMod)
+            expressMergeLogCollect.loadData()
+            expressMergeLogCollectWorkflow = Workflow(name="TestWorkload",
+                                                      task="/TestWorkload/Express/ExpressMerge%s/Express%sMergeLogCollect" % (goldenOutputMod, goldenOutputMod))
+            expressMergeLogCollectWorkflow.load()
+            logCollectSubscription = Subscription(fileset=expressMergeLogCollect, workflow=expressMergeLogCollectWorkflow)
+            logCollectSubscription.loadData()
+
+            self.assertEqual(logCollectSub["type"], "LogCollect",
+                             "Error: Wrong subscription type.")
+            self.assertEqual(logCollectSub["split_algo"], "MinFileBased",
+                             "Error: Wrong split algorithm.")
+
+        for dqmStrings in [("ExpressMergewrite_StreamExpress_DQMIOEndOfRunDQMHarvestMerged",
+                            "ExpressMergewrite_StreamExpress_DQMIOMergedEndOfRunDQMHarvestLogCollect"),
+                           ("ExpressMergewrite_StreamExpress_DQMIOPeriodicDQMHarvestMerged",
+                            "ExpressMergewrite_StreamExpress_DQMIOMergedPeriodicDQMHarvestLogCollect")]:
+
+            dqmFileset = "/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO/%s/unmerged-logArchive" % dqmStrings[0]
+            dqmHarvestLogCollect = Fileset(name=dqmFileset)
+            dqmHarvestLogCollect.loadData()
+
+            dqmTask = "/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO/%s/%s" % dqmStrings
+            dqmHarvestLogCollectWorkflow = Workflow(name="TestWorkload", task=dqmTask)
+            dqmHarvestLogCollectWorkflow.load()
+
+            logCollectSub = Subscription(fileset=dqmHarvestLogCollect, workflow=dqmHarvestLogCollectWorkflow)
+            logCollectSub.loadData()
+
+            self.assertEqual(logCollectSub["type"], "LogCollect",
+                             "Error: Wrong subscription type.")
+            self.assertEqual(logCollectSub["split_algo"], "MinFileBased",
+                             "Error: Wrong split algo.")
+
+        return
+
+
+    def testMemCoresSettings(self):
+        """
+        _testMemCoresSettings_
+
+        Make sure the multicore and memory setings are properly propagated to
+        all tasks and steps.
+        """
+        testArguments = ExpressWorkloadFactory.getTestArguments()
+        testArguments['ProcessingString'] = "Express"
+        testArguments['ProcessingVersion'] = 9
+        testArguments['Scenario'] = "test_scenario"
+        testArguments['CMSSWVersion'] = "CMSSW_9_0_0"
+        testArguments['ScramArch'] = "slc6_amd64_gcc530"
+        testArguments['RecoCMSSWVersion'] = "CMSSW_9_0_0"
+        testArguments['RecoScramArch'] = "slc6_amd64_gcc530"
+        testArguments['GlobalTag'] = "SomeGlobalTag"
+        testArguments['GlobalTagTransaction'] = "Express_123456"
+        testArguments['GlobalTagConnect'] = "frontier://PromptProd/CMS_CONDITIONS"
+        testArguments['MaxInputRate'] = 23 * 1000
+        testArguments['MaxInputEvents'] = 400
+        testArguments['MaxInputSize'] = 2 * 1024 * 1024 * 1024
+        testArguments['MaxInputFiles'] = 15
+        testArguments['MaxLatency'] = 15 * 23
+        testArguments['AlcaSkims'] = [ "TkAlMinBias", "PromptCalibProd" ]
+        testArguments['DQMSequences'] = [ "@common" ]
+        testArguments['AlcaHarvestTimeout'] = 12 * 3600
+        testArguments['AlcaHarvestDir'] = "/somepath"
+        testArguments['DQMUploadProxy'] = "/somepath/proxy"
+        testArguments['DQMUploadUrl'] = "https://cmsweb.cern.ch/dqm/offline"
+        testArguments['StreamName'] = "Express"
+        testArguments['SpecialDataset'] = "StreamExpress"
+
+        testArguments['RunNumber'] = 123456
+        testArguments['AcquisitionEra'] = "TestAcquisitionEra"
+        testArguments['ValidStatus'] = "VALID"
+
+        testArguments['Outputs'] = []
+        testArguments['Outputs'].append( { 'dataTier' : "FEVT",
+                                           'eventContent' : "FEVT",
+                                           'selectEvents' : ["Path1:HLT,Path2:HLT"],
+                                           'primaryDataset' : "PrimaryDataset1" } )
+        testArguments['Outputs'].append( { 'dataTier' : "ALCARECO",
+                                           'eventContent' : "ALCARECO",
+                                           'primaryDataset' : "StreamExpress" } )
+        testArguments['Outputs'].append( { 'dataTier' : "DQMIO",
+                                           'eventContent' : "DQMIO",
+                                           'primaryDataset' : "StreamExpress" } )
+
+        factory = ExpressWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
+
+        # test default values
+        taskPaths = ['/TestWorkload/Express', '/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO']
+        for task in taskPaths:
+            taskObj = testWorkload.getTaskByPath(task)
+            for step in ('cmsRun1', 'stageOut1', 'logArch1'):
+                stepHelper = taskObj.getStepHelper(step)
+                self.assertEqual(stepHelper.getNumberOfCores(), 1)
+                self.assertEqual(stepHelper.getNumberOfStreams(), 0)
+            # then test Memory requirements
+            perfParams = taskObj.jobSplittingParameters()['performance']
+            self.assertEqual(perfParams['memoryRequirement'], 2300.0)
+
+        # now test case where args are provided
+        testArguments = ExpressWorkloadFactory.getTestArguments()
+        testArguments['ProcessingString'] = "Express"
+        testArguments['ProcessingVersion'] = 9
+        testArguments['Scenario'] = "test_scenario"
+        testArguments['CMSSWVersion'] = "CMSSW_9_0_0"
+        testArguments['ScramArch'] = "slc6_amd64_gcc530"
+        testArguments['RecoCMSSWVersion'] = "CMSSW_9_0_0"
+        testArguments['RecoScramArch'] = "slc6_amd64_gcc530"
+        testArguments['GlobalTag'] = "SomeGlobalTag"
+        testArguments['GlobalTagTransaction'] = "Express_123456"
+        testArguments['GlobalTagConnect'] = "frontier://PromptProd/CMS_CONDITIONS"
+        testArguments['MaxInputRate'] = 23 * 1000
+        testArguments['MaxInputEvents'] = 400
+        testArguments['MaxInputSize'] = 2 * 1024 * 1024 * 1024
+        testArguments['MaxInputFiles'] = 15
+        testArguments['MaxLatency'] = 15 * 23
+        testArguments['AlcaSkims'] = [ "TkAlMinBias", "PromptCalibProd" ]
+        testArguments['DQMSequences'] = [ "@common" ]
+        testArguments['AlcaHarvestTimeout'] = 12 * 3600
+        testArguments['AlcaHarvestDir'] = "/somepath"
+        testArguments['DQMUploadProxy'] = "/somepath/proxy"
+        testArguments['DQMUploadUrl'] = "https://cmsweb.cern.ch/dqm/offline"
+        testArguments['StreamName'] = "Express"
+        testArguments['SpecialDataset'] = "StreamExpress"
+
+        testArguments['RunNumber'] = 123456
+        testArguments['AcquisitionEra'] = "TestAcquisitionEra"
+        testArguments['ValidStatus'] = "VALID"
+
+        testArguments['Outputs'] = []
+        testArguments['Outputs'].append( { 'dataTier' : "FEVT",
+                                           'eventContent' : "FEVT",
+                                           'selectEvents' : ["Path1:HLT,Path2:HLT"],
+                                           'primaryDataset' : "PrimaryDataset1" } )
+        testArguments['Outputs'].append( { 'dataTier' : "ALCARECO",
+                                           'eventContent' : "ALCARECO",
+                                           'primaryDataset' : "StreamExpress" } )
+        testArguments['Outputs'].append( { 'dataTier' : "DQMIO",
+                                           'eventContent' : "DQMIO",
+                                           'primaryDataset' : "StreamExpress" } )
+
+        testArguments["Multicore"] = 6
+        testArguments["Memory"] = 4600.0
+        testArguments["EventStreams"] = 3
+
+        factory = ExpressWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
+
+        for task in taskPaths:
+            taskObj = testWorkload.getTaskByPath(task)
+            for step in ('cmsRun1', 'stageOut1', 'logArch1'):
+                stepHelper = taskObj.getStepHelper(step)
+                if task == '/TestWorkload/Express' and step == 'cmsRun1':
+                    self.assertEqual(stepHelper.getNumberOfCores(), testArguments["Multicore"])
+                    self.assertEqual(stepHelper.getNumberOfStreams(), testArguments["EventStreams"])
+                elif step in ('stageOut1', 'logArch1'):
+                    self.assertEqual(stepHelper.getNumberOfCores(), 1)
+                    self.assertEqual(stepHelper.getNumberOfStreams(), 0)
+                else:
+                    self.assertEqual(stepHelper.getNumberOfCores(), 1, "%s should be single-core" % task)
+                    self.assertEqual(stepHelper.getNumberOfStreams(), 0)
+            # then test Memory requirements
+            perfParams = taskObj.jobSplittingParameters()['performance']
+            self.assertEqual(perfParams['memoryRequirement'], testArguments["Memory"])
+
+        return
+
+
+    def testWithRepackStep(self):
+        """
+        _testWithRepackStep_
+
+        Make sure we get an initial repack step if CMSSW versions are mismatched
+        """
+        testArguments = ExpressWorkloadFactory.getTestArguments()
+        testArguments['ProcessingString'] = "Express"
+        testArguments['ProcessingVersion'] = 9
+        testArguments['Scenario'] = "test_scenario"
+        testArguments['CMSSWVersion'] = "CMSSW_9_0_0"
+        testArguments['ScramArch'] = "slc6_amd64_gcc530"
+        testArguments['RecoCMSSWVersion'] = "CMSSW_9_0_1"
+        testArguments['RecoScramArch'] = "slc6_amd64_gcc630"
+        testArguments['GlobalTag'] = "SomeGlobalTag"
+        testArguments['GlobalTagTransaction'] = "Express_123456"
+        testArguments['GlobalTagConnect'] = "frontier://PromptProd/CMS_CONDITIONS"
+        testArguments['MaxInputRate'] = 23 * 1000
+        testArguments['MaxInputEvents'] = 400
+        testArguments['MaxInputSize'] = 2 * 1024 * 1024 * 1024
+        testArguments['MaxInputFiles'] = 15
+        testArguments['MaxLatency'] = 15 * 23
+        testArguments['AlcaSkims'] = [ "TkAlMinBias", "PromptCalibProd" ]
+        testArguments['DQMSequences'] = [ "@common" ]
+        testArguments['AlcaHarvestTimeout'] = 12 * 3600
+        testArguments['AlcaHarvestDir'] = "/somepath"
+        testArguments['DQMUploadProxy'] = "/somepath/proxy"
+        testArguments['DQMUploadUrl'] = "https://cmsweb.cern.ch/dqm/offline"
+        testArguments['StreamName'] = "Express"
+        testArguments['SpecialDataset'] = "StreamExpress"
+
+        testArguments['RunNumber'] = 123456
+        testArguments['AcquisitionEra'] = "TestAcquisitionEra"
+        testArguments['ValidStatus'] = "VALID"
+
+        testArguments['Outputs'] = []
+        testArguments['Outputs'].append( { 'dataTier' : "FEVT",
+                                           'eventContent' : "FEVT",
+                                           'selectEvents' : ["Path1:HLT,Path2:HLT"],
+                                           'primaryDataset' : "PrimaryDataset1" } )
+        testArguments['Outputs'].append( { 'dataTier' : "ALCARECO",
+                                           'eventContent' : "ALCARECO",
+                                           'primaryDataset' : "StreamExpress" } )
+        testArguments['Outputs'].append( { 'dataTier' : "DQMIO",
+                                           'eventContent' : "DQMIO",
+                                           'primaryDataset' : "StreamExpress" } )
+
+        factory = ExpressWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
+
+        taskObj = testWorkload.getTaskByPath('/TestWorkload/Express')
+
+        stepHelper = taskObj.getStepHelper('cmsRun1')
+        self.assertEqual(stepHelper.getScenario(), "test_scenario")
+        self.assertEqual(stepHelper.getCMSSWVersion(), "CMSSW_9_0_0")
+        self.assertEqual(stepHelper.getScramArch(), ["slc6_amd64_gcc530"])
+
+        stepHelper = taskObj.getStepHelper('cmsRun2')
+        self.assertEqual(stepHelper.getScenario(), "test_scenario")
+        self.assertEqual(stepHelper.getCMSSWVersion(), "CMSSW_9_0_1")
+        self.assertEqual(stepHelper.getScramArch(), ["slc6_amd64_gcc630"])
+
+        return
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Repack_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Repack_t.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python
+"""
+_Repack_t_
+
+Unit tests for the Tier0 Repack workflow.
+"""
+
+from __future__ import division
+
+import unittest
+
+from WMCore.WMBS.Fileset import Fileset
+from WMCore.WMBS.Subscription import Subscription
+from WMCore.WMBS.Workflow import Workflow
+
+from WMCore.WorkQueue.WMBSHelper import WMBSHelper
+from WMCore.WMSpec.StdSpecs.Repack import RepackWorkloadFactory
+
+from WMQuality.TestInitCouchApp import TestInitCouchApp
+
+
+class Repack(unittest.TestCase):
+    def setUp(self):
+        """
+        _setUp_
+
+        Initialize the database and couch.
+        """
+        self.testInit = TestInitCouchApp(__file__)
+        self.testInit.setLogging()
+        self.testInit.setDatabaseConnection()
+        self.testInit.setSchema(customModules=["WMCore.WMBS"],
+                                useDefault=False)
+        self.testDir = self.testInit.generateWorkDir()
+        return
+
+    def tearDown(self):
+        """
+        _tearDown_
+
+        Clear out the database.
+        """
+        self.testInit.clearDatabase()
+        self.testInit.delWorkDir()
+        return
+
+
+    def testRepack(self):
+        """
+        _testRepack_
+
+        Create a Repack workflow
+        and verify it installs into WMBS correctly.
+        """
+        testArguments = RepackWorkloadFactory.getTestArguments()
+        testArguments['MaxSizeSingleLumi'] = 12 * 1024 * 1024 * 1024
+        testArguments['MaxSizeMultiLumi'] = 8 * 1024 * 1024 * 1024
+        testArguments['MinInputSize'] = 2.1 * 1024 * 1024 * 1024
+        testArguments['MaxInputSize'] = 4 * 1024 * 1024 * 1024
+        testArguments['MaxEdmSize'] = 12 * 1024 * 1024 * 1024
+        testArguments['MaxOverSize'] = 8 * 1024 * 1024 * 1024
+        testArguments['MaxInputEvents'] = 3 * 1000 * 1000
+        testArguments['MaxInputFiles'] = 1000
+        testArguments['MaxLatency'] = 24 * 3600
+        testArguments['MinMergeSize'] = 2.1 * 1024 * 1024 * 1024
+        testArguments['MaxMergeEvents'] = 3 * 1000 * 1000
+        testArguments['RunNumber'] = 123456
+        testArguments['AcquisitionEra'] = "TestAcquisitionEra"
+        testArguments['ValidStatus'] = "VALID"
+
+        testArguments['Outputs'] = []
+        testArguments['Outputs'].append( { 'dataTier' : "RAW",
+                                           'eventContent' : "All",
+                                           'selectEvents' : ["Path1:HLT,Path2:HLT"],
+                                           'primaryDataset' : "PrimaryDataset1" } )
+        testArguments['Outputs'].append( { 'dataTier' : "RAW",
+                                           'eventContent' : "All",
+                                           'selectEvents' : ["Path3:HLT,Path4:HLT"],
+                                           'primaryDataset' : "PrimaryDataset2" } )
+
+        factory = RepackWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
+        testWorkload.setSpecUrl("somespec")
+        testWorkload.setOwnerDetails("Dirk.Hufnagel@cern.ch", "T0")
+
+        testWMBSHelper = WMBSHelper(testWorkload, "Repack", cachepath=self.testDir)
+        testWMBSHelper.createTopLevelFileset()
+        testWMBSHelper._createSubscriptionsInWMBS(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
+
+        repackWorkflow = Workflow(name="TestWorkload",
+                                  task="/TestWorkload/Repack")
+        repackWorkflow.load()
+        self.assertEqual(len(repackWorkflow.outputMap.keys()), len(testArguments["Outputs"]) + 1,
+                         "Error: Wrong number of WF outputs in the Repack WF.")
+
+        goldenOutputMods = ["write_PrimaryDataset1_RAW", "write_PrimaryDataset2_RAW"]
+        for goldenOutputMod in goldenOutputMods:
+            mergedOutput = repackWorkflow.outputMap[goldenOutputMod][0]["merged_output_fileset"]
+            unmergedOutput = repackWorkflow.outputMap[goldenOutputMod][0]["output_fileset"]
+            mergedOutput.loadData()
+            unmergedOutput.loadData()
+
+            if goldenOutputMod != "write_PrimaryDataset1_RAW":
+                self.assertEqual(mergedOutput.name, "/TestWorkload/Repack/RepackMerge%s/merged-Merged" % goldenOutputMod,
+                                 "Error: Merged output fileset is wrong: %s" % mergedOutput.name)
+            self.assertEqual(unmergedOutput.name, "/TestWorkload/Repack/unmerged-%s" % goldenOutputMod,
+                             "Error: Unmerged output fileset is wrong: %s" % unmergedOutput.name)
+
+        logArchOutput = repackWorkflow.outputMap["logArchive"][0]["merged_output_fileset"]
+        unmergedLogArchOutput = repackWorkflow.outputMap["logArchive"][0]["output_fileset"]
+        logArchOutput.loadData()
+        unmergedLogArchOutput.loadData()
+
+        self.assertEqual(logArchOutput.name, "/TestWorkload/Repack/unmerged-logArchive",
+                         "Error: LogArchive output fileset is wrong.")
+        self.assertEqual(unmergedLogArchOutput.name, "/TestWorkload/Repack/unmerged-logArchive",
+                         "Error: LogArchive output fileset is wrong.")
+
+        goldenOutputMods = ["write_PrimaryDataset1_RAW", "write_PrimaryDataset2_RAW"]
+        for goldenOutputMod in goldenOutputMods:
+            mergeWorkflow = Workflow(name="TestWorkload",
+                                     task="/TestWorkload/Repack/RepackMerge%s" % goldenOutputMod)
+            mergeWorkflow.load()
+
+            self.assertEqual(len(mergeWorkflow.outputMap.keys()), 3,
+                             "Error: Wrong number of WF outputs.")
+
+            mergedMergeOutput = mergeWorkflow.outputMap["Merged"][0]["merged_output_fileset"]
+            unmergedMergeOutput = mergeWorkflow.outputMap["Merged"][0]["output_fileset"]
+
+            mergedMergeOutput.loadData()
+            unmergedMergeOutput.loadData()
+
+            self.assertEqual(mergedMergeOutput.name, "/TestWorkload/Repack/RepackMerge%s/merged-Merged" % goldenOutputMod,
+                             "Error: Merged output fileset is wrong.")
+            self.assertEqual(unmergedMergeOutput.name, "/TestWorkload/Repack/RepackMerge%s/merged-Merged" % goldenOutputMod,
+                             "Error: Unmerged output fileset is wrong.")
+
+            logArchOutput = mergeWorkflow.outputMap["logArchive"][0]["merged_output_fileset"]
+            unmergedLogArchOutput = mergeWorkflow.outputMap["logArchive"][0]["output_fileset"]
+            logArchOutput.loadData()
+            unmergedLogArchOutput.loadData()
+
+            self.assertEqual(logArchOutput.name, "/TestWorkload/Repack/RepackMerge%s/merged-logArchive" % goldenOutputMod,
+                             "Error: LogArchive output fileset is wrong: %s" % logArchOutput.name)
+            self.assertEqual(unmergedLogArchOutput.name, "/TestWorkload/Repack/RepackMerge%s/merged-logArchive" % goldenOutputMod,
+                             "Error: LogArchive output fileset is wrong.")
+
+        topLevelFileset = Fileset(name="TestWorkload-Repack")
+        topLevelFileset.loadData()
+
+        repackSubscription = Subscription(fileset=topLevelFileset, workflow=repackWorkflow)
+        repackSubscription.loadData()
+
+        self.assertEqual(repackSubscription["type"], "Repack",
+                         "Error: Wrong subscription type.")
+        self.assertEqual(repackSubscription["split_algo"], "Repack",
+                         "Error: Wrong split algorithm. %s" % repackSubscription["split_algo"])
+
+        unmergedOutputs = ["write_PrimaryDataset1_RAW", "write_PrimaryDataset2_RAW"]
+        for unmergedOutput in unmergedOutputs:
+            unmergedDataTier = Fileset(name="/TestWorkload/Repack/unmerged-%s" % unmergedOutput)
+            unmergedDataTier.loadData()
+            dataTierMergeWorkflow = Workflow(name="TestWorkload",
+                                             task="/TestWorkload/Repack/RepackMerge%s" % unmergedOutput)
+            dataTierMergeWorkflow.load()
+            mergeSubscription = Subscription(fileset=unmergedDataTier, workflow=dataTierMergeWorkflow)
+            mergeSubscription.loadData()
+
+            self.assertEqual(mergeSubscription["type"], "Merge",
+                             "Error: Wrong subscription type.")
+            self.assertEqual(mergeSubscription["split_algo"], "RepackMerge",
+                             "Error: Wrong split algorithm. %s" % mergeSubscription["split_algo"])
+
+        goldenOutputMods = ["write_PrimaryDataset1_RAW", "write_PrimaryDataset2_RAW"]
+        for goldenOutputMod in goldenOutputMods:
+            unmergedFileset = Fileset(name="/TestWorkload/Repack/unmerged-%s" % goldenOutputMod)
+            unmergedFileset.loadData()
+            cleanupWorkflow = Workflow(name="TestWorkload",
+                                       task="/TestWorkload/Repack/RepackCleanupUnmerged%s" % goldenOutputMod)
+            cleanupWorkflow.load()
+            cleanupSubscription = Subscription(fileset=unmergedFileset, workflow=cleanupWorkflow)
+            cleanupSubscription.loadData()
+
+            self.assertEqual(cleanupSubscription["type"], "Cleanup",
+                             "Error: Wrong subscription type.")
+            self.assertEqual(cleanupSubscription["split_algo"], "SiblingProcessingBased",
+                             "Error: Wrong subscription type.")
+
+        repackLogCollect = Fileset(name="/TestWorkload/Repack/unmerged-logArchive")
+        repackLogCollect.loadData()
+        repackLogCollectWorkflow = Workflow(name="TestWorkload",
+                                          task="/TestWorkload/Repack/LogCollect")
+        repackLogCollectWorkflow.load()
+        logCollectSub = Subscription(fileset=repackLogCollect, workflow=repackLogCollectWorkflow)
+        logCollectSub.loadData()
+
+        self.assertEqual(logCollectSub["type"], "LogCollect",
+                         "Error: Wrong subscription type.")
+        self.assertEqual(logCollectSub["split_algo"], "MinFileBased",
+                         "Error: Wrong split algorithm.")
+
+        goldenOutputMods = ["write_PrimaryDataset1_RAW", "write_PrimaryDataset2_RAW"]
+        for goldenOutputMod in goldenOutputMods:
+            repackMergeLogCollect = Fileset(name="/TestWorkload/Repack/RepackMerge%s/merged-logArchive" % goldenOutputMod)
+            repackMergeLogCollect.loadData()
+            repackMergeLogCollectWorkflow = Workflow(name="TestWorkload",
+                                                     task="/TestWorkload/Repack/RepackMerge%s/Repack%sMergeLogCollect" % (goldenOutputMod, goldenOutputMod))
+            repackMergeLogCollectWorkflow.load()
+            logCollectSubscription = Subscription(fileset=repackMergeLogCollect, workflow=repackMergeLogCollectWorkflow)
+            logCollectSubscription.loadData()
+
+            self.assertEqual(logCollectSub["type"], "LogCollect",
+                             "Error: Wrong subscription type.")
+            self.assertEqual(logCollectSub["split_algo"], "MinFileBased",
+                             "Error: Wrong split algorithm.")
+
+        return
+
+
+    def testMemCoresSettings(self):
+        """
+        _testMemCoresSettings_
+        
+        Make sure the multicore and memory setings are properly propagated to
+        all tasks and steps.
+        """
+        testArguments = RepackWorkloadFactory.getTestArguments()
+        testArguments['MaxSizeSingleLumi'] = 12 * 1024 * 1024 * 1024
+        testArguments['MaxSizeMultiLumi'] = 8 * 1024 * 1024 * 1024
+        testArguments['MinInputSize'] = 2.1 * 1024 * 1024 * 1024
+        testArguments['MaxInputSize'] = 4 * 1024 * 1024 * 1024
+        testArguments['MaxEdmSize'] = 12 * 1024 * 1024 * 1024
+        testArguments['MaxOverSize'] = 8 * 1024 * 1024 * 1024
+        testArguments['MaxInputEvents'] = 3 * 1000 * 1000
+        testArguments['MaxInputFiles'] = 1000
+        testArguments['MaxLatency'] = 24 * 3600
+        testArguments['MinMergeSize'] = 2.1 * 1024 * 1024 * 1024
+        testArguments['MaxMergeEvents'] = 3 * 1000 * 1000
+        testArguments['RunNumber'] = 123456
+        testArguments['AcquisitionEra'] = "TestAcquisitionEra"
+        testArguments['ValidStatus'] = "VALID"
+
+        testArguments['Outputs'] = []
+        testArguments['Outputs'].append( { 'dataTier' : "RAW",
+                                           'eventContent' : "All",
+                                           'selectEvents' : ["Path1:HLT,Path2:HLT"],
+                                           'primaryDataset' : "PrimaryDataset1" } )
+        testArguments['Outputs'].append( { 'dataTier' : "RAW",
+                                           'eventContent' : "All",
+                                           'selectEvents' : ["Path3:HLT,Path4:HLT"],
+                                           'primaryDataset' : "PrimaryDataset2" } )
+
+        factory = RepackWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
+
+        # test default values
+        taskPaths = ['/TestWorkload/Repack']
+        for task in taskPaths:
+            taskObj = testWorkload.getTaskByPath(task)
+            for step in ('cmsRun1', 'stageOut1', 'logArch1'):
+                stepHelper = taskObj.getStepHelper(step)
+                self.assertEqual(stepHelper.getNumberOfCores(), 1)
+                self.assertEqual(stepHelper.getNumberOfStreams(), 0)
+            # then test Memory requirements
+            perfParams = taskObj.jobSplittingParameters()['performance']
+            self.assertEqual(perfParams['memoryRequirement'], 2300.0)
+
+        # now test case where args are provided
+        testArguments = RepackWorkloadFactory.getTestArguments()
+        testArguments['MaxSizeSingleLumi'] = 12 * 1024 * 1024 * 1024
+        testArguments['MaxSizeMultiLumi'] = 8 * 1024 * 1024 * 1024
+        testArguments['MinInputSize'] = 2.1 * 1024 * 1024 * 1024
+        testArguments['MaxInputSize'] = 4 * 1024 * 1024 * 1024
+        testArguments['MaxEdmSize'] = 12 * 1024 * 1024 * 1024
+        testArguments['MaxOverSize'] = 8 * 1024 * 1024 * 1024
+        testArguments['MaxInputEvents'] = 3 * 1000 * 1000
+        testArguments['MaxInputFiles'] = 1000
+        testArguments['MaxLatency'] = 24 * 3600
+        testArguments['MinMergeSize'] = 2.1 * 1024 * 1024 * 1024
+        testArguments['MaxMergeEvents'] = 3 * 1000 * 1000
+        testArguments['RunNumber'] = 123456
+        testArguments['AcquisitionEra'] = "TestAcquisitionEra"
+        testArguments['ValidStatus'] = "VALID"
+
+        testArguments['Outputs'] = []
+        testArguments['Outputs'].append( { 'dataTier' : "RAW",
+                                           'eventContent' : "All",
+                                           'selectEvents' : ["Path1:HLT,Path2:HLT"],
+                                           'primaryDataset' : "PrimaryDataset1" } )
+        testArguments['Outputs'].append( { 'dataTier' : "RAW",
+                                           'eventContent' : "All",
+                                           'selectEvents' : ["Path3:HLT,Path4:HLT"],
+                                           'primaryDataset' : "PrimaryDataset2" } )
+
+        testArguments["Multicore"] = 6
+        testArguments["Memory"] = 4600.0
+        testArguments["EventStreams"] = 3
+
+        factory = RepackWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
+
+        for task in taskPaths:
+            taskObj = testWorkload.getTaskByPath(task)
+            for step in ('cmsRun1', 'stageOut1', 'logArch1'):
+                stepHelper = taskObj.getStepHelper(step)
+                if task == '/TestWorkload/Repack' and step == 'cmsRun1':
+                    self.assertEqual(stepHelper.getNumberOfCores(), testArguments["Multicore"])
+                    self.assertEqual(stepHelper.getNumberOfStreams(), testArguments["EventStreams"])
+                elif step in ('stageOut1', 'logArch1'):
+                    self.assertEqual(stepHelper.getNumberOfCores(), 1)
+                    self.assertEqual(stepHelper.getNumberOfStreams(), 0)
+                else:
+                    self.assertEqual(stepHelper.getNumberOfCores(), 1, "%s should be single-core" % task)
+                    self.assertEqual(stepHelper.getNumberOfStreams(), 0)
+            # then test Memory requirements
+            perfParams = taskObj.jobSplittingParameters()['performance']
+            self.assertEqual(perfParams['memoryRequirement'], testArguments["Memory"])
+
+        return
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Also change the whole parameter setup so it passes the WMCore validation. Add Repack and Express spec unit tests as well.

The Repack unit test is ok. The Express has problems, but I need feedback on it. In Express there is a TaskChain and AlcaSkim follows Express. AlcaSkim only uses one core, but seems to inherit the number of streams setting from Express, which it should not. I likely have to change something in the Express spec to fix this. Any suggestions ?

Another issue, if you check the last Express unit test, the cmsswVersion for step cmsRun1 is a list with a single entry while the cmsswVersion for step cmsRun2 is a string. This seems to work, but also seems wrong and should be fixed in the spec. Suggestions welcome as well.

@amaltaro @ticoann , please comment.