### PR TITLE
Fix ReqMgrAux update wmagent config method

### DIFF
--- a/src/python/WMCore/Services/ReqMgrAux/ReqMgrAux.py
+++ b/src/python/WMCore/Services/ReqMgrAux/ReqMgrAux.py
@@ -86,7 +86,11 @@ class ReqMgrAux(Service):
                   'campaignconfig': self.getCampaignConfig,
                   'transferinfo': self.getTransferInfo}
 
-        thisDoc = apiMap[callName](resource)[0]
+        thisDoc = apiMap[callName](resource)
+        # getWMAgentConfig method returns directly the document, while the others
+        # return a list of document(s)
+        if isinstance(thisDoc, (list, set)):
+            thisDoc = thisDoc[0]
         thisDoc.update(kwparams)
         return self["requests"].put("%s/%s" % (callName, resource), thisDoc)[0]['result']
 


### PR DESCRIPTION
Fixes #9469 

#### Status
ready

#### Description
`getWMAgentConfig` method is actually used in multiple places, including a few components. So it might be easier and cleaner to just deal with that list within the updateRecords in place method.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none