### PR TITLE
upload lumi text file from AlcaHarvest

### DIFF
--- a/src/python/Utils/Utilities.py
+++ b/src/python/Utils/Utilities.py
@@ -3,6 +3,8 @@
 from __future__ import division, print_function
 
 import subprocess
+import os
+import re
 
 
 def makeList(stringList):
@@ -86,3 +88,18 @@ def numberCouchProcess():
     process = ps.communicate()[0].count('couchjs')
 
     return process
+
+
+def rootUrlJoin(base, extend):
+    """
+    Adds a path element to the path within a ROOT url
+    """
+    if base:
+        match = re.match("^root://([^/]+)/(.+)", base)
+        if match:
+            host = match.group(1)
+            path = match.group(2)
+            newpath = os.path.join(path, extend)
+            newurl = "root://%s/%s" % (host, newpath)
+            return newurl
+    return None

--- a/src/python/WMCore/WMSpec/StdSpecs/Express.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Express.py
@@ -212,11 +212,13 @@ class ExpressWorkloadFactory(StdBase):
 
                 for alcaSkimOutLabel, alcaSkimOutInfo in alcaSkimOutMods.items():
 
-                    if alcaSkimOutInfo['dataTier'] == "ALCAPROMPT" and self.alcaHarvestDir != None:
+                    if alcaSkimOutInfo['dataTier'] == "ALCAPROMPT" and \
+                            ( self.alcaHarvestCondLFNBase != None or self.alcaHarvestLumiURL != None ):
                         harvestTask = self.addAlcaHarvestTask(alcaSkimTask, alcaSkimOutLabel,
                                                               alcapromptdataset=alcaSkimOutInfo['filterName'],
                                                               condOutLabel=self.alcaHarvestOutLabel,
-                                                              condUploadDir=self.alcaHarvestDir,
+                                                              condLFNBase=self.alcaHarvestCondLFNBase,
+                                                              lumiURL=self.alcaHarvestLumiURL,
                                                               uploadProxy=self.dqmUploadProxy,
                                                               doLogCollect=True)
 
@@ -316,8 +318,8 @@ class ExpressWorkloadFactory(StdBase):
         return mergeTask
 
     def addAlcaHarvestTask(self, parentTask, parentOutputModuleName,
-                           alcapromptdataset, condOutLabel, condUploadDir, uploadProxy,
-                           parentStepName="cmsRun1", doLogCollect=True):
+                           alcapromptdataset, condOutLabel, condLFNBase, lumiURL,
+                           uploadProxy, parentStepName="cmsRun1", doLogCollect=True):
         """
         _addAlcaHarvestTask_
 
@@ -386,7 +388,8 @@ class ExpressWorkloadFactory(StdBase):
         harvestTaskConditionHelper = harvestTaskCondition.getTypeHelper()
         harvestTaskConditionHelper.setRunNumber(self.runNumber)
         harvestTaskConditionHelper.setConditionOutputLabel(condOutLabel+"ALCAPROMPT")
-        harvestTaskConditionHelper.setConditionDir(condUploadDir)
+        harvestTaskConditionHelper.setConditionLFNBase(condLFNBase)
+        harvestTaskConditionHelper.setLuminosityURL(lumiURL)
 
         self.addOutputModule(harvestTask, condOutLabel,
                              primaryDataset=getattr(parentOutputModule, "primaryDataset"),
@@ -478,7 +481,8 @@ class ExpressWorkloadFactory(StdBase):
                     "StreamName": {"optional": False},
                     "SpecialDataset": {"optional": False},
                     "AlcaHarvestTimeout": {"type": int, "optional": False},
-                    "AlcaHarvestDir": {"optional": False, "null": True},
+                    "AlcaHarvestCondLFNBase": {"optional": False, "null": True},
+                    "AlcaHarvestLumiURL": {"optional": False, "null": True},
                     "AlcaSkims": {"type": makeList, "optional": False},
                     "DQMSequences": {"type": makeList, "attr": "dqmSequences", "optional": False},
                     "Outputs": {"type": makeList, "optional": False},

--- a/src/python/WMCore/WMSpec/Steps/Templates/AlcaHarvest.py
+++ b/src/python/WMCore/WMSpec/Steps/Templates/AlcaHarvest.py
@@ -33,13 +33,18 @@ class AlcaHarvestStepHelper(CoreHelper):
         """
         self.data.condition.outLabel = outLabel
 
-    def setConditionDir(self, dir):
+    def setConditionLFNBase(self, lfnbase):
         """
-        Sets the directory for condition file copy,
-        assumed to be a POSIX accessible path (AFS)
+        Sets the LFNBase for condition file copy
+        (within the EOSCMS CERN EOS instance)
         """
-        self.data.condition.dir = dir
+        self.data.condition.lfnbase = lfnbase
 
+    def setLuminosityURL(self, url):
+        """
+        Sets the ROOT URL for luminosity file copy
+        """
+        self.data.luminosity.url = url
 
 class AlcaHarvest(Template):
     """
@@ -55,7 +60,9 @@ class AlcaHarvest(Template):
         step.section_("condition")
         step.condition.runNumber = None
         step.condition.outLabel = None
-        step.condition.dir = None
+        step.condition.lfnbase = None
+        step.section_("luminosity")
+        step.luminosity.url = None
 
     def helper(self, step):
         """

--- a/test/python/Utils_t/Utilities_t.py
+++ b/test/python/Utils_t/Utilities_t.py
@@ -6,7 +6,7 @@ Unittests for Utilities functions
 from __future__ import division, print_function
 
 import unittest
-from Utils.Utilities import makeList, makeNonEmptyList, strToBool, safeStr
+from Utils.Utilities import makeList, makeNonEmptyList, strToBool, safeStr, rootUrlJoin
 
 
 class UtilitiesTests(unittest.TestCase):
@@ -75,6 +75,17 @@ class UtilitiesTests(unittest.TestCase):
 
         for v in [[1, 2], {'x': 123}, set([1])]:
             self.assertRaises(ValueError, safeStr, v)
+
+    def testRootUrlJoin(self):
+        """
+        Test the testRootUrlJoin function.
+        """
+        urlbase = "root://site.domain//somepath"
+        self.assertEqual(rootUrlJoin(urlbase, "extend"), "root://site.domain//somepath/extend")
+        urlbase = "random"
+        self.assertEqual(rootUrlJoin(urlbase, "extend"), None)
+        urlbase = None
+        self.assertEqual(rootUrlJoin(urlbase, "extend"), None)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Express_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Express_t.py
@@ -22,7 +22,8 @@ from WMQuality.TestInitCouchApp import TestInitCouchApp
 REQUEST = {
     "AcquisitionEra": "TestAcquisitionEra",
     "AlcaHarvestTimeout": 12 * 3600,
-    "AlcaHarvestDir": "/somepath",
+    "AlcaHarvestCondLFNBase": "somelfn",
+    "AlcaHarvestLumiURL": "someurl",
     "AlcaSkims": ["TkAlMinBias", "PromptCalibProd"],
     "CMSSWVersion": "CMSSW_9_0_0",
     "DQMSequences": ["@common"],


### PR DESCRIPTION
1.1.12_wmagent branch of #8563
AlcaHarvest will produce a luminosity text file with information for the LHC.

Since this is uploaded to a different EOS system (not CMS EOS), refactor the
AlcaHarvest code a bit to be able to pass in upload URL for both condition
and luminosity output.