### PR TITLE
Add CRIC flag for central services

### DIFF
--- a/src/python/WMCore/Services/SiteDB/SiteDBAPI.py
+++ b/src/python/WMCore/Services/SiteDB/SiteDBAPI.py
@@ -33,7 +33,7 @@ class SiteDBAPI(Service):
 
     def __init__(self, config={}, logger=None):
         config = dict(config)
-        if os.getenv("WMAGENT_USE_CRIC", False):
+        if os.getenv("WMAGENT_USE_CRIC", False) or os.getenv("WMCORE_USE_CRIC", False):
             # just to make sure we don't use SiteDB anywhere when CRIC flag is true
             config.setdefault('endpoint', "https://BLAH.cern.ch/sitedb/data/prod/")
         else:

--- a/src/python/WMCore/WorkQueue/Policy/Start/Block.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Block.py
@@ -29,7 +29,7 @@ class Block(StartPolicyInterface):
 
         # Initialize modifiers of the policy
         self.blockBlackListModifier = []
-        if os.getenv("WMAGENT_USE_CRIC", False):
+        if os.getenv("WMAGENT_USE_CRIC", False) or os.getenv("WMCORE_USE_CRIC", False):
             self.cric = CRIC()
         else:
             self.cric = None

--- a/src/python/WMCore/WorkQueue/Policy/Start/Dataset.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Dataset.py
@@ -28,7 +28,7 @@ class Dataset(StartPolicyInterface):
         self.args.setdefault('SliceSize', 1)
         self.lumiType = "NumberOfLumis"
         self.sites = []
-        if os.getenv("WMAGENT_USE_CRIC", False):
+        if os.getenv("WMAGENT_USE_CRIC", False) or os.getenv("WMCORE_USE_CRIC", False):
             self.cric = CRIC()
         else:
             self.cric = None

--- a/src/python/WMCore/WorkQueue/Policy/Start/ResubmitBlock.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/ResubmitBlock.py
@@ -50,7 +50,7 @@ class ResubmitBlock(StartPolicyInterface):
         self.unsupportedAlgos = ['WMBSMergeBySize', 'SiblingProcessingBased']
         self.defaultAlgo = self.fixedSizeChunk
         self.sites = []
-        if os.getenv("WMAGENT_USE_CRIC", False):
+        if os.getenv("WMAGENT_USE_CRIC", False) or os.getenv("WMCORE_USE_CRIC", False):
             self.cric = CRIC()
         else:
             self.cric = None

--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -150,7 +150,7 @@ class WorkQueue(WorkQueueBase):
         elif self.params.get('PopulateFilesets'):
             raise RuntimeError('CacheDir mandatory for local queue')
 
-        if os.getenv("WMAGENT_USE_CRIC", False):
+        if os.getenv("WMAGENT_USE_CRIC", False) or os.getenv("WMCORE_USE_CRIC", False):
             if self.params.get('CRIC'):
                 self.SiteDB = self.params['CRIC']  # FIXME: rename the attr to self.cric
             else:

--- a/src/python/WMCore/WorkQueue/WorkQueueUtils.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueUtils.py
@@ -38,7 +38,7 @@ def get_dbs(url):
         __dbses[url] = DBSReader(url)
         return __dbses[url]
 
-__USE_CRIC = os.getenv("WMAGENT_USE_CRIC", False)
+__USE_CRIC = os.getenv("WMAGENT_USE_CRIC", False) or os.getenv("WMCORE_USE_CRIC", False)
 __sitedb = None  # FIXME: rename it to __cric
 __cmsSiteNames = []
 

--- a/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/ResubmitBlock_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/ResubmitBlock_t.py
@@ -25,7 +25,7 @@ from WMQuality.Emulators.EmulatedUnitTestCase import EmulatedUnitTestCase
 
 from WMQuality.TestInitCouchApp import TestInitCouchApp
 from WMQuality.Emulators.WMSpecGenerator.WMSpecGenerator import createConfig
-from WMCore.Services.SiteDB.SiteDB import SiteDBJSON as SiteDB
+from WMCore.Services.CRIC.CRIC import CRIC
 
 class ResubmitBlockTest(EmulatedUnitTestCase):
     """
@@ -58,9 +58,9 @@ class ResubmitBlockTest(EmulatedUnitTestCase):
         self.acdcDBName = 'resubmitblock_t'
         self.validLocations = ['T2_US_Nebraska', 'T1_US_FNAL_Disk', 'T1_UK_RAL_Disk']
         self.siteWhitelist = ['T2_XX_SiteA']
-        siteDB = SiteDB()
+        cric = CRIC()
         #Convert phedex node name to a valid processing site name
-        self.PSNs = siteDB.PNNstoPSNs(self.validLocations)
+        self.PSNs = cric.PNNstoPSNs(self.validLocations)
         self.workflowName = 'dballest_ReReco_workflow'
         couchServer = CouchServer(dburl=self.couchUrl)
         self.acdcDB = couchServer.connectDatabase(self.acdcDBName, create=False)


### PR DESCRIPTION
Fixes #8834
Requires these deployment changes https://github.com/dmwm/deployment/pull/682

Created a new `WMCORE_USE_CRIC` environment variable for central services (ReqMgr2 and WorkQueue) such that we can switch between CRIC and SiteDB.