### PR TITLE
Raise HTTPException instead of ServerNotFoundError

### DIFF
--- a/src/python/WMCore/Database/CouchUtils.py
+++ b/src/python/WMCore/Database/CouchUtils.py
@@ -8,11 +8,10 @@ Copyright (c) 2010 Fermilab. All rights reserved.
 """
 from __future__ import print_function
 
-import sys
-import os
-import unittest
 import functools
+from httplib import HTTPException
 import WMCore.Database.CMSCouch as CMSCouch
+
 
 class CouchConnectionError(Exception):
     """docstring for CouchConnectionError"""
@@ -34,6 +33,11 @@ def initialiseCouch(objectRef):
     try:
         objectRef.server = CMSCouch.CouchServer(objectRef.url)
         objectRef.couchdb = objectRef.server.connectDatabase(objectRef.database)
+    except HTTPException as e:
+        msg = "%s with status: %s and reason: %s" % (repr(e),
+                                                     getattr(e, 'status', ""),
+                                                     getattr(e, 'reason', ""))
+        raise CouchConnectionError(msg)
     except Exception as e:
         msg = "Exception instantiating couch services for :\n"
         msg += " url = %s\n database = %s\n" % (objectRef.url, objectRef.database)

--- a/src/python/WMCore/Services/Requests.py
+++ b/src/python/WMCore/Services/Requests.py
@@ -255,6 +255,13 @@ class Requests(dict):
                 # socket/httplib really screwed up - nuclear option
                 conn.connections = {}
                 raise socket.error('Error contacting: %s: %s' % (self.getDomainName(), msg))
+        except Exception as ex:
+            if "Unable to find the server at" in str(ex):
+                e = HTTPException()
+                setattr(e, 'url', uri)
+                setattr(e, 'status', 404)
+                setattr(e, 'reason', str(ex))
+                raise e
         if response.status >= 400:
             e = HTTPException()
             setattr(e, 'req_data', encoded_data)


### PR DESCRIPTION
Fixes #7942 

Apparently there are other services relying on this package and they use pycurl, that's why I didn't add the httplib2 dependency here, though I'm not sure the fix proposed is good enough(?)
Another possibility would just let the ServerNotFoundError exception be raised here and let it propagate until the components, where we handle the error message and crash or not the component.
@ticoann any thoughts on it?

If accepted, we need to update the exit status code on at least ErrorHandler and Phedex components.