### PR TITLE
Fix StoreResults spec; added required PhysicsGroup argument

### DIFF
--- a/doc/createSpecs/StoreResults_createSpec.json
+++ b/doc/createSpecs/StoreResults_createSpec.json
@@ -23,12 +23,7 @@
         "default": "", 
         "optional": true, 
         "type": "<type 'str'>"
-    }, 
-    "CmsPath": {
-        "default": "/tmp", 
-        "optional": false, 
-        "type": "<type 'str'>"
-    }, 
+    },
     "Comments": {
         "default": "", 
         "optional": true, 
@@ -36,7 +31,7 @@
     }, 
     "ConfigCacheID": {
         "default": null, 
-        "optional": false, 
+        "optional": true,
         "type": "<type 'str'>"
     }, 
     "ConfigCacheUrl": {
@@ -188,7 +183,12 @@
         "default": 0, 
         "optional": true, 
         "type": "<type 'int'>"
-    }, 
+    },
+    "PhysicsGroup": {
+        "default": "",
+        "optional": false,
+        "type": "<type 'str'>"
+    },
     "PrepID": {
         "default": null, 
         "optional": true, 

--- a/src/python/WMCore/Lexicon.py
+++ b/src/python/WMCore/Lexicon.py
@@ -222,6 +222,14 @@ def userprocdataset(candidate):
     return (commonCheck and anlaysisCheck)
 
 
+def physicsgroup(candidate):
+    """
+    Check for Physics Group string which is added to StoreResults
+    merged LFN base. Up to 30 letters, numbers, dashes, underscores.
+    """
+    return check(r'%(physics_group)s$' % lfnParts, candidate, 30)
+
+
 def procversion(candidate):
     """ Integers """
     if isinstance(candidate, dict):

--- a/src/python/WMCore/WMSpec/StdSpecs/StoreResults.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StoreResults.py
@@ -14,6 +14,7 @@ from Utils.Utilities import makeList
 from WMCore.Lexicon import dataset, block, physicsgroup
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
 
+
 class StoreResultsWorkloadFactory(StdBase):
     """
     _StoreResultsWorkloadFactory_
@@ -35,7 +36,6 @@ class StoreResultsWorkloadFactory(StdBase):
 
         workload = self.createWorkload()
 
-
         mergeTask = workload.newTask("StoreResults")
         self.addDashboardMonitoring(mergeTask)
         mergeTaskCmssw = mergeTask.makeStep("cmsRun1")
@@ -47,40 +47,39 @@ class StoreResultsWorkloadFactory(StdBase):
         mergeTaskLogArch = mergeTaskCmssw.addStep("logArch1")
         mergeTaskLogArch.setStepType("LogArchive")
 
-
-        self.addLogCollectTask(mergeTask, taskName = "StoreResultsLogCollect")
+        self.addLogCollectTask(mergeTask, taskName="StoreResultsLogCollect")
 
         mergeTask.setTaskType("Merge")
         mergeTask.applyTemplates()
 
         mergeTask.addInputDataset(name=self.inputDataset,
-                                  primary = inputPrimaryDataset,
-                                  processed = inputProcessedDataset,
-                                  tier = inputDataTier,
-                                  dbsurl = self.dbsUrl,
-                                  block_blacklist = self.blockBlacklist,
-                                  block_whitelist = self.blockWhitelist,
-                                  run_blacklist = self.runBlacklist,
-                                  run_whitelist = self.runWhitelist)
+                                  primary=inputPrimaryDataset,
+                                  processed=inputProcessedDataset,
+                                  tier=inputDataTier,
+                                  dbsurl=self.dbsUrl,
+                                  block_blacklist=self.blockBlacklist,
+                                  block_whitelist=self.blockWhitelist,
+                                  run_blacklist=self.runBlacklist,
+                                  run_whitelist=self.runWhitelist)
 
         splitAlgo = "ParentlessMergeBySize"
         mergeTask.setSplittingAlgorithm(splitAlgo,
-                                        max_merge_size = self.maxMergeSize,
-                                        min_merge_size = self.minMergeSize,
-                                        max_merge_events = self.maxMergeEvents)
+                                        max_merge_size=self.maxMergeSize,
+                                        min_merge_size=self.minMergeSize,
+                                        max_merge_events=self.maxMergeEvents)
 
         mergeTaskCmsswHelper = mergeTaskCmssw.getTypeHelper()
-        mergeTaskCmsswHelper.cmsswSetup(self.frameworkVersion, softwareEnvironment = "",
-                                        scramArch = self.scramArch)
+        mergeTaskCmsswHelper.cmsswSetup(self.frameworkVersion, softwareEnvironment="",
+                                        scramArch=self.scramArch)
         mergeTaskCmsswHelper.setGlobalTag(self.globalTag)
         mergeTaskCmsswHelper.setSkipBadFiles(True)
         mergeTaskCmsswHelper.setDataProcessingConfig("do_not_use", "merge")
 
         self.addOutputModule(mergeTask, "Merged",
-                             primaryDataset = inputPrimaryDataset,
-                             dataTier = self.dataTier,
-                             filterName = None,
-                             forceMerged = True)
+                             primaryDataset=inputPrimaryDataset,
+                             dataTier=self.dataTier,
+                             filterName=None,
+                             forceMerged=True)
 
         workload.setLFNBase(self.mergedLFNBase, self.unmergedLFNBase)
         workload.setDashboardActivity("StoreResults")
@@ -95,12 +94,12 @@ class StoreResultsWorkloadFactory(StdBase):
     @staticmethod
     def getWorkloadCreateArgs():
         baseArgs = StdBase.getWorkloadCreateArgs()
-        specArgs = {"RequestType" : {"default" : "StoreResults", "optional" : False},
-                    "InputDataset" : {"optional" : False, "validate" : dataset, "null" : False},
+        specArgs = {"RequestType": {"default": "StoreResults", "optional": False},
+                    "InputDataset": {"optional": False, "validate": dataset, "null": False},
                     "ConfigCacheID": {"optional": True, "null": True},
-                    "DataTier" : {"default" : "USER", "type" : str,
-                                  "optional" : True, "validate" : None,
-                                  "attr" : "dataTier", "null" : False},
+                    "DataTier": {"default": "USER", "type": str,
+                                 "optional": True, "validate": None,
+                                 "attr": "dataTier", "null": False},
                     "PhysicsGroup": {"default": "", "optional": False,
                                      "null": False, "validate": physicsgroup},
                     "MergedLFNBase": {"default": "/store/results", "type": str,

--- a/src/python/WMCore/WMSpec/StdSpecs/StoreResults.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StoreResults.py
@@ -11,7 +11,7 @@ Standard StoreResults workflow.
 """
 
 from Utils.Utilities import makeList
-from WMCore.Lexicon import dataset, block
+from WMCore.Lexicon import dataset, block, physicsgroup
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
 
 class StoreResultsWorkloadFactory(StdBase):
@@ -27,14 +27,14 @@ class StoreResultsWorkloadFactory(StdBase):
 
         Create a StoreResults workload with the given parameters.
         """
+        # first of all, we update the merged LFN based on the physics group
+        arguments['MergedLFNBase'] += "/" + arguments['PhysicsGroup'].lower()
         StdBase.__call__(self, workloadName, arguments)
 
         (inputPrimaryDataset, inputProcessedDataset, inputDataTier) = self.inputDataset[1:].split("/")
 
         workload = self.createWorkload()
 
-        workload.setLFNBase(self.mergedLFNBase, self.unmergedLFNBase)
-        workload.setDashboardActivity("StoreResults")
 
         mergeTask = workload.newTask("StoreResults")
         self.addDashboardMonitoring(mergeTask)
@@ -82,6 +82,9 @@ class StoreResultsWorkloadFactory(StdBase):
                              filterName = None,
                              forceMerged = True)
 
+        workload.setLFNBase(self.mergedLFNBase, self.unmergedLFNBase)
+        workload.setDashboardActivity("StoreResults")
+
         # setting the parameters which need to be set for all the tasks
         # sets acquisitionEra, processingVersion, processingString
         workload.setTaskPropertiesFromWorkload()
@@ -94,27 +97,27 @@ class StoreResultsWorkloadFactory(StdBase):
         baseArgs = StdBase.getWorkloadCreateArgs()
         specArgs = {"RequestType" : {"default" : "StoreResults", "optional" : False},
                     "InputDataset" : {"optional" : False, "validate" : dataset, "null" : False},
-                    "CmsPath" : {"default" : "/tmp", "type" : str,
-                                 "optional" : False, "validate" : None,
-                                 "attr" : "cmsPath", "null" : False},
+                    "ConfigCacheID": {"optional": True, "null": True},
                     "DataTier" : {"default" : "USER", "type" : str,
                                   "optional" : True, "validate" : None,
                                   "attr" : "dataTier", "null" : False},
-                    "MergedLFNBase" : {"default" : "/store/results", "type" : str,
-                                       "optional" : True, "validate" : None,
-                                       "attr" : "mergedLFNBase", "null" : False},
-                    "BlockBlacklist" : {"default" : [], "type" : makeList,
-                                        "optional" : True, "validate" : lambda x: all([block(y) for y in x]),
-                                        "attr" : "blockBlacklist", "null" : False},
-                    "BlockWhitelist" : {"default" : [], "type" : makeList,
-                                        "optional" : True, "validate" : lambda x: all([block(y) for y in x]),
-                                        "attr" : "blockWhitelist", "null" : False},
-                    "RunBlacklist" : {"default" : [], "type" : makeList,
-                                      "optional" : True, "validate" : lambda x: all([int(y) > 0 for y in x]),
-                                      "attr" : "runBlacklist", "null" : False},
-                    "RunWhitelist" : {"default" : [], "type" : makeList,
-                                      "optional" : True, "validate" : lambda x: all([int(y) > 0 for y in x]),
-                                      "attr" : "runWhitelist", "null" : False}}
+                    "PhysicsGroup": {"default": "", "optional": False,
+                                     "null": False, "validate": physicsgroup},
+                    "MergedLFNBase": {"default": "/store/results", "type": str,
+                                      "optional": True, "validate": None,
+                                      "attr": "mergedLFNBase", "null": False},
+                    "BlockBlacklist": {"default": [], "type": makeList,
+                                       "optional": True, "validate": lambda x: all([block(y) for y in x]),
+                                       "attr": "blockBlacklist", "null": False},
+                    "BlockWhitelist": {"default": [], "type": makeList,
+                                       "optional": True, "validate": lambda x: all([block(y) for y in x]),
+                                       "attr": "blockWhitelist", "null": False},
+                    "RunBlacklist": {"default": [], "type": makeList,
+                                     "optional": True, "validate": lambda x: all([int(y) > 0 for y in x]),
+                                     "attr": "runBlacklist", "null": False},
+                    "RunWhitelist": {"default": [], "type": makeList,
+                                     "optional": True, "validate": lambda x: all([int(y) > 0 for y in x]),
+                                     "attr": "runWhitelist", "null": False}}
         baseArgs.update(specArgs)
         StdBase.setDefaultArgumentsProperty(baseArgs)
         return baseArgs

--- a/test/data/ReqMgr/requests/DMWM/StoreResults.json
+++ b/test/data/ReqMgr/requests/DMWM/StoreResults.json
@@ -1,27 +1,39 @@
 {
-    "createRequest": {
-        "AcquisitionEra": "StoreResults",
-        "CMSSWVersion": "CMSSW_5_3_8",
-        "CmsPath": "/uscmst1/prod/sw/cms",
-        "DataTier": "USER",
-        "DbsUrl": "https://cmsweb.cern.ch/dbs/prod/phys02/DBSReader",
-        "GlobalTag": "UNKNOWN",
-        "Group": "DATAOPS",
-        "InputDataset": "/SingletopWprime_M-1800_right_TuneZ2star_8TeV-comphep/dsperka-Summer12_DR53X-PU_S10_START53_V7A-v1_TLBSM_53x_v3-99bd99199697666ff01397dad5652e9e/USER",
-        "MaxMergeEvents": 100000,
-        "MaxMergeSize": 5000000000,
-        "Memory": 2394,
-        "MergedLFNBase": "/store/results/b2g",
-        "MinMergeSize": 1500000000,
-        "ProcessingString": "Summer12_DR53X_PU_S10_START53_V7A_v1_TLBSM_53x_v3_99bd99199697666ff01397dad5652e9e",
-        "ProcessingVersion": "1",
-        "RequestType": "StoreResults",
-        "ScramArch": "slc5_amd64_gcc462",
-        "SiteWhitelist": [
-            "T1_US_FNAL"
-        ],
-        "SizePerEvent": 512.0,
-        "TimePerEvent": 40,
-        "UnmergedLFNBase": "/store/unmerged"
-    }
+  "assignRequest": {
+    "AcquisitionEra": "StoreResults",
+    "Dashboard": "Dashboard-OVERRIDE-ME",
+    "GracePeriod": 300,
+    "MaxRSS": 2400000,
+    "MaxVSize": 20000000,
+    "ProcessingString": "RECO_HIMinBiasUPC_HIRun2011_v1_HLT_HIMinBiasHfOrBSC_CMSSW740pre8_20150728",
+    "ProcessingVersion": 19,
+    "SiteBlacklist": [],
+    "SiteWhitelist": [
+      "SiteWhitelist-OVERRIDE-ME"
+    ],
+    "SoftTimeout": 129600,
+    "Team": "Team-OVERRIDE-ME",
+    "TrustSitelists": true
+  },
+  "createRequest": {
+    "AcquisitionEra": "StoreResults",
+    "CMSSWVersion": "CMSSW_7_4_0_patch1",
+    "DataTier": "USER",
+    "DbsUrl": "https://cmsweb.cern.ch/dbs/prod/phys03/DBSReader",
+    "GlobalTag": "crab3_tag",
+    "PhysicsGroup": "HIN",
+    "InputDataset": "/HIMinBiasUPC/twang-RECO_HIMinBiasUPC_HIRun2011_v1_HLT_HIMinBiasHfOrBSC_CMSSW740pre8_20150728-e4923d8707beca9ac7717c2aaa486589/USER",
+    "MaxMergeEvents": 200000,
+    "MaxMergeSize": 5000000000,
+    "Memory": 2394,
+    "MergedLFNBase": "/store/results",
+    "MinMergeSize": 1500000000,
+    "ProcessingString": "RECO_HIMinBiasUPC_HIRun2011_v1_HLT_HIMinBiasHfOrBSC_CMSSW740pre8_20150728",
+    "ProcessingVersion": "1",
+    "RequestType": "StoreResults",
+    "ScramArch": "slc6_amd64_gcc491",
+    "SizePerEvent": 512.0,
+    "TimePerEvent": 1,
+    "UnmergedLFNBase": "/store/unmerged"
+  }
 }

--- a/test/python/WMCore_t/Lexicon_t.py
+++ b/test/python/WMCore_t/Lexicon_t.py
@@ -816,6 +816,26 @@ class LexiconTest(unittest.TestCase):
         self.assertTrue(primaryDatasetType("cosmic"), "data should be allowed")
         self.assertTrue(primaryDatasetType("test"), "test should be allowed")
 
+    def testPhysicsGroup(self):
+        """
+        _testPhysicsGroup_
+
+        Test a few use cases for PhysicsGroup
+        """
+        self.assertRaises(AssertionError, physicsgroup, '')
+        self.assertRaises(AssertionError, physicsgroup, 'A-30-length-Str_that_is_not_allowed')
+
+        self.assertTrue(physicsgroup('1'))
+        self.assertTrue(physicsgroup('A'))
+        self.assertTrue(physicsgroup('_'))
+        self.assertTrue(physicsgroup('-'))
+        self.assertTrue(physicsgroup('FacOps'))
+        self.assertTrue(physicsgroup('Heavy-Ions'))
+        self.assertTrue(physicsgroup('Heavy_Ions'))
+        self.assertTrue(physicsgroup('Tracker-POG'))
+        self.assertTrue(physicsgroup('Trigger'))
+        return
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StoreResults_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StoreResults_t.py
@@ -60,7 +60,6 @@ class StoreResultsTest(unittest.TestCase):
         correctly.
         """
         arguments = StoreResultsWorkloadFactory.getTestArguments()
-        arguments.update({'CmsPath': "/uscmst1/prod/sw/cms"})
 
         factory = StoreResultsWorkloadFactory()
         testWorkload = factory.factoryWorkloadConstruction("TestWorkload", arguments)
@@ -135,7 +134,6 @@ class StoreResultsTest(unittest.TestCase):
                     'Merge')]
 
         testArguments = StoreResultsWorkloadFactory.getTestArguments()
-        testArguments.update({'CmsPath': "/uscmst1/prod/sw/cms"})
 
         factory = StoreResultsWorkloadFactory()
         testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)


### PR DESCRIPTION
Fixes #8075 
As you can see, we update the MergedLFNBase inside the spec such that it reflects the PhysicsGroup the user is member of. I'm not sure there is a store results namespace after each of those physics groups? @ericvaandering would you know?