### PR TITLE
Send notification/email on large data transfers

### DIFF
--- a/src/python/Utils/EmailAlert.py
+++ b/src/python/Utils/EmailAlert.py
@@ -14,11 +14,12 @@ class EmailAlert:
 
     EMAIL_HEADER = "From: %s\r\nSubject: %s\r\nTo: %s\r\n\r\n"
 
-    def __init__(self, config):
-        self.config = config
-        self.serverName = getattr(config.EmailAlert, "smtpServer")
-        self.fromAddr = getattr(config.EmailAlert, "fromAddr")
-        self.toAddr = getattr(config.EmailAlert, "toAddr")
+    def __init__(self, configDict):
+        self.serverName = configDict.get("smtpServer", "localhost")
+        self.fromAddr = configDict.get("fromAddr", "noreply@cern.ch")
+        self.toAddr = configDict.get("toAddr", "cms-service-production-admins@cern.ch")
+        if not isinstance(self.toAddr, (list, set)):
+            self.toAddr = [self.toAddr]
 
     def send(self, subject, message):
         """

--- a/src/python/WMComponent/AgentStatusWatcher/DrainStatusPoller.py
+++ b/src/python/WMComponent/AgentStatusWatcher/DrainStatusPoller.py
@@ -35,7 +35,7 @@ class DrainStatusPoller(BaseWorkerThread):
         self.previousConfig = {}
         self.validSpeedDrainConfigKeys = ['CondorPriority', 'NoJobRetries', 'EnableAllSites']
         self.reqAuxDB = ReqMgrAux(self.config.General.ReqMgr2ServiceURL)
-        self.emailAlert = EmailAlert(config)
+        self.emailAlert = EmailAlert(config.EmailAlert.dictionary_())
 
     @timeFunction
     def algorithm(self, parameters):

--- a/test/python/WMCore_t/MicroService_t/Unified_t/MSManager_t.py
+++ b/test/python/WMCore_t/MicroService_t/Unified_t/MSManager_t.py
@@ -27,6 +27,10 @@ class MSManagerTest(unittest.TestCase):
         data.rucioAccount = "test"
         data.phedexUrl = "https://cmsweb.cern.ch/phedex/datasvc/json/prod"
         data.dbsUrl = "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader"
+        data.smtpServer = "localhost"
+        data.fromAddr = "noreply@cern.ch"
+        data.toAddr = ["cms-comp-ops-workflow-team@cern.ch"]
+        data.warningTransferThreshold = 100. * (1000 ** 4) # 100 TB (terabyte)
         self.mgr = MSManager(data)
 
         data.services = ['monitor']


### PR DESCRIPTION
Fixes #9564

#### Status
ready

#### Description
We want to notify any input data placement going over some threshold, both in the system logging and as emails to a specific group. Also, do not auto-approve such phedex requests. Changes here:

- Notify any data transfer above X TB (where "X" is configurable and "100" at present) 
- Do not auto-approve phedex requests in such cases
- Send an email to comp-ops-workflow-team egroup?
- Make a special record in the logs

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
https://github.com/dmwm/deployment/pull/878

#### External dependencies / deployment changes
None

