### PR TITLE
Implement minute heartbeat for the components and monitor it

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -462,6 +462,15 @@ config.AnalyticsDataCollector.summaryLevel = "task"
 config.AnalyticsDataCollector.couchProcessThreshold = 50
 config.AnalyticsDataCollector.pluginName = None
 
+config.component_("ArchiveDataReporter")
+config.ArchiveDataReporter.namespace = "WMComponent.ArchiveDataReporter.ArchiveDataReporter"
+config.ArchiveDataReporter.componentDir = config.General.workDir + "/ArchiveDataReporter"
+config.ArchiveDataReporter.pollInterval = 300
+config.ArchiveDataReporter.WMArchiveURL = None
+config.ArchiveDataReporter.numDocsRetrievePerPolling = 1000  # number of documents needed to be polled each time
+config.ArchiveDataReporter.numDocsUploadPerCall = 200  # number of documents upload each time in bulk to WMArchive
+
+# AgentStatusWatcher has to be the last one in the config to avoid false alarms during startup
 config.component_("AgentStatusWatcher")
 config.AgentStatusWatcher.namespace = "WMComponent.AgentStatusWatcher.AgentStatusWatcher"
 config.AgentStatusWatcher.componentDir = config.General.workDir + "/AgentStatusWatcher"
@@ -484,11 +493,3 @@ config.AgentStatusWatcher.agentPollInterval = 300
 config.AgentStatusWatcher.drainStatusPollInterval = 43200
 config.AgentStatusWatcher.defaultAgentsNumByTeam = 5
 config.AgentStatusWatcher.jsonFile = config.AgentStatusWatcher.componentDir + "/WMA_monitoring.json"
-
-config.component_("ArchiveDataReporter")
-config.ArchiveDataReporter.namespace = "WMComponent.ArchiveDataReporter.ArchiveDataReporter"
-config.ArchiveDataReporter.componentDir = config.General.workDir + "/ArchiveDataReporter"
-config.ArchiveDataReporter.pollInterval = 300
-config.ArchiveDataReporter.WMArchiveURL = None
-config.ArchiveDataReporter.numDocsRetrievePerPolling = 1000  # number of documents needed to be polled each time
-config.ArchiveDataReporter.numDocsUploadPerCall = 200  # number of documents upload each time in bulk to WMArchive

--- a/src/couchapps/WMStats/_attachments/js/Views/HTMLList/WMStats.AgentDetailList.js
+++ b/src/couchapps/WMStats/_attachments/js/Views/HTMLList/WMStats.AgentDetailList.js
@@ -6,12 +6,12 @@ WMStats.namespace("AgentDetailList");
         var formatStr = "";
         for (var i in componentList) {
             formatStr += "<details> <summary>" + componentList[i].name +"</summary> <ul>";
-            formatStr += "<li><b>" + componentList[i].worker_name +"</b> </li>";
-            formatStr += "<li><b>status</b>: " + componentList[i].state + "</li>";
-            formatStr += "<li><b>error</b>: " + WMStats.Utils.utcClock(new Date(componentList[i].last_error * 1000)) + "</li>";
-            formatStr += "<li><b>error message</b>: <pre>" + componentList[i].error_message + "</pre></li>";
-            //formatStr += "<li><b>time</b>: " + WMStats.Utils.utcClock(new Date(componentList[i].last_updated * 1000)) + "</li>";
-            formatStr += "<li><b>pid</b>: " + componentList[i].pid + "</li>";
+            formatStr += "<li><b>worker thread:</b> " + componentList[i].worker_name +"</li>";
+            formatStr += "<li><b>status:</b> " + componentList[i].state + "</li>";
+            //formatStr += "<li><b>error:</b> " + WMStats.Utils.utcClock(new Date(componentList[i].last_error * 1000)) + "</li>";
+            formatStr += "<li><b>last updated:</b> " + WMStats.Utils.utcClock(new Date(componentList[i].last_updated * 1000)) + "</li>";
+            formatStr += "<li><b>pid:</b> " + componentList[i].pid + "</li>";
+            formatStr += "<li><b>error message:</b> <pre>" + componentList[i].error_message + "</pre></li>";
             formatStr += "</ul></details>";
         }
         
@@ -40,13 +40,15 @@ WMStats.namespace("AgentDetailList");
             htmlstr += "<li><b>status:</b> " + agentInfo.alert.message + "</li>";
             htmlstr += "<li><b>team:</b> " + agentInfo.agent_team+ "</li>";
         };
-        var detailInfo = agentInfo.down_component_detail;
-        if (detailInfo && (detailInfo.length > 0)) {
-            htmlstr += "<li><b>component errors:</b> ";
-            htmlstr += componentFormat(detailInfo);
+        var componentsDown = agentInfo.down_components;
+        if (componentsDown && (componentsDown.length > 0)) {
+            htmlstr += "<li><b>component errors for:</b> " + componentsDown;
+            if (agentInfo.down_component_detail && (agentInfo.down_component_detail.length > 0)) {
+                htmlstr += componentFormat(agentInfo.down_component_detail);
+            }
             htmlstr +="</li>";
-           };
-           
+        };
+
         var diskInfo = agentInfo.disk_warning;
         if (diskInfo && (diskInfo.length > 0)) {
             htmlstr += "<li><b>disk warning:</b> ";

--- a/src/couchapps/WMStats/_attachments/js/WMStats.Utils.js
+++ b/src/couchapps/WMStats/_attachments/js/WMStats.Utils.js
@@ -91,7 +91,7 @@ WMStats.Utils.formatDate = function (timestamp) {
 };
 
 WMStats.Utils.formatDuration = function (timestamp) {
-    if (timestamp == -1) return "N/A";
+    if (timestamp < 0) return "N/A";
     var totalMin = Math.floor(timestamp / 60);
     var hours = Math.floor(totalMin / 60);
     var min = totalMin % 60;

--- a/src/couchapps/WMStats/_attachments/js/minified/global.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/global.min.js
@@ -303,7 +303,7 @@ WMStats.Utils.formatDate = function (timestamp) {
 };
 
 WMStats.Utils.formatDuration = function (timestamp) {
-    if (timestamp == -1) return "N/A";
+    if (timestamp < 0) return "N/A";
     var totalMin = Math.floor(timestamp / 60);
     var hours = Math.floor(totalMin / 60);
     var min = totalMin % 60;

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
@@ -2774,12 +2774,12 @@ WMStats.namespace("AgentDetailList");
         var formatStr = "";
         for (var i in componentList) {
             formatStr += "<details> <summary>" + componentList[i].name +"</summary> <ul>";
-            formatStr += "<li><b>" + componentList[i].worker_name +"</b> </li>";
-            formatStr += "<li><b>status</b>: " + componentList[i].state + "</li>";
-            formatStr += "<li><b>error</b>: " + WMStats.Utils.utcClock(new Date(componentList[i].last_error * 1000)) + "</li>";
-            formatStr += "<li><b>error message</b>: <pre>" + componentList[i].error_message + "</pre></li>";
-            //formatStr += "<li><b>time</b>: " + WMStats.Utils.utcClock(new Date(componentList[i].last_updated * 1000)) + "</li>";
-            formatStr += "<li><b>pid</b>: " + componentList[i].pid + "</li>";
+            formatStr += "<li><b>worker thread:</b> " + componentList[i].worker_name +"</li>";
+            formatStr += "<li><b>status:</b> " + componentList[i].state + "</li>";
+            //formatStr += "<li><b>error:</b> " + WMStats.Utils.utcClock(new Date(componentList[i].last_error * 1000)) + "</li>";
+            formatStr += "<li><b>last updated:</b> " + WMStats.Utils.utcClock(new Date(componentList[i].last_updated * 1000)) + "</li>";
+            formatStr += "<li><b>pid:</b> " + componentList[i].pid + "</li>";
+            formatStr += "<li><b>error message:</b> <pre>" + componentList[i].error_message + "</pre></li>";
             formatStr += "</ul></details>";
         }
         
@@ -2808,12 +2808,15 @@ WMStats.namespace("AgentDetailList");
             htmlstr += "<li><b>status:</b> " + agentInfo.alert.message + "</li>";
             htmlstr += "<li><b>team:</b> " + agentInfo.agent_team+ "</li>";
         };
-        var detailInfo = agentInfo.down_component_detail;
-        if (detailInfo && (detailInfo.length > 0)) {
-            htmlstr += "<li><b>component errors:</b> ";
-            htmlstr += componentFormat(detailInfo);
+
+        var componentsDown = agentInfo.down_components;
+        if (componentsDown && (componentsDown.length > 0)) {
+            htmlstr += "<li><b>component errors for:</b> " + componentsDown;
+            if (agentInfo.down_component_detail && (agentInfo.down_component_detail.length > 0)) {
+                htmlstr += componentFormat(agentInfo.down_component_detail);
+            }
             htmlstr +="</li>";
-           };
+        };
            
         var diskInfo = agentInfo.disk_warning;
         if (diskInfo && (diskInfo.length > 0)) {

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
@@ -2917,12 +2917,12 @@ WMStats.namespace("AgentDetailList");
         var formatStr = "";
         for (var i in componentList) {
             formatStr += "<details> <summary>" + componentList[i].name +"</summary> <ul>";
-            formatStr += "<li><b>" + componentList[i].worker_name +"</b> </li>";
-            formatStr += "<li><b>status</b>: " + componentList[i].state + "</li>";
-            formatStr += "<li><b>error</b>: " + WMStats.Utils.utcClock(new Date(componentList[i].last_error * 1000)) + "</li>";
-            formatStr += "<li><b>error message</b>: <pre>" + componentList[i].error_message + "</pre></li>";
-            //formatStr += "<li><b>time</b>: " + WMStats.Utils.utcClock(new Date(componentList[i].last_updated * 1000)) + "</li>";
-            formatStr += "<li><b>pid</b>: " + componentList[i].pid + "</li>";
+            formatStr += "<li><b>worker thread:</b> " + componentList[i].worker_name +"</li>";
+            formatStr += "<li><b>status:</b> " + componentList[i].state + "</li>";
+            //formatStr += "<li><b>error:</b> " + WMStats.Utils.utcClock(new Date(componentList[i].last_error * 1000)) + "</li>";
+            formatStr += "<li><b>last updated:</b> " + WMStats.Utils.utcClock(new Date(componentList[i].last_updated * 1000)) + "</li>";
+            formatStr += "<li><b>pid:</b> " + componentList[i].pid + "</li>";
+            formatStr += "<li><b>error message:</b> <pre>" + componentList[i].error_message + "</pre></li>";
             formatStr += "</ul></details>";
         }
         
@@ -2951,12 +2951,15 @@ WMStats.namespace("AgentDetailList");
             htmlstr += "<li><b>status:</b> " + agentInfo.alert.message + "</li>";
             htmlstr += "<li><b>team:</b> " + agentInfo.agent_team+ "</li>";
         };
-        var detailInfo = agentInfo.down_component_detail;
-        if (detailInfo && (detailInfo.length > 0)) {
-            htmlstr += "<li><b>component errors:</b> ";
-            htmlstr += componentFormat(detailInfo);
+
+        var componentsDown = agentInfo.down_components;
+        if (componentsDown && (componentsDown.length > 0)) {
+            htmlstr += "<li><b>component errors for:</b> " + componentsDown;
+            if (agentInfo.down_component_detail && (agentInfo.down_component_detail.length > 0)) {
+                htmlstr += componentFormat(agentInfo.down_component_detail);
+            }
             htmlstr +="</li>";
-           };
+        };
            
         var diskInfo = agentInfo.disk_warning;
         if (diskInfo && (diskInfo.length > 0)) {

--- a/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
+++ b/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
@@ -221,8 +221,7 @@ class AgentStatusPoller(BaseWorkerThread):
             if agentInfo.get('data_error', 'ok') != 'ok' or agentInfo.get('couch_process_warning', 0):
                 agentInfo['status'] = "error"
 
-        if agentInfo['down_components']:
-            logging.info("List of agent components down: %s", agentInfo['down_components'])
+        logging.info("List of agent components down: %s", agentInfo['down_components'])
 
         return agentInfo
 

--- a/src/python/WMComponent/AnalyticsDataCollector/DataCollectAPI.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/DataCollectAPI.py
@@ -1,6 +1,7 @@
 """
 Provide functions to collect data and upload data
 """
+from __future__ import division
 
 import os
 import time
@@ -199,28 +200,49 @@ class WMAgentDBData(object):
         return monitoring
 
     def getHeartbeatWarning(self):
+        """
+        _getHeartbeatWarning_
+
+        Fetch the status and last hearbeat for every single component
+        and their threads.
+
+        :return: returns a dictionary with a summary of the component
+        status and a short error message, if any.
+        """
 
         results = self.componentStatusAction.execute()
         currentTime = time.time()
         agentInfo = {}
-        agentInfo['down_components'] = []
-
-        agentInfo['down_component_detail'] = []
         agentInfo['status'] = 'ok'
+        agentInfo['down_components'] = []
+        agentInfo['down_component_detail'] = []
+
         for componentInfo in results:
-            hearbeatFlag = (currentTime - componentInfo["last_updated"]) > componentInfo["update_threshold"]
-            if (componentInfo["state"] != "Error") or hearbeatFlag:
-                agentInfo['down_components'].append(componentInfo['name'])
+            noHeartbeat = (currentTime - componentInfo["last_updated"]) > componentInfo["update_threshold"]
+            if componentInfo["state"] == "Error" or noHeartbeat:
                 agentInfo['status'] = 'down'
+                agentInfo['down_components'].append(componentInfo['name'])
+                if componentInfo["state"] == "Running":
+                    componentInfo["state"] = "Timeout"
+                    lastHeartbeat = (currentTime - componentInfo["last_updated"]) // 60
+                    componentInfo["error_message"] = "Last worker thread heartbeat was %d min ago" % lastHeartbeat
                 agentInfo['down_component_detail'].append(componentInfo)
+
         return agentInfo
 
     def getComponentStatus(self, config):
+        """
+        _getComponentStatus_
+
+        Aggregates the output of getHeartbeatWarning method with the Daemon
+        checks performed.
+        :param config: agent configuration object
+        :return: returns a dictionary with a summary of the component
+        status and a short error message, if any.
+        """
+        agentInfo = self.getHeartbeatWarning()
+
         components = config.listComponents_() + config.listWebapps_()
-        agentInfo = {}
-        agentInfo['down_components'] = set()
-        agentInfo['down_component_detail'] = []
-        agentInfo['status'] = 'ok'
         # check the component status
         for component in components:
             compDir = config.section_(component).componentDir
@@ -233,19 +255,11 @@ class WMAgentDBData(object):
                 daemon = Details(daemonXml)
                 if not daemon.isAlive():
                     downFlag = True
-            if downFlag:
-                agentInfo['down_components'].add(component)
+            if downFlag and component not in agentInfo['down_components']:
                 agentInfo['status'] = 'down'
+                agentInfo['down_components'].append(component)
+                agentInfo['down_component_detail'].append(component)
 
-        # check the thread status
-        results = self.componentStatusAction.execute()
-        for componentInfo in results:
-            if componentInfo["state"] == "Error":
-                agentInfo['down_components'].add(componentInfo['name'])
-                agentInfo['status'] = 'down'
-                agentInfo['down_component_detail'].append(componentInfo)
-
-        agentInfo['down_components'] = list(agentInfo['down_components'])
         return agentInfo
 
     def getBatchJobInfo(self):

--- a/src/python/WMCore/Agent/Database/MySQL/GetAllHeartbeatInfo.py
+++ b/src/python/WMCore/Agent/Database/MySQL/GetAllHeartbeatInfo.py
@@ -8,7 +8,6 @@ __all__ = []
 
 
 
-import time
 from WMCore.Database.DBFormatter import DBFormatter
 
 class GetAllHeartbeatInfo(DBFormatter):

--- a/src/python/WMCore/Agent/Database/MySQL/InsertComponent.py
+++ b/src/python/WMCore/Agent/Database/MySQL/InsertComponent.py
@@ -23,7 +23,7 @@ class InsertComponent(DBFormatter):
     sql = """INSERT INTO wm_components (name, pid, update_threshold)
              VALUES (:name, :pid, :update_threshold)"""
 
-    def execute(self, name, pid, update_threshold = 6000,
+    def execute(self, name, pid, update_threshold = 1800,
                 conn = None, transaction = False):
         deleteBinds = {"name": name}
 

--- a/src/python/WMCore/WorkerThreads/BaseWorkerThread.py
+++ b/src/python/WMCore/WorkerThreads/BaseWorkerThread.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#pylint: disable=R0902,R0201,W0613,W0703,E1102
+#pylint: disable=R0902,R0201,W0703,E1102
 """
 _BaseWorkerThread_
 
@@ -17,8 +17,6 @@ import traceback
 import sys
 
 from WMCore.Database.Transaction import Transaction
-from WMCore.Database.CMSCouch import CouchError
-from WMCore.Database.CouchUtils import CouchConnectionError
 from WMCore.Alerts import API as alertAPI
 
 class BaseWorkerThread:
@@ -45,6 +43,10 @@ class BaseWorkerThread:
 
         # Termination callback function
         self.terminateCallback = None
+
+        # Init heartbeat flag and worker name
+        self.useHeartbeat = False
+        self.workerName = None
 
         # Init the timing
         self.lastTime = time.time()
@@ -77,8 +79,12 @@ class BaseWorkerThread:
     def terminate(self, parameters):
         """
         Called when thread is being terminated. Optional in derived classes.
+        If inherited, then derived class has to call this method.
         """
-        pass
+        msg = "Thread gracefully terminated at %s" % time.strftime("%Y-%m-%dT%H:%M:%S")
+        logging.info(msg)
+        if self.useHeartbeat:
+            self.heartbeatAPI.updateWorkerError(self.workerName, msg)
 
     def algorithm(self, parameters):
         """
@@ -140,6 +146,10 @@ class BaseWorkerThread:
             # to get the right name
             myThread = threading.currentThread()
 
+            if hasattr(self.component.config, "Agent"):
+                self.useHeartbeat = getattr(self.component.config.Agent, "useHeartbeat", True)
+                self.workerName = myThread.getName()
+
             if hasattr(self.component.config, "General") and \
                hasattr(self.component.config.General, "central_logdb_url") and \
                hasattr(self.component.config, "Agent"):
@@ -149,9 +159,9 @@ class BaseWorkerThread:
             else:
                 myThread.logdbClient = None
 
-            if hasattr(self.component.config, "Agent"):
-                if getattr(self.component.config.Agent, "useHeartbeat", True):
-                    self.heartbeatAPI.updateWorkerHeartbeat(myThread.getName())
+            if self.useHeartbeat:
+                self.heartbeatAPI.updateWorkerHeartbeat(self.workerName)
+
             # Run event loop while termination is not flagged
             while not self.notifyTerminate.isSet():
                 # Check manager hasn't paused threads
@@ -166,11 +176,9 @@ class BaseWorkerThread:
                             try:
                                 # heartbeat needed to be called after self.initInThread
                                 # to get the right name
-                                if hasattr(self.component.config, "Agent"):
-                                    if getattr(self.component.config.Agent, "useHeartbeat", True):
-                                        self.heartbeatAPI.updateWorkerHeartbeat(
-                                            myThread.getName(), "Running")
-                            except (CouchError, CouchConnectionError) as ex:
+                                if self.useHeartbeat:
+                                    self.heartbeatAPI.updateWorkerHeartbeat(self.workerName, "Running")
+                            except Exception as ex:
                                 msg  = " Failed to update heartbeat for worker %s" % str(self)
                                 msg += ":\n %s" % str(ex)
                                 msg += "\n Skipping worker algorithm!"
@@ -180,7 +188,7 @@ class BaseWorkerThread:
                                 # Catch if someone forgets to commit/rollback
                                 if myThread.transaction.transaction is not None:
                                     msg = """ Thread %s:  Transaction reached
-                                              end of poll loop.""" % myThread.getName()
+                                              end of poll loop.""" % self.workerName
                                     msg += " Raise a bug against me. Rollback."
                                     logging.error(msg)
                                     myThread.transaction.rollback()
@@ -198,10 +206,8 @@ class BaseWorkerThread:
                                 self.component.prepareToStop()
                             except Exception as ex:
                                 logging.error("Failed to halt component after worker crash: %s" % str(ex))
-                            if hasattr(self.component.config, "Agent"):
-                                if getattr(self.component.config.Agent, "useHeartbeat", True):
-                                    self.heartbeatAPI.updateWorkerError(
-                                        myThread.getName(), msg)
+                            if self.useHeartbeat:
+                                self.heartbeatAPI.updateWorkerError(self.workerName, msg)
                             raise ex
                         # Put the thread to sleep
                         self.sleepThread()
@@ -233,10 +239,25 @@ class BaseWorkerThread:
         The default (naiive) time.sleep(self.idleTime) isn't always
         the best idea, let different workers do it differently.
 
+        Wakes the thread up every minute for a quick heartbeat.
+        Need to constantly watch if the thread is terminated for
+        properly stopping/terminating it.
+
         returns control when it's time to wake back up
         doesn't return any values
         """
-        time.sleep( self.idleTime )
+        idleTime = self.idleTime
+        while idleTime > 0:
+            if self.useHeartbeat and idleTime % 60 == 0:
+                # send a heartbeat every minute
+                self.heartbeatAPI.updateWorkerHeartbeat(self.workerName, "Running")
+
+            if not self.notifyTerminate.isSet():
+                break
+
+            time.sleep(1)
+            idleTime -= 1
+
 
     def initAlerts(self, compName = None):
         """

--- a/src/python/WMCore/WorkerThreads/BaseWorkerThread.py
+++ b/src/python/WMCore/WorkerThreads/BaseWorkerThread.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#pylint: disable=R0902,R0201,W0703,E1102
+# pylint: disable=R0902,R0201,W0703,E1102
 """
 _BaseWorkerThread_
 
@@ -8,24 +8,24 @@ Deriving classes should override algorithm, and optionally setup and terminate
 to perform thread-specific setup and clean-up operations
 """
 
-
-
-import threading
 import logging
+import sys
+import threading
 import time
 import traceback
-import sys
 
-from WMCore.Database.Transaction import Transaction
 from WMCore.Alerts import API as alertAPI
+from WMCore.Database.Transaction import Transaction
 
-class BaseWorkerThread:
+
+class BaseWorkerThread(object):
     """
     A base class for worker threads, used for work that needs to occur at
     regular intervals. Framework (through WorkerThreadManager) ensures that
     a default transaction, trigger and message service are available as in
     event handler threads.
     """
+
     def __init__(self):
         """
         Creates the worker, called from parent thread
@@ -67,7 +67,6 @@ class BaseWorkerThread:
         self.procid = 0
         if hasattr(myThread, 'msgService'):
             self.procid = myThread.msgService.procid
-
 
     def setup(self, parameters):
         """
@@ -151,11 +150,11 @@ class BaseWorkerThread:
                 self.workerName = myThread.getName()
 
             if hasattr(self.component.config, "General") and \
-               hasattr(self.component.config.General, "central_logdb_url") and \
-               hasattr(self.component.config, "Agent"):
+                    hasattr(self.component.config.General, "central_logdb_url") and \
+                    hasattr(self.component.config, "Agent"):
                 from WMCore.Services.LogDB.LogDB import LogDB
                 myThread.logdbClient = LogDB(self.component.config.General.central_logdb_url,
-                                         self.component.config.Agent.hostName, logger=logging)
+                                             self.component.config.Agent.hostName, logger=logging)
             else:
                 myThread.logdbClient = None
 
@@ -179,7 +178,7 @@ class BaseWorkerThread:
                                 if self.useHeartbeat:
                                     self.heartbeatAPI.updateWorkerHeartbeat(self.workerName, "Running")
                             except Exception as ex:
-                                msg  = " Failed to update heartbeat for worker %s" % str(self)
+                                msg = " Failed to update heartbeat for worker %s" % str(self)
                                 msg += ":\n %s" % str(ex)
                                 msg += "\n Skipping worker algorithm!"
                                 logging.error(msg)
@@ -205,7 +204,7 @@ class BaseWorkerThread:
                             try:
                                 self.component.prepareToStop()
                             except Exception as ex:
-                                logging.error("Failed to halt component after worker crash: %s" % str(ex))
+                                logging.error("Failed to halt component after worker crash: %s", str(ex))
                             if self.useHeartbeat:
                                 self.heartbeatAPI.updateWorkerError(self.workerName, msg)
                             raise ex
@@ -258,8 +257,7 @@ class BaseWorkerThread:
             time.sleep(1)
             idleTime -= 1
 
-
-    def initAlerts(self, compName = None):
+    def initAlerts(self, compName=None):
         """
         _initAlerts_
 
@@ -277,12 +275,11 @@ class BaseWorkerThread:
         if not compName:
             compName = self.__class__.__name__
         preAlert, sender = alertAPI.setUpAlertsMessaging(self,
-                                                         compName = compName)
-        sendAlert = alertAPI.getSendAlert(sender = sender,
-                                          preAlert = preAlert)
+                                                         compName=compName)
+        sendAlert = alertAPI.getSendAlert(sender=sender,
+                                          preAlert=preAlert)
         self.sender = sender
         self.sendAlert = sendAlert
-
 
     def __del__(self):
         """


### PR DESCRIPTION
Fixes #8109

Changes so far are:
* while the threads are sleeping, send a heartbeat every 60secs;
* monitor heartbeat (last_updated) based on update_threshold (decreased from 6000 to 1800). Ideally it should be smaller, like 10min, but I'm afraid there are components that may spend > 10min in a busy cycle;
* update the db with a (nice) error when a worker thread is gracefully terminated (TODO: update all the components overriding it).