### PR TITLE
Prevent crash on failed DNS lookups

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
@@ -347,9 +347,7 @@ class DBSUploadPoller(BaseWorkerThread):
             if 'Service Unavailable' in reason or 'Proxy Error' in reason or \
                             'Error reading from remote server' in reason:
                 pass
-            elif 'Connection refused' in str(ex):
-                msg += 'Error: %s' % str(ex)
-            elif 'timed out' in str(ex):
+            elif 'Connection refused' in str(ex) or 'timed out' in str(ex) or 'Could not resolve' in str(ex):
                 msg += 'Error: %s' % str(ex)
             else:
                 msg = "Unknown failure while fetching parentage map from WMStats. Error: %s" % str(ex)


### PR DESCRIPTION
Fixes #9486

#### Status
Tested

#### Description
In DBSUploadPoller ~and JobUpdaterPoller~ failed DNS lookups would cause the thread to crash. This PR adds a check for "Could not resolve" in the exception, preventing the crash and keeping the thread alive for the next polling cycle.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
NA

#### External dependencies / deployment changes
NA
