### PR TITLE
Only set events_per_lumi for the first cmsRun step

### DIFF
--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -56,7 +56,8 @@ dependencies = {
         'packages': ['WMCore.ReqMgr+',
                      'WMCore.WMDataMining+',
                      'WMCore.Services+',
-                     'WMCore.ACDC'
+                     'WMCore.ACDC',
+                     'Utils'
                      ],
         'systems': ['wmc-rest', 'wmc-runtime', 'wmc-database'],
         'statics': ['src/couchapps/ReqMgr+',

--- a/src/python/WMCore/ReqMgr/Service/RequestAdditionalInfo.py
+++ b/src/python/WMCore/ReqMgr/Service/RequestAdditionalInfo.py
@@ -16,7 +16,6 @@ from WMCore.WMSpec.WMWorkload import WMWorkloadHelper
 
 
 def format_algo_web_list(task_name, task_type, split_param):
-
     algo_config = ReqMgrConfigDataCache.getConfig("EDITABLE_SPLITTING_PARAM_CONFIG")
 
     fdict = {"taskName": task_name}
@@ -47,14 +46,16 @@ def format_algo_web_list(task_name, task_type, split_param):
     fdict["splitParamList"] = param_list
     return fdict
 
+
 def create_web_splitting_format(split_info):
     web_form = []
     for sp in split_info:
         # skip Cleanup and LogCollect: don't allow change the param
         if sp["taskType"] not in ["Cleanup", "LogCollect"]:
             web_form.append(format_algo_web_list(sp["taskName"], sp["taskType"],
-                                               sp["splitParams"]))
+                                                 sp["splitParams"]))
     return web_form
+
 
 def _validate_split_param(split_algo, split_param):
     """
@@ -72,8 +73,9 @@ def _validate_split_param(split_algo, split_param):
     else:
         return (False, None)
 
+
 def _assign_key_value(keyname, keyvalue, return_params, cast_type):
-    if cast_type == None:
+    if cast_type is None:
         return_params[keyname] = keyvalue
     elif cast_type == bool:
         try:
@@ -84,8 +86,8 @@ def _assign_key_value(keyname, keyvalue, return_params, cast_type):
     else:
         return_params[keyname] = cast_type(keyvalue)
 
-class RequestSpec(RESTEntity):
 
+class RequestSpec(RESTEntity):
     def validate(self, apiobj, method, api, param, safe):
         """
         Validate request input data.
@@ -96,8 +98,7 @@ class RequestSpec(RESTEntity):
         """
         validate_str("name", param, safe, rx.RX_REQUEST_NAME, optional=False)
 
-
-    @restcall(formats = [('text/plain', PrettyJSONFormat()), ('application/json', JSONFormat())])
+    @restcall(formats=[('text/plain', PrettyJSONFormat()), ('application/json', JSONFormat())])
     @tools.expires(secs=-1)
     def get(self, name):
         """
@@ -110,8 +111,8 @@ class RequestSpec(RESTEntity):
         result = get_request_template_from_type(name)
         return [result]
 
-class WorkloadConfig(RESTEntity):
 
+class WorkloadConfig(RESTEntity):
     def __init__(self, app, api, config, mount):
         # main CouchDB database where requests/workloads are stored
         RESTEntity.__init__(self, app, api, config, mount)
@@ -125,7 +126,6 @@ class WorkloadConfig(RESTEntity):
             param.args.pop()
         return
 
-
     def validate(self, apiobj, method, api, param, safe):
         """
         Validate request input data.
@@ -137,8 +137,7 @@ class WorkloadConfig(RESTEntity):
 
         self._validate_args(param, safe)
 
-
-    @restcall(formats = [('text/plain', PrettyJSONFormat()), ('application/json', JSONFormat())])
+    @restcall(formats=[('text/plain', PrettyJSONFormat()), ('application/json', JSONFormat())])
     @tools.expires(secs=-1)
     def get(self, name):
         """
@@ -157,13 +156,12 @@ class WorkloadConfig(RESTEntity):
 
         return str(helper.data)
 
-class WorkloadSplitting(RESTEntity):
 
+class WorkloadSplitting(RESTEntity):
     def __init__(self, app, api, config, mount):
         # main CouchDB database where requests/workloads are stored
         RESTEntity.__init__(self, app, api, config, mount)
         self.reqdb_url = "%s/%s" % (config.couch_host, config.couch_reqmgr_db)
-
 
     def _validate_args(self, param, safe):
         # TODO: need proper validation but for now pass everything
@@ -171,13 +169,12 @@ class WorkloadSplitting(RESTEntity):
         if args_length == 1:
             safe.kwargs["name"] = param.args[0]
             param.args.pop()
-        elif args_length == 2 and  param.args[0] == "web_form":
+        elif args_length == 2 and param.args[0] == "web_form":
             safe.kwargs["web_form"] = True
             safe.kwargs["name"] = param.args[1]
             param.args.pop()
             param.args.pop()
         return
-
 
     def validate(self, apiobj, method, api, param, safe):
         """
@@ -189,8 +186,7 @@ class WorkloadSplitting(RESTEntity):
         """
         self._validate_args(param, safe)
 
-
-    @restcall(formats = [('text/plain', PrettyJSONFormat()), ('application/json', JSONFormat())])
+    @restcall(formats=[('text/plain', PrettyJSONFormat()), ('application/json', JSONFormat())])
     @tools.expires(secs=-1)
     def get(self, name, web_form=False):
         """
@@ -207,7 +203,7 @@ class WorkloadSplitting(RESTEntity):
         except Exception:
             raise cherrypy.HTTPError(404, "Cannot find workload: %s" % name)
 
-        splittingDict = helper.listJobSplittingParametersByTask(performance = False)
+        splittingDict = helper.listJobSplittingParametersByTask(performance=False)
         taskNames = sorted(splittingDict.keys())
         splitInfo = []
         for taskName in taskNames:
@@ -220,7 +216,7 @@ class WorkloadSplitting(RESTEntity):
 
         return splitInfo
 
-    @restcall(formats = [('application/json', JSONFormat())])
+    @restcall(formats=[('application/json', JSONFormat())])
     @tools.expires(secs=-1)
     def post(self, name):
         """

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -1084,10 +1084,9 @@ class WMWorkloadHelper(PersistencyHelper):
                     and stepHelper.getSkipBadFiles():
                 stepHelper.setSkipBadFiles(False)
 
-            if taskHelper.isTopOfTree() and stepHelper.stepType() == "CMSSW" \
-                    and taskHelper.taskType() == "Production":
-                stepHelper.setEventsPerLumi(splitArgs.get("events_per_lumi",
-                                                          None))
+            if taskHelper.isTopOfTree() and taskHelper.taskType() == "Production" and stepName == "cmsRun1":
+                # set it only for the first cmsRun in multi-steps tasks
+                stepHelper.setEventsPerLumi(splitArgs.get("events_per_lumi", None))
         return
 
     def listJobSplittingParametersByTask(self, initialTask=None, performance=True):


### PR DESCRIPTION
Fixes #8025 

In addition to that, I added a code which raises an exception if the splitting arguments provided are incorrect (including its data type). Also removed the "include_parents" from the splitting API, so it's something defined during creation-only.