### PR TITLE
Set PSN for PileupData location at GQE level

### DIFF
--- a/src/python/WMCore/WorkQueue/Policy/Start/Block.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Block.py
@@ -8,7 +8,6 @@ from __future__ import print_function, division
 import logging
 from math import ceil
 from WMCore.WorkQueue.Policy.Start.StartPolicyInterface import StartPolicyInterface
-from WMCore.Services.CRIC.CRIC import CRIC
 from WMCore.WorkQueue.WorkQueueExceptions import WorkQueueWMSpecError
 from WMCore.WorkQueue.WorkQueueUtils import makeLocationsList
 from WMCore import Lexicon
@@ -28,8 +27,6 @@ class Block(StartPolicyInterface):
 
         # Initialize modifiers of the policy
         self.blockBlackListModifier = []
-        self.cric = CRIC()
-
 
     def split(self):
         """Apply policy to spec"""

--- a/src/python/WMCore/WorkQueue/Policy/Start/Dataset.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Dataset.py
@@ -11,7 +11,6 @@ make it generic enough that could be used by other spec types.
 import logging
 from math import ceil
 from WMCore import Lexicon
-from WMCore.Services.CRIC.CRIC import CRIC
 from WMCore.WorkQueue.Policy.Start.StartPolicyInterface import StartPolicyInterface
 from WMCore.WorkQueue.WorkQueueExceptions import WorkQueueWMSpecError
 from WMCore.WorkQueue.WorkQueueUtils import makeLocationsList
@@ -26,7 +25,6 @@ class Dataset(StartPolicyInterface):
         self.args.setdefault('SliceSize', 1)
         self.lumiType = "NumberOfLumis"
         self.sites = []
-        self.cric = CRIC()
 
     def split(self):
         """Apply policy to spec"""

--- a/src/python/WMCore/WorkQueue/Policy/Start/ResubmitBlock.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/ResubmitBlock.py
@@ -20,7 +20,6 @@ ACDC unsupported:
 
 from math import ceil
 from WMCore.WorkQueue.Policy.Start.StartPolicyInterface import StartPolicyInterface
-from WMCore.Services.CRIC.CRIC import CRIC
 from WMCore.WorkQueue.WorkQueueExceptions import WorkQueueWMSpecError
 from WMCore.WorkQueue.WorkQueueUtils import makeLocationsList
 from WMCore.WorkQueue.DataStructs.ACDCBlock import ACDCBlock
@@ -47,7 +46,6 @@ class ResubmitBlock(StartPolicyInterface):
         self.unsupportedAlgos = ['WMBSMergeBySize', 'SiblingProcessingBased']
         self.defaultAlgo = self.fixedSizeChunk
         self.sites = []
-        self.cric = CRIC()
 
     def split(self):
         """Apply policy to spec"""

--- a/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
@@ -10,6 +10,7 @@ from WMCore.WorkQueue.DataStructs.WorkQueueElement import WorkQueueElement
 from WMCore.DataStructs.LumiList import LumiList
 from WMCore.WorkQueue.WorkQueueExceptions import WorkQueueWMSpecError, WorkQueueNoWorkError
 from dbs.exceptions.dbsClientException import dbsClientException
+from WMCore.Services.CRIC.CRIC import CRIC
 from WMCore.Services.DBS.DBSErrors import DBSReaderError
 from WMCore import Lexicon
 
@@ -31,6 +32,7 @@ class StartPolicyInterface(PolicyInterface):
         self.rejectedWork = []  # List of inputs that were rejected
         self.badWork = []  # list of bad work unit (e.g. without any valid files)
         self.pileupData = {}
+        self.cric = CRIC()
 
     def split(self):
         """Apply policy to spec"""
@@ -238,5 +240,5 @@ class StartPolicyInterface(PolicyInterface):
             dbs = self.dbs(dbsUrl)
             for datasetPath in datasets[dbsUrl]:
                 locations = dbs.listDatasetLocation(datasetPath)
-                result[datasetPath] = locations
+                result[datasetPath] = self.cric.PNNstoPSNs(locations)
         return result

--- a/src/python/WMQuality/Emulators/EmulatedUnitTestCase.py
+++ b/src/python/WMQuality/Emulators/EmulatedUnitTestCase.py
@@ -116,9 +116,7 @@ class EmulatedUnitTestCase(unittest.TestCase):
             patchCRICAt = ['WMCore.ReqMgr.Tools.cms.CRIC',
                            'WMCore.WorkQueue.WorkQueue.CRIC',
                            'WMCore.WorkQueue.WorkQueueUtils.CRIC',
-                           'WMCore.WorkQueue.Policy.Start.Dataset.CRIC',
-                           'WMCore.WorkQueue.Policy.Start.ResubmitBlock.CRIC',
-                           'WMCore.WorkQueue.Policy.Start.Block.CRIC']
+                           'WMCore.WorkQueue.Policy.Start.StartPolicyInterface.CRIC']
             for module in patchCRICAt:
                 self.cricPatchers.append(mock.patch(module, new=MockCRICApi))
                 self.cricPatchers[-1].start()


### PR DESCRIPTION
Fixes #9334 

#### Status
not-tested

#### Description
Just as we do for the input data (and parent), use a list of PSNs instead of PNNs for data location, since we use the PSN to match elements.

#### Is it backward compatible (if not, which system it affects?)
No. And GQEs already created will have to be fixed manually

#### Related PRs
We'll have to make a cmsdist PR and upgrade global workqueue in CMSWEB.

#### External dependencies / deployment changes
