### PR TITLE
Log workflows and document IDs going through bulk deletion requests

### DIFF
--- a/src/python/WMCore/Database/CMSCouch.py
+++ b/src/python/WMCore/Database/CMSCouch.py
@@ -674,6 +674,9 @@ class Database(CouchDBRequests):
         docs = self.allDocs(keys=ids)['rows']
         for j in docs:
             doc = {}
+            if "id" not in j:
+                print("Document not found: %s" % j)
+                continue
             doc["_id"] = j['id']
             doc["_rev"] = j['value']['rev']
             self.queueDelete(doc)

--- a/src/python/WMCore/GlobalWorkQueue/CherryPyThreads/CleanUpTask.py
+++ b/src/python/WMCore/GlobalWorkQueue/CherryPyThreads/CleanUpTask.py
@@ -1,5 +1,6 @@
 from __future__ import (division, print_function)
 
+from time import time
 from WMCore.REST.CherryPyPeriodicTask import CherryPyPeriodicTask
 from WMCore.WorkQueue.WorkQueue import globalQueue
 
@@ -22,8 +23,9 @@ class CleanUpTask(CherryPyPeriodicTask):
         2. synchronize cancelled elements.
         We can also make this in the separate thread
         """
-
+        start = int(time())
         globalQ = globalQueue(**config.queueParams)
         globalQ.performQueueCleanupActions(skipWMBS=True)
-
+        end = int(time())
+        self.logger.info("%s executed in %d secs.", self.__class__.__name__, end - start)
         return

--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -911,12 +911,14 @@ class WorkQueue(WorkQueueBase):
 
         # fetch workflows known to workqueue + workqueue_inbox and with spec attachments
         reqNames = self.backend.getWorkflows(includeInbox=True, includeSpecs=True)
+        self.logger.info("Retrieved %d workflows known by WorkQueue", len(reqNames))
         requestsInfo = self.requestDB.getRequestByNames(reqNames)
         deleteRequests = []
         for key, value in requestsInfo.items():
             if (value["RequestStatus"] is None) or (value["RequestStatus"] in deletableStates):
                 deleteRequests.append(key)
-
+        self.logger.info("Found %d out of %d workflows in a deletable state",
+                         len(deleteRequests), len(reqNames))
         return self.backend.deleteWQElementsByWorkflow(deleteRequests)
 
     def performSyncAndCancelAction(self, skipWMBS):
@@ -987,6 +989,7 @@ class WorkQueue(WorkQueueBase):
         msg = 'Finished elements: %s\nCanceled workflows: %s' % (', '.join(["%s (%s)" % (x.id, x['RequestName']) \
                                                                             for x in finished_elements]),
                                                                  ', '.join(wf_to_cancel))
+        self.logger.info(msg)
         self.backend.recordTaskActivity('housekeeping', msg)
 
     def performQueueCleanupActions(self, skipWMBS=False):


### PR DESCRIPTION
Fixes #9445 

#### Status
ready

#### Description
It doesn't really fix the issue it says to fix, because we didn't manage to get to the root cause of the problem, but ...

Changes are mostly related to logging. With this patch, we can see:
* against which couch database we are executing a bulk deletion
* against which workflow
* and which document IDs exactly!

In addition to that, I added a try/except when fetching all the docs (within the bulk request), because documents might get deleted during the whole and we'd get a KeyError exception.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
None

#### External dependencies / deployment changes
None
