### PR TITLE
'future_builtins' fix applied

### DIFF
--- a/bin/combineMinifyWMStats.py
+++ b/bin/combineMinifyWMStats.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import str
 from glob import iglob
 import shutil
 import os

--- a/bin/couch-thrash.py
+++ b/bin/couch-thrash.py
@@ -4,6 +4,7 @@ _couch-trash_
 
 """
 
+from builtins import range
 import os
 import random
 import time

--- a/bin/wmstats-request-status-change.py
+++ b/bin/wmstats-request-status-change.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from builtins import input
 import os
 import sys
 from optparse import OptionParser

--- a/etc/harvestingInjector.py
+++ b/etc/harvestingInjector.py
@@ -5,6 +5,7 @@ _harvestingInjector_
 """
 from __future__ import print_function
 
+from builtins import str
 import os
 import sys
 import threading

--- a/setup_test.py
+++ b/setup_test.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+from builtins import str
 import atexit
 import hashlib
 import os

--- a/src/html/WorkQueue/examples/PlotFairyBarChart.py
+++ b/src/html/WorkQueue/examples/PlotFairyBarChart.py
@@ -10,6 +10,7 @@ from __future__ import print_function
 #     -> this prints out html file, normally resulting html snippet will be used ...
 
 
+from builtins import range
 import json
 import random
 import urllib

--- a/src/html/WorkQueue/examples/PlotFairyLineChart.py
+++ b/src/html/WorkQueue/examples/PlotFairyLineChart.py
@@ -10,6 +10,7 @@ from __future__ import print_function
 #     -> this prints out html file, normally resulting html snippet will be used ...
 
 
+from builtins import range
 import json
 import random
 import urllib

--- a/src/python/PSetTweaks/PSetTweak.py
+++ b/src/python/PSetTweaks/PSetTweak.py
@@ -7,6 +7,8 @@ independent python structure
 
 """
 
+from builtins import range
+from builtins import map
 import StringIO
 import imp
 import inspect

--- a/src/python/PSetTweaks/WMTweak.py
+++ b/src/python/PSetTweaks/WMTweak.py
@@ -8,6 +8,9 @@ process/config but does not depend on any CMSSW libraries. It needs to stay like
 
 """
 from __future__ import print_function
+from builtins import range
+from builtins import map
+from builtins import str
 import logging
 import pickle
 import traceback

--- a/src/python/Utils/IteratorTools.py
+++ b/src/python/Utils/IteratorTools.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 from __future__ import division, print_function
 
+from builtins import str
+from builtins import map
 import collections
 from itertools import islice
 from itertools import chain

--- a/src/python/Utils/Utilities.py
+++ b/src/python/Utils/Utilities.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 from __future__ import division, print_function
+from builtins import str
 import time
 import subprocess
 

--- a/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
+++ b/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
@@ -5,6 +5,7 @@ Perform general agent monitoring, like:
  3. Couchdb replication status (and status of its database)
  4. Disk usage status
 """
+from builtins import str
 __all__ = []
 
 import threading

--- a/src/python/WMComponent/AgentStatusWatcher/DrainStatusPoller.py
+++ b/src/python/WMComponent/AgentStatusWatcher/DrainStatusPoller.py
@@ -5,6 +5,7 @@ to be shutdown and a new version be put in place.
 """
 from __future__ import division
 
+from builtins import str
 __all__ = []
 
 import logging

--- a/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
+++ b/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
@@ -1,6 +1,7 @@
 """
 Perform cleanup actions
 """
+from builtins import str
 __all__ = []
 
 import urllib2

--- a/src/python/WMComponent/AlertGenerator/Pollers/Agent.py
+++ b/src/python/WMComponent/AlertGenerator/Pollers/Agent.py
@@ -12,6 +12,7 @@ of agent's components, etc.
 # be ensured automatically
 
 
+from builtins import zip
 import os
 import logging
 from xml.etree.ElementTree import ElementTree

--- a/src/python/WMComponent/AlertGenerator/Pollers/Base.py
+++ b/src/python/WMComponent/AlertGenerator/Pollers/Base.py
@@ -4,6 +4,7 @@ within the Alert messaging framework.
 
 """
 
+from builtins import zip
 import sys
 import time
 import logging

--- a/src/python/WMComponent/AlertGenerator/Pollers/Couch.py
+++ b/src/python/WMComponent/AlertGenerator/Pollers/Couch.py
@@ -3,6 +3,8 @@ Module for all CouchDb related polling.
 
 """
 
+from builtins import zip
+from builtins import str
 import os
 import logging
 

--- a/src/python/WMComponent/AlertGenerator/Pollers/System.py
+++ b/src/python/WMComponent/AlertGenerator/Pollers/System.py
@@ -5,6 +5,7 @@ utilisation by particular processes, etc.
 
 """
 
+from builtins import zip
 import logging
 import subprocess
 

--- a/src/python/WMComponent/AnalyticsDataCollector/AnalyticsPoller.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/AnalyticsPoller.py
@@ -1,6 +1,7 @@
 """
 Perform cleanup actions
 """
+from builtins import str
 __all__ = []
 
 

--- a/src/python/WMComponent/AnalyticsDataCollector/DataCollectAPI.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/DataCollectAPI.py
@@ -2,6 +2,7 @@
 Provide functions to collect data and upload data
 """
 
+from builtins import str
 import os
 import time
 import logging

--- a/src/python/WMComponent/AnalyticsDataCollector/Plugins/Tier0Plugin.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/Plugins/Tier0Plugin.py
@@ -10,6 +10,8 @@ Created on Nov 2, 2012
 @author: dballest
 """
 
+from builtins import filter
+from builtins import str
 import threading
 import traceback
 import re

--- a/src/python/WMComponent/ArchiveDataReporter/ArchiveDataPoller.py
+++ b/src/python/WMComponent/ArchiveDataReporter/ArchiveDataPoller.py
@@ -2,6 +2,7 @@
 ArchiveDataPoller
 """
 
+from builtins import str
 from __future__ import (division, print_function)
 import logging
 import traceback

--- a/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
@@ -25,6 +25,8 @@ add them, and then add the files.  This is why everything is
 so convoluted.
 """
 
+from builtins import range
+from builtins import str
 import time
 import threading
 import logging

--- a/src/python/WMComponent/ErrorHandler/ErrorHandlerPoller.py
+++ b/src/python/WMComponent/ErrorHandler/ErrorHandlerPoller.py
@@ -22,6 +22,7 @@ immediately to the 'created' state, skipping cooloff.  It defaults to [].
 
 Note that exitCodesNoRetry has precedence over passExitCodes.
 """
+from builtins import str
 import logging
 import os.path
 import threading

--- a/src/python/WMComponent/JobAccountant/AccountantWorker.py
+++ b/src/python/WMComponent/JobAccountant/AccountantWorker.py
@@ -11,6 +11,7 @@ _AccountantWorker_
 Used by the JobAccountant to do the actual processing of completed jobs.
 """
 
+from builtins import str
 import collections
 import gc
 import logging

--- a/src/python/WMComponent/JobAccountant/JobAccountantPoller.py
+++ b/src/python/WMComponent/JobAccountant/JobAccountantPoller.py
@@ -5,6 +5,7 @@ _JobAccountantPoller_
 Poll WMBS for complete jobs and process their framework job reports.
 """
 
+from builtins import str
 import threading
 import logging
 

--- a/src/python/WMComponent/JobArchiver/JobArchiverPoller.py
+++ b/src/python/WMComponent/JobArchiver/JobArchiverPoller.py
@@ -2,6 +2,7 @@
 """
 The actual jobArchiver algorithm
 """
+from builtins import str
 __all__ = []
 
 import threading

--- a/src/python/WMComponent/JobCreator/CreateWorkArea.py
+++ b/src/python/WMComponent/JobCreator/CreateWorkArea.py
@@ -11,6 +11,7 @@ Class(es) that create the work area for each jobGroup
 Used in JobCreator
 """
 
+from builtins import str
 import os
 import os.path
 import threading

--- a/src/python/WMComponent/JobCreator/JobCreatorPoller.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorPoller.py
@@ -2,6 +2,9 @@
 """
 The JobCreator Poller for the JSM
 """
+from builtins import filter
+from builtins import str
+from builtins import next
 __all__ = []
 
 

--- a/src/python/WMComponent/JobCreator/JobCreatorWorker.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorWorker.py
@@ -27,6 +27,7 @@ Note:  Jobs are split up by subscription, so having
 one long subscription can make the JobCreatorWorker
 wait for excessively long amounts of time while it runs.
 """
+from builtins import next
 __all__ = []
 
 

--- a/src/python/WMComponent/JobStatusLite/JobStatusLite.py
+++ b/src/python/WMComponent/JobStatusLite/JobStatusLite.py
@@ -10,6 +10,7 @@ from __future__ import print_function
 
 
 
+from builtins import str
 import logging
 import threading
 

--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -8,6 +8,8 @@ _JobSubmitterPoller_t_
 Submit jobs for execution.
 """
 
+from builtins import range
+from builtins import str
 import logging
 import threading
 import os.path

--- a/src/python/WMComponent/JobTracker/JobTrackerPoller.py
+++ b/src/python/WMComponent/JobTracker/JobTrackerPoller.py
@@ -2,6 +2,7 @@
 """
 The actual jobTracker algorithm
 """
+from builtins import str
 __all__ = []
 
 import threading

--- a/src/python/WMComponent/JobUpdater/JobUpdaterPoller.py
+++ b/src/python/WMComponent/JobUpdater/JobUpdaterPoller.py
@@ -9,6 +9,7 @@ Created on Apr 16, 2013
 @author: dballest
 """
 
+from builtins import str
 import logging
 import threading
 

--- a/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
+++ b/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
@@ -41,6 +41,7 @@ deleted from the site it was originally injected at.
 
 """
 
+from builtins import str
 import threading
 import logging
 import traceback

--- a/src/python/WMComponent/RetryManager/RetryManagerPoller.py
+++ b/src/python/WMComponent/RetryManager/RetryManagerPoller.py
@@ -49,6 +49,7 @@ component won't crash but it won't do anything at all. All
 jobs that get in cooloff would stay there forever.
 Any parameter can be skipped and the component will use internal defaults.
 """
+from builtins import str
 __all__ = []
 
 

--- a/src/python/WMComponent/TaskArchiver/CleanCouchPoller.py
+++ b/src/python/WMComponent/TaskArchiver/CleanCouchPoller.py
@@ -1,6 +1,8 @@
 """
 Perform cleanup actions
 """
+from builtins import range
+from builtins import str
 import httplib
 import json
 import logging

--- a/src/python/WMComponent/TaskArchiver/TaskArchiverPoller.py
+++ b/src/python/WMComponent/TaskArchiver/TaskArchiverPoller.py
@@ -23,6 +23,7 @@ histogramLimit: Limit in terms of number of standard deviations from the
   average at which you cut the histogram off.  All points outside of that
   go into overflow and underflow.
 """
+from builtins import str
 __all__ = []
 import logging
 import threading

--- a/src/python/WMComponent/WorkQueueManager/WorkQueueManagerCleaner.py
+++ b/src/python/WMComponent/WorkQueueManager/WorkQueueManagerCleaner.py
@@ -2,6 +2,7 @@
 """
 Perform cleanup actions
 """
+from builtins import str
 __all__ = []
 
 

--- a/src/python/WMComponent/WorkQueueManager/WorkQueueManagerLocationPoller.py
+++ b/src/python/WMComponent/WorkQueueManager/WorkQueueManagerLocationPoller.py
@@ -2,6 +2,7 @@
 """
 updateLocations poller
 """
+from builtins import str
 __all__ = []
 
 

--- a/src/python/WMComponent/WorkQueueManager/WorkQueueManagerReqMgrPoller.py
+++ b/src/python/WMComponent/WorkQueueManager/WorkQueueManagerReqMgrPoller.py
@@ -2,6 +2,7 @@
 """
 Poll request manager for new work
 """
+from builtins import str
 __all__ = []
 
 

--- a/src/python/WMComponent/WorkQueueManager/WorkQueueManagerWMBSFileFeeder.py
+++ b/src/python/WMComponent/WorkQueueManager/WorkQueueManagerWMBSFileFeeder.py
@@ -2,6 +2,7 @@
 """
 pullWork poller
 """
+from builtins import str
 __all__ = []
 
 

--- a/src/python/WMComponent/WorkQueueManager/WorkQueueManagerWorkPoller.py
+++ b/src/python/WMComponent/WorkQueueManager/WorkQueueManagerWorkPoller.py
@@ -5,6 +5,7 @@ _WorkQueueManagerPoller_
 Pull work out of the work queue.
 """
 
+from builtins import str
 import time
 import random
 import traceback

--- a/src/python/WMCore/ACDC/CouchFileset.py
+++ b/src/python/WMCore/ACDC/CouchFileset.py
@@ -6,6 +6,7 @@ CouchFileset.py
 Created by Dave Evans on 2010-03-19.
 Copyright (c) 2010 Fermilab. All rights reserved.
 """
+from builtins import str
 import time
 
 from WMCore.ACDC.Fileset import Fileset

--- a/src/python/WMCore/ACDC/DataCollectionService.py
+++ b/src/python/WMCore/ACDC/DataCollectionService.py
@@ -7,6 +7,7 @@ Created by Dave Evans on 2010-07-30.
 Copyright (c) 2010 Fermilab. All rights reserved.
 """
 
+from builtins import str
 import logging
 
 import WMCore.ACDC.CollectionTypes as CollectionTypes

--- a/src/python/WMCore/Agent/BaseHandler.py
+++ b/src/python/WMCore/Agent/BaseHandler.py
@@ -9,6 +9,7 @@ Handlers are mapped to messages in the component.
 
 
 
+from builtins import str
 import logging
 
 

--- a/src/python/WMCore/Agent/Daemon/Create.py
+++ b/src/python/WMCore/Agent/Daemon/Create.py
@@ -20,6 +20,7 @@
       http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/66012
 '''
 from __future__ import print_function
+from builtins import str
 import logging
 from logging.handlers import RotatingFileHandler
 import sys, os, time

--- a/src/python/WMCore/Agent/Daemon/Details.py
+++ b/src/python/WMCore/Agent/Daemon/Details.py
@@ -10,6 +10,8 @@ Also, provides utils to shutdown the daemon process
 """
 from __future__ import print_function
 
+from builtins import range
+from builtins import str
 import os
 import subprocess
 import shutil

--- a/src/python/WMCore/Agent/Database/CouchDB/CouchService.py
+++ b/src/python/WMCore/Agent/Database/CouchDB/CouchService.py
@@ -1,3 +1,4 @@
+from builtins import str
 import WMCore.Database.CouchUtils as CouchUtils
 import traceback
 import logging

--- a/src/python/WMCore/Agent/Flow/Generate.py
+++ b/src/python/WMCore/Agent/Flow/Generate.py
@@ -13,6 +13,7 @@ from __future__ import print_function
 
 
 
+from builtins import str
 import os
 import sys
 try:

--- a/src/python/WMCore/Agent/Harness.py
+++ b/src/python/WMCore/Agent/Harness.py
@@ -25,6 +25,7 @@ from __future__ import print_function
 
 
 
+from builtins import str
 from logging.handlers import RotatingFileHandler
 
 import logging

--- a/src/python/WMCore/Alerts/ZMQ/Processor.py
+++ b/src/python/WMCore/Alerts/ZMQ/Processor.py
@@ -5,6 +5,7 @@ by a Receiver to process Alert streams sent from Agent components.
 
 """
 
+from builtins import next
 import sys
 import logging
 import traceback

--- a/src/python/WMCore/Algorithms/MathAlgos.py
+++ b/src/python/WMCore/Algorithms/MathAlgos.py
@@ -7,6 +7,8 @@ Simple mathematical tools and tricks that might prove to
 be useful.
 """
 
+from builtins import range
+from builtins import str
 import math
 import decimal
 import logging

--- a/src/python/WMCore/Algorithms/ParseXMLFile.py
+++ b/src/python/WMCore/Algorithms/ParseXMLFile.py
@@ -8,6 +8,8 @@ Used for the expat xml parsers
 
 """
 
+from builtins import next
+from builtins import str
 import os
 import re
 import xml.parsers.expat

--- a/src/python/WMCore/Algorithms/Permissions.py
+++ b/src/python/WMCore/Algorithms/Permissions.py
@@ -5,6 +5,7 @@ be, or more restrictive.
 
 
 
+from builtins import oct
 import os
 import stat
 

--- a/src/python/WMCore/Algorithms/SubprocessAlgos.py
+++ b/src/python/WMCore/Algorithms/SubprocessAlgos.py
@@ -8,6 +8,7 @@ i.e., stand-ins for Linux command line functions
 
 """
 
+from builtins import str
 import os
 import re
 import signal

--- a/src/python/WMCore/Algorithms/TreeSort.py
+++ b/src/python/WMCore/Algorithms/TreeSort.py
@@ -15,6 +15,7 @@ Caveats:
 
 
 
+from builtins import range
 class _SearchOp:
     """
     __SearchOp_

--- a/src/python/WMCore/BossAir/BossAirAPI.py
+++ b/src/python/WMCore/BossAir/BossAirAPI.py
@@ -16,6 +16,7 @@ Interfaces geared toward the outside expect WMBS objects.  Interfaces
 geared toward the inside expect RunJob objects.  Interior interfaces are
 marked by names starting with '_' such as '_listRunning'
 """
+from builtins import str
 import os.path
 import threading
 import logging

--- a/src/python/WMCore/BossAir/Plugins/LsfPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/LsfPlugin.py
@@ -8,6 +8,7 @@ Does not support rerunnable jobs, ie. which are
 automatically requeued by LSF with a different job id
 """
 
+from builtins import str
 import os
 import re
 import errno

--- a/src/python/WMCore/BossAir/Plugins/MockPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/MockPlugin.py
@@ -5,6 +5,8 @@ _BossAirPlugin_
 Base class for BossAir plugins
 """
 
+from builtins import range
+from builtins import str
 import os
 import logging
 from WMCore.BossAir.Plugins.BasePlugin import BasePlugin, BossAirPluginException

--- a/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
@@ -7,6 +7,8 @@ For glide-in use.
 """
 from __future__ import division
 
+from builtins import range
+from builtins import str
 import Queue
 import glob
 import logging

--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -5,6 +5,7 @@ _SimpleCondorPlugin_
 """
 from __future__ import division, print_function
 
+from builtins import str
 import logging
 import os
 import os.path

--- a/src/python/WMCore/BossAir/StatusPoller.py
+++ b/src/python/WMCore/BossAir/StatusPoller.py
@@ -8,6 +8,7 @@ Possible non-production poller prototype for
 JobStatusAir
 """
 
+from builtins import str
 import time
 import logging
 import threading

--- a/src/python/WMCore/Cache/WMConfigCache.py
+++ b/src/python/WMCore/Cache/WMConfigCache.py
@@ -6,6 +6,7 @@ Being in itself a wrapped class around a config cache
 """
 
 
+from builtins import str
 import hashlib
 import logging
 import traceback

--- a/src/python/WMCore/Configuration.py
+++ b/src/python/WMCore/Configuration.py
@@ -8,6 +8,7 @@ Module dealing with Configuration file in python format
 
 """
 
+from builtins import str
 import imp
 import os
 import sys

--- a/src/python/WMCore/Credential/Proxy.py
+++ b/src/python/WMCore/Credential/Proxy.py
@@ -4,6 +4,8 @@ _Proxy_
 Wrap gLite proxy commands.
 """
 
+from builtins import filter
+from builtins import str
 import contextlib
 import copy
 import os

--- a/src/python/WMCore/Credential/SimpleMyProxy.py
+++ b/src/python/WMCore/Credential/SimpleMyProxy.py
@@ -12,6 +12,7 @@
 # Mattia Cinquilli <mcinquil@cern.ch>
 # on 2013/04/14 for integration on CRAB services.
 
+from builtins import str
 import logging
 import socket
 import re

--- a/src/python/WMCore/DataStructs/Fileset.py
+++ b/src/python/WMCore/DataStructs/Fileset.py
@@ -6,6 +6,8 @@ Data object that contains a set of files
 
 """
 from __future__ import print_function
+from builtins import str
+from builtins import map
 __all__ = []
 
 

--- a/src/python/WMCore/DataStructs/Job.py
+++ b/src/python/WMCore/DataStructs/Job.py
@@ -6,6 +6,8 @@ Data object that describes a job
 
 """
 
+from builtins import range
+from builtins import map
 __all__ = []
 
 

--- a/src/python/WMCore/DataStructs/LumiList.py
+++ b/src/python/WMCore/DataStructs/LumiList.py
@@ -13,6 +13,9 @@ This code began life in COMP/CRAB/python/LumiList.py
 """
 
 
+from builtins import range
+from builtins import next
+from builtins import str
 import copy
 import itertools
 import json

--- a/src/python/WMCore/DataStructs/Mask.py
+++ b/src/python/WMCore/DataStructs/Mask.py
@@ -10,6 +10,7 @@ job in two ways:
 
 """
 
+from builtins import range
 from WMCore.DataStructs.Run import Run
 
 class Mask(dict):

--- a/src/python/WMCore/DataStructs/MathStructs/SummaryHistogram.py
+++ b/src/python/WMCore/DataStructs/MathStructs/SummaryHistogram.py
@@ -8,6 +8,7 @@ Created on Nov 16, 2012
 
 @author: dballest
 """
+from builtins import str
 from WMCore.DataStructs.WMObject import WMObject
 
 class SummaryHistogram(WMObject):

--- a/src/python/WMCore/DataStructs/Subscription.py
+++ b/src/python/WMCore/DataStructs/Subscription.py
@@ -5,6 +5,7 @@ _Subscription_
 workflow + fileset = subscription
 """
 
+from builtins import range
 import copy
 
 from WMCore.DataStructs.Pickleable import Pickleable

--- a/src/python/WMCore/DataStructs/Workflow.py
+++ b/src/python/WMCore/DataStructs/Workflow.py
@@ -5,6 +5,7 @@ _Workflow_
 A class that describes some work to be undertaken on some files
 """
 
+from builtins import str
 from WMCore.DataStructs.Pickleable import Pickleable
 
 class Workflow(Pickleable):

--- a/src/python/WMCore/Database/CMSCouch.py
+++ b/src/python/WMCore/Database/CMSCouch.py
@@ -10,6 +10,7 @@ NOT A THREAD SAFE CLASS.
 """
 from __future__ import print_function
 
+from builtins import str
 import time
 import urllib
 import re

--- a/src/python/WMCore/Database/CouchUtils.py
+++ b/src/python/WMCore/Database/CouchUtils.py
@@ -8,6 +8,7 @@ Copyright (c) 2010 Fermilab. All rights reserved.
 """
 from __future__ import print_function
 
+from builtins import str
 import functools
 from httplib import HTTPException
 

--- a/src/python/WMCore/Database/DBCreator.py
+++ b/src/python/WMCore/Database/DBCreator.py
@@ -13,6 +13,7 @@ Base class for formatters that create tables.
 
 
 
+from builtins import str
 from WMCore.Database.DBFormatter import DBFormatter
 from WMCore.WMException import WMException
 from WMCore.WMExceptions import WMEXCEPTION

--- a/src/python/WMCore/Database/DBFormatter.py
+++ b/src/python/WMCore/Database/DBFormatter.py
@@ -8,6 +8,9 @@ interactions.
 
 
 
+from builtins import map
+from builtins import str
+from builtins import zip
 import datetime
 import time
 import types

--- a/src/python/WMCore/Database/ipy_profile_couch.py
+++ b/src/python/WMCore/Database/ipy_profile_couch.py
@@ -9,6 +9,7 @@ from __future__ import print_function
 
 
 
+from builtins import str
 __license__    = "GPL"
 
 __maintainer__ = "Valentin Kuznetsov"

--- a/src/python/WMCore/FwkJobReport/FileInfo.py
+++ b/src/python/WMCore/FwkJobReport/FileInfo.py
@@ -11,6 +11,7 @@ Not in the Framework XML
 from __future__ import print_function
 
 
+from builtins import str
 import os
 import os.path
 import logging

--- a/src/python/WMCore/FwkJobReport/Report.py
+++ b/src/python/WMCore/FwkJobReport/Report.py
@@ -7,6 +7,8 @@ Framework job report object.
 """
 from __future__ import print_function
 
+from builtins import range
+from builtins import str
 import logging
 import math
 import re

--- a/src/python/WMCore/FwkJobReport/ReportEmu.py
+++ b/src/python/WMCore/FwkJobReport/ReportEmu.py
@@ -8,6 +8,7 @@ Class for creating bogus framework job reports.
 
 
 
+from builtins import str
 import os.path
 
 from WMCore.Services.UUIDLib import makeUUID

--- a/src/python/WMCore/GroupUser/CouchObject.py
+++ b/src/python/WMCore/GroupUser/CouchObject.py
@@ -8,6 +8,7 @@ Copyright (c) 2010 Fermilab. All rights reserved.
 """
 from __future__ import print_function
 
+from builtins import str
 import sys
 import os
 import json

--- a/src/python/WMCore/GroupUser/Interface.py
+++ b/src/python/WMCore/GroupUser/Interface.py
@@ -10,6 +10,8 @@ from __future__ import print_function
 
 
 
+from builtins import map
+from builtins import str
 import WMCore.Database.CMSCouch as CMSCouch
 
 class CouchConnectionError(Exception):

--- a/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
+++ b/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
@@ -12,6 +12,7 @@ Created on Sep 25, 2012
 @author: dballest
 """
 
+from builtins import str
 import logging
 import math
 import operator

--- a/src/python/WMCore/JobSplitting/EventAwareLumiByWork.py
+++ b/src/python/WMCore/JobSplitting/EventAwareLumiByWork.py
@@ -13,6 +13,7 @@ class to simplify the code
 
 """
 
+from builtins import str
 from __future__ import (division, print_function)
 
 import logging

--- a/src/python/WMCore/JobSplitting/EventBased.py
+++ b/src/python/WMCore/JobSplitting/EventBased.py
@@ -6,6 +6,7 @@ Event based splitting algorithm that will chop a fileset into
 a set of jobs based on event counts
 """
 
+from builtins import str
 import logging
 import traceback
 from math import ceil

--- a/src/python/WMCore/JobSplitting/Generators/GeneratorFactory.py
+++ b/src/python/WMCore/JobSplitting/Generators/GeneratorFactory.py
@@ -5,6 +5,7 @@ _GeneratorFactory_
 
 """
 
+from builtins import str
 from WMCore.WMFactory import WMFactory
 from WMCore.WMException import WMException
 

--- a/src/python/WMCore/JobSplitting/Generators/GeneratorManager.py
+++ b/src/python/WMCore/JobSplitting/Generators/GeneratorManager.py
@@ -7,6 +7,7 @@ and then apply them to job groups
 
 """
 
+from builtins import map
 from WMCore.JobSplitting.Generators.GeneratorFactory import GeneratorFactory
 
 from WMCore.WMSpec.WMTask import WMTask, WMTaskHelper

--- a/src/python/WMCore/JobSplitting/JobFactory.py
+++ b/src/python/WMCore/JobSplitting/JobFactory.py
@@ -4,6 +4,9 @@ _JobFactory_
 
 """
 
+from builtins import range
+from builtins import map
+from builtins import str
 import logging
 import threading
 

--- a/src/python/WMCore/JobSplitting/LumiBased.py
+++ b/src/python/WMCore/JobSplitting/LumiBased.py
@@ -6,6 +6,7 @@ Lumi based splitting algorithm that will chop a fileset into
 a set of jobs based on lumi sections
 """
 
+from builtins import str
 import logging
 import operator
 import threading

--- a/src/python/WMCore/JobSplitting/RunBased.py
+++ b/src/python/WMCore/JobSplitting/RunBased.py
@@ -13,6 +13,7 @@ If file spans a run will need to create a mask for that file.
 
 
 
+from builtins import range
 from WMCore.JobSplitting.JobFactory import JobFactory
 from WMCore.DataStructs.Fileset import Fileset
 from WMCore.Services.UUIDLib import makeUUID

--- a/src/python/WMCore/JobStateMachine/ChangeState.py
+++ b/src/python/WMCore/JobStateMachine/ChangeState.py
@@ -5,6 +5,7 @@ _ChangeState_
 Propagate a job from one state to another.
 """
 
+from builtins import str
 import time
 import logging
 import traceback

--- a/src/python/WMCore/Lexicon.py
+++ b/src/python/WMCore/Lexicon.py
@@ -7,6 +7,7 @@ to other classes. If a test fails an AssertionError should be raised, and
 handled appropriately by the client methods, on success returns True.
 """
 
+from builtins import str
 import re
 import string
 import urlparse

--- a/src/python/WMCore/ProcessPool/ProcessPool.py
+++ b/src/python/WMCore/ProcessPool/ProcessPool.py
@@ -6,6 +6,8 @@ _ProcessPool_
 """
 from __future__ import print_function
 
+from builtins import range
+from builtins import str
 import zmq
 import subprocess
 import sys

--- a/src/python/WMCore/REST/Auth.py
+++ b/src/python/WMCore/REST/Auth.py
@@ -1,3 +1,4 @@
+from builtins import map
 import cherrypy, hmac, hashlib, logging, re
 
 def user_info_from_headers(key, verbose=False):

--- a/src/python/WMCore/REST/CherryPyPeriodicTask.py
+++ b/src/python/WMCore/REST/CherryPyPeriodicTask.py
@@ -4,6 +4,7 @@ Created on Jul 31, 2014
 @author: sryu
 '''
 from __future__ import print_function, division
+from builtins import str
 import cherrypy
 import traceback
 from WMCore.WMLogging import getTimeRotatingLogger

--- a/src/python/WMCore/REST/Error.py
+++ b/src/python/WMCore/REST/Error.py
@@ -1,3 +1,4 @@
+from builtins import str
 import random, cherrypy
 
 class RESTError(Exception):

--- a/src/python/WMCore/REST/Format.py
+++ b/src/python/WMCore/REST/Format.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+from builtins import str
 import hashlib
 import json
 import types

--- a/src/python/WMCore/REST/Main.py
+++ b/src/python/WMCore/REST/Main.py
@@ -8,6 +8,7 @@ up an appropriately configured CherryPy instance. Views are loaded dynamically
 and can be turned on/off via configuration file."""
 from __future__ import print_function
 
+from builtins import str
 import sys, os, errno, re, os.path, subprocess, socket, time
 import cherrypy, logging, thread, traceback
 import WMCore.REST.Tools

--- a/src/python/WMCore/REST/Server.py
+++ b/src/python/WMCore/REST/Server.py
@@ -1,3 +1,6 @@
+from builtins import map
+from builtins import str
+from builtins import zip
 import cherrypy
 import inspect
 import os

--- a/src/python/WMCore/REST/Validation.py
+++ b/src/python/WMCore/REST/Validation.py
@@ -1,3 +1,5 @@
+from builtins import map
+from builtins import str
 from WMCore.REST.Error import *
 import math, re
 import numbers

--- a/src/python/WMCore/ReqMgr/CherryPyThreads/CouchDBCleanup.py
+++ b/src/python/WMCore/ReqMgr/CherryPyThreads/CouchDBCleanup.py
@@ -3,6 +3,7 @@ Created on Aug 13, 2014
 
 @author: sryu
 '''
+from builtins import str
 from __future__ import (division, print_function)
 
 from WMCore.REST.CherryPyPeriodicTask import CherryPyPeriodicTask

--- a/src/python/WMCore/ReqMgr/CherryPyThreads/StatusChangeTasks.py
+++ b/src/python/WMCore/ReqMgr/CherryPyThreads/StatusChangeTasks.py
@@ -1,6 +1,8 @@
 """
 Created on May 19, 2015
 """
+from builtins import range
+from builtins import str
 from __future__ import (division, print_function)
 
 import time

--- a/src/python/WMCore/ReqMgr/DataStructs/ReqMgrConfigDataCache.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/ReqMgrConfigDataCache.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division
 
+from builtins import str
 from WMCore.ReqMgr.DataStructs.DefaultConfig.EDITABLE_SPLITTING_PARAM_CONFIG import EDITABLE_SPLITTING_PARAM_CONFIG
 from WMCore.ReqMgr.DataStructs.DefaultConfig.DAS_RESULT_FILTER import DAS_RESULT_FILTER
 from WMCore.ReqMgr.DataStructs.DefaultConfig.PERMISSION_BY_REQUEST_TYPE import PERMISSION_BY_REQUEST_TYPE

--- a/src/python/WMCore/ReqMgr/DataStructs/Request.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/Request.py
@@ -17,6 +17,7 @@ TODO/NOTE:
 """
 from __future__ import print_function, division
 
+from builtins import range
 import re
 import time
 

--- a/src/python/WMCore/ReqMgr/Service/Request.py
+++ b/src/python/WMCore/ReqMgr/Service/Request.py
@@ -3,6 +3,8 @@ ReqMgr request handling.
 
 """
 
+from builtins import range
+from builtins import str
 import json
 import traceback
 

--- a/src/python/WMCore/ReqMgr/Service/RequestAdditionalInfo.py
+++ b/src/python/WMCore/ReqMgr/Service/RequestAdditionalInfo.py
@@ -1,3 +1,4 @@
+from builtins import str
 from __future__ import (print_function, division)
 
 import json

--- a/src/python/WMCore/ReqMgr/Tools/cms.py
+++ b/src/python/WMCore/ReqMgr/Tools/cms.py
@@ -7,6 +7,7 @@ Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
 Description: CMS modules
 """
 
+from builtins import str
 from __future__ import (division, print_function)
 
 from WMCore.Cache.GenericDataCache import MemoryCacheStruct

--- a/src/python/WMCore/ReqMgr/Tools/reqMgrClient.py
+++ b/src/python/WMCore/ReqMgr/Tools/reqMgrClient.py
@@ -6,6 +6,7 @@
 """
 
 # system modules
+from builtins import range
 import os
 import re
 import sys

--- a/src/python/WMCore/ReqMgr/Utils/Validation.py
+++ b/src/python/WMCore/ReqMgr/Utils/Validation.py
@@ -4,6 +4,7 @@ ReqMgr request handling.
 """
 from __future__ import print_function
 
+from builtins import str
 import json
 import logging
 import time

--- a/src/python/WMCore/ReqMgr/Utils/url_utils.py
+++ b/src/python/WMCore/ReqMgr/Utils/url_utils.py
@@ -9,6 +9,7 @@ Description:
 from __future__ import print_function
 
 # system modules
+from builtins import str
 import os
 import sys
 import urllib

--- a/src/python/WMCore/ReqMgr/Web/ReqMgrService.py
+++ b/src/python/WMCore/ReqMgr/Web/ReqMgrService.py
@@ -7,6 +7,8 @@ __author__ = "Valentin Kuznetsov"
 """
 from __future__ import print_function
 
+from builtins import map
+from builtins import str
 import collections
 import json
 # system modules

--- a/src/python/WMCore/ReqMgr/Web/tools.py
+++ b/src/python/WMCore/ReqMgr/Web/tools.py
@@ -5,6 +5,7 @@
 Web tools.
 """
 
+from builtins import str
 __revision__ = "$Id: tools.py,v 1.5 2010/04/07 18:19:31 valya Exp $"
 __author__ = "Valentin Kuznetsov"
 __email__ = "vkuznet@gmail.com"

--- a/src/python/WMCore/ReqMgr/Web/utils.py
+++ b/src/python/WMCore/ReqMgr/Web/utils.py
@@ -9,6 +9,7 @@ Description:
 from __future__ import print_function
 
 # system modules
+from builtins import str
 import cgi
 import json
 import time

--- a/src/python/WMCore/ReqMgr/database_cleanup/oracle_couchdb_consistency_checker.py
+++ b/src/python/WMCore/ReqMgr/database_cleanup/oracle_couchdb_consistency_checker.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python
+
+"""
+Compare Oracle ReqMgr tables to data stored in CouchDB database.
+
+Needs to have credentials for accessing CMS web ready in
+$X509_USER_CERT $X509_USER_KEY, or proxy stored in /tmp/x509up_u<ID>
+
+Assumes ReqMgr's CouchDB database consistent with Oracle reqmgr_request
+    table, so that both of these contains the same and mutually
+    corresponding requests.
+
+This tools checks consistency on the request level, that is data
+fields in CouchDB request documents with data stored in Oracle.
+
+This script should also correct any inconsistencies (correcting values
+in CouchDB and later removing dispensable CouchDB request fields).
+It will have to be run repeatedly like Oracle/CouchDB database level
+consistency check (which is done here at the beginning too).
+
+Run with -c (commit) to perform updates in CouchDB.
+
+All checks and updates correspond to progress recoreded on
+https://github.com/dmwm/WMCore/issues/4388
+
+"""
+from __future__ import print_function
+
+from builtins import zip
+from builtins import str
+couch_url = "https://cmsweb.cern.ch/couchdb"
+couchdb_name = "reqmgr_workload_cache"
+
+import sys
+import re
+
+import cx_Oracle
+
+from WMCore.Database.CMSCouch import CouchServer, Database, Document
+
+# do not consider consistency of these, to be removed from Couch later
+COUCH_TO_IGNORE = (
+    "ReqMgrGroupID",
+    "ReqMgrRequestID",
+    "ReqMgrRequestBasePriority",
+    "ReqMgrRequestorID",
+    "Workflowspec",
+    "RequestSizeEvents",
+    "RequestEventSize",
+)
+
+# columns in the Oracle SQL statement,
+# the order and number of items here have to agree with select columns ...
+MAPPING = (
+    {"oracle": "REQUEST_NAME", "couch": "RequestName"},
+    {"oracle": "TYPE_NAME", "couch": "RequestType"},
+    {"oracle": "STATUS_NAME", "couch": "RequestStatus"},
+    {"oracle": "REQUEST_PRIORITY", "couch": "RequestPriority"},
+    {"oracle": "REQUESTOR_GROUP_ID", "couch": "ReqMgrGroupID"},
+    {"oracle": "WORKFLOW", "couch": "RequestWorkflow"},
+    {"oracle": "REQUEST_EVENT_SIZE", "couch": "RequestEventSize"},
+    {"oracle": "REQUEST_SIZE_FILES", "couch": "RequestSizeFiles"},
+    {"oracle": "PREP_ID", "couch": "PrepID"},
+    {"oracle": "REQUEST_NUM_EVENTS", "couch": "RequestNumEvents"},
+    {"oracle": "GROUP_NAME", "couch": "Group"},
+    {"oracle": "REQUESTOR_HN_NAME", "couch": "Requestor"},
+    {"oracle": "REQUESTOR_DN_NAME", "couch": "RequestorDN"},
+
+    # team
+    # applies only to requests which reached assignment status
+    # WARNING:
+    # by including teams, not all requests will be returned in
+    # the query to compare/update the above data fields
+    # {"oracle": "TEAM_NAME", "couch": "Team"},
+
+    # reqmgr_input_dataset
+    # WARNING:
+    # only some requests have InputDataset assigned, so not
+    # all requests are returned
+    # {"oracle": "DATASET_NAME", "couch": "InputDataset"},
+    # {"oracle": "DATASET_TYPE", "couch": "InputDatasetTypes"},
+
+    # reqmgr_output_dataset
+    # {"oracle": "DATASET_NAME", "couch": "OutputDatasets"},
+    # {"oracle": "SIZE_PER_EVENT", "couch": "SizePerEvent"},
+
+    # reqmgr_software reqmgr_software_dependency
+    {"oracle": "SOFTWARE_NAME", "couch": "CMSSWVersion"},
+    {"oracle": "SCRAM_ARCH", "couch": "ScramArch"},
+)
+
+ORACLE_FIELDS = [item["oracle"] for item in MAPPING]
+COUCH_FIELDS = [item["couch"] for item in MAPPING]
+
+SQL = ("select "
+       "reqmgr_request.REQUEST_NAME, "
+       "reqmgr_request_type.TYPE_NAME, "
+       "reqmgr_request_status.STATUS_NAME, "
+       "reqmgr_request.REQUEST_PRIORITY, "
+       "reqmgr_request.REQUESTOR_GROUP_ID, "
+       "reqmgr_request.WORKFLOW, "
+       "reqmgr_request.REQUEST_EVENT_SIZE, "
+       "reqmgr_request.REQUEST_SIZE_FILES, "
+       "reqmgr_request.PREP_ID, "
+       "reqmgr_request.REQUEST_NUM_EVENTS, "
+       "reqmgr_group.GROUP_NAME, "
+       "reqmgr_requestor.REQUESTOR_HN_NAME, "
+       "reqmgr_requestor.REQUESTOR_DN_NAME, "
+
+       # team
+       # "reqmgr_teams.TEAM_NAME "
+
+       # reqmgr_input_dataset
+       # "reqmgr_input_dataset.DATASET_NAME, "
+       # "reqmgr_input_dataset.DATASET_TYPE "
+
+       # reqmgr_output_dataset
+       # "reqmgr_output_dataset.DATASET_NAME, "
+       # "reqmgr_output_dataset.SIZE_PER_EVENT "
+
+       # reqmgr_software reqmgr_software_dependency
+       "reqmgr_software.SOFTWARE_NAME, "
+       "reqmgr_software.SCRAM_ARCH "
+
+       "from reqmgr_request, reqmgr_request_type, reqmgr_request_status, "
+       "reqmgr_group, reqmgr_group_association, reqmgr_requestor, "
+
+       # team
+       # "reqmgr_teams, reqmgr_assignment "
+
+       # reqmgr_input_dataset
+       # "reqmgr_input_dataset "
+
+       # reqmgr_output_dataset
+       # "reqmgr_output_dataset "
+
+       # reqmgr_software reqmgr_software_dependency
+       "reqmgr_software, reqmgr_software_dependency "
+
+       "where reqmgr_request_type.TYPE_ID=reqmgr_request.REQUEST_TYPE "
+       "and reqmgr_request_status.STATUS_ID=reqmgr_request.REQUEST_STATUS "
+       "and reqmgr_group.GROUP_ID=reqmgr_group_association.GROUP_ID "
+       "and reqmgr_group_association.ASSOCIATION_ID=reqmgr_request.REQUESTOR_GROUP_ID "
+       "and reqmgr_request.REQUESTOR_GROUP_ID=reqmgr_group_association.ASSOCIATION_ID "
+       "and reqmgr_group_association.REQUESTOR_ID=reqmgr_requestor.REQUESTOR_ID "
+       # team
+       # "and reqmgr_request.REQUEST_ID=reqmgr_assignment.REQUEST_ID "
+       # "and reqmgr_assignment.TEAM_ID=reqmgr_teams.TEAM_ID "
+
+       # reqmgr_input_dataset
+       # "and reqmgr_request.REQUEST_ID=reqmgr_input_dataset.REQUEST_ID"
+
+       # reqmgr_output_dataset
+       # "and reqmgr_request.REQUEST_ID=reqmgr_output_dataset.REQUEST_ID"
+
+       # reqmgr_software reqmgr_software_dependency
+       "and reqmgr_request.REQUEST_ID=reqmgr_software_dependency.REQUEST_ID "
+       "and reqmgr_software_dependency.SOFTWARE_ID=reqmgr_software.SOFTWARE_ID"
+
+       # limit the number of rows returned by oracle
+       #     "and rownum < 5"
+       )
+
+
+# END OF SQL
+
+# ; semi-colon at the end nicely yields
+# cx_Oracle.DatabaseError: ORA-00911: invalid character
+# without any other description
+
+
+
+def oracle_query(oradb, sql_cmd):
+    print("Retrieving data from Oracle ...")
+    ora_cursor = cx_Oracle.Cursor(oradb)
+    print("# SQL: '%s'" % sql_cmd)
+    ora_cursor.prepare(sql_cmd)
+    ora_cursor.execute(sql_cmd)
+    return ora_cursor
+
+
+def get_oracle_row_count(oradb, table_name):
+    cmd = "select * from %s" % table_name
+    ora_cursor = oracle_query(oradb, cmd)
+    # accessing just .rowcount integer was returning 0 on non-empty result
+    num_requests = len(ora_cursor.fetchall())
+    ora_cursor.close()
+    return num_requests
+
+
+def get_oracle_data(oradb):
+    ora_cursor = oracle_query(oradb, SQL)
+    # result is a list of tuples, make a dict from it
+    request = {}
+    for row in ora_cursor.fetchall():
+        for k, v in zip(ORACLE_FIELDS, row):
+            request[k] = v
+        yield request
+    ora_cursor.close()
+
+
+def get_couchdb_row_count(db):
+    """
+    Returns number of request documents excluding design documents.
+
+    """
+    print("Retrieving data from CouchDB ...")
+    doc_count = 0
+    for row in db.allDocs()["rows"]:
+        if row["id"].startswith("_design"): continue
+        doc_count += 1
+    return doc_count
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Missing the connect Oracle TNS argument (user/password@server).")
+        sys.exit(1)
+    tns = sys.argv[1]
+
+    print("Creating CouchDB database connection ...")
+    couchdb = Database(couchdb_name, couch_url)
+    print("Creating Oracle database connection ...")
+    oradb = cx_Oracle.Connection(tns)
+
+    num_couch_requests = get_couchdb_row_count(couchdb)
+    print("Total CouchDB request documents in ReqMgr: %s" % num_couch_requests)
+    num_oracle_requests = get_oracle_row_count(oradb, "reqmgr_request")
+    print("Total Oracle requests entries in ReqMgr: %s" % num_oracle_requests)
+
+    if num_couch_requests != num_oracle_requests:
+        print("Number of requests in Oracle, CouchDB don't agree, fix that first.")
+        sys.exit(1)
+    else:
+        print("Database cross-check (Oracle request names vs CouchDB): DONE, THE SAME.")
+
+    def get_couch_value(couch_req, mapping):
+        try:
+            c = couch_req[mapping["couch"]]
+            couch_missing = False
+        except KeyError:
+            # comparison will not happen due to missing flag, the value
+            # will be stored in couch
+            c = "N/A"
+            couch_missing = False
+        return str(c), couch_missing
+
+    def check_oracle_worflow_value(oracle_value, mapping, req_name):
+        # check Oracle WORKFLOW value
+        if mapping["oracle"] == "WORKFLOW":
+            # https://cmsweb.cern.ch/couchdb/reqmgr_workload_cache/linacre_2011A_442p2_DataReprocessingMuOnia_111119_005717/spec
+            from_wf_url_req_name = oracle_value.rsplit('/', 2)[-2]
+            if req_name != from_wf_url_req_name:
+                print("Workflow URL mismatch: %s" % o)
+                sys.exit(1)
+
+    counter = 0
+    for oracle_req in get_oracle_data(oradb):
+        req_name = oracle_req["REQUEST_NAME"]
+
+        # FILTER
+        # check only requests injected approx. after last deployment (a lot of
+        # stuff should have already been fixed in ReqMgr)
+        # _13041._*$ (ending of request name with date/time)
+        # if not re.match(".*_1304[0-3][0-9]_.*$", req_name): # all April 2013
+        #    continue
+
+        counter += 1
+        print("\n\n%s (%s)" % (req_name, counter))
+
+        couch_req = couchdb.document(req_name)
+        couch_fields_to_correct = {}
+        for mapping in MAPPING:
+            if mapping["couch"] in COUCH_TO_IGNORE:
+                continue
+            o = str(oracle_req[mapping["oracle"]])
+            c, couch_missing = get_couch_value(couch_req, mapping)
+            check_oracle_worflow_value(o, mapping, req_name)
+
+            # compare oracle and couch values
+            # don't update value in couch if it exists and is non-empty
+            if (couch_missing or o != c) and c in ('None', '0', '', "N/A"):
+                print("%s %s != %s" % (mapping, o, c))
+                # correct couch request by oracle value
+                couch_fields_to_correct[mapping["couch"]] = o
+
+        if couch_fields_to_correct:
+            print("Couch corrected fields:")
+            print(couch_fields_to_correct)
+            if sys.argv[-1] == "-c":
+                couchdb.updateDocument(req_name, "ReqMgr", "updaterequest",
+                                       fields=couch_fields_to_correct, useBody=True)
+                print("Couch updated")
+        else:
+            print("OK")
+
+        # fields that should be removed from couch
+        """
+        print "Couch fields to remove, values: ..."
+        for removable in COUCH_TO_IGNORE:
+            try:
+                val = couch_req[removable]
+            except KeyError:
+                continue
+            print "%s: %s: %s" % (req_name, removable, val)
+        """
+
+        # // for for oracle_req in ...
+
+
+if __name__ == "__main__":
+    main()

--- a/src/python/WMCore/ReqMgr/database_cleanup/oracle_dump.py
+++ b/src/python/WMCore/ReqMgr/database_cleanup/oracle_dump.py
@@ -1,0 +1,61 @@
+"""
+Dump of Oracle database into Python dictionary.
+
+Usage:
+   python oracle_dump.py user/password@server [TABLE_NAME] > output.dump
+   python ./oracle_dump.py user/password@server reqmgr_request > \
+       oracle_dump_request_table.py
+
+"""
+from __future__ import print_function
+
+
+from builtins import zip
+import sys
+import cx_Oracle
+from .oracle_tables import reqmgr_oracle_tables_defition
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Missing the connect TNS argument.")
+        sys.exit(1)
+    tns = sys.argv[1]
+    # tables is dictionary:
+    # {"table1": [col1, col2, ...], "table2": [col1, col2, ...], ...}
+
+    # printout statements with # (comment, result must be functional Python
+    # file)
+
+    # if another argument is specified, it's assumed it's the table name
+    # which only shall be dumped
+    tables = {}
+    if len(sys.argv) > 2:
+        table_name = sys.argv[2]
+        print("# Dumping only '%s' ..." % table_name)
+        tables[table_name] = reqmgr_oracle_tables_defition[table_name]
+    else:
+        tables = reqmgr_oracle_tables_defition
+
+    connection = cx_Oracle.Connection(tns)
+    cursor = cx_Oracle.Cursor(connection)
+
+    for table in tables:
+        cmd = "select %s from %s" % (", ".join(tables[table]), table)
+        print("# %s" % cmd)
+        cursor.prepare(cmd)
+        cursor.execute(cmd)
+        print("%s = [" % table)
+        for row in cursor.fetchall():
+            print("{")
+            for k, v in zip(tables[table], row):
+                print("\t'%s': '%s'," % (k, v))
+            print("},")
+        print("]")
+        print("# rowcount: %s\n\n\n" % cursor.rowcount)
+
+    cursor.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -5,6 +5,7 @@ _DBSReader_
 Readonly DBS Interface
 
 """
+from builtins import str
 import time
 from collections import defaultdict
 

--- a/src/python/WMCore/Services/DBS/DBSErrors.py
+++ b/src/python/WMCore/Services/DBS/DBSErrors.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 
+from builtins import str
 from WMCore.Services.DBS.ProdException import ProdException
 
 

--- a/src/python/WMCore/Services/DBS/DBSReader.py
+++ b/src/python/WMCore/Services/DBS/DBSReader.py
@@ -6,6 +6,7 @@ Readonly DBS Interface
 
 """
 
+from builtins import str
 from WMCore.Services.DBS.DBSErrors import DBSReaderError
 from WMCore.Services.DBS.DBS3Reader import DBS3Reader
 

--- a/src/python/WMCore/Services/DBS/DBSWriterObjects.py
+++ b/src/python/WMCore/Services/DBS/DBSWriterObjects.py
@@ -8,6 +8,7 @@ into DBS if required
 """
 from __future__ import print_function
 
+from builtins import str
 import logging
 
 from DBSAPI.dbsApi import DbsApi

--- a/src/python/WMCore/Services/DBS/ProdException.py
+++ b/src/python/WMCore/Services/DBS/ProdException.py
@@ -9,6 +9,7 @@ General Exception class for Prod modules
 
 
 
+from builtins import str
 import exceptions
 import inspect
 import logging

--- a/src/python/WMCore/Services/Dashboard/API/ApmonTransPort.py
+++ b/src/python/WMCore/Services/Dashboard/API/ApmonTransPort.py
@@ -11,6 +11,7 @@ from __future__ import print_function
 
 
 
+from builtins import str
 import random
 import time
 import sys

--- a/src/python/WMCore/Services/Dashboard/API/DashboardBase.py
+++ b/src/python/WMCore/Services/Dashboard/API/DashboardBase.py
@@ -11,6 +11,8 @@ from __future__ import print_function
 
 
 
+from builtins import range
+from builtins import str
 import uuid
 import types
 import time

--- a/src/python/WMCore/Services/Dashboard/DashboardAPI.py
+++ b/src/python/WMCore/Services/Dashboard/DashboardAPI.py
@@ -5,6 +5,7 @@ This is the Dashboard API Module for the Worker Node
 """
 from __future__ import print_function
 
+from builtins import str
 import sys
 import os
 import traceback

--- a/src/python/WMCore/Services/Dashboard/DashboardReporter.py
+++ b/src/python/WMCore/Services/Dashboard/DashboardReporter.py
@@ -4,6 +4,7 @@ __DashboardReporter__
 Utilities for reporting information to the dashboard
 """
 
+from builtins import str
 import time
 import logging
 

--- a/src/python/WMCore/Services/Dashboard/Logger.py
+++ b/src/python/WMCore/Services/Dashboard/Logger.py
@@ -30,6 +30,7 @@
  * MODIFICATIONS.
 """
 from __future__ import print_function
+from builtins import range
 import time
 import threading
 import traceback

--- a/src/python/WMCore/Services/Dashboard/ProcInfo.py
+++ b/src/python/WMCore/Services/Dashboard/ProcInfo.py
@@ -32,6 +32,7 @@
 """
 from __future__ import print_function
 from __future__ import division
+from builtins import str
 from WMCore.Services.Dashboard.Logger import Logger
 import socket
 import os

--- a/src/python/WMCore/Services/Dashboard/apmon.py
+++ b/src/python/WMCore/Services/Dashboard/apmon.py
@@ -41,6 +41,7 @@ Sending strings is supported, but they will not be stored in the
 farm's store nor shown in the farm's window in the MonALISA client.
 """
 from __future__ import division
+from builtins import str
 import re
 import xdrlib
 import socket

--- a/src/python/WMCore/Services/LogDB/LogDB.py
+++ b/src/python/WMCore/Services/LogDB/LogDB.py
@@ -5,6 +5,7 @@ https://github.com/dmwm/WMCore/issues/5705
 """
 
 # standard modules
+from builtins import str
 import re
 import logging
 import threading

--- a/src/python/WMCore/Services/LogDB/LogDBBackend.py
+++ b/src/python/WMCore/Services/LogDB/LogDBBackend.py
@@ -6,6 +6,7 @@ Interface to LogDB persistent storage
 """
 
 # syste modules
+from builtins import str
 import datetime
 import hashlib
 import time

--- a/src/python/WMCore/Services/LogDB/LogDBReport.py
+++ b/src/python/WMCore/Services/LogDB/LogDBReport.py
@@ -9,6 +9,8 @@ Description: LogDB report class to represent LogDB messages
 from __future__ import print_function
 
 # system modules
+from builtins import range
+from builtins import str
 import os
 import sys
 

--- a/src/python/WMCore/Services/McM/McM.py
+++ b/src/python/WMCore/Services/McM/McM.py
@@ -5,6 +5,7 @@ A service class for retrieving data from McM using
 an SSO cookie since it sits behind CERN SSO
 """
 
+from builtins import str
 import json
 import os
 import pycurl

--- a/src/python/WMCore/Services/PhEDEx/DataStructs/SubscriptionList.py
+++ b/src/python/WMCore/Services/PhEDEx/DataStructs/SubscriptionList.py
@@ -4,6 +4,8 @@ _SubscriptionList_
 Module with data structures to handle PhEDEx subscriptions
 in bulk.
 """
+from builtins import next
+from builtins import str
 import logging
 
 from WMCore.WMException import WMException

--- a/src/python/WMCore/Services/PhEDEx/PhEDEx.py
+++ b/src/python/WMCore/Services/PhEDEx/PhEDEx.py
@@ -1,3 +1,4 @@
+from builtins import str
 import json
 import logging
 from xml.dom.minidom import parseString

--- a/src/python/WMCore/Services/PhEDEx/XMLDrop.py
+++ b/src/python/WMCore/Services/PhEDEx/XMLDrop.py
@@ -8,6 +8,7 @@ Modified from ProdCommon.DataMgmt.PhEDEx.DropMaker.py
 TODO: Need to merge with ProdCommon.DataMgmt.PhEDEx.DropMaker.py - Talk to Stuart
 """
 
+from builtins import str
 import logging
 from xml.dom.minidom import getDOMImplementation
 

--- a/src/python/WMCore/Services/Registration/Registration.py
+++ b/src/python/WMCore/Services/Registration/Registration.py
@@ -24,6 +24,7 @@ reg.refreshCache()
 
 This will push the configuration up to the Registration service
 '''
+from builtins import str
 from WMCore.Database.CMSCouch import CouchServer
 
 class Registration():

--- a/src/python/WMCore/Services/Requests.py
+++ b/src/python/WMCore/Services/Requests.py
@@ -9,6 +9,7 @@ deserialising the response.
 The response from the remote server is cached if expires/etags are set.
 """
 
+from builtins import str
 import base64
 import cStringIO as StringIO
 import logging

--- a/src/python/WMCore/Services/SAM/SAM.py
+++ b/src/python/WMCore/Services/SAM/SAM.py
@@ -8,6 +8,7 @@ Talk to the SAM Service to get site status from the results of SAM tests.
 
 
 
+from builtins import zip
 from WMCore.Services.Service import Service
 
 class SAM(Service):

--- a/src/python/WMCore/Services/Service.py
+++ b/src/python/WMCore/Services/Service.py
@@ -48,6 +48,7 @@ service cache   |    no    |   yes    |   yes    |     no     |
 result          |  cached  |  cached  |  cached  | not cached |
 """
 
+from builtins import str
 import datetime
 import json
 import logging

--- a/src/python/WMCore/Services/SiteDB/SiteDBAPI.py
+++ b/src/python/WMCore/Services/SiteDB/SiteDBAPI.py
@@ -7,6 +7,7 @@ API for retrieving information from SiteDB
 """
 from __future__ import print_function
 from __future__ import division
+from builtins import zip
 import json
 import logging
 from WMCore.Services.Service import Service

--- a/src/python/WMCore/Services/StompAMQ/StompAMQ.py
+++ b/src/python/WMCore/Services/StompAMQ/StompAMQ.py
@@ -5,6 +5,7 @@ Basic interface to CERN ActiveMQ via stomp
 from __future__ import print_function
 from __future__ import division
 
+from builtins import str
 import json
 import logging
 import time

--- a/src/python/WMCore/Services/UUIDLib.py
+++ b/src/python/WMCore/Services/UUIDLib.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from builtins import str
 import uuid
 
 

--- a/src/python/WMCore/Services/UserFileCache/UserFileCache.py
+++ b/src/python/WMCore/Services/UserFileCache/UserFileCache.py
@@ -5,6 +5,7 @@ _UserFileCache_
 API for UserFileCache service
 """
 
+from builtins import str
 import os
 import json
 import shutil

--- a/src/python/WMCore/Services/WMArchive/DataMap.py
+++ b/src/python/WMCore/Services/WMArchive/DataMap.py
@@ -1,3 +1,4 @@
+from builtins import str
 from __future__ import (division, print_function)
 
 import socket

--- a/src/python/WMCore/Services/WMStats/WMStatsReader.py
+++ b/src/python/WMCore/Services/WMStats/WMStatsReader.py
@@ -1,5 +1,6 @@
 from __future__ import division, print_function
 
+from builtins import str
 from Utils.IteratorTools import nestedDictUpdate
 from WMCore.Database.CMSCouch import CouchServer
 from WMCore.Services.WMStats.DataStruct.RequestInfoCollection import RequestInfo

--- a/src/python/WMCore/Services/pycurl_manager.py
+++ b/src/python/WMCore/Services/pycurl_manager.py
@@ -38,10 +38,13 @@ for row in data:
 """
 from __future__ import print_function
 
+from builtins import str
+
 # system modules
 import os
 import re
 import sys
+
 import cStringIO as StringIO
 import httplib
 import json

--- a/src/python/WMCore/Storage/Backends/CPImpl.py
+++ b/src/python/WMCore/Storage/Backends/CPImpl.py
@@ -7,6 +7,7 @@ Implementation of StageOutImpl interface for plain cp
 """
 from __future__ import print_function
 
+from builtins import str
 import os
 
 from WMCore.Storage.Execute import runCommandWithOutput

--- a/src/python/WMCore/Storage/Backends/LCGImpl.py
+++ b/src/python/WMCore/Storage/Backends/LCGImpl.py
@@ -5,6 +5,7 @@ _LCGImpl_
 Implementation of StageOutImpl interface for lcg-cp
 
 """
+from builtins import str
 import os
 
 from WMCore.Storage.Registry import registerStageOutImpl

--- a/src/python/WMCore/Storage/Backends/SRMV2Impl.py
+++ b/src/python/WMCore/Storage/Backends/SRMV2Impl.py
@@ -7,6 +7,9 @@ Implementation of StageOutImpl interface for SRM Version 2
 """
 from __future__ import print_function
 
+from builtins import zip
+from builtins import range
+from builtins import str
 import os
 import re
 

--- a/src/python/WMCore/Storage/Backends/TestFallbackToOldBackend.py
+++ b/src/python/WMCore/Storage/Backends/TestFallbackToOldBackend.py
@@ -8,6 +8,7 @@ this will let us test that the fallback works properly
 """
 from __future__ import print_function
 
+from builtins import str
 import os
 
 from WMCore.Storage.Execute import runCommandWithOutput

--- a/src/python/WMCore/Storage/DeleteMgr.py
+++ b/src/python/WMCore/Storage/DeleteMgr.py
@@ -9,6 +9,7 @@ Based on StageOutMgr class
 """
 from __future__ import print_function
 
+from builtins import str
 import os
 
 #from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig

--- a/src/python/WMCore/Storage/Execute.py
+++ b/src/python/WMCore/Storage/Execute.py
@@ -7,6 +7,7 @@ Run the stage out commands in a nice non-blocking way
 """
 from __future__ import print_function
 
+from builtins import str
 from subprocess import Popen, PIPE
 
 from WMCore.Storage.StageOutError import StageOutError

--- a/src/python/WMCore/Storage/FileManager.py
+++ b/src/python/WMCore/Storage/FileManager.py
@@ -7,6 +7,8 @@ Refactoring of StageOutMgr -- for now, not accessed by default
 
 """
 
+from builtins import range
+from builtins import str
 import os
 import logging
 log = logging

--- a/src/python/WMCore/Storage/Plugins/Examples/SRMV2Impl.py
+++ b/src/python/WMCore/Storage/Plugins/Examples/SRMV2Impl.py
@@ -5,6 +5,9 @@ _SRMV2Impl_
 Implementation of StageOutImpl interface for SRM Version 2
 
 """
+from builtins import zip
+from builtins import range
+from builtins import str
 import os, re
 import logging, tempfile
 import subprocess

--- a/src/python/WMCore/Storage/Plugins/FNALImpl.py
+++ b/src/python/WMCore/Storage/Plugins/FNALImpl.py
@@ -5,6 +5,8 @@ _FNALImpl_
 Implementation of StageOutImpl interface for FNAL
 
 """
+from builtins import range
+from builtins import str
 import logging
 import os
 

--- a/src/python/WMCore/Storage/RuntimeCleanUp.py
+++ b/src/python/WMCore/Storage/RuntimeCleanUp.py
@@ -6,6 +6,8 @@ Runtime binary file for CleanUp type nodes
 
 """
 from __future__ import print_function
+from builtins import filter
+from builtins import str
 import sys
 import os
 from WMCore.Storage.TaskState import TaskState, getTaskState

--- a/src/python/WMCore/Storage/SiteLocalConfig.py
+++ b/src/python/WMCore/Storage/SiteLocalConfig.py
@@ -8,6 +8,8 @@ into an object with an API for getting info from it.
 """
 
 
+from builtins import next
+from builtins import str
 import os
 import logging
 

--- a/src/python/WMCore/Storage/StageInMgr.py
+++ b/src/python/WMCore/Storage/StageInMgr.py
@@ -9,6 +9,7 @@ Based on StageOutMgr class
 """
 from __future__ import print_function
 
+from builtins import str
 import os
 
 from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig

--- a/src/python/WMCore/Storage/StageOutImpl.py
+++ b/src/python/WMCore/Storage/StageOutImpl.py
@@ -7,6 +7,8 @@ inherit this object and implement the methods accordingly
 
 """
 from __future__ import print_function
+from builtins import range
+from builtins import str
 import time
 import os
 from WMCore.Storage.Execute import runCommandWithOutput

--- a/src/python/WMCore/Storage/StageOutMgr.py
+++ b/src/python/WMCore/Storage/StageOutMgr.py
@@ -10,6 +10,7 @@ use this class as a basic API
 from __future__ import print_function
 
 # If we don't import them, they cannot be ever used (bad PyCharm!)
+from builtins import str
 import WMCore.Storage.Backends
 import WMCore.Storage.Plugins
 

--- a/src/python/WMCore/Storage/StoreFail.py
+++ b/src/python/WMCore/Storage/StoreFail.py
@@ -11,6 +11,7 @@ from __future__ import print_function
 
 
 
+from builtins import str
 from WMCore.Storage.StageOutError import StageOutFailure
 from WMCore.Storage.StageOutMgr import StageOutMgr
 

--- a/src/python/WMCore/Storage/TestImpl.py
+++ b/src/python/WMCore/Storage/TestImpl.py
@@ -7,6 +7,7 @@ Test harness for invoking an Implementation plugin
 """
 from __future__ import print_function
 
+from builtins import str
 import sys
 import getopt
 

--- a/src/python/WMCore/Storage/TrivialFileCatalog.py
+++ b/src/python/WMCore/Storage/TrivialFileCatalog.py
@@ -25,6 +25,9 @@ Usage: Given a TFC constact string: trivialcatalog_file:/path?protocol=proto
 
 """
 
+from builtins import next
+from builtins import range
+from builtins import str
 import os
 import re
 import urlparse

--- a/src/python/WMCore/ThreadPool/ThreadPool.py
+++ b/src/python/WMCore/ThreadPool/ThreadPool.py
@@ -11,6 +11,7 @@ To use this you need to use the ThreadSlave class
 
 
 
+from builtins import str
 import base64
 import logging
 import random

--- a/src/python/WMCore/ThreadPool/ThreadSlave.py
+++ b/src/python/WMCore/ThreadPool/ThreadSlave.py
@@ -16,6 +16,7 @@ attribute.
 
 
 
+from builtins import str
 import base64
 import logging
 import threading

--- a/src/python/WMCore/WMBS/Fileset.py
+++ b/src/python/WMCore/WMBS/Fileset.py
@@ -17,6 +17,7 @@ workflow + fileset = subscription
 
 
 
+from builtins import str
 from WMCore.WMBS.File import File, addFilesToWMBSInBulk
 from WMCore.WMBS.WMBSBase import WMBSBase
 from WMCore.DataStructs.Fileset import Fileset as WMFileset

--- a/src/python/WMCore/WMBS/JobGroup.py
+++ b/src/python/WMCore/WMBS/JobGroup.py
@@ -24,6 +24,7 @@ talking to the group, and WMBS JobGroups can calculate status from the database
 instead of the in memory objects.
 """
 
+from builtins import str
 import logging
 import threading
 

--- a/src/python/WMCore/WMBS/MySQL/Fileset/ListOpen.py
+++ b/src/python/WMCore/WMBS/MySQL/Fileset/ListOpen.py
@@ -5,6 +5,7 @@ _ListOpen_
 MySQL implementation of Fileset.ListOpen
 """
 
+from builtins import str
 __all__ = []
 
 

--- a/src/python/WMCore/WMBS/MySQL/Fileset/ListOpenByName.py
+++ b/src/python/WMCore/WMBS/MySQL/Fileset/ListOpenByName.py
@@ -5,6 +5,7 @@ _ListOpenByName_
 MySQL implementation of Fileset.ListOpenByName
 """
 
+from builtins import str
 __all__ = []
 
 

--- a/src/python/WMCore/WMBS/MySQL/Jobs/ChangeState.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/ChangeState.py
@@ -8,6 +8,7 @@ wrapper class), a retry count for that state, and an id for the couchdb record
 (also added in by the wrapper class, if not present).
 """
 
+from builtins import map
 from WMCore.Database.DBFormatter import DBFormatter
 
 class ChangeState(DBFormatter):

--- a/src/python/WMCore/WMBS/MySQL/Jobs/LoadForErrorHandler.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/LoadForErrorHandler.py
@@ -5,6 +5,7 @@ _LoadForErrHandler_
 MySQL implementation of Jobs.LoadForErrorHandler.
 """
 
+from builtins import filter
 from WMCore.Database.DBFormatter import DBFormatter
 
 from WMCore.WMBS.File       import File

--- a/src/python/WMCore/WMBS/MySQL/Jobs/Monitoring.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/Monitoring.py
@@ -4,6 +4,7 @@ _Monitoring_
 
 Monitoring DAO classes for Jobs in WMBS
 """
+from builtins import map
 __all__ = []
 
 

--- a/src/python/WMCore/WMBS/Oracle/Fileset/List.py
+++ b/src/python/WMCore/WMBS/Oracle/Fileset/List.py
@@ -5,6 +5,7 @@ _List_
 Oracle implementation of ListFileset
 
 """
+from builtins import str
 __all__ = []
 
 

--- a/src/python/WMCore/WMDataMining/Utils.py
+++ b/src/python/WMCore/WMDataMining/Utils.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 from __future__ import division
 
+from builtins import str
 import copy
 import json
 import logging

--- a/src/python/WMCore/WMException.py
+++ b/src/python/WMCore/WMException.py
@@ -6,6 +6,7 @@ General Exception class for WM modules
 
 """
 
+from builtins import str
 import exceptions
 import inspect
 import logging

--- a/src/python/WMCore/WMInit.py
+++ b/src/python/WMCore/WMInit.py
@@ -11,6 +11,7 @@ from __future__ import print_function
 
 
 
+from builtins import str
 import logging
 import threading
 import traceback

--- a/src/python/WMCore/WMRuntime/Bootstrap.py
+++ b/src/python/WMCore/WMRuntime/Bootstrap.py
@@ -5,6 +5,7 @@ _TaskSpace_
 Frontend module for setting up TaskSpace & StepSpace areas within a job.
 """
 
+from builtins import str
 import inspect
 import pickle
 import os

--- a/src/python/WMCore/WMRuntime/Monitors/DashboardMonitor.py
+++ b/src/python/WMCore/WMRuntime/Monitors/DashboardMonitor.py
@@ -6,6 +6,7 @@ _DashboardMonitor_
 This class monitors the job progress and reports to the dashboard
 """
 
+from builtins import str
 import time
 import logging
 import os

--- a/src/python/WMCore/WMRuntime/Monitors/PerformanceMonitor.py
+++ b/src/python/WMCore/WMRuntime/Monitors/PerformanceMonitor.py
@@ -8,6 +8,7 @@ the agreed limits of virtual memory and wallclock time, and terminate it
 if it exceeds them.
 """
 
+from builtins import str
 import os
 import signal
 import os.path

--- a/src/python/WMCore/WMRuntime/SandboxCreator.py
+++ b/src/python/WMCore/WMRuntime/SandboxCreator.py
@@ -5,6 +5,7 @@
     Given a path, workflow and task, create a sandbox within the path
 """
 
+from builtins import map
 import os
 import shutil
 import tarfile

--- a/src/python/WMCore/WMRuntime/ScriptFactory.py
+++ b/src/python/WMCore/WMRuntime/ScriptFactory.py
@@ -6,6 +6,7 @@ WMFactory for instantiating runtime implementations of the ScriptInterface
 
 """
 
+from builtins import str
 from WMCore.WMFactory import WMFactory
 from WMCore.WMException import WMException
 

--- a/src/python/WMCore/WMRuntime/ScriptInvoke.py
+++ b/src/python/WMCore/WMRuntime/ScriptInvoke.py
@@ -12,6 +12,7 @@ environment in which the Runtime Script implementation needs to be called.
 
 """
 
+from builtins import str
 import os
 import sys
 import traceback

--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -6,6 +6,7 @@ Create a CMSSW PSet suitable for running a WMAgent job.
 """
 from __future__ import print_function
 
+from builtins import str
 import json
 import os
 import pickle

--- a/src/python/WMCore/WMRuntime/TaskSpace.py
+++ b/src/python/WMCore/WMRuntime/TaskSpace.py
@@ -8,6 +8,7 @@ Runtime utils for a Task
 
 """
 
+from builtins import str
 import os
 import sys
 import inspect

--- a/src/python/WMCore/WMRuntime/Tools/Scram.py
+++ b/src/python/WMCore/WMRuntime/Tools/Scram.py
@@ -25,6 +25,7 @@ sample usage:
 
 """
 
+from builtins import str
 import os
 import os.path
 import sys

--- a/src/python/WMCore/WMRuntime/Unpacker.py
+++ b/src/python/WMCore/WMRuntime/Unpacker.py
@@ -19,6 +19,7 @@ This will then do the following:
 
 """
 from __future__ import print_function
+from builtins import str
 import sys
 import os
 import tarfile

--- a/src/python/WMCore/WMRuntime/Watchdog.py
+++ b/src/python/WMCore/WMRuntime/Watchdog.py
@@ -8,6 +8,7 @@ This cleverly named object is the thread that handles the monitoring of individu
 from __future__ import division
 from __future__ import print_function
 
+from builtins import str
 import os
 import os.path
 import threading

--- a/src/python/WMCore/WMSpec/ConfigSectionTree.py
+++ b/src/python/WMCore/WMSpec/ConfigSectionTree.py
@@ -10,6 +10,7 @@ of ConfigSections
 
 
 
+from builtins import str
 import types
 
 from WMCore.Configuration import ConfigSection

--- a/src/python/WMCore/WMSpec/DashboardInterface.py
+++ b/src/python/WMCore/WMSpec/DashboardInterface.py
@@ -15,6 +15,8 @@ from __future__ import print_function
 
 
 
+from builtins import range
+from builtins import str
 from xml.dom import minidom
 import logging
 import traceback

--- a/src/python/WMCore/WMSpec/Makers/Handlers/MakeJob.py
+++ b/src/python/WMCore/WMSpec/Makers/Handlers/MakeJob.py
@@ -3,6 +3,7 @@
 Default function for Job Maker
 """
 from __future__ import print_function
+from builtins import str
 __all__ = []
 
 

--- a/src/python/WMCore/WMSpec/Makers/TaskMaker.py
+++ b/src/python/WMCore/WMSpec/Makers/TaskMaker.py
@@ -14,6 +14,7 @@ from __future__ import print_function
 
 
 
+from builtins import str
 import os.path
 import threading
 import inspect

--- a/src/python/WMCore/WMSpec/StdSpecs/ReReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/ReReco.py
@@ -4,6 +4,7 @@ _ReReco_
 
 Standard ReReco workflow.
 """
+from builtins import str
 from Utils.Utilities import makeList
 from WMCore.WMSpec.StdSpecs.DataProcessing import DataProcessing
 from WMCore.WMSpec.WMWorkloadTools import validateArgumentsCreate

--- a/src/python/WMCore/WMSpec/StdSpecs/Resubmission.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Resubmission.py
@@ -6,6 +6,7 @@ Resubmission module, this creates truncated workflows
 with limited input for error recovery.
 """
 
+from builtins import str
 from Utils.Utilities import makeList
 from WMCore.Lexicon import couchurl, identifier, cmsname, dataset
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -4,6 +4,8 @@ _StdBase_
 
 Base class with helper functions for standard WMSpec files.
 """
+from builtins import range
+from builtins import str
 import logging
 
 from Utils.Utilities import makeList, makeNonEmptyList, strToBool, safeStr

--- a/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
@@ -13,6 +13,8 @@ It also assumes all the intermediate steps output are transient and do not need
 to be staged out and registered in DBS/PhEDEx. Only the last step output will be
 made available.
 """
+from builtins import range
+from builtins import str
 from Utils.Utilities import strToBool
 import WMCore.WMSpec.Steps.StepFactory as StepFactory
 from WMCore.Lexicon import primdataset

--- a/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
@@ -84,6 +84,7 @@ Example initial processing task
  },
 """
 from __future__ import division
+from builtins import str
 from Utils.Utilities import makeList, strToBool
 from WMCore.Lexicon import primdataset
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase

--- a/src/python/WMCore/WMSpec/Steps/BuildTools.py
+++ b/src/python/WMCore/WMSpec/Steps/BuildTools.py
@@ -7,6 +7,7 @@ Utils to assist in the build process
 
 """
 
+from builtins import str
 import os
 import logging
 from WMCore.WMSpec.ConfigSectionTree import nodeName

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/AlcaHarvest.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/AlcaHarvest.py
@@ -7,6 +7,7 @@ Diagnostic implementation for a AlcaHarvest job
 
 """
 
+from builtins import range
 import os
 
 from WMCore.WMSpec.Steps.Diagnostic import Diagnostic, DiagnosticHandler

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/CMSSW.py
@@ -10,6 +10,8 @@ Diagnostic implementation for a CMSSW job
 """
 from __future__ import print_function
 
+from builtins import range
+from builtins import str
 import logging
 import os.path
 import socket

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/DQMUpload.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/DQMUpload.py
@@ -7,6 +7,7 @@ Diagnostic implementation for a job DQMUpload
 
 """
 
+from builtins import range
 import os
 
 from WMCore.WMSpec.Steps.Diagnostic import Diagnostic, DiagnosticHandler

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/DeleteFiles.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/DeleteFiles.py
@@ -10,6 +10,7 @@ Diagnostic implementation for a job's DeleteFiles step
 
 
 
+from builtins import range
 import os
 from WMCore.WMSpec.Steps.Diagnostic import Diagnostic, DiagnosticHandler
 

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/LogArchive.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/LogArchive.py
@@ -5,6 +5,8 @@ _LogArchive_
 Diagnostic implementation for a job's LogArchive step
 """
 
+from builtins import range
+from builtins import str
 import os
 
 from WMCore.WMSpec.Steps.Diagnostic import Diagnostic, DiagnosticHandler

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/LogCollect.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/LogCollect.py
@@ -10,6 +10,8 @@ Diagnostic implementation for a job's LogCollect step
 
 
 
+from builtins import range
+from builtins import str
 import os
 from WMCore.WMSpec.Steps.Diagnostic import Diagnostic, DiagnosticHandler
 

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/StageOut.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/StageOut.py
@@ -7,6 +7,8 @@ Diagnostic implementation for a job StageOut
 
 """
 
+from builtins import range
+from builtins import str
 import os
 from WMCore.WMSpec.Steps.Diagnostic import Diagnostic, DiagnosticHandler
 

--- a/src/python/WMCore/WMSpec/Steps/Emulators/AlcaHarvest.py
+++ b/src/python/WMCore/WMSpec/Steps/Emulators/AlcaHarvest.py
@@ -7,6 +7,7 @@ Basic Emulator for AlcaHarvest Step
 """
 from __future__ import print_function
 
+from builtins import str
 from WMCore.WMSpec.Steps.Emulator import Emulator
 
 class AlcaHarvest(Emulator):

--- a/src/python/WMCore/WMSpec/Steps/Emulators/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Emulators/CMSSW.py
@@ -5,6 +5,7 @@ _CMSSW_
 Basic Emulator for CMSSW Step
 
 """
+from builtins import str
 from WMCore.WMSpec.Steps.Emulator import Emulator
 from WMCore.FwkJobReport.ReportEmu import ReportEmu
 from WMCore.WMSpec.WMStep import WMStepHelper

--- a/src/python/WMCore/WMSpec/Steps/Emulators/DQMUpload.py
+++ b/src/python/WMCore/WMSpec/Steps/Emulators/DQMUpload.py
@@ -7,6 +7,7 @@ Basic Emulator for DQMUpload Step
 """
 from __future__ import print_function
 
+from builtins import str
 from WMCore.WMSpec.Steps.Emulator import Emulator
 
 class DQMUpload(Emulator):

--- a/src/python/WMCore/WMSpec/Steps/Emulators/DeleteFiles.py
+++ b/src/python/WMCore/WMSpec/Steps/Emulators/DeleteFiles.py
@@ -7,6 +7,7 @@ Basic Emulator for DeleteFiles Step
 """
 from __future__ import print_function
 
+from builtins import str
 from WMCore.WMSpec.Steps.Emulator import Emulator
 
 class DeleteFiles(Emulator):

--- a/src/python/WMCore/WMSpec/Steps/Emulators/LogArchive.py
+++ b/src/python/WMCore/WMSpec/Steps/Emulators/LogArchive.py
@@ -7,6 +7,7 @@ Basic Emulator for LogArchive Step
 """
 from __future__ import print_function
 
+from builtins import str
 import os
 import os.path
 import re

--- a/src/python/WMCore/WMSpec/Steps/Emulators/LogCollect.py
+++ b/src/python/WMCore/WMSpec/Steps/Emulators/LogCollect.py
@@ -7,6 +7,7 @@ Basic Emulator for LogCollect Step
 """
 from __future__ import print_function
 
+from builtins import str
 import os
 import os.path
 import re

--- a/src/python/WMCore/WMSpec/Steps/Emulators/StageOut.py
+++ b/src/python/WMCore/WMSpec/Steps/Emulators/StageOut.py
@@ -7,6 +7,7 @@ Basic Emulator for StageOut Step
 """
 from __future__ import print_function
 
+from builtins import str
 from WMCore.WMSpec.Steps.Emulator import Emulator
 
 class StageOut(Emulator):

--- a/src/python/WMCore/WMSpec/Steps/ExecuteMaster.py
+++ b/src/python/WMCore/WMSpec/Steps/ExecuteMaster.py
@@ -10,6 +10,7 @@ for each step
 
 """
 
+from builtins import str
 import os
 import threading
 import traceback

--- a/src/python/WMCore/WMSpec/Steps/Executor.py
+++ b/src/python/WMCore/WMSpec/Steps/Executor.py
@@ -7,6 +7,7 @@ Interface definition for a step executor
 
 """
 
+from builtins import str
 import os
 import sys
 import json

--- a/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
@@ -6,6 +6,7 @@ _Step.Executor.CMSSW_
 Implementation of an Executor for a CMSSW step.
 """
 
+from builtins import str
 import logging
 import os
 import subprocess

--- a/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
@@ -7,6 +7,7 @@ Implementation of an Executor for a DQMUpload step
 """
 from __future__ import print_function
 
+from builtins import str
 import os
 import sys
 import logging

--- a/src/python/WMCore/WMSpec/Steps/Executors/DeleteFiles.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/DeleteFiles.py
@@ -11,6 +11,7 @@ from __future__ import print_function
 
 
 
+from builtins import str
 import os.path
 import logging
 import signal

--- a/src/python/WMCore/WMSpec/Steps/Executors/LogArchive.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/LogArchive.py
@@ -5,6 +5,7 @@ _Step.Executor.LogArchive_
 Implementation of an Executor for a LogArchive step
 """
 
+from builtins import str
 import os
 import os.path
 import logging

--- a/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
@@ -6,6 +6,7 @@ Implementation of an Executor for a LogCollect step.
 """
 from __future__ import print_function
 
+from builtins import str
 import os
 import re
 import logging

--- a/src/python/WMCore/WMSpec/Steps/Executors/StageOut.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/StageOut.py
@@ -7,6 +7,7 @@ Implementation of an Executor for a StageOut step
 """
 from __future__ import print_function
 
+from builtins import str
 import sys
 import os
 import os.path

--- a/src/python/WMCore/WMSpec/Steps/Fetchers/URLFetcher.py
+++ b/src/python/WMCore/WMSpec/Steps/Fetchers/URLFetcher.py
@@ -5,6 +5,7 @@ _URLFetcher_
 Fetch urls based on the sandbox information in a WMStep
 
 """
+from builtins import str
 import os
 import re
 import logging

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -8,6 +8,9 @@ set of jobs.
 Equivalent of a WorkflowSpec in the ProdSystem.
 """
 
+from builtins import map
+from builtins import zip
+from builtins import str
 import os.path
 import time
 

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -6,6 +6,7 @@ Request level processing specification, acts as a container of a set
 of related tasks.
 """
 from __future__ import print_function
+from builtins import range
 from Utils.Utilities import strToBool
 from WMCore.Configuration import ConfigSection
 from WMCore.WMSpec.ConfigSectionTree import findTop

--- a/src/python/WMCore/WMSpec/WMWorkloadTools.py
+++ b/src/python/WMCore/WMSpec/WMWorkloadTools.py
@@ -8,6 +8,7 @@ Created on Jun 13, 2013
 
 @author: dballest
 """
+from builtins import str
 import json
 import logging
 import re

--- a/src/python/WMCore/WMStats/CherryPyThreads/CleanUpTask.py
+++ b/src/python/WMCore/WMStats/CherryPyThreads/CleanUpTask.py
@@ -1,3 +1,4 @@
+from builtins import str
 from __future__ import (division, print_function)
 
 import traceback

--- a/src/python/WMCore/WMStats/CherryPyThreads/DataCacheUpdate.py
+++ b/src/python/WMCore/WMStats/CherryPyThreads/DataCacheUpdate.py
@@ -1,6 +1,7 @@
 '''
 
 '''
+from builtins import str
 from __future__ import (division, print_function)
 
 from WMCore.REST.CherryPyPeriodicTask import CherryPyPeriodicTask

--- a/src/python/WMCore/WMStats/T0/CherryPyThreads/T0DataCacheUpdate.py
+++ b/src/python/WMCore/WMStats/T0/CherryPyThreads/T0DataCacheUpdate.py
@@ -1,6 +1,7 @@
 '''
 
 '''
+from builtins import str
 from __future__ import (division, print_function)
 
 from WMCore.REST.CherryPyPeriodicTask import CherryPyPeriodicTask

--- a/src/python/WMCore/WebTools/DASRESTFormatter.py
+++ b/src/python/WMCore/WebTools/DASRESTFormatter.py
@@ -11,6 +11,7 @@ A REST formatter that appends the DAS headers to the result data
 # I want dasjson and plist to be methods instead of functions
 # pylint: disable=R0201
 
+from builtins import str
 import json
 import plistlib
 

--- a/src/python/WMCore/WebTools/NestedModel.py
+++ b/src/python/WMCore/WebTools/NestedModel.py
@@ -1,3 +1,4 @@
+from builtins import str
 from WMCore.WebTools.RESTModel import RESTModel
 from cherrypy import response, request, HTTPError
 

--- a/src/python/WMCore/WebTools/Page.py
+++ b/src/python/WMCore/WebTools/Page.py
@@ -3,6 +3,7 @@
 Some generic base classes for building web pages with.
 """
 
+from builtins import str
 import hashlib
 import json
 import logging

--- a/src/python/WMCore/WebTools/RESTApi.py
+++ b/src/python/WMCore/WebTools/RESTApi.py
@@ -19,6 +19,7 @@ active.rest.formatter.templates = '/templates/WMCore/WebTools/'
 
 """
 
+from builtins import str
 import cgi
 import traceback
 

--- a/src/python/WMCore/WebTools/RESTFormatter.py
+++ b/src/python/WMCore/WebTools/RESTFormatter.py
@@ -7,6 +7,7 @@ appropriate format and sets the CherryPy header appropriately.
 
 Could add YAML via http://pyyaml.org/
 """
+from builtins import str
 import json
 from types import GeneratorType
 

--- a/src/python/WMCore/WebTools/RESTModel.py
+++ b/src/python/WMCore/WebTools/RESTModel.py
@@ -4,6 +4,7 @@
 """
 Rest Model abstract implementation
 """
+from builtins import str
 from functools import wraps
 from WMCore.Lexicon import check
 from WMCore.WebTools.WebAPI import WebAPI

--- a/src/python/WMCore/WorkQueue/DataLocationMapper.py
+++ b/src/python/WMCore/WorkQueue/DataLocationMapper.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Map data to locations for WorkQueue"""
 
+from builtins import str
 from collections import defaultdict
 import time
 import logging

--- a/src/python/WMCore/WorkQueue/DataStructs/ACDCBlock.py
+++ b/src/python/WMCore/WorkQueue/DataStructs/ACDCBlock.py
@@ -3,6 +3,7 @@ Set of rules and functions
 Handling resubmission Block construction
 """
 
+from builtins import str
 ACDC_PREFIX = "acdc"
 
 class ACDCBlock(object):

--- a/src/python/WMCore/WorkQueue/DataStructs/CouchWorkQueueElement.py
+++ b/src/python/WMCore/WorkQueue/DataStructs/CouchWorkQueueElement.py
@@ -7,6 +7,7 @@ Created by Dave Evans on 2010-10-12.
 Copyright (c) 2010 Fermilab. All rights reserved.
 """
 
+from builtins import str
 import unittest
 import time
 import logging

--- a/src/python/WMCore/WorkQueue/DataStructs/WorkQueueElementResult.py
+++ b/src/python/WMCore/WorkQueue/DataStructs/WorkQueueElementResult.py
@@ -9,6 +9,7 @@ A dictionary based object meant to represent a WorkQueue block
 
 
 
+from builtins import str
 class WorkQueueElementResult(dict):
     """Class to hold the status of a related group of WorkQueueElements"""
     def __init__(self, **kwargs):

--- a/src/python/WMCore/WorkQueue/Policy/Start/Block.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Block.py
@@ -5,6 +5,7 @@ WorkQueue splitting by block
 """
 from __future__ import print_function, division
 
+from builtins import str
 from math import ceil
 from WMCore.WorkQueue.Policy.Start.StartPolicyInterface import StartPolicyInterface
 from WMCore.Services.SiteDB.SiteDB import SiteDBJSON as SiteDB

--- a/src/python/WMCore/WorkQueue/Policy/Start/MonteCarlo.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/MonteCarlo.py
@@ -5,6 +5,7 @@ WorkQueue splitting by block
 """
 from __future__ import division
 
+from builtins import str
 import os
 from WMCore.WorkQueue.Policy.Start.StartPolicyInterface import StartPolicyInterface
 from WMCore.WorkQueue.WorkQueueExceptions import WorkQueueWMSpecError, WorkQueueNoWorkError

--- a/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
@@ -3,6 +3,7 @@
 WorkQueue SplitPolicyInterface
 
 """
+from builtins import str
 __all__ = []
 
 from WMCore.WorkQueue.Policy.PolicyInterface import PolicyInterface

--- a/src/python/WMCore/WorkQueue/WMBSHelper.py
+++ b/src/python/WMCore/WorkQueue/WMBSHelper.py
@@ -5,6 +5,9 @@ _WMBSHelper_
 Use WMSpecParser to extract information for creating workflow, fileset, and subscription
 """
 
+from builtins import range
+from builtins import zip
+from builtins import str
 import logging
 import threading
 import traceback

--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -12,6 +12,7 @@ https://twiki.cern.ch/twiki/bin/view/CMS/WMCoreJobPool
 
 from __future__ import division, print_function
 
+from builtins import str
 import os
 import threading
 import time

--- a/src/python/WMCore/WorkQueue/WorkQueueBackend.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueBackend.py
@@ -5,6 +5,8 @@ WorkQueueBackend
 Interface to WorkQueue persistent storage
 """
 
+from builtins import map
+from builtins import str
 import json
 import random
 import time

--- a/src/python/WMCore/WorkQueue/WorkQueueReqMgrInterface.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueReqMgrInterface.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Helper class for RequestManager interaction
 """
+from builtins import str
 import os
 import time
 import socket

--- a/src/python/WMCore/WorkerThreads/BaseWorkerThread.py
+++ b/src/python/WMCore/WorkerThreads/BaseWorkerThread.py
@@ -10,6 +10,7 @@ to perform thread-specific setup and clean-up operations
 
 
 
+from builtins import str
 import threading
 import logging
 import time

--- a/src/python/WMCore/WorkerThreads/WorkerThreadManager.py
+++ b/src/python/WMCore/WorkerThreads/WorkerThreadManager.py
@@ -6,6 +6,7 @@ A class used to manage regularly running worker threads.
 """
 from __future__ import print_function
 
+from builtins import str
 import threading
 import logging
 import time

--- a/src/python/WMCore/Wrappers/JsonWrapper/JSONThunker.py
+++ b/src/python/WMCore/Wrappers/JsonWrapper/JSONThunker.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+from builtins import str
 import sys
 import types
 

--- a/src/python/WMQuality/Emulators/AnalyticsDataCollector/DataCollectorAPI.py
+++ b/src/python/WMQuality/Emulators/AnalyticsDataCollector/DataCollectorAPI.py
@@ -3,6 +3,7 @@ Provide functions to collect data and upload data
 """
 from __future__ import print_function
 
+from builtins import range
 import logging
 
 from WMCore.Lexicon import splitCouchServiceURL

--- a/src/python/WMQuality/Emulators/DBSClient/MakeDBSMockFiles.py
+++ b/src/python/WMQuality/Emulators/DBSClient/MakeDBSMockFiles.py
@@ -9,6 +9,7 @@ new files from scratch (i.e., you need to delete the previous DBS json
 mocked data).
 """
 
+from builtins import str
 from __future__ import (division, print_function)
 
 import json

--- a/src/python/WMQuality/Emulators/DataBlockGenerator/DataBlockGenerator.py
+++ b/src/python/WMQuality/Emulators/DataBlockGenerator/DataBlockGenerator.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import
+from builtins import str
+from builtins import range
 from .Globals import GlobalParams
 from . import Globals
 

--- a/src/python/WMQuality/Emulators/SiteDBClient/MakeSiteDBMockFiles.py
+++ b/src/python/WMQuality/Emulators/SiteDBClient/MakeSiteDBMockFiles.py
@@ -4,6 +4,7 @@ MakeSiteDBMockFiles
 Program to create mock SiteDB JSON files used by the SiteDB mock-based emulator
 """
 
+from builtins import str
 from __future__ import (division, print_function)
 
 import json

--- a/src/python/WMQuality/Emulators/WMSpecGenerator/WMSpecGenerator.py
+++ b/src/python/WMQuality/Emulators/WMSpecGenerator/WMSpecGenerator.py
@@ -4,6 +4,7 @@
 """
 from __future__ import absolute_import
 from __future__ import print_function
+from builtins import range
 import os
 import shutil
 import tempfile

--- a/src/python/WMQuality/Emulators/__init__.py
+++ b/src/python/WMQuality/Emulators/__init__.py
@@ -2,6 +2,7 @@
 """
 
 
+from builtins import str
 import logging
 import os
 from WMCore.Configuration import loadConfigurationFile

--- a/src/python/WMQuality/TestInit.py
+++ b/src/python/WMQuality/TestInit.py
@@ -13,6 +13,7 @@ is based on the WMCore.WMInit class.
 """
 from __future__ import print_function
 
+from builtins import str
 import logging
 import os
 import shutil

--- a/test/data/ReqMgr/MigrationToGlobal.py
+++ b/test/data/ReqMgr/MigrationToGlobal.py
@@ -6,6 +6,7 @@ This migrates a dataset from local to global
 Input: Dictionary from RequestQuery
 """
 from __future__ import print_function
+from builtins import str
 import os
 import traceback
 from dbs.apis.dbsClient import DbsApi

--- a/test/data/ReqMgr/RequestQuery.py
+++ b/test/data/ReqMgr/RequestQuery.py
@@ -8,6 +8,7 @@ Request.
 """
 from __future__ import print_function
 
+from builtins import str
 import json
 import os
 

--- a/test/data/ReqMgr/SavannahRequestQuery.py
+++ b/test/data/ReqMgr/SavannahRequestQuery.py
@@ -10,6 +10,7 @@ providing information for the bookeeping database
 """
 from __future__ import print_function
 
+from builtins import str
 import json
 import os
 import re

--- a/test/data/ReqMgr/inject-test-wfs.py
+++ b/test/data/ReqMgr/inject-test-wfs.py
@@ -14,6 +14,7 @@ It will:
 """
 from __future__ import print_function
 
+from builtins import range
 import sys
 import os
 import pwd

--- a/test/data/ReqMgr/reqmgr.py
+++ b/test/data/ReqMgr/reqmgr.py
@@ -33,6 +33,8 @@ by a user on the command line, whichever other argument can be overridden too.
 from __future__ import print_function
 
 
+from builtins import filter
+from builtins import str
 import os
 import sys
 from httplib import HTTPSConnection, HTTPConnection

--- a/test/data/ReqMgr/reqmgr2.py
+++ b/test/data/ReqMgr/reqmgr2.py
@@ -15,6 +15,7 @@ Note: tests for checking data directly in CouchDB in ReqMgr1 test script:
     WMCore/test/data/ReqMgr/reqmgr.py
 """
 from __future__ import print_function
+from builtins import filter
 import os
 import sys
 from httplib import HTTPSConnection, HTTPConnection

--- a/test/data/ReqMgr/validate-test-wfs.py
+++ b/test/data/ReqMgr/validate-test-wfs.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
+from builtins import str
 import os
 import sys
 import urllib

--- a/test/python/PSetTweaks_t/WMTweak_t.py
+++ b/test/python/PSetTweaks_t/WMTweak_t.py
@@ -4,6 +4,7 @@ Unittest for WMTweak module
 
 """
 
+from builtins import str
 import unittest
 
 import PSetTweaks.WMTweak as WMTweaks

--- a/test/python/Utils_t/IteratorTools_t.py
+++ b/test/python/Utils_t/IteratorTools_t.py
@@ -5,6 +5,7 @@ Unittests for IteratorTools functions
 
 from __future__ import division, print_function
 
+from builtins import range
 import itertools
 import unittest
 

--- a/test/python/WMComponent_t/AnalyticsDataCollector_t/AnalyticsDataCollector_t.py
+++ b/test/python/WMComponent_t/AnalyticsDataCollector_t/AnalyticsDataCollector_t.py
@@ -4,6 +4,7 @@
 WorkQueuManager test
 """
 
+from builtins import range
 import os
 import logging
 import threading

--- a/test/python/WMComponent_t/AnalyticsDataCollector_t/Plugins_t/Tier0Plugin_t.py
+++ b/test/python/WMComponent_t/AnalyticsDataCollector_t/Plugins_t/Tier0Plugin_t.py
@@ -8,6 +8,8 @@ Created on Nov 7, 2012
 @author: dballest
 """
 
+from builtins import range
+from builtins import filter
 import os
 import unittest
 

--- a/test/python/WMComponent_t/DBS3Buffer_t/DBSBufferUtil_t.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/DBSBufferUtil_t.py
@@ -5,6 +5,8 @@ _DBSBufferUtil_t_
 Unit tests for DBSBufferUtil class
 """
 
+from builtins import range
+from builtins import str
 import unittest
 import threading
 

--- a/test/python/WMComponent_t/DBS3Buffer_t/DBSUpload_t.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/DBSUpload_t.py
@@ -6,6 +6,7 @@
 DBSUpload test TestDBSUpload module and the harness
 
 """
+from builtins import range
 import os
 import threading
 import time

--- a/test/python/WMComponent_t/DBS3Buffer_t/scaleTest.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/scaleTest.py
@@ -6,6 +6,7 @@ _scaleTest_
 Fills a DBSBuffer with random data and then runs a DBSUpload process on it.
 """
 from __future__ import print_function
+from builtins import range
 import os
 import sys
 import time

--- a/test/python/WMComponent_t/ErrorHandler_t/ErrorHandler_t.py
+++ b/test/python/WMComponent_t/ErrorHandler_t/ErrorHandler_t.py
@@ -4,6 +4,7 @@ ErrorHandler test TestErrorHandler module and the harness
 """
 from __future__ import print_function
 
+from builtins import range
 import os
 import os.path
 import threading

--- a/test/python/WMComponent_t/JobAccountant_t/JobAccountant_t.py
+++ b/test/python/WMComponent_t/JobAccountant_t/JobAccountant_t.py
@@ -6,6 +6,8 @@ Unit tests for the WMAgent JobAccountant component.
 """
 from __future__ import print_function
 
+from builtins import range
+from builtins import str
 import copy
 import os.path
 import threading

--- a/test/python/WMComponent_t/JobAccountant_t/fwjrs/genheritagetest.py
+++ b/test/python/WMComponent_t/JobAccountant_t/fwjrs/genheritagetest.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from builtins import range
 import random
 
 from WMCore.FwkJobReport import Report

--- a/test/python/WMComponent_t/JobAccountant_t/fwjrs/genloadtest.py
+++ b/test/python/WMComponent_t/JobAccountant_t/fwjrs/genloadtest.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from builtins import range
 import random
 
 from WMCore.FwkJobReport import Report

--- a/test/python/WMComponent_t/JobArchiver_t/JobArchiver_t.py
+++ b/test/python/WMComponent_t/JobArchiver_t/JobArchiver_t.py
@@ -4,6 +4,7 @@
 JobArchiver test
 """
 
+from builtins import range
 import os
 import shutil
 import threading

--- a/test/python/WMComponent_t/JobCreator_t/JobCreator_t.py
+++ b/test/python/WMComponent_t/JobCreator_t/JobCreator_t.py
@@ -7,6 +7,7 @@
 
 from __future__ import print_function
 
+from builtins import range
 import cProfile
 import os
 import pickle

--- a/test/python/WMComponent_t/JobSubmitter_t/JobSubmitterCaching_t.py
+++ b/test/python/WMComponent_t/JobSubmitter_t/JobSubmitterCaching_t.py
@@ -5,6 +5,7 @@ _JobSubmitterCaching_t_
 Verify that the caching of jobs and white/black lists works correctly.
 """
 
+from builtins import range
 import unittest
 import os
 import pickle

--- a/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
+++ b/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
@@ -7,6 +7,7 @@ the different dynamics that occur inside the JobSubmitter.
 """
 from __future__ import print_function
 
+from builtins import range
 import cProfile
 import os
 import pickle

--- a/test/python/WMComponent_t/JobTracker_t/JobTracker_t.py
+++ b/test/python/WMComponent_t/JobTracker_t/JobTracker_t.py
@@ -8,6 +8,7 @@ from __future__ import print_function
 
 
 
+from builtins import range
 import os
 import os.path
 import logging

--- a/test/python/WMComponent_t/RetryManager_t/RetryManager_t.py
+++ b/test/python/WMComponent_t/RetryManager_t/RetryManager_t.py
@@ -11,6 +11,7 @@ from __future__ import print_function
 
 
 
+from builtins import range
 import os
 import os.path
 import threading

--- a/test/python/WMComponent_t/TaskArchiver_t/TaskArchiver_t.py
+++ b/test/python/WMComponent_t/TaskArchiver_t/TaskArchiver_t.py
@@ -5,6 +5,8 @@ TaskArchiver test
 Tests both the archiving of tasks and the creation of the
 workloadSummary
 """
+from builtins import str
+from builtins import range
 import json
 import logging
 import os.path

--- a/test/python/WMComponent_t/WorkQueueManager_t/WorkQueueManager_t.py
+++ b/test/python/WMComponent_t/WorkQueueManager_t/WorkQueueManager_t.py
@@ -5,6 +5,7 @@ WorkQueuManager test
 """
 from __future__ import print_function, division
 
+from builtins import next
 import unittest
 
 from WMCore_t.WorkQueue_t.WorkQueueTestCase import WorkQueueTestCase

--- a/test/python/WMCore_t/ACDC_t/CouchCollection_t.py
+++ b/test/python/WMCore_t/ACDC_t/CouchCollection_t.py
@@ -6,6 +6,7 @@ Created by Dave Evans on 2010-10-04.
 Copyright (c) 2010 Fermilab. All rights reserved.
 """
 
+from builtins import range
 import unittest
 import random
 

--- a/test/python/WMCore_t/ACDC_t/CouchFileset_t.py
+++ b/test/python/WMCore_t/ACDC_t/CouchFileset_t.py
@@ -6,6 +6,7 @@ Created by Dave Evans on 2010-10-05.
 Copyright (c) 2010 Fermilab. All rights reserved.
 """
 
+from builtins import range
 import unittest
 import random
 

--- a/test/python/WMCore_t/ACDC_t/CouchService_t.py
+++ b/test/python/WMCore_t/ACDC_t/CouchService_t.py
@@ -7,6 +7,7 @@ Created by Dave Evans on 2010-10-04.
 Copyright (c) 2010 Fermilab. All rights reserved.
 """
 
+from builtins import range
 import unittest
 import random
 import time

--- a/test/python/WMCore_t/Agent_t/Configuration_t.py
+++ b/test/python/WMCore_t/Agent_t/Configuration_t.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #pylint: disable=E1101,C0103,R0902
 
+from builtins import range
+from builtins import str
 import unittest
 import os
 import tempfile

--- a/test/python/WMCore_t/Agent_t/Harness_t.py
+++ b/test/python/WMCore_t/Agent_t/Harness_t.py
@@ -5,6 +5,7 @@ Component test TestComponent module and the harness
 """
 from __future__ import print_function
 
+from builtins import str
 import os
 import threading
 import time

--- a/test/python/WMCore_t/BossAir_t/BossAir_t.py
+++ b/test/python/WMCore_t/BossAir_t/BossAir_t.py
@@ -5,6 +5,7 @@ BossAir preliminary test
 """
 from __future__ import print_function
 
+from builtins import range
 import os.path
 import threading
 import unittest

--- a/test/python/WMCore_t/BossAir_t/RunJob_t.py
+++ b/test/python/WMCore_t/BossAir_t/RunJob_t.py
@@ -4,6 +4,7 @@
 BossAir preliminary test
 """
 
+from builtins import range
 import unittest
 import threading
 

--- a/test/python/WMCore_t/Configuration_t.py
+++ b/test/python/WMCore_t/Configuration_t.py
@@ -2,6 +2,8 @@
 #pylint: disable=E1101,C0103,R0902
 
 
+from builtins import range
+from builtins import str
 import unittest
 
 from WMCore.Configuration import ConfigSection

--- a/test/python/WMCore_t/DataStructs_t/Fileset_t.py
+++ b/test/python/WMCore_t/DataStructs_t/Fileset_t.py
@@ -5,6 +5,7 @@ _Fileset_t_
 Testcase for Fileset
 
 """
+from builtins import range
 import logging
 import random
 import unittest

--- a/test/python/WMCore_t/DataStructs_t/JobPackage_t.py
+++ b/test/python/WMCore_t/DataStructs_t/JobPackage_t.py
@@ -5,6 +5,7 @@ _JobPackage_
 Unittests for JobPackage persistency mechanism
 """
 
+from builtins import range
 import os
 import unittest
 

--- a/test/python/WMCore_t/DataStructs_t/Job_t.py
+++ b/test/python/WMCore_t/DataStructs_t/Job_t.py
@@ -5,6 +5,7 @@ _Job_t_
 Testcase for the Job class.
 """
 
+from builtins import range
 import unittest, logging, random, time
 
 from WMCore.DataStructs.Job import Job

--- a/test/python/WMCore_t/DataStructs_t/LumiList_t.py
+++ b/test/python/WMCore_t/DataStructs_t/LumiList_t.py
@@ -1,5 +1,8 @@
 #! /usr/bin/env python
 
+from builtins import zip
+from builtins import str
+from builtins import range
 import unittest
 
 # import FWCore.ParameterSet.Config as cms

--- a/test/python/WMCore_t/DataStructs_t/MathStructs_t/ContinuousSummaryHistogram_t.py
+++ b/test/python/WMCore_t/DataStructs_t/MathStructs_t/ContinuousSummaryHistogram_t.py
@@ -10,6 +10,7 @@ Created on Nov 20, 2012
 
 @author: dballest
 """
+from builtins import range
 import unittest
 import random
 

--- a/test/python/WMCore_t/DataStructs_t/MathStructs_t/DiscreteSummaryHistogram_t.py
+++ b/test/python/WMCore_t/DataStructs_t/MathStructs_t/DiscreteSummaryHistogram_t.py
@@ -11,6 +11,7 @@ Created on Nov 20, 2012
 @author: dballest
 """
 
+from builtins import range
 import unittest
 
 from WMCore.DataStructs.MathStructs.DiscreteSummaryHistogram import DiscreteSummaryHistogram

--- a/test/python/WMCore_t/DataStructs_t/Subscription_t.py
+++ b/test/python/WMCore_t/DataStructs_t/Subscription_t.py
@@ -5,6 +5,8 @@ _Subscription_t_
 Testcase for the Subscription class
 """
 
+from builtins import range
+from builtins import str
 import random
 import unittest
 

--- a/test/python/WMCore_t/Database_t/CMSCouch_t.py
+++ b/test/python/WMCore_t/Database_t/CMSCouch_t.py
@@ -6,6 +6,7 @@ CouchDB instance, and is not going to work in an automated way just yet - we'll
 need to add Couch as an external, include it in start up scripts etc.
 """
 
+from builtins import range
 from WMCore.Database.CMSCouch import CouchServer, Document, Database, CouchInternalServerError, CouchNotFoundError
 import random
 import unittest

--- a/test/python/WMCore_t/Database_t/CouchUtils_t.py
+++ b/test/python/WMCore_t/Database_t/CouchUtils_t.py
@@ -7,6 +7,7 @@ Created by Dave Evans on 2010-10-04.
 Copyright (c) 2010 Fermilab. All rights reserved.
 """
 
+from builtins import str
 import unittest
 
 import WMCore.Database.CouchUtils as CouchUtils

--- a/test/python/WMCore_t/Database_t/DBCore_t.py
+++ b/test/python/WMCore_t/Database_t/DBCore_t.py
@@ -8,6 +8,8 @@ Unit tests for the DBInterface class
 
 
 
+from builtins import range
+from builtins import str
 import unittest
 import logging
 import threading

--- a/test/python/WMCore_t/Database_t/DBFormatter_t.py
+++ b/test/python/WMCore_t/Database_t/DBFormatter_t.py
@@ -7,6 +7,7 @@ Unit tests for the DBFormatter class
 """
 from __future__ import print_function
 
+from builtins import str
 import threading
 import unittest
 

--- a/test/python/WMCore_t/Database_t/Performance.py
+++ b/test/python/WMCore_t/Database_t/Performance.py
@@ -11,6 +11,7 @@ DB Performance Testcases
 """
 from __future__ import print_function
 
+from builtins import str
 import logging, time
 
 class Performance:

--- a/test/python/WMCore_t/Database_t/ResultSet_t.py
+++ b/test/python/WMCore_t/Database_t/ResultSet_t.py
@@ -10,6 +10,8 @@ Unit tests for the Database/ResultSet class
 #Written to test the ResultSet class initially by mnorman
 #Dependent on DBCore, specifically DBCore.processData()
 
+from builtins import range
+from builtins import str
 import unittest
 import logging
 import threading

--- a/test/python/WMCore_t/Database_t/RotatingDatabase_t.py
+++ b/test/python/WMCore_t/Database_t/RotatingDatabase_t.py
@@ -1,3 +1,4 @@
+from builtins import range
 import unittest
 import os
 import sys

--- a/test/python/WMCore_t/FwkJobReport_t/ReportIntegration_t.py
+++ b/test/python/WMCore_t/FwkJobReport_t/ReportIntegration_t.py
@@ -6,6 +6,7 @@ Verify that the whole FWJR chain works correctly:
   CMSSW XML -> XMLParser -> Report -> Pickle -> UnPickle -> Accountant
 """
 
+from builtins import str
 import unittest
 import os
 import xml.dom.minidom

--- a/test/python/WMCore_t/GroupUser_t/Interface_t.py
+++ b/test/python/WMCore_t/GroupUser_t/Interface_t.py
@@ -7,6 +7,7 @@ Created by Dave Evans on 2010-07-29.
 Copyright (c) 2010 Fermilab. All rights reserved.
 """
 
+from builtins import range
 import unittest
 import os
 

--- a/test/python/WMCore_t/JobSplitting_t/EventAwareLumiBased_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/EventAwareLumiBased_t.py
@@ -9,6 +9,7 @@ Created on Sep 25, 2012
 
 @author: dballest
 """
+from builtins import range
 import unittest
 
 from WMCore.DataStructs.File import File

--- a/test/python/WMCore_t/JobSplitting_t/EventAwareLumiByWork_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/EventAwareLumiByWork_t.py
@@ -8,6 +8,7 @@ specific ones for this algorithm.
 
 from __future__ import division, print_function
 
+from builtins import range
 import logging
 import unittest
 from collections import Counter

--- a/test/python/WMCore_t/JobSplitting_t/EventBased_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/EventBased_t.py
@@ -5,6 +5,7 @@ _EventBased_t_
 Event based splitting test.
 """
 
+from builtins import range
 import unittest
 
 from WMCore.DataStructs.File import File

--- a/test/python/WMCore_t/JobSplitting_t/FileBased_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/FileBased_t.py
@@ -8,6 +8,7 @@ File based splitting test.
 
 
 
+from builtins import range
 import unittest
 
 from WMCore.DataStructs.File import File

--- a/test/python/WMCore_t/JobSplitting_t/FixedDelay_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/FixedDelay_t.py
@@ -5,6 +5,7 @@ _FixedDelay_t_
 Fixed Delay splitting test.
 """
 
+from builtins import range
 import unittest
 
 from WMCore.DataStructs.File import File

--- a/test/python/WMCore_t/JobSplitting_t/Generators_t/AutomaticSeeding_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/Generators_t/AutomaticSeeding_t.py
@@ -8,6 +8,7 @@ Copyright (c) 2010 Fermilab. All rights reserved.
 """
 from __future__ import print_function
 
+from builtins import str
 import sys
 import os
 import unittest

--- a/test/python/WMCore_t/JobSplitting_t/Generators_t/Seeders_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/Generators_t/Seeders_t.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from builtins import range
 import unittest
 
 

--- a/test/python/WMCore_t/JobSplitting_t/Harvest_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/Harvest_t.py
@@ -6,6 +6,8 @@ Harvest job splitting test
 
 """
 
+from builtins import range
+from builtins import str
 import unittest
 import threading
 import logging

--- a/test/python/WMCore_t/JobSplitting_t/LumiBased_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/LumiBased_t.py
@@ -5,6 +5,8 @@ _LumiBased_t_
 Lumi based splitting test.
 """
 
+from builtins import next
+from builtins import range
 import unittest
 
 from WMCore.DataStructs.File import File

--- a/test/python/WMCore_t/JobSplitting_t/RunBased_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/RunBased_t.py
@@ -8,6 +8,7 @@ RunBased splitting test.
 
 
 
+from builtins import range
 import unittest
 
 from WMCore.DataStructs.File import File

--- a/test/python/WMCore_t/JobSplitting_t/SizeBased_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/SizeBased_t.py
@@ -8,6 +8,7 @@ Size based splitting test.
 
 
 
+from builtins import range
 import unittest
 
 from WMCore.DataStructs.File import File

--- a/test/python/WMCore_t/JobStateMachine_t/ChangeState_t.py
+++ b/test/python/WMCore_t/JobStateMachine_t/ChangeState_t.py
@@ -4,6 +4,8 @@ _ChangeState_t_
 
 """
 
+from builtins import range
+from builtins import str
 import unittest
 import os
 import threading

--- a/test/python/WMCore_t/JobStateMachine_t/Couchapp_t.py
+++ b/test/python/WMCore_t/JobStateMachine_t/Couchapp_t.py
@@ -8,6 +8,7 @@ test couchapps.  Its utility is probably limited for people who
 know what they're doing, and for couchapps that will never need
 to be altered
 """
+from builtins import range
 import os
 import unittest
 import threading

--- a/test/python/WMCore_t/Misc_t/Runtime_t.py
+++ b/test/python/WMCore_t/Misc_t/Runtime_t.py
@@ -10,6 +10,7 @@ from __future__ import print_function
 
 
 # Basic libraries
+from builtins import range
 import unittest
 import threading
 import logging

--- a/test/python/WMCore_t/Misc_t/WMAgent_t.py
+++ b/test/python/WMCore_t/Misc_t/WMAgent_t.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 
+from builtins import range
 import os
 import time
 import shutil

--- a/test/python/WMCore_t/Operations_t/RecoveryCode_t.py
+++ b/test/python/WMCore_t/Operations_t/RecoveryCode_t.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from builtins import range
 import unittest
 import os
 import os.path

--- a/test/python/WMCore_t/ProcessPool_t/ProcessPool_t.py
+++ b/test/python/WMCore_t/ProcessPool_t/ProcessPool_t.py
@@ -4,6 +4,7 @@ _ProcessPool_t
 Unit tests for the ProcessPool class.
 """
 
+from builtins import range
 import unittest
 import nose
 

--- a/test/python/WMCore_t/REST_t/Daemon_t.py
+++ b/test/python/WMCore_t/REST_t/Daemon_t.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 # system modules
+from builtins import str
 import cherrypy
 from multiprocessing import Process
 from cherrypy.test import webtest

--- a/test/python/WMCore_t/ResourceControl_t/ResourceControl_t.py
+++ b/test/python/WMCore_t/ResourceControl_t/ResourceControl_t.py
@@ -5,6 +5,7 @@ _ResourceControl_t_
 Unit tests for ResourceControl.
 """
 
+from builtins import str
 import os
 import subprocess
 import sys

--- a/test/python/WMCore_t/Services_t/Dashboard_t/DashboardAPI_t.py
+++ b/test/python/WMCore_t/Services_t/Dashboard_t/DashboardAPI_t.py
@@ -8,6 +8,7 @@ Created on Tue Feb 23 13:30:04 2016
 @author: jbalcas
 """
 from __future__ import print_function, division
+from builtins import range
 import unittest
 
 import os

--- a/test/python/WMCore_t/Services_t/Registration_t/Registration_t.py
+++ b/test/python/WMCore_t/Services_t/Registration_t/Registration_t.py
@@ -5,6 +5,7 @@ Created on 16 Jul 2009
 @author: metson
 '''
 
+from builtins import str
 import unittest
 import logging
 import os

--- a/test/python/WMCore_t/Services_t/Requests_t.py
+++ b/test/python/WMCore_t/Services_t/Requests_t.py
@@ -7,6 +7,7 @@ Created on Aug 6, 2009
 '''
 from __future__ import print_function
 
+from builtins import range
 import os
 import shutil
 import tempfile

--- a/test/python/WMCore_t/Services_t/UUID_t.py
+++ b/test/python/WMCore_t/Services_t/UUID_t.py
@@ -5,6 +5,7 @@
 
 
 from __future__ import print_function
+from builtins import range
 import unittest
 import os
 import logging

--- a/test/python/WMCore_t/Services_t/WMArchive_t/DataMap_t.py
+++ b/test/python/WMCore_t/Services_t/WMArchive_t/DataMap_t.py
@@ -1,3 +1,4 @@
+from builtins import str
 from __future__ import (division, print_function)
 import unittest
 import time

--- a/test/python/WMCore_t/Services_t/WorkQueue_t/WorkQueue_t.py
+++ b/test/python/WMCore_t/Services_t/WorkQueue_t/WorkQueue_t.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function, division
+from builtins import str
 import unittest
 import time
 

--- a/test/python/WMCore_t/Storage_t/TrivialFileCatalog_t.py
+++ b/test/python/WMCore_t/Storage_t/TrivialFileCatalog_t.py
@@ -5,6 +5,7 @@ _TrivialFileCatalog_t_
 Test the parsing of the TFC.
 """
 
+from builtins import str
 import os
 import unittest
 import nose

--- a/test/python/WMCore_t/ThreadPool_t/ThreadPool_t.py
+++ b/test/python/WMCore_t/ThreadPool_t/ThreadPool_t.py
@@ -12,6 +12,7 @@ from __future__ import print_function
 
 
 
+from builtins import str
 import unittest
 import threading
 import time

--- a/test/python/WMCore_t/WMBS_t/CursorLeak_t.py
+++ b/test/python/WMCore_t/WMBS_t/CursorLeak_t.py
@@ -5,6 +5,7 @@ _File_t_
 Unit tests for the WMBS File class.
 """
 
+from builtins import range
 import threading
 import unittest
 

--- a/test/python/WMCore_t/WMBS_t/JobGroup_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobGroup_t.py
@@ -5,6 +5,7 @@ _JobGroup_t_
 Unit tests for the WMBS JobGroup class.
 """
 
+from builtins import range
 import threading
 import unittest
 

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/EventAwareLumiBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/EventAwareLumiBased_t.py
@@ -7,6 +7,7 @@ Created on Oct 2, 2012
 @author: dballest
 """
 
+from builtins import range
 import unittest
 import threading
 

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/EventBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/EventBased_t.py
@@ -5,6 +5,8 @@ _EventBased_t_
 Event based splitting test.
 """
 
+from builtins import str
+from builtins import range
 import unittest
 import threading
 import os

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/FileBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/FileBased_t.py
@@ -6,6 +6,8 @@ File based splitting test.
 """
 
 
+from builtins import range
+from builtins import next
 import unittest
 import threading
 

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/FixedDelay_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/FixedDelay_t.py
@@ -5,6 +5,7 @@ _FixedDelay_t_
 Fixed delay job splitting.
 """
 
+from builtins import range
 import unittest
 import os
 import threading

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/LumiBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/LumiBased_t.py
@@ -7,6 +7,7 @@ Test lumi based splitting.
 
 from __future__ import division
 
+from builtins import range
 import threading
 import unittest
 import random

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/MinFileBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/MinFileBased_t.py
@@ -6,6 +6,7 @@ File based splitting test.
 """
 
 
+from builtins import range
 import unittest
 import os
 import threading

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/RunBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/RunBased_t.py
@@ -8,6 +8,7 @@ Event based splitting test.
 
 
 
+from builtins import range
 import unittest
 import os
 import threading

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/SiblingProcessingBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/SiblingProcessingBased_t.py
@@ -5,6 +5,8 @@ _SiblingProcessingBased_t_
 Test SiblingProcessing job splitting.
 """
 
+from builtins import range
+from builtins import str
 import unittest
 import threading
 

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/SizeBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/SizeBased_t.py
@@ -5,6 +5,7 @@ _SizeBased_t_
 Size based splitting test.
 """
 
+from builtins import range
 import unittest
 import threading
 import os

--- a/test/python/WMCore_t/WMBS_t/Job_t.py
+++ b/test/python/WMCore_t/WMBS_t/Job_t.py
@@ -6,6 +6,7 @@ Unit tests for the WMBS job class.
 """
 from __future__ import absolute_import
 
+from builtins import str
 import threading
 import unittest
 

--- a/test/python/WMCore_t/WMBS_t/Workflow_t.py
+++ b/test/python/WMCore_t/WMBS_t/Workflow_t.py
@@ -5,6 +5,8 @@ _Workflow_t_
 Unit tests for the WMBS Workflow class.
 """
 
+from builtins import range
+from builtins import str
 import threading
 import unittest
 

--- a/test/python/WMCore_t/WMException_t.py
+++ b/test/python/WMCore_t/WMException_t.py
@@ -6,6 +6,7 @@ General test for WMException
 
 """
 from __future__ import print_function, division
+from builtins import str
 import logging
 import unittest
 import os

--- a/test/python/WMCore_t/WMFactory_t/TestCollection_1/TestRegistryFile1.py
+++ b/test/python/WMCore_t/WMFactory_t/TestCollection_1/TestRegistryFile1.py
@@ -1,3 +1,4 @@
+from builtins import str
 import logging
 
 class TestRegistryFile1:

--- a/test/python/WMCore_t/WMFactory_t/TestCollection_1/TestRegistryFile2.py
+++ b/test/python/WMCore_t/WMFactory_t/TestCollection_1/TestRegistryFile2.py
@@ -1,3 +1,4 @@
+from builtins import str
 import logging
 
 class TestRegistryFile2:

--- a/test/python/WMCore_t/WMFactory_t/TestCollection_2/TestRegistryFile1.py
+++ b/test/python/WMCore_t/WMFactory_t/TestCollection_2/TestRegistryFile1.py
@@ -1,3 +1,4 @@
+from builtins import str
 import logging
 
 class TestRegistryFile1:

--- a/test/python/WMCore_t/WMFactory_t/TestCollection_2/TestRegistryFile2.py
+++ b/test/python/WMCore_t/WMFactory_t/TestCollection_2/TestRegistryFile2.py
@@ -1,3 +1,4 @@
+from builtins import str
 import logging
 
 class TestRegistryFile2:

--- a/test/python/WMCore_t/WMFactory_t/TestCollection_3/TestRegistryFile1.py
+++ b/test/python/WMCore_t/WMFactory_t/TestCollection_3/TestRegistryFile1.py
@@ -1,3 +1,4 @@
+from builtins import str
 import logging
 
 class TestRegistryFile1:

--- a/test/python/WMCore_t/WMLogging_t.py
+++ b/test/python/WMCore_t/WMLogging_t.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
+from builtins import range
 import logging
 import unittest
 import os

--- a/test/python/WMCore_t/WMRuntime_t/Scripts_t/SetupCMSSWPset_t.py
+++ b/test/python/WMCore_t/WMRuntime_t/Scripts_t/SetupCMSSWPset_t.py
@@ -7,6 +7,8 @@ Tests for the PSet configuration code.
 """
 from __future__ import print_function
 
+from builtins import zip
+from builtins import str
 import imp
 import unittest
 import os

--- a/test/python/WMCore_t/WMRuntime_t/Tools_t/Scram_t.py
+++ b/test/python/WMCore_t/WMRuntime_t/Tools_t/Scram_t.py
@@ -7,6 +7,7 @@ Created by Dave Evans on 2012-01-27.
 Copyright (c) 2012 evansde77. All rights reserved.
 """
 
+from builtins import str
 import unittest
 import os
 import tempfile

--- a/test/python/WMCore_t/WMSpec_t/ConfigSectionTree_t.py
+++ b/test/python/WMCore_t/WMSpec_t/ConfigSectionTree_t.py
@@ -3,6 +3,7 @@
 Tests for ConfigSectionTree
 """
 
+from builtins import str
 import unittest
 
 from WMCore.WMSpec.ConfigSectionTree import ConfigSectionTree

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
@@ -8,6 +8,7 @@ Copyright (c) 2011 Fermilab. All rights reserved.
 """
 from __future__ import print_function
 
+from builtins import range
 import json
 import os
 import threading

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Builder_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Builder_t.py
@@ -8,6 +8,7 @@ Unittest for Builder.py
 
 
 
+from builtins import str
 import unittest
 import tempfile
 import shutil

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Builders_t/CMSSW_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Builders_t/CMSSW_t.py
@@ -3,6 +3,7 @@
 Unittest for CMSSW.py
 """
 
+from builtins import str
 import unittest
 import tempfile
 import shutil

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Builders_t/StageOut_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Builders_t/StageOut_t.py
@@ -8,6 +8,7 @@ Unittest for StageOut.py
 
 
 
+from builtins import str
 import unittest
 import tempfile
 import shutil

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/CMSSW_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/CMSSW_t.py
@@ -10,6 +10,7 @@ Created by Dave Evans on 2010-03-15.
 Copyright (c) 2010 Fermilab. All rights reserved.
 """
 
+from builtins import str
 import inspect
 import os
 import shutil

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/StepFactory_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/StepFactory_t.py
@@ -7,6 +7,7 @@ Unittests for StepFactory module
 """
 
 
+from builtins import str
 import unittest
 import WMCore.WMSpec.Steps.StepFactory as StepFactory
 

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Template_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Template_t.py
@@ -6,6 +6,7 @@ Unittest for WMCore.WMSpec.Steps.Template module
 
 """
 
+from builtins import str
 import unittest
 
 from WMCore.WMSpec.WMStep import WMStep, WMStepHelper

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Templates_t/CMSSWTemplate_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Templates_t/CMSSWTemplate_t.py
@@ -7,6 +7,7 @@ Created by Dave Evans on 2010-03-30.
 Copyright (c) 2010 Fermilab. All rights reserved.
 """
 
+from builtins import str
 import unittest
 
 from WMCore.WMSpec.Steps.Templates.CMSSW import CMSSW as CMSSWTemplate

--- a/test/python/WMCore_t/WMSpec_t/WMStep_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMStep_t.py
@@ -4,6 +4,7 @@ Unittest for WMStep
 """
 
 
+from builtins import str
 import unittest
 from WMCore.WMSpec.WMStep import WMStep, makeWMStep
 

--- a/test/python/WMCore_t/WebTools_t/DummyRESTModel.py
+++ b/test/python/WMCore_t/WebTools_t/DummyRESTModel.py
@@ -1,3 +1,5 @@
+from builtins import map
+from builtins import range
 from WMCore.WebTools.RESTModel import RESTModel, restexpose
 from cherrypy import HTTPError
 

--- a/test/python/WMCore_t/WebTools_t/RESTFormat_t.py
+++ b/test/python/WMCore_t/WebTools_t/RESTFormat_t.py
@@ -7,6 +7,7 @@ Unit tests for checking RESTModel works correctly
 TODO: duplicate all direct call tests to ones that use HTTP
 """
 
+from builtins import range
 import json
 import unittest
 import logging

--- a/test/python/WMCore_t/WorkQueue_t/DataStructs_t/WorkQueueElement_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/DataStructs_t/WorkQueueElement_t.py
@@ -3,6 +3,7 @@
     WorkQueueElement unit tests
 """
 
+from builtins import range
 import unittest
 import itertools
 

--- a/test/python/WMCore_t/WorkQueue_t/LocalQueueProfile_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/LocalQueueProfile_t.py
@@ -4,6 +4,7 @@
 """
 from __future__ import absolute_import, division, print_function
 
+from builtins import range
 import cProfile
 import pstats
 import shutil

--- a/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Block_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Block_t.py
@@ -3,6 +3,7 @@
     WorkQueue.Policy.Start.Block tests
 """
 
+from builtins import str
 import unittest
 
 from WMCore_t.WMSpec_t.samples.MultiTaskProcessingWorkload import workload as MultiTaskProcessingWorkload

--- a/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/ResubmitBlock_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/ResubmitBlock_t.py
@@ -9,6 +9,7 @@ Created on Feb 19, 2013
 @author: dballest
 """
 
+from builtins import range
 import os
 import unittest
 

--- a/test/python/WMCore_t/WorkQueue_t/WMBSHelper_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WMBSHelper_t.py
@@ -5,6 +5,7 @@ _WMBSHelper_t_
 Unit tests for the WMBSHelper class.
 """
 
+from builtins import next
 import os
 import threading
 import unittest

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueueProfile_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueueProfile_t.py
@@ -4,6 +4,8 @@
 """
 from __future__ import absolute_import
 
+from builtins import range
+from builtins import str
 import tempfile
 import unittest
 import cProfile

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueueReqMgrInterface_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueueReqMgrInterface_t.py
@@ -4,6 +4,7 @@
 WorkQueueRegMgrInterface test
 """
 
+from builtins import next
 import unittest
 
 from WMCore_t.WorkQueue_t.WorkQueueTestCase import WorkQueueTestCase

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
@@ -6,6 +6,9 @@ WorkQueue tests
 """
 from __future__ import print_function
 
+from builtins import next
+from builtins import range
+from builtins import str
 import os
 import threading
 import time


### PR DESCRIPTION
Builtins feature provides Py2/3 compatibility for new code using **future** is to include the following imports at the top of every module:
`from builtins import *`
On Python 3, this has no effect. (It shadows builtins with globals of the same names.)
On Python 2, this import line shadows 18 builtins (listed below) to provide their Python 3 semantics.
[[source]](http://python-future.org/imports.html#builtins)
