### PR TITLE
Temporary fetch StepChain parentage data from ReqMgr2 instead of WMStats

### DIFF
--- a/src/python/WMCore/Services/RequestDB/RequestDBReader.py
+++ b/src/python/WMCore/Services/RequestDB/RequestDBReader.py
@@ -251,3 +251,20 @@ class RequestDBReader(object):
         data = self._getCouchView("byparentageflag", options)
         datasetParentageInfo = self._formatCouchData(data, returnDict=True)
         return datasetParentageInfo
+
+    def getRequestsByStatusAndType(self, status, reqType, detail=False):
+        """
+        Fetch requests by status and type
+        :param status: either a single status or a list of them
+        :param reqType: either a single request type or a list of them
+        :return: a list of workflows matching the input parameters
+        """
+        if not isinstance(status, (list, set)):
+            status = [status]
+        if not isinstance(reqType, (list, set)):
+            reqType = [reqType]
+        query_keys = [[s, rt] for rt in reqType for s in status]
+
+        options = {"include_docs": detail}
+        data = self._getCouchView("requestsbystatusandtype", options, query_keys)
+        return self._formatCouchData(data, returnDict=True)


### PR DESCRIPTION
Fixes #9685 (wmagent branch only)

#### Status
not-tested

#### Description
Temporary workaround to get DBS3Upload working again.
Instead of fetching the StepChain parentage information from WMStats, get StepChain workflows (sitting in running-open, running-closed and completed) from ReqMgr2.

We are not going to merge it. And might need to backport to 1.3.0_wmagent branch as well.

#### Is it backward compatible (if not, which system it affects?)
no (new interesting method under RequestDBReader)

#### Related PRs
none

#### External dependencies / deployment changes
none
