### PR TITLE
Make data location update task more verbose

### DIFF
--- a/src/python/WMCore/GlobalWorkQueue/CherryPyThreads/LocationUpdateTask.py
+++ b/src/python/WMCore/GlobalWorkQueue/CherryPyThreads/LocationUpdateTask.py
@@ -1,5 +1,5 @@
 from __future__ import (division, print_function)
-
+from time import time
 from WMCore.REST.CherryPyPeriodicTask import CherryPyPeriodicTask
 from WMCore.WorkQueue.WorkQueue import globalQueue
 
@@ -19,8 +19,11 @@ class LocationUpdateTask(CherryPyPeriodicTask):
         """
         gather active data statistics
         """
-
+        tStart = time()
         globalQ = globalQueue(**config.queueParams)
-        globalQ.updateLocationInfo()
+        res = globalQ.updateLocationInfo()
+        tEnd = time()
+        self.logger.info("LocationUpdateTask took %.3f secs and updated %d non-unique elements",
+                         tEnd - tStart, res)
 
         return

--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -725,8 +725,9 @@ class WorkQueue(WorkQueueBase):
         """
         Update locations info for elements.
         """
+        self.logger.info('Executing data location update...')
         if not self.backend.isAvailable():
-            self.logger.info('Backend busy or down: skipping location update')
+            self.logger.warning('Backend busy or down: skipping location update')
             return 0
         result = self.dataLocationMapper()
         self.backend.recordTaskActivity('location_refresh')


### PR DESCRIPTION
Fixes #9375 

#### Status
ready

#### Description
Honestly, I'm not sure it fixes the problem reported in the GH issue, but what goes in here is:
* fixes data location update for multiple parent blocks within the same GQE
* fixes data location update for multiple pileup datasets within the same GQE
* remove `fullResync` flag; full resync will be the standard operation mode now (with a polling cycle of 6 hours though)
* remove `datasetSearch` flag (given that we automatically find out whether it's a dataset or block)
* last but not least, make things slightly more verbose

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
Yes, deployment changes here: https://github.com/dmwm/deployment/pull/807
