### PR TITLE
Define PU dataset name in WMTask and in the job classad

### DIFF
--- a/src/python/WMComponent/JobCreator/JobCreatorPoller.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorPoller.py
@@ -119,7 +119,8 @@ def capResourceEstimates(jobGroups, constraints):
 def saveJob(job, workflow, sandbox, wmTask=None, jobNumber=0,
             owner=None, ownerDN=None, ownerGroup='', ownerRole='',
             scramArch=None, swVersion=None, agentNumber=0, numberOfCores=1,
-            inputDataset=None, inputDatasetLocations=None, allowOpportunistic=False, agentName=''):
+            inputDataset=None, inputDatasetLocations=None, inputPileup=None,
+            allowOpportunistic=False, agentName=''):
     """
     _saveJob_
 
@@ -147,11 +148,11 @@ def saveJob(job, workflow, sandbox, wmTask=None, jobNumber=0,
     job['numberOfCores'] = numberOfCores
     job['inputDataset'] = inputDataset
     job['inputDatasetLocations'] = inputDatasetLocations
+    job['inputPileup'] = inputPileup
     job['allowOpportunistic'] = allowOpportunistic
 
-    output = open(os.path.join(cacheDir, 'job.pkl'), 'w')
-    pickle.dump(job, output, pickle.HIGHEST_PROTOCOL)
-    output.close()
+    with open(os.path.join(cacheDir, 'job.pkl'), 'w') as output:
+        pickle.dump(job, output, pickle.HIGHEST_PROTOCOL)
 
     return
 
@@ -180,6 +181,7 @@ def creatorProcess(work, jobCacheDir):
         numberOfCores = work.get('numberOfCores', 1)
         inputDataset = work.get('inputDataset', None)
         inputDatasetLocations = work.get('inputDatasetLocations', None)
+        inputPileup = work.get('inputPileup', None)
         allowOpportunistic = work.get('allowOpportunistic', False)
         agentName = work.get('agentName', '')
 
@@ -220,6 +222,7 @@ def creatorProcess(work, jobCacheDir):
                     numberOfCores=numberOfCores,
                     inputDataset=inputDataset,
                     inputDatasetLocations=inputDatasetLocations,
+                    inputPileup=inputPileup,
                     allowOpportunistic=allowOpportunistic,
                     agentName=agentName)
 
@@ -576,7 +579,8 @@ class JobCreatorPoller(BaseWorkerThread):
                                'ownerGroup': wmWorkload.getOwner().get('vogroup', ''),
                                'ownerRole': wmWorkload.getOwner().get('vorole', ''),
                                'numberOfCores': 1,
-                               'inputDataset': wmTask.getInputDatasetPath()}
+                               'inputDataset': wmTask.getInputDatasetPath(),
+                               'inputPileup': wmTask.getInputPileupDatasets()}
                 try:
                     maxCores = 1
                     stepNames = wmTask.listAllStepNames()

--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -390,6 +390,7 @@ class JobSubmitterPoller(BaseWorkerThread):
                        'numberOfCores': loadedJob.get("numberOfCores"),  # may update it later
                        'inputDataset': loadedJob.get('inputDataset', None),
                        'inputDatasetLocations': loadedJob.get('inputDatasetLocations', None),
+                       'inputPileup': loadedJob.get('inputPileup', None),
                        'allowOpportunistic': loadedJob.get('allowOpportunistic', False)}
             # then update it with the info retrieved from the database
             jobInfo.update(newJob)

--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -575,12 +575,16 @@ class SimpleCondorPlugin(BasePlugin):
                 ad['DESIRED_CMSDataset'] = job['inputDataset']
             else:
                 ad['DESIRED_CMSDataset'] = classad.Value.Undefined
-
             if job.get('inputDatasetLocations'):
                 sites = ','.join(sorted(job['inputDatasetLocations']))
                 ad['DESIRED_CMSDataLocations'] = sites
             else:
                 ad['DESIRED_CMSDataLocations'] = classad.Value.Undefined
+
+            if job.get('inputPileup'):
+                ad['DESIRED_CMSPileups'] = ','.join(sorted(job['inputPileup']))
+            else:
+                ad['DESIRED_CMSPileups'] = classad.Value.Undefined
 
             # HighIO and repack jobs
             ad['Requestioslots'] = 1 if job['task_type'] in ["Merge", "Cleanup", "LogCollect"] else 0

--- a/src/python/WMCore/BossAir/RunJob.py
+++ b/src/python/WMCore/BossAir/RunJob.py
@@ -63,6 +63,7 @@ class RunJob(dict):
         self.setdefault('potentialSites', None)
         self.setdefault('inputDataset', None)
         self.setdefault('inputDatasetLocations', None)
+        self.setdefault('inputPileup', None)
         self.setdefault('allowOpportunistic', False)
 
         return

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -848,7 +848,12 @@ class StdBase(object):
         _setupPileup_
 
         Setup pileup for every CMSSW step in the task.
+        pileupConfig has the following data structure:
+            {'mc': ['/mc_pd/procds/tier'], 'data': ['/data_pd/procds/tier']}
         """
+        for puType, puList in pileupConfig.items():
+            task.setInputPileupDatasets(puList)
+
         for stepName in task.listAllStepNames():
             step = task.getStep(stepName)
             if step.stepType() != "CMSSW":

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -832,10 +832,37 @@ class WMTaskHelper(TreeHelper):
         """
 
         if hasattr(self.data.input, 'dataset'):
-            if hasattr(self.data.input.dataset, 'name') and self.data.input.dataset.name:
-                return self.data.input.dataset.name
+            return getattr(self.data.input.dataset, 'name', None)
 
         return None
+
+    def setInputPileupDatasets(self, dsetName):
+        """
+        _setInputPileupDatasets_
+
+        Create a list of pileup datasets to be used by this task (possible
+        multiple CMSSW steps)
+        """
+        self.data.input.section_("pileup")
+        if not hasattr(self.data.input.pileup, "datasets"):
+            self.data.input.pileup.datasets = []
+
+        if isinstance(dsetName, list):
+            self.data.input.pileup.datasets.extend(dsetName)
+        elif isinstance(dsetName, basestring):
+            self.data.input.pileup.datasets.append(dsetName)
+        else:
+            raise ValueError("Pileup dataset must be either a list or basestring")
+
+    def getInputPileupDatasets(self):
+        """
+        _getInputPileupDatasets_
+
+        Get a list of the input pileup dataset name(s) for this task.
+        """
+        if hasattr(self.data.input, 'pileup'):
+            return getattr(self.data.input.pileup, 'datasets', [])
+        return []
 
     def siteWhitelist(self):
         """

--- a/src/python/WMCore/WMSpec/WMWorkloadTools.py
+++ b/src/python/WMCore/WMSpec/WMWorkloadTools.py
@@ -34,7 +34,7 @@ def parsePileupConfig(mcPileup, dataPileup):
 
     If the pileup config is defined as MCPileup and DataPileup
     then make sure we get the usual dictionary as
-    PileupConfig : {'mc' : '/mc/procds/tier', 'data': '/minbias/procds/tier'}
+    PileupConfig : {'mc': ['/mc_pd/procds/tier'], 'data': ['/data_pd/procds/tier']}
     """
     pileUpConfig = {}
     if mcPileup is not None:


### PR DESCRIPTION
Fixes #8801

Changes are:
 * assumes each task can have multiple PU samples and multiple PU types
 * persist the PU name(s) under a WMTask object (and in the workload object)
 * pass the PU name(s) all the way from JobCreator to JobSubmitter and the submitter plugin
 * define a new job classad `DESIRED_CMSPileups` with the PU name(s) for that job/task. Leave it undefined if there is no PU dataset.

Note this will only be visible in the job classads for workflows created after this change goes to ReqMgr2.