### PR TITLE
Update CherryPy configuration of WebTools/RESTModel via WMCore configuration

### DIFF
--- a/src/python/WMCore/WebTools/RESTModel.py
+++ b/src/python/WMCore/WebTools/RESTModel.py
@@ -34,6 +34,17 @@ class RESTModel(WebAPI):
         # If not set expire data after 5 mins
         self.defaultExpires = config.default_expires
 
+        # update cherrypy configuration if it is provided in configuration
+        # please note that we assume that config should contains CherryPy component, e.g.
+        # config = Configuration()
+        # config.component_('CherryPy')
+        # config.CherryPy.accepted_queue_size = 5
+        if getattr(config, 'CherryPy', None) != None:
+            cpy = config.CherryPy.dictionary_()
+            for key, val in cpy.items():
+                if val:
+                    cherrypy.config.update({key:val}
+
     def _classifyHTTPError(self, verb, args, kwargs):
         """
         There are a few cases where input will cause an error which needs

--- a/src/python/WMCore/WebTools/Root.py
+++ b/src/python/WMCore/WebTools/Root.py
@@ -87,6 +87,7 @@ class WTLogger(LogManager):
         response = cherrypy.response
         inheaders = lowerCmsHeaders(request.headers)
         outheaders = response.headers
+        body = request.body
         # identify size of body from HTTP Content-Length header
         rbytes = int(cherrypy.request.headers.get('Content-Length', 0))
         if not rbytes:
@@ -96,10 +97,10 @@ class WTLogger(LogManager):
             # request.rfile.rfile.bytes_read is a custom CMS web
             #  cherrypy patch not always available, hence the test
             rbytes = (getattr(request.rfile, 'rfile', None)
-                      and getattr(request.rfile.rfile, "bytes_read", None)
-                      and request.rfile.rfile.bytes_read) or "-"
+                 and getattr(request.rfile.rfile, "bytes_read", None)
+                 and request.rfile.rfile.bytes_read) or "-"
         msg = ('%(t)s %(H)s %(h)s "%(r)s" %(s)s'
-               + ' [data: %(i)s in %(b)s out %(T).0f us ]'
+               + ' [data: %(i) in %(b)s out %(T).0f us ]'
                + ' [auth: %(AS)s "%(AU)s" "%(AC)s" ]'
                + ' [ref: "%(f)s" "%(a)s" ]') % {'t': self.time(),
                                                 'H': self.host,


### PR DESCRIPTION
Based on discussion with Brian we may change CherryPy engine configuration dynamically. In particular Brian pointed to `accepted_queue_size` which controls CherryPy queue size. By default it is set to -1 which means unlimited queue. This patch provides ability to setup CherryPy configuration which will be applied to CherryPy engine, i.e. it updates cherrypy config. This is particular important for DBS server where we can apply this configuration

```
config = Configuration()
config.component_('CherryPy')
config.CherryPy.accepted_queue_size = 5 # whatever number we can use to limit the queue size
```