### PR TITLE
Fix to jobsByChildQueue workqueue views; WQ monitoring data reformat - wmagent branch

### DIFF
--- a/src/python/WMCore/Services/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/Services/WorkQueue/WorkQueue.py
@@ -93,7 +93,8 @@ class WorkQueue(object):
         data = self.db.loadView('WorkQueue', 'jobsByChildQueueAndStatus', options)
         result = {}
         for x in data.get('rows', []):
-            result[x['key'][0]] = {x['key'][1]: x['value']}
+            result.setdefault(x['key'][0], {})
+            result[x['key'][0]][x['key'][1]] = x['value']
 
         return result
 
@@ -108,7 +109,8 @@ class WorkQueue(object):
         data = self.db.loadView('WorkQueue', 'jobsByChildQueueAndPriority', options)
         result = {}
         for x in data.get('rows', []):
-            result[x['key'][0]] = {x['key'][1]: x['value']}
+            result.setdefault(x['key'][0], {})
+            result[x['key'][0]][x['key'][1]] = x['value']
 
         return result
 


### PR DESCRIPTION
wmagent branch version of #7893
We'll likely have to patch the agents to avoid having two different monitoring data format when we migrate to the new verrsion.