### PR TITLE
Fix ACDC of StepChain Merge tasks

### DIFF
--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -118,6 +118,9 @@ class WMWorkloadHelper(PersistencyHelper):
 
         stepNameMapping = self.getStepMapping()
         for task in self.taskIterator():
+            # Merge task has cmsRun1 step, so it gets messy on Merge ACDC of StepChain
+            if task.taskType() == "Merge":
+                continue
             task.updateLFNsAndDatasets(dictValues=assignArgs, stepMapping=stepNameMapping)
 
         return


### PR DESCRIPTION
Fixes #8102

I'm not proud of it, but it does fix the problem :)

We call this `setStepProperties` method in the very end of a StepChain request in order to fix the multi-cmsRun tasks with the proper settings. However, for this specific case it actually screws up with the settings, since a Merge task has a `cmsRun1` step, which is then mapped to the first step in the assignment dictionary.

I feel like start a refactoring of this StepChain code (mainly the step settings), but oh well, it works now and I'm not sure it will become any better.

PS.: I've just noticed these ACDCs - of stepchain merge task - carry an empty list for `OutputModulesLFNBases`, in the workload doc. I'll try to fix that too later today.