### PR TITLE
Decrease EventsPerLumi if its way beyond 8h jobs

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -99,6 +99,8 @@ class StdBase(object):
 
         if ePerLumi is None:
             ePerLumi = ePerJob
+        elif ePerLumi > ePerJob:
+            ePerLumi = ePerJob
         else:
             # then make EventsPerJob multiple of EventsPerLumi and still closer to 8h jobs
             multiplier = int(round(ePerJob / ePerLumi))

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StdBase_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StdBase_t.py
@@ -57,18 +57,18 @@ class StdBaseTest(unittest.TestCase):
         Check that EventsPerJob and EventsPerLumi are properly calculated
         for EventBased job splitting.
         """
-        self.assertEqual((345, 345), StdBase.calcEvtsPerJobLumi(123, 345, 1))
+        self.assertEqual((123, 123), StdBase.calcEvtsPerJobLumi(123, 345, 1))
         self.assertEqual((123, 123), StdBase.calcEvtsPerJobLumi(123, None, 1))
 
         self.assertEqual((28800, 100), StdBase.calcEvtsPerJobLumi(None, 100, 1))
         self.assertEqual((600, 100), StdBase.calcEvtsPerJobLumi(None, 100, 50.5))
-        self.assertEqual((1000, 1000), StdBase.calcEvtsPerJobLumi(None, 1000, 50.5))
+        self.assertEqual((570, 570), StdBase.calcEvtsPerJobLumi(None, 1000, 50.5))
 
         self.assertEqual((23040, 23040), StdBase.calcEvtsPerJobLumi(None, None, 1.25))
         self.assertEqual((229, 229), StdBase.calcEvtsPerJobLumi(None, None, 125.5))
 
         self.assertEqual((23528, 11764), StdBase.calcEvtsPerJobLumi(24000, 11764, 10.157120496967591))
-        self.assertEqual((11764, 11764), StdBase.calcEvtsPerJobLumi(None, 11764, 10.157120496967591))  # non rounded result is 2835
+        self.assertEqual((2835, 2835), StdBase.calcEvtsPerJobLumi(None, 11764, 10.157120496967591))
 
         return
 


### PR DESCRIPTION
Fixes #8639 
Behavior is:
IF eventsPerLumi >= calculated eventsPerJob OR provided eventsPerJob; then
  eventsPerLumi = eventsPerJob