### PR TITLE
Use cmssw exit code from job report

### DIFF
--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/CMSSW_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/CMSSW_t.py
@@ -195,10 +195,10 @@ class CMSSW_t(unittest.TestCase):
                 self.fail("An exception should have been raised")
             except WMExecutionFailure as ex:
                 executor.diagnostic(ex.code, executor, ExceptionInstance=ex)
-                self.assertEqual(134, executor.report.getExitCode())
+                self.assertEqual(50115, executor.report.getExitCode())
                 report = Report()
                 report.load("Report.pkl")
-                self.assertEqual(134, report.getExitCode())
+                self.assertEqual(50115, report.getExitCode())
         except Exception as ex:
             self.fail("Failure encountered, %s" % str(ex))
         finally:


### PR DESCRIPTION
Fixes #9006 
Edit: Tested on `vocms0193`, schedd shows the following now:

```
cmst1@vocms0193:~ $ condor_history -constraint 'regexp("khurtado_stepchaindup_v3", Arguments)' -limit 20 -af:h ClusterId ProcId Chirp_WMCore_cmsRun_ExitCode ExitCode MachineAttrGLIDEIN_CMSSite0 REQUIRED_OS Arguments
ClusterId ProcId Chirp_WMCore_cmsRun_ExitCode ExitCode MachineAttrGLIDEIN_CMSSite0 REQUIRED_OS Arguments
6015      9      8001                         65       T1_US_FNAL                  rhel6       wmagent_StepChain_DupOutMod_khurtado_stepchaindup_v3_190215_161125_3120-Sandbox.tar.bz2 242 0
6015      7      8001                         65       T1_US_FNAL                  rhel6       wmagent_StepChain_DupOutMod_khurtado_stepchaindup_v3_190215_161125_3120-Sandbox.tar.bz2 240 0
6015      6      8001                         65       T1_US_FNAL                  rhel6       wmagent_StepChain_DupOutMod_khurtado_stepchaindup_v3_190215_161125_3120-Sandbox.tar.bz2 239 0
6015      2      8001                         65       T2_CH_CERN                  rhel6       wmagent_StepChain_DupOutMod_khurtado_stepchaindup_v3_190215_161125_3120-Sandbox.tar.bz2 235 0
6015      3      8001                         65       T2_CH_CERN                  rhel6       wmagent_StepChain_DupOutMod_khurtado_stepchaindup_v3_190215_161125_3120-Sandbox.tar.bz2 236 0
6015      4      8001                         65       T2_CH_CERN                  rhel6       wmagent_StepChain_DupOutMod_khurtado_stepchaindup_v3_190215_161125_3120-Sandbox.tar.bz2 237 0
6015      0      8001                         65       T1_US_FNAL                  rhel6       wmagent_StepChain_DupOutMod_khurtado_stepchaindup_v3_190215_161125_3120-Sandbox.tar.bz2 233 0
6015      1      8001                         65       T1_US_FNAL                  rhel6       wmagent_StepChain_DupOutMod_khurtado_stepchaindup_v3_190215_161125_3120-Sandbox.tar.bz2 234 0
```