### PR TITLE
Remove MaxVSize argument; retry softKill with hardKill; remove RSS backwards compatibility

### DIFF
--- a/src/python/WMCore/ReqMgr/Tools/cms.py
+++ b/src/python/WMCore/ReqMgr/Tools/cms.py
@@ -175,7 +175,6 @@ def web_ui_names():
 #             "Minmergesize": "Min merge size",
 #             "Maxmergesize": "Max merge size",
 #             "Maxmergeevents": "Max merge events",
-#             "Maxvsize": "Maximum VSize",
 #             "Blockclosemaxwaittime": "Block close max wait time",
 #             "Blockclosemaxfiles": "Block close max files",
 #             "Blockclosemaxevents": "Block close max events",

--- a/src/python/WMCore/ReqMgr/Tools/cms.py
+++ b/src/python/WMCore/ReqMgr/Tools/cms.py
@@ -10,14 +10,16 @@ Description: CMS modules
 from __future__ import (division, print_function)
 
 import os
+
 from WMCore.Cache.GenericDataCache import MemoryCacheStruct
 from WMCore.ReqMgr.DataStructs.RequestStatus import REQUEST_STATE_LIST, REQUEST_STATE_TRANSITION
-from WMCore.Services.SiteDB.SiteDB import SiteDBJSON
 from WMCore.Services.CRIC.CRIC import CRIC
+from WMCore.Services.SiteDB.SiteDB import SiteDBJSON
 from WMCore.Services.TagCollector.TagCollector import TagCollector
 
 # initialize TagCollector instance to be used in this module
 TC = TagCollector()
+
 
 def next_status(status=None):
     "Return next ReqMgr status for given status"
@@ -27,6 +29,7 @@ def next_status(status=None):
         else:
             return 'N/A'
     return REQUEST_STATE_LIST
+
 
 def sites():
     "Return known CMS site list from SiteDB"
@@ -43,8 +46,10 @@ def sites():
         raise Exception(msg)
     return site_list
 
+
 # create a site cache and pnn cache 2 hour duration
 SITE_CACHE = MemoryCacheStruct(5200, sites)
+
 
 def pnns():
     """
@@ -62,18 +67,22 @@ def pnns():
         raise Exception(msg)
     return pnn_list
 
+
 # create a site cache and pnn cache 2 hour duration
-PNN_CACHE= MemoryCacheStruct(5200, pnns)
+PNN_CACHE = MemoryCacheStruct(5200, pnns)
+
 
 def site_white_list():
     "site white list, default all T1"
     t1_sites = [s for s in SITE_CACHE.getData() if s.startswith('T1_')]
     return t1_sites
 
+
 def site_black_list():
     "site black list, default all T3"
     t3_sites = [s for s in SITE_CACHE.getData() if s.startswith('T3_')]
     return t3_sites
+
 
 def lfn_bases():
     "Return LFN Base list"
@@ -107,94 +116,98 @@ def lfn_bases():
         "/store/results/trigger"]
     return storeResultLFNBase
 
+
 def lfn_unmerged_bases():
     "Return list of LFN unmerged bases"
     out = ["/store/unmerged", "/store/data", "/store/temp"]
     return out
 
+
 def web_ui_names():
     "Return dict of web UI JSON naming conventions"
     maps = {
-            "TimePerEvent": "TimePerEvent (seconds)",
-            "OpenRunningTimeout": "OpenRunningTimeout (deprecated)",
-            "SizePerEvent": "SizePerEvent (KBytes)",
-            "Memory": "Memory (MBytes)",
-            "BlockCloseMaxSize": "BlockCloseMaxSize (Bytes)",
-            "SoftTimeout": "SoftTimeout (seconds)",
-            }
-#     maps = {"InputDataset": "Input dataset",
-#             "IncludeParents": "Include parents",
-#             "PrepID": "Optional Prep ID String",
-#             "BlockBlacklist": "Block black list",
-#             "RequestPriority": "Request priority",
-#             "TimePerEvent": "Time per event (seconds)",
-#             "RunWhitelist": "Run white list",
-#             "BlockWhitelist": "Block white list",
-#             "OpenRunningTimeout": "Open Running Timeout",
-#             "DQLUploadURL": "DQM URL",
-#             "DqmSequences": "DQM Sequences",
-#             "SizePerEvent": "Size per event (KBytes)",
-#             "ScramArch": "Architecture",
-#             "EnableHarvesting": "Enable DQM Harvesting",
-#             "DQMConfigCacheID": "DQM Config CacheID",
-#             "Memory": "Memory (MBytes)",
-#             "RunBlacklist": "Run black list",
-#             "RequestString": "Optional request ID string",
-#             "CMSSWVersion": "Software releases",
-#             "DQMUploadURL":"DQM URL",
-#             "DQMSequences": "DQM sequences",
-#             "DataPileup": "Data pileup",
-#             "FilterEfficiency": "Filter efficiency",
-#             "GlobalTag": "Global tag",
-#             "MCPileup": "MonteCarlo pileup",
-#             "PrimaryDataset": "Parimary dataset",
-#             "Acquisitionera": "Acquisition era",
-#             "CmsPath": "CMS path",
-#             "DBS": "DBS urls",
-#             "ProcessingVersion": "Processing version",
-#             "ProcessingString": "Processing string",
-#             "RequestType": "Request type",
-#             "ACDCDatabase": "ACDC database",
-#             "ACDCServer": "ACDC server",
-#             "CollectionName": "Collection name",
-#             "IgnoredOutputModules": "Ignored output modules",
-#             "InitialTaskPath": "Initial task path",
-#             "KeepStepOneOutput": "Keep step one output",
-#             "KeepStepTwoOutput": "Keep step two output",
-#             "StepOneConfigCacheID": "Step one config cache id",
-#             "StepOneOutputModuleName": "Step one output module name",
-#             "StepThreeConfigCacheID": "Step three config cache id",
-#             "StepTwoConfigCacheID": "Step two config cache id",
-#             "StepTwoOutputModuleName": "Step two output module name",
-#             "Sitewhitelist": "Site white list",
-#             "Siteblacklist": "Site black list",
-#             "Mergedlfnbase": "Merged LFN base",
-#             "Maxrss": "Max RSS",
-#             "Trustsitelists": "Trust site lists",
-#             "Unmergedlfnbase": "Unmerged LFN base",
-#             "Minmergesize": "Min merge size",
-#             "Maxmergesize": "Max merge size",
-#             "Maxmergeevents": "Max merge events",
-#             "Blockclosemaxwaittime": "Block close max wait time",
-#             "Blockclosemaxfiles": "Block close max files",
-#             "Blockclosemaxevents": "Block close max events",
-#             "Blockclosemaxsize": "Block close max size",
-#             "Softtimeout": "Soft time out",
-#             "Graceperiod": "Grace period"
-#             }
+        "TimePerEvent": "TimePerEvent (seconds)",
+        "OpenRunningTimeout": "OpenRunningTimeout (deprecated)",
+        "SizePerEvent": "SizePerEvent (KBytes)",
+        "Memory": "Memory (MBytes)",
+        "BlockCloseMaxSize": "BlockCloseMaxSize (Bytes)",
+        "SoftTimeout": "SoftTimeout (seconds)",
+    }
+    #     maps = {"InputDataset": "Input dataset",
+    #             "IncludeParents": "Include parents",
+    #             "PrepID": "Optional Prep ID String",
+    #             "BlockBlacklist": "Block black list",
+    #             "RequestPriority": "Request priority",
+    #             "TimePerEvent": "Time per event (seconds)",
+    #             "RunWhitelist": "Run white list",
+    #             "BlockWhitelist": "Block white list",
+    #             "OpenRunningTimeout": "Open Running Timeout",
+    #             "DQLUploadURL": "DQM URL",
+    #             "DqmSequences": "DQM Sequences",
+    #             "SizePerEvent": "Size per event (KBytes)",
+    #             "ScramArch": "Architecture",
+    #             "EnableHarvesting": "Enable DQM Harvesting",
+    #             "DQMConfigCacheID": "DQM Config CacheID",
+    #             "Memory": "Memory (MBytes)",
+    #             "RunBlacklist": "Run black list",
+    #             "RequestString": "Optional request ID string",
+    #             "CMSSWVersion": "Software releases",
+    #             "DQMUploadURL":"DQM URL",
+    #             "DQMSequences": "DQM sequences",
+    #             "DataPileup": "Data pileup",
+    #             "FilterEfficiency": "Filter efficiency",
+    #             "GlobalTag": "Global tag",
+    #             "MCPileup": "MonteCarlo pileup",
+    #             "PrimaryDataset": "Parimary dataset",
+    #             "Acquisitionera": "Acquisition era",
+    #             "CmsPath": "CMS path",
+    #             "DBS": "DBS urls",
+    #             "ProcessingVersion": "Processing version",
+    #             "ProcessingString": "Processing string",
+    #             "RequestType": "Request type",
+    #             "ACDCDatabase": "ACDC database",
+    #             "ACDCServer": "ACDC server",
+    #             "CollectionName": "Collection name",
+    #             "IgnoredOutputModules": "Ignored output modules",
+    #             "InitialTaskPath": "Initial task path",
+    #             "KeepStepOneOutput": "Keep step one output",
+    #             "KeepStepTwoOutput": "Keep step two output",
+    #             "StepOneConfigCacheID": "Step one config cache id",
+    #             "StepOneOutputModuleName": "Step one output module name",
+    #             "StepThreeConfigCacheID": "Step three config cache id",
+    #             "StepTwoConfigCacheID": "Step two config cache id",
+    #             "StepTwoOutputModuleName": "Step two output module name",
+    #             "Sitewhitelist": "Site white list",
+    #             "Siteblacklist": "Site black list",
+    #             "Mergedlfnbase": "Merged LFN base",
+    #             "Maxrss": "Max RSS",
+    #             "Trustsitelists": "Trust site lists",
+    #             "Unmergedlfnbase": "Unmerged LFN base",
+    #             "Minmergesize": "Min merge size",
+    #             "Maxmergesize": "Max merge size",
+    #             "Maxmergeevents": "Max merge events",
+    #             "Blockclosemaxwaittime": "Block close max wait time",
+    #             "Blockclosemaxfiles": "Block close max files",
+    #             "Blockclosemaxevents": "Block close max events",
+    #             "Blockclosemaxsize": "Block close max size",
+    #             "Softtimeout": "Soft time out",
+    #             "Graceperiod": "Grace period"
+    #             }
     return maps
+
 
 def dqm_urls():
     "Return list of DQM urls"
     urls = [
-            "https://cmsweb.cern.ch/dqm/dev",
-            "https://cmsweb.cern.ch/dqm/offline",
-            "https://cmsweb.cern.ch/dqm/relval",
-            "https://cmsweb-testbed.cern.ch/dqm/dev",
-            "https://cmsweb-testbed.cern.ch/dqm/offline",
-            "https://cmsweb-testbed.cern.ch/dqm/relval",
-            ]
+        "https://cmsweb.cern.ch/dqm/dev",
+        "https://cmsweb.cern.ch/dqm/offline",
+        "https://cmsweb.cern.ch/dqm/relval",
+        "https://cmsweb-testbed.cern.ch/dqm/dev",
+        "https://cmsweb-testbed.cern.ch/dqm/offline",
+        "https://cmsweb-testbed.cern.ch/dqm/relval",
+    ]
     return urls
+
 
 def dbs_urls():
     "Return list of DBS urls"
@@ -204,28 +217,34 @@ def dbs_urls():
         urls.append(base.replace("prod", inst))
     return urls
 
+
 def couch_url():
     "Return central couch url"
     url = "https://cmsweb.cern.ch/couchdb"
     return url
 
+
 def releases(arch=None):
     "Return list of CMSSW releases"
     return TC.releases(arch)
 
+
 def architectures():
     "Return list of CMSSW architectures"
     return TC.architectures()
+
 
 def scenarios():
     "Return list of scenarios"
     slist = ["pp", "cosmics", "hcalnzs", "preprodmc", "prodmc"]
     return slist
 
+
 def cms_groups():
     "Return list of CMS data-ops groups"
     groups = ["DATAOPS"]
     return groups
+
 
 def dashboardActivities():
     "Return list of dashboard activities"

--- a/src/python/WMCore/ReqMgr/Utils/Validation.py
+++ b/src/python/WMCore/ReqMgr/Utils/Validation.py
@@ -81,10 +81,6 @@ def validate_request_create_args(request_args, config, reqmgr_db_service, *args,
     3. convert data from body to arguments (spec instance, argument with default setting)
     TODO: raise right kind of error with clear message
     """
-    ### TODO: backwards compatibility. Remove these 2 lines in ~HG1805
-    request_args.pop('MaxRSS', None)
-    request_args.pop('MaxVSize', None)
-
     if request_args["RequestType"] == "Resubmission":
         # do not set default values for Resubmission since it will be inherited from parent
         # both create & assign args are accepted for Resubmission creation
@@ -169,10 +165,6 @@ def validate_clone_create_args(request_args, config, reqmgr_db_service, *args, *
 
     cloned_args = initialize_clone(request_args, originalArgs, createArgs, chainArgs)
     initialize_request_args(cloned_args, config)
-
-    ### TODO: backwards compatibility. Remove these 2 lines in ~HG1805
-    cloned_args.pop('MaxRSS', None)
-    cloned_args.pop('MaxVSize', None)
 
     permission = getWritePermission(cloned_args)
     authz_match(permission['role'], permission['group'])

--- a/src/python/WMCore/WMExceptions.py
+++ b/src/python/WMCore/WMExceptions.py
@@ -154,7 +154,6 @@ WM_JOB_ERROR_CODES = {-1: "Error return without specification.",
                       50116: "Could not determine exit code of cmsRun executable at runtime.",  # (WMA)
                       50513: "Failure to run SCRAM setup scripts.",  # (WMA, CRAB3)
                       50660: "Application terminated by wrapper because using too much RAM (RSS).",  # (WMA, CRAB3)
-                      50661: "Application terminated by wrapper because using too much Virtual Memory (VSIZE).",  # (WMA)
                       50662: "Application terminated by wrapper because using too much disk.",  # (CRAB3)
                       50664: "Application terminated by wrapper because using too much Wall Clock time.",  # (WMA, CRAB3)
                       50665: "Application terminated by wrapper because it stay idle too long.",  # (CRAB3)

--- a/src/python/WMCore/WMRuntime/Monitors/PerformanceMonitor.py
+++ b/src/python/WMCore/WMRuntime/Monitors/PerformanceMonitor.py
@@ -16,7 +16,7 @@ import signal
 import time
 
 import WMCore.Algorithms.SubprocessAlgos as subprocessAlgos
-import WMCore.FwkJobReport.Report        as Report
+import WMCore.FwkJobReport.Report as Report
 from WMCore.WMException import WMException
 from WMCore.WMRuntime.Monitors.DashboardMonitor import getStepPID
 from WMCore.WMRuntime.Monitors.WMRuntimeMonitor import WMRuntimeMonitor
@@ -184,7 +184,7 @@ class PerformanceMonitor(WMRuntimeMonitor):
 
         # Now we run the monitor command and collate the data
         cmd = self.monitorBase % (stepPID, stepPID)
-        stdout, stderr, retcode = subprocessAlgos.runCommand(cmd)
+        stdout, _stderr, _retcode = subprocessAlgos.runCommand(cmd)
 
         output = stdout.split()
         if not len(output) > 6:

--- a/src/python/WMCore/WMRuntime/Monitors/PerformanceMonitor.py
+++ b/src/python/WMCore/WMRuntime/Monitors/PerformanceMonitor.py
@@ -14,7 +14,6 @@ import os
 import os.path
 import signal
 import time
-import traceback
 
 import WMCore.Algorithms.SubprocessAlgos as subprocessAlgos
 import WMCore.FwkJobReport.Report        as Report
@@ -60,22 +59,21 @@ class PerformanceMonitor(WMRuntimeMonitor):
 
         self.pid = None
         self.uid = os.getuid()
-        self.monitorBase = "ps -p %i -o pid,ppid,rss,vsize,pcpu,pmem,cmd -ww | grep %i"
+        self.monitorBase = "ps -p %i -o pid,ppid,rss,pcpu,pmem,cmd -ww | grep %i"
         self.monitorCommand = None
         self.currentStepSpace = None
         self.currentStepName = None
 
         self.rss = []
-        self.vsize = []
         self.pcpu = []
         self.pmem = []
 
         self.maxRSS = None
-        self.maxVSize = None
         self.softTimeout = None
         self.hardTimeout = None
         self.logPath = None
         self.startTime = None
+        self.killRetry = False  # will trigger a hard (SIGTERM) instead of soft kill
 
         self.watchStepTypes = []
 
@@ -98,7 +96,6 @@ class PerformanceMonitor(WMRuntimeMonitor):
         self.watchStepTypes = args.get('WatchStepTypes', ['CMSSW', 'PerfTest'])
 
         self.maxRSS = args.get('maxRSS', None)
-        self.maxVSize = args.get('maxVSize', None)
         self.softTimeout = args.get('softTimeout', None)
         self.hardTimeout = args.get('hardTimeout', None)
         self.numOfCores = args.get('cores', None)
@@ -163,7 +160,6 @@ class PerformanceMonitor(WMRuntimeMonitor):
         killHard = False
         reason = ''
         errorCodeLookup = {'RSS': 50660,
-                           'VSZ': 50661,
                            'Wallclock time': 50664,
                            '': 99999}
 
@@ -191,26 +187,19 @@ class PerformanceMonitor(WMRuntimeMonitor):
         stdout, stderr, retcode = subprocessAlgos.runCommand(cmd)
 
         output = stdout.split()
-        if not len(output) > 7:
+        if not len(output) > 6:
             # Then something went wrong in getting the ps data
             msg = "Error when grabbing output from process ps\n"
             msg += "output = %s\n" % output
             msg += "command = %s\n" % self.monitorCommand
             logging.error(msg)
             return
-        # FIXME: making it backwards compatible. Keep only the "else" block in HG1801
-        if self.maxRSS is not None and self.maxRSS >= (1024 * 1024):
-            # then workload value is still in KiB (old way)
-            rss = int(output[2])
-            vsize = int(output[3])
-        else:
-            # ps returns data in kiloBytes, let's make it megaBytes
-            # I'm so confused with these megabytes and mebibytes...
-            rss = int(output[2]) // 1000  # convert it to MiB
-            vsize = int(output[3]) // 1000  # convert it to MiB
+
+        # ps returns data in kiloBytes, let's make it megaBytes
+        # I'm so confused with these megabytes and mebibytes...
+        rss = int(output[2]) // 1000  # convert it to MiB
         logging.info("Retrieved following performance figures:")
-        logging.info("RSS: %s;  VSize: %s; PCPU: %s; PMEM: %s", output[2], output[3],
-                     output[4], output[5])
+        logging.info("RSS: %s; PCPU: %s; PMEM: %s", output[2], output[3], output[4])
 
         msg = 'Error in CMSSW step %s\n' % self.currentStepName
         msg += 'Number of Cores: %s\n' % self.numOfCores
@@ -220,11 +209,6 @@ class PerformanceMonitor(WMRuntimeMonitor):
             msg += "Job has RSS: %s\n" % rss
             killProc = True
             reason = 'RSS'
-        elif self.maxVSize is not None and vsize >= self.maxVSize:
-            msg += "Job has exceeded maxVSize: %s\n" % self.maxVSize
-            msg += "Job has VSize: %s\n" % vsize
-            killProc = True
-            reason = 'VSZ'
         elif self.hardTimeout is not None and self.softTimeout is not None:
             currentTime = time.time()
             if (currentTime - self.startTime) > self.softTimeout:
@@ -236,7 +220,12 @@ class PerformanceMonitor(WMRuntimeMonitor):
                 killHard = True
                 msg += "Job exceeded soft timeout"
 
-        if killProc:
+        if not killProc:
+            # then job is behaving well, there is nothing to do
+            return
+
+        # make sure we persist the performance error only once
+        if not self.killRetry:
             logging.error(msg)
             report = Report.Report()
             # Find the global report
@@ -260,19 +249,20 @@ class PerformanceMonitor(WMRuntimeMonitor):
                 # Kill anyway, and hope the logging file gets written out
                 msg2 = "Exception while writing out jobReport.\n"
                 msg2 += "Aborting job anyway: unlikely you'll get any error report.\n"
-                msg2 += str(ex)
-                msg2 += str(traceback.format_exc()) + '\n'
-                logging.error(msg2)
+                msg2 += "Error: %s" % str(ex)
+                logging.exception(msg2)
 
-            try:
-                if not killHard:
-                    logging.error("Attempting to kill step using SIGUSR2")
-                    os.kill(stepPID, signal.SIGUSR2)
-                else:
-                    logging.error("Attempting to kill step using SIGTERM")
-                    os.kill(stepPID, signal.SIGTERM)
-            except Exception:
+        try:
+            if not killHard and not self.killRetry:
+                logging.error("Attempting to kill step using SIGUSR2")
+                os.kill(stepPID, signal.SIGUSR2)
+            else:
                 logging.error("Attempting to kill step using SIGTERM")
                 os.kill(stepPID, signal.SIGTERM)
+        except Exception:
+            logging.error("Attempting to kill step using SIGTERM")
+            os.kill(stepPID, signal.SIGTERM)
+        finally:
+            self.killRetry = True
 
         return

--- a/src/python/WMCore/WMRuntime/Watchdog.py
+++ b/src/python/WMCore/WMRuntime/Watchdog.py
@@ -99,17 +99,12 @@ class Watchdog(threading.Thread):
                 # We decided to only touch Watchdog settings if the number of cores changed.
                 # (even if this means the watchdog memory is wrong for a slot this size).
                 changedCores = origCores != resources['cores']
-                # HTCondor doesn't explicitly scale VSize; it's also not clear what
-                # resources this manages (as we already watch the memory use) or how
-                # it should relate to other resources (such as memory or cores used).
-                # Hence, we simply remove it if we change anything about the memory.
                 # If we did base maxRSS off the memory in the HTCondor slot, subtract a bit
                 # off the top so watchdog triggers before HTCondor does.
                 # Add the new number of cores to the args such that DashboardInterface can see it
                 args['cores'] = resources['cores']
                 if changedCores:
                     if origMaxRSS:
-                        args.pop('maxVSize', None)
                         args['maxRSS'] = resources['memory'] - 50
 
                 logging.info("Watchdog modified: %s. Final settings:", changedCores)

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -226,7 +226,6 @@ class StdBase(object):
         """
         # Default settings defined by CMS policy
         maxrss = 2.3 * 1024  # 2.3 GiB, but in MiB
-        vsize = 1 * 1024 * 1024  # 1 TiB, but in MiB
         softTimeout = 47 * 3600  # 47h
         hardTimeout = 47 * 3600 + 5 * 60  # 47h + 5 minutes
 
@@ -238,7 +237,6 @@ class StdBase(object):
         monitoring.DashboardMonitor.destinationPort = self.dashboardPort
         monitoring.section_("PerformanceMonitor")
         monitoring.PerformanceMonitor.maxRSS = maxrss
-        monitoring.PerformanceMonitor.maxVSize = vsize
         monitoring.PerformanceMonitor.softTimeout = softTimeout
         monitoring.PerformanceMonitor.hardTimeout = hardTimeout
         return task

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -83,10 +83,10 @@ class StdBase(object):
     def calcEvtsPerJobLumi(ePerJob, ePerLumi, tPerEvent):
         """
         _calcEvtsPerJobLumi_
-        
+
         Given EventsPerJob, EventsPerLumi and TimePerEvent information,
         calculates the final values for EventsPerJob and EventsPerLumi.
-        
+
         Final result will always be an EventsPerJob multiple of EventsPerLumi,
         no matter whether EventsPerJob was provided or not.
         :param ePerJob: events per job

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -1219,27 +1219,6 @@ class WMTaskHelper(TreeHelper):
                 task.setMaxRSS(maxRSS)
         return
 
-    def setMaxVSize(self, maxVSize):
-        """
-        _setMaxVSize_
-
-        Set maxVSize performance monitoring for this task.
-        :param maxVSize: maximum VSize memory comsumption in MiB
-        """
-        if self.taskType() in ["Merge", "Cleanup", "LogCollect"]:
-            # keep the default settings (from StdBase) for these task types
-            return
-
-        if isinstance(maxVSize, dict):
-            maxVSize = maxVSize.get(self.name(), None)
-
-        if maxVSize:
-            self._setPerformanceMonitorConfig()
-            self.monitoring.PerformanceMonitor.maxVSize = int(maxVSize)
-            for task in self.childTaskIterator():
-                task.setMaxVSize(maxVSize)
-        return
-
     def setPerformanceMonitor(self, softTimeout=None, gracePeriod=None):
         """
         _setPerformanceMonitor_

--- a/test/python/WMCore_t/WMSpec_t/WMTask_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMTask_t.py
@@ -412,7 +412,6 @@ class WMTaskTest(unittest.TestCase):
 
         self.assertEqual(testTask.data.watchdog.monitors, ['PerformanceMonitor'])
         self.assertFalse(hasattr(testTask.data.watchdog.PerformanceMonitor, "maxRSS"))
-        self.assertFalse(hasattr(testTask.data.watchdog.PerformanceMonitor, "maxVSize"))
         self.assertEqual(testTask.data.watchdog.PerformanceMonitor.softTimeout, 100)
         self.assertEqual(testTask.data.watchdog.PerformanceMonitor.hardTimeout, 101)
         return

--- a/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
@@ -497,7 +497,7 @@ class WMWorkloadTest(unittest.TestCase):
             dataTier = outputModule.dataTier
             filterName = outputModule.filterName
 
-            if filterName == None:
+            if filterName is None:
                 procDataset = "%s-v0" % (acquisitionEra)
                 self.assertEqual(outputModule.processedDataset, procDataset,
                                  "Error: Processed dataset is incorrect.")
@@ -506,7 +506,7 @@ class WMWorkloadTest(unittest.TestCase):
                 self.assertEqual(outputModule.processedDataset, procDataset,
                                  "Error: Processed dataset is incorrect.")
 
-            if filterName != None:
+            if filterName is not None:
                 mergedLFN = "/store/data/%s/%s/%s/%s-%s" % (acquisitionEra, primaryDataset,
                                                             dataTier, filterName, 'v0')
                 unmergedLFN = "/store/unmerged/%s/%s/%s/%s-%s" % (acquisitionEra, primaryDataset,
@@ -539,7 +539,7 @@ class WMWorkloadTest(unittest.TestCase):
             dataTier = outputModule.dataTier
             filterName = outputModule.filterName
 
-            if filterName == None:
+            if filterName is None:
                 procDataset = "TestAcqEra-v2"
                 self.assertEqual(outputModule.processedDataset, procDataset,
                                  "Error: Processed dataset is incorrect.")
@@ -548,7 +548,7 @@ class WMWorkloadTest(unittest.TestCase):
                 self.assertEqual(outputModule.processedDataset, procDataset,
                                  "Error: Processed dataset is incorrect.")
 
-            if filterName != None:
+            if filterName is not None:
                 mergedLFN = "/store/data/%s/%s/%s/%s-%s" % (acquisitionEra, primaryDataset,
                                                             dataTier, filterName, "v2")
                 unmergedLFN = "/store/unmerged/%s/%s/%s/%s-%s" % (acquisitionEra, primaryDataset,
@@ -577,7 +577,7 @@ class WMWorkloadTest(unittest.TestCase):
             dataTier = outputModule.dataTier
             filterName = outputModule.filterName
 
-            if filterName == None:
+            if filterName is None:
                 procDataset = "TestAcqEra-Test-v2"
                 self.assertEqual(outputModule.processedDataset, procDataset,
                                  "Error: Processed dataset is incorrect.")
@@ -586,7 +586,7 @@ class WMWorkloadTest(unittest.TestCase):
                 self.assertEqual(outputModule.processedDataset, procDataset,
                                  "Error: Processed dataset is incorrect.")
 
-            if filterName != None:
+            if filterName is not None:
                 mergedLFN = "/store/data/%s/%s/%s/%s-%s" % (acquisitionEra, primaryDataset,
                                                             dataTier, filterName, "Test-v2")
                 unmergedLFN = "/store/unmerged/%s/%s/%s/%s-%s" % (acquisitionEra, primaryDataset,
@@ -625,7 +625,7 @@ class WMWorkloadTest(unittest.TestCase):
             dataTier = outputModule.dataTier
             filterName = outputModule.filterName
 
-            if filterName == None:
+            if filterName is None:
                 procDataset = "TestAcqEra-Test-v2"
                 self.assertEqual(outputModule.processedDataset, procDataset,
                                  "Error: Processed dataset is incorrect.")
@@ -634,7 +634,7 @@ class WMWorkloadTest(unittest.TestCase):
                 self.assertEqual(outputModule.processedDataset, procDataset,
                                  "Error: Processed dataset is incorrect.")
 
-            if filterName != None:
+            if filterName is not None:
                 mergedLFN = "/store/temp/merged/%s/%s/%s/%s-%s" % (acquisitionEra, primaryDataset,
                                                                    dataTier, filterName, 'Test-v2')
                 unmergedLFN = "/store/temp/unmerged/%s/%s/%s/%s-%s" % (acquisitionEra, primaryDataset,
@@ -699,7 +699,7 @@ class WMWorkloadTest(unittest.TestCase):
             dataTier = outputModule.dataTier
             filterName = outputModule.filterName
 
-            if filterName == None:
+            if filterName is None:
                 procDataset = "%s-v0" % (acquisitionEras["ProcessingTask"])
                 self.assertEqual(outputModule.processedDataset, procDataset,
                                  "Error: Processed dataset is incorrect.")
@@ -708,7 +708,7 @@ class WMWorkloadTest(unittest.TestCase):
                 self.assertEqual(outputModule.processedDataset, procDataset,
                                  "Error: Processed dataset is incorrect.")
 
-            if filterName != None:
+            if filterName is not None:
                 mergedLFN = "/store/data/%s/%s/%s/%s-%s" % (acquisitionEras["SkimTask"],
                                                             primaryDataset, dataTier, filterName, 'v0')
                 unmergedLFN = "/store/unmerged/%s/%s/%s/%s-%s" % (acquisitionEras["SkimTask"],
@@ -740,7 +740,7 @@ class WMWorkloadTest(unittest.TestCase):
             dataTier = outputModule.dataTier
             filterName = outputModule.filterName
 
-            if filterName == None:
+            if filterName is None:
                 procDataset = "TestAcqEra-v2"
                 self.assertEqual(outputModule.processedDataset, procDataset,
                                  "Error: Processed dataset is incorrect.")
@@ -749,7 +749,7 @@ class WMWorkloadTest(unittest.TestCase):
                 self.assertEqual(outputModule.processedDataset, procDataset,
                                  "Error: Processed dataset is incorrect.")
 
-            if filterName != None:
+            if filterName is not None:
                 mergedLFN = "/store/data/%s/%s/%s/%s-%s" % (acquisitionEras["SkimTask"],
                                                             primaryDataset, dataTier, filterName, "v3")
                 unmergedLFN = "/store/unmerged/%s/%s/%s/%s-%s" % (acquisitionEras["SkimTask"],
@@ -781,7 +781,7 @@ class WMWorkloadTest(unittest.TestCase):
             dataTier = outputModule.dataTier
             filterName = outputModule.filterName
 
-            if filterName == None:
+            if filterName is None:
                 procDataset = "TestAcqEra-Test-v2"
                 self.assertEqual(outputModule.processedDataset, procDataset,
                                  "Error: Processed dataset is incorrect.")
@@ -790,7 +790,7 @@ class WMWorkloadTest(unittest.TestCase):
                 self.assertEqual(outputModule.processedDataset, procDataset,
                                  "Error: Processed dataset is incorrect.")
 
-            if filterName != None:
+            if filterName is not None:
                 mergedLFN = "/store/data/%s/%s/%s/%s-%s" % (acquisitionEras["SkimTask"],
                                                             primaryDataset, dataTier, filterName, "SkimTest-v3")
                 unmergedLFN = "/store/unmerged/%s/%s/%s/%s-%s" % (acquisitionEras["SkimTask"],
@@ -825,7 +825,7 @@ class WMWorkloadTest(unittest.TestCase):
             dataTier = outputModule.dataTier
             filterName = outputModule.filterName
 
-            if filterName == None:
+            if filterName is None:
                 procDataset = "TestAcqEra-Test-v2"
                 self.assertEqual(outputModule.processedDataset, procDataset,
                                  "Error: Processed dataset is incorrect.")
@@ -834,7 +834,7 @@ class WMWorkloadTest(unittest.TestCase):
                 self.assertEqual(outputModule.processedDataset, procDataset,
                                  "Error: Processed dataset is incorrect.")
 
-            if filterName != None:
+            if filterName is not None:
                 mergedLFN = "/store/temp/merged/%s/%s/%s/%s-%s" % (acquisitionEras["SkimTask"],
                                                                    primaryDataset, dataTier, filterName, 'SkimTest-v3')
                 unmergedLFN = "/store/temp/unmerged/%s/%s/%s/%s-%s" % (acquisitionEras["SkimTask"],
@@ -1607,7 +1607,6 @@ class WMWorkloadTest(unittest.TestCase):
 
         testWorkload.setupPerformanceMonitoring(softTimeout=100, gracePeriod=1)
         self.assertFalse(hasattr(testWorkload.data.tasks.ProcessingTask.watchdog.PerformanceMonitor, "maxRSS"))
-        self.assertFalse(hasattr(testWorkload.data.tasks.ProcessingTask.watchdog.PerformanceMonitor, "maxVSize"))
         self.assertEqual(testWorkload.data.tasks.ProcessingTask.watchdog.PerformanceMonitor.softTimeout, 100)
         self.assertEqual(testWorkload.data.tasks.ProcessingTask.watchdog.PerformanceMonitor.hardTimeout, 101)
         self.assertTrue(hasattr(testWorkload.data.tasks.ProcessingTask.tree.children.MergeTask, 'watchdog'))


### PR DESCRIPTION
Fixes #8221 , #8222 ,  #8345 and #7274 

Summary of changes are:
* completely remove MaxVSize spec attribute and no longer monitor it in the watchdog
* remove code for backwards compatibility for creation/clone of requests
* remove WMAgent exit code 50661
* if SIGUSR2 signal didn't kill the process in the worker node, retry with a SIGTERM in the next cycle (every 5min)
* remove RSS backwards compatibility to work with RSS either in KiB or MiB