### PR TITLE
import division on new module to silent py3 tests

### DIFF
--- a/src/python/WMCore/Services/PyCondor/PyCondorUtils.py
+++ b/src/python/WMCore/Services/PyCondor/PyCondorUtils.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, division
 
 import logging
 import os


### PR DESCRIPTION
just to make it python3 compatible, according to jenkins