### PR TITLE
Set retries to 0 for LogArchive to EOS prod/recent

### DIFF
--- a/src/python/WMCore/Storage/StageOutImpl.py
+++ b/src/python/WMCore/Storage/StageOutImpl.py
@@ -185,7 +185,7 @@ class StageOutImpl(object):
         #  //
         # // Create the output directory if implemented
         # //
-        for retryCount in range(1, self.numRetries + 1):
+        for retryCount in range(self.numRetries + 1):
             try:
                 logging.info("Creating output directory...")
                 self.createOutputDirectory(targetPFN)
@@ -210,7 +210,7 @@ class StageOutImpl(object):
         # // Run the command
         # //
 
-        for retryCount in range(1, self.numRetries + 1):
+        for retryCount in range(self.numRetries + 1):
             try:
                 logging.info("Running the stage out...")
                 self.executeCommand(command)

--- a/src/python/WMCore/WMSpec/Steps/Executors/LogArchive.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/LogArchive.py
@@ -15,8 +15,8 @@ import time
 
 import WMCore.Storage.FileManager
 import WMCore.Storage.StageOutMgr as StageOutMgr
-from WMCore.Algorithms.Alarm import Alarm, alarmHandler
 from Utils.FileTools import calculateChecksums
+from WMCore.Algorithms.Alarm import Alarm, alarmHandler
 from WMCore.WMException import WMException
 from WMCore.WMSpec.Steps.Executor import Executor
 from WMCore.WMSpec.Steps.WMExecutionFailure import WMExecutionFailure
@@ -111,7 +111,7 @@ class LogArchive(Executor):
             return emulator.emulate(self.step, self.job)
 
         overrides = {}
-        #TODO need to set override using addOverride method in WMStep
+        # TODO need to set override using addOverride method in WMStep
         if hasattr(self.step, 'override'):
             overrides = self.step.override.dictionary_()
 
@@ -131,7 +131,7 @@ class LogArchive(Executor):
             "^PSet.py$",
             "^PSet.pkl$",
             "_condor_std*",  # condor wrapper logs at the pilot top level
-            ]
+        ]
 
         ignoredDirs = ['Utils', 'WMCore', 'WMSandbox']
 
@@ -294,7 +294,7 @@ class LogArchive(Executor):
         taskPath = self.task.getPathName().split("/")
         requestName = taskPath[1]
         lastTask = taskPath[-1]
-        LFN = "/%s/%s/%s-%s-%s-log.tar.gz" % (requestName, lastTask, self.job.get("agentName",'NA'),
-                                      self.job["id"], self.job.get('retry_count', 0))
+        LFN = "/%s/%s/%s-%s-%s-log.tar.gz" % (requestName, lastTask, self.job.get("agentName", 'NA'),
+                                              self.job["id"], self.job.get('retry_count', 0))
 
         return LFN


### PR DESCRIPTION
Fixes #9060 

Disable retries for the logArch1 step when staging out the logArchive tarball to CERN EOS recent area (the one available over HTTP).