### PR TITLE
StompAMQ changes to integrate with different versions

### DIFF
--- a/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
+++ b/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
@@ -550,8 +550,8 @@ class AgentStatusPoller(BaseWorkerThread):
                                 host_and_ports=self.hostPortAMQ,
                                 logger=logging)
 
-            notifications = stompSvc.make_notification(payload=docs, docType=docType,
-                                                       docId=producer, ts=timeS)
+            notifications = [stompSvc.make_notification(payload=doc, docType=docType,
+                                                        ts=timeS) for doc in docs]
 
             failures = stompSvc.send(notifications)
             logging.info("%i docs successfully sent to AMQ", len(notifications) - len(failures))

--- a/src/python/WMCore/REST/HeartbeatMonitorBase.py
+++ b/src/python/WMCore/REST/HeartbeatMonitorBase.py
@@ -71,8 +71,8 @@ class HeartbeatMonitorBase(CherryPyPeriodicTask):
                                 host_and_ports=self.hostPortAMQ,
                                 logger=self.logger)
 
-            notifications = stompSvc.make_notification(payload=docs, docType=self.docTypeAMQ,
-                                                       docId=producer, ts=ts)
+            notifications = [stompSvc.make_notification(payload=doc, docType=self.docTypeAMQ,
+                                                        ts=ts) for doc in docs]
 
             failures = stompSvc.send(notifications)
             self.logger.info("%i docs successfully sent to Stomp AMQ", len(notifications) - len(failures))


### PR DESCRIPTION
- Renamed `make_notification` to `make_notification_list` without changes.
- Added new `make_notification` method that produces a single notification.
- Adding new functionality to pass user-defined metadata.
- No longer add unnecessary `'payload'` subfield to notification body.

We can discuss here how best to proceed. In my opinion, `make_notification_list` is still confusing, as it assigns the same document id, type, and timestamp to all notifications. As in this PR now, it's also not really consistent with the other method, as it still uses the `'payload'` subfield.