### PR TITLE
Check process source when enabling GUID checks

### DIFF
--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -643,11 +643,21 @@ class SetupCMSSWPset(ScriptInterface):
 
         Enable enforceGUIDInFileName for CMSSW releases that support it.
         """
+        # skip it for CRAB jobs
+        if self.crabPSet:
+            return
+
         # only check this if we are in the first step of a workflow as output files of chained processing
         # steps will not have correct GUID information
         if self.step.data._internal_name != "cmsRun1":
             self.logger.info("Not evaluating enforceGUIDInFileName parameter for step %s",
                              self.step.data._internal_name)
+            return
+
+        # only enable if source is PoolSource or EmbeddedRootSource
+        if self.process.source.type_() not in ["PoolSource", "EmbeddedRootSource"]:
+            self.logger.info("Not evaluating enforceGUIDInFileName parameter for process source %s",
+                             self.process.source.type_())
             return
 
         self.logger.info("Evaluating if release %s supports enforceGUIDInFileName parameter...",

--- a/test/python/WMCore_t/WMRuntime_t/Scripts_t/WMTaskSpace/cmsRun1/PSet.py
+++ b/test/python/WMCore_t/WMRuntime_t/Scripts_t/WMTaskSpace/cmsRun1/PSet.py
@@ -15,6 +15,9 @@ class Container():
     """
     pass
 
+    def type_(self):
+        return "PoolSource"
+
 class Process():
     """
     _Process_
@@ -63,5 +66,6 @@ class Process():
         self.services[service.serviceName] = service
         setattr(self, service.serviceName, service)
         return
+
 
 process = Process()

--- a/test/python/WMCore_t/WMRuntime_t/Scripts_t/override_catalog.xml
+++ b/test/python/WMCore_t/WMRuntime_t/Scripts_t/override_catalog.xml
@@ -1,0 +1,4 @@
+<storage-mapping>
+	<pfn-to-lfn path-match="../my_first_step/my_input_module.root" protocol="direct" result="../my_first_step/my_input_module.root"/>
+	<lfn-to-pfn path-match="../my_first_step/my_input_module.root" protocol="direct" result="../my_first_step/my_input_module.root"/>
+</storage-mapping>

--- a/test/python/WMCore_t/WMRuntime_t/Tools_t/Scram_t.py
+++ b/test/python/WMCore_t/WMRuntime_t/Tools_t/Scram_t.py
@@ -12,7 +12,8 @@ import os
 import tempfile
 from WMQuality.TestInit import TestInit
 from Utils.TemporaryEnvironment import tmpEnv
-from WMCore.WMRuntime.Tools.Scram import Scram, OS_TO_ARCH, ARCH_TO_OS, getSingleScramArch, isCMSSWSupported
+from WMCore.WMRuntime.Tools.Scram import (Scram, OS_TO_ARCH, ARCH_TO_OS, getSingleScramArch,
+                                          isCMSSWSupported, isEnforceGUIDInFileNameSupported)
 
 
 class Scram_t(unittest.TestCase):
@@ -162,6 +163,45 @@ class Scram_t(unittest.TestCase):
         self.assertTrue(isCMSSWSupported('CMSSW_2_2_3', 'CMSSW_1_2_3'))
         self.assertTrue(isCMSSWSupported('CMSSW_1_3_3', 'CMSSW_1_2_3'))
         self.assertTrue(isCMSSWSupported('CMSSW_1_2_4', 'CMSSW_1_2_3'))
+
+    def testisEnforceGUIDInFileNameSupported(self):
+        """
+        Test functionality of the `isEnforceGUIDInFileNameSupported` function
+        """
+        ### invalid input
+        self.assertFalse(isEnforceGUIDInFileNameSupported(None))
+        self.assertFalse(isEnforceGUIDInFileNameSupported(''))
+
+        ### forever supported
+        self.assertTrue(isEnforceGUIDInFileNameSupported('CMSSW_11_0_0'))
+        self.assertTrue(isEnforceGUIDInFileNameSupported('CMSSW_11_0_2'))
+        self.assertTrue(isEnforceGUIDInFileNameSupported('CMSSW_11_1_0_pre1'))
+        self.assertTrue(isEnforceGUIDInFileNameSupported('CMSSW_11_1_0_patch1'))
+        self.assertTrue(isEnforceGUIDInFileNameSupported('CMSSW_11_1_1'))
+
+        ### specific releases
+        self.assertTrue(isEnforceGUIDInFileNameSupported('CMSSW_10_2_20_UL'))
+        self.assertTrue(isEnforceGUIDInFileNameSupported('CMSSW_9_4_16_UL'))
+        self.assertTrue(isEnforceGUIDInFileNameSupported('CMSSW_8_0_34_UL'))
+        self.assertTrue(isEnforceGUIDInFileNameSupported('CMSSW_7_1_45_patch3'))
+
+        ### minor supported releases
+        self.assertTrue(isEnforceGUIDInFileNameSupported('CMSSW_10_6_8'))
+        self.assertTrue(isEnforceGUIDInFileNameSupported('CMSSW_10_6_9'))
+        self.assertTrue(isEnforceGUIDInFileNameSupported('CMSSW_10_6_8_patch1'))
+        self.assertTrue(isEnforceGUIDInFileNameSupported('CMSSW_10_6_9_patch1'))
+        self.assertTrue(isEnforceGUIDInFileNameSupported('CMSSW_10_2_20'))
+        self.assertTrue(isEnforceGUIDInFileNameSupported('CMSSW_9_4_16'))
+        self.assertTrue(isEnforceGUIDInFileNameSupported('CMSSW_9_3_17'))
+        self.assertTrue(isEnforceGUIDInFileNameSupported('CMSSW_8_0_34'))
+
+        ### releases not supported
+        self.assertFalse(isEnforceGUIDInFileNameSupported('CMSSW_10_6_7'))
+        self.assertFalse(isEnforceGUIDInFileNameSupported('CMSSW_10_7_0'))
+        self.assertFalse(isEnforceGUIDInFileNameSupported('CMSSW_10_2_19'))
+        self.assertFalse(isEnforceGUIDInFileNameSupported('CMSSW_10_3_10'))
+        self.assertFalse(isEnforceGUIDInFileNameSupported('CMSSW_5_3_10'))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #9468 
Complement to https://github.com/dmwm/WMCore/pull/9618

#### Status
ready

#### Description
Check the process source before enabling enforceGUIDInFileName. It's only supported for `PoolSource` and `EmbeddedRootSource`.
Also check if the PSet belongs to a CRAB job, if so, then do not set that parameter.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
#9618 

#### External dependencies / deployment changes
No
