### PR TITLE
Support ACDC for recovery workflows

### DIFF
--- a/src/python/WMCore/ReqMgr/Utils/Validation.py
+++ b/src/python/WMCore/ReqMgr/Utils/Validation.py
@@ -116,6 +116,9 @@ def validate_resubmission_create_args(request_args, config, reqmgr_db_service, *
     response = reqmgr_db_service.getRequestByNames(request_args["OriginalRequestName"])
     originalArgs = response.values()[0]
 
+    ### not a nice fix for #8245, but we cannot inherit the CollectionName attr
+    originalArgs.pop("CollectionName", None)
+
     chainArgs = None
     if originalArgs["RequestType"] == 'Resubmission':
         # ACDC of ACDC, we can't validate this case


### PR DESCRIPTION
Fixes #8245 

Standard ACDC workflows don't explicitly set `CollectionName`, it's actually just set to the parent workload name (the workflow we're creating an ACDC for). While recovery ACDCs do set it, since they create a brand new CollectionName in the ACDCServer. The moment that recovery workflow is used for creating a standard ACDC, it inherits the previous CollectionName and we're screwed, given that the new CollectionName is supposed to be the name of the parent workload.

After writing the paragraph above, it all sounds very confusing, but we have what we have ;)