### PR TITLE
Change cmsRun executable with cmsRunPython3

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Templates/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Templates/CMSSW.py
@@ -433,7 +433,7 @@ class CMSSW(Template):
         step.application.setup.softwareEnvironment = None
 
         step.application.section_("command")
-        step.application.command.executable = "cmsRun"
+        step.application.command.executable = "cmsRunPython3"
         step.application.command.configuration = "PSet.py"
         step.application.command.configurationPickle = "PSet.pkl"
         step.application.command.configurationHash = None


### PR DESCRIPTION
Fixes #9598

#### Status
In development && DO NOT MERGE

#### Description
Changes needed for Python3 tests. For more details see the: issue https://github.com/dmwm/WMCore/issues/9598

#### Is it backward compatible (if not, which system it affects?)
NO 

#### Related PRs

#### External dependencies / deployment changes

