### PR TITLE
fix the replication on wmstats

### DIFF
--- a/src/python/WMCore/Services/WMStats/WMStatsWriter.py
+++ b/src/python/WMCore/Services/WMStats/WMStatsWriter.py
@@ -90,10 +90,10 @@ class WMStatsWriter(WMStatsReader):
             if doc['_id'] in existingDocs:
                 revList = existingDocs[doc['_id']].split('-')
                 # update the revision number
-                doc['_rev'] = "%s-%s" % (int(revList[0]) + 1, revList[1])
+                doc['_revisions'] = {"start":int(revList[0]) + 1,"ids":[str(int(revList[1]) + 1), revList[1]]}
             else:
                 # just send well formatted revision for the new documents which required by new_edits=False
-                doc['_rev'] = "1-123456789"
+                doc['_rev'] = "1-1234567890"
             self.couchDB.queue(doc)
 
         self.couchDB.commit(new_edits=False)


### PR DESCRIPTION
@amaltaro, Alan, I think this is the reason replication didn't work well. To make the replication work, it keeps the revision history. With just rev change it doesn't seem to have revision history stored.

I am testing this in my vm.
1. update the agent with thjs patch.
2. remove the cental wmstats data base
3. replicate the data again.

It seems  replication is very slow. It might be stuck though.I will check back tomorrow morning