### PR TITLE
Allow clients to scan JSON object

### DIFF
--- a/src/python/WMCore/WebTools/RESTFormatter.py
+++ b/src/python/WMCore/WebTools/RESTFormatter.py
@@ -29,15 +29,15 @@ class RESTFormatter(TemplatedPage):
         TemplatedPage.__init__(self, config)
 
     def genstreamer(self, data):
-        yield "["
+        yield "[\n"
         firstItem  = True
         for item in data:
             if not firstItem:
-                yield ","
+                yield "\n,\n"
             else:
                 firstItem = False
             yield json.dumps(item)
-        yield "]"
+        yield "\n]"
 
     def json(self, data):
         if isinstance(data, GeneratorType):


### PR DESCRIPTION
Fixes issue(s) with memory consumption in #9330

#### Status

#### Description
Changing JSON representation of output to allow clients to scan JSON documents instead of loading them via `json.load` function. This technique will be extremely useful when dealing with large JSON objects, e.g. output from DBS, for instance, blocks API. The client code can read the output line by line and extract records.


#### Is it backward compatible (if not, which system it affects?)
YES, but it changes the json output will be modified. Instead of object written as one line, e.g.
```
[{"bla":1}, {"bla":2}]
```
the output will yield records one per line, e.g. the same output but formatted differently
```
[
{"bla":1}
,
{"bla":2}
]
```

#### Related PRs
#9330 

#### External dependencies / deployment changes
no