### PR TITLE
MSOutput: handle very old StepChain/TaskChain workflows with diff schema

### DIFF
--- a/src/python/WMCore/MicroService/DataStructs/MSOutputTemplate.py
+++ b/src/python/WMCore/MicroService/DataStructs/MSOutputTemplate.py
@@ -258,7 +258,7 @@ class MSOutputTemplate(dict):
 
         campOutputMap = {}
         finalMap = []
-        if reqDoc["RequestType"] in ["StepChain", "TaskChain"]:
+        if reqDoc["RequestType"] in ["StepChain", "TaskChain"] and "ChainParentageMap" in reqDoc:
             for key in reqDoc["ChainParentageMap"]:
                 # key is Step1, Step2 or Task1, Task2, etc
                 # use the Task/Step level campaign, fallback to the top level one
@@ -272,7 +272,7 @@ class MSOutputTemplate(dict):
             for campName, dsetList in campOutputMap.items():
                 finalMap.append(dict(campaignName=campName, datasets=dsetList))
         else:
-            # ReReco and StoreResults
+            # ReReco and StoreResults (or very old - <=2018 - non-archived workflows)
             finalMap.append(dict(campaignName=reqDoc["Campaign"], datasets=reqDoc["OutputDatasets"]))
 
         # finally, update this object


### PR DESCRIPTION
Fixes #9726 

#### Status
not-tested

#### Description
The `ChainParentageMap` attribute was introduced in the system a few years ago (2017/2018), which means that, if we haven't yet archived all of those, MSOutput service would fail to parse that map.
This PR adds a protection against that and simply uses the top level `Campaign` attribute of the workflow.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Todor is making similar changes here: https://github.com/dmwm/WMCore/pull/9750

#### External dependencies / deployment changes
none
