### PR TITLE
renamed ReqMgrAux method name called from DrainStatusPoller - wmagent branch

### DIFF
--- a/src/python/WMComponent/AgentStatusWatcher/DrainStatusPoller.py
+++ b/src/python/WMComponent/AgentStatusWatcher/DrainStatusPoller.py
@@ -110,7 +110,7 @@ class DrainStatusPoller(BaseWorkerThread):
         # update the aux db speed drain config with any changes
         if updateConfig:
             self.agentConfig['SpeedDrainMode'] = True
-            self.reqAuxDB.updateAgentConfig(self.config.Agent.hostName, self.agentConfig)
+            self.reqAuxDB.updateWMAgentConfig(self.config.Agent.hostName, self.agentConfig)
 
         return
 
@@ -126,7 +126,7 @@ class DrainStatusPoller(BaseWorkerThread):
                 if key in self.validSpeedDrainConfigKeys and v['Enabled']:
                     speedDrainConfig[key]['Enabled'] = False
 
-            self.reqAuxDB.updateAgentConfig(self.config.Agent.hostName, self.agentConfig)
+            self.reqAuxDB.updateWMAgentConfig(self.config.Agent.hostName, self.agentConfig)
         return
 
     def checkSpeedDrainThresholds(self):


### PR DESCRIPTION
Fixes #9297 

#### Status
ready

#### Description
One of the patches applied to the 1.2.2 agents had a method rename, and I missed it in the DrainStatusPoller. 

#### Is it backward compatible (if not, which system it affects?)
no

#### Related PRs
It complements PR https://github.com/dmwm/WMCore/pull/9255

#### External dependencies / deployment changes
no
