### PR TITLE
Fix raw_input

### DIFF
--- a/bin/wmstats-request-status-change.py
+++ b/bin/wmstats-request-status-change.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
         print("new status needs to be set")
         sys.exit(1)
 
-    answer = raw_input("%s change to %s in wmstats db (yes, no)?" % (options.request, options.newstatus))
+    answer = input("%s change to %s in wmstats db (yes, no)?" % (options.request, options.newstatus))
     if not answer.lower() == "yes":
         print("Canceled")
         sys.exit(1)


### PR DESCRIPTION
The input() function was fixed in Python 3 so that it always stores the user inputs as str objects. In order to avoid the dangerous behavior in Python 2 to read in other types than strings, we have to use raw_input() instead. 
@vkuznet 