### PR TITLE
Bypass "timed out" errors in DBS3Upload when contacting WMStats

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
@@ -349,9 +349,7 @@ class DBSUploadPoller(BaseWorkerThread):
                 pass
             elif 'Connection refused' in str(ex):
                 msg += 'Error: %s' % str(ex)
-            elif 'The read operation timed out' in str(ex):
-                msg += 'Error: %s' % str(ex)
-            elif 'Connection timed out' in str(ex):
+            elif 'timed out' in str(ex):
                 msg += 'Error: %s' % str(ex)
             else:
                 msg = "Unknown failure while fetching parentage map from WMStats. Error: %s" % str(ex)


### PR DESCRIPTION
Fixes #9404 

#### Status
ready

#### Description
Bypass the wmstats parentage request in DBS3Upload if it hits any sort of `timed out` error, which can be a Connection, Operation, read operation, etc. 

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Basically the same fix as in: https://github.com/dmwm/WMCore/pull/9397

#### External dependencies / deployment changes
none
