### PR TITLE
adjust some tier0 workflows to automatic data tier in output module

### DIFF
--- a/src/python/WMComponent/JobAccountant/AccountantWorker.py
+++ b/src/python/WMComponent/JobAccountant/AccountantWorker.py
@@ -478,12 +478,12 @@ class AccountantWorker(WMConnectionBase):
             elif jobType == "LogCollect" and len(outputMap.keys()) == 0 and outputModules == set(['LogCollect']):
                 pass
             elif jobType == "Merge" and set(outputMap.keys()) == set(
-                    ['Merged', 'MergedError', 'logArchive']) and outputModules == set(['Merged', 'logArchive']):
+                    ['MergedRAW', 'MergedErrorRAW', 'logArchive']) and outputModules == set(['MergedRAW', 'logArchive']):
                 pass
             elif jobType == "Merge" and set(outputMap.keys()) == set(
-                    ['Merged', 'MergedError', 'logArchive']) and outputModules == set(['MergedError', 'logArchive']):
+                    ['MergedRAW', 'MergedErrorRAW', 'logArchive']) and outputModules == set(['MergedErrorRAW', 'logArchive']):
                 pass
-            elif jobType == "Express" and set(outputMap.keys()).difference(outputModules) == set(['write_RAW']):
+            elif jobType == "Express" and set(outputMap.keys()).difference(outputModules) == set(['write_RAWRAW']):
                 pass
             else:
                 failJob = True

--- a/src/python/WMCore/Services/Dashboard/DashboardReporter.py
+++ b/src/python/WMCore/Services/Dashboard/DashboardReporter.py
@@ -219,7 +219,7 @@ class DashboardReporter(WMObject):
             for outputMod in outputModules:
 
                 # we don't report logArchive, LogCollect and Sqlite output
-                if outputMod in [ "logArchive", "LogCollect", "Sqlite" ]:
+                if outputMod in [ "logArchive", "LogCollect", "SqliteALCAPROMPT" ]:
                     continue
 
                 outFiles = fwjr.getFilesFromOutputModule(step = stepName,

--- a/src/python/WMCore/WMSpec/StdSpecs/Express.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Express.py
@@ -181,7 +181,8 @@ class ExpressWorkloadFactory(StdBase):
                 alcaSkimTask = expressTask.addTask("%sAlcaSkim%s" % (expressTask.name(), expressOutLabel))
 
                 alcaSkimTask.setInputReference(expressTask.getStep(expressRecoStepName),
-                                               outputModule=expressOutLabel)
+                                               outputModule=expressOutLabel,
+                                               dataTier="ALCARECO")
 
                 alcaTaskConf = {'Multicore': 1,
                                 'EventStreams': 0}
@@ -362,7 +363,8 @@ class ExpressWorkloadFactory(StdBase):
         parentTaskCmssw = parentTask.getStep(parentStepName)
         parentOutputModule = parentTaskCmssw.getOutputModule(parentOutputModuleName)
 
-        harvestTask.setInputReference(parentTaskCmssw, outputModule=parentOutputModuleName)
+        dataTier=getattr(parentOutputModule, "dataTier")
+        harvestTask.setInputReference(parentTaskCmssw, outputModule=parentOutputModuleName, dataTier=dataTier)
 
         harvestTask.setSplittingAlgorithm("AlcaHarvest",
                                           **mySplitArgs)
@@ -370,7 +372,7 @@ class ExpressWorkloadFactory(StdBase):
         scenarioArgs = {'globalTag': self.globalTag,
                         'datasetName': "/%s/%s/%s" % (getattr(parentOutputModule, "primaryDataset"),
                                                       getattr(parentOutputModule, "processedDataset"),
-                                                      getattr(parentOutputModule, "dataTier")),
+                                                      dataTier),
                         'runNumber': self.runNumber,
                         'alcapromptdataset': alcapromptdataset}
 
@@ -383,7 +385,7 @@ class ExpressWorkloadFactory(StdBase):
 
         harvestTaskConditionHelper = harvestTaskCondition.getTypeHelper()
         harvestTaskConditionHelper.setRunNumber(self.runNumber)
-        harvestTaskConditionHelper.setConditionOutputLabel(condOutLabel)
+        harvestTaskConditionHelper.setConditionOutputLabel(condOutLabel+"ALCAPROMPT")
         harvestTaskConditionHelper.setConditionDir(condUploadDir)
 
         self.addOutputModule(harvestTask, condOutLabel,
@@ -415,6 +417,7 @@ class ExpressWorkloadFactory(StdBase):
         mySplitArgs['streamName'] = self.streamName
 
         parentTaskCmssw = parentTask.getStep("cmsRun1")
+        parentOutputModule = parentTaskCmssw.getOutputModule(parentOutputModuleName)
 
         conditionTask = parentTask.addTask("%sCondition%s" % (parentTask.name(), parentOutputModuleName))
 
@@ -422,7 +425,8 @@ class ExpressWorkloadFactory(StdBase):
         conditionTaskBogus = conditionTask.makeStep("bogus")
         conditionTaskBogus.setStepType("DQMUpload")
 
-        conditionTask.setInputReference(parentTaskCmssw, outputModule=parentOutputModuleName)
+        dataTier=getattr(parentOutputModule, "dataTier")
+        conditionTask.setInputReference(parentTaskCmssw, outputModule=parentOutputModuleName, dataTier=dataTier)
 
         conditionTask.applyTemplates()
 


### PR DESCRIPTION
Tier0 repack and express has some special output modules, whose handling got broken by the automatic inclusion of data tier in output modules. In the Express spec there was also a couple places where the change in the input references was simply forgotten.

@amaltaro @ticoann , please review

Without this patch the Tier0 can't use recent WMCore versions. We will also need to merge this patch into the 1.1.6 branch and make a new patch tag. Should I just make a pull request from the same branch into the 1.1.6 branch ? Or do you want to use separate source branch ?