### PR TITLE
Switch from UUID1 to UUID4.

### DIFF
--- a/src/python/WMCore/Services/StompAMQ/StompAMQ.py
+++ b/src/python/WMCore/Services/StompAMQ/StompAMQ.py
@@ -169,7 +169,7 @@ class StompAMQ(object):
             'metadata': {
                 'timestamp': int(time.time()),
                 'id': id_,
-                'uuid': str(uuid.uuid1()),
+                'uuid': str(uuid.uuid4()),
             }
         }
 

--- a/src/python/WMCore/Services/UUIDLib.py
+++ b/src/python/WMCore/Services/UUIDLib.py
@@ -9,4 +9,4 @@ def makeUUID():
 
     Makes a UUID from the uuid class, returns it
     """
-    return str(uuid.uuid1())
+    return str(uuid.uuid4())

--- a/test/python/WMCore_t/Services_t/UUID_t.py
+++ b/test/python/WMCore_t/Services_t/UUID_t.py
@@ -27,21 +27,20 @@ class UUIDTest(unittest.TestCase):
 
         listOfIDs = []
 
+        tmpID = makeUUID()
         splitID = None
+        splitID = tmpID.split('-')
 
         for i in range(0,1000):
             tmpID = makeUUID()
-            if not splitID:
-                splitID = tmpID.split('-')
             tmpSplit = tmpID.split('-')
-            self.assertEqual(tmpSplit[1], splitID[1], "Second component of UUID not the same %s != %s" \
-                             %(tmpSplit[1], splitID[1]))
-            self.assertEqual(tmpSplit[2], splitID[2], "Third component of UUID not the same %s != %s" \
-                             %(tmpSplit[2], splitID[2]))
-            self.assertEqual(tmpSplit[4], splitID[4], "Fourth component of UUID not the same %s != %s" \
-                             %(tmpSplit[4], splitID[4]))
+            self.assertNotEqual(tmpSplit[1], splitID[1], "Second component of UUID the same %s != %s"
+                             % (tmpSplit[1], splitID[1]))
+            self.assertNotEqual(tmpSplit[4], splitID[4], "Fourth component of UUID the same %s != %s"
+                             % (tmpSplit[4], splitID[4]))
             self.assertEqual(type(tmpID), str)
-            self.assertEqual(listOfIDs.count(tmpID), 0, "UUID repeated!  %s found in list %i times!" %(tmpID, listOfIDs.count(tmpID)))
+            self.assertEqual(listOfIDs.count(tmpID), 0, "UUID repeated!  %s found in list %i times!"
+                             % (tmpID, listOfIDs.count(tmpID)))
             listOfIDs.append(tmpID)
 
 


### PR DESCRIPTION
The UUID1 algorithm generates UUIDs based on a host's MAC address
and a timestamp.  While physical MACs are all indeed unique, Docker
containers very commonly use the same MAC address.  In practice, given
the number of sites converting to Docker, this removes a lot of the
uniqueness and has led to observed collisions.

This changes to UUID4, where the UUID is generated entirely from
the RNG.