### PR TITLE
Do not transfer block/dataset if already available within the SiteWhitelist

### DIFF
--- a/src/python/WMCore/MicroService/Unified/MSCore.py
+++ b/src/python/WMCore/MicroService/Unified/MSCore.py
@@ -31,8 +31,8 @@ class MSCore(object):
         self.msConfig = msConfig
         self.logger.info("Configuration including default values:\n%s", self.msConfig)
 
-        self.reqmgr2 = ReqMgr(self.msConfig['reqmgrUrl'], logger=self.logger)
-        self.reqmgrAux = ReqMgrAux(self.msConfig['reqmgrUrl'],
+        self.reqmgr2 = ReqMgr(self.msConfig['reqmgr2Url'], logger=self.logger)
+        self.reqmgrAux = ReqMgrAux(self.msConfig['reqmgr2Url'],
                                    httpDict={'cacheduration': 1.0},
                                    logger=self.logger)
 

--- a/src/python/WMCore/MicroService/Unified/MSManager.py
+++ b/src/python/WMCore/MicroService/Unified/MSManager.py
@@ -92,25 +92,15 @@ class MSManager(object):
         Parse the MicroService configuration and set any default values.
         :param config: config as defined in the deployment
         """
-        self.logger.info("Using the following config:\n%s", config)
-
-        self.msConfig = {}
-        self.msConfig['verbose'] = getattr(config, 'verbose', False)
-        self.msConfig['group'] = getattr(config, 'group', 'DataOps')
-        self.msConfig['interval'] = getattr(config, 'interval', 5 * 60)
-        self.msConfig['readOnly'] = getattr(config, 'readOnly', True)
-        self.msConfig['rucioAccount'] = getattr(config, 'rucioAccount', 'wma_prod')
+        self.logger.info("Using the following MicroServices config: %s", config.dictionary_())
         self.services = getattr(config, 'services', [])
 
-        reqmgr2Url = 'https://cmsweb.cern.ch/reqmgr2'
-        self.msConfig['reqmgrUrl'] = getattr(config, 'reqmgr2Url', reqmgr2Url)
-        self.msConfig['reqmgrCacheUrl'] = \
-            self.msConfig['reqmgrUrl'].replace(
-                'reqmgr2', 'couchdb/reqmgr_workload_cache')
-        phedexUrl = 'https://cmsweb.cern.ch/phedex/datasvc/json/prod'
-        self.msConfig['phedexUrl'] = getattr(config, 'phedexUrl', phedexUrl)
-        dbsUrl = 'https://cmsweb.cern.ch/dbs/prod/global/DBSReader'
-        self.msConfig['dbsUrl'] = getattr(config, 'dbsUrl', dbsUrl)
+        self.msConfig = {}
+        self.msConfig.update(config.dictionary_())
+        self.msConfig.setdefault("useRucio", False)
+
+        self.msConfig['reqmgrCacheUrl'] = self.msConfig['reqmgr2Url'].replace('reqmgr2',
+                                                                              'couchdb/reqmgr_workload_cache')
 
     def transferor(self, reqStatus):
         """

--- a/src/python/WMCore/MicroService/Unified/RequestInfo.py
+++ b/src/python/WMCore/MicroService/Unified/RequestInfo.py
@@ -20,7 +20,8 @@ from WMCore.MicroService.DataStructs.Workflow import Workflow
 from WMCore.MicroService.Unified.Common import \
     elapsedTime, cert, ckey, workflowsInfo, eventsLumisInfo, getIO, \
     dbsInfo, phedexInfo, getComputingTime, getNCopies, teraBytes, \
-    findBlockParents, findParent, getDbsBlocksRun, getFileLumisInBlock, phedexValidBlocks
+    findBlockParents, findParent, getDbsBlocksRun, getFileLumisInBlock, \
+    getBlockReplicasAndSize, getPileupDatasetSizes, getPileupSubscriptions
 from WMCore.MicroService.Unified.MSCore import MSCore
 from WMCore.MicroService.Unified.SiteInfo import SiteInfo
 from WMCore.Services.pycurl_manager import getdata \
@@ -38,7 +39,6 @@ class RequestInfo(MSCore):
         Basic setup for this RequestInfo module
         """
         super(RequestInfo, self).__init__(msConfig, logger)
-        self.cachePileupSize = {}
 
     def __call__(self, reqRecords):
         """
@@ -69,14 +69,6 @@ class RequestInfo(MSCore):
 
         return workflows
 
-    def clearPileupCache(self):
-        """
-        Clears the in-memory pileup cache for every cycle of
-        the MSTransferor module.
-        Cache stores only the total size for secondary datasets
-        """
-        self.cachePileupSize.clear()
-
     def unified(self, uConfig, workflows):
         """
         Unified Transferor black box
@@ -85,25 +77,34 @@ class RequestInfo(MSCore):
         """
         # get aux info for dataset/blocks from inputs/parents/pileups
         # make subscriptions based on site white/black lists
-        self.logger.info("unified processing %d requests", len(workflows))
+        self.logger.info("### unified processing %d requests", len(workflows))
 
         orig = time.time()
         # start by finding what are the parent datasets for requests requiring it
         time0 = time.time()
-        self.getParentDatasets(workflows)
+        parentMap = self.getParentDatasets(workflows)
+        self.setParentDatasets(workflows, parentMap)
         self.logger.debug(elapsedTime(time0, "### getParentDatasets"))
 
-        # get final primary and secondaries list of blocks to be replicated
-        # as well as an initial list of block parents
+        # then check the secondary dataset sizes and locations
         time0 = time.time()
-        self.getInputDataBlocks(workflows)
+        sizeByDset, locationByDset = self.getSecondaryDatasets(workflows)
+        self.setSecondaryDatasets(workflows, sizeByDset, locationByDset)
+        self.logger.debug(elapsedTime(time0, "### getSecondaryDatasets"))
+
+        # get final primary and parent list of valid blocks,
+        # considering run, block and lumi lists
+        time0 = time.time()
+        blocksByDset = self.getInputDataBlocks(workflows)
+        self.setInputDataBlocks(workflows, blocksByDset)
         self.logger.debug(elapsedTime(time0, "### getInputDataBlocks"))
 
         # get a final list of parent blocks
         time0 = time.time()
-        self.getParentChildBlocks(workflows)
+        parentageMap = self.getParentChildBlocks(workflows)
+        self.setParentChildBlocks(workflows, parentageMap)
         self.logger.debug(elapsedTime(time0, "### getParentChildBlocks"))
-        self.logger.debug(elapsedTime(orig, '### total time'))
+        self.logger.debug(elapsedTime(orig, '### total time for unified method'))
 
         return workflows
 
@@ -134,7 +135,7 @@ class RequestInfo(MSCore):
 
         # find dataset info
         time0 = time.time()
-        datasetBlocks, datasetSizes, datasetTransfers = dbsInfo(datasets, self.msConfig['dbsUrl'])
+        datasetBlocks, datasetSizes, _datasetTransfers = dbsInfo(datasets, self.msConfig['dbsUrl'])
         self.logger.debug(elapsedTime(time0, "### dbsInfo"))
 
         # find block nodes information for our datasets
@@ -216,8 +217,9 @@ class RequestInfo(MSCore):
 
     def getParentDatasets(self, workflows):
         """
-        Given a list of requests, find which requests need to process the parent
+        Given a list of requests, find which requests need to process a parent
         dataset, and discover what the parent dataset name is.
+        :return: dictionary with the child and the parent dataset
         """
         datasetByDbs = {}
         for wflow in workflows:
@@ -225,49 +227,84 @@ class RequestInfo(MSCore):
                 datasetByDbs.setdefault(wflow.getDbsUrl(), set())
                 datasetByDbs[wflow.getDbsUrl()].add(wflow.getInputDataset())
 
+        parentageMap = {}
         for dbsUrl, datasets in datasetByDbs.items():
             self.logger.info("Resolving %d dataset parentage against DBS: %s", len(datasets), dbsUrl)
             # first find out what's the parent dataset name
-            parentageMap = findParent(datasets, dbsUrl)
-            for wflow in workflows:
-                if wflow.hasParents() and wflow.getInputDataset() in parentageMap:
-                    wflow.setParentDataset(parentageMap[wflow.getInputDataset()])
+            parentageMap.update(findParent(datasets, dbsUrl))
+        return parentageMap
 
-    def getInputDataBlocks(self, workflows):
+    def setParentDatasets(self, workflows, parentageMap):
         """
-        Given a list of requests and their input data -  primary, secondary and
-        parent datasets - find all their respective blocks (and their sizes) to
-        be transferred.
+        Set the parent dataset for workflows requiring parents
+        """
+        for wflow in workflows:
+            if wflow.hasParents() and wflow.getInputDataset() in parentageMap:
+                wflow.setParentDataset(parentageMap[wflow.getInputDataset()])
+
+    def getSecondaryDatasets(self, workflows):
+        """
+        Given a list of requests, list all the pileup datasets and, find their
+        total dataset sizes and which locations host completed and subscribed datasets.
         NOTE it only uses valid blocks (i.e., blocks with at least one replica!)
         :param workflows: a list of Workflow objects
+        :return: two dictionaries keyed by the dataset.
+           First contains dataset size as value.
+           Second contains a list of locations as value.
         """
         datasets = set()
         for wflow in workflows:
-            if wflow.getReqType() == 'StoreResults':
-                # don't make any transfer, such requests are assigned where
-                # the data is already available
-                continue
-            else:
-                for dataIn in wflow.getDataCampaignMap():
-                    if dataIn['type'] == "secondary" and dataIn['name'] in self.cachePileupSize:
-                        # fetch the total dataset size from the cache then
-                        continue
+            datasets = datasets | wflow.getPileupDatasets()
+
+        # now fetch valid blocks from PhEDEx and calculate the total dataset size
+        self.logger.info("Fetching pileup dataset sizes for %d datasets against PhEDEx: %s",
+                         len(datasets), self.msConfig['phedexUrl'])
+        sizesByDset = getPileupDatasetSizes(datasets, self.msConfig['phedexUrl'])
+
+        # then fetch data location for subscribed data, under the group provided in the config
+        self.logger.info("Fetching pileup dataset location for %d datasets against PhEDEx: %s",
+                         len(datasets), self.msConfig['phedexUrl'])
+        locationsByDset = getPileupSubscriptions(datasets, self.msConfig['phedexUrl'],
+                                              self.msConfig['quotaAccount'], self.msConfig['minPercentCompletion'])
+        return sizesByDset, locationsByDset
+
+    def setSecondaryDatasets(self, workflows, sizesByDset, locationsByDset):
+        """
+        Given dictionaries with the pileup dataset size and locations, set the
+        workflow object accordingly.
+        """
+        for wflow in workflows:
+            for dsetName in wflow.getPileupDatasets():
+                wflow.setSecondarySummary(dsetName, sizesByDset[dsetName], locationsByDset[dsetName])
+
+    def getInputDataBlocks(self, workflows):
+        """
+        Given a list of requests, list all the primary and parent datasets and, find
+        their block sizes and which locations host completed and subscribed blocks
+        NOTE it only uses valid blocks (i.e., blocks with at least one replica!)
+        :param workflows: a list of Workflow objects
+        :return: dictionary with dataset and a few block information
+        """
+        datasets = set()
+        for wflow in workflows:
+            for dataIn in wflow.getDataCampaignMap():
+                if dataIn['type'] in ["primary", "parent"]:
                     datasets.add(dataIn['name'])
 
         # now fetch block names from DBS
         self.logger.info("Fetching block info for %d datasets against PhEDEx: %s",
                          len(datasets), self.msConfig['phedexUrl'])
-        blocksByDset = phedexValidBlocks(datasets, self.msConfig['phedexUrl'])
+        blocksByDset = getBlockReplicasAndSize(datasets, self.msConfig['phedexUrl'], self.msConfig['quotaAccount'])
+        return blocksByDset
+
+    def setInputDataBlocks(self, workflows, blocksByDset):
+        """
+        Provided a dictionary structure of dictionary, block name, and a couple of
+        block information, set the workflow attributes accordingly.
+        """
         for wflow in workflows:
             for dataIn in wflow.getDataCampaignMap():
-                if dataIn['type'] == "secondary" and dataIn['name'] in self.cachePileupSize:
-                    self.logger.debug("Using PU data from the cache for %s", dataIn['name'])
-                    wflow.setSecondarySummary(dataIn['name'], self.cachePileupSize[dataIn['name']])
-                elif dataIn['type'] == "secondary":
-                    # simply calculate the total dataset size and cache it as well
-                    totalSize = self._getPileupSize(dataIn['name'], blocksByDset[dataIn['name']])
-                    wflow.setSecondarySummary(dataIn['name'], totalSize)
-                elif dataIn['type'] == "primary":
+                if dataIn['type'] == "primary":
                     newBlockDict = self._handleInputDataInfo(wflow, dataIn['name'],
                                                              blocksByDset[dataIn['name']])
                     wflow.setPrimaryBlocks(newBlockDict)
@@ -350,19 +387,6 @@ class RequestInfo(MSCore):
         # case where there is no lumi list neither run list
         return blocksDict
 
-    def _getPileupSize(self, dsetName, blocksDict):
-        """
-        Iterate over all blocks in the dictionary and sum up their
-        block sizes. In the end store the dataset and its total size
-        in the local cache as well.
-        :param dsetName: secondary dataset name string.
-        :param blocksDict: dictionary of block names and their size
-        :return: total size in bytes
-        """
-        totalSize = sum(blocksDict.values())
-        self.cachePileupSize[dsetName] = totalSize
-        return totalSize
-
     def getParentChildBlocks(self, workflows):
         """
         Given a list of requests, get their children block, discover their parent blocks
@@ -374,23 +398,30 @@ class RequestInfo(MSCore):
         for wflow in workflows:
             blocksByDbs.setdefault(wflow.getDbsUrl(), set())
             if wflow.getParentDataset():
-                blocksByDbs[wflow.getDbsUrl()] = \
-                    blocksByDbs[wflow.getDbsUrl()].union(set(wflow.getPrimaryBlocks().keys()))
+                blocksByDbs[wflow.getDbsUrl()] = blocksByDbs[wflow.getDbsUrl()] | set(wflow.getPrimaryBlocks().keys())
 
+        parentageMap = {}
         for dbsUrl, blocks in blocksByDbs.items():
             if not blocks:
                 continue
             self.logger.debug("Fetching DBS parent blocks for %d children blocks...", len(blocks))
             # first find out what's the parent dataset name
-            parentageMap = findBlockParents(blocks, dbsUrl)
-            for wflow in workflows:
-                if wflow.getParentDataset() and wflow.getInputDataset() in parentageMap:
-                    wflow.setChildToParentBlocks(parentageMap[wflow.getInputDataset()])
+            parentageMap.update(findBlockParents(blocks, dbsUrl))
+        return parentageMap
+
+    def setParentChildBlocks(self, workflows, parentageMap):
+        """
+        Provided a dictionary with the dataset, the child block and a set
+        of the parent blocks, set the workflow attribute accordingly
+        """
+        for wflow in workflows:
+            if wflow.getParentDataset() and wflow.getInputDataset() in parentageMap:
+                wflow.setChildToParentBlocks(parentageMap[wflow.getInputDataset()])
 
     # FIXME: get rid of this method and use the Workflow objects instead
     def _getRequestWorkflows(self, requestNames):
         "Helper function to get all specs for given set of request names"
-        urls = [str('%s/data/request/%s' % (self.msConfig['reqmgrUrl'], r)) for r in requestNames]
+        urls = [str('%s/data/request/%s' % (self.msConfig['reqmgr2Url'], r)) for r in requestNames]
         self.logger.debug("getRequestWorkflows")
         for u in urls:
             self.logger.debug("url %s", u)

--- a/test/python/WMCore_t/MicroService_t/DataStructs_t/Workflow_t.py
+++ b/test/python/WMCore_t/MicroService_t/DataStructs_t/Workflow_t.py
@@ -18,7 +18,8 @@ class WorkflowTest(unittest.TestCase):
         Test setting the data campaign map for a TaskChain-like request
         """
         parentDset = "/any/parent-dataset/tier"
-        tChainSpec = {"TaskChain": 4,
+        tChainSpec = {"RequestType": "TaskChain",
+                      "TaskChain": 4,
                       "Campaign": "top-campaign",
                       "RequestName": "whatever_name",
                       "Task1": {"InputDataset": "/task1/input-dataset/tier",
@@ -56,7 +57,8 @@ class WorkflowTest(unittest.TestCase):
         Test loading a ReReco like request into Workflow
         """
         parentDset = "/rereco/parent-dataset/tier"
-        rerecoSpec = {"InputDataset": "/rereco/input-dataset/tier",
+        rerecoSpec = {"RequestType": "ReReco",
+                      "InputDataset": "/rereco/input-dataset/tier",
                       "Campaign": "any-campaign",
                       "RequestName": "whatever_name",
                       "DbsUrl": "a_dbs_url",
@@ -85,7 +87,8 @@ class WorkflowTest(unittest.TestCase):
         """
         Test loading a TaskChain like request into Workflow
         """
-        tChainSpec = {"TaskChain": 3,
+        tChainSpec = {"RequestType": "TaskChain",
+                      "TaskChain": 3,
                       "Campaign": "top-campaign",
                       "RequestName": "whatever_name",
                       "DbsUrl": "a_dbs_url",
@@ -120,7 +123,8 @@ class WorkflowTest(unittest.TestCase):
         """
         Test loading a StepChain like request into Workflow
         """
-        tChainSpec = {"StepChain": 3,
+        tChainSpec = {"RequestType": "StepChain",
+                      "StepChain": 3,
                       "Campaign": "top-campaign",
                       "RequestName": "whatever_name",
                       "DbsUrl": "a_dbs_url",
@@ -150,6 +154,21 @@ class WorkflowTest(unittest.TestCase):
         self.assertEqual(wflow.getParentBlocks(), {})
         self.assertEqual(wflow._getValue("NoKey"), None)
         self.assertEqual(len(wflow.getDataCampaignMap()), 3)
+
+    def testResubmission(self):
+        """
+        Test loading a Resubmission like request into Workflow
+        """
+        rerecoSpec = {"RequestType": "Resubmission",
+                      "InputDataset": "/rereco/input-dataset/tier",
+                      "Campaign": "any-campaign",
+                      "RequestName": "whatever_name",
+                      "DbsUrl": "a_dbs_url",
+                      "SiteWhitelist": ["CERN", "FNAL", "DESY"],
+                      "SiteBlacklist": ["FNAL"]}
+        wflow = Workflow(rerecoSpec['RequestName'], rerecoSpec)
+        # we do not set any map for Resubmission workflows
+        self.assertEqual(wflow.getDataCampaignMap(), [])
 
 
 if __name__ == '__main__':

--- a/test/python/WMCore_t/MicroService_t/Unified_t/MSManager_t.py
+++ b/test/python/WMCore_t/MicroService_t/Unified_t/MSManager_t.py
@@ -17,17 +17,23 @@ class MSManagerTest(unittest.TestCase):
     def setUp(self):
         "Setup MSManager for testing"
         config = Configuration()
-        self.mgr = MSManager(config)
+        data = config.section_('data')
+        data.reqmgr2Url = "http://localhost/reqmgr2"
+        data.readOnly = True
+        data.verbose = True
+        data.interval = 600
+        data.quotaUsage = 0.8
+        data.quotaAccount = "DataOps"
+        data.rucioAccount = "test"
+        data.phedexUrl = "https://cmsweb.cern.ch/phedex/datasvc/json/prod"
+        data.dbsUrl = "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader"
+        self.mgr = MSManager(data)
 
-        config = Configuration()
-        config.section_("MS")
-        config.MS.services = ['transferor']
-        self.mgr_trans = MSManager(config.MS)
+        data.services = ['transferor']
+        self.mgr_trans = MSManager(data)
 
-        config = Configuration()
-        config.section_("MS")
-        config.MS.services = ['monitor']
-        self.mgr_monit = MSManager(config.MS)
+        data.services = ['monitor']
+        self.mgr_monit = MSManager(data)
 
     def tearDown(self):
         "Tear down MSManager"

--- a/test/python/WMCore_t/MicroService_t/Unified_t/MSMonitor_t.py
+++ b/test/python/WMCore_t/MicroService_t/Unified_t/MSMonitor_t.py
@@ -26,7 +26,7 @@ class MSMonitorTest(EmulatedUnitTestCase):
                          'interval': 1 * 60,
                          'updateInterval': 0,
                          'readOnly': True,
-                         'reqmgrUrl': 'https://cmsweb-testbed.cern.ch/reqmgr2',
+                         'reqmgr2Url': 'https://cmsweb-testbed.cern.ch/reqmgr2',
                          'reqmgrCacheUrl': 'https://cmsweb-testbed.cern.ch/couchdb/reqmgr_workload_cache',
                          'phedexUrl': 'https://cmsweb-testbed.cern.ch/phedex/datasvc/json/prod',
                          'dbsUrl': 'https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader'}


### PR DESCRIPTION
Fixes #9436 

#### Status
not-tested

#### Description
In short, don't transfer any input data if it's already available in a sub-set of the SiteWhitelist.

At length, changes are:
* added a new configurable parameter `minPercentCompletion`, used to evaluate whether a dataset is fully available at a location or not (default is 99%)
* bypass any input data placement for `StoreResults` and `Resubmission` workflows
* changed the format of `primaryBlocks` within a Workflow object such that it holds the block location too
* changed the format of `parentBlocks` within a Workflow object such that it holds the block location too
* changed the format of `secondarySummaries` within a Workflow object such that it holds the dataset location too
* use `blockreplicas` PhEDEx API to fetch the pileup dataset size (getPileupDatasetSizes)
* use `blockreplicas` PhEDEx API to fetch the parent/primary block size and location, assuming that `complete=y & subscribed=y & group=DataOps` (getBlockReplicasAndSize)
* use `subscriptions` PhEDEx API to fetch DATASETs subscribed and their locations, assuming that `group=DataOps & percent_min=99` (getPileupSubscriptions)
* removed the in memory object caching for pileup dataset size. Rely on the Requests module cache.
* added `MSTransferor/checkDataPlacement` method to evaluate which input data is already available at the SiteWhitelist-SiteBlacklist; any data found is removed from the data placement

TODO:
* use the equivalent Rucio APIs (if service is configured to use Rucio)
* deal with multiple copies

#### Is it backward compatible (if not, which system it affects?)
different logic, but works with whatever is already in the system

#### Related PRs
none

#### External dependencies / deployment changes
none
