### PR TITLE
Add CreationFailure exit code

### DIFF
--- a/src/python/WMComponent/JobCreator/JobCreatorPoller.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorPoller.py
@@ -27,6 +27,7 @@ from WMCore.WMBS.Subscription import Subscription
 from WMCore.WMBS.Workflow import Workflow
 from WMCore.WMSpec.WMWorkload import WMWorkload, WMWorkloadHelper
 from WMCore.FwkJobReport.Report import Report
+from WMCore.WMExceptions import WM_JOB_ERROR_CODES
 
 
 def retrieveWMSpec(workflow=None, wmWorkloadURL=None):
@@ -735,8 +736,8 @@ class JobCreatorPoller(BaseWorkerThread):
         fjrsToSave = []
         for failedJob in createFailedJobs:
             report = Report()
-            defaultMsg = "There is a condition which assures that this job will fail if it's submitted"
-            report.addError("CreationFailure", 99305, "CreationFailure", failedJob.get("failedReason", defaultMsg))
+            report.addError("CreationFailure", 99305, "CreationFailure",
+                            failedJob.get("failedReason", WM_JOB_ERROR_CODES[99305]))
             jobCache = failedJob.getCache()
             try:
                 fjrPath = os.path.join(jobCache, "Report.0.pkl")

--- a/src/python/WMCore/WMExceptions.py
+++ b/src/python/WMCore/WMExceptions.py
@@ -204,6 +204,7 @@ WM_JOB_ERROR_CODES = {-1: "Error return without specification.",
                       99109: "Uncaught exception in WMAgent step executor.",  # WMA TODO: Maybe move to 7****?
                       99303: "Job failed and the original job report got lost",
                       99304: "Could not find jobCache directory. Job will be failed",
+                      99305: "Found single input file with too many events to be processed in a pilot lifetime",
                       99400: "Job is killed by condor_rm or SYSTEM_PERIODIC_REMOVE",
                       99401: "Job is killed by unknown reason ",
                       99996: "Failed to find a step report in the worker node",


### PR DESCRIPTION
Fixes #9531 

#### Status
Not tested

#### Description
Add a missing exit code to WMExceptions.py:
```
99305: "Found single input file with too many events to be processed in a pilot lifetime"
```

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
NA

#### External dependencies / deployment changes
NA
