### PR TITLE
Fix typo in T0 updaterequest couch function

### DIFF
--- a/src/couchapps/T0Request/updates/updaterequest.js
+++ b/src/couchapps/T0Request/updates/updaterequest.js
@@ -57,18 +57,18 @@ function(doc, req)
     }
     // req.query is dictionary fields into the 
     // CMSCouch.Database.updateDocument() method, which is a dictionary
-    var massege = "OK";
+    var message = "OK";
     var newValues = req.query;
     for (key in newValues)
-    {   
-        if (key == "RequestTransition") {
-    		 doc[key] = JSON.parse(newValues[key]);
-    	} if (key == "RequestStatus") {
+    {
+        if (key == "RequestStatus") {
         	message = updateTransition(newValues[key]);
-        } else {
+        } else if (key == "RequestTransition") {
+    	    doc[key] = JSON.parse(newValues[key]);
+    	} else {
     		doc[key] = newValues[key];
     	}
-       
+
     }
     
     return [doc, message];


### PR DESCRIPTION
Besides the 'message' typo, I don't know whether it fixes anything.
The 'RequestTransition' transition handle is also strange, I don't see it pushing another entry to the RequestTransition dictionary (even though T0 workflows have it correctly).

This needs to be tested. Maybe @vytjan or Andres could give me a help here?