### PR TITLE
Properly deal with MSS/Tape container rule creation

### DIFF
--- a/src/python/WMCore/Services/Rucio/Rucio.py
+++ b/src/python/WMCore/Services/Rucio/Rucio.py
@@ -455,6 +455,8 @@ class Rucio(object):
            * comment:   Comment about the rule.
            * meta:      Metadata, as dictionary.
         :return: it returns either an empty list or a list with a string id for the rule created
+
+        NOTE: if there is an AccessDenied rucio exception, it raises a WMRucioException
         """
         kwargs.setdefault('grouping', 'ALL')
         kwargs.setdefault('account', self.rucioParams.get('account'))
@@ -473,6 +475,9 @@ class Rucio(object):
         response = []
         try:
             response = self.cli.add_replication_rule(dids, copies, rseExpression, **kwargs)
+        except AccessDenied as ex:
+            msg = "AccessDenied creating DID replication rule. Error: %s" % str(ex)
+            raise WMRucioException(msg)
         except Exception as ex:
             self.logger.error("Exception creating rule replica for data: %s. Error: %s", names, str(ex))
         return response


### PR DESCRIPTION
Fixes #9638 

#### Status
ready

#### Description
Summary of changes are:
* Convert *_MSS endpoints to *_Tape
* added `activity="Production Output"` to container and block level rules (as per this request: https://github.com/dmwm/WMCore/issues/9654#issuecomment-620793995)
* raise `WMRucioException` exception from the Services/Rucio wrapper if we get a `rucio.AccessDenied` exception in the `createReplicationRule` method
* if container-level rule creation fails with `WMRucioException`, then retry with `ask_approval=True`

It's important to highlight that both `Custodial` and `NonCustodial` subscriptions can go through.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
