### PR TITLE
Record site status changes timestamp and allow grace period for drain…

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -203,6 +203,7 @@ config.JobSubmitter.cacheRefreshSize = 30000  # set -1 if cache need to refresh 
 config.JobSubmitter.skipRefreshCount = 20  # (If above the threshold meet, cache will updates every 20 polling cycle) 120 * 20 = 40 minutes
 config.JobSubmitter.submitScript = os.path.join(os.environ["WMCORE_ROOT"], "etc/submit.sh")
 config.JobSubmitter.extraMemoryPerCore = 500  # in MB
+config.JobSubmitter.drainGraceTime = 2 * 24 * 60 * 60  # in seconds
 
 config.component_("JobTracker")
 config.JobTracker.namespace = "WMComponent.JobTracker.JobTracker"

--- a/src/python/WMCore/ResourceControl/MySQL/ListThresholdsForSubmit.py
+++ b/src/python/WMCore/ResourceControl/MySQL/ListThresholdsForSubmit.py
@@ -22,7 +22,8 @@ class ListThresholdsForSubmit(DBFormatter):
                     job_count.wf_highest_priority,
                     wmbs_sub_types.priority,
                     wmbs_location_state.name AS state,
-                    wmbs_location.plugin AS plugin
+                    wmbs_location.plugin AS plugin,
+                    wmbs_location.state_time AS state_time
                     FROM wmbs_location
                INNER JOIN rc_threshold ON
                  wmbs_location.id = rc_threshold.site_id
@@ -103,6 +104,7 @@ class ListThresholdsForSubmit(DBFormatter):
                 siteInfo = {}
                 siteInfo['pnns'] = mappedPNNs.get(siteName, [])
                 siteInfo['state'] = result['state']
+                siteInfo['state_time'] = result['state_time']
                 siteInfo['total_pending_slots'] = result['pending_slots']
                 siteInfo['total_running_slots'] = result['running_slots']
                 siteInfo['total_pending_jobs'] = task_pending_jobs

--- a/src/python/WMCore/ResourceControl/ResourceControl.py
+++ b/src/python/WMCore/ResourceControl/ResourceControl.py
@@ -5,6 +5,7 @@ _ResourceControl_
 Library from manipulating and querying the resource control database.
 """
 
+import time
 from WMCore.BossAir.BossAirAPI import BossAirAPI
 from WMCore.DAOFactory import DAOFactory
 from WMCore.WMConnectionBase import WMConnectionBase
@@ -40,11 +41,12 @@ class ResourceControl(WMConnectionBase):
          2. then add PNNs into wmbs_pnns
          3. at last, create a mapping of PSN/PNN in wmbs_location_pnns
         """
+        timeNow = int(time.time())
         insertAction = self.wmbsDAOFactory(classname="Locations.New")
         insertAction.execute(siteName=siteName, pendingSlots=pendingSlots,
                              runningSlots=runningSlots,
                              pnn=pnn, ceName=ceName,
-                             plugin=plugin, cmsName=cmsName,
+                             plugin=plugin, cmsName=cmsName, stateTime=timeNow,
                              conn=self.getDBConn(),
                              transaction=self.existingTransaction())
         return
@@ -66,6 +68,7 @@ class ResourceControl(WMConnectionBase):
         Set a site to some of the possible states and perform
         proper actions with the jobs, according to the state
         """
+        timeNow = int(time.time())
         state2ExitCode = {"Aborted": 71301,
                           "Draining": 71302,
                           "Down": 71303}
@@ -81,7 +84,7 @@ class ResourceControl(WMConnectionBase):
 
         # only now that jobs were updated by the plugin, we flip the site state
         setStateAction = self.wmbsDAOFactory(classname="Locations.SetState")
-        setStateAction.execute(siteName=siteName, state=state,
+        setStateAction.execute(siteName=siteName, state=state, stateTime=timeNow,
                                conn=self.getDBConn(),
                                transaction=self.existingTransaction())
 
@@ -187,6 +190,7 @@ class ResourceControl(WMConnectionBase):
           cms_name            - CMS name of the site
           pnns                - List with associated PNNs
           state               - State of the site
+          state_time          - Timestamp in which the site joined the current state
           total_pending_slots - Total number of pending slots available at the site
           total_running_slots - Total number of running slots available at the site
           total_pending_jobs  - Total jobs pending at the site

--- a/src/python/WMCore/ResourceControl/ResourceControl.py
+++ b/src/python/WMCore/ResourceControl/ResourceControl.py
@@ -241,13 +241,13 @@ class ResourceControl(WMConnectionBase):
 
         Set the number of running and/or pending job slots for the given site.
         """
-        if pendingJobSlots != None:
+        if pendingJobSlots is not None:
             pendingSlotsAction = self.daofactory(classname="SetPendingJobSlotsForSite")
             pendingSlotsAction.execute(siteName, pendingJobSlots,
                                        conn=self.getDBConn(),
                                        transaction=self.existingTransaction())
 
-        if runningJobSlots != None:
+        if runningJobSlots is not None:
             runningSlotsAction = self.daofactory(classname="SetRunningJobSlotsForSite")
             runningSlotsAction.execute(siteName, runningJobSlots,
                                        conn=self.getDBConn(),

--- a/src/python/WMCore/WMBS/CreateWMBSBase.py
+++ b/src/python/WMCore/WMBS/CreateWMBSBase.py
@@ -124,6 +124,7 @@ class CreateWMBSBase(DBCreator):
                running_slots   INTEGER,
                pending_slots   INTEGER,
                plugin      VARCHAR(255),
+               state_time  INTEGER NOT NULL,
                UNIQUE(site_name),
                FOREIGN KEY (state) REFERENCES wmbs_location_state(id))"""
 

--- a/src/python/WMCore/WMBS/MySQL/Jobs/LoadFromID.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/LoadFromID.py
@@ -15,7 +15,7 @@ class LoadFromID(DBFormatter):
     job group and last update time.
     """
     sql = """SELECT wmbs_job.id, jobgroup, wmbs_job.name AS name,
-                    wmbs_job_state.name AS state, state_time, retry_count,
+                    wmbs_job_state.name AS state, wmbs_job.state_time, retry_count,
                     couch_record,  cache_dir, wmbs_location.site_name AS location,
                     outcome AS bool_outcome, fwjr_path AS fwjr_path
              FROM wmbs_job

--- a/src/python/WMCore/WMBS/MySQL/Jobs/LoadFromID.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/LoadFromID.py
@@ -7,6 +7,7 @@ MySQL implementation of Jobs.LoadFromID.
 
 from WMCore.Database.DBFormatter import DBFormatter
 
+
 class LoadFromID(DBFormatter):
     """
     _LoadFromID_
@@ -48,7 +49,7 @@ class LoadFromID(DBFormatter):
         else:
             return formattedResult
 
-    def execute(self, jobID, conn = None, transaction = False):
+    def execute(self, jobID, conn=None, transaction=False):
         """
         _execute_
 
@@ -56,11 +57,11 @@ class LoadFromID(DBFormatter):
         the result.
         """
 
-        if type(jobID) == list:
+        if isinstance(jobID, list):
             binds = jobID
         else:
             binds = {"jobid": jobID}
 
-        result = self.dbi.processData(self.sql, binds, conn = conn,
-                                      transaction = transaction)
+        result = self.dbi.processData(self.sql, binds, conn=conn,
+                                      transaction=transaction)
         return self.formatDict(result)

--- a/src/python/WMCore/WMBS/MySQL/Jobs/LoadFromIDWithType.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/LoadFromIDWithType.py
@@ -20,7 +20,7 @@ class LoadFromIDWithType(LoadFromID):
     """
 
     sql = """SELECT wmbs_job.id, jobgroup, wmbs_job.name AS name,
-                    wmbs_job_state.name AS state, state_time, retry_count,
+                    wmbs_job_state.name AS state, wmbs_job.state_time, retry_count,
                     couch_record,  cache_dir, wmbs_location.site_name AS location,
                     outcome AS bool_outcome, fwjr_path AS fwjr_path,
                     wmbs_sub_types.name AS type

--- a/src/python/WMCore/WMBS/MySQL/Jobs/LoadFromIDWithWorkflow.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/LoadFromIDWithWorkflow.py
@@ -14,7 +14,7 @@ class LoadFromIDWithWorkflow(LoadFromID):
     """
 
     sql = """SELECT wmbs_job.id, jobgroup, wmbs_job.name AS name,
-                    wmbs_job_state.name AS state, state_time, retry_count,
+                    wmbs_job_state.name AS state, wmbs_job.state_time, retry_count,
                     couch_record,  cache_dir, wmbs_location.site_name AS location,
                     outcome AS bool_outcome, fwjr_path AS fwjr_path,
                     ww.name AS workflow, ww.task AS task

--- a/src/python/WMCore/WMBS/MySQL/Jobs/LoadFromName.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/LoadFromName.py
@@ -7,9 +7,8 @@ MySQL implementation of Jobs.LoadFromName.
 
 __all__ = []
 
-
-
 from WMCore.Database.DBFormatter import DBFormatter
+
 
 class LoadFromName(DBFormatter):
     """
@@ -46,7 +45,7 @@ class LoadFromName(DBFormatter):
         del formattedResult["bool_outcome"]
         return formattedResult
 
-    def execute(self, name, conn = None, transaction = False):
-        result = self.dbi.processData(self.sql, {"name": name}, conn = conn,
-                                      transaction = transaction)
+    def execute(self, name, conn=None, transaction=False):
+        result = self.dbi.processData(self.sql, {"name": name}, conn=conn,
+                                      transaction=transaction)
         return self.formatDict(result)

--- a/src/python/WMCore/WMBS/MySQL/Jobs/LoadFromName.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/LoadFromName.py
@@ -19,7 +19,7 @@ class LoadFromName(DBFormatter):
     job group and last update time.
     """
     sql = """SELECT wmbs_job.id, jobgroup, wmbs_job.name AS name,
-                    wmbs_job_state.name AS state, state_time, retry_count,
+                    wmbs_job_state.name AS state, wmbs_job.state_time, retry_count,
                     couch_record, cache_dir, wmbs_location.site_name AS location,
                     outcome AS bool_outcome, fwjr_path AS fwjr_path
              FROM wmbs_job

--- a/src/python/WMCore/WMBS/MySQL/Locations/New.py
+++ b/src/python/WMCore/WMBS/MySQL/Locations/New.py
@@ -11,14 +11,15 @@ from WMCore.Database.DBFormatter import DBFormatter
 class New(DBFormatter):
     sql = """INSERT IGNORE INTO wmbs_location (site_name, ce_name,
                                                pending_slots, running_slots,
-                                               plugin, cms_name, state)
+                                               plugin, cms_name, state, state_time)
                       SELECT
                       :location AS site_name, :cename AS ce_name,
                       :pending_slots AS pending_slots,
                       :running_slots AS running_slots,
-                      :plugin as plugin,
+                      :plugin AS plugin,
                       :cmsname AS cms_name,
-                      (SELECT id FROM wmbs_location_state WHERE name = 'Normal') AS state"""
+                      (SELECT id FROM wmbs_location_state WHERE name = 'Normal') AS state,
+                      :state_time AS state_time"""
 
     pnnSQL = "INSERT IGNORE INTO wmbs_pnns (pnn) VALUES (:pnn)"
 
@@ -27,7 +28,7 @@ class New(DBFormatter):
                   WHERE wl.site_name = :location AND wpnn.pnn = :pnn"""
 
     def execute(self, siteName, cmsName=None, ceName=None, pnn="None",
-                runningSlots=0, pendingSlots=0, plugin=None,
+                runningSlots=0, pendingSlots=0, plugin=None, stateTime=None,
                 conn=None, transaction=False):
         """
         _execute_
@@ -36,7 +37,7 @@ class New(DBFormatter):
         """
         binds = {"location": siteName, "cmsname": cmsName, "cename": ceName,
                  "running_slots": runningSlots, "pending_slots": pendingSlots,
-                 "plugin": plugin}
+                 "plugin": plugin, "state_time": stateTime}
         self.dbi.processData(self.sql, binds, conn=conn,
                              transaction=transaction)
 

--- a/src/python/WMCore/WMBS/MySQL/Locations/SetState.py
+++ b/src/python/WMCore/WMBS/MySQL/Locations/SetState.py
@@ -15,12 +15,13 @@ from WMCore.Database.DBFormatter import DBFormatter
 class SetState(DBFormatter):
 
     sql = """UPDATE wmbs_location
-             SET state = (SELECT id FROM wmbs_location_state WHERE name = :state)
+             SET state = (SELECT id FROM wmbs_location_state WHERE name = :state),
+             state_time = :state_time
              WHERE site_name = :location
              """
 
-    def execute(self, siteName, state, conn = None, transaction = False):
-        binds = {"location": siteName, "state": state}
+    def execute(self, siteName, state, stateTime, conn = None, transaction = False):
+        binds = {"location": siteName, "state": state, "state_time": stateTime}
         self.dbi.processData(self.sql, binds, conn = conn,
                              transaction = transaction)
         return

--- a/src/python/WMCore/WMBS/MySQL/Locations/SetState.py
+++ b/src/python/WMCore/WMBS/MySQL/Locations/SetState.py
@@ -9,19 +9,18 @@ Created on Mon Jun 18 13:16:00 2012
 @author: dballest
 """
 
-
 from WMCore.Database.DBFormatter import DBFormatter
 
-class SetState(DBFormatter):
 
+class SetState(DBFormatter):
     sql = """UPDATE wmbs_location
              SET state = (SELECT id FROM wmbs_location_state WHERE name = :state),
              state_time = :state_time
              WHERE site_name = :location
              """
 
-    def execute(self, siteName, state, stateTime, conn = None, transaction = False):
+    def execute(self, siteName, state, stateTime, conn=None, transaction=False):
         binds = {"location": siteName, "state": state, "state_time": stateTime}
-        self.dbi.processData(self.sql, binds, conn = conn,
-                             transaction = transaction)
+        self.dbi.processData(self.sql, binds, conn=conn,
+                             transaction=transaction)
         return

--- a/src/python/WMCore/WMBS/Oracle/Create.py
+++ b/src/python/WMCore/WMBS/Oracle/Create.py
@@ -173,7 +173,8 @@ class Create(CreateWMBSBase):
                  ce_name     VARCHAR(255),
                  running_slots   INTEGER,
                  pending_slots   INTEGER,
-                 plugin      VARCHAR(255)
+                 plugin      VARCHAR(255),
+                 state_time INTEGER NOT NULL
                  ) %s""" % tablespaceTable
 
         self.indexes["01_pk_wmbs_location"] = \

--- a/src/python/WMCore/WMBS/Oracle/Locations/New.py
+++ b/src/python/WMCore/WMBS/Oracle/Locations/New.py
@@ -9,11 +9,13 @@ from WMCore.WMBS.MySQL.Locations.New import New as NewLocationMySQL
 
 
 class New(NewLocationMySQL):
-    sql = """INSERT INTO wmbs_location (id, site_name, ce_name, running_slots, pending_slots, plugin, cms_name, state)
+    sql = """INSERT INTO wmbs_location (id, site_name, ce_name, running_slots, pending_slots,
+               plugin, cms_name, state, state_time)
                SELECT wmbs_location_SEQ.nextval, :location, :cename, :running_slots AS running_slots,
                :pending_slots AS pending_slots,
                :plugin AS plugin, :cmsname AS cms_name,
-               (SELECT id FROM wmbs_location_state where name = 'Normal') AS state
+               (SELECT id FROM wmbs_location_state where name = 'Normal') AS state,
+               :state_time AS state_time
                FROM DUAL
              WHERE NOT EXISTS (SELECT site_name FROM wmbs_location
                                WHERE site_name = :location)"""

--- a/test/python/WMCore_t/WMBS_t/Locations_t.py
+++ b/test/python/WMCore_t/WMBS_t/Locations_t.py
@@ -5,14 +5,14 @@ Locations_t
 Unit tests for the Locations DAO objects.
 """
 
-import os
-import unittest
 import threading
+import time
+import unittest
 
 from WMCore.DAOFactory import DAOFactory
-from WMCore.WMFactory import WMFactory
 from WMCore.Database.Transaction import Transaction
 from WMQuality.TestInit import TestInit
+
 
 class LocationsTest(unittest.TestCase):
     def setUp(self):
@@ -25,8 +25,8 @@ class LocationsTest(unittest.TestCase):
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
         self.testInit.setDatabaseConnection()
-        self.testInit.setSchema(customModules = ["WMCore.WMBS"],
-                                useDefault = False)
+        self.testInit.setSchema(customModules=["WMCore.WMBS"],
+                                useDefault=False)
         return
 
     def tearDown(self):
@@ -47,24 +47,24 @@ class LocationsTest(unittest.TestCase):
         goldenLocations = ["goodse.cern.ch", "goodse.fnal.gov"]
 
         myThread = threading.currentThread()
-        daoFactory = DAOFactory(package="WMCore.WMBS", logger = myThread.logger,
-                                dbinterface = myThread.dbi)
+        daoFactory = DAOFactory(package="WMCore.WMBS", logger=myThread.logger,
+                                dbinterface=myThread.dbi)
 
-        locationNew = daoFactory(classname = "Locations.New")
+        locationNew = daoFactory(classname="Locations.New")
         for location in goldenLocations:
             # The following is intentional, I want to test that inserting the
             # same location multiple times does not cause problems.
-            locationNew.execute(siteName = location, runningSlots = 300, pendingSlots = 150)
-            locationNew.execute(siteName = location, runningSlots = 300, pendingSlots = 150)
+            locationNew.execute(siteName=location, runningSlots=300, pendingSlots=150)
+            locationNew.execute(siteName=location, runningSlots=300, pendingSlots=150)
 
-        locationNew.execute(siteName = "empty_site")
+        locationNew.execute(siteName="empty_site")
         goldenLocations.append("empty_site")
 
-        locationList = daoFactory(classname = "Locations.List")
+        locationList = daoFactory(classname="Locations.List")
         currentLocations = locationList.execute()
         for location in currentLocations:
             assert location[1] in goldenLocations, \
-                   "ERROR: Unknown location was returned"
+                "ERROR: Unknown location was returned"
 
             if location[1] == "empty_site":
                 assert location[2] == 0, \
@@ -80,11 +80,11 @@ class LocationsTest(unittest.TestCase):
             goldenLocations.remove(location[1])
 
         assert len(goldenLocations) == 0, \
-               "ERROR: Some locations are missing..."
+            "ERROR: Some locations are missing..."
 
-        locationDelete = daoFactory(classname = "Locations.Delete")
-        locationDelete.execute(siteName = "goodse.fnal.gov")
-        locationDelete.execute(siteName = "goodse.cern.ch")
+        locationDelete = daoFactory(classname="Locations.Delete")
+        locationDelete.execute(siteName="goodse.fnal.gov")
+        locationDelete.execute(siteName="goodse.cern.ch")
 
         currentLocations = locationList.execute()
         assert len(currentLocations) == 1, \
@@ -101,17 +101,17 @@ class LocationsTest(unittest.TestCase):
         Test the ability to list all sites in the database.
         """
         myThread = threading.currentThread()
-        daoFactory = DAOFactory(package="WMCore.WMBS", logger = myThread.logger,
-                                dbinterface = myThread.dbi)
+        daoFactory = DAOFactory(package="WMCore.WMBS", logger=myThread.logger,
+                                dbinterface=myThread.dbi)
 
-        locationNew = daoFactory(classname = "Locations.New")
+        locationNew = daoFactory(classname="Locations.New")
 
         locationNew.execute("Satsuma")
         locationNew.execute("Choshu")
         locationNew.execute("Tosa")
 
-        listSites = daoFactory(classname = "Locations.ListSites")
-        sites     = listSites.execute()
+        listSites = daoFactory(classname="Locations.ListSites")
+        sites = listSites.execute()
 
         self.assertEqual("Satsuma" in sites, True)
         self.assertEqual("Choshu" in sites, True)
@@ -124,31 +124,31 @@ class LocationsTest(unittest.TestCase):
         Verify that select behave appropriately when dealing with transactions.
         """
         myThread = threading.currentThread()
-        daoFactory = DAOFactory(package="WMCore.WMBS", logger = myThread.logger,
-                                dbinterface = myThread.dbi)
+        daoFactory = DAOFactory(package="WMCore.WMBS", logger=myThread.logger,
+                                dbinterface=myThread.dbi)
 
         myThread.transaction.begin()
 
         localTransaction = Transaction(myThread.dbi)
         localTransaction.begin()
 
-        locationNew = daoFactory(classname = "Locations.New")
+        locationNew = daoFactory(classname="Locations.New")
 
-        locationNew.execute("Satsuma", conn = myThread.transaction.conn, transaction = True)
-        locationNew.execute("Choshu", conn = myThread.transaction.conn, transaction = True)
+        locationNew.execute("Satsuma", conn=myThread.transaction.conn, transaction=True)
+        locationNew.execute("Choshu", conn=myThread.transaction.conn, transaction=True)
 
-        listSites = daoFactory(classname = "Locations.ListSites")
-        nonTransSites = listSites.execute(conn = localTransaction.conn, transaction = True)
-        transSites = listSites.execute(conn = myThread.transaction.conn, transaction = True)
+        listSites = daoFactory(classname="Locations.ListSites")
+        nonTransSites = listSites.execute(conn=localTransaction.conn, transaction=True)
+        transSites = listSites.execute(conn=myThread.transaction.conn, transaction=True)
 
         assert len(nonTransSites) == 0, \
-               "Error: Wrong number of sites in non transaction list."
+            "Error: Wrong number of sites in non transaction list."
         assert len(transSites) == 2, \
-               "Error: Wrong number of sites in transaction list."
+            "Error: Wrong number of sites in transaction list."
         assert "Satsuma" in transSites, \
-               "Error: Site missing in transaction list."
+            "Error: Site missing in transaction list."
         assert "Choshu" in transSites, \
-               "Error: Site missing in transaction list."
+            "Error: Site missing in transaction list."
 
         localTransaction.commit()
         myThread.transaction.commit()
@@ -162,47 +162,45 @@ class LocationsTest(unittest.TestCase):
         """
 
         myThread = threading.currentThread()
-        daoFactory = DAOFactory(package="WMCore.WMBS", logger = myThread.logger,
-                                dbinterface = myThread.dbi)
+        daoFactory = DAOFactory(package="WMCore.WMBS", logger=myThread.logger,
+                                dbinterface=myThread.dbi)
 
-        locationNew = daoFactory(classname = "Locations.New")
+        locationNew = daoFactory(classname="Locations.New")
 
         locationNew.execute("Satsuma")
         locationNew.execute("Choshu")
         locationNew.execute("Tosa")
 
-        setPendingSlots = daoFactory(classname = "Locations.SetPendingSlots")
-        setPendingSlots.execute(siteName = 'Satsuma', jobSlots = 1868)
-        setPendingSlots.execute(siteName = 'Choshu',  jobSlots = 1868)
-        setPendingSlots.execute(siteName = 'Tosa',    jobSlots = 1868)
+        setPendingSlots = daoFactory(classname="Locations.SetPendingSlots")
+        setPendingSlots.execute(siteName='Satsuma', jobSlots=1868)
+        setPendingSlots.execute(siteName='Choshu', jobSlots=1868)
+        setPendingSlots.execute(siteName='Tosa', jobSlots=1868)
 
-        setRunningSlots = daoFactory(classname = "Locations.SetRunningSlots")
-        setRunningSlots.execute(siteName = 'Satsuma', jobSlots = 42)
-        setRunningSlots.execute(siteName = 'Choshu',  jobSlots = 42)
-        setRunningSlots.execute(siteName = 'Tosa',    jobSlots = 42)
+        setRunningSlots = daoFactory(classname="Locations.SetRunningSlots")
+        setRunningSlots.execute(siteName='Satsuma', jobSlots=42)
+        setRunningSlots.execute(siteName='Choshu', jobSlots=42)
+        setRunningSlots.execute(siteName='Tosa', jobSlots=42)
 
-        locationList = daoFactory(classname = "Locations.List")
+        locationList = daoFactory(classname="Locations.List")
         currentLocations = locationList.execute()
 
         for location in currentLocations:
             self.assertEqual(location[2], 1868)
             self.assertEqual(location[3], 42)
 
-        jobSlotDAO = daoFactory(classname = "Locations.GetJobSlots")
+        jobSlotDAO = daoFactory(classname="Locations.GetJobSlots")
         jobSlots = jobSlotDAO.execute("Satsuma")
         self.assertEqual(jobSlots, [{'running_slots': 42, 'pending_slots': 1868}])
 
-        pendingSlotDAO = daoFactory(classname = "Locations.GetPendingSlots")
+        pendingSlotDAO = daoFactory(classname="Locations.GetPendingSlots")
         pendingSlots = pendingSlotDAO.execute("Satsuma")
         self.assertEqual(pendingSlots, 1868)
 
-        runningSlotDAO = daoFactory(classname = "Locations.GetRunningSlots")
+        runningSlotDAO = daoFactory(classname="Locations.GetRunningSlots")
         runningSlots = runningSlotDAO.execute("Satsuma")
         self.assertEqual(runningSlots, 42)
 
         return
-
-
 
     def testGetSiteInfo(self):
         """
@@ -212,20 +210,18 @@ class LocationsTest(unittest.TestCase):
         """
 
         myThread = threading.currentThread()
-        daoFactory = DAOFactory(package="WMCore.WMBS", logger = myThread.logger,
-                                dbinterface = myThread.dbi)
+        daoFactory = DAOFactory(package="WMCore.WMBS", logger=myThread.logger,
+                                dbinterface=myThread.dbi)
 
+        locationNew = daoFactory(classname="Locations.New")
 
-        locationNew = daoFactory(classname = "Locations.New")
+        locationNew.execute(siteName="Satsuma", ceName="Satsuma", pnn="Satsuma", runningSlots=50, pendingSlots=20)
+        locationNew.execute(siteName="Choshu", ceName="Choshu", pnn="Choshu", runningSlots=50, pendingSlots=20)
+        locationNew.execute(siteName="Tosa", ceName="Tosa", pnn="Choshu", runningSlots=50, pendingSlots=20)
 
-        locationNew.execute(siteName = "Satsuma", ceName = "Satsuma", pnn = "Satsuma", runningSlots = 50, pendingSlots = 20)
-        locationNew.execute(siteName = "Choshu", ceName = "Choshu", pnn = "Choshu", runningSlots = 50, pendingSlots = 20)
-        locationNew.execute(siteName = "Tosa", ceName = "Tosa", pnn = "Choshu", runningSlots = 50, pendingSlots = 20)
+        locationInfo = daoFactory(classname="Locations.GetSiteInfo")
 
-
-        locationInfo = daoFactory(classname = "Locations.GetSiteInfo")
-
-        result = locationInfo.execute(siteName = "Choshu")
+        result = locationInfo.execute(siteName="Choshu")
 
         self.assertEqual(result[0]['ce_name'], 'Choshu')
         self.assertEqual(result[0]['pnn'], 'Choshu')
@@ -238,36 +234,36 @@ class LocationsTest(unittest.TestCase):
     def testDrain(self):
         """Drain sites"""
         myThread = threading.currentThread()
-        daoFactory = DAOFactory(package="WMCore.WMBS", logger = myThread.logger,
-                                dbinterface = myThread.dbi)
-        locationNew = daoFactory(classname = "Locations.New")
-        locationInfo = daoFactory(classname = "Locations.GetSiteInfo")
-        setState = daoFactory(classname = "Locations.SetState")
+        daoFactory = DAOFactory(package="WMCore.WMBS", logger=myThread.logger,
+                                dbinterface=myThread.dbi)
+        locationNew = daoFactory(classname="Locations.New")
+        locationInfo = daoFactory(classname="Locations.GetSiteInfo")
+        setState = daoFactory(classname="Locations.SetState")
 
         # add site and check it's in normal
-        locationNew.execute(siteName = "Satsuma", ceName = "Satsuma", pnn = "Satsuma")
-        result = locationInfo.execute(siteName = "Satsuma")
+        locationNew.execute(siteName="Satsuma", ceName="Satsuma", pnn="Satsuma",
+                            stateTime=int(time.time()))
+        result = locationInfo.execute(siteName="Satsuma")
         self.assertEqual(result[0]['site_name'], 'Satsuma')
         self.assertEqual(result[0]['state'], 'Normal')
 
-        #Now set it to down, it's dead jim
-        setState.execute(siteName = 'Satsuma', state = 'Down')
-        result = locationInfo.execute(siteName = "Satsuma")
+        # Now set it to down, it's dead jim
+        setState.execute(siteName='Satsuma', state='Down', stateTime=int(time.time()))
+        result = locationInfo.execute(siteName="Satsuma")
         self.assertEqual(result[0]['site_name'], 'Satsuma')
         self.assertEqual(result[0]['state'], 'Down')
 
         # Now let's set it to aborted mode
-        setState.execute(siteName = 'Satsuma', state = 'Aborted')
-        result = locationInfo.execute(siteName = "Satsuma")
+        setState.execute(siteName='Satsuma', state='Aborted', stateTime=int(time.time()))
+        result = locationInfo.execute(siteName="Satsuma")
         self.assertEqual(result[0]['site_name'], 'Satsuma')
         self.assertEqual(result[0]['state'], 'Aborted')
 
         # Now let's set it to drain mode
-        setState.execute(siteName = 'Satsuma', state = 'Draining')
-        result = locationInfo.execute(siteName = "Satsuma")
+        setState.execute(siteName='Satsuma', state='Draining', stateTime=int(time.time()))
+        result = locationInfo.execute(siteName="Satsuma")
         self.assertEqual(result[0]['site_name'], 'Satsuma')
         self.assertEqual(result[0]['state'], 'Draining')
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…ing sites
Fixes #8858 

Changes are:
* there are database schema changes (additional `state_time` column for wmbs_location table)
* record the timestamp for adding a new site to the local database or changing its state
* default grace period for sites in drain set to 2 days. This grace period allows jobs to sit in the Submitter queue either waiting for the site to come back to Normal state OR for the grace period to expire, where JobSubmitter would mark those jobs as submitfailed.

Note that the behavior for sites changing states hasn't been touched. Thus a site being put into drain will keep triggering the job removal IF a job is pending in condor and assigned to only that site