### PR TITLE
Temp patch which disables PhEDEx block deletion for T0 agent

### DIFF
--- a/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
+++ b/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
@@ -174,7 +174,7 @@ class PhEDExInjectorPoller(BaseWorkerThread):
 
             if self.pollCounter == self.subFrequency:
                 self.pollCounter = 0
-                self.deleteBlocks()
+                # self.deleteBlocks()  # skip block deletion until situation gets under control
                 self.subscribeDatasets()
         except HTTPException as ex:
             if hasattr(ex, "status") and ex.status in [502, 503]:


### PR DESCRIPTION
There *might* be a problem with the T0 agent and how it makes block deletion, see discussion in:
https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/1900.html

Honestly, I doubt there is a logic issue since it hasn't been changed for a long time (the last patch was only to fix the delete method signature)

FYI @hufnagel @vytjan and Dima (I don't know his GH user)