### PR TITLE
Very basic validation of dict spec args

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/ReDigi.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/ReDigi.py
@@ -5,10 +5,10 @@ _ReDigi_
 Standard two/three step redigi workflow.
 """
 import WMCore.WMSpec.Steps.StepFactory as StepFactory
-
+from Utils.Utilities import strToBool
 from WMCore.Lexicon import dataset
 from WMCore.WMSpec.StdSpecs.DataProcessing import DataProcessing
-from WMCore.WMSpec.WMWorkloadTools import strToBool, parsePileupConfig
+from WMCore.WMSpec.WMWorkloadTools import parsePileupConfig
 
 class ReDigiWorkloadFactory(DataProcessing):
     """


### PR DESCRIPTION
Fixes #8584 and #8517

The current dictionary validation was trying to assume things... In order to avoid false alarms, it's better not to validate any dict internals (since we don't have their definition anyways) and only check the actual argument.
In the future we can improve it and maybe make a function for every single dict argument, such that we can validate the whole thing.