### PR TITLE
'future_standard_library' fix applied

### DIFF
--- a/src/python/PSetTweaks/PSetTweak.py
+++ b/src/python/PSetTweaks/PSetTweak.py
@@ -7,7 +7,9 @@ independent python structure
 
 """
 
-import StringIO
+from future import standard_library
+standard_library.install_aliases()
+import io
 import imp
 import inspect
 import json
@@ -400,7 +402,7 @@ class PSetTweak:
 
 
             jsoniser = JSONiser()
-            jsoniser.dejson(json.load(StringIO.StringIO(jsonContent)))
+            jsoniser.dejson(json.load(io.StringIO(jsonContent)))
 
             for param, value in jsoniser.parameters.items():
                 self.addParameter(param , value)

--- a/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
@@ -25,10 +25,12 @@ add them, and then add the files.  This is why everything is
 so convoluted.
 """
 
+from future import standard_library
+standard_library.install_aliases()
 import time
 import threading
 import logging
-import Queue
+import queue
 import traceback
 import multiprocessing
 
@@ -686,7 +688,7 @@ class DBSUploadPoller(BaseWorkerThread):
                 blocksToClose.append(blockresult)
                 self.blockCount -= 1
                 logging.debug("Got a block to close")
-            except Queue.Empty:
+            except queue.Empty:
                 # This means the queue has no current results
                 time.sleep(2)
                 emptyCount += 1

--- a/src/python/WMComponent/ErrorHandler/ErrorHandlerPoller.py
+++ b/src/python/WMComponent/ErrorHandler/ErrorHandlerPoller.py
@@ -25,10 +25,12 @@ immediately to the 'created' state, skipping cooloff.  It defaults to [].
 
 Note that failureExitCodes has precedence over passExitCodes.
 """
+from future import standard_library
+standard_library.install_aliases()
 import logging
 import os.path
 import threading
-from httplib import HTTPException
+from http.client import HTTPException
 
 from WMCore.ACDC.DataCollectionService import DataCollectionService
 from WMCore.DAOFactory import DAOFactory

--- a/src/python/WMComponent/JobCreator/JobCreatorPoller.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorPoller.py
@@ -2,6 +2,8 @@
 """
 The JobCreator Poller for the JSM
 """
+from future import standard_library
+standard_library.install_aliases()
 __all__ = []
 
 
@@ -11,7 +13,7 @@ import logging
 import traceback
 import threading
 try:
-    import cPickle as pickle
+    import pickle as pickle
 except ImportError:
     import pickle
 

--- a/src/python/WMComponent/JobCreator/JobCreatorWorker.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorWorker.py
@@ -27,6 +27,8 @@ Note:  Jobs are split up by subscription, so having
 one long subscription can make the JobCreatorWorker
 wait for excessively long amounts of time while it runs.
 """
+from future import standard_library
+standard_library.install_aliases()
 __all__ = []
 
 
@@ -40,7 +42,7 @@ import os.path
 import gc
 
 try:
-    import cPickle as pickle
+    import pickle as pickle
 except ImportError:
     import pickle
 

--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -8,13 +8,15 @@ _JobSubmitterPoller_t_
 Submit jobs for execution.
 """
 
+from future import standard_library
+standard_library.install_aliases()
 import logging
 import threading
 import os.path
 from collections import defaultdict, Counter
 from operator import itemgetter
 try:
-    import cPickle as pickle
+    import pickle as pickle
 except ImportError:
     import pickle
 

--- a/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
+++ b/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
@@ -41,11 +41,13 @@ deleted from the site it was originally injected at.
 
 """
 
+from future import standard_library
+standard_library.install_aliases()
 import threading
 import logging
 import traceback
 import time
-from httplib import HTTPException
+from http.client import HTTPException
 
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 from WMCore.WMException import WMException

--- a/src/python/WMComponent/TaskArchiver/CleanCouchPoller.py
+++ b/src/python/WMComponent/TaskArchiver/CleanCouchPoller.py
@@ -1,7 +1,9 @@
 """
 Perform cleanup actions
 """
-import httplib
+from future import standard_library
+standard_library.install_aliases()
+import http.client
 import json
 import logging
 import os.path
@@ -953,7 +955,7 @@ class CleanCouchPoller(BaseWorkerThread):
         dqmHost = regExpResult.group(1)
         dqmPath = regExpResult.group(2)
 
-        connection = httplib.HTTPSConnection(dqmHost, 443, hostKey, hostCert)
+        connection = http.client.HTTPSConnection(dqmHost, 443, hostKey, hostCert)
         try:
             connection.request('GET', dqmPath)
             response = connection.getresponse()

--- a/src/python/WMCore/Agent/Flow/DefaultFlow.py
+++ b/src/python/WMCore/Agent/Flow/DefaultFlow.py
@@ -11,9 +11,11 @@ Sample configuration for generating workflow.
 
 
 
+from future import standard_library
+standard_library.install_aliases()
 import os
 try:
-    import cPickle as pickle
+    import pickle as pickle
 except ImportError:
     import pickle
 

--- a/src/python/WMCore/Agent/Flow/Generate.py
+++ b/src/python/WMCore/Agent/Flow/Generate.py
@@ -13,10 +13,12 @@ from __future__ import print_function
 
 
 
+from future import standard_library
+standard_library.install_aliases()
 import os
 import sys
 try:
-    import cPickle as pickle
+    import pickle as pickle
 except ImportError:
     import pickle
 

--- a/src/python/WMCore/BossAir/Plugins/MockPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/MockPlugin.py
@@ -5,6 +5,8 @@ _BossAirPlugin_
 Base class for BossAir plugins
 """
 
+from future import standard_library
+standard_library.install_aliases()
 import os
 import logging
 from WMCore.BossAir.Plugins.BasePlugin import BasePlugin, BossAirPluginException
@@ -13,7 +15,7 @@ from datetime import timedelta
 from random import randint
 import multiprocessing
 try:
-    import cPickle as pickle
+    import pickle as pickle
 except ImportError:
     import pickle
 

--- a/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/PyCondorPlugin.py
@@ -7,7 +7,9 @@ For glide-in use.
 """
 from __future__ import division
 
-import Queue
+from future import standard_library
+standard_library.install_aliases()
+import queue
 import glob
 import logging
 import multiprocessing
@@ -444,7 +446,7 @@ class PyCondorPlugin(BasePlugin):
         for dummy in range(nSubmits):
             try:
                 res = self.result.get(block=True, timeout=timeout)
-            except Queue.Empty:
+            except queue.Empty:
                 # If the queue was empty go to the next submit
                 # Those jobs have vanished
                 logging.error("Queue.Empty error received!")

--- a/src/python/WMCore/DataStructs/JobPackage.py
+++ b/src/python/WMCore/DataStructs/JobPackage.py
@@ -6,8 +6,10 @@ Data structure for storing and retreiving multiple job objects.
 """
 
 
+from future import standard_library
+standard_library.install_aliases()
 try:
-    import cPickle as pickle
+    import pickle as pickle
 except ImportError:
     import pickle
 

--- a/src/python/WMCore/Database/CMSCouch.py
+++ b/src/python/WMCore/Database/CMSCouch.py
@@ -10,6 +10,8 @@ NOT A THREAD SAFE CLASS.
 """
 from __future__ import print_function
 
+from future import standard_library
+standard_library.install_aliases()
 import time
 import urllib
 import re
@@ -17,7 +19,7 @@ import hashlib
 import base64
 import logging
 import traceback
-from httplib import HTTPException
+from http.client import HTTPException
 from datetime import datetime
 
 from WMCore.Services.Requests import JSONRequests

--- a/src/python/WMCore/Database/CouchUtils.py
+++ b/src/python/WMCore/Database/CouchUtils.py
@@ -8,8 +8,10 @@ Copyright (c) 2010 Fermilab. All rights reserved.
 """
 from __future__ import print_function
 
+from future import standard_library
+standard_library.install_aliases()
 import functools
-from httplib import HTTPException
+from http.client import HTTPException
 
 import WMCore.Database.CMSCouch as CMSCouch
 

--- a/src/python/WMCore/Database/ipy_profile_couch.py
+++ b/src/python/WMCore/Database/ipy_profile_couch.py
@@ -9,6 +9,8 @@ from __future__ import print_function
 
 
 
+from future import standard_library
+standard_library.install_aliases()
 __license__    = "GPL"
 
 __maintainer__ = "Valentin Kuznetsov"

--- a/src/python/WMCore/FwkJobReport/Report.py
+++ b/src/python/WMCore/FwkJobReport/Report.py
@@ -7,6 +7,8 @@ Framework job report object.
 """
 from __future__ import print_function
 
+from future import standard_library
+standard_library.install_aliases()
 import logging
 import math
 import re
@@ -22,7 +24,7 @@ from WMCore.WMException import WMException
 from WMCore.WMExceptions import WM_JOB_ERROR_CODES
 
 try:
-    import cPickle as pickle
+    import pickle as pickle
 except ImportError:
     import pickle
 

--- a/src/python/WMCore/Lexicon.py
+++ b/src/python/WMCore/Lexicon.py
@@ -7,9 +7,11 @@ to other classes. If a test fails an AssertionError should be raised, and
 handled appropriately by the client methods, on success returns True.
 """
 
+from future import standard_library
+standard_library.install_aliases()
 import re
 import string
-import urlparse
+import urllib.parse
 
 from WMCore.WMException import WMException
 
@@ -588,7 +590,7 @@ def sanitizeURL(url):
        WANNING: This doesn't check the correctness of url format.
        Don't use ':' in username or password.
     """
-    endpoint_components = urlparse.urlparse(url)
+    endpoint_components = urllib.parse.urlparse(url)
     # Cleanly pull out the user/password from the url
     if endpoint_components.port:
         netloc = '%s:%s' % (endpoint_components.hostname,
@@ -597,7 +599,7 @@ def sanitizeURL(url):
         netloc = endpoint_components.hostname
 
     # Build a URL without the username/password information
-    url = urlparse.urlunparse(
+    url = urllib.parse.urlunparse(
             [endpoint_components.scheme,
              netloc,
              endpoint_components.path,

--- a/src/python/WMCore/ProcessPool/ProcessPool.py
+++ b/src/python/WMCore/ProcessPool/ProcessPool.py
@@ -6,6 +6,8 @@ _ProcessPool_
 """
 from __future__ import print_function
 
+from future import standard_library
+standard_library.install_aliases()
 import zmq
 import subprocess
 import sys
@@ -14,7 +16,7 @@ import os
 import threading
 import traceback
 try:
-    import cPickle as pickle
+    import pickle as pickle
 except ImportError:
     import pickle
 

--- a/src/python/WMCore/REST/Main.py
+++ b/src/python/WMCore/REST/Main.py
@@ -8,11 +8,13 @@ up an appropriately configured CherryPy instance. Views are loaded dynamically
 and can be turned on/off via configuration file."""
 from __future__ import print_function
 
+from future import standard_library
+standard_library.install_aliases()
 import sys, os, errno, re, os.path, subprocess, socket, time
-import cherrypy, logging, thread, traceback
+import cherrypy, logging, _thread, traceback
 import WMCore.REST.Tools
 from WMCore.Configuration import ConfigSection, loadConfigurationFile
-from cStringIO import StringIO
+from io import StringIO
 from optparse import OptionParser
 from cherrypy import Application
 from cherrypy.lib import profiler
@@ -183,7 +185,7 @@ class RESTMain:
         cpconfig.update({'engine.autoreload.on': False})
         cpconfig.update({'request.show_tracebacks': False})
         cpconfig.update({'request.methods_with_bodies': ("POST", "PUT", "DELETE")})
-        thread.stack_size(getattr(self.srvconfig, 'thread_stack_size', 128*1024))
+        _thread.stack_size(getattr(self.srvconfig, 'thread_stack_size', 128*1024))
         sys.setcheckinterval(getattr(self.srvconfig, 'sys_check_interval', 10000))
         self.silent = getattr(self.srvconfig, 'silent', False)
 

--- a/src/python/WMCore/ReqMgr/Tools/WorkflowTools.py
+++ b/src/python/WMCore/ReqMgr/Tools/WorkflowTools.py
@@ -9,10 +9,12 @@ Description: Workflow management tools
 from __future__ import print_function
 
 # system modules
+from future import standard_library
+standard_library.install_aliases()
 import os
 import re
 import json
-import httplib
+import http.client
 
 # ReqMgr modules
 from ReqMgr.tools.reqMgrClient import WorkflowManager
@@ -41,7 +43,7 @@ def getDatasetStatus(dataset):
 
 def getWorkload(url, workflow):
     "Return workload list"
-    conn = httplib.HTTPSConnection(url,
+    conn = http.client.HTTPSConnection(url,
                                    cert_file=os.getenv('X509_USER_PROXY'),
                                    key_file=os.getenv('X509_USER_PROXY'))
     r1 = conn.request("GET", '/reqmgr/view/showWorkload?requestName=' + workflow)
@@ -571,7 +573,7 @@ def getPileup(config):
 
 def getConfig(url, cacheID):
     "Helper function to get configuration for given cacheID"
-    conn = httplib.HTTPSConnection(url,
+    conn = http.client.HTTPSConnection(url,
                                    cert_file=os.getenv('X509_USER_PROXY'),
                                    key_file=os.getenv('X509_USER_PROXY'))
     conn.request("GET", '/couchdb/reqmgr_config_cache/' + cacheID + '/configFile')
@@ -581,7 +583,7 @@ def getConfig(url, cacheID):
 
 def findCustodialLocation(url, dataset):
     "Helper function to find custodial location for given dataset"
-    conn = httplib.HTTPSConnection(url, cert_file=os.getenv('X509_USER_PROXY'), key_file=os.getenv('X509_USER_PROXY'))
+    conn = http.client.HTTPSConnection(url, cert_file=os.getenv('X509_USER_PROXY'), key_file=os.getenv('X509_USER_PROXY'))
     r1 = conn.request("GET", '/phedex/datasvc/json/prod/blockreplicas?dataset=' + dataset)
     r2 = conn.getresponse()
     result = json.loads(r2.read())
@@ -598,7 +600,7 @@ def findCustodialLocation(url, dataset):
 
 def checkAcceptedSubscriptionRequest(url, dataset, site):
     "Helper function"
-    conn = httplib.HTTPSConnection(url,
+    conn = http.client.HTTPSConnection(url,
                                    cert_file=os.getenv('X509_USER_PROXY'),
                                    key_file=os.getenv('X509_USER_PROXY'))
     conn.request("GET", '/phedex/datasvc/json/prod/requestlist?dataset=' + dataset + '&type=xfer')

--- a/src/python/WMCore/ReqMgr/Tools/reqMgrClient.py
+++ b/src/python/WMCore/ReqMgr/Tools/reqMgrClient.py
@@ -6,13 +6,15 @@
 """
 
 # system modules
+from future import standard_library
+standard_library.install_aliases()
 import os
 import re
 import sys
 import json
 import urllib
 import urllib2
-import httplib
+import http.client
 
 # default headers for PUT and POST methods
 HEADERS={"Content-type": "application/x-www-form-urlencoded","Accept": "text/plain"}
@@ -28,7 +30,7 @@ def requestManagerGet(url, request, retries=4):
     cert = os.getenv('X509_USER_PROXY')
     ckey = os.getenv('X509_USER_PROXY')
     for _ in range(retries):
-        conn = httplib.HTTPSConnection(url, cert_file=cert, key_file=ckey)
+        conn = http.client.HTTPSConnection(url, cert_file=cert, key_file=ckey)
         conn.request("GET", request)
         resp = conn.getresponse()
         request = json.load(resp)
@@ -44,7 +46,7 @@ def requestManagerPost(url, request, params, head = HEADERS):
     request: the request suffix url for the POST method
     params: a dict with the POST parameters
     """
-    conn  =  httplib.HTTPSConnection(url, cert_file = os.getenv('X509_USER_PROXY'),
+    conn  =  http.client.HTTPSConnection(url, cert_file = os.getenv('X509_USER_PROXY'),
                                     key_file = os.getenv('X509_USER_PROXY'))
     headers = head
     encodedParams = urllib.urlencode(params)
@@ -63,7 +65,7 @@ def requestManagerPut(url, request, params, head = HEADERS):
     params: a dict with the PUT parameters
     head: optional headers param. If not given it takes default value (HEADERS)
     """
-    conn  =  httplib.HTTPSConnection(url, cert_file = os.getenv('X509_USER_PROXY'),
+    conn  =  http.client.HTTPSConnection(url, cert_file = os.getenv('X509_USER_PROXY'),
                                     key_file = os.getenv('X509_USER_PROXY'))
     headers = head
     encodedParams = urllib.urlencode(params)

--- a/src/python/WMCore/ReqMgr/Utils/url_utils.py
+++ b/src/python/WMCore/ReqMgr/Utils/url_utils.py
@@ -9,11 +9,13 @@ Description:
 from __future__ import print_function
 
 # system modules
+from future import standard_library
+standard_library.install_aliases()
 import os
 import sys
 import urllib
 import urllib2
-import httplib
+import http.client
 import json
 
 def get_key_cert():
@@ -89,9 +91,9 @@ class HTTPSClientAuthHandler(urllib2.HTTPSHandler):
     def get_connection(self, host, timeout=300):
         """Connection method"""
         if  self.key:
-            return httplib.HTTPSConnection(host, key_file=self.key,
+            return http.client.HTTPSConnection(host, key_file=self.key,
                                                 cert_file=self.cert)
-        return httplib.HTTPSConnection(host)
+        return http.client.HTTPSConnection(host)
 
 def getdata(url, params, headers=None, post=None, verbose=False, jsondecoder=True):
     """

--- a/src/python/WMCore/ReqMgr/database_cleanup/couchdb_cleanup.py
+++ b/src/python/WMCore/ReqMgr/database_cleanup/couchdb_cleanup.py
@@ -15,12 +15,14 @@ too, however, only id, rev, and _deleted flag, everything else is wiped.
 """
 from __future__ import print_function
 
+from future import standard_library
+standard_library.install_aliases()
 couch_host = "https://cmsweb.cern.ch"
 couch_uri = "couchdb/reqmgr_workload_cache"
 
 import sys
 import os
-import httplib
+import http.client
 import json
 
 
@@ -37,7 +39,7 @@ def main():
 
     key_file = os.getenv("X509_USER_KEY", None) or "/tmp/x509up_u%s" % os.getuid()
     cert_file = os.getenv("X509_USER_CERT", None) or "/tmp/x509up_u%s" % os.getuid()
-    conn = httplib.HTTPSConnection(couch_host, key_file=key_file, cert_file=cert_file)
+    conn = http.client.HTTPSConnection(couch_host, key_file=key_file, cert_file=cert_file)
     input_file = sys.argv[1]
     f = open(input_file, 'r')
     # have to specify the documents revision, otherwise getting:

--- a/src/python/WMCore/Services/HTTPS/HTTPSAuthHandler.py
+++ b/src/python/WMCore/Services/HTTPS/HTTPSAuthHandler.py
@@ -5,9 +5,11 @@ See usage example in:
 src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
 """
 from __future__ import print_function, division
+from future import standard_library
+standard_library.install_aliases()
 import logging
 import urllib2
-import httplib
+import http.client
 import ssl
 
 
@@ -43,8 +45,8 @@ class HTTPSAuthHandler(urllib2.HTTPSHandler):
 
     def get_connection(self, host, **kwargs):
         if self.ctx:
-            return httplib.HTTPSConnection(host, context=self.ctx, **kwargs)
-        return httplib.HTTPSConnection(host)
+            return http.client.HTTPSConnection(host, context=self.ctx, **kwargs)
+        return http.client.HTTPSConnection(host)
 
     def https_open(self, req):
         """

--- a/src/python/WMCore/Services/McM/McM.py
+++ b/src/python/WMCore/Services/McM/McM.py
@@ -5,12 +5,14 @@ A service class for retrieving data from McM using
 an SSO cookie since it sits behind CERN SSO
 """
 
+from future import standard_library
+standard_library.install_aliases()
 import json
 import os
 import pycurl
 import subprocess
 
-from StringIO import StringIO
+from io import StringIO
 
 
 from WMCore.WMException import WMException

--- a/src/python/WMCore/Services/Requests.py
+++ b/src/python/WMCore/Services/Requests.py
@@ -9,8 +9,10 @@ deserialising the response.
 The response from the remote server is cached if expires/etags are set.
 """
 
+from future import standard_library
+standard_library.install_aliases()
 import base64
-import cStringIO as StringIO
+import io as StringIO
 import logging
 import os
 import shutil
@@ -20,9 +22,9 @@ import sys
 import tempfile
 import traceback
 import urllib
-import urlparse
+import urllib.parse
 import types
-from httplib import HTTPException
+from http.client import HTTPException
 from json import JSONEncoder, JSONDecoder
 
 from WMCore.Algorithms import Permissions
@@ -90,7 +92,7 @@ class Requests(dict):
         # then update with the incoming dict
         self.update(idict)
 
-        self['endpoint_components'] = urlparse.urlparse(self['host'])
+        self['endpoint_components'] = urllib.parse.urlparse(self['host'])
 
         # If cachepath = None disable caching
         if 'cachepath' in idict and idict['cachepath'] is None:

--- a/src/python/WMCore/Services/Service.py
+++ b/src/python/WMCore/Services/Service.py
@@ -48,13 +48,15 @@ service cache   |    no    |   yes    |   yes    |     no     |
 result          |  cached  |  cached  |  cached  | not cached |
 """
 
+from future import standard_library
+standard_library.install_aliases()
 import datetime
 import json
 import logging
 import os
 import time
-from cStringIO import StringIO
-from httplib import HTTPException
+from io import StringIO
+from http.client import HTTPException
 
 from WMCore.Services.Requests import Requests, JSONRequests
 from WMCore.WMException import WMException

--- a/src/python/WMCore/Services/TagCollector/XMLUtils.py
+++ b/src/python/WMCore/Services/TagCollector/XMLUtils.py
@@ -7,9 +7,11 @@ Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
 Description: Set of utilities for RequestManager code
 """
 
+from future import standard_library
+standard_library.install_aliases()
 from __future__ import (division, print_function)
 
-import cStringIO as StringIO
+import io as StringIO
 import re
 import xml.etree.cElementTree as ET
 

--- a/src/python/WMCore/Services/pycurl_manager.py
+++ b/src/python/WMCore/Services/pycurl_manager.py
@@ -11,8 +11,10 @@ underlying data-services.
 """
 from __future__ import print_function
 
-import cStringIO as StringIO
-import httplib
+from future import standard_library
+standard_library.install_aliases()
+import io as StringIO
+import http.client
 import json
 import logging
 import urllib
@@ -194,7 +196,7 @@ class RequestHandler(object):
             data = bbuf.getvalue()
             msg = 'url=%s, code=%s, reason=%s, headers=%s' \
                     % (url, header.status, header.reason, header.header)
-            exc = httplib.HTTPException(msg)
+            exc = http.client.HTTPException(msg)
             setattr(exc, 'req_data', params)
             setattr(exc, 'req_headers', headers)
             setattr(exc, 'url', url)

--- a/src/python/WMCore/Storage/Plugins/FNALImpl.py
+++ b/src/python/WMCore/Storage/Plugins/FNALImpl.py
@@ -5,6 +5,8 @@ _FNALImpl_
 Implementation of StageOutImpl interface for FNAL
 
 """
+from future import standard_library
+standard_library.install_aliases()
 import logging
 import os
 
@@ -13,7 +15,7 @@ from WMCore.Storage.Plugins.LCGImpl import LCGImpl
 from WMCore.Storage.StageOutImplV2 import StageOutImplV2
 
 try:
-    from commands import getoutput
+    from subprocess import getoutput
 except ImportError:
     # python3
     from subprocess import getoutput

--- a/src/python/WMCore/Storage/TrivialFileCatalog.py
+++ b/src/python/WMCore/Storage/TrivialFileCatalog.py
@@ -25,9 +25,11 @@ Usage: Given a TFC constact string: trivialcatalog_file:/path?protocol=proto
 
 """
 
+from future import standard_library
+standard_library.install_aliases()
 import os
 import re
-import urlparse
+import urllib.parse
 from xml.dom.minidom import Element
 
 from WMCore.Algorithms.ParseXMLFile import Node, xmlFileToNode
@@ -179,7 +181,7 @@ def tfcProtocol(contactString):
     protocol from it.
 
     """
-    args = urlparse.urlsplit(contactString)[3]
+    args = urllib.parse.urlsplit(contactString)[3]
     value = args.replace("protocol=", '')
     return value
 

--- a/src/python/WMCore/ThreadPool/ThreadPool.py
+++ b/src/python/WMCore/ThreadPool/ThreadPool.py
@@ -11,13 +11,15 @@ To use this you need to use the ThreadSlave class
 
 
 
+from future import standard_library
+standard_library.install_aliases()
 import base64
 import logging
 import random
 import threading
 import time
 try:
-    import cPickle as pickle
+    import pickle as pickle
 except ImportError:
     import pickle
 

--- a/src/python/WMCore/ThreadPool/ThreadSlave.py
+++ b/src/python/WMCore/ThreadPool/ThreadSlave.py
@@ -16,12 +16,14 @@ attribute.
 
 
 
+from future import standard_library
+standard_library.install_aliases()
 import base64
 import logging
 import threading
 import os
 try:
-    import cPickle as pickle
+    import pickle as pickle
 except ImportError:
     import pickle
 

--- a/src/python/WMCore/ThreadPool/WorkQueue.py
+++ b/src/python/WMCore/ThreadPool/WorkQueue.py
@@ -34,6 +34,8 @@ function. This helps the caller to determine which function
 
 
 
+from future import standard_library
+standard_library.install_aliases()
 import threading
 
 class SerializedThreadPool( object ):

--- a/src/python/WMCore/WMRuntime/DashboardInterface.py
+++ b/src/python/WMCore/WMRuntime/DashboardInterface.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # This is the interface to the Dashboard that the monitor will use
 
+from future import standard_library
+standard_library.install_aliases()
 import threading
 import os
 import time

--- a/src/python/WMCore/WMRuntime/SandboxCreator.py
+++ b/src/python/WMCore/WMRuntime/SandboxCreator.py
@@ -5,11 +5,13 @@
     Given a path, workflow and task, create a sandbox within the path
 """
 
+from future import standard_library
+standard_library.install_aliases()
 import os
 import shutil
 import tarfile
 import tempfile
-import urlparse
+import urllib.parse
 import zipfile
 import logging
 
@@ -179,7 +181,7 @@ class SandboxCreator:
             tarContent.append((utilsPath, '/Utils'))
 
         for sb in userSandboxes:
-            splitResult = urlparse.urlsplit(sb)
+            splitResult = urllib.parse.urlsplit(sb)
             if not splitResult[0]:
                 tarContent.append((sb, os.path.basename(sb)))
 

--- a/src/python/WMCore/WMRuntime/Scripts/UnpackUserTarball.py
+++ b/src/python/WMCore/WMRuntime/Scripts/UnpackUserTarball.py
@@ -6,6 +6,8 @@ Unpack the user tarball and put it's contents in the right place
 """
 from __future__ import print_function
 
+from future import standard_library
+standard_library.install_aliases()
 import os
 import re
 import shutil
@@ -13,11 +15,11 @@ import subprocess
 import sys
 import tempfile
 import urllib
-import urlparse
+import urllib.parse
 from urllib import URLopener
 
 try:
-    from commands import getstatusoutput
+    from subprocess import getstatusoutput
 except ImportError:
     # python3
     from subprocess import getstatusoutput
@@ -80,7 +82,7 @@ def UnpackUserTarball():
     jobDir = os.environ['WMAGENTJOBDIR']
 
     for tarball in tarballs:
-        splitResult = urlparse.urlsplit(tarball)
+        splitResult = urllib.parse.urlsplit(tarball)
         tarFile = os.path.join(jobDir, os.path.basename(tarball))
 
         # Is it a URL or a file that exists in the jobDir?

--- a/src/python/WMCore/WMSpec/Persistency.py
+++ b/src/python/WMCore/WMSpec/Persistency.py
@@ -10,10 +10,12 @@ Placeholder for ideas at present....
 """
 from __future__ import print_function
 
+from future import standard_library
+standard_library.install_aliases()
 from urllib2 import urlopen, Request
-from urlparse import urlparse
+from urllib.parse import urlparse
 try:
-    import cPickle as pickle
+    import pickle as pickle
 except ImportError:
     import pickle
 

--- a/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
@@ -7,11 +7,13 @@ Implementation of an Executor for a DQMUpload step
 """
 from __future__ import print_function
 
+from future import standard_library
+standard_library.install_aliases()
 import os
 import sys
 import logging
 import urllib2
-from cStringIO import StringIO
+from io import StringIO
 from functools import reduce
 from gzip import GzipFile
 from hashlib import md5

--- a/src/python/WMCore/WorkQueue/DataLocationMapper.py
+++ b/src/python/WMCore/WorkQueue/DataLocationMapper.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 """Map data to locations for WorkQueue"""
 
+from future import standard_library
+standard_library.install_aliases()
 from collections import defaultdict
 import time
 import logging
@@ -21,7 +23,7 @@ def isGlobalDBS(dbs):
     try:
         # try to determine from name - save a trip to server
         # fragile but if this url changes many other things will break also...
-        from urlparse import urlparse
+        from urllib.parse import urlparse
         url = urlparse(dbs.dbs.getServerUrl())  # DBSApi has url not DBSReader
         if url.hostname.startswith('cmsweb.cern.ch') and url.path.startswith('/dbs/prod/global'):
             return True

--- a/src/python/WMQuality/WebTools/RESTClientAPI.py
+++ b/src/python/WMQuality/WebTools/RESTClientAPI.py
@@ -1,8 +1,10 @@
+from future import standard_library
+standard_library.install_aliases()
 import hashlib
 import hmac
 import urllib
-from httplib import HTTPConnection
-from urlparse import urlparse
+from http.client import HTTPConnection
+from urllib.parse import urlparse
 
 from WMCore.WebTools.Page import make_rfc_timestamp
 

--- a/test/data/ReqMgr/reqmgr.py
+++ b/test/data/ReqMgr/reqmgr.py
@@ -33,9 +33,11 @@ by a user on the command line, whichever other argument can be overridden too.
 from __future__ import print_function
 
 
+from future import standard_library
+standard_library.install_aliases()
 import os
 import sys
-from httplib import HTTPSConnection, HTTPConnection
+from http.client import HTTPSConnection, HTTPConnection
 import urllib
 import logging
 from optparse import OptionParser, TitledHelpFormatter

--- a/test/data/ReqMgr/reqmgr2.py
+++ b/test/data/ReqMgr/reqmgr2.py
@@ -15,9 +15,11 @@ Note: tests for checking data directly in CouchDB in ReqMgr1 test script:
     WMCore/test/data/ReqMgr/reqmgr.py
 """
 from __future__ import print_function
+from future import standard_library
+standard_library.install_aliases()
 import os
 import sys
-from httplib import HTTPSConnection, HTTPConnection
+from http.client import HTTPSConnection, HTTPConnection
 import urllib
 import logging
 from optparse import OptionParser, TitledHelpFormatter

--- a/test/data/ReqMgr/validate-test-wfs.py
+++ b/test/data/ReqMgr/validate-test-wfs.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
+from future import standard_library
+standard_library.install_aliases()
 import os
 import sys
 import urllib
 import urllib2
-import httplib
+import http.client
 import json
 import argparse
 import pwd
@@ -40,7 +42,7 @@ class HTTPSClientAuthHandler(urllib2.HTTPSHandler):
         return self.do_open(self.getConnection, req)
 
     def getConnection(self, host, timeout=290):
-        return httplib.HTTPSConnection(host, key_file=self.key, cert_file=self.cert)
+        return http.client.HTTPSConnection(host, key_file=self.key, cert_file=self.cert)
 
 
 def getX509():

--- a/test/python/WMCore_t/BossAir_t/BossAir_t.py
+++ b/test/python/WMCore_t/BossAir_t/BossAir_t.py
@@ -5,6 +5,8 @@ BossAir preliminary test
 """
 from __future__ import print_function
 
+from future import standard_library
+standard_library.install_aliases()
 import os.path
 import threading
 import unittest
@@ -12,7 +14,7 @@ import getpass
 import subprocess
 
 try:
-    import cPickle as pickle
+    import pickle as pickle
 except ImportError:
     import pickle
 

--- a/test/python/WMCore_t/Misc_t/WMAgent_t.py
+++ b/test/python/WMCore_t/Misc_t/WMAgent_t.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 
+from future import standard_library
+standard_library.install_aliases()
 import os
 import time
 import shutil
@@ -12,7 +14,7 @@ import threading
 
 from subprocess import Popen, PIPE
 try:
-    import cPickle as pickle
+    import pickle as pickle
 except ImportError:
     import pickle
 

--- a/test/python/WMCore_t/Services_t/Requests_t.py
+++ b/test/python/WMCore_t/Services_t/Requests_t.py
@@ -7,12 +7,14 @@ Created on Aug 6, 2009
 '''
 from __future__ import print_function
 
+from future import standard_library
+standard_library.install_aliases()
 import os
 import shutil
 import tempfile
 import time
 import unittest
-from httplib import HTTPException
+from http.client import HTTPException
 
 import nose
 

--- a/test/python/WMCore_t/Services_t/Service_t.py
+++ b/test/python/WMCore_t/Services_t/Service_t.py
@@ -1,5 +1,7 @@
 """
 """
+from future import standard_library
+standard_library.install_aliases()
 import unittest
 import os
 import logging
@@ -8,8 +10,8 @@ import socket
 import time
 import tempfile
 import shutil
-from httplib import HTTPException
-from httplib import BadStatusLine, IncompleteRead
+from http.client import HTTPException
+from http.client import BadStatusLine, IncompleteRead
 
 from nose.plugins.attrib import attr
 

--- a/test/python/WMCore_t/Services_t/pycurlFileUpload_t.py
+++ b/test/python/WMCore_t/Services_t/pycurlFileUpload_t.py
@@ -1,7 +1,9 @@
+from future import standard_library
+standard_library.install_aliases()
 import logging
 import os
 import unittest
-from httplib import HTTPException
+from http.client import HTTPException
 
 from WMCore.Services.Requests import Requests
 from WMCore.WMBase import getTestBase


### PR DESCRIPTION
Renames standard-library imports to their Py3 names and adds these two lines:
```
from future import standard_library
standard_library.install_aliases()
```
For example:

`import ConfigParser`

becomes:

```
from future import standard_library
standard_library.install_aliases()
import configparser
```

