### PR TITLE
seems like python3 doesn't know maxint

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Executors/StageOut.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/StageOut.py
@@ -153,7 +153,7 @@ class StageOut(Executor):
                     if fileName.module_label not in getattr(self.step.output, 'forceUnmergedOutputs', []):
                         if getattr(fileName, 'size', 0) >= self.step.output.minMergeSize:
                             straightToMerge = True
-                        if getattr(fileName, 'events', 0) >= getattr(self.step.output, 'maxMergeEvents', sys.maxint):
+                        if getattr(fileName, 'events', 0) >= getattr(self.step.output, 'maxMergeEvents', sys.maxsize):
                             straightToMerge = True
 
                 if straightToMerge:


### PR DESCRIPTION
Old version works just fine (and is functionally equivalent to the new version) on python2. So this should get merged at some point, but there is no practical impact at the moment. Well, jenkins is complaining, that is the impact :-).