### PR TITLE
Increase wmbs_fileset.name column from 700 to 767 varchar

### DIFF
--- a/src/python/WMCore/WMBS/CreateWMBSBase.py
+++ b/src/python/WMCore/WMBS/CreateWMBSBase.py
@@ -67,7 +67,7 @@ class CreateWMBSBase(DBCreator):
         self.create["01wmbs_fileset"] = \
             """CREATE TABLE wmbs_fileset (
                id          INTEGER      PRIMARY KEY AUTO_INCREMENT,
-               name        VARCHAR(700) NOT NULL,
+               name        VARCHAR(767) NOT NULL,
                open        INT(1)       NOT NULL DEFAULT 0,
                last_update INTEGER      NOT NULL,
                UNIQUE (name))"""
@@ -169,8 +169,8 @@ class CreateWMBSBase(DBCreator):
             """CREATE TABLE wmbs_workflow (
                id           INTEGER          PRIMARY KEY AUTO_INCREMENT,
                spec         VARCHAR(700)     NOT NULL,
-               name         VARCHAR(700)     NOT NULL,
-               task         VARCHAR(700)     NOT NULL,
+               name         VARCHAR(255)     NOT NULL,
+               task         VARCHAR(767)     NOT NULL,
                type         VARCHAR(255),
                owner        INTEGER          NOT NULL,
                alt_fs_close INT(1)           NOT NULL,

--- a/src/python/WMCore/WMBS/MySQL/Create.py
+++ b/src/python/WMCore/WMBS/MySQL/Create.py
@@ -27,7 +27,7 @@ class Create(CreateWMBSBase):
         self.create["01wmbs_fileset"] = \
             """CREATE TABLE wmbs_fileset (
                id          INTEGER      PRIMARY KEY AUTO_INCREMENT,
-               name        VARCHAR(700) NOT NULL,
+               name        VARCHAR(767) NOT NULL,
                open        INT(1)       NOT NULL DEFAULT 0,
                last_update INT(11)      NOT NULL,
                UNIQUE (name))"""

--- a/src/python/WMCore/WMBS/Oracle/Create.py
+++ b/src/python/WMCore/WMBS/Oracle/Create.py
@@ -55,7 +55,7 @@ class Create(CreateWMBSBase):
         self.create["01wmbs_fileset"] = \
             """CREATE TABLE wmbs_fileset (
                  id          INTEGER      NOT NULL,
-                 name        VARCHAR(700) NOT NULL,
+                 name        VARCHAR(767) NOT NULL,
                  open        CHAR(1)      CHECK (open IN ('0', '1' )) NOT NULL,
                  last_update INTEGER      NOT NULL
                  ) %s""" % tablespaceTable
@@ -273,7 +273,7 @@ class Create(CreateWMBSBase):
                  id    INTEGER      NOT NULL,
                  spec  VARCHAR(700) NOT NULL,
                  name  VARCHAR(255) NOT NULL,
-                 task  VARCHAR(700) NOT NULL,
+                 task  VARCHAR(767) NOT NULL,
                  type  VARCHAR(255),
                  owner INTEGER      NOT NULL,
                  alt_fs_close INTEGER NOT NULL,

--- a/test/python/WMCore_t/WMBS_t/Fileset_t.py
+++ b/test/python/WMCore_t/WMBS_t/Fileset_t.py
@@ -5,9 +5,6 @@ _Fileset_t_
 Unit tests for the WMBS Fileset class.
 """
 
-import logging
-import os
-import random
 import threading
 import unittest
 
@@ -19,7 +16,6 @@ from WMCore.WMBS.Job import Job
 from WMCore.WMBS.JobGroup import JobGroup
 from WMCore.WMBS.Subscription import Subscription
 from WMCore.WMBS.Workflow import Workflow
-from WMCore.WMFactory import WMFactory
 from WMQuality.TestInit import TestInit
 
 
@@ -75,6 +71,27 @@ class FilesetTest(unittest.TestCase):
 
         assert testFileset.exists() == False, \
             "ERROR: Fileset exists after it was deleted"
+
+        return
+
+    def testCreateDeleteLongChar(self):
+        """
+        _testCreateDeleteLongChar_
+
+        Create and delete a fileset name with 750 characters, InnoDB tables
+        are limited to 767 chars
+        """
+        # fileset name with 750 chars
+        fsetName = "test_Fileset_with_30_character" * 25
+        testFileset = Fileset(name=fsetName)
+
+        self.assertFalse(testFileset.exists())
+
+        testFileset.create()
+        self.assertTrue(testFileset.exists() >= 0)
+
+        testFileset.delete()
+        self.assertFalse(testFileset.exists())
 
         return
 


### PR DESCRIPTION
Fixes #9239

#### Status
not-tested

#### Description
With the increase in the number of tasks/steps in each workflow, and the use of long Task/Step names, we need to extend the column length such that it can store longer fileset names.

This is only buying us more time though, InnoDB tables have a prefix limitation of 767 bytes, which won't be enough in the near future. We'll actualy have to limit the TaskName/StepName fields to make sure it won't cause problems downstream.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Similar issue happened in the past: https://github.com/dmwm/WMCore/issues/5641

#### External dependencies / deployment changes
Database schema changes need to be manually applied to all production agents though.
```
ALTER TABLE wmbs_fileset MODIFY name VARCHAR(767);
ALTER TABLE wmbs_workflow MODIFY task VARCHAR(767);
commit;  # on oracle backend
```
