### PR TITLE
keep only one job summary docs per agent and request

### DIFF
--- a/src/couchapps/WMStats/_attachments/js/Models/WMStats._RequestModelBase.js
+++ b/src/couchapps/WMStats/_attachments/js/Models/WMStats._RequestModelBase.js
@@ -84,8 +84,7 @@ WMStats._RequestModelBase.prototype = {
     },
 
     _getLatestRequestAgentUrlAndCreateTable: function (overviewData, keys, objPtr) {
-        var options = {"keys": keys, 
-                       "reduce": true, "group": true, "descending": true};
+        var options = {"keys": keys, "reduce": false, "descending": true};
         WMStats.Couch.view('latestRequest', options,
               function(agentIDs) {
                   objPtr._getRequestDetailsAndTriggerEvent(agentIDs, overviewData, objPtr);

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
@@ -4028,8 +4028,7 @@ WMStats._RequestModelBase.prototype = {
     },
 
     _getLatestRequestAgentUrlAndCreateTable: function (overviewData, keys, objPtr) {
-        var options = {"keys": keys, 
-                       "reduce": true, "group": true, "descending": true};
+        var options = {"keys": keys, "reduce": false, "descending": true};
         WMStats.Couch.view('latestRequest', options,
               function(agentIDs) {
                   objPtr._getRequestDetailsAndTriggerEvent(agentIDs, overviewData, objPtr);

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
@@ -4676,8 +4676,7 @@ WMStats._RequestModelBase.prototype = {
     },
 
     _getLatestRequestAgentUrlAndCreateTable: function (overviewData, keys, objPtr) {
-        var options = {"keys": keys, 
-                       "reduce": true, "group": true, "descending": true};
+        var options = {"keys": keys, "reduce": false, "descending": true};
         WMStats.Couch.view('latestRequest', options,
               function(agentIDs) {
                   objPtr._getRequestDetailsAndTriggerEvent(agentIDs, overviewData, objPtr);

--- a/src/couchapps/WMStatsAgent/views/agentRequests/map.js
+++ b/src/couchapps/WMStatsAgent/views/agentRequests/map.js
@@ -1,0 +1,8 @@
+function(doc) {
+  if (doc.type === "agent_request" && doc.agent_url) {
+    // this condition check can be removed when there is no historical data is left. Not sure why this check is not working
+    //if (doc['_id'].startsWith(doc.agent_url)) {
+        emit(doc['_id'],  {'rev': doc['_rev']});
+    //}
+  }
+}

--- a/src/python/WMComponent/AnalyticsDataCollector/AnalyticsPoller.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/AnalyticsPoller.py
@@ -138,7 +138,9 @@ class AnalyticsPoller(BaseWorkerThread):
             if self.plugin != None:
                 self.plugin(requestDocs, self.localSummaryCouchDB, self.centralRequestCouchDB)
 
-            self.localSummaryCouchDB.uploadData(requestDocs)
+            existingDocs = self.localSummaryCouchDB.getAllAgentRequestRevByID()
+            self.localSummaryCouchDB.bulkUpdateData(requestDocs, existingDocs)
+
             logging.info("Request data upload success\n %s request, \nsleep for next cycle", len(requestDocs))
 
             self.centralWMStatsCouchDB.updateAgentInfoInPlace(self.agentInfo["agent_url"],

--- a/src/python/WMComponent/AnalyticsDataCollector/DataCollectAPI.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/DataCollectAPI.py
@@ -318,6 +318,7 @@ def convertToRequestCouchDoc(combinedRequests, fwjrInfo, finishedTasks,
     requestDocs = []
     for request, status in combinedRequests.items():
         doc = {}
+        doc['_id'] = '%s-%s' % (agentInfo['agent_url'], request)
         doc.update(agentInfo)
         doc['type'] = "agent_request"
         doc['workflow'] = request

--- a/src/python/WMCore/Services/WMStats/WMStatsReader.py
+++ b/src/python/WMCore/Services/WMStats/WMStatsReader.py
@@ -414,3 +414,12 @@ class WMStatsReader(object):
             finalStruct["samples"].append(row["doc"])
 
         return jobInfoDoc
+
+    def getAllAgentRequestRevByID(self):
+
+        results = self.couchDB.loadView(self.couchapp, "agentRequests")
+        idRevMap = {}
+        for row in results['rows']:
+            idRevMap[row['key']] = row['value']['rev']
+
+        return idRevMap

--- a/src/python/WMCore/Services/WMStats/WMStatsReader.py
+++ b/src/python/WMCore/Services/WMStats/WMStatsReader.py
@@ -222,8 +222,7 @@ class WMStatsReader(object):
         if len(keys) == 0:
             return []
         options = {}
-        options["reduce"] = True
-        options["group"] = True
+        options["reduce"] = False
         result = self._getCouchView("latestRequest", options, keys)
         ids = [row['value']['id'] for row in result["rows"]]
         return ids

--- a/src/python/WMCore/WMStats/CherryPyThreads/CleanUpTask.py
+++ b/src/python/WMCore/WMStats/CherryPyThreads/CleanUpTask.py
@@ -20,17 +20,7 @@ class CleanUpTask(CherryPyPeriodicTask):
         """
         sets the list of functions which runs concurrently
         """
-        self.concurrentTasks = [{'func': self.cleanUpOldRequests, 'duration': (config.DataKeepDays * 24 * 60 * 60)},
-                                {'func': self.cleanUpArchivedRequests, 'duration': config.archivedCleanUpDuration}]
-
-    def cleanUpOldRequests(self, config):
-        """
-        clean up wmstats data older then given days
-        """
-        self.logger.info("deleting %s hours old docs", (config.DataKeepDays * 24))
-        result = self.wmstatsDB.deleteOldDocs(config.DataKeepDays)
-        self.logger.info("%s old doc deleted", result)
-        return
+        self.concurrentTasks = [{'func': self.cleanUpArchivedRequests, 'duration': config.archivedCleanUpDuration}]
 
     def cleanUpArchivedRequests(self, config):
         """


### PR DESCRIPTION
related to #8827 (The code is just skeleton, need to be tested and refined)

This is agent part of the patch, I will create separate patch for wmstats serverside.

1. instead of adding new document for workflow job summary we will update the old document.
  (id is set to [agent-name]-[request-name])
2. This has to be backward compatible.  (Still agent will delete the document every 3 hours from TaskArchiver - new agent doesn't have to do that but if this is patched to current agent it still need that feature) 
3. With new id, central wmstats view still need to work.
4. Agent patch has to be applied before wmstats are updated. (After agents are updated we have to rotate wmstats to remove all the previous job summary document from wmstats)