### PR TITLE
Add Utils dependency for acdcserver

### DIFF
--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -165,7 +165,7 @@ dependencies = {
         },
     'acdcserver': {
         'packages': ['WMCore.ACDC', 'WMCore.GroupUser', 'WMCore.DataStructs',
-                     'WMCore.Wrappers+', 'WMCore.Database'],
+                     'WMCore.Wrappers+', 'WMCore.Database', 'Utils'],
         'modules': ['WMCore.Configuration',
                     'WMCore.Algorithms.ParseXMLFile', 'WMCore.Algorithms.Permissions',
                     'WMCore.Lexicon', 'WMCore.WMException', 'WMCore.Services.Requests',


### PR DESCRIPTION
Found it while manually running the acdc cleanup task, this was the traceback
```
Traceback (most recent call last):
  File "/data/srv/HG1810a-comp2/sw.amaltaro/slc7_amd64_gcc630/cms/acdcserver/1.1.17.pre1/bin/acdcserver-tools", line 15, in <module>
    from WMCore.ACDC.CouchService import CouchService
  File "/data/srv/HG1810a-comp2/sw.amaltaro/slc7_amd64_gcc630/cms/acdcserver/1.1.17.pre1/lib/python2.7/site-packages/WMCore/ACDC/CouchService.py", line 11, in <module>
    import WMCore.Database.CouchUtils as CouchUtils
  File "/data/srv/HG1810a-comp2/sw.amaltaro/slc7_amd64_gcc630/cms/acdcserver/1.1.17.pre1/lib/python2.7/site-packages/WMCore/Database/CouchUtils.py", line 14, in <module>
    import WMCore.Database.CMSCouch as CMSCouch
  File "/data/srv/HG1810a-comp2/sw.amaltaro/slc7_amd64_gcc630/cms/acdcserver/1.1.17.pre1/lib/python2.7/site-packages/WMCore/Database/CMSCouch.py", line 23, in <module>
    from Utils.IteratorTools import grouper, nestedDictUpdate
ImportError: No module named Utils.IteratorTools
```

something else that I'm investigating is the lack of log file (including on testbed)... investigating.