### PR TITLE
Allow acquired to failed status transition; allow Failed GQEs to exis

### DIFF
--- a/src/python/WMCore/ReqMgr/DataStructs/RequestStatus.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/RequestStatus.py
@@ -18,7 +18,8 @@ REQUEST_STATE_TRANSITION = {
                  "failed"],
 
     "acquired": ["running-open",
-                 "aborted"],
+                 "aborted",
+                 "failed"],
 
     "running-open": ["running-closed",
                      "force-complete",  # manual transition

--- a/src/python/WMCore/Services/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/Services/WorkQueue/WorkQueue.py
@@ -17,20 +17,27 @@ def convertWQElementsStatusToWFStatus(elementsStatusSet):
                        no Available Negotiating or Acquired status. all the work is in WMBS db (in agents)
     4. completed: if all the GQEs are in 'Done', 'Canceled' status.
                    - all work is finsed in wmbs (excluding cleanup, logcollect)
-    5. failed: if all the GQEs are in Failed status - this is not currently possible. failed status directly updated from GQ
+    5. failed: if all the GQEs are in Failed status. If the workflow has multiple GQEs and only a few are
+               in Failed status, then just follow the usual request status.
 
     CancelRequest status treated as transient status.
     '''
     if len(elementsStatusSet) == 0:
         return None
 
-    available = set(["Available", "Negotiating"])
+    available = set(["Available", "Negotiating", "Failed"])
     acquired = set(["Acquired"])
     running = set(["Running"])
-    completed = set(['Done', 'Canceled'])
+    completed = set(['Done', 'Canceled', "Failed"])
     failed = set(["Failed"])
 
-    if elementsStatusSet <= available:
+    if elementsStatusSet == acquired:
+        return "running-open"
+    elif elementsStatusSet == running:
+        return "running-closed"
+    elif elementsStatusSet == failed:
+        return "failed"
+    elif elementsStatusSet <= available:
         # if all the elements are Available status.
         return "acquired"
     elif elementsStatusSet <= completed:
@@ -47,7 +54,7 @@ def convertWQElementsStatusToWFStatus(elementsStatusSet):
         # Acquired or Assigned status
         return "running-closed"
     else:
-        # transitional status. Negociating status won't be changed.
+        # transitional status. Negotiating status won't be changed.
         return None
 
 

--- a/test/python/WMCore_t/Services_t/WorkQueue_t/WorkQueue_t.py
+++ b/test/python/WMCore_t/Services_t/WorkQueue_t/WorkQueue_t.py
@@ -226,6 +226,15 @@ class WorkQueueTest(EmulatedUnitTestCase):
         # workflows failed
         self.assertEqual(convertWQElementsStatusToWFStatus(set(["Failed"])), "failed")
 
+        # non-failed workflows but with Failed elements
+        self.assertEqual(convertWQElementsStatusToWFStatus(set(["Available", "Negotiating", "Acquired", "Failed"])), "running-open")
+        self.assertEqual(convertWQElementsStatusToWFStatus(set(["Available", "Negotiating", "Acquired", "Running", "Done", "Failed"])), "running-open")
+        self.assertEqual(convertWQElementsStatusToWFStatus(set(["Negotiating", "Acquired", "Running", "Done", "Canceled", "Failed"])), "running-open")
+        self.assertEqual(convertWQElementsStatusToWFStatus(set(["Running", "Failed"])), "running-closed")
+        self.assertEqual(convertWQElementsStatusToWFStatus(set(["Running", "Done", "Canceled", "Failed"])), "running-closed")
+        self.assertEqual(convertWQElementsStatusToWFStatus(set(["Done", "Failed"])), "completed")
+        self.assertEqual(convertWQElementsStatusToWFStatus(set(["Canceled", "Failed"])), "completed")
+
         # workflows in a temporary state, nothing to do with them yet
         self.assertIsNone(convertWQElementsStatusToWFStatus(set(["Done", "CancelRequested"])))
         self.assertIsNone(convertWQElementsStatusToWFStatus(set(["CancelRequested"])))


### PR DESCRIPTION
Fixes #8828 

Changes are:
* allow request transition from `acquired` to `failed`
* allow a request to have GQEs in `Failed` - while having other GQEs in valid status - such that the workflow proceeds with normal processing while that/those blocks are not processed. 