### PR TITLE
Use x509 attributes directly, rather than a classad expression to handle

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/BasePlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/BasePlugin.py
@@ -21,7 +21,7 @@ class BossAirPluginException(WMException):
 
 
 
-class BasePlugin:
+class BasePlugin(object):
     """
     Base class for BossAir Plugins
 
@@ -30,10 +30,13 @@ class BasePlugin:
 
 
     # the common states which needs to be mapped from each plugIn states
-    globalState = ['Pending', 'Running', 'Complete','Error']
+    globalState = ['Pending', 'Running', 'Complete', 'Error']
 
     @staticmethod
     def verifyState(stateMap):
+        """
+        Verify state of map values
+        """
         for state in stateMap.values():
             if state not in BasePlugin.globalState:
                 raise BossAirPluginException("not valid state %s" % state)
@@ -58,14 +61,14 @@ class BasePlugin:
 
 
 
-    def submit(self, jobs, info = None):
+    def submit(self, jobs, info=None):
         """
         _submit_
 
         Submits jobs
         """
 
-        return
+        pass
 
 
     def track(self, jobs):
@@ -90,18 +93,17 @@ class BasePlugin:
         """
 
 
-        return
+        pass
 
 
-    def kill(self, jobs):
+    def kill(self, jobs, raiseEx):
         """
         _kill_
 
         Kill any and all jobs
         """
 
-
-        return
+        pass
 
     def updateJobInformation(self, workflow, task, **kwargs):
         """
@@ -113,7 +115,7 @@ class BasePlugin:
         """
         pass
 
-    def updateSiteInformation(self, jobs, siteName, excludeSite) :
+    def updateSiteInformation(self, jobs, siteName, excludeSite):
         """
         _updateSiteInformation_
 

--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -138,8 +138,6 @@ class SimpleCondorPlugin(BasePlugin):
         self.x509userproxy = proxy.getProxyFilename()
         self.x509userproxysubject = proxy.getSubject()
         self.x509userproxyfqan = proxy.getAttributeFromProxy(self.x509userproxy)
-        # Remove the x509 ads if the job is matching a volunteer resource
-        self.x509Expr = 'ifThenElse("$$(GLIDEIN_CMSSite)" =?= "T3_CH_Volunteer",undefined,"%s")'
 
         return
 
@@ -571,9 +569,9 @@ class SimpleCondorPlugin(BasePlugin):
             if self.reqStr and "T3_CH_Volunteer" not in job.get('possibleSites'):
                 ad['Requirements'] = classad.ExprTree(self.reqStr)
 
-            ad['x509userproxy'] = classad.ExprTree(self.x509Expr % self.x509userproxy)
-            ad['x509userproxysubject'] = classad.ExprTree(self.x509Expr % self.x509userproxysubject)
-            ad['x509userproxyfirstfqan'] = classad.ExprTree(self.x509Expr % self.x509userproxyfqan)
+            ad['x509userproxy'] = self.x509userproxy
+            ad['x509userproxysubject'] = self.x509userproxysubject
+            ad['x509userproxyfirstfqan'] = self.x509userproxyfqan
 
 
             sites = ','.join(sorted(job.get('possibleSites')))


### PR DESCRIPTION
Fixes #9331

This passes the x509 attributes rather than a classad expression that was created to handle proxy issues with `T3_CH_Volunteer`. The volunteer schedd(s) will handle that in the condor the configuration instead.
Condor changes will be applied to the volunteer schedd(s) only, through puppet rules [here](https://gitlab.cern.ch/ai/it-puppet-hostgroup-vocmsglidein/tree/qa/code/templates/modules/condor).

For reference, rules look like this:
```
JOB_TRANSFORM_NAMES = REMOVE_X509_ATTRS
JOB_TRANSFORM_REMOVE_X509_ATTRS = [ \
  Requirements = !isUndefined(x509userproxy) && isString(x509userproxy); \
  Copy_x509userproxy = "original_x509userproxy"; \
  set_x509userproxy = ifThenElse( \
   !isUndefined(MachineAttrGLIDEIN_CMSSite0) &&  \
   MachineAttrGLIDEIN_CMSSite0 =?= "T3_CH_Volunteer", \
      undefined, \
      strcat(original_x509userproxy)); \
]
```

EDIT: Keeping "Do not merge yet" label until we do the final test in the volunteer schedd.