### PR TITLE
Dont perform write operations from MS Transferor

### DIFF
--- a/src/python/WMCore/MicroService/Unified/Transferor.py
+++ b/src/python/WMCore/MicroService/Unified/Transferor.py
@@ -350,7 +350,8 @@ class MSManager(object):
             self.logger.debug('%s changing %s status of record %s to req_status=%s' \
                 % (prefix, request, rec, req_status))
             if rec.get('reqStatus', None) != req_status:
-                self.svc.reqmgr.updateRequestStatus(request, req_status)
+                ### FIXME: we're still not executing write operations from MS
+                #self.svc.reqmgr.updateRequestStatus(request, req_status)
                 self.store.update(request, {'reqStatus': req_status})
             if req_status == 'staged':
                 self.store.delete(request)


### PR DESCRIPTION
Change introduced in this PR: https://github.com/dmwm/WMCore/pull/9140

Let's make sure central production services don't rely on MS Transferor until it becomes solid.
This transition is taken care by ReqMgr2 CP thread, from this PR: https://github.com/dmwm/WMCore/pull/9209