### PR TITLE
Do not parse scramOutput.log for debugging SCRAM problems

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/CMSSW.py
@@ -66,16 +66,6 @@ class Exit50513(DiagnosticHandler):
         if args.get('ExceptionInstance', False):
             msg += str(args.get('ExceptionInstance'))
 
-        jobReport = os.path.join(executor.step.builder.workingDir,
-                                 executor.step.output.jobReport)
-        errLog = os.path.join(os.path.dirname(jobReport),
-                              'scramOutput.log')
-
-        if os.path.exists(errLog):
-            logTail = FileTools.tail(errLog, DEFAULT_TAIL_LINES_FROM_LOG)
-            msg += '\n Adding last %s lines of SCRAM error log:\n' % DEFAULT_TAIL_LINES_FROM_LOG
-            msg += logTail
-
         executor.report.addError(executor.stepName,
                                  50513, "SCRAMScriptFailure", msg)
 
@@ -131,17 +121,6 @@ class CMSDefaultHandler(DiagnosticHandler):
             msg += '\n Adding last %s lines of CMSSW stdout:\n' % DEFAULT_TAIL_LINES_FROM_LOG
             msg += logTail
 
-        # If it exists, grab the SCRAM log
-        errLog = os.path.join(os.path.dirname(jobRepXml),
-                              'scramOutput.log')
-
-        if os.path.exists(errLog):
-            logTail = FileTools.tail(errLog, 25)
-            msg += '\n Adding last ten lines of SCRAM error log:\n'
-            msg += logTail
-
-        # make sure the report has the error in it
-        dummy = getattr(executor.report.report, "errors", None)  # Seems to do nothing
         executor.report.addError(executor.stepName,
                                  errCode, description, msg)
 

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/CMSSW.py
@@ -21,6 +21,7 @@ from WMCore.WMSpec.Steps.Diagnostic import Diagnostic, DiagnosticHandler
 # strip the lines from the log for the report
 DEFAULT_TAIL_LINES_FROM_LOG = 25
 
+
 class Exit127(DiagnosticHandler):
     """
     Handle non-existant executable
@@ -111,7 +112,6 @@ class CMSDefaultHandler(DiagnosticHandler):
         outLog = os.path.join(os.path.dirname(jobRepXml),
                               '%s-stdout.log' % (executor.stepName))
 
-
         if os.path.exists(errLog):
             logTail = FileTools.tail(errLog, DEFAULT_TAIL_LINES_FROM_LOG)
             msg += '\n Adding last %s lines of CMSSW stderr:\n' % DEFAULT_TAIL_LINES_FROM_LOG
@@ -172,7 +172,7 @@ class CMSRunHandler(DiagnosticHandler):
 
         # make sure the report has the error in it
         errSection = getattr(executor.report.report, "errors", None)
-        if errSection == None:
+        if errSection is None:
             executor.report.addError(executor.stepName,
                                      self.code, self.desc, msg)
         else:
@@ -246,7 +246,7 @@ class EDMExceptionHandler(DiagnosticHandler):
 
         # make sure the report has the error in it
         errSection = getattr(executor.report.report, "errors", None)
-        if errSection == None:
+        if errSection is None:
             msg = "Job Report contains no error report, but cmsRun exited non-zero: %s" % errCode
             msg += addOn
             executor.report.addError(executor.stepName,

--- a/src/python/WMCore/WMSpec/Steps/ExecuteMaster.py
+++ b/src/python/WMCore/WMSpec/Steps/ExecuteMaster.py
@@ -145,7 +145,7 @@ class ExecuteMaster:
             logging.error("Exception is %s" % ex)
             logging.error("Traceback: ")
             logging.error(traceback.format_exc())
-            executor.diagnostic(99109, executor, ex=ex)
+            executor.diagnostic(99109, executor, ExceptionInstance=ex)
             executor.report.addError(executor.stepName, 99109, "WMAgentStepExecutionError", str(ex))
             error = True
         executor.report.setStepStopTime(stepName=executor.stepName)

--- a/src/python/WMCore/WMSpec/Steps/ExecuteMaster.py
+++ b/src/python/WMCore/WMSpec/Steps/ExecuteMaster.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-#pylint: disable=W1201, E1101
-# W1201: Allow string formatting in logging messages
+# pylint: disable=E1101
 # E1101: Allow imports from currentThread
 """
 _ExecuteMaster_
@@ -10,19 +9,18 @@ for each step
 
 """
 
+import logging
 import os
 import threading
 import traceback
-import logging
 
-from WMCore.WMException import WMException
-
-from WMCore.WMSpec.WMStep import WMStepHelper
 import WMCore.WMSpec.Steps.StepFactory as StepFactory
+from WMCore.WMException import WMException
 from WMCore.WMSpec.Steps.WMExecutionFailure import WMExecutionFailure
+from WMCore.WMSpec.WMStep import WMStepHelper
 
 
-class ExecuteMaster:
+class ExecuteMaster(object):
     """
     _ExecuteMaster_
 
@@ -31,6 +29,7 @@ class ExecuteMaster:
     instead of the executor
 
     """
+
     def __init__(self):
         pass
 
@@ -126,7 +125,7 @@ class ExecuteMaster:
 
         preOutcome = executionObject.pre()
         if preOutcome is not None:
-            logging.info("Pre Executor Task Change: %s" % preOutcome)
+            logging.info("Pre Executor Task Change: %s", preOutcome)
             executor.saveReport()
             self.toTaskDirectory()
             myThread.watchdogMonitor.notifyStepEnd(step=step,
@@ -142,7 +141,7 @@ class ExecuteMaster:
             error = True
         except Exception as ex:
             logging.error("Exception occured when executing step")
-            logging.error("Exception is %s" % ex)
+            logging.error("Exception is %s", ex)
             logging.error("Traceback: ")
             logging.error(traceback.format_exc())
             executor.diagnostic(99109, executor, ExceptionInstance=ex)
@@ -154,7 +153,7 @@ class ExecuteMaster:
 
         postOutcome = executionObject.post()
         if postOutcome is not None:
-            logging.info("Post Executor Task Change: %s" % postOutcome)
+            logging.info("Post Executor Task Change: %s", postOutcome)
             executor.saveReport()
             self.toTaskDirectory()
             myThread.watchdogMonitor.notifyStepEnd(step=step,

--- a/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
@@ -194,9 +194,6 @@ class LogCollect(Executor):
                     self.report.addInputFile(sourceName="logArchives", lfn=log['lfn'])
             else:
                 logging.error("Unable to copy logArchives to local disk")
-                if useEdmCopyUtil:
-                    with open('scramOutput.log', 'r') as f:
-                        logging.error("Scram output: %s", f.read())
                 for log in logs:
                     self.report.addSkippedFile(log['lfn'], None)
 


### PR DESCRIPTION
Further fix on top of #8989 
We no longer create the scramOutput.log file under each step environment, instead we only use wmagentJob.log log.
It's still not clear whether we might be missing any important error information here, I believe not because we record the stdout and stderr to wmagentJob.log