### PR TITLE
[PY3] Replace StringIO by the python3 compatible io module

### DIFF
--- a/src/python/PSetTweaks/PSetTweak.py
+++ b/src/python/PSetTweaks/PSetTweak.py
@@ -7,13 +7,13 @@ independent python structure
 
 """
 
-import StringIO
 import imp
 import inspect
 import json
 import pickle
 import sys
 from functools import reduce
+from io import BytesIO
 
 
 class PSetHolder(object):
@@ -394,7 +394,7 @@ class PSetTweak:
 
 
             jsoniser = JSONiser()
-            jsoniser.dejson(json.load(StringIO.StringIO(jsonContent)))
+            jsoniser.dejson(json.load(BytesIO(jsonContent)))
 
             for param, value in jsoniser.parameters.items():
                 self.addParameter(param , value)

--- a/src/python/WMCore/REST/Main.py
+++ b/src/python/WMCore/REST/Main.py
@@ -20,7 +20,7 @@ import thread
 import time
 import traceback
 from argparse import ArgumentParser
-from cStringIO import StringIO
+from io import StringIO
 from glob import glob
 from subprocess import Popen, PIPE
 from pprint import pformat

--- a/src/python/WMCore/Services/McM/McM.py
+++ b/src/python/WMCore/Services/McM/McM.py
@@ -10,8 +10,7 @@ import os
 import pycurl
 import subprocess
 
-from StringIO import StringIO
-
+from io import BytesIO
 
 from WMCore.WMException import WMException
 
@@ -63,7 +62,7 @@ class McM(object):
         """
 
         try:
-            b = StringIO()
+            b = BytesIO()
             c = pycurl.Curl()
 
             fullUrl = '%s/%s' % (self.url, extendURL)

--- a/src/python/WMCore/Services/Requests.py
+++ b/src/python/WMCore/Services/Requests.py
@@ -11,7 +11,6 @@ The response from the remote server is cached if expires/etags are set.
 from __future__ import division, print_function
 
 import base64
-import cStringIO as StringIO
 import logging
 import os
 import shutil
@@ -32,6 +31,7 @@ try:
 except ImportError:
     # PY3
     from urllib.parse import urlparse
+from io import BytesIO
 from httplib import HTTPException
 from json import JSONEncoder, JSONDecoder
 
@@ -475,8 +475,8 @@ class Requests(dict):
         fullParams = [(fieldName, (c.FORM_FILE, fileName))]
         fullParams.extend(params)
         c.setopt(c.HTTPPOST, fullParams)
-        bbuf = StringIO.StringIO()
-        hbuf = StringIO.StringIO()
+        bbuf = BytesIO()
+        hbuf = BytesIO()
         c.setopt(pycurl.WRITEFUNCTION, bbuf.write)
         c.setopt(pycurl.HEADERFUNCTION, hbuf.write)
         if capath:
@@ -513,7 +513,7 @@ class Requests(dict):
         capath = self.getCAPath()
         import pycurl
 
-        hbuf = StringIO.StringIO()
+        hbuf = BytesIO()
 
         with open(fileName, "wb") as fp:
             curl = pycurl.Curl()

--- a/src/python/WMCore/Services/Service.py
+++ b/src/python/WMCore/Services/Service.py
@@ -53,7 +53,7 @@ import json
 import logging
 import os
 import time
-from cStringIO import StringIO
+from io import BytesIO
 from httplib import HTTPException
 
 from WMCore.Services.Requests import Requests, JSONRequests
@@ -177,7 +177,7 @@ class Service(dict):
         """
         # if not caching to disk return StringIO object
         if not self['cachepath'] or not cachefile:
-            return StringIO()
+            return BytesIO()
 
         inputdata = inputdata or {}
         if inputdata:

--- a/src/python/WMCore/Services/TagCollector/XMLUtils.py
+++ b/src/python/WMCore/Services/TagCollector/XMLUtils.py
@@ -9,7 +9,7 @@ Description: Set of utilities for RequestManager code
 
 from __future__ import (division, print_function)
 
-import cStringIO as StringIO
+from io import BytesIO
 import re
 import xml.etree.cElementTree as ET
 
@@ -39,7 +39,7 @@ def adjust_value(value):
 def xml_parser(data, prim_key):
     "Generic XML parser"
     if isinstance(data, basestring):
-        stream = StringIO.StringIO()
+        stream = BytesIO()
         stream.write(data)
         stream.seek(0)
     else:

--- a/src/python/WMCore/Services/pycurl_manager.py
+++ b/src/python/WMCore/Services/pycurl_manager.py
@@ -38,7 +38,8 @@ for row in data:
 """
 from __future__ import print_function
 
-import cStringIO as StringIO
+
+# system modules
 import httplib
 import json
 import logging
@@ -46,19 +47,13 @@ import os
 import re
 import subprocess
 import sys
-
+import pycurl
+from io import BytesIO
 try:
     from urllib import urlencode
 except ImportError:
     # PY3
     from urllib.parse import urlencode
-
-# python3
-if sys.version.startswith('3.'):
-    import io
-
-# 3d-party libraries
-import pycurl
 
 
 class ResponseHeader(object):
@@ -198,9 +193,9 @@ class RequestHandler(object):
         curl.setopt(pycurl.URL, str(url))
         if headers:
             curl.setopt(pycurl.HTTPHEADER, \
-                        ["%s: %s" % (k, v) for k, v in headers.items()])
-        bbuf = StringIO.StringIO()
-        hbuf = StringIO.StringIO()
+                    ["%s: %s" % (k, v) for k, v in headers.items()])
+        bbuf = BytesIO()
+        hbuf = BytesIO()
         curl.setopt(pycurl.WRITEFUNCTION, bbuf.write)
         curl.setopt(pycurl.HEADERFUNCTION, hbuf.write)
         if capath:
@@ -417,12 +412,8 @@ def getdata(urls, ckey, cert, headers=None, options=None, num_conn=100, cookie=N
             if cookie and url in cookie:
                 curl.setopt(pycurl.COOKIEFILE, cookie[url])
                 curl.setopt(pycurl.COOKIEJAR, cookie[url])
-            if sys.version.startswith('3.'):
-                bbuf = io.BytesIO()
-                hbuf = io.BytesIO()
-            else:
-                bbuf = StringIO.StringIO()
-                hbuf = StringIO.StringIO()
+            bbuf = BytesIO()
+            hbuf = BytesIO()
             curl.setopt(pycurl.WRITEFUNCTION, bbuf.write)
             curl.setopt(pycurl.HEADERFUNCTION, hbuf.write)
             mcurl.add_handle(curl)

--- a/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
@@ -11,7 +11,7 @@ import logging
 import os
 import sys
 import urllib2
-from cStringIO import StringIO
+from io import BytesIO
 from functools import reduce
 from gzip import GzipFile
 from hashlib import md5
@@ -255,6 +255,6 @@ class DQMUpload(Executor):
 
         data = result.read()
         if result.headers.get('Content-encoding', '') == 'gzip':
-            data = GzipFile(fileobj=StringIO(data)).read()
+            data = GzipFile(fileobj=BytesIO(data)).read()
 
         return (result.headers, data)

--- a/test/python/WMCore_t/Services_t/Service_t.py
+++ b/test/python/WMCore_t/Services_t/Service_t.py
@@ -1,6 +1,6 @@
 """
 """
-import StringIO
+from io import BytesIO
 import logging
 import logging.config
 import os
@@ -104,7 +104,7 @@ class ServiceTest(unittest.TestCase):
         f.close()
         self.assertTrue(isfile(f))
 
-        strio = StringIO.StringIO()
+        strio = BytesIO()
         self.assertTrue(isfile(strio))
         strio.close()
         self.assertTrue(isfile(strio))


### PR DESCRIPTION
Superseeds #7112 (before we forget it)

Given that Adelina had a few modules directly importing `io`, I went ahead and simply imported it instead of trying to import the one available in python2.7.