### PR TITLE
'division_safe' fix applied

### DIFF
--- a/src/python/PSetTweaks/WMTweak.py
+++ b/src/python/PSetTweaks/WMTweak.py
@@ -8,6 +8,8 @@ process/config but does not depend on any CMSSW libraries. It needs to stay like
 
 """
 from __future__ import print_function
+from __future__ import division
+from past.utils import old_div
 import logging
 import pickle
 import traceback
@@ -120,7 +122,7 @@ def lfnGroup(job):
     default both to 0. The result will be a 5-digit string.
     """
     modifier = str(job.get("agentNumber", 0))
-    lfnGroup = modifier + str(job.get("counter", 0) / 1000).zfill(4)
+    lfnGroup = modifier + str(old_div(job.get("counter", 0), 1000)).zfill(4)
     return lfnGroup
 
 

--- a/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
+++ b/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
@@ -5,6 +5,8 @@ Perform general agent monitoring, like:
  3. Couchdb replication status (and status of its database)
  4. Disk usage status
 """
+from __future__ import division
+from past.utils import old_div
 __all__ = []
 
 import threading
@@ -285,7 +287,7 @@ class AgentStatusPoller(BaseWorkerThread):
 
         if proxyWarning:
             warnMsg = "Agent proxy '%s' must be renewed ASAP. " % self.proxyFile
-            warnMsg += "Its time left is: %.2f hours." % (secsLeft / 3600.)
+            warnMsg += "Its time left is: %.2f hours." % (old_div(secsLeft, 3600.))
             agInfo['proxy_warning'] = warnMsg
 
         return

--- a/src/python/WMComponent/AlertGenerator/Pollers/Agent.py
+++ b/src/python/WMComponent/AlertGenerator/Pollers/Agent.py
@@ -3,6 +3,7 @@ Module encapsulates agent-related tests, e.g. CPU, memory utilisation
 of agent's components, etc.
 
 """
+from __future__ import division
 
 # TODO
 # Should consider ProcessDetail and Measurement occupying a common
@@ -12,6 +13,7 @@ of agent's components, etc.
 # be ensured automatically
 
 
+from past.utils import old_div
 import os
 import logging
 from xml.etree.ElementTree import ElementTree
@@ -98,7 +100,7 @@ class ComponentsPoller(PeriodPoller):
         and Measurements classes.
 
         """
-        self.numOfMeasurements = round(self.config.period / self.config.pollInterval, 0)
+        self.numOfMeasurements = round(old_div(self.config.period, self.config.pollInterval), 0)
         # list of pairs (componentPID, componentName)
         componentsInfo = self._getComponentsInfo()
         for compName, compPID in componentsInfo.items():

--- a/src/python/WMComponent/AlertGenerator/Pollers/Base.py
+++ b/src/python/WMComponent/AlertGenerator/Pollers/Base.py
@@ -3,7 +3,9 @@ Module accommodates base and/or general purpose classes for pollers
 within the Alert messaging framework.
 
 """
+from __future__ import division
 
+from past.utils import old_div
 import sys
 import time
 import logging
@@ -257,7 +259,7 @@ class PeriodPoller(BasePoller):
         avgPerc = None
         if len(measurements) >= measurements._numOfMeasurements:
             # evaluate: calculate average value and react
-            avgPerc = round((sum(measurements) / len(measurements)), 2)
+            avgPerc = round((old_div(sum(measurements), len(measurements))), 2)
             details = dict(period = self.config.period,
                            numMeasurements = len(measurements),
                            average = "%s%%" % avgPerc)

--- a/src/python/WMComponent/AlertGenerator/Pollers/Couch.py
+++ b/src/python/WMComponent/AlertGenerator/Pollers/Couch.py
@@ -2,7 +2,9 @@
 Module for all CouchDb related polling.
 
 """
+from __future__ import division
 
+from past.utils import old_div
 import os
 import logging
 
@@ -85,7 +87,7 @@ class CouchPoller(PeriodPoller):
         """
         pid = self._getProcessPID()
         self._dbProcessDetail = ProcessDetail(pid, "CouchDB")
-        numOfMeasurements = round(self.config.period / self.config.pollInterval, 0)
+        numOfMeasurements = round(old_div(self.config.period, self.config.pollInterval), 0)
         self._measurements = Measurements(numOfMeasurements)
 
 

--- a/src/python/WMComponent/AlertGenerator/Pollers/MySQL.py
+++ b/src/python/WMComponent/AlertGenerator/Pollers/MySQL.py
@@ -2,7 +2,9 @@
 Common module for all MySQL related checked metrics.
 
 """
+from __future__ import division
 
+from past.utils import old_div
 import threading
 import logging
 
@@ -61,7 +63,7 @@ class MySQLPoller(PeriodPoller):
         """
         pid = self._getProcessPID()
         self._dbProcessDetail = ProcessDetail(pid, "MySQL")
-        numOfMeasurements = round(self.config.period / self.config.pollInterval, 0)
+        numOfMeasurements = round(old_div(self.config.period, self.config.pollInterval), 0)
         self._measurements = Measurements(numOfMeasurements)
 
 

--- a/src/python/WMComponent/AlertGenerator/Pollers/System.py
+++ b/src/python/WMComponent/AlertGenerator/Pollers/System.py
@@ -4,7 +4,9 @@ CPU and memory utilisation, available disk space, CPU/mem
 utilisation by particular processes, etc.
 
 """
+from __future__ import division
 
+from past.utils import old_div
 import logging
 import subprocess
 
@@ -80,7 +82,7 @@ class CPUPoller(PeriodPoller):
     """
     def __init__(self, config, generator):
         PeriodPoller.__init__(self, config, generator)
-        numOfMeasurements = round(self.config.period / self.config.pollInterval, 0)
+        numOfMeasurements = round(old_div(self.config.period, self.config.pollInterval), 0)
         self._measurements = Measurements(numOfMeasurements)
 
 
@@ -107,7 +109,7 @@ class MemoryPoller(PeriodPoller):
     """
     def __init__(self, config, generator):
         PeriodPoller.__init__(self, config, generator)
-        numOfMeasurements = round(self.config.period / self.config.pollInterval, 0)
+        numOfMeasurements = round(old_div(self.config.period, self.config.pollInterval), 0)
         self._measurements = Measurements(numOfMeasurements)
 
 
@@ -271,7 +273,7 @@ class DirectorySizePoller(BasePoller):
                  (self._myName, ex, out))
             logging.error(m)
             return None
-        return round(size / self._prefixBytesFactor, 3)
+        return round(old_div(size, self._prefixBytesFactor), 3)
 
 
     def check(self):

--- a/src/python/WMComponent/JobArchiver/JobArchiverPoller.py
+++ b/src/python/WMComponent/JobArchiver/JobArchiverPoller.py
@@ -2,6 +2,8 @@
 """
 The actual jobArchiver algorithm
 """
+from __future__ import division
+from past.utils import old_div
 __all__ = []
 
 import threading
@@ -244,7 +246,7 @@ class JobArchiverPoller(BaseWorkerThread):
             workflow = job['workflow']
             firstCharacter = workflow[0]
             jobFolder = 'JobCluster_%i' \
-                        % (int(job['id'] / self.numberOfJobsToCluster))
+                        % (int(old_div(job['id'], self.numberOfJobsToCluster)))
             logDir = os.path.join(self.logDir, firstCharacter,
                                   workflow, jobFolder)
             if not os.path.exists(logDir):

--- a/src/python/WMComponent/JobCreator/CreateWorkArea.py
+++ b/src/python/WMComponent/JobCreator/CreateWorkArea.py
@@ -10,7 +10,9 @@ _CreateWorkArea_
 Class(es) that create the work area for each jobGroup
 Used in JobCreator
 """
+from __future__ import division
 
+from past.utils import old_div
 import os
 import os.path
 import threading
@@ -311,7 +313,7 @@ class CreateWorkArea:
         Create a sub-directory to allow storage of large jobs
         """
 
-        value = jobCounter/1000
+        value = old_div(jobCounter,1000)
         jobCollDir = '%s/JobCollection_%i_%i' % (taskDir, self.jobGroup.id, value)
         #Set this to a global variable
         self.collectionDir = jobCollDir

--- a/src/python/WMComponent/JobCreator/JobCreatorPoller.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorPoller.py
@@ -2,6 +2,8 @@
 """
 The JobCreator Poller for the JSM
 """
+from __future__ import division
+from past.utils import old_div
 __all__ = []
 
 
@@ -112,7 +114,7 @@ def capResourceEstimates(jobGroups, nCores, constraints):
                 j['estimatedDiskUsage'] = min(j['estimatedDiskUsage'], constraints['MaxRequestDiskKB'])
             else:
                 # we assume job efficiency as nCores * 0.8 for multicore
-                j['estimatedJobTime'] = min(j['estimatedJobTime']/(nCores * 0.8),
+                j['estimatedJobTime'] = min(old_div(j['estimatedJobTime'],(nCores * 0.8)),
                                             constraints['MaxWallTimeSecs'])
                 j['estimatedDiskUsage'] = min(j['estimatedDiskUsage'],
                                               constraints['MaxRequestDiskKB'] * nCores)

--- a/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
+++ b/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
@@ -40,7 +40,9 @@ being present for the site we injected it at. If all these conditions are met, i
 deleted from the site it was originally injected at.
 
 """
+from __future__ import division
 
+from past.utils import old_div
 import threading
 import logging
 import traceback
@@ -86,7 +88,7 @@ class PhEDExInjectorPoller(BaseWorkerThread):
         if getattr(config.PhEDExInjector, "subscribeDatasets", False):
             pollInterval = config.PhEDExInjector.pollInterval
             subInterval = config.PhEDExInjector.subscribeInterval
-            self.subFrequency = max(1, int(round(subInterval / pollInterval)))
+            self.subFrequency = max(1, int(round(old_div(subInterval, pollInterval))))
             logging.info("SubscribeDataset and deleteBlocks will run every %d polling cycles", self.subFrequency)
             # subscribe on first cycle
             self.pollCounter = self.subFrequency - 1

--- a/src/python/WMComponent/TaskArchiver/CleanCouchPoller.py
+++ b/src/python/WMComponent/TaskArchiver/CleanCouchPoller.py
@@ -1,6 +1,8 @@
 """
 Perform cleanup actions
 """
+from __future__ import division
+from past.utils import old_div
 import httplib
 import json
 import logging
@@ -716,13 +718,13 @@ class CleanCouchPoller(BaseWorkerThread):
         workflowData['histograms'] = jsonHistograms
 
         # No easy way to get the memory footprint of a python object.
-        summarySize = len(json.dumps(workflowData)) / 1024
+        summarySize = old_div(len(json.dumps(workflowData)), 1024)
         if summarySize > 6 * 1024:  # 6MB
             msg = "Workload summary for %s is too big: %d Kb. " % (workflowName, summarySize)
             msg += "Wiping out the 'errors' section to make it smaller."
             logging.warning(msg)
             workflowData['errors'] = {}
-        summarySize = len(json.dumps(workflowData)) / 1024
+        summarySize = old_div(len(json.dumps(workflowData)), 1024)
 
         # Now we have the workflowData in the right format, time to push it
         logging.info("About to commit %d Kb of data for workflow summary for %s", summarySize, workflowName)
@@ -989,7 +991,7 @@ class CleanCouchPoller(BaseWorkerThread):
             # Those should come from the config :
             if points[i] == 0:
                 continue
-            binSize = responseJSON["hist"]["xaxis"]["last"]["value"] / responseJSON["hist"]["xaxis"]["last"]["id"]
+            binSize = old_div(responseJSON["hist"]["xaxis"]["last"]["value"], responseJSON["hist"]["xaxis"]["last"]["id"])
             # Fetching the important values
             instLuminosity = i * binSize
             timePerEvent = points[i]

--- a/src/python/WMCore/Algorithms/MathAlgos.py
+++ b/src/python/WMCore/Algorithms/MathAlgos.py
@@ -6,7 +6,9 @@ _MathAlgos_
 Simple mathematical tools and tricks that might prove to
 be useful.
 """
+from __future__ import division
 
+from past.utils import old_div
 import math
 import decimal
 import logging
@@ -57,13 +59,13 @@ def getAverageStdDev(numList):
     if length < 1:
         return average, total
 
-    average = float(total)/length
+    average = old_div(float(total),length)
 
     for value in numList:
         tmpValue = value - average
         stdBase += (tmpValue * tmpValue)
 
-    stdDev = math.sqrt(stdBase/length)
+    stdDev = math.sqrt(old_div(stdBase,length))
 
     if math.isnan(average) or math.isinf(average):
         average = 0.0
@@ -127,7 +129,7 @@ def createHistogram(numList, nBins, limit):
         nBins = 1
         upperBound = upperBound + 1
         lowerBound = lowerBound - 1
-    binSize = float(upperBound - lowerBound)/nBins
+    binSize = old_div(float(upperBound - lowerBound),nBins)
     binSize = floorTruncate(binSize)
 
     for x in range(nBins):
@@ -184,7 +186,7 @@ def floorTruncate(value, precision = 3):
 
     prec = math.pow(10, precision)
 
-    return math.floor(float(value * prec))/float(prec)
+    return old_div(math.floor(float(value * prec)),float(prec))
 
 
 def sortDictionaryListByKey(dictList, key, reverse = False):
@@ -256,7 +258,7 @@ def calculateRunningAverageAndQValue(newPoint, n, oldM, oldQ):
     else:
         if not validateNumericInput(oldM): raise MathAlgoException("Provided a non-valid oldM")
         if not validateNumericInput(oldQ): raise MathAlgoException("Provided a non-valid oldQ")
-        M = oldM + (newPoint - oldM) / n
+        M = oldM + old_div((newPoint - oldM), n)
         Q = oldQ + ((n - 1) * (newPoint - oldM) * (newPoint - oldM) / n)
 
     return M, Q
@@ -275,7 +277,7 @@ def calculateStdDevFromQ(Q, n):
     if not validateNumericInput(Q): raise MathAlgoException("Provided a non-valid Q")
     if not validateNumericInput(n): raise MathAlgoException("Provided a non-valid n")
 
-    sigma = math.sqrt(Q / n)
+    sigma = math.sqrt(old_div(Q, n))
 
     if not validateNumericInput(sigma): return 0.0
 

--- a/src/python/WMCore/Credential/Proxy.py
+++ b/src/python/WMCore/Credential/Proxy.py
@@ -3,7 +3,9 @@
 _Proxy_
 Wrap gLite proxy commands.
 """
+from __future__ import division
 
+from past.utils import old_div
 import contextlib
 import copy
 import os
@@ -209,7 +211,7 @@ class Proxy(Credential):
         if self.retcode:
             raise CredentialException('Cannot get user certificate remaining time with "voms-proxy-info"')
 
-        daystoexp = int(timeleft / (60 * 60 * 24))
+        daystoexp = int(old_div(timeleft, (60 * 60 * 24)))
         return daystoexp
 
     def getProxyDetails(self):
@@ -603,7 +605,7 @@ class Proxy(Credential):
         timeLeft = int(timeLeft.strip())
 
         if timeLeft > 0:
-            vomsValid = "%d:%02d" % (timeLeft / 3600, (timeLeft - (timeLeft / 3600) * 3600) / 60)
+            vomsValid = "%d:%02d" % (old_div(timeLeft, 3600), old_div((timeLeft - (old_div(timeLeft, 3600)) * 3600), 60))
 
         self.logger.debug('Requested voms validity: %s' % vomsValid)
 

--- a/src/python/WMCore/DataStructs/MathStructs/ContinuousSummaryHistogram.py
+++ b/src/python/WMCore/DataStructs/MathStructs/ContinuousSummaryHistogram.py
@@ -8,6 +8,8 @@ Created on Nov 20, 2012
 
 @author: dballest
 """
+from __future__ import division
+from past.utils import old_div
 import math
 
 from WMCore.DataStructs.MathStructs.SummaryHistogram import SummaryHistogram
@@ -148,7 +150,7 @@ class ContinuousSummaryHistogram(SummaryHistogram):
         # Number of bins can be specified or calculated based on number of points
         nBins = self.fixedNBins
         if nBins is None:
-            nBins = int(math.floor((5.0 / 3.0) * math.pow(self.nPoints, 1.0 / 3.0)))
+            nBins = int(math.floor((old_div(5.0, 3.0)) * math.pow(self.nPoints, old_div(1.0, 3.0))))
 
         # Define min and max
         if not self.dropOutliers:
@@ -160,7 +162,7 @@ class ContinuousSummaryHistogram(SummaryHistogram):
             lowerLimit = self.average - (stdDev * self.sigmaLimit)
 
         # Incremental delta
-        delta = abs(float(upperLimit - lowerLimit)) / nBins
+        delta = old_div(abs(float(upperLimit - lowerLimit)), nBins)
 
         # Build the bins, it's a list of tuples for now
         bins = []

--- a/src/python/WMCore/Database/CMSCouch.py
+++ b/src/python/WMCore/Database/CMSCouch.py
@@ -9,7 +9,9 @@ http://wiki.apache.org/couchdb/API_Cheatsheet
 NOT A THREAD SAFE CLASS.
 """
 from __future__ import print_function
+from __future__ import division
 
+from past.utils import old_div
 import time
 import urllib
 import re
@@ -1144,7 +1146,7 @@ class CouchMonitor(object):
         adhoc way to check the replication
         """
         # monitor the last update on replications according to 5 min + checkpoint_interval
-        secsUpdateOn = 5 * 60 + activeStatus['checkpoint_interval'] / 1000
+        secsUpdateOn = 5 * 60 + old_div(activeStatus['checkpoint_interval'], 1000)
         lastUpdate = activeStatus["updated_on"]
         updateNum = int(activeStatus["source_seq"])
         previousUpdateNum = self.getPreviousUpdateSequence(source, target)

--- a/src/python/WMCore/FwkJobReport/ReportEmu.py
+++ b/src/python/WMCore/FwkJobReport/ReportEmu.py
@@ -4,10 +4,12 @@ _ReportEmu_
 
 Class for creating bogus framework job reports.
 """
+from __future__ import division
 
 
 
 
+from past.utils import old_div
 import os.path
 
 from WMCore.Services.UUIDLib import makeUUID
@@ -73,7 +75,7 @@ class ReportEmu(object):
         else:
             outputTotalEvents = totalEvents
 
-        outputSize = int(totalSize * ((outputTotalEvents * 1.0) / (totalEvents * 1.0)))
+        outputSize = int(totalSize * (old_div((outputTotalEvents * 1.0), (totalEvents * 1.0))))
         return (outputSize, outputTotalEvents)
 
     def addOutputFilesToReport(self, report):

--- a/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
+++ b/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
@@ -11,7 +11,9 @@ Created on Sep 25, 2012
 
 @author: dballest
 """
+from __future__ import division
 
+from past.utils import old_div
 import logging
 import math
 import operator
@@ -112,7 +114,7 @@ class EventAwareLumiBased(JobFactory):
 
                 # Do average event per lumi calculation
                 if f['lumiCount']:
-                    f['avgEvtsPerLumi'] = round(float(f['events']) / f['lumiCount'])
+                    f['avgEvtsPerLumi'] = round(old_div(float(f['events']), f['lumiCount']))
                     if deterministicPileup:
                         # We assume that all lumis are equal in the dataset
                         eventsPerLumiInDataset = f['avgEvtsPerLumi']
@@ -161,7 +163,7 @@ class EventAwareLumiBased(JobFactory):
                     # Adapt the lumis per job to match the target conditions
                     if f['avgEvtsPerLumi']:
                         # If there are events in the file
-                        ratio = float(avgEventsPerJob) / f['avgEvtsPerLumi']
+                        ratio = old_div(float(avgEventsPerJob), f['avgEvtsPerLumi'])
                         lumisPerJob = max(int(math.floor(ratio)), 1)
                     else:
                         # Zero event file, then the ratio goes to infinity. Computers don't like that
@@ -172,7 +174,7 @@ class EventAwareLumiBased(JobFactory):
                     updateSplitOnJobStop = True
                     eventsRemaining = max(avgEventsPerJob - currentJobAvgEventCount, 0)
                     if f['avgEvtsPerLumi']:
-                        lumisAllowed = int(math.floor(float(eventsRemaining) / f['avgEvtsPerLumi']))
+                        lumisAllowed = int(math.floor(old_div(float(eventsRemaining), f['avgEvtsPerLumi'])))
                     else:
                         lumisAllowed = f['lumiCount']
                     lumisPerJob = max(lumisInJob + lumisAllowed, 1)
@@ -263,7 +265,7 @@ class EventAwareLumiBased(JobFactory):
                                 # Reset calculations for this file
                                 updateSplitOnJobStop = False
                                 if f['avgEvtsPerLumi']:
-                                    ratio = float(avgEventsPerJob) / f['avgEvtsPerLumi']
+                                    ratio = old_div(float(avgEventsPerJob), f['avgEvtsPerLumi'])
                                     lumisPerJob = max(int(math.floor(ratio)), 1)
                                 else:
                                     lumisPerJob = f['lumiCount']

--- a/src/python/WMCore/JobSplitting/EventBased.py
+++ b/src/python/WMCore/JobSplitting/EventBased.py
@@ -5,7 +5,9 @@ _EventBased_
 Event based splitting algorithm that will chop a fileset into
 a set of jobs based on event counts
 """
+from __future__ import division
 
+from past.utils import old_div
 import logging
 import traceback
 from math import ceil
@@ -149,8 +151,7 @@ class EventBased(JobFactory):
                             self.newJob(name=self.getJobName(length=totalJobs))
                             self.currentJob.addFile(f)
                             self.currentJob.addBaggageParameter("lheInputFiles", lheInput)
-                            lumisPerJob = int(ceil(float(eventsPerJob)
-                                                   / eventsPerLumi))
+                            lumisPerJob = int(ceil(old_div(float(eventsPerJob), eventsPerLumi)))
                             # Limit the number of events to a unsigned 32bit int
                             eventsRemaining = eventsInFile - totalEvents
                             if (currentEvent + eventsPerJob - 1) > (2 ** 32 - 1) and (
@@ -166,7 +167,7 @@ class EventBased(JobFactory):
                             else:
                                 jobTime = eventsRemaining * timePerEvent
                                 diskRequired = eventsRemaining * sizePerEvent
-                                lumisPerJob = int(ceil(float(eventsRemaining) / eventsPerLumi))
+                                lumisPerJob = int(ceil(old_div(float(eventsRemaining), eventsPerLumi)))
                                 self.currentJob["mask"].setMaxAndSkipEvents(eventsRemaining,
                                                                             currentEvent)
                                 self.currentJob["mask"].setMaxAndSkipLumis(lumisPerJob,
@@ -226,12 +227,12 @@ class EventBased(JobFactory):
                     if eventsToRun >= eventsPerJob:
                         self.currentJob["mask"].setMaxAndSkipEvents(eventsPerJob, currentEvent)
                         if fakeFile['lfn'].startswith("MCFakeFile"):
-                            lumisPerJob = int(ceil(float(eventsPerJob) / eventsPerLumi))
+                            lumisPerJob = int(ceil(old_div(float(eventsPerJob), eventsPerLumi)))
                             self.currentJob["mask"].setMaxAndSkipLumis(lumisPerJob, currentLumi)
                     else:
                         self.currentJob["mask"].setMaxAndSkipEvents(eventsToRun, currentEvent)
                         if fakeFile['lfn'].startswith("MCFakeFile"):
-                            lumisPerJob = int(ceil(float(eventsToRun) / eventsPerLumi))
+                            lumisPerJob = int(ceil(old_div(float(eventsToRun), eventsPerLumi)))
                             self.currentJob["mask"].setMaxAndSkipLumis(lumisPerJob, currentLumi)
                         eventsToRun = eventsPerJob
                     jobTime = eventsPerJob * timePerEvent

--- a/src/python/WMCore/JobSplitting/FileBased.py
+++ b/src/python/WMCore/JobSplitting/FileBased.py
@@ -5,7 +5,9 @@ _FileBased_
 File based splitting algorithm that will chop a fileset into
 a set of jobs based on file boundaries
 """
+from __future__ import division
 
+from past.utils import old_div
 from WMCore.JobSplitting.JobFactory import JobFactory
 from WMCore.WMBS.File import File
 from WMCore.WMSpec.WMTask import buildLumiMask
@@ -59,7 +61,7 @@ class FileBased(JobFactory):
                     if f['lumiCount'] == 0:
                         continue
                     ## Do average event per lumi calculation.
-                    f['avgEvtsPerLumi'] = round(float(f['events']) / f['lumiCount'])
+                    f['avgEvtsPerLumi'] = round(old_div(float(f['events']), f['lumiCount']))
                 newlist.append(f)
             locationDict[key] = sorted(newlist, key = lambda f: f['lfn'])
 

--- a/src/python/WMCore/JobSplitting/LumiBased.py
+++ b/src/python/WMCore/JobSplitting/LumiBased.py
@@ -5,7 +5,9 @@ _LumiBased_
 Lumi based splitting algorithm that will chop a fileset into
 a set of jobs based on lumi sections
 """
+from __future__ import division
 
+from past.utils import old_div
 import logging
 import operator
 import threading
@@ -218,7 +220,7 @@ class LumiBased(JobFactory):
                 f['lowestRun'] = f['runs'][0]
                 # Do average event per lumi calculation
                 if f['lumiCount']:
-                    f['avgEvtsPerLumi'] = round(float(f['events']) / f['lumiCount'])
+                    f['avgEvtsPerLumi'] = round(old_div(float(f['events']), f['lumiCount']))
                     if deterministicPileup:
                         # We assume that all lumis are equal in the dataset
                         eventsPerLumiInDataset = f['avgEvtsPerLumi']

--- a/src/python/WMCore/JobSplitting/ParentlessMergeBySize.py
+++ b/src/python/WMCore/JobSplitting/ParentlessMergeBySize.py
@@ -4,6 +4,8 @@ _ParentlessMergeBySize_
 
 WMBS merging that ignores file parents.
 """
+from __future__ import division
+from past.utils import old_div
 import time
 import threading
 
@@ -105,8 +107,8 @@ class ParentlessMergeBySize(JobFactory):
         # job disk based on
         #  - input for largest file on local disk
         #  - output on local disk (factor 1)
-        jobTime = 300 + (jobSize*4)/5000000
-        self.currentJob.addResourceEstimates(jobTime = jobTime, disk = (jobSize+largestFile)/1024)
+        jobTime = 300 + old_div((jobSize*4),5000000)
+        self.currentJob.addResourceEstimates(jobTime = jobTime, disk = old_div((jobSize+largestFile),1024))
 
         return
 

--- a/src/python/WMCore/JobSplitting/WMBSMergeBySize.py
+++ b/src/python/WMCore/JobSplitting/WMBSMergeBySize.py
@@ -5,7 +5,9 @@ _WMBSMergeBySize_
 Generic merging for WMBS.  This will correctly handle merging files that have
 been split up honoring the original file boundaries.
 """
+from __future__ import division
 
+from past.utils import old_div
 import threading
 
 from WMCore.WMBS.File import File
@@ -147,7 +149,7 @@ class WMBSMergeBySize(JobFactory):
         sortedFiles = sortedFilesFromMergeUnits(mergeUnits)
 
         for file in sortedFiles:
-            self.currentJob.addResourceEstimates(disk = float(file["size"])/1024)
+            self.currentJob.addResourceEstimates(disk = old_div(float(file["size"]),1024))
             self.currentJob.addFile(file)
 
     def defineMergeJobs(self, mergeUnits):

--- a/src/python/WMCore/WMRuntime/Monitors/PerformanceMonitor.py
+++ b/src/python/WMCore/WMRuntime/Monitors/PerformanceMonitor.py
@@ -7,7 +7,9 @@ Monitor object which checks the job to ensure it is working inside
 the agreed limits of virtual memory and wallclock time, and terminate it
 if it exceeds them.
 """
+from __future__ import division
 
+from past.utils import old_div
 import os
 import signal
 import os.path
@@ -31,7 +33,7 @@ def average(numbers):
     Quick averaging function
 
     """
-    return float(sum(numbers)) / len(numbers)
+    return old_div(float(sum(numbers)), len(numbers))
 
 class PerformanceMonitorException(WMException):
     """

--- a/src/python/WMCore/WMSpec/Makers/Interface/CreateWorkArea.py
+++ b/src/python/WMCore/WMSpec/Makers/Interface/CreateWorkArea.py
@@ -2,6 +2,8 @@
 
 
 
+from __future__ import division
+from past.utils import old_div
 import os
 import os.path
 import threading
@@ -286,7 +288,7 @@ class CreateWorkArea:
         Create a sub-directory to allow storage of large jobs
         """
 
-        value = jobCounter/1000
+        value = old_div(jobCounter,1000)
         jobCollDir = '%s/JobCollection_%i_%i' %(taskDir, self.jobGroup.id, value)
         #Set this to a global variable
         self.collectionDir = jobCollDir

--- a/src/python/WMCore/WMSpec/StdSpecs/DataProcessing.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/DataProcessing.py
@@ -4,6 +4,8 @@ _DataProcessing_
 
 Base module for workflows with input.
 """
+from __future__ import division
+from past.utils import old_div
 from Utils.Utilities import makeList
 from WMCore.Lexicon import dataset, block, primdataset
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
@@ -24,7 +26,7 @@ class DataProcessing(StdBase):
         self.procJobSplitArgs = {"include_parents" : self.includeParents}
         if self.procJobSplitAlgo == "EventBased" or self.procJobSplitAlgo == "EventAwareLumiBased":
             if self.eventsPerJob is None:
-                self.eventsPerJob = int((8.0 * 3600.0) / self.timePerEvent)
+                self.eventsPerJob = int(old_div((8.0 * 3600.0), self.timePerEvent))
             self.procJobSplitArgs["events_per_job"] = self.eventsPerJob
             if self.procJobSplitAlgo == "EventAwareLumiBased":
                 self.procJobSplitArgs["max_events_per_lumi"] = 20000

--- a/src/python/WMCore/WMSpec/StdSpecs/MonteCarlo.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/MonteCarlo.py
@@ -10,7 +10,9 @@ Normally, the generation task has no input. However, if there is a
 pile up section defined in the configuration, the generation task
 fetches from DBS the information about pileup input.
 """
+from __future__ import division
 
+from past.utils import old_div
 import math
 from Utils.Utilities import strToBool
 from WMCore.Lexicon import primdataset, dataset
@@ -95,7 +97,7 @@ class MonteCarloWorkloadFactory(StdBase):
         StdBase.__call__(self, workloadName, arguments)
 
         # Adjust the events by the filter efficiency
-        self.totalEvents = int(self.requestNumEvents / self.filterEfficiency)
+        self.totalEvents = int(old_div(self.requestNumEvents, self.filterEfficiency))
 
         # We don't write out every event in MC,
         # adjust the size per event accordingly
@@ -105,7 +107,7 @@ class MonteCarloWorkloadFactory(StdBase):
         # 8h jobs are CMS standard, set the default with that in mind
         self.prodJobSplitAlgo = "EventBased"
         if self.eventsPerJob is None:
-            self.eventsPerJob = int((8.0 * 3600.0) / self.timePerEvent)
+            self.eventsPerJob = int(old_div((8.0 * 3600.0), self.timePerEvent))
         if self.eventsPerLumi is None:
             self.eventsPerLumi = self.eventsPerJob
         self.prodJobSplitArgs = {"events_per_job": self.eventsPerJob,
@@ -121,7 +123,7 @@ class MonteCarloWorkloadFactory(StdBase):
         # need to move the initial lfn counter
         self.previousJobCount = 0
         if self.firstLumi > 1:
-            self.previousJobCount = int(math.ceil((self.firstEvent - 1) / self.eventsPerJob))
+            self.previousJobCount = int(math.ceil(old_div((self.firstEvent - 1), self.eventsPerJob)))
             self.prodJobSplitArgs["initial_lfn_counter"] = self.previousJobCount
 
         return self.buildWorkload()

--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -4,7 +4,9 @@ _PromptReco_
 
 Standard PromptReco workflow.
 """
+from __future__ import division
 
+from past.utils import old_div
 from Utils.Utilities import makeList, strToBool
 from WMCore.Lexicon import procstringT0
 from WMCore.WMSpec.StdSpecs.DataProcessing import DataProcessing
@@ -127,7 +129,7 @@ class PromptRecoWorkloadFactory(DataProcessing):
         self.procJobSplitArgs = {}
         if self.procJobSplitAlgo == "EventBased" or self.procJobSplitAlgo == "EventAwareLumiBased":
             if self.eventsPerJob is None:
-                self.eventsPerJob = int((8.0 * 3600.0) / self.timePerEvent)
+                self.eventsPerJob = int(old_div((8.0 * 3600.0), self.timePerEvent))
             self.procJobSplitArgs["events_per_job"] = self.eventsPerJob
             if self.procJobSplitAlgo == "EventAwareLumiBased":
                 self.procJobSplitArgs["max_events_per_lumi"] = 100000
@@ -138,7 +140,7 @@ class PromptRecoWorkloadFactory(DataProcessing):
         self.skimJobSplitArgs = {}
         if self.skimJobSplitAlgo == "EventBased" or self.skimJobSplitAlgo == "EventAwareLumiBased":
             if self.eventsPerJob is None:
-                self.eventsPerJob = int((8.0 * 3600.0) / self.timePerEvent)
+                self.eventsPerJob = int(old_div((8.0 * 3600.0), self.timePerEvent))
             self.skimJobSplitArgs["events_per_job"] = self.eventsPerJob
             if self.skimJobSplitAlgo == "EventAwareLumiBased":
                 self.skimJobSplitArgs["max_events_per_lumi"] = 20000

--- a/src/python/WMCore/WMSpec/StdSpecs/ReReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/ReReco.py
@@ -4,6 +4,8 @@ _ReReco_
 
 Standard ReReco workflow.
 """
+from __future__ import division
+from past.utils import old_div
 from Utils.Utilities import makeList
 from WMCore.WMSpec.StdSpecs.DataProcessing import DataProcessing
 from WMCore.WMSpec.WMWorkloadTools import validateArgumentsCreate
@@ -160,7 +162,7 @@ class ReRecoWorkloadFactory(DataProcessing):
             if skimConfig["SkimJobSplitAlgo"] == "FileBased":
                 skimConfig["SkimJobSplitArgs"]["files_per_job"] = int(arguments.get("SkimFilesPerJob%s" % skimIndex, 1))
             elif skimConfig["SkimJobSplitAlgo"] == "EventBased" or skimConfig["SkimJobSplitAlgo"] == "EventAwareLumiBased":
-                skimConfig["SkimJobSplitArgs"]["events_per_job"] = int(arguments.get("SkimEventsPerJob%s" % skimIndex, int((8.0 * 3600.0) / skimConfig["TimePerEvent"])))
+                skimConfig["SkimJobSplitArgs"]["events_per_job"] = int(arguments.get("SkimEventsPerJob%s" % skimIndex, int(old_div((8.0 * 3600.0), skimConfig["TimePerEvent"]))))
                 if skimConfig["SkimJobSplitAlgo"] == "EventAwareLumiBased":
                     skimConfig["SkimJobSplitAlgo"]["max_events_per_lumi"] = 20000
             elif skimConfig["SkimJobSplitAlgo"] == "LumiBased":

--- a/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
@@ -13,6 +13,8 @@ It also assumes all the intermediate steps output are transient and do not need
 to be staged out and registered in DBS/PhEDEx. Only the last step output will be
 made available.
 """
+from __future__ import division
+from past.utils import old_div
 from Utils.Utilities import strToBool
 import WMCore.WMSpec.Steps.StepFactory as StepFactory
 from WMCore.Lexicon import primdataset
@@ -323,11 +325,11 @@ class StepChainWorkloadFactory(StdBase):
             filterEff = taskConf.get("FilterEfficiency")
             # Adjust totalEvents according to the filter efficiency
             taskConf["SplittingAlgo"] = "EventBased"
-            taskConf["RequestNumEvents"] = int(requestNumEvts / filterEff)
+            taskConf["RequestNumEvents"] = int(old_div(requestNumEvts, filterEff))
             taskConf["SizePerEvent"] = self.sizePerEvent * filterEff
 
         if taskConf["EventsPerJob"] is None:
-            taskConf["EventsPerJob"] = int((8.0 * 3600.0) / self.timePerEvent)
+            taskConf["EventsPerJob"] = int(old_div((8.0 * 3600.0), self.timePerEvent))
         if taskConf["EventsPerLumi"] is None:
             taskConf["EventsPerLumi"] = taskConf["EventsPerJob"]
 

--- a/src/python/WMCore/WMSpec/Steps/Executors/LogArchive.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/LogArchive.py
@@ -4,7 +4,9 @@ _Step.Executor.LogArchive_
 
 Implementation of an Executor for a LogArchive step
 """
+from __future__ import division
 
+from past.utils import old_div
 import os
 import os.path
 import logging
@@ -27,7 +29,7 @@ import WMCore.Storage.StageOutMgr as StageOutMgr
 import WMCore.Storage.FileManager
 
 
-lfnGroup = lambda j : str(j.get("counter", 0) / 1000).zfill(4)
+lfnGroup = lambda j : str(old_div(j.get("counter", 0), 1000)).zfill(4)
 
 class LogArchive(Executor):
     """

--- a/src/python/WMCore/WorkQueue/DataLocationMapper.py
+++ b/src/python/WMCore/WorkQueue/DataLocationMapper.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 """Map data to locations for WorkQueue"""
+from __future__ import division
 
+from past.utils import old_div
 from collections import defaultdict
 import time
 import logging
@@ -46,7 +48,7 @@ def isGlobalDBS(dbs):
 def timeFloor(number, interval=UPDATE_INTERVAL_COARSENESS):
     """Get numerical floor of time to given interval"""
     from math import floor
-    return floor(number / interval) * interval
+    return floor(old_div(number, interval)) * interval
 
 
 def isDataset(inputData):

--- a/src/python/WMCore/WorkQueue/DataStructs/WorkQueueElementResult.py
+++ b/src/python/WMCore/WorkQueue/DataStructs/WorkQueueElementResult.py
@@ -3,12 +3,14 @@ WorkQueueElementResult
 
 A dictionary based object meant to represent a WorkQueue block
 """
+from __future__ import division
 
 #Can we re-use WorkQueueElement for this?
 
 
 
 
+from past.utils import old_div
 class WorkQueueElementResult(dict):
     """Class to hold the status of a related group of WorkQueueElements"""
     def __init__(self, **kwargs):
@@ -25,11 +27,11 @@ class WorkQueueElementResult(dict):
                             sum([x['FilesProcessed'] for x in self['Elements']]))
             self.setdefault('Jobs', sum([x['Jobs'] for x in self['Elements']]))
             self.setdefault('PercentComplete',
-                            int(sum([x['PercentComplete'] for x in self['Elements']],
-                                0.0) / len(self['Elements'])))
+                            int(old_div(sum([x['PercentComplete'] for x in self['Elements']],
+                                0.0), len(self['Elements']))))
             self.setdefault('PercentSuccess',
-                            int(sum([x['PercentSuccess'] for x in self['Elements']],
-                                0.0) / len(self['Elements'])))
+                            int(old_div(sum([x['PercentSuccess'] for x in self['Elements']],
+                                0.0), len(self['Elements']))))
             self.setdefault('RequestName', self['Elements'][0]['RequestName'])
             self.setdefault('TeamName', self['Elements'][0]['TeamName'])
             self.setdefault('Priority', self['Elements'][0]['Priority'])
@@ -54,7 +56,7 @@ class WorkQueueElementResult(dict):
 
     def fractionComplete(self):
         """Return fraction successful"""
-        return len(self.completeItems()) / float(len(self['Elements']))
+        return old_div(len(self.completeItems()), float(len(self['Elements'])))
 
     def completeItems(self):
         """Return complete items"""

--- a/src/python/WMCore/WorkQueue/Policy/Start/Dataset.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Dataset.py
@@ -7,6 +7,8 @@ This policy is specifically used by DQMHarvest workflows, which requires
 some special handling based on run information. Nonetheless, trying to
 make it generic enough that could be used by other spec types.
 """
+from __future__ import division
+from past.utils import old_div
 __all__ = []
 
 from math import ceil
@@ -54,9 +56,9 @@ class Dataset(StartPolicyInterface):
             numEvents += int(block['NumberOfEvents'])
 
         if self.args['SliceType'] == 'NumberOfRuns':
-            numJobs = ceil(len(work) / float(self.args['SliceSize']))
+            numJobs = ceil(old_div(len(work), float(self.args['SliceSize'])))
         else:
-            numJobs = ceil(float(work) / float(self.args['SliceSize']))
+            numJobs = ceil(old_div(float(work), float(self.args['SliceSize'])))
 
         # parentage
         parentFlag = True if self.initialTask.parentProcessingFlag() else False

--- a/src/python/WMCore/WorkQueue/Policy/Start/ResubmitBlock.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/ResubmitBlock.py
@@ -17,6 +17,8 @@ ACDC unsupported:
 - SiblingProcessingBased
 
 """
+from __future__ import division
+from past.utils import old_div
 __all__ = []
 
 from WMCore.WorkQueue.Policy.Start.StartPolicyInterface import StartPolicyInterface
@@ -70,8 +72,8 @@ class ResubmitBlock(StartPolicyInterface):
                                  NumberOfLumis=block[self.lumiType],
                                  NumberOfFiles=block['NumberOfFiles'],
                                  NumberOfEvents=block['NumberOfEvents'],
-                                 Jobs=ceil(float(block[self.args['SliceType']]) /
-                                           float(self.args['SliceSize'])),
+                                 Jobs=ceil(old_div(float(block[self.args['SliceType']]),
+                                           float(self.args['SliceSize']))),
                                  ACDC=block['ACDC'],
                                  NoInputUpdate=self.initialTask.getTrustSitelists().get('trustlists'),
                                  NoPileupUpdate=self.initialTask.getTrustSitelists().get('trustPUlists')

--- a/test/python/WMComponent_t/AnalyticsDataCollector_t/Plugins_t/Tier0Plugin_t.py
+++ b/test/python/WMComponent_t/AnalyticsDataCollector_t/Plugins_t/Tier0Plugin_t.py
@@ -7,7 +7,9 @@ Created on Nov 7, 2012
 
 @author: dballest
 """
+from __future__ import division
 
+from past.utils import old_div
 import os
 import unittest
 
@@ -274,11 +276,11 @@ class Tier0PluginTest(unittest.TestCase):
         """
 
         for idx in range(0, len(self.orderedStates) * 2):
-            nextState = self.orderedStates[idx / 2]
-            if (idx / 2) == 0:
+            nextState = self.orderedStates[old_div(idx, 2)]
+            if (old_div(idx, 2)) == 0:
                 currentState = 'Closed'
             else:
-                currentState = self.orderedStates[idx / 2 - 1]
+                currentState = self.orderedStates[old_div(idx, 2) - 1]
             if idx % 2 == 0:
                 for transitionObject in self.stateMap[nextState][:-1]:
                     method = getattr(transitionObject, transitionMethod)

--- a/test/python/WMComponent_t/DBS3Buffer_t/DBSUpload_t.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/DBSUpload_t.py
@@ -6,6 +6,8 @@
 DBSUpload test TestDBSUpload module and the harness
 
 """
+from __future__ import division
+from past.utils import old_div
 import os
 import threading
 import time
@@ -246,7 +248,7 @@ class DBSUploadTest(unittest.TestCase):
                          "Error: Wrong physics group name.")
 
         results = self.dbsApi.listBlocks(dataset = datasetName, detail = True)
-        self.assertEqual(len(results), len(files) / 5,
+        self.assertEqual(len(results), old_div(len(files), 5),
                          "Error: Wrong number of blocks.")
         for result in results:
             self.assertEqual(result["block_size"], 5120,

--- a/test/python/WMComponent_t/JobAccountant_t/JobAccountant_t.py
+++ b/test/python/WMComponent_t/JobAccountant_t/JobAccountant_t.py
@@ -5,7 +5,9 @@ _JobAccountant_t_
 Unit tests for the WMAgent JobAccountant component.
 """
 from __future__ import print_function
+from __future__ import division
 
+from past.utils import old_div
 import copy
 import os.path
 import threading
@@ -1299,7 +1301,7 @@ class JobAccountantTest(unittest.TestCase):
         startTime = time.time()
         accountant.algorithm()
         endTime = time.time()
-        print("  Performance: %s fwjrs/sec" % (100 / (endTime - startTime)))
+        print("  Performance: %s fwjrs/sec" % (old_div(100, (endTime - startTime))))
 
         for (jobID, fwjrPath) in self.jobs:
             print("  Validating %s, %s" % (jobID, fwjrPath))
@@ -1636,7 +1638,7 @@ class JobAccountantTest(unittest.TestCase):
 
         endTime = time.time()
         print("  Time: %f" % (endTime - startTime))
-        print("  Performance: %s fwjrs/sec" % (100 / (endTime - startTime)))
+        print("  Performance: %s fwjrs/sec" % (old_div(100, (endTime - startTime))))
 
         for (jobID, fwjrPath) in self.jobs:
             print("  Validating %s, %s" % (jobID, fwjrPath))

--- a/test/python/WMComponent_t/JobTracker_t/JobTracker_t.py
+++ b/test/python/WMComponent_t/JobTracker_t/JobTracker_t.py
@@ -4,10 +4,12 @@
 JobTracker test
 """
 from __future__ import print_function
+from __future__ import division
 
 
 
 
+from past.utils import old_div
 import os
 import os.path
 import logging
@@ -507,7 +509,7 @@ class JobTrackerTest(unittest.TestCase):
 
 
         # Now create some jobs
-        for job in testJobGroup.jobs[:(nJobs/2)]:
+        for job in testJobGroup.jobs[:(old_div(nJobs,2))]:
             jdl = createJDL(id = job['id'], directory = submitDir, jobCE = jobCE)
             jdlFile = os.path.join(submitDir, 'condorJDL_%i.jdl' % (job['id']))
             handle = open(jdlFile, 'w')
@@ -528,10 +530,10 @@ class JobTrackerTest(unittest.TestCase):
 
         # Are jobs in the right state?
         result = self.getJobs.execute(state = 'Executing', jobType = "Processing")
-        self.assertEqual(len(result), nJobs/2)
+        self.assertEqual(len(result), old_div(nJobs,2))
 
         result = self.getJobs.execute(state = 'Complete', jobType = "Processing")
-        self.assertEqual(len(result), nJobs/2)
+        self.assertEqual(len(result), old_div(nJobs,2))
 
 
         # Then we're done
@@ -543,7 +545,7 @@ class JobTrackerTest(unittest.TestCase):
         self.assertEqual(nRunning, 0)
 
         print ("Process took %f seconds to process %i classAds" %((stopTime - startTime),
-                                                                  nJobs/2))
+                                                                  old_div(nJobs,2)))
         p = pstats.Stats('testStats.stat')
         p.sort_stats('cumulative')
         p.print_stats()

--- a/test/python/WMComponent_t/TaskArchiver_t/TaskArchiver_t.py
+++ b/test/python/WMComponent_t/TaskArchiver_t/TaskArchiver_t.py
@@ -5,6 +5,8 @@ TaskArchiver test
 Tests both the archiving of tasks and the creation of the
 workloadSummary
 """
+from __future__ import division
+from past.utils import old_div
 import json
 import logging
 import os.path
@@ -280,7 +282,7 @@ class TaskArchiverTest(unittest.TestCase):
         changer.propagate(testJobGroup.jobs, 'executing', 'created')
         changer.propagate(testJobGroup.jobs, 'complete', 'executing')
         for i in range(self.nJobs):
-            if i < self.nJobs / 2:
+            if i < old_div(self.nJobs, 2):
                 testJobGroup.jobs[i]['fwjr'] = report1
             else:
                 testJobGroup.jobs[i]['fwjr'] = report2
@@ -401,7 +403,7 @@ class TaskArchiverTest(unittest.TestCase):
             # Those should come from the config :
             if points[i] == 0:
                 continue
-            binSize = responseJSON["hist"]["xaxis"]["last"]["value"] / responseJSON["hist"]["xaxis"]["last"]["id"]
+            binSize = old_div(responseJSON["hist"]["xaxis"]["last"]["value"], responseJSON["hist"]["xaxis"]["last"]["id"])
             # Fetching the important values
             instLuminosity = i * binSize
             timePerEvent = points[i]

--- a/test/python/WMCore_t/Credential_t/MyProxy_t.py
+++ b/test/python/WMCore_t/Credential_t/MyProxy_t.py
@@ -5,7 +5,9 @@ Test the basic MyProxy operations.
 You need to source your UI before running these tests.
 The user Proxy and MyProxy is initialized in testCreateMyProxy method and they are used by the remaining tests.
 """
+from __future__ import division
 
+from past.utils import old_div
 import unittest
 import os
 import logging
@@ -91,7 +93,7 @@ class MyProxyTest(unittest.TestCase):
         self.proxy.renewMyProxy( proxy = self.proxyPath )
         time.sleep( 5 )
         timeLeft = self.proxy.getMyProxyTimeLeft( proxy = self.proxyPath )
-        self.assertEqual(int(timeLeft) / 3600, 167)
+        self.assertEqual(old_div(int(timeLeft), 3600), 167)
 
     @attr("integration")
     def testRenewMyProxyForServer( self ):
@@ -102,7 +104,7 @@ class MyProxyTest(unittest.TestCase):
         self.proxy.renewMyProxy( proxy = self.proxyPath, serverRenewer = True )
         time.sleep( 5 )
         timeLeft = self.proxy.getMyProxyTimeLeft( proxy = self.proxyPath, serverRenewer = True )
-        self.assertEqual(int(timeLeft) / 3600, 167)
+        self.assertEqual(old_div(int(timeLeft), 3600), 167)
 
     @attr("integration")
     def testMyProxyEnvironment(self):

--- a/test/python/WMCore_t/Credential_t/Proxy_t.py
+++ b/test/python/WMCore_t/Credential_t/Proxy_t.py
@@ -6,7 +6,9 @@ You need to source your UI before running these tests.
 Your proxy is initialized in testAAACreateProxy method and it is used by the remaining tests.
 """
 from __future__ import print_function
+from __future__ import division
 
+from past.utils import old_div
 import unittest
 import os
 import logging
@@ -111,7 +113,7 @@ class ProxyTest(unittest.TestCase):
         Test if getTimeLeft method returns correctly the proxy time left.
         """
         timeLeft = self.proxy.getTimeLeft()
-        self.assertEqual(int(timeLeft) / 3600, 191)
+        self.assertEqual(old_div(int(timeLeft), 3600), 191)
 
     @attr("integration")
     def testRenewProxy( self ):
@@ -122,7 +124,7 @@ class ProxyTest(unittest.TestCase):
         self.proxy.renew()
         time.sleep( 10 )
         timeLeft = self.proxy.getTimeLeft()
-        self.assertEqual(int(timeLeft) / 3600, 191)
+        self.assertEqual(old_div(int(timeLeft), 3600), 191)
 
     @attr("integration")
     def testDestroyProxy(self ):
@@ -185,7 +187,7 @@ class ProxyTest(unittest.TestCase):
         attribute = self.proxy.prepareAttForVomsRenewal( self.proxy.getAttributeFromProxy( proxyPath ) )
         self.proxy.vomsExtensionRenewal( proxyPath, attribute )
         vomsTimeLeft = self.proxy.getVomsLife( proxyPath )
-        self.assertEqual(int(vomsTimeLeft) / 3600, 191)
+        self.assertEqual(old_div(int(vomsTimeLeft), 3600), 191)
 
     @attr("integration")
     def testElevateAttribute( self ):

--- a/test/python/WMCore_t/DataStructs_t/MathStructs_t/ContinuousSummaryHistogram_t.py
+++ b/test/python/WMCore_t/DataStructs_t/MathStructs_t/ContinuousSummaryHistogram_t.py
@@ -10,6 +10,8 @@ Created on Nov 20, 2012
 
 @author: dballest
 """
+from __future__ import division
+from past.utils import old_div
 import unittest
 import random
 
@@ -179,7 +181,7 @@ class ContinuousSummaryHistogramTest(unittest.TestCase):
 
         # With high probability we must have chopped at least one point
         self.assertTrue(pointsInHistogram < 1000)
-        self.assertAlmostEqual(pointsInHistogram / 1000.0, 0.68, places = 1)
+        self.assertAlmostEqual(old_div(pointsInHistogram, 1000.0), 0.68, places = 1)
 
         # Create a histogram without histogram data
         histogram = ContinuousSummaryHistogram('TestHisto', 'MyLabel', 'SomeoneElsesLabel',

--- a/test/python/WMCore_t/JobSplitting_t/FixedDelay_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/FixedDelay_t.py
@@ -4,7 +4,9 @@ _FixedDelay_t_
 
 Fixed Delay splitting test.
 """
+from __future__ import division
 
+from past.utils import old_div
 import unittest
 
 from WMCore.DataStructs.File import File
@@ -39,7 +41,7 @@ class FixedDelayTest(unittest.TestCase):
         self.multipleFileLumiset = Fileset(name = "TestFileset3")
         for i in range(10):
             newFile = File(makeUUID(), size = 1000, events = 100)
-            newFile.addRun(Run(1, *[45+i/3]))
+            newFile.addRun(Run(1, *[45+old_div(i,3)]))
             self.multipleFileLumiset.addFile(newFile)
 
         self.singleLumiFileset = Fileset(name = "TestFileset4")

--- a/test/python/WMCore_t/JobSplitting_t/Generators_t/Seeders_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/Generators_t/Seeders_t.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import division
+from past.utils import old_div
 import unittest
 
 
@@ -122,7 +124,7 @@ class SeederTest(unittest.TestCase):
                 self.assertEqual(hasattr(conf.RandomSeeder.evtgenproducer, 'initialSeed'), True)
                 self.assertEqual(hasattr(conf.RandomSeeder.generator, 'initialSeed'), True)
                 self.assertEqual(job["mask"]["FirstLumi"], count%11)
-                self.assertEqual(job["mask"]["FirstRun"],  (count/11) + 1)
+                self.assertEqual(job["mask"]["FirstRun"],  (old_div(count,11)) + 1)
                 count += 1
 
         return

--- a/test/python/WMCore_t/JobSplitting_t/RunBased_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/RunBased_t.py
@@ -4,10 +4,12 @@ _RunBased_t_
 
 RunBased splitting test.
 """
+from __future__ import division
 
 
 
 
+from past.utils import old_div
 import unittest
 
 from WMCore.DataStructs.File import File
@@ -43,7 +45,7 @@ class RunBasedTest(unittest.TestCase):
         self.multipleFileRunset = Fileset(name = "TestFileset3")
         for i in range(10):
             newFile = File(makeUUID(), size = 1000, events = 100, locations = set(["somese.cern.ch"]))
-            newFile.addRun(Run(i/3, *[45]))
+            newFile.addRun(Run(old_div(i,3), *[45]))
             self.multipleFileRunset.addFile(newFile)
 
         self.singleRunFileset = Fileset(name = "TestFileset4")

--- a/test/python/WMCore_t/Misc_t/WMAgent_t.py
+++ b/test/python/WMCore_t/Misc_t/WMAgent_t.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 
+from __future__ import division
+from past.utils import old_div
 import os
 import time
 import shutil
@@ -585,7 +587,7 @@ class WMAgentTest(unittest.TestCase):
         for job in completeJobs:
             self.assertFalse(os.path.exists(job['fwjr_path']))
             jobFolder = 'JobCluster_%i' \
-                    % (int(job['id']/config.JobArchiver.numberOfJobsToCluster))
+                    % (int(old_div(job['id'],config.JobArchiver.numberOfJobsToCluster)))
             jobPath = os.path.join(logDir, jobFolder, 'Job_%i.tar' %(job['id']))
             self.assertTrue(os.path.isfile(jobPath))
             self.assertTrue(os.path.getsize(jobPath) > 0)

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/FixedDelay_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/FixedDelay_t.py
@@ -4,7 +4,9 @@ _FixedDelay_t_
 
 Fixed delay job splitting.
 """
+from __future__ import division
 
+from past.utils import old_div
 import unittest
 import os
 import threading
@@ -66,7 +68,7 @@ class FixedDelayTest(unittest.TestCase):
         self.multipleFileLumiset.create()
         for i in range(10):
             newFile = File(makeUUID(), size = 1000, events = 100, locations = set(["T2_CH_CERN"]))
-            newFile.addRun(Run(1, *[45+i/3]))
+            newFile.addRun(Run(1, *[45+old_div(i,3)]))
             newFile.create()
             self.multipleFileLumiset.addFile(newFile)
         self.multipleFileLumiset.commit()

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/RunBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/RunBased_t.py
@@ -4,10 +4,12 @@ _EventBased_t_
 
 Event based splitting test.
 """
+from __future__ import division
 
 
 
 
+from past.utils import old_div
 import unittest
 import os
 import threading
@@ -78,7 +80,7 @@ class EventBasedTest(unittest.TestCase):
         self.multipleFileRunset.create()
         for i in range(10):
             newFile = File(makeUUID(), size = 1000, events = 100, locations = "T2_CH_CERN")
-            newFile.addRun(Run(i/3, *[45]))
+            newFile.addRun(Run(old_div(i,3), *[45]))
             newFile.create()
             self.multipleFileRunset.addFile(newFile)
         self.multipleFileRunset.commit()


### PR DESCRIPTION
This fix used instead of libfuturize.fixes.fix_division.
  
**Division**  
Integer division (rounding down):  
```
# Python 2 only:
assert 2 / 3 == 0
```
```
# Python 2 and 3:
assert 2 // 3 == 0
```
“True division” (float division):
```
# Python 3 only:
assert 3 / 2 == 1.5
```
```
# Python 2 and 3:
from __future__ import division    # (at top of module)

assert 3 / 2 == 1.5
```

“Old division” (i.e. compatible with Py2 behaviour):
```
# Python 2 only:
a = b / c            # with any types
```
```
# Python 2 and 3:
from past.utils import old_div

a = old_div(b, c)    # always same as / on Py2
```