### PR TITLE
improve performance in wmstats

### DIFF
--- a/src/couchapps/WMStats/_attachments/js/Models/WMStats._RequestModelBase.js
+++ b/src/couchapps/WMStats/_attachments/js/Models/WMStats._RequestModelBase.js
@@ -84,7 +84,7 @@ WMStats._RequestModelBase.prototype = {
     },
 
     _getLatestRequestAgentUrlAndCreateTable: function (overviewData, keys, objPtr) {
-        var options = {"keys": keys, "reduce": true, "group": true, "descending": true};
+        var options = {"keys": keys, "reduce": false};
         WMStats.Couch.view('latestRequest', options,
               function(agentIDs) {
                   objPtr._getRequestDetailsAndTriggerEvent(agentIDs, overviewData, objPtr);

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
@@ -4028,7 +4028,7 @@ WMStats._RequestModelBase.prototype = {
     },
 
     _getLatestRequestAgentUrlAndCreateTable: function (overviewData, keys, objPtr) {
-        var options = {"keys": keys, "reduce": true, "group": true, "descending": true};
+        var options = {"keys": keys, "reduce": false};
         WMStats.Couch.view('latestRequest', options,
               function(agentIDs) {
                   objPtr._getRequestDetailsAndTriggerEvent(agentIDs, overviewData, objPtr);

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
@@ -4676,7 +4676,7 @@ WMStats._RequestModelBase.prototype = {
     },
 
     _getLatestRequestAgentUrlAndCreateTable: function (overviewData, keys, objPtr) {
-        var options = {"keys": keys, "reduce": true, "group": true, "descending": true};
+        var options = {"keys": keys, "reduce": false};
         WMStats.Couch.view('latestRequest', options,
               function(agentIDs) {
                   objPtr._getRequestDetailsAndTriggerEvent(agentIDs, overviewData, objPtr);

--- a/src/couchapps/WMStatsErl/views/latestRequest/map.erl
+++ b/src/couchapps/WMStatsErl/views/latestRequest/map.erl
@@ -5,9 +5,7 @@ fun({Doc}) ->
     <<"agent_request">> ->
       Workflow = couch_util:get_value(<<"workflow">>, Doc),
       AgentUrl = couch_util:get_value(<<"agent_url">>, Doc),
-      Id = couch_util:get_value(<<"_id">>, Doc),
-      Timestamp = couch_util:get_value(<<"timestamp">>, Doc),
-      Emit([Workflow, AgentUrl], {[{id,Id},{timestamp,Timestamp}]});
+      Emit([Workflow, AgentUrl], null);
     _ -> ok
   end
 end.

--- a/src/couchapps/WMStatsErl/views/latestRequest/reduce.erl
+++ b/src/couchapps/WMStatsErl/views/latestRequest/reduce.erl
@@ -1,7 +1,0 @@
-fun(Keys, Values, ReReduce) ->
-  [H|T] = Values,
-  lists:foldl(fun(Req, LatestReq) -> {[_, {<<"timestamp">>,LatestTimestamp}]} = LatestReq,
-                                     {[_, {<<"timestamp">>,Timestamp}]} = Req, 
-                                     if LatestTimestamp < Timestamp -> Req; true -> LatestReq end
-              end, H, T)
-end.

--- a/src/python/WMCore/Services/WMStats/WMStatsReader.py
+++ b/src/python/WMCore/Services/WMStats/WMStatsReader.py
@@ -115,8 +115,7 @@ class WMStatsReader(object):
 
         if len(requestNames) > 0:
             requestAndAgentKey = self._getRequestAndAgent(requestNames)
-            jobDocIds = self._getLatestJobInfo(requestAndAgentKey)
-            jobInfoByRequestAndAgent = self._getAllDocsByIDs(jobDocIds)
+            jobInfoByRequestAndAgent = self._getLatestJobInfo(requestAndAgentKey)
         return jobInfoByRequestAndAgent
 
     def _updateRequestInfoWithJobInfo(self, requestInfo):
@@ -221,12 +220,10 @@ class WMStatsReader(object):
         """
         if len(keys) == 0:
             return []
-        options = {}
-        options["reduce"] = True
-        options["group"] = True
+        options = {"include_docs": True}
+        options["reduce"] = False
         result = self._getCouchView("latestRequest", options, keys)
-        ids = [row['value']['id'] for row in result["rows"]]
-        return ids
+        return result
 
     def _getAllDocsByIDs(self, ids, include_docs=True):
         """


### PR DESCRIPTION
This patch will reduce the cpu time or requestcache REST api,
1. not calling the reduce = true. (Since it is not doing reduce call time is 9 times faster - However, it is a small portion of whole call, data transfer time is the dominant factor. 
2. by emitting null instead of rev and time in value section, it reduces the data size.
3. reduces the 2 calls to one.
