### PR TITLE
Fix RequestPriority update during assignment

### DIFF
--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -411,7 +411,7 @@ class WMWorkloadHelper(PersistencyHelper):
     def priority(self):
         """
         _priority_
-        return priorty of workload
+        return priority of workload
         """
         return self.data.request.priority
 
@@ -1908,6 +1908,12 @@ class WMWorkloadHelper(PersistencyHelper):
         specClass = loadSpecClassByType(self.getRequestType())
         argumentDefinition = specClass.getWorkloadAssignArgs()
         setAssignArgumentsWithDefault(kwargs, argumentDefinition)
+
+        if kwargs.get('RequestPriority') is not None and kwargs['RequestPriority'] != self.priority():
+            self.setPriority(kwargs['RequestPriority'])
+        else:
+            # if it's the same, pop it out to avoid priority transition update
+            kwargs.pop("RequestPriority", None)
 
         self.setWorkloadOverrides(kwargs["Override"])
         self.setSiteWhitelist(kwargs["SiteWhitelist"])

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
@@ -700,6 +700,7 @@ class StepChainTests(EmulatedUnitTestCase):
                             'NonCustodialSubType': 'Move',
                             'Priority': 'High'}
         assignDict = {"SiteWhitelist": ["T2_US_Nebraska", "T2_IT_Rome"], "Team": "The-A-Team",
+                      "RequestStatus": "assigned", "RequestPriority": 111,
                       "CustodialSites": subscriptionInfo['CustodialSites'],
                       "NonCustodialSites": subscriptionInfo['NonCustodialSites'],
                       "AutoApproveSubscriptionSites": subscriptionInfo['AutoApproveSites'],
@@ -722,8 +723,14 @@ class StepChainTests(EmulatedUnitTestCase):
         factory = StepChainWorkloadFactory()
         testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
 
+        # test default request priority
+        self.assertEqual(testWorkload.priority(), 8000)
+
         # and assign it
         testWorkload.updateArguments(assignDict)
+
+        # test new priority in the spec
+        self.assertEqual(testWorkload.priority(), assignDict["RequestPriority"])
 
         outputDsets = testWorkload.listOutputDatasets()
         self.assertEqual(len(outputDsets), 4)


### PR DESCRIPTION
Fixes #9743 

#### Status
tested

#### Description
We were missing the priority spec update when assigning a workflow. Only update it if it has been provided and if priority is different than the current one.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
