### PR TITLE
Limit the number of archiveable jobs to be loaded each cycle

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -244,9 +244,10 @@ config.RetryManager.SquaredAlgo.default.coolOffTime = retryAlgoParams
 config.component_("JobArchiver")
 config.JobArchiver.namespace = "WMComponent.JobArchiver.JobArchiver"
 config.JobArchiver.componentDir = config.General.workDir + "/JobArchiver"
-config.JobArchiver.pollInterval = 240
+config.JobArchiver.pollInterval = 120
 config.JobArchiver.logLevel = globalLogLevel
 config.JobArchiver.numberOfJobsToCluster = 1000
+config.JobArchiver.numberOfJobsToArchive = 10000
 # This is now OPTIONAL, it defaults to the componentDir
 # HOWEVER: Is is HIGHLY recommended that you do NOT run this on the same
 # disk as the JobCreator

--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -271,9 +271,12 @@ config.TaskArchiver.dqmUrl = "OVER_WRITE_BY_SECETES"
 config.TaskArchiver.requireCouch = True
 # set to False couch data if request mgr is not used (Tier0, PromptSkiming)
 config.TaskArchiver.useReqMgrForCompletionCheck = True
-config.TaskArchiver.localCouchURL = "%s/%s" % (config.JobStateMachine.couchurl, config.JobStateMachine.couchDBName)
-config.TaskArchiver.localQueueURL = "%s/%s" % (config.WorkQueueManager.couchurl, config.WorkQueueManager.dbname)
-config.TaskArchiver.localWMStatsURL = "%s/%s" % (config.JobStateMachine.couchurl, config.JobStateMachine.jobSummaryDBName)
+config.TaskArchiver.localCouchURL = "%s/%s" % (config.JobStateMachine.couchurl,
+                                               config.JobStateMachine.couchDBName)
+config.TaskArchiver.localQueueURL = "%s/%s" % (config.WorkQueueManager.couchurl,
+                                               config.WorkQueueManager.dbname)
+config.TaskArchiver.localWMStatsURL = "%s/%s" % (config.JobStateMachine.couchurl,
+                                                 config.JobStateMachine.jobSummaryDBName)
 config.TaskArchiver.DataKeepDays = 0.125  # couhch history keeping days.
 config.TaskArchiver.cleanCouchInterval = 60 * 20  # 20 min
 config.TaskArchiver.archiveDelayHours = 24  # delay the archiving so monitor can still show. default 24 hours
@@ -296,10 +299,12 @@ config.AnalyticsDataCollector.namespace = "WMComponent.AnalyticsDataCollector.An
 config.AnalyticsDataCollector.componentDir = config.General.workDir + "/AnalyticsDataCollector"
 config.AnalyticsDataCollector.logLevel = globalLogLevel
 config.AnalyticsDataCollector.pollInterval = 600
-config.AnalyticsDataCollector.localCouchURL = "%s/%s" % (
-config.JobStateMachine.couchurl, config.JobStateMachine.couchDBName)
-config.AnalyticsDataCollector.localQueueURL = "%s/%s" % (config.WorkQueueManager.couchurl, config.WorkQueueManager.dbname)
-config.AnalyticsDataCollector.localWMStatsURL = "%s/%s" % (config.JobStateMachine.couchurl, config.JobStateMachine.jobSummaryDBName)
+config.AnalyticsDataCollector.localCouchURL = "%s/%s" % (config.JobStateMachine.couchurl,
+                                                         config.JobStateMachine.couchDBName)
+config.AnalyticsDataCollector.localQueueURL = "%s/%s" % (config.WorkQueueManager.couchurl,
+                                                         config.WorkQueueManager.dbname)
+config.AnalyticsDataCollector.localWMStatsURL = "%s/%s" % (config.JobStateMachine.couchurl,
+                                                           config.JobStateMachine.jobSummaryDBName)
 config.AnalyticsDataCollector.centralWMStatsURL = "Central WMStats URL"
 config.AnalyticsDataCollector.centralRequestDBURL = "Cental Request DB URL"
 config.AnalyticsDataCollector.summaryLevel = "task"

--- a/src/python/WMComponent/JobArchiver/JobArchiverPoller.py
+++ b/src/python/WMComponent/JobArchiver/JobArchiverPoller.py
@@ -56,6 +56,8 @@ class JobArchiverPoller(BaseWorkerThread):
         # Variables
         self.numberOfJobsToCluster = getattr(self.config.JobArchiver,
                                              "numberOfJobsToCluster", 1000)
+        self.numberOfJobsToArchive = getattr(self.config.JobArchiver,
+                                             "numberOfJobsToArchive", 10000)
 
         # initialize the alert framework (if available)
         self.initAlerts(compName="JobArchiver")
@@ -172,9 +174,9 @@ class JobArchiverPoller(BaseWorkerThread):
         jobList = []
 
         jobListAction = self.daoFactory(classname="Jobs.GetAllJobs")
-        jobList1 = jobListAction.execute(state="success")
-        jobList2 = jobListAction.execute(state="exhausted")
-        jobList3 = jobListAction.execute(state="killed")
+        jobList1 = jobListAction.execute(state="success", limitRows=self.numberOfJobsToArchive)
+        jobList2 = jobListAction.execute(state="exhausted", limitRows=self.numberOfJobsToArchive)
+        jobList3 = jobListAction.execute(state="killed", limitRows=self.numberOfJobsToArchive)
 
         jobList.extend(jobList1)
         jobList.extend(jobList2)

--- a/src/python/WMComponent/JobArchiver/JobArchiverPoller.py
+++ b/src/python/WMComponent/JobArchiver/JobArchiverPoller.py
@@ -2,28 +2,25 @@
 """
 The actual jobArchiver algorithm
 """
-__all__ = []
-
-import threading
 import logging
 import os
 import os.path
 import shutil
 import tarfile
+import threading
 
 from Utils.IteratorTools import grouper
 from Utils.Timers import timeFunction
-from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
+from WMCore.DAOFactory import DAOFactory
 from WMCore.JobStateMachine.ChangeState import ChangeState
+from WMCore.Services.ReqMgrAux.ReqMgrAux import isDrainMode
+from WMCore.WMBS.Fileset import Fileset
+from WMCore.WMBS.Job import Job
+from WMCore.WMException import WMException
 from WMCore.WorkQueue.WorkQueueExceptions import WorkQueueNoMatchingElements
 from WMCore.WorkQueue.WorkQueueUtils import queueFromConfig
+from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 
-from WMCore.WMBS.Job import Job
-from WMCore.DAOFactory import DAOFactory
-from WMCore.WMBS.Fileset import Fileset
-from WMCore.WMException import WMException
-
-from WMCore.Services.ReqMgrAux.ReqMgrAux import isDrainMode
 
 class JobArchiverPollerException(WMException):
     """
@@ -51,7 +48,6 @@ class JobArchiverPoller(BaseWorkerThread):
                                      logger=myThread.logger,
                                      dbinterface=myThread.dbi)
         self.loadAction = self.daoFactory(classname="Jobs.LoadFromIDWithWorkflow")
-
 
         # Variables
         self.numberOfJobsToCluster = getattr(self.config.JobArchiver,
@@ -114,8 +110,8 @@ class JobArchiverPoller(BaseWorkerThread):
             self.markInjected()
         except WMException:
             myThread = threading.currentThread()
-            if getattr(myThread, 'transaction', None) != None \
-                    and getattr(myThread.transaction, 'transaction', None) != None:
+            if getattr(myThread, 'transaction', None) is not None \
+                    and getattr(myThread.transaction, 'transaction', None) is not None:
                 myThread.transaction.rollback()
             raise
         except Exception as ex:
@@ -123,8 +119,8 @@ class JobArchiverPoller(BaseWorkerThread):
             msg = "Caught exception in JobArchiver\n"
             msg += str(ex)
             msg += "\n\n"
-            if getattr(myThread, 'transaction', None) != None \
-                    and getattr(myThread.transaction, 'transaction', None) != None:
+            if getattr(myThread, 'transaction', None) is not None \
+                    and getattr(myThread.transaction, 'transaction', None) is not None:
                 myThread.transaction.rollback()
             raise JobArchiverPollerException(msg)
 

--- a/src/python/WMCore/WMBS/MySQL/Jobs/GetAllJobs.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/GetAllJobs.py
@@ -5,11 +5,8 @@ _GetLocation_
 MySQL implementation of Jobs.GetAllJobs
 """
 
-__all__ = []
-
-
-
 from WMCore.Database.DBFormatter import DBFormatter
+
 
 class GetAllJobs(DBFormatter):
     """
@@ -18,7 +15,7 @@ class GetAllJobs(DBFormatter):
     Retrieve all files that are associated with the given job from the
     database.
     """
-    sql_all   = "SELECT id FROM wmbs_job"
+    sql_all = "SELECT id FROM wmbs_job"
 
     sql_state = "SELECT id FROM wmbs_job WHERE state = (SELECT id FROM wmbs_job_state WHERE name = :state)"
 
@@ -28,11 +25,9 @@ class GetAllJobs(DBFormatter):
                           INNER JOIN wmbs_job_state ON wmbs_job.state = wmbs_job_state.id
                           INNER JOIN wmbs_sub_types ON wmbs_subscription.subtype = wmbs_sub_types.id
                           WHERE wmbs_job_state.name = :state
-                          AND wmbs_sub_types.name = :type
-    """
+                          AND wmbs_sub_types.name = :type"""
 
     limit_sql = " limit %d"
-
 
     def format(self, results):
         """
@@ -51,9 +46,8 @@ class GetAllJobs(DBFormatter):
                 final.append(i.values()[0])
             return final
 
-
-    def execute(self, state = None, jobType = None, conn = None,
-                transaction = False, limitRows=None):
+    def execute(self, state=None, jobType=None, conn=None,
+                transaction=False, limitRows=None):
         """
         _execute_
 
@@ -65,16 +59,16 @@ class GetAllJobs(DBFormatter):
         else:
             extraSql = ""
 
-        if state == None:
-            result = self.dbi.processData(self.sql_all + extraSql, {}, conn = conn,
-                                          transaction = transaction)
+        if state is None:
+            result = self.dbi.processData(self.sql_all + extraSql, {}, conn=conn,
+                                          transaction=transaction)
         else:
             if jobType:
-                result = self.dbi.processData(self.sql_state_type + extraSql, {'state':state.lower(),'type': jobType},
-                                              conn = conn, transaction = transaction)
+                result = self.dbi.processData(self.sql_state_type + extraSql, {'state': state.lower(), 'type': jobType},
+                                              conn=conn, transaction=transaction)
             else:
-                result = self.dbi.processData(self.sql_state + extraSql, {'state':state.lower()},
-                                              conn = conn, transaction = transaction)
+                result = self.dbi.processData(self.sql_state + extraSql, {'state': state.lower()},
+                                              conn=conn, transaction=transaction)
 
         res = self.format(result)
         return res

--- a/src/python/WMCore/WMBS/MySQL/Jobs/GetAllJobs.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/GetAllJobs.py
@@ -31,6 +31,9 @@ class GetAllJobs(DBFormatter):
                           AND wmbs_sub_types.name = :type
     """
 
+    limit_sql = " limit %d"
+
+
     def format(self, results):
         """
         _formatDict_
@@ -49,23 +52,29 @@ class GetAllJobs(DBFormatter):
             return final
 
 
-    def execute(self, state = None, jobType = None, conn = None, transaction = False):
+    def execute(self, state = None, jobType = None, conn = None,
+                transaction = False, limitRows=None):
         """
         _execute_
 
         Execute the SQL for the given job ID and then format and return
         the result.
         """
+        if limitRows:
+            extraSql = self.limit_sql % limitRows
+        else:
+            extraSql = ""
+
         if state == None:
-            result = self.dbi.processData(self.sql_all, {}, conn = conn,
+            result = self.dbi.processData(self.sql_all + extraSql, {}, conn = conn,
                                           transaction = transaction)
         else:
             if jobType:
-                result = self.dbi.processData(self.sql_state_type, {'state':state.lower(), 'type': jobType}, conn = conn,
-                                          transaction = transaction)
+                result = self.dbi.processData(self.sql_state_type + extraSql, {'state':state.lower(),'type': jobType},
+                                              conn = conn, transaction = transaction)
             else:
-                result = self.dbi.processData(self.sql_state, {'state':state.lower()}, conn = conn,
-                                              transaction = transaction)
+                result = self.dbi.processData(self.sql_state + extraSql, {'state':state.lower()},
+                                              conn = conn, transaction = transaction)
 
         res = self.format(result)
         return res

--- a/src/python/WMCore/WMBS/Oracle/Jobs/GetAllJobs.py
+++ b/src/python/WMCore/WMBS/Oracle/Jobs/GetAllJobs.py
@@ -5,11 +5,8 @@ _GetAllJobs_
 Oracle implementation of Jobs.GetAllJobs
 """
 
-__all__ = []
-
-
-
 from WMCore.WMBS.MySQL.Jobs.GetAllJobs import GetAllJobs as MySQLGetAllJobs
+
 
 class GetAllJobs(MySQLGetAllJobs):
     """

--- a/src/python/WMCore/WMBS/Oracle/Jobs/GetAllJobs.py
+++ b/src/python/WMCore/WMBS/Oracle/Jobs/GetAllJobs.py
@@ -13,6 +13,6 @@ from WMCore.WMBS.MySQL.Jobs.GetAllJobs import GetAllJobs as MySQLGetAllJobs
 
 class GetAllJobs(MySQLGetAllJobs):
     """
-    Right now the same as the MySQL version
-
+    Besides the row limitation, it's the same as in MySQL
     """
+    limit_sql = " AND ROWNUM <= %d"


### PR DESCRIPTION
Fixes #8649
Also cuts the polling cycle by half.
This patch avoids loading tons of Job objects into memory, in case we have a huge number of jobs being aborted in one shot.

I had a quick look at the `processData` method and it seems there is no mechanism yet to limit the number of rows to be returned. For now I'm adding it to this DAO only, but I'm pretty sure we'll want it for other DAOs in the near future.

For the record, 10k jobs takes around 600 to 700 secs to be archived.