### PR TITLE
ResourceControl API to add standalone PNNs into the database

### DIFF
--- a/bin/wmagent-resource-control
+++ b/bin/wmagent-resource-control
@@ -109,7 +109,7 @@ def getCMSSiteInfo(pattern=''):
     """
     print("Querying SiteDB for site information...")
 
-    return SiteDBJSON().PSNtoPNNMap(pattern.replace('*', '.*').replace('%', '.*'))
+    return SiteDBJSON().PSNtoPNNMap(pattern)
 
 
 def addSites(resourceControl, allSites, ceName, plugin, pendingSlots, runningSlots,
@@ -139,6 +139,20 @@ def addSites(resourceControl, allSites, ceName, plugin, pendingSlots, runningSlo
     if state:
         for siteName in allSites.keys():
             setSiteState(resourceControl, siteName, state)
+
+    return
+
+def addPNNs(resourceControl, pattern):
+    """
+    _addPNNs_
+
+    Add the given sites to resource control and add tasks as well.
+    """
+    print("Querying SiteDB for PhEDEx Node Names...")
+
+    pnns = SiteDBJSON().getAllPhEDExNodeNames(pattern, excludeBuffer=True)
+    print("Inserting %i PNNs into WMBS table" % len(pnns))
+    resourceControl.insertPNNs(pnns)
 
     return
 
@@ -312,21 +326,29 @@ else:
         addSites(myResourceControl, testSite, "CERN", "SimpleCondorPlugin",
                  500, 1, state=options.state)
     elif options.addT1s:
-        t1Sites = getCMSSiteInfo("T1*")
+        pattern = "T1.*"
+        t1Sites = getCMSSiteInfo(pattern)
         addSites(myResourceControl, t1Sites, options.ceName, options.plugin,
                  options.pendingSlots, options.runningSlots, state=options.state)
+        addPNNs(myResourceControl, pattern=pattern)
     elif options.addT2s:
-        t2Sites = getCMSSiteInfo("T2*")
+        pattern = "T2.*"
+        t2Sites = getCMSSiteInfo(pattern)
         addSites(myResourceControl, t2Sites, options.ceName, options.plugin,
                  options.pendingSlots, options.runningSlots, state=options.state)
+        addPNNs(myResourceControl, pattern=pattern)
     elif options.addT3s:
-        t3Sites = getCMSSiteInfo("T3*")
+        pattern = "T3.*"
+        t3Sites = getCMSSiteInfo(pattern)
         addSites(myResourceControl, t3Sites, options.ceName, options.plugin,
                  options.pendingSlots, options.runningSlots, state=options.state)
+        addPNNs(myResourceControl, pattern=pattern)
     elif options.addAllSites:
-        allSites = getCMSSiteInfo("*")
+        pattern = ".*"
+        allSites = getCMSSiteInfo(pattern)
         addSites(myResourceControl, allSites, options.ceName, options.plugin,
                  options.pendingSlots, options.runningSlots, state=options.state)
+        addPNNs(myResourceControl, pattern=pattern)
     elif options.addOneSite:
         oneSite = getCMSSiteInfo(options.addOneSite)
         addSites(myResourceControl, oneSite, options.ceName, options.plugin,

--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -229,7 +229,7 @@ config.ErrorHandler.logLevel = globalLogLevel
 config.ErrorHandler.pollInterval = 240
 config.ErrorHandler.readFWJR = True
 config.ErrorHandler.maxFailTime = 120000
-config.ErrorHandler.maxProcessSize = 30
+config.ErrorHandler.maxProcessSize = 500
 
 config.component_("RetryManager")
 config.RetryManager.namespace = "WMComponent.RetryManager.RetryManager"

--- a/src/python/WMCore/ACDC/DataCollectionService.py
+++ b/src/python/WMCore/ACDC/DataCollectionService.py
@@ -9,6 +9,7 @@ Copyright (c) 2010 Fermilab. All rights reserved.
 
 import logging
 import threading
+from operator import itemgetter
 from WMCore.DAOFactory import DAOFactory
 
 import WMCore.ACDC.CollectionTypes as CollectionTypes
@@ -90,20 +91,28 @@ class DataCollectionService(CouchService):
 
         NOTE: jobs must have a non-standard task, workflow attributes assigned to them.
         """
+        # first we sort the list of dictionary by two keys: workflow then task
+        failedJobs.sort(key=itemgetter('workflow'))
+        failedJobs.sort(key=itemgetter('task'))
+
+        previousWorkflow = ""
+        previousTask = ""
         for job in failedJobs:
             try:
-                taskName = job['task']
                 workflow = job['workflow']
+                taskName = job['task']
             except KeyError as ex:
                 msg = "Missing required, non-standard key %s in job in ACDC.DataCollectionService" % (str(ex))
                 logging.error(msg)
                 raise ACDCDCSException(msg)
 
-            coll = CouchCollection(database=self.database, url=self.url,
-                                   name=workflow,
-                                   type=CollectionTypes.DataCollection)
-            fileset = CouchFileset(database=self.database, url=self.url,
-                                   name=taskName)
+            if workflow != previousWorkflow:
+                coll = CouchCollection(database=self.database, url=self.url,
+                                       name=workflow,
+                                       type=CollectionTypes.DataCollection)
+            if taskName != previousTask:
+                fileset = CouchFileset(database=self.database, url=self.url,
+                                       name=taskName)
             coll.addFileset(fileset)
             inputFiles = job['input_files']
             for fInfo in inputFiles:
@@ -121,6 +130,9 @@ class DataCollectionService(CouchService):
                 fileset.add(files=inputFiles, mask=job['mask'])
             else:
                 fileset.add(files=inputFiles)
+
+            previousWorkflow = workflow
+            previousTask = taskName
 
         return
 

--- a/src/python/WMCore/ResourceControl/ResourceControl.py
+++ b/src/python/WMCore/ResourceControl/ResourceControl.py
@@ -49,6 +49,17 @@ class ResourceControl(WMConnectionBase):
                              transaction=self.existingTransaction())
         return
 
+    def insertPNNs(self, pnns):
+        """
+        _insertPNNs_
+
+        Insert a list of standalone PNNs into WMBS (usually used for MSS nodes)
+        """
+        addAction = self.wmbsDAOFactory(classname="Locations.AddPNNs")
+        addAction.execute(pnns=pnns, conn=self.getDBConn(),
+                          transaction=self.existingTransaction())
+        return
+
     def changeSiteState(self, siteName, state):
         """
         _changeSiteState_

--- a/src/python/WMCore/Services/SiteDB/SiteDB.py
+++ b/src/python/WMCore/Services/SiteDB/SiteDB.py
@@ -82,12 +82,6 @@ class SiteDBJSON(SiteDBAPI):
         """
         raise NotImplementedError
 
-    def cmsNametoSE(self, cmsName):
-        """
-        Convert CMS name (also pattern) to list of SEs
-        """
-        return self.cmsNametoList(cmsName, 'SE')
-
     def getAllCENames(self):
         """
         _getAllCENames_
@@ -121,7 +115,7 @@ class SiteDBJSON(SiteDBAPI):
         cmsnames = [x['alias'] for x in sitenames if x['type'] == 'psn']
         return cmsnames
 
-    def getAllPhEDExNodeNames(self, excludeBuffer=False):
+    def getAllPhEDExNodeNames(self, pattern=None, excludeBuffer=False):
         """
         _getAllPhEDExNodeNames_
 
@@ -132,6 +126,10 @@ class SiteDBJSON(SiteDBAPI):
         nodeNames = [x['alias'] for x in sitenames if x['type'] == 'phedex']
         if excludeBuffer:
             nodeNames = [x for x in nodeNames if not x.endswith("_Buffer")]
+        if pattern and isinstance(pattern, basestring):
+            pattern = re.compile(pattern)
+            nodeNames = [x for x in nodeNames if pattern.match(x)]
+
         return nodeNames
 
     def cmsNametoList(self, cmsnamePattern, kind):
@@ -163,37 +161,6 @@ class SiteDBJSON(SiteDBAPI):
             siteNames.extend(self._sitenames(sitename=resource['site_name']))
         cmsname = [x for x in siteNames if x['type'] == 'cms']
         return [x['alias'] for x in cmsname]
-
-    def seToCMSName(self, se):
-        """
-        Convert SE name to the CMS Site they belong to,
-        this is not a 1-to-1 relation but 1-to-many, return a list of cms site alias
-        """
-        try:
-            siteresources = [x for x in self._siteresources() if x['fqdn'] == se]
-        except IndexError:
-            return None
-        siteNames = []
-        for resource in siteresources:
-            siteNames.extend(self._sitenames(sitename=resource['site_name']))
-        cmsname = [x for x in siteNames if x['type'] == 'cms']
-        return [x['alias'] for x in cmsname]
-
-    def seToPNNs(self, se):
-        """
-        Convert SE name to the PNN they belong to,
-        this is not a 1-to-1 relation but 1-to-many, return a list of pnns
-        """
-        try:
-            siteresources = [x for x in self._siteresources() if  x['fqdn'] == se]
-        except IndexError:
-            return None
-        siteNames = []
-        for resource in siteresources:
-            siteNames.extend(self._sitenames(sitename=resource['site_name']))
-        pnns = [x for x in siteNames if x['type'] == 'phedex']
-        return [x['alias'] for x in pnns]
-
 
     def cmsNametoPhEDExNode(self, cmsName):
         """

--- a/src/python/WMCore/WMBS/MySQL/Jobs/LoadForErrorHandler.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/LoadForErrorHandler.py
@@ -19,25 +19,16 @@ class LoadForErrorHandler(DBFormatter):
     to determine ACDC records for skipped files in successful jobs, this mode
     is used when a file selection is provided.
     """
-    sql = """SELECT wmbs_job.id, jobgroup, wmbs_job.name AS name,
-                    wmbs_job_state.name AS state, state_time, retry_count,
-                    couch_record,  cache_dir, wmbs_location.site_name AS location,
-                    outcome AS bool_outcome, fwjr_path AS fwjr_path, ww.name as workflow,
-                    ww.task as task, ww.spec as spec, wmbs_users.owner as owner,
-                    wmbs_users.grp as grp
+    sql = """SELECT wmbs_job.id, wmbs_job.jobgroup,
+               ww.name as workflow, ww.task as task
              FROM wmbs_job
                INNER JOIN wmbs_jobgroup ON wmbs_jobgroup.id = wmbs_job.jobgroup
                INNER JOIN wmbs_subscription ON wmbs_subscription.id = wmbs_jobgroup.subscription
                INNER JOIN wmbs_workflow ww ON ww.id = wmbs_subscription.workflow
-               INNER JOIN wmbs_users ON ww.owner = wmbs_users.id
-               LEFT OUTER JOIN wmbs_location ON
-                 wmbs_job.location = wmbs_location.id
-               LEFT OUTER JOIN wmbs_job_state ON
-                 wmbs_job.state = wmbs_job_state.id
              WHERE wmbs_job.id = :jobid"""
 
-    fileSQL = """SELECT wfd.id, wfd.lfn, wfd.filesize size, wfd.events, wfd.first_event,
-                   wfd.merged, wja.job jobid, wpnn.pnn
+    fileSQL = """SELECT wfd.id, wfd.lfn, wfd.filesize AS size, wfd.events, wfd.first_event,
+                   wfd.merged, wja.job AS jobid, wpnn.pnn
                  FROM wmbs_file_details wfd
                  INNER JOIN wmbs_job_assoc wja ON wja.fileid = wfd.id
                  INNER JOIN wmbs_file_location wfl ON wfl.fileid = wfd.id
@@ -52,28 +43,42 @@ class LoadForErrorHandler(DBFormatter):
     runLumiSQL = """SELECT fileid, run, lumi, num_events FROM wmbs_file_runlumi_map
                      WHERE fileid = :fileid"""
 
-    def formatJobs(self, result):
+
+    def getRunLumis(self, fileBinds, fileList,
+                    conn=None, transaction=False):
         """
-        _formatJobs_
+        _getRunLumis_
 
-        Cast the id, jobgroup and last_update columns to integers because
-        formatDict() turns everything into strings.
+        Fetch run/lumi/events information for each file and append Run objects
+        to the files information.
         """
+        lumiResult = self.dbi.processData(self.runLumiSQL, fileBinds, conn=conn,
+                                          transaction=transaction)
+        lumiList = self.formatDict(lumiResult)
 
-        formattedResult = DBFormatter.formatDict(self, result)
+        lumiDict = {}
+        for l in lumiList:
+            lumiDict.setdefault(l['fileid'], [])
+            lumiDict[l['fileid']].append(l)
 
-        for entry in formattedResult:
-            if entry["bool_outcome"] == 0:
-                entry["outcome"] = "failure"
-            else:
-                entry["outcome"] = "success"
+        for f in fileList:
+            # Add new runs
+            f.setdefault('newRuns', [])
 
-            del entry["bool_outcome"]
+            fileRuns = {}
+            if f['id'] in lumiDict.keys():
+                for l in lumiDict[f['id']]:
+                    run = l['run']
+                    lumi = l['lumi']
+                    numEvents = l['num_events']
+                    fileRuns.setdefault(run, [])
+                    fileRuns[run].append((lumi, numEvents))
 
-            entry['group'] = entry['grp']
-            entry['input_files'] = []
-
-        return formattedResult
+            for r in fileRuns.keys():
+                newRun = Run(runNumber=r)
+                newRun.lumis = fileRuns[r]
+                f['newRuns'].append(newRun)
+        return
 
     def execute(self, jobID, fileSelection=None,
                 conn=None, transaction=False):
@@ -82,32 +87,33 @@ class LoadForErrorHandler(DBFormatter):
 
         Execute the SQL for the given job ID and then format and return
         the result.
+        fileSelection is a dictionary key'ed by the job id and with a list
+        of lfns
         """
 
-        if isinstance(jobID, list):
-            if len(jobID) < 1:
-                # Nothing to do
-                return []
+        if isinstance(jobID, list) and not len(jobID):
+            return []
+        elif isinstance(jobID, list):
             binds = jobID
         else:
-            binds = {"jobid": jobID}
+            binds = [{"jobid": jobID}]
 
         result = self.dbi.processData(self.sql, binds, conn=conn,
                                       transaction=transaction)
-
-        jobList = self.formatJobs(result)
+        jobList = self.formatDict(result)
+        for entry in jobList:
+            entry.setdefault('input_files', [])
 
         filesResult = self.dbi.processData(self.fileSQL, binds, conn=conn,
                                            transaction=transaction)
         fileList = self.formatDict(filesResult)
+
         fileBinds = []
         if fileSelection:
             fileList = [x for x in fileList if x['lfn'] in fileSelection[x['jobid']]]
         for x in fileList:
-            # Add new runs
-            x['newRuns'] = []
             # Assemble unique list of binds
-            if not {'fileid': x['id']} in fileBinds:
+            if {'fileid': x['id']} not in fileBinds:
                 fileBinds.append({'fileid': x['id']})
 
         parentList = []
@@ -116,47 +122,27 @@ class LoadForErrorHandler(DBFormatter):
                                                 transaction=transaction)
             parentList = self.formatDict(parentResult)
 
-            lumiResult = self.dbi.processData(self.runLumiSQL, fileBinds, conn=conn,
-                                              transaction=transaction)
-            lumiList = self.formatDict(lumiResult)
-            lumiDict = {}
-            for l in lumiList:
-                if not l['fileid'] in lumiDict.keys():
-                    lumiDict[l['fileid']] = []
-                lumiDict[l['fileid']].append(l)
-
-            for f in fileList:
-                fileRuns = {}
-                if f['id'] in lumiDict.keys():
-                    for l in lumiDict[f['id']]:
-                        run = l['run']
-                        lumi = l['lumi']
-                        numEvents = l['num_events']
-                        fileRuns.setdefault(run, [])
-                        fileRuns[run].append((lumi, numEvents))
-
-                for r in fileRuns.keys():
-                    newRun = Run(runNumber=r)
-                    newRun.lumis = fileRuns[r]
-                    f['newRuns'].append(newRun)
+            self.getRunLumis(fileBinds, fileList, conn, transaction)
 
         filesForJobs = {}
         for f in fileList:
             jobid = f['jobid']
-            if jobid not in filesForJobs.keys():
-                filesForJobs[jobid] = {}
-            if f['id'] not in filesForJobs[jobid].keys():
+            filesForJobs.setdefault(jobid, {})
+
+            if f['id'] not in filesForJobs[jobid]:
                 wmbsFile = File(id=f['id'])
                 wmbsFile.update(f)
-                wmbsFile['locations'].add(f['pnn'])
-                for r in wmbsFile['newRuns']:
+                if 'pnn' in f:  # file might not have a valid location
+                    wmbsFile['locations'].add(f['pnn'])
+                for r in wmbsFile.pop('newRuns'):
                     wmbsFile.addRun(r)
                 for entry in parentList:
                     if entry['id'] == f['id']:
                         wmbsFile['parents'].add(entry['lfn'])
+                wmbsFile.pop('pnn', None)  # not needed for anything
                 filesForJobs[jobid][f['id']] = wmbsFile
-            else:
-                # If the file is there, just add the location
+            elif 'pnn' in f:
+                # If the file is there and it has a location, just add it
                 filesForJobs[jobid][f['id']]['locations'].add(f['pnn'])
 
         for j in jobList:

--- a/src/python/WMCore/WMBS/MySQL/Locations/AddPNNs.py
+++ b/src/python/WMCore/WMBS/MySQL/Locations/AddPNNs.py
@@ -2,6 +2,7 @@
 """
 Adds PhEDEx Node Names into the WMBS database.
 """
+from __future__ import division
 
 from WMCore.Database.DBFormatter import DBFormatter
 

--- a/src/python/WMCore/WMBS/MySQL/Locations/AddPNNs.py
+++ b/src/python/WMCore/WMBS/MySQL/Locations/AddPNNs.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+"""
+Adds PhEDEx Node Names into the WMBS database.
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+
+class AddPNNs(DBFormatter):
+
+    sql = "INSERT IGNORE INTO wmbs_pnns (pnn) VALUES (:pnn)"
+
+    def execute(self, pnns, conn=None, transaction=False):
+        """
+        Adds either a single or a list of PNNs into WMBS
+        """
+        if isinstance(pnns, basestring):
+            pnns = [pnns]
+
+        binds = []
+        for pnn in pnns:
+            binds.append({'pnn': pnn})
+
+        self.dbi.processData(self.sql, binds, conn=conn, transaction=transaction)
+
+        return

--- a/src/python/WMCore/WMBS/Oracle/Jobs/LoadForErrorHandler.py
+++ b/src/python/WMCore/WMBS/Oracle/Jobs/LoadForErrorHandler.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-_LoadForErrHandler_
+_LoadForErrorHandler_
 
 Oracle implementation of Jobs.LoadForErrorHandler.
 """
@@ -10,15 +10,12 @@ from WMCore.WMBS.MySQL.Jobs.LoadForErrorHandler import LoadForErrorHandler as My
 
 class LoadForErrorHandler(MySQLLoadForErrorHandler):
     """
-    _LoadForErrorHandler_
-
-    If it's not the same as MySQL, I don't want to know.
+    The MySQL query should work, but no, it doesn't...
     """
-
     fileSQL = """SELECT wfd.id, wfd.lfn, wfd.filesize "size", wfd.events, wfd.first_event,
                    wfd.merged, wja.job "jobid", wpnn.pnn
                  FROM wmbs_file_details wfd
-                 INNER JOIN wmbs_job_assoc wja ON wja.fileid = wfd.id
-                 INNER JOIN wmbs_file_location wfl ON wfl.fileid = wfd.id
-                 INNER JOIN wmbs_pnns wpnn ON wpnn.id = wfl.pnn
+                   INNER JOIN wmbs_job_assoc wja ON wja.fileid = wfd.id
+                   INNER JOIN wmbs_file_location wfl ON wfl.fileid = wfd.id
+                   INNER JOIN wmbs_pnns wpnn ON wpnn.id = wfl.pnn
                  WHERE wja.job = :jobid"""

--- a/src/python/WMCore/WMBS/Oracle/Locations/AddPNNs.py
+++ b/src/python/WMCore/WMBS/Oracle/Locations/AddPNNs.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+"""
+Oracle implementation of AddPNNs
+"""
+
+from WMCore.WMBS.MySQL.Locations.AddPNNs import AddPNNs as AddPNNsMySQL
+
+
+class AddPNNs(AddPNNsMySQL):
+
+    sql = """INSERT /*+ IGNORE_ROW_ON_DUPKEY_INDEX (wmbs_pnns (pnn)) */
+               INTO wmbs_pnns (id, pnn) VALUES (wmbs_pnns_SEQ.nextval, :pnn)"""

--- a/src/python/WMCore/WMBS/Oracle/Locations/AddPNNs.py
+++ b/src/python/WMCore/WMBS/Oracle/Locations/AddPNNs.py
@@ -2,6 +2,7 @@
 """
 Oracle implementation of AddPNNs
 """
+from __future__ import division
 
 from WMCore.WMBS.MySQL.Locations.AddPNNs import AddPNNs as AddPNNsMySQL
 

--- a/src/python/WMCore/WMBS/Oracle/Locations/Delete.py
+++ b/src/python/WMCore/WMBS/Oracle/Locations/Delete.py
@@ -12,4 +12,4 @@ __all__ = []
 from WMCore.WMBS.MySQL.Locations.Delete import Delete as DeleteLocationsMySQL
 
 class Delete(DeleteLocationsMySQL):
-    sql = DeleteLocationsMySQL.sql
+    pass

--- a/src/python/WMCore/WMBS/Oracle/Locations/New.py
+++ b/src/python/WMCore/WMBS/Oracle/Locations/New.py
@@ -18,10 +18,8 @@ class New(NewLocationMySQL):
              WHERE NOT EXISTS (SELECT site_name FROM wmbs_location
                                WHERE site_name = :location)"""
 
-    pnnSQL = """INSERT INTO wmbs_pnns (id, pnn)
-                  SELECT wmbs_pnns_SEQ.nextval, :pnn
-                  FROM DUAL WHERE NOT EXISTS
-                (SELECT pnn FROM wmbs_pnns where pnn = :pnn)"""
+    pnnSQL = """INSERT /*+ IGNORE_ROW_ON_DUPKEY_INDEX (wmbs_pnns (pnn)) */
+                   INTO wmbs_pnns (id, pnn) VALUES (wmbs_pnns_SEQ.nextval, :pnn)"""
 
     mapSQL = """INSERT INTO wmbs_location_pnns (location, pnn)
                   SELECT (SELECT id from wmbs_location WHERE site_name = :location),

--- a/test/python/WMCore_t/Services_t/SiteDB_t/SiteDB_t.py
+++ b/test/python/WMCore_t/Services_t/SiteDB_t/SiteDB_t.py
@@ -90,11 +90,60 @@ class SiteDBTest(EmulatedUnitTestCase):
 
         Test converting PhEDEx Node Names to Processing Site Names
         """
-
         result = self.mySiteDB.PNNstoPSNs(['T1_US_FNAL_Disk', 'T1_US_FNAL_Buffer', 'T1_US_FNAL_MSS'])
         self.assertTrue(result == ['T1_US_FNAL'])
         result = self.mySiteDB.PNNstoPSNs(['T2_UK_London_IC', 'T2_US_Purdue'])
         self.assertItemsEqual(result, ['T2_UK_London_IC', 'T2_US_Purdue'])
+        return
+
+    def testPSNtoPNNMap(self):
+        """
+        _PSNtoPNNMap_
+
+        Test API to get a map of PSNs and PNNs 
+        """
+        result = self.mySiteDB.PSNtoPNNMap()
+        self.assertTrue([psn for psn in result.keys() if psn.startswith('T1_')])
+        self.assertTrue([psn for psn in result.keys() if psn.startswith('T2_')])
+        self.assertTrue([psn for psn in result.keys() if psn.startswith('T3_')])
+        self.assertTrue(len(result) > 50)
+
+        result = self.mySiteDB.PSNtoPNNMap(psnPattern='T1.*')
+        self.assertFalse([psn for psn in result.keys() if not psn.startswith('T1_')])
+        self.assertTrue(len(result) < 10)
+
+        result = self.mySiteDB.PSNtoPNNMap(psnPattern='T2.*')
+        self.assertFalse([psn for psn in result.keys() if not psn.startswith('T2_')])
+        self.assertTrue(len(result) > 10)
+
+        result = self.mySiteDB.PSNtoPNNMap(psnPattern='T3.*')
+        self.assertFalse([psn for psn in result.keys() if not psn.startswith('T3_')])
+        self.assertTrue(len(result) > 10)
+
+        return
+
+    def testGetAllPhEDExNodeNames(self):
+        """
+        _testGetAllPhEDExNodeNames_
+
+        Test API to get all PhEDEx Node Names 
+        """
+        result = self.mySiteDB.getAllPhEDExNodeNames(excludeBuffer=True)
+        self.assertFalse([pnn for pnn in result if pnn.endswith('_Buffer')])
+
+        result = self.mySiteDB.getAllPhEDExNodeNames(excludeBuffer=False)
+        self.assertTrue(len([pnn for pnn in result if pnn.endswith('_Buffer')]) > 5)
+
+        result = self.mySiteDB.getAllPhEDExNodeNames(pattern='T1.*', excludeBuffer=True)
+        self.assertFalse([pnn for pnn in result if not pnn.startswith('T1_')])
+        self.assertTrue(len(result) > 10)
+
+        result = self.mySiteDB.getAllPhEDExNodeNames(pattern='.*', excludeBuffer=True)
+        self.assertTrue([pnn for pnn in result if pnn.startswith('T1_')])
+        self.assertTrue([pnn for pnn in result if pnn.startswith('T2_')])
+        self.assertTrue([pnn for pnn in result if pnn.startswith('T3_')])
+        self.assertTrue(len(result) > 60)
+
         return
 
 if __name__ == '__main__':

--- a/test/python/WMCore_t/Services_t/SiteDB_t/SiteDB_t.py
+++ b/test/python/WMCore_t/Services_t/SiteDB_t/SiteDB_t.py
@@ -26,27 +26,10 @@ class SiteDBTest(EmulatedUnitTestCase):
 
     def testCmsNametoPhEDExNode(self):
         """
-        #Tests CmsNametoSE
+        Tests CMS Name to PhEDEx Node Name
         """
         target = ['T1_US_FNAL_Buffer', 'T1_US_FNAL_MSS']
         results = self.mySiteDB.cmsNametoPhEDExNode('T1_US_FNAL')
-        self.assertItemsEqual(results, target)
-
-    def testSEtoCmsName(self):
-        """
-        Tests CmsNametoSE
-        """
-        target = [u'T1_US_FNAL', u'T1_US_FNAL_Disk']
-        results = self.mySiteDB.seToCMSName("cmsdcadisk01.fnal.gov")
-        self.assertTrue(results == target)
-        target = sorted([u'T2_CH_CERN', u'T2_CH_CERN_HLT'])
-        results = sorted(self.mySiteDB.seToCMSName("srm-eoscms.cern.ch"))
-        self.assertItemsEqual(results, target)
-        target = sorted([u'T0_CH_CERN', u'T1_CH_CERN'])
-        results = sorted(self.mySiteDB.seToCMSName("srm-cms.cern.ch"))
-        self.assertItemsEqual(results, target)
-        target = sorted([u'T2_CH_CERN_AI'])
-        results = sorted(self.mySiteDB.seToCMSName("eoscmsftp.cern.ch"))
         self.assertItemsEqual(results, target)
 
     def testDNUserName(self):


### PR DESCRIPTION
Fixes #8448 
Superseeds a commit or two from #8503
It also changes the PNNs added to the resource control, which will then contain the MSS endpoints again (just to make sure any valid file has a replica mapped inside the agent).

@ticoann this is what we discussed yesterday. I still need to test, and if it works Ok, then I'll do further clean up (SE stuff). 
@hufnagel maybe there was a good reason we didn't add MSS to resource control anymore?