### PR TITLE
Fix pop error when ssbStatus is unknown

### DIFF
--- a/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
+++ b/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
@@ -266,7 +266,7 @@ class ResourceControlUpdater(BaseWorkerThread):
             wmcoreStatus = self.getState(str(ssbStatus))
             if not wmcoreStatus:
                 logging.warning("Site %s has an unknown SSB status '%s'. Skipping it!", site, ssbStatus)
-                ssbStatus.pop(site, None)
+                ssbState.pop(site, None)
             else:
                 ssbState[site] = {'state': wmcoreStatus}
 


### PR DESCRIPTION
Fixes #9601

#### Status
tested

#### Description
Change ssbStatus to ssbState.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
#9585 

#### External dependencies / deployment changes
No
