### PR TITLE
make crabtaskworker depend on all services, so it gets the new CRIC one

### DIFF
--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -137,9 +137,7 @@ dependencies = {
     },
     'crabtaskworker': {
         'packages': ['WMCore.WorkQueue', 'WMCore.Credential', 'WMCore.Algorithms+', 'WMCore.WMSpec+',
-                     'WMCore.JobSplitting', 'WMCore.Services.SiteDB+', 'WMCore.Services.DBS+',
-                     'WMCore.Services.UserFileCache+', 'WMCore.Services.PhEDEx+', 'WMCore.Services.Dashboard+',
-                     'WMCore.Services.WMArchive+', 'Utils+'],
+                     'WMCore.JobSplitting', 'WMCore.Services+', 'Utils+'],
         'modules': ['WMCore.WMBS.File', 'WMCore.WMBS.WMBSBase', 'WMCore.WMBS.__init__'],
         'systems': ['wmc-database', 'wmc-runtime'],
     },


### PR DESCRIPTION
@amaltaro @ticoann we need this in order to have CRIC in the rpm when we build CRAB TaskWorker. Can you please review, merge, and include in next tag ?
