### PR TITLE
Pass PYTHONPATH with the WMCore libraries to the CMSSW environment

### DIFF
--- a/src/python/WMCore/WMRuntime/Tools/Scram.py
+++ b/src/python/WMCore/WMRuntime/Tools/Scram.py
@@ -25,13 +25,13 @@ sample usage:
 
 """
 
+import logging
 import os
 import os.path
-import sys
 import subprocess
-import logging
-from PSetTweaks.WMTweak import readAdValues
+import sys
 
+from PSetTweaks.WMTweak import readAdValues
 
 ARCH_TO_OS = {'slc5': ['rhel6'], 'slc6': ['rhel6'], 'slc7': ['rhel7']}
 
@@ -145,10 +145,10 @@ class Scram(object):
 
         """
         result = ""
-        if self.architecture != None:
+        if self.architecture is not None:
             result += "export SCRAM_ARCH=%s\n" % self.architecture
 
-        if self.initialise != None:
+        if self.initialise is not None:
             result += "%s\n" % self.initialise
             result += """if [ "$?" -ne "0" ]; then exit 2; fi\n"""
         return result
@@ -194,7 +194,7 @@ class Scram(object):
         Scram runtime command
 
         """
-        if self.projectArea == None:
+        if self.projectArea is None:
             msg = "Scram Runtime called with Project Area not set"
             self.stdout = msg
             self.stderr = ""
@@ -252,21 +252,20 @@ class Scram(object):
         Run the command in the runtime environment
 
         """
-        if self.projectArea == None:
+        if self.projectArea is None:
             msg = "Scram Project Area not set/project() not called"
             raise RuntimeError(msg)
         if self.runtimeEnv == {}:
             msg = "Scram runtime environment is empty/runtime() not called"
             raise RuntimeError(msg)
         executeIn = runtimeDir
-        if runtimeDir == None:
+        if runtimeDir is None:
             executeIn = self.projectArea
         # if the caller passed a filename and not a filehandle and if the logfile does not exist then create one
         if isinstance(logName, basestring) and not os.path.exists(logName):
-            f = open(logName, 'w')
-            f.write('Log for recording SCRAM command-line output\n')
-            f.write('-------------------------------------------\n')
-            f.close()
+            with open(logName, 'w') as f:
+                f.write('Log for recording SCRAM command-line output\n')
+                f.write('-------------------------------------------\n')
         logFile = open(logName, 'a') if isinstance(logName, basestring) else logName
         bashcmd = "/bin/bash"
         if cleanEnv:
@@ -275,7 +274,7 @@ class Scram(object):
                                 stdout=logFile,
                                 stderr=logFile,
                                 stdin=subprocess.PIPE,
-                               )
+                                )
 
         # Passing the environment in to the subprocess call results in all of
         # the variables being quoted which causes problems for search paths.
@@ -294,11 +293,11 @@ class Scram(object):
         if "PYTHONPATH" not in self.runtimeEnv:
             self.procWriter(proc, 'export PYTHONPATH=%s\n' % os.environ['PYTHONPATH'])
 
-        if os.environ.get('VO_CMS_SW_DIR', None) != None:
+        if os.environ.get('VO_CMS_SW_DIR', None) is not None:
             self.procWriter(proc, 'export VO_CMS_SW_DIR=%s\n' % os.environ['VO_CMS_SW_DIR'])
-        if os.environ.get('OSG_APP', None) != None:
+        if os.environ.get('OSG_APP', None) is not None:
             self.procWriter(proc, 'export VO_CMS_SW_DIR=%s/cmssoft/cms\n' % os.environ['OSG_APP'])
-        if os.environ.get('CMS_PATH', None) != None:
+        if os.environ.get('CMS_PATH', None) is not None:
             self.procWriter(proc, 'export CMS_PATH=%s\n' % os.environ['CMS_PATH'])
         if os.environ.get('_CONDOR_JOB_AD'):
             self.procWriter(proc, 'export _CONDOR_JOB_AD=%s\n' % os.environ['_CONDOR_JOB_AD'])
@@ -310,7 +309,7 @@ class Scram(object):
 
         self.procWriter(proc, "%s\n" % self.preCommand())
 
-        if self.envCmd != None:
+        if self.envCmd is not None:
             self.procWriter(proc, "%s\n" % self.envCmd)
 
         if command.startswith(sys.executable):

--- a/src/python/WMCore/WMRuntime/Tools/Scram.py
+++ b/src/python/WMCore/WMRuntime/Tools/Scram.py
@@ -289,6 +289,11 @@ class Scram(object):
             if varName == "SCRAM_ARCH":
                 rtScramArch = self.runtimeEnv[varName].replace('\"', '')
 
+        # Make sure to pass PYTHONPATH env (with WMCore path) to CMSSW python
+        # Scram was modified in CMSSW_10_1_0 and it no longer returns this env var
+        if "PYTHONPATH" not in self.runtimeEnv:
+            self.procWriter(proc, 'export PYTHONPATH=%s\n' % os.environ['PYTHONPATH'])
+
         if os.environ.get('VO_CMS_SW_DIR', None) != None:
             self.procWriter(proc, 'export VO_CMS_SW_DIR=%s\n' % os.environ['VO_CMS_SW_DIR'])
         if os.environ.get('OSG_APP', None) != None:
@@ -318,7 +323,7 @@ class Scram(object):
                 command = command.replace(sys.executable, python26exec)
             elif hackLdLibPath:
                 # reset python path for DMWM python (scram will have changed env to point at its own)
-                self.procWriter(proc, "export PYTHONPATH==%s:$PYTHONPATH\n" % ":".join(sys.path)[1:])
+                self.procWriter(proc, "export PYTHONPATH=%s:$PYTHONPATH\n" % ":".join(sys.path)[1:])
 
         logging.info("    Invoking command: %s", command)
         self.procWriter(proc, "%s\n" % command)

--- a/src/python/WMCore/WMRuntime/Unpacker.py
+++ b/src/python/WMCore/WMRuntime/Unpacker.py
@@ -19,13 +19,14 @@ This will then do the following:
 
 """
 from __future__ import print_function
-import sys
-import os
-import tarfile
-import zipfile
+
 import getopt
-import traceback
 import logging
+import os
+import sys
+import tarfile
+import traceback
+import zipfile
 
 options = {
     "sandbox=": "WMAGENT_SANDBOX",  # sandbox archive file
@@ -57,9 +58,8 @@ def makeErrorReport(jobName, exitCode, message):
     xml += "</FrameworkError>\n"
     xml += "</FrameworkJobReport>\n"
     xml += "</xml>\n"
-    handle = open("FrameworkJobReport.xml", 'w')
-    handle.write(xml)
-    handle.close()
+    with open("FrameworkJobReport.xml", 'w') as handle:
+        handle.write(xml)
 
 
 def createWorkArea(sandbox):
@@ -77,18 +77,16 @@ def createWorkArea(sandbox):
     if not os.path.exists(os.path.join(jobDir, 'StartupScript')):
         os.makedirs(os.path.join(jobDir, 'StartupScript'))
 
-    tfile = tarfile.open(sandbox, "r")
-    tfile.extractall(jobDir)
-    tfile.close()
+    with tarfile.open(sandbox, "r") as tfile:
+        tfile.extractall(jobDir)
 
     # need to pull out the startup file from the zipball
-    zfile = zipfile.ZipFile(os.path.join(jobDir, 'WMCore.zip'), 'r')
-    startupScript = zfile.read('WMCore/WMRuntime/Startup.py')
-    fd = os.open(os.path.join(jobDir, 'Startup.py'), os.O_CREAT | os.O_WRONLY)
-    os.write(fd, startupScript)
-    os.close(fd)
+    with zipfile.ZipFile(os.path.join(jobDir, 'WMCore.zip'), 'r') as zfile:
+        startupScript = zfile.read('WMCore/WMRuntime/Startup.py')
+        fd = os.open(os.path.join(jobDir, 'Startup.py'), os.O_CREAT | os.O_WRONLY)
+        os.write(fd, startupScript)
+        os.close(fd)
 
-    zfile.close()
     logging.info("PYTHONPATH=%s", os.environ.get("PYTHONPATH"))
 
     return jobDir
@@ -108,9 +106,8 @@ def installPackage(jobArea, jobPackage, jobIndex):
     os.system("/bin/cp %s %s" % (jobPackage, pkgTarget))
 
     indexPy = "%s/JobIndex.py" % target
-    handle = open(indexPy, 'w')
-    handle.write("jobIndex = %s\n" % jobIndex)
-    handle.close()
+    with open(indexPy, 'w') as handle:
+        handle.write("jobIndex = %s\n" % jobIndex)
 
     return
 
@@ -130,7 +127,7 @@ def runUnpacker(sandbox, package, jobIndex, jobname):
         msg += str(ex)
         msg += str(traceback.format_exc())
         makeErrorReport(jobname, 1, msg)
-        print(msg)
+        logging.error(msg)
         sys.exit(1)
 
 
@@ -141,7 +138,7 @@ if __name__ == '__main__':
     except getopt.GetoptError as ex:
         msg = "Error processing commandline args:\n"
         msg += str(ex)
-        print(msg)
+        logging.error(msg)
         sys.exit(1)
 
     sandbox = os.environ.get('WMAGENT_SANDBOX', None)
@@ -158,20 +155,20 @@ if __name__ == '__main__':
         if opt == "--jobname":
             jobname = arg
 
-    if sandbox == None:
+    if sandbox is None:
         msg = "No Sandbox provided"
         makeErrorReport(jobname, 1, msg)
-        print(msg)
+        logging.error(msg)
         sys.exit(1)
-    if package == None:
+    if package is None:
         msg = "No Job Package provided"
         makeErrorReport(jobname, 1, msg)
-        print(msg)
+        logging.error(msg)
         sys.exit(1)
-    if jobIndex == None:
+    if jobIndex is None:
         msg = "No Job Index provided"
         makeErrorReport(jobname, 1, msg)
-        print(msg)
+        logging.error(msg)
         sys.exit(1)
 
     runUnpacker(sandbox=sandbox, package=package,

--- a/src/python/WMCore/WMRuntime/Unpacker.py
+++ b/src/python/WMCore/WMRuntime/Unpacker.py
@@ -25,6 +25,7 @@ import tarfile
 import zipfile
 import getopt
 import traceback
+import logging
 
 options = {
     "sandbox=": "WMAGENT_SANDBOX",  # sandbox archive file
@@ -88,8 +89,8 @@ def createWorkArea(sandbox):
     os.close(fd)
 
     zfile.close()
+    logging.info("PYTHONPATH=%s", os.environ.get("PYTHONPATH"))
 
-    print("export PYTHONPATH=$PYTHONPATH:%s/WMCore.zip:%s" % (jobDir, jobDir))
     return jobDir
 
 


### PR DESCRIPTION
As a follow up of https://its.cern.ch/jira/browse/CMSCOMPPR-2560

Starting in this 10_1_0 release, CMSSW is no longer using PYTHONPATH but instead PYTHON27PATH environment variable. That means we do not have PYTHONPATH in the CMSSW environment anymore (which we used to have for older releases, while running the scram runtime step).

This patch sets PYTHONPATH when it's not available in the scram/cmssw runtime environment.
