### PR TITLE
Make XML parser to always return a list of elements

### DIFF
--- a/src/python/WMCore/Services/TagCollector/XMLUtils.py
+++ b/src/python/WMCore/Services/TagCollector/XMLUtils.py
@@ -16,14 +16,15 @@ import xml.etree.cElementTree as ET
 int_number_pattern = re.compile(r'(^[0-9-]$|^[0-9-][0-9]*$)')
 float_number_pattern = re.compile(r'(^[-]?\d+\.\d*$|^\d*\.{1,1}\d+$)')
 
+
 def adjust_value(value):
     """
     Change null value to None.
     """
-    pat_float   = float_number_pattern
+    pat_float = float_number_pattern
     pat_integer = int_number_pattern
-    if  isinstance(value, str):
-        if  value == 'null' or value == '(null)':
+    if isinstance(value, str):
+        if value == 'null' or value == '(null)':
             return None
         elif pat_float.match(value):
             return float(value)
@@ -37,7 +38,7 @@ def adjust_value(value):
 
 def xml_parser(data, prim_key):
     "Generic XML parser"
-    if  isinstance(data, basestring):
+    if isinstance(data, basestring):
         stream = StringIO.StringIO()
         stream.write(data)
         stream.seek(0)
@@ -48,7 +49,7 @@ def xml_parser(data, prim_key):
     for event, elem in context:
         row = {}
         key = elem.tag
-        if  key != prim_key:
+        if key != prim_key:
             continue
         row[key] = elem.attrib
         get_children(elem, event, row, key)
@@ -64,14 +65,14 @@ def get_children(elem, event, row, key):
     parsing step by using provided notations dictionary.
     """
     for child in elem.getchildren():
-        child_key  = child.tag
+        child_key = child.tag
         child_data = child.attrib
-        if  not child_data:
+        if not child_data:
             child_dict = adjust_value(child.text)
         else:
             child_dict = child_data
 
-        if  child.getchildren():  # we got grand-children
+        if child.getchildren():  # we got grand-children
             if child_dict:
                 row[key][child_key] = child_dict
             else:

--- a/test/python/WMCore_t/Services_t/TagCollector_t/XMLUtils_t.py
+++ b/test/python/WMCore_t/Services_t/TagCollector_t/XMLUtils_t.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+"""
+Unittests for XMLUtils functions
+"""
+
+from __future__ import division, print_function
+
+import unittest
+
+from WMCore.Services.TagCollector.XMLUtils import xml_parser
+
+
+class XMLUtilsTest(unittest.TestCase):
+    """
+    unittest for XMLUtils functions
+    """
+
+    def testParser(self):
+        """
+        Test parsing a basic XML as the one retrieved from TagCollector
+        """
+        data = '<projects>\n' \
+               '  <architecture name="slc5_amd64_gcc462">\n' \
+               '    <project label="CMSSW_5_3_6" type="Production" state="Announced"/>\n' \
+               '    <project label="CMSSW_5_3_7" type="Production" state="Announced"/>\n' \
+               '    <project label="CMSSW_5_3_8" type="Production" state="Announced"/>\n' \
+               '  </architecture>\n' \
+               '  <architecture name="slc7_ppc64le_gcc530">\n' \
+               '    <project label="CMSSW_8_1_0_pre15" type="Development" state="Announced"/>\n' \
+               '  </architecture>\n' \
+               '  <architecture name="slc6_amd64_gcc620">\n' \
+               '    <project label="CMSSW_9_0_0_pre3" type="Development" state="Announced"/>\n' \
+               '    <project label="CMSSW_9_0_0_pre4" type="Development" state="Announced"/>\n' \
+               '  </architecture>\n' \
+               '</projects>\n'
+        pkey = 'architecture'
+
+        for row in xml_parser(data, pkey):
+            self.assertEqual(type(row[pkey]['project']), list)
+            print(row)
+            if row[pkey]['name'] == 'slc5_amd64_gcc462':
+                releases = [item['label'] for item in row[pkey]['project']]
+                self.assertItemsEqual(['CMSSW_5_3_6', 'CMSSW_5_3_7', 'CMSSW_5_3_8'], releases)
+            elif row[pkey]['name'] == 'slc7_ppc64le_gcc530':
+                releases = [item['label'] for item in row[pkey]['project']]
+                self.assertItemsEqual(['CMSSW_8_1_0_pre15'], releases)
+            elif row[pkey]['name'] == 'slc6_amd64_gcc620':
+                releases = [item['label'] for item in row[pkey]['project']]
+                self.assertItemsEqual(['CMSSW_9_0_0_pre3', 'CMSSW_9_0_0_pre4'], releases)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #8981
Current code was also adding duplicate entries to the list (parsing at both start and end events).
Last but not least, added a basic unit test, as it was supposed to have since day 1.