### PR TITLE
Fix CMSSW seg fault showing up as BadFWJRXML error

### DIFF
--- a/src/python/WMCore/FwkJobReport/Report.py
+++ b/src/python/WMCore/FwkJobReport/Report.py
@@ -152,7 +152,6 @@ class Report(object):
             for stackFrame in stackTrace:
                 crashMessage += stackFrame
 
-            self.addError(stepName, 50115, "BadFWJRXML", msg)
             logging.debug(crashMessage)
             raise FwkJobReportException(msg)
 

--- a/src/python/WMCore/WMSpec/Steps/Diagnostic.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostic.py
@@ -8,7 +8,7 @@ Interface and base class for step specific diagnostic handlers
 
 """
 
-
+from WMCore.FwkJobReport.Report import FwkJobReportException
 
 
 class DiagnosticHandler(object):
@@ -33,6 +33,19 @@ class DiagnosticHandler(object):
         msg = "DiagnosticHandler.__call__ not "
         msg += "implemented for class %s" % self.__class__.__name__
         raise NotImplementedError(msg)
+
+    def parse(self, executorInstance, jobRepXml):
+        """
+        Add an error to report if parsing the xml fails.
+        """
+        try:
+            executorInstance.report.parse(jobRepXml, executorInstance.stepName)
+        except FwkJobReportException as ex:
+            # Job report is bad, the parse already puts a 50115 in the file
+            msg = "Error reading XML job report file, possibly corrupt XML File:\n"
+            msg += "Details: %s" % str(ex)
+            executorInstance.report.addError(executorInstance.stepName, 50115, "BadFWJRXML", msg)
+            raise
 
 
 class DefaultDiagnosticHandler(DiagnosticHandler):

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/AlcaHarvest.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/AlcaHarvest.py
@@ -45,7 +45,7 @@ class AHExceptionHandler(DiagnosticHandler):
             return
 
         # job report XML exists, load the exception information from it
-        executor.report.parse(jobRepXml)
+        self.parse(executor, jobRepXml)
 
         # make sure the report has the error in it
         errSection = getattr(executor.report.report, "errors", None)

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/AlcaHarvest.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/AlcaHarvest.py
@@ -66,4 +66,6 @@ class AlcaHarvest(Diagnostic):
         self.handlers[60319] = Exit60319()
 
         catchAll = AHExceptionHandler()
-        [self.handlers.__setitem__(x, catchAll) for x in range(0, 255) if x not in self.handlers]
+        for x in range(0, 255):
+            if x not in self.handlers:
+                self.handlers.__setitem__(x, catchAll)

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/CMSSW.py
@@ -99,10 +99,11 @@ class CMSDefaultHandler(DiagnosticHandler):
         if os.path.exists(jobRepXml):
             # job report XML exists, load the exception information from it
             try:
-                executor.report.parse(jobRepXml)
-            except FwkJobReportException:
-                # Job report is bad, the parse already puts a 50115 in the file
+                self.parse(executor, jobRepXml)
+            except FwkJobReportException:    
+                # Job report is bad, the parse already puts a 50115 in the file    
                 pass
+
             reportStep = executor.report.retrieveStep(executor.stepName)
             reportStep.status = errCode
 
@@ -149,10 +150,11 @@ class CMSRunHandler(DiagnosticHandler):
         if os.path.exists(jobRepXml):
             # job report XML exists, load the exception information from it
             try:
-                executor.report.parse(jobRepXml)
-            except FwkJobReportException:
-                # Job report is bad, the parse already puts a 50115 in the file
+                self.parse(executor, jobRepXml)
+            except FwkJobReportException:    
+                # Job report is bad, the parse already puts a 50115 in the file    
                 pass
+
             reportStep = executor.report.retrieveStep(executor.stepName)
             reportStep.status = self.code
 
@@ -238,10 +240,9 @@ class EDMExceptionHandler(DiagnosticHandler):
 
         # job report XML exists, load the exception information from it
         try:
-            executor.report.parse(jobRepXml)
-        except FwkJobReportException:
-            # Job report is bad, the parse already puts a 50115 in the file
-            # just go on
+            self.parse(executor, jobRepXml)
+        except FwkJobReportException:    
+            # Job report is bad, the parse already puts a 50115 in the file    
             pass
 
         # make sure the report has the error in it

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/CMSSW.py
@@ -295,4 +295,6 @@ class CMSSW(Diagnostic):
         # for all the exception codes between 1 and 225, use a default that attempts to read the code
         # from the job report
         catchAll = EDMExceptionHandler()
-        [self.handlers.__setitem__(x, catchAll) for x in range(0, 255) if x not in self.handlers]
+        for x in range(0, 255):
+            if x not in self.handlers:
+                self.handlers.__setitem__(x, catchAll)

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/DQMUpload.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/DQMUpload.py
@@ -44,7 +44,7 @@ class DUExceptionHandler(DiagnosticHandler):
             return
 
         # job report XML exists, load the exception information from it
-        executor.report.parse(jobRepXml)
+        self.parse(executor, jobRepXml)
 
         # make sure the report has the error in it
         errSection = getattr(executor.report.report, "errors", None)

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/DeleteFiles.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/DeleteFiles.py
@@ -40,8 +40,7 @@ class DFExceptionHandler(DiagnosticHandler):
             return
 
         # job report XML exists, load the exception information from it
-        executor.report.parse(jobRepXml)
-
+        self.parse(executor, jobRepXml)
 
         # make sure the report has the error in it
         errSection = getattr(executor.report.report, "errors", None)

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/DeleteFiles.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/DeleteFiles.py
@@ -63,4 +63,6 @@ class DeleteFiles(Diagnostic):
 
 
         catchAll = DFExceptionHandler()
-        [ self.handlers.__setitem__(x, catchAll) for x in range(0, 255) if x not in self.handlers ]
+        for x in range(0, 255):
+            if x not in self.handlers:
+                self.handlers.__setitem__(x, catchAll)

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/LogArchive.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/LogArchive.py
@@ -70,5 +70,6 @@ class LogArchive(Diagnostic):
         # Setup a default handler
         catchAll            = LAExceptionHandler()
         self.defaultHandler = catchAll
-
-        [ self.handlers.__setitem__(x, catchAll) for x in range(0, 255) if x not in self.handlers ]
+        for x in range(0, 255):
+            if x not in self.handlers:
+                self.handlers.__setitem__(x, catchAll)

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/LogArchive.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/LogArchive.py
@@ -42,8 +42,7 @@ class LAExceptionHandler(DiagnosticHandler):
             return
 
         # job report XML exists, load the exception information from it
-        executor.report.parse(jobRepXml)
-
+        self.parse(executor, jobRepXml)
 
         # make sure the report has the error in it
         errSection = getattr(executor.report.report, "errors", None)

--- a/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
@@ -43,6 +43,10 @@ class CMSSW(Executor):
 
     """
 
+    def __init__(self):
+        super(CMSSW, self).__init__()
+        self.failedPreviousStep = None
+
     def _setStatus(self, returnCode, returnMessage):
         """
         Set return code.

--- a/test/python/WMCore_t/FwkJobReport_t/Report_t.py
+++ b/test/python/WMCore_t/FwkJobReport_t/Report_t.py
@@ -253,8 +253,6 @@ class ReportTest(unittest.TestCase):
         myReport = Report("cmsRun1")
         from WMCore.FwkJobReport.Report import FwkJobReportException
         self.assertRaises(FwkJobReportException, myReport.parse, self.badxmlPath)
-        self.assertEqual(myReport.getStepErrors("cmsRun1")['error0'].type, 'BadFWJRXML')
-        self.assertEqual(myReport.getStepErrors("cmsRun1")['error0'].exitCode, 50115)
         return
 
     def testErrorReporting(self):

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/CMSSW_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/CMSSW_t.py
@@ -20,6 +20,7 @@ import WMCore_t.WMSpec_t.Steps_t as ModuleLocator
 
 from WMCore.DataStructs.Job import Job
 from WMCore.FwkJobReport.Report import Report
+from WMCore.FwkJobReport.Report import FwkJobReportException
 from WMCore.WMBase import getTestBase
 from WMCore.WMSpec.Makers.TaskMaker import TaskMaker
 from WMCore.WMSpec.Steps import StepFactory
@@ -195,10 +196,11 @@ class CMSSW_t(unittest.TestCase):
                 self.fail("An exception should have been raised")
             except WMExecutionFailure as ex:
                 executor.diagnostic(ex.code, executor, ExceptionInstance=ex)
-                self.assertEqual(50115, executor.report.getExitCode())
+                #self.assertEqual(50115, executor.report.getExitCode())
+                self.assertEqual(134, executor.report.getExitCode())
                 report = Report()
                 report.load("Report.pkl")
-                self.assertEqual(50115, report.getExitCode())
+                self.assertEqual(134, report.getExitCode())
         except Exception as ex:
             self.fail("Failure encountered, %s" % str(ex))
         finally:

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/CMSSW_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/CMSSW_t.py
@@ -20,7 +20,6 @@ import WMCore_t.WMSpec_t.Steps_t as ModuleLocator
 
 from WMCore.DataStructs.Job import Job
 from WMCore.FwkJobReport.Report import Report
-from WMCore.FwkJobReport.Report import FwkJobReportException
 from WMCore.WMBase import getTestBase
 from WMCore.WMSpec.Makers.TaskMaker import TaskMaker
 from WMCore.WMSpec.Steps import StepFactory


### PR DESCRIPTION
Fixes #9289

#### Status
Tested and working. 

#### Description
Whenever the method parse() in FwkJobReport is used, it adds an error to the report when it fails.
We use this method in Executors/CMSSW and Diagnostics/CMSSW. The latter adds the errors corresponding to cmsRun exit code, and also bad job report errors,etc. However, since we also call this funcion from executors and this runs first, we end up adding the BadFWJRXML error report first, before anything coming from Diagnostics/CMSSW.

This change adds an option to parse(), so that addError can be disabled when needed. This is enabled by default, but it is disabled when called from Executors/CMSSW.

#### Is it backward compatible (if not, which system it affects?)
YES