### PR TITLE
Getters/setters for CMSSW/WMStep object; fix StepChain straight to merge - wmagent version

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -392,6 +392,7 @@ class StdBase(object):
         acqEra = taskConf.get("AcquisitionEra") or self.acquisitionEra
         procStr = taskConf.get("ProcessingString") or self.processingString
         procVer = taskConf.get("ProcessingVersion") or self.processingVersion
+        prepID = taskConf.get("PrepID") or self.prepID
         procTask.setAcquisitionEra(acqEra)
         procTask.setProcessingString(procStr)
         procTask.setProcessingVersion(procVer)
@@ -431,6 +432,7 @@ class StdBase(object):
         procTaskCmsswHelper.setUserSandbox(userSandbox)
         procTaskCmsswHelper.setUserFiles(userFiles)
         procTaskCmsswHelper.setGlobalTag(globalTag)
+        procTaskCmsswHelper.setPrepId(prepID)
         procTaskCmsswHelper.setOverrideCatalog(self.overrideCatalog)
         procTaskCmsswHelper.setErrorDestinationStep(stepName=procTaskLogArch.name())
 
@@ -479,7 +481,6 @@ class StdBase(object):
             procTaskCmsswHelper.setDataProcessingConfig(scenarioName, scenarioFunc,
                                                         **scenarioArgs)
         # only in the very end, in order to get it in for the children tasks as well
-        prepID = taskConf.get("PrepID") or self.prepID
         procTask.setPrepID(prepID)
 
         # has to be done in the very end such that child tasks are set too

--- a/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
@@ -298,6 +298,7 @@ class StepChainWorkloadFactory(StdBase):
             globalTag = self.getStepValue('GlobalTag', taskConf, self.globalTag)
             frameworkVersion = self.getStepValue('CMSSWVersion', taskConf, self.frameworkVersion)
             scramArch = self.getStepValue('ScramArch', taskConf, self.scramArch)
+            prepId = self.getStepValue('PrepID', taskConf, self.prepID)
 
             currentCmssw = parentCmsswStep.addTopStep(currentCmsRun)
             currentCmssw.setStepType("CMSSW")
@@ -305,6 +306,7 @@ class StepChainWorkloadFactory(StdBase):
             template(currentCmssw.data)
 
             currentCmsswStepHelper = currentCmssw.getTypeHelper()
+            currentCmsswStepHelper.setPrepId(prepId)
             currentCmsswStepHelper.setGlobalTag(globalTag)
             currentCmsswStepHelper.setupChainedProcessing(parentCmsRun, taskConf['InputFromOutputModule'])
             currentCmsswStepHelper.cmsswSetup(frameworkVersion, softwareEnvironment="", scramArch=scramArch)

--- a/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
@@ -277,13 +277,13 @@ class CMSSW(Executor):
         stepHelper = WMStepHelper(self.step)
         typeHelper = stepHelper.getTypeHelper()
 
-        acquisitionEra = self.task.getAcquisitionEra()
-        processingVer = self.task.getProcessingVersion()
-        processingStr = self.task.getProcessingString()
+        acquisitionEra = typeHelper.getAcqEra() or self.task.getAcquisitionEra()
+        processingVer = typeHelper.getProcVer() or self.task.getProcessingVersion()
+        processingStr = typeHelper.getProcStr() or self.task.getProcessingString()
+        prepID = typeHelper.getPrepId() or self.task.getPrepID()
+        globalTag = typeHelper.getGlobalTag()
         validStatus = self.workload.getValidStatus()
         inputPath = self.task.getInputDatasetPath()
-        globalTag = typeHelper.getGlobalTag()
-        prepID = self.task.getPrepID()
         campaign = self.workload.getCampaign()
         cacheUrl, cacheDB, configID = stepHelper.getConfigInfo()
 

--- a/src/python/WMCore/WMSpec/Steps/Templates/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Templates/CMSSW.py
@@ -20,6 +20,61 @@ class CMSSWStepHelper(CoreHelper):
     for CMSSW tasks
 
     """
+    def setAcqEra(self, acqEra):
+        """
+        _setAcqEra_
+        Set the acquisition era attribute for this step.
+        """
+        self.data.output.acqEra = acqEra
+
+    def setProcStr(self, procStr):
+        """
+        _setProcStr_
+        Set the processing string attribute for this step.
+        """
+        self.data.output.procStr = procStr
+
+    def setProcVer(self, procVer):
+        """
+        _setProcVer_
+        Set the processing version era attribute for this step.
+        """
+        self.data.output.procVer = procVer
+
+    def getAcqEra(self):
+        """
+        _getAcqEra_
+        Retrieve the acquisition era for this step, or return None if non-existent.
+        """
+        return getattr(self.data.output, 'acqEra', None)
+
+    def getProcStr(self):
+        """
+        _getProcStr_
+        Retrieve the processing string for this step, or return None if non-existent.
+        """
+        return getattr(self.data.output, 'procStr', None)
+
+    def getProcVer(self):
+        """
+        _getProcVer_
+        Retrieve the processing version for this step, or return None if non-existent.
+        """
+        return getattr(self.data.output, 'procVer', None)
+
+    def setPrepId(self, prepId):
+        """
+        _setPrepId_
+        Set the prep_id attribute for this step.
+        """
+        self.data.output.prepId = prepId
+
+    def getPrepId(self):
+        """
+        _getPrepId_
+        Retrieve the prep_id for this step, or return None if non-existent.
+        """
+        return getattr(self.data.output, 'prepId', None)
 
     def addOutputModule(self, moduleName, **details):
         """
@@ -37,23 +92,6 @@ class CMSSWStepHelper(CoreHelper):
 
         for key, value in details.items():
             setattr(module, key, value)
-
-        return
-
-    def addAnalysisFile(self, fileLabel, **details):
-        """
-        _addAnalysisFile_
-
-        Add in an additional file produced by the user to be staged out
-        """
-        analysisFiles = self.data.output.analysisFiles
-
-        if getattr(analysisFiles, fileLabel, None) == None:
-            analysisFiles.section_(fileLabel)
-        analysisFile = getattr(analysisFiles, fileLabel)
-
-        for key, value in details.items():
-            setattr(analysisFile, key, value)
 
         return
 

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -1306,14 +1306,15 @@ class WMTaskHelper(TreeHelper):
                 IDs.append(ID)
         return IDs
 
-    def setProcessingVersion(self, procVer, parentProcessingVersion=0, stepChain=False):
+    def setProcessingVersion(self, procVer, parentProcessingVersion=0, stepChainMap=False):
         """
         _setProcessingVersion_
 
         Set the task processing version
         """
-        if isinstance(procVer, dict) and stepChain:
+        if isinstance(procVer, dict) and stepChainMap:
             taskProcVer = self._getStepValue(procVer, parentProcessingVersion)
+            self._setStepProperty("ProcessingVersion", procVer, stepChainMap)
         elif isinstance(procVer, dict):
             taskProcVer = procVer.get(self.name(), parentProcessingVersion)
             if taskProcVer is None:
@@ -1325,7 +1326,7 @@ class WMTaskHelper(TreeHelper):
 
         self.data.parameters.processingVersion = int(taskProcVer)
         for task in self.childTaskIterator():
-            task.setProcessingVersion(procVer, taskProcVer, stepChain)
+            task.setProcessingVersion(procVer, taskProcVer, stepChainMap)
         return
 
     def getProcessingVersion(self):
@@ -1336,14 +1337,15 @@ class WMTaskHelper(TreeHelper):
         """
         return getattr(self.data.parameters, 'processingVersion', 0)
 
-    def setProcessingString(self, procString, parentProcessingString=None, stepChain=False):
+    def setProcessingString(self, procString, parentProcessingString=None, stepChainMap=False):
         """
         _setProcessingString_
 
         Set the task processing string
         """
-        if isinstance(procString, dict) and stepChain:
+        if isinstance(procString, dict) and stepChainMap:
             taskProcString = self._getStepValue(procString, parentProcessingString)
+            self._setStepProperty("ProcessingString", procString, stepChainMap)
         elif isinstance(procString, dict):
             taskProcString = procString.get(self.name(), parentProcessingString)
             if taskProcString is None:
@@ -1356,7 +1358,7 @@ class WMTaskHelper(TreeHelper):
         self.data.parameters.processingString = taskProcString
 
         for task in self.childTaskIterator():
-            task.setProcessingString(procString, taskProcString, stepChain)
+            task.setProcessingString(procString, taskProcString, stepChainMap)
         return
 
     def getProcessingString(self):
@@ -1446,15 +1448,40 @@ class WMTaskHelper(TreeHelper):
 
         return value
 
-    def setAcquisitionEra(self, era, parentAcquisitionEra=None, stepChain=False):
+    def _setStepProperty(self, propertyName, propertyDict, stepMap):
+        """
+        For StepChain workloads, we also need to set AcqEra/ProcStr/ProcVer
+        at the WMStep level, such that we can properly map different cmsRun
+        steps - within the same task - to different meta data information.
+        :param propertyName: the name of the property to set at step level
+        :param propertyDict: a dictionary mapping StepName to its value
+        :param stepMap: map between step name, step number and cmsRun number,
+                        same as returned from the workload getStepMapping
+        """
+        propMethodMap = {"AcquisitionEra": "setAcqEra",
+                         "ProcessingString": "setProcStr",
+                         "ProcessingVersion": "setProcStr"}
+
+        if self.taskType() not in ["Production", "Processing"]:
+            # then there is no need to set anything, single cmsRun step at most
+            return
+
+        for stepName, stepValues in stepMap.items():
+            cmsRunNum = stepValues[1]
+            stepHelper = self.getStepHelper(cmsRunNum)
+            callableMethod = getattr(stepHelper, propMethodMap[propertyName])
+            callableMethod(propertyDict[stepName])
+
+    def setAcquisitionEra(self, era, parentAcquisitionEra=None, stepChainMap=False):
         """
         _setAcquistionEra_
 
         Set the task acquisition era
         """
 
-        if isinstance(era, dict) and stepChain:
+        if isinstance(era, dict) and stepChainMap:
             taskEra = self._getStepValue(era, parentAcquisitionEra)
+            self._setStepProperty("AcquisitionEra", era, stepChainMap)
         elif isinstance(era, dict):
             taskEra = era.get(self.name(), parentAcquisitionEra)
             if taskEra is None:
@@ -1470,14 +1497,14 @@ class WMTaskHelper(TreeHelper):
         self.data.parameters.acquisitionEra = taskEra
 
         for task in self.childTaskIterator():
-            task.setAcquisitionEra(era, taskEra, stepChain)
+            task.setAcquisitionEra(era, taskEra, stepChainMap)
         return
 
     def getAcquisitionEra(self):
         """
         _getAcquisitionEra_
 
-        Get the task acquisition era
+        Get the task acquisition era.
         """
         return getattr(self.data.parameters, 'acquisitionEra', None)
 

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -104,14 +104,13 @@ class WMWorkloadHelper(PersistencyHelper):
         Used for properly setting AcqEra/ProcStr/ProcVer for each step in a StepChain request
         during assignment. Only used if one of those parameters is a dictionary.
         """
-        mustSet = False
         if "AcquisitionEra" in assignArgs and isinstance(assignArgs["AcquisitionEra"], dict):
-            mustSet = True
+            pass
         elif "ProcessingString" in assignArgs and isinstance(assignArgs["ProcessingString"], dict):
-            mustSet = True
+            pass
         elif "ProcessingVersion" in assignArgs and isinstance(assignArgs["ProcessingVersion"], dict):
-            mustSet = True
-        if mustSet is False:
+            pass
+        else:
             return
 
         stepNameMapping = self.getStepMapping()
@@ -886,7 +885,7 @@ class WMWorkloadHelper(PersistencyHelper):
         """
         stepNameMapping = self.getStepMapping()
         for task in self.taskIterator():
-            task.setAcquisitionEra(acquisitionEras, stepChain=stepNameMapping)
+            task.setAcquisitionEra(acquisitionEras, stepChainMap=stepNameMapping)
 
         self.updateLFNsAndDatasets()
         # set acquistionEra for workload (need to refactor)
@@ -903,7 +902,7 @@ class WMWorkloadHelper(PersistencyHelper):
         stepNameMapping = self.getStepMapping()
 
         for task in self.taskIterator():
-            task.setProcessingVersion(processingVersions, stepChain=stepNameMapping)
+            task.setProcessingVersion(processingVersions, stepChainMap=stepNameMapping)
 
         self.updateLFNsAndDatasets()
         self.data.properties.processingVersion = processingVersions
@@ -919,7 +918,7 @@ class WMWorkloadHelper(PersistencyHelper):
         stepNameMapping = self.getStepMapping()
 
         for task in self.taskIterator():
-            task.setProcessingString(processingStrings, stepChain=stepNameMapping)
+            task.setProcessingString(processingStrings, stepChainMap=stepNameMapping)
 
         self.updateLFNsAndDatasets()
         self.data.properties.processingString = processingStrings


### PR DESCRIPTION
wmagent branch backport of #9265 

Agents need to be patched before the new ReqMgr2 release gets deployed to production.
Changes are backward compatible, so we can patch agents at any time, but we better double check.