### PR TITLE
Set PU caching to 0.5h instead of 24

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
+++ b/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
@@ -141,7 +141,7 @@ class PileupFetcher(FetcherInterface):
         """
         cacheFile = self._getCacheFilePath(stepHelper)
 
-        if not self._isCacheExpired(cacheFile) and os.path.getsize(cacheFile) > 0:
+        if not self._isCacheExpired(cacheFile, delta=0.5) and os.path.getsize(cacheFile) > 0:
             # if file already exist don't make a new dbs call and overwrite the file.
             # just return
             fileName = self._getStepFilePath(stepHelper)


### PR DESCRIPTION
Fixes #7894

As discussed in the meeting, I'm simply reducing the cache lifetime to 30min instead of 24h. If we find that it still doesn't meet our needs, then we can think of something more complete/complicated.