### PR TITLE
fix dashboard activity for tier0

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/Express.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Express.py
@@ -16,7 +16,7 @@ from __future__ import division
 import WMCore.WMSpec.Steps.StepFactory as StepFactory
 
 from Utils.Utilities import makeList, makeNonEmptyList
-from WMCore.Lexicon import procstringT0
+from WMCore.Lexicon import procstringT0, activity
 
 from WMCore.ReqMgr.Tools.cms import releases, architectures
 
@@ -493,7 +493,7 @@ class ExpressWorkloadFactory(StdBase):
                     "MaxInputSize": {"type": int, "optional": False},
                     "MaxInputFiles": {"type": int, "optional": False},
                     "MaxLatency": {"type": int, "optional": False},
-
+                    "Dashboard": {"default": "tier0", "type": str, "validate": activity}
                     }
         baseArgs.update(specArgs)
         StdBase.setDefaultArgumentsProperty(baseArgs)

--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -6,7 +6,7 @@ Standard PromptReco workflow.
 """
 
 from Utils.Utilities import makeList, strToBool
-from WMCore.Lexicon import procstringT0
+from WMCore.Lexicon import procstringT0, activity
 from WMCore.WMSpec.StdSpecs.DataProcessing import DataProcessing
 
 
@@ -192,7 +192,8 @@ class PromptRecoWorkloadFactory(DataProcessing):
                     "SkimFilesPerJob" : {"default" : 1, "type" : int, "validate" : lambda x : x > 0,
                                          "null" : False},
                     "BlockCloseDelay" : {"default" : 86400, "type" : int, "validate" : lambda x : x > 0,
-                                         "null" : False}
+                                         "null" : False},
+                    "Dashboard": {"default": "tier0", "type": str, "validate": activity}
                     }
 
         baseArgs.update(specArgs)

--- a/src/python/WMCore/WMSpec/StdSpecs/Repack.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Repack.py
@@ -11,7 +11,7 @@ repacking -> RAW -> optional merge
 from __future__ import division
 
 from Utils.Utilities import makeList
-from WMCore.Lexicon import procstringT0
+from WMCore.Lexicon import procstringT0, activity
 
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
 
@@ -205,6 +205,7 @@ class RepackWorkloadFactory(StdBase):
                     "MaxInputSize": {"type": int, "optional": False},
                     "MaxEdmSize": {"type": int, "optional": False},
                     "MaxOverSize": {"type": int, "optional": False},
+                    "Dashboard": {"default": "tier0", "type": str, "validate": activity}
                     }
         baseArgs.update(specArgs)
         StdBase.setDefaultArgumentsProperty(baseArgs)


### PR DESCRIPTION
@hufnagel, Dirk please review. 


Jen found out that Tier0 workflows are reported as “production” activity in dashboard.

http://dashb-cms-job.cern.ch/dashboard/templates/web-job2/#user=&refresh=60&table=Jobs&p=1&records=25&activemenu=1&usr=&site=&submissiontool=&application=&activity=production&status=&check=submitted&tier=&date1=2017-06-08+19%3A53&date2=2017-06-09+19%3A53&sortby=task&scale=linear&bars=20&ce=&rb=&grid=&jobtype=&submissionui=&dataset=&submissiontype=&task=&subtoolver=&genactivity=&outputse=&appexitcode=&accesstype=&inputse=&cores=


It seems it is hard coded for express, repack and promptreco.
https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/WMSpec/StdSpecs/Express.py#L51
https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/WMSpec/StdSpecs/Repack.py#L46
https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py#L34

But it gets overwritten in assignment stage.
