### PR TITLE
Upper limit for MaxWallTimeSecs set to 45h

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -186,7 +186,7 @@ config.JobCreator.defaultJobType = "Processing"
 config.JobCreator.workerThreads = 1
 # glidein restrictions used for resource estimation (per core)
 config.JobCreator.GlideInRestriction = {"MinWallTimeSecs": 1 * 3600,  # 1h
-                                        "MaxWallTimeSecs": 46 * 3600,  # pilot lifetime is usually 48h
+                                        "MaxWallTimeSecs": 45 * 3600,  # pilot lifetime is usually 48h
                                         "MinRequestDiskKB": 1 * 1000 * 1000,  # 1GB
                                         "MaxRequestDiskKB": 20 * 1000 * 1000}  # site limit is ~27GB
 config.component_("JobSubmitter")


### PR DESCRIPTION
Fixes #9028 
To circumvent a change made to the schedds somewhere in the past, where it rounds MaxWallTimeSecs to the closest 25% (thus 2700 will be 2750).