### PR TITLE
MSOutput implementation for 'RelVal' workflows.

### DIFF
--- a/src/python/WMCore/MicroService/DataStructs/MSOutputTemplate.py
+++ b/src/python/WMCore/MicroService/DataStructs/MSOutputTemplate.py
@@ -81,10 +81,10 @@ class MSOutputTemplate(dict):
             ('isTakenBy', None, (str, unicode)),
             ('OutputDatasets', None, list),
             ('destination', None, list),
-            ('destinationOutputMap', None, dict),
-            ('campaignOutputMap', None, dict),
-            ('transferStatus', None, unicode),
-            ('transferIDs', None, int),
+            ('destinationOutputMap', None, list),
+            ('campaignOutputMap', None, list),
+            ('transferStatus', None, (str, unicode)),
+            ('transferIDs', None, list),
             ('numberOfCopies', None, int)]
 
         self.docTemplate = docTemplate
@@ -231,11 +231,11 @@ class MSOutputTemplate(dict):
             return True
         return False
 
-    def updateDoc(self, myDoc):
+    def updateDoc(self, myDoc, throw=False):
         """
-        Method to be used for updating the document fields from a dictionary
+        A method to be used for updating the document fields from a dictionary
         """
-        if self._checkAttr(self.docTemplate, myDoc, throw=False, update=False, **myDoc):
+        if self._checkAttr(self.docTemplate, myDoc, throw=throw, update=False, **myDoc):
             self.update(myDoc)
             return True
         return False

--- a/src/python/WMCore/Services/DDM/DDM.py
+++ b/src/python/WMCore/Services/DDM/DDM.py
@@ -43,6 +43,7 @@ class DDMReqTemplate(dict):
                          ('group', 'DataOps', str),
                          ('n', None, int),
                          ('cache', None, str)]
+            required = ['item', 'site']
 
         elif api == 'pollcopy':
             tempTuple = [('request_id', None, int),
@@ -50,9 +51,11 @@ class DDMReqTemplate(dict):
                          ('site', None, list),
                          ('status', None, str),
                          ('user', None, str)]
+            required = ['request_id']
 
         elif api == 'cancelcopy':
             tempTuple = [('request_id', None, int)]
+            required = ['request_id']
 
         else:
             msg = "ERROR: Unsupported API: {}".format(api)
@@ -87,6 +90,20 @@ class DDMReqTemplate(dict):
                     kw,
                     kwargs[kw])
                 raise TypeError(msg)
+
+        # check if all mandatory fields do exist
+        valid = []
+        missing = []
+        for mandField in required:
+            if mandField in template.keys() and template[mandField]:
+                valid.append(True)
+            else:
+                valid.append(False)
+                missing.append(mandField)
+
+        if not all(valid):
+            msg = "ERROR: Missing Mandatory Fields: {} for: {}".format(missing, template)
+            raise KeyError(msg)
 
         self.update(template)
 

--- a/test/python/WMCore_t/Services_t/DDM_t/DDM_t.py
+++ b/test/python/WMCore_t/Services_t/DDM_t/DDM_t.py
@@ -25,17 +25,18 @@ class DDMReqTemplateTest(EmulatedUnitTestCase):
         Setup for unit tests
         """
         super(DDMReqTemplateTest, self).setUp()
-        self.myddmReq = DDMReqTemplate('copy')
-        self.myddmReq['item'] = ['/LQLQToTopMuTopTau_M-1200_TuneCP5_13TeV_pythia8/RunIIFall17NanoAODv5-PU2017_12Apr2018_Nano1June2019_102X_mc2017_realistic_v7-v1/NANOAODSIM']
+        self.myddmReq = DDMReqTemplate('copy',
+                                       item=['/LQLQToTopMuTopTau_M-1200_TuneCP5_13TeV_pythia8/RunIIFall17NanoAODv5-PU2017_12Apr2018_Nano1June2019_102X_mc2017_realistic_v7-v1/NANOAODSIM'])
 
     def testConstructor(self):
         # Test construct with default values:
         expectedDdmReq = {'group': 'DataOps',
-                          'item': [],
+                          'item': ['someDatasetName'],
                           'site': ['T2_*', 'T1_*_Disk'],
                           'n': None,
                           'cache': None}
-        self.ddmReq = DDMReqTemplate('copy')
+        self.ddmReq = DDMReqTemplate('copy',
+                                     item=['someDatasetName'])
         self.assertEqual(self.ddmReq, expectedDdmReq)
 
         # Test bad API:
@@ -96,7 +97,7 @@ class DDMReqTemplateTest(EmulatedUnitTestCase):
         self.assertFalse(ddmReq2.isEqual(ddmReq3, 'item'))
 
         # Test compare requests with equal keys, different APIS:
-        ddmReq0 = DDMReqTemplate('pollcopy', item=['DataSet1'], site=['T2_*', 'T1_*_Disk'])
+        ddmReq0 = DDMReqTemplate('pollcopy', request_id=46633, item=['DataSet1'], site=['T2_*', 'T1_*_Disk'])
         self.assertFalse(ddmReq0.isEqual(ddmReq1))
         self.assertFalse(ddmReq0.isEqual(ddmReq1, 'item'))
         self.assertFalse(ddmReq0.isEqual(ddmReq2, 'item'))


### PR DESCRIPTION
Fixes #9608 

#### Status
ready

#### Description
Implements the Output data placement for RelVal workflows. The basic logic is simple it builds the destination map for the RelVal workflows in the Producer thread and later in the Consumer just uses it to create a series of transfers requests aggregated per dataset name and destination eg. A workflow with the following destination map [1] would get those 3 transfer requests created [2]    

NOTE: Before deployment of this one the MongoDB needs to be wiped out.

[1]
```
u'destination': [u'T2_CH_CERN', u'T1_US_FNAL_Disk'],
u'destinationOutputMap': [{u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-111X_mcRun3_2021_realistic_v4-v1/GEN-SIM'],
                           u'destination': [u'T2_CH_CERN',
                                            u'T1_US_FNAL_Disk']},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-111X_mcRun3_2021_realistic_v4-v1/GEN-SIM-DIGI-RAW'],
                           u'destination': [u'T2_CH_CERN',
                                            u'T1_US_FNAL_Disk']},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-111X_mcRun3_2021_realistic_v4-v1/GEN-SIM-RECO'],
                           u'destination': [u'T2_CH_CERN',
                                            u'T1_US_FNAL_Disk']},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-TkAlMinBias-111X_mcRun3_2021_realistic_v4-v1/ALCARECO'],
                           u'destination': []},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-HcalCalHBHEMuonFilter-111X_mcRun3_2021_realistic_v4-v1/ALCARECO'],
                           u'destination': []},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-EcalESAlign-111X_mcRun3_2021_realistic_v4-v1/ALCARECO'],
                           u'destination': []},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-TkAlZMuMu-111X_mcRun3_2021_realistic_v4-v1/ALCARECO'],
                           u'destination': []},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-TkAlMuonIsolated-111X_mcRun3_2021_realistic_v4-v1/ALCARECO'],
                           u'destination': []},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-SiStripCalMinBias-111X_mcRun3_2021_realistic_v4-v1/ALCARECO'],
                           u'destination': []},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-TkAlJpsiMuMu-111X_mcRun3_2021_realistic_v4-v1/ALCARECO'],
                           u'destination': []},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-SiPixelCalSingleMuon-111X_mcRun3_2021_realistic_v4-v1/ALCARECO'],
                           u'destination': []},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-MuAlOverlaps-111X_mcRun3_2021_realistic_v4-v1/ALCARECO'],
                           u'destination': []},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-TkAlUpsilonMuMu-111X_mcRun3_2021_realistic_v4-v1/ALCARECO'],
                           u'destination': []},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-111X_mcRun3_2021_realistic_v4-v1/DQMIO'],
                           u'destination': [u'T2_CH_CERN']},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-111X_mcRun3_2021_realistic_v4-v1/MINIAODSIM'],
                           u'destination': [u'T2_CH_CERN']}],

```

[2]
```
2020-06-03 11:01:00,319:INFO:MSOutput: Making transfer subscriptions for nwickram_RVCMSSW_11_1_0_pre7NuGun_200511_194429_2673
2020-06-03 11:01:00,320:WARNING:MSOutput: No data found in ddmResults for nwickram_RVCMSSW_11_1_0_pre7NuGun_200511_194429_2673. Either dry run mode or broken transfer submission to DDM. ddmResults: 
[{'cache': None,
  'group': 'RelVal',
  'item': [u'/RelValNuGun/CMSSW_11_1_0_pre7-111X_mcRun3_2021_realistic_v4-v1/MINIAODSIM',
           u'/RelValNuGun/CMSSW_11_1_0_pre7-111X_mcRun3_2021_realistic_v4-v1/DQMIO'],
  'n': None,
  'site': [u'T2_CH_CERN']},
 {'cache': None,
  'group': 'RelVal',
  'item': [u'/RelValNuGun/CMSSW_11_1_0_pre7-TkAlUpsilonMuMu-111X_mcRun3_2021_realistic_v4-v1/ALCARECO',
           u'/RelValNuGun/CMSSW_11_1_0_pre7-MuAlOverlaps-111X_mcRun3_2021_realistic_v4-v1/ALCARECO',
           u'/RelValNuGun/CMSSW_11_1_0_pre7-SiPixelCalSingleMuon-111X_mcRun3_2021_realistic_v4-v1/ALCARECO',
           u'/RelValNuGun/CMSSW_11_1_0_pre7-TkAlJpsiMuMu-111X_mcRun3_2021_realistic_v4-v1/ALCARECO',
           u'/RelValNuGun/CMSSW_11_1_0_pre7-SiStripCalMinBias-111X_mcRun3_2021_realistic_v4-v1/ALCARECO',
           u'/RelValNuGun/CMSSW_11_1_0_pre7-TkAlMuonIsolated-111X_mcRun3_2021_realistic_v4-v1/ALCARECO',
           u'/RelValNuGun/CMSSW_11_1_0_pre7-TkAlZMuMu-111X_mcRun3_2021_realistic_v4-v1/ALCARECO',
           u'/RelValNuGun/CMSSW_11_1_0_pre7-EcalESAlign-111X_mcRun3_2021_realistic_v4-v1/ALCARECO',
           u'/RelValNuGun/CMSSW_11_1_0_pre7-HcalCalHBHEMuonFilter-111X_mcRun3_2021_realistic_v4-v1/ALCARECO',
           u'/RelValNuGun/CMSSW_11_1_0_pre7-TkAlMinBias-111X_mcRun3_2021_realistic_v4-v1/ALCARECO'],
  'n': None,
  'site': []},
 {'cache': None,
  'group': 'RelVal',
  'item': [u'/RelValNuGun/CMSSW_11_1_0_pre7-111X_mcRun3_2021_realistic_v4-v1/GEN-SIM-RECO',
           u'/RelValNuGun/CMSSW_11_1_0_pre7-111X_mcRun3_2021_realistic_v4-v1/GEN-SIM-DIGI-RAW',
           u'/RelValNuGun/CMSSW_11_1_0_pre7-111X_mcRun3_2021_realistic_v4-v1/GEN-SIM'],
  'n': None,
  'site': [u'T2_CH_CERN', u'T1_US_FNAL_Disk']}]

```

#### Is it backward compatible (if not, which system it affects?)
Yes

#### Related PRs


#### External dependencies / deployment changes

