### PR TITLE
Limit EventsPerJob to RequestNumEvents

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -80,15 +80,17 @@ class StdBase(object):
     skimMap = {}
 
     @staticmethod
-    def calcEvtsPerJobLumi(ePerJob, ePerLumi, tPerEvent):
+    def calcEvtsPerJobLumi(ePerJob, ePerLumi, tPerEvent, requestedEvents=None):
         """
         _calcEvtsPerJobLumi_
 
-        Given EventsPerJob, EventsPerLumi and TimePerEvent information,
-        calculates the final values for EventsPerJob and EventsPerLumi.
+        Given RequestNumEvents (for MC from scratch), EventsPerJob,
+        EventsPerLumi and TimePerEvent information, calculates the final
+        values for EventsPerJob and EventsPerLumi.
 
         Final result will always be an EventsPerJob multiple of EventsPerLumi,
-        no matter whether EventsPerJob was provided or not.
+        no matter whether EventsPerJob was provided or not. In addition to that,
+        makes sure EventsPerJob is not greater than RequestNumEvents.
         :param ePerJob: events per job
         :param ePerLumi: events per lumi
         :param tPerEvent: time per event
@@ -96,6 +98,8 @@ class StdBase(object):
         # if not set, let's calculate an 8h job and set it for you
         if ePerJob is None:
             ePerJob = int((8.0 * 3600.0) / tPerEvent)
+        if requestedEvents and ePerJob > requestedEvents:
+            ePerJob = requestedEvents
 
         if ePerLumi is None:
             ePerLumi = ePerJob

--- a/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
@@ -439,7 +439,8 @@ class StepChainWorkloadFactory(StdBase):
         if taskConf["SplittingAlgo"] in ["EventBased", "EventAwareLumiBased"]:
             taskConf["EventsPerJob"], taskConf["EventsPerLumi"] = StdBase.calcEvtsPerJobLumi(taskConf.get("EventsPerJob"),
                                                                                              taskConf.get("EventsPerLumi"),
-                                                                                             self.timePerEvent)
+                                                                                             self.timePerEvent,
+                                                                                             taskConf.get("RequestNumEvents"))
             self.eventsPerJob = taskConf["EventsPerJob"]
             self.eventsPerLumi = taskConf["EventsPerLumi"]
             taskConf["SplittingArguments"]["events_per_job"] = taskConf["EventsPerJob"]

--- a/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
@@ -574,7 +574,8 @@ class TaskChainWorkloadFactory(StdBase):
             taskConf["EventsPerJob"], taskConf["EventsPerLumi"] = StdBase.calcEvtsPerJobLumi(taskConf.get("EventsPerJob"),
                                                                                              taskConf.get("EventsPerLumi"),
                                                                                              taskConf.get("TimePerEvent",
-                                                                                                          self.timePerEvent))
+                                                                                                          self.timePerEvent),
+                                                                                             taskConf.get("RequestNumEvents"))
             if firstTask:
                 self.eventsPerJob = taskConf["EventsPerJob"]
                 self.eventsPerLumi = taskConf["EventsPerLumi"]

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StdBase_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StdBase_t.py
@@ -70,6 +70,11 @@ class StdBaseTest(unittest.TestCase):
         self.assertEqual((23528, 11764), StdBase.calcEvtsPerJobLumi(24000, 11764, 10.157120496967591))
         self.assertEqual((2835, 2835), StdBase.calcEvtsPerJobLumi(None, 11764, 10.157120496967591))
 
+        self.assertEqual((10, 10), StdBase.calcEvtsPerJobLumi(123, 345, 1, requestedEvents=10))
+        self.assertEqual((690, 345), StdBase.calcEvtsPerJobLumi(750, 345, 1, requestedEvents=700))
+        self.assertEqual((15000, 100), StdBase.calcEvtsPerJobLumi(None, 100, 1, requestedEvents=15000))
+        self.assertEqual((15000, 15000), StdBase.calcEvtsPerJobLumi(None, None, 1, requestedEvents=15000))
+
         return
 
 


### PR DESCRIPTION
Fixes #9156 

Make sure a job is not splitted beyond the total number of events to be produced.