### PR TITLE
[PY3] Make StringIO and httplib compatible with python3

### DIFF
--- a/src/python/PSetTweaks/PSetTweak.py
+++ b/src/python/PSetTweaks/PSetTweak.py
@@ -6,8 +6,11 @@ Record a set of tweakable parameters from a CMSSW Configuration in a CMSSW
 independent python structure
 
 """
+try:
+    from StringIO import StringIO ## for Python 2
+except ImportError:
+    from io import StringIO ## for Python 3
 
-import StringIO
 import imp
 import inspect
 import json
@@ -394,7 +397,7 @@ class PSetTweak:
 
 
             jsoniser = JSONiser()
-            jsoniser.dejson(json.load(StringIO.StringIO(jsonContent)))
+            jsoniser.dejson(json.load(StringIO(jsonContent)))
 
             for param, value in jsoniser.parameters.items():
                 self.addParameter(param , value)

--- a/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
+++ b/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
@@ -45,7 +45,7 @@ import logging
 import threading
 import time
 import traceback
-from httplib import HTTPException
+from http.client import HTTPException
 
 from Utils.Timers import timeFunction
 from WMCore.DAOFactory import DAOFactory

--- a/src/python/WMComponent/TaskArchiver/CleanCouchPoller.py
+++ b/src/python/WMComponent/TaskArchiver/CleanCouchPoller.py
@@ -1,7 +1,7 @@
 """
 Perform cleanup actions
 """
-import httplib
+import http.client as httplib
 import json
 import logging
 import os.path

--- a/src/python/WMCore/Database/CMSCouch.py
+++ b/src/python/WMCore/Database/CMSCouch.py
@@ -18,7 +18,7 @@ import time
 import traceback
 import urllib
 from datetime import datetime
-from httplib import HTTPException
+from http.client import HTTPException
 
 from Utils.IteratorTools import grouper, nestedDictUpdate
 from WMCore.Services.Requests import JSONRequests

--- a/src/python/WMCore/MicroService/Unified/MSTransferor.py
+++ b/src/python/WMCore/MicroService/Unified/MSTransferor.py
@@ -12,7 +12,7 @@ tasks might be extended to multi-threading in the future.
 from __future__ import division, print_function
 
 # system modules
-from httplib import HTTPException
+from http.client import HTTPException
 from operator import itemgetter
 from pprint import pformat
 from retry import retry

--- a/src/python/WMCore/REST/Main.py
+++ b/src/python/WMCore/REST/Main.py
@@ -20,7 +20,7 @@ import thread
 import time
 import traceback
 from argparse import ArgumentParser
-from cStringIO import StringIO
+from io import StringIO
 from glob import glob
 from subprocess import Popen, PIPE
 from pprint import pformat

--- a/src/python/WMCore/Services/HTTPS/HTTPSAuthHandler.py
+++ b/src/python/WMCore/Services/HTTPS/HTTPSAuthHandler.py
@@ -7,7 +7,7 @@ src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
 from __future__ import print_function, division
 import logging
 import urllib2
-import httplib
+import http.client as httplib
 import ssl
 
 

--- a/src/python/WMCore/Services/LogDB/LogDB.py
+++ b/src/python/WMCore/Services/LogDB/LogDB.py
@@ -9,7 +9,7 @@ import logging
 import re
 import threading
 from collections import defaultdict
-from httplib import HTTPException
+from http.client import HTTPException
 
 from WMCore.Lexicon import splitCouchServiceURL
 # project modules

--- a/src/python/WMCore/Services/Requests.py
+++ b/src/python/WMCore/Services/Requests.py
@@ -11,7 +11,7 @@ The response from the remote server is cached if expires/etags are set.
 from __future__ import division, print_function
 
 import base64
-import cStringIO as StringIO
+from io import StringIO
 import logging
 import os
 import shutil
@@ -32,7 +32,7 @@ try:
 except ImportError:
     # PY3
     from urllib.parse import urlparse
-from httplib import HTTPException
+from http.client import HTTPException
 from json import JSONEncoder, JSONDecoder
 
 from Utils.CertTools import getKeyCertFromEnv, getCAPathFromEnv
@@ -475,8 +475,8 @@ class Requests(dict):
         fullParams = [(fieldName, (c.FORM_FILE, fileName))]
         fullParams.extend(params)
         c.setopt(c.HTTPPOST, fullParams)
-        bbuf = StringIO.StringIO()
-        hbuf = StringIO.StringIO()
+        bbuf = StringIO()
+        hbuf = StringIO()
         c.setopt(pycurl.WRITEFUNCTION, bbuf.write)
         c.setopt(pycurl.HEADERFUNCTION, hbuf.write)
         if capath:
@@ -513,7 +513,7 @@ class Requests(dict):
         capath = self.getCAPath()
         import pycurl
 
-        hbuf = StringIO.StringIO()
+        hbuf = StringIO()
 
         with open(fileName, "wb") as fp:
             curl = pycurl.Curl()

--- a/src/python/WMCore/Services/Service.py
+++ b/src/python/WMCore/Services/Service.py
@@ -53,8 +53,8 @@ import json
 import logging
 import os
 import time
-from cStringIO import StringIO
-from httplib import HTTPException
+from io import StringIO
+from http.client import HTTPException
 
 from WMCore.Services.Requests import Requests, JSONRequests
 from WMCore.WMException import WMException

--- a/src/python/WMCore/Services/TagCollector/XMLUtils.py
+++ b/src/python/WMCore/Services/TagCollector/XMLUtils.py
@@ -9,7 +9,7 @@ Description: Set of utilities for RequestManager code
 
 from __future__ import (division, print_function)
 
-import cStringIO as StringIO
+from io import StringIO
 import re
 import xml.etree.cElementTree as ET
 
@@ -39,7 +39,7 @@ def adjust_value(value):
 def xml_parser(data, prim_key):
     "Generic XML parser"
     if isinstance(data, basestring):
-        stream = StringIO.StringIO()
+        stream = io.StringIO()
         stream.write(data)
         stream.seek(0)
     else:

--- a/src/python/WMCore/Services/pycurl_manager.py
+++ b/src/python/WMCore/Services/pycurl_manager.py
@@ -38,8 +38,8 @@ for row in data:
 """
 from __future__ import print_function
 
-import cStringIO as StringIO
-import httplib
+from io import StringIO
+import http.client as httplib
 import json
 import logging
 import os
@@ -199,8 +199,8 @@ class RequestHandler(object):
         if headers:
             curl.setopt(pycurl.HTTPHEADER, \
                         ["%s: %s" % (k, v) for k, v in headers.items()])
-        bbuf = StringIO.StringIO()
-        hbuf = StringIO.StringIO()
+        bbuf = StringIO()
+        hbuf = StringIO()
         curl.setopt(pycurl.WRITEFUNCTION, bbuf.write)
         curl.setopt(pycurl.HEADERFUNCTION, hbuf.write)
         if capath:
@@ -421,8 +421,8 @@ def getdata(urls, ckey, cert, headers=None, options=None, num_conn=100, cookie=N
                 bbuf = io.BytesIO()
                 hbuf = io.BytesIO()
             else:
-                bbuf = StringIO.StringIO()
-                hbuf = StringIO.StringIO()
+                bbuf = StringIO()
+                hbuf = StringIO()
             curl.setopt(pycurl.WRITEFUNCTION, bbuf.write)
             curl.setopt(pycurl.HEADERFUNCTION, hbuf.write)
             mcurl.add_handle(curl)

--- a/src/python/WMCore/WMException.py
+++ b/src/python/WMCore/WMException.py
@@ -6,7 +6,11 @@ General Exception class for WM modules
 
 """
 
-import exceptions
+try:
+    import exceptions
+except ImportError:
+    import builtins as exceptions
+
 import inspect
 import logging
 import sys

--- a/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
@@ -11,7 +11,7 @@ import logging
 import os
 import sys
 import urllib2
-from cStringIO import StringIO
+from io import StringIO
 from functools import reduce
 from gzip import GzipFile
 from hashlib import md5

--- a/src/python/WMQuality/WebTools/RESTClientAPI.py
+++ b/src/python/WMQuality/WebTools/RESTClientAPI.py
@@ -1,7 +1,7 @@
 import hashlib
 import hmac
 import urllib
-from httplib import HTTPConnection
+from http.client import HTTPConnection
 
 try:
     from urlparse import urlparse


### PR DESCRIPTION
Fixes #
(no issue created yet)

#### Status
In development

#### Description
Make some imports compatible between python2 and python3, such as:
* httplib --> http.client
* StringIO --> io.StringIO

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
