### PR TITLE
Skip input data placement if data has availability AND AAA is enabled

### DIFF
--- a/src/python/WMCore/MicroService/DataStructs/Workflow.py
+++ b/src/python/WMCore/MicroService/DataStructs/Workflow.py
@@ -65,6 +65,15 @@ class Workflow(object):
         """
         return self.data['RequestType']
 
+    def getReqParam(self, param):
+        """
+        Return a top level parameter for this request.
+        Read: parameters internal to Task/Steps are not looked up.
+        """
+        if param not in self.data:
+            self.logger.warning("Request parameter '%s' not found in the workflow %s", param, self.getName())
+        return self.data.get(param)
+
     def getSitelist(self):
         """
         Get the SiteWhitelist minus the black list for this request

--- a/test/python/WMCore_t/MicroService_t/DataStructs_t/Workflow_t.py
+++ b/test/python/WMCore_t/MicroService_t/DataStructs_t/Workflow_t.py
@@ -170,6 +170,28 @@ class WorkflowTest(unittest.TestCase):
         # we do not set any map for Resubmission workflows
         self.assertEqual(wflow.getDataCampaignMap(), [])
 
+    def testGetParam(self):
+        """
+        Test the `getReqParam` method
+        """
+        tChainSpec = {"RequestType": "StepChain",
+                      "StepChain": 1,
+                      "Campaign": "top-campaign",
+                      "RequestName": "whatever_name",
+                      "DbsUrl": "a_dbs_url",
+                      "TrustSitelists": True,
+                      "SiteWhitelist": ["CERN", "FNAL", "DESY"],
+                      "SiteBlacklist": [],
+                      "Step1": {"InputDataset": "/step1/input-dataset/tier",
+                                "MCPileup": "/step1/mc-pileup/tier",
+                                "Campaign": "step1-campaign"},
+                      }
+        wflow = Workflow(tChainSpec['RequestName'], tChainSpec)
+        self.assertTrue(wflow.getReqParam("TrustSitelists"))
+        self.assertIsNone(wflow.getReqParam("MCPileup"))
+        self.assertEqual(wflow.getReqParam("RequestType"), wflow.getReqType())
+        self.assertEqual(wflow.getReqParam("RequestName"), wflow.getName())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #9482 

#### Status
not-tested

#### Description
With this patch, MSTransferor takes into consideration the AAA flags (`TrustSitelists`, `TrustPUSitelists`) before actually performing any input data placement.

In short:
* if `TrustSitelists` is enabled, check whether the input blocks are available somewhere on disk. If so, skip that given block from the data placement
* if `TrustPUSitelists` is enabled, check whether the input dataset is available somewhere on disk. If so, skip that dataset from the data placement

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none