### PR TITLE
New REST API parentlocks; new WMStats CP thread for resolving parentage

### DIFF
--- a/src/python/WMCore/WMStats/CherryPyThreads/BuildParentLock.py
+++ b/src/python/WMCore/WMStats/CherryPyThreads/BuildParentLock.py
@@ -1,0 +1,63 @@
+"""
+This CherryPy thread is meant to parse all the active requests
+from the WMStats DataCache; find which requests require parent
+dataset to be processed; and run the DBS parentage lookup.
+"""
+from __future__ import division, print_function
+
+from WMCore.REST.CherryPyPeriodicTask import CherryPyPeriodicTask
+from WMCore.WMStats.DataStructs.DataCache import DataCache
+from WMCore.Services.DBS.DBSReader import DBS3Reader
+
+class BuildParentLock(CherryPyPeriodicTask):
+
+    def __init__(self, rest, config):
+
+        super(BuildParentLock, self).__init__(config)
+        self.dbs = DBS3Reader(config.dbs_url)
+
+    def setConcurrentTasks(self, config):
+        """
+        sets the list of functions which
+        """
+        self.concurrentTasks = [{'func': self.fetchIncludeParentsRequests,
+                                 'duration': config.updateParentsInterval}]
+
+    def fetchIncludeParentsRequests(self, config):
+        """
+        Fetch requests from the DataCache that have IncludeParents=True
+        """
+        # use this boolean to signal whether there were datasets that failed
+        # to get their parentage resolved
+        incompleteParentage = False
+
+        setDsets = set()
+        setParents = set()
+        self.logger.info("Executing parent lock cherrypy thread")
+        filterDict = {"IncludeParents": True}
+        for inputDset in DataCache.filterData(filterDict, ["InputDataset"]):
+            setDsets.add(inputDset)
+
+        self.logger.info("Found %d unique datasets requiring the parent dataset", len(setDsets))
+        for dset in setDsets:
+            try:
+                res = self.dbs.listDatasetParents(dset)
+            except Exception as exc:
+                self.logger.warning("Failed to resolve parentage for: %s. Error: %s", dset, str(exc))
+                incompleteParentage = True
+                continue
+            self.logger.info("Resolved parentage for: %s", res)
+            if res:
+                setParents.add(res[0]['parent_dataset'])
+
+        if not incompleteParentage:
+            DataCache.setParentDatasetList(list(setParents))
+            self.logger.info("Parentage lookup complete and cache renewed")
+        else:
+            # then don't replace any data for the moment, simply add new parents
+            previousData = set(DataCache.getParentDatasetList())
+            setParents = setParents | previousData
+            DataCache.setParentDatasetList(list(setParents))
+            self.logger.info("Parentage lookup complete and cache updated")
+
+        return

--- a/src/python/WMCore/WMStats/DataStructs/DataCache.py
+++ b/src/python/WMCore/WMStats/DataStructs/DataCache.py
@@ -7,6 +7,7 @@ class DataCache(object):
     # from each server.
     _duration = 300  # 5 minitues
     _lastedActiveDataFromAgent = {}
+    _parentDatasets = []
 
     @staticmethod
     def getDuration():
@@ -22,6 +23,14 @@ class DataCache(object):
             return DataCache._lastedActiveDataFromAgent["data"]
         else:
             return {}
+
+    @staticmethod
+    def getParentDatasetList():
+        return DataCache._parentDatasets
+
+    @staticmethod
+    def setParentDatasetList(parentData):
+        DataCache._parentDatasets = parentData
 
     @staticmethod
     def setlatestJobData(jobData):

--- a/src/python/WMCore/WMStats/Service/ActiveRequestJobInfo.py
+++ b/src/python/WMCore/WMStats/Service/ActiveRequestJobInfo.py
@@ -113,3 +113,19 @@ class GlobalLockList(RESTEntity):
         # If data is not updated, need to check, dataCacheUpdate log
         return rows(DataCache.filterData(ACTIVE_NO_CLOSEOUT_FILTER,
                                          ["InputDataset", "OutputDatasets", "MCPileup", "DataPileup"]))
+
+class ParentLockList(RESTEntity):
+    def __init__(self, app, api, config, mount):
+        # main CouchDB database where requests/workloads are stored
+        RESTEntity.__init__(self, app, api, config, mount)
+
+    def validate(self, apiobj, method, api, param, safe):
+        return
+
+    @restcall(formats=[('text/plain', PrettyJSONFormat()), ('application/json', JSONFormat())])
+    @tools.expires(secs=-1)
+    def get(self):
+        # This assumes both the DataCache and the parentage cache list
+        # get periodically updated.
+        # In case of problems, the WMStats cherrypy threads logs need to be checked
+        return rows(DataCache.getParentDatasetList())

--- a/src/python/WMCore/WMStats/Service/RestApiHub.py
+++ b/src/python/WMCore/WMStats/Service/RestApiHub.py
@@ -15,7 +15,8 @@ from WMCore.WMStats.Service.MetaDataInfo import ServerInfo
 from WMCore.WMStats.Service.RequestInfo import (RequestInfo, FinishedStatusInfo,
                                                 TeamInfo, JobDetailInfo)
 from WMCore.WMStats.Service.ActiveRequestJobInfo import (ActiveRequestJobInfo, GlobalLockList,
-                        ProtectedLFNList, ProtectedLFNListOnlyFinalOutput, FilteredActiveRequestJobInfo)
+                                                         ProtectedLFNList, ProtectedLFNListOnlyFinalOutput,
+                                                         FilteredActiveRequestJobInfo, ParentLockList)
 
 
 
@@ -47,5 +48,6 @@ class RestApiHub(RESTApi):
                    "protectedlfns": ProtectedLFNList(app, self, config, mount),
                    "protectedlfns_final": ProtectedLFNListOnlyFinalOutput(app, self, config, mount),
                    "globallocks": GlobalLockList(app, self, config, mount),
+                   "parentlocks": ParentLockList(app, self, config, mount),
                    "proc_status": ProcessMatrix(app, self, config, mount)
                   })


### PR DESCRIPTION
Fixes #7651 

#### Status
In development

#### Description
This PR provides the following:
* a new wmstatsserver REST API `parentlocks`, which should return a list of active parent datasets in the system
* a new WMStats CherryPy thread `BuildParentLock`. Responsable for parsing the active data cached in WMStats, and running the DBS parentage discovery
* an extra `DataCache` property to store a list of parent datasets, to be served through the REST `parentlocks`

Basic test looks ok, e.g.:
https://alancc7-cloud2.cern.ch/wmstatsserver/data/parentlocks

What deserves extra work are those corner cases where the data cache might be empty.
In other words, for WMStats unavailability and/or redeployment, there is a small time window that we would not have data populated in the cache, thus yielding an empty result for either the `parentlocks` or the `globallocks` REST API.

In addition to that, I also _think_ we should extend the `globallocks` to consider workflows sitting in `assignment-approved` status.

#### Is it backward compatible (if not, which system it affects?)
No, it's new!

#### Related PRs
none

#### External dependencies / deployment changes
It requires these deployment changes:
https://github.com/dmwm/deployment/pull/850
