### PR TITLE
Added staging and staged request status

### DIFF
--- a/src/python/WMCore/ReqMgr/CherryPyThreads/StatusChangeTasks.py
+++ b/src/python/WMCore/ReqMgr/CherryPyThreads/StatusChangeTasks.py
@@ -11,9 +11,36 @@ from WMCore.Services.ReqMgr.ReqMgr import ReqMgr
 from WMCore.Services.WMStatsServer.WMStatsServer import WMStatsServer
 
 
+# FIXME: remove this function once MS Transferor is solid and in production
+def moveTransferorStatus(reqmgrSvc, logger):
+    """
+    Function to temporarily make the status transition supposed
+    to happen in the MS Transferor module.
+    Once that's fully functional and in production, we can completely
+    remove this function.
+    """
+    thisTransition = {"assigned": "staging",
+                      "staging": "staged"}
+    # Let's try to keep these requests in this status for a bit longer
+    # and give MS Transferor a chance to find them and run its logic.
+    # That's why starting with the inverse order
+    for status in ["staging", "assigned"]:
+        requests = reqmgrSvc.getRequestByStatus([status], detail=False)
+        newStatus = thisTransition[status]
+        for wf in requests:
+            reqmgrSvc.updateRequestStatus(wf, newStatus)
+            logger.info("%s in %s moved to %s", wf, status, newStatus)
+        logger.info("%d requests moved from: %s to: %s", len(requests), status, newStatus)
+    return
+
+
 def moveForwardStatus(reqmgrSvc, wfStatusDict, logger):
 
     for status, nextStatus in AUTO_TRANSITION.iteritems():
+        ### FIXME: remove this if statement when the function above gets removed
+        if status in ["staging", "assigned"]:
+            continue
+
         count = 0
         requests = reqmgrSvc.getRequestByStatus([status], detail=False)
         for wf in requests:
@@ -22,10 +49,15 @@ def moveForwardStatus(reqmgrSvc, wfStatusDict, logger):
                 continue
             elif stateFromGQ == status:
                 continue
-            elif stateFromGQ == "failed" and status == "assigned":
+            elif stateFromGQ == "failed" and status == "staged":
+                count += 1
+                reqmgrSvc.updateRequestStatus(wf, nextStatus[0])
+                logger.info("%s in %s moved to %s", wf, status, nextStatus[0])
+                continue
+            elif stateFromGQ == "failed" and status == "acquired":
                 count += 1
                 reqmgrSvc.updateRequestStatus(wf, stateFromGQ)
-                logger.debug("%s in %s moved to %s", wf, status, stateFromGQ)
+                logger.info("%s in %s moved to %s", wf, status, stateFromGQ)
                 continue
 
             try:
@@ -37,12 +69,12 @@ def moveForwardStatus(reqmgrSvc, wfStatusDict, logger):
             if status == "aborted" and i == 0:
                 count += 1
                 reqmgrSvc.updateRequestStatus(wf, "aborted-completed")
-                logger.debug("%s in %s moved to %s", wf, status, "aborted-completed")
+                logger.info("%s in %s moved to %s", wf, status, "aborted-completed")
             else:
                 for j in range(i + 1):
                     count += 1
                     reqmgrSvc.updateRequestStatus(wf, nextStatus[j])
-                    logger.debug("%s in %s moved to %s", wf, status, nextStatus[j])
+                    logger.info("%s in %s moved to %s", wf, status, nextStatus[j])
         logger.info("%s requests moved to new state from %s", count, status)
     return
 
@@ -131,6 +163,7 @@ class StatusChangeTasks(CherryPyPeriodicTask):
         wfStatusDict = gqService.getWorkflowStatusFromWQE()
 
         self.logger.info("Advancing status")
+        moveTransferorStatus(reqmgrSvc, self.logger)
         moveForwardStatus(reqmgrSvc, wfStatusDict, self.logger)
         moveToCompletedForNoWQJobs(reqmgrSvc, wfStatusDict, self.logger)
         moveToArchived(wmstatsSvc, reqmgrSvc, self.logDB, config.archiveDelayHours, self.logger)

--- a/src/python/WMCore/ReqMgr/DataStructs/RequestStatus.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/RequestStatus.py
@@ -13,14 +13,16 @@ REQUEST_STATE_TRANSITION = {
     "assignment-approved": ["assigned",  # manual transition
                             "rejected"],  # manual transition
 
-    "assigned": ["acquired",
+    "assigned": ["staging",
+                 "aborted"],  # manual transition
+    "staging": ["staged",
+                "aborted"],  # manual transition
+    "staged": ["acquired",
+               "aborted",  # manual transition
+               "failed"],
+    "acquired": ["running-open",
                  "aborted",  # manual transition
                  "failed"],
-
-    "acquired": ["running-open",
-                 "aborted",
-                 "failed"],
-
     "running-open": ["running-closed",
                      "force-complete",  # manual transition
                      "aborted"],  # manual transition
@@ -64,10 +66,11 @@ REQUEST_HUMAN_STATES = ["assignment-approved",
                         "rejected",
                         "aborted"]
 
-
 ACTIVE_STATUS = ["new",
                  "assignment-approved",
                  "assigned",
+                 "staging",
+                 "staged",
                  "acquired",
                  "running-open",
                  "running-closed",
@@ -79,6 +82,15 @@ ACTIVE_STATUS = ["new",
                  "aborted",
                  "aborted-completed",
                  "rejected"]
+
+### Used for monitoring in T0-WMStats. See: Services/WMStats/WMStatsReader
+T0_ACTIVE_STATUS = ["new",
+                    "Closed",
+                    "Merge",
+                    "Harvesting",
+                    "Processing Done",
+                    "AlcaSkim",
+                    "completed"]
 
 # if the state is not defined here (new) allows all the property to get
 # states in the key is the source states (need to define source states instead of destination states for GUI update)
@@ -95,6 +107,8 @@ ALLOWED_ACTIONS_FOR_STATUS = {
                             "NonCustodialSites", "NonCustodialSubType", "Override",
                             "AutoApproveSubscriptionSites", "SubscriptionPriority"],
     "assigned": ["RequestPriority"],
+    "staging": ["RequestPriority"],
+    "staged": ["RequestPriority"],
     "acquired": ["RequestPriority"],
     "running-open": ["RequestPriority"],
     "running-closed": ["RequestPriority"],
@@ -111,28 +125,33 @@ ALLOWED_ACTIONS_FOR_STATUS = {
     "rejected-archived": [],
 }
 
-# transition controlled by ReqMgr2 automatically
+# transition automatically controlled by ReqMgr2
 # aborted to completed instead of aborted-completed
 # since workqueue mapping doesn't have aborted-completed status.
 # but it need to be converted to aborted-completed whenever update db
-AUTO_TRANSITION = {"assigned": ["acquired", "running-open", "running-closed", "completed"],
+### NOTE: the order of the list matters and it's used for status transition
+AUTO_TRANSITION = {"assigned": ["staging", "staged", "acquired", "running-open", "running-closed", "completed"],
+                   "staging": ["staged", "acquired", "running-open", "running-closed", "completed"],
+                   "staged": ["acquired", "running-open", "running-closed", "completed"],
                    "acquired": ["running-open", "running-closed", "completed"],
                    "running-open": ["running-closed", "completed"],
                    "aborted": ["completed"],
                    "running-closed": ["completed"],
                    "force-complete": ["completed"]}
 
-# list of destiantion states which doesn't allow any additional arguement update
+
+# list of destination states which doesn't allow any additional arguement update
 STATES_ALLOW_ONLY_STATE_TRANSITION = [key for key, val in ALLOWED_ACTIONS_FOR_STATUS.iteritems() if len(val) == 0]
 # each item from STATUS_TRANSITION is a dictionary with 1 item, the key
 # is name of the status
 REQUEST_STATE_LIST = REQUEST_STATE_TRANSITION.keys()
 
-ACTIVE_STATUS_FILTER = {"RequestStatus": ['assigned', 'acquired', 'running-open',
-                                          'running-closed', 'force-complete', 'completed',
-                                          'closed-out']}
-ACTIVE_NO_CLOSEOUT_FILTER = {"RequestStatus": ['assigned', 'acquired', 'running-open',
-                                          'running-closed', 'force-complete', 'completed']}
+ACTIVE_STATUS_FILTER = {"RequestStatus": ['assigned', 'staging', 'staged', 'acquired',
+                                          'running-open', 'running-closed', 'force-complete',
+                                          'completed', 'closed-out']}
+ACTIVE_NO_CLOSEOUT_FILTER = {"RequestStatus": ['assigned', 'staging', 'staged', 'acquired',
+                                               'running-open', 'running-closed', 'force-complete',
+                                               'completed']}
 
 def check_allowed_transition(preState, postState):
     stateList = REQUEST_STATE_TRANSITION.get(preState, [])

--- a/src/python/WMCore/Services/WMStats/WMStatsReader.py
+++ b/src/python/WMCore/Services/WMStats/WMStatsReader.py
@@ -5,6 +5,7 @@ from WMCore.Database.CMSCouch import CouchServer
 from WMCore.Lexicon import splitCouchServiceURL, sanitizeURL
 from WMCore.Services.RequestDB.RequestDBReader import RequestDBReader
 from WMCore.Services.WMStats.DataStruct.RequestInfoCollection import RequestInfo
+from WMCore.ReqMgr.DataStructs.RequestStatus import T0_ACTIVE_STATUS, ACTIVE_STATUS
 
 REQUEST_PROPERTY_MAP = {
     "_id": "_id",
@@ -54,30 +55,6 @@ def convertToLegacyFormat(requestDoc):
 
 
 class WMStatsReader(object):
-    # TODO need to get this from reqmgr api
-    ACTIVE_STATUS = ["new",
-                     "assignment-approved",
-                     "assigned",
-                     "acquired",
-                     "running",
-                     "running-open",
-                     "running-closed",
-                     "failed",
-                     "force-complete",
-                     "completed",
-                     "closed-out",
-                     "announced",
-                     "aborted",
-                     "aborted-completed",
-                     "rejected"]
-
-    T0_ACTIVE_STATUS = ["new",
-                        "Closed",
-                        "Merge",
-                        "Harvesting",
-                        "Processing Done",
-                        "AlcaSkim",
-                        "completed"]
 
     def __init__(self, couchURL, appName="WMStats", reqdbURL=None, reqdbCouchApp="ReqMgr"):
         self._sanitizeURL(couchURL)
@@ -298,11 +275,11 @@ class WMStatsReader(object):
 
     def getActiveData(self, jobInfoFlag=False):
 
-        return self.getRequestByStatus(WMStatsReader.ACTIVE_STATUS, jobInfoFlag)
+        return self.getRequestByStatus(ACTIVE_STATUS, jobInfoFlag)
 
     def getT0ActiveData(self, jobInfoFlag=False):
 
-        return self.getRequestByStatus(WMStatsReader.T0_ACTIVE_STATUS, jobInfoFlag)
+        return self.getRequestByStatus(T0_ACTIVE_STATUS, jobInfoFlag)
 
     def getRequestByStatus(self, statusList, jobInfoFlag=False, limit=None, skip=None,
                            legacyFormat=False):

--- a/src/python/WMCore/Services/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/Services/WorkQueue/WorkQueue.py
@@ -6,7 +6,7 @@ from WMCore.WorkQueue.DataStructs.WorkQueueElement import STATES
 
 
 def convertWQElementsStatusToWFStatus(elementsStatusSet):
-    '''
+    """
     Defined Workflow status from its WorkQeuueElement status.
     :param: elementsStatusSet - dictionary of {request_name: set of all WQE status of this request, ...}
     :returns: request status
@@ -22,7 +22,7 @@ def convertWQElementsStatusToWFStatus(elementsStatusSet):
                in Failed status, then just follow the usual request status.
 
     CancelRequest status treated as transient status.
-    '''
+    """
     if len(elementsStatusSet) == 0:
         return None
 

--- a/src/python/WMCore/WorkQueue/WorkQueueReqMgrInterface.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueReqMgrInterface.py
@@ -209,8 +209,7 @@ class WorkQueueReqMgrInterface(object):
         Get available requests and sort by team and priority
         returns [(team, request_name, request_spec_url)]
         """
-
-        tempResults = self.reqMgr2.getRequestByStatus("assigned")
+        tempResults = self.reqMgr2.getRequestByStatus("staged")
         filteredResults = []
         for requests in tempResults:
             for request in requests.values():


### PR DESCRIPTION
Fixes #9134 , #9192 and #9193

Sumary of changes is:
* added two new request status: `staging` and `staged`
* global workqueue will acquire work sitting in status `staged` instead of `assigned`
* ReqMgr2 CherryPy thread taking care of the following status transition (this will be moved to ReqMgr2MS in the near future)
  * `assigned to staging`
  * `staging to staged`