### PR TITLE
fix capitalization for CRAB/ASO message

### DIFF
--- a/src/python/WMCore/WMExceptions.py
+++ b/src/python/WMCore/WMExceptions.py
@@ -272,7 +272,7 @@ value - is a list, which has dictionaries with the following content:
            b) CRAB3 Postjob decides should it retry job or not;
            c) ASO decides should it resubmit transfer to FTS;
 """
-STAGEOUT_ERRORS = {60317: [{"regex": ".*cancelled aso transfer after timeout.*",
+STAGEOUT_ERRORS = {60317: [{"regex": ".*Cancelled ASO transfer after timeout.*",
                             "error-msg": "ASO Transfer canceled due to timeout.",
                             "isPermanent": True}
                           ],


### PR DESCRIPTION
how do I hate this thing which parses error messages to set exit code !
This is very safe, please merge and add in next tag
will prevent CRAB from setting wrong exit code.