### PR TITLE
Accept plain list of lumis in the Run object

### DIFF
--- a/src/python/WMCore/DataStructs/Run.py
+++ b/src/python/WMCore/DataStructs/Run.py
@@ -157,13 +157,21 @@ class Run(WMObject):
         Method to replace myRun.lumis.extend() which does not work with the property
         """
         for lumi in lumiList:
-            if isinstance(lumi, (list, tuple)) and lumi[0] in self.eventsPerLumi and self.eventsPerLumi[lumi[0]]:
-                self.eventsPerLumi[lumi[0]] += lumi[1]  # Already exists, add events
-            elif isinstance(lumi, (list, tuple)):  # Doesn't exist or is 0 or None
-                self.eventsPerLumi[lumi[0]] = lumi[1]
-            else:  # Just given lumis, not events
-                if lumi not in self.eventsPerLumi:  # Don't overwrite existing events
-                    self.eventsPerLumi[lumi] = None
+            if not isinstance(lumi, (list, tuple)):  # comma separated lumi numbers
+                self.eventsPerLumi[lumi] = None
+            else:
+                if isinstance(lumi, list) and not isinstance(lumi[0], tuple):  # then it's a plain list
+                    for l in lumi:
+                        self.eventsPerLumi[l] = None
+                else:
+                    if isinstance(lumi, tuple):  # it's an unpacked list of tuples
+                        lumi = [(lumi)]
+                    # it's a list/tuple of tuples
+                    for tp in lumi:
+                        if tp[0] in self.eventsPerLumi and self.eventsPerLumi[tp[0]]:
+                            self.eventsPerLumi[tp[0]] += tp[1]  # Already exists, add events
+                        else:  # Doesn't exist or is 0 or None
+                            self.eventsPerLumi[tp[0]] = tp[1]
 
     def appendLumi(self, lumi):
         """
@@ -176,7 +184,7 @@ class Run(WMObject):
         else:  # Just given lumis, not events
             if lumi not in self.eventsPerLumi:  # Don't overwrite existing events
                 self.eventsPerLumi[lumi] = None
-    
+
     def getEventsByLumi(self, lumi):
         """
         getter to select event counts by given lumi

--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -375,7 +375,7 @@ class WorkQueue(WorkQueueBase):
                     self.logdb.delete(wmspec.name(), "error", this_thread=True)
                 except Exception as ex:
                     msg = "%s, %s: \ncreating subscription failed in LQ: \n%s" % (wmspec.name(), blockName, str(ex))
-                    self.logger.error(msg)
+                    self.logger.exception(msg)
                     self.logdb.post(wmspec.name(), msg, 'error')
                     continue
 

--- a/test/python/WMCore_t/DataStructs_t/Run_t.py
+++ b/test/python/WMCore_t/DataStructs_t/Run_t.py
@@ -6,8 +6,8 @@ Unittest for the WMCore.DataStructs.Run class
 
 """
 
-
 import unittest
+
 from WMCore.DataStructs.Run import Run
 
 
@@ -24,7 +24,6 @@ class RunTest(unittest.TestCase):
         self.assertEqual(run1.run, None)
         self.assertEqual(len(run1), 0)
 
-
         run2 = Run(1000000)
         self.assertEqual(run2.run, 1000000)
         self.assertEqual(len(run2), 0)
@@ -34,48 +33,94 @@ class RunTest(unittest.TestCase):
         self.assertEqual(len(run3), 1)
         self.assertEqual(run3[0], 1)
 
-
-        run4 = Run(1000000, 1,2,3,4,5)
+        run4 = Run(1000000, 1, 2, 3, 4, 5)
         self.assertEqual(run4.run, 1000000)
         self.assertEqual(len(run4), 5)
         self.assertEqual(run4[0], 1)
         self.assertEqual(run4[4], 5)
 
+        # using new DBS lumi/event format
+        run5 = Run(555, [1, 2, 3])
+        self.assertEqual(run5.run, 555)
+        self.assertEqual(len(run5), 3)
+        self.assertDictEqual(run5.eventsPerLumi, {1: None, 2: None, 3: None})
+
+        run6 = Run(666, [(1, 11), (2, 22), (3, 33)])
+        self.assertEqual(run6.run, 666)
+        self.assertEqual(len(run6), 3)
+        self.assertDictEqual(run6.eventsPerLumi, {1: 11, 2: 22, 3: 33})
+
+        run7 = Run(666, [(1, 11), (2, 22), (3, 33), (1, 4), (3, 2)])
+        self.assertEqual(run7.run, 666)
+        self.assertEqual(len(run7), 3)
+        self.assertDictEqual(run7.eventsPerLumi, {1: 15, 2: 22, 3: 35})
+
+        run8 = Run(666, [(1, None), (2, None), (3, None)])
+        self.assertEqual(run8.run, 666)
+        self.assertEqual(len(run8), 3)
+        self.assertDictEqual(run8.eventsPerLumi, {1: None, 2: None, 3: None})
+
+        run9 = Run(666, [(1L, None), (2L, None), (3L, None), (2L, None)])
+        self.assertEqual(run9.run, 666)
+        self.assertEqual(len(run9), 3)
+        self.assertDictEqual(run9.eventsPerLumi, {1: None, 2: None, 3: None})
+
+        run10 = Run(555, *[1, 2, 3])
+        self.assertEqual(run10.run, 555)
+        self.assertEqual(len(run10), 3)
+        self.assertDictEqual(run10.eventsPerLumi, {1: None, 2: None, 3: None})
+
+        run11 = Run(666, *[(1, None), (2, None), (3, None)])
+        self.assertEqual(run11.run, 666)
+        self.assertDictEqual(run11.eventsPerLumi, {1: None, 2: None, 3: None})
+        self.assertEqual(len(run11), 3)
+
+        run12 = Run(666, *[(1L, None), (2L, None), (3L, None), (2L, None)])
+        self.assertEqual(run12.run, 666)
+        self.assertEqual(len(run12), 3)
+        self.assertDictEqual(run12.eventsPerLumi, {1: None, 2: None, 3: None})
+
+        run13 = Run(666, *[(1, 11), (2, 22), (3, 33), (1, 4), (3, 2)])
+        self.assertEqual(run13.run, 666)
+        self.assertEqual(len(run13), 3)
+        self.assertDictEqual(run13.eventsPerLumi, {1: 15, 2: 22, 3: 35})
+
+        run20 = Run(1L, *[1L, 2L, 3L, 4L, 5L])
+        self.assertEqual(run20.run, 1L)
+        self.assertEqual(len(run20), 5)
+        self.assertDictEqual(run20.eventsPerLumi, {1L: None, 2L: None, 3L: None, 4L: None, 5L: None})
+        self.assertItemsEqual(run20.lumis, [1, 2, 3, 4, 5])
 
     def test2(self):
         """
         test equality & addition operators
 
         """
-        run1 = Run(1, 1,2,3,4,5)
-        run1copy = Run(1, 1, 2,3,4,5)
-        run1difflumi = Run(1, 6,7,8,9,10)
-        run1overlap  = Run(1, 3,4,5,6,7)
-        run2 = Run(2, 1,2,3,4,5)
-        run3 = Run(2, 6,7,8,9,10)
+        run1 = Run(1, 1, 2, 3, 4, 5)
+        run1copy = Run(1, 1, 2, 3, 4, 5)
+        run1difflumi = Run(1, 6, 7, 8, 9, 10)
+        run1overlap = Run(1, 3, 4, 5, 6, 7)
+        run2 = Run(2, 1, 2, 3, 4, 5)
 
-        self.assertTrue( run1 == run1copy)
+        self.assertTrue(run1 == run1copy)
         self.assertFalse(run1 == run1difflumi)
         self.assertFalse(run1 == run1overlap)
         self.assertFalse(run1 == run2)
         self.assertTrue(run1 != run2)
-
 
         run1 += run1difflumi
         self.assertEqual(len(run1), 10)
         for l in run1difflumi:
             self.assertTrue(l in run1)
 
-
-
     def testC(self):
         """
         comparision and sorting
 
         """
-        run1 = Run(1, 1,2,3)
-        run2 = Run(2, 4,5,6)
-        run3 = Run(3, 7,8,9)
+        run1 = Run(1, 1, 2, 3)
+        run2 = Run(2, 4, 5, 6)
+        run3 = Run(3, 7, 8, 9)
 
         runlist = [run2, run3, run1]
         runlist.sort()
@@ -83,10 +128,9 @@ class RunTest(unittest.TestCase):
         self.assertEqual(runlist[1], run2)
         self.assertEqual(runlist[2], run3)
 
-
-        run4 = Run(4, 1,2,3)
-        run5 = Run(4, 4,5,6)
-        run6 = Run(4, 7,8,9)
+        run4 = Run(4, 1, 2, 3)
+        run5 = Run(4, 4, 5, 6)
+        run6 = Run(4, 7, 8, 9)
 
         runlist = [run5, run6, run4]
         runlist.sort()
@@ -104,13 +148,11 @@ class RunTest(unittest.TestCase):
         self.assertEqual(runlist[4], run5)
         self.assertEqual(runlist[5], run6)
 
-
-        run7 = Run(9, 1,2,3)
-        run8 = Run(9, 1,2,3)
+        run7 = Run(9, 1, 2, 3)
+        run8 = Run(9, 1, 2, 3)
         run9 = Run(9, 2)
         run10 = Run(9, 3, 4, 5)
-        run11 = Run(9, 8,9,10)
-
+        run11 = Run(9, 8, 9, 10)
 
         runlist = [run10, run8, run11, run7, run9]
         runlist.sort()
@@ -120,23 +162,22 @@ class RunTest(unittest.TestCase):
         self.assertEqual(runlist[3], run10)
         self.assertEqual(runlist[4], run11)
 
-
     def testD(self):
         """
         test hashing for sets
 
         """
-        run1 = Run(1, 1,2,3)
-        run2 = Run(2, 4,5,6)
-        run3 = Run(3, 7,8,9)
-        run4 = Run(4, 1,2,3)
-        run5 = Run(4, 4,5,6)
-        run6 = Run(4, 7,8,9)
-        run7 = Run(9, 1,2,3)
-        run8 = Run(9, 1,2,3)
+        run1 = Run(1, 1, 2, 3)
+        run2 = Run(2, 4, 5, 6)
+        run3 = Run(3, 7, 8, 9)
+        run4 = Run(4, 1, 2, 3)
+        run5 = Run(4, 4, 5, 6)
+        run6 = Run(4, 7, 8, 9)
+        run7 = Run(9, 1, 2, 3)
+        run8 = Run(9, 1, 2, 3)
         run9 = Run(9, 2)
         run10 = Run(9, 3, 4, 5)
-        run11 = Run(9, 8,9,10)
+        run11 = Run(9, 8, 9, 10)
 
         s = set()
         s.add(run1)
@@ -150,9 +191,6 @@ class RunTest(unittest.TestCase):
         s.add(run9)
         s.add(run10)
         s.add(run11)
-
-
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #7941
Got this exception [1] in WorkQueueManager while validating 1.1.4.patch1.

This Run object is somehow tricky with its arguments, besides the run number argument, the others are positional arguments, which means the class constructor sees a tuple of data, which can even be a tuple of a list of tuples :-) (see unit tests)

I'm open for suggestions on a better way or a better performance for fixing it.

[1]
```
2017-06-15 20:53:42,464:140585872336640:INFO:WMBSHelper:"amaltaro_ReReco_Parents_Agent114_Validation_170615_150800_1173" Injecting block /Cosmics/Commissioning2015-PromptReco-v1/RECO#77f9d258-b5d6-11e4-8732-02163e00d625 (89 files) into wmbs
2017-06-15 20:53:42,466:140585872336640:ERROR:WorkQueue:amaltaro_ReReco_Parents_Agent114_Validation_170615_150800_1173, /Cosmics/Commissioning2015-PromptReco-v1/RECO#77f9d258-b5d6-11e4-8732-02163e00d625: 
creating subscription failed in LQ: 
list index out of range
Traceback (most recent call last):
  File "/data/srv/wmagent/v1.1.4.patch1/sw/slc6_amd64_gcc493/cms/wmagent/1.1.4.patch1/lib/python2.7/site-packages/WMCore/WorkQueue/WorkQueue.py", line 374, in getWork
    dbsBlock)
  File "/data/srv/wmagent/v1.1.4.patch1/sw/slc6_amd64_gcc493/cms/wmagent/1.1.4.patch1/lib/python2.7/site-packages/WMCore/WorkQueue/WorkQueue.py", line 442, in _wmbsPreparation
    sub, match['NumOfFilesAdded'] = wmbsHelper.createSubscriptionAndAddFiles(block=dbsBlock)
  File "/data/srv/wmagent/v1.1.4.patch1/sw/slc6_amd64_gcc493/cms/wmagent/1.1.4.patch1/lib/python2.7/site-packages/WMCore/WorkQueue/WMBSHelper.py", line 417, in createSubscriptionAndAddFiles
    addedFiles = self.addFiles(block)
  File "/data/srv/wmagent/v1.1.4.patch1/sw/slc6_amd64_gcc493/cms/wmagent/1.1.4.patch1/lib/python2.7/site-packages/WMCore/WorkQueue/WMBSHelper.py", line 449, in addFiles
    self._addDBSFileToWMBSFile(dbsFile, block['PhEDExNodeNames'])
  File "/data/srv/wmagent/v1.1.4.patch1/sw/slc6_amd64_gcc493/cms/wmagent/1.1.4.patch1/lib/python2.7/site-packages/WMCore/WorkQueue/WMBSHelper.py", line 620, in _addDBSFileToWMBSFile
    storageElements, inFileset=False))
  File "/data/srv/wmagent/v1.1.4.patch1/sw/slc6_amd64_gcc493/cms/wmagent/1.1.4.patch1/lib/python2.7/site-packages/WMCore/WorkQueue/WMBSHelper.py", line 640, in _addDBSFileToWMBSFile
    run = Run(lumi['RunNumber'], lumiSecList)
  File "/data/srv/wmagent/v1.1.4.patch1/sw/slc6_amd64_gcc493/cms/wmagent/1.1.4.patch1/lib/python2.7/site-packages/WMCore/DataStructs/Run.py", line 25, in __init__
    self.extendLumis(newLumis)
  File "/data/srv/wmagent/v1.1.4.patch1/sw/slc6_amd64_gcc493/cms/wmagent/1.1.4.patch1/lib/python2.7/site-packages/WMCore/DataStructs/Run.py", line 163, in extendLumis
    self.eventsPerLumi[lumi[0]] = lumi[1]
IndexError: list index out of range
```