### PR TITLE
Make PyCondorAPI compatible with HTCondor v8.8.3

### DIFF
--- a/src/python/WMCore/Services/PyCondor/PyCondorAPI.py
+++ b/src/python/WMCore/Services/PyCondor/PyCondorAPI.py
@@ -79,7 +79,9 @@ class PyCondorAPI(object):
         """
         try:
             scheddAd = self.coll.locate(htcondor.DaemonTypes.Schedd)
-            isOverloaded = scheddAd['CurbMatchmaking'].eval()
+            q = self.coll.query(htcondor.AdTypes.Schedd, 'Name == "%s"' % scheddAd['Name'],
+                                projection=['CurbMatchmaking'])[0]
+            isOverloaded = q['CurbMatchmaking'].eval()
             return isOverloaded
         except Exception:
             # if there is an error, try to recreate the collector instance
@@ -87,7 +89,9 @@ class PyCondorAPI(object):
             self.coll = htcondor.Collector()
         try:
             scheddAd = self.coll.locate(htcondor.DaemonTypes.Schedd)
-            isOverloaded = scheddAd['CurbMatchmaking'].eval()
+            q = self.coll.query(htcondor.AdTypes.Schedd, 'Name == "%s"' % scheddAd['Name'],
+                                projection=['CurbMatchmaking'])[0]
+            isOverloaded = q['CurbMatchmaking'].eval()
         except Exception as ex:
             msg = "Condor failed to fetch schedd attributes."
             msg += "Error message: %s" % str(ex)


### PR DESCRIPTION
Makes WMCore compatible with HTCondor v8.8.3 python bindings. It also works with the current v8.5.7 binding.

https://github.com/cms-sw/cmsdist/pull/4899


#### Description
After locating the schedd, query it with the proper CurbMatchmaking projection. 

#### Is it backward compatible (if not, which system it affects?)
Yes, works with v8.5.7 too.

#### Related PRs
https://github.com/cms-sw/cmsdist/pull/4899
