### PR TITLE
Quantize job time and disk usage

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -187,9 +187,9 @@ config.JobCreator.jobCacheDir = config.General.workDir + "/JobCache"
 config.JobCreator.defaultJobType = "Processing"
 config.JobCreator.workerThreads = 1
 # glidein restrictions used for resource estimation (per core)
-config.JobCreator.GlideInRestriction = {"MinWallTimeSecs": 1 * 60 * 60, "MaxWallTimeSecs": 45 * 60 * 60,
-                                        # pilot lifetime is usually 48h
-                                        "MinRequestDiskKB": 1 * 1024 * 1024,
+config.JobCreator.GlideInRestriction = {"MinWallTimeSecs": 1 * 3600,  # 1h
+                                        "MaxWallTimeSecs": 46 * 3600,  # pilot lifetime is usually 48h
+                                        "MinRequestDiskKB": 1 * 1024 * 1024,  # 1GB
                                         "MaxRequestDiskKB": 20 * 1024 * 1024}  # site limit is ~27GB
 config.component_("JobSubmitter")
 config.JobSubmitter.namespace = "WMComponent.JobSubmitter.JobSubmitter"

--- a/src/python/Utils/MathUtils.py
+++ b/src/python/Utils/MathUtils.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""
+Module containing mathematical and physics utils
+"""
+from __future__ import division, print_function
+
+from math import ceil
+
+
+def quantize(inputVal, quanta):
+    """
+    _quantize_
+
+    Quantize the input value following the quanta provided.
+    """
+    if isinstance(inputVal, basestring):
+        inputVal = float(inputVal)
+    elif not isinstance(inputVal, (int, float)):
+        msg = "Input value has to be either int or float, not %s" % (type(inputVal))
+        raise ValueError(msg)
+
+    if isinstance(quanta, (basestring, float)):
+        quanta = int(float(quanta))
+    elif not isinstance(quanta, int):
+        msg = "Quanta value has to be either int or float, not %s" % (type(quanta))
+        raise ValueError(msg)
+
+    res = int(ceil(inputVal / quanta))
+
+    return res * quanta

--- a/src/python/WMComponent/JobCreator/JobCreatorPoller.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorPoller.py
@@ -16,6 +16,7 @@ except ImportError:
     import pickle
 
 from Utils.Timers import timeFunction
+from Utils.MathUtils import quantize
 from WMComponent.JobCreator.CreateWorkArea import CreateWorkArea
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 from WMCore.DAOFactory import DAOFactory
@@ -108,6 +109,10 @@ def capResourceEstimates(jobGroups, constraints):
 
             j['estimatedJobTime'] = min(j['estimatedJobTime'], constraints['MaxWallTimeSecs'])
             j['estimatedDiskUsage'] = min(j['estimatedDiskUsage'], constraints['MaxRequestDiskKB'])
+
+            # finally, quantize those
+            j['estimatedJobTime'] = quantize(j['estimatedJobTime'], constraints['MinWallTimeSecs'])
+            j['estimatedDiskUsage'] = quantize(j['estimatedDiskUsage'], constraints['MinRequestDiskKB'])
 
     return
 

--- a/test/python/Utils_t/MathUtils_t.py
+++ b/test/python/Utils_t/MathUtils_t.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+"""
+Unittests for MathUtils functions
+"""
+
+from __future__ import division, print_function
+
+import unittest
+
+from Utils.MathUtils import quantize
+
+
+class MathUtilsTest(unittest.TestCase):
+    """
+    unittest for MathUtils functions
+    """
+
+    def testQuantize(self):
+        """
+        Test the quantize function
+        """
+        self.assertEqual(quantize(15, 5), 15)
+        self.assertEqual(quantize(14, 5), 15)
+        self.assertEqual(quantize(16, 5), 20)
+
+        self.assertEqual(quantize(15, 5.0), 15)
+        self.assertEqual(quantize(14, 5.0), 15)
+        self.assertEqual(quantize(16, 5.0), 20)
+
+        self.assertRaises(ValueError, quantize, [1], 50)
+        self.assertRaises(ValueError, quantize, {1}, 50)
+
+        self.assertRaises(ValueError, quantize, 1, [50])
+        self.assertRaises(ValueError, quantize, 1, {50})


### PR DESCRIPTION
Fixes #8174 

First commit contains the utilitarian function, second contains the actual changes to the job factory.
We could quantize the memory usage too (by 250MB?), but then we need to make sure the MaxRSS follows the same rule (even though the global pool is broken already with its automatic rounding...).