### PR TITLE
Only save logs in EOS/recent area for failed and a very small fraction of success jobs

### DIFF
--- a/src/python/WMCore/FwkJobReport/Report.py
+++ b/src/python/WMCore/FwkJobReport/Report.py
@@ -697,7 +697,7 @@ class Report(object):
         _setStep_
 
         """
-        if stepName not in self.data.steps:
+        if stepName not in self.listSteps():
             self.data.steps.append(stepName)
         else:
             logging.info("Step %s is now being overridden by a new step report", stepName)
@@ -830,7 +830,7 @@ class Report(object):
         """
         listOfFiles = []
 
-        for step in self.data.steps:
+        for step in self.listSteps():
             listOfFiles.extend(self.getAllFilesFromStep(step=step))
 
         return listOfFiles
@@ -843,7 +843,7 @@ class Report(object):
         """
 
         listOfFiles = []
-        for step in self.data.steps:
+        for step in self.listSteps():
             tmp = self.getInputFilesFromStep(stepName=step)
             if tmp:
                 listOfFiles.extend(tmp)
@@ -932,7 +932,7 @@ class Report(object):
         listed as skipped on the report.
         """
         listOfFiles = []
-        for step in self.data.steps:
+        for step in self.listSteps():
             tmp = self.getSkippedFilesFromStep(stepName=step)
             if tmp:
                 listOfFiles.extend(tmp)
@@ -947,7 +947,7 @@ class Report(object):
         listed as fallback attempt on the report
         """
         listOfFiles = []
-        for step in self.data.steps:
+        for step in self.listSteps():
             tmp = self.getFallbackFilesFromStep(stepName=step)
             if tmp:
                 listOfFiles.extend(tmp)
@@ -1043,13 +1043,13 @@ class Report(object):
         """
         value = True
 
-        if len(self.data.steps) == 0:
+        if len(self.listSteps()) == 0:
             # Mark jobs as failed if they have no steps
             msg = "Could not find any steps"
             logging.error(msg)
             return False
 
-        for stepName in self.data.steps:
+        for stepName in self.listSteps():
             # Ignore specified steps
             # i.e., logArch steps can fail without causing
             # the task to fail
@@ -1268,7 +1268,7 @@ class Report(object):
         """
 
         fileRefs = []
-        for step in self.data.steps:
+        for step in self.listSteps():
             tmpRefs = self.getAllFileRefsFromStep(step=step)
             if len(tmpRefs) > 0:
                 fileRefs.extend(tmpRefs)
@@ -1543,7 +1543,7 @@ class Report(object):
         trim the number of input files.
         """
 
-        for stepName in self.data.steps:
+        for stepName in self.listSteps():
             step = self.retrieveStep(stepName)
             inputSources = step.input.listSections_()
             for inputSource in inputSources:

--- a/src/python/WMCore/WMExceptions.py
+++ b/src/python/WMCore/WMExceptions.py
@@ -198,6 +198,7 @@ WM_JOB_ERROR_CODES = {-1: "Error return without specification.",
                       80001: "No exit code set by job wrapper.",  # CRAB3
                       80453: "Unable to determine pset hash from output file (CRAB3).",
                       90000: "Error in CRAB3 post-processing step (includes basically errors in stage out and file metadata upload).",  # CRAB3 TODO: Need to separate. new stageout errors are 60321-60324 and other needed for file metadata.
+                      99108: "Skipping this step due to a failure in a previous one.",  # WMA
                       99109: "Uncaught exception in WMAgent step executor.",  # WMA TODO: Maybe move to 7****?
                       99303: "Job failed and the original job report got lost",
                       99304: "Could not find jobCache directory. Job will be failed",

--- a/src/python/WMCore/WMSpec/Steps/Executors/AlcaHarvest.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/AlcaHarvest.py
@@ -6,17 +6,17 @@ Implementation of an Executor for a AlcaHarvest step
 
 """
 from __future__ import print_function
-import os
-import stat
-import shutil
+
 import logging
+import os
+import shutil
+import stat
 import subprocess
 
 from Utils.Utilities import rootUrlJoin
-from WMCore.WMSpec.Steps.Executor import Executor
 from WMCore.FwkJobReport.Report import Report
 from WMCore.Services.UUIDLib import makeUUID
-
+from WMCore.WMSpec.Steps.Executor import Executor
 from WMCore.WMSpec.Steps.WMExecutionFailure import WMExecutionFailure
 
 
@@ -27,26 +27,27 @@ class AlcaHarvest(Executor):
     Execute a AlcaHarvest Step
 
     """
-    def pre(self, emulator = None):
+
+    def pre(self, emulator=None):
         """
         _pre_
 
         Pre execution checks
 
         """
-        #Are we using an emulator?
+        # Are we using an emulator?
         if emulator != None:
             return emulator.emulatePre(self.step)
 
         logging.info("Steps.Executors.%s.pre called", self.__class__.__name__)
         return None
 
-    def execute(self, emulator = None):
+    def execute(self, emulator=None):
         """
         _execute_
 
         """
-        #Are we using emulators again?
+        # Are we using emulators again?
         if emulator != None:
             return emulator.emulate(self.step, self.job)
 
@@ -55,14 +56,13 @@ class AlcaHarvest(Executor):
         # Search through steps for analysis files
         for step in self.stepSpace.taskSpace.stepSpaces():
             if step == self.stepName:
-                #Don't try to parse your own report; it's not there yet
+                # Don't try to parse your own report; it's not there yet
                 continue
             stepLocation = os.path.join(self.stepSpace.taskSpace.location, step)
-            logging.info("Beginning report processing for step %s" % step)
+            logging.info("Beginning report processing for step %s", step)
             reportLocation = os.path.join(stepLocation, 'Report.pkl')
             if not os.path.isfile(reportLocation):
-                logging.error("Cannot find report for step %s in space %s" \
-                              % (step, stepLocation))
+                logging.error("Cannot find report for step %s in space %s", step, stepLocation)
                 continue
 
             # First, get everything from a file and 'unpersist' it
@@ -103,8 +103,10 @@ class AlcaHarvest(Executor):
                     with open(filenameTXT, "w") as fout:
                         fout.write(textoutput)
 
-                    os.chmod(filenameDB, stat.S_IREAD | stat.S_IWRITE | stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH | stat.S_IWOTH)
-                    os.chmod(filenameTXT, stat.S_IREAD | stat.S_IWRITE | stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH | stat.S_IWOTH)
+                    os.chmod(filenameDB,
+                             stat.S_IREAD | stat.S_IWRITE | stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH | stat.S_IWOTH)
+                    os.chmod(filenameTXT,
+                             stat.S_IREAD | stat.S_IWRITE | stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH | stat.S_IWOTH)
 
                     condFiles2copy.append(filenameDB)
                     condFiles2copy.append(filenameTXT)
@@ -118,17 +120,17 @@ class AlcaHarvest(Executor):
             # copy conditions files out and fake the job report
             addedOutputFJR = False
             if self.step.condition.lfnbase:
-                logging.info("Copy out conditions files to %s" % self.step.condition.lfnbase)
+                logging.info("Copy out conditions files to %s", self.step.condition.lfnbase)
                 for file2copy in condFiles2copy:
 
-                    logging.info("==> copy %s" % file2copy)
+                    logging.info("==> copy %s", file2copy)
 
                     targetLFN = os.path.join(self.step.condition.lfnbase, file2copy)
                     targetPFN = "root://eoscms//eos/cms%s" % targetLFN
 
                     command = "env XRD_WRITERECOVERY=0 xrdcp -s -f %s %s" % (file2copy, targetPFN)
 
-                    p = subprocess.Popen(command, shell = True,
+                    p = subprocess.Popen(command, shell=True,
                                          stdout=subprocess.PIPE,
                                          stderr=subprocess.STDOUT)
                     output = p.communicate()[0]
@@ -141,16 +143,16 @@ class AlcaHarvest(Executor):
                     # add fake output file to job report
                     addedOutputFJR = True
                     stepReport.addOutputFile(self.step.condition.outLabel,
-                                             aFile= {'lfn' : targetLFN,
-                                                     'pfn' : targetPFN,
-                                                     'module_label' : self.step.condition.outLabel})
+                                             aFile={'lfn': targetLFN,
+                                                    'pfn': targetPFN,
+                                                    'module_label': self.step.condition.outLabel})
 
             # copy luminosity files out
             if self.step.luminosity.url:
-                logging.info("Copy out luminosity files to %s" % self.step.luminosity.url)
+                logging.info("Copy out luminosity files to %s", self.step.luminosity.url)
                 for file2copy in lumiFiles2copy:
 
-                    logging.info("==> copy %s" % file2copy)
+                    logging.info("==> copy %s", file2copy)
 
                     targetPFN = rootUrlJoin(self.step.luminosity.url, file2copy)
                     if not targetPFN:
@@ -161,7 +163,7 @@ class AlcaHarvest(Executor):
 
                     command = "env XRD_WRITERECOVERY=0 xrdcp -s -f %s %s" % (file2copy, targetPFN)
 
-                    p = subprocess.Popen(command, shell = True,
+                    p = subprocess.Popen(command, shell=True,
                                          stdout=subprocess.PIPE,
                                          stderr=subprocess.STDOUT)
                     output = p.communicate()[0]
@@ -179,9 +181,9 @@ class AlcaHarvest(Executor):
                 # add fake placeholder output file to job report
                 logging.info("==> no sqlite files from AlcaHarvest job, creating placeholder file record")
                 stepReport.addOutputFile(self.step.condition.outLabel,
-                                         aFile= {'lfn' : "/no/output",
-                                                 'pfn' : "/no/output",
-                                                 'module_label' : self.step.condition.outLabel})
+                                         aFile={'lfn': "/no/output",
+                                                'pfn': "/no/output",
+                                                'module_label': self.step.condition.outLabel})
 
             # Am DONE with report
             # Persist it
@@ -189,7 +191,7 @@ class AlcaHarvest(Executor):
 
         return
 
-    def post(self, emulator = None):
+    def post(self, emulator=None):
         """
         _post_
 

--- a/src/python/WMCore/WMSpec/Steps/Executors/AlcaHarvest.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/AlcaHarvest.py
@@ -38,7 +38,7 @@ class AlcaHarvest(Executor):
         if emulator != None:
             return emulator.emulatePre(self.step)
 
-        print("Steps.Executors.AlcaHarvest.pre called")
+        logging.info("Steps.Executors.%s.pre called", self.__class__.__name__)
         return None
 
     def execute(self, emulator = None):
@@ -49,6 +49,8 @@ class AlcaHarvest(Executor):
         #Are we using emulators again?
         if emulator != None:
             return emulator.emulate(self.step, self.job)
+
+        logging.info("Steps.Executors.%s.execute called", self.__class__.__name__)
 
         # Search through steps for analysis files
         for step in self.stepSpace.taskSpace.stepSpaces():
@@ -198,5 +200,5 @@ class AlcaHarvest(Executor):
         if emulator is not None:
             return emulator.emulatePost(self.step)
 
-        print("Steps.Executors.AlcaHarvest.post called")
+        logging.info("Steps.Executors.%s.post called", self.__class__.__name__)
         return None

--- a/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
@@ -8,17 +8,17 @@ Implementation of an Executor for a CMSSW step.
 
 import logging
 import os
+import socket
 import subprocess
 import sys
-import socket
 
 from WMCore.FwkJobReport.Report import addAttributesToFile
+from WMCore.WMExceptions import WM_JOB_ERROR_CODES
 from WMCore.WMRuntime.Tools.Scram import Scram
+from WMCore.WMRuntime.Tools.Scram import getSingleScramArch
 from WMCore.WMSpec.Steps.Executor import Executor
 from WMCore.WMSpec.Steps.WMExecutionFailure import WMExecutionFailure
 from WMCore.WMSpec.WMStep import WMStepHelper
-from WMCore.WMRuntime.Tools.Scram import getSingleScramArch
-from WMCore.WMExceptions import WM_JOB_ERROR_CODES
 
 
 def analysisFileLFN(fileName, lfnBase, job):

--- a/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
@@ -42,7 +42,7 @@ class DQMUpload(Executor):
         if emulator is not None:
             return emulator.emulatePre(self.step)
 
-        logging.info("Steps.Executors.DQMUpload.pre called")
+        logging.info("Steps.Executors.%s.pre called", self.__class__.__name__)
         return None
 
     def execute(self, emulator=None):
@@ -53,6 +53,8 @@ class DQMUpload(Executor):
         # Are we using emulators again?
         if emulator is not None:
             return emulator.emulate(self.step, self.job)
+
+        logging.info("Steps.Executors.%s.execute called", self.__class__.__name__)
 
         if self.step.upload.proxy:
             try:
@@ -110,7 +112,7 @@ class DQMUpload(Executor):
         if emulator is not None:
             return emulator.emulatePost(self.step)
 
-        logging.info("Steps.Executors.DQMUpload.post called")
+        logging.info("Steps.Executors.%s.post called", self.__class__.__name__)
         return None
 
     #

--- a/src/python/WMCore/WMSpec/Steps/Executors/DeleteFiles.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/DeleteFiles.py
@@ -42,9 +42,7 @@ class DeleteFiles(Executor):
         if (emulator != None):
             return emulator.emulatePre( self.step )
 
-
-
-        print("Steps.Executors.DeleteFiles.pre called")
+        logging.info("Steps.Executors.%s.pre called", self.__class__.__name__)
         return None
 
 
@@ -59,7 +57,7 @@ class DeleteFiles(Executor):
         if (emulator != None):
             return emulator.emulate( self.step, self.job )
 
-
+        logging.info("Steps.Executors.%s.execute called", self.__class__.__name__)
 
         # Look!  I can steal from StageOut
         # DeleteMgr uses the same manager structure as StageOutMgr
@@ -171,5 +169,5 @@ class DeleteFiles(Executor):
         if (emulator != None):
             return emulator.emulatePost( self.step )
 
-        print("Steps.Executors.DeleteFiles.post called")
+        logging.info("Steps.Executors.%s.post called", self.__class__.__name__)
         return None

--- a/src/python/WMCore/WMSpec/Steps/Executors/DeleteFiles.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/DeleteFiles.py
@@ -8,20 +8,15 @@ Implementation of an Executor for a Delete step
 """
 from __future__ import print_function
 
-
-
-
-import os.path
 import logging
 import signal
 import traceback
 
-from WMCore.WMSpec.Steps.Executor           import Executor
-
 import WMCore.Storage.DeleteMgr as DeleteMgr
-
-from WMCore.WMSpec.Steps.Executors.LogArchive import Alarm, alarmHandler
 import WMCore.Storage.FileManager
+from WMCore.WMSpec.Steps.Executor import Executor
+from WMCore.WMSpec.Steps.Executors.LogArchive import Alarm, alarmHandler
+
 
 class DeleteFiles(Executor):
     """
@@ -29,8 +24,7 @@ class DeleteFiles(Executor):
 
     """
 
-
-    def pre(self, emulator = None):
+    def pre(self, emulator=None):
         """
         _pre_
 
@@ -39,23 +33,21 @@ class DeleteFiles(Executor):
         """
 
         # Are we using an emulator?
-        if (emulator != None):
-            return emulator.emulatePre( self.step )
+        if emulator is not None:
+            return emulator.emulatePre(self.step)
 
         logging.info("Steps.Executors.%s.pre called", self.__class__.__name__)
         return None
 
-
-
-    def execute(self, emulator = None):
+    def execute(self, emulator=None):
         """
         _execute_
 
         """
 
         # Are we using emulators again?
-        if (emulator != None):
-            return emulator.emulate( self.step, self.job )
+        if emulator is not None:
+            return emulator.emulate(self.step, self.job)
 
         logging.info("Steps.Executors.%s.execute called", self.__class__.__name__)
 
@@ -77,62 +69,59 @@ class DeleteFiles(Executor):
 
         stageOutCall = {}
         if "command" in overrides and "option" in overrides \
-               and "phedex-node" in overrides \
-               and"lfn-prefix" in overrides:
-            stageOutCall['command']    = overrides.get('command')
-            stageOutCall['option']     = overrides.get('option')
-            stageOutCall['phedex-node']= overrides.get('phedex-node')
+                and "phedex-node" in overrides \
+                and "lfn-prefix" in overrides:
+            stageOutCall['command'] = overrides.get('command')
+            stageOutCall['option'] = overrides.get('option')
+            stageOutCall['phedex-node'] = overrides.get('phedex-node')
             stageOutCall['lfn-prefix'] = overrides.get('lfn-prefix')
 
         # naw man, this is real
         # iterate over all the incoming files
         manager = DeleteMgr.DeleteMgr(**stageOutCall)
         manager.numberOfRetries = self.step.retryCount
-        manager.retryPauseTime  = self.step.retryDelay
+        manager.retryPauseTime = self.step.retryDelay
         # naw man, this is real
         # iterate over all the incoming files
         if not useNewStageOutCode:
             # old style
             manager = DeleteMgr.DeleteMgr(**stageOutCall)
             manager.numberOfRetries = self.step.retryCount
-            manager.retryPauseTime  = self.step.retryDelay
+            manager.retryPauseTime = self.step.retryDelay
         else:
             # new style
             logging.critical("DeleteFiles IS USING NEW STAGEOUT CODE")
             print("DeleteFiles IS USING NEW STAGEOUT CODE")
             manager = WMCore.Storage.FileManager.DeleteMgr(
-                                retryPauseTime  = self.step.retryDelay,
-                                numberOfRetries = self.step.retryCount,
-                                **stageOutCall)
+                    retryPauseTime=self.step.retryDelay,
+                    numberOfRetries=self.step.retryCount,
+                    **stageOutCall)
 
         # This is where the deleted files go
         filesDeleted = []
 
-        for file in self.job['input_files']:
-            logging.debug("Deleting LFN: %s" % file.get('lfn'))
-            fileForTransfer = {'LFN': file.get('lfn'),
+        for fileDict in self.job['input_files']:
+            logging.debug("Deleting LFN: %s", fileDict.get('lfn'))
+            fileForTransfer = {'LFN': fileDict.get('lfn'),
                                'PFN': None,  # PFNs are assigned in the Delete Manager
-                               'PNN' : None,  # PNN is assigned in the delete manager
+                               'PNN': None,  # PNN is assigned in the delete manager
                                'StageOutCommand': None}
-            filesDeleted.append( self.deleteOneFile(fileForTransfer, manager, waitTime))
+            filesDeleted.append(self.deleteOneFile(fileForTransfer, manager, waitTime))
 
         if hasattr(self.step, 'filesToDelete'):
             # files from the configTree to be deleted
             for k, v in self.step.filesToDelete.dictionary_().iteritems():
                 if k.startswith('file'):
-                    logging.debug("Deleting LFN: %s" % v)
-                    fileForTransfer = {'LFN' : v,
-                                       'PFN' : None,
-                                       'PNN' : None,
-                                       'StageOutCommand' : None}
-                    filesDeleted.append( self.deleteOneFile(fileForTransfer, manager, waitTime))
-
-
+                    logging.debug("Deleting LFN: %s", v)
+                    fileForTransfer = {'LFN': v,
+                                       'PFN': None,
+                                       'PNN': None,
+                                       'StageOutCommand': None}
+                    filesDeleted.append(self.deleteOneFile(fileForTransfer, manager, waitTime))
 
         # Now we've got to put things in the report
-        for file in filesDeleted:
-            self.report.addRemovedCleanupFile(**file)
-
+        for fileDict in filesDeleted:
+            self.report.addRemovedCleanupFile(**fileDict)
 
         return
 
@@ -141,8 +130,8 @@ class DeleteFiles(Executor):
         signal.alarm(waitTime)
 
         try:
-            manager(fileToDelete = fileForTransfer)
-            #Afterwards, the file should have updated info.
+            manager(fileToDelete=fileForTransfer)
+            # Afterwards, the file should have updated info.
             return fileForTransfer
 
         except Alarm:
@@ -158,16 +147,16 @@ class DeleteFiles(Executor):
 
         signal.alarm(0)
 
-    def post(self, emulator = None):
+    def post(self, emulator=None):
         """
         _post_
 
         Post execution checkpointing
 
         """
-        #Another emulator check
-        if (emulator != None):
-            return emulator.emulatePost( self.step )
+        # Another emulator check
+        if emulator is not None:
+            return emulator.emulatePost(self.step)
 
         logging.info("Steps.Executors.%s.post called", self.__class__.__name__)
         return None

--- a/src/python/WMCore/WMSpec/Steps/Executors/LogArchive.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/LogArchive.py
@@ -8,11 +8,12 @@ Implementation of an Executor for a LogArchive step
 import logging
 import os
 import os.path
+import random
 import re
 import signal
 import tarfile
 import time
-import random
+
 import WMCore.Storage.FileManager
 import WMCore.Storage.StageOutMgr as StageOutMgr
 from Utils.FileTools import calculateChecksums
@@ -84,9 +85,9 @@ class LogArchive(Executor):
             # new style
             logging.info("LOGARCHIVE IS USING NEW STAGEOUT CODE For EOS Copy")
             eosmanager = WMCore.Storage.FileManager.StageOutMgr(
-                retryPauseTime=retryPauseT,
-                numberOfRetries=numRetries,
-                **eosStageOutParams)
+                    retryPauseTime=retryPauseT,
+                    numberOfRetries=numRetries,
+                    **eosStageOutParams)
 
         eosFileInfo = {'LFN': self.getEOSLogLFN(),
                        'PFN': tarBallLocation,
@@ -157,10 +158,9 @@ class LogArchive(Executor):
         else:
             # new style
             logging.info("LOGARCHIVE IS USING NEW STAGEOUT CODE")
-            manager = WMCore.Storage.FileManager.StageOutMgr(
-                retryPauseTime=self.step.retryDelay,
-                numberOfRetries=self.step.retryCount,
-                **overrides)
+            manager = WMCore.Storage.FileManager.StageOutMgr(retryPauseTime=self.step.retryDelay,
+                                                             numberOfRetries=self.step.retryCount,
+                                                             **overrides)
 
         # Now we need to find all the reports
         # The log search follows this structure: ~pilotArea/jobArea/WMTaskSpaceArea/StepsArea

--- a/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
@@ -24,7 +24,6 @@ from WMCore.WMSpec.Steps.Executor import Executor
 from WMCore.WMSpec.Steps.WMExecutionFailure import WMExecutionFailure
 
 
-
 class LogCollect(Executor):
     """
     _LogCollect_
@@ -116,11 +115,11 @@ class LogCollect(Executor):
         # setup Scram needed to run edmCopyUtil
         if useEdmCopyUtil:
             scram = Scram(
-                command=scramCommand,
-                version=cmsswVersion,
-                initialise=self.step.application.setup.softwareEnvironment,
-                directory=self.step.builder.workingDir,
-                architecture=scramArch,
+                    command=scramCommand,
+                    version=cmsswVersion,
+                    initialise=self.step.application.setup.softwareEnvironment,
+                    directory=self.step.builder.workingDir,
+                    architecture=scramArch,
             )
             logging.info("Running scram")
             try:

--- a/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
@@ -44,7 +44,7 @@ class LogCollect(Executor):
         if emulator is not None:
             return emulator.emulatePre(self.step)
 
-        logging.info("Steps.Executors.LogCollect.pre called")
+        logging.info("Steps.Executors.%s.pre called", self.__class__.__name__)
         return None
 
     def execute(self, emulator=None):
@@ -52,15 +52,15 @@ class LogCollect(Executor):
         _execute_
 
         """
-        scramCommand = self.step.application.setup.scramCommand
-        scramArch = self.step.application.setup.scramArch
-        cmsswVersion = self.step.application.setup.cmsswVersion
-
-        scramArch = getSingleScramArch(scramArch)
-
         # Are we using emulators again?
         if emulator is not None:
             return emulator.emulate(self.step, self.job)
+
+        logging.info("Steps.Executors.%s.execute called", self.__class__.__name__)
+
+        scramCommand = self.step.application.setup.scramCommand
+        cmsswVersion = self.step.application.setup.cmsswVersion
+        scramArch = getSingleScramArch(self.step.application.setup.scramArch)
 
         overrides = {}
         if hasattr(self.step, 'override'):
@@ -290,5 +290,5 @@ class LogCollect(Executor):
         if emulator is not None:
             return emulator.emulatePost(self.step)
 
-        logging.info("Steps.Executors.LogCollect.post called")
+        logging.info("Steps.Executors.%s.post called", self.__class__.__name__)
         return None

--- a/src/python/WMCore/WMSpec/Steps/Executors/StageOut.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/StageOut.py
@@ -42,7 +42,7 @@ class StageOut(Executor):
         if emulator is not None:
             return emulator.emulatePre(self.step)
 
-        logging.info("Steps.Executors.StageOut.pre called")
+        logging.info("Steps.Executors.%s.pre called", self.__class__.__name__)
         return None
 
     def execute(self, emulator=None):
@@ -54,6 +54,8 @@ class StageOut(Executor):
         # Are we using emulators again?
         if emulator is not None:
             return emulator.emulate(self.step, self.job)
+
+        logging.info("Steps.Executors.%s.execute called", self.__class__.__name__)
 
         overrides = {}
         if hasattr(self.step, 'override'):
@@ -224,6 +226,8 @@ class StageOut(Executor):
         if emulator is not None:
             return emulator.emulatePost(self.step)
 
+        logging.info("Steps.Executors.%s.post called", self.__class__.__name__)
+
         for step in self.stepSpace.taskSpace.stepSpaces():
 
             if step == self.stepName:
@@ -256,7 +260,6 @@ class StageOut(Executor):
 
             stepReport.persist(reportLocation)
 
-        logging.info("Steps.Executors.StageOut.post called")
         return None
 
     # Accessory methods


### PR DESCRIPTION
Fixes #9202 
Fixes #9287 (2nd commit)

#### Status
not-tested

#### Description
Summary of changes as follows:
* created a new WMCore exit code, for cases where further cmsRun steps are skipped due to a failure in the previous one.
* for chain of cmsRun steps: if the previous step failed, then simply add an error to the report file and refrain from creating the cmsRun bootstrap and the actual cmsRun execution.
* set a step override during runtime to signalize that the logArchive should not be saved to EOS/recent area
* use the standard exception message - only in the CMSSW executor though - as defined in WMExceptions module.

#### Is it backward compatible (if not, which system it affects?)
yes. Changes will only apply to newly created sandboxes though.

#### Related PRs
no

#### External dependencies / deployment changes
no
