### PR TITLE
Update json templates with IncludeParents True; fix Harvesting on StepChain

### DIFF
--- a/test/data/ReqMgr/requests/DMWM/TaskChain_InclParents.json
+++ b/test/data/ReqMgr/requests/DMWM/TaskChain_InclParents.json
@@ -17,51 +17,45 @@
         ], 
         "SoftTimeout": 129600, 
         "Team": "Team-OVERRIDE-ME", 
-        "TrustSitelists": true,
         "UnmergedLFNBase": "/store/unmerged"
     }, 
     "createRequest": {
         "AcquisitionEra": {
-            "DQMHLTonRAWAOD_2017": "CMSSW_9_4_0"
+            "DQMHLTonRAWAOD_2017": "CMSSW_7_3_2"
         }, 
-        "CMSSWVersion": "CMSSW_9_4_0", 
-        "Campaign": "Campaign-OVERRIDE-ME", 
-        "Comments": ["Task1 with IncludeParents and LumiList (29 lumis); LumiBased 10 LpJob; single run (1 blocks);",
-                    "8 cores and 6 GB; TrustSitelists True"],
-        "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb", 
+        "Campaign": "Campaign-OVERRIDE-ME",
+        "CMSSWVersion": "CMSSW_7_3_2",
+        "Comments": "Single task; IncludeParents True and 3 runs whitelisted; auto-splitting",
+        "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb",
         "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/", 
-        "GlobalTag": "94X_dataRun2_PromptLike_v5", 
-        "Multicore": 1, 
-        "PrepID": "TEST-CMSSW_9_4_0__test2inwf-1510737328-RunHLTPhy2017B_RAWAOD", 
+        "GlobalTag": "GR_P_V49",
+        "PrepID": "TEST-CMSSW_7_3_2__test2inwf-1510737328-RunHLTPhy2017B_RAWAOD",
         "ProcessingString": {
-            "DQMHLTonRAWAOD_2017": "94X_dataRun2_PromptLike_v5_RelVal_hltPhy2017Brawaod"
+            "DQMHLTonRAWAOD_2017": "DMWM_ProcStr_TEST"
         }, 
         "ProcessingVersion": 18, 
         "RequestPriority": 160000, 
         "RequestString": "RequestString-OVERRIDE-ME", 
         "RequestType": "TaskChain", 
         "ScramArch": [
-            "slc6_amd64_gcc630"
+            "slc6_amd64_gcc491"
         ], 
-        "SizePerEvent": 1234, 
+        "SizePerEvent": 512,
         "SubRequestType": "RelVal", 
         "Task1": {
-            "AcquisitionEra": "CMSSW_9_4_0", 
-            "Campaign": "CMSSW_9_4_0__test2inwf-1510737328", 
-            "ConfigCacheID": "d0bff75e6c119de01942c9a5304629a7", 
-            "GlobalTag": "94X_dataRun2_PromptLike_v5", 
+            "AcquisitionEra": "CMSSW_7_3_2",
+            "Campaign": "CMSSW_7_3_2__test2inwf-1510737328",
+            "ConfigCacheID": "029a0b63329659025f308af53c7e092b",
+            "GlobalTag": "GR_P_V49",
             "IncludeParents": true, 
-            "InputDataset": "/HLTPhysics/Run2017B-PromptReco-v1/AOD", 
+            "InputDataset": "/Cosmics/Commissioning2015-PromptReco-v1/RECO",
             "KeepOutput": true, 
-            "LumiList": {"297557": [[60, 80], [173, 180]]}, 
-            "LumisPerJob": 10, 
-            "Memory": 6000,
-            "Multicore": 8, 
-            "ProcessingString": "Task1_WMCore_TEST", 
-            "SplittingAlgo": "LumiBased", 
+            "RunWhitelist": [234297, 234321, 234332],
+            "Memory": 2300,
+            "ProcessingString": "Task1_WMCore_TEST",
             "TaskName": "DQMHLTonRAWAOD_2017"
         }, 
         "TaskChain": 1, 
-        "TimePerEvent": 0.10000000000000001
+        "TimePerEvent": 2
     }
 }

--- a/test/data/ReqMgr/requests/Integration/ReReco_Parents.json
+++ b/test/data/ReqMgr/requests/Integration/ReReco_Parents.json
@@ -1,7 +1,7 @@
 { 
 "createRequest":
 {         
-    "Comments": "ReReco with IncludeParents True, 4 runs whitelisted, 8h opened",
+    "Comments": "ReReco with IncludeParents True, 3 runs whitelisted, 8h opened",
     "AcquisitionEra": "Integ_Test",
     "ProcessingString": "Integ_ProcStr_TEST",
     "Campaign": "Campaign-OVERRIDE-ME",        
@@ -11,7 +11,7 @@
     "RequestPriority": 150000,
     "ScramArch": "slc6_amd64_gcc491",
     "RequestType": "ReReco",
-    "RunWhitelist": [234297, 234304, 234321, 234332],
+    "RunWhitelist": [234297, 234321, 234332],
     "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb",
     "ConfigCacheID": "029a0b63329659025f308af53c7e092b",
     "IncludeParents": true,

--- a/test/data/ReqMgr/requests/Integration/SC_ReDigi_Harvest.json
+++ b/test/data/ReqMgr/requests/Integration/SC_ReDigi_Harvest.json
@@ -1,6 +1,10 @@
 {
   "assignRequest": {
-    "AcquisitionEra": "CMSSW_10_6_1",
+    "AcquisitionEra": {
+        "QCDForPF_13TeV_TuneCUETP8M1_2017PU_GenSimFull": "AcquisitionEra-OVERRIDE-ME",
+        "DigiFullPU_2017PU": "AcquisitionEra-OVERRIDE-ME",
+        "RecoFullPU_2017PU": "AcquisitionEra-OVERRIDE-ME"
+    },
     "Dashboard": "Dashboard-OVERRIDE-ME",
     "GracePeriod": 300,
     "MergedLFNBase": "/store/backfill/1",
@@ -20,7 +24,7 @@
   },
   "createRequest": {
     "AcquisitionEra": "CMSSW_10_6_1",
-    "CMSSWVersion": "CMSSW_10_6_1_patch1",
+    "CMSSWVersion": "CMSSW_10_6_1",
     "Campaign": "Campaign-OVERRIDE-ME",
     "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb",
     "Comments": [
@@ -46,8 +50,9 @@
     ],
     "SizePerEvent": 1234,
     "Step1": {
-      "AcquisitionEra": "CMSSW_10_6_1",
+      "AcquisitionEra": "CMSSW_10_6_1_patch1",
       "Campaign": "CMSSW_10_6_1_Step1",
+      "CMSSWVersion": "CMSSW_10_6_1_patch1",
       "ConfigCacheID": "7186ff14d71d8ed7c336513eb2fcc177",
       "EventsPerJob": 100,
       "EventsPerLumi": 100,
@@ -60,8 +65,9 @@
       "StepName": "QCDForPF_13TeV_TuneCUETP8M1_2017PU_GenSimFull"
     },
     "Step2": {
-      "AcquisitionEra": "CMSSW_10_6_1",
+      "AcquisitionEra": "CMSSW_10_6_1_patch2",
       "Campaign": "CMSSW_10_6_1_Step2",
+      "CMSSWVersion": "CMSSW_10_6_1_patch2",
       "ConfigCacheID": "7186ff14d71d8ed7c336513eb2f46652",
       "GlobalTag": "106X_mc2017_realistic_v6",
       "InputFromOutputModule": "FEVTDEBUGoutput",
@@ -71,8 +77,9 @@
       "StepName": "DigiFullPU_2017PU"
     },
     "Step3": {
-      "AcquisitionEra": "CMSSW_10_6_1",
+      "AcquisitionEra": "CMSSW_10_6_1_patch3",
       "Campaign": "CMSSW_10_6_1_Step3",
+      "CMSSWVersion": "CMSSW_10_6_1_patch3",
       "ConfigCacheID": "7186ff14d71d8ed7c336513eb2f259a1",
       "GlobalTag": "106X_mc2017_realistic_v6",
       "InputFromOutputModule": "FEVTDEBUGHLToutput",

--- a/test/data/ReqMgr/requests/Integration/StepChain_InclParents.json
+++ b/test/data/ReqMgr/requests/Integration/StepChain_InclParents.json
@@ -1,32 +1,29 @@
 {
   "createRequest": {
-    "Comments": "StepChain single step and LumiList (29 lumis); single run; 8 cores; Trust enabled to read the parent blocks",
+    "AcquisitionEra": "CMSSW_7_3_2",
     "Campaign": "Campaign-OVERRIDE-ME",
-    "RequestString": "RequestString-OVERRIDE-ME",
-    "CMSSWVersion": "CMSSW_9_4_0",
+    "CMSSWVersion": "CMSSW_7_3_2",
+    "Comments": "Single step; IncludeParents True and 3 runs whitelisted; auto-splitting",
     "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb",
     "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/",
     "DeterministicPileup": true,
-    "GlobalTag": "94X_dataRun2_PromptLike_v5",
-    "AcquisitionEra": "CMSSW_9_4_0",
-    "ProcessingString": "TEST_StepChain_WMCore_TEST",
+    "RequestString": "RequestString-OVERRIDE-ME",
+    "GlobalTag": "GR_P_V49",
+    "ProcessingString": "Integ_ProcStr_TEST",
     "PrepID": "PrepID-test2inwf-1510737328-RunHLTPhy2017B_RAWAOD",
     "ProcessingVersion": 21,
     "RequestPriority": 420000,
     "RequestType": "StepChain",
-    "ScramArch": "slc6_amd64_gcc630",
-    "Memory": 6000,
-    "SizePerEvent": 2600,
-    "TimePerEvent": 14.4,
+    "ScramArch": "slc6_amd64_gcc491",
+    "Memory": 2300,
+    "SizePerEvent": 512,
+    "TimePerEvent": 2,
     "Step1": {
-      "ConfigCacheID": "d0bff75e6c119de01942c9a5304629a7",
-      "GlobalTag": "94X_dataRun2_PromptLike_v5",
+      "ConfigCacheID": "029a0b63329659025f308af53c7e092b",
+      "GlobalTag": "GR_P_V49",
       "IncludeParents": true,
-      "InputDataset": "/HLTPhysics/Run2017B-PromptReco-v1/AOD",
-      "LumiList": {
-        "297557": [[60, 80], [173, 180]]
-      },
-      "Multicore": 8,
+      "InputDataset": "/Cosmics/Commissioning2015-PromptReco-v1/RECO",
+      "RunWhitelist": [234297, 234321, 234332],
       "StepName": "DQMHLTonRAWAOD_2017"
     },
     "StepChain": 1
@@ -45,7 +42,6 @@
     ],
     "SoftTimeout": 129600,
     "Team": "Team-OVERRIDE-ME",
-    "TrustSitelists" : true,
     "UnmergedLFNBase": "/store/unmerged"
   }
 }


### PR DESCRIPTION
#### Status
not-tested

#### Description
Update the StepChain template such that the file upload to the DQMGui succeeds.
Also updated all the templates processing the parent dataset - since the current one has been DELETED - so they now use the same input dataset, release and configuration.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs

#### External dependencies / deployment changes
no
