### PR TITLE
Fetch monitoring metrics from the ReqMgr monitoring thread

### DIFF
--- a/src/python/WMCore/REST/HeartbeatMonitorBase.py
+++ b/src/python/WMCore/REST/HeartbeatMonitorBase.py
@@ -8,6 +8,9 @@ class HeartbeatMonitorBase(CherryPyPeriodicTask):
         super(HeartbeatMonitorBase, self).__init__(config)
         self.centralWMStats = WMStatsWriter(config.wmstats_url)
         self.threadList = config.thread_list
+        self.postToAMQ = getattr(config, "post_to_amq", False)
+        self.topicAMQ = getattr(config, "topic_amq", None)
+        self.hostPortAMQ = getattr(config, "host_port_amq", None)
 
     def setConcurrentTasks(self, config):
         """
@@ -18,7 +21,7 @@ class HeartbeatMonitorBase(CherryPyPeriodicTask):
     def reportToWMStats(self, config):
         """
         report thread status and heartbeat.
-        Also can report additional mointoring information by rewriting addAdditionalMonitorReport method
+        Also can report additional monitoring information by rewriting addAdditionalMonitorReport method
         """
         self.logger.info("Checking Thread status...")
         downThreadInfo = self.logDB.wmstats_down_components_report(self.threadList)

--- a/src/python/WMCore/ReqMgr/CherryPyThreads/HeartbeatMonitor.py
+++ b/src/python/WMCore/ReqMgr/CherryPyThreads/HeartbeatMonitor.py
@@ -1,5 +1,187 @@
-from __future__ import (division, print_function)
+from __future__ import division, print_function
+
+import time
+from pprint import pformat
+
 from WMCore.REST.HeartbeatMonitorBase import HeartbeatMonitorBase
+from WMCore.ReqMgr.DataStructs.RequestStatus import ACTIVE_STATUS
+from WMCore.Services.StompAMQ.StompAMQ import StompAMQ
+from WMCore.Services.WMStatsServer.WMStatsServer import WMStatsServer
+
+
+def _getCampaign(propertyValue):
+    """
+    WMStats server can return this argument in three different data types.
+    If there are multiple values, return only the first one.
+    """
+    if not propertyValue:  # Empty string is Ok; it should never be None though
+        return ["NONE"]
+    elif isinstance(propertyValue, basestring):
+        return [propertyValue]
+    # then it's a list
+    return propertyValue
+
+
+def _getRequestNumEvents(propertyValue):
+    """
+    WMStats server can return this argument in three different data types.
+    If there are multiple values, return only the first one.
+    """
+    if not propertyValue:
+        return 0
+    elif isinstance(propertyValue, list):
+        return propertyValue[0]
+    # then it's integer
+    return propertyValue
+
+
+def initMetrics():
+    """
+    Initialize the metrics dictionary
+    :param veryActiveStatus: a small list of active status
+    """
+    results = {"requestsByStatus": {},
+               "requestsByStatusAndCampaign": {},
+               "requestsByStatusAndPrio": {},
+               "requestsByStatusAndNumEvts": {}}
+
+    for st in ACTIVE_STATUS:
+        results["requestsByStatus"].setdefault(st, 0)
+        results["requestsByStatusAndNumEvts"].setdefault(st, 0)
+        results["requestsByStatusAndCampaign"].setdefault(st, {})
+        results["requestsByStatusAndPrio"].setdefault(st, {})
+
+    return results
+
 
 class HeartbeatMonitor(HeartbeatMonitorBase):
-    pass
+
+    def __init__(self, rest, config):
+        super(HeartbeatMonitor, self).__init__(rest, config)
+        self.userAMQ = getattr(config, "user_amq", None)
+        self.passAMQ = getattr(config, "pass_amq", None)
+
+        self.producer = "reqmgr2"
+        self.docTypeAMQ = "cms_%s_info" % self.producer
+
+    def addAdditionalMonitorReport(self, config):
+        """
+        _addAdditionalMonitorReport_
+
+        Collect general request information and post it to both central
+        couchdb and MonIT. Items to fetch:
+         * number of requests in each status (excluding archived ones)
+         * for requests in assignment-approved:
+           * their priority
+           * their RequestNumEvents (if there is no input dataset)
+         * for assignment-approved, assigned, acquired, running-* and completed:
+           * number of requests in each campaign
+        """
+        self.logger.info("Collecting ReqMgr2 statistics...")
+        wmstatsSvc = WMStatsServer(config.wmstatsSvc_url, logger=self.logger)
+
+        results = initMetrics()
+
+        inputConditon = {}
+        outputMask = ["RequestStatus", "RequestType", "RequestPriority",
+                      "Campaign", "RequestNumEvents"]
+        startT = int(time.time())
+        for reqInfo in wmstatsSvc.getFilteredActiveData(inputConditon, outputMask):
+            status = reqInfo['RequestStatus']
+            results['requestsByStatus'][status] += 1
+
+            for campaign in _getCampaign(reqInfo["Campaign"]):
+                results["requestsByStatusAndCampaign"][status].setdefault(campaign, 0)
+                results['requestsByStatusAndCampaign'][status][campaign] += 1
+
+            requestPrio = reqInfo['RequestPriority']
+            results["requestsByStatusAndPrio"][status].setdefault(requestPrio, 0)
+            results['requestsByStatusAndPrio'][status][requestPrio] += 1
+
+            results['requestsByStatusAndNumEvts'][status] += _getRequestNumEvents(reqInfo['RequestNumEvents'])
+
+        endT = int(time.time())
+        results["total_query_time"] = endT - startT
+
+        if self.postToAMQ:
+            allDocs = self.buildMonITDocs(results)
+            self.uploadToAMQ(allDocs)
+
+        return results
+
+    def buildMonITDocs(self, stats):
+        """
+        Given the statistics that are uploaded to wmstats, create different
+        documents to post to MonIT AMQ (aggregation-friendly docs).
+        """
+        commonInfo = {"version": '0.3',
+                      "agent_url": "reqmgr2"}
+
+        docs = []
+        for status, numReq in stats['requestsByStatus'].iteritems():
+            doc = {}
+            doc["type"] = "reqmgr2_status"
+            doc["request_status"] = status
+            doc["num_requests"] = numReq
+            doc.update((commonInfo))
+            docs.append(doc)
+
+        for status, items in stats['requestsByStatusAndCampaign'].iteritems():
+            for campaign, numReq in items.iteritems():
+                doc = {}
+                doc["type"] = "reqmgr2_campaign"
+                doc["request_status"] = status
+                doc["campaign"] = campaign
+                doc["num_requests"] = numReq
+                doc.update((commonInfo))
+                docs.append(doc)
+
+        for status, items in stats['requestsByStatusAndPrio'].iteritems():
+            for prio, numReq in items.iteritems():
+                doc = {}
+                doc["type"] = "reqmgr2_prio"
+                doc["request_status"] = status
+                doc["request_priority"] = prio
+                doc["num_requests"] = numReq
+                doc.update((commonInfo))
+                docs.append(doc)
+
+        for status, evts in stats['requestsByStatusAndNumEvts'].iteritems():
+            doc = {}
+            doc["type"] = "reqmgr2_events"
+            doc["request_status"] = status
+            doc["total_num_events"] = evts
+            doc.update((commonInfo))
+            docs.append(doc)
+
+        self.logger.info("%i docs created to post to MonIT", len(docs))
+        return docs
+
+    def uploadToAMQ(self, docs, producer="reqmgr2"):
+        """
+        _uploadToAMQ_
+
+        Submits all the docs to CERN MonIT AMQ..
+        :param docs: list of documents to be posted
+        :param producer: service providing this info
+        """
+        self.logger.debug("Sending %s", pformat(docs))
+        ts = int(time.time())
+
+        try:
+            stompSvc = StompAMQ(username=self.userAMQ,
+                                password=self.passAMQ,
+                                producer=self.producer,
+                                topic=self.topicAMQ,
+                                host_and_ports=self.hostPortAMQ,
+                                logger=self.logger)
+
+            notifications = stompSvc.make_notification(payload=docs, docType=self.docTypeAMQ,
+                                                       docId=self.producer, ts=ts)
+
+            failures = stompSvc.send(notifications)
+            self.logger.info("%i docs successfully sent to Stomp AMQ", len(notifications) - len(failures))
+        except Exception as ex:
+            self.logger.exception("Failed to send data to StompAMQ. Error %s", str(ex))
+
+        return

--- a/src/python/WMCore/Services/StompAMQ/StompAMQ.py
+++ b/src/python/WMCore/Services/StompAMQ/StompAMQ.py
@@ -8,44 +8,44 @@ from __future__ import division
 import json
 import logging
 import time
-import uuid
-
 import stomp
+from WMCore.Services.UUIDLib import makeUUID
+
 
 class StompyListener(object):
     """
     Auxiliar listener class to fetch all possible states in the Stomp
     connection.
     """
-    def __init__(self):
-        self.logr = logging.getLogger(__name__)
+    def __init__(self, logger=None):
+        self.logger = logger if logger else logging.getLogger()
 
     def on_connecting(self, host_and_port):
-        self.logr.info('on_connecting %s', str(host_and_port))
+        self.logger.debug('on_connecting %s', str(host_and_port))
 
     def on_error(self, headers, message):
-        self.logr.info('received an error %s %s', str(headers), str(message))
+        self.logger.debug('received an error %s %s', str(headers), str(message))
 
     def on_message(self, headers, body):
-        self.logr.info('on_message %s %s', str(headers), str(body))
+        self.logger.debug('on_message %s %s', str(headers), str(body))
 
     def on_heartbeat(self):
-        self.logr.info('on_heartbeat')
+        self.logger.debug('on_heartbeat')
 
     def on_send(self, frame):
-        self.logr.info('on_send HEADERS: %s, BODY: %s ...', str(frame.headers), str(frame.body)[:160])
+        self.logger.debug('on_send HEADERS: %s, BODY: %s ...', str(frame.headers), str(frame.body)[:160])
 
     def on_connected(self, headers, body):
-        self.logr.info('on_connected %s %s', str(headers), str(body))
+        self.logger.debug('on_connected %s %s', str(headers), str(body))
 
     def on_disconnected(self):
-        self.logr.info('on_disconnected')
+        self.logger.debug('on_disconnected')
 
     def on_heartbeat_timeout(self):
-        self.logr.info('on_heartbeat_timeout')
+        self.logger.debug('on_heartbeat_timeout')
 
     def on_before_message(self, headers, body):
-        self.logr.info('on_before_message %s %s', str(headers), str(body))
+        self.logger.debug('on_before_message %s %s', str(headers), str(body))
 
         return (headers, body)
 
@@ -64,18 +64,16 @@ class StompAMQ(object):
     """
 
     # Version number to be added in header
-    _version = '0.1'
+    _version = '0.2'
 
-    def __init__(self, username, password,
-                 producer='CMS_WMCore_StompAMQ',
-                 topic='/topic/cms.jobmon.wmagent',
-                 host_and_ports=None, verbose=0):
-        self._host_and_ports = host_and_ports or [('agileinf-mb.cern.ch', 61213)]
+    def __init__(self, username, password, producer, topic,
+                 host_and_ports=None, logger=None):
         self._username = username
         self._password = password
         self._producer = producer
         self._topic = topic
-        self.verbose = verbose
+        self._host_and_ports = host_and_ports or [('agileinf-mb.cern.ch', 61213)]
+        self.logger = logger if logger else logging.getLogger()
 
     def send(self, data):
         """
@@ -87,31 +85,33 @@ class StompAMQ(object):
 
         :return: a list of successfully sent notification bodies
         """
+        if not isinstance(data, list):
+            self.logger.error("Argument for send method has to be a list, not %s", type(data))
+            return data
 
         conn = stomp.Connection(host_and_ports=self._host_and_ports)
-        conn.set_listener('StompyListener', StompyListener())
+        conn.set_listener('StompyListener', StompyListener(self.logger))
         try:
             conn.start()
             conn.connect(username=self._username, passcode=self._password, wait=True)
         except stomp.exception.ConnectFailedException as exc:
-            print("ERROR: Connection to %s failed %s" % (repr(self._host_and_ports), str(exc)))
+            self.logger.error("Connection to %s failed %s", repr(self._host_and_ports), str(exc))
             return []
 
-        # If only a single notification, put it in a list
-        if isinstance(data, dict) and 'topic' in data:
-            data = [data]
-
-        successfully_sent = []
+        failedNotifications = []
         for notification in data:
-            body = self._send_single(conn, notification)
-            if body:
-                successfully_sent.append(body)
+            result = self._send_single(conn, notification)
+            if result:
+                failedNotifications.append(result)
 
         if conn.is_connected():
             conn.disconnect()
 
-        print('Sent %d docs to %s' % (len(successfully_sent), repr(self._host_and_ports)))
-        return successfully_sent
+        if failedNotifications:
+            self.logger.warning('Failed to send to %s %i docs out of %i', repr(self._host_and_ports),
+                                len(failedNotifications), len(data))
+
+        return failedNotifications
 
     def _send_single(self, conn, notification):
         """
@@ -120,60 +120,54 @@ class StompAMQ(object):
         :param conn: An already connected stomp.Connection
         :param notification: A dictionary as returned by `make_notification`
 
-        :return: The notification body in case of success, or else None
+        :return: The notification body in case of failure, or else None
         """
         try:
             body = notification.pop('body')
-            destination = notification.pop('topic')
-            conn.send(destination=destination,
+            conn.send(destination=self._topic,
                       headers=notification,
                       body=json.dumps(body),
                       ack='auto')
-            if  self.verbose:
-                print('Notification %s sent' % str(notification))
-            return body
+            self.logger.debug('Notification %s sent', str(notification))
         except Exception as exc:
-            print('ERROR: Notification: %s not send, error: %s' % \
-                          (str(notification), str(exc)))
-            return None
+            self.logger.error('Notification: %s not send, error: %s', str(notification), str(exc))
+            return body
+        return
 
-
-    def make_notification(self, payload, id_, producer=None):
+    def make_notification(self, payload, docType, docId, producer=None, ts=None):
         """
-        Generate a notification with the specified data
+        Given a single payload (or a list of them), generate a list
+        of notifications including the specified data.
 
         :param payload: Actual notification data.
-        :param id_: Id representing the notification.
+        :param docType: document type for the high level metadata.
+        :param docId: document id representing the notification.
         :param producer: The notification producer.
-            Default: StompAMQ._producer
+        :param ts: timestamp to be added to each document metadata.
 
-        :return: the generated notification
+        :return: a list of notifications with the proper metadata
         """
         producer = producer or self._producer
+        ts = ts or int(time.time())
 
-        notification = {}
-        notification['topic'] = self._topic
+        if isinstance(payload, dict):
+            payload = [payload]  # it was a single document
 
-        # Add headers
-        headers = {
-                   'type': 'cms_wmagent_info',
-                   'version': self._version,
-                   'producer': producer
-        }
+        commonHeaders = {'type': docType,
+                         'version': self._version,
+                         'producer': producer}
 
-        notification.update(headers)
+        docs = []
+        for doc in payload:
+            notification = {}
+            notification.update(commonHeaders)
+            # Add body consisting of the payload and metadata
+            body = {'payload': doc,
+                    'metadata': {'timestamp': ts,
+                                 'id': docId,
+                                 'uuid': makeUUID()}
+                   }
+            notification['body'] = body
+            docs.append(notification)
 
-        # Add body consisting of the payload and metadata
-        body = {
-            'payload': payload,
-            'metadata': {
-                'timestamp': int(time.time()),
-                'id': id_,
-                'uuid': str(uuid.uuid4()),
-            }
-        }
-
-        notification['body'] = body
-
-        return notification
-
+        return docs


### PR DESCRIPTION
Supposedly fixing #8443 , but I still need to get my AMQ topic created and those documents properly structured and posted to MonIT.

It needs this deployment patch as well: https://github.com/dmwm/deployment/pull/590
There are also a few tweaks that I need to make in this patch, but in theory it's working :)

This is how these metrics will look like for wmstats and MonIT:
http://amaltaro.web.cern.ch/amaltaro/forWMCore/PR_8521/data_struct

There are changes to the spec files as well, we need to add a new dependency on: py2-stomp