### PR TITLE
Temporary fix for sites with multi-pnns

### DIFF
--- a/bin/wmagent-resource-control
+++ b/bin/wmagent-resource-control
@@ -315,6 +315,9 @@ else:
                  options.pendingSlots, options.runningSlots, state=options.state)
     elif options.addAllSites == True:
         allSites = getCMSSiteInfo("*")
+        # FIXME temporary fix while #8280 doesn't get merged
+        allSites.pop('T3_UK_London_QMUL', None)
+        allSites.pop('T3_UK_ScotGrid_GLA', None)
         addSites(myResourceControl, allSites, options.ceName, options.plugin,
                  options.pendingSlots, options.runningSlots, state=options.state)
     elif options.addOneSite:


### PR DESCRIPTION
1.1.6 wmagent branch workaround for T3_UK multi-pnn sites.
@ticoann can you port it to the new wmagent branch (1.1.8_wmagent?) once that's created?