### PR TITLE
Avoid WebTools depending on the REST package 

### DIFF
--- a/src/python/WMCore/WebTools/FrontEndAuth.py
+++ b/src/python/WMCore/WebTools/FrontEndAuth.py
@@ -41,7 +41,7 @@ class FrontEndAuth(cherrypy.Tool):
         group = group or []
         site = site or []
         # Sets initial user information for this request
-        assert (getattr(cherrypy.request, "user", None) == None)
+        assert getattr(cherrypy.request, "user", None) is None
         cherrypy.request.user = {'dn': None,
                                  'method': None,
                                  'login': None,
@@ -87,7 +87,7 @@ class FrontEndAuth(cherrypy.Tool):
                     user['roles'][hkname] = {'site': set(), 'group': set()}
                     for r in headers[hk].split():
                         ste_or_grp, name = r.split(':')
-                        user['roles'][hkname][ste_or_grp].add(name);
+                        user['roles'][hkname][ste_or_grp].add(name)
 
         vfy = hmac.new(self.key, prefix + "#" + suffix, hashlib.sha1).hexdigest()
         if vfy != headers["cms-authn-hmac"]:
@@ -99,7 +99,7 @@ class FrontEndAuth(cherrypy.Tool):
     def check_authorization(self, role, group, site, authzfunc):
         """Format the authorization rules into lists and verify if the given
         user is allowed to access."""
-        if authzfunc == None:
+        if authzfunc is None:
             authzfunc = self.defaultAuth
 
         # TOFIX: put role, group and site into canonical form
@@ -138,7 +138,6 @@ class FrontEndAuth(cherrypy.Tool):
         return False
 
 
-# -------------------------------------------------------------------------------
 class NullAuth(cherrypy.Tool):
     def __init__(self, config):
         # Defines the hook point for cherrypy
@@ -156,10 +155,10 @@ class NullAuth(cherrypy.Tool):
         group = group or []
         site = site or []
         cherrypy.log.access_log.warning('NullAuth called for:')
-        cherrypy.log.access_log.warning('\trole(s): %s \n\tgroup(s): %s \n\tsite(s): %s' % (role, group, site))
+        cherrypy.log.access_log.warning('\trole(s): %s \n\tgroup(s): %s \n\tsite(s): %s', role, group, site)
 
         if authzfunc:
-            cherrypy.log.access_log.warning('\tusing authorisation function %s' % authzfunc.__name__)
+            cherrypy.log.access_log.warning('\tusing authorisation function %s', authzfunc.__name__)
         cherrypy.request.user = {'dn': 'None',
                                  'method': 'Null Auth - totally insecure!',
                                  'login': 'fbloggs',

--- a/src/python/WMCore/WebTools/FrontEndAuth.py
+++ b/src/python/WMCore/WebTools/FrontEndAuth.py
@@ -5,10 +5,16 @@ import hmac
 
 import cherrypy
 
-from WMCore.REST.Auth import get_user_info
 from Utils.Utilities import lowerCmsHeaders
 
-# -----------------------------------------------------------------------------
+
+def get_user_info():
+    """
+    Helper function to return user based information of the request
+    """
+    return cherrypy.request.user
+
+
 class FrontEndAuth(cherrypy.Tool):
     """
     Transparently allows a back-end cmsweb app to do
@@ -56,7 +62,7 @@ class FrontEndAuth(cherrypy.Tool):
         """Read and verify the front-end headers, update the user
         dict with information about the authorized user."""
         headers = lowerCmsHeaders(cherrypy.request.headers)
-        user = cherrypy.request.user
+        user = get_user_info()
 
         if 'cms-auth-status' not in headers:
             # Non SSL request

--- a/src/python/WMCore/WebTools/SecureDocumentation.py
+++ b/src/python/WMCore/WebTools/SecureDocumentation.py
@@ -1,13 +1,17 @@
-from cherrypy import expose, tools
 import cherrypy
-from WMCore.WebTools.Page import TemplatedPage
-from WMCore.WebTools.FrontEndAuth import get_user_info
 from os import listdir
+
+from cherrypy import expose, tools
+
+from WMCore.WebTools.FrontEndAuth import get_user_info
+from WMCore.WebTools.Page import TemplatedPage
+
 
 class SecureDocumentation(TemplatedPage):
     """
     The documentation for the framework
     """
+
     @expose
     @tools.secmodv2()
     def index(self):
@@ -23,7 +27,7 @@ class SecureDocumentation(TemplatedPage):
         index += "<li>Your roles:\n"
         index += "<ul>\n"
         for k, v in user['roles'].iteritems():
-            for t in ['group','site']:
+            for t in ['group', 'site']:
                 for n in v[t]:
                     index += "<li><b>%s</b>: %s=%s</li>\n" % (k, t, n)
         index += "</ul></li></ul>\n"
@@ -35,8 +39,8 @@ class SecureDocumentation(TemplatedPage):
         for t in templates:
             if '.tmpl' in t:
                 index = "%s\n<li><a href='%s'>%s</a></li>" % (index,
-                                                      t.replace('.tmpl', ''),
-                                                      t.replace('.tmpl', ''))
+                                                              t.replace('.tmpl', ''),
+                                                              t.replace('.tmpl', ''))
         index = "%s\n<li><a href='https://twiki.cern.ch/twiki/bin/view/CMS/DMWebtools'>twiki</a>" % (index)
         index = "%s\n</ol>" % (index)
 
@@ -61,5 +65,4 @@ class SecureDocumentation(TemplatedPage):
     def default(self, *args, **kwargs):
         if len(args) > 0:
             return self.templatepage(args[0])
-        else:
-            return self.index()
+        return self.index()

--- a/src/python/WMCore/WebTools/SecureDocumentation.py
+++ b/src/python/WMCore/WebTools/SecureDocumentation.py
@@ -1,7 +1,7 @@
 from cherrypy import expose, tools
 import cherrypy
 from WMCore.WebTools.Page import TemplatedPage
-from WMCore.REST.Auth import get_user_info
+from WMCore.WebTools.FrontEndAuth import get_user_info
 from os import listdir
 
 class SecureDocumentation(TemplatedPage):


### PR DESCRIPTION
Fixes #9263 

#### Status
not-tested

#### Description
Duplicated the `get_user_info` util function such that WebTools don't need to depend on the REST package.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs

#### External dependencies / deployment changes
No
