### PR TITLE
Auto-detect drain mode at WorkQueueManager level

### DIFF
--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -732,10 +732,6 @@ class WorkQueue(WorkQueueBase):
             msg = 'Backend busy or down: skipping work pull'
             self._printLog(msg, printFlag, "warning")
             return False
-        if self.params['DrainMode']:
-            msg = 'Draining queue: skipping work pull'
-            self._printLog(msg, printFlag, "warning")
-            return False
 
         left_over = self.parent_queue.getElements('Negotiating', returnIdOnly=True,
                                                   ChildQueueUrl=self.params['QueueURL'])


### PR DESCRIPTION
Complement of #7731 (WorkQueueManager part)

I still have to figure how to handle the `getWMBSInjectionStatus` method, which is called from WorkQueueManager and from JobArchiverPoller. They create a queue instance and that no longer changes (and this method checks the DrainMode attr). We could pass the DrainMode value to this method, or we could override that attr in case it changed. I don't know what's the cleanest way of doing that.