### PR TITLE
Fix status REST API for ReqMgr2MS

### DIFF
--- a/src/python/WMCore/MicroService/Unified/MSManager.py
+++ b/src/python/WMCore/MicroService/Unified/MSManager.py
@@ -159,3 +159,13 @@ class MSManager(object):
     def delete(self, request):
         "Delete request in backend"
         pass
+
+    def status(self, **kwargs):
+        """
+        Return current status for the MicroService Manager
+        Args:
+            **kwargs: it will be a request name in the future
+        """
+        # TODO: eventually give it the correct purpose like, given
+        # a request name, return its transfer status
+        return "OK"


### PR DESCRIPTION
Fixes #9318 

#### Status
ready

#### Description
Put the `status` method back to the MSManager such that we can get the `status` REST API working again. I have also added some extra information to the results, until the service commissioning phase is over and we can re-purpose that API.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Complement/fix bug introduced by https://github.com/dmwm/WMCore/pull/9296

#### External dependencies / deployment changes
no
