### PR TITLE
Allow CRIC to be used by the agent via an environment variable

### DIFF
--- a/bin/deploy-wmagent.sh
+++ b/bin/deploy-wmagent.sh
@@ -23,10 +23,11 @@
 ### Usage:               -p <patches>      List of PR numbers in double quotes and space separated (e.g., "5906 5934 5922")
 ### Usage:               -n <agent_number> Agent number to be set when more than 1 agent connected to the same team (defaults to 0)
 ### Usage:               -c <central_services> Url to central services hosting central couchdb (e.g. alancc7-cloud1.cern.ch)
+### Usage:               -X This option enables usage of the CRIC data service
 ### Usage:
 ### Usage: deploy-wmagent.sh -w <wma_version> -d <deployment_tag> -t <team_name> [-s <scram_arch>] [-r <repository>] [-n <agent_number>] [-c <central_services_url>]
 ### Usage: Example: sh deploy-wmagent.sh -w 1.1.15.patch5 -d HG1808g -t production -n 30
-### Usage: Example: sh deploy-wmagent.sh -w 1.1.15.patch5 -d HG1808g -t testbed-vocms001 -p "8788" -r comp=comp.amaltaro -c cmsweb-testbed.cern.ch
+### Usage: Example: sh deploy-wmagent.sh -w 1.1.15.patch5 -d HG1808g -t testbed-vocms001 -p "8788" -r comp=comp.amaltaro -c cmsweb-testbed.cern.ch -X
 ### Usage:
  
 BASE_DIR=/data/srv 
@@ -43,6 +44,7 @@ REPO="comp=comp"
 AG_NUM=0
 FLAVOR=mysql
 CENTRAL_SERVICES="cmsweb.cern.ch"
+USE_CRIC=false
 
 ### Usage function: print the usage of the script
 usage()
@@ -131,6 +133,7 @@ for arg; do
     -p) PATCHES=$2; shift; shift ;;
     -n) AG_NUM=$2; shift; shift ;;
     -c) CENTRAL_SERVICES=$2; shift; shift ;;
+    -X) USE_CRIC=true; shift;;
     -*) usage ;;
   esac
 done
@@ -183,7 +186,12 @@ echo " - Repository      : $REPO"
 echo " - Agent number    : $AG_NUM"
 echo " - DB Flavor       : $FLAVOR"
 echo " - Central Services: $CENTRAL_SERVICES"
-echo " - Use /data1      : $DATA1" && echo
+echo " - Use /data1      : $DATA1"
+echo " - Using CRIC      : $USE_CRIC" && echo
+
+if [ "$USE_CRIC" = true ]; then
+  export WMAGENT_USE_CRIC=true
+fi
 
 mkdir -p $DEPLOY_DIR || true
 cd $BASE_DIR

--- a/bin/wmagent-resource-control
+++ b/bin/wmagent-resource-control
@@ -14,6 +14,7 @@ from WMCore.Configuration import loadConfigurationFile
 from WMCore.ResourceControl.ResourceControl import ResourceControl
 from WMCore.Services.SiteDB.SiteDB import SiteDBJSON
 from WMCore.Services.SiteDB.SiteDBAPI import SiteDBAPI
+from WMCore.Services.CRIC.CRIC import CRIC
 from WMCore.WMInit import connectToDB
 from WMQuality.Emulators.SiteDBClient.MockSiteDBApi import mockGetJSON
 
@@ -100,16 +101,21 @@ def createOptionParser():
     return myOptParser
 
 
-def getCMSSiteInfo(pattern=''):
+def getCMSSiteInfo(pattern):
     """
     _getCMSSiteInfo_
 
     Query SiteDB for the site and SE names matching the pattern.  Return a
     dictionary keyed by site name.
     """
-    print("Querying SiteDB for site information...")
+    if os.getenv("WMAGENT_USE_CRIC", False):
+        cricObj = CRIC()
+    else:
+        cricObj = SiteDBJSON()  # this will be removed anyways
 
-    return SiteDBJSON().PSNtoPNNMap(pattern)
+    mapping = cricObj.PSNtoPNNMap(pattern)
+    print("Retrieved %i maps from %s" % (len(mapping), cricObj['endpoint']))
+    return mapping
 
 
 def addSites(resourceControl, allSites, ceName, plugin, pendingSlots, runningSlots,
@@ -148,10 +154,13 @@ def addPNNs(resourceControl, pattern):
 
     Add the given sites to resource control and add tasks as well.
     """
-    print("Querying SiteDB for PhEDEx Node Names...")
+    if os.getenv("WMAGENT_USE_CRIC", False):
+        cricObj = CRIC()
+    else:
+        cricObj = SiteDBJSON()  # this will be removed anyways
 
-    pnns = SiteDBJSON().getAllPhEDExNodeNames(pattern, excludeBuffer=True)
-    print("Inserting %i PNNs into WMBS table" % len(pnns))
+    pnns = cricObj.getAllPhEDExNodeNames(pattern, excludeBuffer=True)
+    print("Retrieved %i PNNs from %s" % (len(pnns), cricObj['endpoint']))
     resourceControl.insertPNNs(pnns)
 
     return

--- a/src/python/WMCore/Services/SiteDB/SiteDBAPI.py
+++ b/src/python/WMCore/Services/SiteDB/SiteDBAPI.py
@@ -8,6 +8,7 @@ API for retrieving information from SiteDB
 from __future__ import print_function
 from __future__ import division
 import json
+import os
 import logging
 from WMCore.Services.Service import Service
 
@@ -32,9 +33,12 @@ class SiteDBAPI(Service):
 
     def __init__(self, config={}, logger=None):
         config = dict(config)
-        config['endpoint'] = "https://cmsweb.cern.ch/sitedb/data/prod/"
-        config['logger'] = logger if logger else logging.getLogger()
-
+        if os.getenv("WMAGENT_USE_CRIC", False):
+            # just to make sure we don't use SiteDB anywhere when CRIC flag is true
+            config.setdefault('endpoint', "https://BLAH.cern.ch/sitedb/data/prod/")
+        else:
+            config.setdefault('endpoint', "https://cmsweb.cern.ch/sitedb/data/prod/")
+        config.setdefault('logger', logging.getLogger())
         Service.__init__(self, config)
 
     def getJSON(self, callname, filename='result.json', clearCache=False, verb='GET', data={}):


### PR DESCRIPTION
Fixes #8696
CRIC usage is disabled, by default.

Allow CRIC to be used by the agent by setting an environment variable. This
`export WMAGENT_USE_CRIC=true`
has to be defined in /data/admin/wmagent/env.sh

If one wants to populate the resource-control based on CRIC queries, then the `-X` deploy parameter has to be used.