### PR TITLE
Fetch quota from Detox; fetch usage from Rucio/PhEDEx; input primary/…

### DIFF
--- a/src/python/WMCore/MicroService/DataStructs/Workflow.py
+++ b/src/python/WMCore/MicroService/DataStructs/Workflow.py
@@ -5,8 +5,8 @@ required by MS Transferor
 from __future__ import division, print_function
 
 import operator
-
 from WMCore.DataStructs.LumiList import LumiList
+from WMCore.MicroService.Unified.Common import getMSLogger, gigaBytes
 
 
 class Workflow(object):
@@ -15,9 +15,11 @@ class Workflow(object):
     its information within MS
     """
 
-    def __init__(self, reqName, reqData):
+    def __init__(self, reqName, reqData, logger=None, verbose=False):
         self.reqName = reqName
         self.data = reqData
+        self.logger = getMSLogger(verbose, logger)
+
         self.inputDataset = ""
         self.parentDataset = ""
         self.pileupDatasets = set()
@@ -270,49 +272,64 @@ class Workflow(object):
         of chunks (usually the amount of sites available for data
         placement).
         :param numChunks: integer representing the number of chunks to be created
-        :return: a list of sets, where each set corresponds to a set of blocks to be
-        transferred to a single location
+        :return: it returns two lists:
+          * a list of sets, where each set corresponds to a set of blocks to be
+            transferred to a single location;
+          * and a list integers, which references the total size of each chunk in
+            the list above (same order).
         """
         if numChunks <= 1:
-            blockList = self.getPrimaryBlocks().keys()
+            thisChunk = set()
+            thisChunk.update(self.getPrimaryBlocks().keys())
+            thisChunkSize = sum(self.getPrimaryBlocks().values())
             if self.getParentDataset():
-                blockList.extend(self.getParentBlocks().keys())
-            return blockList
+                thisChunk.update(self.getParentBlocks().keys())
+                thisChunkSize += sum(self.getParentBlocks().values())
+            # keep same data structure as multiple chunks, so list of lists
+            return [thisChunk], [thisChunkSize]
 
         # create a descendant list of blocks according to their sizes
         sortedPrimary = sorted(self.getPrimaryBlocks().items(), key=operator.itemgetter(1), reverse=True)
         chunkSize = sum(item[1] for item in sortedPrimary) // numChunks
 
+        self.logger.info("Found %d blocks and the avg chunkSize is: %s GB",
+                         len(sortedPrimary), gigaBytes(chunkSize))
         # list of sets with the block names
         blockChunks = []
         # list of integers with the total block sizes in each chunk (same order as above)
-        chunksSize = []
+        sizeChunks = []
         for i in range(numChunks):
             thisChunk = set()
             thisChunkSize = 0
             idx = 0
             while True:
-                if sortedPrimary[idx][1] <= chunkSize:
+                self.logger.debug("Chunk: %d and idx: %s and length: %s", i, idx, len(sortedPrimary))
+                if not sortedPrimary or idx >= len(sortedPrimary):
+                    # then all blocks have been distributed
+                    break
+                elif thisChunkSize + sortedPrimary[idx][1] <= chunkSize:
                     thisChunk.add(sortedPrimary[idx][0])
                     thisChunkSize += sortedPrimary[idx][1]
                     sortedPrimary.pop(idx)
                 else:
                     idx += 1
-                    if idx >= len(sortedPrimary):
-                        break
             blockChunks.append(thisChunk)
-            chunksSize.append(thisChunkSize)
+            sizeChunks.append(thisChunkSize)
 
         # now take care of the leftovers... in a round-robin style....
         while sortedPrimary:
             for chunkNum in range(numChunks):
                 blockChunks[chunkNum].add(sortedPrimary[0][0])
-                chunksSize[chunkNum] += sortedPrimary[0][0]
+                sizeChunks[chunkNum] += sortedPrimary[0][1]
                 sortedPrimary.pop(0)
                 if not sortedPrimary:
                     break
-        print("AMR primary!!! Chunks size distribution: %s" % chunksSize)
-        print("AMR primary!!! Created %d chunks out of %d chunks" % (len(blockChunks), numChunks))
+        self.logger.info("Created %d primary data chunks out of %d chunks",
+                         len(blockChunks), numChunks)
+        self.logger.info("    with chunk size distribution: %s", sizeChunks)
+
+        if not self.getParentDataset():
+            return blockChunks, sizeChunks
 
         # now add the parent blocks, considering that input blocks were evenly
         # distributed, I'd expect the same to automatically happen to the parents...
@@ -327,10 +344,11 @@ class Workflow(object):
             # of blocks within the chunk and update the chunk size as well
             blockChunks[chunkNum].update(parentSet)
             for parent in parentSet:
-                chunkSize[chunkNum] += parentsSize[parent]
-        print("AMR parents!!! Chunks size distribution: %s" % chunksSize)
-        print("AMR parents!!! Created %d chunks out of %d chunks" % (len(blockChunks), numChunks))
-
+                sizeChunks[chunkNum] += parentsSize[parent]
+        self.logger.info("Created %d primary+parent data chunks out of %d chunks",
+                         len(blockChunks), numChunks)
+        self.logger.info("    with chunk size distribution: %s", sizeChunks)
+        return blockChunks, sizeChunks
 
     def _getValue(self, keyName, defaultValue=None):
         """

--- a/src/python/WMCore/MicroService/Unified/Common.py
+++ b/src/python/WMCore/MicroService/Unified/Common.py
@@ -180,6 +180,16 @@ def getWorkflow(requestName, reqMgrUrl):
     return data.get('result', [])
 
 
+def getDetoxQuota(url):
+    "Get list of workflow info from ReqMgr2 data-service for given request name"
+    headers = {}
+    params = {}
+    mgr = RequestHandler()
+    res = mgr.getdata(url, params=params, headers=headers, ckey=ckey(), cert=cert())
+    res = res.split('\n')
+    return res
+
+
 def workflowsInfo(workflows):
     "Return minimum info about workflows in flat format"
     winfo = {}

--- a/src/python/WMCore/MicroService/Unified/Common.py
+++ b/src/python/WMCore/MicroService/Unified/Common.py
@@ -341,8 +341,13 @@ def getNCopies(cpuHours, minN=2, maxN=3, weight=50000, constant=100000):
 
 
 def teraBytes(size):
-    "Return size in TB"
-    return float(size) / float(1024 ** 4)
+    "Return size in TB (Terabytes)"
+    return size / (1000 ** 4)
+
+
+def gigaBytes(size):
+    "Return size in GB (Gigabytes), rounded to 2 digits"
+    return round(size / (1000 ** 3), 2)
 
 
 def ckey():

--- a/src/python/WMCore/MicroService/Unified/MSCore.py
+++ b/src/python/WMCore/MicroService/Unified/MSCore.py
@@ -29,8 +29,7 @@ class MSCore(object):
         """
         self.logger = getMSLogger(getattr(msConfig, 'verbose', False), logger)
         self.msConfig = msConfig
-        self.logger.info(
-            "Configuration including default values:\n%s", self.msConfig)
+        self.logger.info("Configuration including default values:\n%s", self.msConfig)
 
         self.reqmgr2 = ReqMgr(self.msConfig['reqmgrUrl'], logger=self.logger)
         self.reqmgrAux = ReqMgrAux(self.msConfig['reqmgrUrl'],

--- a/src/python/WMCore/MicroService/Unified/MSCore.py
+++ b/src/python/WMCore/MicroService/Unified/MSCore.py
@@ -29,7 +29,8 @@ class MSCore(object):
         """
         self.logger = getMSLogger(getattr(msConfig, 'verbose', False), logger)
         self.msConfig = msConfig
-        self.logger.info("Configuration including default values:\n%s", self.msConfig)
+        self.logger.info(
+            "Configuration including default values:\n%s", self.msConfig)
 
         self.reqmgr2 = ReqMgr(self.msConfig['reqmgrUrl'], logger=self.logger)
         self.reqmgrAux = ReqMgrAux(self.msConfig['reqmgrUrl'],

--- a/src/python/WMCore/MicroService/Unified/MSTransferor.py
+++ b/src/python/WMCore/MicroService/Unified/MSTransferor.py
@@ -4,6 +4,9 @@ Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
              Alan Malta <alan dot malta AT cern dot ch >
 Description: MSTransferor class provide whole logic behind
 the transferor module.
+
+This is NOT a thread-safe module, even though some internal
+tasks might be extended to multi-threading in the future.
 """
 # futures
 from __future__ import division, print_function
@@ -16,11 +19,26 @@ from retry import retry
 
 # WMCore modules
 from Utils.IteratorTools import grouper
-from WMCore.MicroService.Unified.Common import getDetoxQuota
+from WMCore.MicroService.Unified.Common import gigaBytes
 from WMCore.MicroService.Unified.MSCore import MSCore
 from WMCore.MicroService.Unified.RequestInfo import RequestInfo
+from WMCore.MicroService.Unified.RSEQuotas import RSEQuotas
 from WMCore.Services.CRIC.CRIC import CRIC
 from WMCore.Services.PhEDEx.DataStructs.SubscriptionList import PhEDExSubscription
+
+
+def newTransferRec(dataIn):
+    """
+    Create a basic transfer record to be appended to a transfer document
+    :param dataIn: dictionary with information relevant to this transfer doc
+    :return: a transfer record dictionary
+    """
+    transferRecord = {"dataset": dataIn['name'],
+                      "dataType": dataIn['type'],
+                      "transferIDs": set(),  # casted to list before going to couch
+                      "campaignName": dataIn['campaign'],
+                      "completion": [0.0]}
+    return transferRecord
 
 
 class MSTransferor(MSCore):
@@ -36,13 +54,19 @@ class MSTransferor(MSCore):
         """
         super(MSTransferor, self).__init__(msConfig, logger)
         # url for fetching the storage quota
-        self.msConfig.setdefault("detoxUrl",
-                                 "http://t3serv001.mit.edu/~cmsprod/IntelROCCS/Detox/SitesInfo.txt")
-        self.msConfig.setdefault("quotaUsage", 0.8)  # use only 80% of the quota
+        detoxUrl = self.msConfig.get("detoxUrl",
+                                     "http://t3serv001.mit.edu/~cmsprod/IntelROCCS/Detox/SitesInfo.txt")
+        quotaFraction = self.msConfig.get("quotaUsage", 0.8)  # use only 80% of the quota
         # now a PhEDEx group name, then the Rucio account name in the near future
-        self.msConfig.setdefault("quotaAccount", "DataOps")
+        dataAcct = self.msConfig.get("quotaAccount", "DataOps")
+        # minimum available storage to consider a resource good for receiving data
+        minimumThreshold = self.msConfig.get("minimumThreshold", 1 * (1000 ** 4))  # 1TB
 
+        self.rseQuotas = RSEQuotas(detoxUrl, dataAcct, quotaFraction, useRucio=hasattr(self, "rucio"),
+                                   logger=logger, verbose=self.msConfig.get('verbose'),
+                                   minimumThreshold=minimumThreshold)
         self.reqInfo = RequestInfo(msConfig, logger)
+
         self.cric = CRIC(logger=self.logger)
         self.inputMap = {"InputDataset": "primary",
                          "MCPileup": "secondary",
@@ -50,14 +74,10 @@ class MSTransferor(MSCore):
         self.uConfig = {}
         self.campaigns = {}
         self.psn2pnnMap = {}
-        # information about RSE/PNNs and their quota/usage
-        self.nodesUsage = {}
-        # list of RSE/PNNs with less than 1TB available, skipped from data placement
-        self.fullRSEs = set()
         self.dsetCounter = 0
         self.blockCounter = 0
 
-    @retry(tries=2, delay=2, jitter=2)
+    @retry(tries=3, delay=2, jitter=2)
     def updateCaches(self):
         """
         Fetch some data required for the transferor logic, e.g.:
@@ -67,23 +87,27 @@ class MSTransferor(MSCore):
          * all campaign configuration
          * PSN to PNN map from CRIC
         """
-        self._getStorageQuota()
-        self._getStorageUsage()
+        self.logger.info("Updating RSE/PNN quota and usage")
+        self.rseQuotas.fetchStorageQuota()
+        self.rseQuotas.fetchStorageUsage(getattr(self, "rucio", self.phedex))
+        self.rseQuotas.evaluateQuotaExceeded()
+        if not self.rseQuotas.getNodeUsage():
+            raise RuntimeWarning("Failed to fetch storage usage stats")
 
+        self.logger.info("Updating all local caches...")
         self.dsetCounter = 0
         self.blockCounter = 0
-        self.fullRSEs = set()
         self.uConfig = self.unifiedConfig()
         campaigns = self.reqmgrAux.getCampaignConfig("ALL_DOCS")
         self.psn2pnnMap = self.cric.PSNtoPNNMap()
         # also clear the RequestInfo pileup cache
         self.reqInfo.clearPileupCache()
         if not self.uConfig:
-            raise RuntimeWarning("Failed to fetch the unified configuration. Retrying...")
+            raise RuntimeWarning("Failed to fetch the unified configuration")
         elif not campaigns:
-            raise RuntimeWarning("Failed to fetch the campaign configurations. Retrying...")
+            raise RuntimeWarning("Failed to fetch the campaign configurations")
         elif not self.psn2pnnMap:
-            raise RuntimeWarning("Failed to fetch PSN x PNN map from CRIC. Retrying...")
+            raise RuntimeWarning("Failed to fetch PSN x PNN map from CRIC")
         else:
             # let's make campaign look-up easier and more efficient
             self.campaigns = {}
@@ -98,15 +122,15 @@ class MSTransferor(MSCore):
         """
         try:
             requestRecords = self.getRequestRecords(reqStatus)
-            self.logger.debug('### transferor found %s requests in %s state',
-                              len(requestRecords), reqStatus)
+            self.logger.info('  retrieved %s requests.', len(requestRecords))
         except Exception as err:  # general error
-            self.logger.exception('### transferor error: %s', str(err))
+            self.logger.exception('Unknown exception while fetching requests from ReqMgr2', str(err))
 
         try:
             self.updateCaches()
-        except RuntimeWarning:
-            msg = "All retries exhausted! Retrying to update caches again in the next cycle"
+        except RuntimeWarning as ex:
+            msg = "All retries exhausted! Last error was: '%s'" % str(ex)
+            msg += "\nRetrying to update caches again in the next cycle."
             self.logger.error(msg)
             return
         except Exception as ex:
@@ -140,6 +164,7 @@ class MSTransferor(MSCore):
         and return a subset of each request with important information for the
         data placement algorithm.
         """
+        self.logger.info("Fetching requests in status: %s", reqStatus)
         # get requests from ReqMgr2 data-service for given statue
         reqData = self.reqmgr2.getRequestByStatus([reqStatus], detail=True)
 
@@ -172,21 +197,28 @@ class MSTransferor(MSCore):
                 self.logger.warning(msg)
                 return False, response
 
-            transRec = self._makeTransferRec(dataIn)
-            for nodes, blocks in self._decideDataDestination(wflow, dataIn):
-                if not nodes and not blocks:
+            nodes = self._getValidSites(wflow, dataIn)
+            if not nodes:
+                msg = "There are no RSEs with available space for %s. " % wflow.getName()
+                msg += "Skipping this workflow until RSEs get enough free space"
+                self.logger.warning(msg)
+                return False, response
+
+            transRec = newTransferRec(dataIn)
+            for blocks, dataSize, idx in self._decideDataDestination(wflow, dataIn, len(nodes)):
+                if not blocks and dataIn["type"] == "primary":
                     # no valid files in any blocks, it will likely fail in global workqueue
                     return success, response
-                if not blocks:
+                if blocks:
+                    subLevel = "block"
+                    data = {dataIn['name']: blocks}
+                else:
                     # then it's a dataset level subscription
                     subLevel = "dataset"
                     data = None
-                else:
-                    subLevel = "block"
-                    data = {dataIn['name']: blocks}
 
                 subscription = PhEDExSubscription(datasetPathList=dataIn['name'],
-                                                  nodeList=nodes,
+                                                  nodeList=nodes[idx],
                                                   group=self.msConfig['group'],
                                                   level=subLevel,  # use dataset for premix
                                                   priority="low",
@@ -196,7 +228,7 @@ class MSTransferor(MSCore):
                 msg = "Creating '%s' level subscription for %s dataset: %s" % (subscription.level,
                                                                                dataIn['type'],
                                                                                dataIn['name'])
-                if dataIn['type'] == "parent":
+                if wflow.getParentDataset():
                     msg += ", where parent blocks have also been added for dataset: %s" % wflow.getParentDataset()
                 self.logger.info(msg)
 
@@ -204,74 +236,85 @@ class MSTransferor(MSCore):
                     self.logger.info("TODO readOnly mode, subscription not made. Faking id to 1111")
                     transRec['transferIDs'].add(1111)  # any fake number
                 else:
-                    try:
-                        if hasattr(self, "rucio"):
-                            # FIXME: then it should create a Rucio rule instead
-                            res = self.phedex.subscribe(subscription)
-                        else:
-                            res = self.phedex.subscribe(subscription)
-                        self.logger.debug("Subscription done, result: %s", res)
-                    except HTTPException as ex:
-                        # It might be that the block has no more replicas (all files invalidated)
-                        # let it go and fail at global workqueue level
-                        msg = "Subscription failed for workflow: %s and dataset: %s " % (wflow.getName(),
-                                                                                         dataIn['name'])
-                        if ex.status == 400 and "request matched no data in TMDB" in ex.reason:
-                            msg += "because data cannot be found in TMDB. Bypassing this/these blocks..."
-                            self.logger.warning(msg)
-                        else:
-                            msg += "with status code: %s and result: %s. " % (ex.status, ex.result)
-                            msg += "It will be retried in the next cycle"
-                            self.logger.error(msg)
-                            success = False
-                            break
-                    except Exception as ex:
-                        msg = "Unknown exception while subscribing data for workflow: %s " % wflow.getName()
-                        msg += "and dataset: %s. Will retry again later. Error details: %s" % (dataIn['name'],
-                                                                                               str(ex))
-                        self.logger.exception(msg)
-                        success = False
+                    # Then make the data subscription, for real!!!
+                    success, transferId = self._subscribeData(subscription, wflow.getName(), dataIn['name'])
+                    if not success:
                         break
-                    else:
-                        transferId = res['phedex']['request_created'][0]['id']
+                    if transferId:
                         transRec['transferIDs'].add(transferId)
+
+                    # and update some instance caches
+                    self.rseQuotas.updateNodeUsage(nodes[idx], dataSize)
+                    if subLevel == 'dataset':
+                        self.dsetCounter += 1
+                    else:
+                        self.blockCounter += len(blocks)
+
             transRec['transferIDs'] = list(transRec['transferIDs'])
             response.append(transRec)
+
+        # once the workflow has been completely processed, update the node usage
+        self.rseQuotas.evaluateQuotaExceeded()
         return success, response
 
-    def _decideDataDestination(self, wflow, dataIn):
+    def _subscribeData(self, subscriptionObj, wflowName, dsetName):
         """
-        Given a global list of blocks and the campaign configuration,
-        decide which blocks have to be transferred and to where.
-        :param wflow: workflow object
-        :param dataIn: dictionary with a summary of the data to be placed
-        :return: yield the node and a list of block names to be transferred
+        Make the actual PhEDEx subscription - or create a Rucio rule - for the
+        input data placement
+        :param subscriptionObj:
+        :param wflowName:
+        :param dsetName:
+        :return:
         """
-        # FIXME: implement multiple copies (MaxCopies > 1)
-        blockList = []
-        dsetName = dataIn["name"]
+        success, transferId = True, 0
+        try:
+            if hasattr(self, "rucio"):
+                # FIXME: then it should create a Rucio rule instead
+                res = self.phedex.subscribe(subscriptionObj)
+            else:
+                res = self.phedex.subscribe(subscriptionObj)
+            self.logger.debug("Subscription done, result: %s", res)
+        except HTTPException as ex:
+            # It might be that the block has no more replicas (all files invalidated)
+            # let it go and fail at global workqueue level
+            msg = "Subscription failed for workflow: %s and dataset: %s " % (wflowName, dsetName)
+            if ex.status == 400 and "request matched no data in TMDB" in ex.reason:
+                msg += "because data cannot be found in TMDB. Bypassing this/these blocks..."
+                self.logger.warning(msg)
+            else:
+                msg += "with status code: %s and result: %s. " % (ex.status, ex.result)
+                msg += "It will be retried in the next cycle"
+                self.logger.error(msg)
+                success = False
+        except Exception as ex:
+            msg = "Unknown exception while subscribing data for workflow: %s " % wflowName
+            msg += "and dataset: %s. Will retry again later. Error details: %s" % (dsetName, str(ex))
+            self.logger.exception(msg)
+            success = False
+        else:
+            transferId = res['phedex']['request_created'][0]['id']
 
+        return success, transferId
+
+    def _getValidSites(self, wflow, dataIn):
+        """
+        Given a workflow object and the data short summary, find out
+        the Campaign name, the workflow SiteWhitelist, map the PSNs to
+        PNNs and finally remove PNNs without space
+        can still receive data
+        :param wflow: the workflow object
+        :param dataIn: short summary of data to be transferred
+        :return: a unique and ordered list of PNNs to take data
+        """
+        dsetName = dataIn["name"]
         campConfig = self.campaigns[dataIn['campaign']]
         psns = wflow.getSitelist()
 
-        ### NOTE: data placement done in a block basis
         if dataIn["type"] == "primary":
             if campConfig['SiteWhiteList']:
                 psns = set(psns) & set(campConfig['SiteWhiteList'])
             if campConfig['SiteBlackList']:
                 psns = set(psns) - set(campConfig['SiteBlackList'])
-            nodes = self._getFinalPNNs(psns)
-
-            listBlockSets = wflow.getChunkBlocks(len(nodes))
-            if not listBlockSets:
-                # use empty nodes to avoid making a dataset level subscription
-                self.logger.warning("  found 0 primary/parent blocks for dataset: %s, moving on...", dsetName)
-                nodes = []
-            for idx, blocksSet in enumerate(listBlockSets):
-                self.logger.info("Placing %d blocks for dataset: %s at %s", len(blocksSet), dsetName, nodes[idx])
-                self.blockCounter += len(blocksSet)
-                yield nodes, blockList
-        ### NOTE: data placement done in a dataset basis
         elif dataIn["type"] == "secondary":
             # if the dataset has a location list, use solely that one
             if campConfig['Secondaries'].get(dsetName, []):
@@ -285,13 +328,51 @@ class MSTransferor(MSCore):
                         psns = set(psns) & set(campConfig['SiteWhiteList'])
                     if campConfig['SiteBlackList']:
                         psns = set(psns) - set(campConfig['SiteBlackList'])
-            nodes = self._getFinalPNNs(psns)
 
+        self.logger.info("  final list of PSNs to be use: %s", psns)
+        pnns = set()
+        for psn in psns:
+            for pnn in self.psn2pnnMap.get(psn, []):
+                if pnn == "T2_CH_CERNBOX" or pnn.startswith("T3_") or pnn.endswith("_MSS") or pnn.endswith("_Export"):
+                    pass
+                else:
+                    pnns.add(pnn)
+
+        self.logger.info("List of out-of-space RSEs dropped for '%s' is: %s",
+                         wflow.getName(), pnns & self.rseQuotas.getOutOfSpaceRSEs())
+        return list(pnns & self.rseQuotas.getAvailableRSEs())
+
+
+    def _decideDataDestination(self, wflow, dataIn, numNodes):
+        """
+        Given a global list of blocks and the campaign configuration,
+        decide which blocks have to be transferred and to where.
+        :param wflow: workflow object
+        :param dataIn: dictionary with a summary of the data to be placed
+        :param numNodes: amount of nodes/RSEs that can receive data
+        :return: yield a block list, the total chunk size and a node index
+        """
+        # FIXME: implement multiple copies (MaxCopies > 1)
+        blockList = []
+        dsetName = dataIn["name"]
+
+        ### NOTE: data placement done in a block basis
+        if dataIn["type"] == "primary":
+            listBlockSets, listSetsSize = wflow.getChunkBlocks(numNodes)
+            if not listBlockSets:
+                self.logger.warning("  found 0 primary/parent blocks for dataset: %s, moving on...", dsetName)
+                yield blockList, 0, 0
+            for idx, blocksSet in enumerate(listBlockSets):
+                self.logger.info("Have a chunk of %d blocks (%s GB) for dataset: %s",
+                                 len(blocksSet), gigaBytes(listSetsSize[idx]), dsetName)
+                yield blocksSet, listSetsSize[idx], idx
+        ### NOTE: data placement done in a dataset basis
+        elif dataIn["type"] == "secondary":
             # secondary datasets are transferred as a whole, until better days...
-            self.dsetCounter += 1
-            for node in nodes:
-                self.logger.info("Placing pileup dataset: %s at %s", dsetName, node)
-                yield node, blockList
+            dsetSize = wflow.getSecondarySummary()
+            for idx in range(numNodes):
+                self.logger.info("Have whole PU dataset: %s (%s GB)", dsetName, gigaBytes(dsetSize[dsetName]))
+                yield blockList, dsetSize[dsetName], idx
 
     def _getFinalPNNs(self, psns):
         """
@@ -306,30 +387,14 @@ class MSTransferor(MSCore):
         pnns = set()
         for psn in psns:
             for pnn in self.psn2pnnMap.get(psn, []):
-                if pnn == "T2_CH_CERNBOX":
-                    self.logger.debug("%s maps to %s, skipping it.", psn, pnn)
-                elif pnn.startswith("T3_"):
-                    self.logger.debug("%s maps to a T3 PNN resource: %s, skipping it.", psn, pnn)
-                elif pnn.endswith("_MSS") or pnn.endswith("_Export"):
-                    self.logger.debug("%s maps to a archival storage PNN: %s, skipping it.", psn, pnn)
+                if pnn == "T2_CH_CERNBOX" or pnn.startswith("T3_") or pnn.endswith("_MSS") or pnn.endswith("_Export"):
+                    pass
                 else:
                     pnns.add(pnn)
 
-        self.logger.info("List of out-of-space RSEs dropped: %s", pnns & self.fullRSEs)
-        return list(pnns - self.fullRSEs)
-
-    def _makeTransferRec(self, dataIn):
-        """
-        Create a basic transfer record to be appended to a transfer document
-        :param data:
-        :return: a dictionary
-        """
-        transferRecord = {"dataset": dataIn['name'],
-                          "dataType": dataIn['type'],
-                          "transferIDs": set(),  # casted to list before going to couch
-                          "campaignName": dataIn['campaign'],
-                          "completion": [0.0]}
-        return transferRecord
+        self.logger.info("List of out-of-space RSEs dropped for this dataset: %s",
+                         pnns & self.rseQuotas.getOutOfSpaceRSEs())
+        return list(pnns & self.rseQuotas.getAvailableRSEs())
 
     def createTransferDoc(self, reqName, transferRecords):
         """
@@ -349,78 +414,3 @@ class MSTransferor(MSCore):
         msg += "Error: %s" % resp
         self.logger.error(msg)
         return False
-
-
-    def _getStorageQuota(self):
-        """
-        Fetch the DataOps quota from Detox. At this stage, we do not do
-        any manipulation with the quota value (Unified uses 80% of the quota),
-        use it as is!
-
-        :return: update the cache self.nodesUsage with the quota value from
-          Detox
-
-        NOTE: code extracted/modified from Unified, see `fetch_detox_info` in
-          https://github.com/CMSCompOps/WmAgentScripts/blob/master/utils.py#L2514
-        """
-        # FIXME: extremely fragile code that has to be replaced by a proper
-        # CRIC/Rucio API in the very near future
-        info = getDetoxQuota(self.msConfig['detoxUrl'])
-
-        doRead = False
-        for line in info:
-            if 'DDM Partition:' in line and self.msConfig['quotaAccount'] in line:
-                doRead = True
-                continue
-            elif 'DDM Partition:' in line:
-                doRead = False
-                continue
-            elif line.startswith('#'):
-                continue
-
-            if not doRead:
-                continue
-
-            _, quota, _, _, pnn = line.split()
-
-            if pnn.endswith("_MSS") or pnn.endswith("_Export"):
-                continue
-            # convert from TB to bytes
-            self.nodesUsage[pnn]['quota'] = int(quota) * (1024 ** 4)
-
-    def _getStorageUsage(self):
-        """
-        Fetch the storage usage from either Rucio or PhEDEx, which will then
-        be used as part of the data placement mechanism.
-        Also calculate the available quota - given the configurable quota
-        fraction - and mark RSEs with less than 1TB available as NOT usable.
-
-        Keys definition is:
-         * quota: the PhEDEx group quota provided by Detox
-         * bytes_limit: either the PhEDEx quota or the account quota from Rucio
-         * bytes: data volume placed by Rucio (or subscribed in PhEDEx)
-         * bytes_remaining: storage available for our account/group
-         * quota_avail: space left (in bytes) that we can use for data placement
-        :return: update our cache in place with the up-to-date values
-        """
-        if hasattr(self, "rucio"):
-            for item in self.rucio.getAccountUsage(self.msConfig['rucioAccount']):
-                self.nodesUsage[item['rse']].update({'bytes_limit': item['bytes_limit'],
-                                                     'bytes': item['bytes'],
-                                                     'bytes_remaining': item['bytes_remaining']})
-        else:
-            # for PhEDEx, we have also to remap the key's to keep in sync with Rucio
-            res = self.phedex.getGroupUsage(group=self.msConfig['group'])
-            for item in res['phedex']['node']:
-                quota = self.nodesUsage[item['name']]['quota']
-                self.nodesUsage[item['name']].update({'bytes_limit': quota,
-                                                      'bytes': item['dest_bytes'],
-                                                      'bytes_remaining': quota - item['dest_bytes']})
-
-        # given a configurable sub-fraction of our quota, recalculate how much storage is left
-        for rse, info in self.nodesUsage.items():
-            quota_avail = info['quota'] * self.msConfig["quotaUsage"]
-            info['quota_avail'] = min(quota_avail, info['bytes_remaining'])
-            if info['quota_avail'] < 1000 * (1024 ** 3):
-                self.logger.info("RSE: %s out of quota, skipping this storage!!")
-                self.fullRSEs.add(rse)

--- a/src/python/WMCore/MicroService/Unified/RSEQuotas.py
+++ b/src/python/WMCore/MicroService/Unified/RSEQuotas.py
@@ -1,0 +1,204 @@
+"""
+Non thread-safe object which provides all the RSE/PNN information
+required for automatic data placement.
+It can also communicate with other data management tools, like
+Detox, Rucio and PhEDEx.
+"""
+from __future__ import division, print_function
+
+from WMCore.MicroService.Unified.Common import getDetoxQuota
+from WMCore.MicroService.Unified.Common import getMSLogger
+
+
+class RSEQuotas(object):
+    """
+    Class which represents a list of RSEs, their quota and
+    their storage usage
+    """
+
+    def __init__(self, detoxUrl, dataAcct, quotaFraction, **kwargs):
+        """
+        Executes a basic setup, including proper logging.
+        :param detoxUrl: string with the detox url (to fetch the quota)
+        :param dataAcct: string with either the Rucio account or PhEDEx group name
+        :param quotaFraction: float point number representing the fraction of the quota
+        :param kwargs: the supported keyword arguments are:
+          minimumThreshold: integer value defining the minimum available space required
+          useRucio: boolean flag used to decide between Rucio and PhEDEx data management
+          verbose: logger verbosity
+          logger: logger object
+        """
+        self.detoxUrl = detoxUrl
+        self.dataAcct = dataAcct
+        self.quotaFraction = quotaFraction
+
+        self.minimumSpace = kwargs["minimumThreshold"]
+        self.useRucio = kwargs.get("useRucio", False)
+        self.logger = getMSLogger(kwargs.get("verbose"), kwargs.get("logger"))
+
+        self.nodeUsage = {}
+        self.availableRSEs = set()
+        self.outOfSpaceNodes = set()
+
+    def __str__(self):
+        """
+        Write out useful information for this object
+        :return: a stringified dictionary
+        """
+        res = {'detoxUrl': self.detoxUrl, 'dataAcct': self.dataAcct,
+               'useRucio': self.useRucio, 'quotaFraction': self.quotaFraction,
+               'minimumSpace': self.minimumSpace}
+        return str(res)
+
+    def getNodeUsage(self):
+        """
+        Return a dictionary of RSEs and a few storage statistics
+        """
+        return self.nodeUsage
+
+    def getAvailableRSEs(self):
+        """
+        Return a list of out-of-space RSE/PNNs
+        """
+        return self.availableRSEs
+
+    def getOutOfSpaceRSEs(self):
+        """
+        Return a list of out-of-space RSE/PNNs
+        """
+        return self.outOfSpaceNodes
+
+    def fetchStorageQuota(self):
+        """
+        Fetch the DataOps quota from Detox. At this stage, we do not do
+        any manipulation with the quota value (Unified uses 80% of the quota),
+        use it as is!
+
+        :return: create an instance cache structure to keep track of quota
+          and available storage. The structure is as follows:
+          {"pnn_name": {"quota": quota in bytes for the rucio account or phedex group,
+                        "bytes_limit": total space for the account/group,
+                        "bytes": amount of bytes currently used/archived,
+                        "bytes_remaining": space remaining for the acct/group,
+                        "quota_avail": a fraction of the quota that we will use}
+
+        NOTE: code extracted/modified from Unified, see `fetch_detox_info` in
+          https://github.com/CMSCompOps/WmAgentScripts/blob/master/utils.py#L2514
+        """
+        self.nodeUsage.clear()
+        if self.useRucio:
+            msg = "You called getStorageQuota method, while we're supposed to use Rucio. "
+            msg += "Fix whatever mistake you made and come again. Skipping this method!"
+            self.logger.error(msg)
+            return
+        # FIXME: extremely fragile code that has to be replaced by a proper
+        # CRIC/Rucio API in the very near future
+        info = getDetoxQuota(self.detoxUrl)
+
+        doRead = False
+        for line in info:
+            if 'DDM Partition:' in line and self.dataAcct in line:
+                doRead = True
+                continue
+            elif 'DDM Partition:' in line:
+                doRead = False
+                continue
+            elif line.startswith('#'):
+                continue
+
+            if not doRead:
+                continue
+
+            _, quota, _, _, pnn = line.split()
+
+            if pnn.endswith("_MSS") or pnn.endswith("_Export"):
+                continue
+            self.nodeUsage.setdefault(pnn, {})
+            # convert from TB to bytes
+            self.nodeUsage[pnn] = dict(quota=int(quota) * (1000 ** 4),
+                                       bytes_limit=0,
+                                       bytes=0,
+                                       bytes_remaining=0,
+                                       quota_avail=0)
+        self.logger.info("Storage quota filled from Detox information")
+
+    def fetchStorageUsage(self, dataSvcObj):
+        """
+        Fetch the storage usage from either Rucio or PhEDEx, which will then
+        be used as part of the data placement mechanism.
+        Also calculate the available quota - given the configurable quota
+        fraction - and mark RSEs with less than 1TB available as NOT usable.
+        :param dataSvcObj: object instance for the data service
+
+        Keys definition is:
+         * quota: the PhEDEx group quota provided by Detox
+         * bytes_limit: either the PhEDEx quota or the account quota from Rucio
+         * bytes: data volume placed by Rucio (or subscribed in PhEDEx)
+         * bytes_remaining: storage available for our account/group
+         * quota_avail: space left (in bytes) that we can use for data placement
+        :return: update our cache in place with up-to-date values, in the format of:
+            {"pnn_name": {"bytes_limit": total space for the account/group,
+                          "bytes": amount of bytes currently used/archived,
+                          "bytes_remaining": space remaining for the acct/group}
+        """
+        if self.useRucio:
+            self.logger.debug("Using Rucio for storage usage, with acct: %s", self.dataAcct)
+            for item in dataSvcObj.getAccountUsage(self.dataAcct):
+                if item['rse'] not in self.nodeUsage:
+                    continue
+                self.nodeUsage[item['rse']].update({'quota': item['bytes_limit'],
+                                                    'bytes_limit': item['bytes_limit'],
+                                                    'bytes': item['bytes'],
+                                                    'bytes_remaining': item['bytes_remaining']})
+        else:
+            self.logger.debug("Using PhEDEx for storage usage, with acct: %s", self.dataAcct)
+            # for PhEDEx, we have also to remap the key's to keep in sync with Rucio
+            res = dataSvcObj.getGroupUsage(group=self.dataAcct)
+            for item in res['phedex']['node']:
+                if item['name'] not in self.nodeUsage:
+                    continue
+                quota = self.nodeUsage[item['name']]['quota']
+                self.nodeUsage[item['name']].update({'bytes_limit': quota,
+                                                     'bytes': item['group'][0]['dest_bytes'],
+                                                     'bytes_remaining': quota - item['group'][0]['dest_bytes']})
+
+        self.logger.info("Summary of the initial quotas:")
+        for site, info in self.nodeUsage.items():
+            self.logger.info("  %s : %s", site, info)
+
+    def evaluateQuotaExceeded(self):
+        """
+        Goes through every single site, their quota and their remaining
+        storage; and mark those with less than X TB available (1TB at the
+        moment) as not eligible to receive data
+        :return: updates instance structures in place
+        """
+        self.availableRSEs.clear()
+        self.outOfSpaceNodes.clear()
+        # given a configurable sub-fraction of our quota, recalculate how much storage is left
+        for rse, info in self.nodeUsage.items():
+            quotaAvail = info['quota'] * self.quotaFraction
+            info['quota_avail'] = min(quotaAvail, info['bytes_remaining'])
+            if info['quota_avail'] < self.minimumSpace:
+                self.outOfSpaceNodes.add(rse)
+            else:
+                self.availableRSEs.add(rse)
+
+        self.logger.info("List of RSE's out of quota: %s", self.outOfSpaceNodes)
+
+    def updateNodeUsage(self, node, dataSize):
+        """
+        Provided a RSE/PNN name and the data size, in bytes, update the node
+        storage usage by subtracting it from the current available quota.
+        If it gets a list of nodes, the same dataSize is accounted for all
+        of them.
+        :param node: string with the PNN/RSE
+        :param dataSize: integer with the amount of bytes allocated
+        :return: nothing. updates nodeUsage cache
+        """
+        if isinstance(node, basestring):
+            node = [node]
+        if not isinstance(dataSize, int):
+            self.logger.error("dataSize needs to be integer, not '%s'!", type(dataSize))
+        for rse in node:
+            self.nodeUsage[rse]['quota_avail'] -= dataSize

--- a/src/python/WMCore/MicroService/Unified/RequestInfo.py
+++ b/src/python/WMCore/MicroService/Unified/RequestInfo.py
@@ -57,7 +57,7 @@ class RequestInfo(MSCore):
         # create a Workflow object representing the request
         workflows = []
         for record in reqRecords:
-            wflow = Workflow(record['RequestName'], record)
+            wflow = Workflow(record['RequestName'], record, logger=self.logger)
             workflows.append(wflow)
             msg = "Processing request: %s, with campaigns: %s, " % (wflow.getName(),
                                                                     wflow.getCampaigns())

--- a/test/python/WMCore_t/ReqMgr_t/Service_t/Auxiliary_t.py
+++ b/test/python/WMCore_t/ReqMgr_t/Service_t/Auxiliary_t.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import unittest
+import time
 from httplib import HTTPException
 
 from WMCore_t.ReqMgr_t.TestConfig import config
@@ -207,8 +208,17 @@ class AuxiliaryTest(RESTBaseUnitTestWithDBBackend):
         res = self.jsonSender.get("data/transferinfo/ALL_DOCS")  # views still to be updated...
         self.assertEqual(len(res[0]["result"]), 1)
 
-        res = self.jsonSender.get("data/transferinfo/ALL_DOCS")
-        self.assertEqual(len(res[0]["result"]), 2)
+        # trick to make sure views have been updated
+        for i in range(3):
+            try:
+                res = self.jsonSender.get("data/transferinfo/ALL_DOCS")
+                self.assertEqual(len(res[0]["result"]), 2)
+            except AssertionError:
+                if i == 2:
+                    raise
+                else:
+                    print("waiting 1 second for views to be updated...")
+                    time.sleep(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…parent block placement made by chunks

Fixes #9372 

#### Status
In development

#### Description
There are many changes in this PR, like:
* fetch the PhEDEx group quota from Detox (FRAGILE!!! it needs to go away as soon as possible)
* given a PhEDEx group, fetch the storage usage from PhEDEx; or
  * given a Rucio account, fetch the account usage and quota (limit) from Rucio
* a configurable quota usage has been set to 80%
* PNNs with less than 1TB of available space are skipped from the data placement (should probably be made configurable)
* Workflow API to create chunks of blocks as evenly as possible - size is not fixed and it depends on the number of PNNs to receive data - it also adds the parent blocks to their correspondent chunks (primary + parent)
* fixed logger for the data structures
* retry up to 2 times to update the local MSTransferor caches (required for running the whole cycle)

this logic has also been put in place:
* update the internal cache of storage usage for every single input data placement;
* re-evaluate sites out-of-quota between every single data placement;

what needs further thought is:
* what to do with chunks that are too big for the space/quota available? Do we skip the whole workflow data placement? Do we oversubscribe it? Do we distribute the extra load among other PNNs?

#### Is it backward compatible (if not, which system it affects?)
No (it has new features)

#### Related PRs
none

#### External dependencies / deployment changes
<Does it require deployment changes? Does it rely on third-party libraries?>
