### PR TITLE
Make type REST api to return json-like instead of xml results

### DIFF
--- a/src/python/WMCore/ReqMgr/Service/Request.py
+++ b/src/python/WMCore/ReqMgr/Service/Request.py
@@ -602,6 +602,6 @@ class RequestType(RESTEntity):
     def validate(self, apiobj, method, api, param, safe):
         pass
 
-    @restcall
+    @restcall(formats=[('application/json', JSONFormat())])
     def get(self):
         return rows(REQUEST_TYPES)


### PR DESCRIPTION
Return a nicely formatted output when calling the `type` REST API, e.g.:
https://cmsweb.cern.ch/reqmgr2/data/type