### PR TITLE
Properly handle exceptions inside docTransformer for MSOutput Producer thread.

### DIFF
--- a/src/python/WMCore/MicroService/DataStructs/MSOutputTemplate.py
+++ b/src/python/WMCore/MicroService/DataStructs/MSOutputTemplate.py
@@ -258,7 +258,7 @@ class MSOutputTemplate(dict):
 
         campOutputMap = {}
         finalMap = []
-        if reqDoc["RequestType"] in ["StepChain", "TaskChain"]:
+        if reqDoc["RequestType"] in ["StepChain", "TaskChain"] and "ChainParentageMap" in reqDoc:
             for key in reqDoc["ChainParentageMap"]:
                 # key is Step1, Step2 or Task1, Task2, etc
                 # use the Task/Step level campaign, fallback to the top level one
@@ -272,7 +272,7 @@ class MSOutputTemplate(dict):
             for campName, dsetList in campOutputMap.items():
                 finalMap.append(dict(campaignName=campName, datasets=dsetList))
         else:
-            # ReReco and StoreResults
+            # ReReco and StoreResults (or very old - <=2018 - non-archived workflows)
             finalMap.append(dict(campaignName=reqDoc["Campaign"], datasets=reqDoc["OutputDatasets"]))
 
         # finally, update this object

--- a/src/python/WMCore/MicroService/Unified/MSOutput.py
+++ b/src/python/WMCore/MicroService/Unified/MSOutput.py
@@ -619,9 +619,10 @@ class MSOutput(MSCore):
             msOutDoc = MSOutputTemplate(doc)
             doc.clear()
         except Exception as ex:
-            msg = "ERR: Unable to create MSOutputTemplate for document %s" % pformat(doc)
+            msg = "ERR: Unable to create MSOutputTemplate for document: \n%s\n" % pformat(doc)
             msg += "ERR: %s" % str(ex)
-            self.logger.error(msg)
+            self.logger.exception(msg)
+            raise ex
         return msOutDoc
 
     def docDump(self, msOutDoc, pipeLine=None):


### PR DESCRIPTION
Fixes #9749 
Fixes #9726 

#### Status
ready 
(may need further development depending on the review)

#### Description
The full details about the bug which this PR is solving can be found in the Issue resolved. In short:
For some of the workflows in the system, the creation of Campaign Map turns out to be not that trivial (if at all possible), so we should protect the MSOutput Producer thread from failing because of those workflows.
   
One of the commits in this PR is addressing only the issue regarding not interrupting the whole cycle of the Producer thread. 

The second commit is related on How to treat those types of workflows inside the `_setCampMap` method - it is a follow up on the discussion that we already had.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
NO

#### External dependencies / deployment changes
NO
