### PR TITLE
Set centralWMStatsURL under the General section 

### DIFF
--- a/bin/wmagent-couchapp-init
+++ b/bin/wmagent-couchapp-init
@@ -370,7 +370,7 @@ if __name__ == "__main__":
     
     if hasattr(wmagentConfig, "Tier0Feeder"):
         installCouchApp(wmagentConfig.JobStateMachine.couchurl, wmagentConfig.Tier0Feeder.requestDBName, "T0Request")
-        centralWMStatsURL = wmagentConfig.AgentStatusWatcher.centralWMStatsURL
+        centralWMStatsURL = wmagentConfig.General.centralWMStatsURL
         # checks whether this is test agent. if T0 agent is setting local wmstats as central it creates the db
         if "localhost:" in centralWMStatsURL:
             couchURL, wmstatsDBName = splitCouchServiceURL(centralWMStatsURL)

--- a/bin/wmagent-mod-config
+++ b/bin/wmagent-mod-config
@@ -129,6 +129,7 @@ def modifyConfiguration(config, **args):
 
     if hasattr(config, "General"):
         config.General.central_logdb_url = args["central_logdb_url"]
+        config.General.centralWMStatsURL = args["wmstats_url"]
         # t0 agent doesn't have reqmgr2_url
         if "reqmgr2_url" in args:
             config.General.ReqMgr2ServiceURL = args["reqmgr2_url"]
@@ -148,7 +149,6 @@ def modifyConfiguration(config, **args):
                                                        config.WorkQueueManager.dbname)
         config.TaskArchiver.localWMStatsURL = "%s/%s" % (config.JobStateMachine.couchurl,
                                                          config.JobStateMachine.jobSummaryDBName)
-        config.TaskArchiver.centralWMStatsURL = args["wmstats_url"]
         config.TaskArchiver.dqmUrl = args["dqm_url"]
 
     if hasattr(config, "ACDC"):
@@ -303,13 +303,11 @@ def modifyConfiguration(config, **args):
                                                                  config.WorkQueueManager.dbname)
         config.AnalyticsDataCollector.localWMStatsURL = "%s/%s" % (config.JobStateMachine.couchurl,
                                                                    config.JobStateMachine.jobSummaryDBName)
-        config.AnalyticsDataCollector.centralWMStatsURL = args["wmstats_url"]
         config.AnalyticsDataCollector.centralRequestDBURL = args["requestcouch_url"]
         config.AnalyticsDataCollector.RequestCouchApp = "ReqMgr"
 
     # custom AgentStatusWatcher
     if hasattr(config, "AgentStatusWatcher"):
-        config.AgentStatusWatcher.centralWMStatsURL = args["wmstats_url"]
         config.AgentStatusWatcher.dashboard = args["dashboard_url"]
         if args.get("amq_credentials"):
             # e.g.: user@@@pass@@@topic

--- a/bin/wmagent-unregister-wmstats
+++ b/bin/wmagent-unregister-wmstats
@@ -24,17 +24,16 @@ if __name__ == "__main__":
     else:
         agentUrl = args[0]
 
-    msg = "Are you sure you want to remove agent info record for %s from wmstats? Type 'Y' or 'N' (type quotes too!): "
+    msg = "Are you sure you want to remove agent info record for %s from wmstats? Type 'yes' or 'no' (type quotes too!): "
     answer = input(msg % agentUrl)
-    if answer != "Y":
+    if answer != "yes":
         print("Aborting... no changes were made.")
         sys.exit(1)
 
-    if hasattr(wmagentConfig, "AnalyticsDataCollector") and hasattr(wmagentConfig.AnalyticsDataCollector,
-                                                                    "centralWMStatsURL"):
-        wmstats = WMStatsWriter(wmagentConfig.AnalyticsDataCollector.centralWMStatsURL)
+    if hasattr(wmagentConfig, "General") and hasattr(wmagentConfig.General, "centralWMStatsURL"):
+        wmstats = WMStatsWriter(wmagentConfig.General.centralWMStatsURL)
     else:
-        print("AnalyticsDataCollector.centralWMStatsURL is not specified")
+        print("General.centralWMStatsURL is not specified")
         sys.exit(1)
 
     report = wmstats.deleteDocsByIDs([agentUrl])

--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -82,6 +82,7 @@ config.General.workDir = workDirectory
 config.General.logdb_name = logDBName
 config.General.central_logdb_url = "need to get from secrets file"
 config.General.ReqMgr2ServiceURL = "ReqMgr2 rest service"
+config.General.centralWMStatsURL = "Central WMStats URL"
 
 config.section_("JobStateMachine")
 config.JobStateMachine.couchurl = couchURL
@@ -305,7 +306,6 @@ config.AnalyticsDataCollector.localQueueURL = "%s/%s" % (config.WorkQueueManager
                                                          config.WorkQueueManager.dbname)
 config.AnalyticsDataCollector.localWMStatsURL = "%s/%s" % (config.JobStateMachine.couchurl,
                                                            config.JobStateMachine.jobSummaryDBName)
-config.AnalyticsDataCollector.centralWMStatsURL = "Central WMStats URL"
 config.AnalyticsDataCollector.centralRequestDBURL = "Cental Request DB URL"
 config.AnalyticsDataCollector.summaryLevel = "task"
 config.AnalyticsDataCollector.couchProcessThreshold = 50
@@ -329,7 +329,6 @@ config.AgentStatusWatcher.siteStatusMetric = 237  # [column number in SSB] The s
 config.AgentStatusWatcher.cpuBoundMetric = 160  # [column number in SSB] The source of the information in SSB for CPUBound
 config.AgentStatusWatcher.ioBoundMetric = 161  # [column number in SSB] The source of the information in SSB for IOBound
 config.AgentStatusWatcher.dashboard = "Dashboard URL"
-config.AgentStatusWatcher.centralWMStatsURL = "Central WMStats URL"
 config.AgentStatusWatcher.pendingSlotsSitePercent = 75  # [percent] Pending slots percent over site max running for a site
 config.AgentStatusWatcher.pendingSlotsTaskPercent = 70  # [percent] Pending slots percent over task max running for tasks
 config.AgentStatusWatcher.runningExpressPercent = 30  # [percent] Only used for tier0 agent

--- a/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
+++ b/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
@@ -64,7 +64,7 @@ class AgentStatusPoller(BaseWorkerThread):
         self.replicatorDocs = []
         # set up common replication code
         wmstatsSource = self.config.JobStateMachine.jobSummaryDBName
-        wmstatsTarget = self.config.AnalyticsDataCollector.centralWMStatsURL
+        wmstatsTarget = self.config.General.centralWMStatsURL
 
         self.replicatorDocs.append({'source': wmstatsSource, 'target': wmstatsTarget,
                                     'filter': "WMStatsAgent/repfilter"})
@@ -106,7 +106,7 @@ class AgentStatusPoller(BaseWorkerThread):
         # set wmagent db data
         self.wmagentDB = WMAgentDBData(self.summaryLevel, myThread.dbi, myThread.logger)
 
-        self.centralWMStatsCouchDB = WMStatsWriter(self.config.AnalyticsDataCollector.centralWMStatsURL)
+        self.centralWMStatsCouchDB = WMStatsWriter(self.config.General.centralWMStatsURL)
 
         self.localCouchMonitor = CouchMonitor(self.config.JobStateMachine.couchurl)
         self.setUpCouchDBReplication()

--- a/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
+++ b/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
@@ -65,7 +65,7 @@ class ResourceControlUpdater(BaseWorkerThread):
         self.resourceControl = ResourceControl(config=self.config)
 
         # wmstats connection
-        self.centralCouchDBReader = WMStatsReader(self.config.AgentStatusWatcher.centralWMStatsURL)
+        self.centralCouchDBReader = WMStatsReader(self.config.General.centralWMStatsURL)
 
     @timeFunction
     def algorithm(self, parameters):

--- a/src/python/WMComponent/AnalyticsDataCollector/AnalyticsPoller.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/AnalyticsPoller.py
@@ -66,7 +66,7 @@ class AnalyticsPoller(BaseWorkerThread):
 
         self.centralRequestCouchDB = RequestDBWriter(centralRequestCouchDBURL,
                                                      couchapp=self.config.AnalyticsDataCollector.RequestCouchApp)
-        self.centralWMStatsCouchDB = WMStatsWriter(self.config.AnalyticsDataCollector.centralWMStatsURL)
+        self.centralWMStatsCouchDB = WMStatsWriter(self.config.General.centralWMStatsURL)
 
         #TODO: change the config to hold couch url
         self.localCouchServer = CouchMonitor(self.config.JobStateMachine.couchurl)

--- a/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
@@ -168,8 +168,8 @@ class DBSUploadPoller(BaseWorkerThread):
         if hasattr(self.config, "Tier0Feeder"):
             self.wmstatsServerSvc = None
         else:
-            wmstatsSvcURL = (self.config.AgentStatusWatcher.centralWMStatsURL).replace("couchdb/wmstats",
-                                                                                       "wmstatsserver")
+            wmstatsSvcURL = self.config.General.centralWMStatsURL.replace("couchdb/wmstats",
+                                                                          "wmstatsserver")
             self.wmstatsServerSvc = WMStatsServer(wmstatsSvcURL)
 
         self.dbsUtil = DBSBufferUtil()

--- a/test/python/WMComponent_t/AnalyticsDataCollector_t/AnalyticsDataCollector_t.py
+++ b/test/python/WMComponent_t/AnalyticsDataCollector_t/AnalyticsDataCollector_t.py
@@ -83,6 +83,9 @@ class AnalyticsDataCollector_t(unittest.TestCase):
         config.Agent.useTrigger = False
         config.Agent.useHeartbeat = False
 
+        config.section_("General")
+        config.General.centralWMStatsURL = "%s/%s" % (couchURL, self.reqmonDBName)
+
         config.section_("ACDC")
         config.ACDC.couchurl = couchURL
         config.ACDC.database = "acdc"
@@ -95,7 +98,6 @@ class AnalyticsDataCollector_t(unittest.TestCase):
         config.AnalyticsDataCollector.localCouchURL = "%s/%s" % (couchURL, "jobDump")
         config.AnalyticsDataCollector.localQueueURL = "%s/%s" % (couchURL, "workqueue")
         config.AnalyticsDataCollector.localWMStatsURL = "%s/%s" % (couchURL, self.localDBName)
-        config.AnalyticsDataCollector.centralWMStatsURL = "%s/%s" % (couchURL, self.reqmonDBName)
         config.AnalyticsDataCollector.centralRequestDBURL = "%s/%s" % (couchURL, "requset_db_t")
         config.AnalyticsDataCollector.reqMonURL = "%s/%s" % (couchURL, self.reqmonDBName)
         config.AnalyticsDataCollector.RequestCouchApp = "ReqMgr"


### PR DESCRIPTION
Fixes #8753 

Given that this attribute is generic enough and used by multiple components, let's set it under the `General` section.