### PR TITLE
Set agents connected to "production" team to drain mode

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -56,7 +56,7 @@ diskSites = ['storm-fe-cms.cr.cnaf.infn.it', 'srm-cms-disk.gridpp.rl.ac.uk',
 
 # Job retry information.  This includes the number of times a job will be retried and
 # for how long it will sit in cool off.
-maxJobRetries = {'default': 3, 'Merge': 4, 'LogCollect': 1, 'Cleanup': 2, 'Harvesting': 2}
+maxJobRetries = {'default': 3, 'Merge': 4, 'LogCollect': 2, 'Cleanup': 2, 'Harvesting': 2}
 retryAlgoParams = {"create": 5000, "submit": 5000, "job": 5000}
 
 # The amount of time to wait after a workflow has completed before archiving it.


### PR DESCRIPTION
Changes are:
* example deployment updated, including patches for patch3
* removed the logCollect tweaks for the relval agent (changed default value to 2)
* removed the hlt team tweaks. There is no more specific agent for those activities
* by default, update agent to drain mode if it's connected to the production team (reqmgr aux db)