### PR TITLE
Yield also locationless files to the ACDC creation

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -229,7 +229,7 @@ config.ErrorHandler.logLevel = globalLogLevel
 config.ErrorHandler.pollInterval = 240
 config.ErrorHandler.readFWJR = True
 config.ErrorHandler.maxFailTime = 120000
-config.ErrorHandler.maxProcessSize = 30
+config.ErrorHandler.maxProcessSize = 300
 
 config.component_("RetryManager")
 config.RetryManager.namespace = "WMComponent.RetryManager.RetryManager"

--- a/src/python/WMCore/WMBS/MySQL/Jobs/LoadForErrorHandler.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/LoadForErrorHandler.py
@@ -4,6 +4,7 @@ _LoadForErrHandler_
 
 MySQL implementation of Jobs.LoadForErrorHandler.
 """
+from pprint import pprint, pformat
 
 from WMCore.DataStructs.Run import Run
 from WMCore.Database.DBFormatter import DBFormatter
@@ -19,30 +20,34 @@ class LoadForErrorHandler(DBFormatter):
     to determine ACDC records for skipped files in successful jobs, this mode
     is used when a file selection is provided.
     """
-    sql = """SELECT wmbs_job.id, jobgroup, wmbs_job.name AS name,
+    sql = """SELECT wmbs_job.id, wmbs_job.jobgroup, wmbs_job.name,
                     wmbs_job_state.name AS state, state_time, retry_count,
                     couch_record,  cache_dir, wmbs_location.site_name AS location,
                     outcome AS bool_outcome, fwjr_path AS fwjr_path, ww.name as workflow,
-                    ww.task as task, ww.spec as spec, wmbs_users.owner as owner,
-                    wmbs_users.grp as grp
+                    ww.task as task, ww.spec as spec
              FROM wmbs_job
                INNER JOIN wmbs_jobgroup ON wmbs_jobgroup.id = wmbs_job.jobgroup
                INNER JOIN wmbs_subscription ON wmbs_subscription.id = wmbs_jobgroup.subscription
                INNER JOIN wmbs_workflow ww ON ww.id = wmbs_subscription.workflow
-               INNER JOIN wmbs_users ON ww.owner = wmbs_users.id
                LEFT OUTER JOIN wmbs_location ON
                  wmbs_job.location = wmbs_location.id
                LEFT OUTER JOIN wmbs_job_state ON
                  wmbs_job.state = wmbs_job_state.id
              WHERE wmbs_job.id = :jobid"""
 
-    fileSQL = """SELECT wfd.id, wfd.lfn, wfd.filesize size, wfd.events, wfd.first_event,
-                   wfd.merged, wja.job jobid, wpnn.pnn
+    fileSQL = """SELECT wfd.id, wfd.lfn, wfd.filesize AS size, wfd.events, wfd.first_event,
+                   wfd.merged, wja.job AS jobid, wpnn.pnn
                  FROM wmbs_file_details wfd
                  INNER JOIN wmbs_job_assoc wja ON wja.fileid = wfd.id
                  INNER JOIN wmbs_file_location wfl ON wfl.fileid = wfd.id
                  INNER JOIN wmbs_pnns wpnn ON wpnn.id = wfl.pnn
                  WHERE wja.job = :jobid"""
+
+    fileNoLocationSQL = """SELECT wfd.id, wfd.lfn, wfd.filesize AS size, wfd.events,
+                             wfd.first_event, wfd.merged, wja.job AS jobid
+                           FROM wmbs_file_details wfd
+                           INNER JOIN wmbs_job_assoc wja ON wja.fileid = wfd.id
+                           WHERE wja.job = :jobid"""
 
     parentSQL = """SELECT parent.lfn AS lfn, wfp.child AS id
                      FROM wmbs_file_parent wfp
@@ -63,17 +68,44 @@ class LoadForErrorHandler(DBFormatter):
         formattedResult = DBFormatter.formatDict(self, result)
 
         for entry in formattedResult:
-            if entry["bool_outcome"] == 0:
+            entry['input_files'] = []
+            if entry.pop("bool_outcome") == 0:
                 entry["outcome"] = "failure"
             else:
                 entry["outcome"] = "success"
 
-            del entry["bool_outcome"]
-
-            entry['group'] = entry['grp']
-            entry['input_files'] = []
-
         return formattedResult
+
+    def checkNoLocation(self, jobBinds, fileList,
+                        conn=None, transaction=False):
+        """
+        _checkNoLocation_
+
+        There might be files without any valid location (thus no rows in
+        wmbs_file_location), in such cases, run a different query such that
+        they can get uploaded to the ACDCServer
+        :param jobBinds: list of dicts with jobid
+        :param fileList: formatted result returned by fileSQL query
+        :return: nothing, changes fileList in place with the non-location files.
+        """
+        missingJobs = []
+        for job in jobBinds:
+            found = False
+            for fDict in fileList:
+                if job["jobid"] == fDict['jobid']:
+                    found = True
+                    break
+            if not found and job not in missingJobs:
+                missingJobs.append(job)
+
+        if not missingJobs:
+            return
+
+        filesResult = self.dbi.processData(self.fileNoLocationSQL, missingJobs,
+                                           conn=conn, transaction=transaction)
+        filesResult = self.formatDict(filesResult)
+        fileList.extend(filesResult)
+        return
 
     def execute(self, jobID, fileSelection=None,
                 conn=None, transaction=False):
@@ -82,6 +114,8 @@ class LoadForErrorHandler(DBFormatter):
 
         Execute the SQL for the given job ID and then format and return
         the result.
+        fileSelection is a dictionary key'ed by the job id and with a list
+        of lfns
         """
 
         if isinstance(jobID, list):
@@ -90,16 +124,19 @@ class LoadForErrorHandler(DBFormatter):
                 return []
             binds = jobID
         else:
-            binds = {"jobid": jobID}
+            binds = [{"jobid": jobID}]
 
         result = self.dbi.processData(self.sql, binds, conn=conn,
                                       transaction=transaction)
-
         jobList = self.formatJobs(result)
+        print("jobList %s" % pformat(jobList))
 
         filesResult = self.dbi.processData(self.fileSQL, binds, conn=conn,
                                            transaction=transaction)
         fileList = self.formatDict(filesResult)
+        self.checkNoLocation(binds, fileList)
+        print("fileList %s" % pformat(fileList))
+
         fileBinds = []
         if fileSelection:
             fileList = [x for x in fileList if x['lfn'] in fileSelection[x['jobid']]]
@@ -107,7 +144,7 @@ class LoadForErrorHandler(DBFormatter):
             # Add new runs
             x['newRuns'] = []
             # Assemble unique list of binds
-            if not {'fileid': x['id']} in fileBinds:
+            if {'fileid': x['id']} not in fileBinds:
                 fileBinds.append({'fileid': x['id']})
 
         parentList = []
@@ -148,15 +185,16 @@ class LoadForErrorHandler(DBFormatter):
             if f['id'] not in filesForJobs[jobid].keys():
                 wmbsFile = File(id=f['id'])
                 wmbsFile.update(f)
-                wmbsFile['locations'].add(f['pnn'])
+                if 'pnn' in f:  # file might not have a valid location
+                    wmbsFile['locations'].add(f['pnn'])
                 for r in wmbsFile['newRuns']:
                     wmbsFile.addRun(r)
                 for entry in parentList:
                     if entry['id'] == f['id']:
                         wmbsFile['parents'].add(entry['lfn'])
                 filesForJobs[jobid][f['id']] = wmbsFile
-            else:
-                # If the file is there, just add the location
+            elif 'pnn' in f:
+                # If the file is there and it has a location, just add it
                 filesForJobs[jobid][f['id']]['locations'].add(f['pnn'])
 
         for j in jobList:

--- a/src/python/WMCore/WMBS/MySQL/Jobs/LoadForErrorHandler.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/LoadForErrorHandler.py
@@ -4,7 +4,6 @@ _LoadForErrHandler_
 
 MySQL implementation of Jobs.LoadForErrorHandler.
 """
-from pprint import pprint, pformat
 
 from WMCore.DataStructs.Run import Run
 from WMCore.Database.DBFormatter import DBFormatter
@@ -52,7 +51,7 @@ class LoadForErrorHandler(DBFormatter):
 
 
     def updateFilesWithoutLocation(self, jobBinds, fileList,
-                          conn=None, transaction=False):
+                                   conn=None, transaction=False):
         """
         _updateFilesWithoutLocation_
 
@@ -141,8 +140,6 @@ class LoadForErrorHandler(DBFormatter):
         jobList = self.formatDict(result)
         for entry in jobList:
             entry.setdefault('input_files', [])
-
-        print("jobList %s" % pformat(jobList))
 
         filesResult = self.dbi.processData(self.fileSQL, binds, conn=conn,
                                            transaction=transaction)

--- a/src/python/WMCore/WMBS/Oracle/Jobs/LoadForErrorHandler.py
+++ b/src/python/WMCore/WMBS/Oracle/Jobs/LoadForErrorHandler.py
@@ -14,11 +14,4 @@ class LoadForErrorHandler(MySQLLoadForErrorHandler):
 
     If it's not the same as MySQL, I don't want to know.
     """
-
-    fileSQL = """SELECT wfd.id, wfd.lfn, wfd.filesize "size", wfd.events, wfd.first_event,
-                   wfd.merged, wja.job "jobid", wpnn.pnn
-                 FROM wmbs_file_details wfd
-                 INNER JOIN wmbs_job_assoc wja ON wja.fileid = wfd.id
-                 INNER JOIN wmbs_file_location wfl ON wfl.fileid = wfd.id
-                 INNER JOIN wmbs_pnns wpnn ON wpnn.id = wfl.pnn
-                 WHERE wja.job = :jobid"""
+    pass

--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -413,6 +413,16 @@ class WorkQueue(WorkQueueBase):
                                            splitedBlockName['Offset'],
                                            splitedBlockName['NumOfFiles'])
 
+            # If TrustSitelist is enabled, then assume files without location are
+            # available at the ACDC collection location
+            if match['NoInputUpdate']:
+                acdcLocations = match['Inputs'].values()[0]
+                for f in fileLists:
+                    if not f['locations']:
+                        msg = "ACDC file %s with no location, but trusting the TrustSitelists" % f['lfn']
+                        self.logger.info(msg)
+                        for loc in acdcLocations:
+                            f['locations'].add(loc)
             block = {}
             block["Files"] = fileLists
             return blockName, block


### PR DESCRIPTION
Fixes #8448 and partially fixes #8253
In addition to that:
* I cleaned up several keys that are not used for ACDC collection creation
* improved ACDC collection creation with sorted failed jobs (also bumped slice of jobs to process from 30 to 300)

The performance speed up is much lower than what I expected, but I think that's just because all tests are accessing local couchdb. Old failedJobs() takes around 65secs, with these changes it takes around 40secs for 5k jobs.