### PR TITLE
Make sure job splitting parameters are positive

### DIFF
--- a/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
+++ b/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
@@ -63,6 +63,10 @@ class EventAwareLumiBased(JobFactory):
 
         eventsPerLumiInDataset = 0
 
+        if avgEventsPerJob <= 0:
+            msg = "events_per_job parameter must be positive. Its value is: %d" % avgEventsPerJob
+            raise RuntimeError(msg)
+
         if self.package == 'WMCore.WMBS':
             self.loadRunLumi = self.daoFactory(classname="Files.GetBulkRunLumi")
             if deterministicPileup:

--- a/src/python/WMCore/JobSplitting/EventAwareLumiByWork.py
+++ b/src/python/WMCore/JobSplitting/EventAwareLumiByWork.py
@@ -76,6 +76,10 @@ class EventAwareLumiByWork(JobFactory):
         self.deterministicPU = kwargs.get('deterministicPileup', False)
         self.perfParameters = kwargs.get('performance', {})
 
+        if avgEventsPerJob <= 0:
+            msg = "events_per_job parameter must be positive. Its value is: %d" % avgEventsPerJob
+            raise RuntimeError(msg)
+
         # Set the lumi mask for the fileset based on ACDC or runs & lumis and/or runWhitelist
         lumiMask = LumiList()
         if self.collectionName:

--- a/src/python/WMCore/JobSplitting/EventBased.py
+++ b/src/python/WMCore/JobSplitting/EventBased.py
@@ -37,6 +37,11 @@ class EventBased(JobFactory):
         acdcFileList = []
         deterministicPileup = kwargs.get('deterministicPileup', False)
 
+        if eventsPerJob <= 0 or eventsPerLumi <= 0:
+            msg = "events_per_job and events_per_lumi must be positive. Their values are: "
+            msg += "events_per_job: %d, events_per_lumi: %d" % (eventsPerJob, eventsPerLumi)
+            raise RuntimeError(msg)
+
         if deterministicPileup and self.package == 'WMCore.WMBS':
             getJobNumber = self.daoFactory(classname="Jobs.GetNumberOfJobsPerWorkflow")
             self.nJobs = getJobNumber.execute(workflow=self.subscription.getWorkflow().id)

--- a/src/python/WMCore/JobSplitting/LumiBased.py
+++ b/src/python/WMCore/JobSplitting/LumiBased.py
@@ -162,6 +162,10 @@ class LumiBased(JobFactory):
         applyLumiCorrection = bool(kwargs.get('applyLumiCorrection', False))
         eventsPerLumiInDataset = 0
 
+        if lumisPerJob <= 0:
+            msg = "lumis_per_job parameter must be positive. Its value is: %d" % lumisPerJob
+            raise RuntimeError(msg)
+
         if self.package == 'WMCore.WMBS':
             self.loadRunLumi = self.daoFactory(classname="Files.GetBulkRunLumi")
             if deterministicPileup:


### PR DESCRIPTION
Fixes #8289

StdBase already validates these inputs and WMAgent should be safe.
However, adding another protection at the job splitting layer is not going to hurt and it will protect any other services importing these somehow generic job splitting algorithms