### PR TITLE
Added WorkerThreads.testWorkerError to unstable tests

### DIFF
--- a/test/etc/UnstableTests.txt
+++ b/test/etc/UnstableTests.txt
@@ -19,3 +19,4 @@ WMCore_t.WorkQueue_t.WorkQueue_t.WorkQueueTest:test0eventBlock
 WMCore_t.WorkQueue_t.WorkQueue_t.WorkQueueTest:testPrioritiesWorkPolling
 WMCore_t.Services_t.pycurlFileUpload_t.PyCurlRESTServer:testFailingFileUpload
 WMCore_t.Services_t.LogDB_t.LogDB_t.LogDBTest:test_heartbeat
+WMCore_t.WorkerThreads_t.WorkerThreads_t.WorkerThreadsTest:testWorkerError


### PR DESCRIPTION
Fixes #4294

I didn't manage to reproduce any errors neither on mysql nor on oracle backends (and I ran tests around 10 times!). I'm marking this test as unstable because I think it's worthy to keep it running in jenkins (and I'll touch that code soon :))