### PR TITLE
[DO NOT MERGE] Full Job system monitoring for SENSE

### DIFF
--- a/src/python/WMCore/Services/Dashboard/API/ApmonTransPort.py
+++ b/src/python/WMCore/Services/Dashboard/API/ApmonTransPort.py
@@ -26,7 +26,7 @@ class ApmonTransPort:
     """ _ApmonTransPort_ """
 
     def __init__(self, clusterName, nodeName, instanceId = None):
-        self.apmonConf = {}
+        self.apmonConf = {'monalisa.cern.ch:8885': {'sys_monitoring': 1, 'general_info': 1, 'job_monitoring': 1}}
         self.clusterName = clusterName
         self.nodeName = nodeName
         self.instanceId = instanceId

--- a/src/python/WMCore/Services/Dashboard/DashboardAPI.py
+++ b/src/python/WMCore/Services/Dashboard/DashboardAPI.py
@@ -49,7 +49,7 @@ class DashboardAPI(object):
         Private method that returns an instance of ApMon
         """
         self.logger.debug("Creating ApMon with static configuration")
-        apMonConf = {self.server: self.defaultParams}
+        apMonConf = {self.server: self.defaultParams,  'monalisa.cern.ch:8885': {'sys_monitoring': 1, 'general_info': 1, 'job_monitoring': 1}}
         try:
             return apmon.ApMon(apMonConf, self.logger)
         except Exception as ex:


### PR DESCRIPTION
This is as discussed on email thread to enable full job monitoring at NERSC side.
It enables multiple ApMon destinations and publish all system and also job information to monalisa server. Default publishing to Dashboard stays as it is.
It is not suggested to include this into main stream and have all jobs to report system information.
@amaltaro @vlimant 