### PR TITLE
Fix info REST API for ReqMgr2MS; changed kwarg to detail

### DIFF
--- a/src/python/WMCore/MicroService/Service/Data.py
+++ b/src/python/WMCore/MicroService/Service/Data.py
@@ -90,7 +90,10 @@ class Data(with_metaclass(Singleton, RESTEntity, object)):
                'microservice': self.mgr.__class__.__name__}
 
         if kwds.get('API') == "status":
-            res.update(self.mgr.status(kwds.get("service")))
+            detail = kwds.get("detail", True)
+            if detail not in (True, "true", "True", "TRUE"):
+                detail = False
+            res.update(self.mgr.status(detail))
         elif kwds.get('API') == "info":
             res.update(self.mgr.info(kwds.get("request")))
         return results(res)

--- a/src/python/WMCore/MicroService/Unified/MSManager.py
+++ b/src/python/WMCore/MicroService/Unified/MSManager.py
@@ -156,34 +156,34 @@ class MSManager(object):
         :param reqName: request name
         :return: data transfer information for this request
         """
+        data = {"request": reqName, "transferDoc": None}
         if reqName:
             # obtain the transfer information for a given request records from couchdb for given request
             if 'monitor' in self.services:
-                data = self.msMonitor.reqmgrAux.getTransferInfo(reqName)
+                transferDoc = self.msMonitor.reqmgrAux.getTransferInfo(reqName)
             elif 'transferor' in self.services:
-                data = self.msTransferor.reqmgrAux.getTransferInfo(reqName)
-            if not data:
-                data = {"request": reqName}
-        else:
-            data = {"request": ""}
+                transferDoc = self.msTransferor.reqmgrAux.getTransferInfo(reqName)
+            if transferDoc:
+                # it's always a single document in Couch
+                data['transferDoc'] = transferDoc[0]
         return data
 
     def delete(self, request):
         "Delete request in backend"
         pass
 
-    def status(self, service=None):
+    def status(self, detail):
         """
         Return the current status of a MicroService and a summary
         of its last execution activity.
-        :param service: string with the service name.
-            Supported names are: transferor or monitor
+        :param detail: boolean used to retrieve some extra information
+          regarding the service
         :return: a dictionary
         """
         data = {"status": "OK"}
-        if service and service == "transferor":
+        if detail and 'transferor' in self.services:
             data.update(self.statusTrans)
-        elif service and service == "monitor":
+        elif detail and 'monitor' in self.services:
             data.update(self.statusMon)
         return data
 

--- a/src/python/WMCore/MicroService/Unified/MSMonitor.py
+++ b/src/python/WMCore/MicroService/Unified/MSMonitor.py
@@ -136,7 +136,7 @@ class MSMonitor(MSCore):
         :param transferRecords: list of transfer records
         """
         # FIXME: create concurrent phedex calls using multi_getdata
-        tstamp = time.time()
+        tstamp = int(time.time())
         for doc in transferRecords:
             self.logger.debug("Checking transfers for: %s", doc['workflowName'])
             for rec in doc.get('transfers', []):


### PR DESCRIPTION
Fixes #9495 

#### Status
not-tested

#### Description
Problem is that we were trying to add a key/value to a list object.
Summary of changes is:
* the `status` API accepts the following keyword argument `detail` (instead of `service`); it's meant to be a boolean (but string variations are also accepted)
* the `info` API will always return these two extra keys (`request`, `transferDoc`); being null in case a request is not provided and/or a transfer document cannot be found in couchdb. Otherwise, `transferDoc` will have the same content as it's currently in couch database.
* updated `lastUpdate` field in the transfer document to be an integer instead of float.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none