### PR TITLE
Use ReqMgrAux service to get campaign name for given request

### DIFF
--- a/src/python/WMCore/MicroService/Unified/Transferor.py
+++ b/src/python/WMCore/MicroService/Unified/Transferor.py
@@ -198,7 +198,8 @@ class MSManager(object):
 
     def requestCampaign(self, req):
         "Return request campaign"
-        return 'campaign_TODO' # TODO
+        cname = "" # TODO: we should get it somehow
+        return self.svc.reqmgraux.getCampaignConfig(cname)
 
     def requestConfiguration(self, req):
         "Return request configuration"


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/9228

#### Status
in development

#### Description
implement how to get campaign configuration for given request

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
https://github.com/dmwm/WMCore/issues/9228

#### External dependencies / deployment changes
no