### PR TITLE
Report RSE storage summary in terabytes instead of bytes

### DIFF
--- a/src/python/WMCore/MicroService/Unified/RSEQuotas.py
+++ b/src/python/WMCore/MicroService/Unified/RSEQuotas.py
@@ -6,7 +6,7 @@ Detox, Rucio and PhEDEx.
 """
 from __future__ import division, print_function
 
-from WMCore.MicroService.Unified.Common import getDetoxQuota, getMSLogger, gigaBytes
+from WMCore.MicroService.Unified.Common import getDetoxQuota, getMSLogger, gigaBytes, teraBytes
 
 
 class RSEQuotas(object):
@@ -187,9 +187,15 @@ class RSEQuotas(object):
         """
         Print a summary of the current quotas, space usage and space available
         """
-        self.logger.info("Summary of the current quotas:")
+        self.logger.info("Summary of the current quotas Terabytes:")
         for node in sorted(self.nodeUsage.keys()):
-            self.logger.debug("  %s : %s", node, self.nodeUsage[node])
+            msg = "  %s:\t\tbytes_limit: %.2f, bytes_used: %.2f, bytes_remaining: %.2f, "
+            msg += "quota: %.2f, quota_avail: %.2f"
+            self.logger.debug(msg, node, teraBytes(self.nodeUsage[node]['bytes_limit']),
+                              teraBytes(self.nodeUsage[node]['bytes']),
+                              teraBytes(self.nodeUsage[node]['bytes_remaining']),
+                              teraBytes(self.nodeUsage[node]['quota']),
+                              teraBytes(self.nodeUsage[node]['quota_avail']))
         self.logger.info("List of RSE's out of quota: %s", self.outOfSpaceNodes)
 
     def updateNodeUsage(self, node, dataSize):


### PR DESCRIPTION
Fixes #9587

#### Status
not-tested

#### Description
Print the storage report in terabytes. Example:
```
2020-03-26 23:07:33,647:INFO:RSEQuotas: Summary of the current quotas (in TB - Terabytes):
2020-03-26 23:07:33,647:DEBUG:RSEQuotas:   T1_DE_KIT_Disk:		bytes_limit: 2676.00, bytes_used: 3167.57, bytes_remaining: -491.57, quota: 2676.00, quota_avail: -491.57
2020-03-26 23:07:33,648:DEBUG:RSEQuotas:   T1_ES_PIC_Disk:		bytes_limit: 882.00, bytes_used: 2161.76, bytes_remaining: -1279.76, quota: 882.00, quota_avail: -1279.76
2020-03-26 23:07:33,648:DEBUG:RSEQuotas:   T1_FR_CCIN2P3_Disk:		bytes_limit: 1174.00, bytes_used: 1509.53, bytes_remaining: -335.53, quota: 1174.00, quota_avail: -335.53
2020-03-26 23:07:33,648:DEBUG:RSEQuotas:   T1_IT_CNAF_Disk:		bytes_limit: 2183.00, bytes_used: 1553.85, bytes_remaining: 629.15, quota: 2183.00, quota_avail: 629.15
2020-03-26 23:07:33,648:DEBUG:RSEQuotas:   T1_RU_JINR_Disk:		bytes_limit: 1650.00, bytes_used: 1384.76, bytes_remaining: 265.24, quota: 1650.00, quota_avail: 265.24
2020-03-26 23:07:33,648:DEBUG:RSEQuotas:   T1_UK_RAL_Disk:		bytes_limit: 2000.00, bytes_used: 1735.87, bytes_remaining: 264.13, quota: 2000.00, quota_avail: 264.13
2020-03-26 23:07:33,648:DEBUG:RSEQuotas:   T1_US_FNAL_Disk:		bytes_limit: 6248.00, bytes_used: 8766.93, bytes_remaining: -2518.93, quota: 6248.00, quota_avail: -2518.93
...
```

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
