### PR TITLE
Make APIMethodMismatch exception verbose to print details of what actually happened

### DIFF
--- a/src/python/WMCore/REST/Error.py
+++ b/src/python/WMCore/REST/Error.py
@@ -112,6 +112,12 @@ class NoSuchInstance(RESTError):
     app_code = 206
     message = "No such instance"
 
+class APINotSupported(RESTError):
+    "The request URL provides wrong API argument."
+    http_code = 404
+    app_code = 207
+    message = "API not supported"
+
 class DatabaseError(RESTError):
     """Parent class for database-related errors.
 

--- a/src/python/WMCore/REST/Server.py
+++ b/src/python/WMCore/REST/Server.py
@@ -767,9 +767,14 @@ class MiniRESTApi:
             raise APINotSpecified()
         api = param.args.pop(0)
         if api not in self.methods[request.method]:
-            response.headers['Allow'] = \
-                " ".join(sorted([m for m, d in self.methods.iteritems() if api in d]))
-            raise APIMethodMismatch()
+            methods = " ".join(sorted([m for m, d in self.methods.iteritems() if api in d]))
+            response.headers['Allow'] = methods
+            if not methods:
+                msg = 'Api "%s" not found. This method supports these Apis: %s' % (api, self.methods[request.method].keys())
+                raise APINotSupported(msg)
+            else:
+                msg = 'Api "%s" only supported in method(s): "%s"' % (api, methods)
+                raise APIMethodMismatch(msg)
         apiobj = self.methods[request.method][api]
 
         # Check what format the caller requested. At least one is required; HTTP


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/9233

#### Status
In development

#### Description
Provide details of failed API in exception message which will allow to understand what actually happens

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
https://github.com/dmwm/WMCore/issues/9233

#### External dependencies / deployment changes
no
