### PR TITLE
'itertools' fix applied

### DIFF
--- a/src/python/WMCore/DataStructs/LumiList.py
+++ b/src/python/WMCore/DataStructs/LumiList.py
@@ -120,7 +120,7 @@ class LumiList(object):
             if len(runs) <= 0 or len(lumis) != len(runs):
                 raise RuntimeError('Improper format for wmagentFormat. # of lumi lists must match # of runs')
 
-            for run, lumiString in itertools.izip(runs, lumis):
+            for run, lumiString in zip(runs, lumis):
                 runLumis = lumiString.split(',')
                 if not str(run) in self.compactList:
                     self.compactList[str(run)] = []

--- a/test/python/Utils_t/IteratorTools_t.py
+++ b/test/python/Utils_t/IteratorTools_t.py
@@ -24,7 +24,7 @@ class IteratorToolsTest(unittest.TestCase):
         listChunks = [i for i in grouper(list(range(0, 7)), 3)]  # Want list(range) for python 3
         iterChunks = [i for i in grouper(xrange(0, 7), 3)]  # xrange becomes range in python 3
 
-        for a, b in itertools.izip_longest(listChunks, iterChunks):
+        for a, b in itertools.zip_longest(listChunks, iterChunks):
             self.assertEqual(a, b)
 
         self.assertEqual(listChunks[-1], [6])


### PR DESCRIPTION
In Python 2 the itertools module define variants of the global zip(), map(), and filter() functions that returned iterators instead of lists. In Python 3, those global functions return iterators, so those functions in the itertools module have been eliminated. @vkuznet 