### PR TITLE
bump deployment example to use changes in wmagent manage script

### DIFF
--- a/deploy/deploy-wmagent.sh
+++ b/deploy/deploy-wmagent.sh
@@ -25,8 +25,8 @@
 ### Usage:               -c <central_services> Url to central services hosting central couchdb (e.g. alancc7-cloud1.cern.ch)
 ### Usage:
 ### Usage: deploy-wmagent.sh -w <wma_version> -d <deployment_tag> -t <team_name> [-s <scram_arch>] [-r <repository>] [-n <agent_number>] [-c <central_services_url>]
-### Usage: Example: sh deploy-wmagent.sh -w 1.3.0 -d HG2002h -t production -n 30
-### Usage: Example: sh deploy-wmagent.sh -w 1.3.0 -d HG2002h -t testbed-vocms001 -p "9403" -r comp=comp.amaltaro -c cmsweb-testbed.cern.ch
+### Usage: Example: sh deploy-wmagent.sh -w 1.3.0.patch1 -d HG2004c -t production -n 30
+### Usage: Example: sh deploy-wmagent.sh -w 1.3.0.patch1 -d HG2004c -t testbed-vocms001 -p "9403" -r comp=comp.amaltaro -c cmsweb-testbed.cern.ch
 ### Usage:
 
 IAM=`whoami`


### PR DESCRIPTION
No issue created

#### Status
ready

#### Description
Updates the deployment tag to be used, given that this patch release requires a new secrets variable for the grafana site information.

#### Is it backward compatible (if not, which system it affects?)
no

#### Related PRs
none

#### External dependencies / deployment changes
Deployment change: https://github.com/dmwm/deployment/pull/873