### PR TITLE
Default ProcVer to 1 on the StoreResults script

### DIFF
--- a/bin/createStoreResults.py
+++ b/bin/createStoreResults.py
@@ -109,12 +109,17 @@ def buildRequest(userDict):
     # Truncate the ProcessingString, otherwise it can be larger than allowed
     primDset, procDset, _tier = newSchema['InputDataset'].split("/")[1:]
     acqEra, procStr = procDset.split("-", 1)
-    newSchema["AcquisitionEra"] = acqEra  # should we worry about lenght limits?
+    newSchema["AcquisitionEra"] = acqEra  # should we worry about length limits?
     procStr, procVer = procStr.rsplit("-", 1)
     newSchema["ProcessingString"] = "StoreResults_" + procStr[:67]  # limit to 80 chars
-    newSchema["ProcessingVersion"] = int(procVer[1:])
+    # ProcessingString cannot have a dash char
+    newSchema["ProcessingString"] = newSchema["ProcessingString"].replace("-", "_")
+    try:
+        newSchema["ProcessingVersion"] = int(procVer[1:])
+    except ValueError:
+        newSchema["ProcessingVersion"] = 1
     # Use PrimaryDataset and ProcessedDataset in the RequestString
-    newSchema["RequestString"] = primDset[:50] + "-" + procDset[:50]
+    newSchema["RequestString"] = primDset[:35] + "-" + procDset[:35]
     return newSchema
 
 


### PR DESCRIPTION
Fixes #9328 

#### Status
not-tested

#### Description
Three basic changes:
* in case ProcessingVersion can't be defined from the InputDataset, set it to 1.
* remove dashes `-` from the ProcessingString (replacing by underscore).
* the whole RequestName parameter cannot be greater than 100 chars, so limit RequestString to only 70 chars.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
no

#### External dependencies / deployment changes
no