### PR TITLE
NATS interface for WMAgent monitoring

### DIFF
--- a/src/python/WMCore/Services/NATS.py
+++ b/src/python/WMCore/Services/NATS.py
@@ -1,0 +1,47 @@
+from __future__ import division
+
+# system modules
+import json
+import logging
+import traceback
+
+# CMSMonitoring modules
+from CMSMonitoring.NATS import NATSManager
+
+
+class NATS(object):
+    def __init__(self, config):
+        # initialize NATS if requested
+        self.nats = None
+        if getattr(config, 'use_nats', False) and getattr(config, 'nats_server', None):
+            topic = getattr(config, 'nats_topic', 'cms.reqmgr2')
+            topics = ['%s.topic' % topic]
+            self.nats = NATSManager(config.nats_server, topics=topics, default_topic=topic)
+            msg = "NATS: {}".format(self.nats)
+            logging.info(msg)
+
+    def request2NATS(self, workload, request_args):
+        "Publish messages about reqmgr2 workflow to NATS server"
+        # send update to NATS
+        if self.nats:
+            try:
+                name = workload.name()
+                priority = request_args.get('RequestPriority', -1)
+                status = request_args.get('RequestStatus', 'NA')
+                proc = request_args.get('ProcessingString', '')
+                if isinstance(proc, dict):
+                    proc = [k for k in proc.keys()]
+                if isinstance(proc, list):
+                    proc = json.dumps(proc)
+                outputDatasets = request_args.get('OutputDatasets', [])
+                if isinstance(outputDatasets, list):
+                    outputDatasets = json.dumps(outputDatasets)
+                doc = {'name': name,
+                       'status': status,
+                       'prority': priority,
+                       'processing': proc,
+                       'outputDatasets': outputDatasets}
+                self.nats.publish(doc)
+            except Exception as exc:
+                logging.error(str(exc))
+                logging.error(traceback.format_exc())

--- a/src/python/WMCore/WMRuntime/Monitors/NATSMonitor.py
+++ b/src/python/WMCore/WMRuntime/Monitors/NATSMonitor.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+
+"""
+_NATSMonitor_
+"""
+from __future__ import division
+
+# system modules
+import logging
+import traceback
+
+# WMCore modules
+from WMCore.WMRuntime.Monitors.WMRuntimeMonitor import WMRuntimeMonitor
+from WMCore.WMRuntime.NATSInterface import NATSPublisher
+
+
+class NATSMonitor(WMRuntimeMonitor):
+    "NATSMonitoring provide generic interface to NATS for WMAgent"
+    def __init__(self):
+        self.mgr = None
+        WMRuntimeMonitor.__init__(self)
+
+    def initMonitor(self, task, job, logPath, args=None):
+        "Initialize NATSMonitor"
+        if not args:
+            args = {}
+        server = args.get('server', '')
+        if not server:
+            logging.error("Please provide valid NATS server")
+        topics = args.get('topics', None)
+        attrs = args.get('attrs', None)
+        self.mgr = NATSPublisher(task, job, server, topics, attrs)
+
+    def jobStart(self, task=None):
+        """
+        Job start notifier.
+        """
+        try:
+            self.mgr.jobStart()
+        except Exception as ex:
+            logging.error(str(ex))
+            logging.error(str(traceback.format_exc()))
+
+    def jobEnd(self, task):
+        """
+        Job End notification
+        """
+        try:
+            self.mgr.jobEnd()
+        except Exception as ex:
+            logging.error(str(ex))
+            logging.error(str(traceback.format_exc()))
+
+    def stepStart(self, step):
+        """
+        Step start notification
+        """
+        try:
+            self.mgr.stepStart(step=step)
+        except Exception as ex:
+            logging.error(str(ex))
+            logging.error(str(traceback.format_exc()))
+
+    def stepEnd(self, step, stepReport):
+        """
+        Step end notification
+
+        """
+        try:
+            self.mgr.stepEnd(step=step, stepReport=stepReport)
+        except Exception as ex:
+            logging.error(str(ex))
+            logging.error(str(traceback.format_exc()))
+
+    def stepKilled(self):
+        """
+        Step killed notification
+        """
+        try:
+            self.mgr.stepKilled(step=self.currentStep)
+        except Exception as ex:
+            logging.error(str(ex))
+            logging.error(str(traceback.format_exc()))
+
+    def jobKilled(self):
+        """
+        Killed job notification
+        """
+        try:
+            self.mgr.jobKilled()
+        except Exception as ex:
+            logging.error(str(ex))
+            logging.error(str(traceback.format_exc()))
+
+    def periodicUpdate(self):
+        """
+        Run on the defined intervals. Tell the dashboard info to run the
+        periodic update
+        """
+        try:
+            self.mgr.periodicUpdate()
+        except Exception as ex:
+            logging.error(str(ex))
+            logging.error(str(traceback.format_exc()))

--- a/src/python/WMCore/WMRuntime/NATSInterface.py
+++ b/src/python/WMCore/WMRuntime/NATSInterface.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+"""
+NATSPublisher provides wrapper around NATS to send WMAgent messages
+"""
+from __future__ import division
+
+# system modules
+import socket
+import logging
+
+# WMCore modules
+from WMCore.WMSpec.WMStep import WMStepHelper
+from WMCore.WMSpec.WMWorkload import getWorkloadFromTask, WMWorkloadHelper
+from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig, SiteConfigError
+from WMCore.WMRuntime.Bootstrap import getSyncCE
+
+# CMSMonitoring modules
+from CMSMonitoring.NATS import NATSManager
+
+
+class NATSPublisher(object):
+    """
+    NATSPublisher class provides generic wrapper to send NATS messages from WMAgent
+    """
+    def __init__(self, task, job, server, topics=None, attrs=None):
+        """
+        Constructor takes task and job and extract relevant information
+        """
+        # Basic task/job objects
+        workload = getWorkloadFromTask(task)
+        whelper = WMWorkloadHelper(workload)
+        campaign = whelper.getCampaign()
+        taskName = workload.name()
+        jobName = job['name']
+
+        siteCfg = {}
+        try:
+            siteCfg = loadSiteLocalConfig()
+        except SiteConfigError:
+            pass
+        siteName = getattr(siteCfg, 'siteName', 'Unknown')
+        hostName = socket.gethostname()
+        ceName = getSyncCE()
+
+        # doc we'll start with
+        self.data = {'task': taskName, 'job': jobName, 'campaign': campaign,
+                     'site': siteName, 'host': hostName, 'ce': ceName}
+
+        # NATS manager
+        self.nats = NATSManager(server, topics=topics, attrs=attrs, default_topic='cms.wma')
+        msg = "NATS: {}".format(self.nats)
+        logging.info(msg)
+
+    def jobStart(self):
+        """
+        _jobStart_
+
+        Fill with basic information upon job start, we shouldn't send anything
+        until the first step starts.
+        """
+        # Announce that the job is running
+        data = dict(self.data)
+        self.nats.publish(data)
+
+    def jobEnd(self):
+        """
+        _jobEnd_
+
+        Fill with jobEnding info
+        """
+        data = dict(self.data)
+        self.nats.publish(data)
+
+    def jobKilled(self):
+        """
+        _jobKilled_
+
+        If the job is killed let's inform its ungraceful end
+        """
+        data = dict(self.data)
+        data['exitCode'] = 71300  # WMAgent job kill exit code
+        self.nats.publish(data=data)
+
+    def stepStart(self, step):
+        """
+        _stepStart_
+
+        Fill with the step-based information. If it is the first step, report
+        that the job started its execution.
+        """
+
+        helper = WMStepHelper(step)
+        data = dict(self.data)
+        data['step'] = helper.name()
+        self.nats.publish(data)
+
+    def stepEnd(self, step, stepReport):
+        """
+        _stepEnd_
+
+        Fill with step-ending information
+        """
+        helper = WMStepHelper(step)
+        data = dict(self.data)
+        data['step'] = helper.name()
+        data['exitCode'] = stepReport.getStepExitCode(stepName=helper.name())
+        self.nats.publish(data=data)
+
+    def stepKilled(self, step):
+        """
+        _stepKilled_
+
+        Fill with step-ending information assuming utter failure
+        """
+
+        helper = WMStepHelper(step)
+        data = dict(self.data)
+        data['step'] = helper.name()
+        # step should have: step.execution.exitStatus
+        # we'll try to extract it , otherwise assign WMAgent job kill exit code
+        exitCode = getattr(getattr(step, 'execution', ''), 'exitStatus', 71300)
+        data['exitCode'] = exitCode
+        self.nats.publish(data=data)
+
+    def periodicUpdate(self):
+        """
+        _periodicUpdate_
+        One day this will do something useful.
+        """
+        pass

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -243,6 +243,7 @@ class StdBase(object):
         monitoring.PerformanceMonitor.maxPSS = maxpss
         monitoring.PerformanceMonitor.softTimeout = softTimeout
         monitoring.PerformanceMonitor.hardTimeout = hardTimeout
+        monitoring.section_("NATSMonitor")
         return task
 
     def reportWorkflowToDashboard(self, dashboardActivity):


### PR DESCRIPTION
Fixes : there is no issues

#### Status
In development

#### Description
This PR provides a NATS interface for WMAgent/WMCore/ReqMgr2. It was defined as analogous to DashboardInterface and consists of two classes:
- NATSInterface which extract proper information from task/job
- NATSMonitor a generic monitor interface for WMAgent/WMCore
It also adds [NATSManager](https://github.com/dmwm/CMSMonitoring/blob/master/src/python/CMSMonitoring/NATS.py) to [Request.py](https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/ReqMgr/Service/Request.py) and NATSMonitor to [StdBase](https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/WMSpec/StdSpecs/StdBase.py). The former will allow to yield messages on ReqMgr workflow transitions, while later supposes to cover WMAgent production activity at a site.

To validate the functionality we need to run an external NATS subscriber which will listen to NATS server. The NATS subscriber tool can be obtained on AFS: /afs/cern.ch/user/v/valya/public/nats-sub and it can be run as following:
```
# to monitor reqmgr2 messages
./nats-sub -rootCAs=/path/certificates/CERN_CA.crt,/path/certificates/CERN_CA1.crt -t "cms.reqmgr2.>"

# to monitor WMA messages
./nats-sub -rootCAs=/path/certificates/CERN_CA.crt,/path/certificates/CERN_CA1.crt -t "cms.wma.>"
```

The tool requires rootCAs certificates which can be obtained from `ca.cern.ch` and placed elsewhere, as well as it requires `$HOME/.nats/cms-auth` file which contains login:password to authenticate with NATS server.

In case of ReqMgr2 monitoring we should simply add a new workflow to ReqMgr2 and monitor its transition changes, e.g. here are expected messages:
```
# the message is composed by TimeStamp Task OutputDatasets ProcessingString Priority Status
2019/12/10 16:07:30 valya_TaskChain_MC_Agent105_CDB16_pre_191210_160725_4377 ["/RelValProdQCD_Pt_3000_3500_13/CMSSW_8_1_0-81X_mcRun2_asymptotic_v12-v20/GEN-SIM", "/RelValProdQCD_Pt_3000_3500_13/CMSSW_8_1_0-81X_mcRun2_asymptotic_v12-v20/AODSIM", "/RelValProdQCD_Pt_3000_3500_13/CMSSW_8_1_0-81X_mcRun2_asymptotic_v12-v20/DQMIO", "/RelValProdQCD_Pt_3000_3500_13/CMSSW_8_1_0-81X_mcRun2_asymptotic_v12-v20/MINIAODSIM"] 81X_mcRun2_asymptotic_v12 600000 new
2019/12/10 16:07:30 valya_TaskChain_MC_Agent105_CDB16_pre_191210_160725_4377 []  0 assignment-approved
2019/12/10 16:07:30 valya_TaskChain_MC_Agent105_CDB16_pre_191210_160725_4377 ["/RelValProdQCD_Pt_3000_3500_13/CMSSW_8_1_0-ProdQCD_Pt_3000_3500_13_TaskChain_MC_pre_VK_TEST-v11/GEN-SIM", "/RelValProdQCD_Pt_3000_3500_13/CMSSW_8_1_0-RECOPRODUP15_TaskChain_MC_pre_VK_TEST-v11/AODSIM", "/RelValProdQCD_Pt_3000_3500_13/CMSSW_8_1_0-RECOPRODUP15_TaskChain_MC_pre_VK_TEST-v11/DQMIO", "/RelValProdQCD_Pt_3000_3500_13/CMSSW_8_1_0-RECOPRODUP15_TaskChain_MC_pre_VK_TEST-v11/MINIAODSIM"] ["DIGIUP15PROD1", "ProdQCD_Pt_3000_3500_13", "RECOPRODUP15"] 0 assigned
```

In case of WMA monitoring we need to assign a job to WMAgent and monitor its progress using `cms.wma.>` end-point of NATS subscriber (see example of `nats-sub` call above). In that case the messages on that end-point should contains site, job, exitcode, step information. These attributes are defined in NATSMonitor (see files in this PR).

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
This PR fixes the following issues: #9449, #9448 

#### External dependencies / deployment changes
[CMSMonitoring](github.com/dmwm/CMSMonitoring) package provides all required dependencies.
