### PR TITLE
Fix MSTransferor logic for block distribution

### DIFF
--- a/src/python/WMCore/MicroService/Unified/MSCore.py
+++ b/src/python/WMCore/MicroService/Unified/MSCore.py
@@ -69,7 +69,7 @@ class MSCore(object):
                 self.logger.info('%s updating %s status to: %s', prefix, reqName, reqStatus)
                 self.reqmgr2.updateRequestStatus(reqName, reqStatus)
             else:
-                self.logger.info('%s FAKE updating %s status to: %s', prefix, reqName, reqStatus)
+                self.logger.info('DRY-RUN:: %s updating %s status to: %s', prefix, reqName, reqStatus)
         except Exception as err:
             self.logger.exception("Failed to change request status. Error: %s", str(err))
 

--- a/src/python/WMCore/MicroService/Unified/MSTransferor.py
+++ b/src/python/WMCore/MicroService/Unified/MSTransferor.py
@@ -164,7 +164,7 @@ class MSTransferor(MSCore):
             self.updateReportDict(summary, "error", msg)
             return summary
         except Exception as ex:
-            msg = "Unknown exception updating caches. Error: %s", str(ex)
+            msg = "Unknown exception updating caches. Error: %s" % str(ex)
             self.logger.exception(msg)
             self.updateReportDict(summary, "error", msg)
             return summary
@@ -180,7 +180,13 @@ class MSTransferor(MSCore):
                 # first check which data is already in place and filter them out
                 self.checkDataLocation(wflow)
 
-                success, transfers = self.makeTransferRequest(wflow)
+                try:
+                    success, transfers = self.makeTransferRequest(wflow)
+                except Exception as ex:
+                    success = False
+                    msg = "Unknown exception while making Transfer Request for %s " % wflow.getName()
+                    msg += "\tError: %s" % str(ex)
+                    self.logger.exception(msg)
                 if success:
                     self.logger.info("Transfer requests successful for %s. Summary: %s",
                                      wflow.getName(), pformat(transfers))                    # then create a document in ReqMgr Aux DB
@@ -358,7 +364,7 @@ class MSTransferor(MSCore):
                     else:
                         self.blockCounter += len(blocks)
                 else:
-                    self.logger.info("NOT making any data subscriptions, as it's disabled in the configuration")
+                    self.logger.info("DRY-RUN: making subscription: %s", subscription)
 
             transRec['transferIDs'] = list(transRec['transferIDs'])
             response.append(transRec)


### PR DESCRIPTION
Fixes #9551 
Superseeds #9552 

#### Status
tested

#### Description
It contains a few bug fixes, like:
* a bug reading the data structure (accessing a dict instead of `blockSize`)
* bug dealing with parent x child relationship
* decrease number of chunks (sites) when there are less blocks than sites to distribute data
* fix bug where transfer IDs might be skipped from the transfer doc (when a chunk has 0 blocks)

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
