### PR TITLE
Fix wmstats filtered_requests for Chain wfs

### DIFF
--- a/src/python/WMCore/ReqMgr/DataStructs/Request.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/Request.py
@@ -250,8 +250,11 @@ class RequestInfo(object):
 
             reqValue = self.get(key)
             if reqValue is not None:
-                if isinstance(reqValue, list):
+                if isinstance(reqValue, list) and isinstance(value, list):
                     if not set(reqValue).intersection(set(value)):
+                        return False
+                elif isinstance(reqValue, list):
+                    if value not in reqValue:
                         return False
                 elif isinstance(reqValue, bool):
                     if reqValue is not value:

--- a/src/python/WMCore/ReqMgr/DataStructs/Request.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/Request.py
@@ -20,8 +20,6 @@ from __future__ import print_function, division
 import re
 import time
 
-import cherrypy
-
 from WMCore.REST.Auth import get_user_info
 from WMCore.ReqMgr.DataStructs.RequestStatus import REQUEST_START_STATE, ACTIVE_STATUS_FILTER
 

--- a/test/python/WMCore_t/WMStats_t/DataStructs_t/DataCache.json
+++ b/test/python/WMCore_t/WMStats_t/DataStructs_t/DataCache.json
@@ -1,0 +1,3568 @@
+{
+  "amaltaro_ReReco_RunBlockWhite_HG1812_Validation_181203_121031_9539": {
+    "PrepID": "TEST-ReReco-Run2016H-v1-09Nov2016-0016", 
+    "MaxMergeEvents": 100000000, 
+    "Comments": "[u'ReReco run 283171 from one block (out of 2); harvesting enabled; 3 lumis only', u'Automatic splitting at 389 EpJob (actually 1 lumi and file per job)']", 
+    "Requestor": "amaltaro", 
+    "RunBlacklist": [], 
+    "Group": "DATAOPS", 
+    "CustodialGroup": "DataOps", 
+    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev", 
+    "SubRequestType": "", 
+    "TrustPUSitelists": false, 
+    "HardTimeout": 129900, 
+    "OpenRunningTimeout": 0, 
+    "LumiList": {}, 
+    "DashboardHost": "cms-jobmon.cern.ch", 
+    "EnableHarvesting": true, 
+    "Scenario": "pp", 
+    "BlockCloseMaxWaitTime": 66400, 
+    "SiteWhitelist": [
+      "T1_US_FNAL", 
+      "T2_CH_CERN"
+    ], 
+    "BlockCloseMaxSize": 5000000000000, 
+    "DQMConfigCacheID": "947d11a5076ed983a3f9aaafd7a2b04c", 
+    "ValidStatus": "PRODUCTION", 
+    "AcquisitionEra": "Run2016H", 
+    "GlobalTag": "80X_dataRun2_SPECIALHIGHPUFILL_v0", 
+    "Campaign": "HG1812_Validation", 
+    "ScramArch": [
+      "slc6_amd64_gcc530"
+    ], 
+    "EnableNewStageout": false, 
+    "NonCustodialGroup": "DataOps", 
+    "EventsPerJob": 389, 
+    "InputDataset": "/HLTPhysicsIsolatedBunch/Run2016H-v1/RAW", 
+    "DeleteFromSource": false, 
+    "TotalInputEvents": 3008, 
+    "SizePerEvent": 1500, 
+    "ConfigCacheID": "31b62d6a0629158d7246ce34e82c20c3", 
+    "CustodialSubType": "Replica", 
+    "GracePeriod": 300, 
+    "MergedLFNBase": "/store/backfill/1", 
+    "CouchDBName": "reqmgr_config_cache", 
+    "TransientOutputModules": [], 
+    "SubscriptionPriority": "Low", 
+    "RobustMerge": true, 
+    "SplittingAlgo": "EventAwareLumiBased", 
+    "Team": "devvm-cloud1", 
+    "AllowOpportunistic": false, 
+    "DQMHarvestUnit": "byRun", 
+    "AutoApproveSubscriptionSites": [], 
+    "RequestWorkflow": "https://alancc7-cloud1.cern.ch/couchdb/reqmgr_workload_cache/amaltaro_ReReco_RunBlockWhite_HG1812_Validation_181203_121031_9539/spec", 
+    "BlockBlacklist": [], 
+    "BlockCloseMaxFiles": 500, 
+    "VoGroup": "unknown", 
+    "RequestType": "ReReco", 
+    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/", 
+    "SiteBlacklist": [], 
+    "RequestStatus": "acquired", 
+    "SoftTimeout": 129600, 
+    "TotalInputFiles": 3, 
+    "BlockCloseMaxEvents": 25000000, 
+    "CustodialSites": [], 
+    "ProcessingString": "ReReco_RunBlockWhite_HG1812_Validation_Alan_v1112", 
+    "Multicore": 8, 
+    "TrustSitelists": false, 
+    "UnmergedLFNBase": "/store/unmerged", 
+    "LumisPerJob": 8, 
+    "DashboardPort": 8884, 
+    "TimePerEvent": 73.85, 
+    "DQMSequences": [], 
+    "OutputModulesLFNBases": [
+      "/store/unmerged/Run2016H/HLTPhysicsIsolatedBunch/DQMIO/ReReco_RunBlockWhite_HG1812_Validation_Alan_v1112-v11", 
+      "/store/unmerged/Run2016H/HLTPhysicsIsolatedBunch/AOD/ReReco_RunBlockWhite_HG1812_Validation_Alan_v1112-v11", 
+      "/store/unmerged/Run2016H/HLTPhysicsIsolatedBunch/MINIAOD/ReReco_RunBlockWhite_HG1812_Validation_Alan_v1112-v11"
+    ], 
+    "OutputDatasets": [
+      "/HLTPhysicsIsolatedBunch/Run2016H-ReReco_RunBlockWhite_HG1812_Validation_Alan_v1112-v11/DQMIO", 
+      "/HLTPhysicsIsolatedBunch/Run2016H-ReReco_RunBlockWhite_HG1812_Validation_Alan_v1112-v11/MINIAOD", 
+      "/HLTPhysicsIsolatedBunch/Run2016H-ReReco_RunBlockWhite_HG1812_Validation_Alan_v1112-v11/AOD"
+    ], 
+    "PrimaryDataset": null, 
+    "NonCustodialSubType": "Replica", 
+    "MaxMergeSize": 4294967296, 
+    "OverrideCatalog": null, 
+    "PeriodicHarvestInterval": 0, 
+    "TotalEstimatedJobs": 8, 
+    "MaxWaitTime": 86400, 
+    "RequestString": "ReReco_RunBlockWhite_HG1812_Validation", 
+    "RequestorDN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+    "RunWhitelist": [
+      283171
+    ], 
+    "RequestDate": [
+      2018, 
+      12, 
+      3, 
+      11, 
+      10, 
+      31
+    ], 
+    "InitialPriority": 190000, 
+    "RunNumber": 0, 
+    "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+    "EventStreams": null, 
+    "Memory": 12000, 
+    "Override": {
+      "eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/TESTBED"
+    }, 
+    "FilesPerJob": 1, 
+    "IncludeParents": false, 
+    "BlockWhitelist": [
+      "/HLTPhysicsIsolatedBunch/Run2016H-v1/RAW#92049f6e-92f9-11e6-b150-001e67abf228"
+    ], 
+    "VoRole": "unknown", 
+    "PriorityTransition": [
+      {
+        "Priority": 190000, 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835431
+      }
+    ], 
+    "CMSSWVersion": "CMSSW_8_0_23", 
+    "NonCustodialSites": [], 
+    "GlobalTagConnect": null, 
+    "MinMergeSize": 2147483648, 
+    "RequestPriority": 190000, 
+    "ProcessingVersion": 11, 
+    "TotalInputLumis": 3, 
+    "RequestName": "amaltaro_ReReco_RunBlockWhite_HG1812_Validation_181203_121031_9539", 
+    "CouchURL": "https://alancc7-cloud1.cern.ch/couchdb", 
+    "CouchWorkloadDBName": "reqmgr_workload_cache", 
+    "RequestTransition": [
+      {
+        "Status": "new", 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835431
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assignment-approved", 
+        "UpdateTime": 1543835436
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assigned", 
+        "UpdateTime": 1543835436
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+        "Status": "acquired", 
+        "UpdateTime": 1543836339
+      }
+    ], 
+    "DQMUploadProxy": null, 
+    "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb", 
+    "_id": "amaltaro_ReReco_RunBlockWhite_HG1812_Validation_181203_121031_9539", 
+    "Dashboard": "integration"
+  }, 
+  "amaltaro_MonteCarlo_Ext_PhEDEx_HG1812_Validation_181203_121047_1513": {
+    "PrepID": "TEST-pp502Fall15-00013", 
+    "MaxMergeEvents": 50000, 
+    "Comments": "[u'MC extension wf; FacOps Custodial Replica to MSS; AnalysisOps NonCustodial Move to Disk auto-approved;', u'Given 150EpL and 250EpJ, set EpJ to 300 instead']", 
+    "Requestor": "amaltaro", 
+    "Group": "DATAOPS", 
+    "CustodialGroup": "FacOps", 
+    "DQMUploadUrl": "https://cmsweb.cern.ch/dqm/dev", 
+    "SubRequestType": "", 
+    "TrustPUSitelists": false, 
+    "HardTimeout": 129900, 
+    "OpenRunningTimeout": 0, 
+    "LumiList": {}, 
+    "DashboardHost": "cms-jobmon.cern.ch", 
+    "EnableHarvesting": false, 
+    "BlockCloseMaxWaitTime": 36000, 
+    "SiteWhitelist": [
+      "T1_US_FNAL", 
+      "T2_CH_CERN"
+    ], 
+    "GlobalTagConnect": null, 
+    "DQMConfigCacheID": null, 
+    "DeterministicPileup": false, 
+    "ValidStatus": "PRODUCTION", 
+    "PriorityTransition": [
+      {
+        "Priority": 250000, 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835447
+      }
+    ], 
+    "GlobalTag": "MCRUN2_71_V1::All", 
+    "Campaign": "HG1812_Validation", 
+    "Multicore": 1, 
+    "EnableNewStageout": false, 
+    "NonCustodialGroup": "AnalysisOps", 
+    "EventsPerJob": 300, 
+    "RequestNumEvents": 5000, 
+    "DeleteFromSource": false, 
+    "TotalInputEvents": 5000, 
+    "SizePerEvent": 414, 
+    "ConfigCacheID": "ddd2e6e7b1e63afbffb9fa7b5d059ecd", 
+    "DataPileup": null, 
+    "CustodialSubType": "Replica", 
+    "GracePeriod": 300, 
+    "MergedLFNBase": "/store/backfill/1", 
+    "CouchDBName": "reqmgr_config_cache", 
+    "SubscriptionPriority": "Normal", 
+    "RobustMerge": true, 
+    "SplittingAlgo": "EventBased", 
+    "Team": "devvm-cloud1", 
+    "AllowOpportunistic": false, 
+    "DQMHarvestUnit": "byRun", 
+    "AutoApproveSubscriptionSites": [
+      "T1_US_FNAL_Disk"
+    ], 
+    "RequestWorkflow": "https://alancc7-cloud1.cern.ch/couchdb/reqmgr_workload_cache/amaltaro_MonteCarlo_Ext_PhEDEx_HG1812_Validation_181203_121047_1513/spec", 
+    "BlockCloseMaxFiles": 500, 
+    "VoGroup": "unknown", 
+    "RequestType": "MonteCarlo", 
+    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader", 
+    "SiteBlacklist": [], 
+    "FirstLumi": 101, 
+    "SoftTimeout": 129600, 
+    "TotalInputFiles": 0, 
+    "BlockCloseMaxEvents": 20000000, 
+    "CustodialSites": [
+      "T1_US_FNAL_MSS"
+    ], 
+    "ProcessingString": "MonteCarlo_Ext_PhEDEx_HG1812_Validation_Alan_v1112", 
+    "ScramArch": [
+      "slc6_amd64_gcc481"
+    ], 
+    "TrustSitelists": false, 
+    "UnmergedLFNBase": "/store/unmerged", 
+    "DashboardPort": 8884, 
+    "TimePerEvent": 115.2, 
+    "DQMSequences": [], 
+    "OutputModulesLFNBases": [
+      "/store/unmerged/DMWM_Test/Pythia8_Dijet15_pp502_TuneCUETP8M1/GEN-SIM/MonteCarlo_Ext_PhEDEx_HG1812_Validation_Alan_v1112-v11"
+    ], 
+    "OutputDatasets": [
+      "/Pythia8_Dijet15_pp502_TuneCUETP8M1/DMWM_Test-MonteCarlo_Ext_PhEDEx_HG1812_Validation_Alan_v1112-v11/GEN-SIM"
+    ], 
+    "PrimaryDataset": "Pythia8_Dijet15_pp502_TuneCUETP8M1", 
+    "NonCustodialSubType": "Move", 
+    "MaxMergeSize": 4294967296, 
+    "OverrideCatalog": null, 
+    "PeriodicHarvestInterval": 0, 
+    "TotalEstimatedJobs": 17, 
+    "MaxWaitTime": 86400, 
+    "RequestString": "MonteCarlo_Ext_PhEDEx_HG1812_Validation", 
+    "RequestorDN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+    "RequestDate": [
+      2018, 
+      12, 
+      3, 
+      11, 
+      10, 
+      47
+    ], 
+    "InitialPriority": 250000, 
+    "RunNumber": 0, 
+    "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+    "EventStreams": null, 
+    "Memory": 1250, 
+    "Override": {
+      "eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/TESTBED"
+    }, 
+    "IncludeParents": false, 
+    "MCPileup": null, 
+    "VoRole": "unknown", 
+    "AcquisitionEra": "DMWM_Test", 
+    "CMSSWVersion": "CMSSW_7_1_20_patch2", 
+    "NonCustodialSites": [
+      "T1_US_FNAL_Disk"
+    ], 
+    "BlockCloseMaxSize": 5000000000000, 
+    "MinMergeSize": 2147483648, 
+    "RequestPriority": 250000, 
+    "ProcessingVersion": 11, 
+    "TotalInputLumis": 34, 
+    "FirstEvent": 10001, 
+    "RequestName": "amaltaro_MonteCarlo_Ext_PhEDEx_HG1812_Validation_181203_121047_1513", 
+    "LheInputFiles": false, 
+    "CouchURL": "https://alancc7-cloud1.cern.ch/couchdb", 
+    "CouchWorkloadDBName": "reqmgr_workload_cache", 
+    "RequestTransition": [
+      {
+        "Status": "new", 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835447
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assignment-approved", 
+        "UpdateTime": 1543835453
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assigned", 
+        "UpdateTime": 1543835454
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+        "Status": "acquired", 
+        "UpdateTime": 1543836340
+      }
+    ], 
+    "RequestStatus": "acquired", 
+    "FilterEfficiency": 1, 
+    "DQMUploadProxy": null, 
+    "Seeding": "AutomaticSeeding", 
+    "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb", 
+    "_id": "amaltaro_MonteCarlo_Ext_PhEDEx_HG1812_Validation_181203_121047_1513", 
+    "EventsPerLumi": 150, 
+    "Dashboard": "integration"
+  }, 
+  "amaltaro_ReReco_BlockWhiteBlack_HG1812_Validation_181203_121036_1728": {
+    "PrepID": "TEST-ReReco-Run2018A-DoubleMuon-17Sep2018-0002", 
+    "MaxMergeEvents": 100000000, 
+    "Comments": "Large RunWhitelist; only 1 block BlockWhitelisted, which has only invalid files; thus, this wf will go to failed", 
+    "Requestor": "amaltaro", 
+    "RunBlacklist": [], 
+    "CustodialGroup": "DataOps", 
+    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev", 
+    "SubRequestType": "", 
+    "TrustPUSitelists": false, 
+    "HardTimeout": 129900, 
+    "OpenRunningTimeout": 0, 
+    "LumiList": {}, 
+    "DashboardHost": "cms-jobmon.cern.ch", 
+    "EnableHarvesting": false, 
+    "Scenario": "pp", 
+    "BlockCloseMaxWaitTime": 66400, 
+    "SiteWhitelist": [
+      "T1_US_FNAL", 
+      "T2_CH_CERN"
+    ], 
+    "VoRole": "unknown", 
+    "DQMConfigCacheID": "573976a90ba04b7a9dbdd98e43fcfeea", 
+    "ValidStatus": "PRODUCTION", 
+    "PriorityTransition": [
+      {
+        "Priority": 210000, 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835436
+      }
+    ], 
+    "GlobalTag": "102X_dataRun2_Sep2018Rereco_v1", 
+    "Campaign": "HG1812_Validation", 
+    "ScramArch": [
+      "slc6_amd64_gcc700"
+    ], 
+    "EnableNewStageout": false, 
+    "NonCustodialGroup": "DataOps", 
+    "EventsPerJob": 2215, 
+    "InputDataset": "/DoubleMuon/Run2018A-v1/RAW", 
+    "DeleteFromSource": false, 
+    "SizePerEvent": 800, 
+    "ConfigCacheID": "573976a90ba04b7a9dbdd98e43ffcc9d", 
+    "CustodialSubType": "Replica", 
+    "GracePeriod": 300, 
+    "MergedLFNBase": "/store/backfill/1", 
+    "CouchDBName": "reqmgr_config_cache", 
+    "TransientOutputModules": [], 
+    "SubscriptionPriority": "Low", 
+    "RobustMerge": true, 
+    "SplittingAlgo": "EventAwareLumiBased", 
+    "Team": "devvm-cloud1", 
+    "AllowOpportunistic": false, 
+    "DQMHarvestUnit": "byRun", 
+    "AutoApproveSubscriptionSites": [], 
+    "RequestWorkflow": "https://alancc7-cloud1.cern.ch/couchdb/reqmgr_workload_cache/amaltaro_ReReco_BlockWhiteBlack_HG1812_Validation_181203_121036_1728/spec", 
+    "BlockBlacklist": [], 
+    "BlockCloseMaxFiles": 500, 
+    "VoGroup": "unknown", 
+    "RequestType": "ReReco", 
+    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/", 
+    "SiteBlacklist": [], 
+    "RequestStatus": "failed", 
+    "SoftTimeout": 129600, 
+    "Group": "DATAOPS", 
+    "BlockCloseMaxEvents": 25000000, 
+    "CustodialSites": [], 
+    "ProcessingString": "ReReco_BlockWhiteBlack_HG1812_Validation_Alan_v1112", 
+    "Multicore": 8, 
+    "TrustSitelists": true, 
+    "UnmergedLFNBase": "/store/unmerged", 
+    "DashboardPort": 8884, 
+    "TimePerEvent": 13, 
+    "DQMSequences": [], 
+    "OutputModulesLFNBases": [
+      "/store/unmerged/DMWM_Test/DoubleMuon/AOD/ReReco_BlockWhiteBlack_HG1812_Validation_Alan_v1112-v11", 
+      "/store/unmerged/DMWM_Test/DoubleMuon/ALCARECO/MuAlZMuMu-ReReco_BlockWhiteBlack_HG1812_Validation_Alan_v1112-v11", 
+      "/store/unmerged/DMWM_Test/DoubleMuon/ALCARECO/DtCalib-ReReco_BlockWhiteBlack_HG1812_Validation_Alan_v1112-v11", 
+      "/store/unmerged/DMWM_Test/DoubleMuon/DQMIO/ReReco_BlockWhiteBlack_HG1812_Validation_Alan_v1112-v11", 
+      "/store/unmerged/DMWM_Test/DoubleMuon/MINIAOD/ReReco_BlockWhiteBlack_HG1812_Validation_Alan_v1112-v11", 
+      "/store/unmerged/DMWM_Test/DoubleMuon/ALCARECO/MuAlOverlaps-ReReco_BlockWhiteBlack_HG1812_Validation_Alan_v1112-v11", 
+      "/store/unmerged/DMWM_Test/DoubleMuon/ALCARECO/MuAlCalIsolatedMu-ReReco_BlockWhiteBlack_HG1812_Validation_Alan_v1112-v11", 
+      "/store/unmerged/DMWM_Test/DoubleMuon/ALCARECO/TkAlZMuMu-ReReco_BlockWhiteBlack_HG1812_Validation_Alan_v1112-v11"
+    ], 
+    "OutputDatasets": [
+      "/DoubleMuon/DMWM_Test-MuAlZMuMu-ReReco_BlockWhiteBlack_HG1812_Validation_Alan_v1112-v11/ALCARECO", 
+      "/DoubleMuon/DMWM_Test-ReReco_BlockWhiteBlack_HG1812_Validation_Alan_v1112-v11/MINIAOD", 
+      "/DoubleMuon/DMWM_Test-TkAlZMuMu-ReReco_BlockWhiteBlack_HG1812_Validation_Alan_v1112-v11/ALCARECO", 
+      "/DoubleMuon/DMWM_Test-DtCalib-ReReco_BlockWhiteBlack_HG1812_Validation_Alan_v1112-v11/ALCARECO", 
+      "/DoubleMuon/DMWM_Test-MuAlOverlaps-ReReco_BlockWhiteBlack_HG1812_Validation_Alan_v1112-v11/ALCARECO", 
+      "/DoubleMuon/DMWM_Test-ReReco_BlockWhiteBlack_HG1812_Validation_Alan_v1112-v11/DQMIO", 
+      "/DoubleMuon/DMWM_Test-ReReco_BlockWhiteBlack_HG1812_Validation_Alan_v1112-v11/AOD", 
+      "/DoubleMuon/DMWM_Test-MuAlCalIsolatedMu-ReReco_BlockWhiteBlack_HG1812_Validation_Alan_v1112-v11/ALCARECO"
+    ], 
+    "PrimaryDataset": null, 
+    "NonCustodialSubType": "Replica", 
+    "GlobalTagConnect": null, 
+    "MaxMergeSize": 4294967296, 
+    "OverrideCatalog": null, 
+    "PeriodicHarvestInterval": 0, 
+    "MaxWaitTime": 86400, 
+    "RequestString": "ReReco_BlockWhiteBlack_HG1812_Validation", 
+    "RequestorDN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+    "RunWhitelist": [
+      315257, 
+      315258, 
+      315259, 
+      315264, 
+      315265, 
+      315267, 
+      315270, 
+      315322, 
+      315339, 
+      315357, 
+      315361, 
+      315363, 
+      315365, 
+      315366, 
+      315420, 
+      315488, 
+      315489, 
+      315490, 
+      315506, 
+      315509, 
+      315510, 
+      315512, 
+      315543, 
+      315555, 
+      315556, 
+      315557, 
+      315640, 
+      315641, 
+      315642, 
+      315644, 
+      315645, 
+      315646, 
+      315647, 
+      315648, 
+      315689, 
+      315690, 
+      315702, 
+      315703, 
+      315704, 
+      315705, 
+      315713, 
+      315721, 
+      315741, 
+      315764, 
+      315770, 
+      315784, 
+      315785, 
+      315786, 
+      315788, 
+      315789, 
+      315790, 
+      315800, 
+      315801, 
+      315840, 
+      315973, 
+      315974, 
+      316058, 
+      316059, 
+      316060, 
+      316061, 
+      316062, 
+      316082, 
+      316109, 
+      316110, 
+      316111, 
+      316112, 
+      316113, 
+      316114, 
+      316151, 
+      316153, 
+      316186, 
+      316187, 
+      316199, 
+      316200, 
+      316201, 
+      316202, 
+      316216, 
+      316217, 
+      316218, 
+      316219, 
+      316239, 
+      316240, 
+      316241, 
+      316271, 
+      316361, 
+      316362, 
+      316363, 
+      316377, 
+      316378, 
+      316379, 
+      316380, 
+      316455, 
+      316456, 
+      316457, 
+      316469, 
+      316470, 
+      316472, 
+      316505, 
+      316569, 
+      316590, 
+      316613, 
+      316615, 
+      316664, 
+      316665, 
+      316666, 
+      316667, 
+      316700, 
+      316701, 
+      316702, 
+      316715, 
+      316716, 
+      316717, 
+      316718, 
+      316719, 
+      316720, 
+      316721, 
+      316722, 
+      316723, 
+      316758, 
+      316766, 
+      316876, 
+      316877, 
+      316879, 
+      316928, 
+      316944, 
+      316985, 
+      316993, 
+      316994, 
+      316995
+    ], 
+    "RequestDate": [
+      2018, 
+      12, 
+      3, 
+      11, 
+      10, 
+      36
+    ], 
+    "InitialPriority": 210000, 
+    "RunNumber": 0, 
+    "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+    "EventStreams": null, 
+    "Memory": 14000, 
+    "Override": {
+      "Override": {
+        "eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/TESTBED"
+      }
+    }, 
+    "FilesPerJob": 1, 
+    "IncludeParents": false, 
+    "BlockWhitelist": [
+      "/DoubleMuon/Run2018A-v1/RAW#7bb3cd63-f1a9-4a76-bd89-ccdd81af526a"
+    ], 
+    "LumisPerJob": 8, 
+    "AcquisitionEra": "DMWM_Test", 
+    "CMSSWVersion": "CMSSW_10_2_4_patch1", 
+    "NonCustodialSites": [], 
+    "BlockCloseMaxSize": 5000000000000, 
+    "MinMergeSize": 2147483648, 
+    "RequestPriority": 210000, 
+    "ProcessingVersion": 11, 
+    "RequestName": "amaltaro_ReReco_BlockWhiteBlack_HG1812_Validation_181203_121036_1728", 
+    "CouchURL": "https://alancc7-cloud1.cern.ch/couchdb", 
+    "CouchWorkloadDBName": "reqmgr_workload_cache", 
+    "RequestTransition": [
+      {
+        "Status": "new", 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835436
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assignment-approved", 
+        "UpdateTime": 1543835440
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assigned", 
+        "UpdateTime": 1543835441
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+        "Status": "failed", 
+        "UpdateTime": 1543835775
+      }
+    ], 
+    "DQMUploadProxy": null, 
+    "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb", 
+    "_id": "amaltaro_ReReco_BlockWhiteBlack_HG1812_Validation_181203_121036_1728", 
+    "Dashboard": "integration"
+  }, 
+  "amaltaro_ReReco_Parents_HG1812_Validation_181203_121714_7387": {
+    "PrepID": "IncludeParents-Prep-Alan", 
+    "MaxMergeEvents": 50000, 
+    "Comments": "ReReco with IncludeParents True, 4 runs whitelisted, 8h opened", 
+    "Requestor": "amaltaro", 
+    "RunBlacklist": [], 
+    "Group": "DATAOPS", 
+    "CustodialGroup": "DataOps", 
+    "DQMUploadUrl": "https://cmsweb.cern.ch/dqm/dev", 
+    "SubRequestType": "", 
+    "TrustPUSitelists": false, 
+    "HardTimeout": 129900, 
+    "OpenRunningTimeout": 28800, 
+    "LumiList": {}, 
+    "DashboardHost": "cms-jobmon.cern.ch", 
+    "EnableHarvesting": false, 
+    "Scenario": null, 
+    "BlockCloseMaxWaitTime": 72000, 
+    "SiteWhitelist": [
+      "T1_US_FNAL", 
+      "T2_CH_CERN"
+    ], 
+    "BlockCloseMaxSize": 5000000000000, 
+    "DQMConfigCacheID": null, 
+    "ValidStatus": "PRODUCTION", 
+    "AcquisitionEra": "Integ_Test", 
+    "GlobalTag": "GR_P_V49", 
+    "Campaign": "HG1812_Validation", 
+    "Multicore": 1, 
+    "EnableNewStageout": false, 
+    "NonCustodialGroup": "DataOps", 
+    "EventsPerJob": 14400, 
+    "InputDataset": "/Cosmics/Commissioning2015-PromptReco-v1/RECO", 
+    "DeleteFromSource": false, 
+    "TotalInputEvents": 5153697, 
+    "SizePerEvent": 512, 
+    "ConfigCacheID": "029a0b63329659025f308af53c7e092b", 
+    "CustodialSubType": "Move", 
+    "GracePeriod": 300, 
+    "MergedLFNBase": "/store/backfill/1", 
+    "CouchDBName": "reqmgr_config_cache", 
+    "TransientOutputModules": [], 
+    "SubscriptionPriority": "Low", 
+    "RobustMerge": true, 
+    "SplittingAlgo": "EventAwareLumiBased", 
+    "Team": "testbed-vocms0192", 
+    "AllowOpportunistic": false, 
+    "DQMHarvestUnit": "byRun", 
+    "AutoApproveSubscriptionSites": [], 
+    "RequestWorkflow": "https://alancc7-cloud1.cern.ch/couchdb/reqmgr_workload_cache/amaltaro_ReReco_Parents_HG1812_Validation_181203_121714_7387/spec", 
+    "BlockBlacklist": [], 
+    "BlockCloseMaxFiles": 500, 
+    "VoGroup": "unknown", 
+    "RequestType": "ReReco", 
+    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader", 
+    "SiteBlacklist": [], 
+    "RequestStatus": "acquired", 
+    "SoftTimeout": 129600, 
+    "TotalInputFiles": 254, 
+    "BlockCloseMaxEvents": 200000000, 
+    "CustodialSites": [], 
+    "ProcessingString": "ReReco_Parents_HG1812_Validation_TEST_Alan_v112", 
+    "ScramArch": [
+      "slc6_amd64_gcc491"
+    ], 
+    "TrustSitelists": false, 
+    "UnmergedLFNBase": "/store/unmerged", 
+    "LumisPerJob": 8, 
+    "DashboardPort": 8884, 
+    "TimePerEvent": 2, 
+    "DQMSequences": [], 
+    "OutputModulesLFNBases": [
+      "/store/unmerged/Integ_Test/Cosmics/RAW-RECO/CosmicSP-ReReco_Parents_HG1812_Validation_TEST_Alan_v112-v11"
+    ], 
+    "OutputDatasets": [
+      "/Cosmics/Integ_Test-CosmicSP-ReReco_Parents_HG1812_Validation_TEST_Alan_v112-v11/RAW-RECO"
+    ], 
+    "PrimaryDataset": null, 
+    "NonCustodialSubType": "Replica", 
+    "MaxMergeSize": 4294967296, 
+    "OverrideCatalog": null, 
+    "PeriodicHarvestInterval": 0, 
+    "TotalEstimatedJobs": 360, 
+    "MaxWaitTime": 86400, 
+    "RequestString": "ReReco_Parents_HG1812_Validation", 
+    "RequestorDN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+    "RunWhitelist": [
+      234297, 
+      234304, 
+      234321, 
+      234332
+    ], 
+    "RequestDate": [
+      2018, 
+      12, 
+      3, 
+      11, 
+      17, 
+      14
+    ], 
+    "InitialPriority": 150000, 
+    "RunNumber": 0, 
+    "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+    "EventStreams": null, 
+    "Memory": 2300, 
+    "Override": {
+      "eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/TESTBED"
+    }, 
+    "FilesPerJob": 1, 
+    "IncludeParents": true, 
+    "BlockWhitelist": [], 
+    "VoRole": "unknown", 
+    "PriorityTransition": [
+      {
+        "Priority": 150000, 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835834
+      }
+    ], 
+    "CMSSWVersion": "CMSSW_7_3_2", 
+    "NonCustodialSites": [], 
+    "GlobalTagConnect": null, 
+    "MinMergeSize": 2147483648, 
+    "RequestPriority": 150000, 
+    "ProcessingVersion": 11, 
+    "TotalInputLumis": 1744, 
+    "RequestName": "amaltaro_ReReco_Parents_HG1812_Validation_181203_121714_7387", 
+    "CouchURL": "https://alancc7-cloud1.cern.ch/couchdb", 
+    "CouchWorkloadDBName": "reqmgr_workload_cache", 
+    "RequestTransition": [
+      {
+        "Status": "new", 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835834
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assignment-approved", 
+        "UpdateTime": 1543835839
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assigned", 
+        "UpdateTime": 1543835839
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+        "Status": "acquired", 
+        "UpdateTime": 1543836945
+      }
+    ], 
+    "DQMUploadProxy": null, 
+    "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb", 
+    "_id": "amaltaro_ReReco_Parents_HG1812_Validation_181203_121714_7387", 
+    "Dashboard": "integration"
+  }, 
+  "amaltaro_ReReco_badBlocks_HG1812_Validation_181203_121108_2682": {
+    "PrepID": "TEST-ReReco-Run2018A-DoubleMuon-17Sep2018-0002", 
+    "MaxMergeEvents": 100000000, 
+    "Comments": "Large RunWhitelist which will match some blocks with only invalid files; Trust flag enabled", 
+    "Requestor": "amaltaro", 
+    "RunBlacklist": [], 
+    "Group": "DATAOPS", 
+    "CustodialGroup": "DataOps", 
+    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev", 
+    "SubRequestType": "", 
+    "TrustPUSitelists": false, 
+    "HardTimeout": 129900, 
+    "OpenRunningTimeout": 0, 
+    "LumiList": {}, 
+    "DashboardHost": "cms-jobmon.cern.ch", 
+    "EnableHarvesting": false, 
+    "Scenario": "pp", 
+    "BlockCloseMaxWaitTime": 66400, 
+    "SiteWhitelist": [
+      "T1_US_FNAL", 
+      "T2_CH_CERN"
+    ], 
+    "BlockCloseMaxSize": 5000000000000, 
+    "DQMConfigCacheID": "573976a90ba04b7a9dbdd98e43fcfeea", 
+    "ValidStatus": "PRODUCTION", 
+    "AcquisitionEra": "DMWM_Test", 
+    "GlobalTag": "102X_dataRun2_Sep2018Rereco_v1", 
+    "Campaign": "HG1812_Validation", 
+    "ScramArch": [
+      "slc6_amd64_gcc700"
+    ], 
+    "EnableNewStageout": false, 
+    "NonCustodialGroup": "DataOps", 
+    "EventsPerJob": 2215, 
+    "InputDataset": "/DoubleMuon/Run2018A-v1/RAW", 
+    "DeleteFromSource": false, 
+    "TotalInputEvents": 1731207, 
+    "SizePerEvent": 800, 
+    "ConfigCacheID": "573976a90ba04b7a9dbdd98e43ffcc9d", 
+    "CustodialSubType": "Replica", 
+    "GracePeriod": 300, 
+    "MergedLFNBase": "/store/backfill/1", 
+    "CouchDBName": "reqmgr_config_cache", 
+    "TransientOutputModules": [], 
+    "SubscriptionPriority": "Low", 
+    "RobustMerge": true, 
+    "SplittingAlgo": "EventAwareLumiBased", 
+    "Team": "devvm-cloud1", 
+    "AllowOpportunistic": false, 
+    "DQMHarvestUnit": "byRun", 
+    "AutoApproveSubscriptionSites": [], 
+    "RequestWorkflow": "https://alancc7-cloud1.cern.ch/couchdb/reqmgr_workload_cache/amaltaro_ReReco_badBlocks_HG1812_Validation_181203_121108_2682/spec", 
+    "BlockBlacklist": [], 
+    "BlockCloseMaxFiles": 500, 
+    "VoGroup": "unknown", 
+    "RequestType": "ReReco", 
+    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/", 
+    "SiteBlacklist": [], 
+    "RequestStatus": "acquired", 
+    "SoftTimeout": 129600, 
+    "TotalInputFiles": 392, 
+    "BlockCloseMaxEvents": 25000000, 
+    "CustodialSites": [], 
+    "ProcessingString": "ReReco_badBlocks_HG1812_Validation_Alan_v1112", 
+    "Multicore": 8, 
+    "TrustSitelists": true, 
+    "UnmergedLFNBase": "/store/unmerged", 
+    "LumisPerJob": 8, 
+    "DashboardPort": 8884, 
+    "TimePerEvent": 13, 
+    "DQMSequences": [], 
+    "OutputModulesLFNBases": [
+      "/store/unmerged/DMWM_Test/DoubleMuon/DQMIO/ReReco_badBlocks_HG1812_Validation_Alan_v1112-v11", 
+      "/store/unmerged/DMWM_Test/DoubleMuon/ALCARECO/DtCalib-ReReco_badBlocks_HG1812_Validation_Alan_v1112-v11", 
+      "/store/unmerged/DMWM_Test/DoubleMuon/ALCARECO/MuAlCalIsolatedMu-ReReco_badBlocks_HG1812_Validation_Alan_v1112-v11", 
+      "/store/unmerged/DMWM_Test/DoubleMuon/AOD/ReReco_badBlocks_HG1812_Validation_Alan_v1112-v11", 
+      "/store/unmerged/DMWM_Test/DoubleMuon/ALCARECO/TkAlZMuMu-ReReco_badBlocks_HG1812_Validation_Alan_v1112-v11", 
+      "/store/unmerged/DMWM_Test/DoubleMuon/ALCARECO/MuAlZMuMu-ReReco_badBlocks_HG1812_Validation_Alan_v1112-v11", 
+      "/store/unmerged/DMWM_Test/DoubleMuon/ALCARECO/MuAlOverlaps-ReReco_badBlocks_HG1812_Validation_Alan_v1112-v11", 
+      "/store/unmerged/DMWM_Test/DoubleMuon/MINIAOD/ReReco_badBlocks_HG1812_Validation_Alan_v1112-v11"
+    ], 
+    "OutputDatasets": [
+      "/DoubleMuon/DMWM_Test-MuAlZMuMu-ReReco_badBlocks_HG1812_Validation_Alan_v1112-v11/ALCARECO", 
+      "/DoubleMuon/DMWM_Test-ReReco_badBlocks_HG1812_Validation_Alan_v1112-v11/MINIAOD", 
+      "/DoubleMuon/DMWM_Test-TkAlZMuMu-ReReco_badBlocks_HG1812_Validation_Alan_v1112-v11/ALCARECO", 
+      "/DoubleMuon/DMWM_Test-DtCalib-ReReco_badBlocks_HG1812_Validation_Alan_v1112-v11/ALCARECO", 
+      "/DoubleMuon/DMWM_Test-MuAlOverlaps-ReReco_badBlocks_HG1812_Validation_Alan_v1112-v11/ALCARECO", 
+      "/DoubleMuon/DMWM_Test-ReReco_badBlocks_HG1812_Validation_Alan_v1112-v11/DQMIO", 
+      "/DoubleMuon/DMWM_Test-ReReco_badBlocks_HG1812_Validation_Alan_v1112-v11/AOD", 
+      "/DoubleMuon/DMWM_Test-MuAlCalIsolatedMu-ReReco_badBlocks_HG1812_Validation_Alan_v1112-v11/ALCARECO"
+    ], 
+    "PrimaryDataset": null, 
+    "NonCustodialSubType": "Replica", 
+    "MaxMergeSize": 4294967296, 
+    "OverrideCatalog": null, 
+    "PeriodicHarvestInterval": 0, 
+    "TotalEstimatedJobs": 787, 
+    "MaxWaitTime": 86400, 
+    "RequestString": "ReReco_badBlocks_HG1812_Validation", 
+    "RequestorDN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+    "RunWhitelist": [
+      316877, 
+      316879, 
+      316928, 
+      316985
+    ], 
+    "RequestDate": [
+      2018, 
+      12, 
+      3, 
+      11, 
+      11, 
+      8
+    ], 
+    "InitialPriority": 210000, 
+    "RunNumber": 0, 
+    "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+    "EventStreams": null, 
+    "Memory": 14000, 
+    "Override": {
+      "Override": {
+        "eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/TESTBED"
+      }
+    }, 
+    "FilesPerJob": 1, 
+    "IncludeParents": false, 
+    "BlockWhitelist": [], 
+    "VoRole": "unknown", 
+    "PriorityTransition": [
+      {
+        "Priority": 210000, 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835468
+      }
+    ], 
+    "CMSSWVersion": "CMSSW_10_2_4_patch1", 
+    "NonCustodialSites": [], 
+    "GlobalTagConnect": null, 
+    "MinMergeSize": 2147483648, 
+    "RequestPriority": 210000, 
+    "ProcessingVersion": 11, 
+    "TotalInputLumis": 1306, 
+    "RequestName": "amaltaro_ReReco_badBlocks_HG1812_Validation_181203_121108_2682", 
+    "CouchURL": "https://alancc7-cloud1.cern.ch/couchdb", 
+    "CouchWorkloadDBName": "reqmgr_workload_cache", 
+    "RequestTransition": [
+      {
+        "Status": "new", 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835468
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assignment-approved", 
+        "UpdateTime": 1543835473
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assigned", 
+        "UpdateTime": 1543835474
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+        "Status": "acquired", 
+        "UpdateTime": 1543836340
+      }
+    ], 
+    "DQMUploadProxy": null, 
+    "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb", 
+    "_id": "amaltaro_ReReco_badBlocks_HG1812_Validation_181203_121108_2682", 
+    "Dashboard": "integration"
+  }, 
+  "amaltaro_MonteCarloFromGEN_HG1812_Validation_181203_120946_7160": {
+    "PrepID": "TEST-EXO-RunIISummer15GS-08440", 
+    "MaxMergeEvents": 100000000, 
+    "Comments": "Automatic EventAware setting 507 EpJob, around 2LpJob", 
+    "Requestor": "amaltaro", 
+    "RunBlacklist": [], 
+    "Group": "DATAOPS", 
+    "CustodialGroup": "DataOps", 
+    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev", 
+    "SubRequestType": "", 
+    "TrustPUSitelists": false, 
+    "HardTimeout": 129900, 
+    "OpenRunningTimeout": 0, 
+    "LumiList": {}, 
+    "DashboardHost": "cms-jobmon.cern.ch", 
+    "EnableHarvesting": false, 
+    "Scenario": null, 
+    "BlockCloseMaxWaitTime": 66400, 
+    "SiteWhitelist": [
+      "T1_US_FNAL", 
+      "T2_CH_CERN"
+    ], 
+    "BlockCloseMaxSize": 5000000000000, 
+    "DQMConfigCacheID": null, 
+    "DeterministicPileup": false, 
+    "ValidStatus": "PRODUCTION", 
+    "AcquisitionEra": "DMWM_Test", 
+    "GlobalTag": "MCRUN2_71_V1::All", 
+    "Campaign": "HG1812_Validation", 
+    "Multicore": 1, 
+    "EnableNewStageout": false, 
+    "NonCustodialGroup": "DataOps", 
+    "EventsPerJob": 507, 
+    "InputDataset": "/H1H2Jet_M80_400To800_13TeV-Calchep/RunIIWinter15pLHE-MCRUN2_71_V1-v1/LHE", 
+    "DeleteFromSource": false, 
+    "TotalInputEvents": 50000, 
+    "SizePerEvent": 747, 
+    "ConfigCacheID": "e86c9397d893f309853b83f87f674f6b", 
+    "DataPileup": null, 
+    "CustodialSubType": "Replica", 
+    "GracePeriod": 300, 
+    "MergedLFNBase": "/store/backfill/1", 
+    "CouchDBName": "reqmgr_config_cache", 
+    "SubscriptionPriority": "Low", 
+    "RobustMerge": true, 
+    "SplittingAlgo": "EventAwareLumiBased", 
+    "Team": "devvm-cloud1", 
+    "AllowOpportunistic": false, 
+    "DQMHarvestUnit": "byRun", 
+    "AutoApproveSubscriptionSites": [], 
+    "RequestWorkflow": "https://alancc7-cloud1.cern.ch/couchdb/reqmgr_workload_cache/amaltaro_MonteCarloFromGEN_HG1812_Validation_181203_120946_7160/spec", 
+    "BlockBlacklist": [], 
+    "BlockCloseMaxFiles": 500, 
+    "VoGroup": "unknown", 
+    "RequestType": "MonteCarloFromGEN", 
+    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/", 
+    "SiteBlacklist": [], 
+    "RequestStatus": "acquired", 
+    "SoftTimeout": 129600, 
+    "TotalInputFiles": 1, 
+    "BlockCloseMaxEvents": 25000000, 
+    "CustodialSites": [], 
+    "ProcessingString": "MonteCarloFromGEN_HG1812_Validation_Alan_v1112", 
+    "ScramArch": [
+      "slc6_amd64_gcc481"
+    ], 
+    "TrustSitelists": false, 
+    "UnmergedLFNBase": "/store/unmerged", 
+    "LumisPerJob": 8, 
+    "DashboardPort": 8884, 
+    "TimePerEvent": 56.8, 
+    "DQMSequences": [], 
+    "OutputModulesLFNBases": [
+      "/store/unmerged/DMWM_Test/H1H2Jet_M80_400To800_13TeV-Calchep/GEN-SIM/MonteCarloFromGEN_HG1812_Validation_Alan_v1112-v11"
+    ], 
+    "OutputDatasets": [
+      "/H1H2Jet_M80_400To800_13TeV-Calchep/DMWM_Test-MonteCarloFromGEN_HG1812_Validation_Alan_v1112-v11/GEN-SIM"
+    ], 
+    "PrimaryDataset": "H1H2Jet_M80_400To800_13TeV-Calchep", 
+    "NonCustodialSubType": "Replica", 
+    "MaxMergeSize": 4294967296, 
+    "OverrideCatalog": null, 
+    "PeriodicHarvestInterval": 0, 
+    "TotalEstimatedJobs": 99, 
+    "MaxWaitTime": 86400, 
+    "RequestString": "MonteCarloFromGEN_HG1812_Validation", 
+    "RequestorDN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+    "RunWhitelist": [], 
+    "RequestDate": [
+      2018, 
+      12, 
+      3, 
+      11, 
+      9, 
+      46
+    ], 
+    "InitialPriority": 180000, 
+    "RunNumber": 0, 
+    "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+    "EventStreams": null, 
+    "Memory": 1200, 
+    "Override": {
+      "eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/TESTBED"
+    }, 
+    "FilesPerJob": 1, 
+    "IncludeParents": false, 
+    "MCPileup": null, 
+    "BlockWhitelist": [], 
+    "VoRole": "unknown", 
+    "PriorityTransition": [
+      {
+        "Priority": 180000, 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835386
+      }
+    ], 
+    "CMSSWVersion": "CMSSW_7_1_25_patch2", 
+    "NonCustodialSites": [], 
+    "GlobalTagConnect": null, 
+    "MinMergeSize": 2147483648, 
+    "RequestPriority": 180000, 
+    "ProcessingVersion": 11, 
+    "TotalInputLumis": 250, 
+    "RequestName": "amaltaro_MonteCarloFromGEN_HG1812_Validation_181203_120946_7160", 
+    "CouchURL": "https://alancc7-cloud1.cern.ch/couchdb", 
+    "CouchWorkloadDBName": "reqmgr_workload_cache", 
+    "RequestTransition": [
+      {
+        "Status": "new", 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835386
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assignment-approved", 
+        "UpdateTime": 1543835391
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assigned", 
+        "UpdateTime": 1543835392
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+        "Status": "acquired", 
+        "UpdateTime": 1543836341
+      }
+    ], 
+    "DQMUploadProxy": null, 
+    "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb", 
+    "_id": "amaltaro_MonteCarloFromGEN_HG1812_Validation_181203_120946_7160", 
+    "Dashboard": "integration"
+  }, 
+  "amaltaro_MonteCarlo_eff_HG1812_Validation_181203_120941_3893": {
+    "PrepID": "TEST-EXO-RunIISummer15wmLHEGS-03608", 
+    "MaxMergeEvents": 100000000, 
+    "Comments": "Given 40 EpLumi, set 80 EpJob (instead of 87.3), so 2LpJ; Eff. < 1.0", 
+    "Requestor": "amaltaro", 
+    "Group": "DATAOPS", 
+    "CustodialGroup": "DataOps", 
+    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev", 
+    "SubRequestType": "", 
+    "TrustPUSitelists": false, 
+    "HardTimeout": 129900, 
+    "OpenRunningTimeout": 0, 
+    "LumiList": {}, 
+    "DashboardHost": "cms-jobmon.cern.ch", 
+    "EnableHarvesting": false, 
+    "BlockCloseMaxWaitTime": 66400, 
+    "SiteWhitelist": [
+      "T1_US_FNAL", 
+      "T2_CH_CERN"
+    ], 
+    "GlobalTagConnect": null, 
+    "DQMConfigCacheID": null, 
+    "DeterministicPileup": false, 
+    "ValidStatus": "PRODUCTION", 
+    "PriorityTransition": [
+      {
+        "Priority": 185000, 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835381
+      }
+    ], 
+    "Campaign": "HG1812_Validation", 
+    "GlobalTag": "MCRUN2_71_V1::All", 
+    "Multicore": 1, 
+    "CouchDBName": "reqmgr_config_cache", 
+    "NonCustodialGroup": "DataOps", 
+    "EventsPerJob": 80, 
+    "RequestNumEvents": 8000, 
+    "DeleteFromSource": false, 
+    "TotalInputEvents": 9382, 
+    "SizePerEvent": 1000, 
+    "ConfigCacheID": "3910f87c1c1ff387d33a6415da869b44", 
+    "DataPileup": null, 
+    "CustodialSubType": "Replica", 
+    "GracePeriod": 300, 
+    "MergedLFNBase": "/store/backfill/1", 
+    "EnableNewStageout": false, 
+    "SubscriptionPriority": "Low", 
+    "RobustMerge": true, 
+    "SplittingAlgo": "EventBased", 
+    "Team": "devvm-cloud1", 
+    "AllowOpportunistic": false, 
+    "DQMHarvestUnit": "byRun", 
+    "AutoApproveSubscriptionSites": [], 
+    "RequestWorkflow": "https://alancc7-cloud1.cern.ch/couchdb/reqmgr_workload_cache/amaltaro_MonteCarlo_eff_HG1812_Validation_181203_120941_3893/spec", 
+    "BlockCloseMaxFiles": 500, 
+    "VoGroup": "unknown", 
+    "RequestType": "MonteCarlo", 
+    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/", 
+    "SiteBlacklist": [], 
+    "RequestStatus": "acquired", 
+    "SoftTimeout": 129600, 
+    "TotalInputFiles": 0, 
+    "BlockCloseMaxEvents": 25000000, 
+    "CustodialSites": [], 
+    "ProcessingString": "MonteCarlo_eff_HG1812_Validation_Alan_v1112", 
+    "ScramArch": [
+      "slc6_amd64_gcc481"
+    ], 
+    "TrustSitelists": false, 
+    "UnmergedLFNBase": "/store/unmerged", 
+    "DashboardPort": 8884, 
+    "TimePerEvent": 330, 
+    "DQMSequences": [], 
+    "OutputModulesLFNBases": [
+      "/store/unmerged/DMWM_Test/SeesawTypeIII_SIGMAplusSIGMAminusHH_M-1180_13TeV-madgraph-pythia8/LHE/MonteCarlo_eff_HG1812_Validation_Alan_v1112-v11", 
+      "/store/unmerged/DMWM_Test/SeesawTypeIII_SIGMAplusSIGMAminusHH_M-1180_13TeV-madgraph-pythia8/GEN-SIM/MonteCarlo_eff_HG1812_Validation_Alan_v1112-v11"
+    ], 
+    "OutputDatasets": [
+      "/SeesawTypeIII_SIGMAplusSIGMAminusHH_M-1180_13TeV-madgraph-pythia8/DMWM_Test-MonteCarlo_eff_HG1812_Validation_Alan_v1112-v11/GEN-SIM", 
+      "/SeesawTypeIII_SIGMAplusSIGMAminusHH_M-1180_13TeV-madgraph-pythia8/DMWM_Test-MonteCarlo_eff_HG1812_Validation_Alan_v1112-v11/LHE"
+    ], 
+    "PrimaryDataset": "SeesawTypeIII_SIGMAplusSIGMAminusHH_M-1180_13TeV-madgraph-pythia8", 
+    "NonCustodialSubType": "Replica", 
+    "MaxMergeSize": 4294967296, 
+    "OverrideCatalog": null, 
+    "PeriodicHarvestInterval": 0, 
+    "TotalEstimatedJobs": 118, 
+    "MaxWaitTime": 86400, 
+    "RequestString": "MonteCarlo_eff_HG1812_Validation", 
+    "RequestorDN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+    "RequestDate": [
+      2018, 
+      12, 
+      3, 
+      11, 
+      9, 
+      41
+    ], 
+    "InitialPriority": 185000, 
+    "RunNumber": 0, 
+    "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+    "EventStreams": null, 
+    "Memory": 1000, 
+    "Override": {
+      "eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/TESTBED"
+    }, 
+    "IncludeParents": false, 
+    "MCPileup": null, 
+    "VoRole": "unknown", 
+    "AcquisitionEra": "DMWM_Test", 
+    "CMSSWVersion": "CMSSW_7_1_25_patch3", 
+    "NonCustodialSites": [], 
+    "BlockCloseMaxSize": 5000000000000, 
+    "MinMergeSize": 2147483648, 
+    "RequestPriority": 185000, 
+    "ProcessingVersion": 11, 
+    "TotalInputLumis": 235, 
+    "FirstEvent": 1, 
+    "RequestName": "amaltaro_MonteCarlo_eff_HG1812_Validation_181203_120941_3893", 
+    "LheInputFiles": false, 
+    "CouchURL": "https://alancc7-cloud1.cern.ch/couchdb", 
+    "CouchWorkloadDBName": "reqmgr_workload_cache", 
+    "RequestTransition": [
+      {
+        "Status": "new", 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835381
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assignment-approved", 
+        "UpdateTime": 1543835386
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assigned", 
+        "UpdateTime": 1543835387
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+        "Status": "acquired", 
+        "UpdateTime": 1543836340
+      }
+    ], 
+    "FirstLumi": 1, 
+    "FilterEfficiency": 0.8526879218, 
+    "DQMUploadProxy": null, 
+    "Seeding": "AutomaticSeeding", 
+    "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb", 
+    "_id": "amaltaro_MonteCarlo_eff_HG1812_Validation_181203_120941_3893", 
+    "EventsPerLumi": 40, 
+    "Dashboard": "integration"
+  }, 
+  "amaltaro_MonteCarlo_LHE_HG1812_Validation_181203_121113_7425": {
+    "PrepID": "TEST-HIG-RunIIWinter15pLHE-00330", 
+    "MaxMergeEvents": 100000000, 
+    "Comments": "Manual splitting at 50k EpJob and 1k EpLumi, so 50 LpJ; LheInputFiles enabled", 
+    "Requestor": "amaltaro", 
+    "Group": "DATAOPS", 
+    "CustodialGroup": "DataOps", 
+    "DQMUploadUrl": "https://cmsweb.cern.ch/dqm/dev", 
+    "SubRequestType": "", 
+    "TrustPUSitelists": false, 
+    "HardTimeout": 129900, 
+    "OpenRunningTimeout": 0, 
+    "LumiList": {}, 
+    "DashboardHost": "cms-jobmon.cern.ch", 
+    "EnableHarvesting": false, 
+    "BlockCloseMaxWaitTime": 66400, 
+    "SiteWhitelist": [
+      "T2_CH_CERN"
+    ], 
+    "GlobalTagConnect": null, 
+    "DQMConfigCacheID": null, 
+    "DeterministicPileup": false, 
+    "ValidStatus": "PRODUCTION", 
+    "PriorityTransition": [
+      {
+        "Priority": 170000, 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835473
+      }
+    ], 
+    "GlobalTag": "MCRUN2_71_V1::All", 
+    "Campaign": "HG1812_Validation", 
+    "Multicore": 1, 
+    "CouchDBName": "reqmgr_config_cache", 
+    "NonCustodialGroup": "DataOps", 
+    "EventsPerJob": 50000, 
+    "RequestNumEvents": 500000, 
+    "DeleteFromSource": false, 
+    "TotalInputEvents": 500000, 
+    "SizePerEvent": 3, 
+    "ConfigCacheID": "b233cc749d98d4ae0796ca3673cc5823", 
+    "DataPileup": null, 
+    "CustodialSubType": "Replica", 
+    "GracePeriod": 300, 
+    "MergedLFNBase": "/store/backfill/1", 
+    "EnableNewStageout": false, 
+    "SubscriptionPriority": "Low", 
+    "RobustMerge": true, 
+    "SplittingAlgo": "EventBased", 
+    "Team": "devvm-cloud1", 
+    "AllowOpportunistic": false, 
+    "DQMHarvestUnit": "byRun", 
+    "AutoApproveSubscriptionSites": [], 
+    "RequestWorkflow": "https://alancc7-cloud1.cern.ch/couchdb/reqmgr_workload_cache/amaltaro_MonteCarlo_LHE_HG1812_Validation_181203_121113_7425/spec", 
+    "BlockCloseMaxFiles": 500, 
+    "VoGroup": "unknown", 
+    "RequestType": "MonteCarlo", 
+    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/", 
+    "SiteBlacklist": [], 
+    "RequestStatus": "acquired", 
+    "SoftTimeout": 129600, 
+    "TotalInputFiles": 0, 
+    "BlockCloseMaxEvents": 25000000, 
+    "CustodialSites": [], 
+    "ProcessingString": "MonteCarlo_LHE_HG1812_Validation_Alan_v1112", 
+    "ScramArch": [
+      "slc6_amd64_gcc481"
+    ], 
+    "TrustSitelists": false, 
+    "UnmergedLFNBase": "/store/unmerged", 
+    "DashboardPort": 8884, 
+    "TimePerEvent": 5.576, 
+    "DQMSequences": [], 
+    "OutputModulesLFNBases": [
+      "/store/unmerged/DMWM_Test/VBFHToTauTau_0L1_M125_13TeV-JHUGenV6/LHE/MonteCarlo_LHE_HG1812_Validation_Alan_v1112-v11"
+    ], 
+    "OutputDatasets": [
+      "/VBFHToTauTau_0L1_M125_13TeV-JHUGenV6/DMWM_Test-MonteCarlo_LHE_HG1812_Validation_Alan_v1112-v11/LHE"
+    ], 
+    "PrimaryDataset": "VBFHToTauTau_0L1_M125_13TeV-JHUGenV6", 
+    "NonCustodialSubType": "Replica", 
+    "MaxMergeSize": 4294967296, 
+    "OverrideCatalog": null, 
+    "PeriodicHarvestInterval": 0, 
+    "TotalEstimatedJobs": 10, 
+    "MaxWaitTime": 86400, 
+    "RequestString": "MonteCarlo_LHE_HG1812_Validation", 
+    "RequestorDN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+    "RequestDate": [
+      2018, 
+      12, 
+      3, 
+      11, 
+      11, 
+      13
+    ], 
+    "InitialPriority": 170000, 
+    "RunNumber": 0, 
+    "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+    "EventStreams": null, 
+    "Memory": 1000, 
+    "Override": {
+      "eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/TESTBED"
+    }, 
+    "IncludeParents": false, 
+    "MCPileup": null, 
+    "VoRole": "unknown", 
+    "AcquisitionEra": "DMWM_Test", 
+    "CMSSWVersion": "CMSSW_7_1_16_patch2", 
+    "NonCustodialSites": [], 
+    "BlockCloseMaxSize": 5000000000000, 
+    "MinMergeSize": 2147483648, 
+    "RequestPriority": 170000, 
+    "ProcessingVersion": 11, 
+    "TotalInputLumis": 500, 
+    "FirstEvent": 1, 
+    "RequestName": "amaltaro_MonteCarlo_LHE_HG1812_Validation_181203_121113_7425", 
+    "LheInputFiles": true, 
+    "CouchURL": "https://alancc7-cloud1.cern.ch/couchdb", 
+    "CouchWorkloadDBName": "reqmgr_workload_cache", 
+    "RequestTransition": [
+      {
+        "Status": "new", 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835473
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assignment-approved", 
+        "UpdateTime": 1543835478
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assigned", 
+        "UpdateTime": 1543835478
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+        "Status": "acquired", 
+        "UpdateTime": 1543836341
+      }
+    ], 
+    "FirstLumi": 1, 
+    "FilterEfficiency": 1, 
+    "DQMUploadProxy": null, 
+    "Seeding": "AutomaticSeeding", 
+    "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb", 
+    "_id": "amaltaro_MonteCarlo_LHE_HG1812_Validation_181203_121113_7425", 
+    "EventsPerLumi": 1000, 
+    "Dashboard": "integration"
+  }, 
+  "amaltaro_ReDigi_3steps_HG1812_Validation_181203_120956_4300": {
+    "PrepID": "ReDigi-cmsRun3", 
+    "MaxMergeEvents": 50000, 
+    "Comments": "ReDigi with 3 separated steps; TpE and SpE provided for each step, sets 1371 EpJob; One block whitelisted; Don't write to prod/recent logs", 
+    "Requestor": "amaltaro", 
+    "RunBlacklist": [], 
+    "Group": "DATAOPS", 
+    "CustodialGroup": "DataOps", 
+    "DQMUploadUrl": "https://cmsweb.cern.ch/dqm/dev", 
+    "SubRequestType": "", 
+    "TrustPUSitelists": false, 
+    "HardTimeout": 129900, 
+    "OpenRunningTimeout": 3600, 
+    "LumiList": {}, 
+    "ValidStatus": "PRODUCTION", 
+    "DashboardHost": "cms-jobmon.cern.ch", 
+    "EnableHarvesting": false, 
+    "Scenario": null, 
+    "BlockCloseMaxWaitTime": 14400, 
+    "SiteWhitelist": [
+      "T1_US_FNAL", 
+      "T2_CH_CERN"
+    ], 
+    "BlockCloseMaxSize": 5000000000000, 
+    "DQMConfigCacheID": null, 
+    "DeterministicPileup": false, 
+    "StepThreeTimePerEvent": 23, 
+    "AcquisitionEra": "DMWM_Test", 
+    "Campaign": "HG1812_Validation", 
+    "GlobalTag": "94X_mc2017_realistic_v10", 
+    "Multicore": 1, 
+    "EnableNewStageout": false, 
+    "NonCustodialGroup": "DataOps", 
+    "EventsPerJob": 1371, 
+    "InputDataset": "/Chib2PToUpsilon2SGamma_TuneCP5_13TeV-pythia8-evtgen/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM", 
+    "DeleteFromSource": false, 
+    "TotalInputEvents": 43912, 
+    "SizePerEvent": 1600, 
+    "ConfigCacheID": null, 
+    "DataPileup": null, 
+    "StepThreeConfigCacheID": "c2ec78ab26b32d18525a1f9c277072af", 
+    "CustodialSubType": "Move", 
+    "StepThreeSizePerEvent": 3600, 
+    "GracePeriod": 300, 
+    "MergedLFNBase": "/store/backfill/1", 
+    "StepTwoSizePerEvent": 2600, 
+    "CouchDBName": "reqmgr_config_cache", 
+    "InitialPriority": 123000, 
+    "RobustMerge": true, 
+    "SplittingAlgo": "EventAwareLumiBased", 
+    "Team": "devvm-cloud1", 
+    "AllowOpportunistic": false, 
+    "DQMHarvestUnit": "byRun", 
+    "AutoApproveSubscriptionSites": [], 
+    "RequestWorkflow": "https://alancc7-cloud1.cern.ch/couchdb/reqmgr_workload_cache/amaltaro_ReDigi_3steps_HG1812_Validation_181203_120956_4300/spec", 
+    "BlockBlacklist": [], 
+    "BlockCloseMaxFiles": 500, 
+    "StepTwoMemory": null, 
+    "VoGroup": "unknown", 
+    "RequestType": "ReDigi", 
+    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/", 
+    "SiteBlacklist": [], 
+    "StepOneOutputModuleName": "PREMIXRAWoutput", 
+    "RequestStatus": "acquired", 
+    "KeepStepOneOutput": true, 
+    "SoftTimeout": 129600, 
+    "StepTwoTimePerEvent": 22, 
+    "TotalInputFiles": 7, 
+    "BlockCloseMaxEvents": 200000000, 
+    "CustodialSites": [], 
+    "ProcessingString": "ReDigi_3steps_HG1812_Validation_Alan_v1112", 
+    "ScramArch": [
+      "slc6_amd64_gcc630"
+    ], 
+    "TrustSitelists": false, 
+    "StepTwoConfigCacheID": "c2ec78ab26b32d18525a1f9c276e9267", 
+    "UnmergedLFNBase": "/store/unmerged", 
+    "LumisPerJob": 8, 
+    "DashboardPort": 8884, 
+    "TimePerEvent": 21, 
+    "DQMSequences": [], 
+    "OutputModulesLFNBases": [
+      "/store/unmerged/DMWM_Test/Chib2PToUpsilon2SGamma_TuneCP5_13TeV-pythia8-evtgen/GEN-SIM-RAW/ReDigi_3steps_HG1812_Validation_Alan_v1112-v11", 
+      "/store/unmerged/DMWM_Test/Chib2PToUpsilon2SGamma_TuneCP5_13TeV-pythia8-evtgen/AODSIM/ReDigi_3steps_HG1812_Validation_Alan_v1112-v11", 
+      "/store/unmerged/DMWM_Test/Chib2PToUpsilon2SGamma_TuneCP5_13TeV-pythia8-evtgen/MINIAODSIM/ReDigi_3steps_HG1812_Validation_Alan_v1112-v11"
+    ], 
+    "OutputDatasets": [
+      "/Chib2PToUpsilon2SGamma_TuneCP5_13TeV-pythia8-evtgen/DMWM_Test-ReDigi_3steps_HG1812_Validation_Alan_v1112-v11/GEN-SIM-RAW", 
+      "/Chib2PToUpsilon2SGamma_TuneCP5_13TeV-pythia8-evtgen/DMWM_Test-ReDigi_3steps_HG1812_Validation_Alan_v1112-v11/AODSIM", 
+      "/Chib2PToUpsilon2SGamma_TuneCP5_13TeV-pythia8-evtgen/DMWM_Test-ReDigi_3steps_HG1812_Validation_Alan_v1112-v11/MINIAODSIM"
+    ], 
+    "PrimaryDataset": "Chib2PToUpsilon2SGamma_TuneCP5_13TeV-pythia8-evtgen", 
+    "NonCustodialSubType": "Replica", 
+    "StepThreeMemory": null, 
+    "MaxMergeSize": 4294967296, 
+    "OverrideCatalog": null, 
+    "PeriodicHarvestInterval": 0, 
+    "TotalEstimatedJobs": 33, 
+    "MaxWaitTime": 86400, 
+    "RequestString": "ReDigi_3steps_HG1812_Validation", 
+    "RequestorDN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+    "RunWhitelist": [], 
+    "RequestDate": [
+      2018, 
+      12, 
+      3, 
+      11, 
+      9, 
+      56
+    ], 
+    "SubscriptionPriority": "Low", 
+    "RunNumber": 0, 
+    "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+    "EventStreams": null, 
+    "Memory": 8000, 
+    "Override": {
+      "eos-lfn-prefix": ""
+    }, 
+    "FilesPerJob": 1, 
+    "IncludeParents": false, 
+    "MCPileup": "/Neutrino_E-10_gun/RunIISummer17PrePremix-MC_v2_94X_mc2017_realistic_v9-v1/GEN-SIM-DIGI-RAW", 
+    "BlockWhitelist": [
+      "/Chib2PToUpsilon2SGamma_TuneCP5_13TeV-pythia8-evtgen/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM#4feb05dc-dc81-11e7-9df4-02163e01c3a1"
+    ], 
+    "StepTwoOutputModuleName": "AODSIMoutput", 
+    "VoRole": "unknown", 
+    "PriorityTransition": [
+      {
+        "Priority": 123000, 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835396
+      }
+    ], 
+    "CMSSWVersion": "CMSSW_9_4_0_patch1", 
+    "NonCustodialSites": [], 
+    "GlobalTagConnect": null, 
+    "MinMergeSize": 2147483648, 
+    "RequestPriority": 123000, 
+    "ProcessingVersion": 11, 
+    "TotalInputLumis": 49, 
+    "RequestName": "amaltaro_ReDigi_3steps_HG1812_Validation_181203_120956_4300", 
+    "KeepStepTwoOutput": true, 
+    "CouchURL": "https://alancc7-cloud1.cern.ch/couchdb", 
+    "CouchWorkloadDBName": "reqmgr_workload_cache", 
+    "RequestTransition": [
+      {
+        "Status": "new", 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835396
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assignment-approved", 
+        "UpdateTime": 1543835404
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assigned", 
+        "UpdateTime": 1543835405
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+        "Status": "acquired", 
+        "UpdateTime": 1543836341
+      }
+    ], 
+    "DQMUploadProxy": null, 
+    "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb", 
+    "_id": "amaltaro_ReDigi_3steps_HG1812_Validation_181203_120956_4300", 
+    "StepOneConfigCacheID": "c2ec78ab26b32d18525a1f9c276e3bb8", 
+    "Dashboard": "integration"
+  }, 
+  "amaltaro_ReDigi_BadTier_HG1812_Validation_181203_121724_3130": {
+    "PrepID": "TEST-BPH-RunIISpring16DR80-00037", 
+    "MaxMergeEvents": 100000000, 
+    "Comments": "ReDigi with a BAD [GEN-SIM-ALAN] datatier that will fail assignment", 
+    "Requestor": "amaltaro", 
+    "RunBlacklist": [], 
+    "DQMUploadUrl": "https://cmsweb.cern.ch/dqm/dev", 
+    "SubRequestType": "", 
+    "OpenRunningTimeout": 0, 
+    "LumiList": {
+      "1": [
+        [
+          11, 
+          11
+        ], 
+        [
+          23, 
+          23
+        ], 
+        [
+          72, 
+          72
+        ], 
+        [
+          96, 
+          96
+        ], 
+        [
+          132, 
+          132
+        ], 
+        [
+          203, 
+          204
+        ]
+      ]
+    }, 
+    "ValidStatus": "PRODUCTION", 
+    "DashboardHost": "cms-jobmon.cern.ch", 
+    "EnableHarvesting": false, 
+    "Scenario": null, 
+    "VoRole": "unknown", 
+    "DQMConfigCacheID": null, 
+    "DeterministicPileup": false, 
+    "StepThreeTimePerEvent": null, 
+    "PriorityTransition": [
+      {
+        "Priority": 900000, 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835844
+      }
+    ], 
+    "Campaign": "HG1812_Validation", 
+    "GlobalTag": "80X_mcRun2_asymptotic_2016_v3", 
+    "Multicore": 1, 
+    "EnableNewStageout": false, 
+    "EventsPerJob": null, 
+    "InputDataset": "/BuToJpsiK_SoftQCDnonD_TuneCUEP8M1_13TeV-pythia8-evtgen/RunIISummer15GS-MCRUN2_71_V1-v1/GEN-SIM", 
+    "DeleteFromSource": false, 
+    "SizePerEvent": 3500, 
+    "ConfigCacheID": null, 
+    "DataPileup": null, 
+    "StepThreeConfigCacheID": null, 
+    "StepThreeSizePerEvent": null, 
+    "MergedLFNBase": "/store/data", 
+    "StepTwoSizePerEvent": null, 
+    "CouchDBName": "reqmgr_config_cache", 
+    "RobustMerge": true, 
+    "SplittingAlgo": "LumiBased", 
+    "DQMHarvestUnit": "byRun", 
+    "RequestWorkflow": "https://alancc7-cloud1.cern.ch/couchdb/reqmgr_workload_cache/amaltaro_ReDigi_BadTier_HG1812_Validation_181203_121724_3130/spec", 
+    "BlockBlacklist": [], 
+    "StepTwoMemory": null, 
+    "VoGroup": "unknown", 
+    "DashboardPort": 8884, 
+    "DbsUrl": "https://cmsweb.cern.ch/dbs/prod/global/DBSReader/", 
+    "StepOneOutputModuleName": "RAWSIMoutput", 
+    "RequestStatus": "assignment-approved", 
+    "KeepStepOneOutput": true, 
+    "StepTwoTimePerEvent": null, 
+    "Group": "DATAOPS", 
+    "ProcessingString": "Integ_ProcStr_TEST", 
+    "ScramArch": [
+      "slc6_amd64_gcc530"
+    ], 
+    "StepTwoConfigCacheID": "5b1b8ee6341a111f57d81198fb99ae20", 
+    "UnmergedLFNBase": "/store/unmerged", 
+    "RequestType": "ReDigi", 
+    "TimePerEvent": 35, 
+    "DQMSequences": [], 
+    "OutputDatasets": [
+      "/BuToJpsiK_SoftQCDnonD_TuneCUEP8M1_13TeV-pythia8-evtgen/Integ_Test-Integ_ProcStr_TEST-v1/GEN-SIM-ALAN", 
+      "/BuToJpsiK_SoftQCDnonD_TuneCUEP8M1_13TeV-pythia8-evtgen/Integ_Test-Integ_ProcStr_TEST-v1/GEN-SIM-RECO", 
+      "/BuToJpsiK_SoftQCDnonD_TuneCUEP8M1_13TeV-pythia8-evtgen/Integ_Test-Integ_ProcStr_TEST-v1/DQMIO"
+    ], 
+    "PrimaryDataset": "BuToJpsiK_SoftQCDnonD_TuneCUEP8M1_13TeV-pythia8-evtgen", 
+    "StepThreeMemory": null, 
+    "MaxMergeSize": 4294967296, 
+    "OverrideCatalog": null, 
+    "PeriodicHarvestInterval": 0, 
+    "MaxWaitTime": 86400, 
+    "RequestString": "ReDigi_BadTier_HG1812_Validation", 
+    "RequestorDN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+    "RunWhitelist": [], 
+    "RequestDate": [
+      2018, 
+      12, 
+      3, 
+      11, 
+      17, 
+      24
+    ], 
+    "InitialPriority": 900000, 
+    "RunNumber": 0, 
+    "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+    "EventStreams": null, 
+    "Memory": 1980, 
+    "FilesPerJob": 1, 
+    "IncludeParents": false, 
+    "MCPileup": "/MinBias_TuneCUETP8M1_13TeV-pythia8/RunIISummer15GS-MCRUN2_71_V1-v2/GEN-SIM", 
+    "BlockWhitelist": [
+      "/QDTojWinc_NC_M-1400_TuneZ2star_8TeV-madgraph/Summer12-START53_V7C-v1/GEN-SIM#88227ef0-0bea-11e4-be54-003048f0e38c"
+    ], 
+    "StepTwoOutputModuleName": null, 
+    "LumisPerJob": 1, 
+    "AcquisitionEra": "Integ_Test", 
+    "CMSSWVersion": "CMSSW_8_0_3_patch2", 
+    "GlobalTagConnect": null, 
+    "MinMergeSize": 2147483648, 
+    "RequestPriority": 900000, 
+    "ProcessingVersion": 1, 
+    "RequestName": "amaltaro_ReDigi_BadTier_HG1812_Validation_181203_121724_3130", 
+    "KeepStepTwoOutput": true, 
+    "CouchURL": "https://alancc7-cloud1.cern.ch/couchdb", 
+    "CouchWorkloadDBName": "reqmgr_workload_cache", 
+    "RequestTransition": [
+      {
+        "Status": "new", 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835844
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assignment-approved", 
+        "UpdateTime": 1543835851
+      }
+    ], 
+    "DQMUploadProxy": null, 
+    "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb", 
+    "_id": "amaltaro_ReDigi_BadTier_HG1812_Validation_181203_121724_3130", 
+    "StepOneConfigCacheID": "7c03c83d92dbf10229026a04cfe72365"
+  }, 
+  "amaltaro_ReRecoSkim_HG1812_Validation_181203_121731_6800": {
+    "PrepID": "RERECOTEST-0001", 
+    "MaxMergeEvents": 50000, 
+    "Comments": "ReReco wf with one skim processing. Two runs whitelisted. 10l per job. Two hours opened. Xrootd enabled", 
+    "Requestor": "amaltaro", 
+    "RunBlacklist": [], 
+    "Group": "DATAOPS", 
+    "CustodialGroup": "DataOps", 
+    "DQMUploadUrl": "https://cmsweb.cern.ch/dqm/dev", 
+    "SubRequestType": "", 
+    "TrustPUSitelists": false, 
+    "HardTimeout": 129900, 
+    "OpenRunningTimeout": 3600, 
+    "LumiList": {}, 
+    "SkimInput1": "RECOoutput", 
+    "DashboardHost": "cms-jobmon.cern.ch", 
+    "EnableHarvesting": false, 
+    "Scenario": "pp", 
+    "BlockCloseMaxWaitTime": 72000, 
+    "SiteWhitelist": [
+      "T1_US_FNAL", 
+      "T2_CH_CERN"
+    ], 
+    "BlockCloseMaxSize": 5000000000000, 
+    "DQMConfigCacheID": null, 
+    "ValidStatus": "PRODUCTION", 
+    "AcquisitionEra": "Integ_Test", 
+    "Campaign": "HG1812_Validation", 
+    "GlobalTag": "FT_R_53_V18::All", 
+    "SkimName1": "skim_2012A_BTag", 
+    "Multicore": 1, 
+    "EnableNewStageout": false, 
+    "NonCustodialGroup": "DataOps", 
+    "EventsPerJob": null, 
+    "Skim1ConfigCacheID": "2f7942d681da6a0f0f7cbc8eb21fcec9", 
+    "InputDataset": "/BTag/Run2012A-v1/RAW", 
+    "DeleteFromSource": false, 
+    "TotalInputEvents": 14194, 
+    "SizePerEvent": 500, 
+    "ConfigCacheID": "2f7942d681da6a0f0f7cbc8eb21fd47e", 
+    "CustodialSubType": "Move", 
+    "GracePeriod": 300, 
+    "MergedLFNBase": "/store/backfill/1", 
+    "CouchDBName": "reqmgr_config_cache", 
+    "TransientOutputModules": [], 
+    "SubscriptionPriority": "Low", 
+    "RobustMerge": true, 
+    "SplittingAlgo": "LumiBased", 
+    "Team": "testbed-vocms0192", 
+    "AllowOpportunistic": false, 
+    "DQMHarvestUnit": "byRun", 
+    "AutoApproveSubscriptionSites": [], 
+    "RequestWorkflow": "https://alancc7-cloud1.cern.ch/couchdb/reqmgr_workload_cache/amaltaro_ReRecoSkim_HG1812_Validation_181203_121731_6800/spec", 
+    "BlockBlacklist": [], 
+    "BlockCloseMaxFiles": 500, 
+    "VoGroup": "unknown", 
+    "RequestType": "ReReco", 
+    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader", 
+    "SiteBlacklist": [], 
+    "RequestStatus": "acquired", 
+    "SoftTimeout": 129600, 
+    "TotalInputFiles": 2, 
+    "BlockCloseMaxEvents": 200000000, 
+    "CustodialSites": [], 
+    "ProcessingString": "ReRecoSkim_HG1812_Validation_TEST_Alan_v112", 
+    "ScramArch": [
+      "slc5_amd64_gcc462"
+    ], 
+    "TrustSitelists": true, 
+    "UnmergedLFNBase": "/store/unmerged", 
+    "LumisPerJob": 10, 
+    "DashboardPort": 8884, 
+    "TimePerEvent": 0.5, 
+    "DQMSequences": [], 
+    "OutputModulesLFNBases": [
+      "/store/unmerged/Integ_Test/BTag/DQM/ReRecoSkim_HG1812_Validation_TEST_Alan_v112-v11", 
+      "/store/unmerged/Integ_Test/BTag/USER/LogErrorMonitor-ReRecoSkim_HG1812_Validation_TEST_Alan_v112-v11", 
+      "/store/unmerged/Integ_Test/BTag/AOD/ReRecoSkim_HG1812_Validation_TEST_Alan_v112-v11", 
+      "/store/unmerged/Integ_Test/BTag/RAW-RECO/LogError-ReRecoSkim_HG1812_Validation_TEST_Alan_v112-v11", 
+      "/store/unmerged/Integ_Test/BTag/RAW-RECO/HighLumi-ReRecoSkim_HG1812_Validation_TEST_Alan_v112-v11", 
+      "/store/unmerged/Integ_Test/BTag/RECO/ReRecoSkim_HG1812_Validation_TEST_Alan_v112-v11"
+    ], 
+    "OutputDatasets": [
+      "/BTag/Integ_Test-ReRecoSkim_HG1812_Validation_TEST_Alan_v112-v11/RECO", 
+      "/BTag/Integ_Test-HighLumi-ReRecoSkim_HG1812_Validation_TEST_Alan_v112-v11/RAW-RECO", 
+      "/BTag/Integ_Test-LogError-ReRecoSkim_HG1812_Validation_TEST_Alan_v112-v11/RAW-RECO", 
+      "/BTag/Integ_Test-LogErrorMonitor-ReRecoSkim_HG1812_Validation_TEST_Alan_v112-v11/USER", 
+      "/BTag/Integ_Test-ReRecoSkim_HG1812_Validation_TEST_Alan_v112-v11/DQM", 
+      "/BTag/Integ_Test-ReRecoSkim_HG1812_Validation_TEST_Alan_v112-v11/AOD"
+    ], 
+    "PrimaryDataset": null, 
+    "NonCustodialSubType": "Replica", 
+    "MaxMergeSize": 4294967296, 
+    "OverrideCatalog": null, 
+    "PeriodicHarvestInterval": 0, 
+    "TotalEstimatedJobs": 20, 
+    "MaxWaitTime": 86400, 
+    "RequestString": "ReRecoSkim_HG1812_Validation", 
+    "RequestorDN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+    "RunWhitelist": [
+      193556, 
+      193557
+    ], 
+    "RequestDate": [
+      2018, 
+      12, 
+      3, 
+      11, 
+      17, 
+      31
+    ], 
+    "InitialPriority": 50000, 
+    "RunNumber": 0, 
+    "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+    "EventStreams": null, 
+    "Memory": 2394, 
+    "Override": {
+      "eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/TESTBED"
+    }, 
+    "FilesPerJob": 1, 
+    "IncludeParents": false, 
+    "BlockWhitelist": [], 
+    "VoRole": "unknown", 
+    "PriorityTransition": [
+      {
+        "Priority": 50000, 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835851
+      }
+    ], 
+    "CMSSWVersion": "CMSSW_5_3_7_patch5", 
+    "NonCustodialSites": [], 
+    "GlobalTagConnect": null, 
+    "MinMergeSize": 2147483648, 
+    "RequestPriority": 50000, 
+    "ProcessingVersion": 11, 
+    "TotalInputLumis": 193, 
+    "RequestName": "amaltaro_ReRecoSkim_HG1812_Validation_181203_121731_6800", 
+    "CouchURL": "https://alancc7-cloud1.cern.ch/couchdb", 
+    "CouchWorkloadDBName": "reqmgr_workload_cache", 
+    "RequestTransition": [
+      {
+        "Status": "new", 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835851
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assignment-approved", 
+        "UpdateTime": 1543835857
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assigned", 
+        "UpdateTime": 1543835858
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+        "Status": "acquired", 
+        "UpdateTime": 1543836945
+      }
+    ], 
+    "DQMUploadProxy": null, 
+    "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb", 
+    "_id": "amaltaro_ReRecoSkim_HG1812_Validation_181203_121731_6800", 
+    "Dashboard": "integration"
+  }, 
+  "amaltaro_ReDigi_HG1812_Validation_181203_121719_3698": {
+    "PrepID": "TEST-B2G-RunIISummer16MiniAODv2-00972", 
+    "MaxMergeEvents": 100000000, 
+    "Comments": "MiniAOD ReDigi with 4 cores and no PU", 
+    "Requestor": "amaltaro", 
+    "RunBlacklist": [], 
+    "Group": "DATAOPS", 
+    "CustodialGroup": "DataOps", 
+    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev", 
+    "SubRequestType": "", 
+    "TrustPUSitelists": false, 
+    "HardTimeout": 129900, 
+    "OpenRunningTimeout": 0, 
+    "LumiList": {}, 
+    "ValidStatus": "PRODUCTION", 
+    "DashboardHost": "cms-jobmon.cern.ch", 
+    "EnableHarvesting": false, 
+    "Scenario": null, 
+    "BlockCloseMaxWaitTime": 66400, 
+    "SiteWhitelist": [
+      "T1_US_FNAL", 
+      "T2_CH_CERN"
+    ], 
+    "BlockCloseMaxSize": 5000000000000, 
+    "DQMConfigCacheID": null, 
+    "DeterministicPileup": false, 
+    "StepThreeTimePerEvent": null, 
+    "AcquisitionEra": "Integ_Test", 
+    "GlobalTag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6", 
+    "Campaign": "HG1812_Validation", 
+    "ScramArch": [
+      "slc6_amd64_gcc530"
+    ], 
+    "EnableNewStageout": false, 
+    "NonCustodialGroup": "DataOps", 
+    "EventsPerJob": 19200, 
+    "InputDataset": "/BprimeBprime_M-1600_TuneCUETP8M1_13TeV-madgraph-pythia8/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM", 
+    "DeleteFromSource": false, 
+    "TotalInputEvents": 684000, 
+    "SizePerEvent": 60, 
+    "ConfigCacheID": null, 
+    "DataPileup": null, 
+    "StepThreeConfigCacheID": null, 
+    "CustodialSubType": "Replica", 
+    "StepThreeSizePerEvent": null, 
+    "GracePeriod": 300, 
+    "MergedLFNBase": "/store/backfill/1", 
+    "StepTwoSizePerEvent": null, 
+    "CouchDBName": "reqmgr_config_cache", 
+    "InitialPriority": 185000, 
+    "RobustMerge": true, 
+    "SplittingAlgo": "EventAwareLumiBased", 
+    "Team": "testbed-vocms0192", 
+    "AllowOpportunistic": false, 
+    "DQMHarvestUnit": "byRun", 
+    "AutoApproveSubscriptionSites": [], 
+    "RequestWorkflow": "https://alancc7-cloud1.cern.ch/couchdb/reqmgr_workload_cache/amaltaro_ReDigi_HG1812_Validation_181203_121719_3698/spec", 
+    "BlockBlacklist": [], 
+    "BlockCloseMaxFiles": 500, 
+    "StepTwoMemory": null, 
+    "VoGroup": "unknown", 
+    "RequestType": "ReDigi", 
+    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/", 
+    "SiteBlacklist": [], 
+    "StepOneOutputModuleName": null, 
+    "RequestStatus": "acquired", 
+    "KeepStepOneOutput": true, 
+    "SoftTimeout": 129600, 
+    "StepTwoTimePerEvent": null, 
+    "TotalInputFiles": 88, 
+    "BlockCloseMaxEvents": 25000000, 
+    "CustodialSites": [], 
+    "ProcessingString": "ReDigi_HG1812_Validation_TEST_Alan_v112", 
+    "Multicore": 4, 
+    "TrustSitelists": false, 
+    "StepTwoConfigCacheID": null, 
+    "UnmergedLFNBase": "/store/unmerged", 
+    "LumisPerJob": 8, 
+    "DashboardPort": 8884, 
+    "TimePerEvent": 1.5, 
+    "DQMSequences": [], 
+    "OutputModulesLFNBases": [
+      "/store/unmerged/Integ_Test/BprimeBprime_M-1600_TuneCUETP8M1_13TeV-madgraph-pythia8/MINIAODSIM/ReDigi_HG1812_Validation_TEST_Alan_v112-v11"
+    ], 
+    "OutputDatasets": [
+      "/BprimeBprime_M-1600_TuneCUETP8M1_13TeV-madgraph-pythia8/Integ_Test-ReDigi_HG1812_Validation_TEST_Alan_v112-v11/MINIAODSIM"
+    ], 
+    "PrimaryDataset": "BprimeBprime_M-1600_TuneCUETP8M1_13TeV-madgraph-pythia8", 
+    "NonCustodialSubType": "Replica", 
+    "StepThreeMemory": null, 
+    "MaxMergeSize": 4294967296, 
+    "OverrideCatalog": null, 
+    "PeriodicHarvestInterval": 0, 
+    "TotalEstimatedJobs": 36, 
+    "MaxWaitTime": 86400, 
+    "RequestString": "ReDigi_HG1812_Validation", 
+    "RequestorDN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+    "RunWhitelist": [], 
+    "RequestDate": [
+      2018, 
+      12, 
+      3, 
+      11, 
+      17, 
+      19
+    ], 
+    "SubscriptionPriority": "Low", 
+    "RunNumber": 0, 
+    "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+    "EventStreams": null, 
+    "Memory": 1900, 
+    "Override": {
+      "eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/TESTBED"
+    }, 
+    "FilesPerJob": 1, 
+    "IncludeParents": false, 
+    "MCPileup": null, 
+    "BlockWhitelist": [], 
+    "StepTwoOutputModuleName": null, 
+    "VoRole": "unknown", 
+    "PriorityTransition": [
+      {
+        "Priority": 185000, 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835839
+      }
+    ], 
+    "CMSSWVersion": "CMSSW_8_0_21", 
+    "NonCustodialSites": [], 
+    "GlobalTagConnect": null, 
+    "MinMergeSize": 2147483648, 
+    "RequestPriority": 185000, 
+    "ProcessingVersion": 11, 
+    "TotalInputLumis": 3420, 
+    "RequestName": "amaltaro_ReDigi_HG1812_Validation_181203_121719_3698", 
+    "KeepStepTwoOutput": true, 
+    "CouchURL": "https://alancc7-cloud1.cern.ch/couchdb", 
+    "CouchWorkloadDBName": "reqmgr_workload_cache", 
+    "RequestTransition": [
+      {
+        "Status": "new", 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835839
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assignment-approved", 
+        "UpdateTime": 1543835844
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assigned", 
+        "UpdateTime": 1543835844
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+        "Status": "acquired", 
+        "UpdateTime": 1543836945
+      }
+    ], 
+    "DQMUploadProxy": null, 
+    "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb", 
+    "_id": "amaltaro_ReDigi_HG1812_Validation_181203_121719_3698", 
+    "StepOneConfigCacheID": "08f0caca17411fd89e0adbdd7f1f82f4", 
+    "Dashboard": "integration"
+  }, 
+  "amaltaro_TaskChain_PUMCRecyc_HG1812_Validation_181203_121738_3187": {
+    "PrepID": "TEST-PUMCRecyc-TopLevel", 
+    "MaxMergeEvents": 100000000, 
+    "Comments": "PU recycling with 4 cores; 4.5GB for Task1, 9GB for Task2; PrepID at top level and Task2; DeterministicPU enabled for both tasks; Harvesting enabled", 
+    "Requestor": "amaltaro", 
+    "IgnoredOutputModules": [], 
+    "Group": "DATAOPS", 
+    "ChainParentageMap": {
+      "Task1": {
+        "ParentDset": "/RelValH125GGgluonfusion_13/CMSSW_8_1_0-81X_upgrade2017_realistic_v26-v1/GEN-SIM", 
+        "ChildDsets": [
+          "/RelValH125GGgluonfusion_13/CMSSW_8_1_0-DigiFullPU_2017PU_TaskChain_PUMCRecyc_HG1812_Validation_TEST_Alan_v112-v11/GEN-SIM-DIGI-RAW"
+        ]
+      }, 
+      "Task2": {
+        "ParentDset": "/RelValH125GGgluonfusion_13/CMSSW_8_1_0-DigiFullPU_2017PU_TaskChain_PUMCRecyc_HG1812_Validation_TEST_Alan_v112-v11/GEN-SIM-DIGI-RAW", 
+        "ChildDsets": [
+          "/RelValH125GGgluonfusion_13/CMSSW_8_1_0-RecoFullPU_2017PU_TaskChain_PUMCRecyc_HG1812_Validation_TEST_Alan_v112-v11/DQMIO", 
+          "/RelValH125GGgluonfusion_13/CMSSW_8_1_0-RecoFullPU_2017PU_TaskChain_PUMCRecyc_HG1812_Validation_TEST_Alan_v112-v11/GEN-SIM-RECO", 
+          "/RelValH125GGgluonfusion_13/CMSSW_8_1_0-RecoFullPU_2017PU_TaskChain_PUMCRecyc_HG1812_Validation_TEST_Alan_v112-v11/MINIAODSIM"
+        ]
+      }
+    }, 
+    "CustodialGroup": "DataOps", 
+    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev", 
+    "SubRequestType": "RelVal", 
+    "TrustPUSitelists": false, 
+    "HardTimeout": 129900, 
+    "OpenRunningTimeout": 0, 
+    "LumiList": {}, 
+    "DashboardHost": "cms-jobmon.cern.ch", 
+    "EnableHarvesting": true, 
+    "BlockCloseMaxWaitTime": 66400, 
+    "SiteWhitelist": [
+      "T1_US_FNAL", 
+      "T2_CH_CERN"
+    ], 
+    "GlobalTagConnect": null, 
+    "DQMConfigCacheID": "e2a5c7c675f60b4777564d5dd16b0dcd", 
+    "ValidStatus": "PRODUCTION", 
+    "PriorityTransition": [
+      {
+        "Priority": 600000, 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835858
+      }
+    ], 
+    "Campaign": "HG1812_Validation", 
+    "GlobalTag": "81X_upgrade2017_realistic_v26", 
+    "Multicore": 1, 
+    "EnableNewStageout": false, 
+    "NonCustodialGroup": "DataOps", 
+    "DeleteFromSource": false, 
+    "TotalInputEvents": 9000, 
+    "SizePerEvent": 1234, 
+    "ConfigCacheID": null, 
+    "Task1": {
+      "InputDataset": "/RelValH125GGgluonfusion_13/CMSSW_8_1_0-81X_upgrade2017_realistic_v26-v1/GEN-SIM", 
+      "KeepOutput": true, 
+      "MCPileup": "/RelValMinBias_13/CMSSW_8_1_0-81X_upgrade2017_realistic_v26-v1/GEN-SIM", 
+      "ConfigCacheID": "e2a5c7c675f60b4777564d5dd157112a", 
+      "GlobalTag": "81X_upgrade2017_realistic_v26", 
+      "Memory": 4500, 
+      "SplittingAlgo": "LumiBased", 
+      "ProcessingString": "DigiFullPU_2017PU_TaskChain_PUMCRecyc_HG1812_Validation_TEST_Alan_v112", 
+      "Multicore": 4, 
+      "DeterministicPileup": true, 
+      "LumisPerJob": 10, 
+      "TaskName": "DigiFullPU_2017PU", 
+      "AcquisitionEra": "CMSSW_8_1_0"
+    }, 
+    "Task2": {
+      "KeepOutput": true, 
+      "MCPileup": "/RelValMinBias_13/CMSSW_8_1_0-81X_upgrade2017_realistic_v26-v1/GEN-SIM", 
+      "PrepID": "TEST-PUMCRecyc-Task2", 
+      "InputFromOutputModule": "FEVTDEBUGHLToutput", 
+      "GlobalTag": "81X_upgrade2017_realistic_v26", 
+      "Memory": 9000, 
+      "ProcessingString": "RecoFullPU_2017PU_TaskChain_PUMCRecyc_HG1812_Validation_TEST_Alan_v112", 
+      "SplittingAlgo": "LumiBased", 
+      "InputTask": "DigiFullPU_2017PU", 
+      "Multicore": 4, 
+      "DeterministicPileup": true, 
+      "LumisPerJob": 10, 
+      "TaskName": "RecoFullPU_2017PU", 
+      "AcquisitionEra": "CMSSW_8_1_0", 
+      "ConfigCacheID": "e2a5c7c675f60b4777564d5dd15b240e"
+    }, 
+    "CustodialSubType": "Replica", 
+    "GracePeriod": 300, 
+    "MergedLFNBase": "/store/backfill/1", 
+    "CouchDBName": "reqmgr_config_cache", 
+    "SubscriptionPriority": "Low", 
+    "RobustMerge": true, 
+    "Team": "testbed-vocms0192", 
+    "AllowOpportunistic": false, 
+    "DQMHarvestUnit": "byRun", 
+    "AutoApproveSubscriptionSites": [], 
+    "RequestWorkflow": "https://alancc7-cloud1.cern.ch/couchdb/reqmgr_workload_cache/amaltaro_TaskChain_PUMCRecyc_HG1812_Validation_181203_121738_3187/spec", 
+    "BlockCloseMaxFiles": 500, 
+    "VoGroup": "unknown", 
+    "RequestType": "TaskChain", 
+    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/", 
+    "SiteBlacklist": [], 
+    "TaskChain": 2, 
+    "RequestStatus": "acquired", 
+    "SoftTimeout": 129600, 
+    "TotalInputFiles": 4, 
+    "BlockCloseMaxEvents": 25000000, 
+    "CustodialSites": [], 
+    "ProcessingString": {
+      "RecoFullPU_2017PU": "RecoFullPU_2017PU_TaskChain_PUMCRecyc_HG1812_Validation_TEST_Alan_v112", 
+      "DigiFullPU_2017PU": "DigiFullPU_2017PU_TaskChain_PUMCRecyc_HG1812_Validation_TEST_Alan_v112"
+    }, 
+    "ScramArch": [
+      "slc6_amd64_gcc530"
+    ], 
+    "TrustSitelists": false, 
+    "UnmergedLFNBase": "/store/unmerged", 
+    "DashboardPort": 8884, 
+    "TimePerEvent": 0.1, 
+    "DQMSequences": [], 
+    "OutputModulesLFNBases": [
+      "/store/unmerged/CMSSW_8_1_0/RelValH125GGgluonfusion_13/GEN-SIM-RECO/RecoFullPU_2017PU_TaskChain_PUMCRecyc_HG1812_Validation_TEST_Alan_v112-v11", 
+      "/store/unmerged/CMSSW_8_1_0/RelValH125GGgluonfusion_13/GEN-SIM-DIGI-RAW/DigiFullPU_2017PU_TaskChain_PUMCRecyc_HG1812_Validation_TEST_Alan_v112-v11", 
+      "/store/unmerged/CMSSW_8_1_0/RelValH125GGgluonfusion_13/DQMIO/RecoFullPU_2017PU_TaskChain_PUMCRecyc_HG1812_Validation_TEST_Alan_v112-v11", 
+      "/store/unmerged/CMSSW_8_1_0/RelValH125GGgluonfusion_13/MINIAODSIM/RecoFullPU_2017PU_TaskChain_PUMCRecyc_HG1812_Validation_TEST_Alan_v112-v11"
+    ], 
+    "OutputDatasets": [
+      "/RelValH125GGgluonfusion_13/CMSSW_8_1_0-DigiFullPU_2017PU_TaskChain_PUMCRecyc_HG1812_Validation_TEST_Alan_v112-v11/GEN-SIM-DIGI-RAW", 
+      "/RelValH125GGgluonfusion_13/CMSSW_8_1_0-RecoFullPU_2017PU_TaskChain_PUMCRecyc_HG1812_Validation_TEST_Alan_v112-v11/GEN-SIM-RECO", 
+      "/RelValH125GGgluonfusion_13/CMSSW_8_1_0-RecoFullPU_2017PU_TaskChain_PUMCRecyc_HG1812_Validation_TEST_Alan_v112-v11/DQMIO", 
+      "/RelValH125GGgluonfusion_13/CMSSW_8_1_0-RecoFullPU_2017PU_TaskChain_PUMCRecyc_HG1812_Validation_TEST_Alan_v112-v11/MINIAODSIM"
+    ], 
+    "NonCustodialSubType": "Replica", 
+    "MaxMergeSize": 4294967296, 
+    "OverrideCatalog": null, 
+    "PeriodicHarvestInterval": 0, 
+    "TotalEstimatedJobs": 18, 
+    "MaxWaitTime": 86400, 
+    "RequestString": "TaskChain_PUMCRecyc_HG1812_Validation", 
+    "RequestorDN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+    "RequestDate": [
+      2018, 
+      12, 
+      3, 
+      11, 
+      17, 
+      38
+    ], 
+    "InitialPriority": 600000, 
+    "RunNumber": 0, 
+    "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+    "EventStreams": null, 
+    "Memory": 3000, 
+    "Override": {
+      "eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/TESTBED"
+    }, 
+    "IncludeParents": false, 
+    "VoRole": "unknown", 
+    "AcquisitionEra": {
+      "RecoFullPU_2017PU": "CMSSW_8_1_0", 
+      "DigiFullPU_2017PU": "CMSSW_8_1_0"
+    }, 
+    "CMSSWVersion": "CMSSW_8_1_0", 
+    "NonCustodialSites": [], 
+    "BlockCloseMaxSize": 5000000000000, 
+    "MinMergeSize": 2147483648, 
+    "RequestPriority": 600000, 
+    "ProcessingVersion": 11, 
+    "TotalInputLumis": 180, 
+    "FirstEvent": 1, 
+    "RequestName": "amaltaro_TaskChain_PUMCRecyc_HG1812_Validation_181203_121738_3187", 
+    "CouchURL": "https://alancc7-cloud1.cern.ch/couchdb", 
+    "CouchWorkloadDBName": "reqmgr_workload_cache", 
+    "RequestTransition": [
+      {
+        "Status": "new", 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835858
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assignment-approved", 
+        "UpdateTime": 1543835866
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assigned", 
+        "UpdateTime": 1543835866
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+        "Status": "acquired", 
+        "UpdateTime": 1543836945
+      }
+    ], 
+    "FirstLumi": 1, 
+    "DQMUploadProxy": null, 
+    "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb", 
+    "_id": "amaltaro_TaskChain_PUMCRecyc_HG1812_Validation_181203_121738_3187", 
+    "Dashboard": "integration"
+  }, 
+  "amaltaro_TaskChain_NanoAOD_HG1812_Validation_181203_120951_9572": {
+    "PrepID": "TEST-task_SUS-RunIIFall17NanoAOD-00019", 
+    "MaxMergeEvents": 100000000, 
+    "Comments": "Process MINIAOD to NANO with EventAware; Automatic split at 711 EpJob; Multicore 8; Memory 4000", 
+    "Requestor": "amaltaro", 
+    "IgnoredOutputModules": [], 
+    "Group": "DATAOPS", 
+    "ChainParentageMap": {
+      "Task1": {
+        "ParentDset": "/WJetsToLNu_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM", 
+        "ChildDsets": [
+          "/WJetsToLNu_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAOD-RunIIFall17NanoAOD_TaskChain_NanoAOD_HG1812_Validation_Alan_v1112-v11/NANOAODSIM"
+        ]
+      }
+    }, 
+    "CustodialGroup": "DataOps", 
+    "DQMUploadUrl": "https://cmsweb.cern.ch/dqm/dev", 
+    "SubRequestType": "Alan", 
+    "TrustPUSitelists": false, 
+    "HardTimeout": 129900, 
+    "OpenRunningTimeout": 0, 
+    "LumiList": {}, 
+    "DashboardHost": "cms-jobmon.cern.ch", 
+    "EnableHarvesting": false, 
+    "BlockCloseMaxWaitTime": 66400, 
+    "SiteWhitelist": [
+      "T1_US_FNAL", 
+      "T2_CH_CERN"
+    ], 
+    "GlobalTagConnect": null, 
+    "DQMConfigCacheID": null, 
+    "ValidStatus": "PRODUCTION", 
+    "PriorityTransition": [
+      {
+        "Priority": 800000, 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835391
+      }
+    ], 
+    "Campaign": "HG1812_Validation", 
+    "GlobalTag": "94X_mcRun2_asymptotic_v2", 
+    "ScramArch": [
+      "slc6_amd64_gcc630"
+    ], 
+    "EnableNewStageout": false, 
+    "NonCustodialGroup": "DataOps", 
+    "DeleteFromSource": false, 
+    "TotalInputEvents": 14815928, 
+    "SizePerEvent": 5.25, 
+    "ConfigCacheID": null, 
+    "Task1": {
+      "InputDataset": "/WJetsToLNu_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM", 
+      "Campaign": "RunIIFall17NanoAOD", 
+      "GlobalTag": "94X_mcRun2_asymptotic_v2", 
+      "SplittingAlgo": "EventAwareLumiBased", 
+      "ProcessingString": "RunIIFall17NanoAOD_TaskChain_NanoAOD_HG1812_Validation_Alan_v1112", 
+      "ConfigCacheID": "2a58f56f5ee74ecc34c76d1bce3d1268", 
+      "TaskName": "RunIIFall17NanoAOD", 
+      "AcquisitionEra": "RunIIFall17NanoAOD", 
+      "EventsPerJob": 288000, 
+      "EventsPerLumi": 288000
+    }, 
+    "CustodialSubType": "Replica", 
+    "GracePeriod": 300, 
+    "MergedLFNBase": "/store/backfill/1", 
+    "CouchDBName": "reqmgr_config_cache", 
+    "SubscriptionPriority": "Low", 
+    "RobustMerge": true, 
+    "Team": "devvm-cloud1", 
+    "AllowOpportunistic": false, 
+    "DQMHarvestUnit": "byRun", 
+    "AutoApproveSubscriptionSites": [], 
+    "RequestWorkflow": "https://alancc7-cloud1.cern.ch/couchdb/reqmgr_workload_cache/amaltaro_TaskChain_NanoAOD_HG1812_Validation_181203_120951_9572/spec", 
+    "BlockCloseMaxFiles": 500, 
+    "VoGroup": "unknown", 
+    "RequestType": "TaskChain", 
+    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/", 
+    "SiteBlacklist": [], 
+    "TaskChain": 1, 
+    "RequestStatus": "acquired", 
+    "SoftTimeout": 129600, 
+    "TotalInputFiles": 186, 
+    "BlockCloseMaxEvents": 25000000, 
+    "CustodialSites": [], 
+    "ProcessingString": {
+      "RunIIFall17NanoAOD": "RunIIFall17NanoAOD_TaskChain_NanoAOD_HG1812_Validation_Alan_v1112"
+    }, 
+    "Multicore": 8, 
+    "TrustSitelists": false, 
+    "UnmergedLFNBase": "/store/unmerged", 
+    "DashboardPort": 8884, 
+    "TimePerEvent": 0.1, 
+    "DQMSequences": [], 
+    "OutputModulesLFNBases": [
+      "/store/unmerged/RunIIFall17NanoAOD/WJetsToLNu_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/NANOAODSIM/RunIIFall17NanoAOD_TaskChain_NanoAOD_HG1812_Validation_Alan_v1112-v11"
+    ], 
+    "OutputDatasets": [
+      "/WJetsToLNu_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIIFall17NanoAOD-RunIIFall17NanoAOD_TaskChain_NanoAOD_HG1812_Validation_Alan_v1112-v11/NANOAODSIM"
+    ], 
+    "NonCustodialSubType": "Replica", 
+    "MaxMergeSize": 4294967296, 
+    "OverrideCatalog": null, 
+    "PeriodicHarvestInterval": 0, 
+    "TotalEstimatedJobs": 61, 
+    "MaxWaitTime": 86400, 
+    "RequestString": "TaskChain_NanoAOD_HG1812_Validation", 
+    "RequestorDN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+    "RequestDate": [
+      2018, 
+      12, 
+      3, 
+      11, 
+      9, 
+      51
+    ], 
+    "InitialPriority": 800000, 
+    "RunNumber": 0, 
+    "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+    "EventStreams": null, 
+    "Memory": 4000, 
+    "Override": {
+      "eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/TESTBED"
+    }, 
+    "IncludeParents": false, 
+    "VoRole": "unknown", 
+    "AcquisitionEra": {
+      "RunIIFall17NanoAOD": "RunIIFall17NanoAOD"
+    }, 
+    "CMSSWVersion": "CMSSW_9_4_2", 
+    "NonCustodialSites": [], 
+    "BlockCloseMaxSize": 5000000000000, 
+    "MinMergeSize": 2147483648, 
+    "RequestPriority": 800000, 
+    "ProcessingVersion": 11, 
+    "TotalInputLumis": 108330, 
+    "FirstEvent": 1, 
+    "RequestName": "amaltaro_TaskChain_NanoAOD_HG1812_Validation_181203_120951_9572", 
+    "CouchURL": "https://alancc7-cloud1.cern.ch/couchdb", 
+    "CouchWorkloadDBName": "reqmgr_workload_cache", 
+    "RequestTransition": [
+      {
+        "Status": "new", 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835391
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assignment-approved", 
+        "UpdateTime": 1543835396
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assigned", 
+        "UpdateTime": 1543835396
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+        "Status": "acquired", 
+        "UpdateTime": 1543836341
+      }
+    ], 
+    "FirstLumi": 1, 
+    "DQMUploadProxy": null, 
+    "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb", 
+    "_id": "amaltaro_TaskChain_NanoAOD_HG1812_Validation_181203_120951_9572", 
+    "Dashboard": "integration"
+  }, 
+  "amaltaro_TaskChain_ProdMinBias_HG1812_Validation_181203_121009_5217": {
+    "PrepID": null, 
+    "MaxMergeEvents": 100000000, 
+    "Comments": "[u'MC from scratch; Given 100 EpLumi for Task1, set EpJob and EpLumi to 41 (instead of 100), so 1LpJob;', u'Task2 and Task3 EventAwareLumiBased with 800 and 900 EpJob; diff ProcStr']", 
+    "Requestor": "amaltaro", 
+    "IgnoredOutputModules": [], 
+    "Group": "DATAOPS", 
+    "ChainParentageMap": {
+      "Task1": {
+        "ParentDset": null, 
+        "ChildDsets": [
+          "/RelValProdMinBias/DMWM_Test-ProdMinBias_TaskChain_ProdMinBias_HG1812_Validation_Alan_v1112-v11/GEN-SIM"
+        ]
+      }, 
+      "Task2": {
+        "ParentDset": "/RelValProdMinBias/DMWM_Test-ProdMinBias_TaskChain_ProdMinBias_HG1812_Validation_Alan_v1112-v11/GEN-SIM", 
+        "ChildDsets": [
+          "/RelValProdMinBias/DMWM_Test-DIGIPROD1_TaskChain_ProdMinBias_HG1812_Validation_Alan_v1112-v11/GEN-SIM-RAW"
+        ]
+      }, 
+      "Task3": {
+        "ParentDset": "/RelValProdMinBias/DMWM_Test-DIGIPROD1_TaskChain_ProdMinBias_HG1812_Validation_Alan_v1112-v11/GEN-SIM-RAW", 
+        "ChildDsets": [
+          "/RelValProdMinBias/DMWM_Test-RECOPROD1_TaskChain_ProdMinBias_HG1812_Validation_Alan_v1112-v11/AODSIM", 
+          "/RelValProdMinBias/DMWM_Test-RECOPROD1_TaskChain_ProdMinBias_HG1812_Validation_Alan_v1112-v11/GEN-SIM-RECO"
+        ]
+      }
+    }, 
+    "CustodialGroup": "DataOps", 
+    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev", 
+    "SubRequestType": "RelVal", 
+    "TrustPUSitelists": false, 
+    "HardTimeout": 129900, 
+    "OpenRunningTimeout": 0, 
+    "LumiList": {}, 
+    "DashboardHost": "cms-jobmon.cern.ch", 
+    "EnableHarvesting": false, 
+    "BlockCloseMaxWaitTime": 66400, 
+    "SiteWhitelist": [
+      "T1_US_FNAL", 
+      "T2_CH_CERN"
+    ], 
+    "BlockCloseMaxSize": 5000000000000, 
+    "DQMConfigCacheID": null, 
+    "ValidStatus": "PRODUCTION", 
+    "PriorityTransition": [
+      {
+        "Priority": 600000, 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835409
+      }
+    ], 
+    "Campaign": "HG1812_Validation", 
+    "GlobalTag": "81X_mcRun1_realistic_v5", 
+    "Multicore": 1, 
+    "EnableNewStageout": false, 
+    "NonCustodialGroup": "DataOps", 
+    "DeleteFromSource": false, 
+    "TotalInputEvents": 9000, 
+    "SizePerEvent": 1234, 
+    "ConfigCacheID": null, 
+    "Task1": {
+      "KeepOutput": true, 
+      "GlobalTag": "81X_mcRun1_realistic_v5", 
+      "TimePerEvent": 700, 
+      "RequestNumEvents": 9000, 
+      "SplittingAlgo": "EventBased", 
+      "ProcessingString": "ProdMinBias_TaskChain_ProdMinBias_HG1812_Validation_Alan_v1112", 
+      "EventsPerLumi": 41, 
+      "ConfigCacheID": "fd79406f016da454e5ac53c393476d2d", 
+      "Memory": 1200, 
+      "TaskName": "ProdMinBias", 
+      "AcquisitionEra": "CMSSW_8_1_0", 
+      "PrimaryDataset": "RelValProdMinBias", 
+      "EventsPerJob": 41, 
+      "Seeding": "AutomaticSeeding"
+    }, 
+    "Task2": {
+      "KeepOutput": true, 
+      "GlobalTag": "81X_mcRun1_realistic_v5", 
+      "InputFromOutputModule": "RAWSIMoutput", 
+      "TimePerEvent": 36, 
+      "ProcessingString": "DIGIPROD1_TaskChain_ProdMinBias_HG1812_Validation_Alan_v1112", 
+      "SplittingAlgo": "EventAwareLumiBased", 
+      "InputTask": "ProdMinBias", 
+      "ConfigCacheID": "fd79406f016da454e5ac53c393491320", 
+      "Memory": 1500, 
+      "TaskName": "DIGIPROD1", 
+      "AcquisitionEra": "CMSSW_8_1_0"
+    }, 
+    "Task3": {
+      "KeepOutput": true, 
+      "GlobalTag": "81X_mcRun1_realistic_v5", 
+      "InputFromOutputModule": "RAWSIMoutput", 
+      "TimePerEvent": 32, 
+      "ProcessingString": "RECOPROD1_TaskChain_ProdMinBias_HG1812_Validation_Alan_v1112", 
+      "SplittingAlgo": "EventAwareLumiBased", 
+      "InputTask": "DIGIPROD1", 
+      "ConfigCacheID": "fd79406f016da454e5ac53c3934a46df", 
+      "Memory": 2000, 
+      "TaskName": "RECOPROD1", 
+      "AcquisitionEra": "CMSSW_8_1_0"
+    }, 
+    "CustodialSubType": "Replica", 
+    "GracePeriod": 300, 
+    "MergedLFNBase": "/store/backfill/1", 
+    "CouchDBName": "reqmgr_config_cache", 
+    "SubscriptionPriority": "Low", 
+    "RobustMerge": true, 
+    "Team": "devvm-cloud1", 
+    "AllowOpportunistic": false, 
+    "DQMHarvestUnit": "byRun", 
+    "AutoApproveSubscriptionSites": [], 
+    "RequestWorkflow": "https://alancc7-cloud1.cern.ch/couchdb/reqmgr_workload_cache/amaltaro_TaskChain_ProdMinBias_HG1812_Validation_181203_121009_5217/spec", 
+    "BlockCloseMaxFiles": 500, 
+    "VoGroup": "unknown", 
+    "RequestType": "TaskChain", 
+    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/", 
+    "SiteBlacklist": [], 
+    "TaskChain": 3, 
+    "RequestStatus": "acquired", 
+    "SoftTimeout": 129600, 
+    "TotalInputFiles": 0, 
+    "BlockCloseMaxEvents": 25000000, 
+    "CustodialSites": [], 
+    "ProcessingString": {
+      "ProdMinBias": "ProdMinBias_TaskChain_ProdMinBias_HG1812_Validation_Alan_v1112", 
+      "DIGIPROD1": "DIGIPROD1_TaskChain_ProdMinBias_HG1812_Validation_Alan_v1112", 
+      "RECOPROD1": "RECOPROD1_TaskChain_ProdMinBias_HG1812_Validation_Alan_v1112"
+    }, 
+    "ScramArch": [
+      "slc6_amd64_gcc530"
+    ], 
+    "TrustSitelists": false, 
+    "UnmergedLFNBase": "/store/unmerged", 
+    "DashboardPort": 8884, 
+    "TimePerEvent": 0.1, 
+    "DQMSequences": [], 
+    "OutputModulesLFNBases": [
+      "/store/unmerged/DMWM_Test/RelValProdMinBias/GEN-SIM-RECO/RECOPROD1_TaskChain_ProdMinBias_HG1812_Validation_Alan_v1112-v11", 
+      "/store/unmerged/DMWM_Test/RelValProdMinBias/GEN-SIM/ProdMinBias_TaskChain_ProdMinBias_HG1812_Validation_Alan_v1112-v11", 
+      "/store/unmerged/DMWM_Test/RelValProdMinBias/GEN-SIM-RAW/DIGIPROD1_TaskChain_ProdMinBias_HG1812_Validation_Alan_v1112-v11", 
+      "/store/unmerged/DMWM_Test/RelValProdMinBias/AODSIM/RECOPROD1_TaskChain_ProdMinBias_HG1812_Validation_Alan_v1112-v11"
+    ], 
+    "OutputDatasets": [
+      "/RelValProdMinBias/DMWM_Test-ProdMinBias_TaskChain_ProdMinBias_HG1812_Validation_Alan_v1112-v11/GEN-SIM", 
+      "/RelValProdMinBias/DMWM_Test-DIGIPROD1_TaskChain_ProdMinBias_HG1812_Validation_Alan_v1112-v11/GEN-SIM-RAW", 
+      "/RelValProdMinBias/DMWM_Test-RECOPROD1_TaskChain_ProdMinBias_HG1812_Validation_Alan_v1112-v11/AODSIM", 
+      "/RelValProdMinBias/DMWM_Test-RECOPROD1_TaskChain_ProdMinBias_HG1812_Validation_Alan_v1112-v11/GEN-SIM-RECO"
+    ], 
+    "NonCustodialSubType": "Replica", 
+    "MaxMergeSize": 4294967296, 
+    "OverrideCatalog": null, 
+    "PeriodicHarvestInterval": 0, 
+    "TotalEstimatedJobs": 220, 
+    "MaxWaitTime": 86400, 
+    "RequestString": "TaskChain_ProdMinBias_HG1812_Validation", 
+    "RequestorDN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+    "RequestDate": [
+      2018, 
+      12, 
+      3, 
+      11, 
+      10, 
+      9
+    ], 
+    "InitialPriority": 600000, 
+    "RunNumber": 0, 
+    "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+    "EventStreams": null, 
+    "Memory": 2300, 
+    "Override": {
+      "eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent"
+    }, 
+    "IncludeParents": false, 
+    "VoRole": "unknown", 
+    "AcquisitionEra": "DMWM_Test", 
+    "CMSSWVersion": "CMSSW_8_1_0", 
+    "NonCustodialSites": [], 
+    "GlobalTagConnect": null, 
+    "MinMergeSize": 2147483648, 
+    "RequestPriority": 600000, 
+    "ProcessingVersion": 11, 
+    "TotalInputLumis": 220, 
+    "FirstEvent": 1, 
+    "RequestName": "amaltaro_TaskChain_ProdMinBias_HG1812_Validation_181203_121009_5217", 
+    "CouchURL": "https://alancc7-cloud1.cern.ch/couchdb", 
+    "CouchWorkloadDBName": "reqmgr_workload_cache", 
+    "RequestTransition": [
+      {
+        "Status": "new", 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835409
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assignment-approved", 
+        "UpdateTime": 1543835417
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assigned", 
+        "UpdateTime": 1543835417
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+        "Status": "acquired", 
+        "UpdateTime": 1543836342
+      }
+    ], 
+    "FirstLumi": 1, 
+    "DQMUploadProxy": null, 
+    "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb", 
+    "_id": "amaltaro_TaskChain_ProdMinBias_HG1812_Validation_181203_121009_5217", 
+    "Dashboard": "integration"
+  }, 
+  "amaltaro_ReDigi_cmsRun2_HG1812_Validation_181203_121040_9858": {
+    "PrepID": "TEST-BPH-RunIISpring15DR74-00074", 
+    "MaxMergeEvents": 100000000, 
+    "Comments": "Two cmsRun in the same job; Save step2 only; Two blocks whitelisted; Manual splitting at 275 EpJob", 
+    "Requestor": "amaltaro", 
+    "RunBlacklist": [], 
+    "Group": "DATAOPS", 
+    "CustodialGroup": "DataOps", 
+    "DQMUploadUrl": "https://cmsweb.cern.ch/dqm/dev", 
+    "SubRequestType": "", 
+    "TrustPUSitelists": false, 
+    "HardTimeout": 129900, 
+    "OpenRunningTimeout": 0, 
+    "LumiList": {}, 
+    "ValidStatus": "PRODUCTION", 
+    "DashboardHost": "cms-jobmon.cern.ch", 
+    "EnableHarvesting": false, 
+    "Scenario": null, 
+    "BlockCloseMaxWaitTime": 66400, 
+    "SiteWhitelist": [
+      "T1_US_FNAL", 
+      "T2_CH_CERN"
+    ], 
+    "BlockCloseMaxSize": 5000000000000, 
+    "DQMConfigCacheID": null, 
+    "DeterministicPileup": false, 
+    "StepThreeTimePerEvent": null, 
+    "AcquisitionEra": "DMWM_Test", 
+    "GlobalTag": "MCRUN2_74_V9", 
+    "Campaign": "HG1812_Validation", 
+    "ScramArch": [
+      "slc6_amd64_gcc491"
+    ], 
+    "EnableNewStageout": false, 
+    "NonCustodialGroup": "DataOps", 
+    "EventsPerJob": 275, 
+    "InputDataset": "/BuToJpsiKV2_BMuonFilter_TuneCUEP8M1_13TeV-pythia8-evtgen/RunIIWinter15GS-MCRUN2_71_V1_ext1-v2/GEN-SIM", 
+    "DeleteFromSource": false, 
+    "TotalInputEvents": 17551, 
+    "SizePerEvent": 2482, 
+    "ConfigCacheID": null, 
+    "DataPileup": null, 
+    "StepThreeConfigCacheID": null, 
+    "CustodialSubType": "Replica", 
+    "StepThreeSizePerEvent": null, 
+    "GracePeriod": 300, 
+    "MergedLFNBase": "/store/backfill/1", 
+    "StepTwoSizePerEvent": null, 
+    "CouchDBName": "reqmgr_config_cache", 
+    "InitialPriority": 170000, 
+    "RobustMerge": true, 
+    "SplittingAlgo": "EventAwareLumiBased", 
+    "Team": "devvm-cloud1", 
+    "AllowOpportunistic": false, 
+    "DQMHarvestUnit": "byRun", 
+    "AutoApproveSubscriptionSites": [], 
+    "RequestWorkflow": "https://alancc7-cloud1.cern.ch/couchdb/reqmgr_workload_cache/amaltaro_ReDigi_cmsRun2_HG1812_Validation_181203_121040_9858/spec", 
+    "BlockBlacklist": [], 
+    "BlockCloseMaxFiles": 500, 
+    "StepTwoMemory": null, 
+    "VoGroup": "unknown", 
+    "RequestType": "ReDigi", 
+    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/", 
+    "SiteBlacklist": [], 
+    "StepOneOutputModuleName": "RAWSIMoutput", 
+    "RequestStatus": "acquired", 
+    "KeepStepOneOutput": false, 
+    "SoftTimeout": 129600, 
+    "StepTwoTimePerEvent": null, 
+    "TotalInputFiles": 5, 
+    "BlockCloseMaxEvents": 25000000, 
+    "CustodialSites": [], 
+    "ProcessingString": "ReDigi_cmsRun2_HG1812_Validation_Alan_v1112", 
+    "Multicore": 1, 
+    "TrustSitelists": false, 
+    "StepTwoConfigCacheID": "8654d0a1dde0b1463693a416ef7b6a1f", 
+    "UnmergedLFNBase": "/store/unmerged", 
+    "LumisPerJob": 8, 
+    "DashboardPort": 8884, 
+    "TimePerEvent": 125, 
+    "DQMSequences": [], 
+    "OutputModulesLFNBases": [
+      "/store/unmerged/DMWM_Test/BuToJpsiKV2_BMuonFilter_TuneCUEP8M1_13TeV-pythia8-evtgen/DQMIO/ReDigi_cmsRun2_HG1812_Validation_Alan_v1112-v11", 
+      "/store/unmerged/DMWM_Test/BuToJpsiKV2_BMuonFilter_TuneCUEP8M1_13TeV-pythia8-evtgen/AODSIM/ReDigi_cmsRun2_HG1812_Validation_Alan_v1112-v11", 
+      "/store/unmerged/DMWM_Test/BuToJpsiKV2_BMuonFilter_TuneCUEP8M1_13TeV-pythia8-evtgen/GEN-SIM-RAW/ReDigi_cmsRun2_HG1812_Validation_Alan_v1112-v11"
+    ], 
+    "OutputDatasets": [
+      "/BuToJpsiKV2_BMuonFilter_TuneCUEP8M1_13TeV-pythia8-evtgen/DMWM_Test-ReDigi_cmsRun2_HG1812_Validation_Alan_v1112-v11/AODSIM", 
+      "/BuToJpsiKV2_BMuonFilter_TuneCUEP8M1_13TeV-pythia8-evtgen/DMWM_Test-ReDigi_cmsRun2_HG1812_Validation_Alan_v1112-v11/DQMIO"
+    ], 
+    "PrimaryDataset": "BuToJpsiKV2_BMuonFilter_TuneCUEP8M1_13TeV-pythia8-evtgen", 
+    "NonCustodialSubType": "Replica", 
+    "StepThreeMemory": null, 
+    "MaxMergeSize": 4294967296, 
+    "OverrideCatalog": null, 
+    "PeriodicHarvestInterval": 0, 
+    "TotalEstimatedJobs": 65, 
+    "MaxWaitTime": 86400, 
+    "RequestString": "ReDigi_cmsRun2_HG1812_Validation", 
+    "RequestorDN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+    "RunWhitelist": [], 
+    "RequestDate": [
+      2018, 
+      12, 
+      3, 
+      11, 
+      10, 
+      40
+    ], 
+    "SubscriptionPriority": "Low", 
+    "RunNumber": 0, 
+    "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+    "EventStreams": null, 
+    "Memory": 1980, 
+    "Override": {
+      "eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/TESTBED"
+    }, 
+    "FilesPerJob": 1, 
+    "IncludeParents": false, 
+    "MCPileup": "/MinBias_TuneCUETP8M1_13TeV-pythia8/RunIIWinter15GS-MCRUN2_71_V1-v1/GEN-SIM", 
+    "BlockWhitelist": [
+      "/BuToJpsiKV2_BMuonFilter_TuneCUEP8M1_13TeV-pythia8-evtgen/RunIIWinter15GS-MCRUN2_71_V1_ext1-v2/GEN-SIM#f51d440c-c067-11e6-9206-001e67abefa8", 
+      "/BuToJpsiKV2_BMuonFilter_TuneCUEP8M1_13TeV-pythia8-evtgen/RunIIWinter15GS-MCRUN2_71_V1_ext1-v2/GEN-SIM#cc0feda2-c027-11e6-8e8a-001e67abef8c"
+    ], 
+    "StepTwoOutputModuleName": "AODSIMoutput", 
+    "VoRole": "unknown", 
+    "PriorityTransition": [
+      {
+        "Priority": 170000, 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835440
+      }
+    ], 
+    "CMSSWVersion": "CMSSW_7_4_1_patch4", 
+    "NonCustodialSites": [], 
+    "GlobalTagConnect": null, 
+    "MinMergeSize": 2147483648, 
+    "RequestPriority": 170000, 
+    "ProcessingVersion": 11, 
+    "TotalInputLumis": 100, 
+    "RequestName": "amaltaro_ReDigi_cmsRun2_HG1812_Validation_181203_121040_9858", 
+    "KeepStepTwoOutput": true, 
+    "CouchURL": "https://alancc7-cloud1.cern.ch/couchdb", 
+    "CouchWorkloadDBName": "reqmgr_workload_cache", 
+    "RequestTransition": [
+      {
+        "Status": "new", 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835440
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assignment-approved", 
+        "UpdateTime": 1543835447
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assigned", 
+        "UpdateTime": 1543835447
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+        "Status": "acquired", 
+        "UpdateTime": 1543836342
+      }
+    ], 
+    "DQMUploadProxy": null, 
+    "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb", 
+    "_id": "amaltaro_ReDigi_cmsRun2_HG1812_Validation_181203_121040_9858", 
+    "StepOneConfigCacheID": "8654d0a1dde0b1463693a416ef7a77f0", 
+    "Dashboard": "integration"
+  }, 
+  "amaltaro_StepChain_DupOutMod_HG1812_Validation_181203_121053_7505": {
+    "PrepID": "TEST-StepChain-DupOutMod", 
+    "MaxMergeEvents": 100000000, 
+    "Comments": "[u'MC from scratch; 3 steps in the same job; Step1 and Step2 have the same RAWSIM output module', u'save all outputs; Given 50 EpLumi, sets 150 EpJob (instead of 174), so 3 LpJob']", 
+    "Requestor": "amaltaro", 
+    "Step3": {
+      "StepName": "RECOPROD1", 
+      "PrepID": "TEST-Step3-DupOutMod", 
+      "GlobalTag": "90X_mcRun1_realistic_v4", 
+      "InputFromOutputModule": "RAWSIMoutput", 
+      "InputStep": "DIGIPROD1", 
+      "ScramArch": [
+        "slc6_amd64_gcc530"
+      ], 
+      "ConfigCacheID": "f739820360b865fbaec79db3ed10c012", 
+      "CMSSWVersion": "CMSSW_9_0_0"
+    }, 
+    "Step2": {
+      "StepName": "DIGIPROD1", 
+      "PrepID": "TEST-Step2-DupOutMod", 
+      "GlobalTag": "90X_mcRun1_realistic_v4", 
+      "InputFromOutputModule": "RAWSIMoutput", 
+      "InputStep": "ProdMinBias", 
+      "ScramArch": [
+        "slc6_amd64_gcc530"
+      ], 
+      "ConfigCacheID": "f739820360b865fbaec79db3ed0d8bde", 
+      "CMSSWVersion": "CMSSW_9_0_0"
+    }, 
+    "Step1": {
+      "PrepID": "TEST-Step1-DupOutMod", 
+      "GlobalTag": "90X_mcRun1_realistic_v4", 
+      "StepName": "ProdMinBias", 
+      "RequestNumEvents": 1500, 
+      "SplittingAlgo": "EventBased", 
+      "ScramArch": [
+        "slc6_amd64_gcc530"
+      ], 
+      "EventsPerLumi": 50, 
+      "ConfigCacheID": "f739820360b865fbaec79db3ed0cf0d1", 
+      "EventsPerJob": 150, 
+      "Seeding": "AutomaticSeeding", 
+      "CMSSWVersion": "CMSSW_9_0_0"
+    }, 
+    "Group": "DATAOPS", 
+    "ChainParentageMap": {
+      "Step3": {
+        "ParentDset": "/RelValProdMinBias/DMWM_Test-StepChain_DupOutMod_HG1812_Validation_Alan_v1112-v11/GEN-SIM-RAW", 
+        "ChildDsets": [
+          "/RelValProdMinBias/DMWM_Test-StepChain_DupOutMod_HG1812_Validation_Alan_v1112-v11/AODSIM", 
+          "/RelValProdMinBias/DMWM_Test-StepChain_DupOutMod_HG1812_Validation_Alan_v1112-v11/GEN-SIM-RECO"
+        ]
+      }, 
+      "Step2": {
+        "ParentDset": "/RelValProdMinBias/DMWM_Test-StepChain_DupOutMod_HG1812_Validation_Alan_v1112-v11/GEN-SIM", 
+        "ChildDsets": [
+          "/RelValProdMinBias/DMWM_Test-StepChain_DupOutMod_HG1812_Validation_Alan_v1112-v11/GEN-SIM-RAW"
+        ]
+      }, 
+      "Step1": {
+        "ParentDset": null, 
+        "ChildDsets": [
+          "/RelValProdMinBias/DMWM_Test-StepChain_DupOutMod_HG1812_Validation_Alan_v1112-v11/GEN-SIM"
+        ]
+      }
+    }, 
+    "CustodialGroup": "DataOps", 
+    "DQMUploadUrl": "https://cmsweb.cern.ch/dqm/dev", 
+    "SubRequestType": "", 
+    "TrustPUSitelists": false, 
+    "HardTimeout": 129900, 
+    "OpenRunningTimeout": 0, 
+    "LumiList": {}, 
+    "DashboardHost": "cms-jobmon.cern.ch", 
+    "EnableHarvesting": false, 
+    "BlockCloseMaxWaitTime": 66400, 
+    "SiteWhitelist": [
+      "T1_US_FNAL", 
+      "T2_CH_CERN"
+    ], 
+    "GlobalTagConnect": null, 
+    "DQMConfigCacheID": null, 
+    "DeterministicPileup": false, 
+    "ValidStatus": "PRODUCTION", 
+    "PriorityTransition": [
+      {
+        "Priority": 316000, 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835453
+      }
+    ], 
+    "GlobalTag": "90X_mcRun1_realistic_v4", 
+    "Campaign": "HG1812_Validation", 
+    "Multicore": 1, 
+    "EnableNewStageout": false, 
+    "NonCustodialGroup": "DataOps", 
+    "DeleteFromSource": false, 
+    "TotalInputEvents": 1500, 
+    "SizePerEvent": 250, 
+    "ConfigCacheID": null, 
+    "StepChain": 3, 
+    "CustodialSubType": "Replica", 
+    "GracePeriod": 300, 
+    "MergedLFNBase": "/store/backfill/1", 
+    "ParentageResolved": false, 
+    "CouchDBName": "reqmgr_config_cache", 
+    "SubscriptionPriority": "Low", 
+    "RobustMerge": true, 
+    "Team": "devvm-cloud1", 
+    "AllowOpportunistic": false, 
+    "DQMHarvestUnit": "byRun", 
+    "AutoApproveSubscriptionSites": [], 
+    "RequestWorkflow": "https://alancc7-cloud1.cern.ch/couchdb/reqmgr_workload_cache/amaltaro_StepChain_DupOutMod_HG1812_Validation_181203_121053_7505/spec", 
+    "BlockCloseMaxFiles": 500, 
+    "VoGroup": "unknown", 
+    "RequestType": "StepChain", 
+    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader", 
+    "SiteBlacklist": [], 
+    "RequestStatus": "acquired", 
+    "SoftTimeout": 129600, 
+    "TotalInputFiles": 0, 
+    "BlockCloseMaxEvents": 25000000, 
+    "CustodialSites": [], 
+    "ProcessingString": "StepChain_DupOutMod_HG1812_Validation_Alan_v1112", 
+    "ScramArch": [
+      "slc6_amd64_gcc530"
+    ], 
+    "TrustSitelists": false, 
+    "UnmergedLFNBase": "/store/unmerged", 
+    "DashboardPort": 8884, 
+    "TimePerEvent": 165, 
+    "DQMSequences": [], 
+    "OutputModulesLFNBases": [
+      "/store/unmerged/DMWM_Test/RelValProdMinBias/GEN-SIM-RECO/StepChain_DupOutMod_HG1812_Validation_Alan_v1112-v11", 
+      "/store/unmerged/DMWM_Test/RelValProdMinBias/AODSIM/StepChain_DupOutMod_HG1812_Validation_Alan_v1112-v11", 
+      "/store/unmerged/DMWM_Test/RelValProdMinBias/GEN-SIM-RAW/StepChain_DupOutMod_HG1812_Validation_Alan_v1112-v11", 
+      "/store/unmerged/DMWM_Test/RelValProdMinBias/GEN-SIM/StepChain_DupOutMod_HG1812_Validation_Alan_v1112-v11"
+    ], 
+    "OutputDatasets": [
+      "/RelValProdMinBias/DMWM_Test-StepChain_DupOutMod_HG1812_Validation_Alan_v1112-v11/GEN-SIM", 
+      "/RelValProdMinBias/DMWM_Test-StepChain_DupOutMod_HG1812_Validation_Alan_v1112-v11/GEN-SIM-RAW", 
+      "/RelValProdMinBias/DMWM_Test-StepChain_DupOutMod_HG1812_Validation_Alan_v1112-v11/AODSIM", 
+      "/RelValProdMinBias/DMWM_Test-StepChain_DupOutMod_HG1812_Validation_Alan_v1112-v11/GEN-SIM-RECO"
+    ], 
+    "PrimaryDataset": "RelValProdMinBias", 
+    "NonCustodialSubType": "Replica", 
+    "MaxMergeSize": 4294967296, 
+    "OverrideCatalog": null, 
+    "PeriodicHarvestInterval": 0, 
+    "TotalEstimatedJobs": 10, 
+    "MaxWaitTime": 86400, 
+    "RequestString": "StepChain_DupOutMod_HG1812_Validation", 
+    "RequestorDN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+    "RequestDate": [
+      2018, 
+      12, 
+      3, 
+      11, 
+      10, 
+      53
+    ], 
+    "InitialPriority": 316000, 
+    "RunNumber": 0, 
+    "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+    "EventStreams": null, 
+    "Memory": 2200, 
+    "Override": {
+      "eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/TESTBED"
+    }, 
+    "IncludeParents": false, 
+    "VoRole": "unknown", 
+    "AcquisitionEra": "DMWM_Test", 
+    "CMSSWVersion": "CMSSW_9_0_0", 
+    "NonCustodialSites": [], 
+    "BlockCloseMaxSize": 5000000000000, 
+    "MinMergeSize": 2147483648, 
+    "RequestPriority": 316000, 
+    "ProcessingVersion": 11, 
+    "TotalInputLumis": 30, 
+    "FirstEvent": 1, 
+    "RequestName": "amaltaro_StepChain_DupOutMod_HG1812_Validation_181203_121053_7505", 
+    "CouchURL": "https://alancc7-cloud1.cern.ch/couchdb", 
+    "CouchWorkloadDBName": "reqmgr_workload_cache", 
+    "RequestTransition": [
+      {
+        "Status": "new", 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835453
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assignment-approved", 
+        "UpdateTime": 1543835468
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assigned", 
+        "UpdateTime": 1543835468
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+        "Status": "acquired", 
+        "UpdateTime": 1543836342
+      }
+    ], 
+    "FirstLumi": 1, 
+    "DQMUploadProxy": null, 
+    "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb", 
+    "_id": "amaltaro_StepChain_DupOutMod_HG1812_Validation_181203_121053_7505", 
+    "Dashboard": "integration"
+  }, 
+  "amaltaro_DQMHarvesting_RunWhitelist_HG1812_Validation_181203_121028_5865": {
+    "PrepID": "TEST-Harvest-ReReco-Run2016F-v1-NoBPTX-23Sep2016-0001", 
+    "MaxMergeEvents": 100000000, 
+    "Comments": "Harvest 3 runs out of 37. Only 277934, 278273 and 278805.", 
+    "Requestor": "amaltaro", 
+    "RunBlacklist": [], 
+    "Group": "DATAOPS", 
+    "CustodialGroup": "DataOps", 
+    "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev", 
+    "SubRequestType": "", 
+    "TrustPUSitelists": false, 
+    "HardTimeout": 129900, 
+    "OpenRunningTimeout": 0, 
+    "LumiList": {}, 
+    "DashboardHost": "cms-jobmon.cern.ch", 
+    "EnableHarvesting": false, 
+    "Scenario": null, 
+    "BlockCloseMaxWaitTime": 66400, 
+    "SiteWhitelist": [
+      "T2_CH_CERN"
+    ], 
+    "BlockCloseMaxSize": 5000000000000, 
+    "DQMConfigCacheID": "253c586d672c6c7a88c048d8c7b62135", 
+    "ValidStatus": "PRODUCTION", 
+    "AcquisitionEra": "DMWM_Test", 
+    "GlobalTag": "80X_dataRun2_2016SeptRepro_v3", 
+    "Campaign": "HG1812_Validation", 
+    "Multicore": 1, 
+    "EnableNewStageout": false, 
+    "NonCustodialGroup": "DataOps", 
+    "EventsPerJob": 28800, 
+    "InputDataset": "/NoBPTX/Run2016F-23Sep2016-v1/DQMIO", 
+    "DeleteFromSource": false, 
+    "TotalInputEvents": 0, 
+    "SizePerEvent": 1600, 
+    "ConfigCacheID": null, 
+    "CustodialSubType": "Replica", 
+    "GracePeriod": 300, 
+    "MergedLFNBase": "/store/backfill/1", 
+    "CouchDBName": "reqmgr_config_cache", 
+    "SubscriptionPriority": "Low", 
+    "RobustMerge": true, 
+    "SplittingAlgo": "EventAwareLumiBased", 
+    "Team": "devvm-cloud1", 
+    "AllowOpportunistic": false, 
+    "DQMHarvestUnit": "byRun", 
+    "AutoApproveSubscriptionSites": [], 
+    "RequestWorkflow": "https://alancc7-cloud1.cern.ch/couchdb/reqmgr_workload_cache/amaltaro_DQMHarvesting_RunWhitelist_HG1812_Validation_181203_121028_5865/spec", 
+    "BlockBlacklist": [], 
+    "BlockCloseMaxFiles": 500, 
+    "VoGroup": "unknown", 
+    "RequestType": "DQMHarvest", 
+    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/", 
+    "SiteBlacklist": [], 
+    "RequestStatus": "acquired", 
+    "SoftTimeout": 129600, 
+    "TotalInputFiles": 4, 
+    "BlockCloseMaxEvents": 25000000, 
+    "CustodialSites": [], 
+    "ProcessingString": "DQMHarvesting_RunWhitelist_HG1812_Validation_Alan_v1112", 
+    "ScramArch": [
+      "slc6_amd64_gcc530"
+    ], 
+    "TrustSitelists": false, 
+    "UnmergedLFNBase": "/store/unmerged", 
+    "LumisPerJob": 8, 
+    "DashboardPort": 8884, 
+    "TimePerEvent": 1, 
+    "DQMSequences": [], 
+    "OutputModulesLFNBases": [], 
+    "OutputDatasets": [], 
+    "PrimaryDataset": null, 
+    "NonCustodialSubType": "Replica", 
+    "MaxMergeSize": 4294967296, 
+    "OverrideCatalog": null, 
+    "PeriodicHarvestInterval": 0, 
+    "TotalEstimatedJobs": 3, 
+    "MaxWaitTime": 86400, 
+    "RequestString": "DQMHarvesting_RunWhitelist_HG1812_Validation", 
+    "RequestorDN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+    "RunWhitelist": [
+      277934, 
+      278273, 
+      278805
+    ], 
+    "RequestDate": [
+      2018, 
+      12, 
+      3, 
+      11, 
+      10, 
+      28
+    ], 
+    "InitialPriority": 999999, 
+    "RunNumber": 0, 
+    "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+    "EventStreams": null, 
+    "Memory": 1100, 
+    "Override": {
+      "eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/TESTBED"
+    }, 
+    "FilesPerJob": 1, 
+    "IncludeParents": false, 
+    "BlockWhitelist": [], 
+    "VoRole": "unknown", 
+    "PriorityTransition": [
+      {
+        "Priority": 999999, 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835428
+      }
+    ], 
+    "CMSSWVersion": "CMSSW_8_0_20", 
+    "NonCustodialSites": [], 
+    "GlobalTagConnect": null, 
+    "MinMergeSize": 2147483648, 
+    "RequestPriority": 999999, 
+    "ProcessingVersion": 11, 
+    "TotalInputLumis": 392, 
+    "RequestName": "amaltaro_DQMHarvesting_RunWhitelist_HG1812_Validation_181203_121028_5865", 
+    "CouchURL": "https://alancc7-cloud1.cern.ch/couchdb", 
+    "CouchWorkloadDBName": "reqmgr_workload_cache", 
+    "RequestTransition": [
+      {
+        "Status": "new", 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835428
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assignment-approved", 
+        "UpdateTime": 1543835431
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assigned", 
+        "UpdateTime": 1543835432
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+        "Status": "acquired", 
+        "UpdateTime": 1543836342
+      }
+    ], 
+    "DQMUploadProxy": null, 
+    "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb", 
+    "_id": "amaltaro_DQMHarvesting_RunWhitelist_HG1812_Validation_181203_121028_5865", 
+    "Dashboard": "integration"
+  }, 
+  "amaltaro_TaskChain_InclParents_HG1812_Validation_181203_121005_1483": {
+    "PrepID": "TEST-CMSSW_9_4_0__test2inwf-1510737328-RunHLTPhy2017B_RAWAOD", 
+    "MaxMergeEvents": 100000000, 
+    "Comments": "[u'Task1 with IncludeParents and LumiList (29 lumis); LumiBased 10 LpJob; single run (1 blocks);', u'8 cores and 6 GB; TrustSitelists True']", 
+    "Requestor": "amaltaro", 
+    "IgnoredOutputModules": [], 
+    "Group": "DATAOPS", 
+    "ChainParentageMap": {
+      "Task1": {
+        "ParentDset": "/HLTPhysics/Run2017B-PromptReco-v1/AOD", 
+        "ChildDsets": [
+          "/HLTPhysics/CMSSW_9_4_0-DQMHLTonRAWAOD_2017_TaskChain_InclParents_HG1812_Validation_Alan_v1112-v11/DQMIO"
+        ]
+      }
+    }, 
+    "CustodialGroup": "DataOps", 
+    "DQMUploadUrl": "https://cmsweb.cern.ch/dqm/dev", 
+    "SubRequestType": "RelVal", 
+    "TrustPUSitelists": false, 
+    "HardTimeout": 129900, 
+    "OpenRunningTimeout": 0, 
+    "LumiList": {}, 
+    "DashboardHost": "cms-jobmon.cern.ch", 
+    "EnableHarvesting": false, 
+    "BlockCloseMaxWaitTime": 66400, 
+    "SiteWhitelist": [
+      "T1_US_FNAL", 
+      "T2_CH_CERN"
+    ], 
+    "GlobalTagConnect": null, 
+    "DQMConfigCacheID": null, 
+    "ValidStatus": "PRODUCTION", 
+    "PriorityTransition": [
+      {
+        "Priority": 160000, 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835405
+      }
+    ], 
+    "Campaign": "HG1812_Validation", 
+    "GlobalTag": "94X_dataRun2_PromptLike_v5", 
+    "ScramArch": [
+      "slc6_amd64_gcc630"
+    ], 
+    "EnableNewStageout": false, 
+    "NonCustodialGroup": "DataOps", 
+    "DeleteFromSource": false, 
+    "TotalInputEvents": 5633, 
+    "SizePerEvent": 1234, 
+    "ConfigCacheID": null, 
+    "Task1": {
+      "InputDataset": "/HLTPhysics/Run2017B-PromptReco-v1/AOD", 
+      "IncludeParents": true, 
+      "KeepOutput": true, 
+      "Campaign": "CMSSW_9_4_0__test2inwf-1510737328", 
+      "GlobalTag": "94X_dataRun2_PromptLike_v5", 
+      "Memory": 6000, 
+      "LumiList": {
+        "297557": [
+          [
+            60, 
+            80
+          ], 
+          [
+            173, 
+            180
+          ]
+        ]
+      }, 
+      "SplittingAlgo": "LumiBased", 
+      "ProcessingString": "DQMHLTonRAWAOD_2017_TaskChain_InclParents_HG1812_Validation_Alan_v1112", 
+      "Multicore": 8, 
+      "ConfigCacheID": "d0bff75e6c119de01942c9a5304629a7", 
+      "LumisPerJob": 10, 
+      "TaskName": "DQMHLTonRAWAOD_2017", 
+      "AcquisitionEra": "CMSSW_9_4_0"
+    }, 
+    "CustodialSubType": "Replica", 
+    "GracePeriod": 300, 
+    "MergedLFNBase": "/store/backfill/1", 
+    "CouchDBName": "reqmgr_config_cache", 
+    "SubscriptionPriority": "Low", 
+    "RobustMerge": true, 
+    "Team": "devvm-cloud1", 
+    "AllowOpportunistic": false, 
+    "DQMHarvestUnit": "byRun", 
+    "AutoApproveSubscriptionSites": [], 
+    "RequestWorkflow": "https://alancc7-cloud1.cern.ch/couchdb/reqmgr_workload_cache/amaltaro_TaskChain_InclParents_HG1812_Validation_181203_121005_1483/spec", 
+    "BlockCloseMaxFiles": 500, 
+    "VoGroup": "unknown", 
+    "RequestType": "TaskChain", 
+    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/", 
+    "SiteBlacklist": [], 
+    "TaskChain": 1, 
+    "RequestStatus": "acquired", 
+    "SoftTimeout": 129600, 
+    "TotalInputFiles": 1, 
+    "BlockCloseMaxEvents": 25000000, 
+    "CustodialSites": [], 
+    "ProcessingString": {
+      "DQMHLTonRAWAOD_2017": "DQMHLTonRAWAOD_2017_TaskChain_InclParents_HG1812_Validation_Alan_v1112"
+    }, 
+    "Multicore": 1, 
+    "TrustSitelists": true, 
+    "UnmergedLFNBase": "/store/unmerged", 
+    "DashboardPort": 8884, 
+    "TimePerEvent": 0.1, 
+    "DQMSequences": [], 
+    "OutputModulesLFNBases": [
+      "/store/unmerged/CMSSW_9_4_0/HLTPhysics/DQMIO/DQMHLTonRAWAOD_2017_TaskChain_InclParents_HG1812_Validation_Alan_v1112-v11"
+    ], 
+    "OutputDatasets": [
+      "/HLTPhysics/CMSSW_9_4_0-DQMHLTonRAWAOD_2017_TaskChain_InclParents_HG1812_Validation_Alan_v1112-v11/DQMIO"
+    ], 
+    "NonCustodialSubType": "Replica", 
+    "MaxMergeSize": 4294967296, 
+    "OverrideCatalog": null, 
+    "PeriodicHarvestInterval": 0, 
+    "TotalEstimatedJobs": 3, 
+    "MaxWaitTime": 86400, 
+    "RequestString": "TaskChain_InclParents_HG1812_Validation", 
+    "RequestorDN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+    "RequestDate": [
+      2018, 
+      12, 
+      3, 
+      11, 
+      10, 
+      5
+    ], 
+    "InitialPriority": 160000, 
+    "RunNumber": 0, 
+    "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+    "EventStreams": null, 
+    "Memory": 2300, 
+    "Override": {
+      "eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/TESTBED"
+    }, 
+    "IncludeParents": false, 
+    "VoRole": "unknown", 
+    "AcquisitionEra": {
+      "DQMHLTonRAWAOD_2017": "CMSSW_9_4_0"
+    }, 
+    "CMSSWVersion": "CMSSW_9_4_0", 
+    "NonCustodialSites": [], 
+    "BlockCloseMaxSize": 5000000000000, 
+    "MinMergeSize": 2147483648, 
+    "RequestPriority": 160000, 
+    "ProcessingVersion": 11, 
+    "TotalInputLumis": 29, 
+    "FirstEvent": 1, 
+    "RequestName": "amaltaro_TaskChain_InclParents_HG1812_Validation_181203_121005_1483", 
+    "CouchURL": "https://alancc7-cloud1.cern.ch/couchdb", 
+    "CouchWorkloadDBName": "reqmgr_workload_cache", 
+    "RequestTransition": [
+      {
+        "Status": "new", 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835405
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assignment-approved", 
+        "UpdateTime": 1543835409
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assigned", 
+        "UpdateTime": 1543835409
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+        "Status": "acquired", 
+        "UpdateTime": 1543836343
+      }
+    ], 
+    "FirstLumi": 1, 
+    "DQMUploadProxy": null, 
+    "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb", 
+    "_id": "amaltaro_TaskChain_InclParents_HG1812_Validation_181203_121005_1483", 
+    "Dashboard": "integration"
+  }, 
+  "amaltaro_StepChain_MC_HG1812_Validation_181203_121017_2487": {
+    "PrepID": "TEST-TEST-HIG-RunIISummer15wmLHEGS-00744", 
+    "MaxMergeEvents": 100000000, 
+    "Comments": "[u'No input data; PU in Step2; Given 160EpJ and 100EpL, tweak EpJ to 200, so2 LpJ; List gcc530 top level;', u'Step1 7_1_25_patch2/gcc481; Step2 8_0_21/gcc530; Step3 8_0_21/gcc530; PrepID set top level and each Step']", 
+    "Requestor": "amaltaro", 
+    "Step3": {
+      "KeepOutput": true, 
+      "StepName": "RECO", 
+      "PrepID": "TEST-Step3-RunIISummer15wmLHEGS-00744", 
+      "GlobalTag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6", 
+      "InputFromOutputModule": "PREMIXRAWoutput", 
+      "InputStep": "DIGI", 
+      "SplittingAlgo": "EventAwareLumiBased", 
+      "ConfigCacheID": "f7e311f2c6b5a0884faea133990f66cc"
+    }, 
+    "Step2": {
+      "MCPileup": "/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW", 
+      "PrepID": "TEST-Step2-RunIISummer15wmLHEGS-00744", 
+      "GlobalTag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6", 
+      "InputFromOutputModule": "RAWSIMoutput", 
+      "InputStep": "GENSIM", 
+      "SplittingAlgo": "EventAwareLumiBased", 
+      "ScramArch": [
+        "slc6_amd64_gcc530"
+      ], 
+      "ConfigCacheID": "f7e311f2c6b5a0884faea133990edcbf", 
+      "StepName": "DIGI", 
+      "CMSSWVersion": "CMSSW_8_0_21"
+    }, 
+    "Step1": {
+      "PrepID": "TEST-Step1-RunIISummer15wmLHEGS-00744", 
+      "GlobalTag": "MCRUN2_71_V1::All", 
+      "StepName": "GENSIM", 
+      "RequestNumEvents": 20000, 
+      "SplittingAlgo": "EventBased", 
+      "ScramArch": [
+        "slc6_amd64_gcc481"
+      ], 
+      "EventsPerLumi": 100, 
+      "ConfigCacheID": "526ca0745cd309b7cfef9f23b3d43acb", 
+      "EventsPerJob": 200, 
+      "Seeding": "AutomaticSeeding", 
+      "CMSSWVersion": "CMSSW_7_1_25_patch2"
+    }, 
+    "Group": "DATAOPS", 
+    "ChainParentageMap": {
+      "Step3": {
+        "ParentDset": "/DYJetsToLL_Pt-50To100_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/DMWM_Test-StepChain_MC_HG1812_Validation_Alan_v1112-v20/GEN-SIM-RAW", 
+        "ChildDsets": [
+          "/DYJetsToLL_Pt-50To100_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/DMWM_Test-StepChain_MC_HG1812_Validation_Alan_v1112-v20/AODSIM"
+        ]
+      }, 
+      "Step2": {
+        "ParentDset": "/DYJetsToLL_Pt-50To100_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/DMWM_Test-StepChain_MC_HG1812_Validation_Alan_v1112-v20/GEN-SIM", 
+        "ChildDsets": [
+          "/DYJetsToLL_Pt-50To100_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/DMWM_Test-StepChain_MC_HG1812_Validation_Alan_v1112-v20/GEN-SIM-RAW"
+        ]
+      }, 
+      "Step1": {
+        "ParentDset": null, 
+        "ChildDsets": [
+          "/DYJetsToLL_Pt-50To100_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/DMWM_Test-StepChain_MC_HG1812_Validation_Alan_v1112-v20/GEN-SIM", 
+          "/DYJetsToLL_Pt-50To100_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/DMWM_Test-StepChain_MC_HG1812_Validation_Alan_v1112-v20/LHE"
+        ]
+      }
+    }, 
+    "CustodialGroup": "DataOps", 
+    "DQMUploadUrl": "https://cmsweb.cern.ch/dqm/dev", 
+    "SubRequestType": "", 
+    "TrustPUSitelists": false, 
+    "HardTimeout": 129900, 
+    "OpenRunningTimeout": 0, 
+    "LumiList": {}, 
+    "DashboardHost": "cms-jobmon.cern.ch", 
+    "EnableHarvesting": false, 
+    "BlockCloseMaxWaitTime": 66400, 
+    "SiteWhitelist": [
+      "T1_US_FNAL", 
+      "T2_CH_CERN"
+    ], 
+    "GlobalTagConnect": null, 
+    "DQMConfigCacheID": null, 
+    "DeterministicPileup": false, 
+    "ValidStatus": "PRODUCTION", 
+    "PriorityTransition": [
+      {
+        "Priority": 316000, 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835417
+      }
+    ], 
+    "GlobalTag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6", 
+    "Campaign": "HG1812_Validation", 
+    "ScramArch": [
+      "slc6_amd64_gcc530"
+    ], 
+    "EnableNewStageout": false, 
+    "NonCustodialGroup": "DataOps", 
+    "DeleteFromSource": false, 
+    "TotalInputEvents": 20000, 
+    "SizePerEvent": 250, 
+    "ConfigCacheID": null, 
+    "StepChain": 3, 
+    "CustodialSubType": "Replica", 
+    "GracePeriod": 300, 
+    "MergedLFNBase": "/store/backfill/1", 
+    "ParentageResolved": false, 
+    "CouchDBName": "reqmgr_config_cache", 
+    "SubscriptionPriority": "Low", 
+    "RobustMerge": true, 
+    "Team": "devvm-cloud1", 
+    "AllowOpportunistic": false, 
+    "DQMHarvestUnit": "byRun", 
+    "AutoApproveSubscriptionSites": [], 
+    "RequestWorkflow": "https://alancc7-cloud1.cern.ch/couchdb/reqmgr_workload_cache/amaltaro_StepChain_MC_HG1812_Validation_181203_121017_2487/spec", 
+    "BlockCloseMaxFiles": 500, 
+    "VoGroup": "unknown", 
+    "RequestType": "StepChain", 
+    "DbsUrl": "https://cmsweb.cern.ch/dbs/prod/global/DBSReader/", 
+    "SiteBlacklist": [], 
+    "RequestStatus": "acquired", 
+    "SoftTimeout": 129600, 
+    "TotalInputFiles": 0, 
+    "BlockCloseMaxEvents": 25000000, 
+    "CustodialSites": [], 
+    "ProcessingString": "StepChain_MC_HG1812_Validation_Alan_v1112", 
+    "Multicore": 1, 
+    "TrustSitelists": false, 
+    "UnmergedLFNBase": "/store/unmerged", 
+    "DashboardPort": 8884, 
+    "TimePerEvent": 144, 
+    "DQMSequences": [], 
+    "OutputModulesLFNBases": [
+      "/store/unmerged/DMWM_Test/DYJetsToLL_Pt-50To100_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/GEN-SIM/StepChain_MC_HG1812_Validation_Alan_v1112-v20", 
+      "/store/unmerged/DMWM_Test/DYJetsToLL_Pt-50To100_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/GEN-SIM-RAW/StepChain_MC_HG1812_Validation_Alan_v1112-v20", 
+      "/store/unmerged/DMWM_Test/DYJetsToLL_Pt-50To100_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/AODSIM/StepChain_MC_HG1812_Validation_Alan_v1112-v20", 
+      "/store/unmerged/DMWM_Test/DYJetsToLL_Pt-50To100_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/LHE/StepChain_MC_HG1812_Validation_Alan_v1112-v20"
+    ], 
+    "OutputDatasets": [
+      "/DYJetsToLL_Pt-50To100_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/DMWM_Test-StepChain_MC_HG1812_Validation_Alan_v1112-v20/GEN-SIM", 
+      "/DYJetsToLL_Pt-50To100_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/DMWM_Test-StepChain_MC_HG1812_Validation_Alan_v1112-v20/LHE", 
+      "/DYJetsToLL_Pt-50To100_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/DMWM_Test-StepChain_MC_HG1812_Validation_Alan_v1112-v20/GEN-SIM-RAW", 
+      "/DYJetsToLL_Pt-50To100_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/DMWM_Test-StepChain_MC_HG1812_Validation_Alan_v1112-v20/AODSIM"
+    ], 
+    "PrimaryDataset": "DYJetsToLL_Pt-50To100_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8", 
+    "NonCustodialSubType": "Replica", 
+    "MaxMergeSize": 4294967296, 
+    "OverrideCatalog": null, 
+    "PeriodicHarvestInterval": 0, 
+    "TotalEstimatedJobs": 100, 
+    "MaxWaitTime": 86400, 
+    "RequestString": "StepChain_MC_HG1812_Validation", 
+    "RequestorDN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+    "RequestDate": [
+      2018, 
+      12, 
+      3, 
+      11, 
+      10, 
+      17
+    ], 
+    "InitialPriority": 316000, 
+    "RunNumber": 0, 
+    "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+    "EventStreams": null, 
+    "Memory": 2300, 
+    "Override": {
+      "eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/TESTBED"
+    }, 
+    "IncludeParents": false, 
+    "VoRole": "unknown", 
+    "AcquisitionEra": "DMWM_Test", 
+    "CMSSWVersion": "CMSSW_8_0_21", 
+    "NonCustodialSites": [], 
+    "BlockCloseMaxSize": 5000000000000, 
+    "MinMergeSize": 2147483648, 
+    "RequestPriority": 316000, 
+    "ProcessingVersion": 20, 
+    "TotalInputLumis": 200, 
+    "FirstEvent": 1, 
+    "RequestName": "amaltaro_StepChain_MC_HG1812_Validation_181203_121017_2487", 
+    "CouchURL": "https://alancc7-cloud1.cern.ch/couchdb", 
+    "CouchWorkloadDBName": "reqmgr_workload_cache", 
+    "RequestTransition": [
+      {
+        "Status": "new", 
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "UpdateTime": 1543835417
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assignment-approved", 
+        "UpdateTime": 1543835428
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues", 
+        "Status": "assigned", 
+        "UpdateTime": 1543835428
+      }, 
+      {
+        "DN": "/DC=ch/DC=cern/OU=computers/CN=wmagent/vocms0192.cern.ch", 
+        "Status": "acquired", 
+        "UpdateTime": 1543836343
+      }
+    ], 
+    "FirstLumi": 1, 
+    "DQMUploadProxy": null, 
+    "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb", 
+    "_id": "amaltaro_StepChain_MC_HG1812_Validation_181203_121017_2487", 
+    "Dashboard": "integration"
+  }
+}

--- a/test/python/WMCore_t/WMStats_t/DataStructs_t/DataCache_t.py
+++ b/test/python/WMCore_t/WMStats_t/DataStructs_t/DataCache_t.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+
+from __future__ import division, print_function
+
+import json
+import os
+import unittest
+
+from WMCore.WMStats.DataStructs.DataCache import DataCache
+
+
+class DataCacheTests(unittest.TestCase):
+    """
+    Unit tests for WMStats DataCache
+    """
+
+    def setUp(self):
+        self.fileCache = os.path.join(os.path.dirname(__file__), 'DataCache.json')
+        with open(self.fileCache) as jo:
+            data = json.load(jo)
+        DataCache().setlatestJobData(data)
+
+    def tearDown(self):
+        pass
+
+    def testDuration(self):
+        self.assertEqual(300, DataCache.getDuration())
+
+        DataCache.setDuration(100)
+        self.assertEqual(100, DataCache.getDuration())
+
+    def testLatestJobData(self):
+        self.assertEqual(20, len(DataCache.getlatestJobData()))
+        self.assertItemsEqual(['time', 'data'], DataCache._lastedActiveDataFromAgent.keys())
+
+        DataCache.setlatestJobData("ALAN")
+        self.assertEqual("ALAN", DataCache.getlatestJobData())
+        self.assertItemsEqual(['time', 'data'], DataCache._lastedActiveDataFromAgent.keys())
+
+    def testLatestJobDataExpired(self):
+        self.assertFalse(DataCache.islatestJobDataExpired())
+
+        DataCache.setDuration(-1)
+        self.assertTrue(DataCache.islatestJobDataExpired())
+
+        DataCache.setDuration(300)
+        self.assertFalse(DataCache.islatestJobDataExpired())
+        DataCache._lastedActiveDataFromAgent = {}
+        self.assertTrue(DataCache.islatestJobDataExpired())
+
+        self.assertEqual({}, DataCache.getlatestJobData())
+
+    def testFilterData(self):
+        data = list(DataCache.filterData(filterDict={}, maskList=['RequestType']))
+        self.assertEqual(20, len(data))
+        self.assertItemsEqual(['ReReco', 'MonteCarlo', 'StepChain', 'MonteCarloFromGEN',
+                               'ReDigi', 'TaskChain', 'DQMHarvest'], set(list(data)))
+
+        data = list(DataCache.filterData(filterDict={}, maskList=['Campaign', 'RequestType']))
+        self.assertEqual(40, len(data))
+
+        data = list(DataCache.filterData(filterDict={'IncludeParents': 'True'}, maskList=['Campaign']))
+        self.assertEqual(2, len(data))
+
+        data = list(DataCache.filterData(filterDict={'Campaign': 'CMSSW_9_4_0__test2inwf-1510737328'},
+                                         maskList=['RequestName']))
+        self.assertItemsEqual(["amaltaro_TaskChain_InclParents_HG1812_Validation_181203_121005_1483"],
+                              data)
+
+    def testFilterDataByRequest(self):
+        data = list(DataCache.filterDataByRequest(filterDict={}, maskList='RequestType'))
+        self.assertEqual(20, len(data))
+        self.assertItemsEqual(['RequestName', 'RequestType'], data[0].keys())
+        reqTypes = [item['RequestType'] for item in data]
+        self.assertItemsEqual(['ReReco', 'MonteCarlo', 'StepChain', 'MonteCarloFromGEN',
+                               'ReDigi', 'TaskChain', 'DQMHarvest'], set(list(reqTypes)))
+
+        data = list(DataCache.filterDataByRequest(filterDict={}, maskList=['Campaign', 'RequestType']))
+        self.assertEqual(20, len(data))
+
+        data = list(DataCache.filterDataByRequest(filterDict={'IncludeParents': 'True'}, maskList=['Campaign']))
+        self.assertEqual(2, len(data))
+
+        data = list(DataCache.filterDataByRequest(filterDict={'Campaign': 'CMSSW_9_4_0__test2inwf-1510737328'},
+                                                  maskList=['RequestName']))
+        self.assertEqual(1, len(data))
+        self.assertEqual("amaltaro_TaskChain_InclParents_HG1812_Validation_181203_121005_1483",
+                         data[0]['RequestName'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #8936 

Problem being that `reqValue` might be a list for Chain requests while `value` is not, does failing to process the intersection of both objects.