### PR TITLE
Add additional workflow statuses for data locking

### DIFF
--- a/src/python/WMCore/ReqMgr/CherryPyThreads/BuildParentLock.py
+++ b/src/python/WMCore/ReqMgr/CherryPyThreads/BuildParentLock.py
@@ -23,8 +23,9 @@ class BuildParentLock(CherryPyPeriodicTask):
         # set of of currently active datasets requiring parent dataset
         self.inputDatasetCache = set()
         self.reqDB = RequestDBReader(config.reqmgrdb_url)
-        self.filterKeys = ['assignment-approved', 'assigned', 'staging', 'staged', 'acquired',
-                      'running-open', 'running-closed', 'force-complete', 'completed']
+        self.filterKeys = ['assignment-approved', 'assigned', 'staging', 'staged',
+                           'failed', 'acquired', 'running-open', 'running-closed',
+                           'force-complete', 'completed', 'closed-out']
 
 
     def setConcurrentTasks(self, config):

--- a/src/python/WMCore/ReqMgr/DataStructs/RequestStatus.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/RequestStatus.py
@@ -144,16 +144,10 @@ STATES_ALLOW_ONLY_STATE_TRANSITION = [key for key, val in ALLOWED_ACTIONS_FOR_ST
 # is name of the status
 REQUEST_STATE_LIST = REQUEST_STATE_TRANSITION.keys()
 
-ACTIVE_STATUS_FILTER = {"RequestStatus": ['assignment-approved', 'assigned', 'staging', 'staged', 'acquired',
-                                          'running-open', 'running-closed', 'force-complete',
-                                          'completed', 'closed-out']}
-ACTIVE_NO_CLOSEOUT_FILTER = {"RequestStatus": ['assignment-approved', 'assigned', 'staging', 'staged', 'acquired',
-                                               'running-open', 'running-closed', 'force-complete',
-                                               'completed']}
-# used to determine active workflows requiring parent datasets
-ACTIVE_NO_CLOSEOUT_PARENT_FILTER = {"RequestStatus": ['assignment-approved', 'assigned', 'staging', 'staged', 'acquired',
-                                               'running-open', 'running-closed', 'force-complete',
-                                               'completed'], "IncludeParents": True}
+ACTIVE_STATUS_FILTER = {"RequestStatus": ['assignment-approved', 'assigned', 'staging', 'staged',
+                                          'failed', 'acquired', 'running-open', 'running-closed',
+                                          'force-complete', 'completed', 'closed-out']}
+
 
 def check_allowed_transition(preState, postState):
     stateList = REQUEST_STATE_TRANSITION.get(preState, [])

--- a/src/python/WMCore/WMStats/Service/ActiveRequestJobInfo.py
+++ b/src/python/WMCore/WMStats/Service/ActiveRequestJobInfo.py
@@ -8,7 +8,7 @@ from WMCore.REST.Tools import tools
 from WMCore.REST.Error import DataCacheEmpty
 from WMCore.WMStats.DataStructs.DataCache import DataCache
 from WMCore.REST.Format import JSONFormat, PrettyJSONFormat
-from WMCore.ReqMgr.DataStructs.RequestStatus import ACTIVE_NO_CLOSEOUT_FILTER, ACTIVE_STATUS_FILTER
+from WMCore.ReqMgr.DataStructs.RequestStatus import ACTIVE_STATUS_FILTER
 
 
 class ActiveRequestJobInfo(RESTEntity):
@@ -119,5 +119,5 @@ class GlobalLockList(RESTEntity):
         if DataCache.isEmpty():
             raise DataCacheEmpty()
         else:
-            return rows(DataCache.filterData(ACTIVE_NO_CLOSEOUT_FILTER,
+            return rows(DataCache.filterData(ACTIVE_STATUS_FILTER,
                                              ["InputDataset", "OutputDatasets", "MCPileup", "DataPileup"]))


### PR DESCRIPTION
Fixes #9579

#### Status
tested

#### Description
Adds the "failed" and "closed-out" status to filters used to determine what datasets should be locked. Updates the WMStats globalocks and RegMgr2 parentlocks APIs to include the new filters.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
#9561 #9540 

#### External dependencies / deployment changes
No
