### PR TITLE
more fine-grained options to force unmerged and use them in PromptReco

### DIFF
--- a/src/python/WMCore/WMExceptions.py
+++ b/src/python/WMCore/WMExceptions.py
@@ -165,8 +165,7 @@ WM_JOB_ERROR_CODES = {-1: "Error return without specification.",
                       60322: "User is not authorized to write to destination site.", # (To be used in CRAB3/ASO)
                       60323: "User quota exceeded.", # (To be used in CRAB3/ASO)
                       60324: "Other stageout exception.", # (To be used in CRAB3/ASO)
-                      60401: "Failure to assemble LFN in direct-to-merge by size (WMAgent).", # (WMA)
-                      60402: "Failure to assemble LFN in direct-to-merge by event (WMAgent).", # (WMA)
+                      60401: "Failure to assemble LFN in direct-to-merge (WMAgent).", # (WMA)
                       60403: "Timeout during files stage out.", # (WMA, CRAB3)
                       60404: "Timeout during staging of log archives- status unknown (WMAgent).", # (WMA)
                       60405: "General failure to stage out log archives (WMAgent).", # (WMA)
@@ -235,6 +234,7 @@ WM_JOB_ERROR_CODES = {-1: "Error return without specification.",
 # 60313: "Failed to delete the output from the previous run via lcg-del command.", # Mh.. only lcg-del? Not used
 # 60314: "Failed to invoke ProdAgent StageOut Script.", Not used
 # 60316: "Failed to create a directory on the SE.", Not used
+# 60402: "Failure to assemble LFN in direct-to-merge by event (WMAgent).", # (WMA)
 # 60406: "Failure in staging in log files during log collection (WMAgent).", Not used
 # 60410: "Failure in deleting log files in log collection (WMAgent).", # Not used
 # 60411: "Timeout in deleting log files in log collection (WMAgent).", # Not used

--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -61,7 +61,7 @@ class PromptRecoWorkloadFactory(DataProcessing):
                                                splitAlgo = self.procJobSplitAlgo,
                                                splitArgs = self.procJobSplitArgs,
                                                stepType = cmsswStepType,
-                                               forceUnmerged = True)
+                                               forceUnmerged = ["write_ALCARECO"] if 'ALCARECO' in self.writeTiers else False)
         if self.doLogCollect:
             self.addLogCollectTask(recoTask)
 

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -393,10 +393,12 @@ class StdBase(object):
 
         if forceMerged:
             procTaskStageHelper.setMinMergeSize(0, 0)
-        elif forceUnmerged:
+        elif forceUnmerged and not isinstance(forceUnmerged, list):
             procTaskStageHelper.disableStraightToMerge()
         else:
             procTaskStageHelper.setMinMergeSize(self.minMergeSize, self.maxMergeEvents)
+            if forceUnmerged and isinstance(forceUnmerged, list):
+                procTaskStageHelper.disableStraightToMergeForOutputModules(forceUnmerged)
 
         procTaskCmsswHelper.cmsswSetup(cmsswVersion,
                                        softwareEnvironment="",

--- a/src/python/WMCore/WMSpec/Steps/Templates/StageOut.py
+++ b/src/python/WMCore/WMSpec/Steps/Templates/StageOut.py
@@ -48,6 +48,16 @@ class StageOutStepHelper(CoreHelper):
 
         return
 
+    def disableStraightToMergeForOutputModules(self, outputModules):
+        """
+        _disableStraightToMergeForOutputModules_
+
+        Disable straight to merge only for these output modules.
+        """
+        self.data.output.forceUnmergedOutputs = outputModules
+
+        return
+
     def setMinMergeSize(self, minMergeSize, maxMergeEvents):
         """
         _setMinMergeSize_
@@ -76,7 +86,6 @@ class StageOut(Template):
     """
 
     def install(self, step):
-        stepname = nodeName(step)
         step.stepType = "StageOut"
         step.section_("files")
         step.filecount = 0


### PR DESCRIPTION
Allowing to override all outputs to either merged or unmerged is not enough. Add a way to go with the default (straight to merge enabled for all outputs) but force specific output modules to always write unmerged. Use this to force PromptReco to write ALCARECO output always unmerged.

@ticoann @amaltaro please review. This super-seeds #6994, which was a much more invasive way to accomplish the same thing.