### PR TITLE
Disconsider phedex group for input data existence check

### DIFF
--- a/src/python/WMCore/MicroService/Unified/Common.py
+++ b/src/python/WMCore/MicroService/Unified/Common.py
@@ -112,14 +112,16 @@ def getPileupDatasetSizes(datasets, phedexUrl):
     return sizeByDset
 
 
-def getBlockReplicasAndSize(datasets, phedexUrl, group):
+def getBlockReplicasAndSize(datasets, phedexUrl, group=None):
     """
     Given a list of datasets, find all their blocks with replicas
-    available, i.e., blocks that have valid files to be processed,
-    keeping the block size and blocks completed and subscribed
+    available (thus blocks with at least 1 valid file), completed
+    and subscribed.
+    If PhEDEx group is provided, make sure it's subscribed under that
+    same group.
     :param datasets: list of dataset names
     :param phedexUrl: a string with the PhEDEx URL
-    :param group: PhEDEx group name
+    :param group: optional PhEDEx group name
     :return: a dictionary in the form of:
     {"dataset":
         {"block":
@@ -146,8 +148,11 @@ def getBlockReplicasAndSize(datasets, phedexUrl, group):
         for item in rows['phedex']['block']:
             block = {item['name']: {'blockSize': item['bytes'], 'locations': []}}
             for repli in item['replica']:
-                if repli['complete'] == 'y' and repli['subscribed'] == 'y' and repli['group'] == group:
-                    block[item['name']]['locations'].append(repli['node'])
+                if repli['complete'] == 'y' and repli['subscribed'] == 'y':
+                    if not group:
+                        block[item['name']]['locations'].append(repli['node'])
+                    elif repli['group'] == group:
+                        block[item['name']]['locations'].append(repli['node'])
             dsetBlockSize[dataset].update(block)
     return dsetBlockSize
 

--- a/src/python/WMCore/MicroService/Unified/RequestInfo.py
+++ b/src/python/WMCore/MicroService/Unified/RequestInfo.py
@@ -291,10 +291,10 @@ class RequestInfo(MSCore):
                 if dataIn['type'] in ["primary", "parent"]:
                     datasets.add(dataIn['name'])
 
-        # now fetch block names from DBS
+        # now fetch block names from PhEDEx
         self.logger.info("Fetching block info for %d datasets against PhEDEx: %s",
                          len(datasets), self.msConfig['phedexUrl'])
-        blocksByDset = getBlockReplicasAndSize(datasets, self.msConfig['phedexUrl'], self.msConfig['quotaAccount'])
+        blocksByDset = getBlockReplicasAndSize(datasets, self.msConfig['phedexUrl'])
         return blocksByDset
 
     def setInputDataBlocks(self, workflows, blocksByDset):


### PR DESCRIPTION
Fixes #9484 

#### Status
not-tested

#### Description
During the MSTransferor input data placement, we first check for data existence such that we don't need to subscribe all the input. With this patch, the input data don't need to be necessarily subscribed under `DataOps`.

Usual input data placement made by MSTransferor will keep subscribing data under `DataOps` though, that remains untouched.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
