### PR TITLE
PhEDEx group usage and Rucio account usage wrapper APIs

### DIFF
--- a/src/python/WMCore/Services/PhEDEx/PhEDEx.py
+++ b/src/python/WMCore/Services/PhEDEx/PhEDEx.py
@@ -452,3 +452,18 @@ class PhEDEx(Service):
             blockNodes[blockInfo['name']] = list(nodes)
 
         return blockNodes
+
+    def getGroupUsage(self, **kwargs):
+        """
+        _getGroupUsage_
+
+        Get storage statistics node per group, like data already
+        stored and data subscribed
+        :param kwargs: accepts the optional parameters, as defined by PhEDEx:
+            node    node name, could be multiple
+            se      storage element name, could be multiple
+            group   group name, could be multiple
+        :return: a dictionary if `json` response type is defined, otherwise it's XML
+        """
+        callname = 'groupusage'
+        return self._getResult(callname, clearCache=True, args=kwargs, verb="GET")

--- a/src/python/WMCore/Services/Rucio/Rucio.py
+++ b/src/python/WMCore/Services/Rucio/Rucio.py
@@ -10,7 +10,8 @@ from __future__ import division, print_function, absolute_import
 import logging
 
 from rucio.client import Client
-from rucio.common.exception import AccountNotFound, DataIdentifierNotFound
+from rucio.common.exception import AccountNotFound, DataIdentifierNotFound,\
+    AccessDenied
 
 from WMCore.WMException import WMException
 
@@ -90,11 +91,29 @@ class Rucio(object):
         Gets information about a specific account
         :return: a dict with the account information. None in case of failure
         """
+        res = None
         try:
             res = self.cli.get_account(acct)
-        except AccountNotFound as ex:
+        except (AccountNotFound, AccessDenied) as ex:
             self.logger.error("Failed to get account information from Rucio. Error: %s", str(ex))
-            res = None
+        return res
+
+    def getAccountUsage(self, acct, rse=None):
+        """
+        _getAccountUsage_
+
+        Provided an account name, gets the storage usage for it against
+        a given RSE (or all RSEs)
+        :param acct: a string with the rucio account name
+        :param rse: an optional string with the RSE name
+        :return: a list of dictionaries with the account usage information.
+          None in case of failure
+        """
+        res = None
+        try:
+            res = list(self.cli.get_account_usage(acct, rse=rse))
+        except (AccountNotFound, AccessDenied) as ex:
+            self.logger.error("Failed to get account usage information from Rucio. Error: %s", str(ex))
         return res
 
     def getBlocksInContainer(self, container, scope='cms'):

--- a/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
+++ b/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
@@ -100,6 +100,19 @@ class RucioTest(EmulatedUnitTestCase):
         self.assertTrue({"status", "account", "account_type"}.issubset(set(res2.keys())))
         self.assertTrue({self.acct, "ACTIVE", "USER"}.issubset(set(res2.values())))
 
+    def testGetAccountUsage(self):
+        """
+        Test whether we can fetch data about a specific rucio account
+        """
+        res = list(self.client.get_account_usage(self.acct))
+        res2 = self.myRucio.getAccountUsage(self.acct)
+        self.assertEqual(res, [])
+        self.assertEqual(res, res2)
+
+        # now test against an account that either does not exist or that we cannot access
+        res = self.myRucio.getAccountUsage("admin")
+        self.assertIsNone(res)
+
     # @attr('integration')
     def testWhoAmI(self):
         """


### PR DESCRIPTION
Fixes #9415 

#### Status
not-tested

#### Description
Created wrapper API to talk to the PhEDEx `groupusage`, such that we can retrieve the amount of data subscribed at a given PNN (`dest_bytes`) and compare with the amount of data already transferred/archived (`node_bytes`). No quotas are available through this API though.

Created a similar wrraper API for Rucio `get_account_usage`, which reports the account quota (`bytes_limit`) and the space remaining (`bytes_remaining`) at a given PNN (here called RSE).

A Rucio account has basically the same meaning as of a PhEDEx group (for this purpose, at least).

Example of response for the Rucio call:
```
>>> pprint(list(client.get_account_usage("transfer_ops")))
[{u'bytes': 94216814068955,
  u'bytes_limit': 1000000000000000,
  u'bytes_remaining': 905783185931045,
  u'files': 42322,
  u'rse': u'T3_US_NERSC',
  u'rse_id': u'1cb4cc86c6674c17b20463fa36c4aa9e'},
 {u'bytes': 7080039001511,
  u'bytes_limit': 10000000000000,
  u'bytes_remaining': 2919960998489,
  u'files': 10857,
  u'rse': u'T1_DE_KIT_Disk_Test',
  u'rse_id': u'dc967804cd6a407a8603b54ddc73adf7'},
```

example of response for the PhEDEx call:
```
{u'phedex': {u'call_time': 0.02239,
             u'instance': u'prod',
             u'node': [{u'group': [{u'dest_bytes': 381473176240784,
                                    u'dest_files': 82640,
                                    u'id': 18,
                                    u'name': u'DataOps',
                                    u'node_bytes': 381473156906157,
                                    u'node_files': 82638}],
                        u'id': 33,
                        u'name': u'T2_US_Florida',
                        u'se': u'cmsio.rc.ufl.edu'},
                       {u'group': [{u'dest_bytes': 1277544063805,
                                    u'dest_files': 60,
                                    u'id': 18,
                                    u'name': u'DataOps',
                                    u'node_bytes': 1162065730449,
                                    u'node_files': 56}],
                        u'id': 32,
                        u'name': u'T2_EE_Estonia',
                        u'se': u'ganymede.hep.kbfi.ee'},
```

#### Is it backward compatible (if not, which system it affects?)
no, it's a new stuff!

#### Related PRs
none

#### External dependencies / deployment changes
none
