### PR TITLE
check schedd limit before pulling the work

### DIFF
--- a/src/python/WMCore/Services/PyCondor/PyCondorAPI.py
+++ b/src/python/WMCore/Services/PyCondor/PyCondorAPI.py
@@ -1,0 +1,19 @@
+from __future__ import print_function, division
+
+try:
+    # This module has dependency with python binding for condor package (condor)
+    import htcondor
+except:
+    pass
+
+
+def isScheddOverloaded():
+    """
+    check whether job limit is reached in local schedd.
+    Condition is check by following logic.
+    ( ShadowsRunning > 9.700000000000000E-01 * MAX_RUNNING_JOBS) )
+    || ( RecentDaemonCoreDutyCycle > 9.800000000000000E-01 )
+    """
+    coll = htcondor.Collector()
+    scheddAd = coll.locate(htcondor.DaemonTypes.Schedd)
+    return scheddAd['CurbMatchmaking'].eval()


### PR DESCRIPTION
fixes #7559 
Initial version (We can still add what Jean-Roch requested if necessary)

>can we have a >N hours after hitting CurbMatchmaking "no work acquired" cooloff period so that it does not start right back ? or is there already such cooloff period on the schedd side @bbockelm ?
>can we record the total number of running jobs when CurbMatchmaking is met, and use 80% of that value to prevent work for getting in ?can we have a >N hours after hitting CurbMatchmaking "no work acquired" cooloff period so that it does not start right back ? or is there already such cooloff period on the schedd side @bbockelm ?
>can we record the total number of running jobs when CurbMatchmaking is met, and use 80% of that value to prevent work for getting in ?