### PR TITLE
Handle oracle "not connected" as a soft error

### DIFF
--- a/src/python/WMCore/Database/DBExceptionHandler.py
+++ b/src/python/WMCore/Database/DBExceptionHandler.py
@@ -11,9 +11,11 @@ import threading
 # ORA-12545: Connect failed because target host or object does not exist
 # ORA-00060: deadlock detected while waiting for resource
 # ORA-01033: ORACLE initialization or shutdown in progress
+# (cx_Oracle.InterfaceError) not connected  # same as ORA-03114, in the new SQLAlchemy
 # and those two MySQL exceptions
 DB_CONNECTION_ERROR_STR = ["ORA-03113", "ORA-03114", "ORA-03135", "ORA-12545", "ORA-00060", "ORA-01033",
-                           "MySQL server has gone away", "Lock wait timeout exceeded"]
+                           "MySQL server has gone away", "Lock wait timeout exceeded",
+                           "(cx_Oracle.InterfaceError) not connected"]
 
 
 def db_exception_handler(f):


### PR DESCRIPTION
Fixes #9256 

#### Status
not-tested

#### Description
With the latest SQLAlchemy update, the database error string patter has changed.
Thus, add `(cx_Oracle.InterfaceError) not connected` to the list of SQL database errors to be bypassed in the components (i.e.. not to crash the component, but just skips it to the next cycle).

#### Is it backward compatible (if not, which system it affects?)
Yes

#### Related PRs

#### External dependencies / deployment changes

