### PR TITLE
Fix LogCollect empty scramArch issue  

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Template.py
+++ b/src/python/WMCore/WMSpec/Steps/Template.py
@@ -73,7 +73,6 @@ class CoreHelper(WMStepHelper):
         split = [ x for x in split if x.strip() != "" ]
 
         dirs = getattr(self.data.build.directories, self.stepName())
-        lastDir = dirs
         for subdir in split:
             exists = getattr(dirs, subdir, None)
             if exists == None:
@@ -127,18 +126,18 @@ class Template:
     def __init__(self):
         pass
 
-    def __call__(self, wmStep):
+    def __call__(self, step):
         """
-        _operator(wmStep)_
+        _operator(step)_
 
         Install the template on the step instance provided
 
         """
-        self.coreInstall(wmStep)
-        self.install(wmStep)
+        self.coreInstall(step)
+        self.install(step)
 
 
-    def coreInstall(self, wmStep):
+    def coreInstall(self, step):
         """
         _coreInstall_
 
@@ -146,29 +145,29 @@ class Template:
 
         """
         # Environment settings to pass to the step
-        wmStep.section_("environment")
-        wmStep.environment.section_("variables")
-        wmStep.environment.section_("paths")
+        step.section_("environment")
+        step.environment.section_("variables")
+        step.environment.section_("paths")
 
         # Directory structure and files to be included in the job
         # beyond those that would be added by a Step Specific builder
         # Step Specific subclasses can simply append to these to get files
         # and dirs into the job
-        wmStep.section_("build")
-        wmStep.build.section_("directories")
-        wmStep.build.directories.section_(nodeName(wmStep))
+        step.section_("build")
+        step.build.section_("directories")
+        step.build.directories.section_(nodeName(step))
 
 
 
 
 
 
-    def install(self, wmStep):
+    def install(self, step):
         """
         _install_
 
         Override this method to install the required attributes
-        in the wmStep Instance provided
+        in the step Instance provided
 
         """
         msg = "WMSpec.Steps.Template.install method not overridden in "
@@ -176,11 +175,11 @@ class Template:
         raise NotImplementedError(msg)
 
 
-    def helper(self, wmStep):
+    def helper(self, step):
         """
         _helper_
 
-        Wrap the wmStep instance in a helper class tailored to this particular
+        Wrap the step instance in a helper class tailored to this particular
         step type
 
         """

--- a/src/python/WMCore/WMSpec/Steps/Templates/LogCollect.py
+++ b/src/python/WMCore/WMSpec/Steps/Templates/LogCollect.py
@@ -57,6 +57,21 @@ class LogCollectStepHelper(CoreHelper):
             setattr(self.data.application.setup, k, v)
         return
 
+    def getScramArch(self):
+        """
+        _getScramArch_
+
+        Retrieve the scram architecture used for this step.
+        """
+        return self.data.application.setup.scramArch
+
+    def getCMSSWVersion(self):
+        """
+        _getCMSSWVersion_
+
+        Retrieve the version of the framework used for this step.
+        """
+        return self.data.application.setup.cmsswVersion
 
 class LogCollect(Template):
     """

--- a/src/python/WMCore/WMSpec/Steps/Templates/LogCollect.py
+++ b/src/python/WMCore/WMSpec/Steps/Templates/LogCollect.py
@@ -13,8 +13,6 @@ Mostly borrowed from StageOut since they share a similar function
 
 from WMCore.WMSpec.Steps.Template import Template
 from WMCore.WMSpec.Steps.Template import CoreHelper
-from WMCore.WMSpec.ConfigSectionTree import nodeName
-
 
 
 class LogCollectStepHelper(CoreHelper):
@@ -53,7 +51,7 @@ class LogCollectStepHelper(CoreHelper):
         softwareEnvironment - setup command to bootstrap scram,defaults to None
         """
         self.data.application.setup.cmsswVersion = cmsswVersion
-        for k,v in options.items():
+        for k, v in options.items():
             setattr(self.data.application.setup, k, v)
         return
 
@@ -82,7 +80,6 @@ class LogCollect(Template):
     """
 
     def install(self, step):
-        stepname = nodeName(step)
         step.stepType = "LogCollect"
         step.section_("logs")
         step.logcount = 0

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -1245,7 +1245,7 @@ class WMTaskHelper(TreeHelper):
         versions = []
         for stepName in self.listAllStepNames():
             stepHelper = self.getStepHelper(stepName)
-            if stepHelper.stepType() == "CMSSW":
+            if stepHelper.stepType() in ["CMSSW", "LogCollect"]:
                 if not allSteps:
                     return stepHelper.getCMSSWVersion()
                 else:
@@ -1262,7 +1262,7 @@ class WMTaskHelper(TreeHelper):
         scrams = []
         for stepName in self.listAllStepNames():
             stepHelper = self.getStepHelper(stepName)
-            if stepHelper.stepType() == "CMSSW":
+            if stepHelper.stepType() in ["CMSSW", "LogCollect"]:
                 if not allSteps:
                     return stepHelper.getScramArch()
                 else:

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# pylint: disable=W0212
+# W0212 (protected-access): Access to protected names of a client class.
 """
 _WMTask_
 


### PR DESCRIPTION
Fixes #9049

#### Status
Tested. 
Task name:
wmagent_TC_SLC7_khurtado_slc7test_vb2_190710_192451_2218

#### Description
JobCreator is adding  an empty list for scramArch/swVersion on LogCollect jobs, hence not setting the REQUIRED_OS classad at submission level on LogCollect (which depend con scramArch) jobs either.
Solution:
Add methods in the LogCollect step type template to retrieve scram/swVersion and use make sure JobCreatorPoller use those methods for LogCollect step types.

#### Is it backward compatible (if not, which system it affects?)
YES