### PR TITLE
Handle worker node info when there was no worker node in the job life…

### DIFF
--- a/src/python/WMCore/FwkJobReport/Report.py
+++ b/src/python/WMCore/FwkJobReport/Report.py
@@ -1516,8 +1516,8 @@ class Report(object):
         return
 
     def getWorkerNodeInfo(self):
-        wnInfo = {"HostName": self.data.hostName,
-                  "MachineFeatures": self.data.machineFeatures,
-                  "JobFeatures": self.data.jobFeatures}
+        wnInfo = {"HostName": getattr(self.data, 'hostName', ''),
+                  "MachineFeatures": getattr(self.data, 'machineFeatures', {}),
+                  "JobFeatures": getattr(self.data, 'jobFeatures', {})}
 
         return wnInfo


### PR DESCRIPTION
…time
Complement for #8304 and #8470

There are cases that the job dies before it reaches a worker node, thus we won't have hostName and job/machine features for those cases.