### PR TITLE
Util function to calculate size of custom objects

### DIFF
--- a/src/python/Utils/Utilities.py
+++ b/src/python/Utils/Utilities.py
@@ -7,6 +7,10 @@ import os
 import re
 import zlib
 import base64
+import sys
+from types import ModuleType, FunctionType
+from gc import get_referents
+
 
 def lowerCmsHeaders(headers):
     """
@@ -150,3 +154,35 @@ def zipEncodeStr(message, maxLen=5120, compressLevel=9, steps=100, truncateIndic
         encodedStr = zipEncodeStr(message, maxLen=-1)
 
     return encodedStr
+
+
+def getSize(obj):
+    """
+    _getSize_
+
+    Function to traverse an object and calculate its total size in bytes
+    :param obj: a python object
+    :return: an integer representing the total size of the object
+
+    Code extracted from Stack Overflow:
+    https://stackoverflow.com/questions/449560/how-do-i-determine-the-size-of-an-object-in-python
+    """
+    # Custom objects know their class.
+    # Function objects seem to know way too much, including modules.
+    # Exclude modules as well.
+    BLACKLIST = type, ModuleType, FunctionType
+
+    if isinstance(obj, BLACKLIST):
+        raise TypeError('getSize() does not take argument of type: '+ str(type(obj)))
+    seen_ids = set()
+    size = 0
+    objects = [obj]
+    while objects:
+        need_referents = []
+        for obj in objects:
+            if not isinstance(obj, BLACKLIST) and id(obj) not in seen_ids:
+                seen_ids.add(id(obj))
+                size += sys.getsizeof(obj)
+                need_referents.append(obj)
+        objects = get_referents(*need_referents)
+    return size

--- a/test/python/Utils_t/Utilities_t.py
+++ b/test/python/Utils_t/Utilities_t.py
@@ -6,8 +6,9 @@ Unittests for Utilities functions
 from __future__ import division, print_function
 
 import unittest
-from Utils.Utilities import makeList, makeNonEmptyList, strToBool, safeStr, rootUrlJoin, zipEncodeStr
-from Utils.Utilities import lowerCmsHeaders
+
+from Utils.Utilities import makeList, makeNonEmptyList, strToBool, \
+    safeStr, rootUrlJoin, zipEncodeStr, lowerCmsHeaders, getSize
 
 
 class UtilitiesTests(unittest.TestCase):
@@ -39,7 +40,7 @@ class UtilitiesTests(unittest.TestCase):
     def testLowerCmsHeaders(self):
         "Test lowerCmsHeaders function"
         val = 'cms-xx-yy'
-        headers = {'CAPITAL':1, 'Camel':1, 'Cms-Xx-Yy': val, 'CMS-XX-YY': val, 'cms-xx-yy': val}
+        headers = {'CAPITAL': 1, 'Camel': 1, 'Cms-Xx-Yy': val, 'CMS-XX-YY': val, 'cms-xx-yy': val}
         lheaders = lowerCmsHeaders(headers)
         self.assertEqual(sorted(lheaders.keys()), sorted(['CAPITAL', 'Camel', val]))
         self.assertEqual(lheaders['CAPITAL'], 1)
@@ -124,11 +125,32 @@ cms::Exception caught in CMS.EventProcessor and rethrown
 """
         encodedMessage = \
             'eNp1j8FqwzAMhu95Cl0G2yEhaXvyrU3dkkFHqfcCnq02hkQOtlz6+HM2MrbDdBLS9/1CxdNJHcsI7UnJh8GJnScBsL0yhoMbEOpV+ZqoXNVNDc1GrBuxWUMr1TucfWRJ9pKoMGMU4scHo9OtZ3C5G+O8L3OBvCPxOXiDMfpw0G5IAWEnj91b8Xvn6KbYTxPab0+ZHm0aUD7QpDn/r/qP1dFdD85e8IoBySz0Ts+j1md9y4zjxMAebGYWTsMCGE+sHeVk0JS/+Qqc79lkuNtDryN8IBLAc1VVL5+o0W8i'
-        self.assertEqual(zipEncodeStr(message, maxLen=300, compressLevel=9, steps=10, truncateIndicator=" (...)"), encodedMessage)
+        self.assertEqual(zipEncodeStr(message, maxLen=300, compressLevel=9, steps=10, truncateIndicator=" (...)"),
+                         encodedMessage)
         # Test different maximum lengths
         # Encoded message should always be less than the maximum limit.
         for maxLen in (800, 500, 20):
-            self.assertLessEqual(len(zipEncodeStr(message, maxLen=maxLen, compressLevel=9, steps=10, truncateIndicator=" (...)")), maxLen)
+            self.assertLessEqual(
+                len(zipEncodeStr(message, maxLen=maxLen, compressLevel=9, steps=10, truncateIndicator=" (...)")),
+                maxLen)
+
+    def testGetSize(self):
+        """
+        Test the getSize function.
+        """
+        for item in (1234, 1234.1234, set([12, 34]), "test", (1, 2), {'k1': 'v1'}):
+            self.assertTrue(getSize(item) > 20)
+        with self.assertRaises(TypeError):
+            getSize(zipEncodeStr)
+
+        class TestClass():
+            def __init__(self):
+                self.data = "blah"
+
+        cls = TestClass()
+        print(getSize(cls))
+        self.assertTrue(getSize(cls) > 1000)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #9337

#### Status
ready

#### Description
Utilitarian function to get the size of custom objects.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
no

#### External dependencies / deployment changes
no