### PR TITLE
import division on CPImpl

### DIFF
--- a/src/python/WMCore/Storage/Backends/CPImpl.py
+++ b/src/python/WMCore/Storage/Backends/CPImpl.py
@@ -6,7 +6,7 @@ Implementation of StageOutImpl interface for plain cp
 
 Useful for sites with large shared POSIX file systems (HPC)
 """
-from __future__ import print_function
+from __future__ import division
 
 import os
 import errno

--- a/src/python/WMCore/Storage/Plugins/CPImpl.py
+++ b/src/python/WMCore/Storage/Plugins/CPImpl.py
@@ -5,6 +5,8 @@ _CPImpl_
 Implementation of StageOutImpl interface for plain cp
 
 """
+from __future__ import division
+
 import os
 import errno
 import shutil


### PR DESCRIPTION
Added missing import from https://github.com/dmwm/WMCore/pull/9145 , in order to make python3 compatibility checks quiet.