### PR TITLE
Use available secondary dataset regardless of which group its subscribed to

### DIFF
--- a/src/python/WMCore/MicroService/Unified/Common.py
+++ b/src/python/WMCore/MicroService/Unified/Common.py
@@ -190,7 +190,8 @@ def getPileupSubscriptions(datasets, phedexUrl, group=None, percentMin=99):
         url = "%s/subscriptions?group=%s" % (phedexUrl, group)
         url += "&percent_min=%s&dataset=%s"
     else:
-        url = "%s/subscriptions?percent_min=%s&dataset=%s" % phedexUrl
+        url = "%s/subscriptions?" % phedexUrl
+        url += "percent_min=%s&dataset=%s"
     urls = [url % (percentMin, dset) for dset in datasets]
 
     data = multi_getdata(urls, ckey(), cert())

--- a/src/python/WMCore/MicroService/Unified/Common.py
+++ b/src/python/WMCore/MicroService/Unified/Common.py
@@ -170,24 +170,29 @@ def getBlockReplicasAndSize(datasets, phedexUrl, group=None):
     return dsetBlockSize
 
 
-def getPileupSubscriptions(datasets, phedexUrl, group="DataOps", percentMin=99):
+# FIXME: implement the same logic for Rucio
+def getPileupSubscriptions(datasets, phedexUrl, group=None, percentMin=99):
     """
     Provided a list of datasets, find dataset level subscriptions where it's
     as complete as `percent_min`.
     :param datasets: list of dataset names
     :param phedexUrl: a string with the PhEDEx URL
-    :param group: PhEDEx group
+    :param group: optional string with the PhEDEx group
     :param percent_min: only return subscriptions that are this complete
     :return: a dictionary of datasets and a list of their location.
     NOTE: Value `None` is returned in case the data-service failed to serve a given request.
     """
-    #FIXME: implement the same logic for Rucio
     locationByDset = {}
     if not datasets:
         return locationByDset
 
-    url = "%s/subscriptions?group=%s&group=RelVal&percent_min=%s&dataset=%s"
-    urls = [url % (phedexUrl, group, percentMin, dset) for dset in datasets]
+    if group:
+        url = "%s/subscriptions?group=%s" % (phedexUrl, group)
+        url += "&percent_min=%s&dataset=%s"
+    else:
+        url = "%s/subscriptions?percent_min=%s&dataset=%s" % phedexUrl
+    urls = [url % (percentMin, dset) for dset in datasets]
+
     data = multi_getdata(urls, ckey(), cert())
 
     for row in data:

--- a/src/python/WMCore/MicroService/Unified/RequestInfo.py
+++ b/src/python/WMCore/MicroService/Unified/RequestInfo.py
@@ -296,7 +296,7 @@ class RequestInfo(MSCore):
         self.logger.info("Fetching pileup dataset location for %d datasets against PhEDEx: %s",
                          len(datasets), self.msConfig['phedexUrl'])
         locationsByDset = getPileupSubscriptions(datasets, self.msConfig['phedexUrl'],
-                                                 self.msConfig['minPercentCompletion'])
+                                                 percentMin=self.msConfig['minPercentCompletion'])
 
         # now check if any of our calls failed; if so, workflow needs to be skipped from this cycle
         # FIXME: isn't there a better way to do this?!?

--- a/src/python/WMCore/MicroService/Unified/RequestInfo.py
+++ b/src/python/WMCore/MicroService/Unified/RequestInfo.py
@@ -296,7 +296,7 @@ class RequestInfo(MSCore):
         self.logger.info("Fetching pileup dataset location for %d datasets against PhEDEx: %s",
                          len(datasets), self.msConfig['phedexUrl'])
         locationsByDset = getPileupSubscriptions(datasets, self.msConfig['phedexUrl'],
-                                                 self.msConfig['quotaAccount'], self.msConfig['minPercentCompletion'])
+                                                 self.msConfig['minPercentCompletion'])
 
         # now check if any of our calls failed; if so, workflow needs to be skipped from this cycle
         # FIXME: isn't there a better way to do this?!?


### PR DESCRIPTION
Fixes #9576 

#### Status
not-tested

#### Description
When retrieving the secondary dataset subscription, no longer filter by PhEDEx group. Keep the functionality in place though.
This means that MSTransferor will not create any data placement requests if the pileup dataset is available under other groups, including the `local` group.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
