### PR TITLE
Update PUT behaviour for ReqMgrAux APIs; use PUT method for updating CMSSW releases

### DIFF
--- a/bin/wmagent-upload-config
+++ b/bin/wmagent-upload-config
@@ -2,33 +2,17 @@
 from __future__ import division, print_function
 
 import os
-import time
 from pprint import pformat
 
 from WMCore.Agent.DefaultConfig import DEFAULT_AGENT_CONFIG
 from WMCore.Configuration import loadConfigurationFile
 from WMCore.Services.ReqMgrAux.ReqMgrAux import ReqMgrAux
 
+wmConfig = loadConfigurationFile(os.environ['WMAGENT_CONFIG'])
+reqMgrAux = ReqMgrAux(wmConfig.General.ReqMgr2ServiceURL)
 
-def insertWMAgentConfig(reqMgrAux, agentName, agentConfig):
-    print("\nUploading new agent configuration to ReqMgrAux. Data is\n%s" % pformat(agentConfig))
-    res = reqMgrAux.postWMAgentConfig(agentName, agentConfig)
-    print(res)
-
-def removeWMAgentConfig(reqMgrAux, agentName):
-    print("Deleting previous config...")
-    reqMgrAux.deleteWMAgentConfig(agentName)
-    time.sleep(2)
-
-if __name__ == "__main__":
-    wmConfig = loadConfigurationFile(os.environ['WMAGENT_CONFIG'])
-    reqMgrAux = ReqMgrAux(wmConfig.General.ReqMgr2ServiceURL)
-
-    removeWMAgentConfig(reqMgrAux, wmConfig.Agent.hostName)
-    insertWMAgentConfig(reqMgrAux, wmConfig.Agent.hostName, DEFAULT_AGENT_CONFIG)
-
-    # check whether the document was properly inserted (for some reason,
-    # it doesn't get from time to time
-    if not reqMgrAux.getWMAgentConfig(wmConfig.Agent.hostName):
-        print("Agent config not found, trying to insert it again...")
-        insertWMAgentConfig(reqMgrAux, wmConfig.Agent.hostName, DEFAULT_AGENT_CONFIG)
+print("Posting agent default configuration:\n%s" % pformat(DEFAULT_AGENT_CONFIG))
+if not reqMgrAux.updateWMAgentConfig(wmConfig.Agent.hostName, DEFAULT_AGENT_CONFIG):
+    # then the document does not exist, create it
+    res = reqMgrAux.postWMAgentConfig(wmConfig.Agent.hostName, DEFAULT_AGENT_CONFIG)
+    print("Agent config successfully created: %s" % res.get("ok", False))

--- a/src/python/WMComponent/AgentStatusWatcher/DrainStatusPoller.py
+++ b/src/python/WMComponent/AgentStatusWatcher/DrainStatusPoller.py
@@ -9,9 +9,9 @@ __all__ = []
 
 import logging
 from Utils.Timers import timeFunction
+from WMComponent.AgentStatusWatcher.DrainStatusAPI import DrainStatusAPI
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 from WMCore.Services.ReqMgrAux.ReqMgrAux import ReqMgrAux
-from WMComponent.AgentStatusWatcher.DrainStatusAPI import DrainStatusAPI
 from WMCore.Services.PyCondor.PyCondorAPI import PyCondorAPI
 
 
@@ -109,24 +109,24 @@ class DrainStatusPoller(BaseWorkerThread):
 
         # update the aux db speed drain config with any changes
         if updateConfig:
-            self.reqAuxDB.updateAgentConfig(self.config.Agent.hostName, "SpeedDrainMode", True)
-            self.reqAuxDB.updateAgentConfig(self.config.Agent.hostName, "SpeedDrainConfig", speedDrainConfig)
+            self.agentConfig['SpeedDrainMode'] = True
+            self.reqAuxDB.updateAgentConfig(self.config.Agent.hostName, self.agentConfig)
 
         return
 
     def resetAgentSpeedDrainConfig(self):
         """
-        resetting SpeedDrainMode to False and SpeedDrainiConfig Enabled to False
+        resetting SpeedDrainMode to False and SpeedDrainConfig Enabled to False
         """
 
         if self.agentConfig.get("SpeedDrainMode"):
-            self.reqAuxDB.updateAgentConfig(self.config.Agent.hostName, "SpeedDrainMode", False)
+            self.agentConfig['SpeedDrainMode'] = False
             speedDrainConfig = self.agentConfig.get("SpeedDrainConfig")
             for key, v in speedDrainConfig.items():
                 if key in self.validSpeedDrainConfigKeys and v['Enabled']:
                     speedDrainConfig[key]['Enabled'] = False
 
-            self.reqAuxDB.updateAgentConfig(self.config.Agent.hostName, "SpeedDrainConfig", speedDrainConfig)
+            self.reqAuxDB.updateAgentConfig(self.config.Agent.hostName, self.agentConfig)
         return
 
     def checkSpeedDrainThresholds(self):

--- a/src/python/WMCore/Cache/GenericDataCache.py
+++ b/src/python/WMCore/Cache/GenericDataCache.py
@@ -1,6 +1,5 @@
 from __future__ import print_function, division
 import time
-import traceback
 import logging
 
 
@@ -10,19 +9,20 @@ class MemoryCacheStruct(object):
     But this cache is not thread safe.
     """
 
-    def __init__(self, expire, func, initCacheValue=None, kwargs=None):
+    def __init__(self, expire, func, initCacheValue=None, logger=None, kwargs=None):
         """
         expire is the seconds which cache will be refreshed when cache is older than the expire.
         func is the fuction which cache data is retrieved
         kwargs are func arguments for cache data
         """
+        kwargs = kwargs or {}
         self.data = initCacheValue
         self.expire = expire
         self.func = func
-        if kwargs == None:
-            kwargs = {}
+
         self.kwargs = kwargs
         self.lastUpdated = -1
+        self.logger = logger if logger else logging.getLogger()
 
     def isDataExpired(self):
         if self.lastUpdated == -1:
@@ -38,7 +38,8 @@ class MemoryCacheStruct(object):
                 self.lastUpdated = int(time.time())
             except Exception:
                 if noFail:
-                    logging.error(traceback.format_exc())
+                    msg = "Passive failure while looking data up in the memory cache"
+                    self.logger.exception(msg)
                 else:
                     raise
         return self.data

--- a/src/python/WMCore/ReqMgr/CherryPyThreads/AuxCacheUpdateTasks.py
+++ b/src/python/WMCore/ReqMgr/CherryPyThreads/AuxCacheUpdateTasks.py
@@ -25,7 +25,13 @@ class AuxCacheUpdateTasks(CherryPyPeriodicTask):
 
     def updateCMSSW(self, config):
         """
-        gather active data statistics
+        Update the central couch document which contains a map of
+        releases and their ScramArch
         """
-        self.reqmgrAux.populateCMSSWVersion(config.tagcollect_url, **config.tagcollect_args)
-        self.logger.info("Updated CMSSW versions in the auxiliar db")
+        self.logger.info("Updating the CMSSW/ScramArch map document ...")
+
+        res = self.reqmgrAux.populateCMSSWVersion(config.tagcollect_url, **config.tagcollect_args)
+        if 'error' in res:
+            self.logger.error("Failed to update releases. Response: %s", res)
+        else:
+            self.logger.info("CMSSW releases successfully updated.")

--- a/src/python/WMCore/Services/ReqMgr/ReqMgr.py
+++ b/src/python/WMCore/Services/ReqMgr/ReqMgr.py
@@ -218,7 +218,7 @@ class ReqMgr(Service):
     def getRequestByStatusFromMemoryCache(self, statusList, expire=0):
 
         return MemoryCacheStruct(expire=expire, func=self.getRequestByStatus, initCacheValue=[],
-                                 kwargs={'statusList': statusList, "detail": False})
+                                 logger=self['logger'], kwargs={'statusList': statusList, "detail": False})
 
     def cloneRequest(self, requestName, overwrittenParams=None):
         """


### PR DESCRIPTION
Fixes #9248 

#### Status
ready

#### Description
Use PUT HTTP method for updating the CMSSW_VERSION couchdb doc, and create it if it does not exist.

Also changes the behaviour of PUT request - as it should be - such that it expects the whole content to be passed and it does an update like replace. It affects the following APIs:
* CMSSWVersions (cmsswversions)
* WMAgentConfig (wmagentconfig)
* PermissionsConfig (permissions)
* UnifiedConfig (unifiedconfig)
* CampaignConfig (campaignconfig)
A new option `inPlace` is supported for WMAgent and Campaign config though, in case a client wants to update only a few key/value pairs.

Last but not least, a DELETE API was implemented to delete wmagent/campaign/unified configuration documents from reqmgr_aux db.

Documentation updated in: https://github.com/dmwm/WMCore/wiki/ReqMgr2-apis#rest-apis-for-reqmgr2-auxiliary

#### Is it backward compatible (if not, which system it affects?)
No! It changes the behaviour of PUT requests for the agent config, so the agents have to be patched.

#### Related PRs
Ops changes proposed here: https://github.com/CMSCompOps/WmAgentScripts/pull/428

#### External dependencies / deployment changes
Agents need to be patched (can happen before the production upgrade).
