### PR TITLE
Use 2to3 to remove deprecated unit test asserts

### DIFF
--- a/test/python/Utils_t/TemporaryEnvironment_t.py
+++ b/test/python/Utils_t/TemporaryEnvironment_t.py
@@ -23,7 +23,7 @@ class TemporaryEnvironmentTest(unittest.TestCase):
 
         with tmpEnv(NEW_ENV_VAR=u'blah'):
             self.assertTrue('NEW_ENV_VAR' in os.environ)
-            self.assertEquals(os.environ['NEW_ENV_VAR'], u'blah')
+            self.assertEqual(os.environ['NEW_ENV_VAR'], u'blah')
         self.assertFalse('NEW_ENV_VAR' in os.environ)
 
 

--- a/test/python/WMComponent_t/TaskArchiver_t/TaskArchiver_t.py
+++ b/test/python/WMComponent_t/TaskArchiver_t/TaskArchiver_t.py
@@ -533,7 +533,7 @@ class TaskArchiverTest(unittest.TestCase):
                          ['/TestWorkload/ReReco', '/TestWorkload/ReReco/LogCollect'])
         # Check performance
         # Check histograms
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             workloadSummary['performance']['/TestWorkload/ReReco']['cmsRun1']['AvgEventTime']['histogram'][0][
                 'average'],
             0.89405199999999996, places=2)
@@ -543,11 +543,11 @@ class TaskArchiverTest(unittest.TestCase):
             10)
 
         # Check standard performance
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             workloadSummary['performance']['/TestWorkload/ReReco']['cmsRun1']['TotalJobCPU']['average'],
             17.786300000000001,
             places=2)
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             workloadSummary['performance']['/TestWorkload/ReReco']['cmsRun1']['TotalJobCPU']['stdDev'], 0.0,
             places=2)
 
@@ -570,7 +570,7 @@ class TaskArchiverTest(unittest.TestCase):
             if x in config.TaskArchiver.histogramKeys:
                 continue
             for y in ['average', 'stdDev']:
-                self.assertAlmostEquals(
+                self.assertAlmostEqual(
                     workloadSummary['performance']['/TestWorkload/ReReco/LogCollect']['cmsRun1'][x][y],
                     workloadSummary['performance']['/TestWorkload/ReReco']['cmsRun1'][x][y],
                     places=2)
@@ -779,7 +779,7 @@ class TaskArchiverTest(unittest.TestCase):
             if PD in interestingPDs and dataTier == "DQM":
                 interestingDatasets.append(dataset)
         # We should have found 1 interesting dataset
-        self.assertAlmostEquals(len(interestingDatasets), 1)
+        self.assertAlmostEqual(len(interestingDatasets), 1)
         if len(interestingDatasets) == 0:
             return
         # Request will be only interesting for performance if it's a ReReco or PromptReco

--- a/test/python/WMCore_t/WMRuntime_t/Tools_t/Scram_t.py
+++ b/test/python/WMCore_t/WMRuntime_t/Tools_t/Scram_t.py
@@ -116,24 +116,24 @@ class Scram_t(unittest.TestCase):
                 tf.write('Memory = 2048\n')
                 tf.flush()
                 with tmpEnv(_CONDOR_MACHINE_AD=tf.name):
-                    self.assertEquals(getSingleScramArch('slc6_blah_blah'), 'slc6_blah_blah')
-                    self.assertEquals(getSingleScramArch('slc5_blah_blah'), 'slc5_blah_blah')
-                    self.assertEquals(getSingleScramArch(['slc6_blah_blah', 'slc7_blah_blah']),
+                    self.assertEqual(getSingleScramArch('slc6_blah_blah'), 'slc6_blah_blah')
+                    self.assertEqual(getSingleScramArch('slc5_blah_blah'), 'slc5_blah_blah')
+                    self.assertEqual(getSingleScramArch(['slc6_blah_blah', 'slc7_blah_blah']),
                                       'slc6_blah_blah')
-                    self.assertEquals(getSingleScramArch(['slc6_blah_blah', 'slc5_blah_blah']),
+                    self.assertEqual(getSingleScramArch(['slc6_blah_blah', 'slc5_blah_blah']),
                                       'slc6_blah_blah')
-                    self.assertEquals(getSingleScramArch(['slc7_blah_blah', 'slc8_blah_blah']), None)
+                    self.assertEqual(getSingleScramArch(['slc7_blah_blah', 'slc8_blah_blah']), None)
             with tempfile.NamedTemporaryFile() as tf:
                 tf.write('GLIDEIN_REQUIRED_OS = "rhel7" \n')
                 tf.write('Memory = 2048\n')
                 tf.flush()
                 with tmpEnv(_CONDOR_MACHINE_AD=tf.name):
-                    self.assertEquals(getSingleScramArch('slc6_blah_blah'), 'slc6_blah_blah')
-                    self.assertEquals(getSingleScramArch('slc7_blah_blah'), 'slc7_blah_blah')
-                    self.assertEquals(getSingleScramArch(['slc6_blah_blah', 'slc7_blah_blah']),
+                    self.assertEqual(getSingleScramArch('slc6_blah_blah'), 'slc6_blah_blah')
+                    self.assertEqual(getSingleScramArch('slc7_blah_blah'), 'slc7_blah_blah')
+                    self.assertEqual(getSingleScramArch(['slc6_blah_blah', 'slc7_blah_blah']),
                                       'slc7_blah_blah')
-                    self.assertEquals(getSingleScramArch(['slc6_blah_blah', 'slc5_blah_blah']), None)
-                    self.assertEquals(getSingleScramArch(['slc7_blah_blah', 'slc8_blah_blah']),
+                    self.assertEqual(getSingleScramArch(['slc6_blah_blah', 'slc5_blah_blah']), None)
+                    self.assertEqual(getSingleScramArch(['slc7_blah_blah', 'slc8_blah_blah']),
                                       'slc7_blah_blah')
         except Exception:
             raise


### PR DESCRIPTION
Some of our code uses old, out of date, names for unit test assertion methods