### PR TITLE
Limit MSTransferor in terms of successful workflows

### DIFF
--- a/src/python/WMCore/MicroService/Unified/MSTransferor.py
+++ b/src/python/WMCore/MicroService/Unified/MSTransferor.py
@@ -146,6 +146,7 @@ class MSTransferor(MSCore):
         :param reqStatus: request status to process
         :return:
         """
+        counterWorkflows = 0
         counterFailedRequests = 0
         counterSuccessRequests = 0
         summary = dict(TRANSFEROR_REPORT)
@@ -155,7 +156,6 @@ class MSTransferor(MSCore):
             msg = "  retrieved %s requests. " % len(requestRecords)
             msg += "Service set to process up to %s requests per cycle." % self.msConfig["limitRequestsPerCycle"]
             self.logger.info(msg)
-            requestRecords = requestRecords[:self.msConfig["limitRequestsPerCycle"]]
         except Exception as err:  # general error
             msg = "Unknown exception while fetching requests from ReqMgr2. Error: %s", str(err)
             self.logger.exception(msg)
@@ -179,6 +179,8 @@ class MSTransferor(MSCore):
 
         # process all requests
         for reqSlice in grouper(requestRecords, 100):
+            self.logger.info("Processing workflows from %d to %d.",
+                             counterWorkflows + 1, counterWorkflows + len(reqSlice))
             # get complete requests information
             # based on Unified Transferor logic
             reqResults = self.reqInfo(reqSlice)
@@ -207,6 +209,16 @@ class MSTransferor(MSCore):
                         counterFailedRequests += 1
                 else:
                     counterFailedRequests += 1
+            # it can go slightly beyond the limit. It's evaluated for every slice
+            if counterSuccessRequests >= self.msConfig["limitRequestsPerCycle"]:
+                msg = "Transferor succeeded acting on %d workflows in this cycle. " % counterSuccessRequests
+                msg += "Which exceeds the configuration limit set to: %s" % self.msConfig["limitRequestsPerCycle"]
+                self.logger.info(msg)
+                break
+            counterWorkflows += len(reqSlice)
+
+        self.logger.info("There were %d failed and %d success requests in this cycle",
+                         counterFailedRequests, counterSuccessRequests)
         self.logger.info("%s subscribed %d datasets and %d blocks in this cycle",
                          self.__class__.__name__, self.dsetCounter, self.blockCounter)
         self.updateReportDict(summary, "success_request_transition", counterSuccessRequests)


### PR DESCRIPTION
Fixes #9592 

#### Status
not-tested

#### Description
One of the MSTransferor configuration parameters is:
`limitRequestsPerCycle`
which is used to limit how many workflows MSTransferor can deal with in each cycle.

With this patch, we extend a bit the definition of that parameter to the number of successful workflows handled by MSTransferor. Thus, always targeting to properly handle (and moving them to the next status) that amount of workflows in every cycle (currently set to 500). Avoiding workflow starvation in the MSTransferor queue.

Note, that check has been placed under the slice level. So it could be that MSTransferor successfully updates a few more workflows in a cycle. Not a big deal though.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
