### PR TITLE
Remove code left for backwards compatibility

### DIFF
--- a/src/python/WMCore/ReqMgr/DataStructs/DefaultConfig/EDITABLE_SPLITTING_PARAM_CONFIG.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/DefaultConfig/EDITABLE_SPLITTING_PARAM_CONFIG.py
@@ -6,7 +6,6 @@ ALGO_DICT = {"FileBased": {"files_per_job": ''},
              "LumiBased": {"lumis_per_job": '',
                            "halt_job_on_file_boundaries": True},
              "EventAwareLumiBased": {"events_per_job": '',
-                                     "max_events_per_lumi": '',  # has to be removed in ~HG1804
                                      "job_time_limit": '',
                                      "halt_job_on_file_boundaries": True},
              "EventBased": {"events_per_job": '',

--- a/src/python/WMCore/WMRuntime/Watchdog.py
+++ b/src/python/WMCore/WMRuntime/Watchdog.py
@@ -88,12 +88,8 @@ class Watchdog(threading.Thread):
                     origCores = max(origCores, sh.getNumberOfCores())
                 resources = {'cores': origCores}
                 origMaxRSS = args.get('maxRSS')
-                ### TODO: keep only the else clause after ~HG1805
-                if origMaxRSS and origMaxRSS > 100 * 1000:  # in case MaxRSS is in KB
-                    origMaxRSS = int(origMaxRSS / 1024.)  # HTCondor expects MB; we get KB.
+                if origMaxRSS:
                     resources['memory'] = origMaxRSS
-                elif origMaxRSS:
-                    resources['memory'] = origMaxRSS  # then it's already in MB
                 # Actually parses the HTCondor runtime
                 resizeResources(resources)
                 # We decided to only touch Watchdog settings if the number of cores changed.

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -1029,11 +1029,7 @@ class WMTaskHelper(TreeHelper):
         if not hasattr(self.data, "subscriptions"):
             return {}
 
-        # FIXME making it backwards compatible.
-        # New key is 'outputSubs', remove the outputModule handle around HG1710
-        subKeyName = 'outputModules'
-        if hasattr(self.data.subscriptions, 'outputSubs'):
-            subKeyName = 'outputSubs'
+        subKeyName = 'outputSubs'
 
         subInformation = {}
         for outputSub in getattr(self.data.subscriptions, subKeyName):


### PR DESCRIPTION
This change should be pretty safe, since those changes were supposed to be removed by May 2018, at most.
For the splitting param change, we might have to manually remove that key from the central couch doc.

We'll need this update to the manage script: https://github.com/dmwm/deployment/pull/726
and then ask Lina to run the following command in one of the ReqMgr2 backends:
`/data/srv/current/config/reqmgr2/manage postdefaultconfig cmsweb-testbed.cern.ch 'I did read documentation'`