### PR TITLE
Only fail cleanup jobs if they fail to delete all input files

### DIFF
--- a/src/python/WMCore/Storage/DeleteMgr.py
+++ b/src/python/WMCore/Storage/DeleteMgr.py
@@ -10,13 +10,15 @@ Based on StageOutMgr class
 from __future__ import print_function
 
 import logging
-#from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig
 
-#do we want seperate exceptions - for the moment no
+from WMCore.Storage.Registry import retrieveStageOutImpl
+# do we want seperate exceptions - for the moment no
 from WMCore.Storage.StageOutError import StageOutFailure
 from WMCore.Storage.StageOutError import StageOutInitError
-from WMCore.Storage.Registry import retrieveStageOutImpl
 from WMCore.WMException import WMException
+
+
+# from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig
 
 
 class DeleteMgrError(WMException):
@@ -25,6 +27,7 @@ class DeleteMgrError(WMException):
 
     Specific exception class to work out file deletion exception details
     """
+
     def __init__(self, message, **data):
         WMException.__init__(self, message, **data)
         self.data.setdefault("ErrorCode", 60313)
@@ -39,6 +42,7 @@ class DeleteMgr:
     using TFC or an override.
 
     """
+
     def __init__(self, **overrideParams):
         self.override = False
         self.logger = overrideParams.pop("logger", logging.getLogger())
@@ -48,21 +52,19 @@ class DeleteMgr:
 
         #  //
         # // Try an get the TFC for the site
-        #//
+        # //
         self.tfc = None
 
         from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig
 
-
-
         self.numberOfRetries = 3
-        self.retryPauseTime  = 600
-        self.pnn             = None
-        self.fallbacks       = []
+        self.retryPauseTime = 600
+        self.pnn = None
+        self.fallbacks = []
 
         #  //
         # // If override isnt None, we dont need SiteCfg, if it is
-        #//  then we need siteCfg otherwise we are dead.
+        # //  then we need siteCfg otherwise we are dead.
 
         if self.override == False:
             self.siteCfg = loadSiteLocalConfig()
@@ -71,7 +73,6 @@ class DeleteMgr:
             self.initialiseOverride()
         else:
             self.initialiseSiteConf()
-
 
     def initialiseSiteConf(self):
         """
@@ -86,7 +87,7 @@ class DeleteMgr:
             msg = "Unable to retrieve local stage out command\n"
             msg += "From site config file.\n"
             msg += "Unable to perform StageOut operation"
-            raise StageOutInitError( msg)
+            raise StageOutInitError(msg)
         msg = "Local Stage Out Implementation to be used is:"
         msg += "%s\n" % implName
 
@@ -95,14 +96,14 @@ class DeleteMgr:
             msg = "Unable to retrieve local stage out phedex-node\n"
             msg += "From site config file.\n"
             msg += "Unable to perform StageOut operation"
-            raise StageOutInitError( msg)
+            raise StageOutInitError(msg)
         msg += "Local Stage Out PNN to be used is %s\n" % pnn
         catalog = self.siteCfg.localStageOut.get("catalog", None)
         if catalog == None:
             msg = "Unable to retrieve local stage out catalog\n"
             msg += "From site config file.\n"
             msg += "Unable to perform StageOut operation"
-            raise StageOutInitError( msg)
+            raise StageOutInitError(msg)
         msg += "Local Stage Out Catalog to be used is %s\n" % catalog
 
         try:
@@ -113,12 +114,11 @@ class DeleteMgr:
             msg = "Unable to load Trivial File Catalog:\n"
             msg += "Local stage out will not be attempted\n"
             msg += str(ex)
-            raise StageOutInitError( msg )
+            raise StageOutInitError(msg)
 
         self.logger.info(msg)
         self.pnn = pnn
         return
-
 
     def initialiseOverride(self):
         """
@@ -129,11 +129,11 @@ class DeleteMgr:
         """
         overrideConf = self.overrideConf
         overrideParams = {
-            "command" : None,
-            "option" : None,
-            "phedex-node" : None,
-            "lfn-prefix" : None,
-            }
+            "command": None,
+            "option": None,
+            "phedex-node": None,
+            "lfn-prefix": None,
+        }
 
         try:
             overrideParams['command'] = overrideConf['command']
@@ -158,7 +158,6 @@ class DeleteMgr:
         self.pnn = overrideParams['phedex-node']
         return
 
-
     def __call__(self, fileToDelete):
         """
         _operator()_
@@ -175,7 +174,7 @@ class DeleteMgr:
 
         #  //
         # // No override => use local-stage-out from site conf
-        #//  invoke for all files and check failures/successes
+        # //  invoke for all files and check failures/successes
         if not self.override:
             self.logger.info("===> Attempting To Delete.")
             try:
@@ -187,7 +186,7 @@ class DeleteMgr:
         if not deleteSuccess and len(self.fallbacks) > 0:
             #  //
             # // Still here => override start using the fallback stage outs
-            #//  If override is set, then that will be the only fallback available
+            # //  If override is set, then that will be the only fallback available
             self.logger.info("===> Attempting To Delete files with fallback.")
             for fallback in self.fallbacks:
                 if not deleteSuccess:
@@ -209,8 +208,7 @@ class DeleteMgr:
             msg += fileToDelete['LFN']
             raise StageOutFailure(msg, **fileToDelete)
 
-
-    def deleteLFN(self, lfn, override = None):
+    def deleteLFN(self, lfn, override=None):
         """
         deleteLFN
 
@@ -221,29 +219,20 @@ class DeleteMgr:
         option - the option values to be passed to that command (None is allowed)
         lfn-prefix - the LFN prefix to generate the PFN
         phedex-node - the Name of the PNN to which the file is being xferred
-
-
         """
 
         if override:
-            pnn = override['phedex-node']
             command = override['command']
-            options = override['option']
             pfn = "%s%s" % (override['lfn-prefix'], lfn)
-            protocol = command
         else:
-            pnn = self.siteCfg.localStageOut['phedex-node']
             command = self.siteCfg.localStageOut['command']
-            options = self.siteCfg.localStageOut.get('option', None)
             pfn = self.searchTFC(lfn)
-            protocol = self.tfc.preferredProtocol
 
         if pfn == None:
             msg = "Unable to match lfn to pfn: \n  %s" % lfn
-            raise StageOutFailure(msg, LFN = lfn, TFC = str(self.tfc))
+            raise StageOutFailure(msg, LFN=lfn, TFC=str(self.tfc))
 
         return self.deletePFN(pfn, lfn, command)
-
 
     def deletePFN(self, pfn, lfn, command):
         """
@@ -255,8 +244,8 @@ class DeleteMgr:
             msg = "Unable to retrieve impl for file deletion in:\n"
             msg += "Error retrieving StageOutImpl for command named: %s\n" % (
                 command,)
-            raise StageOutFailure(msg, Command = command,
-                                  LFN = lfn, ExceptionDetail = str(ex))
+            raise StageOutFailure(msg, Command=command,
+                                  LFN=lfn, ExceptionDetail=str(ex))
         impl.numRetries = self.numberOfRetries
         impl.retryPause = self.retryPauseTime
 
@@ -269,26 +258,23 @@ class DeleteMgr:
 
         return pfn
 
-#    def reportStageOutFailure(self, stageOutExcep):
-#        """
-#        _reportStageOutFailure_
-#
-#        When a stage out failure occurs, report it to the input
-#        framework job report.
-#
-#        - *stageOutExcep* : Instance of on of the StageOutError derived classes
-#
-#        """
-#        errStatus = stageOutExcep.data["ErrorCode"]
-#        errType = stageOutExcep.data["ErrorType"]
-#        desc = stageOutExcep.message
-#
-#        errReport = self.inputReport.addError(errStatus, errType)
-#        errReport['Description'] = desc
-#        return
-
-
-
+    #    def reportStageOutFailure(self, stageOutExcep):
+    #        """
+    #        _reportStageOutFailure_
+    #
+    #        When a stage out failure occurs, report it to the input
+    #        framework job report.
+    #
+    #        - *stageOutExcep* : Instance of on of the StageOutError derived classes
+    #
+    #        """
+    #        errStatus = stageOutExcep.data["ErrorCode"]
+    #        errType = stageOutExcep.data["ErrorType"]
+    #        desc = stageOutExcep.message
+    #
+    #        errReport = self.inputReport.addError(errStatus, errType)
+    #        errReport['Description'] = desc
+    #        return
 
     def searchTFC(self, lfn):
         """
@@ -320,8 +306,6 @@ class DeleteMgr:
         msg += "LFN: %s\nPFN: %s\n" % (lfn, pfn)
         self.logger.info(msg)
         return pfn
-
-
 
 ##if __name__ == '__main__':
 ##    import StageOut.Impl

--- a/src/python/WMCore/WMExceptions.py
+++ b/src/python/WMCore/WMExceptions.py
@@ -163,6 +163,7 @@ WM_JOB_ERROR_CODES = {-1: "Error return without specification.",
                       60307: "General failure during files stage out.",  # (WMA, CRAB3)
                       60311: "Local Stage Out Failure using site specific plugin.",  # (WMA, CRAB3)
                       60312: "Failure in staging in log files during log collection (WMAgent).",  # (WMA)
+                      60313: "Failed to clean up any files that were no longer needed (WMAgent).",  # (WMA)
                       60315: "StageOut initialisation error (Due to TFC, SITECONF etc).",  # (WMA)
                       60317: "Forced timeout for stuck stage out.",  # (To be used in CRAB3/ASO)
                       60318: "Internal error in Crab cmscp.py stageout script.",  # (CRAB3)

--- a/src/python/WMCore/WMSpec/Steps/Executor.py
+++ b/src/python/WMCore/WMSpec/Steps/Executor.py
@@ -8,20 +8,21 @@ Interface definition for a step executor
 """
 from __future__ import absolute_import
 
-import os
-import sys
 import json
-import subprocess
 import logging
+import os
+import subprocess
+import sys
 
 from Utils.FileTools import getFullPath
 from Utils.Utilities import zipEncodeStr
 from WMCore.FwkJobReport.Report import Report
-from WMCore.WMSpec.WMStep import WMStepHelper
 from WMCore.WMSpec.Steps.StepFactory import getStepEmulator
+from WMCore.WMSpec.WMStep import WMStepHelper
 
 getStepName = lambda step: WMStepHelper(step).name()
 getStepErrorDestination = lambda step: WMStepHelper(step).getErrorDestinationStep()
+
 
 def getStepSpace(stepName):
     """
@@ -37,13 +38,13 @@ def getStepSpace(stepName):
         taskspace = sys.modules[modName]
     else:
         try:
-            #taskspace = __import__(modName, globals(), locals(), ['taskSpace'], -1)
+            # taskspace = __import__(modName, globals(), locals(), ['taskSpace'], -1)
             taskspace = __import__(modName, globals(), locals(), ['taskSpace'])
 
         except ImportError as ex:
             msg = "Unable to load WMTaskSpace module:\n"
             msg += str(ex)
-            #TODO: Generic ExecutionException...
+            # TODO: Generic ExecutionException...
             raise RuntimeError(msg)
 
     try:
@@ -62,7 +63,6 @@ class Executor(object):
     Define API for a step during execution
 
     """
-
 
     def __init__(self):
         self.report = None
@@ -103,14 +103,14 @@ class Executor(object):
         self.step.execution.exitStatus = 0
         self.step.execution.reportLocation = "%s/Report.pkl" % (
             self.stepSpace.location,
-            )
+        )
 
         # Set overall step status to 1 (failed)
         self.report.setStepStatus(stepName=self.stepName, status=1)
 
         #  //
         # //  Does the step contain settings for an emulator?
-        #//   If so, load it up
+        # //   If so, load it up
 
         emulatorName = getattr(self.step.emulator, "emulatorName", None)
         if emulatorName != None:
@@ -119,7 +119,6 @@ class Executor(object):
             self.emulationMode = True
 
         return
-
 
     def saveReport(self):
         """
@@ -130,7 +129,6 @@ class Executor(object):
         """
         self.report.persist(self.step.execution.reportLocation)
         return
-
 
     def pre(self, emulator=None):
         """
@@ -145,7 +143,6 @@ class Executor(object):
         """
         return None
 
-
     def execute(self, emulator=None):
         """
         _execute_
@@ -158,7 +155,6 @@ class Executor(object):
         msg = "WMSpec.Steps.Executor.execute method not overridden in "
         msg += "implementation: %s\n" % self.__class__.__name__
         raise NotImplementedError(msg)
-
 
     def post(self, emulator=None):
         """

--- a/src/python/WMCore/WMSpec/Steps/Executor.py
+++ b/src/python/WMCore/WMSpec/Steps/Executor.py
@@ -6,6 +6,7 @@ Interface definition for a step executor
 
 
 """
+from __future__ import absolute_import
 
 import os
 import sys
@@ -75,6 +76,8 @@ class Executor(object):
         self.workload = None
         self.job = None
         self.errorDestination = None
+        self.logger = logging.getLogger()
+        self.logger.info("Steps.Executor logging started")
 
     def initialise(self, step, job):
         """
@@ -201,6 +204,6 @@ class Executor(object):
                 msg = 'condor_chirp was found in: %s, but it was not an executable.' % condor_chirp_bin
             else:
                 msg = 'condor_chirp was not found in the system.'
-            logging.warning(msg)
+            self.logger.warning(msg)
 
         return

--- a/src/python/WMCore/WMSpec/Steps/Executors/DeleteFiles.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/DeleteFiles.py
@@ -12,9 +12,10 @@ import signal
 
 from WMCore.Storage.DeleteMgr import DeleteMgr, DeleteMgrError
 from WMCore.Storage.FileManager import DeleteMgr as NewDeleteMgr
+from WMCore.WMExceptions import WM_JOB_ERROR_CODES
 from WMCore.WMSpec.Steps.Executor import Executor
 from WMCore.WMSpec.Steps.Executors.LogArchive import Alarm, alarmHandler
-from WMCore.WMExceptions import WM_JOB_ERROR_CODES
+
 
 class DeleteFiles(Executor):
     """


### PR DESCRIPTION
Fixes #9753 

#### Status
tested

#### Description
In general, it provides a better logging for Cleanup jobs and the file deletions carried out by such jobs. Other specific changes are:
* don't crash the job in the first file that hits an exception, instead keep going with the file deletions and succeed the job if at least 1 file managed to get deleted;
* timeout file deletion command at 5min (instead of the previous 15min);
* created a specific exception `DeleteMgrError` for cases where the cleanup job fails to delete all the input files.
* new exit code / error message `60313`
* replaced print statements by the logging library (can be inherited by any other class created from the Executor module)

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
