### PR TITLE
submit higher priority jobs regardless the threshold

### DIFF
--- a/src/python/WMComponent/JobSubmitter/JobSubmitAPI.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitAPI.py
@@ -1,0 +1,24 @@
+from __future__ import print_function, division
+import logging
+from WMCore.DAOFactory import DAOFactory
+from WMCore.Services.PyCondor.PyCondorAPI import getScheddParamValue
+
+
+def availableScheddSlots(dbi, logger=logging, condorFraction=1):
+    """
+    check executing jobs and compare with condor limit.
+    return the difference -- executing jobs - (condor limit * condorFraction)
+    """
+    action = DAOFactory(package='WMCore.WMBS',
+                        logger=logger,
+                        dbinterface=dbi)(classname="Jobs.GetCountByState")
+    executingJobs = int(action.execute("executing"))
+
+    maxScheddJobs = getScheddParamValue("MAX_JOBS_PER_OWNER")
+
+    if maxScheddJobs is None:
+        logger.warning("Failed to retrieve 'MAX_JOBS_PER_OWNER' from HTCondor")
+        return 0
+
+    freeSubmitSlots = int(int(maxScheddJobs) * condorFraction - executingJobs)
+    return freeSubmitSlots

--- a/src/python/WMCore/ResourceControl/MySQL/ListThresholdsForSubmit.py
+++ b/src/python/WMCore/ResourceControl/MySQL/ListThresholdsForSubmit.py
@@ -18,6 +18,7 @@ class ListThresholdsForSubmit(DBFormatter):
                     wmbs_sub_types.name AS task_type,
                     job_count.job_status,
                     job_count.jobs,
+                    job_count.wf_highest_priority,
                     wmbs_sub_types.priority,
                     wmbs_location_state.name AS state,
                     wmbs_location.plugin AS plugin
@@ -32,6 +33,7 @@ class ListThresholdsForSubmit(DBFormatter):
                  (SELECT wmbs_job.location AS location,
                          wmbs_subscription.subtype AS subtype,
                          COUNT(wmbs_job.id) as jobs,
+                         MAX(wmbs_workflow.priority) as wf_highest_priority,
                          bl_status.name as job_status
                          FROM wmbs_job
                     INNER JOIN wmbs_jobgroup ON
@@ -44,6 +46,8 @@ class ListThresholdsForSubmit(DBFormatter):
                       bl_runjob.wmbs_id = wmbs_job.id
                     INNER JOIN bl_status ON
                       bl_status.id = bl_runjob.sched_status
+                    INNER JOIN wmbs_workflow ON
+                      wmbs_workflow.id = wmbs_subscription.workflow
                   WHERE wmbs_job_state.name = 'executing' AND
                         bl_runjob.status = '1'
                   GROUP BY wmbs_job.location, wmbs_subscription.subtype,
@@ -98,6 +102,7 @@ class ListThresholdsForSubmit(DBFormatter):
                 siteInfo['state']                = result['state']
                 siteInfo['total_pending_slots']  = result['pending_slots']
                 siteInfo['total_running_slots']  = result['running_slots']
+                siteInfo['wf_highest_priority'] = result['wf_highest_priority']
                 siteInfo['total_pending_jobs']   = task_pending_jobs
                 siteInfo['total_running_jobs']   = task_running_jobs
                 siteInfo['thresholds']           = {}

--- a/src/python/WMCore/ResourceControl/ResourceControl.py
+++ b/src/python/WMCore/ResourceControl/ResourceControl.py
@@ -184,6 +184,7 @@ class ResourceControl(WMConnectionBase):
           state               - State of the site
           total_pending_slots - Total number of pending slots available at the site
           total_running_slots - Total number of running slots available at the site
+          wf_highest_priority - highest priority value among pending and running joba
           total_pending_jobs  - Total jobs pending at the site
           total_running_jobs  - Total jobs running at the site
           thresholds          - List of dictionaries with threshold information ordered by descending priority

--- a/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
+++ b/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
@@ -136,7 +136,8 @@ class JobSubmitterTest(EmulatedUnitTestCase):
             name = makeUUID()
 
         testWorkflow = Workflow(spec=workloadSpec, owner="tapas",
-                                name=name, task="basicWorkload/Production")
+                                name=name, task="basicWorkload/Production",
+                                priority=1)
         testWorkflow.create()
 
         # Create subscriptions
@@ -495,13 +496,13 @@ class JobSubmitterTest(EmulatedUnitTestCase):
             jobSubmitter.algorithm()
 
         result = getJobsAction.execute(state='Executing', jobType='Processing')
-        self.assertEqual(len(result), 240)
+        self.assertEqual(len(result), 238)
         result = getJobsAction.execute(state='Created', jobType='Processing')
-        self.assertEqual(len(result), 110)
+        self.assertEqual(len(result), 112)
         result = getJobsAction.execute(state='Executing', jobType='Merge')
-        self.assertEqual(len(result), 30)
+        self.assertEqual(len(result), 32)
         result = getJobsAction.execute(state='Created', jobType='Merge')
-        self.assertEqual(len(result), 280)
+        self.assertEqual(len(result), 278)
 
         return
 


### PR DESCRIPTION
fixes #8129, #8284
The simplest way I can think of to solve this issue. (There are short comings though)

1. It will still submit higher priority workflow but only the highest one first.
   i.e. current highest priority is 5 and there are jobs in 7,8,9 in the wmbs queue. It will submit priority 9 only then once 9 is done, 8, etc
2. Not all the jobs with 9 will be submitted. only 20% of current slot. (This can be increased) - maybe will make configurable.  