### PR TITLE
update CherryPy version in the requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # All dependencies needed to run WMAgent
 Cheetah==2.4.0
-CherryPy==5.4.0
+CherryPy==17.4.0
 Markdown==3.0.1
 MySQL-python==1.2.5
 SQLAlchemy==1.3.3

--- a/requirements.wmagent.txt
+++ b/requirements.wmagent.txt
@@ -1,6 +1,5 @@
 # All dependencies needed to run WMAgent
 Cheetah==2.4.0
-CherryPy==5.4.0
 Markdown==3.0.1
 MySQL-python==1.2.5
 SQLAlchemy==1.3.3


### PR DESCRIPTION
#### Status
ready

#### Description
Mirroring changes applied to the cmsdist spec files, WMCore central services are now running under CherryPy 17.4.0
And WMAgent no longer depends on CherryPy, so removing it from its requirements.

#### Is it backward compatible (if not, which system it affects?)
Yes, it didn't require any deployment changes.

#### Related PRs
https://github.com/cms-sw/cmsdist/pull/4480

#### External dependencies / deployment changes
no
