### PR TITLE
post workflow summary doc directly to wmstats - 1.1.14 version

### DIFF
--- a/src/couchapps/WMStatsAgent/filters/repfilter.js
+++ b/src/couchapps/WMStatsAgent/filters/repfilter.js
@@ -1,5 +1,5 @@
 function(doc, req) {
-  if (doc._deleted){
+  if (doc._deleted || doc.type === 'agent_request'){
     return false;
   } else {
   	return !doc._id.match('_design/(.*)');

--- a/src/python/WMComponent/AnalyticsDataCollector/AnalyticsPoller.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/AnalyticsPoller.py
@@ -36,6 +36,9 @@ class AnalyticsPoller(BaseWorkerThread):
         self.summaryLevel = (config.AnalyticsDataCollector.summaryLevel).lower()
         self.pluginName = getattr(config.AnalyticsDataCollector, "pluginName", None)
         self.plugin = None
+        self.revCache = {} # key: doc id, value doc rev
+        self.loopCount = 0
+        self.crashFlag = False
 
     def setup(self, parameters):
         """
@@ -138,8 +141,27 @@ class AnalyticsPoller(BaseWorkerThread):
             if self.plugin != None:
                 self.plugin(requestDocs, self.localSummaryCouchDB, self.centralRequestCouchDB)
 
-            existingDocs = self.localSummaryCouchDB.getAllAgentRequestRevByID()
-            self.localSummaryCouchDB.bulkUpdateData(requestDocs, existingDocs)
+            if self.loopCount < 2 and not self.revCache:
+                try:
+                    logging.info("Populating cache of revision number...")
+                    start = int(time.time())
+                    self.revCache = self.centralWMStatsCouchDB.getAllAgentRequestFromCentralServer()
+                    end = int(time.time())
+                    logging.info("Cache populated - took %s sec", (end - start))
+                except Exception as ex:
+                    logging.warning("Populating cache failed: %s ", str(ex))
+
+            if self.loopCount >= 2 and not self.revCache:
+                self.crashFlag = True
+                raise Exception("CacheUpload failed")
+
+            notInCacheDoc, notInCacheKey = self.centralWMStatsCouchDB.bulkUpdateDataAnUpdateCache(requestDocs, self.revCache)
+
+            if notInCacheKey:
+                missingDocs = self.centralWMStatsCouchDB.getAllAgentRequestFromCentralServer(notInCacheKey)
+                self.centralWMStatsCouchDB.bulkUpdateDataAnUpdateCache(notInCacheDoc, missingDocs, secondTry=True)
+
+            self.loopCount += 1
 
             logging.info("Request data upload success\n %s request, \nsleep for next cycle", len(requestDocs))
 
@@ -148,7 +170,10 @@ class AnalyticsPoller(BaseWorkerThread):
 
         except Exception as ex:
             msg = str(ex)
-            logging.exception("Error occurred, will retry later: %s", msg)
+            if self.crashFlag:
+                raise
+            else:
+                logging.exception("Error occurred, will retry later: %s", msg)
 
             try:
                 self.centralWMStatsCouchDB.updateAgentInfoInPlace(self.agentInfo["agent_url"], {"data_error": msg})

--- a/src/python/WMCore/Services/WMStats/WMStatsReader.py
+++ b/src/python/WMCore/Services/WMStats/WMStatsReader.py
@@ -415,26 +415,12 @@ class WMStatsReader(object):
 
         return jobInfoDoc
 
-    def getAllAgentRequestRevByID(self):
+    def getAllAgentRequestRevByID(self, agentURL):
 
-        results = self.couchDB.loadView(self.couchapp, "agentRequests")
+        options = {"reduce": False}
+        results = self.couchDB.loadView(self.couchapp, "byAgentURL", options=options, keys=[agentURL])
         idRevMap = {}
         for row in results['rows']:
-            idRevMap[row['key']] = row['value']['rev']
-
-        return idRevMap
-
-    def getAllAgentRequestFromCentralServer(self, keys=None):
-
-        if keys:
-            results = self.couchDB.loadView(self.couchapp, "requestAgentUrl", options={"reduce": False, "include_docs": True},
-                                  keys=keys)
-        else:
-            results = self.couchDB.loadView(self.couchapp, "requestAgentUrl", options={"reduce": False,
-                                                                                       "include_docs": True})
-        idRevMap = {}
-
-        for row in results['rows']:
-            idRevMap[row['id']] = row['doc']['_rev']
+            idRevMap[row['id']] = row['value']['rev']
 
         return idRevMap

--- a/src/python/WMCore/Services/WMStats/WMStatsReader.py
+++ b/src/python/WMCore/Services/WMStats/WMStatsReader.py
@@ -423,3 +423,18 @@ class WMStatsReader(object):
             idRevMap[row['key']] = row['value']['rev']
 
         return idRevMap
+
+    def getAllAgentRequestFromCentralServer(self, keys=None):
+
+        if keys:
+            results = self.couchDB.loadView(self.couchapp, "requestAgentUrl", options={"reduce": False, "include_docs": True},
+                                  keys=keys)
+        else:
+            results = self.couchDB.loadView(self.couchapp, "requestAgentUrl", options={"reduce": False,
+                                                                                       "include_docs": True})
+        idRevMap = {}
+
+        for row in results['rows']:
+            idRevMap[row['id']] = row['doc']['_rev']
+
+        return idRevMap

--- a/src/python/WMCore/Services/WMStats/WMStatsWriter.py
+++ b/src/python/WMCore/Services/WMStats/WMStatsWriter.py
@@ -126,16 +126,16 @@ class WMStatsWriter(WMStatsReader):
                     magicStr = ".fnal.gov-"
                     idParts = doc['_id'].split(magicStr)
                     if len(idParts) == 2:
-                        agentURL = "%s.fnal.gov" % idParts[1]
+                        agentURL = "%s.fnal.gov" % idParts[0]
                     else:
                         magicStr = ".cern.ch-"
                         idParts = doc['_id'].split(magicStr)
                         if len(idParts) == 2:
-                            agentURL = "%s.cern.ch" % idParts[1]
+                            agentURL = "%s.cern.ch" % idParts[0]
                         else:
                             raise Exception("wrong id %s" % doc['_id'])
 
-                    notInCacheKey.append([agentURL, idParts[0]])
+                    notInCacheKey.append([agentURL, idParts[1]])
                     notInCacheDoc.append(doc)
 
         self.couchDB.commit(new_edits=False)


### PR DESCRIPTION
On top of this PR that has already been merged to 1.1.14_wmagent branch:
https://github.com/dmwm/WMCore/pull/8843

it has:
1.1.15_wmagent wmstats replication temp fix #8859
fix cache refresh #8889
Use byAgentURL for wmstats updates; create smaller chunks to update - wmagent 1.1.15 version #8909 

We had so many tproblems and patch on top of other patches, that I dislike very much applying this patch to the T0 production agent. In order to keep couchdb sane, I'd suggest to only apply it to the T0 agent once vocms0313 is completely down. We should also rotate once again tier0_wmstats to make sure it has sane documents.