### PR TITLE
Update deploy_unittest.sh

### DIFF
--- a/test/deploy/deploy_unittest.sh
+++ b/test/deploy/deploy_unittest.sh
@@ -12,7 +12,7 @@
 #
 # for running the test check the tutorial, https://github.com/dmwm/WMCore/wiki/Setup-wmcore-unittest
 ###
-DMWM_ARCH=slc6_amd64_gcc493
+DMWM_ARCH=slc7_amd64_gcc630
 VERSION=$(curl -s "http://cmsrep.cern.ch/cgi-bin/repos/comp/$DMWM_ARCH?C=M;O=D" | grep -oP "(?<=>cms\+wmagent-dev\+).*(?=-1-1)" | head -1)
 
 REPOSITORY=dmwm


### PR DESCRIPTION
@ticoann @amaltaro any reason we shouldn't do this? SLC7 build is already being used for unit tests and the test of the deployment, but this is the version that ends up in the docker containers we build.