### PR TITLE
Validate KeepOutput settings in TaskChain spec

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
@@ -539,8 +539,8 @@ class StepChainWorkloadFactory(StdBase):
 
         lastStep = "Step%s" % schema['StepChain']
         if not strToBool(schema[lastStep].get('KeepOutput', True)):
-            msg = "Dropping the output of the last step is prohibited.\n"
-            msg += "Set the 'KeepOutput' value to True and try again."
+            msg = "Dropping the output (KeepOutput=False) of the last step is prohibited.\n"
+            msg += "You probably want to remove that step completely and try again."
             self.raiseValidationException(msg=msg)
 
         outputModTier = []

--- a/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
@@ -665,6 +665,7 @@ class TaskChainWorkloadFactory(StdBase):
         Go over each task and make sure it matches validation
         parameters derived from Dave's requirements. They are:
          * cannot have more than 10 tasks
+         * output from the last task *must* be saved
          * task must be described as a python dictionary type
          * transient output modules must be an input for further task(s)
          * and the usual Task arguments validation, as defined in the spec
@@ -674,6 +675,12 @@ class TaskChainWorkloadFactory(StdBase):
             msg = "Workflow exceeds the maximum allowed number of tasks. "
             msg += "Limited to up to 10 tasks, found %s tasks." % numTasks
             self.raiseValidationException(msg)
+
+        lastTask = "Task%s" % schema['TaskChain']
+        if not strToBool(schema[lastTask].get('KeepOutput', True)):
+            msg = "Dropping the output (KeepOutput=False) of the last task is prohibited.\n"
+            msg += "You probably want to remove that task completely and try again."
+            self.raiseValidationException(msg=msg)
 
         transientMapping = {}
         for i in xrange(1, numTasks + 1):

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
@@ -2288,6 +2288,21 @@ class TaskChainTests(EmulatedUnitTestCase):
         with self.assertRaises(WMSpecFactoryException):
             factory.factoryWorkloadConstruction("ElevenTasks", testArguments)
 
+    def testBadKeepOutput(self):
+        """
+        Test usage of KeepOutput=false in the last task
+        """
+        processorDocs = makeProcessingConfigs(self.configDatabase)
+
+        arguments = TaskChainWorkloadFactory.getTestArguments()
+        arguments.update(REQUEST_INPUT)
+        arguments['Task1']['ConfigCacheID'] = processorDocs['DigiHLT']
+        arguments['Task2']['ConfigCacheID'] = processorDocs['Reco']
+        arguments['Task2']['KeepOutput'] = False
+
+        factory = TaskChainWorkloadFactory()
+        with self.assertRaises(WMSpecFactoryException):
+            factory.factoryWorkloadConstruction("PullingTheChain", arguments)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #9636

#### Status
not-tested

#### Description
Validate the usage of KeepOutput in a TaskChain workflow and fail workflow creation if the last task is set to drop its output data.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none