### PR TITLE
Round workflow completion to 2 decimal digits; remove fake transfer ID

### DIFF
--- a/src/python/WMCore/MicroService/Unified/MSMonitor.py
+++ b/src/python/WMCore/MicroService/Unified/MSMonitor.py
@@ -143,7 +143,7 @@ class MSMonitor(MSCore):
                 # obtain new transfer ids and completion for given dataset
                 completion = self._getTransferstatus(rec['dataset'], rec['transferIDs'])
                 # Per Alan request, we'll update only completion and not tids
-                rec['completion'].append(round(completion, 1))
+                rec['completion'].append(round(completion, 2))
             doc['lastUpdate'] = tstamp
 
     def _getTransferstatus(self, dataset, requestList):

--- a/src/python/WMCore/MicroService/Unified/MSTransferor.py
+++ b/src/python/WMCore/MicroService/Unified/MSTransferor.py
@@ -358,8 +358,7 @@ class MSTransferor(MSCore):
                     else:
                         self.blockCounter += len(blocks)
                 else:
-                    self.logger.info("FAKE data subscription. Default transfer id set to: '1111'")
-                    transRec['transferIDs'].add("1111")  # any fake number
+                    self.logger.info("NOT making any data subscriptions, as it's disabled in the configuration")
 
             transRec['transferIDs'] = list(transRec['transferIDs'])
             response.append(transRec)


### PR DESCRIPTION
No issue created

#### Status
tested

#### Description
Transfer completion goes from 0 to 1. Increase the accuracy of transfer completion to 2 decimal digits, so between 0.00 and 1.

In addition to that, I'm removing the fake transfer ID `1111` before it harms us. Everything has been tested and it's no longer needed.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
None

#### External dependencies / deployment changes
None
