### PR TITLE
Minor improvements to MS Transferor; don.t query gwmsmon

### DIFF
--- a/src/python/WMCore/MicroService/Unified/Common.py
+++ b/src/python/WMCore/MicroService/Unified/Common.py
@@ -22,7 +22,6 @@ import urllib
 
 # WMCore modules
 from Utils.CertTools import getKeyCertFromEnv
-from WMCore.Services.ReqMgr.ReqMgr import ReqMgr
 from WMCore.Services.pycurl_manager import RequestHandler
 from WMCore.Services.pycurl_manager import getdata as multi_getdata
 
@@ -286,9 +285,9 @@ def reqmgrUrl(url=None):
 
 def reqmgrCacheUrl(url=None):
     "Return ReqMgr cache url"
-    if not url:
-        url = 'https://cmsweb.cern.ch/couchdb/reqmgr_workload_cache'
-    return uConfig.get('reqmgrCacheUrl', url)
+    url = reqmgrUrl()
+    url = url.replace("reqmgr2", "couchdb/reqmgr_workload_cache")
+    return url
 
 def phedexUrl(url=None):
     "Return PhEDEx url"

--- a/src/python/WMCore/MicroService/Unified/SiteInfo.py
+++ b/src/python/WMCore/MicroService/Unified/SiteInfo.py
@@ -35,8 +35,7 @@ from Utils.Patterns import Singleton
 from WMCore.Services.pycurl_manager import RequestHandler
 from WMCore.Services.pycurl_manager import getdata as multi_getdata, cern_sso_cookie
 from WMCore.MicroService.Unified.Common import agentInfoUrl, \
-        phedexUrl, cert, ckey, uConfig, stucktransferUrl, monitoringUrl, \
-        dashboardUrl
+        phedexUrl, cert, ckey, uConfig, monitoringUrl, dashboardUrl
 
 def getNodeQueues():
     "Helper function to fetch nodes usage from PhEDEx data service"
@@ -74,10 +73,13 @@ class SiteCache(with_metaclass(Singleton, object)):
             '%s/getplotdata?columnid=159&batch=1&lastdata=1' % dashboardUrl(),
             '%s/getplotdata?columnid=160&batch=1&lastdata=1' % dashboardUrl(),
             '%s/getplotdata?columnid=237&batch=1&lastdata=1' % dashboardUrl(),
-            'https://cms-gwmsmon.cern.ch/totalview/json/site_summary',
-            'https://cms-gwmsmon.cern.ch/prodview/json/site_summary',
-            'https://cms-gwmsmon.cern.ch/poolview/json/totals',
-            'https://cms-gwmsmon.cern.ch/prodview/json/maxusedcpus',
+            ### FIXME: these calls to gwmsmon are failing pretty badly with
+            ### "302 Found" and failing to decode, causing a huge error dump
+            ### to the logs
+            # 'https://cms-gwmsmon.cern.ch/totalview/json/site_summary',
+            # 'https://cms-gwmsmon.cern.ch/prodview/json/site_summary',
+            # 'https://cms-gwmsmon.cern.ch/poolview/json/totals',
+            # 'https://cms-gwmsmon.cern.ch/prodview/json/maxusedcpus',
             'http://cmsgwms-frontend-global.cern.ch/vofrontend/stage/mcore_siteinfo.json',
             'http://t3serv001.mit.edu/~cmsprod/IntelROCCS/Detox/SitesInfo.txt',
             '%s/storageoverview/latest/StorageOverview.json' % monitoringUrl(),


### PR DESCRIPTION
Fixes #9223 

#### Status
not-tested

#### Description
Minor improvements to MS Transferor module, like:
* read the reqmgr2 and dbs url from the config file
* commented out any queries to gwmsmon, which is failing BIG time at the moment
* log the whole exception/traceback in case of general exceptions

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Related to #9216 and #9140 

#### External dependencies / deployment changes
Yes, it needs these deployment changes: https://github.com/dmwm/deployment/pull/776
