### PR TITLE
Fixed UserFileCache.removeFile throwing on success. Fixes #9594

### DIFF
--- a/src/python/WMCore/Services/UserFileCache/UserFileCache.py
+++ b/src/python/WMCore/Services/UserFileCache/UserFileCache.py
@@ -120,7 +120,7 @@ class UserFileCache(Service):
 
     def removeFile(self, haskey):
         result=self['requests'].makeRequest(uri = 'info', data = {'subresource':'fileremove', 'hashkey': haskey})
-        return result[0]['result'][0]
+        return json.loads(result[0])['result'][0]
 
     def download(self, hashkey, output, username=None):
         """


### PR DESCRIPTION
Fixes #9594 

#### Status
ready

#### Description
UserFileCache.removeFile throws on success.

```result[0]``` in that function is a json-encoded dictionary, not a python dictionary, and so it must be parsed with ```json.loads()``` prior to having a key accessed.

#### Is it backward compatible (if not, which system it affects?)
YES