### PR TITLE
Remove wrong reference in Plugins.FNALImpl

### DIFF
--- a/src/python/WMCore/Storage/Plugins/FNALImpl.py
+++ b/src/python/WMCore/Storage/Plugins/FNALImpl.py
@@ -8,7 +8,6 @@ Implementation of StageOutImpl interface for FNAL
 import logging
 import os
 
-from WMCore.Storage.Plugins.CPImpl import CPImpl
 from WMCore.Storage.Plugins.LCGImpl import LCGImpl
 from WMCore.Storage.StageOutImplV2 import StageOutImplV2
 


### PR DESCRIPTION
While grepping for the /lustre/unmerged thing, I found this dead reference (which means nobody is using these plugins, most likely ...)