### PR TITLE
add doc string to generat proper docment.

### DIFF
--- a/src/python/Utils/Throttled.py
+++ b/src/python/Utils/Throttled.py
@@ -70,9 +70,17 @@ class UserThrottle(object):
         return _ThrottleCounter(self, user, debug)
 
     def make_throttled(self, debug=False):
-        "decorator for throttled context"
+        """
+        decorator for throttled context
+        """
         def throttled_decorator(fn):
+            """
+            A decorator
+            """
             def throttled_wrapped_function(*args, **kw):
+                """
+                A wrapped function.
+                """
                 username = cherrypy.request.user.get('login', 'Unknown') \
                         if hasattr(cherrypy.request, 'user') else 'Unknown'
                 with self.throttleContext(username, debug):


### PR DESCRIPTION
Fixes  NO GH issue opend

#### Status
ready

#### Description
Missing doc string and caused error in auto generated doc.

#### Is it backward compatible (if not, which system it affects?)
YES 

#### Related PRs
None
#### External dependencies / deployment changes
 it require deployment changes.  it does not rely on third-party libraries.
