### PR TITLE
Fix ReqMgr2 dependency on WorkQueue

### DIFF
--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -57,9 +57,10 @@ dependencies = {
                      'WMCore.WMDataMining+',
                      'WMCore.Services+',
                      'WMCore.ACDC',
-                     'Utils',
-                     'WMCore.WorkQueue.DataStructs+'
-                     ],
+                     'Utils'],
+        'modules': ['WMCore.WorkQueue.__init__',
+                    'WMCore.WorkQueue.DataStructs.__init__',
+                    'WMCore.WorkQueue.DataStructs.WorkQueueElement'],
         'systems': ['wmc-rest', 'wmc-runtime', 'wmc-database'],
         'statics': ['src/couchapps/ReqMgr+',
                     'src/couchapps/ReqMgrAux+',


### PR DESCRIPTION
Fixes #8930 

Honestly, I don't get why the previous code didn't work, it had all the DataStructs as dependency.
@ticoann please review

I'll try to get it tested, even though I'm not sure that's going to work. I'll patch the source code when building the ReqMgr2 RPM and deploy it afterwards.