### PR TITLE
Make sure analytics data structure contains the skipped task name key

### DIFF
--- a/src/python/WMComponent/AnalyticsDataCollector/DataCollectAPI.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/DataCollectAPI.py
@@ -341,6 +341,7 @@ def convertToRequestCouchDoc(combinedRequests, fwjrInfo, finishedTasks,
                 doc['sites'] = tempData['sites']
                 if doc['skipped']:
                     for task in skippedInfoFromCouch[request]['tasks']:
+                        doc['tasks'].setdefault(task, {"skipped": {}})
                         doc['tasks'][task]["skipped"] = skippedInfoFromCouch[request]['tasks'][task]
 
             # TODO need to handle this correctly by task


### PR DESCRIPTION
Fixes #9362 

#### Status
ready

#### Description
I'm not sure whether it's expected to have a task name with skipped file but without any other metrics (pending/submitted/success/etc). Anyways, just make sure the task name key exists before we try to reference it.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
no

#### External dependencies / deployment changes
no
