### PR TITLE
Fix WMBSHelper transactions; Warning record if there is no run/lumi map

### DIFF
--- a/src/python/WMComponent/JobAccountant/AccountantWorker.py
+++ b/src/python/WMComponent/JobAccountant/AccountantWorker.py
@@ -246,7 +246,7 @@ class AccountantWorker(WMConnectionBase):
 
             self.count += 1
 
-        self.beginTransaction()
+        existingTransaction = self.beginTransaction()
 
         # Now things done at the end of the job
         # Do what we can with WMBS files
@@ -304,7 +304,7 @@ class AccountantWorker(WMConnectionBase):
         if len(self.jobsWithSkippedFiles) > 0:
             self.handleSkippedFiles()
 
-        self.commitTransaction(existingTransaction=False)
+        self.commitTransaction(existingTransaction)
 
         return returnList
 

--- a/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
+++ b/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
@@ -109,6 +109,9 @@ class EventAwareLumiBased(JobFactory):
             # First we need to load the data
             if self.loadRunLumi:
                 fileLumis = self.loadRunLumi.execute(files=lDict[key])
+                if not fileLumis:
+                    logging.warning("Empty fileLumis dict for workflow %s, subs %s.",
+                                    self.subscription.workflowName(), self.subscription['id'])
                 for f in lDict[key]:
                     lumiDict = fileLumis.get(f['id'], {})
                     for run in lumiDict.keys():

--- a/src/python/WMCore/JobSplitting/EventAwareLumiByWork.py
+++ b/src/python/WMCore/JobSplitting/EventAwareLumiByWork.py
@@ -337,6 +337,9 @@ class EventAwareLumiByWork(JobFactory):
         """
 
         fileLumis = self.loadRunLumi.execute(files=filesByLocation)
+        if not fileLumis:
+            logging.warning("Empty fileLumis dict for workflow %s, subs %s.",
+                            self.subscription.workflowName(), self.subscription['id'])
         for f in filesByLocation:
             lumiDict = fileLumis.get(f['id'], {})
             for run in lumiDict.keys():

--- a/src/python/WMCore/JobSplitting/EventBased.py
+++ b/src/python/WMCore/JobSplitting/EventBased.py
@@ -83,6 +83,9 @@ class EventBased(JobFactory):
                 if self.package == 'WMCore.WMBS':
                     loadRunLumi = self.daoFactory(classname="Files.GetBulkRunLumi")
                     fileLumis = loadRunLumi.execute(files=fileList)
+                    if not fileLumis:
+                        logging.warning("Empty fileLumis dict for workflow %s, subs %s.",
+                                        self.subscription.workflowName(), self.subscription['id'])
                     for f in fileList:
                         lumiDict = fileLumis.get(f['id'], {})
                         for run in lumiDict.keys():

--- a/src/python/WMCore/JobSplitting/LumiBased.py
+++ b/src/python/WMCore/JobSplitting/LumiBased.py
@@ -389,6 +389,9 @@ class LumiBased(JobFactory):
         # first, check whether we have enough files to reach the desired lumis_per_job
         for sites in lDict.keys():
             fileLumis = self.loadRunLumi.execute(files=lDict[sites])
+            if not fileLumis:
+                logging.warning("Empty fileLumis dict for workflow %s, subs %s.",
+                                self.subscription.workflowName(), self.subscription['id'])
             if checkMinimumWork:
                 # fileLumis has a format like {230: {1: [1]}, 232: {1: [2]}, 304: {1: [3]}, 306: {1: [4]}}
                 availableLumisPerLocation = [runL for fileItem in fileLumis.values() for runL in fileItem.values()]

--- a/src/python/WMCore/WorkQueue/WMBSHelper.py
+++ b/src/python/WMCore/WorkQueue/WMBSHelper.py
@@ -7,7 +7,6 @@ Use WMSpecParser to extract information for creating workflow, fileset, and subs
 
 import logging
 import threading
-import traceback
 from collections import defaultdict
 
 from WMComponent.DBS3Buffer.DBSBufferDataset import DBSBufferDataset


### PR DESCRIPTION
Fixes #8334

@ticoann Seangchan, I create smaller transactions in WMBSHelper for cases where we have insert ignore. I also fixed that transaction code in the AccountantWorker. Let me know if there is any reason it was like that.

It will also log in the JobCreator when it finds a workflow+subscription with files available but no run/lumi information.