### PR TITLE
Use port 8443 to communicate with cmsweb services

### DIFF
--- a/src/python/WMCore/Services/Service.py
+++ b/src/python/WMCore/Services/Service.py
@@ -103,6 +103,10 @@ class Service(dict):
         if not cfg_dict['endpoint'].endswith('/'):
             cfg_dict['endpoint'] = cfg_dict['endpoint'].strip() + '/'
 
+        # setup port 8443 for cmsweb services
+        if cfg_dict['endpoint'].startswith("https://cmsweb"):
+            cfg_dict['endpoint'] = cfg_dict['endpoint'].replace('.cern.ch/', '.cern.ch:8443/', 1)
+
         #set up defaults
         self.setdefault("inputdata", {})
         self.setdefault("cacheduration", 0.5)


### PR DESCRIPTION
Fixes #8565
Replaces #8704 

Instead of changing every single place that defines a cmsweb endpoint, we can simply change it in this base class and make sure the other Services modules inherit from it (there seems to be a few that don't).