### PR TITLE
Update Team and make Teams a 1-element list

### DIFF
--- a/bin/check-request-wq-status
+++ b/bin/check-request-wq-status
@@ -1,14 +1,15 @@
 #!/usr/bin/env python
 from __future__ import print_function, division
+
 import os
 from argparse import ArgumentParser
-from pprint import pprint, pformat
+from pprint import pformat
+
 from WMCore.Configuration import loadConfigurationFile
 from WMCore.WorkQueue.DataStructs.WorkQueueElementsSummary import WorkQueueElementsSummary
 from WMCore.WorkQueue.WMBSHelper import freeSlots
 from WMCore.WorkQueue.WorkQueueUtils import cmsSiteNames
 from WMCore.WorkQueue.WorkQueueUtils import queueFromConfig
-from WMCore.WorkQueue.WorkQueue import globalQueue
 
 
 def getOptions():
@@ -19,16 +20,16 @@ def getOptions():
     parser.add_argument("-g", "--global", action='store_true', dest='wqGlobal',
                         help="Use it to get an overview of global WQ")
     args = parser.parse_args()
-    
+
     return args
 
+
 def getAcceptableSites(ele):
-    
     if ele['SiteWhitelist']:
         commonSites = set(ele['SiteWhitelist'])
     else:
         commonSites = set()
-    
+
     if ele['Inputs']:
         if commonSites:
             commonSites = commonSites & set([y for x in ele['Inputs'].values() for y in x])
@@ -42,6 +43,7 @@ def getAcceptableSites(ele):
 
     return commonSites
 
+
 def createWorkQueue(config):
     """Create a workqueue from wmagent config"""
     # if config has a db sction instantiate a dbi
@@ -50,14 +52,13 @@ def createWorkQueue(config):
         wmInit = WMInit()
         (dialect, junk) = config.CoreDatabase.connectUrl.split(":", 1)
         socket = getattr(config.CoreDatabase, "socket", None)
-        wmInit.setDatabaseConnection(dbConfig = config.CoreDatabase.connectUrl,
-                                     dialect = dialect,
-                                     socketLoc = socket)
+        wmInit.setDatabaseConnection(dbConfig=config.CoreDatabase.connectUrl,
+                                     dialect=dialect,
+                                     socketLoc=socket)
     return queueFromConfig(config)
 
 
 def jobSiteSummary(localQ, request, possibleSites, resources, jobCounts, flag="LQ"):
-    
     # filter resource and job_count by request
     filteredResources = {}
     filteredJobCounts = {}
@@ -65,30 +66,29 @@ def jobSiteSummary(localQ, request, possibleSites, resources, jobCounts, flag="L
         if site in resources:
             filteredResources[site] = resources[site]
             filteredJobCounts[site] = jobCounts[site]
-         
-        
+
     siteSummary = {}
     for res in filteredResources:
         siteSummary.setdefault(res, {})
         siteSummary[res] = {'slots': resources[res]}
-    
+
     for res in filteredJobCounts:
         siteSummary.setdefault(res, {})
         countByPriority = jobCounts[res]
-        siteSummary[res].update({'priority': countByPriority, 
-                            'total jobs created': sum(countByPriority.values())})
-    
+        siteSummary[res].update({'priority': countByPriority,
+                                 'total jobs created': sum(countByPriority.values())})
+
     print("Possible sites for the request %s" % request)
     for site in possibleSites:
         print("%s: %s" % (site, siteSummary.get(site)))
-    
+
     if flag == "LQ":
         work = localQ.getAvailableWorkfromParent(filteredResources, filteredJobCounts)
         print("Get available work from GQ")
     else:
         work, _, _ = localQ.backend.availableWork(resources, jobCounts)
         print("Get available work from LQ for job creation")
-    
+
     eleCount = 0
     jobCount = 0
     highJobs = 0
@@ -100,7 +100,7 @@ def jobSiteSummary(localQ, request, possibleSites, resources, jobCounts, flag="L
             else:
                 highJobs += wqe["Jobs"]
                 print("%s, higher priority %s, jobs %s " % (wqe["RequestName"], wqe["Priority"], wqe["Jobs"]))
-        
+
         if eleCount > 0:
             print("%s , elements %s, total jobs %s will be pull to %s" % (request, eleCount, jobCount, flag))
         else:
@@ -111,34 +111,35 @@ def jobSiteSummary(localQ, request, possibleSites, resources, jobCounts, flag="L
         else:
             print("Resource is full no jobs will be created by this WMAgent")
 
+
 def checkLQPullStatusFromGQ(localQ, request, possibleSites):
-    
     # check pre condition
-    if localQ.pullWorkConditionCheck(printFlag = True):
+    if localQ.pullWorkConditionCheck(printFlag=True):
         print("All pre condition checks are passed to pullWork to LQ")
     else:
         print("Error: Failed to pull elements from GQ")
         return
-           
-    resources, jobCounts = localQ.freeResouceCheck(printFlag=True) 
+
+    resources, jobCounts = localQ.freeResouceCheck(printFlag=True)
     jobSiteSummary(localQ, request, possibleSites, resources, jobCounts, flag="LQ")
     return
-    
+
+
 def checkCreateWorkStatusFromLQ(localQ, request, possibleSites):
-    
     ### get Work check
     if not localQ.backend.isAvailable():
         print('LocalQueue Backend busy or down: skipping try later')
         return
-    
-    resources, jobCounts = freeSlots(minusRunning = True, allowedStates = ['Normal', 'Draining'],
-                              knownCmsSites = cmsSiteNames())
+
+    resources, jobCounts = freeSlots(minusRunning=True, allowedStates=['Normal', 'Draining'],
+                                     knownCmsSites=cmsSiteNames())
     jobSiteSummary(localQ, request, possibleSites, resources, jobCounts, flag="WMBS")
-    
+
+
 def reportByRequest(wqSummary, request, eleStatus, localQ):
     wqSummary.printSummary(request)
     possibleSites = wqSummary.getPossibleSitesByRequest(request)
-    
+
     #### Local queue pullWork status (only checks when gq status is Available)
     ### for Acquired state skip this
     if eleStatus == "Available":
@@ -146,7 +147,8 @@ def reportByRequest(wqSummary, request, eleStatus, localQ):
     elif eleStatus == "Acquired":
         ### get Work check
         checkCreateWorkStatusFromLQ(localQ, request, possibleSites)
-    
+
+
 def main():
     """
     It retrieves GQ and LQ information regarding a specific request name
@@ -164,7 +166,7 @@ def main():
     team = cfgObject.Agent.teamName
 
     localQ = createWorkQueue(cfgObject)
-    
+
     gqElements = localQ.parent_queue.getElements(status=args.status, WorkflowName=args.request, TeamName=team)
     print("### GQ at %s: There are a total of %s elements in %s" % (localQ.parent_queue.queueUrl,
                                                                     len(gqElements), args.status or '*'))
@@ -189,6 +191,7 @@ def main():
     for request in requests:
         reportByRequest(wqSummary, request, args.status, localQ)
         print("\n\n")
-        
+
+
 if __name__ == '__main__':
     main()

--- a/bin/check-request-wq-status
+++ b/bin/check-request-wq-status
@@ -161,12 +161,8 @@ def main():
     cfgObject = loadConfigurationFile(os.environ.get("WMAGENT_CONFIG", None))
     args = getOptions()
 
-    teams = cfgObject.Agent.teamName.split(",")
-    if len(teams) != 1:
-        print("No team or multiple teams are set %s" % teams)
-        return
-    team = teams[0].strip()
-    
+    team = cfgObject.Agent.teamName
+
     localQ = createWorkQueue(cfgObject)
     
     gqElements = localQ.parent_queue.getElements(status=args.status, WorkflowName=args.request, TeamName=team)

--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -38,13 +38,6 @@ workqueueInboxDbName = 'workqueue_inbox'
 workloadSummaryDB = "workloadsummary"
 workloadSummaryURL = couchURL
 
-# Information for the workqueue, email of the administrator and the team names
-# for this agent.
-userEmail = "cms-comp-ops-workflow-team@cern.ch"
-agentTeams = "team1,team2,cmsdataops"
-agentName = "WMAgentCommissioning"
-agentNumber = 0
-
 # List of BossAir plugins that this agent will use.
 bossAirPlugins = ["SimpleCondorPlugin"]
 
@@ -78,10 +71,10 @@ config = Configuration()
 
 config.section_("Agent")
 config.Agent.hostName = serverHostName
-config.Agent.contact = userEmail
-config.Agent.teamName = agentTeams
-config.Agent.agentName = agentName
-config.Agent.agentNumber = agentNumber
+config.Agent.contact = "cms-comp-ops-workflow-team@cern.ch"
+config.Agent.teamName = "cmsdataops"
+config.Agent.agentName = "WMAgentCommissioning"
+config.Agent.agentNumber = 0
 config.Agent.useMsgService = False
 config.Agent.useTrigger = False
 config.Agent.useHeartbeat = True

--- a/src/couchapps/ReqMgr/updates/updaterequest.js
+++ b/src/couchapps/ReqMgr/updates/updaterequest.js
@@ -17,15 +17,12 @@ function(doc, req) {
             doc.RequestTransition.push(statusObj);
         }
     }
-    
+
     function updateTeams(team) {
-        if (!doc.Teams) {
-            doc.Teams = new Array();
-            doc.Teams.push(team);
-        } else {
-            doc.Teams.push(team);
-        }
+        doc.Teams = new Array();
+        doc.Teams.push(team);
     }
+
     // req.query is dictionary fields into the 
     // CMSCouch.Database.updateDocument() method, which is a dictionary
     function isEmpty(obj) {
@@ -72,24 +69,24 @@ function(doc, req) {
                 key == "SiteBlacklist" ||
                 key == "BlockWhitelist" ||
                 key == "CMSSWVersion" ||
-                key == "InputDatasetTypes" ||
                 key == "InputDataset" ||
                 key == "OutputDatasets" ||
                 key == "CustodialSites" ||
                 key == "NonCustodialSites" ||
                 key == "AutoApproveSubscriptionSites" ||
-                key == "OutputModulesLFNBases" ||
-                key == "Teams") {
+                key == "OutputModulesLFNBases") {
 
                doc[key] = JSON.parse(newValues[key]);
            }
         }
 
+        doc[key] = newValues[key];
+
+        // FIXME keep updating Teams for now to make it easier to deprecate in HG1710
         if (key == "Team") {
             updateTeams(newValues[key]);
-        } else {
-            doc[key] = newValues[key];
         }
+
         // If key is RequestStatus, also update the transition
         if (key == "RequestStatus") {
             updateTransition();

--- a/src/couchapps/WMStats/_attachments/js/DataStruct/WMStats.GenericRequests.js
+++ b/src/couchapps/WMStats/_attachments/js/DataStruct/WMStats.GenericRequests.js
@@ -442,7 +442,7 @@ WMStats.GenericRequests.prototype = {
                                  *    "SizePerEvent": 1154, "ConfigCacheID": "1ad063a0d73c1d81143b4182cbf84793", "Memory": 2300, 
                                  *    "RunBlacklist": [], "PrepID": "B2G-Summer12-00736", "AutoApproveSubscriptionSites": [], 
                                  *    "BlockBlacklist": [], "BlockWhitelist": [], "CustodialSubType": "Move", 
-                                 *    "RequestType": "MonteCarloFromGEN", "TimePerEvent": 16.87, "InputDatasetTypes": {},  
+                                 *    "RequestType": "MonteCarloFromGEN", "TimePerEvent": 16.87
                                  *    "OutputDatasets": ["/QDTojWinc_NC_M-1200_TuneZ2star_8TeV-madgraph/Integ_Test-MonteCarloFromGEN_SRYU_pnn-v1/GEN-SIM"], 
                                  *    "LumisPerJob": 1, "SoftwareVersions": ["CMSSW_5_3_19"], 
                                  *    "AcquisitionEra": "Integ_Test", "PrimaryDataset": "QDTojWinc_NC_M-1200_TuneZ2star_8TeV-madgraph", 

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
@@ -479,7 +479,7 @@ WMStats.GenericRequests.prototype = {
                                  *    "SizePerEvent": 1154, "ConfigCacheID": "1ad063a0d73c1d81143b4182cbf84793", "Memory": 2300, 
                                  *    "RunBlacklist": [], "PrepID": "B2G-Summer12-00736", "AutoApproveSubscriptionSites": [], 
                                  *    "BlockBlacklist": [], "BlockWhitelist": [], "CustodialSubType": "Move", 
-                                 *    "RequestType": "MonteCarloFromGEN", "TimePerEvent": 16.87, "InputDatasetTypes": {},  
+                                 *    "RequestType": "MonteCarloFromGEN", "TimePerEvent": 16.87
                                  *    "OutputDatasets": ["/QDTojWinc_NC_M-1200_TuneZ2star_8TeV-madgraph/Integ_Test-MonteCarloFromGEN_SRYU_pnn-v1/GEN-SIM"], 
                                  *    "LumisPerJob": 1, "SoftwareVersions": ["CMSSW_5_3_19"], 
                                  *    "AcquisitionEra": "Integ_Test", "PrimaryDataset": "QDTojWinc_NC_M-1200_TuneZ2star_8TeV-madgraph", 

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
@@ -479,7 +479,7 @@ WMStats.GenericRequests.prototype = {
                                  *    "SizePerEvent": 1154, "ConfigCacheID": "1ad063a0d73c1d81143b4182cbf84793", "Memory": 2300, 
                                  *    "RunBlacklist": [], "PrepID": "B2G-Summer12-00736", "AutoApproveSubscriptionSites": [], 
                                  *    "BlockBlacklist": [], "BlockWhitelist": [], "CustodialSubType": "Move", 
-                                 *    "RequestType": "MonteCarloFromGEN", "TimePerEvent": 16.87, "InputDatasetTypes": {},  
+                                 *    "RequestType": "MonteCarloFromGEN", "TimePerEvent": 16.87
                                  *    "OutputDatasets": ["/QDTojWinc_NC_M-1200_TuneZ2star_8TeV-madgraph/Integ_Test-MonteCarloFromGEN_SRYU_pnn-v1/GEN-SIM"], 
                                  *    "LumisPerJob": 1, "SoftwareVersions": ["CMSSW_5_3_19"], 
                                  *    "AcquisitionEra": "Integ_Test", "PrimaryDataset": "QDTojWinc_NC_M-1200_TuneZ2star_8TeV-madgraph", 

--- a/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
+++ b/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
@@ -40,8 +40,8 @@ class ResourceControlUpdater(BaseWorkerThread):
         # sites forced to down
         self.forceSiteDown = getattr(config.AgentStatusWatcher, 'forceSiteDown', [])
 
-        # agent teams (for dynamic threshold) and queueParams (drain mode)
-        self.teamNames = config.Agent.teamName
+        # agent team (for dynamic threshold) and queueParams (drain mode)
+        self.teamName = config.Agent.teamName
         self.agentsNumByTeam = getattr(config.AgentStatusWatcher, 'defaultAgentsNumByTeam', 5)
 
         # only SSB sites
@@ -114,14 +114,7 @@ class ResourceControlUpdater(BaseWorkerThread):
         if not agentsByTeam:
             logging.warning("agentInfo couch view is not available, use default value %s", self.agentsNumByTeam)
         else:
-            agentsCount = []
-            for team in self.teamNames.split(','):
-                if team not in agentsByTeam:
-                    agentsCount.append(self.agentsNumByTeam)
-                else:
-                    agentsCount.append(agentsByTeam[team])
-            # If agent is in several teams, we choose the team with less agents
-            self.agentsNumByTeam = min(min(agentsCount), self.agentsNumByTeam)
+            self.agentsNumByTeam = agentsByTeam.get(self.teamName, self.agentsNumByTeam)
             logging.debug("Agents connected to the same team (not in DrainMode): %d", self.agentsNumByTeam)
         return
 

--- a/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
+++ b/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
@@ -4,7 +4,6 @@ Perform cleanup actions
 __all__ = []
 
 import urllib2
-import threading
 import logging
 import traceback
 import json
@@ -108,7 +107,7 @@ class ResourceControlUpdater(BaseWorkerThread):
         agentsByTeam = {}
         try:
             agentsByTeam = self.centralCouchDBReader.agentsByTeam(filterDrain=True)
-        except Exception as ex:
+        except Exception:
             logging.error("WMStats is not available or is unresponsive.")
 
         if not agentsByTeam:

--- a/src/python/WMCore/ReqMgr/Service/Request.py
+++ b/src/python/WMCore/ReqMgr/Service/Request.py
@@ -398,8 +398,6 @@ class Request(RESTEntity):
 
     def _handleAssignmentStateTransition(self, workload, request_args, dn):
         if ('SoftTimeout' in request_args) and ('GracePeriod' in request_args):
-            request_args['SoftTimeout'] = int(request_args['SoftTimeout'])
-            request_args['GracePeriod'] = int(request_args['GracePeriod'])
             request_args['HardTimeout'] = request_args['SoftTimeout'] + request_args['GracePeriod']
 
         # Only allow extra value update for assigned status
@@ -417,6 +415,11 @@ class Request(RESTEntity):
 
         # by default, it contains all unmerged LFNs (used by sites to protect the unmerged area)
         request_args['OutputModulesLFNBases'] = workload.listAllOutputModulesLFNBases()
+
+        # FIXME: remove it on HG1710, when this #7355 is complete fixed
+        if not request_args['Team'] or isinstance(request_args['Team'], basestring):
+            raise InvalidSpecParameterValue("Team MUST be a non-empty string")
+
         # legacy update schema to support ops script
         loadRequestSchema(workload, request_args)
         # save the spec first before update the reqmgr request status to prevent race condition

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -1109,6 +1109,7 @@ class StdBase(object):
                      "MaxVSize": {"default": 20411724, "type": int, "validate": lambda x: x > 0},
                      "SoftTimeout": {"default": 129600, "type": int, "validate": lambda x: x > 0},
                      "GracePeriod": {"default": 300, "type": int, "validate": lambda x: x > 0},
+                     "HardTimeout": {"default": 129600 + 300, "type": int, "validate": lambda x: x > 0},
                      # Block closing information
                      "BlockCloseMaxWaitTime": {"default": 66400, "type": int, "validate": lambda x: x > 0},
                      "BlockCloseMaxFiles": {"default": 500, "type": int, "validate": lambda x: x > 0},

--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -317,7 +317,7 @@ class WorkQueue(WorkQueueBase):
         return self.backend.updateElements(*ids, Status='Available',
                                            ChildQueueUrl=None, WMBSUrl=None)
 
-    def getWork(self, jobSlots, siteJobCounts, excludeWorkflows=[]):
+    def getWork(self, jobSlots, siteJobCounts, excludeWorkflows=None):
         """
         Get available work from the queue, inject into wmbs & mark as running
 
@@ -326,6 +326,7 @@ class WorkQueue(WorkQueueBase):
 
         siteJobCounts is a dict format of {site: {prio: jobs}}
         """
+        excludeWorkflows = excludeWorkflows or []
         results = []
         numElems = self.params['WorkPerCycle']
         if not self.backend.isAvailable():
@@ -544,7 +545,10 @@ class WorkQueue(WorkQueueBase):
             self.logger.info("New list of cancelled requests: %s" % requestNames)
 
             # Don't update as fails sometimes due to conflicts (#3856)
-            [x.load().__setitem__('Status', 'Canceled') for x in inbox_elements if x['Status'] != 'Canceled']
+            for x in inbox_elements:
+                if x['Status'] != 'Canceled':
+                    x.load().__setitem__('Status', 'Canceled')
+
             self.backend.saveElements(*inbox_elements)
 
         # if global queue, update non-acquired to Canceled, update parent to CancelRequested
@@ -563,7 +567,8 @@ class WorkQueue(WorkQueueBase):
 
             if elements_not_requested:
                 # Don't update as fails sometimes due to conflicts (#3856)
-                [x.load().__setitem__('Status', 'CancelRequested') for x in elements_not_requested]
+                for x in elements_not_requested:
+                    x.load().__setitem__('Status', 'CancelRequested')
                 self.backend.saveElements(*elements_not_requested)
                 self.logger.info("CancelRequest-ed element(s) %s" % str([x.id for x in elements_not_requested]))
 
@@ -576,7 +581,9 @@ class WorkQueue(WorkQueueBase):
                 if (time.time() - last_update) > self.params['cancelGraceTime']:
                     self.logger.info("%s cancelation has stalled, mark as finished" % elements[0]['RequestName'])
                     # Don't update as fails sometimes due to conflicts (#3856)
-                    [x.load().__setitem__('Status', 'Canceled') for x in elements if not x.inEndState()]
+                    for x in elements:
+                        if not x.inEndState():
+                            x.load().__setitem__('Status', 'Canceled')
                     self.backend.saveElements(*[x for x in elements if not x.inEndState()])
 
         return [x.id for x in elements]
@@ -957,7 +964,8 @@ class WorkQueue(WorkQueueBase):
                     if not updated_elements and (
                         float(parent.updatetime) + self.params['stuckElementAlertTime']) < time.time():
                         self.sendAlert(5, msg='Element for %s stuck for 24 hours.' % wf)
-                    [self.backend.updateElements(x.id, **x.statusMetrics()) for x in updated_elements]
+                    for x in updated_elements:
+                        self.backend.updateElements(x.id, **x.statusMetrics())
             except Exception as ex:
                 self.logger.error('Error processing workflow "%s": %s' % (wf, str(ex)))
 

--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -193,10 +193,6 @@ class WorkQueue(WorkQueueBase):
         else:
             self.SiteDB = SiteDB()
 
-        if isinstance(self.params['Teams'], basestring):
-            self.params['Teams'] = [x.strip() for x in \
-                                    self.params['Teams'].split(',')]
-
         self.dataLocationMapper = WorkQueueDataLocationMapper(self.logger, self.backend,
                                                               phedex=self.phedexService,
                                                               sitedb=self.SiteDB,

--- a/src/python/WMCore/WorkQueue/WorkQueueUtils.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueUtils.py
@@ -4,10 +4,12 @@
 __all__ = ['get_remote_queue', 'get_dbs',
            'queueConfigFromConfigObject', 'queueFromConfig']
 
-import os
 import logging
+import os
 
 __queues = {}
+
+
 def get_remote_queue(queue, logger):
     """
     Get an object to talk to a remote queue
@@ -20,10 +22,13 @@ def get_remote_queue(queue, logger):
         return __queues[queue]
     except KeyError:
         from WMCore.Services.WorkQueue.WorkQueue import WorkQueue as WorkQueueDS
-        __queues[queue] = WorkQueueDS({'endpoint' : queue, 'logger' : logger})
+        __queues[queue] = WorkQueueDS({'endpoint': queue, 'logger': logger})
         return __queues[queue]
 
+
 __dbses = {}
+
+
 def get_dbs(url):
     """Return DBS object for url"""
     try:
@@ -33,8 +38,11 @@ def get_dbs(url):
         __dbses[url] = DBSReader(url)
         return __dbses[url]
 
+
 __sitedb = None
 __cmsSiteNames = []
+
+
 def cmsSiteNames():
     """Get all cms sites"""
     global __cmsSiteNames
@@ -46,9 +54,10 @@ def cmsSiteNames():
         __sitedb = SiteDB()
     try:
         __cmsSiteNames = __sitedb.getAllCMSNames()
-    except:
+    except Exception:
         pass
     return __cmsSiteNames
+
 
 def makeLocationsList(siteWhitelist, siteBlacklist):
     """
@@ -63,8 +72,9 @@ def makeLocationsList(siteWhitelist, siteBlacklist):
         sites = list(set(sites) & set(siteWhitelist))
     if siteBlacklist:
         # Get all CMS sites less the blacklist
-        sites = list(set(sites) - set (siteBlacklist))
+        sites = list(set(sites) - set(siteBlacklist))
     return sites
+
 
 def queueFromConfig(config):
     """Create a queue from the config object"""
@@ -78,6 +88,7 @@ def queueFromConfig(config):
     else:
         from WMCore.WorkQueue.WorkQueue import WorkQueue
         return WorkQueue(**config.WorkQueueManager.queueParams)
+
 
 def queueConfigFromConfigObject(config):
     """From a config object create a config dict suitable for a queue object"""
@@ -126,7 +137,7 @@ def queueConfigFromConfigObject(config):
         if not hasattr(myThread, 'logger'):
             loggingLevelName = getattr(wqManager, 'logLevel', 'INFO')
             logging.basicConfig(format='%(asctime)-15s %(levelname)-8s %(module)s: %(message)s',
-                                level = getattr(logging, loggingLevelName))
+                                level=getattr(logging, loggingLevelName))
             myThread.logger = logging.getLogger('workqueue')
         qConfig['logger'] = myThread.logger
 

--- a/src/python/WMCore/WorkQueue/WorkQueueUtils.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueUtils.py
@@ -118,9 +118,9 @@ def queueConfigFromConfigObject(config):
     if hasattr(config, 'Alert'):
         qConfig['Config'] = config.Alert
 
-    if 'Teams' not in qConfig and hasattr(config.Agent, 'teamName'):
-        qConfig['Teams'] = config.Agent.teamName
-    if not 'logger' in qConfig:
+    if 'Team' not in qConfig and hasattr(config.Agent, 'teamName'):
+        qConfig['Team'] = config.Agent.teamName
+    if 'logger' not in qConfig:
         import threading
         myThread = threading.currentThread()
         if not hasattr(myThread, 'logger'):

--- a/test/data/ReqMgr/reqmgr.py
+++ b/test/data/ReqMgr/reqmgr.py
@@ -483,7 +483,6 @@ class ReqMgrClient(RESTClient):
         # implement this check automatically without listing request arguments
         # TODO 2:
         # double list: OutputDatasets (ticket already filed ...)
-        # Oracle:InputDatasetTypes: '{u'/QCD_HT-1000ToInf_TuneZ2star_8TeV-madgraph-pythia6/Summer12-START50_V13-v1/GEN': u'source'}' != CouchDB:InputDatasetTypes: '{}'
         # Oracle:RequestNumEvents: '0' != CouchDB:RequestNumEvents: 'None'
         fields = """RequestStatus
             RequestSizeFiles


### PR DESCRIPTION
Partially fixes #7355 
Fixes #8074 

Removing only part of the Teams logic for now, otherwise we'd need to make several codes handling it both ways (Team and Teams). So I'd rather make sure Team has the proper value and then in the next month we proceed with the final cleanup.

Real change is on updaterequest.js, such that we:
* properly set `Team` to the string provided during assignment
* set `Teams` to the same value as Team, but list type

in addition to that:
* assumes the agent can only be connected to a single team name
* removed `InputDatasetTypes`, I guess it has never been used