### PR TITLE
when userName argument is present. Use it as myproxy credential. Fix #9544

### DIFF
--- a/src/python/WMCore/Credential/Proxy.py
+++ b/src/python/WMCore/Credential/Proxy.py
@@ -372,9 +372,13 @@ class Proxy(Credential):
                 'rfc' if self.rfcCompliant else 'old', self.myproxyServer)
 
             if nokey is True:
-                self.logger.debug(
-                    "Calculating hash of %s for credential name" % (self.userDN + "_" + self.myproxyAccount))
-                credname = sha1(self.userDN + "_" + self.myproxyAccount).hexdigest()
+                if self.userName:
+                    self.logger.debug("using %s as credential login name", self.userName)
+                    credname = self.userName
+                else:
+                    self.logger.debug(
+                        "Calculating hash of %s for credential name" % (self.userDN + "_" + self.myproxyAccount))
+                    credname = sha1(self.userDN + "_" + self.myproxyAccount).hexdigest()
                 myproxyDelegCmd = 'export GT_PROXY_MODE=%s ; myproxy-init -d -n -s %s -x -R \'%s\' -x -Z \'%s\' -l \'%s\' -t 168:00 -c %s' \
                                   % ('rfc' if self.rfcCompliant else 'old', self.myproxyServer, self.serverDN, \
                                      self.serverDN, credname, self.myproxyValidity)
@@ -399,9 +403,13 @@ class Proxy(Credential):
         proxyTimeleft = -1
         if self.myproxyServer:
             if nokey is True and serverRenewer is True:
-                self.logger.debug(
-                    "Calculating hash of %s for credential name" % (self.userDN + "_" + self.myproxyAccount))
-                credname = sha1(self.userDN + "_" + self.myproxyAccount).hexdigest()
+                if self.userName:
+                    self.logger.debug("using %s as credential login name", self.userName)
+                    credname = self.userName
+                else:
+                    self.logger.debug(
+                        "Calculating hash of %s for credential name" % (self.userDN + "_" + self.myproxyAccount))
+                    credname = sha1(self.userDN + "_" + self.myproxyAccount).hexdigest()
                 checkMyProxyCmd = 'myproxy-info -l %s -s %s' % (credname, self.myproxyServer)
                 output, _, retcode = execute_command(self.setEnv(checkMyProxyCmd), self.logger, self.commandTimeout)
                 if retcode > 0 or not output:


### PR DESCRIPTION

Fixes #9544 

#### Status
ready

#### Description
use existing userName argument of Credential.py to pass a predefined myproxy credential username as alternative to creating one from the hash of the DN and the obscure myproxyAccount variable which pointed to the CRAB rest hostname.

#### Is it backward compatible (if not, which system it affects?)
YES 

#### Related PRs
None
#### External dependencies / deployment changes
None