### PR TITLE
Increase the wmbs_file_details/lfn column length to 1250

### DIFF
--- a/src/python/WMCore/WMBS/CreateWMBSBase.py
+++ b/src/python/WMCore/WMBS/CreateWMBSBase.py
@@ -75,7 +75,7 @@ class CreateWMBSBase(DBCreator):
         self.create["02wmbs_file_details"] = \
             """CREATE TABLE wmbs_file_details (
                id           INTEGER      PRIMARY KEY AUTO_INCREMENT,
-               lfn          VARCHAR(700) NOT NULL,
+               lfn          VARCHAR(1250) NOT NULL,
                filesize     BIGINT,
                events       BIGINT UNSIGNED,
                first_event  BIGINT       UNSIGNED NOT NULL DEFAULT 0,

--- a/src/python/WMCore/WMBS/Oracle/Create.py
+++ b/src/python/WMCore/WMBS/Oracle/Create.py
@@ -71,7 +71,7 @@ class Create(CreateWMBSBase):
         self.create["02wmbs_file_details"] = \
             """CREATE TABLE wmbs_file_details (
                  id          INTEGER NOT NULL,
-                 lfn         VARCHAR(700) NOT NULL,
+                 lfn         VARCHAR(1250) NOT NULL,
                  filesize    INTEGER,
                  events      INTEGER,
                  first_event INTEGER      DEFAULT 0,


### PR DESCRIPTION
Fixes #9366 

#### Status
ready

#### Description
Given that logArchive LFNs are prefixed by the task name (and its whole chain), we might have files with more than the current 700 chars. Given that the task path has been recently increased to 1250 chars, I'm setting the `LFN` column to the same length.

#### Is it backward compatible (if not, which system it affects?)
no (db schema changes)

#### Related PRs
Somehow related to: https://github.com/dmwm/WMCore/pull/9243

#### External dependencies / deployment changes
Yes, we need to update the database schema on the agents already deployed. Or deploy the agent from scratch (and using a new RPM).
