### PR TITLE
Perform lowering Cms headers

### DIFF
--- a/src/python/Utils/Utilities.py
+++ b/src/python/Utils/Utilities.py
@@ -8,6 +8,20 @@ import re
 import zlib
 import base64
 
+def lowerCmsHeaders(headers):
+    """
+    Lower CMS headers in provided header's dict. The WMCore Authentication
+    code check only cms headers in lower case, e.g. cms-xxx-yyy.
+    """
+    lheaders = {}
+    for hkey, hval in headers.items(): # perform lower-case
+        # lower header keys since we check lower-case in headers
+        if hkey.startswith('Cms-') or hkey.startswith('CMS-'):
+            lheaders[hkey.lower()] = hval
+        else:
+            lheaders[hkey] = hval
+    return lheaders
+
 def makeList(stringList):
     """
     _makeList_

--- a/src/python/WMCore/REST/Auth.py
+++ b/src/python/WMCore/REST/Auth.py
@@ -3,6 +3,7 @@ import hashlib
 import hmac
 import re
 
+from Utils.Utilities import lowerCmsHeaders
 
 def get_user_info():
     "Helper function to return user based information of the request"
@@ -15,7 +16,7 @@ def user_info_from_headers(key, verbose=False):
     returns user info object with the data from the headers."""
     # Set initial user information for this request
     log = cherrypy.log
-    headers = cherrypy.request.headers
+    headers = lowerCmsHeaders(cherrypy.request.headers)
     user = {'dn': None, 'method': None, 'login': None, 'name': None, 'roles': {}}
 
     # Reject if request was not authenticated.

--- a/src/python/WMCore/REST/Main.py
+++ b/src/python/WMCore/REST/Main.py
@@ -32,6 +32,7 @@ from cherrypy.lib import profiler
 ### Tools is needed for CRABServer startup: it sets up the tools attributes
 import WMCore.REST.Tools
 from WMCore.Configuration import ConfigSection, loadConfigurationFile
+from Utils.Utilities import lowerCmsHeaders
 
 #: Terminal controls to switch to "OK" status message colour.
 COLOR_OK = "\033[0;32m"
@@ -98,7 +99,7 @@ class Logger(LogManager):
         request = cherrypy.request
         remote = request.remote
         response = cherrypy.response
-        inheaders = request.headers
+        inheaders = lowerCmsHeaders(request.headers)
         outheaders = response.headers
         wfile = request.wsgi_environ.get('cherrypy.wfile', None)
         nout = (wfile and wfile.bytes_written) or outheaders.get('Content-Length', 0)
@@ -122,8 +123,8 @@ class Logger(LogManager):
                      and request.rfile.rfile.bytes_read) or "-",
                'b': nout or "-",
                'T': delta_time,
-               'AS': inheaders.get("CMS-Auth-Status", "-"),
-               'AU': inheaders.get("CMS-Auth-Cert", inheaders.get("CMS-Auth-Host", "")),
+               'AS': inheaders.get("cms-auth-status", "-"),
+               'AU': inheaders.get("cms-auth-cert", inheaders.get("cms-auth-host", "")),
                'AC': getattr(request.cookie.get("cms-auth", None), "value", ""),
                'f': inheaders.get("Referer", ""),
                'a': inheaders.get("User-Agent", "")}

--- a/src/python/WMCore/WebTools/FrontEndAuth.py
+++ b/src/python/WMCore/WebTools/FrontEndAuth.py
@@ -6,7 +6,7 @@ import hmac
 import cherrypy
 
 from WMCore.REST.Auth import get_user_info
-
+from Utils.Utilities import lowerCmsHeaders
 
 # -----------------------------------------------------------------------------
 class FrontEndAuth(cherrypy.Tool):
@@ -56,7 +56,7 @@ class FrontEndAuth(cherrypy.Tool):
     def check_authentication(self):
         """Read and verify the front-end headers, update the user
         dict with information about the authorized user."""
-        headers = cherrypy.request.headers
+        headers = lowerCmsHeaders(cherrypy.request.headers)
         user = cherrypy.request.user
 
         if 'cms-auth-status' not in headers:
@@ -87,7 +87,7 @@ class FrontEndAuth(cherrypy.Tool):
         vfy = hmac.new(self.key, prefix + "#" + suffix, hashlib.sha1).hexdigest()
         if vfy != headers["cms-authn-hmac"]:
             # HMAC does not match
-            raise cherrypy.HTTPError(403, "You are not allowed to access this resource.")
+            raise cherrypy.HTTPError(403, "You are not allowed to access this resource, hmac mismatch")
 
             # User authn accepted
 
@@ -110,7 +110,7 @@ class FrontEndAuth(cherrypy.Tool):
         # Finally checks if the user is allowed
         if not authzfunc(get_user_info(), role, group, site):
             # Authorization denied
-            raise cherrypy.HTTPError(403, "You are not allowed to access this resource.")
+            raise cherrypy.HTTPError(403, "You are not allowed to access this resource, authz denied")
 
     def defaultAuth(self, user, role, group, site):
         """ Return True for authorized user, False otherwise.

--- a/src/python/WMCore/WebTools/Root.py
+++ b/src/python/WMCore/WebTools/Root.py
@@ -33,6 +33,8 @@ from WMCore.WMFactory import WMFactory
 from WMCore.WebTools.FrontEndAuth import FrontEndAuth, NullAuth
 from WMCore.WebTools.Welcome import Welcome
 
+from Utils.Utilities import lowerCmsHeaders
+
 lastTest = ""
 
 
@@ -84,7 +86,7 @@ class WTLogger(LogManager):
         request = cherrypy.request
         remote = request.remote
         response = cherrypy.response
-        inheaders = request.headers
+        inheaders = lowerCmsHeaders(request.headers)
         outheaders = response.headers
         msg = ('%(t)s %(H)s %(h)s "%(r)s" %(s)s'
                + ' [data: - in %(b)s out %(T).0f us ]'
@@ -96,9 +98,9 @@ class WTLogger(LogManager):
                                                 's': response.status,
                                                 'b': outheaders.get('Content-Length', '') or "-",
                                                 'T': (time.time() - request.start_time) * 1e6,
-                                                'AS': inheaders.get("CMS-Auth-Status", "-"),
-                                                'AU': inheaders.get("CMS-Auth-Cert",
-                                                                    inheaders.get("CMS-Auth-Host", "")),
+                                                'AS': inheaders.get("cms-auth-status", "-"),
+                                                'AU': inheaders.get("cms-auth-cert",
+                                                                    inheaders.get("cms-auth-host", "")),
                                                 'AC': getattr(request.cookie.get("cms-auth", None), "value", ""),
                                                 'f': inheaders.get("Referer", ""),
                                                 'a': inheaders.get("User-Agent", "")}

--- a/test/python/Utils_t/Utilities_t.py
+++ b/test/python/Utils_t/Utilities_t.py
@@ -7,6 +7,7 @@ from __future__ import division, print_function
 
 import unittest
 from Utils.Utilities import makeList, makeNonEmptyList, strToBool, safeStr, rootUrlJoin, zipEncodeStr
+from Utils.Utilities import lowerCmsHeaders
 
 
 class UtilitiesTests(unittest.TestCase):
@@ -34,6 +35,17 @@ class UtilitiesTests(unittest.TestCase):
         self.assertRaises(ValueError, makeList, 123)
         self.assertRaises(ValueError, makeList, 123.456)
         self.assertRaises(ValueError, makeList, {1: 123})
+
+    def testLowerCmsHeaders(self):
+        "Test lowerCmsHeaders function"
+        val = 'cms-xx-yy'
+        headers = {'CAPITAL':1, 'Camel':1, 'Cms-Xx-Yy': val, 'CMS-XX-YY': val, 'cms-xx-yy': val}
+        lheaders = lowerCmsHeaders(headers)
+        self.assertEqual(sorted(lheaders.keys()), sorted(['CAPITAL', 'Camel', val]))
+        self.assertEqual(lheaders['CAPITAL'], 1)
+        self.assertEqual(lheaders['Camel'], 1)
+        self.assertEqual(lheaders[val], val)
+        self.assertEqual(len(lheaders.keys()), 3)
 
     def testMakeNonEmptyList(self):
         """


### PR DESCRIPTION
When testing WMCore code on k8s I found that Cms headers are passed as is, i.e. non lower-case, e.g.  Cms-Auth-Status. But Auth code expects all cms headers in lower-case format. Moreover we found that WMCore in some place also look at `CMS-Auth-XXX` header. To avoid all different type of capitalization of cms auth headers this patch performs lowering all Cms-XXX headers if they are present.

Alan pointed out that JavaScripts used with CouchDB use Camel-Case headers convention. But so far we didn't find any issues with that and therefore leave them as is in JavaScripts.