### PR TITLE
Replace agentName WMAgentCommissioning by WMAgent

### DIFF
--- a/bin/adhoc-scripts/drainAgent.py
+++ b/bin/adhoc-scripts/drainAgent.py
@@ -200,7 +200,7 @@ def getCondorJobs():
     """
     jobDict = {}
     schedd = condor.Schedd()
-    jobs = schedd.xquery('WMAgent_AgentName == "WMAgentCommissioning"', ['WMAgent_RequestName', 'JobStatus'])
+    jobs = schedd.xquery('WMAgent_AgentName == "WMAgent"', ['WMAgent_RequestName', 'JobStatus'])
     for job in jobs:
         jobStatus = job['JobStatus']
         jobDict.setdefault(jobStatus, {})

--- a/etc/GlobalWorkQueueConfig.py
+++ b/etc/GlobalWorkQueueConfig.py
@@ -36,7 +36,7 @@ workqueueInboxDbName = 'workqueue_inbox'
 wmstatDBName = "wmstats"
 
 # Agent name and team name.
-agentName = "WMAgentCommissioning"
+agentName = "WMAgent"
 teamName = "cmsdataops"
 contactName = "cmsdataops@cern.ch"
 

--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -75,7 +75,7 @@ config.section_("Agent")
 config.Agent.hostName = serverHostName
 config.Agent.contact = contactName
 config.Agent.teamName = "REPLACE_TEAM_NAME"
-config.Agent.agentName = "WMAgentCommissioning"
+config.Agent.agentName = "WMAgent"
 config.Agent.agentNumber = 0
 config.Agent.useMsgService = False
 config.Agent.useTrigger = False

--- a/src/couchapps/WMStats/_attachments/js/DataStruct/WMStats.GenericRequests.js
+++ b/src/couchapps/WMStats/_attachments/js/DataStruct/WMStats.GenericRequests.js
@@ -482,7 +482,7 @@ WMStats.GenericRequests.prototype = {
                                  *                        "timestamp": 1437498506, 
                                  *                        "_rev": "1-d792c9d73285ff1318d7f5c0e2b2f486", 
                                  *                        "sites": {"T2_CH_CERN": {"success": 107}}, 
-                                 *                        "agent": "WMAgentCommissioning", 
+                                 *                        "agent": "WMAgent", 
                                  *                        "tasks": {"/sryu_ReReco_reqmgr2_validation_150717_180724_9878/ReReco/ReRecoMergeRAWSIMoutput/ReRecoRAWSIMoutputMergeLogCollect": 
                                  *                                     {"status": {"success": 1}, 
                                  *                                      "sites": {"T2_CH_CERN": 

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
@@ -519,7 +519,7 @@ WMStats.GenericRequests.prototype = {
                                  *                        "timestamp": 1437498506, 
                                  *                        "_rev": "1-d792c9d73285ff1318d7f5c0e2b2f486", 
                                  *                        "sites": {"T2_CH_CERN": {"success": 107}}, 
-                                 *                        "agent": "WMAgentCommissioning", 
+                                 *                        "agent": "WMAgent", 
                                  *                        "tasks": {"/sryu_ReReco_reqmgr2_validation_150717_180724_9878/ReReco/ReRecoMergeRAWSIMoutput/ReRecoRAWSIMoutputMergeLogCollect": 
                                  *                                     {"status": {"success": 1}, 
                                  *                                      "sites": {"T2_CH_CERN": 

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
@@ -519,7 +519,7 @@ WMStats.GenericRequests.prototype = {
                                  *                        "timestamp": 1437498506, 
                                  *                        "_rev": "1-d792c9d73285ff1318d7f5c0e2b2f486", 
                                  *                        "sites": {"T2_CH_CERN": {"success": 107}}, 
-                                 *                        "agent": "WMAgentCommissioning", 
+                                 *                        "agent": "WMAgent", 
                                  *                        "tasks": {"/sryu_ReReco_reqmgr2_validation_150717_180724_9878/ReReco/ReRecoMergeRAWSIMoutput/ReRecoRAWSIMoutputMergeLogCollect": 
                                  *                                     {"status": {"success": 1}, 
                                  *                                      "sites": {"T2_CH_CERN": 

--- a/src/python/WMCore/Services/WMStats/WMStatsReader.py
+++ b/src/python/WMCore/Services/WMStats/WMStatsReader.py
@@ -129,7 +129,7 @@ class WMStatsReader(object):
         "timestamp":1394738860,"sites":{"T2_CH_CERN_AI":{"submitted":{"retry":1,"pending":1}},
         "T2_CH_CERN":{"success":6,"submitted":{"retry":1,"pending":1}},
         "T2_DE_DESY":{"failure":{"exception":3},"success":375}},
-        "agent":"WMAgentCommissioning",
+        "agent":"WMAgent",
         "tasks":
            {"/amaltaro_OracleUpgrade_TEST_HG1401_140220_090116_6731/Production":
             {"status":{"failure":{"exception":3},"success":331},

--- a/src/python/WMQuality/Emulators/EmulatorSetup.py
+++ b/src/python/WMQuality/Emulators/EmulatorSetup.py
@@ -45,7 +45,7 @@ def _wmAgentConfig(configFile):
     # User specific parameter
     config.Agent.teamName = "DMWM"
     # User specific parameter
-    config.Agent.agentName = "WMAgentCommissioning"
+    config.Agent.agentName = "WMAgent"
     config.Agent.useMsgService = False
     config.Agent.useTrigger = False
     config.Agent.isDocker = False

--- a/src/python/WMQuality/Emulators/WMSpecGenerator/ReqMgrDocGenerator.py
+++ b/src/python/WMQuality/Emulators/WMSpecGenerator/ReqMgrDocGenerator.py
@@ -127,7 +127,7 @@ def generate_agent_requests(number=NUM_OF_REQUEST, iterations=ITERATIONS):
                }
            }
        },
-       "agent": "WMAgentCommissioning",
+       "agent": "WMAgent",
        "team": "team1,team2,cmsdataops",
        "agent_url": "cms-xen39.fnal.gov",
        "type": "agent_request"
@@ -167,7 +167,7 @@ def generate_agent_requests(number=NUM_OF_REQUEST, iterations=ITERATIONS):
                               "success": 1
                              }
                           },
-                "agent": "WMAgentCommissioning",
+                "agent": "WMAgent",
                 "agent_teams": "team1,team2,cmsdataops",
                 "agent_url": "cms-xen39.fnal.gov",
                 "type": "agent_request"

--- a/test/data/WMStats/doc_generator.py
+++ b/test/data/WMStats/doc_generator.py
@@ -89,7 +89,7 @@ def generate_agent_requests(number=NUM_OF_REQUEST, iterations=ITERATIONS):
                }
            }
        },
-       "agent": "WMAgentCommissioning",
+       "agent": "WMAgent",
        "team": "team1,team2,cmsdataops",
        "agent_url": "cms-xen39.fnal.gov",
        "type": "agent_request"
@@ -129,7 +129,7 @@ def generate_agent_requests(number=NUM_OF_REQUEST, iterations=ITERATIONS):
                                "success": 1
                            }
                    },
-                   "agent": "WMAgentCommissioning",
+                   "agent": "WMAgent",
                    "agent_teams": "cmsdataops",
                    "agent_url": "cms-xen39.fnal.gov",
                    "type": "agent_request"

--- a/test/data/WMStats/generator.py
+++ b/test/data/WMStats/generator.py
@@ -184,7 +184,7 @@ def generate_agent_requests(number=NUM_OF_REQUEST, iterations=ITERATIONS):
                }
            }
        },
-       "agent": "WMAgentCommissioning",
+       "agent": "WMAgent",
        "team": "team1,team2,cmsdataops",
        "agent_url": "cms-xen39.fnal.gov",
        "type": "agent_request"
@@ -224,7 +224,7 @@ def generate_agent_requests(number=NUM_OF_REQUEST, iterations=ITERATIONS):
                                "success": 1
                            }
                    },
-                   "agent": "WMAgentCommissioning",
+                   "agent": "WMAgent",
                    "agent_teams": "cmsdataops",
                    "agent_url": "cms-xen39.fnal.gov",
                    "type": "agent_request"

--- a/test/python/WMCore_t/Services_t/WMStats_t/WMStatsDocGenerator.py
+++ b/test/python/WMCore_t/Services_t/WMStats_t/WMStatsDocGenerator.py
@@ -126,7 +126,7 @@ def generate_agent_requests(number=NUM_OF_REQUEST, iterations=ITERATIONS):
                }
            }
        },
-       "agent": "WMAgentCommissioning",
+       "agent": "WMAgent",
        "team": "team1,team2,cmsdataops",
        "agent_url": "cms-xen39.fnal.gov",
        "type": "agent_request"
@@ -166,7 +166,7 @@ def generate_agent_requests(number=NUM_OF_REQUEST, iterations=ITERATIONS):
                               "success": 1
                              }
                           },
-                "agent": "WMAgentCommissioning",
+                "agent": "WMAgent",
                 "agent_teams": "cmsdataops",
                 "agent_url": "cms-xen39.fnal.gov",
                 "type": "agent_request"
@@ -248,7 +248,7 @@ def generate_jobsummary(request, number=NUM_OF_JOBS_PER_REQUEST):
 sample_request_info = {'AcquisitionEra': 'Integ_Test',
  'AgentJobInfo': {'vocms008.cern.ch:9999': {'_id': '1444db7834fdedaf68fbf7498330adab',
                                             '_rev': '1-82d7cef10f3df98b481609152b048dd5',
-                                            'agent': 'WMAgentCommissioning',
+                                            'agent': 'WMAgent',
                                             'agent_team': 'testbed-dev',
                                             'agent_url': 'vocms008.cern.ch:9999',
                                             'sites': {'T1_US_FNAL': {'submitted': {'first': 35,
@@ -389,7 +389,7 @@ sample_request_info = {'AcquisitionEra': 'Integ_Test',
 sample_complete = {'AcquisitionEra': 'Integ_Test',
  'AgentJobInfo': {'vocms008.cern.ch:9999': {'_id': '1444db7834fdedaf68fbf7498394376c',
                                             '_rev': '1-0250fbe480c56e57b2c939ff491aab8b',
-                                            'agent': 'WMAgentCommissioning',
+                                            'agent': 'WMAgent',
                                             'agent_team': 'testbed-dev',
                                             'agent_url': 'vocms008.cern.ch:9999',
                                             'sites': {'T2_CH_CERN_HLT': {'failure': {'exception': 1},


### PR DESCRIPTION
Fixes #9625 

#### Status
not-tested

#### Description
Rename agentName from `WMAgentCommissioning` to `WMAgent`, since it will be part of the meta-data injected into Rucio.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
