### PR TITLE
only look for HTTP/ at beginning of line. Fix #8882

### DIFF
--- a/src/python/WMCore/Services/pycurl_manager.py
+++ b/src/python/WMCore/Services/pycurl_manager.py
@@ -71,7 +71,7 @@ class ResponseHeader(object):
             row = row.replace('\n', '')
             if  not row:
                 continue
-            if  row.find('HTTP') != -1 and \
+            if  row.find('HTTP/') == 0 and \
                 row.find('100') == -1: #HTTP/1.1 100 found: real header is later
                 res = row.replace('HTTP/1.1', '')
                 res = res.replace('HTTP/1.0', '')


### PR DESCRIPTION
this solves current problem, but as I wrote in dmwm#8882 it would be better that someone who knows what HTTP specs are makes sure that header parsing is done properly.