### PR TITLE
Consider the RelVal phedex group for pileup dataset location

### DIFF
--- a/src/python/WMCore/MicroService/Unified/Common.py
+++ b/src/python/WMCore/MicroService/Unified/Common.py
@@ -186,7 +186,7 @@ def getPileupSubscriptions(datasets, phedexUrl, group="DataOps", percentMin=99):
     if not datasets:
         return locationByDset
 
-    url = "%s/subscriptions?group=%s&percent_min=%s&dataset=%s"
+    url = "%s/subscriptions?group=%s&group=RelVal&percent_min=%s&dataset=%s"
     urls = [url % (phedexUrl, group, percentMin, dset) for dset in datasets]
     data = multi_getdata(urls, ckey(), cert())
 


### PR DESCRIPTION
Fixes #<GH_Issue_Number>

#### Status
not-tested

#### Description
RelVal workflows rely on data subscribed under the `RelVal` PhEDEx group. MicroServices does the pileup location against only the `DataOps` group.

We should make it configurable for the next month, but for now hard-wiring it will let the RelVal workflows go through.

We don't really patch CMSWEB services, instead we cut a new release, build a new RPM, test it in testbed and only then we push hot fixes to production. However, given that it's a new service, I'm trying to discuss it with @muhammadimranfarooqi to see if we can patch `reqmgr2ms` on vocms0742 instead...

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
no

#### External dependencies / deployment changes
no