### PR TITLE
Handle HTTP in the pycurl response header

### DIFF
--- a/src/python/WMCore/Services/pycurl_manager.py
+++ b/src/python/WMCore/Services/pycurl_manager.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-#-*- coding: ISO-8859-1 -*-
-#pylint: disable=R0913,W0702,R0914,R0912,R0201
+# -*- coding: ISO-8859-1 -*-
+# pylint: disable=R0913,W0702,R0914,R0912,R0201
 """
 File: pycurl_manager.py
 Author: Valentin Kuznetsov <vkuznet@gmail.com>
@@ -38,16 +38,15 @@ for row in data:
 """
 from __future__ import print_function
 
-# system modules
-import os
-import re
-import sys
 import cStringIO as StringIO
 import httplib
 import json
 import logging
-import urllib
+import os
+import re
 import subprocess
+import sys
+import urllib
 
 # python3
 if sys.version.startswith('3.'):
@@ -56,8 +55,10 @@ if sys.version.startswith('3.'):
 # 3d-party libraries
 import pycurl
 
+
 class ResponseHeader(object):
     """ResponseHeader parses HTTP response header"""
+
     def __init__(self, response):
         super(ResponseHeader, self).__init__()
         self.header = {}
@@ -73,7 +74,7 @@ class ResponseHeader(object):
 
         for row in response.split('\r'):
             row = row.replace('\n', '')
-            if  not row:
+            if not row:
                 continue
             if re.search(startRegex, row):
                 if re.search(continueRegex, row):
@@ -89,14 +90,16 @@ class ResponseHeader(object):
             except:
                 pass
 
+
 class RequestHandler(object):
     """
     RequestHandler provides APIs to fetch single/multiple
     URL requests based on pycurl library
     """
+
     def __init__(self, config=None, logger=None):
         super(RequestHandler, self).__init__()
-        if  not config:
+        if not config:
             config = {}
         self.nosignal = config.get('nosignal', 1)
         self.timeout = config.get('timeout', 30)
@@ -111,11 +114,11 @@ class RequestHandler(object):
             uses a different encoding depending on the HTTP verb
             (either json.dumps or urllib.urlencode)
         """
-        #data is already encoded, just return it
+        # data is already encoded, just return it
         if isinstance(params, basestring):
             return params
 
-        #data is not encoded, we need to do that
+        # data is not encoded, we need to do that
         if verb in ['GET', 'HEAD']:
             if params:
                 encoded_data = urllib.urlencode(params, doseq=doseq)
@@ -146,11 +149,11 @@ class RequestHandler(object):
 
         encoded_data = self.encode_params(params, verb, doseq)
 
-        if  verb == 'GET':
-            if  encoded_data:
+        if verb == 'GET':
+            if encoded_data:
                 url = url + '?' + encoded_data
         elif verb == 'HEAD':
-            if  encoded_data:
+            if encoded_data:
                 url = url + '?' + encoded_data
             curl.setopt(pycurl.CUSTOMREQUEST, verb)
             curl.setopt(pycurl.HEADER, 1)
@@ -171,25 +174,25 @@ class RequestHandler(object):
         # TypeError: invalid arguments to setopt
         # see https://curl.haxx.se/mail/curlpython-2007-07/0001.html
         curl.setopt(pycurl.URL, str(url))
-        if  headers:
+        if headers:
             curl.setopt(pycurl.HTTPHEADER, \
-                    ["%s: %s" % (k, v) for k, v in headers.items()])
+                        ["%s: %s" % (k, v) for k, v in headers.items()])
         bbuf = StringIO.StringIO()
         hbuf = StringIO.StringIO()
         curl.setopt(pycurl.WRITEFUNCTION, bbuf.write)
         curl.setopt(pycurl.HEADERFUNCTION, hbuf.write)
-        if  capath:
+        if capath:
             curl.setopt(pycurl.CAPATH, capath)
             curl.setopt(pycurl.SSL_VERIFYPEER, True)
             if cainfo:
                 curl.setopt(pycurl.CAINFO, cainfo)
         else:
             curl.setopt(pycurl.SSL_VERIFYPEER, False)
-        if  ckey:
+        if ckey:
             curl.setopt(pycurl.SSLKEY, ckey)
-        if  cert:
+        if cert:
             curl.setopt(pycurl.SSLCERT, cert)
-        if  verbose:
+        if verbose:
             curl.setopt(pycurl.VERBOSE, 1)
             curl.setopt(pycurl.DEBUGFUNCTION, self.debug)
         return bbuf, hbuf
@@ -203,12 +206,12 @@ class RequestHandler(object):
         Parse body part of URL request (by default use json).
         This method can be overwritten.
         """
-        if  decode:
+        if decode:
             try:
                 res = json.loads(data)
             except ValueError as exc:
                 msg = 'Unable to load JSON data, %s, data type=%s, pass as is' \
-                        % (str(exc), type(data))
+                      % (str(exc), type(data))
                 logging.warning(msg)
                 return data
             return res
@@ -228,20 +231,20 @@ class RequestHandler(object):
         """Fetch data for given set of parameters"""
         curl = pycurl.Curl()
         bbuf, hbuf = self.set_opts(curl, url, params, headers,
-                ckey, cert, capath, verbose, verb, doseq, cainfo, cookie)
+                                   ckey, cert, capath, verbose, verb, doseq, cainfo, cookie)
         curl.perform()
-        if  verbose:
+        if verbose:
             print(verb, url, params, headers)
         header = self.parse_header(hbuf.getvalue())
-        if  header.status < 300:
-            if  verb == 'HEAD':
+        if header.status < 300:
+            if verb == 'HEAD':
                 data = ''
             else:
                 data = self.parse_body(bbuf.getvalue(), decode)
         else:
             data = bbuf.getvalue()
             msg = 'url=%s, code=%s, reason=%s, headers=%s' \
-                    % (url, header.status, header.reason, header.header)
+                  % (url, header.status, header.reason, header.header)
             exc = httplib.HTTPException(msg)
             setattr(exc, 'req_data', params)
             setattr(exc, 'req_headers', headers)
@@ -262,18 +265,18 @@ class RequestHandler(object):
                 verbose=0, ckey=None, cert=None, doseq=True, cookie=None):
         """Fetch data for given set of parameters"""
         _, data = self.request(url=url, params=params, headers=headers, verb=verb,
-                    verbose=verbose, ckey=ckey, cert=cert, doseq=doseq, cookie=cookie)
+                               verbose=verbose, ckey=ckey, cert=cert, doseq=doseq, cookie=cookie)
         return data
 
     def getheader(self, url, params, headers=None, verb='GET',
-                verbose=0, ckey=None, cert=None, doseq=True):
+                  verbose=0, ckey=None, cert=None, doseq=True):
         """Fetch HTTP header"""
         header, _ = self.request(url, params, headers, verb,
-                    verbose, ckey, cert, doseq)
+                                 verbose, ckey, cert, doseq)
         return header
 
     def multirequest(self, url, parray, headers=None,
-                ckey=None, cert=None, verbose=None, cookie=None):
+                     ckey=None, cert=None, verbose=None, cookie=None):
         """Fetch data for given set of parameters"""
         multi = pycurl.CurlMulti()
         for params in parray:
@@ -283,42 +286,45 @@ class RequestHandler(object):
             multi.add_handle(curl)
             while True:
                 ret, num_handles = multi.perform()
-                if  ret != pycurl.E_CALL_MULTI_PERFORM:
+                if ret != pycurl.E_CALL_MULTI_PERFORM:
                     break
             while num_handles:
                 ret = multi.select(1.0)
-                if  ret == -1:
+                if ret == -1:
                     continue
                 while True:
                     ret, num_handles = multi.perform()
-                    if  ret != pycurl.E_CALL_MULTI_PERFORM:
+                    if ret != pycurl.E_CALL_MULTI_PERFORM:
                         break
             dummyNumq, response, dummyErr = multi.info_read()
             for dummyCobj in response:
                 data = json.loads(bbuf.getvalue())
-                if  isinstance(data, dict):
+                if isinstance(data, dict):
                     data.update(params)
                     yield data
-                if  isinstance(data, list):
+                if isinstance(data, list):
                     for item in data:
-                        if  isinstance(item, dict):
+                        if isinstance(item, dict):
                             item.update(params)
                             yield item
                         else:
-                            err = 'Unsupported data format: data=%s, type=%s'\
-                                % (item, type(item))
+                            err = 'Unsupported data format: data=%s, type=%s' \
+                                  % (item, type(item))
                             raise Exception(err)
                 bbuf.flush()
                 hbuf.flush()
 
-HTTP_PAT = re.compile(\
-        "(https|http)://[-A-Za-z0-9_+&@#/%?=~_|!:,.;]*[-A-Za-z0-9+&@#/%=~_|]")
+
+HTTP_PAT = re.compile( \
+    "(https|http)://[-A-Za-z0-9_+&@#/%?=~_|!:,.;]*[-A-Za-z0-9+&@#/%=~_|]")
+
 
 def validate_url(url):
     "Validate URL"
-    if  HTTP_PAT.match(url):
+    if HTTP_PAT.match(url):
         return True
     return False
+
 
 def pycurl_options():
     "Default set of options for pycurl"
@@ -333,12 +339,14 @@ def pycurl_options():
     }
     return opts
 
+
 def cern_sso_cookie(url, fname, cert, ckey):
     "Obtain cern SSO cookie and store it in given file name"
     cmd = 'cern-get-sso-cookie -cert %s -key %s -r -u %s -o %s' \
-            % (cert, ckey, url, fname)
+          % (cert, ckey, url, fname)
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, env=os.environ)
     proc.wait()
+
 
 def getdata(urls, ckey, cert, headers=None, options=None, num_conn=100, cookie=None):
     """
@@ -367,9 +375,9 @@ def getdata(urls, ckey, cert, headers=None, options=None, num_conn=100, cookie=N
         curl.setopt(pycurl.SSLKEY, ckey)
         curl.setopt(pycurl.SSLCERT, cert)
         mcurl.handles.append(curl)
-        if  headers:
+        if headers:
             curl.setopt(pycurl.HTTPHEADER, \
-                    ["%s: %s" % (k, v) for k, v in headers.items()])
+                        ["%s: %s" % (k, v) for k, v in headers.items()])
 
     # Main loop
     freelist = mcurl.handles[:]
@@ -384,7 +392,7 @@ def getdata(urls, ckey, cert, headers=None, options=None, num_conn=100, cookie=N
             if cookie and url in cookie:
                 curl.setopt(pycurl.COOKIEFILE, cookie[url])
                 curl.setopt(pycurl.COOKIEJAR, cookie[url])
-            if  sys.version.startswith('3.'):
+            if sys.version.startswith('3.'):
                 bbuf = io.BytesIO()
                 hbuf = io.BytesIO()
             else:
@@ -400,20 +408,20 @@ def getdata(urls, ckey, cert, headers=None, options=None, num_conn=100, cookie=N
         # Run the internal curl state machine for the multi stack
         while True:
             ret, _ = mcurl.perform()
-            if  ret != pycurl.E_CALL_MULTI_PERFORM:
+            if ret != pycurl.E_CALL_MULTI_PERFORM:
                 break
         # Check for curl objects which have terminated, and add them to the
         # freelist
         while True:
             num_q, ok_list, err_list = mcurl.info_read()
             for curl in ok_list:
-                if  sys.version.startswith('3.'):
-                    hdrs  = curl.hbuf.getvalue().decode('utf-8')
-                    data  = curl.bbuf.getvalue().decode('utf-8')
+                if sys.version.startswith('3.'):
+                    hdrs = curl.hbuf.getvalue().decode('utf-8')
+                    data = curl.bbuf.getvalue().decode('utf-8')
                 else:
-                    hdrs  = curl.hbuf.getvalue()
-                    data  = curl.bbuf.getvalue()
-                url   = curl.url
+                    hdrs = curl.hbuf.getvalue()
+                    data = curl.bbuf.getvalue()
+                url = curl.url
                 curl.bbuf.flush()
                 curl.bbuf.close()
                 curl.hbuf.close()
@@ -423,9 +431,9 @@ def getdata(urls, ckey, cert, headers=None, options=None, num_conn=100, cookie=N
                 freelist.append(curl)
                 yield {'url': url, 'data': data, 'headers': hdrs}
             for curl, errno, errmsg in err_list:
-                hdrs  = curl.hbuf.getvalue()
-                data  = curl.bbuf.getvalue()
-                url   = curl.url
+                hdrs = curl.hbuf.getvalue()
+                data = curl.bbuf.getvalue()
+                url = curl.url
                 curl.bbuf.flush()
                 curl.bbuf.close()
                 curl.hbuf.close()
@@ -433,8 +441,8 @@ def getdata(urls, ckey, cert, headers=None, options=None, num_conn=100, cookie=N
                 curl.bbuf = None
                 mcurl.remove_handle(curl)
                 freelist.append(curl)
-                yield {'url': url, 'data': None, 'headers': hdrs,\
-                        'error': errmsg, 'code': errno}
+                yield {'url': url, 'data': None, 'headers': hdrs, \
+                       'error': errmsg, 'code': errno}
             num_processed = num_processed + len(ok_list) + len(err_list)
             if num_q == 0:
                 break
@@ -445,13 +453,14 @@ def getdata(urls, ckey, cert, headers=None, options=None, num_conn=100, cookie=N
 
     cleanup(mcurl)
 
+
 def cleanup(mcurl):
     "Clean-up MultiCurl handles"
     for curl in mcurl.handles:
-        if  curl.hbuf is not None:
+        if curl.hbuf is not None:
             curl.hbuf.close()
             curl.hbuf = None
-        if  curl.bbuf is not None:
+        if curl.bbuf is not None:
             curl.bbuf.close()
             curl.bbuf = None
         curl.close()

--- a/src/python/WMCore/Services/pycurl_manager.py
+++ b/src/python/WMCore/Services/pycurl_manager.py
@@ -67,15 +67,18 @@ class ResponseHeader(object):
 
     def parse(self, response):
         """Parse response header and assign class member data"""
+        startRegex = r"^HTTP/\d.\d \d{3}"
+        continueRegex = r"^HTTP/\d.\d 100"  # Continue: client should continue its request
+        replaceRegex = r"^HTTP/\d.\d"
+
         for row in response.split('\r'):
             row = row.replace('\n', '')
             if  not row:
                 continue
-            if  row.find('HTTP') != -1 and \
-                row.find('100') == -1: #HTTP/1.1 100 found: real header is later
-                res = row.replace('HTTP/1.1', '')
-                res = res.replace('HTTP/1.0', '')
-                res = res.strip()
+            if re.search(startRegex, row):
+                if re.search(continueRegex, row):
+                    continue
+                res = re.sub(replaceRegex, "", row).strip()
                 status, reason = res.split(' ', 1)
                 self.status = int(status)
                 self.reason = reason

--- a/test/python/WMCore_t/Services_t/pycurl_manager_t.py
+++ b/test/python/WMCore_t/Services_t/pycurl_manager_t.py
@@ -8,7 +8,8 @@ import os
 import tempfile
 import unittest
 
-from WMCore.Services.pycurl_manager import RequestHandler, getdata, cern_sso_cookie
+from WMCore.Services.pycurl_manager import RequestHandler, ResponseHeader, getdata, cern_sso_cookie
+
 
 class PyCurlManager(unittest.TestCase):
     """Test pycurl_manager module"""
@@ -18,6 +19,10 @@ class PyCurlManager(unittest.TestCase):
         self.mgr = RequestHandler()
         self.ckey = os.path.join(os.environ['HOME'], '.globus/userkey.pem')
         self.cert = os.path.join(os.environ['HOME'], '.globus/usercert.pem')
+
+        self.cricheader = 'Date: Tue, 06 Nov 2018 14:50:29 GMT\r\nServer: Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips mod_wsgi/3.4 Python/2.7.5 mod_gridsite/2.3.4\r\nVary: Cookie\r\nX-Frame-Options: SAMEORIGIN\r\nSet-Cookie: sessionid=bc1xu8zi5rbbsd5fgjuklb2tk2r3f6tw; expires=Sun, 11-Nov-2018 14:50:29 GMT; httponly; Max-Age=432000; Path=/\r\nContent-Length: 32631\r\nContent-Type: application/json\r\n\r\n'
+        self.dbsheader = 'Date: Tue, 06 Nov 2018 14:39:07 GMT\r\nServer: Apache\r\nCMS-Server-Time: D=1503 t=1541515147806112\r\nTransfer-Encoding: chunked\r\nContent-Type: text/html\r\n\r\n'
+        self.HTTPheader = 'Date: Tue, 06 Nov 2018 14:50:29 GMT\r\nServer: Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips mod_wsgi/3.4 Python/2.7.5 mod_gridsite/2.3.4\r\nVary: Cookie\r\nX-Frame-Options: SAMEORIGIN\r\nSet-Cookie: GRIDHTTP_PASSCODE=2c6da9c96efa2ad0farhda; domain=cms-cric.cern.ch; path=/; secure\r\nContent-Length: 32631\r\nContent-Type: application/json\r\n\r\n'
 
     def testMulti(self):
         """
@@ -49,6 +54,87 @@ class PyCurlManager(unittest.TestCase):
         cookie = {url: tfile.name}
         header, _ = self.mgr.request(url, params, cookie=cookie)
         self.assertTrue(header.status, 200)
+
+    def testContinue(self):
+        """
+        Test HTTP exit code 100 - Continue
+        """
+        header = "HTTP/1.1 100 Continue\r\n" + self.dbsheader
+
+        resp = ResponseHeader(header)
+        self.assertIsNone(getattr(resp, "status", None))
+        self.assertEqual(resp.reason, "")
+        self.assertFalse(resp.fromcache)
+        self.assertIn("CMS-Server-Time", resp.header)
+        self.assertIn("Date", resp.header)
+        self.assertEqual(resp.header['Content-Type'], 'text/html')
+        self.assertEqual(resp.header['Server'], 'Apache')
+        self.assertEqual(resp.header['Transfer-Encoding'], 'chunked')
+        return
+
+    def testOK(self):
+        """
+        Test HTTP exit code 200 - OK
+        """
+        header = "HTTP/1.1 200 OK\r\n" + self.dbsheader
+
+        resp = ResponseHeader(header)
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(resp.reason, "OK")
+        self.assertFalse(resp.fromcache)
+        return
+
+    def testForbidden(self):
+        """
+        Test HTTP exit code 403 - Forbidden
+        """
+        header = "HTTP/1.1 403 Forbidden\r\n" + self.dbsheader
+
+        resp = ResponseHeader(header)
+        self.assertEqual(resp.status, 403)
+        self.assertEqual(resp.reason, "Forbidden")
+        self.assertFalse(resp.fromcache)
+        return
+
+    def testOKCRIC(self):
+        """
+        Test HTTP exit code 200 - OK for a CRIC response header
+        """
+        header = "HTTP/1.1 200 OK\r\n" + self.cricheader
+
+        resp = ResponseHeader(header)
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(resp.reason, "OK")
+        self.assertFalse(resp.fromcache)
+        self.assertIn("Content-Length", resp.header)
+        self.assertIn("Date", resp.header)
+        self.assertIn("Server", resp.header)
+        self.assertIn("sessionid", resp.header['Set-Cookie'])
+        self.assertEqual(resp.header['Content-Type'], 'application/json')
+        self.assertEqual(resp.header['Vary'], 'Cookie')
+        self.assertEqual(resp.header['X-Frame-Options'], 'SAMEORIGIN')
+        return
+
+    def testUnavailableCRICHTTP(self):
+        """
+        Test HTTP exit code 503 - Service Unavailable for a CRIC response header
+        when it also contains a HTTP string in the Set-Cookie header section
+        """
+        header = "HTTP/1.1 503 Service Unavailable\r\n" + self.HTTPheader
+
+        resp = ResponseHeader(header)
+        self.assertEqual(resp.status, 503)
+        self.assertEqual(resp.reason, "Service Unavailable")
+        self.assertFalse(resp.fromcache)
+        self.assertIn("Content-Length", resp.header)
+        self.assertIn("Date", resp.header)
+        self.assertIn("Server", resp.header)
+        self.assertIn("GRIDHTTP_PASSCODE", resp.header['Set-Cookie'])
+        self.assertEqual(resp.header['Content-Type'], 'application/json')
+        self.assertEqual(resp.header['Vary'], 'Cookie')
+        self.assertEqual(resp.header['X-Frame-Options'], 'SAMEORIGIN')
+        return
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/WMCore_t/WMInit_t.py
+++ b/test/python/WMCore_t/WMInit_t.py
@@ -6,6 +6,8 @@ WMInit_t.py
 Created by Dave Evans on 2011-05-20.
 Copyright (c) 2011 Fermilab. All rights reserved.
 """
+from __future__ import print_function
+
 import os
 import threading
 import unittest
@@ -30,7 +32,7 @@ class WMInit_t(unittest.TestCase):
 
         init = WMInit()
         url = os.environ.get("DATABASE")
-        dialect = os.environ.get("DIALECT")
+        dialect = os.environ.get("DIALECT", "MySQL")
         sock = os.environ.get("DBSOCK", None)
 
         init.setDatabaseConnection(url, dialect, sock)


### PR DESCRIPTION
Fixes #8882
Superseeds #8883

HTTP header/response format seems to be well defined, looking at:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Messages

The only real change is:
* Search for `HTTP/\d.\d \d{3}` (e.g. HTTP/1.1 200) at the very beginning of the header line.