### PR TITLE
Bump deployment example

### DIFF
--- a/deploy/deploy-wmagent.sh
+++ b/deploy/deploy-wmagent.sh
@@ -25,8 +25,8 @@
 ### Usage:               -c <central_services> Url to central services hosting central couchdb (e.g. alancc7-cloud1.cern.ch)
 ### Usage:
 ### Usage: deploy-wmagent.sh -w <wma_version> -d <deployment_tag> -t <team_name> [-s <scram_arch>] [-r <repository>] [-n <agent_number>] [-c <central_services_url>]
-### Usage: Example: sh deploy-wmagent.sh -w 1.2.8 -d HG1911c -t production -n 30
-### Usage: Example: sh deploy-wmagent.sh -w 1.2.8 -d HG1911c -t testbed-vocms001 -p "9403" -r comp=comp.amaltaro -c cmsweb-testbed.cern.ch
+### Usage: Example: sh deploy-wmagent.sh -w 1.3.0 -d HG2002h -t production -n 30
+### Usage: Example: sh deploy-wmagent.sh -w 1.3.0 -d HG2002h -t testbed-vocms001 -p "9403" -r comp=comp.amaltaro -c cmsweb-testbed.cern.ch
 ### Usage:
 
 IAM=`whoami`


### PR DESCRIPTION
No issue

#### Status
tested

#### Description
Simply bump the agent deployment command line to the latest stable production release and the corresponding deployment tag.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
