### PR TITLE
Fix to jobsByChildQueue workqueue views; WQ monitoring data reformat

### DIFF
--- a/src/python/WMCore/Services/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/Services/WorkQueue/WorkQueue.py
@@ -93,7 +93,8 @@ class WorkQueue(object):
         data = self.db.loadView('WorkQueue', 'jobsByChildQueueAndStatus', options)
         result = {}
         for x in data.get('rows', []):
-            result[x['key'][0]] = {x['key'][1]: x['value']}
+            result.setdefault(x['key'][0], {})
+            result[x['key'][0]][x['key'][1]] = x['value']
 
         return result
 
@@ -108,7 +109,8 @@ class WorkQueue(object):
         data = self.db.loadView('WorkQueue', 'jobsByChildQueueAndPriority', options)
         result = {}
         for x in data.get('rows', []):
-            result[x['key'][0]] = {x['key'][1]: x['value']}
+            result.setdefault(x['key'][0], {})
+            result[x['key'][0]][x['key'][1]] = x['value']
 
         return result
 


### PR DESCRIPTION
and Reformat workqueue monitoring information

Fixes #7847

@stiegerb noticed we had only one priority dict per agent (the last one), this is what this PR really fixes.
Then on top of that, I've changed the data format for most of the workqueue monitoring information such that the real value we want to query for are in a value field instead of a key. E.g.:
```
"workByAgentAndPriority": {
    "http://vocms0309.cern.ch:5984": {
           "900000": {
               "count": 1,
               "min": 39374,
               "max": 39374,
               "sum": 39374,
               "sumsqr": 1550311876
           }
       },
```

should become
```
"workByAgentAndPriority": [
    {
        "agent_name": "vocms0309",
        "priority": "900000"
        "count": 1,
        "min": 39374,
        "max": 39374,
        "sum": 39374,
        "sumsqr": 1550311876
    },
```

Benjamin will still have to break that up into several smaller docs before pushing that into stompAMQ, but at least it should be a bit easier now and it will also be helpful once we start injecting data directly into stompAMQ.

@ticoann @stiegerb @vkuznet can you please review it.
Still needs to be tested.