### PR TITLE
add back copy stageout plugin

### DIFF
--- a/src/python/WMCore/Storage/Backends/CPImpl.py
+++ b/src/python/WMCore/Storage/Backends/CPImpl.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+"""
+_CPImpl_
+
+Implementation of StageOutImpl interface for plain cp
+
+Useful for sites with large shared POSIX file systems (HPC)
+"""
+from __future__ import print_function
+
+import os
+import errno
+
+from WMCore.Storage.Registry import registerStageOutImpl
+from WMCore.Storage.StageOutImpl import StageOutImpl
+
+
+class CPImpl(StageOutImpl):
+    """
+    _CPImpl_
+
+    """
+
+    def __init__(self, stagein=False):
+        StageOutImpl.__init__(self, stagein)
+        self.numRetries = 5
+        self.retryPause = 300
+
+    def createSourceName(self, protocol, pfn):
+        """
+        _createSourceName_
+
+        """
+        return pfn
+
+    def createOutputDirectory(self, targetPFN):
+        """
+        _createOutputDirectory_
+
+        create output directory if needed
+        """
+        targetdir = os.path.dirname(targetPFN)
+
+        if not os.path.isdir(targetdir):
+            try:
+                os.makedirs(targetdir)
+            except OSError as exc:
+                if exc.errno != errno.EEXIST:
+                    raise
+        return
+
+    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+        """
+        _createStageOutCommand_
+
+        Build the actual cp stageout command
+
+        """
+        copyCommand = ""
+
+        if self.stageIn:
+            remotePFN, localPFN = sourcePFN, targetPFN
+        else:
+            remotePFN, localPFN = targetPFN, sourcePFN
+            copyCommand += "LOCAL_SIZE=`stat -c%%s %s`\n" % localPFN
+            copyCommand += "echo \"Local File Size is: $LOCAL_SIZE\"\n"
+
+        copyCommand += "cp %s %s\n" % (sourcePFN, targetPFN)
+
+        if self.stageIn:
+            copyCommand += "LOCAL_SIZE=`stat -c%%s %s`\n" % localPFN
+            copyCommand += "echo \"Local File Size is: $LOCAL_SIZE\"\n"
+            removeCommand = ""
+        else:
+            removeCommand = "rm %s;" % remotePFN
+
+        copyCommand += "REMOTE_SIZE=`stat -c%%s %s`\n" % remotePFN
+        copyCommand += "echo \"Remote File Size is: $REMOTE_SIZE\"\n"
+
+        copyCommand += "if [ $REMOTE_SIZE ] && [ $LOCAL_SIZE == $REMOTE_SIZE ]; then exit 0; "
+        copyCommand += "else echo \"ERROR: Size Mismatch between local and SE\"; %s exit 60311 ; fi" % removeCommand
+
+        return copyCommand
+
+    def removeFile(self, pfnToRemove):
+        """
+        _removeFile_
+
+        """
+        os.remove(pfnToRemove)
+        return
+
+registerStageOutImpl("cp", CPImpl)

--- a/src/python/WMCore/Storage/Backends/__init__.py
+++ b/src/python/WMCore/Storage/Backends/__init__.py
@@ -17,6 +17,7 @@ __all__ = []
 # //
 #//
 
+from WMCore.Storage.Backends import CPImpl
 from WMCore.Storage.Backends import FNALImpl
 from WMCore.Storage.Backends import SRMV2Impl
 from WMCore.Storage.Backends import LCGImpl

--- a/src/python/WMCore/Storage/Plugins/CPImpl.py
+++ b/src/python/WMCore/Storage/Plugins/CPImpl.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+"""
+_CPImpl_
+
+Implementation of StageOutImpl interface for plain cp
+
+"""
+import os
+import errno
+import shutil
+
+from WMCore.Storage.StageOutImplV2 import StageOutImplV2
+from WMCore.Storage.StageOutError import StageOutFailure
+
+
+class CPImpl(StageOutImplV2):
+    """
+    _CPImpl_
+
+    Implement interface for plain cp command
+
+    """
+
+    def createOutputDirectory(self, targetPFN):
+        targetdir = os.path.dirname(targetPFN)
+        if not os.path.isdir(targetdir):
+            try:
+                os.makedirs(targetdir)
+            except OSError as exc:
+                if exc.errno != errno.EEXIST:
+                    raise
+        return
+
+    def doTransfer(self, fromPfn, toPfn, stageOut, pnn, command, options, protocol, checksum ):
+        self.createOutputDirectory(toPfn)
+        shutil.copy(fromPfn, toPfn)
+        if os.path.getsize(fromPfn) != os.path.getsize(toPfn):
+            raise StageOutFailure("Invalid file size")
+        return toPfn
+
+    def doDelete(self, pfn, pnn, command, options, protocol):
+        os.remove(pfn)
+        return

--- a/src/python/WMCore/Storage/Registry.py
+++ b/src/python/WMCore/Storage/Registry.py
@@ -83,6 +83,7 @@ def retrieveStageOutImpl(name, stagein=False, useNewVersion=False):
 pluginLookup = {'test-win': 'TestWinImpl',
                 'test-fail': 'TestFailImpl',
                 'test-copy': 'TestLocalCopyImpl',
+                "cp": "CPImpl",
                 "stageout-xrdcp-fnal": 'FNALImpl',
                 "srmv2": 'SRMV2Impl',
                 "srmv2-lcg": 'LCGImpl',

--- a/test/python/WMCore_t/Storage_t/Backends_t/CPImpl_t.py
+++ b/test/python/WMCore_t/Storage_t/Backends_t/CPImpl_t.py
@@ -1,0 +1,71 @@
+from __future__ import (print_function, division)
+
+import unittest
+
+from mock import mock
+
+from WMCore.Storage.Backends.CPImpl import CPImpl
+
+
+class CPImplTest(unittest.TestCase):
+    def setUp(self):
+        self.CPImpl = CPImpl()
+
+    def testCreateSourceName_simple(self):
+        self.assertEqual("name", self.CPImpl.createSourceName("", "name"))
+
+    @mock.patch('WMCore.Storage.Backends.CPImpl.os')
+    def testCreateOutputDirectory_noDir(self, mock_os):
+        mock_os.path.dirname.return_value = "/dir1/dir2"
+        mock_os.path.isdir.return_value = False
+        self.CPImpl.createOutputDirectory("/dir1/dir2/file")
+        mock_os.path.dirname.assert_called_once_with("/dir1/dir2/file")
+        mock_os.path.isdir.assert_called_once_with("/dir1/dir2")
+        mock_os.makedirs.assert_called_once_with("/dir1/dir2")
+
+    @mock.patch('WMCore.Storage.Backends.CPImpl.os')
+    def testCreateOutputDirectory_withDir(self, mock_os):
+        mock_os.path.dirname.return_value = "/dir1/dir2"
+        mock_os.path.isdir.return_value = True
+        self.CPImpl.createOutputDirectory("/dir1/dir2/file")
+        mock_os.path.dirname.assert_called_once_with("/dir1/dir2/file")
+        mock_os.path.isdir.assert_called_once_with("/dir1/dir2")
+        mock_os.makedirs.assert_not_called()
+
+    def testCreateStageOutCommand_noStageInNoOptionsNoChecksum(self):
+        self.CPImpl.stageIn = False
+        results = self.CPImpl.createStageOutCommand("sourcePFN", "targetPFN")
+        expectedResults = self.createStageOutCommandResults(False, "sourcePFN", "targetPFN")
+        self.assertEqual(expectedResults, results)
+
+    def testCreateStageOutCommand_stageInNoOptionsNoChecksum(self):
+        self.CPImpl.stageIn = True
+        results = self.CPImpl.createStageOutCommand("sourcePFN", "targetPFN")
+        expectedResults = self.createStageOutCommandResults(True, "sourcePFN", "targetPFN")
+        self.assertEqual(expectedResults, results)
+
+    def createStageOutCommandResults(self, stageIn, sourcePFN, targetPFN):
+        copyCommand = ""
+        if stageIn:
+            remotePFN, localPFN = sourcePFN, targetPFN
+        else:
+            remotePFN, localPFN = targetPFN, sourcePFN
+            copyCommand += "LOCAL_SIZE=`stat -c%%s %s`\n" % localPFN
+            copyCommand += "echo \"Local File Size is: $LOCAL_SIZE\"\n"
+        copyCommand += "cp %s %s\n" % (sourcePFN, targetPFN)
+        if stageIn:
+            copyCommand += "LOCAL_SIZE=`stat -c%%s %s`\n" % localPFN
+            copyCommand += "echo \"Local File Size is: $LOCAL_SIZE\"\n"
+            removeCommand = ""
+        else:
+            removeCommand = "rm %s;" % remotePFN
+        copyCommand += "REMOTE_SIZE=`stat -c%%s %s`\n" % remotePFN
+        copyCommand += "echo \"Remote File Size is: $REMOTE_SIZE\"\n"
+        copyCommand += "if [ $REMOTE_SIZE ] && [ $LOCAL_SIZE == $REMOTE_SIZE ]; then exit 0; "
+        copyCommand += "else echo \"ERROR: Size Mismatch between local and SE\"; %s exit 60311 ; fi" % removeCommand
+        return copyCommand
+
+    @mock.patch('WMCore.Storage.Backends.CPImpl.os')
+    def testRemoveFile(self, mock_os):
+        self.CPImpl.removeFile("file")
+        mock_os.remove.assert_called_once_with("file")

--- a/test/python/WMCore_t/Storage_t/FileManager_t.py
+++ b/test/python/WMCore_t/Storage_t/FileManager_t.py
@@ -104,7 +104,7 @@ class FileManagerTest(unittest.TestCase):
                            'PNN': None, \
                            'StageOutCommand': None}
         wrapper = StageOutMgr(**{
-            'command': 'test-copy',
+            'command': 'cp',
             'option': '',
             'phedex-node': 'test-win',
             'lfn-prefix': self.testDir})
@@ -160,7 +160,7 @@ class FileManagerTest(unittest.TestCase):
                            'StageOutCommand': None}
 
         wrapper = StageInMgr(**{
-            'command': 'test-copy',
+            'command': 'cp',
             'option': '',
             'phedex-node': 'test-win',
             'lfn-prefix': self.testDir})
@@ -190,14 +190,14 @@ class FileManagerTest(unittest.TestCase):
                            'StageOutCommand': None}
 
         wrapper = StageInMgr(**{
-            'command': 'test-copy',
+            'command': 'cp',
             'option': '',
             'phedex-node': 'test-win',
             'lfn-prefix': self.testDir})
         retval = wrapper(fileForTransfer)
         print("got the retval %s" % retval)
         wrapper = DeleteMgr(**{
-            'command': 'test-copy',
+            'command': 'cp',
             'option': '',
             'phedex-node': 'test-win',
             'lfn-prefix': self.testDir})

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/DeleteFiles_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/DeleteFiles_t.py
@@ -68,7 +68,7 @@ class deleteFileTest(unittest.TestCase):
 
     def setLocalOverride(self, step):
         step.section_('override')
-        step.override.command    = 'test-copy'
+        step.override.command    = 'cp'
         step.override.option     = ''
         step.override.__setattr__('lfn-prefix', '')
         step.override.__setattr__('phedex-node','DUMMYPNN')

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/LogArch_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/LogArch_t.py
@@ -219,7 +219,7 @@ class LogArchiveTest(unittest.TestCase):
 
     def setLocalOverride(self, step):
         step.section_('override')
-        step.override.command = 'test-copy'
+        step.override.command = 'cp'
         step.override.option = ''
         step.override.__setattr__('lfn-prefix', self.testDir + "/")
         step.override.__setattr__('phedex-node', 'DUMMYPNN')


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/9144
Not just the same old Backends/CPImpl, but a rewrite. Added stagein support since this exists in XRDCPImpl, which this new version is based on. Do we even still support stagein? If not maybe we should clean that up, it makes the code much more complicated than it has to be.

The Plugins/CPImpl is similar to the old version, with a few minor tweaks/changes.

@amaltaro , what do you think?