### PR TITLE
Performance improvements for getting ACDC work; slicing insert DAOs

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/DBSBufferFile.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSBufferFile.py
@@ -325,20 +325,20 @@ class DBSBufferFile(WMBSBase, WMFile):
         if len(self["newlocations"]) == 0:
             return
 
+        insertAction = self.daofactory(classname="DBSBufferFiles.AddLocation")
+        addAction = self.daofactory(classname="DBSBufferFiles.SetLocationByLFN")
+
         existingTransaction = self.beginTransaction()
 
-        for location in self['newlocations']:
-            insertAction = self.daofactory(classname="DBSBufferFiles.AddLocation")
-            insertAction.execute(siteName=location,
-                                 conn=self.getDBConn(),
-                                 transaction=self.existingTransaction())
+        insertAction.execute(siteName=self['newlocations'],
+                             conn=self.getDBConn(),
+                             transaction=self.existingTransaction())
 
         binds = []
         for location in self["newlocations"]:
             binds.append({"lfn": self["lfn"],
                           "pnn": location})
 
-        addAction = self.daofactory(classname="DBSBufferFiles.SetLocationByLFN")
         addAction.execute(binds=binds,
                           conn=self.getDBConn(),
                           transaction=self.existingTransaction())

--- a/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/Add.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/Add.py
@@ -5,8 +5,8 @@ MySQL implementation of AddFile
 
 from WMCore.Database.DBFormatter import DBFormatter
 
-class Add(DBFormatter):
 
+class Add(DBFormatter):
     sql = """insert into dbsbuffer_file(lfn, filesize, events, dataset_algo, status, workflow, in_phedex)
                 values (:lfn, :filesize, :events, :dataset_algo, :status, :workflow, :in_phedex)"""
 
@@ -15,12 +15,12 @@ class Add(DBFormatter):
         binds = []
         if isinstance(files, basestring):
             bind = {'lfn': files,
-                     'filesize': size,
-                     'events': events,
-                     'dataset_algo': dataset_algo,
-                     'status' : status,
-                     'workflow': workflowID,
-                     'in_phedex': inPhedex}
+                    'filesize': size,
+                    'events': events,
+                    'dataset_algo': dataset_algo,
+                    'status': status,
+                    'workflow': workflowID,
+                    'in_phedex': inPhedex}
             binds.append(bind)
         elif isinstance(files, (list, set)):
             # files is a list of tuples containing lfn, size, events, cksum, dataset, status
@@ -29,14 +29,14 @@ class Add(DBFormatter):
                               'filesize': f[1],
                               'events': f[2],
                               'dataset_algo': f[3],
-                              'status' : f[4],
+                              'status': f[4],
                               'workflow': f[5],
                               'in_phedex': f[6]})
         return binds
 
-    def execute(self, files = None, size = 0, events = 0, cksum = 0,
-                datasetAlgo = 0, status = "NOTUPLOADED", workflowID = None,
-                inPhedex=0, conn = None, transaction = False):
+    def execute(self, files=None, size=0, events=0, cksum=0,
+                datasetAlgo=0, status="NOTUPLOADED", workflowID=None,
+                inPhedex=0, conn=None, transaction=False):
         binds = self.getBinds(files, size, events, cksum, datasetAlgo, status,
                               workflowID, inPhedex)
 

--- a/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/Add.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/Add.py
@@ -1,12 +1,8 @@
 #!/usr/bin/env python
-
-
-
-
-
 """
 MySQL implementation of AddFile
 """
+
 from WMCore.Database.DBFormatter import DBFormatter
 
 class Add(DBFormatter):
@@ -16,18 +12,18 @@ class Add(DBFormatter):
 
     def getBinds(self, files, size, events, cksum, dataset_algo, status, workflowID, inPhedex):
         # Can't use self.dbi.buildbinds here...
-        binds = {}
+        binds = []
         if isinstance(files, basestring):
-            binds = {'lfn': files,
+            bind = {'lfn': files,
                      'filesize': size,
                      'events': events,
                      'dataset_algo': dataset_algo,
                      'status' : status,
                      'workflow': workflowID,
                      'in_phedex': inPhedex}
-        elif isinstance(files, list):
-        # files is a list of tuples containing lfn, size, events, cksum, dataset, status
-            binds = []
+            binds.append(bind)
+        elif isinstance(files, (list, set)):
+            # files is a list of tuples containing lfn, size, events, cksum, dataset, status
             for f in files:
                 binds.append({'lfn': f[0],
                               'filesize': f[1],

--- a/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/AddChecksumByLFN.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/AddChecksumByLFN.py
@@ -7,7 +7,6 @@ MySQL implementation of AddChecksumByLFN
 
 
 
-
 from WMCore.Database.DBFormatter import DBFormatter
 
 class AddChecksumByLFN(DBFormatter):
@@ -21,9 +20,9 @@ class AddChecksumByLFN(DBFormatter):
         if bulkList:
             binds = bulkList
         else:
-            binds = {'lfn': lfn, 'cktype': cktype, 'cksum': cksum}
+            binds = [{'lfn': lfn, 'cktype': cktype, 'cksum': cksum}]
 
-        result = self.dbi.processData(self.sql, binds,
-                         conn = conn, transaction = transaction)
+        self.dbi.processData(self.sql, binds,
+                             conn = conn, transaction = transaction)
 
         return

--- a/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/AddChecksumByLFN.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/AddChecksumByLFN.py
@@ -4,18 +4,16 @@
 MySQL implementation of AddChecksumByLFN
 """
 
-
-
-
 from WMCore.Database.DBFormatter import DBFormatter
+
 
 class AddChecksumByLFN(DBFormatter):
     sql = """INSERT IGNORE INTO dbsbuffer_file_checksums (fileid, typeid, cksum)
              SELECT (SELECT id FROM dbsbuffer_file WHERE lfn = :lfn),
              (SELECT id FROM dbsbuffer_checksum_type WHERE type = :cktype), :cksum FROM dual"""
 
-    def execute(self, lfn = None, cktype = None, cksum = None, bulkList = None, conn = None,
-                transaction = False):
+    def execute(self, lfn=None, cktype=None, cksum=None, bulkList=None, conn=None,
+                transaction=False):
 
         if bulkList:
             binds = bulkList
@@ -23,6 +21,6 @@ class AddChecksumByLFN(DBFormatter):
             binds = [{'lfn': lfn, 'cktype': cktype, 'cksum': cksum}]
 
         self.dbi.processData(self.sql, binds,
-                             conn = conn, transaction = transaction)
+                             conn=conn, transaction=transaction)
 
         return

--- a/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/AddLocation.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/AddLocation.py
@@ -13,7 +13,11 @@ class AddLocation(DBFormatter):
 
     def execute(self, siteName, conn = None, transaction = False):
         binds = []
-        binds.append({"location": siteName})
+        if isinstance(siteName, basestring):
+            siteName = [siteName]
+
+        for site in siteName:
+            binds.append({"location": site})
 
         self.dbi.processData(self.sql, binds, conn = conn,
                              transaction = True)

--- a/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/SetLocationByLFN.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/SetLocationByLFN.py
@@ -6,15 +6,12 @@ MySQL implementation of DBSBuffer.SetLocationByLFN
 """
 
 
-
-
 from WMCore.Database.DBFormatter import DBFormatter
 
 class SetLocationByLFN(DBFormatter):
     sql = """INSERT IGNORE INTO dbsbuffer_file_location (filename, location)
                SELECT df.id, dl.id
-               FROM dbsbuffer_file df
-               INNER JOIN dbsbuffer_location dl
+               FROM dbsbuffer_file df, dbsbuffer_location dl
                WHERE df.lfn = :lfn
                AND dl.pnn = :pnn
     """

--- a/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/SetLocationByLFN.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/SetLocationByLFN.py
@@ -5,8 +5,8 @@ _SetLocationByLFN_
 MySQL implementation of DBSBuffer.SetLocationByLFN
 """
 
-
 from WMCore.Database.DBFormatter import DBFormatter
+
 
 class SetLocationByLFN(DBFormatter):
     sql = """INSERT IGNORE INTO dbsbuffer_file_location (filename, location)
@@ -16,12 +16,11 @@ class SetLocationByLFN(DBFormatter):
                AND dl.pnn = :pnn
     """
 
-
-    def execute(self, binds, conn = None, transaction = None):
+    def execute(self, binds, conn=None, transaction=None):
         """
         Expect binds in the form {lfn, pnn}
 
         """
-        self.dbi.processData(self.sql, binds, conn = conn,
-                             transaction = transaction)
+        self.dbi.processData(self.sql, binds, conn=conn,
+                             transaction=transaction)
         return

--- a/src/python/WMComponent/DBS3Buffer/Oracle/DBSBufferFiles/Add.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/DBSBufferFiles/Add.py
@@ -3,7 +3,6 @@
 Oracle implementation of AddFile
 """
 
-#This has been modified for Oracle
 
 
 

--- a/src/python/WMComponent/DBS3Buffer/Oracle/DBSBufferFiles/SetLocationByLFN.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/DBSBufferFiles/SetLocationByLFN.py
@@ -15,11 +15,8 @@ class SetLocationByLFN(MySQLSetLocationByLFN):
     Set the location of files using lfn as the key
 
     """
-    sql = """INSERT INTO dbsbuffer_file_location (filename, location)
-               SELECT (SELECT id FROM dbsbuffer_file WHERE lfn= :lfn) AS filename,
-                      (SELECT id FROM dbsbuffer_location WHERE pnn= :pnn) AS location
-               FROM DUAL WHERE NOT EXISTS
-                 (SELECT filename FROM dbsbuffer_file_location
-                   WHERE filename= (SELECT id FROM dbsbuffer_file WHERE lfn= :lfn) AND
-                   location= (SELECT id FROM dbsbuffer_location WHERE pnn= :pnn))
-               """
+    sql = """INSERT /*+ IGNORE_ROW_ON_DUPKEY_INDEX (dbsbuffer_file_location (filename, location)) */
+               INTO dbsbuffer_file_location (filename, location)
+             SELECT df.id, dl.id FROM dbsbuffer_file df, dbsbuffer_location dl
+             WHERE df.lfn = :lfn AND dl.pnn = :pnn
+          """

--- a/src/python/WMComponent/DBS3Buffer/Oracle/DBSBufferFiles/SetLocationByLFN.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/DBSBufferFiles/SetLocationByLFN.py
@@ -5,10 +5,8 @@ _SetLocationByLFN_
 Oracle implementation of DBSBuffer.SetLocationByLFN
 """
 
-
-
-
 from WMComponent.DBS3Buffer.MySQL.DBSBufferFiles.SetLocationByLFN import SetLocationByLFN as MySQLSetLocationByLFN
+
 
 class SetLocationByLFN(MySQLSetLocationByLFN):
     """

--- a/src/python/WMComponent/JobAccountant/AccountantWorker.py
+++ b/src/python/WMComponent/JobAccountant/AccountantWorker.py
@@ -730,12 +730,10 @@ class AccountantWorker(WMConnectionBase):
         try:
 
             diffLocation = jobLocations.difference(self.dbsLocations)
-
-            for jobLocation in diffLocation:
-                self.dbsInsertLocation.execute(siteName=jobLocation,
-                                               conn=self.getDBConn(),
-                                               transaction=self.existingTransaction())
-                self.dbsLocations.add(jobLocation)
+            self.dbsInsertLocation.execute(siteName=diffLocation,
+                                           conn=self.getDBConn(),
+                                           transaction=self.existingTransaction())
+            self.dbsLocations.union(diffLocation)  # update the component cache location list
 
             self.dbsCreateFiles.execute(files=dbsFileTuples,
                                         conn=self.getDBConn(),

--- a/src/python/WMCore/WMBS/MySQL/Files/Add.py
+++ b/src/python/WMCore/WMBS/MySQL/Files/Add.py
@@ -14,7 +14,7 @@ class Add(DBFormatter):
                  first_event=0, merged=False):
         # Can't use self.dbi.buildbinds here...
         binds = {}
-        if not isinstance(files, list):
+        if not isinstance(files, (list, set)):
             binds = {'lfn': files,
                      'filesize': size,
                      'events': events,

--- a/src/python/WMCore/WMBS/MySQL/Files/AddDupsToFileset.py
+++ b/src/python/WMCore/WMBS/MySQL/Files/AddDupsToFileset.py
@@ -9,6 +9,7 @@ import time
 
 from WMCore.Database.DBFormatter import DBFormatter
 
+
 class AddDupsToFileset(DBFormatter):
     existSQL = """SELECT lfn FROM wmbs_file_details wfd
                     INNER JOIN wmbs_fileset_files wff ON wff.fileid = wfd.id
@@ -46,16 +47,16 @@ class AddDupsToFileset(DBFormatter):
                           wmbs_workflow.name = :workflow AND
                           wmbs_fileset_files.fileset != :fileset)"""
 
-    def execute(self, file, fileset, workflow, conn = None, transaction = False):
-        binds      = []
+    def execute(self, file, fileset, workflow, conn=None, transaction=False):
+        binds = []
         availBinds = []
         existBinds = []
         timestamp = int(time.time())
         for fileLFN in file:
             existBinds.append({'lfn': fileLFN, 'fileset': fileset})
         existResult = self.dbi.processData(self.existSQL, existBinds,
-                                           conn = conn,
-                                           transaction = transaction)
+                                           conn=conn,
+                                           transaction=transaction)
         existsLFNs = self.formatDict(existResult)
         for result in existsLFNs:
             file.remove(result.get('lfn'))
@@ -71,8 +72,8 @@ class AddDupsToFileset(DBFormatter):
             availBinds.append({"lfn": fileLFN, "fileset": fileset,
                                "workflow": workflow})
 
-        self.dbi.processData(self.sql, binds, conn = conn,
-                             transaction = transaction)
-        self.dbi.processData(self.sqlAvail, availBinds, conn = conn,
-                             transaction = transaction)
+        self.dbi.processData(self.sql, binds, conn=conn,
+                             transaction=transaction)
+        self.dbi.processData(self.sqlAvail, availBinds, conn=conn,
+                             transaction=transaction)
         return

--- a/src/python/WMCore/WMBS/MySQL/Files/SetLocationForWorkQueue.py
+++ b/src/python/WMCore/WMBS/MySQL/Files/SetLocationForWorkQueue.py
@@ -36,14 +36,14 @@ class SetLocationForWorkQueue(DBFormatter):
         Else:
         Simply insert the new locations
         """
-        binds = []
-        for lfn in lfns:
-            binds.append({'lfn': lfn})
-
         if isDBS:
+            binds = []
+            for lfn in lfns:
+                binds.append({'lfn': lfn})
             self.dbi.processData(self.deleteSQL, binds, conn=conn,
                                  transaction=transaction)
 
         self.dbi.processData(self.insertSQL, locations, conn=conn,
                              transaction=transaction)
+
         return

--- a/src/python/WMCore/WMBS/Oracle/Files/AddDupsToFileset.py
+++ b/src/python/WMCore/WMBS/Oracle/Files/AddDupsToFileset.py
@@ -5,8 +5,6 @@ _AddDupsToFileset_
 Oracle implementation of Files.AddDupsToFileset
 """
 
-import time
-
 from WMCore.WMBS.MySQL.Files.AddDupsToFileset import AddDupsToFileset as MySQLAddDupsToFileset
 
 class AddDupsToFileset(MySQLAddDupsToFileset):

--- a/src/python/WMCore/WMBS/Oracle/Files/SetLocationForWorkQueue.py
+++ b/src/python/WMCore/WMBS/Oracle/Files/SetLocationForWorkQueue.py
@@ -17,10 +17,8 @@ class SetLocationForWorkQueue(MySQLSetLocationForWorkQueue):
 
     """
 
-    insertSQL = """INSERT INTO wmbs_file_location (fileid, pnn)
-                     SELECT wfd.id, wpnn.id FROM wmbs_file_details wfd, wmbs_pnns wpnn
-                     WHERE wfd.lfn = :lfn AND wpnn.pnn = :location
-                     AND NOT EXISTS (SELECT fileid FROM wmbs_file_location
-                                     WHERE fileid = wfd.id
-                                     AND pnn=
-                                     (SELECT id from wmbs_pnns where pnn=:location))"""
+    insertSQL = """INSERT /*+ IGNORE_ROW_ON_DUPKEY_INDEX (wmbs_file_location (fileid, pnn)) */ 
+                     INTO wmbs_file_location (fileid, pnn)
+                   SELECT wfd.id, wpnn.id FROM wmbs_file_details wfd, wmbs_pnns wpnn
+                   WHERE wfd.lfn = :lfn AND wpnn.pnn = :location
+                """

--- a/src/python/WMCore/WorkQueue/WMBSHelper.py
+++ b/src/python/WMCore/WorkQueue/WMBSHelper.py
@@ -196,9 +196,8 @@ class WMBSHelper(WMConnectionBase):
         self.dbsInsertWorkflow = self.dbsDaoFactory(classname="InsertWorkflow")
 
         # Added for file creation bookkeeping
-        self.dbsFilesToCreate = []
-        self.addedLocations = []
-        self.wmbsFilesToCreate = []
+        self.dbsFilesToCreate = set()
+        self.wmbsFilesToCreate = set()
         self.insertedBogusDataset = -1
 
         return
@@ -385,7 +384,7 @@ class WMBSHelper(WMConnectionBase):
 
         logging.info("WMBS MC Fake File: %s on Location: %s", wmbsFile['lfn'], wmbsFile['newlocations'])
 
-        self.wmbsFilesToCreate.append(wmbsFile)
+        self.wmbsFilesToCreate.add(wmbsFile)
 
         totalFiles = self.topLevelFileset.addFilesToWMBSInBulk(self.wmbsFilesToCreate,
                                                                self.wmSpec.name(),
@@ -432,6 +431,10 @@ class WMBSHelper(WMConnectionBase):
 
         self.commitTransaction(existingTransaction)
 
+        # Now that we've created those files, clear the list
+        self.dbsFilesToCreate = set()
+        self.wmbsFilesToCreate = set()
+
         return sub, addedFiles
 
     def addFiles(self, block):
@@ -441,24 +444,30 @@ class WMBSHelper(WMConnectionBase):
         create wmbs files from given dbs block.
         as well as run lumi update
         """
+        blockOpen = block.get('IsOpen', False)
 
         if self.topLevelTask.getInputACDC():
             self.isDBS = False
+            logging.info('Adding ACDC files into WMBS for %s', self.wmSpec.name())
             for acdcFile in self.validFiles(block['Files']):
                 self._addACDCFileToWMBSFile(acdcFile)
         else:
             self.isDBS = True
+            logging.info('Adding files into WMBS for %s', self.wmSpec.name())
+            blockPNNs = block['PhEDExNodeNames']
             for dbsFile in self.validFiles(block['Files']):
-                self._addDBSFileToWMBSFile(dbsFile, block['PhEDExNodeNames'])
+                self._addDBSFileToWMBSFile(dbsFile, blockPNNs)
 
         # Add files to WMBS
+        logging.info('Inserting in bulk all the file info into WMBS for %s', self.wmSpec.name())
         totalFiles = self.topLevelFileset.addFilesToWMBSInBulk(self.wmbsFilesToCreate,
                                                                self.wmSpec.name(),
                                                                isDBS=self.isDBS)
         # Add files to DBSBuffer
+        logging.info('Inserting all the file info into DBSBuffer for %s', self.wmSpec.name())
         self._createFilesInDBSBuffer()
 
-        self.topLevelFileset.markOpen(block.get('IsOpen', False))
+        self.topLevelFileset.markOpen(blockOpen)
         return totalFiles
 
     def getMergeOutputMapping(self):
@@ -516,19 +525,19 @@ class WMBSHelper(WMConnectionBase):
         It does the actual job of creating things in DBSBuffer
 
         """
-        if len(self.dbsFilesToCreate) == 0:
+        if not self.dbsFilesToCreate:
             # Whoops, nothing to do!
             return
 
-        dbsFileTuples = []
+        dbsFileTuples = set()
         dbsFileLoc = []
         dbsCksumBinds = []
-        locationsToAdd = []
+        locationsToAdd = set()
 
         # The first thing we need to do is add the datasetAlgo
         # Assume all files in a pass come from one datasetAlgo?
         if self.insertedBogusDataset == -1:
-            self.insertedBogusDataset = self.dbsFilesToCreate[0].insertDatasetAlgo()
+            self.insertedBogusDataset = next(iter(self.dbsFilesToCreate)).insertDatasetAlgo()
 
         for dbsFile in self.dbsFilesToCreate:
             # Append a tuple in the format specified by DBSBufferFiles.Add
@@ -541,9 +550,7 @@ class WMBSHelper(WMConnectionBase):
                         self.insertedBogusDataset, dbsFile['status'],
                         self.topLevelTaskDBSBufferId, dbsFile['in_phedex'])
 
-            # TODO: we can probably optmize it
-            if newTuple not in dbsFileTuples:
-                dbsFileTuples.append(newTuple)
+            dbsFileTuples.add(newTuple)
 
             if len(dbsFile['newlocations']) < 1:
                 msg = ''
@@ -554,10 +561,7 @@ class WMBSHelper(WMConnectionBase):
                 raise WorkQueueWMBSException(msg)
 
             for jobLocation in dbsFile['newlocations']:
-                if jobLocation not in self.addedLocations:
-                    # If we don't have it, try and add it
-                    locationsToAdd.append(jobLocation)
-                    self.addedLocations.append(jobLocation)
+                locationsToAdd.add(jobLocation)
                 dbsFileLoc.append({'lfn': lfn, 'pnn': jobLocation})
 
             if selfChecksums:
@@ -567,10 +571,9 @@ class WMBSHelper(WMConnectionBase):
                     dbsCksumBinds.append({'lfn': lfn, 'cksum': selfChecksums[entry],
                                           'cktype': entry})
 
-        for jobLocation in locationsToAdd:
-            self.dbsInsertLocation.execute(siteName=jobLocation,
-                                           conn=self.getDBConn(),
-                                           transaction=self.existingTransaction())
+        self.dbsInsertLocation.execute(siteName=locationsToAdd,
+                                       conn=self.getDBConn(),
+                                       transaction=self.existingTransaction())
 
         self.dbsCreateFiles.execute(files=dbsFileTuples,
                                     conn=self.getDBConn(),
@@ -585,8 +588,6 @@ class WMBSHelper(WMConnectionBase):
                                         conn=self.getDBConn(),
                                         transaction=self.existingTransaction())
 
-        # Now that we've created those files, clear the list
-        self.dbsFilesToCreate = []
         return
 
     def _addToDBSBuffer(self, dbsFile, checksums, locations):
@@ -607,7 +608,7 @@ class WMBSHelper(WMConnectionBase):
                                configContent="Unknown")
 
         if not dbsBuffer.exists():
-            self.dbsFilesToCreate.append(dbsBuffer)
+            self.dbsFilesToCreate.add(dbsBuffer)
         # dbsBuffer.create()
         return
 
@@ -658,7 +659,7 @@ class WMBSHelper(WMConnectionBase):
         logging.info("WMBS File: %s\n on Location: %s", wmbsFile['lfn'], wmbsFile['newlocations'])
 
         wmbsFile['inFileset'] = bool(inFileset)
-        self.wmbsFilesToCreate.append(wmbsFile)
+        self.wmbsFilesToCreate.add(wmbsFile)
 
         return wmbsFile
 
@@ -678,22 +679,21 @@ class WMBSHelper(WMConnectionBase):
         """
         wmbsParents = []
         # TODO:  this check can be removed when ErrorHandler filters parents file for unmerged data
-        # If files is merged and has unmerged parents skip the wmbs population
-        firstParent = ""
         if acdcFile["parents"]:
             firstParent = next(iter(acdcFile["parents"]))
-        if acdcFile.get("merged", 0) and ("/store/unmerged/" in firstParent or "MCFakeFile" in firstParent):
-            # don't set the parents
-            pass
-        else:
-            # set the parentage for all the unmerged parents
-            for parent in acdcFile["parents"]:
-                logging.debug("WMBS ACDC Parent File: %s", parent)
-                parent = self._addACDCFileToWMBSFile(DatastructFile(lfn=parent,
-                                                                    locations=acdcFile["locations"],
-                                                                    merged=True),
-                                                     inFileset=False)
-                wmbsParents.append(parent)
+            # If files is merged and has unmerged parents skip the wmbs population
+            if acdcFile.get("merged", 0) and ("/store/unmerged/" in firstParent or "MCFakeFile" in firstParent):
+                # don't set the parents
+                pass
+            else:
+                # set the parentage for all the unmerged parents
+                for parent in acdcFile["parents"]:
+                    logging.debug("WMBS ACDC Parent File: %s", parent)
+                    parent = self._addACDCFileToWMBSFile(DatastructFile(lfn=parent,
+                                                                        locations=acdcFile["locations"],
+                                                                        merged=True),
+                                                         inFileset=False)
+                    wmbsParents.append(parent)
 
         # pass empty check sum since it won't be updated to dbs anyway
         checksums = {}
@@ -718,7 +718,7 @@ class WMBSHelper(WMConnectionBase):
 
         wmbsFile['inFileset'] = bool(inFileset)
 
-        self.wmbsFilesToCreate.append(wmbsFile)
+        self.wmbsFilesToCreate.add(wmbsFile)
 
         return wmbsFile
 

--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -453,6 +453,8 @@ class WorkQueue(WorkQueueBase):
             Assumes elements are from the same workflow"""
         if not self.params['LocalQueueFlag']:
             return
+
+        from WMCore.WorkQueue.WMBSHelper import WMBSHelper
         wmspec = None
         for ele in elements:
             if not ele.isRunning() or not ele['SubscriptionId'] or not ele:
@@ -464,7 +466,6 @@ class WorkQueue(WorkQueueBase):
             blockName, dbsBlock = self._getDBSBlock(ele, wmspec)
             if ele['NumOfFilesAdded'] != len(dbsBlock['Files']):
                 self.logger.info("Adding new files to open block %s (%s)" % (blockName, ele.id))
-                from WMCore.WorkQueue.WMBSHelper import WMBSHelper
                 wmbsHelper = WMBSHelper(wmspec, ele['TaskName'], blockName, ele['Mask'], self.params['CacheDir'])
                 ele['NumOfFilesAdded'] += wmbsHelper.createSubscriptionAndAddFiles(block=dbsBlock)[1]
                 self.backend.updateElements(ele.id, NumOfFilesAdded=ele['NumOfFilesAdded'])

--- a/test/python/WMComponent_t/DBS3Buffer_t/DBSBufferFile_t.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/DBSBufferFile_t.py
@@ -808,7 +808,7 @@ class DBSBufferFileTest(unittest.TestCase):
         testFileA.create()
 
         setLocationAction = self.daoFactory(classname="DBSBufferFiles.SetLocationByLFN")
-        setLocationAction.execute(binds={'lfn': "/this/is/a/lfn", 'pnn': 'se1.cern.ch'})
+        setLocationAction.execute(binds=[{'lfn': "/this/is/a/lfn", 'pnn': 'se1.cern.ch'}])
 
         testFileB = DBSBufferFile(id=testFileA["id"])
         testFileB.load()

--- a/test/python/WMCore_t/ACDC_t/DataCollectionService_t.py
+++ b/test/python/WMCore_t/ACDC_t/DataCollectionService_t.py
@@ -11,7 +11,7 @@ import unittest
 
 from nose.plugins.attrib import attr
 
-from WMCore.ACDC.DataCollectionService import DataCollectionService, mergeFakeFiles
+from WMCore.ACDC.DataCollectionService import DataCollectionService, mergeFilesInfo
 from WMCore.DataStructs.File import File
 from WMCore.DataStructs.LumiList import LumiList
 from WMCore.DataStructs.Run import Run
@@ -276,74 +276,74 @@ class DataCollectionService_t(unittest.TestCase):
 
         return
 
-    def testMergeFakeFiles(self):
+    def testFakeMergeFilesInfo(self):
         """
-        _testMergeFakeFiles_
+        _testFakeMergeFilesInfo_
 
         Verify that we can merge MCFakeFiles together when a fileset contains
         several failures for the same input fake file.
         """
-        originalFiles = [{'checksums': {},
-                          'events': 500000,
-                          'first_event': 1,
-                          'id': 40,
-                          'last_event': 0,
-                          'lfn': 'MCFakeFile-File1',
-                          'locations': ['T1_DE_KIT_Disk'],
-                          'merged': '0',
-                          'parents': [],
-                          'runs': [{'lumis': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], 'run_number': 1}],
-                          'size': 0},
-                         {'checksums': {},
-                          'events': 500000,
-                          'first_event': 1000001,
-                          'id': 40,
-                          'last_event': 0,
-                          'lfn': 'MCFakeFile-File2',
-                          'locations': ['T1_DE_KIT_Disk'],
-                          'merged': '0',
-                          'parents': [],
-                          'runs': [{'lumis': [21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31],
-                                    'run_number': 1}],
-                          'size': 0},
-                         {'checksums': {},
-                          'events': 500000,
-                          'first_event': 2000001,
-                          'id': 40,
-                          'last_event': 0,
-                          'lfn': 'MCFakeFile-File1',
-                          'locations': ['T1_DE_KIT_Disk'],
-                          'merged': '0',
-                          'parents': [],
-                          'runs': [{'lumis': [41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51],
-                                    'run_number': 1}],
-                          'size': 0},
-                         {'checksums': {},
-                          'events': 500000,
-                          'first_event': 7000001,
-                          'id': 40,
-                          'last_event': 0,
-                          'lfn': 'MCFakeFile-File3',
-                          'locations': ['T1_DE_KIT_Disk'],
-                          'merged': '0',
-                          'parents': [],
-                          'runs': [{'lumis': [81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91],
-                                    'run_number': 1}],
-                          'size': 0},
-                         {'checksums': {},
-                          'events': 500000,
-                          'first_event': 4000001,
-                          'id': 40,
-                          'last_event': 0,
-                          'lfn': 'MCFakeFile-File3',
-                          'locations': ['T1_DE_KIT_Disk'],
-                          'merged': '0',
-                          'parents': [],
-                          'runs': [{'lumis': [51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61],
-                                    'run_number': 1}],
-                          'size': 0}]
+        fakeFiles = [{'checksums': {},
+                      'events': 500000,
+                      'first_event': 1,
+                      'id': 40,
+                      'last_event': 0,
+                      'lfn': 'MCFakeFile-File1',
+                      'locations': ['T1_DE_KIT_Disk'],
+                      'merged': '0',
+                      'parents': [],
+                      'runs': [{'lumis': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], 'run_number': 1}],
+                      'size': 0},
+                     {'checksums': {},
+                      'events': 500000,
+                      'first_event': 1000001,
+                      'id': 40,
+                      'last_event': 0,
+                      'lfn': 'MCFakeFile-File2',
+                      'locations': ['T1_DE_KIT_Disk'],
+                      'merged': '0',
+                      'parents': [],
+                      'runs': [{'lumis': [21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31],
+                                'run_number': 1}],
+                      'size': 0},
+                     {'checksums': {},
+                      'events': 500000,
+                      'first_event': 2000001,
+                      'id': 40,
+                      'last_event': 0,
+                      'lfn': 'MCFakeFile-File1',
+                      'locations': ['T1_DE_KIT_Disk'],
+                      'merged': '0',
+                      'parents': [],
+                      'runs': [{'lumis': [41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51],
+                                'run_number': 1}],
+                      'size': 0},
+                     {'checksums': {},
+                      'events': 500000,
+                      'first_event': 7000001,
+                      'id': 40,
+                      'last_event': 0,
+                      'lfn': 'MCFakeFile-File3',
+                      'locations': ['T1_DE_KIT_Disk'],
+                      'merged': '0',
+                      'parents': [],
+                      'runs': [{'lumis': [81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91],
+                                'run_number': 1}],
+                      'size': 0},
+                     {'checksums': {},
+                      'events': 500000,
+                      'first_event': 4000001,
+                      'id': 40,
+                      'last_event': 0,
+                      'lfn': 'MCFakeFile-File3',
+                      'locations': ['T1_DE_KIT_Disk'],
+                      'merged': '0',
+                      'parents': [],
+                      'runs': [{'lumis': [51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61],
+                                'run_number': 1}],
+                      'size': 0}]
 
-        mergedFiles = mergeFakeFiles(originalFiles)
+        mergedFiles = mergeFilesInfo(fakeFiles)
         self.assertEqual(len(mergedFiles), 3, "Error: wrong number of files.")
 
         totalEvents = 0
@@ -355,6 +355,71 @@ class DataCollectionService_t(unittest.TestCase):
             if job['lfn'] == 'MCFakeFile-File1':
                 lumiList = job['runs'][0]['lumis']
                 self.assertEqual(len(lumiList), 22)
+
+    def testDataMergeFilesInfo(self):
+        """
+        _testDataMergeFilesInfo_
+
+        Verify that we can properly merge real input files coming from
+        the ACDCServer.
+        """
+        originalFiles = [{u'events': 165,
+                          u'lfn': u'/store/unmerged/fileA.root',
+                          u'locations': [u'T2_CH_CERN', u'T2_CH_CERNBOX'],
+                          u'parents': [],
+                          u'runs': [{u'lumis': [1810823], u'run_number': 1}]},
+                         {u'events': 165,
+                          u'lfn': u'/store/unmerged/fileA.root',
+                          u'locations': [u'T2_CH_CERN', u'T2_CH_CERNBOX'],
+                          u'parents': [],
+                          u'runs': [{u'lumis': [1810823], u'run_number': 2}]},
+                         {u'events': 50,
+                          u'lfn': u'/store/unmerged/fileB.root',
+                          u'locations': [u'T1_US_FNAL_MSS'],
+                          u'parents': ['file1', 'file3'],
+                          u'runs': [{u'lumis': [1, 2, 3], u'run_number': 1}]},
+                         {u'events': 165,
+                          u'lfn': u'/store/unmerged/fileA.root',
+                          u'locations': [u'T2_CH_CERN', u'T2_CH_CERNBOX'],
+                          u'parents': [],
+                          u'runs': [{u'lumis': [1810824], u'run_number': 1}]},
+                         {u'events': 50,
+                          u'lfn': u'/store/unmerged/fileB.root',
+                          u'locations': [u'T1_US_FNAL_MSS'],
+                          u'parents': ['file2'],
+                          u'runs': [{u'lumis': [4, 5, 6], u'run_number': 1}, {u'lumis': [9], u'run_number': 1}]},
+                         {u'events': 10,
+                          u'lfn': u'/store/unmerged/fileC.root',
+                          u'locations': [u'T1_US_FNAL_Disk', u'T2_US_MIT'],
+                          u'parents': [],
+                          u'runs': [{u'lumis': [111], u'run_number': 222}]}]
+
+        mergedFiles = mergeFilesInfo(originalFiles)
+        self.assertEqual(len(mergedFiles), 3, "Error: wrong number of files.")
+        self.assertItemsEqual([i['lfn'] for i in mergedFiles], ['/store/unmerged/fileA.root',
+                                                                '/store/unmerged/fileB.root',
+                                                                '/store/unmerged/fileC.root'])
+
+        for item in mergedFiles:
+            if item['lfn'] == '/store/unmerged/fileA.root':
+                self.assertEqual(item['events'], 165)
+                self.assertItemsEqual(item['locations'], ['T2_CH_CERN', 'T2_CH_CERNBOX'])
+                self.assertItemsEqual(item['runs'], [{'lumis': [1810823], 'run_number': 1},
+                                                     {'lumis': [1810823], 'run_number': 2},
+                                                     {'lumis': [1810824], 'run_number': 1}])
+                self.assertEqual(item['parents'], [])
+            elif item['lfn'] == '/store/unmerged/fileB.root':
+                self.assertEqual(item['events'], 50)
+                self.assertItemsEqual(item['locations'], ['T1_US_FNAL_MSS'])
+                self.assertItemsEqual(item['runs'], [{'lumis': [1, 2, 3], 'run_number': 1},
+                                                     {'lumis': [4, 5, 6], 'run_number': 1},
+                                                     {'lumis': [9], 'run_number': 1}])
+                self.assertItemsEqual(item['parents'], ['file1', 'file2', 'file3'])
+            elif item['lfn'] == '/store/unmerged/fileB.root':
+                self.assertEqual(item['events'], 10)
+                self.assertItemsEqual(item['locations'], ['T1_US_FNAL_Disk', 'T2_US_MIT'])
+                self.assertItemsEqual(item['runs'], [{'lumis': [111], 'run_number': 222}])
+                self.assertEqual(item['parents'], [])
 
     def jobConfig(self, wf, task, jobid, lfn):
         """


### PR DESCRIPTION
Fixes #8528

General changes are:
* merge acdc docs/files before passing them to WMBSHelper (we were merging only MCFakeFiles)
* use a group of up to 10k bindings for insert/update DAOs
* release memory when possible (we expand lots of objects and binds in memory while handling all those different information for WMBS/DBSBuffer)

I'll probably get a small set of these changes to push to the agent branch.