### PR TITLE
fix ReqMgr2 request API by request type

### DIFF
--- a/src/couchapps/ReqMgr/views/bystatusandtype/map.js
+++ b/src/couchapps/ReqMgr/views/bystatusandtype/map.js
@@ -1,3 +1,0 @@
-function(doc) {
-  emit([doc.RequestName, doc.RequestStatus, doc.RequestType], null);
-}

--- a/src/couchapps/ReqMgr/views/bytype/map.js
+++ b/src/couchapps/ReqMgr/views/bytype/map.js
@@ -1,0 +1,3 @@
+function(doc) {
+    emit(doc.RequestType, null);
+}

--- a/src/python/WMCore/ReqMgr/Service/Request.py
+++ b/src/python/WMCore/ReqMgr/Service/Request.py
@@ -281,14 +281,13 @@ class Request(RESTEntity):
         outputdataset = kwargs.get("outputdataset", [])
         date_range = kwargs.get("date_range", False)
         campaign = kwargs.get("campaign", [])
-        workqueue = kwargs.get("workqueue", [])
         team = kwargs.get("team", [])
         mc_pileup = kwargs.get("mc_pileup", [])
         data_pileup = kwargs.get("data_pileup", [])
         requestor = kwargs.get("requestor", [])
         mask = kwargs.get("mask", [])
         detail = kwargs.get("detail", True)
-        # set the return format. default format has requset name as a key
+        # set the return format. default format has request name as a key
         # if is set to one it returns list of dictionary with RequestName field.
         common_dict = int(kwargs.get("common_dict", 0))
         if detail in (False, "false", "False", "FALSE"):
@@ -321,6 +320,8 @@ class Request(RESTEntity):
 
         if name:
             request_info.append(self.reqmgr_db_service.getRequestByNames(name))
+        if request_type:
+            request_info.append(self.reqmgr_db_service.getRequestByCouchView("bytype", option, request_type))
         if prep_id:
             request_info.append(self.reqmgr_db_service.getRequestByCouchView("byprepid", option, prep_id))
         if inputdataset:
@@ -331,8 +332,6 @@ class Request(RESTEntity):
             request_info.append(self.reqmgr_db_service.getRequestByCouchView("bydate", option, date_range))
         if campaign:
             request_info.append(self.reqmgr_db_service.getRequestByCouchView("bycampaign", option, campaign))
-        if workqueue:
-            request_info.append(self.reqmgr_db_service.getRequestByCouchView("byworkqueue", option, workqueue))
         if mc_pileup:
             request_info.append(self.reqmgr_db_service.getRequestByCouchView("bymcpileup", option, mc_pileup))
         if data_pileup:

--- a/src/python/WMCore/Services/RequestDB/RequestDBReader.py
+++ b/src/python/WMCore/Services/RequestDB/RequestDBReader.py
@@ -229,7 +229,8 @@ class RequestDBReader(object):
         requestInfo = self._formatCouchData(data, detail=detail)
         return requestInfo
 
-    def getRequestByCouchView(self, view, options, keys=[], returnDict=True):
+    def getRequestByCouchView(self, view, options, keys=None, returnDict=True):
+        keys = keys or []
         options.setdefault("include_docs", True)
         data = self._getCouchView(view, options, keys)
         requestInfo = self._formatCouchData(data, returnDict=returnDict)

--- a/src/python/WMCore/Services/RequestDB/RequestDBReader.py
+++ b/src/python/WMCore/Services/RequestDB/RequestDBReader.py
@@ -1,4 +1,5 @@
 import time
+
 from WMCore.Database.CMSCouch import CouchServer, Database
 from WMCore.Lexicon import splitCouchServiceURL, sanitizeURL
 
@@ -39,8 +40,8 @@ class RequestDBReader(object):
         """
         self.defaultStale = {}
 
-    def _getCouchView(self, view, options, keys=[]):
-
+    def _getCouchView(self, view, options, keys=None):
+        keys = keys or []
         options = self.setDefaultStaleOptions(options)
 
         if keys and isinstance(keys, basestring):
@@ -126,7 +127,6 @@ class RequestDBReader(object):
 
         return self._getCouchView("bystatusandtime", options)
 
-
     def _getRequestByTeamAndStatus(self, team, status, limit):
         """
         'status': is the status of the workflow
@@ -188,7 +188,7 @@ class RequestDBReader(object):
         :return: a list of request names
         """
         if startTime == 0:
-            data = self._getRequestByStatus([status], detail, limit = None, skip = None)
+            data = self._getRequestByStatus([status], detail, limit=None, skip=None)
         else:
             data = self._getRequestByStatusAndStartTime(status, detail, startTime)
 
@@ -208,7 +208,7 @@ class RequestDBReader(object):
         else:
             data = self._getRequestByStatusAndEndTime(status, detail, endTime)
 
-        requestInfo = self._formatCouchData(data, detail = detail)
+        requestInfo = self._formatCouchData(data, detail=detail)
         return requestInfo
 
     def getRequestByTeamAndStatus(self, team, status, detail=False, limit=None):


### PR DESCRIPTION
Fixes #9395 

#### Status
not-tested

#### Description
Removed the request `byworkqueue`, since there is no such view.
Also removed the `bystatusandtype` view, which is not used anywhere and actually there is another view very similar to that under usage.
Created another view `bytype`, to be used when the user wants to know requests belong to a given request type.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
