### PR TITLE
fix report location when bootstrap error happens

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -258,9 +258,12 @@ class SimpleCondorPlugin(BasePlugin):
                 continue
 
             reportName = os.path.join(job['cache_dir'], 'Report.%i.pkl' % job['retry_count'])
+            reportNameWithBootstapError =  os.path.join(job['cache_dir'], 'Report.0.pkl')
             if os.path.isfile(reportName) and os.path.getsize(reportName) > 0:
                 # everything in order, move on
                 continue
+            elif os.path.isfile(reportNameWithBootstapError) and os.path.getsize(reportNameWithBootstapError) > 0:
+                os.rename(reportNameWithBootstapError, reportName)
             elif os.path.isdir(reportName):
                 # Then something weird has happened. Report error, do nothing
                 logging.error("The job report for job with id %s and gridid %s is a directory", job['id'],


### PR DESCRIPTION
When job fails in Bootstrap state. FrameWorkJob Report retry number is always 0. 
And WMAgent won't find the Repork.[retry_number].pkl file.

https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/WMRuntime/Bootstrap.py#L133
https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/WMRuntime/Bootstrap.py#L141
https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/WMRuntime/Bootstrap.py#L152

This it temporary patch for tier 0 agent. (Need to find the better solution) - Not tested yet.