### PR TITLE
Allow not failing job creation in JobSplitting/ EventAwareLumiBased if specified in WMAgent config

### DIFF
--- a/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
+++ b/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
@@ -37,6 +37,7 @@ class EventAwareLumiBased(JobFactory):
         self.collectionName = None  # Placeholder for ACDC Collection Name, if needed
         # TODO this might need to be configurable instead of being hardcoded
         self.defaultJobTimeLimit = 48 * 3600  # 48 hours
+        self.lumiChecker = None
 
     def algorithm(self, *args, **kwargs):
         """
@@ -59,6 +60,7 @@ class EventAwareLumiBased(JobFactory):
         lumis = kwargs.get('lumis', None)
         applyLumiCorrection = bool(kwargs.get('applyLumiCorrection', False))
         deterministicPileup = kwargs.get('deterministicPileup', False)
+        allowCreationFailure = kwargs.get('allowCreationFailure', True)
 
         timePerEvent, sizePerEvent, memoryRequirement = \
             self.getPerformanceParameters(kwargs.get('performance', {}))
@@ -169,9 +171,10 @@ class EventAwareLumiBased(JobFactory):
                 # and it's only one lumi then ditch that lumi
                 timePerLumi = f['avgEvtsPerLumi'] * timePerEvent
                 if timePerLumi > jobTimeLimit and f['lumiCount'] == 1:
-                    failNextJob = True
-                    stopJob = True
                     lumisPerJob = 1
+                    stopJob = True
+                    if allowCreationFailure:
+                        failNextJob = True
                 elif splitOnFile:
                     # Then we have to split on every boundary
                     stopJob = True

--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -17,6 +17,15 @@ class PromptRecoWorkloadFactory(DataProcessing):
     Stamp out PromptReco workflows.
     """
 
+    def __init__(self):
+        super(PromptRecoWorkloadFactory, self).__init__()
+        self.procJobSplitArgs = {}
+        self.skimJobSplitArgs = {}
+        self.inputProcessedDataset = None
+        self.inputPrimaryDataset = None
+        self.eventsPerJob = None
+        self.inputDataTier = None
+
     def buildWorkload(self):
         """
         _buildWorkload_
@@ -131,6 +140,7 @@ class PromptRecoWorkloadFactory(DataProcessing):
             self.procJobSplitArgs["events_per_job"] = self.eventsPerJob
             if self.procJobSplitAlgo == "EventAwareLumiBased":
                 self.procJobSplitArgs["job_time_limit"] = 96 * 3600  # 4 days in seconds
+                self.procJobSplitArgs["allowCreationFailure"] = False
         elif self.procJobSplitAlgo == "LumiBased":
             self.procJobSplitArgs["lumis_per_job"] = self.lumisPerJob
         elif self.procJobSplitAlgo == "FileBased":
@@ -142,6 +152,7 @@ class PromptRecoWorkloadFactory(DataProcessing):
                 self.eventsPerJob = int((8.0 * 3600.0) / self.timePerEvent)
             if self.skimJobSplitAlgo == "EventAwareLumiBased":
                 self.skimJobSplitArgs["job_time_limit"] = 48 * 3600  # 2 days
+                self.skimJobSplitArgs["allowCreationFailure"] = False
             self.skimJobSplitArgs["events_per_job"] = self.eventsPerJob
         elif self.skimJobSplitAlgo == "LumiBased":
             self.skimJobSplitArgs["lumis_per_job"] = self.lumisPerJob

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/PromptReco_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/PromptReco_t.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# pylint: disable=W0212
+# Access to a protected member (_createSubscriptionsInWMBS)  of a client class
 """
 _PromptReco_t_
 
@@ -45,6 +47,7 @@ class PromptRecoTest(unittest.TestCase):
         self.listTasksByWorkflow = self.daoFactory(classname="Workflow.LoadFromName")
         self.listFilesets = self.daoFactory(classname="Fileset.List")
         self.listSubsMapping = self.daoFactory(classname="Subscriptions.ListSubsAndFilesetsFromWorkflow")
+        self.promptSkim = None
 
         return
 
@@ -688,6 +691,18 @@ class PromptRecoTest(unittest.TestCase):
         subscriptions = self.listSubsMapping.execute(workflow="TestWorkload", returnTuple=True)
         self.assertItemsEqual(subscriptions, subMaps)
 
+
+    def testallowCreationFailureArgExists(self):
+        """
+        Test allowCreationFailure arguments exists.
+        """
+        testArguments = PromptRecoWorkloadFactory.getTestArguments()
+        testArguments["CouchURL"] = os.environ["COUCHURL"]
+        testArguments["EnableHarvesting"] = True
+        factory = PromptRecoWorkloadFactory()
+        factory.factoryWorkloadConstruction("TestWorkload", testArguments)
+        factory.procJobSplitArgs["allowCreationFailure"] = False
+        self.assertItemsEqual(factory.procJobSplitArgs, {'events_per_job': 500, 'allowCreationFailure': False, 'job_time_limit': 345600})
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #9053
- Add a new parameter to the `EventAwareLumiBased` algorithm (allowCreationFailure) to allow or avoid job creation failures when estimated job time is higher the job time limit. Defaults to `True`.
- Set the splitting parameter above in the StdSpec of PromptReco for `EventAwareLumiBased` and default it to `False`.