### PR TITLE
Use PSN as PNN for opportunistic diskless resources

### DIFF
--- a/src/python/WMCore/Services/CRIC/CRIC.py
+++ b/src/python/WMCore/Services/CRIC/CRIC.py
@@ -168,11 +168,12 @@ class CRIC(Service):
                 self["logger"].debug("No PSNs for PNN: %s" % pnn)
         return list(psns)
 
-    def PSNstoPNNs(self, psns):
+    def PSNstoPNNs(self, psns, allowPNNLess=False):
         """
         Given a list of PSNs, return all their PNNs
 
         :param psns: a string or a list of PSNs
+        :param allowPNNLess: flag to return the PSN as a PNN if no match
         :return: a list with unique PNNs matching those PSNs
         """
         mapping = self._CRICSiteQuery(callname='data-processing')
@@ -188,6 +189,9 @@ class CRIC(Service):
                     pnnSet.add(item['phedex_name'])
             if pnnSet:
                 pnns.update(pnnSet)
+            elif allowPNNLess:
+                pnns.add(psn)
+                self["logger"].debug("PSN %s has no PNNs. PNNLess flag enabled though.", psn)
             else:
                 self["logger"].debug("No PNNs for PSN: %s" % psn)
         return list(pnns)

--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -431,7 +431,7 @@ class WorkQueue(WorkQueueBase):
 
         # Keep in mind that WQE contains sites, wmbs location contains pnns
         commonSites = possibleSites(match)
-        commonLocation = self.cric.PSNstoPNNs(commonSites)
+        commonLocation = self.cric.PSNstoPNNs(commonSites, allowPNNLess=True)
         msg = "Running WMBS preparation for %s with ParentQueueId %s,\n  with common location %s"
         self.logger.info(msg, match['RequestName'], match['ParentQueueId'], commonLocation)
 

--- a/src/python/WMQuality/Emulators/CRICClient/MockCRICApi.py
+++ b/src/python/WMQuality/Emulators/CRICClient/MockCRICApi.py
@@ -86,7 +86,7 @@ class MockCRICApi(object):
                 psns.update(psnSet)
         return list(psns)
 
-    def PSNstoPNNs(self, psns):
+    def PSNstoPNNs(self, psns, allowPNNLess=False):
         callname = 'data-processing'
         mapping = self.genericLookup(callname)
         if isinstance(psns, basestring):
@@ -100,6 +100,8 @@ class MockCRICApi(object):
                     pnnSet.add(item['phedex_name'])
             if pnnSet:
                 pnns.update(pnnSet)
+            elif allowPNNLess:
+                pnns.add(psn)
         return list(pnns)
 
     def PSNtoPNNMap(self, psnPattern=''):


### PR DESCRIPTION
Fixes #9676

#### Status
ready

#### Description
Given that input data must be associated to - at least - one storage/disk/pnn/rse name (so many definitions for it!) within the WMBS workflow preparation. 
I decided to add this **backwards compatible** flag to support diskless resources to be accepted from the SiteWhitelist, such that they can show up in the DESIRED_Sites job classad.

NOTE: it still needs further thought though. This solution isn't the best, but at the same time we are trying to find a solution for the past 3 years...

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
