### PR TITLE
Change how run number is defined for harvested root files in multiRun mode

### DIFF
--- a/src/python/WMCore/JobSplitting/Harvest.py
+++ b/src/python/WMCore/JobSplitting/Harvest.py
@@ -173,12 +173,15 @@ class Harvest(JobFactory):
             self.currentJob.addBaggageParameter("runIsComplete", True)
         self.mergeLumiRange(self.currentJob['mask']['runAndLumis'])
 
-        # now calculate the minimum and maximum run number, it has to go to the root name
-        minRun = min(self.currentJob['mask']['runAndLumis'].keys())
-        maxRun = max(self.currentJob['mask']['runAndLumis'].keys())
+        # assume run_number 1 is MC (might - one day - no longer work)
+        if set(self.currentJob['mask']['runAndLumis'].keys()) == {1}:
+            forceRunNumber = 1
+        else:
+            # then it's data harvesting, force run number in runtime
+            forceRunNumber = 999999
 
         self.currentJob.addBaggageParameter("multiRun", True)
-        self.currentJob.addBaggageParameter("runLimits", "-%s-%s" % (minRun, maxRun))
+        self.currentJob.addBaggageParameter("forceRunNumber", forceRunNumber)
 
         return
 

--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -538,22 +538,18 @@ class SetupCMSSWPset(ScriptInterface):
 
         runIsComplete = getattr(self.jobBag, "runIsComplete", False)
         multiRun = getattr(self.jobBag, "multiRun", False)
-        runLimits = getattr(self.jobBag, "runLimits", "")
-        self.logger.info("DQMFileSaver set to multiRun: %s, runIsComplete: %s, runLimits: %s",
-                         multiRun, runIsComplete, runLimits)
+        forceRunNumber = getattr(self.jobBag, "forceRunNumber", False)
+        self.logger.info("DQMFileSaver set to multiRun: %s, runIsComplete: %s, forceRunNumber: %s",
+                         multiRun, runIsComplete, forceRunNumber)
 
         self.process.dqmSaver.runIsComplete = cms.untracked.bool(runIsComplete)
         if multiRun and isCMSSWSupported(self.getCmsswVersion(), "CMSSW_8_0_0"):
-            self.process.dqmSaver.forceRunNumber = cms.untracked.int32(999999)
+            if forceRunNumber:
+                self.process.dqmSaver.forceRunNumber = cms.untracked.int32(forceRunNumber)
         if hasattr(self.step.data.application.configuration, "pickledarguments"):
             args = pickle.loads(self.step.data.application.configuration.pickledarguments)
             datasetName = args.get('datasetName', None)
             if datasetName:
-                if multiRun:
-                    # then change the dataset name in order to get a different root file name
-                    datasetName = datasetName.rsplit('/', 1)
-                    datasetName[0] += runLimits
-                    datasetName = "/".join(datasetName)
                 self.process.dqmSaver.workflow = cms.untracked.string(datasetName)
         return
 

--- a/test/python/WMCore_t/JobSplitting_t/Harvest_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/Harvest_t.py
@@ -473,7 +473,7 @@ class HarvestTest(unittest.TestCase):
             for job in jobGroup.jobs:
                 baggage = job.getBaggage()
                 self.assertTrue(getattr(baggage, "multiRun", False), "It's supposed to be a multiRun job")
-                self.assertEqual(getattr(baggage, "runLimits", ""), "-1-6")
+                self.assertEqual(getattr(baggage, "forceRunNumber", False), 999999)
 
     def testByRunHarvesting(self):
         """


### PR DESCRIPTION
Fixes #9690 

#### Status
not-tested

#### Description
In short:
* if harvesting MC data (be it in byRun or multiRun mode): run number is set to 1
* if harvesting data in byRun mode, apply no change to the run number: so it takes it from the data harvested
* if harvesting data in multiRun mode, force run to be 999999 

#### Is it backward compatible (if not, which system it affects?)
no, it cannot be applied to workflows with harvesting jobs already created

#### Related PRs
none

#### External dependencies / deployment changes
none
