### PR TITLE
Make list of allowed tiers for Rucio; disallowed tiers for PhEDEx

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -367,6 +367,7 @@ config.RucioInjector.pollIntervalRules = 43200
 config.RucioInjector.cacheExpiration = 2 * 24 * 60 * 60  # two days
 config.RucioInjector.createBlockRules = True
 config.RucioInjector.RSEPostfix = False  # enable it to append _Test to the RSE names
+config.RucioInjector.listTiersToInject = ["NANOAOD", "NANOAODSIM"]
 config.RucioInjector.skipRulesForTiers = ["NANOAOD", "NANOAODSIM"]
 config.RucioInjector.rucioAccount = "OVER_WRITE_BY_SECRETS"
 config.RucioInjector.rucioUrl = "OVER_WRITE_BY_SECRETS"

--- a/test/python/WMComponent_t/PhEDExInjector_t/PhEDExInjectorSubscriber_t.py
+++ b/test/python/WMComponent_t/PhEDExInjector_t/PhEDExInjectorSubscriber_t.py
@@ -88,6 +88,8 @@ class PhEDExInjectorSubscriberTest(EmulatedUnitTestCase):
         config.PhEDExInjector.group = "Saturn"
         config.PhEDExInjector.pollInterval = 30
         config.PhEDExInjector.subscribeInterval = 60
+        config.component_("RucioInjector")
+        config.RucioInjector.listTiersToInject = ["NANOAOD", "NANOAODSIM"]
 
         return config
 

--- a/test/python/WMComponent_t/RucioInjector_t/RucioInjectorPoller_t.py
+++ b/test/python/WMComponent_t/RucioInjector_t/RucioInjectorPoller_t.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+"""
+Unit tests for the RucioInjectorPoller module
+"""
+
+from __future__ import division
+
+import unittest
+from WMComponent.RucioInjector.RucioInjectorPoller import filterDataByTier
+
+
+class RucioInjectorPollerTest(unittest.TestCase):
+
+    def testFilterDataByTier(self):
+        """
+        _testFilterDataByTier_
+
+        Test the `filterDataByTier` function, which is supposed to return
+        only data for the allowed data tiers.
+        """
+        allowedTiers = ["NANOAOD", "NANOAODSIM"]
+        uninjectedFiles = {"SiteA": {"/dset1/procStr-v1/GEN": ["blah"],
+                                     "/dset2/procStr-v1/GEN-SIM": ["blah"],
+                                     "/dset3/procStr-v1/AOD": ["blah"],
+                                     "/dset4/procStr-v1/NANOAODSIM": ["blah"],
+                                     "/dset5/procStr-v1/NANOAOD": ["blah"],
+                                     "/dset6/procStr-v1/RECO": ["blah"]},
+                           "SiteB": {"/dset7/procStr-v1/NANOAOD": ["blah"]},
+                           "SiteC": {"/dset8/procStr-v1/GEN": ["blah"]}}
+
+        finalData = filterDataByTier(uninjectedFiles, allowedTiers)
+        self.assertEqual(len(finalData), 3)
+        self.assertItemsEqual(finalData.keys(), ["SiteA", "SiteB", "SiteC"])
+
+        self.assertItemsEqual(finalData["SiteA"].keys(), ["/dset4/procStr-v1/NANOAODSIM",
+                                                          "/dset5/procStr-v1/NANOAOD"])
+        self.assertItemsEqual(finalData["SiteB"].keys(), ["/dset7/procStr-v1/NANOAOD"])
+        self.assertItemsEqual(finalData["SiteC"].keys(), [])
+
+        return
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #9600

#### Status
ready

#### Description
Created another parameter `listTiersToInject` for the RucioInjector component.
This parameter has a list of datatiers that we want RucioInjector to inject data into Rucio. Data that belongs to any other datatiers will be completely skipped from any actions performed by the RucioInjector component.

Uses the same RucioInjector parameter - but in the opposite logic - for the PhEDExInjector component. Thus, PhEDExInjector will drop any data that matches that list of datatiers. Including dataset subscription, block deletion, closure of blocks, etc.

#### Is it backward compatible (if not, which system it affects?)
somehow

#### Related PRs
none

#### External dependencies / deployment changes
none
