### PR TITLE
Fix wmbs_location/state_time schema to default to 0

### DIFF
--- a/src/python/WMCore/WMBS/CreateWMBSBase.py
+++ b/src/python/WMCore/WMBS/CreateWMBSBase.py
@@ -124,7 +124,7 @@ class CreateWMBSBase(DBCreator):
                running_slots   INTEGER,
                pending_slots   INTEGER,
                plugin      VARCHAR(255),
-               state_time  INTEGER NOT NULL,
+               state_time  INTEGER DEFAULT 0,
                UNIQUE(site_name),
                FOREIGN KEY (state) REFERENCES wmbs_location_state(id))"""
 

--- a/src/python/WMCore/WMBS/Oracle/Create.py
+++ b/src/python/WMCore/WMBS/Oracle/Create.py
@@ -174,7 +174,7 @@ class Create(CreateWMBSBase):
                  running_slots   INTEGER,
                  pending_slots   INTEGER,
                  plugin      VARCHAR(255),
-                 state_time INTEGER NOT NULL
+                 state_time INTEGER DEFAULT 0
                  ) %s""" % tablespaceTable
 
         self.indexes["01_pk_wmbs_location"] = \


### PR DESCRIPTION
I was getting an IntegrityError while running the JobCreator_t unit tests with oracle backend [1].

[1]
```
IntegrityError: (cx_Oracle.IntegrityError) ORA-01400: cannot insert NULL into ("CMS_WMBS_PREPROD4"."WMBS_LOCATION"."STATE_TIME")

[SQL: INSERT INTO wmbs_location (id, site_name, ce_name, running_slots, pending_slots,
               plugin, cms_name, state, state_time)
               SELECT wmbs_location_SEQ.nextval, :location, :cename, :running_slots AS running_slots,
               :pending_slots AS pending_slots,
               :plugin AS plugin, :cmsname AS cms_name,
               (SELECT id FROM wmbs_location_state where name = 'Normal') AS state,
               :state_time AS state_time
               FROM DUAL
             WHERE NOT EXISTS (SELECT site_name FROM wmbs_location
                               WHERE site_name = :location)]
[parameters: {'plugin': None, 'state_time': None, 'cmsname': None, 'pending_slots': 0, 'running_slots': 0, 'cename': None, 'location': 'T2_US_Florida'}]
(Background on this error at: http://sqlalche.me/e/gkpj)
```