### PR TITLE
Create new DAOs for workflow, filesets, subscriptions

### DIFF
--- a/src/python/WMCore/WMBS/MySQL/Subscriptions/ListSubsAndFilesetsFromWorkflow.py
+++ b/src/python/WMCore/WMBS/MySQL/Subscriptions/ListSubsAndFilesetsFromWorkflow.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+"""
+_ListSubsAndFilesetsFromWorkflow_
+
+Creates a mapping between subscriptions id, fileset names and workflow
+tasks.
+"""
+from __future__ import division
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+
+class ListSubsAndFilesetsFromWorkflow(DBFormatter):
+    """ Returns a list of tuples """
+    sql = """SELECT wmbs_subscription.id as subID, wmbs_fileset.name AS fileset,
+                 wmbs_workflow.task AS wfTask, wmbs_subscription.split_algo,
+                 wmbs_sub_types.name AS subType
+               FROM wmbs_subscription
+                 INNER JOIN wmbs_fileset ON wmbs_subscription.fileset = wmbs_fileset.id
+                 INNER JOIN wmbs_workflow ON wmbs_subscription.workflow = wmbs_workflow.id
+                 INNER JOIN wmbs_sub_types ON wmbs_subscription.subtype = wmbs_sub_types.id
+               WHERE wmbs_workflow.name = :workflow
+               ORDER BY wmbs_fileset.name, wmbs_workflow.task"""
+
+    def format(self, results):
+        "Build a list of tuples"
+        result = []
+        results = DBFormatter.format(self, results)
+        for item in results:
+            result.append(tuple(item))
+
+        return result
+
+    def execute(self, workflow, returnTuple=False, conn=None, transaction=False):
+        result = self.dbi.processData(self.sql, {"workflow": workflow},
+                                      conn=conn, transaction=transaction)
+        if returnTuple:
+            # easier for comparison
+            return self.format(result)
+        else:
+            return self.formatDict(result)

--- a/src/python/WMCore/WMBS/MySQL/Workflow/LoadFromName.py
+++ b/src/python/WMCore/WMBS/MySQL/Workflow/LoadFromName.py
@@ -7,19 +7,12 @@ MySQL implementation of Workflow.LoadFromName
 
 from WMCore.Database.DBFormatter import DBFormatter
 
-class LoadFromName(DBFormatter):
-    sql = """SELECT wmbs_workflow.id, wmbs_workflow.spec, wmbs_workflow.name,
-                    wmbs_users.cert_dn as dn, wmbs_users.owner as owner,
-                    wmbs_users.grp as grp, wmbs_users.group_name as vogrp,
-                    wmbs_users.role_name as vorole, wmbs_workflow.task,
-                    wmbs_workflow.type, wmbs_workflow.priority
-             FROM wmbs_workflow
-             INNER JOIN wmbs_users ON
-               wmbs_workflow.owner = wmbs_users.id
-             WHERE wmbs_workflow.name = :workflow AND wmbs_workflow.task = :task"""
 
-    def execute(self, workflow, task, conn = None, transaction = False):
-        result = self.dbi.processData(self.sql, {"workflow": workflow,
-                                                 "task": task},
-                         conn = conn, transaction = transaction)
-        return self.formatDict(result)[0]
+class LoadFromName(DBFormatter):
+    sql = """SELECT * FROM wmbs_workflow WHERE wmbs_workflow.name = :workflow
+             ORDER BY task"""
+
+    def execute(self, workflow, conn=None, transaction=False):
+        result = self.dbi.processData(self.sql, {"workflow": workflow},
+                                      conn=conn, transaction=transaction)
+        return self.formatDict(result)

--- a/src/python/WMCore/WMBS/MySQL/Workflow/LoadFromNameAndTask.py
+++ b/src/python/WMCore/WMBS/MySQL/Workflow/LoadFromNameAndTask.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+"""
+_LoadFromNameAndTask_
+
+MySQL implementation of Workflow.LoadFromNameAndTask
+"""
+from __future__ import division
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+
+class LoadFromNameAndTask(DBFormatter):
+    sql = """SELECT wmbs_workflow.id, wmbs_workflow.spec, wmbs_workflow.name,
+                    wmbs_users.cert_dn as dn, wmbs_users.owner as owner,
+                    wmbs_users.grp as grp, wmbs_users.group_name as vogrp,
+                    wmbs_users.role_name as vorole, wmbs_workflow.task,
+                    wmbs_workflow.type, wmbs_workflow.priority
+             FROM wmbs_workflow
+             INNER JOIN wmbs_users ON
+               wmbs_workflow.owner = wmbs_users.id
+             WHERE wmbs_workflow.name = :workflow AND wmbs_workflow.task = :task"""
+
+    def execute(self, workflow, task, conn=None, transaction=False):
+        result = self.dbi.processData(self.sql, {"workflow": workflow, "task": task},
+                                      conn=conn, transaction=transaction)
+        return self.formatDict(result)[0]

--- a/src/python/WMCore/WMBS/Oracle/Subscriptions/ListSubsAndFilesetsFromWorkflow.py
+++ b/src/python/WMCore/WMBS/Oracle/Subscriptions/ListSubsAndFilesetsFromWorkflow.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+"""
+_ListSubsAndFilesetsFromWorkflow_
+
+Oracle implementation of Subscriptions.ListSubsAndFilesetsFromWorkflow
+"""
+from __future__ import division
+
+from WMCore.WMBS.MySQL.Subscriptions.ListSubsAndFilesetsFromWorkflow import ListSubsAndFilesetsFromWorkflow \
+    as ListSubsAndFilesetsFromWorkflowMySQL
+
+
+class ListSubsAndFilesetsFromWorkflow(ListSubsAndFilesetsFromWorkflowMySQL):
+    pass

--- a/src/python/WMCore/WMBS/Oracle/Workflow/LoadFromName.py
+++ b/src/python/WMCore/WMBS/Oracle/Workflow/LoadFromName.py
@@ -3,14 +3,11 @@
 _LoadFromName_
 
 Oracle implementation of Workflow.LoadFromName
-
 """
-__all__ = []
-
-
 
 from WMCore.WMBS.MySQL.Workflow.LoadFromName import LoadFromName \
-     as LoadWorkflowMySQL
+    as LoadFromNameMySQL
 
-class LoadFromName(LoadWorkflowMySQL):
-    sql = LoadWorkflowMySQL.sql
+
+class LoadFromName(LoadFromNameMySQL):
+    pass

--- a/src/python/WMCore/WMBS/Oracle/Workflow/LoadFromNameAndTask.py
+++ b/src/python/WMCore/WMBS/Oracle/Workflow/LoadFromNameAndTask.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+"""
+_LoadFromNameAndTask_
+
+Oracle implementation of Workflow.LoadFromNameAndTask
+
+"""
+from __future__ import division
+
+from WMCore.WMBS.MySQL.Workflow.LoadFromNameAndTask import LoadFromNameAndTask \
+    as LoadFromNameAndTaskMySQL
+
+
+class LoadFromNameAndTask(LoadFromNameAndTaskMySQL):
+    pass

--- a/src/python/WMCore/WMBS/Workflow.py
+++ b/src/python/WMCore/WMBS/Workflow.py
@@ -15,9 +15,10 @@ bunch of data).
 workflow + fileset = subscription
 """
 
-from WMCore.WMBS.WMBSBase import WMBSBase
 from WMCore.DataStructs.Workflow import Workflow as WMWorkflow
 from WMCore.WMBS.Fileset import Fileset
+from WMCore.WMBS.WMBSBase import WMBSBase
+
 
 class Workflow(WMBSBase, WMWorkflow):
     """
@@ -33,16 +34,17 @@ class Workflow(WMBSBase, WMWorkflow):
 
     workflow + fileset = subscription
     """
-    def __init__(self, spec = None, owner = "unknown", dn = "unknown",
-                 group = "unknown", owner_vogroup = "DEFAULT",
-                 owner_vorole = "DEFAULT", name = None, task = None,
-                 wfType = None, id = -1, alternativeFilesetClose = False,
-                 priority = None):
+
+    def __init__(self, spec=None, owner="unknown", dn="unknown",
+                 group="unknown", owner_vogroup="DEFAULT",
+                 owner_vorole="DEFAULT", name=None, task=None,
+                 wfType=None, id=-1, alternativeFilesetClose=False,
+                 priority=None):
         WMBSBase.__init__(self)
-        WMWorkflow.__init__(self, spec = spec, owner = owner, dn = dn,
-                            group = group, owner_vogroup = owner_vogroup,
-                            owner_vorole = owner_vorole, name = name,
-                            task = task, wfType = wfType, priority = priority)
+        WMWorkflow.__init__(self, spec=spec, owner=owner, dn=dn,
+                            group=group, owner_vogroup=owner_vogroup,
+                            owner_vorole=owner_vorole, name=name,
+                            task=task, wfType=wfType, priority=priority)
 
         if self.dn == "unknown":
             self.dn = owner
@@ -58,16 +60,15 @@ class Workflow(WMBSBase, WMWorkflow):
         Determine whether or not a workflow exists with the given spec, owner
         and name.  Return the ID if the workflow exists, False otherwise.
         """
-        action = self.daofactory(classname = "Workflow.Exists")
-        result = action.execute(spec = self.spec, owner = self.dn,
-                                group_name = self.vogroup,
-                                role_name = self.vorole,
-                                name = self.name, task = self.task,
-                                conn = self.getDBConn(),
-                                transaction = self.existingTransaction())
+        action = self.daofactory(classname="Workflow.Exists")
+        result = action.execute(spec=self.spec, owner=self.dn,
+                                group_name=self.vogroup,
+                                role_name=self.vorole,
+                                name=self.name, task=self.task,
+                                conn=self.getDBConn(),
+                                transaction=self.existingTransaction())
 
         return result
-
 
     def insertUser(self):
         """
@@ -78,20 +79,20 @@ class Workflow(WMBSBase, WMWorkflow):
         """
         existingTransaction = self.beginTransaction()
 
-        userfactory = self.daofactory(classname = "Users.GetUserId")
-        userid = userfactory.execute(dn = self.dn,
-                                     group_name = self.vogroup,
-                                     role_name = self.vorole,
-                                     conn = self.getDBConn(),
-                                     transaction = self.existingTransaction())
+        userfactory = self.daofactory(classname="Users.GetUserId")
+        userid = userfactory.execute(dn=self.dn,
+                                     group_name=self.vogroup,
+                                     role_name=self.vorole,
+                                     conn=self.getDBConn(),
+                                     transaction=self.existingTransaction())
         if not userid:
-            newuser = self.daofactory(classname = "Users.New")
-            userid  = newuser.execute(dn = self.dn, hn = self.owner,
-                                      owner = self.owner, group = self.group,
-                                      group_name = self.vogroup,
-                                      role_name = self.vorole,
-                                      conn = self.getDBConn(),
-                                      transaction = self.existingTransaction())
+            newuser = self.daofactory(classname="Users.New")
+            userid = newuser.execute(dn=self.dn, hn=self.owner,
+                                     owner=self.owner, group=self.group,
+                                     group_name=self.vogroup,
+                                     role_name=self.vorole,
+                                     conn=self.getDBConn(),
+                                     transaction=self.existingTransaction())
 
         self.commitTransaction(existingTransaction)
         return userid
@@ -115,13 +116,13 @@ class Workflow(WMBSBase, WMWorkflow):
             self.commitTransaction(existingTransaction)
             return
 
-        action = self.daofactory(classname = "Workflow.New")
-        action.execute(spec = self.spec, owner = userid, name = self.name,
-                       task = self.task, wfType = self.wfType,
-                       alt_fs_close = self.alternativeFilesetClose,
-                       priority = self.priority,
-                       conn = self.getDBConn(),
-                       transaction = self.existingTransaction())
+        action = self.daofactory(classname="Workflow.New")
+        action.execute(spec=self.spec, owner=userid, name=self.name,
+                       task=self.task, wfType=self.wfType,
+                       alt_fs_close=self.alternativeFilesetClose,
+                       priority=self.priority,
+                       conn=self.getDBConn(),
+                       transaction=self.existingTransaction())
 
         self.id = self.exists()
         self.commitTransaction(existingTransaction)
@@ -133,9 +134,9 @@ class Workflow(WMBSBase, WMWorkflow):
 
         Remove this workflow from the database.
         """
-        action = self.daofactory(classname = "Workflow.Delete")
-        action.execute(id = self.id, conn = self.getDBConn(),
-                       transaction = self.existingTransaction())
+        action = self.daofactory(classname="Workflow.Delete")
+        action.execute(id=self.id, conn=self.getDBConn(),
+                       transaction=self.existingTransaction())
 
         return
 
@@ -151,20 +152,20 @@ class Workflow(WMBSBase, WMWorkflow):
         existingTransaction = self.beginTransaction()
 
         if self.id > 0:
-            action = self.daofactory(classname = "Workflow.LoadFromID")
-            result = action.execute(workflow = self.id,
-                                    conn = self.getDBConn(),
-                                    transaction = self.existingTransaction())
+            action = self.daofactory(classname="Workflow.LoadFromID")
+            result = action.execute(workflow=self.id,
+                                    conn=self.getDBConn(),
+                                    transaction=self.existingTransaction())
         elif self.name != None:
-            action = self.daofactory(classname = "Workflow.LoadFromNameAndTask")
-            result = action.execute(workflow = self.name, task = self.task,
-                                    conn = self.getDBConn(),
-                                    transaction = self.existingTransaction())
+            action = self.daofactory(classname="Workflow.LoadFromNameAndTask")
+            result = action.execute(workflow=self.name, task=self.task,
+                                    conn=self.getDBConn(),
+                                    transaction=self.existingTransaction())
         else:
-            action = self.daofactory(classname = "Workflow.LoadFromSpecOwner")
-            result = action.execute(spec = self.spec, dn = self.dn,
-                                    task = self.task, conn = self.getDBConn(),
-                                    transaction = self.existingTransaction())
+            action = self.daofactory(classname="Workflow.LoadFromSpecOwner")
+            result = action.execute(spec=self.spec, dn=self.dn,
+                                    task=self.task, conn=self.getDBConn(),
+                                    transaction=self.existingTransaction())
 
         self.id = result["id"]
         self.spec = result["spec"]
@@ -178,16 +179,16 @@ class Workflow(WMBSBase, WMWorkflow):
         self.wfType = result["type"]
         self.priority = result["priority"]
 
-        action = self.daofactory(classname = "Workflow.LoadOutput")
-        results = action.execute(workflow = self.id, conn = self.getDBConn(),
-                                transaction = self.existingTransaction())
+        action = self.daofactory(classname="Workflow.LoadOutput")
+        results = action.execute(workflow=self.id, conn=self.getDBConn(),
+                                 transaction=self.existingTransaction())
 
         self.outputMap = {}
         for outputID in results.keys():
             for outputMap in results[outputID]:
-                outputFileset = Fileset(id = outputMap["output_fileset"])
+                outputFileset = Fileset(id=outputMap["output_fileset"])
                 if outputMap["merged_output_fileset"] != None:
-                    mergedOutputFileset = Fileset(id = outputMap["merged_output_fileset"])
+                    mergedOutputFileset = Fileset(id=outputMap["merged_output_fileset"])
                 else:
                     mergedOutputFileset = None
 
@@ -201,7 +202,7 @@ class Workflow(WMBSBase, WMWorkflow):
         return
 
     def addOutput(self, outputIdentifier, outputFileset,
-                  mergedOutputFileset = None):
+                  mergedOutputFileset=None):
         """
         _addOutput_
 
@@ -218,16 +219,16 @@ class Workflow(WMBSBase, WMWorkflow):
         self.outputMap[outputIdentifier].append({"output_fileset": outputFileset,
                                                  "merged_output_fileset": mergedOutputFileset})
 
-        action = self.daofactory(classname = "Workflow.InsertOutput")
+        action = self.daofactory(classname="Workflow.InsertOutput")
         if mergedOutputFileset != None:
             mergedFilesetID = mergedOutputFileset.id
         else:
             mergedFilesetID = None
 
-        action.execute(workflowID = self.id, outputIdentifier = outputIdentifier,
-                       filesetID = outputFileset.id, mergedFilesetID = mergedFilesetID,
-                       conn = self.getDBConn(),
-                       transaction = self.existingTransaction())
+        action.execute(workflowID=self.id, outputIdentifier=outputIdentifier,
+                       filesetID=outputFileset.id, mergedFilesetID=mergedFilesetID,
+                       conn=self.getDBConn(),
+                       transaction=self.existingTransaction())
 
         self.commitTransaction(existingTransaction)
         return
@@ -240,8 +241,8 @@ class Workflow(WMBSBase, WMWorkflow):
         """
 
         existingTransaction = self.beginTransaction()
-        action = self.daofactory(classname = "Workflow.CountWorkflowBySpec")
-        result = action.execute(spec = self.spec)
+        action = self.daofactory(classname="Workflow.CountWorkflowBySpec")
+        result = action.execute(spec=self.spec)
         self.commitTransaction(existingTransaction)
 
         return result

--- a/src/python/WMCore/WMBS/Workflow.py
+++ b/src/python/WMCore/WMBS/Workflow.py
@@ -156,7 +156,7 @@ class Workflow(WMBSBase, WMWorkflow):
                                     conn = self.getDBConn(),
                                     transaction = self.existingTransaction())
         elif self.name != None:
-            action = self.daofactory(classname = "Workflow.LoadFromName")
+            action = self.daofactory(classname = "Workflow.LoadFromNameAndTask")
             result = action.execute(workflow = self.name, task = self.task,
                                     conn = self.getDBConn(),
                                     transaction = self.existingTransaction())

--- a/test/python/WMCore_t/WMBS_t/Workflow_t.py
+++ b/test/python/WMCore_t/WMBS_t/Workflow_t.py
@@ -5,18 +5,17 @@ _Workflow_t_
 Unit tests for the WMBS Workflow class.
 """
 
-import unittest
 import threading
+import unittest
 
 from WMCore.DAOFactory import DAOFactory
 from WMCore.WMBS.Fileset import Fileset
 from WMCore.WMBS.Subscription import Subscription
 from WMCore.WMBS.Workflow import Workflow
-
 from WMQuality.TestInit import TestInit
 
-class WorkflowTest(unittest.TestCase):
 
+class WorkflowTest(unittest.TestCase):
     def setUp(self):
         """
         _setUp_
@@ -27,8 +26,8 @@ class WorkflowTest(unittest.TestCase):
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
         self.testInit.setDatabaseConnection()
-        self.testInit.setSchema(customModules = ["WMCore.WMBS"],
-                                useDefault = False)
+        self.testInit.setSchema(customModules=["WMCore.WMBS"],
+                                useDefault=False)
         return
 
     def tearDown(self):
@@ -48,8 +47,8 @@ class WorkflowTest(unittest.TestCase):
         by creating and deleting a workflow.  The exists() method will be
         called before and after creation and after deletion.
         """
-        testWorkflow = Workflow(spec = "spec.xml", owner = "Simon",
-                                name = "wf001", task='Test', wfType="ReReco")
+        testWorkflow = Workflow(spec="spec.xml", owner="Simon",
+                                name="wf001", task='Test', wfType="ReReco")
 
         self.assertEqual(testWorkflow.exists(), False,
                          "ERROR: Workflow exists before it was created")
@@ -78,8 +77,8 @@ class WorkflowTest(unittest.TestCase):
         myThread = threading.currentThread()
         myThread.transaction.begin()
 
-        testWorkflow = Workflow(spec = "spec.xml", owner = "Simon",
-                                name = "wf001", task='Test')
+        testWorkflow = Workflow(spec="spec.xml", owner="Simon",
+                                name="wf001", task='Test')
 
         self.assertEqual(testWorkflow.exists(), False,
                          "ERROR: Workflow exists before it was created")
@@ -106,8 +105,8 @@ class WorkflowTest(unittest.TestCase):
         is called, it doesn't exist after delete() is called and it does exist
         after the transaction is rolled back.
         """
-        testWorkflow = Workflow(spec = "spec.xml", owner = "Simon",
-                                name = "wf001", task='Test')
+        testWorkflow = Workflow(spec="spec.xml", owner="Simon",
+                                name="wf001", task='Test')
 
         self.assertEqual(testWorkflow.exists(), False,
                          "ERROR: Workflow exists before it was created")
@@ -138,16 +137,16 @@ class WorkflowTest(unittest.TestCase):
 
         Create a workflow and then try to load it from the database using the
         following load methods:
-          Workflow.LoadFromName
+          Workflow.LoadFromNameAndTask
           Workflow.LoadFromID
           Workflow.LoadFromSpecOwner
         """
-        testWorkflowA = Workflow(spec = "spec.xml", owner = "Simon",
-                                 name = "wf001", task='Test', wfType="ReReco",
-                                 priority = 1000)
+        testWorkflowA = Workflow(spec="spec.xml", owner="Simon",
+                                 name="wf001", task='Test', wfType="ReReco",
+                                 priority=1000)
         testWorkflowA.create()
 
-        testWorkflowB = Workflow(name = "wf001", task='Test')
+        testWorkflowB = Workflow(name="wf001", task='Test')
         testWorkflowB.load()
 
         self.assertTrue((testWorkflowA.id == testWorkflowB.id) and
@@ -157,9 +156,9 @@ class WorkflowTest(unittest.TestCase):
                         (testWorkflowA.wfType == testWorkflowB.wfType) and
                         (testWorkflowA.owner == testWorkflowB.owner) and
                         (testWorkflowA.priority == testWorkflowB.priority),
-                        "ERROR: Workflow.LoadFromName Failed")
+                        "ERROR: Workflow.LoadFromNameAndTask Failed")
 
-        testWorkflowC = Workflow(id = testWorkflowA.id)
+        testWorkflowC = Workflow(id=testWorkflowA.id)
         testWorkflowC.load()
 
         self.assertTrue((testWorkflowA.id == testWorkflowC.id) and
@@ -171,7 +170,7 @@ class WorkflowTest(unittest.TestCase):
                         (testWorkflowA.priority == testWorkflowB.priority),
                         "ERROR: Workflow.LoadFromID Failed")
 
-        testWorkflowD = Workflow(spec = "spec.xml", owner = "Simon", task='Test')
+        testWorkflowD = Workflow(spec="spec.xml", owner="Simon", task='Test')
         testWorkflowD.load()
 
         self.assertTrue((testWorkflowA.id == testWorkflowD.id) and
@@ -191,17 +190,17 @@ class WorkflowTest(unittest.TestCase):
 
         Create a workflow and then try to load it from the database using the
         following load methods:
-          Workflow.LoadFromName
+          Workflow.LoadFromNameAndTask
           Workflow.LoadFromID
           Workflow.LoadFromSpecOwner
         Test if the Workflow is created correctly.
         """
-        testWorkflowA = Workflow(spec = "spec.xml", owner = "Simon",
-                                 owner_vogroup = 'integration', owner_vorole = 'priority',
-                                 name = "wf001", task='Test', wfType="ReReco")
+        testWorkflowA = Workflow(spec="spec.xml", owner="Simon",
+                                 owner_vogroup='integration', owner_vorole='priority',
+                                 name="wf001", task='Test', wfType="ReReco")
         testWorkflowA.create()
 
-        testWorkflowB = Workflow(name = "wf001", task='Test')
+        testWorkflowB = Workflow(name="wf001", task='Test')
         testWorkflowB.load()
 
         self.assertTrue((testWorkflowA.id == testWorkflowB.id) and
@@ -210,9 +209,9 @@ class WorkflowTest(unittest.TestCase):
                         (testWorkflowA.task == testWorkflowB.task) and
                         (testWorkflowA.wfType == testWorkflowB.wfType) and
                         (testWorkflowA.owner == testWorkflowB.owner),
-                        "ERROR: Workflow.LoadFromName Failed")
+                        "ERROR: Workflow.LoadFromNameAndTask Failed")
 
-        testWorkflowC = Workflow(id = testWorkflowA.id)
+        testWorkflowC = Workflow(id=testWorkflowA.id)
         testWorkflowC.load()
 
         self.assertTrue((testWorkflowA.id == testWorkflowC.id) and
@@ -223,7 +222,7 @@ class WorkflowTest(unittest.TestCase):
                         (testWorkflowA.owner == testWorkflowC.owner),
                         "ERROR: Workflow.LoadFromID Failed")
 
-        testWorkflowD = Workflow(spec = "spec.xml", owner = "Simon", task='Test')
+        testWorkflowD = Workflow(spec="spec.xml", owner="Simon", task='Test')
         testWorkflowD.load()
 
         self.assertTrue((testWorkflowA.id == testWorkflowD.id) and
@@ -234,9 +233,9 @@ class WorkflowTest(unittest.TestCase):
                         (testWorkflowA.owner == testWorkflowD.owner),
                         "ERROR: Workflow.LoadFromSpecOwner Failed")
 
-        testWorkflowE = Workflow(spec = "spec_1.xml", owner = "Simon",
-                                 owner_vogroup = 't1access', owner_vorole = 't1access',
-                                 name = "wf002", task='Test_1', wfType="ReReco")
+        testWorkflowE = Workflow(spec="spec_1.xml", owner="Simon",
+                                 owner_vogroup='t1access', owner_vorole='t1access',
+                                 name="wf002", task='Test_1', wfType="ReReco")
         testWorkflowE.create()
 
         self.assertTrue((testWorkflowE.id != testWorkflowA.id) and
@@ -259,12 +258,12 @@ class WorkflowTest(unittest.TestCase):
         Creat a workflow and add some outputs to it.  Verify that these are
         stored to and loaded from the database correctly.
         """
-        testFilesetA = Fileset(name = "testFilesetA")
-        testMergedFilesetA = Fileset(name = "testMergedFilesetA")
-        testFilesetB = Fileset(name = "testFilesetB")
-        testMergedFilesetB = Fileset(name = "testMergedFilesetB")
-        testFilesetC = Fileset(name = "testFilesetC")
-        testMergedFilesetC = Fileset(name = "testMergedFilesetC")
+        testFilesetA = Fileset(name="testFilesetA")
+        testMergedFilesetA = Fileset(name="testMergedFilesetA")
+        testFilesetB = Fileset(name="testFilesetB")
+        testMergedFilesetB = Fileset(name="testMergedFilesetB")
+        testFilesetC = Fileset(name="testFilesetC")
+        testMergedFilesetC = Fileset(name="testMergedFilesetC")
         testFilesetA.create()
         testFilesetB.create()
         testFilesetC.create()
@@ -272,11 +271,11 @@ class WorkflowTest(unittest.TestCase):
         testMergedFilesetB.create()
         testMergedFilesetC.create()
 
-        testWorkflowA = Workflow(spec = "spec.xml", owner = "Simon",
-                                 name = "wf001", task='Test')
+        testWorkflowA = Workflow(spec="spec.xml", owner="Simon",
+                                 name="wf001", task='Test')
         testWorkflowA.create()
 
-        testWorkflowB = Workflow(name = "wf001", task='Test')
+        testWorkflowB = Workflow(name="wf001", task='Test')
         testWorkflowB.load()
 
         self.assertEqual(len(testWorkflowB.outputMap.keys()), 0,
@@ -286,7 +285,7 @@ class WorkflowTest(unittest.TestCase):
         testWorkflowA.addOutput("outModOne", testFilesetC, testMergedFilesetC)
         testWorkflowA.addOutput("outModTwo", testFilesetB, testMergedFilesetB)
 
-        testWorkflowC = Workflow(name = "wf001", task='Test')
+        testWorkflowC = Workflow(name="wf001", task='Test')
         testWorkflowC.load()
 
         self.assertEqual(len(testWorkflowC.outputMap.keys()), 2,
@@ -324,19 +323,19 @@ class WorkflowTest(unittest.TestCase):
         Verify that Workflow.LoadFromTask DAO correct loads the workflow by
         task.
         """
-        testWorkflow1 = Workflow(spec = "spec1.xml", owner = "Hassen",
-                                 name = "wf001", task = "sometask")
+        testWorkflow1 = Workflow(spec="spec1.xml", owner="Hassen",
+                                 name="wf001", task="sometask")
         testWorkflow1.create()
 
         myThread = threading.currentThread()
-        daoFactory = DAOFactory(package="WMCore.WMBS", logger = myThread.logger,
-                                dbinterface = myThread.dbi)
-        loadFromTaskDAO = daoFactory(classname = "Workflow.LoadFromTask")
+        daoFactory = DAOFactory(package="WMCore.WMBS", logger=myThread.logger,
+                                dbinterface=myThread.dbi)
+        loadFromTaskDAO = daoFactory(classname="Workflow.LoadFromTask")
 
-        listFromTask = loadFromTaskDAO.execute(task = testWorkflow1.task)
+        listFromTask = loadFromTaskDAO.execute(task=testWorkflow1.task)
 
         self.assertEqual(len(listFromTask), 1,
-                          "ERROR: listFromTask should be 1.")
+                         "ERROR: listFromTask should be 1.")
         self.assertEqual(listFromTask[0]["task"], "sometask",
                          "ERROR: task should be sometask.")
         return
@@ -349,35 +348,34 @@ class WorkflowTest(unittest.TestCase):
         """
 
         owner = "Spiga"
-        testWorkflow1 = Workflow(spec = "spec1.xml", owner = owner,
-                                 name = "wf001", task = "MultiUser-support")
+        testWorkflow1 = Workflow(spec="spec1.xml", owner=owner,
+                                 name="wf001", task="MultiUser-support")
         testWorkflow1.create()
 
         myThread = threading.currentThread()
-        daoFactory = DAOFactory(package="WMCore.WMBS", logger = myThread.logger,
-                                dbinterface = myThread.dbi)
-        loadFromOwnerDAO = daoFactory(classname = "Workflow.LoadFromSpecOwner")
+        daoFactory = DAOFactory(package="WMCore.WMBS", logger=myThread.logger,
+                                dbinterface=myThread.dbi)
+        loadFromOwnerDAO = daoFactory(classname="Workflow.LoadFromSpecOwner")
 
-        listFromOwner1 = loadFromOwnerDAO.execute(task = testWorkflow1.task,
-                                                  dn   = testWorkflow1.owner,
-                                                  spec = testWorkflow1.spec )
+        listFromOwner1 = loadFromOwnerDAO.execute(task=testWorkflow1.task,
+                                                  dn=testWorkflow1.owner,
+                                                  spec=testWorkflow1.spec)
 
-        testWorkflow2 = Workflow(spec = "spec2.xml", owner = owner,
-                                 name = "wf002", task = "MultiUser-support")
+        testWorkflow2 = Workflow(spec="spec2.xml", owner=owner,
+                                 name="wf002", task="MultiUser-support")
         testWorkflow2.create()
 
-        listFromOwner2 = loadFromOwnerDAO.execute(task = testWorkflow2.task,
-                                                  dn   = testWorkflow2.owner,
-                                                  spec = testWorkflow2.spec )
+        listFromOwner2 = loadFromOwnerDAO.execute(task=testWorkflow2.task,
+                                                  dn=testWorkflow2.owner,
+                                                  spec=testWorkflow2.spec)
 
-        testWorkflow3 = Workflow(spec = "spec3.xml", owner = "Ciccio",
-                                 name = "wf003", task = "MultiUser-support")
+        testWorkflow3 = Workflow(spec="spec3.xml", owner="Ciccio",
+                                 name="wf003", task="MultiUser-support")
         testWorkflow3.create()
 
-        listFromOwner3 = loadFromOwnerDAO.execute(task = testWorkflow3.task,
-                                                  dn   = testWorkflow3.owner,
-                                                  spec = testWorkflow3.spec )
-
+        listFromOwner3 = loadFromOwnerDAO.execute(task=testWorkflow3.task,
+                                                  dn=testWorkflow3.owner,
+                                                  spec=testWorkflow3.spec)
 
         self.assertEqual(testWorkflow1.owner, owner)
         self.assertEqual(listFromOwner1["owner"], owner)
@@ -392,30 +390,28 @@ class WorkflowTest(unittest.TestCase):
         _testCountWorkflow_
 
         """
-        spec  = "spec.py"
+        spec = "spec.py"
         owner = "moron"
         myThread = threading.currentThread()
-        daoFactory = DAOFactory(package="WMCore.WMBS", logger = myThread.logger,
-                                dbinterface = myThread.dbi)
-        countSpecDAO = daoFactory(classname = "Workflow.CountWorkflowBySpec")
+        daoFactory = DAOFactory(package="WMCore.WMBS", logger=myThread.logger,
+                                dbinterface=myThread.dbi)
+        countSpecDAO = daoFactory(classname="Workflow.CountWorkflowBySpec")
 
         workflows = []
         for i in range(0, 10):
-            testWorkflow = Workflow(spec = spec, owner = owner,
-                                    name = "wf00%i" % i, task = "task%i" % i)
+            testWorkflow = Workflow(spec=spec, owner=owner,
+                                    name="wf00%i" % i, task="task%i" % i)
             testWorkflow.create()
             workflows.append(testWorkflow)
 
-        self.assertEqual(countSpecDAO.execute(spec = spec), 10)
+        self.assertEqual(countSpecDAO.execute(spec=spec), 10)
 
         for i in range(0, 10):
             wf = workflows.pop()
             wf.delete()
-            self.assertEqual(countSpecDAO.execute(spec = spec), 10 - (i + 1))
-
+            self.assertEqual(countSpecDAO.execute(spec=spec), 10 - (i + 1))
 
         return
-
 
     def testWorkflowInjectMarking(self):
         """
@@ -423,36 +419,32 @@ class WorkflowTest(unittest.TestCase):
 
         Test whether or not we can mark a workflow as injected or not.
         """
-
-        spec  = "spec.py"
         owner = "moron"
-
 
         workflows = []
         for i in range(0, 10):
-            testWorkflow = Workflow(spec = "sp00%i" % i, owner = owner,
-                                    name = "wf00%i" % i, task = "task%i" % i)
+            testWorkflow = Workflow(spec="sp00%i" % i, owner=owner,
+                                    name="wf00%i" % i, task="task%i" % i)
             testWorkflow.create()
             workflows.append(testWorkflow)
 
         myThread = threading.currentThread()
-        daoFactory = DAOFactory(package="WMCore.WMBS", logger = myThread.logger,
-                                dbinterface = myThread.dbi)
-        getAction = daoFactory(classname = "Workflow.GetInjectedWorkflows")
-        markAction = daoFactory(classname = "Workflow.MarkInjectedWorkflows")
+        daoFactory = DAOFactory(package="WMCore.WMBS", logger=myThread.logger,
+                                dbinterface=myThread.dbi)
+        getAction = daoFactory(classname="Workflow.GetInjectedWorkflows")
+        markAction = daoFactory(classname="Workflow.MarkInjectedWorkflows")
 
-        result = getAction.execute(injected = True)
+        result = getAction.execute(injected=True)
         self.assertEqual(len(result), 0)
-        result = getAction.execute(injected = False)
+        result = getAction.execute(injected=False)
         self.assertEqual(len(result), 10)
 
         names = ['wf002', 'wf004', 'wf006', 'wf008']
-        markAction.execute(names = names, injected = True)
+        markAction.execute(names=names, injected=True)
 
-
-        result = getAction.execute(injected = True)
+        result = getAction.execute(injected=True)
         self.assertEqual(result, names)
-        result = getAction.execute(injected = False)
+        result = getAction.execute(injected=False)
         self.assertEqual(len(result), 6)
         return
 
@@ -468,71 +460,71 @@ class WorkflowTest(unittest.TestCase):
 
         owner = "no-one"
 
-        #Create a bunch of worklows with "different" specs and tasks
+        # Create a bunch of worklows with "different" specs and tasks
         workflows = []
         for i in range(0, 100):
             scaledIndex = i % 10
-            testWorkflow = Workflow(spec = "sp00%i" % scaledIndex,
-                                    owner = owner,
-                                    name = "wf00%i" % scaledIndex,
-                                    task = "task%i" % i)
+            testWorkflow = Workflow(spec="sp00%i" % scaledIndex,
+                                    owner=owner,
+                                    name="wf00%i" % scaledIndex,
+                                    task="task%i" % i)
             testWorkflow.create()
             workflows.append(testWorkflow)
 
-        #Everyone will use this fileset
-        testFileset = Fileset(name = "TestFileset")
+        # Everyone will use this fileset
+        testFileset = Fileset(name="TestFileset")
         testFileset.create()
 
-        #Create subscriptions!
+        # Create subscriptions!
         subscriptions = []
         for workflow in workflows:
-            subscription = Subscription(fileset = testFileset,
-                                        workflow = workflow)
+            subscription = Subscription(fileset=testFileset,
+                                        workflow=workflow)
             subscription.create()
             subscriptions.append(subscription)
 
-        #Check that all workflows are NOT finished
+        # Check that all workflows are NOT finished
         myThread = threading.currentThread()
-        daoFactory = DAOFactory(package = "WMCore.WMBS", logger = myThread.logger,
-                                dbinterface = myThread.dbi)
+        daoFactory = DAOFactory(package="WMCore.WMBS", logger=myThread.logger,
+                                dbinterface=myThread.dbi)
 
-        getFinishedDAO = daoFactory(classname = "Workflow.GetFinishedWorkflows")
+        getFinishedDAO = daoFactory(classname="Workflow.GetFinishedWorkflows")
         result = getFinishedDAO.execute()
         self.assertEqual(len(result), 0, "A workflow is incorrectly flagged as finished: %s" % str(result))
 
-        #Mark the first 50 subscriptions as finished
+        # Mark the first 50 subscriptions as finished
         for idx, sub in enumerate(subscriptions):
             if idx > 49:
                 break
             sub.markFinished()
 
-        #No workflow is finished, none of them has all the subscriptions completed
+        # No workflow is finished, none of them has all the subscriptions completed
         result = getFinishedDAO.execute()
         self.assertEqual(len(result), 0, "A workflow is incorrectly flagged as finished: %s" % str(result))
 
-        #Now finish all workflows in wf{000-5}
+        # Now finish all workflows in wf{000-5}
         for idx, sub in enumerate(subscriptions):
             if idx < 50 or idx % 10 > 5:
                 continue
             sub.markFinished()
 
-        #Check the workflows
+        # Check the workflows
         result = getFinishedDAO.execute()
         self.assertEqual(len(result), 6, "A workflow is incorrectly flagged as finished: %s" % str(result))
 
-        #Check the overall structure of the workflows
+        # Check the overall structure of the workflows
         for wf in result:
-            #Sanity checks on the results
+            # Sanity checks on the results
             # These are very specific checks and depends heavily on the names of task, spec and workflow
             self.assertEqual(wf[2:], result[wf]['spec'][2:],
-                            "A workflow has the wrong spec-name combination: %s" % str(wf))
+                             "A workflow has the wrong spec-name combination: %s" % str(wf))
             self.assertTrue(int(wf[2:]) < 6,
                             "A workflow is incorrectly flagged as finished: %s" % str(wf))
             self.assertEqual(len(result[wf]['workflows']), 10,
-                              "A workflow has more tasks than it should: %s" % str(result[wf]))
+                             "A workflow has more tasks than it should: %s" % str(result[wf]))
             for task in result[wf]['workflows']:
                 self.assertEqual(len(result[wf]['workflows'][task]), 1,
-                                  "A workflow has more subscriptions than it should: %s" % str(result[wf]))
+                                 "A workflow has more subscriptions than it should: %s" % str(result[wf]))
 
         return
 

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Express_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Express_t.py
@@ -5,18 +5,53 @@ _Express_t_
 Unit tests for the Express workflow.
 """
 
-from __future__ import division
+from __future__ import division, print_function
 
+import threading
 import unittest
+from copy import deepcopy
+from pprint import pprint, pformat
 
+from WMCore.DAOFactory import DAOFactory
 from WMCore.WMBS.Fileset import Fileset
 from WMCore.WMBS.Subscription import Subscription
 from WMCore.WMBS.Workflow import Workflow
-
-from WMCore.WorkQueue.WMBSHelper import WMBSHelper
 from WMCore.WMSpec.StdSpecs.Express import ExpressWorkloadFactory
-
+from WMCore.WorkQueue.WMBSHelper import WMBSHelper
 from WMQuality.TestInitCouchApp import TestInitCouchApp
+
+REQUEST = {
+    "AcquisitionEra": "TestAcquisitionEra",
+    "AlcaHarvestTimeout": 12 * 3600,
+    "AlcaHarvestDir": "/somepath",
+    "AlcaSkims": ["TkAlMinBias", "PromptCalibProd"],
+    "CMSSWVersion": "CMSSW_9_0_0",
+    "DQMSequences": ["@common"],
+    "DQMUploadProxy": "/somepath/proxy",
+    "DQMUploadUrl": "https://cmsweb.cern.ch/dqm/offline",
+    "GlobalTag": "SomeGlobalTag",
+    "GlobalTagTransaction": "Express_123456",
+    "GlobalTagConnect": "frontier://PromptProd/CMS_CONDITIONS",
+    "MaxInputRate": 23 * 1000,
+    "MaxInputEvents": 400,
+    "MaxInputSize": 2 * 1024 * 1024 * 1024,
+    "MaxInputFiles": 15,
+    "MaxLatency": 15 * 23,
+    "Outputs": [{'dataTier': "FEVT", 'eventContent': "FEVT",
+                 'selectEvents': ["Path1:HLT,Path2:HLT"], 'primaryDataset': "PrimaryDataset1"},
+                {'dataTier': "ALCARECO", 'eventContent': "ALCARECO", 'primaryDataset': "StreamExpress"},
+                {'dataTier': "DQMIO", 'eventContent': "DQMIO", 'primaryDataset': "StreamExpress"}],
+    "PeriodicHarvestInterval": 20 * 60,
+    "ProcessingString": "Express",
+    "ProcessingVersion": 9,
+    "RecoCMSSWVersion": "CMSSW_9_0_1",
+    "RecoScramArch": "slc6_amd64_gcc630",
+    "RunNumber": 123456,
+    "ScramArch": "slc6_amd64_gcc530",
+    "Scenario": "test_scenario",
+    "SpecialDataset": "StreamExpress",
+    "StreamName": "Express"
+}
 
 
 class ExpressTest(unittest.TestCase):
@@ -32,6 +67,15 @@ class ExpressTest(unittest.TestCase):
         self.testInit.setSchema(customModules=["WMCore.WMBS"],
                                 useDefault=False)
         self.testDir = self.testInit.generateWorkDir()
+
+        myThread = threading.currentThread()
+        self.daoFactory = DAOFactory(package="WMCore.WMBS",
+                                     logger=myThread.logger,
+                                     dbinterface=myThread.dbi)
+        self.listTasksByWorkflow = self.daoFactory(classname="Workflow.LoadFromName")
+        self.listFilesets = self.daoFactory(classname="Fileset.List")
+        self.listSubsMapping = self.daoFactory(classname="Subscriptions.ListSubsAndFilesetsFromWorkflow")
+
         return
 
     def tearDown(self):
@@ -52,48 +96,9 @@ class ExpressTest(unittest.TestCase):
         and verify it installs into WMBS correctly.
         """
         testArguments = ExpressWorkloadFactory.getTestArguments()
-        testArguments['ProcessingString'] = "Express"
-        testArguments['ProcessingVersion'] = 9
-        testArguments['Scenario'] = "test_scenario"
-        testArguments['CMSSWVersion'] = "CMSSW_9_0_0"
-        testArguments['ScramArch'] = "slc6_amd64_gcc530"
+        testArguments.update(deepcopy(REQUEST))
         testArguments['RecoCMSSWVersion'] = "CMSSW_9_0_0"
-        testArguments['RecoScramArch'] = "slc6_amd64_gcc530"
-        testArguments['GlobalTag'] = "SomeGlobalTag"
-        testArguments['GlobalTagTransaction'] = "Express_123456"
-        testArguments['GlobalTagConnect'] = "frontier://PromptProd/CMS_CONDITIONS"
-        testArguments['MaxInputRate'] = 23 * 1000
-        testArguments['MaxInputEvents'] = 400
-        testArguments['MaxInputSize'] = 2 * 1024 * 1024 * 1024
-        testArguments['MaxInputFiles'] = 15
-        testArguments['MaxLatency'] = 15 * 23
-        testArguments['AlcaSkims'] = [ "TkAlMinBias", "PromptCalibProd" ]
-        testArguments['DQMSequences'] = [ "@common" ]
-        testArguments['AlcaHarvestTimeout'] = 12 * 3600
-        testArguments['AlcaHarvestDir'] = "/somepath"
-        testArguments['DQMUploadProxy'] = "/somepath/proxy"
-        testArguments['DQMUploadUrl'] = "https://cmsweb.cern.ch/dqm/offline"
-        testArguments['StreamName'] = "Express"
-        testArguments['SpecialDataset'] = "StreamExpress"
 
-        testArguments['RunNumber'] = 123456
-        testArguments['AcquisitionEra'] = "TestAcquisitionEra"
-        testArguments['ValidStatus'] = "VALID"
-
-        testArguments['Outputs'] = []
-        testArguments['Outputs'].append( { 'dataTier' : "FEVT",
-                                           'eventContent' : "FEVT",
-                                           'selectEvents' : ["Path1:HLT,Path2:HLT"],
-                                           'primaryDataset' : "PrimaryDataset1" } )
-        testArguments['Outputs'].append( { 'dataTier' : "ALCARECO",
-                                           'eventContent' : "ALCARECO",
-                                           'primaryDataset' : "StreamExpress" } )
-        testArguments['Outputs'].append( { 'dataTier' : "DQMIO",
-                                           'eventContent' : "DQMIO",
-                                           'primaryDataset' : "StreamExpress" } )
-
-        testArguments['PeriodicHarvestInterval'] = 20 * 60
-                                         
         factory = ExpressWorkloadFactory()
         testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
         testWorkload.setSpecUrl("somespec")
@@ -106,6 +111,7 @@ class ExpressTest(unittest.TestCase):
         expressWorkflow = Workflow(name="TestWorkload",
                                    task="/TestWorkload/Express")
         expressWorkflow.load()
+        pprint(expressWorkflow.outputMap)
         self.assertEqual(len(expressWorkflow.outputMap.keys()), len(testArguments["Outputs"]) + 1,
                          "Error: Wrong number of WF outputs in the Express WF.")
 
@@ -117,7 +123,8 @@ class ExpressTest(unittest.TestCase):
             unmergedOutput.loadData()
 
             if goldenOutputMod != "write_StreamExpress_ALCARECO":
-                self.assertEqual(mergedOutput.name, "/TestWorkload/Express/ExpressMerge%s/merged-Merged" % goldenOutputMod,
+                self.assertEqual(mergedOutput.name,
+                                 "/TestWorkload/Express/ExpressMerge%s/merged-Merged" % goldenOutputMod,
                                  "Error: Merged output fileset is wrong: %s" % mergedOutput.name)
             self.assertEqual(unmergedOutput.name, "/TestWorkload/Express/unmerged-%s" % goldenOutputMod,
                              "Error: Unmerged output fileset is wrong: %s" % unmergedOutput.name)
@@ -147,9 +154,11 @@ class ExpressTest(unittest.TestCase):
             unmergedOutput = alcaSkimWorkflow.outputMap[goldenOutputMod][0]["output_fileset"]
             mergedOutput.loadData()
             unmergedOutput.loadData()
-            self.assertEqual(mergedOutput.name, "/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/unmerged-%s" % goldenOutputMod,
+            self.assertEqual(mergedOutput.name,
+                             "/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/unmerged-%s" % goldenOutputMod,
                              "Error: Merged output fileset is wrong: %s" % mergedOutput.name)
-            self.assertEqual(unmergedOutput.name, "/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/unmerged-%s" % goldenOutputMod,
+            self.assertEqual(unmergedOutput.name,
+                             "/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/unmerged-%s" % goldenOutputMod,
                              "Error: Unmerged output fileset is wrong: %s" % unmergedOutput.name)
 
         logArchOutput = alcaSkimWorkflow.outputMap["logArchive"][0]["merged_output_fileset"]
@@ -157,20 +166,21 @@ class ExpressTest(unittest.TestCase):
         logArchOutput.loadData()
         unmergedLogArchOutput.loadData()
 
-        self.assertEqual(logArchOutput.name, "/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/unmerged-logArchive",
+        self.assertEqual(logArchOutput.name,
+                         "/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/unmerged-logArchive",
                          "Error: LogArchive output fileset is wrong.")
-        self.assertEqual(unmergedLogArchOutput.name, "/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/unmerged-logArchive",
+        self.assertEqual(unmergedLogArchOutput.name,
+                         "/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/unmerged-logArchive",
                          "Error: LogArchive output fileset is wrong.")
 
         for dqmString in ["ExpressMergewrite_StreamExpress_DQMIOEndOfRunDQMHarvestMerged",
                           "ExpressMergewrite_StreamExpress_DQMIOPeriodicDQMHarvestMerged"]:
-
             dqmTask = "/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO/%s" % dqmString
 
             dqmWorkflow = Workflow(name="TestWorkload",
                                    task=dqmTask)
             dqmWorkflow.load()
-        
+
             logArchOutput = dqmWorkflow.outputMap["logArchive"][0]["merged_output_fileset"]
             unmergedLogArchOutput = dqmWorkflow.outputMap["logArchive"][0]["output_fileset"]
             logArchOutput.loadData()
@@ -198,9 +208,11 @@ class ExpressTest(unittest.TestCase):
             mergedMergeOutput.loadData()
             unmergedMergeOutput.loadData()
 
-            self.assertEqual(mergedMergeOutput.name, "/TestWorkload/Express/ExpressMerge%s/merged-Merged" % goldenOutputMod,
+            self.assertEqual(mergedMergeOutput.name,
+                             "/TestWorkload/Express/ExpressMerge%s/merged-Merged" % goldenOutputMod,
                              "Error: Merged output fileset is wrong.")
-            self.assertEqual(unmergedMergeOutput.name, "/TestWorkload/Express/ExpressMerge%s/merged-Merged" % goldenOutputMod,
+            self.assertEqual(unmergedMergeOutput.name,
+                             "/TestWorkload/Express/ExpressMerge%s/merged-Merged" % goldenOutputMod,
                              "Error: Unmerged output fileset is wrong.")
 
             logArchOutput = mergeWorkflow.outputMap["logArchive"][0]["merged_output_fileset"]
@@ -208,9 +220,11 @@ class ExpressTest(unittest.TestCase):
             logArchOutput.loadData()
             unmergedLogArchOutput.loadData()
 
-            self.assertEqual(logArchOutput.name, "/TestWorkload/Express/ExpressMerge%s/merged-logArchive" % goldenOutputMod,
+            self.assertEqual(logArchOutput.name,
+                             "/TestWorkload/Express/ExpressMerge%s/merged-logArchive" % goldenOutputMod,
                              "Error: LogArchive output fileset is wrong: %s" % logArchOutput.name)
-            self.assertEqual(unmergedLogArchOutput.name, "/TestWorkload/Express/ExpressMerge%s/merged-logArchive" % goldenOutputMod,
+            self.assertEqual(unmergedLogArchOutput.name,
+                             "/TestWorkload/Express/ExpressMerge%s/merged-logArchive" % goldenOutputMod,
                              "Error: LogArchive output fileset is wrong.")
 
         topLevelFileset = Fileset(name="TestWorkload-Express")
@@ -289,7 +303,8 @@ class ExpressTest(unittest.TestCase):
         self.assertEqual(logCollectSub["split_algo"], "MinFileBased",
                          "Error: Wrong split algorithm.")
 
-        alcaSkimLogCollect = Fileset(name="/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/unmerged-logArchive")
+        alcaSkimLogCollect = Fileset(
+            name="/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/unmerged-logArchive")
         alcaSkimLogCollect.loadData()
         alcaSkimLogCollectWorkflow = Workflow(name="TestWorkload",
                                               task="/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/AlcaSkimLogCollect")
@@ -304,12 +319,15 @@ class ExpressTest(unittest.TestCase):
 
         goldenOutputMods = ["write_PrimaryDataset1_FEVT", "write_StreamExpress_DQMIO"]
         for goldenOutputMod in goldenOutputMods:
-            expressMergeLogCollect = Fileset(name="/TestWorkload/Express/ExpressMerge%s/merged-logArchive" % goldenOutputMod)
+            expressMergeLogCollect = Fileset(
+                name="/TestWorkload/Express/ExpressMerge%s/merged-logArchive" % goldenOutputMod)
             expressMergeLogCollect.loadData()
             expressMergeLogCollectWorkflow = Workflow(name="TestWorkload",
-                                                      task="/TestWorkload/Express/ExpressMerge%s/Express%sMergeLogCollect" % (goldenOutputMod, goldenOutputMod))
+                                                      task="/TestWorkload/Express/ExpressMerge%s/Express%sMergeLogCollect" % (
+                                                      goldenOutputMod, goldenOutputMod))
             expressMergeLogCollectWorkflow.load()
-            logCollectSubscription = Subscription(fileset=expressMergeLogCollect, workflow=expressMergeLogCollectWorkflow)
+            logCollectSubscription = Subscription(fileset=expressMergeLogCollect,
+                                                  workflow=expressMergeLogCollectWorkflow)
             logCollectSubscription.loadData()
 
             self.assertEqual(logCollectSub["type"], "LogCollect",
@@ -321,8 +339,8 @@ class ExpressTest(unittest.TestCase):
                             "ExpressMergewrite_StreamExpress_DQMIOMergedEndOfRunDQMHarvestLogCollect"),
                            ("ExpressMergewrite_StreamExpress_DQMIOPeriodicDQMHarvestMerged",
                             "ExpressMergewrite_StreamExpress_DQMIOMergedPeriodicDQMHarvestLogCollect")]:
-
-            dqmFileset = "/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO/%s/unmerged-logArchive" % dqmStrings[0]
+            dqmFileset = "/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO/%s/unmerged-logArchive" % \
+                         dqmStrings[0]
             dqmHarvestLogCollect = Fileset(name=dqmFileset)
             dqmHarvestLogCollect.loadData()
 
@@ -340,7 +358,6 @@ class ExpressTest(unittest.TestCase):
 
         return
 
-
     def testMemCoresSettings(self):
         """
         _testMemCoresSettings_
@@ -349,45 +366,7 @@ class ExpressTest(unittest.TestCase):
         all tasks and steps.
         """
         testArguments = ExpressWorkloadFactory.getTestArguments()
-        testArguments['ProcessingString'] = "Express"
-        testArguments['ProcessingVersion'] = 9
-        testArguments['Scenario'] = "test_scenario"
-        testArguments['CMSSWVersion'] = "CMSSW_9_0_0"
-        testArguments['ScramArch'] = "slc6_amd64_gcc530"
-        testArguments['RecoCMSSWVersion'] = "CMSSW_9_0_0"
-        testArguments['RecoScramArch'] = "slc6_amd64_gcc530"
-        testArguments['GlobalTag'] = "SomeGlobalTag"
-        testArguments['GlobalTagTransaction'] = "Express_123456"
-        testArguments['GlobalTagConnect'] = "frontier://PromptProd/CMS_CONDITIONS"
-        testArguments['MaxInputRate'] = 23 * 1000
-        testArguments['MaxInputEvents'] = 400
-        testArguments['MaxInputSize'] = 2 * 1024 * 1024 * 1024
-        testArguments['MaxInputFiles'] = 15
-        testArguments['MaxLatency'] = 15 * 23
-        testArguments['AlcaSkims'] = [ "TkAlMinBias", "PromptCalibProd" ]
-        testArguments['DQMSequences'] = [ "@common" ]
-        testArguments['AlcaHarvestTimeout'] = 12 * 3600
-        testArguments['AlcaHarvestDir'] = "/somepath"
-        testArguments['DQMUploadProxy'] = "/somepath/proxy"
-        testArguments['DQMUploadUrl'] = "https://cmsweb.cern.ch/dqm/offline"
-        testArguments['StreamName'] = "Express"
-        testArguments['SpecialDataset'] = "StreamExpress"
-
-        testArguments['RunNumber'] = 123456
-        testArguments['AcquisitionEra'] = "TestAcquisitionEra"
-        testArguments['ValidStatus'] = "VALID"
-
-        testArguments['Outputs'] = []
-        testArguments['Outputs'].append( { 'dataTier' : "FEVT",
-                                           'eventContent' : "FEVT",
-                                           'selectEvents' : ["Path1:HLT,Path2:HLT"],
-                                           'primaryDataset' : "PrimaryDataset1" } )
-        testArguments['Outputs'].append( { 'dataTier' : "ALCARECO",
-                                           'eventContent' : "ALCARECO",
-                                           'primaryDataset' : "StreamExpress" } )
-        testArguments['Outputs'].append( { 'dataTier' : "DQMIO",
-                                           'eventContent' : "DQMIO",
-                                           'primaryDataset' : "StreamExpress" } )
+        testArguments.update(deepcopy(REQUEST))
 
         factory = ExpressWorkloadFactory()
         testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
@@ -405,50 +384,11 @@ class ExpressTest(unittest.TestCase):
             self.assertEqual(perfParams['memoryRequirement'], 2300.0)
 
         # now test case where args are provided
-        testArguments = ExpressWorkloadFactory.getTestArguments()
-        testArguments['ProcessingString'] = "Express"
-        testArguments['ProcessingVersion'] = 9
-        testArguments['Scenario'] = "test_scenario"
-        testArguments['CMSSWVersion'] = "CMSSW_9_0_0"
-        testArguments['ScramArch'] = "slc6_amd64_gcc530"
-        testArguments['RecoCMSSWVersion'] = "CMSSW_9_0_0"
-        testArguments['RecoScramArch'] = "slc6_amd64_gcc530"
-        testArguments['GlobalTag'] = "SomeGlobalTag"
-        testArguments['GlobalTagTransaction'] = "Express_123456"
-        testArguments['GlobalTagConnect'] = "frontier://PromptProd/CMS_CONDITIONS"
-        testArguments['MaxInputRate'] = 23 * 1000
-        testArguments['MaxInputEvents'] = 400
-        testArguments['MaxInputSize'] = 2 * 1024 * 1024 * 1024
-        testArguments['MaxInputFiles'] = 15
-        testArguments['MaxLatency'] = 15 * 23
-        testArguments['AlcaSkims'] = [ "TkAlMinBias", "PromptCalibProd" ]
-        testArguments['DQMSequences'] = [ "@common" ]
-        testArguments['AlcaHarvestTimeout'] = 12 * 3600
-        testArguments['AlcaHarvestDir'] = "/somepath"
-        testArguments['DQMUploadProxy'] = "/somepath/proxy"
-        testArguments['DQMUploadUrl'] = "https://cmsweb.cern.ch/dqm/offline"
-        testArguments['StreamName'] = "Express"
-        testArguments['SpecialDataset'] = "StreamExpress"
-
-        testArguments['RunNumber'] = 123456
-        testArguments['AcquisitionEra'] = "TestAcquisitionEra"
-        testArguments['ValidStatus'] = "VALID"
-
-        testArguments['Outputs'] = []
-        testArguments['Outputs'].append( { 'dataTier' : "FEVT",
-                                           'eventContent' : "FEVT",
-                                           'selectEvents' : ["Path1:HLT,Path2:HLT"],
-                                           'primaryDataset' : "PrimaryDataset1" } )
-        testArguments['Outputs'].append( { 'dataTier' : "ALCARECO",
-                                           'eventContent' : "ALCARECO",
-                                           'primaryDataset' : "StreamExpress" } )
-        testArguments['Outputs'].append( { 'dataTier' : "DQMIO",
-                                           'eventContent' : "DQMIO",
-                                           'primaryDataset' : "StreamExpress" } )
-
+        # testArguments = ExpressWorkloadFactory.getTestArguments()
         testArguments["Multicore"] = 6
         testArguments["Memory"] = 4600.0
         testArguments["EventStreams"] = 3
+        testArguments["Outputs"] = deepcopy(REQUEST['Outputs'])
 
         factory = ExpressWorkloadFactory()
         testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
@@ -472,7 +412,6 @@ class ExpressTest(unittest.TestCase):
 
         return
 
-
     def testWithRepackStep(self):
         """
         _testWithRepackStep_
@@ -480,45 +419,7 @@ class ExpressTest(unittest.TestCase):
         Make sure we get an initial repack step if CMSSW versions are mismatched
         """
         testArguments = ExpressWorkloadFactory.getTestArguments()
-        testArguments['ProcessingString'] = "Express"
-        testArguments['ProcessingVersion'] = 9
-        testArguments['Scenario'] = "test_scenario"
-        testArguments['CMSSWVersion'] = "CMSSW_9_0_0"
-        testArguments['ScramArch'] = "slc6_amd64_gcc530"
-        testArguments['RecoCMSSWVersion'] = "CMSSW_9_0_1"
-        testArguments['RecoScramArch'] = "slc6_amd64_gcc630"
-        testArguments['GlobalTag'] = "SomeGlobalTag"
-        testArguments['GlobalTagTransaction'] = "Express_123456"
-        testArguments['GlobalTagConnect'] = "frontier://PromptProd/CMS_CONDITIONS"
-        testArguments['MaxInputRate'] = 23 * 1000
-        testArguments['MaxInputEvents'] = 400
-        testArguments['MaxInputSize'] = 2 * 1024 * 1024 * 1024
-        testArguments['MaxInputFiles'] = 15
-        testArguments['MaxLatency'] = 15 * 23
-        testArguments['AlcaSkims'] = [ "TkAlMinBias", "PromptCalibProd" ]
-        testArguments['DQMSequences'] = [ "@common" ]
-        testArguments['AlcaHarvestTimeout'] = 12 * 3600
-        testArguments['AlcaHarvestDir'] = "/somepath"
-        testArguments['DQMUploadProxy'] = "/somepath/proxy"
-        testArguments['DQMUploadUrl'] = "https://cmsweb.cern.ch/dqm/offline"
-        testArguments['StreamName'] = "Express"
-        testArguments['SpecialDataset'] = "StreamExpress"
-
-        testArguments['RunNumber'] = 123456
-        testArguments['AcquisitionEra'] = "TestAcquisitionEra"
-        testArguments['ValidStatus'] = "VALID"
-
-        testArguments['Outputs'] = []
-        testArguments['Outputs'].append( { 'dataTier' : "FEVT",
-                                           'eventContent' : "FEVT",
-                                           'selectEvents' : ["Path1:HLT,Path2:HLT"],
-                                           'primaryDataset' : "PrimaryDataset1" } )
-        testArguments['Outputs'].append( { 'dataTier' : "ALCARECO",
-                                           'eventContent' : "ALCARECO",
-                                           'primaryDataset' : "StreamExpress" } )
-        testArguments['Outputs'].append( { 'dataTier' : "DQMIO",
-                                           'eventContent' : "DQMIO",
-                                           'primaryDataset' : "StreamExpress" } )
+        testArguments.update(deepcopy(REQUEST))
 
         factory = ExpressWorkloadFactory()
         testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
@@ -536,6 +437,172 @@ class ExpressTest(unittest.TestCase):
         self.assertEqual(stepHelper.getScramArch(), ["slc6_amd64_gcc630"])
 
         return
+
+    def testFilesets(self):
+        """
+        Test filesets created for an Express workflow
+        """
+        # expected tasks, filesets, subscriptions, etc
+        expOutTasks = ['/TestWorkload/Express',
+                       '/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO',
+                       '/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/ExpressAlcaSkimwrite_StreamExpress_ALCARECOAlcaHarvestALCARECOStreamPromptCalibProd',
+                       '/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO',
+                       '/TestWorkload/Express/ExpressMergewrite_PrimaryDataset1_FEVT']
+        expWfTasks = ['/TestWorkload/Express',
+                      '/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO',
+                      '/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/AlcaSkimLogCollect',
+                      '/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/ExpressAlcaSkimwrite_StreamExpress_ALCARECOAlcaHarvestALCARECOStreamPromptCalibProd',
+                      '/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/ExpressAlcaSkimwrite_StreamExpress_ALCARECOAlcaHarvestALCARECOStreamPromptCalibProd/ExpressAlcaSkimwrite_StreamExpress_ALCARECOAlcaHarvestALCARECOStreamPromptCalibProdConditionSqlite',
+                      '/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/ExpressAlcaSkimwrite_StreamExpress_ALCARECOAlcaHarvestALCARECOStreamPromptCalibProd/ExpressAlcaSkimwrite_StreamExpress_ALCARECOALCARECOStreamPromptCalibProdAlcaHarvestLogCollect',
+                      '/TestWorkload/Express/ExpressCleanupUnmergedwrite_PrimaryDataset1_FEVT',
+                      '/TestWorkload/Express/ExpressCleanupUnmergedwrite_StreamExpress_ALCARECO',
+                      '/TestWorkload/Express/ExpressCleanupUnmergedwrite_StreamExpress_DQMIO',
+                      '/TestWorkload/Express/ExpressLogCollect',
+                      '/TestWorkload/Express/ExpressMergewrite_PrimaryDataset1_FEVT',
+                      '/TestWorkload/Express/ExpressMergewrite_PrimaryDataset1_FEVT/Expresswrite_PrimaryDataset1_FEVTMergeLogCollect',
+                      '/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO',
+                      '/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO/ExpressMergewrite_StreamExpress_DQMIOEndOfRunDQMHarvestMerged',
+                      '/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO/ExpressMergewrite_StreamExpress_DQMIOEndOfRunDQMHarvestMerged/ExpressMergewrite_StreamExpress_DQMIOMergedEndOfRunDQMHarvestLogCollect',
+                      '/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO/ExpressMergewrite_StreamExpress_DQMIOPeriodicDQMHarvestMerged',
+                      '/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO/ExpressMergewrite_StreamExpress_DQMIOPeriodicDQMHarvestMerged/ExpressMergewrite_StreamExpress_DQMIOMergedPeriodicDQMHarvestLogCollect',
+                      '/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO/Expresswrite_StreamExpress_DQMIOMergeLogCollect']
+        expFsets = ['TestWorkload-Express-Run123456',
+                    '/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/unmerged-ALCARECOStreamPromptCalibProd',
+                    '/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/unmerged-ALCARECOStreamTkAlMinBias',
+                    '/TestWorkload/Express/unmerged-write_RAW',
+                    '/TestWorkload/Express/unmerged-write_StreamExpress_ALCARECO',
+                    '/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/ExpressAlcaSkimwrite_StreamExpress_ALCARECOAlcaHarvestALCARECOStreamPromptCalibProd/unmerged-logArchive',
+                    '/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/ExpressAlcaSkimwrite_StreamExpress_ALCARECOAlcaHarvestALCARECOStreamPromptCalibProd/unmerged-Sqlite',
+                    '/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/unmerged-logArchive',
+                    '/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO/ExpressMergewrite_StreamExpress_DQMIOPeriodicDQMHarvestMerged/unmerged-logArchive',
+                    '/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO/merged-Merged',
+                    '/TestWorkload/Express/unmerged-write_StreamExpress_DQMIO',
+                    '/TestWorkload/Express/ExpressMergewrite_PrimaryDataset1_FEVT/merged-logArchive',
+                    '/TestWorkload/Express/ExpressMergewrite_PrimaryDataset1_FEVT/merged-Merged',
+                    '/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO/ExpressMergewrite_StreamExpress_DQMIOEndOfRunDQMHarvestMerged/unmerged-logArchive',
+                    '/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO/merged-logArchive',
+                    '/TestWorkload/Express/unmerged-logArchive',
+                    '/TestWorkload/Express/unmerged-write_PrimaryDataset1_FEVT']
+
+        subMaps = [(5,
+                    '/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/ExpressAlcaSkimwrite_StreamExpress_ALCARECOAlcaHarvestALCARECOStreamPromptCalibProd/unmerged-logArchive',
+                    '/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/ExpressAlcaSkimwrite_StreamExpress_ALCARECOAlcaHarvestALCARECOStreamPromptCalibProd/ExpressAlcaSkimwrite_StreamExpress_ALCARECOALCARECOStreamPromptCalibProdAlcaHarvestLogCollect',
+                    'MinFileBased',
+                    'LogCollect'),
+                   (4,
+                    '/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/ExpressAlcaSkimwrite_StreamExpress_ALCARECOAlcaHarvestALCARECOStreamPromptCalibProd/unmerged-Sqlite',
+                    '/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/ExpressAlcaSkimwrite_StreamExpress_ALCARECOAlcaHarvestALCARECOStreamPromptCalibProd/ExpressAlcaSkimwrite_StreamExpress_ALCARECOAlcaHarvestALCARECOStreamPromptCalibProdConditionSqlite',
+                    'Condition',
+                    'Harvesting'),
+                   (3,
+                    '/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/unmerged-ALCARECOStreamPromptCalibProd',
+                    '/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/ExpressAlcaSkimwrite_StreamExpress_ALCARECOAlcaHarvestALCARECOStreamPromptCalibProd',
+                    'AlcaHarvest',
+                    'Harvesting'),
+                   (6,
+                    '/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/unmerged-logArchive',
+                    '/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO/AlcaSkimLogCollect',
+                    'MinFileBased',
+                    'LogCollect'),
+                   (16,
+                    '/TestWorkload/Express/ExpressMergewrite_PrimaryDataset1_FEVT/merged-logArchive',
+                    '/TestWorkload/Express/ExpressMergewrite_PrimaryDataset1_FEVT/Expresswrite_PrimaryDataset1_FEVTMergeLogCollect',
+                    'MinFileBased',
+                    'LogCollect'),
+                   (12,
+                    '/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO/ExpressMergewrite_StreamExpress_DQMIOEndOfRunDQMHarvestMerged/unmerged-logArchive',
+                    '/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO/ExpressMergewrite_StreamExpress_DQMIOEndOfRunDQMHarvestMerged/ExpressMergewrite_StreamExpress_DQMIOMergedEndOfRunDQMHarvestLogCollect',
+                    'MinFileBased',
+                    'LogCollect'),
+                   (10,
+                    '/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO/ExpressMergewrite_StreamExpress_DQMIOPeriodicDQMHarvestMerged/unmerged-logArchive',
+                    '/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO/ExpressMergewrite_StreamExpress_DQMIOPeriodicDQMHarvestMerged/ExpressMergewrite_StreamExpress_DQMIOMergedPeriodicDQMHarvestLogCollect',
+                    'MinFileBased',
+                    'LogCollect'),
+                   (13,
+                    '/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO/merged-logArchive',
+                    '/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO/Expresswrite_StreamExpress_DQMIOMergeLogCollect',
+                    'MinFileBased',
+                    'LogCollect'),
+                   (11,
+                    '/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO/merged-Merged',
+                    '/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO/ExpressMergewrite_StreamExpress_DQMIOEndOfRunDQMHarvestMerged',
+                    'Harvest',
+                    'Harvesting'),
+                   (9,
+                    '/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO/merged-Merged',
+                    '/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO/ExpressMergewrite_StreamExpress_DQMIOPeriodicDQMHarvestMerged',
+                    'Harvest',
+                    'Harvesting'),
+                   (18,
+                    '/TestWorkload/Express/unmerged-logArchive',
+                    '/TestWorkload/Express/ExpressLogCollect',
+                    'MinFileBased',
+                    'LogCollect'),
+                   (17,
+                    '/TestWorkload/Express/unmerged-write_PrimaryDataset1_FEVT',
+                    '/TestWorkload/Express/ExpressCleanupUnmergedwrite_PrimaryDataset1_FEVT',
+                    'SiblingProcessingBased',
+                    'Cleanup'),
+                   (15,
+                    '/TestWorkload/Express/unmerged-write_PrimaryDataset1_FEVT',
+                    '/TestWorkload/Express/ExpressMergewrite_PrimaryDataset1_FEVT',
+                    'ExpressMerge',
+                    'Merge'),
+                   (2,
+                    '/TestWorkload/Express/unmerged-write_StreamExpress_ALCARECO',
+                    '/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO',
+                    'ExpressMerge',
+                    'Express'),
+                   (7,
+                    '/TestWorkload/Express/unmerged-write_StreamExpress_ALCARECO',
+                    '/TestWorkload/Express/ExpressCleanupUnmergedwrite_StreamExpress_ALCARECO',
+                    'SiblingProcessingBased',
+                    'Cleanup'),
+                   (14,
+                    '/TestWorkload/Express/unmerged-write_StreamExpress_DQMIO',
+                    '/TestWorkload/Express/ExpressCleanupUnmergedwrite_StreamExpress_DQMIO',
+                    'SiblingProcessingBased',
+                    'Cleanup'),
+                   (8,
+                    '/TestWorkload/Express/unmerged-write_StreamExpress_DQMIO',
+                    '/TestWorkload/Express/ExpressMergewrite_StreamExpress_DQMIO',
+                    'ExpressMerge',
+                    'Merge'),
+                   (1,
+                    'TestWorkload-Express-Run123456',
+                    '/TestWorkload/Express',
+                    'Express',
+                    'Express')]
+
+        testArguments = ExpressWorkloadFactory.getTestArguments()
+        testArguments.update(deepcopy(REQUEST))
+
+        factory = ExpressWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
+
+        testWMBSHelper = WMBSHelper(testWorkload, "Express",
+                                    blockName="Run123456",
+                                    cachepath=self.testInit.testDir)
+        testWMBSHelper.createTopLevelFileset()
+        testWMBSHelper._createSubscriptionsInWMBS(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
+
+        print("Tasks producing output:\n%s" % pformat(testWorkload.listOutputProducingTasks()))
+        self.assertItemsEqual(testWorkload.listOutputProducingTasks(), expOutTasks)
+
+        workflows = self.listTasksByWorkflow.execute(workflow="TestWorkload")
+        print("List of workflows:\n%s" % pformat([item['task'] for item in workflows]))
+        self.assertItemsEqual([item['task'] for item in workflows], expWfTasks)
+
+        # returns a tuple of id, name, open and last_update
+        filesets = self.listFilesets.execute()
+        print("List of filesets:\n%s" % pformat([item[1] for item in filesets]))
+        self.assertItemsEqual([item[1] for item in filesets], expFsets)
+
+        subscriptions = self.listSubsMapping.execute(workflow="TestWorkload", returnTuple=True)
+        print("List of subscriptions:\n%s" % pformat(subscriptions))
+        self.assertItemsEqual(subscriptions, subMaps)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/ReDigi_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/ReDigi_t.py
@@ -4,10 +4,14 @@ _ReDigi_t_
 
 Unit tests for the ReDigi workflow.
 """
+from __future__ import print_function
 
 import os
+import threading
 import unittest
+from pprint import pformat
 
+from WMCore.DAOFactory import DAOFactory
 from WMCore.Database.CMSCouch import CouchServer, Document
 from WMCore.WMBS.Fileset import Fileset
 from WMCore.WMBS.Subscription import Subscription
@@ -89,6 +93,14 @@ class ReDigiTest(EmulatedUnitTestCase):
         couchServer = CouchServer(os.environ["COUCHURL"])
         self.configDatabase = couchServer.connectDatabase("redigi_t")
 
+        myThread = threading.currentThread()
+        self.daoFactory = DAOFactory(package="WMCore.WMBS",
+                                     logger=myThread.logger,
+                                     dbinterface=myThread.dbi)
+        self.listTasksByWorkflow = self.daoFactory(classname="Workflow.LoadFromName")
+        self.listFilesets = self.daoFactory(classname="Fileset.List")
+        self.listSubsMapping = self.daoFactory(classname="Subscriptions.ListSubsAndFilesetsFromWorkflow")
+
         return
 
     def tearDown(self):
@@ -137,43 +149,43 @@ class ReDigiTest(EmulatedUnitTestCase):
         stepOneLogArchiveFileset = Fileset(name="/TestWorkload/StepOneProc/unmerged-logArchive")
         stepOneLogArchiveFileset.loadData()
         stepOneMergeLogArchiveFileset = Fileset(
-                name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/merged-logArchive")
+            name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/merged-logArchive")
         stepOneMergeLogArchiveFileset.loadData()
 
         stepTwoUnmergedDQMFileset = Fileset(
-                name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/unmerged-DQMoutput")
+            name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/unmerged-DQMoutput")
         stepTwoUnmergedDQMFileset.loadData()
         stepTwoUnmergedRECOFileset = Fileset(
-                name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/unmerged-RECODEBUGoutput")
+            name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/unmerged-RECODEBUGoutput")
         stepTwoUnmergedRECOFileset.loadData()
         stepTwoMergedDQMFileset = Fileset(
-                name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeDQMoutput/merged-Merged")
+            name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeDQMoutput/merged-Merged")
         stepTwoMergedDQMFileset.loadData()
         stepTwoMergedRECOFileset = Fileset(
-                name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeRECODEBUGoutput/merged-Merged")
+            name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeRECODEBUGoutput/merged-Merged")
         stepTwoMergedRECOFileset.loadData()
         stepTwoLogArchiveFileset = Fileset(
-                name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/unmerged-logArchive")
+            name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/unmerged-logArchive")
         stepTwoLogArchiveFileset.loadData()
         stepTwoMergeDQMLogArchiveFileset = Fileset(
-                name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeDQMoutput/merged-logArchive")
+            name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeDQMoutput/merged-logArchive")
         stepTwoMergeDQMLogArchiveFileset.loadData()
         stepTwoMergeRECOLogArchiveFileset = Fileset(
-                name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeRECODEBUGoutput/merged-logArchive")
+            name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeRECODEBUGoutput/merged-logArchive")
         stepTwoMergeRECOLogArchiveFileset.loadData()
 
         stepThreeUnmergedAODFileset = Fileset(
-                name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeRECODEBUGoutput/StepThreeProc/unmerged-aodOutputModule")
+            name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeRECODEBUGoutput/StepThreeProc/unmerged-aodOutputModule")
         stepThreeUnmergedAODFileset.loadData()
         stepThreeMergedAODFileset = Fileset(
-                name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeRECODEBUGoutput/StepThreeProc/StepThreeProcMergeaodOutputModule/merged-Merged")
+            name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeRECODEBUGoutput/StepThreeProc/StepThreeProcMergeaodOutputModule/merged-Merged")
         stepThreeMergedAODFileset.loadData()
         stepThreeLogArchiveFileset = Fileset(
-                name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeRECODEBUGoutput/StepThreeProc/unmerged-logArchive")
+            name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeRECODEBUGoutput/StepThreeProc/unmerged-logArchive")
         stepThreeLogArchiveFileset.loadData()
 
         stepThreeMergeLogArchiveFileset = Fileset(
-                name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeRECODEBUGoutput/StepThreeProc/StepThreeProcMergeaodOutputModule/merged-logArchive")
+            name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeRECODEBUGoutput/StepThreeProc/StepThreeProcMergeaodOutputModule/merged-logArchive")
         stepThreeMergeLogArchiveFileset.loadData()
 
         stepOneWorkflow = Workflow(spec="somespec", name="TestWorkload",
@@ -460,15 +472,15 @@ class ReDigiTest(EmulatedUnitTestCase):
         stepTwoMergedDQMFileset = Fileset(name="/TestWorkload/StepOneProc/StepOneProcMergeDQMoutput/merged-Merged")
         stepTwoMergedDQMFileset.loadData()
         stepTwoMergedRECOFileset = Fileset(
-                name="/TestWorkload/StepOneProc/StepOneProcMergeRECODEBUGoutput/merged-Merged")
+            name="/TestWorkload/StepOneProc/StepOneProcMergeRECODEBUGoutput/merged-Merged")
         stepTwoMergedRECOFileset.loadData()
         stepTwoLogArchiveFileset = Fileset(name="/TestWorkload/StepOneProc/unmerged-logArchive")
         stepTwoLogArchiveFileset.loadData()
         stepTwoMergeDQMLogArchiveFileset = Fileset(
-                name="/TestWorkload/StepOneProc/StepOneProcMergeDQMoutput/merged-logArchive")
+            name="/TestWorkload/StepOneProc/StepOneProcMergeDQMoutput/merged-logArchive")
         stepTwoMergeDQMLogArchiveFileset.loadData()
         stepTwoMergeRECOLogArchiveFileset = Fileset(
-                name="/TestWorkload/StepOneProc/StepOneProcMergeRECODEBUGoutput/merged-logArchive")
+            name="/TestWorkload/StepOneProc/StepOneProcMergeRECODEBUGoutput/merged-logArchive")
         stepTwoMergeRECOLogArchiveFileset.loadData()
 
         stepTwoWorkflow = Workflow(spec="somespec", name="TestWorkload",
@@ -601,12 +613,12 @@ class ReDigiTest(EmulatedUnitTestCase):
         stepTwoUnmergedAODFileset = Fileset(name="/TestWorkload/StepOneProc/unmerged-aodOutputModule")
         stepTwoUnmergedAODFileset.loadData()
         stepTwoMergedAODFileset = Fileset(
-                name="/TestWorkload/StepOneProc/StepOneProcMergeaodOutputModule/merged-Merged")
+            name="/TestWorkload/StepOneProc/StepOneProcMergeaodOutputModule/merged-Merged")
         stepTwoMergedAODFileset.loadData()
         stepTwoLogArchiveFileset = Fileset(name="/TestWorkload/StepOneProc/unmerged-logArchive")
         stepTwoLogArchiveFileset.loadData()
         stepTwoMergeAODLogArchiveFileset = Fileset(
-                name="/TestWorkload/StepOneProc/StepOneProcMergeaodOutputModule/merged-logArchive")
+            name="/TestWorkload/StepOneProc/StepOneProcMergeaodOutputModule/merged-logArchive")
         stepTwoMergeAODLogArchiveFileset.loadData()
 
         stepTwoWorkflow = Workflow(spec="somespec", name="TestWorkload",
@@ -1111,6 +1123,180 @@ class ReDigiTest(EmulatedUnitTestCase):
         self.assertEqual(perfParams['memoryRequirement'], defaultArguments["Memory"])
 
         return
+
+    def test1StepFilesets(self):
+        """
+        Test workflow tasks, filesets and subscriptions creation for a single step ReDigi
+        """
+        # expected tasks, filesets, subscriptions, etc
+        expOutTasks = ['/TestWorkload/StepOneProc',
+                       '/TestWorkload/StepOneProc/StepOneProcMergeaodOutputModule']
+        expWfTasks = ['/TestWorkload/StepOneProc',
+                      '/TestWorkload/StepOneProc/LogCollect',
+                      '/TestWorkload/StepOneProc/StepOneProcCleanupUnmergedaodOutputModule',
+                      '/TestWorkload/StepOneProc/StepOneProcMergeaodOutputModule',
+                      '/TestWorkload/StepOneProc/StepOneProcMergeaodOutputModule/StepOneProcaodOutputModuleMergeLogCollect']
+        expFsets = ['TestWorkload-StepOneProc-/MinimumBias/ComissioningHI-v1/RAW',
+                    '/TestWorkload/StepOneProc/StepOneProcMergeaodOutputModule/merged-logArchive',
+                    '/TestWorkload/StepOneProc/StepOneProcMergeaodOutputModule/merged-Merged',
+                    '/TestWorkload/StepOneProc/unmerged-aodOutputModule',
+                    '/TestWorkload/StepOneProc/unmerged-logArchive']
+        subMaps = [(3,
+                    '/TestWorkload/StepOneProc/StepOneProcMergeaodOutputModule/merged-logArchive',
+                    '/TestWorkload/StepOneProc/StepOneProcMergeaodOutputModule/StepOneProcaodOutputModuleMergeLogCollect',
+                    'MinFileBased',
+                    'LogCollect'),
+                   (4,
+                    '/TestWorkload/StepOneProc/unmerged-aodOutputModule',
+                    '/TestWorkload/StepOneProc/StepOneProcCleanupUnmergedaodOutputModule',
+                    'SiblingProcessingBased',
+                    'Cleanup'),
+                   (2,
+                    '/TestWorkload/StepOneProc/unmerged-aodOutputModule',
+                    '/TestWorkload/StepOneProc/StepOneProcMergeaodOutputModule',
+                    'ParentlessMergeBySize',
+                    'Merge'),
+                   (5,
+                    '/TestWorkload/StepOneProc/unmerged-logArchive',
+                    '/TestWorkload/StepOneProc/LogCollect',
+                    'MinFileBased',
+                    'LogCollect'),
+                   (1,
+                    'TestWorkload-StepOneProc-/MinimumBias/ComissioningHI-v1/RAW',
+                    '/TestWorkload/StepOneProc',
+                    'EventAwareLumiBased',
+                    'Processing')]
+
+        testArguments = ReDigiWorkloadFactory.getTestArguments()
+        testArguments["CouchURL"] = os.environ["COUCHURL"]
+        testArguments["CouchDBName"] = "redigi_t"
+        configs = injectReDigiConfigs(self.configDatabase)
+        testArguments["StepOneConfigCacheID"] = configs[2]
+
+        factory = ReDigiWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
+
+        testWMBSHelper = WMBSHelper(testWorkload, "StepOneProc", blockName=testArguments['InputDataset'],
+                                    cachepath=self.testInit.testDir)
+        testWMBSHelper.createTopLevelFileset()
+        testWMBSHelper._createSubscriptionsInWMBS(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
+
+        print("Tasks producing output:\n%s" % pformat(testWorkload.listOutputProducingTasks()))
+        self.assertItemsEqual(testWorkload.listOutputProducingTasks(), expOutTasks)
+
+        workflows = self.listTasksByWorkflow.execute(workflow="TestWorkload")
+        print("List of workflow tasks:\n%s" % pformat([item['task'] for item in workflows]))
+        self.assertItemsEqual([item['task'] for item in workflows], expWfTasks)
+
+        # returns a tuple of id, name, open and last_update
+        filesets = self.listFilesets.execute()
+        print("List of filesets:\n%s" % pformat([item[1] for item in filesets]))
+        self.assertItemsEqual([item[1] for item in filesets], expFsets)
+
+        subscriptions = self.listSubsMapping.execute(workflow="TestWorkload", returnTuple=True)
+        print("List of subscriptions:\n%s" % pformat(subscriptions))
+        self.assertItemsEqual(subscriptions, subMaps)
+
+    def test2StepFilesets(self):
+        """
+        Test workflow tasks, filesets and subscriptions creation for a double steps ReDigi
+        """
+        # expected tasks, filesets, subscriptions, etc
+        expOutTasks = ['/TestWorkload/StepOneProc',
+                       '/TestWorkload/StepOneProc/StepOneProcMergeDQMoutput',
+                       '/TestWorkload/StepOneProc/StepOneProcMergeRECODEBUGoutput']
+        expWfTasks = ['/TestWorkload/StepOneProc',
+                      '/TestWorkload/StepOneProc/LogCollect',
+                      '/TestWorkload/StepOneProc/StepOneProcCleanupUnmergedDQMoutput',
+                      '/TestWorkload/StepOneProc/StepOneProcCleanupUnmergedRECODEBUGoutput',
+                      '/TestWorkload/StepOneProc/StepOneProcMergeDQMoutput',
+                      '/TestWorkload/StepOneProc/StepOneProcMergeDQMoutput/StepOneProcDQMoutputMergeLogCollect',
+                      '/TestWorkload/StepOneProc/StepOneProcMergeRECODEBUGoutput',
+                      '/TestWorkload/StepOneProc/StepOneProcMergeRECODEBUGoutput/StepOneProcRECODEBUGoutputMergeLogCollect']
+        expFsets = ['TestWorkload-StepOneProc-/MinimumBias/ComissioningHI-v1/RAW',
+                    '/TestWorkload/StepOneProc/unmerged-DQMoutput',
+                    '/TestWorkload/StepOneProc/unmerged-RAWDEBUGoutput',
+                    '/TestWorkload/StepOneProc/StepOneProcMergeDQMoutput/merged-logArchive',
+                    '/TestWorkload/StepOneProc/StepOneProcMergeDQMoutput/merged-Merged',
+                    '/TestWorkload/StepOneProc/StepOneProcMergeRECODEBUGoutput/merged-logArchive',
+                    '/TestWorkload/StepOneProc/StepOneProcMergeRECODEBUGoutput/merged-Merged',
+                    '/TestWorkload/StepOneProc/unmerged-logArchive',
+                    '/TestWorkload/StepOneProc/unmerged-RECODEBUGoutput']
+        subMaps = [(3,
+                    '/TestWorkload/StepOneProc/StepOneProcMergeDQMoutput/merged-logArchive',
+                    '/TestWorkload/StepOneProc/StepOneProcMergeDQMoutput/StepOneProcDQMoutputMergeLogCollect',
+                    'MinFileBased',
+                    'LogCollect'),
+                   (6,
+                    '/TestWorkload/StepOneProc/StepOneProcMergeRECODEBUGoutput/merged-logArchive',
+                    '/TestWorkload/StepOneProc/StepOneProcMergeRECODEBUGoutput/StepOneProcRECODEBUGoutputMergeLogCollect',
+                    'MinFileBased',
+                    'LogCollect'),
+                   (4,
+                    '/TestWorkload/StepOneProc/unmerged-DQMoutput',
+                    '/TestWorkload/StepOneProc/StepOneProcCleanupUnmergedDQMoutput',
+                    'SiblingProcessingBased',
+                    'Cleanup'),
+                   (2,
+                    '/TestWorkload/StepOneProc/unmerged-DQMoutput',
+                    '/TestWorkload/StepOneProc/StepOneProcMergeDQMoutput',
+                    'ParentlessMergeBySize',
+                    'Merge'),
+                   (8,
+                    '/TestWorkload/StepOneProc/unmerged-logArchive',
+                    '/TestWorkload/StepOneProc/LogCollect',
+                    'MinFileBased',
+                    'LogCollect'),
+                   (7,
+                    '/TestWorkload/StepOneProc/unmerged-RECODEBUGoutput',
+                    '/TestWorkload/StepOneProc/StepOneProcCleanupUnmergedRECODEBUGoutput',
+                    'SiblingProcessingBased',
+                    'Cleanup'),
+                   (5,
+                    '/TestWorkload/StepOneProc/unmerged-RECODEBUGoutput',
+                    '/TestWorkload/StepOneProc/StepOneProcMergeRECODEBUGoutput',
+                    'ParentlessMergeBySize',
+                    'Merge'),
+                   (1,
+                    'TestWorkload-StepOneProc-/MinimumBias/ComissioningHI-v1/RAW',
+                    '/TestWorkload/StepOneProc',
+                    'EventAwareLumiBased',
+                    'Processing')]
+
+        testArguments = ReDigiWorkloadFactory.getTestArguments()
+        testArguments["CouchURL"] = os.environ["COUCHURL"]
+        testArguments["CouchDBName"] = "redigi_t"
+        configs = injectReDigiConfigs(self.configDatabase)
+        testArguments["StepOneConfigCacheID"] = configs[0]
+        testArguments["StepTwoConfigCacheID"] = configs[1]
+        testArguments["KeepStepOneOutput"] = False
+        testArguments["KeepStepTwoOutput"] = True
+        testArguments["StepOneOutputModuleName"] = "RAWDEBUGoutput"
+        testArguments["StepTwoOutputModuleName"] = "RECODEBUGoutput"
+
+        factory = ReDigiWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
+
+        testWMBSHelper = WMBSHelper(testWorkload, "StepOneProc", blockName=testArguments['InputDataset'],
+                                    cachepath=self.testInit.testDir)
+        testWMBSHelper.createTopLevelFileset()
+        testWMBSHelper._createSubscriptionsInWMBS(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
+
+        print("Tasks producing output:\n%s" % pformat(testWorkload.listOutputProducingTasks()))
+        self.assertItemsEqual(testWorkload.listOutputProducingTasks(), expOutTasks)
+
+        workflows = self.listTasksByWorkflow.execute(workflow="TestWorkload")
+        print("List of workflow tasks:\n%s" % pformat([item['task'] for item in workflows]))
+        self.assertItemsEqual([item['task'] for item in workflows], expWfTasks)
+
+        # returns a tuple of id, name, open and last_update
+        filesets = self.listFilesets.execute()
+        print("List of filesets:\n%s" % pformat([item[1] for item in filesets]))
+        self.assertItemsEqual([item[1] for item in filesets], expFsets)
+
+        subscriptions = self.listSubsMapping.execute(workflow="TestWorkload", returnTuple=True)
+        print("List of subscriptions:\n%s" % pformat(subscriptions))
+        self.assertItemsEqual(subscriptions, subMaps)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Real src code changes are:
* a couple of DAOs added, so far used only by unit tests
* another one just renamed

All the rest is unittests created for all WMSpec requests, such that we can test how workflow tasks, filesets and subscriptions get created on the agent side. 

There is quite a few things still being printed, since I'll have to come back to all these tests later this week (once I push changes to StepChain). I'll then clean them up.