### PR TITLE
Change RSS to PSS in Performance Monitor

### DIFF
--- a/src/python/WMCore/WMExceptions.py
+++ b/src/python/WMCore/WMExceptions.py
@@ -153,7 +153,7 @@ WM_JOB_ERROR_CODES = {-1: "Error return without specification.",
                       50115: "cmsRun did not produce a valid job report at runtime (often means cmsRun segfaulted).",  # (WMA, CRAB3)
                       50116: "Could not determine exit code of cmsRun executable at runtime.",  # (WMA)
                       50513: "Failure to run SCRAM setup scripts.",  # (WMA, CRAB3)
-                      50660: "Application terminated by wrapper because using too much RAM (RSS).",  # (WMA, CRAB3)
+                      50660: "Application terminated by wrapper because using too much RAM (PSS).",  # (WMA, CRAB3)
                       50662: "Application terminated by wrapper because using too much disk.",  # (CRAB3)
                       50664: "Application terminated by wrapper because using too much Wall Clock time.",  # (WMA, CRAB3)
                       50665: "Application terminated by wrapper because it stay idle too long.",  # (CRAB3)

--- a/src/python/WMCore/WMRuntime/Watchdog.py
+++ b/src/python/WMCore/WMRuntime/Watchdog.py
@@ -87,21 +87,21 @@ class Watchdog(threading.Thread):
                     sh = task.getStepHelper(stepName)
                     origCores = max(origCores, sh.getNumberOfCores())
                 resources = {'cores': origCores}
-                origMaxRSS = args.get('maxRSS')
-                if origMaxRSS:
-                    resources['memory'] = origMaxRSS
+                origMaxPSS = args.get('maxPSS', args.get('maxRSS'))
+                if origMaxPSS:
+                    resources['memory'] = origMaxPSS
                 # Actually parses the HTCondor runtime
                 resizeResources(resources)
                 # We decided to only touch Watchdog settings if the number of cores changed.
                 # (even if this means the watchdog memory is wrong for a slot this size).
                 changedCores = origCores != resources['cores']
-                # If we did base maxRSS off the memory in the HTCondor slot, subtract a bit
+                # If we did base maxPSS off the memory in the HTCondor slot, subtract a bit
                 # off the top so watchdog triggers before HTCondor does.
                 # Add the new number of cores to the args such that DashboardInterface can see it
                 args['cores'] = resources['cores']
                 if changedCores:
-                    if origMaxRSS:
-                        args['maxRSS'] = resources['memory'] - 50
+                    if origMaxPSS:
+                        args['maxPSS'] = resources['memory'] - 50
 
                 logging.info("Watchdog modified: %s. Final settings:", changedCores)
                 for k, v in args.iteritems():

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -225,7 +225,7 @@ class StdBase(object):
         Memory settings are defined in Megabytes and timing in seconds.
         """
         # Default settings defined by CMS policy
-        maxrss = 2.3 * 1024  # 2.3 GiB, but in MiB
+        maxpss = 2.3 * 1024  # 2.3 GiB, but in MiB
         softTimeout = 47 * 3600  # 47h
         hardTimeout = 47 * 3600 + 5 * 60  # 47h + 5 minutes
 
@@ -236,7 +236,7 @@ class StdBase(object):
         monitoring.DashboardMonitor.destinationHost = self.dashboardHost
         monitoring.DashboardMonitor.destinationPort = self.dashboardPort
         monitoring.section_("PerformanceMonitor")
-        monitoring.PerformanceMonitor.maxRSS = maxrss
+        monitoring.PerformanceMonitor.maxPSS = maxpss
         monitoring.PerformanceMonitor.softTimeout = softTimeout
         monitoring.PerformanceMonitor.hardTimeout = hardTimeout
         return task

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -580,8 +580,8 @@ class WMTaskHelper(TreeHelper):
             performanceParams.sizePerEvent = sizePerEvent or getattr(performanceParams, "sizePerEvent")
         if memoryReq or getattr(performanceParams, "memoryRequirement", None):
             performanceParams.memoryRequirement = memoryReq or getattr(performanceParams, "memoryRequirement")
-            # if we change memory requirements, then we must change MaxRSS as well
-            self.setMaxRSS(performanceParams.memoryRequirement)
+            # if we change memory requirements, then we must change MaxPSS as well
+            self.setMaxPSS(performanceParams.memoryRequirement)
 
         return
 
@@ -1196,25 +1196,25 @@ class WMTaskHelper(TreeHelper):
             self.monitoring.section_("PerformanceMonitor")
         return
 
-    def setMaxRSS(self, maxRSS):
+    def setMaxPSS(self, maxPSS):
         """
-        _setMaxRSS_
+        _setMaxPSS_
 
-        Set MaxRSS performance monitoring for this task.
-        :param maxRSS: maximum RSS memory comsumption in MiB
+        Set MaxPSS performance monitoring for this task.
+        :param maxPSS: maximum Proportional Set Size (PSS) memory consumption in MiB
         """
         if self.taskType() in ["Merge", "Cleanup", "LogCollect"]:
             # keep the default settings (from StdBase) for these task types
             return
 
-        if isinstance(maxRSS, dict):
-            maxRSS = maxRSS.get(self.name(), None)
+        if isinstance(maxPSS, dict):
+            maxPSS = maxPSS.get(self.name(), None)
 
-        if maxRSS:
+        if maxPSS:
             self._setPerformanceMonitorConfig()
-            self.monitoring.PerformanceMonitor.maxRSS = int(maxRSS)
+            self.monitoring.PerformanceMonitor.maxPSS = int(maxPSS)
             for task in self.childTaskIterator():
-                task.setMaxRSS(maxRSS)
+                task.setMaxPSS(maxPSS)
         return
 
     def setPerformanceMonitor(self, softTimeout=None, gracePeriod=None):

--- a/test/python/WMCore_t/WMSpec_t/WMTask_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMTask_t.py
@@ -411,7 +411,7 @@ class WMTaskTest(unittest.TestCase):
                                        gracePeriod=1)
 
         self.assertEqual(testTask.data.watchdog.monitors, ['PerformanceMonitor'])
-        self.assertFalse(hasattr(testTask.data.watchdog.PerformanceMonitor, "maxRSS"))
+        self.assertFalse(hasattr(testTask.data.watchdog.PerformanceMonitor, "maxPSS"))
         self.assertEqual(testTask.data.watchdog.PerformanceMonitor.softTimeout, 100)
         self.assertEqual(testTask.data.watchdog.PerformanceMonitor.hardTimeout, 101)
         return
@@ -630,19 +630,19 @@ class WMTaskTest(unittest.TestCase):
 
         return
 
-    def testMaxRSS(self):
+    def testMaxPSS(self):
         """
-        _testMaxRSS_
+        _testMaxPSS_
 
-        Test whether we can properly add MaxRSS performance monitor
+        Test whether we can properly add MaxPSS performance monitor
         to this task.
         """
         testTask = makeWMTask("TestTask")
 
-        testTask.setMaxRSS(123)
+        testTask.setMaxPSS(123)
 
         self.assertEqual(testTask.data.watchdog.monitors, ['PerformanceMonitor'])
-        self.assertEqual(testTask.data.watchdog.PerformanceMonitor.maxRSS, 123)
+        self.assertEqual(testTask.data.watchdog.PerformanceMonitor.maxPSS, 123)
         return
 
     def testGetSwVersionAndScramArch(self):

--- a/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
@@ -1606,7 +1606,7 @@ class WMWorkloadTest(unittest.TestCase):
         mergeTask.setTaskType("Merge")
 
         testWorkload.setupPerformanceMonitoring(softTimeout=100, gracePeriod=1)
-        self.assertFalse(hasattr(testWorkload.data.tasks.ProcessingTask.watchdog.PerformanceMonitor, "maxRSS"))
+        self.assertFalse(hasattr(testWorkload.data.tasks.ProcessingTask.watchdog.PerformanceMonitor, "maxPSS"))
         self.assertEqual(testWorkload.data.tasks.ProcessingTask.watchdog.PerformanceMonitor.softTimeout, 100)
         self.assertEqual(testWorkload.data.tasks.ProcessingTask.watchdog.PerformanceMonitor.hardTimeout, 101)
         self.assertTrue(hasattr(testWorkload.data.tasks.ProcessingTask.tree.children.MergeTask, 'watchdog'))


### PR DESCRIPTION
Fixes #8498
References to RSS have been updated to PSS in PerformanceMonitor.  There are lots of other refs around in WMTask, StdBase, Watchdog and the WMTask unit tests.  I'd like to give the PerformanceMonitor changes a test, then work on updating the other references.