### PR TITLE
MSOutput nonRelVal - two run modes for MSOutput thread

### DIFF
--- a/src/python/Utils/Pipeline.py
+++ b/src/python/Utils/Pipeline.py
@@ -1,7 +1,7 @@
 from functools import reduce
 
 
-class Functor:
+class Functor(object):
     """
     A simple functor class used to construct a function call which later to be
     applied on an (any type) object.
@@ -62,17 +62,23 @@ class Functor:
         return self.func(obj, *self.args, **self.kwargs)
 
 
-class Pipeline:
+class Pipeline(object):
     """
     A simple Functional Pipeline Class: applies a set of functions to an object,
-    where the output of every previous function is an input to the next one
+    where the output of every previous function is an input to the next one.
     """
-    # DONE:
-    #   To implement passing arguments to the functions - it will allow us to
-    #   keep the object creation outside of the pipeline
-    def __init__(self, funcLine=[]):
+    # NOTE:
+    #    Similar and inspiring approaches but yet some different implementations
+    #    are discussed in the following two links [1] & [2]. With a quite good
+    #    explanation in [1], which helped a lot. All in all at the bottom always
+    #    sits the reduce function.
+    #    [1]
+    #    https://softwarejourneyman.com/python-function-pipelines.html
+    #    [2]
+    #    https://gitlab.com/mc706/functional-pipeline
+
+    def __init__(self, funcLine=None):
         """
-        :obj: The object to be passed through the pipeline
         :funcLine: A list of functions or Functors of function + arguments (see
                    the Class definition above) that are to be applied sequentially
                    to the object.
@@ -107,7 +113,7 @@ class Pipeline:
         adder kwargs: {'update': True}
         adder res: 27
         """
-        self.funcLine = funcLine
+        self.funcLine = funcLine or []
 
     def run(self, obj):
         return reduce(lambda obj, functor: functor(obj), self.funcLine, obj)

--- a/src/python/Utils/Pipeline.py
+++ b/src/python/Utils/Pipeline.py
@@ -1,0 +1,113 @@
+from functools import reduce
+
+
+class Functor:
+    """
+    A simple functor class used to construct a function call which later to be
+    applied on an (any type) object.
+    NOTE:
+        It expects a function in the constructor and an (any type) object
+        passed to the run or __call__ methods, which methods once called they
+        construct and return the following function:
+        func(obj, *args, **kwargs)
+    NOTE:
+        All the additional arguments which the function may take must be set in
+        the __init__ method. If any of them are passed during run time an error
+        will be raised.
+
+    :func:
+        The function to which the rest of the constructor arguments are about
+        to be attached and then the newly created function will be returned.
+        - The function needs to take at least one parameter since the object
+        passed to the run/__call__ methods will always be put as a first
+        argument to the function.
+
+    :Example:
+
+    def adder(a, b, *args, **kwargs):
+        if args:
+            print("adder args: %s" % args)
+        if kwargs:
+            print("adder kwargs: %s" % kwargs)
+        res = a + b
+        return res
+
+    >>> x=Functor(adder, 8, 'foo', bar=True)
+    >>> x(2)
+    adder args: foo
+    adder kwargs: {'bar': True}
+    adder res: 10
+    10
+
+    >>> x
+    <Pipeline.Functor instance at 0x7f319bbaeea8>
+
+
+    """
+    def __init__(self, func, *args, **kwargs):
+        """
+        The init method for class Functor
+        """
+        self.func = func
+        self.args = args
+        self.kwargs = kwargs
+
+    def __call__(self, obj):
+        """
+        The call method for class Functor
+        """
+        return self.run(obj)
+
+    def run(self, obj):
+        return self.func(obj, *self.args, **self.kwargs)
+
+
+class Pipeline:
+    """
+    A simple Functional Pipeline Class: applies a set of functions to an object,
+    where the output of every previous function is an input to the next one
+    """
+    # DONE:
+    #   To implement passing arguments to the functions - it will allow us to
+    #   keep the object creation outside of the pipeline
+    def __init__(self, funcLine=[]):
+        """
+        :obj: The object to be passed through the pipeline
+        :funcLine: A list of functions or Functors of function + arguments (see
+                   the Class definition above) that are to be applied sequentially
+                   to the object.
+                   - If any of the elements of 'funcLine' is a function, a direct
+                   function call with the object as an argument is performed.
+                   - If any of the elements of 'funcLine' is a Functor, then the
+                   first argument of the Functor constructor is the function to
+                   be evaluated and the object is passed as a first argument to
+                   the function with all the rest of the arguments passed right
+                   after it eg. the following Functor in the funcLine:
+
+                   Functor(func, 'foo', bar=True)
+
+                   will result in the following function call later when the
+                   pipeline is executed:
+
+                   func(obj, 'foo', bar=True)
+
+        :Example:
+            (using the adder function from above and an object of type int)
+
+        >>> pipe = Pipeline([Functor(adder, 5),
+                             Functor(adder, 6),
+                             Functor(adder, 7, "extraArg"),
+                             Functor(adder, 8, update=True)])
+
+        >>> pipe.run(1)
+        adder res: 6
+        adder res: 12
+        adder args: extraArg
+        adder res: 19
+        adder kwargs: {'update': True}
+        adder res: 27
+        """
+        self.funcLine = funcLine
+
+    def run(self, obj):
+        return reduce(lambda obj, functor: functor(obj), self.funcLine, obj)

--- a/src/python/Utils/Pipeline.py
+++ b/src/python/Utils/Pipeline.py
@@ -77,7 +77,7 @@ class Pipeline(object):
     #    [2]
     #    https://gitlab.com/mc706/functional-pipeline
 
-    def __init__(self, funcLine=None):
+    def __init__(self, funcLine=None, name=None):
         """
         :funcLine: A list of functions or Functors of function + arguments (see
                    the Class definition above) that are to be applied sequentially
@@ -114,6 +114,7 @@ class Pipeline(object):
         adder res: 27
         """
         self.funcLine = funcLine or []
+        self.name = name
 
     def run(self, obj):
         return reduce(lambda obj, functor: functor(obj), self.funcLine, obj)

--- a/src/python/Utils/Pipeline.py
+++ b/src/python/Utils/Pipeline.py
@@ -1,3 +1,15 @@
+"""
+File       : Pipeline.py
+Description: Provides 2 basic classes:
+             - Functor:  A class to create function calls from a function object
+                         and arbitrary number of arguments
+             - Pipeline: A class to provide building blocks for creating functional
+                         pipelines for cumulative execution on an arbitrary object
+"""
+
+# futures
+from __future__ import division, print_function
+
 from functools import reduce
 
 
@@ -115,6 +127,13 @@ class Pipeline(object):
         """
         self.funcLine = funcLine or []
         self.name = name
+
+    def getPiplineName(self):
+        """
+        __gePipelineName__
+        """
+        name = self.name or "Unnamed Pipeline"
+        return name
 
     def run(self, obj):
         return reduce(lambda obj, functor: functor(obj), self.funcLine, obj)

--- a/src/python/Utils/Pipeline.py
+++ b/src/python/Utils/Pipeline.py
@@ -128,9 +128,9 @@ class Pipeline(object):
         self.funcLine = funcLine or []
         self.name = name
 
-    def getPiplineName(self):
+    def getPipelineName(self):
         """
-        __gePipelineName__
+        __getPipelineName__
         """
         name = self.name or "Unnamed Pipeline"
         return name

--- a/src/python/WMCore/Database/MongoDB.py
+++ b/src/python/WMCore/Database/MongoDB.py
@@ -1,0 +1,156 @@
+from pymongo import MongoClient, errors, IndexModel
+
+
+class MongoDB(object):
+    """
+    A simple wrapper class for creating a connection to a MongoDB instance
+    """
+    def __init__(self,
+                 database=None,
+                 server=None,
+                 port=None,
+                 create=False,
+                 collections=[],
+                 testIndexes=False,
+                 logger=None):
+        """
+        :databases:   A list of databases to connect to
+        :create:      A flag to trigger a database creation (if missing) during
+                      object construction, together with collections if present.
+        :collections: A list of tuples describing collections with indexes -
+                      the first element is considered the collection name, all
+                      the rest elements are considered as indexes
+        :testIndexes: A flag to trigger index test and eventually to create them
+                      if missing (TODO)
+        """
+        # DONE:
+        #    Database: msoutput
+        #    To create two different collections for Relval and NonRelval
+        # DONE:
+        #    To read the configuration parameters (server, port) from service config
+        self.server = server # '127.0.0.1'
+        self.port = port # 8230
+        try:
+            self.client = MongoClient(self.server, self.port)
+            self.client.server_info()
+        except Exception as ex:
+            msg = "ERR: could not connect to MongoDB server: %s\n%s" % (self.server, str(ex))
+            msg += "Giving up Now."
+            self.logger.error(msg)
+            raise ex
+        self.create = create
+        self.testIndexes = testIndexes
+        self.logger = logger
+        self.dbName = database
+        self.collections = collections
+
+        self._dbConnect(database)
+
+        if self.create and self.collections:
+            for collection in self.collections:
+                self._collCreate(collection, database)
+
+        if self.testIndexes and self.collections:
+            for collection in self.collections:
+                self._indexTest(collection, database)
+
+    def _indexTest(self, index):
+        pass
+
+    def _collTest(self, coll, db):
+        # self[self.db].list_collection_names()
+        pass
+
+    def _collCreate(self, coll, db):
+        """
+        :coll: A tuple describing one collection with indexes -
+               The first element is considered to be the collection name, and all
+               the rest elements are considered to be indexes.
+               The indexes must beof type IndexModel. See pymongo documentation:
+
+               https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.create_index
+        """
+        # DONE:
+        #     to create indexes on the proper fields
+
+        collName = coll[0]
+        collIndexes = list(coll[1:])
+        try:
+            self.client[db].create_collection(collName)
+        except errors.CollectionInvalid:
+            # this error is thrown in case of an already existing collection
+            pass
+        if collIndexes:
+            # DONE:
+            #    To implement a check for index types - should be either string or type IndexModel
+            #    see: https://api.mongodb.com/python/current/api/pymongo/operations.html#pymongo.operations.IndexModel
+            for index in collIndexes:
+                if not isinstance(index, IndexModel):
+                    msg = "ERR: Bad Index type for collection %s" % collName
+                    raise errors.InvalidName
+            try:
+                self.client[db][collName].create_indexes(collIndexes)
+            except Exception as ex:
+                msg = "ERR: Failed to create indexes on collection: %s\n%s" % (collName, str(ex))
+                self.logger.error(msg)
+                raise ex
+
+    def _dbTest(self, db):
+        # Test connection (from mongoDB documentation):
+        try:
+            # The 'ismaster' command is cheap and does not require auth.
+            self.client.admin.command('ismaster')
+        except errors.ConnectionFailure as ex:
+            msg = "Server not available: %s" % str(ex)
+            self.logger.error(msg)
+            raise ex
+
+        # Test for database existence
+        if db not in self.client.database_names():
+            msg = "ERR: Missing MongoDB databases: %s" % db
+            self.logger.error(msg)
+            raise errors.InvalidName
+
+    def _dbCreate(self, db):
+        # creating an empty collection in order to create the database
+        _initColl = self.client[db].create_collection('_initCollection')
+        _initColl.insert_one({})
+        # NOTE: never delete the _initCollection if you want the database to persist
+        # self.client[db].drop_collection('_initCollection')
+
+    def _dbConnect(self, db):
+        try:
+            setattr(self, db, self.client[db])
+            self._dbTest(db)
+        except errors.ConnectionFailure as ex:
+            msg = "ERR: Could not connect to MongoDB server for database: %s\n%s\n" % (db, str(ex))
+            msg += "Giving up Now."
+            self.logger.error(msg)
+            raise ex
+        except errors.InvalidName as ex:
+            msg = "ERR: Could not connect to a missing MongoDB databases: %s\n%s" % (db, str(ex))
+            self.logger.error(msg)
+            if self.create:
+                msg = "Trying to create: %s" % db
+                self.logger.error(msg)
+                try:
+                    # self._dbCreate(getattr(self, db))
+                    self._dbCreate(db)
+                except Exception as ex:
+                    msg = "ERR: could not create MongoDB databases: %s\n%s\n" % (db, str(ex))
+                    msg += "Giving up Now."
+                    self.logger.error(msg)
+                    raise ex
+                try:
+                    self._dbTest(db)
+                except Exception as ex:
+                    msg = "ERR: Second failure while testing %s\n%s\n" % (db, str(ex))
+                    msg += "Giving up Now."
+                    self.logger.error(msg)
+                    raise(ex)
+                msg = "Database %s successfully created" % db
+                self.logger.error(msg)
+        except Exception as ex:
+            msg = "ERR: General Exception while trying to connect to : %s\n%s" % (db, str(ex))
+            self.logger.error(msg)
+            raise ex

--- a/src/python/WMCore/Database/MongoDB.py
+++ b/src/python/WMCore/Database/MongoDB.py
@@ -1,3 +1,8 @@
+"""
+File       : MongoDB.py
+Description: Provides a wrapper class for MongoDB
+"""
+
 from pymongo import MongoClient, errors, IndexModel
 
 
@@ -49,12 +54,18 @@ class MongoDB(object):
             for collection in self.collections:
                 self._indexTest(collection, database)
 
-    def _indexTest(self, index):
+    def _indexTest(self, index, db):
         pass
 
     def _collTest(self, coll, db):
         # self[db].list_collection_names()
         pass
+
+    def collCreate(self, coll):
+        """
+        A public method for _collCreate
+        """
+        self._collCreate(coll, self.database)
 
     def _collCreate(self, coll, db):
         """
@@ -120,7 +131,16 @@ class MongoDB(object):
         # NOTE: never delete the _initCollection if you want the database to persist
         # self.client[db].drop_collection('_initCollection')
 
+    def dbConnect(self):
+        """
+        A public method for _dbConnect
+        """
+        self._dbConnect(self.database)
+
     def _dbConnect(self, db):
+        """
+        The function to be used for the initial database connection creation and testing
+        """
         try:
             setattr(self, db, self.client[db])
             self._dbTest(db)
@@ -149,7 +169,7 @@ class MongoDB(object):
                     msg = "Second failure while testing %s\n%s\n" % (db, str(ex))
                     msg += "Giving up Now."
                     self.logger.error(msg)
-                    raise(ex)
+                    raise ex
                 msg = "Database %s successfully created" % db
                 self.logger.error(msg)
         except Exception as ex:

--- a/src/python/WMCore/Database/MongoDB.py
+++ b/src/python/WMCore/Database/MongoDB.py
@@ -3,6 +3,9 @@ File       : MongoDB.py
 Description: Provides a wrapper class for MongoDB
 """
 
+# futures
+from __future__ import division, print_function
+
 from pymongo import MongoClient, errors, IndexModel
 
 
@@ -20,6 +23,8 @@ class MongoDB(object):
                  logger=None):
         """
         :databases:   A database Name to connect to
+        :server:      The server url (see https://docs.mongodb.com/manual/reference/connection-string/)
+        :port:        Server port
         :create:      A flag to trigger a database creation (if missing) during
                       object construction, together with collections if present.
         :collections: A list of tuples describing collections with indexes -
@@ -27,6 +32,7 @@ class MongoDB(object):
                       the rest elements are considered as indexes
         :testIndexes: A flag to trigger index test and eventually to create them
                       if missing (TODO)
+        :logger:      Logger
         """
         self.server = server # '127.0.0.1'
         self.port = port # 8230
@@ -52,9 +58,9 @@ class MongoDB(object):
 
         if self.testIndexes and self.collections:
             for collection in self.collections:
-                self._indexTest(collection, database)
+                self._indexTest(collection[0], collection[1])
 
-    def _indexTest(self, index, db):
+    def _indexTest(self, collection, index):
         pass
 
     def _collTest(self, coll, db):

--- a/src/python/WMCore/MicroService/DataStructs/DefaultStructs.py
+++ b/src/python/WMCore/MicroService/DataStructs/DefaultStructs.py
@@ -52,8 +52,10 @@ OUTPUT_REPORT = dict(start_time=0,
                      end_time=0,
                      execution_time=0,
                      error="",
+                     total_num_requests=0,
+                     total_num_campaigns=0,
                      num_datasets_subscribed=0,
-                     ddm_request_id=0)
+                     num_ddm_requests=0)
 
 
 OUTPUT_MONGO_DOC = dict()

--- a/src/python/WMCore/MicroService/DataStructs/DefaultStructs.py
+++ b/src/python/WMCore/MicroService/DataStructs/DefaultStructs.py
@@ -48,14 +48,22 @@ TRANSFER_RECORD = dict(dataset="",
 
 # summary metrics for the MSOutput thread
 # (also available through the `info` REST API)
-OUTPUT_REPORT = dict(start_time=0,
-                     end_time=0,
-                     execution_time=0,
-                     error="",
-                     total_num_requests=0,
-                     total_num_campaigns=0,
-                     num_datasets_subscribed=0,
-                     num_ddm_requests=0)
+OUTPUT_PRODUCER_REPORT = dict(thread_id="",
+                              start_time=0,
+                              end_time=0,
+                              execution_time=0,
+                              error="",
+                              total_num_requests=0,
+                              total_num_campaigns=0,
+                              num_datasets_subscribed=0,
+                              num_ddm_requests=0)
 
-
-OUTPUT_MONGO_DOC = dict()
+OUTPUT_CONSUMER_REPORT = dict(thread_id="",
+                              start_time=0,
+                              end_time=0,
+                              execution_time=0,
+                              error="",
+                              total_num_requests=0,
+                              total_num_campaigns=0,
+                              num_datasets_subscribed=0,
+                              num_ddm_requests=0)

--- a/src/python/WMCore/MicroService/DataStructs/DefaultStructs.py
+++ b/src/python/WMCore/MicroService/DataStructs/DefaultStructs.py
@@ -56,7 +56,7 @@ OUTPUT_PRODUCER_REPORT = dict(thread_id="",
                               total_num_requests=0,
                               total_num_campaigns=0,
                               num_datasets_subscribed=0,
-                              num_ddm_requests=0)
+                              num_data_requests=0)
 
 OUTPUT_CONSUMER_REPORT = dict(thread_id="",
                               start_time=0,
@@ -66,4 +66,4 @@ OUTPUT_CONSUMER_REPORT = dict(thread_id="",
                               total_num_requests=0,
                               total_num_campaigns=0,
                               num_datasets_subscribed=0,
-                              num_ddm_requests=0)
+                              num_data_requests=0)

--- a/src/python/WMCore/MicroService/DataStructs/MSOutputTemplate.py
+++ b/src/python/WMCore/MicroService/DataStructs/MSOutputTemplate.py
@@ -6,10 +6,9 @@ Description: Provides a document Template for MSOutput MicroServices
 # futures
 from __future__ import division, print_function
 
-import time
+from time import time
 
 from copy import deepcopy
-from bson import Timestamp
 
 
 class MSOutputTemplate(dict):
@@ -75,8 +74,8 @@ class MSOutputTemplate(dict):
             ('_id', None, unicode),
             ('RequestName', None, unicode),
             ('Campaign', None, unicode),
-            ('creationTime', None, Timestamp),
-            ('lastUpdate', None, Timestamp),
+            ('creationTime', None, int),
+            ('lastUpdate', None, int),
             ('isRelVal', None, bool),
             ('isTaken', False, bool),
             ('isTakenBy', None, (str, unicode)),
@@ -99,7 +98,7 @@ class MSOutputTemplate(dict):
         # set creation time - if already present in the document it will be
         # overwritten with the value from the document itself during the _checkAttr
         # call and this value here will be ignored
-        myDoc['creationTime'] = Timestamp(int(time.time()), 1)
+        myDoc['creationTime'] = int(time())
 
         # if no document was passed consider only **kwargs
         if doc is not None:
@@ -249,12 +248,12 @@ class MSOutputTemplate(dict):
 
     def setDestMap(self):
         """
-        __setDestMap_
+        __setDestMap__
         """
         pass
 
     def updateTime(self):
         """
-        __updateTeim__
+        __updateTime__
         """
-        self.setKey('lastUpdate', Timestamp(int(time.time()), 1))
+        self.setKey('lastUpdate', int(time()))

--- a/src/python/WMCore/MicroService/DataStructs/MSOutputTemplate.py
+++ b/src/python/WMCore/MicroService/DataStructs/MSOutputTemplate.py
@@ -3,6 +3,9 @@ File       : MSOutputTemplate.py
 Description: Provides a document Template for MSOutput MicroServices
 """
 
+# futures
+from __future__ import division, print_function
+
 import time
 
 from copy import deepcopy
@@ -27,6 +30,7 @@ class MSOutputTemplate(dict):
     "lastUpdate": integer timestamp,
     "isRelVal": (True|False),
     "isTaken": (True|False),
+    "isTakenBy": "ThreadIdentifier",
     "destination": ["list of locations"],
     "OutputDatasets": ["list of datasets"],
     "destinationOutputMap": [{"destination": ["list of locations"],
@@ -70,13 +74,12 @@ class MSOutputTemplate(dict):
         docTemplate = [
             ('_id', None, unicode),
             ('RequestName', None, unicode),
-            ('RequestStatus', None, unicode),
             ('Campaign', None, unicode),
             ('creationTime', None, Timestamp),
             ('lastUpdate', None, Timestamp),
             ('isRelVal', None, bool),
             ('isTaken', False, bool),
-            ('isTakenby', None, (str, unicode)),
+            ('isTakenBy', None, (str, unicode)),
             ('OutputDatasets', None, list),
             ('destination', None, list),
             ('destinationOutputMap', None, dict),
@@ -154,7 +157,7 @@ class MSOutputTemplate(dict):
                         typeok = True
                         if update:
                             # NOTE: Here we may consider deepcopy
-                            myDoc[kw] = kwargs[kw]
+                            myDoc[kw] = deepcopy(kwargs[kw])
             if not found:
                 # NOTE: We can raise an error here and decide if we want to drop
                 #       the whole document or we can jut ignore the current field
@@ -229,11 +232,14 @@ class MSOutputTemplate(dict):
             return True
         return False
 
-    def setWflowType(self):
+    def updateDoc(self, myDoc):
         """
-        __setWflowType__
+        Method to be used for updating the document fields from a dictionary
         """
-        pass
+        if self._checkAttr(self.docTemplate, myDoc, throw=False, update=False, **myDoc):
+            self.update(myDoc)
+            return True
+        return False
 
     def setCampMap(self):
         """
@@ -252,15 +258,3 @@ class MSOutputTemplate(dict):
         __updateTeim__
         """
         self.setKey('lastUpdate', Timestamp(int(time.time()), 1))
-
-    def updateStatus(self):
-        """
-        __updateStatus__
-        """
-        pass
-
-    def strip(self):
-        """
-        __strp__
-        """
-        pass

--- a/src/python/WMCore/MicroService/DataStructs/MSOutputTemplate.py
+++ b/src/python/WMCore/MicroService/DataStructs/MSOutputTemplate.py
@@ -17,6 +17,7 @@ class MSOutputTemplate(dict):
     {
     "RequestName": "ReqName",
     "RequestStatus": "(clompletd|cloed-out|announced),
+    'Campaign': "Campaign",
     "creationTime": integer timestamp,
     "lastUpdate": integer timestamp,
     "isRelVal": (True|False),
@@ -65,16 +66,18 @@ class MSOutputTemplate(dict):
             ('_id', None, unicode),
             ('RequestName', None, unicode),
             ('RequestStatus', None, unicode),
+            ('Campaign', None, unicode),
             ('creationTime', None, Timestamp),
             ('lastUpdate', None, Timestamp),
             ('isRelVal', None, bool),
-            ('isTaken', None, bool),
+            ('isTaken', False, bool),
+            ('isTakenby', None, (str, unicode)),
             ('OutputDatasets', None, list),
             ('destination', None, list),
             ('destinationOutputMap', None, dict),
             ('campaignOutputMap', None, dict),
             ('transferStatus', None, unicode),
-            ('transferIDs', None, unicode),
+            ('transferIDs', None, int),
             ('numberOfCopies', None, int)]
 
         self.docTemplate = docTemplate
@@ -194,12 +197,19 @@ class MSOutputTemplate(dict):
 
         if not all(valid):
             # NOTE: Same as above
-            msg = "ERROR: Missing Mandatory Fields: {} for: {}".format(missing, template)
+            msg = "ERROR: Missing Mandatory Fields: {} for: {}".format(missing, myDoc)
             if throw:
                 raise KeyError(msg)
             else:
                 return False
         return True
+
+    def setKey(self, key, value):
+        myDoc = {key: value}
+        if self._checkAttr(self.docTemplate, myDoc, throw=True, update=False, **myDoc):
+            self.update(myDoc)
+            return True
+        return False
 
     def setRelVal(self, isRelVal):
         myDoc = {'isRelVal': isRelVal}

--- a/src/python/WMCore/MicroService/DataStructs/MSOutputTemplate.py
+++ b/src/python/WMCore/MicroService/DataStructs/MSOutputTemplate.py
@@ -1,7 +1,12 @@
+"""
+File       : MSOutputTemplate.py
+Description: Provides a document Template for MSOutput MicroServices
+"""
+
 import time
 
 from copy import deepcopy
-from bson import Timestamp, ObjectId
+from bson import Timestamp
 
 
 class MSOutputTemplate(dict):
@@ -99,7 +104,7 @@ class MSOutputTemplate(dict):
             # the document passed and fill them into internal document so that they
             # can pass the needed checks later, throw the unneeded/unrecognised
             # key/values from the passed document
-            for key in map(lambda tup: tup[0], docTemplate):
+            for key in [tup[0] for tup in docTemplate]:
                 if key in doc.keys():
                     myDoc[key] = deepcopy(doc[key])
 
@@ -137,14 +142,14 @@ class MSOutputTemplate(dict):
         """
 
         # check if we can fit all the arguments provided through **kwargs
-        for kw, arg in kwargs.items():
+        for kw in kwargs.keys():
             found = False
             typeok = False
             for tup in docTemplate:
                 if kw == tup[0]:
                     found = True
                     # NOTE: Here we can allow more than one type per field if we
-                    #       set them as a list of types eg. [str, unicode]
+                    #       set them as a tuple of types eg. (str, unicode)
                     if isinstance(kwargs[kw], tup[2]) or kwargs[kw] is None:
                         typeok = True
                         if update:
@@ -205,6 +210,9 @@ class MSOutputTemplate(dict):
         return True
 
     def setKey(self, key, value):
+        """
+        A method to be used for setting a key in the document
+        """
         myDoc = {key: value}
         if self._checkAttr(self.docTemplate, myDoc, throw=True, update=False, **myDoc):
             self.update(myDoc)
@@ -212,6 +220,9 @@ class MSOutputTemplate(dict):
         return False
 
     def setRelVal(self, isRelVal):
+        """
+        A method to be used for setting the isRelval key in the document
+        """
         myDoc = {'isRelVal': isRelVal}
         if self._checkAttr(self.docTemplate, myDoc, throw=False, update=False, **myDoc):
             self.update(myDoc)
@@ -219,20 +230,37 @@ class MSOutputTemplate(dict):
         return False
 
     def setWflowType(self):
+        """
+        __setWflowType__
+        """
         pass
 
     def setCampMap(self):
+        """
+        __setCampMap__
+        """
         pass
 
     def setDestMap(self):
+        """
+        __setDestMap_
+        """
         pass
 
     def updateTime(self):
-        pass
+        """
+        __updateTeim__
+        """
+        self.setKey('lastUpdate', Timestamp(int(time.time()), 1))
 
     def updateStatus(self):
+        """
+        __updateStatus__
+        """
         pass
 
     def strip(self):
+        """
+        __strp__
+        """
         pass
-

--- a/src/python/WMCore/MicroService/DataStructs/MSOutputTemplate.py
+++ b/src/python/WMCore/MicroService/DataStructs/MSOutputTemplate.py
@@ -66,7 +66,7 @@ class MSOutputTemplate(dict):
             ('RequestName', None, unicode),
             ('RequestStatus', None, unicode),
             ('creationTime', None, Timestamp),
-            ('lastUpdate', None, float),
+            ('lastUpdate', None, Timestamp),
             ('isRelVal', None, bool),
             ('isTaken', None, bool),
             ('OutputDatasets', None, list),

--- a/src/python/WMCore/MicroService/Unified/MSManager.py
+++ b/src/python/WMCore/MicroService/Unified/MSManager.py
@@ -95,9 +95,10 @@ class MSManager(object):
         # initialize output module
         if 'output' in self.services:
             reqStatus = ['completed', 'closed-out', 'announced']
-            self.msOutputConsumer = MSOutput(self.msConfig, logger=self.logger,
-                                             mode='MSOutputConsumer')
+
             thname = 'MSOutputConsumer'
+            self.msOutputConsumer = MSOutput(self.msConfig, logger=self.logger,
+                                             mode=thname)
             self.outputConsumerThread = start_new_thread(thname, daemon,
                                                          (self.outputConsumer,
                                                           reqStatus,
@@ -106,9 +107,9 @@ class MSManager(object):
             self.logger.debug(
                 "=== Running %s thread %s", thname, self.outputConsumerThread.running())
 
-            self.msOutputProducer = MSOutput(self.msConfig, logger=self.logger,
-                                             mode='MSOutputProducer')
             thname = 'MSOutputProducer'
+            self.msOutputProducer = MSOutput(self.msConfig, logger=self.logger,
+                                             mode=thname)
             self.outputProducerThread = start_new_thread(thname, daemon,
                                                          (self.outputProducer,
                                                           reqStatus,

--- a/src/python/WMCore/MicroService/Unified/MSManager.py
+++ b/src/python/WMCore/MicroService/Unified/MSManager.py
@@ -77,8 +77,7 @@ class MSManager(object):
                                                   'assigned',
                                                   self.msConfig['interval'],
                                                   self.logger))
-            self.logger.debug(
-                "### Running %s thread %s", thname, self.transfThread.running())
+            self.logger.info("### Running %s thread %s", thname, self.transfThread.running())
 
         # initialize monitoring module
         if 'monitor' in self.services:
@@ -89,34 +88,29 @@ class MSManager(object):
                                                  'staging',
                                                  self.msConfig['interval'],
                                                  self.logger))
-            self.logger.debug(
-                "+++ Running %s thread %s", thname, self.monitThread.running())
+            self.logger.info("+++ Running %s thread %s", thname, self.monitThread.running())
 
         # initialize output module
         if 'output' in self.services:
             reqStatus = ['completed', 'closed-out', 'announced']
 
             thname = 'MSOutputConsumer'
-            self.msOutputConsumer = MSOutput(self.msConfig, logger=self.logger,
-                                             mode=thname)
+            self.msOutputConsumer = MSOutput(self.msConfig, mode=thname, logger=self.logger)
             self.outputConsumerThread = start_new_thread(thname, daemon,
                                                          (self.outputConsumer,
                                                           reqStatus,
                                                           self.msConfig['interval'],
                                                           self.logger))
-            self.logger.debug(
-                "=== Running %s thread %s", thname, self.outputConsumerThread.running())
+            self.logger.info("=== Running %s thread %s", thname, self.outputConsumerThread.running())
 
             thname = 'MSOutputProducer'
-            self.msOutputProducer = MSOutput(self.msConfig, logger=self.logger,
-                                             mode=thname)
+            self.msOutputProducer = MSOutput(self.msConfig, mode=thname, logger=self.logger)
             self.outputProducerThread = start_new_thread(thname, daemon,
                                                          (self.outputProducer,
                                                           reqStatus,
                                                           self.msConfig['interval'],
                                                           self.logger))
-            self.logger.debug(
-                "=== Running %s thread %s", thname, self.outputProducerThread.running())
+            self.logger.info("=== Running %s thread %s", thname, self.outputProducerThread.running())
 
     def _parseConfig(self, config):
         """

--- a/src/python/WMCore/MicroService/Unified/MSOutput.py
+++ b/src/python/WMCore/MicroService/Unified/MSOutput.py
@@ -10,6 +10,7 @@ from __future__ import division, print_function
 
 # system modules
 from retry import retry
+from pprint import pformat
 
 # WMCore modules
 from WMCore.MicroService.DataStructs.DefaultStructs import OUTPUT_REPORT,\
@@ -27,13 +28,21 @@ class MSOutput(MSCore):
     in MicroServices.
     """
 
-    def __init__(self, msConfig, logger=None):
+    def __init__(self, msConfig, logger=None, mode=None):
         """
         Runs the basic setup and initialization for the MSOutput module
-        :param microConfig: microservice configuration
+        :microConfig: microservice configuration
+        :mode: MSOutput Run mode:
+            - MSOutput:
+                Reads The workflow and transfer subscriptions from MongoDB and
+                makes transfer subscriptions.
+            - MongoDBUploader:
+                Fetches Workflows in a given status from Reqmgr2 then creates
+                and uploads the documents to MongoDB.
         """
         super(MSOutput, self).__init__(msConfig, logger)
 
+        self.mode = mode
         self.msConfig.setdefault("limitRequestsPerCycle", 500)
         self.msConfig.setdefault("verbose", True)
         self.msConfig.setdefault("interval", 600)
@@ -62,6 +71,17 @@ class MSOutput(MSCore):
         Executes the whole output data placement logic
         :return: summary
         """
+
+        # TODO:
+        # To implement two modes of running the outputModule:
+        # MongoDBUploader - to fill in the MongoDB with workflows
+        # MSOutput - to deal with every each one of them accordingly
+        # The threads to be created from MSmanager - the code base should be
+        # contained all in this file
+        # we need to add additional status to the mongo documment called
+        # msOutpuStatus: (processing|done) or a bool value in order to avoid
+        # race conditions in case we have more than a single consummer running.
+
         # start threads in MSManager which should call this method
         # NOTE:
         #    Here we should make the whole logic - like:
@@ -75,35 +95,58 @@ class MSOutput(MSCore):
         #      object (through the bookkeeping machinery we choose/develop)
         summary = dict(OUTPUT_REPORT)
 
-        # We should decide here what variable name to use request vs. workflow
-        try:
-            requestRecords = self.getRequestRecords(reqStatus)
-            self.updateReportDict(summary, "total_num_requests", len(requestRecords))
-            msg = "  retrieved %s requests. " % len(requestRecords)
-            msg += "Service set to process up to %s requests per cycle." % self.msConfig["limitRequestsPerCycle"]
-            self.logger.info(msg)
-        except Exception as err:  # general error
-            msg = "Unknown exception while fetching requests from ReqMgr2. Error: %s", str(err)
-            self.logger.exception(msg)
-            self.updateReportDict(summary, "error", msg)
+        if self.mode == 'MongoDBUploader':
+            self.logger.info("MSOutput is running in mode: %s" % self.mode)
+            try:
+                total_num_requests = 0
+                for status in reqStatus:
+                    requestRecords = self.getRequestRecords(status)
+                    total_num_requests += len(requestRecords)
+                    self.updateReportDict(summary, "total_num_requests", total_num_requests)
+                    msg = "  retrieved {} requests in status {}.".format(
+                        len(requestRecords), status)
+                    msg += "Service set to process up to {} requests per cycle.".format(
+                        self.msConfig["limitRequestsPerCycle"])
+                    self.logger.info(msg)
+                    self.logger.debug("requestRecords: {}".format(pformat(requestRecords)))
 
-        try:
-            self.updateCaches()
-        except RuntimeWarning as ex:
-            msg = "All retries exhausted! Last error was: '%s'" % str(ex)
-            msg += "\nRetrying to update caches again in the next cycle."
-            self.logger.error(msg)
-            self.updateReportDict(summary, "error", msg)
-            return summary
-        except Exception as ex:
-            msg = "Unknown exception updating caches. Error: %s" % str(ex)
-            self.logger.exception(msg)
-            self.updateReportDict(summary, "error", msg)
+            except Exception as err:  # general error
+                msg = "Unknown exception while fetching requests from ReqMgr2. Error: %s", str(err)
+                self.logger.exception(msg)
+                self.updateReportDict(summary, "error", msg)
+
+            try:
+                self.updateCaches()
+            except RuntimeWarning as ex:
+                msg = "All retries exhausted! Last error was: '%s'" % str(ex)
+                msg += "\nRetrying to update caches again in the next cycle."
+                self.logger.error(msg)
+                self.updateReportDict(summary, "error", msg)
+                return summary
+            except Exception as ex:
+                msg = "Unknown exception updating caches. Error: %s" % str(ex)
+                self.logger.exception(msg)
+                self.updateReportDict(summary, "error", msg)
+                return summary
+
             return summary
 
-        # this one is put here just for example.
-        self.updateReportDict(summary, "ddm_request_id", 42)
-        return summary
+        elif self.mode == 'MSOutput':
+            self.logger.info("MSOutput is running in mode: %s" % self.mode)
+
+            # this one is put here just for example.
+            self.updateReportDict(summary, "ddm_request_id", 42)
+
+            # here to call all the funciotns from bellow and at the end to call
+            # makeSubscriptions with the proper subscr parameters
+            # those could be determined or kept in the mongoDB
+            return summary
+
+        else:
+            msg = "MSOutput is running in unsupported mode: %s\n" % self.mode
+            msg += "Skipping the current run!"
+            self.logger.warning(msg)
+            return summary
 
     def makeSubscriptions(self, workflows=[]):
         """
@@ -151,20 +194,64 @@ class MSOutput(MSCore):
 
         # NOTE:
         #    If we are about to use an additional database for book keeping like
-        #    MongoDb, we can fetch up to 'limitRequestsPerCycle' and keep track
+        #    MongoDB, we can fetch up to 'limitRequestsPerCycle' and keep track
         #    their status.
 
         # The following is taken from MSMonitor, just for an example.
         # get requests from ReqMgr2 data-service for given status
         # here with detail=False we get back list of records
-        requests = self.reqmgr2.getRequestByStatus([reqStatus], detail=False)
+        requests = self.reqmgr2.getRequestByStatus([reqStatus], detail=True)
         self.logger.info('  retrieved %s requests in status: %s', len(requests), reqStatus)
 
         return requests
+
+    def mongoUploader(self):
+        pass
+
+    def mongoReader(self):
+        pass
+
+    def workflowCollector(self):
+        # query Reqmgr /cache - push to mongo
+        pass
+
+    def workflowFinder(self):
+        # searches and returns a workflow or a an aggregation of or flows to work on
+        pass
+
+    def _updateMongo(self):
+        pass
+
+    def _insertMongo(self):
+        # Measure time and log queries
+        pass
 
     def _pushToMongo(self, reqStatus):
         """
         An auxiliary function to push documents with workflow/request
         representation into mongoDB
+
+        reqStatus: Is not the right parameter for that function
+        pass
+
+        {
+        "workflowName": "blah",
+        "transferStatus": "blah", # either "pending" or "done",
+        "creationTime": integer timestamp,
+        "lastUpdate": integer timestamp,
+        "outputDatasets": ["list of datasets"],
+        "transferIDs": ["list of transfer IDs"],
+        "destination": ["list of locations"],
+        "destinationOutputMap": [{"destination": ["list of locations"],
+                                  "datasets": ["list of datasets"]},
+                                 {"destination": ["list of locations"],
+                                  "datasets": ["list of datasets"]}],
+        "campaignOutputMap": [{"campaignName": "blah",
+                               "datasets": ["list of datasets"]},
+                              {"campaignName": "blah",
+                               "datasets": ["list of datasets"]}],
+        "numberOfCopies": integer
+        }
         """
+
         pass

--- a/src/python/WMCore/MicroService/Unified/MSOutput.py
+++ b/src/python/WMCore/MicroService/Unified/MSOutput.py
@@ -355,12 +355,12 @@ class MSOutput(MSCore):
             self.logger.error(msg)
         return msOutDoc
 
-    def docUpdater(self, msOutDocs):
+    def docUpdater(self, msOutDoc):
         """
         A function intended to fetch and fill into the document all the needed
         additional information like campaignOutputMap etc.
         """
-        pass
+        return msOutDoc
 
     def docUploader(self, msOutDoc, dbColl, stride=None):
         """

--- a/src/python/WMCore/MicroService/Unified/MSOutputStreamer.py
+++ b/src/python/WMCore/MicroService/Unified/MSOutputStreamer.py
@@ -9,18 +9,18 @@ placement service in WMCore MicroServices.
 from __future__ import division, print_function
 
 import json
-from itertools import islice
-from collections import deque
+# from itertools import islice
+# from collections import deque
 
 
-class MSOutputStreamer():
+class MSOutputStreamer(object):
     """
     MSOutputStreamer class
     """
     # NOTE: This module here is just a placeholder for future development
     #       It is placed here so we can make the basic construction of the MSOutput module
 
-    def __init__(self, requestRecords=None, bufferFile=None, stride=1, logger=None, *args, **kwargs):
+    def __init__(self, requestRecords=None, bufferFile=None, stride=1, logger=None):
         """
         Creates a basic streamer object.
         For the purpose of testing this two modes of streaming are defined:

--- a/src/python/WMCore/MicroService/Unified/MSOutputStreamer.py
+++ b/src/python/WMCore/MicroService/Unified/MSOutputStreamer.py
@@ -1,0 +1,68 @@
+"""
+File       : MSOutputStreamer.py
+
+Description: MSOutputStreamer.py class is a simple wrapper for the Output data
+placement service in WMCore MicroServices.
+"""
+
+# futures
+from __future__ import division, print_function
+
+import json
+from itertools import islice
+from collections import deque
+
+
+class MSOutputStreamer():
+    """
+    MSOutputStreamer class
+    """
+    # NOTE: This module here is just a placeholder for future development
+    #       It is placed here so we can make the basic construction of the MSOutput module
+
+    def __init__(self, requestRecords=None, bufferFile=None, stride=1, logger=None, *args, **kwargs):
+        """
+        Creates a basic streamer object.
+        For the purpose of testing this two modes of streaming are defined:
+           - From a dictionary buffer
+           - From a file buffer
+        :requestRecords: - a dictionary with request records
+        :bufferFile:     - a buffer file containing the same information as :requestRecords:
+        :stride:         - the stride at which to stream - N records at a time
+        """
+
+        self.requestRecords = requestRecords
+        self.bufferFile = bufferFile
+        self.logger = logger
+        self.stride = stride
+
+    def __call__(self, *args, **kwargs):
+        """
+        The call method from the Streamer class
+        """
+        return self.streamer()
+
+    def streamer(self):
+        """
+        The default streamer function
+        NOTE:
+            If provided bufferFile takes precedence
+        TODO:
+            For implementing the streaming for stride != 1 we should use:
+            itertools.islice(iterable, start, stop[, step]) + collections.deque() 
+        """
+        try:
+            with open(self.bufferFile) as fp:
+                result = json.load(fp)
+            requests = result['result'][0]
+        except Exception as ex:
+            msg = "Could not open bufferFile: %s. Exception %s" % (self.bufferFile, str(ex))
+            msg += "Falling back to dictionary buffer."
+            self.logger.info(msg)
+            requests = self.requestRecords
+
+        if requests is None:
+            requests = {}
+
+        while requests:
+            yield requests.popitem()

--- a/src/python/WMCore/MicroService/Unified/MSOutputTemplate.py
+++ b/src/python/WMCore/MicroService/Unified/MSOutputTemplate.py
@@ -101,14 +101,14 @@ class MSOutputTemplate(dict):
                     myDoc[key] = deepcopy(doc[key])
 
         # if any object attribute is passed as a **kwargs parameter then
-        # overwrite those from the doc
+        # overwrite the equivalent parameter which was coming with the doc
         self._checkAttr(docTemplate, myDoc, update=True, throw=True, **kwargs)
 
         # enforce a full check on the final document
         self._checkAttr(docTemplate, myDoc, update=False, throw=True, **myDoc)
 
         # final validation:
-        if self._checkValid(myDoc):
+        if self._checkValid(myDoc, throw=True):
             self.update(myDoc)
 
     def checkAttr(self):
@@ -171,7 +171,7 @@ class MSOutputTemplate(dict):
                     return False
         return True
 
-    def _checkValid(self, myDoc):
+    def _checkValid(self, myDoc, throw=False):
         """
         An internal method to be used in order to check for some mandatory fields
         before announcing the created document for valid
@@ -195,7 +195,10 @@ class MSOutputTemplate(dict):
         if not all(valid):
             # NOTE: Same as above
             msg = "ERROR: Missing Mandatory Fields: {} for: {}".format(missing, template)
-            raise KeyError(msg)
+            if throw:
+                raise KeyError(msg)
+            else:
+                return False
         return True
 
     def setRelVal(self, isRelVal):

--- a/src/python/WMCore/MicroService/Unified/MSOutputTemplate.py
+++ b/src/python/WMCore/MicroService/Unified/MSOutputTemplate.py
@@ -1,0 +1,225 @@
+import time
+
+from copy import deepcopy
+from bson import Timestamp, ObjectId
+
+
+class MSOutputTemplate(dict):
+    """
+    A simple template to represent the objects stored in Mongodb for MSOutput
+    Its purpose should be to serve as a bidirectional representation of the
+    objects stored in Mongodb. The instances of this class should be used as a
+    buffer for both inbound (reading from the database) and outbound (writing to
+    database) documents. And it must have all the methods needed to set or update
+    various fields in the object. So that we assure the uniformity of all documents.
+
+    Template format:
+    {
+    "RequestName": "ReqName",
+    "RequestStatus": "(clompletd|cloed-out|announced),
+    "creationTime": integer timestamp,
+    "lastUpdate": integer timestamp,
+    "isRelVal": (True|False),
+    "isTaken": (True|False),
+    "destination": ["list of locations"],
+    "OutputDatasets": ["list of datasets"],
+    "destinationOutputMap": [{"destination": ["list of locations"],
+                              "datasets": ["list of datasets"]},
+                             {"destination": ["list of locations"],
+                              "datasets": ["list of datasets"]}],
+    "campaignOutputMap": [{"campaignName": "blah",
+                           "datasets": ["list of datasets"]},
+                          {"campaignName": "blah",
+                           "datasets": ["list of datasets"]}],
+    "transferStatus": "blah", # either "pending" or "done",
+    "transferIDs": ["list of transfer IDs"],
+    "numberOfCopies": integer
+    }
+    """
+    # TODO:
+    #    To add an identifier parameter to __init__
+    #    to distinguish inbound from outbound documents.
+
+    # DONE:
+    #    to figure out how to pass params as dict not only kwargs so I can use
+    #    the same logic for both inbound and outbound documents
+
+    # TODO:
+    #    to implement document mutex in a model similar to the one described here:
+    #    https://stackoverflow.com/questions/32728670/mutex-with-mongodb
+    #    ```
+    #    db.collection.update({done: false, taken: false},{$set: {taken: true, takenBy: myIp}});
+    #    ```
+
+    # TODO:
+    #    as soon as any change in the instantiated object happens ( any call of
+    #    a set method) the same change must be updated in Mongodb too -
+    #    this may happen from outside or from the object itself. The former method
+    #    keeps the document independent from the underlying Database technology
+
+    def __init__(self, doc=None, **kwargs):
+        super(MSOutputTemplate, self).__init__(**kwargs)
+        # super(MSOutputTemplate, self).__init__()
+
+        docTemplate = [
+            ('_id', None, unicode),
+            ('RequestName', None, unicode),
+            ('RequestStatus', None, unicode),
+            ('creationTime', None, Timestamp),
+            ('lastUpdate', None, float),
+            ('isRelVal', None, bool),
+            ('isTaken', None, bool),
+            ('OutputDatasets', None, list),
+            ('destination', None, list),
+            ('destinationOutputMap', None, dict),
+            ('campaignOutputMap', None, dict),
+            ('transferStatus', None, unicode),
+            ('transferIDs', None, unicode),
+            ('numberOfCopies', None, int)]
+
+        self.docTemplate = docTemplate
+        self.required = ['_id', 'RequestName', 'creationTime']
+        self.allowEmpty = ['OutputDatasets']
+
+        myDoc = dict()
+        for tup in docTemplate:
+            myDoc.update({tup[0]: tup[1]})
+
+        # set creation time - if already present in the document it will be
+        # overwritten with the value from the document itself during the _checkAttr
+        # call and this value here will be ignored
+        myDoc['creationTime'] = Timestamp(int(time.time()), 1)
+
+        # if no document was passed consider only **kwargs
+        if doc is not None:
+            # Search the keys from the document template for their equivalent into
+            # the document passed and fill them into internal document so that they
+            # can pass the needed checks later, throw the unneeded/unrecognised
+            # key/values from the passed document
+            for key in map(lambda tup: tup[0], docTemplate):
+                if key in doc.keys():
+                    myDoc[key] = deepcopy(doc[key])
+
+        # if any object attribute is passed as a **kwargs parameter then
+        # overwrite those from the doc
+        self._checkAttr(docTemplate, myDoc, update=True, throw=True, **kwargs)
+
+        # enforce a full check on the final document
+        self._checkAttr(docTemplate, myDoc, update=False, throw=True, **myDoc)
+
+        # final validation:
+        if self._checkValid(myDoc):
+            self.update(myDoc)
+
+    def checkAttr(self):
+        """
+        A function to perform a self consistency check
+        """
+        return self._checkAttr(self.docTemplate, self, update=False, throw=False, **self)
+
+    def _checkAttr(self, docTemplate, myDoc, update=False, throw=False, **kwargs):
+        """
+        Basically checks everything given in **kwargs against the docTemplate and
+        if it passes the check then it is absorbed in myDoc or just the
+        result from the check is returned depending on the flags given
+        :docTemplate: The document Templaint against which the check is performed
+        :myDoc:       The document where the valid keys to be copied
+        :**kwarg:     The source set of kwargs whose values to be checked
+        :update:      Update flag:
+                      - If True the keys from **kwargs will be copied to myDoc
+                      - If False only the consistency checks will be performed
+        :throw:       Error handling flag:
+                      - If True upon a failed check an Error will be thrown
+                      - If False only bool value from the checks will be returned
+        """
+
+        # check if we can fit all the arguments provided through **kwargs
+        for kw, arg in kwargs.items():
+            found = False
+            typeok = False
+            for tup in docTemplate:
+                if kw == tup[0]:
+                    found = True
+                    # NOTE: Here we can allow more than one type per field if we
+                    #       set them as a list of types eg. [str, unicode]
+                    if isinstance(kwargs[kw], tup[2]) or kwargs[kw] is None:
+                        typeok = True
+                        if update:
+                            # NOTE: Here we may consider deepcopy
+                            myDoc[kw] = kwargs[kw]
+            if not found:
+                # NOTE: We can raise an error here and decide if we want to drop
+                #       the whole document or we can jut ignore the current field
+                # NOTE: We should keep in mind that raising an error from the object
+                #       Creates a reference which will stay outside the normal
+                #       scope of the object (until not caught) which may prevent
+                #       GC cleaning the object
+                msg = "ERROR: Unrecognized parameter: {}: {}".format(kw, kwargs[kw])
+                if throw:
+                    raise KeyError(msg)
+                else:
+                    return False
+            if not typeok:
+                # NOTE: Same as above
+                msg = "ERROR: Wrong type: {} for parameter: {}: {}".format(
+                    type(kwargs[kw]),
+                    kw,
+                    kwargs[kw])
+                if throw:
+                    raise TypeError(msg)
+                else:
+                    return False
+        return True
+
+    def _checkValid(self, myDoc):
+        """
+        An internal method to be used in order to check for some mandatory fields
+        before announcing the created document for valid
+        """
+        valid = []
+        missing = []
+        for mandField in self.required:
+            if mandField in myDoc.keys() and myDoc[mandField]:
+                valid.append(True)
+            else:
+                valid.append(False)
+                missing.append(mandField)
+
+        for mandField in self.allowEmpty:
+            if mandField in myDoc.keys():
+                valid.append(True)
+            else:
+                valid.append(False)
+                missing.append(mandField)
+
+        if not all(valid):
+            # NOTE: Same as above
+            msg = "ERROR: Missing Mandatory Fields: {} for: {}".format(missing, template)
+            raise KeyError(msg)
+        return True
+
+    def setRelVal(self, isRelVal):
+        myDoc = {'isRelVal': isRelVal}
+        if self._checkAttr(self.docTemplate, myDoc, throw=False, update=False, **myDoc):
+            self.update(myDoc)
+            return True
+        return False
+
+    def setWflowType(self):
+        pass
+
+    def setCampMap(self):
+        pass
+
+    def setDestMap(self):
+        pass
+
+    def updateTime(self):
+        pass
+
+    def updateStatus(self):
+        pass
+
+    def strip(self):
+        pass
+

--- a/src/python/WMCore/Services/DDM/DDM.py
+++ b/src/python/WMCore/Services/DDM/DDM.py
@@ -70,7 +70,12 @@ class DDMReqTemplate(dict):
             for tup in tempTuple:
                 if kw == tup[0]:
                     found = True
-                    if isinstance(kwargs[kw], tup[2]):
+                    # pass the type check for None values but do not substitute the
+                    # default value with None - use the default provided from the template
+                    if kwargs[kw] is None:
+                        typeok = True
+                    # Perform a type check and if passed absorb the value from kwargs
+                    elif isinstance(kwargs[kw], tup[2]):
                         typeok = True
                         template[kw] = kwargs[kw]
             if not found:


### PR DESCRIPTION
Fixes #9609 

#### Status
Ready

#### Description
Changes for the `MSOutput` Module needed for `nonRelVal` Workflows. For more details about the requirements to the module see the Description in the Issue. For the Current PR  read bellow.

This PR should provide the following functionality:
   - Fetch all Request Records in status `completed`, `announce`, `closed-out` from ReqMgr 
   - Create Data transfer subscriptions to the relevant Data Management System (DDM, Phedex, Rucio)
   - Implement local book keeping for transfers subscribed

It should work in two modes Producer an Consumer:
   - The Producer is a single thread fetching data from Reqmgr API and uploading ti to MongoDB
   - The Consumers are N threads to fetch records from MongoDB and take the relevant actions about making the the needed output data placement transfers, taking into account  the workflow type (`RelVal` | `NonRelval`) and eventual campaign/workflow  output data mapping.   

In order to reduce Memory footprint and increase scalability, the `Producer` is split in two basic components:
   - A Functional Pipeline to apply all the changes and transformations to the documents one step at a time and upload them to MongoDB.
   - A Document Streamer (not yet fully implemented, may come with another PR, though) to feed the pipeline either a single document at a time or in strides of N documents at a time (in order to reduce communication with database in the future).

*NOTE:* A similar approach is intended for the `Consumer` too.

*NOTE*: The current PR is related to `NonRelVal` workflows only,  as well as to all the auxiliary code changes and modules needed to implement the service architecture explained above.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs

#### External dependencies / deployment changes
NO