### PR TITLE
Add an earlier status ('closed-out') to fix the parentage dependencies

### DIFF
--- a/src/python/WMCore/REST/CherryPyPeriodicTask.py
+++ b/src/python/WMCore/REST/CherryPyPeriodicTask.py
@@ -25,6 +25,7 @@ class CherryPyPeriodicTask(object):
         TODO: add validation for config.duration
         """
         self.logger = getTimeRotatingLogger(config._internal_name, config.log_file)
+        self.logger.info("Setting CherryPy periodic task with the following config:\n%s", config)
         self.setConcurrentTasks(config)
         self.setUpLogDB(config)
 

--- a/src/python/WMCore/ReqMgr/CherryPyThreads/StepChainParentageFixTask.py
+++ b/src/python/WMCore/ReqMgr/CherryPyThreads/StepChainParentageFixTask.py
@@ -35,7 +35,7 @@ class StepChainParentageFixTask(CherryPyPeriodicTask):
         super(StepChainParentageFixTask, self).__init__(config)
         self.reqmgrDB = RequestDBWriter(config.reqmgrdb_url)
         self.dbsSvc = DBS3Reader(config.dbs_url, logger=self.logger)
-        self.statusToCheck = ["announced", "normal-archived"]
+        self.statusToCheck = ["closed-out", "announced", "normal-archived"]
 
     def setConcurrentTasks(self, config):
         """

--- a/src/python/WMCore/ReqMgr/CherryPyThreads/StepChainParentageFixTask.py
+++ b/src/python/WMCore/ReqMgr/CherryPyThreads/StepChainParentageFixTask.py
@@ -48,12 +48,14 @@ class StepChainParentageFixTask(CherryPyPeriodicTask):
         Look through the stepchain workflows with ParentageResolved flag is False.
         Fix the StepChain parentage and update the ParentageResolved flag to True
         """
-        self.logger.info("Updating parentage for StepChain workflows for %s", self.statusToCheck)
+        self.logger.info("Running fixStepChainParentage thread for statuses: %s", self.statusToCheck)
         childDatasets = set()
         requests = set()
         requestsByChildDataset = {}
         for status in self.statusToCheck:
             reqByChildDS= getChildDatasetsForStepChainMissingParent(self.reqmgrDB, status)
+            self.logger.info("Retrieved %d datasets to fix parentage, in status: %s",
+                             len(reqByChildDS), status)
             childDatasets = childDatasets.union(set(reqByChildDS.keys()))
             # We need to just get one of the StepChain workflow if multiple workflow contains the same datasets. (i.e. ACDC)
             requestsByChildDataset.update(reqByChildDS)
@@ -65,6 +67,7 @@ class StepChainParentageFixTask(CherryPyPeriodicTask):
         totalChildDS = len(childDatasets)
         fixCount = 0
         for childDS in childDatasets:
+            self.logger.info("Resolving parentage for dataset: %s", childDS)
             start = int(time.time())
             failedBlocks = self.dbsSvc.fixMissingParentageDatasets(childDS, insertFlag=True)
             end = int(time.time())

--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -1008,6 +1008,7 @@ class DBS3Reader(object):
         :return: blocks which failed to insert parentage. for retry
         """
         pDatasets = self.listDatasetParents(childDataset)
+        self.logger.info("Parent datasets for %s are: %s", childDataset, pDatasets)
         # print("parent datasets %s\n" % pDatasets)
         # pDatasets format is
         # [{'this_dataset': '/SingleMuon/Run2016D-03Feb2017-v1/MINIAOD', 'parent_dataset_id': 13265209, 'parent_dataset': '/SingleMuon/Run2016D-23Sep2016-v1/AOD'}]
@@ -1017,6 +1018,7 @@ class DBS3Reader(object):
 
         blocks = self.listBlocksWithNoParents(childDataset)
         failedBlocks = []
+        self.logger.info("Found %d blocks without parentage information", len(blocks))
         for blockName in blocks:
             try:
                 numFiles = self.findAndInsertMissingParentage(blockName, insertFlag=insertFlag)


### PR DESCRIPTION
Fixes #9656 

#### Status
ready

#### Description
Add an earlier status ('closed-out') in the list of statuses  to be considered when fixing the parentage dependencies

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
There should be one in the Unified repository. 

#### External dependencies / deployment changes
The flag `ParentageResolved`, which now (once this PR is merged) should be set in the `closoed-out` status, should be checked and taken into account by Unified. 
