### PR TITLE
Print warning in Executor if condor_chirp is not found.

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Executor.py
+++ b/src/python/WMCore/WMSpec/Steps/Executor.py
@@ -11,6 +11,7 @@ import os
 import sys
 import json
 import subprocess
+import logging
 
 from Utils.FileTools import getFullPath
 from Utils.Utilities import zipEncodeStr
@@ -193,5 +194,11 @@ class Executor(object):
         if condor_chirp_bin and os.access(condor_chirp_bin, os.X_OK):
             args = [condor_chirp_bin, 'set_job_attr_delayed', key, json.dumps(value)]
             subprocess.call(args)
+        else:
+            if condor_chirp_bin and not os.access(condor_chirp_bin, os.X_OK):
+                msg = 'condor_chirp was found in: %s, but it was not an executable.' % condor_chirp_bin
+            else:
+                msg = 'condor_chirp was not found in the system.'
+            logging.warning(msg)
 
         return


### PR DESCRIPTION
Fixes #9674

#### Status
Ready

#### Description
Print warning in Executor if condor_chirp is not found. This will be seen in the JobCache of the JobCreator.

#### Is it backward compatible (if not, which system it affects?)
YES