### PR TITLE
Simplify my proxy fix 9544

### DIFF
--- a/src/python/WMCore/Credential/Proxy.py
+++ b/src/python/WMCore/Credential/Proxy.py
@@ -586,10 +586,17 @@ class Proxy(Credential):
         # Note that this is saved in a temporary file with the pid appended to the filename. This way we will avoid adding many
         # signatures later on with vomsExtensionRenewal in case of multiple processing running at the same time
         tmpProxyFilename = proxyFilename + '.' + str(os.getpid())
+
+        if self.userName:
+            self.logger.debug("using %s as credential login name", self.userName)
+            credname = self.userName
+        else:
+            self.logger.debug(
+                "Calculating hash of %s for credential name" % (self.userDN + "_" + self.myproxyAccount))
+            credname = sha1(self.userDN + "_" + self.myproxyAccount).hexdigest()
+
         cmdList.append('myproxy-logon -d -n -s %s -o %s -l \"%s\" -t 168:00'
-                       % (
-                           self.myproxyServer, tmpProxyFilename,
-                           sha1(self.userDN + "_" + self.myproxyAccount).hexdigest()))
+                       % (self.myproxyServer, tmpProxyFilename, credname)
         logonCmd = ' '.join(cmdList)
         msg, _, retcode = execute_command(self.setEnv(logonCmd), self.logger, self.commandTimeout)
 

--- a/src/python/WMCore/Credential/Proxy.py
+++ b/src/python/WMCore/Credential/Proxy.py
@@ -635,11 +635,18 @@ class Proxy(Credential):
             self.logger.error("Error while checking retrieved proxy timeleft for %s" % proxy)
             return
 
+        # timeLeft indicates how maby seconds the proxy is still valid for
+        # we will add  a voms extension via voms-proxy-init -noregen but we
+        # ask for an exactly matchinng validity time, we often end with
+        #  Warning: your certificate and proxy will expire Tue Mar 31 23:46:06 2020
+        #  which is within the requested lifetime of the proxy
+        # which causes a non zero exit status and hence a face error logging
+        # Therefore let's take 10 minutes off
         vomsValid = '00:00'
-        timeLeft = int(timeLeft.strip())
+        vomsTime = int(timeLeft.strip()) - 600
 
-        if timeLeft > 0:
-            vomsValid = "%d:%02d" % (timeLeft / 3600, (timeLeft - (timeLeft / 3600) * 3600) / 60)
+        if vomsTime > 0:
+            vomsValid = "%d:%02d" % (vomsTime / 3600, (vomsTime - (vomsTime / 3600) * 3600) / 60)
 
         self.logger.debug('Requested voms validity: %s' % vomsValid)
 

--- a/src/python/WMCore/Credential/Proxy.py
+++ b/src/python/WMCore/Credential/Proxy.py
@@ -618,8 +618,8 @@ class Proxy(Credential):
         msg, _, retcode = execute_command(self.setEnv(logonCmd), self.logger, self.commandTimeout)
 
         if retcode > 0:
-            self.logger.error("Unable to retrieve delegated proxy for user DN %s! Exit code:%s output:%s" \
-                              % (self.userDN, retcode, msg))
+            self.logger.error("Unable to retrieve delegated proxy using login %s for user DN %s! Exit code:%s output:%s" \
+                              % (myproxyUsername, self.userDN, retcode, msg))
             return proxyFilename
 
         self.vomsExtensionRenewal(tmpProxyFilename, voAttribute)

--- a/src/python/WMCore/Credential/Proxy.py
+++ b/src/python/WMCore/Credential/Proxy.py
@@ -596,7 +596,7 @@ class Proxy(Credential):
             credname = sha1(self.userDN + "_" + self.myproxyAccount).hexdigest()
 
         cmdList.append('myproxy-logon -d -n -s %s -o %s -l \"%s\" -t 168:00'
-                       % (self.myproxyServer, tmpProxyFilename, credname)
+                       % (self.myproxyServer, tmpProxyFilename, credname) )
         logonCmd = ' '.join(cmdList)
         msg, _, retcode = execute_command(self.setEnv(logonCmd), self.logger, self.commandTimeout)
 


### PR DESCRIPTION
Fixes #9544 

#### Status
ready

#### Description
1. if username is given in proxycfg, use it also for `logonRenewMyProxy()`
2. removes some fake error logging from `vomsExtensionRenewal`
Those functions are only used  by CRAB. You can safely merge and kindly add in next tag so that we can build a new TaskWorker with this and test in preprod.
I tested already in my VM.

#### Is it backward compatible (if not, which system it affects?)
YES 

#### Related PRs
#9548 was a partial fix for same issue

#### External dependencies / deployment changes
None
