### PR TITLE
Handle non-EDM files without file location in JobAccountant

### DIFF
--- a/src/python/WMComponent/JobAccountant/AccountantWorker.py
+++ b/src/python/WMComponent/JobAccountant/AccountantWorker.py
@@ -496,7 +496,9 @@ class AccountantWorker(WMConnectionBase):
             # Make sure every file has a valid location
             # see https://github.com/dmwm/WMCore/issues/9353
             for fwjrFile in fileList:
-                if not fwjrFile.get("locations"):
+                # T0 has analysis file without any location, see:
+                # https://github.com/dmwm/WMCore/issues/9497
+                if not fwjrFile.get("locations") and fwjrFile.get("lfn", "").endswith(".root"):
                     logging.warning("The following file doesn't have any location: %s", fwjrFile)
                     jobSuccess = False
                     break
@@ -871,9 +873,9 @@ class AccountantWorker(WMConnectionBase):
         wmbsFile = File()
         wmbsFile.update(fname)
 
-        if isinstance(fname["locations"], set):
+        if fname["locations"] and isinstance(fname["locations"], set):
             pnn = list(fname["locations"])[0]
-        elif isinstance(fname["locations"], list):
+        elif fname["locations"] and isinstance(fname["locations"], list):
             if len(fname['locations']) > 1:
                 logging.error("Have more then one location for a file in job %i", jobID)
                 logging.error("Choosing location %s", fname['locations'][0])

--- a/src/python/WMCore/FwkJobReport/Report.py
+++ b/src/python/WMCore/FwkJobReport/Report.py
@@ -431,7 +431,7 @@ class Report(object):
 
         Add an output file to the outputModule provided.
         """
-
+        logging.info("addOutputFile method called with outputModule: %s, aFile: %s", outputModule, aFile)
         aFile = aFile or {}
 
         # Now load the output module and create the file object
@@ -442,6 +442,7 @@ class Report(object):
         fileSection = "file%s" % count
         outMod.files.section_(fileSection)
         fileRef = getattr(outMod.files, fileSection)
+        logging.info("addOutputFile method fileRef: %s, whole tree: %s", fileRef, fileRef.dictionary_whole_tree_())
         outMod.files.fileCount += 1
 
         # Now we need to eliminate the optional and non-primitives:


### PR DESCRIPTION
Fixes #9402 

#### Status
tested

#### Description
Enforce file location only for EDM files (ending with .`root`). T0 specific files as `.txt` and `.db` (and `.tar.gz`) are allowed not to have a valid location for the output files extracted from the job report.

Also added some debugging to the method used to register a new file in the job report, given that we still don't know why there has been a few cases with root files with an empty location...
 
#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Yes, follow up from this incomplete fix: https://github.com/dmwm/WMCore/pull/9354

#### External dependencies / deployment changes
none