### PR TITLE
Make DbsUrl homogeneous in the json template

### DIFF
--- a/test/data/ReqMgr/requests/DMWM/StepChain_DupOutMod.json
+++ b/test/data/ReqMgr/requests/DMWM/StepChain_DupOutMod.json
@@ -22,7 +22,7 @@
         "Comments": ["MC from scratch; 3 steps in the same job; Step1 and Step2 have the same RAWSIM output module",
                      "save all outputs; Given 50 EpLumi, sets 150 EpJob (instead of 174), so 3 LpJob"],
         "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb",
-        "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader",
+        "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/",
         "GlobalTag": "90X_mcRun1_realistic_v4",
         "Group": "DATAOPS",
         "Memory": 2200,

--- a/test/data/ReqMgr/requests/DMWM/StoreResults.json
+++ b/test/data/ReqMgr/requests/DMWM/StoreResults.json
@@ -15,7 +15,7 @@
   "createRequest": {
     "AcquisitionEra": "StoreResults",
     "CMSSWVersion": "CMSSW_8_0_26_patch1",
-    "DbsUrl": "https://cmsweb.cern.ch/dbs/prod/phys03/DBSReader",
+    "DbsUrl": "https://cmsweb.cern.ch/dbs/prod/phys03/DBSReader/",
     "GlobalTag": "crab3_tag",
     "PhysicsGroup": "TauPOG",
     "InputDataset": "/EmbeddingRun2016B/MuTauFinalState-imputSep16DoubleMu_mirror_miniAOD-v2/USER",

--- a/test/data/ReqMgr/requests/Integration/ReRecoSkim.json
+++ b/test/data/ReqMgr/requests/Integration/ReRecoSkim.json
@@ -25,7 +25,7 @@
     "Memory": 2394,
     "SizePerEvent":500,
     "InputDataset": "/BTag/Run2012A-v1/RAW",
-    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader",
+    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/",
     "Scenario": "pp",	  
     "SkimName1": "skim_2012A_BTag",
     "SkimInput1": "RECOoutput",

--- a/test/data/ReqMgr/requests/Integration/ReReco_Parents.json
+++ b/test/data/ReqMgr/requests/Integration/ReReco_Parents.json
@@ -21,7 +21,7 @@
     "Memory": 2300,
     "SizePerEvent": 512,
     "InputDataset": "/Cosmics/Commissioning2015-PromptReco-v1/RECO",
-    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader",
+    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/",
     "OpenRunningTimeout" : 28800
 },
 "assignRequest":

--- a/test/data/ReqMgr/requests/Integration/StepChain_InclParents.json
+++ b/test/data/ReqMgr/requests/Integration/StepChain_InclParents.json
@@ -5,7 +5,7 @@
     "RequestString": "RequestString-OVERRIDE-ME",
     "CMSSWVersion": "CMSSW_9_4_0",
     "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb",
-    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader",
+    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/",
     "DeterministicPileup": true,
     "GlobalTag": "94X_dataRun2_PromptLike_v5",
     "AcquisitionEra": "CMSSW_9_4_0",

--- a/test/data/ReqMgr/requests/Integration/TaskChain_LumiMask_multiRun.json
+++ b/test/data/ReqMgr/requests/Integration/TaskChain_LumiMask_multiRun.json
@@ -8,7 +8,7 @@
     "RequestString": "RequestString-OVERRIDE-ME",
     "CMSSWVersion": "CMSSW_7_2_0",
     "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb",
-    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader",
+    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/",
     "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev;https://cmsweb.cern.ch/dqm/relval-test",
     "EnableHarvesting": true,
     "DQMConfigCacheID": "cf0f08f510b46c89e73b3c1c3624d5d4",

--- a/test/data/ReqMgr/requests/Integration/TaskChain_RelVal_Multicore.json
+++ b/test/data/ReqMgr/requests/Integration/TaskChain_RelVal_Multicore.json
@@ -9,7 +9,7 @@
     "RequestString": "RequestString-OVERRIDE-ME",
     "CMSSWVersion": "CMSSW_7_4_0",
     "ConfigCacheUrl": "https://cmsweb-testbed.cern.ch/couchdb",
-    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader",
+    "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/",
     "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev;https://cmsweb.cern.ch/dqm/relval-test",
     "EnableHarvesting": "True",
     "DQMConfigCacheID": "0d6d2c921e3ce552e8f513db7f91d75f",


### PR DESCRIPTION
#### Status
not-tested

#### Description
While testing the microservices, I noticed we split DBS calls to different DBS instances because some templates add the slash symbol at the end, while others don't. Make them uniform to take the best advantage of the MicroServices.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
no

#### External dependencies / deployment changes
no
