### PR TITLE
Consider PU location for top level MC task

### DIFF
--- a/src/python/WMCore/WMBS/MySQL/Locations/GetSiteInfo.py
+++ b/src/python/WMCore/WMBS/MySQL/Locations/GetSiteInfo.py
@@ -19,10 +19,14 @@ class GetSiteInfo(DBFormatter):
                  INNER JOIN wmbs_location_pnns wls ON wls.location = wl.id
                  INNER JOIN wmbs_pnns wpnn ON wpnn.id = wls.pnn
                  INNER JOIN wmbs_location_state wlst ON wlst.id = wl.state
-               WHERE wl.site_name = :site"""
+          """
 
     def execute(self, siteName=None, conn=None, transaction=False):
-        results = self.dbi.processData(self.sql, {'site': siteName},
+        if not siteName:
+            results = self.dbi.processData(self.sql, conn=conn,
+                                           transaction=transaction)
+        else:
+            sql = self.sql + " WHERE wl.site_name = :site"
+            results = self.dbi.processData(sql, {'site': siteName},
                                        conn=conn, transaction=transaction)
-        formatted = self.formatDict(results)
-        return formatted
+        return self.formatDict(results)

--- a/test/python/WMCore_t/WorkQueue_t/WMBSHelper_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WMBSHelper_t.py
@@ -529,12 +529,13 @@ class WMBSHelperTest(EmulatedUnitTestCase):
         # dbsDict = {self.inputDataset.dbsurl : self.dbs}
         return dbs
 
-    def createWMBSHelperWithTopTask(self, wmspec, block, mask=None,
-                                    parentFlag=False, detail=False):
+    def createWMBSHelperWithTopTask(self, wmspec, block, mask=None, parentFlag=False,
+                                    detail=False, commonLocation=None):
 
         topLevelTask = getFirstTask(wmspec)
 
-        wmbs = WMBSHelper(wmspec, topLevelTask.name(), block, mask, cachepath=self.workDir)
+        wmbs = WMBSHelper(wmspec, topLevelTask.name(), block, mask, cachepath=self.workDir,
+                          commonLocation=commonLocation)
         if block:
             if parentFlag:
                 block = self.dbs.getFileBlockWithParents(block)[block]
@@ -891,6 +892,7 @@ class WMBSHelperTest(EmulatedUnitTestCase):
 
     def testDuplicateSubscription(self):
         """Can't duplicate subscriptions"""
+        siteWhitelist = ["T2_XX_SiteA", "T2_XX_SiteB"]
         # using default wmspec
         block = self.dataset + "#" + BLOCK1
         wmbs = self.createWMBSHelperWithTopTask(self.wmspec, block)
@@ -918,7 +920,8 @@ class WMBSHelperTest(EmulatedUnitTestCase):
         self.setupMCWMSpec()
         mask = Mask(FirstRun=12, FirstLumi=1234, FirstEvent=12345,
                     LastEvent=999995, LastLumi=12345, LastRun=12)
-        wmbs = self.createWMBSHelperWithTopTask(self.wmspec, None, mask)
+        wmbs = self.createWMBSHelperWithTopTask(self.wmspec, None, mask,
+                                                commonLocation=siteWhitelist)
         wmbs.topLevelFileset.loadData()
         numOfFiles = len(wmbs.topLevelFileset.files)
         filesetId = wmbs.topLevelFileset.id
@@ -932,7 +935,8 @@ class WMBSHelperTest(EmulatedUnitTestCase):
         self.assertEqual(numOfFiles, numDbsFiles)
 
         # reinsert subscription - shouldn't create anything new
-        wmbs = self.createWMBSHelperWithTopTask(self.wmspec, None, mask)
+        wmbs = self.createWMBSHelperWithTopTask(self.wmspec, None, mask,
+                                                commonLocation=siteWhitelist)
         wmbs.topLevelFileset.loadData()
         self.assertEqual(numOfFiles, len(wmbs.topLevelFileset.files))
         self.assertEqual(filesetId, wmbs.topLevelFileset.id)
@@ -977,13 +981,15 @@ class WMBSHelperTest(EmulatedUnitTestCase):
         # in BasicProductionWorkload.getProdArgs() but changing it to
         # "reqmgr_config_cache_t" from StdBase test arguments does not fix the
         # situation. testDuplicateSubscription probably has the same issue
+        siteWhitelist = ["T2_XX_SiteA", "T2_XX_SiteB"]
 
         self.setupMCWMSpec()
 
         mask = Mask(FirstRun=12, FirstLumi=1234, FirstEvent=12345,
                     LastEvent=999995, LastLumi=12345, LastRun=12)
 
-        wmbs = self.createWMBSHelperWithTopTask(self.wmspec, None, mask)
+        wmbs = self.createWMBSHelperWithTopTask(self.wmspec, None, mask,
+                                                commonLocation=siteWhitelist)
         subscription = wmbs.topLevelSubscription
         self.assertEqual(1, subscription.exists())
         fileset = subscription['fileset']

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
@@ -266,7 +266,7 @@ class WorkQueueTest(WorkQueueTestCase):
 
         # create relevant sites in wmbs
         rc = ResourceControl()
-        site_se_mapping = {'T2_XX_SiteA': 'a.example.com', 'T2_XX_SiteB': 'b.example.com'}
+        site_se_mapping = {'T2_XX_SiteA': 'T2_XX_SiteA', 'T2_XX_SiteB': 'T2_XX_SiteB'}
         for site, se in site_se_mapping.iteritems():
             rc.insertSite(site, 100, 200, se, cmsName=site, plugin="MockPlugin")
             daofactory = DAOFactory(package="WMCore.WMBS",
@@ -874,22 +874,22 @@ class WorkQueueTest(WorkQueueTestCase):
         self.queue.queueWork(processingSpec.specUrl())
         elements = len(self.queue)
         self.queue.updateLocationInfo()
+        self.assertEqual(len(self.queue.status()), NBLOCKS_HICOMM)
         work = self.queue.getWork({'T2_XX_SiteA': 1000, 'T2_XX_SiteB': 1000}, {})
         self.assertEqual(len(self.queue), 0)
         self.assertEqual(len(self.queue.status(status='Running')), elements)
         ids = [x.id for x in work]
+        self.assertEqual(len(ids), NBLOCKS_HICOMM)
         canceled = self.queue.cancelWork(ids)
         self.assertEqual(sorted(canceled), sorted(ids))
-        self.assertEqual(len(self.queue), 0)
         self.assertEqual(len(self.queue.status()), NBLOCKS_HICOMM)
+        self.assertEqual(len(self.queue.status(status='Running')), NBLOCKS_HICOMM)
         self.assertEqual(len(self.queue.statusInbox(status='Canceled')), 1)
 
-        # now cancel a request
+        # create a new request with one fake file
         self.queue.queueWork(self.spec.specUrl())
-        elements = len(self.queue)
-        work = self.queue.getWork({'T2_XX_SiteA': 1000, 'T2_XX_SiteB': 1000},
-                                  {})
-        self.assertEqual(len(self.queue), 0)
+        self.assertEqual(len(self.queue), 1)
+        work = self.queue.getWork({'T2_XX_SiteA': 1000, 'T2_XX_SiteB': 1000}, {})
         self.assertEqual(len(self.queue.status(status='Running')), len(self.queue.status()))
         ids = [x.id for x in work]
         canceled = self.queue.cancelWork(WorkflowName='testProduction')


### PR DESCRIPTION
Fixes #9658

#### Status
ready

#### Description
When adding MCFakeFile files into `wmbs_file_details` table, consider the common locations of the WQE instead of setting every single PNN as a candidate for that file.

In other words, when fetching a WQE without any input dataset, but with pileup dataset, set the MCFakeFile location to the same location as of the pileup data, such that we ensure that jobs will only be submitted to sites hosting some of the pileup data (be it a top level task or the subsequent ones).

NOTE: we should probably make the same changes to top level tasks **with* input data (or ACDC data). I'm not making those changes right now because I believe we would have negative side effects. E.g., misassignment generating an empty file location; e.g., ACDC collections with much less locations than it should... and anything else that still didn't come to my mind. 

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
