### PR TITLE
Override T0-spec assignment parameters with a new Override value

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/DataProcessing.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/DataProcessing.py
@@ -65,3 +65,9 @@ class DataProcessing(StdBase):
         baseArgs.update(specArgs)
         StdBase.setDefaultArgumentsProperty(baseArgs)
         return baseArgs
+
+    @staticmethod
+    def getWorkloadAssignArgs():
+        baseArgs = StdBase.getWorkloadAssignArgs()
+        StdBase.setDefaultArgumentsProperty(baseArgs)
+        return baseArgs

--- a/src/python/WMCore/WMSpec/StdSpecs/Express.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Express.py
@@ -213,7 +213,7 @@ class ExpressWorkloadFactory(StdBase):
                 for alcaSkimOutLabel, alcaSkimOutInfo in alcaSkimOutMods.items():
 
                     if alcaSkimOutInfo['dataTier'] == "ALCAPROMPT" and \
-                            ( self.alcaHarvestCondLFNBase != None or self.alcaHarvestLumiURL != None ):
+                            (self.alcaHarvestCondLFNBase is not None or self.alcaHarvestLumiURL is not None):
                         harvestTask = self.addAlcaHarvestTask(alcaSkimTask, alcaSkimOutLabel,
                                                               alcapromptdataset=alcaSkimOutInfo['filterName'],
                                                               condOutLabel=self.alcaHarvestOutLabel,
@@ -365,7 +365,7 @@ class ExpressWorkloadFactory(StdBase):
         parentTaskCmssw = parentTask.getStep(parentStepName)
         parentOutputModule = parentTaskCmssw.getOutputModule(parentOutputModuleName)
 
-        dataTier=getattr(parentOutputModule, "dataTier")
+        dataTier = getattr(parentOutputModule, "dataTier")
         harvestTask.setInputReference(parentTaskCmssw, outputModule=parentOutputModuleName, dataTier=dataTier)
 
         harvestTask.setSplittingAlgorithm("AlcaHarvest",
@@ -387,7 +387,7 @@ class ExpressWorkloadFactory(StdBase):
 
         harvestTaskConditionHelper = harvestTaskCondition.getTypeHelper()
         harvestTaskConditionHelper.setRunNumber(self.runNumber)
-        harvestTaskConditionHelper.setConditionOutputLabel(condOutLabel+"ALCAPROMPT")
+        harvestTaskConditionHelper.setConditionOutputLabel(condOutLabel + "ALCAPROMPT")
         harvestTaskConditionHelper.setConditionLFNBase(condLFNBase)
         harvestTaskConditionHelper.setLuminosityURL(lumiURL)
 
@@ -428,7 +428,7 @@ class ExpressWorkloadFactory(StdBase):
         conditionTaskBogus = conditionTask.makeStep("bogus")
         conditionTaskBogus.setStepType("DQMUpload")
 
-        dataTier=getattr(parentOutputModule, "dataTier")
+        dataTier = getattr(parentOutputModule, "dataTier")
         conditionTask.setInputReference(parentTaskCmssw, outputModule=parentOutputModuleName, dataTier=dataTier)
 
         conditionTask.applyTemplates()
@@ -500,9 +500,10 @@ class ExpressWorkloadFactory(StdBase):
     @staticmethod
     def getWorkloadAssignArgs():
         baseArgs = StdBase.getWorkloadAssignArgs()
-        specArgs = {"Override": {"default": {"eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/Express"},
-                                  "type": dict},
-                    }
+        specArgs = {
+            "Override": {"default": {"eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/Express"},
+                         "type": dict},
+            }
         baseArgs.update(specArgs)
         StdBase.setDefaultArgumentsProperty(baseArgs)
         return baseArgs

--- a/src/python/WMCore/WMSpec/StdSpecs/Express.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Express.py
@@ -496,3 +496,13 @@ class ExpressWorkloadFactory(StdBase):
         baseArgs.update(specArgs)
         StdBase.setDefaultArgumentsProperty(baseArgs)
         return baseArgs
+
+    @staticmethod
+    def getWorkloadAssignArgs():
+        baseArgs = StdBase.getWorkloadAssignArgs()
+        specArgs = {"Override": {"default": {"eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/Express"},
+                                  "type": dict},
+                    }
+        baseArgs.update(specArgs)
+        StdBase.setDefaultArgumentsProperty(baseArgs)
+        return baseArgs

--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -197,9 +197,10 @@ class PromptRecoWorkloadFactory(DataProcessing):
     @staticmethod
     def getWorkloadAssignArgs():
         baseArgs = DataProcessing.getWorkloadAssignArgs()
-        specArgs = {"Override": {"default": {"eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/PromptReco"},
-                                  "type": dict},
-                    }
+        specArgs = {
+            "Override": {"default": {"eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/PromptReco"},
+                         "type": dict},
+            }
         baseArgs.update(specArgs)
         DataProcessing.setDefaultArgumentsProperty(baseArgs)
         return baseArgs

--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -193,3 +193,13 @@ class PromptRecoWorkloadFactory(DataProcessing):
         baseArgs.update(specArgs)
         DataProcessing.setDefaultArgumentsProperty(baseArgs)
         return baseArgs
+
+    @staticmethod
+    def getWorkloadAssignArgs():
+        baseArgs = DataProcessing.getWorkloadAssignArgs()
+        specArgs = {"Override": {"default": {"eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/PromptReco"},
+                                  "type": dict},
+                    }
+        baseArgs.update(specArgs)
+        DataProcessing.setDefaultArgumentsProperty(baseArgs)
+        return baseArgs

--- a/src/python/WMCore/WMSpec/StdSpecs/Repack.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Repack.py
@@ -207,9 +207,10 @@ class RepackWorkloadFactory(StdBase):
     @staticmethod
     def getWorkloadAssignArgs():
         baseArgs = StdBase.getWorkloadAssignArgs()
-        specArgs = {"Override": {"default": {"eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/Repack"},
-                                  "type": dict},
-                    }
+        specArgs = {
+            "Override": {"default": {"eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/Repack"},
+                         "type": dict},
+            }
         baseArgs.update(specArgs)
         StdBase.setDefaultArgumentsProperty(baseArgs)
         return baseArgs

--- a/src/python/WMCore/WMSpec/StdSpecs/Repack.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Repack.py
@@ -203,3 +203,13 @@ class RepackWorkloadFactory(StdBase):
         baseArgs.update(specArgs)
         StdBase.setDefaultArgumentsProperty(baseArgs)
         return baseArgs
+
+    @staticmethod
+    def getWorkloadAssignArgs():
+        baseArgs = StdBase.getWorkloadAssignArgs()
+        specArgs = {"Override": {"default": {"eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/Repack"},
+                                  "type": dict},
+                    }
+        baseArgs.update(specArgs)
+        StdBase.setDefaultArgumentsProperty(baseArgs)
+        return baseArgs


### PR DESCRIPTION
Fixes #8634

However, since it's an assignment parameter and the T0 system "assigns" workflow differently, I'll leave this PR open until I can check with @hufnagel whether this fix is reasonable for T0 operations.