### PR TITLE
Don.t crash DBS3Upload on wmstats connection time out

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
@@ -224,7 +224,7 @@ class DBSUploadPoller(BaseWorkerThread):
 
         Set up the processing pool for work
         """
-        if len(self.pool) > 0:
+        if self.pool:
             # Then something already exists.  Continue
             return
 
@@ -285,13 +285,13 @@ class DBSUploadPoller(BaseWorkerThread):
         self.workResult = None
         return
 
-    def terminate(self, params):
+    def terminate(self, parameters):
         """
         Do one more pass, then terminate
 
         """
         logging.debug("terminating. doing one more pass before we die")
-        self.algorithm(params)
+        self.algorithm(parameters)
 
     @timeFunction
     def algorithm(self, parameters=None):
@@ -344,7 +344,7 @@ class DBSUploadPoller(BaseWorkerThread):
             reason = getattr(ex, 'reason', '')
             msg = 'Failed to fetch parentage map from WMStats, skipping this cycle. '
             msg += 'Exception: %s. Reason: %s. ' % (type(ex).__name__, reason)
-            if 'Service Unavailable' in reason or 'Proxy Error' in reason or\
+            if 'Service Unavailable' in reason or 'Proxy Error' in reason or \
                             'Error reading from remote server' in reason:
                 pass
             elif 'Connection refused' in str(ex):
@@ -461,8 +461,7 @@ class DBSUploadPoller(BaseWorkerThread):
 
                 files = fileDict.get(location)
 
-                if len(files) > 0:
-
+                if files:
                     currentBlock = self.getBlock(files[0], location, True)
                     currentBlock.setAcquisitionEra(era=dspInfo['AcquisitionEra'])
                     currentBlock.setProcessingVer(procVer=dspInfo['ProcessingVer'])
@@ -620,14 +619,14 @@ class DBSUploadPoller(BaseWorkerThread):
                 createInDBSBuffer.append(block)
 
         # First handle new and updated blocks
-        if len(createInDBSBuffer) > 0 or len(updateInDBSBuffer) > 0:
+        if createInDBSBuffer or updateInDBSBuffer:
             try:
                 myThread.transaction.begin()
-                if len(createInDBSBuffer) > 0:
+                if createInDBSBuffer:
                     self.createBlocksDAO.execute(blocks=createInDBSBuffer,
                                                  conn=myThread.transaction.conn,
                                                  transaction=True)
-                if len(updateInDBSBuffer) > 0:
+                if updateInDBSBuffer:
                     self.updateBlocksDAO.execute(blocks=updateInDBSBuffer,
                                                  conn=myThread.transaction.conn,
                                                  transaction=True)
@@ -651,7 +650,7 @@ class DBSUploadPoller(BaseWorkerThread):
             self.blockCache.get(block.getName()).inBuff = True
 
         # Record new file/block associations in DBSBuffer.
-        if len(self.filesToUpdate) > 0:
+        if self.filesToUpdate:
             try:
                 myThread.transaction.begin()
                 self.setBlockFilesDAO.execute(binds=self.filesToUpdate,
@@ -676,12 +675,12 @@ class DBSUploadPoller(BaseWorkerThread):
             return
 
         # Build the pool if it was closed
-        if len(self.pool) == 0:
+        if not self.pool:
             self.setupPool()
 
         # Finally upload blocks to DBS.
         for block in createInDBS:
-            if len(block.files) < 1:
+            if not block.files:
                 # What are we doing?
                 logging.debug("Skipping empty block")
                 continue
@@ -770,7 +769,7 @@ class DBSUploadPoller(BaseWorkerThread):
                 # Continue to the next block
                 # Block will remain in pending status until it is transferred
 
-        if len(loadedBlocks) > 0:
+        if loadedBlocks:
             try:
                 myThread.transaction.begin()
                 self.updateFilesDAO.execute(blocks=loadedBlocks, status="InDBS",
@@ -811,7 +810,7 @@ class DBSUploadPoller(BaseWorkerThread):
             del self.blockCache[name]
 
         # Clean up the pool so we don't have stuff waiting around
-        if len(self.pool) > 0:
+        if self.pool:
             self.close()
 
         # And we're done
@@ -844,7 +843,7 @@ class DBSUploadPoller(BaseWorkerThread):
                 logging.exception(msg)
 
         # Update the status of those blocks that were truly inserted
-        if len(blocksUploaded) > 0:
+        if blocksUploaded:
             try:
                 myThread.transaction.begin()
                 self.updateBlocksDAO.execute(blocks=blocksUploaded,

--- a/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
@@ -343,12 +343,15 @@ class DBSUploadPoller(BaseWorkerThread):
         except Exception as ex:
             reason = getattr(ex, 'reason', '')
             msg = 'Failed to fetch parentage map from WMStats, skipping this cycle. '
+            msg += 'Exception: %s. Reason: %s. ' % (type(ex).__name__, reason)
             if 'Service Unavailable' in reason or 'Proxy Error' in reason or\
                             'Error reading from remote server' in reason:
-                msg += 'Error: %s' % reason
+                pass
             elif 'Connection refused' in str(ex):
                 msg += 'Error: %s' % str(ex)
             elif 'The read operation timed out' in str(ex):
+                msg += 'Error: %s' % str(ex)
+            elif 'Connection timed out' in str(ex):
                 msg += 'Error: %s' % str(ex)
             else:
                 msg = "Unknown failure while fetching parentage map from WMStats. Error: %s" % str(ex)


### PR DESCRIPTION
Fixes #9396 

#### Status
ready

#### Description
Catch a `Connection timed out` error in DBS3upload and instead of crashing the component, skip the thread cycle and retry again in the next one. When it fails, a LogDB record is made.
In addition to that, also log the exception type such that we can revisit it and replace the generic except by something more specific.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
