### PR TITLE
Fix for ACDCs when updating the task parentage map

### DIFF
--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -276,6 +276,10 @@ class WMWorkloadHelper(PersistencyHelper):
                 continue
 
             taskO = self.getTaskByName(tName)
+            if taskO is None:
+                # Resubmission requests might not have certain tasks
+                continue
+
             for outInfo in taskO.listOutputDatasetsAndModules():
                 oldOutputDset = taskMap[tName]['OutputDatasetMap'][outInfo['outputModule']]
                 taskMap[tName]['OutputDatasetMap'][outInfo['outputModule']] = outInfo['outputDataset']


### PR DESCRIPTION
Fixes #8741

@ticoann I'm not sure whether we should also update that workload property (remove the task map if the task is no longer in the workload) or we just skip it and move on?

I think we also need to create a new branch off 1.1.15.pre6, backport this fix and cut a pre7 **only** with pre6 + this patch. What do you think? Should I go ahead and do so?