### PR TITLE
Automatically set MaxRSS according to Memory requirements

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -193,12 +193,13 @@ class StdBase(object):
         _addDashboardMonitoring_
 
         Add dashboard monitoring for the given task.
+        Memory settings are defined in Megabytes and timing in seconds.
         """
-        # A gigabyte defined as 1024^3 (assuming RSS and VSize is in KiByte)
-        gb = 1024.0 * 1024.0
-        # Default timeout defined in CMS policy
-        softTimeout = 47.0 * 3600.0 + 40.0 * 60.0
-        hardTimeout = 47.0 * 3600.0 + 45.0 * 60.0
+        # Default settings defined by CMS policy
+        maxrss = 2.3 * 1024  # 2.3 GiB, but in MiB
+        vsize = 1 * 1024 * 1024  # 1 TiB, but in MiB
+        softTimeout = 47 * 3600  # 47h
+        hardTimeout = 47 * 3600 + 5 * 60  # 47h + 5 minutes
 
         monitoring = task.data.section_("watchdog")
         monitoring.interval = 300
@@ -207,8 +208,8 @@ class StdBase(object):
         monitoring.DashboardMonitor.destinationHost = self.dashboardHost
         monitoring.DashboardMonitor.destinationPort = self.dashboardPort
         monitoring.section_("PerformanceMonitor")
-        monitoring.PerformanceMonitor.maxRSS = 2.3 * gb
-        monitoring.PerformanceMonitor.maxVSize = 2.3 * gb
+        monitoring.PerformanceMonitor.maxRSS = maxrss
+        monitoring.PerformanceMonitor.maxVSize = vsize
         monitoring.PerformanceMonitor.softTimeout = softTimeout
         monitoring.PerformanceMonitor.hardTimeout = hardTimeout
         return task
@@ -369,11 +370,6 @@ class StdBase(object):
         procTask.setProcessingString(procStr)
         procTask.setProcessingVersion(procVer)
 
-        procTask.setPerformanceMonitor(taskConf.get("MaxRSS", None),
-                                       taskConf.get("MaxVSize", None),
-                                       taskConf.get("SoftTimeout", None),
-                                       taskConf.get("GracePeriod", None))
-
         if taskType in ["Production", 'PrivateMC'] and totalEvents is not None:
             procTask.addGenerator(seeding)
             procTask.addProduction(totalEvents=totalEvents)
@@ -404,7 +400,6 @@ class StdBase(object):
             multicore = taskConf['Multicore']
         if 'EventStreams' in taskConf and taskConf['EventStreams'] >= 0:
             eventStreams = taskConf['EventStreams']
-
         procTaskCmsswHelper.setNumberOfCores(multicore, eventStreams)
 
         procTaskCmsswHelper.setUserSandbox(userSandbox)
@@ -460,6 +455,12 @@ class StdBase(object):
         # only in the very end, in order to get it in for the children tasks as well
         prepID = taskConf.get("PrepID") or self.prepID
         procTask.setPrepID(prepID)
+
+        # has to be done in the very end such that child tasks are set too
+        procTask.setPerformanceMonitor(maxRSS=memoryReq,
+                                       maxVSize=self.maxVSize,
+                                       softTimeout=taskConf.get("SoftTimeout", None),
+                                       gracePeriod=taskConf.get("GracePeriod", None))
 
         return outputModules
 
@@ -1057,7 +1058,9 @@ class StdBase(object):
                       "RequestDate": {"optional": False, "type": list},
                       "CouchURL": {"default": "https://cmsweb.cern.ch/couchdb", "validate": couchurl},
                       "CouchDBName": {"default": "reqmgr_config_cache", "type": str, "validate": identifier},
-                      "CouchWorkloadDBName": {"default": "reqmgr_workload_cache", "validate": identifier}
+                      "CouchWorkloadDBName": {"default": "reqmgr_workload_cache", "validate": identifier},
+                      "MaxRSS": {"default": 2300, "type": int, "validate": lambda x: x > 0},
+                      "MaxVSize": {"default": 1024 * 1024, "type": int, "validate": lambda x: x > 0}
                       }
 
         arguments.update(reqmgrArgs)
@@ -1126,8 +1129,8 @@ class StdBase(object):
                      "TrustPUSitelists": {"default": False, "type": strToBool},
                      "AllowOpportunistic": {"default": False, "type": strToBool},
                      # from assignment: performance monitoring data
-                     "MaxRSS": {"default": 2411724, "type": int, "validate": lambda x: x > 0},
-                     "MaxVSize": {"default": 20411724, "type": int, "validate": lambda x: x > 0},
+                     "MaxRSS": {"type": int, "null": True, "validate": lambda x: x > 0},
+                     "MaxVSize": {"type": int, "null": True, "validate": lambda x: x > 0},
                      "SoftTimeout": {"default": 129600, "type": int, "validate": lambda x: x > 0},
                      "GracePeriod": {"default": 300, "type": int, "validate": lambda x: x > 0},
                      "HardTimeout": {"default": 129600 + 300, "type": int, "validate": lambda x: x > 0},

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -1646,8 +1646,7 @@ class WMWorkloadHelper(PersistencyHelper):
 
         return summary
 
-    def setupPerformanceMonitoring(self, maxRSS, maxVSize, softTimeout,
-                                   gracePeriod):
+    def setupPerformanceMonitoring(self, maxRSS, maxVSize, softTimeout, gracePeriod):
         """
         _setupPerformanceMonitoring_
 
@@ -1655,8 +1654,7 @@ class WMWorkloadHelper(PersistencyHelper):
         """
         for task in self.getAllTasks():
             task.setPerformanceMonitor(maxRSS=maxRSS, maxVSize=maxVSize,
-                                       softTimeout=softTimeout,
-                                       gracePeriod=gracePeriod)
+                                       softTimeout=softTimeout, gracePeriod=gracePeriod)
 
         return
 
@@ -1742,8 +1740,8 @@ class WMWorkloadHelper(PersistencyHelper):
         if kwargs.get("ProcessingVersion") is not None:
             self.setProcessingVersion(kwargs["ProcessingVersion"])
 
-        self.setupPerformanceMonitoring(kwargs["MaxRSS"],
-                                        kwargs["MaxVSize"],
+        self.setupPerformanceMonitoring(kwargs.get("MaxRSS"),
+                                        kwargs.get("MaxVSize"),
                                         kwargs["SoftTimeout"],
                                         kwargs["GracePeriod"])
 


### PR DESCRIPTION
Fixes #8091
Basic changes are:
* given the Memory requirements for a workload/task, automatically set the MaxRSS watchdog to the same value as the Memory one.
* creation default MaxVSize to an "infinite" number (1TiB)
* also changed the MaxRSS and MaxVSize unit from KiB to MiB

plus the following required changes:
* PerformanceMonitor watchdog works with both KiB or MiB MaxRSS/MaxVSize settings (TODO: remove the backwards compatibility in a couple of months)
* kill a job with the first `reason`, not the last one in case of multiple reasons
* MaxRSS and MaxVSize default assignment values were removed.
* Merge/Cleanup/Logcollect tasks aren't affected by Memory requirements

That means Ops will have to provide the correct rss/vsize values during assignment, only for old workflows (created before cmsweb upgrade). Newer workflows should have the correct settings and rss/vsize parameters can be skipped during assignment.

TODO: It also means we have to update all WMAgents with the Watchdog changes (KiB vs MiB).

There will be a transition phase here, but once CMSWEB upgrade is completed (next Tuesday Oct 10th), this is the impact on the clients:
* clients *must* provide rss/vsize for old workflows;
* clients don't need to provide rss/vsize for new workflows (created after the workflow is finished). Though it's still fine if it's provided;
* redundant, but clients *can* keep providing these rss/vsize settings during assignment for old or new workflows;

Moreover, if memory requirements are overwritten during assignment, that will properly set the maxRSS as well.