### PR TITLE
Fix finding condor_chirp for containers 

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Executor.py
+++ b/src/python/WMCore/WMSpec/Steps/Executor.py
@@ -181,15 +181,17 @@ class Executor(object):
             value = zipEncodeStr(value, maxLen=maxLen)
 
         # construct condor_chirp binary location from CONDOR_CONFIG
+        # Note: This works when we do not use containers.
         condor_chirp_bin = None
         condor_config = os.getenv('CONDOR_CONFIG', None)
         if condor_config:
             condor_config_dir = os.path.dirname(condor_config)
             condor_chirp_bin = os.path.join(condor_config_dir, 'main/condor/libexec/condor_chirp')
-            if not os.path.isfile(condor_chirp_bin):
-                # Singularity container might not have CONDOR_CONFIG env.
-                #TODO: It should have fixed from Singularity setting
-                condor_chirp_bin = getFullPath("condor_chirp")
+
+        # If the above fails, look for the executable in the environment
+        # This is the usual case for containers
+        if not condor_chirp_bin or not os.path.isfile(condor_chirp_bin):
+            condor_chirp_bin = getFullPath("condor_chirp")
 
         if condor_chirp_bin and os.access(condor_chirp_bin, os.X_OK):
             args = [condor_chirp_bin, 'set_job_attr_delayed', key, json.dumps(value)]


### PR DESCRIPTION
Fixes #9688

#### Status
 ready

#### Description
Do not only rely on `CONDOR_CONFIG` being present in the environment to find `condor_chirp`.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Goes along with the already merged PR: https://github.com/dmwm/WMCore/pull/9682
