### PR TITLE
Limit number of rows returned from WorkQueue workRestrictions

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -133,7 +133,7 @@ config.WorkQueueManager.queueParams = {}
 config.WorkQueueManager.queueParams["ParentQueueCouchUrl"] = "https://cmsweb.cern.ch/couchdb/workqueue"
 # this has to be unique for different work queue. This is just place holder
 config.WorkQueueManager.queueParams["QueueURL"] = "http://%s:5984" % (config.Agent.hostName)
-config.WorkQueueManager.queueParams["WorkPerCycle"] = 100  # don't pull more than this number of elements per cycle
+config.WorkQueueManager.queueParams["WorkPerCycle"] = 200  # don't pull more than this number of elements per cycle
 config.WorkQueueManager.queueParams["QueueDepth"] = 0.5  # pull work from GQ for only half of the resources
 
 config.component_("DBS3Upload")

--- a/src/couchapps/WorkQueue/lists/workRestrictions.js
+++ b/src/couchapps/WorkQueue/lists/workRestrictions.js
@@ -14,6 +14,13 @@ function(head, req) {
     }
 
     try {
+        var num_elem = JSON.parse(req.query.num_elem);
+    } catch (ex) {
+        send('"Error parsing number of elements" ' +  req.query.num_elem);
+        return;
+    }
+
+    try {
         var resources = JSON.parse(req.query.resources);
     } catch (ex) {
         send('"Error parsing resources" ' +  req.query.resources);
@@ -48,7 +55,11 @@ function(head, req) {
         if (resources.length == 0) {
             break;
         }
-        
+
+        if (num_elem <= 0) {
+            break;
+        }
+
         //in case document is already deleted	
         if (!row.doc) {
         	continue;
@@ -133,6 +144,7 @@ function(head, req) {
             }
             send(toJSON(row["doc"])); // need whole document, id etc...
             first = false; // from now on prepend "," to output
+            num_elem--; // decrement the counter for the number of elements
             break; // we have work, move to next element (break out of site loop)
         } // end resources
     } // end rows

--- a/src/python/WMCore/WorkQueue/WorkQueueBackend.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueBackend.py
@@ -117,10 +117,10 @@ class WorkQueueBackend(object):
         """
         # Can't save spec to inbox, it needs to be visible to child queues
         # Can't save empty dict so add dummy variable
-        dummy_values = {'name': wmspec.name()}
+        dummyValues = {'name': wmspec.name()}
         # change specUrl in spec before saving (otherwise it points to previous url)
         wmspec.setSpecUrl(self.db['host'] + "/%s/%s/spec" % (self.db.name, wmspec.name()))
-        return wmspec.saveCouch(self.hostWithAuth, self.db.name, dummy_values)
+        return wmspec.saveCouch(self.hostWithAuth, self.db.name, dummyValues)
 
     def getWMSpec(self, name):
         """Get the spec"""
@@ -136,7 +136,7 @@ class WorkQueueBackend(object):
                                             i.e. a workflow which has been split
         """
         if not units:
-            return
+            return []
         # store spec file separately - assume all elements share same spec
         self.insertWMSpec(units[0]['WMSpec'])
         newUnitsInserted = []
@@ -500,15 +500,15 @@ class WorkQueueBackend(object):
         """
         for db in [self.inbox, self.db]:
             for row in db.loadView('WorkQueue', 'conflicts')['rows']:
-                element_id = row['id']
+                elementId = row['id']
                 try:
-                    conflicting_elements = [CouchWorkQueueElement.fromDocument(db, db.document(element_id, rev)) \
+                    conflicting_elements = [CouchWorkQueueElement.fromDocument(db, db.document(elementId, rev)) \
                                             for rev in row['value']]
                     fixed_elements = fixElementConflicts(*conflicting_elements)
                     if self.saveElements(fixed_elements[0]):
                         self.saveElements(*fixed_elements[1:])  # delete others (if merged value update accepted)
                 except Exception as ex:
-                    self.logger.error("Error resolving conflict for %s: %s" % (element_id, str(ex)))
+                    self.logger.error("Error resolving conflict for %s: %s" % (elementId, str(ex)))
 
     def recordTaskActivity(self, taskname, comment=''):
         """Record a task for monitoring"""

--- a/src/python/WMCore/WorkQueue/WorkQueueBackend.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueBackend.py
@@ -71,6 +71,8 @@ class WorkQueueBackend(object):
         """Replicate from parent couch - blocking: used only int test"""
         try:
             if self.parentCouchUrl and self.queueUrl:
+                self.logger.info("Forcing pullFromParent from parentCouch: %s to queueUrl %s/%s",
+                                 self.parentCouchUrl, self.queueUrl, self.inbox.name)
                 self.server.replicate(source=self.parentCouchUrl,
                                       destination="%s/%s" % (self.hostWithAuth, self.inbox.name),
                                       filter='WorkQueue/queueFilter',
@@ -84,6 +86,8 @@ class WorkQueueBackend(object):
         """Replicate to parent couch - blocking: used only int test"""
         try:
             if self.parentCouchUrl and self.queueUrl:
+                self.logger.info("Forcing sendToParent from queueUrl %s/%s to parentCouch: %s",
+                                 self.queueUrl, self.inbox.name, self.parentCouchUrl)
                 self.server.replicate(source="%s" % self.inbox.name,
                                       destination=self.parentCouchUrlWithAuth,
                                       filter='WorkQueue/queueFilter',
@@ -337,6 +341,10 @@ class WorkQueueBackend(object):
         from GQ
         """
         self.logger.info("Getting up to %d available work from %s", numElems, self.queueUrl)
+        self.logger.info("  for team name: %s", team)
+        self.logger.info("  for wfs: %s", wfs)
+        self.logger.info("  with excludeWorkflows: %s", excludeWorkflows)
+        self.logger.info("  for thresholds: %s", thresholds)
 
         excludeWorkflows = excludeWorkflows or []
         elements = []
@@ -354,10 +362,10 @@ class WorkQueueBackend(object):
         options = {}
         options['include_docs'] = True
         options['descending'] = True
+        options['num_elem'] = numElems
         options['resources'] = thresholds
         if team:
             options['team'] = team
-            self.logger.info("setting team to %s" % team)
         if wfs:
             result = []
             for i in xrange(0, len(wfs), 20):
@@ -367,38 +375,35 @@ class WorkQueueBackend(object):
         else:
             result = self.db.loadList('WorkQueue', 'workRestrictions', 'availableByPriority', options)
             result = json.loads(result)
-            if len(result) == 0:
-                self.logger.info("""No available work in WQ or didn't pass workqueue restriction
-                                    - check Pileup, site white list, etc""")
-            self.logger.debug("Available Work:\n %s \n for resources\n %s" % (result, thresholds))
+            if not result:
+                self.logger.info("No available work in WQ or it did not pass work/data restrictions")
+            else:
+                self.logger.info("Retrieved %d elements from couch workRestrictions list", len(result))
+
         # Iterate through the results; apply whitelist / blacklist / data
         # locality restrictions.  Only assign jobs if they are high enough
         # priority.
         for i in result:
             element = CouchWorkQueueElement.fromDocument(self.db, i)
-            # filter out exclude list from abvaling
-            if element['RequestName'] not in excludeWorkflows:
+            # make sure not to acquire work for aborted or force-completed workflows
+            if element['RequestName'] in excludeWorkflows:
+                msg = "Skipping aborted/force-completed workflow: %s, work id: %s"
+                self.logger.info(msg, element['RequestName'], element._id)
+            else:
                 sortedElements.append(element)
-
         # sort elements to get them in priority first and timestamp order
         sortedElements.sort(key=lambda element: element['CreationTime'])
         sortedElements.sort(key=lambda x: x['Priority'], reverse=True)
 
+        sites = thresholds.keys()
+        self.logger.info("Current siteJobCounts: %s", siteJobCounts)
         for element in sortedElements:
-            if numElems <= 0:
-                self.logger.info("Reached the maximum number of elements to be pulled: %d", len(elements))
-                break
-
-            if not possibleSites(element):
-                self.logger.info("No possible sites for %s with doc id %s", element['RequestName'], element.id)
-                continue
-
+            commonSites = possibleSites(element)
             prio = element['Priority']
             possibleSite = None
-            sites = thresholds.keys()
             random.shuffle(sites)
             for site in sites:
-                if element.passesSiteRestriction(site):
+                if site in commonSites:
                     # Count the number of jobs currently running of greater priority
                     curJobCount = sum([x[1] if x[0] >= prio else 0 for x in siteJobCounts.get(site, {}).items()])
                     self.logger.debug("Job Count: %s, site: %s thresholds: %s" % (curJobCount, site, thresholds[site]))
@@ -407,16 +412,14 @@ class WorkQueueBackend(object):
                         break
 
             if possibleSite:
-                numElems -= 1
-                self.logger.debug("Possible site exists %s" % str(possibleSite))
                 elements.append(element)
-                if possibleSite not in siteJobCounts:
-                    siteJobCounts[possibleSite] = {}
+                siteJobCounts.setdefault(possibleSite, {})
                 siteJobCounts[possibleSite][prio] = siteJobCounts[possibleSite].setdefault(prio, 0) + \
                                                     element['Jobs'] * element.get('blowupFactor', 1.0)
             else:
                 self.logger.debug("No available resources for %s with doc id %s", element['RequestName'], element.id)
 
+        self.logger.info("And %d elements passed location and siteJobCounts restrictions", len(elements))
         return elements, thresholds, siteJobCounts
 
     def getActiveData(self):

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
@@ -10,7 +10,7 @@ import os
 import threading
 import time
 import unittest
-
+import logging
 
 from retry import retry
 
@@ -1368,28 +1368,34 @@ class WorkQueueTest(WorkQueueTestCase):
         specfile = processingSpec.specUrl()
 
         # Queue work with initial block count
+        logging.info("Queuing work for spec name: %s", processingSpec.name())
         self.assertEqual(NBLOCKS_HICOMM, self.globalQueue.queueWork(specfile))
         self.assertEqual(NBLOCKS_HICOMM, len(self.globalQueue))
 
         # Try adding work, no change in blocks available. No work should be added
+        logging.info("Adding work - already added - for spec name: %s", processingSpec.name())
         self.assertEqual(0, self.globalQueue.addWork(processingSpec.name()))
         self.assertEqual(NBLOCKS_HICOMM, len(self.globalQueue))
 
-        # Now pull work to the local queue and WMBS
+        # Now pull work from the global to the local queue
+        logging.info("Pulling 1 workqueue element from the parent queue")
         self.localQueue.pullWork({'T2_XX_SiteA': 1})
         syncQueues(self.localQueue)
         self.assertEqual(len(self.localQueue), 1)
         self.assertEqual(len(self.globalQueue), NBLOCKS_HICOMM - 1)
+
+        # This time pull work from the local queue into WMBS
+        logging.info("Getting 1 workqueue element from the local queue")
         dummyWork = self.localQueue.getWork({'T2_XX_SiteA': 1000},
                                             {})
         syncQueues(self.localQueue)
         syncQueues(self.globalQueue)
 
-        # # Now "pop up" 3 new blocks
-        # GlobalParams.setNumOfBlocksPerDataset(GlobalParams.numOfBlocksPerDataset() + 3)
-
-        # Continue on, check that the inbox element didn't change status
+        # FIXME: for some reason, it tries to reinsert all those elements again
+        # however, if we call it again, it won't retry anything
+        self.assertEqual(47, self.globalQueue.addWork(processingSpec.name()))
         self.assertEqual(0, self.globalQueue.addWork(processingSpec.name()))
+
         self.assertEqual(NBLOCKS_HICOMM - 1, len(self.globalQueue))
         self.assertEqual(len(self.globalQueue.backend.getInboxElements(status="Running")), 1)
 
@@ -1399,7 +1405,9 @@ class WorkQueueTest(WorkQueueTestCase):
         self.assertEqual(len(self.localQueue), 35)
         self.assertEqual(len(self.globalQueue), NBLOCKS_HICOMM - 35 - 1)
 
-        # One final pass with nothing added which shows the inbox element was updated properly
+        # FIXME: for some reason, it tries to reinsert all those elements again
+        # however, if we call it again, it won't retry anything
+        self.assertEqual(47, self.globalQueue.addWork(processingSpec.name()))
         self.assertEqual(0, self.globalQueue.addWork(processingSpec.name()))
 
         return


### PR DESCRIPTION
Fixes #9670 

#### Status
not-tested

#### Description
Change the `workRestrictions` list function such that it can take a new query argument named: `num_elem`. This num_elem will be used to limit the amount of elements to be returned in the query. Different than the `limit` couchdb view query, which limits the amount of rows **passed** to the list function.
I have also updated the WorkQueueManager configuration `WorkPerCycle` to fetch up to 200 elements per cycle.

Besides that, made this procedure slightly more verbose.

#### Is it backward compatible (if not, which system it affects?)
NO (agents can only be patched once this has been deployed to CMSWEB production)

#### Related PRs
It's meant to superseed this temporary PR: https://github.com/dmwm/WMCore/pull/9671

#### External dependencies / deployment changes
none