### PR TITLE
Log job splitting changes in ReqMgr2

### DIFF
--- a/src/python/WMCore/ReqMgr/Service/RequestAdditionalInfo.py
+++ b/src/python/WMCore/ReqMgr/Service/RequestAdditionalInfo.py
@@ -285,6 +285,7 @@ class WorkloadSplitting(RESTEntity):
 
         data = cherrypy.request.body.read()
         splittingInfo = json.loads(data)
+        cherrypy.log("Updating job splitting for '%s' with these args: %s" % (name, splittingInfo))
 
         helper = WMWorkloadHelper()
         try:


### PR DESCRIPTION
No issue created, but recording the POST parameters in the reqmgr2 log is going to be helpful for any future investigation.