### PR TITLE
Convert unicode to bytestring in formatCursor

### DIFF
--- a/src/python/WMCore/Database/DBFormatter.py
+++ b/src/python/WMCore/Database/DBFormatter.py
@@ -137,7 +137,13 @@ class DBFormatter(WMObject):
                     cursor.close()
                     break
                 for r in rows:
-                    result.append(dict(list(zip(keys, r))))
+                    entry = {}
+                    for index in range(0, len(keys)):
+                        if isinstance(r[index], unicode):
+                            entry[str(keys[index])] = str(r[index])
+                        else:
+                            entry[str(keys[index])] = r[index]
+                    result.append(entry)
             else:
                 break
         if not cursor.closed:


### PR DESCRIPTION
Fixes https://github.com/dmwm/DBS/issues/605
Well, another proposal to fix it. This fix goes as close as possible to the SQL/database layer.

I have a couple of concerns though:
* it will apply to every single result calling DBFormatter.formatCursor. So there is some overhead here (complexity O(n^3)!)
* if data is not formatted with one of those methods handling unicode, then there is the risk to pass unicode string data to the next SQL query.

PS.: Oracle returns table/column names in capital, should we apply `.lower()`? I guess not, there wasn't anything in the previous implementation.

