### PR TITLE
Consider number of jobs per cycle for the job submission conditions

### DIFF
--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -817,7 +817,7 @@ class JobSubmitterPoller(BaseWorkerThread):
                                                condorFraction=self.condorFraction)
         self.maxJobsThisCycle = min(freeSubmitSlots, self.maxJobsPerPoll)
 
-        return (freeSubmitSlots > 0)
+        return (self.maxJobsThisCycle > 0)
 
     def terminate(self, params):
         """


### PR DESCRIPTION
This way, if someone sets the JobSubmitter `maxJobsPerPoll` config to 0, no jobs will get submitted.