### PR TITLE
Accept CherryPy accepted_queue_size parameter; print service config

### DIFF
--- a/src/python/WMCore/REST/Main.py
+++ b/src/python/WMCore/REST/Main.py
@@ -23,6 +23,7 @@ from argparse import ArgumentParser
 from cStringIO import StringIO
 from glob import glob
 from subprocess import Popen, PIPE
+from pprint import pformat
 
 import cherrypy
 from cherrypy import Application
@@ -238,6 +239,7 @@ class RESTMain(object):
 
         if hasattr(self.srvconfig, 'authz_policy'):
             cpconfig.update({'tools.cms_auth.policy': self.srvconfig.authz_policy})
+        cherrypy.log("INFO: final CherryPy configuration: %s" % pformat(cpconfig))
 
     def install_application(self):
         """Install application and its components from the configuration."""

--- a/src/python/WMCore/WebTools/DefaultConfig.py
+++ b/src/python/WMCore/WebTools/DefaultConfig.py
@@ -21,7 +21,7 @@ config.component_('Webtools')
 config.Webtools.autoreload = True
 config.Webtools.environment = 'development'
 config.Webtools.log_screen = True
-config.Webtools.error_log_level = logging.DEBUG
+config.Webtools.error_log_level = logging.INFO
 #config.Webtools.thread_pool = 10
 # etc. Check Root.py for all configurables
 # The above short-hand can be replaced with explicit namespaced configuration

--- a/src/python/WMCore/WebTools/Root.py
+++ b/src/python/WMCore/WebTools/Root.py
@@ -15,6 +15,7 @@ import socket
 import sys
 import time
 from argparse import ArgumentParser
+from pprint import pformat
 
 # CherryPy
 import cherrypy
@@ -242,6 +243,8 @@ class Root(Harness):
         if "server.socket_port" in cherrypy.config.keys():
             default_port = cherrypy.config["server.socket_port"]
         cherrypy.config["server.thread_pool"] = configDict.get("thread_pool", 10)
+        cherrypy.config["server.accepted_queue_size"] = configDict.get("accepted_queue_size", -1)
+        cherrypy.config["server.accepted_queue_timeout"] = configDict.get("accepted_queue_timeout", 10)
         cherrypy.config["server.socket_port"] = configDict.get("port", default_port)
         cherrypy.config["server.socket_host"] = configDict.get("host", "0.0.0.0")
         # A little hacky way to pass the expire second to config
@@ -262,6 +265,7 @@ class Root(Harness):
                                         'tools.secmodv2.group': self.secconfig.default.group,
                                         'tools.secmodv2.site': self.secconfig.default.site})
         cherrypy.log.error_log.debug('Application %s initialised in %s mode', self.app, self.mode)
+        cherrypy.log.access_log.info("Final CherryPy configuration: %s" % pformat(cherrypy.config))
 
     def _loadPages(self):
         """

--- a/src/python/WMQuality/REST/ServerSetup.py
+++ b/src/python/WMQuality/REST/ServerSetup.py
@@ -41,6 +41,9 @@ class RESTMainTestServer(object):
         cherrypy.config.update({'server.socket_host': self.host})
         cherrypy.config.update({'request.show_tracebacks': True})
         cherrypy.config.update({'environment': 'test_suite'})
+        cherrypy.config.update({'server.thread_pool': 10})
+        cherrypy.config.update({'server.accepted_queue_size': -1})
+        cherrypy.config.update({'server.accepted_queue_timeout': 10})
         for app in cherrypy.tree.apps.values():
             if '/' in app.config:
                 app.config["/"]["request.show_tracebacks"] = True

--- a/src/python/WMQuality/WebTools/RESTServerSetup.py
+++ b/src/python/WMQuality/WebTools/RESTServerSetup.py
@@ -39,6 +39,9 @@ class DefaultConfig(Configuration):
         self.Webtools.port = 8888
         self.Webtools.host = "localhost"
         self.Webtools.expires = 300
+        self.Webtools.thread_pool = 10  # CherryPy default
+        self.Webtools.accepted_queue_size = -1  # CherryPy default
+        self.Webtools.accepted_queue_timeout = 10  # CherryPy default
 
         self.component_('UnitTests')
         self.UnitTests.title = 'CMS WMCore/WebTools Unit Tests'


### PR DESCRIPTION
Superseeds #9200 

Support `accepted_queue_size` as defined by the DBS configuration file. Also print the configuration arguments.

Deployment changes are like this: https://github.com/dmwm/deployment/pull/771