### PR TITLE
update Rucio urls to testbed

### DIFF
--- a/deploy/WMAgent.testbed
+++ b/deploy/WMAgent.testbed
@@ -25,4 +25,4 @@ WMARCHIVE_URL=https://cmsweb-testbed.cern.ch/wmarchive
 AMQ_CREDENTIALS=
 RUCIO_ACCOUNT="wmagent_testing"
 RUCIO_HOST=http://cms-rucio-testbed.cern.ch
-RUCIO_AUTH=https://cms-rucio-tb-authz.cern.ch
+RUCIO_AUTH=https://cms-rucio-auth-testbed.cern.ch

--- a/test/deploy/WMAgent_unittest.secrets
+++ b/test/deploy/WMAgent_unittest.secrets
@@ -6,4 +6,4 @@ COUCH_PORT=6994
 COUCH_HOST=0.0.0.0
 RUCIO_ACCOUNT="wmagent_testing"
 RUCIO_HOST=http://cms-rucio-testbed.cern.ch
-RUCIO_AUTH=https://cms-rucio-tb-authz.cern.ch
+RUCIO_AUTH=https://cms-rucio-auth-testbed.cern.ch

--- a/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
+++ b/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
@@ -34,8 +34,8 @@ class RucioTest(EmulatedUnitTestCase):
         self.creds = {"client_cert": os.getenv("X509_USER_CERT", "Unknown"),
                       "client_key": os.getenv("X509_USER_KEY", "Unknown")}
 
-        self.defaultArgs = {"host": 'http://cms-rucio-dev.cern.ch',
-                            "auth_host": 'https://cms-rucio-auth-dev.cern.ch',
+        self.defaultArgs = {"host": 'http://cms-rucio-testbed.cern.ch',
+                            "auth_host": 'https://cms-rucio-auth-testbed.cern.ch',
                             "auth_type": "x509", "account": self.acct,
                             "ca_cert": False, "timeout": 30, "request_retries": 3,
                             "creds": self.creds}
@@ -74,8 +74,8 @@ class RucioTest(EmulatedUnitTestCase):
         self.assertTrue(getattr(self.myRucio.cli, "user_agent").startswith("wmcore-client/"))
         self.assertTrue(getattr(self.client, "user_agent").startswith("rucio-clients/"))
 
-        newParams = {"host": 'http://cms-rucio-dev.cern.ch',
-                     "auth_host": 'https://cms-rucio-auth-dev.cern.ch',
+        newParams = {"host": 'http://cms-rucio-testbed.cern.ch',
+                     "auth_host": 'https://cms-rucio-auth-testbed.cern.ch',
                      "auth_type": "x509", "account": self.acct,
                      "ca_cert": False, "timeout": 5, "phedexCompatible": False}
         newKeys = newParams.keys()


### PR DESCRIPTION
#### Status
ready

#### Description
As discussed with Eric, the testbed instance should be more stable than the dev one by now.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
Yes, deployment changes: https://github.com/dmwm/deployment/pull/807
