### PR TITLE
Cache results from DBSReader.listDatatiers for 1 hours by default.

### DIFF
--- a/src/python/WMCore/Cache/GenericDataCache.py
+++ b/src/python/WMCore/Cache/GenericDataCache.py
@@ -84,3 +84,12 @@ class GenericDataCache(object):
             raise CacheWithWrongStructException(cacheName)
         else:
             GenericDataCache._dataCache[cacheName] = memoryCache
+
+    @staticmethod
+    def cacheExists(cacheName):
+        """
+        Return True if provided cache name is already cached, else False.
+        :param cacheName: cache name string
+        :return: boolean
+        """
+        return cacheName in GenericDataCache._dataCache

--- a/test/python/WMCore_t/Cache_t/GenericDataCache_t.py
+++ b/test/python/WMCore_t/Cache_t/GenericDataCache_t.py
@@ -62,6 +62,16 @@ class GenericDataCacheTest(unittest.TestCase):
 
         return
 
+    def testExists(self):
+        """
+        Tests whether a given cache already exists
+        """
+        mc = MemoryCacheStruct(1, lambda x: int(time.time()), kwargs={'x':1})
+        self.assertFalse(GenericDataCache.cacheExists("tCache"))
+
+        GenericDataCache.registerCache("tCache", mc)
+        self.assertTrue(GenericDataCache.cacheExists("tCache"))
+        self.assertFalse(GenericDataCache.cacheExists("tCache2"))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Retry query if it fails for up to 5 times.

Fixes #9332

#### Status
In development | not-tested

#### Description
Cache data tier list for up to 1 hour by default. Query to DBS is retried if failed at first for up to 5 times before caching.

#### Is it backward compatible (if not, which system it affects?)
YES 


#### External dependencies / deployment changes
Uses py2-retry, available as an external dependency with the wmagent builds.
