### PR TITLE
Minor DBS3Upload enhancements

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/DBSBufferBlock.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSBufferBlock.py
@@ -37,6 +37,7 @@ class DBSBufferBlock:
         Expects:
           name:  The blockname in full
           location: The PNN of the site the block is at
+          datasetpath: the dataset name
         """
 
 
@@ -153,7 +154,7 @@ class DBSBufferBlock:
         self.data['files'].append(fileDict)
 
         # If dataset_parent_list is defined don't add the file parentage.
-        # This means it is block from StepChain workflow and parentage of file will be resloved later
+        # This means it is block from StepChain workflow and parentage of file will be resolved later
         if not self.data['dataset_parent_list']:
             # now add file to data
             parentLFNs = dbsFile.getParentLFNs()
@@ -455,15 +456,12 @@ class DBSBufferBlock:
         self.startTime = blockInfo.get('creation_date')
         self.inBuff    = True
 
-        if 'status' in blockInfo.keys():
-            self.status = blockInfo['status']
+        if 'status' in blockInfo:
+            self.status = blockInfo.pop("status")
             if self.status == "Pending":
                 self.data['block']['open_for_writing'] = 0
 
-            del blockInfo['status']
-
-        for key in blockInfo.keys():
-            self.data['block'][key] = blockInfo.get(key)
+        self.data['block'].update(blockInfo)
 
     def convertToDBSBlock(self):
         """

--- a/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
@@ -389,7 +389,7 @@ class DBSUploadPoller(BaseWorkerThread):
         # Load them if we don't have them
         blocksToLoad = []
         for block in openBlocks:
-            if block['blockname'] not in self.blockCache.keys():
+            if block['blockname'] not in self.blockCache:
                 blocksToLoad.append(block['blockname'])
 
         # Now load the blocks

--- a/src/python/WMComponent/DBS3Buffer/MySQL/LoadDBSFilesByDAS.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/LoadDBSFilesByDAS.py
@@ -87,30 +87,14 @@ class LoadDBSFilesByDAS(DBFormatter):
         resultList = self.formatDict(result)
 
         for resultDict in resultList:
-            resultDict["appName"] = resultDict["app_name"]
-            del resultDict["app_name"]
-
-            resultDict["appVer"] = resultDict["app_ver"]
-            del resultDict["app_ver"]
-
-            resultDict["appFam"] = resultDict["app_fam"]
-            del resultDict["app_fam"]
-
-            resultDict["psetHash"] = resultDict["pset_hash"]
-            del resultDict["pset_hash"]
-
-            resultDict["configContent"] = resultDict["config_content"]
-            del resultDict["config_content"]
-
-            resultDict["datasetPath"] = resultDict["dataset_path"]
-            del resultDict["dataset_path"]
-
-            resultDict["size"] = resultDict["filesize"]
-            del resultDict["filesize"]
-
-            resultDict["globalTag"] = resultDict['global_tag']
-            del resultDict['global_tag']
-
+            resultDict["appName"] = resultDict.pop("app_name")
+            resultDict["appVer"] = resultDict.pop("app_ver")
+            resultDict["appFam"] = resultDict.pop("app_fam")
+            resultDict["psetHash"] = resultDict.pop("pset_hash")
+            resultDict["configContent"] = resultDict.pop("config_content")
+            resultDict["datasetPath"] = resultDict.pop("dataset_path")
+            resultDict["size"] = resultDict.pop("filesize")
+            resultDict["globalTag"] = resultDict.pop("global_tag")
         return resultList
 
 
@@ -220,9 +204,8 @@ class LoadDBSFilesByDAS(DBFormatter):
 
     def getBinds(self, files):
         binds = []
-        files = self.dbi.makelist(files)
-        for f in files:
-            binds.append({'fileid': f})
+        for item in files:
+            binds.append({'fileid': item['id']})
         return binds
 
     def execute(self, datasetpath, conn = None, transaction = False):
@@ -237,8 +220,7 @@ class LoadDBSFilesByDAS(DBFormatter):
                                         transaction = transaction)
         fileInfo = self.formatFileInfo(result)
 
-        fileIDs  = [x['id'] for x in fileInfo]
-        binds    = self.getBinds(fileIDs)
+        binds    = self.getBinds(fileInfo)
 
         if len(fileInfo) == 0:
             # Then we have no files for this DAS

--- a/src/python/WMComponent/DBS3Buffer/MySQL/LoadFilesByBlock.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/LoadFilesByBlock.py
@@ -47,8 +47,7 @@ class LoadFilesByBlock(MySQLLoadDBSFilesByDAS):
                                         transaction = transaction)
         fileInfo = self.formatFileInfo(result)
 
-        fileIDs  = [x['id'] for x in fileInfo]
-        binds    = self.getBinds(fileIDs)
+        binds    = self.getBinds(fileInfo)
 
         if len(fileInfo) == 0:
             # Then we have no files for this DAS


### PR DESCRIPTION
Fixes #

#### Status
In development

#### Description
Fixed the mechanism to do a json dump of the data posted to the DBSServer (via blockdump api), such that it creates a new json file (based on the block hash id only) for every block, instead of writing over and over the same file.

Second commit has some minor code improvements as I went through the DBS3Upload code. Still have to get back to two heavy methods executing basically the same DAO though (one for block and the other based on dataset)...

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs

#### External dependencies / deployment changes