### PR TITLE
Correctly define int arguments for argparse

### DIFF
--- a/doc/generate_modules.py
+++ b/doc/generate_modules.py
@@ -263,7 +263,7 @@ Note: By default this script will not overwrite already created files.""")
     parser.add_argument("-s", "--suffix", action="store", dest="suffix", help="module suffix (default=txt)",
                         default="txt")
     parser.add_argument("-m", "--maxdepth", action="store", dest="maxdepth",
-                        help="Maximum depth of submodules to show in the TOC (default=4)", type="int", default=4)
+                        help="Maximum depth of submodules to show in the TOC (default=4)", type=int, default=4)
     parser.add_argument("-r", "--dry-run", action="store_true", dest="dryrun",
                         help="Run the script without creating the files")
     parser.add_argument("-f", "--force", action="store_true", dest="force", help="Overwrite all the files")

--- a/test/data/WMStats/doc_generator.py
+++ b/test/data/WMStats/doc_generator.py
@@ -219,12 +219,12 @@ if __name__ == "__main__":
         parser.add_argument("-i", "--iterations",
                             dest="iterations",
                             default=ITERATIONS,
-                            type="int",
+                            type=int,
                             help="The number of iterations to make, default=%s" % ITERATIONS)
         parser.add_argument("-r", "--requests",
                             dest="requests",
                             default=NUM_OF_REQUEST,
-                            type="int",
+                            type=int,
                             help="The number of requests to simulate, default=%s" % NUM_OF_REQUEST)
 
         return parser.parse_args()
@@ -239,6 +239,6 @@ if __name__ == "__main__":
     docList.extend(agent_requests)
     for req in agent_requests:
         docList.extend(generate_jobsummary(req['workflow']))
-    docs = {"docs": docList};
+    docs = {"docs": docList}
 
     json.dump(docs, open("sample_docs.json", "w+"))

--- a/test/data/WMStats/generator.py
+++ b/test/data/WMStats/generator.py
@@ -73,32 +73,32 @@ def parse_opts():
     parser.add_argument("-u", "--users",
                         dest="users",
                         default=10,
-                        type="int",
+                        type=int,
                         help="The number of users, default=10")
     parser.add_argument("-s", "--sites",
                         dest="sites",
                         default=5,
-                        type="int",
+                        type=int,
                         help="The number of sites, default=5")
     parser.add_argument("-a", "--agents",
                         dest="agents",
                         default=2,
-                        type="int",
+                        type=int,
                         help="The number of agents, default=2")
     parser.add_argument("-i", "--iterations",
                         dest="iterations",
                         default=ITERATIONS,
-                        type="int",
+                        type=int,
                         help="The number of iterations to make, default=%s" % ITERATIONS)
     parser.add_argument("-r", "--requests",
                         dest="requests",
                         default=NUM_OF_REQUEST,
-                        type="int",
+                        type=int,
                         help="The number of requests to simulate, default=%s" % NUM_OF_REQUEST)
     parser.add_argument("-w", "--wait",
                         dest="wait",
                         default=0,
-                        type="int",
+                        type=int,
                         help="Wait W seconds between iterations, default=0")
 
     return parser.parse_args()


### PR DESCRIPTION
Fixes a bug introduced in #8849
type definition format changed between optparse and argparse, and without this fix it fails to build workqueue with the following error:
```
* The action "build-cms+workqueue+1.1.18.pre1" was not completed successfully because Failed to build workqueue. Log file in /build/amaltaro/w/BUILD/slc7_amd64_gcc630/cms/workqueue/1.1.18.pre1/log. Final lines of the log file:
make -C doc html PROJECT=workqueue
make: Entering directory `/build/amaltaro/w/BUILD/slc7_amd64_gcc630/cms/workqueue/1.1.18.pre1/workqueue/doc'
[ -d workqueue ] || cp -rp wmcore workqueue
python generate_modules.py -f -d workqueue -s rst ${PYTHONPATH%%:*}
Traceback (most recent call last):
File "generate_modules.py", line 289, in <module>
main()
File "generate_modules.py", line 266, in main
help="Maximum depth of submodules to show in the TOC (default=4)", type="int", default=4)
File "/build/amaltaro/w/slc7_amd64_gcc630/external/python/2.7.13/lib/python2.7/argparse.py", line 1299, in add_argument
raise ValueError('%r is not callable' % (type_func,))
ValueError: 'int' is not callable
make: *** [apidoc] Error 1
make: Leaving directory `/build/amaltaro/w/BUILD/slc7_amd64_gcc630/cms/workqueue/1.1.18.pre1/workqueue/doc'
error: command 'make' failed with exit status 2
error: Bad exit status from /build/amaltaro/w/tmp/rpm-tmp.pYeKCb (%build)
```