### PR TITLE
Update deployment script to 1.1.6 and fix team name matching

### DIFF
--- a/bin/deploy-wmagent.sh
+++ b/bin/deploy-wmagent.sh
@@ -25,7 +25,7 @@
 ### Usage:
 ### Usage: deploy-wmagent.sh -w <wma_version> -c <cmsweb_tag> -t <team_name> [-s <scram_arch>] [-r <repository>] [-n <agent_number>]
 ### Usage: Example: sh deploy-wmagent.sh -w 1.1.4.patch2 -c HG1706e -t production -n 2
-### Usage: Example: sh deploy-wmagent.sh -w 1.1.4.patch1 -c HG1706e -t testbed-cmssrv214 -p "7926" -s slc6_amd64_gcc493 -r comp=comp.amaltaro
+### Usage: Example: sh deploy-wmagent.sh -w 1.1.6.pre11 -c HG1709c -t testbed-cmssrv214 -p "7926" -s slc7_amd64_gcc630 -r comp=comp.amaltaro
 ### Usage:
  
 BASE_DIR=/data/srv 
@@ -269,7 +269,7 @@ echo "Done!" && echo
 # tweak configuration
 ### 
 echo "*** Tweaking configuration ***"
-sed -i "s+team1,team2,cmsdataops+$TEAMNAME+" $MANAGE/config.py
+sed -i "s+cmsdataops+$TEAMNAME+" $MANAGE/config.py
 sed -i "s+Agent.agentNumber = 0+Agent.agentNumber = $AG_NUM+" $MANAGE/config.py
 if [[ "$TEAMNAME" == relval ]]; then
   sed -i "s+'LogCollect': 1+'LogCollect': 2+" $MANAGE/config.py


### PR DESCRIPTION
We can leave it open for a while, I'll probably have further updates.
@ticoann you need this version for latest agent deployment, otherwise it will have cmsdataops team.