### PR TITLE
Stop duplicating cherrypy log records

### DIFF
--- a/src/python/WMCore/REST/Main.py
+++ b/src/python/WMCore/REST/Main.py
@@ -128,6 +128,8 @@ class Logger(LogManager):
                'f': inheaders.get("Referer", ""),
                'a': inheaders.get("User-Agent", "")}
         self.access_log.log(logging.INFO, msg)
+        self.access_log.propagate = False  # to avoid duplicate records on the log
+        self.error_log.propagate = False  # to avoid duplicate records on the log
 
 
 class RESTMain(object):


### PR DESCRIPTION
A long standing issue that I've been trying to fix. Right now it always duplicate the log records, e.g.:
```
[21/Mar/2019:08:51:21]  Create request, input args: ....
...
INFO:cherrypy.error:[21/Mar/2019:08:51:21]  Create request, input args: ...
```

and I wanted to get rid of the `cherrypy.error:` one.

These 2 lines seem to do the trick.. still checking

Reference: https://github.com/cherrypy/cherrypy/issues/1566