### PR TITLE
Fix wrong number of requests by status retrieved from Reqmgr2

### DIFF
--- a/src/python/WMCore/MicroService/Unified/MSOutput.py
+++ b/src/python/WMCore/MicroService/Unified/MSOutput.py
@@ -181,9 +181,10 @@ class MSOutput(MSCore):
         try:
             requestRecords = {}
             for status in reqStatus:
+                numRequestRecords = len(requestRecords)
                 requestRecords.update(self.getRequestRecords(status))
                 msg = "{}: Retrieved {} requests in status {} from ReqMgr2. ".format(self.currThreadIdent,
-                                                                                     len(requestRecords),
+                                                                                     len(requestRecords) - numRequestRecords,
                                                                                      status)
                 self.logger.info(msg)
         except Exception as err:  # general error


### PR DESCRIPTION
Fixes #9714 
#### Status
ready

#### Description
Recalculate the number of requests by status as a difference between the initial length of the `requestRecords` dictionary and the length of the updated one. 

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
N/A

#### External dependencies / deployment changes
NO
