### PR TITLE
Explicitly set LFNBase during creation - Chained requests

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
@@ -97,6 +97,8 @@ class StepChainWorkloadFactory(StdBase):
             self.setupNextSteps(firstTask, arguments)
 
         self.workload.setStepMapping(self.stepMapping)
+        self.workload.setLFNBase(self.mergedLFNBase, self.unmergedLFNBase)
+
         self.reportWorkflowToDashboard(self.workload.getDashboardActivity())
 
         return self.workload

--- a/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
@@ -275,6 +275,8 @@ class TaskChainWorkloadFactory(StdBase):
             self.taskMapping[task.name()] = taskConf
 
         self.workload.ignoreOutputModules(self.ignoredOutputModules)
+        self.workload.setLFNBase(self.mergedLFNBase, self.unmergedLFNBase)
+
         self.reportWorkflowToDashboard(self.workload.getDashboardActivity())
 
         return self.workload


### PR DESCRIPTION
Fixes #8151
Since (un)mergedLFNBase is not mandatory during assignment (the same as AcqEra/ProcStr/ProcVer), we need to make sure the workload configuration (steps, output modules, etc) are coherent with the value passed during request creation.

These 2 spec files were missing that call, so even though the request json contains one MergedLFNBase, the workload config contains the default /store/data

Given that the workflow team always set those 2 parameters, I'd rather not merge and push it to the current testbed because I'm not sure whether it can have - bad - side effects, especially on StepChain. 