### PR TITLE
Tier0 sets WorkQueue to None, so we cannot/shouldn't use any WorkQueue methods…

### DIFF
--- a/src/python/WMComponent/TaskArchiver/TaskArchiverPoller.py
+++ b/src/python/WMComponent/TaskArchiver/TaskArchiverPoller.py
@@ -193,7 +193,8 @@ class TaskArchiverPoller(BaseWorkerThread):
             statusList = [statusList]
         reqNames = self.centralCouchDBWriter.getRequestByStatus(statusList)
         logging.info("There are %d requests in %s status in central couch.", len(reqNames), statusList)
-        self.workQueue.killWMBSWorkflows(reqNames)
+        if self.workQueue is not None:
+            self.workQueue.killWMBSWorkflows(reqNames)
         return reqNames
 
     def completeTasks(self, finishedwfs):


### PR DESCRIPTION
… on Tier0 WMAgent.

Fixes #9313

#### Status
ready

#### Description
A simple condition check seemed the simplest way not to end up in calling a method of a None object.
It shouldn't affect Production agents since you always define the WorkQueue there.
Also,  @amaltaro  Alan, this leaves in place your improvements in the WorkQueue logic.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Changes (non-T0 compatible) introduced by: https://github.com/dmwm/WMCore/pull/9183

#### External dependencies / deployment changes

