### PR TITLE
Overwrite default WMAgent config couch doc

### DIFF
--- a/bin/wmagent-upload-config
+++ b/bin/wmagent-upload-config
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 from __future__ import division, print_function
+
 import os
 from pprint import pformat
+
 from WMCore.Agent.DefaultConfig import DEFAULT_AGENT_CONFIG
 from WMCore.Configuration import loadConfigurationFile
 from WMCore.Services.ReqMgrAux.ReqMgrAux import ReqMgrAux

--- a/bin/wmagent-upload-config
+++ b/bin/wmagent-upload-config
@@ -1,17 +1,24 @@
 #!/usr/bin/env python
 from __future__ import division, print_function
 import os
+from pprint import pformat
 from WMCore.Agent.DefaultConfig import DEFAULT_AGENT_CONFIG
 from WMCore.Configuration import loadConfigurationFile
 from WMCore.Services.ReqMgrAux.ReqMgrAux import ReqMgrAux
 
-def insertWMAgentConfig(reqmgrURL, hostName, agentConfig):
-    reqMgrAux = ReqMgrAux(reqmgrURL)
-    reqMgrAux.postWMAgentConfig(wmConfig.Agent.hostName, agentConfig)
+
+def insertWMAgentConfig(reqMgrAux, agentName, agentConfig):
+    print("Uploading agent configuration to ReqMgrAux. Data is\n%s" % pformat(agentConfig))
+    reqMgrAux.postWMAgentConfig(agentName, agentConfig)
+
+
+def removeWMAgentConfig(reqMgrAux, agentName):
+    reqMgrAux.deleteWMAgentConfig(agentName)
+
 
 if __name__ == "__main__":
     wmConfig = loadConfigurationFile(os.environ['WMAGENT_CONFIG'])
-    
-    insertWMAgentConfig(wmConfig.General.ReqMgr2ServiceURL,
-                        wmConfig.Agent.hostName, DEFAULT_AGENT_CONFIG)
-    
+    reqMgrAux = ReqMgrAux(wmConfig.General.ReqMgr2ServiceURL)
+
+    removeWMAgentConfig(reqMgrAux, wmConfig.Agent.hostName)
+    insertWMAgentConfig(reqMgrAux, wmConfig.Agent.hostName, DEFAULT_AGENT_CONFIG)

--- a/src/python/WMCore/ReqMgr/Service/Auxiliary.py
+++ b/src/python/WMCore/ReqMgr/Service/Auxiliary.py
@@ -7,15 +7,15 @@ Teams, Groups, Software versions handling for ReqMgr.
 from __future__ import print_function, division
 
 import json
+
 import cherrypy
 
 import WMCore
 from WMCore.Database.CMSCouch import Document, CouchNotFoundError, CouchError
+from WMCore.REST.Error import RESTError, NoSuchInstance, APINotSpecified
+from WMCore.REST.Format import JSONFormat, PrettyJSONFormat
 from WMCore.REST.Server import RESTEntity, restcall, rows
 from WMCore.REST.Tools import tools
-from WMCore.REST.Format import JSONFormat, PrettyJSONFormat
-from WMCore.REST.Error import RESTError, NoSuchInstance, APINotSpecified
-
 from WMCore.ReqMgr.DataStructs.ReqMgrConfigDataCache import ReqMgrConfigDataCache
 
 
@@ -28,10 +28,12 @@ class MissingPostData(RESTError):
         RESTError.__init__(self)
         self.message = "Empty data has passed"
 
+
 class Info(RESTEntity):
     """
     general information about reqmgr2, i.e. version, etc
     """
+
     def __init__(self, app, api, config, mount):
         RESTEntity.__init__(self, app, api, config, mount)
         self.reqmgr_db = api.db_handler.get_db(config.couch_reqmgr_db)
@@ -39,7 +41,6 @@ class Info(RESTEntity):
 
     def validate(self, apiobj, method, api, param, safe):
         pass
-
 
     @restcall
     @tools.expires(secs=-1)
@@ -49,11 +50,11 @@ class Info(RESTEntity):
         # from HTTP headers. CMS web frontend puts this information into
         # headers as read from SiteDB (or on private VM from a fake
         # SiteDB file)
-#        print "cherrypy.request", cherrypy.request
-#        print "DN: %s" % cherrypy.request.user['dn']
-#        print "Requestor/login: %s" % cherrypy.request.user['login']
-#        print "cherrypy.request: %s" % cherrypy.request
-#        print "cherrypy.request.user: %s" % cherrypy.request.user
+        #        print "cherrypy.request", cherrypy.request
+        #        print "DN: %s" % cherrypy.request.user['dn']
+        #        print "Requestor/login: %s" % cherrypy.request.user['login']
+        #        print "cherrypy.request: %s" % cherrypy.request
+        #        print "cherrypy.request.user: %s" % cherrypy.request.user
         # from WMCore.REST.Auth import authz_match
         # authz_match(role=["Global Admin"], group=["global"])
         # check SiteDB/DataWhoAmI.py
@@ -80,7 +81,6 @@ class Info(RESTEntity):
 
 
 class ReqMgrConfigData(RESTEntity):
-
     def __init__(self, app, api, config, mount):
         # CouchDB auxiliary database name
         RESTEntity.__init__(self, app, api, config, mount)
@@ -108,7 +108,7 @@ class ReqMgrConfigData(RESTEntity):
 
         if data:
             config_args = json.loads(data)
-            #TODO need to validate the args depending on the config
+            # TODO need to validate the args depending on the config
             safe.kwargs["config_dict"] = config_args
 
     def validate(self, apiobj, method, api, param, safe):
@@ -124,21 +124,22 @@ class ReqMgrConfigData(RESTEntity):
         elif method == "PUT":
             self._validate_put_args(param, safe)
 
-    @restcall(formats = [('text/plain', PrettyJSONFormat()), ('application/json', JSONFormat())])
+    @restcall(formats=[('text/plain', PrettyJSONFormat()), ('application/json', JSONFormat())])
     def get(self, doc_name):
         """
         """
         config = ReqMgrConfigDataCache.getConfig(doc_name)
         return rows([config])
 
-    @restcall(formats = [('text/plain', PrettyJSONFormat()), ('application/json', JSONFormat())])
-    def put(self, doc_name, config_dict = None):
+    @restcall(formats=[('text/plain', PrettyJSONFormat()), ('application/json', JSONFormat())])
+    def put(self, doc_name, config_dict=None):
         """
         """
         if doc_name == "DEFAULT":
             return ReqMgrConfigDataCache.putDefaultConfig()
         else:
             return ReqMgrConfigDataCache.replaceConfig(doc_name, config_dict)
+
 
 class AuxBaseAPI(RESTEntity):
     """
@@ -150,11 +151,10 @@ class AuxBaseAPI(RESTEntity):
         # CouchDB auxiliary database name
         self.reqmgr_aux_db = api.db_handler.get_db(config.couch_reqmgr_aux_db)
         self.setName()
-    
+
     def setName(self):
         "Sets the document name"
         raise NotImplementedError("Couch document id(name) should be specified. i.e. self.name='software'")
-
 
     def validate(self, apiobj, method, api, param, safe):
         args_length = len(param.args)
@@ -162,7 +162,6 @@ class AuxBaseAPI(RESTEntity):
             safe.kwargs["subName"] = param.args.pop(0)
             return
         return
-
 
     @restcall(formats=[('text/plain', PrettyJSONFormat()), ('application/json', JSONFormat())])
     def get(self, subName=None):
@@ -180,9 +179,9 @@ class AuxBaseAPI(RESTEntity):
             del sw["_rev"]
         except CouchNotFoundError:
             raise NoSuchInstance
-            
+
         return rows([sw])
-    
+
     @restcall(formats=[('application/json', JSONFormat())])
     def post(self, subName=None):
         """
@@ -248,6 +247,7 @@ class CMSSWVersions(AuxBaseAPI):
     CMSSWVersions - handle CMSSW versions and scram architectures.
     Stored in stored in the ReqMgr reqmgr_auxiliary database,
     """
+
     def setName(self):
         self.name = "CMSSW_VERSIONS"
 
@@ -256,12 +256,15 @@ class WMAgentConfig(AuxBaseAPI):
     """
     Config which used for Agent
     """
+
     def setName(self):
         self.name = "WMAGENT_CONFIG"
+
 
 class PermissionsConig(AuxBaseAPI):
     """
     Pemissions' config for REST call, i.e. certain group and role can only update specific data.
     """
+
     def setName(self):
         self.name = "PERMISSION_BY_REQUEST_TYPE"

--- a/src/python/WMCore/Services/ReqMgrAux/ReqMgrAux.py
+++ b/src/python/WMCore/Services/ReqMgrAux/ReqMgrAux.py
@@ -99,8 +99,15 @@ class ReqMgrAux(Service):
         return agentConfig[0]
 
     def postWMAgentConfig(self, agentName, agentConfig):
-
+        """
+        Create a new WMAgent configuration file in ReqMgrAux.
+        If document already exists, nothing happens.
+        """
         return self["requests"].post('wmagentconfig/%s' % agentName, agentConfig)[0]['result']
+
+    def deleteWMAgentConfig(self, agentName):
+        """Mind your own business. Delete the agent config from ReqMgrAux"""
+        self["requests"].delete('wmagentconfig/%s' % agentName)
 
     def updateAgentDrainingMode(self, agentName, drainFlag):
         # update config DB

--- a/src/python/WMCore/Services/ReqMgrAux/ReqMgrAux.py
+++ b/src/python/WMCore/Services/ReqMgrAux/ReqMgrAux.py
@@ -4,14 +4,16 @@ import json
 import logging
 
 from Utils.Utilities import diskUse
-from WMCore.Services.Service import Service
 from WMCore.Cache.GenericDataCache import MemoryCacheStruct
+from WMCore.Services.Service import Service
+
 
 class ReqMgrAux(Service):
     """
     API for dealing with retrieving information from RequestManager dataservice
 
     """
+
     def __init__(self, url, header=None, logger=None):
         """
         responseType will be either xml or json
@@ -55,7 +57,7 @@ class ReqMgrAux(Service):
 
     def _getDataFromMemoryCache(self, callname):
         cache = MemoryCacheStruct(expire=0, func=self._getResult, initCacheValue={},
-                                 kwargs={'callname': callname, "verb": "GET"})
+                                  kwargs={'callname': callname, "verb": "GET"})
         return cache.getData()
 
     def getCMSSWVersion(self):
@@ -118,10 +120,12 @@ class ReqMgrAux(Service):
             return True
         else:
             self["logger"].warning("update agent drain mode failed: it should be %s, response: %s" %
-                                (drainFlag, resp))
+                                   (drainFlag, resp))
             return False
 
+
 AUXDB_AGENT_CONFIG_CACHE = {}
+
 
 # function to check whether agent is should be in draining status.
 def isDrainMode(config):
@@ -142,6 +146,7 @@ def isDrainMode(config):
     else:
         # if the cache is empty this will raise Key not exist exception.
         return AUXDB_AGENT_CONFIG_CACHE["UserDrainMode"] or AUXDB_AGENT_CONFIG_CACHE["AgentDrainMode"]
+
 
 def listDiskUsageOverThreshold(config, updateDB):
     """
@@ -171,7 +176,7 @@ def listDiskUsageOverThreshold(config, updateDB):
     overThresholdDisks = []
     for disk in diskUseList:
         if (float(disk['percent'].strip('%')) >= diskUseThreshold and
-                        disk['mounted'] not in ignoredDisks):
+                    disk['mounted'] not in ignoredDisks):
             overThresholdDisks.append(disk)
 
     if updateDB and not t0Flag:


### PR DESCRIPTION
Fixes #8350

Changes are:
* the script run during the deployment, will first try to remove the agent couch doc, then it uploads a new one
* if one uses the post method to upload a document that already exists, nothing happens
* if one uses the put method, then it updates the couch doc properties (like a dict.update)