### PR TITLE
Collect local and global WQE statistics when draining agent

### DIFF
--- a/src/couchapps/WMStats/_attachments/js/Views/HTMLList/WMStats.AgentDetailList.js
+++ b/src/couchapps/WMStats/_attachments/js/Views/HTMLList/WMStats.AgentDetailList.js
@@ -38,7 +38,9 @@ WMStats.namespace("AgentDetailList");
                               agentInfo.alert.agent_update  + "</li>";
             htmlstr += "<li><b>data last updated:</b> " + agentInfo.alert.data_update  + "</li>";
             htmlstr += "<li><b>status:</b> " + agentInfo.alert.message + "</li>";
-            htmlstr += "<li><b>team:</b> " + agentInfo.agent_team+ "</li>";
+            if (agentInfo.agent_team) {
+                htmlstr += "<li><b>team:</b> " + agentInfo.agent_team+ "</li>";
+            }
         };
         var componentsDown = agentInfo.down_components;
         if (componentsDown && (componentsDown.length > 0)) {
@@ -69,8 +71,21 @@ WMStats.namespace("AgentDetailList");
                 htmlstr += "<li>dbs open blocks (" + agentInfo.drain_stats.upload_status.dbs_open_blocks + ")</li>";
                 htmlstr += "<li>dbs not uploaded (" + agentInfo.drain_stats.upload_status.dbs_notuploaded + ")</li>";
                 htmlstr += "<li>phedex not uploaded (" + agentInfo.drain_stats.upload_status.phedex_notuploaded + ")</li>";
+                for (var key in agentInfo.drain_stats.global_wq_status) {
+                    htmlstr += "<li>global WQ in '" + key + "' status (" + agentInfo.drain_stats.global_wq_status[key] + ")</li>";
+                }
+                for (var key in agentInfo.drain_stats.local_wq_status) {
+                    htmlstr += "<li>local WQ in '" + key + "' status (" + agentInfo.drain_stats.local_wq_status[key] + ")</li>";
+                }
+                for (var key in agentInfo.drain_stats.local_wqinbox_status) {
+                    htmlstr += "<li>local WQInbox in '" + key + "' status (" + agentInfo.drain_stats.local_wqinbox_status[key] + ")</li>";
+                }
+                // only print job information that are != than 0
+                htmlstr += "<li>there are no wmbs jobs in the agent, except for...</li>";
                 for (var key in agentInfo.WMBS_INFO.wmbsCountByState) {
-                    htmlstr += "<li>jobs in '" + key + "' state (" + agentInfo.WMBS_INFO.wmbsCountByState[key] + ")</li>";
+                    if (agentInfo.WMBS_INFO.wmbsCountByState[key]) {
+                        htmlstr += "<li>  jobs in '" + key + "' state (" + agentInfo.WMBS_INFO.wmbsCountByState[key] + ")</li>";
+                    }
                 }
             }
             htmlstr += "</ul>"

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
@@ -2825,7 +2825,9 @@ WMStats.namespace("AgentDetailList");
                               agentInfo.alert.agent_update  + "</li>";
             htmlstr += "<li><b>data last updated:</b> " + agentInfo.alert.data_update  + "</li>";
             htmlstr += "<li><b>status:</b> " + agentInfo.alert.message + "</li>";
-            htmlstr += "<li><b>team:</b> " + agentInfo.agent_team+ "</li>";
+            if (agentInfo.agent_team) {
+                htmlstr += "<li><b>team:</b> " + agentInfo.agent_team+ "</li>";
+            }
         };
         var componentsDown = agentInfo.down_components;
         if (componentsDown && (componentsDown.length > 0)) {
@@ -2856,8 +2858,21 @@ WMStats.namespace("AgentDetailList");
                 htmlstr += "<li>dbs open blocks (" + agentInfo.drain_stats.upload_status.dbs_open_blocks + ")</li>";
                 htmlstr += "<li>dbs not uploaded (" + agentInfo.drain_stats.upload_status.dbs_notuploaded + ")</li>";
                 htmlstr += "<li>phedex not uploaded (" + agentInfo.drain_stats.upload_status.phedex_notuploaded + ")</li>";
+                for (var key in agentInfo.drain_stats.global_wq_status) {
+                    htmlstr += "<li>global WQ in '" + key + "' status (" + agentInfo.drain_stats.global_wq_status[key] + ")</li>";
+                }
+                for (var key in agentInfo.drain_stats.local_wq_status) {
+                    htmlstr += "<li>local WQ in '" + key + "' status (" + agentInfo.drain_stats.local_wq_status[key] + ")</li>";
+                }
+                for (var key in agentInfo.drain_stats.local_wqinbox_status) {
+                    htmlstr += "<li>local WQInbox in '" + key + "' status (" + agentInfo.drain_stats.local_wqinbox_status[key] + ")</li>";
+                }
+                // only print job information that are != than 0
+                htmlstr += "<li>there are no wmbs jobs in the agent, except for...</li>";
                 for (var key in agentInfo.WMBS_INFO.wmbsCountByState) {
-                    htmlstr += "<li>jobs in '" + key + "' state (" + agentInfo.WMBS_INFO.wmbsCountByState[key] + ")</li>";
+                    if (agentInfo.WMBS_INFO.wmbsCountByState[key]) {
+                        htmlstr += "<li>  jobs in '" + key + "' state (" + agentInfo.WMBS_INFO.wmbsCountByState[key] + ")</li>";
+                    }
                 }
             }
             htmlstr += "</ul>"

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
@@ -2968,7 +2968,9 @@ WMStats.namespace("AgentDetailList");
                               agentInfo.alert.agent_update  + "</li>";
             htmlstr += "<li><b>data last updated:</b> " + agentInfo.alert.data_update  + "</li>";
             htmlstr += "<li><b>status:</b> " + agentInfo.alert.message + "</li>";
-            htmlstr += "<li><b>team:</b> " + agentInfo.agent_team+ "</li>";
+            if (agentInfo.agent_team) {
+                htmlstr += "<li><b>team:</b> " + agentInfo.agent_team+ "</li>";
+            }
         };
         var componentsDown = agentInfo.down_components;
         if (componentsDown && (componentsDown.length > 0)) {
@@ -2999,8 +3001,21 @@ WMStats.namespace("AgentDetailList");
                 htmlstr += "<li>dbs open blocks (" + agentInfo.drain_stats.upload_status.dbs_open_blocks + ")</li>";
                 htmlstr += "<li>dbs not uploaded (" + agentInfo.drain_stats.upload_status.dbs_notuploaded + ")</li>";
                 htmlstr += "<li>phedex not uploaded (" + agentInfo.drain_stats.upload_status.phedex_notuploaded + ")</li>";
+                for (var key in agentInfo.drain_stats.global_wq_status) {
+                    htmlstr += "<li>global WQ in '" + key + "' status (" + agentInfo.drain_stats.global_wq_status[key] + ")</li>";
+                }
+                for (var key in agentInfo.drain_stats.local_wq_status) {
+                    htmlstr += "<li>local WQ in '" + key + "' status (" + agentInfo.drain_stats.local_wq_status[key] + ")</li>";
+                }
+                for (var key in agentInfo.drain_stats.local_wqinbox_status) {
+                    htmlstr += "<li>local WQInbox in '" + key + "' status (" + agentInfo.drain_stats.local_wqinbox_status[key] + ")</li>";
+                }
+                // only print job information that are != than 0
+                htmlstr += "<li>there are no wmbs jobs in the agent, except for...</li>";
                 for (var key in agentInfo.WMBS_INFO.wmbsCountByState) {
-                    htmlstr += "<li>jobs in '" + key + "' state (" + agentInfo.WMBS_INFO.wmbsCountByState[key] + ")</li>";
+                    if (agentInfo.WMBS_INFO.wmbsCountByState[key]) {
+                        htmlstr += "<li>  jobs in '" + key + "' state (" + agentInfo.WMBS_INFO.wmbsCountByState[key] + ")</li>";
+                    }
                 }
             }
             htmlstr += "</ul>"

--- a/src/python/WMComponent/AgentStatusWatcher/DrainStatusAPI.py
+++ b/src/python/WMComponent/AgentStatusWatcher/DrainStatusAPI.py
@@ -5,14 +5,18 @@ API for querying the status of agent drain process
 from __future__ import division
 from WMComponent.DBS3Buffer.DBSBufferUtil import DBSBufferUtil
 from WMCore.Services.PyCondor.PyCondorAPI import PyCondorAPI
+from WMCore.WorkQueue.WorkQueueBackend import WorkQueueBackend
 
 
 class DrainStatusAPI(object):
     """
     Provides methods for querying dbs and condor for drain statistics
     """
-    def __init__(self):
-
+    def __init__(self, config):
+        # queue url used in WorkQueueManager
+        self.thisAgentUrl = "http://" + config.Agent.hostName + ":5984"
+        self.globalBackend = WorkQueueBackend(config.WorkloadSummary.couchurl)
+        self.localBackend = WorkQueueBackend(config.WorkQueueManager.couchurl)
         self.dbsUtil = DBSBufferUtil()
         self.condorAPI = PyCondorAPI()
 
@@ -27,6 +31,9 @@ class DrainStatusAPI(object):
         if results['workflows_completed']:
             results['upload_status'] = self.checkFileUploadStatus()
             results['condor_status'] = self.checkCondorStates()
+            results['local_wq_status'] = self.checkLocalWQStatus(dbname="workqueue")
+            results['local_wqinbox_status'] = self.checkLocalWQStatus(dbname="workqueue_inbox")
+            results['global_wq_status'] = self.checkGlobalWQStatus()
 
         return results
 
@@ -65,4 +72,32 @@ class DrainStatusAPI(object):
         results['dbs_open_blocks'] = self.dbsUtil.countOpenBlocks()
         results['dbs_notuploaded'] = self.dbsUtil.countFilesByStatus(status="NOTUPLOADED")
         results['phedex_notuploaded'] = self.dbsUtil.countPhedexNotUploaded()
+        return results
+
+    def checkLocalWQStatus(self, dbname):
+        """
+        Query local WorkQueue workqueue/workqueue_inbox database to see whether
+        there are any active elements in this agent.
+        """
+        results = {}
+
+        for st in ('Available', 'Negotiating', 'Acquired', 'Running'):
+            if dbname == "workqueue":
+                elements = self.localBackend.getElements(status=st, returnIdOnly=True)
+            else:
+                elements = self.localBackend.getInboxElements(status=st, returnIdOnly=True)
+            results[st] = len(elements)
+        return results
+
+    def checkGlobalWQStatus(self):
+        """
+        Query Global WorkQueue workqueue database to see whether there are
+        any active elements set to this agent.
+        """
+        results = {}
+
+        for st in ("Acquired", "Running"):
+            elements = self.globalBackend.getElements(status=st, returnIdOnly=True,
+                                                      ChildQueueUrl=self.thisAgentUrl)
+            results[st] = len(elements)
         return results

--- a/src/python/WMComponent/AgentStatusWatcher/DrainStatusPoller.py
+++ b/src/python/WMComponent/AgentStatusWatcher/DrainStatusPoller.py
@@ -27,7 +27,7 @@ class DrainStatusPoller(BaseWorkerThread):
         """
         BaseWorkerThread.__init__(self)
         self.config = config
-        self.drainAPI = DrainStatusAPI()
+        self.drainAPI = DrainStatusAPI(config)
         self.condorAPI = PyCondorAPI()
         self.agentConfig = {}
         self.validSpeedDrainConfigKeys = ['CondorPriority', 'NoJobRetries', 'EnableAllSites']
@@ -51,6 +51,7 @@ class DrainStatusPoller(BaseWorkerThread):
             if thresholdsHit:
                 logging.info("Updating agent configuration for speed drain...")
                 self.updateAgentSpeedDrainConfig(thresholdsHit)
+            # now collect drain statistics
             try:
                 DrainStatusPoller.drainStats = self.drainAPI.collectDrainInfo()
                 logging.info("Finished collecting agent drain status.")


### PR DESCRIPTION
Fixes #9076

Actually it doesn't fix, but it will at least refrain an agent from being redeployed when it should not.
Changes are:
* when running the drain status cycle, query global workqueue for active elements in the agent being drained
* also check the local workqueue and workqueue_inbox for any active element
* show this information in WMStats
* do not show wmbs job summary in WMStats, unless there are actual jobs in the agent in a given state.
* do not show `team` in WMStats unless the agent has this property (reqmgr2, wmstats, etc do not)