### PR TITLE
Send CE information to CMS monitoring/Elasticsearch

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -531,7 +531,7 @@ class SimpleCondorPlugin(BasePlugin):
         ad['Rank'] = 0.0
         ad['TransferIn'] = False
 
-        ad['JobMachineAttrs'] = "GLIDEIN_CMSSite"
+        ad['JobMachineAttrs'] = "GLIDEIN_CMSSite,GLIDEIN_Gatekeeper"
         ad['JobAdInformationAttrs'] = ("JobStatus,QDate,EnteredCurrentStatus,JobStartDate,DESIRED_Sites,"
                                        "ExtDESIRED_Sites,WMAgent_JobID,MachineAttrGLIDEIN_CMSSite0")
 


### PR DESCRIPTION
Fixes #8355

#### Status
Ready

#### Description
Propagate CE name as: MachineAttrGLIDEIN_Gatekeeper0 in ElasticSearch

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
This is a follow-up of: #9352
