### PR TITLE
Added ORA-25408 to the soft database error list

### DIFF
--- a/src/python/WMCore/Database/DBExceptionHandler.py
+++ b/src/python/WMCore/Database/DBExceptionHandler.py
@@ -12,10 +12,11 @@ import threading
 # ORA-00060: deadlock detected while waiting for resource
 # ORA-01033: ORACLE initialization or shutdown in progress
 # (cx_Oracle.InterfaceError) not connected  # same as ORA-03114, in the new SQLAlchemy
+# (cx_Oracle.DatabaseError) ORA-25408: can not safely replay call
 # and those two MySQL exceptions
 DB_CONNECTION_ERROR_STR = ["ORA-03113", "ORA-03114", "ORA-03135", "ORA-12545", "ORA-00060", "ORA-01033",
                            "MySQL server has gone away", "Lock wait timeout exceeded",
-                           "(cx_Oracle.InterfaceError) not connected"]
+                           "(cx_Oracle.InterfaceError) not connected", "ORA-25408"]
 
 
 def db_exception_handler(f):


### PR DESCRIPTION
Fixes #9277 

#### Status
ready

#### Description
Don't let components crash if they hit an `ORA-25408: can not safely replay call` database exception. Instead, rollback the transaction and try again in the next thread cycle.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
no

#### External dependencies / deployment changes
no