### PR TITLE
check job location for basestring type

### DIFF
--- a/src/python/WMCore/BossAir/BossAirAPI.py
+++ b/src/python/WMCore/BossAir/BossAirAPI.py
@@ -247,9 +247,19 @@ class BossAirAPI(WMConnectionBase):
         self.updateDAO.execute(jobs=jobs, conn=self.getDBConn(),
                                transaction=self.existingTransaction())
 
-        jobsWithLocation = [job for job in jobs if job.get('location') is not None]
+        jobsWithLocation = []
+        jobsWithOutLocation = []
+        for job in jobs:
+            if isinstance(job.get('location'), basestring):
+                jobsWithLocation.append(job)
+            else:
+                jobsWithOutLocation.append(job)
+
         if jobsWithLocation:
             self.stateMachine.recordLocationChange(jobsWithLocation)
+
+        if jobsWithOutLocation:
+            logging.warning("No record of job location from BoasAir, Job list: %s", jobsWithOutLocation)
 
         self.commitTransaction(existingTransaction)
 


### PR DESCRIPTION
on @cmshome test agent some jobs come back with 'location': classad.Value.Undefined
instead of None. I am not sure how that happens.  - needs further investigation
This temp patch is applied to vocms0267

```
{'proxyPath': None, 'siteName': None, 'taskType': None, 'globalState': 'Running', 'userrole': 'unknown', 'usergroup': 'unknown', 'taskPriority': None, 'id': 358373, 'estimatedJobTime': None, 'potentialSites': None, 'estimatedDiskUsage': None, 'inputDatasetLocations': None, 'userdn': '/C=UK/O=eScience/OU=Brunel/L=ECE/CN=ivan reid', 'bulkid': None, 'priority': None, 'location': classad.Value.Undefined, 'allowOpportunistic': False, 'status_time': 1522423310, 'possibleSites': None, 'site_cms_name': None, 'requestName': None, 'status': 'Running', 'swVersion': None, 'cache_dir': '/data/srv/wmagent/v1.1.10.patch2/install/wmagent/JobCreator/JobCache/ireid_MonteCarlo_eff2_IDR_CMS_Home_180327_140157_5941/Production/LogCollect/JobCollection_9825_0/job_314436', 'estimatedMemoryUsage': None, 'taskName': None, 'inputDataset': None, 'name': None, 'plugin': 'SimpleCondorPlugin', 'gridid': '72271.15', 'numberOfCores': 1, 'jobid': 314436, 'retry_count': 0, 'sandbox': None, 'scramArch': None, 'taskID': None, 'packageDir': None}, {'proxyPath': None, 'siteName': None, 'taskType': None, 'globalState': 'Running', 'userrole': 'unknown', 'usergroup': 'unknown', 'taskPriority': None, 'id': 358366, 'estimatedJobTime': None, 'potentialSites': None, 'estimatedDiskUsage': None, 
```