### PR TITLE
Distinguish between bad work units and work that doesnt pass constraints

### DIFF
--- a/src/python/WMCore/WorkQueue/Policy/Start/Block.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Block.py
@@ -122,6 +122,7 @@ class Block(StartPolicyInterface):
                 # Don't duplicate blocks rejected before or blocks that were included and therefore are now in the blacklist
                 continue
             if task.getLumiMask() and blockName not in maskedBlocks:
+                logging.warning("Block %s doesn't pass the lumi mask constraints", blockName)
                 self.rejectedWork.append(blockName)
                 continue
 
@@ -130,7 +131,7 @@ class Block(StartPolicyInterface):
             # - ideally they would be deleted but dbs can't delete blocks
             if int(block.get('NumberOfFiles', 0)) == 0:
                 logging.warning("Block %s being rejected for lack of valid files to process", blockName)
-                self.rejectedWork.append(blockName)
+                self.badWork.append(blockName)
                 continue
 
             # check lumi restrictions

--- a/src/python/WMCore/WorkQueue/Policy/Start/Dataset.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Dataset.py
@@ -108,7 +108,7 @@ class Dataset(StartPolicyInterface):
             blockSummary = dbs.getDBSSummaryInfo(block=blockName)
             if int(blockSummary.get('NumberOfFiles', 0)) == 0:
                 logging.warning("Block %s being rejected for lack of valid files to process", blockName)
-                self.rejectedWork.append(blockName)
+                self.badWork.append(blockName)
                 continue
 
             if self.args['SliceType'] == 'NumberOfRuns':
@@ -117,6 +117,7 @@ class Dataset(StartPolicyInterface):
             # check lumi restrictions
             if lumiMask:
                 if blockName not in maskedBlocks:
+                    logging.warning("Block %s doesn't pass the lumi mask constraints", blockName)
                     self.rejectedWork.append(blockName)
                     continue
 

--- a/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
@@ -29,6 +29,7 @@ class StartPolicyInterface(PolicyInterface):
         self.lumi = None
         self.couchdb = None
         self.rejectedWork = []  # List of inputs that were rejected
+        self.badWork = []  # list of bad work unit (e.g. without any valid files)
         self.pileupData = {}
 
     def split(self):
@@ -170,7 +171,7 @@ class StartPolicyInterface(PolicyInterface):
             error = WorkQueueNoWorkError(self.wmspec, msg)
             raise error
 
-        return self.workQueueElements, self.rejectedWork
+        return self.workQueueElements, self.rejectedWork, self.badWork
 
     def dbs(self, dbs_url=None):
         """Get DBSReader"""

--- a/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Block_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Block_t.py
@@ -58,7 +58,7 @@ class BlockTestCase(EmulatedUnitTestCase):
                                  inputDataset.tier)
         dbs = {inputDataset.dbsurl: DBSReader(inputDataset.dbsurl)}
         for task in Tier1ReRecoWorkload.taskIterator():
-            units, _ = Block(**self.splitArgs)(Tier1ReRecoWorkload, task)
+            units, _, _ = Block(**self.splitArgs)(Tier1ReRecoWorkload, task)
             self.assertEqual(47, len(units))
             for unit in units:
                 self.assertEqual(69, unit['Priority'])
@@ -84,7 +84,7 @@ class BlockTestCase(EmulatedUnitTestCase):
         dbs = {inputDataset.dbsurl: DBSReader(inputDataset.dbsurl)}
 
         for task in MultiTaskProcessingWorkload.taskIterator():
-            units, _ = Block(**self.splitArgs)(MultiTaskProcessingWorkload, task)
+            units, _, _ = Block(**self.splitArgs)(MultiTaskProcessingWorkload, task)
             self.assertEqual(58, len(units))
 
             for unit in units:
@@ -110,9 +110,10 @@ class BlockTestCase(EmulatedUnitTestCase):
                                   assignArgs={'SiteWhitelist': ['T2_XX_SiteA']})
 
         task = getFirstTask(workload)
-        units, rejectedWork = Block(**self.splitArgs)(workload, task)
+        units, rejectedWork, badWork = Block(**self.splitArgs)(workload, task)
         self.assertEqual(len(units), 47)
         self.assertEqual(len(rejectedWork), 0)
+        self.assertEqual(len(badWork), 0)
 
         # Block blacklist
         newArgs = {}
@@ -122,9 +123,10 @@ class BlockTestCase(EmulatedUnitTestCase):
                                   assignArgs={'SiteWhitelist': ['T2_XX_SiteA']})
 
         task = getFirstTask(workload)
-        units, rejectedWork = Block(**self.splitArgs)(workload, task)
+        units, rejectedWork, badWork = Block(**self.splitArgs)(workload, task)
         self.assertEqual(len(units), 46)
         self.assertEqual(len(rejectedWork), 0)
+        self.assertEqual(len(badWork), 0)
         self.assertNotEqual(units[0]['Inputs'].keys(), newArgs['BlockBlacklist'])
 
         # Block Whitelist
@@ -135,9 +137,10 @@ class BlockTestCase(EmulatedUnitTestCase):
                                   assignArgs={'SiteWhitelist': ['T2_XX_SiteA']})
 
         task = getFirstTask(workload)
-        units, rejectedWork = Block(**self.splitArgs)(workload, task)
+        units, rejectedWork, badWork = Block(**self.splitArgs)(workload, task)
         self.assertEqual(len(units), 1)
         self.assertEqual(len(rejectedWork), 0)
+        self.assertEqual(len(badWork), 0)
         self.assertEqual(units[0]['Inputs'].keys(), newArgs['BlockWhitelist'])
 
         # Block Mixed Whitelist
@@ -149,9 +152,10 @@ class BlockTestCase(EmulatedUnitTestCase):
                                   assignArgs={'SiteWhitelist': ['T2_XX_SiteA']})
 
         task = getFirstTask(workload)
-        units, rejectedWork = Block(**self.splitArgs)(workload, task)
+        units, rejectedWork, badWork = Block(**self.splitArgs)(workload, task)
         self.assertEqual(len(units), 1)
         self.assertEqual(len(rejectedWork), 0)
+        self.assertEqual(len(badWork), 0)
         self.assertEqual(units[0]['Inputs'].keys(), newArgs['BlockWhitelist'])
 
         # Run Whitelist
@@ -162,9 +166,10 @@ class BlockTestCase(EmulatedUnitTestCase):
                                   assignArgs={'SiteWhitelist': ['T2_XX_SiteA']})
 
         task = getFirstTask(workload)
-        units, rejectedWork = Block(**self.splitArgs)(workload, task)
+        units, rejectedWork, badWork = Block(**self.splitArgs)(workload, task)
         self.assertEqual(len(units), 1)
         self.assertEqual(len(rejectedWork), 46)
+        self.assertEqual(len(badWork), 0)
         self.assertEqual(units[0]['Inputs'].keys(), [dataset + '#03fe83c2-0c23-11e1-b764-003048caaace'])
 
         # Run Blacklist
@@ -175,9 +180,10 @@ class BlockTestCase(EmulatedUnitTestCase):
                                   assignArgs={'SiteWhitelist': ['T2_XX_SiteA']})
 
         task = getFirstTask(workload)
-        units, rejectedWork = Block(**self.splitArgs)(workload, task)
+        units, rejectedWork, badWork = Block(**self.splitArgs)(workload, task)
         self.assertEqual(len(units), 45)
         self.assertEqual(len(rejectedWork), 2)
+        self.assertEqual(len(badWork), 0)
         self.assertEqual(units[0]['Inputs'].keys(), [dataset + '#217ea8d8-0c4f-11e1-b764-003048caaace'])
 
         # Run Mixed Whitelist
@@ -188,9 +194,10 @@ class BlockTestCase(EmulatedUnitTestCase):
                                   assignArgs={'SiteWhitelist': ['T2_XX_SiteA']})
 
         task = getFirstTask(workload)
-        units, rejectedWork = Block(**self.splitArgs)(workload, task)
+        units, rejectedWork, badWork = Block(**self.splitArgs)(workload, task)
         self.assertEqual(len(units), 1)
         self.assertEqual(len(rejectedWork), 46)
+        self.assertEqual(len(badWork), 0)
         self.assertEqual(units[0]['Inputs'].keys(), [dataset + '#b469f816-0946-11e1-8347-003048caaace'])
 
     def testLumiMask(self):
@@ -203,14 +210,15 @@ class BlockTestCase(EmulatedUnitTestCase):
 
         # Block blacklist
         lumiWorkload = rerecoWorkload('ReRecoWorkload', rerecoArgs2,
-                                       assignArgs={'SiteWhitelist': ['T2_XX_SiteA']})
+                                      assignArgs={'SiteWhitelist': ['T2_XX_SiteA']})
         task = getFirstTask(lumiWorkload)
-        #task.data.input.splitting.runs = ['1']
+        # task.data.input.splitting.runs = ['1']
         task.data.input.splitting.runs = ['180992']
         task.data.input.splitting.lumis = ['1,1']
-        units, rejectedWork = Block(**self.splitArgs)(lumiWorkload, task)
+        units, rejectedWork, badWork = Block(**self.splitArgs)(lumiWorkload, task)
         self.assertEqual(len(units), 1)
         self.assertEqual(len(rejectedWork), 46)
+        self.assertEqual(len(badWork), 0)
 
     def testDataDirectiveFromQueue(self):
         """Test data directive from queue"""
@@ -223,7 +231,8 @@ class BlockTestCase(EmulatedUnitTestCase):
         dbs = {inputDataset.dbsurl: DBSReader(inputDataset.dbsurl)}
         for task in Tier1ReRecoWorkload.taskIterator():
             # Take dataset and force to run over only 1 block
-            units, _ = Block(**self.splitArgs)(Tier1ReRecoWorkload, task, {dataset + '#28315b28-0c5c-11e1-b764-003048caaace': []})
+            units, _, _ = Block(**self.splitArgs)(Tier1ReRecoWorkload, task,
+                                                  {dataset + '#28315b28-0c5c-11e1-b764-003048caaace': []})
             self.assertEqual(1, len(units))
             for unit in units:
                 self.assertEqual(1, unit['Jobs'])
@@ -241,11 +250,12 @@ class BlockTestCase(EmulatedUnitTestCase):
         Tier1ReRecoWorkload.setStartPolicy('Block', **splitArgs)
 
         for task in Tier1ReRecoWorkload.taskIterator():
-            units, rejectedWork = Block(**splitArgs)(Tier1ReRecoWorkload, task)
+            units, rejectedWork, badWork = Block(**splitArgs)(Tier1ReRecoWorkload, task)
             self.assertEqual(47, len(units))
             for unit in units:
                 self.assertTrue(1 <= unit['Jobs'])
             self.assertEqual(0, len(rejectedWork))
+            self.assertEqual(0, len(badWork))
 
     def testRunWhitelist(self):
         """
@@ -263,10 +273,11 @@ class BlockTestCase(EmulatedUnitTestCase):
 
         dbs = {inputDataset.dbsurl: DBSReader(inputDataset.dbsurl)}
         for task in Tier1ReRecoWorkload.taskIterator():
-            units, rejectedWork = Block(**splitArgs)(Tier1ReRecoWorkload, task)
+            units, rejectedWork, badWork = Block(**splitArgs)(Tier1ReRecoWorkload, task)
             # Blocks 1 and 2 match run distribution
             self.assertEqual(2, len(units))
             self.assertEqual(len(rejectedWork), 45)
+            self.assertEqual(len(badWork), 0)
             # Check number of jobs in element match number for
             # dataset in run whitelist
             wq_jobs = 0
@@ -327,11 +338,9 @@ class BlockTestCase(EmulatedUnitTestCase):
                                  inputDataset.tier)
         dbs = {inputDataset.dbsurl: DBSReader(inputDataset.dbsurl)}
         for task in parentProcSpec.taskIterator():
-            units, _ = Block(**self.splitArgs)(parentProcSpec, task)
+            units, _, _ = Block(**self.splitArgs)(parentProcSpec, task)
             self.assertEqual(47, len(units))
             for unit in units:
-                import pdb
-                pdb.set_trace()
                 self.assertTrue(1 <= unit['Jobs'])
                 self.assertEqual(parentProcSpec, unit['WMSpec'])
                 self.assertEqual(task, unit['Task'])
@@ -362,7 +371,7 @@ class BlockTestCase(EmulatedUnitTestCase):
                                  inputDataset.tier)
         dbs = {inputDataset.dbsurl: DBSReader(inputDataset.dbsurl)}
         for task in Tier1ReRecoWorkload.taskIterator():
-            units, _ = policyInstance(Tier1ReRecoWorkload, task)
+            units, _, _ = policyInstance(Tier1ReRecoWorkload, task)
             self.assertEqual(47, len(units))
             blocks = []  # fill with blocks as we get work units for them
             inputs = {}
@@ -420,7 +429,7 @@ class BlockTestCase(EmulatedUnitTestCase):
         if it is present in the workload.
         """
         for task in MultiTaskProcessingWorkload.taskIterator():
-            units, _ = Block(**self.splitArgs)(MultiTaskProcessingWorkload, task)
+            units, _, _ = Block(**self.splitArgs)(MultiTaskProcessingWorkload, task)
             self.assertEqual(58, len(units))
             for unit in units:
                 pileupData = unit["PileupData"]
@@ -445,7 +454,7 @@ class BlockTestCase(EmulatedUnitTestCase):
         task.data.input.splitting.lumis = ['1,50,60,70', '1,1']
         lumiMask = LumiList(compactList={'206371': [[1, 50], [60, 70]], '180899': [[1, 1]], })
 
-        units, dummyRejectedWork = Block(**self.splitArgs)(Tier1ReRecoWorkload, task)
+        units, _, _ = Block(**self.splitArgs)(Tier1ReRecoWorkload, task)
 
         nLumis = 0
         for unit in units:

--- a/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Dataset_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Dataset_t.py
@@ -4,13 +4,14 @@
 """
 
 import unittest
-from WMCore_t.WorkQueue_t.WorkQueue_t import getFirstTask
+
 from WMCore_t.WMSpec_t.samples.MultiTaskProcessingWorkload \
     import workload as MultiTaskProcessingWorkload
+from WMCore_t.WorkQueue_t.WorkQueue_t import getFirstTask
 
 from WMCore.Services.DBS.DBSErrors import DBSReaderError
-from WMCore.WMSpec.StdSpecs.ReReco import ReRecoWorkloadFactory
 from WMCore.WMSpec.StdSpecs.DQMHarvest import DQMHarvestWorkloadFactory
+from WMCore.WMSpec.StdSpecs.ReReco import ReRecoWorkloadFactory
 from WMCore.WorkQueue.Policy.Start.Dataset import Dataset
 from WMCore.WorkQueue.WorkQueueExceptions import (WorkQueueWMSpecError, WorkQueueNoWorkError)
 from WMQuality.Emulators.EmulatedUnitTestCase import EmulatedUnitTestCase
@@ -64,7 +65,7 @@ class DatasetTestCase(EmulatedUnitTestCase):
         inputDataset = getFirstTask(DQMHarvWorkload).getInputDatasetPath()
 
         for task in DQMHarvWorkload.taskIterator():
-            units, _ = Dataset(**splitArgs)(DQMHarvWorkload, task)
+            units, _, _ = Dataset(**splitArgs)(DQMHarvWorkload, task)
             self.assertEqual(1, len(units))
             for unit in units:
                 self.assertEqual(47, unit['Jobs'])
@@ -89,7 +90,7 @@ class DatasetTestCase(EmulatedUnitTestCase):
         inputDataset = getFirstTask(DQMHarvWorkload).getInputDatasetPath()
 
         for task in DQMHarvWorkload.taskIterator():
-            units, _ = Dataset(**splitArgs)(DQMHarvWorkload, task)
+            units, _, _ = Dataset(**splitArgs)(DQMHarvWorkload, task)
             self.assertEqual(1, len(units))
             for unit in units:
                 self.assertEqual(4, unit['Jobs'])
@@ -114,7 +115,7 @@ class DatasetTestCase(EmulatedUnitTestCase):
         inputDataset = getFirstTask(DQMHarvWorkload).getInputDatasetPath()
 
         for task in DQMHarvWorkload.taskIterator():
-            units, _ = Dataset(**splitArgs)(DQMHarvWorkload, task)
+            units, _, _ = Dataset(**splitArgs)(DQMHarvWorkload, task)
             self.assertEqual(1, len(units))
             for unit in units:
                 self.assertEqual(2, unit['Jobs'])
@@ -139,7 +140,7 @@ class DatasetTestCase(EmulatedUnitTestCase):
         inputDataset = getFirstTask(DQMHarvWorkload).getInputDatasetPath()
 
         for task in DQMHarvWorkload.taskIterator():
-            units, _ = Dataset(**splitArgs)(DQMHarvWorkload, task)
+            units, _, _ = Dataset(**splitArgs)(DQMHarvWorkload, task)
             self.assertEqual(1, len(units))
             for unit in units:
                 self.assertEqual(1, unit['Jobs'])
@@ -161,7 +162,7 @@ class DatasetTestCase(EmulatedUnitTestCase):
         Tier1ReRecoWorkload.setStartPolicy('Dataset', **splitArgs)
         inputDataset = getFirstTask(Tier1ReRecoWorkload).getInputDatasetPath()
         for task in Tier1ReRecoWorkload.taskIterator():
-            units, _ = Dataset(**splitArgs)(Tier1ReRecoWorkload, task)
+            units, _, _ = Dataset(**splitArgs)(Tier1ReRecoWorkload, task)
             self.assertEqual(1, len(units))
             for unit in units:
                 self.assertEqual(15, unit['Jobs'])
@@ -182,7 +183,7 @@ class DatasetTestCase(EmulatedUnitTestCase):
             inputDataset = task.getInputDatasetPath()
             datasets.append(inputDataset)
         for task in MultiTaskProcessingWorkload.taskIterator():
-            units, _ = Dataset(**splitArgs)(MultiTaskProcessingWorkload, task)
+            units, _, _ = Dataset(**splitArgs)(MultiTaskProcessingWorkload, task)
             self.assertEqual(1, len(units))
             for unit in units:
                 self.assertEqual(22, unit['Jobs'])
@@ -202,7 +203,7 @@ class DatasetTestCase(EmulatedUnitTestCase):
         Tier1ReRecoWorkload.setStartPolicy('Dataset', **splitArgs)
         Tier1ReRecoWorkload.setSiteWhitelist(["T2_XX_SiteA", "T2_XX_SiteB", "T2_XX_SiteC"])
         for task in Tier1ReRecoWorkload.taskIterator():
-            units, _ = Dataset(**splitArgs)(Tier1ReRecoWorkload, task)
+            units, _, _ = Dataset(**splitArgs)(Tier1ReRecoWorkload, task)
             self.assertEqual(1, len(units))
             for unit in units:
                 self.assertEqual(2428, unit['Jobs'])
@@ -221,11 +222,11 @@ class DatasetTestCase(EmulatedUnitTestCase):
         parentProcArgs2.update(parentProcArgs)
         parentProcArgs2.update({'InputDataset': '/SingleMu/CMSSW_6_2_0_pre4-PRE_61_V1_RelVal_mu2012A-v1/RECO'})
         parentProcSpec = rerecoWorkload('ReRecoWorkload', parentProcArgs2,
-                                             assignArgs={'SiteWhitelist': ['T2_XX_SiteA']})
+                                        assignArgs={'SiteWhitelist': ['T2_XX_SiteA']})
         parentProcSpec.setStartPolicy('Dataset', **splitArgs)
         inputDataset = getFirstTask(parentProcSpec).getInputDatasetPath()
         for task in parentProcSpec.taskIterator():
-            units, _ = Dataset(**splitArgs)(parentProcSpec, task)
+            units, _, _ = Dataset(**splitArgs)(parentProcSpec, task)
             self.assertEqual(1, len(units))
             for unit in units:
                 self.assertEqual(847, unit['Jobs'])

--- a/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/MonteCarlo_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/MonteCarlo_t.py
@@ -35,7 +35,7 @@ class MonteCarloTestCase(EmulatedUnitTestCase):
         getFirstTask(BasicProductionWorkload).addProduction(totalEvents=totalevents)
         getFirstTask(BasicProductionWorkload).setSiteWhitelist(['T2_XX_SiteA', 'T2_XX_SiteB'])
         for task in BasicProductionWorkload.taskIterator():
-            units, _ = MonteCarlo(**splitArgs)(BasicProductionWorkload, task)
+            units, _, _ = MonteCarlo(**splitArgs)(BasicProductionWorkload, task)
 
             SliceSize = BasicProductionWorkload.startPolicyParameters()['SliceSize']
             self.assertEqual(math.ceil(totalevents / (SliceSize * splitArgs['MaxJobsPerElement'])), len(units))
@@ -83,7 +83,7 @@ class MonteCarloTestCase(EmulatedUnitTestCase):
         getFirstTask(LHEProductionWorkload).addProduction(totalEvents=totalevents)
         getFirstTask(LHEProductionWorkload).setSiteWhitelist(['T2_XX_SiteA', 'T2_XX_SiteB'])
         for task in LHEProductionWorkload.taskIterator():
-            units, _ = MonteCarlo(**splitArgs)(LHEProductionWorkload, task)
+            units, _, _ = MonteCarlo(**splitArgs)(LHEProductionWorkload, task)
 
             SliceSize = LHEProductionWorkload.startPolicyParameters()['SliceSize']
             self.assertEqual(math.ceil(totalevents / (SliceSize * splitArgs['MaxJobsPerElement'])), len(units))
@@ -132,7 +132,7 @@ class MonteCarloTestCase(EmulatedUnitTestCase):
         getFirstTask(LHEProductionWorkload).addProduction(totalEvents=totalevents)
         getFirstTask(LHEProductionWorkload).setSiteWhitelist(['T2_XX_SiteA', 'T2_XX_SiteB'])
         for task in LHEProductionWorkload.taskIterator():
-            units, _ = MonteCarlo(**splitArgs)(LHEProductionWorkload, task)
+            units, _, _ = MonteCarlo(**splitArgs)(LHEProductionWorkload, task)
 
             SliceSize = LHEProductionWorkload.startPolicyParameters()['SliceSize']
             self.assertEqual(math.ceil(totalevents / (SliceSize * splitArgs['MaxJobsPerElement'])), len(units))
@@ -173,7 +173,7 @@ class MonteCarloTestCase(EmulatedUnitTestCase):
         getFirstTask(LHEProductionWorkload).setFirstEventAndLumi(50, 100)
         getFirstTask(LHEProductionWorkload).setSiteWhitelist(['T2_XX_SiteA', 'T2_XX_SiteB'])
         for task in LHEProductionWorkload.taskIterator():
-            units, _ = MonteCarlo(**splitArgs)(LHEProductionWorkload, task)
+            units, _, _ = MonteCarlo(**splitArgs)(LHEProductionWorkload, task)
 
             SliceSize = LHEProductionWorkload.startPolicyParameters()['SliceSize']
             self.assertEqual(math.ceil(totalevents / (SliceSize * splitArgs['MaxJobsPerElement'])), len(units))
@@ -207,7 +207,7 @@ class MonteCarloTestCase(EmulatedUnitTestCase):
         getFirstTask(MultiMergeProductionWorkload).setSiteWhitelist(['T2_XX_SiteA', 'T2_XX_SiteB'])
         getFirstTask(MultiMergeProductionWorkload).setFirstEventAndLumi(1, 1)
         for task in MultiMergeProductionWorkload.taskIterator():
-            units, _ = MonteCarlo(**self.splitArgs)(MultiMergeProductionWorkload, task)
+            units, _, _ = MonteCarlo(**self.splitArgs)(MultiMergeProductionWorkload, task)
 
             self.assertEqual(10.0, len(units))
             for unit in units:
@@ -222,7 +222,7 @@ class MonteCarloTestCase(EmulatedUnitTestCase):
         for task in MultiTaskProductionWorkload.taskIterator():
             count += 1
             task.setFirstEventAndLumi(1, 1)
-            units, _ = MonteCarlo(**self.splitArgs)(MultiTaskProductionWorkload, task)
+            units, _, _ = MonteCarlo(**self.splitArgs)(MultiTaskProductionWorkload, task)
 
             self.assertEqual(10 * count, len(units))
             for unit in units:

--- a/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/ResubmitBlock_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/ResubmitBlock_t.py
@@ -11,21 +11,20 @@ Created on Feb 19, 2013
 
 import os
 import unittest
-
 from random import choice
 
-from WMCore.Database.CMSCouch import CouchServer
 from WMCore.DataStructs.File import File
 from WMCore.DataStructs.Run import Run
+from WMCore.Database.CMSCouch import CouchServer
 from WMCore.GroupUser.User import makeUser
+from WMCore.Services.CRIC.CRIC import CRIC
 from WMCore.WMSpec.StdSpecs.ReReco import ReRecoWorkloadFactory
 from WMCore.WorkQueue.Policy.Start.ResubmitBlock import ResubmitBlock
 from WMCore.WorkQueue.WorkQueueExceptions import WorkQueueNoWorkError, WorkQueueWMSpecError
 from WMQuality.Emulators.EmulatedUnitTestCase import EmulatedUnitTestCase
-
-from WMQuality.TestInitCouchApp import TestInitCouchApp
 from WMQuality.Emulators.WMSpecGenerator.WMSpecGenerator import createConfig
-from WMCore.Services.CRIC.CRIC import CRIC
+from WMQuality.TestInitCouchApp import TestInitCouchApp
+
 
 class ResubmitBlockTest(EmulatedUnitTestCase):
     """
@@ -59,7 +58,7 @@ class ResubmitBlockTest(EmulatedUnitTestCase):
         self.validLocations = ['T2_US_Nebraska', 'T1_US_FNAL_Disk', 'T1_UK_RAL_Disk']
         self.siteWhitelist = ['T2_XX_SiteA']
         cric = CRIC()
-        #Convert phedex node name to a valid processing site name
+        # Convert phedex node name to a valid processing site name
         self.PSNs = cric.PNNstoPSNs(self.validLocations)
         self.workflowName = 'dballest_ReReco_workflow'
         couchServer = CouchServer(dburl=self.couchUrl)
@@ -87,19 +86,21 @@ class ResubmitBlockTest(EmulatedUnitTestCase):
         Get a ACDC spec for the processing task of a ReReco workload
         """
         if splittingArgs is None:
-            splittingArgs = {'lumis_per_job' : 8}
+            splittingArgs = {'lumis_per_job': 8}
         factory = ReRecoWorkloadFactory()
         rerecoArgs = ReRecoWorkloadFactory.getTestArguments()
         rerecoArgs["ConfigCacheID"] = createConfig(rerecoArgs["CouchDBName"])
         rerecoArgs["Requestor"] = self.user
         rerecoArgs["Group"] = self.group
         Tier1ReRecoWorkload = factory.factoryWorkloadConstruction(self.workflowName, rerecoArgs)
-        Tier1ReRecoWorkload.truncate('ACDC_%s' % self.workflowName, '/%s/DataProcessing' % self.workflowName, self.couchUrl, self.acdcDBName)
-        Tier1ReRecoWorkload.setJobSplittingParameters('/ACDC_%s/DataProcessing' % self.workflowName, splittingAlgo, splittingArgs)
+        Tier1ReRecoWorkload.truncate('ACDC_%s' % self.workflowName, '/%s/DataProcessing' % self.workflowName,
+                                     self.couchUrl, self.acdcDBName)
+        Tier1ReRecoWorkload.setJobSplittingParameters('/ACDC_%s/DataProcessing' % self.workflowName, splittingAlgo,
+                                                      splittingArgs)
         Tier1ReRecoWorkload.setSiteWhitelist(self.siteWhitelist)
         if setLocationFlag:
             Tier1ReRecoWorkload.setTrustLocationFlag(setLocationFlag)
-#            Tier1ReRecoWorkload.setSiteWhitelist(self.siteWhitelist)
+        #            Tier1ReRecoWorkload.setSiteWhitelist(self.siteWhitelist)
         return Tier1ReRecoWorkload
 
     def getMergeACDCSpec(self, splittingAlgo='ParentlessMergeBySize', splittingArgs=None):
@@ -117,7 +118,9 @@ class ResubmitBlockTest(EmulatedUnitTestCase):
         rerecoArgs["Requestor"] = self.user
         rerecoArgs["Group"] = self.group
         Tier1ReRecoWorkload = factory.factoryWorkloadConstruction(self.workflowName, rerecoArgs)
-        Tier1ReRecoWorkload.truncate('ACDC_%s' % self.workflowName, '/%s/DataProcessing/DataProcessingMergeRECOoutput' % self.workflowName, self.couchUrl, self.acdcDBName)
+        Tier1ReRecoWorkload.truncate('ACDC_%s' % self.workflowName,
+                                     '/%s/DataProcessing/DataProcessingMergeRECOoutput' % self.workflowName,
+                                     self.couchUrl, self.acdcDBName)
         Tier1ReRecoWorkload.setJobSplittingParameters('/ACDC_%s/DataProcessingMergeRECOoutput' % self.workflowName,
                                                       splittingAlgo, splittingArgs)
         return Tier1ReRecoWorkload
@@ -130,9 +133,6 @@ class ResubmitBlockTest(EmulatedUnitTestCase):
         and merge
         """
         filesetName = '/%s/DataProcessing' % self.workflowName
-        owner = self.user
-        group = self.group
-
 
         for i in range(numFiles):
             for j in range(1, lumisPerFile + 1, lumisPerACDCRecord):
@@ -140,27 +140,23 @@ class ResubmitBlockTest(EmulatedUnitTestCase):
                 acdcFile = File(lfn=lfn, size=100, events=250, locations=self.validLocations, merged=1)
                 run = Run(i + 1, *range(j, min(j + lumisPerACDCRecord, lumisPerFile + 1)))
                 acdcFile.addRun(run)
-                acdcDoc = {'collection_name' : self.workflowName,
-                           'collection_type' : 'ACDC.CollectionTypes.DataCollection',
-                           'files' : {lfn : acdcFile},
-                           'fileset_name' : filesetName,
-                           'owner' : {'user': owner,
-                                      'group' : group}}
+                acdcDoc = {'collection_name': self.workflowName,
+                           'collection_type': 'ACDC.CollectionTypes.DataCollection',
+                           'files': {lfn: acdcFile},
+                           'fileset_name': filesetName}
                 self.acdcDB.queue(acdcDoc)
-        filesetName = '/%s/DataProcessing/DataProcessingMergeRECOoutput' % self.workflowName
 
+        filesetName = '/%s/DataProcessing/DataProcessingMergeRECOoutput' % self.workflowName
         for i in range(numFiles):
             for j in range(1, lumisPerFile + 1, lumisPerACDCRecord):
                 lfn = '/store/unmerged/b/%d' % i
                 acdcFile = File(lfn=lfn, size=100, events=250, locations=set([choice(self.validLocations)]), merged=0)
                 run = Run(i + 1, *range(j, min(j + lumisPerACDCRecord, lumisPerFile + 1)))
                 acdcFile.addRun(run)
-                acdcDoc = {'collection_name' : self.workflowName,
-                           'collection_type' : 'ACDC.CollectionTypes.DataCollection',
-                           'files' : {lfn : acdcFile},
-                           'fileset_name' : filesetName,
-                           'owner' : {'user': owner,
-                                      'group' : group}}
+                acdcDoc = {'collection_name': self.workflowName,
+                           'collection_type': 'ACDC.CollectionTypes.DataCollection',
+                           'files': {lfn: acdcFile},
+                           'fileset_name': filesetName}
                 self.acdcDB.queue(acdcDoc)
         self.acdcDB.commit()
 
@@ -181,7 +177,7 @@ class ResubmitBlockTest(EmulatedUnitTestCase):
             self.assertRaises(WorkQueueNoWorkError, policy, acdcWorkload, task)
 
         # FixedSizeChunks
-        acdcWorkload = self.getProcessingACDCSpec('FileBased', {'files_per_job' : 2000})
+        acdcWorkload = self.getProcessingACDCSpec('FileBased', {'files_per_job': 2000})
         for task in acdcWorkload.taskIterator():
             policy = ResubmitBlock()
             self.assertRaises(WorkQueueNoWorkError, policy, acdcWorkload, task)
@@ -210,11 +206,11 @@ class ResubmitBlockTest(EmulatedUnitTestCase):
         use a ReReco ACDC of the processing task.
         """
         self.stuffACDCDatabase()
-        acdcWorkload = self.getProcessingACDCSpec('FileBased', {'files_per_job' : 5})
+        acdcWorkload = self.getProcessingACDCSpec('FileBased', {'files_per_job': 5})
         acdcWorkload.data.request.priority = 10000
         for task in acdcWorkload.taskIterator():
             policy = ResubmitBlock()
-            units, _ = policy(acdcWorkload, task)
+            units, _, _ = policy(acdcWorkload, task)
             self.assertEqual(len(units), 2)
             for unit in units:
                 self.assertEqual(len(unit['Inputs']), 1)
@@ -227,10 +223,10 @@ class ResubmitBlockTest(EmulatedUnitTestCase):
                 self.assertEqual(500, unit['NumberOfLumis'])
                 self.assertEqual(250, unit['NumberOfFiles'])
                 self.assertEqual(62500, unit['NumberOfEvents'])
-                self.assertEqual(unit['ACDC'], {'database' : self.acdcDBName,
-                                                'fileset' : '/%s/DataProcessing' % self.workflowName,
-                                                'collection' : self.workflowName,
-                                                'server' : self.couchUrl})
+                self.assertEqual(unit['ACDC'], {'database': self.acdcDBName,
+                                                'fileset': '/%s/DataProcessing' % self.workflowName,
+                                                'collection': self.workflowName,
+                                                'server': self.couchUrl})
         return
 
     def testSingleChunksSplit(self):
@@ -243,11 +239,11 @@ class ResubmitBlockTest(EmulatedUnitTestCase):
         independent.
         """
         self.stuffACDCDatabase()
-        acdcWorkload = self.getProcessingACDCSpec('LumiBased', {'lumis_per_job' : 10})
+        acdcWorkload = self.getProcessingACDCSpec('LumiBased', {'lumis_per_job': 10})
         acdcWorkload.data.request.priority = 10000
         for task in acdcWorkload.taskIterator():
             policy = ResubmitBlock()
-            units, _ = policy(acdcWorkload, task)
+            units, _, _ = policy(acdcWorkload, task)
             self.assertEqual(len(units), 1)
             for unit in units:
                 self.assertEqual(len(unit['Inputs']), 1)
@@ -260,10 +256,10 @@ class ResubmitBlockTest(EmulatedUnitTestCase):
                 self.assertEqual(1000, unit['NumberOfLumis'])
                 self.assertEqual(500, unit['NumberOfFiles'])
                 self.assertEqual(125000, unit['NumberOfEvents'])
-                self.assertEqual(unit['ACDC'], {'database' : self.acdcDBName,
-                                                'fileset' : '/%s/DataProcessing' % self.workflowName,
-                                                'collection' : self.workflowName,
-                                                'server' : self.couchUrl})
+                self.assertEqual(unit['ACDC'], {'database': self.acdcDBName,
+                                                'fileset': '/%s/DataProcessing' % self.workflowName,
+                                                'collection': self.workflowName,
+                                                'server': self.couchUrl})
 
     def testMergeACDCSpec(self):
         """
@@ -276,7 +272,7 @@ class ResubmitBlockTest(EmulatedUnitTestCase):
         acdcWorkload.data.request.priority = 10000
         for task in acdcWorkload.taskIterator():
             policy = ResubmitBlock()
-            units, _ = policy(acdcWorkload, task)
+            units, _, _ = policy(acdcWorkload, task)
 
             self.assertEqual(len(units), 1)
             for unit in units:
@@ -290,10 +286,10 @@ class ResubmitBlockTest(EmulatedUnitTestCase):
                 self.assertEqual(1000, unit['NumberOfLumis'])
                 self.assertEqual(500, unit['NumberOfFiles'])
                 self.assertEqual(125000, unit['NumberOfEvents'])
-                self.assertEqual(unit['ACDC'], {'database' : self.acdcDBName,
-                                                'fileset' : '/%s/DataProcessing/DataProcessingMergeRECOoutput' % self.workflowName,
-                                                'collection' : self.workflowName,
-                                                'server' : self.couchUrl})
+                self.assertEqual(unit['ACDC'], {'database': self.acdcDBName,
+                                                'fileset': '/%s/DataProcessing/DataProcessingMergeRECOoutput' % self.workflowName,
+                                                'collection': self.workflowName,
+                                                'server': self.couchUrl})
         return
 
     def testLocalQueueACDCSplit(self):
@@ -304,11 +300,11 @@ class ResubmitBlockTest(EmulatedUnitTestCase):
         with the information, namely the block name, produced by the global split.
         """
         self.stuffACDCDatabase()
-        acdcWorkload = self.getProcessingACDCSpec('LumiBased', {'lumis_per_job' : 10})
+        acdcWorkload = self.getProcessingACDCSpec('LumiBased', {'lumis_per_job': 10})
         acdcWorkload.data.request.priority = 10000
         for task in acdcWorkload.taskIterator():
             policy = ResubmitBlock()
-            units, _ = policy(acdcWorkload, task)
+            units, _, _ = policy(acdcWorkload, task)
             self.assertEqual(len(units), 1)
             for unit in units:
                 self.assertEqual(len(unit['Inputs']), 1)
@@ -321,10 +317,12 @@ class ResubmitBlockTest(EmulatedUnitTestCase):
                 self.assertEqual(1000, unit['NumberOfLumis'])
                 self.assertEqual(500, unit['NumberOfFiles'])
                 self.assertEqual(125000, unit['NumberOfEvents'])
-                self.assertEqual(unit['ACDC'], {'database' : self.acdcDBName, 'fileset' : '/%s/DataProcessing' % self.workflowName, 'collection' : self.workflowName, 'server' : self.couchUrl})
+                self.assertEqual(unit['ACDC'],
+                                 {'database': self.acdcDBName, 'fileset': '/%s/DataProcessing' % self.workflowName,
+                                  'collection': self.workflowName, 'server': self.couchUrl})
                 globalUnit = unit
             policy = ResubmitBlock()
-            units, _ = policy(acdcWorkload, task, data=globalUnit['Inputs'])
+            units, _, _ = policy(acdcWorkload, task, data=globalUnit['Inputs'])
             self.assertEqual(len(units), 1)
             for unit in units:
                 self.assertEqual(len(unit['Inputs']), 1)
@@ -337,7 +335,9 @@ class ResubmitBlockTest(EmulatedUnitTestCase):
                 self.assertEqual(1000, unit['NumberOfLumis'])
                 self.assertEqual(500, unit['NumberOfFiles'])
                 self.assertEqual(125000, unit['NumberOfEvents'])
-                self.assertEqual(unit['ACDC'], {'database' : self.acdcDBName, 'fileset' : '/%s/DataProcessing' % self.workflowName, 'collection' : self.workflowName, 'server' : self.couchUrl})
+                self.assertEqual(unit['ACDC'],
+                                 {'database': self.acdcDBName, 'fileset': '/%s/DataProcessing' % self.workflowName,
+                                  'collection': self.workflowName, 'server': self.couchUrl})
         return
 
     def testSiteWhitelistsLocation(self):
@@ -348,12 +348,12 @@ class ResubmitBlockTest(EmulatedUnitTestCase):
         according to the given site whitelist.
         """
         self.stuffACDCDatabase()
-        acdcWorkload = self.getProcessingACDCSpec('FileBased', {'files_per_job' : 5},
+        acdcWorkload = self.getProcessingACDCSpec('FileBased', {'files_per_job': 5},
                                                   setLocationFlag=True)
         acdcWorkload.data.request.priority = 10000
         for task in acdcWorkload.taskIterator():
             policy = ResubmitBlock()
-            units, _ = policy(acdcWorkload, task)
+            units, _, _ = policy(acdcWorkload, task)
             self.assertEqual(len(units), 2)
             for unit in units:
                 self.assertEqual(len(unit['Inputs']), 1)
@@ -366,12 +366,12 @@ class ResubmitBlockTest(EmulatedUnitTestCase):
                 self.assertEqual(500, unit['NumberOfLumis'])
                 self.assertEqual(250, unit['NumberOfFiles'])
                 self.assertEqual(62500, unit['NumberOfEvents'])
-                self.assertEqual(unit['ACDC'], {'database' : self.acdcDBName,
-                                                'fileset' : '/%s/DataProcessing' % self.workflowName,
-                                                'collection' : self.workflowName,
-                                                'server' : self.couchUrl})
+                self.assertEqual(unit['ACDC'], {'database': self.acdcDBName,
+                                                'fileset': '/%s/DataProcessing' % self.workflowName,
+                                                'collection': self.workflowName,
+                                                'server': self.couchUrl})
         return
+
 
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
Fixes #8872 

I didn't notice `self.rejectedWork` was also used for keeping track of work units (blocks) that don't pass possible work restrictions (block, run, lumi mask). We need to separate those, otherwise there are tons of LogDB request-level warnings that aren't supposed to be there.

Looking into the usefulness of `self.rejectedWork`. Apparently we keep it in the single workqueue_inbox document where we have a complete list of `RejectedInputs` and `ProcessedInputs` such that it can have a more efficient cycle the next time it runs (through `modifyPolicyForWorkAddition`). However, didn't we kill this WorkAddition when we deprecated OpenRunningTimeout?