### PR TITLE
Skip PU blocks with full replicas but not present in DBS

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
+++ b/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
@@ -9,6 +9,7 @@ import datetime
 import os
 import shutil
 import time
+import logging
 from json import JSONEncoder
 
 import WMCore.WMSpec.WMStep as WMStep
@@ -73,8 +74,11 @@ class PileupFetcher(FetcherInterface):
                 blockReplicasInfo = phedex.getReplicaPhEDExNodesForBlocks(dataset=dataset, complete='y')
                 for block in blockReplicasInfo:
                     nodes = set(blockReplicasInfo[block]) - node_filter
-                    blockDict[block]['PhEDExNodeNames'] = list(nodes)
-                    blockDict[block]['FileList'] = sorted(blockDict[block]['FileList'])
+                    try:
+                        blockDict[block]['PhEDExNodeNames'] = list(nodes)
+                        blockDict[block]['FileList'] = sorted(blockDict[block]['FileList'])
+                    except KeyError:
+                        logging.warning("Block '%s' does not have any complete PhEDEx replica", block)
 
             resultDict[pileupType] = blockDict
         return resultDict


### PR DESCRIPTION
Fixes #8993

I have never seen this happening in production, it happened to my testbed node today after cloning a production request and migrating the PU dataset from prod to integration DBS server.

Anyways, this change will make sure the block is skipped from the pileupconf.json file if a block contains complete replicas but it does *not* contain any data in DBS.