### PR TITLE
Does not raise DBSReaderError when block has no valid files

### DIFF
--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -378,21 +378,21 @@ class DBS3Reader(object):
         """
         Get dataset summary includes # of files, events, blocks and total size
         """
-        # FIXME: Doesnt raise exceptions on missing data as old api did
         if dataset:
             self.checkDatasetPath(dataset)
         try:
             if block:
                 summary = self.dbs.listFileSummaries(block_name=block, validFileOnly=1)
-            else:  # dataset case dataset shouldn't be None
+            else:
                 summary = self.dbs.listFileSummaries(dataset=dataset, validFileOnly=1)
         except Exception as ex:
             msg = "Error in DBSReader.getDBSSummaryInfo(%s, %s)\n" % (dataset, block)
             msg += "%s\n" % formatEx3(ex)
             raise DBSReaderError(msg)
-        if not summary or summary[0].get('file_size') is None:  # appears to indicate missing dataset
-            msg = "DBSReader.listDatasetSummary(%s, %s): No matching data"
-            raise DBSReaderError(msg % (dataset, block))
+
+        if not summary:  # missing data or all files invalid
+            return {}
+
         result = remapDBS3Keys(summary[0], stringify=True)
         result['path'] = dataset if dataset else ''
         result['block'] = block if block else ''

--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -7,20 +7,22 @@ Readonly DBS Interface
 """
 from __future__ import print_function, division
 
-import time
 import logging
+import time
 import traceback
 from collections import defaultdict
 
+from RestClient.ErrorHandling.RestClientExceptions import HTTPError
 from dbs.apis.dbsClient import DbsApi
 from dbs.exceptions.dbsClientException import dbsClientException
 
-from RestClient.ErrorHandling.RestClientExceptions import HTTPError
 from Utils.IteratorTools import grouper
 from WMCore.Services.DBS.DBSErrors import DBSReaderError, formatEx3
 from WMCore.Services.PhEDEx.PhEDEx import PhEDEx
-from WMCore.Services.pycurl_manager import getdata as multi_getdata
 
+
+### Needed for the pycurl comment, leave it out for now
+# from WMCore.Services.pycurl_manager import getdata as multi_getdata
 
 
 def remapDBS3Keys(data, stringify=False, **others):
@@ -37,10 +39,10 @@ def remapDBS3Keys(data, stringify=False, **others):
                'block_name': 'BlockName', 'lumi_section_num': 'LumiSectionNumber'}
 
     mapping.update(others)
-    format = lambda x: str(x) if stringify and isinstance(x, unicode) else x
+    formatFunc = lambda x: str(x) if stringify and isinstance(x, unicode) else x
     for name, newname in mapping.iteritems():
         if name in data:
-            data[newname] = format(data[name])
+            data[newname] = formatFunc(data[name])
     return data
 
 
@@ -82,7 +84,7 @@ class DBS3Reader(object):
             elif lfns:
                 lumiLists = []
                 for slfn in grouper(lfns, 50):
-                    lumiLists.extend(self.dbs.listFileLumiArray(logical_file_name = slfn))
+                    lumiLists.extend(self.dbs.listFileLumiArray(logical_file_name=slfn))
             else:
                 # shouldn't call this with both blockName and lfns empty
                 # but still returns empty dict for that case
@@ -184,7 +186,8 @@ class DBS3Reader(object):
             msg = "Error in DBSReader.listRuns(%s, %s)\n" % (dataset, block)
             msg += "%s\n" % formatEx3(ex)
             raise DBSReaderError(msg)
-        [runs.extend(x['run_num']) for x in results]
+        for x in results:
+            runs.extend(x['run_num'])
         return runs
 
     def listRunLumis(self, dataset=None, block=None):
@@ -693,7 +696,7 @@ class DBS3Reader(object):
             "PhEDExNodeNames": self.listFileBlockLocation(fileBlockName, dbsOnly),
             "Files": self.listFilesInBlock(fileBlockName),
             "IsOpen": self.blockIsOpen(fileBlockName)
-            }
+        }
         }
         return result
 
@@ -722,7 +725,7 @@ class DBS3Reader(object):
             "PhEDExNodeNames": self.listFileBlockLocation(fileBlockName),
             "Files": self.listFilesInBlockWithParents(fileBlockName),
             "IsOpen": self.blockIsOpen(fileBlockName)
-            }
+        }
         }
         return result
 
@@ -738,7 +741,8 @@ class DBS3Reader(object):
         result = {}
         blocks = self.listFileBlocks(dataset, onlyClosedBlocks)
 
-        [result.update(self.getFileBlock(x)) for x in blocks]
+        for x in blocks:
+            result.update(self.getFileBlock(x))
 
         return result
 
@@ -927,7 +931,6 @@ class DBS3Reader(object):
             parentFiles[f['logical_file_name']] = parentFiles[f['logical_file_name']].union(pFiles)
         return parentFiles
 
-
     def getParentFilesByLumi(self, childLFN):
         """
         get the parent file's lfns by lumi (This might not be the actual parentage relations in DBS just parentage by Lumis).
@@ -945,13 +948,14 @@ class DBS3Reader(object):
                 result.append({"ParentDataset": parent['parent_dataset'], "ParentFiles": list(parentFiles)})
         return result
 
-    def listParentsByLumi(self, childBlockName, childLFNs=[]):
+    def listParentsByLumi(self, childBlockName, childLFNs=None):
         """
         :param childBlockName: child block name
         :param childLFNs: list of child lfns if it is not specified, all the file in the block will be used,
                if specified, dbs validate child lfns from the childBlockName
         :return: list of list with child and parent id pair.  [[1,2], [3,4]...]
         """
+        childLFNs = childLFNs or []
         return self.dbs.listFileParentsByLumi(block_name=childBlockName, logical_file_name=childLFNs)
 
     def insertFileParents(self, childBlockName, childParentsIDPairs):
@@ -961,15 +965,16 @@ class DBS3Reader(object):
                 dbs validate child ids from the childBlockName
         :return: None
         """
-        return self.dbs.insertFileParents({"block_name": childBlockName, "child_parent_id_list":childParentsIDPairs})
+        return self.dbs.insertFileParents({"block_name": childBlockName, "child_parent_id_list": childParentsIDPairs})
 
-    def findAndInsertMissingParentage(self, childBlockName, childLFNs=[], insertFlag=True):
+    def findAndInsertMissingParentage(self, childBlockName, childLFNs=None, insertFlag=True):
         """
         :param childBlockName: child block name
         :param childLFNs: list of child lfns if it is not specified, all the file in the block will be used,
                if specified, dbs validate child lfns from the childBlockName
         :return: number of file parents pair inserted
         """
+        childLFNs = childLFNs or []
         fileParents = self.dbs.listFileParentsByLumi(block_name=childBlockName, logical_file_name=childLFNs)
         childParentsIDPairs = fileParents[0]["child_parent_id_list"]
 
@@ -1038,7 +1043,6 @@ class DBS3Reader(object):
                 failedBlocks.append(blockName)
 
         return failedBlocks
-
 
     def insertMissingParentageForAllFiles(self, childDataset, filterFilesWithParents=True, insertFlag=False):
         """

--- a/src/python/WMCore/WorkQueue/Policy/Start/Block.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Block.py
@@ -5,6 +5,7 @@ WorkQueue splitting by block
 """
 from __future__ import print_function, division
 import os
+import logging
 from math import ceil
 from WMCore.WorkQueue.Policy.Start.StartPolicyInterface import StartPolicyInterface
 from WMCore.Services.SiteDB.SiteDB import SiteDBJSON as SiteDB
@@ -127,7 +128,8 @@ class Block(StartPolicyInterface):
             block = dbs.getDBSSummaryInfo(datasetPath, block=blockName)
             # blocks with 0 valid files should be ignored
             # - ideally they would be deleted but dbs can't delete blocks
-            if not block['NumberOfFiles'] or block['NumberOfFiles'] == '0':
+            if int(block.get('NumberOfFiles', 0)) == 0:
+                logging.warning("Block %s being rejected for lack of valid files to process", blockName)
                 self.rejectedWork.append(blockName)
                 continue
 
@@ -159,6 +161,7 @@ class Block(StartPolicyInterface):
                     runs = runs.intersection(runWhiteList)
                 # any runs left are ones we will run on, if none ignore block
                 if not runs:
+                    logging.warning("Block %s doesn't pass the runs constraints", blockName)
                     self.rejectedWork.append(blockName)
                     continue
 

--- a/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
@@ -155,8 +155,7 @@ class StartPolicyInterface(PolicyInterface):
             raise error
         except DBSReaderError as ex:
             # Hacky way of identifying non-existant data, DbsBadRequest chomped by DBSReader
-            # DbsConnectionError: Database exception,Invalid parameters thrown by Summary api
-            if 'DbsBadRequest' in str(ex) or 'Invalid parameters' in str(ex):
+            if 'Invalid parameters' in str(ex):
                 data = task.data.input.pythonise_() if task.data.input else 'None'
                 msg = """data: %s, mask: %s, pileup: %s. %s""" % (str(data), str(mask), str(pileupDatasets), str(ex))
                 error = WorkQueueNoWorkError(self.wmspec, msg)

--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -1113,6 +1113,9 @@ class WorkQueue(WorkQueueBase):
                         if not self.params.get("UnittestFlag", False):
                             self.reqmgrSvc.updateRequestStats(inbound['WMSpec'].name(), totalStats)
 
+                    if rejectedWork:
+                        msg = "Request with the following unprocessable input data: %s" % rejectedWork
+                        self.logdb.post(inbound['RequestName'], msg, 'warning')
             except TERMINAL_EXCEPTIONS as ex:
                 msg = 'Terminal exception splitting WQE: %s' % inbound
                 self.logger.error(msg)


### PR DESCRIPTION
Fixes #8846 

Changes are:
* no longer raise an exception in DBS3Reader getDBSSummaryInfo API when it cannot find any valid file in the block/dataset
* adapted the Workqueue code to handle an empty dictionary instead of the exception
* log every time we find a block where all files are invalid
* log every time we find a block that doesn't pass the runs restrictions
* post rejected work to the LogDB as a warning
  * TODO: make sure this warning remains there until the workflow gets archived (see #7808)