### PR TITLE
Resolve StepChain parentage information with new DBS APIs

### DIFF
--- a/bin/fix-dbs-parentage
+++ b/bin/fix-dbs-parentage
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-Fix the missing dataset parenatage by dates specified.
+Fix the missing dataset parentage by dates specified.
 
 1. Looking for the dataset which has a parent datasets
 2. Check any of the blocks has missing parents.
@@ -30,11 +30,6 @@ insert options (when missing parentage is found you can specify to insert to DBS
 --insert: insert to the specified dbs instance (production or testbed)
 --no-insert: not inserting the data - only for the testing purpose
 
-Method for the search: (By default it searches only for blocks with missing parents first then searches file parentage for those blocks)
-
--f: search for all the files in the dataset for missing parentage - very expensive to run only use when block has parent
-    but some files in the block doesn't have parents. This is normally used -d option for only one dataset.
-
 Usage:
 
 Uses block parentage to fix the problem (faster checks block parentage first to fix the missing parentage.)
@@ -51,11 +46,13 @@ from __future__ import print_function, division
 import time
 import datetime
 import argparse
+import logging
+import sys
 
 from WMCore.Services.DBS.DBS3Reader import DBS3Reader
 from dbs.apis.dbsClient import DbsApi
 
-def updateParentageInfo(datasetList, fileFix=False, insertFlag=False):
+def updateParentageInfo(datasetList, insertFlag=False, logger=logger):
 
     missingParentsFailed = {}
     start = int(time.time())
@@ -63,15 +60,10 @@ def updateParentageInfo(datasetList, fileFix=False, insertFlag=False):
     if insertFlag:
         answer = input("fixing DBS parentage: Are you sure?('y'/'n') - needs ' single quote: ").lower()
         if answer != 'y':
-            print("Aborting the procedure, Nothing updated")
+            logger.info("Aborting the procedure, Nothing updated")
             exit(1)
     else:
-        print("Only testing perfomance: No insert")
-
-    if fileFix:
-        print("Missing parentage fix using missing file checking for datasets")
-    else:
-        print("Missing parentage fix using missing block checking for datasets")
+        logger.info("Only testing perfomance: No insert")
 
     for dataset in datasetList:
         if isinstance(dataset, dict):
@@ -79,11 +71,7 @@ def updateParentageInfo(datasetList, fileFix=False, insertFlag=False):
         else:
             dsName = dataset
 
-        if fileFix:
-            failedBlocks = dbsService.insertMissingParentageForAllFiles(dsName, filterFilesWithParents=fileFix,
-                                                                        insertFlag=insertFlag)
-        else:
-            failedBlocks = dbsService.fixMissingParentageDatasets(dsName, insertFlag=insertFlag)
+        failedBlocks = dbsService.fixMissingParentageDatasets(dsName, insertFlag=insertFlag)
 
         missingParentsFailed[dsName] = failedBlocks
     return missingParentsFailed
@@ -107,10 +95,10 @@ if __name__ == '__main__':
     group3.add_argument('--no-insert', dest='insert', action='store_false')
     parser.set_defaults(insert=False)
 
-    parser.add_argument('-f', '--fix-partial-block', dest='filefix', action='store_true',
-                        help='fix the case some not all the files in the block has missing parentage (ReReco)')
-
     args = parser.parse_args()
+
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+    logger = logging.getLogger()
 
     if args.start:
         start = time.mktime(datetime.datetime.strptime(args.start, "%d/%m/%Y").timetuple())
@@ -119,25 +107,26 @@ if __name__ == '__main__':
 
     if args.prod:
         dbsURL = 'https://cmsweb.cern.ch/dbs/prod/global/DBSWriter'
-        print("Using production: ", dbsURL)
+        logger.info("Using production: %s", dbsURL)
     else:
         dbsURL = 'https://cmsweb-testbed.cern.ch/dbs/int/global/DBSWriter'
-        print("Using testbed: ", dbsURL)
+        logger.info("Using testbed: %s", dbsURL)
+
     dbs = DbsApi(dbsURL)
-    dbsService = DBS3Reader(dbsURL)
+    dbsService = DBS3Reader(dbsURL, logger=logger)
 
     if args.dataset:
         datasetList = [args.dataset]
     else:
         datasetList = dbs.listDatasets(min_cdate=int(start), max_cdate=int(end))
 
-    print("Number of datasets to check: ", len(datasetList))
+    logger.info("Number of datasets to check: %s", len(datasetList))
 
     startTime = int(time.time())
-    failedBlocks = updateParentageInfo(datasetList, fileFix=args.filefix, insertFlag=args.insert)
+    failedBlocks = updateParentageInfo(datasetList, insertFlag=args.insert, logger=logger)
     endTime = int(time.time())
 
     for dataset in failedBlocks:
         if failedBlocks[dataset]:
-            print("Update failed blocks: dataset: %s, blocks %s", (dataset, failedBlocks[dataset]))
-    print("Total Time: ", endTime - startTime)
+            logger.info("Update failed blocks: dataset: %s, blocks %s", dataset, failedBlocks[dataset])
+    logger.info("Total Time: %s", endTime - startTime)

--- a/src/python/WMCore/ReqMgr/CherryPyThreads/StepChainParentageFixTask.py
+++ b/src/python/WMCore/ReqMgr/CherryPyThreads/StepChainParentageFixTask.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 from __future__ import (division, print_function)
+
 import time
 from collections import defaultdict
 
 from WMCore.REST.CherryPyPeriodicTask import CherryPyPeriodicTask
-from WMCore.Services.RequestDB.RequestDBWriter import RequestDBWriter
 from WMCore.Services.DBS.DBS3Reader import DBS3Reader
+from WMCore.Services.RequestDB.RequestDBWriter import RequestDBWriter
 
 
 def getChildDatasetsForStepChainMissingParent(reqmgrDB, status):

--- a/src/python/WMCore/ReqMgr/CherryPyThreads/StepChainParentageFixTask.py
+++ b/src/python/WMCore/ReqMgr/CherryPyThreads/StepChainParentageFixTask.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import (division, print_function)
 import time
 from collections import defaultdict
@@ -53,7 +54,7 @@ class StepChainParentageFixTask(CherryPyPeriodicTask):
         requests = set()
         requestsByChildDataset = {}
         for status in self.statusToCheck:
-            reqByChildDS= getChildDatasetsForStepChainMissingParent(self.reqmgrDB, status)
+            reqByChildDS = getChildDatasetsForStepChainMissingParent(self.reqmgrDB, status)
             self.logger.info("Retrieved %d datasets to fix parentage, in status: %s",
                              len(reqByChildDS), status)
             childDatasets = childDatasets.union(set(reqByChildDS.keys()))
@@ -68,23 +69,33 @@ class StepChainParentageFixTask(CherryPyPeriodicTask):
         fixCount = 0
         for childDS in childDatasets:
             self.logger.info("Resolving parentage for dataset: %s", childDS)
-            start = int(time.time())
-            failedBlocks = self.dbsSvc.fixMissingParentageDatasets(childDS, insertFlag=True)
-            end = int(time.time())
-            timeTaken = end - start
-            if failedBlocks:
-                self.logger.warning("Failed to fix the parentage for %s will be retried: time took: %s (sec)",
-                                 failedBlocks, timeTaken)
+            start = time.time()
+            try:
+                failedBlocks = self.dbsSvc.fixMissingParentageDatasets(childDS, insertFlag=True)
+            except Exception as exc:
+                self.logger.exception("Failed to resolve parentage data for dataset: %s. Error: %s",
+                                      childDS, str(exc))
                 failedRequests = failedRequests.union(requestsByChildDataset[childDS])
             else:
-                fixCount += 1
-                self.logger.info("Fixed %s parentage: %s out of %s datasets. time took: %s (sec)",
-                                 childDS, fixCount, totalChildDS, timeTaken)
+                if failedBlocks:
+                    self.logger.warning("These blocks failed to be resolved and will be retried later: %s",
+                                        failedBlocks)
+                    failedRequests = failedRequests.union(requestsByChildDataset[childDS])
+                else:
+                    fixCount += 1
+                    self.logger.info("Parentage for '%s' successfully updated. Processed %s out of %s datasets.",
+                                     childDS, fixCount, totalChildDS)
+            timeTaken = time.time() - start
+            self.logger.info("    spent %s secs on this dataset: %s", timeTaken, childDS)
 
         requestsToUpdate = requests - failedRequests
 
         for request in requestsToUpdate:
-            self.reqmgrDB.updateRequestProperty(request, {"ParentageResolved": True})
+            try:
+                self.reqmgrDB.updateRequestProperty(request, {"ParentageResolved": True})
+                self.logger.info("Marked ParentageResolved=True for request: %s", request)
+            except Exception as exc:
+                self.logger.error("Failed to update 'ParentageResolved' flag to True for request: %s", request)
 
-        self.logger.info("Total %s requests' ParentageResolved flag is set to True", len(requestsToUpdate))
-        self.logger.info("Total %s requests will be retried next cycle: %s", len(failedRequests), failedRequests)
+        msg = "A total of %d requests have been processed, where %d will have to be retried in the next cycle."
+        self.logger.info(msg, len(requestsToUpdate), len(failedRequests))

--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -9,11 +9,11 @@ from __future__ import print_function, division
 
 import logging
 from collections import defaultdict
-from retry import retry
 
 from RestClient.ErrorHandling.RestClientExceptions import HTTPError
 from dbs.apis.dbsClient import DbsApi
 from dbs.exceptions.dbsClientException import dbsClientException
+from retry import retry
 
 from Utils.IteratorTools import grouper
 from WMCore.Services.DBS.DBSErrors import DBSReaderError, formatEx3


### PR DESCRIPTION
Fixes #9537 

#### Status
In development

#### Description
Logic is the following:
 * fetch the parent dataset information (fileid/run/lumi)
 * fetch all the blocks in the child
 * for each block in the child:
   * fetch the child block information (fileid/run/lumi)
   * map the child block run/lumi against the parent dataset run/lumi
   * insert the block parentage information
If everything went fine, update `ParentageResolved=True`.

This PR also deprecates the old DBS API used for this parentage logic: `listFileParentsByLumi`

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none