### PR TITLE
Print WQ queue url when fetching available elements; break long line down

### DIFF
--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -999,7 +999,8 @@ class WorkQueue(WorkQueueBase):
         msg = 'Finished elements: %s\nCanceled workflows: %s' % (', '.join(["%s (%s)" % (x.id, x['RequestName']) \
                                                                             for x in finished_elements]),
                                                                  ', '.join(wf_to_cancel))
-        self.logger.info(msg)
+
+        self.logger.debug(msg)
         self.backend.recordTaskActivity('housekeeping', msg)
 
     def performQueueCleanupActions(self, skipWMBS=False):


### PR DESCRIPTION
Fixes #9741 

#### Status
not-tested

#### Description
First, break that `siteJobCounts` into many lines, one for each site.
Second, always print the queueUrl because WorkQueueManager runs multiple threads, and it gets confusing to know whether logs are talking about LQ or parent queue.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Complement to #9679

#### External dependencies / deployment changes
none
