### PR TITLE
Bump CMSMonitoring version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,6 @@ retry==0.9.1
 setuptools==39.2.0
 stomp.py==4.1.15
 rucio-clients==1.19.3
-CMSMonitoring>=0.2.4
+CMSMonitoring>=0.3.4
 # All dependencies needed to run Global WorkQueue
 # All dependencies needed to run ReqMgr2


### PR DESCRIPTION
Fixes None

#### Status
ready

#### Description
Change CMSMonitoring version to latest one which fix increasing number of failed connection to CERN brokers if the interrupted. The issue spotted in WMArchive where over time it accummulated large number of file descriptors, which I think related to large number of broken connection to CERN brokers.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
none

#### External dependencies / deployment changes
it is good to pick up latest version of CMSMonitoring module for future WMCore builds.