### PR TITLE
Update rucio-clients version and add pymongo to the requirements list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,9 @@ pyzmq==17.1.2
 retry==0.9.1
 setuptools==39.2.0
 stomp.py==4.1.15
-rucio-clients==1.19.3
+rucio-clients==1.22.2
 CMSMonitoring>=0.3.4
+# All dependencies needed to run MicroServices
+pymongo==3.10.1
 # All dependencies needed to run Global WorkQueue
 # All dependencies needed to run ReqMgr2

--- a/requirements.wmagent.txt
+++ b/requirements.wmagent.txt
@@ -18,4 +18,4 @@ python-cjson==1.2.1
 pyzmq==17.1.2
 retry==0.9.1
 stomp.py==4.1.15
-rucio-clients==1.19.3
+rucio-clients==1.22.2


### PR DESCRIPTION
No issue created

#### Status
ready

#### Description
Rucio client is getting updated in this PR: https://github.com/cms-sw/cmsdist/pull/5753

and pymongo has already been made a dependency for reqmgr2ms service (a quite old version btw).

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
Depends on this cmsdist PR: https://github.com/cms-sw/cmsdist/pull/5753
and
https://github.com/cms-sw/cmsdist/pull/5754