### PR TITLE
Properly check whether Services cache is expired or not

### DIFF
--- a/src/python/WMCore/Services/Requests.py
+++ b/src/python/WMCore/Services/Requests.py
@@ -220,7 +220,7 @@ class Requests(dict):
         if verb != 'GET' and data:
             if isinstance(encoder, (types.MethodType, types.FunctionType)):
                 encoded_data = encoder(data)
-            elif encoder == False:
+            elif encoder is False:
                 # Don't encode the data more than we have to
                 #  we don't want to URL encode the data blindly,
                 #  that breaks POSTing attachments... ConfigCache_t
@@ -417,7 +417,7 @@ class Requests(dict):
         # Set but not found
         if key is None or cert is None:
             raise WMException('Request requires a host certificate and key',
-                                  "WMCORE-11")
+                              "WMCORE-11")
 
         # All looks OK, still doesn't guarantee proxy's validity etc.
         return key, cert

--- a/src/python/WMCore/Services/TagCollector/TagCollector.py
+++ b/src/python/WMCore/Services/TagCollector/TagCollector.py
@@ -26,7 +26,7 @@ class TagCollector(Service):
         params = {}
         params["timeout"] = 300
         params['endpoint'] = url or defaultURL
-        params.setdefault('cacheduration', 3600)
+        params.setdefault('cacheduration', 1)
         params['logger'] = logger if logger else logging.getLogger()
 
         Service.__init__(self, params)


### PR DESCRIPTION
Fixes #8841

Actually it fixes the first issue, which is now correctly checking whether the (Services) cache file is expired or not, based on the `cacheduration`. Before this patch, cache was always considered as expired.

In short, the new behavior is:
* if the cache file is a file-like object, assume it's expired
* if file does not exist, assume it's expired
* otherwise, check if last modification of the file is greater than `cacheduration`, in hours
* (this is not changed, but...) the cache file is only updated if there is an actual query to the data-service
* if cache is dead/expired and the actual query failed, it raises an exception (no matter the `usestalecache` flag value)