### PR TITLE
Trigger transaction rollback if exception is raised in wmbsPreparation 

### DIFF
--- a/src/python/WMComponent/WorkQueueManager/WorkQueueManagerWMBSFileFeeder.py
+++ b/src/python/WMComponent/WorkQueueManager/WorkQueueManagerWMBSFileFeeder.py
@@ -2,23 +2,21 @@
 """
 pullWork poller
 """
-__all__ = []
-
-
-
-
-import time
 import random
+import time
+
 from Utils.Timers import timeFunction
-from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
+from WMCore.Services.ReqMgr.ReqMgr import ReqMgr
 from WMCore.WorkQueue.WMBSHelper import freeSlots
 from WMCore.WorkQueue.WorkQueueUtils import cmsSiteNames
-from WMCore.Services.ReqMgr.ReqMgr import ReqMgr
+from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
+
 
 class WorkQueueManagerWMBSFileFeeder(BaseWorkerThread):
     """
     Polls for Work
     """
+
     def __init__(self, queue, config):
         """
         Initialise class members
@@ -31,14 +29,13 @@ class WorkQueueManagerWMBSFileFeeder(BaseWorkerThread):
         # state lists which shouldn't be populated in wmbs. (To prevent creating work before WQE status updated)
         self.abortedAndForceCompleteWorkflowCache = self.reqmgr2Svc.getAbortedAndForceCompleteRequestsFromMemoryCache()
 
-
     def setup(self, parameters):
         """
         Called at startup - introduce random delay
              to avoid workers all starting at once
         """
         t = random.randrange(self.idleTime)
-        self.logger.info('Sleeping for %d seconds before 1st loop' % t)
+        self.logger.info('Sleeping for %d seconds before 1st loop', t)
         time.sleep(t)
 
     @timeFunction

--- a/src/python/WMCore/WMBS/Fileset.py
+++ b/src/python/WMCore/WMBS/Fileset.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 #Turn off to many arguments
 #pylint: disable=R0913
-#Turn off over riding built in id
-#pylint: disable=W0622
 """
 _Fileset_
 
@@ -16,7 +14,7 @@ workflow + fileset = subscription
 
 
 
-
+import logging
 from WMCore.WMBS.File import File, addFilesToWMBSInBulk
 from WMCore.WMBS.WMBSBase import WMBSBase
 from WMCore.DataStructs.Fileset import Fileset as WMFileset
@@ -104,20 +102,18 @@ class Fileset(WMBSBase, WMFileset):
         """
         Add the new fileset to WMBS, and commit the files
         """
-        existingTransaction = self.beginTransaction()
-
-        if self.exists() != False:
+        if self.exists() is not False:
             self.load()
-            self.commitTransaction(existingTransaction)
             return
 
+        existingTransaction = self.beginTransaction()
         createAction = self.daofactory(classname = "Fileset.New")
         createAction.execute(self.name, self.open, conn = self.getDBConn(),
                              transaction = self.existingTransaction())
         self.commit()
         self.loadData()
-
         self.commitTransaction(existingTransaction)
+        logging.info("Fileset created: %s", self.name)
         return
 
     def delete(self):

--- a/src/python/WMCore/WMBS/Fileset.py
+++ b/src/python/WMCore/WMBS/Fileset.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-#Turn off to many arguments
-#pylint: disable=R0913
+# Turn off to many arguments
+# pylint: disable=R0913
 """
 _Fileset_
 
@@ -12,12 +12,12 @@ complete block, a block in transfer, some user defined dataset etc.
 workflow + fileset = subscription
 """
 
-
-
 import logging
+
+from WMCore.DataStructs.Fileset import Fileset as WMFileset
 from WMCore.WMBS.File import File, addFilesToWMBSInBulk
 from WMCore.WMBS.WMBSBase import WMBSBase
-from WMCore.DataStructs.Fileset import Fileset as WMFileset
+
 
 class Fileset(WMBSBase, WMFileset):
     """
@@ -29,12 +29,13 @@ class Fileset(WMBSBase, WMFileset):
 
     workflow + fileset = subscription
     """
+
     def __init__(self, name=None, id=-1, is_open=True, files=None,
                  parents=None, parents_open=True, source=None, sourceUrl=None):
         WMBSBase.__init__(self)
-        WMFileset.__init__(self, name = name, files=files)
+        WMFileset.__init__(self, name=name, files=files)
 
-        if parents == None:
+        if parents is None:
             parents = set()
 
         # Create a new fileset
@@ -53,10 +54,9 @@ class Fileset(WMBSBase, WMFileset):
         Change the last update time of this fileset.  The lastUpdate parameter is a int
         representing the last time where the fileset was modifed.
         """
-        closeAction = self.daofactory(classname = "Fileset.SetLastUpdate")
-        closeAction.execute(fileset = self.name, timeUpdate = timeUpdate, \
-                            conn = self.getDBConn(),\
-                            transaction = self.existingTransaction())
+        closeAction = self.daofactory(classname="Fileset.SetLastUpdate")
+        closeAction.execute(fileset=self.name, timeUpdate=timeUpdate, conn=self.getDBConn(),
+                            transaction=self.existingTransaction())
 
         self.lastUpdate = timeUpdate
         return
@@ -86,14 +86,14 @@ class Fileset(WMBSBase, WMFileset):
         Does a fileset exist with this name in the database
         """
         if self.id != -1:
-            action = self.daofactory(classname = "Fileset.ExistsByID")
-            result = action.execute(id = self.id, conn = self.getDBConn(),
-                                    transaction = self.existingTransaction())
+            action = self.daofactory(classname="Fileset.ExistsByID")
+            result = action.execute(id=self.id, conn=self.getDBConn(),
+                                    transaction=self.existingTransaction())
         else:
-            action = self.daofactory(classname = "Fileset.Exists")
-            result = action.execute(self.name, conn = self.getDBConn(),
-                                    transaction = self.existingTransaction())
-            if result != False:
+            action = self.daofactory(classname="Fileset.Exists")
+            result = action.execute(self.name, conn=self.getDBConn(),
+                                    transaction=self.existingTransaction())
+            if result is not False:
                 self.id = result
 
         return result
@@ -107,9 +107,9 @@ class Fileset(WMBSBase, WMFileset):
             return
 
         existingTransaction = self.beginTransaction()
-        createAction = self.daofactory(classname = "Fileset.New")
-        createAction.execute(self.name, self.open, conn = self.getDBConn(),
-                             transaction = self.existingTransaction())
+        createAction = self.daofactory(classname="Fileset.New")
+        createAction.execute(self.name, self.open, conn=self.getDBConn(),
+                             transaction=self.existingTransaction())
         self.commit()
         self.loadData()
         self.commitTransaction(existingTransaction)
@@ -120,9 +120,9 @@ class Fileset(WMBSBase, WMFileset):
         """
         Remove this fileset from WMBS
         """
-        action = self.daofactory(classname = "Fileset.Delete")
-        result = action.execute(name = self.name, conn = self.getDBConn(),
-                                transaction = self.existingTransaction())
+        action = self.daofactory(classname="Fileset.Delete")
+        result = action.execute(name=self.name, conn=self.getDBConn(),
+                                transaction=self.existingTransaction())
 
         return result
 
@@ -134,15 +134,15 @@ class Fileset(WMBSBase, WMFileset):
         database.
         """
         if self.id > 0:
-            action = self.daofactory(classname = "Fileset.LoadFromID")
-            result = action.execute(fileset = self.id,
-                                    conn = self.getDBConn(),
-                                    transaction = self.existingTransaction())
+            action = self.daofactory(classname="Fileset.LoadFromID")
+            result = action.execute(fileset=self.id,
+                                    conn=self.getDBConn(),
+                                    transaction=self.existingTransaction())
         else:
-            action = self.daofactory(classname = "Fileset.LoadFromName")
-            result = action.execute(fileset = self.name,
-                                    conn = self.getDBConn(),
-                                    transaction = self.existingTransaction())
+            action = self.daofactory(classname="Fileset.LoadFromName")
+            result = action.execute(fileset=self.name,
+                                    conn=self.getDBConn(),
+                                    transaction=self.existingTransaction())
 
         self.id = result["id"]
         self.name = result["name"]
@@ -151,7 +151,7 @@ class Fileset(WMBSBase, WMFileset):
 
         return self
 
-    def loadData(self, parentage = 1):
+    def loadData(self, parentage=1):
         """
         _loadData_
 
@@ -159,21 +159,21 @@ class Fileset(WMBSBase, WMFileset):
         """
         existingTransaction = self.beginTransaction()
 
-        if self.name == None or self.id < 0:
+        if self.name is None or self.id < 0:
             self.load()
 
-        action = self.daofactory(classname = "Files.InFileset")
-        results = action.execute(fileset = self.id,
-                                 conn = self.getDBConn(),
-                                 transaction = self.existingTransaction())
+        action = self.daofactory(classname="Files.InFileset")
+        results = action.execute(fileset=self.id,
+                                 conn=self.getDBConn(),
+                                 transaction=self.existingTransaction())
 
         self.files = set()
         self.newfiles = set()
 
         for result in results:
-            file = File(id = result["fileid"])
-            file.loadData(parentage = parentage)
-            self.files.add(file)
+            thisFile = File(id=result["fileid"])
+            thisFile.loadData(parentage=parentage)
+            self.files.add(thisFile)
 
         self.commitTransaction(existingTransaction)
         return
@@ -190,19 +190,19 @@ class Fileset(WMBSBase, WMFileset):
 
         ids = []
         while len(self.newfiles) > 0:
-            #Check file objects exist in the database, save those that don't
+            # Check file objects exist in the database, save those that don't
             f = self.newfiles.pop()
             if not f.exists():
                 f.create()
             ids.append(f["id"])
             self.files.add(f)
 
-        #Add Files to DB only if there are any files on newfiles
+        # Add Files to DB only if there are any files on newfiles
         if len(ids) > 0:
-            addAction = self.daofactory(classname = "Files.AddToFilesetByIDs")
-            addAction.execute(file = ids, fileset = self.id,
-                              conn = self.getDBConn(),
-                              transaction = self.existingTransaction())
+            addAction = self.daofactory(classname="Files.AddToFilesetByIDs")
+            addAction.execute(file=ids, fileset=self.id,
+                              conn=self.getDBConn(),
+                              transaction=self.existingTransaction())
 
         self.commitTransaction(existingTransaction)
         return
@@ -214,14 +214,13 @@ class Fileset(WMBSBase, WMFileset):
         Change the open status of this fileset.  The isOpen parameter is a bool
         representing whether or not the fileset is open.
         """
-        closeAction = self.daofactory(classname = "Fileset.MarkOpen")
-        closeAction.execute(fileset = self.name, isOpen = isOpen,
-                            conn = self.getDBConn(),
-                            transaction = self.existingTransaction())
+        closeAction = self.daofactory(classname="Fileset.MarkOpen")
+        closeAction.execute(fileset=self.name, isOpen=isOpen,
+                            conn=self.getDBConn(),
+                            transaction=self.existingTransaction())
         self.open = isOpen
 
         return
-
 
     def __str__(self):
         """
@@ -237,8 +236,7 @@ class Fileset(WMBSBase, WMFileset):
 
         return str(st)
 
-
-    def addFilesToWMBSInBulk(self, files, workflowName, isDBS = True):
+    def addFilesToWMBSInBulk(self, files, workflowName, isDBS=True):
         """
         _addFilesToWMBSInBulk
 
@@ -246,7 +244,7 @@ class Fileset(WMBSBase, WMFileset):
         """
         # Can / should we move this to commit???
         files = addFilesToWMBSInBulk(self.id, workflowName, files,
-                                     isDBS = isDBS,
-                                     conn = self.getDBConn(),
-                                     transaction = self.existingTransaction())
+                                     isDBS=isDBS,
+                                     conn=self.getDBConn(),
+                                     transaction=self.existingTransaction())
         return files

--- a/src/python/WMCore/WMBS/Subscription.py
+++ b/src/python/WMCore/WMBS/Subscription.py
@@ -53,12 +53,11 @@ class Subscription(WMBSBase, WMSubscription):
         """
         Add the subscription to the database
         """
-        existingTransaction = self.beginTransaction()
-
-        if self.exists():
+        if self.exists() is not False:
             self.load()
             return
 
+        existingTransaction = self.beginTransaction()
         action = self.daofactory(classname="Subscriptions.New")
         action.execute(fileset=self["fileset"].id, type=self["type"],
                        split_algo=self["split_algo"],

--- a/src/python/WMCore/WMBS/Subscription.py
+++ b/src/python/WMCore/WMBS/Subscription.py
@@ -540,8 +540,6 @@ class Subscription(WMBSBase, WMSubscription):
         jobGroupList = []
         nameList = []
 
-        wfid = self['workflow'].id
-
         # You have to do things in this order:
         # 1) First create Filesets, then jobGroups
         # 2) Second, create jobs pointing to jobGroups
@@ -640,12 +638,13 @@ class Subscription(WMBSBase, WMSubscription):
         fileAction.execute(jobDict=fileDict, conn=self.getDBConn(),
                            transaction=self.existingTransaction())
 
+        # wfid = self['workflow'].id
         # Add work units and associate them
-        wuAction = self.daofactory(classname='WorkUnit.Add')
-        wufAction = self.daofactory(classname='Jobs.AddWorkUnits')
+        # wuAction = self.daofactory(classname='WorkUnit.Add')
+        # wufAction = self.daofactory(classname='Jobs.AddWorkUnits')
 
         # Make a count of how many times each job appears in the list of jobFileRunLumis
-        jobUnitCounts = Counter([jid for jid, _, _, _ in jobFileRunLumis])
+        # jobUnitCounts = Counter([jid for jid, _, _, _ in jobFileRunLumis])
 
         # for jid, fid, run, lumi in jobFileRunLumis:
         #     wuAction.execute(taskid=wfid, fileid=fid, run=run, lumi=lumi, last_unit_count=jobUnitCounts[jid],

--- a/src/python/WMCore/WMBS/Workflow.py
+++ b/src/python/WMCore/WMBS/Workflow.py
@@ -16,6 +16,7 @@ workflow + fileset = subscription
 """
 
 import logging
+
 from WMCore.DataStructs.Workflow import Workflow as WMWorkflow
 from WMCore.WMBS.Fileset import Fileset
 from WMCore.WMBS.WMBSBase import WMBSBase
@@ -153,7 +154,7 @@ class Workflow(WMBSBase, WMWorkflow):
             result = action.execute(workflow=self.id,
                                     conn=self.getDBConn(),
                                     transaction=self.existingTransaction())
-        elif self.name != None:
+        elif self.name is not None:
             action = self.daofactory(classname="Workflow.LoadFromNameAndTask")
             result = action.execute(workflow=self.name, task=self.task,
                                     conn=self.getDBConn(),
@@ -184,7 +185,7 @@ class Workflow(WMBSBase, WMWorkflow):
         for outputID in results.keys():
             for outputMap in results[outputID]:
                 outputFileset = Fileset(id=outputMap["output_fileset"])
-                if outputMap["merged_output_fileset"] != None:
+                if outputMap["merged_output_fileset"] is not None:
                     mergedOutputFileset = Fileset(id=outputMap["merged_output_fileset"])
                 else:
                     mergedOutputFileset = None
@@ -207,7 +208,7 @@ class Workflow(WMBSBase, WMWorkflow):
         """
         existingTransaction = self.beginTransaction()
 
-        if self.id == False:
+        if self.id is False:
             self.create()
 
         if outputIdentifier not in self.outputMap:
@@ -217,7 +218,7 @@ class Workflow(WMBSBase, WMWorkflow):
                                                  "merged_output_fileset": mergedOutputFileset})
 
         action = self.daofactory(classname="Workflow.InsertOutput")
-        if mergedOutputFileset != None:
+        if mergedOutputFileset is not None:
             mergedFilesetID = mergedOutputFileset.id
         else:
             mergedFilesetID = None

--- a/src/python/WMCore/WorkQueue/WMBSHelper.py
+++ b/src/python/WMCore/WorkQueue/WMBSHelper.py
@@ -709,7 +709,7 @@ class WMBSHelper(WMConnectionBase):
             # only add to DBSBuffer if is not unmerged file or it has parents.
             dbsFile = self._convertACDCFileToDBSFile(acdcFile)
             self._addToDBSBuffer(dbsFile, checksums, acdcFile["locations"])
-        
+
         logging.debug("WMBS ACDC File: %s on Location: %s", wmbsFile['lfn'], wmbsFile['newlocations'])
 
         wmbsFile['inFileset'] = bool(inFileset)

--- a/src/python/WMCore/WorkQueue/WMBSHelper.py
+++ b/src/python/WMCore/WorkQueue/WMBSHelper.py
@@ -254,12 +254,12 @@ class WMBSHelper(WMConnectionBase):
         and phedex subscriptions, and filesets for each task below and including
         the given task.
         """
-        sub = self._createSubscriptionsInWMBS(task, fileset, alternativeFilesetClose)
+        self._createSubscriptionsInWMBS(task, fileset, alternativeFilesetClose)
 
         self._createWorkflowsInDBSBuffer()
         self._createDatasetSubscriptionsInDBSBuffer()
 
-        return sub
+        return
 
     def _createSubscriptionsInWMBS(self, task, fileset, alternativeFilesetClose=False):
         """
@@ -285,12 +285,9 @@ class WMBSHelper(WMConnectionBase):
         subscription = Subscription(fileset=fileset, workflow=workflow,
                                     split_algo=task.jobSplittingAlgorithm(),
                                     type=task.getPrimarySubType())
-        if subscription.exists():
-            subscription.load()
-            msg = "Subscription %s already exists for %s (you may ignore file insertion messages below, existing files wont be duplicated)"
-            self.logger.info(msg % (subscription['id'], task.getPathName()))
-        else:
-            subscription.create()
+        subscription.create()
+
+        ### FIXME: I'm pretty sure we can improve how we handle this site white/black list
         for site in task.siteWhitelist():
             subscription.addWhiteBlackList([{"site_name": site, "valid": True}])
 
@@ -299,16 +296,17 @@ class WMBSHelper(WMConnectionBase):
 
         if self.topLevelSubscription is None:
             self.topLevelSubscription = subscription
-            logging.info("Top level subscription created: %s", subscription["id"])
+            logging.info("Top level subscription %s created for %s", subscription["id"], self.wmSpec.name())
         else:
-            logging.info("Child subscription created: %s", subscription["id"])
+            logging.info("Child subscription %s created for %s", subscription["id"], self.wmSpec.name())
 
         outputModules = task.getOutputModulesForTask()
         ignoredOutputModules = task.getIgnoredOutputModulesForTask()
         for outputModule in outputModules:
             for outputModuleName in outputModule.listSections_():
                 if outputModuleName in ignoredOutputModules:
-                    logging.info("IgnoredOutputModule set for %s, skipping fileset creation.", outputModuleName)
+                    msg = "%s has %s as IgnoredOutputModule, skipping fileset creation."
+                    logging.info(msg, task.getPathName(), outputModuleName)
                     continue
                 dataTier = getattr(getattr(outputModule, outputModuleName), "dataTier", '')
                 filesetName = self.outputFilesetName(task, outputModuleName, dataTier)
@@ -341,7 +339,7 @@ class WMBSHelper(WMConnectionBase):
                     workflow.addOutput(outputModuleName + dataTier, outputFileset,
                                        mergedOutputFileset)
 
-        return self.topLevelSubscription
+        return
 
     def addMCFakeFile(self):
         """Add a fake file for wmbs to run production over"""
@@ -405,37 +403,33 @@ class WMBSHelper(WMConnectionBase):
 
         self.createTopLevelFileset()
         try:
-            sub = self.createSubscription(self.topLevelTask, self.topLevelFileset)
+            self.createSubscription(self.topLevelTask, self.topLevelFileset)
         except Exception as ex:
             myThread = threading.currentThread()
             myThread.transaction.rollback()
             logging.exception("Failed to create subscription. Error: %s", str(ex))
             raise ex
 
-        if block != None:
-            logging.info('"%s" Injecting block %s (%d files) into wmbs', self.wmSpec.name(),
-                         self.block,
-                         len(block['Files']))
+        if block:
+            logging.info('"%s" Injecting block %s (%d files) into wmbs.',
+                         self.wmSpec.name(), self.block, len(block['Files']))
             addedFiles = self.addFiles(block)
-        # For MC case
         else:
-            logging.info(
-                '"%s" Injecting production %s:%s:%s - %s:%s:%s (run:lumi:event) into wmbs', self.wmSpec.name(),
-                self.mask['FirstRun'],
-                self.mask['FirstLumi'],
-                self.mask['FirstEvent'],
-                self.mask['LastRun'],
-                self.mask['LastLumi'],
-                self.mask['LastEvent'])
+            # For MC case
+            logging.info('"%s" Injecting production %s:%s:%s - %s:%s:%s (run:lumi:event) into wmbs',
+                         self.wmSpec.name(),
+                         self.mask['FirstRun'], self.mask['FirstLumi'], self.mask['FirstEvent'],
+                         self.mask['LastRun'], self.mask['LastLumi'], self.mask['LastEvent'])
             addedFiles = self.addMCFakeFile()
 
         self.commitTransaction(existingTransaction)
+        logging.info("Transaction committed: %s, for %s", not existingTransaction, self.wmSpec.name())
 
         # Now that we've created those files, clear the list
         self.dbsFilesToCreate = set()
         self.wmbsFilesToCreate = set()
 
-        return sub, addedFiles
+        return self.topLevelSubscription, addedFiles
 
     def addFiles(self, block):
         """
@@ -453,18 +447,20 @@ class WMBSHelper(WMConnectionBase):
                 self._addACDCFileToWMBSFile(acdcFile)
         else:
             self.isDBS = True
-            logging.info('Adding files into WMBS for %s', self.wmSpec.name())
             blockPNNs = block['PhEDExNodeNames']
+            logging.info('Adding files into WMBS for %s with PNNs: %s', self.wmSpec.name(), blockPNNs)
             for dbsFile in self.validFiles(block['Files']):
                 self._addDBSFileToWMBSFile(dbsFile, blockPNNs)
 
         # Add files to WMBS
-        logging.info('Inserting in bulk all the file info into WMBS for %s', self.wmSpec.name())
+        logging.info('Inserting %d files in bulk into WMBS for %s', len(self.wmbsFilesToCreate),
+                     self.wmSpec.name())
         totalFiles = self.topLevelFileset.addFilesToWMBSInBulk(self.wmbsFilesToCreate,
                                                                self.wmSpec.name(),
                                                                isDBS=self.isDBS)
         # Add files to DBSBuffer
-        logging.info('Inserting all the file info into DBSBuffer for %s', self.wmSpec.name())
+        logging.info('Inserting %d files in bulk into DBSBuffer for %s', len(self.dbsFilesToCreate),
+                     self.wmSpec.name())
         self._createFilesInDBSBuffer()
 
         self.topLevelFileset.markOpen(blockOpen)


### PR DESCRIPTION
Fixes #9041 

Make sure to rollback the current transaction in case an exception happens in the second stage of the _wmbsPreparation (somewhere in addFiles() or addMCFakeFile()). Otherwise the transactions is not properly reset and all further `commitTransaction()` in the same cycle won't take any effect, because `existingTransaction` in `createSubscriptionAndAddFiles` will be True.

Improve logging as well, and make it slightly more verbose.