### PR TITLE
Update deploy script to support patching non-standard locations

### DIFF
--- a/bin/deploy-wmagent.sh
+++ b/bin/deploy-wmagent.sh
@@ -207,6 +207,13 @@ for step in prep sw post; do
 done
 set +e
 
+# XXX: update the PR number below, if needed :-)
+echo -e "\n*** Applying database schema patches ***"
+cd $CURRENT
+#  wget -nv https://github.com/dmwm/WMCore/pull/8315.patch -O - | patch -d apps/wmagent/bin -p 2
+cd -
+echo "Done!" && echo
+
 echo -e "\n*** Activating the agent ***"
 cd $MANAGE
 ./manage activate-agent


### PR DESCRIPTION
Since I had to do it a few times already, I decided to put this placeholder for patching files in a non-standard location (basically different than src/python).

We usually don't use it, that's why I left it there hardcoded. But if you Seangchan think it's better to create a new option for this script, that's fine with me too.