### PR TITLE
Remove duplicate cherrypy logs in the central services

### DIFF
--- a/src/python/WMCore/REST/Main.py
+++ b/src/python/WMCore/REST/Main.py
@@ -8,18 +8,28 @@ up an appropriately configured CherryPy instance. Views are loaded dynamically
 and can be turned on/off via configuration file."""
 from __future__ import print_function
 
-import sys, os, errno, re, os.path, subprocess, socket, time
-import cherrypy, logging, thread, traceback
-import WMCore.REST.Tools
-from WMCore.Configuration import ConfigSection, loadConfigurationFile
+import errno
+import logging
+import os
+import os.path
+import re
+import signal
+import socket
+import sys
+import thread
+import time
+import traceback
 from cStringIO import StringIO
-from optparse import OptionParser
-from cherrypy import Application
-from cherrypy.lib import profiler
-from cherrypy._cplogging import LogManager
-from subprocess import Popen, PIPE
 from glob import glob
-from signal import *
+from optparse import OptionParser
+from subprocess import Popen, PIPE
+
+import cherrypy
+from cherrypy import Application
+from cherrypy._cplogging import LogManager
+from cherrypy.lib import profiler
+
+from WMCore.Configuration import ConfigSection, loadConfigurationFile
 
 #: Terminal controls to switch to "OK" status message colour.
 COLOR_OK = "\033[0;32m"
@@ -29,6 +39,7 @@ COLOR_WARN = "\033[0;31m"
 
 #: Terminal controls to restore normal message colour.
 COLOR_NORMAL = "\033[0;39m"
+
 
 def sig_terminate(signum=None, frame=None):
     """Termination signal handler.
@@ -41,12 +52,14 @@ def sig_terminate(signum=None, frame=None):
     cherrypy.log("INFO: exiting server from termination signal %d" % signum, severity=logging.INFO)
     cherrypy.engine.exit()
 
+
 def sig_reload(signum=None, frame=None):
     """SIGHUP handler to restart the server.
 
     This just adds some logging compared to the CherryPy signal handler."""
     cherrypy.log("INFO: restarting server from hang-up signal %d" % signum, severity=logging.INFO)
     cherrypy.engine.restart()
+
 
 def sig_graceful(signum=None, frame=None):
     """SIGUSR1 handler to restart the server gracefully.
@@ -55,19 +68,25 @@ def sig_graceful(signum=None, frame=None):
     cherrypy.log("INFO: restarting server gracefully from signal %d" % signum, severity=logging.INFO)
     cherrypy.engine.graceful()
 
+
 class ProfiledApp(Application):
     """Wrapper CherryPy Application object which generates aggregated
     profiles for the component on each call. Note that there needs to
     be an instance of this for each mount point to be profiled."""
+
     def __init__(self, app, path):
         Application.__init__(self, app.root, app.script_name, app.config)
         self.profiler = profiler.ProfileAggregator(path)
+
     def __call__(self, env, handler):
         def gather(): return Application.__call__(self, env, handler)
+
         return self.profiler.run(gather)
+
 
 class Logger(LogManager):
     """Custom logger to record information in format we prefer."""
+
     def __init__(self, *args, **kwargs):
         self.host = socket.gethostname()
         LogManager.__init__(self, *args, **kwargs)
@@ -82,33 +101,34 @@ class Logger(LogManager):
         wfile = request.wsgi_environ.get('cherrypy.wfile', None)
         nout = (wfile and wfile.bytes_written) or outheaders.get('Content-Length', 0)
         if hasattr(request, 'start_time'):
-            delta_time = (time.time() - request.start_time)*1e6
+            delta_time = (time.time() - request.start_time) * 1e6
         else:
             delta_time = 0
         msg = ('%(t)s %(H)s %(h)s "%(r)s" %(s)s'
                ' [data: %(i)s in %(b)s out %(T).0f us ]'
                ' [auth: %(AS)s "%(AU)s" "%(AC)s" ]'
-               ' [ref: "%(f)s" "%(a)s" ]') %\
-              { 't': self.time(),
-                'H': self.host,
-                'h': remote.name or remote.ip,
-                'r': request.request_line,
-                's': response.status,
-                # request.rfile.rfile.bytes_read is a custom CMS web
-                #  cherrypy patch not always available, hence the test
-                'i': (getattr(request.rfile, 'rfile', None)
-                      and getattr(request.rfile.rfile, "bytes_read", None)
-                      and request.rfile.rfile.bytes_read) or "-",
-                'b': nout or "-",
-                'T': delta_time,
-                'AS': inheaders.get("CMS-Auth-Status", "-"),
-                'AU': inheaders.get("CMS-Auth-Cert", inheaders.get("CMS-Auth-Host", "")),
-                'AC': getattr(request.cookie.get("cms-auth", None), "value", ""),
-                'f': inheaders.get("Referer", ""),
-                'a': inheaders.get("User-Agent", "") }
+               ' [ref: "%(f)s" "%(a)s" ]') % \
+              {'t': self.time(),
+               'H': self.host,
+               'h': remote.name or remote.ip,
+               'r': request.request_line,
+               's': response.status,
+               # request.rfile.rfile.bytes_read is a custom CMS web
+               #  cherrypy patch not always available, hence the test
+               'i': (getattr(request.rfile, 'rfile', None)
+                     and getattr(request.rfile.rfile, "bytes_read", None)
+                     and request.rfile.rfile.bytes_read) or "-",
+               'b': nout or "-",
+               'T': delta_time,
+               'AS': inheaders.get("CMS-Auth-Status", "-"),
+               'AU': inheaders.get("CMS-Auth-Cert", inheaders.get("CMS-Auth-Host", "")),
+               'AC': getattr(request.cookie.get("cms-auth", None), "value", ""),
+               'f': inheaders.get("Referer", ""),
+               'a': inheaders.get("User-Agent", "")}
+        self.access_log.log(logging.INFO, msg)
 
 
-class RESTMain:
+class RESTMain(object):
     """Base class for the core CherryPy main application object.
 
     The :class:`~.RESTMain` implements basic functionality of a CherryPy-based
@@ -122,6 +142,7 @@ class RESTMain:
     The main application object takes the server configuration and state
     directory as parametres. It provides methods to create full CherryPy
     serer and configure the application based on configuration description."""
+
     def __init__(self, config, statedir):
         """Prepare the server.
 
@@ -183,7 +204,7 @@ class RESTMain:
         cpconfig.update({'engine.autoreload.on': False})
         cpconfig.update({'request.show_tracebacks': False})
         cpconfig.update({'request.methods_with_bodies': ("POST", "PUT", "DELETE")})
-        thread.stack_size(getattr(self.srvconfig, 'thread_stack_size', 128*1024))
+        thread.stack_size(getattr(self.srvconfig, 'thread_stack_size', 128 * 1024))
         sys.setcheckinterval(getattr(self.srvconfig, 'sys_check_interval', 10000))
         self.silent = getattr(self.srvconfig, 'silent', False)
 
@@ -249,6 +270,7 @@ class RESTMain:
             cherrypy.tree.mount(app)
             self.views[name] = obj
 
+
 class RESTDaemon(RESTMain):
     """Web server object.
 
@@ -264,6 +286,7 @@ class RESTDaemon(RESTMain):
     The daemon takes the server configuration as a parametre. When the
     server is started, it creates a CherryPy server and configuration
     from the application config contents."""
+
     def __init__(self, config, statedir):
         """Initialise the daemon.
 
@@ -293,7 +316,7 @@ class RESTDaemon(RESTMain):
         except:
             return (False, pid)
 
-    def kill_daemon(self, silent = False):
+    def kill_daemon(self, silent=False):
         """Check if the daemon is running, and if so kill it.
 
         If there is no daemon running and no pid file, does nothing. If there
@@ -324,9 +347,9 @@ class RESTDaemon(RESTMain):
                 sys.stdout.flush()
 
             dead = False
-            for sig, grace in ((SIGINT, .5), (SIGINT, 1),
-                               (SIGINT, 3), (SIGINT, 5),
-                               (SIGKILL, 0)):
+            for sig, grace in ((signal.SIGINT, .5), (signal.SIGINT, 1),
+                               (signal.SIGINT, 3), (signal.SIGINT, 5),
+                               (signal.SIGKILL, 0)):
                 try:
                     if not silent:
                         sys.stdout.write(".")
@@ -341,8 +364,10 @@ class RESTDaemon(RESTMain):
                     raise
 
             if not dead:
-                try: os.killpg(pid, SIGKILL)
-                except: pass
+                try:
+                    os.killpg(pid, signal.SIGKILL)
+                except:
+                    pass
 
             if not silent:
                 sys.stdout.write("\n")
@@ -395,8 +420,10 @@ class RESTDaemon(RESTMain):
                 cherrypy.log("ERROR:   %s" % line)
 
         # Remove pid file once we are done.
-        try: os.remove(self.pidfile)
-        except: pass
+        try:
+            os.remove(self.pidfile)
+        except:
+            pass
 
         # Exit
         sys.exit((error and 1) or 0)
@@ -411,9 +438,9 @@ class RESTDaemon(RESTMain):
         while True:
             serverpid = os.fork()
             if not serverpid: break
-            signal(SIGINT, SIG_IGN)
-            signal(SIGTERM, SIG_IGN)
-            signal(SIGQUIT, SIG_IGN)
+            signal.signal(signal.SIGINT, signal.SIG_IGN)
+            signal.signal(signal.SIGTERM, signal.SIG_IGN)
+            signal.signal(signal.SIGQUIT, signal.SIG_IGN)
             (xpid, exitrc) = os.waitpid(serverpid, 0)
             (exitcode, exitsigno, exitcore) = (exitrc >> 8, exitrc & 127, exitrc & 128)
             retval = (exitsigno and ("signal %d" % exitsigno)) or str(exitcode)
@@ -430,8 +457,10 @@ class RESTDaemon(RESTMain):
                     pid = int(open(pidfile).readline())
                     os.remove(pidfile)
                     cherrypy.log("WATCHDOG: killing slave server %d" % pid)
-                    try: os.kill(pid, 9)
-                    except: pass
+                    try:
+                        os.kill(pid, 9)
+                    except:
+                        pass
 
         # Run. Override signal handlers after CherryPy has itself started and
         # installed its own handlers. To achieve this we need to start the
@@ -442,12 +471,13 @@ class RESTDaemon(RESTMain):
         cherrypy.log("INFO: starting server in %s" % self.statedir)
         cherrypy.config.update({'log.screen': bool(getattr(self.srvconfig, "log_screen", False))})
         cherrypy.engine.start()
-        signal(SIGHUP, sig_reload)
-        signal(SIGUSR1, sig_graceful)
-        signal(SIGTERM, sig_terminate)
-        signal(SIGQUIT, sig_terminate)
-        signal(SIGINT, sig_terminate)
+        signal.signal(signal.SIGHUP, sig_reload)
+        signal.signal(signal.SIGUSR1, sig_graceful)
+        signal.signal(signal.SIGTERM, sig_terminate)
+        signal.signal(signal.SIGQUIT, sig_terminate)
+        signal.signal(signal.SIGINT, sig_terminate)
         cherrypy.engine.block()
+
 
 def main():
     # Re-exec if we don't have unbuffered i/o. This is essential to get server
@@ -458,7 +488,7 @@ def main():
         os.environ['PYTHONUNBUFFERED'] = "1"
         os.execvp("python", ["python"] + sys.argv)
 
-    opt = OptionParser(usage = __doc__)
+    opt = OptionParser(usage=__doc__)
     opt.add_option("-q", "--quiet", action="store_true", dest="quiet", default=False,
                    help="be quiet, don't print unnecessary output")
     opt.add_option("-v", "--verify", action="store_true", dest="verify", default=False,
@@ -484,8 +514,8 @@ def main():
         sys.exit(1)
 
     if not opts.statedir or \
-       not os.path.isdir(opts.statedir) or \
-       not os.access(opts.statedir, os.W_OK):
+            not os.path.isdir(opts.statedir) or \
+            not os.access(opts.statedir, os.W_OK):
         print("%s: %s: invalid state directory" % (sys.argv[0], opts.statedir), file=sys.stderr)
         sys.exit(1)
 
@@ -504,23 +534,23 @@ def main():
         if running:
             if not opts.quiet:
                 print("%s is %sRUNNING%s, PID %d" \
-                  % (app, COLOR_OK, COLOR_NORMAL, pid))
+                      % (app, COLOR_OK, COLOR_NORMAL, pid))
             sys.exit(0)
         elif pid != None:
             if not opts.quiet:
                 print("%s is %sNOT RUNNING%s, stale PID %d" \
-                  % (app, COLOR_WARN, COLOR_NORMAL, pid))
+                      % (app, COLOR_WARN, COLOR_NORMAL, pid))
             sys.exit(2)
         else:
             if not opts.quiet:
                 print("%s is %sNOT RUNNING%s" \
-                  % (app, COLOR_WARN, COLOR_NORMAL))
+                      % (app, COLOR_WARN, COLOR_NORMAL))
             sys.exit(1)
 
     elif opts.kill:
         # Stop any previously running daemon. If quiet squelch messages,
         # except removal of stale pid file cannot be silenced.
-        server.kill_daemon(silent = opts.quiet)
+        server.kill_daemon(silent=opts.quiet)
 
     else:
         # We are handling a server start, in one of many possible ways:
@@ -538,7 +568,7 @@ def main():
         # daemons is not supported because pid file would be overwritten
         # and we'd lose track of the previous daemon.
         if opts.restart:
-            server.kill_daemon(silent = opts.quiet)
+            server.kill_daemon(silent=opts.quiet)
         else:
             running, pid = server.daemon_pid()
             if running:

--- a/src/python/WMCore/ReqMgr/Service/Request.py
+++ b/src/python/WMCore/ReqMgr/Service/Request.py
@@ -70,6 +70,8 @@ class Request(RESTEntity):
             request_args = json.loads(data)
         else:
             request_args = {}
+        cherrypy.log('Updating request "%s" with these user-provided args: %s' % (requestName, request_args))
+
         # In case key args are also passed and request body also exists.
         # If the request.body is dictionally update the key args value as well
         if isinstance(request_args, dict):
@@ -387,6 +389,7 @@ class Request(RESTEntity):
             report = self.reqmgr_db_service.updateRequestProperty(workload.name(), request_args, dn)
             workload.setPriority(request_args['RequestPriority'])
             workload.saveCouchUrl(workload.specUrl())
+            cherrypy.log('Updating priority for request "%s" to %s' % (workload.name(), request_args['RequestPriority']))
         elif workqueue_stat_validation(request_args):
             report = self.reqmgr_db_service.updateRequestStats(workload.name(), request_args)
         else:
@@ -411,7 +414,7 @@ class Request(RESTEntity):
             request_args['HardTimeout'] = request_args['SoftTimeout'] + request_args['GracePeriod']
 
         # Only allow extra value update for assigned status
-        cherrypy.log("INFO: Assign request %s, input args: %s ..." % (workload.name(), request_args))
+        cherrypy.log("Assign request %s, input args: %s ..." % (workload.name(), request_args))
         try:
             workload.updateArguments(request_args)
         except Exception as ex:
@@ -449,6 +452,7 @@ class Request(RESTEntity):
             for req_name in cascade_list:
                 self.reqmgr_db_service.updateRequestStatus(req_name, req_status, dn)
 
+        cherrypy.log('Updating request status for request "%s" to %s. Cascade mode: %s' % (workload.name(), req_status, cascade))
         # then update original workflow status in couchdb
         report = self.reqmgr_db_service.updateRequestStatus(workload.name(), req_status, dn)
         return report
@@ -547,7 +551,7 @@ class Request(RESTEntity):
         for workload, request_args in workload_pair_list:
             self._update_additional_request_args(workload, request_args)
 
-            cherrypy.log("INFO: Create request, input args: %s ..." % request_args)
+            cherrypy.log("Create request, input args: %s ..." % request_args)
             workload.saveCouch(request_args["CouchURL"], request_args["CouchWorkloadDBName"],
                                metadata=request_args)
             out.append({'request': workload.name()})


### PR DESCRIPTION
Fixes #8111 and #8644

The actual change to stop the duplicate log records was just with the `log.screen=False` line, which disables writing log records to stdout. This way we keep only the cherrypy access and error logs (with a format that ain't great, but I couldn't fix it yet). Notice that everything that is not an HTTP request (access) is logged with the error log manager, see documentation in:
https://tools.ietf.org/doc/python-cherrypy3/api/cherrypy._cplogging-module.html

Second change was to make ReqMgr2 slightly more verbose, recording original user parameters, priority and status transitions.
Seangchan, as we discussed, logging for priority change of requests not assigned yet are ugly, since the web UI posts to ReqMgr server the whole dictionary built for the client's browser.