### PR TITLE
Bundle patch for 1.3.3.patch3

### DIFF
--- a/deploy/deploy-wmagent.sh
+++ b/deploy/deploy-wmagent.sh
@@ -340,10 +340,12 @@ sed -i "s+Agent.agentNumber = 0+Agent.agentNumber = $AG_NUM+" $MANAGE_DIR/config
 if [[ "$TEAMNAME" == relval ]]; then
   sed -i "s+config.TaskArchiver.archiveDelayHours = 24+config.TaskArchiver.archiveDelayHours = 336+" $MANAGE_DIR/config.py
   sed -i "s+config.PhEDExInjector.phedexGroup = 'DataOps'+config.PhEDExInjector.phedexGroup = 'RelVal'+" $MANAGE_DIR/config.py
+  sed -i "s+config.RucioInjector.metaDIDProject = 'Production'+config.RucioInjector.metaDIDProject = 'RelVal'+" $MANAGE_DIR/config.py
 elif [[ "$TEAMNAME" == *testbed* ]] || [[ "$TEAMNAME" == *dev* ]]; then
   GLOBAL_DBS_URL=https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader
   sed -i "s+DBSInterface.globalDBSUrl = 'https://cmsweb.cern.ch/dbs/prod/global/DBSReader'+DBSInterface.globalDBSUrl = '$GLOBAL_DBS_URL'+" $MANAGE_DIR/config.py
   sed -i "s+DBSInterface.DBSUrl = 'https://cmsweb.cern.ch/dbs/prod/global/DBSReader'+DBSInterface.DBSUrl = '$GLOBAL_DBS_URL'+" $MANAGE_DIR/config.py
+  sed -i "s+config.RucioInjector.metaDIDProject = 'Production'+config.RucioInjector.metaDIDProject = 'Test'+" $MANAGE_DIR/config.py
 fi
 
 if [[ "$HOSTNAME" == *fnal.gov ]]; then

--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -368,6 +368,7 @@ config.RucioInjector.pollIntervalRules = 43200
 config.RucioInjector.cacheExpiration = 2 * 24 * 60 * 60  # two days
 config.RucioInjector.createBlockRules = True
 config.RucioInjector.RSEPostfix = False  # enable it to append _Test to the RSE names
+config.RucioInjector.metaDIDProject = "Production"
 config.RucioInjector.listTiersToInject = []  # ["NANOAOD", "NANOAODSIM"]
 config.RucioInjector.skipRulesForTiers = ["NANOAOD", "NANOAODSIM"]
 config.RucioInjector.rucioAccount = "OVER_WRITE_BY_SECRETS"

--- a/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
+++ b/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
@@ -242,16 +242,13 @@ class RucioInjectorPoller(BaseWorkerThread):
     # TODO: this will likely go away once the phedex to rucio migration is over
     def _isBlockTierAllowed(self, blockName):
         """
-        Performs a couple of checks on the block datatier, such as:
-          * is the datatier supposed to be injected by this component
-          * is the datatier supposed to get rules created by this component
+        Checks whether this blockname contains a datatier that we want to
+        be handled by this component, thus block-level rule creation as well
         :return: True if the component can proceed with this block, False otherwise
         """
         endBlock = blockName.rsplit('/', 1)[1]
         endTier = endBlock.split('#')[0]
         if endTier not in self.listTiersToInject:
-            return False
-        if endTier in self.skipRulesForTiers:
             return False
         return True
 
@@ -355,6 +352,7 @@ class RucioInjectorPoller(BaseWorkerThread):
                 if not self._isContainerTierAllowed(container, checkRulesList=False):
                     continue
                 for block in migratedBlocks[location][container]:
+                    logging.info("Closing block: %s", block)
                     if self.rucio.closeBlockContainer(block):
                         self.setBlockClosed.execute(block)
                     else:

--- a/src/python/WMCore/Services/Rucio/Rucio.py
+++ b/src/python/WMCore/Services/Rucio/Rucio.py
@@ -455,6 +455,8 @@ class Rucio(object):
            * comment:   Comment about the rule.
            * meta:      Metadata, as dictionary.
         :return: it returns either an empty list or a list with a string id for the rule created
+
+        NOTE: if there is an AccessDenied rucio exception, it raises a WMRucioException
         """
         kwargs.setdefault('grouping', 'ALL')
         kwargs.setdefault('account', self.rucioParams.get('account'))
@@ -473,6 +475,9 @@ class Rucio(object):
         response = []
         try:
             response = self.cli.add_replication_rule(dids, copies, rseExpression, **kwargs)
+        except AccessDenied as ex:
+            msg = "AccessDenied creating DID replication rule. Error: %s" % str(ex)
+            raise WMRucioException(msg)
         except Exception as ex:
             self.logger.error("Exception creating rule replica for data: %s. Error: %s", names, str(ex))
         return response


### PR DESCRIPTION
wmagent branch version of:
 Added "project" metadata for block and container objects #9667 
 Properly deal with MSS/Tape container rule creation #9666 
 Always create block-level rules for blocks inserted by RucioInjector #9672 

When applying this patch to the production agents, we need to manually:
* add this configuration line to the config.py
```
config.RucioInjector.metaDIDProject = 'Production'
```
* or this line for the relval agent:
```
config.RucioInjector.metaDIDProject = 'RelVal'
```

further configuration will be required once we decide to enable RucioInjector in production.