### PR TITLE
Update port and library for webtest in the REST unit tests

### DIFF
--- a/test/python/WMCore_t/REST_t/Api_t.py
+++ b/test/python/WMCore_t/REST_t/Api_t.py
@@ -6,7 +6,7 @@ from multiprocessing import Process
 
 import cherrypy
 from cherrypy import response
-from cherrypy.test import webtest
+from cheroot.test import webtest
 
 # WMCore modules
 from WMCore.REST.Server import RESTApi, RESTEntity, restcall, rows
@@ -22,7 +22,7 @@ gif_bytes = ('GIF89a\x01\x00\x01\x00\x82\x00\x01\x99"\x1e\x00\x00\x00\x00\x00'
              '\x00,\x00\x00\x00\x00\x01\x00\x01\x00\x02\x03\x02\x08\t\x00;')
 
 FAKE_FILE = fake_authz_key_file()
-PORT = 8888
+PORT = 8887
 
 class Simple(RESTEntity):
     def validate(self, *args): pass

--- a/test/python/WMCore_t/REST_t/Simple_t.py
+++ b/test/python/WMCore_t/REST_t/Simple_t.py
@@ -1,6 +1,6 @@
 # system modules
 import cherrypy
-from cherrypy.test import webtest
+from cheroot.test import webtest
 from cherrypy import expose
 from multiprocessing import Process
 


### PR DESCRIPTION
Fixes #9476 

#### Status
not-tested

#### Description
It might be that the server isn't completely down when we try to start another one on the same port... Giving it a try.

I have also updated the `webtest` from cherrypy to cheroot. The former seems to have a deprecation warning.
 
#### Is it backward compatible (if not, which system it affects?)
yes
#### Related PRs
no

#### External dependencies / deployment changes
no