### PR TITLE
Added "project" metadata for block and container objects

### DIFF
--- a/deploy/deploy-wmagent.sh
+++ b/deploy/deploy-wmagent.sh
@@ -340,10 +340,12 @@ sed -i "s+Agent.agentNumber = 0+Agent.agentNumber = $AG_NUM+" $MANAGE_DIR/config
 if [[ "$TEAMNAME" == relval ]]; then
   sed -i "s+config.TaskArchiver.archiveDelayHours = 24+config.TaskArchiver.archiveDelayHours = 336+" $MANAGE_DIR/config.py
   sed -i "s+config.PhEDExInjector.phedexGroup = 'DataOps'+config.PhEDExInjector.phedexGroup = 'RelVal'+" $MANAGE_DIR/config.py
+  sed -i "s+config.RucioInjector.metaDIDProject = 'Production'+config.RucioInjector.metaDIDProject = 'RelVal'+" $MANAGE_DIR/config.py
 elif [[ "$TEAMNAME" == *testbed* ]] || [[ "$TEAMNAME" == *dev* ]]; then
   GLOBAL_DBS_URL=https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader
   sed -i "s+DBSInterface.globalDBSUrl = 'https://cmsweb.cern.ch/dbs/prod/global/DBSReader'+DBSInterface.globalDBSUrl = '$GLOBAL_DBS_URL'+" $MANAGE_DIR/config.py
   sed -i "s+DBSInterface.DBSUrl = 'https://cmsweb.cern.ch/dbs/prod/global/DBSReader'+DBSInterface.DBSUrl = '$GLOBAL_DBS_URL'+" $MANAGE_DIR/config.py
+  sed -i "s+config.RucioInjector.metaDIDProject = 'Production'+config.RucioInjector.metaDIDProject = 'Test'+" $MANAGE_DIR/config.py
 fi
 
 if [[ "$HOSTNAME" == *fnal.gov ]]; then

--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -368,6 +368,7 @@ config.RucioInjector.pollIntervalRules = 43200
 config.RucioInjector.cacheExpiration = 2 * 24 * 60 * 60  # two days
 config.RucioInjector.createBlockRules = True
 config.RucioInjector.RSEPostfix = False  # enable it to append _Test to the RSE names
+config.RucioInjector.metaDIDProject = "Production"
 config.RucioInjector.listTiersToInject = []  # ["NANOAOD", "NANOAODSIM"]
 config.RucioInjector.skipRulesForTiers = ["NANOAOD", "NANOAODSIM"]
 config.RucioInjector.rucioAccount = "OVER_WRITE_BY_SECRETS"

--- a/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
+++ b/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
@@ -8,7 +8,7 @@ import os
 
 from rucio.client import Client as testClient
 
-from WMCore.Services.Rucio.Rucio import Rucio
+from WMCore.Services.Rucio.Rucio import Rucio, validateMetaData, RUCIO_VALID_PROJECT
 from WMQuality.Emulators.EmulatedUnitTestCase import EmulatedUnitTestCase
 
 DSET = "/SingleElectron/Run2017F-17Nov2017-v1/MINIAOD"
@@ -234,3 +234,19 @@ class RucioTest(EmulatedUnitTestCase):
         # Properly formatted rule, rule manually created
         res = self.myRucio.getRule("1d6ea1d916d5492e81b1bb30ed4aebc1")
         self.assertTrue(res)
+
+    def testMetaDataValidation(self):
+        """
+        Test the `validateMetaData` validation function
+        """
+        for thisProj in RUCIO_VALID_PROJECT:
+            response = validateMetaData("any_DID_name", dict(project=thisProj), self.myRucio.logger)
+            self.assertTrue(response)
+
+        # test with no "project" meta data at all
+        response = validateMetaData("any_DID_name", dict(), self.myRucio.logger)
+        self.assertTrue(response)
+
+        # now an invalid "project" meta data
+        response = validateMetaData("any_DID_name", dict(project="mistake"), self.myRucio.logger)
+        self.assertFalse(response)


### PR DESCRIPTION
Fixes #9655

#### Status
not-tested

#### Description
This pull request injects deployment changes, where there will be a different RucioInjector parameter configuration for agents dealing with different workflow activities.

So, this PR uses the Rucio supported `project` DID metadata block and container creation, in short:
* `Production`: for central production activities/workflows
* `RelVal`: for Release Validation activities/workflows
* `Tier0`: for Tier0 production activities/workflows
* `Test`: for any test/dev/replay activities/workflows
* `User`: to be used by Analysis

Validation of the `project` value has also been added to the Rucio Services wrapper, such that we can ensure that data created through those APIs will be validated and consistent.

TODO: the Tier0 team will need to make the necessary changes on their side as well.

#### Is it backward compatible (if not, which system it affects?)
Yes, as a component functionality. But not due to a new DID information.

#### Related PRs
none

#### External dependencies / deployment changes
none
