### PR TITLE
Drop bytes that cannot be encoded with utf-8

### DIFF
--- a/src/python/WMCore/Algorithms/BasicAlgos.py
+++ b/src/python/WMCore/Algorithms/BasicAlgos.py
@@ -59,22 +59,20 @@ def tail(filename, nLines = 20):
     A version of tail
     Adapted from code on http://stackoverflow.com/questions/136168/get-last-n-lines-of-a-file-with-python-similar-to-tail
     """
-    # make sure only valid utf8 encoded chars will be passed along
-    f = io.open(filename, 'r', encoding='utf8', errors='ignore')
-
     assert nLines >= 0
     pos, lines = nLines+1, []
-    while len(lines) <= nLines:
-        try:
-            f.seek(-pos, 2)
-        except IOError:
-            f.seek(0)
-            break
-        finally:
-            lines = list(f)
-        pos *= 2
 
-    f.close()
+    # make sure only valid utf8 encoded chars will be passed along
+    with io.open(filename, 'r', encoding='utf8', errors='ignore') as f:
+        while len(lines) <= nLines:
+            try:
+                f.seek(-pos, 2)
+            except IOError:
+                f.seek(0)
+                break
+            finally:
+                lines = list(f)
+            pos *= 2
 
     text = "".join(lines[-nLines:])
 
@@ -99,8 +97,11 @@ def getFileInfo(filename):
 
 def findMagicStr(filename, matchString):
     """
+    _findMagicStr_
+
+    Parse a log file looking for a pattern string
     """
-    with open(filename, 'r') as logfile:
+    with io.open(filename, 'r', encoding='utf8', errors='ignore') as logfile:
         # TODO: can we avoid reading the whole file
         for line in logfile:
             if matchString in line:

--- a/src/python/WMCore/Algorithms/BasicAlgos.py
+++ b/src/python/WMCore/Algorithms/BasicAlgos.py
@@ -9,9 +9,10 @@ Python implementations of basic Linux functionality
 import io
 import os
 import stat
+import subprocess
 import time
 import zlib
-import subprocess
+
 
 def calculateChecksums(filename):
     """
@@ -28,13 +29,13 @@ def calculateChecksums(filename):
     to calculate the adler32 checksum.
 
     """
-    adler32Checksum = 1 # adler32 of an empty string
-    cksumProcess = subprocess.Popen("cksum", stdin = subprocess.PIPE, stdout = subprocess.PIPE)
+    adler32Checksum = 1  # adler32 of an empty string
+    cksumProcess = subprocess.Popen("cksum", stdin=subprocess.PIPE, stdout=subprocess.PIPE)
 
     # the lambda basically creates an iterator function with zero
     # arguments that steps through the file in 4096 byte chunks
     with open(filename, 'rb') as f:
-        for chunk in iter((lambda:f.read(4096)),''):
+        for chunk in iter((lambda: f.read(4096)), ''):
             adler32Checksum = zlib.adler32(chunk, adler32Checksum)
             cksumProcess.stdin.write(chunk)
 
@@ -52,7 +53,7 @@ def calculateChecksums(filename):
     return ("%x" % (adler32Checksum & 0xffffffff), "%s" % cksumStdout[0])
 
 
-def tail(filename, nLines = 20):
+def tail(filename, nLines=20):
     """
     _tail_
 
@@ -60,7 +61,7 @@ def tail(filename, nLines = 20):
     Adapted from code on http://stackoverflow.com/questions/136168/get-last-n-lines-of-a-file-with-python-similar-to-tail
     """
     assert nLines >= 0
-    pos, lines = nLines+1, []
+    pos, lines = nLines + 1, []
 
     # make sure only valid utf8 encoded chars will be passed along
     with io.open(filename, 'r', encoding='utf8', errors='ignore') as f:
@@ -90,8 +91,8 @@ def getFileInfo(filename):
 
     fileInfo = {'Name': filename,
                 'Size': filestats[stat.ST_SIZE],
-                'LastModification': time.strftime("%m/%d/%Y %I:%M:%S %p",time.localtime(filestats[stat.ST_MTIME])),
-                'LastAccess': time.strftime("%m/%d/%Y %I:%M:%S %p",time.localtime(filestats[stat.ST_ATIME]))}
+                'LastModification': time.strftime("%m/%d/%Y %I:%M:%S %p", time.localtime(filestats[stat.ST_MTIME])),
+                'LastAccess': time.strftime("%m/%d/%Y %I:%M:%S %p", time.localtime(filestats[stat.ST_ATIME]))}
     return fileInfo
 
 

--- a/src/python/WMCore/JobStateMachine/SummaryDB.py
+++ b/src/python/WMCore/JobStateMachine/SummaryDB.py
@@ -71,7 +71,8 @@ def fwjr_parser(doc):
     pdict = dict(totalJobCPU=0, totalJobTime=0, totalEventCPU=0)
     ddict = {}
     for key, val in steps.items():
-        wrappedTotalJobTime += val['stop'] - val['start']
+        if val['stop'] is not None and val['start'] is not None:
+            wrappedTotalJobTime += val['stop'] - val['start']
         site_name = val['site']
         site_summary = dict(wrappedTotalJobTime=wrappedTotalJobTime,
                             inputEvents=0, dataset=ddict,

--- a/src/python/WMCore/JobStateMachine/SummaryDB.py
+++ b/src/python/WMCore/JobStateMachine/SummaryDB.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-#-*- coding: utf-8 -*-
-#pylint: disable=
+# -*- coding: utf-8 -*-
+# pylint: disable=
 """
 File       : SummaryDB.py
 Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
@@ -10,7 +10,9 @@ Description: Set of modules/functions to update WMAgent SummaryDB.
 # system modules
 import logging
 from pprint import pformat
+
 from WMCore.Database.CMSCouch import CouchNotFoundError
+
 
 def fwjr_parser(doc):
     """
@@ -44,9 +46,9 @@ def fwjr_parser(doc):
     # In that case it shouldn't crash but move on.
     dataCollectedFlag = False
 
-    if  'fwjr' in doc:
+    if 'fwjr' in doc:
         fwjr = doc['fwjr']
-        if  not isinstance(fwjr, dict):
+        if not isinstance(fwjr, dict):
             fwjr = fwjr.__to_json__(None)
     else:
         raise Exception('Document does not contain FWJR part')
@@ -65,7 +67,7 @@ def fwjr_parser(doc):
         if not stepName.startswith('logArch') and fwjr['steps'][stepName]['status'] != 0:
             return dataCollectedFlag
 
-    sdict = {} # all sites summary
+    sdict = {}  # all sites summary
     steps = fwjr['steps']
     wrappedTotalJobTime = 0
     pdict = dict(totalJobCPU=0, totalJobTime=0, totalEventCPU=0)
@@ -77,7 +79,7 @@ def fwjr_parser(doc):
         site_summary = dict(wrappedTotalJobTime=wrappedTotalJobTime,
                             inputEvents=0, dataset=ddict,
                             cmsRunCPUPerformance=pdict)
-        if  key.startswith('cmsRun'):
+        if key.startswith('cmsRun'):
             perf = val['performance']
             pdict['totalJobCPU'] += float(perf['cpu']['TotalJobCPU'])
             pdict['totalJobTime'] += float(perf['cpu']['TotalJobTime'])
@@ -89,22 +91,22 @@ def fwjr_parser(doc):
             odict = val['output']
             for kkk, vvv in odict.items():
                 for row in vvv:
-                    if  row.get('merged', False):
+                    if row.get('merged', False):
                         prim = row['dataset']['primaryDataset']
                         proc = row['dataset']['processedDataset']
                         tier = row['dataset']['dataTier']
                         dataset = '/%s/%s/%s' % (prim, proc, tier)
                         totalLumis = sum([len(r) for r in row['runs'].values()])
                         dataset_summary = \
-                                dict(size=row['size'], events=row['events'], totalLumis=totalLumis)
+                            dict(size=row['size'], events=row['events'], totalLumis=totalLumis)
                         ddict[dataset] = dataset_summary
-            if  ddict: # if we got dataset summary
+            if ddict:  # if we got dataset summary
                 site_summary.update({'dataset': ddict})
 
             idict = val.get('input', {})
-            if  idict:
+            if idict:
                 source = idict.get('source', {})
-                if  isinstance(source, list):
+                if isinstance(source, list):
                     for item in source:
                         site_summary['inputEvents'] += item.get('events', 0)
                 else:
@@ -119,47 +121,50 @@ def fwjr_parser(doc):
     else:
         return dataCollectedFlag
 
+
 def merge_docs(doc1, doc2):
     "Merge two summary documents use dict in place strategy"
     for key in ['_id', '_rev']:
-        if  key in doc1:
+        if key in doc1:
             del doc1[key]
-        if  key in doc2:
+        if key in doc2:
             del doc2[key]
     for key, val in doc1.items():
-        if  key not in doc2:
+        if key not in doc2:
             return False
         if isinstance(val, dict):
-            if  not merge_docs(doc1[key], doc2[key]):
+            if not merge_docs(doc1[key], doc2[key]):
                 return False
         else:
             doc1[key] += doc2[key]
     return True
 
+
 def update_tasks(old_tasks, new_tasks):
     "Update tasks dictionaries"
     for task, tval in new_tasks.items():
-        if  task in old_tasks:
+        if task in old_tasks:
             for site, sval in tval['sites'].items():
-                if  site in old_tasks[task]['sites']:
+                if site in old_tasks[task]['sites']:
                     old_sdict = old_tasks[task]['sites'][site]
                     new_sdict = sval
                     status = merge_docs(old_sdict, new_sdict)
-                    if  not status:
-                        logging.error("Error merge_docs:\n%s\n%s\n" % (pformat(old_sdict),
-                                                                     pformat(new_sdict)))
+                    if not status:
+                        logging.error("Error merge_docs:\n%s\n%s\n", pformat(old_sdict),
+                                      pformat(new_sdict))
                 else:
-                    old_tasks[task]['sites'].update({site:sval})
+                    old_tasks[task]['sites'].update({site: sval})
         else:
             old_tasks.update({task: tval})
     return old_tasks
+
 
 def updateSummaryDB(sumdb, document):
     "Update summary DB with given document"
     # parse input doc and create summary doc
     sum_doc = fwjr_parser(document)
     # check if DB has FWJR statistics
-    if sum_doc == False:
+    if sum_doc is False:
         return False
 
     try:
@@ -174,12 +179,10 @@ def updateSummaryDB(sumdb, document):
         combinedDoc = {'_id': sum_doc['_id'], 'tasks': tasks}
         resp = sumdb.updateDocument(sum_doc['_id'], "SummaryStats",
                                     "genericUpdate",
-                                    fields = combinedDoc,
-                                    useBody = True)
-        #TODO: check response whether update successfull or not
+                                    fields=combinedDoc,
+                                    useBody=True)
+        # TODO: check response whether update successfull or not
         return True
-    except Exception as ex:
-        import traceback
-        logging.error("Error fetching summary doc %s: %s" % (
-                                    sum_doc['_id'], traceback.format_exc()))
+    except Exception:
+        logging.exception("Error fetching summary doc %s:", sum_doc['_id'])
         return False


### PR DESCRIPTION
Fixes #8056
Replaces #8057

I think `findMagicStr` method is the reason why we started seeing these problems again, since it does not drop bytes that it cannot encode.