### PR TITLE
ReqMgr2MS more configurable: # of workflows; status transition; data transfers

### DIFF
--- a/src/python/WMCore/MicroService/Unified/MSCore.py
+++ b/src/python/WMCore/MicroService/Unified/MSCore.py
@@ -64,10 +64,12 @@ class MSCore(object):
         """
         Update the request status in ReqMgr2
         """
-        self.logger.info('%s updating %s status to: %s', prefix, reqName, reqStatus)
         try:
-            if not self.msConfig['readOnly']:
+            if self.msConfig['enableStatusTransition']:
+                self.logger.info('%s updating %s status to: %s', prefix, reqName, reqStatus)
                 self.reqmgr2.updateRequestStatus(reqName, reqStatus)
+            else:
+                self.logger.info('%s FAKE updating %s status to: %s', prefix, reqName, reqStatus)
         except Exception as err:
             self.logger.exception("Failed to change request status. Error: %s", str(err))
 

--- a/src/python/WMCore/MicroService/Unified/MSManager.py
+++ b/src/python/WMCore/MicroService/Unified/MSManager.py
@@ -13,7 +13,9 @@ used in service config.py as following
     data.object = 'WMCore.MicroService.Service.RestApiHub.RestApiHub'
     data.manager = 'WMCore.MicroService.Unified.MSManager.MSManager'
     data.reqmgr2Url = "%s/reqmgr2" % BASE_URL
-    data.readOnly = False
+    data.limitRequestsPerCycle = 500
+    data.enableStatusTransition = False
+    data.enableDataTransfer = False
     data.verbose = True
     data.interval = 60
     data.rucioAccount = RUCIO_ACCT

--- a/test/python/WMCore_t/MicroService_t/Unified_t/MSManager_t.py
+++ b/test/python/WMCore_t/MicroService_t/Unified_t/MSManager_t.py
@@ -19,21 +19,24 @@ class MSManagerTest(unittest.TestCase):
         config = Configuration()
         data = config.section_('data')
         data.reqmgr2Url = "http://localhost/reqmgr2"
-        data.readOnly = True
         data.verbose = True
         data.interval = 600
         data.quotaUsage = 0.8
         data.quotaAccount = "DataOps"
+        data.enableStatusTransition = True
         data.rucioAccount = "test"
         data.phedexUrl = "https://cmsweb.cern.ch/phedex/datasvc/json/prod"
         data.dbsUrl = "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader"
         self.mgr = MSManager(data)
 
-        data.services = ['transferor']
-        self.mgr_trans = MSManager(data)
-
         data.services = ['monitor']
         self.mgr_monit = MSManager(data)
+
+        data.services = ['transferor']
+        data.limitRequestsPerCycle = 50
+        data.enableDataTransfer = True
+        self.mgr_trans = MSManager(data)
+
 
     def tearDown(self):
         "Tear down MSManager"
@@ -65,6 +68,14 @@ class MSManagerTest(unittest.TestCase):
         self.assertEqual(hasattr(self.mgr_monit, 'transfThread'), False)
         self.assertEqual(hasattr(self.mgr_monit, 'msMonitor'), True)
         self.assertEqual(hasattr(self.mgr_monit, 'monitThread'), True)
+
+        # test a few configuration parameters as well
+        self.assertEqual(self.mgr_trans.msConfig.get("limitRequestsPerCycle"), 50)
+        self.assertFalse("limitRequestsPerCycle" in self.mgr_monit.msConfig)
+        self.assertTrue(self.mgr_trans.msConfig.get("enableStatusTransition"))
+        self.assertTrue("enableStatusTransition" in self.mgr_monit.msConfig)
+        self.assertTrue(self.mgr_trans.msConfig.get("enableDataTransfer"))
+        self.assertFalse("enableDataTransfer" in self.mgr_monit.msConfig)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/WMCore_t/MicroService_t/Unified_t/MSMonitor_t.py
+++ b/test/python/WMCore_t/MicroService_t/Unified_t/MSMonitor_t.py
@@ -25,7 +25,7 @@ class MSMonitorTest(EmulatedUnitTestCase):
                          'group': 'DataOps',
                          'interval': 1 * 60,
                          'updateInterval': 0,
-                         'readOnly': True,
+                         'enableStatusTransition': True,
                          'reqmgr2Url': 'https://cmsweb-testbed.cern.ch/reqmgr2',
                          'reqmgrCacheUrl': 'https://cmsweb-testbed.cern.ch/couchdb/reqmgr_workload_cache',
                          'phedexUrl': 'https://cmsweb-testbed.cern.ch/phedex/datasvc/json/prod',

--- a/test/python/WMCore_t/MicroService_t/Unified_t/MSTransferor_t.py
+++ b/test/python/WMCore_t/MicroService_t/Unified_t/MSTransferor_t.py
@@ -31,7 +31,7 @@ class TransferorTest(EmulatedUnitTestCase):
         self.msConfig = {'verbose': False,
                          'group': 'DataOps',
                          'interval': 1 * 60,
-                         'readOnly': True,
+                         'enableStatusTransition': True,
                          'reqmgrUrl': 'https://cmsweb-testbed.cern.ch/reqmgr2',
                          'reqmgrCacheUrl': 'https://cmsweb-testbed.cern.ch/couchdb/reqmgr_workload_cache',
                          'phedexUrl': 'https://cmsweb-testbed.cern.ch/phedex/datasvc/json/prod',


### PR DESCRIPTION
Fixes #9479 

#### Status
ready

#### Description
It supports different service configuration parameters, such as:
* `readOnly` has been removed
* `enableStatusTransition` decides whether MSTransferor/MSMonitor are allowed to request status transition
* `enableDataTransfer` decides whether MSTransferor can make data transfer requests (PhEDEx subscriptions and/or Rucio rules)
* `limitRequestsPerCycle` limit MSTransferor service to this amount of workflows per cycle (still obeying to the workflow priorities).

#### Is it backward compatible (if not, which system it affects?)
nope, new configuration attributes.

#### Related PRs
None

#### External dependencies / deployment changes
Yes, these deployment changes: https://github.com/dmwm/deployment/pull/829