### PR TITLE
Add creation details for files

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/DBSBufferBlock.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSBufferBlock.py
@@ -127,6 +127,8 @@ class DBSBufferBlock:
         fileDict['last_modified_by'] = "WMAgent"
         fileDict['last_modification_date'] = int(time.time())
         fileDict['auto_cross_section'] = 0.0
+        fileDict['create_by'] = "WMAgent"
+        fileDict['creation_date'] = int(time.time())
 
         # Do the checksums
         for cktype in dbsFile['checksums'].keys():


### PR DESCRIPTION
Fixes #9042 

What I found was that the block has "create_by" and "creation_date" fields:
https://cmsweb.cern.ch/dbs/prod/global/DBSReader/blocks?block_name=/WminusH_HToZZTo4L_M190_13TeV_powheg2-minlo-HWJ_JHUGenV7011_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM%239fef307a-6fe4-4dce-9df1-ca700e5dc7a9&detail=true

The file does not:
https://cmsweb.cern.ch/dbs/prod/global/DBSReader/files?block_name=/WminusH_HToZZTo4L_M190_13TeV_powheg2-minlo-HWJ_JHUGenV7011_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM%239fef307a-6fe4-4dce-9df1-ca700e5dc7a9&detail=true

This PR adds the "create_by" and "creation_date" to a file, similar to how it is added to the block.
