### PR TITLE
allow other compressions beside gzip for tarball

### DIFF
--- a/src/python/WMCore/WMRuntime/Scripts/UnpackUserTarball.py
+++ b/src/python/WMCore/WMRuntime/Scripts/UnpackUserTarball.py
@@ -89,7 +89,7 @@ def UnpackUserTarball():
             logging.info("Fetching tarball %s through xrootd", tarball)
             try:
                 subprocess.check_call(['xrdcp', '-d', '1', '-f', tarball, 'TEMP_TARBALL.tgz'])
-                subprocess.check_call(['tar', 'xzf', 'TEMP_TARBALL.tgz'])
+                subprocess.check_call(['tar', 'xf', 'TEMP_TARBALL.tgz'])
             except subprocess.CalledProcessError:
                 logging.error("Couldn't retrieve/extract file from xrootd")
                 raise
@@ -113,12 +113,12 @@ def UnpackUserTarball():
                     fileName, headers = retriever(tarball, tempFile.name)
 
                 try:
-                    subprocess.check_call(['tar', 'xzf', fileName])
+                    subprocess.check_call(['tar', 'xf', fileName])
                 except subprocess.CalledProcessError:
                     raise RuntimeError('Error extracting %s' % tarball)
         elif os.path.isfile(tarFile):
             logging.info("Untarring %s", tarFile)
-            subprocess.check_call(['tar', 'xzf', tarFile])
+            subprocess.check_call(['tar', 'xf', tarFile])
         else:
             raise IOError('%s does not exist' % tarFile)
 


### PR DESCRIPTION
Alan, Seanchan, please consider if you like this PR.
It has been pointed out that CRAB tarball can get significantly smaller by usiing gzip2 instead of gzip. Since modern tar self-detect the compression algorithm, removing 'z' option from untar in here allows to use gzip2 transparently.
ref: https://github.com/dmwm/CRABServer/issues/5729
No hurry to get it in, though.