### PR TITLE
added `failed` status to the list of transfer docs to be kept around

### DIFF
--- a/src/python/WMCore/ReqMgr/CherryPyThreads/CouchDBCleanup.py
+++ b/src/python/WMCore/ReqMgr/CherryPyThreads/CouchDBCleanup.py
@@ -20,7 +20,7 @@ class CouchDBCleanup(CherryPyPeriodicTask):
         self.reqmgrAux = ReqMgrAux(config.reqmgr2_url, logger=self.logger)
         # statuses that we want to keep the transfer documents
         self.transferStatuses = ["assigned", "staging", "staged", "acquired",
-                                 "running-open", "running-closed"]
+                                 "failed", "running-open", "running-closed"]
 
         baseURL, acdcDB = splitCouchServiceURL(config.acdc_url)
         self.acdcService = CouchService(url=baseURL, database=acdcDB)


### PR DESCRIPTION
Fixes #9580 

#### Status
not-tested

#### Description
If the workflow is sitting in the `failed` status, then do not delete its transfer info document from the reqmgr_auxiliary db.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Complement to: https://github.com/dmwm/WMCore/pull/9574

#### External dependencies / deployment changes
none
