### PR TITLE
Enable RucioInjector component for NANO tiers

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -362,14 +362,14 @@ config.component_("RucioInjector")
 config.RucioInjector.namespace = "WMComponent.RucioInjector.RucioInjector"
 config.RucioInjector.componentDir = config.General.workDir + "/RucioInjector"
 config.RucioInjector.logLevel = globalLogLevel
-config.RucioInjector.enabled = False
+config.RucioInjector.enabled = True
 config.RucioInjector.pollInterval = 300
 config.RucioInjector.pollIntervalRules = 43200
 config.RucioInjector.cacheExpiration = 2 * 24 * 60 * 60  # two days
 config.RucioInjector.createBlockRules = True
 config.RucioInjector.RSEPostfix = False  # enable it to append _Test to the RSE names
 config.RucioInjector.metaDIDProject = "Production"
-config.RucioInjector.listTiersToInject = []  # ["NANOAOD", "NANOAODSIM"]
+config.RucioInjector.listTiersToInject = ["NANOAOD", "NANOAODSIM"]  # []
 config.RucioInjector.skipRulesForTiers = ["NANOAOD", "NANOAODSIM"]
 config.RucioInjector.rucioAccount = "OVER_WRITE_BY_SECRETS"
 config.RucioInjector.rucioUrl = "OVER_WRITE_BY_SECRETS"


### PR DESCRIPTION
Fixes #9732 

#### Status
ready

#### Description
Changes are:
* switch on the RucioInjector component
* only inject data for the NANOAOD and NANOAODSIM tiers

Configurations that did not change, but worth mentioning:
* datasets rules are not created
* block rules are created

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
NOT to be patched in agents with any work on going.
