### PR TITLE
more selective assignment overrides

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/Express.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Express.py
@@ -231,11 +231,6 @@ class ExpressWorkloadFactory(StdBase):
                                            periodic_harvest_interval=self.periodicHarvestInterval,
                                            doLogCollect=True)
 
-        workload.setBlockCloseSettings(self.blockCloseDelay,
-                                       workload.getBlockCloseMaxFiles(),
-                                       workload.getBlockCloseMaxEvents(),
-                                       workload.getBlockCloseMaxSize())
-
         # setting the parameters which need to be set for all the tasks
         # sets acquisitionEra, processingVersion, processingString
         workload.setTaskPropertiesFromWorkload()
@@ -482,8 +477,6 @@ class ExpressWorkloadFactory(StdBase):
                     "AlcaHarvestDir": {"optional": False, "null": True},
                     "AlcaSkims": {"type": makeList, "optional": False},
                     "DQMSequences": {"type": makeList, "attr": "dqmSequences", "optional": False},
-                    "BlockCloseDelay": {"type": int, "optional": False,
-                                        "validate": lambda x: x > 0},
                     "Outputs": {"type": makeList, "optional": False},
                     "MaxInputRate": {"type": int, "optional": False},
                     "MaxInputEvents": {"type": int, "optional": False},

--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -102,11 +102,6 @@ class PromptRecoWorkloadFactory(DataProcessing):
                     self.addMergeTask(alcaTask, self.procJobSplitAlgo, alcaOutLabel,
                                       doLogCollect=self.doLogCollect)
 
-        workload.setBlockCloseSettings(self.blockCloseDelay,
-                                       workload.getBlockCloseMaxFiles(),
-                                       workload.getBlockCloseMaxEvents(),
-                                       workload.getBlockCloseMaxSize())
-
         # setting the parameters which need to be set for all the tasks
         # sets acquisitionEra, processingVersion, processingString
         workload.setTaskPropertiesFromWorkload()
@@ -192,8 +187,6 @@ class PromptRecoWorkloadFactory(DataProcessing):
                                         "null": False},
                     "SkimFilesPerJob": {"default": 1, "type": int, "validate": lambda x: x > 0,
                                         "null": False},
-                    "BlockCloseDelay": {"default": 86400, "type": int, "validate": lambda x: x > 0,
-                                        "null": False}
                     }
 
         baseArgs.update(specArgs)

--- a/src/python/WMCore/WMSpec/StdSpecs/Repack.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Repack.py
@@ -74,11 +74,6 @@ class RepackWorkloadFactory(StdBase):
         for repackOutLabel in repackOutMods:
             self.addRepackMergeTask(repackTask, repackOutLabel)
 
-        workload.setBlockCloseSettings(self.blockCloseDelay,
-                                       workload.getBlockCloseMaxFiles(),
-                                       workload.getBlockCloseMaxEvents(),
-                                       workload.getBlockCloseMaxSize())
-
         # setting the parameters which need to be set for all the tasks
         # sets acquisitionEra, processingVersion, processingString
         workload.setTaskPropertiesFromWorkload()
@@ -194,8 +189,6 @@ class RepackWorkloadFactory(StdBase):
                     "Scenario": {"default": "fake", "attr": "procScenario"},
                     "GlobalTag": {"default": "fake"},
                     "ProcessingString": {"default": "", "validate": procstringT0},
-                    "BlockCloseDelay": {"type": int, "optional": False,
-                                        "validate": lambda x: x > 0},
                     "Outputs": {"type": makeList, "optional": False},
                     "MaxSizeSingleLumi": {"type": int, "optional": False},
                     "MaxSizeMultiLumi": {"type": int, "optional": False},

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -1770,15 +1770,16 @@ class WMWorkloadHelper(PersistencyHelper):
 
         # Since it lists the output datasets, it has to be done in the very end
         # Set phedex subscription information
-        self.setSubscriptionInformation(custodialSites=kwargs["CustodialSites"],
-                                        nonCustodialSites=kwargs["NonCustodialSites"],
-                                        autoApproveSites=kwargs["AutoApproveSubscriptionSites"],
-                                        custodialSubType=kwargs["CustodialSubType"],
-                                        nonCustodialSubType=kwargs["NonCustodialSubType"],
-                                        custodialGroup=kwargs["CustodialGroup"],
-                                        nonCustodialGroup=kwargs["NonCustodialGroup"],
-                                        priority=kwargs["SubscriptionPriority"],
-                                        deleteFromSource=kwargs["DeleteFromSource"])
+        if kwargs.get("CustodialSites") or kwargs.get("NonCustodialSites"):
+            self.setSubscriptionInformation(custodialSites=kwargs["CustodialSites"],
+                                            nonCustodialSites=kwargs["NonCustodialSites"],
+                                            autoApproveSites=kwargs["AutoApproveSubscriptionSites"],
+                                            custodialSubType=kwargs["CustodialSubType"],
+                                            nonCustodialSubType=kwargs["NonCustodialSubType"],
+                                            custodialGroup=kwargs["CustodialGroup"],
+                                            nonCustodialGroup=kwargs["NonCustodialGroup"],
+                                            priority=kwargs["SubscriptionPriority"],
+                                            deleteFromSource=kwargs["DeleteFromSource"])
 
         return
 

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
@@ -1484,7 +1484,7 @@ class TaskChainTests(EmulatedUnitTestCase):
         self.assertItemsEqual(testWorkload.listAllOutputModulesLFNBases(onlyUnmerged=False), outputLFNBases)
         for t in ["Task1", "Task2", "Task3", "Task4"]:
             task = testWorkload.getTaskByName(REQUEST[t]['TaskName'])
-            self._checkOutputDsetsAndMods(task, outMods[t], outDsets[t], lfnBases, assigned=True)
+            self._checkOutputDsetsAndMods(task, outMods[t], outDsets[t], lfnBases)
             # then test the merge tasks
             for modName in mergedMods[t]:
                 mergeName = REQUEST[t]['TaskName'] + "Merge" + modName
@@ -1506,7 +1506,7 @@ class TaskChainTests(EmulatedUnitTestCase):
         testWorkload.updateArguments(assignDict)
         for t in ["Task1", "Task2", "Task3", "Task4"]:
             task = testWorkload.getTaskByName(REQUEST[t]['TaskName'])
-            self._checkOutputDsetsAndMods(task, outMods[t], outDsets[t], lfnBases, assigned=True)
+            self._checkOutputDsetsAndMods(task, outMods[t], outDsets[t], lfnBases)
             # then test the merge tasks
             for modName, value in mergedMods[t].iteritems():
                 mergeName = REQUEST[t]['TaskName'] + "Merge" + modName
@@ -1549,7 +1549,7 @@ class TaskChainTests(EmulatedUnitTestCase):
         lfnBases = ("/store/unmerged", "/store/mc")
         for t in ["Task1", "Task2", "Task3", "Task4"]:
             task = testWorkload.getTaskByName(REQUEST[t]['TaskName'])
-            self._checkOutputDsetsAndMods(task, outMods[t], outDsets[t], lfnBases, assigned=True)
+            self._checkOutputDsetsAndMods(task, outMods[t], outDsets[t], lfnBases)
             # then test the merge tasks
             for modName, value in mergedMods[t].iteritems():
                 mergeName = REQUEST[t]['TaskName'] + "Merge" + modName
@@ -1559,13 +1559,12 @@ class TaskChainTests(EmulatedUnitTestCase):
 
         return
 
-    def _checkOutputDsetsAndMods(self, task, outMods, outDsets, lfnBases, assigned=False):
+    def _checkOutputDsetsAndMods(self, task, outMods, outDsets, lfnBases):
         """
         Validate data related to output dataset, output modules and subscriptions
         :param task: task object
         :param outMods: dictionary with the output module info for this task
         :param outDsets: dictionary with the output datasets info for this task
-        :param assigned: flag saying whether the workload was assigned or not
         """
         self.assertItemsEqual(task.getIgnoredOutputModulesForTask(), [])
 
@@ -1577,14 +1576,7 @@ class TaskChainTests(EmulatedUnitTestCase):
         for modName in outModDict:
             self._validateOutputModule(outModDict[modName], outMods[modName])
 
-        if assigned:
-            defaultSubs = {'Priority': 'Low', 'NonCustodialSites': [], 'AutoApproveSites': [],
-                           'DeleteFromSource': False, 'NonCustodialGroup': 'DataOps', 'CustodialSites': [],
-                           'CustodialSubType': 'Replica', 'CustodialGroup': 'DataOps', 'NonCustodialSubType': 'Replica'}
-            subscription = {dset: defaultSubs for dset in outputDsets}
-        else:
-            subscription = {}
-        self.assertDictEqual(task.getSubscriptionInformation(), subscription)
+        self.assertDictEqual(task.getSubscriptionInformation(), {})
 
         # step level checks
         self.assertEqual(task.getTopStepName(), 'cmsRun1')


### PR DESCRIPTION
Tier0 subscriptions are completely broken in the current WMCore since updateArguments overrides all subscriptions and sets default values. Tier0 does NOT use spec arguments to set subscriptions, we make the subscription calls ourselves.

Not sure about performance monitoring or block closing, but most likely they are also affected (if they use defaults). Tier0 also uses custom values here.

I don't necessarily want this version merged, but there is an urgency here since we want to deploy the latest Tier0 release ASAP. Suggest another patch if you don't like this version. 