### PR TITLE
Bump JobAccountant polling cycle to 5min

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -170,7 +170,7 @@ config.JobAccountant.namespace = "WMComponent.JobAccountant.JobAccountant"
 config.JobAccountant.componentDir = config.General.workDir + "/JobAccountant"
 config.JobAccountant.logLevel = globalLogLevel
 config.JobAccountant.workerThreads = 1
-config.JobAccountant.pollInterval = 60
+config.JobAccountant.pollInterval = 300
 config.JobAccountant.specDir = config.General.workDir + "/JobAccountant/SpecCache"
 
 config.component_("JobCreator")


### PR DESCRIPTION
Not really necessary, but it is supposed to mitigate a race condition where the component starts processing completed jobs while the job Report.pkl hasn't been transferred back to the schedd.