### PR TITLE
Remove lustre from the ignoredDisks list; added /mnt/ramdisk

### DIFF
--- a/src/python/WMCore/Agent/DefaultConfig.py
+++ b/src/python/WMCore/Agent/DefaultConfig.py
@@ -10,7 +10,7 @@ DEFAULT_AGENT_CONFIG = {
     # disk usage percentage for warning
     "DiskUseThreshold": 85,
      # list of disks which shouldn't be included in monitoring for the Threshold
-    "IgnoreDisks": ["/lustre/unmerged"],
+    "IgnoreDisks": ["/mnt/ramdisk"],
     # fraction of condor schedd limit, used for job submission
     "CondorJobsFraction": 0.75,
     # In JobSumitter, submit jobs over the threshold if the priority is higher than current pending/running jobs


### PR DESCRIPTION
I saw one of the newest agents going into drain because `/mnt/ramdisk` was almost full. We have to of course blacklist that mount point.
I can no longer see lustre mounted on the FNAL agents, so I'm removing that as well.