### PR TITLE
Add two new APIs: getTrainsferIDs/postTransferIDs to deal with transfer IDs

### DIFF
--- a/src/python/WMCore/Services/ReqMgrAux/ReqMgrAux.py
+++ b/src/python/WMCore/Services/ReqMgrAux/ReqMgrAux.py
@@ -229,6 +229,29 @@ class ReqMgrAux(Service):
         else:
             return self["requests"].delete('%sconfig/%s' % (docType, docName))[0]['result']
 
+    def getTransferInfo(self):
+        """
+        Get transfer document from coudhdb backend. The document has the following form:
+        {
+          "wf_A": [record1, record2, ...],
+          "wf_B": [....],
+        }
+        where each record has the following format:
+        {"timestamp":000, "dataset":"/a/b/c", "dataType": "primary", "transferIDs": [1,2,3]}
+        transferIDs here either represent PhEDEx subscription or Rucio transfer/rules IDs.
+        """
+        return self._getDataFromMemoryCache('transferinfo')
+
+    def postTransferInfo(self, transferInfo):
+        """
+        Post new transfer document into couchdb backend.
+        :param transferInfo: represent a transferInfo document
+        {
+          "wf_A": [record1, record2, ...],
+          "wf_B": [....],
+        }
+        """
+        return self["requests"].post('transferinfo', transferInfo)[0]['result']
 
 AUXDB_AGENT_CONFIG_CACHE = {}
 


### PR DESCRIPTION
Fixes #9198 

#### Status
not-tested

#### Description
Add two new APIs to deal with transfer IDs

We need a new transferids database in CouchDB to store this data.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
#9198 

#### External dependencies / deployment changes
no