### PR TITLE
Added rule_id column to dbsbuffer_block; create a rule for every block produced

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -165,9 +165,10 @@ config.PhEDExInjector.subscribeDatasets = True
 config.PhEDExInjector.safeMode = False
 # phedex address "https://cmsweb.cern.ch/phedex/datasvc/json/prod/"
 config.PhEDExInjector.phedexurl = "OVER_WRITE_BY_SECETES"
-config.PhEDExInjector.pollInterval = 100
-config.PhEDExInjector.subscribeInterval = 43200
+config.PhEDExInjector.pollInterval = 300
+config.PhEDExInjector.subscribeInterval = 6 * 60 * 60  # 6h
 config.PhEDExInjector.diskSites = diskSites
+config.PhEDExInjector.phedexGroup = "DataOps"
 
 config.component_("JobAccountant")
 config.JobAccountant.namespace = "WMComponent.JobAccountant.JobAccountant"

--- a/src/python/WMComponent/DBS3Buffer/MySQL/Create.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/Create.py
@@ -135,6 +135,7 @@ class Create(DBCreator):
                  create_time  INTEGER,
                  status       VARCHAR(20),
                  deleted      INTEGER      DEFAULT 0,
+                 rule_id      VARCHAR(40)  NOT NULL DEFAULT '0',
                  PRIMARY KEY (id),
                  CONSTRAINT uq_dbs_blo UNIQUE (blockname, location))"""
 

--- a/src/python/WMComponent/DBS3Buffer/Oracle/Create.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/Create.py
@@ -145,6 +145,7 @@ class Create(DBCreator):
                  create_time INTEGER,
                  status      VARCHAR(20),
                  deleted     INTEGER      DEFAULT 0,
+                 rule_id     VARCHAR(40)  DEFAULT '0' NOT NULL,
                  PRIMARY KEY (id),
                  CONSTRAINT uq_dbs_blo UNIQUE (blockname, location)
                )"""

--- a/src/python/WMComponent/RucioInjector/Database/MySQL/GetUnsubscribedBlocks.py
+++ b/src/python/WMComponent/RucioInjector/Database/MySQL/GetUnsubscribedBlocks.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+"""
+_GetUnsubscribedBlocks_
+
+MySQL implementation of RucioInjector.Database.GetUnsubscribedBlocks
+"""
+from __future__ import division
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+
+class GetUnsubscribedBlocks(DBFormatter):
+    """
+    _GetUnsubscribedBlocks_
+
+    Gets the unsubscribed blocks from DBSBuffer, so blocks
+    without a valid rule id
+    """
+    sql = """SELECT dbsbuffer_block.blockname, dbsbuffer_location.pnn
+               FROM dbsbuffer_block
+             INNER JOIN dbsbuffer_location ON
+                   dbsbuffer_block.location = dbsbuffer_location.id
+             WHERE dbsbuffer_block.rule_id = '0'"""
+
+    def execute(self, conn=None, transaction=False):
+        result = self.dbi.processData(self.sql, conn=conn,
+                                      transaction=transaction)
+        return self.formatDict(result)

--- a/src/python/WMComponent/RucioInjector/Database/MySQL/SetBlocksRule.py
+++ b/src/python/WMComponent/RucioInjector/Database/MySQL/SetBlocksRule.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+"""
+_SetBlocksRule_
+
+MySQL implementation of RucioInjector.Database.SetBlocksRule
+"""
+
+from __future__ import division
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+
+class SetBlocksRule(DBFormatter):
+    """
+    _SetBlocksRule_
+
+    Set rules ID for blocks in the DBSBuffer
+    """
+    sql = """UPDATE dbsbuffer_block
+               SET dbsbuffer_block.rule_id = :RULE_ID
+             WHERE dbsbuffer_block.blockname = :BLOCKNAME
+             """
+
+    def execute(self, binds, conn=None, transaction=False):
+        self.dbi.processData(self.sql, binds, conn=conn,
+                             transaction=transaction)
+
+        return

--- a/src/python/WMComponent/RucioInjector/Database/Oracle/GetUnsubscribedBlocks.py
+++ b/src/python/WMComponent/RucioInjector/Database/Oracle/GetUnsubscribedBlocks.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+"""
+_GetUnsubscribedBlocks_
+
+Oracle implementation of GetUnsubscribedBlocks.
+"""
+
+from __future__ import division
+
+from WMComponent.RucioInjector.Database.MySQL.GetUnsubscribedBlocks import GetUnsubscribedBlocks as MySQLBase
+
+
+class GetUnsubscribedBlocks(MySQLBase):
+    pass

--- a/src/python/WMComponent/RucioInjector/Database/Oracle/SetBlocksRule.py
+++ b/src/python/WMComponent/RucioInjector/Database/Oracle/SetBlocksRule.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+"""
+_SetBlocksRule_
+
+Oracle implementation of SetBlocksRule
+"""
+
+from __future__ import division
+
+from WMComponent.RucioInjector.Database.MySQL.SetBlocksRule import SetBlocksRule as MySQLBase
+
+
+class SetBlocksRule(MySQLBase):
+    pass

--- a/src/python/WMCore/Services/PhEDEx/DataStructs/SubscriptionList.py
+++ b/src/python/WMCore/Services/PhEDEx/DataStructs/SubscriptionList.py
@@ -139,6 +139,17 @@ class PhEDExSubscription(object):
         """
         return self.blocks
 
+    def getBlocks(self):
+        """
+        _getBlocks_
+
+        Return only the list of blocks
+        """
+        blocks = []
+        for dset, listBlocks in self.blocks.items():
+            blocks.extend(listBlocks)
+        return blocks
+
     def getNodes(self):
         return list(self.nodes)
 

--- a/src/python/WMCore/Services/Rucio/Rucio.py
+++ b/src/python/WMCore/Services/Rucio/Rucio.py
@@ -449,7 +449,7 @@ class Rucio(object):
         try:
             response = self.cli.add_replication_rule(dids, copies, rseExpression, **kwargs)
         except Exception as ex:
-            self.logger.error("Exception creating replica for data: %s. Error: %s", names, str(ex))
+            self.logger.error("Exception creating rule replica for data: %s. Error: %s", names, str(ex))
         return response
 
     def listContent(self, name, scope='cms'):

--- a/test/python/WMComponent_t/PhEDExInjector_t/PhEDExInjectorSubscriber_t.py
+++ b/test/python/WMComponent_t/PhEDExInjector_t/PhEDExInjectorSubscriber_t.py
@@ -88,6 +88,7 @@ class PhEDExInjectorSubscriberTest(EmulatedUnitTestCase):
         config.PhEDExInjector.group = "Saturn"
         config.PhEDExInjector.pollInterval = 30
         config.PhEDExInjector.subscribeInterval = 60
+        config.PhEDExInjector.phedexGroup = "DataOps"
         config.component_("RucioInjector")
         config.RucioInjector.listTiersToInject = ["NANOAOD", "NANOAODSIM"]
 


### PR DESCRIPTION
Fixes #9604 

#### Status
tested

#### Description
List of changes include:
* new configuration parameter for PhEDExInjector: `phedexGroup`, default to `DataOps`
* increased PhEDExInjector polling cycle to 300secs (and subscription decreased to 6h)
* a DBSBuffer database schema change:
  * created a new column `rule_id` (varchar default to '0') to store the rule id retrieved from Rucio; or the request id retrieved from PhEDEx subscriptions
* two new DAOs to get unsubscribed blocks; and to set the rule/request id for blocks recently subscribed
* for PhEDEx, we add as many blocks as we can in the same subscription request
  * and update the local database in bulk
* for Rucio, we make a new rule for every block
  * update the local database with single binds (might have to change it)
* also fixed a bug with the `rseName` variable handling

This block rule/subscription creation does NOT follow the same component cycle, but it follows the rule/subscription polling cycle (every 12h)

#### Is it backward compatible (if not, which system it affects?)
NO

#### Related PRs
none

#### External dependencies / deployment changes
none
