### PR TITLE
EventsPerLumi multiplier cannot be 0!!!

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -99,6 +99,8 @@ class StdBase(object):
             ePerJob = int((8.0 * 3600.0) / tPerEvent)
             # then make EventsPerJob multiple of EventsPerLumi and still closer to 8h jobs
             multiplier = int(round(ePerJob / ePerLumi))
+            # make sure not to have 0 EventsPerJob
+            multiplier = max(multiplier, 1)
             ePerJob = ePerLumi * multiplier
         elif ePerLumi is None:
             ePerLumi = ePerJob

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StdBase_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StdBase_t.py
@@ -67,6 +67,9 @@ class StdBaseTest(unittest.TestCase):
         self.assertEqual((23040, 23040), StdBase.calcEvtsPerJobLumi(None, None, 1.25))
         self.assertEqual((229, 229), StdBase.calcEvtsPerJobLumi(None, None, 125.5))
 
+        self.assertEqual((24000, 11764), StdBase.calcEvtsPerJobLumi(24000, 11764, 10.157120496967591))
+        self.assertEqual((11764, 11764), StdBase.calcEvtsPerJobLumi(None, 11764, 10.157120496967591))  # non rounded result is 2835
+
         return
 
 


### PR DESCRIPTION
Fixes #8566
First the unit test, just to prove it fails where it fails 