### PR TITLE
set the dataset parentage for StepChain

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/DBSBufferBlock.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSBufferBlock.py
@@ -49,6 +49,7 @@ class DBSBufferBlock:
                           'primds':               {},   # Dict of primary dataset info
                           'dataset':              {},   # Dict of processed dataset info
                           'file_parent_list':     [],   # List of file parents
+                          'dataset_parent_list':  [],   # List of parent datasets (DBS requires this as list although it only allows one parent)
                           'close_settings':       {}}   # Dict of info about block close settings
 
         self.files        = []
@@ -151,10 +152,13 @@ class DBSBufferBlock:
         # Append to the files list
         self.data['files'].append(fileDict)
 
-        # now add file to data
-        parentLFNs = dbsFile.getParentLFNs()
-        for lfn in parentLFNs:
-            self.addFileParent(child = dbsFile['lfn'], parent = lfn)
+        # If dataset_parent_list is defined don't add the file parentage.
+        # This means it is block from StepChain workflow and parentage of file will be resloved later
+        if not self.data['dataset_parent_list']:
+            # now add file to data
+            parentLFNs = dbsFile.getParentLFNs()
+            for lfn in parentLFNs:
+                self.addFileParent(child = dbsFile['lfn'], parent = lfn)
 
 
         # Do the algo
@@ -217,8 +221,7 @@ class DBSBufferBlock:
 
         Add the parent datasets to the data block
         """
-
-        self.data['ds_parent_list'].append({'parent_dataset': parent})
+        self.data['dataset_parent_list'].append(parent)
         return
 
     def setProcessingVer(self, procVer):

--- a/src/python/WMCore/Services/WMStatsServer/WMStatsServer.py
+++ b/src/python/WMCore/Services/WMStatsServer/WMStatsServer.py
@@ -90,3 +90,24 @@ class WMStatsServer(Service):
         query = self._createQuery(inputCondition)
         callname = 'filtered_requests?%s' % query
         return self._getResult(callname, verb="GET")
+
+    def getChildParentDatasetMap(self, requestType="StepChain", parentageResolved=False):
+        """
+
+        :param requestType: specify the type of requests you want find the parentag
+        :param dataset: child dataset
+        :param includeInputDataset:
+        :return: dict of {child_dataset_name: parent_dataset_name}
+        """
+        filter = {"RequestType": requestType, "ParentageResolved": parentageResolved}
+        mask = ["ChainParentageMap"]
+
+        results = self.getFilteredActiveData(filter, mask)
+        childParentMap = {}
+        for info in results:
+            if info["ChainParentageMap"]:
+                for childParentDS in info["ChainParentageMap"]:
+                    if childParentDS["ParentDset"]:
+                        for childDS in childParentDS["ChildDsets"]:
+                            childParentMap[childDS] = childParentDS["ParentDset"]
+        return childParentMap

--- a/test/python/WMComponent_t/DBS3Buffer_t/DBSUpload_t.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/DBSUpload_t.py
@@ -110,6 +110,9 @@ class DBSUploadTest(unittest.TestCase):
         config.DBS3Upload.nProcesses = 1
         config.DBS3Upload.dbsWaitTime = 0.1
         config.DBS3Upload.datasetType = "VALID"
+
+        # added to skip the StepChain parentage setting test
+        config.component_("Tier0Feeder")
         return config
 
     def createParentFiles(self, acqEra, nFiles=10,
@@ -603,8 +606,8 @@ class DBSUploadTest(unittest.TestCase):
                 self.assertTrue('block_events' not in block['block'])
                 self.assertEqual(block['block']['open_for_writing'], 0)
                 self.assertTrue('close_settings' not in block)
-        except Exception:
-            self.fail("We failed at some point in the test")
+        except Exception as ex:
+            self.fail("We failed at some point in the test: %s" % str(ex))
         finally:
             # We don't trust anyone else with _exit
             del os.environ["DONT_TRAP_EXIT"]


### PR DESCRIPTION
fixes #8671

Just initial version. 

1. getting the StepChain parentage from wmstats server. (Since update will occur only active data, this will be more performative than getting the information from WMBS)
2. Rely on the order of dataset reported from filtered query (which will order the output dataset with the same order as Step definition - Need to be sure this is the right parentage relation, if not, we need to have the way to get precise information.)
3. Maintain the cache for parent dataset for every cycle. - May need to keep more than one cycle.
4. Handles the case if only one step in StepChain  - parentage will be set correctly by file as other request type.
5. Pass the parentage information through insertBulkBlock call. (requires DBS api updated https://github.com/dmwm/DBS/issues/566)