### PR TITLE
Support pileup for StepChain MC top step

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
@@ -225,6 +225,9 @@ class StepChainWorkloadFactory(StdBase):
                                            globalTag=taskConf.get("GlobalTag", None),
                                            taskConf=taskConf)
 
+        if taskConf["PileupConfig"]:
+            self.setupPileup(task, taskConf['PileupConfig'])
+
         # outputModules were added already, we just want to create merge tasks here
         if strToBool(taskConf.get('KeepOutput', True)):
             self.setupMergeTask(task, taskConf, "cmsRun1", outMods)


### PR DESCRIPTION
Fixes #9025

As the title says, handle Pileup datasets for top level steps that do not have any input dataset (and have a single step).