### PR TITLE
removing the .read from the with open() file open method.

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
@@ -200,7 +200,7 @@ class DQMUpload(Executor):
                      % (key, os.path.basename(filename))) + crlf
             body += ('Content-Type: %s' % self.filetype(filename)) + crlf
             body += ('Content-Length: %d' % os.path.getsize(filename)) + crlf
-            with open(filename, "r").read() as fd:
+            with open(filename, "r") as fd:
                 body += crlf + fd.read() + crlf
             body += '--' + boundary + '--' + crlf + crlf
         return ('multipart/form-data; boundary=' + boundary, body)


### PR DESCRIPTION
Fixes #9186 

#### Status
ready

#### Description
Fixes the file open method.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
#9186 

#### External dependencies / deployment changes
None
