### PR TITLE
Support large integer values for events in MariaDB

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/MySQL/Create.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/Create.py
@@ -90,7 +90,7 @@ class Create(DBCreator):
                  id                    INTEGER      AUTO_INCREMENT,
                  lfn                   VARCHAR(500) NOT NULL,
                  filesize              BIGINT,
-                 events                INTEGER,
+                 events                BIGINT UNSIGNED,
                  dataset_algo          INTEGER      NOT NULL,
                  block_id              INTEGER,
                  status                VARCHAR(20),
@@ -111,7 +111,7 @@ class Create(DBCreator):
                  filename    INTEGER NOT NULL,
                  run         INTEGER NOT NULL,
                  lumi        INTEGER NOT NULL,
-                 num_events      INTEGER)"""
+                 num_events  BIGINT UNSIGNED)"""
 
         self.create[len(self.create)] = \
             """CREATE TABLE dbsbuffer_location (

--- a/src/python/WMCore/WMBS/CreateWMBSBase.py
+++ b/src/python/WMCore/WMBS/CreateWMBSBase.py
@@ -77,8 +77,8 @@ class CreateWMBSBase(DBCreator):
                id           INTEGER      PRIMARY KEY AUTO_INCREMENT,
                lfn          VARCHAR(700) NOT NULL,
                filesize     BIGINT,
-               events       INTEGER,
-               first_event  BIGINT       NOT NULL DEFAULT 0,
+               events       BIGINT UNSIGNED,
+               first_event  BIGINT       UNSIGNED NOT NULL DEFAULT 0,
                merged       INT(1)       NOT NULL DEFAULT 0,
                UNIQUE (lfn))"""
 
@@ -104,7 +104,7 @@ class CreateWMBSBase(DBCreator):
                fileid  INTEGER NOT NULL,
                run     INTEGER NOT NULL,
                lumi    INTEGER NOT NULL,
-               num_events  INTEGER,
+               num_events  BIGINT UNSIGNED,
                PRIMARY KEY (fileid, run, lumi),
                FOREIGN KEY (fileid) references wmbs_file_details(id)
                  ON DELETE CASCADE)"""

--- a/src/python/WMCore/WMBS/MySQL/Create.py
+++ b/src/python/WMCore/WMBS/MySQL/Create.py
@@ -67,6 +67,5 @@ class Create(CreateWMBSBase):
     def execute(self, conn=None, transaction=None):
         for i in self.create.keys():
             self.create[i] += " ENGINE=InnoDB ROW_FORMAT=DYNAMIC"
-            self.create[i] = self.create[i].replace('INTEGER', 'INT(11)')
 
         return CreateWMBSBase.execute(self, conn, transaction)


### PR DESCRIPTION
Fixes #9303 

#### Status
not-tested

#### Description
Provided a very low filter efficiency, it might be that plain integer (32 bits) is not enough to represent a file mask and its event information (total, first, last event). It only happens in MariaDB though, Oracle maps an `INTEGER` data type to `NUMBER(38)`, which gives us a very high limit of `9223372036854775807`.

This patch replaces MariaDB integer by `BIGINT`, which should give us the same upper limit is given by oracle.

#### Is it backward compatible (if not, which system it affects?)
no, it has database schema changes

#### Related PRs

#### External dependencies / deployment changes
no
