### PR TITLE
Retry condor job removal for timeout

### DIFF
--- a/src/python/WMCore/BossAir/MySQL/UpdateJobs.py
+++ b/src/python/WMCore/BossAir/MySQL/UpdateJobs.py
@@ -5,8 +5,8 @@ _UpdateJobs_
 MySQL implementation for updating jobs
 """
 
-
 from WMCore.Database.DBFormatter import DBFormatter
+
 
 class UpdateJobs(DBFormatter):
     """
@@ -14,7 +14,6 @@ class UpdateJobs(DBFormatter):
 
     Update jobs with new values
     """
-
 
     sql = """UPDATE bl_runjob SET wmbs_id = :jobid, grid_id = :gridid,
                bulk_id = :bulkid, status_time = :status_time,
@@ -24,9 +23,7 @@ class UpdateJobs(DBFormatter):
                WHERE id = :id
                """
 
-
-
-    def execute(self, jobs, conn = None, transaction = False):
+    def execute(self, jobs, conn=None, transaction=False):
         """
         _execute_
 
@@ -44,8 +41,6 @@ class UpdateJobs(DBFormatter):
                           'status_time': job.get('status_time', None), 'owner': job['userdn'],
                           'usergroup': job['usergroup'], 'userrole': job['userrole']})
 
-
-        self.dbi.processData(self.sql, binds, conn = conn,
-                                      transaction = transaction)
+        self.dbi.processData(self.sql, binds, conn=conn, transaction=transaction)
 
         return

--- a/src/python/WMCore/BossAir/MySQL/UpdateJobs.py
+++ b/src/python/WMCore/BossAir/MySQL/UpdateJobs.py
@@ -45,7 +45,7 @@ class UpdateJobs(DBFormatter):
                           'usergroup': job['usergroup'], 'userrole': job['userrole']})
 
 
-        result = self.dbi.processData(self.sql, binds, conn = conn,
+        self.dbi.processData(self.sql, binds, conn = conn,
                                       transaction = transaction)
 
         return

--- a/src/python/WMCore/BossAir/Plugins/MockPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/MockPlugin.py
@@ -196,7 +196,7 @@ class MockPlugin(BasePlugin):
 
         return runningList, changeList, completeList
 
-    def kill(self, jobs):
+    def kill(self, jobs, raiseEx=False):
         """
         _kill_
 

--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -407,7 +407,7 @@ class SimpleCondorPlugin(BasePlugin):
 
         return jobtokill
 
-    def kill(self, jobs):
+    def kill(self, jobs, raiseEx=False):
         """
         _kill_
 
@@ -422,6 +422,8 @@ class SimpleCondorPlugin(BasePlugin):
             schedd.act(htcondor.JobAction.Remove, gridIds)
         except RuntimeError:
             logging.warn("Error while killing jobs on the schedd: %s", gridIds)
+            if raiseEx:
+                raise
 
         return
 


### PR DESCRIPTION
Fixes #8963 

If we are aborting/force-completing a workflow, run the job completion code no matter whether the condor job removal succeeded or not (thus keep the same behaviour as before).

For standalone jobs, only complete jobs (update their status in BossAir) if the condor job removal succeeded, otherwise skip it and wait for the next next cycle of JobStatusLite, such that it can find the same jobs again and try to do the removal again.

It needs to be careful tested though, it's not much uncommon that something slips through the cracks when touching BossAir.