### PR TITLE
Fix count of leftover processes in deploy-wmagent

### DIFF
--- a/deploy/deploy-wmagent.sh
+++ b/deploy/deploy-wmagent.sh
@@ -147,7 +147,7 @@ check_certs()
 check_process()
 {
   echo -n "Checking whether there are any leftover processes ..."
-  output=`ps aux | egrep 'couch|wmcore|mysql|beam' | wc -l`
+  output=`ps aux | egrep 'couch|wmcore|mysql|beam' | grep -v deploy-wmagent.sh | wc -l`
   if [ "$output" -gt 1 ]; then
     echo "  FAILED!\n There are still $output WMCore process running. Quitting!"
     exit 8


### PR DESCRIPTION
Fix count of leftover processes in deploy-wmagent.sh script in the case one of the argument strings (e.g the machine hostname) for the deployment script itself matches one of the process names we are trying to count (i.e.: couch, wmcore, mysql, beam)
 
Fixes #8942