### PR TITLE
WMAgent and WMCore pypi packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,4 @@
 include setup_*.py
+include requirements.txt
+include LICENSE
+include NOTICE

--- a/requirements.wmagent.txt
+++ b/requirements.wmagent.txt
@@ -1,0 +1,22 @@
+# All dependencies needed to run WMAgent
+Cheetah==2.4.0
+CherryPy==5.4.0
+Markdown==3.0.1
+MySQL-python==1.2.5
+SQLAlchemy==1.3.3
+Sphinx==1.3.5
+cx-Oracle==5.2.1
+dbs-client==3.7.8
+decorator==3.4.2
+future==0.16.0
+httplib2==0.7.3
+psutil==5.4.5
+py==1.7.0
+pyOpenSSL==18.0.0
+pycurl-client==3.7.8
+pycurl==7.19.3
+python-cjson==1.2.1
+pyzmq==17.1.2
+retry==0.9.1
+stomp.py==4.1.15
+rucio-clients==1.19.3

--- a/requirements.wmcore.txt
+++ b/requirements.wmcore.txt
@@ -1,0 +1,1 @@
+# WMCore requirements intentionally left blank

--- a/setup.py
+++ b/setup.py
@@ -126,5 +126,6 @@ setup(name='wmcore',
       packages=DEFAULT_PACKAGES,
       data_files=list_static_files(),
       url="https://github.com/dmwm/WMCore",
+      license="Apache License, Version 2.0",
       download_url="https://github.com/dmwm/WMCore/tarball/%s" % wmcore_version
       )

--- a/setup_wmagent.py
+++ b/setup_wmagent.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+# This setup script is used to build the WMAgent pypi package.
+# The version number comes from WMCore/__init__.py and needs to
+# follow PEP 440 conventions
+
+from __future__ import print_function, division
+import os
+import sys
+import imp
+from setuptools import setup
+from setup_build import list_packages, list_static_files, get_path_to_wmcore_root
+
+# Obnoxiously, there's a dependency cycle when building packages. We'd like
+# to simply get the current WMCore version by using
+# from WMCore import __version__
+# But PYTHONPATH isn't set until after the package is built, so we can't
+# depend on the python module resolution behavior to load the version.
+# Instead, we use the imp module to load the source file directly by
+# filename.
+wmcore_root = get_path_to_wmcore_root()
+wmcore_package = imp.load_source('temp_module', os.path.join(wmcore_root,
+                                                             'src',
+                                                             'python',
+                                                             'WMCore',
+                                                             '__init__.py'))
+wmcore_version = wmcore_package.__version__
+
+# Requirements file for pip dependencies
+requirements = "requirements.txt"
+
+
+def parse_requirements(requirements_file):
+    """
+      Create a list for the 'install_requires' component of the setup function
+      by parsing a requirements file
+    """
+
+    if os.path.exists(requirements_file):
+        # return a list that contains each line of the requirements file
+        return open(requirements_file, 'r').read().splitlines()
+    else:
+        print("ERROR: requirements file " + requirements_file + " not found.")
+        sys.exit(1)
+
+
+setup(name='wmagent',
+      version=wmcore_version,
+      maintainer='CMS DMWM Group',
+      maintainer_email='hn-cms-dmDevelopment@cern.ch',
+      package_dir={'': 'src/python/'},
+      packages=list_packages(['src/python/Utils',
+                              'src/python/WMCore',
+                              'src/python/WMComponent',
+                              'src/python/WMQuality',
+                              'src/python/PSetTweaks']),
+      data_files=list_static_files(),
+      install_requires=parse_requirements(requirements),
+      url="https://github.com/dmwm/WMCore",
+      license="Apache License, Version 2.0",
+      )

--- a/setup_wmcore.py
+++ b/setup_wmcore.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+# This setup script is used to build the WMCore pypi package.
+# The version number comes from WMCore/__init__.py and needs to
+# follow PEP 440 conventions
+
+from __future__ import print_function, division
+import os
+import sys
+import imp
+from setuptools import setup
+from setup_build import list_packages, list_static_files, get_path_to_wmcore_root
+
+# Obnoxiously, there's a dependency cycle when building packages. We'd like
+# to simply get the current WMCore version by using
+# from WMCore import __version__
+# But PYTHONPATH isn't set until after the package is built, so we can't
+# depend on the python module resolution behavior to load the version.
+# Instead, we use the imp module to load the source file directly by
+# filename.
+wmcore_root = get_path_to_wmcore_root()
+wmcore_package = imp.load_source('temp_module', os.path.join(wmcore_root,
+                                                             'src',
+                                                             'python',
+                                                             'WMCore',
+                                                             '__init__.py'))
+wmcore_version = wmcore_package.__version__
+
+# Requirements file for pip dependencies
+requirements = "requirements.txt"
+
+
+def parse_requirements(requirements_file):
+    """
+      Create a list for the 'install_requires' component of the setup function
+      by parsing a requirements file
+    """
+
+    if os.path.exists(requirements_file):
+        # return a list that contains each line of the requirements file
+        return open(requirements_file, 'r').read().splitlines()
+    else:
+        print("ERROR: requirements file " + requirements_file + " not found.")
+        sys.exit(1)
+
+
+setup(name='wmcore',
+      version=wmcore_version,
+      maintainer='CMS DMWM Group',
+      maintainer_email='hn-cms-dmDevelopment@cern.ch',
+      package_dir={'': 'src/python/'},
+      packages=list_packages(['src/python/Utils',
+                              'src/python/WMCore',
+                              'src/python/WMComponent',
+                              'src/python/WMQuality',
+                              'src/python/PSetTweaks']),
+      data_files=list_static_files(),
+      install_requires=parse_requirements(requirements),
+      url="https://github.com/dmwm/WMCore",
+      license="Apache License, Version 2.0",
+      )

--- a/tools/build_pypi_packages.sh
+++ b/tools/build_pypi_packages.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Script used to build each application from the WMCore repo and upload to pypi.
+#
+# Usage:
+# sh tools/build_pypi_packages.sh <wmagent|wmcore|all>
+#
+
+
+wmcore=false
+wmagent=false
+
+TOBUILD=$1
+
+case $TOBUILD in
+    wmagent)
+      echo "Building wmagent package"
+      wmagent=true
+      ;;
+    wmcore)
+      echo "Building wmcore package"
+      wmcore=true
+      ;;
+    all)
+      echo "Building wmagent package"
+      echo "Building wmcore package"
+      wmcore=true
+      wmagent=true
+      ;;
+    *)
+      echo "Please enter one of the following arguments."
+      echo "  all       Build all WMCore packages"
+      echo "  wmagent   Build wmagent package"
+      echo "  wmcore    Build wmcore package"
+      exit 1
+esac
+
+if $wmagent
+  then
+  /bin/cp requirements.wmagent.txt requirements.txt
+  /bin/cp setup_wmagent.py setup.py
+  python setup.py sdist upload
+fi
+
+if $wmcore
+  then
+  /bin/cp requirements.wmcore.txt requirements.txt
+  /bin/cp setup_wmcore.py setup.py
+  python setup.py sdist upload
+fi
+
+


### PR DESCRIPTION
Fixes #7647
These are the changes I have made to be able to build the WMAgent pypi package.  

Documentation updates regarding pypi packaging will be made on this wiki page:
https://github.com/dmwm/WMCore/wiki/DMWM-Packaging-with-PyPi

There are some caveats regarding setup.py that I will explain.

~~The original setup.py (used to build the wmagent rpm) has been renamed to setup_wmcore.py~~
~~A new file setup_wmagent.py was created that is used to build the wmagent pypi package.~~

~~To build the pypi package, I create a symlink setup.py -> setup_wmagent.py~~
~~To build the rpm, the symlink can be changed setup.py -> setup_wmcore.py~~

Regarding versioning, pypi packages need to follow PEP 440: https://www.python.org/dev/peps/pep-0440/
WMCore uses versioning like "1.1.15.pre6", which will get normalized during the build process.

`UserWarning: Normalizing '1.1.15.pre8' to '1.1.15rc8'`