### PR TITLE
Create bl_status states only in JobSubmitter component 

### DIFF
--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -72,7 +72,7 @@ class JobSubmitterPoller(BaseWorkerThread):
         # Libraries
         self.resourceControl = ResourceControl()
         self.changeState = ChangeState(self.config)
-        self.bossAir = BossAirAPI(config=self.config)
+        self.bossAir = BossAirAPI(config=self.config, insertStates=True)
 
         self.hostName = self.config.Agent.hostName
         self.repollCount = getattr(self.config.JobSubmitter, 'repollCount', 10000)

--- a/src/python/WMCore/BossAir/BossAirAPI.py
+++ b/src/python/WMCore/BossAir/BossAirAPI.py
@@ -44,7 +44,7 @@ class BossAirAPI(WMConnectionBase):
     The API layer for the BossAir prototype
     """
 
-    def __init__(self, config, noSetup=False):
+    def __init__(self, config, insertStates=False):
         """
         __init__
 
@@ -91,11 +91,11 @@ class BossAirAPI(WMConnectionBase):
         self.monitorDAO = self.daoFactory(classname="JobStatusForMonitoring")
 
         self.states = None
-        self.loadPlugin(noSetup)
+        self.loadPlugin(insertStates)
 
         return
 
-    def loadPlugin(self, noSetup=False):
+    def loadPlugin(self, insertStates):
         """
         _loadPlugin_
 
@@ -113,7 +113,7 @@ class BossAirAPI(WMConnectionBase):
         if self.newState not in states:
             states.add(self.newState)
 
-        if not noSetup:
+        if insertStates:
             # Add states only if we're not
             # doing a secondary instantiation
             self.addStates(states=states)
@@ -126,7 +126,8 @@ class BossAirAPI(WMConnectionBase):
         """
         _addStates_
 
-        Add States to bl_status table
+        Add States to bl_status table. Meant to be done only
+        once in an agent lifetime.
         """
         existingTransaction = self.beginTransaction()
 

--- a/src/python/WMCore/ResourceControl/ResourceControl.py
+++ b/src/python/WMCore/ResourceControl/ResourceControl.py
@@ -73,7 +73,7 @@ class ResourceControl(WMConnectionBase):
         jobInfo = executingJobs.execute(state='executing')
 
         if jobInfo:
-            bossAir = BossAirAPI(self.config, noSetup=True)
+            bossAir = BossAirAPI(self.config)
             jobtokill = bossAir.updateSiteInformation(jobInfo, siteName, state in state2ExitCode)
 
             ercode = state2ExitCode.get(state, 71300)

--- a/src/python/WMCore/WorkQueue/WMBSHelper.py
+++ b/src/python/WMCore/WorkQueue/WMBSHelper.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 
 from WMComponent.DBS3Buffer.DBSBufferDataset import DBSBufferDataset
 from WMComponent.DBS3Buffer.DBSBufferFile import DBSBufferFile
-from WMCore.BossAir.BossAirAPI import (BossAirAPI, BossAirException)
+from WMCore.BossAir.BossAirAPI import BossAirAPI, BossAirException
 from WMCore.DAOFactory import DAOFactory
 from WMCore.DataStructs.File import File as DatastructFile
 from WMCore.DataStructs.LumiList import LumiList
@@ -78,7 +78,7 @@ def killWorkflow(workflowName, jobCouchConfig, bossAirConfig=None):
     # Deal with any jobs that are running in the batch system
     # only works if we can start the API
     if bossAirConfig:
-        bossAir = BossAirAPI(config=bossAirConfig, noSetup=True)
+        bossAir = BossAirAPI(config=bossAirConfig)
         killableJobs = []
         for liveJob in liveJobs:
             if liveJob["state"].lower() == 'executing':

--- a/test/python/WMCore_t/BossAir_t/BossAir_t.py
+++ b/test/python/WMCore_t/BossAir_t/BossAir_t.py
@@ -5,11 +5,11 @@ BossAir preliminary test
 """
 from __future__ import print_function
 
+import getpass
 import os.path
+import subprocess
 import threading
 import unittest
-import getpass
-import subprocess
 
 try:
     import cPickle as pickle
@@ -377,7 +377,7 @@ class BossAirTest(unittest.TestCase):
 
         config = self.getConfig()
 
-        baAPI = BossAirAPI(config=config)
+        baAPI = BossAirAPI(config=config, insertStates=True)
 
         # We should have loaded a plugin
         self.assertTrue('TestPlugin' in baAPI.plugins.keys())
@@ -457,7 +457,7 @@ class BossAirTest(unittest.TestCase):
 
         config = self.getConfig()
 
-        baAPI = BossAirAPI(config=config)
+        baAPI = BossAirAPI(config=config, insertStates=True)
 
         # Create some jobs
         nJobs = 10
@@ -516,7 +516,7 @@ class BossAirTest(unittest.TestCase):
 
         config = self.getConfig()
 
-        baAPI = BossAirAPI(config=config)
+        baAPI = BossAirAPI(config=config, insertStates=True)
 
         # Create some jobs
         nJobs = 10

--- a/test/python/WMCore_t/BossAir_t/CondorPluginProfileTest.py
+++ b/test/python/WMCore_t/BossAir_t/CondorPluginProfileTest.py
@@ -5,19 +5,18 @@ _CondorPluginProfile_
 
 CondorPluginProfile unittests
 """
-import os.path
-import unittest
 import cProfile
+import os.path
 import pstats
-
-
-from nose.plugins.attrib import attr
-
-from WMCore.BossAir.BossAirAPI   import BossAirAPI
-from WMCore.JobStateMachine.ChangeState          import ChangeState
-from WMComponent.JobSubmitter.JobSubmitterPoller import JobSubmitterPoller
+import unittest
 
 from WMCore_t.BossAir_t.BossAir_t import BossAirTest, getCondorRunningJobs
+from nose.plugins.attrib import attr
+
+from WMComponent.JobSubmitter.JobSubmitterPoller import JobSubmitterPoller
+from WMCore.BossAir.BossAirAPI import BossAirAPI
+from WMCore.JobStateMachine.ChangeState import ChangeState
+
 
 class CondorPluginProfileTest(BossAirTest):
     """
@@ -41,7 +40,7 @@ class CondorPluginProfileTest(BossAirTest):
         config.BossAir.pluginName = 'PyCondorPlugin'
         config.BossAir.submitWMSMode = True
 
-        baAPI  = BossAirAPI(config=config)
+        baAPI = BossAirAPI(config=config, insertStates=True)
 
         workload = self.createTestWorkload()
 
@@ -63,7 +62,6 @@ class CondorPluginProfileTest(BossAirTest):
         for group in jobGroupList:
             changeState.propagate(group.jobs, 'created', 'new')
 
-
         jobSubmitter = JobSubmitterPoller(config=config)
 
         jobSubmitter.algorithm()
@@ -80,7 +78,6 @@ class CondorPluginProfileTest(BossAirTest):
 
         return
 
-
     @attr('integration')
     def testT_updateJobInfo(self):
         """
@@ -96,7 +93,7 @@ class CondorPluginProfileTest(BossAirTest):
         config.BossAir.pluginName = 'PyCondorPlugin'
         config.BossAir.submitWMSMode = True
 
-        baAPI  = BossAirAPI(config=config)
+        baAPI = BossAirAPI(config=config, insertStates=True)
         workload = self.createTestWorkload()
         workloadName = "basicWorkload"
         changeState = ChangeState(config)
@@ -140,7 +137,7 @@ class CondorPluginProfileTest(BossAirTest):
         p.strip_dirs().sort_stats('cumulative').print_stats(0.1)
         p.strip_dirs().sort_stats('time').print_stats(0.1)
         p.strip_dirs().sort_stats('calls').print_stats(0.1)
-        #p.strip_dirs().sort_stats('name').print_stats(10)
+        # p.strip_dirs().sort_stats('name').print_stats(10)
 
     def ProfileWMSMode(self):
         self.createProfile('PyCondorProfile.prof', self.testF_WMSMode)

--- a/test/python/WMCore_t/BossAir_t/SimpleCondorPlugin_t.py
+++ b/test/python/WMCore_t/BossAir_t/SimpleCondorPlugin_t.py
@@ -6,21 +6,22 @@ _SimpleCondorPlugin_t_
 SimpleCondorPlugin unittests
 """
 from __future__ import division, print_function
-import time
-import os.path
-import threading
-import unittest
-import re
 
-from nose.plugins.attrib import attr
+import os.path
+import re
+import threading
+import time
+import unittest
 from subprocess import Popen, PIPE
 
-from WMCore.BossAir.BossAirAPI   import BossAirAPI
-from WMCore.BossAir.StatusPoller import StatusPoller
-from WMCore.JobStateMachine.ChangeState          import ChangeState
-from WMComponent.JobSubmitter.JobSubmitterPoller import JobSubmitterPoller
-from WMComponent.JobTracker.JobTrackerPoller     import JobTrackerPoller
 from WMCore_t.BossAir_t.BossAir_t import BossAirTest, getCondorRunningJobs
+from nose.plugins.attrib import attr
+
+from WMComponent.JobSubmitter.JobSubmitterPoller import JobSubmitterPoller
+from WMComponent.JobTracker.JobTrackerPoller import JobTrackerPoller
+from WMCore.BossAir.BossAirAPI import BossAirAPI
+from WMCore.BossAir.StatusPoller import StatusPoller
+from WMCore.JobStateMachine.ChangeState import ChangeState
 
 
 class SimpleCondorPluginTest(BossAirTest):
@@ -47,7 +48,7 @@ class SimpleCondorPluginTest(BossAirTest):
 
         nJobs = 10
         jobDummies = self.createDummyJobs(nJobs=nJobs)
-        baAPI = BossAirAPI(config=config)
+        baAPI = BossAirAPI(config=config, insertStates=True)
 
         jobPackage = os.path.join(self.testDir, 'JobPackage.pkl')
         f = open(jobPackage, 'w')
@@ -170,7 +171,7 @@ class SimpleCondorPluginTest(BossAirTest):
         config = self.getConfig()
         config.BossAir.pluginName = 'SimpleCondorPlugin'
 
-        baAPI = BossAirAPI(config=config)
+        baAPI = BossAirAPI(config=config, insertStates=True)
 
         workload = self.createTestWorkload()
 
@@ -264,9 +265,9 @@ class SimpleCondorPluginTest(BossAirTest):
         Full test going through the chain; using polling cycles and everything
         """
 
-        from WMComponent.JobSubmitter.JobSubmitter   import JobSubmitter
+        from WMComponent.JobSubmitter.JobSubmitter import JobSubmitter
         from WMComponent.JobStatusLite.JobStatusLite import JobStatusLite
-        from WMComponent.JobTracker.JobTracker       import JobTracker
+        from WMComponent.JobTracker.JobTracker import JobTracker
 
         myThread = threading.currentThread()
 
@@ -276,7 +277,7 @@ class SimpleCondorPluginTest(BossAirTest):
         config = self.getConfig()
         config.BossAir.pluginName = 'SimpleCondorPlugin'
 
-        baAPI = BossAirAPI(config=config)
+        baAPI = BossAirAPI(config=config, insertStates=True)
 
         workload = self.createTestWorkload()
 
@@ -341,7 +342,7 @@ class SimpleCondorPluginTest(BossAirTest):
         config.BossAir.pluginName = 'SimpleCondorPlugin'
         config.BossAir.submitWMSMode = True
 
-        baAPI = BossAirAPI(config=config)
+        baAPI = BossAirAPI(config=config, insertStates=True)
 
         workload = self.createTestWorkload()
 
@@ -393,7 +394,7 @@ class SimpleCondorPluginTest(BossAirTest):
         config.BossAir.pluginName = 'SimpleCondorPlugin'
         config.BossAir.submitWMSMode = True
 
-        baAPI = BossAirAPI(config=config)
+        baAPI = BossAirAPI(config=config, insertStates=True)
         workload = self.createTestWorkload()
         workloadName = "basicWorkload"
         changeState = ChangeState(config)
@@ -447,6 +448,7 @@ class SimpleCondorPluginTest(BossAirTest):
             match = GROUP_NAME_RE.match(request)
             matchedGroup = match.groups()[0] if match else 'undefined'
             self.assertEqual(group, matchedGroup)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/WMCore_t/WorkQueue_t/WMBSHelper_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WMBSHelper_t.py
@@ -9,7 +9,6 @@ import os
 import threading
 import unittest
 
-from WMCore.WMBase import getTestBase
 from WMCore.BossAir.BossAirAPI import BossAirAPI
 from WMCore.Configuration import loadConfigurationFile
 from WMCore.DAOFactory import DAOFactory
@@ -23,6 +22,7 @@ from WMCore.WMBS.Job import Job
 from WMCore.WMBS.JobGroup import JobGroup
 from WMCore.WMBS.Subscription import Subscription
 from WMCore.WMBS.Workflow import Workflow
+from WMCore.WMBase import getTestBase
 from WMCore.WMSpec.StdSpecs.ReReco import ReRecoWorkloadFactory
 from WMCore.WMSpec.WMWorkload import WMWorkload, WMWorkloadHelper
 from WMCore.WorkQueue.WMBSHelper import WMBSHelper
@@ -552,7 +552,7 @@ class WMBSHelperTest(EmulatedUnitTestCase):
 
         Verify that workflow killing works correctly.
         """
-        baAPI = BossAirAPI(config=self.config)
+        baAPI = BossAirAPI(config=self.config, insertStates=True)
 
         # Create nine jobs
         self.setupForKillTest(baAPI=baAPI)
@@ -660,12 +660,14 @@ class WMBSHelperTest(EmulatedUnitTestCase):
         unmergedSkimOutputA.loadData()
         unmergedSkimOutputB.loadData()
 
-        self.assertEqual(mergedSkimOutputA.name, "/TestWorkload/ProcessingTask/MergeTask/SkimTask/unmerged-SkimOutputADataTierA",
+        self.assertEqual(mergedSkimOutputA.name,
+                         "/TestWorkload/ProcessingTask/MergeTask/SkimTask/unmerged-SkimOutputADataTierA",
                          "Error: Merged output fileset is wrong: %s" % mergedSkimOutputA.name)
         self.assertEqual(unmergedSkimOutputA.name,
                          "/TestWorkload/ProcessingTask/MergeTask/SkimTask/unmerged-SkimOutputADataTierA",
                          "Error: Unmerged output fileset is wrong.")
-        self.assertEqual(mergedSkimOutputB.name, "/TestWorkload/ProcessingTask/MergeTask/SkimTask/unmerged-SkimOutputBDataTierB",
+        self.assertEqual(mergedSkimOutputB.name,
+                         "/TestWorkload/ProcessingTask/MergeTask/SkimTask/unmerged-SkimOutputBDataTierB",
                          "Error: Merged output fileset is wrong.")
         self.assertEqual(unmergedSkimOutputB.name,
                          "/TestWorkload/ProcessingTask/MergeTask/SkimTask/unmerged-SkimOutputBDataTierB",
@@ -778,13 +780,17 @@ class WMBSHelperTest(EmulatedUnitTestCase):
         unmergedSkimOutputA.loadData()
         unmergedSkimOutputB.loadData()
 
-        self.assertEqual(mergedSkimOutputA.name, "/ResubmitTestWorkload/MergeTask/SkimTask/unmerged-SkimOutputADataTierA",
+        self.assertEqual(mergedSkimOutputA.name,
+                         "/ResubmitTestWorkload/MergeTask/SkimTask/unmerged-SkimOutputADataTierA",
                          "Error: Merged output fileset is wrong: %s" % mergedSkimOutputA.name)
-        self.assertEqual(unmergedSkimOutputA.name, "/ResubmitTestWorkload/MergeTask/SkimTask/unmerged-SkimOutputADataTierA",
+        self.assertEqual(unmergedSkimOutputA.name,
+                         "/ResubmitTestWorkload/MergeTask/SkimTask/unmerged-SkimOutputADataTierA",
                          "Error: Unmerged output fileset is wrong.")
-        self.assertEqual(mergedSkimOutputB.name, "/ResubmitTestWorkload/MergeTask/SkimTask/unmerged-SkimOutputBDataTierB",
+        self.assertEqual(mergedSkimOutputB.name,
+                         "/ResubmitTestWorkload/MergeTask/SkimTask/unmerged-SkimOutputBDataTierB",
                          "Error: Merged output fileset is wrong.")
-        self.assertEqual(unmergedSkimOutputB.name, "/ResubmitTestWorkload/MergeTask/SkimTask/unmerged-SkimOutputBDataTierB",
+        self.assertEqual(unmergedSkimOutputB.name,
+                         "/ResubmitTestWorkload/MergeTask/SkimTask/unmerged-SkimOutputBDataTierB",
                          "Error: Unmerged output fileset is wrong.")
 
         topLevelFileset = Fileset(name="ResubmitTestWorkload-MergeTask-SomeBlock2")


### PR DESCRIPTION
Fixes #8744 

There were a couple of components adding the boss air states into the table and very very unluckily they must have ran at the same time.

With this change, we add those states when JobSubmitter is started, since it has to update both wmbs and bl tables when jobs get submitted. Insertion has been disabled in all the other places.