### PR TITLE
move to archived status only depends on the time

### DIFF
--- a/src/python/WMCore/ReqMgr/CherryPyThreads/StatusChangeTasks.py
+++ b/src/python/WMCore/ReqMgr/CherryPyThreads/StatusChangeTasks.py
@@ -87,7 +87,7 @@ def moveToArchived(wmstatsSvc, reqmgrSvc, logdb, archiveDelayHours, logger):
     outputMask = ["RequestTransition"]
 
     for status, nextStatus in statusTransition.items():
-        inputConditon = {"RequestStatus": [status], "AgentJobInfo": "CLEANED"}
+        inputConditon = {"RequestStatus": [status]}
         for reqInfo in wmstatsSvc.getFilteredActiveData(inputConditon, outputMask):
             reqName = reqInfo["RequestName"]
             if reqName and (not reqInfo["RequestTransition"] or


### PR DESCRIPTION
fixes #8894 

Since AgentJobInfo document won't be cleaned anymore, move do archive status only depend on the time. This is not the permanent fix. 
(We need to add the clean up status back to wmstats for each agent) 
But for now this will be OK with increased archive delay for 7 days.

update the delay hours below
https://github.com/dmwm/deployment/pull/703