### PR TITLE
Use special merge output module for NANOAOD{SIM} tier

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -669,9 +669,12 @@ class StdBase(object):
                                         max_wait_time=self.maxWaitTime,
                                         initial_lfn_counter=lfn_counter)
 
-        if getattr(parentOutputModule, "dataTier") == "DQMIO":
+        if dataTier == "DQMIO":
             mergeTaskCmsswHelper.setDataProcessingConfig("do_not_use", "merge",
                                                          newDQMIO=True)
+        elif dataTier in ("NANOAOD", "NANOAODSIM"):
+            mergeTaskCmsswHelper.setDataProcessingConfig("do_not_use", "merge",
+                                                         mergeNANO=True)
         else:
             mergeTaskCmsswHelper.setDataProcessingConfig("do_not_use", "merge")
 


### PR DESCRIPTION
Fixes #8273 

Eventually we might remove it from ReqMgr2 and just apply these settings at runtime code (SetupCMSSW).

These datatiers still have to be added to DBS Server though. @yuyiguo 