### PR TITLE
Ensure StageOut error details contain only valid bytes

### DIFF
--- a/src/python/WMCore/WMException.py
+++ b/src/python/WMCore/WMException.py
@@ -27,8 +27,12 @@ class WMException(exceptions.Exception):
     """
     def __init__(self, message, errorNo=None, **data):
         self.name = str(self.__class__.__name__)
-        exceptions.Exception.__init__(self, self.name,
-                                      message)
+        if hasattr(message, "decode"):
+            # Fix for the unicode encoding issue, see #8056 and #8403
+            # interprets this string using utf-8 codec and ignoring any errors
+            message = message.decode('utf-8', 'ignore')
+
+        exceptions.Exception.__init__(self, self.name, message)
 
         #  //
         # // Init data dictionary with defaults
@@ -40,7 +44,7 @@ class WMException(exceptions.Exception):
         self.data.setdefault("ClassInstance", None)
         self.data.setdefault("FileName", None)
         self.data.setdefault("LineNumber", None)
-        if errorNo == None:
+        if errorNo is None:
             self.data.setdefault("ErrorNr", 0)
         else:
             self.data.setdefault("ErrorNr", errorNo)
@@ -51,7 +55,7 @@ class WMException(exceptions.Exception):
         #  //
         # // Automatically determine the module name
         # //  if not set
-        if self.data['ModuleName'] == None:
+        if self.data['ModuleName'] is None:
             try:
                 frame = inspect.currentframe()
                 lastframe = inspect.getouterframes(frame)[1][0]


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/8403
Replaces #8404 (but to be applied in new agents only)

I did run that recipe in https://github.com/dmwm/WMCore/issues/8056 to see whether I could encode the sicky FJR and it seems to go through with this fix.

Just for reference, another complement to #8295