### PR TITLE
Update JobSubmitter for docker support

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -80,6 +80,7 @@ config.Agent.agentNumber = 0
 config.Agent.useMsgService = False
 config.Agent.useTrigger = False
 config.Agent.useHeartbeat = True
+config.Agent.isDocker = False
 
 config.section_("General")
 config.General.workDir = workDirectory

--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -100,10 +100,16 @@ class SimpleCondorPlugin(BasePlugin):
 
         self.packageDir = None
 
-        if os.path.exists(os.path.join(getWMBASE(),
-                                       'src/python/WMCore/WMRuntime/Unpacker.py')):
-            self.unpacker = os.path.join(getWMBASE(),
-                                         'src/python/WMCore/WMRuntime/Unpacker.py')
+        # if agent is running in a container, Unpacker.py must come from a directory
+        # on the host so the condor schedd can see it
+        # config.General.workDir should always be bind mounted to the container
+        if getattr(config.Agent, "isDocker", False):
+            unpackerPath = os.path.join(config.General.workDir + "/Docker/WMRuntime/Unpacker.py")
+        else:
+            unpackerPath = os.path.join(getWMBASE(), 'src/python/WMCore/WMRuntime/Unpacker.py')
+
+        if os.path.exists(unpackerPath):
+            self.unpacker = unpackerPath
         else:
             self.unpacker = os.path.join(getWMBASE(),
                                          'WMCore/WMRuntime/Unpacker.py')

--- a/src/python/WMQuality/Emulators/EmulatorSetup.py
+++ b/src/python/WMQuality/Emulators/EmulatorSetup.py
@@ -48,6 +48,7 @@ def _wmAgentConfig(configFile):
     config.Agent.agentName = "WMAgentCommissioning"
     config.Agent.useMsgService = False
     config.Agent.useTrigger = False
+    config.Agent.isDocker = False
 
     # BossAir setup
     config.section_("BossAir")

--- a/test/python/WMComponent_t/JobSubmitter_t/JobSubmitterCaching_t.py
+++ b/test/python/WMComponent_t/JobSubmitter_t/JobSubmitterCaching_t.py
@@ -77,6 +77,9 @@ class JobSubmitterCachingTest(EmulatedUnitTestCase):
         config = self.testInit.getConfiguration()
         self.testInit.generateWorkDir(config)
 
+        config.component_("Agent")
+        config.Agent.isDocker = False
+
         config.section_("JobStateMachine")
         config.JobStateMachine.couchurl = os.getenv("COUCHURL")
         config.JobStateMachine.couchDBName = "jobsubmittercaching_t"

--- a/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
+++ b/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
@@ -247,6 +247,7 @@ class JobSubmitterTest(EmulatedUnitTestCase):
         config.Agent.hostName = 'testAgent'
         config.Agent.componentName = self.componentName
         config.Agent.useHeartbeat = False
+        config.Agent.isDocker = False
 
         # First the general stuff
         config.section_("General")

--- a/test/python/WMCore_t/BossAir_t/BossAir_t.py
+++ b/test/python/WMCore_t/BossAir_t/BossAir_t.py
@@ -160,6 +160,7 @@ class BossAirTest(unittest.TestCase):
         config.Agent.agentName = 'testAgent'
         config.Agent.componentName = 'test'
         config.Agent.useHeartbeat = False
+        config.Agent.isDocker = False
 
         config.section_("CoreDatabase")
         config.CoreDatabase.connectUrl = os.getenv("DATABASE")


### PR DESCRIPTION
#### Status
Tested

#### Description
We need to modify the location of Unpacker.py for agents running in Docker containers. Since the schedd runs on the host, this script must exist somewhere on the host and be available through bind mounts in the container.

Uses an "isDocker" configuration parameter to differentiate between Docker and the standard VM WMAgent deployment and change the Unpacker.py path. The isDocker variable is updated to True when a container starts via https://github.com/dmwm/CMSKubernetes/blob/master/docker/wmagent/run.sh.

#### Is it backward compatible (if not, which system it affects?)
Yes

#### Related PRs
NA

#### External dependencies / deployment changes
NA
