### PR TITLE
Enable pycurl by default for all Service client APIs

### DIFF
--- a/src/python/WMCore/Cache/WMConfigCache.py
+++ b/src/python/WMCore/Cache/WMConfigCache.py
@@ -5,25 +5,22 @@ _WMConfigCache_
 Being in itself a wrapped class around a config cache
 """
 
-
 import hashlib
 import logging
 import traceback
 import urllib
 from contextlib import closing
+
 from future.utils import with_metaclass
 
-from Utils.Patterns import Singleton
-
-from WMCore.Database.CMSCouch import CouchServer, Document
-from WMCore.DataStructs.WMObject import WMObject
-
-from WMCore.WMException import WMException
-from WMCore.Database.CMSCouch import CouchNotFoundError
-from WMCore.GroupUser.Group import Group
-from WMCore.GroupUser.User  import makeUser
-
 import WMCore.GroupUser.Decorators as Decorators
+from Utils.Patterns import Singleton
+from WMCore.DataStructs.WMObject import WMObject
+from WMCore.Database.CMSCouch import CouchNotFoundError
+from WMCore.Database.CMSCouch import CouchServer, Document
+from WMCore.GroupUser.Group import Group
+from WMCore.GroupUser.User import makeUser
+from WMCore.WMException import WMException
 
 
 class ConfigCacheException(WMException):
@@ -36,7 +33,8 @@ class ConfigCacheException(WMException):
 
 class DocumentCache(with_metaclass(Singleton, object)):
     """DocumentCache holds config ids. Use this class as singleton"""
-    def __init__(self, database, detail = True):
+
+    def __init__(self, database, detail=True):
         super(DocumentCache, self).__init__()
         self.cache = {}
         self.database = database
@@ -47,7 +45,7 @@ class DocumentCache(with_metaclass(Singleton, object)):
         """
         Internal get method to fetch document based on provided ID
         """
-        if  configID not in self.cache:
+        if configID not in self.cache:
             self.prefetch([configID])
         return self.cache[configID]
 
@@ -58,7 +56,7 @@ class DocumentCache(with_metaclass(Singleton, object)):
         Clean-up given ids from local cache
         """
         for rid in ids:
-            if  rid in self.cache:
+            if rid in self.cache:
                 del self.cache[rid]
 
     def prefetch(self, keys):
@@ -68,7 +66,7 @@ class DocumentCache(with_metaclass(Singleton, object)):
         Pre-fetch given list of documents from CouchDB
         """
         if self.detail:
-            options = {'include_docs':True}
+            options = {'include_docs': True}
         else:
             options = {}
         result = self.database.allDocs(options=options, keys=keys)
@@ -78,6 +76,7 @@ class DocumentCache(with_metaclass(Singleton, object)):
             else:
                 self.cache[row['id']] = True
 
+
 class ConfigCache(WMObject):
     """
     _ConfigCache_
@@ -85,11 +84,12 @@ class ConfigCache(WMObject):
     The class that handles the upload and download of configCache
     artifacts from Couch
     """
-    def __init__(self, dbURL, couchDBName = None, id = None, rev = None, usePYCurl = True,
-                 ckey = None, cert = None, capath = None, detail = True):
+
+    def __init__(self, dbURL, couchDBName=None, id=None, rev=None, usePYCurl=True,
+                 ckey=None, cert=None, capath=None, detail=True):
         super(ConfigCache, self).__init__()
         self.dbname = couchDBName
-        self.dburl  = dbURL
+        self.dburl = dbURL
         self.detail = detail
         try:
             self.couchdb = CouchServer(self.dburl, usePYCurl=usePYCurl, ckey=ckey, cert=cert, capath=capath)
@@ -101,7 +101,7 @@ class ConfigCache(WMObject):
             msg = "Error connecting to couch: %s\n" % str(ex)
             msg += str(traceback.format_exc())
             logging.error(msg)
-            raise ConfigCacheException(message = msg)
+            raise ConfigCacheException(message=msg)
 
         # local cache
         self.docs_cache = DocumentCache(self.database, self.detail)
@@ -111,7 +111,7 @@ class ConfigCache(WMObject):
         self.owner = None
 
         # Internal data structure
-        self.document  = Document()
+        self.document = Document()
         self.attachments = {}
         self.document['type'] = "config"
         self.document['description'] = {}
@@ -119,10 +119,10 @@ class ConfigCache(WMObject):
         self.document['description']['config_desc'] = None
 
         if id != None:
-            self.document['_id']                = id
+            self.document['_id'] = id
         self.document['pset_tweak_details'] = None
-        self.document['info']               = None
-        self.document['config']             = None
+        self.document['info'] = None
+        self.document['config'] = None
         return
 
     def createDatabase(self):
@@ -139,12 +139,12 @@ class ConfigCache(WMObject):
         _connectUserGroup_
 
         """
-        self.group = Group(name = groupname)
+        self.group = Group(name=groupname)
         self.group.setCouch(self.dburl, self.dbname)
         self.group.connect()
         self.owner = makeUser(groupname, username,
-                              couchUrl = self.dburl,
-                              couchDatabase = self.dbname)
+                              couchUrl=self.dburl,
+                              couchDatabase=self.dbname)
         return
 
     def createUserGroup(self, groupname, username):
@@ -153,8 +153,8 @@ class ConfigCache(WMObject):
 
         Create all the userGroup information
         """
-        self.createGroup(name = groupname)
-        self.createUser(username = username)
+        self.createGroup(name=groupname)
+        self.createUser(username=username)
         return
 
     def createGroup(self, name):
@@ -163,7 +163,7 @@ class ConfigCache(WMObject):
 
         Create Group for GroupUser
         """
-        self.group = Group(name = name)
+        self.group = Group(name=name)
         self.group.setCouch(self.dburl, self.dbname)
         self.group.connect()
         self.group.create()
@@ -188,8 +188,8 @@ class ConfigCache(WMObject):
     @Decorators.requireGroup
     def createUser(self, username):
         self.owner = makeUser(self.group['name'], username,
-                              couchUrl = self.dburl,
-                              couchDatabase = self.dbname)
+                              couchUrl=self.dburl,
+                              couchDatabase=self.dbname)
         self.owner.create()
         self.owner.ownThis(self.document)
         return
@@ -202,7 +202,7 @@ class ConfigCache(WMObject):
 
         Save yourself!  Save your internal document.
         """
-        rawResults = self.database.commit(doc = self.document)
+        rawResults = self.database.commit(doc=self.document)
 
         # We should only be committing one document at a time
         # if not, get the last one.
@@ -210,23 +210,20 @@ class ConfigCache(WMObject):
         try:
             commitResults = rawResults[-1]
             self.document["_rev"] = commitResults.get('rev')
-            self.document["_id"]  = commitResults.get('id')
+            self.document["_id"] = commitResults.get('id')
         except KeyError as ex:
-            msg  = "Document returned from couch without ID or Revision\n"
+            msg = "Document returned from couch without ID or Revision\n"
             msg += "Document probably bad\n"
             msg += str(ex)
             logging.error(msg)
-            raise ConfigCacheException(message = msg)
-
+            raise ConfigCacheException(message=msg)
 
         # Now do the attachments
         for attachName in self.attachments:
-            self.saveAttachment(name = attachName,
-                                attachment = self.attachments[attachName])
-
+            self.saveAttachment(name=attachName,
+                                attachment=self.attachments[attachName])
 
         return
-
 
     def saveAttachment(self, name, attachment):
         """
@@ -234,7 +231,6 @@ class ConfigCache(WMObject):
 
         Save an attachment to the document
         """
-
 
         retval = self.database.addAttachment(self.document["_id"],
                                              self.document["_rev"],
@@ -250,11 +246,10 @@ class ConfigCache(WMObject):
             raise ConfigCacheException(msg)
 
         self.document["_rev"] = retval['rev']
-        self.document["_id"]  = retval['id']
+        self.document["_id"] = retval['id']
         self.attachments[name] = attachment
 
         return
-
 
     def loadDocument(self, configID):
         """
@@ -271,36 +266,35 @@ class ConfigCache(WMObject):
         Load a document from the server given its couchID
         """
         try:
-            self.document = self.database.document(id = configID)
+            self.document = self.database.document(id=configID)
             if 'owner' in self.document.keys():
-                self.connectUserGroup(groupname = self.document['owner'].get('group', None),
-                                      username  = self.document['owner'].get('user', None))
+                self.connectUserGroup(groupname=self.document['owner'].get('group', None),
+                                      username=self.document['owner'].get('user', None))
             if '_attachments' in self.document.keys():
                 # Then we need to load the attachments
                 for key in self.document['_attachments'].keys():
-                    self.loadAttachment(name = key)
+                    self.loadAttachment(name=key)
         except CouchNotFoundError as ex:
-            msg =  "Document with id %s not found in couch\n" % (configID)
+            msg = "Document with id %s not found in couch\n" % (configID)
             msg += str(ex)
             msg += str(traceback.format_exc())
             logging.error(msg)
-            raise ConfigCacheException(message = msg)
+            raise ConfigCacheException(message=msg)
         except Exception as ex:
-            msg =  "Error loading document from couch\n"
+            msg = "Error loading document from couch\n"
             msg += str(ex)
             msg += str(traceback.format_exc())
             logging.error(msg)
-            raise ConfigCacheException(message = msg)
+            raise ConfigCacheException(message=msg)
 
         return
 
-    def loadAttachment(self, name, overwrite = True):
+    def loadAttachment(self, name, overwrite=True):
         """
         _loadAttachment_
 
         Load an attachment from the database and put it somewhere useful
         """
-
 
         attach = self.database.getAttachment(self.document["_id"], name)
 
@@ -320,9 +314,9 @@ class ConfigCache(WMObject):
         Underlying code to load views
         """
 
-        viewRes = self.database.loadView( 'ConfigCache', view, {}, [value] )
+        viewRes = self.database.loadView('ConfigCache', view, {}, [value])
 
-        if len(viewRes['rows']) == 0:
+        if not viewRes['rows']:
             # Then we have a problem
             msg = "Unable to load using view %s and value %s" % (view, str(value))
             logging.error(msg)
@@ -346,7 +340,6 @@ class ConfigCache(WMObject):
             f.write(config)
         return
 
-
     def load(self):
         """
         _load_
@@ -361,19 +354,15 @@ class ConfigCache(WMObject):
 
         # Otherwise we have to load by view
 
-        if not self.document.get('md5_hash', None) == None:
+        if not self.document.get('md5_hash', None) is None:
             # Then we have an md5_hash
-            self.loadByView(view = 'config_by_md5hash', value = self.document['md5_hash'])
-        # TODO: Add more views as they become available.
+            self.loadByView(view='config_by_md5hash', value=self.document['md5_hash'])
+            # TODO: Add more views as they become available.
 
 
-        #elif not self.owner == None:
+            # elif not self.owner == None:
             # Then we have an owner
-            #self.loadByView(view = 'config_by_owner', value = self.owner['name'])
-
-
-
-
+            # self.loadByView(view = 'config_by_owner', value = self.owner['name'])
 
     def unwrapView(self, view):
         """
@@ -382,11 +371,8 @@ class ConfigCache(WMObject):
         Move view information into the main document
         """
 
-        self.document["_id"]  = view['rows'][0].get('id')
+        self.document["_id"] = view['rows'][0].get('id')
         self.document["_rev"] = view['rows'][0].get('value').get('_rev')
-
-
-
 
     def setPSetTweaks(self, PSetTweak):
         """
@@ -417,7 +403,7 @@ class ConfigCache(WMObject):
         try:
             outputModuleNames = psetTweaks["process"]["outputModules_"]
         except KeyError as ex:
-            msg =  "Could not find outputModules_ in psetTweaks['process'] while getting output modules.\n"
+            msg = "Could not find outputModules_ in psetTweaks['process'] while getting output modules.\n"
             msg += str(ex)
             logging.error(msg)
             raise ConfigCacheException(msg)
@@ -439,8 +425,7 @@ class ConfigCache(WMObject):
 
         return results
 
-
-    def addConfig(self, newConfig, psetHash = None):
+    def addConfig(self, newConfig, psetHash=None):
         """
         _addConfig_
 
@@ -473,7 +458,6 @@ class ConfigCache(WMObject):
 
         return self.document["_id"]
 
-
     def getCouchRev(self):
         """
         _getCouchRev_
@@ -481,9 +465,7 @@ class ConfigCache(WMObject):
         Return the document's couchRevision
         """
 
-
         return self.document["_rev"]
-
 
     @Decorators.requireGroup
     @Decorators.requireUser
@@ -496,18 +478,16 @@ class ConfigCache(WMObject):
         if not self.document["_id"]:
             logging.error("Attempted to delete with no couch ID")
 
-
         # TODO: Delete without loading first
         try:
             self.database.queueDelete(self.document)
             self.database.commit()
         except Exception as ex:
-            msg =  "Error in deleting document from couch"
+            msg = "Error in deleting document from couch"
             msg += str(ex)
             msg += str(traceback.format_exc())
             logging.error(msg)
-            raise ConfigCacheException(message = msg)
-
+            raise ConfigCacheException(message=msg)
 
         return
 
@@ -541,7 +521,6 @@ class ConfigCache(WMObject):
 
         return configs
 
-
     def __str__(self):
         """
         Make something printable
@@ -553,9 +532,9 @@ class ConfigCache(WMObject):
     def validate(self, configID):
 
         try:
-            #TODO: need to change to DataCache
-            #self.loadDocument(configID = configID)
-            self.loadByID(configID = configID)
+            # TODO: need to change to DataCache
+            # self.loadDocument(configID = configID)
+            self.loadByID(configID=configID)
         except Exception as ex:
             raise ConfigCacheException("Failure to load ConfigCache while validating workload: %s" % str(ex))
 
@@ -568,7 +547,7 @@ class ConfigCache(WMObject):
                 msg = "Error in getting output modules from ConfigCache during workload validation.  Check ConfigCache formatting!"
                 raise ConfigCacheException("%s: %s" % (msg, str(ex)))
             for outputModule in outputModuleInfo.values():
-                dataTier   = outputModule.get('dataTier', None)
+                dataTier = outputModule.get('dataTier', None)
                 filterName = outputModule.get('filterName', None)
                 if not dataTier:
                     raise ConfigCacheException("No DataTier in output module.")
@@ -582,7 +561,4 @@ class ConfigCache(WMObject):
                 else:
                     duplicateCheck[dataTier].append(filterName)
             return outputModuleInfo
-        else:
-            return True
-
-
+        return True

--- a/src/python/WMCore/Cache/WMConfigCache.py
+++ b/src/python/WMCore/Cache/WMConfigCache.py
@@ -85,7 +85,7 @@ class ConfigCache(WMObject):
     The class that handles the upload and download of configCache
     artifacts from Couch
     """
-    def __init__(self, dbURL, couchDBName = None, id = None, rev = None, usePYCurl = False,
+    def __init__(self, dbURL, couchDBName = None, id = None, rev = None, usePYCurl = True,
                  ckey = None, cert = None, capath = None, detail = True):
         super(ConfigCache, self).__init__()
         self.dbname = couchDBName

--- a/src/python/WMCore/Database/CMSCouch.py
+++ b/src/python/WMCore/Database/CMSCouch.py
@@ -10,15 +10,15 @@ NOT A THREAD SAFE CLASS.
 """
 from __future__ import print_function, division
 
-import time
-import urllib
-import re
-import hashlib
 import base64
+import hashlib
 import logging
+import re
+import time
 import traceback
-from httplib import HTTPException
+import urllib
 from datetime import datetime
+from httplib import HTTPException
 
 from Utils.IteratorTools import grouper, nestedDictUpdate
 from WMCore.Services.Requests import JSONRequests
@@ -42,11 +42,12 @@ class Document(dict):
     Document class is the instantiation of one document in the CouchDB
     """
 
-    def __init__(self, id=None, inputDict={}):
+    def __init__(self, id=None, inputDict=None):
         """
         Initialise our Document object - a dictionary which has an id field
         inputDict - input dictionary to initialise this instance
         """
+        inputDict = inputDict or {}
         dict.__init__(self)
         self.update(inputDict)
         if id:
@@ -104,7 +105,7 @@ class CouchDBRequests(JSONRequests):
         """
         return self.makeRequest(uri, data, 'COPY')
 
-    def makeRequest(self, uri=None, data=None, type='GET', incoming_headers={},
+    def makeRequest(self, uri=None, data=None, type='GET', incoming_headers=None,
                     encode=True, decode=True, contentType=None, cache=False):
         """
         Make the request, handle any failed status, return just the data (for
@@ -112,12 +113,13 @@ class CouchDBRequests(JSONRequests):
 
         TODO: set caching in the calling methods.
         """
+        incoming_headers = incoming_headers or {}
         try:
             if not cache:
                 incoming_headers.update({'Cache-Control': 'no-cache'})
             result, status, reason, cached = JSONRequests.makeRequest(
-                self, uri, data, type, incoming_headers,
-                encode, decode, contentType)
+                    self, uri, data, type, incoming_headers,
+                    encode, decode, contentType)
         except HTTPException as e:
             self.checkForCouchError(getattr(e, "status", None),
                                     getattr(e, "reason", None), data)
@@ -189,7 +191,7 @@ class Database(CouchDBRequests):
         """
         Time stamp each doc in a list
         """
-        if label == True:
+        if label is True:
             label = 'timestamp'
 
         if isinstance(data, type({})):
@@ -200,7 +202,7 @@ class Database(CouchDBRequests):
                     doc[label] = int(time.time())
         return data
 
-    def queue(self, doc, timestamp=False, viewlist=[], callback=None):
+    def queue(self, doc, timestamp=False, viewlist=None, callback=None):
         """
         Queue up a doc for bulk insert. If timestamp = True add a timestamp
         field if one doesn't exist. Use this over commit(timestamp=True) if you
@@ -209,6 +211,7 @@ class Database(CouchDBRequests):
         If a callback is specified then pass it to the commit function if a
         commit is triggered
         """
+        viewlist = viewlist or []
         if timestamp:
             self.timestamp(doc, timestamp)
         # TODO: Thread this off so that it's non blocking...
@@ -226,12 +229,13 @@ class Database(CouchDBRequests):
         doc = {'_id': doc['_id'], '_rev': doc['_rev'], '_deleted': True}
         self.queue(doc)
 
-    def commitOne(self, doc, timestamp=False, viewlist=[]):
+    def commitOne(self, doc, timestamp=False, viewlist=None):
         """
         Helper function for when you know you only want to insert one doc
         additionally keeps from having to rewrite ConfigCache to handle the
         new commit function's semantics
         """
+        viewlist = viewlist or []
         uri = '/%s/_bulk_docs/' % self.name
         if timestamp:
             self.timestamp(doc, timestamp)
@@ -244,7 +248,7 @@ class Database(CouchDBRequests):
         return retval
 
     def commit(self, doc=None, returndocs=False, timestamp=False,
-               viewlist=[], callback=None, **data):
+               viewlist=None, callback=None, **data):
         """
         Add doc and/or the contents of self._queue to the database.
         If timestamp is true timestamp all documents with a unix style
@@ -266,10 +270,11 @@ class Database(CouchDBRequests):
         Returns a list of good documents
             throws an exception otherwise
         """
+        viewlist = viewlist or []
         if doc:
             self.queue(doc, timestamp, viewlist)
 
-        if len(self._queue) == 0:
+        if not self._queue:
             return
 
         if timestamp:
@@ -326,13 +331,14 @@ class Database(CouchDBRequests):
 
         return self.document(doc_id, preRev)
 
-    def updateDocument(self, doc_id, design, update_func, fields={}, useBody=False):
+    def updateDocument(self, doc_id, design, update_func, fields=None, useBody=False):
         """
         Call the update function update_func defined in the design document
         design for the document doc_id with a query string built from fields.
 
         http://wiki.apache.org/couchdb/Document_Update_Handlers
         """
+        fields = fields or {}
         # Clean up /'s in the name etc.
         doc_id = urllib.quote_plus(doc_id)
 
@@ -361,7 +367,7 @@ class Database(CouchDBRequests):
                 nestedDictUpdate(doc, paramsToUpdate)
                 data['docs'].append(doc)
 
-            if len(data['docs']) > 0:
+            if data['docs']:
                 retval = self.post(uri, data)
                 for result in retval:
                     if result.get('error', None) == 'conflict':
@@ -377,12 +383,13 @@ class Database(CouchDBRequests):
         pram maxConflictLimit: number of conflicts fix tries before we give up to fix it to prevent infinite calls
         """
         conflictDocIDs = self.updateBulkDocuments(doc_ids, updateParams, updateLimits)
-        if len(conflictDocIDs) > 0:
+        if conflictDocIDs:
             # wait a second before trying again for the confict documents
             if maxConflictLimit == 0:
                 return conflictDocIDs
             time.sleep(1)
-            self.updateBulkDocumentsWithConflictHandle(conflictDocIDs, updateParams, maxConflictLimit=maxConflictLimit - 1)
+            self.updateBulkDocumentsWithConflictHandle(conflictDocIDs, updateParams,
+                                                       maxConflictLimit=maxConflictLimit - 1)
         return []
 
     def putDocument(self, doc_id, fields):
@@ -419,7 +426,7 @@ class Database(CouchDBRequests):
         doc.delete()
         return self.commitOne(doc)
 
-    def compact(self, views=[], blocking=False, blocking_poll=5, callback=False):
+    def compact(self, views=None, blocking=False, blocking_poll=5, callback=False):
         """
         Compact the database: http://wiki.apache.org/couchdb/Compaction
 
@@ -438,8 +445,9 @@ class Database(CouchDBRequests):
         as an argument. If the callback function raises an exception the block is
         removed and the compact call returns.
         """
+        views = views or []
         response = self.post('/%s/_compact' % self.name)
-        if len(views) > 0:
+        if views:
             for view in views:
                 response[view] = self.post('/%s/_compact/%s' % (self.name, view))
                 response['view_cleanup'] = self.post('/%s/_view_cleanup' % (self.name))
@@ -479,7 +487,7 @@ class Database(CouchDBRequests):
     def purge(self, data):
         return self.post('/%s/_purge' % self.name, data)
 
-    def loadView(self, design, view, options={}, keys=[]):
+    def loadView(self, design, view, options=None, keys=None):
         """
         Load a view by getting, for example:
         http://localhost:5984/tester/_view/viewtest/age_name?count=10&group=true
@@ -505,6 +513,8 @@ class Database(CouchDBRequests):
 
         more info: http://wiki.apache.org/couchdb/HTTP_view_API
         """
+        options = options or {}
+        keys = keys or []
         encodedOptions = {}
         for k, v in options.iteritems():
             # We can't encode the stale option, as it will be converted to '"ok"'
@@ -514,7 +524,7 @@ class Database(CouchDBRequests):
             else:
                 encodedOptions[k] = self.encode(v)
 
-        if len(keys):
+        if keys:
             if encodedOptions:
                 data = urllib.urlencode(encodedOptions)
                 retval = self.post('/%s/_design/%s/_view/%s?%s' % \
@@ -531,18 +541,20 @@ class Database(CouchDBRequests):
         else:
             return retval
 
-    def loadList(self, design, list, view, options={}, keys=[]):
+    def loadList(self, design, list, view, options=None, keys=None):
         """
         Load data from a list function. This returns data that hasn't been
         decoded, since a list can return data in any format. It is expected that
         the caller of this function knows what data is being returned and how to
         deal with it appropriately.
         """
+        options = options or {}
+        keys = keys or []
         encodedOptions = {}
         for k, v in options.iteritems():
             encodedOptions[k] = self.encode(v)
 
-        if len(keys):
+        if keys:
             if encodedOptions:
                 data = urllib.urlencode(encodedOptions)
                 retval = self.post('/%s/_design/%s/_list/%s/%s?%s' % \
@@ -571,18 +583,20 @@ class Database(CouchDBRequests):
                 return {}
             self.checkForCouchError(getattr(e, "status", None), getattr(e, "reason", None))
 
-    def allDocs(self, options={}, keys=[]):
+    def allDocs(self, options=None, keys=None):
         """
         Return all the documents in the database
         options is a dict type parameter which can be passed to _all_docs
         id {'startkey': 'a', 'limit':2, 'include_docs': true}
         keys is the list of key (ids) for doc to be returned
         """
+        options = options or {}
+        keys = keys or []
         encodedOptions = {}
         for k, v in options.iteritems():
             encodedOptions[k] = self.encode(v)
 
-        if len(keys):
+        if keys:
             if encodedOptions:
                 data = urllib.urlencode(encodedOptions)
                 return self.post('/%s/_all_docs?%s' % (self.name, data),
@@ -654,7 +668,7 @@ class Database(CouchDBRequests):
         # do the safety check other wise it will delete whole db.
         if not isinstance(ids, list):
             raise
-        if len(ids) == 0:
+        if not ids:
             return None
 
         docs = self.allDocs(keys=ids)['rows']
@@ -704,7 +718,7 @@ class RotatingDatabase(Database):
 
     def __init__(self, dbname='database', url='http://localhost:5984',
                  size=1000, archivename=None, seedname=None,
-                 timing=None, views=[]):
+                 timing=None, views=None):
         """
         dbaname:     base name for databases, active databases will have
                      timestamp appended
@@ -721,6 +735,7 @@ class RotatingDatabase(Database):
                      is that these views have been loaded into the seed
                      database via couchapp or someother process.
         """
+        views = views or []
         # Store the base database name
         self.basename = dbname
 
@@ -843,7 +858,8 @@ class RotatingDatabase(Database):
             self.seed_db.queueDelete(db_state)
         self.seed_db.commit()
 
-    def _find_dbs_in_state(self, state, options={}):
+    def _find_dbs_in_state(self, state, options=None):
+        options = options or {}
         # TODO: couchapp this, how to make sure that the app is deployed?
         find = {'map': "function(doc) {if(doc.rotate_state == '%s') {emit(doc.timestamp, doc._id);}}" % state}
         uri = '/%s/_temp_view' % self.seed_db.name
@@ -868,13 +884,14 @@ class RotatingDatabase(Database):
         # might need this after all....
         pass
 
-    def makeRequest(self, uri=None, data=None, type='GET', incoming_headers={},
+    def makeRequest(self, uri=None, data=None, type='GET', incoming_headers=None,
                     encode=True, decode=True, contentType=None,
                     cache=False, rotate=True):
         """
         Intercept the request, determine if I need to rotate, then carry out the
         request as normal.
         """
+        incoming_headers = incoming_headers or {}
         if self.timing and rotate:
 
             # check to see whether I should rotate the database before processing the request
@@ -883,7 +900,7 @@ class RotatingDatabase(Database):
             if datetime.now() > db_expires:
                 # save the current name for later
                 old_db = self.name
-                if len(self._queue) > 0:
+                if self._queue:
                     # data I've got queued up should go to the old database
                     # can't call self.commit() due to recursion
                     uri = '/%s/_bulk_docs/' % self.name
@@ -1103,7 +1120,7 @@ class CouchMonitor(object):
             repDocs = self.replicatorDB.allDocs(options={'include_docs': True})['rows']
 
         filteredDocs = self._filterReplicationDocs(repDocs, source, target)
-        if len(filteredDocs) == 0:
+        if not filteredDocs:
             return
         for doc in filteredDocs:
             self.replicatorDB.queueDelete(doc)
@@ -1136,9 +1153,9 @@ class CouchMonitor(object):
         couchInfo = self.checkCouchServerStatus(source, target, checkUpdateSeq)
 
         if couchInfo['status'] == 'error':
-            logging.info("Deleting the replicator documents from %s..." % source)
+            logging.info("Deleting the replicator documents from %s...", source)
             self.deleteReplicatorDocs(source, target)
-            logging.info("Setting the replication from %s ..." % source)
+            logging.info("Setting the replication from %s ...", source)
             self.couchServer.replicate(source, target, filter=filter,
                                        query_params=query_params,
                                        continuous=continuous)
@@ -1170,9 +1187,8 @@ class CouchMonitor(object):
 
             if replicationFlag:
                 return {'status': 'ok'}
-            else:
-                msg = "Replication stopped from %s to %s.\n" % (source, passwdStrippedTarget)
-                return {'status': 'error', 'error_message': msg}
+            msg = "Replication stopped from %s to %s.\n" % (source, passwdStrippedTarget)
+            return {'status': 'error', 'error_message': msg}
         except Exception as ex:
             msg = traceback.format_exc()
             logging.error(msg)
@@ -1192,15 +1208,11 @@ class CouchMonitor(object):
         if checkUpdateSeq:
             if updateNum == dbInfo["update_seq"] or updateNum > previousUpdateNum:
                 return True
-            else:
-                logging.warning("'update_seq for replication from %s to %s is falling behind", source, target)
-                return False
+            logging.warning("'update_seq for replication from %s to %s is falling behind", source, target)
+            return False
         else:
             if int(time.time()) - lastUpdate < secsUpdateOn:
                 return True
-            else:
-                logging.warning("Replication from %s to %s has not been updated for more than %d minutes", source,
-                                target,
-                                secsUpdateOn)
-                return False
-        return False
+            logging.warning("Replication from %s to %s has not been updated for more than %d minutes",
+                            source, target, secsUpdateOn)
+            return False

--- a/src/python/WMCore/Database/CMSCouch.py
+++ b/src/python/WMCore/Database/CMSCouch.py
@@ -83,7 +83,7 @@ class CouchDBRequests(JSONRequests):
     completeness, and talks to the CouchDB port
     """
 
-    def __init__(self, url='http://localhost:5984', usePYCurl=False, ckey=None, cert=None, capath=None):
+    def __init__(self, url='http://localhost:5984', usePYCurl=True, ckey=None, cert=None, capath=None):
         """
         Initialise requests
         """
@@ -909,7 +909,7 @@ class CouchServer(CouchDBRequests):
     More info http://wiki.apache.org/couchdb/HTTP_database_API
     """
 
-    def __init__(self, dburl='http://localhost:5984', usePYCurl=False, ckey=None, cert=None, capath=None):
+    def __init__(self, dburl='http://localhost:5984', usePYCurl=True, ckey=None, cert=None, capath=None):
         """
         Set up a connection to the CouchDB server
         """

--- a/src/python/WMCore/Services/PhEDEx/PhEDEx.py
+++ b/src/python/WMCore/Services/PhEDEx/PhEDEx.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from xml.dom.minidom import parseString
+
 from WMCore.Services.PhEDEx import XMLDrop
 from WMCore.Services.Service import Service
 

--- a/src/python/WMCore/Services/PhEDEx/PhEDEx.py
+++ b/src/python/WMCore/Services/PhEDEx/PhEDEx.py
@@ -1,10 +1,5 @@
 import json
 import logging
-try:
-    from urllib import urlencode
-except ImportError:
-    # PY3
-    from urllib.parse import urlencode
 from xml.dom.minidom import parseString
 from WMCore.Services.PhEDEx import XMLDrop
 from WMCore.Services.Service import Service
@@ -51,8 +46,6 @@ class PhEDEx(Service):
         if clearCache:
             self.clearCache(ifile, args, verb=verb)
 
-        if args:
-            args = urlencode(args, doseq=True)
         fobj = self.refreshCache(ifile, callname, args, verb=verb)
         result = fobj.read()
         fobj.close()

--- a/src/python/WMCore/Services/Requests.py
+++ b/src/python/WMCore/Services/Requests.py
@@ -21,6 +21,7 @@ import sys
 import tempfile
 import traceback
 import types
+
 try:
     from urllib import urlencode
 except ImportError:
@@ -48,14 +49,14 @@ except ImportError:
 try:
     from httplib2 import ServerNotFoundError
 except ImportError:
-    #Mock ServerNotFoundError since we don't want that WMCore depend on httplib2 using pycurl
+    # Mock ServerNotFoundError since we don't want that WMCore depend on httplib2 using pycurl
     class ServerNotFoundError(Exception):
         pass
-
 
 # Python3 compatibility
 if sys.version.startswith('3.'):  # PY3 Remove when python 3 transition complete
     basestring = str
+
 
 def check_server_url(srvurl):
     """Check given url for correctness"""
@@ -64,6 +65,7 @@ def check_server_url(srvurl):
         msg = "You must include "
         msg += "http(s):// in your server's address, %s doesn't" % srvurl
         raise ValueError(msg)
+
 
 class Requests(dict):
     """

--- a/src/python/WMCore/Services/Service.py
+++ b/src/python/WMCore/Services/Service.py
@@ -271,8 +271,10 @@ class Service(dict):
             # Get the data
             if not inputdata:
                 inputdata = self["inputdata"]
-            self['logger'].debug('getData: \n\turl: %s\n\tdata: %s' % \
-                                 (url, inputdata))
+            self['logger'].debug('getData: \n\turl: %s\n\tverb: %s\n\tincoming_headers: %s\n\tdata: %s',
+                                 url, verb, incoming_headers, inputdata)
+            #self['logger'].debug('getData: \n\turl: %s\n\tdata: %s' % \
+            #                     (url, inputdata))
             data, dummyStatus, dummyReason, from_cache = self["requests"].makeRequest(uri=url,
                                                                                       verb=verb,
                                                                                       data=inputdata,

--- a/src/python/WMCore/Services/Service.py
+++ b/src/python/WMCore/Services/Service.py
@@ -273,7 +273,7 @@ class Service(dict):
                 inputdata = self["inputdata"]
             self['logger'].debug('getData: \n\turl: %s\n\tverb: %s\n\tincoming_headers: %s\n\tdata: %s',
                                  url, verb, incoming_headers, inputdata)
-            #self['logger'].debug('getData: \n\turl: %s\n\tdata: %s' % \
+            # self['logger'].debug('getData: \n\turl: %s\n\tdata: %s' % \
             #                     (url, inputdata))
             data, dummyStatus, dummyReason, from_cache = self["requests"].makeRequest(uri=url,
                                                                                       verb=verb,

--- a/src/python/WMCore/Services/pycurl_manager.py
+++ b/src/python/WMCore/Services/pycurl_manager.py
@@ -46,6 +46,7 @@ import os
 import re
 import subprocess
 import sys
+
 try:
     from urllib import urlencode
 except ImportError:

--- a/test/python/WMCore_t/MicroService_t/MicroService_t.py
+++ b/test/python/WMCore_t/MicroService_t/MicroService_t.py
@@ -7,10 +7,11 @@ Author: Valentin Kuznetsov <vkuznet [AT] gmail [DOT] com>
 from __future__ import division, print_function
 
 import json
-import cherrypy
 import unittest
 
+import cherrypy
 from WMCore_t.MicroService_t import TestConfig
+
 from WMCore.MicroService.Service.RestApiHub import RestApiHub
 from WMCore.MicroService.Unified.Common import cert, ckey
 from WMCore.Services.pycurl_manager import RequestHandler
@@ -20,10 +21,11 @@ class ServiceManager(object):
     """
     Initialize ServiceManager class
     """
+
     def __init__(self, config=None):
         self.config = config
         self.state = None
-        self.appname = 'test' # keep it since it is used by XMLFormat(self.app.appname))
+        self.appname = 'test'  # keep it since it is used by XMLFormat(self.app.appname))
 
     def status(self, **kwargs):
         "Return current status about our service"
@@ -36,8 +38,10 @@ class ServiceManager(object):
         self.state = kwargs.get('state', None)
         return {'state': self.state}
 
+
 class MicroServiceTest(unittest.TestCase):
     "Unit test for MicroService module"
+
     def setUp(self):
         "Setup MicroService for testing"
         self.app = ServiceManager()
@@ -64,16 +68,16 @@ class MicroServiceTest(unittest.TestCase):
         headers = {'Content-type': 'application/json'}
         print("### post call %s params=%s headers=%s" % (self.url, params, headers))
         data = self.mgr.getdata(self.url, params=params, headers=headers, \
-                verb='POST', cert=cert(), ckey=ckey())
+                                verb='POST', cert=cert(), ckey=ckey(), encode=True, decode=True)
         print("### post call data %s" % data)
-        return json.loads(data)
+        return data
 
     def test_getState(self):
         "Test function for getting state of the MicroService"
         url = '%s/status' % self.url
         data = self.mgr.getdata(url, params={})
         state = "bla"
-        data = {"request":{"state": state}}
+        data = {"request": {"state": state}}
         self.postRequest(data)
         data = self.mgr.getdata(url, params={})
         data = json.loads(data)
@@ -81,6 +85,7 @@ class MicroServiceTest(unittest.TestCase):
         for row in data['result']:
             if 'state' in row:
                 self.assertEqual(state, row['state'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/WMCore_t/Services_t/Requests_t.py
+++ b/test/python/WMCore_t/Services_t/Requests_t.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#-*- coding: ISO-8859-1 -*-
+# -*- coding: ISO-8859-1 -*-
 '''n
 Created on Aug 6, 2009
 
@@ -7,6 +7,7 @@ Created on Aug 6, 2009
 '''
 from __future__ import print_function
 
+import json
 import os
 import shutil
 import tempfile
@@ -28,13 +29,12 @@ from WMQuality.WebTools.RESTServerSetup import DefaultConfig
 
 
 class testRequestExceptions(unittest.TestCase):
-
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
-        self.request_dict = {'req_cache_path' : self.tmp}
+        self.request_dict = {'req_cache_path': self.tmp}
 
     def tearDown(self):
-        shutil.rmtree(self.tmp, ignore_errors = True)
+        shutil.rmtree(self.tmp, ignore_errors=True)
 
     def test404Error(self):
         endp = "http://cmsweb.cern.ch"
@@ -45,22 +45,23 @@ class testRequestExceptions(unittest.TestCase):
         try:
             req.makeRequest(url, verb='GET')
         except HTTPException as e:
-            #print e
+            # print e
             self.assertEqual(e.status, 404)
 
     def test404Error_with_pycurl(self):
         endp = "http://cmsweb.cern.ch"
         url = "/thispagedoesntexist/"
         idict = dict(self.request_dict)
-        idict.update({'pycurl':1})
+        idict.update({'pycurl': 1})
         req = Requests.Requests(endp, idict)
         for v in ['GET', 'POST']:
             self.assertRaises(HTTPException, req.makeRequest, url, verb=v)
         try:
             req.makeRequest(url, verb='GET')
         except HTTPException as e:
-            #print e
+            # print e
             self.assertEqual(e.status, 404)
+
 
 # comment out so we don't ddos someone else's server
 #    def test408Error(self):
@@ -83,7 +84,7 @@ class testRepeatCalls(RESTBaseUnitTest):
         self.cache_path = tempfile.mkdtemp()
 
     def tearDown(self):
-        shutil.rmtree(self.cache_path, ignore_errors = True)
+        shutil.rmtree(self.cache_path, ignore_errors=True)
         self.rt.stop()
 
     def test10Calls(self):
@@ -94,7 +95,7 @@ class testRepeatCalls(RESTBaseUnitTest):
             time.sleep(i)
             print('test %s starting at %s' % (i, time.time()))
             try:
-                result = req.get('/', incoming_headers={'Cache-Control':'no-cache'})
+                result = req.get('/', incoming_headers={'Cache-Control': 'no-cache'})
                 self.assertEqual(False, result[3])
                 self.assertEqual(200, result[1])
             except HTTPException as he:
@@ -109,14 +110,14 @@ class testRepeatCalls(RESTBaseUnitTest):
 
     def test10Calls_with_pycurl(self):
         fail_count = 0
-        idict = {'req_cache_path': self.cache_path, 'pycurl':1}
+        idict = {'req_cache_path': self.cache_path, 'pycurl': 1}
         req = Requests.Requests(self.urlbase, idict)
 
         for i in range(0, 5):
             time.sleep(i)
             print('test %s starting at %s' % (i, time.time()))
             try:
-                result = req.get('/', incoming_headers={'Cache-Control':'no-cache'}, decode=False)
+                result = req.get('/', incoming_headers={'Cache-Control': 'no-cache'}, decode=False)
                 self.assertEqual(False, result[3])
                 self.assertEqual(200, result[1])
             except HTTPException as he:
@@ -134,7 +135,7 @@ class testRepeatCalls(RESTBaseUnitTest):
         import socket
         self.rt.stop()
         req = Requests.Requests(self.urlbase, {'req_cache_path': self.cache_path, 'pycurl': False})
-        headers = {'Cache-Control':'no-cache'}
+        headers = {'Cache-Control': 'no-cache'}
         self.assertRaises(socket.error, req.get, '/', incoming_headers=headers)
 
         # now restart server and hope we can connect
@@ -147,9 +148,9 @@ class testRepeatCalls(RESTBaseUnitTest):
         """Connections succeed after server down"""
         import pycurl
         self.rt.stop()
-        idict = {'req_cache_path': self.cache_path, 'pycurl':1}
+        idict = {'req_cache_path': self.cache_path, 'pycurl': 1}
         req = Requests.Requests(self.urlbase, idict)
-        headers = {'Cache-Control':'no-cache'}
+        headers = {'Cache-Control': 'no-cache'}
         self.assertRaises(pycurl.error, req.get, '/', incoming_headers=headers, decode=False)
 
         # now restart server and hope we can connect
@@ -158,20 +159,21 @@ class testRepeatCalls(RESTBaseUnitTest):
         self.assertEqual(result[3], False)
         self.assertEqual(result[1], 200)
 
+
 class testJSONRequests(unittest.TestCase):
     def setUp(self):
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
         tmp = self.testInit.generateWorkDir()
-        self.request = Requests.JSONRequests(idict={'req_cache_path' : tmp})
+        self.request = Requests.JSONRequests(idict={'req_cache_path': tmp})
 
     def roundTrip(self, data):
         encoded = self.request.encode(data)
-        #print encoded
-        #print encoded.__class__.__name__
+        # print encoded
+        # print encoded.__class__.__name__
         decoded = self.request.decode(encoded)
-        #print decoded.__class__.__name__
-        self.assertEqual( data, decoded )
+        # print decoded.__class__.__name__
+        self.assertEqual(data, decoded)
 
     def roundTripLax(self, data):
         encoded = self.request.encode(data)
@@ -181,7 +183,7 @@ class testJSONRequests(unittest.TestCase):
         for k in decoded.keys():
             assert k in datakeys
             datakeys.pop(datakeys.index(k))
-        #print 'the following keys were dropped\n\t',datakeys
+            # print 'the following keys were dropped\n\t',datakeys
 
     def testSet1(self):
         self.roundTrip(set([]))
@@ -223,7 +225,7 @@ class testJSONRequests(unittest.TestCase):
 
     def testMask4(self):
         self.roundTrip({'LastRun': None, 'FirstRun': None, 'LastEvent': None,
-        'FirstEvent': None, 'LastLumi': None, 'FirstLumi': None})
+                        'FirstEvent': None, 'LastLumi': None, 'FirstLumi': None})
 
     def testMask5(self):
         mymask = Mask()
@@ -245,8 +247,8 @@ class testJSONRequests(unittest.TestCase):
         self.assertEqual(req['host'], 'http://localhost:6666')
         self.assertEqual(req.additionalHeaders['Authorization'], 'Basic dXNlcm5hbWU6cEBzc3c6cmQ=')
 
-class TestRequests(unittest.TestCase):
 
+class TestRequests(unittest.TestCase):
     def testGetKeyCert(self):
         """test existance of key/cert"""
         proxy = os.environ.get('X509_USER_PROXY')
@@ -285,10 +287,10 @@ class TestRequests(unittest.TestCase):
         os.environ.pop('X509_HOST_KEY', None)
         os.environ.pop('X509_USER_CERT', None)
         os.environ.pop('X509_USER_KEY', None)
-        req = Requests.Requests('https://cmsweb.cern.ch', {'pycurl':1})
-        out = req.makeRequest('/phedex/datasvc/json/prod/groups')
+        req = Requests.Requests('https://cmsweb.cern.ch', {'pycurl': 1})
+        out = req.makeRequest('/phedex/datasvc/json/prod/groups', decoder=True)
         self.assertEqual(out[1], 200)
-        if  not isinstance(out[0], dict):
+        if not isinstance(json.loads(out[0]), dict):
             msg = 'wrong data type'
             raise Exception(msg)
         out = req.makeRequest('/auth/trouble', decoder=False)
@@ -306,7 +308,7 @@ class TestRequests(unittest.TestCase):
 
     def testSecureNoAuth_with_pycurl(self):
         """https with no client authentication"""
-        req = Requests.Requests('https://cmsweb.cern.ch', {'pycurl':1})
+        req = Requests.Requests('https://cmsweb.cern.ch', {'pycurl': 1})
         out = req.makeRequest('', decoder=False)
         self.assertEqual(out[1], 200)
         # we should get an html page in response
@@ -335,17 +337,18 @@ class TestRequests(unittest.TestCase):
         os.environ.pop('X509_HOST_KEY', None)
         os.environ.pop('X509_USER_CERT', None)
         os.environ.pop('X509_USER_KEY', None)
-        req = Requests.Requests('https://cmsweb.cern.ch:443', {'pycurl':1})
+        req = Requests.Requests('https://cmsweb.cern.ch:443', {'pycurl': 1})
         out = req.makeRequest('/auth/trouble', decoder=False)
         self.assertEqual(out[1], 200)
         self.assertNotEqual(out[0].find('passed basic validation'), -1)
 
     def testNoCache(self):
         """Cache disabled"""
-        req = Requests.Requests('https://cmssdt.cern.ch/SDT/', {'cachepath' : None})
+        req = Requests.Requests('https://cmssdt.cern.ch/SDT/', {'cachepath': None})
         out = req.makeRequest('/', decoder=False)
         self.assertEqual(out[3], False)
         self.assertTrue('html' in out[0])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #9359 
Superseeds https://github.com/dmwm/WMCore/pull/6360

#### Status
tested

#### Description
As the subject says, use pycurl library instead of httplib in any of the WMCore client Service APIs, including those interfacing with Couch, that have been previously missed.

Additional important changes are:
* integrated the `pycurl` module with the `Requests` one, such that the proper headers and encoding/decoding can be applied from the sub classes.
* consolidate HTTP requests setup for both httplib and pycurl library usage
* support compression algorithms `Accept-Encoding` in the pycurl module
* changed the signature of a few methods in the `pycurl` module

I have also executed some performance/concurrency tests using the `hey` tool and the pycurl version seems to be around 50% faster (GET requests). 
Workflow creation and assignment (POST requests) seems to be almost 50% slower though. But for this case we can't isolate WMCore from the other services (DBS/PhEDEx), so there might be some side effect there...

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
First attempt made 4 years ago, here: https://github.com/dmwm/WMCore/pull/6360
It now includes changes proposed in this PR: Now it includes https://github.com/dmwm/WMCore/pull/9386 

#### External dependencies / deployment changes
no
