### PR TITLE
post wmstats summary directly to central wmstats

### DIFF
--- a/src/couchapps/WMStats/rewrites.json
+++ b/src/couchapps/WMStats/rewrites.json
@@ -49,6 +49,11 @@
   },
 
   {
+    "from": "_view/byAgentURL",
+    "to": "../WMStatsErl/_view/byAgentURL"
+  },
+
+  {
     "from": "_view/cooledoffRequests",
     "to": "../WMStatsErl/_view/cooledoffRequests"
   },

--- a/src/couchapps/WMStatsAgent/views/agentRequests/map.js
+++ b/src/couchapps/WMStatsAgent/views/agentRequests/map.js
@@ -1,8 +1,0 @@
-function(doc) {
-  if (doc.type === "agent_request" && doc.agent_url) {
-    // this condition check can be removed when there is no historical data is left. Not sure why this check is not working
-    //if (doc['_id'].startsWith(doc.agent_url)) {
-        emit(doc['_id'],  {'rev': doc['_rev']});
-    //}
-  }
-}

--- a/src/couchapps/WMStatsErl/views/byAgentURL/map.erl
+++ b/src/couchapps/WMStatsErl/views/byAgentURL/map.erl
@@ -1,0 +1,11 @@
+fun({Doc}) ->
+  DocType = couch_util:get_value(<<"type">>, Doc),
+  case DocType of
+    undefined -> ok;
+    <<"agent_request">> ->
+      AgentUrl = couch_util:get_value(<<"agent_url">>, Doc),
+      Rev = couch_util:get_value(<<"_rev">>, Doc),
+      Emit(AgentUrl, {[{rev,Rev}]});
+    _ -> ok
+  end
+end.

--- a/src/python/WMComponent/AnalyticsDataCollector/AnalyticsPoller.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/AnalyticsPoller.py
@@ -138,8 +138,8 @@ class AnalyticsPoller(BaseWorkerThread):
             if self.plugin != None:
                 self.plugin(requestDocs, self.localSummaryCouchDB, self.centralRequestCouchDB)
 
-            existingDocs = self.localSummaryCouchDB.getAllAgentRequestRevByID()
-            self.localSummaryCouchDB.bulkUpdateData(requestDocs, existingDocs)
+            existingDocs = self.centralWMStatsCouchDB.getAllAgentRequestRevByID(self.agentInfo["agent_url"])
+            self.centralWMStatsCouchDB.bulkUpdateData(requestDocs, existingDocs)
 
             logging.info("Request data upload success\n %s request, \nsleep for next cycle", len(requestDocs))
 

--- a/src/python/WMCore/Services/WMStats/WMStatsReader.py
+++ b/src/python/WMCore/Services/WMStats/WMStatsReader.py
@@ -414,11 +414,11 @@ class WMStatsReader(object):
 
         return jobInfoDoc
 
-    def getAllAgentRequestRevByID(self):
-
-        results = self.couchDB.loadView(self.couchapp, "agentRequests")
+    def getAllAgentRequestRevByID(self, agentURL):
+        options = {"reduce": False}
+        results = self.couchDB.loadView(self.couchapp, "byAgentURL", options=options, keys=[agentURL])
         idRevMap = {}
         for row in results['rows']:
-            idRevMap[row['key']] = row['value']['rev']
+            idRevMap[row['id']] = row['value']['rev']
 
         return idRevMap

--- a/src/python/WMCore/Services/WMStats/WMStatsWriter.py
+++ b/src/python/WMCore/Services/WMStats/WMStatsWriter.py
@@ -89,11 +89,11 @@ class WMStatsWriter(WMStatsReader):
         for doc in docs:
             if doc['_id'] in existingDocs:
                 revList = existingDocs[doc['_id']].split('-')
-                # update the revision number
-                doc['_rev'] = "%s-%s" % (int(revList[0]) + 1, revList[1])
+                # update the revision number and keep the history of the revision
+                doc['_revisions'] = {"start": int(revList[0]) + 1, "ids": [str(int(revList[1]) + 1), revList[1]]}
             else:
                 # just send well formatted revision for the new documents which required by new_edits=False
-                doc['_rev'] = "1-123456789"
+                doc['_rev'] = "1-1234567890"
             self.couchDB.queue(doc)
 
         self.couchDB.commit(new_edits=False)


### PR DESCRIPTION
fixes #8851

This fix contains new view. - Need to come up with temporary WMAgent patch without updating the views in cmsweb couch. Then reapply this patch when cmsweb is updated.

We still need replication since local wmstats db contains docs for failed job as well. 