### PR TITLE
Create a map of output datasets by campaign for the MSOutput component

### DIFF
--- a/src/python/WMCore/MicroService/DataStructs/MSOutputTemplate.py
+++ b/src/python/WMCore/MicroService/DataStructs/MSOutputTemplate.py
@@ -82,7 +82,7 @@ class MSOutputTemplate(dict):
             ('OutputDatasets', None, list),
             ('destination', None, list),
             ('destinationOutputMap', None, dict),
-            ('campaignOutputMap', None, dict),
+            ('campaignOutputMap', None, list),
             ('transferStatus', None, unicode),
             ('transferIDs', None, int),
             ('numberOfCopies', None, int)]
@@ -113,6 +113,9 @@ class MSOutputTemplate(dict):
         # if any object attribute is passed as a **kwargs parameter then
         # overwrite the equivalent parameter which was coming with the doc
         self._checkAttr(docTemplate, myDoc, update=True, throw=True, **kwargs)
+
+        if doc is not None:
+            self._setCampMap(doc, myDoc)
 
         # enforce a full check on the final document
         self._checkAttr(docTemplate, myDoc, update=False, throw=True, **myDoc)
@@ -240,11 +243,41 @@ class MSOutputTemplate(dict):
             return True
         return False
 
-    def setCampMap(self):
+    def _setCampMap(self, reqDoc, thisDoc):
         """
         __setCampMap__
+        Provided the request content retrieved from ReqMgr2, build a map
+        of output dataset per campaign.
+        :param reqDoc: meant to be the request dictionary retrieved from ReqMgr2
+        :param thisDoc: meant to be a template msoutput object
         """
-        pass
+        # first, check whether we are loading a document from MongoDB or CouchDB
+        if "RequestType" not in reqDoc:
+            # then no mapping needs to be created
+            return True
+
+        campOutputMap = {}
+        finalMap = []
+        if reqDoc["RequestType"] in ["StepChain", "TaskChain"]:
+            for key in reqDoc["ChainParentageMap"]:
+                # key is Step1, Step2 or Task1, Task2, etc
+                # use the Task/Step level campaign, fallback to the top level one
+                if not reqDoc["ChainParentageMap"][key]["ChildDsets"]:
+                    # this task/step does not stage any output data
+                    continue
+                campName = reqDoc[key].get("Campaign", reqDoc.get("Campaign"))
+                campOutputMap.setdefault(campName, [])
+                campOutputMap[campName].extend(reqDoc["ChainParentageMap"][key]["ChildDsets"])
+            # now just write the final data structure out
+            for campName, dsetList in campOutputMap.items():
+                finalMap.append(dict(campaignName=campName, datasets=dsetList))
+        else:
+            # ReReco and StoreResults
+            finalMap.append(dict(campaignName=reqDoc["Campaign"], datasets=reqDoc["OutputDatasets"]))
+
+        # finally, update this object
+        thisDoc["campaignOutputMap"] = finalMap
+        return True
 
     def setDestMap(self):
         """


### PR DESCRIPTION
Fixes #9718 

#### Status
not-tested

#### Description
When MSOutputTemplate is called to convert a ReqMgr2 request dictionary into our MSOutput internal object, perform a map of output datasets in each campaign and persist this information in the MSOutput object.
Note that StepChain and TaskChain requests can have many campaign names, while all the others are single campaign'ed requests.

#### Is it backward compatible (if not, which system it affects?)
no, in the sense of being a new feature.

#### Related PRs
none

#### External dependencies / deployment changes
none