### PR TITLE
improve query speed by 30%

### DIFF
--- a/src/couchapps/WMStats/_attachments/js/Models/WMStats._RequestModelBase.js
+++ b/src/couchapps/WMStats/_attachments/js/Models/WMStats._RequestModelBase.js
@@ -84,7 +84,7 @@ WMStats._RequestModelBase.prototype = {
     },
 
     _getLatestRequestAgentUrlAndCreateTable: function (overviewData, keys, objPtr) {
-        var options = {"keys": keys, "reduce": false, "descending": true};
+        var options = {"keys": keys, "reduce": true, "group": true, "descending": true};
         WMStats.Couch.view('latestRequest', options,
               function(agentIDs) {
                   objPtr._getRequestDetailsAndTriggerEvent(agentIDs, overviewData, objPtr);

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
@@ -4028,7 +4028,7 @@ WMStats._RequestModelBase.prototype = {
     },
 
     _getLatestRequestAgentUrlAndCreateTable: function (overviewData, keys, objPtr) {
-        var options = {"keys": keys, "reduce": false, "descending": true};
+        var options = {"keys": keys, "reduce": true, "group": true, "descending": true};
         WMStats.Couch.view('latestRequest', options,
               function(agentIDs) {
                   objPtr._getRequestDetailsAndTriggerEvent(agentIDs, overviewData, objPtr);

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
@@ -4676,7 +4676,7 @@ WMStats._RequestModelBase.prototype = {
     },
 
     _getLatestRequestAgentUrlAndCreateTable: function (overviewData, keys, objPtr) {
-        var options = {"keys": keys, "reduce": false, "descending": true};
+        var options = {"keys": keys, "reduce": true, "group": true, "descending": true};
         WMStats.Couch.view('latestRequest', options,
               function(agentIDs) {
                   objPtr._getRequestDetailsAndTriggerEvent(agentIDs, overviewData, objPtr);

--- a/src/python/WMCore/Services/WMStats/WMStatsReader.py
+++ b/src/python/WMCore/Services/WMStats/WMStatsReader.py
@@ -222,7 +222,8 @@ class WMStatsReader(object):
         if len(keys) == 0:
             return []
         options = {}
-        options["reduce"] = False
+        options["reduce"] = True
+        options["group"] = True
         result = self._getCouchView("latestRequest", options, keys)
         ids = [row['value']['id'] for row in result["rows"]]
         return ids


### PR DESCRIPTION
@amaltaro, Alan please review. Although this not changing the result of the data but it seems it improves the speed of query 30%. I thought it would be the other way, since previous query doesn't have to reduce. But it seems it is more of data size it is transferring than the computation work on reduce.  I think we should put this on this release since we are suffering from the performance of wmstats. 