### PR TITLE
Update DBS global mocked data

### DIFF
--- a/src/python/WMQuality/Emulators/DBSClient/MockedDBSGlobalCalls.py
+++ b/src/python/WMQuality/Emulators/DBSClient/MockedDBSGlobalCalls.py
@@ -6,7 +6,7 @@ endpoint = 'https://cmsweb.cern.ch/dbs/prod/global/DBSReader'
 
 # Datasets to get all blocks, array, and lumis from
 datasets = ['/HighPileUp/Run2011A-v1/RAW', '/MinimumBias/ComissioningHI-v1/RAW', '/Cosmics/ComissioningHI-v1/RAW',
-            '/Cosmics/ComissioningHI-PromptReco-v1/RECO', '/SingleMu/CMSSW_6_2_0_pre4-PRE_61_V1_RelVal_mu2012A-v1/RECO',
+            '/Cosmics/ComissioningHI-PromptReco-v1/RECO',
             '/SingleElectron/StoreResults-Run2011A-WElectron-PromptSkim-v4-ALCARECO-NOLC-36cfce5a1d3f3ab4df5bd2aa0a4fa380/USER',
            ]
 

--- a/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Dataset_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Dataset_t.py
@@ -220,7 +220,10 @@ class DatasetTestCase(EmulatedUnitTestCase):
         # It seems like "dbs" below is never used
         parentProcArgs2 = {}
         parentProcArgs2.update(parentProcArgs)
-        parentProcArgs2.update({'InputDataset': '/SingleMu/CMSSW_6_2_0_pre4-PRE_61_V1_RelVal_mu2012A-v1/RECO'})
+        #parentProcArgs2.update({'InputDataset': '/SingleMu/CMSSW_6_2_0_pre4-PRE_61_V1_RelVal_mu2012A-v1/RECO'})
+        parentProcArgs2.update({'InputDataset': '/Cosmics/ComissioningHI-PromptReco-v1/RECO'})
+        from pprint import pprint
+        pprint(parentProcArgs2)
         parentProcSpec = rerecoWorkload('ReRecoWorkload', parentProcArgs2,
                                         assignArgs={'SiteWhitelist': ['T2_XX_SiteA']})
         parentProcSpec.setStartPolicy('Dataset', **splitArgs)
@@ -229,8 +232,8 @@ class DatasetTestCase(EmulatedUnitTestCase):
             units, _, _ = Dataset(**splitArgs)(parentProcSpec, task)
             self.assertEqual(1, len(units))
             for unit in units:
-                self.assertEqual(847, unit['Jobs'])
-                self.assertEqual(1694, unit['NumberOfLumis'])
+                self.assertEqual(3993, unit['Jobs'])
+                self.assertEqual(7985, unit['NumberOfLumis'])
                 self.assertEqual(parentProcSpec, unit['WMSpec'])
                 self.assertEqual(task, unit['Task'])
                 self.assertEqual(unit['Inputs'].keys(), [inputDataset])

--- a/test/python/WMQuality_t/Emulators_t/DBSClient_t/MockDbsApi_t.py
+++ b/test/python/WMQuality_t/Emulators_t/DBSClient_t/MockDbsApi_t.py
@@ -3,7 +3,7 @@
 from __future__ import (division, print_function)
 
 import unittest
-
+import logging
 from dbs.apis.dbsClient import DbsApi
 
 from Utils.ExtendedUnitTestCase import ExtendedUnitTestCase
@@ -45,7 +45,6 @@ class MockDbsApiTest(ExtendedUnitTestCase):
                    'listFileParents': {'block_name': block_with_parent},
                    'listPrimaryDatasets': {'primary_ds_name': 'Jet*'},
                    'listRuns': {'dataset': DATASET},
-                   'listFileArray': {'dataset': DATASET},
                    'listFileArray': {'dataset': DATASET, 'detail': True, 'validFileOnly': 1},
                    'listFileSummaries': {'dataset': DATASET, 'validFileOnly': 1},
                    'listBlocks': {'dataset': DATASET, 'detail': True},
@@ -56,7 +55,7 @@ class MockDbsApiTest(ExtendedUnitTestCase):
             # Get from  mock DBS
             args = []
             kwargs = members[member]
-
+            logging.info("Querying API: %s, with parameters: %s", member, members[member])
             real = getattr(self.realDBS, member)(*args, **kwargs)
             mock = getattr(self.mockDBS, member)(*args, **kwargs)
 


### PR DESCRIPTION
Fix the unit test error reported here:
https://github.com/dmwm/WMCore/pull/9045#issuecomment-467214774
and here
https://cmssdt.cern.ch/dmwm-jenkins/view/All/job/DMWM-WMCore-PR-test/8490/artifact/artifacts/PullRequestReport.html

The way to recreate this json is by:
```
/data/amaltaro/wmagent/wmcore_unittest/WMCore/src/python/WMQuality/Emulators/DBSClient $ python MakeDBSMockFiles.py
```