### PR TITLE
Default CERN EOS logArchive copy under prod/recent/PRODUCTION

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -1172,7 +1172,7 @@ class StdBase(object):
                      "Dashboard": {"default": "production", "type": str, "validate": activity},
                      # Override parameters for step (EOS log location, etc
                      # set to "" string or None for eos-lfn-prefix if you don't want to save the log in eos
-                     "Override": {"default": {"eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent"},
+                     "Override": {"default": {"eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/PRODUCTION"},
                                   "type": dict},
                      }
         # Set defaults for the argument specification


### PR DESCRIPTION
As suggested in this JIRA ticket:
https://its.cern.ch/jira/browse/CMSTRANSF-53

it's a minor improvement, but it certainly helps when managing/cleaning up this area.

@vlimant @bbockelm don't we have some documentation out there describing how to grab those logs? If so, can you point me to them such that we can update it after the CMSWEB upgrade.