### PR TITLE
Store each worker thread cycle elapsed time and polling cycle

### DIFF
--- a/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
+++ b/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
@@ -104,6 +104,7 @@ class AgentStatusPoller(BaseWorkerThread):
         self.localCouchMonitor = CouchMonitor(self.config.JobStateMachine.couchurl)
         self.setUpCouchDBReplication()
 
+    @timeFunction
     def algorithm(self, parameters):
         """
         get information from wmbs, workqueue and local couch

--- a/src/python/WMComponent/AgentStatusWatcher/AgentStatusWatcher.py
+++ b/src/python/WMComponent/AgentStatusWatcher/AgentStatusWatcher.py
@@ -40,15 +40,15 @@ class AgentStatusWatcher(Harness):
         drainStatusPollInterval = self.config.AgentStatusWatcher.drainStatusPollInterval
         myThread = threading.currentThread()
 
-        logging.info("Setting AgentStatus poll interval to %s seconds", agentPollInterval)
+        logging.info("Setting AgentStatusPoller poll interval to %s seconds", agentPollInterval)
         myThread.workerThreadManager.addWorker(AgentStatusPoller(self.config),
                                                agentPollInterval)
 
-        logging.info("Setting ResourcesUpdate poll interval to %s seconds", resourceUpdaterPollInterval)
+        logging.info("Setting ResourceControlUpdater poll interval to %s seconds", resourceUpdaterPollInterval)
         myThread.workerThreadManager.addWorker(ResourceControlUpdater(self.config),
                                                resourceUpdaterPollInterval)
 
-        logging.info("Setting DrainStatus poll interval to %s seconds", drainStatusPollInterval)
+        logging.info("Setting DrainStatusPoller poll interval to %s seconds", drainStatusPollInterval)
         myThread.workerThreadManager.addWorker(DrainStatusPoller(self.config),
                                                drainStatusPollInterval)
         return

--- a/src/python/WMComponent/AgentStatusWatcher/DrainStatusPoller.py
+++ b/src/python/WMComponent/AgentStatusWatcher/DrainStatusPoller.py
@@ -8,6 +8,7 @@ from __future__ import division
 __all__ = []
 
 import logging
+from Utils.Timers import timeFunction
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 from WMCore.Services.ReqMgrAux.ReqMgrAux import isDrainMode
 from WMComponent.AgentStatusWatcher.DrainStatusAPI import DrainStatusAPI
@@ -27,6 +28,7 @@ class DrainStatusPoller(BaseWorkerThread):
         self.config = config
         self.drainAPI = DrainStatusAPI()
 
+    @timeFunction
     def algorithm(self, parameters):
         """
         Update drainStats if agent is in drain mode

--- a/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
+++ b/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
@@ -7,6 +7,7 @@ import urllib2
 import logging
 import traceback
 import json
+from Utils.Timers import timeFunction
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 from WMCore.ResourceControl.ResourceControl import ResourceControl
 from WMCore.Services.WMStats.WMStatsReader import WMStatsReader
@@ -59,6 +60,7 @@ class ResourceControlUpdater(BaseWorkerThread):
         # wmstats connection
         self.centralCouchDBReader = WMStatsReader(self.config.AgentStatusWatcher.centralWMStatsURL)
 
+    @timeFunction
     def algorithm(self, parameters):
         """
         _algorithm_

--- a/src/python/WMComponent/AnalyticsDataCollector/AnalyticsPoller.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/AnalyticsPoller.py
@@ -9,6 +9,7 @@ import threading
 import logging
 import time
 import traceback
+from Utils.Timers import timeFunction
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 from WMCore.Database.CMSCouch import CouchMonitor
 from WMCore.Services.WorkQueue.WorkQueue import WorkQueue as WorkQueueService
@@ -76,6 +77,7 @@ class AnalyticsPoller(BaseWorkerThread):
             pluginFactory = WMFactory("plugins", "WMComponent.AnalyticsDataCollector.Plugins")
             self.plugin = pluginFactory.loadObject(classname = self.pluginName)
 
+    @timeFunction
     def algorithm(self, parameters):
         """
         get information from wmbs, workqueue and local couch

--- a/src/python/WMComponent/ArchiveDataReporter/ArchiveDataPoller.py
+++ b/src/python/WMComponent/ArchiveDataReporter/ArchiveDataPoller.py
@@ -6,6 +6,7 @@ from __future__ import (division, print_function)
 import logging
 import traceback
 from Utils.IteratorTools import grouper
+from Utils.Timers import timeFunction
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 from WMCore.Services.WMArchive.DataMap import createArchiverDoc
 from WMCore.Services.WMArchive.WMArchive import WMArchive
@@ -36,6 +37,7 @@ class ArchiveDataPoller(BaseWorkerThread):
         self.numDocsRetrievePerPolling = getattr(self.config.ArchiveDataReporter, "numDocsRetrievePerPolling", 1000)
         self.numDocsUploadPerCall = getattr(self.config.ArchiveDataReporter, "numDocsUploadPerCall", 200)
 
+    @timeFunction
     def algorithm(self, parameters):
         """
         get information from wmbs, workqueue and local couch

--- a/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
@@ -34,7 +34,7 @@ import traceback
 import os.path
 
 from dbs.apis.dbsClient import DbsApi
-
+from Utils.Timers import timeFunction
 from WMComponent.DBS3Buffer.DBSBufferBlock import DBSBufferBlock
 from WMComponent.DBS3Buffer.DBSBufferUtil import DBSBufferUtil
 from WMCore.Algorithms.MiscAlgos import sortListByKey
@@ -278,6 +278,7 @@ class DBSUploadPoller(BaseWorkerThread):
         logging.debug("terminating. doing one more pass before we die")
         self.algorithm(params)
 
+    @timeFunction
     def algorithm(self, parameters=None):
         """
         _algorithm_

--- a/src/python/WMComponent/ErrorHandler/ErrorHandlerPoller.py
+++ b/src/python/WMComponent/ErrorHandler/ErrorHandlerPoller.py
@@ -26,7 +26,7 @@ import logging
 import os.path
 import threading
 from httplib import HTTPException
-
+from Utils.Timers import timeFunction
 from WMCore.ACDC.DataCollectionService import DataCollectionService
 from WMCore.DAOFactory import DAOFactory
 from WMCore.Database.CouchUtils import CouchConnectionError
@@ -367,6 +367,7 @@ class ErrorHandlerPoller(BaseWorkerThread):
 
         return listOfJobs
 
+    @timeFunction
     def algorithm(self, parameters=None):
         """
         Performs the handleErrors method, looking for each type of failure

--- a/src/python/WMComponent/JobAccountant/JobAccountantPoller.py
+++ b/src/python/WMComponent/JobAccountant/JobAccountantPoller.py
@@ -9,6 +9,7 @@ import threading
 import logging
 
 from Utils.IteratorTools import grouper
+from Utils.Timers import timeFunction
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 from WMCore.Database.CouchUtils import CouchConnectionError
 from WMCore.DAOFactory import DAOFactory
@@ -49,6 +50,7 @@ class JobAccountantPoller(BaseWorkerThread):
         self.getJobsAction = daoFactory(classname="Jobs.GetFWJRByState")
         return
 
+    @timeFunction
     def algorithm(self, parameters=None):
         """
         _algorithm_

--- a/src/python/WMComponent/JobArchiver/JobArchiverPoller.py
+++ b/src/python/WMComponent/JobArchiver/JobArchiverPoller.py
@@ -12,6 +12,7 @@ import shutil
 import tarfile
 
 from Utils.IteratorTools import grouper
+from Utils.Timers import timeFunction
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 from WMCore.JobStateMachine.ChangeState import ChangeState
 from WMCore.WorkQueue.WorkQueueExceptions import WorkQueueNoMatchingElements
@@ -99,6 +100,7 @@ class JobArchiverPoller(BaseWorkerThread):
         self.algorithm(params)
         return
 
+    @timeFunction
     def algorithm(self, parameters=None):
         """
         Performs the archiveJobs method, looking for each type of failure

--- a/src/python/WMComponent/JobCreator/JobCreatorPoller.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorPoller.py
@@ -15,6 +15,7 @@ try:
 except ImportError:
     import pickle
 
+from Utils.Timers import timeFunction
 from WMCore.WorkerThreads.BaseWorkerThread  import BaseWorkerThread
 from WMCore.DAOFactory                      import DAOFactory
 from WMCore.WMException                     import WMException
@@ -417,7 +418,7 @@ class JobCreatorPoller(BaseWorkerThread):
                       % (self.jobCacheDir)
                 raise JobCreatorException (msg)
 
-
+    @timeFunction
     def algorithm(self, parameters = None):
         """
         Actually runs the code

--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -18,6 +18,7 @@ try:
 except ImportError:
     import pickle
 
+from Utils.Timers import timeFunction
 from WMCore.DAOFactory        import DAOFactory
 from WMCore.WMExceptions      import WM_JOB_ERROR_CODES
 
@@ -700,6 +701,7 @@ class JobSubmitterPoller(BaseWorkerThread):
                 self.locationDict[jobSite].get('plugin'),
                 self.locationDict[jobSite].get('cms_name'))
 
+    @timeFunction
     def algorithm(self, parameters=None):
         """
         _algorithm_

--- a/src/python/WMComponent/JobTracker/JobTrackerPoller.py
+++ b/src/python/WMComponent/JobTracker/JobTrackerPoller.py
@@ -9,8 +9,8 @@ import logging
 import os
 import os.path
 
+from Utils.Timers import timeFunction
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
-
 from WMCore.DAOFactory import DAOFactory
 from WMCore.WMException import WMException
 from WMCore.FwkJobReport.Report import Report
@@ -69,6 +69,7 @@ class JobTrackerPoller(BaseWorkerThread):
         self.algorithm(params)
         return
 
+    @timeFunction
     def algorithm(self, parameters=None):
         """
         Performs the archiveJobs method, looking for each type of failure

--- a/src/python/WMComponent/JobUpdater/JobUpdaterPoller.py
+++ b/src/python/WMComponent/JobUpdater/JobUpdaterPoller.py
@@ -11,7 +11,7 @@ Created on Apr 16, 2013
 
 import logging
 import threading
-
+from Utils.Timers import timeFunction
 from WMCore.BossAir.BossAirAPI import BossAirAPI
 from WMCore.DAOFactory import DAOFactory
 from WMCore.Services.ReqMgr.ReqMgr import ReqMgr
@@ -74,6 +74,7 @@ class JobUpdaterPoller(BaseWorkerThread):
         """
         pass
 
+    @timeFunction
     def algorithm(self, parameters=None):
         """
         _algorithm_

--- a/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
+++ b/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
@@ -46,7 +46,7 @@ import logging
 import traceback
 import time
 from httplib import HTTPException
-
+from Utils.Timers import timeFunction
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 from WMCore.WMException import WMException
 from WMCore.Services.PhEDEx.PhEDEx import PhEDEx
@@ -150,6 +150,7 @@ class PhEDExInjectorPoller(BaseWorkerThread):
 
         return
 
+    @timeFunction
     def algorithm(self, parameters):
         """
         _algorithm_

--- a/src/python/WMComponent/RetryManager/RetryManagerPoller.py
+++ b/src/python/WMComponent/RetryManager/RetryManagerPoller.py
@@ -55,7 +55,7 @@ import logging
 import threading
 import time
 import traceback
-
+from Utils.Timers import timeFunction
 from WMCore.DAOFactory import DAOFactory
 from WMCore.JobStateMachine.ChangeState import ChangeState
 from WMCore.JobStateMachine.Transitions import Transitions
@@ -149,6 +149,7 @@ class RetryManagerPoller(BaseWorkerThread):
         logging.debug("Terminating. doing one more pass before we die")
         self.algorithm(params)
 
+    @timeFunction
     def algorithm(self, parameters=None):
         """
         Performs the doRetries method, loading the appropriate

--- a/src/python/WMComponent/TaskArchiver/CleanCouchPoller.py
+++ b/src/python/WMComponent/TaskArchiver/CleanCouchPoller.py
@@ -10,7 +10,7 @@ import shutil
 import threading
 import time
 import urllib2
-
+from Utils.Timers import timeFunction
 from WMComponent.JobCreator.CreateWorkArea import getMasterName
 from WMComponent.JobCreator.JobCreatorPoller import retrieveWMSpec
 from WMComponent.TaskArchiver.DataCache import DataCache
@@ -133,6 +133,7 @@ class CleanCouchPoller(BaseWorkerThread):
         logging.debug("Using url %s/%s for job", jobDBurl, jobDBName)
         logging.debug("Writing to  %s/%s for workloadSummary", sanitizeURL(workDBurl)['url'], workDBName)
 
+    @timeFunction
     def algorithm(self, parameters=None):
         """
         Get information from wmbs, workqueue and local couch and:

--- a/src/python/WMComponent/TaskArchiver/TaskArchiverPoller.py
+++ b/src/python/WMComponent/TaskArchiver/TaskArchiverPoller.py
@@ -27,7 +27,7 @@ __all__ = []
 import logging
 import threading
 import traceback
-
+from Utils.Timers import timeFunction
 from WMComponent.TaskArchiver.DataCache import DataCache
 from WMCore.DAOFactory import DAOFactory
 from WMCore.Services.ReqMgr.ReqMgr import ReqMgr
@@ -116,6 +116,7 @@ class TaskArchiverPoller(BaseWorkerThread):
         self.algorithm(params)
         return
 
+    @timeFunction
     def algorithm(self, parameters=None):
         """
         _algorithm_

--- a/src/python/WMComponent/WorkQueueManager/WorkQueueManagerCleaner.py
+++ b/src/python/WMComponent/WorkQueueManager/WorkQueueManagerCleaner.py
@@ -8,6 +8,7 @@ __all__ = []
 
 import time
 import random
+from Utils.Timers import timeFunction
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 from WMCore.Services.ReqMgr.ReqMgr import ReqMgr
 
@@ -35,6 +36,7 @@ class WorkQueueManagerCleaner(BaseWorkerThread):
         self.logger.info('Sleeping for %d seconds before 1st loop' % t)
         time.sleep(t)
 
+    @timeFunction
     def algorithm(self, parameters):
         """
         Check & expire negotiation failures

--- a/src/python/WMComponent/WorkQueueManager/WorkQueueManagerLocationPoller.py
+++ b/src/python/WMComponent/WorkQueueManager/WorkQueueManagerLocationPoller.py
@@ -7,7 +7,7 @@ __all__ = []
 
 import time
 import random
-
+from Utils.Timers import timeFunction
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 
 
@@ -32,6 +32,7 @@ class WorkQueueManagerLocationPoller(BaseWorkerThread):
         self.logger.info('Sleeping for %d seconds before 1st loop' % t)
         time.sleep(t)
 
+    @timeFunction
     def algorithm(self, parameters):
         """
         Update locations

--- a/src/python/WMComponent/WorkQueueManager/WorkQueueManagerReqMgrPoller.py
+++ b/src/python/WMComponent/WorkQueueManager/WorkQueueManagerReqMgrPoller.py
@@ -8,7 +8,7 @@ __all__ = []
 
 import time
 import random
-
+from Utils.Timers import timeFunction
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 from WMCore.WorkQueue.WorkQueueReqMgrInterface import WorkQueueReqMgrInterface
 
@@ -38,6 +38,7 @@ class WorkQueueManagerReqMgrPoller(BaseWorkerThread):
         self.logger.info('Sleeping for %d seconds before 1st loop' % t)
         time.sleep(t)
 
+    @timeFunction
     def algorithm(self, parameters):
         """
         retrieve work from RequestManager and send updates

--- a/src/python/WMComponent/WorkQueueManager/WorkQueueManagerWMBSFileFeeder.py
+++ b/src/python/WMComponent/WorkQueueManager/WorkQueueManagerWMBSFileFeeder.py
@@ -9,7 +9,7 @@ __all__ = []
 
 import time
 import random
-
+from Utils.Timers import timeFunction
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 from WMCore.WorkQueue.WMBSHelper import freeSlots
 from WMCore.WorkQueue.WorkQueueUtils import cmsSiteNames
@@ -41,6 +41,7 @@ class WorkQueueManagerWMBSFileFeeder(BaseWorkerThread):
         self.logger.info('Sleeping for %d seconds before 1st loop' % t)
         time.sleep(t)
 
+    @timeFunction
     def algorithm(self, parameters):
         """
         Pull in work

--- a/src/python/WMComponent/WorkQueueManager/WorkQueueManagerWorkPoller.py
+++ b/src/python/WMComponent/WorkQueueManager/WorkQueueManagerWorkPoller.py
@@ -9,7 +9,7 @@ import time
 import random
 import traceback
 import threading
-
+from Utils.Timers import timeFunction
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 from WMCore.Services.PyCondor.PyCondorAPI import isScheddOverloaded
 from WMCore.Services.ReqMgrAux.ReqMgrAux import isDrainMode
@@ -35,6 +35,7 @@ class WorkQueueManagerWorkPoller(BaseWorkerThread):
         self.logger.info('Sleeping for %d seconds before 1st loop' % t)
         time.sleep(t)
 
+    @timeFunction
     def algorithm(self, parameters):
         """
         Pull in work

--- a/src/python/WMCore/Agent/Database/CreateAgentBase.py
+++ b/src/python/WMCore/Agent/Database/CreateAgentBase.py
@@ -57,7 +57,10 @@ class CreateAgentBase(DBCreator):
              last_updated  INTEGER      NOT NULL,
              state         VARCHAR(255),
              pid           INTEGER,
+             poll_interval INTEGER      NOT NULL,
              last_error    INTEGER,
+             cycle_time    DECIMAL(6,4) DEFAULT 0 NOT NULL,
+             outcome       VARCHAR(1000),
              error_message VARCHAR(1000),
              UNIQUE (component_id, name))"""
 

--- a/src/python/WMCore/Agent/Database/MySQL/Create.py
+++ b/src/python/WMCore/Agent/Database/MySQL/Create.py
@@ -30,4 +30,5 @@ class Create(CreateAgentBase):
             self.create[i] = self.create[i] + " ENGINE=InnoDB"
             self.create[i] = self.create[i].replace('INTEGER', 'INT(11)')
 
+
         return CreateAgentBase.execute(self, conn, transaction)

--- a/src/python/WMCore/Agent/Database/MySQL/GetAllHeartbeatInfo.py
+++ b/src/python/WMCore/Agent/Database/MySQL/GetAllHeartbeatInfo.py
@@ -13,8 +13,9 @@ from WMCore.Database.DBFormatter import DBFormatter
 class GetAllHeartbeatInfo(DBFormatter):
 
     sql = """SELECT comp.name as name, comp.pid, worker.name as worker_name,
-                    worker.state, worker.last_updated,
-                    comp.update_threshold, worker.last_error, worker.error_message
+                 worker.state, worker.last_updated, comp.update_threshold,
+                 worker.poll_interval, worker.cycle_time, worker.outcome,
+                 worker.last_error, worker.error_message
              FROM wm_workers worker
              INNER JOIN wm_components comp ON comp.id = worker.component_id
              """

--- a/src/python/WMCore/Agent/Database/MySQL/GetHeartbeatInfo.py
+++ b/src/python/WMCore/Agent/Database/MySQL/GetHeartbeatInfo.py
@@ -8,14 +8,14 @@ __all__ = []
 
 
 
-import time
 from WMCore.Database.DBFormatter import DBFormatter
 
 class GetHeartbeatInfo(DBFormatter):
 
     sql = """SELECT comp.name as name, comp.pid, worker.name as worker_name,
-                    worker.state, worker.last_updated,
-                    comp.update_threshold, worker.last_error, worker.error_message
+                    worker.state, worker.last_updated, comp.update_threshold,
+                    worker.poll_interval, worker.cycle_time, worker.outcome,
+                    worker.last_error, worker.error_message
              FROM wm_workers worker
              INNER JOIN wm_components comp ON comp.id = worker.component_id
              INNER JOIN (SELECT component_id, MAX(last_updated) AS last_updated FROM wm_workers
@@ -24,7 +24,6 @@ class GetHeartbeatInfo(DBFormatter):
                            AND max_result.component_id = comp.id)
              ORDER BY worker.last_updated ASC
              """
-    #sql = """select max(last_updated) from wm_workers"""
 
     def execute(self, conn = None, transaction = False):
 

--- a/src/python/WMCore/Agent/Database/MySQL/InsertWorker.py
+++ b/src/python/WMCore/Agent/Database/MySQL/InsertWorker.py
@@ -13,18 +13,21 @@ from WMCore.Database.DBFormatter import DBFormatter
 
 class InsertWorker(DBFormatter):
 
-    sql = """INSERT INTO wm_workers (component_id, name, last_updated, state, pid)
+    sql = """INSERT INTO wm_workers (component_id, name, last_updated, state, pid, poll_interval, cycle_time)
              VALUES ((SELECT id FROM wm_components WHERE name = :component_name),
-                     :worker_name, :last_updated, :state, :pid)
+                     :worker_name, :last_updated, :state, :pid, :poll_interval, :cycle_time)
              """
 
-    def execute(self, componentName, workerName, state = None,
-                pid = None, conn = None, transaction = False):
+    def execute(self, componentName, workerName, state, pid, pollInt, cycleTime,
+                conn = None, transaction = False):
 
         binds = {"component_name": componentName,
                  "worker_name": workerName,
                  "last_updated": int(time.time()),
-                 "state": state, "pid": pid}
+                 "state": state,
+                 "pid": pid,
+                 "poll_interval": pollInt,
+                 "cycle_time": cycleTime}
 
         self.dbi.processData(self.sql, binds, conn = conn,
                              transaction = transaction)

--- a/src/python/WMCore/Agent/Database/MySQL/UpdateWorker.py
+++ b/src/python/WMCore/Agent/Database/MySQL/UpdateWorker.py
@@ -16,24 +16,28 @@ class UpdateWorker(DBFormatter):
     sqlpart1 = """UPDATE wm_workers
                       SET last_updated = :last_updated
                """
-    sqlpart2 = """WHERE component_id = :component_id
+    sqlpart3 = """ WHERE component_id = :component_id
                    AND name = :worker_name"""
 
-    def execute(self, componentID, workerName, state = None,
-                pid = None, conn = None, transaction = False):
+    def execute(self, componentID, workerName, state = None, timeSpent=None,
+                results=None, conn = None, transaction = False):
 
         binds = {"component_id": componentID,
                  "worker_name": workerName,
                  "last_updated": int(time.time())}
 
+        sqlpart2 = ""
         if state:
             binds["state"] = state
-            self.sqlpart1 += ", state = :state"
-        if pid:
-            binds["pid"] = pid
-            self.sqlpart1 += ", pid = :pid"
+            sqlpart2 += ", state = :state"
+        if timeSpent:
+            binds["cycle_time"] = timeSpent
+            sqlpart2 += ", cycle_time = :cycle_time"
+        if results:
+            binds["outcome"] = results
+            sqlpart2 += ", outcome = :outcome"
 
-        sql = self.sqlpart1 + " " + self.sqlpart2
+        sql = self.sqlpart1 + sqlpart2 + self.sqlpart3
 
         self.dbi.processData(sql, binds, conn = conn,
                              transaction = transaction)

--- a/src/python/WMCore/Agent/HeartbeatAPI.py
+++ b/src/python/WMCore/Agent/HeartbeatAPI.py
@@ -17,7 +17,7 @@ class HeartbeatAPI(WMConnectionBase):
     """
     Generic methods used by all of the WMBS classes.
     """
-    def __init__(self, componentName, logger=None, dbi=None):
+    def __init__(self, componentName, pollInterval=None, logger=None, dbi=None):
         """
         ___init___
 
@@ -29,53 +29,77 @@ class HeartbeatAPI(WMConnectionBase):
         WMConnectionBase.__init__(self, daoPackage = "WMCore.Agent.Database",
                                   logger = logger, dbi = dbi)
 
+        self.insertComp = self.daofactory(classname = "InsertComponent")
+        self.existWorker = self.daofactory(classname = "ExistWorker")
+        self.insertWorker = self.daofactory(classname="InsertWorker")
+        self.updateWorker = self.daofactory(classname="UpdateWorker")
+        self.updateErrorWorker = self.daofactory(classname = "UpdateWorkerError")
+        self.getHeartbeat = self.daofactory(classname = "GetHeartbeatInfo")
+        self.getAllHeartbeat = self.daofactory(classname = "GetAllHeartbeatInfo")
+
         self.componentName = componentName
         self.pid = os.getpid()
+        self.pollInterval = pollInterval
 
     def registerComponent(self):
 
-        insertAction = self.daofactory(classname = "InsertComponent")
-        insertAction.execute(self.componentName, self.pid,
+        self.insertComp.execute(self.componentName, self.pid,
                              conn = self.getDBConn(),
                              transaction = self.existingTransaction())
 
-    def updateWorkerHeartbeat(self, workerName, state = "Start", pid = None):
+    def getComponentID(self, workerName):
+        """Retrieve the component_id from the workers table"""
 
-        existAction = self.daofactory(classname = "ExistWorker")
-        componentID = existAction.execute(self.componentName, workerName,
-                                    conn = self.getDBConn(),
-                                    transaction = self.existingTransaction())
+        componentID = self.existWorker.execute(self.componentName, workerName,
+                                               conn = self.getDBConn(),
+                                               transaction = self.existingTransaction())
+        return componentID
+
+    def updateWorkerHeartbeat(self, workerName, state = "Start", pid = None, pollInt=None, timeSpent=None):
+        """
+        Update a worker's heartbeat. If it still doesn't exist, then add it
+        with Start state.
+        """
+        componentID = self.getComponentID(workerName)
+
         if not componentID:
-            action = self.daofactory(classname = "InsertWorker")
-            action.execute(self.componentName, workerName, state, pid,
+            pid = pid or self.pid
+            pollInt = pollInt or self.pollInterval
+            self.insertWorker.execute(self.componentName, workerName, state, pid, pollInt, cycleTime=0,
                            conn = self.getDBConn(),
                            transaction = self.existingTransaction())
         else:
-            action = self.daofactory(classname = "UpdateWorker")
-            action.execute(componentID, workerName, state, pid,
+            self.updateWorker.execute(componentID, workerName, state, timeSpent,
                            conn = self.getDBConn(),
                            transaction = self.existingTransaction())
+
+    def updateWorkerCycle(self, workerName, timeSpent, results):
+        """
+        Update an already registered worker thread with the time it spent running
+        the main algorithm call. It's state is unchanged.
+        """
+        componentID = self.getComponentID(workerName)
+
+        self.updateWorker.execute(componentID, workerName, "Running", timeSpent, results,
+                                  conn = self.getDBConn(),
+                                  transaction = self.existingTransaction())
 
     def updateWorkerError(self, workerName, errorMessage):
 
-        action = self.daofactory(classname = "UpdateWorkerError")
-        action.execute(self.componentName, workerName, errorMessage,
-                           conn = self.getDBConn(),
-                           transaction = self.existingTransaction())
+        self.updateErrorWorker.execute(self.componentName, workerName, errorMessage,
+                                       conn = self.getDBConn(),
+                                       transaction = self.existingTransaction())
 
     def getHeartbeatInfo(self):
 
-        heartbeatInfo = self.daofactory(classname = "GetHeartbeatInfo")
-        results = heartbeatInfo.execute(conn = self.getDBConn(),
-                                        transaction = self.existingTransaction())
+        results = self.getHeartbeat.execute(conn = self.getDBConn(),
+                                            transaction = self.existingTransaction())
 
         return results
 
-
     def getAllHeartbeatInfo(self):
 
-        heartbeatInfo = self.daofactory(classname = "GetAllHeartbeatInfo")
-        results = heartbeatInfo.execute(conn = self.getDBConn(),
-                                        transaction = self.existingTransaction())
+        results = self.getAllHeartbeat.execute(conn = self.getDBConn(),
+                                               transaction = self.existingTransaction())
 
         return results

--- a/src/python/WMCore/BossAir/StatusPoller.py
+++ b/src/python/WMCore/BossAir/StatusPoller.py
@@ -14,6 +14,7 @@ import threading
 from collections import defaultdict
 
 from Utils.IteratorTools import flattenList
+from Utils.Timers import timeFunction
 from WMCore.WMException                    import WMException
 from WMCore.WMExceptions                   import WM_JOB_ERROR_CODES
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
@@ -56,6 +57,7 @@ class StatusPoller(BaseWorkerThread):
         self.initAlerts(compName="StatusPoller")
         return
 
+    @timeFunction
     def algorithm(self, parameters=None):
         """
         _algorithm_

--- a/src/python/WMCore/WorkerThreads/BaseWorkerThread.py
+++ b/src/python/WMCore/WorkerThreads/BaseWorkerThread.py
@@ -17,7 +17,6 @@ import traceback
 from WMCore.Alerts import API as alertAPI
 from WMCore.Database.Transaction import Transaction
 
-
 class BaseWorkerThread(object):
     """
     A base class for worker threads, used for work that needs to occur at
@@ -181,7 +180,11 @@ class BaseWorkerThread(object):
                                 msg += "\n Skipping worker algorithm!"
                                 logging.error(msg)
                             else:
-                                self.algorithm(parameters)
+                                tSpent, results, _ = self.algorithm(parameters)
+                                if tSpent and self.useHeartbeat:
+                                    logging.info("%s took %.3f secs to execute", self.workerName, tSpent)
+                                    self.heartbeatAPI.updateWorkerCycle(self.workerName, tSpent, results)
+
                                 # Catch if someone forgets to commit/rollback
                                 if myThread.transaction.transaction is not None:
                                     msg = """ Thread %s:  Transaction reached

--- a/src/python/WMCore/WorkerThreads/WorkerThreadManager.py
+++ b/src/python/WMCore/WorkerThreads/WorkerThreadManager.py
@@ -73,7 +73,7 @@ class WorkerThreadManager:
         worker.notifyResume = self.resumeSlaves
         if hasattr(self.component.config, "Agent"):
             if getattr(self.component.config.Agent, "useHeartbeat", True):
-                worker.heartbeatAPI = HeartbeatAPI(self.component.config.Agent.componentName)
+                worker.heartbeatAPI = HeartbeatAPI(self.component.config.Agent.componentName, idleTime)
 
 
     def addWorker(self, worker, idleTime = 60, parameters = None):

--- a/test/python/WMCore_t/Agent_t/Heartbeat_t.py
+++ b/test/python/WMCore_t/Agent_t/Heartbeat_t.py
@@ -28,7 +28,6 @@ class HeartbeatTest(unittest.TestCase):
         self.testInit.setDatabaseConnection()
         self.testInit.setSchema(customModules = ["WMCore.Agent.Database"],
                                 useDefault = False)
-        self.heartbeat = HeartbeatAPI("testComponent")
 
     def tearDown(self):
         """
@@ -41,6 +40,7 @@ class HeartbeatTest(unittest.TestCase):
 
     def testHeartbeat(self):
         testComponent = HeartbeatAPI("testComponent")
+        testComponent.pollInterval = 10
         testComponent.registerComponent()
         self.assertEqual(testComponent.getHeartbeatInfo(), [])
 
@@ -63,6 +63,7 @@ class HeartbeatTest(unittest.TestCase):
 
 
         testComponent = HeartbeatAPI("test2Component")
+        testComponent.pollInterval = 20
         testComponent.registerComponent()
         time.sleep(1)
         testComponent.updateWorkerHeartbeat("test2Worker")

--- a/test/python/WMCore_t/WorkerThreads_t/WorkerThreads_t.py
+++ b/test/python/WMCore_t/WorkerThreads_t/WorkerThreads_t.py
@@ -13,6 +13,7 @@ import threading
 import time
 import unittest
 
+from Utils.Timers import timeFunction
 # local import
 from WMCore_t.WorkerThreads_t.Dummy import Dummy
 
@@ -47,6 +48,7 @@ class DummyWorker1(BaseWorkerThread):
         logging.info("DummyWorker1 setup called")
         self.dummySetupCallback()
 
+    @timeFunction
     def algorithm(self, parameters):
         """
         Check the algorithm method is called
@@ -69,6 +71,7 @@ class DummyWorker2(BaseWorkerThread):
     A very basic dummy worker
     """
 
+    @timeFunction
     def algorithm(self, parameters):
         pass
 
@@ -78,6 +81,7 @@ class ErrorWorker(DummyWorker1):
     A worker that throws an error
     """
 
+    @timeFunction
     def algorithm(self, parameters):
         # workerThreadManager will be added by Harness
         # that isnt used here so add manually


### PR DESCRIPTION
In short, improve the worker threads monitoring and store more info into the database.
* has a database schema change (wm_workers)
* store the polling cycle settings for each worker thread
* time the `algorithm` execution for every worker thread and store it in the database
* retrieve any results from `algorithm` and store it in the database as well. Can be used in the future for keeping track of e.g. how many jobs JobCreator created in that cycle, jobs submitted by JobSubmitter, etc.

This means, any future worker thread (inheriting from BaseWorkerThread) has to use the `@timeFunction` decorator. 

I might add to this PR:
* recording when a thread is terminated and distinguish between a graceful stop and a crash