### PR TITLE
Dump the WN environment before defining the finish function

### DIFF
--- a/etc/submit.sh
+++ b/etc/submit.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+# On some sites we know there were some problems with environment cleaning
+# with using 'env -i'. To overcome this issue, whenever we start a job, we have
+# to save full current environment into file, and whenever it is needed we can load
+# it. Be aware, that there are some read-only variables, like: BASHOPTS, BASH_VERSINFO,
+# EUID, PPID, SHELLOPTS, UID, etc.
+set | sed 's/^/export /g' > startup_environment.sh
+
 # Function to check the exit code of this bootstrap script and the job/python
 # wrapper exit code.
 # 1) If the bootstrap exit code is not 0, then something is wrong with the worker
@@ -46,14 +53,6 @@ WMA_SCRAM_ARCH=slc6_amd64_gcc493
 WMA_MIN_JOB_RUNTIMESECS=300
 START_TIME=$(date +%s)
 
-# On some sites we know there was some problems with environment cleaning
-# with using 'env -i'. To overcome this issue, whenever we start a job, we have
-# to save full current environment into file, and whenever it is needed we can load
-# it. Be aware, that there are some read-only variables, like: BASHOPTS, BASH_VERSINFO,
-# EUID, PPID, SHELLOPTS, UID, etc.
-set > startup_environment.sh
-sed -e 's/^/export /' startup_environment.sh > tmp_env.sh
-mv tmp_env.sh startup_environment.sh
 export JOBSTARTDIR=$PWD
 
 if [ "X$_CONDOR_JOB_AD" != "X" ];


### PR DESCRIPTION
Supposed to fix an error we see in every single job log
```
 stderr: /var/lib/condor/execute/dir_6175/startup_environment.sh: line 2: BASHOPTS: readonly variable
/var/lib/condor/execute/dir_6175/startup_environment.sh: line 9: BASH_VERSINFO: readonly variable
/var/lib/condor/execute/dir_6175/startup_environment.sh: line 13: EUID: readonly variable
/var/lib/condor/execute/dir_6175/startup_environment.sh: line 25: PPID: readonly variable
/var/lib/condor/execute/dir_6175/startup_environment.sh: line 29: SHELLOPTS: readonly variable
/var/lib/condor/execute/dir_6175/startup_environment.sh: line 36: UID: readonly variable
/var/lib/condor/execute/dir_6175/startup_environment.sh: line 52: syntax error near unexpected token `('
/var/lib/condor/execute/dir_6175/startup_environment.sh: line 52: `export finish () ‘
```