### PR TITLE
Return the exact exit code from the stage out copy command

### DIFF
--- a/src/python/WMCore/Storage/Backends/AWSS3Impl.py
+++ b/src/python/WMCore/Storage/Backends/AWSS3Impl.py
@@ -48,12 +48,11 @@ class AWSS3Impl(StageOutImpl):
             EXIT_STATUS=$?
             echo "aws s3 cp exit status: $EXIT_STATUS"
             if [[ $EXIT_STATUS != 0 ]]; then
-               echo "Non-zero aws s3 cp Exit status!!!"
+               echo "ERROR: Non-zero aws s3 cp Exit status!!!"
                echo "Cleaning up failed file:"
-                %s
-               exit 60311
+               %s
             fi
-            exit 0
+            exit $EXIT_STATUS
             """ % self.createRemoveFileCommand(targetPFN)
 
         return result

--- a/src/python/WMCore/Storage/Backends/CPImpl.py
+++ b/src/python/WMCore/Storage/Backends/CPImpl.py
@@ -6,10 +6,12 @@ Implementation of StageOutImpl interface for plain cp
 
 """
 from __future__ import print_function
+
 import os
+
+from WMCore.Storage.Execute import runCommandWithOutput
 from WMCore.Storage.Registry import registerStageOutImpl
 from WMCore.Storage.StageOutImpl import StageOutImpl
-from WMCore.Storage.Execute import runCommandWithOutput
 
 
 class CPImpl(StageOutImpl):
@@ -36,9 +38,9 @@ class CPImpl(StageOutImpl):
 
         create dir with group permission
         """
-        targetdir= os.path.dirname(targetPFN)
+        targetdir = os.path.dirname(targetPFN)
         checkdirexitCode = None
-        checkdircmd="/bin/ls %s > /dev/null " % targetdir
+        checkdircmd = "/bin/ls %s > /dev/null " % targetdir
         print("Check dir existence : %s" % checkdircmd)
         try:
             checkdirexitCode, output = self.run(checkdircmd)
@@ -68,8 +70,7 @@ class CPImpl(StageOutImpl):
         else:
             print("=> dir already exists... do nothing.")
 
-
-    def createStageOutCommand(self, sourcePFN, targetPFN, options = None, checksums = None):
+    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
         """
         _createStageOutCommand_
 
@@ -83,10 +84,10 @@ class CPImpl(StageOutImpl):
             result += " %s " % options
         result += " %s " % sourcePFN
         result += " %s " % targetPFN
-        result += "; DEST_SIZE=`/bin/ls -l %s | awk '{print $5}'` ; if [ $DEST_SIZE ] && [ '%s' -eq $DEST_SIZE ]; then exit 0; else echo \"Error: Size Mismatch between local and SE\"; exit 60311 ; fi " % (targetPFN,original_size)
+        result += "; DEST_SIZE=`/bin/ls -l %s | awk '{print $5}'` ; if [ $DEST_SIZE ] && [ '%s' -eq $DEST_SIZE ]; then exit 0; else echo \"Error: Size Mismatch between local and SE\"; exit 60311 ; fi " % (
+        targetPFN, original_size)
         print(result)
         return result
-
 
     def removeFile(self, pfnToRemove):
         """

--- a/src/python/WMCore/Storage/Backends/FNALImpl.py
+++ b/src/python/WMCore/Storage/Backends/FNALImpl.py
@@ -126,7 +126,13 @@ class FNALImpl(StageOutImpl):
                 result += " %s " % options
             result += " %s " % sourcePFN
             result += " %s " % targetPFN
-            result += "; if [ $? -eq 0 ] ; then exit 0; else echo \"Error: xrdcp exited with $?\"; exit 60311 ; fi "
+            result += """
+            EXIT_STATUS=$?
+            if [[ $EXIT_STATUS != 0 ]]; then
+                echo "ERROR: xrdcp exited with $EXIT_STATUS"
+            fi
+            exit $EXIT_STATUS
+            """
             return result
 
     def buildStageInCommand(self, sourcePFN, targetPFN, options=None):
@@ -140,7 +146,13 @@ class FNALImpl(StageOutImpl):
             result += " %s " % options
         result += " %s " % sourcePFN
         result += " %s " % targetPFN
-        result += "; if [ $? -eq 0 ] ; then exit 0; else echo \"Error: xrdcp exited with $?\"; exit 60311 ; fi "
+        result += """
+        EXIT_STATUS=$?
+        if [[ $EXIT_STATUS != 0 ]]; then
+            echo "ERROR: xrdcp exited with $EXIT_STATUS"
+        fi
+        exit $EXIT_STATUS
+        """
         return result
 
     def removeFile(self, pfnToRemove):

--- a/src/python/WMCore/Storage/Backends/FNALImpl.py
+++ b/src/python/WMCore/Storage/Backends/FNALImpl.py
@@ -6,10 +6,12 @@ Implementation of StageOutImpl interface for FNAL
 
 """
 from __future__ import print_function
+
 import os
+
+from WMCore.Storage.Backends.LCGImpl import LCGImpl
 from WMCore.Storage.Registry import registerStageOutImpl
 from WMCore.Storage.StageOutImpl import StageOutImpl
-from WMCore.Storage.Backends.LCGImpl import LCGImpl
 
 _CheckExitCodeOption = True
 

--- a/src/python/WMCore/Storage/Backends/GFAL2Impl.py
+++ b/src/python/WMCore/Storage/Backends/GFAL2Impl.py
@@ -3,9 +3,8 @@
 _GFAL2Impl_
 Implementation of StageOutImpl interface for gfal-copy
 """
-import os
 import argparse
-import logging
+import os
 
 from WMCore.Storage.Registry import registerStageOutImpl
 from WMCore.Storage.StageOutImpl import StageOutImpl
@@ -29,7 +28,6 @@ class GFAL2Impl(StageOutImpl):
         self.removeCommand = self.setups % '. $JOBSTARTDIR/startup_environment.sh; date; gfal-rm -t 600 %s '
         self.copyCommand = self.setups % '. $JOBSTARTDIR/startup_environment.sh; date; gfal-copy -t 2400 -T 2400 -p %(checksum)s %(options)s %(source)s %(destination)s'
 
-
     def createFinalPFN(self, pfn):
         """
         _createFinalPFN_
@@ -43,14 +41,12 @@ class GFAL2Impl(StageOutImpl):
             return "file://%s" % os.path.abspath(pfn)
         return pfn
 
-
     def createSourceName(self, protocol, pfn):
         """
         _createSourceName_
         GFAL2 uses file:/// urls
         """
         return self.createFinalPFN(pfn)
-
 
     def createTargetName(self, protocol, pfn):
         """
@@ -59,7 +55,6 @@ class GFAL2Impl(StageOutImpl):
         """
         return self.createFinalPFN(pfn)
 
-
     def createOutputDirectory(self, targetPFN):
         """
         _createOutputDirectory_
@@ -67,7 +62,6 @@ class GFAL2Impl(StageOutImpl):
         it is not needed to create directory
         """
         return
-
 
     def createRemoveFileCommand(self, pfn):
         """
@@ -82,7 +76,6 @@ class GFAL2Impl(StageOutImpl):
             return "/bin/rm -f %s" % os.path.abspath(pfn)
         else:
             return self.removeCommand % self.createFinalPFN(pfn)
-
 
     def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
         """
@@ -136,7 +129,6 @@ class GFAL2Impl(StageOutImpl):
             """ % self.createRemoveFileCommand(targetPFN)
 
         return result
-
 
     def removeFile(self, pfnToRemove):
         """

--- a/src/python/WMCore/Storage/Backends/GFAL2Impl.py
+++ b/src/python/WMCore/Storage/Backends/GFAL2Impl.py
@@ -9,7 +9,6 @@ import logging
 
 from WMCore.Storage.Registry import registerStageOutImpl
 from WMCore.Storage.StageOutImpl import StageOutImpl
-from WMCore.Storage.Execute import runCommandWithOutput as runCommand
 
 _CheckExitCodeOption = True
 
@@ -19,7 +18,6 @@ class GFAL2Impl(StageOutImpl):
     _GFAL2Impl_
     Implement interface for GFAL2 commands (gfal-copy, gfal-rm)
     """
-    run = staticmethod(runCommand)
 
     def __init__(self, stagein=False):
         StageOutImpl.__init__(self, stagein)
@@ -130,12 +128,11 @@ class GFAL2Impl(StageOutImpl):
             EXIT_STATUS=$?
             echo "gfal-copy exit status: $EXIT_STATUS"
             if [[ $EXIT_STATUS != 0 ]]; then
-               echo "Non-zero gfal-copy Exit status!!!"
+               echo "ERROR: gfal-copy exited with $EXIT_STATUS"
                echo "Cleaning up failed file:"
-                %s
-               exit 60311
+               %s
             fi
-            exit 0
+            exit $EXIT_STATUS
             """ % self.createRemoveFileCommand(targetPFN)
 
         return result

--- a/src/python/WMCore/Storage/Backends/LCGImpl.py
+++ b/src/python/WMCore/Storage/Backends/LCGImpl.py
@@ -8,7 +8,6 @@ Implementation of StageOutImpl interface for lcg-cp
 import os
 from WMCore.Storage.Registry import registerStageOutImpl
 from WMCore.Storage.StageOutImpl import StageOutImpl
-from WMCore.Storage.Execute import runCommandWithOutput as runCommand
 
 _CheckExitCodeOption = True
 
@@ -20,8 +19,6 @@ class LCGImpl(StageOutImpl):
     Implement interface for srmcp v2 command with lcg-* commands
 
     """
-
-    run = staticmethod(runCommand)
 
     def __init__(self, stagein=False):
         StageOutImpl.__init__(self, stagein)
@@ -135,10 +132,10 @@ class LCGImpl(StageOutImpl):
             cat stageout.log
             echo -e "\nlcg-cp exit status: $EXIT_STATUS"
             if [[ $EXIT_STATUS != 0 ]]; then
-                echo "Non-zero lcg-cp Exit status!!!"
+                echo "ERROR: lcg-cp exited with $EXIT_STATUS"
                 echo "Cleaning up failed file:"
                 %s
-                exit 60311
+                exit $EXIT_STATUS
             fi
 
             """ % self.createRemoveFileCommand(targetPFN)
@@ -169,9 +166,8 @@ class LCGImpl(StageOutImpl):
                         %s
                         exit 60311
                     fi
-                else
-                    exit 0
                 fi
+                exit 0
                 """ % (localAdler32, removeCommand)
         else:
             checksumCommand = "exit 0"

--- a/src/python/WMCore/Storage/Backends/LCGImpl.py
+++ b/src/python/WMCore/Storage/Backends/LCGImpl.py
@@ -6,6 +6,7 @@ Implementation of StageOutImpl interface for lcg-cp
 
 """
 import os
+
 from WMCore.Storage.Registry import registerStageOutImpl
 from WMCore.Storage.StageOutImpl import StageOutImpl
 

--- a/src/python/WMCore/Storage/Backends/TestFallbackToOldBackend.py
+++ b/src/python/WMCore/Storage/Backends/TestFallbackToOldBackend.py
@@ -10,8 +10,7 @@ from __future__ import print_function
 import os
 from WMCore.Storage.Registry import registerStageOutImpl
 from WMCore.Storage.StageOutImpl import StageOutImpl
-
-from WMCore.Storage.Execute import runCommand
+from WMCore.Storage.Execute import runCommandWithOutput
 
 
 class TestFallbackToOldBackendImpl(StageOutImpl):
@@ -21,8 +20,6 @@ class TestFallbackToOldBackendImpl(StageOutImpl):
     Implement interface for plain cp command
 
     """
-
-    run = staticmethod(runCommand)
 
     def createSourceName(self, protocol, pfn):
         """
@@ -44,27 +41,30 @@ class TestFallbackToOldBackendImpl(StageOutImpl):
         checkdircmd="/bin/ls %s > /dev/null " % targetdir
         print("Check dir existence : %s" %checkdircmd)
         try:
-            checkdirexitCode = self.run(checkdircmd)
+            checkdirexitCode, output = runCommandWithOutput(checkdircmd)
         except Exception as ex:
             msg = "Warning: Exception while invoking command:\n"
             msg += "%s\n" % checkdircmd
             msg += "Exception: %s\n" % str(ex)
             msg += "Go on anyway..."
             print(msg)
-            pass
 
         if checkdirexitCode:
             mkdircmd = "/bin/mkdir -m 775 -p %s" % targetdir
             print("=> creating the dir : %s" %mkdircmd)
             try:
-                self.run(mkdircmd)
+                exitCode, output = runCommandWithOutput(mkdircmd)
             except Exception as ex:
                 msg = "Warning: Exception while invoking command:\n"
                 msg += "%s\n" % mkdircmd
                 msg += "Exception: %s\n" % str(ex)
                 msg += "Go on anyway..."
                 print(msg)
-                pass
+            if exitCode:
+                msg = "Warning: failed to create the dir %s with the following error:\n%s" % (targetdir, output)
+                print(msg)
+            else:
+                print("=> dir %s correctly created" % targetdir)
         else:
             print("=> dir already exists... do nothing.")
 
@@ -83,7 +83,15 @@ class TestFallbackToOldBackendImpl(StageOutImpl):
             result += " %s " % options
         result += " %s " % sourcePFN
         result += " %s " % targetPFN
-        result += "; DEST_SIZE=`/bin/ls -l %s | awk '{print $5}'` ; if [ $DEST_SIZE ] && [ '%s' -eq $DEST_SIZE ]; then exit 0; else echo \"Error: Size Mismatch between local and SE\"; exit 60311 ; fi " % (targetPFN,original_size)
+        result += """
+        DEST_SIZE=`/bin/ls -l %s | awk '{print $5}'`
+        if [ $DEST_SIZE ] && [ '%s' -eq $DEST_SIZE ]; then
+            exit 0
+        else
+            echo "ERROR: Size Mismatch between local and SE"
+            exit 60311
+        fi
+        """ % (targetPFN,original_size)
         print(result)
         return result
 

--- a/src/python/WMCore/Storage/Backends/TestFallbackToOldBackend.py
+++ b/src/python/WMCore/Storage/Backends/TestFallbackToOldBackend.py
@@ -7,10 +7,12 @@ this will let us test that the fallback works properly
 
 """
 from __future__ import print_function
+
 import os
+
+from WMCore.Storage.Execute import runCommandWithOutput
 from WMCore.Storage.Registry import registerStageOutImpl
 from WMCore.Storage.StageOutImpl import StageOutImpl
-from WMCore.Storage.Execute import runCommandWithOutput
 
 
 class TestFallbackToOldBackendImpl(StageOutImpl):
@@ -36,10 +38,10 @@ class TestFallbackToOldBackendImpl(StageOutImpl):
 
         create dir with group permission
         """
-        targetdir= os.path.dirname(targetPFN)
+        targetdir = os.path.dirname(targetPFN)
 
-        checkdircmd="/bin/ls %s > /dev/null " % targetdir
-        print("Check dir existence : %s" %checkdircmd)
+        checkdircmd = "/bin/ls %s > /dev/null " % targetdir
+        print("Check dir existence : %s" % checkdircmd)
         try:
             checkdirexitCode, output = runCommandWithOutput(checkdircmd)
         except Exception as ex:
@@ -51,7 +53,7 @@ class TestFallbackToOldBackendImpl(StageOutImpl):
 
         if checkdirexitCode:
             mkdircmd = "/bin/mkdir -m 775 -p %s" % targetdir
-            print("=> creating the dir : %s" %mkdircmd)
+            print("=> creating the dir : %s" % mkdircmd)
             try:
                 exitCode, output = runCommandWithOutput(mkdircmd)
             except Exception as ex:
@@ -68,8 +70,7 @@ class TestFallbackToOldBackendImpl(StageOutImpl):
         else:
             print("=> dir already exists... do nothing.")
 
-
-    def createStageOutCommand(self, sourcePFN, targetPFN, options = None, checksums = None):
+    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
         """
         _createStageOutCommand_
 
@@ -91,10 +92,9 @@ class TestFallbackToOldBackendImpl(StageOutImpl):
             echo "ERROR: Size Mismatch between local and SE"
             exit 60311
         fi
-        """ % (targetPFN,original_size)
+        """ % (targetPFN, original_size)
         print(result)
         return result
-
 
     def removeFile(self, pfnToRemove):
         """

--- a/src/python/WMCore/Storage/Backends/VandyImpl.py
+++ b/src/python/WMCore/Storage/Backends/VandyImpl.py
@@ -11,8 +11,6 @@ import os.path
 from WMCore.Storage.Registry import registerStageOutImpl
 from WMCore.Storage.StageOutImpl import StageOutImpl
 
-from WMCore.Storage.Execute import runCommand
-
 
 
 class VandyImpl(StageOutImpl):

--- a/src/python/WMCore/Storage/Backends/VandyImpl.py
+++ b/src/python/WMCore/Storage/Backends/VandyImpl.py
@@ -12,26 +12,23 @@ from WMCore.Storage.Registry import registerStageOutImpl
 from WMCore.Storage.StageOutImpl import StageOutImpl
 
 
-
 class VandyImpl(StageOutImpl):
-
     '''
     _VandyImp_
 
     Implement the vandy interface
     '''
 
-    #BASEDIR='/Users/brumgard/Documents/workspace/VandyStageOut/src/scripts'
-    BASEDIR='/usr/local/cms-stageout'
+    # BASEDIR='/Users/brumgard/Documents/workspace/VandyStageOut/src/scripts'
+    BASEDIR = '/usr/local/cms-stageout'
 
     def __init__(self, stagein=False):
 
         StageOutImpl.__init__(self, stagein)
 
-
-        self._mkdirScript    = os.path.join(VandyImpl.BASEDIR, 'vandyMkdir.sh')
-        self._cpScript       = os.path.join(VandyImpl.BASEDIR, 'vandyCp.sh')
-        self._rmScript       = os.path.join(VandyImpl.BASEDIR, 'vandyRm.sh')
+        self._mkdirScript = os.path.join(VandyImpl.BASEDIR, 'vandyMkdir.sh')
+        self._cpScript = os.path.join(VandyImpl.BASEDIR, 'vandyCp.sh')
+        self._rmScript = os.path.join(VandyImpl.BASEDIR, 'vandyRm.sh')
         self._downloadScript = os.path.join(VandyImpl.BASEDIR, 'vandyDownload.sh')
 
     def createSourceName(self, protocol, pfn):
@@ -44,7 +41,6 @@ class VandyImpl(StageOutImpl):
         """
 
         return "%s" % pfn
-
 
     def createOutputDirectory(self, targetPFN):
 
@@ -60,8 +56,7 @@ class VandyImpl(StageOutImpl):
         # throw a stage out error
         self.executeCommand(command)
 
-
-    def createStageOutCommand(self, sourcePFN, targetPFN, options = None, checksums = None):
+    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
 
         """
         _createStageOutCommand_
@@ -74,7 +69,6 @@ class VandyImpl(StageOutImpl):
             return "%s %s %s" % (self._downloadScript, sourcePFN, targetPFN)
         else:
             return "%s %s %s" % (self._cpScript, sourcePFN, targetPFN)
-
 
     def removeFile(self, pfnToRemove):
 

--- a/src/python/WMCore/Storage/Backends/XRDCPImpl.py
+++ b/src/python/WMCore/Storage/Backends/XRDCPImpl.py
@@ -15,7 +15,6 @@ import argparse
 from WMCore.Storage.Registry import registerStageOutImpl
 from WMCore.Storage.StageOutImpl import StageOutImpl
 
-from WMCore.Storage.Execute import execute
 
 
 class XRDCPImpl(StageOutImpl):
@@ -150,12 +149,12 @@ class XRDCPImpl(StageOutImpl):
             copyCommand += "echo \"Remote File Checksum is: $REMOTE_XS\"\n"
 
             copyCommand += "if [ $REMOTE_SIZE ] && [ $REMOTE_XS ] && [ $LOCAL_SIZE == $REMOTE_SIZE ] && [ '%s' == $REMOTE_XS ]; then exit 0; " % checksums['adler32']
-            copyCommand += "else echo \"Error: Size or Checksum Mismatch between local and SE\"; %s exit 60311 ; fi" % removeCommand
+            copyCommand += "else echo \"ERROR: Size or Checksum Mismatch between local and SE\"; %s exit 60311 ; fi" % removeCommand
 
         else:
 
             copyCommand += "if [ $REMOTE_SIZE ] && [ $LOCAL_SIZE == $REMOTE_SIZE ]; then exit 0; "
-            copyCommand += "else echo \"Error: Size Mismatch between local and SE\"; %s exit 60311 ; fi" % removeCommand
+            copyCommand += "else echo \"ERROR: Size Mismatch between local and SE\"; %s exit 60311 ; fi" % removeCommand
 
         return copyCommand
 
@@ -166,7 +165,7 @@ class XRDCPImpl(StageOutImpl):
         """
         (_, host, path, _) = self.splitPFN(pfnToRemove)
         command = "xrdfs %s rm %s" % (host, path)
-        execute(command)
+        self.executeCommand(command)
         return
 
 registerStageOutImpl("xrdcp", XRDCPImpl)

--- a/src/python/WMCore/Storage/Backends/XRDCPImpl.py
+++ b/src/python/WMCore/Storage/Backends/XRDCPImpl.py
@@ -9,12 +9,11 @@ Generic, will/should work with any site.
 """
 from __future__ import print_function
 
-import os
 import argparse
+import os
 
 from WMCore.Storage.Registry import registerStageOutImpl
 from WMCore.Storage.StageOutImpl import StageOutImpl
-
 
 
 class XRDCPImpl(StageOutImpl):

--- a/src/python/WMCore/Storage/Plugins/FNALImpl.py
+++ b/src/python/WMCore/Storage/Plugins/FNALImpl.py
@@ -281,7 +281,7 @@ class FNALImpl(StageOutImplV2):
             try:
                 self.runCommandFailOnNonZero(result)
             except:
-                logging.info("dccp failed, removing failed file")
+                logging.info("xrdcp failed, removing failed file")
                 if not stageOut and os.path.exists(pnfsPfn2(targetPFN)):
                     logging.info("unlinking %s" % pnfsPfn2(targetPFN))
                     os.unlink(pnfsPfn2(targetPFN))

--- a/src/python/WMCore/Storage/Plugins/FNALImpl.py
+++ b/src/python/WMCore/Storage/Plugins/FNALImpl.py
@@ -99,7 +99,7 @@ class FNALImpl(StageOutImplV2):
         if PFN.find('/store/user/meloam/lustre/') != -1:
             method = 'lustre'
 
-        logging.debug("Using method %s for PFN %s" % (method, PFN))
+        logging.debug("Using method %s for PFN %s", method, PFN)
         return method
 
     def substituteLustrePath(self, pfn):
@@ -137,26 +137,26 @@ class FNALImpl(StageOutImplV2):
 
 
         """
-        logging.info("createOutputDirectoryDCAP called on %s" % targetPFN)
+        logging.info("createOutputDirectoryDCAP called on %s", targetPFN)
         # only create dir on remote storage
         if targetPFN.find('/pnfs/') == -1:
             return
 
         filePath = self.dcapToPNFS(targetPFN)
         directory = os.path.dirname(filePath)
-        logging.info("Creating path: %s" % directory)
+        logging.info("Creating path: %s", directory)
         if not os.path.exists(directory):
             os.makedirs(directory)
 
     def createOutputDirectoryEOS(self, targetPFN):
-        logging.info("createOutputDirectoryEOS called on %s" % targetPFN)
+        logging.info("createOutputDirectoryEOS called on %s", targetPFN)
         # only create dir on remote storage
         if targetPFN.find('root://cmseos.fnal.gov') == -1:
             return
 
         filePath = targetPFN.split("root://cmseos.fnal.gov/", 1)[1]
         directory = os.path.dirname(filePath)
-        logging.info("Creating path: %s" % directory)
+        logging.info("Creating path: %s", directory)
         if not os.path.exists(directory):
             os.makedirs(directory)
 
@@ -175,17 +175,17 @@ class FNALImpl(StageOutImplV2):
         if method == 'srm':
             return self.srmImpl.createSourceName(protocol, pfn)
         elif method == 'dccp':
-            logging.info("Translating PFN for dcache: %s" % pfn)
+            logging.info("Translating PFN for dcache: %s", pfn)
             pfn = pfn.split("/store/")[1]
             dcacheDoor = getoutput(
                 ". " + envScript + "\n" + \
                 "/opt/d-cache/dcap/bin/select_RdCapDoor.sh")
             pfn = "%s%s" % (dcacheDoor, pfn)
-            logging.info("  Translated PFN: %s" % pfn)
+            logging.info("  Translated PFN: %s", pfn)
         elif method == 'lustre':
-            logging.info("Translating PFN for lustre: %s" % pfn)
+            logging.info("Translating PFN for lustre: %s", pfn)
             pfn = self.substituteLustrePath(pfn)
-            logging.info("  Translated PFN: %s" % pfn)
+            logging.info("  Translated PFN: %s", pfn)
         else:
             raise RuntimeError("Unknown method found in createSourceName: %s" % method)
 
@@ -207,13 +207,13 @@ class FNALImpl(StageOutImplV2):
             pfnSplit = pfnToRemove.split("/11/store/", 1)[1]
             filePath = "/pnfs/cms/WAX/11/store/%s" % pfnSplit
             if os.path.exists(filePath):
-                logging.info("Removing file: " + filePath)
+                logging.info("Removing file: %s", filePath)
                 os.unlink(filePath)
         elif method == 'lustre':
             pfnToRemove = self.substituteLustrePath(pfnToRemove)
             filePath = pfnToRemove.split("root://cmseos.fnal.gov/", 1)[1]
             if os.path.exists(filePath):
-                logging.info("Removing file: " + filePath)
+                logging.info("Removing file: %s", filePath)
                 os.unlink(filePath)
         else:
             raise RuntimeError("Unsupported storage method in doDelete: %s" % method)
@@ -283,7 +283,7 @@ class FNALImpl(StageOutImplV2):
             except:
                 logging.info("xrdcp failed, removing failed file")
                 if not stageOut and os.path.exists(pnfsPfn2(targetPFN)):
-                    logging.info("unlinking %s" % pnfsPfn2(targetPFN))
+                    logging.info("unlinking %s", pnfsPfn2(targetPFN))
                     os.unlink(pnfsPfn2(targetPFN))
                 else:
                     self.doDelete(targetPFN, pnn, command, options, protocol)
@@ -301,7 +301,6 @@ class FNALImpl(StageOutImplV2):
             optionsStr = ""
             if options != None:
                 optionsStr = str(options)
-            dirname = os.path.dirname(targetPFN)
             result = "#!/bin/bash\n"
             result += ". " + envScript + "\n"
             result += "dccp -o 86400  -d 0 -X -role=cmsprod %s %s %s" % (optionsStr, sourcePFN, targetPFN)
@@ -310,7 +309,7 @@ class FNALImpl(StageOutImplV2):
             except:
                 logging.info("dccp failed, removing failed file")
                 if not stageOut and os.path.exists(pnfsPfn2(targetPFN)):
-                    logging.info("unlinking %s" % pnfsPfn2(targetPFN))
+                    logging.info("unlinking %s", pnfsPfn2(targetPFN))
                     os.unlink(pnfsPfn2(targetPFN))
                 else:
                     self.doDelete(targetPFN, pnn, command, options, protocol)

--- a/test/python/WMCore_t/Storage_t/Backends_t/CPImpl_t.py
+++ b/test/python/WMCore_t/Storage_t/Backends_t/CPImpl_t.py
@@ -31,14 +31,14 @@ class CPImplTest(unittest.TestCase):
 
     def testCreateOutputDirectory_error1Exception(self):
         self.CPImpl.run = Mock()
-        self.CPImpl.run.side_effect = [1, Exception()]
+        self.CPImpl.run.return_value = [1, Exception("Failed to create directory")]
         self.CPImpl.createOutputDirectory("dir/file/test")
         self.CPImpl.run.assert_has_calls([call("/bin/ls dir/file > /dev/null "),
                                           call("umask 002 ; /bin/mkdir -p dir/file")])
 
     @mock.patch('WMCore.Storage.Backends.CPImpl.CPImpl.run')
     def testCreateOutputDirectory_error1(self, mock_runCommand):
-        mock_runCommand.return_value = 1
+        mock_runCommand.return_value = [1, 2]
         self.CPImpl.createOutputDirectory("dir/file/test")
         mock_runCommand.assert_has_calls([call("/bin/ls dir/file > /dev/null "),
                                           call("umask 002 ; /bin/mkdir -p dir/file")])
@@ -46,7 +46,7 @@ class CPImplTest(unittest.TestCase):
     def testCreateStageOutCommand_realFile(self):
         base = os.path.join(getTestBase(), "WMCore_t/Storage_t/ExecutableCommands.py")
         result = self.CPImpl.createStageOutCommand(base, "test")
-        expectedResult = [" '590' -eq $DEST_SIZE", "DEST_SIZE=`/bin/ls -l test", base]
+        expectedResult = [" '642' -eq $DEST_SIZE", "DEST_SIZE=`/bin/ls -l test", base]
         for text in expectedResult:
             self.assertIn(text, result)
 

--- a/test/python/WMCore_t/Storage_t/Backends_t/GFAL2Impl_t.py
+++ b/test/python/WMCore_t/Storage_t/Backends_t/GFAL2Impl_t.py
@@ -112,12 +112,11 @@ class GFAL2ImplTest(unittest.TestCase):
             EXIT_STATUS=$?
             echo "gfal-copy exit status: $EXIT_STATUS"
             if [[ $EXIT_STATUS != 0 ]]; then
-               echo "Non-zero gfal-copy Exit status!!!"
+               echo "ERROR: gfal-copy exited with $EXIT_STATUS"
                echo "Cleaning up failed file:"
-                %s
-               exit 60311
+               %s
             fi
-            exit 0
+            exit $EXIT_STATUS
             """ % createRemoveFileCommandResult
 
         return result

--- a/test/python/WMCore_t/Storage_t/Backends_t/LCGImpl_t.py
+++ b/test/python/WMCore_t/Storage_t/Backends_t/LCGImpl_t.py
@@ -102,10 +102,10 @@ class LCGImplTest(unittest.TestCase):
             cat stageout.log
             echo -e "\nlcg-cp exit status: $EXIT_STATUS"
             if [[ $EXIT_STATUS != 0 ]]; then
-                echo "Non-zero lcg-cp Exit status!!!"
+                echo "ERROR: lcg-cp exited with $EXIT_STATUS"
                 echo "Cleaning up failed file:"
                 %s
-                exit 60311
+                exit $EXIT_STATUS
             fi
 
             """ % createRemoveFileCommandResult
@@ -126,9 +126,8 @@ class LCGImplTest(unittest.TestCase):
                         %s
                         exit 60311
                     fi
-                else
-                    exit 0
                 fi
+                exit 0
                 """ % (checksums, createRemoveFileCommandResult)
         else:
             checksumCommand = "exit 0"

--- a/test/python/WMCore_t/Storage_t/Backends_t/XRDCPImpl_t.py
+++ b/test/python/WMCore_t/Storage_t/Backends_t/XRDCPImpl_t.py
@@ -111,13 +111,13 @@ class XRDCPImplTest(unittest.TestCase):
 
             copyCommand += "if [ $REMOTE_SIZE ] && [ $REMOTE_XS ] && [ $LOCAL_SIZE == $REMOTE_SIZE ] && [ '%s' == $REMOTE_XS ]; then exit 0; " % \
                            checksums
-            copyCommand += "else echo \"Error: Size or Checksum Mismatch between local and SE\"; %s exit 60311 ; fi" % removeCommand
+            copyCommand += "else echo \"ERROR: Size or Checksum Mismatch between local and SE\"; %s exit 60311 ; fi" % removeCommand
         else:
             copyCommand += "if [ $REMOTE_SIZE ] && [ $LOCAL_SIZE == $REMOTE_SIZE ]; then exit 0; "
-            copyCommand += "else echo \"Error: Size Mismatch between local and SE\"; %s exit 60311 ; fi" % removeCommand
+            copyCommand += "else echo \"ERROR: Size Mismatch between local and SE\"; %s exit 60311 ; fi" % removeCommand
         return copyCommand
 
-    @mock.patch('WMCore.Storage.Backends.XRDCPImpl.execute')
+    @mock.patch('WMCore.Storage.Backends.XRDCPImpl.XRDCPImpl.executeCommand')
     def testRemoveFile(self, mock_executeCommand):
         self.XRDCPImpl.removeFile("gsiftp://site.com/inputs/f.a")
         mock_executeCommand.assert_called_with("xrdfs site.com rm inputs/f.a")


### PR DESCRIPTION
Fixes #8010
Fixes #8004

Made changes such that we always return the exit code returned from the actual stage out copy command. If other errors happen - like checksum or size - then I kept the usual 60311 stage out exit code. I couldn't see any possible issues in case we return the actual copy command exit code. @ticoann @hufnagel would you see any possible issues?

Second commit just makes sure we use StageOutImpl.executeCommand (which runs command with output).

Still to be tested