### PR TITLE
JSON templates updates: trust PU and less runs

### DIFF
--- a/test/data/ReqMgr/requests/DMWM/ReReco_badBlocks.json
+++ b/test/data/ReqMgr/requests/DMWM/ReReco_badBlocks.json
@@ -48,9 +48,7 @@
         "RunWhitelist": [
             316877, 
             316879, 
-            316928, 
-            316985
-        ], 
+            316928],
         "Scenario": "pp", 
         "ScramArch": [
             "slc6_amd64_gcc700"

--- a/test/data/ReqMgr/requests/Integration/SC_MultiPU.json
+++ b/test/data/ReqMgr/requests/Integration/SC_MultiPU.json
@@ -11,7 +11,8 @@
             "SiteWhitelist-OVERRIDE-ME"
         ], 
         "SoftTimeout": 129600, 
-        "Team": "Team-OVERRIDE-ME", 
+        "Team": "Team-OVERRIDE-ME",
+        "TrustPUSitelists": true,
         "UnmergedLFNBase": "/store/unmerged"
     }, 
     "createRequest": {
@@ -19,7 +20,7 @@
         "CMSSWVersion": "CMSSW_8_0_21", 
         "Campaign": "Campaign-OVERRIDE-ME", 
         "Comments": ["Two steps, PU for Step1 without input dataset; Step2 using a different PU;",
-            "Given 100EpL, tweak EpJ to 200 instead of 205"],
+            "Given 100EpL, tweak EpJ to 200 instead of 205; TrustPU enabled for the MinBias"],
         "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb", 
         "CouchDBName": "reqmgr_config_cache", 
         "DbsUrl": "https://cmsweb.cern.ch/dbs/prod/global/DBSReader/", 


### PR DESCRIPTION
The MinBias PU sample has been removed from Disk, so we need to set the TrustPU flag on otherwise the GQE won't get acquired. BTW, for the record such that I don't forget, the GQE for that workflow has the following PileupData
```
"PileupData":{"/MinBias_TuneCUETP8M1_13TeV-pythia8/RunIIWinter15GS-MCRUN2_71_V1-v1/GEN-SIM":["T3_TW_NCU"],"/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW":["T2_CH_CERN_HLT","T3_TW_NCU","T2_CH_CERN","T1_US_FNAL"]}
```

So both PUs in the same task. It doesn't break anything, but we should make sure it's completely supported (meaning, both PU locations are taken into consideration; both PU locations are automatically updated by the cherrypy thread; etc).

Removing a run from the ReReco because it creates 1.5k jobs, without that run it goes down to 600 jobs.