### PR TITLE
Enable late materialization factory in condor

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -649,6 +649,11 @@ class SimpleCondorPlugin(BasePlugin):
         sub['My.CMS_WMTool'] = classad.quote("WMAgent")
         sub['My.CMS_SubmissionTool'] = classad.quote("WMAgent")
 
+        # Enable late materialization factory feature
+        # Use a high number to materialize all jobs for now
+        # until job splitting is properly adapted.
+        sub['max_materialize'] = 1000000
+
         jobParameters = self.getJobParameters(jobList)
        
         return sub, jobParameters


### PR DESCRIPTION
Enable late materialization with a huge materializion parameter number until job splitting is properly adapted for this feature.
Note: Even if all jobs are materialized, this
already enables the late materialiation factory in condor, so it requires HTCondor 8.9.2+ in the schedd in order to handle proxy certificates properly during the submission requests.

#### Status
In testing

#### Is it backward compatible (if not, which system it affects?)
YES

#### External dependencies / deployment changes
Schedd: HTCondor v8.9.2+