### PR TITLE
'long' fix applied

### DIFF
--- a/src/python/WMCore/Configuration.py
+++ b/src/python/WMCore/Configuration.py
@@ -22,7 +22,6 @@ _SimpleTypes = [
     float,
     basestring,  # For py2/py3 compatibility, don't let futurize remove PY3 Remove when python 3 transition complete
     str,
-    long,  # PY3: Not needed in python3, will be converted to duplicate int
     type(None),
     int,
 ]

--- a/src/python/WMCore/ReqMgr/Web/utils.py
+++ b/src/python/WMCore/ReqMgr/Web/utils.py
@@ -37,8 +37,7 @@ def quote(data):
         res = data
     elif  isinstance(data, list):
         res = data
-    elif  isinstance(data, long) or isinstance(data, int) or\
-          isinstance(data, float):
+    elif  isinstance(data, int) or isinstance(data, float):
         res = data
     else:
         try:

--- a/src/python/WMCore/Services/DBS/DBSWriterObjects.py
+++ b/src/python/WMCore/Services/DBS/DBSWriterObjects.py
@@ -292,7 +292,7 @@ def createDBSFiles(fjrFileInfo, jobType = None, apiRef = None):
             for runinfo in fjrFileInfo.runs:
 
                 run = DbsRun(
-                    RunNumber = long(runinfo),
+                    RunNumber = int(runinfo),
                     NumberOfEvents = 0,
                     NumberOfLumiSections = 0,
                     TotalLuminosity = 0,
@@ -310,12 +310,12 @@ def createDBSFiles(fjrFileInfo, jobType = None, apiRef = None):
         for lumiinfo in fjrFileInfo.getLumiSections():
 
             lumi = DbsLumiSection(
-                LumiSectionNumber = long(lumiinfo['LumiSectionNumber']),
+                LumiSectionNumber = int(lumiinfo['LumiSectionNumber']),
                 StartEventNumber = 0,
                 EndEventNumber = 0,
                 LumiStartTime = 0,
                 LumiEndTime = 0,
-                RunNumber = long(lumiinfo['RunNumber']),
+                RunNumber = int(lumiinfo['RunNumber']),
                 )
 
             # Isnt needed, causes monster slowdown

--- a/src/python/WMCore/WMBS/Job.py
+++ b/src/python/WMCore/WMBS/Job.py
@@ -410,7 +410,7 @@ class Job(WMBSBase, WMJob):
         # Transfer all simple keys
         for key in self.keys():
             keyType = type(self.get(key))
-            if keyType in [str, long, int, float]:
+            if keyType in [str, int, float]:
                 job[key] = self[key]
 
         for file in self['input_files']:

--- a/src/python/WMCore/WMBS/MySQL/Jobs/GetTask.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/GetTask.py
@@ -45,7 +45,7 @@ class GetTask(DBFormatter):
             binds = []
             for ID in jobID:
                 binds.append({'jobid': int(ID)})
-        elif isinstance(jobID, (int, long)):
+        elif isinstance(jobID, (int)):
             binds = {'jobid': int(jobID)}
         else:
             logging.error('Incompatible jobid in GetTask')

--- a/src/python/WMCore/Wrappers/JsonWrapper/JSONThunker.py
+++ b/src/python/WMCore/Wrappers/JsonWrapper/JSONThunker.py
@@ -41,7 +41,6 @@ class JSONThunker(object):
                                  bool,
                                  int,
                                  float,
-                                 long,
                                  complex,
                                  str,
                                  bytes,

--- a/test/python/WMComponent_t/DBS3Buffer_t/DBSBufferFile_t.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/DBSBufferFile_t.py
@@ -244,18 +244,18 @@ class DBSBufferFileTest(unittest.TestCase):
         assert testFileA == testFileC, \
             "ERROR: File load by ID didn't work"
 
-        assert isinstance(testFileB["id"], int) or isinstance(testFileB["id"], long), \
+        assert isinstance(testFileB["id"], int) \
             "ERROR: File id is not an integer type."
-        assert isinstance(testFileB["size"], int) or isinstance(testFileB["size"], long), \
+        assert isinstance(testFileB["size"], int) or \
             "ERROR: File size is not an integer type."
-        assert isinstance(testFileB["events"], int) or isinstance(testFileB["events"], long), \
+        assert isinstance(testFileB["events"], int) or \
             "ERROR: File events is not an integer type."
 
-        assert isinstance(testFileC["id"], int) or isinstance(testFileC["id"], long), \
+        assert isinstance(testFileC["id"], int) or \
             "ERROR: File id is not an integer type."
-        assert isinstance(testFileC["size"], int) or isinstance(testFileC["size"], long), \
+        assert isinstance(testFileC["size"], int) or \
             "ERROR: File size is not an integer type."
-        assert isinstance(testFileC["events"], int) or isinstance(testFileC["events"], long), \
+        assert isinstance(testFileC["events"], int) or \
             "ERROR: File events is not an integer type."
 
         testFileA.delete()

--- a/test/python/WMCore_t/JobStateMachine_t/ChangeState_t.py
+++ b/test/python/WMCore_t/JobStateMachine_t/ChangeState_t.py
@@ -140,8 +140,7 @@ class TestChangeState(unittest.TestCase):
         testJobADoc = change.jobsdatabase.document(testJobA["couch_record"])
 
         for transition in testJobADoc["states"].itervalues():
-            self.assertTrue(isinstance(transition["timestamp"], int) or 
-                            isinstance(transition["timestamp"], long))
+            self.assertTrue(isinstance(transition["timestamp"], int))
 
         self.assertEqual(testJobADoc["jobid"] , testJobA["id"], "Error: ID parameter is incorrect.")
         assert testJobADoc["name"] == testJobA["name"], \


### PR DESCRIPTION
Strips the `L` prefix on long literals and renames `long` to `int`.