### PR TITLE
Set CMS_Type job classad based on the dashboard activity

### DIFF
--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -385,6 +385,7 @@ class JobSubmitterPoller(BaseWorkerThread):
 
             # Create a job dictionary object and put it in the cache (needs to be in sync with RunJob)
             jobInfo = {'taskPriority': newJob['task_prio'],
+                       'activity': loadedJob.get("taskType"),
                        'custom': {'location': None},  # update later
                        'packageDir': batchDir,
                        'retry_count': newJob["retry_count"],

--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -23,6 +23,27 @@ from WMCore.FwkJobReport.Report import Report
 from WMCore.WMInit import getWMBASE
 from WMCore.Lexicon import getIterMatchObjectOnRegexp, WMEXCEPTION_REGEXP, CONDOR_LOG_FILTER_REGEXP
 
+
+def activityToType(jobActivity):
+    """
+    Function to map a workflow activity to a generic CMS job type.
+    :param jobActivity: a workflow activity string
+    :return: string which it maps to
+
+    NOTE: this map is based on the Lexicon.activity list
+    """
+    activityMap = {"reprocessing": "production",
+                   "production": "production",
+                   "relval": "production",
+                   "harvesting": "production",
+                   "storeresults": "production",
+                   "tier0": "tier0",
+                   "t0": "tier0",
+                   "integration": "test",
+                   "test": "test"}
+    return activityMap.get(jobActivity, "unknown")
+
+
 class SimpleCondorPlugin(BasePlugin):
     """
     _SimpleCondorPlugin_
@@ -573,6 +594,7 @@ class SimpleCondorPlugin(BasePlugin):
             ad['WMAgent_JobID'] = job['jobid']
             ad['WMAgent_SubTaskName'] = job['task_name']
             ad['CMS_JobType'] = job['task_type']
+            ad['CMS_Type'] = activityToType(job['activity'])
 
             # Handling for AWS, cloud and opportunistic resources
             ad['AllowOpportunistic'] = job.get('allowOpportunistic', False)

--- a/src/python/WMCore/BossAir/RunJob.py
+++ b/src/python/WMCore/BossAir/RunJob.py
@@ -65,6 +65,7 @@ class RunJob(dict):
         self.setdefault('inputDatasetLocations', None)
         self.setdefault('inputPileup', None)
         self.setdefault('allowOpportunistic', False)
+        self.setdefault('activity', None)
 
         return
 

--- a/test/python/WMCore_t/BossAir_t/SimpleCondorPlugin_t.py
+++ b/test/python/WMCore_t/BossAir_t/SimpleCondorPlugin_t.py
@@ -21,6 +21,7 @@ from WMComponent.JobSubmitter.JobSubmitterPoller import JobSubmitterPoller
 from WMComponent.JobTracker.JobTrackerPoller import JobTrackerPoller
 from WMCore.BossAir.BossAirAPI import BossAirAPI
 from WMCore.BossAir.StatusPoller import StatusPoller
+from WMCore.BossAir.Plugins.SimpleCondorPlugin import activityToType
 from WMCore.JobStateMachine.ChangeState import ChangeState
 
 
@@ -448,6 +449,21 @@ class SimpleCondorPluginTest(BossAirTest):
             match = GROUP_NAME_RE.match(request)
             matchedGroup = match.groups()[0] if match else 'undefined'
             self.assertEqual(group, matchedGroup)
+
+    def testActivityToTypeMap(self):
+        """
+        _testActivityToTypeMap_
+        Test mapping from dashboard activity to cms type
+        """
+        self.assertEqual(activityToType("production"), "production")
+        self.assertEqual(activityToType("reprocessing"), "production")
+        self.assertEqual(activityToType("relval"), "production")
+        self.assertEqual(activityToType("tier0"), "tier0")
+        self.assertEqual(activityToType("integration"), "test")
+        self.assertEqual(activityToType("alan"), "unknown")
+        self.assertEqual(activityToType("none"), "unknown")
+        self.assertEqual(activityToType(None), "unknown")
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #9252 

#### Status
not-tested

#### Description
Created a new job class ad called `CMS_Type` which has a very very generic classification of our job.
It's based on the dashboard activity - which has an schema as is validated for every single request - which might be repurposed in the future.

#### Is it backward compatible (if not, which system it affects?)
Yes

#### Related PRs
Goes along the lines of https://github.com/dmwm/WMCore/pull/9184

#### External dependencies / deployment changes
No
