### PR TITLE
Fix analytics data collector

### DIFF
--- a/test/python/WMComponent_t/AnalyticsDataCollector_t/AnalyticsDataCollector_t.py
+++ b/test/python/WMComponent_t/AnalyticsDataCollector_t/AnalyticsDataCollector_t.py
@@ -4,17 +4,11 @@
 WorkQueuManager test
 """
 
-import os
-import logging
 import threading
 import unittest
-import time
 from WMQuality.TestInitCouchApp import TestInitCouchApp as TestInit
 from WMQuality.Emulators.AnalyticsDataCollector.DataCollectorAPI import REQUEST_NAME_PREFIX, NUM_REQUESTS
 
-from WMCore.Agent.Configuration import loadConfigurationFile
-from WMCore.DAOFactory import DAOFactory
-from WMComponent.AnalyticsDataCollector.AnalyticsDataCollector import AnalyticsDataCollector
 from WMComponent.AnalyticsDataCollector.AnalyticsPoller import AnalyticsPoller
 from WMComponent.AnalyticsDataCollector.DataCollectorEmulatorSwitch import EmulatorHelper
 
@@ -30,8 +24,8 @@ class MockLocalQService():
         status = {}
         inputDataset = {}
         for i in range(NUM_REQUESTS + 1):
-            status['%s%s' % (REQUEST_NAME_PREFIX, i+1)] = {'inQueue': 1, 'inWMBS': 1}
-            inputDataset['%s%s' % (REQUEST_NAME_PREFIX, i+1)] = 'inputdataset-%s' % (i+1)
+            status['%s%s' % (REQUEST_NAME_PREFIX, i + 1)] = {'inQueue': 1, 'inWMBS': 1}
+            inputDataset['%s%s' % (REQUEST_NAME_PREFIX, i + 1)] = 'inputdataset-%s' % (i + 1)
 
         return {'status': status, 'input_dataset': inputDataset}
 
@@ -56,17 +50,18 @@ class AnalyticsDataCollector_t(unittest.TestCase):
         self.testInit.setupCouch(self.reqmonDBName, "WMStats")
         self.testInit.setupCouch(self.localDBName, "WMStats")
         self.testDir = self.testInit.generateWorkDir()
-        EmulatorHelper.setEmulators(localCouch = True, reqMon = False, wmagentDB = True)
+        EmulatorHelper.setEmulators(localCouch=True, reqMon=False, wmagentDB=True)
         return
 
     def tearDown(self):
         """
         Database deletion
         """
-        myThread = threading.currentThread()
+        threading.currentThread()
 
         self.testInit.delWorkDir()
         self.testInit.tearDownCouch()
+        self.testInit.clearDatabase()
         EmulatorHelper.resetEmulators()
         return
 
@@ -76,9 +71,6 @@ class AnalyticsDataCollector_t(unittest.TestCase):
 
         General config file
         """
-        #configPath=os.path.join(WMCore.WMInit.getWMBASE(), \
-        #                        'src/python/WMComponent/WorkQueueManager/DefaultConfig.py')):
-
         couchURL = self.testInit.couchUrl
         config = self.testInit.getConfiguration()
         self.testInit.generateWorkDir(config)
@@ -116,7 +108,7 @@ class AnalyticsDataCollector_t(unittest.TestCase):
         Tests the components, as in sees if they load.
         Otherwise does nothing.
         """
-        myThread = threading.currentThread()
+        threading.currentThread()
         config = self.getConfig()
         analytics = AnalyticsPoller(config)
 


### PR DESCRIPTION
AnalyticsDataCollector_t complains regarding database not being empty when run more than once.

```
$ nosetests AnalyticsDataCollector_t.py
E
======================================================================
ERROR: Tests the components, as in sees if they load.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/data/wmcore/wmcore_unittest/WMCore/test/python/WMComponent_t/AnalyticsDataCollector_t/AnalyticsDataCollector_t.py", line 49, in setUp
    self.testInit.setDatabaseConnection()
  File "/data/wmcore/unittestdeploy/wmagent/1.1.18.pre6/sw/slc7_amd64_gcc630/cms/wmagent/1.1.18.pre6/lib/python2.7/site-packages/WMQuality/TestInit.py", line 167, in setDatabaseConnection
    raise TestInitException(msg)
TestInitException: <@========== WMException Start ==========@>
Exception Class: TestInitException
Message: Database not empty, cannot set schema !
[{'table_name': 'dbsbuffer_algo'}, {'table_name': 'dbsbuffer_algo_dataset_assoc'}, {'table_name': 'dbsbuffer_block'}, {'table_name': 'dbsbuffer_checksum_type'}, {'table_name': 'dbsbuffer_dataset'}, {'table_name': 'dbsbuffer_dataset_subscription'}, {'table_name': 'dbsbuffer_file'}, {'table_name': 'dbsbuffer_file_checksums'}, {'table_name': 'dbsbuffer_file_location'}, {'table_name': 'dbsbuffer_file_parent'}, {'table_name': 'dbsbuffer_file_runlumi_map'}, {'table_name': 'dbsbuffer_location'}, {'table_name': 'dbsbuffer_workflow'}, {'table_name': 'wmbs_checksum_type'}, {'table_name': 'wmbs_file_checksums'}, {'table_name': 'wmbs_file_details'}, {'table_name': 'wmbs_file_location'}, {'table_name': 'wmbs_file_parent'}, {'table_name': 'wmbs_file_runlumi_map'}, {'table_name': 'wmbs_fileset'}, {'table_name': 'wmbs_fileset_files'}, {'table_name': 'wmbs_frl_workunit_assoc'}, {'table_name': 'wmbs_job'}, {'table_name': 'wmbs_job_assoc'}, {'table_name': 'wmbs_job_mask'}, {'table_name': 'wmbs_job_state'}, {'table_name': 'wmbs_job_workunit_assoc'}, {'table_name': 'wmbs_jobgroup'}, {'table_name': 'wmbs_location'}, {'table_name': 'wmbs_location_pnns'}, {'table_name': 'wmbs_location_state'}, {'table_name': 'wmbs_pnns'}, {'table_name': 'wmbs_sub_files_acquired'}, {'table_name': 'wmbs_sub_files_available'}, {'table_name': 'wmbs_sub_files_complete'}, {'table_name': 'wmbs_sub_files_failed'}, {'table_name': 'wmbs_sub_types'}, {'table_name': 'wmbs_subscription'}, {'table_name': 'wmbs_subscription_validation'}, {'table_name': 'wmbs_users'}, {'table_name': 'wmbs_workflow'}, {'table_name': 'wmbs_workflow_output'}, {'table_name': 'wmbs_workunit'}]
    ModuleName : WMQuality.TestInit
    MethodName : setDatabaseConnection
    ClassInstance : None
    FileName : /data/wmcore/unittestdeploy/wmagent/1.1.18.pre6/sw/slc7_amd64_gcc630/cms/wmagent/1.1.18.pre6/lib/python2.7/site-packages/WMQuality/TestInit.py
    ClassName : None

▽
    def getAnalyticsData(self):
    LineNumber : 167
    ErrorNr : 0

Traceback:

<@---------- WMException End ----------@>
-------------------- >> begin captured logging << --------------------
root: DEBUG: Using SQLAlchemy v.0.9.6
root: INFO: Instantiating base WM DBInterface
root: ERROR: Database not empty, cannot set schema !
[{'table_name': 'dbsbuffer_algo'}, {'table_name': 'dbsbuffer_algo_dataset_assoc'}, {'table_name': 'dbsbuffer_block'}, {'table_name': 'dbsbuffer_checksum_type'}, {'table_name': 'dbsbuffer_dataset'}, {'table_name': 'dbsbuffer_dataset_subscription'}, {'table_name': 'dbsbuffer_file'}, {'table_name': 'dbsbuffer_file_checksums'}, {'table_name': 'dbsbuffer_file_location'}, {'table_name': 'dbsbuffer_file_parent'}, {'table_name': 'dbsbuffer_file_runlumi_map'}, {'table_name': 'dbsbuffer_location'}, {'table_name': 'dbsbuffer_workflow'}, {'table_name': 'wmbs_checksum_type'}, {'table_name': 'wmbs_file_checksums'}, {'table_name': 'wmbs_file_details'}, {'table_name': 'wmbs_file_location'}, {'table_name': 'wmbs_file_parent'}, {'table_name': 'wmbs_file_runlumi_map'}, {'table_name': 'wmbs_fileset'}, {'table_name': 'wmbs_fileset_files'}, {'table_name': 'wmbs_frl_workunit_assoc'}, {'table_name': 'wmbs_job'}, {'table_name': 'wmbs_job_assoc'}, {'table_name': 'wmbs_job_mask'}, {'table_name': 'wmbs_job_state'}, {'table_name': 'wmbs_job_workunit_assoc'}, {'table_name': 'wmbs_jobgroup'}, {'table_name': 'wmbs_location'}, {'table_name': 'wmbs_location_pnns'}, {'table_name': 'wmbs_location_state'}, {'table_name': 'wmbs_pnns'}, {'table_name': 'wmbs_sub_files_acquired'}, {'table_name': 'wmbs_sub_files_available'}, {'table_name': 'wmbs_sub_files_complete'}, {'table_name': 'wmbs_sub_files_failed'}, {'table_name': 'wmbs_sub_types'}, {'table_name': 'wmbs_subscription'}, {'table_name': 'wmbs_subscription_validation'}, {'table_name': 'wmbs_users'}, {'table_name': 'wmbs_workflow'}, {'table_name': 'wmbs_workflow_output'}, {'table_name': 'wmbs_workunit'}]
--------------------- >> end captured logging << ---------------------

----------------------------------------------------------------------
Ran 1 test in 0.111s

FAILED (errors=1)
```