### PR TITLE
Adjust MSMonitoring logic according to the requirements

### DIFF
--- a/src/python/WMCore/MicroService/Unified/MSMonitor.py
+++ b/src/python/WMCore/MicroService/Unified/MSMonitor.py
@@ -9,7 +9,6 @@ the transferor monitoring module.
 from __future__ import division, print_function
 
 # system modules
-import json
 import time
 
 # WMCore modules
@@ -35,7 +34,7 @@ class MSMonitor(MSCore):
         :return: True if all of them succeeded, else False
         """
         campaigns = self.reqmgrAux.getCampaignConfig("ALL_DOCS")
-        transferRecords = [d for d in self.getTransferInfo('ALL_DOCS')]
+        transferRecords = self.reqmgrAux.getTransferInfo('ALL_DOCS')
         cdict = {}
         if not campaigns:
             self.logger.warning("Failed to fetch campaign configurations")
@@ -43,24 +42,41 @@ class MSMonitor(MSCore):
             self.logger.warning("Failed to fetch transfer records")
         else:
             for camp in campaigns:
-                if 'CampaignName' not in camp:
-                    self.logger.warning(
-                        'No CampaignName attribute in campaign dict: %s',
-                        json.dumps(camp))
-                    continue
                 cdict[camp['CampaignName']] = camp
         return cdict, transferRecords
+
+    def filterTransferDocs(self, requests, transferDocs):
+        """
+        Given a list of requests in the `staging` status and all the
+        transfer documents; select the transfer documents that:
+         * match against a workflow in requests
+         * haven't been updated over the last updateInterval seconds
+        :param requests: list of workflow names
+        :param transferDocs: list of transfer documents
+        :return: a filtered out list of transfer documents
+        """
+        now = time.time()
+        newTransferDocs = []
+        self.logger.info("Matching %d requests to %d transfer documents...",
+                         len(requests), len(transferDocs))
+        for record in transferDocs:
+            if record['workflowName'] in requests:
+                if now - record['lastUpdate'] > self.updateInterval:
+                    newTransferDocs.append(record)
+        msg = "Only %d transfer documents passed the status and timestamp filter."
+        self.logger.info(msg, len(newTransferDocs))
+        return newTransferDocs
 
     def execute(self, reqStatus):
         """
         Executes the MS monitoring logic, see
         https://github.com/dmwm/WMCore/wiki/ReqMgr2-MicroService-Monitor
 
-        :param reqStatus: request statue to process
+        :param reqStatus: request status to process
         :return:
         """
         try:
-            # get requests from ReqMgr2 data-service for given statue
+            # get requests from ReqMgr2 data-service for given status
             # here with detail=False we get back list of records
             requests = self.reqmgr2.getRequestByStatus([reqStatus], detail=False)
             self.logger.debug('+++ monit found %s requests in %s state',
@@ -72,134 +88,130 @@ class MSMonitor(MSCore):
                 msg = "Failed to fetch data from one of the data sources. Retrying again in the next cycle"
                 self.logger.error(msg)
                 return
+            transferRecords = self.filterTransferDocs(requests, transferRecords)
+        except Exception as err:  # general error
+            self.logger.exception('Failed to bootstrap the MSMonitor thread. Error: %s', str(err))
+            return
 
+        try:
             # keep track of request and their new statuses
-            requestsToStage = []
-            # main logic
-            for reqName in requests:
-                self.logger.debug("+++ request %s", reqName)
-                # obtain transfer records for our request
-                transfers = []
-                for rec in transferRecords:
-                    if reqName == rec['workflowName']:
-                        transfers = rec['transfers']
-                        break
-                if not transfers:
-                    continue
-                # if all transfers are completed
-                # move the request status staging -> staged
-                if self.completion(transfers, campaigns):
-                    self.logger.debug(
-                        "+++ request %s all transfers are completed", reqName)
-                    requestsToStage.append(reqName)
-                # if pileup transfers are completed AND
-                # some input blocks are completed,
-                # move the request status staging -> staged
-                elif self.completion(transfers, campaigns, pileup=True):
-                    self.logger.debug(
-                        "+++ request %s pileup transfers are completed", reqName)
-                    requestsToStage.append(reqName)
-                # transfers not completed
-                # just update the database with their completion
-                else:
-                    self.logger.debug(
-                        "+++ request %s transfers are completed", reqName)
-            self.updateTransferInfo(transferRecords)
+            self.getTransferInfo(transferRecords)
+            requestsToStage = self.getCompletedWorkflows(transferRecords, campaigns)
+            failedDocs = self.updateTransferDocs(transferRecords)
             # finally, update statuses for requests
             for reqName in requestsToStage:
+                if reqName in failedDocs:
+                    msg = "Can't proceed with status transition for %s, because" % reqName
+                    msg += "the transfer document failed to get updated"
+                    self.logger.warning(msg)
+                    continue
                 self.change(reqName, 'staged', '+++ monit')
+                msg = "%s updated %d transfer records and " % (self.__class__.__name__, len(transferRecords))
+                msg += "changed the request status for %d workflows" % (len(requestsToStage) - len(failedDocs))
+                self.logger.info(msg)
         except Exception as err:  # general error
             self.logger.exception('+++ monit error: %s', str(err))
 
-    def completion(self, transfers, campaigns, pileup=None):
+    def getTransferInfo(self, transferRecords):
         """
-        Helper function to calculate completion of given records
-        :param transfers: list of transfers records
-        :param pileup: check pileup completion (optional)
-        :return: completion status
-        """
-        # check completion of all transfers
-        statuses = []
-        transferTypes = ['primary', 'secondary']
-        for rec in transfers:
-            campaign = rec['CampaignName']
-            cdict = campaigns[campaign]
-            thr = cdict.get('PartialCopy', 0)
-            if pileup and rec['dataType'] not in transferTypes:
-                continue
-            if rec['completion'] >= thr:
-                status = 1
-            else:
-                status = 0
-            statuses.append(status)
-        return True if sum(statuses) == len(transfers) else False
-
-    def updateTransferInfo(self, transferRecords):
-        """
-        Update transfer records in backend
+        Contact the data management tool in order to get a status
+        update for the transfer request.
         :param transferRecords: list of transfer records
         """
+        # FIXME: create concurrent phedex calls using multi_getdata
         tstamp = time.time()
         for doc in transferRecords:
-            transfers = []
+            self.logger.debug("Checking transfers for: %s", doc['workflowName'])
             for rec in doc.get('transfers', []):
                 # obtain new transfer ids and completion for given dataset
-                _, completion = self.getTransferIds(rec['dataset'])
+                completion = self._getTransferstatus(rec['dataset'], rec['transferIDs'])
                 # Per Alan request, we'll update only completion and not tids
-                rec.update({'completion': completion})
-                transfers.append(rec)
-            wname = doc['workflowName']
+                rec['completion'].append(round(completion, 1))
             doc['lastUpdate'] = tstamp
-            doc['transfers'] = transfers
-            self.reqmgrAux.updateTransferInfo(wname, doc, inPlace=True)
 
-    def getTransferIds(self, dataset):
+    def _getTransferstatus(self, dataset, requestList):
         """
-        Get transfer ids document for given request name and datasets.
-        :param dataset: dataset name
-        :return: a list of transfer ids and completion value
+        Fetch the transfer request status from the data management tool
+        :param dataset: dataset name string
+        :param requestList: list of request IDs
+        :return: the transfer percent completion normalized to the nodes
+
+        The subscription API response structure is something like:
+        {u'phedex': {u'call_time': 0.09359,
+                     u'dataset': [{u'block': [{u'bytes': 2827742840,
+                                               u'files': 3,
+                                               u'id': u'7702606',
+                                               u'is_open': u'n',
+                                               u'name': u'/HLTPhysicsIsolatedBunch/Run2016H-v1/RAW#92049f6e-92f9-11e6-b150-001e67abf228',
+                                               u'subscription': [{u'custodial': u'n',
+                                                                  u'group': u'DataOps',
+                                                                  u'percent_files': 100,
+                                                                  ...
         """
-        # phedex implementation, TODO: implement Rucio logic when it is ready
-        data = self.phedex.subscriptions(
-            dataset=dataset, group=self.msConfig['group'])
-        self.logger.debug(
-            "### dataset %s group %s", dataset, self.msConfig['group'])
-        self.logger.debug("### subscription %s", data)
-        tids = []
-        vals = []
-        for row in data['phedex']['dataset']:
-            if row['name'] == dataset:
-                for rec in row['subscription']:
-                    vals.append(int(rec['percent_files']))
-                    tids.append(int(rec['request']))
-        if not vals:
-            return tids, 0
-        return tids, float(sum(vals))/len(vals)
-
-    def getTransferInfo(self, wname):
-        """
-        Get transfer document from backend. The document has the following form:
-
-        .. doctest::
-
-            {"workflowName": "bla",
-             "lastUpdate": 123,
-             "transfers": [rec1, rec2, ... ]
-            }
-            where each record has the following format:
-            {"dataset":"/a/b/c", "dataType": "primary", "transferIDs": [1,2], "completion": 0}
-
-
-        :param wname: workflow name
-        :return: a generator of transfer records
-        """
-        records = self.reqmgrAux.getTransferInfo(wname)
-        # according to https://github.com/dmwm/WMCore/wiki/ReqMgr2-MicroService-Monitor
-        # we may need to select only record since last updated according
-        # to configuration UpdateInterval setting
-        for rec in records:
-            if self.updateInterval:
-                if time.time()-rec['lastUpdate'] > self.updateInterval:
-                    yield rec
+        completion = []
+        for reqId in requestList:
+            # if we query by dataset and the subscription was at block level,
+            # we get an empty response. So always wildcard the block parameter
+            data = self.phedex.subscriptions(block=dataset + '#*', request=reqId)
+            if not data or not data['phedex']['dataset']:
+                self.logger.error("Failed to retrieve information for dataset: %s and request ID: %s",
+                                  dataset, reqId)
             else:
-                yield rec
+                self.logger.debug("Subscription result for dataset: %s and request ID: %s was: %s",
+                                  dataset, reqId, data)
+            # the response structure is nested as hell!
+            for dsetRow in data['phedex']['dataset']:
+                # TODO: check what happens when we subscribe both the primary and parent in the same request
+                for blockRow in dsetRow['block']:
+                    for subs in blockRow['subscription']:
+                        if subs['percent_files'] is None:
+                            completion.append(0)
+                        else:
+                            completion.append(int(subs['percent_files']))
+        if not completion:
+            return 0
+        return sum(completion)/len(completion)
+
+    def getCompletedWorkflows(self, transfers, campaigns):
+        """
+        Parse the transfer documents, compare against the campaign settings
+        and decide whether the workflow is completed or not.
+        :param transfers: list of transfers records
+        :param campaigns: dictionary of campaigns
+        :return: completion status
+        """
+        completedWfs = []
+        for record in transfers:
+            reqName = record['workflowName']
+            if not record['transfers']:
+                self.logger.info("%s OK, no input data transfers, move it on.", reqName)
+                completedWfs.append(reqName)
+                continue
+            # check completion of all transfers
+            statuses = []
+            for transfer in record['transfers']:
+                cdict = campaigns[transfer['campaignName']]
+                # compare against the last completion number, which is from the last cycle execution
+                if transfer['completion'][-1] >= cdict['PartialCopy'] * 100:
+                    status = 1
+                else:
+                    status = 0
+                statuses.append(status)
+            if all(statuses):
+                self.logger.info("%s OK, all transfers completed or above threshold, move it on.", reqName)
+                completedWfs.append(reqName)
+        return completedWfs
+
+    def updateTransferDocs(self, docs):
+        """
+        Given a list of transfer documents, update all of them in
+        ReqMgrAux database.
+        :param docs: list of transfer docs
+        :return: a list of request names that failed to be updated
+        """
+        failedWfs = []
+        for rec in docs:
+            if not self.reqmgrAux.updateTransferInfo(rec['workflowName'], rec):
+                # then it failed to update the doc, ReqMgrAux client is logging it already
+                failedWfs.append(rec['workflowName'])
+        return failedWfs

--- a/src/python/WMQuality/Emulators/ReqMgrAux/MockReqMgrAux.py
+++ b/src/python/WMQuality/Emulators/ReqMgrAux/MockReqMgrAux.py
@@ -1,5 +1,15 @@
+"""
+MockReqMgrAux class provides mocking methods of ReqMgrAux class
+"""
+# futures
 from __future__ import (division, print_function)
+
+# system modules
+import time
+
+# WMCore modues
 from WMCore.Agent.DefaultConfig import DEFAULT_AGENT_CONFIG
+
 
 class MockReqMgrAux(object):
     """
@@ -7,10 +17,54 @@ class MockReqMgrAux(object):
     """
 
     def __init__(self, *args, **kwargs):
-        print("Using MockReqMgrAux")
+        print("Using MockReqMgrAux", args, kwargs)
+        tstamp = int(time.time())
+        cname = 'testCampaign'
+        cdict = {"CampaignName": cname,
+                 "PrimaryAAA": True,
+                 "SecondaryAAA": False,
+                 "SiteWhiteList": ["T1", "T2"],
+                 "SiteBlackList": [],
+                 "SecondaryLocation": ["T1", "T2"],
+                 "Secondaries": {"datasetA": ["T1", "T2"], "datasetB": ["T1"]},
+                 "MaxCopies": -1,
+                 "PartialCopy": 0
+	}
+        self.campaigns = [cdict]
+        self.transferRecords = []
+        rec = {"dataset":"/a/b/c", "dataType": "primary",
+               "transferIDs": [1,2], "completion": 1, "CampaignName": cname}
+        self.transferRecords = \
+                [{'workflowName': 'test', 'lastupdate':tstamp, 'transfers':[rec]}]
 
     def getWMAgentConfig(self, agentName):
         """
         macking getWMAgentConfig returns default config.
         """
         return DEFAULT_AGENT_CONFIG
+
+    def getCampaignConfig(self, name):
+        "mocking getCampaignConfig method"
+        campaigns = []
+        if name == 'ALL_DOCS':
+            return self.campaigns
+        for camp in self.campaigns:
+            if camp['CampaignName'] == name:
+                campaigns.append(camp)
+        return campaigns
+
+    def getTransferInfo(self, name):
+        "mocking getTransferInfo method"
+        if name == 'ALL_DOCS':
+            return self.transferRecords
+        records = []
+        for rec in self.transferRecords:
+            if rec['workflowName'] == name:
+                records.append(rec)
+        return records
+
+    def updateTransferInfo(self, name, doc, inPlace=False):
+        "mocking updateTransferInfo method"
+        # while mocking we do nothing
+        print('mock method updateTransferInfo: name=%s, doc=%s inPlace=%s' \
+                % (name, doc, inPlace))

--- a/src/python/WMQuality/Emulators/ReqMgrAux/MockReqMgrAux.py
+++ b/src/python/WMQuality/Emulators/ReqMgrAux/MockReqMgrAux.py
@@ -27,15 +27,14 @@ class MockReqMgrAux(object):
                  "SiteBlackList": [],
                  "SecondaryLocation": ["T1", "T2"],
                  "Secondaries": {"datasetA": ["T1", "T2"], "datasetB": ["T1"]},
-                 "MaxCopies": -1,
-                 "PartialCopy": 0
-	}
+                 "MaxCopies": 2,
+                 "PartialCopy": 1
+                 }
         self.campaigns = [cdict]
         self.transferRecords = []
-        rec = {"dataset":"/a/b/c", "dataType": "primary",
-               "transferIDs": [1,2], "completion": 1, "CampaignName": cname}
-        self.transferRecords = \
-                [{'workflowName': 'test', 'lastupdate':tstamp, 'transfers':[rec]}]
+        rec = {"dataset": "/a/b/c", "dataType": "primary",
+               "transferIDs": [1, 2], "completion": [1], "campaignName": cname}
+        self.transferRecords = [{'workflowName': 'test', 'lastUpdate': tstamp, 'transfers': [rec]}]
 
     def getWMAgentConfig(self, agentName):
         """
@@ -67,4 +66,4 @@ class MockReqMgrAux(object):
         "mocking updateTransferInfo method"
         # while mocking we do nothing
         print('mock method updateTransferInfo: name=%s, doc=%s inPlace=%s' \
-                % (name, doc, inPlace))
+              % (name, doc, inPlace))

--- a/test/python/WMCore_t/MicroService_t/Unified_t/MSMonitor_t.py
+++ b/test/python/WMCore_t/MicroService_t/Unified_t/MSMonitor_t.py
@@ -1,0 +1,88 @@
+"""
+Unit tests for Unified/Monitor.py module
+
+Author: Valentin Kuznetsov <vkuznet [AT] gmail [DOT] com>
+"""
+from __future__ import division, print_function
+
+# system modules
+import json
+import unittest
+
+# WMCore modules
+from WMCore.MicroService.Unified.MSMonitor import MSMonitor
+from WMQuality.Emulators.EmulatedUnitTestCase import EmulatedUnitTestCase
+from WMQuality.Emulators.ReqMgrAux.MockReqMgrAux import MockReqMgrAux
+
+
+
+class MonitorTest(EmulatedUnitTestCase):
+    "Unit test for Monitor module"
+
+    def setUp(self):
+        "init test class"
+        self.msConfig = {'verbose': False,
+                         'group': 'DataOps',
+                         'interval': 1 * 60,
+                         'updateInterval': 0,
+                         'readOnly': True,
+                         'reqmgrUrl': 'https://cmsweb-testbed.cern.ch/reqmgr2',
+                         'reqmgrCacheUrl': 'https://cmsweb-testbed.cern.ch/couchdb/reqmgr_workload_cache',
+                         'phedexUrl': 'https://cmsweb-testbed.cern.ch/phedex/datasvc/json/prod',
+                         'dbsUrl': 'https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader'}
+
+        self.ms = MSMonitor(self.msConfig)
+        self.ms.reqmgrAux = MockReqMgrAux()
+        super(MonitorTest, self).setUp()
+
+    def testGetTransferInfo(self):
+        """
+        Test the getTransferInfo method
+        """
+        transferRecords = [d for d in self.ms.getTransferInfo('ALL_DOCS')]
+        self.assertNotEqual(transferRecords, [])
+        for rec in transferRecords:
+            self.assertEqual(isinstance(rec, dict), True)
+            keys = sorted(['workflowName', 'lastupdate', 'transfers'])
+            self.assertEqual(keys, sorted(rec.keys()))
+            print('### transfer rec %s' % json.dumps(rec))
+
+    def testCompletion(self):
+        """
+        Test the completion method
+        """
+        campaigns, transferRecords = self.ms.updateCaches()
+        self.assertNotEqual(campaigns, [])
+        self.assertNotEqual(transferRecords, [])
+        transfers = []
+        for rec in transferRecords:
+            self.assertEqual('transfers' in rec, True)
+            for item in rec['transfers']:
+                transfers.append(item)
+        print("### transfers: %s" % transfers)
+        completion = self.ms.completion(transfers, campaigns)
+        self.assertEqual(completion, True)
+
+    def testGetCampaignConfig(self):
+        """
+        Test the getCampaignConfig method
+        """
+        campaigns, _ = self.ms.updateCaches()
+        self.assertNotEqual(campaigns, [])
+        for cname, cdict in campaigns.items():
+            self.assertEqual(isinstance(cdict, dict), True)
+            self.assertNotEqual(cdict.get('CampaignName', {}), {})
+            print('### campaign %s config %s' % (cname, json.dumps(cdict)))
+
+    def testUpdateTransferInfo(self):
+        """
+        Test the updateTransferInfo method
+        """
+        campaigns, transferRecords = self.ms.updateCaches()
+        self.assertNotEqual(campaigns, [])
+        self.assertNotEqual(transferRecords, [])
+        self.ms.updateTransferInfo(transferRecords)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #9347 
Superseeds #9325 

#### Status
not-tested

#### Description
Complete MSMonitor architecture, in short:
* fetch transfer docs from reqmgr_aux DB and process those without any updates for 6 hours
* fetch all the campaign configurations
* fixed phedex `subscriptions` call to use input dataset and request ID as arguments - if needed - and use average of `percent_files` for the workflow completion
* update transfer documents in couchdb
* change request status, if data transfers are completed or above campaign thresholds 

#### Is it backward compatible (if not, which system it affects?)
no

#### Related PRs
Follow up of #9325 and #9276

#### External dependencies / deployment changes
updateInterval needs to be set in the deployment scripts.
