### PR TITLE
Fix phedex delete call - wmagent version

### DIFF
--- a/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
+++ b/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
@@ -521,12 +521,8 @@ class PhEDExInjectorPoller(BaseWorkerThread):
                                   comments="WMAgent blocks auto-delete from %s" % location,
                                   blocks=blocksToDelete)
 
-        xmlData = XMLDrop.makePhEDExXMLForBlocks(self.dbsUrl,
-                                                 deletion.getDatasetsAndBlocks())
-        logging.debug("deleteBlocks XMLData: %s", xmlData)
-
         try:
-            response = self.phedex.delete(deletion, xmlData)
+            response = self.phedex.delete(deletion)
             requestId = response['phedex']['request_created'][0]['id']
             # auto-approve deletion request
             self.phedex.updateRequest(requestId, 'approve', location)


### PR DESCRIPTION
1.1.10 wmagent version of #8625 
We missed this delete call when these changes https://github.com/dmwm/WMCore/pull/8164 were applied, and now (well, for half an year, the T0 agent fails to delete blocks...)