### PR TITLE
Consider RunWhitelist/RunBlacklist and runs from LumiList for MSTransferor

### DIFF
--- a/src/python/WMCore/MicroService/Unified/MSTransferor.py
+++ b/src/python/WMCore/MicroService/Unified/MSTransferor.py
@@ -161,6 +161,9 @@ class MSTransferor(MSCore):
                 else:
                     subLevel = "block"
                     data = {dataIn['name']: blocks}
+                if not nodes and not blocks:
+                    # no valid files in any blocks, let it go and fail at the workqueue level
+                    return success, response
                 subscription = PhEDExSubscription(datasetPathList=dataIn['name'],
                                                   nodeList=nodes,
                                                   group=self.msConfig['group'],
@@ -238,7 +241,10 @@ class MSTransferor(MSCore):
             # YES, parents go together with the primary data
             if wflow.getParentDataset():
                 blockList.extend(wflow.getParentBlocks().keys())
-            # FIXME: use whatever algorithm Unified uses to distribute blocks
+            if not blockList:
+                # use empty nodes to avoid making a dataset level subscription
+                self.logger.warning("  found 0 primary blocks to be transferred, just move on...")
+                nodes = []
             self.logger.info("Placing %d blocks for dataset: %s at %s", len(blockList), dsetName, nodes)
             self.blockCounter += len(blockList)
             yield nodes, blockList


### PR DESCRIPTION
Fixes #9371 

#### Status
ready

#### Description
Complete the data discovery loop, so in addition to blocks white/black list, it now also supports runs white/black list and a lumi list. In addition to that:
* use PhEDEx `blockreplicas` API to keep track of which blocks have at least one single replica (equivalent to checking whether a block has at least 1 valid file)
* make sure only valid blocks will be requested to be transferred (for primary, secondary and parent)
* skip input data placement for `StoreResults` workflows
* added two DBS APIs; one to find blocks given a run number or run list; the second which retrieves all files and their lumi sections within a block (used for the LumiList check)
* bypass workflows with only invalid blocks as input (will fail at the next stage, in global workqueue)

Note that data discovery for workflows with either run or lumi list is executed in a sequential mode. Different than the rest of the data discovery logic, where many workflows (100) are performed concurrently. If performance becomes an issue, we need to revisit this case.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Yes, #9330 

#### External dependencies / deployment changes
none
