### PR TITLE
Always decode error messages before persisting them into the FJR

### DIFF
--- a/src/python/WMCore/FwkJobReport/Report.py
+++ b/src/python/WMCore/FwkJobReport/Report.py
@@ -592,7 +592,9 @@ class Report(object):
             # interprets this string using utf-8 codec and ignoring any errors
             errDetails.details = errorDetails.decode('utf-8', 'ignore')
         else:
-            errDetails.details = errorDetails
+            # Then cast it to string and decode it
+            errorDetails = str(errorDetails)
+            errDetails.details = errorDetails.decode('utf-8', 'ignore')
 
         setattr(stepSection.errors, "errorCount", errorCount + 1)
         self.setStepStatus(stepName=stepName, status=exitCode)

--- a/src/python/WMCore/WMException.py
+++ b/src/python/WMCore/WMException.py
@@ -153,6 +153,9 @@ class WMException(exceptions.Exception):
         strg += self.traceback
         strg += '\n'
         strg += WMEXCEPTION_END_STR
+        if hasattr(strg, "decode"):
+            # Fix for the unicode encoding issue, #8043
+            strg = strg.decode('utf-8', 'ignore')
         return strg
 
     def message(self):

--- a/src/python/WMCore/WMException.py
+++ b/src/python/WMCore/WMException.py
@@ -9,9 +9,8 @@ General Exception class for WM modules
 import exceptions
 import inspect
 import logging
-import traceback
 import sys
-import re
+import traceback
 
 WMEXCEPTION_START_STR = "<@========== WMException Start ==========@>"
 WMEXCEPTION_END_STR = "<@---------- WMException End ----------@>"
@@ -25,6 +24,7 @@ class WMException(exceptions.Exception):
     it was raised.
 
     """
+
     def __init__(self, message, errorNo=None, **data):
         self.name = str(self.__class__.__name__)
         if hasattr(message, "decode"):
@@ -66,7 +66,7 @@ class WMException(exceptions.Exception):
             finally:
                 frame = None
 
-        #  //
+        # //
         # // Find out where the exception came from
         # //
         try:
@@ -77,21 +77,19 @@ class WMException(exceptions.Exception):
         finally:
             stack = None
 
-        #  //
+        # //
         # // ClassName if ClassInstance is passed
         # //
         try:
             if self.data['ClassInstance'] != None:
-                self.data['ClassName'] = \
-                      self.data['ClassInstance'].__class__.__name__
-        except:
+                self.data['ClassName'] = self.data['ClassInstance'].__class__.__name__
+        except Exception:
             pass
-
 
         # Determine the traceback at time of __init__
         try:
             self.traceback = "\n".join(traceback.format_tb(sys.exc_info()[2]))
-        except:
+        except Exception:
             self.traceback = "WMException error: Couldn't get traceback\n"
 
     def __getitem__(self, key):


### PR DESCRIPTION
Fixes #8403

Added the same fix to the stringification of the exception as well, very likely redundant, but I'm happy provided it fixes this issue.

Honestly speaking, I do not see how it happened. Every error persisted in the FJR goes through the `def addError` method, which was properly fixed in the past (making sure ANY error messages are sanitized before persisted in the FJR):
https://github.com/dmwm/WMCore/pull/8524

This fix only apply if we get an error message which is not a string, but another object type (I don't think it ever happens, but I'm out of ideas).

For the record, this was the report/job that caused this issue:
2019-03-20 08:58:47,478:140143375185664:INFO:AccountantWorker:Handling /data/srv/wmagent/v1.1.20.patch3/install/wmagent/JobCreator/JobCache/pdmvserv_task_TOP-RunIIFall18wmLHEGS-00207__v1_T_190124_121044_6304/TOP-RunIIFall18wmLHEGS-00207_0/JobCollection_314448_0/job_2287826/Report.0.pkl


and in order to reproduce this failure, one can:
```
badErr = {'details': "<@========== WMException Start ==========@>\nException Class: CmsRunFailure\nMessage: Error running cmsRun\n{'arguments': ['/bin/bash', '/srv/job/WMTaskSpace/cmsRun1/cmsRun1-main.sh', '', 'slc6_amd64_gcc700', 'scramv1', 'CMSSW', 'CMSSW_10_2_7', 'FrameworkJobReport.xml', 'cmsRun', 'PSet.py', '', '', '']}\nCMSSW Return code: 8001\n\n\tModuleName : WMCore.W\xffMSpec.Steps.WMExecutionFailure\n\tMethodName : __init__\n\tClassInstance : None\n\tFileName : /srv/job/WMCore.zip/WMCore/WMSpec/Steps/WMExecutionFailure.py\n\tClassName : None\n\tLineNumber : 18\n\tErrorNr : 8001\n\nTraceback: \n\n<@---------- WMException End ----------@>", 'type': 'WMAgentStepExecutionError', 'exitCode': 8001}

from json import JSONEncoder
from WMCore.Wrappers.JsonWrapper.JSONThunker import JSONThunker
encoder = JSONEncoder()
thunker = JSONThunker()
thunked = thunker.thunk(badErr)
encoder.encode(thunked)
```

or load it from the original job report:
```
from WMCore.FwkJobReport.Report import Report

jobReport = Report()
jobReport.load('Report.0.pkl')
jsonFWJR = jobReport.__to_json__(None)
badStr = jsonFWJR["steps"]["cmsRun1"]["errors"]
```

Report was saved in
cmst1@vocms0282:/data/srv/wmagent/current/alan

I'm removing it now and restarting the component.