### PR TITLE
Catch data-service queries that failed and retry workflow in the next cycle

### DIFF
--- a/test/python/WMCore_t/MicroService_t/DataStructs_t/Workflow_t.py
+++ b/test/python/WMCore_t/MicroService_t/DataStructs_t/Workflow_t.py
@@ -192,6 +192,26 @@ class WorkflowTest(unittest.TestCase):
         self.assertEqual(wflow.getReqParam("RequestType"), wflow.getReqType())
         self.assertEqual(wflow.getReqParam("RequestName"), wflow.getName())
 
+    def testComparison(self):
+        """
+        Perform basic operations over Workflow objects
+        """
+        wflow1 = Workflow("workflow_1", {"RequestType": "StepChain"})
+        wflow2 = Workflow("workflow_2", {"RequestType": "TaskChain"})
+        wflow3 = Workflow("workflow_3", {"RequestType": "ReReco"})
+        wflow4 = Workflow("workflow_4", {"RequestType": "StepChain"})
+        listWflows = [wflow1, wflow2, wflow3, wflow4]
+
+        self.assertNotEqual(wflow1, wflow4)
+
+        badWflows = [wflow3, wflow3]
+        self.assertEqual(len(listWflows), 4)
+        self.assertEqual(len(badWflows), 2)
+        for wflow in set(badWflows):
+            listWflows.remove(wflow)
+        self.assertEqual(len(listWflows), 3)
+        self.assertEqual(len(badWflows), 2)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #9500 
Fixes #9493 

#### Status
tested

#### Description
In short, this PR defines a mechanism to identify calls that failed to get responded by the server (or came back with an invalid result); with that, we can also identify which workflows are affected by them and pop those workflows out of the cycle (they will be retried in the next cycle).

Changes are:
* when parsing the output of bulk calls, set the value to `None` in case the call failed and/or returned invalid data
* in `RequestInfo` module, we need to identify those calls (by the input parameter), then scan all the workflows looking for that input parameter. Workflow matching that will get removed from the MSTransferor cycle and will be retried later.
* if the bulk call is made for a single workflow, we can just raise an exception and catch it upstream, removing the concerning workflow.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
