### PR TITLE
Load wmstats couch views with stale=update_after in WMStats Service wrappers

### DIFF
--- a/src/python/WMCore/Services/WMStats/WMStatsReader.py
+++ b/src/python/WMCore/Services/WMStats/WMStatsReader.py
@@ -318,7 +318,7 @@ class WMStatsReader(object):
 
         options = {"group_level": 1, "reduce": True}
 
-        results = self.couchDB.loadView(self.couchapp, "allWorkflows", options=options)['rows']
+        results = self._getCouchView("allWorkflows", options)['rows']
         requestNames = [x['key'] for x in results]
 
         workflowDict = self.reqDB.getStatusAndTypeByRequest(requestNames)
@@ -345,7 +345,7 @@ class WMStatsReader(object):
 
         options = {'reduce': True, 'group_level': 5, 'startkey': [requestName],
                    'endkey': [requestName, {}]}
-        results = self.couchDB.loadView(self.couchapp, "jobsByStatusWorkflow", options=options)
+        results = self._getCouchView("jobsByStatusWorkflow", options)
         jobDetails = {}
         for row in results['rows']:
             # row["key"] = ['workflow', 'task', 'jobstatus', 'exitCode', 'site']
@@ -367,7 +367,7 @@ class WMStatsReader(object):
         options = {'include_docs': True, 'reduce': False,
                    'startkey': startKey, 'endkey': endKey,
                    'limit': limit}
-        result = self.couchDB.loadView(self.couchapp, "jobsByStatusWorkflow", options=options)
+        result = self._getCouchView("jobsByStatusWorkflow", options)
         jobInfoDoc = {}
         for row in result['rows']:
             keys = row['key']
@@ -391,7 +391,7 @@ class WMStatsReader(object):
 
     def getAllAgentRequestRevByID(self, agentURL):
         options = {"reduce": False}
-        results = self.couchDB.loadView(self.couchapp, "byAgentURL", options=options, keys=[agentURL])
+        results = self._getCouchView("byAgentURL", options, keys=[agentURL])
         idRevMap = {}
         for row in results['rows']:
             idRevMap[row['id']] = row['value']['rev']

--- a/src/python/WMCore/Services/WMStats/WMStatsWriter.py
+++ b/src/python/WMCore/Services/WMStats/WMStatsWriter.py
@@ -188,7 +188,7 @@ class WMStatsWriter(WMStatsReader):
         threshold = int(time.time()) - sec
         options = {"startkey": threshold, "descending": True,
                    "stale": "update_after"}
-        result = self.couchDB.loadView(self.couchapp, "time", options)
+        result = self._getCouchView("time", options)
 
         for row in result['rows']:
             doc = {}
@@ -261,9 +261,8 @@ class WMStatsWriter(WMStatsReader):
         """
         delete all wmstats docs for a given requestName
         """
-        view = "allWorkflows"
-        options = {"key": requestName, "reduce": False}
-        docs = self.couchDB.loadView(self.couchapp, view, options=options)['rows']
+        options = {"reduce": False, "key": requestName}
+        docs = self._getCouchView("allWorkflows", options)['rows']
 
         for j in docs:
             doc = {}


### PR DESCRIPTION
Fixes #9680 

#### Status
not-tested

#### Description
Instead of loading wmstats views in different ways. Always go through via `_getCouchView()`, which by default would add `stale=update_after` view option (unless provided a different value).

This `update_after` means: return whatever data that is already indexed in the view at the moment (thus, it allows for a quick response). Once CouchDB serves the request, a view indexing is triggered (in case there are new documents), i.e., the view data is updated.

Documentation for 1.6.1: https://docs.couchdb.org/en/1.6.1/api/ddoc/views.html

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
This is another fix: https://github.com/dmwm/WMCore/pull/9684

#### External dependencies / deployment changes
none
