### PR TITLE
Post global_workqueue data to MonIT

### DIFF
--- a/src/python/WMCore/GlobalWorkQueue/CherryPyThreads/HeartbeatMonitor.py
+++ b/src/python/WMCore/GlobalWorkQueue/CherryPyThreads/HeartbeatMonitor.py
@@ -1,34 +1,145 @@
 from __future__ import (division, print_function)
+
 from WMCore.REST.HeartbeatMonitorBase import HeartbeatMonitorBase
 from WMCore.WorkQueue.WorkQueue import globalQueue
+from WMCore.WorkQueue.DataStructs.WorkQueueElement import STATES
+
 
 class HeartbeatMonitor(HeartbeatMonitorBase):
 
+    def __init__(self, rest, config):
+        super(HeartbeatMonitor, self).__init__(rest, config)
+        self.initialStatus = ['Available', 'Negotiating', 'Acquired']
+        self.producer = "global_workqueue"
+        self.docTypeAMQ = "cms_%s_info" % self.producer
+
     def addAdditionalMonitorReport(self, config):
         """
-        Collect some statistics for Global Workqueue and upload it to WMStats. They are:
-        - by status: count of elements and total number of estimated jobs
-        - by status: count of elements and sum of jobs by *priority*.
-        - by agent: count of elements and sum of jobs by *status*
-        - by agent: count of elements and sum of jobs by *priority*
-        - by status: unique (distributed) and possible (total assigned) number
-          of jobs and elements per *site*, taking into account data locality
-        - by status: unique (distributed) and possible (total assigned) number
-          of jobs and elements per *site*, regardless data locality (using AAA)
-
-        TODO: these still need to be done
-        * for Available workqueue elements:
-         - WQE without a common site list (that does not pass the work restrictions)
-         - WQE older than 7 days (or whatever number we decide)
-         - WQE that create > 30k jobs (or whatever number we decide)
-        * for Acquired workqueue elements
-         - WQE older than 7 days (or whatever the number is)
+        Collect some statistics for Global Workqueue and upload it to WMStats and
+        MonIT.
         """
         self.logger.info("Collecting GlobalWorkqueue statistics...")
 
         # retrieve whole docs for these status in order to create site metrics
-        status = ['Available', 'Negotiating', 'Acquired']
         globalQ = globalQueue(**config.queueParams)
-        results = globalQ.monitorWorkQueue(status)
+        results = globalQ.monitorWorkQueue(self.initialStatus)
+
+        if self.postToAMQ:
+            allDocs = self.buildMonITDocs(results)
+            self.uploadToAMQ(allDocs)
 
         return results
+
+    def _fillMissingStatus(self, data):
+        """
+        Utilitarian method which creates an entry in the stats for each
+        status that is missing, such that it can be better used in MonIT
+        aggregations
+        :param data: list of dicts for one specific metric
+        :return: the list updated in-place
+        """
+        if data:
+            defaultStruct = dict(data[0])  # make a copy of it
+            for keyName in defaultStruct:
+                if keyName == 'agent_name':
+                    defaultStruct[keyName] = 'AgentNotDefined'
+                else:
+                    defaultStruct[keyName] = 0
+        else:
+            return
+
+        availableStatus = set([item['status'] for item in data])
+        missingStatus = set(STATES) - availableStatus
+        for st in missingStatus:
+            defaultStruct['status'] = st
+            data.append(dict(defaultStruct))
+        return
+
+    def buildMonITDocs(self, stats):
+        """
+        Given the statistics that are uploaded to wmstats, create different
+        documents to post to MonIT AMQ (aggregation-friendly docs).
+        """
+        commonInfo = {"agent_url": "global_workqueue"}
+
+        docs = []
+        self._fillMissingStatus(stats['workByStatus'])
+        for item in stats['workByStatus']:
+            doc = dict()
+            doc["type"] = "work_info"
+            doc["status"] = item['status']
+            doc["count"] = item['count']  # total number of workqueue elements
+            doc["sum"] = item['sum']  # total number of top level jobs
+            doc.update(commonInfo)
+            docs.append(doc)
+
+        self._fillMissingStatus(stats['workByStatusAndPriority'])
+        for item in stats['workByStatusAndPriority']:
+            doc = dict()
+            doc["type"] = "work_prio_status"
+            doc["status"] = item['status']
+            doc["priority"] = item['priority']
+            doc["count"] = item['count']  # total number of workqueue elements
+            doc["sum"] = item['sum']  # total number of top level jobs
+            doc.update(commonInfo)
+            docs.append(doc)
+
+        self._fillMissingStatus(stats['workByAgentAndStatus'])
+        for item in stats['workByAgentAndStatus']:
+            doc = dict()
+            doc["type"] = "work_agent_status"
+            doc["status"] = item['status']
+            doc["agent_name"] = item['agent_name']
+            doc["count"] = item['count']  # total number of workqueue elements
+            doc["sum"] = item['sum']  # total number of top level jobs
+            doc.update(commonInfo)
+            docs.append(doc)
+
+        for item in stats['workByAgentAndPriority']:
+            doc = dict()
+            doc["type"] = "work_agent_prio"
+            doc["priority"] = item['priority']
+            doc["agent_name"] = item['agent_name']
+            doc["count"] = item['count']  # total number of workqueue elements
+            doc["sum"] = item['sum']  # total number of top level jobs
+            doc.update(commonInfo)
+            docs.append(doc)
+
+        # jobs respecting data location constraints
+        for status, items in stats['uniqueJobsPerSite'].iteritems():
+            for item in items:
+                doc = {}
+                doc["type"] = "work_site_unique"
+                doc["status"] = status
+                doc.update(commonInfo)
+                doc.update(item)
+                docs.append(doc)
+        for status, items in stats['possibleJobsPerSite'].iteritems():
+            for item in items:
+                doc = {}
+                doc["type"] = "work_site_possible"
+                doc["status"] = status
+                doc.update(commonInfo)
+                doc.update(item)
+                docs.append(doc)
+
+        # jobs NOT respecting any data location, so assuming they can run anywhere on the sitewhitelist
+        for status, items in stats['uniqueJobsPerSiteAAA'].iteritems():
+            for item in items:
+                doc = {}
+                doc["type"] = "work_site_uniqueAAA"
+                doc["status"] = status
+                doc.update(commonInfo)
+                doc.update(item)
+                docs.append(doc)
+        for status, items in stats['possibleJobsPerSiteAAA'].iteritems():
+            for item in items:
+                doc = {}
+                doc["type"] = "work_site_possibleAAA"
+                doc["status"] = status
+                doc.update(commonInfo)
+                doc.update(item)
+                docs.append(doc)
+
+        self.logger.info("%i docs created to post to MonIT", len(docs))
+        return docs

--- a/src/python/WMCore/REST/HeartbeatMonitorBase.py
+++ b/src/python/WMCore/REST/HeartbeatMonitorBase.py
@@ -1,6 +1,10 @@
 from __future__ import (division, print_function)
+import time
+from pprint import pformat
 from WMCore.REST.CherryPyPeriodicTask import CherryPyPeriodicTask
 from WMCore.Services.WMStats.WMStatsWriter import WMStatsWriter, convertToServiceCouchDoc
+from WMCore.Services.StompAMQ.StompAMQ import StompAMQ
+
 
 class HeartbeatMonitorBase(CherryPyPeriodicTask):
 
@@ -8,6 +12,8 @@ class HeartbeatMonitorBase(CherryPyPeriodicTask):
         super(HeartbeatMonitorBase, self).__init__(config)
         self.centralWMStats = WMStatsWriter(config.wmstats_url)
         self.threadList = config.thread_list
+        self.userAMQ = getattr(config, "user_amq", None)
+        self.passAMQ = getattr(config, "pass_amq", None)
         self.postToAMQ = getattr(config, "post_to_amq", False)
         self.topicAMQ = getattr(config, "topic_amq", None)
         self.hostPortAMQ = getattr(config, "host_port_amq", None)
@@ -40,3 +46,37 @@ class HeartbeatMonitorBase(CherryPyPeriodicTask):
         overwite the method with each applications monitoring info. (Need to follow the format displayed in wmstats)
         """
         return {}
+
+    def uploadToAMQ(self, docs, producer=None):
+        """
+        _uploadToAMQ_
+
+        Sends data to AMQ, which ends up in elastic search.
+        :param docs: list of documents/dicts to be posted
+        :param producer: service name that's providing this info
+        """
+        if not docs:
+            self.logger.info("There are no documents to send to AMQ")
+            return
+
+        producer = producer or self.producer
+        self.logger.debug("Sending the following data to AMQ %s", pformat(docs))
+        ts = int(time.time())
+
+        try:
+            stompSvc = StompAMQ(username=self.userAMQ,
+                                password=self.passAMQ,
+                                producer=producer,
+                                topic=self.topicAMQ,
+                                host_and_ports=self.hostPortAMQ,
+                                logger=self.logger)
+
+            notifications = stompSvc.make_notification(payload=docs, docType=self.docTypeAMQ,
+                                                       docId=producer, ts=ts)
+
+            failures = stompSvc.send(notifications)
+            self.logger.info("%i docs successfully sent to Stomp AMQ", len(notifications) - len(failures))
+        except Exception as ex:
+            self.logger.exception("Failed to send data to StompAMQ. Error %s", str(ex))
+
+        return

--- a/src/python/WMCore/Services/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/Services/WorkQueue/WorkQueue.py
@@ -1,4 +1,3 @@
-import json
 from collections import defaultdict
 from WMCore.Database.CMSCouch import CouchServer, CouchConflictError
 from WMCore.Lexicon import splitCouchServiceURL


### PR DESCRIPTION
Fixes #8420 (besides the full list of sites).
Changes are:
* Add all the logic to get the WorkQueue Heartbeat thread to post data to MonIT as well (in addition to wmstats).
* for such cases, the data structure has to be changed such that it can be easily aggregated on the ES end
* when possible (any data returned from the workqueue internal queries), I try to create default docs such that we always have that info (even if 0)

It depends on https://github.com/dmwm/deployment/pull/603 and we need to add a stomp dependency on the workqueue RPM spec file.
And, we have to disable global_workqueue docs from @stiegerb script, once it goes into prod.