### PR TITLE
Set InnoDB tables to DYNAMIC row format; increased length of a few columns

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/MySQL/Create.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/Create.py
@@ -8,9 +8,9 @@ import threading
 
 from WMCore.Database.DBCreator import DBCreator
 
-class Create(DBCreator):
 
-    def __init__(self, logger = None, dbi = None, params = None):
+class Create(DBCreator):
+    def __init__(self, logger=None, dbi=None, params=None):
         """
         _init_
 
@@ -65,12 +65,12 @@ class Create(DBCreator):
                  CONSTRAINT uq_dbs_alg UNIQUE (app_name, app_ver, app_fam, pset_hash))"""
 
         self.create[len(self.create)] = \
-              """CREATE TABLE dbsbuffer_algo_dataset_assoc (
-                   id         INTEGER AUTO_INCREMENT,
-                   algo_id    INTEGER NOT NULL,
-                   dataset_id INTEGER NOT NULL,
-                   in_dbs     INTEGER DEFAULT 0,
-                   PRIMARY KEY (id))"""
+            """CREATE TABLE dbsbuffer_algo_dataset_assoc (
+                 id         INTEGER AUTO_INCREMENT,
+                 algo_id    INTEGER NOT NULL,
+                 dataset_id INTEGER NOT NULL,
+                 in_dbs     INTEGER DEFAULT 0,
+                 PRIMARY KEY (id))"""
 
         self.create[len(self.create)] = \
             """CREATE TABLE dbsbuffer_workflow (
@@ -293,7 +293,6 @@ class Create(DBCreator):
                  FOREIGN KEY (dataset_algo)
                  REFERENCES dbsbuffer_algo_dataset_assoc(id)
                  ON DELETE CASCADE"""
-
 
         checksumTypes = ['cksum', 'adler32', 'md5']
         for i in checksumTypes:

--- a/src/python/WMComponent/DBS3Buffer/MySQL/Create.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/Create.py
@@ -35,8 +35,7 @@ class Create(DBCreator):
                  parent          VARCHAR(500),
                  prep_id         VARCHAR(255),
                  PRIMARY KEY (id),
-                 CONSTRAINT uq_dbs_dat UNIQUE (path)
-               ) ENGINE=InnoDB"""
+                 CONSTRAINT uq_dbs_dat UNIQUE (path))"""
 
         self.create[len(self.create)] = \
             """CREATE TABLE dbsbuffer_dataset_subscription (
@@ -51,8 +50,7 @@ class Create(DBCreator):
                  phedex_group           VARCHAR(100),
                  delete_blocks          INTEGER,
                  PRIMARY KEY (id),
-                 CONSTRAINT uq_dbs_dat_sub UNIQUE (dataset_id, site, custodial, auto_approve, move, priority)
-               ) ENGINE=InnoDB"""
+                 CONSTRAINT uq_dbs_dat_sub UNIQUE (dataset_id, site, custodial, auto_approve, move, priority))"""
 
         self.create[len(self.create)] = \
             """CREATE TABLE dbsbuffer_algo (
@@ -64,8 +62,7 @@ class Create(DBCreator):
                  config_content LONGTEXT,
                  in_dbs         INTEGER,
                  PRIMARY KEY (id),
-                 CONSTRAINT uq_dbs_alg UNIQUE (app_name, app_ver, app_fam, pset_hash)
-               ) ENGINE=InnoDB"""
+                 CONSTRAINT uq_dbs_alg UNIQUE (app_name, app_ver, app_fam, pset_hash))"""
 
         self.create[len(self.create)] = \
               """CREATE TABLE dbsbuffer_algo_dataset_assoc (
@@ -73,8 +70,7 @@ class Create(DBCreator):
                    algo_id    INTEGER NOT NULL,
                    dataset_id INTEGER NOT NULL,
                    in_dbs     INTEGER DEFAULT 0,
-                   PRIMARY KEY (id)
-                 ) ENGINE = InnoDB"""
+                   PRIMARY KEY (id))"""
 
         self.create[len(self.create)] = \
             """CREATE TABLE dbsbuffer_workflow (
@@ -87,8 +83,7 @@ class Create(DBCreator):
                  block_close_max_size         BIGINT,
                  completed                    INTEGER       DEFAULT 0,
                  PRIMARY KEY (id),
-                 CONSTRAINT uq_dbs_wor UNIQUE (name, task)
-               ) ENGINE = InnoDB"""
+                 CONSTRAINT uq_dbs_wor UNIQUE (name, task))"""
 
         self.create[len(self.create)] = \
             """CREATE TABLE dbsbuffer_file (
@@ -103,39 +98,33 @@ class Create(DBCreator):
                  workflow              INTEGER,
                  LastModificationDate  INTEGER,
                  PRIMARY KEY (id),
-                 CONSTRAINT uq_dbs_fil UNIQUE (lfn)
-               ) ENGINE=InnoDB"""
+                 CONSTRAINT uq_dbs_fil UNIQUE (lfn))"""
 
         self.create[len(self.create)] = \
             """CREATE TABLE dbsbuffer_file_parent (
                  child  INTEGER NOT NULL,
                  parent INTEGER NOT NULL,
-                 CONSTRAINT pk_dbs_fil_par PRIMARY KEY (child, parent)
-               ) ENGINE=InnoDB
-               """
+                 CONSTRAINT pk_dbs_fil_par PRIMARY KEY (child, parent))"""
 
         self.create[len(self.create)] = \
             """CREATE TABLE dbsbuffer_file_runlumi_map (
                  filename    INTEGER NOT NULL,
                  run         INTEGER NOT NULL,
                  lumi        INTEGER NOT NULL,
-                 num_events      INTEGER
-               ) ENGINE=InnoDB"""
+                 num_events      INTEGER)"""
 
         self.create[len(self.create)] = \
             """CREATE TABLE dbsbuffer_location (
                  id       INTEGER      AUTO_INCREMENT,
                  pnn  VARCHAR(255) NOT NULL,
                  PRIMARY KEY (id),
-                 CONSTRAINT uq_dbs_loc UNIQUE (pnn)
-               ) ENGINE=InnoDB"""
+                 CONSTRAINT uq_dbs_loc UNIQUE (pnn))"""
 
         self.create[len(self.create)] = \
             """CREATE TABLE dbsbuffer_file_location (
                  filename INTEGER NOT NULL,
                  location INTEGER NOT NULL,
-                 CONSTRAINT pk_dbs_fil_loc PRIMARY KEY (filename, location)
-               ) ENGINE=InnoDB"""
+                 CONSTRAINT pk_dbs_fil_loc PRIMARY KEY (filename, location))"""
 
         self.create[len(self.create)] = \
             """CREATE TABLE dbsbuffer_block (
@@ -147,23 +136,20 @@ class Create(DBCreator):
                  status       VARCHAR(20),
                  deleted      INTEGER      DEFAULT 0,
                  PRIMARY KEY (id),
-                 CONSTRAINT uq_dbs_blo UNIQUE (blockname, location)
-               ) ENGINE=InnoDB"""
+                 CONSTRAINT uq_dbs_blo UNIQUE (blockname, location))"""
 
         self.create[len(self.create)] = \
             """CREATE TABLE dbsbuffer_checksum_type (
                  id   INTEGER      AUTO_INCREMENT,
                  type VARCHAR(255),
-                 PRIMARY KEY (id)
-               ) ENGINE=InnoDB"""
+                 PRIMARY KEY (id))"""
 
         self.create[len(self.create)] = \
             """CREATE TABLE dbsbuffer_file_checksums (
                  fileid  INTEGER,
                  typeid  INTEGER,
                  cksum   VARCHAR(100),
-                 CONSTRAINT pk_dbs_fil_che PRIMARY KEY (fileid, typeid)
-               ) ENGINE=InnoDB"""
+                 CONSTRAINT pk_dbs_fil_che PRIMARY KEY (fileid, typeid))"""
 
         #
         # Indexes
@@ -316,3 +302,6 @@ class Create(DBCreator):
                                    VALUES ('%s')
                                    """ % (i)
             self.inserts["wmbs_checksum_type_%s" % (i)] = checksumTypeQuery
+
+        for i in self.create.keys():
+            self.create[i] += " ENGINE=InnoDB ROW_FORMAT=DYNAMIC"

--- a/src/python/WMCore/Agent/Database/CreateAgentBase.py
+++ b/src/python/WMCore/Agent/Database/CreateAgentBase.py
@@ -27,14 +27,6 @@ class CreateAgentBase(DBCreator):
         if dbi is None:
             dbi = myThread.dbi
 
-        tablespaceTable = ""
-        tablespaceIndex = ""
-        if params:
-            if "tablespace_table" in params:
-                tablespaceTable = "TABLESPACE %s" % params["tablespace_table"]
-            if "tablespace_index" in params:
-                tablespaceIndex = "USING INDEX TABLESPACE %s" % params["tablespace_index"]
-
         DBCreator.__init__(self, logger, dbi)
 
         self.create["01wm_components"] = \

--- a/src/python/WMCore/Agent/Database/MySQL/Create.py
+++ b/src/python/WMCore/Agent/Database/MySQL/Create.py
@@ -27,7 +27,7 @@ class Create(CreateAgentBase):
 
     def execute(self, conn = None, transaction = None):
         for i in self.create.keys():
-            self.create[i] = self.create[i] + " ENGINE=InnoDB"
+            self.create[i] += " ENGINE=InnoDB ROW_FORMAT=DYNAMIC"
             self.create[i] = self.create[i].replace('INTEGER', 'INT(11)')
 
 

--- a/src/python/WMCore/Agent/Database/MySQL/Create.py
+++ b/src/python/WMCore/Agent/Database/MySQL/Create.py
@@ -7,16 +7,15 @@ Inherit from CreateAgentBase, and add MySQL specific substitutions (e.g. add
 INNODB).
 """
 
-
-
-
 from WMCore.Agent.Database.CreateAgentBase import CreateAgentBase
+
 
 class Create(CreateAgentBase):
     """
     Class to set up the Agent schema in a MySQL database
     """
-    def __init__(self, logger = None, dbi = None, params = None):
+
+    def __init__(self, logger=None, dbi=None, params=None):
         """
         _init_
 
@@ -25,10 +24,9 @@ class Create(CreateAgentBase):
         """
         CreateAgentBase.__init__(self, logger, dbi, params)
 
-    def execute(self, conn = None, transaction = None):
+    def execute(self, conn=None, transaction=None):
         for i in self.create.keys():
             self.create[i] += " ENGINE=InnoDB ROW_FORMAT=DYNAMIC"
             self.create[i] = self.create[i].replace('INTEGER', 'INT(11)')
-
 
         return CreateAgentBase.execute(self, conn, transaction)

--- a/src/python/WMCore/BossAir/MySQL/Create.py
+++ b/src/python/WMCore/BossAir/MySQL/Create.py
@@ -47,7 +47,7 @@ class Create(DBCreator):
                 PRIMARY KEY (id),
                 UNIQUE (name)
                 )
-                ENGINE = InnoDB DEFAULT CHARSET=latin1;
+                ENGINE=InnoDB ROW_FORMAT=DYNAMIC;
             """
 
         self.create['02bl_runjob'] = \
@@ -70,7 +70,7 @@ class Create(DBCreator):
                FOREIGN KEY (location) REFERENCES wmbs_location(id) ON DELETE CASCADE,
                UNIQUE (retry_count, wmbs_id)
                )
-               ENGINE = InnoDB DEFAULT CHARSET=latin1;
+               ENGINE=InnoDB ROW_FORMAT=DYNAMIC;
 
             """
 

--- a/src/python/WMCore/ResourceControl/MySQL/Create.py
+++ b/src/python/WMCore/ResourceControl/MySQL/Create.py
@@ -30,6 +30,7 @@ class Create(DBCreator):
             pending_slots INTEGER NOT NULL,
             max_slots     INTEGER NOT NULL,
             FOREIGN KEY (site_id) REFERENCES wmbs_location(id) ON DELETE CASCADE,
-            FOREIGN KEY (sub_type_id) REFERENCES wmbs_sub_types(id) ON DELETE CASCADE)"""
+            FOREIGN KEY (sub_type_id) REFERENCES wmbs_sub_types(id) ON DELETE CASCADE
+            ) ENGINE=InnoDB ROW_FORMAT=DYNAMIC"""
 
         return

--- a/src/python/WMCore/ResourceControl/MySQL/Create.py
+++ b/src/python/WMCore/ResourceControl/MySQL/Create.py
@@ -5,11 +5,10 @@ _Create_
 Class for creating MySQL specific schema for resource control.
 """
 
-
-
-
 import threading
+
 from WMCore.Database.DBCreator import DBCreator
+
 
 class Create(DBCreator):
     """
@@ -17,7 +16,8 @@ class Create(DBCreator):
 
     Class for creating MySQL specific schema for resource control.
     """
-    def __init__(self, logger = None, dbi = None, params = None):
+
+    def __init__(self, logger=None, dbi=None, params=None):
         myThread = threading.currentThread()
         DBCreator.__init__(self, myThread.logger, myThread.dbi)
         self.create = {}

--- a/src/python/WMCore/ResourceControl/Oracle/Create.py
+++ b/src/python/WMCore/ResourceControl/Oracle/Create.py
@@ -25,13 +25,10 @@ class Create(DBCreator):
         self.constraints = {}
 
         tablespaceTable = ""
-        tablespaceIndex = ""
 
         if params:
             if "tablespace_table" in params:
                 tablespaceTable = "TABLESPACE %s" % params["tablespace_table"]
-            if "tablespace_index" in params:
-                tablespaceIndex = "USING INDEX TABLESPACE %s" % params["tablespace_index"]
 
         self.create["rc_threshold"] = """
         CREATE TABLE rc_threshold(

--- a/src/python/WMCore/ResourceControl/Oracle/Create.py
+++ b/src/python/WMCore/ResourceControl/Oracle/Create.py
@@ -5,12 +5,10 @@ _Create_
 Class for creating Oracle specific schema for resource control.
 """
 
-
-
-
 import threading
 
 from WMCore.Database.DBCreator import DBCreator
+
 
 class Create(DBCreator):
     """
@@ -18,7 +16,8 @@ class Create(DBCreator):
 
     Class for creating Oracle specific schema for resource control.
     """
-    def __init__(self, logger = None, dbi = None, params = None):
+
+    def __init__(self, logger=None, dbi=None, params=None):
         myThread = threading.currentThread()
         DBCreator.__init__(self, myThread.logger, myThread.dbi)
         self.create = {}
@@ -38,9 +37,9 @@ class Create(DBCreator):
             max_slots INTEGER NOT NULL) %s""" % tablespaceTable
 
         self.constraints["rc_threshold_fk1"] = \
-          """ALTER TABLE rc_threshold ADD
-               (CONSTRAINT rc_threshold_fk1 FOREIGN KEY (site_id) REFERENCES wmbs_location(id) ON DELETE CASCADE)"""
+            """ALTER TABLE rc_threshold ADD
+                 (CONSTRAINT rc_threshold_fk1 FOREIGN KEY (site_id) REFERENCES wmbs_location(id) ON DELETE CASCADE)"""
 
         self.constraints["rc_threshold_fk2"] = \
-          """ALTER TABLE rc_threshold ADD
-               (CONSTRAINT rc_threshold_fk2 FOREIGN KEY (sub_type_id) REFERENCES wmbs_sub_types(id) ON DELETE CASCADE)"""
+            """ALTER TABLE rc_threshold ADD
+                 (CONSTRAINT rc_threshold_fk2 FOREIGN KEY (sub_type_id) REFERENCES wmbs_sub_types(id) ON DELETE CASCADE)"""

--- a/src/python/WMCore/ThreadPool/MySQL/Create.py
+++ b/src/python/WMCore/ThreadPool/MySQL/Create.py
@@ -40,7 +40,7 @@ CREATE TABLE tp_threadpool(
    thread_pool_id          varchar(255) NOT NULL,
    state                 enum('queued','process') default 'queued',
    primary key(id)
-   ) ENGINE=InnoDB;
+   ) ENGINE=InnoDB ROW_FORMAT=DYNAMIC;
 """
         self.create['threadpool_buffer_in'] = """
 CREATE TABLE tp_threadpool_buffer_in(
@@ -51,7 +51,7 @@ CREATE TABLE tp_threadpool_buffer_in(
    thread_pool_id          varchar(255) NOT NULL,
    state                 enum('queued','process') default 'queued',
    primary key(id)
-   ) ENGINE=InnoDB;
+   ) ENGINE=InnoDB ROW_FORMAT=DYNAMIC;
 """
         self.create['threadpool_buffer_out'] = """
 CREATE TABLE tp_threadpool_buffer_out(
@@ -62,5 +62,5 @@ CREATE TABLE tp_threadpool_buffer_out(
    thread_pool_id          varchar(255) NOT NULL,
    state                 enum('queued','process') default 'queued',
    primary key(id)
-   ) ENGINE=InnoDB;
+   ) ENGINE=InnoDB ROW_FORMAT=DYNAMIC;
 """

--- a/src/python/WMCore/ThreadPool/MySQL/Create.py
+++ b/src/python/WMCore/ThreadPool/MySQL/Create.py
@@ -7,13 +7,10 @@ Class for creating MySQL specific schema for persistent messages.
 
 """
 
-
-
-
-
 import threading
 
 from WMCore.Database.DBCreator import DBCreator
+
 
 class Create(DBCreator):
     """
@@ -22,9 +19,7 @@ class Create(DBCreator):
     Class for creating MySQL specific schema for persistent messages.
     """
 
-
-
-    def __init__(self, logger = None, dbi = None, params = None):
+    def __init__(self, logger=None, dbi=None, params=None):
         myThread = threading.currentThread()
         DBCreator.__init__(self, myThread.logger, myThread.dbi)
         self.create = {}

--- a/src/python/WMCore/ThreadPool/MySQL/Queries.py
+++ b/src/python/WMCore/ThreadPool/MySQL/Queries.py
@@ -203,7 +203,7 @@ CREATE TABLE %s(
    payload                 text         NOT NULL,
    state                 enum('queued','process') default 'queued',
    primary key(id)
-   ) ENGINE=InnoDB; """ % (threadpool)
+   ) ENGINE=InnoDB ROW_FORMAT=DYNAMIC""" % (threadpool)
 
         self.execute(sqlStr, {})
 

--- a/src/python/WMCore/ThreadPool/MySQL/Queries.py
+++ b/src/python/WMCore/ThreadPool/MySQL/Queries.py
@@ -11,6 +11,7 @@ import threading
 
 from WMCore.Database.DBFormatter import DBFormatter
 
+
 class Queries(DBFormatter):
     """
     _Queries_
@@ -23,8 +24,7 @@ class Queries(DBFormatter):
         myThread = threading.currentThread()
         DBFormatter.__init__(self, myThread.logger, myThread.dbi)
 
-
-    def selectWork(self, args, pooltable = 'tp_threadpool'):
+    def selectWork(self, args, pooltable='tp_threadpool'):
         """
         Select work that is not yet being processed.
         """
@@ -33,7 +33,7 @@ class Queries(DBFormatter):
         # getting the same work.
         result = ''
         if pooltable in ['tp_threadpool', 'tp_threadpool_buffer_in', \
-            'tp_threadpool_buffer_out']:
+                         'tp_threadpool_buffer_out']:
             sqlStr = """
 SELECT min(id) FROM %s WHERE component = :component AND
 thread_pool_id = :thread_pool_id AND state='queued'
@@ -46,7 +46,7 @@ SELECT min(id) FROM %s WHERE state='queued'
             result = self.execute(sqlStr, {})
         return self.formatOne(result)
 
-    def retrieveWork(self, args, pooltable = 'tp_threadpool'):
+    def retrieveWork(self, args, pooltable='tp_threadpool'):
         """
         Retrieve work (its payload) from a queue.
         """
@@ -57,17 +57,16 @@ SELECT id, event,payload FROM %s WHERE id = :id
         result = self.execute(sqlStr, args)
         return self.formatOne(result)
 
-
-    def tagWork(self, args, pooltable = 'tp_threadpool'):
+    def tagWork(self, args, pooltable='tp_threadpool'):
         """
         Tag work in queue as being processed.
         """
         sqlStr = """
 UPDATE %s SET state='process' WHERE id = :id
-        """  % (pooltable)
+        """ % (pooltable)
         self.execute(sqlStr, args)
 
-    def removeWork(self, args, pooltable = 'tp_threadpool'):
+    def removeWork(self, args, pooltable='tp_threadpool'):
         """
         Remove work from the queue.
         """
@@ -76,13 +75,13 @@ DELETE FROM %s WHERE id = :id
         """ % (pooltable)
         self.execute(sqlStr, args)
 
-    def updateWorkStatus(self, args, pooltable = 'tp_threadpool'):
+    def updateWorkStatus(self, args, pooltable='tp_threadpool'):
         """
         Updates work status of work being processed.
         """
         # differentiate between one queue and multi queue
         if pooltable in ['tp_threadpool', 'tp_threadpool_buffer_in', \
-            'tp_threadpool_buffer_out']:
+                         'tp_threadpool_buffer_out']:
             sqlStr = """UPDATE %s SET state = 'queued'
                           WHERE component = :componentName AND
                                 thread_pool_id = :thread_pool_id
@@ -94,7 +93,7 @@ DELETE FROM %s WHERE id = :id
 
         return
 
-    def getQueueLength(self, args, pooltable = 'tp_threadpool'):
+    def getQueueLength(self, args, pooltable='tp_threadpool'):
         """
         Returns the queue length from the different tables
         through a parameterized query.
@@ -102,7 +101,7 @@ DELETE FROM %s WHERE id = :id
         # differentiate between onequeu and multi queue
         result = None
         if pooltable in ['tp_threadpool', 'tp_threadpool_buffer_in', \
-            'tp_threadpool_buffer_out']:
+                         'tp_threadpool_buffer_out']:
             sqlStr = """
 SELECT COUNT(*) FROM  %s WHERE component = :componentName
 AND thread_pool_id = :thread_pool_id
@@ -144,7 +143,7 @@ INSERT INTO %s(event,payload) SELECT event,payload FROM %s
         sqlStr1 = ''
         sqlStr2 = ''
         if source in ['tp_threadpool', 'tp_threadpool_buffer_in', \
-            'tp_threadpool_buffer_out']:
+                      'tp_threadpool_buffer_out']:
             # we need a for update in the select to prevent (harmless) deadlock
             # situations with innodb
             sqlStr1 = """
@@ -169,25 +168,25 @@ DELETE FROM %s ORDER BY id LIMIT %s
             self.execute(sqlStr1, {})
             self.execute(sqlStr2, {})
 
-    def insertWork(self, args, pooltable = 'tp_threadpool'):
+    def insertWork(self, args, pooltable='tp_threadpool'):
         """
         Inserts work into the database in case no thread can be found.
         """
         # differentiate between onequeu and multi queue
         if pooltable in ['tp_threadpool', 'tp_threadpool_buffer_in', \
-            'tp_threadpool_buffer_out']:
+                         'tp_threadpool_buffer_out']:
             sqlStr = """
 INSERT INTO %s(event,component,payload,thread_pool_id)
 VALUES(:event,:component,:payload,:thread_pool_id)
-        """  % (pooltable)
+        """ % (pooltable)
             self.execute(sqlStr, args)
         else:
             sqlStr = """
 INSERT INTO %s(event,payload)
 VALUES(:event,:payload)
-        """  % (pooltable)
-            self.execute(sqlStr, {'event':args['event'], \
-                'payload':args['payload']})
+        """ % (pooltable)
+            self.execute(sqlStr, {'event': args['event'], \
+                                  'payload': args['payload']})
 
     def insertThreadPoolTables(self, threadpool):
         """
@@ -207,9 +206,6 @@ CREATE TABLE %s(
 
         self.execute(sqlStr, {})
 
-
-
-
     def execute(self, sqlStr, args):
         """"
         __execute__
@@ -217,8 +213,8 @@ CREATE TABLE %s(
         and dbinterface object that is stored in the reserved words of
         the thread it operates in.
         """
-        #FIXME: we use this method in all kinds of places perhaps upgrade
-        #FIXME: this method?
+        # FIXME: we use this method in all kinds of places perhaps upgrade
+        # FIXME: this method?
         myThread = threading.currentThread()
         currentTransaction = myThread.transaction
         return currentTransaction.processData(sqlStr, args)

--- a/src/python/WMCore/WMBS/CreateWMBSBase.py
+++ b/src/python/WMCore/WMBS/CreateWMBSBase.py
@@ -67,7 +67,7 @@ class CreateWMBSBase(DBCreator):
         self.create["01wmbs_fileset"] = \
             """CREATE TABLE wmbs_fileset (
                id          INTEGER      PRIMARY KEY AUTO_INCREMENT,
-               name        VARCHAR(700) NOT NULL,
+               name        VARCHAR(1250) NOT NULL,
                open        INT(1)       NOT NULL DEFAULT 0,
                last_update INTEGER      NOT NULL,
                UNIQUE (name))"""
@@ -169,8 +169,8 @@ class CreateWMBSBase(DBCreator):
             """CREATE TABLE wmbs_workflow (
                id           INTEGER          PRIMARY KEY AUTO_INCREMENT,
                spec         VARCHAR(700)     NOT NULL,
-               name         VARCHAR(700)     NOT NULL,
-               task         VARCHAR(700)     NOT NULL,
+               name         VARCHAR(255)     NOT NULL,
+               task         VARCHAR(1250)     NOT NULL,
                type         VARCHAR(255),
                owner        INTEGER          NOT NULL,
                alt_fs_close INT(1)           NOT NULL,
@@ -303,8 +303,8 @@ class CreateWMBSBase(DBCreator):
                couch_record VARCHAR(255),
                location     INTEGER,
                outcome      INTEGER       DEFAULT 0,
-               cache_dir    VARCHAR(767)  DEFAULT 'None',
-               fwjr_path    VARCHAR(767),
+               cache_dir    VARCHAR(1250)  DEFAULT 'None',
+               fwjr_path    VARCHAR(1250),
                FOREIGN KEY (jobgroup)
                REFERENCES wmbs_jobgroup(id) ON DELETE CASCADE,
                FOREIGN KEY (state) REFERENCES wmbs_job_state(id),

--- a/src/python/WMCore/WMBS/MySQL/Create.py
+++ b/src/python/WMCore/WMBS/MySQL/Create.py
@@ -27,7 +27,7 @@ class Create(CreateWMBSBase):
         self.create["01wmbs_fileset"] = \
             """CREATE TABLE wmbs_fileset (
                id          INTEGER      PRIMARY KEY AUTO_INCREMENT,
-               name        VARCHAR(700) NOT NULL,
+               name        VARCHAR(1250) NOT NULL,
                open        INT(1)       NOT NULL DEFAULT 0,
                last_update INT(11)      NOT NULL,
                UNIQUE (name))"""
@@ -66,7 +66,7 @@ class Create(CreateWMBSBase):
 
     def execute(self, conn=None, transaction=None):
         for i in self.create.keys():
-            self.create[i] += " ENGINE=InnoDB"
+            self.create[i] += " ENGINE=InnoDB ROW_FORMAT=DYNAMIC"
             self.create[i] = self.create[i].replace('INTEGER', 'INT(11)')
 
         return CreateWMBSBase.execute(self, conn, transaction)

--- a/src/python/WMCore/WMBS/MySQL/WorkUnit/Add.py
+++ b/src/python/WMCore/WMBS/MySQL/WorkUnit/Add.py
@@ -7,11 +7,7 @@ MySQL implementation of WorkUnit.Add
 
 from __future__ import absolute_import, division, print_function
 
-import time
-
 from WMCore.Database.DBFormatter import DBFormatter
-
-MAX_EVENT = 2**31 - 1
 
 
 class Add(DBFormatter):
@@ -27,8 +23,8 @@ class Add(DBFormatter):
     assocSQL = ('INSERT INTO wmbs_frl_workunit_assoc (workunit, firstevent, lastevent, fileid, run, lumi)'
                 ' VALUES (LAST_INSERT_ID(), :firstevent, :lastevent, :fileid, :run, :lumi)')
 
-    def execute(self, taskid=None, retry_count=0, last_unit_count=0, last_submit_time=time.time(),
-                status=0, first_event=0, last_event=MAX_EVENT,
+    def execute(self, taskid=None, retry_count=0, last_unit_count=0, last_submit_time=0,
+                status=0, first_event=0, last_event=0,
                 fileid=None, run=None, lumi=None,
                 conn=None, transaction=False):
         """

--- a/src/python/WMCore/WMBS/Oracle/Create.py
+++ b/src/python/WMCore/WMBS/Oracle/Create.py
@@ -55,7 +55,7 @@ class Create(CreateWMBSBase):
         self.create["01wmbs_fileset"] = \
             """CREATE TABLE wmbs_fileset (
                  id          INTEGER      NOT NULL,
-                 name        VARCHAR(700) NOT NULL,
+                 name        VARCHAR(1250) NOT NULL,
                  open        CHAR(1)      CHECK (open IN ('0', '1' )) NOT NULL,
                  last_update INTEGER      NOT NULL
                  ) %s""" % tablespaceTable
@@ -273,7 +273,7 @@ class Create(CreateWMBSBase):
                  id    INTEGER      NOT NULL,
                  spec  VARCHAR(700) NOT NULL,
                  name  VARCHAR(255) NOT NULL,
-                 task  VARCHAR(700) NOT NULL,
+                 task  VARCHAR(1250) NOT NULL,
                  type  VARCHAR(255),
                  owner INTEGER      NOT NULL,
                  alt_fs_close INTEGER NOT NULL,
@@ -556,8 +556,8 @@ class Create(CreateWMBSBase):
                  couch_record VARCHAR(255),
                  location     INTEGER,
                  outcome      INTEGER       DEFAULT 0,
-                 cache_dir    VARCHAR(767)  DEFAULT 'None',
-                 fwjr_path    VARCHAR(767)
+                 cache_dir    VARCHAR(1250)  DEFAULT 'None',
+                 fwjr_path    VARCHAR(1250)
                  ) %s""" % tablespaceTable
 
         self.indexes["01_pk_wmbs_job"] = \

--- a/src/python/WMCore/WMBS/WorkUnit.py
+++ b/src/python/WMCore/WMBS/WorkUnit.py
@@ -12,7 +12,7 @@ import time
 from WMCore.DataStructs.WorkUnit import WorkUnit as DSWorkUnit
 from WMCore.WMBS.WMBSBase import WMBSBase
 
-MAX_EVENT = 2**31 - 1
+MAX_EVENT = 2 ** 31 - 1
 
 
 class WorkUnit(WMBSBase, DSWorkUnit):

--- a/src/python/WMCore/WMBS/WorkUnit.py
+++ b/src/python/WMCore/WMBS/WorkUnit.py
@@ -7,11 +7,12 @@ Represents a work unit in WMBS
 
 from __future__ import absolute_import, division, print_function
 
-import sys
 import time
 
 from WMCore.DataStructs.WorkUnit import WorkUnit as DSWorkUnit
 from WMCore.WMBS.WMBSBase import WMBSBase
+
+MAX_EVENT = 2**31 - 1
 
 
 class WorkUnit(WMBSBase, DSWorkUnit):
@@ -20,7 +21,7 @@ class WorkUnit(WMBSBase, DSWorkUnit):
     """
 
     def __init__(self, wuid=None, taskID=None, retryCount=0, lastUnitCount=None, lastSubmitTime=int(time.time()),
-                 status=0, firstEvent=1, lastEvent=sys.maxsize, fileid=None, runLumi=None):
+                 status=0, firstEvent=1, lastEvent=MAX_EVENT, fileid=None, runLumi=None):
         WMBSBase.__init__(self)
         DSWorkUnit.__init__(self, taskID=taskID, retryCount=retryCount, lastUnitCount=lastUnitCount,
                             lastSubmitTime=lastSubmitTime, status=status, firstEvent=firstEvent, lastEvent=lastEvent,

--- a/test/python/WMCore_t/WMBS_t/Fileset_t.py
+++ b/test/python/WMCore_t/WMBS_t/Fileset_t.py
@@ -5,9 +5,6 @@ _Fileset_t_
 Unit tests for the WMBS Fileset class.
 """
 
-import logging
-import os
-import random
 import threading
 import unittest
 
@@ -19,7 +16,6 @@ from WMCore.WMBS.Job import Job
 from WMCore.WMBS.JobGroup import JobGroup
 from WMCore.WMBS.Subscription import Subscription
 from WMCore.WMBS.Workflow import Workflow
-from WMCore.WMFactory import WMFactory
 from WMQuality.TestInit import TestInit
 
 
@@ -63,7 +59,7 @@ class FilesetTest(unittest.TestCase):
         """
         testFileset = Fileset(name="TestFileset")
 
-        assert testFileset.exists() == False, \
+        assert testFileset.exists() is False, \
             "ERROR: Fileset exists before it was created"
 
         testFileset.create()
@@ -73,8 +69,35 @@ class FilesetTest(unittest.TestCase):
 
         testFileset.delete()
 
-        assert testFileset.exists() == False, \
+        assert testFileset.exists() is False, \
             "ERROR: Fileset exists after it was deleted"
+
+        return
+
+    def testCreateDeleteLongChar(self):
+        """
+        _testCreateDeleteLongChar_
+
+        Create and delete a fileset name with 750 characters, InnoDB tables
+        are limited to 767 chars
+        """
+        # fileset name with 1000 chars
+        fsetName = "test_Fileset_with_50_character_and_anything_else_" * 20
+        testFileset = Fileset(name=fsetName)
+
+        self.assertFalse(testFileset.exists())
+        testFileset.create()
+        self.assertTrue(testFileset.exists() >= 0)
+        testFileset.delete()
+        self.assertFalse(testFileset.exists())
+
+        # fileset name with 1500 chars
+        fsetName = "test_Fileset_with_50_character_and_anything_else_" * 30
+        testFileset = Fileset(name=fsetName)
+
+        self.assertFalse(testFileset.exists())
+        with self.assertRaises(Exception):
+            testFileset.create()
 
         return
 
@@ -93,7 +116,7 @@ class FilesetTest(unittest.TestCase):
 
         testFileset = Fileset(name="TestFileset")
 
-        assert testFileset.exists() == False, \
+        assert testFileset.exists() is False, \
             "ERROR: Fileset exists before it was created"
 
         testFileset.create()
@@ -103,7 +126,7 @@ class FilesetTest(unittest.TestCase):
 
         myThread.transaction.rollback()
 
-        assert testFileset.exists() == False, \
+        assert testFileset.exists() is False, \
             "ERROR: Fileset exists after transaction was rolled back."
 
         return
@@ -119,7 +142,7 @@ class FilesetTest(unittest.TestCase):
         """
         testFileset = Fileset(name="TestFileset")
 
-        assert testFileset.exists() == False, \
+        assert testFileset.exists() is False, \
             "ERROR: Fileset exists before it was created"
 
         testFileset.create()
@@ -132,7 +155,7 @@ class FilesetTest(unittest.TestCase):
 
         testFileset.delete()
 
-        assert testFileset.exists() == False, \
+        assert testFileset.exists() is False, \
             "ERROR: Fileset exists after it was deleted"
 
         myThread.transaction.rollback()
@@ -157,11 +180,8 @@ class FilesetTest(unittest.TestCase):
         testFilesetC = Fileset(id=testFilesetA.id)
         testFilesetC.load()
 
-        assert type(testFilesetB.id) == int, \
-            "ERROR: Fileset id is not an int."
-
-        assert type(testFilesetC.id) == int, \
-            "ERROR: Fileset id is not an int."
+        self.assertTrue(isinstance(testFilesetB.id, int), "Fileset id is not an int.")
+        self.assertTrue(isinstance(testFilesetC.id, int), "Fileset id is not an int.")
 
         assert testFilesetB.id == testFilesetA.id, \
             "ERROR: Load from name didn't load id"
@@ -490,10 +510,10 @@ class FilesetTest(unittest.TestCase):
         testFilesetD = Fileset(name=testFilesetB.name)
         testFilesetD.load()
 
-        assert testFilesetC.open == False, \
+        assert testFilesetC.open is False, \
             "ERROR: FilesetC should be closed."
 
-        assert testFilesetD.open == True, \
+        assert testFilesetD.open is True, \
             "ERROR: FilesetD should be open."
 
         testFilesetA.markOpen(True)
@@ -504,10 +524,10 @@ class FilesetTest(unittest.TestCase):
         testFilesetF = Fileset(name=testFilesetB.name)
         testFilesetF.load()
 
-        assert testFilesetE.open == True, \
+        assert testFilesetE.open is True, \
             "ERROR: FilesetE should be open."
 
-        assert testFilesetF.open == False, \
+        assert testFilesetF.open is False, \
             "ERROR: FilesetF should be closed."
 
         myThread = threading.currentThread()


### PR DESCRIPTION
Fixes #9239 

#### Status
ready

#### Description
Summary of changes is:
* changed ROW_FORMAT from COMPACT to DYNAMIC (to support larger index prefix)
  * which depends on a new file format for MariaDB (Barracuda instead of Antelope)
* increased the column length for possible problematic strings (up to 1250 bytes now), like:
  * wmbs_job: cache_dir and fwjr_path
  * wmbs_fileset: name
  * wmbs_workflow:task

In the future, we should try to use COMPRESSED row format though. It's theoretically more CPU intensive but it takes much less storage (and is less I/O intensive as well). It's probably coupled to this ticket though: https://github.com/dmwm/WMCore/issues/9241

#### Is it backward compatible (if not, which system it affects?)
YES, in terms of requests. NO, in terms of database schema. It requires a new WMAgent deployment.

#### Related PRs
A more complete fix than https://github.com/dmwm/WMCore/pull/9240
Also related to this original issue: https://github.com/dmwm/WMCore/issues/5641

#### External dependencies / deployment changes
It depends on these deployment changes: https://github.com/dmwm/deployment/pull/783