### PR TITLE
Limit number of jobs to cache in JobSubmitter; also order by task_id - wmagent version

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -198,6 +198,7 @@ config.JobSubmitter.pollInterval = 120
 config.JobSubmitter.workerThreads = 1
 config.JobSubmitter.jobsPerWorker = 100
 config.JobSubmitter.maxJobsPerPoll = 1000
+config.JobSubmitter.maxJobsToCache = 50000
 config.JobSubmitter.cacheRefreshSize = 30000  # set -1 if cache need to refresh all the time.
 config.JobSubmitter.skipRefreshCount = 20  # (If above the threshold meet, cache will updates every 20 polling cycle) 120 * 20 = 40 minutes
 config.JobSubmitter.submitScript = os.path.join(os.environ["WMCORE_ROOT"], "etc/submit.sh")

--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -77,6 +77,7 @@ class JobSubmitterPoller(BaseWorkerThread):
         self.hostName = self.config.Agent.hostName
         self.repollCount = getattr(self.config.JobSubmitter, 'repollCount', 10000)
         self.maxJobsPerPoll = int(getattr(self.config.JobSubmitter, 'maxJobsPerPoll', 1000))
+        self.maxJobsToCache = int(getattr(self.config.JobSubmitter, 'maxJobsToCache', 50000))
         self.maxJobsThisCycle = self.maxJobsPerPoll  # changes as per schedd limit
         self.cacheRefreshSize = int(getattr(self.config.JobSubmitter, 'cacheRefreshSize', 30000))
         self.skipRefreshCount = int(getattr(self.config.JobSubmitter, 'skipRefreshCount', 20))
@@ -92,7 +93,6 @@ class JobSubmitterPoller(BaseWorkerThread):
         self.jobDataCache = {}  # key'ed by the job id, containing the whole job info dict
         self.jobsToPackage = {}
         self.locationDict = {}
-        self.taskTypePrioMap = {}
         self.drainSites = set()
         self.abortSites = set()
         self.refreshPollingCount = 0
@@ -266,7 +266,7 @@ class JobSubmitterPoller(BaseWorkerThread):
 
         logging.info("Refreshing priority cache with currently %i jobs", len(self.jobDataCache))
 
-        newJobs = self.listJobsAction.execute()
+        newJobs = self.listJobsAction.execute(limitRows=self.maxJobsToCache)
         if self.useReqMgrForCompletionCheck:
             # if reqmgr is used (not Tier0 Agent) get the aborted/forceCompleted record
             abortedAndForceCompleteRequests = self.abortedAndForceCompleteWorkflowCache.getData()
@@ -349,7 +349,7 @@ class JobSubmitterPoller(BaseWorkerThread):
             batchDir = self.addJobsToPackage(loadedJob)
 
             # calculate the final job priority such that we can order cached jobs by prio
-            jobPrio = self.taskTypePrioMap.get(newJob['task_type'], 0) + newJob['wf_priority']
+            jobPrio = newJob['task_prio'] * self.maxTaskPriority + newJob['wf_priority']
             self.jobsByPrio.setdefault(jobPrio, set())
             self.jobsByPrio[jobPrio].add(jobID)
 
@@ -362,7 +362,7 @@ class JobSubmitterPoller(BaseWorkerThread):
             loadedJob['numberOfCores'] = numberOfCores
 
             # Create a job dictionary object and put it in the cache (needs to be in sync with RunJob)
-            jobInfo = {'taskPriority': None,  # update from the thresholds
+            jobInfo = {'taskPriority': newJob['task_prio'],
                        'custom': {'location': None},  # update later
                        'packageDir': batchDir,
                        'retry_count': newJob["retry_count"],
@@ -474,7 +474,6 @@ class JobSubmitterPoller(BaseWorkerThread):
         Also update the list of draining and abort/down sites.
         Finally, creates a map between task type and its priority.
         """
-        self.taskTypePrioMap = {}
         newDrainSites = set()
         newAbortSites = set()
 
@@ -488,11 +487,6 @@ class JobSubmitterPoller(BaseWorkerThread):
                 newDrainSites.add(siteName)
             if state in ["Down", "Aborted"]:
                 newAbortSites.add(siteName)
-
-            # then update the task type x task priority mapping
-            if not self.taskTypePrioMap:
-                for task, value in rcThresholds[siteName]['thresholds'].items():
-                    self.taskTypePrioMap[task] = value.get('priority', 0) * self.maxTaskPriority
 
         # When the list of drain/abort sites change between iteration then a location
         # refresh is needed, for now it forces a full cache refresh
@@ -640,7 +634,6 @@ class JobSubmitterPoller(BaseWorkerThread):
                     cachedJob = self.jobDataCache.pop(jobid)
                     cachedJob['custom'] = {'location': siteName}
                     cachedJob['possibleSites'] = possibleSites
-                    cachedJob['taskPriority'] = self.currentRcThresholds[siteName]['thresholds'][jobType]["priority"]
 
                     # Sort jobs by jobPackage and get it in place to be submitted by the plugin
                     package = cachedJob['packageDir']

--- a/src/python/WMCore/WMBS/CreateWMBSBase.py
+++ b/src/python/WMCore/WMBS/CreateWMBSBase.py
@@ -500,8 +500,8 @@ class CreateWMBSBase(DBCreator):
             jobStateQuery = "INSERT INTO wmbs_job_state (name) VALUES ('%s')" % jobState
             self.inserts["job_state_%s" % jobState] = jobStateQuery
 
-        self.subTypes = [("Processing", 0), ("Merge", 5), ("Harvesting", 3), ("Cleanup", 5),
-                         ("LogCollect", 3), ("Skim", 3), ("Production", 0)]
+        self.subTypes = [("Processing", 0), ("Merge", 4), ("Harvesting", 5), ("Cleanup", 1),
+                         ("LogCollect", 2), ("Skim", 3), ("Production", 0)]
         for pair in self.subTypes:
             subTypeQuery = """INSERT INTO wmbs_sub_types (name, priority)
                                 VALUES ('%s', %d)""" % (pair[0], pair[1])

--- a/src/python/WMCore/WMBS/MySQL/Jobs/ListForSubmitter.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/ListForSubmitter.py
@@ -13,6 +13,7 @@ class ListForSubmitter(DBFormatter):
                     wmbs_job.name AS name,
                     wmbs_job.cache_dir AS cache_dir,
                     wmbs_sub_types.name AS task_type,
+                    wmbs_sub_types.priority AS task_prio,
                     wmbs_job.retry_count AS retry_count,
                     wmbs_workflow.name AS request_name,
                     wmbs_workflow.id AS task_id,
@@ -29,9 +30,21 @@ class ListForSubmitter(DBFormatter):
                  wmbs_job.state = wmbs_job_state.id
                INNER JOIN wmbs_workflow ON
                  wmbs_subscription.workflow = wmbs_workflow.id
-             WHERE wmbs_job_state.name = 'created'"""
+             WHERE wmbs_job_state.name = 'created'
+             ORDER BY
+               wmbs_sub_types.priority DESC,
+               wmbs_workflow.priority DESC,
+               wmbs_workflow.id DESC"""
 
-    def execute(self, conn=None, transaction=False):
-        result = self.dbi.processData(self.sql, conn=conn,
+    limit_sql = " limit %d"
+
+
+    def execute(self, conn=None, transaction=False, limitRows=None):
+        if limitRows:
+            extraSql = self.limit_sql % limitRows
+        else:
+            extraSql = ""
+
+        result = self.dbi.processData(self.sql + extraSql, conn=conn,
                                       transaction=transaction)
         return self.formatDict(result)

--- a/src/python/WMCore/WMBS/Oracle/Create.py
+++ b/src/python/WMCore/WMBS/Oracle/Create.py
@@ -735,8 +735,8 @@ class Create(CreateWMBSBase):
                                (wmbs_job_state_SEQ.nextval, '%s')""" % jobState
             self.inserts["job_state_%s" % jobState] = jobStateQuery
 
-        self.subTypes = [("Processing", 0), ("Merge", 5), ("Harvesting", 3), ("Cleanup", 5),
-                         ("LogCollect", 3), ("Skim", 3), ("Production", 0)]
+        self.subTypes = [("Processing", 0), ("Merge", 4), ("Harvesting", 5), ("Cleanup", 1),
+                         ("LogCollect", 2), ("Skim", 3), ("Production", 0)]
         for pair in self.subTypes:
             subTypeQuery = """INSERT INTO wmbs_sub_types (id, name, priority)
                               VALUES (wmbs_sub_types_SEQ.nextval, '%s', %d)""" % (pair[0], pair[1])

--- a/src/python/WMCore/WMBS/Oracle/Jobs/ListForSubmitter.py
+++ b/src/python/WMCore/WMBS/Oracle/Jobs/ListForSubmitter.py
@@ -11,4 +11,32 @@ Oracle implementation of Jobs.ListForSubmitter
 from WMCore.WMBS.MySQL.Jobs.ListForSubmitter import ListForSubmitter as MySQLListForSubmitter
 
 class ListForSubmitter(MySQLListForSubmitter):
-    pass
+    sql = """SELECT * FROM
+               (SELECT wmbs_job.id AS id,
+                    wmbs_job.name AS name,
+                    wmbs_job.cache_dir AS cache_dir,
+                    wmbs_sub_types.name AS task_type,
+                    wmbs_sub_types.priority AS task_prio,
+                    wmbs_job.retry_count AS retry_count,
+                    wmbs_workflow.name AS request_name,
+                    wmbs_workflow.id AS task_id,
+                    wmbs_workflow.priority AS wf_priority,
+                    wmbs_workflow.task AS task_name
+               FROM wmbs_job
+               INNER JOIN wmbs_jobgroup ON
+                 wmbs_job.jobgroup = wmbs_jobgroup.id
+               INNER JOIN wmbs_subscription ON
+                 wmbs_jobgroup.subscription = wmbs_subscription.id
+               INNER JOIN wmbs_sub_types ON
+                 wmbs_subscription.subtype = wmbs_sub_types.id
+               INNER JOIN wmbs_job_state ON
+                 wmbs_job.state = wmbs_job_state.id
+               INNER JOIN wmbs_workflow ON
+                 wmbs_subscription.workflow = wmbs_workflow.id
+               WHERE wmbs_job_state.name = 'created'
+               ORDER BY
+                 wmbs_sub_types.priority DESC,
+                 wmbs_workflow.priority DESC,
+                 wmbs_workflow.id DESC)"""
+
+    limit_sql = " WHERE ROWNUM <= %d"


### PR DESCRIPTION
wmagent version of #8661

I'm pushing it to vocms0250 now, since it has 1M jobs to submit. I'm not changing those job types priorities in the database though.