### PR TITLE
New REST API parentlocks; new WMStats CP thread for resolving parentage

### DIFF
--- a/src/python/WMCore/REST/Error.py
+++ b/src/python/WMCore/REST/Error.py
@@ -118,6 +118,12 @@ class APINotSupported(RESTError):
     app_code = 207
     message = "API not supported"
 
+class DataCacheEmpty(RESTError):
+    "The wmstats data cache has not be created."
+    http_code = 503
+    app_code = 208
+    message = "DataCache is Empty"
+
 class DatabaseError(RESTError):
     """Parent class for database-related errors.
 

--- a/src/python/WMCore/ReqMgr/DataStructs/RequestStatus.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/RequestStatus.py
@@ -144,12 +144,16 @@ STATES_ALLOW_ONLY_STATE_TRANSITION = [key for key, val in ALLOWED_ACTIONS_FOR_ST
 # is name of the status
 REQUEST_STATE_LIST = REQUEST_STATE_TRANSITION.keys()
 
-ACTIVE_STATUS_FILTER = {"RequestStatus": ['assigned', 'staging', 'staged', 'acquired',
+ACTIVE_STATUS_FILTER = {"RequestStatus": ['assignment-approved', 'assigned', 'staging', 'staged', 'acquired',
                                           'running-open', 'running-closed', 'force-complete',
                                           'completed', 'closed-out']}
-ACTIVE_NO_CLOSEOUT_FILTER = {"RequestStatus": ['assigned', 'staging', 'staged', 'acquired',
+ACTIVE_NO_CLOSEOUT_FILTER = {"RequestStatus": ['assignment-approved', 'assigned', 'staging', 'staged', 'acquired',
                                                'running-open', 'running-closed', 'force-complete',
                                                'completed']}
+# used to determine active workflows requiring parent datasets
+ACTIVE_NO_CLOSEOUT_PARENT_FILTER = {"RequestStatus": ['assignment-approved', 'assigned', 'staging', 'staged', 'acquired',
+                                               'running-open', 'running-closed', 'force-complete',
+                                               'completed'], "IncludeParents": True}
 
 def check_allowed_transition(preState, postState):
     stateList = REQUEST_STATE_TRANSITION.get(preState, [])

--- a/src/python/WMCore/WMStats/CherryPyThreads/BuildParentLock.py
+++ b/src/python/WMCore/WMStats/CherryPyThreads/BuildParentLock.py
@@ -1,0 +1,64 @@
+"""
+This CherryPy thread is meant to parse all the active requests
+from the WMStats DataCache; find which requests require parent
+dataset to be processed; and run the DBS parentage lookup.
+"""
+from __future__ import division, print_function
+
+from WMCore.REST.CherryPyPeriodicTask import CherryPyPeriodicTask
+from WMCore.WMStats.DataStructs.DataCache import DataCache
+from WMCore.Services.DBS.DBSReader import DBS3Reader
+from WMCore.ReqMgr.DataStructs.RequestStatus import ACTIVE_NO_CLOSEOUT_PARENT_FILTER
+
+
+class BuildParentLock(CherryPyPeriodicTask):
+
+    def __init__(self, rest, config):
+
+        super(BuildParentLock, self).__init__(config)
+        self.dbs = DBS3Reader(config.dbs_url)
+
+    def setConcurrentTasks(self, config):
+        """
+        sets the list of functions which
+        """
+        self.concurrentTasks = [{'func': self.fetchIncludeParentsRequests,
+                                 'duration': config.updateParentsInterval}]
+
+    def fetchIncludeParentsRequests(self, config):
+        """
+        Fetch active requests from the DataCache that have IncludeParents=True
+        """
+        # use this boolean to signal whether there were datasets that failed
+        # to get their parentage resolved
+        incompleteParentage = False
+
+        setDsets = set()
+        setParents = set()
+        self.logger.info("Executing parent lock cherrypy thread")
+        for inputDset in DataCache.filterData(ACTIVE_NO_CLOSEOUT_PARENT_FILTER, ["InputDataset"]):
+            setDsets.add(inputDset)
+
+        self.logger.info("Found %d unique datasets requiring the parent dataset", len(setDsets))
+        for dset in setDsets:
+            try:
+                res = self.dbs.listDatasetParents(dset)
+            except Exception as exc:
+                self.logger.warning("Failed to resolve parentage for: %s. Error: %s", dset, str(exc))
+                incompleteParentage = True
+                continue
+            self.logger.info("Resolved parentage for: %s", res)
+            if res:
+                setParents.add(res[0]['parent_dataset'])
+
+        if not incompleteParentage:
+            DataCache.setParentDatasetList(list(setParents))
+            self.logger.info("Parentage lookup complete and cache renewed")
+        else:
+            # then don't replace any data for the moment, simply add new parents
+            previousData = set(DataCache.getParentDatasetList())
+            setParents = setParents | previousData
+            DataCache.setParentDatasetList(list(setParents))
+            self.logger.info("Parentage lookup complete and cache updated")
+
+        return

--- a/src/python/WMCore/WMStats/DataStructs/DataCache.py
+++ b/src/python/WMCore/WMStats/DataStructs/DataCache.py
@@ -7,6 +7,7 @@ class DataCache(object):
     # from each server.
     _duration = 300  # 5 minitues
     _lastedActiveDataFromAgent = {}
+    _parentDatasets = []
 
     @staticmethod
     def getDuration():
@@ -22,6 +23,19 @@ class DataCache(object):
             return DataCache._lastedActiveDataFromAgent["data"]
         else:
             return {}
+
+    @staticmethod
+    def isEmpty():
+        # simple check to see if the data cache is populated
+        return not DataCache._lastedActiveDataFromAgent.get("data")
+
+    @staticmethod
+    def getParentDatasetList():
+        return DataCache._parentDatasets
+
+    @staticmethod
+    def setParentDatasetList(parentData):
+        DataCache._parentDatasets = parentData
 
     @staticmethod
     def setlatestJobData(jobData):

--- a/src/python/WMCore/WMStats/Service/RestApiHub.py
+++ b/src/python/WMCore/WMStats/Service/RestApiHub.py
@@ -15,7 +15,8 @@ from WMCore.WMStats.Service.MetaDataInfo import ServerInfo
 from WMCore.WMStats.Service.RequestInfo import (RequestInfo, FinishedStatusInfo,
                                                 TeamInfo, JobDetailInfo)
 from WMCore.WMStats.Service.ActiveRequestJobInfo import (ActiveRequestJobInfo, GlobalLockList,
-                        ProtectedLFNList, ProtectedLFNListOnlyFinalOutput, FilteredActiveRequestJobInfo)
+                                                         ProtectedLFNList, ProtectedLFNListOnlyFinalOutput,
+                                                         FilteredActiveRequestJobInfo, ParentLockList)
 
 
 
@@ -47,5 +48,6 @@ class RestApiHub(RESTApi):
                    "protectedlfns": ProtectedLFNList(app, self, config, mount),
                    "protectedlfns_final": ProtectedLFNListOnlyFinalOutput(app, self, config, mount),
                    "globallocks": GlobalLockList(app, self, config, mount),
+                   "parentlocks": ParentLockList(app, self, config, mount),
                    "proc_status": ProcessMatrix(app, self, config, mount)
                   })


### PR DESCRIPTION
Fixes #7651 
Replaces #9540 

#### Status
In development

#### Description
Since Alan is enjoying vacation, I picked the commits from his PR #9540 and added some additional required pieces. 
* an updated filter to only query active datasets requesting parent datasets
* a check for an empty data cache which returns a 503 error

This PR provides the following:
* a new wmstatsserver REST API `parentlocks`, which should return a list of active parent datasets in the system
* a new WMStats CherryPy thread `BuildParentLock`. Responsable for parsing the active data cached in WMStats, and running the DBS parentage discovery
* an extra `DataCache` property to store a list of parent datasets, to be served through the REST `parentlocks`

What deserves extra work are those corner cases where the data cache might be empty.
In other words, for WMStats unavailability and/or redeployment, there is a small time window that we would not have data populated in the cache, thus yielding an empty result for either the `parentlocks` or the `globallocks` REST API.

In addition to that, I also _think_ we should extend the `globallocks` to consider workflows sitting in `assignment-approved` status. (done)

#### Is it backward compatible (if not, which system it affects?)
No, it's new!

#### Related PRs
none

#### External dependencies / deployment changes
It requires these deployment changes:
https://github.com/dmwm/deployment/pull/850
