### PR TITLE
Expand override arguments into the section

### DIFF
--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -1395,8 +1395,8 @@ class WMWorkloadHelper(PersistencyHelper):
                     stepHelper = task.getStepHelper(stepName)
                     for key, value in overrides.items():
                         stepHelper.addOverride(key, value)
-
-            self.data.overrides = overrides
+            for key, value in overrides.items():
+                setattr(self.data.overrides, key, value)
 
         return
 


### PR DESCRIPTION
Fixes #8580

I can now load the workload config, not sure whether the override is still respected though :)