### PR TITLE
Publish CMSSW versions via htcondor class ad

### DIFF
--- a/src/python/WMComponent/JobCreator/JobCreatorPoller.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorPoller.py
@@ -608,7 +608,7 @@ class JobCreatorPoller(BaseWorkerThread):
                     tempDict = {}
                     tempDict.update(processDict)
                     tempDict['jobGroup'] = wmbsJobGroup
-                    tempDict['swVersion'] = wmTask.getSwVersion()
+                    tempDict['swVersion'] = wmTask.getSwVersion(allSteps=True)
                     tempDict['scramArch'] = wmTask.getScramArch()
                     tempDict['jobNumber'] = jobNumber
                     tempDict['agentNumber'] = self.agentNumber

--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -372,7 +372,7 @@ class JobSubmitterPoller(BaseWorkerThread):
                        'possibleSites': frozenset(possibleLocations),  # abort and drain sites filtered out
                        'potentialSites': frozenset(potentialLocations),  # original list of sites
                        'scramArch': loadedJob.get("scramArch", None),
-                       'swVersion': loadedJob.get("swVersion", None),
+                       'swVersion': loadedJob.get("swVersion", []),
                        'proxyPath': loadedJob.get("proxyPath", None),
                        'estimatedJobTime': loadedJob.get("estimatedJobTime", None),
                        'estimatedDiskUsage': loadedJob.get("estimatedDiskUsage", None),

--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -636,6 +636,8 @@ class SimpleCondorPlugin(BasePlugin):
             # Add OS requirements for jobs
             requiredOSes = self.scramArchtoRequiredOS(job.get('scramArch'))
             ad['REQUIRED_OS'] = requiredOSes
+            cmsswVersions = ','.join(job.get('swVersion'))
+            ad['CMSSW_Versions'] = cmsswVersions
 
             ad = convertFromUnicodeToStr(ad)
             condorAd = classad.ClassAd()

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -1238,14 +1238,14 @@ class WMTaskHelper(TreeHelper):
          used in this task
         :return: a string with the release name or a list of releases if allSteps is True.
         """
-        versions = set()
+        versions = []
         for stepName in self.listAllStepNames():
             stepHelper = self.getStepHelper(stepName)
             if stepHelper.stepType() == "CMSSW":
                 if not allSteps:
                     return stepHelper.getCMSSWVersion()
                 else:
-                    versions.add(stepHelper.getCMSSWVersion(allSteps))
+                    versions.append(stepHelper.getCMSSWVersion())
         return versions
 
     def getScramArch(self, allSteps=False):
@@ -1255,14 +1255,14 @@ class WMTaskHelper(TreeHelper):
         Get the scram architecture for the first CMSSW step of workload.
         Set allSteps to true to retrieve all the scramArchs used in this task.
         """
-        scrams = set()
+        scrams = []
         for stepName in self.listAllStepNames():
             stepHelper = self.getStepHelper(stepName)
             if stepHelper.stepType() == "CMSSW":
                 if not allSteps:
                     return stepHelper.getScramArch()
                 else:
-                    scrams.add(stepHelper.getScramArch(allSteps))
+                    scrams.append(stepHelper.getScramArch())
         return scrams
 
     def setPrimarySubType(self, subType):


### PR DESCRIPTION
Fixes #7786

Create an htcondor class ad to keep all CMSSW versions to be used in the job. Format is a comma separated string following the order as cmsRun1, cmsRun2, cmsRun3, etc.
