### PR TITLE
Keep using payload sub-key for MonIT

### DIFF
--- a/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
+++ b/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
@@ -550,8 +550,8 @@ class AgentStatusPoller(BaseWorkerThread):
                                 host_and_ports=self.hostPortAMQ,
                                 logger=logging)
 
-            notifications = [stompSvc.make_notification(payload=doc, docType=docType,
-                                                        ts=timeS) for doc in docs]
+            notifications = [stompSvc.make_notification(payload=doc, docType=docType, ts=timeS,
+                                                        dataSubfield="payload") for doc in docs]
 
             failures = stompSvc.send(notifications)
             logging.info("%i docs successfully sent to AMQ", len(notifications) - len(failures))

--- a/src/python/WMCore/REST/HeartbeatMonitorBase.py
+++ b/src/python/WMCore/REST/HeartbeatMonitorBase.py
@@ -71,8 +71,8 @@ class HeartbeatMonitorBase(CherryPyPeriodicTask):
                                 host_and_ports=self.hostPortAMQ,
                                 logger=self.logger)
 
-            notifications = [stompSvc.make_notification(payload=doc, docType=self.docTypeAMQ,
-                                                        ts=ts) for doc in docs]
+            notifications = [stompSvc.make_notification(payload=doc, docType=self.docTypeAMQ, ts=ts,
+                                                        dataSubfield="payload") for doc in docs]
 
             failures = stompSvc.send(notifications)
             self.logger.info("%i docs successfully sent to Stomp AMQ", len(notifications) - len(failures))


### PR DESCRIPTION
I oversaw this detail while reviewing the previous PR. Without the subfield, it breaks the compatibility with the previous docs in MonIT which follow 'data.payload.....'