### PR TITLE
Wrapper for HTCondor job submission

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -11,7 +11,7 @@ import os.path
 import re
 import threading
 import time
-
+import pickle
 import classad
 import htcondor
 
@@ -23,7 +23,7 @@ from WMCore.DAOFactory import DAOFactory
 from WMCore.FwkJobReport.Report import Report
 from WMCore.WMInit import getWMBASE
 from WMCore.Lexicon import getIterMatchObjectOnRegexp, WMEXCEPTION_REGEXP, CONDOR_LOG_FILTER_REGEXP
-
+from WMCore.Services.PyCondor.PyCondorUtils import AuthenticatedSubprocess
 
 class SimpleCondorPlugin(BasePlugin):
     """
@@ -128,8 +128,7 @@ class SimpleCondorPlugin(BasePlugin):
         """
         _submit_
 
-
-        Submit jobs for one subscription
+        Submits jobs to the condor queue
         """
         successfulJobs = []
         failedJobs = []
@@ -148,11 +147,27 @@ class SimpleCondorPlugin(BasePlugin):
 
             logging.debug("Start: Submitting %d jobs using Condor Python SubmitMany", len(procAds))
             try:
-                clusterId = schedd.submitMany(clusterAd, procAds)
-            except Exception as ex:
+                condorIdDict = {}
+                ### HTCondor submitMany is leaking memory (as of 8.6.11 and 8.7.7), so let's wrap
+                # the submitMany call in this context manager such that memory stays under control
+                # I see no need for it though once HTCondor gets fixed...
+                with AuthenticatedSubprocess(pickleOut=True, outputObj=condorIdDict) as (parent, rpipe):
+                    if not parent:
+                        # getting this clusterId out of the context manager in an obscured way
+                        condorIdDict['clusterId'] = schedd.submitMany(clusterAd, procAds)
+                # clusterId = schedd.submitMany(clusterAd, procAds)
+                results = pickle.load(rpipe)
+                if results.outputMessage != "OK":
+                    raise Exception(results.outputMessage)
+                clusterId = results.outputObj["clusterId"]
+            except EOFError:
+                raise RuntimeError("Timeout executing condor submit command.")
+            except (EOFError, Exception) as ex:
                 logging.error("SimpleCondorPlugin job submission failed.")
-                logging.error("Moving on the the next batch of jobs and/or cycle....")
+                if ex.__class__ == EOFError:
+                    logging.error("Timeout executing condor submit command.")
                 logging.exception(ex)
+                logging.error("Moving on the the next batch of jobs and/or cycle....")
 
                 condorErrorReport = Report()
                 condorErrorReport.addError("JobSubmit", 61202, "CondorError", str(ex))
@@ -160,7 +175,7 @@ class SimpleCondorPlugin(BasePlugin):
                     job['fwjr'] = condorErrorReport
                     failedJobs.append(job)
             else:
-                logging.debug("Finish: Submitting jobs using Condor Python SubmitMany")
+                print("Job submission to condor suceeded, clusterId is %s" % clusterId)
                 for index, job in enumerate(jobsReady):
                     job['gridid'] = "%s.%s" % (clusterId, index)
                     job['status'] = 'Idle'

--- a/src/python/WMCore/Services/PyCondor/PyCondorUtils.py
+++ b/src/python/WMCore/Services/PyCondor/PyCondorUtils.py
@@ -1,0 +1,101 @@
+from __future__ import print_function
+
+import logging
+import os
+import pickle
+import signal
+import time
+import traceback
+
+import htcondor
+
+
+class OutputObj(object):
+    """
+    Class used when AuthenticatedSubprocess is created with pickleOut
+    It stores the output message of the subprocess, any output object provided
+    and extra information for debugging purposes, such as the environment
+    """
+
+    def __init__(self, outputMessage, outputObj):
+        self.outputMessage = outputMessage
+        self.outputObj = outputObj
+        self.environmentStr = ""
+        for key, val in os.environ.iteritems():
+            self.environmentStr += "%s=%s\n" % (key, val)
+
+
+class AuthenticatedSubprocess(object):
+    """
+    Context manager for execution of condor commands in a forked, especially useful for
+    those commands where a different proxy credential is needed.
+    """
+
+    def __init__(self, proxy=None, pickleOut=False, outputObj=None, logger=logging):
+        """
+        Basic setup of the context manager
+        :param proxy: optional path to the proxy file
+        :param pickleOut: boolean flag which enables pickled output data
+        :param outputObj: structure storing the actual output of the htcondor call
+        :param logger: logger object
+        """
+        self.proxy = proxy
+        self.pickleOut = pickleOut
+        self.outputObj = outputObj
+        self.timedout = False
+        self.logger = logger
+
+    def __enter__(self):
+        self.r, self.w = os.pipe()
+        self.rpipe = os.fdopen(self.r, 'r')
+        self.wpipe = os.fdopen(self.w, 'w')
+        self.pid = os.fork()
+        if self.pid == 0 and self.proxy:
+            # CRAB case
+            htcondor.SecMan().invalidateAllSessions()
+            htcondor.param['SEC_CLIENT_AUTHENTICATION_METHODS'] = 'FS,GSI'
+            htcondor.param['DELEGATE_FULL_JOB_GSI_CREDENTIALS'] = 'true'
+            htcondor.param['DELEGATE_JOB_GSI_CREDENTIALS_LIFETIME'] = '0'
+            os.environ['X509_USER_PROXY'] = self.proxy
+            self.rpipe.close()
+        elif self.pid == 0:
+            self.rpipe.close()
+        else:
+            self.wpipe.close()
+        return self.pid, self.rpipe
+
+    def __exit__(self, a, b, c):
+        if self.pid == 0:
+            if a is None and b is None and c is None:
+                if self.pickleOut:
+                    oo = OutputObj("OK", self.outputObj)
+                    self.wpipe.write(pickle.dumps(oo))
+                else:
+                    self.wpipe.write("OK")
+                self.wpipe.close()
+                os._exit(0)
+            else:
+                tracebackString = str('\n'.join(traceback.format_tb(c)))
+                msg = "Trapped exception in AuthenticatedSubprocess.Fork: %s %s %s \n%s" % \
+                      (a, b, c, tracebackString)
+                if self.pickleOut:
+                    oo = OutputObj(msg, self.outputObj)
+                    self.wpipe.write(pickle.dumps(oo))
+                else:
+                    self.wpipe.write(msg)
+                self.wpipe.close()
+                os._exit(1)
+        else:
+            timestart = time.time()
+            self.timedout = True
+            while (time.time() - timestart) < 3600:
+                res = os.waitpid(self.pid, os.WNOHANG)
+                if res != (0, 0):
+                    self.timedout = False
+                    break
+                time.sleep(0.100)
+            if self.timedout:
+                self.logger.warning(
+                    "Subprocess with PID %s (executed in AuthenticatedSubprocess) timed out. Killing it." % self.pid)
+                os.kill(self.pid, signal.SIGTERM)
+                # we should probably wait again and send SIGKILL if the kill does not work


### PR DESCRIPTION
Fixes #8493 (until the real issue gets fixed in HTCondor, developers are already aware)

As pointed out by @bbockelm and @belforte , CRAB has to do condor submissions with a different user proxy, so they implemented this context manager class which manages proxy/environment and encapsulates the final condor submission/command in a forked process. It turns out it properly manages the memory footprint, which remains stables between different bulk submissions (tested in an ad-hoc script, around 40MB for 1k jobs submitted).

@bbockelm @belforte I'd welcome your review too. I made only minor changes to the wrapper class such that it works for CRAB and WMAgent, hopefully :)