### PR TITLE
Add initial sleep to CP threads; improve logging

### DIFF
--- a/src/python/WMCore/GlobalWorkQueue/CherryPyThreads/CleanUpTask.py
+++ b/src/python/WMCore/GlobalWorkQueue/CherryPyThreads/CleanUpTask.py
@@ -18,11 +18,11 @@ class CleanUpTask(CherryPyPeriodicTask):
 
     def cleanUpAndSyncCanceledElements(self, config):
         """
-
         1. deleted the wqe in end states
         2. synchronize cancelled elements.
         We can also make this in the separate thread
         """
+        self.logger.info("Executing workqueue cleanup and sync task...")
         start = int(time())
         globalQ = globalQueue(**config.queueParams)
         globalQ.performQueueCleanupActions(skipWMBS=True)

--- a/src/python/WMCore/GlobalWorkQueue/CherryPyThreads/HeartbeatMonitor.py
+++ b/src/python/WMCore/GlobalWorkQueue/CherryPyThreads/HeartbeatMonitor.py
@@ -25,7 +25,7 @@ class HeartbeatMonitor(HeartbeatMonitorBase):
         if self.postToAMQ:
             allDocs = self.buildMonITDocs(results)
             self.uploadToAMQ(allDocs)
-
+        self.logger.info("GlobalWorkqueue statistics uploaded")
         return results
 
     def buildMonITDocs(self, stats):

--- a/src/python/WMCore/GlobalWorkQueue/CherryPyThreads/LocationUpdateTask.py
+++ b/src/python/WMCore/GlobalWorkQueue/CherryPyThreads/LocationUpdateTask.py
@@ -19,6 +19,7 @@ class LocationUpdateTask(CherryPyPeriodicTask):
         """
         gather active data statistics
         """
+        self.logger.info("Executing data location update task...")
         tStart = time()
         globalQ = globalQueue(**config.queueParams)
         res = globalQ.updateLocationInfo()

--- a/src/python/WMCore/GlobalWorkQueue/CherryPyThreads/ReqMgrInteractionTask.py
+++ b/src/python/WMCore/GlobalWorkQueue/CherryPyThreads/ReqMgrInteractionTask.py
@@ -1,5 +1,5 @@
 from __future__ import (division, print_function)
-
+from time import time
 from WMCore.REST.CherryPyPeriodicTask import CherryPyPeriodicTask
 from WMCore.WorkQueue.WorkQueue import globalQueue
 from WMCore.WorkQueue.WorkQueueReqMgrInterface import WorkQueueReqMgrInterface
@@ -24,9 +24,12 @@ class ReqMgrInteractionTask(CherryPyPeriodicTask):
         3. report element status to reqmgr (need to be removed and set as reqmgr task)
         4. record this activity
         """
+        self.logger.info("Executing interaction with ReqMgr2 task...")
 
+        tStart = time()
         globalQ = globalQueue(**config.queueParams)
         reqMgrInt = WorkQueueReqMgrInterface(**config.reqMgrConfig)
         reqMgrInt(globalQ)
-
+        tEnd = time()
+        self.logger.info("ReqMgrInteractionTask took %.3f secs to execute", tEnd - tStart)
         return

--- a/src/python/WMCore/REST/CherryPyPeriodicTask.py
+++ b/src/python/WMCore/REST/CherryPyPeriodicTask.py
@@ -1,11 +1,14 @@
-'''
+"""
+
 Created on Jul 31, 2014
 
 @author: sryu
-'''
+"""
 from __future__ import print_function, division
 import cherrypy
 import traceback
+from random import randint
+from time import sleep
 from WMCore.WMLogging import getTimeRotatingLogger
 
 from threading import Thread, Condition
@@ -13,7 +16,6 @@ from threading import Thread, Condition
 class CherryPyPeriodicTask(object):
 
     def __init__(self, config):
-
         """
         BaseClass which can set up the concurrent task using cherrypy thread.
         WARNING: This assumes each task doesn't share the object.
@@ -84,6 +86,10 @@ class PeriodicWorker(Thread):
         self.wakeUp.release()
 
     def run(self):
+        firstSleep = randint(30,90)
+        self.logger.info("Sleeping thread '%s' for %d seconds before its first run",
+                         self.config._internal_name, firstSleep)
+        sleep(firstSleep)
 
         while not self.stopFlag:
             self.wakeUp.acquire()

--- a/src/python/WMCore/ReqMgr/CherryPyThreads/AuxCacheUpdateTasks.py
+++ b/src/python/WMCore/ReqMgr/CherryPyThreads/AuxCacheUpdateTasks.py
@@ -32,7 +32,7 @@ class AuxCacheUpdateTasks(CherryPyPeriodicTask):
         that need to be constanly updated whenever an update is
         made at the data source
         """
-        self.logger.info("Updating auxiliary couch documents ...")
+        self.logger.info("Updating auxiliary couch documents...")
 
         self.reqmgrAux.populateCMSSWVersion(config.tagcollect_url, **config.tagcollect_args)
 
@@ -47,3 +47,4 @@ class AuxCacheUpdateTasks(CherryPyPeriodicTask):
             return
 
         self.reqmgrAux.updateUnifiedConfig(data, docName="config")
+        self.logger.info("Done updating auxiliary couch documents...")

--- a/src/python/WMCore/ReqMgr/CherryPyThreads/CouchDBCleanup.py
+++ b/src/python/WMCore/ReqMgr/CherryPyThreads/CouchDBCleanup.py
@@ -25,7 +25,7 @@ class CouchDBCleanup(CherryPyPeriodicTask):
         """
         gather active data statistics
         """
-
+        self.logger.info("Executing ACDC couch cleanup ...")
         reqDB = RequestDBReader(config.reqmgrdb_url)
 
         from WMCore.ACDC.CouchService import CouchService
@@ -37,7 +37,7 @@ class CouchDBCleanup(CherryPyPeriodicTask):
             return
         # filter requests
         results = reqDB._getCouchView("byrequest", {}, originalRequests)
-        # checkt he status of the requests [announced, rejected-archived, aborted-archived, normal-archived]
+        # check the status of the requests [announced, rejected-archived, aborted-archived, normal-archived]
         deleteStates = ["announced", "rejected-archived", "aborted-archived", "normal-archived"]
         filteredRequests = []
         for row in results["rows"]:
@@ -49,11 +49,11 @@ class CouchDBCleanup(CherryPyPeriodicTask):
             try:
                 deleted = acdcService.removeFilesetsByCollectionName(req)
                 if deleted == None:
-                    self.logger.warning("request alread deleted %s", req)
+                    self.logger.warning("request already deleted %s", req)
                 else:
                     total += len(deleted)
                     self.logger.info("request %s deleted", req)
             except Exception as ex:
-                self.logger.error("request deleted failed: will try again %s: %s", req, str(ex))
-        self.logger.info("total %s requests deleted", total)
+                self.logger.exception("Failed to delete ACDC documents for %s. Error: %s", req, str(ex))
+        self.logger.info("Removed %d documents for a total of %d requests", total, len(filteredRequests))
         return

--- a/src/python/WMCore/ReqMgr/CherryPyThreads/HeartbeatMonitor.py
+++ b/src/python/WMCore/ReqMgr/CherryPyThreads/HeartbeatMonitor.py
@@ -100,7 +100,7 @@ class HeartbeatMonitor(HeartbeatMonitorBase):
         if self.postToAMQ:
             allDocs = self.buildMonITDocs(results)
             self.uploadToAMQ(allDocs)
-
+        self.logger.info("ReqMgr2 statistics uploaded")
         return results
 
     def buildMonITDocs(self, stats):

--- a/src/python/WMCore/ReqMgr/CherryPyThreads/StatusChangeTasks.py
+++ b/src/python/WMCore/ReqMgr/CherryPyThreads/StatusChangeTasks.py
@@ -128,6 +128,7 @@ class StatusChangeTasks(CherryPyPeriodicTask):
         """
         Advance the request status based on the global workqueue elements status
         """
+        self.logger.info("Executing status change tasks...")
         reqmgrSvc = ReqMgr(config.reqmgr2_url, logger=self.logger)
         gqService = WorkQueue(config.workqueue_url)
         wmstatsSvc = WMStatsServer(config.wmstats_url, logger=self.logger)

--- a/src/python/WMCore/WMStats/CherryPyThreads/CleanUpTask.py
+++ b/src/python/WMCore/WMStats/CherryPyThreads/CleanUpTask.py
@@ -1,6 +1,5 @@
 from __future__ import (division, print_function)
 
-import traceback
 from WMCore.REST.CherryPyPeriodicTask import CherryPyPeriodicTask
 from WMCore.Services.WMStats.WMStatsWriter import WMStatsWriter
 
@@ -26,7 +25,7 @@ class CleanUpTask(CherryPyPeriodicTask):
         """
         loop through the workflows in couchdb, if archived delete all the data in couchdb
         """
-        self.logger.info("getting archived data")
+        self.logger.info("Executing cleanup of archived data...")
         requestNames = self.wmstatsDB.getArchivedRequests()
         self.logger.info("archived list %s", requestNames)
 
@@ -35,9 +34,7 @@ class CleanUpTask(CherryPyPeriodicTask):
             try:
                 result = self.wmstatsDB.deleteDocsByWorkflow(req)
             except Exception as ex:
-                self.logger.error("deleting %s failed: %s", req, str(ex))
-                for line in traceback.format_exc().rstrip().split("\n"):
-                    self.logger.error(" " + line)
+                self.logger.exception("deleting %s failed: %s", req, str(ex))
             else:
                 if result is None:
                     self.logger.info("there were no documents to delete.")

--- a/src/python/WMCore/WMStats/CherryPyThreads/DataCacheUpdate.py
+++ b/src/python/WMCore/WMStats/CherryPyThreads/DataCacheUpdate.py
@@ -23,6 +23,7 @@ class DataCacheUpdate(CherryPyPeriodicTask):
         """
         gather active data statistics
         """
+        self.logger.info("Executing data cache update task...")
         try:
             if DataCache.islatestJobDataExpired():
                 wmstatsDB = WMStatsReader(config.wmstats_url, reqdbURL=config.reqmgrdb_url,
@@ -31,5 +32,5 @@ class DataCacheUpdate(CherryPyPeriodicTask):
                 DataCache.setlatestJobData(jobData)
                 self.logger.info("DataCache is updated: %s", len(jobData))
         except Exception as ex:
-            self.logger.error(str(ex))
+            self.logger.exception("Failed to fetch data from WMStats. Error: %s", str(ex))
         return

--- a/src/python/WMCore/WMStats/CherryPyThreads/LogDBTasks.py
+++ b/src/python/WMCore/WMStats/CherryPyThreads/LogDBTasks.py
@@ -22,7 +22,7 @@ class LogDBTasks(CherryPyPeriodicTask):
         """
         gather active data statistics
         """
-        self.logger.info("Cleaning documents from LogDB WMStats")
+        self.logger.info("Executing logDB cleanup task...")
         docs = self.logDB.cleanup(config.keepDocsAge)
         self.logger.info("Deleted %d old documents", len(docs))
 


### PR DESCRIPTION
Fixes #9488 

#### Status
ready

#### Description
Started this patch by simply printing the traceback in the cherrypy threads, when reasonable.
In addition to that:
* try to log when the thread starts and when it's about to end
* added a random 30 to 90 secs initial sleep before the thread runs for the first time (not to start all of them at the same time; and to give dependencies some extra time to get started)

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
