### PR TITLE
Add CherryPy stats to WebTools/RESTModel based server

### DIFF
--- a/src/python/WMCore/REST/Server.py
+++ b/src/python/WMCore/REST/Server.py
@@ -10,6 +10,7 @@ from functools import wraps
 from threading import Thread, Condition
 
 from cherrypy import engine, expose, request, response, HTTPError, HTTPRedirect, tools
+from cherrypy.lib import cpstats
 
 from WMCore.REST.Error import *
 from WMCore.REST.Format import *
@@ -354,6 +355,12 @@ class RESTFrontPage:
         URL arguments; they are not used here."""
         return self._serve([self._frontpage])
 
+    @expose
+    def stats(self):
+        "Return CherryPy stats dict about underlying service activities"
+        return cpstats.StatsPage().data()
+
+
 
 ######################################################################
 ######################################################################
@@ -688,6 +695,11 @@ class MiniRESTApi:
         apiobj = {"args": args, "validation": validation, "call": callable}
         apiobj.update(**kwargs)
         self.methods[method][api] = apiobj
+
+    @expose
+    def stats(self):
+        "Return CherryPy stats dict about underlying service activities"
+        return cpstats.StatsPage().data()
 
     @expose
     def default(self, *args, **kwargs):

--- a/src/python/WMCore/WebTools/Root.py
+++ b/src/python/WMCore/WebTools/Root.py
@@ -261,6 +261,7 @@ class Root(Harness):
                                         'tools.secmodv2.role': self.secconfig.default.role,
                                         'tools.secmodv2.group': self.secconfig.default.group,
                                         'tools.secmodv2.site': self.secconfig.default.site})
+        cherrypy.config.update({'tools.cpstats.on': configDict.get('cpstats', False)})
         cherrypy.log.error_log.debug('Application %s initialised in %s mode', self.app, self.mode)
 
     def _loadPages(self):

--- a/src/python/WMCore/WebTools/Welcome.py
+++ b/src/python/WMCore/WebTools/Welcome.py
@@ -6,6 +6,7 @@ A sane default welcome page
 import time
 from cherrypy import expose
 from cherrypy import __version__ as cherrypy_version
+from cherrypy.lib import cpstats
 from Cheetah import Version as cheetah_version
 from WMCore.WebTools.Page import Page
 
@@ -49,3 +50,8 @@ class Welcome(Page):
         Return the index.
         """
         return self.index()
+
+    @expose
+    def stats(self):
+        "Return CherryPy stats dict about underlying service activities"
+        return cpstats.StatsPage().data()


### PR DESCRIPTION
The code provides ability to expose CherryPy statistics from https://cherrypydocrework.readthedocs.io/pkg/cherrypy.lib.html#module-cherrypy.lib.cpstats

Any web service which depends on WebTools/RESTModel class (e.g. DBS) will now serve CherryPy statistics via /stats endpoint, e.g. `cmsweb.cern.ch/dbs/stats` will provide this. The statistics dict will provide various metrics about underlying cherrypy activity. Here is an example of stats dict:
```
{
    "Cheroot HTTPServer 4517118096": {
        "Accepts": 0,
        "Accepts/sec": 0.0,
        "Bind Address": "('127.0.0.1', 8080)",
        "Bytes Read": -1,
        "Bytes Written": -1,
        "Enabled": false,
        "Queue": 0,
        "Read Throughput": -1,
        "Requests": -1,
        "Run time": -1,
        "Socket Errors": 0,
        "Threads": 10,
        "Threads Idle": 9,
        "Work Time": -1,
        "Worker Threads": {
            "CP Server Thread-10": {
                "Bytes Read": 0,
                "Bytes Written": 0,
                "Read Throughput": 0.0,
                "Requests": 0,
                "Work Time": 0,
                "Write Throughput": 0.0
            },
            "CP Server Thread-11": {
                "Bytes Read": 0,
                "Bytes Written": 0,
                "Read Throughput": 0.0,
                "Requests": 0,
                "Work Time": 0,
                "Write Throughput": 0.0
            },
            "CP Server Thread-12": {
                "Bytes Read": 0,
                "Bytes Written": 0,
                "Read Throughput": 0.0,
                "Requests": 0,
                "Work Time": 0,
                "Write Throughput": 0.0
            },
            "CP Server Thread-3": {
                "Bytes Read": 0,
                "Bytes Written": 0,
                "Read Throughput": 0.0,
                "Requests": 0,
                "Work Time": 0,
                "Write Throughput": 0.0
            },
            "CP Server Thread-4": {
                "Bytes Read": 0,
                "Bytes Written": 0,
                "Read Throughput": 0.0,
                "Requests": 0,
                "Work Time": 0,
                "Write Throughput": 0.0
            },
            "CP Server Thread-5": {
                "Bytes Read": 0,
                "Bytes Written": 0,
                "Read Throughput": 0.0,
                "Requests": 0,
                "Work Time": 0,
                "Write Throughput": 0.0
            },
            "CP Server Thread-6": {
                "Bytes Read": 0,
                "Bytes Written": 0,
                "Read Throughput": 0.0,
                "Requests": 0,
                "Work Time": 0,
                "Write Throughput": 0.0
            },
            "CP Server Thread-7": {
                "Bytes Read": 0,
                "Bytes Written": 0,
                "Read Throughput": 0.0,
                "Requests": 0,
                "Work Time": 0,
                "Write Throughput": 0.0
            },
            "CP Server Thread-8": {
                "Bytes Read": 0,
                "Bytes Written": 0,
                "Read Throughput": 0.0,
                "Requests": 0,
                "Work Time": 0,
                "Write Throughput": 0.0
            },
            "CP Server Thread-9": {
                "Bytes Read": 0,
                "Bytes Written": 0,
                "Read Throughput": 0.0,
                "Requests": 0,
                "Work Time": 0,
                "Write Throughput": 0.0
            }
        },
        "Write Throughput": -1
    },
    "CherryPy Applications": {
        "Bytes Read/Request": 0.0,
        "Bytes Read/Second": 0.0,
        "Bytes Written/Request": 0.0,
        "Bytes Written/Second": 0.0,
        "Current Requests": 1,
        "Current Time": 1558095776.530752,
        "Enabled": true,
        "Requests": {
            "123145431896064": {
                "Bytes Read": null,
                "Bytes Written": null,
                "Client": "127.0.0.1:56683",
                "End Time": null,
                "Processing Time": 0.0001900196075439453,
                "Request-Line": "GET /stats HTTP/1.1",
                "Response Status": null,
                "Start Time": 1558095776.530613
            }
        },
        "Requests/Second": 0.4752343140987292,
        "Server Version": "17.4.1",
        "Start Time": 1558095774.426585,
        "Total Bytes Read": 0,
        "Total Bytes Written": 0,
        "Total Requests": 1,
        "Total Time": 0,
        "Uptime": 2.1041579246520996
    }
}
```

Once we'll have this in place this statistics can be captured by Prometheus exporters and we'll get them in Grafana dashboards. To do that I need to write new cherrypy exporter to get this metrics.