### PR TITLE
'map' fix applied 

### DIFF
--- a/src/python/PSetTweaks/PSetTweak.py
+++ b/src/python/PSetTweaks/PSetTweak.py
@@ -88,7 +88,7 @@ class PSetLister:
         self.psets.append(psetPath)
         params = childParameters(psetPath, pset)
         self.parameters[psetPath] = params
-        map(self, childPSets(pset))
+        list(map(self, childPSets(pset)))
         self.queue.pop(-1)
 
 

--- a/src/python/PSetTweaks/WMTweak.py
+++ b/src/python/PSetTweaks/WMTweak.py
@@ -357,7 +357,7 @@ class ConfigSectionDecomposer:
             paramVal = getattr(configSect, par)
             self.parameters[paramName] = paramVal
 
-        map(self, childSections(configSect))
+        list(map(self, childSections(configSect)))
         self.queue.pop(-1)
 
 

--- a/src/python/Utils/IteratorTools.py
+++ b/src/python/Utils/IteratorTools.py
@@ -46,8 +46,8 @@ def convertFromUnicodeToStr(data):
     if isinstance(data, basestring):
         return str(data)
     elif isinstance(data, collections.Mapping):
-        return dict(map(convertFromUnicodeToStr, data.iteritems()))
+        return dict(list(map(convertFromUnicodeToStr, data.iteritems())))
     elif isinstance(data, collections.Iterable):
-        return type(data)(map(convertFromUnicodeToStr, data))
+        return type(data)(list(map(convertFromUnicodeToStr, data)))
     else:
         return data

--- a/src/python/WMCore/DataStructs/Fileset.py
+++ b/src/python/WMCore/DataStructs/Fileset.py
@@ -84,7 +84,7 @@ class Fileset(WMObject):
             """
             def getLFN(file):
                 return file["lfn"]
-            files = map(getLFN, self.getFiles(type='list'))
+            files = list(map(getLFN, self.getFiles(type='list')))
             return files
         elif type == 'id':
             """
@@ -93,7 +93,7 @@ class Fileset(WMObject):
             def getID(file):
                 return file["id"]
 
-            files = map(getID, self.getFiles(type='list'))
+            files = list(map(getID, self.getFiles(type='list')))
             return files
 
     def listNewFiles(self):

--- a/src/python/WMCore/DataStructs/Job.py
+++ b/src/python/WMCore/DataStructs/Job.py
@@ -82,13 +82,13 @@ class Job(WMObject, dict):
             def getLFN(file):
                 return file["lfn"]
 
-            lfns = map(getLFN, self["input_files"])
+            lfns = list(map(getLFN, self["input_files"]))
             return lfns
         elif type == "id":
             def getID(file):
                 return file["id"]
 
-            ids = map(getID, self["input_files"])
+            ids = list(map(getID, self["input_files"]))
             return ids
 
     def addFile(self, file):

--- a/src/python/WMCore/Database/DBFormatter.py
+++ b/src/python/WMCore/Database/DBFormatter.py
@@ -94,7 +94,7 @@ class DBFormatter(WMObject):
             return {}
 
         r = result[0]
-        description = map(lambda x: str(x).lower(), r.keys)
+        description = [str(x).lower() for x in r.keys]
         if len(r.data) < 1:
             return {}
 

--- a/src/python/WMCore/GroupUser/Interface.py
+++ b/src/python/WMCore/GroupUser/Interface.py
@@ -45,7 +45,7 @@ class Interface:
                  {'startkey' :[group, user],
                    'endkey' : [group, user]}, []
                 )
-        output = map(lambda x : str(x[u'id']), result[u'rows'])
+        output = [str(x[u'id']) for x in result[u'rows']]
         return output
 
 

--- a/src/python/WMCore/JobSplitting/Generators/GeneratorManager.py
+++ b/src/python/WMCore/JobSplitting/Generators/GeneratorManager.py
@@ -67,7 +67,7 @@ class GeneratorManager:
         job group provided
 
         """
-        [ map(generator, jobGroup.jobs) for generator in self.generators.values()]
+        [ list(map(generator, jobGroup.jobs)) for generator in self.generators.values()]
         return
 
 

--- a/src/python/WMCore/JobSplitting/JobFactory.py
+++ b/src/python/WMCore/JobSplitting/JobFactory.py
@@ -88,13 +88,13 @@ class JobFactory(WMObject):
         module = __import__(module, globals(), locals(), [grouptype])
         self.groupInstance = getattr(module, grouptype.split('.')[-1])
 
-        map(lambda x: x.start(), self.generators)
+        list(map(lambda x: x.start(), self.generators))
 
         self.limit = int(kwargs.get("file_load_limit", self.limit))
         self.algorithm(*args, **kwargs)
         self.commit()
 
-        map(lambda x: x.finish(), self.generators)
+        list(map(lambda x: x.finish(), self.generators))
         return self.jobGroups
 
     def algorithm(self, *args, **kwargs):
@@ -115,7 +115,7 @@ class JobFactory(WMObject):
         """
         self.appendJobGroup()
         self.currentGroup = self.groupInstance(subscription=self.subscription)
-        map(lambda x: x.startGroup(self.currentGroup), self.generators)
+        list(map(lambda x: x.startGroup(self.currentGroup), self.generators))
         return
 
     def newJob(self, name=None, files=None, failedJob=False, failedReason=None):
@@ -157,7 +157,7 @@ class JobFactory(WMObject):
         """
 
         if self.currentGroup:
-            map(lambda x: x.finishGroup(self.currentGroup), self.generators)
+            list(map(lambda x: x.finishGroup(self.currentGroup), self.generators))
         if self.currentGroup:
             self.jobGroups.append(self.currentGroup)
             self.currentGroup = None

--- a/src/python/WMCore/REST/Auth.py
+++ b/src/python/WMCore/REST/Auth.py
@@ -67,9 +67,9 @@ def authz_match(role=[], group=[], site=[], verbose=False):
     site = (site and isinstance(site, str) and [site]) or site
 
     # Reformat all items into canonical format.
-    role = role and map(authz_canonical, role)
-    group = group and map(authz_canonical, group)
-    site = site and map(authz_canonical, site)
+    role = role and list(map(authz_canonical, role))
+    group = group and list(map(authz_canonical, group))
+    site = site and list(map(authz_canonical, site))
 
     # If role, group and site are all empty, no authz requirements: pass
     if not (role or group or site):

--- a/src/python/WMCore/REST/Server.py
+++ b/src/python/WMCore/REST/Server.py
@@ -1728,7 +1728,7 @@ class DatabaseRESTApi(RESTApi):
     @staticmethod
     def _logconnections(*args):
         """SIGUSR2 signal handler to log status of all pools."""
-        map(lambda p: p.logstatus(), DatabaseRESTApi._ALL_POOLS)
+        list(map(lambda p: p.logstatus(), DatabaseRESTApi._ALL_POOLS))
 
     def _add(self, entities):
         """Add entities.

--- a/src/python/WMCore/REST/Validation.py
+++ b/src/python/WMCore/REST/Validation.py
@@ -85,8 +85,7 @@ def _validate_one(argname, param, safe, checker, optional, *args):
         del param.kwargs[argname]
 
 def _validate_all(argname, param, safe, checker, *args):
-    safe.kwargs[argname] = map(lambda v: checker(argname, v, *args),
-                               _arglist(argname, param.kwargs))
+    safe.kwargs[argname] = [checker(argname, v, *args) for v in _arglist(argname, param.kwargs)]
     if argname in param.kwargs:
         del param.kwargs[argname]
 

--- a/src/python/WMCore/ReqMgr/Web/ReqMgrService.py
+++ b/src/python/WMCore/ReqMgr/Web/ReqMgrService.py
@@ -230,9 +230,9 @@ def toString(data):
     if isinstance(data, basestring):
         return str(data)
     elif isinstance(data, collections.Mapping):
-        return dict(map(toString, data.iteritems()))
+        return dict(list(map(toString, data.iteritems())))
     elif isinstance(data, collections.Iterable):
-        return type(data)(map(toString, data))
+        return type(data)(list(map(toString, data)))
     else:
         return data
 

--- a/src/python/WMCore/WMBS/MySQL/Jobs/ChangeState.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/ChangeState.py
@@ -29,7 +29,7 @@ class ChangeState(DBFormatter):
                     'time': self.timestamp(),
                     'couch_record': job['couch_record']}
             return dict
-        return map(function, jobs)
+        return list(map(function, jobs))
 
     def execute(self, jobs = [], conn = None, transaction = False):
         """

--- a/src/python/WMCore/WMBS/MySQL/Jobs/Monitoring.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/Monitoring.py
@@ -23,4 +23,4 @@ class JobsByState(DBFormatter):
         def reduce_function(x, y):
             x.update(y)
             return x
-        return reduce(reduce_function, map(map_function, list))
+        return reduce(reduce_function, list(map(map_function, list)))

--- a/src/python/WMCore/WMRuntime/SandboxCreator.py
+++ b/src/python/WMCore/WMRuntime/SandboxCreator.py
@@ -101,7 +101,7 @@ class SandboxCreator:
                 fetcherNames = commonFetchers[:]
                 taskFetchers = getattr(task.data, "fetchers", [])
                 fetcherNames.extend(taskFetchers)
-                fetcherInstances = map(getFetcher, fetcherNames)
+                fetcherInstances = list(map(getFetcher, fetcherNames))
 
                 taskPath = "%s/%s" % (path, task.name())
                 self._makePathonPackage(taskPath)

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -61,7 +61,7 @@ def buildLumiMask(runs, lumis):
         if len(lumi.split(',')) % 2:
             raise ValueError("Needs an even number of lumi in each element of lumis list")
 
-    lumiLists = [map(list, list(zip([int(y) for y in x.split(',')][::2], [int(y) for y in x.split(',')][1::2]))) for x
+    lumiLists = [list(map(list, list(zip([int(y) for y in x.split(',')][::2], [int(y) for y in x.split(',')][1::2])))) for x
                  in lumis]
     strRuns = [str(run) for run in runs]
 

--- a/src/python/WMCore/WorkQueue/WorkQueueBackend.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueBackend.py
@@ -400,7 +400,7 @@ class WorkQueueBackend(object):
             for site in sites:
                 if element.passesSiteRestriction(site):
                     # Count the number of jobs currently running of greater priority
-                    curJobCount = sum(map(lambda x: x[1] if x[0] >= prio else 0, siteJobCounts.get(site, {}).items()))
+                    curJobCount = sum([x[1] if x[0] >= prio else 0 for x in siteJobCounts.get(site, {}).items()])
                     self.logger.debug("Job Count: %s, site: %s thresholds: %s" % (curJobCount, site, thresholds[site]))
                     if curJobCount < thresholds[site]:
                         possibleSite = site

--- a/test/python/WMCore_t/WebTools_t/DummyRESTModel.py
+++ b/test/python/WMCore_t/WebTools_t/DummyRESTModel.py
@@ -141,7 +141,7 @@ class DummyRESTModel(RESTModel):
         if not isinstance(request_input["aList"], list):
             request_input["aList"] = [int(request_input["aList"])]
         else:
-            request_input["aList"] = map(int, request_input["aList"])
+            request_input["aList"] = list(map(int, request_input["aList"]))
         return request_input
 
     def val_0(self, request_input):


### PR DESCRIPTION
Wraps `map()` in a list call. It also changes `map(None, x)` to `list(x)`.
Using from `future_builtins import map` disables this fixer.
Fix applied because `map()` don’t return lists anymore in Python 3.