### PR TITLE
Import Tools in REST.Main

### DIFF
--- a/src/python/WMCore/REST/Main.py
+++ b/src/python/WMCore/REST/Main.py
@@ -29,8 +29,8 @@ from cherrypy import Application
 from cherrypy._cplogging import LogManager
 from cherrypy.lib import profiler
 
-# WARNING don't remove this import it sets up the tools attributes
-import WMCore.REST.Main
+### Tools is needed for CRABServer startup: it sets up the tools attributes
+import WMCore.REST.Tools
 from WMCore.Configuration import ConfigSection, loadConfigurationFile
 
 #: Terminal controls to switch to "OK" status message colour.


### PR DESCRIPTION
This import was removed in https://github.com/dmwm/WMCore/pull/8691
unfortunately it's actually used by CRABServer during startup, setting up tools attributes or something like that.
Fix https://github.com/dmwm/WMCore/pull/8771