### PR TITLE
Added pycurl to the list of extension-pkg-whitelist in pylintrc

### DIFF
--- a/standards/.pylintrc
+++ b/standards/.pylintrc
@@ -8,6 +8,11 @@ ignore=CVS
 # Pickle collected data for later comparisons.
 persistent=yes
 
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=pycurl
+
 # Tells wether to display a full report or only the messages
 reports=yes
 


### PR DESCRIPTION
Fixes #9368 

#### Status
ready

#### Description
Allow pylint to also inspect on pycurl objects.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs

#### External dependencies / deployment changes

