### PR TITLE
Changes for transfer IDs logic

### DIFF
--- a/src/python/WMCore/MicroService/Unified/MSCore.py
+++ b/src/python/WMCore/MicroService/Unified/MSCore.py
@@ -1,0 +1,136 @@
+"""
+File       : MSCore.py
+Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
+Description: MSCore class provides core functionality of the MS.
+"""
+# futures
+from __future__ import division, print_function
+
+# system modules
+import time
+
+# WMCore modules
+from WMCore.MicroService.Unified.Common import getMSLogger
+from WMCore.Services.ReqMgr.ReqMgr import ReqMgr
+from WMCore.Services.ReqMgrAux.ReqMgrAux import ReqMgrAux
+from WMCore.Services.PhEDEx.PhEDEx import PhEDEx
+
+
+class MSCore(object):
+    """
+    This class provides core functionality for both
+    MSTransferor and MSMonitor classes.
+    """
+
+    def __init__(self, msConfig, logger=None):
+        """
+        Provides setup for MSTransferor and MSMonitor classes
+
+        :param config: MS service configuration
+        :param logger: logger object (optional)
+        """
+        self.logger = getMSLogger(getattr(msConfig, 'verbose', False), logger)
+        self.msConfig = msConfig
+        self.logger.info(
+            "Configuration including default values:\n%s", self.msConfig)
+
+        self.reqmgr2 = ReqMgr(self.msConfig['reqmgrUrl'], logger=self.logger)
+        self.reqmgrAux = ReqMgrAux(self.msConfig['reqmgrUrl'],
+                                   httpDict={'cacheduration': 60},
+                                   logger=self.logger)
+
+        # eventually will change it to Rucio
+        self.phedex = PhEDEx(httpDict={'cacheduration': 10 * 60},
+                             dbsUrl=self.msConfig['dbsUrl'], logger=self.logger)
+
+    def unifiedConfig(self):
+        """
+        Fetches the unified configuration
+        :return: unified configuration content
+        """
+        res = self.reqmgrAux.getUnifiedConfig(docName="config")
+        if res:
+            if isinstance(res, list):
+                return res[0]
+            return res
+        else:
+            return {}
+
+    def change(self, req, reqStatus, prefix='###'):
+        """
+        Change request status, internally it is done via PUT request to ReqMgr2:
+        curl -X PUT -H "Content-Type: application/json" \
+             -d '{"RequestStatus":"staging", "RequestName":"bla-bla"}' \
+             https://xxx.yyy.zz/reqmgr2/data/request
+        """
+        self.logger.debug(
+            '%s updating %s status to %s', prefix, req['name'], reqStatus)
+        try:
+            if not self.msConfig['readOnly']:
+                self.reqmgr2.updateRequestStatus(req['name'], reqStatus)
+        except Exception as err:
+            self.logger.exception(
+                "Failed to change request status. Error: %s", str(err))
+
+    def updateTransferInfo(self, requestStatuses):
+        "Update transfer ids in backend"
+        tstamp = time.time()
+        # Alan's suggestion to use bulk query
+        # get all docs from CouchDB
+        docs = self.getTransferInfo('ALL_DOCS')
+        for wname, statusRecord in requestStatuses:
+            # obtain records from CouchDB
+            # doc = self.getTransferInfo(wname)
+            # find record in our list of docs
+            # VK: I don't know if it will be faster then fetching the record
+            #     in CouchDB, we need to loop every time to find proper record
+            doc = {}
+            for doc in docs:
+                if wname in doc:
+                    break
+            records = doc.get('transfers', [])
+            records += statusRecord
+            doc['workflowName'] = wname
+            doc['timestamp'] = tstamp
+            doc['transfers'] = records
+            self.reqmgrAux.postTransferInfo(wname, doc)
+
+    def getTransferInfo(self, wname):
+        """
+        Get transfer document from backend. The document has the following form:
+
+        .. doctest::
+
+            {"workflowName": "bla",
+             "timestamp": 123,
+             "transfers": [rec1, rec2, ... ]
+            }
+            where each record has the following format:
+            {"dataset":"/a/b/c", "dataType": "primary", "transferIDs": [1,2], "completion": 0}
+
+
+        :param wname: workflow name
+        :return: a tranfer ids document
+        """
+        return self.reqmgrAux.getTransferInfo(wname)
+
+    def getTransferIds(self, dataset):
+        """
+        Get transfer ids document for given request name and datasets.
+        :param dataset: dataset name
+        :return: a list of transfer ids
+        """
+        # phedex implementation, TODO: implement Rucio logic when it is ready
+        data = self.phedex.subscriptions(
+            dataset=dataset, group=self.msConfig['group'])
+        self.logger.debug(
+            "### dataset %s group %s", dataset, self.msConfig['group'])
+        self.logger.debug("### subscription %s", data)
+        tids = []
+        vals = []
+        for row in data['phedex']['dataset']:
+            if row['name'] == dataset:
+                for rec in row['subscription']:
+                    vals.append(int(rec['percent_files']))
+                    tids.append(int(rec['request']))
+        return tids, float(sum(vals))/len(vals)

--- a/src/python/WMCore/MicroService/Unified/MSManager.py
+++ b/src/python/WMCore/MicroService/Unified/MSManager.py
@@ -1,11 +1,26 @@
 """
-File       : UnifiedTransferorManager.py
+File       : MSManager.py
 Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
-Description: UnifiedTransferorManager class provides full functionality of the UnifiedTransferor service.
-"""
+             Alan Malta <alan dot malta AT cern dot ch >
+Description: MSManager class provides full functionality of the MSManager service.
+It provides a interface to reqmgr2ms service and should be
+used in service config.py as following
 
+.. doctest::
+
+    # REST interface
+    data = views.section_('data')
+    data.object = 'WMCore.MicroService.Service.RestApiHub.RestApiHub'
+    data.manager = 'WMCore.MicroService.Unified.MSManager.MSManager'
+    data.reqmgr2Url = "%s/reqmgr2" % BASE_URL
+    data.readOnly = False
+    data.verbose = True
+    data.interval = 60
+    data.rucioAccount = RUCIO_ACCT
+    data.dbsUrl = "%s/dbs/%s/global/DBSReader" % (BASE_URL, DBS_INS)
+"""
 # futures
-from __future__ import division
+from __future__ import division, print_function
 
 # system modules
 import time
@@ -13,9 +28,8 @@ import time
 # WMCore modules
 from WMCore.MicroService.Unified.Common import getMSLogger
 from WMCore.MicroService.Unified.MSTransferor import MSTransferor
+from WMCore.MicroService.Unified.MSMonitor import MSMonitor
 from WMCore.MicroService.Unified.TaskManager import start_new_thread
-from WMCore.Services.ReqMgr.ReqMgr import ReqMgr
-from WMCore.Services.ReqMgrAux.ReqMgrAux import ReqMgrAux
 
 
 def daemon(func, reqStatus, interval, logger):
@@ -31,42 +45,48 @@ def daemon(func, reqStatus, interval, logger):
 class MSManager(object):
     """
     Entry point for the MicroServices.
-    This class manages both transferor and monitor services/threads.
+    This class manages both transferor and monitoring services.
     """
 
     def __init__(self, config=None, logger=None):
         """
-        Setup a bunch of things, like:
-         * logger for this service
-         * initialize all the necessary service helpers
-         * fetch the unified configuration from central couch
-         * update the unified configuration with some deployment and default settings
-         * start both transfer and monitor threads
+        Initialize MSManager class with given configuation,
+        logger, ReqMgr2/ReqMgrAux/PhEDEx/Rucio objects,
+        and start transferor and monitoring threads.
         :param config: reqmgr2ms service configuration
         :param logger:
         """
         self.uConfig = {}
         self.config = config
         self.logger = getMSLogger(getattr(config, 'verbose', False), logger)
+        self._msConfig = None  # will be defined by _parseConfig API call
         self._parseConfig(config)
-        self.logger.info("Configuration including default values:\n%s", self.msConfig)
+        self.logger.info(
+            "Configuration including default values:\n%s", self.msConfig)
 
-        self.reqmgr2 = ReqMgr(self.msConfig['reqmgrUrl'], logger=self.logger)
-        self.reqmgrAux = ReqMgrAux(self.msConfig['reqmgrUrl'], httpDict={'cacheduration': 60}, logger=self.logger)
+        # initialize transferor class with assigned status as default
+        self.msTransferor = MSTransferor(self.msConfig, logger=self.logger)
+        # initialize monitoring class with staging status as default
+        self.msMonitor = MSMonitor(self.msConfig, logger=self.logger)
 
-        # transferor has to look at workflows in assigned status
-        self.msTransferor = MSTransferor(self.msConfig, "assigned", logger=self.logger)
-
-        ### Last but not least, get the threads started
+        # Last but not least, get the threads started
         thname = 'MSTransferor'
         self.transfThread = start_new_thread(thname, daemon,
-                                             (self.transferor, 'assigned', self.msConfig['interval'], self.logger))
-        self.logger.debug("### Running %s thread %s", thname, self.transfThread.running())
+                                             (self.transferor,
+                                              'assigned',
+                                              self.msConfig['interval'],
+                                              self.logger))
+        self.logger.debug(
+            "### Running %s thread %s", thname, self.transfThread.running())
 
         thname = 'MSTransferorMonit'
         self.monitThread = start_new_thread(thname, daemon,
-                                            (self.monitor, 'staging', self.msConfig['interval'] * 2, self.logger))
-        self.logger.debug("+++ Running %s thread %s", thname, self.monitThread.running())
+                                            (self.monitor,
+                                             'staging',
+                                             self.msConfig['interval'] * 2,
+                                             self.logger))
+        self.logger.debug(
+            "+++ Running %s thread %s", thname, self.monitThread.running())
 
     def _parseConfig(self, config):
         """
@@ -82,10 +102,15 @@ class MSManager(object):
         self.msConfig['interval'] = getattr(config, 'interval', 5 * 60)
         self.msConfig['readOnly'] = getattr(config, 'readOnly', True)
 
-        self.msConfig['reqmgrUrl'] = getattr(config, 'reqmgr2Url', 'https://cmsweb.cern.ch/reqmgr2')
-        self.msConfig['reqmgrCacheUrl'] = self.msConfig['reqmgrUrl'].replace('reqmgr2', 'couchdb/reqmgr_workload_cache')
-        self.msConfig['phedexUrl'] = getattr(config, 'phedexUrl', 'https://cmsweb.cern.ch/phedex/datasvc/json/prod')
-        self.msConfig['dbsUrl'] = getattr(config, 'dbsUrl', 'https://cmsweb.cern.ch/dbs/prod/global/DBSReader')
+        reqmgr2Url = 'https://cmsweb.cern.ch/reqmgr2'
+        self.msConfig['reqmgrUrl'] = getattr(config, 'reqmgr2Url', reqmgr2Url)
+        self.msConfig['reqmgrCacheUrl'] = \
+            self.msConfig['reqmgrUrl'].replace(
+                'reqmgr2', 'couchdb/reqmgr_workload_cache')
+        phedexUrl = 'https://cmsweb.cern.ch/phedex/datasvc/json/prod'
+        self.msConfig['phedexUrl'] = getattr(config, 'phedexUrl', phedexUrl)
+        dbsUrl = 'https://cmsweb.cern.ch/dbs/prod/global/DBSReader'
+        self.msConfig['dbsUrl'] = getattr(config, 'dbsUrl', dbsUrl)
 
     def transferor(self, reqStatus):
         """
@@ -97,10 +122,11 @@ class MSManager(object):
         """
         startT = time.time()
         self.logger.info("Starting the transferor thread...")
-        self.msTransferor.execute()
-        self.logger.info("Total transferor execution time: %.2f secs", time.time() - startT)
+        self.msTransferor.execute(reqStatus)
+        self.logger.info(
+            "Total transferor execution time: %.2f secs", time.time() - startT)
 
-    def monitor(self, reqStatus='staging'):
+    def monitor(self, reqStatus):
         """
         MSManager monitoring function.
         It performs transfer requests from staging to staged state of ReqMgr2.
@@ -109,50 +135,9 @@ class MSManager(object):
         """
         startT = time.time()
         self.logger.info("Starting the monitor thread...")
-        # First, fetch/update our unified configuration from reqmgr_aux db
-        # Keep our own copy of the unified config to avoid race conditions
-        self.uConfig = self.reqmgrAux.getUnifiedConfig(docName="config")
-        if not self.uConfig:
-            self.logger.warning("Monitor failed to fetch the unified config. Skipping this cycle.")
-            return
-        self.uConfig = self.uConfig[0]
-
-        try:
-            # get requests from ReqMgr2 data-service for given statue
-            # here with detail=False we get back list of records
-            requests = self.reqmgr2.getRequestByStatus([reqStatus], detail=False)
-            self.logger.debug('+++ monit found %s requests in %s state', len(requests), reqStatus)
-
-            requestStatus = {}  # keep track of request statuses
-            for reqName in requests:
-                req = {'name': reqName, 'reqStatus': reqStatus}
-                # get transfer IDs
-                tids = self.getTransferIDs()
-                # get transfer status
-                transferStatuses = self.getTransferStatuses(tids)
-                # get campaing and unified configuration
-                campaign = self.requestCampaign(reqName)
-                conf = self.requestConfiguration(reqName)
-                self.logger.debug("+++ request %s campaing %s conf %s", req, campaign, conf)
-
-                # if all transfers are completed, move the request status staging -> staged
-                # completed = self.checkSubscription(request)
-                completed = 100  # TMP
-                if completed == 100:  # all data are staged
-                    self.logger.debug("+++ request %s all transfers are completed", req)
-                    self.change(req, 'staged', '+++ monit')
-                # if pileup transfers are completed AND some input blocks are completed, move the request status staging -> staged
-                elif self.pileupTransfersCompleted(tids):
-                    self.logger.debug("+++ request %s pileup transfers are completed", req)
-                    self.change(req, 'staged', '+++ monit')
-                # transfers not completed, just update the database with their completion
-                else:
-                    self.logger.debug("+++ request %s transfers are not completed", req)
-                    requestStatus[req] = transferStatuses  # TODO: implement update of transfer ids
-            self.updateTransferIDs(requestStatus)
-        except Exception as err:  # general error
-            self.logger.exception('+++ monit error: %s', str(err))
-        self.logger.info("Total monitor execution time: %.2f secs", time.time() - startT)
+        self.msMonitor.execute(reqStatus)
+        self.logger.info(
+            "Total monitor execution time: %.2f secs", time.time() - startT)
 
     def stop(self):
         "Stop MSManager"
@@ -163,112 +148,14 @@ class MSManager(object):
         status = self.transfThread.running()
         return status
 
-    def getTransferIDsDoc(self):
-        """
-        Get transfer ids document from backend. The document has the following form:
-        {
-          "wf_A": [record1, record2, ...],
-          "wf_B": [....],
-        }
-        where each record has the following format:
-        {"timestamp":000, "dataset":"/a/b/c", "type": "primary", "trainsferIDs": [1,2,3]}
-        """
-        doc = {}
-        return doc
-
-    def updateTransferIDs(self, requestStatus):
-        "Update transfer ids in backend"
-        # TODO/Wait: https://github.com/dmwm/WMCore/issues/9198
-        # doc = self.getTransferIDsDoc()
-
-    def getTransferIDs(self):
-        "Get transfer ids from backend"
-        # TODO/Wait: https://github.com/dmwm/WMCore/issues/9198
-        # meanwhile return transfer ids from internal store 
-        return []
-
-    def getTransferStatuses(self, tids):
-        "get transfer statuses for given transfer IDs from backend"
-        # transfer docs on backend has the following form
-        # https://gist.github.com/amaltaro/72599f995b37a6e33566f3c749143154
-        statuses = {}
-        for tid in tids:
-            # TODO: I need to find request name from transfer ID
-            # status = self.checkSubscription(request)
-            status = 100
-            statuses[tid] = status
-        return statuses
-
-    def requestCampaign(self, req):
-        "Return request campaign"
-        return 'campaign_TODO'  # TODO
-
-    def requestConfiguration(self, req):
-        "Return request configuration"
-        return {}
-
-    def pileupTransfersCompleted(self, tids):
-        "Check if pileup transfers are completed"
-        # TODO: add implementation
-        return False
-
-    def checkSubscription(self, req):
-        "Send request to Phedex and return status of request subscription"
-        sdict = {}
-        for dataset in req.get('datasets', []):
-            data = self.phedex.subscriptions(dataset=dataset, group=self.msConfig['group'])
-            self.logger.debug("### dataset %s group %s", dataset, self.msConfig['group'])
-            self.logger.debug("### subscription %s", data)
-            for row in data['phedex']['dataset']:
-                if row['name'] != dataset:
-                    continue
-                nodes = [s['node'] for s in row['subscription']]
-                rNodes = req.get('sites')
-                self.logger.debug("### nodes %s %s", nodes, rNodes)
-                subset = set(nodes) & set(rNodes)
-                if subset == set(rNodes):
-                    sdict[dataset] = 1
-                else:
-                    pct = float(len(subset)) / float(len(set(rNodes)))
-                    sdict[dataset] = pct
-        self.logger.debug("### sdict %s", sdict)
-        tot = len(sdict.keys())
-        if not tot:
-            return -1
-        # return percentage of completion
-        return round(float(sum(sdict.values())) / float(tot), 2) * 100
-
-    def checkStatus(self, req):
-        "Check status of request in local storage"
-        self.logger.debug("### checkStatus of request: %s", req['name'])
-        # check subscription status of the request
-        # completed = self.checkSubscription(req)
-        completed = 100
-        if completed == 100:  # all data are staged
-            self.logger.debug("### request is completed, change its status and remove it from the store")
-            self.change(req, 'staged', '### transferor')
-        else:
-            self.logger.debug("### request %s, completed %s", req, completed)
-
-    def info(self, req):
+    def info(self, reqName):
         "Return info about given request"
-        completed = self.checkSubscription(req)
-        return {'request': req, 'status': completed}
+        # obtain status records from couchdb for given request
+        statusRecords = self.getStatusRecords(reqName)
+        # check status records and obtain completion status
+        _, completed = self.checkStatusRecords(statusRecords)
+        return {'request': reqName, 'status': completed}
 
     def delete(self, request):
         "Delete request in backend"
         pass
-
-    def change(self, req, reqStatus, prefix='###'):
-        """
-        Change request status, internally it is done via PUT request to ReqMgr2:
-        curl -X PUT -H "Content-Type: application/json" \
-             -d '{"RequestStatus":"staging", "RequestName":"bla-bla"}' \
-             https://xxx.yyy.zz/reqmgr2/data/request
-        """
-        self.logger.debug('%s updating %s status to %s', prefix, req['name'], reqStatus)
-        try:
-            if not self.msConfig['readOnly']:
-                self.reqmgr2.updateRequestStatus(req['name'], reqStatus)
-        except Exception as err:
-            self.logger.exception("Failed to change request status. Error: %s", str(err))

--- a/src/python/WMCore/MicroService/Unified/MSMonitor.py
+++ b/src/python/WMCore/MicroService/Unified/MSMonitor.py
@@ -1,0 +1,139 @@
+"""
+File       : MSMonitor.py
+Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
+             Alan Malta <alan dot malta AT cern dot ch >
+Description: MSMonitor class provide whole logic behind
+the transferor monitoring module.
+"""
+# futures
+from __future__ import division, print_function
+
+# WMCore modules
+from WMCore.MicroService.Unified.MSCore import MSCore
+
+
+class MSMonitor(MSCore):
+    """
+    MSMonitor class provide whole logic behind
+    the transferor monitoring module.
+    """
+    def execute(self, reqStatus):
+        """
+        Executes the MS monitoring logic
+        :param reqStatus: request statue to process
+        :return:
+        """
+        try:
+            # get requests from ReqMgr2 data-service for given statue
+            # here with detail=False we get back list of records
+            requests = self.reqmgr2.getRequestByStatus([reqStatus], detail=False)
+            self.logger.debug('+++ monit found %s requests in %s state',
+                              len(requests), reqStatus)
+
+            # FIXME: completion threshold should come either from unified
+            # or campaign configuration, e.g.
+            # thr = self.unifiedConfig().get('completedThreshold', 100)
+            thr = 100
+
+            requestStatuses = {}  # keep track of request statuses
+            for reqName in requests:
+                req = {'name': reqName, 'reqStatus': reqStatus}
+                self.logger.debug("+++ request %s", req)
+                # obtain status records from couchdb for given request
+                transferRecords = self.getTransferRecords(reqName)
+                if not transferRecords:
+                    continue
+                completion = self.completion(transferRecords)
+                # if all transfers are completed
+                # move the request status staging -> staged
+                if completion == thr:
+                    self.logger.debug(
+                        "+++ request %s all transfers are completed", req)
+                    self.change(req, 'staged', '+++ monit')
+                # if pileup transfers are completed AND
+                # some input blocks are completed,
+                # move the request status staging -> staged
+                elif self.pileupTransfersCompleted(transferRecords):
+                    self.logger.debug(
+                        "+++ request %s pileup transfers are completed", req)
+                    self.change(req, 'staged', '+++ monit')
+                # transfers not completed
+                # just update the database with their completion
+                else:
+                    self.logger.debug(
+                        "+++ request %s transfers are %s completed",
+                        req, completion)
+                    # for us workflow name is the same as request name
+                    wname = reqName
+                    requestStatuses[wname] = transferRecords
+            self.updateTransferInfo(requestStatuses)
+        except Exception as err:  # general error
+            self.logger.exception('+++ monit error: %s', str(err))
+
+    def getTransferRecords(self, reqName):
+        """
+        Get transfer records for given request name from CouchDB.
+        Transfer records on backend has the following form
+        https://gist.github.com/amaltaro/72599f995b37a6e33566f3c749143154
+        So far logic is based on option D of the records
+
+        .. doctest::
+
+            {"workflowName": "bla",
+             "timestamp": 123,
+             "transfers": [rec1, rec2, ... ]
+            }
+            where each record has the following format:
+            {"dataset":"/a/b/c", "dataType": "primary", "transferIDs": [1,2], "completion":0}
+
+        :param reqName: name of the request
+        :return: list of of status records
+        """
+        transferRecords = []
+
+        # in our case workflow name is the same as request name
+        wname = reqName
+        # get existing transfer IDs record
+        doc = self.getTransferInfo(wname)
+        if not doc:
+            self.logger.error("Failed to find a transfer document for request: %s", wname)
+            return transferRecords
+
+        # loop over all records and obtain new transfer IDs
+        for rec in doc['transfers']:
+            dataset = rec['dataset']
+            dtype = rec['dataType']
+            # obtain new transfer ids for given request name and dataset
+            tids, completion = self.getTransferIds(dataset)
+            rec = {'dataset': dataset, 'dataType': dtype,
+                   'transferIDs': tids, "completion": completion}
+            transferRecords.append(rec)
+        return transferRecords
+
+    def pileupTransfersCompleted(self, transferRecords):
+        "Check if pileup transfers are completed for given transfer records"
+        # FIXME: completion threshold should come either from unified
+        # or campaign configuration, e.g.
+        # thr = self.unifiedConfig().get('completedThreshold', 100)
+        thr = 100
+
+        records = 0
+        transferTypes = ['primary', 'secondary']
+        # loop over all records and obtain new transfer IDs
+        for rec in transferRecords:
+            ctype = rec['dataType']
+            completion = rec['completion']
+            # count records above threshold
+            if ctype in transferTypes and completion > thr:
+                records += 1
+        return True if records == len(transferRecords) else False
+
+    def completion(self, records):
+        """
+        Helper function to calculate completion of given records
+        :param records: list of status records
+        :return: completion value
+        """
+        # may need to implement proper algorithm, so far we take average
+        val = [r['completion'] for r in records]/len(records)
+        return val

--- a/src/python/WMQuality/Emulators/EmulatedUnitTestCase.py
+++ b/src/python/WMQuality/Emulators/EmulatedUnitTestCase.py
@@ -63,8 +63,6 @@ class EmulatedUnitTestCase(unittest.TestCase):
             self.phedexPatchers = []
             patchPhedexAt = ['WMCore.Services.PhEDEx.PhEDEx.PhEDEx', 'WMCore.WorkQueue.WorkQueue.PhEDEx',
                              'WMCore.Services.DBS.DBS3Reader.PhEDEx',
-                             'WMCore.MicroService.Unified.MSTransferor.PhEDEx',
-                             'WMCore.MicroService.Unified.RequestInfo.PhEDEx',
                              'WMComponent.PhEDExInjector.PhEDExInjectorPoller.PhEDEx']
             for module in patchPhedexAt:
                 self.phedexPatchers.append(mock.patch(module, new=MockPhEDExApi))

--- a/test/python/WMCore_t/MicroService_t/Unified_t/MSTransferor_t.py
+++ b/test/python/WMCore_t/MicroService_t/Unified_t/MSTransferor_t.py
@@ -37,21 +37,11 @@ class TransferorTest(EmulatedUnitTestCase):
                          'phedexUrl': 'https://cmsweb-testbed.cern.ch/phedex/datasvc/json/prod',
                          'dbsUrl': 'https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader'}
 
-        self.msTransferor = MSTransferor(self.msConfig, "assigned")
+        self.msTransferor = MSTransferor(self.msConfig)
 
         self.taskChainTempl = getTestFile('data/ReqMgr/requests/Integration/TaskChain_Prod.json')
         self.stepChainTempl = getTestFile('data/ReqMgr/requests/Integration/SC_LumiMask_PhEDEx.json')
         super(TransferorTest, self).setUp()
-
-    def tearDown(self):
-        super(TransferorTest, self).tearDown()
-
-    def testPrep(self):
-        """
-        Test the `prep` method
-        """
-        # TODO: it should be eventually mocked
-        self.assertTrue(self.msTransferor.prep())
 
     def testRequestRecord(self):
         """


### PR DESCRIPTION
Partially fixes #9196 

#### Status
In development

#### Description
It implements logic for MS based on transfer IDs. Here is how it is done:
  - code refactoring
     - `MSCore` is a base class for `MSMonitor`, `MSTransferor` and `RequestInfo`
  - transferor API obtain request info and perform transferRequest
    the transferRequest performs phedex subscription (via subscribe API which
    so far is commented out) and obtain transfer ids via getTransferIds API
    It does this for every dataset in request spec. At the end transfer API
    received status (transfer) records which its store to couchdb via
    `updateTransferInfo` API (which calls apis from 9275)
  - monit API get requests and fetch status (transfer) records from couchdb
    via `getTransferRecords` API (which by itself calls getTransferIds one).
    Then we check completion of transfer via `completion` API. If completed value is
    100 (percent) we are done, otherwise we update new set of records
    in couchdb via updateTransferInfo API.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
depends on #9198 , #9275, #9307 

#### External dependencies / deployment changes
no