### PR TITLE
Fix services logging for TagCollector and ReqMgrAuxDB

### DIFF
--- a/src/python/WMCore/REST/CherryPyPeriodicTask.py
+++ b/src/python/WMCore/REST/CherryPyPeriodicTask.py
@@ -35,7 +35,7 @@ class CherryPyPeriodicTask(object):
         if hasattr(config, "central_logdb_url"):
             # default set up for logDB config section need to contain propervalues
             from WMCore.Services.LogDB.LogDB import LogDB
-            self.logDB = LogDB(config.central_logdb_url, config.log_reporter,
+            self.logDB = LogDB(config.central_logdb_url, config.log_reporter, logger=self.logger,
                                thread_name=config.object.rsplit(".", 1)[-1])
         else:
             self.logDB = None

--- a/src/python/WMCore/ReqMgr/CherryPyThreads/AuxCacheUpdateTasks.py
+++ b/src/python/WMCore/ReqMgr/CherryPyThreads/AuxCacheUpdateTasks.py
@@ -1,7 +1,6 @@
-'''
+"""
 Created on May 19, 2015
-
-'''
+"""
 
 from __future__ import (division, print_function)
 
@@ -16,7 +15,7 @@ class AuxCacheUpdateTasks(CherryPyPeriodicTask):
     def __init__(self, rest, config):
 
         super(AuxCacheUpdateTasks, self).__init__(config)
-        self.reqmgrAux = ReqMgrAux(config.reqmgr2_url)
+        self.reqmgrAux = ReqMgrAux(config.reqmgr2_url, logger=self.logger)
 
     def setConcurrentTasks(self, config):
         """
@@ -28,5 +27,5 @@ class AuxCacheUpdateTasks(CherryPyPeriodicTask):
         """
         gather active data statistics
         """
-
         self.reqmgrAux.populateCMSSWVersion(config.tagcollect_url, **config.tagcollect_args)
+        self.logger.info("Updated CMSSW versions in the auxiliar db")

--- a/src/python/WMCore/ReqMgr/CherryPyThreads/StatusChangeTasks.py
+++ b/src/python/WMCore/ReqMgr/CherryPyThreads/StatusChangeTasks.py
@@ -118,9 +118,9 @@ class StatusChangeTasks(CherryPyPeriodicTask):
         gather active data statistics
         """
 
-        reqmgrSvc = ReqMgr(config.reqmgr2_url)
+        reqmgrSvc = ReqMgr(config.reqmgr2_url, logger=self.logger)
         gqService = WorkQueue(config.workqueue_url)
-        wmstatsSvc = WMStatsServer(config.wmstats_url)
+        wmstatsSvc = WMStatsServer(config.wmstats_url, logger=self.logger)
 
         self.logger.info("Getting GQ data for status check")
         wfStatusDict = gqService.getWorkflowStatusFromWQE()

--- a/src/python/WMCore/Services/PhEDEx/PhEDEx.py
+++ b/src/python/WMCore/Services/PhEDEx/PhEDEx.py
@@ -13,21 +13,20 @@ class PhEDEx(Service):
     https://cmsweb.cern.ch/phedex/datasvc/doc
     """
 
-    def __init__(self, dict=None, responseType="json", secure=True):
+    def __init__(self, httpDict=None, responseType="json", logger=None):
         """
         responseType will be either xml or json
         """
-        if not dict:
-            dict = {}
+        httpDict = httpDict or {}
         self.responseType = responseType.lower()
 
-        dict["timeout"] = 300
+        httpDict['logger'] = logger if logger else logging.getLogger()
+        httpDict["timeout"] = 300
+        if 'endpoint' not in httpDict:
+            httpDict['endpoint'] = "https://cmsweb.cern.ch/phedex/datasvc/%s/prod/" % self.responseType
+        httpDict.setdefault('cacheduration', 0)
 
-        if 'endpoint' not in dict:
-            dict['endpoint'] = "https://cmsweb.cern.ch/phedex/datasvc/%s/prod/" % self.responseType
-
-        dict.setdefault('cacheduration', 0)
-        Service.__init__(self, dict)
+        Service.__init__(self, httpDict)
 
     def _getResult(self, callname, clearCache=False,
                    args=None, verb="POST"):

--- a/src/python/WMCore/Services/ReqMgr/ReqMgr.py
+++ b/src/python/WMCore/Services/ReqMgr/ReqMgr.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from WMCore.Services.Service import Service
 
@@ -9,7 +10,7 @@ class ReqMgr(Service):
 
     """
 
-    def __init__(self, url, header=None):
+    def __init__(self, url, header=None, logger=None):
         """
         responseType will be either xml or json
         """
@@ -18,6 +19,7 @@ class ReqMgr(Service):
         header = header or {}
         # url is end point
         httpDict['endpoint'] = "%s/data" % url
+        httpDict['logger'] = logger if logger else logging.getLogger()
 
         # cherrypy converts request.body to params when content type is set
         # application/x-www-form-urlencodeds

--- a/src/python/WMCore/Services/ReqMgrAux/ReqMgrAux.py
+++ b/src/python/WMCore/Services/ReqMgrAux/ReqMgrAux.py
@@ -1,6 +1,7 @@
 from __future__ import division, print_function
 
 import json
+import logging
 
 from Utils.Utilities import diskUse
 from WMCore.Services.Service import Service
@@ -12,7 +13,7 @@ class ReqMgrAux(Service):
 
     """
 
-    def __init__(self, url, header=None):
+    def __init__(self, url, header=None, logger=None):
         """
         responseType will be either xml or json
         """
@@ -21,6 +22,7 @@ class ReqMgrAux(Service):
         header = header or {}
         # url is end point
         httpDict['endpoint'] = "%s/data" % url
+        httpDict['logger'] = logger if logger else logging.getLogger()
 
         # cherrypy converts request.body to params when content type is set
         # application/x-www-form-urlencodeds

--- a/src/python/WMCore/Services/SiteDB/SiteDBAPI.py
+++ b/src/python/WMCore/Services/SiteDB/SiteDBAPI.py
@@ -8,6 +8,7 @@ API for retrieving information from SiteDB
 from __future__ import print_function
 from __future__ import division
 import json
+import logging
 from WMCore.Services.Service import Service
 
 def unflattenJSON(data):
@@ -29,9 +30,11 @@ class SiteDBAPI(Service):
     Class to define just the data interaction layer with SiteDB
     """
 
-    def __init__(self, config={}):
+    def __init__(self, config={}, logger=None):
         config = dict(config)
         config['endpoint'] = "https://cmsweb.cern.ch/sitedb/data/prod/"
+        config['logger'] = logger if logger else logging.getLogger()
+
         Service.__init__(self, config)
 
     def getJSON(self, callname, filename='result.json', clearCache=False, verb='GET', data={}):

--- a/src/python/WMCore/Services/TagCollector/TagCollector.py
+++ b/src/python/WMCore/Services/TagCollector/TagCollector.py
@@ -1,5 +1,7 @@
 from __future__ import (division, print_function)
 
+import logging
+
 from collections import defaultdict
 from WMCore.Services.Service import Service
 from WMCore.Services.TagCollector.XMLUtils import xml_parser
@@ -25,8 +27,8 @@ class TagCollector(Service):
         params["timeout"] = 300
         params['endpoint'] = url or defaultURL
         params.setdefault('cacheduration', 3600)
-        if logger:
-            params["logger"] = logger
+        params['logger'] = logger if logger else logging.getLogger()
+
         Service.__init__(self, params)
 
     def _getResult(self, callname="", clearCache=False,

--- a/src/python/WMCore/Services/WMStatsServer/WMStatsServer.py
+++ b/src/python/WMCore/Services/WMStatsServer/WMStatsServer.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from WMCore.Services.Service import Service
 
@@ -9,7 +10,7 @@ class WMStatsServer(Service):
 
     """
 
-    def __init__(self, url, header=None):
+    def __init__(self, url, header=None, logger=None):
         """
         responseType will be either xml or json
         """
@@ -18,6 +19,7 @@ class WMStatsServer(Service):
         header = header or {}
         # url is end point
         httpDict['endpoint'] = "%s/data" % url
+        httpDict['logger'] = logger if logger else logging.getLogger()
 
         # cherrypy converts request.body to params when content type is set
         # application/x-www-form-urlencodeds

--- a/src/python/WMCore/WMLogging.py
+++ b/src/python/WMCore/WMLogging.py
@@ -4,7 +4,7 @@ _WMLogging_
 
 Logging facilities used in WMCore.
 """
-
+import time
 import logging
 from logging.handlers import HTTPHandler, RotatingFileHandler, TimedRotatingFileHandler
 
@@ -37,13 +37,51 @@ def getTimeRotatingLogger(name, logFile, duration = 'midnight'):
     """ Set the logger for time based lotaing.
     """
     logger = logging.getLogger(name)
-    handler = TimedRotatingFileHandler(logFile, duration, backupCount = 10)
+    if duration == 'midnight':
+        handler = MyTimedRotatingFileHandler(logFile, duration, backupCount = 10)
+    else:
+        handler = TimedRotatingFileHandler(logFile, duration, backupCount = 10)
     formatter = logging.Formatter("%(asctime)s:%(levelname)s:%(module)s:%(message)s")
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     logger.setLevel(logging.INFO)
 
     return logger
+
+
+class MyTimedRotatingFileHandler(TimedRotatingFileHandler):
+    """
+    _MyTimedRotatingFileHandler_
+
+    Overwrite the standard filename functionality from
+    logging.handlers.MyTimedRotatingFileHandler
+    such that it mimics the same behaviour as rotatelogs tool.
+
+    Source code from:
+    https://stackoverflow.com/questions/338450/timedrotatingfilehandler-changing-file-name
+    """
+    def __init__(self, logName, interval, backupCount):
+        super(MyTimedRotatingFileHandler, self).__init__(logName, when=interval,
+                                                         backupCount=backupCount)
+
+    def doRollover(self):
+        """
+        _doRollover_
+
+        Rotate the log file and add the date between the log name
+        and its extension, e.g.:
+        reqmgr2.log becomes reqmgr2-20170815.log
+        """
+        self.stream.close()
+        # replace yesterday's date by today
+        yesterdayStr = time.strftime("%Y%m%d", time.localtime(time.time() - 7200))
+        self.baseFilename = self.baseFilename.replace(yesterdayStr, time.strftime("%Y%m%d"))
+        if self.encoding:
+            self.stream = codecs.open(self.baseFilename, 'w', self.encoding)
+        else:
+            self.stream = open(self.baseFilename, 'w')
+        self.rolloverAt = self.rolloverAt + self.interval
+
 
 class CouchHandler(logging.handlers.HTTPHandler):
     def __init__(self, host, database):


### PR DESCRIPTION
Fixes #8038
This fix the problem reported by Lina where ReqMgr2 services are writing to two different log files:
* usual and correct /data/srv/logs/reqmgr2/*
* and forbidden directory /data/srv/state/reqmgr2/*

In addition to that, it also fixes a problem with the cherrypy log rotation that was using an incorrect logging name.
