### PR TITLE
Use DELETE method to delete single couch documents

### DIFF
--- a/src/python/WMCore/Database/CMSCouch.py
+++ b/src/python/WMCore/Database/CMSCouch.py
@@ -422,9 +422,13 @@ class Database(CouchDBRequests):
         """
         Immediately delete a document identified by id and rev.
         """
-        doc = self.document(id, rev)
-        doc.delete()
-        return self.commitOne(doc)
+        uri = '/%s/%s' % (self.name, urllib.quote_plus(id))
+        if not rev:
+            # then we need to fetch the latest revision number
+            doc = self.getDoc(id)
+            rev = doc["_rev"]
+        uri += '?' + urllib.urlencode({'rev': rev})
+        return self.delete(uri)
 
     def compact(self, views=None, blocking=False, blocking_poll=5, callback=False):
         """


### PR DESCRIPTION
Fixes #9705 

#### Status
not-tested

#### Description
As the subject says, delete couchdb documents via DELETE http method, instead of PUTting/POSTing the same document with `_deleted=true`.

TODO: evaluate `_bulk_docs` API for many deletions against many DELETE calls.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
