### PR TITLE
Reduce the BossAir memory footprint

### DIFF
--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -13,7 +13,6 @@ import logging
 import os.path
 import threading
 from collections import defaultdict, Counter
-
 try:
     import cPickle as pickle
 except ImportError:
@@ -708,7 +707,6 @@ class JobSubmitterPoller(BaseWorkerThread):
         self.changeState.propagate(successList, 'executing', 'created')
         logging.debug("Propagating fail state to WMBS.")
         self.changeState.propagate(failList, 'submitfailed', 'created')
-
         # At the end we mark the locations of the jobs
         # This applies even to failed jobs, since the location
         # could be part of the failure reason.

--- a/src/python/WMCore/BossAir/BossAirAPI.py
+++ b/src/python/WMCore/BossAir/BossAirAPI.py
@@ -20,7 +20,6 @@ import os.path
 import threading
 import logging
 import subprocess
-
 from WMCore.JobStateMachine.ChangeState import ChangeState
 from WMCore.DAOFactory import DAOFactory
 from WMCore.WMFactory import WMFactory
@@ -260,6 +259,7 @@ class BossAirAPI(WMConnectionBase):
         _deleteJobs_
 
         Delete the job entries in the BossAir database
+        NOTE: only used by unit tests
         """
 
         if len(jobs) < 1:
@@ -293,16 +293,15 @@ class BossAirAPI(WMConnectionBase):
         loadedJobs = []
         for job in jobList:
             rj = RunJob()
-            rj.update(job)
+            rj.buildFromJob(job)
             loadedJobs.append(rj)
 
         if len(loadedJobs) != len(wmbsJobs):
-            logging.error("Mismatch in WMBS load: Some requested jobs not found!")
+            logging.error("Could not load all jobs in BossAir for WMBS input!")
             idList = [x['jobid'] for x in loadedJobs]
             for job in wmbsJobs:
                 if job['id'] not in idList:
-                    logging.error("Could not retrieve job with WMBS ID %i from BossAir database", job['id'])
-                    logging.error("  ... WMBS job info is: %s", job)
+                    logging.error("Failed to retrieve wmbs_id %i and WMBS job info: %s", job['id'], job)
 
         return loadedJobs
 
@@ -353,24 +352,19 @@ class BossAirAPI(WMConnectionBase):
         # IMPORTANT IMPORTANT IMPORTANT
 
         # Put job into RunJob format
-        runJobs = []
+        pluginDict = {}
+
         for job in jobs:
             rj = RunJob()
             rj.buildFromJob(job=job)
             if not job.get('location', False):
                 rj['location'] = job.get('custom', {}).get('location', None)
-            runJobs.append(rj)
+            plugin = rj['plugin']
+            pluginDict.setdefault(plugin, [])
+            pluginDict[plugin].append(rj)
             # Can't add to the cache in submit()
             # It's NOT the same bossAir instance
             # self.jobs.append(rj)
-
-        # Now figure out which plugin we need
-        pluginDict = {}
-        for job in runJobs:
-            plugin = job['plugin']
-            if plugin not in pluginDict.keys():
-                pluginDict[plugin] = []
-            pluginDict[plugin].append(job)
 
         for plugin in pluginDict.keys():
             if plugin not in self.plugins.keys():
@@ -399,6 +393,10 @@ class BossAirAPI(WMConnectionBase):
                 logging.debug("Jobs being submitted: %s\n", jobsToSubmit)
                 logging.debug("Job info: %s\n", info)
                 raise BossAirException(msg)
+            finally:
+                # make sure we release this memory
+                pluginDict.clear()
+                del jobsToSubmit[:]
 
         # Create successful jobs in BossAir
         try:
@@ -578,22 +576,6 @@ class BossAirAPI(WMConnectionBase):
 
         return completeJobs
 
-    def removeComplete(self, jobs):
-        """
-        _removeComplete_
-
-        Remove jobs from BossAir
-        This is meant to operate ONLY on completed jobs
-        It does not operate any plugin cleanup or
-        batch system kills
-        """
-
-        jobsToRemove = self._buildRunningJobs(wmbsJobs=jobs)
-
-        self._deleteJobs(jobs=jobsToRemove)
-
-        return
-
     def kill(self, jobs, workflowName=None, killMsg=None, errorCode=71300):
         """
         _kill_
@@ -607,10 +589,8 @@ class BossAirAPI(WMConnectionBase):
         a standard message associated with the exit code will be used.
         If a previous FWJR exists, this error will be appended to it.
         """
-        if not len(jobs):
-            # Nothing to do here
+        if not jobs:
             return
-        self.check()
         jobsToKill = {}
 
         # Now get a list of which jobs are in the batch system
@@ -619,8 +599,7 @@ class BossAirAPI(WMConnectionBase):
 
         for runningJob in loadedJobs:
             plugin = runningJob['plugin']
-            if plugin not in jobsToKill.keys():
-                jobsToKill[plugin] = []
+            jobsToKill.setdefault(plugin, [])
             jobsToKill[plugin].append(runningJob)
 
         for plugin in jobsToKill.keys():
@@ -782,30 +761,6 @@ class BossAirAPI(WMConnectionBase):
         compiling it into a runJob object.  This overwrites any information
         from the database with the info from the WMBS Job
         """
+        runJobsLoaded = self.loadByWMBS(wmbsJobs=wmbsJobs)
 
-        finalJobs = []
-        loadedJobs = self.loadByWMBS(wmbsJobs=wmbsJobs)
-
-        if len(wmbsJobs) != len(loadedJobs):
-            logging.error("Could not load all jobs in BossAir for WMBS input")
-
-        for wmbsJob in wmbsJobs:
-            for runJob in loadedJobs:
-                if runJob['jobid'] == wmbsJob['id'] and runJob['retry_count'] == wmbsJob['retry_count']:
-                    rj = RunJob()
-                    rj.buildFromJob(wmbsJob)
-                    rj['id'] = runJob['id']
-                    for key in rj.keys():
-                        if rj[key] is None:
-                            rj[key] = runJob.get(key, None)
-                    finalJobs.append(rj)
-                    break
-            # If we get here, we're sort of screwed
-            # It means that although we sent for it, we couldn't find it.
-            # Possibly means that the job just isn't in there yet.
-            # Make a note of it, then do nothing
-            logging.debug("Could not successfully load a runJob for wmbsJob %i:%i\n", wmbsJob['id'],
-                          wmbsJob['retry_count'])
-            logging.debug("WMBS Job: %s\n", wmbsJob)
-
-        return finalJobs
+        return runJobsLoaded

--- a/src/python/WMCore/BossAir/BossAirAPI.py
+++ b/src/python/WMCore/BossAir/BossAirAPI.py
@@ -716,7 +716,7 @@ class BossAirAPI(WMConnectionBase):
             try:
                 pluginInst = self.plugins[plugin]
                 tempjoblist = pluginInst.updateSiteInformation(jobs, siteName, excludeSite)
-                if tempjoblist != None:
+                if tempjoblist is not None:
                     jobkill.extend(tempjoblist)
             except WMException:
                 raise

--- a/src/python/WMCore/BossAir/MySQL/LoadByWMBSID.py
+++ b/src/python/WMCore/BossAir/MySQL/LoadByWMBSID.py
@@ -20,7 +20,7 @@ class LoadByWMBSID(DBFormatter):
                st.name AS status, rj.retry_count as retry_count, rj.id AS id,
                rj.status_time as status_time, wu.cert_dn AS userdn,
                wu.group_name AS usergroup, wu.role_name AS userrole,
-               wl.plugin AS plugin
+               wl.plugin AS plugin, wj.cache_dir AS cache_dir
                FROM bl_runjob rj
                INNER JOIN bl_status st ON rj.sched_status = st.id
                LEFT OUTER JOIN wmbs_users wu ON wu.id = rj.user_id

--- a/src/python/WMCore/BossAir/MySQL/LoadByWMBSID.py
+++ b/src/python/WMCore/BossAir/MySQL/LoadByWMBSID.py
@@ -5,8 +5,8 @@ _LoadByWMBSID_
 MySQL implementation for loading a job by WMBS info
 """
 
-
 from WMCore.Database.DBFormatter import DBFormatter
+
 
 class LoadByWMBSID(DBFormatter):
     """
@@ -14,7 +14,6 @@ class LoadByWMBSID(DBFormatter):
 
     Load all jobs in full by WMBS ID and retry count
     """
-
 
     sql = """SELECT rj.wmbs_id AS jobid, rj.grid_id AS gridid, rj.bulk_id AS bulkid,
                st.name AS status, rj.retry_count as retry_count, rj.id AS id,
@@ -28,9 +27,7 @@ class LoadByWMBSID(DBFormatter):
                INNER JOIN wmbs_location wl ON wl.id = wj.location
                WHERE rj.wmbs_id = :id AND rj.retry_count = :retry_count"""
 
-
-
-    def execute(self, jobs, conn = None, transaction = False):
+    def execute(self, jobs, conn=None, transaction=False):
         """
         _execute_
 
@@ -47,7 +44,7 @@ class LoadByWMBSID(DBFormatter):
         for job in jobs:
             binds.append({'id': job['id'], 'retry_count': job['retry_count']})
 
-        result = self.dbi.processData(self.sql, binds, conn = conn,
-                                      transaction = transaction)
+        result = self.dbi.processData(self.sql, binds, conn=conn,
+                                      transaction=transaction)
 
         return self.formatDict(result)

--- a/src/python/WMCore/WorkerThreads/BaseWorkerThread.py
+++ b/src/python/WMCore/WorkerThreads/BaseWorkerThread.py
@@ -230,7 +230,7 @@ class BaseWorkerThread(object):
                 try:
                     self.heartbeatAPI.updateWorkerError(self.workerName, errMsg)
                 except Exception as ex:
-                    logging.error("Heartbeat error update failed %s" % str(ex))
+                    logging.error("Heartbeat error update failed %s", str(ex))
 
         # Indicate to manager that thread is done
         self.terminateCallback(threading.currentThread().name)

--- a/src/python/WMCore/WorkerThreads/BaseWorkerThread.py
+++ b/src/python/WMCore/WorkerThreads/BaseWorkerThread.py
@@ -170,6 +170,7 @@ class BaseWorkerThread(object):
             myThread = threading.currentThread()
 
             # Run event loop while termination is not flagged
+            algorithmWithDBExceptionHandler = db_exception_handler(self.algorithm)
             while not self.notifyTerminate.isSet():
                 # Check manager hasn't paused threads
                 if self.notifyPause.isSet():
@@ -183,7 +184,6 @@ class BaseWorkerThread(object):
                             if self.useHeartbeat:
                                 self.heartbeatAPI.updateWorkerHeartbeat(self.workerName, "Running")
 
-                            algorithmWithDBExceptionHandler = db_exception_handler(self.algorithm)
                             tSpent, results, _ = algorithmWithDBExceptionHandler(parameters)
                             if tSpent and self.useHeartbeat:
                                 logging.info("%s took %.3f secs to execute", self.workerName, tSpent)

--- a/test/python/WMCore_t/BossAir_t/BossAir_t.py
+++ b/test/python/WMCore_t/BossAir_t/BossAir_t.py
@@ -498,7 +498,8 @@ class BossAirTest(unittest.TestCase):
         result = myThread.dbi.processData("SELECT id FROM bl_runjob")[0].fetchall()
         self.assertEqual(len(result), nJobs)
 
-        baAPI.removeComplete(jobs=jobDummies)
+        jobsToRemove = baAPI._buildRunningJobs(wmbsJobs=jobDummies)
+        baAPI._deleteJobs(jobs=jobsToRemove)
 
         result = myThread.dbi.processData("SELECT id FROM bl_runjob")[0].fetchall()
         self.assertEqual(len(result), 0)


### PR DESCRIPTION
While investigating #8493 - which I can't reproduce/pinpoint the memory leak via unittests - I saw large spikes (and sort of random) of memory consumption when a site status is changed and all `executing` jobs have to be loaded, the site white list parsed and jobs eventually updated.

Note for myself: when profiling memory usage via unit tests, the component class/algorithm is attached to the same thread running the unit test, that means objects in memory might be from both unit test and the component object instance (so not exactly what the component running in the agent would see...).