### PR TITLE
Inherit PrepID from the workload level for StepChain

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
@@ -47,6 +47,7 @@ class StepChainWorkloadFactory(StdBase):
         self.sizePerEvent = None
         self.timePerEvent = None
         self.primaryDataset = None
+        self.prepID = None
         # stepMapping is going to be used during assignment for properly mapping
         # the arguments to each step/cmsRun
         self.stepMapping = {}
@@ -273,6 +274,9 @@ class StepChainWorkloadFactory(StdBase):
         """
         frameworkVersion = taskConf.get("CMSSWVersion", self.frameworkVersion)
         scramArch = taskConf.get("ScramArch", self.scramArch)
+        # PrepID has to be inherited from the workload level, not from task
+        if not taskConf.get('PrepID'):
+            taskConf['PrepID'] = self.prepID
 
         for outputModuleName in outputMods.keys():
             dummyTask = self.addMergeTask(task, self.splittingAlgo, outputModuleName, stepCmsRun,

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
@@ -1062,10 +1062,9 @@ class StepChainTests(EmulatedUnitTestCase):
         task = testWorkload.getTaskByName('GENSIMMergeRAWSIMoutput')
         self.assertEqual(task.getPrepID(), testArguments['Step1']['PrepID'])
         task = testWorkload.getTaskByName('RECOMergeAODSIMoutput')
-        # TODO: update the fallback PrepId to the workload level. PR issue: #7978
-        self.assertEqual(task.getPrepID(), testArguments['Step3'].get('PrepID', testArguments['Step1']['PrepID']))
+        self.assertEqual(task.getPrepID(), testArguments['Step3'].get('PrepID', testArguments['PrepID']))
         task = testWorkload.getTaskByName('RECOMergeRECOSIMoutput')
-        self.assertEqual(task.getPrepID(), testArguments['Step3'].get('PrepID', testArguments['Step1']['PrepID']))
+        self.assertEqual(task.getPrepID(), testArguments['Step3'].get('PrepID', testArguments['PrepID']))
 
         # and we assign it too, better safe than sorry
         assignDict = {"SiteWhitelist": ["T2_US_Nebraska", "T2_IT_Rome"], "Team": "The-A-Team"}
@@ -1078,9 +1077,9 @@ class StepChainTests(EmulatedUnitTestCase):
         task = testWorkload.getTaskByName('GENSIMMergeRAWSIMoutput')
         self.assertEqual(task.getPrepID(), testArguments['Step1']['PrepID'])
         task = testWorkload.getTaskByName('RECOMergeAODSIMoutput')
-        self.assertEqual(task.getPrepID(), testArguments['Step3'].get('PrepID', testArguments['Step1']['PrepID']))
+        self.assertEqual(task.getPrepID(), testArguments['Step3'].get('PrepID', testArguments['PrepID']))
         task = testWorkload.getTaskByName('RECOMergeRECOSIMoutput')
-        self.assertEqual(task.getPrepID(), testArguments['Step3'].get('PrepID', testArguments['Step1']['PrepID']))
+        self.assertEqual(task.getPrepID(), testArguments['Step3'].get('PrepID', testArguments['PrepID']))
 
         return
 


### PR DESCRIPTION
Fixes #7978

Make sure StepChain inheritance comes from the workflow level and not from the task one (which is set according to the first step settings).
