### PR TITLE
Skip heartbeat update failures; support diff hearbeat timeout per worker

### DIFF
--- a/src/python/WMCore/Agent/Database/CreateAgentBase.py
+++ b/src/python/WMCore/Agent/Database/CreateAgentBase.py
@@ -5,21 +5,16 @@ Base class for creating the WMBS database.
 """
 from __future__ import print_function
 
-
-
-
 import threading
 
 from WMCore.Database.DBCreator import DBCreator
-
 from WMCore.WMException import WMException
-from WMCore.WMExceptions import WMEXCEPTION
+
 
 class CreateAgentBase(DBCreator):
-
     requiredTables = ["01wm_components", "02wm_workers"]
 
-    def __init__(self, logger = None, dbi = None, params = None):
+    def __init__(self, logger=None, dbi=None, params=None):
         """
         _init_
 
@@ -27,9 +22,9 @@ class CreateAgentBase(DBCreator):
         """
         myThread = threading.currentThread()
 
-        if logger == None:
+        if logger is None:
             logger = myThread.logger
-        if dbi == None:
+        if dbi is None:
             dbi = myThread.dbi
 
         tablespaceTable = ""
@@ -43,32 +38,32 @@ class CreateAgentBase(DBCreator):
         DBCreator.__init__(self, logger, dbi)
 
         self.create["01wm_components"] = \
-          """CREATE TABLE wm_components (
-             id               INTEGER      PRIMARY KEY AUTO_INCREMENT,
-             name             VARCHAR(255) NOT NULL,
-             pid              INTEGER      NOT NULL,
-             update_threshold INTEGER      NOT NULL,
-             UNIQUE (name))"""
+            """CREATE TABLE wm_components (
+               id               INTEGER      PRIMARY KEY AUTO_INCREMENT,
+               name             VARCHAR(255) NOT NULL,
+               pid              INTEGER      NOT NULL,
+               update_threshold INTEGER      NOT NULL,
+               UNIQUE (name))"""
 
         self.create["02wm_workers"] = \
-          """CREATE TABLE wm_workers (
-             component_id  INTEGER NOT NULL,
-             name          VARCHAR(255) NOT NULL,
-             last_updated  INTEGER      NOT NULL,
-             state         VARCHAR(255),
-             pid           INTEGER,
-             poll_interval INTEGER      NOT NULL,
-             last_error    INTEGER,
-             cycle_time    FLOAT DEFAULT 0 NOT NULL,
-             outcome       VARCHAR(1000),
-             error_message VARCHAR(1000),
-             UNIQUE (name))"""
+            """CREATE TABLE wm_workers (
+               component_id  INTEGER NOT NULL,
+               name          VARCHAR(255) NOT NULL,
+               last_updated  INTEGER      NOT NULL,
+               state         VARCHAR(255),
+               pid           INTEGER,
+               poll_interval INTEGER      NOT NULL,
+               last_error    INTEGER,
+               cycle_time    FLOAT DEFAULT 0 NOT NULL,
+               outcome       VARCHAR(1000),
+               error_message VARCHAR(1000),
+               UNIQUE (name))"""
 
         self.constraints["FK_wm_component_worker"] = \
-              """ALTER TABLE wm_workers ADD CONSTRAINT FK_wm_component_worker
-                 FOREIGN KEY(component_id) REFERENCES wm_components(id)"""
+            """ALTER TABLE wm_workers ADD CONSTRAINT FK_wm_component_worker
+               FOREIGN KEY(component_id) REFERENCES wm_components(id)"""
 
-    def execute(self, conn = None, transaction = None):
+    def execute(self, conn=None, transaction=None):
         """
         _execute_
 

--- a/src/python/WMCore/Agent/Database/CreateAgentBase.py
+++ b/src/python/WMCore/Agent/Database/CreateAgentBase.py
@@ -59,10 +59,10 @@ class CreateAgentBase(DBCreator):
              pid           INTEGER,
              poll_interval INTEGER      NOT NULL,
              last_error    INTEGER,
-             cycle_time    DECIMAL(9,4) DEFAULT 0 NOT NULL,
+             cycle_time    FLOAT DEFAULT 0 NOT NULL,
              outcome       VARCHAR(1000),
              error_message VARCHAR(1000),
-             UNIQUE (component_id, name))"""
+             UNIQUE (name))"""
 
         self.constraints["FK_wm_component_worker"] = \
               """ALTER TABLE wm_workers ADD CONSTRAINT FK_wm_component_worker

--- a/src/python/WMCore/Agent/Database/MySQL/GetHeartbeatInfo.py
+++ b/src/python/WMCore/Agent/Database/MySQL/GetHeartbeatInfo.py
@@ -7,12 +7,10 @@ the component name passed in.
 
 __all__ = []
 
-
-
 from WMCore.Database.DBFormatter import DBFormatter
 
-class GetHeartbeatInfo(DBFormatter):
 
+class GetHeartbeatInfo(DBFormatter):
     sql = """SELECT comp.name as name, comp.pid, worker.name as worker_name,
                     worker.state, worker.last_updated, comp.update_threshold,
                     worker.poll_interval, worker.cycle_time, worker.outcome,
@@ -23,9 +21,9 @@ class GetHeartbeatInfo(DBFormatter):
              ORDER BY worker.last_updated ASC
              """
 
-    def execute(self, compName, conn = None, transaction = False):
+    def execute(self, compName, conn=None, transaction=False):
         bind = {"component_name": compName}
 
-        result = self.dbi.processData(self.sql, bind, conn = conn,
-                             transaction = transaction)
+        result = self.dbi.processData(self.sql, bind, conn=conn,
+                                      transaction=transaction)
         return self.formatDict(result)

--- a/src/python/WMCore/Agent/Database/MySQL/GetHeartbeatInfo.py
+++ b/src/python/WMCore/Agent/Database/MySQL/GetHeartbeatInfo.py
@@ -1,7 +1,8 @@
 """
 _GetHeartbeatInfo_
 
-MySQL implementation of GetHeartbeatInfo
+Fetches the hearbeat info for all worker threads associated to
+the component name passed in.
 """
 
 __all__ = []
@@ -18,15 +19,13 @@ class GetHeartbeatInfo(DBFormatter):
                     worker.last_error, worker.error_message
              FROM wm_workers worker
              INNER JOIN wm_components comp ON comp.id = worker.component_id
-             INNER JOIN (SELECT component_id, MAX(last_updated) AS last_updated FROM wm_workers
-                         GROUP BY component_id) max_result
-                        ON (worker.last_updated = max_result.last_updated
-                           AND max_result.component_id = comp.id)
+             WHERE comp.name = :component_name
              ORDER BY worker.last_updated ASC
              """
 
-    def execute(self, conn = None, transaction = False):
+    def execute(self, compName, conn = None, transaction = False):
+        bind = {"component_name": compName}
 
-        result = self.dbi.processData(self.sql, conn = conn,
+        result = self.dbi.processData(self.sql, bind, conn = conn,
                              transaction = transaction)
         return self.formatDict(result)

--- a/src/python/WMCore/Agent/Database/MySQL/InsertComponent.py
+++ b/src/python/WMCore/Agent/Database/MySQL/InsertComponent.py
@@ -23,7 +23,7 @@ class InsertComponent(DBFormatter):
     sql = """INSERT INTO wm_components (name, pid, update_threshold)
              VALUES (:name, :pid, :update_threshold)"""
 
-    def execute(self, name, pid, update_threshold = 7200,
+    def execute(self, name, pid, update_threshold,
                 conn = None, transaction = False):
         deleteBinds = {"name": name}
 

--- a/src/python/WMCore/Agent/Database/MySQL/InsertComponent.py
+++ b/src/python/WMCore/Agent/Database/MySQL/InsertComponent.py
@@ -6,12 +6,10 @@ MySQL implementation of Block.New
 
 __all__ = []
 
-
-
 from WMCore.Database.DBFormatter import DBFormatter
 
-class InsertComponent(DBFormatter):
 
+class InsertComponent(DBFormatter):
     deleteWorkerSql = """DELETE FROM wm_workers
                             WHERE component_id = (SELECT id FROM wm_components
                                    WHERE name = :name)
@@ -24,14 +22,14 @@ class InsertComponent(DBFormatter):
              VALUES (:name, :pid, :update_threshold)"""
 
     def execute(self, name, pid, update_threshold,
-                conn = None, transaction = False):
+                conn=None, transaction=False):
         deleteBinds = {"name": name}
 
-        self.dbi.processData(self.deleteWorkerSql, deleteBinds, conn = conn,
-                             transaction = transaction)
-        self.dbi.processData(self.deleteSql, deleteBinds, conn = conn,
-                             transaction = transaction)
+        self.dbi.processData(self.deleteWorkerSql, deleteBinds, conn=conn,
+                             transaction=transaction)
+        self.dbi.processData(self.deleteSql, deleteBinds, conn=conn,
+                             transaction=transaction)
         binds = {"name": name, "pid": pid, "update_threshold": update_threshold}
-        self.dbi.processData(self.sql, binds, conn = conn,
-                             transaction = transaction)
+        self.dbi.processData(self.sql, binds, conn=conn,
+                             transaction=transaction)
         return

--- a/src/python/WMCore/Agent/Database/MySQL/UpdateWorker.py
+++ b/src/python/WMCore/Agent/Database/MySQL/UpdateWorker.py
@@ -16,24 +16,21 @@ class UpdateWorker(DBFormatter):
     sqlpart1 = """UPDATE wm_workers
                       SET last_updated = :last_updated
                """
-    sqlpart3 = """ WHERE component_id = :component_id
-                   AND name = :worker_name"""
+    sqlpart3 = """ WHERE name = :worker_name"""
 
-    def execute(self, componentID, workerName, state = None, timeSpent=None,
+    def execute(self, workerName, state = None, timeSpent=None,
                 results=None, conn = None, transaction = False):
 
-        binds = {"component_id": componentID,
-                 "worker_name": workerName,
+        binds = {"worker_name": workerName,
                  "last_updated": int(time.time())}
 
         sqlpart2 = ""
         if state:
             binds["state"] = state
             sqlpart2 += ", state = :state"
-        if timeSpent:
+        if timeSpent is not None:
             binds["cycle_time"] = timeSpent
             sqlpart2 += ", cycle_time = :cycle_time"
-        if results:
             binds["outcome"] = results
             sqlpart2 += ", outcome = :outcome"
 

--- a/src/python/WMCore/Agent/Database/MySQL/UpdateWorker.py
+++ b/src/python/WMCore/Agent/Database/MySQL/UpdateWorker.py
@@ -6,20 +6,19 @@ MySQL implementation of UpdateWorker
 
 __all__ = []
 
-
-
 import time
+
 from WMCore.Database.DBFormatter import DBFormatter
 
-class UpdateWorker(DBFormatter):
 
+class UpdateWorker(DBFormatter):
     sqlpart1 = """UPDATE wm_workers
                       SET last_updated = :last_updated
                """
     sqlpart3 = """ WHERE name = :worker_name"""
 
-    def execute(self, workerName, state = None, timeSpent=None,
-                results=None, conn = None, transaction = False):
+    def execute(self, workerName, state=None, timeSpent=None,
+                results=None, conn=None, transaction=False):
 
         binds = {"worker_name": workerName,
                  "last_updated": int(time.time())}
@@ -36,6 +35,6 @@ class UpdateWorker(DBFormatter):
 
         sql = self.sqlpart1 + sqlpart2 + self.sqlpart3
 
-        self.dbi.processData(sql, binds, conn = conn,
-                             transaction = transaction)
+        self.dbi.processData(sql, binds, conn=conn,
+                             transaction=transaction)
         return

--- a/src/python/WMCore/Agent/HeartbeatAPI.py
+++ b/src/python/WMCore/Agent/HeartbeatAPI.py
@@ -17,15 +17,23 @@ class HeartbeatAPI(WMConnectionBase):
     """
     Generic methods used by all of the WMBS classes.
     """
-    def __init__(self, componentName, pollInterval=None, logger=None, dbi=None):
+    def __init__(self, componentName, pollInterval=None, heartbeatTimeout=7200,
+                 logger=None, dbi=None):
         """
         ___init___
 
         Initialize all the database connection attributes and the logging
-        attritbutes.  Create a DAO factory for WMCore.WorkQueue as well. Finally,
-        check to see if a transaction object has been created.  If none exists,
-        create one but leave the transaction closed.
+        attributes.
+        Every worker has a different instance of this class, thus they can have
+        a different polling interval and a different heartbeat timeout.
+        Finally, check to see if a transaction object has been created.
+        If none exists, create one but leave the transaction closed.
         """
+        self.componentName = componentName
+        self.pollInterval = pollInterval
+        self.heartbeatTimeout = heartbeatTimeout or 7200
+        self.compId = os.getpid()
+
         WMConnectionBase.__init__(self, daoPackage = "WMCore.Agent.Database",
                                   logger = logger, dbi = dbi)
 
@@ -37,15 +45,23 @@ class HeartbeatAPI(WMConnectionBase):
         self.getHeartbeat = self.daofactory(classname = "GetHeartbeatInfo")
         self.getAllHeartbeat = self.daofactory(classname = "GetAllHeartbeatInfo")
 
-        self.componentName = componentName
-        self.pid = os.getpid()
-        self.pollInterval = pollInterval
-
     def registerComponent(self):
+        """
+        Deletes any leftover for a component with the same name and then
+        inserts it again with a new PID into wm_components table
+        """
+        self.insertComp.execute(self.componentName, self.compId, self.heartbeatTimeout,
+                                conn = self.getDBConn(), transaction = self.existingTransaction())
 
-        self.insertComp.execute(self.componentName, self.pid,
-                             conn = self.getDBConn(),
-                             transaction = self.existingTransaction())
+    def registerWorker(self, workerName, state="Start"):
+        """
+        Inserts a worker thread into the database, setting an initial state
+        and a polling cycle.
+        """
+        self.insertWorker.execute(self.componentName, workerName, state,
+                                  self.compId, self.pollInterval, cycleTime=0,
+                                  conn=self.getDBConn(),
+                                  transaction=self.existingTransaction())
 
     def getComponentID(self, workerName):
         """Retrieve the component_id from the workers table"""
@@ -55,32 +71,22 @@ class HeartbeatAPI(WMConnectionBase):
                                                transaction = self.existingTransaction())
         return componentID
 
-    def updateWorkerHeartbeat(self, workerName, state = "Start", pid = None, pollInt=None, timeSpent=None):
+    def updateWorkerHeartbeat(self, workerName, state):
         """
-        Update a worker's heartbeat. If it still doesn't exist, then add it
-        with Start state.
+        Update a worker's heartbeat and its state
         """
-        componentID = self.getComponentID(workerName)
-
-        if not componentID:
-            pid = pid or self.pid
-            pollInt = pollInt or self.pollInterval
-            self.insertWorker.execute(self.componentName, workerName, state, pid, pollInt, cycleTime=0,
-                           conn = self.getDBConn(),
-                           transaction = self.existingTransaction())
-        else:
-            self.updateWorker.execute(componentID, workerName, state, timeSpent,
-                           conn = self.getDBConn(),
-                           transaction = self.existingTransaction())
+        try:
+            self.updateWorker.execute(workerName, state, conn = self.getDBConn(),
+                                      transaction = self.existingTransaction())
+        except Exception as ex:
+            logging.warning("Heartbeat update failed! Wait for the next time...:\n%s", str(ex))
 
     def updateWorkerCycle(self, workerName, timeSpent, results):
         """
-        Update an already registered worker thread with the time it spent running
-        the main algorithm call. It's state is unchanged.
+        Update a worker's heartbeat as well as the time spent on that
+        cycle and any results returned.
         """
-        componentID = self.getComponentID(workerName)
-
-        self.updateWorker.execute(componentID, workerName, "Running", timeSpent, results,
+        self.updateWorker.execute(workerName, "Running", timeSpent, results,
                                   conn = self.getDBConn(),
                                   transaction = self.existingTransaction())
 
@@ -92,7 +98,7 @@ class HeartbeatAPI(WMConnectionBase):
 
     def getHeartbeatInfo(self):
 
-        results = self.getHeartbeat.execute(conn = self.getDBConn(),
+        results = self.getHeartbeat.execute(self.componentName, conn = self.getDBConn(),
                                             transaction = self.existingTransaction())
 
         return results

--- a/src/python/WMCore/Agent/HeartbeatAPI.py
+++ b/src/python/WMCore/Agent/HeartbeatAPI.py
@@ -4,19 +4,16 @@ _HartbeatAPI_
 A simple object representing a file in WMBS.
 """
 
-
-
-
-import threading
 import os
-import logging
 
 from WMCore.WMConnectionBase import WMConnectionBase
+
 
 class HeartbeatAPI(WMConnectionBase):
     """
     Generic methods used by all of the WMBS classes.
     """
+
     def __init__(self, componentName, pollInterval=None, heartbeatTimeout=7200,
                  logger=None, dbi=None):
         """
@@ -34,16 +31,16 @@ class HeartbeatAPI(WMConnectionBase):
         self.heartbeatTimeout = heartbeatTimeout or 7200
         self.compId = os.getpid()
 
-        WMConnectionBase.__init__(self, daoPackage = "WMCore.Agent.Database",
-                                  logger = logger, dbi = dbi)
+        WMConnectionBase.__init__(self, daoPackage="WMCore.Agent.Database",
+                                  logger=logger, dbi=dbi)
 
-        self.insertComp = self.daofactory(classname = "InsertComponent")
-        self.existWorker = self.daofactory(classname = "ExistWorker")
+        self.insertComp = self.daofactory(classname="InsertComponent")
+        self.existWorker = self.daofactory(classname="ExistWorker")
         self.insertWorker = self.daofactory(classname="InsertWorker")
         self.updateWorker = self.daofactory(classname="UpdateWorker")
-        self.updateErrorWorker = self.daofactory(classname = "UpdateWorkerError")
-        self.getHeartbeat = self.daofactory(classname = "GetHeartbeatInfo")
-        self.getAllHeartbeat = self.daofactory(classname = "GetAllHeartbeatInfo")
+        self.updateErrorWorker = self.daofactory(classname="UpdateWorkerError")
+        self.getHeartbeat = self.daofactory(classname="GetHeartbeatInfo")
+        self.getAllHeartbeat = self.daofactory(classname="GetAllHeartbeatInfo")
 
     def registerComponent(self):
         """
@@ -51,7 +48,7 @@ class HeartbeatAPI(WMConnectionBase):
         inserts it again with a new PID into wm_components table
         """
         self.insertComp.execute(self.componentName, self.compId, self.heartbeatTimeout,
-                                conn = self.getDBConn(), transaction = self.existingTransaction())
+                                conn=self.getDBConn(), transaction=self.existingTransaction())
 
     def registerWorker(self, workerName, state="Start"):
         """
@@ -67,8 +64,8 @@ class HeartbeatAPI(WMConnectionBase):
         """Retrieve the component_id from the workers table"""
 
         componentID = self.existWorker.execute(self.componentName, workerName,
-                                               conn = self.getDBConn(),
-                                               transaction = self.existingTransaction())
+                                               conn=self.getDBConn(),
+                                               transaction=self.existingTransaction())
         return componentID
 
     def updateWorkerHeartbeat(self, workerName, state):
@@ -76,8 +73,8 @@ class HeartbeatAPI(WMConnectionBase):
         Update a worker's heartbeat and its state
         """
         try:
-            self.updateWorker.execute(workerName, state, conn = self.getDBConn(),
-                                      transaction = self.existingTransaction())
+            self.updateWorker.execute(workerName, state, conn=self.getDBConn(),
+                                      transaction=self.existingTransaction())
         except Exception as ex:
             logging.warning("Heartbeat update failed! Wait for the next time...:\n%s", str(ex))
 
@@ -87,25 +84,25 @@ class HeartbeatAPI(WMConnectionBase):
         cycle and any results returned.
         """
         self.updateWorker.execute(workerName, "Running", timeSpent, results,
-                                  conn = self.getDBConn(),
-                                  transaction = self.existingTransaction())
+                                  conn=self.getDBConn(),
+                                  transaction=self.existingTransaction())
 
     def updateWorkerError(self, workerName, errorMessage):
 
         self.updateErrorWorker.execute(self.componentName, workerName, errorMessage,
-                                       conn = self.getDBConn(),
-                                       transaction = self.existingTransaction())
+                                       conn=self.getDBConn(),
+                                       transaction=self.existingTransaction())
 
     def getHeartbeatInfo(self):
 
-        results = self.getHeartbeat.execute(self.componentName, conn = self.getDBConn(),
-                                            transaction = self.existingTransaction())
+        results = self.getHeartbeat.execute(self.componentName, conn=self.getDBConn(),
+                                            transaction=self.existingTransaction())
 
         return results
 
     def getAllHeartbeatInfo(self):
 
-        results = self.getAllHeartbeat.execute(conn = self.getDBConn(),
-                                               transaction = self.existingTransaction())
+        results = self.getAllHeartbeat.execute(conn=self.getDBConn(),
+                                               transaction=self.existingTransaction())
 
         return results

--- a/src/python/WMCore/Services/PhEDEx/DataStructs/SubscriptionList.py
+++ b/src/python/WMCore/Services/PhEDEx/DataStructs/SubscriptionList.py
@@ -32,9 +32,9 @@ class PhEDExSubscription(object):
         """
         Initialize PhEDEx subscription with default value
         """
-        if type(datasetPathList) == str:
+        if isinstance(datasetPathList, basestring):
             datasetPathList = [datasetPathList]
-        if type(nodeList) == str:
+        if isinstance(nodeList, basestring):
             nodeList = [nodeList]
 
         self.datasetPaths = set(datasetPathList)

--- a/src/python/WMCore/WorkerThreads/BaseWorkerThread.py
+++ b/src/python/WMCore/WorkerThreads/BaseWorkerThread.py
@@ -156,7 +156,7 @@ class BaseWorkerThread(object):
                 myThread.logdbClient = None
 
             if self.useHeartbeat:
-                self.heartbeatAPI.updateWorkerHeartbeat(self.workerName)
+                self.heartbeatAPI.registerWorker(self.workerName)
 
             # Run event loop while termination is not flagged
             while not self.notifyTerminate.isSet():

--- a/src/python/WMCore/WorkerThreads/BaseWorkerThread.py
+++ b/src/python/WMCore/WorkerThreads/BaseWorkerThread.py
@@ -17,6 +17,7 @@ import traceback
 from WMCore.Alerts import API as alertAPI
 from WMCore.Database.Transaction import Transaction
 
+
 class BaseWorkerThread(object):
     """
     A base class for worker threads, used for work that needs to occur at
@@ -107,7 +108,7 @@ class BaseWorkerThread(object):
         # Now we're in our own thread, set the logger
         myThread.logger = self.logger
 
-        (connectDialect, junk) = self.component.config.CoreDatabase.connectUrl.split(":", 1)
+        (connectDialect, _junk) = self.component.config.CoreDatabase.connectUrl.split(":", 1)
 
         if connectDialect.lower() == "mysql":
             myThread.dialect = "MySQL"

--- a/src/python/WMCore/WorkerThreads/WorkerThreadManager.py
+++ b/src/python/WMCore/WorkerThreads/WorkerThreadManager.py
@@ -6,20 +6,22 @@ A class used to manage regularly running worker threads.
 """
 from __future__ import print_function
 
-import threading
 import logging
+import threading
 import time
 
-from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 from WMCore.Agent.HeartbeatAPI import HeartbeatAPI
+from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 
 # keep track of a unique WTM number
 wtmcount = 0
 
-class WorkerThreadManager:
+
+class WorkerThreadManager(object):
     """
     Manages regular worker slave threads
     """
+
     def __init__(self, component):
         """
         Set up the events used to pause, resume and terminate worker threads
@@ -65,7 +67,6 @@ class WorkerThreadManager:
         worker.slaveid = "%s-%s" % (self.wtmnumber, self.slavecounter)
         self.lock.release()
 
-
         # Thread synchronisation
         worker.notifyTerminate = self.terminateSlaves
         worker.terminateCallback = self.slaveTerminateCallback
@@ -76,8 +77,7 @@ class WorkerThreadManager:
                 worker.heartbeatAPI = HeartbeatAPI(self.component.config.Agent.componentName,
                                                    idleTime, heartbeatTimeout)
 
-
-    def addWorker(self, worker, idleTime = 60, hbTimeout=None, parameters = None):
+    def addWorker(self, worker, idleTime=60, hbTimeout=None, parameters=None):
         """
         Adds a worker object and sets it running. Worker thread will sleep for
         idleTime seconds between runs. Parameters, if present, are passed into
@@ -92,7 +92,7 @@ class WorkerThreadManager:
 
         # Prepare the new worker thread
         self.prepareWorker(worker, idleTime, hbTimeout)
-        workerThread = threading.Thread(target = worker, args = (parameters,))
+        workerThread = threading.Thread(target=worker, args=(parameters,))
         msg = "Created worker thread %s" % str(worker)
         logging.info(msg)
 
@@ -122,16 +122,15 @@ class WorkerThreadManager:
         finished = False
         while not finished:
             self.lock.acquire()
-            msg = "Waiting for %s worker threads to terminate"
-            logging.info(msg % self.activeThreadCount)
-            logging.debug("\n slavelist is %s" % self.slavelist)
-            logging.debug("\n threadlist is %s" % threading.enumerate())
+            logging.info("Waiting for %s worker threads to terminate", self.activeThreadCount)
+            logging.debug("\n slavelist is %s", self.slavelist)
+            logging.debug("\n threadlist is %s", threading.enumerate())
 
             if self.activeThreadCount == 0:
                 finished = True
             else:
                 # check to make sure we aren't waiting on dead threads
-                threadlist  = threading.enumerate()
+                threadlist = threading.enumerate()
                 # we want to look for all the slavenames
                 #  that correspond to nonexistant or dead threads
                 # also, I realize this is O(N^2), but my brain hurts too hard
@@ -143,19 +142,17 @@ class WorkerThreadManager:
                 # everywhere else that tries to modify active thread count
                 # also does it with a try-except-else around removing from
                 # slavelist. Slavelist becomes our synchronization
-                toRemove = []
                 for slavename in self.slavelist:
                     found = False
                     for threadobj in threadlist:
-                        if ((hasattr(threadobj, 'name')) and (slavename == threadobj.name) and (threadobj.isAlive())):
+                        if hasattr(threadobj, 'name') and (slavename == threadobj.name) and (threadobj.isAlive()):
                             found = True
-                    if found == False:
+                    if found is False:
                         # the slave we wanted wasn't running
                         try:
                             self.slavelist.remove(slavename)
                         except Exception as ex:
                             print("couldn't remove thread.. %s " % ex)
-                            pass
                         else:
                             self.activeThreadCount -= 1
             self.lock.release()

--- a/src/python/WMCore/WorkerThreads/WorkerThreadManager.py
+++ b/src/python/WMCore/WorkerThreads/WorkerThreadManager.py
@@ -53,7 +53,7 @@ class WorkerThreadManager:
             self.activeThreadCount -= 1
         self.lock.release()
 
-    def prepareWorker(self, worker, idleTime):
+    def prepareWorker(self, worker, idleTime, heartbeatTimeout):
         """
         Prepares a worker thread before running
         """
@@ -73,10 +73,11 @@ class WorkerThreadManager:
         worker.notifyResume = self.resumeSlaves
         if hasattr(self.component.config, "Agent"):
             if getattr(self.component.config.Agent, "useHeartbeat", True):
-                worker.heartbeatAPI = HeartbeatAPI(self.component.config.Agent.componentName, idleTime)
+                worker.heartbeatAPI = HeartbeatAPI(self.component.config.Agent.componentName,
+                                                   idleTime, heartbeatTimeout)
 
 
-    def addWorker(self, worker, idleTime = 60, parameters = None):
+    def addWorker(self, worker, idleTime = 60, hbTimeout=None, parameters = None):
         """
         Adds a worker object and sets it running. Worker thread will sleep for
         idleTime seconds between runs. Parameters, if present, are passed into
@@ -90,7 +91,7 @@ class WorkerThreadManager:
             return
 
         # Prepare the new worker thread
-        self.prepareWorker(worker, idleTime)
+        self.prepareWorker(worker, idleTime, hbTimeout)
         workerThread = threading.Thread(target = worker, args = (parameters,))
         msg = "Created worker thread %s" % str(worker)
         logging.info(msg)

--- a/test/python/WMCore_t/Agent_t/Heartbeat_t.py
+++ b/test/python/WMCore_t/Agent_t/Heartbeat_t.py
@@ -4,17 +4,16 @@ _WorkQueueTestCase_
 Unit tests for the WMBS File class.
 """
 
+from __future__ import print_function
 
-
-
-import unittest
 import time
-from WMQuality.TestInit import TestInit
+import unittest
+
 from WMCore.Agent.HeartbeatAPI import HeartbeatAPI
-# pylint: disable = W0611
+from WMQuality.TestInit import TestInit
+
 
 class HeartbeatTest(unittest.TestCase):
-
     def setUp(self):
         """
         _setUp_
@@ -24,10 +23,10 @@ class HeartbeatTest(unittest.TestCase):
         """
 
         self.testInit = TestInit(__file__)
-        self.testInit.setLogging() # logLevel = logging.SQLDEBUG
+        self.testInit.setLogging()  # logLevel = logging.SQLDEBUG
         self.testInit.setDatabaseConnection()
-        self.testInit.setSchema(customModules = ["WMCore.Agent.Database"],
-                                useDefault = False)
+        self.testInit.setSchema(customModules=["WMCore.Agent.Database"],
+                                useDefault=False)
 
     def tearDown(self):
         """
@@ -38,59 +37,95 @@ class HeartbeatTest(unittest.TestCase):
 
         self.testInit.clearDatabase()
 
-    def testHeartbeat(self):
-        testComponent = HeartbeatAPI("testComponent")
-        testComponent.pollInterval = 10
-        testComponent.registerComponent()
-        self.assertEqual(testComponent.getHeartbeatInfo(), [])
+    def testAddComponent(self):
+        """
+        _testAddComponent_
 
-        testComponent.updateWorkerHeartbeat("testWorker")
-        result = testComponent.getHeartbeatInfo()
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]['worker_name'], "testWorker")
-        time.sleep(1)
+        Test creation of components and worker threads as well as the
+        get heartbeat DAOs
+        """
+        comp1 = HeartbeatAPI("testComponent1", pollInterval=60, heartbeatTimeout=600)
+        comp1.registerComponent()
+        self.assertEqual(comp1.getHeartbeatInfo(), [])  # no worker thread yet
 
-        testComponent.updateWorkerHeartbeat("testWorker2")
-        result = testComponent.getHeartbeatInfo()
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]['worker_name'], "testWorker2")
+        comp1.registerWorker("testWorker1")
+        self.assertEqual(len(comp1.getHeartbeatInfo()), 1)
 
-        time.sleep(1)
-        testComponent.updateWorkerHeartbeat("testWorker")
-        result = testComponent.getHeartbeatInfo()
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]['worker_name'], "testWorker")
+        comp1.registerWorker("testWorker2")
+        self.assertEqual(len(comp1.getHeartbeatInfo()), 2)
 
+        comp2 = HeartbeatAPI("testComponent2", pollInterval=30, heartbeatTimeout=300)
+        comp2.registerComponent()
+        self.assertEqual(comp2.getHeartbeatInfo(), [])  # no worker thread yet
+        self.assertEqual(len(comp2.getAllHeartbeatInfo()), 2)
 
-        testComponent = HeartbeatAPI("test2Component")
-        testComponent.pollInterval = 20
-        testComponent.registerComponent()
-        time.sleep(1)
-        testComponent.updateWorkerHeartbeat("test2Worker")
+        comp2.registerWorker("testWorker21")
+        self.assertEqual(len(comp2.getHeartbeatInfo()), 1)
+        self.assertEqual(len(comp2.getAllHeartbeatInfo()), 3)
 
-        result = testComponent.getHeartbeatInfo()
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]['worker_name'], "testWorker")
-        self.assertEqual(result[1]['worker_name'], "test2Worker")
+        comp1.updateWorkerHeartbeat("testWorker1", "Running")
+        comp1.updateWorkerHeartbeat("testWorker2", "Running")
+        comp2.updateWorkerHeartbeat("testWorker21", "Running")
+        self.assertEqual(len(comp1.getAllHeartbeatInfo()), 3)
+        self.assertEqual(len(comp2.getAllHeartbeatInfo()), 3)
 
-        time.sleep(1)
-        testComponent.updateWorkerHeartbeat("test2Worker2")
-        result = testComponent.getHeartbeatInfo()
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]['worker_name'], "testWorker")
-        self.assertEqual(result[1]['worker_name'], "test2Worker2")
+        comp1Res = comp1.getHeartbeatInfo()
+        comp2Res = comp2.getHeartbeatInfo()
+        self.assertEqual(len(comp1Res), 2)
+        self.assertEqual(len(comp2Res), 1)
 
-        time.sleep(1)
-        testComponent.updateWorkerHeartbeat("test2Worker")
-        result = testComponent.getHeartbeatInfo()
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]['worker_name'], "testWorker")
-        self.assertEqual(result[1]['worker_name'], "test2Worker")
+        self.assertItemsEqual([item["name"] for item in comp1Res], ["testComponent1", "testComponent1"])
+        self.assertItemsEqual([item["worker_name"] for item in comp1Res], ["testWorker1", "testWorker2"])
+        self.assertItemsEqual([item["state"] for item in comp1Res], ["Running", "Running"])
+        self.assertItemsEqual([item["poll_interval"] for item in comp1Res], [60, 60])
+        self.assertItemsEqual([item["update_threshold"] for item in comp1Res], [600, 600])
 
-        testComponent.updateWorkerError("test2Worker", "Error1")
-        result = testComponent.getHeartbeatInfo()
-        self.assertEqual(result[1]['error_message'], "Error1")
+        self.assertItemsEqual([item["name"] for item in comp2Res], ["testComponent2"])
+        self.assertItemsEqual([item["worker_name"] for item in comp2Res], ["testWorker21"])
+        self.assertItemsEqual([item["state"] for item in comp2Res], ["Running"])
+        self.assertItemsEqual([item["poll_interval"] for item in comp2Res], [30])
+        self.assertItemsEqual([item["update_threshold"] for item in comp2Res], [300])
 
+    def testUpdateWorkers(self):
+        """
+        _testUpdateWorkers_
+
+        Create a couple of components and workers and test the update methods
+        """
+        comp1 = HeartbeatAPI("testComponent1", pollInterval=60, heartbeatTimeout=600)
+        comp1.registerComponent()
+        comp1.registerWorker("testWorker1")
+        comp1.registerWorker("testWorker2")
+
+        comp2 = HeartbeatAPI("testComponent2", pollInterval=30, heartbeatTimeout=300)
+        comp2.registerComponent()
+        comp2.registerWorker("testWorker21")
+
+        comp1.updateWorkerCycle("testWorker1", 1.001, None)
+        comp2.updateWorkerCycle("testWorker21", 1234.1, 100)
+        hb1 = comp1.getHeartbeatInfo()
+        hb2 = comp2.getHeartbeatInfo()
+
+        for worker in hb1:
+            if worker['worker_name'] == 'testWorker1':
+                self.assertTrue(worker["cycle_time"] > 1.0)
+            else:
+                self.assertEqual(worker["cycle_time"], 0)
+        self.assertItemsEqual([item["outcome"] for item in hb1], [None, None])
+        self.assertItemsEqual([item["error_message"] for item in hb1], [None, None])
+
+        self.assertEqual(round(hb2[0]["cycle_time"], 1), 1234.1)
+        self.assertEqual(hb2[0]["outcome"], '100')
+        self.assertEqual(hb2[0]["error_message"], None)
+
+        # time to update workers with an error
+        comp1.updateWorkerError("testWorker2", "BAD JOB!!!")
+        hb1 = comp1.getHeartbeatInfo()
+        for worker in hb1:
+            if worker['worker_name'] == 'testWorker2':
+                self.assertTrue(worker["last_error"] > int(time.time() - 10))
+                self.assertEqual(worker["state"], "Error")
+                self.assertEqual(worker["error_message"], "BAD JOB!!!")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In short, changes are:
* change wm_workers table unique constraint to a worker thread name only
* configurable heartbeat timeout (update_threshold), though not used yet
* don't crash the component if it fails to update the database with a heartbeat
* updated wm_workers cycle_time data type, otherwise oracle returns an e.g. DECIMAL('1') which can't be used in any arithmetic operations
* getheartbeat gets the heartbeat of all workers for a specific component (before it was getting it for one worker only)
