### PR TITLE
EventsPerJob multiple of EventsPerLumi even if both provided

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -87,23 +87,24 @@ class StdBase(object):
         Given EventsPerJob, EventsPerLumi and TimePerEvent information,
         calculates the final values for EventsPerJob and EventsPerLumi.
         
-        If user provided both values, then we don't do anything.
+        Final result will always be an EventsPerJob multiple of EventsPerLumi,
+        no matter whether EventsPerJob was provided or not.
         :param ePerJob: events per job
         :param ePerLumi: events per lumi
         :param tPerEvent: time per event
         """
-        if ePerLumi is None and ePerJob is None:
+        # if not set, let's calculate an 8h job and set it for you
+        if ePerJob is None:
             ePerJob = int((8.0 * 3600.0) / tPerEvent)
+
+        if ePerLumi is None:
             ePerLumi = ePerJob
-        elif ePerJob is None:
-            ePerJob = int((8.0 * 3600.0) / tPerEvent)
+        else:
             # then make EventsPerJob multiple of EventsPerLumi and still closer to 8h jobs
             multiplier = int(round(ePerJob / ePerLumi))
             # make sure not to have 0 EventsPerJob
             multiplier = max(multiplier, 1)
             ePerJob = ePerLumi * multiplier
-        elif ePerLumi is None:
-            ePerLumi = ePerJob
 
         return ePerJob, ePerLumi
 

--- a/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
@@ -49,6 +49,7 @@ class StepChainWorkloadFactory(StdBase):
         self.primaryDataset = None
         self.prepID = None
         self.eventsPerJob = None
+        self.eventsPerLumi = None
         # stepMapping is going to be used during assignment for properly mapping
         # the arguments to each step/cmsRun
         self.stepMapping = {}
@@ -103,6 +104,8 @@ class StepChainWorkloadFactory(StdBase):
         # Feed values back to save in couch
         if self.eventsPerJob:
             arguments['Step1']['EventsPerJob'] = self.eventsPerJob
+        if self.eventsPerLumi:
+            arguments['Step1']['EventsPerLumi'] = self.eventsPerLumi
         return self.workload
 
     def setupGeneratorTask(self, task, taskConf):
@@ -336,6 +339,7 @@ class StepChainWorkloadFactory(StdBase):
                                                                                              taskConf.get("EventsPerLumi"),
                                                                                              self.timePerEvent)
             self.eventsPerJob = taskConf["EventsPerJob"]
+            self.eventsPerLumi = taskConf["EventsPerLumi"]
             taskConf["SplittingArguments"]["events_per_job"] = taskConf["EventsPerJob"]
             if taskConf["SplittingAlgo"] == "EventBased":
                 taskConf["SplittingArguments"]["events_per_lumi"] = taskConf["EventsPerLumi"]

--- a/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
@@ -204,6 +204,7 @@ class TaskChainWorkloadFactory(StdBase):
     def __init__(self):
         StdBase.__init__(self)
         self.eventsPerJob = None
+        self.eventsPerLumi = None
         self.mergeMapping = {}
         self.taskMapping = {}
 
@@ -281,6 +282,8 @@ class TaskChainWorkloadFactory(StdBase):
         # Feed values back to save in couch
         if self.eventsPerJob:
             arguments['Task1']['EventsPerJob'] = self.eventsPerJob
+        if self.eventsPerLumi:
+            arguments['Task1']['EventsPerLumi'] = self.eventsPerLumi
         return self.workload
 
     def makeTask(self, taskConf, parentTask=None):
@@ -495,7 +498,9 @@ class TaskChainWorkloadFactory(StdBase):
                                                                                              taskConf.get("EventsPerLumi"),
                                                                                              taskConf.get("TimePerEvent",
                                                                                                           self.timePerEvent))
-            self.eventsPerJob = taskConf["EventsPerJob"]
+            if firstTask:
+                self.eventsPerJob = taskConf["EventsPerJob"]
+                self.eventsPerLumi = taskConf["EventsPerLumi"]
             taskConf["SplittingArguments"]["events_per_job"] = taskConf["EventsPerJob"]
             if taskConf["SplittingAlgo"] == "EventBased":
                 taskConf["SplittingArguments"]["events_per_lumi"] = taskConf["EventsPerLumi"]

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StdBase_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StdBase_t.py
@@ -57,7 +57,7 @@ class StdBaseTest(unittest.TestCase):
         Check that EventsPerJob and EventsPerLumi are properly calculated
         for EventBased job splitting.
         """
-        self.assertEqual((123, 345), StdBase.calcEvtsPerJobLumi(123, 345, 1))
+        self.assertEqual((345, 345), StdBase.calcEvtsPerJobLumi(123, 345, 1))
         self.assertEqual((123, 123), StdBase.calcEvtsPerJobLumi(123, None, 1))
 
         self.assertEqual((28800, 100), StdBase.calcEvtsPerJobLumi(None, 100, 1))
@@ -67,7 +67,7 @@ class StdBaseTest(unittest.TestCase):
         self.assertEqual((23040, 23040), StdBase.calcEvtsPerJobLumi(None, None, 1.25))
         self.assertEqual((229, 229), StdBase.calcEvtsPerJobLumi(None, None, 125.5))
 
-        self.assertEqual((24000, 11764), StdBase.calcEvtsPerJobLumi(24000, 11764, 10.157120496967591))
+        self.assertEqual((23528, 11764), StdBase.calcEvtsPerJobLumi(24000, 11764, 10.157120496967591))
         self.assertEqual((11764, 11764), StdBase.calcEvtsPerJobLumi(None, 11764, 10.157120496967591))  # non rounded result is 2835
 
         return


### PR DESCRIPTION
Fixes #8124
Complement for #8515 , basically to fix the case below
>    if requestor provides both EpJ and EpL, then nothing gets changed

as just discussed with @vlimant , even if the requestor provides EventsPerJob value, we'll recalculate it such that it's multiple of EventsPerLumi and override it in the spec.