### PR TITLE
Use absolute numbers for lumis and completion in the workflow completion

### DIFF
--- a/bin/adhoc-scripts/workflowCompletion.py
+++ b/bin/adhoc-scripts/workflowCompletion.py
@@ -157,7 +157,7 @@ def main():
         dbsInfo = handleDBS(reqmgrOutDsets, cmswebUrl)
         print("OutputDatasets:")
         for dset in reqmgrOutDsets:
-            print("    %s (lumi completion: %.3f)" % (dset, dbsInfo[dset] / inputLumis))
+            print("    %s (lumis: %s, lumi completion: %s)" % (dset, dbsInfo[dset], dbsInfo[dset] / inputLumis))
         print("")
 
     sys.exit(0)


### PR DESCRIPTION
Fixes #9565 

#### Status
ready

#### Description
Print absolute number of lumi sections and the real division result.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
