### PR TITLE
Add services into configuration to separate MSTransferor/MSMonitor

### DIFF
--- a/test/python/WMCore_t/MicroService_t/MSManager_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSManager_t.py
@@ -1,0 +1,65 @@
+"""
+Unit tests for MSManager.py module
+
+Author: Valentin Kuznetsov <vkuznet [AT] gmail [DOT] com>
+"""
+
+from __future__ import division, print_function
+
+import unittest
+
+from WMCore.MicroService.Unified.MSManager import MSManager
+from WMCore.Agent.Configuration import Configuration
+
+
+class MSManagerTest(unittest.TestCase):
+    "Unit test for MSManager module"
+    def setUp(self):
+        "Setup MSManager for testing"
+        config = Configuration()
+        self.mgr = MSManager(config)
+
+        config = Configuration()
+        config.section_("MS")
+        config.MS.services = ['transferor']
+        self.mgr_trans = MSManager(config.MS)
+
+        config = Configuration()
+        config.section_("MS")
+        config.MS.services = ['monitor']
+        self.mgr_monit = MSManager(config.MS)
+
+    def tearDown(self):
+        "Tear down MSManager"
+        self.mgr.stop()
+        self.mgr_trans.stop()
+        self.mgr_monit.stop()
+
+    def test_services(self):
+        "test MSManager services"
+        # check self.mgrt object attributes
+        self.assertEqual('monitor' in self.mgr.services, True)
+        self.assertEqual('transferor' in self.mgr.services, True)
+        self.assertEqual(hasattr(self.mgr, 'msTransferor'), True)
+        self.assertEqual(hasattr(self.mgr, 'transfThread'), True)
+        self.assertEqual(hasattr(self.mgr, 'msMonitor'), True)
+        self.assertEqual(hasattr(self.mgr, 'monitThread'), True)
+
+        # check self.mgr_trans object attributes
+        self.assertEqual('monitor' in self.mgr_trans.services, False)
+        self.assertEqual('transferor' in self.mgr_trans.services, True)
+        self.assertEqual(hasattr(self.mgr_trans, 'msTransferor'), True)
+        self.assertEqual(hasattr(self.mgr_trans, 'transfThread'), True)
+        self.assertEqual(hasattr(self.mgr_trans, 'msMonitor'), False)
+        self.assertEqual(hasattr(self.mgr_trans, 'monitThread'), False)
+
+        # check self.mgr_monit object attributes
+        self.assertEqual('monitor' in self.mgr_monit.services, True)
+        self.assertEqual('transferor' in self.mgr_monit.services, False)
+        self.assertEqual(hasattr(self.mgr_monit, 'msTransferor'), False)
+        self.assertEqual(hasattr(self.mgr_monit, 'transfThread'), False)
+        self.assertEqual(hasattr(self.mgr_monit, 'msMonitor'), True)
+        self.assertEqual(hasattr(self.mgr_monit, 'monitThread'), True)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #9339 

#### Status
tested with unit test

#### Description
Add 3 new configuration parameters:
- services should specify list of services to run, e.g. 'transferor' or 'transferor,monitor' to run both services, if not specified we'll run both services
- transferorInterval, new value to specify transferor polling interval
- monitorInterval, new value to specify monitor polling interval

I make it backward compatible with single interval option which is assigned to both intervals if not specified.

I also make it safe to start transferor/monitor execute and threads since they should only be started if appropriate objects are initialized.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
This PR complements discussion of #9330 

#### External dependencies / deployment changes
no