### PR TITLE
Update eoscmshttp url

### DIFF
--- a/src/python/WMCore/FwkJobReport/Report.py
+++ b/src/python/WMCore/FwkJobReport/Report.py
@@ -1532,7 +1532,7 @@ class Report(object):
     def setLogURL(self, url):
         """
         Set log url for the this job report.
-        https://eoscmshttp.cern.ch/store/logs/prod/recent/
+        https://eoscmshttp.cern.ch/eos/cms/store/logs/prod/recent/
         """
         self.data.logURL = url
 

--- a/src/python/WMCore/WMSpec/Steps/Executors/LogArchive.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/LogArchive.py
@@ -85,7 +85,7 @@ class LogArchive(Executor):
         try:
             eosmanager(eosFileInfo)
             eosServerPrefix = eosStageOutParams['lfn-prefix'].replace("root://eoscms.cern.ch//eos/cms",
-                                                                      "https://eoscmshttp.cern.ch")
+                                                                      "https://eoscmshttp.cern.ch/eos/cms")
             self.report.setLogURL(eosServerPrefix + eosFileInfo['LFN'])
             self.saveReport()
         except Alarm:


### PR DESCRIPTION
After getting a 502 Bad Gateway today (and a snow ticket), Daniel (VoC) told me the correct url should be
https://eoscmshttp.cern.ch/eos/cms/store/logs/prod/recent/amaltaro_ACDC_ReDigi_AllFlag_HG1805_Validation_180425_222943_9511/StepOneProc/
instead of
https://eoscmshttp.cern.ch/store/logs/prod/recent/amaltaro_ACDC_ReDigi_AllFlag_HG1805_Validation_180425_222943_9511/StepOneProc/

Basically there is a `/eos/cms` in front of the LFN.
The current/previous url always gives me a bold red message about quota, while the new one doesn't.

Since both seem to work just fine, I think we can leave this PR for the next cmsweb cycle upgrade.
Seangchan, what do you think?

Still untested btw.