### PR TITLE
Correct reference to blocksize in PrimaryBlocks && Catch exception while calling makeTransferRequest in MSTrasferor

### DIFF
--- a/src/python/WMCore/MicroService/DataStructs/Workflow.py
+++ b/src/python/WMCore/MicroService/DataStructs/Workflow.py
@@ -330,7 +330,7 @@ class Workflow(object):
 
         # create a descendant list of blocks according to their sizes
         sortedPrimary = sorted(self.getPrimaryBlocks().items(), key=operator.itemgetter(1), reverse=True)
-        chunkSize = sum(item[1] for item in sortedPrimary) // numChunks
+        chunkSize = sum(item[1]['blockSize'] for item in sortedPrimary) // numChunks
 
         self.logger.info("Found %d blocks and the avg chunkSize is: %s GB",
                          len(sortedPrimary), gigaBytes(chunkSize))
@@ -347,9 +347,9 @@ class Workflow(object):
                 if not sortedPrimary or idx >= len(sortedPrimary):
                     # then all blocks have been distributed
                     break
-                elif thisChunkSize + sortedPrimary[idx][1] <= chunkSize:
+                elif thisChunkSize + sortedPrimary[idx][1]['blockSize'] <= chunkSize:
                     thisChunk.add(sortedPrimary[idx][0])
-                    thisChunkSize += sortedPrimary[idx][1]
+                    thisChunkSize += sortedPrimary[idx][1]['blockSize']
                     sortedPrimary.pop(idx)
                 else:
                     idx += 1
@@ -360,7 +360,7 @@ class Workflow(object):
         while sortedPrimary:
             for chunkNum in range(numChunks):
                 blockChunks[chunkNum].add(sortedPrimary[0][0])
-                sizeChunks[chunkNum] += sortedPrimary[0][1]
+                sizeChunks[chunkNum] += sortedPrimary[0][1]['blockSize']
                 sortedPrimary.pop(0)
                 if not sortedPrimary:
                     break

--- a/src/python/WMCore/MicroService/Unified/MSTransferor.py
+++ b/src/python/WMCore/MicroService/Unified/MSTransferor.py
@@ -164,7 +164,7 @@ class MSTransferor(MSCore):
             self.updateReportDict(summary, "error", msg)
             return summary
         except Exception as ex:
-            msg = "Unknown exception updating caches. Error: %s", str(ex)
+            msg = "Unknown exception updating caches. Error: %s" % str(ex)
             self.logger.exception(msg)
             self.updateReportDict(summary, "error", msg)
             return summary
@@ -180,7 +180,13 @@ class MSTransferor(MSCore):
                 # first check which data is already in place and filter them out
                 self.checkDataLocation(wflow)
 
-                success, transfers = self.makeTransferRequest(wflow)
+                try:
+                    success, transfers = self.makeTransferRequest(wflow)
+                except Exception as ex:
+                    success = False
+                    msg = "Unknown exception while making Transfer Request for %s " % wflow.getName()
+                    msg += "\tError: %s" % str(ex)
+                    self.logger.exception(msg)
                 if success:
                     self.logger.info("Transfer requests successful for %s. Summary: %s",
                                      wflow.getName(), pformat(transfers))                    # then create a document in ReqMgr Aux DB


### PR DESCRIPTION
Fixes #9551

#### Status
not-tested

#### Description
Fixing the bug with the wrong reference to the 'blockSize' when trying to get PrimaryBlocks in Workflow.py and also catching any exception that  may be thrown while calling makeTransferRequest in MSTransferor.py. The exception is handled in a per workflow basis and only for that function call, so that the cycle is not interrupted and also later in the same iteration the success/failure counters could be updated.    

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
