### PR TITLE
Fixed lumis list in the ACDC docs and added a new version field

### DIFF
--- a/src/python/WMCore/ACDC/CouchFileset.py
+++ b/src/python/WMCore/ACDC/CouchFileset.py
@@ -7,7 +7,6 @@ Created by Dave Evans on 2010-03-19.
 Copyright (c) 2010 Fermilab. All rights reserved.
 """
 import time
-
 from WMCore.ACDC.Fileset import Fileset
 from WMCore.Database.CouchUtils import connectToCouch, requireFilesetName
 
@@ -106,12 +105,12 @@ class CouchFileset(Fileset):
         filteredFiles = []
         if mask:
             for f in files:
-                # There is no LastEvent for last job of a file
+                # There might be no LastEvent for last job of a file
                 if mask['LastEvent'] and mask['FirstEvent']:
-                    f['events'] = mask['LastEvent'] - mask['FirstEvent']
+                    f['events'] = mask['LastEvent'] - mask['FirstEvent'] + 1
                     f['first_event'] = mask['FirstEvent']
                 elif mask['FirstEvent']:
-                    f['events'] -= mask['FirstEvent']
+                    f['events'] = f['events'] - mask['FirstEvent'] + 1
                     f['first_event'] = mask['FirstEvent']
 
             maskLumis = mask.getRunAndLumis()
@@ -141,10 +140,13 @@ class CouchFileset(Fileset):
 
         Create a new filelist document containing the id
         """
+        # add a versioning to each of these ACDC docs such that we can properly
+        # parse them and avoid issues between ACDC docs and agent base code
         input = {"collection_name": self.collectionName,
                  "collection_type": self.collectionType,
                  "fileset_name": self["name"],
                  "files": files,
+                 "acdc_version": 2,
                  "timestamp": time.time()}
 
         document = CMSCouch.Document(None, input)

--- a/src/python/WMCore/ACDC/DataCollectionService.py
+++ b/src/python/WMCore/ACDC/DataCollectionService.py
@@ -10,13 +10,13 @@ Copyright (c) 2010 Fermilab. All rights reserved.
 import logging
 import threading
 from operator import itemgetter
-from WMCore.DAOFactory import DAOFactory
 
 import WMCore.ACDC.CollectionTypes as CollectionTypes
 import WMCore.Database.CouchUtils as CouchUtils
 from WMCore.ACDC.CouchCollection import CouchCollection
 from WMCore.ACDC.CouchFileset import CouchFileset
 from WMCore.ACDC.CouchService import CouchService
+from WMCore.DAOFactory import DAOFactory
 from WMCore.DataStructs.File import File
 from WMCore.DataStructs.LumiList import LumiList
 from WMCore.DataStructs.Run import Run
@@ -84,6 +84,7 @@ def _isRunMaskDuplicate(run, lumis, runLumis):
             if lumis.issubset(runLumi['lumis']):
                 return True
     return False
+
 
 def _mergeRealDataRunLumis(mergedFiles):
     """
@@ -457,10 +458,9 @@ class DataCollectionService(CouchService):
 
 
 def getMergedParents(childLFNs):
-
     myThread = threading.currentThread()
     daoFactory = DAOFactory(package="WMCore.WMBS", logger=myThread.logger,
-                                dbinterface=myThread.dbi)
+                            dbinterface=myThread.dbi)
 
     getParentInfoAction = daoFactory(classname="Files.GetParentInfo")
 

--- a/src/python/WMCore/ACDC/DataCollectionService.py
+++ b/src/python/WMCore/ACDC/DataCollectionService.py
@@ -104,6 +104,30 @@ def _mergeRealDataRunLumis(mergedFiles):
                                                'lumis': list(set(lumis))})
     return
 
+
+def fixupMCFakeLumis(files, acdcVersion):
+    """
+    This is complicated!
+    The lumi list uploaded to the ACDC Server is incorrect for, at least,
+    the MCFakeFiles. Reason being that it also includes the LastLumi, which
+    is actually not processed by the job, but just set as an upper boundary
+    (inclusiveMask). However, if the job is the last one for a given MCFakeFile,
+    then it might have a single lumi section in the list, and in this case it
+    would be correct...
+
+    This function updates data in-place.
+
+    For more info, see issue: https://github.com/dmwm/WMCore/issues/9126
+    """
+    for fname, fvalues in files.items():
+        if fname.startswith('MCFakeFile') and acdcVersion < 2:
+            for run in fvalues['runs']:
+                if len(run['lumis']) > 1:
+                    run['lumis'].pop()
+        else:
+            break
+
+
 class ACDCDCSException(WMException):
     """
     Yet another dummy variable class
@@ -189,6 +213,8 @@ class DataCollectionService(CouchService):
     @CouchUtils.connectToCouch
     def _getFilesetInfo(self, collectionName, filesetName, chunkOffset=None, chunkSize=None):
         """
+        Fetches all the data from the ACDC Server that matches the collection
+        and fileset names.
         """
         option = {"include_docs": True, "reduce": False}
         keys = [[collectionName, filesetName]]
@@ -196,9 +222,9 @@ class DataCollectionService(CouchService):
 
         filesInfo = []
         for row in results["rows"]:
-            files = row["doc"].get("files", False)
-            if files:
-                filesInfo.extend(files.values())
+            files = row["doc"].get("files", [])
+            fixupMCFakeLumis(files, row['doc'].get("acdc_version", 1))
+            filesInfo.extend(files.values())
 
         # second lfn sort
         filesInfo.sort(key=lambda x: x["lfn"])

--- a/src/python/WMCore/DataStructs/Mask.py
+++ b/src/python/WMCore/DataStructs/Mask.py
@@ -12,13 +12,12 @@ job in two ways:
 
 from WMCore.DataStructs.Run import Run
 
+
 class Mask(dict):
     """
     _Mask_
-
-
-
     """
+
     def __init__(self, **kwargs):
         dict.__init__(self, **kwargs)
         self.inclusive = True
@@ -31,7 +30,6 @@ class Mask(dict):
         self.setdefault("LastRun", None)
         self.setdefault("runAndLumis", {})
 
-
     def setMaxAndSkipEvents(self, maxEvents, skipEvents):
         """
         _setMaxAndSkipEvents_
@@ -42,7 +40,7 @@ class Mask(dict):
 
         self['FirstEvent'] = skipEvents
         if maxEvents is not None:
-            self['LastEvent']  = skipEvents + maxEvents
+            self['LastEvent'] = skipEvents + maxEvents
 
         return
 
@@ -55,10 +53,9 @@ class Mask(dict):
         """
 
         self['FirstLumi'] = skipLumi
-        self['LastLumi']  = skipLumi + maxLumis
+        self['LastLumi'] = skipLumi + maxLumis
 
         return
-
 
     def setMaxAndSkipRuns(self, maxRuns, skipRun):
         """
@@ -69,7 +66,7 @@ class Mask(dict):
         """
 
         self['FirstRun'] = skipRun
-        self['LastRun']  = skipRun + maxRuns
+        self['LastRun'] = skipRun + maxRuns
 
         return
 
@@ -80,23 +77,21 @@ class Mask(dict):
         return maxevents setting
 
         """
-        if (self['LastEvent'] == None) or (self['FirstEvent'] == None):
+        if self['LastEvent'] is None or self['FirstEvent'] is None:
             return None
         return self['LastEvent'] - self['FirstEvent'] + 1
 
-    def getMax(self, type = None):
+    def getMax(self, keyType=None):
         """
         _getMax_
 
         returns the maximum number of runs/events/etc of the type of the type string
-
         """
-
-        if 'First%s' %(type) not in self:
+        if 'First%s' % (keyType) not in self:
             return None
-        if (self['First%s'%(type)] == None) or (self['Last%s'%(type)] == None):
+        if self['First%s' % (keyType)] is None or self['Last%s' % (keyType)] is None:
             return None
-        return self['Last%s'%(type)] - self['First%s'%(type)] + 1
+        return self['Last%s' % (keyType)] - self['First%s' % (keyType)] + 1
 
     def addRun(self, run):
         """
@@ -106,14 +101,14 @@ class Mask(dict):
         """
         run.lumis.sort()
         firstLumi = run.lumis[0]
-        lastLumi  = run.lumis[0]
+        lastLumi = run.lumis[0]
         for lumi in run.lumis:
             if lumi <= lastLumi + 1:
                 lastLumi = lumi
             else:
                 self.addRunAndLumis(run.run, lumis=[firstLumi, lastLumi])
                 firstLumi = lumi
-                lastLumi  = lumi
+                lastLumi = lumi
         self.addRunAndLumis(run.run, lumis=[firstLumi, lastLumi])
         return
 
@@ -127,7 +122,7 @@ class Mask(dict):
         self['runAndLumis'][run] = lumiList
         return
 
-    def addRunAndLumis(self, run, lumis = []):
+    def addRunAndLumis(self, run, lumis=None):
         """
         _addRunAndLumis_
 
@@ -140,6 +135,7 @@ class Mask(dict):
               mask, no attempt is made to merge these together.  This can result in a mask
               with duplicate lumis.
         """
+        lumis = lumis or []
         if not isinstance(lumis, list):
             lumis = list(lumis)
 
@@ -181,7 +177,6 @@ class Mask(dict):
                 return True
 
         return False
-
 
     def filterRunLumisByMask(self, runs):
         """

--- a/src/python/WMCore/DataStructs/Mask.py
+++ b/src/python/WMCore/DataStructs/Mask.py
@@ -82,8 +82,7 @@ class Mask(dict):
         """
         if (self['LastEvent'] == None) or (self['FirstEvent'] == None):
             return None
-        return self['LastEvent'] - self['FirstEvent']
-
+        return self['LastEvent'] - self['FirstEvent'] + 1
 
     def getMax(self, type = None):
         """
@@ -97,7 +96,7 @@ class Mask(dict):
             return None
         if (self['First%s'%(type)] == None) or (self['Last%s'%(type)] == None):
             return None
-        return self['Last%s'%(type)] - self['First%s'%(type)]
+        return self['Last%s'%(type)] - self['First%s'%(type)] + 1
 
     def addRun(self, run):
         """
@@ -141,8 +140,7 @@ class Mask(dict):
               mask, no attempt is made to merge these together.  This can result in a mask
               with duplicate lumis.
         """
-
-        if not type(lumis) == list:
+        if not isinstance(lumis, list):
             lumis = list(lumis)
 
         if not run in self['runAndLumis'].keys():
@@ -215,7 +213,7 @@ class Mask(dict):
                 if pair[0] == pair[1]:
                     maskLumis.add(pair[0])
                 else:
-                    maskLumis = maskLumis.union(range(pair[0], pair[1] + 1, 1))
+                    maskLumis = maskLumis.union(range(pair[0], pair[1] + 1))
 
             filteredLumis = set(runDict[runNumber].lumis).intersection(maskLumis)
             if len(filteredLumis) > 0:

--- a/src/python/WMCore/FwkJobReport/ReportEmu.py
+++ b/src/python/WMCore/FwkJobReport/ReportEmu.py
@@ -67,9 +67,9 @@ class ReportEmu(object):
             totalSize += inputFile["size"]
             totalEvents += inputFile["events"]
 
-        if self.job["mask"]["FirstEvent"] != None and \
-               self.job["mask"]["LastEvent"] != None:
-            outputTotalEvents = self.job["mask"]["LastEvent"] - self.job["mask"]["FirstEvent"]
+        if self.job["mask"]["FirstEvent"] is not None and \
+            self.job["mask"]["LastEvent"] is not None:
+            outputTotalEvents = self.job["mask"]["LastEvent"] - self.job["mask"]["FirstEvent"] + 1
         else:
             outputTotalEvents = totalEvents
 

--- a/src/python/WMCore/FwkJobReport/ReportEmu.py
+++ b/src/python/WMCore/FwkJobReport/ReportEmu.py
@@ -5,16 +5,12 @@ _ReportEmu_
 Class for creating bogus framework job reports.
 """
 
-
-
-
 import os.path
 
-from WMCore.Services.UUIDLib import makeUUID
 from WMCore.DataStructs.File import File
-from WMCore.DataStructs.Run import Run
-
 from WMCore.FwkJobReport import Report
+from WMCore.Services.UUIDLib import makeUUID
+
 
 class ReportEmu(object):
     """
@@ -22,6 +18,7 @@ class ReportEmu(object):
 
     Job Report Emulator that creates a Report given a WMTask/WMStep and a Job instance.
     """
+
     def __init__(self, **options):
         """
         ___init___
@@ -41,9 +38,9 @@ class ReportEmu(object):
         report.addInputSource("PoolSource")
 
         for inputFile in self.job["input_files"]:
-            inputFileSection = report.addInputFile("PoolSource", lfn = inputFile["lfn"],
-                                                   size = inputFile["size"],
-                                                   events = inputFile["events"])
+            inputFileSection = report.addInputFile("PoolSource", lfn=inputFile["lfn"],
+                                                   size=inputFile["size"],
+                                                   events=inputFile["events"])
             Report.addRunInfoToFile(inputFileSection, inputFile["runs"])
 
         return
@@ -59,16 +56,12 @@ class ReportEmu(object):
         totalSize = 0
         totalEvents = 0
 
-        outputFirstEvent = 0
-        outputTotalEvents = 0
-        outputSize = 0
-
         for inputFile in self.job["input_files"]:
             totalSize += inputFile["size"]
             totalEvents += inputFile["events"]
 
         if self.job["mask"]["FirstEvent"] is not None and \
-            self.job["mask"]["LastEvent"] is not None:
+                        self.job["mask"]["LastEvent"] is not None:
             outputTotalEvents = self.job["mask"]["LastEvent"] - self.job["mask"]["FirstEvent"] + 1
         else:
             outputTotalEvents = totalEvents
@@ -92,13 +85,13 @@ class ReportEmu(object):
 
         for outputModuleName in self.step.listOutputModules():
             outputModuleSection = self.step.getOutputModule(outputModuleName)
-            outputModuleSection.fixedLFN    = False
+            outputModuleSection.fixedLFN = False
             outputModuleSection.disableGUID = False
 
             outputLFN = "%s/%s.root" % (outputModuleSection.lfnBase,
                                         str(makeUUID()))
-            outputFile = File(lfn = outputLFN, size = outputSize, events = outputEvents,
-                              merged = False)
+            outputFile = File(lfn=outputLFN, size=outputSize, events=outputEvents,
+                              merged=False)
             outputFile.setLocation(self.job["location"])
             outputFile['pfn'] = "ReportEmuTestFile.txt"
             outputFile['guid'] = "ThisIsGUID"

--- a/src/python/WMCore/JobSplitting/EventBased.py
+++ b/src/python/WMCore/JobSplitting/EventBased.py
@@ -10,9 +10,9 @@ import logging
 import traceback
 from math import ceil
 
+from WMCore.DataStructs.Run import Run
 from WMCore.JobSplitting.JobFactory import JobFactory
 from WMCore.WMBS.File import File
-from WMCore.DataStructs.Run import Run
 
 
 class EventBased(JobFactory):
@@ -56,7 +56,8 @@ class EventBased(JobFactory):
                 couchDB = kwargs.get('couchDB')
                 filesetName = kwargs.get('filesetName')
                 collectionName = kwargs.get('collectionName')
-                logging.info('Loading ACDC info for collectionName: %s, with filesetName: %s', collectionName, filesetName)
+                logging.info('Loading ACDC info for collectionName: %s, with filesetName: %s', collectionName,
+                             filesetName)
                 dcs = DataCollectionService(couchURL, couchDB)
                 acdcFileList = dcs.getProductionACDCInfo(collectionName, filesetName)
             except Exception as ex:
@@ -160,7 +161,7 @@ class EventBased(JobFactory):
                         self.currentJob.addBaggageParameter("lheInputFiles", lheInput)
 
                         # Limit the number of events to a unsigned 32bit int
-                        if (currentEvent + eventsPerJob - 1) > (2 ** 32 - 1) and\
+                        if (currentEvent + eventsPerJob - 1) > (2 ** 32 - 1) and \
                                         (currentEvent + eventsInFile) > (2 ** 32 - 1):
                             currentEvent = 1
 
@@ -192,7 +193,6 @@ class EventBased(JobFactory):
                         logging.info("Job created with mask: %s", self.currentJob['mask'])
 
         return
-
 
     def createACDCJobs(self, fakeFile, acdcFileInfo, timePerEvent, sizePerEvent,
                        memoryRequirement, lheInputOption, eventsPerJob,

--- a/src/python/WMCore/JobStateMachine/ChangeState.py
+++ b/src/python/WMCore/JobStateMachine/ChangeState.py
@@ -570,10 +570,10 @@ class ChangeState(WMObject, WMConnectionBase):
                 if getattr(job["mask"], "daofactory", None):
                     job["mask"].load(jobID = job["id"])
             #If the mask is event based, then we have info to report
-            if job["mask"]["LastEvent"] != None and \
-               job["mask"]["FirstEvent"] != None and job["mask"]['inclusivemask']:
+            if job["mask"]['inclusivemask'] and job["mask"]["LastEvent"] is not None and \
+                job["mask"]["FirstEvent"] is not None:
                 job["nEventsToProc"] = int(job["mask"]["LastEvent"] -
-                                            job["mask"]["FirstEvent"])
+                                            job["mask"]["FirstEvent"] + 1)
             #Increment retry when commanded
             if incrementRetry:
                 job["retry_count"] += 1

--- a/src/python/WMCore/JobStateMachine/ChangeState.py
+++ b/src/python/WMCore/JobStateMachine/ChangeState.py
@@ -5,22 +5,23 @@ _ChangeState_
 Propagate a job from one state to another.
 """
 
-import time
 import logging
-import traceback
 import re
+import time
+import traceback
 
-from WMCore.Database.CMSCouch import CouchServer
-from WMCore.Database.CMSCouch import CouchNotFoundError, CouchError
 from WMCore.DataStructs.WMObject import WMObject
+from WMCore.Database.CMSCouch import CouchNotFoundError, CouchError
+from WMCore.Database.CMSCouch import CouchServer
+from WMCore.JobStateMachine.SummaryDB import updateSummaryDB
 from WMCore.JobStateMachine.Transitions import Transitions
+from WMCore.Lexicon import sanitizeURL
 from WMCore.Services.Dashboard.DashboardReporter import DashboardReporter
 from WMCore.WMConnectionBase import WMConnectionBase
-from WMCore.Lexicon import sanitizeURL
-from WMCore.JobStateMachine.SummaryDB import updateSummaryDB
 from WMCore.WMSpec.WMWorkload import WMWorkloadHelper
 
 CMSSTEP = re.compile(r'^cmsRun[0-9]+$')
+
 
 def discardConflictingDocument(couchDbInstance, data, result):
     """
@@ -58,6 +59,7 @@ def discardConflictingDocument(couchDbInstance, data, result):
         logging.error("Error: %s", str(ex))
         return result
 
+
 def getDataFromSpecFile(specFile):
     workload = WMWorkloadHelper()
     workload.load(specFile)
@@ -67,15 +69,17 @@ def getDataFromSpecFile(specFile):
         result[task.getPathName()] = task.getPrepID()
     return result
 
+
 class ChangeState(WMObject, WMConnectionBase):
     """
     Propagate the state of a job through the JSM.
     """
-    def __init__(self, config, couchDbName = None):
+
+    def __init__(self, config, couchDbName=None):
         WMObject.__init__(self, config)
         WMConnectionBase.__init__(self, "WMCore.WMBS")
 
-        if couchDbName == None:
+        if couchDbName is None:
             self.dbname = getattr(self.config.JobStateMachine, "couchDBName")
         else:
             self.dbname = couchDbName
@@ -112,7 +116,7 @@ class ChangeState(WMObject, WMConnectionBase):
         """
         if not hasattr(self, 'jobsdatabase') or self.jobsdatabase is None:
             try:
-                self.jobsdatabase = self.couchdb.connectDatabase("%s/jobs" % self.dbname, size = 250)
+                self.jobsdatabase = self.couchdb.connectDatabase("%s/jobs" % self.dbname, size=250)
             except Exception as ex:
                 logging.error("Error connecting to couch db '%s/jobs': %s", self.dbname, str(ex))
                 self.jobsdatabase = None
@@ -120,7 +124,7 @@ class ChangeState(WMObject, WMConnectionBase):
 
         if not hasattr(self, 'fwjrdatabase') or self.fwjrdatabase is None:
             try:
-                self.fwjrdatabase = self.couchdb.connectDatabase("%s/fwjrs" % self.dbname, size = 250)
+                self.fwjrdatabase = self.couchdb.connectDatabase("%s/fwjrs" % self.dbname, size=250)
             except Exception as ex:
                 logging.error("Error connecting to couch db '%s/fwjrs': %s", self.dbname, str(ex))
                 self.fwjrdatabase = None
@@ -146,7 +150,7 @@ class ChangeState(WMObject, WMConnectionBase):
 
         return True
 
-    def propagate(self, jobs, newstate, oldstate, updatesummary = False):
+    def propagate(self, jobs, newstate, oldstate, updatesummary=False):
         """
         Move the job from a state to another. Book keep the change to CouchDB.
         Report the information to the Dashboard.
@@ -200,9 +204,9 @@ class ChangeState(WMObject, WMConnectionBase):
         # Check for wrong transitions
         transitions = Transitions()
         assert newstate in transitions[oldstate], \
-               "Illegal state transition requested: %s -> %s" % (oldstate, newstate)
+            "Illegal state transition requested: %s -> %s" % (oldstate, newstate)
 
-    def recordInCouch(self, jobs, newstate, oldstate, updatesummary = False):
+    def recordInCouch(self, jobs, newstate, oldstate, updatesummary=False):
         """
         _recordInCouch_
 
@@ -231,7 +235,7 @@ class ChangeState(WMObject, WMConnectionBase):
             else:
                 jobLocation = "Agent"
 
-            if couchDocID == None:
+            if couchDocID is None:
                 jobDocument = {}
                 jobDocument["_id"] = str(job["id"])
                 job["couch_record"] = jobDocument["_id"]
@@ -278,7 +282,7 @@ class ChangeState(WMObject, WMConnectionBase):
 
                 couchRecordsToUpdate.append({"jobid": job["id"],
                                              "couchid": jobDocument["_id"]})
-                self.jobsdatabase.queue(jobDocument, callback = discardConflictingDocument)
+                self.jobsdatabase.queue(jobDocument, callback=discardConflictingDocument)
             else:
                 # We send a PUT request to the stateTransition update handler.
                 # Couch expects the parameters to be passed as arguments to in
@@ -291,7 +295,7 @@ class ChangeState(WMObject, WMConnectionBase):
                                                                                     newstate,
                                                                                     jobLocation,
                                                                                     timestamp)
-                self.jobsdatabase.makeRequest(uri = updateUri, type = "PUT", decode = False)
+                self.jobsdatabase.makeRequest(uri=updateUri, type="PUT", decode=False)
 
             # updating the status of the summary doc only when it is explicitely requested
             # doc is already in couch
@@ -304,7 +308,7 @@ class ChangeState(WMObject, WMConnectionBase):
                 else:
                     monitorState = newstate
                 updateUri += "?newstate=%s&timestamp=%s" % (monitorState, timestamp)
-                self.jsumdatabase.makeRequest(uri = updateUri, type = "PUT", decode = False)
+                self.jsumdatabase.makeRequest(uri=updateUri, type="PUT", decode=False)
                 logging.debug("Updated job summary status for job %s", jobSummaryId)
 
                 updateUri = "/" + self.jsumdatabase.name + "/_design/WMStatsAgent/_update/jobStateTransition/" + jobSummaryId
@@ -312,14 +316,15 @@ class ChangeState(WMObject, WMConnectionBase):
                                                                                     monitorState,
                                                                                     job["location"],
                                                                                     timestamp)
-                self.jsumdatabase.makeRequest(uri = updateUri, type = "PUT", decode = False)
+                self.jsumdatabase.makeRequest(uri=updateUri, type="PUT", decode=False)
                 logging.debug("Updated job summary state history for job %s", jobSummaryId)
 
             if job.get("fwjr", None):
-                
-                cachedByWorkflow = self.workloadCache.setdefault(job['workflow'], 
-                                            getDataFromSpecFile(
-                                             self.getWorkflowSpecDAO.execute(job['task'])[job['task']]['spec']))
+
+                cachedByWorkflow = self.workloadCache.setdefault(job['workflow'],
+                                                                 getDataFromSpecFile(
+                                                                     self.getWorkflowSpecDAO.execute(job['task'])[
+                                                                         job['task']]['spec']))
                 job['fwjr'].setCampaign(cachedByWorkflow.get('Campaign', ''))
                 job['fwjr'].setPrepID(cachedByWorkflow.get(job['task'], ''))
                 # If there are too many input files, strip them out
@@ -344,7 +349,7 @@ class ChangeState(WMObject, WMConnectionBase):
                 job["fwjr"].setTaskName(job["task"])
                 jsonFWJR = job["fwjr"].__to_json__(None)
 
-                #Don't archive cleanup job report
+                # Don't archive cleanup job report
                 if job["jobType"] == "Cleanup":
                     archStatus = "skip"
                 else:
@@ -358,11 +363,11 @@ class ChangeState(WMObject, WMConnectionBase):
                                 "archivestatus": archStatus,
                                 "fwjr": jsonFWJR,
                                 "type": "fwjr"}
-                self.fwjrdatabase.queue(fwjrDocument, timestamp = True, callback = discardConflictingDocument)
+                self.fwjrdatabase.queue(fwjrDocument, timestamp=True, callback=discardConflictingDocument)
 
                 updateSummaryDB(self.statsumdatabase, job)
 
-                #TODO: can add config switch to swich on and off
+                # TODO: can add config switch to swich on and off
                 # if self.config.JobSateMachine.propagateSuccessJobs or (job["retry_count"] > 0) or (newstate != 'success'):
                 if (job["retry_count"] > 0) or (newstate != 'success'):
                     jobSummaryId = job["name"]
@@ -374,8 +379,11 @@ class ChangeState(WMObject, WMConnectionBase):
                         for step in fwjrDocument["fwjr"]["steps"]:
                             if "errors" in fwjrDocument["fwjr"]["steps"][step]:
                                 errmsgs[step] = [error for error in fwjrDocument["fwjr"]["steps"][step]["errors"]]
-                            if "input" in fwjrDocument["fwjr"]["steps"][step] and "source" in fwjrDocument["fwjr"]["steps"][step]["input"]:
-                                inputs.extend( [source["runs"] for source in fwjrDocument["fwjr"]['steps'][step]["input"]["source"] if "runs" in source] )
+                            if "input" in fwjrDocument["fwjr"]["steps"][step] and "source" in \
+                                    fwjrDocument["fwjr"]["steps"][step]["input"]:
+                                inputs.extend(
+                                    [source["runs"] for source in fwjrDocument["fwjr"]['steps'][step]["input"]["source"]
+                                     if "runs" in source])
 
                     outputs = []
                     outputDataset = None
@@ -384,11 +392,12 @@ class ChangeState(WMObject, WMConnectionBase):
                             if singlefile:
                                 outputs.append({'type': 'output' if CMSSTEP.match(singlestep) else singlefile.get('module_label', None),
                                                 'lfn': singlefile.get('lfn', None),
-                                                'location': list(singlefile.get('locations', set([]))) if len(singlefile.get('locations', set([]))) > 1
-                                                                                                       else singlefile['locations'].pop(),
+                                                'location': list(singlefile.get('locations', set([]))) if len(
+                                                    singlefile.get('locations', set([]))) > 1
+                                                else singlefile['locations'].pop(),
                                                 'checksums': singlefile.get('checksums', {}),
-                                                'size': singlefile.get('size', None) })
-                                #it should have one output dataset for all the files
+                                                'size': singlefile.get('size', None)})
+                                # it should have one output dataset for all the files
                                 outputDataset = singlefile.get('dataset', None) if not outputDataset else outputDataset
                     inputFiles = []
                     for inputFileStruct in job["fwjr"].getAllInputFiles():
@@ -422,12 +431,13 @@ class ChangeState(WMObject, WMConnectionBase):
                                   "lumis": inputs,
                                   "outputdataset": outputDataset,
                                   "inputfiles": inputFiles,
-                                  "acdc_url": "%s/%s" % (sanitizeURL(self.config.ACDC.couchurl)['url'], self.config.ACDC.database),
+                                  "acdc_url": "%s/%s" % (
+                                  sanitizeURL(self.config.ACDC.couchurl)['url'], self.config.ACDC.database),
                                   "agent_name": self.config.Agent.hostName,
-                                  "output": outputs }
+                                  "output": outputs}
                     if couchDocID is not None:
                         try:
-                            currentJobDoc = self.jsumdatabase.document(id = jobSummaryId)
+                            currentJobDoc = self.jsumdatabase.document(id=jobSummaryId)
                             jobSummary['_rev'] = currentJobDoc['_rev']
                             jobSummary['state_history'] = currentJobDoc.get('state_history', [])
                             # record final status transition
@@ -443,15 +453,15 @@ class ChangeState(WMObject, WMConnectionBase):
                                 jobSummary[prop] = jobSummary[prop] if jobSummary[prop] else currentJobDoc.get(prop, [])
                         except CouchNotFoundError:
                             pass
-                    self.jsumdatabase.queue(jobSummary, timestamp = True)
+                    self.jsumdatabase.queue(jobSummary, timestamp=True)
 
         if len(couchRecordsToUpdate) > 0:
-            self.setCouchDAO.execute(bulkList = couchRecordsToUpdate,
-                                     conn = self.getDBConn(),
-                                     transaction = self.existingTransaction())
+            self.setCouchDAO.execute(bulkList=couchRecordsToUpdate,
+                                     conn=self.getDBConn(),
+                                     transaction=self.existingTransaction())
 
-        self.jobsdatabase.commit(callback = discardConflictingDocument)
-        self.fwjrdatabase.commit(callback = discardConflictingDocument)
+        self.jobsdatabase.commit(callback=discardConflictingDocument)
+        self.fwjrdatabase.commit(callback=discardConflictingDocument)
         self.jsumdatabase.commit()
         return
 
@@ -463,20 +473,20 @@ class ChangeState(WMObject, WMConnectionBase):
         """
 
         if newstate == "killed":
-            self.incrementRetryDAO.execute(jobs, increment = 99999,
-                                           conn = self.getDBConn(),
-                                           transaction = self.existingTransaction())
-        elif oldstate == "submitcooloff" or oldstate == "jobcooloff" or oldstate == "createcooloff" :
+            self.incrementRetryDAO.execute(jobs, increment=99999,
+                                           conn=self.getDBConn(),
+                                           transaction=self.existingTransaction())
+        elif oldstate == "submitcooloff" or oldstate == "jobcooloff" or oldstate == "createcooloff":
             self.incrementRetryDAO.execute(jobs,
-                                           conn = self.getDBConn(),
-                                           transaction = self.existingTransaction())
+                                           conn=self.getDBConn(),
+                                           transaction=self.existingTransaction())
         for job in jobs:
             job['state'] = newstate
             job['oldstate'] = oldstate
 
-        dao = self.daofactory(classname = "Jobs.ChangeState")
-        dao.execute(jobs, conn = self.getDBConn(),
-                    transaction = self.existingTransaction())
+        dao = self.daofactory(classname="Jobs.ChangeState")
+        dao.execute(jobs, conn=self.getDBConn(),
+                    transaction=self.existingTransaction())
 
     def reportToDashboard(self, jobs, newstate, oldstate):
         """
@@ -486,42 +496,42 @@ class ChangeState(WMObject, WMConnectionBase):
         with any additional information needed
         """
 
-        #If the new state is created it possible came from 3 locations:
-        #JobCreator in that case it comes with all the needed info
-        #ErrorHandler comes with the standard information of a WMBSJob
-        #RetryManager comes with the standard information of a WMBSJob
-        #Unpause script comes with the standard information of a WMBSJob
-        #For those last 3 cases we need to fill the gaps
+        # If the new state is created it possible came from 3 locations:
+        # JobCreator in that case it comes with all the needed info
+        # ErrorHandler comes with the standard information of a WMBSJob
+        # RetryManager comes with the standard information of a WMBSJob
+        # Unpause script comes with the standard information of a WMBSJob
+        # For those last 3 cases we need to fill the gaps
         if newstate == 'created':
             incrementRetry = True if 'cooloff' in oldstate else False
             self.completeCreatedJobsInformation(jobs, incrementRetry)
             self.dashboardReporter.handleCreated(jobs)
-        #If the new state is executing that was done only by the JobSubmitter,
-        #it sends jobs with select information, nevertheless is enough
+        # If the new state is executing that was done only by the JobSubmitter,
+        # it sends jobs with select information, nevertheless is enough
         elif newstate == 'executing':
             statusMessage = 'Job was successfuly submitted'
             self.dashboardReporter.handleJobStatusChange(jobs, 'submitted',
                                                          statusMessage)
-        #If the new state is success, then the JobAccountant sent the jobs.
-        #Jobs come with all the standard information of a WMBSJob plus FWJR
+        # If the new state is success, then the JobAccountant sent the jobs.
+        # Jobs come with all the standard information of a WMBSJob plus FWJR
         elif newstate == 'success':
             statusMessage = 'Job has completed successfully'
             self.dashboardReporter.handleJobStatusChange(jobs, 'succeeded',
                                                          statusMessage)
         elif newstate == 'jobfailed':
-            #If it failed after being in complete state, then  the JobAccountant
-            #sent the jobs, these come with all the standard information of a WMBSJob
-            #plus FWJR
+            # If it failed after being in complete state, then  the JobAccountant
+            # sent the jobs, these come with all the standard information of a WMBSJob
+            # plus FWJR
             if oldstate == 'complete':
                 statusMessage = 'Job failed at the site'
-            #If it failed while executing then it timed out in BossAir
-            #The JobTracker should sent the jobs with the required information
+            # If it failed while executing then it timed out in BossAir
+            # The JobTracker should sent the jobs with the required information
             elif oldstate == 'executing':
                 statusMessage = 'Job timed out in the agent'
             self.dashboardReporter.handleJobStatusChange(jobs, 'failed',
-                                                        statusMessage)
-        #In this case either a paused job was killed or the workqueue is killing
-        #a workflow, in both cases a WMBSJob with all the info should come
+                                                         statusMessage)
+        # In this case either a paused job was killed or the workqueue is killing
+        # a workflow, in both cases a WMBSJob with all the info should come
         elif newstate == 'killed':
             if oldstate == 'jobpaused':
                 statusMessage = 'A paused job was killed, maybe it is beyond repair'
@@ -531,50 +541,50 @@ class ChangeState(WMObject, WMConnectionBase):
                                                          statusMessage)
 
     def loadExtraJobInformation(self, jobs):
-        #This is needed for both couch and dashboard
+        # This is needed for both couch and dashboard
         jobIDsToCheck = []
         jobTasksToCheck = []
-        #This is for mapping ids to the position in the list
+        # This is for mapping ids to the position in the list
         jobMap = {}
         for idx, job in enumerate(jobs):
-            if job["couch_record"] == None:
+            if job["couch_record"] is None:
                 jobIDsToCheck.append(job["id"])
-            if job.get("task", None) == None or job.get("workflow", None) == None \
-                or job.get("taskType", None) == None or job.get("jobType", None) == None:
+            if job.get("task", None) is None or job.get("workflow", None) is None \
+                    or job.get("taskType", None) is None or job.get("jobType", None) is None:
                 jobTasksToCheck.append(job["id"])
             jobMap[job["id"]] = idx
 
         if len(jobIDsToCheck) > 0:
-            couchIDs = self.getCouchDAO.execute(jobID = jobIDsToCheck,
-                                                conn = self.getDBConn(),
-                                                transaction = self.existingTransaction())
+            couchIDs = self.getCouchDAO.execute(jobID=jobIDsToCheck,
+                                                conn=self.getDBConn(),
+                                                transaction=self.existingTransaction())
             for couchID in couchIDs:
                 idx = jobMap[couchID["jobid"]]
                 jobs[idx]["couch_record"] = couchID["couch_record"]
         if len(jobTasksToCheck) > 0:
-            jobTasks = self.workflowTaskDAO.execute(jobIDs = jobTasksToCheck,
-                                                    conn = self.getDBConn(),
-                                                    transaction = self.existingTransaction())
+            jobTasks = self.workflowTaskDAO.execute(jobIDs=jobTasksToCheck,
+                                                    conn=self.getDBConn(),
+                                                    transaction=self.existingTransaction())
             for jobTask in jobTasks:
                 idx = jobMap[jobTask["id"]]
                 jobs[idx]["task"] = jobTask["task"]
                 jobs[idx]["workflow"] = jobTask["name"]
                 jobs[idx]["taskType"] = jobTask["type"]
-                jobs[idx]["jobType"]  = jobTask["subtype"]
+                jobs[idx]["jobType"] = jobTask["subtype"]
 
-    def completeCreatedJobsInformation(self, jobs, incrementRetry = False):
+    def completeCreatedJobsInformation(self, jobs, incrementRetry=False):
         for job in jobs:
-            #It there's no jobID in the mask then it's not loaded
+            # It there's no jobID in the mask then it's not loaded
             if "jobID" not in job["mask"]:
-                #Make sure the daofactory was not stripped
+                # Make sure the daofactory was not stripped
                 if getattr(job["mask"], "daofactory", None):
-                    job["mask"].load(jobID = job["id"])
-            #If the mask is event based, then we have info to report
+                    job["mask"].load(jobID=job["id"])
+            # If the mask is event based, then we have info to report
             if job["mask"]['inclusivemask'] and job["mask"]["LastEvent"] is not None and \
-                job["mask"]["FirstEvent"] is not None:
+                            job["mask"]["FirstEvent"] is not None:
                 job["nEventsToProc"] = int(job["mask"]["LastEvent"] -
-                                            job["mask"]["FirstEvent"] + 1)
-            #Increment retry when commanded
+                                           job["mask"]["FirstEvent"] + 1)
+            # Increment retry when commanded
             if incrementRetry:
                 job["retry_count"] += 1
 
@@ -592,20 +602,20 @@ class ChangeState(WMObject, WMConnectionBase):
             return
 
         # First update safely in WMBS
-        self.updateLocationDAO.execute(jobs, conn = self.getDBConn(),
-                                       transaction = self.existingTransaction())
+        self.updateLocationDAO.execute(jobs, conn=self.getDBConn(),
+                                       transaction=self.existingTransaction())
         # Now try couch, this can fail and we don't require it to succeed
         try:
             jobIDs = [x['jobid'] for x in jobs]
-            couchIDs = self.getCouchDAO.execute(jobIDs, conn = self.getDBConn(),
-                                                transaction = self.existingTransaction())
+            couchIDs = self.getCouchDAO.execute(jobIDs, conn=self.getDBConn(),
+                                                transaction=self.existingTransaction())
             locationCache = dict((x['jobid'], x['location']) for x in jobs)
             for entry in couchIDs:
                 couchRecord = entry['couch_record']
                 location = locationCache[entry['jobid']]
                 updateUri = "/" + self.jobsdatabase.name + "/_design/JobDump/_update/locationTransition/" + couchRecord
                 updateUri += "?location=%s" % (location)
-                self.jobsdatabase.makeRequest(uri = updateUri, type = "PUT", decode = False)
+                self.jobsdatabase.makeRequest(uri=updateUri, type="PUT", decode=False)
         except Exception as ex:
             logging.error("Error updating job in couch: %s", str(ex))
             logging.error(traceback.format_exc())

--- a/src/python/WMCore/WMBS/MySQL/Masks/New.py
+++ b/src/python/WMCore/WMBS/MySQL/Masks/New.py
@@ -7,8 +7,8 @@ MySQL implementation of Masks.New
 
 from WMCore.Database.DBFormatter import DBFormatter
 
-class New(DBFormatter):
 
+class New(DBFormatter):
     sql = """INSERT INTO wmbs_job_mask (job, firstevent, lastevent, firstrun, lastrun, firstlumi, lastlumi, inclusivemask) VALUES
                (:jobid, :firstevent, :lastevent, :firstrun, :lastrun, :firstlumi, :lastlumi, :inclusivemask)"""
 
@@ -17,15 +17,15 @@ class New(DBFormatter):
         for job in jobList:
             binds.append({'jobid': job['id'], 'inclusivemask': inclusivemask,
                           'firstevent': job['mask']['FirstEvent'],
-                          'lastevent':  job['mask']['LastEvent'],
-                          'firstrun':   job['mask']['FirstRun'],
-                          'lastrun':    job['mask']['LastRun'],
-                          'firstlumi':  job['mask']['FirstLumi'],
-                          'lastlumi':   job['mask']['LastLumi'],})
+                          'lastevent': job['mask']['LastEvent'],
+                          'firstrun': job['mask']['FirstRun'],
+                          'lastrun': job['mask']['LastRun'],
+                          'firstlumi': job['mask']['FirstLumi'],
+                          'lastlumi': job['mask']['LastLumi'], })
 
         return binds
 
-    def execute(self, jobList, inclusivemask = True, conn = None, transaction = False):
+    def execute(self, jobList, inclusivemask=True, conn=None, transaction=False):
         binds = self.getDictBinds(jobList, inclusivemask)
-        self.dbi.processData(self.sql, binds, conn = conn, transaction = transaction)
+        self.dbi.processData(self.sql, binds, conn=conn, transaction=transaction)
         return

--- a/src/python/WMCore/WMBS/MySQL/Masks/New.py
+++ b/src/python/WMCore/WMBS/MySQL/Masks/New.py
@@ -5,25 +5,14 @@ _New_
 MySQL implementation of Masks.New
 """
 
-__all__ = []
-
-
-
-import logging
-
 from WMCore.Database.DBFormatter import DBFormatter
 
 class New(DBFormatter):
 
-    plainsql = """INSERT INTO wmbs_job_mask (job, inclusivemask) VALUES (:jobid, :inclusivemask)"""
-
     sql = """INSERT INTO wmbs_job_mask (job, firstevent, lastevent, firstrun, lastrun, firstlumi, lastlumi, inclusivemask) VALUES
                (:jobid, :firstevent, :lastevent, :firstrun, :lastrun, :firstlumi, :lastlumi, :inclusivemask)"""
 
-    def format(self,result):
-        return True
-
-    def getDictBinds(self, jobList, inclusivemask = True):
+    def getDictBinds(self, jobList, inclusivemask):
         binds = []
         for job in jobList:
             binds.append({'jobid': job['id'], 'inclusivemask': inclusivemask,
@@ -36,24 +25,7 @@ class New(DBFormatter):
 
         return binds
 
-    def execute(self, jobid = None, inclusivemask = None, conn = None,
-                transaction = False, jobList = None):
-
-        if jobList:
-            binds = self.getDictBinds(jobList, inclusivemask)
-            result = self.dbi.processData(self.sql, binds, conn = conn, transaction = transaction)
-            return self.format(result)
-
-        elif jobid:
-            if inclusivemask == None:
-                binds = self.getBinds(jobid = jobid, inclusivemask=True)
-            else:
-                binds = self.getBinds(jobid = jobid, inclusivemask = inclusivemask)
-
-            result = self.dbi.processData(self.plainsql, binds, conn = conn,
-                                          transaction = transaction)
-            return self.format(result)
-
-        else:
-            logging.error('Masks.New asked to create Mask with no Job ID')
-            return
+    def execute(self, jobList, inclusivemask = True, conn = None, transaction = False):
+        binds = self.getDictBinds(jobList, inclusivemask)
+        self.dbi.processData(self.sql, binds, conn = conn, transaction = transaction)
+        return

--- a/src/python/WMCore/WMBS/Oracle/Masks/New.py
+++ b/src/python/WMCore/WMBS/Oracle/Masks/New.py
@@ -5,51 +5,27 @@ _New_
 Oracle implementation of Masks.New
 """
 
-import logging
-
 from WMCore.WMBS.MySQL.Masks.New import New as NewMasksMySQL
-
-__all__ = []
 
 
 class New(NewMasksMySQL):
     sql = NewMasksMySQL.sql
 
-    def getDictBinds(self, jobList, inclusivemask=True):
+    def getDictBinds(self, jobList, inclusivemask):
         binds = []
+        maskV = 'T' if inclusivemask else 'F'
         for job in jobList:
-            if inclusivemask:
-                mask = 'Y'
-            else:
-                mask = 'N'
-            binds.append({'jobid': job['id'], 'inclusivemask': mask,
+            binds.append({'jobid': job['id'], 'inclusivemask': maskV,
                           'firstevent': job['mask']['FirstEvent'],
                           'lastevent': job['mask']['LastEvent'],
                           'firstrun': job['mask']['FirstRun'],
                           'lastrun': job['mask']['LastRun'],
                           'firstlumi': job['mask']['FirstLumi'],
-                          'lastlumi': job['mask']['LastLumi'], })
+                          'lastlumi': job['mask']['LastLumi']})
 
         return binds
 
-    def execute(self, jobid=None, inclusivemask=None, conn=None,
-                transaction=False, jobList=None):
-
-        if jobList:
-            binds = self.getDictBinds(jobList, inclusivemask)
-            result = self.dbi.processData(self.sql, binds, conn=conn, transaction=transaction)
-            return self.format(result)
-
-        elif jobid:
-            if inclusivemask == None:
-                binds = self.getBinds(jobid=jobid, inclusivemask='Y')
-            else:
-                binds = self.getBinds(jobid=jobid, inclusivemask='N')
-
-            result = self.dbi.processData(self.plainsql, binds, conn=conn,
-                                          transaction=transaction)
-            return self.format(result)
-
-        else:
-            logging.error('Masks.New asked to create Mask with no Job ID')
-            return
+    def execute(self, jobList, inclusivemask=True, conn=None, transaction=False):
+        binds = self.getDictBinds(jobList, inclusivemask)
+        self.dbi.processData(self.sql, binds, conn=conn, transaction=transaction)
+        return

--- a/src/python/WMQuality/Emulators/EmulatedUnitTestCase.py
+++ b/src/python/WMQuality/Emulators/EmulatedUnitTestCase.py
@@ -10,6 +10,7 @@ import unittest
 import mock
 
 from WMCore.Services.SiteDB.SiteDBAPI import SiteDBAPI
+from WMQuality.Emulators.CRICClient.MockCRICApi import MockCRICApi
 from WMQuality.Emulators.Cache.MockMemoryCacheStruct import MockMemoryCacheStruct
 from WMQuality.Emulators.DBSClient.MockDbsApi import MockDbsApi
 from WMQuality.Emulators.DashboardApMon.MockApMon import MockApMon
@@ -18,7 +19,7 @@ from WMQuality.Emulators.PhEDExClient.MockPhEDExApi import MockPhEDExApi
 from WMQuality.Emulators.PyCondorAPI.MockPyCondorAPI import MockPyCondorAPI
 from WMQuality.Emulators.ReqMgrAux.MockReqMgrAux import MockReqMgrAux
 from WMQuality.Emulators.SiteDBClient.MockSiteDBApi import mockGetJSON
-from WMQuality.Emulators.CRICClient.MockCRICApi import MockCRICApi
+
 
 class EmulatedUnitTestCase(unittest.TestCase):
     """

--- a/src/python/WMQuality/Emulators/EmulatedUnitTestCase.py
+++ b/src/python/WMQuality/Emulators/EmulatedUnitTestCase.py
@@ -113,7 +113,7 @@ class EmulatedUnitTestCase(unittest.TestCase):
 
         if self.mockCRIC:
             self.cricPatchers = []
-            patchCRICAt = ['WMCore.ReqMgr.Tools.cms',
+            patchCRICAt = ['WMCore.ReqMgr.Tools.cms.CRIC',
                            'WMCore.WorkQueue.WorkQueue.CRIC',
                            'WMCore.WorkQueue.WorkQueueUtils.CRIC',
                            'WMCore.WorkQueue.Policy.Start.Dataset.CRIC',

--- a/test/python/WMCore_t/DataStructs_t/Mask_t.py
+++ b/test/python/WMCore_t/DataStructs_t/Mask_t.py
@@ -6,13 +6,13 @@ Unittest for the WMCore.DataStructs.Mask class
 
 """
 
-
 # This code written as essentially a blank for future
 # Mask development
 # -mnorman
 
 
 import unittest
+
 from WMCore.DataStructs.Mask import Mask
 from WMCore.DataStructs.Run import Run
 
@@ -23,8 +23,6 @@ class MaskTest(unittest.TestCase):
 
     """
 
-
-
     def testSetMaxAndSkipEvents(self):
         """
         test class for setMaxAndSkipEvents in Mask.py
@@ -32,16 +30,15 @@ class MaskTest(unittest.TestCase):
         """
 
         testMask = Mask()
-        maxEvents  = 100
+        maxEvents = 100
         skipEvents = 10
 
         testMask.setMaxAndSkipEvents(maxEvents, skipEvents)
 
         self.assertEqual(testMask['FirstEvent'], skipEvents)
-        self.assertEqual(testMask['LastEvent'],  maxEvents + skipEvents)
+        self.assertEqual(testMask['LastEvent'], maxEvents + skipEvents)
 
         return
-
 
     def testSetMaxAndSkipLumis(self):
         """
@@ -49,17 +46,16 @@ class MaskTest(unittest.TestCase):
 
         """
 
-        testMask  = Mask()
-        maxLumis  = 10
+        testMask = Mask()
+        maxLumis = 10
         skipLumis = 2
 
         testMask.setMaxAndSkipLumis(maxLumis, skipLumis)
 
         self.assertEqual(testMask['FirstLumi'], skipLumis)
-        self.assertEqual(testMask['LastLumi'],  maxLumis + skipLumis)
+        self.assertEqual(testMask['LastLumi'], maxLumis + skipLumis)
 
         return
-
 
     def testSetMaxAndSkipRuns(self):
         """
@@ -67,14 +63,14 @@ class MaskTest(unittest.TestCase):
 
         """
 
-        testMask  = Mask()
-        maxRuns   = 1000
-        skipRuns  = 200
+        testMask = Mask()
+        maxRuns = 1000
+        skipRuns = 200
 
         testMask.setMaxAndSkipRuns(maxRuns, skipRuns)
 
         self.assertEqual(testMask['FirstRun'], skipRuns)
-        self.assertEqual(testMask['LastRun'],  maxRuns + skipRuns)
+        self.assertEqual(testMask['LastRun'], maxRuns + skipRuns)
 
         return
 
@@ -84,27 +80,22 @@ class MaskTest(unittest.TestCase):
 
         """
 
-        #The way I've decided to implement this depends on SetMaxAndSkipEvents()
-        #Therefore a failure in one will result in a failure in the second
-        #I'm not sure if this is the best way, but it's the one users will use
-        #The problem is that it's called in reverse order by unittest so you have to
-        #remember that.
+        # The way I've decided to implement this depends on SetMaxAndSkipEvents()
+        # Therefore a failure in one will result in a failure in the second
+        # I'm not sure if this is the best way, but it's the one users will use
+        # The problem is that it's called in reverse order by unittest so you have to
+        # remember that.
         # -mnorman
 
         testMask = Mask()
-        maxEvents  = 100
-        skipEvents = 0
+        maxEvents = 100
+        skipEvents = 1
 
-        tempMax = testMask.getMaxEvents()
-
-        self.assertEqual(tempMax, None)
+        self.assertEqual(testMask.getMaxEvents(), None)
 
         testMask.setMaxAndSkipEvents(maxEvents, skipEvents)
 
-        tempMax = testMask.getMaxEvents()
-
-        self.assertEqual(tempMax, maxEvents + skipEvents)
-
+        self.assertEqual(testMask.getMaxEvents(), maxEvents + skipEvents)
 
     def testGetMax(self):
         """
@@ -112,16 +103,15 @@ class MaskTest(unittest.TestCase):
 
         """
 
-        testMask  = Mask()
-        maxRuns   = 1000
-        skipRuns  = 200
+        testMask = Mask()
+        maxRuns = 999
+        skipRuns = 201
 
         testMask.setMaxAndSkipRuns(maxRuns, skipRuns)
-
+        self.assertEqual(testMask.getMax('Event'), None)
         self.assertEqual(testMask.getMax('Lumi'), None)
         self.assertEqual(testMask.getMax('junk'), None)
-        self.assertEqual(testMask.getMax('Run'),  1000)
-
+        self.assertEqual(testMask.getMax('Run'), 1000)
 
     def testRunsAndLumis(self):
         """
@@ -129,13 +119,13 @@ class MaskTest(unittest.TestCase):
         of runs and lumis
         """
 
-        runMask         = Mask()
-        rangesMask      = Mask()
+        runMask = Mask()
+        rangesMask = Mask()
         runAndLumisMask = Mask()
 
-        runMask.addRun(Run(100,1,2,3,4,5,6,8,9,10))
-        runMask.addRun(Run(200,6,7,8))
-        runMask.addRun(Run(300,12))
+        runMask.addRun(Run(100, 1, 2, 3, 4, 5, 6, 8, 9, 10))
+        runMask.addRun(Run(200, 6, 7, 8))
+        runMask.addRun(Run(300, 12))
 
         rangesMask.addRunWithLumiRanges(run=100, lumiList=[[1, 6], [8, 10]])
         rangesMask.addRunWithLumiRanges(run=200, lumiList=[[6, 8]])
@@ -150,7 +140,6 @@ class MaskTest(unittest.TestCase):
         # Note, this may break if the TODO in Mask.addRunAndLumis() is addressed
         self.assertEqual(runMask.getRunAndLumis(), runAndLumisMask.getRunAndLumis())
 
-
     def testFilter(self):
         """
         Test filtering of a set(run) object
@@ -160,23 +149,41 @@ class MaskTest(unittest.TestCase):
 
         runs = set()
         runs.add(Run(1, 148, 166, 185, 195, 203, 212))
-        newRuns = mask.filterRunLumisByMask(runs = runs)
+        newRuns = mask.filterRunLumisByMask(runs=runs)
         self.assertEqual(len(newRuns), 0)
 
         runs = set()
         runs.add(Run(1, 2, 148, 166, 185, 195, 203, 212))
         runs.add(Run(2, 148, 166, 185, 195, 203, 212))
-        newRuns = mask.filterRunLumisByMask(runs = runs)
+        newRuns = mask.filterRunLumisByMask(runs=runs)
         self.assertEqual(len(newRuns), 1)
 
         runs = set()
         runs.add(Run(1, 2, 9, 148, 166, 185, 195, 203, 212))
-        newRuns = mask.filterRunLumisByMask(runs = runs)
+        newRuns = mask.filterRunLumisByMask(runs=runs)
         self.assertEqual(len(newRuns), 1)
-
         run = newRuns.pop()
         self.assertEqual(run.run, 1)
-        self.assertEqual(run.lumis, [2,9])
+        self.assertEqual(run.lumis, [2, 9])
+
+    def testFilterRealCase(self):
+        """
+        Test filtering of a set(run) object based on real cases from production
+        """
+        mask = Mask()
+        mask.addRunWithLumiRanges(run=1, lumiList=[[9, 9], [8, 8], [3, 4], [7, 7]])
+        mask.setMaxAndSkipLumis(0, 7)
+        mask.setMaxAndSkipRuns(0, 1)
+
+        runs = set()
+        runs.add(Run(1, *[(9, 500), (10, 500)]))
+        runs.add(Run(1, *[(3, 500), (4, 500)]))
+        runs.add(Run(1, *[(7, 500), (8, 500)]))
+        newRuns = mask.filterRunLumisByMask(runs=runs)
+        self.assertEqual(len(newRuns), 1)
+        run = newRuns.pop()
+        self.assertEqual(run.run, 1)
+        self.assertEqual(run.lumis, [3, 4, 7, 8, 9])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #9126
Superseeds #9130 

Summary of changes are:
* added a new field to every single acdc document in order to know how to handle it depending on its version (acdc_version=2)
* if document belongs to the old (current) version, then pop the very last lumi section of the `lumis` list (only the last job of a MCFakeFile would be correct, and in such case we'd be popping a good lumi! C'est la vie!)
* Mask object now considers LastEvent/LastLumi/LastRun as processeable, thus I had to update the `getMax*` methods.
* Mask filterRunLumisByMask method updated to no longer yield a lumi section that isn't really processeable
* EventBased algo updated to properly set FirstEvent/LastEvent and FirstLumi/LastLumi, according to the always True `inclusiveMask` parameter. Thus `setMaxAndSkipEvents` and `setMaxAndSkipLumis` are usually provided with maxvalue - 1
* handle non-sequential list of lumis (and with different number of lumis per job) for a MCFakeFile in the EventBased algorithm