### PR TITLE
Workaround voms-proxy-init imcompatibilities

### DIFF
--- a/deploy/renew_proxy.sh
+++ b/deploy/renew_proxy.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 credname=CREDNAME
+
 source /data/admin/wmagent/env.sh
-source /data/srv/wmagent/current/apps/wmagent/etc/profile.d/init.sh
+### FNAL and CERN have different versions of voms-proxy-init
+if [[ "$credname" == amaltaroCERN ]]; then
+    source /data/srv/wmagent/current/apps/wmagent/etc/profile.d/init.sh
+fi
 myproxy-get-delegation -v -l amaltaro -t 168 -s 'myproxy.cern.ch' -k $credname -n \
   -o /data/certs/mynewproxy.pem && voms-proxy-init -rfc -voms cms:/cms/Role=production -valid 168:00 \
   -noregen -cert /data/certs/mynewproxy.pem -key /data/certs/mynewproxy.pem -out /data/certs/myproxy.pem


### PR DESCRIPTION
Fixes #9641 
Complement to https://github.com/dmwm/WMCore/pull/9642

#### Status
ready

#### Description
CERN and FNAL have different versions of voms-proxy-init, one java based, while the other is c++ based. When we load the agent libraries, there are incompatibilities with voms-proxy-init2, so skip sourcing the agent environment for FNAL nodes.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Fixes this fix: https://github.com/dmwm/WMCore/pull/9642

#### External dependencies / deployment changes
none
