### PR TITLE
Enable pycurl by default also for CouchDB related modules

### DIFF
--- a/src/python/WMCore/Cache/WMConfigCache.py
+++ b/src/python/WMCore/Cache/WMConfigCache.py
@@ -85,7 +85,7 @@ class ConfigCache(WMObject):
     The class that handles the upload and download of configCache
     artifacts from Couch
     """
-    def __init__(self, dbURL, couchDBName = None, id = None, rev = None, usePYCurl = False,
+    def __init__(self, dbURL, couchDBName = None, id = None, rev = None, usePYCurl = True,
                  ckey = None, cert = None, capath = None, detail = True):
         super(ConfigCache, self).__init__()
         self.dbname = couchDBName

--- a/src/python/WMCore/Database/CMSCouch.py
+++ b/src/python/WMCore/Database/CMSCouch.py
@@ -83,7 +83,7 @@ class CouchDBRequests(JSONRequests):
     completeness, and talks to the CouchDB port
     """
 
-    def __init__(self, url='http://localhost:5984', usePYCurl=False, ckey=None, cert=None, capath=None):
+    def __init__(self, url='http://localhost:5984', usePYCurl=True, ckey=None, cert=None, capath=None):
         """
         Initialise requests
         """
@@ -909,7 +909,7 @@ class CouchServer(CouchDBRequests):
     More info http://wiki.apache.org/couchdb/HTTP_database_API
     """
 
-    def __init__(self, dburl='http://localhost:5984', usePYCurl=False, ckey=None, cert=None, capath=None):
+    def __init__(self, dburl='http://localhost:5984', usePYCurl=True, ckey=None, cert=None, capath=None):
         """
         Set up a connection to the CouchDB server
         """


### PR DESCRIPTION
Fixes #9359 

#### Status
not-tested

#### Description
There were these two modules that were explicitly setting `pycurl` to False, thus avoid the default value set in the Requests.py module.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Complement to https://github.com/dmwm/WMCore/pull/9365

#### External dependencies / deployment changes
none
