### PR TITLE
[py2py3] futurize on WMCore/src/python/PSetTweaks

### DIFF
--- a/src/python/PSetTweaks/PSetTweak.py
+++ b/src/python/PSetTweaks/PSetTweak.py
@@ -7,14 +7,19 @@ independent python structure
 
 """
 
+from future import standard_library
+standard_library.install_aliases()
+
+from builtins import object, map, range
+from past.builtins import basestring
+from future.utils import viewitems, viewvalues
+
 import imp
 import inspect
 import json
 import pickle
 import sys
 from functools import reduce
-from io import BytesIO
-
 
 class PSetHolder(object):
     """
@@ -31,7 +36,7 @@ class PSetHolder(object):
 #  //
 # // Assistant lambda functions
 #//
-childPSets = lambda x: [ value for value in x.__dict__.values()
+childPSets = lambda x: [ value for value in viewvalues(x.__dict__)
                          if value.__class__.__name__ == "PSetHolder" ]
 childParameters = lambda p, x: [ "%s.%s" % (p,i) for i in  x.parameters_ ]
 
@@ -61,7 +66,7 @@ def psetIterator(obj):
 
 
 
-class PSetLister:
+class PSetLister(object):
     """
     _PSetLister_
 
@@ -92,7 +97,7 @@ class PSetLister:
         self.queue.pop(-1)
 
 
-class JSONiser:
+class JSONiser(object):
     """
     _JSONiser_
 
@@ -139,7 +144,7 @@ class JSONiser:
         queue = ".".join(self.queue)
         for param in params:
             self.parameters["%s.%s" % (queue, param)]  = dictionary[param]
-        for key, value in dictionary.items():
+        for key, value in viewitems(dictionary):
             if isinstance(value, dict):
                 self.queue.append(key)
                 self.dejson(dictionary[key])
@@ -152,7 +157,7 @@ class JSONiser:
 
 
 
-class PSetTweak:
+class PSetTweak(object):
     """
     _PSetTweak_
 
@@ -394,9 +399,9 @@ class PSetTweak:
 
 
             jsoniser = JSONiser()
-            jsoniser.dejson(json.load(BytesIO(jsonContent)))
+            jsoniser.dejson(json.loads(jsonContent))
 
-            for param, value in jsoniser.parameters.items():
+            for param, value in viewitems(jsoniser.parameters):
                 self.addParameter(param , value)
 
 
@@ -411,6 +416,6 @@ def makeTweakFromJSON(jsonDictionary):
     jsoniser = JSONiser()
     jsoniser.dejson(jsonDictionary)
     tweak = PSetTweak()
-    for param, value in jsoniser.parameters.items():
+    for param, value in viewitems(jsoniser.parameters):
         tweak.addParameter(param , value)
     return tweak

--- a/src/python/PSetTweaks/WMTweak.py
+++ b/src/python/PSetTweaks/WMTweak.py
@@ -7,7 +7,10 @@ Note: This can be used within the CMSSW environment to act on a
 process/config but does not depend on any CMSSW libraries. It needs to stay like this.
 
 """
-from __future__ import print_function
+from __future__ import print_function, division
+
+from builtins import map, range, str, object
+from future.utils import viewitems, viewkeys
 
 import logging
 import os
@@ -119,7 +122,7 @@ def lfnGroup(job):
     default both to 0. The result will be a 5-digit string.
     """
     modifier = str(job.get("agentNumber", 0))
-    jobLfnGroup = modifier + str(job.get("counter", 0) / 1000).zfill(4)
+    jobLfnGroup = modifier + str(job.get("counter", 0) // 1000).zfill(4)
     return jobLfnGroup
 
 
@@ -213,7 +216,7 @@ def expandParameter(process, param):
         pset = params.pop(0)
         if pset == "*":
             newResults = {}
-            for lastResultKey, lastResultVal in lastResults.items():
+            for lastResultKey, lastResultVal in viewitems(lastResults):
                 for param in listParams(lastResultVal):
                     newResultKey = "%s.%s" % (lastResultKey, param)
                     newResultVal = getattr(lastResultVal, param)
@@ -227,7 +230,7 @@ def expandParameter(process, param):
 
         else:
             newResults = {}
-            for lastResultKey, lastResultVal in lastResults.items():
+            for lastResultKey, lastResultVal in viewitems(lastResults):
                 newResultKey = "%s.%s" % (lastResultKey, pset)
                 newResultVal = getattr(lastResultVal, pset, None)
                 if not hasattr(newResultVal, "parameters_"):
@@ -265,7 +268,7 @@ class TweakMaker(object):
         # handle process parameters
         processParams = []
         for param in self.processLevel:
-            processParams.extend(expandParameter(process, param).keys())
+            processParams.extend(viewkeys(expandParameter(process, param)))
 
         for param in processParams:
             if hasParameter(process, param):
@@ -474,7 +477,7 @@ def makeJobTweak(job):
 
     runs = mask.getRunAndLumis()
     lumisToProcess = []
-    for run in runs.keys():
+    for run in viewkeys(runs):
         lumiPairs = runs[run]
         for lumiPair in lumiPairs:
             if len(lumiPair) != 2:
@@ -492,7 +495,7 @@ def makeJobTweak(job):
         return result
 
     baggageParams = decomposeConfigSection(procSection)
-    for k, v in baggageParams.items():
+    for k, v in viewitems(baggageParams):
         result.addParameter(k, v)
 
     return result


### PR DESCRIPTION
Fixes #9739 

#### Status
ready

#### Description
Run futurize on the modules in the PSetTweaks package

The log of the commands and tests run is available at https://cms-dmwm-test.docs.cern.ch/py2py3/porting_log/001_9740_psettweaks/

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
It will be necessary to run the unit test in a python3 environment, too
