### PR TITLE
Hotfixes for reqmon 1.3.4.cmsweb1

### DIFF
--- a/src/python/WMCore/ReqMgr/DataStructs/RequestStatus.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/RequestStatus.py
@@ -83,6 +83,25 @@ ACTIVE_STATUS = ["new",
                  "aborted-completed",
                  "rejected"]
 
+### WMSTATS_JOB_INFO + WMSTATS_NO_JOB_INFO is meant to be equal to ACTIVE_STATUS
+WMSTATS_JOB_INFO = ["running-open",
+                    "running-closed",
+                    "force-complete",
+                    "completed",
+                    "closed-out"]
+
+WMSTATS_NO_JOB_INFO = ["new",
+                       "assignment-approved",
+                       "assigned",
+                       "staging",
+                       "staged",
+                       "acquired",
+                       "failed",
+                       "announced",
+                       "aborted",
+                       "aborted-completed",
+                       "rejected"]
+
 ### Used for monitoring in T0-WMStats. See: Services/WMStats/WMStatsReader
 T0_ACTIVE_STATUS = ["new",
                     "Closed",

--- a/src/python/WMCore/Services/WMStats/WMStatsReader.py
+++ b/src/python/WMCore/Services/WMStats/WMStatsReader.py
@@ -344,7 +344,7 @@ class WMStatsReader(object):
 
         options = {"group_level": 1, "reduce": True}
 
-        results = self.couchDB.loadView(self.couchapp, "allWorkflows", options=options)['rows']
+        results = self._getCouchView("allWorkflows", options)['rows']
         requestNames = [x['key'] for x in results]
 
         workflowDict = self.reqDB.getStatusAndTypeByRequest(requestNames)
@@ -371,7 +371,7 @@ class WMStatsReader(object):
 
         options = {'reduce': True, 'group_level': 5, 'startkey': [requestName],
                    'endkey': [requestName, {}]}
-        results = self.couchDB.loadView(self.couchapp, "jobsByStatusWorkflow", options=options)
+        results = self._getCouchView("jobsByStatusWorkflow", options)
         jobDetails = {}
         for row in results['rows']:
             # row["key"] = ['workflow', 'task', 'jobstatus', 'exitCode', 'site']
@@ -393,7 +393,7 @@ class WMStatsReader(object):
         options = {'include_docs': True, 'reduce': False,
                    'startkey': startKey, 'endkey': endKey,
                    'limit': limit}
-        result = self.couchDB.loadView(self.couchapp, "jobsByStatusWorkflow", options=options)
+        result = self._getCouchView("jobsByStatusWorkflow", options)
         jobInfoDoc = {}
         for row in result['rows']:
             keys = row['key']
@@ -417,7 +417,7 @@ class WMStatsReader(object):
 
     def getAllAgentRequestRevByID(self, agentURL):
         options = {"reduce": False}
-        results = self.couchDB.loadView(self.couchapp, "byAgentURL", options=options, keys=[agentURL])
+        results = self._getCouchView("byAgentURL", options, keys=[agentURL])
         idRevMap = {}
         for row in results['rows']:
             idRevMap[row['id']] = row['value']['rev']

--- a/src/python/WMCore/Services/WMStats/WMStatsReader.py
+++ b/src/python/WMCore/Services/WMStats/WMStatsReader.py
@@ -1,11 +1,12 @@
 from __future__ import division, print_function
 
-from Utils.IteratorTools import nestedDictUpdate
+import logging
+from Utils.IteratorTools import nestedDictUpdate, grouper
 from WMCore.Database.CMSCouch import CouchServer
 from WMCore.Lexicon import splitCouchServiceURL, sanitizeURL
 from WMCore.Services.RequestDB.RequestDBReader import RequestDBReader
 from WMCore.Services.WMStats.DataStruct.RequestInfoCollection import RequestInfo
-from WMCore.ReqMgr.DataStructs.RequestStatus import T0_ACTIVE_STATUS, ACTIVE_STATUS
+from WMCore.ReqMgr.DataStructs.RequestStatus import T0_ACTIVE_STATUS, WMSTATS_JOB_INFO, WMSTATS_NO_JOB_INFO
 
 REQUEST_PROPERTY_MAP = {
     "_id": "_id",
@@ -56,7 +57,8 @@ def convertToLegacyFormat(requestDoc):
 
 class WMStatsReader(object):
 
-    def __init__(self, couchURL, appName="WMStats", reqdbURL=None, reqdbCouchApp="ReqMgr"):
+    def __init__(self, couchURL, appName="WMStats", reqdbURL=None,
+                 reqdbCouchApp="ReqMgr", logger=None):
         self._sanitizeURL(couchURL)
         # set the connection for local couchDB call
         self._commonInit(couchURL, appName)
@@ -64,6 +66,7 @@ class WMStatsReader(object):
             self.reqDB = RequestDBReader(reqdbURL, reqdbCouchApp)
         else:
             self.reqDB = None
+        self.logger = logger if logger else logging.getLogger()
 
     def _sanitizeURL(self, couchURL):
         return sanitizeURL(couchURL)['url']
@@ -96,7 +99,7 @@ class WMStatsReader(object):
         return jobInfoByRequestAndAgent
 
     def _updateRequestInfoWithJobInfo(self, requestInfo):
-        if len(requestInfo.keys()) != 0:
+        if requestInfo:
             jobInfoByRequestAndAgent = self.getLatestJobInfoByRequests(requestInfo.keys())
             self._combineRequestAndJobData(requestInfo, jobInfoByRequestAndAgent)
 
@@ -192,15 +195,33 @@ class WMStatsReader(object):
 
     def _getLatestJobInfo(self, keys):
         """
-        keys is [['request_name', 'agent_url'], ....]
-        returns ids
+        Given a list of lists as keys, in the format of:
+            [['request_name', 'agent_url'], ['request_name2', 'agent_url2'], ....]
+        The result format from the latestRequest view is:
+            {u'offset': 527,
+             u'rows': [{u'doc': {u'_rev': u'32-6027014210',
+             ...
+                        u'id': u'cmsgwms-submit6.fnal.gov-cmsunified_ACDC0_task_BTV-RunIISummer19UL18wmLHEGEN-00004__v1_T_200507_162125_3670',
+                        u'key': [u'cmsunified_ACDC0_task_BTV-RunIISummer19UL18wmLHEGEN-00004__v1_T_200507_162125_3670',
+                                 u'cmsgwms-submit6.fnal.gov'],
+                        u'value': None}],
+             u'total_rows': 49606}
         """
-        if len(keys) == 0:
+        if not keys:
             return []
-        options = {"include_docs": True}
+        options = {}
+        options["include_docs"] = True
         options["reduce"] = False
-        result = self._getCouchView("latestRequest", options, keys)
-        return result
+        finalResults = {}
+        # magic number: 5000 keys (need to check which number is optimal)
+        for sliceKeys in grouper(keys, 5000):
+            self.logger.info("Querying latestRequest with %d keys", len(sliceKeys))
+            result = self._getCouchView("latestRequest", options, sliceKeys)
+            if not finalResults and result:
+                finalResults = result
+            elif result.get('rows'):
+                finalResults['rows'].extend(result['rows'])
+        return finalResults
 
     def _getAllDocsByIDs(self, ids, include_docs=True):
         """
@@ -273,9 +294,8 @@ class WMStatsReader(object):
             self._updateRequestInfoWithJobInfo(requestInfo)
         return requestInfo
 
-    def getActiveData(self, jobInfoFlag=False):
-
-        return self.getRequestByStatus(ACTIVE_STATUS, jobInfoFlag)
+    def getActiveData(self, listStatuses, jobInfoFlag=False):
+        return self.getRequestByStatus(listStatuses, jobInfoFlag)
 
     def getT0ActiveData(self, jobInfoFlag=False):
 
@@ -290,18 +310,24 @@ class WMStatsReader(object):
         If legacyFormat is True convert data to old wmstats format from current reqmgr format.
         Shouldn't be set to True unless existing code breaks
         """
+        results = dict()
+        for status in statusList:
+            self.logger.info("Fetching workflows by status from ReqMgr2, status: %s", status)
+            requestInfo = self.reqDB.getRequestByStatus(status, True, limit, skip)
+            self.logger.info("Found %d workflows in status: %s", len(requestInfo), status)
 
-        requestInfo = self.reqDB.getRequestByStatus(statusList, True, limit, skip)
+            if legacyFormat:
+                # convert the format to wmstats old format
+                for requestName, doc in requestInfo.items():
+                    requestInfo[requestName] = convertToLegacyFormat(doc)
+            results.update(requestInfo)
 
-        if legacyFormat:
-            # convert the format to wmstas old format
-            for requestName, doc in requestInfo.items():
-                requestInfo[requestName] = convertToLegacyFormat(doc)
+        # now update these requests with agent information too
+        if results and jobInfoFlag:
+            self.logger.info("Now updating these requests with job info...")
+            self._updateRequestInfoWithJobInfo(results)
 
-        if jobInfoFlag:
-            # get request and agent info
-            self._updateRequestInfoWithJobInfo(requestInfo)
-        return requestInfo
+        return results
 
     def getRequestSummaryWithJobInfo(self, requestName):
         """

--- a/src/python/WMCore/Services/WMStats/WMStatsWriter.py
+++ b/src/python/WMCore/Services/WMStats/WMStatsWriter.py
@@ -188,7 +188,7 @@ class WMStatsWriter(WMStatsReader):
         threshold = int(time.time()) - sec
         options = {"startkey": threshold, "descending": True,
                    "stale": "update_after"}
-        result = self.couchDB.loadView(self.couchapp, "time", options)
+        result = self._getCouchView("time", options)
 
         for row in result['rows']:
             doc = {}
@@ -261,9 +261,8 @@ class WMStatsWriter(WMStatsReader):
         """
         delete all wmstats docs for a given requestName
         """
-        view = "allWorkflows"
-        options = {"key": requestName, "reduce": False}
-        docs = self.couchDB.loadView(self.couchapp, view, options=options)['rows']
+        options = {"reduce": False, "key": requestName}
+        docs = self._getCouchView("allWorkflows", options)['rows']
 
         for j in docs:
             doc = {}

--- a/src/python/WMCore/WMStats/CherryPyThreads/DataCacheUpdate.py
+++ b/src/python/WMCore/WMStats/CherryPyThreads/DataCacheUpdate.py
@@ -1,15 +1,15 @@
-'''
-
-'''
 from __future__ import (division, print_function)
 
+import time
 from WMCore.REST.CherryPyPeriodicTask import CherryPyPeriodicTask
 from WMCore.WMStats.DataStructs.DataCache import DataCache
 from WMCore.Services.WMStats.WMStatsReader import WMStatsReader
+from WMCore.ReqMgr.DataStructs.RequestStatus import WMSTATS_JOB_INFO, WMSTATS_NO_JOB_INFO
 
 class DataCacheUpdate(CherryPyPeriodicTask):
 
     def __init__(self, rest, config):
+        self.getJobInfo = getattr(config, "getJobInfo", False)
 
         super(DataCacheUpdate, self).__init__(config)
 
@@ -23,13 +23,21 @@ class DataCacheUpdate(CherryPyPeriodicTask):
         """
         gather active data statistics
         """
+        self.logger.info("Starting gatherActiveDataStats with jobInfo set to: %s", self.getJobInfo)
         try:
+            tStart = time.time()
             if DataCache.islatestJobDataExpired():
                 wmstatsDB = WMStatsReader(config.wmstats_url, reqdbURL=config.reqmgrdb_url,
-                                          reqdbCouchApp="ReqMgr")
-                jobData = wmstatsDB.getActiveData(jobInfoFlag = True)
+                                          reqdbCouchApp="ReqMgr", logger=self.logger)
+                self.logger.info("Getting active data with job info for statuses: %s", WMSTATS_JOB_INFO)
+                jobData = wmstatsDB.getActiveData(WMSTATS_JOB_INFO, jobInfoFlag=self.getJobInfo)
+                self.logger.info("Getting active data with NO job info for statuses: %s", WMSTATS_NO_JOB_INFO)
+                tempData = wmstatsDB.getActiveData(WMSTATS_NO_JOB_INFO, jobInfoFlag=False)
+                jobData.update(tempData)
+                self.logger.info("Running setlatestJobData...")
                 DataCache.setlatestJobData(jobData)
-                self.logger.info("DataCache is updated: %s", len(jobData))
+                self.logger.info("DataCache is up-to-date with %d requests data", len(jobData))
         except Exception as ex:
-            self.logger.error(str(ex))
+            self.logger.exception("Exception updating DataCache. Error: %s", str(ex))
+        self.logger.info("Total time loading data from ReqMgr2 and WMStats: %s", time.time() - tStart)
         return


### PR DESCRIPTION
1.3.4_cmsweb branch version of:
 Break up WMStats DataCache update into multiple calls #9684 
 Load wmstats couch views with stale=update_after in WMStats Service wrappers #9692 

It provides basically two changes:
* DataCacheUpdate thread logic with more granular requests (instead one fat request fetching tons of data in the same call)
* by default, WMStats view calls will be made with `stale=update_after`, such that view requests are non-blocking.