### PR TITLE
Enable CherryPy stats for internal HTTP server

### DIFF
--- a/src/python/WMCore/WebTools/Root.py
+++ b/src/python/WMCore/WebTools/Root.py
@@ -269,6 +269,7 @@ class Root(Harness):
                                         'tools.secmodv2.group': self.secconfig.default.group,
                                         'tools.secmodv2.site': self.secconfig.default.site})
         cherrypy.config.update({'tools.cpstats.on': configDict.get('cpstats', False)})
+        cherrypy.config.update({'server.statistics': configDict.get('cpstats', False)})
         cherrypy.log.error_log.debug('Application %s initialised in %s mode', self.app, self.mode)
         cherrypy.log.access_log.info("Final CherryPy configuration: %s" % pformat(cherrypy.config))
 


### PR DESCRIPTION
Fixes #<GH_Issue_Number>

#### Status
ready

#### Description
Upon further investigation with zeroed values in CherryPy HTTP server metrics I found that an additional parameter should be turned on in order to enable them. There are two type of stats: one which is controlled by `tools.cpstats.on` flag enabled CherryPy application statistics, while another one which is controlled by `server.statistics` flag is enable internal HTTP server stats.


#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
https://github.com/dmwm/WMCore/pull/9205

#### External dependencies / deployment changes
no