### PR TITLE
Update AMQ broker/port

### DIFF
--- a/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
+++ b/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
@@ -54,7 +54,7 @@ class AgentStatusPoller(BaseWorkerThread):
         self.passAMQ = getattr(config.AgentStatusWatcher, "passAMQ", None)
         self.postToAMQ = getattr(config.AgentStatusWatcher, "enableAMQ", False)
         self.topicAMQ = getattr(config.AgentStatusWatcher, "topicAMQ", None)
-        self.hostPortAMQ = getattr(config.AgentStatusWatcher, "hostPortAMQ", [('dashb-mb.cern.ch', 61113)])
+        self.hostPortAMQ = getattr(config.AgentStatusWatcher, "hostPortAMQ", [('cms-mb.cern.ch', 61313)])
 
         # T0 doesn't have WorkQueue, so some monitoring/replication code has to be skipped here
         if hasattr(self.config, "Tier0Feeder"):


### PR DESCRIPTION
There were a few complaints from CERN IT about T0 using the old broker. So let's update these default values until we can finally migrate to CMSMonitoring schema.