### PR TITLE
Use pycurl library by default; urlencode PhEDEx body request

### DIFF
--- a/src/python/WMCore/Services/PhEDEx/PhEDEx.py
+++ b/src/python/WMCore/Services/PhEDEx/PhEDEx.py
@@ -1,7 +1,11 @@
 import json
 import logging
+try:
+    from urllib import urlencode
+except ImportError:
+    # PY3
+    from urllib.parse import urlencode
 from xml.dom.minidom import parseString
-
 from WMCore.Services.PhEDEx import XMLDrop
 from WMCore.Services.Service import Service
 
@@ -47,6 +51,8 @@ class PhEDEx(Service):
         if clearCache:
             self.clearCache(ifile, args, verb=verb)
 
+        if args:
+            args = urlencode(args, doseq=True)
         fobj = self.refreshCache(ifile, callname, args, verb=verb)
         result = fobj.read()
         fobj.close()

--- a/src/python/WMCore/Services/Requests.py
+++ b/src/python/WMCore/Services/Requests.py
@@ -74,7 +74,7 @@ class Requests(dict):
         if not idict:
             idict = {}
         dict.__init__(self, idict)
-        self.pycurl = idict.get('pycurl', None)
+        self.pycurl = idict.get('pycurl', True)
         self.capath = idict.get('capath', None)
         if self.pycurl:
             self.reqmgr = RequestHandler()
@@ -150,15 +150,14 @@ class Requests(dict):
         Wrapper around request helper functions.
         """
         if self.pycurl:
-            result = self.makeRequest_pycurl(uri, data, verb, incoming_headers,
-                                             encoder, decoder, contentType)
+            result = self.makeRequest_pycurl(uri, data, verb, incoming_headers, contentType)
         else:
             result = self.makeRequest_httplib(uri, data, verb, incoming_headers,
                                               encoder, decoder, contentType)
         return result
 
     def makeRequest_pycurl(self, uri=None, params={}, verb='GET',
-                           incoming_headers={}, encoder=True, decoder=True, contentType=None):
+                           incoming_headers={}, contentType=None):
         """
         Make HTTP(s) request via pycurl library. Stay complaint with
         makeRequest_httplib method.
@@ -176,7 +175,7 @@ class Requests(dict):
         headers.update(incoming_headers)
         url = self['host'] + uri
         response, data = self.reqmgr.request(url, params, headers, verb=verb,
-                                             ckey=ckey, cert=cert, capath=capath, decode=decoder)
+                                             ckey=ckey, cert=cert, capath=capath, decode=True)
         return data, response.status, response.reason, response.fromcache
 
     def makeRequest_httplib(self, uri=None, data={}, verb='GET',
@@ -235,12 +234,11 @@ class Requests(dict):
                 # Either the encoder is set to True or it's junk, so use
                 # self.encode
                 encoded_data = self.encode(data)
-            headers["Content-length"] = len(encoded_data)
         elif verb == 'GET' and data:
             # encode the data as a get string
             uri = "%s?%s" % (uri, urllib.urlencode(data, doseq=True))
 
-        headers["Content-length"] = str(len(encoded_data))
+        headers["Content-Length"] = str(len(encoded_data))
 
         # PY3 needed for compatibility because str under futurize is not a string. Can be just str in Py3 only
         # PY3 Don't let futurize change this
@@ -301,7 +299,7 @@ class Requests(dict):
         """
         encode data into some appropriate format, for now make it a string...
         """
-        return urllib.urlencode(data, doseq=1)
+        return urllib.urlencode(data, doseq=True)
 
     def decode(self, data):
         """

--- a/src/python/WMQuality/CherrypyTestInit.py
+++ b/src/python/WMQuality/CherrypyTestInit.py
@@ -4,7 +4,6 @@ import threading
 import traceback
 
 import cherrypy
-import cherrypy.process.wspbus as cherrybus
 
 
 def start(server):
@@ -24,29 +23,5 @@ def start(server):
 def stop(server):
     server.stop()
     server.setLastTest()
-    # there was a ton of racy failures in REST tools because of
-    # how much global state cherrypy has. this resets it
-
-    # Also, it sucks I had to copy/paste this from
-    # https://bitbucket.org/cherrypy/cherrypy/src/9720342ad159/cherrypy/__init__.py
-    # but reload() doesn't have the right semantics
-
-    cherrybus.bus = cherrybus.Bus()
-    cherrypy.engine = cherrybus.bus
-    # cherrypy.engine.timeout_monitor = cherrypy._TimeoutMonitor(cherrypy.engine)
-    # cherrypy.engine.timeout_monitor.subscribe()
-
-    cherrypy.engine.autoreload = cherrypy.process.plugins.Autoreloader(cherrypy.engine)
-    cherrypy.engine.autoreload.subscribe()
-
-    cherrypy.engine.thread_manager = cherrypy.process.plugins.ThreadManager(cherrypy.engine)
-    cherrypy.engine.thread_manager.subscribe()
-
-    cherrypy.engine.signal_handler = cherrypy.process.plugins.SignalHandler(cherrypy.engine)
-    cherrypy.engine.subscribe('log', cherrypy._buslog)
-
-    from cherrypy import _cpserver
-    cherrypy.server = _cpserver.Server()
-    cherrypy.server.subscribe()
-    cherrypy.checker = cherrypy._cpchecker.Checker()
-    cherrypy.engine.subscribe('start', cherrypy.checker)
+    cherrypy.engine.exit()
+    return

--- a/src/python/WMQuality/REST/RESTBaseUnitTestWithDBBackend.py
+++ b/src/python/WMQuality/REST/RESTBaseUnitTestWithDBBackend.py
@@ -1,12 +1,9 @@
 from __future__ import print_function
 import unittest
 import cherrypy
-import cherrypy.process.wspbus as cherrybus
 import logging
 import threading
 import os
-import traceback
-import time
 
 #decorator import for RESTServer setup
 from WMQuality.REST.ServerSetup import RESTMainTestServer
@@ -56,7 +53,7 @@ class RESTBaseUnitTestWithDBBackend(unittest.TestCase):
                         self.testInit.setupCouch(dbName)
 
 
-        logging.info("This is our config: %s" % self.config)
+        logging.info("RESTBaseUnitTestWithDBBackend configuration: %s" % self.config)
 
         self.initRoot = initRoot
         if initRoot:
@@ -68,6 +65,7 @@ class RESTBaseUnitTestWithDBBackend(unittest.TestCase):
             print("init root")
 
     def tearDown(self):
+        logging.info("RESTBaseUnitTestWithDBBackend executing tearDown")
         if self.initRoot:
             CherrypyTestInit.stop(self.server)
             self.test_authz_key = None

--- a/test/python/WMCore_t/ReqMgr_t/Service_t/ReqMgr_t.py
+++ b/test/python/WMCore_t/ReqMgr_t/Service_t/ReqMgr_t.py
@@ -10,7 +10,6 @@ from WMCore_t.ReqMgr_t.TestConfig import config
 
 from WMCore.REST.Test import fake_authz_headers
 from WMCore.ReqMgr.Auth import getWritePermission
-from WMCore.WMBase import getWMBASE
 from WMQuality.REST.RESTBaseUnitTestWithDBBackend import RESTBaseUnitTestWithDBBackend
 
 req_args = {"RequestType": "ReReco", "RequestStatus": None}
@@ -77,20 +76,19 @@ class ReqMgrTest(RESTBaseUnitTestWithDBBackend):
         #print "%s" % self.test_authz_key.data
         self.default_status_header = getAuthHeader(self.test_authz_key.data, DEFAULT_STATUS_PERMISSION)
 
-        requestPath = os.path.join(getWMBASE(), "test", "data", "ReqMgr", "requests", "DMWM")
-        rerecoFile = open(os.path.join(requestPath, "ReReco_RunBlockWhite.json"), 'r')
-
-        rerecoArgs = json.load(rerecoFile)
+        normPath = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', '..', '..', '..'))
+        rerecoPath = os.path.join(normPath, 'data/ReqMgr/requests/DMWM/ReReco_RunBlockWhite.json')
+        with open(rerecoPath) as jObj:
+            rerecoArgs = json.load(jObj)
         self.rerecoCreateArgs = rerecoArgs["createRequest"]
         self.rerecoCreateArgs["PrepID"] = "test_prepid"
-        self.rerecoCreateArgs["MCPileup"] = "/MCdata/pileup/RAW"
-        self.rerecoCreateArgs["DataPileup"] = "/Data/pileup/RAW"
         self.rerecoAssignArgs = rerecoArgs["assignRequest"]
         # overwrite rereco args
         self.rerecoAssignArgs["AcquisitionEra"] = "test_aqc"
 
-        lheFile = open(os.path.join(requestPath, "TaskChain_Data.json"), 'r')
-        lheArgs = json.load(lheFile)
+        taskChainPath = os.path.join(normPath, 'data/ReqMgr/requests/DMWM/TaskChain_InclParents.json')
+        with open(taskChainPath) as jObj:
+            lheArgs = json.load(jObj)
         self.lheStep0CreateArgs = lheArgs["createRequest"]
         self.lheStep0AssignArgs = lheArgs["assignRequest"]
         self.lheStep0AssignArgs["AcquisitionEra"] = "test_aqc"

--- a/test/python/WMCore_t/Services_t/CRIC_t/CRIC_t.py
+++ b/test/python/WMCore_t/Services_t/CRIC_t/CRIC_t.py
@@ -35,13 +35,13 @@ class CRICTest(EmulatedUnitTestCase):
         self.assertEqual(self.myCRIC['cacheduration'], 1)
         self.assertEqual(self.myCRIC['accept_type'], 'application/json')
         self.assertEqual(self.myCRIC['content_type'], 'application/json')
-        self.assertEqual(self.myCRIC['requests'].pycurl, None)
+        self.assertEqual(self.myCRIC['requests'].pycurl, True)
 
-        newParams = {"cacheduration": 100, "pycurl": True}
+        newParams = {"cacheduration": 100, "pycurl": False}
         cric = CRIC(url='https://BLAH.cern.ch/', configDict=newParams)
         self.assertEqual(cric['endpoint'], 'https://BLAH.cern.ch/')
         self.assertEqual(cric['cacheduration'], newParams['cacheduration'])
-        self.assertTrue(cric['requests'].pycurl)
+        self.assertEqual(cric['requests'].pycurl, False)
 
     @attr('integration')
     def testWhoAmI(self):

--- a/test/python/WMCore_t/Services_t/ReqMgr_t/ReqMgr_t.py
+++ b/test/python/WMCore_t/Services_t/ReqMgr_t/ReqMgr_t.py
@@ -11,7 +11,6 @@ from WMCore_t.ReqMgr_t.TestConfig import config
 from WMCore.REST.Test import fake_authz_headers
 from WMCore.ReqMgr.Auth import getWritePermission
 from WMCore.Services.ReqMgr.ReqMgr import ReqMgr
-from WMCore.WMBase import getWMBASE
 from WMQuality.REST.RESTBaseUnitTestWithDBBackend import RESTBaseUnitTestWithDBBackend
 
 req_args = {"RequestType": "ReReco", "RequestStatus": None}
@@ -79,9 +78,10 @@ class ReqMgrTest(RESTBaseUnitTestWithDBBackend):
 
         self.setFakeDN()
 
-        requestPath = os.path.join(getWMBASE(), "test", "data", "ReqMgr", "requests", "DMWM")
-        with open(os.path.join(requestPath, "ReReco_RunBlockWhite.json")) as fo:
-            rerecoArgs = json.load(fo)
+        normPath = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', '..', '..', '..'))
+        rerecoPath = os.path.join(normPath, 'data/ReqMgr/requests/DMWM/ReReco_RunBlockWhite.json')
+        with open(rerecoPath) as jObj:
+            rerecoArgs = json.load(jObj)
 
         self.rerecoCreateArgs = rerecoArgs["createRequest"]
         self.rerecoAssignArgs = rerecoArgs["assignRequest"]

--- a/test/python/WMCore_t/Services_t/Requests_t.py
+++ b/test/python/WMCore_t/Services_t/Requests_t.py
@@ -133,7 +133,7 @@ class testRepeatCalls(RESTBaseUnitTest):
         """Connections succeed after server down"""
         import socket
         self.rt.stop()
-        req = Requests.Requests(self.urlbase, {'req_cache_path': self.cache_path})
+        req = Requests.Requests(self.urlbase, {'req_cache_path': self.cache_path, 'pycurl': False})
         headers = {'Cache-Control':'no-cache'}
         self.assertRaises(socket.error, req.get, '/', incoming_headers=headers)
 
@@ -342,7 +342,7 @@ class TestRequests(unittest.TestCase):
 
     def testNoCache(self):
         """Cache disabled"""
-        req = Requests.Requests('http://cmssw.cvs.cern.ch', {'cachepath' : None})
+        req = Requests.Requests('https://cmssdt.cern.ch/SDT/', {'cachepath' : None})
         out = req.makeRequest('/', decoder=False)
         self.assertEqual(out[3], False)
         self.assertTrue('html' in out[0])

--- a/test/python/WMCore_t/Services_t/Service_t.py
+++ b/test/python/WMCore_t/Services_t/Service_t.py
@@ -247,7 +247,7 @@ class ServiceTest(unittest.TestCase):
 
     def testUsingStaleCache(self):
         myConfig = {'logger': self.logger,
-                'endpoint': 'http://cmssw.cvs.cern.ch',
+                'endpoint': 'https://cmssdt.cern.ch/SDT/',
                 'cacheduration': 0.0005,  # cache file lasts 1.8 secs
                 'timeout': 10,
                 'usestalecache': True,


### PR DESCRIPTION
Fixes #9359
Superseeds #9360
Superseeds https://github.com/dmwm/WMCore/pull/6360

#### Status
ready

#### Description
Summary of changes as follows:
* for any sub-class of `WMCore/Services/Requests` (or `WMCore/Services/Services`), use by default the `pycurl` library instead of httplib.
  * don't encode the body data again within the pycurl module
* set the `Content-Length` HTTP header for PUT/POST requests within the pycurl module
* given that the PhEDEx service class relies on `Requests` instead of `JSONRequests`, use `urlencode` to encode the body data (if any)

The pycurl module is still missing a better integration with the Services/Requests super class though, as proposed in this PR: https://github.com/dmwm/WMCore/pull/9360

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Old and initial proposed fix in: https://github.com/dmwm/WMCore/pull/6360

#### External dependencies / deployment changes
no
