### PR TITLE
Complement for 8748 skipping dbsbuffer inserts

### DIFF
--- a/src/python/WMCore/WorkQueue/WMBSHelper.py
+++ b/src/python/WMCore/WorkQueue/WMBSHelper.py
@@ -709,10 +709,9 @@ class WMBSHelper(WMConnectionBase):
         for run in acdcFile['runs']:
             wmbsFile.addRun(run)
 
-        dbsFile = self._convertACDCFileToDBSFile(acdcFile)
-
-        if not dbsFile["LogicalFileName"].startswith("/store/unmerged") or dbsFile["ParentList"]:
+        if not acdcFile["lfn"].startswith("/store/unmerged") or wmbsParents:
             # only add to DBSBuffer if is not unmerged file or it has parents.
+            dbsFile = self._convertACDCFileToDBSFile(acdcFile)
             self._addToDBSBuffer(dbsFile, checksums, acdcFile["locations"])
         
         logging.debug("WMBS ACDC File: %s on Location: %s", wmbsFile['lfn'], wmbsFile['newlocations'])


### PR DESCRIPTION
Fix for second commit in #8748

Error message from WorkQueueManager logs is
```
2018-08-22 10:26:01,113:139968594216704:INFO:WMBSHelper:Adding ACDC files into WMBS for amaltaro_ACDC_MergeHLT_TaskChain_RelVal_Multicore_Agent1115_Validation_180822_092952_874
2018-08-22 10:26:01,114:139968594216704:ERROR:WorkQueue:amaltaro_ACDC_MergeHLT_TaskChain_RelVal_Multicore_Agent1115_Validation_180822_092952_874, /acdc/amaltaro_ACDC_MergeHLT_TaskChain_RelVal_Multicore_Agent1115_Validation_180822_092952
_874/:amaltaro_TaskChain_RelVal_Multicore_Agent1115_Validation_180813_161937_4769:HLTD:HLTDMergeRAWoutput/0/2: 
creating subscription failed in LQ: 
'ParentList'
Traceback (most recent call last):
  File "/data/srv/wmagent/v1.1.15.patch2/sw/slc7_amd64_gcc630/cms/wmagent/1.1.15.patch2/lib/python2.7/site-packages/WMCore/WorkQueue/WorkQueue.py", line 372, in getWork
    dbsBlock)
  File "/data/srv/wmagent/v1.1.15.patch2/sw/slc7_amd64_gcc630/cms/wmagent/1.1.15.patch2/lib/python2.7/site-packages/WMCore/WorkQueue/WorkQueue.py", line 442, in _wmbsPreparation
    sub, match['NumOfFilesAdded'] = wmbsHelper.createSubscriptionAndAddFiles(block=dbsBlock)
  File "/data/srv/wmagent/v1.1.15.patch2/sw/slc7_amd64_gcc630/cms/wmagent/1.1.15.patch2/lib/python2.7/site-packages/WMCore/WorkQueue/WMBSHelper.py", line 419, in createSubscriptionAndAddFiles
    addedFiles = self.addFiles(block)
  File "/data/srv/wmagent/v1.1.15.patch2/sw/slc7_amd64_gcc630/cms/wmagent/1.1.15.patch2/lib/python2.7/site-packages/WMCore/WorkQueue/WMBSHelper.py", line 453, in addFiles
    self._addACDCFileToWMBSFile(acdcFile)
  File "/data/srv/wmagent/v1.1.15.patch2/sw/slc7_amd64_gcc630/cms/wmagent/1.1.15.patch2/lib/python2.7/site-packages/WMCore/WorkQueue/WMBSHelper.py", line 714, in _addACDCFileToWMBSFile
    if not dbsFile["LogicalFileName"].startswith("/store/unmerged") or dbsFile["ParentList"]:
KeyError: 'ParentList'
2018-08-22 10:26:01,963:139968594216704:INFO:DataCollectionService:Merging 11 real input files...
```