### PR TITLE
split STAGEOUT_ERRORS for code 60317. Fix #8405

### DIFF
--- a/src/python/WMCore/WMExceptions.py
+++ b/src/python/WMCore/WMExceptions.py
@@ -237,6 +237,7 @@ WM_JOB_ERROR_CODES = {-1: "Error return without specification.",
 # 60313: "Failed to delete the output from the previous run via lcg-del command.", # Mh.. only lcg-del? Not used
 # 60314: "Failed to invoke ProdAgent StageOut Script.", Not used
 # 60316: "Failed to create a directory on the SE.", Not used
+# 60317: "Forced timeout for stuck stage out.",  # (To be used in CRAB3/ASO)
 # 60402: "Failure to assemble LFN in direct-to-merge by event (WMAgent).", # (WMA)
 # 60406: "Failure in staging in log files during log collection (WMAgent).", Not used
 # 60410: "Failure in deleting log files in log collection (WMAgent).", # Not used
@@ -260,10 +261,11 @@ value - is a list, which has dictionaries with the following content:
            b) CRAB3 Postjob decides should it retry job or not;
            c) ASO decides should it resubmit transfer to FTS;
 """
-STAGEOUT_ERRORS = {60321: [{"regex": ".*cancelled aso transfer after timeout.*",
-                            "error-msg": "Transfer canceled due to timeout.",
-                            "isPermanent": True},
-                           {"regex": ".*reports could not open connection to.*",
+STAGEOUT_ERRORS = {60317: [{"regex": ".*cancelled aso transfer after timeout.*",
+                            "error-msg": "ASO Transfer canceled due to timeout.",
+                            "isPermanent": True}
+                          ],
+                   60321: [{"regex": ".*reports could not open connection to.*",
                             "error-msg": "Storage element is not accessible.",
                             "isPermanent": False},
                            {"regex": ".*451 operation failed\\: all pools are full.*",


### PR DESCRIPTION
Fixes #8405
It turns out to be too much time expensive to set up a test of this. OTOH the only place where the affected lines are used is in CRABServer/ServerUtilities.py. So this is should be pretty safe  on your side.
A different story would be to move such CRAB specific code out or WMCore... too much work as well. I'll get back to it after ASOv2 is rolled out, hopefully we clean code and get rid of whatever makes use of this.
