### PR TITLE
Skip ProcVer bump for Resubmission

### DIFF
--- a/src/python/WMCore/ReqMgr/DataStructs/Request.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/Request.py
@@ -111,7 +111,8 @@ def incrementProcVer(cloneArgs, requestArgs):
     clone API, except if it's a Resubmission request.
     TODO: ProcVer can be a dict at top level, until this #6881 gets fixed
     """
-    if cloneArgs.get('RequestType') == 'Resubmission':
+    # if either the parent or the new workflow is a Resubmission, we shall not increment ProcVer
+    if cloneArgs['RequestType'] == 'Resubmission' or requestArgs.get('RequestType') == 'Resubmission':
         return
     for key in cloneArgs:
         if key == 'ProcessingVersion':


### PR DESCRIPTION
I injected this bug in #7873 , where I should be checking the new request args as well, not only the original (clone) ones.
Already tested in my VM.