### PR TITLE
During deployment, activate agent after applying PR patches

### DIFF
--- a/deploy/deploy-wmagent.sh
+++ b/deploy/deploy-wmagent.sh
@@ -281,11 +281,6 @@ cd $CURRENT_DIR
 cd -
 echo "Done!" && echo
 
-echo -e "\n*** Activating the agent ***"
-cd $MANAGE_DIR
-./manage activate-agent
-echo "Done!" && echo
-
 # By default, it will only work for official WMCore patches in the general path
 echo -e "\n*** Applying agent patches ***"
 if [ "x$PATCHES" != "x" ]; then
@@ -295,6 +290,11 @@ if [ "x$PATCHES" != "x" ]; then
   done
 cd -
 fi
+echo "Done!" && echo
+
+echo -e "\n*** Activating the agent ***"
+cd $MANAGE_DIR
+./manage activate-agent
 echo "Done!" && echo
 
 ### Enabling couch watchdog; couchdb fix for file descriptors


### PR DESCRIPTION
#### Status
Tested

#### Description
If you have a PR that updates the agent base config (WMAgentConfig.py) and you try to apply it during agent deployment, it never updates. That is because the "activate-agent" function of the manage script copies the default config to /data/srv/wmagent/current/config before the PR patches are applied. 

https://github.com/dmwm/deployment/blob/2536c3673535d1e19515f3ca06c92db7007bf1a4/wmagent/manage#L102

This PR reverses the order so you can at least apply a WMAgentConfig.py patch during deployment by specifying the pull path to the file like this:

```
|diff --git a/etc/WMAgentConfig.py b/etc/WMAgentConfig.py
|index 6a0087de07..34049fcd79 100644
|--- a/etc/WMAgentConfig.py
|+++ b/etc/WMAgentConfig.py
--------------------------
File to patch: /data/srv/wmagent/current/sw/slc7_amd64_gcc630/cms/wmagent/1.2.6.patch1/etc/WMAgentConfig.py
patching file /data/srv/wmagent/current/sw/slc7_amd64_gcc630/cms/wmagent/1.2.6.patch1/etc/WMAgentConfig.py
```
Then you don't have to manually patch the agent config later (after `wmagent-mod-config` has already run), which is pretty annoying in some cases.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
NA

#### External dependencies / deployment changes
NA
