### PR TITLE
Set result attr in HTTPException. Fix for 7964

### DIFF
--- a/src/python/WMCore/Database/CouchUtils.py
+++ b/src/python/WMCore/Database/CouchUtils.py
@@ -10,6 +10,7 @@ from __future__ import print_function
 
 import functools
 from httplib import HTTPException
+
 import WMCore.Database.CMSCouch as CMSCouch
 
 
@@ -34,9 +35,10 @@ def initialiseCouch(objectRef):
         objectRef.server = CMSCouch.CouchServer(objectRef.url)
         objectRef.couchdb = objectRef.server.connectDatabase(objectRef.database)
     except HTTPException as e:
-        msg = "%s with status: %s and reason: %s" % (repr(e),
-                                                     getattr(e, 'status', ""),
-                                                     getattr(e, 'reason', ""))
+        msg = "%s with status: %s, reason: %s and result: %s" % (repr(e),
+                                                                 getattr(e, 'status', ""),
+                                                                 getattr(e, 'reason', ""),
+                                                                 getattr(e, 'result', ""))
         raise CouchConnectionError(msg)
     except Exception as e:
         msg = "Exception instantiating couch services for :\n"

--- a/src/python/WMCore/Services/Requests.py
+++ b/src/python/WMCore/Services/Requests.py
@@ -251,7 +251,8 @@ class Requests(dict):
             e = HTTPException()
             setattr(e, 'url', uri)
             setattr(e, 'status', 503)
-            setattr(e, 'reason', str(ex))
+            setattr(e, 'reason', 'Service Unavailable')
+            setattr(e, 'result', str(ex))
             raise e
         except (socket.error, AttributeError):
             self['logger'].warn("Http request failed, retrying once again..")


### PR DESCRIPTION
Bug introduced with #7964 :(

PhEDExInjectorPoller is relying on `result` attr in a couple of places, like
https://github.com/dmwm/WMCore/blob/master/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py#L531

which isn't set if we got a ServerNotFoundError. I was using only the reason attribute for that.

I think it's best to leave `reason` for the string representing the http exit code and set `result` with any additional messages, as it's done here:
https://github.com/dmwm/WMCore/blob/be9494662fdf5128593ea2d032221935210264c9/src/python/WMCore/Services/Requests.py#L278