### PR TITLE
check the PATH for condor_chirp command

### DIFF
--- a/src/python/Utils/FileTools.py
+++ b/src/python/Utils/FileTools.py
@@ -106,3 +106,15 @@ def findMagicStr(filename, matchString):
         for line in logfile:
             if matchString in line:
                 yield line
+
+def getFullPath(name, envPath="PATH"):
+    """
+    :param name: file name
+    :param envPath: any environment variable specified for path (PATH, PYTHONPATH, etc)
+    :return: full path if it is under PATH env
+    """
+    for path in os.getenv(envPath).split(os.path.pathsep):
+        fullPath = os.path.join(path, name)
+        if os.path.exists(fullPath):
+            return fullPath
+    return None

--- a/src/python/WMCore/WMSpec/Steps/Executor.py
+++ b/src/python/WMCore/WMSpec/Steps/Executor.py
@@ -12,6 +12,7 @@ import sys
 import json
 import subprocess
 
+from Utils.FileTools import getFullPath
 from WMCore.FwkJobReport.Report import Report
 from WMCore.WMSpec.WMStep import WMStepHelper
 from WMCore.WMSpec.Steps.StepFactory import getStepEmulator
@@ -175,9 +176,11 @@ class Executor:
             condor_config_dir = os.path.dirname(condor_config)
             condor_chirp_bin = os.path.join(condor_config_dir, 'main/condor/libexec/condor_chirp')
             if not os.path.isfile(condor_chirp_bin):
-                condor_chirp_bin = None
+                # Singularity container might not have CONDOR_CONFIG env.
+                #TODO: It should have fixed from Singularity setting
+                condor_chirp_bin = getFullPath("condor_chirp")
 
-        if condor_chirp_bin:
+        if condor_chirp_bin and os.access(condor_chirp_bin, os.X_OK):
             args = [ condor_chirp_bin, 'set_job_attr_delayed', key, json.dumps(value) ]
             returncode = subprocess.call(args)
 

--- a/test/python/Utils_t/FileTools_t.py
+++ b/test/python/Utils_t/FileTools_t.py
@@ -77,6 +77,12 @@ class testFileTools(unittest.TestCase):
         self.assertEqual(info['Size'], 34)
         return
 
+    def test_getFullPath(self):
+        fullPath = FileTools.getFullPath("cd")
+        #assuming there is path for cd
+        self.assertIsNotNone(fullPath)
+        fullPath = FileTools.getFullPath("this_shouldnt_be")
+        self.assertEqual(fullPath, None)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
@hufnagel, Dirk, is this what you were thinking to get the right path in Singularity container?
I am not sure whether PATH would be set correctly in Singularity. We can find all the path as well but that would take long time (might be better to look for certain paths if we knows some candidate)
