### PR TITLE
added more test campaigns to the parseUnifiedCampaigns script

### DIFF
--- a/bin/adhoc-scripts/parseUnifiedCampaigns.py
+++ b/bin/adhoc-scripts/parseUnifiedCampaigns.py
@@ -281,8 +281,8 @@ def insertTestCampaigns(mgr):
                    'SiteBlackList': [], 'SiteWhiteList': ["T1_US_FNAL", "T2_CH_CERN"]}
 
     testCamp = ("CMSSW_10_6_1_Step3", "CMSSW_9_4_0__test2inwf-1510737328", "CMSSW_7_3_2__test2inwf-1510737328",
-                "Aug2019_Val", "Sept2019_Val", "Oct2019_Val", "Nov2019_Val",
-                "HG1910_Val", "HG1911_Val", "Agent126_Val", "Agent128_Val")
+                "Dec2019_Val", "Jan2020_Val", "Feb2020_Val", "Agent128_Val",
+                "Agent130_Val", "HG1912_Val", "HG2001_Val", "HG2002_Val")
     for campName in testCamp:
         defaultCamp['CampaignName'] = campName
         upload(mgr, defaultCamp)


### PR DESCRIPTION
#### Status
ready

#### Description
Simply adding a few extra campaigns used during the validation phase.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
