### PR TITLE
No need to insert output files into WMBS if the job failed

### DIFF
--- a/src/python/WMComponent/JobAccountant/AccountantWorker.py
+++ b/src/python/WMComponent/JobAccountant/AccountantWorker.py
@@ -542,6 +542,8 @@ class AccountantWorker(WMConnectionBase):
                 wmbsJob["outcome"] = "success"
             else:
                 wmbsJob["outcome"] = "failure"
+                self.listOfJobsToFail.append(wmbsJob)
+                return jobSuccess
 
             for fwjrFile in fileList:
 
@@ -571,15 +573,11 @@ class AccountantWorker(WMConnectionBase):
 
             # Check if the job had any skipped files, put them in ACDC containers
             # We assume full file processing (no job masks)
-            if jobSuccess:
-                skippedFiles = fwkJobReport.getAllSkippedFiles()
-                if skippedFiles and jobType not in ['LogCollect', 'Cleanup']:
-                    self.jobsWithSkippedFiles[jobID] = skippedFiles
+            skippedFiles = fwkJobReport.getAllSkippedFiles()
+            if skippedFiles and jobType not in ['LogCollect', 'Cleanup']:
+                self.jobsWithSkippedFiles[jobID] = skippedFiles
 
-            if jobSuccess:
-                self.listOfJobsToSave.append(wmbsJob)
-            else:
-                self.listOfJobsToFail.append(wmbsJob)
+            self.listOfJobsToSave.append(wmbsJob)
 
         return jobSuccess
 


### PR DESCRIPTION
Fixes #9402 

#### Status
ready

#### Description
If the job failed, then the output data is not really needed and there is no need to register them into WMBS.
This has been tested in testbed, and with ACDC workflows as well.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Yes, complement to https://github.com/dmwm/WMCore/pull/9354

#### External dependencies / deployment changes
none
