### PR TITLE
Data location update through DBS has to return a dict. not tuple

### DIFF
--- a/src/python/WMCore/WorkQueue/DataLocationMapper.py
+++ b/src/python/WMCore/WorkQueue/DataLocationMapper.py
@@ -65,7 +65,7 @@ class DataLocationMapper(object):
         # the same object is not shared amongst multiple threads
         self.dbses = {}
 
-    def __call__(self, dataItems, dbses=None):
+    def __call__(self, dataItems):
         result = {}
 
         dataByDbs = self.organiseByDbs(dataItems)
@@ -101,7 +101,7 @@ class DataLocationMapper(object):
         elif self.params['locationFrom'] == 'subscription':
             self.logger.info("Fetching subscription data from PhEDEx")
             # subscription api doesn't support partial update
-            result = self.phedex.getSubscriptionMapping(*dataItems), True
+            result = self.phedex.getSubscriptionMapping(*dataItems)
         elif self.params['locationFrom'] == 'location':
             args = {}
             if not self.params['incompleteBlocks']:
@@ -154,7 +154,7 @@ class DataLocationMapper(object):
             psns.update(self.cric.PNNstoPSNs(nodes))
             result[name] = list(psns)
 
-        return result, True  # partial dbs updates not supported
+        return result
 
     def organiseByDbs(self, dataItems):
         """Sort items by dbs instances - return dict with DBSReader as key & data items as values"""


### PR DESCRIPTION
Fixes #9391 

#### Status
not-tested

#### Description
With the changes made here:
https://github.com/dmwm/WMCore/pull/9376

we got rid of the fullResync/non-fullResync thing, but I missed these two places that were still returning a tuple when a dictionary is expected.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Complement to https://github.com/dmwm/WMCore/pull/9376

#### External dependencies / deployment changes
Nothing, but those 80 StoreResult workflows sitting in `acquired` status, need attention and a valid input data location set. I'm working on a script to get those updated.