### PR TITLE
'cmp' fix applied

### DIFF
--- a/src/python/WMCore/DataStructs/Fileset.py
+++ b/src/python/WMCore/DataStructs/Fileset.py
@@ -6,6 +6,7 @@ Data object that contains a set of files
 
 """
 from __future__ import print_function
+from operator import itemgetter
 __all__ = []
 
 
@@ -70,7 +71,7 @@ class Fileset(WMObject):
             files = list(self.getFiles(type='set'))
 
             try:
-                files.sort(lambda x, y: cmp(x['lfn'], y['lfn']))
+        	files.sort(key=itemgetter('lfn'))
             except Exception as e:
                 print('Problem with listFiles for fileset:', self.name)
                 print(files.pop())

--- a/src/python/WMCore/DataStructs/Fileset.py
+++ b/src/python/WMCore/DataStructs/Fileset.py
@@ -5,26 +5,26 @@ _Fileset_
 Data object that contains a set of files
 
 """
+
 from __future__ import print_function
 from operator import itemgetter
+from WMCore.DataStructs.WMObject import WMObject
 __all__ = []
 
-
-from WMCore.DataStructs.WMObject import WMObject
 
 class Fileset(WMObject):
     """
     _Fileset_
     Data object that contains a set of files
     """
-    def __init__(self, name=None, files = None):
+    def __init__(self, name=None, files=None):
         """
         Assume input files are new
         """
         self.name = name
         self.files = set()
 
-        if files == None:
+        if files is None:
             self.newfiles = set()
         else:
             self.newfiles = files
@@ -71,7 +71,7 @@ class Fileset(WMObject):
             files = list(self.getFiles(type='set'))
 
             try:
-        	files.sort(key=itemgetter('lfn'))
+                files.sort(key=itemgetter('lfn'))
             except Exception as e:
                 print('Problem with listFiles for fileset:', self.name)
                 print(files.pop())
@@ -125,7 +125,6 @@ class Fileset(WMObject):
         representing whether or not the fileset is open.
         """
         self.open = isOpen
-
 
     def __str__(self):
         """


### PR DESCRIPTION
`past.builtins.cmp(x, y) → integer`

> Return negative if x<y, zero if x==y, positive if x>y.

[[source]](http://python-future.org/_modules/past/builtins/misc.html#cmp)

-----------------------------------------------------------------------------

> ### Python 2 only:
> `assert cmp('a', 'b') < 0 and cmp('b', 'a') > 0 and cmp('c', 'c') == 0`

> ### Python 2 and 3: alternative 1
> `from past.builtins import cmp`
> `assert cmp('a', 'b') < 0 and cmp('b', 'a') > 0 and cmp('c', 'c') == 0`

> ### Python 2 and 3: alternative 2
> `cmp = lambda(x, y): (x > y) - (x < y)`
> `assert cmp('a', 'b') < 0 and cmp('b', 'a') > 0 and cmp('c', 'c') == 0`

