### PR TITLE
Send CE information to CMS monitoring

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -531,7 +531,7 @@ class SimpleCondorPlugin(BasePlugin):
         ad['Rank'] = 0.0
         ad['TransferIn'] = False
 
-        ad['JobMachineAttrs'] = "GLIDEIN_CMSSite"
+        ad['JobMachineAttrs'] = ("GLIDEIN_CMSSite","GLIDEIN_Gatekeeper")
         ad['JobAdInformationAttrs'] = ("JobStatus,QDate,EnteredCurrentStatus,JobStartDate,DESIRED_Sites,"
                                        "ExtDESIRED_Sites,WMAgent_JobID,MachineAttrGLIDEIN_CMSSite0")
 


### PR DESCRIPTION
Fixes #8355

#### Status
not-tested

#### Description
This PR adds GLIDEIN_Gatekeeper to the classads sent to CMS central monitoring. GLIDEIN_Gatekeeper contents will look like: `hammer-osg.rcac.purdue.edu hammer-osg.rcac.purdue.edu:9619`

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
NA

#### External dependencies / deployment changes
It sounds like this change will be picked up automatically and added into the CMS ES, but I am not certain.
