### PR TITLE
Dont log No available resources in WorkQueue

### DIFF
--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -949,7 +949,7 @@ class WorkQueue(WorkQueueBase):
 
                     if result.inEndState():
                         if elements:
-                            self.logger.info(
+                            self.logger.debug(
                                 "Request %s finished (%s)" % (result['RequestName'], parent.statusMetrics()))
                             finished_elements.extend(result['Elements'])
                         else:

--- a/src/python/WMCore/WorkQueue/WorkQueueBackend.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueBackend.py
@@ -416,7 +416,7 @@ class WorkQueueBackend(object):
                 siteJobCounts[possibleSite][prio] = siteJobCounts[possibleSite].setdefault(prio, 0) + \
                                                     element['Jobs'] * element.get('blowupFactor', 1.0)
             else:
-                self.logger.info("No available resources for %s with doc id %s", element['RequestName'], element.id)
+                self.logger.debug("No available resources for %s with doc id %s", element['RequestName'], element.id)
 
         return elements, thresholds, siteJobCounts
 


### PR DESCRIPTION
Now that the WorkQueueManager polling cycle is much more aggressive, this log causes the ComponentLog to get rotated once a day, if not twice...