### PR TITLE
Fix initialization of the logger

### DIFF
--- a/src/python/WMCore/WebTools/DatabasePage.py
+++ b/src/python/WMCore/WebTools/DatabasePage.py
@@ -7,6 +7,7 @@ A page that knows how to format DB queries
 
 
 import os
+import logging
 import threading
 
 from WMCore.WebTools.Page import TemplatedPage
@@ -45,7 +46,9 @@ class DatabasePage(TemplatedPage, DBFormatter):
         TemplatedPage.__init__(self, config)
         dbConfig = ConfigDBMap(config)
         conn = DBFactory(self, dbConfig.getDBUrl(), dbConfig.getOption()).connect()
-        DBFormatter.__init__(self, self, conn)
+        logger = logging.getLogger(__name__)
+        logger.setLevel(logging.INFO)
+        DBFormatter.__init__(self, logger, conn)
         myThread = threading.currentThread()
         myThread.transaction = Transaction(conn)
         myThread.transaction.commit()


### PR DESCRIPTION
Fixes #<GH_Issue_Number>

#### Status
ready

#### Description
Debugging DBS code I found that its logger is never initialized. Turns out it caused by the very deep dependency chain which lead to DatabaseApi class which improperly call DBFormatter. The constructor of DBFormatter class has this signature
```
class DBFormatter(WMObject):
    def __init__(self, logger, dbinterface):
```
while DatabaseApi initializes its logger with `self`, see
```
DBFormatter.__init__(self, self, conn)
```
This PR fixes the issue and initializes the logger of DBFormatter class properly from DatabaseApi.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
<If it's a follow up work; or porting a fix from a different branch, please mention them here.>

#### External dependencies / deployment changes
<Does it require deployment changes? Does it rely on third-party libraries?>
