### PR TITLE
Initial Rucio Service class with basic functionality

### DIFF
--- a/src/python/WMCore/Services/PhEDEx/PhEDEx.py
+++ b/src/python/WMCore/Services/PhEDEx/PhEDEx.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import sys
 from xml.dom.minidom import parseString
 
 from WMCore.Services.PhEDEx import XMLDrop
@@ -29,10 +28,6 @@ class PhEDEx(Service):
         if 'endpoint' not in httpDict:
             httpDict['endpoint'] = "https://cmsweb.cern.ch/phedex/datasvc/%s/prod/" % self.responseType
         httpDict.setdefault('cacheduration', 0)
-
-        for item in sys.path:
-            if 'rucio' in item:
-                print "AMR PATH: %s" % item
 
         Service.__init__(self, httpDict)
 

--- a/src/python/WMCore/Services/PhEDEx/PhEDEx.py
+++ b/src/python/WMCore/Services/PhEDEx/PhEDEx.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import sys
 from xml.dom.minidom import parseString
 
 from WMCore.Services.PhEDEx import XMLDrop
@@ -28,6 +29,10 @@ class PhEDEx(Service):
         if 'endpoint' not in httpDict:
             httpDict['endpoint'] = "https://cmsweb.cern.ch/phedex/datasvc/%s/prod/" % self.responseType
         httpDict.setdefault('cacheduration', 0)
+
+        for item in sys.path:
+            if 'rucio' in item:
+                print "AMR PATH: %s" % item
 
         Service.__init__(self, httpDict)
 

--- a/src/python/WMCore/Services/Rucio/Rucio.py
+++ b/src/python/WMCore/Services/Rucio/Rucio.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python
+# coding=utf-8
+"""
+Rucio Service class developed on top of the native Rucio Client
+APIs providing custom output and handling as necessary for the
+CMS Workload Management system (and migration from PhEDEx).
+"""
+from __future__ import division, print_function, absolute_import
+
+import logging
+
+from rucio.client import Client
+from rucio.common.exception import AccountNotFound, DataIdentifierNotFound
+
+from WMCore.WMException import WMException
+
+
+class WMRucioException(WMException):
+    """
+    _WMRucioException_
+    Generic WMCore exception for Rucio
+    """
+    pass
+
+
+class Rucio(object):
+    """
+    Service class providing additional Rucio functionality on top of the
+    Rucio client APIs.
+    """
+
+    def __init__(self, acct, hostUrl=None, authUrl=None, configDict=None):
+        """
+        Constructs a Rucio object with the Client object embedded.
+        In order to instantiate a Rucio Client object, it assumes the host has
+        a proper rucio configuration file, where the default host and authentication
+        host URL come from, as well as the X509 certificate information.
+        :param acct: rucio account to be used
+        :param hostUrl: defaults to the rucio config one
+        :param authUrl: defaults to the rucio config one
+        :param configDict: dictionary with extra parameters
+        """
+        configDict = configDict or {}
+        params = configDict.copy()
+        params.setdefault('ca_cert', None)
+        params.setdefault('auth_type', None)
+        params.setdefault('creds', None)
+        params.setdefault('timeout', 600)
+        params.setdefault('user_agent', 'wmcore-client')
+
+        self.logger = params.get("logger", logging.getLogger())
+        # yield output compatible with the PhEDEx service class
+        self.phedexCompat = params.get("phedexCompatible", True)
+
+        msg = "WMCore Rucio initialization with acct: %s, host: %s, auth: %s" % (acct, hostUrl, authUrl)
+        msg += " and these extra parameters: %s" % params
+        self.logger.info(msg)
+        self.cli = Client(rucio_host=hostUrl, auth_host=authUrl, account=acct,
+                          ca_cert=params['ca_cert'], auth_type=params['auth_type'],
+                          creds=params['creds'], timeout=params['timeout'],
+                          user_agent=params['user_agent'])
+        clientParams = {}
+        for k in ("host", "auth_host", "auth_type", "account", "user_agent",
+                  "ca_cert", "creds", "timeout", "request_retries"):
+            clientParams[k] = getattr(self.cli, k)
+        self.logger.info("Rucio client initialization with: %s", clientParams)
+
+    def pingServer(self):
+        """
+        _pingServer_
+
+        Ping the rucio server to see whether it's alive
+        :return: a dict with the server version
+        """
+        return self.cli.ping()
+
+    def whoAmI(self):
+        """
+        _whoAmI_
+
+        Get information about account whose token is used
+        :return: a dict with the account information. None in case of failure
+        """
+        return self.cli.whoami()
+
+    def getAccount(self, acct):
+        """
+        _getAccount_
+
+        Gets information about a specific account
+        :return: a dict with the account information. None in case of failure
+        """
+        try:
+            res = self.cli.get_account(acct)
+        except AccountNotFound as ex:
+            self.logger.error("Failed to get account information from Rucio. Error: %s", str(ex))
+            res = None
+        return res
+
+    def getBlocksInContainer(self, container, scope='cms'):
+        """
+        _getBlocksInContainer_
+
+        Provided a Rucio container - CMS dataset - retrieve all blocks in it.
+        :param container: a CMS dataset string
+        :param scope: string containing the Rucio scope (defaults to 'cms')
+        :return: a list of block names
+        """
+        blockNames = []
+        try:
+            response = self.cli.get_did(scope=scope, name=container)
+        except DataIdentifierNotFound:
+            self.logger.warning("Cannot find a data identifier for: %s", container)
+            return blockNames
+
+        if response['type'].upper() != 'CONTAINER':
+            # input container wasn't really a container
+            return blockNames
+
+        response = self.cli.list_content(scope=scope, name=container)
+        for item in response:
+            if item['type'].upper() == 'DATASET':
+                blockNames.append(item['name'])
+
+        return blockNames
+
+    def getReplicaInfoForBlocks(self, **kwargs):
+        """
+        _getReplicaInfoForBlocks_
+
+        Get block replica information.
+        It mimics the same API available in the PhEDEx Service module.
+
+        kwargs originally available for PhEDEx are:
+        - dataset       dataset name, can be multiple (*)
+        - block         block name, can be multiple (*)
+        - node          node name, can be multiple (*)
+        - se            storage element name, can be multiple (*)
+        - update_since  unix timestamp, only return replicas updated since this time
+        - create_since  unix timestamp, only return replicas created since this time
+        - complete      y or n, whether or not to require complete or incomplete blocks.
+                        Default is to return either
+        - subscribed    y or n, filter for subscription. default is to return either.
+        - custodial     y or n. filter for custodial responsibility.
+                        Default is to return either.
+        - group         group name. Default is to return replicas for any group.
+
+        kwargs supported by Rucio are:
+        - dids             The list of data identifiers (DIDs) like : [{'scope': <scope1>, 'name': <name1>},
+                           {'scope': <scope2>, 'name': <name2>}, ...]
+        - schemes          A list of schemes to filter the replicas. (e.g. file, http, ...)
+        - unavailable      Also include unavailable replicas in the list. Default to False
+        - metalink         False (default) retrieves as JSON, True retrieves as metalink4+xml.
+        - rse_expression   The RSE expression to restrict replicas on a set of RSEs.
+        - client_location  Client location dictionary for PFN modification {'ip', 'fqdn', 'site'}
+        - sort             Sort the replicas:
+                           geoip - based on src/dst IP topographical distance
+                           closeness - based on src/dst closeness
+                           dynamic - Rucio Dynamic Smart Sort (tm)
+        - domain           Define the domain. None is fallback to 'wan', otherwise 'wan', 'lan', or 'all'
+        - resolve_archives When set to True, find archives which contain the replicas.
+        - resolve_parents  When set to True, find all parent datasets which contain the replicas.
+
+        :kwargs: either a dataset or a block name has to be provided. Not both!
+        :return: a list of dictionaries with replica information; or a dictionary
+        compatible with PhEDEx.
+        """
+        kwargs.setdefault("scope", "cms")
+        kwargs.setdefault("deep", False)  # lookup at the file level, probably not needed...
+
+        blockNames = []
+        result = []
+
+        if isinstance(kwargs.get('block', None), (list, set)):
+            blockNames = kwargs['block']
+        elif 'block' in kwargs:
+            blockNames = [kwargs['block']]
+
+        # FIXME: make bulk requests once https://github.com/rucio/rucio/issues/2459 gets fixed
+        if isinstance(kwargs.get('dataset', None), (list, set)):
+            for datasetName in kwargs['dataset']:
+                blockNames.extend(self.getBlocksInContainer(datasetName, scope=kwargs['scope']))
+        elif 'dataset' in kwargs:
+            blockNames.extend(self.getBlocksInContainer(kwargs['dataset'], scope=kwargs['scope']))
+
+        for blockName in blockNames:
+            replicas = []
+            response = self.cli.list_dataset_replicas(kwargs['scope'], blockName,
+                                                      deep=kwargs['deep'])
+            for item in response:
+                # same as complete='y' used for PhEDEx (which is always set within WMCore)
+                if item['state'].upper() == 'AVAILABLE':
+                    replicas.append(item['rse'])
+            result.append({'name': blockName, 'replica': list(set(replicas))})
+
+        if self.phedexCompat:
+            # convert plain node list to list of nodes dict
+            for block in result:
+                replicas = []
+                for node in block['replica']:
+                    replicas.append({'node': node})
+                block['replica'] = replicas
+            result = {'phedex': {'block': result}}
+
+        return result
+
+    def getPFN(self, nodes=None, lfns=None, destination=None, protocol='srmv2', custodial='n'):
+        """
+        Copy of the method from the PhEDEx service class
+        Used by CRABServer
+        """
+        raise NotImplementedError("Apparently not available in the Rucio client as well")

--- a/test/python/WMCore_t/Services_t/CRIC_t/CRIC_t.py
+++ b/test/python/WMCore_t/Services_t/CRIC_t/CRIC_t.py
@@ -14,7 +14,7 @@ from WMQuality.Emulators.EmulatedUnitTestCase import EmulatedUnitTestCase
 
 class CRICTest(EmulatedUnitTestCase):
     """
-    Unit tests for SiteScreening module
+    Unit tests for CRIC Services module
     """
 
     def __init__(self, methodName='runTest'):

--- a/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
+++ b/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python
+"""
+Test case for Rucio WMCore Service class
+"""
+from __future__ import print_function, division, absolute_import
+
+import os
+from pprint import pprint
+
+from rucio.client import Client as testClient
+
+from WMCore.Services.Rucio.Rucio import Rucio
+from WMQuality.Emulators.EmulatedUnitTestCase import EmulatedUnitTestCase
+
+DSET = "/ttPhiS_M-100_2e_13TeV-madgraph/RunIIAutumn18NanoAOD-102X_upgrade2018_realistic_v15-v2/NANOAODSIM"
+BLOCK = "/ttPhiS_M-100_2e_13TeV-madgraph/RunIIAutumn18NanoAOD-102X_upgrade2018_realistic_v15-v2/NANOAODSIM#0f591ca9-341b-46b5-84f3-908e6f9229e6"
+
+
+class RucioTest(EmulatedUnitTestCase):
+    """
+    Unit tests for Rucio Service module
+    """
+
+    def __init__(self, methodName='runTest'):
+        # TODO figure out what's going on with CRIC mock
+        super(RucioTest, self).__init__(methodName=methodName, mockCRIC=False)
+
+        ### FIXME remove this debugging
+        rucioCfg = os.getenv("RUCIO_HOME", None)
+        print("AMR RUCIO_HOME: %s" % rucioCfg)
+        with open("%s/etc/rucio.cfg" % rucioCfg) as fo:
+            pprint(fo.readlines())
+
+        self.acct = "wmagent_testing"
+
+        # HACK: do not verify the SSL certificate because docker images
+        # do not contain the CA certificate bundle
+        # Relying on the config file in the jenkins infrastructure is a PITA
+        # so let's make sure to pass all the necessary arguments
+        self.creds = {"client_cert": os.getenv("X509_USER_CERT", "Unknown"),
+                      "client_key": os.getenv("X509_USER_KEY", "Unknown")}
+
+        self.defaultArgs = {"host": 'http://cms-rucio-dev.cern.ch',
+                            "auth_host": 'https://cms-rucio-auth-dev.cern.ch',
+                            "auth_type": "x509", "account": self.acct,
+                            "ca_cert": False, "timeout": 30, "request_retries": 3,
+                            "creds": self.creds}
+
+    def setUp(self):
+        """
+        Setup for unit tests
+        """
+        super(RucioTest, self).setUp()
+
+        self.myRucio = Rucio(self.acct,
+                             hostUrl=self.defaultArgs['host'],
+                             authUrl=self.defaultArgs['auth_host'],
+                             configDict=self.defaultArgs)
+
+        self.client = testClient(rucio_host=self.defaultArgs['host'],
+                                 auth_host=self.defaultArgs['auth_host'],
+                                 account=self.acct,
+                                 ca_cert=self.defaultArgs['ca_cert'],
+                                 auth_type=self.defaultArgs['auth_type'],
+                                 creds=self.defaultArgs['creds'],
+                                 timeout=self.defaultArgs['timeout'])
+
+    def tearDown(self):
+        """
+        Nothing to be done for this case
+        """
+        pass
+
+    def testConfig(self):
+        """
+        Test service attributes and the override mechanism
+        """
+        for key in self.defaultArgs:
+            self.assertEqual(getattr(self.myRucio.cli, key), self.defaultArgs[key])
+        self.assertTrue(getattr(self.myRucio.cli, "user_agent").startswith("wmcore-client/"))
+        self.assertTrue(getattr(self.client, "user_agent").startswith("rucio-clients/"))
+
+        newParams = {"host": 'http://cms-rucio-dev.cern.ch',
+                     "auth_host": 'https://cms-rucio-auth-dev.cern.ch',
+                     "auth_type": "x509", "account": self.acct,
+                     "ca_cert": False, "timeout": 5, "phedexCompatible": False}
+        newKeys = newParams.keys()
+        newKeys.remove("phedexCompatible")
+
+        rucio = Rucio(newParams['account'], hostUrl=newParams['host'],
+                      authUrl=newParams['auth_host'], configDict=newParams)
+
+        self.assertEqual(getattr(rucio, "phedexCompat"), False)
+        for key in newKeys:
+            self.assertEqual(getattr(rucio.cli, key), newParams[key])
+
+    def testGetAccount(self):
+        """
+        Test whether we can fetch data about a specific rucio account
+        """
+        res = self.client.get_account(self.acct)
+        res2 = self.myRucio.getAccount(self.acct)
+        self.assertEqual(res['account'], self.acct)
+        self.assertEqual(res['status'], "ACTIVE")
+        self.assertEqual(res['account_type'], "USER")
+        self.assertTrue({"status", "account", "account_type"}.issubset(set(res2.keys())))
+        self.assertTrue({self.acct, "ACTIVE", "USER"}.issubset(set(res2.values())))
+
+    # @attr('integration')
+    def testWhoAmI(self):
+        """
+        Test user mapping information from the request headers
+        """
+        res = dict(self.client.whoami())
+        res2 = dict(self.myRucio.whoAmI())
+        self.assertTrue({"status", "account"}.issubset(set(res.keys())))
+        self.assertTrue(set(res.keys()) == set(res2.keys()))
+
+    def testPing(self):
+        """
+        Tests server ping
+        """
+        res = self.client.ping()
+        res2 = self.myRucio.pingServer()
+        self.assertTrue("version" in res)
+        self.assertItemsEqual(res, res2)
+
+    def testGetBlocksInContainer(self):
+        """
+        Test `getBlocksInContainer` method, the ability to retrieve blocks
+        inside a container.
+        """
+        # test a CMS dataset that does not exist
+        res = self.myRucio.getBlocksInContainer("Alan")
+        self.assertEqual(res, [])
+
+        # provide a CMS block instead of a dataset
+        res = self.myRucio.getBlocksInContainer(BLOCK)
+        self.assertEqual(res, [])
+
+        # finally provide a real CMS dataset
+        res = self.myRucio.getBlocksInContainer(DSET)
+        self.assertTrue(len(res) >= len([BLOCK]))
+        self.assertIn(BLOCK, res)
+
+    def testGetReplicaInfoForBlocks(self):
+        """
+        Test `getReplicaInfoForBlocks` method, the ability to retrieve replica
+        locations provided a dataset or block. Same output as PhEDEx.
+        """
+        res = self.myRucio.getReplicaInfoForBlocks(block=BLOCK)
+        self.assertEqual(len(res['phedex']['block']), 1)
+        block = res['phedex']['block'].pop()
+        self.assertEqual(block['name'], BLOCK)
+        replicas = [item['node'] for item in block['replica']]
+        self.assertTrue(len(replicas) > 0)
+
+        # same test, but providing a dataset as input (which has 4 blocks)
+        res = self.myRucio.getReplicaInfoForBlocks(dataset=DSET)
+        self.assertEqual(len(res['phedex']['block']), 1)
+        blocks = [item['name'] for item in res['phedex']['block']]
+        self.assertTrue(BLOCK in blocks)
+        for item in res['phedex']['block']:
+            self.assertTrue(len(item['replica']) > 0)
+
+    def testGetReplicaInfoForBlocksRucio(self):
+        """
+        Test `getReplicaInfoForBlocks` method, however not using
+        the output compatibility with PhEDEx
+        """
+        theseArgs = self.defaultArgs.copy()
+        theseArgs['phedexCompatible'] = False
+        myRucio = Rucio(self.acct,
+                        hostUrl=theseArgs['host'],
+                        authUrl=theseArgs['auth_host'],
+                        configDict=theseArgs)
+
+        res = myRucio.getReplicaInfoForBlocks(dataset=DSET)
+        self.assertTrue(isinstance(res, list))
+        self.assertEqual(len(res), 1)
+        blocks = [item['name'] for item in res]
+        self.assertTrue(BLOCK in blocks)
+        for item in res:
+            self.assertTrue(len(item['replica']) > 0)
+
+    def testGetPFN(self):
+        """
+        Test `getPFN` method
+        """
+        self.assertRaises(NotImplementedError, self.myRucio.getPFN)

--- a/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
+++ b/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
@@ -12,8 +12,8 @@ from rucio.client import Client as testClient
 from WMCore.Services.Rucio.Rucio import Rucio
 from WMQuality.Emulators.EmulatedUnitTestCase import EmulatedUnitTestCase
 
-DSET = "/ttPhiS_M-100_2e_13TeV-madgraph/RunIIAutumn18NanoAOD-102X_upgrade2018_realistic_v15-v2/NANOAODSIM"
-BLOCK = "/ttPhiS_M-100_2e_13TeV-madgraph/RunIIAutumn18NanoAOD-102X_upgrade2018_realistic_v15-v2/NANOAODSIM#0f591ca9-341b-46b5-84f3-908e6f9229e6"
+DSET = "/SingleElectron/Run2017F-17Nov2017-v1/MINIAOD"
+BLOCK = "/SingleElectron/Run2017F-17Nov2017-v1/MINIAOD#f924e248-e029-11e7-aa2a-02163e01b396"
 
 
 class RucioTest(EmulatedUnitTestCase):
@@ -24,12 +24,6 @@ class RucioTest(EmulatedUnitTestCase):
     def __init__(self, methodName='runTest'):
         # TODO figure out what's going on with CRIC mock
         super(RucioTest, self).__init__(methodName=methodName, mockCRIC=False)
-
-        ### FIXME remove this debugging
-        rucioCfg = os.getenv("RUCIO_HOME", None)
-        print("AMR RUCIO_HOME: %s" % rucioCfg)
-        with open("%s/etc/rucio.cfg" % rucioCfg) as fo:
-            pprint(fo.readlines())
 
         self.acct = "wmagent_testing"
 
@@ -157,7 +151,7 @@ class RucioTest(EmulatedUnitTestCase):
 
         # same test, but providing a dataset as input (which has 4 blocks)
         res = self.myRucio.getReplicaInfoForBlocks(dataset=DSET)
-        self.assertEqual(len(res['phedex']['block']), 1)
+        self.assertTrue(len(res['phedex']['block']) >= 1)  # at this very moment, there are 11 replicas
         blocks = [item['name'] for item in res['phedex']['block']]
         self.assertTrue(BLOCK in blocks)
         for item in res['phedex']['block']:
@@ -177,7 +171,7 @@ class RucioTest(EmulatedUnitTestCase):
 
         res = myRucio.getReplicaInfoForBlocks(dataset=DSET)
         self.assertTrue(isinstance(res, list))
-        self.assertEqual(len(res), 1)
+        self.assertTrue(len(res) >= 1)  # at this very moment, there are 11 replicas
         blocks = [item['name'] for item in res]
         self.assertTrue(BLOCK in blocks)
         for item in res:


### PR DESCRIPTION
Fixes #8796 

Summary of changes are:
* added some basic methods just to test communication between client and server
* added API to list blocks present in a Rucio container
* added API to retrieve block replicas (still need a fine tuning)

The last 2 APIs were basically copied from an example pointed out by Eric, here:
https://github.com/dmwm/CMSRucio/blob/3793a0b3f8ed1c0541427060fda81e5cd84d6c47/docker/CMSRucioClient/scripts/CMSRucio.py#L128

I'm still figuring out how to test it; a) which datasets are available in Rucio db; b) getting rucio-clients in the unit tests docker image; and c) finally compare output against PhEDEx