### PR TITLE
Fix another case for ACDC EventBased - wmagent branch

### DIFF
--- a/src/python/WMCore/ACDC/DataCollectionService.py
+++ b/src/python/WMCore/ACDC/DataCollectionService.py
@@ -46,7 +46,8 @@ def mergeFilesInfo(chunkFiles):
             # ErrorHandler expands that in the ACDC document as lumis : [9, 10] sigh...
             firstLumi = min(acdcFile['runs'][0]['lumis'])
             lastLumi = max(acdcFile['runs'][0]['lumis'])
-            acdcFile['runs'][0]['lumis'] = range(firstLumi, lastLumi)
+            if firstLumi != lastLumi:
+                acdcFile['runs'][0]['lumis'] = range(firstLumi, lastLumi)
             if fName not in mergedFiles:
                 mergedFiles[fName] = acdcFile
             else:

--- a/src/python/WMCore/JobSplitting/EventBased.py
+++ b/src/python/WMCore/JobSplitting/EventBased.py
@@ -257,7 +257,7 @@ class EventBased(JobFactory):
                                                          disk=diskRequired)
                     if deterministicPileup:
                         self.currentJob.addBaggageParameter("skipPileupEvents", (self.nJobs - 1) * eventsPerJob)
-                    logging.info("ACDC job created with %s", self.currentJob)
+                    logging.info("ACDC job created with mask: %s", self.currentJob['mask'])
                     eventsToRun -= eventsPerJob
                     currentEvent += eventsPerJob
                     totalJobs += 1


### PR DESCRIPTION
Fixes #9149 
Apologies for my broken patch previously created.  It does not work if we have a MCFakeFile ACDC doc with a run info like `"runs":[{"run_number":1,"lumis":[11000]}]`, as I've just seen for 
pdmvserv_task_HIG-RunIIFall17wmLHEGS-02728__v1_T_181024_163235_6575