### PR TITLE
don't update the document if the new state is the same as old state

### DIFF
--- a/src/couchapps/T0Request/updates/updaterequest.js
+++ b/src/couchapps/T0Request/updates/updaterequest.js
@@ -42,6 +42,11 @@ function(doc, req)
     		// don't update the status just ignore
     		return "not allowed transition " + doc.RequestStatus + " to " + newStatus;
     	}
+    	if (doc.RequestStatus === newStatus) {
+    	    // If it is the same transition don't update the couch doc
+    	    return "OK"
+    	}
+
     	doc.RequestStatus = newStatus;
     	
         var currentTS =  Math.round((new Date()).getTime() / 1000);


### PR DESCRIPTION
Tier0 request has multiple state change update even when it has the same state.
I am not sure whether this will reduce the revisions as well, though.
```
"RequestTransition": [
       {
           "Status": "new",
           "UpdateTime": 1414774821
       },
       {
           "Status": "Closed",
           "UpdateTime": 1414778941
       },
       {
           "Status": "Merge",
           "UpdateTime": 1414781628
       },
       {
           "Status": "Merge",
           "UpdateTime": 1414782230
       },
       {
           "Status": "Harvesting",
           "UpdateTime": 1414782834
       },
       {
           "Status": "Processing Done",
           "UpdateTime": 1414783527
       },
       {
           "Status": "Processing Done",
           "UpdateTime": 1414784146
       },
       {
           "Status": "Processing Done",
           "UpdateTime": 1414784778
       },
       {
           "Status": "Processing Done",
           "UpdateTime": 1414785381
       },
```