### PR TITLE
Set retry_count for jobs to be submitted

### DIFF
--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -345,7 +345,8 @@ class JobSubmitterPoller(BaseWorkerThread):
                     newJob['possibleSites'] = possibleLocations
                     badJobs[71104].append(newJob)
                     continue
-
+            # Sigh...make sure the job added to the package has the proper retry_count
+            loadedJob['retry_count'] = newJob['retry_count']
             batchDir = self.addJobsToPackage(loadedJob)
 
             # calculate the final job priority such that we can order cached jobs by prio
@@ -365,6 +366,7 @@ class JobSubmitterPoller(BaseWorkerThread):
             jobInfo = {'taskPriority': None,  # update from the thresholds
                        'custom': {'location': None},  # update later
                        'packageDir': batchDir,
+                       'retry_count': newJob["retry_count"],
                        'sandbox': loadedJob["sandbox"],  # remove before submit
                        'userdn': loadedJob.get("ownerDN", None),
                        'usergroup': loadedJob.get("ownerGroup", ''),


### PR DESCRIPTION
Fix a problem found in a T0 replay where the job loaded in the worker node always have `retry_count: 0`, thus it tries to transfer back to the schedd a file named "Report.0.pkl", no matter which retry the job is undergoing.

This bug was introduced with https://github.com/dmwm/WMCore/pull/8509 :-(