### PR TITLE
 Get dataset size by summing up block sizes; cache secondary sizes 

### DIFF
--- a/src/python/WMCore/MicroService/Unified/Common.py
+++ b/src/python/WMCore/MicroService/Unified/Common.py
@@ -383,23 +383,3 @@ def findParent(datasets, dbsUrl):
         for item in rows:
             parentByDset[item['this_dataset']] = item['parent_dataset']
     return parentByDset
-
-
-def getDatasetSize(datasets, dbsUrl):
-    """
-    Helper function to get the total dataset dataset.
-    It returns a dictionary key'ed by the child dataset
-    """
-    sizeByDset = {}
-    if not datasets:
-        return sizeByDset
-
-    urls = ['%s/blocksummaries?dataset=%s' % (dbsUrl, d) for d in datasets]
-    data = multi_getdata(urls, ckey(), cert())
-
-    for row in data:
-        dataset = row['url'].split('=')[-1]
-        rows = json.loads(row['data'])
-        for item in rows:
-            sizeByDset[dataset] = item['file_size']
-    return sizeByDset

--- a/src/python/WMCore/MicroService/Unified/Common.py
+++ b/src/python/WMCore/MicroService/Unified/Common.py
@@ -14,6 +14,7 @@ import math
 # system modules
 import re
 import time
+
 try:
     from urllib import quote, unquote
 except ImportError:
@@ -152,7 +153,7 @@ def workflowsInfo(workflows):
                 if kkk == 'MCPileup':
                     pileups.add(vvv)
             winfo[key] = \
-                dict(datasets=list(datasets), pileups=list(pileups), \
+                dict(datasets=list(datasets), pileups=list(pileups),
                      priority=priority, selist=selist, campaign=campaign)
     return winfo
 
@@ -165,9 +166,8 @@ def eventsLumisInfo(inputs, dbsUrl, validFileOnly=0, sumOverLumi=0):
         return eventsLumis
     if '#' in inputs[0]:  # inputs are list of blocks
         what = 'block_name'
-    urls = ['%s/filesummaries?validFileOnly=%s&sumOverLumi=%s&%s=%s' \
-            % (dbsUrl, validFileOnly, sumOverLumi, what, quote(i)) \
-            for i in inputs]
+    urls = ['%s/filesummaries?validFileOnly=%s&sumOverLumi=%s&%s=%s'
+            % (dbsUrl, validFileOnly, sumOverLumi, what, quote(i)) for i in inputs]
     data = multi_getdata(urls, ckey(), cert())
     for row in data:
         key = row['url'].split('=')[-1]
@@ -317,7 +317,7 @@ def postRequest(url, params):
     if 'verbose' in params:
         verbose = params['verbose']
         del params['verbose']
-    data = mgr.getdata(url, params, headers, ckey=ckey(), cert=cert(), \
+    data = mgr.getdata(url, params, headers, ckey=ckey(), cert=cert(),
                        verb='POST', verbose=verbose)
     return data
 

--- a/src/python/WMCore/MicroService/Unified/MSCore.py
+++ b/src/python/WMCore/MicroService/Unified/MSCore.py
@@ -64,7 +64,8 @@ class MSCore(object):
         """
         self.logger.info('%s updating %s status to %s', prefix, reqName, reqStatus)
         try:
-            self.reqmgr2.updateRequestStatus(reqName, reqStatus)
+            if not self.msConfig['readOnly']:
+                self.reqmgr2.updateRequestStatus(reqName, reqStatus)
         except Exception as err:
             self.logger.exception("Failed to change request status. Error: %s", str(err))
 

--- a/src/python/WMCore/MicroService/Unified/MSTransferor.py
+++ b/src/python/WMCore/MicroService/Unified/MSTransferor.py
@@ -56,6 +56,8 @@ class MSTransferor(MSCore):
         self.uConfig = self.unifiedConfig()
         campaigns = self.reqmgrAux.getCampaignConfig("ALL_DOCS")
         self.psn2pnnMap = self.cric.PSNtoPNNMap()
+        # also clear the RequestInfo pileup cache
+        self.reqInfo.clearPileupCache()
         if not self.uConfig:
             self.logger.warning("Failed to fetch the unified configuration")
         elif not campaigns:
@@ -293,7 +295,7 @@ class MSTransferor(MSCore):
                           "dataType": dataIn['type'],
                           "transferIDs": set(),  # casted to list before going to couch
                           "campaignName": dataIn['campaign'],
-                          "completion": 0.0}
+                          "completion": [0.0]}
         return transferRecord
 
     def createTransferDoc(self, reqName, transferRecords):

--- a/src/python/WMCore/MicroService/Unified/MSTransferor.py
+++ b/src/python/WMCore/MicroService/Unified/MSTransferor.py
@@ -9,7 +9,6 @@ the transferor module.
 from __future__ import division, print_function
 
 # system modules
-import time
 from httplib import HTTPException
 from operator import itemgetter
 from pprint import pformat
@@ -18,14 +17,16 @@ from pprint import pformat
 from Utils.IteratorTools import grouper
 from WMCore.MicroService.Unified.MSCore import MSCore
 from WMCore.MicroService.Unified.RequestInfo import RequestInfo
-from WMCore.Services.PhEDEx.DataStructs.SubscriptionList import PhEDExSubscription
 from WMCore.Services.CRIC.CRIC import CRIC
+from WMCore.Services.PhEDEx.DataStructs.SubscriptionList import PhEDExSubscription
+
 
 class MSTransferor(MSCore):
     """
     MSTransferor class provide whole logic behind
     the transferor module.
     """
+
     def __init__(self, msConfig, logger=None):
         """
         Runs the basic setup and initialization for the MS Transferor module
@@ -112,7 +113,6 @@ class MSTransferor(MSCore):
                         self.change(wflow.getName(), 'staging', self.__class__.__name__)
         self.logger.info("%s subscribed %d datasets and %d blocks in this cycle",
                          self.__class__.__name__, self.dsetCounter, self.blockCounter)
-
 
     def getRequestRecords(self, reqStatus):
         """
@@ -312,8 +312,7 @@ class MSTransferor(MSCore):
         resp = self.reqmgrAux.postTransferInfo(reqName, doc)
         if resp and resp[0].get("ok", False):
             return True
-        else:
-            msg = "Failed to create transfer document in CouchDB. Will retry again later."
-            msg += "Error: %s" % resp
-            self.logger.error(msg)
-            return False
+        msg = "Failed to create transfer document in CouchDB. Will retry again later."
+        msg += "Error: %s" % resp
+        self.logger.error(msg)
+        return False

--- a/src/python/WMCore/MicroService/Unified/RequestInfo.py
+++ b/src/python/WMCore/MicroService/Unified/RequestInfo.py
@@ -19,7 +19,7 @@ from WMCore.MicroService.DataStructs.Workflow import Workflow
 from WMCore.MicroService.Unified.Common import \
     elapsedTime, cert, ckey, workflowsInfo, eventsLumisInfo,\
     dbsInfo, phedexInfo, getComputingTime, getNCopies,\
-    teraBytes, getIO, findBlockParents, findParent, getDatasetSize
+    teraBytes, getIO, findBlockParents, findParent
 from WMCore.MicroService.Unified.SiteInfo import SiteInfo
 from WMCore.MicroService.Unified.MSCore import MSCore
 from WMCore.Services.pycurl_manager import getdata \
@@ -31,6 +31,14 @@ class RequestInfo(MSCore):
     RequestInfo class provides functionality to access and
     manipulate requests.
     """
+
+    def __init__(self, msConfig, logger):
+        """
+        Basic setup for this RequestInfo module
+        """
+        super(RequestInfo, self).__init__(msConfig, logger)
+        self.cachePileupSize = {}
+
     def __call__(self, reqRecords):
         """
         Run the unified transferor box
@@ -60,6 +68,14 @@ class RequestInfo(MSCore):
 
         return workflows
 
+    def clearPileupCache(self):
+        """
+        Clears the in-memory pileup cache for every cycle of
+        the MSTransferor module.
+        Cache stores only the total size for secondary datasets
+        """
+        self.cachePileupSize.clear()
+
     def unified(self, uConfig, workflows):
         """
         Unified Transferor black box
@@ -75,11 +91,6 @@ class RequestInfo(MSCore):
         time0 = time.time()
         self.getParentDatasets(workflows)
         self.logger.debug(elapsedTime(time0, "### getParentDatasets"))
-
-        # then fetch the total dataset size of each secondary dataset
-        time0 = time.time()
-        self.getPileupSizes(workflows)
-        self.logger.debug(elapsedTime(time0, "### getPileupSizes"))
 
         # get final primary and secondaries list of blocks to be replicated
         # as well as an initial list of block parents
@@ -220,44 +231,21 @@ class RequestInfo(MSCore):
                 if wflow.hasParents() and wflow.getInputDataset() in parentageMap:
                     wflow.setParentDataset(parentageMap[wflow.getInputDataset()])
 
-    def getPileupSizes(self, workflows):
-        """
-        Given a list of requests, find which requests need to process a secondary
-        dataset and, retrieve its total size from DBS.
-        """
-        datasetByDbs = {}
-        for wflow in workflows:
-            if wflow.getPileupDatasets():
-                datasetByDbs.setdefault(wflow.getDbsUrl(), set())
-                datasetByDbs[wflow.getDbsUrl()] = datasetByDbs[wflow.getDbsUrl()] | wflow.getPileupDatasets()
-
-        for dbsUrl, datasets in datasetByDbs.items():
-            self.logger.info("Fetching total dataset size for %d secondaries against DBS: %s", len(datasets), dbsUrl)
-            sizeByDset = getDatasetSize(datasets, dbsUrl)
-            for wflow in workflows:
-                for second in wflow.getPileupDatasets():
-                    if second not in sizeByDset:
-                        # dataset is in another DBS instance
-                        continue
-                    wflow.setSecondarySummary(second, sizeByDset[second])
-
     def getInputDataBlocks(self, workflows):
         """
-        Given a list of requests and their input data -  primary and parent
-        datasets - find all their respective blocks to be transferred, including
-        the block size information.
-         * finalBlocks: attribute will contain a list of dictionaries with
-          the block name and block size
-         * parent: will contain a list of dictionaries with the block name
-          and block size as well, when needed
+        Given a list of requests and their input data -  primary, secondary and
+        parent datasets - find all their respective blocks (and their sizes) to
+        be transferred.
+         * workflows: a list of Workflow objects
         """
         datasetByDbs = {}
         for wflow in workflows:
             datasetByDbs.setdefault(wflow.getDbsUrl(), set())
             for dataIn in wflow.getDataCampaignMap():
-                if dataIn['type'] in {'primary', 'parent'}:
-                    datasetByDbs.setdefault(wflow.getDbsUrl(), set())
-                    datasetByDbs[wflow.getDbsUrl()].add(dataIn['name'])
+                if dataIn['type'] == "secondary" and dataIn['name'] in self.cachePileupSize:
+                    # fetch the total dataset size from the cache then
+                    continue
+                datasetByDbs[wflow.getDbsUrl()].add(dataIn['name'])
 
         # now fetch block names from DBS
         for dbsUrl, datasets in datasetByDbs.items():
@@ -265,14 +253,33 @@ class RequestInfo(MSCore):
             _, _, blocksByDset = dbsInfo(datasets, dbsUrl)
             for wflow in workflows:
                 for dataIn in wflow.getDataCampaignMap():
-                    if dataIn['name'] not in datasets:
+                    if dataIn['name'] in self.cachePileupSize:
+                        self.logger.debug("Using data from the cache for %s", dataIn['name'])
+                        wflow.setSecondarySummary(dataIn['name'], self.cachePileupSize[dataIn['name']])
+                    elif dataIn['name'] not in datasets:
                         # dataset is in another DBS instance
                         continue
-                    if dataIn['type'] == "primary":
+                    elif dataIn['type'] == "secondary":
+                        # simply calculate the total dataset size and cache it as well
+                        totalSize = self._getPileupSize(dataIn['name'], blocksByDset[dataIn['name']])
+                        wflow.setSecondarySummary(dataIn['name'], totalSize)
+                    elif dataIn['type'] == "primary":
                         wflow.setPrimaryBlocks(blocksByDset[dataIn['name']])
                     elif dataIn['type'] == "parent":
                         wflow.setParentBlocks(blocksByDset[dataIn['name']])
 
+    def _getPileupSize(self, dsetName, blocksDict):
+        """
+        Iterate over all blocks in the dictionary and sum up their
+        block sizes. In the end store the dataset and its total size
+        in the local cache as well.
+        :param dsetName: secondary dataset name string.
+        :param blocksDict: dictionary of block names and their size
+        :return: total size in bytes
+        """
+        totalSize = sum(blocksDict.values())
+        self.cachePileupSize[dsetName] = totalSize
+        return totalSize
 
     def getParentChildBlocks(self, workflows):
         """

--- a/src/python/WMCore/MicroService/Unified/RequestInfo.py
+++ b/src/python/WMCore/MicroService/Unified/RequestInfo.py
@@ -9,19 +9,18 @@ from __future__ import division, print_function
 
 # system modules
 import json
-import time
 import pickle
-
+import time
 # WMCore modules
 from pprint import pformat
 
 from WMCore.MicroService.DataStructs.Workflow import Workflow
 from WMCore.MicroService.Unified.Common import \
-    elapsedTime, cert, ckey, workflowsInfo, eventsLumisInfo,\
-    dbsInfo, phedexInfo, getComputingTime, getNCopies,\
+    elapsedTime, cert, ckey, workflowsInfo, eventsLumisInfo, \
+    dbsInfo, phedexInfo, getComputingTime, getNCopies, \
     teraBytes, getIO, findBlockParents, findParent
-from WMCore.MicroService.Unified.SiteInfo import SiteInfo
 from WMCore.MicroService.Unified.MSCore import MSCore
+from WMCore.MicroService.Unified.SiteInfo import SiteInfo
 from WMCore.Services.pycurl_manager import getdata \
     as multi_getdata, RequestHandler
 
@@ -49,7 +48,7 @@ class RequestInfo(MSCore):
         uConfig = self.unifiedConfig()
         if not uConfig:
             self.logger.warning(
-                "Failed to fetch the latest unified config. Skipping this cycle")
+                    "Failed to fetch the latest unified config. Skipping this cycle")
             return []
         self.logger.info("Going to process %d requests.", len(reqRecords))
 
@@ -158,7 +157,8 @@ class RequestInfo(MSCore):
         for wflow in requestWorkflows:
             for wname, wspec in wflow.items():
                 time0 = time.time()
-                cput = getComputingTime(wspec, eventsLumis=eventsLumis, dbsUrl=self.msConfig['dbsUrl'], logger=self.logger)
+                cput = getComputingTime(wspec, eventsLumis=eventsLumis, dbsUrl=self.msConfig['dbsUrl'],
+                                        logger=self.logger)
                 ncopies = getNCopies(cput)
 
                 attrs = winfo[wname]
@@ -183,8 +183,8 @@ class RequestInfo(MSCore):
                 sites = json.dumps(sorted(list(nodes)))
                 self.logger.debug("### %s", wname)
                 self.logger.debug(
-                    "%s datasets, %s blocks, %s bytes (%s TB), %s nevts, %s nlumis, cput %s, copies %s, %s",
-                    ndatasets, nblocks, size, teraBytes(size), nevts, nlumis, cput, ncopies, sites)
+                        "%s datasets, %s blocks, %s bytes (%s TB), %s nevts, %s nlumis, cput %s, copies %s, %s",
+                        ndatasets, nblocks, size, teraBytes(size), nevts, nlumis, cput, ncopies, sites)
                 # find out which site can serve given workflow request
                 t0 = time.time()
                 lheInput, primary, parent, secondary, allowedSites \

--- a/test/python/WMCore_t/MicroService_t/DataStructs_t/Workflow_t.py
+++ b/test/python/WMCore_t/MicroService_t/DataStructs_t/Workflow_t.py
@@ -1,0 +1,156 @@
+"""
+Unit tests for the WMCore/MicroService/DataStructs/Workflow.py module
+"""
+from __future__ import division, print_function
+
+import unittest
+
+from WMCore.MicroService.DataStructs.Workflow import Workflow
+
+
+class WorkflowTest(unittest.TestCase):
+    """
+    Test the very basic functionality of the Workflow module
+    """
+
+    def testCampaignMap(self):
+        """
+        Test setting the data campaign map for a TaskChain-like request
+        """
+        parentDset = "/any/parent-dataset/tier"
+        tChainSpec = {"TaskChain": 4,
+                      "Campaign": "top-campaign",
+                      "RequestName": "whatever_name",
+                      "Task1": {"InputDataset": "/task1/input-dataset/tier",
+                                "Campaign": "task1-campaign",
+                                "IncludeParents": True},
+                      "Task2": {"DataPileup": "/task2/data-pileup/tier"},
+                      "Task3": {"MCPileup": "/task3/mc-pileup/tier",
+                                "Campaign": "task3-campaign"},
+                      "Task4": {"MCPileup": "/task3/mc-pileup/tier",
+                                "Campaign": "task3-campaign"},
+                      }
+        wflow = Workflow(tChainSpec['RequestName'], tChainSpec)
+        self.assertEqual(len(wflow.getDataCampaignMap()), 3)
+        for dataIn in wflow.getDataCampaignMap():
+            if dataIn['type'] == "primary":
+                self.assertItemsEqual(dataIn, {"type": "primary", "campaign": tChainSpec['Task1']['Campaign'],
+                                               "name": tChainSpec['Task1']['InputDataset']})
+            elif dataIn['name'] == tChainSpec['Task2']['DataPileup']:
+                self.assertItemsEqual(dataIn, {"type": "secondary", "campaign": tChainSpec['Campaign'],
+                                               "name": tChainSpec['Task2']['DataPileup']})
+            else:
+                self.assertItemsEqual(dataIn, {"type": "secondary", "campaign": tChainSpec['Task3']['Campaign'],
+                                               "name": tChainSpec['Task3']['MCPileup']})
+
+        wflow.setParentDataset(parentDset)
+        self.assertEqual(wflow.getParentDataset(), parentDset)
+        self.assertEqual(len(wflow.getDataCampaignMap()), 4)
+        for dataIn in wflow.getDataCampaignMap():
+            if dataIn['type'] == "parent":
+                self.assertItemsEqual(dataIn, {"type": "parent", "campaign": tChainSpec['Task1']['Campaign'],
+                                               "name": parentDset})
+
+    def testReRecoWflow(self):
+        """
+        Test loading a ReReco like request into Workflow
+        """
+        parentDset = "/rereco/parent-dataset/tier"
+        rerecoSpec = {"InputDataset": "/rereco/input-dataset/tier",
+                      "Campaign": "any-campaign",
+                      "RequestName": "whatever_name",
+                      "DbsUrl": "a_dbs_url",
+                      "SiteWhitelist": ["CERN", "FNAL", "DESY"],
+                      "SiteBlacklist": ["FNAL"]}
+        wflow = Workflow(rerecoSpec['RequestName'], rerecoSpec)
+        self.assertEqual(wflow.getName(), rerecoSpec['RequestName'])
+        self.assertEqual(wflow.getDbsUrl(), rerecoSpec['DbsUrl'])
+        self.assertItemsEqual(wflow.getSitelist(), ["CERN", "DESY"])
+        self.assertItemsEqual(wflow.getCampaigns(), [rerecoSpec["Campaign"]])
+        self.assertEqual(wflow.getInputDataset(), rerecoSpec["InputDataset"])
+        self.assertItemsEqual(wflow.getPileupDatasets(), set())
+        self.assertFalse(wflow.hasParents())
+        self.assertEqual(wflow.getParentDataset(), "")
+        self.assertEqual(wflow.getPrimaryBlocks(), {})
+        self.assertEqual(wflow.getSecondarySummary(), {})
+        self.assertEqual(wflow.getParentBlocks(), {})
+        self.assertEqual(wflow._getValue("NoKey"), None)
+        self.assertEqual(len(wflow.getDataCampaignMap()), 1)
+
+        wflow.setParentDataset(parentDset)
+        self.assertEqual(wflow.getParentDataset(), parentDset)
+        self.assertEqual(len(wflow.getDataCampaignMap()), 2)
+
+    def testTaskChainWflow(self):
+        """
+        Test loading a TaskChain like request into Workflow
+        """
+        tChainSpec = {"TaskChain": 3,
+                      "Campaign": "top-campaign",
+                      "RequestName": "whatever_name",
+                      "DbsUrl": "a_dbs_url",
+                      "SiteWhitelist": ["CERN", "FNAL", "DESY"],
+                      "SiteBlacklist": [],
+                      "Task1": {"InputDataset": "/task1/input-dataset/tier",
+                                "MCPileup": "/task1/mc-pileup/tier",
+                                "Campaign": "task1-campaign"},
+                      "Task2": {"DataPileup": "/task2/data-pileup/tier",
+                                "Campaign": "task2-campaign"},
+                      "Task3": {"MCPileup": "/task1/mc-pileup/tier",
+                                "Campaign": "task3-campaign"},
+                      }
+        wflow = Workflow(tChainSpec['RequestName'], tChainSpec)
+        self.assertEqual(wflow.getName(), tChainSpec['RequestName'])
+        self.assertEqual(wflow.getDbsUrl(), tChainSpec['DbsUrl'])
+        self.assertItemsEqual(wflow.getSitelist(), tChainSpec['SiteWhitelist'])
+        campaigns = ["%s-campaign" % c for c in {"task1", "task2", "task3"}]
+        self.assertItemsEqual(wflow.getCampaigns(), campaigns)
+        self.assertEqual(wflow.getInputDataset(), tChainSpec['Task1']['InputDataset'])
+        pileups = [tChainSpec['Task1']['MCPileup'], tChainSpec['Task2']['DataPileup']]
+        self.assertItemsEqual(wflow.getPileupDatasets(), pileups)
+        self.assertFalse(wflow.hasParents())
+        self.assertEqual(wflow.getParentDataset(), "")
+        self.assertEqual(wflow.getPrimaryBlocks(), {})
+        self.assertEqual(wflow.getSecondarySummary(), {})
+        self.assertEqual(wflow.getParentBlocks(), {})
+        self.assertEqual(wflow._getValue("NoKey"), None)
+        self.assertEqual(len(wflow.getDataCampaignMap()), 3)
+
+    def testStepChainWflow(self):
+        """
+        Test loading a StepChain like request into Workflow
+        """
+        tChainSpec = {"StepChain": 3,
+                      "Campaign": "top-campaign",
+                      "RequestName": "whatever_name",
+                      "DbsUrl": "a_dbs_url",
+                      "SiteWhitelist": ["CERN", "FNAL", "DESY"],
+                      "SiteBlacklist": [],
+                      "Step1": {"InputDataset": "/step1/input-dataset/tier",
+                                "MCPileup": "/step1/mc-pileup/tier",
+                                "Campaign": "step1-campaign"},
+                      "Step2": {"DataPileup": "/step2/data-pileup/tier",
+                                "Campaign": "step2-campaign"},
+                      "Step3": {"MCPileup": "/step1/mc-pileup/tier",
+                                "Campaign": "step3-campaign"},
+                      }
+        wflow = Workflow(tChainSpec['RequestName'], tChainSpec)
+        self.assertEqual(wflow.getName(), tChainSpec['RequestName'])
+        self.assertEqual(wflow.getDbsUrl(), tChainSpec['DbsUrl'])
+        self.assertItemsEqual(wflow.getSitelist(), tChainSpec['SiteWhitelist'])
+        campaigns = ["%s-campaign" % c for c in {"step1", "step2", "step3"}]
+        self.assertItemsEqual(wflow.getCampaigns(), campaigns)
+        self.assertEqual(wflow.getInputDataset(), tChainSpec['Step1']['InputDataset'])
+        pileups = [tChainSpec['Step1']['MCPileup'], tChainSpec['Step2']['DataPileup']]
+        self.assertItemsEqual(wflow.getPileupDatasets(), pileups)
+        self.assertFalse(wflow.hasParents())
+        self.assertEqual(wflow.getParentDataset(), "")
+        self.assertEqual(wflow.getPrimaryBlocks(), {})
+        self.assertEqual(wflow.getSecondarySummary(), {})
+        self.assertEqual(wflow.getParentBlocks(), {})
+        self.assertEqual(wflow._getValue("NoKey"), None)
+        self.assertEqual(len(wflow.getDataCampaignMap()), 3)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Complements #9330 

#### Status
not-tested

#### Description
After discussing with Yuyi, it turns out the best way to fetch a dataset size via DBS is by using the `blocks` API and looping over the block sizes.
So, this PR has the following changes:
* calculate pileup dataset sizes using the DBS `blocks` REST API
* cache pileup dataset sizes throughout a whole cycle of the MSTransferor
* not change the request status if `readOnly=true`
* changed the `completion` data type from float to list of float, such that we can keep track of the transfer progress from the MS perspective.
* and created unit tests for the Workflow module

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Yes, it complements #9330 

#### External dependencies / deployment changes
no
