### PR TITLE
TEMP patch to retrieve not more than 50k created jobs for submission

### DIFF
--- a/src/python/WMCore/WMBS/MySQL/Jobs/ListForSubmitter.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/ListForSubmitter.py
@@ -13,6 +13,7 @@ class ListForSubmitter(DBFormatter):
                     wmbs_job.name AS name,
                     wmbs_job.cache_dir AS cache_dir,
                     wmbs_sub_types.name AS task_type,
+                    wmbs_sub_types.priority AS task_prio,
                     wmbs_job.retry_count AS retry_count,
                     wmbs_workflow.name AS request_name,
                     wmbs_workflow.id AS task_id,
@@ -29,7 +30,9 @@ class ListForSubmitter(DBFormatter):
                  wmbs_job.state = wmbs_job_state.id
                INNER JOIN wmbs_workflow ON
                  wmbs_subscription.workflow = wmbs_workflow.id
-             WHERE wmbs_job_state.name = 'created'"""
+             WHERE wmbs_job_state.name = 'created'
+             ORDER BY wmbs_sub_types.priority DESC, wmbs_workflow.priority DESC
+             LIMIT 50000"""
 
     def execute(self, conn=None, transaction=False):
         result = self.dbi.processData(self.sql, conn=conn,

--- a/src/python/WMCore/WMBS/Oracle/Jobs/ListForSubmitter.py
+++ b/src/python/WMCore/WMBS/Oracle/Jobs/ListForSubmitter.py
@@ -11,4 +11,28 @@ Oracle implementation of Jobs.ListForSubmitter
 from WMCore.WMBS.MySQL.Jobs.ListForSubmitter import ListForSubmitter as MySQLListForSubmitter
 
 class ListForSubmitter(MySQLListForSubmitter):
-    pass
+    sql = """SELECT * FROM
+               (SELECT wmbs_job.id AS id,
+                    wmbs_job.name AS name,
+                    wmbs_job.cache_dir AS cache_dir,
+                    wmbs_sub_types.name AS task_type,
+                    wmbs_sub_types.priority AS task_prio,
+                    wmbs_job.retry_count AS retry_count,
+                    wmbs_workflow.name AS request_name,
+                    wmbs_workflow.id AS task_id,
+                    wmbs_workflow.priority AS wf_priority,
+                    wmbs_workflow.task AS task_name
+               FROM wmbs_job
+               INNER JOIN wmbs_jobgroup ON
+                 wmbs_job.jobgroup = wmbs_jobgroup.id
+               INNER JOIN wmbs_subscription ON
+                 wmbs_jobgroup.subscription = wmbs_subscription.id
+               INNER JOIN wmbs_sub_types ON
+                 wmbs_subscription.subtype = wmbs_sub_types.id
+               INNER JOIN wmbs_job_state ON
+                 wmbs_job.state = wmbs_job_state.id
+               INNER JOIN wmbs_workflow ON
+                 wmbs_subscription.workflow = wmbs_workflow.id
+               WHERE wmbs_job_state.name = 'created'
+               ORDER BY wmbs_sub_types.priority DESC, wmbs_workflow.priority DESC)
+             WHERE ROWNUM <= 50000"""


### PR DESCRIPTION
Mitigates #8648 , wmagent branch
Number of rows is hardcoded to 50k, that's why it's temporary and I'm applying it to vocms0256 only.
Still, we can make the number of rows configurable and then push this in into master too.