### PR TITLE
Set a configurable fraction of the condor schedd job limit

### DIFF
--- a/bin/wmagent-mod-config
+++ b/bin/wmagent-mod-config
@@ -122,6 +122,9 @@ def modifyConfiguration(config, **args):
 
     if hasattr(config, "General"):
         config.General.central_logdb_url = args["central_logdb_url"]
+        # t0 agent doesn't have reqmgr2_url
+        if "reqmgr2_url" in args:
+            config.General.ReqMgr2ServiceURL = args["reqmgr2_url"]
 
     if hasattr(config, "WorkloadSummary"):
         splited = args["workload_summary_url"].strip().rstrip('/').rsplit('/', 1)
@@ -140,21 +143,11 @@ def modifyConfiguration(config, **args):
                                                          config.JobStateMachine.jobSummaryDBName)
         config.TaskArchiver.centralWMStatsURL = args["wmstats_url"]
         config.TaskArchiver.dqmUrl = args["dqm_url"]
-        # t0 agent doesn't have reqmgr_url
-        if "reqmgr_url" in args:
-            config.TaskArchiver.ReqMgrServiceURL = args["reqmgr_url"]
-        if "reqmgr2_url" in args:
-            config.TaskArchiver.ReqMgr2ServiceURL = args["reqmgr2_url"]
 
     if hasattr(config, "ACDC"):
         # t0 agent may not have acdc_url
         if "acdc_url" in args:
             config.ACDC.couchurl, config.ACDC.database = splitCouchServiceURL(args["acdc_url"])
-
-    if hasattr(config, "JobUpdater"):
-        # t0 agent doesn't have reqmgr_url
-        if "reqmgr2_url" in args:
-            config.JobUpdater.reqMgr2Url = args["reqmgr2_url"]
 
     if hasattr(config, "DBS3Upload"):
         config.DBS3Upload.dbsUrl = args["dbs3_url"]
@@ -354,7 +347,7 @@ def main(argv=None):
                                         "sb_hostname=", "sb_port=", "sb_basepath=", "ufc_hostname=", "ufc_port=",
                                         "ufc_service_url=", "ufc_cachedir=", "client_mapping=",
                                         "workload_summary_url=", "coredb_url=", "wmstats_url=", "ops_proxy=",
-                                        "reqmgr_url=", "reqmgr2_url=",
+                                        "reqmgr2_url=",
                                         "acdc_url=", "amq_auth_file=", "dbs3_url=", "phedex_url=", "dqm_url=",
                                         "dashboard_url=",
                                         "requestcouch_url=", "central_logdb_url=", "wmarchive_url="])
@@ -377,7 +370,7 @@ def main(argv=None):
                           '--sb_hostname', '--sb_port', '--sb_basepath', '--ufc_hostname',
                           '--ufc_port', '--ufc_service_url', '--ufc_cachedir',
                           '--client_mapping', '--workload_summary_url',
-                          '--wmstats_url', '--ops_proxy', '--reqmgr_url', '--reqmgr2_url', '--acdc_url',
+                          '--wmstats_url', '--ops_proxy', '--reqmgr2_url', '--acdc_url',
                           '--amq_auth_file', '--dbs3_url', '--phedex_url', '--dqm_url', '--dashboard_url',
                           '--requestcouch_url', '--central_logdb_url', '--wmarchive_url'):
                 parameters[option[2:]] = value

--- a/bin/wmagent-upload-config
+++ b/bin/wmagent-upload-config
@@ -12,6 +12,6 @@ def insertWMAgentConfig(reqmgrURL, hostName, agentConfig):
 if __name__ == "__main__":
     wmConfig = loadConfigurationFile(os.environ['WMAGENT_CONFIG'])
     
-    insertWMAgentConfig(wmConfig.TaskArchiver.ReqMgr2ServiceURL,
+    insertWMAgentConfig(wmConfig.General.ReqMgr2ServiceURL,
                         wmConfig.Agent.hostName, DEFAULT_AGENT_CONFIG)
     

--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -203,6 +203,7 @@ config.JobSubmitter.cacheRefreshSize = 30000  # set -1 if cache need to refresh 
 config.JobSubmitter.skipRefreshCount = 20  # (If above the threshold meet, cache will updates every 20 polling cycle) 120 * 20 = 40 minutes
 config.JobSubmitter.submitScript = os.path.join(os.environ["WMCORE_ROOT"], "etc/submit.sh")
 config.JobSubmitter.extraMemoryPerCore = 500  # in MB
+config.JobSubmitter.condorJobsFraction = 0.75  # fraction of the condor schedd limit
 
 config.component_("JobTracker")
 config.JobTracker.namespace = "WMComponent.JobTracker.JobTracker"

--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -84,6 +84,7 @@ config.General.workDir = workDirectory
 config.General.logdb_name = logDBName
 config.General.logdb_url = "%s/%s" % (couchURL, config.General.logdb_name)
 config.General.central_logdb_url = "need to get from secrets file"
+config.General.ReqMgr2ServiceURL = "ReqMgr2 rest service"
 
 config.section_("JobStateMachine")
 config.JobStateMachine.couchurl = couchURL
@@ -203,7 +204,6 @@ config.JobSubmitter.cacheRefreshSize = 30000  # set -1 if cache need to refresh 
 config.JobSubmitter.skipRefreshCount = 20  # (If above the threshold meet, cache will updates every 20 polling cycle) 120 * 20 = 40 minutes
 config.JobSubmitter.submitScript = os.path.join(os.environ["WMCORE_ROOT"], "etc/submit.sh")
 config.JobSubmitter.extraMemoryPerCore = 500  # in MB
-config.JobSubmitter.condorJobsFraction = 0.75  # fraction of the condor schedd limit
 
 config.component_("JobTracker")
 config.JobTracker.namespace = "WMComponent.JobTracker.JobTracker"
@@ -223,8 +223,6 @@ config.JobUpdater.namespace = "WMComponent.JobUpdater.JobUpdater"
 config.JobUpdater.componentDir = config.General.workDir + "/JobUpdater"
 config.JobUpdater.logLevel = globalLogLevel
 config.JobUpdater.pollInterval = 120
-# reqmgr url 'https://cmsweb.cern.ch/reqmgr/reqMgr'
-config.JobUpdater.reqMgr2Url = "OVER_WRITE_BY_SECETES"
 
 config.component_("ErrorHandler")
 config.ErrorHandler.namespace = "WMComponent.ErrorHandler.ErrorHandler"
@@ -280,7 +278,6 @@ config.TaskArchiver.localQueueURL = "%s/%s" % (config.WorkQueueManager.couchurl,
 config.TaskArchiver.localWMStatsURL = "%s/%s" % (config.JobStateMachine.couchurl, config.JobStateMachine.jobSummaryDBName)
 config.TaskArchiver.DataKeepDays = 0.125  # couhch history keeping days.
 config.TaskArchiver.cleanCouchInterval = 60 * 20  # 20 min
-config.TaskArchiver.ReqMgr2ServiceURL = "ReqMgr2 rest service"
 config.TaskArchiver.archiveDelayHours = 24  # delay the archiving so monitor can still show. default 24 hours
 
 # Alert framework configuration

--- a/src/python/WMComponent/ErrorHandler/ErrorHandlerPoller.py
+++ b/src/python/WMComponent/ErrorHandler/ErrorHandlerPoller.py
@@ -86,7 +86,7 @@ class ErrorHandlerPoller(BaseWorkerThread):
         if hasattr(self.config, "Tier0Feeder"):
             self.reqAuxDB = None
         else:
-            self.reqAuxDB = ReqMgrAux(self.config.TaskArchiver.ReqMgr2ServiceURL)
+            self.reqAuxDB = ReqMgrAux(self.config.General.ReqMgr2ServiceURL)
 
         return
 

--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -30,6 +30,7 @@ from WMCore.WMException                       import WMException
 from WMCore.BossAir.BossAirAPI                import BossAirAPI
 from WMCore.Services.ReqMgr.ReqMgr import ReqMgr
 from WMCore.Services.PyCondor.PyCondorAPI import getScheddParamValue
+from WMCore.Services.ReqMgrAux.ReqMgrAux import ReqMgrAux
 
 
 class JobSubmitterPollerException(WMException):
@@ -62,14 +63,16 @@ class JobSubmitterPoller(BaseWorkerThread):
         self.changeState = ChangeState(self.config)
         self.bossAir = BossAirAPI(config=self.config)
 
+        self.hostName = self.config.Agent.hostName
         self.repollCount = getattr(self.config.JobSubmitter, 'repollCount', 10000)
         self.maxJobsPerPoll = int(getattr(self.config.JobSubmitter, 'maxJobsPerPoll', 1000))
+        self.maxJobsThisCycle = self.maxJobsPerPoll  # changes as per schedd limit
         self.cacheRefreshSize = int(getattr(self.config.JobSubmitter, 'cacheRefreshSize', 30000))
         self.skipRefreshCount = int(getattr(self.config.JobSubmitter, 'skipRefreshCount', 20))
         self.packageSize = getattr(self.config.JobSubmitter, 'packageSize', 500)
         self.collSize = getattr(self.config.JobSubmitter, 'collectionSize', self.packageSize * 1000)
         self.maxTaskPriority = getattr(self.config.BossAir, 'maxTaskPriority', 1e7)
-        self.condorFraction = float(getattr(self.config.JobSubmitter, 'condorJobsFraction', 1))
+        self.condorFraction = None  # update during every algorithm cycle
 
         # Additions for caching-based JobSubmitter
         self.cachedJobIDs = set()
@@ -114,8 +117,9 @@ class JobSubmitterPoller(BaseWorkerThread):
 
         if self.useReqMgrForCompletionCheck:
             # only set up this when reqmgr is used (not Tier0)
-            self.reqmgr2Svc = ReqMgr(self.config.TaskArchiver.ReqMgr2ServiceURL)
+            self.reqmgr2Svc = ReqMgr(self.config.General.ReqMgr2ServiceURL)
             self.abortedAndForceCompleteWorkflowCache = self.reqmgr2Svc.getAbortedAndForceCompleteRequestsFromMemoryCache()
+            self.reqAuxDB = ReqMgrAux(self.config.General.ReqMgr2ServiceURL)
         else:
             # Tier0 Case - just for the clarity (This private variable shouldn't be used
             self.abortedAndForceCompleteWorkflowCache = None
@@ -450,13 +454,6 @@ class JobSubmitterPoller(BaseWorkerThread):
                                          ": file locations: " + ', '.join(job['fileLocations']) +
                                          ": site white list: " + ', '.join(job['siteWhitelist']) +
                                          ": site black list: " + ', '.join(job['siteBlacklist']))
-                else:
-                    # This is temporary addition if this is patched for existing agent.
-                    # If jobs are created before the patch is applied fileLocations is not set.
-                    # TODO. remove this later for new agent
-                    job['fwjr'].addError("JobSubmit", exitCode, "SubmitFailed", WM_JOB_ERROR_CODES[exitCode]  +
-                                         ": Job is created before this patch. Please check this input for the jobs: %s " %
-                                         job['fwjr'].getAllInputFiles())
 
             else:
                 job['fwjr'].addError("JobSubmit", exitCode, "SubmitFailed", WM_JOB_ERROR_CODES[exitCode])
@@ -619,7 +616,8 @@ class JobSubmitterPoller(BaseWorkerThread):
                     break
 
                 # set the flag and get out of the job iteration
-                if jobsCount >= self.maxJobsPerPoll:
+                if jobsCount >= self.maxJobsThisCycle:
+                    logging.info("Submitter reached limit of submit slots for this cycle: %i", self.maxJobsThisCycle)
                     exitLoop = True
                     break
 
@@ -751,23 +749,39 @@ class JobSubmitterPoller(BaseWorkerThread):
         """
         _passSubmitConditions_
 
-        Check whether the component is allowed to submit
-        jobs to condor.
+        Check whether the component is allowed to submit jobs to condor.
 
-        Initially it has only one condition, which is the total
-        amount of jobs we can have in condor (pending + running) per schedd,
-        set by MAX_JOBS_PER_OWNER.
+        Initially it has only one condition, which is the total number of
+        jobs we can have in condor (pending + running) per schedd, set by
+        MAX_JOBS_PER_OWNER.
         """
-        passCond = True
-        # fetch idle + running jobs in condor
-        executingJobs = self.countWMBSJobsByState.execute("executing")
+        if not self.reqAuxDB:
+            return False
+
+        agentAuxConfig = self.reqAuxDB.getWMAgentConfig(self.hostName)
+        self.condorFraction = agentAuxConfig.get('CondorJobsFraction')
+        if self.condorFraction is None:
+            logging.warning("Failed to retrieve 'CondorJobsFraction' from auxiliar DB")
+            return False
+        else:
+            self.condorFraction = float(self.condorFraction)
+
         maxScheddJobs = int(getScheddParamValue("MAX_JOBS_PER_OWNER"))
         if maxScheddJobs is None:
-            passCond = False
-        elif int(executingJobs) + self.maxJobsPerPoll >= int(maxScheddJobs * self.condorFraction):
-            passCond = False
+            logging.warning("Failed to retrieve 'MAX_JOBS_PER_OWNER' from HTCondor")
+            return False
 
-        return passCond
+        # fetch idle + running jobs in condor
+        executingJobs = int(self.countWMBSJobsByState.execute("executing"))
+        if executingJobs >= int(maxScheddJobs * self.condorFraction):
+            logging.info("There are way too many jobs in HTCondor already. Limit is: %s",
+                         int(maxScheddJobs * self.condorFraction))
+            return False
+
+        freeSubmitSlots = int(maxScheddJobs * self.condorFraction) - executingJobs
+        self.maxJobsThisCycle = min(freeSubmitSlots, self.maxJobsPerPoll)
+
+        return True
 
     def terminate(self, params):
         """

--- a/src/python/WMComponent/JobUpdater/JobUpdaterPoller.py
+++ b/src/python/WMComponent/JobUpdater/JobUpdaterPoller.py
@@ -46,7 +46,7 @@ class JobUpdaterPoller(BaseWorkerThread):
         self.config = config
 
         self.bossAir = BossAirAPI(config=self.config)
-        self.reqmgr2 = ReqMgr(self.config.JobUpdater.reqMgr2Url)
+        self.reqmgr2 = ReqMgr(self.config.General.ReqMgr2ServiceURL)
         self.workqueue = WorkQueue(self.config.WorkQueueManager.couchurl,
                                    self.config.WorkQueueManager.dbname)
 

--- a/src/python/WMComponent/TaskArchiver/CleanCouchPoller.py
+++ b/src/python/WMComponent/TaskArchiver/CleanCouchPoller.py
@@ -105,7 +105,7 @@ class CleanCouchPoller(BaseWorkerThread):
             self.deletableState = "announced"
             self.centralRequestDBWriter = RequestDBWriter(self.config.AnalyticsDataCollector.centralRequestDBURL,
                                                           couchapp=self.config.AnalyticsDataCollector.RequestCouchApp)
-            self.reqmgr2Svc = ReqMgr(self.config.TaskArchiver.ReqMgr2ServiceURL)
+            self.reqmgr2Svc = ReqMgr(self.config.General.ReqMgr2ServiceURL)
         else:
             # Tier0 case
             self.deletableState = "completed"

--- a/src/python/WMComponent/TaskArchiver/TaskArchiverPoller.py
+++ b/src/python/WMComponent/TaskArchiver/TaskArchiverPoller.py
@@ -98,7 +98,7 @@ class TaskArchiverPoller(BaseWorkerThread):
         else:
             self.centralCouchDBWriter = RequestDBWriter(self.config.AnalyticsDataCollector.centralRequestDBURL)
 
-            self.reqmgr2Svc = ReqMgr(self.config.TaskArchiver.ReqMgr2ServiceURL)
+            self.reqmgr2Svc = ReqMgr(self.config.General.ReqMgr2ServiceURL)
 
         # Load the cleanout state ID and save it
         stateIDDAO = self.daoFactory(classname="Jobs.GetStateID")

--- a/src/python/WMComponent/WorkQueueManager/WorkQueueManagerCleaner.py
+++ b/src/python/WMComponent/WorkQueueManager/WorkQueueManagerCleaner.py
@@ -22,7 +22,7 @@ class WorkQueueManagerCleaner(BaseWorkerThread):
         BaseWorkerThread.__init__(self)
         self.queue = queue
         self.config = config
-        self.reqmgr2Svc = ReqMgr(self.config.TaskArchiver.ReqMgr2ServiceURL)
+        self.reqmgr2Svc = ReqMgr(self.config.General.ReqMgr2ServiceURL)
         # state lists which shouldn't be populated in wmbs. (To prevent creating work before WQE status updated)
         self.abortedAndForceCompleteWorkflowCache = self.reqmgr2Svc.getAbortedAndForceCompleteRequestsFromMemoryCache(expire=120)
 

--- a/src/python/WMComponent/WorkQueueManager/WorkQueueManagerWMBSFileFeeder.py
+++ b/src/python/WMComponent/WorkQueueManager/WorkQueueManagerWMBSFileFeeder.py
@@ -27,7 +27,7 @@ class WorkQueueManagerWMBSFileFeeder(BaseWorkerThread):
 
         self.queue = queue
         self.config = config
-        self.reqmgr2Svc = ReqMgr(self.config.TaskArchiver.ReqMgr2ServiceURL)
+        self.reqmgr2Svc = ReqMgr(self.config.General.ReqMgr2ServiceURL)
         # state lists which shouldn't be populated in wmbs. (To prevent creating work before WQE status updated)
         self.abortedAndForceCompleteWorkflowCache = self.reqmgr2Svc.getAbortedAndForceCompleteRequestsFromMemoryCache()
 

--- a/src/python/WMCore/Agent/DefaultConfig.py
+++ b/src/python/WMCore/Agent/DefaultConfig.py
@@ -9,6 +9,8 @@ DEFAULT_AGENT_CONFIG = {
     "DiskUseThreshold": 85,
      # list of disks which shouldn't be included in monitoring for the Threshold
     "IgnoreDisks": ["/lustre/unmerged"],
+    # fraction of condor schedd limit, used for job submission
+    "CondorJobsFraction": 0.75,
     # ExitCodes returned by jobs which doesn't need to be retried
     "NoRetryExitCodes": [70, 73, 8001, 8006, 8009, 8023, 8026, 50660, 50661, 50664, 71102]
 }

--- a/src/python/WMCore/Services/PyCondor/PyCondorAPI.py
+++ b/src/python/WMCore/Services/PyCondor/PyCondorAPI.py
@@ -64,7 +64,7 @@ def getScheddParamValue(param):
     Given a schedd parameter, retrieve it's value with htcondor, e.g.:
     MAX_JOBS_RUNNING, MAX_JOBS_PER_OWNER, etc
     """
-    if isinstance(param, basestring):
+    if not isinstance(param, basestring):
         logging.error("Parameter %s must be string type", param)
         return
 

--- a/src/python/WMCore/Services/ReqMgrAux/ReqMgrAux.py
+++ b/src/python/WMCore/Services/ReqMgrAux/ReqMgrAux.py
@@ -127,7 +127,7 @@ def isDrainMode(config):
 
     global AUXDB_AGENT_CONFIG_CACHE
 
-    reqMgrAux = ReqMgrAux(config.TaskArchiver.ReqMgr2ServiceURL)
+    reqMgrAux = ReqMgrAux(config.General.ReqMgr2ServiceURL)
     agentConfig = reqMgrAux.getWMAgentConfig(config.Agent.hostName)
     if "UserDrainMode" in agentConfig and "AgentDrainMode" in agentConfig:
         AUXDB_AGENT_CONFIG_CACHE = agentConfig
@@ -153,7 +153,7 @@ def listDiskUsageOverThreshold(config, updateDB):
             diskUseThreshold = config.AgentStatusWatcher.diskUseThreshold
         t0Flag = True
     else:
-        reqMgrAux = ReqMgrAux(config.TaskArchiver.ReqMgr2ServiceURL)
+        reqMgrAux = ReqMgrAux(config.General.ReqMgr2ServiceURL)
         agentConfig = reqMgrAux.getWMAgentConfig(config.Agent.hostName)
         diskUseThreshold = agentConfig["DiskUseThreshold"]
         ignoredDisks = agentConfig["IgnoreDisks"]

--- a/src/python/WMCore/WMBS/MySQL/Jobs/GetCountByState.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/GetCountByState.py
@@ -23,6 +23,4 @@ class GetCountByState(DBFormatter):
         result = self.dbi.processData(self.sql, {'state': state},
                                       conn=conn,
                                       transaction=transaction)
-        result = self.formatDict(result)
-
-        return result[state]
+        return self.format(result)[0][0]

--- a/src/python/WMQuality/Emulators/EmulatorSetup.py
+++ b/src/python/WMQuality/Emulators/EmulatorSetup.py
@@ -27,6 +27,7 @@ def _wmAgentConfig(configFile):
     config.General.logdb_name = "unittest_logdb"
     config.General.logdb_url = "http://localhost/logdb"
     config.General.central_logdb_url = "http://localhost/central_logdb"
+    config.General.ReqMgr2ServiceURL = "http://localhost/reqmgr2"
 
     config.section_("JobStateMachine")
     # Waring setting couchDB to None will cause the ERROR:
@@ -53,9 +54,5 @@ def _wmAgentConfig(configFile):
     config.section_("BossAir")
     config.BossAir.pluginNames = ['TestPlugin', 'SimpleCondorPlugin']
     config.BossAir.pluginDir = 'WMCore.BossAir.Plugins'
-
-    # TaskArchive setup (JobSubmitter needs this)
-    config.component_("TaskArchiver")
-    config.TaskArchiver.ReqMgr2ServiceURL = "https://cmsweb-dev.cern.ch/reqmgr2"
 
     saveConfigurationFile(config, configFile)

--- a/src/python/WMQuality/Emulators/ReqMgrAux/MockReqMgrAux.py
+++ b/src/python/WMQuality/Emulators/ReqMgrAux/MockReqMgrAux.py
@@ -13,5 +13,4 @@ class MockReqMgrAux(object):
         """
         macking getWMAgentConfig returns default config.
         """
-
         return DEFAULT_AGENT_CONFIG

--- a/src/python/WMQuality/TestInit.py
+++ b/src/python/WMQuality/TestInit.py
@@ -233,6 +233,7 @@ class TestInit(object):
         config.section_("General")
         # If you need a testDir, call testInit.generateWorkDir
         # config.General.workDir = os.getenv("TESTDIR")
+        config.General.ReqMgr2ServiceURL = "http://localhost/reqmgr2"
 
         config.section_("CoreDatabase")
         if connectUrl:
@@ -268,8 +269,6 @@ class TestInit(object):
 
         config.component_("TaskArchiver")
         config.TaskArchiver.localWMStatsURL = "%s/%s" % (config.JobStateMachine.couchurl, config.JobStateMachine.jobSummaryDBName)
-        config.TaskArchiver.ReqMgrSeviceURL = "request manager service url"
-        config.TaskArchiver.ReqMgr2ServiceURL = "https://cmsweb-dev.cern.ch/reqmgr2"
 
         return config
 

--- a/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
+++ b/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
@@ -36,7 +36,6 @@ from WMQuality.Emulators import EmulatorSetup
 from WMQuality.Emulators.EmulatedUnitTestCase import EmulatedUnitTestCase
 from WMQuality.Emulators.LogDB.MockLogDB import MockLogDB
 
-
 class JobSubmitterTest(EmulatedUnitTestCase):
     """
     _JobSubmitterTest_
@@ -244,6 +243,7 @@ class JobSubmitterTest(EmulatedUnitTestCase):
         config.section_("General")
         config.General.workDir = os.getenv("TESTDIR", self.testDir)
         config.General.central_logdb_url = "http://localhost/testlogdb"
+        config.General.ReqMgr2ServiceURL = "http://localhost/reqmgr2"
 
         # Now the CoreDatabase information
         config.section_("CoreDatabase")
@@ -280,10 +280,6 @@ class JobSubmitterTest(EmulatedUnitTestCase):
         config.JobStateMachine.couchurl = os.getenv('COUCHURL')
         config.JobStateMachine.couchDBName = "jobsubmitter_t"
         config.JobStateMachine.jobSummaryDBName = 'wmagent_summary_t'
-
-        # TaskArchive setup (JobSubmitter needs this)
-        config.component_("TaskArchiver")
-        config.TaskArchiver.ReqMgr2ServiceURL = "https://cmsweb-dev.cern.ch/reqmgr2"
 
         # Needed, because this is a test
         try:

--- a/test/python/WMComponent_t/TaskArchiver_t/TaskArchiver_t.py
+++ b/test/python/WMComponent_t/TaskArchiver_t/TaskArchiver_t.py
@@ -116,6 +116,7 @@ class TaskArchiverTest(unittest.TestCase):
 
         config.section_("General")
         config.General.workDir = "."
+        config.General.ReqMgr2ServiceURL = "https://cmsweb-dev.cern.ch/reqmgr2"
 
         config.section_("JobStateMachine")
         config.JobStateMachine.couchurl = os.getenv("COUCHURL", "cmssrv52.fnal.gov:5984")
@@ -145,7 +146,6 @@ class TaskArchiverTest(unittest.TestCase):
                                                          config.JobStateMachine.jobSummaryDBName)
         config.TaskArchiver.workloadSummaryCouchURL = config.JobStateMachine.couchurl
         config.TaskArchiver.requireCouch = True
-        config.TaskArchiver.ReqMgr2ServiceURL = "https://cmsweb-dev.cern.ch/reqmgr2"
 
         config.component_("AnalyticsDataCollector")
         config.AnalyticsDataCollector.centralRequestDBURL = '%s/reqmgrdb_t' % config.JobStateMachine.couchurl


### PR DESCRIPTION
Fixes a few bugs inserted in the PR #8228
Further changes are:
* moved a general config attr to the General section (ReqMgr2ServiceURL)
* removed `reqmgr_url` from the wmagent deploy/setup
* removed a backward compatibility code for submitfailed

and mainly:
* given the schedd jobs limit `MAX_JOBS_PER_OWNER` and a configurable `CondorJobsFraction` value, in the ReqMgrAuxDB, proceed with job submission or not. As soon as a single slot gets free, the algo allows one more job to be submitted.
