### PR TITLE
Fail jobs with exit code 8023 or 8026

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -242,7 +242,7 @@ config.ErrorHandler.logLevel = globalLogLevel
 config.ErrorHandler.maxRetries = maxJobRetries
 config.ErrorHandler.pollInterval = 240
 config.ErrorHandler.readFWJR = True
-config.ErrorHandler.failureExitCodes = [50660, 50661, 50664, 71102]
+config.ErrorHandler.failureExitCodes = [8023, 8026, 50660, 50661, 50664, 71102]
 config.ErrorHandler.maxFailTime = 120000
 config.ErrorHandler.maxProcessSize = 30
 


### PR DESCRIPTION
Fixes #7907 and #7901 (for the new agent only)

@vlimant I also noticed we fail jobs - in the RelVal agent only - that are Running for too long (71304), following this timeout:
https://github.com/dmwm/WMCore/blob/master/etc/WMAgentConfig.py#L228

Should we a) keep that, b) add to all the other agents or c) remove that tweak for the relval agent?