### PR TITLE
Use a clean environment when running voms-proxy commands from AgentStatusPoller

### DIFF
--- a/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
+++ b/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
@@ -42,7 +42,7 @@ class AgentStatusPoller(BaseWorkerThread):
         self.agentInfo = initAgentInfo(self.config)
         self.summaryLevel = config.AnalyticsDataCollector.summaryLevel
 
-        proxyArgs = {'logger': logging.getLogger()}
+        proxyArgs = {'logger': logging.getLogger(), 'cleanEnvironment': True}
         self.proxy = Proxy(proxyArgs)
         self.proxyFile = self.proxy.getProxyFilename()  # X509_USER_PROXY
         self.userCertFile = self.proxy.getUserCertFilename()  # X509_USER_CERT


### PR DESCRIPTION
Fixes #9379 

#### Status
ready

#### Description
Make sure we use a clean environment when running voms-proxy-info commands from the AgentStatusWatcher component.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
