### PR TITLE
Fetch unique job info from the ACDCServer in the JobFactory

### DIFF
--- a/src/python/WMCore/JobSplitting/EventBased.py
+++ b/src/python/WMCore/JobSplitting/EventBased.py
@@ -56,7 +56,10 @@ class EventBased(JobFactory):
                 couchDB = kwargs.get('couchDB')
                 filesetName = kwargs.get('filesetName')
                 collectionName = kwargs.get('collectionName')
-                logging.info('Creating jobs for ACDC fileset %s', filesetName)
+                logging.info('Loading ACDC info for collectionName: %s, with filesetName: %s', collectionName, filesetName)
+                ### FIXME Wait, don't we have all this data in WMBS already? Why querying
+                # the ACDCServer again to get the same data that is already stored
+                # in the WMBS table!!!!!?!?!
                 dcs = DataCollectionService(couchURL, couchDB)
                 acdcFileList = dcs.getProductionACDCInfo(collectionName, filesetName)
             except Exception as ex:

--- a/src/python/WMCore/WMBS/MySQL/Files/GetBulkRunLumi.py
+++ b/src/python/WMCore/WMBS/MySQL/Files/GetBulkRunLumi.py
@@ -34,10 +34,8 @@ class GetBulkRunLumi(DBFormatter):
         for entry in res:
             id  = entry['id']
             run = entry['run']
-            if not id in finalResult.keys():
-                finalResult[id] = {}
-            if not run in finalResult[id].keys():
-                finalResult[id][run] = []
+            finalResult.setdefault(id, {})
+            finalResult[id].setdefault(run, [])
             finalResult[id][run].append(entry['lumi'])
 
         return finalResult

--- a/src/python/WMCore/WMBS/MySQL/Files/GetBulkRunLumi.py
+++ b/src/python/WMCore/WMBS/MySQL/Files/GetBulkRunLumi.py
@@ -7,6 +7,7 @@ MySQL implementation of GetBulkRunLumi
 
 from WMCore.Database.DBFormatter import DBFormatter
 
+
 class GetBulkRunLumi(DBFormatter):
     """
     Note that this is ID based.  I may have to change it back
@@ -18,7 +19,7 @@ class GetBulkRunLumi(DBFormatter):
                WHERE flr.fileid = :id
     """
 
-    def getBinds(self, files = None):
+    def getBinds(self, files=None):
         binds = []
         files = self.dbi.makelist(files)
         for f in files:
@@ -32,17 +33,17 @@ class GetBulkRunLumi(DBFormatter):
         res = self.formatDict(result)
 
         for entry in res:
-            id  = entry['id']
+            fileid = entry['id']
             run = entry['run']
-            finalResult.setdefault(id, {})
-            finalResult[id].setdefault(run, [])
-            finalResult[id][run].append(entry['lumi'])
+            finalResult.setdefault(fileid, {})
+            finalResult[fileid].setdefault(run, [])
+            finalResult[fileid][run].append(entry['lumi'])
 
         return finalResult
 
-    def execute(self, files = None, conn = None, transaction = False):
+    def execute(self, files=None, conn=None, transaction=False):
         binds = self.getBinds(files)
 
         result = self.dbi.processData(self.sql, binds,
-                         conn = conn, transaction = transaction)
+                                      conn=conn, transaction=transaction)
         return self.format(result)

--- a/test/python/WMCore_t/ACDC_t/DataCollectionService_t.py
+++ b/test/python/WMCore_t/ACDC_t/DataCollectionService_t.py
@@ -387,7 +387,9 @@ class DataCollectionService_t(unittest.TestCase):
                           u'lfn': u'/store/unmerged/fileB.root',
                           u'locations': [u'T1_US_FNAL_MSS'],
                           u'parents': ['file2'],
-                          u'runs': [{u'lumis': [4, 5, 6], u'run_number': 1}, {u'lumis': [9], u'run_number': 1}]},
+                          u'runs': [{u'lumis': [4, 5, 6], u'run_number': 1},
+                                    {u'lumis': [9], u'run_number': 1},
+                                    {u'lumis': [7, 8], u'run_number': 7}]},
                          {u'events': 10,
                           u'lfn': u'/store/unmerged/fileC.root',
                           u'locations': [u'T1_US_FNAL_Disk', u'T2_US_MIT'],
@@ -404,18 +406,26 @@ class DataCollectionService_t(unittest.TestCase):
             if item['lfn'] == '/store/unmerged/fileA.root':
                 self.assertEqual(item['events'], 165)
                 self.assertItemsEqual(item['locations'], ['T2_CH_CERN', 'T2_CH_CERNBOX'])
-                self.assertItemsEqual(item['runs'], [{'lumis': [1810823], 'run_number': 1},
-                                                     {'lumis': [1810823], 'run_number': 2},
-                                                     {'lumis': [1810824], 'run_number': 1}])
+                for runLumi in item['runs']:
+                    if runLumi['run_number'] == 1:
+                        self.assertItemsEqual(runLumi['lumis'], [1810824, 1810823])
+                    elif runLumi['run_number'] == 2:
+                        self.assertItemsEqual(runLumi['lumis'], [1810823])
+                    else:
+                        raise AssertionError("This should never happen")
                 self.assertEqual(item['parents'], [])
             elif item['lfn'] == '/store/unmerged/fileB.root':
                 self.assertEqual(item['events'], 50)
                 self.assertItemsEqual(item['locations'], ['T1_US_FNAL_MSS'])
-                self.assertItemsEqual(item['runs'], [{'lumis': [1, 2, 3], 'run_number': 1},
-                                                     {'lumis': [4, 5, 6], 'run_number': 1},
-                                                     {'lumis': [9], 'run_number': 1}])
+                for runLumi in item['runs']:
+                    if runLumi['run_number'] == 1:
+                        self.assertItemsEqual(runLumi['lumis'], [1, 2, 3, 4, 5, 6, 9])
+                    elif runLumi['run_number'] == 7:
+                        self.assertItemsEqual(runLumi['lumis'], [7, 8])
+                    else:
+                        raise AssertionError("This should never happen")
                 self.assertItemsEqual(item['parents'], ['file1', 'file2', 'file3'])
-            elif item['lfn'] == '/store/unmerged/fileB.root':
+            elif item['lfn'] == '/store/unmerged/fileC.root':
                 self.assertEqual(item['events'], 10)
                 self.assertItemsEqual(item['locations'], ['T1_US_FNAL_Disk', 'T2_US_MIT'])
                 self.assertItemsEqual(item['runs'], [{'lumis': [111], 'run_number': 222}])


### PR DESCRIPTION
Fixes #9074 

When we need to create jobs using data from the ACDCServer, the JobSplitting algorithms are actually querying the ACDCServer again and fetching all that data, which will then be used in the job splitting factory.
With this patch, `DataCollectionService` will merge file/run/lumi information when possible and no duplicate lumi sections will be handed to the job splitting algorithm.

One thing is still not clear though, apparently we have all the necessary information already in WMBS (added when the workflow gets acquired by WorkQueueManager). So it seems we actually should NOT be fetching data from the ACDCServer at the job factory level.