### PR TITLE
Temporary workaround for timeouts fetching elements from GQ

### DIFF
--- a/src/python/WMCore/WorkQueue/WorkQueueBackend.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueBackend.py
@@ -354,6 +354,7 @@ class WorkQueueBackend(object):
         options = {}
         options['include_docs'] = True
         options['descending'] = True
+        options['limit'] = 50000
         options['resources'] = thresholds
         if team:
             options['team'] = team


### PR DESCRIPTION
Fixes #9670

#### Status
tested

#### Description
Limit the number of elements pulled from global workqueue to 50k, such that we avoid the request timeout hitting us in production. Which, by the way, is also affecting the relval agent (even though the relval agent retrieves only a few kB of data...).

UPDATE: by imposing that `limit` to this list request, we actually limit the number of rows that are passed to the list function. That means, even if we pass 1k rows, it could be that none of the rows would match the resources requirement

TODO: still to investigate whether priorities are enforced.
TODO2: I guess we will have to patch the agents in production until the situation is under control

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
