### PR TITLE
Delete LogDB wmstats docs when wfs are archived

### DIFF
--- a/src/python/WMCore/REST/CherryPyPeriodicTask.py
+++ b/src/python/WMCore/REST/CherryPyPeriodicTask.py
@@ -104,7 +104,7 @@ class PeriodicWorker(Thread):
 
     def heartBeatInfoToLogDB(self):
         if self.logDB:
-            self.logDB.delete(mtype="error", this_thread=True)
+            self.logDB.delete(mtype="error", this_thread=True, agent=False)
             self.logDB.post(mtype="info")
         return
 

--- a/src/python/WMCore/Services/LogDB/LogDB.py
+++ b/src/python/WMCore/Services/LogDB/LogDB.py
@@ -106,7 +106,7 @@ class LogDB(object):
         self.logger.debug("LogDB get_all_requests request, res=%s", res)
         return res
 
-    def delete(self, request=None, mtype=None, this_thread=False):
+    def delete(self, request=None, mtype=None, this_thread=False, agent=True):
         """
         Delete entry in LogDB for given request
         if mtype == None - delete all the log for that request
@@ -115,7 +115,7 @@ class LogDB(object):
         try:
             if request == None:
                 request = self.default_user
-            res = self.backend.delete(request, mtype, this_thread)
+            res = self.backend.delete(request, mtype, this_thread, agent)
         except Exception as exc:
             self.logger.error("LogDBBackend delete API failed, error=%s", str(exc))
             res = 'delete-error'
@@ -124,10 +124,12 @@ class LogDB(object):
 
     def cleanup(self, thr, backend='local'):
         """Clean-up back-end LogDB"""
+        docs = []
         try:
-            self.backend.cleanup(thr)
+            docs = self.backend.cleanup(thr)
         except Exception as exc:
             self.logger.error('LogDBBackend cleanup API failed, backend=%s, error=%s', backend, str(exc))
+        return docs
 
     def heartbeat_report(self):
         report = defaultdict(dict)

--- a/src/python/WMCore/Services/LogDB/LogDBBackend.py
+++ b/src/python/WMCore/Services/LogDB/LogDBBackend.py
@@ -182,3 +182,4 @@ class LogDBBackend(object):
         docs = self.db.loadView(self.design, self.tsview, spec)
         ids = [d['id'] for d in docs.get('rows', [])]
         self.db.bulkDeleteByIDs(ids)
+        return ids

--- a/src/python/WMCore/WMStats/CherryPyThreads/LogDBTasks.py
+++ b/src/python/WMCore/WMStats/CherryPyThreads/LogDBTasks.py
@@ -1,8 +1,8 @@
-'''
+"""
 Created on Aug 13, 2014
-
 @author: sryu
-'''
+"""
+
 from __future__ import (division, print_function)
 
 from WMCore.REST.CherryPyPeriodicTask import CherryPyPeriodicTask
@@ -11,12 +11,12 @@ from WMCore.Services.LogDB.LogDB import LogDB
 class LogDBTasks(CherryPyPeriodicTask):
 
     def __init__(self, rest, config):
-
         super(LogDBTasks, self).__init__(config)
+        self.logdb = LogDB(config.central_logdb_url, config.log_reporter)
 
     def setConcurrentTasks(self, config):
         """
-        sets the list of functions which
+        Set logDBCleanUp method to be executed in a polling cycle
         """
         self.concurrentTasks = [{'func': self.logDBCleanUp, 'duration': config.logDBCleanDuration}]
 
@@ -24,9 +24,8 @@ class LogDBTasks(CherryPyPeriodicTask):
         """
         gather active data statistics
         """
+        self.logger.info("Cleaning documents from LogDB WMStats")
+        docs = self.logdb.cleanup(config.keepDocsAge)
+        self.logger.info("Deleted %d old documents", len(docs))
 
-        logdb = LogDB(config.central_logdb_url, config.log_reporter)
-        logdb.cleanup(config.logDBCleanDuration)
-
-        self.logger.info("cleaned up log db")
         return

--- a/src/python/WMCore/WorkQueue/WorkQueueReqMgrInterface.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueReqMgrInterface.py
@@ -97,7 +97,7 @@ class WorkQueueReqMgrInterface(object):
 
                 self.logger.info("Processing request %s at %s" % (reqName, workLoadUrl))
                 units = queue.queueWork(workLoadUrl, request=reqName, team=team)
-                self.logdb.delete(reqName, "error", this_thread=True)
+                self.logdb.delete(reqName, "error", this_thread=True, agent=False)
             except TERMINAL_EXCEPTIONS as ex:
                 # fatal error - report back to ReqMgr
                 self.logger.error('Permanent failure processing request "%s": %s' % (reqName, str(ex)))
@@ -298,7 +298,7 @@ class WorkQueueReqMgrInterface(object):
             try:
                 self.logger.info("Processing request %s" % (reqName))
                 units = queue.addWork(requestName=reqName)
-                self.logdb.delete(reqName, 'error', True)
+                self.logdb.delete(reqName, 'error', True, agent=False)
             except (WorkQueueWMSpecError, WorkQueueNoWorkError) as ex:
                 # fatal error - but at least it was split the first time. Log and skip.
                 msg = 'Error adding further work to request "%s". Will try again later' % reqName


### PR DESCRIPTION
Fixes #7808

Changes are:
* when moving a request to archive state, first delete any logDB documents it might have and only then make the state transition
* WMStats LogDBTasks thread was kept around (we might completely remove it in the next month), but it's configuration was adapted such that it only deletes docs older than 90 days (if there will be any)

Deployment change in https://github.com/dmwm/deployment/pull/685