### PR TITLE
MSOutput implementation for 'RelVal' workflows

### DIFF
--- a/src/python/WMCore/MicroService/DataStructs/MSOutputTemplate.py
+++ b/src/python/WMCore/MicroService/DataStructs/MSOutputTemplate.py
@@ -81,10 +81,10 @@ class MSOutputTemplate(dict):
             ('isTakenBy', None, (str, unicode)),
             ('OutputDatasets', None, list),
             ('destination', None, list),
-            ('destinationOutputMap', None, dict),
+            ('destinationOutputMap', None, list),
             ('campaignOutputMap', None, list),
-            ('transferStatus', None, unicode),
-            ('transferIDs', None, int),
+            ('transferStatus', None, (str, unicode)),
+            ('transferIDs', None, list),
             ('numberOfCopies', None, int)]
 
         self.docTemplate = docTemplate
@@ -234,11 +234,11 @@ class MSOutputTemplate(dict):
             return True
         return False
 
-    def updateDoc(self, myDoc):
+    def updateDoc(self, myDoc, throw=False):
         """
-        Method to be used for updating the document fields from a dictionary
+        A method to be used for updating the document fields from a dictionary
         """
-        if self._checkAttr(self.docTemplate, myDoc, throw=False, update=False, **myDoc):
+        if self._checkAttr(self.docTemplate, myDoc, throw=throw, update=False, **myDoc):
             self.update(myDoc)
             return True
         return False

--- a/src/python/WMCore/MicroService/Unified/MSOutput.py
+++ b/src/python/WMCore/MicroService/Unified/MSOutput.py
@@ -285,41 +285,80 @@ class MSOutput(MSCore):
             #    but an iterator of length 'stride' and then we should be doing:
             #    for workflow in workflows:
             if isinstance(workflow, MSOutputTemplate):
-                if workflow['isRelVal']:
-                    pass
-                else:
-                    try:
+                ddmReqList = []
+                try:
+                    if workflow['isRelVal']:
+                        for dMap in workflow['destinationOutputMap']:
+                            try:
+                                ddmRequest = DDMReqTemplate('copy',
+                                                            item=dMap['datasets'],
+                                                            n=workflow['numberOfCopies'],
+                                                            site=dMap['destination'],
+                                                            group='RelVal')
+                            except KeyError as ex:
+                                # NOTE:
+                                #    If we get to here it is most probably because the 'site'
+                                #    mandatory field to the DDM request is missing (due to an
+                                #    'ALCARECO' dataset or similar). Since this is expected
+                                #    to happen a lot, we'd better just log a warning and continue
+                                msg = "Could not create DDMReq for Workflow: {}".format(workflow['RequestName'])
+                                msg += "Error: {}".format(ex)
+                                self.logger.warning(msg)
+                                continue
+                            ddmReqList.append(ddmRequest)
+                    else:
+                        # FIXME:
+                        #    We need to create the campaignMap and use it for
+                        #    creating the requests for the nonRelVal workflows
+                        #    it should be also the case when we migrate to Rucio
                         ddmRequest = DDMReqTemplate('copy',
                                                     item=workflow['OutputDatasets'],
                                                     n=workflow['numberOfCopies'],
                                                     site=workflow['destination'])
-                    except Exception as ex:
-                        msg = "Could not create DDMReq for Workflow: {}".format(workflow['RequestName'])
-                        msg += "Error: {}".format(ex)
-                        self.logger.exception(msg)
-                        return workflow
+                        ddmReqList.append(ddmRequest)
+                except Exception as ex:
+                    msg = "Could not create DDMReq for Workflow: {}".format(workflow['RequestName'])
+                    msg += "Error: {}".format(ex)
+                    self.logger.exception(msg)
+                    return workflow
 
-                    try:
-                        # In the message bellow we may want to put the list of datasets too
-                        msg = "Making transfer subscriptions for {}".format(workflow['RequestName'])
-                        self.logger.info(msg)
-                        ddmResult = self.ddm.makeRequest(ddmRequest)
-                    except Exception as ex:
-                        msg = "Could not make transfer subscription for Workflow: {}".format(workflow['RequestName'])
-                        msg += "Error: {}".format(ex)
-                        self.logger.exception(msg)
-                        return workflow
+                try:
+                    # In the message bellow we may want to put the list of datasets too
+                    msg = "Making transfer subscriptions for {}".format(workflow['RequestName'])
+                    self.logger.info(msg)
+                    ddmResultList = self.ddm.makeAggRequests(ddmReqList, aggKey='item')
+                except Exception as ex:
+                    msg = "Could not make transfer subscription for Workflow: {}".format(workflow['RequestName'])
+                    msg += "Error: {}".format(ex)
+                    self.logger.exception(msg)
+                    return workflow
 
+                ddmStatusList = ['new', 'activated', 'completed', 'rejected', 'cancelled']
+                transferIDs = []
+                transferStatusList = []
+                for ddmResult in ddmResultList:
                     if 'data' in ddmResult.keys():
-                        self.docKeyUpdate(workflow,
-                                          transferStatus=deepcopy(ddmResult['data'][0]['status']),
-                                          transferIDs=deepcopy(ddmResult['data'][0]['request_id']))
-                        return workflow
-                    else:
-                        msg = "No data found in ddmResult for %s. Either dry run mode or " % workflow['RequestName']
-                        msg += "broken transfer submission to DDM. "
-                        msg += "ddmResult: \n%s" % pformat(ddmResult)
-                        self.logger.warning(msg)
+                        id = deepcopy(ddmResult['data'][0]['request_id'])
+                        status = deepcopy(ddmResult['data'][0]['status'])
+                        transferStatusList.append({'transferID': id,
+                                                   'status': status})
+                        transferIDs.append(id)
+
+                if transferStatusList and all(map(lambda x:
+                                                  True if x['status'] in ddmStatusList else False,
+                                                  transferStatusList)):
+                    self.docKeyUpdate(workflow,
+                                      transferStatus='done',
+                                      transferIDs=transferIDs)
+                    return workflow
+                else:
+                    self.docKeyUpdate(workflow,
+                                      transferStatus='incomplete')
+                    msg = "No data found in ddmResults for %s. Either dry run mode or " % workflow['RequestName']
+                    msg += "broken transfer submission to DDM. "
+                    msg += "ddmResults: \n%s" % pformat(ddmResultList)
+                    self.logger.warning(msg)
+                return workflow
 
             elif isinstance(workflow, (list, set, CommandCursor)):
                 ddmRequests = {}
@@ -447,12 +486,24 @@ class MSOutput(MSCore):
                 # - which are not already taken or
                 # - a transfer subscription have never been done for them and
                 # - avoid retrying workflows in the same cycle
+                # NOTE:
+                #    Once we are running the service not in a dry run mode we may
+                #    consider adding and $or condition in mQueryDict for transferStatus:
+                #    '$or': [{'transferStatus': None},
+                #            {'transferStatus': 'incomplete'}]
+                #    So that we can collect also workflows with partially or fully
+                #    unsuccessful transfers
                 currTime = int(time())
                 treshTime = currTime - self.msConfig['interval']
-                mQueryDict = {'isTaken': False,
-                              'transferStatus': None,
-                              '$or': [{'lastUpdate': None},
-                                      {'lastUpdate': {'$lt': treshTime}}]}
+                mQueryDict = {
+                    '$and': [
+                        {'isTaken': False},
+                        {'$or': [
+                            {'transferStatus': None},
+                            {'transferStatus': 'incomplete'}]},
+                        {'$or': [
+                            {'lastUpdate': None},
+                            {'lastUpdate': {'$lt': treshTime}}]}]}
                 try:
                     pipeLine.run(mQueryDict)
                 except KeyError as ex:
@@ -504,17 +555,21 @@ class MSOutput(MSCore):
         #    to set a destructive function at the end of the pipeline
         # NOTE:
         #    To discuss the collection names
+        # NOTE:
+        #    Here we should never use docUploader with `update=True`, because
+        #    this will erase the latest state of already existing and fully or
+        #    partially processed documents by the Consumer pipeline
         self.logger.info("Running the msOutputProducer ...")
         msPipelineRelVal = Pipeline(name="MSOutputProducer PipelineRelVal",
                                     funcLine=[Functor(self.docTransformer),
                                               Functor(self.docKeyUpdate, isRelVal=True),
-                                              Functor(self.docInfoUpdate),
+                                              Functor(self.docInfoUpdate, pipeLine='PipelineRelVal'),
                                               Functor(self.docUploader, self.msOutRelValColl),
                                               Functor(self.docCleaner)])
         msPipelineNonRelVal = Pipeline(name="MSOutputProducer PipelineNonRelVal",
                                        funcLine=[Functor(self.docTransformer),
                                                  Functor(self.docKeyUpdate, isRelVal=False),
-                                                 Functor(self.docInfoUpdate),
+                                                 Functor(self.docInfoUpdate, pipeLine='PipelineNonRelVal'),
                                                  Functor(self.docUploader, self.msOutNonRelValColl),
                                                  Functor(self.docCleaner)])
         # TODO:
@@ -588,17 +643,90 @@ class MSOutput(MSCore):
         for key, value in kwargs.items():
             try:
                 msOutDoc.setKey(key, value)
+                msOutDoc.updateTime()
             except Exception as ex:
                 msg = "Cannot update key {} for doc: {}\n".format(key, msOutDoc['_id'])
                 msg += "Error: {}".format(str(ex))
                 self.logger.warning(msg)
         return msOutDoc
 
-    def docInfoUpdate(self, msOutDoc):
+    def docInfoUpdate(self, msOutDoc, pipeLine=None):
         """
         A function intended to fetch and fill into the document all the needed
         additional information like campaignOutputMap etc.
         """
+
+        # Fill the destinationOutputMap first
+        if msOutDoc['isRelVal']:
+            destinationOutputMap = []
+            wflowDstSet = set()
+            updateDict = {}
+            for dataset in msOutDoc['OutputDatasets']:
+                _, dsn, procString, dataTier = dataset.split('/')
+                destination = set()
+                if dataTier != "RECO" and dataTier != "ALCARECO":
+                    destination.add('T2_CH_CERN')
+                if dataTier == "GEN-SIM":
+                    destination.add('T1_US_FNAL_Disk')
+                if dataTier == "GEN-SIM-DIGI-RAW":
+                    destination.add('T1_US_FNAL_Disk')
+                if dataTier == "GEN-SIM-RECO":
+                    destination.add('T1_US_FNAL_Disk')
+                if "RelValTTBar" in dsn and "TkAlMinBias" in procString and dataTier != "ALCARECO":
+                    destination.add('T2_CH_CERN')
+                if "MinimumBias" in dsn and "SiStripCalMinBias" in procString and dataTier != "ALCARECO":
+                    destination.add('T2_CH_CERN')
+                dMap = {'datasets': [dataset],
+                        'destination': list(destination)}
+                destinationOutputMap.append(dMap)
+                wflowDstSet |= destination
+
+            # here we try to aggregate the destination map per destination
+            aggDstMap = []
+
+            # populate the first element in the aggregated list
+            aggDstMap.append(destinationOutputMap.pop())
+
+            # feed the rest
+            while len(destinationOutputMap) != 0:
+                dMap = destinationOutputMap.pop()
+                found = False
+                for aggMap in aggDstMap:
+                    if set(dMap['destination']) == set(aggMap['destination']):
+                        # Check if the two objects are not references to one and the
+                        # same object. Only then copy the values of the dMap,
+                        # otherwise we will enter an endless cycle.
+                        if dMap is not aggMap:
+                            for i in dMap['datasets']:
+                                aggMap['datasets'].append(i)
+                        found = True
+                        del(dMap)
+                        break
+                if not found:
+                    aggDstMap.append(dMap)
+
+            # finally reassign the destination map with the aggregated one
+            destinationOutputMap = aggDstMap
+
+            wflowDstList = list(wflowDstSet)
+            updateDict['destination'] = wflowDstList
+            updateDict['destinationOutputMap'] = destinationOutputMap
+            try:
+                msOutDoc.updateDoc(updateDict, throw=True)
+                # msg = "%s: %s: 'msOutDoc': %s"
+                # self.logger.debug(msg,
+                #                   self.currThreadIdent,
+                #                   pipeLine,
+                #                   pformat(msOutDoc))
+            except Exception as ex:
+                msg = "%s: %s: Could not update the additional information for "
+                msg += "'msOutDoc' with '_id': %s \n"
+                msg += "Error: %s"
+                self.logger.exception(msg,
+                                      self.currThreadIdent,
+                                      pipeLine,
+                                      msOutDoc['_id'],
+                                      str(ex))
         return msOutDoc
 
     def docUploader(self, msOutDoc, dbColl, update=False, keys=None, stride=None):
@@ -633,7 +761,7 @@ class MSOutput(MSCore):
             if not keys:
                 keys = []
 
-            # update only the requested keyes:
+            # update only the requested keys:
             if update and keys:
                 updateDict = {}
                 for key in keys:

--- a/src/python/WMCore/Services/DDM/DDM.py
+++ b/src/python/WMCore/Services/DDM/DDM.py
@@ -43,6 +43,7 @@ class DDMReqTemplate(dict):
                          ('group', 'DataOps', str),
                          ('n', None, int),
                          ('cache', None, str)]
+            required = ['item', 'site']
 
         elif api == 'pollcopy':
             tempTuple = [('request_id', None, int),
@@ -50,9 +51,11 @@ class DDMReqTemplate(dict):
                          ('site', None, list),
                          ('status', None, str),
                          ('user', None, str)]
+            required = ['request_id']
 
         elif api == 'cancelcopy':
             tempTuple = [('request_id', None, int)]
+            required = ['request_id']
 
         else:
             msg = "ERROR: Unsupported API: {}".format(api)
@@ -87,6 +90,20 @@ class DDMReqTemplate(dict):
                     kw,
                     kwargs[kw])
                 raise TypeError(msg)
+
+        # check if all mandatory fields do exist
+        valid = []
+        missing = []
+        for mandField in required:
+            if mandField in template.keys() and template[mandField]:
+                valid.append(True)
+            else:
+                valid.append(False)
+                missing.append(mandField)
+
+        if not all(valid):
+            msg = "ERROR: Missing Mandatory Fields: {} for: {}".format(missing, template)
+            raise KeyError(msg)
 
         self.update(template)
 

--- a/test/python/WMCore_t/Services_t/DDM_t/DDM_t.py
+++ b/test/python/WMCore_t/Services_t/DDM_t/DDM_t.py
@@ -25,17 +25,18 @@ class DDMReqTemplateTest(EmulatedUnitTestCase):
         Setup for unit tests
         """
         super(DDMReqTemplateTest, self).setUp()
-        self.myddmReq = DDMReqTemplate('copy')
-        self.myddmReq['item'] = ['/LQLQToTopMuTopTau_M-1200_TuneCP5_13TeV_pythia8/RunIIFall17NanoAODv5-PU2017_12Apr2018_Nano1June2019_102X_mc2017_realistic_v7-v1/NANOAODSIM']
+        self.myddmReq = DDMReqTemplate('copy',
+                                       item=['/LQLQToTopMuTopTau_M-1200_TuneCP5_13TeV_pythia8/RunIIFall17NanoAODv5-PU2017_12Apr2018_Nano1June2019_102X_mc2017_realistic_v7-v1/NANOAODSIM'])
 
     def testConstructor(self):
         # Test construct with default values:
         expectedDdmReq = {'group': 'DataOps',
-                          'item': [],
+                          'item': ['someDatasetName'],
                           'site': ['T2_*', 'T1_*_Disk'],
                           'n': None,
                           'cache': None}
-        self.ddmReq = DDMReqTemplate('copy')
+        self.ddmReq = DDMReqTemplate('copy',
+                                     item=['someDatasetName'])
         self.assertEqual(self.ddmReq, expectedDdmReq)
 
         # Test bad API:
@@ -96,7 +97,7 @@ class DDMReqTemplateTest(EmulatedUnitTestCase):
         self.assertFalse(ddmReq2.isEqual(ddmReq3, 'item'))
 
         # Test compare requests with equal keys, different APIS:
-        ddmReq0 = DDMReqTemplate('pollcopy', item=['DataSet1'], site=['T2_*', 'T1_*_Disk'])
+        ddmReq0 = DDMReqTemplate('pollcopy', request_id=46633, item=['DataSet1'], site=['T2_*', 'T1_*_Disk'])
         self.assertFalse(ddmReq0.isEqual(ddmReq1))
         self.assertFalse(ddmReq0.isEqual(ddmReq1, 'item'))
         self.assertFalse(ddmReq0.isEqual(ddmReq2, 'item'))


### PR DESCRIPTION
Fixes #9608

#### Status
ready

#### Description
This PR substitutes https://github.com/dmwm/WMCore/pull/9717 due to broken history during conflict resolution with master branch
DESCRIPTION:
Implements the Output data placement for RelVal workflows. The basic logic is simple it builds the destination map for the RelVal workflows in the Producer thread and later in the Consumer just uses it to create a series of transfers requests aggregated per dataset name and destination eg. A workflow with the following destination map [1] would get those 3 transfer requests created [2]    

NOTE: Before deployment of this one the MongoDB needs to be wiped out.

[1]
```
u'destination': [u'T2_CH_CERN', u'T1_US_FNAL_Disk'],
u'destinationOutputMap': [{u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-111X_mcRun3_2021_realistic_v4-v1/GEN-SIM'],
                           u'destination': [u'T2_CH_CERN',
                                            u'T1_US_FNAL_Disk']},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-111X_mcRun3_2021_realistic_v4-v1/GEN-SIM-DIGI-RAW'],
                           u'destination': [u'T2_CH_CERN',
                                            u'T1_US_FNAL_Disk']},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-111X_mcRun3_2021_realistic_v4-v1/GEN-SIM-RECO'],
                           u'destination': [u'T2_CH_CERN',
                                            u'T1_US_FNAL_Disk']},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-TkAlMinBias-111X_mcRun3_2021_realistic_v4-v1/ALCARECO'],
                           u'destination': []},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-HcalCalHBHEMuonFilter-111X_mcRun3_2021_realistic_v4-v1/ALCARECO'],
                           u'destination': []},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-EcalESAlign-111X_mcRun3_2021_realistic_v4-v1/ALCARECO'],
                           u'destination': []},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-TkAlZMuMu-111X_mcRun3_2021_realistic_v4-v1/ALCARECO'],
                           u'destination': []},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-TkAlMuonIsolated-111X_mcRun3_2021_realistic_v4-v1/ALCARECO'],
                           u'destination': []},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-SiStripCalMinBias-111X_mcRun3_2021_realistic_v4-v1/ALCARECO'],
                           u'destination': []},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-TkAlJpsiMuMu-111X_mcRun3_2021_realistic_v4-v1/ALCARECO'],
                           u'destination': []},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-SiPixelCalSingleMuon-111X_mcRun3_2021_realistic_v4-v1/ALCARECO'],
                           u'destination': []},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-MuAlOverlaps-111X_mcRun3_2021_realistic_v4-v1/ALCARECO'],
                           u'destination': []},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-TkAlUpsilonMuMu-111X_mcRun3_2021_realistic_v4-v1/ALCARECO'],
                           u'destination': []},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-111X_mcRun3_2021_realistic_v4-v1/DQMIO'],
                           u'destination': [u'T2_CH_CERN']},
                          {u'datasets': [u'/RelValNuGun/CMSSW_11_1_0_pre7-111X_mcRun3_2021_realistic_v4-v1/MINIAODSIM'],
                           u'destination': [u'T2_CH_CERN']}],

```

[2]
```
2020-06-03 11:01:00,319:INFO:MSOutput: Making transfer subscriptions for nwickram_RVCMSSW_11_1_0_pre7NuGun_200511_194429_2673
2020-06-03 11:01:00,320:WARNING:MSOutput: No data found in ddmResults for nwickram_RVCMSSW_11_1_0_pre7NuGun_200511_194429_2673. Either dry run mode or broken transfer submission to DDM. ddmResults: 
[{'cache': None,
  'group': 'RelVal',
  'item': [u'/RelValNuGun/CMSSW_11_1_0_pre7-111X_mcRun3_2021_realistic_v4-v1/MINIAODSIM',
           u'/RelValNuGun/CMSSW_11_1_0_pre7-111X_mcRun3_2021_realistic_v4-v1/DQMIO'],
  'n': None,
  'site': [u'T2_CH_CERN']},
 {'cache': None,
  'group': 'RelVal',
  'item': [u'/RelValNuGun/CMSSW_11_1_0_pre7-TkAlUpsilonMuMu-111X_mcRun3_2021_realistic_v4-v1/ALCARECO',
           u'/RelValNuGun/CMSSW_11_1_0_pre7-MuAlOverlaps-111X_mcRun3_2021_realistic_v4-v1/ALCARECO',
           u'/RelValNuGun/CMSSW_11_1_0_pre7-SiPixelCalSingleMuon-111X_mcRun3_2021_realistic_v4-v1/ALCARECO',
           u'/RelValNuGun/CMSSW_11_1_0_pre7-TkAlJpsiMuMu-111X_mcRun3_2021_realistic_v4-v1/ALCARECO',
           u'/RelValNuGun/CMSSW_11_1_0_pre7-SiStripCalMinBias-111X_mcRun3_2021_realistic_v4-v1/ALCARECO',
           u'/RelValNuGun/CMSSW_11_1_0_pre7-TkAlMuonIsolated-111X_mcRun3_2021_realistic_v4-v1/ALCARECO',
           u'/RelValNuGun/CMSSW_11_1_0_pre7-TkAlZMuMu-111X_mcRun3_2021_realistic_v4-v1/ALCARECO',
           u'/RelValNuGun/CMSSW_11_1_0_pre7-EcalESAlign-111X_mcRun3_2021_realistic_v4-v1/ALCARECO',
           u'/RelValNuGun/CMSSW_11_1_0_pre7-HcalCalHBHEMuonFilter-111X_mcRun3_2021_realistic_v4-v1/ALCARECO',
           u'/RelValNuGun/CMSSW_11_1_0_pre7-TkAlMinBias-111X_mcRun3_2021_realistic_v4-v1/ALCARECO'],
  'n': None,
  'site': []},
 {'cache': None,
  'group': 'RelVal',
  'item': [u'/RelValNuGun/CMSSW_11_1_0_pre7-111X_mcRun3_2021_realistic_v4-v1/GEN-SIM-RECO',
           u'/RelValNuGun/CMSSW_11_1_0_pre7-111X_mcRun3_2021_realistic_v4-v1/GEN-SIM-DIGI-RAW',
           u'/RelValNuGun/CMSSW_11_1_0_pre7-111X_mcRun3_2021_realistic_v4-v1/GEN-SIM'],
  'n': None,
  'site': [u'T2_CH_CERN', u'T1_US_FNAL_Disk']}]

```

#### Is it backward compatible (if not, which system it affects?)
Yes

#### Related PRs


#### External dependencies / deployment changes

