### PR TITLE
Add rucio variables to the unittest setup

### DIFF
--- a/src/python/WMCore/WMInit.py
+++ b/src/python/WMCore/WMInit.py
@@ -14,6 +14,7 @@ from __future__ import print_function
 import logging
 import threading
 import traceback
+import os
 
 from WMCore.DAOFactory import DAOFactory
 from WMCore.Database.DBFactory import DBFactory
@@ -140,6 +141,11 @@ class WMInit:
         # it here.
         myThread.transaction = Transaction(myThread.dbi)
         myThread.transaction.commit()
+
+        # FIXME: REMOVE IT - debugging which RUCIO_HOME is used in the unit tests
+        var = os.getenv("RUCIO_HOME", None)
+        print("AMR RUCIO_HOME points to: %s" % var)
+
         return
 
     def setSchema(self, modules = [], params = None):
@@ -174,7 +180,7 @@ class WMInit:
                 logging.debug("Tables " + factoryName + " could not be created.")
         myThread.transaction.commit()
 
-    def clearDatabase(self, modules = []):
+    def clearDatabase(self, modules=None):
         """
         Database deletion. Global, ignore modules.
         """

--- a/test/deploy/WMAgent_unittest.secrets
+++ b/test/deploy/WMAgent_unittest.secrets
@@ -4,3 +4,6 @@ COUCH_USER=unittestagent
 COUCH_PASS=passwd
 COUCH_PORT=6994
 COUCH_HOST=0.0.0.0
+RUCIO_ACCOUNT="wmagent_testing"
+RUCIO_HOST=http://cms-rucio-testbed.cern.ch
+RUCIO_AUTH=https://cms-rucio-tb-authz.cern.ch

--- a/test/deploy/env_unittest.sh
+++ b/test/deploy/env_unittest.sh
@@ -41,6 +41,8 @@ export X509_USER_KEY=$CERT_DIR/servicekey.pem
 export install=$INSTALL_DIR/current/install/wmagent
 export config=$INSTALL_DIR/current/config/wmagent
 export manage=$config/manage
+export WMAGENT_USE_CRIC=true
+export RUCIO_HOME=$config/../rucio/
 
 source $INSTALL_DIR/current/apps/wmagent/etc/profile.d/init.sh
 source $INSTALL_DIR/current/apps/wmcore-devtools/etc/profile.d/init.sh


### PR DESCRIPTION
After managing to build a new docker image and running it, I noticed I can't import rucio-clients stuff.
I guess this should fix that problem.