### PR TITLE
Update deployment with the new PUT request behaviour for the agent config

### DIFF
--- a/bin/wmagent-upload-config
+++ b/bin/wmagent-upload-config
@@ -2,17 +2,31 @@
 from __future__ import division, print_function
 
 import os
+import sys
+import json
 from pprint import pformat
 
 from WMCore.Agent.DefaultConfig import DEFAULT_AGENT_CONFIG
 from WMCore.Configuration import loadConfigurationFile
 from WMCore.Services.ReqMgrAux.ReqMgrAux import ReqMgrAux
 
-wmConfig = loadConfigurationFile(os.environ['WMAGENT_CONFIG'])
-reqMgrAux = ReqMgrAux(wmConfig.General.ReqMgr2ServiceURL)
+if __name__ == "__main__":
+    if len(sys.argv) > 2:
+        print("Too many arguments provided: %s" % sys.argv)
+        print("Usage: python wmagent-upload-config [optional override]")
+        print("Example: python wmagent-upload-config '{\"MaxRetries\":2}'")
+        sys.exit(0)
+    elif len(sys.argv) == 2:
+        override = json.loads(sys.argv[1])
+    else:
+        override = {}
 
-print("Posting agent default configuration:\n%s" % pformat(DEFAULT_AGENT_CONFIG))
-if not reqMgrAux.updateWMAgentConfig(wmConfig.Agent.hostName, DEFAULT_AGENT_CONFIG):
-    # then the document does not exist, create it
-    res = reqMgrAux.postWMAgentConfig(wmConfig.Agent.hostName, DEFAULT_AGENT_CONFIG)
-    print("Agent config successfully created: %s" % res.get("ok", False))
+    wmConfig = loadConfigurationFile(os.environ['WMAGENT_CONFIG'])
+    reqMgrAux = ReqMgrAux(wmConfig.General.ReqMgr2ServiceURL)
+
+    DEFAULT_AGENT_CONFIG.update(override)
+    print("Pushing the following agent configuration:\n%s" % pformat(DEFAULT_AGENT_CONFIG))
+    if not reqMgrAux.updateWMAgentConfig(wmConfig.Agent.hostName, DEFAULT_AGENT_CONFIG):
+        # then the document does not exist, create it
+        res = reqMgrAux.postWMAgentConfig(wmConfig.Agent.hostName, DEFAULT_AGENT_CONFIG)
+        print("Agent config successfully created: %s" % res.get("ok", False))

--- a/deploy/deploy-wmagent.sh
+++ b/deploy/deploy-wmagent.sh
@@ -26,7 +26,7 @@
 ### Usage:
 ### Usage: deploy-wmagent.sh -w <wma_version> -d <deployment_tag> -t <team_name> [-s <scram_arch>] [-r <repository>] [-n <agent_number>] [-c <central_services_url>]
 ### Usage: Example: sh deploy-wmagent.sh -w 1.2.2.patch2 -d HG1905e -t production -n 30
-### Usage: Example: sh deploy-wmagent.sh -w 1.2.2.patch1 -d HG1905e -t testbed-vocms001 -p "9174 9183 9184" -r comp=comp.amaltaro -c cmsweb-testbed.cern.ch
+### Usage: Example: sh deploy-wmagent.sh -w 1.2.4 -d HG1908a -t testbed-vocms001 -p "9174 9183 9184" -r comp=comp.amaltaro -c cmsweb-testbed.cern.ch
 ### Usage:
 
 IAM=`whoami`
@@ -365,24 +365,24 @@ else
 fi
 echo "Done!" && echo
 
-### Upload WMAgentConfig to AuxDB
-echo "*** Upload WMAgentConfig to AuxDB ***"
-cd $MANAGE_DIR
-./manage execute-agent wmagent-upload-config
-echo "Done!" && echo
-
 echo "*** Tweaking central agent configuration ***"
 CENTRAL_SERVICES="https://$CENTRAL_SERVICES/reqmgr2/data/wmagentconfig"
 if [[ "$TEAMNAME" == production ]]; then
   echo "Agent connected to the production team, setting it to drain mode"
-  curl --cert /data/certs/servicecert.pem --key /data/certs/servicekey.pem -k -X PUT -H "Content-type: application/json" -d '{"UserDrainMode":true}' $CENTRAL_SERVICES/$HOSTNAME
+  agentExtraConfig='{"UserDrainMode":true}'
 elif [[ "$TEAMNAME" == *testbed* ]]; then
   echo "Testbed agent, setting MaxRetries to 0..."
-  curl --cert /data/certs/servicecert.pem --key /data/certs/servicekey.pem -k -X PUT -H "Content-type: application/json" -d '{"MaxRetries":0}' $CENTRAL_SERVICES/$HOSTNAME
+  agentExtraConfig='{"MaxRetries":0}'
 elif [[ "$TEAMNAME" == *devvm* ]]; then
   echo "Dev agent, setting MaxRetries to 0..."
-  curl --cert /data/certs/servicecert.pem --key /data/certs/servicekey.pem -k -X PUT -H "Content-type: application/json" -d '{"MaxRetries":0}' $CENTRAL_SERVICES/$HOSTNAME
+  agentExtraConfig='{"MaxRetries":0}'
 fi
+echo "Done!" && echo
+
+### Upload WMAgentConfig to AuxDB
+echo "*** Upload WMAgentConfig to AuxDB ***"
+cd $MANAGE_DIR
+./manage execute-agent wmagent-upload-config $agentExtraConfig
 echo "Done!" && echo
 
 ###


### PR DESCRIPTION
Fixes #9257 

#### Status
not-tested

#### Description
Allow the configuration to be overriden in the script to upload the agent configuration to the reqmgr_aux couchdb.
Then adapted the deployment script to use this option.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs

#### External dependencies / deployment changes
no
