### PR TITLE
Consider PileupData and trust flags in the stuckElements couch view

### DIFF
--- a/src/couchapps/WorkQueue/_attachments/js/StuckElementInfo.js
+++ b/src/couchapps/WorkQueue/_attachments/js/StuckElementInfo.js
@@ -30,10 +30,10 @@ WQ.StuckElementInfo.elementTable = function(args) {
         fields: [
         	     {key: "reason"},
         		 {key: "RequestName", label: "Request Name"},
-                 {key: "TaskName", label: "Task Name"},
-                 {key: "Inputs", formatter: siteFormatter},
                  {key: "SiteWhitelist", formatter: listFormatter},
                  {key: "SiteBlacklist", formatter: listFormatter},
+                 {key: "Inputs", formatter: siteFormatter},
+                 {key: "PileupData", formatter: siteFormatter},
                  {key: "ParentData", formatter: siteFormatter},
                  {key: "Priority"},
                  {key: "TeamName", label: "Team"},
@@ -49,7 +49,7 @@ WQ.StuckElementInfo.elementTable = function(args) {
 
     var tableConfig = WQ.createDefaultTableConfig();
 
-    tableConfig.paginator = new YAHOO.widget.Paginator({rowsPerPage : 10});
+    tableConfig.paginator = new YAHOO.widget.Paginator({rowsPerPage : 50});
 
     var dataTable = WQ.createDataTable(args.divID, dataSource,
                          WQ.createDefaultTableDef(dataSchema.fields),

--- a/src/couchapps/WorkQueue/lib/workqueue_utils.js
+++ b/src/couchapps/WorkQueue/lib/workqueue_utils.js
@@ -3,54 +3,59 @@
 var workqueue_utils = {
 
 	commonInputDataSites: function(element) {
-		// Determine sites which contain all the input data (inc. parents)
-		var sites = this.commonSites(element, "Inputs");
-		if (element.ParentData.length) {
-			var parents = this.commonSites(element, "ParentData");
-			for (var i = 0; i < sites.length; i++) {
-    			if (parents.indexOf(sites[i]) === -1) {
-    				sites.splice(i, 1);
-    				continue;
-    			}
-    		}
+		// Determine sites which contain all the input data
+		if (element["NoInputUpdate"] === true) {
+			return element["SiteWhitelist"];
 		}
-		return sites;		
+		return this.commonSites(element, "Inputs");
 	},
 
 	commonInputParentDataSites: function(element) {
 		// Determine sites which contain all the input parent data
+		if (element["NoInputUpdate"] === true) {
+			return element["SiteWhitelist"];
+		}
 		return this.commonSites(element, "ParentData");
 	},
 
+	commonPileupDataSites: function(element) {
+		// Determine sites which contain something of the pileup data
+		if (element["NoPileupUpdate"] === true) {
+			return element["SiteWhitelist"];
+		}
+        return this.commonSites(element, "PileupData");
+	},
+
 	commonSites: function(element, label) {
-		// return common sites in element.label structure
-    	var common_sites = [];
-    	var first = true
-    	for (var data in element.Inputs) {
-    		if (!element.Inputs.hasOwnProperty(data)) {
-    			continue;
-    		}
-    		var locations = element[label][data];
-    		if (first) {
-    			common_sites = locations;
-    			first = false;
-    			continue;
-    		} else {
-    			// remove any site that doesnt host a data item
-    			for (var i = 0; i < common_sites.length; i++) {
-    				if (locations.indexOf(common_sites[i]) === -1) {
-    					common_sites.splice(i, 1);
-    					continue;
-    				}
-    			}
-    		}
-    	}
-    	return common_sites
-    },
+	    // just need to find ONE common site
+		var site_white_list = element["SiteWhitelist"];
+		for (var data in element[label]) {
+			var common_sites = [];
+			if (!element[label][data].length) {
+				// input data has no locations
+				return common_sites;
+			}
+			var locations = element[label][data];
+			// remove any site that doesnt host a data item
+			for (var i = 0; i < locations.length; i++) {
+				if (site_white_list.indexOf(locations[i]) > -1) {
+					common_sites.push(locations[i]);
+					break;
+				}
+			}
+			if (!common_sites.length) {
+				return common_sites;
+			}
+		}
+		// everything is fine then
+		return site_white_list;
+	},
 
 };
 
 //CommonJS bindings
 if( typeof(exports) === 'object' ) {
-   exports.commonInputDataSites = workqueue_utils.commonInputDataSites;
+	exports.commonInputDataSites = workqueue_utils.commonInputDataSites;
+	exports.commonInputParentDataSites = workqueue_utils.commonInputParentDataSites;
+	exports.commonPileupDataSites = workqueue_utils.commonPileupDataSites;
 };

--- a/src/couchapps/WorkQueue/views/stuckElements/map.js
+++ b/src/couchapps/WorkQueue/views/stuckElements/map.js
@@ -10,59 +10,29 @@ function(doc, site) {
 			return;
 		}
 
-		var input_sites = workqueue_utils.commonInputDataSites(ele);
+		var stuck = false;
+		var stuckMsg = "No site hosting ";
+
 		// check for at least one site hosting input data
-		if (ele.Inputs && toJSON(ele.Inputs) != '{}' && !input_sites.length) {
-			emit('No site with data');
-			return;
+		var input_sites = workqueue_utils.commonInputDataSites(ele);
+		if (!input_sites.length) {
+			stuckMsg = stuckMsg.concat("input data; ");
+			stuck = true;
 		}
-		// check for one site with both inputs and parents
+		// check for at least one site hosting the parent data
 		var parent_sites = workqueue_utils.commonInputParentDataSites(ele);
-		if (ele.Inputs && toJSON(ele.Inputs) != '{}' && ele.ParentData && toJSON(ele.ParentData) != '{}') {
-			if (!parent_sites.length) {
-				emit('No site with all parent data');
-				return;
-			}
-			var parents_inputs_same_site = false;
-			for (var i =0; i < input_sites.length; i++) {
-				var site = input_sites[i];
-				if (parent_sites.indexOf(site) > -1) {
-					parents_inputs_same_site = true;
-					break;
-				}
-			}
-			if (!parents_inputs_same_site) {
-				emit('No site with both input & parent data');
-				return;
-			}
+		if (!parent_sites.length) {
+			stuckMsg = stuckMsg.concat("parent data; ");
+			stuck = true;
 		}
-		// check for at least one site with data in the whitelist
-		if (ele.SiteWhitelist.length && input_sites.length) {
-			var inputs_in_whitelist = false;
-			for (var i = 0; i < ele.SiteWhitelist.length; i++) {
-				if (input_sites.indexOf(ele.SiteWhitelist[i]) !== -1) {
-					inputs_in_whitelist = true;
-					break;
-				}
-			}
-			if (!inputs_in_whitelist) {
-				emit('No hosting site in whitelist');
-				return;
-			}
+		// check for at least one site hosting the pileup data
+		var pileup_sites = workqueue_utils.commonPileupDataSites(ele);
+		if (!pileup_sites.length) {
+			stuckMsg = stuckMsg.concat("pileup data");
+			stuck = true;
 		}
-		// check for at least one site with data not in the blacklist
-		if (ele.SiteBlacklist.length && input_sites.length) {
-			var inputs_in_blacklist = true
-			for (var i = 0; i < input_sites.length; i++) {
-				if (ele.SiteBlacklist.indexOf(input_sites[i]) === -1) {
-					inputs_in_blacklist = false;
-					break;
-				}
-			}
-			if (inputs_in_blacklist) {
-				emit('Hosting site in blacklist');
-				return;
-			}
+		if (stuck) {
+			emit(stuckMsg, ele["RequestName"])
 		}
 	}
 }


### PR DESCRIPTION
Fixes #9181 

#### Status
not-tested

#### Description
As the title says, parse the `PileupData` property of the GQE and also consider `NoInputUpdate` and `NoPileupUpdate` when evaluating whether a GQE is stuck (due to lack of data locality) or not.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
no

#### External dependencies / deployment changes
workqueue view will have to be rebuilt, but it shouldn't take more than 30min or so.
