### PR TITLE
Accept long data type as input for quantize

### DIFF
--- a/src/python/Utils/MathUtils.py
+++ b/src/python/Utils/MathUtils.py
@@ -15,11 +15,11 @@ def quantize(inputVal, quanta):
     """
     if isinstance(inputVal, basestring):
         inputVal = float(inputVal)
-    elif not isinstance(inputVal, (int, float)):
+    elif not isinstance(inputVal, (int, float, long)):
         msg = "Input value has to be either int or float, not %s" % (type(inputVal))
         raise ValueError(msg)
 
-    if isinstance(quanta, (basestring, float)):
+    if isinstance(quanta, (basestring, float, long)):
         quanta = int(float(quanta))
     elif not isinstance(quanta, int):
         msg = "Quanta value has to be either int or float, not %s" % (type(quanta))


### PR DESCRIPTION
I've just found JobCreator crashed in submit1 (MySQL backend) with this traceback [1].
Since the relational database can return long data type, we need to allow it in the function.
I'm not making unittest for this case because otherwise jenkins will complain about that until we migrate to python3.


[1]
2018-02-14 17:31:58,569:140336995071744:INFO:JobCreatorPoller:Retrieved 1 jobGroups from jobSplitter
2018-02-14 17:31:58,656:140336995071744:ERROR:JobCreatorPoller:Failed to execute JobCreator 
Input value has to be either int or float, not <type 'long'>

Traceback (most recent call last):
  File "/data/srv/wmagent/v1.1.10.patch2/sw/slc7_amd64_gcc630/cms/wmagent/1.1.10.patch2/lib/python2.7/site-packages/WMComponent/JobCreator/JobCreatorPoller.py", line 418, in algorithm
    self.pollSubscriptions()
  File "/data/srv/wmagent/v1.1.10.patch2/sw/slc7_amd64_gcc630/cms/wmagent/1.1.10.patch2/lib/python2.7/site-packages/WMComponent/JobCreator/JobCreatorPoller.py", line 596, in pollSubscriptions
    capResourceEstimates(wmbsJobGroups, self.glideinLimits)
  File "/data/srv/wmagent/v1.1.10.patch2/sw/slc7_amd64_gcc630/cms/wmagent/1.1.10.patch2/lib/python2.7/site-packages/WMComponent/JobCreator/JobCreatorPoller.py", line 115, in capResourceEstimates
    j['estimatedDiskUsage'] = quantize(j['estimatedDiskUsage'], constraints['MinRequestDiskKB'])
  File "/data/srv/wmagent/v1.1.10.patch2/sw/slc7_amd64_gcc630/cms/wmagent/1.1.10.patch2/lib/python2.7/site-packages/Utils/MathUtils.py", line 20, in quantize
    raise ValueError(msg)
ValueError: Input value has to be either int or float, not <type 'long'>

2018-02-14 17:31:58,922:140336995071744:ERROR:BaseWorkerThread:Error in worker algorithm (1):