### PR TITLE
Validate/limit number of Steps/Tasks and Step/Task Name length 

### DIFF
--- a/src/python/WMCore/Lexicon.py
+++ b/src/python/WMCore/Lexicon.py
@@ -324,6 +324,14 @@ def primdataset(candidate):
     return check(r"%s" % PRIMARY_DS['re'], candidate, PRIMARY_DS['maxLength'])
 
 
+TASK_STEP_NAME = {'re': '^[a-zA-Z][a-zA-Z0-9\-_]*$', 'maxLength': 50}
+def taskStepName(candidate):
+    """
+    Validate the TaskName and/or StepName field.
+    Letters, numbers, dashes and underscores are allowed.
+    """
+    return check(r"%s" % TASK_STEP_NAME['re'], candidate, TASK_STEP_NAME['maxLength'])
+
 def hnName(candidate):
     """
     Use lfn parts definitions to validate a simple HN name
@@ -511,7 +519,7 @@ def validateUrl(candidate):
 def check(regexp, candidate, maxLength=None):
     if maxLength is not None:
         assert len(candidate) <= maxLength, \
-            "%s is longer then max length (%s) allowed" % (candidate, maxLength)
+            "%s is longer than max length (%s) allowed" % (candidate, maxLength)
     assert re.compile(regexp).match(candidate) is not None, \
         "'%s' does not match regular expression %s" % (candidate, regexp)
     return True

--- a/test/python/WMCore_t/Lexicon_t.py
+++ b/test/python/WMCore_t/Lexicon_t.py
@@ -873,5 +873,24 @@ class LexiconTest(unittest.TestCase):
         self.assertEqual(site, 'T1_US_FNAL')
         self.assertEqual(reason, 'via condor_rm (by user cmst1)')
 
+    def testTaskStepName(self):
+        """
+        Test some task and step names
+        """
+        self.assertTrue(taskStepName("T"))
+        self.assertTrue(taskStepName("TaskName-Test_Num1"))
+        self.assertTrue(taskStepName("this_is-a-step-name"))
+        self.assertTrue(taskStepName("Test123-456_789"))
+        self.assertTrue(taskStepName("t" * 50))
+
+        # now bad names
+        self.assertRaises(AssertionError, taskStepName, "")
+        self.assertRaises(AssertionError, taskStepName, "1Task")
+        self.assertRaises(AssertionError, taskStepName, "-Task_testName")
+        self.assertRaises(AssertionError, taskStepName, "_Task_testName")
+        self.assertRaises(AssertionError, taskStepName, "Task@testName")
+        self.assertRaises(AssertionError, taskStepName, "t" * 51)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
@@ -1538,7 +1538,7 @@ class StepChainTests(EmulatedUnitTestCase):
         testArguments['Step3']['ConfigCacheID'] = configDocs['Step3']
 
         factory = StepChainWorkloadFactory()
-        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
+        factory.factoryWorkloadConstruction("TestWorkload", testArguments)
 
     def testMCFilesets(self):
         """
@@ -2217,6 +2217,25 @@ class StepChainTests(EmulatedUnitTestCase):
         self.assertEqual(['RAWSIMoutput'], parentageMapping['GENSIM']['OutputDatasetMap'].keys())
         self.assertEqual(['RAWSIMoutput'], parentageMapping['DIGI2']['OutputDatasetMap'].keys())
         self.assertEqual(['AODSIMoutput', 'RECOSIMoutput'], parentageMapping['RECO']['OutputDatasetMap'].keys())
+
+    def testTooManySteps(self):
+        """
+        Test that requests with more than 10 steps cannot be injected
+        """
+        factory = StepChainWorkloadFactory()
+
+        testArguments = factory.getTestArguments()
+        testArguments.update(deepcopy(REQUEST))
+
+        # now add 8 extra steps to the request
+        for i in range(4, 12):
+            stepNumber = "Step%s" % i
+            testArguments[stepNumber] = deepcopy(testArguments['Step3'])
+            testArguments['TaskName'] = "my%s" % stepNumber
+        testArguments['StepChain'] = 11
+
+        with self.assertRaises(WMSpecFactoryException):
+            factory.factoryWorkloadConstruction("ElevenSteps", testArguments)
 
 
 if __name__ == '__main__':

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
@@ -398,7 +398,7 @@ def buildComplexTaskChain(couchdb):
     """
     Build a TaskChain workflow with different settings (AcqEra/ProcStr/ProcVer/
     CMSSWVersion/ScramArch/GlobalTag/PrepId/TpE/SpE for each task.
-    
+
     Return a TaskChain workload object.
     """
     testArguments = TaskChainWorkloadFactory.getTestArguments()
@@ -2268,6 +2268,26 @@ class TaskChainTests(EmulatedUnitTestCase):
             parentDset = outDsets[t][0]
 
         return
+
+    def testTooManyTasks(self):
+        """
+        Test that requests with more than 10 tasks cannot be injected
+        """
+        factory = TaskChainWorkloadFactory()
+
+        testArguments = factory.getTestArguments()
+        testArguments.update(deepcopy(REQUEST))
+
+        # now add 7 extra tasks to the request
+        for i in range(5, 12):
+            taskNumber = "Task%s" % i
+            testArguments[taskNumber] = deepcopy(testArguments['Task4'])
+            testArguments['TaskName'] = "my%s" % taskNumber
+        testArguments['TaskChain'] = 11
+
+        with self.assertRaises(WMSpecFactoryException):
+            factory.factoryWorkloadConstruction("ElevenTasks", testArguments)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #5641 

#### Status
not-tested

#### Description
Summary of changes as follows:
* set a limit for the number of tasks in a TaskChain workflow, up to 10 tasks allowed
* set a limit for the length of the TaskName value (and defined a regex just like the PrimaryDataset one), up to 50 chars allowed.
* also fixed error message returned to the end user, sending a clear message instead of the whole exception/traceback.

Same changes applied to the StepChain spec as well, such that they remain similar to each other in terms of specs and limitations.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs

#### External dependencies / deployment changes
no