### PR TITLE
Properly deal with RunWhitelist/RunBlacklist within MS

### DIFF
--- a/src/python/WMCore/MicroService/DataStructs/Workflow.py
+++ b/src/python/WMCore/MicroService/DataStructs/Workflow.py
@@ -81,11 +81,18 @@ class Workflow(object):
         """
         return sorted(list(set(self.data['SiteWhitelist']) - set(self.data['SiteBlacklist'])))
 
-    def getRunlist(self):
+    def getRunWhitelist(self):
         """
-        Get the RunWhitelist minus the black list for this request
+        Get the RunWhitelist for this request
         """
-        res = set(self._getValue('RunWhitelist', [])) - set(self._getValue('RunBlacklist', []))
+        res = set(self._getValue('RunWhitelist', []))
+        return sorted(list(res))
+
+    def getRunBlacklist(self):
+        """
+        Get the RunBlacklist for this request
+        """
+        res = set(self._getValue('RunBlacklist', []))
         return sorted(list(res))
 
     def getLumilist(self):

--- a/src/python/WMCore/MicroService/Unified/MSTransferor.py
+++ b/src/python/WMCore/MicroService/Unified/MSTransferor.py
@@ -299,6 +299,9 @@ class MSTransferor(MSCore):
                 msg = "Skipping 'parent' data subscription (done with the 'primary' data), for: %s" % dataIn
                 self.logger.info(msg)
                 continue
+            elif dataIn["type"] == "secondary" and dataIn['name'] not in wflow.getSecondarySummary():
+                # secondary already in place
+                continue
             if dataIn['campaign'] not in self.campaigns:
                 msg = "Data placement can't proceed because campaign '%s' was not found." % dataIn["campaign"]
                 msg += " Skipping this workflow until the campaign gets created."


### PR DESCRIPTION
Fixes #9501 

#### Status
tested

#### Description
Supposedly a simple fix, but NO!
In short, this properly deals with cases where only RunBlacklist is provided. In addition to that, the following changes have been made when dealing with workflows that have either run or lumi lists:
* make bulk calls whenever it's possible. Like, to list runs in blocks; and to list run/lumis in blocks
* catch DBS call errors and remove the corresponding workflow from the MSTransferor cycle
* raise exceptions from the Common functions, such that we can catch and take proper actions with the workflows
* fixed bug when a secondary is already in place and gets removed from the list of secondary datasets.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Yes, reverted a few things put in on this PR: https://github.com/dmwm/WMCore/pull/9503

#### External dependencies / deployment changes
none