### PR TITLE
Acdc unmerged filter

### DIFF
--- a/src/python/WMCore/ACDC/DataCollectionService.py
+++ b/src/python/WMCore/ACDC/DataCollectionService.py
@@ -91,10 +91,16 @@ class DataCollectionService(CouchService):
             fileset = CouchFileset(database=self.database, url=self.url,
                                    name=taskName)
             coll.addFileset(fileset)
+            inputFiles = job['input_files']
+            for fInfo in inputFiles:
+                if fInfo["merged"] and ("parents" in fInfo) and \
+                   len(fInfo["parents"]) and ("/store/unmerged/" in next(iter(fInfo["parents"]))):
+                    # remove parents files from acdc doucment if they are unmerged files
+                    fInfo["parents"] = []
             if useMask:
-                fileset.add(files=job['input_files'], mask=job['mask'])
+                fileset.add(files=inputFiles, mask=job['mask'])
             else:
-                fileset.add(files=job['input_files'])
+                fileset.add(files=inputFiles)
 
         return
 


### PR DESCRIPTION
fixes #8196 
@amaltaro, Alan please review. Still need to be tested.
First commit handles when documents with umerged parents are already in acdc db
Second commit prevent putting the documents with unmerged parents  in acdc db.

We can only cherry pick first commit for current agent if second commit is not tested throughly