### PR TITLE
Adapt EventsPerJob to a multiple of EventsPerLumi - EventBased only

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/DataProcessing.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/DataProcessing.py
@@ -28,6 +28,7 @@ class DataProcessing(StdBase):
             if self.procJobSplitAlgo == "EventAwareLumiBased":
                 self.procJobSplitArgs["job_time_limit"] = 48 * 3600  # 2 days
             self.procJobSplitArgs["events_per_job"] = self.eventsPerJob
+            arguments['EventsPerJob'] = self.eventsPerJob
         elif self.procJobSplitAlgo == "LumiBased":
             self.procJobSplitArgs["lumis_per_job"] = self.lumisPerJob
         elif self.procJobSplitAlgo == "FileBased":

--- a/src/python/WMCore/WMSpec/StdSpecs/MonteCarlo.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/MonteCarlo.py
@@ -105,10 +105,10 @@ class MonteCarloWorkloadFactory(StdBase):
         # Tune the splitting, only EventBased is allowed for MonteCarlo
         # 8h jobs are CMS standard, set the default with that in mind
         self.prodJobSplitAlgo = "EventBased"
-        if self.eventsPerJob is None:
-            self.eventsPerJob = int((8.0 * 3600.0) / self.timePerEvent)
-        if self.eventsPerLumi is None:
-            self.eventsPerLumi = self.eventsPerJob
+        self.eventsPerJob, self.eventsPerLumi = StdBase.calcEvtsPerJobLumi(self.eventsPerJob,
+                                                                           self.eventsPerLumi,
+                                                                           self.timePerEvent)
+
         self.prodJobSplitArgs = {"events_per_job": self.eventsPerJob,
                                  "events_per_lumi": self.eventsPerLumi,
                                  "lheInputFiles": self.lheInputFiles}
@@ -124,6 +124,9 @@ class MonteCarloWorkloadFactory(StdBase):
         if self.firstLumi > 1:
             self.previousJobCount = int(math.ceil((self.firstEvent - 1) / self.eventsPerJob))
             self.prodJobSplitArgs["initial_lfn_counter"] = self.previousJobCount
+
+        # Feed values back to save in couch
+        arguments['EventsPerJob'] = self.eventsPerJob
 
         return self.buildWorkload()
 

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -4,6 +4,7 @@ _StdBase_
 
 Base class with helper functions for standard WMSpec files.
 """
+from __future__ import division
 import logging
 
 from Utils.Utilities import makeList, makeNonEmptyList, strToBool, safeStr
@@ -77,6 +78,32 @@ class StdBase(object):
 
     # static copy of the skim mapping
     skimMap = {}
+
+    @staticmethod
+    def calcEvtsPerJobLumi(ePerJob, ePerLumi, tPerEvent):
+        """
+        _calcEvtsPerJobLumi_
+        
+        Given EventsPerJob, EventsPerLumi and TimePerEvent information,
+        calculates the final values for EventsPerJob and EventsPerLumi.
+        
+        If user provided both values, then we don't do anything.
+        :param ePerJob: events per job
+        :param ePerLumi: events per lumi
+        :param tPerEvent: time per event
+        """
+        if ePerLumi is None and ePerJob is None:
+            ePerJob = int((8.0 * 3600.0) / tPerEvent)
+            ePerLumi = ePerJob
+        elif ePerJob is None:
+            ePerJob = int((8.0 * 3600.0) / tPerEvent)
+            # then make EventsPerJob multiple of EventsPerLumi and still closer to 8h jobs
+            multiplier = int(round(ePerJob / ePerLumi))
+            ePerJob = ePerLumi * multiplier
+        elif ePerLumi is None:
+            ePerLumi = ePerJob
+
+        return ePerJob, ePerLumi
 
     @staticmethod
     def skimToDataTier(cmsswVersion, skim):

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StdBase_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StdBase_t.py
@@ -8,9 +8,8 @@ Created on Jun 14, 2013
 from __future__ import print_function
 
 import unittest
-from nose.plugins.attrib import attr
+
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
-from WMCore.WMSpec.WMSpecErrors import WMSpecFactoryException
 
 
 class StdBaseTest(unittest.TestCase):
@@ -51,38 +50,23 @@ class StdBaseTest(unittest.TestCase):
         stdBaseInstance.factoryWorkloadConstruction("TestWorkload", arguments)
         return
 
-    @attr('integration')
-    def testStdBaseIncludeParentsValidation(self):
+    def testCalcEvtsPerJobLumi(self):
         """
-        _testStdBaseValidation_
+        _testCalcEvtsPerJobLumi_
 
-        Check that the test arguments pass basic validation,
-        i.e. no exception should be raised.
+        Check that EventsPerJob and EventsPerLumi are properly calculated
+        for EventBased job splitting.
         """
-        arguments = StdBase.getTestArguments()
-        stdBaseInstance = StdBase()
+        self.assertEqual((123, 345), StdBase.calcEvtsPerJobLumi(123, 345, 1))
+        self.assertEqual((123, 123), StdBase.calcEvtsPerJobLumi(123, None, 1))
 
-        arguments["IncludeParents"] = True
-        arguments["InputDataset"] = "/Cosmics/Commissioning2015-v1/RAW"
-        self.assertRaises(WMSpecFactoryException, stdBaseInstance.factoryWorkloadConstruction, "TestWorkload",
-                          arguments)
+        self.assertEqual((28800, 100), StdBase.calcEvtsPerJobLumi(None, 100, 1))
+        self.assertEqual((600, 100), StdBase.calcEvtsPerJobLumi(None, 100, 50.5))
+        self.assertEqual((1000, 1000), StdBase.calcEvtsPerJobLumi(None, 1000, 50.5))
 
-        arguments["IncludeParents"] = True
-        self.assertRaises(WMSpecFactoryException, stdBaseInstance.factoryWorkloadConstruction, "TestWorkload",
-                          arguments)
+        self.assertEqual((23040, 23040), StdBase.calcEvtsPerJobLumi(None, None, 1.25))
+        self.assertEqual((229, 229), StdBase.calcEvtsPerJobLumi(None, None, 125.5))
 
-        arguments["IncludeParents"] = True
-        arguments["InputDataset"] = "/Cosmics/Commissioning2015-6Mar2015-v1/RECO"
-        stdBaseInstance.factoryWorkloadConstruction("TestWorkload", arguments)
-
-        arguments["IncludeParents"] = False
-        arguments["InputDataset"] = "/Cosmics/Commissioning2015-6Mar2015-v1/RECO"
-        stdBaseInstance.factoryWorkloadConstruction("TestWorkload", arguments)
-
-        arguments["IncludeParents"] = False
-        arguments["InputDataset"] = "/Cosmics/ABS/RAW"
-        arguments["DbsUrl"] = None
-        stdBaseInstance.factoryWorkloadConstruction("TestWorkload", arguments)
         return
 
 


### PR DESCRIPTION
Fixes #6857

Use cases are:
1) if requestor provides both EpJ and EpL, then nothing gets changed
2) if requestor provides EpJ but *not* EpL, then usual `EpL = EpJ` is applied
3) if requestor provides EpL but *not* EpJ, 8h job is calculate and EpJ is adapted to a multiple of EpL
4) if requestor doesn't provide any of these, 8h job is calculated and usual `EpL = EpJ` is applied.

I'm expecting tests to fail... I also think the workload_cache document won't get updated with the adapted value (that information is uploaded outside of the spec factory, I have to investigate how to update it before it gets persisted)