### PR TITLE
Support any mix of output modules in StepChain

### DIFF
--- a/src/python/WMComponent/JobAccountant/AccountantWorker.py
+++ b/src/python/WMComponent/JobAccountant/AccountantWorker.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
-#pylint: disable=E1103, E1101, C0301
-#E1103: Use DB objects attached to thread
-#E1101: Create config sections
-#C0301: The names for everything are so ridiculously long
+# pylint: disable=E1103, E1101, C0301
+# E1103: Use DB objects attached to thread
+# E1101: Create config sections
+# C0301: The names for everything are so ridiculously long
 # that I'm disabling this.  The rest of you will have to get
 # bigger monitors.
 """
@@ -11,28 +11,25 @@ _AccountantWorker_
 Used by the JobAccountant to do the actual processing of completed jobs.
 """
 
+import collections
+import gc
+import logging
 import os
 import threading
-import logging
-import gc
-import collections
 
-from WMCore.FwkJobReport.Report  import Report
-from WMCore.DAOFactory           import DAOFactory
-from WMCore.WMConnectionBase     import WMConnectionBase
-from WMCore.WMException          import WMException
-
-from WMCore.DataStructs.Run import Run
-from WMCore.WMBS.File       import File
-from WMCore.WMBS.Job        import Job
-
-from WMCore.JobStateMachine.ChangeState import ChangeState
 from WMComponent.DBS3Buffer.DBSBufferFile import DBSBufferFile
+from WMCore.ACDC.DataCollectionService import DataCollectionService
+from WMCore.DAOFactory import DAOFactory
+from WMCore.Database.CMSCouch import CouchServer
+from WMCore.FwkJobReport.Report import Report
+from WMCore.JobStateMachine.ChangeState import ChangeState
+from WMCore.Lexicon import sanitizeURL
 from WMCore.Services.PhEDEx.PhEDEx import PhEDEx
 from WMCore.Services.WMStats.WMStatsWriter import WMStatsWriter
-from WMCore.Database.CMSCouch import CouchServer
-from WMCore.Lexicon import sanitizeURL
-from WMCore.ACDC.DataCollectionService  import DataCollectionService
+from WMCore.WMBS.File import File
+from WMCore.WMBS.Job import Job
+from WMCore.WMConnectionBase import WMConnectionBase
+from WMCore.WMException import WMException
 
 
 class AccountantWorkerException(WMException):
@@ -48,6 +45,7 @@ class AccountantWorker(WMConnectionBase):
     Class that actually does the work of parsing FWJRs for the Accountant
     Run through ProcessPool
     """
+
     def __init__(self, config):
         """
         __init__
@@ -56,40 +54,40 @@ class AccountantWorker(WMConnectionBase):
         """
         WMConnectionBase.__init__(self, "WMCore.WMBS")
         myThread = threading.currentThread()
-        self.dbsDaoFactory = DAOFactory(package = "WMComponent.DBS3Buffer",
-                                        logger = myThread.logger,
-                                        dbinterface = myThread.dbi)
+        self.dbsDaoFactory = DAOFactory(package="WMComponent.DBS3Buffer",
+                                        logger=myThread.logger,
+                                        dbinterface=myThread.dbi)
 
-        self.getOutputMapAction      = self.daofactory(classname = "Jobs.GetOutputMap")
-        self.bulkAddToFilesetAction  = self.daofactory(classname = "Fileset.BulkAddByLFN")
-        self.bulkParentageAction     = self.daofactory(classname = "Files.AddBulkParentage")
-        self.getJobTypeAction        = self.daofactory(classname = "Jobs.GetType")
-        self.getParentInfoAction     = self.daofactory(classname = "Files.GetParentInfo")
-        self.setParentageByJob       = self.daofactory(classname = "Files.SetParentageByJob")
-        self.setParentageByMergeJob  = self.daofactory(classname = "Files.SetParentageByMergeJob")
-        self.setFileRunLumi          = self.daofactory(classname = "Files.AddRunLumi")
-        self.setFileLocation         = self.daofactory(classname = "Files.SetLocationByLFN")
-        self.setFileAddChecksum      = self.daofactory(classname = "Files.AddChecksumByLFN")
-        self.addFileAction           = self.daofactory(classname = "Files.Add")
-        self.jobCompleteInput        = self.daofactory(classname = "Jobs.CompleteInput")
-        self.setBulkOutcome          = self.daofactory(classname = "Jobs.SetOutcomeBulk")
-        self.getWorkflowSpec         = self.daofactory(classname = "Workflow.GetSpecAndNameFromTask")
-        self.getJobInfoByID          = self.daofactory(classname = "Jobs.LoadFromID")
-        self.getFullJobInfo          = self.daofactory(classname = "Jobs.LoadForErrorHandler")
-        self.getJobTaskNameAction    = self.daofactory(classname = "Jobs.GetFWJRTaskName")
-        self.pnn_to_psn              = self.daofactory(classname = "Locations.GetPNNtoPSNMapping").execute()
+        self.getOutputMapAction = self.daofactory(classname="Jobs.GetOutputMap")
+        self.bulkAddToFilesetAction = self.daofactory(classname="Fileset.BulkAddByLFN")
+        self.bulkParentageAction = self.daofactory(classname="Files.AddBulkParentage")
+        self.getJobTypeAction = self.daofactory(classname="Jobs.GetType")
+        self.getParentInfoAction = self.daofactory(classname="Files.GetParentInfo")
+        self.setParentageByJob = self.daofactory(classname="Files.SetParentageByJob")
+        self.setParentageByMergeJob = self.daofactory(classname="Files.SetParentageByMergeJob")
+        self.setFileRunLumi = self.daofactory(classname="Files.AddRunLumi")
+        self.setFileLocation = self.daofactory(classname="Files.SetLocationByLFN")
+        self.setFileAddChecksum = self.daofactory(classname="Files.AddChecksumByLFN")
+        self.addFileAction = self.daofactory(classname="Files.Add")
+        self.jobCompleteInput = self.daofactory(classname="Jobs.CompleteInput")
+        self.setBulkOutcome = self.daofactory(classname="Jobs.SetOutcomeBulk")
+        self.getWorkflowSpec = self.daofactory(classname="Workflow.GetSpecAndNameFromTask")
+        self.getJobInfoByID = self.daofactory(classname="Jobs.LoadFromID")
+        self.getFullJobInfo = self.daofactory(classname="Jobs.LoadForErrorHandler")
+        self.getJobTaskNameAction = self.daofactory(classname="Jobs.GetFWJRTaskName")
+        self.pnn_to_psn = self.daofactory(classname="Locations.GetPNNtoPSNMapping").execute()
 
-        self.dbsStatusAction       = self.dbsDaoFactory(classname = "DBSBufferFiles.SetStatus")
-        self.dbsParentStatusAction = self.dbsDaoFactory(classname = "DBSBufferFiles.GetParentStatus")
-        self.dbsChildrenAction     = self.dbsDaoFactory(classname = "DBSBufferFiles.GetChildren")
-        self.dbsCreateFiles        = self.dbsDaoFactory(classname = "DBSBufferFiles.Add")
-        self.dbsSetLocation        = self.dbsDaoFactory(classname = "DBSBufferFiles.SetLocationByLFN")
-        self.dbsInsertLocation     = self.dbsDaoFactory(classname = "DBSBufferFiles.AddLocation")
-        self.dbsSetChecksum        = self.dbsDaoFactory(classname = "DBSBufferFiles.AddChecksumByLFN")
-        self.dbsSetRunLumi         = self.dbsDaoFactory(classname = "DBSBufferFiles.AddRunLumi")
-        self.dbsGetWorkflow        = self.dbsDaoFactory(classname = "ListWorkflow")
+        self.dbsStatusAction = self.dbsDaoFactory(classname="DBSBufferFiles.SetStatus")
+        self.dbsParentStatusAction = self.dbsDaoFactory(classname="DBSBufferFiles.GetParentStatus")
+        self.dbsChildrenAction = self.dbsDaoFactory(classname="DBSBufferFiles.GetChildren")
+        self.dbsCreateFiles = self.dbsDaoFactory(classname="DBSBufferFiles.Add")
+        self.dbsSetLocation = self.dbsDaoFactory(classname="DBSBufferFiles.SetLocationByLFN")
+        self.dbsInsertLocation = self.dbsDaoFactory(classname="DBSBufferFiles.AddLocation")
+        self.dbsSetChecksum = self.dbsDaoFactory(classname="DBSBufferFiles.AddChecksumByLFN")
+        self.dbsSetRunLumi = self.dbsDaoFactory(classname="DBSBufferFiles.AddRunLumi")
+        self.dbsGetWorkflow = self.dbsDaoFactory(classname="ListWorkflow")
 
-        self.dbsLFNHeritage      = self.dbsDaoFactory(classname = "DBSBufferFiles.BulkHeritageParent")
+        self.dbsLFNHeritage = self.dbsDaoFactory(classname="DBSBufferFiles.BulkHeritageParent")
 
         self.stateChanger = ChangeState(config)
 
@@ -100,40 +98,40 @@ class AccountantWorker(WMConnectionBase):
         self.specDir = getattr(config.JobAccountant, 'specDir', None)
 
         # maximum RAW EDM size for Repack output before data is put into Error dataset and skips PromptReco
-        self.maxAllowedRepackOutputSize = getattr(config.JobAccountant, 'maxAllowedRepackOutputSize', 12 * 1024 * 1024 * 1024)
+        self.maxAllowedRepackOutputSize = getattr(config.JobAccountant, 'maxAllowedRepackOutputSize',
+                                                  12 * 1024 * 1024 * 1024)
 
         # ACDC service
-        self.dataCollection = DataCollectionService(url = config.ACDC.couchurl,
-                                                    database = config.ACDC.database)
+        self.dataCollection = DataCollectionService(url=config.ACDC.couchurl,
+                                                    database=config.ACDC.database)
 
         jobDBurl = sanitizeURL(config.JobStateMachine.couchurl)['url']
         jobDBName = config.JobStateMachine.couchDBName
-        jobCouchdb  = CouchServer(jobDBurl)
+        jobCouchdb = CouchServer(jobDBurl)
         self.fwjrCouchDB = jobCouchdb.connectDatabase("%s/fwjrs" % jobDBName)
         self.localWMStats = WMStatsWriter(config.TaskArchiver.localWMStatsURL, appName="WMStatsAgent")
 
         # Hold data for later commital
-        self.dbsFilesToCreate  = []
-        self.wmbsFilesToBuild  = []
-        self.wmbsMergeFilesToBuild  = []
-        self.fileLocation      = None
+        self.dbsFilesToCreate = []
+        self.wmbsFilesToBuild = []
+        self.wmbsMergeFilesToBuild = []
+        self.fileLocation = None
         self.mergedOutputFiles = []
-        self.listOfJobsToSave  = []
-        self.listOfJobsToFail  = []
-        self.filesetAssoc      = []
-        self.parentageBinds    = []
-        self.parentageBindsForMerge    = []
+        self.listOfJobsToSave = []
+        self.listOfJobsToFail = []
+        self.filesetAssoc = []
+        self.parentageBinds = []
+        self.parentageBindsForMerge = []
         self.jobsWithSkippedFiles = {}
         self.count = 0
-        self.datasetAlgoID     = collections.deque(maxlen = 1000)
-        self.datasetAlgoPaths  = collections.deque(maxlen = 1000)
-        self.dbsLocations      = set()
-        self.workflowIDs       = collections.deque(maxlen = 1000)
-        self.workflowPaths     = collections.deque(maxlen = 1000)
+        self.datasetAlgoID = collections.deque(maxlen=1000)
+        self.datasetAlgoPaths = collections.deque(maxlen=1000)
+        self.dbsLocations = set()
+        self.workflowIDs = collections.deque(maxlen=1000)
+        self.workflowPaths = collections.deque(maxlen=1000)
 
         self.phedex = PhEDEx()
         self.locLists = self.phedex.getNodeMap()
-
 
         return
 
@@ -143,15 +141,15 @@ class AccountantWorker(WMConnectionBase):
 
         Reset all global vars between runs.
         """
-        self.dbsFilesToCreate  = []
-        self.wmbsFilesToBuild  = []
-        self.wmbsMergeFilesToBuild  = []
-        self.fileLocation      = None
+        self.dbsFilesToCreate = []
+        self.wmbsFilesToBuild = []
+        self.wmbsMergeFilesToBuild = []
+        self.fileLocation = None
         self.mergedOutputFiles = []
-        self.listOfJobsToSave  = []
-        self.listOfJobsToFail  = []
-        self.filesetAssoc      = []
-        self.parentageBinds    = []
+        self.listOfJobsToSave = []
+        self.listOfJobsToFail = []
+        self.filesetAssoc = []
+        self.parentageBinds = []
         self.parentageBindsForMerge = []
         self.jobsWithSkippedFiles = {}
         gc.collect()
@@ -169,16 +167,16 @@ class AccountantWorker(WMConnectionBase):
         # removed so it doesn't confuse the FwkJobReport() parser.
         jobReportPath = parameters.get("fwjr_path", None)
         if not jobReportPath:
-            logging.error("Bad FwkJobReport Path: %s" % jobReportPath)
+            logging.error("Bad FwkJobReport Path: %s", jobReportPath)
             return self.createMissingFWKJR(parameters, 99999, "FWJR path is empty")
 
-        jobReportPath = jobReportPath.replace("file://","")
+        jobReportPath = jobReportPath.replace("file://", "")
         if not os.path.exists(jobReportPath):
-            logging.error("Bad FwkJobReport Path: %s" % jobReportPath)
+            logging.error("Bad FwkJobReport Path: %s", jobReportPath)
             return self.createMissingFWKJR(parameters, 99999, 'Cannot find file in jobReport path: %s' % jobReportPath)
 
         if os.path.getsize(jobReportPath) == 0:
-            logging.error("Empty FwkJobReport: %s" % jobReportPath)
+            logging.error("Empty FwkJobReport: %s", jobReportPath)
             return self.createMissingFWKJR(parameters, 99998, 'jobReport of size 0: %s ' % jobReportPath)
 
         jobReport = Report()
@@ -186,14 +184,14 @@ class AccountantWorker(WMConnectionBase):
         try:
             jobReport.load(jobReportPath)
         except Exception as ex:
-            msg =  "Error loading jobReport %s\n" % jobReportPath
+            msg = "Error loading jobReport %s\n" % jobReportPath
             msg += str(ex)
             logging.error(msg)
-            logging.debug("Failing job: %s\n" % parameters)
+            logging.debug("Failing job: %s\n", parameters)
             return self.createMissingFWKJR(parameters, 99997, 'Cannot load jobReport')
 
         if len(jobReport.listSteps()) == 0:
-            logging.error("FwkJobReport with no steps: %s" % jobReportPath)
+            logging.error("FwkJobReport with no steps: %s", jobReportPath)
             return self.createMissingFWKJR(parameters, 99997, 'jobReport with no steps: %s ' % jobReportPath)
 
         return jobReport
@@ -204,11 +202,11 @@ class AccountantWorker(WMConnectionBase):
         recover it getting data from the SQL database.
         """
         if not jobReport.getTaskName():
-            logging.warning("Trying to recover a corrupted FWJR for a %s job with job id %s" % (jobStatus,
-                                                                                                jobReport.getJobID()))
-            jobInfo = self.getJobTaskNameAction.execute(jobId = jobReport.getJobID(),
-                                                        conn = self.getDBConn(),
-                                                        transaction = self.existingTransaction())
+            logging.warning("Trying to recover a corrupted FWJR for a %s job with job id %s", jobStatus,
+                            jobReport.getJobID())
+            jobInfo = self.getJobTaskNameAction.execute(jobId=jobReport.getJobID(),
+                                                        conn=self.getDBConn(),
+                                                        transaction=self.existingTransaction())
 
             jobReport.setTaskName(jobInfo['taskName'])
             jobReport.save(jobInfo['fwjr_path'])
@@ -217,8 +215,8 @@ class AccountantWorker(WMConnectionBase):
                                                                                                    jobReport.getJobID())
                 raise AccountantWorkerException(msg)
             else:
-                logging.info("TaskName '%s' successfully recovered and added to fwjr id %s." % (jobReport.getTaskName(),
-                                                                                                jobReport.getJobID()))
+                logging.info("TaskName '%s' successfully recovered and added to fwjr id %s.", jobReport.getTaskName(),
+                             jobReport.getJobID())
 
         return
 
@@ -233,14 +231,14 @@ class AccountantWorker(WMConnectionBase):
         self.reset()
 
         for job in parameters:
-            logging.info("Handling %s" % job["fwjr_path"])
+            logging.info("Handling %s", job["fwjr_path"])
 
             # Load the job and set the ID
             fwkJobReport = self.loadJobReport(job)
             fwkJobReport.setJobID(job['id'])
 
-            jobSuccess = self.handleJob(jobID = job["id"],
-                                        fwkJobReport = fwkJobReport)
+            jobSuccess = self.handleJob(jobID=job["id"],
+                                        fwkJobReport=fwkJobReport)
 
             if self.returnJobReport:
                 returnList.append({'id': job["id"], 'jobSuccess': jobSuccess,
@@ -265,41 +263,41 @@ class AccountantWorker(WMConnectionBase):
 
         # Handle filesetAssoc
         if len(self.filesetAssoc) > 0:
-            self.bulkAddToFilesetAction.execute(binds = self.filesetAssoc,
-                                                conn = self.getDBConn(),
-                                                transaction = self.existingTransaction())
+            self.bulkAddToFilesetAction.execute(binds=self.filesetAssoc,
+                                                conn=self.getDBConn(),
+                                                transaction=self.existingTransaction())
 
         # Move successful jobs to successful
         if len(self.listOfJobsToSave) > 0:
             idList = [x['id'] for x in self.listOfJobsToSave]
             outcomeBinds = [{'jobid': x['id'], 'outcome': x['outcome']} for x in self.listOfJobsToSave]
-            self.setBulkOutcome.execute(binds = outcomeBinds,
-                                    conn = self.getDBConn(),
-                                    transaction = self.existingTransaction())
+            self.setBulkOutcome.execute(binds=outcomeBinds,
+                                        conn=self.getDBConn(),
+                                        transaction=self.existingTransaction())
 
-            self.jobCompleteInput.execute(id = idList,
-                                          lfnsToSkip = self.jobsWithSkippedFiles,
-                                          conn = self.getDBConn(),
-                                          transaction = self.existingTransaction())
+            self.jobCompleteInput.execute(id=idList,
+                                          lfnsToSkip=self.jobsWithSkippedFiles,
+                                          conn=self.getDBConn(),
+                                          transaction=self.existingTransaction())
             self.stateChanger.propagate(self.listOfJobsToSave, "success", "complete")
 
         # If we have failed jobs, fail them
         if len(self.listOfJobsToFail) > 0:
             outcomeBinds = [{'jobid': x['id'], 'outcome': x['outcome']} for x in self.listOfJobsToFail]
-            self.setBulkOutcome.execute(binds = outcomeBinds,
-                                        conn = self.getDBConn(),
-                                        transaction = self.existingTransaction())
+            self.setBulkOutcome.execute(binds=outcomeBinds,
+                                        conn=self.getDBConn(),
+                                        transaction=self.existingTransaction())
             self.stateChanger.propagate(self.listOfJobsToFail, "jobfailed", "complete")
 
         # Arrange WMBS parentage
         if len(self.parentageBinds) > 0:
-            self.setParentageByJob.execute(binds = self.parentageBinds,
-                                           conn = self.getDBConn(),
-                                           transaction = self.existingTransaction())
+            self.setParentageByJob.execute(binds=self.parentageBinds,
+                                           conn=self.getDBConn(),
+                                           transaction=self.existingTransaction())
         if len(self.parentageBindsForMerge) > 0:
-            self.setParentageByMergeJob.execute(binds = self.parentageBindsForMerge,
-                                           conn = self.getDBConn(),
-                                           transaction = self.existingTransaction())
+            self.setParentageByMergeJob.execute(binds=self.parentageBindsForMerge,
+                                                conn=self.getDBConn(),
+                                                transaction=self.existingTransaction())
 
         # Straighten out DBS Parentage
         if len(self.mergedOutputFiles) > 0:
@@ -308,7 +306,7 @@ class AccountantWorker(WMConnectionBase):
         if len(self.jobsWithSkippedFiles) > 0:
             self.handleSkippedFiles()
 
-        self.commitTransaction(existingTransaction = False)
+        self.commitTransaction(existingTransaction=False)
 
         return returnList
 
@@ -328,15 +326,15 @@ class AccountantWorker(WMConnectionBase):
 
         outputFilesets = []
         for outputFileset in outputMap[moduleLabel]:
-            if merged == False and outputFileset["output_fileset"] != None:
+            if merged is False and outputFileset["output_fileset"] is not None:
                 outputFilesets.append(outputFileset["output_fileset"])
             else:
-                if outputFileset["merged_output_fileset"] != None:
+                if outputFileset["merged_output_fileset"] is not None:
                     outputFilesets.append(outputFileset["merged_output_fileset"])
 
         return outputFilesets
 
-    def addFileToDBS(self, jobReportFile, task, errorDataset = False):
+    def addFileToDBS(self, jobReportFile, task, errorDataset=False):
         """
         _addFileToDBS_
 
@@ -344,17 +342,17 @@ class AccountantWorker(WMConnectionBase):
         """
         datasetInfo = jobReportFile["dataset"]
 
-        dbsFile = DBSBufferFile(lfn = jobReportFile["lfn"],
-                                size = jobReportFile["size"],
-                                events = jobReportFile["events"],
-                                checksums = jobReportFile["checksums"],
-                                status = "NOTUPLOADED",
+        dbsFile = DBSBufferFile(lfn=jobReportFile["lfn"],
+                                size=jobReportFile["size"],
+                                events=jobReportFile["events"],
+                                checksums=jobReportFile["checksums"],
+                                status="NOTUPLOADED",
                                 inPhedex=0)
-        dbsFile.setAlgorithm(appName = datasetInfo["applicationName"],
-                             appVer = datasetInfo["applicationVersion"],
-                             appFam = jobReportFile["module_label"],
-                             psetHash = "GIBBERISH",
-                             configContent = jobReportFile.get('configURL'))
+        dbsFile.setAlgorithm(appName=datasetInfo["applicationName"],
+                             appVer=datasetInfo["applicationVersion"],
+                             appFam=jobReportFile["module_label"],
+                             psetHash="GIBBERISH",
+                             configContent=jobReportFile.get('configURL'))
 
         if errorDataset:
             dbsFile.setDatasetPath("/%s/%s/%s" % (datasetInfo["primaryDataset"] + "-Error",
@@ -365,16 +363,16 @@ class AccountantWorker(WMConnectionBase):
                                                   datasetInfo["processedDataset"],
                                                   datasetInfo["dataTier"]))
 
-        dbsFile.setValidStatus(validStatus = jobReportFile.get("validStatus", None))
-        dbsFile.setProcessingVer(ver = jobReportFile.get('processingVer', None))
-        dbsFile.setAcquisitionEra(era = jobReportFile.get('acquisitionEra', None))
-        dbsFile.setGlobalTag(globalTag = jobReportFile.get('globalTag', None))
-        #TODO need to find where to get the prep id
-        dbsFile.setPrepID(prep_id = jobReportFile.get('prep_id', None))
+        dbsFile.setValidStatus(validStatus=jobReportFile.get("validStatus", None))
+        dbsFile.setProcessingVer(ver=jobReportFile.get('processingVer', None))
+        dbsFile.setAcquisitionEra(era=jobReportFile.get('acquisitionEra', None))
+        dbsFile.setGlobalTag(globalTag=jobReportFile.get('globalTag', None))
+        # TODO need to find where to get the prep id
+        dbsFile.setPrepID(prep_id=jobReportFile.get('prep_id', None))
         dbsFile['task'] = task
         dbsFile['runs'] = jobReportFile['runs']
 
-        dbsFile.setLocation(pnn = list(jobReportFile["locations"])[0], immediateSave = False)
+        dbsFile.setLocation(pnn=list(jobReportFile["locations"])[0], immediateSave=False)
         self.dbsFilesToCreate.append(dbsFile)
         return
 
@@ -386,8 +384,8 @@ class AccountantWorker(WMConnectionBase):
         This is meant to be called recursively
         """
         parentsInfo = self.getParentInfoAction.execute([lfn],
-                                                       conn = self.getDBConn(),
-                                                       transaction = self.existingTransaction())
+                                                       conn=self.getDBConn(),
+                                                       transaction=self.existingTransaction())
         newParents = set()
         for parentInfo in parentsInfo:
             # This will catch straight to merge files that do not have redneck
@@ -396,7 +394,7 @@ class AccountantWorker(WMConnectionBase):
             if int(parentInfo["merged"]) == 1:
                 newParents.add(parentInfo["lfn"])
 
-            elif parentInfo['gpmerged'] == None:
+            elif parentInfo['gpmerged'] is None:
                 continue
 
             # Handle the files that result from merge jobs that aren't redneck
@@ -409,13 +407,13 @@ class AccountantWorker(WMConnectionBase):
             # If that didn't work, we've reached the great-grandparents
             # And we have to work via recursion
             else:
-                parentSet = self.findDBSParents(lfn = parentInfo['gplfn'])
+                parentSet = self.findDBSParents(lfn=parentInfo['gplfn'])
                 for parent in parentSet:
                     newParents.add(parent)
 
         return newParents
 
-    def addFileToWMBS(self, jobType, fwjrFile, jobMask, task, jobID = None):
+    def addFileToWMBS(self, jobType, fwjrFile, jobMask, task, jobID=None):
         """
         _addFileToWMBS_
 
@@ -423,14 +421,14 @@ class AccountantWorker(WMConnectionBase):
         """
         fwjrFile["first_event"] = jobMask["FirstEvent"]
 
-        if fwjrFile["first_event"] == None:
+        if fwjrFile["first_event"] is None:
             fwjrFile["first_event"] = 0
 
         if jobType == "Merge" and fwjrFile["module_label"] != "logArchive":
             setattr(fwjrFile["fileRef"], 'merged', True)
             fwjrFile["merged"] = True
 
-        wmbsFile = self.createFileFromDataStructsFile(file = fwjrFile, jobID = jobID)
+        wmbsFile = self.createFileFromDataStructsFile(file=fwjrFile, jobID=jobID)
 
         if jobType == "Merge":
             self.wmbsMergeFilesToBuild.append(wmbsFile)
@@ -443,12 +441,10 @@ class AccountantWorker(WMConnectionBase):
 
         return wmbsFile
 
-
     def _mapLocation(self, fwkJobReport):
         for file in fwkJobReport.getAllFileRefs():
             if file and hasattr(file, 'location'):
                 file.location = self.phedex.getBestNodeName(file.location, self.locLists)
-
 
     def handleJob(self, jobID, fwkJobReport):
         """
@@ -460,13 +456,13 @@ class AccountantWorker(WMConnectionBase):
         """
         jobSuccess = fwkJobReport.taskSuccessful()
 
-        outputMap = self.getOutputMapAction.execute(jobID = jobID,
-                                                    conn = self.getDBConn(),
-                                                    transaction = self.existingTransaction())
+        outputMap = self.getOutputMapAction.execute(jobID=jobID,
+                                                    conn=self.getDBConn(),
+                                                    transaction=self.existingTransaction())
 
-        jobType = self.getJobTypeAction.execute(jobID = jobID,
-                                                conn = self.getDBConn(),
-                                                transaction = self.existingTransaction())
+        jobType = self.getJobTypeAction.execute(jobID=jobID,
+                                                conn=self.getDBConn(),
+                                                transaction=self.existingTransaction())
 
         if jobSuccess:
             fileList = fwkJobReport.getAllFiles()
@@ -481,15 +477,17 @@ class AccountantWorker(WMConnectionBase):
                 pass
             elif jobType == "LogCollect" and len(outputMap.keys()) == 0 and outputModules == set(['LogCollect']):
                 pass
-            elif jobType == "Merge" and set(outputMap.keys()) == set(['Merged', 'MergedError', 'logArchive']) and outputModules == set(['Merged', 'logArchive']):
+            elif jobType == "Merge" and set(outputMap.keys()) == set(
+                    ['Merged', 'MergedError', 'logArchive']) and outputModules == set(['Merged', 'logArchive']):
                 pass
-            elif jobType == "Merge" and set(outputMap.keys()) == set(['Merged', 'MergedError', 'logArchive']) and outputModules == set(['MergedError', 'logArchive']):
+            elif jobType == "Merge" and set(outputMap.keys()) == set(
+                    ['Merged', 'MergedError', 'logArchive']) and outputModules == set(['MergedError', 'logArchive']):
                 pass
             elif jobType == "Express" and set(outputMap.keys()).difference(outputModules) == set(['write_RAW']):
                 pass
             else:
                 failJob = True
-                if jobType in [ "Processing", "Production" ]:
+                if jobType in ["Processing", "Production"]:
                     cmsRunSteps = 0
                     for step in fwkJobReport.listSteps():
                         if step.startswith("cmsRun"):
@@ -499,19 +497,22 @@ class AccountantWorker(WMConnectionBase):
 
                 if failJob:
                     jobSuccess = False
-                    logging.error("Job %d , list of expected outputModules does not match job report, failing job", jobID)
+                    logging.error("Job %d , list of expected outputModules does not match job report, failing job",
+                                  jobID)
                     logging.debug("Job %d , expected outputModules %s", jobID, sorted(outputMap.keys()))
                     logging.debug("Job %d , fwjr outputModules %s", jobID, sorted(outputModules))
-                    fileList = fwkJobReport.getAllFilesFromStep(step = 'logArch1')
+                    fileList = fwkJobReport.getAllFilesFromStep(step='logArch1')
                 else:
-                    logging.warning("Job %d , list of expected outputModules does not match job report, accepted for multi-step CMSSW job", jobID)
+                    logging.warning(
+                        "Job %d , list of expected outputModules does not match job report, accepted for multi-step CMSSW job",
+                        jobID)
         else:
-            fileList = fwkJobReport.getAllFilesFromStep(step = 'logArch1')
+            fileList = fwkJobReport.getAllFilesFromStep(step='logArch1')
 
         if jobSuccess:
             logging.info("Job %d , handle successful job", jobID)
         else:
-            logging.warning("Job %d , bad jobReport, failing job",  jobID)
+            logging.warning("Job %d , bad jobReport, failing job", jobID)
 
         # make sure the task name is present in FWJR (recover from WMBS if needed)
         if len(fileList) > 0:
@@ -526,16 +527,17 @@ class AccountantWorker(WMConnectionBase):
             for fwjrFile in fileList:
                 try:
                     # this assumes there is only one file for LogCollect jobs, not sure what happend if that changes
-                    self.associateLogCollectToParentJobsInWMStats(fwkJobReport, fwjrFile["lfn"], fwkJobReport.getTaskName())
+                    self.associateLogCollectToParentJobsInWMStats(fwkJobReport, fwjrFile["lfn"],
+                                                                  fwkJobReport.getTaskName())
                 except Exception as ex:
                     skipLogCollect = True
-                    logging.error("Error occurred: associating log collect location, will try again\n %s" % str(ex))
+                    logging.error("Error occurred: associating log collect location, will try again\n %s", str(ex))
                     break
 
         # now handle the job (unless the special LogCollect check failed)
         if not skipLogCollect:
 
-            wmbsJob = Job(id = jobID)
+            wmbsJob = Job(id=jobID)
             wmbsJob.load()
             outputID = wmbsJob.loadOutputID()
             wmbsJob.getMask()
@@ -552,7 +554,7 @@ class AccountantWorker(WMConnectionBase):
                 logging.debug("Job %d , register output %s", jobID, fwjrFile["lfn"])
 
                 wmbsFile = self.addFileToWMBS(jobType, fwjrFile, wmbsJob["mask"],
-                                              jobID = jobID, task = fwkJobReport.getTaskName())
+                                              jobID=jobID, task=fwkJobReport.getTaskName())
                 merged = fwjrFile['merged']
                 moduleLabel = fwjrFile["module_label"]
 
@@ -601,14 +603,14 @@ class AccountantWorker(WMConnectionBase):
         for inputFile in inputFileList:
             keys.append([requestName, inputFile["lfn"]])
         resultRows = self.fwjrCouchDB.loadView("FWJRDump", 'jobsByOutputLFN',
-                                               options = {"stale": "update_after"},
-                                               keys = keys)['rows']
+                                               options={"stale": "update_after"},
+                                               keys=keys)['rows']
         if len(resultRows) > 0:
-            #get data from wmbs
+            # get data from wmbs
             parentWMBSJobIDs = []
             for row in resultRows:
                 parentWMBSJobIDs.append({"jobid": row["value"]})
-            #update Job doc in wmstats
+            # update Job doc in wmstats
             results = self.getJobInfoByID.execute(parentWMBSJobIDs)
             parentJobNames = []
 
@@ -620,14 +622,15 @@ class AccountantWorker(WMConnectionBase):
 
             self.localWMStats.updateLogArchiveLFN(parentJobNames, logAchiveLFN)
         else:
-            #TODO: if the couch db is consistent with DB this should be removed (checking resultRow > 0)
-            #It need to be failed and retried.
-            logging.error("job report is missing for updating log archive mapping\n Input file list\n %s" % inputFileList)
+            # TODO: if the couch db is consistent with DB this should be removed (checking resultRow > 0)
+            # It need to be failed and retried.
+            logging.error(
+                "job report is missing for updating log archive mapping\n Input file list\n %s", inputFileList)
 
         return
 
-    def createMissingFWKJR(self, parameters, errorCode = 999,
-                           errorDescription = 'Failure of unknown type'):
+    def createMissingFWKJR(self, parameters, errorCode=999,
+                           errorDescription='Failure of unknown type'):
         """
         _createMissingFWJR_
 
@@ -650,16 +653,16 @@ class AccountantWorker(WMConnectionBase):
             return
 
         dbsFileTuples = []
-        dbsFileLoc    = []
+        dbsFileLoc = []
         dbsCksumBinds = []
-        runLumiBinds  = []
-        jobLocations  = set()
+        runLumiBinds = []
+        jobLocations = set()
 
         for dbsFile in self.dbsFilesToCreate:
             # Append a tuple in the format specified by DBSBufferFiles.Add
             # Also run insertDatasetAlgo
 
-            assocID         = None
+            assocID = None
             datasetAlgoPath = '%s:%s:%s:%s:%s:%s:%s:%s' % (dbsFile['datasetPath'],
                                                            dbsFile["appName"],
                                                            dbsFile["appVer"],
@@ -685,7 +688,7 @@ class AccountantWorker(WMConnectionBase):
                 except WMException:
                     raise
                 except Exception as ex:
-                    msg =  "Unhandled exception while inserting datasetAlgo: %s\n" % datasetAlgoPath
+                    msg = "Unhandled exception while inserting datasetAlgo: %s\n" % datasetAlgoPath
                     msg += str(ex)
                     logging.error(msg)
                     raise AccountantWorkerException(msg)
@@ -705,22 +708,22 @@ class AccountantWorker(WMConnectionBase):
                         workflowID = wf['workflowID']
                         break
             else:
-                result = self.dbsGetWorkflow.execute(workflowName, taskPath, conn = self.getDBConn(),
-                                                         transaction = self.existingTransaction())
+                result = self.dbsGetWorkflow.execute(workflowName, taskPath, conn=self.getDBConn(),
+                                                     transaction=self.existingTransaction())
                 workflowID = result['id']
 
             self.workflowPaths.append(workflowPath)
             self.workflowIDs.append({'workflowPath': workflowPath, 'workflowID': workflowID})
 
-            lfn           = dbsFile['lfn']
+            lfn = dbsFile['lfn']
             selfChecksums = dbsFile['checksums']
-            jobLocation   = dbsFile.getLocations()[0]
+            jobLocation = dbsFile.getLocations()[0]
             jobLocations.add(jobLocation)
             dbsFileTuples.append((lfn, dbsFile['size'],
                                   dbsFile['events'], assocID,
                                   dbsFile['status'], workflowID, dbsFile['in_phedex']))
 
-            dbsFileLoc.append({'lfn': lfn, 'pnn' : jobLocation})
+            dbsFileLoc.append({'lfn': lfn, 'pnn': jobLocation})
             if dbsFile['runs']:
                 runLumiBinds.append({'lfn': lfn, 'runs': dbsFile['runs']})
 
@@ -728,54 +731,52 @@ class AccountantWorker(WMConnectionBase):
                 # If we have checksums we have to create a bind
                 # For each different checksum
                 for entry in selfChecksums.keys():
-                    dbsCksumBinds.append({'lfn': lfn, 'cksum' : selfChecksums[entry],
-                                          'cktype' : entry})
+                    dbsCksumBinds.append({'lfn': lfn, 'cksum': selfChecksums[entry],
+                                          'cktype': entry})
 
         try:
 
             diffLocation = jobLocations.difference(self.dbsLocations)
 
             for jobLocation in diffLocation:
-                self.dbsInsertLocation.execute(siteName = jobLocation,
-                                               conn = self.getDBConn(),
-                                               transaction = self.existingTransaction())
+                self.dbsInsertLocation.execute(siteName=jobLocation,
+                                               conn=self.getDBConn(),
+                                               transaction=self.existingTransaction())
                 self.dbsLocations.add(jobLocation)
 
-            self.dbsCreateFiles.execute(files = dbsFileTuples,
-                                        conn = self.getDBConn(),
-                                        transaction = self.existingTransaction())
+            self.dbsCreateFiles.execute(files=dbsFileTuples,
+                                        conn=self.getDBConn(),
+                                        transaction=self.existingTransaction())
 
-            self.dbsSetLocation.execute(binds = dbsFileLoc,
-                                        conn = self.getDBConn(),
-                                        transaction = self.existingTransaction())
+            self.dbsSetLocation.execute(binds=dbsFileLoc,
+                                        conn=self.getDBConn(),
+                                        transaction=self.existingTransaction())
 
-            self.dbsSetChecksum.execute(bulkList = dbsCksumBinds,
-                                        conn = self.getDBConn(),
-                                        transaction = self.existingTransaction())
+            self.dbsSetChecksum.execute(bulkList=dbsCksumBinds,
+                                        conn=self.getDBConn(),
+                                        transaction=self.existingTransaction())
 
             if len(runLumiBinds) > 0:
-                self.dbsSetRunLumi.execute(file = runLumiBinds,
-                                           conn = self.getDBConn(),
-                                           transaction = self.existingTransaction())
+                self.dbsSetRunLumi.execute(file=runLumiBinds,
+                                           conn=self.getDBConn(),
+                                           transaction=self.existingTransaction())
         except WMException:
             raise
         except Exception as ex:
-            msg =  "Got exception while inserting files into DBSBuffer!\n"
+            msg = "Got exception while inserting files into DBSBuffer!\n"
             msg += str(ex)
             logging.error(msg)
             logging.debug("Listing binds:")
-            logging.debug("jobLocation: %s\n" % jobLocation)
-            logging.debug("dbsFiles: %s\n" % dbsFileTuples)
-            logging.debug("dbsFileLoc: %s\n" %dbsFileLoc)
-            logging.debug("Checksum binds: %s\n" % dbsCksumBinds)
-            logging.debug("RunLumi binds: %s\n" % runLumiBinds)
+            logging.debug("jobLocation: %s", jobLocation)
+            logging.debug("dbsFiles: %s", dbsFileTuples)
+            logging.debug("dbsFileLoc: %s", dbsFileLoc)
+            logging.debug("Checksum binds: %s", dbsCksumBinds)
+            logging.debug("RunLumi binds: %s", runLumiBinds)
             raise AccountantWorkerException(msg)
-
 
         # Now that we've created those files, clear the list
         self.dbsFilesToCreate = []
         return
-
 
     def handleWMBSFiles(self, wmbsFilesToBuild, parentageBinds):
         """
@@ -787,14 +788,14 @@ class AccountantWorker(WMConnectionBase):
             # Nothing to do
             return
 
-        runLumiBinds   = []
+        runLumiBinds = []
         fileCksumBinds = []
-        fileLocations  = []
-        fileCreate     = []
+        fileLocations = []
+        fileCreate = []
 
         for wmbsFile in wmbsFilesToBuild:
-            lfn           = wmbsFile['lfn']
-            if lfn == None:
+            lfn = wmbsFile['lfn']
+            if lfn is None:
                 continue
 
             selfChecksums = wmbsFile['checksums']
@@ -819,8 +820,8 @@ class AccountantWorker(WMConnectionBase):
                 # If we have checksums we have to create a bind
                 # For each different checksum
                 for entry in selfChecksums.keys():
-                    fileCksumBinds.append({'lfn': lfn, 'cksum' : selfChecksums[entry],
-                                           'cktype' : entry})
+                    fileCksumBinds.append({'lfn': lfn, 'cksum': selfChecksums[entry],
+                                           'cktype': entry})
 
             fileCreate.append([lfn,
                                wmbsFile['size'],
@@ -834,36 +835,36 @@ class AccountantWorker(WMConnectionBase):
 
         try:
 
-            self.addFileAction.execute(files = fileCreate,
-                                       conn = self.getDBConn(),
-                                       transaction = self.existingTransaction())
+            self.addFileAction.execute(files=fileCreate,
+                                       conn=self.getDBConn(),
+                                       transaction=self.existingTransaction())
 
             if runLumiBinds:
-                self.setFileRunLumi.execute(file = runLumiBinds,
-                                            conn = self.getDBConn(),
-                                            transaction = self.existingTransaction())
+                self.setFileRunLumi.execute(file=runLumiBinds,
+                                            conn=self.getDBConn(),
+                                            transaction=self.existingTransaction())
 
-            self.setFileAddChecksum.execute(bulkList = fileCksumBinds,
-                                            conn = self.getDBConn(),
-                                            transaction = self.existingTransaction())
+            self.setFileAddChecksum.execute(bulkList=fileCksumBinds,
+                                            conn=self.getDBConn(),
+                                            transaction=self.existingTransaction())
 
-            self.setFileLocation.execute(lfn = fileLocations,
-                                         location = self.fileLocation,
-                                         conn = self.getDBConn(),
-                                         transaction = self.existingTransaction())
+            self.setFileLocation.execute(lfn=fileLocations,
+                                         location=self.fileLocation,
+                                         conn=self.getDBConn(),
+                                         transaction=self.existingTransaction())
 
 
         except WMException:
             raise
         except Exception as ex:
-            msg =  "Error while adding files to WMBS!\n"
+            msg = "Error while adding files to WMBS!\n"
             msg += str(ex)
             logging.error(msg)
-            logging.debug("Printing binds: \n")
-            logging.debug("FileCreate binds: %s\n" % fileCreate)
-            logging.debug("Runlumi binds: %s\n" % runLumiBinds)
-            logging.debug("Checksum binds: %s\n" % fileCksumBinds)
-            logging.debug("FileLocation binds: %s\n" % fileLocations)
+            logging.debug("Printing binds:")
+            logging.debug("FileCreate binds: %s", fileCreate)
+            logging.debug("Runlumi binds: %s", runLumiBinds)
+            logging.debug("Checksum binds: %s", fileCksumBinds)
+            logging.debug("FileLocation binds: %s", fileLocations)
             raise AccountantWorkerException(msg)
 
         # Clear out finished files
@@ -883,8 +884,8 @@ class AccountantWorker(WMConnectionBase):
             pnn = list(file["locations"])[0]
         elif isinstance(file["locations"], list):
             if len(file['locations']) > 1:
-                logging.error("Have more then one location for a file in job %i" % (jobID))
-                logging.error("Choosing location %s" % (file['locations'][0]))
+                logging.error("Have more then one location for a file in job %i", jobID)
+                logging.error("Choosing location %s", file['locations'][0])
             pnn = file["locations"][0]
         else:
             pnn = file["locations"]
@@ -892,7 +893,7 @@ class AccountantWorker(WMConnectionBase):
         wmbsFile["locations"] = set()
 
         if pnn != None:
-            wmbsFile.setLocation(pnn = pnn, immediateSave = False)
+            wmbsFile.setLocation(pnn=pnn, immediateSave=False)
         wmbsFile['jid'] = jobID
 
         return wmbsFile
@@ -904,9 +905,9 @@ class AccountantWorker(WMConnectionBase):
         Handle all the DBSBuffer Parentage in bulk if you can
         """
         outputLFNs = [f['lfn'] for f in self.mergedOutputFiles]
-        bindList         = []
+        bindList = []
         for lfn in outputLFNs:
-            newParents = self.findDBSParents(lfn = lfn)
+            newParents = self.findDBSParents(lfn=lfn)
             for parentLFN in newParents:
                 bindList.append({'child': lfn, 'parent': parentLFN})
 
@@ -917,13 +918,13 @@ class AccountantWorker(WMConnectionBase):
 
         if len(bindList) > 0:
             try:
-                self.dbsLFNHeritage.execute(binds = bindList,
-                                            conn = self.getDBConn(),
-                                            transaction = self.existingTransaction())
+                self.dbsLFNHeritage.execute(binds=bindList,
+                                            conn=self.getDBConn(),
+                                            transaction=self.existingTransaction())
             except WMException:
                 raise
             except Exception as ex:
-                msg =  "Error while trying to handle the DBS LFN heritage\n"
+                msg = "Error while trying to handle the DBS LFN heritage\n"
                 msg += str(ex)
                 msg += "BindList: %s" % bindList
                 logging.error(msg)
@@ -944,9 +945,9 @@ class AccountantWorker(WMConnectionBase):
         Here ACDC records and created and the file are moved
         to wmbs_sub_files_failed from completed.
         """
-        jobList = self.getFullJobInfo.execute([{'jobid' : x} for x in self.jobsWithSkippedFiles.keys()],
-                                              fileSelection = self.jobsWithSkippedFiles,
-                                              conn = self.getDBConn(),
-                                              transaction = self.existingTransaction())
-        self.dataCollection.failedJobs(jobList, useMask = False)
+        jobList = self.getFullJobInfo.execute([{'jobid': x} for x in self.jobsWithSkippedFiles.keys()],
+                                              fileSelection=self.jobsWithSkippedFiles,
+                                              conn=self.getDBConn(),
+                                              transaction=self.existingTransaction())
+        self.dataCollection.failedJobs(jobList, useMask=False)
         return

--- a/src/python/WMCore/WMSpec/StdSpecs/Express.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Express.py
@@ -14,12 +14,9 @@ express processing -> FEVT/RAW/RECO/whatever -> express merge
 from __future__ import division
 
 import WMCore.WMSpec.Steps.StepFactory as StepFactory
-
 from Utils.Utilities import makeList, makeNonEmptyList
 from WMCore.Lexicon import procstringT0
-
 from WMCore.ReqMgr.Tools.cms import releases, architectures
-
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
 
 
@@ -29,6 +26,7 @@ class ExpressWorkloadFactory(StdBase):
 
     Stamp out Express workflows.
     """
+
     def __init__(self):
         StdBase.__init__(self)
 
@@ -70,43 +68,43 @@ class ExpressWorkloadFactory(StdBase):
         # one is direct reco from the streamer files
         # the other is conversion and then reco
         #
-        if self.recoFrameworkVersion == None or self.recoFrameworkVersion == self.frameworkVersion:
+        if self.recoFrameworkVersion is None or self.recoFrameworkVersion == self.frameworkVersion:
 
             expressRecoStepName = "cmsRun1"
 
-            scenarioArgs = { 'globalTag' : self.globalTag,
-                             'globalTagTransaction' : self.globalTagTransaction,
-                             'skims' : self.alcaSkims,
-                             'dqmSeq' : self.dqmSequences,
-                             'outputs' : self.outputs,
-                             'inputSource' : "DAT" }
+            scenarioArgs = {'globalTag': self.globalTag,
+                            'globalTagTransaction': self.globalTagTransaction,
+                            'skims': self.alcaSkims,
+                            'dqmSeq': self.dqmSequences,
+                            'outputs': self.outputs,
+                            'inputSource': "DAT"}
 
             if self.globalTagConnect:
                 scenarioArgs['globalTagConnect'] = self.globalTagConnect
 
             expressOutMods = self.setupProcessingTask(expressTask, taskType,
-                                                      scenarioName = self.procScenario,
-                                                      scenarioFunc = "expressProcessing",
-                                                      scenarioArgs = scenarioArgs,
-                                                      splitAlgo = "Express",
-                                                      splitArgs = mySplitArgs,
-                                                      stepType = cmsswStepType,
-                                                      forceUnmerged = True)
+                                                      scenarioName=self.procScenario,
+                                                      scenarioFunc="expressProcessing",
+                                                      scenarioArgs=scenarioArgs,
+                                                      splitAlgo="Express",
+                                                      splitArgs=mySplitArgs,
+                                                      stepType=cmsswStepType,
+                                                      forceUnmerged=True)
         else:
 
             expressRecoStepName = "cmsRun2"
 
             conversionOutMods = self.setupProcessingTask(expressTask, taskType,
-                                                         scenarioName = self.procScenario,
-                                                         scenarioFunc = "repack",
-                                                         scenarioArgs = { 'outputs' : [ { 'dataTier' : "RAW",
-                                                                                          'eventContent' : "ALL",
-                                                                                          'primaryDataset' : self.specialDataset,
-                                                                                          'moduleLabel' : "write_RAW" } ] },
-                                                         splitAlgo = "Express",
-                                                         splitArgs = mySplitArgs,
-                                                         stepType = cmsswStepType,
-                                                         forceUnmerged = True)
+                                                         scenarioName=self.procScenario,
+                                                         scenarioFunc="repack",
+                                                         scenarioArgs={'outputs': [{'dataTier': "RAW",
+                                                                                    'eventContent': "ALL",
+                                                                                    'primaryDataset': self.specialDataset,
+                                                                                    'moduleLabel': "write_RAW"}]},
+                                                         splitAlgo="Express",
+                                                         splitArgs=mySplitArgs,
+                                                         stepType=cmsswStepType,
+                                                         forceUnmerged=True)
 
             # there is only one
             conversionOutLabel = conversionOutMods.keys()[0]
@@ -131,16 +129,16 @@ class ExpressWorkloadFactory(StdBase):
 
             stepTwoCmsswHelper.setGlobalTag(self.globalTag)
             stepTwoCmsswHelper.setupChainedProcessing("cmsRun1", conversionOutLabel)
-            stepTwoCmsswHelper.cmsswSetup(self.frameworkVersion, softwareEnvironment = "",
-                                          scramArch = self.scramArch)
+            stepTwoCmsswHelper.cmsswSetup(self.frameworkVersion, softwareEnvironment="",
+                                          scramArch=self.scramArch)
 
             scenarioFunc = "expressProcessing"
-            scenarioArgs = { 'globalTag' : self.globalTag,
-                             'globalTagTransaction' : self.globalTagTransaction,
-                             'skims' : self.alcaSkims,
-                             'dqmSeq' : self.dqmSequences,
-                             'outputs' : self.outputs,
-                             'inputSource' : "EDM" }
+            scenarioArgs = {'globalTag': self.globalTag,
+                            'globalTagTransaction': self.globalTagTransaction,
+                            'skims': self.alcaSkims,
+                            'dqmSeq': self.dqmSequences,
+                            'outputs': self.outputs,
+                            'inputSource': "EDM"}
 
             if self.globalTagConnect:
                 scenarioArgs['globalTagConnect'] = self.globalTagConnect
@@ -154,7 +152,7 @@ class ExpressWorkloadFactory(StdBase):
                                                     configOutput[outputModuleName]['primaryDataset'],
                                                     configOutput[outputModuleName]['dataTier'],
                                                     configOutput[outputModuleName].get('filterName', None),
-                                                    stepName = "cmsRun2", forceUnmerged = True)
+                                                    stepName="cmsRun2", forceUnmerged=True)
                 expressOutMods[outputModuleName] = outputModule
 
             if 'outputs' in scenarioArgs:
@@ -168,10 +166,9 @@ class ExpressWorkloadFactory(StdBase):
                                                        scenarioFunc,
                                                        **scenarioArgs)
 
-
         expressTask.setTaskType("Express")
 
-        self.addLogCollectTask(expressTask, taskName = "ExpressLogCollect")
+        self.addLogCollectTask(expressTask, taskName="ExpressLogCollect")
 
         for expressOutLabel, expressOutInfo in expressOutMods.items():
 
@@ -184,44 +181,43 @@ class ExpressWorkloadFactory(StdBase):
                 alcaSkimTask = expressTask.addTask("%sAlcaSkim%s" % (expressTask.name(), expressOutLabel))
 
                 alcaSkimTask.setInputReference(expressTask.getStep(expressRecoStepName),
-                                               outputModule = expressOutLabel)
+                                               outputModule=expressOutLabel)
 
                 alcaTaskConf = {'Multicore': 1,
                                 'EventStreams': 0}
 
-                scenarioArgs = { 'globalTag' : self.globalTag,
-                                 'globalTagTransaction' : self.globalTagTransaction,
-                                 'skims' : self.alcaSkims,
-                                 'primaryDataset' : self.specialDataset }
+                scenarioArgs = {'globalTag': self.globalTag,
+                                'globalTagTransaction': self.globalTagTransaction,
+                                'skims': self.alcaSkims,
+                                'primaryDataset': self.specialDataset}
 
                 if self.globalTagConnect:
                     scenarioArgs['globalTagConnect'] = self.globalTagConnect
 
                 alcaSkimOutMods = self.setupProcessingTask(alcaSkimTask, taskType,
-                                                           scenarioName = self.procScenario,
-                                                           scenarioFunc = "alcaSkim",
-                                                           scenarioArgs = scenarioArgs,
-                                                           splitAlgo = "ExpressMerge",
-                                                           splitArgs = mySplitArgs,
-                                                           stepType = cmsswStepType,
-                                                           forceMerged = True,
+                                                           scenarioName=self.procScenario,
+                                                           scenarioFunc="alcaSkim",
+                                                           scenarioArgs=scenarioArgs,
+                                                           splitAlgo="ExpressMerge",
+                                                           splitArgs=mySplitArgs,
+                                                           stepType=cmsswStepType,
+                                                           forceMerged=True,
                                                            taskConf=alcaTaskConf)
 
                 alcaSkimTask.setTaskType("Express")
 
-                self.addLogCollectTask(alcaSkimTask, taskName = "AlcaSkimLogCollect")
+                self.addLogCollectTask(alcaSkimTask, taskName="AlcaSkimLogCollect")
                 self.addCleanupTask(expressTask, expressOutLabel, dataTier=expressOutInfo['dataTier'])
 
                 for alcaSkimOutLabel, alcaSkimOutInfo in alcaSkimOutMods.items():
 
                     if alcaSkimOutInfo['dataTier'] == "ALCAPROMPT" and self.alcaHarvestDir != None:
-
                         harvestTask = self.addAlcaHarvestTask(alcaSkimTask, alcaSkimOutLabel,
-                                                              alcapromptdataset = alcaSkimOutInfo['filterName'],
-                                                              condOutLabel = self.alcaHarvestOutLabel,
-                                                              condUploadDir = self.alcaHarvestDir,
-                                                              uploadProxy = self.dqmUploadProxy,
-                                                              doLogCollect = True)
+                                                              alcapromptdataset=alcaSkimOutInfo['filterName'],
+                                                              condOutLabel=self.alcaHarvestOutLabel,
+                                                              condUploadDir=self.alcaHarvestDir,
+                                                              uploadProxy=self.dqmUploadProxy,
+                                                              doLogCollect=True)
 
                         self.addConditionTask(harvestTask, self.alcaHarvestOutLabel)
 
@@ -229,12 +225,11 @@ class ExpressWorkloadFactory(StdBase):
 
                 mergeTask = self.addExpressMergeTask(expressTask, expressRecoStepName, expressOutLabel)
 
-                if expressOutInfo['dataTier'] in [ "DQM", "DQMIO" ]:
-
+                if expressOutInfo['dataTier'] in ["DQM", "DQMIO"]:
                     self.addDQMHarvestTask(mergeTask, "Merged",
-                                           uploadProxy = self.dqmUploadProxy,
-                                           periodic_harvest_interval = self.periodicHarvestInterval,
-                                           doLogCollect = True)
+                                           uploadProxy=self.dqmUploadProxy,
+                                           periodic_harvest_interval=self.periodicHarvestInterval,
+                                           doLogCollect=True)
 
         workload.setBlockCloseSettings(self.blockCloseDelay,
                                        workload.getBlockCloseMaxFiles(),
@@ -248,7 +243,7 @@ class ExpressWorkloadFactory(StdBase):
         # set the LFN bases (normally done by request manager)
         # also pass run number to add run based directories
         workload.setLFNBase(self.mergedLFNBase, self.unmergedLFNBase,
-                            runNumber = self.runNumber)
+                            runNumber=self.runNumber)
 
         return workload
 
@@ -269,7 +264,7 @@ class ExpressWorkloadFactory(StdBase):
         mergeTask = parentTask.addTask("%sMerge%s" % (parentTask.name(), parentOutputModuleName))
 
         dataTier = getattr(parentOutputModule, "dataTier")
-        mergeTask.setInputReference(parentTaskCmssw, outputModule = parentOutputModuleName, dataTier=dataTier)
+        mergeTask.setInputReference(parentTaskCmssw, outputModule=parentOutputModuleName, dataTier=dataTier)
 
         self.addDashboardMonitoring(mergeTask)
         mergeTaskCmssw = mergeTask.makeStep("cmsRun1")
@@ -282,21 +277,21 @@ class ExpressWorkloadFactory(StdBase):
 
         mergeTask.setTaskLogBaseLFN(self.unmergedLFNBase)
 
-        self.addLogCollectTask(mergeTask, taskName = "%s%sMergeLogCollect" % (parentTask.name(), parentOutputModuleName))
+        self.addLogCollectTask(mergeTask, taskName="%s%sMergeLogCollect" % (parentTask.name(), parentOutputModuleName))
 
         mergeTask.applyTemplates()
 
         mergeTaskCmsswHelper = mergeTaskCmssw.getTypeHelper()
 
-        mergeTaskCmsswHelper.cmsswSetup(self.frameworkVersion, softwareEnvironment = "",
-                                        scramArch = self.scramArch)
+        mergeTaskCmsswHelper.cmsswSetup(self.frameworkVersion, softwareEnvironment="",
+                                        scramArch=self.scramArch)
 
-        mergeTaskCmsswHelper.setErrorDestinationStep(stepName = mergeTaskLogArch.name())
+        mergeTaskCmsswHelper.setErrorDestinationStep(stepName=mergeTaskLogArch.name())
         mergeTaskCmsswHelper.setGlobalTag(self.globalTag)
         mergeTaskCmsswHelper.setOverrideCatalog(self.overrideCatalog)
 
-        #mergeTaskStageHelper = mergeTaskStageOut.getTypeHelper()
-        #mergeTaskStageHelper.setMinMergeSize(0, 0)
+        # mergeTaskStageHelper = mergeTaskStageOut.getTypeHelper()
+        # mergeTaskStageHelper.setMinMergeSize(0, 0)
 
         mergeTask.setTaskType("Merge")
 
@@ -306,19 +301,19 @@ class ExpressWorkloadFactory(StdBase):
         #  only harvest every 15 min
         #                => higher limits for latency (disabled for now)
         dataTier = getattr(parentOutputModule, "dataTier")
-        if dataTier in [ "DQM", "DQMIO" ]:
+        if dataTier in ["DQM", "DQMIO"]:
             mySplitArgs['maxInputSize'] *= 100
 
         mergeTask.setSplittingAlgorithm("ExpressMerge",
                                         **mySplitArgs)
         mergeTaskCmsswHelper.setDataProcessingConfig(self.procScenario, "merge",
-                                                     newDQMIO = (dataTier == "DQMIO"))
+                                                     newDQMIO=(dataTier == "DQMIO"))
 
         self.addOutputModule(mergeTask, "Merged",
-                             primaryDataset = getattr(parentOutputModule, "primaryDataset"),
-                             dataTier = getattr(parentOutputModule, "dataTier"),
-                             filterName = getattr(parentOutputModule, "filterName"),
-                             forceMerged = True)
+                             primaryDataset=getattr(parentOutputModule, "primaryDataset"),
+                             dataTier=getattr(parentOutputModule, "dataTier"),
+                             filterName=getattr(parentOutputModule, "filterName"),
+                             forceMerged=True)
 
         self.addCleanupTask(parentTask, parentOutputModuleName, dataTier=getattr(parentOutputModule, "dataTier"))
 
@@ -326,7 +321,7 @@ class ExpressWorkloadFactory(StdBase):
 
     def addAlcaHarvestTask(self, parentTask, parentOutputModuleName,
                            alcapromptdataset, condOutLabel, condUploadDir, uploadProxy,
-                           parentStepName = "cmsRun1", doLogCollect = True):
+                           parentStepName="cmsRun1", doLogCollect=True):
         """
         _addAlcaHarvestTask_
 
@@ -353,16 +348,17 @@ class ExpressWorkloadFactory(StdBase):
 
         harvestTask.setTaskLogBaseLFN(self.unmergedLFNBase)
         if doLogCollect:
-            self.addLogCollectTask(harvestTask, taskName = "%s%sAlcaHarvestLogCollect" % (parentTask.name(), parentOutputModuleName))
+            self.addLogCollectTask(harvestTask,
+                                   taskName="%s%sAlcaHarvestLogCollect" % (parentTask.name(), parentOutputModuleName))
 
         harvestTask.setTaskType("Harvesting")
         harvestTask.applyTemplates()
 
         harvestTaskCmsswHelper = harvestTaskCmssw.getTypeHelper()
-        harvestTaskCmsswHelper.cmsswSetup(self.frameworkVersion, softwareEnvironment = "",
-                                          scramArch = self.scramArch)
+        harvestTaskCmsswHelper.cmsswSetup(self.frameworkVersion, softwareEnvironment="",
+                                          scramArch=self.scramArch)
 
-        harvestTaskCmsswHelper.setErrorDestinationStep(stepName = harvestTaskLogArch.name())
+        harvestTaskCmsswHelper.setErrorDestinationStep(stepName=harvestTaskLogArch.name())
         harvestTaskCmsswHelper.setGlobalTag(self.globalTag)
         harvestTaskCmsswHelper.setOverrideCatalog(self.overrideCatalog)
 
@@ -371,17 +367,17 @@ class ExpressWorkloadFactory(StdBase):
         parentTaskCmssw = parentTask.getStep(parentStepName)
         parentOutputModule = parentTaskCmssw.getOutputModule(parentOutputModuleName)
 
-        harvestTask.setInputReference(parentTaskCmssw, outputModule = parentOutputModuleName)
+        harvestTask.setInputReference(parentTaskCmssw, outputModule=parentOutputModuleName)
 
         harvestTask.setSplittingAlgorithm("AlcaHarvest",
                                           **mySplitArgs)
 
-        scenarioArgs = { 'globalTag' : self.globalTag,
-                         'datasetName' : "/%s/%s/%s" % (getattr(parentOutputModule, "primaryDataset"),
-                                                        getattr(parentOutputModule, "processedDataset"),
-                                                        getattr(parentOutputModule, "dataTier")),
-                         'runNumber' : self.runNumber,
-                         'alcapromptdataset' : alcapromptdataset }
+        scenarioArgs = {'globalTag': self.globalTag,
+                        'datasetName': "/%s/%s/%s" % (getattr(parentOutputModule, "primaryDataset"),
+                                                      getattr(parentOutputModule, "processedDataset"),
+                                                      getattr(parentOutputModule, "dataTier")),
+                        'runNumber': self.runNumber,
+                        'alcapromptdataset': alcapromptdataset}
 
         if self.globalTagConnect:
             scenarioArgs['globalTagConnect'] = self.globalTagConnect
@@ -396,9 +392,9 @@ class ExpressWorkloadFactory(StdBase):
         harvestTaskConditionHelper.setConditionDir(condUploadDir)
 
         self.addOutputModule(harvestTask, condOutLabel,
-                             primaryDataset = getattr(parentOutputModule, "primaryDataset"),
-                             dataTier = getattr(parentOutputModule, "dataTier"),
-                             filterName = getattr(parentOutputModule, "filterName"))
+                             primaryDataset=getattr(parentOutputModule, "primaryDataset"),
+                             dataTier=getattr(parentOutputModule, "dataTier"),
+                             filterName=getattr(parentOutputModule, "filterName"))
 
         harvestTaskUploadHelper = harvestTaskUpload.getTypeHelper()
         harvestTaskUploadHelper.setProxyFile(uploadProxy)
@@ -431,7 +427,7 @@ class ExpressWorkloadFactory(StdBase):
         conditionTaskBogus = conditionTask.makeStep("bogus")
         conditionTaskBogus.setStepType("DQMUpload")
 
-        conditionTask.setInputReference(parentTaskCmssw, outputModule = parentOutputModuleName)
+        conditionTask.setInputReference(parentTaskCmssw, outputModule=parentOutputModuleName)
 
         conditionTask.applyTemplates()
 
@@ -487,7 +483,7 @@ class ExpressWorkloadFactory(StdBase):
                     "AlcaSkims": {"type": makeList, "optional": False},
                     "DQMSequences": {"type": makeList, "attr": "dqmSequences", "optional": False},
                     "BlockCloseDelay": {"type": int, "optional": False,
-                                        "validate": lambda x : x > 0},
+                                        "validate": lambda x: x > 0},
                     "Outputs": {"type": makeList, "optional": False},
                     "MaxInputRate": {"type": int, "optional": False},
                     "MaxInputEvents": {"type": int, "optional": False},

--- a/src/python/WMCore/WMSpec/StdSpecs/Express.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Express.py
@@ -210,7 +210,7 @@ class ExpressWorkloadFactory(StdBase):
                 alcaSkimTask.setTaskType("Express")
 
                 self.addLogCollectTask(alcaSkimTask, taskName = "AlcaSkimLogCollect")
-                self.addCleanupTask(expressTask, expressOutLabel)
+                self.addCleanupTask(expressTask, expressOutLabel, dataTier=expressOutInfo['dataTier'])
 
                 for alcaSkimOutLabel, alcaSkimOutInfo in alcaSkimOutMods.items():
 
@@ -268,7 +268,8 @@ class ExpressWorkloadFactory(StdBase):
 
         mergeTask = parentTask.addTask("%sMerge%s" % (parentTask.name(), parentOutputModuleName))
 
-        mergeTask.setInputReference(parentTaskCmssw, outputModule = parentOutputModuleName)
+        dataTier = getattr(parentOutputModule, "dataTier")
+        mergeTask.setInputReference(parentTaskCmssw, outputModule = parentOutputModuleName, dataTier=dataTier)
 
         self.addDashboardMonitoring(mergeTask)
         mergeTaskCmssw = mergeTask.makeStep("cmsRun1")
@@ -319,7 +320,7 @@ class ExpressWorkloadFactory(StdBase):
                              filterName = getattr(parentOutputModule, "filterName"),
                              forceMerged = True)
 
-        self.addCleanupTask(parentTask, parentOutputModuleName)
+        self.addCleanupTask(parentTask, parentOutputModuleName, dataTier=getattr(parentOutputModule, "dataTier"))
 
         return mergeTask
 

--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -95,7 +95,7 @@ class PromptRecoWorkloadFactory(DataProcessing):
                                                        taskConf=alcaTaskConf)
                 if self.doLogCollect:
                     self.addLogCollectTask(alcaTask, taskName = "AlcaSkimLogCollect")
-                self.addCleanupTask(recoTask, recoOutLabel)
+                self.addCleanupTask(recoTask, recoOutLabel, dataTier=recoOutInfo['dataTier'])
 
                 for alcaOutLabel in alcaOutMods:
                     self.addMergeTask(alcaTask, self.procJobSplitAlgo, alcaOutLabel,

--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -40,28 +40,29 @@ class PromptRecoWorkloadFactory(DataProcessing):
 
         recoOutputs = []
         for dataTier in self.writeTiers:
-            recoOutputs.append( { 'dataTier' : dataTier,
-                                  'eventContent' : dataTier,
-                                  'moduleLabel' : "write_%s" % dataTier } )
+            recoOutputs.append({'dataTier': dataTier,
+                                'eventContent': dataTier,
+                                'moduleLabel': "write_%s" % dataTier})
 
         recoTask = workload.newTask("Reco")
 
-        scenarioArgs = { 'globalTag' : self.globalTag,
-                         'skims' : self.alcaSkims,
-                         'PhysicsSkims' : self.physicsSkims,
-                         'dqmSeq' : self.dqmSequences,
-                         'outputs' : recoOutputs }
+        scenarioArgs = {'globalTag': self.globalTag,
+                        'skims': self.alcaSkims,
+                        'PhysicsSkims': self.physicsSkims,
+                        'dqmSeq': self.dqmSequences,
+                        'outputs': recoOutputs}
         if self.globalTagConnect:
             scenarioArgs['globalTagConnect'] = self.globalTagConnect
 
         recoOutMods = self.setupProcessingTask(recoTask, taskType, self.inputDataset,
-                                               scenarioName = self.procScenario,
-                                               scenarioFunc = "promptReco",
-                                               scenarioArgs = scenarioArgs,
-                                               splitAlgo = self.procJobSplitAlgo,
-                                               splitArgs = self.procJobSplitArgs,
-                                               stepType = cmsswStepType,
-                                               forceUnmerged = ["write_ALCARECO"] if 'ALCARECO' in self.writeTiers else False)
+                                               scenarioName=self.procScenario,
+                                               scenarioFunc="promptReco",
+                                               scenarioArgs=scenarioArgs,
+                                               splitAlgo=self.procJobSplitAlgo,
+                                               splitArgs=self.procJobSplitArgs,
+                                               stepType=cmsswStepType,
+                                               forceUnmerged=[
+                                                   "write_ALCARECO"] if 'ALCARECO' in self.writeTiers else False)
         if self.doLogCollect:
             self.addLogCollectTask(recoTask)
 
@@ -69,37 +70,37 @@ class PromptRecoWorkloadFactory(DataProcessing):
         for recoOutLabel, recoOutInfo in recoOutMods.items():
             if recoOutInfo['dataTier'] != "ALCARECO":
                 mergeTask = self.addMergeTask(recoTask, self.procJobSplitAlgo, recoOutLabel,
-                                              doLogCollect = self.doLogCollect)
+                                              doLogCollect=self.doLogCollect)
                 recoMergeTasks[recoOutInfo['dataTier']] = mergeTask
 
             else:
                 alcaTask = recoTask.addTask("AlcaSkim")
                 alcaTaskConf = {'Multicore': 1, 'EventStreams': 0}
-                scenarioArgs = { 'globalTag' : self.globalTag,
-                                 'skims' : self.alcaSkims,
-                                 'primaryDataset' : self.inputPrimaryDataset }
+                scenarioArgs = {'globalTag': self.globalTag,
+                                'skims': self.alcaSkims,
+                                'primaryDataset': self.inputPrimaryDataset}
                 if self.globalTagConnect:
                     scenarioArgs['globalTagConnect'] = self.globalTagConnect
 
                 alcaOutMods = self.setupProcessingTask(alcaTask, taskType,
-                                                       inputStep = recoTask.getStep("cmsRun1"),
-                                                       inputModule = recoOutLabel,
-                                                       scenarioName = self.procScenario,
-                                                       scenarioFunc = "alcaSkim",
-                                                       scenarioArgs = scenarioArgs,
-                                                       splitAlgo = "WMBSMergeBySize",
-                                                       splitArgs = {"max_merge_size": self.maxMergeSize,
-                                                                    "min_merge_size": self.minMergeSize,
-                                                                    "max_merge_events": self.maxMergeEvents},
-                                                       stepType = cmsswStepType,
+                                                       inputStep=recoTask.getStep("cmsRun1"),
+                                                       inputModule=recoOutLabel,
+                                                       scenarioName=self.procScenario,
+                                                       scenarioFunc="alcaSkim",
+                                                       scenarioArgs=scenarioArgs,
+                                                       splitAlgo="WMBSMergeBySize",
+                                                       splitArgs={"max_merge_size": self.maxMergeSize,
+                                                                  "min_merge_size": self.minMergeSize,
+                                                                  "max_merge_events": self.maxMergeEvents},
+                                                       stepType=cmsswStepType,
                                                        taskConf=alcaTaskConf)
                 if self.doLogCollect:
-                    self.addLogCollectTask(alcaTask, taskName = "AlcaSkimLogCollect")
+                    self.addLogCollectTask(alcaTask, taskName="AlcaSkimLogCollect")
                 self.addCleanupTask(recoTask, recoOutLabel, dataTier=recoOutInfo['dataTier'])
 
                 for alcaOutLabel in alcaOutMods:
                     self.addMergeTask(alcaTask, self.procJobSplitAlgo, alcaOutLabel,
-                                      doLogCollect = self.doLogCollect)
+                                      doLogCollect=self.doLogCollect)
 
         workload.setBlockCloseSettings(self.blockCloseDelay,
                                        workload.getBlockCloseMaxFiles(),
@@ -113,7 +114,7 @@ class PromptRecoWorkloadFactory(DataProcessing):
         # set the LFN bases (normally done by request manager)
         # also pass runNumber (workload evaluates it)
         workload.setLFNBase(self.mergedLFNBase, self.unmergedLFNBase,
-                            runNumber = self.runNumber)
+                            runNumber=self.runNumber)
         self.reportWorkflowToDashboard(workload.getDashboardActivity())
 
         return workload
@@ -159,40 +160,40 @@ class PromptRecoWorkloadFactory(DataProcessing):
     @staticmethod
     def getWorkloadCreateArgs():
         baseArgs = DataProcessing.getWorkloadCreateArgs()
-        specArgs = {"RequestType" : {"default" : "PromptReco", "optional" : True},
+        specArgs = {"RequestType": {"default": "PromptReco", "optional": True},
                     "ConfigCacheID": {"optional": True, "null": True},
-                    "Scenario" : {"default" : None, "optional" : False,
-                                  "attr" : "procScenario", "null" : False},
+                    "Scenario": {"default": None, "optional": False,
+                                 "attr": "procScenario", "null": False},
                     "ProcessingString": {"default": "", "validate": procstringT0},
-                    "WriteTiers" : {"default" : ["RECO", "AOD", "DQM", "ALCARECO"],
-                                    "type" : makeList, "optional" : False, "null" : False},
-                    "AlcaSkims" : {"default" : ["TkAlCosmics0T","MuAlGlobalCosmics","HcalCalHOCosmics"],
-                                   "type" : makeList, "optional" : False, "null" : False},
-                    "PhysicsSkims" : {"default" : [], "type" : makeList,
-                                      "optional" : True, "null" : False},
-                    "InitCommand" : {"default" : None, "optional" : True, "null" : True},
-                    "EnvPath" : {"default" : None, "optional" : True, "null" : True},
-                    "BinPath" : {"default" : None, "optional" : True,  "null" : True},
-                    "DoLogCollect" : {"default" : True, "type" : strToBool,
-                                      "optional" : True, "null" : False},
-                    "SplittingAlgo" : {"default" : "EventBased", "null" : False,
-                                       "validate" : lambda x: x in ["EventBased", "LumiBased",
-                                                                    "EventAwareLumiBased", "FileBased"],
-                                       "attr" : "procJobSplitAlgo"},
-                    "EventsPerJob" : {"default" : 500, "type" : int, "validate" : lambda x : x > 0,
-                                      "null" : False},
-                    "SkimSplittingAlgo" : {"default" : "FileBased", "null" : False,
-                                           "validate" : lambda x: x in ["EventBased", "LumiBased",
-                                                                        "EventAwareLumiBased", "FileBased"],
-                                           "attr" : "skimJobSplitAlgo"},
-                    "SkimEventsPerJob" : {"default" : 500, "type" : int, "validate" : lambda x : x > 0,
-                                          "null" : False},
-                    "SkimLumisPerJob" : {"default" : 8, "type" : int, "validate" : lambda x : x > 0,
-                                         "null" : False},
-                    "SkimFilesPerJob" : {"default" : 1, "type" : int, "validate" : lambda x : x > 0,
-                                         "null" : False},
-                    "BlockCloseDelay" : {"default" : 86400, "type" : int, "validate" : lambda x : x > 0,
-                                         "null" : False}
+                    "WriteTiers": {"default": ["RECO", "AOD", "DQM", "ALCARECO"],
+                                   "type": makeList, "optional": False, "null": False},
+                    "AlcaSkims": {"default": ["TkAlCosmics0T", "MuAlGlobalCosmics", "HcalCalHOCosmics"],
+                                  "type": makeList, "optional": False, "null": False},
+                    "PhysicsSkims": {"default": [], "type": makeList,
+                                     "optional": True, "null": False},
+                    "InitCommand": {"default": None, "optional": True, "null": True},
+                    "EnvPath": {"default": None, "optional": True, "null": True},
+                    "BinPath": {"default": None, "optional": True, "null": True},
+                    "DoLogCollect": {"default": True, "type": strToBool,
+                                     "optional": True, "null": False},
+                    "SplittingAlgo": {"default": "EventBased", "null": False,
+                                      "validate": lambda x: x in ["EventBased", "LumiBased",
+                                                                  "EventAwareLumiBased", "FileBased"],
+                                      "attr": "procJobSplitAlgo"},
+                    "EventsPerJob": {"default": 500, "type": int, "validate": lambda x: x > 0,
+                                     "null": False},
+                    "SkimSplittingAlgo": {"default": "FileBased", "null": False,
+                                          "validate": lambda x: x in ["EventBased", "LumiBased",
+                                                                      "EventAwareLumiBased", "FileBased"],
+                                          "attr": "skimJobSplitAlgo"},
+                    "SkimEventsPerJob": {"default": 500, "type": int, "validate": lambda x: x > 0,
+                                         "null": False},
+                    "SkimLumisPerJob": {"default": 8, "type": int, "validate": lambda x: x > 0,
+                                        "null": False},
+                    "SkimFilesPerJob": {"default": 1, "type": int, "validate": lambda x: x > 0,
+                                        "null": False},
+                    "BlockCloseDelay": {"default": 86400, "type": int, "validate": lambda x: x > 0,
+                                        "null": False}
                     }
 
         baseArgs.update(specArgs)

--- a/src/python/WMCore/WMSpec/StdSpecs/Repack.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Repack.py
@@ -12,8 +12,8 @@ from __future__ import division
 
 from Utils.Utilities import makeList
 from WMCore.Lexicon import procstringT0
-
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
+
 
 class RepackWorkloadFactory(StdBase):
     """
@@ -60,18 +60,18 @@ class RepackWorkloadFactory(StdBase):
 
         repackTask = workload.newTask("Repack")
         repackOutMods = self.setupProcessingTask(repackTask, taskType,
-                                                 scenarioName = self.procScenario,
-                                                 scenarioFunc = "repack",
-                                                 scenarioArgs = { 'outputs' : self.outputs },
-                                                 splitAlgo = "Repack",
-                                                 splitArgs = mySplitArgs,
-                                                 stepType = cmsswStepType)
+                                                 scenarioName=self.procScenario,
+                                                 scenarioFunc="repack",
+                                                 scenarioArgs={'outputs': self.outputs},
+                                                 splitAlgo="Repack",
+                                                 splitArgs=mySplitArgs,
+                                                 stepType=cmsswStepType)
 
         repackTask.setTaskType("Repack")
 
         self.addLogCollectTask(repackTask)
 
-        for repackOutLabel in repackOutMods.keys():
+        for repackOutLabel in repackOutMods:
             self.addRepackMergeTask(repackTask, repackOutLabel)
 
         workload.setBlockCloseSettings(self.blockCloseDelay,
@@ -86,7 +86,7 @@ class RepackWorkloadFactory(StdBase):
         # set the LFN bases (normally done by request manager)
         # also pass run number to add run based directories
         workload.setLFNBase(self.mergedLFNBase, self.unmergedLFNBase,
-                            runNumber = self.runNumber)
+                            runNumber=self.runNumber)
 
         return workload
 
@@ -109,7 +109,7 @@ class RepackWorkloadFactory(StdBase):
 
         mergeTask.setTaskLogBaseLFN(self.unmergedLFNBase)
 
-        self.addLogCollectTask(mergeTask, taskName = "%s%sMergeLogCollect" % (parentTask.name(), parentOutputModuleName))
+        self.addLogCollectTask(mergeTask, taskName="%s%sMergeLogCollect" % (parentTask.name(), parentOutputModuleName))
 
         mergeTask.applyTemplates()
 
@@ -121,15 +121,15 @@ class RepackWorkloadFactory(StdBase):
 
         mergeTaskCmsswHelper = mergeTaskCmssw.getTypeHelper()
 
-        mergeTaskCmsswHelper.cmsswSetup(self.frameworkVersion, softwareEnvironment = "",
-                                        scramArch = self.scramArch)
+        mergeTaskCmsswHelper.cmsswSetup(self.frameworkVersion, softwareEnvironment="",
+                                        scramArch=self.scramArch)
 
-        mergeTaskCmsswHelper.setErrorDestinationStep(stepName = mergeTaskLogArch.name())
+        mergeTaskCmsswHelper.setErrorDestinationStep(stepName=mergeTaskLogArch.name())
         mergeTaskCmsswHelper.setGlobalTag(self.globalTag)
         mergeTaskCmsswHelper.setOverrideCatalog(self.overrideCatalog)
 
-        #mergeTaskStageHelper = mergeTaskStageOut.getTypeHelper()
-        #mergeTaskStageHelper.setMinMergeSize(0, 0)
+        # mergeTaskStageHelper = mergeTaskStageOut.getTypeHelper()
+        # mergeTaskStageHelper.setMinMergeSize(0, 0)
 
         mergeTask.setTaskType("Merge")
 
@@ -142,16 +142,16 @@ class RepackWorkloadFactory(StdBase):
         mergeTaskCmsswHelper.setDataProcessingConfig(self.procScenario, "merge")
 
         self.addOutputModule(mergeTask, "Merged",
-                             primaryDataset = getattr(parentOutputModule, "primaryDataset"),
-                             dataTier = getattr(parentOutputModule, "dataTier"),
-                             filterName = getattr(parentOutputModule, "filterName"),
-                             forceMerged = True)
+                             primaryDataset=getattr(parentOutputModule, "primaryDataset"),
+                             dataTier=getattr(parentOutputModule, "dataTier"),
+                             filterName=getattr(parentOutputModule, "filterName"),
+                             forceMerged=True)
 
         self.addOutputModule(mergeTask, "MergedError",
-                             primaryDataset = getattr(parentOutputModule, "primaryDataset") + "-Error",
-                             dataTier = getattr(parentOutputModule, "dataTier"),
-                             filterName = getattr(parentOutputModule, "filterName"),
-                             forceMerged = True)
+                             primaryDataset=getattr(parentOutputModule, "primaryDataset") + "-Error",
+                             dataTier=getattr(parentOutputModule, "dataTier"),
+                             filterName=getattr(parentOutputModule, "filterName"),
+                             forceMerged=True)
 
         self.addCleanupTask(parentTask, parentOutputModuleName, dataTier=getattr(parentOutputModule, "dataTier"))
 
@@ -195,7 +195,7 @@ class RepackWorkloadFactory(StdBase):
                     "GlobalTag": {"default": "fake"},
                     "ProcessingString": {"default": "", "validate": procstringT0},
                     "BlockCloseDelay": {"type": int, "optional": False,
-                                        "validate": lambda x : x > 0},
+                                        "validate": lambda x: x > 0},
                     "Outputs": {"type": makeList, "optional": False},
                     "MaxSizeSingleLumi": {"type": int, "optional": False},
                     "MaxSizeMultiLumi": {"type": int, "optional": False},

--- a/src/python/WMCore/WMSpec/StdSpecs/Repack.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Repack.py
@@ -115,8 +115,9 @@ class RepackWorkloadFactory(StdBase):
 
         parentTaskCmssw = parentTask.getStep("cmsRun1")
         parentOutputModule = parentTaskCmssw.getOutputModule(parentOutputModuleName)
+        dataTier = getattr(parentOutputModule, "dataTier")
 
-        mergeTask.setInputReference(parentTaskCmssw, outputModule = parentOutputModuleName)
+        mergeTask.setInputReference(parentTaskCmssw, outputModule=parentOutputModuleName, dataTier=dataTier)
 
         mergeTaskCmsswHelper = mergeTaskCmssw.getTypeHelper()
 
@@ -152,7 +153,7 @@ class RepackWorkloadFactory(StdBase):
                              filterName = getattr(parentOutputModule, "filterName"),
                              forceMerged = True)
 
-        self.addCleanupTask(parentTask, parentOutputModuleName)
+        self.addCleanupTask(parentTask, parentOutputModuleName, dataTier=getattr(parentOutputModule, "dataTier"))
 
         return mergeTask
 

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -622,7 +622,8 @@ class StdBase(object):
         parentTaskCmssw = parentTask.getStep(parentStepName)
         parentOutputModule = parentTaskCmssw.getOutputModule(parentOutputModuleName)
 
-        mergeTask.setInputReference(parentTaskCmssw, outputModule=parentOutputModuleName)
+        dataTier = getattr(parentOutputModule, "dataTier")
+        mergeTask.setInputReference(parentTaskCmssw, outputModule=parentOutputModuleName, dataTier=dataTier)
 
         mergeTaskCmsswHelper = mergeTaskCmssw.getTypeHelper()
         mergeTaskStageHelper = mergeTaskStageOut.getTypeHelper()
@@ -659,7 +660,7 @@ class StdBase(object):
                              filterName=getattr(parentOutputModule, "filterName"),
                              forceMerged=True, taskConf=taskConf)
 
-        self.addCleanupTask(parentTask, parentOutputModuleName, forceTaskName)
+        self.addCleanupTask(parentTask, parentOutputModuleName, forceTaskName, dataTier)
         if self.enableHarvesting and getattr(parentOutputModule, "dataTier") in ["DQMIO", "DQM"]:
             self.addDQMHarvestTask(mergeTask, "Merged",
                                    uploadProxy=self.dqmUploadProxy,
@@ -673,7 +674,7 @@ class StdBase(object):
 
         return mergeTask
 
-    def addCleanupTask(self, parentTask, parentOutputModuleName, forceTaskName=None):
+    def addCleanupTask(self, parentTask, parentOutputModuleName, forceTaskName=None, dataTier=''):
         """
         _addCleanupTask_
 
@@ -687,7 +688,7 @@ class StdBase(object):
         cleanupTask.setTaskType("Cleanup")
 
         parentTaskCmssw = parentTask.getStep("cmsRun1")
-        cleanupTask.setInputReference(parentTaskCmssw, outputModule=parentOutputModuleName)
+        cleanupTask.setInputReference(parentTaskCmssw, outputModule=parentOutputModuleName, dataTier=dataTier)
         cleanupTask.setSplittingAlgorithm("SiblingProcessingBased", files_per_job=50)
 
         cleanupStep = cleanupTask.makeStep("cleanupUnmerged%s" % parentOutputModuleName)

--- a/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
@@ -454,7 +454,7 @@ class TaskChainWorkloadFactory(StdBase):
 
         procTasks = {}
         for outputModuleName in unmergedModules:
-            self.addCleanupTask(parentTask, outputModuleName)
+            self.addCleanupTask(parentTask, outputModuleName, dataTier=outputModules[outputModuleName]['dataTier'])
             procTasks[outputModuleName] = parentTask
         self.mergeMapping[parentTask.name()].update(procTasks)
 

--- a/src/python/WMCore/WorkQueue/WMBSHelper.py
+++ b/src/python/WMCore/WorkQueue/WMBSHelper.py
@@ -10,23 +10,24 @@ import threading
 import traceback
 from collections import defaultdict
 
-from WMCore.WMRuntime.SandboxCreator import SandboxCreator
-from WMCore.WMBS.File import File
+from WMComponent.DBS3Buffer.DBSBufferDataset import DBSBufferDataset
+from WMComponent.DBS3Buffer.DBSBufferFile import DBSBufferFile
+from WMCore.BossAir.BossAirAPI import (BossAirAPI, BossAirException)
+from WMCore.DAOFactory import DAOFactory
 from WMCore.DataStructs.File import File as DatastructFile
 from WMCore.DataStructs.LumiList import LumiList
-from WMCore.WMBS.Workflow import Workflow
-from WMCore.WMBS.Fileset import Fileset
-from WMCore.WMBS.Subscription import Subscription
-from WMCore.WMBS.Job import Job
-from WMCore.WMException import WMException
 from WMCore.DataStructs.Run import Run
-from WMCore.DAOFactory import DAOFactory
-from WMCore.WMConnectionBase import WMConnectionBase
 from WMCore.JobStateMachine.ChangeState import ChangeState
-from WMCore.BossAir.BossAirAPI import (BossAirAPI, BossAirException)
 from WMCore.ResourceControl.ResourceControl import ResourceControl
-from WMComponent.DBS3Buffer.DBSBufferFile import DBSBufferFile
-from WMComponent.DBS3Buffer.DBSBufferDataset import DBSBufferDataset
+from WMCore.WMBS.File import File
+from WMCore.WMBS.Fileset import Fileset
+from WMCore.WMBS.Job import Job
+from WMCore.WMBS.Subscription import Subscription
+from WMCore.WMBS.Workflow import Workflow
+from WMCore.WMConnectionBase import WMConnectionBase
+from WMCore.WMException import WMException
+from WMCore.WMRuntime.SandboxCreator import SandboxCreator
+
 
 def wmbsSubscriptionStatus(logger, dbi, conn, transaction):
     """Function to return status of wmbs subscriptions
@@ -119,13 +120,14 @@ def killWorkflow(workflowName, jobCouchConfig, bossAirConfig=None):
     return
 
 
-def freeSlots(multiplier=1.0, minusRunning=False, allowedStates=['Normal'], knownCmsSites=None):
+def freeSlots(multiplier=1.0, minusRunning=False, allowedStates=None, knownCmsSites=None):
     """
     Get free resources from wmbs.
 
     Specify multiplier to apply a ratio to the actual numbers.
     minusRunning control if running jobs should be counted
     """
+    allowedStates = allowedStates or ['Normal']
     rc_sites = ResourceControl().listThresholdsForCreate()
     thresholds = defaultdict(lambda: 0)
     jobCounts = defaultdict(dict)
@@ -338,10 +340,10 @@ class WMBSHelper(WMConnectionBase):
                         self._createSubscriptionsInWMBS(childTask, outputFileset, alternativeFilesetClose)
 
                 if mergedOutputFileset is None:
-                    workflow.addOutput(outputModuleName+dataTier, outputFileset,
+                    workflow.addOutput(outputModuleName + dataTier, outputFileset,
                                        outputFileset)
                 else:
-                    workflow.addOutput(outputModuleName+dataTier, outputFileset,
+                    workflow.addOutput(outputModuleName + dataTier, outputFileset,
                                        mergedOutputFileset)
 
         return self.topLevelSubscription
@@ -375,7 +377,7 @@ class WMBSHelper(WMConnectionBase):
                         events=self.mask['LastEvent'] - self.mask['FirstEvent'] + 1,  # inclusive range
                         locations=locations,
                         merged=False,  # merged causes dbs parentage relation
-                       )
+                        )
 
         if self.mask:
             lumis = range(self.mask['FirstLumi'], self.mask['LastLumi'] + 1)  # inclusive range
@@ -418,19 +420,19 @@ class WMBSHelper(WMConnectionBase):
 
         if block != None:
             logging.info('"%s" Injecting block %s (%d files) into wmbs', self.wmSpec.name(),
-                                                                         self.block,
-                                                                         len(block['Files']))
+                         self.block,
+                         len(block['Files']))
             addedFiles = self.addFiles(block)
         # For MC case
         else:
             logging.info(
                 '"%s" Injecting production %s:%s:%s - %s:%s:%s (run:lumi:event) into wmbs', self.wmSpec.name(),
-                                                                                            self.mask['FirstRun'],
-                                                                                            self.mask['FirstLumi'],
-                                                                                            self.mask['FirstEvent'],
-                                                                                            self.mask['LastRun'],
-                                                                                            self.mask['LastLumi'],
-                                                                                            self.mask['LastEvent'])
+                self.mask['FirstRun'],
+                self.mask['FirstLumi'],
+                self.mask['FirstEvent'],
+                self.mask['LastRun'],
+                self.mask['LastLumi'],
+                self.mask['LastEvent'])
             addedFiles = self.addMCFakeFile()
 
         self.commitTransaction(existingTransaction=False)
@@ -646,7 +648,7 @@ class WMBSHelper(WMConnectionBase):
                 run = Run(lumi['RunNumber'], lumiSecList)
             else:
                 lumiSecTuple = ((lumi['LumiSectionNumber'], lumi['EventCount'])
-                               if 'EventCount' in lumi else lumi['LumiSectionNumber'])
+                                if 'EventCount' in lumi else lumi['LumiSectionNumber'])
                 run = Run(lumi['RunNumber'], lumiSecTuple)
             wmbsFile.addRun(run)
 

--- a/test/data/ReqMgr/requests/DMWM/StepChain_DupOutMod.json
+++ b/test/data/ReqMgr/requests/DMWM/StepChain_DupOutMod.json
@@ -1,0 +1,74 @@
+{
+    "assignRequest": {
+        "AcquisitionEra": "AcquisitionEra-OVERRIDE-ME",
+        "ProcessingString": "ProcessingString-OVERRIDE-ME",
+        "ProcessingVersion": 21,
+        "Dashboard": "Dashboard-OVERRIDE-ME",
+        "GracePeriod": 300,
+        "MaxRSS": 2372000,
+        "MaxVSize": 40000000,
+        "MergedLFNBase": "/store/backfill/1",
+        "SiteBlacklist": [],
+        "SiteWhitelist": [
+            "SiteWhitelist-OVERRIDE-ME"
+        ],
+        "SoftTimeout": 129600,
+        "Team": "Team-OVERRIDE-ME",
+        "UnmergedLFNBase": "/store/unmerged"
+    },
+    "createRequest": {
+        "AcquisitionEra": "DMWM_Test",
+        "CMSSWVersion": "CMSSW_9_0_0",
+        "Campaign": "Campaign-OVERRIDE-ME",
+        "Comments": ["MC from scratch; 3 steps in the same job; save all outputs; Step1 and Step2 have the same RAWSIM output module"],
+        "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb",
+        "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader",
+        "GlobalTag": "90X_mcRun1_realistic_v4",
+        "Group": "DATAOPS",
+        "Memory": 2200,
+        "PrepID": "TEST-StepChain-DupOutMod",
+        "PrimaryDataset": "RelValProdMinBias",
+        "ProcessingString": "StepChain_MC_DupOutMod",
+        "ProcessingVersion": 20,
+        "RequestPriority": 316000,
+        "RequestString": "RequestString-OVERRIDE-ME",
+        "RequestType": "StepChain",
+        "ScramArch": "slc6_amd64_gcc530",
+        "SizePerEvent": 250,
+        "Step1": {
+            "CMSSWVersion": "CMSSW_9_0_0",
+            "ConfigCacheID": "f739820360b865fbaec79db3ed0cf0d1",
+            "EventsPerJob": 150,
+            "EventsPerLumi": 50,
+            "GlobalTag": "90X_mcRun1_realistic_v4",
+            "PrepID": "TEST-Step1-DupOutMod",
+            "RequestNumEvents": 1500,
+            "ScramArch": ["slc6_amd64_gcc530"],
+            "Seeding": "AutomaticSeeding",
+            "SplittingAlgo": "EventBased",
+            "StepName": "ProdMinBias"
+        },
+        "Step2": {
+            "CMSSWVersion": "CMSSW_9_0_0",
+            "ConfigCacheID": "f739820360b865fbaec79db3ed0d8bde",
+            "GlobalTag": "90X_mcRun1_realistic_v4",
+            "InputFromOutputModule": "RAWSIMoutput",
+            "InputStep": "ProdMinBias",
+            "PrepID": "TEST-Step2-DupOutMod",
+            "ScramArch": "slc6_amd64_gcc530",
+            "StepName": "DIGIPROD1"
+        },
+        "Step3": {
+            "CMSSWVersion": "CMSSW_9_0_0",
+            "ConfigCacheID": "f739820360b865fbaec79db3ed10c012",
+            "GlobalTag": "90X_mcRun1_realistic_v4",
+            "InputFromOutputModule": "RAWSIMoutput",
+            "InputStep": "DIGIPROD1",
+            "PrepID": "TEST-Step3-DupOutMod",
+            "ScramArch": "slc6_amd64_gcc530",
+            "StepName": "RECOPROD1"
+        },
+        "StepChain": 3,
+        "TimePerEvent": 144
+    }
+}

--- a/test/python/WMComponent_t/AnalyticsDataCollector_t/Plugins_t/Tier0Plugin_t.py
+++ b/test/python/WMComponent_t/AnalyticsDataCollector_t/Plugins_t/Tier0Plugin_t.py
@@ -12,22 +12,17 @@ import os
 import unittest
 
 from WMComponent.AnalyticsDataCollector.Plugins.Tier0Plugin import Tier0Plugin
-
 from WMCore.Services.RequestDB.RequestDBWriter import RequestDBWriter
 from WMCore.WMBS.Fileset import Fileset
 from WMCore.WMBS.Subscription import Subscription
 from WMCore.WMBS.Workflow import Workflow
-from WMCore.WMSpec.WMWorkload import newWorkload
 from WMCore.WMSpec.StdSpecs.PromptReco import PromptRecoWorkloadFactory
-
-from WMQuality.TestInitCouchApp import TestInitCouchApp as TestInit
+from WMCore.WMSpec.WMWorkload import newWorkload
 from WMCore.WorkQueue.WMBSHelper import WMBSHelper
-
+from WMQuality.TestInitCouchApp import TestInitCouchApp as TestInit
 
 
 class Tier0PluginTest(unittest.TestCase):
-
-
     def setUp(self):
         """
         _setUp_
@@ -74,8 +69,8 @@ class Tier0PluginTest(unittest.TestCase):
         mergeTasks = ['RepackMergewrite_QuadElectron_RAW', 'RepackMergewrite_TriPhoton_RAW',
                       'RepackMergewrite_SingleNeutrino_RAW']
 
-        self.stateMap = {'Merge' : [],
-                         'Processing Done' : []}
+        self.stateMap = {'Merge': [],
+                         'Processing Done': []}
         self.orderedStates = ['Merge', 'Processing Done']
 
         # Populate WMStats
@@ -93,29 +88,29 @@ class Tier0PluginTest(unittest.TestCase):
         workload.save(specPath)
 
         # Populate WMBS
-        topFileset = Fileset(name = 'TestStreamerFileset')
+        topFileset = Fileset(name='TestStreamerFileset')
         topFileset.create()
 
-        options = {'spec' : specPath, 'owner' : 'ItsAMeMario',
-                   'name' : workflowName, 'wfType' : 'tier0'}
-        topLevelWorkflow = Workflow(task = '/%s/Repack' % workflowName,
+        options = {'spec': specPath, 'owner': 'ItsAMeMario',
+                   'name': workflowName, 'wfType': 'tier0'}
+        topLevelWorkflow = Workflow(task='/%s/Repack' % workflowName,
                                     **options)
         topLevelWorkflow.create()
         topLevelSub = Subscription(topFileset, topLevelWorkflow)
         topLevelSub.create()
         self.stateMap['Merge'].append(topFileset)
         for task in mergeTasks:
-            mergeWorkflow = Workflow(task = '/%s/Repack/%s' % (workflowName, task), **options)
+            mergeWorkflow = Workflow(task='/%s/Repack/%s' % (workflowName, task), **options)
             mergeWorkflow.create()
-            unmergedFileset = Fileset(name = 'TestUnmergedFileset%s' % task)
+            unmergedFileset = Fileset(name='TestUnmergedFileset%s' % task)
             unmergedFileset.create()
             mergeSub = Subscription(unmergedFileset, mergeWorkflow)
             mergeSub.create()
             self.stateMap['Processing Done'].append(unmergedFileset)
-        cleanupWorkflow = Workflow(task = '/Repack_Run481516_StreamZ/Repack/RepackCleanupUnmergedwrite_QuadElectron_RAW',
+        cleanupWorkflow = Workflow(task='/Repack_Run481516_StreamZ/Repack/RepackCleanupUnmergedwrite_QuadElectron_RAW',
                                    **options)
         cleanupWorkflow.create()
-        unmergedFileset = Fileset(name = 'TestUnmergedFilesetToCleanup')
+        unmergedFileset = Fileset(name='TestUnmergedFilesetToCleanup')
         unmergedFileset.create()
         cleanupSub = Subscription(unmergedFileset, cleanupWorkflow)
         cleanupSub.create()
@@ -133,17 +128,18 @@ class Tier0PluginTest(unittest.TestCase):
         workflowName = 'Express_Run481516_StreamZFast'
         secondLevelTasks = ['ExpressMergewrite_StreamZFast_DQM', 'ExpressMergewrite_ExpressPhysics_FEVT',
                             'ExpressAlcaSkimwrite_StreamZFast_ALCARECO', 'ExpressCleanupUnmergedwrite_StreamZFast_DQM',
-                            'ExpressCleanupUnmergedwrite_ExpressPhysics_FEVT', 'ExpressCleanupUnmergedwrite_StreamZFast_ALCARECO']
+                            'ExpressCleanupUnmergedwrite_ExpressPhysics_FEVT',
+                            'ExpressCleanupUnmergedwrite_StreamZFast_ALCARECO']
         alcaHarvestTask = 'ExpressAlcaSkimwrite_StreamZFast_ALCARECOAlcaHarvestALCARECOStreamPromptCalibProd'
         dqmHarvestTask = 'ExpressMergewrite_StreamZFast_DQMEndOfRunDQMHarvestMerged'
 
-        self.stateMap = {'Merge' : [],
-                         'Harvesting' : [],
-                         'Processing Done' : []}
+        self.stateMap = {'Merge': [],
+                         'Harvesting': [],
+                         'Processing Done': []}
         self.orderedStates = ['Merge', 'Harvesting', 'Processing Done']
 
         # Populate WMStats
-        self.requestDBWriter.insertGenericRequest({'RequestName' : workflowName})
+        self.requestDBWriter.insertGenericRequest({'RequestName': workflowName})
         self.requestDBWriter.updateRequestStatus(workflowName, 'Closed')
 
         # Create a wmspec in disk
@@ -160,20 +156,20 @@ class Tier0PluginTest(unittest.TestCase):
         workload.save(specPath)
 
         # Populate WMBS
-        sharedFileset = Fileset(name = 'TestFileset')
+        sharedFileset = Fileset(name='TestFileset')
         sharedFileset.create()
         sharedFileset.markOpen(False)
 
-        options = {'spec' : specPath, 'owner' : 'ItsAMeMario',
-                   'name' : workflowName, 'wfType' : 'tier0'}
-        topLevelWorkflow = Workflow(task = '/%s/Express' % workflowName,
+        options = {'spec': specPath, 'owner': 'ItsAMeMario',
+                   'name': workflowName, 'wfType': 'tier0'}
+        topLevelWorkflow = Workflow(task='/%s/Express' % workflowName,
                                     **options)
         topLevelWorkflow.create()
         topLevelSub = Subscription(sharedFileset, topLevelWorkflow)
         topLevelSub.create()
         self.stateMap['Merge'].append(topLevelSub)
-        for task in filter(lambda x : not x.count('CleanupUnmerged'), secondLevelTasks):
-            secondLevelWorkflow = Workflow(task = '/%s/Express/%s' % (workflowName, task), **options)
+        for task in filter(lambda x: not x.count('CleanupUnmerged'), secondLevelTasks):
+            secondLevelWorkflow = Workflow(task='/%s/Express/%s' % (workflowName, task), **options)
             secondLevelWorkflow.create()
             mergeSub = Subscription(sharedFileset, secondLevelWorkflow)
             mergeSub.create()
@@ -181,7 +177,7 @@ class Tier0PluginTest(unittest.TestCase):
 
         for (parent, child) in [('ExpressAlcaSkimwrite_StreamZFast_ALCARECO', alcaHarvestTask),
                                 ('ExpressMergewrite_StreamZFast_DQM', dqmHarvestTask)]:
-            harvestingWorkflow = Workflow(task = '/%s/Express/%s/%s' % (workflowName, parent, child),
+            harvestingWorkflow = Workflow(task='/%s/Express/%s/%s' % (workflowName, parent, child),
                                           **options)
             harvestingWorkflow.create()
             harvestingSub = Subscription(sharedFileset, harvestingWorkflow)
@@ -207,18 +203,18 @@ class Tier0PluginTest(unittest.TestCase):
         testArguments["CouchURL"] = os.environ["COUCHURL"]
         workload = factory.factoryWorkloadConstruction(workflowName, testArguments)
 
-        wmbsHelper = WMBSHelper(workload, 'Reco', 'SomeBlock', cachepath = self.testDir)
+        wmbsHelper = WMBSHelper(workload, 'Reco', 'SomeBlock', cachepath=self.testDir)
         wmbsHelper.createTopLevelFileset()
         wmbsHelper._createSubscriptionsInWMBS(wmbsHelper.topLevelTask, wmbsHelper.topLevelFileset)
 
-        self.stateMap = {'AlcaSkim' : [],
-                         'Merge' : [],
-                         'Harvesting' : [],
-                         'Processing Done' : []}
+        self.stateMap = {'AlcaSkim': [],
+                         'Merge': [],
+                         'Harvesting': [],
+                         'Processing Done': []}
         self.orderedStates = ['AlcaSkim', 'Merge', 'Harvesting', 'Processing Done']
 
         # Populate WMStats
-        self.requestDBWriter.insertGenericRequest({'RequestName' : workflowName})
+        self.requestDBWriter.insertGenericRequest({'RequestName': workflowName})
         self.requestDBWriter.updateRequestStatus(workflowName, 'Closed')
 
         topLevelTask = '/%s/Reco' % workflowName
@@ -233,9 +229,9 @@ class Tier0PluginTest(unittest.TestCase):
 
         self.stateMap['AlcaSkim'].append(wmbsHelper.topLevelSubscription)
 
-        alcaSkimWorkflow = Workflow(name = workflowName, task = alcaSkimTask)
+        alcaSkimWorkflow = Workflow(name=workflowName, task=alcaSkimTask)
         alcaSkimWorkflow.load()
-        alcarecoFileset = Fileset(name = '/PromptReco_Run195360_Cosmics/Reco/unmerged-write_ALCARECO')
+        alcarecoFileset = Fileset(name='/PromptReco_Run195360_Cosmics/Reco/unmerged-write_ALCARECOALCARECO')
         alcarecoFileset.load()
         alcaSkimSub = Subscription(alcarecoFileset, alcaSkimWorkflow)
         alcaSkimSub.load()
@@ -243,23 +239,23 @@ class Tier0PluginTest(unittest.TestCase):
 
         for task in mergeTasks:
             mergeTask = task % topLevelTask
-            mergeWorkflow = Workflow(name = workflowName, task = mergeTask)
+            mergeWorkflow = Workflow(name=workflowName, task=mergeTask)
             mergeWorkflow.load()
             if 'AlcaSkim' in mergeTask:
                 stream = mergeTask.split('/')[-1][13:]
-                unmergedFileset = Fileset(name = '%s/unmerged-%s' % (alcaSkimTask, stream))
+                unmergedFileset = Fileset(name='%s/unmerged-%sALCARECO' % (alcaSkimTask, stream))
                 unmergedFileset.load()
             else:
                 dataTier = mergeTask.split('/')[-1].split('_')[-1]
-                unmergedFileset = Fileset(name = '%s/unmerged-write_%s' % (topLevelTask, dataTier))
+                unmergedFileset = Fileset(name='%s/unmerged-write_%s%s' % (topLevelTask, dataTier, dataTier))
                 unmergedFileset.load()
             mergeSub = Subscription(unmergedFileset, mergeWorkflow)
             mergeSub.load()
             self.stateMap['Harvesting'].append(mergeSub)
 
-        harvestingWorkflow = Workflow(name = workflowName, task = harvestingTask)
+        harvestingWorkflow = Workflow(name=workflowName, task=harvestingTask)
         harvestingWorkflow.load()
-        harvestingFileset = Fileset(name = '/PromptReco_Run195360_Cosmics/Reco/RecoMergewrite_DQM/merged-Merged')
+        harvestingFileset = Fileset(name='/PromptReco_Run195360_Cosmics/Reco/RecoMergewrite_DQM/merged-MergedDQM')
         harvestingFileset.load()
         harvestingSub = Subscription(harvestingFileset, harvestingWorkflow)
         harvestingSub.load()
@@ -267,7 +263,7 @@ class Tier0PluginTest(unittest.TestCase):
 
         return
 
-    def verifyStateTransitions(self, transitionMethod = 'markFinished', transitionTrigger = True):
+    def verifyStateTransitions(self, transitionMethod='markFinished', transitionTrigger=True):
         """
         _verifyStateTransitions_
 
@@ -299,7 +295,8 @@ class Tier0PluginTest(unittest.TestCase):
                 self.plugin([], self.requestDBWriter, self.requestDBWriter)
                 currentStateWorkflows = self.requestDBWriter.getRequestByStatus([currentState])
                 nextStateWorkflows = self.requestDBWriter.getRequestByStatus([nextState])
-                self.assertEqual(len(currentStateWorkflows), 0, 'Workflow did not move correctly from %s' % currentState)
+                self.assertEqual(len(currentStateWorkflows), 0,
+                                 'Workflow did not move correctly from %s' % currentState)
                 self.assertEqual(len(nextStateWorkflows), 1, 'Workflow did not move correctly to %s' % nextState)
         return
 
@@ -353,6 +350,7 @@ class Tier0PluginTest(unittest.TestCase):
         self.verifyStateTransitions()
 
         return
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/DQMHarvest_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/DQMHarvest_t.py
@@ -8,7 +8,6 @@ from __future__ import print_function
 import os
 import threading
 import unittest
-from pprint import pformat
 
 from WMCore.DAOFactory import DAOFactory
 from WMCore.Database.CMSCouch import CouchServer, Document
@@ -203,20 +202,16 @@ class DQMHarvestTests(EmulatedUnitTestCase):
         testWMBSHelper.createTopLevelFileset()
         testWMBSHelper._createSubscriptionsInWMBS(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
 
-        print("Tasks producing output:\n%s" % pformat(testWorkload.listOutputProducingTasks()))
         self.assertItemsEqual(testWorkload.listOutputProducingTasks(), expOutTasks)
 
         workflows = self.listTasksByWorkflow.execute(workflow="TestWorkload")
-        print("List of workflows:\n%s" % pformat(workflows))
         self.assertItemsEqual([item['task'] for item in workflows], expWfTasks)
 
         # returns a tuple of id, name, open and last_update
         filesets = self.listFilesets.execute()
-        print("List of filesets:\n%s" % pformat(filesets))
         self.assertItemsEqual([item[1] for item in filesets], expFsets)
 
         subscriptions = self.listSubsMapping.execute(workflow="TestWorkload", returnTuple=True)
-        print("List of subscriptions:\n%s" % pformat(subscriptions))
         self.assertItemsEqual(subscriptions, subMaps)
 
 

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/MonteCarloFromGEN_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/MonteCarloFromGEN_t.py
@@ -9,7 +9,6 @@ from __future__ import print_function
 import os
 import threading
 import unittest
-from pprint import pformat
 
 from WMCore.DAOFactory import DAOFactory
 from WMCore.Database.CMSCouch import CouchServer, Document
@@ -179,11 +178,11 @@ class MonteCarloFromGENTest(EmulatedUnitTestCase):
                       '/TestWorkload/MonteCarloFromGEN/MonteCarloFromGENMergeRECOoutput/MonteCarloFromGENRECOoutputMergeLogCollect']
         expFsets = ['TestWorkload-MonteCarloFromGEN-/MinimumBias/ComissioningHI-v1/RAW',
                     '/TestWorkload/MonteCarloFromGEN/MonteCarloFromGENMergeALCARECOoutput/merged-logArchive',
-                    '/TestWorkload/MonteCarloFromGEN/MonteCarloFromGENMergeALCARECOoutput/merged-Merged',
+                    '/TestWorkload/MonteCarloFromGEN/MonteCarloFromGENMergeALCARECOoutput/merged-MergedALCARECO',
                     '/TestWorkload/MonteCarloFromGEN/MonteCarloFromGENMergeRECOoutput/merged-logArchive',
-                    '/TestWorkload/MonteCarloFromGEN/MonteCarloFromGENMergeRECOoutput/merged-Merged',
-                    '/TestWorkload/MonteCarloFromGEN/unmerged-ALCARECOoutput',
-                    '/TestWorkload/MonteCarloFromGEN/unmerged-RECOoutput',
+                    '/TestWorkload/MonteCarloFromGEN/MonteCarloFromGENMergeRECOoutput/merged-MergedRECO',
+                    '/TestWorkload/MonteCarloFromGEN/unmerged-ALCARECOoutputALCARECO',
+                    '/TestWorkload/MonteCarloFromGEN/unmerged-RECOoutputRECO',
                     '/TestWorkload/MonteCarloFromGEN/unmerged-logArchive']
         subMaps = [(6,
                     '/TestWorkload/MonteCarloFromGEN/MonteCarloFromGENMergeALCARECOoutput/merged-logArchive',
@@ -196,12 +195,12 @@ class MonteCarloFromGENTest(EmulatedUnitTestCase):
                     'MinFileBased',
                     'LogCollect'),
                    (7,
-                    '/TestWorkload/MonteCarloFromGEN/unmerged-ALCARECOoutput',
+                    '/TestWorkload/MonteCarloFromGEN/unmerged-ALCARECOoutputALCARECO',
                     '/TestWorkload/MonteCarloFromGEN/MonteCarloFromGENCleanupUnmergedALCARECOoutput',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (5,
-                    '/TestWorkload/MonteCarloFromGEN/unmerged-ALCARECOoutput',
+                    '/TestWorkload/MonteCarloFromGEN/unmerged-ALCARECOoutputALCARECO',
                     '/TestWorkload/MonteCarloFromGEN/MonteCarloFromGENMergeALCARECOoutput',
                     'ParentlessMergeBySize',
                     'Merge'),
@@ -211,12 +210,12 @@ class MonteCarloFromGENTest(EmulatedUnitTestCase):
                     'MinFileBased',
                     'LogCollect'),
                    (4,
-                    '/TestWorkload/MonteCarloFromGEN/unmerged-RECOoutput',
+                    '/TestWorkload/MonteCarloFromGEN/unmerged-RECOoutputRECO',
                     '/TestWorkload/MonteCarloFromGEN/MonteCarloFromGENCleanupUnmergedRECOoutput',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (2,
-                    '/TestWorkload/MonteCarloFromGEN/unmerged-RECOoutput',
+                    '/TestWorkload/MonteCarloFromGEN/unmerged-RECOoutputRECO',
                     '/TestWorkload/MonteCarloFromGEN/MonteCarloFromGENMergeRECOoutput',
                     'ParentlessMergeBySize',
                     'Merge'),
@@ -239,20 +238,16 @@ class MonteCarloFromGENTest(EmulatedUnitTestCase):
         testWMBSHelper.createTopLevelFileset()
         testWMBSHelper._createSubscriptionsInWMBS(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
 
-        print("Tasks producing output:\n%s" % pformat(testWorkload.listOutputProducingTasks()))
         self.assertItemsEqual(testWorkload.listOutputProducingTasks(), expOutTasks)
 
         workflows = self.listTasksByWorkflow.execute(workflow="TestWorkload")
-        print("List of workflow tasks:\n%s" % pformat([item['task'] for item in workflows]))
         self.assertItemsEqual([item['task'] for item in workflows], expWfTasks)
 
         # returns a tuple of id, name, open and last_update
         filesets = self.listFilesets.execute()
-        print("List of filesets:\n%s" % pformat([item[1] for item in filesets]))
         self.assertItemsEqual([item[1] for item in filesets], expFsets)
 
         subscriptions = self.listSubsMapping.execute(workflow="TestWorkload", returnTuple=True)
-        print("List of subscriptions:\n%s" % pformat(subscriptions))
         self.assertItemsEqual(subscriptions, subMaps)
 
 

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/PromptReco_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/PromptReco_t.py
@@ -9,7 +9,6 @@ from __future__ import print_function
 import os
 import threading
 import unittest
-from pprint import pformat
 
 from WMCore.Configuration import ConfigSection
 from WMCore.DAOFactory import DAOFactory
@@ -73,17 +72,24 @@ class PromptRecoTest(unittest.TestCase):
         self.promptSkim.ProcessingVersion = "PromptSkim-v1"
         self.promptSkim.ConfigURL = "http://cmssw.cvs.cern.ch/cgi-bin/cmssw.cgi/CMSSW/Configuration/DataOps/python/prescaleskimmer.py?revision=1.1"
 
-    def testPromptReco(self):
-        """
-        _testPromptReco_
+        # def testPromptReco(self):
+        #     """
+        #     _testPromptReco_
 
-        Create a Prompt Reconstruction workflow
+    #
+    #        Create a Prompt Reconstruction workflow
+    #        and verify it installs into WMBS correctly.
+    #        """
+    def testPromptRecoWithSkims(self):
+        """
+        _testT1PromptRecoWithSkim_
+
+        Create a T1 Prompt Reconstruction workflow with PromptSkims
         and verify it installs into WMBS correctly.
         """
         testArguments = PromptRecoWorkloadFactory.getTestArguments()
         testArguments["CouchURL"] = os.environ["COUCHURL"]
         testArguments["EnableHarvesting"] = True
-
         factory = PromptRecoWorkloadFactory()
         testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
         testWorkload.setSpecUrl("somespec")
@@ -99,17 +105,19 @@ class PromptRecoTest(unittest.TestCase):
         self.assertEqual(len(recoWorkflow.outputMap.keys()), len(testArguments["WriteTiers"]) + 1,
                          "Error: Wrong number of WF outputs in the Reco WF.")
 
-        goldenOutputMods = ["write_RECO", "write_ALCARECO", "write_AOD", "write_DQM"]
-        for goldenOutputMod in goldenOutputMods:
-            mergedOutput = recoWorkflow.outputMap[goldenOutputMod][0]["merged_output_fileset"]
-            unmergedOutput = recoWorkflow.outputMap[goldenOutputMod][0]["output_fileset"]
+        goldenOutputMods = {"write_RECO": "RECO", "write_ALCARECO": "ALCARECO", "write_AOD": "AOD", "write_DQM": "DQM"}
+        for goldenOutputMod, tier in goldenOutputMods.items():
+            fset = goldenOutputMod + tier
+            mergedOutput = recoWorkflow.outputMap[fset][0]["merged_output_fileset"]
+            unmergedOutput = recoWorkflow.outputMap[fset][0]["output_fileset"]
             mergedOutput.loadData()
             unmergedOutput.loadData()
 
             if goldenOutputMod != "write_ALCARECO":
-                self.assertEqual(mergedOutput.name, "/TestWorkload/Reco/RecoMerge%s/merged-Merged" % goldenOutputMod,
+                self.assertEqual(mergedOutput.name,
+                                 "/TestWorkload/Reco/RecoMerge%s/merged-Merged%s" % (goldenOutputMod, tier),
                                  "Error: Merged output fileset is wrong: %s" % mergedOutput.name)
-            self.assertEqual(unmergedOutput.name, "/TestWorkload/Reco/unmerged-%s" % goldenOutputMod,
+            self.assertEqual(unmergedOutput.name, "/TestWorkload/Reco/unmerged-%s" % fset,
                              "Error: Unmerged output fileset is wrong: %s" % unmergedOutput.name)
 
         logArchOutput = recoWorkflow.outputMap["logArchive"][0]["merged_output_fileset"]
@@ -133,14 +141,15 @@ class PromptRecoTest(unittest.TestCase):
             goldenOutputMods.append("ALCARECOStream%s" % alcaProd)
 
         for goldenOutputMod in goldenOutputMods:
-            mergedOutput = alcaSkimWorkflow.outputMap[goldenOutputMod][0]["merged_output_fileset"]
-            unmergedOutput = alcaSkimWorkflow.outputMap[goldenOutputMod][0]["output_fileset"]
+            fset = goldenOutputMod + "ALCARECO"
+            mergedOutput = alcaSkimWorkflow.outputMap[fset][0]["merged_output_fileset"]
+            unmergedOutput = alcaSkimWorkflow.outputMap[fset][0]["output_fileset"]
             mergedOutput.loadData()
             unmergedOutput.loadData()
             self.assertEqual(mergedOutput.name,
-                             "/TestWorkload/Reco/AlcaSkim/AlcaSkimMerge%s/merged-Merged" % goldenOutputMod,
+                             "/TestWorkload/Reco/AlcaSkim/AlcaSkimMerge%s/merged-MergedALCARECO" % goldenOutputMod,
                              "Error: Merged output fileset is wrong: %s" % mergedOutput.name)
-            self.assertEqual(unmergedOutput.name, "/TestWorkload/Reco/AlcaSkim/unmerged-%s" % goldenOutputMod,
+            self.assertEqual(unmergedOutput.name, "/TestWorkload/Reco/AlcaSkim/unmerged-%sALCARECO" % goldenOutputMod,
                              "Error: Unmerged output fileset is wrong: %s" % unmergedOutput.name)
 
         logArchOutput = alcaSkimWorkflow.outputMap["logArchive"][0]["merged_output_fileset"]
@@ -169,8 +178,9 @@ class PromptRecoTest(unittest.TestCase):
                          "/TestWorkload/Reco/RecoMergewrite_DQM/RecoMergewrite_DQMEndOfRunDQMHarvestMerged/unmerged-logArchive",
                          "Error: LogArchive output fileset is wrong.")
 
-        goldenOutputMods = ["write_RECO", "write_AOD", "write_DQM"]
-        for goldenOutputMod in goldenOutputMods:
+        goldenOutputMods = {"write_RECO": "RECO", "write_AOD": "AOD", "write_DQM": "DQM"}
+        for goldenOutputMod, tier in goldenOutputMods.items():
+            fset = goldenOutputMod + tier
             mergeWorkflow = Workflow(name="TestWorkload",
                                      task="/TestWorkload/Reco/RecoMerge%s" % goldenOutputMod)
             mergeWorkflow.load()
@@ -178,15 +188,17 @@ class PromptRecoTest(unittest.TestCase):
             self.assertEqual(len(mergeWorkflow.outputMap.keys()), 2,
                              "Error: Wrong number of WF outputs.")
 
-            mergedMergeOutput = mergeWorkflow.outputMap["Merged"][0]["merged_output_fileset"]
-            unmergedMergeOutput = mergeWorkflow.outputMap["Merged"][0]["output_fileset"]
+            mergedMergeOutput = mergeWorkflow.outputMap["Merged%s" % tier][0]["merged_output_fileset"]
+            unmergedMergeOutput = mergeWorkflow.outputMap["Merged%s" % tier][0]["output_fileset"]
 
             mergedMergeOutput.loadData()
             unmergedMergeOutput.loadData()
 
-            self.assertEqual(mergedMergeOutput.name, "/TestWorkload/Reco/RecoMerge%s/merged-Merged" % goldenOutputMod,
+            self.assertEqual(mergedMergeOutput.name,
+                             "/TestWorkload/Reco/RecoMerge%s/merged-Merged%s" % (goldenOutputMod, tier),
                              "Error: Merged output fileset is wrong.")
-            self.assertEqual(unmergedMergeOutput.name, "/TestWorkload/Reco/RecoMerge%s/merged-Merged" % goldenOutputMod,
+            self.assertEqual(unmergedMergeOutput.name,
+                             "/TestWorkload/Reco/RecoMerge%s/merged-Merged%s" % (goldenOutputMod, tier),
                              "Error: Unmerged output fileset is wrong.")
 
             logArchOutput = mergeWorkflow.outputMap["logArchive"][0]["merged_output_fileset"]
@@ -212,17 +224,17 @@ class PromptRecoTest(unittest.TestCase):
             self.assertEqual(len(mergeWorkflow.outputMap.keys()), 2,
                              "Error: Wrong number of WF outputs %d." % len(mergeWorkflow.outputMap.keys()))
 
-            mergedMergeOutput = mergeWorkflow.outputMap["Merged"][0]["merged_output_fileset"]
-            unmergedMergeOutput = mergeWorkflow.outputMap["Merged"][0]["output_fileset"]
+            mergedMergeOutput = mergeWorkflow.outputMap["MergedALCARECO"][0]["merged_output_fileset"]
+            unmergedMergeOutput = mergeWorkflow.outputMap["MergedALCARECO"][0]["output_fileset"]
 
             mergedMergeOutput.loadData()
             unmergedMergeOutput.loadData()
 
             self.assertEqual(mergedMergeOutput.name,
-                             "/TestWorkload/Reco/AlcaSkim/AlcaSkimMerge%s/merged-Merged" % goldenOutputMod,
+                             "/TestWorkload/Reco/AlcaSkim/AlcaSkimMerge%s/merged-MergedALCARECO" % goldenOutputMod,
                              "Error: Merged output fileset is wrong.")
             self.assertEqual(unmergedMergeOutput.name,
-                             "/TestWorkload/Reco/AlcaSkim/AlcaSkimMerge%s/merged-Merged" % goldenOutputMod,
+                             "/TestWorkload/Reco/AlcaSkim/AlcaSkimMerge%s/merged-MergedALCARECO" % goldenOutputMod,
                              "Error: Unmerged output fileset is wrong.")
 
             logArchOutput = mergeWorkflow.outputMap["logArchive"][0]["merged_output_fileset"]
@@ -248,7 +260,7 @@ class PromptRecoTest(unittest.TestCase):
         self.assertEqual(recoSubscription["split_algo"], "EventBased",
                          "Error: Wrong split algorithm. %s" % recoSubscription["split_algo"])
 
-        alcaRecoFileset = Fileset(name="/TestWorkload/Reco/unmerged-write_ALCARECO")
+        alcaRecoFileset = Fileset(name="/TestWorkload/Reco/unmerged-write_ALCARECOALCARECO")
         alcaRecoFileset.loadData()
 
         alcaSkimSubscription = Subscription(fileset=alcaRecoFileset, workflow=alcaSkimWorkflow)
@@ -259,7 +271,7 @@ class PromptRecoTest(unittest.TestCase):
         self.assertEqual(alcaSkimSubscription["split_algo"], "WMBSMergeBySize",
                          "Error: Wrong split algorithm. %s" % alcaSkimSubscription["split_algo"])
 
-        mergedDQMFileset = Fileset(name="/TestWorkload/Reco/RecoMergewrite_DQM/merged-Merged")
+        mergedDQMFileset = Fileset(name="/TestWorkload/Reco/RecoMergewrite_DQM/merged-MergedDQM")
         mergedDQMFileset.loadData()
 
         dqmSubscription = Subscription(fileset=mergedDQMFileset, workflow=dqmWorkflow)
@@ -270,9 +282,10 @@ class PromptRecoTest(unittest.TestCase):
         self.assertEqual(dqmSubscription["split_algo"], "Harvest",
                          "Error: Wrong split algo.")
 
-        unmergedOutputs = ["write_RECO", "write_AOD", "write_DQM"]
-        for unmergedOutput in unmergedOutputs:
-            unmergedDataTier = Fileset(name="/TestWorkload/Reco/unmerged-%s" % unmergedOutput)
+        unmergedOutputs = {"write_RECO": "RECO", "write_AOD": "AOD", "write_DQM": "DQM"}
+        for unmergedOutput, tier in unmergedOutputs.items():
+            fset = unmergedOutput + tier
+            unmergedDataTier = Fileset(name="/TestWorkload/Reco/unmerged-%s" % fset)
             unmergedDataTier.loadData()
             dataTierMergeWorkflow = Workflow(name="TestWorkload",
                                              task="/TestWorkload/Reco/RecoMerge%s" % unmergedOutput)
@@ -288,7 +301,7 @@ class PromptRecoTest(unittest.TestCase):
         for alcaProd in testArguments["AlcaSkims"]:
             unmergedOutputs.append("ALCARECOStream%s" % alcaProd)
         for unmergedOutput in unmergedOutputs:
-            unmergedAlcaSkim = Fileset(name="/TestWorkload/Reco/AlcaSkim/unmerged-%s" % unmergedOutput)
+            unmergedAlcaSkim = Fileset(name="/TestWorkload/Reco/AlcaSkim/unmerged-%sALCARECO" % unmergedOutput)
             unmergedAlcaSkim.loadData()
             alcaSkimMergeWorkflow = Workflow(name="TestWorkload",
                                              task="/TestWorkload/Reco/AlcaSkim/AlcaSkimMerge%s" % unmergedOutput)
@@ -301,9 +314,10 @@ class PromptRecoTest(unittest.TestCase):
             self.assertEqual(mergeSubscription["split_algo"], "WMBSMergeBySize",
                              "Error: Wrong split algorithm. %s" % mergeSubscription["split_algo"])
 
-        goldenOutputMods = ["write_RECO", "write_AOD", "write_DQM", "write_ALCARECO"]
-        for goldenOutputMod in goldenOutputMods:
-            unmergedFileset = Fileset(name="/TestWorkload/Reco/unmerged-%s" % goldenOutputMod)
+        goldenOutputMods = {"write_RECO": "RECO", "write_AOD": "AOD", "write_DQM": "DQM"}
+        for goldenOutputMod, tier in goldenOutputMods.items():
+            fset = goldenOutputMod + tier
+            unmergedFileset = Fileset(name="/TestWorkload/Reco/unmerged-%s" % fset)
             unmergedFileset.loadData()
             cleanupWorkflow = Workflow(name="TestWorkload",
                                        task="/TestWorkload/Reco/RecoCleanupUnmerged%s" % goldenOutputMod)
@@ -320,7 +334,7 @@ class PromptRecoTest(unittest.TestCase):
         for alcaProd in testArguments["AlcaSkims"]:
             goldenOutputMods.append("ALCARECOStream%s" % alcaProd)
         for goldenOutputMod in goldenOutputMods:
-            unmergedFileset = Fileset(name="/TestWorkload/Reco/AlcaSkim/unmerged-%s" % goldenOutputMod)
+            unmergedFileset = Fileset(name="/TestWorkload/Reco/AlcaSkim/unmerged-%sALCARECO" % goldenOutputMod)
             unmergedFileset.loadData()
             cleanupWorkflow = Workflow(name="TestWorkload",
                                        task="/TestWorkload/Reco/AlcaSkim/AlcaSkimCleanupUnmerged%s" % goldenOutputMod)
@@ -408,309 +422,6 @@ class PromptRecoTest(unittest.TestCase):
                          "Error: Wrong subscription type.")
         self.assertEqual(logCollectSub["split_algo"], "MinFileBased",
                          "Error: Wrong split algo.")
-
-        return
-
-    def testPromptRecoWithSkims(self):
-        """
-        _testT1PromptRecoWithSkim_
-
-        Create a T1 Prompt Reconstruction workflow with PromptSkims
-        and verify it installs into WMBS correctly.
-        """
-        self.setupPromptSkimConfigObject()
-        testArguments = PromptRecoWorkloadFactory.getTestArguments()
-        # testArguments["PromptSkims"] = [self.promptSkim]
-        testArguments["CouchURL"] = os.environ["COUCHURL"]
-        testArguments["CouchDBName"] = "promptreco_t"
-        testArguments["EnvPath"] = os.environ.get("EnvPath", None)
-        testArguments["BinPath"] = os.environ.get("BinPath", None)
-
-        factory = PromptRecoWorkloadFactory()
-        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
-        testWorkload.setSpecUrl("somespec")
-        testWorkload.setOwnerDetails("dballest@fnal.gov", "T0")
-
-        testWMBSHelper = WMBSHelper(testWorkload, "Reco", "SomeBlock", cachepath=self.testDir)
-        testWMBSHelper.createTopLevelFileset()
-        testWMBSHelper._createSubscriptionsInWMBS(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
-
-        recoWorkflow = Workflow(name="TestWorkload",
-                                task="/TestWorkload/Reco")
-        recoWorkflow.load()
-        self.assertEqual(len(recoWorkflow.outputMap.keys()), len(testArguments["WriteTiers"]) + 1,
-                         "Error: Wrong number of WF outputs in the Reco WF.")
-
-        goldenOutputMods = ["write_RECO", "write_ALCARECO", "write_AOD", "write_DQM"]
-        for goldenOutputMod in goldenOutputMods:
-            mergedOutput = recoWorkflow.outputMap[goldenOutputMod][0]["merged_output_fileset"]
-            unmergedOutput = recoWorkflow.outputMap[goldenOutputMod][0]["output_fileset"]
-            mergedOutput.loadData()
-            unmergedOutput.loadData()
-
-            if goldenOutputMod != "write_ALCARECO":
-                self.assertEqual(mergedOutput.name, "/TestWorkload/Reco/RecoMerge%s/merged-Merged" % goldenOutputMod,
-                                 "Error: Merged output fileset is wrong: %s" % mergedOutput.name)
-            self.assertEqual(unmergedOutput.name, "/TestWorkload/Reco/unmerged-%s" % goldenOutputMod,
-                             "Error: Unmerged output fileset is wrong: %s" % unmergedOutput.name)
-
-        logArchOutput = recoWorkflow.outputMap["logArchive"][0]["merged_output_fileset"]
-        unmergedLogArchOutput = recoWorkflow.outputMap["logArchive"][0]["output_fileset"]
-        logArchOutput.loadData()
-        unmergedLogArchOutput.loadData()
-
-        self.assertEqual(logArchOutput.name, "/TestWorkload/Reco/unmerged-logArchive",
-                         "Error: LogArchive output fileset is wrong.")
-        self.assertEqual(unmergedLogArchOutput.name, "/TestWorkload/Reco/unmerged-logArchive",
-                         "Error: LogArchive output fileset is wrong.")
-
-        alcaSkimWorkflow = Workflow(name="TestWorkload",
-                                    task="/TestWorkload/Reco/AlcaSkim")
-        alcaSkimWorkflow.load()
-        self.assertEqual(len(alcaSkimWorkflow.outputMap.keys()), len(testArguments["AlcaSkims"]) + 1,
-                         "Error: Wrong number of WF outputs in the AlcaSkim WF.")
-
-        goldenOutputMods = []
-        for alcaProd in testArguments["AlcaSkims"]:
-            goldenOutputMods.append("ALCARECOStream%s" % alcaProd)
-
-        for goldenOutputMod in goldenOutputMods:
-            mergedOutput = alcaSkimWorkflow.outputMap[goldenOutputMod][0]["merged_output_fileset"]
-            unmergedOutput = alcaSkimWorkflow.outputMap[goldenOutputMod][0]["output_fileset"]
-            mergedOutput.loadData()
-            unmergedOutput.loadData()
-            self.assertEqual(mergedOutput.name,
-                             "/TestWorkload/Reco/AlcaSkim/AlcaSkimMerge%s/merged-Merged" % goldenOutputMod,
-                             "Error: Merged output fileset is wrong: %s" % mergedOutput.name)
-            self.assertEqual(unmergedOutput.name, "/TestWorkload/Reco/AlcaSkim/unmerged-%s" % goldenOutputMod,
-                             "Error: Unmerged output fileset is wrong: %s" % unmergedOutput.name)
-
-        logArchOutput = alcaSkimWorkflow.outputMap["logArchive"][0]["merged_output_fileset"]
-        unmergedLogArchOutput = alcaSkimWorkflow.outputMap["logArchive"][0]["output_fileset"]
-        logArchOutput.loadData()
-        unmergedLogArchOutput.loadData()
-
-        self.assertEqual(logArchOutput.name, "/TestWorkload/Reco/AlcaSkim/unmerged-logArchive",
-                         "Error: LogArchive output fileset is wrong.")
-        self.assertEqual(unmergedLogArchOutput.name, "/TestWorkload/Reco/AlcaSkim/unmerged-logArchive",
-                         "Error: LogArchive output fileset is wrong.")
-
-        goldenOutputMods = ["write_RECO", "write_AOD", "write_DQM"]
-        for goldenOutputMod in goldenOutputMods:
-            mergeWorkflow = Workflow(name="TestWorkload",
-                                     task="/TestWorkload/Reco/RecoMerge%s" % goldenOutputMod)
-            mergeWorkflow.load()
-
-            self.assertEqual(len(mergeWorkflow.outputMap.keys()), 2,
-                             "Error: Wrong number of WF outputs.")
-
-            mergedMergeOutput = mergeWorkflow.outputMap["Merged"][0]["merged_output_fileset"]
-            unmergedMergeOutput = mergeWorkflow.outputMap["Merged"][0]["output_fileset"]
-
-            mergedMergeOutput.loadData()
-            unmergedMergeOutput.loadData()
-
-            self.assertEqual(mergedMergeOutput.name, "/TestWorkload/Reco/RecoMerge%s/merged-Merged" % goldenOutputMod,
-                             "Error: Merged output fileset is wrong.")
-            self.assertEqual(unmergedMergeOutput.name, "/TestWorkload/Reco/RecoMerge%s/merged-Merged" % goldenOutputMod,
-                             "Error: Unmerged output fileset is wrong.")
-
-            logArchOutput = mergeWorkflow.outputMap["logArchive"][0]["merged_output_fileset"]
-            unmergedLogArchOutput = mergeWorkflow.outputMap["logArchive"][0]["output_fileset"]
-            logArchOutput.loadData()
-            unmergedLogArchOutput.loadData()
-
-            self.assertEqual(logArchOutput.name, "/TestWorkload/Reco/RecoMerge%s/merged-logArchive" % goldenOutputMod,
-                             "Error: LogArchive output fileset is wrong: %s" % logArchOutput.name)
-            self.assertEqual(unmergedLogArchOutput.name,
-                             "/TestWorkload/Reco/RecoMerge%s/merged-logArchive" % goldenOutputMod,
-                             "Error: LogArchive output fileset is wrong.")
-
-        goldenOutputMods = []
-        for alcaProd in testArguments["AlcaSkims"]:
-            goldenOutputMods.append("ALCARECOStream%s" % alcaProd)
-
-        for goldenOutputMod in goldenOutputMods:
-            mergeWorkflow = Workflow(name="TestWorkload",
-                                     task="/TestWorkload/Reco/AlcaSkim/AlcaSkimMerge%s" % goldenOutputMod)
-            mergeWorkflow.load()
-
-            self.assertEqual(len(mergeWorkflow.outputMap.keys()), 2,
-                             "Error: Wrong number of WF outputs %d." % len(mergeWorkflow.outputMap.keys()))
-
-            mergedMergeOutput = mergeWorkflow.outputMap["Merged"][0]["merged_output_fileset"]
-            unmergedMergeOutput = mergeWorkflow.outputMap["Merged"][0]["output_fileset"]
-
-            mergedMergeOutput.loadData()
-            unmergedMergeOutput.loadData()
-
-            self.assertEqual(mergedMergeOutput.name,
-                             "/TestWorkload/Reco/AlcaSkim/AlcaSkimMerge%s/merged-Merged" % goldenOutputMod,
-                             "Error: Merged output fileset is wrong.")
-            self.assertEqual(unmergedMergeOutput.name,
-                             "/TestWorkload/Reco/AlcaSkim/AlcaSkimMerge%s/merged-Merged" % goldenOutputMod,
-                             "Error: Unmerged output fileset is wrong.")
-
-            logArchOutput = mergeWorkflow.outputMap["logArchive"][0]["merged_output_fileset"]
-            unmergedLogArchOutput = mergeWorkflow.outputMap["logArchive"][0]["output_fileset"]
-            logArchOutput.loadData()
-            unmergedLogArchOutput.loadData()
-
-            self.assertEqual(logArchOutput.name,
-                             "/TestWorkload/Reco/AlcaSkim/AlcaSkimMerge%s/merged-logArchive" % goldenOutputMod,
-                             "Error: LogArchive output fileset is wrong: %s" % logArchOutput.name)
-            self.assertEqual(unmergedLogArchOutput.name,
-                             "/TestWorkload/Reco/AlcaSkim/AlcaSkimMerge%s/merged-logArchive" % goldenOutputMod,
-                             "Error: LogArchive output fileset is wrong.")
-
-        topLevelFileset = Fileset(name="TestWorkload-Reco-SomeBlock")
-        topLevelFileset.loadData()
-
-        recoSubscription = Subscription(fileset=topLevelFileset, workflow=recoWorkflow)
-        recoSubscription.loadData()
-
-        self.assertEqual(recoSubscription["type"], "Processing",
-                         "Error: Wrong subscription type.")
-        self.assertEqual(recoSubscription["split_algo"], "EventBased",
-                         "Error: Wrong split algorithm. %s" % recoSubscription["split_algo"])
-
-        alcaRecoFileset = Fileset(name="/TestWorkload/Reco/unmerged-write_ALCARECO")
-        alcaRecoFileset.loadData()
-
-        alcaSkimSubscription = Subscription(fileset=alcaRecoFileset, workflow=alcaSkimWorkflow)
-        alcaSkimSubscription.loadData()
-
-        self.assertEqual(alcaSkimSubscription["type"], "Processing",
-                         "Error: Wrong subscription type.")
-        self.assertEqual(alcaSkimSubscription["split_algo"], "WMBSMergeBySize",
-                         "Error: Wrong split algorithm. %s" % alcaSkimSubscription["split_algo"])
-
-        mergedRecoFileset = Fileset(name="/TestWorkload/Reco/RecoMergewrite_RECO/merged-Merged")
-        mergedRecoFileset.loadData()
-
-        unmergedOutputs = ["write_RECO", "write_AOD", "write_DQM"]
-        for unmergedOutput in unmergedOutputs:
-            unmergedDataTier = Fileset(name="/TestWorkload/Reco/unmerged-%s" % unmergedOutput)
-            unmergedDataTier.loadData()
-            dataTierMergeWorkflow = Workflow(name="TestWorkload",
-                                             task="/TestWorkload/Reco/RecoMerge%s" % unmergedOutput)
-            dataTierMergeWorkflow.load()
-            mergeSubscription = Subscription(fileset=unmergedDataTier, workflow=dataTierMergeWorkflow)
-            mergeSubscription.loadData()
-
-            self.assertEqual(mergeSubscription["type"], "Merge",
-                             "Error: Wrong subscription type.")
-            self.assertEqual(mergeSubscription["split_algo"], "WMBSMergeBySize",
-                             "Error: Wrong split algorithm. %s" % mergeSubscription["split_algo"])
-        unmergedOutputs = []
-        for alcaProd in testArguments["AlcaSkims"]:
-            unmergedOutputs.append("ALCARECOStream%s" % alcaProd)
-        for unmergedOutput in unmergedOutputs:
-            unmergedAlcaSkim = Fileset(name="/TestWorkload/Reco/AlcaSkim/unmerged-%s" % unmergedOutput)
-            unmergedAlcaSkim.loadData()
-            alcaSkimMergeWorkflow = Workflow(name="TestWorkload",
-                                             task="/TestWorkload/Reco/AlcaSkim/AlcaSkimMerge%s" % unmergedOutput)
-            alcaSkimMergeWorkflow.load()
-            mergeSubscription = Subscription(fileset=unmergedAlcaSkim, workflow=alcaSkimMergeWorkflow)
-            mergeSubscription.loadData()
-
-            self.assertEqual(mergeSubscription["type"], "Merge",
-                             "Error: Wrong subscription type.")
-            self.assertEqual(mergeSubscription["split_algo"], "WMBSMergeBySize",
-                             "Error: Wrong split algorithm. %s" % mergeSubscription["split_algo"])
-
-        goldenOutputMods = ["write_RECO", "write_AOD", "write_DQM", "write_ALCARECO"]
-        for goldenOutputMod in goldenOutputMods:
-            unmergedFileset = Fileset(name="/TestWorkload/Reco/unmerged-%s" % goldenOutputMod)
-            unmergedFileset.loadData()
-            cleanupWorkflow = Workflow(name="TestWorkload",
-                                       task="/TestWorkload/Reco/RecoCleanupUnmerged%s" % goldenOutputMod)
-            cleanupWorkflow.load()
-            cleanupSubscription = Subscription(fileset=unmergedFileset, workflow=cleanupWorkflow)
-            cleanupSubscription.loadData()
-
-            self.assertEqual(cleanupSubscription["type"], "Cleanup",
-                             "Error: Wrong subscription type.")
-            self.assertEqual(cleanupSubscription["split_algo"], "SiblingProcessingBased",
-                             "Error: Wrong subscription type.")
-
-        goldenOutputMods = []
-        for alcaProd in testArguments["AlcaSkims"]:
-            goldenOutputMods.append("ALCARECOStream%s" % alcaProd)
-        for goldenOutputMod in goldenOutputMods:
-            unmergedFileset = Fileset(name="/TestWorkload/Reco/AlcaSkim/unmerged-%s" % goldenOutputMod)
-            unmergedFileset.loadData()
-            cleanupWorkflow = Workflow(name="TestWorkload",
-                                       task="/TestWorkload/Reco/AlcaSkim/AlcaSkimCleanupUnmerged%s" % goldenOutputMod)
-            cleanupWorkflow.load()
-            cleanupSubscription = Subscription(fileset=unmergedFileset, workflow=cleanupWorkflow)
-            cleanupSubscription.loadData()
-
-            self.assertEqual(cleanupSubscription["type"], "Cleanup",
-                             "Error: Wrong subscription type.")
-            self.assertEqual(cleanupSubscription["split_algo"], "SiblingProcessingBased",
-                             "Error: Wrong subscription type.")
-
-        recoLogCollect = Fileset(name="/TestWorkload/Reco/unmerged-logArchive")
-        recoLogCollect.loadData()
-        recoLogCollectWorkflow = Workflow(name="TestWorkload",
-                                          task="/TestWorkload/Reco/LogCollect")
-        recoLogCollectWorkflow.load()
-        logCollectSub = Subscription(fileset=recoLogCollect, workflow=recoLogCollectWorkflow)
-        logCollectSub.loadData()
-
-        self.assertEqual(logCollectSub["type"], "LogCollect",
-                         "Error: Wrong subscription type.")
-        self.assertEqual(logCollectSub["split_algo"], "MinFileBased",
-                         "Error: Wrong split algorithm.")
-
-        alcaSkimLogCollect = Fileset(name="/TestWorkload/Reco/AlcaSkim/unmerged-logArchive")
-        alcaSkimLogCollect.loadData()
-        alcaSkimLogCollectWorkflow = Workflow(name="TestWorkload",
-                                              task="/TestWorkload/Reco/AlcaSkim/AlcaSkimLogCollect")
-        alcaSkimLogCollectWorkflow.load()
-        logCollectSub = Subscription(fileset=alcaSkimLogCollect, workflow=alcaSkimLogCollectWorkflow)
-        logCollectSub.loadData()
-
-        self.assertEqual(logCollectSub["type"], "LogCollect",
-                         "Error: Wrong subscription type.")
-        self.assertEqual(logCollectSub["split_algo"], "MinFileBased",
-                         "Error: Wrong split algorithm.")
-
-        goldenOutputMods = ["write_RECO", "write_AOD", "write_DQM"]
-        for goldenOutputMod in goldenOutputMods:
-            recoMergeLogCollect = Fileset(name="/TestWorkload/Reco/RecoMerge%s/merged-logArchive" % goldenOutputMod)
-            recoMergeLogCollect.loadData()
-            recoMergeLogCollectWorkflow = Workflow(name="TestWorkload",
-                                                   task="/TestWorkload/Reco/RecoMerge%s/Reco%sMergeLogCollect" % (
-                                                       goldenOutputMod, goldenOutputMod))
-            recoMergeLogCollectWorkflow.load()
-            logCollectSubscription = Subscription(fileset=recoMergeLogCollect, workflow=recoMergeLogCollectWorkflow)
-            logCollectSubscription.loadData()
-
-            self.assertEqual(logCollectSub["type"], "LogCollect",
-                             "Error: Wrong subscription type.")
-            self.assertEqual(logCollectSub["split_algo"], "MinFileBased",
-                             "Error: Wrong split algorithm.")
-
-        goldenOutputMods = []
-        for alcaProd in testArguments["AlcaSkims"]:
-            goldenOutputMods.append("ALCARECOStream%s" % alcaProd)
-        for goldenOutputMod in goldenOutputMods:
-            alcaSkimLogCollect = Fileset(
-                name="/TestWorkload/Reco/AlcaSkim/AlcaSkimMerge%s/merged-logArchive" % goldenOutputMod)
-            alcaSkimLogCollect.loadData()
-            alcaSkimLogCollectWorkflow = Workflow(name="TestWorkload",
-                                                  task="/TestWorkload/Reco/AlcaSkim/AlcaSkimMerge%s/AlcaSkim%sMergeLogCollect" % (
-                                                      goldenOutputMod, goldenOutputMod))
-            alcaSkimLogCollectWorkflow.load()
-            logCollectSubscription = Subscription(fileset=alcaSkimLogCollect, workflow=alcaSkimLogCollectWorkflow)
-            logCollectSubscription.loadData()
-
-            self.assertEqual(logCollectSub["type"], "LogCollect",
-                             "Error: Wrong subscription type.")
-            self.assertEqual(logCollectSub["split_algo"], "MinFileBased",
-                             "Error: Wrong split algorithm.")
 
         return
 
@@ -804,28 +515,28 @@ class PromptRecoTest(unittest.TestCase):
                       '/TestWorkload/Reco/RecoMergewrite_RECO',
                       '/TestWorkload/Reco/RecoMergewrite_RECO/Recowrite_RECOMergeLogCollect']
         expFsets = ['TestWorkload-Reco-/MinimumBias/ComissioningHI-v1/RAW',
-                    '/TestWorkload/Reco/AlcaSkim/AlcaSkimMergeALCARECOStreamHcalCalHOCosmics/merged-Merged',
-                    '/TestWorkload/Reco/AlcaSkim/unmerged-ALCARECOStreamHcalCalHOCosmics',
-                    '/TestWorkload/Reco/unmerged-write_ALCARECO',
+                    '/TestWorkload/Reco/AlcaSkim/AlcaSkimMergeALCARECOStreamHcalCalHOCosmics/merged-MergedALCARECO',
+                    '/TestWorkload/Reco/AlcaSkim/unmerged-ALCARECOStreamHcalCalHOCosmicsALCARECO',
+                    '/TestWorkload/Reco/unmerged-write_ALCARECOALCARECO',
                     '/TestWorkload/Reco/AlcaSkim/AlcaSkimMergeALCARECOStreamHcalCalHOCosmics/merged-logArchive',
                     '/TestWorkload/Reco/AlcaSkim/AlcaSkimMergeALCARECOStreamMuAlGlobalCosmics/merged-logArchive',
-                    '/TestWorkload/Reco/AlcaSkim/AlcaSkimMergeALCARECOStreamMuAlGlobalCosmics/merged-Merged',
+                    '/TestWorkload/Reco/AlcaSkim/AlcaSkimMergeALCARECOStreamMuAlGlobalCosmics/merged-MergedALCARECO',
                     '/TestWorkload/Reco/AlcaSkim/AlcaSkimMergeALCARECOStreamTkAlCosmics0T/merged-logArchive',
-                    '/TestWorkload/Reco/AlcaSkim/AlcaSkimMergeALCARECOStreamTkAlCosmics0T/merged-Merged',
-                    '/TestWorkload/Reco/AlcaSkim/unmerged-ALCARECOStreamMuAlGlobalCosmics',
-                    '/TestWorkload/Reco/AlcaSkim/unmerged-ALCARECOStreamTkAlCosmics0T',
+                    '/TestWorkload/Reco/AlcaSkim/AlcaSkimMergeALCARECOStreamTkAlCosmics0T/merged-MergedALCARECO',
+                    '/TestWorkload/Reco/AlcaSkim/unmerged-ALCARECOStreamMuAlGlobalCosmicsALCARECO',
+                    '/TestWorkload/Reco/AlcaSkim/unmerged-ALCARECOStreamTkAlCosmics0TALCARECO',
                     '/TestWorkload/Reco/AlcaSkim/unmerged-logArchive',
                     '/TestWorkload/Reco/RecoMergewrite_AOD/merged-logArchive',
-                    '/TestWorkload/Reco/RecoMergewrite_AOD/merged-Merged',
-                    '/TestWorkload/Reco/unmerged-write_AOD',
-                    '/TestWorkload/Reco/unmerged-write_DQM',
+                    '/TestWorkload/Reco/RecoMergewrite_AOD/merged-MergedAOD',
+                    '/TestWorkload/Reco/unmerged-write_AODAOD',
+                    '/TestWorkload/Reco/unmerged-write_DQMDQM',
                     '/TestWorkload/Reco/RecoMergewrite_DQM/merged-logArchive',
-                    '/TestWorkload/Reco/RecoMergewrite_DQM/merged-Merged',
+                    '/TestWorkload/Reco/RecoMergewrite_DQM/merged-MergedDQM',
                     '/TestWorkload/Reco/RecoMergewrite_DQM/RecoMergewrite_DQMEndOfRunDQMHarvestMerged/unmerged-logArchive',
                     '/TestWorkload/Reco/RecoMergewrite_RECO/merged-logArchive',
-                    '/TestWorkload/Reco/RecoMergewrite_RECO/merged-Merged',
+                    '/TestWorkload/Reco/RecoMergewrite_RECO/merged-MergedRECO',
                     '/TestWorkload/Reco/unmerged-logArchive',
-                    '/TestWorkload/Reco/unmerged-write_RECO']
+                    '/TestWorkload/Reco/unmerged-write_RECORECO']
         subMaps = [(4,
                     '/TestWorkload/Reco/AlcaSkim/AlcaSkimMergeALCARECOStreamHcalCalHOCosmics/merged-logArchive',
                     '/TestWorkload/Reco/AlcaSkim/AlcaSkimMergeALCARECOStreamHcalCalHOCosmics/AlcaSkimALCARECOStreamHcalCalHOCosmicsMergeLogCollect',
@@ -842,32 +553,32 @@ class PromptRecoTest(unittest.TestCase):
                     'MinFileBased',
                     'LogCollect'),
                    (5,
-                    '/TestWorkload/Reco/AlcaSkim/unmerged-ALCARECOStreamHcalCalHOCosmics',
+                    '/TestWorkload/Reco/AlcaSkim/unmerged-ALCARECOStreamHcalCalHOCosmicsALCARECO',
                     '/TestWorkload/Reco/AlcaSkim/AlcaSkimCleanupUnmergedALCARECOStreamHcalCalHOCosmics',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (3,
-                    '/TestWorkload/Reco/AlcaSkim/unmerged-ALCARECOStreamHcalCalHOCosmics',
+                    '/TestWorkload/Reco/AlcaSkim/unmerged-ALCARECOStreamHcalCalHOCosmicsALCARECO',
                     '/TestWorkload/Reco/AlcaSkim/AlcaSkimMergeALCARECOStreamHcalCalHOCosmics',
                     'WMBSMergeBySize',
                     'Merge'),
                    (11,
-                    '/TestWorkload/Reco/AlcaSkim/unmerged-ALCARECOStreamMuAlGlobalCosmics',
+                    '/TestWorkload/Reco/AlcaSkim/unmerged-ALCARECOStreamMuAlGlobalCosmicsALCARECO',
                     '/TestWorkload/Reco/AlcaSkim/AlcaSkimCleanupUnmergedALCARECOStreamMuAlGlobalCosmics',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (9,
-                    '/TestWorkload/Reco/AlcaSkim/unmerged-ALCARECOStreamMuAlGlobalCosmics',
+                    '/TestWorkload/Reco/AlcaSkim/unmerged-ALCARECOStreamMuAlGlobalCosmicsALCARECO',
                     '/TestWorkload/Reco/AlcaSkim/AlcaSkimMergeALCARECOStreamMuAlGlobalCosmics',
                     'WMBSMergeBySize',
                     'Merge'),
                    (8,
-                    '/TestWorkload/Reco/AlcaSkim/unmerged-ALCARECOStreamTkAlCosmics0T',
+                    '/TestWorkload/Reco/AlcaSkim/unmerged-ALCARECOStreamTkAlCosmics0TALCARECO',
                     '/TestWorkload/Reco/AlcaSkim/AlcaSkimCleanupUnmergedALCARECOStreamTkAlCosmics0T',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (6,
-                    '/TestWorkload/Reco/AlcaSkim/unmerged-ALCARECOStreamTkAlCosmics0T',
+                    '/TestWorkload/Reco/AlcaSkim/unmerged-ALCARECOStreamTkAlCosmics0TALCARECO',
                     '/TestWorkload/Reco/AlcaSkim/AlcaSkimMergeALCARECOStreamTkAlCosmics0T',
                     'WMBSMergeBySize',
                     'Merge'),
@@ -887,7 +598,7 @@ class PromptRecoTest(unittest.TestCase):
                     'MinFileBased',
                     'LogCollect'),
                    (18,
-                    '/TestWorkload/Reco/RecoMergewrite_DQM/merged-Merged',
+                    '/TestWorkload/Reco/RecoMergewrite_DQM/merged-MergedDQM',
                     '/TestWorkload/Reco/RecoMergewrite_DQM/RecoMergewrite_DQMEndOfRunDQMHarvestMerged',
                     'Harvest',
                     'Harvesting'),
@@ -907,42 +618,42 @@ class PromptRecoTest(unittest.TestCase):
                     'MinFileBased',
                     'LogCollect'),
                    (2,
-                    '/TestWorkload/Reco/unmerged-write_ALCARECO',
+                    '/TestWorkload/Reco/unmerged-write_ALCARECOALCARECO',
                     '/TestWorkload/Reco/AlcaSkim',
                     'WMBSMergeBySize',
                     'Processing'),
                    (13,
-                    '/TestWorkload/Reco/unmerged-write_ALCARECO',
+                    '/TestWorkload/Reco/unmerged-write_ALCARECOALCARECO',
                     '/TestWorkload/Reco/RecoCleanupUnmergedwrite_ALCARECO',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (16,
-                    '/TestWorkload/Reco/unmerged-write_AOD',
+                    '/TestWorkload/Reco/unmerged-write_AODAOD',
                     '/TestWorkload/Reco/RecoCleanupUnmergedwrite_AOD',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (14,
-                    '/TestWorkload/Reco/unmerged-write_AOD',
+                    '/TestWorkload/Reco/unmerged-write_AODAOD',
                     '/TestWorkload/Reco/RecoMergewrite_AOD',
                     'WMBSMergeBySize',
                     'Merge'),
                    (21,
-                    '/TestWorkload/Reco/unmerged-write_DQM',
+                    '/TestWorkload/Reco/unmerged-write_DQMDQM',
                     '/TestWorkload/Reco/RecoCleanupUnmergedwrite_DQM',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (17,
-                    '/TestWorkload/Reco/unmerged-write_DQM',
+                    '/TestWorkload/Reco/unmerged-write_DQMDQM',
                     '/TestWorkload/Reco/RecoMergewrite_DQM',
                     'WMBSMergeBySize',
                     'Merge'),
                    (24,
-                    '/TestWorkload/Reco/unmerged-write_RECO',
+                    '/TestWorkload/Reco/unmerged-write_RECORECO',
                     '/TestWorkload/Reco/RecoCleanupUnmergedwrite_RECO',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (22,
-                    '/TestWorkload/Reco/unmerged-write_RECO',
+                    '/TestWorkload/Reco/unmerged-write_RECORECO',
                     '/TestWorkload/Reco/RecoMergewrite_RECO',
                     'WMBSMergeBySize',
                     'Merge'),
@@ -965,20 +676,16 @@ class PromptRecoTest(unittest.TestCase):
         testWMBSHelper.createTopLevelFileset()
         testWMBSHelper._createSubscriptionsInWMBS(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
 
-        print("Tasks producing output:\n%s" % pformat(testWorkload.listOutputProducingTasks()))
         self.assertItemsEqual(testWorkload.listOutputProducingTasks(), expOutTasks)
 
         workflows = self.listTasksByWorkflow.execute(workflow="TestWorkload")
-        print("List of workflow tasks:\n%s" % pformat([item['task'] for item in workflows]))
         self.assertItemsEqual([item['task'] for item in workflows], expWfTasks)
 
         # returns a tuple of id, name, open and last_update
         filesets = self.listFilesets.execute()
-        print("List of filesets:\n%s" % pformat([item[1] for item in filesets]))
         self.assertItemsEqual([item[1] for item in filesets], expFsets)
 
         subscriptions = self.listSubsMapping.execute(workflow="TestWorkload", returnTuple=True)
-        print("List of subscriptions:\n%s" % pformat(subscriptions))
         self.assertItemsEqual(subscriptions, subMaps)
 
 

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/ReDigi_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/ReDigi_t.py
@@ -9,7 +9,6 @@ from __future__ import print_function
 import os
 import threading
 import unittest
-from pprint import pformat
 
 from WMCore.DAOFactory import DAOFactory
 from WMCore.Database.CMSCouch import CouchServer, Document
@@ -142,9 +141,10 @@ class ReDigiTest(EmulatedUnitTestCase):
         topLevelFileset = Fileset(name="TestWorkload-StepOneProc-SomeBlock")
         topLevelFileset.loadData()
 
-        stepOneUnmergedRAWFileset = Fileset(name="/TestWorkload/StepOneProc/unmerged-RAWDEBUGoutput")
+        stepOneUnmergedRAWFileset = Fileset(name="/TestWorkload/StepOneProc/unmerged-RAWDEBUGoutputRAW-DEBUG-OUTPUT")
         stepOneUnmergedRAWFileset.loadData()
-        stepOneMergedRAWFileset = Fileset(name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/merged-Merged")
+        stepOneMergedRAWFileset = Fileset(
+            name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/merged-MergedRAW-DEBUG-OUTPUT")
         stepOneMergedRAWFileset.loadData()
         stepOneLogArchiveFileset = Fileset(name="/TestWorkload/StepOneProc/unmerged-logArchive")
         stepOneLogArchiveFileset.loadData()
@@ -153,16 +153,16 @@ class ReDigiTest(EmulatedUnitTestCase):
         stepOneMergeLogArchiveFileset.loadData()
 
         stepTwoUnmergedDQMFileset = Fileset(
-            name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/unmerged-DQMoutput")
+            name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/unmerged-DQMoutputDQM")
         stepTwoUnmergedDQMFileset.loadData()
         stepTwoUnmergedRECOFileset = Fileset(
-            name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/unmerged-RECODEBUGoutput")
+            name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/unmerged-RECODEBUGoutputRECO-DEBUG-OUTPUT")
         stepTwoUnmergedRECOFileset.loadData()
         stepTwoMergedDQMFileset = Fileset(
-            name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeDQMoutput/merged-Merged")
+            name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeDQMoutput/merged-MergedDQM")
         stepTwoMergedDQMFileset.loadData()
         stepTwoMergedRECOFileset = Fileset(
-            name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeRECODEBUGoutput/merged-Merged")
+            name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeRECODEBUGoutput/merged-MergedRECO-DEBUG-OUTPUT")
         stepTwoMergedRECOFileset.loadData()
         stepTwoLogArchiveFileset = Fileset(
             name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/unmerged-logArchive")
@@ -175,10 +175,10 @@ class ReDigiTest(EmulatedUnitTestCase):
         stepTwoMergeRECOLogArchiveFileset.loadData()
 
         stepThreeUnmergedAODFileset = Fileset(
-            name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeRECODEBUGoutput/StepThreeProc/unmerged-aodOutputModule")
+            name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeRECODEBUGoutput/StepThreeProc/unmerged-aodOutputModuleAODSIM")
         stepThreeUnmergedAODFileset.loadData()
         stepThreeMergedAODFileset = Fileset(
-            name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeRECODEBUGoutput/StepThreeProc/StepThreeProcMergeaodOutputModule/merged-Merged")
+            name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeRECODEBUGoutput/StepThreeProc/StepThreeProcMergeaodOutputModule/merged-MergedAODSIM")
         stepThreeMergedAODFileset.loadData()
         stepThreeLogArchiveFileset = Fileset(
             name="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeRECODEBUGoutput/StepThreeProc/unmerged-logArchive")
@@ -194,17 +194,17 @@ class ReDigiTest(EmulatedUnitTestCase):
         self.assertEqual(stepOneWorkflow.wfType, 'reprocessing')
         self.assertTrue("logArchive" in stepOneWorkflow.outputMap.keys(),
                         "Error: Step one missing output module.")
-        self.assertTrue("RAWDEBUGoutput" in stepOneWorkflow.outputMap.keys(),
+        self.assertTrue("RAWDEBUGoutputRAW-DEBUG-OUTPUT" in stepOneWorkflow.outputMap.keys(),
                         "Error: Step one missing output module.")
         self.assertEqual(stepOneWorkflow.outputMap["logArchive"][0]["merged_output_fileset"].id,
                          stepOneLogArchiveFileset.id,
                          "Error: logArchive fileset is wrong.")
         self.assertEqual(stepOneWorkflow.outputMap["logArchive"][0]["output_fileset"].id, stepOneLogArchiveFileset.id,
                          "Error: logArchive fileset is wrong.")
-        self.assertEqual(stepOneWorkflow.outputMap["RAWDEBUGoutput"][0]["merged_output_fileset"].id,
+        self.assertEqual(stepOneWorkflow.outputMap["RAWDEBUGoutputRAW-DEBUG-OUTPUT"][0]["merged_output_fileset"].id,
                          stepOneMergedRAWFileset.id,
                          "Error: RAWDEBUG output fileset is wrong.")
-        self.assertEqual(stepOneWorkflow.outputMap["RAWDEBUGoutput"][0]["output_fileset"].id,
+        self.assertEqual(stepOneWorkflow.outputMap["RAWDEBUGoutputRAW-DEBUG-OUTPUT"][0]["output_fileset"].id,
                          stepOneUnmergedRAWFileset.id,
                          "Error: RAWDEBUG output fileset is wrong.")
 
@@ -240,7 +240,7 @@ class ReDigiTest(EmulatedUnitTestCase):
         stepOneMergeWorkflow = Workflow(spec="somespec", name="TestWorkload",
                                         task="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput")
         stepOneMergeWorkflow.load()
-        self.assertTrue("Merged" in stepOneMergeWorkflow.outputMap.keys(),
+        self.assertTrue("MergedRAW-DEBUG-OUTPUT" in stepOneMergeWorkflow.outputMap.keys(),
                         "Error: Step one merge missing output module.")
         self.assertTrue("logArchive" in stepOneMergeWorkflow.outputMap.keys(),
                         "Error: Step one merge missing output module.")
@@ -250,10 +250,11 @@ class ReDigiTest(EmulatedUnitTestCase):
         self.assertEqual(stepOneMergeWorkflow.outputMap["logArchive"][0]["output_fileset"].id,
                          stepOneMergeLogArchiveFileset.id,
                          "Error: logArchive fileset is wrong.")
-        self.assertEqual(stepOneMergeWorkflow.outputMap["Merged"][0]["merged_output_fileset"].id,
+        self.assertEqual(stepOneMergeWorkflow.outputMap["MergedRAW-DEBUG-OUTPUT"][0]["merged_output_fileset"].id,
                          stepOneMergedRAWFileset.id,
                          "Error: RAWDEBUG merge output fileset is wrong.")
-        self.assertEqual(stepOneMergeWorkflow.outputMap["Merged"][0]["output_fileset"].id, stepOneMergedRAWFileset.id,
+        self.assertEqual(stepOneMergeWorkflow.outputMap["MergedRAW-DEBUG-OUTPUT"][0]["output_fileset"].id,
+                         stepOneMergedRAWFileset.id,
                          "Error: RAWDEBUG merge output fileset is wrong.")
         for outputMod in stepOneMergeWorkflow.outputMap.keys():
             self.assertTrue(len(stepOneMergeWorkflow.outputMap[outputMod]) == 1,
@@ -266,25 +267,26 @@ class ReDigiTest(EmulatedUnitTestCase):
         stepTwoWorkflow = Workflow(spec="somespec", name="TestWorkload",
                                    task="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc")
         stepTwoWorkflow.load()
-        self.assertTrue("RECODEBUGoutput" in stepTwoWorkflow.outputMap.keys(),
+        self.assertTrue("RECODEBUGoutputRECO-DEBUG-OUTPUT" in stepTwoWorkflow.outputMap.keys(),
                         "Error: Step two missing output module.")
-        self.assertTrue("DQMoutput" in stepTwoWorkflow.outputMap.keys(),
+        self.assertTrue("DQMoutputDQM" in stepTwoWorkflow.outputMap.keys(),
                         "Error: Step two missing output module.")
         self.assertEqual(stepTwoWorkflow.outputMap["logArchive"][0]["merged_output_fileset"].id,
                          stepTwoLogArchiveFileset.id,
                          "Error: logArchive fileset is wrong.")
         self.assertEqual(stepTwoWorkflow.outputMap["logArchive"][0]["output_fileset"].id, stepTwoLogArchiveFileset.id,
                          "Error: logArchive fileset is wrong.")
-        self.assertEqual(stepTwoWorkflow.outputMap["RECODEBUGoutput"][0]["merged_output_fileset"].id,
+        self.assertEqual(stepTwoWorkflow.outputMap["RECODEBUGoutputRECO-DEBUG-OUTPUT"][0]["merged_output_fileset"].id,
                          stepTwoMergedRECOFileset.id,
                          "Error: RECODEBUG output fileset is wrong.")
-        self.assertEqual(stepTwoWorkflow.outputMap["RECODEBUGoutput"][0]["output_fileset"].id,
+        self.assertEqual(stepTwoWorkflow.outputMap["RECODEBUGoutputRECO-DEBUG-OUTPUT"][0]["output_fileset"].id,
                          stepTwoUnmergedRECOFileset.id,
                          "Error: RECODEBUG output fileset is wrong.")
-        self.assertEqual(stepTwoWorkflow.outputMap["DQMoutput"][0]["merged_output_fileset"].id,
+        self.assertEqual(stepTwoWorkflow.outputMap["DQMoutputDQM"][0]["merged_output_fileset"].id,
                          stepTwoMergedDQMFileset.id,
                          "Error: DQM output fileset is wrong.")
-        self.assertEqual(stepTwoWorkflow.outputMap["DQMoutput"][0]["output_fileset"].id, stepTwoUnmergedDQMFileset.id,
+        self.assertEqual(stepTwoWorkflow.outputMap["DQMoutputDQM"][0]["output_fileset"].id,
+                         stepTwoUnmergedDQMFileset.id,
                          "Error: DQM output fileset is wrong.")
         stepTwoSub = Subscription(workflow=stepTwoWorkflow, fileset=stepOneMergedRAWFileset)
         stepTwoSub.loadData()
@@ -328,7 +330,7 @@ class ReDigiTest(EmulatedUnitTestCase):
         stepTwoMergeRECOWorkflow = Workflow(spec="somespec", name="TestWorkload",
                                             task="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeRECODEBUGoutput")
         stepTwoMergeRECOWorkflow.load()
-        self.assertTrue("Merged" in stepTwoMergeRECOWorkflow.outputMap.keys(),
+        self.assertTrue("MergedRECO-DEBUG-OUTPUT" in stepTwoMergeRECOWorkflow.outputMap.keys(),
                         "Error: Step two merge missing output module.")
         self.assertTrue("logArchive" in stepTwoMergeRECOWorkflow.outputMap.keys(),
                         "Error: Step two merge missing output module.")
@@ -338,10 +340,10 @@ class ReDigiTest(EmulatedUnitTestCase):
         self.assertEqual(stepTwoMergeRECOWorkflow.outputMap["logArchive"][0]["output_fileset"].id,
                          stepTwoMergeRECOLogArchiveFileset.id,
                          "Error: logArchive fileset is wrong.")
-        self.assertEqual(stepTwoMergeRECOWorkflow.outputMap["Merged"][0]["merged_output_fileset"].id,
+        self.assertEqual(stepTwoMergeRECOWorkflow.outputMap["MergedRECO-DEBUG-OUTPUT"][0]["merged_output_fileset"].id,
                          stepTwoMergedRECOFileset.id,
                          "Error: RECODEBUG merge output fileset is wrong.")
-        self.assertEqual(stepTwoMergeRECOWorkflow.outputMap["Merged"][0]["output_fileset"].id,
+        self.assertEqual(stepTwoMergeRECOWorkflow.outputMap["MergedRECO-DEBUG-OUTPUT"][0]["output_fileset"].id,
                          stepTwoMergedRECOFileset.id,
                          "Error: RECODEBUG merge output fileset is wrong.")
         stepTwoMergeRECOSub = Subscription(workflow=stepTwoMergeRECOWorkflow, fileset=stepTwoUnmergedRECOFileset)
@@ -355,7 +357,7 @@ class ReDigiTest(EmulatedUnitTestCase):
         stepTwoMergeDQMWorkflow = Workflow(spec="somespec", name="TestWorkload",
                                            task="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeDQMoutput")
         stepTwoMergeDQMWorkflow.load()
-        self.assertTrue("Merged" in stepTwoMergeDQMWorkflow.outputMap.keys(),
+        self.assertTrue("MergedDQM" in stepTwoMergeDQMWorkflow.outputMap.keys(),
                         "Error: Step two merge missing output module.")
         self.assertTrue("logArchive" in stepTwoMergeDQMWorkflow.outputMap.keys(),
                         "Error: Step two merge missing output module.")
@@ -365,10 +367,10 @@ class ReDigiTest(EmulatedUnitTestCase):
         self.assertEqual(stepTwoMergeDQMWorkflow.outputMap["logArchive"][0]["output_fileset"].id,
                          stepTwoMergeDQMLogArchiveFileset.id,
                          "Error: logArchive fileset is wrong.")
-        self.assertEqual(stepTwoMergeDQMWorkflow.outputMap["Merged"][0]["merged_output_fileset"].id,
+        self.assertEqual(stepTwoMergeDQMWorkflow.outputMap["MergedDQM"][0]["merged_output_fileset"].id,
                          stepTwoMergedDQMFileset.id,
                          "Error: DQM merge output fileset is wrong.")
-        self.assertEqual(stepTwoMergeDQMWorkflow.outputMap["Merged"][0]["output_fileset"].id,
+        self.assertEqual(stepTwoMergeDQMWorkflow.outputMap["MergedDQM"][0]["output_fileset"].id,
                          stepTwoMergedDQMFileset.id,
                          "Error: DQM merge output fileset is wrong.")
         stepTwoMergeDQMSub = Subscription(workflow=stepTwoMergeDQMWorkflow, fileset=stepTwoUnmergedDQMFileset)
@@ -382,7 +384,7 @@ class ReDigiTest(EmulatedUnitTestCase):
         stepThreeWorkflow = Workflow(spec="somespec", name="TestWorkload",
                                      task="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeRECODEBUGoutput/StepThreeProc")
         stepThreeWorkflow.load()
-        self.assertTrue("aodOutputModule" in stepThreeWorkflow.outputMap.keys(),
+        self.assertTrue("aodOutputModuleAODSIM" in stepThreeWorkflow.outputMap.keys(),
                         "Error: Step three missing output module.")
         self.assertTrue("logArchive" in stepThreeWorkflow.outputMap.keys(),
                         "Error: Step three missing output module.")
@@ -392,12 +394,12 @@ class ReDigiTest(EmulatedUnitTestCase):
         self.assertEqual(stepThreeWorkflow.outputMap["logArchive"][0]["output_fileset"].id,
                          stepThreeLogArchiveFileset.id,
                          "Error: logArchive fileset is wrong.")
-        self.assertEqual(stepThreeWorkflow.outputMap["aodOutputModule"][0]["merged_output_fileset"].id,
+        self.assertEqual(stepThreeWorkflow.outputMap["aodOutputModuleAODSIM"][0]["merged_output_fileset"].id,
                          stepThreeMergedAODFileset.id,
-                         "Error: RECODEBUG output fileset is wrong.")
-        self.assertEqual(stepThreeWorkflow.outputMap["aodOutputModule"][0]["output_fileset"].id,
+                         "Error: aodOutputModuleAODSIM output fileset is wrong.")
+        self.assertEqual(stepThreeWorkflow.outputMap["aodOutputModuleAODSIM"][0]["output_fileset"].id,
                          stepThreeUnmergedAODFileset.id,
-                         "Error: RECODEBUG output fileset is wrong.")
+                         "Error: aodOutputModuleAODSIM output fileset is wrong.")
         stepThreeSub = Subscription(workflow=stepThreeWorkflow, fileset=stepTwoMergedRECOFileset)
         stepThreeSub.loadData()
         self.assertEqual(stepThreeSub["type"], "Processing",
@@ -429,7 +431,7 @@ class ReDigiTest(EmulatedUnitTestCase):
         stepThreeMergeWorkflow = Workflow(spec="somespec", name="TestWorkload",
                                           task="/TestWorkload/StepOneProc/StepOneProcMergeRAWDEBUGoutput/StepTwoProc/StepTwoProcMergeRECODEBUGoutput/StepThreeProc/StepThreeProcMergeaodOutputModule")
         stepThreeMergeWorkflow.load()
-        self.assertTrue("Merged" in stepThreeMergeWorkflow.outputMap.keys(),
+        self.assertTrue("MergedAODSIM" in stepThreeMergeWorkflow.outputMap.keys(),
                         "Error: Step three merge missing output module.")
         self.assertTrue("logArchive" in stepThreeMergeWorkflow.outputMap.keys(),
                         "Error: Step three merge missing output module.")
@@ -439,10 +441,10 @@ class ReDigiTest(EmulatedUnitTestCase):
         self.assertEqual(stepThreeMergeWorkflow.outputMap["logArchive"][0]["output_fileset"].id,
                          stepThreeMergeLogArchiveFileset.id,
                          "Error: logArchive fileset is wrong.")
-        self.assertEqual(stepThreeMergeWorkflow.outputMap["Merged"][0]["merged_output_fileset"].id,
+        self.assertEqual(stepThreeMergeWorkflow.outputMap["MergedAODSIM"][0]["merged_output_fileset"].id,
                          stepThreeMergedAODFileset.id,
                          "Error: AOD merge output fileset is wrong.")
-        self.assertEqual(stepThreeMergeWorkflow.outputMap["Merged"][0]["output_fileset"].id,
+        self.assertEqual(stepThreeMergeWorkflow.outputMap["MergedAODSIM"][0]["output_fileset"].id,
                          stepThreeMergedAODFileset.id,
                          "Error: AOD merge output fileset is wrong.")
         stepThreeMergeSub = Subscription(workflow=stepThreeMergeWorkflow, fileset=stepThreeUnmergedAODFileset)
@@ -465,14 +467,14 @@ class ReDigiTest(EmulatedUnitTestCase):
         topLevelFileset = Fileset(name="TestWorkload-StepOneProc-SomeBlock")
         topLevelFileset.loadData()
 
-        stepTwoUnmergedDQMFileset = Fileset(name="/TestWorkload/StepOneProc/unmerged-DQMoutput")
+        stepTwoUnmergedDQMFileset = Fileset(name="/TestWorkload/StepOneProc/unmerged-DQMoutputDQM")
         stepTwoUnmergedDQMFileset.loadData()
-        stepTwoUnmergedRECOFileset = Fileset(name="/TestWorkload/StepOneProc/unmerged-RECODEBUGoutput")
+        stepTwoUnmergedRECOFileset = Fileset(name="/TestWorkload/StepOneProc/unmerged-RECODEBUGoutputRECO-DEBUG-OUTPUT")
         stepTwoUnmergedRECOFileset.loadData()
-        stepTwoMergedDQMFileset = Fileset(name="/TestWorkload/StepOneProc/StepOneProcMergeDQMoutput/merged-Merged")
+        stepTwoMergedDQMFileset = Fileset(name="/TestWorkload/StepOneProc/StepOneProcMergeDQMoutput/merged-MergedDQM")
         stepTwoMergedDQMFileset.loadData()
         stepTwoMergedRECOFileset = Fileset(
-            name="/TestWorkload/StepOneProc/StepOneProcMergeRECODEBUGoutput/merged-Merged")
+            name="/TestWorkload/StepOneProc/StepOneProcMergeRECODEBUGoutput/merged-MergedRECO-DEBUG-OUTPUT")
         stepTwoMergedRECOFileset.loadData()
         stepTwoLogArchiveFileset = Fileset(name="/TestWorkload/StepOneProc/unmerged-logArchive")
         stepTwoLogArchiveFileset.loadData()
@@ -486,25 +488,26 @@ class ReDigiTest(EmulatedUnitTestCase):
         stepTwoWorkflow = Workflow(spec="somespec", name="TestWorkload",
                                    task="/TestWorkload/StepOneProc")
         stepTwoWorkflow.load()
-        self.assertTrue("RECODEBUGoutput" in stepTwoWorkflow.outputMap.keys(),
+        self.assertTrue("RECODEBUGoutputRECO-DEBUG-OUTPUT" in stepTwoWorkflow.outputMap.keys(),
                         "Error: Step two missing output module.")
-        self.assertTrue("DQMoutput" in stepTwoWorkflow.outputMap.keys(),
+        self.assertTrue("DQMoutputDQM" in stepTwoWorkflow.outputMap.keys(),
                         "Error: Step two missing output module.")
         self.assertEqual(stepTwoWorkflow.outputMap["logArchive"][0]["merged_output_fileset"].id,
                          stepTwoLogArchiveFileset.id,
                          "Error: logArchive fileset is wrong.")
         self.assertEqual(stepTwoWorkflow.outputMap["logArchive"][0]["output_fileset"].id, stepTwoLogArchiveFileset.id,
                          "Error: logArchive fileset is wrong.")
-        self.assertEqual(stepTwoWorkflow.outputMap["RECODEBUGoutput"][0]["merged_output_fileset"].id,
+        self.assertEqual(stepTwoWorkflow.outputMap["RECODEBUGoutputRECO-DEBUG-OUTPUT"][0]["merged_output_fileset"].id,
                          stepTwoMergedRECOFileset.id,
                          "Error: RECODEBUG output fileset is wrong.")
-        self.assertEqual(stepTwoWorkflow.outputMap["RECODEBUGoutput"][0]["output_fileset"].id,
+        self.assertEqual(stepTwoWorkflow.outputMap["RECODEBUGoutputRECO-DEBUG-OUTPUT"][0]["output_fileset"].id,
                          stepTwoUnmergedRECOFileset.id,
                          "Error: RECODEBUG output fileset is wrong.")
-        self.assertEqual(stepTwoWorkflow.outputMap["DQMoutput"][0]["merged_output_fileset"].id,
+        self.assertEqual(stepTwoWorkflow.outputMap["DQMoutputDQM"][0]["merged_output_fileset"].id,
                          stepTwoMergedDQMFileset.id,
                          "Error: DQM output fileset is wrong.")
-        self.assertEqual(stepTwoWorkflow.outputMap["DQMoutput"][0]["output_fileset"].id, stepTwoUnmergedDQMFileset.id,
+        self.assertEqual(stepTwoWorkflow.outputMap["DQMoutputDQM"][0]["output_fileset"].id,
+                         stepTwoUnmergedDQMFileset.id,
                          "Error: DQM output fileset is wrong.")
         stepTwoSub = Subscription(workflow=stepTwoWorkflow, fileset=topLevelFileset)
         stepTwoSub.loadData()
@@ -548,7 +551,7 @@ class ReDigiTest(EmulatedUnitTestCase):
         stepTwoMergeRECOWorkflow = Workflow(spec="somespec", name="TestWorkload",
                                             task="/TestWorkload/StepOneProc/StepOneProcMergeRECODEBUGoutput")
         stepTwoMergeRECOWorkflow.load()
-        self.assertTrue("Merged" in stepTwoMergeRECOWorkflow.outputMap.keys(),
+        self.assertTrue("MergedRECO-DEBUG-OUTPUT" in stepTwoMergeRECOWorkflow.outputMap.keys(),
                         "Error: Step two merge missing output module.")
         self.assertTrue("logArchive" in stepTwoMergeRECOWorkflow.outputMap.keys(),
                         "Error: Step two merge missing output module.")
@@ -558,10 +561,10 @@ class ReDigiTest(EmulatedUnitTestCase):
         self.assertEqual(stepTwoMergeRECOWorkflow.outputMap["logArchive"][0]["output_fileset"].id,
                          stepTwoMergeRECOLogArchiveFileset.id,
                          "Error: logArchive fileset is wrong.")
-        self.assertEqual(stepTwoMergeRECOWorkflow.outputMap["Merged"][0]["merged_output_fileset"].id,
+        self.assertEqual(stepTwoMergeRECOWorkflow.outputMap["MergedRECO-DEBUG-OUTPUT"][0]["merged_output_fileset"].id,
                          stepTwoMergedRECOFileset.id,
                          "Error: RECODEBUG merge output fileset is wrong.")
-        self.assertEqual(stepTwoMergeRECOWorkflow.outputMap["Merged"][0]["output_fileset"].id,
+        self.assertEqual(stepTwoMergeRECOWorkflow.outputMap["MergedRECO-DEBUG-OUTPUT"][0]["output_fileset"].id,
                          stepTwoMergedRECOFileset.id,
                          "Error: RECODEBUG merge output fileset is wrong.")
         stepTwoMergeRECOSub = Subscription(workflow=stepTwoMergeRECOWorkflow, fileset=stepTwoUnmergedRECOFileset)
@@ -575,7 +578,7 @@ class ReDigiTest(EmulatedUnitTestCase):
         stepTwoMergeDQMWorkflow = Workflow(spec="somespec", name="TestWorkload",
                                            task="/TestWorkload/StepOneProc/StepOneProcMergeDQMoutput")
         stepTwoMergeDQMWorkflow.load()
-        self.assertTrue("Merged" in stepTwoMergeDQMWorkflow.outputMap.keys(),
+        self.assertTrue("MergedDQM" in stepTwoMergeDQMWorkflow.outputMap.keys(),
                         "Error: Step two merge missing output module.")
         self.assertTrue("logArchive" in stepTwoMergeDQMWorkflow.outputMap.keys(),
                         "Error: Step two merge missing output module.")
@@ -585,10 +588,10 @@ class ReDigiTest(EmulatedUnitTestCase):
         self.assertEqual(stepTwoMergeDQMWorkflow.outputMap["logArchive"][0]["output_fileset"].id,
                          stepTwoMergeDQMLogArchiveFileset.id,
                          "Error: logArchive fileset is wrong.")
-        self.assertEqual(stepTwoMergeDQMWorkflow.outputMap["Merged"][0]["merged_output_fileset"].id,
+        self.assertEqual(stepTwoMergeDQMWorkflow.outputMap["MergedDQM"][0]["merged_output_fileset"].id,
                          stepTwoMergedDQMFileset.id,
                          "Error: DQM merge output fileset is wrong.")
-        self.assertEqual(stepTwoMergeDQMWorkflow.outputMap["Merged"][0]["output_fileset"].id,
+        self.assertEqual(stepTwoMergeDQMWorkflow.outputMap["MergedDQM"][0]["output_fileset"].id,
                          stepTwoMergedDQMFileset.id,
                          "Error: DQM merge output fileset is wrong.")
         stepTwoMergeDQMSub = Subscription(workflow=stepTwoMergeDQMWorkflow, fileset=stepTwoUnmergedDQMFileset)
@@ -610,10 +613,10 @@ class ReDigiTest(EmulatedUnitTestCase):
         topLevelFileset = Fileset(name="TestWorkload-StepOneProc-SomeBlock")
         topLevelFileset.loadData()
 
-        stepTwoUnmergedAODFileset = Fileset(name="/TestWorkload/StepOneProc/unmerged-aodOutputModule")
+        stepTwoUnmergedAODFileset = Fileset(name="/TestWorkload/StepOneProc/unmerged-aodOutputModuleAODSIM")
         stepTwoUnmergedAODFileset.loadData()
         stepTwoMergedAODFileset = Fileset(
-            name="/TestWorkload/StepOneProc/StepOneProcMergeaodOutputModule/merged-Merged")
+            name="/TestWorkload/StepOneProc/StepOneProcMergeaodOutputModule/merged-MergedAODSIM")
         stepTwoMergedAODFileset.loadData()
         stepTwoLogArchiveFileset = Fileset(name="/TestWorkload/StepOneProc/unmerged-logArchive")
         stepTwoLogArchiveFileset.loadData()
@@ -624,17 +627,17 @@ class ReDigiTest(EmulatedUnitTestCase):
         stepTwoWorkflow = Workflow(spec="somespec", name="TestWorkload",
                                    task="/TestWorkload/StepOneProc")
         stepTwoWorkflow.load()
-        self.assertTrue("aodOutputModule" in stepTwoWorkflow.outputMap.keys(),
+        self.assertTrue("aodOutputModuleAODSIM" in stepTwoWorkflow.outputMap.keys(),
                         "Error: Step two missing output module.")
         self.assertEqual(stepTwoWorkflow.outputMap["logArchive"][0]["merged_output_fileset"].id,
                          stepTwoLogArchiveFileset.id,
                          "Error: logArchive fileset is wrong.")
         self.assertEqual(stepTwoWorkflow.outputMap["logArchive"][0]["output_fileset"].id, stepTwoLogArchiveFileset.id,
                          "Error: logArchive fileset is wrong.")
-        self.assertEqual(stepTwoWorkflow.outputMap["aodOutputModule"][0]["merged_output_fileset"].id,
+        self.assertEqual(stepTwoWorkflow.outputMap["aodOutputModuleAODSIM"][0]["merged_output_fileset"].id,
                          stepTwoMergedAODFileset.id,
                          "Error: AOD output fileset is wrong.")
-        self.assertEqual(stepTwoWorkflow.outputMap["aodOutputModule"][0]["output_fileset"].id,
+        self.assertEqual(stepTwoWorkflow.outputMap["aodOutputModuleAODSIM"][0]["output_fileset"].id,
                          stepTwoUnmergedAODFileset.id,
                          "Error: AOD output fileset is wrong.")
         stepTwoSub = Subscription(workflow=stepTwoWorkflow, fileset=topLevelFileset)
@@ -669,7 +672,7 @@ class ReDigiTest(EmulatedUnitTestCase):
         stepTwoMergeAODWorkflow = Workflow(spec="somespec", name="TestWorkload",
                                            task="/TestWorkload/StepOneProc/StepOneProcMergeaodOutputModule")
         stepTwoMergeAODWorkflow.load()
-        self.assertTrue("Merged" in stepTwoMergeAODWorkflow.outputMap.keys(),
+        self.assertTrue("MergedAODSIM" in stepTwoMergeAODWorkflow.outputMap.keys(),
                         "Error: Step two merge missing output module.")
         self.assertTrue("logArchive" in stepTwoMergeAODWorkflow.outputMap.keys(),
                         "Error: Step two merge missing output module.")
@@ -679,10 +682,10 @@ class ReDigiTest(EmulatedUnitTestCase):
         self.assertEqual(stepTwoMergeAODWorkflow.outputMap["logArchive"][0]["output_fileset"].id,
                          stepTwoMergeAODLogArchiveFileset.id,
                          "Error: logArchive fileset is wrong.")
-        self.assertEqual(stepTwoMergeAODWorkflow.outputMap["Merged"][0]["merged_output_fileset"].id,
+        self.assertEqual(stepTwoMergeAODWorkflow.outputMap["MergedAODSIM"][0]["merged_output_fileset"].id,
                          stepTwoMergedAODFileset.id,
                          "Error: AOD merge output fileset is wrong.")
-        self.assertEqual(stepTwoMergeAODWorkflow.outputMap["Merged"][0]["output_fileset"].id,
+        self.assertEqual(stepTwoMergeAODWorkflow.outputMap["MergedAODSIM"][0]["output_fileset"].id,
                          stepTwoMergedAODFileset.id,
                          "Error: AOD merge output fileset is wrong.")
         stepTwoMergeAODSub = Subscription(workflow=stepTwoMergeAODWorkflow, fileset=stepTwoUnmergedAODFileset)
@@ -1138,8 +1141,8 @@ class ReDigiTest(EmulatedUnitTestCase):
                       '/TestWorkload/StepOneProc/StepOneProcMergeaodOutputModule/StepOneProcaodOutputModuleMergeLogCollect']
         expFsets = ['TestWorkload-StepOneProc-/MinimumBias/ComissioningHI-v1/RAW',
                     '/TestWorkload/StepOneProc/StepOneProcMergeaodOutputModule/merged-logArchive',
-                    '/TestWorkload/StepOneProc/StepOneProcMergeaodOutputModule/merged-Merged',
-                    '/TestWorkload/StepOneProc/unmerged-aodOutputModule',
+                    '/TestWorkload/StepOneProc/StepOneProcMergeaodOutputModule/merged-MergedAODSIM',
+                    '/TestWorkload/StepOneProc/unmerged-aodOutputModuleAODSIM',
                     '/TestWorkload/StepOneProc/unmerged-logArchive']
         subMaps = [(3,
                     '/TestWorkload/StepOneProc/StepOneProcMergeaodOutputModule/merged-logArchive',
@@ -1147,12 +1150,12 @@ class ReDigiTest(EmulatedUnitTestCase):
                     'MinFileBased',
                     'LogCollect'),
                    (4,
-                    '/TestWorkload/StepOneProc/unmerged-aodOutputModule',
+                    '/TestWorkload/StepOneProc/unmerged-aodOutputModuleAODSIM',
                     '/TestWorkload/StepOneProc/StepOneProcCleanupUnmergedaodOutputModule',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (2,
-                    '/TestWorkload/StepOneProc/unmerged-aodOutputModule',
+                    '/TestWorkload/StepOneProc/unmerged-aodOutputModuleAODSIM',
                     '/TestWorkload/StepOneProc/StepOneProcMergeaodOutputModule',
                     'ParentlessMergeBySize',
                     'Merge'),
@@ -1181,20 +1184,16 @@ class ReDigiTest(EmulatedUnitTestCase):
         testWMBSHelper.createTopLevelFileset()
         testWMBSHelper._createSubscriptionsInWMBS(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
 
-        print("Tasks producing output:\n%s" % pformat(testWorkload.listOutputProducingTasks()))
         self.assertItemsEqual(testWorkload.listOutputProducingTasks(), expOutTasks)
 
         workflows = self.listTasksByWorkflow.execute(workflow="TestWorkload")
-        print("List of workflow tasks:\n%s" % pformat([item['task'] for item in workflows]))
         self.assertItemsEqual([item['task'] for item in workflows], expWfTasks)
 
         # returns a tuple of id, name, open and last_update
         filesets = self.listFilesets.execute()
-        print("List of filesets:\n%s" % pformat([item[1] for item in filesets]))
         self.assertItemsEqual([item[1] for item in filesets], expFsets)
 
         subscriptions = self.listSubsMapping.execute(workflow="TestWorkload", returnTuple=True)
-        print("List of subscriptions:\n%s" % pformat(subscriptions))
         self.assertItemsEqual(subscriptions, subMaps)
 
     def test2StepFilesets(self):
@@ -1214,14 +1213,14 @@ class ReDigiTest(EmulatedUnitTestCase):
                       '/TestWorkload/StepOneProc/StepOneProcMergeRECODEBUGoutput',
                       '/TestWorkload/StepOneProc/StepOneProcMergeRECODEBUGoutput/StepOneProcRECODEBUGoutputMergeLogCollect']
         expFsets = ['TestWorkload-StepOneProc-/MinimumBias/ComissioningHI-v1/RAW',
-                    '/TestWorkload/StepOneProc/unmerged-DQMoutput',
-                    '/TestWorkload/StepOneProc/unmerged-RAWDEBUGoutput',
+                    '/TestWorkload/StepOneProc/unmerged-DQMoutputDQM',
+                    '/TestWorkload/StepOneProc/unmerged-RAWDEBUGoutputRAW-DEBUG-OUTPUT',
                     '/TestWorkload/StepOneProc/StepOneProcMergeDQMoutput/merged-logArchive',
-                    '/TestWorkload/StepOneProc/StepOneProcMergeDQMoutput/merged-Merged',
+                    '/TestWorkload/StepOneProc/StepOneProcMergeDQMoutput/merged-MergedDQM',
                     '/TestWorkload/StepOneProc/StepOneProcMergeRECODEBUGoutput/merged-logArchive',
-                    '/TestWorkload/StepOneProc/StepOneProcMergeRECODEBUGoutput/merged-Merged',
+                    '/TestWorkload/StepOneProc/StepOneProcMergeRECODEBUGoutput/merged-MergedRECO-DEBUG-OUTPUT',
                     '/TestWorkload/StepOneProc/unmerged-logArchive',
-                    '/TestWorkload/StepOneProc/unmerged-RECODEBUGoutput']
+                    '/TestWorkload/StepOneProc/unmerged-RECODEBUGoutputRECO-DEBUG-OUTPUT']
         subMaps = [(3,
                     '/TestWorkload/StepOneProc/StepOneProcMergeDQMoutput/merged-logArchive',
                     '/TestWorkload/StepOneProc/StepOneProcMergeDQMoutput/StepOneProcDQMoutputMergeLogCollect',
@@ -1233,12 +1232,12 @@ class ReDigiTest(EmulatedUnitTestCase):
                     'MinFileBased',
                     'LogCollect'),
                    (4,
-                    '/TestWorkload/StepOneProc/unmerged-DQMoutput',
+                    '/TestWorkload/StepOneProc/unmerged-DQMoutputDQM',
                     '/TestWorkload/StepOneProc/StepOneProcCleanupUnmergedDQMoutput',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (2,
-                    '/TestWorkload/StepOneProc/unmerged-DQMoutput',
+                    '/TestWorkload/StepOneProc/unmerged-DQMoutputDQM',
                     '/TestWorkload/StepOneProc/StepOneProcMergeDQMoutput',
                     'ParentlessMergeBySize',
                     'Merge'),
@@ -1248,12 +1247,12 @@ class ReDigiTest(EmulatedUnitTestCase):
                     'MinFileBased',
                     'LogCollect'),
                    (7,
-                    '/TestWorkload/StepOneProc/unmerged-RECODEBUGoutput',
+                    '/TestWorkload/StepOneProc/unmerged-RECODEBUGoutputRECO-DEBUG-OUTPUT',
                     '/TestWorkload/StepOneProc/StepOneProcCleanupUnmergedRECODEBUGoutput',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (5,
-                    '/TestWorkload/StepOneProc/unmerged-RECODEBUGoutput',
+                    '/TestWorkload/StepOneProc/unmerged-RECODEBUGoutputRECO-DEBUG-OUTPUT',
                     '/TestWorkload/StepOneProc/StepOneProcMergeRECODEBUGoutput',
                     'ParentlessMergeBySize',
                     'Merge'),
@@ -1282,20 +1281,16 @@ class ReDigiTest(EmulatedUnitTestCase):
         testWMBSHelper.createTopLevelFileset()
         testWMBSHelper._createSubscriptionsInWMBS(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
 
-        print("Tasks producing output:\n%s" % pformat(testWorkload.listOutputProducingTasks()))
         self.assertItemsEqual(testWorkload.listOutputProducingTasks(), expOutTasks)
 
         workflows = self.listTasksByWorkflow.execute(workflow="TestWorkload")
-        print("List of workflow tasks:\n%s" % pformat([item['task'] for item in workflows]))
         self.assertItemsEqual([item['task'] for item in workflows], expWfTasks)
 
         # returns a tuple of id, name, open and last_update
         filesets = self.listFilesets.execute()
-        print("List of filesets:\n%s" % pformat([item[1] for item in filesets]))
         self.assertItemsEqual([item[1] for item in filesets], expFsets)
 
         subscriptions = self.listSubsMapping.execute(workflow="TestWorkload", returnTuple=True)
-        print("List of subscriptions:\n%s" % pformat(subscriptions))
         self.assertItemsEqual(subscriptions, subMaps)
 
 

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
@@ -1493,6 +1493,167 @@ class StepChainTests(EmulatedUnitTestCase):
         print("List of subscriptions:\n%s" % pformat(subscriptions))
         self.assertItemsEqual(subscriptions, subMaps)
 
+    def testDupOutputModule(self):
+        """
+        Test a StepChain saving duplicate output module
+        """
+        expOutTasks = ['/TestWorkload/GENSIM',
+                       '/TestWorkload/GENSIM/GENSIMMergeRAWSIMoutput',
+                       '/TestWorkload/GENSIM/DIGIMergeRAWSIMoutput',
+                       '/TestWorkload/GENSIM/RECOMergeAODSIMoutput',
+                       '/TestWorkload/GENSIM/RECOMergeRECOSIMoutput']
+        expWfTasks = ['/TestWorkload/GENSIM',
+                      '/TestWorkload/GENSIM/DIGICleanupUnmergedRAWSIMoutput',
+                      '/TestWorkload/GENSIM/DIGIMergeRAWSIMoutput',
+                      '/TestWorkload/GENSIM/DIGIMergeRAWSIMoutput/DIGIRAWSIMoutputMergeLogCollect',
+                      '/TestWorkload/GENSIM/GENSIMCleanupUnmergedRAWSIMoutput',
+                      '/TestWorkload/GENSIM/GENSIMMergeRAWSIMoutput',
+                      '/TestWorkload/GENSIM/GENSIMMergeRAWSIMoutput/GENSIMRAWSIMoutputMergeLogCollect',
+                      '/TestWorkload/GENSIM/RECOCleanupUnmergedAODSIMoutput',
+                      '/TestWorkload/GENSIM/RECOCleanupUnmergedRECOSIMoutput',
+                      '/TestWorkload/GENSIM/RECOMergeAODSIMoutput',
+                      '/TestWorkload/GENSIM/RECOMergeAODSIMoutput/RECOAODSIMoutputMergeLogCollect',
+                      '/TestWorkload/GENSIM/RECOMergeRECOSIMoutput',
+                      '/TestWorkload/GENSIM/RECOMergeRECOSIMoutput/RECORECOSIMoutputMergeLogCollect']
+        expFsets = ['FILESET_DEFINED_DURING_RUNTIME',
+                    '/TestWorkload/GENSIM/DIGIMergeRAWSIMoutput/merged-MergedGEN-SIM-RAW',
+                    '/TestWorkload/GENSIM/DIGIMergeRAWSIMoutput/merged-logArchive',
+                    '/TestWorkload/GENSIM/GENSIMMergeRAWSIMoutput/merged-MergedGEN-SIM',
+                    '/TestWorkload/GENSIM/GENSIMMergeRAWSIMoutput/merged-logArchive',
+                    '/TestWorkload/GENSIM/RECOMergeAODSIMoutput/merged-MergedAODSIM',
+                    '/TestWorkload/GENSIM/RECOMergeAODSIMoutput/merged-logArchive',
+                    '/TestWorkload/GENSIM/RECOMergeRECOSIMoutput/merged-MergedGEN-SIM-RECO',
+                    '/TestWorkload/GENSIM/RECOMergeRECOSIMoutput/merged-logArchive',
+                    '/TestWorkload/GENSIM/unmerged-AODSIMoutputAODSIM',
+                    '/TestWorkload/GENSIM/unmerged-RAWSIMoutputGEN-SIM',
+                    '/TestWorkload/GENSIM/unmerged-RAWSIMoutputGEN-SIM-RAW',
+                    '/TestWorkload/GENSIM/unmerged-RECOSIMoutputGEN-SIM-RECO',
+                    '/TestWorkload/GENSIM/unmerged-logArchive']
+        # mapping of subscriptions to fileset and workflow task
+        subMaps = ['FILESET_DEFINED_DURING_RUNTIME',
+                   (6,
+                    '/TestWorkload/GENSIM/DIGIMergeRAWSIMoutput/merged-logArchive',
+                    '/TestWorkload/GENSIM/DIGIMergeRAWSIMoutput/DIGIRAWSIMoutputMergeLogCollect',
+                    'MinFileBased',
+                    'LogCollect'),
+                   (3,
+                    '/TestWorkload/GENSIM/GENSIMMergeRAWSIMoutput/merged-logArchive',
+                    '/TestWorkload/GENSIM/GENSIMMergeRAWSIMoutput/GENSIMRAWSIMoutputMergeLogCollect',
+                    'MinFileBased',
+                    'LogCollect'),
+                   (9,
+                    '/TestWorkload/GENSIM/RECOMergeAODSIMoutput/merged-logArchive',
+                    '/TestWorkload/GENSIM/RECOMergeAODSIMoutput/RECOAODSIMoutputMergeLogCollect',
+                    'MinFileBased',
+                    'LogCollect'),
+                   (12,
+                    '/TestWorkload/GENSIM/RECOMergeRECOSIMoutput/merged-logArchive',
+                    '/TestWorkload/GENSIM/RECOMergeRECOSIMoutput/RECORECOSIMoutputMergeLogCollect',
+                    'MinFileBased',
+                    'LogCollect'),
+                   (10,
+                    '/TestWorkload/GENSIM/unmerged-AODSIMoutputAODSIM',
+                    '/TestWorkload/GENSIM/RECOCleanupUnmergedAODSIMoutput',
+                    'SiblingProcessingBased',
+                    'Cleanup'),
+                   (8,
+                    '/TestWorkload/GENSIM/unmerged-AODSIMoutputAODSIM',
+                    '/TestWorkload/GENSIM/RECOMergeAODSIMoutput',
+                    'ParentlessMergeBySize',
+                    'Merge'),
+                   (7,
+                    '/TestWorkload/GENSIM/unmerged-RAWSIMoutputGEN-SIM-RAW',
+                    '/TestWorkload/GENSIM/DIGICleanupUnmergedRAWSIMoutput',
+                    'SiblingProcessingBased',
+                    'Cleanup'),
+                   (5,
+                    '/TestWorkload/GENSIM/unmerged-RAWSIMoutputGEN-SIM-RAW',
+                    '/TestWorkload/GENSIM/DIGIMergeRAWSIMoutput',
+                    'ParentlessMergeBySize',
+                    'Merge'),
+                   (4,
+                    '/TestWorkload/GENSIM/unmerged-RAWSIMoutputGEN-SIM',
+                    '/TestWorkload/GENSIM/GENSIMCleanupUnmergedRAWSIMoutput',
+                    'SiblingProcessingBased',
+                    'Cleanup'),
+                   (2,
+                    '/TestWorkload/GENSIM/unmerged-RAWSIMoutputGEN-SIM',
+                    '/TestWorkload/GENSIM/GENSIMMergeRAWSIMoutput',
+                    'ParentlessMergeBySize',
+                    'Merge'),
+                   (13,
+                    '/TestWorkload/GENSIM/unmerged-RECOSIMoutputGEN-SIM-RECO',
+                    '/TestWorkload/GENSIM/RECOCleanupUnmergedRECOSIMoutput',
+                    'SiblingProcessingBased',
+                    'Cleanup'),
+                   (11,
+                    '/TestWorkload/GENSIM/unmerged-RECOSIMoutputGEN-SIM-RECO',
+                    '/TestWorkload/GENSIM/RECOMergeRECOSIMoutput',
+                    'ParentlessMergeBySize',
+                    'Merge')]
+
+        testArguments = StepChainWorkloadFactory.getTestArguments()
+        testArguments.update(deepcopy(REQUEST))
+
+        configDocs = injectStepChainConfigMC(self.configDatabase)
+        for s in ['Step1', 'Step2', 'Step3']:
+            testArguments[s]['ConfigCacheID'] = configDocs[s]
+
+        factory = StepChainWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
+
+        myMask = Mask(FirstRun=1, FirstLumi=1, FirstEvent=1, LastRun=1, LastLumi=10, LastEvent=1000)
+        testWMBSHelper = WMBSHelper(testWorkload, "GENSIM", mask=myMask,
+                                    cachepath=self.testInit.testDir)
+        testWMBSHelper.createTopLevelFileset()
+        testWMBSHelper._createSubscriptionsInWMBS(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
+
+        print("Tasks producing output:\n%s" % pformat(testWorkload.listOutputProducingTasks()))
+        self.assertItemsEqual(testWorkload.listOutputProducingTasks(), expOutTasks)
+
+        workflows = self.listTasksByWorkflow.execute(workflow="TestWorkload")
+        print("List of workflow tasks:\n%s" % pformat([item['task'] for item in workflows]))
+        self.assertItemsEqual([item['task'] for item in workflows], expWfTasks)
+
+        # same function as in WMBSHelper, otherwise we cannot know which fileset name is
+        maskString = ",".join(["%s=%s" % (x, myMask[x]) for x in sorted(myMask)])
+        topFilesetName = 'TestWorkload-GENSIM-%s' % md5(maskString).hexdigest()
+        expFsets[0] = topFilesetName
+        # returns a tuple of id, name, open and last_update
+        filesets = self.listFilesets.execute()
+        print("List of filesets:\n%s" % pformat([item[1] for item in filesets]))
+        self.assertItemsEqual([item[1] for item in filesets], expFsets)
+
+        subMaps[0] = (1, topFilesetName, '/TestWorkload/GENSIM', 'EventBased', 'Production')
+        subscriptions = self.listSubsMapping.execute(workflow="TestWorkload", returnTuple=True)
+        print("List of subscriptions:\n%s" % pformat(subscriptions))
+        self.assertItemsEqual(subscriptions, subMaps)
+
+        ### create another top level subscription
+        myMask = Mask(FirstRun=1, FirstLumi=11, FirstEvent=1001, LastRun=1, LastLumi=20, LastEvent=2000)
+        testWMBSHelper = WMBSHelper(testWorkload, "GENSIM", mask=myMask,
+                                    cachepath=self.testInit.testDir)
+        testWMBSHelper.createTopLevelFileset()
+        testWMBSHelper._createSubscriptionsInWMBS(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
+
+        workflows = self.listTasksByWorkflow.execute(workflow="TestWorkload")
+        print("List of workflow tasks:\n%s" % pformat([item['task'] for item in workflows]))
+        self.assertItemsEqual([item['task'] for item in workflows], expWfTasks)
+
+        # same function as in WMBSHelper, otherwise we cannot know which fileset name is
+        maskString = ",".join(["%s=%s" % (x, myMask[x]) for x in sorted(myMask)])
+        topFilesetName = 'TestWorkload-GENSIM-%s' % md5(maskString).hexdigest()
+        expFsets.append(topFilesetName)
+        # returns a tuple of id, name, open and last_update
+        filesets = self.listFilesets.execute()
+        print("List of filesets:\n%s" % pformat([item[1] for item in filesets]))
+        self.assertItemsEqual([item[1] for item in filesets], expFsets)
+
+        subMaps.append((14, topFilesetName, '/TestWorkload/GENSIM', 'EventBased', 'Production'))
+        subscriptions = self.listSubsMapping.execute(workflow="TestWorkload", returnTuple=True)
+        print("List of subscriptions:\n%s" % pformat(subscriptions))
+        self.assertItemsEqual(subscriptions, subMaps)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
@@ -10,7 +10,6 @@ import threading
 import unittest
 from copy import deepcopy
 from hashlib import md5
-from pprint import pformat
 
 from WMCore.DAOFactory import DAOFactory
 from WMCore.DataStructs.Mask import Mask
@@ -352,14 +351,9 @@ class StepChainTests(EmulatedUnitTestCase):
         configDocs = injectStepChainConfigMC(self.configDatabase)
         for s in ['Step1', 'Step2', 'Step3']:
             testArguments[s]['ConfigCacheID'] = configDocs[s]
+        testArguments['Step2']['KeepOutput'] = False
 
         factory = StepChainWorkloadFactory()
-
-        # test that we cannot stage out different samples with the same output module
-        self.assertRaises(WMSpecFactoryException, factory.factoryWorkloadConstruction,
-                          "TestWorkload", testArguments)
-
-        testArguments['Step2']['KeepOutput'] = False
         testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
 
         # workload level check
@@ -1215,6 +1209,46 @@ class StepChainTests(EmulatedUnitTestCase):
 
         return
 
+    def testBadTrident(self):
+        """
+        Test a setup which is not supported. A request with the same output module AND
+        datatier in different steps.
+        Example would be a trident configuration where Step2 and Step3 read the output
+        from Step1, producing the same datasets with a different CMSSW release (or GT).
+        """
+        testArguments = StepChainWorkloadFactory.getTestArguments()
+        testArguments.update(deepcopy(REQUEST))
+        testArguments['Step3']['InputStep'] = testArguments['Step2']['InputStep']
+        testArguments['Step3']['InputFromOutputModule'] = testArguments['Step2']['InputFromOutputModule']
+
+        configDocs = injectStepChainConfigMC(self.configDatabase)
+        testArguments['Step1']['ConfigCacheID'] = configDocs['Step1']
+        testArguments['Step2']['ConfigCacheID'] = configDocs['Step3']
+        testArguments['Step3']['ConfigCacheID'] = configDocs['Step3']
+
+        factory = StepChainWorkloadFactory()
+
+        self.assertRaises(WMSpecFactoryException, factory.factoryWorkloadConstruction,
+                          "TestWorkload", testArguments)
+
+    def testGoodTrident(self):
+        """
+        Test a trident request setup where steps don't define the same
+        set of output module AND datatier.
+        """
+        testArguments = StepChainWorkloadFactory.getTestArguments()
+        testArguments.update(deepcopy(REQUEST))
+        testArguments['Step3']['InputStep'] = testArguments['Step2']['InputStep']
+        testArguments['Step3']['InputFromOutputModule'] = testArguments['Step2']['InputFromOutputModule']
+
+        configDocs = injectStepChainConfigMC(self.configDatabase)
+        testArguments['Step1']['ConfigCacheID'] = configDocs['Step1']
+        testArguments['Step2']['ConfigCacheID'] = configDocs['Step2']
+        testArguments['Step3']['ConfigCacheID'] = configDocs['Step3']
+
+        factory = StepChainWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
+
     def testMCFilesets(self):
         """
         Test workflow tasks, filesets and subscriptions creation
@@ -1236,14 +1270,15 @@ class StepChainTests(EmulatedUnitTestCase):
                       '/TestWorkload/GENSIM/RECOMergeRECOSIMoutput/RECORECOSIMoutputMergeLogCollect']
         expFsets = ['FILESET_DEFINED_DURING_RUNTIME',
                     '/TestWorkload/GENSIM/GENSIMMergeRAWSIMoutput/merged-logArchive',
-                    '/TestWorkload/GENSIM/GENSIMMergeRAWSIMoutput/merged-Merged',
+                    '/TestWorkload/GENSIM/GENSIMMergeRAWSIMoutput/merged-MergedGEN-SIM',
                     '/TestWorkload/GENSIM/RECOMergeAODSIMoutput/merged-logArchive',
-                    '/TestWorkload/GENSIM/RECOMergeAODSIMoutput/merged-Merged',
+                    '/TestWorkload/GENSIM/RECOMergeAODSIMoutput/merged-MergedAODSIM',
                     '/TestWorkload/GENSIM/RECOMergeRECOSIMoutput/merged-logArchive',
-                    '/TestWorkload/GENSIM/RECOMergeRECOSIMoutput/merged-Merged',
-                    '/TestWorkload/GENSIM/unmerged-AODSIMoutput',
-                    '/TestWorkload/GENSIM/unmerged-RAWSIMoutput',
-                    '/TestWorkload/GENSIM/unmerged-RECOSIMoutput',
+                    '/TestWorkload/GENSIM/RECOMergeRECOSIMoutput/merged-MergedGEN-SIM-RECO',
+                    '/TestWorkload/GENSIM/unmerged-AODSIMoutputAODSIM',
+                    '/TestWorkload/GENSIM/unmerged-RAWSIMoutputGEN-SIM',
+                    '/TestWorkload/GENSIM/unmerged-RAWSIMoutputGEN-SIM-RAW',
+                    '/TestWorkload/GENSIM/unmerged-RECOSIMoutputGEN-SIM-RECO',
                     '/TestWorkload/GENSIM/unmerged-logArchive']
 
         subMaps = ['FILESET_DEFINED_DURING_RUNTIME',
@@ -1263,32 +1298,32 @@ class StepChainTests(EmulatedUnitTestCase):
                     'MinFileBased',
                     'LogCollect'),
                    (7,
-                    '/TestWorkload/GENSIM/unmerged-AODSIMoutput',
+                    '/TestWorkload/GENSIM/unmerged-AODSIMoutputAODSIM',
                     '/TestWorkload/GENSIM/RECOCleanupUnmergedAODSIMoutput',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (5,
-                    '/TestWorkload/GENSIM/unmerged-AODSIMoutput',
+                    '/TestWorkload/GENSIM/unmerged-AODSIMoutputAODSIM',
                     '/TestWorkload/GENSIM/RECOMergeAODSIMoutput',
                     'ParentlessMergeBySize',
                     'Merge'),
                    (4,
-                    '/TestWorkload/GENSIM/unmerged-RAWSIMoutput',
+                    '/TestWorkload/GENSIM/unmerged-RAWSIMoutputGEN-SIM',
                     '/TestWorkload/GENSIM/GENSIMCleanupUnmergedRAWSIMoutput',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (2,
-                    '/TestWorkload/GENSIM/unmerged-RAWSIMoutput',
+                    '/TestWorkload/GENSIM/unmerged-RAWSIMoutputGEN-SIM',
                     '/TestWorkload/GENSIM/GENSIMMergeRAWSIMoutput',
                     'ParentlessMergeBySize',
                     'Merge'),
                    (10,
-                    '/TestWorkload/GENSIM/unmerged-RECOSIMoutput',
+                    '/TestWorkload/GENSIM/unmerged-RECOSIMoutputGEN-SIM-RECO',
                     '/TestWorkload/GENSIM/RECOCleanupUnmergedRECOSIMoutput',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (8,
-                    '/TestWorkload/GENSIM/unmerged-RECOSIMoutput',
+                    '/TestWorkload/GENSIM/unmerged-RECOSIMoutputGEN-SIM-RECO',
                     '/TestWorkload/GENSIM/RECOMergeRECOSIMoutput',
                     'ParentlessMergeBySize',
                     'Merge')]
@@ -1310,11 +1345,9 @@ class StepChainTests(EmulatedUnitTestCase):
         testWMBSHelper.createTopLevelFileset()
         testWMBSHelper._createSubscriptionsInWMBS(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
 
-        print("Tasks producing output:\n%s" % pformat(testWorkload.listOutputProducingTasks()))
         self.assertItemsEqual(testWorkload.listOutputProducingTasks(), expOutTasks)
 
         workflows = self.listTasksByWorkflow.execute(workflow="TestWorkload")
-        print("List of workflow tasks:\n%s" % pformat([item['task'] for item in workflows]))
         self.assertItemsEqual([item['task'] for item in workflows], expWfTasks)
 
         # same function as in WMBSHelper, otherwise we cannot know which fileset name is
@@ -1323,12 +1356,10 @@ class StepChainTests(EmulatedUnitTestCase):
         expFsets[0] = topFilesetName
         # returns a tuple of id, name, open and last_update
         filesets = self.listFilesets.execute()
-        print("List of filesets:\n%s" % pformat([item[1] for item in filesets]))
         self.assertItemsEqual([item[1] for item in filesets], expFsets)
 
         subMaps[0] = (1, topFilesetName, '/TestWorkload/GENSIM', 'EventBased', 'Production')
         subscriptions = self.listSubsMapping.execute(workflow="TestWorkload", returnTuple=True)
-        print("List of subscriptions:\n%s" % pformat(subscriptions))
         self.assertItemsEqual(subscriptions, subMaps)
 
         ### create another top level subscription
@@ -1339,7 +1370,6 @@ class StepChainTests(EmulatedUnitTestCase):
         testWMBSHelper._createSubscriptionsInWMBS(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
 
         workflows = self.listTasksByWorkflow.execute(workflow="TestWorkload")
-        print("List of workflow tasks:\n%s" % pformat([item['task'] for item in workflows]))
         self.assertItemsEqual([item['task'] for item in workflows], expWfTasks)
 
         # same function as in WMBSHelper, otherwise we cannot know which fileset name is
@@ -1348,12 +1378,10 @@ class StepChainTests(EmulatedUnitTestCase):
         expFsets.append(topFilesetName)
         # returns a tuple of id, name, open and last_update
         filesets = self.listFilesets.execute()
-        print("List of filesets:\n%s" % pformat([item[1] for item in filesets]))
         self.assertItemsEqual([item[1] for item in filesets], expFsets)
 
         subMaps.append((11, topFilesetName, '/TestWorkload/GENSIM', 'EventBased', 'Production'))
         subscriptions = self.listSubsMapping.execute(workflow="TestWorkload", returnTuple=True)
-        print("List of subscriptions:\n%s" % pformat(subscriptions))
         self.assertItemsEqual(subscriptions, subMaps)
 
     def testInputDataFilesets(self):
@@ -1378,15 +1406,16 @@ class StepChainTests(EmulatedUnitTestCase):
         expFsets = [
             'TestWorkload-StepOne-/BprimeJetToBZ_M800GeV_Tune4C_13TeV-madgraph-tauola/Fall13-POSTLS162_V1-v1/GEN-SIM#block1',
             '/TestWorkload/StepOne/StepOneMergeRAWSIMoutput/merged-logArchive',
-            '/TestWorkload/StepOne/StepOneMergeRAWSIMoutput/merged-Merged',
+            '/TestWorkload/StepOne/StepOneMergeRAWSIMoutput/merged-MergedGEN-SIM',
             '/TestWorkload/StepOne/StepThreeMergeAODSIMoutput/merged-logArchive',
-            '/TestWorkload/StepOne/StepThreeMergeAODSIMoutput/merged-Merged',
-            '/TestWorkload/StepOne/unmerged-AODSIMoutput',
-            '/TestWorkload/StepOne/unmerged-RAWSIMoutput',
+            '/TestWorkload/StepOne/StepThreeMergeAODSIMoutput/merged-MergedAODSIM',
+            '/TestWorkload/StepOne/unmerged-AODSIMoutputAODSIM',
+            '/TestWorkload/StepOne/unmerged-RAWSIMoutputGEN-SIM',
+            '/TestWorkload/StepOne/unmerged-RAWSIMoutputGEN-SIM-RAW',
             '/TestWorkload/StepOne/StepThreeMergeRECOSIMoutput/merged-logArchive',
-            '/TestWorkload/StepOne/StepThreeMergeRECOSIMoutput/merged-Merged',
+            '/TestWorkload/StepOne/StepThreeMergeRECOSIMoutput/merged-MergedGEN-SIM-RECO',
             '/TestWorkload/StepOne/unmerged-logArchive',
-            '/TestWorkload/StepOne/unmerged-RECOSIMoutput']
+            '/TestWorkload/StepOne/unmerged-RECOSIMoutputGEN-SIM-RECO']
         subMaps = [(3,
                     '/TestWorkload/StepOne/StepOneMergeRAWSIMoutput/merged-logArchive',
                     '/TestWorkload/StepOne/StepOneMergeRAWSIMoutput/StepOneRAWSIMoutputMergeLogCollect',
@@ -1403,32 +1432,32 @@ class StepChainTests(EmulatedUnitTestCase):
                     'MinFileBased',
                     'LogCollect'),
                    (7,
-                    '/TestWorkload/StepOne/unmerged-AODSIMoutput',
+                    '/TestWorkload/StepOne/unmerged-AODSIMoutputAODSIM',
                     '/TestWorkload/StepOne/StepThreeCleanupUnmergedAODSIMoutput',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (5,
-                    '/TestWorkload/StepOne/unmerged-AODSIMoutput',
+                    '/TestWorkload/StepOne/unmerged-AODSIMoutputAODSIM',
                     '/TestWorkload/StepOne/StepThreeMergeAODSIMoutput',
                     'ParentlessMergeBySize',
                     'Merge'),
                    (4,
-                    '/TestWorkload/StepOne/unmerged-RAWSIMoutput',
+                    '/TestWorkload/StepOne/unmerged-RAWSIMoutputGEN-SIM',
                     '/TestWorkload/StepOne/StepOneCleanupUnmergedRAWSIMoutput',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (2,
-                    '/TestWorkload/StepOne/unmerged-RAWSIMoutput',
+                    '/TestWorkload/StepOne/unmerged-RAWSIMoutputGEN-SIM',
                     '/TestWorkload/StepOne/StepOneMergeRAWSIMoutput',
                     'ParentlessMergeBySize',
                     'Merge'),
                    (10,
-                    '/TestWorkload/StepOne/unmerged-RECOSIMoutput',
+                    '/TestWorkload/StepOne/unmerged-RECOSIMoutputGEN-SIM-RECO',
                     '/TestWorkload/StepOne/StepThreeCleanupUnmergedRECOSIMoutput',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (8,
-                    '/TestWorkload/StepOne/unmerged-RECOSIMoutput',
+                    '/TestWorkload/StepOne/unmerged-RECOSIMoutputGEN-SIM-RECO',
                     '/TestWorkload/StepOne/StepThreeMergeRECOSIMoutput',
                     'ParentlessMergeBySize',
                     'Merge'),
@@ -1454,20 +1483,16 @@ class StepChainTests(EmulatedUnitTestCase):
         testWMBSHelper.createTopLevelFileset()
         testWMBSHelper._createSubscriptionsInWMBS(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
 
-        print("Tasks producing output:\n%s" % pformat(testWorkload.listOutputProducingTasks()))
         self.assertItemsEqual(testWorkload.listOutputProducingTasks(), expOutTasks)
 
         workflows = self.listTasksByWorkflow.execute(workflow="TestWorkload")
-        print("List of workflow tasks:\n%s" % pformat([item['task'] for item in workflows]))
         self.assertItemsEqual([item['task'] for item in workflows], expWfTasks)
 
         # returns a tuple of id, name, open and last_update
         filesets = self.listFilesets.execute()
-        print("List of filesets:\n%s" % pformat([item[1] for item in filesets]))
         self.assertItemsEqual([item[1] for item in filesets], expFsets)
 
         subscriptions = self.listSubsMapping.execute(workflow="TestWorkload", returnTuple=True)
-        print("List of subscriptions:\n%s" % pformat(subscriptions))
         self.assertItemsEqual(subscriptions, subMaps)
 
         ### create another top level subscription
@@ -1478,19 +1503,16 @@ class StepChainTests(EmulatedUnitTestCase):
         testWMBSHelper._createSubscriptionsInWMBS(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
 
         workflows = self.listTasksByWorkflow.execute(workflow="TestWorkload")
-        print("List of workflow tasks:\n%s" % pformat([item['task'] for item in workflows]))
         self.assertItemsEqual([item['task'] for item in workflows], expWfTasks)
 
         # returns a tuple of id, name, open and last_update
         topFilesetName = 'TestWorkload-StepOne-/BprimeJetToBZ_M800GeV_Tune4C_13TeV-madgraph-tauola/Fall13-POSTLS162_V1-v1/GEN-SIM#block2'
         expFsets.append(topFilesetName)
         filesets = self.listFilesets.execute()
-        print("List of filesets:\n%s" % pformat([item[1] for item in filesets]))
         self.assertItemsEqual([item[1] for item in filesets], expFsets)
 
         subMaps.append((11, topFilesetName, '/TestWorkload/StepOne', 'EventAwareLumiBased', 'Processing'))
         subscriptions = self.listSubsMapping.execute(workflow="TestWorkload", returnTuple=True)
-        print("List of subscriptions:\n%s" % pformat(subscriptions))
         self.assertItemsEqual(subscriptions, subMaps)
 
     def testDupOutputModule(self):
@@ -1608,11 +1630,9 @@ class StepChainTests(EmulatedUnitTestCase):
         testWMBSHelper.createTopLevelFileset()
         testWMBSHelper._createSubscriptionsInWMBS(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
 
-        print("Tasks producing output:\n%s" % pformat(testWorkload.listOutputProducingTasks()))
         self.assertItemsEqual(testWorkload.listOutputProducingTasks(), expOutTasks)
 
         workflows = self.listTasksByWorkflow.execute(workflow="TestWorkload")
-        print("List of workflow tasks:\n%s" % pformat([item['task'] for item in workflows]))
         self.assertItemsEqual([item['task'] for item in workflows], expWfTasks)
 
         # same function as in WMBSHelper, otherwise we cannot know which fileset name is
@@ -1621,12 +1641,10 @@ class StepChainTests(EmulatedUnitTestCase):
         expFsets[0] = topFilesetName
         # returns a tuple of id, name, open and last_update
         filesets = self.listFilesets.execute()
-        print("List of filesets:\n%s" % pformat([item[1] for item in filesets]))
         self.assertItemsEqual([item[1] for item in filesets], expFsets)
 
         subMaps[0] = (1, topFilesetName, '/TestWorkload/GENSIM', 'EventBased', 'Production')
         subscriptions = self.listSubsMapping.execute(workflow="TestWorkload", returnTuple=True)
-        print("List of subscriptions:\n%s" % pformat(subscriptions))
         self.assertItemsEqual(subscriptions, subMaps)
 
         ### create another top level subscription
@@ -1637,7 +1655,6 @@ class StepChainTests(EmulatedUnitTestCase):
         testWMBSHelper._createSubscriptionsInWMBS(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
 
         workflows = self.listTasksByWorkflow.execute(workflow="TestWorkload")
-        print("List of workflow tasks:\n%s" % pformat([item['task'] for item in workflows]))
         self.assertItemsEqual([item['task'] for item in workflows], expWfTasks)
 
         # same function as in WMBSHelper, otherwise we cannot know which fileset name is
@@ -1646,12 +1663,10 @@ class StepChainTests(EmulatedUnitTestCase):
         expFsets.append(topFilesetName)
         # returns a tuple of id, name, open and last_update
         filesets = self.listFilesets.execute()
-        print("List of filesets:\n%s" % pformat([item[1] for item in filesets]))
         self.assertItemsEqual([item[1] for item in filesets], expFsets)
 
         subMaps.append((14, topFilesetName, '/TestWorkload/GENSIM', 'EventBased', 'Production'))
         subscriptions = self.listSubsMapping.execute(workflow="TestWorkload", returnTuple=True)
-        print("List of subscriptions:\n%s" % pformat(subscriptions))
         self.assertItemsEqual(subscriptions, subMaps)
 
 

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StoreResults_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StoreResults_t.py
@@ -8,7 +8,6 @@ from __future__ import print_function
 
 import threading
 import unittest
-from pprint import pformat
 
 from WMCore.DAOFactory import DAOFactory
 from WMCore.WMBS.Fileset import Fileset
@@ -76,18 +75,18 @@ class StoreResultsTest(unittest.TestCase):
 
         self.assertEqual(len(testWorkflow.outputMap.keys()), 2,
                          "Error: Wrong number of WF outputs.")
-
-        goldenOutputMods = ["Merged"]
-        for goldenOutputMod in goldenOutputMods:
-            mergedOutput = testWorkflow.outputMap[goldenOutputMod][0]["merged_output_fileset"]
-            unmergedOutput = testWorkflow.outputMap[goldenOutputMod][0]["output_fileset"]
+        goldenOutputMods = {"Merged": "USER"}
+        for goldenOutputMod, tier in goldenOutputMods.items():
+            fset = goldenOutputMod + tier
+            mergedOutput = testWorkflow.outputMap[fset][0]["merged_output_fileset"]
+            unmergedOutput = testWorkflow.outputMap[fset][0]["output_fileset"]
 
             mergedOutput.loadData()
             unmergedOutput.loadData()
 
-            self.assertEqual(mergedOutput.name, "/TestWorkload/StoreResults/merged-%s" % goldenOutputMod,
+            self.assertEqual(mergedOutput.name, "/TestWorkload/StoreResults/merged-%s" % fset,
                              "Error: Merged output fileset is wrong: %s" % mergedOutput.name)
-            self.assertEqual(unmergedOutput.name, "/TestWorkload/StoreResults/merged-%s" % goldenOutputMod,
+            self.assertEqual(unmergedOutput.name, "/TestWorkload/StoreResults/merged-%s" % fset,
                              "Error: Unmerged output fileset is wrong: %s." % unmergedOutput.name)
 
         logArchOutput = testWorkflow.outputMap["logArchive"][0]["merged_output_fileset"]
@@ -122,7 +121,7 @@ class StoreResultsTest(unittest.TestCase):
         expWfTasks = ['/TestWorkload/StoreResults',
                       '/TestWorkload/StoreResults/StoreResultsLogCollect']
         expFsets = ['TestWorkload-StoreResults-/MinimumBias/ComissioningHI-v1/RAW',
-                    '/TestWorkload/StoreResults/merged-Merged',
+                    '/TestWorkload/StoreResults/merged-MergedUSER',
                     '/TestWorkload/StoreResults/merged-logArchive']
         subMaps = [(2,
                     '/TestWorkload/StoreResults/merged-logArchive',
@@ -146,20 +145,16 @@ class StoreResultsTest(unittest.TestCase):
         testWMBSHelper.createTopLevelFileset()
         testWMBSHelper._createSubscriptionsInWMBS(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
 
-        print("Tasks producing output:\n%s" % pformat(testWorkload.listOutputProducingTasks()))
         self.assertItemsEqual(testWorkload.listOutputProducingTasks(), expOutTasks)
 
         workflows = self.listTasksByWorkflow.execute(workflow="TestWorkload")
-        print("List of workflow tasks:\n%s" % pformat([item['task'] for item in workflows]))
         self.assertItemsEqual([item['task'] for item in workflows], expWfTasks)
 
         # returns a tuple of id, name, open and last_update
         filesets = self.listFilesets.execute()
-        print("List of filesets:\n%s" % pformat([item[1] for item in filesets]))
         self.assertItemsEqual([item[1] for item in filesets], expFsets)
 
         subscriptions = self.listSubsMapping.execute(workflow="TestWorkload", returnTuple=True)
-        print("List of subscriptions:\n%s" % pformat(subscriptions))
         self.assertItemsEqual(subscriptions, subMaps)
 
 

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
@@ -14,13 +14,10 @@ import threading
 import unittest
 from copy import deepcopy
 from hashlib import md5
-from pprint import pformat
 
 from WMCore.DAOFactory import DAOFactory
 from WMCore.DataStructs.Mask import Mask
 from WMCore.Database.CMSCouch import CouchServer, Document
-from WMCore.WMBS.Fileset import Fileset
-from WMCore.WMBS.Subscription import Subscription
 from WMCore.WMBS.Workflow import Workflow
 from WMCore.WMSpec.StdSpecs.TaskChain import TaskChainWorkloadFactory
 from WMCore.WMSpec.WMSpecErrors import WMSpecFactoryException
@@ -312,10 +309,9 @@ def outputModuleList(task):
     util to return list of output module names
 
     """
-    result = []
+    result = {}
     for om in task.getOutputModulesForTask():
-        mods = om.listSections_()
-        result.extend([str(x) for x in mods])
+        result.update(om.dictionary_whole_tree_())
     return result
 
 
@@ -534,7 +530,6 @@ class TaskChainTests(EmulatedUnitTestCase):
         testArguments = TaskChainWorkloadFactory.getTestArguments()
         testArguments.update(self.getGeneratorRequest())
         arguments = testArguments
-        print(pformat(testArguments))
         factory = TaskChainWorkloadFactory()
         # Test a malformed task chain definition
         arguments['Task4']['TransientOutputModules'].append('writeAOD')
@@ -570,7 +565,6 @@ class TaskChainTests(EmulatedUnitTestCase):
 
         # Verify the output datasets
         outputDatasets = testWorkload.listOutputDatasets()
-        print(pformat(outputDatasets))
         self.assertEqual(len(outputDatasets), 6, "Number of output datasets doesn't match")
         self.assertTrue("/RelValTTBar/ReleaseValidation-GenSimFilter-FAKE-v1/GEN-SIM" in outputDatasets)
         self.assertFalse("/RelValTTBar/ReleaseValidation-reco-FAKE-v1/RECO" in outputDatasets)
@@ -612,24 +606,27 @@ class TaskChainTests(EmulatedUnitTestCase):
         workflow.load()
 
         outputMods = outputModuleList(task)
-        ignoredOutputMods = task.getIgnoredOutputModulesForTask()
-        outputMods = set(outputMods) - set(ignoredOutputMods)
+        for ignoreMod in task.getIgnoredOutputModulesForTask():
+            outputMods.pop(ignoreMod, None)
+
         self.assertEqual(len(workflow.outputMap.keys()), len(outputMods),
                          "Error: Wrong number of WF outputs")
 
-        for outputModule in outputMods:
-            filesets = workflow.outputMap[outputModule][0]
+        for outputModule, value in outputMods.items():
+            tier = value.get('dataTier', '')
+            fset = outputModule + tier
+            filesets = workflow.outputMap[fset][0]
             merged = filesets['merged_output_fileset']
             unmerged = filesets['output_fileset']
 
             merged.loadData()
             unmerged.loadData()
 
-            mergedset = task.getPathName() + "/" + task.name() + "Merge" + outputModule + "/merged-Merged"
+            mergedset = task.getPathName() + "/" + task.name() + "Merge" + outputModule + "/merged-Merged" + tier
             if outputModule == "logArchive" or not taskConf.get("KeepOutput", True) or outputModule in taskConf.get(
                     "TransientOutputModules", []) or outputModule in centralConf.get("IgnoredOutputModules", []):
-                mergedset = task.getPathName() + "/unmerged-" + outputModule
-            unmergedset = task.getPathName() + "/unmerged-" + outputModule
+                mergedset = task.getPathName() + "/unmerged-" + outputModule + tier
+            unmergedset = task.getPathName() + "/unmerged-" + outputModule + tier
 
             self.assertEqual(mergedset, merged.name, "Merged fileset name is wrong")
             self.assertEqual(unmergedset, unmerged.name, "Unmerged fileset name  is wrong")
@@ -642,9 +639,9 @@ class TaskChainTests(EmulatedUnitTestCase):
                 mergeWorkflow = Workflow(name=workload.name(),
                                          task=mergeTask)
                 mergeWorkflow.load()
-                self.assertTrue("Merged" in mergeWorkflow.outputMap,
+                self.assertTrue("Merged%s" % tier in mergeWorkflow.outputMap,
                                 "Merge workflow does not contain a Merged output key")
-                mergedOutputMod = mergeWorkflow.outputMap['Merged'][0]
+                mergedOutputMod = mergeWorkflow.outputMap['Merged%s' % tier][0]
                 mergedFileset = mergedOutputMod['merged_output_fileset']
                 unmergedFileset = mergedOutputMod['output_fileset']
                 mergedFileset.loadData()
@@ -678,36 +675,6 @@ class TaskChainTests(EmulatedUnitTestCase):
                     self.assertEqual("%s-%s-v%s" % (taskConf["AcquisitionEra"], taskConf["ProcessingString"],
                                                     taskConf["ProcessingVersion"]),
                                      "Wrong processed dataset for module")
-
-        # Test subscriptions
-        if taskConf.get("InputTask") is None:
-            inputFileset = "%s-%s-SomeBlock" % (workload.name(), task.name())
-        elif "Merge" in task.getPathName().split("/")[-2]:
-            inpTaskPath = task.getPathName().replace(task.name(), "")
-            inputFileset = inpTaskPath + "merged-Merged"
-        else:
-            inpTaskPath = task.getPathName().replace(task.name(), "")
-            inputFileset = inpTaskPath + "unmerged-%s" % taskConf["InputFromOutputModule"]
-        taskFileset = Fileset(name=inputFileset)
-        taskFileset.loadData()
-
-        taskSubscription = Subscription(fileset=taskFileset, workflow=workflow)
-        taskSubscription.loadData()
-
-        if taskConf.get("InputTask") is None and taskConf.get("InputDataset") is None:
-            # Production type
-            self.assertEqual(taskSubscription["type"], "Production",
-                             "Error: Wrong subscription type for processing task")
-            self.assertEqual(taskSubscription["split_algo"], taskConf["SplittingAlgo"],
-                             "Error: Wrong split algo for generation task")
-        else:
-            # Processing type
-            self.assertEqual(taskSubscription["type"], "Processing", "Wrong subscription type for task")
-            if taskSubscription["split_algo"] != "WMBSMergeBySize":
-                self.assertEqual(taskSubscription["split_algo"], taskConf['SplittingAlgo'], "Splitting algo mismatch")
-            else:
-                self.assertEqual(taskFileset.name, inpTaskPath + "unmerged-%s" % taskConf["InputFromOutputModule"],
-                                 "Subscription uses WMBSMergeBySize on a merge fileset")
 
         return
 
@@ -1666,12 +1633,12 @@ class TaskChainTests(EmulatedUnitTestCase):
                       '/TestWorkload/GenSim/LogCollectForGenSim']
         expFsets = ['FILESET_DEFINED_DURING_RUNTIME',
                     '/TestWorkload/GenSim/GenSimMergewriteGENSIM/DigiHLT_new/unmerged-logArchive',
-                    '/TestWorkload/GenSim/GenSimMergewriteGENSIM/DigiHLT_new/unmerged-writeRAWDIGI',
+                    '/TestWorkload/GenSim/GenSimMergewriteGENSIM/DigiHLT_new/unmerged-writeRAWDIGIRAW-DIGI',
                     '/TestWorkload/GenSim/GenSimMergewriteGENSIM/DigiHLT_ref/DigiHLT_refMergewriteRAWDIGI/merged-logArchive',
-                    '/TestWorkload/GenSim/GenSimMergewriteGENSIM/DigiHLT_ref/DigiHLT_refMergewriteRAWDIGI/merged-Merged',
-                    '/TestWorkload/GenSim/GenSimMergewriteGENSIM/DigiHLT_ref/unmerged-writeRAWDIGI',
-                    '/TestWorkload/GenSim/GenSimMergewriteGENSIM/merged-Merged',
-                    '/TestWorkload/GenSim/unmerged-writeGENSIM',
+                    '/TestWorkload/GenSim/GenSimMergewriteGENSIM/DigiHLT_ref/DigiHLT_refMergewriteRAWDIGI/merged-MergedRAW-DIGI',
+                    '/TestWorkload/GenSim/GenSimMergewriteGENSIM/DigiHLT_ref/unmerged-writeRAWDIGIRAW-DIGI',
+                    '/TestWorkload/GenSim/GenSimMergewriteGENSIM/merged-MergedGEN-SIM',
+                    '/TestWorkload/GenSim/unmerged-writeGENSIMGEN-SIM',
                     '/TestWorkload/GenSim/GenSimMergewriteGENSIM/DigiHLT_ref/unmerged-logArchive',
                     '/TestWorkload/GenSim/GenSimMergewriteGENSIM/merged-logArchive',
                     '/TestWorkload/GenSim/unmerged-logArchive']
@@ -1682,7 +1649,7 @@ class TaskChainTests(EmulatedUnitTestCase):
                     'MinFileBased',
                     'LogCollect'),
                    (4,
-                    '/TestWorkload/GenSim/GenSimMergewriteGENSIM/DigiHLT_new/unmerged-writeRAWDIGI',
+                    '/TestWorkload/GenSim/GenSimMergewriteGENSIM/DigiHLT_new/unmerged-writeRAWDIGIRAW-DIGI',
                     '/TestWorkload/GenSim/GenSimMergewriteGENSIM/DigiHLT_new/DigiHLT_newCleanupUnmergedwriteRAWDIGI',
                     'SiblingProcessingBased',
                     'Cleanup'),
@@ -1697,12 +1664,12 @@ class TaskChainTests(EmulatedUnitTestCase):
                     'MinFileBased',
                     'LogCollect'),
                    (9,
-                    '/TestWorkload/GenSim/GenSimMergewriteGENSIM/DigiHLT_ref/unmerged-writeRAWDIGI',
+                    '/TestWorkload/GenSim/GenSimMergewriteGENSIM/DigiHLT_ref/unmerged-writeRAWDIGIRAW-DIGI',
                     '/TestWorkload/GenSim/GenSimMergewriteGENSIM/DigiHLT_ref/DigiHLT_refCleanupUnmergedwriteRAWDIGI',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (7,
-                    '/TestWorkload/GenSim/GenSimMergewriteGENSIM/DigiHLT_ref/unmerged-writeRAWDIGI',
+                    '/TestWorkload/GenSim/GenSimMergewriteGENSIM/DigiHLT_ref/unmerged-writeRAWDIGIRAW-DIGI',
                     '/TestWorkload/GenSim/GenSimMergewriteGENSIM/DigiHLT_ref/DigiHLT_refMergewriteRAWDIGI',
                     'WMBSMergeBySize',
                     'Merge'),
@@ -1712,12 +1679,12 @@ class TaskChainTests(EmulatedUnitTestCase):
                     'MinFileBased',
                     'LogCollect'),
                    (3,
-                    '/TestWorkload/GenSim/GenSimMergewriteGENSIM/merged-Merged',
+                    '/TestWorkload/GenSim/GenSimMergewriteGENSIM/merged-MergedGEN-SIM',
                     '/TestWorkload/GenSim/GenSimMergewriteGENSIM/DigiHLT_new',
                     'LumiBased',
                     'Processing'),
                    (6,
-                    '/TestWorkload/GenSim/GenSimMergewriteGENSIM/merged-Merged',
+                    '/TestWorkload/GenSim/GenSimMergewriteGENSIM/merged-MergedGEN-SIM',
                     '/TestWorkload/GenSim/GenSimMergewriteGENSIM/DigiHLT_ref',
                     'EventBased',
                     'Processing'),
@@ -1727,12 +1694,12 @@ class TaskChainTests(EmulatedUnitTestCase):
                     'MinFileBased',
                     'LogCollect'),
                    (12,
-                    '/TestWorkload/GenSim/unmerged-writeGENSIM',
+                    '/TestWorkload/GenSim/unmerged-writeGENSIMGEN-SIM',
                     '/TestWorkload/GenSim/GenSimCleanupUnmergedwriteGENSIM',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (2,
-                    '/TestWorkload/GenSim/unmerged-writeGENSIM',
+                    '/TestWorkload/GenSim/unmerged-writeGENSIMGEN-SIM',
                     '/TestWorkload/GenSim/GenSimMergewriteGENSIM',
                     'ParentlessMergeBySize',
                     'Merge')]
@@ -1753,11 +1720,9 @@ class TaskChainTests(EmulatedUnitTestCase):
         testWMBSHelper.createTopLevelFileset()
         testWMBSHelper._createSubscriptionsInWMBS(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
 
-        print("Tasks producing output:\n%s" % pformat(testWorkload.listOutputProducingTasks()))
         self.assertItemsEqual(testWorkload.listOutputProducingTasks(), expOutTasks)
 
         workflows = self.listTasksByWorkflow.execute(workflow="TestWorkload")
-        print("List of workflow tasks:\n%s" % pformat([item['task'] for item in workflows]))
         self.assertItemsEqual([item['task'] for item in workflows], expWfTasks)
 
         # same function as in WMBSHelper, otherwise we cannot know which fileset name is
@@ -1766,12 +1731,10 @@ class TaskChainTests(EmulatedUnitTestCase):
         expFsets[0] = topFilesetName
         # returns a tuple of id, name, open and last_update
         filesets = self.listFilesets.execute()
-        print("List of filesets:\n%s" % pformat([item[1] for item in filesets]))
         self.assertItemsEqual([item[1] for item in filesets], expFsets)
 
         subMaps[0] = (1, topFilesetName, '/TestWorkload/GenSim', 'EventBased', 'Production')
         subscriptions = self.listSubsMapping.execute(workflow="TestWorkload", returnTuple=True)
-        print("List of subscriptions:\n%s" % pformat(subscriptions))
         self.assertItemsEqual(subscriptions, subMaps)
 
         ### create another top level subscription
@@ -1782,7 +1745,6 @@ class TaskChainTests(EmulatedUnitTestCase):
         testWMBSHelper._createSubscriptionsInWMBS(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
 
         workflows = self.listTasksByWorkflow.execute(workflow="TestWorkload")
-        print("List of workflow tasks:\n%s" % pformat([item['task'] for item in workflows]))
         self.assertItemsEqual([item['task'] for item in workflows], expWfTasks)
 
         # same function as in WMBSHelper, otherwise we cannot know which fileset name is
@@ -1791,12 +1753,10 @@ class TaskChainTests(EmulatedUnitTestCase):
         expFsets.append(topFilesetName)
         # returns a tuple of id, name, open and last_update
         filesets = self.listFilesets.execute()
-        print("List of filesets:\n%s" % pformat([item[1] for item in filesets]))
         self.assertItemsEqual([item[1] for item in filesets], expFsets)
 
         subMaps.append((14, topFilesetName, '/TestWorkload/GenSim', 'EventBased', 'Production'))
         subscriptions = self.listSubsMapping.execute(workflow="TestWorkload", returnTuple=True)
-        print("List of subscriptions:\n%s" % pformat(subscriptions))
         self.assertItemsEqual(subscriptions, subMaps)
 
     def testInputDataFilesets(self):
@@ -1854,37 +1814,37 @@ class TaskChainTests(EmulatedUnitTestCase):
                       '/TestWorkload/DigiHLT/LogCollectForDigiHLT']
         expFsets = [
             'TestWorkload-DigiHLT-/BprimeJetToBZ_M800GeV_Tune4C_13TeV-madgraph-tauola/Fall13-POSTLS162_V1-v1/GEN-SIM#block1',
-            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/merged-Merged',
-            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/unmerged-writeRECO',
-            '/TestWorkload/DigiHLT/unmerged-writeRAWDIGI',
-            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/merged-Merged',
+            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/merged-MergedRAW-DIGI',
+            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/unmerged-writeRECORECO',
+            '/TestWorkload/DigiHLT/unmerged-writeRAWDIGIRAW-DIGI',
+            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/merged-MergedRECO',
             '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/Skims/SkimsMergewriteSkim1/merged-logArchive',
-            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/Skims/SkimsMergewriteSkim1/merged-Merged',
+            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/Skims/SkimsMergewriteSkim1/merged-MergedRECO-AOD',
             '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/Skims/SkimsMergewriteSkim2/merged-logArchive',
-            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/Skims/SkimsMergewriteSkim2/merged-Merged',
-            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/Skims/unmerged-writeSkim1',
-            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/Skims/unmerged-writeSkim2',
-            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/ALCAReco/ALCARecoMergewriteALCA1/merged-Merged',
-            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/ALCAReco/unmerged-writeALCA1',
-            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/merged-Merged',
+            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/Skims/SkimsMergewriteSkim2/merged-MergedRECO-AOD',
+            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/Skims/unmerged-writeSkim1RECO-AOD',
+            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/Skims/unmerged-writeSkim2RECO-AOD',
+            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/ALCAReco/ALCARecoMergewriteALCA1/merged-MergedALCARECO',
+            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/ALCAReco/unmerged-writeALCA1ALCARECO',
+            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/merged-MergedALCARECO',
             '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/merged-logArchive',
             '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/Skims/unmerged-logArchive',
-            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/unmerged-writeALCA',
+            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/unmerged-writeALCAALCARECO',
             '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/ALCAReco/ALCARecoMergewriteALCA1/merged-logArchive',
             '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/ALCAReco/ALCARecoMergewriteALCA2/merged-logArchive',
-            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/ALCAReco/ALCARecoMergewriteALCA2/merged-Merged',
+            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/ALCAReco/ALCARecoMergewriteALCA2/merged-MergedALCARECO',
             '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/ALCAReco/unmerged-logArchive',
-            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/ALCAReco/unmerged-writeALCA2',
+            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/ALCAReco/unmerged-writeALCA2ALCARECO',
             '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/merged-logArchive',
             '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/merged-logArchive',
             '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteAOD/merged-logArchive',
-            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteAOD/merged-Merged',
+            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteAOD/merged-MergedAOD',
             '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/unmerged-logArchive',
-            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/unmerged-writeAOD',
+            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/unmerged-writeAODAOD',
             '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDEBUGDIGI/merged-logArchive',
-            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDEBUGDIGI/merged-Merged',
+            '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDEBUGDIGI/merged-MergedRAW-DEBUG-DIGI',
             '/TestWorkload/DigiHLT/unmerged-logArchive',
-            '/TestWorkload/DigiHLT/unmerged-writeRAWDEBUGDIGI']
+            '/TestWorkload/DigiHLT/unmerged-writeRAWDEBUGDIGIRAW-DEBUG-DIGI']
         subMaps = [(33,
                     '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDEBUGDIGI/merged-logArchive',
                     '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDEBUGDIGI/DigiHLTwriteRAWDEBUGDIGIMergeLogCollect',
@@ -1896,7 +1856,7 @@ class TaskChainTests(EmulatedUnitTestCase):
                     'MinFileBased',
                     'LogCollect'),
                    (3,
-                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/merged-Merged',
+                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/merged-MergedRAW-DIGI',
                     '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco',
                     'EventAwareLumiBased',
                     'Processing'),
@@ -1916,22 +1876,22 @@ class TaskChainTests(EmulatedUnitTestCase):
                     'MinFileBased',
                     'LogCollect'),
                    (19,
-                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/ALCAReco/unmerged-writeALCA1',
+                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/ALCAReco/unmerged-writeALCA1ALCARECO',
                     '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/ALCAReco/ALCARecoCleanupUnmergedwriteALCA1',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (17,
-                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/ALCAReco/unmerged-writeALCA1',
+                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/ALCAReco/unmerged-writeALCA1ALCARECO',
                     '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/ALCAReco/ALCARecoMergewriteALCA1',
                     'ParentlessMergeBySize',
                     'Merge'),
                    (22,
-                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/ALCAReco/unmerged-writeALCA2',
+                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/ALCAReco/unmerged-writeALCA2ALCARECO',
                     '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/ALCAReco/ALCARecoCleanupUnmergedwriteALCA2',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (20,
-                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/ALCAReco/unmerged-writeALCA2',
+                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/ALCAReco/unmerged-writeALCA2ALCARECO',
                     '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/ALCAReco/ALCARecoMergewriteALCA2',
                     'ParentlessMergeBySize',
                     'Merge'),
@@ -1941,7 +1901,7 @@ class TaskChainTests(EmulatedUnitTestCase):
                     'MinFileBased',
                     'LogCollect'),
                    (16,
-                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/merged-Merged',
+                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/merged-MergedALCARECO',
                     '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA/ALCAReco',
                     'EventAwareLumiBased',
                     'Processing'),
@@ -1956,7 +1916,7 @@ class TaskChainTests(EmulatedUnitTestCase):
                     'MinFileBased',
                     'LogCollect'),
                    (5,
-                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/merged-Merged',
+                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/merged-MergedRECO',
                     '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/Skims',
                     'EventAwareLumiBased',
                     'Processing'),
@@ -1976,22 +1936,22 @@ class TaskChainTests(EmulatedUnitTestCase):
                     'MinFileBased',
                     'LogCollect'),
                    (8,
-                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/Skims/unmerged-writeSkim1',
+                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/Skims/unmerged-writeSkim1RECO-AOD',
                     '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/Skims/SkimsCleanupUnmergedwriteSkim1',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (6,
-                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/Skims/unmerged-writeSkim1',
+                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/Skims/unmerged-writeSkim1RECO-AOD',
                     '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/Skims/SkimsMergewriteSkim1',
                     'ParentlessMergeBySize',
                     'Merge'),
                    (11,
-                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/Skims/unmerged-writeSkim2',
+                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/Skims/unmerged-writeSkim2RECO-AOD',
                     '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/Skims/SkimsCleanupUnmergedwriteSkim2',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (9,
-                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/Skims/unmerged-writeSkim2',
+                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/Skims/unmerged-writeSkim2RECO-AOD',
                     '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO/Skims/SkimsMergewriteSkim2',
                     'ParentlessMergeBySize',
                     'Merge'),
@@ -2001,32 +1961,32 @@ class TaskChainTests(EmulatedUnitTestCase):
                     'MinFileBased',
                     'LogCollect'),
                    (25,
-                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/unmerged-writeALCA',
+                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/unmerged-writeALCAALCARECO',
                     '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoCleanupUnmergedwriteALCA',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (15,
-                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/unmerged-writeALCA',
+                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/unmerged-writeALCAALCARECO',
                     '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteALCA',
                     'ParentlessMergeBySize',
                     'Merge'),
                    (28,
-                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/unmerged-writeAOD',
+                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/unmerged-writeAODAOD',
                     '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoCleanupUnmergedwriteAOD',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (26,
-                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/unmerged-writeAOD',
+                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/unmerged-writeAODAOD',
                     '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteAOD',
                     'ParentlessMergeBySize',
                     'Merge'),
                    (14,
-                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/unmerged-writeRECO',
+                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/unmerged-writeRECORECO',
                     '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoCleanupUnmergedwriteRECO',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (4,
-                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/unmerged-writeRECO',
+                    '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/unmerged-writeRECORECO',
                     '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI/Reco/RecoMergewriteRECO',
                     'ParentlessMergeBySize',
                     'Merge'),
@@ -2036,22 +1996,22 @@ class TaskChainTests(EmulatedUnitTestCase):
                     'MinFileBased',
                     'LogCollect'),
                    (34,
-                    '/TestWorkload/DigiHLT/unmerged-writeRAWDEBUGDIGI',
+                    '/TestWorkload/DigiHLT/unmerged-writeRAWDEBUGDIGIRAW-DEBUG-DIGI',
                     '/TestWorkload/DigiHLT/DigiHLTCleanupUnmergedwriteRAWDEBUGDIGI',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (32,
-                    '/TestWorkload/DigiHLT/unmerged-writeRAWDEBUGDIGI',
+                    '/TestWorkload/DigiHLT/unmerged-writeRAWDEBUGDIGIRAW-DEBUG-DIGI',
                     '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDEBUGDIGI',
                     'ParentlessMergeBySize',
                     'Merge'),
                    (31,
-                    '/TestWorkload/DigiHLT/unmerged-writeRAWDIGI',
+                    '/TestWorkload/DigiHLT/unmerged-writeRAWDIGIRAW-DIGI',
                     '/TestWorkload/DigiHLT/DigiHLTCleanupUnmergedwriteRAWDIGI',
                     'SiblingProcessingBased',
                     'Cleanup'),
                    (2,
-                    '/TestWorkload/DigiHLT/unmerged-writeRAWDIGI',
+                    '/TestWorkload/DigiHLT/unmerged-writeRAWDIGIRAW-DIGI',
                     '/TestWorkload/DigiHLT/DigiHLTMergewriteRAWDIGI',
                     'ParentlessMergeBySize',
                     'Merge'),
@@ -2077,20 +2037,16 @@ class TaskChainTests(EmulatedUnitTestCase):
         testWMBSHelper.createTopLevelFileset()
         testWMBSHelper._createSubscriptionsInWMBS(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
 
-        print("Tasks producing output:\n%s" % pformat(testWorkload.listOutputProducingTasks()))
         self.assertItemsEqual(testWorkload.listOutputProducingTasks(), expOutTasks)
 
         workflows = self.listTasksByWorkflow.execute(workflow="TestWorkload")
-        print("List of workflow tasks:\n%s" % pformat([item['task'] for item in workflows]))
         self.assertItemsEqual([item['task'] for item in workflows], expWfTasks)
 
         # returns a tuple of id, name, open and last_update
         filesets = self.listFilesets.execute()
-        print("List of filesets:\n%s" % pformat([item[1] for item in filesets]))
         self.assertItemsEqual([item[1] for item in filesets], expFsets)
 
         subscriptions = self.listSubsMapping.execute(workflow="TestWorkload", returnTuple=True)
-        print("List of subscriptions:\n%s" % pformat(subscriptions))
         self.assertItemsEqual(subscriptions, subMaps)
 
         ### create another top level subscription
@@ -2101,19 +2057,16 @@ class TaskChainTests(EmulatedUnitTestCase):
         testWMBSHelper._createSubscriptionsInWMBS(testWMBSHelper.topLevelTask, testWMBSHelper.topLevelFileset)
 
         workflows = self.listTasksByWorkflow.execute(workflow="TestWorkload")
-        print("List of workflow tasks:\n%s" % pformat([item['task'] for item in workflows]))
         self.assertItemsEqual([item['task'] for item in workflows], expWfTasks)
 
         # returns a tuple of id, name, open and last_update
         topFilesetName = 'TestWorkload-DigiHLT-/BprimeJetToBZ_M800GeV_Tune4C_13TeV-madgraph-tauola/Fall13-POSTLS162_V1-v1/GEN-SIM#block2'
         expFsets.append(topFilesetName)
         filesets = self.listFilesets.execute()
-        print("List of filesets:\n%s" % pformat([item[1] for item in filesets]))
         self.assertItemsEqual([item[1] for item in filesets], expFsets)
 
         subMaps.append((36, topFilesetName, '/TestWorkload/DigiHLT', 'EventAwareLumiBased', 'Processing'))
         subscriptions = self.listSubsMapping.execute(workflow="TestWorkload", returnTuple=True)
-        print("List of subscriptions:\n%s" % pformat(subscriptions))
         self.assertItemsEqual(subscriptions, subMaps)
 
 

--- a/test/python/WMCore_t/WorkQueue_t/WMBSHelper_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WMBSHelper_t.py
@@ -432,7 +432,7 @@ class WMBSHelperTest(EmulatedUnitTestCase):
                                             filterName=None)
 
         mergeTask = procTask.addTask("MergeTask")
-        mergeTask.setInputReference(procTaskCMSSW, outputModule="OutputA")
+        mergeTask.setInputReference(procTaskCMSSW, outputModule="OutputA", dataTier='DataTierA')
         mergeTask.setTaskType("Merge")
         mergeTask.setSplittingAlgorithm("WMBSMergeBySize", min_merge_size=1,
                                         max_merge_size=2, max_merge_events=3)
@@ -451,18 +451,17 @@ class WMBSHelperTest(EmulatedUnitTestCase):
                                              filterName=None)
 
         cleanupTask = procTask.addTask("CleanupTask")
-        cleanupTask.setInputReference(procTaskCMSSW, outputModule="OutputA")
+        cleanupTask.setInputReference(procTaskCMSSW, outputModule="OutputA", dataTier="DataTierA")
         cleanupTask.setTaskType("Merge")
         cleanupTask.setSplittingAlgorithm("SiblingProcessingBased", files_per_job=50)
         cleanupTaskCMSSW = cleanupTask.makeStep("cmsRun1")
         cleanupTaskCMSSW.setStepType("CMSSW")
-        dummyCleanupTaskCMSSWHelper = cleanupTaskCMSSW.getTypeHelper()
         cleanupTask.setTaskType("Cleanup")
         cleanupTask.applyTemplates()
 
         skimTask = mergeTask.addTask("SkimTask")
         skimTask.setTaskType("Skim")
-        skimTask.setInputReference(mergeTaskCMSSW, outputModule="Merged")
+        skimTask.setInputReference(mergeTaskCMSSW, outputModule="Merged", dataTier="DataTierA")
         skimTask.setSplittingAlgorithm("FileBased", files_per_job=1, include_parents=True)
         skimTaskCMSSW = skimTask.makeStep("cmsRun1")
         skimTaskCMSSW.setStepType("CMSSW")
@@ -481,7 +480,7 @@ class WMBSHelperTest(EmulatedUnitTestCase):
         skimTaskCMSSWHelper.addOutputModule("SkimOutputB",
                                             primaryDataset="bogusPrimary",
                                             processedDataset="bogusProcessed",
-                                            dataTier="DataTierA",
+                                            dataTier="DataTierB",
                                             lfnBase="bogusUnmerged",
                                             mergedLFNBase="bogusMerged",
                                             filterName=None)
@@ -599,16 +598,14 @@ class WMBSHelperTest(EmulatedUnitTestCase):
                          "Error: Wrong spec URL")
         self.assertEqual(len(procWorkflow.outputMap.keys()), 1,
                          "Error: Wrong number of WF outputs.")
-
-        mergedProcOutput = procWorkflow.outputMap["OutputA"][0]["merged_output_fileset"]
-        unmergedProcOutput = procWorkflow.outputMap["OutputA"][0]["output_fileset"]
+        mergedProcOutput = procWorkflow.outputMap["OutputADataTierA"][0]["merged_output_fileset"]
+        unmergedProcOutput = procWorkflow.outputMap["OutputADataTierA"][0]["output_fileset"]
 
         mergedProcOutput.loadData()
         unmergedProcOutput.loadData()
-
-        self.assertEqual(mergedProcOutput.name, "/TestWorkload/ProcessingTask/MergeTask/merged-Merged",
+        self.assertEqual(mergedProcOutput.name, "/TestWorkload/ProcessingTask/MergeTask/merged-MergedDataTierA",
                          "Error: Merged output fileset is wrong.")
-        self.assertEqual(unmergedProcOutput.name, "/TestWorkload/ProcessingTask/unmerged-OutputA",
+        self.assertEqual(unmergedProcOutput.name, "/TestWorkload/ProcessingTask/unmerged-OutputADataTierA",
                          "Error: Unmerged output fileset is wrong.")
 
         mergeWorkflow = Workflow(name="TestWorkload",
@@ -635,10 +632,10 @@ class WMBSHelperTest(EmulatedUnitTestCase):
         self.assertEqual(len(cleanupWorkflow.outputMap.keys()), 0,
                          "Error: Wrong number of WF outputs.")
 
-        unmergedMergeOutput = mergeWorkflow.outputMap["Merged"][0]["output_fileset"]
+        unmergedMergeOutput = mergeWorkflow.outputMap["MergedDataTierA"][0]["output_fileset"]
         unmergedMergeOutput.loadData()
 
-        self.assertEqual(unmergedMergeOutput.name, "/TestWorkload/ProcessingTask/MergeTask/merged-Merged",
+        self.assertEqual(unmergedMergeOutput.name, "/TestWorkload/ProcessingTask/MergeTask/merged-MergedDataTierA",
                          "Error: Unmerged output fileset is wrong.")
 
         skimWorkflow = Workflow(name="TestWorkload",
@@ -653,25 +650,25 @@ class WMBSHelperTest(EmulatedUnitTestCase):
         self.assertEqual(len(skimWorkflow.outputMap.keys()), 2,
                          "Error: Wrong number of WF outputs.")
 
-        mergedSkimOutputA = skimWorkflow.outputMap["SkimOutputA"][0]["merged_output_fileset"]
-        unmergedSkimOutputA = skimWorkflow.outputMap["SkimOutputA"][0]["output_fileset"]
-        mergedSkimOutputB = skimWorkflow.outputMap["SkimOutputB"][0]["merged_output_fileset"]
-        unmergedSkimOutputB = skimWorkflow.outputMap["SkimOutputB"][0]["output_fileset"]
+        mergedSkimOutputA = skimWorkflow.outputMap["SkimOutputADataTierA"][0]["merged_output_fileset"]
+        unmergedSkimOutputA = skimWorkflow.outputMap["SkimOutputADataTierA"][0]["output_fileset"]
+        mergedSkimOutputB = skimWorkflow.outputMap["SkimOutputBDataTierB"][0]["merged_output_fileset"]
+        unmergedSkimOutputB = skimWorkflow.outputMap["SkimOutputBDataTierB"][0]["output_fileset"]
 
         mergedSkimOutputA.loadData()
         mergedSkimOutputB.loadData()
         unmergedSkimOutputA.loadData()
         unmergedSkimOutputB.loadData()
 
-        self.assertEqual(mergedSkimOutputA.name, "/TestWorkload/ProcessingTask/MergeTask/SkimTask/unmerged-SkimOutputA",
+        self.assertEqual(mergedSkimOutputA.name, "/TestWorkload/ProcessingTask/MergeTask/SkimTask/unmerged-SkimOutputADataTierA",
                          "Error: Merged output fileset is wrong: %s" % mergedSkimOutputA.name)
         self.assertEqual(unmergedSkimOutputA.name,
-                         "/TestWorkload/ProcessingTask/MergeTask/SkimTask/unmerged-SkimOutputA",
+                         "/TestWorkload/ProcessingTask/MergeTask/SkimTask/unmerged-SkimOutputADataTierA",
                          "Error: Unmerged output fileset is wrong.")
-        self.assertEqual(mergedSkimOutputB.name, "/TestWorkload/ProcessingTask/MergeTask/SkimTask/unmerged-SkimOutputB",
+        self.assertEqual(mergedSkimOutputB.name, "/TestWorkload/ProcessingTask/MergeTask/SkimTask/unmerged-SkimOutputBDataTierB",
                          "Error: Merged output fileset is wrong.")
         self.assertEqual(unmergedSkimOutputB.name,
-                         "/TestWorkload/ProcessingTask/MergeTask/SkimTask/unmerged-SkimOutputB",
+                         "/TestWorkload/ProcessingTask/MergeTask/SkimTask/unmerged-SkimOutputBDataTierB",
                          "Error: Unmerged output fileset is wrong.")
 
         topLevelFileset = Fileset(name="TestWorkload-ProcessingTask-SomeBlock")
@@ -753,10 +750,10 @@ class WMBSHelperTest(EmulatedUnitTestCase):
         self.assertEqual(len(mergeWorkflow.outputMap.keys()), 1,
                          "Error: Wrong number of WF outputs.")
 
-        unmergedMergeOutput = mergeWorkflow.outputMap["Merged"][0]["output_fileset"]
+        unmergedMergeOutput = mergeWorkflow.outputMap["MergedDataTierA"][0]["output_fileset"]
         unmergedMergeOutput.loadData()
 
-        self.assertEqual(unmergedMergeOutput.name, "/ResubmitTestWorkload/MergeTask/merged-Merged",
+        self.assertEqual(unmergedMergeOutput.name, "/ResubmitTestWorkload/MergeTask/merged-MergedDataTierA",
                          "Error: Unmerged output fileset is wrong.")
 
         skimWorkflow = Workflow(name="ResubmitTestWorkload",
@@ -771,23 +768,23 @@ class WMBSHelperTest(EmulatedUnitTestCase):
         self.assertEqual(len(skimWorkflow.outputMap.keys()), 2,
                          "Error: Wrong number of WF outputs.")
 
-        mergedSkimOutputA = skimWorkflow.outputMap["SkimOutputA"][0]["merged_output_fileset"]
-        unmergedSkimOutputA = skimWorkflow.outputMap["SkimOutputA"][0]["output_fileset"]
-        mergedSkimOutputB = skimWorkflow.outputMap["SkimOutputB"][0]["merged_output_fileset"]
-        unmergedSkimOutputB = skimWorkflow.outputMap["SkimOutputB"][0]["output_fileset"]
+        mergedSkimOutputA = skimWorkflow.outputMap["SkimOutputADataTierA"][0]["merged_output_fileset"]
+        unmergedSkimOutputA = skimWorkflow.outputMap["SkimOutputADataTierA"][0]["output_fileset"]
+        mergedSkimOutputB = skimWorkflow.outputMap["SkimOutputBDataTierB"][0]["merged_output_fileset"]
+        unmergedSkimOutputB = skimWorkflow.outputMap["SkimOutputBDataTierB"][0]["output_fileset"]
 
         mergedSkimOutputA.loadData()
         mergedSkimOutputB.loadData()
         unmergedSkimOutputA.loadData()
         unmergedSkimOutputB.loadData()
 
-        self.assertEqual(mergedSkimOutputA.name, "/ResubmitTestWorkload/MergeTask/SkimTask/unmerged-SkimOutputA",
+        self.assertEqual(mergedSkimOutputA.name, "/ResubmitTestWorkload/MergeTask/SkimTask/unmerged-SkimOutputADataTierA",
                          "Error: Merged output fileset is wrong: %s" % mergedSkimOutputA.name)
-        self.assertEqual(unmergedSkimOutputA.name, "/ResubmitTestWorkload/MergeTask/SkimTask/unmerged-SkimOutputA",
+        self.assertEqual(unmergedSkimOutputA.name, "/ResubmitTestWorkload/MergeTask/SkimTask/unmerged-SkimOutputADataTierA",
                          "Error: Unmerged output fileset is wrong.")
-        self.assertEqual(mergedSkimOutputB.name, "/ResubmitTestWorkload/MergeTask/SkimTask/unmerged-SkimOutputB",
+        self.assertEqual(mergedSkimOutputB.name, "/ResubmitTestWorkload/MergeTask/SkimTask/unmerged-SkimOutputBDataTierB",
                          "Error: Merged output fileset is wrong.")
-        self.assertEqual(unmergedSkimOutputB.name, "/ResubmitTestWorkload/MergeTask/SkimTask/unmerged-SkimOutputB",
+        self.assertEqual(unmergedSkimOutputB.name, "/ResubmitTestWorkload/MergeTask/SkimTask/unmerged-SkimOutputBDataTierB",
                          "Error: Unmerged output fileset is wrong.")
 
         topLevelFileset = Fileset(name="ResubmitTestWorkload-MergeTask-SomeBlock2")


### PR DESCRIPTION
Superseeds #6835
Fixes #6787 

The idea being that we now use the output module AND the datatier name to define filesets (and workflow output identifiers). Since logArchive and cleanup doesn't have an output datatier, the fileset name remains the same.

There is still one limitation though, again the trident workflow where step2 and step3 read the same input (like output of step1) AND they have exactly the same output module(s) and datatier(s). That's why I added that validation in the StepChain, such that such setup would fail creation. Honestly, I think that will be < 0.01% of the cases, at most. And for such cases, 2 workflows can always be created :-)

Few notes for myself:
* remove all the debugging code 