### PR TITLE
Bump WMAgent deployment to 1.2.8

### DIFF
--- a/deploy/deploy-wmagent.sh
+++ b/deploy/deploy-wmagent.sh
@@ -25,8 +25,8 @@
 ### Usage:               -c <central_services> Url to central services hosting central couchdb (e.g. alancc7-cloud1.cern.ch)
 ### Usage:
 ### Usage: deploy-wmagent.sh -w <wma_version> -d <deployment_tag> -t <team_name> [-s <scram_arch>] [-r <repository>] [-n <agent_number>] [-c <central_services_url>]
-### Usage: Example: sh deploy-wmagent.sh -w 1.2.6.patch1 -d HG1909e -t production -n 30
-### Usage: Example: sh deploy-wmagent.sh -w 1.2.4.patch3 -d HG1908a -t testbed-vocms001 -p "9315 9364 9367" -r comp=comp.amaltaro -c cmsweb-testbed.cern.ch
+### Usage: Example: sh deploy-wmagent.sh -w 1.2.8 -d HG1911c -t production -n 30
+### Usage: Example: sh deploy-wmagent.sh -w 1.2.8 -d HG1911c -t testbed-vocms001 -p "9403" -r comp=comp.amaltaro -c cmsweb-testbed.cern.ch
 ### Usage:
 
 IAM=`whoami`


### PR DESCRIPTION
#### Status
ready

#### Description
Just bumping the WMAgent deployment example to the latest stable release: `1.2.8`

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
no

#### External dependencies / deployment changes
no