### PR TITLE
[py2py3] Applied both futurize stage2 fixers related to supporting python3 stdlib only

### DIFF
--- a/bin/adhoc-scripts/setrequeststatus.py
+++ b/bin/adhoc-scripts/setrequeststatus.py
@@ -4,7 +4,9 @@ This script can be used to update the status of a request in ReqMgr2.
 """
 from __future__ import print_function, division
 
-import httplib
+from future import standard_library
+standard_library.install_aliases()
+import http.client
 import json
 import os
 import sys
@@ -20,7 +22,7 @@ def setStatus(url, workflow, newstatus):
     else:
         encodedParams = json.dumps({"RequestStatus": newstatus})
 
-    conn = httplib.HTTPSConnection(url, cert_file=os.getenv('X509_USER_PROXY'), key_file=os.getenv('X509_USER_PROXY'))
+    conn = http.client.HTTPSConnection(url, cert_file=os.getenv('X509_USER_PROXY'), key_file=os.getenv('X509_USER_PROXY'))
     conn.request("PUT", "/reqmgr2/data/request/%s" % workflow, encodedParams, headers)
     resp = conn.getresponse()
     if resp.status != 200:
@@ -37,7 +39,7 @@ def getStatus(url, workflow):
     headers = {"Content-type": "application/json",
                "Accept": "application/json"}
 
-    conn = httplib.HTTPSConnection(url, cert_file=os.getenv('X509_USER_PROXY'), key_file=os.getenv('X509_USER_PROXY'))
+    conn = http.client.HTTPSConnection(url, cert_file=os.getenv('X509_USER_PROXY'), key_file=os.getenv('X509_USER_PROXY'))
     urn = "/reqmgr2/data/request/%s" % workflow
     conn.request("GET", urn, headers=headers)
     res = conn.getresponse()

--- a/bin/adhoc-scripts/summaryWMStatsFailures.py
+++ b/bin/adhoc-scripts/summaryWMStatsFailures.py
@@ -6,7 +6,9 @@ per task
 """
 from __future__ import print_function, division
 
-import httplib
+from future import standard_library
+standard_library.install_aliases()
+import http.client
 import json
 import os
 import sys
@@ -16,7 +18,7 @@ from pprint import pformat
 def getWMStatsData(workflow):
     url = 'cmsweb.cern.ch'
     headers = {"Accept": "application/json", "Content-type": "application/json"}
-    conn = httplib.HTTPSConnection(url, cert_file=os.getenv('X509_USER_PROXY'), key_file=os.getenv('X509_USER_PROXY'))
+    conn = http.client.HTTPSConnection(url, cert_file=os.getenv('X509_USER_PROXY'), key_file=os.getenv('X509_USER_PROXY'))
     urn = "/wmstatsserver/data/request/%s" % workflow
     conn.request("GET", urn, headers=headers)
     r2 = conn.getresponse()

--- a/bin/adhoc-scripts/workflowCompletion.py
+++ b/bin/adhoc-scripts/workflowCompletion.py
@@ -5,27 +5,28 @@ completion, so the ration of input lumis vs output lumis.
 """
 from __future__ import print_function, division
 
+from future import standard_library
+standard_library.install_aliases()
 import argparse
-import httplib
+import http.client
 import json
 import os
 import pwd
 import sys
-import urllib
-import urllib2
-from urllib2 import HTTPError, URLError
+import urllib.request, urllib.parse
+from urllib.error import HTTPError, URLError
 
 # ID for the User-Agent
 CLIENT_ID = 'workflowCompletion::python/%s.%s' % sys.version_info[:2]
 
 
-class HTTPSClientAuthHandler(urllib2.HTTPSHandler):
+class HTTPSClientAuthHandler(urllib.request.HTTPSHandler):
     """
     Basic HTTPS class
     """
 
     def __init__(self, key, cert):
-        urllib2.HTTPSHandler.__init__(self)
+        urllib.request.HTTPSHandler.__init__(self)
         self.key = key
         self.cert = cert
 
@@ -36,7 +37,7 @@ class HTTPSClientAuthHandler(urllib2.HTTPSHandler):
         return self.do_open(self.getConnection, req)
 
     def getConnection(self, host, timeout=290):
-        return httplib.HTTPSConnection(host, key_file=self.key, cert_file=self.cert)
+        return http.client.HTTPSConnection(host, key_file=self.key, cert_file=self.cert)
 
 
 def getX509():
@@ -53,7 +54,7 @@ def getContent(url, params=None):
     cert = getX509()
     client = '%s (%s)' % (CLIENT_ID, os.environ.get('USER', ''))
     handler = HTTPSClientAuthHandler(cert, cert)
-    opener = urllib2.build_opener(handler)
+    opener = urllib.request.build_opener(handler)
     opener.addheaders = [("User-Agent", client),
                          ("Accept", "application/json")]
     try:
@@ -107,7 +108,7 @@ def handleDBS(reqmgrOutDsets, cmswebUrl):
 
     dbsOutput = {}
     for dataset in reqmgrOutDsets:
-        fullUrl = dbsUrl + "filesummaries?" + urllib.urlencode({'dataset': dataset})
+        fullUrl = dbsUrl + "filesummaries?" + urllib.parse.urlencode({'dataset': dataset})
         data = json.loads(getContent(fullUrl))
         if data:
             dbsOutput[dataset] = data[0]['num_lumi']

--- a/bin/check-ACDC-parentage
+++ b/bin/check-ACDC-parentage
@@ -1,16 +1,20 @@
 #!/usr/bin/env python
 from __future__ import print_function, division
+from future import standard_library
+standard_library.install_aliases()
+
 import json
 import time
-import httplib
+import http.client
 import os
 
 from pprint import pprint
 from collections import defaultdict
+
 from dbs.apis.dbsClient import DbsApi
 
 def callRESTAPI(restURL, url="cmsweb.cern.ch"):
-    conn = httplib.HTTPSConnection(url, cert_file=os.getenv('X509_USER_CERT'),
+    conn = http.client.HTTPSConnection(url, cert_file=os.getenv('X509_USER_CERT'),
                                  key_file=os.getenv('X509_USER_KEY'))
     conn.request('GET', restURL, headers={"Accept": "application/json"})
     r2 = conn.getresponse()

--- a/bin/createStoreResults.py
+++ b/bin/createStoreResults.py
@@ -21,7 +21,10 @@ Expected input json file like:
 
 from __future__ import print_function, division
 
-import httplib
+from future import standard_library
+standard_library.install_aliases()
+
+import http.client
 import json
 import os
 import sys
@@ -127,7 +130,7 @@ def submitWorkflow(schema):
     headers = {"Content-type": "application/json",
                "Accept": "application/json"}
     encodedParams = json.dumps(schema)
-    conn = httplib.HTTPSConnection(url, cert_file=os.getenv('X509_USER_PROXY'), key_file=os.getenv('X509_USER_PROXY'))
+    conn = http.client.HTTPSConnection(url, cert_file=os.getenv('X509_USER_PROXY'), key_file=os.getenv('X509_USER_PROXY'))
     conn.request("POST", "/reqmgr2/data/request", encodedParams, headers)
     resp = conn.getresponse()
     data = resp.read()
@@ -150,7 +153,7 @@ def approveRequest(workflow):
     headers = {"Content-type": "application/json",
                "Accept": "application/json"}
 
-    conn = httplib.HTTPSConnection(url, cert_file=os.getenv('X509_USER_PROXY'), key_file=os.getenv('X509_USER_PROXY'))
+    conn = http.client.HTTPSConnection(url, cert_file=os.getenv('X509_USER_PROXY'), key_file=os.getenv('X509_USER_PROXY'))
     conn.request("PUT", "/reqmgr2/data/request/%s" % workflow, encodedParams, headers)
     resp = conn.getresponse()
     data = resp.read()

--- a/bin/reqmgr-put-default-config
+++ b/bin/reqmgr-put-default-config
@@ -8,8 +8,10 @@ It's supposed to be called at every ReqMgr2 deployment, such that the splitting,
 permissions, etc are always up-to-date
 """
 from __future__ import print_function, division
+from future import standard_library
+standard_library.install_aliases()
 
-import httplib
+import http.client
 import json
 import os
 import sys
@@ -23,7 +25,7 @@ print("\nPushing DEFAULT configuration into %s ReqMgr Aux DB..." % hostName)
 encodedParams = json.dumps({})
 headers = {"Content-type": "application/json", "Accept": "application/json"}
 
-conn = httplib.HTTPSConnection(hostName,
+conn = http.client.HTTPSConnection(hostName,
                                cert_file=os.getenv('X509_USER_CERT'),
                                key_file=os.getenv('X509_USER_KEY'))
 conn.request("PUT", "/reqmgr2/data/app_config/DEFAULT", encodedParams, headers)

--- a/bin/wmagent-couchapp-init
+++ b/bin/wmagent-couchapp-init
@@ -5,6 +5,9 @@ wmagent-couchapp-init
 """
 from __future__ import print_function, division
 
+from future import standard_library
+standard_library.install_aliases()
+
 import argparse
 import os
 import shutil
@@ -12,11 +15,7 @@ import sys
 import tempfile
 import urllib
 
-try:
-    from urlparse import urlsplit
-except ImportError:
-    # PY3
-    from urllib.parse import urlsplit
+from urllib.parse import urlsplit
 
 from couchapp.commands import push as couchapppush
 from couchapp.config import Config

--- a/bin/wmagent-mod-config
+++ b/bin/wmagent-mod-config
@@ -10,6 +10,8 @@ Note: this script is also used by ASO deployment, see:
 https://github.com/dmwm/deployment/blob/master/asyncstageout/manage#L246
 """
 from __future__ import print_function
+from future import standard_library
+standard_library.install_aliases()
 
 import getopt
 import imp
@@ -17,11 +19,7 @@ import os
 import socket
 import sys
 import traceback
-try:
-    from urlparse import urlparse
-except ImportError:
-    # PY3
-    from urllib.parse import urlparse
+from urllib.parse import urlparse
 
 from WMCore.Configuration import saveConfigurationFile
 from WMCore.Lexicon import splitCouchServiceURL

--- a/src/html/WorkQueue/examples/PlotFairyBarChart.py
+++ b/src/html/WorkQueue/examples/PlotFairyBarChart.py
@@ -10,9 +10,12 @@ from __future__ import print_function
 #     -> this prints out html file, normally resulting html snippet will be used ...
 
 
+from future import standard_library
+standard_library.install_aliases()
+
 import json
 import random
-import urllib
+import urllib.parse
 
 from WMCore.WorkQueue.DataStructs.WorkQueueElement import STATES
 
@@ -54,7 +57,7 @@ plotDefinition = \
     "legend": "right"
 }
 plotDefinition["title"] = "Element status - hard-coded"
-hardCodedPlotData = urllib.quote(json.dumps(plotDefinition, ensure_ascii = True))
+hardCodedPlotData = urllib.parse.quote(json.dumps(plotDefinition, ensure_ascii = True))
 
 
 

--- a/src/html/WorkQueue/examples/PlotFairyLineChart.py
+++ b/src/html/WorkQueue/examples/PlotFairyLineChart.py
@@ -10,9 +10,12 @@ from __future__ import print_function
 #     -> this prints out html file, normally resulting html snippet will be used ...
 
 
+from future import standard_library
+standard_library.install_aliases()
+
 import json
 import random
-import urllib
+import urllib.parse
 
 
 from WMCore.WorkQueue.DataStructs.WorkQueueElement import STATES
@@ -60,7 +63,7 @@ plotDefinition = \
     # how to set y-axis description just a text label?
     "yaxis": {"label": "thousands of jobs", "format": "si"}
 }
-hardCodedPlotData = urllib.quote(json.dumps(plotDefinition, ensure_ascii = True))
+hardCodedPlotData = urllib.parse.quote(json.dumps(plotDefinition, ensure_ascii = True))
 
 
 # TODO

--- a/src/html/WorkQueue/examples/PlotFairyPieChart.py
+++ b/src/html/WorkQueue/examples/PlotFairyPieChart.py
@@ -10,9 +10,12 @@ from __future__ import print_function
 #     -> this prints out html file, normally resulting html snippet will be used ...
 
 
+from future import standard_library
+standard_library.install_aliases()
+
 import json
 import random
-import urllib
+import urllib.parse
 
 from WMCore.WorkQueue.DataStructs.WorkQueueElement import STATES
 from WMQuality.WebTools.RESTClientAPI import makeRequest
@@ -57,7 +60,7 @@ plotDefinition = \
     "sort": "value"
 }
 plotDefinition["title"] = "Element status - hard-coded"
-hardCodedPlotData = urllib.quote(json.dumps(plotDefinition, ensure_ascii = True))
+hardCodedPlotData = urllib.parse.quote(json.dumps(plotDefinition, ensure_ascii = True))
 
 
 
@@ -79,7 +82,7 @@ for s in systemSeries:
 
 plotDefinition["title"] = "Element status - WorkQueue"
 plotDefinition["series"] = systemSeries
-systemData = urllib.quote(json.dumps(plotDefinition, ensure_ascii = True))
+systemData = urllib.parse.quote(json.dumps(plotDefinition, ensure_ascii = True))
 
 
 

--- a/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
@@ -24,7 +24,10 @@ that is not in DBS, decide whether its components are in DBS,
 add them, and then add the files.  This is why everything is
 so convoluted.
 """
-import Queue
+from future import standard_library
+standard_library.install_aliases()
+
+import queue
 import json
 import logging
 import multiprocessing
@@ -742,7 +745,7 @@ class DBSUploadPoller(BaseWorkerThread):
                 blocksToClose.append(blockresult)
                 self.blockCount -= 1
                 logging.debug("Got a block to close")
-            except Queue.Empty:
+            except queue.Empty:
                 # This means the queue has no current results
                 time.sleep(2)
                 emptyCount += 1

--- a/src/python/WMComponent/ErrorHandler/ErrorHandlerPoller.py
+++ b/src/python/WMComponent/ErrorHandler/ErrorHandlerPoller.py
@@ -22,10 +22,13 @@ immediately to the 'created' state, skipping cooloff.  It defaults to [].
 
 Note that exitCodesNoRetry has precedence over passExitCodes.
 """
+from future import standard_library
+standard_library.install_aliases()
+
 import logging
 import os.path
 import threading
-from httplib import HTTPException
+from http.client import HTTPException
 from Utils.Timers import timeFunction
 from Utils.IteratorTools import grouper
 from WMCore.ACDC.DataCollectionService import DataCollectionService

--- a/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
+++ b/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
@@ -41,11 +41,14 @@ deleted from the site it was originally injected at.
 
 """
 
+from future import standard_library
+standard_library.install_aliases()
+
 import logging
 import threading
 import time
 import traceback
-from httplib import HTTPException
+from http.client import HTTPException
 
 from Utils.Timers import timeFunction
 from WMCore.DAOFactory import DAOFactory

--- a/src/python/WMComponent/TaskArchiver/CleanCouchPoller.py
+++ b/src/python/WMComponent/TaskArchiver/CleanCouchPoller.py
@@ -1,7 +1,10 @@
 """
 Perform cleanup actions
 """
-import httplib
+from future import standard_library
+standard_library.install_aliases()
+
+import http.client
 import json
 import logging
 import os.path
@@ -9,7 +12,7 @@ import re
 import shutil
 import threading
 import time
-import urllib2
+import urllib.request
 from contextlib import closing
 from Utils.Timers import timeFunction
 from WMComponent.JobCreator.CreateWorkArea import getMasterName
@@ -955,7 +958,7 @@ class CleanCouchPoller(BaseWorkerThread):
         dqmHost = regExpResult.group(1)
         dqmPath = regExpResult.group(2)
 
-        connection = httplib.HTTPSConnection(dqmHost, 443, hostKey, hostCert)
+        connection = http.client.HTTPSConnection(dqmHost, 443, hostKey, hostCert)
         try:
             connection.request('GET', dqmPath)
             response = connection.getresponse()
@@ -1017,8 +1020,8 @@ class CleanCouchPoller(BaseWorkerThread):
         logging.debug("Going to upload this payload %s", data)
 
         try:
-            request = urllib2.Request(dashBoardUrl, data, headers)
-            with closing(urllib2.urlopen(request)) as response:
+            request = urllib.request.Request(dashBoardUrl, data, headers)
+            with closing(urllib.request.urlopen(request)) as response:
                 if response.code != 200:
                     logging.info("Something went wrong while uploading to DashBoard, response code %d", response.code)
                     return False

--- a/src/python/WMCore/Cache/WMConfigCache.py
+++ b/src/python/WMCore/Cache/WMConfigCache.py
@@ -5,13 +5,15 @@ _WMConfigCache_
 Being in itself a wrapped class around a config cache
 """
 
+from future.utils import with_metaclass
+from future import standard_library
+standard_library.install_aliases()
+
 import hashlib
 import logging
 import traceback
-import urllib
+import urllib.request
 from contextlib import closing
-
-from future.utils import with_metaclass
 
 import WMCore.GroupUser.Decorators as Decorators
 from Utils.Patterns import Singleton
@@ -432,7 +434,7 @@ class ConfigCache(WMObject):
 
         """
         # The newConfig parameter is a URL suitable for passing to urlopen.
-        with closing(urllib.urlopen(newConfig)) as f:
+        with closing(urllib.request.urlopen(newConfig)) as f:
             configString = f.read(-1)
         configMD5 = hashlib.md5(configString).hexdigest()
 

--- a/src/python/WMCore/DataStructs/LumiList.py
+++ b/src/python/WMCore/DataStructs/LumiList.py
@@ -13,11 +13,14 @@ This code began life in COMP/CRAB/python/LumiList.py
 """
 
 
+from future import standard_library
+standard_library.install_aliases()
+
 import copy
 import itertools
 import json
 import re
-import urllib2
+import urllib.request
 from contextlib import closing
 
 class LumiList(object):
@@ -61,7 +64,7 @@ class LumiList(object):
                 self.compactList = json.load(jsonFile)
         elif url:
             self.url = url
-            with closing(urllib2.urlopen(url)) as jsonFile:
+            with closing(urllib.request.urlopen(url)) as jsonFile:
                 self.compactList = json.load(jsonFile)
         elif lumis:
             runsAndLumis = {}

--- a/src/python/WMCore/Database/CMSCouch.py
+++ b/src/python/WMCore/Database/CMSCouch.py
@@ -10,25 +10,28 @@ NOT A THREAD SAFE CLASS.
 """
 from __future__ import print_function, division
 
+from future import standard_library
+standard_library.install_aliases()
+
 import base64
 import hashlib
 import logging
 import re
 import time
 import traceback
-import urllib
+import urllib.parse
 from datetime import datetime
-from httplib import HTTPException
+from http.client import HTTPException
 
 from Utils.IteratorTools import grouper, nestedDictUpdate
 from WMCore.Services.Requests import JSONRequests
 
 
 def check_name(dbname):
-    match = re.match("^[a-z0-9_$()+-/]+$", urllib.unquote_plus(dbname))
+    match = re.match("^[a-z0-9_$()+-/]+$", urllib.parse.unquote_plus(dbname))
     if not match:
         msg = '%s is not a valid database name'
-        raise ValueError(msg % urllib.unquote_plus(dbname))
+        raise ValueError(msg % urllib.parse.unquote_plus(dbname))
 
 
 def check_server_url(srvurl):
@@ -172,7 +175,7 @@ class Database(CouchDBRequests):
         """
         check_name(dbname)
 
-        self.name = urllib.quote_plus(dbname)
+        self.name = urllib.parse.quote_plus(dbname)
 
         CouchDBRequests.__init__(self, url=url, ckey=ckey, cert=cert)
         self._reset_queue()
@@ -302,9 +305,9 @@ class Database(CouchDBRequests):
         on CouchDB revisions for document history is not safe, as any compaction will
         remove the older revisions.
         """
-        uri = '/%s/%s' % (self.name, urllib.quote_plus(id))
+        uri = '/%s/%s' % (self.name, urllib.parse.quote_plus(id))
         if rev:
-            uri += '?' + urllib.urlencode({'rev': rev})
+            uri += '?' + urllib.parse.urlencode({'rev': rev})
         return Document(id=id, inputDict=self.get(uri))
 
     def getPrevisousRevision(self, doc_id, numberBefore=1):
@@ -314,7 +317,7 @@ class Database(CouchDBRequests):
                               special case 0 means the first revision.
         :return: previous revision document specified by numberBefore
         """
-        uri = '/%s/%s?revs=true&open_revs=all' % (self.name, urllib.quote_plus(doc_id))
+        uri = '/%s/%s?revs=true&open_revs=all' % (self.name, urllib.parse.quote_plus(doc_id))
         revisionRecord = self.get(uri)
         rev = revisionRecord[0]['ok']['_revisions']
 
@@ -340,11 +343,11 @@ class Database(CouchDBRequests):
         """
         fields = fields or {}
         # Clean up /'s in the name etc.
-        doc_id = urllib.quote_plus(doc_id)
+        doc_id = urllib.parse.quote_plus(doc_id)
 
         if not useBody:
             updateUri = '/%s/_design/%s/_update/%s/%s?%s' % \
-                        (self.name, design, update_func, doc_id, urllib.urlencode(fields))
+                        (self.name, design, update_func, doc_id, urllib.parse.urlencode(fields))
 
             return self.put(uri=updateUri, decode=False)
         else:
@@ -400,7 +403,7 @@ class Database(CouchDBRequests):
         http://wiki.apache.org/couchdb/Document_Update_Handlers
         """
         # Clean up /'s in the name etc.
-        doc_id = urllib.quote_plus(doc_id)
+        doc_id = urllib.parse.quote_plus(doc_id)
 
         updateUri = '/%s/%s' % (self.name, doc_id)
         return self.put(uri=updateUri, data=fields, decode=False)
@@ -409,9 +412,9 @@ class Database(CouchDBRequests):
         """
         Check if a document exists by ID. If specified check that the revision rev exists.
         """
-        uri = "/%s/%s" % (self.name, urllib.quote_plus(id))
+        uri = "/%s/%s" % (self.name, urllib.parse.quote_plus(id))
         if rev:
-            uri += '?' + urllib.urlencode({'rev': rev})
+            uri += '?' + urllib.parse.urlencode({'rev': rev})
         try:
             self.makeRequest(uri, {}, 'HEAD')
             return True
@@ -422,12 +425,12 @@ class Database(CouchDBRequests):
         """
         Immediately delete a document identified by id and rev.
         """
-        uri = '/%s/%s' % (self.name, urllib.quote_plus(id))
+        uri = '/%s/%s' % (self.name, urllib.parse.quote_plus(id))
         if not rev:
             # then we need to fetch the latest revision number
             doc = self.getDoc(id)
             rev = doc["_rev"]
-        uri += '?' + urllib.urlencode({'rev': rev})
+        uri += '?' + urllib.parse.urlencode({'rev': rev})
         return self.delete(uri)
 
     def compact(self, views=None, blocking=False, blocking_poll=5, callback=False):
@@ -530,7 +533,7 @@ class Database(CouchDBRequests):
 
         if keys:
             if encodedOptions:
-                data = urllib.urlencode(encodedOptions)
+                data = urllib.parse.urlencode(encodedOptions)
                 retval = self.post('/%s/_design/%s/_view/%s?%s' % \
                                    (self.name, design, view, data), {'keys': keys})
             else:
@@ -560,7 +563,7 @@ class Database(CouchDBRequests):
 
         if keys:
             if encodedOptions:
-                data = urllib.urlencode(encodedOptions)
+                data = urllib.parse.urlencode(encodedOptions)
                 retval = self.post('/%s/_design/%s/_list/%s/%s?%s' % \
                                    (self.name, design, list, view, data), {'keys': keys},
                                    decode=False)
@@ -602,7 +605,7 @@ class Database(CouchDBRequests):
 
         if keys:
             if encodedOptions:
-                data = urllib.urlencode(encodedOptions)
+                data = urllib.parse.urlencode(encodedOptions)
                 return self.post('/%s/_all_docs?%s' % (self.name, data),
                                  {'keys': keys})
             else:
@@ -871,7 +874,7 @@ class RotatingDatabase(Database):
         find = {'map': "function(doc) {if(doc.rotate_state == '%s') {emit(doc.timestamp, doc._id);}}" % state}
         uri = '/%s/_temp_view' % self.seed_db.name
         if options:
-            uri += '?%s' % urllib.urlencode(options)
+            uri += '?%s' % urllib.parse.urlencode(options)
         data = self.seed_db.post(uri, find)
         return data['rows']
 
@@ -955,7 +958,7 @@ class CouchServer(CouchDBRequests):
         """
         check_name(dbname)
 
-        self.put("/%s" % urllib.quote_plus(dbname))
+        self.put("/%s" % urllib.parse.quote_plus(dbname))
         # Pass the Database constructor the unquoted name - the constructor will
         # quote it for us.
         return Database(dbname=dbname, url=self.url, size=size, ckey=self.ckey, cert=self.cert)
@@ -963,7 +966,7 @@ class CouchServer(CouchDBRequests):
     def deleteDatabase(self, dbname):
         "Delete a database from the server"
         check_name(dbname)
-        dbname = urllib.quote_plus(dbname)
+        dbname = urllib.parse.quote_plus(dbname)
         return self.delete("/%s" % dbname)
 
     def connectDatabase(self, dbname='database', create=True, size=1000):

--- a/src/python/WMCore/Database/CouchUtils.py
+++ b/src/python/WMCore/Database/CouchUtils.py
@@ -8,8 +8,12 @@ Copyright (c) 2010 Fermilab. All rights reserved.
 """
 from __future__ import print_function
 
+from future import standard_library
+standard_library.install_aliases()
+
+from http.client import HTTPException
+
 import functools
-from httplib import HTTPException
 
 import WMCore.Database.CMSCouch as CMSCouch
 

--- a/src/python/WMCore/Database/ipy_profile_couch.py
+++ b/src/python/WMCore/Database/ipy_profile_couch.py
@@ -7,9 +7,12 @@
 Couch DB command line admin tool
 """
 from __future__ import print_function
+from future import standard_library
+standard_library.install_aliases()
+
+import urllib.parse
 
 __license__ = "GPL"
-
 __maintainer__ = "Valentin Kuznetsov"
 __email__ = "vkuznet@gmail.com"
 __status__ = "Alpha"
@@ -101,8 +104,8 @@ def httplib_request(host, path, params, request='POST', debug=0):
     """request method using provided HTTP request and httplib library"""
     if debug:
         httplib.HTTPConnection.debuglevel = 1
-    if type(params) is not str:
-        params = urllib.urlencode(params, doseq=True)
+    if not isinstance(params, str):
+        params = urllib.parse.urlencode(params, doseq=True)
     if debug:
         print("input parameters", params)
     headers = {"Content-type": "application/x-www-form-urlencoded",
@@ -139,7 +142,7 @@ def print_data(data, lookup="value"):
     padding = ""
     for row in jsondict['rows']:
         values = row[lookup]
-        if type(values) is dict:
+        if isinstance(values, dict):
             if not padding:
                 for key in values.keys():
                     if len(key) > maxl:

--- a/src/python/WMCore/Lexicon.py
+++ b/src/python/WMCore/Lexicon.py
@@ -8,15 +8,15 @@ handled appropriately by the client methods, on success returns True.
 """
 from __future__ import print_function, division
 
+from future import standard_library
+standard_library.install_aliases()
+
 import io
 import logging
 import mmap
 import re
-try:
-    from urlparse import urlparse, urlunparse
-except ImportError:
-    # PY3
-    from urllib.parse import urlparse, urlunparse
+
+from urllib.parse import urlparse, urlunparse
 
 from WMCore.WMException import WMException, WMEXCEPTION_START_STR, WMEXCEPTION_END_STR
 

--- a/src/python/WMCore/MicroService/Unified/Common.py
+++ b/src/python/WMCore/MicroService/Unified/Common.py
@@ -8,22 +8,20 @@ Original code: https://github.com/CMSCompOps/WmAgentScripts/Unified
 # futures
 from __future__ import division, print_function
 
+from future import standard_library
+standard_library.install_aliases()
+
+# system modules
 import json
 import logging
 import math
-# system modules
 import re
 import time
 
-from Utils.IteratorTools import grouper
-
-try:
-    from urllib import quote, unquote
-except ImportError:
-    # PY3
-    from urllib.parse import quote, unquote
+from urllib.parse import quote, unquote
 
 # WMCore modules
+from Utils.IteratorTools import grouper
 from Utils.CertTools import getKeyCertFromEnv
 from WMCore.Services.pycurl_manager import RequestHandler
 from WMCore.Services.pycurl_manager import getdata as multi_getdata

--- a/src/python/WMCore/MicroService/Unified/MSTransferor.py
+++ b/src/python/WMCore/MicroService/Unified/MSTransferor.py
@@ -10,9 +10,11 @@ tasks might be extended to multi-threading in the future.
 """
 # futures
 from __future__ import division, print_function
+from future import standard_library
+standard_library.install_aliases()
 
 # system modules
-from httplib import HTTPException
+from http.client import HTTPException
 from operator import itemgetter
 from pprint import pformat
 from retry import retry

--- a/src/python/WMCore/MicroService/Unified/TaskManager.py
+++ b/src/python/WMCore/MicroService/Unified/TaskManager.py
@@ -5,13 +5,17 @@ Author: Valentin Kuznetsov <vkuznet [AT] gmail [DOT] com>
 """
 # futures
 from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
 
 # system modules
 import time
 import json
 import hashlib
 import threading
-from Queue import Queue
+from queue import Queue
+
+# WMCore modules
 from WMCore.MicroService.Unified.Common import getMSLogger
 
 

--- a/src/python/WMCore/REST/Main.py
+++ b/src/python/WMCore/REST/Main.py
@@ -8,6 +8,9 @@ up an appropriately configured CherryPy instance. Views are loaded dynamically
 and can be turned on/off via configuration file."""
 from __future__ import print_function
 
+from future import standard_library
+standard_library.install_aliases()
+
 import errno
 import logging
 import os
@@ -16,7 +19,7 @@ import re
 import signal
 import socket
 import sys
-import thread
+import _thread
 import time
 import traceback
 from argparse import ArgumentParser
@@ -210,7 +213,7 @@ class RESTMain(object):
         cpconfig.update({'engine.autoreload.on': False})
         cpconfig.update({'request.show_tracebacks': False})
         cpconfig.update({'request.methods_with_bodies': ("POST", "PUT", "DELETE")})
-        thread.stack_size(getattr(self.srvconfig, 'thread_stack_size', 128 * 1024))
+        _thread.stack_size(getattr(self.srvconfig, 'thread_stack_size', 128 * 1024))
         sys.setcheckinterval(getattr(self.srvconfig, 'sys_check_interval', 10000))
         self.silent = getattr(self.srvconfig, 'silent', False)
 

--- a/src/python/WMCore/ReqMgr/Web/utils.py
+++ b/src/python/WMCore/ReqMgr/Web/utils.py
@@ -7,6 +7,8 @@ Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
 Description:
 """
 from __future__ import print_function
+from future import standard_library
+standard_library.install_aliases()
 
 # system modules
 import cgi
@@ -14,7 +16,7 @@ import json
 import time
 import hashlib
 import cherrypy
-from urllib2 import URLError
+from urllib.error import URLError
 
 def tstamp():
     "Generic time stamp"

--- a/src/python/WMCore/Services/CRIC/CRIC.py
+++ b/src/python/WMCore/Services/CRIC/CRIC.py
@@ -1,9 +1,11 @@
 from __future__ import (division, print_function)
+from future import standard_library
+standard_library.install_aliases()
 
 import json
 import logging
 import re
-from urllib import urlencode
+from urllib.parse import urlencode
 
 from WMCore.Services.Service import Service
 

--- a/src/python/WMCore/Services/HTTPS/HTTPSAuthHandler.py
+++ b/src/python/WMCore/Services/HTTPS/HTTPSAuthHandler.py
@@ -5,13 +5,16 @@ See usage example in:
 src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
 """
 from __future__ import print_function, division
+from future import standard_library
+standard_library.install_aliases()
+
 import logging
-import urllib2
-import httplib
+import urllib.request
+import http.client
 import ssl
 
 
-class HTTPSAuthHandler(urllib2.HTTPSHandler):
+class HTTPSAuthHandler(urllib.request.HTTPSHandler):
     """
     HTTPS authentication class to provide a ssl context with the certificates.
     """
@@ -36,15 +39,15 @@ class HTTPSAuthHandler(urllib2.HTTPSHandler):
             self.logger.info("  protocol : %s", self.ctx.protocol)  # default to 2 (PROTOCOL_SSLv23)
             self.logger.info("  verify_flags : %s", self.ctx.verify_flags)  # default to 0 (VERIFY_DEFAULT)
             self.logger.info("  verify_mode : %s", self.ctx.verify_mode)  # default to 2 (CERT_REQUIRED)
-            urllib2.HTTPSHandler.__init__(self, debuglevel=level, context=self.ctx)
+            urllib.request.HTTPSHandler.__init__(self, debuglevel=level, context=self.ctx)
         else:
             self.logger.info("Certificate not provided for HTTPSHandler")
-            urllib2.HTTPSHandler.__init__(self, debuglevel=level)
+            urllib.request.HTTPSHandler.__init__(self, debuglevel=level)
 
     def get_connection(self, host, **kwargs):
         if self.ctx:
-            return httplib.HTTPSConnection(host, context=self.ctx, **kwargs)
-        return httplib.HTTPSConnection(host)
+            return http.client.HTTPSConnection(host, context=self.ctx, **kwargs)
+        return http.client.HTTPSConnection(host)
 
     def https_open(self, req):
         """

--- a/src/python/WMCore/Services/LogDB/LogDB.py
+++ b/src/python/WMCore/Services/LogDB/LogDB.py
@@ -3,16 +3,19 @@
 LogDB provides functionality to post/search messages into LogDB.
 https://github.com/dmwm/WMCore/issues/5705
 """
+# futures
+from future import standard_library
+standard_library.install_aliases()
 
-import logging
 # standard modules
+import logging
 import re
 import threading
 from collections import defaultdict
-from httplib import HTTPException
+from http.client import HTTPException
 
-from WMCore.Lexicon import splitCouchServiceURL
 # project modules
+from WMCore.Lexicon import splitCouchServiceURL
 from WMCore.Services.LogDB.LogDBBackend import LogDBBackend
 
 

--- a/src/python/WMCore/Services/MonIT/Grafana.py
+++ b/src/python/WMCore/Services/MonIT/Grafana.py
@@ -5,17 +5,16 @@ Wrapper class, based on the PyCuRL module, providing an interface
 to CERN MonIT Grafana APIs
 """
 from __future__ import division, print_function, absolute_import
+from future import standard_library
+standard_library.install_aliases()
 
 import logging
 import json
 from copy import copy
 from pprint import pformat
+from urllib.parse import urljoin
+
 from WMCore.Services.pycurl_manager import RequestHandler
-try:
-    from urlparse import urljoin
-except ImportError:
-    # PY3
-    from urllib.parse import urljoin
 
 class Grafana(object):
     """

--- a/src/python/WMCore/Services/Requests.py
+++ b/src/python/WMCore/Services/Requests.py
@@ -9,6 +9,8 @@ deserialising the response.
 The response from the remote server is cached if expires/etags are set.
 """
 from __future__ import division, print_function
+from future import standard_library
+standard_library.install_aliases()
 
 import base64
 import logging
@@ -21,18 +23,9 @@ import tempfile
 import traceback
 import types
 
-try:
-    from urllib import urlencode
-except ImportError:
-    # PY3
-    from urllib.parse import urlencode
-try:
-    from urlparse import urlparse
-except ImportError:
-    # PY3
-    from urllib.parse import urlparse
+from urllib.parse import urlparse, urlencode
 from io import BytesIO
-from httplib import HTTPException
+from http.client import HTTPException
 from json import JSONEncoder, JSONDecoder
 
 from Utils.CertTools import getKeyCertFromEnv, getCAPathFromEnv

--- a/src/python/WMCore/Services/Service.py
+++ b/src/python/WMCore/Services/Service.py
@@ -48,13 +48,16 @@ service cache   |    no    |   yes    |   yes    |     no     |
 result          |  cached  |  cached  |  cached  | not cached |
 """
 
+from future import standard_library
+standard_library.install_aliases()
+
 import datetime
 import json
 import logging
 import os
 import time
 from io import BytesIO
-from httplib import HTTPException
+from http.client import HTTPException
 
 from WMCore.Services.Requests import Requests, JSONRequests
 from WMCore.WMException import WMException

--- a/src/python/WMCore/Services/TagCollector/TagCollector.py
+++ b/src/python/WMCore/Services/TagCollector/TagCollector.py
@@ -1,11 +1,13 @@
 from __future__ import (division, print_function)
+from future import standard_library
+standard_library.install_aliases()
 
 import logging
+from urllib.parse import urlparse
 
 from collections import defaultdict
 from WMCore.Services.Service import Service
 from WMCore.Services.TagCollector.XMLUtils import xml_parser
-from urlparse import urlparse
 
 class TagCollector(Service):
     """

--- a/src/python/WMCore/Services/pycurl_manager.py
+++ b/src/python/WMCore/Services/pycurl_manager.py
@@ -37,10 +37,10 @@ for row in data:
     print(row)
 """
 from __future__ import print_function
-
+from future import standard_library
+standard_library.install_aliases()
 
 # system modules
-import httplib
 import json
 import logging
 import os
@@ -49,11 +49,8 @@ import subprocess
 import sys
 import pycurl
 from io import BytesIO
-try:
-    from urllib import urlencode
-except ImportError:
-    # PY3
-    from urllib.parse import urlencode
+import http.client
+from urllib.parse import urlencode
 
 
 class ResponseHeader(object):
@@ -286,7 +283,7 @@ class RequestHandler(object):
             data = bbuf.getvalue()
             msg = 'url=%s, code=%s, reason=%s, headers=%s' \
                   % (url, header.status, header.reason, header.header)
-            exc = httplib.HTTPException(msg)
+            exc = http.client.HTTPException(msg)
             setattr(exc, 'req_data', params)
             setattr(exc, 'req_headers', headers)
             setattr(exc, 'url', url)

--- a/src/python/WMCore/Storage/Plugins/FNALImpl.py
+++ b/src/python/WMCore/Storage/Plugins/FNALImpl.py
@@ -5,6 +5,9 @@ _FNALImpl_
 Implementation of StageOutImpl interface for FNAL
 
 """
+from future import standard_library
+standard_library.install_aliases()
+
 import logging
 import os
 
@@ -12,7 +15,7 @@ from WMCore.Storage.Plugins.LCGImpl import LCGImpl
 from WMCore.Storage.StageOutImplV2 import StageOutImplV2
 
 try:
-    from commands import getoutput
+    from subprocess import getoutput
 except ImportError:
     # python3
     from subprocess import getoutput

--- a/src/python/WMCore/Storage/TrivialFileCatalog.py
+++ b/src/python/WMCore/Storage/TrivialFileCatalog.py
@@ -25,14 +25,13 @@ Usage: Given a TFC constact string: trivialcatalog_file:/path?protocol=proto
 
 """
 
+from future import standard_library
+standard_library.install_aliases()
+
 import os
 import re
 
-try:
-    from urlparse import urlsplit
-except ImportError:
-    # PY3
-    from urllib.parse import urlsplit
+from urllib.parse import urlsplit
 from xml.dom.minidom import Element
 
 from WMCore.Algorithms.ParseXMLFile import xmlFileToNode

--- a/src/python/WMCore/ThreadPool/WorkQueue.py
+++ b/src/python/WMCore/ThreadPool/WorkQueue.py
@@ -29,10 +29,8 @@ function. This helps the caller to determine which function
 
 """
 
-
-
-
-
+from future import standard_library
+standard_library.install_aliases()
 
 import threading
 

--- a/src/python/WMCore/WMRuntime/DashboardInterface.py
+++ b/src/python/WMCore/WMRuntime/DashboardInterface.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # This is the interface to the Dashboard that the monitor will use
 
+from future import standard_library
+standard_library.install_aliases()
+
 import threading
 import os
 import time

--- a/src/python/WMCore/WMRuntime/SandboxCreator.py
+++ b/src/python/WMCore/WMRuntime/SandboxCreator.py
@@ -5,6 +5,9 @@
     Given a path, workflow and task, create a sandbox within the path
 """
 
+from future import standard_library
+standard_library.install_aliases()
+
 import logging
 import os
 import shutil
@@ -12,11 +15,7 @@ import tarfile
 import tempfile
 import zipfile
 
-try:
-    from urlparse import urlsplit
-except ImportError:
-    # PY3
-    from urllib.parse import urlsplit
+from urllib.parse import urlsplit
 
 import PSetTweaks
 import Utils

--- a/src/python/WMCore/WMRuntime/Scripts/UnpackUserTarball.py
+++ b/src/python/WMCore/WMRuntime/Scripts/UnpackUserTarball.py
@@ -5,6 +5,8 @@ _UnpackUserTarball_
 Unpack the user tarball and put it's contents in the right place
 """
 from __future__ import print_function
+from future import standard_library
+standard_library.install_aliases()
 
 import logging
 import os
@@ -13,16 +15,10 @@ import shutil
 import subprocess
 import sys
 import tempfile
-import urllib
-from urllib import URLopener
 
-try:
-    from commands import getstatusoutput
-    from urlparse import urlsplit
-except ImportError:
-    # PY3
-    from urllib.parse import urlsplit
-    from subprocess import getstatusoutput
+import urllib.request
+from urllib.parse import urlsplit
+from subprocess import getstatusoutput
 
 
 def setHttpProxy(url):
@@ -61,10 +57,10 @@ def getRetriever(scheme):
         certfile = None
 
     if scheme == 'http' or not certfile:
-        retriever = urllib.urlretrieve
+        retriever = urllib.request.urlretrieve
     else:
         logging.info("Using %s as X509 certificate", certfile)
-        op = URLopener(None, key_file=certfile, cert_file=certfile)
+        op = urllib.request.URLopener(None, key_file=certfile, cert_file=certfile)
         op.addheader('Accept', 'application/octet-stream')
         retriever = op.retrieve
 

--- a/src/python/WMCore/WMSpec/DashboardInterface.py
+++ b/src/python/WMCore/WMSpec/DashboardInterface.py
@@ -9,18 +9,14 @@ of the job and the report.
 
 """
 from __future__ import print_function
-
-
-
-
-
+from future import standard_library
+standard_library.install_aliases()
 
 from xml.dom import minidom
 import logging
 import traceback
 
-
-import urllib, urllib2
+import urllib.request, urllib.parse
 import os
 import socket
 from contextlib import closing
@@ -63,12 +59,12 @@ def HTTPpost(params, url, onFailureFile = None):
     try:
         logging.debug("contacting %s" % url)
 
-        data = urllib.urlencode(params)
+        data = urllib.parse.urlencode(params)
         #put who we are in headers
         headers = { 'User-Agent' : USER_AGENT }
-        req = urllib2.Request(url, data, headers)
+        req = urllib.request.Request(url, data, headers)
 
-        with closing(urllib2.urlopen(req, data)) as response:
+        with closing(urllib.request.urlopen(req, data)) as response:
             logging.debug("received http code: %s, message: %s, response: %s", response.code,
                           response.msg, str(response.read()))
 

--- a/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
@@ -6,11 +6,13 @@ Implementation of an Executor for a DQMUpload step
 
 """
 from __future__ import print_function
+from future import standard_library
+standard_library.install_aliases()
 
 import logging
 import os
 import sys
-import urllib2
+import urllib.request, urllib.error
 from io import BytesIO
 from functools import reduce
 from gzip import GzipFile
@@ -162,7 +164,7 @@ class DQMUpload(Executor):
                 else:
                     msg = 'HTTP upload finished succesfully with response:\n' + msg
                     logging.info(msg)
-        except urllib2.HTTPError as ex:
+        except urllib.error.HTTPError as ex:
             msg = 'HTTP upload failed with response:\n'
             msg += '  Status code: %s\n' % ex.hdrs.get("Dqm-Status-Code", None)
             msg += '  Message: %s\n' % ex.hdrs.get("Dqm-Status-Message", None)
@@ -238,11 +240,11 @@ class DQMUpload(Executor):
         logging.info(msg)
 
         handler = HTTPSAuthHandler(key=uploadProxy, cert=uploadProxy)
-        opener = urllib2.OpenerDirector()
+        opener = urllib.request.OpenerDirector()
         opener.add_handler(handler)
 
         # setup the request object
-        datareq = urllib2.Request(url + '/data/put')
+        datareq = urllib.request.Request(url + '/data/put')
         datareq.add_header('Accept-encoding', 'gzip')
         datareq.add_header('User-agent', ident)
         self.marshall(args, {'file': filename}, datareq)
@@ -250,7 +252,7 @@ class DQMUpload(Executor):
         if 'https://' in url:
             result = opener.open(datareq)
         else:
-            opener.add_handler(urllib2.ProxyHandler({}))
+            opener.add_handler(urllib.request.ProxyHandler({}))
             result = opener.open(datareq)
 
         data = result.read()

--- a/src/python/WMCore/WMSpec/Steps/Fetchers/CMSSWFetcher.py
+++ b/src/python/WMCore/WMSpec/Steps/Fetchers/CMSSWFetcher.py
@@ -6,8 +6,11 @@ Fetch configfiles and PSet TWeaks for CMSSW Steps in a WMTask
 
 """
 
+from future import standard_library
+standard_library.install_aliases()
+
 import os
-import urllib
+import urllib.request
 
 from WMCore.WMSpec.Steps.Fetchers.FetcherInterface import FetcherInterface
 from WMCore.Cache.WMConfigCache import ConfigCache
@@ -39,7 +42,7 @@ class CMSSWFetcher(FetcherInterface):
                 fileTarget = "%s/%s" % (
                     stepPath,
                     t.data.application.command.configuration)
-                #urllib.urlretrieve(
+                #urllib.request.urlretrieve(
                 #    t.data.application.configuration.retrieveConfigUrl,
                 #    fileTarget)
                 # PSet Tweak

--- a/src/python/WMCore/WorkQueue/DataLocationMapper.py
+++ b/src/python/WMCore/WorkQueue/DataLocationMapper.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 """Map data to locations for WorkQueue"""
 
+from future import standard_library
+standard_library.install_aliases()
+
 from collections import defaultdict
 import logging
-try:
-    from urlparse import urlparse
-except ImportError:
-    # PY3
-    from urllib.parse import urlparse
+
+from urllib.parse import urlparse
 
 from WMCore.Services.DBS.DBSReader import DBSReader
 from WMCore.WorkQueue.DataStructs.ACDCBlock import ACDCBlock

--- a/src/python/WMQuality/Emulators/CRICClient/MakeCRICMockFiles.py
+++ b/src/python/WMQuality/Emulators/CRICClient/MakeCRICMockFiles.py
@@ -5,10 +5,12 @@ Program to create mock SiteDB JSON files used by the SiteDB mock-based emulator
 """
 
 from __future__ import division, print_function
+from future import standard_library
+standard_library.install_aliases()
 
 import json
 import os
-from urllib2 import HTTPError
+from urllib.error import HTTPError
 
 from WMCore.Services.CRIC.CRIC import CRIC
 from WMCore.WMBase import getTestBase

--- a/src/python/WMQuality/Emulators/SiteDBClient/MakeSiteDBMockFiles.py
+++ b/src/python/WMQuality/Emulators/SiteDBClient/MakeSiteDBMockFiles.py
@@ -4,11 +4,14 @@ MakeSiteDBMockFiles
 Program to create mock SiteDB JSON files used by the SiteDB mock-based emulator
 """
 
-from __future__ import (division, print_function)
+from __future__ import division, print_function
+
+from future import standard_library
+standard_library.install_aliases()
 
 import json
 import os
-from urllib2 import HTTPError
+from urllib.error import HTTPError
 
 from WMCore.Services.SiteDB.SiteDBAPI import SiteDBAPI
 from WMCore.WMBase import getTestBase

--- a/src/python/WMQuality/TestInitCouchApp.py
+++ b/src/python/WMQuality/TestInitCouchApp.py
@@ -11,8 +11,11 @@ Created by Dave Evans on 2010-08-19.
 Copyright (c) 2010 Fermilab. All rights reserved.
 """
 
+from future import standard_library
+standard_library.install_aliases()
+
 import os
-import urllib
+import urllib.parse
 
 from couchapp.commands import push as couchapppush
 from couchapp.config import Config
@@ -59,7 +62,7 @@ class CouchAppTestHarness:
         push a list of couchapps to the database
         """
         for couchappdir in  couchappdirs:
-            couchapppush(self.couchappConfig, couchappdir, "%s/%s" % (self.couchUrl, urllib.quote_plus(self.dbName)))
+            couchapppush(self.couchappConfig, couchappdir, "%s/%s" % (self.couchUrl, urllib.parse.quote_plus(self.dbName)))
 
 
 class TestInitCouchApp(TestInit):

--- a/src/python/WMQuality/WebTools/RESTClientAPI.py
+++ b/src/python/WMQuality/WebTools/RESTClientAPI.py
@@ -1,13 +1,12 @@
+from future import standard_library
+standard_library.install_aliases()
+
 import hashlib
 import hmac
-import urllib
-from httplib import HTTPConnection
+import urllib.parse
 
-try:
-    from urlparse import urlparse
-except ImportError:
-    # PY3
-    from urllib.parse import urlparse
+from http.client import HTTPConnection
+
 from WMCore.WebTools.Page import make_rfc_timestamp
 
 
@@ -29,15 +28,15 @@ def makeRequest(url, values=None, verb='GET', accept="text/plain",
 
     data = None
     if verb == 'GET' and values:
-        data = urllib.urlencode(values, doseq=True)
+        data = urllib.parse.urlencode(values, doseq=True)
     elif verb != 'GET' and values:
         # needs to test other encoding type
         if contentType == "application/x-www-form-urlencoded":
-            data = urllib.urlencode(values)
+            data = urllib.parse.urlencode(values)
         else:
             # for other encoding scheme values assumed to be encoded already
             data = values
-    parser = urlparse(url)
+    parser = urllib.parse.urlparse(url)
     uri = parser.path
     if parser.query:
         uri += "?" + parser.query

--- a/test/data/ReqMgr/reqmgr2.py
+++ b/test/data/ReqMgr/reqmgr2.py
@@ -16,13 +16,16 @@ Note: tests for checking data directly in CouchDB in ReqMgr1 test script:
 """
 from __future__ import print_function
 
+from future import standard_library
+standard_library.install_aliases()
+
 import json
 import logging
 import os
 import sys
-import urllib
+import urllib.parse
 from argparse import ArgumentParser
-from httplib import HTTPSConnection, HTTPConnection
+from http.client import HTTPSConnection, HTTPConnection
 
 
 class RESTClient(object):
@@ -119,7 +122,7 @@ class ReqMgrClient(RESTClient):
         urn = self.urn_prefix + "/request"
         for request_name in config.request_names:
             self.logger.info("Deleting '%s' request ...", request_name)
-            args = urllib.urlencode({"request_name": request_name})
+            args = urllib.parse.urlencode({"request_name": request_name})
             status, data = self.http_request("DELETE", urn, data=args)
             if status != 200:
                 self.logger.error("Failed to delete request with status: %s, data: %s", status, data)
@@ -228,7 +231,7 @@ class ReqMgrClient(RESTClient):
         self._caller_checker("/about", "GET")
         self._caller_checker("/info", "GET")
         group = "mygroup"
-        args = urllib.urlencode({"group_name": group})
+        args = urllib.parse.urlencode({"group_name": group})
         self._caller_checker("/group", "PUT", input_data=args)
         data = self._caller_checker("/group", "GET")
         assert group in data, "%s should be in %s" % (group, data)
@@ -236,7 +239,7 @@ class ReqMgrClient(RESTClient):
         data = self._caller_checker("/group", "GET")
         assert group not in data, "%s should be deleted from %s" % (group, data)
         team = "myteam"
-        args = urllib.urlencode({"team_name": team})
+        args = urllib.parse.urlencode({"team_name": team})
         self._caller_checker("/team", "PUT", input_data=args)
         data = self._caller_checker("/team", "GET")
         assert team in data, "%s should be in %s" % (team, data)

--- a/test/python/WMCore_t/Cache_t/WMConfigCache_t.py
+++ b/test/python/WMCore_t/Cache_t/WMConfigCache_t.py
@@ -9,6 +9,7 @@ import os
 import unittest
 import tempfile
 import subprocess
+import urllib
 
 from WMCore.Agent.Configuration import Configuration
 from WMCore.Cache.WMConfigCache import ConfigCache, ConfigCacheException
@@ -94,6 +95,7 @@ class testWMConfigCache(unittest.TestCase):
         configCache.setPSetTweaks(PSetTweak = PSetTweak)
         configCache.attachments['attach1'] = attach
         psetPath = os.path.join(getTestBase(), "WMCore_t/Cache_t/PSet.txt")
+        psetPath = "file://" + urllib.quote(os.path.abspath(psetPath))
         configCache.addConfig(newConfig = psetPath, psetHash = None)
 
         configCache.setLabel("sample-label")
@@ -129,6 +131,7 @@ class testWMConfigCache(unittest.TestCase):
         configCache.attachments['attach1'] = attach
         configCache.document['md5_hash'] = "somemd5"
         psetPath = os.path.join(getTestBase(), "WMCore_t/Cache_t/PSet.txt")
+        psetPath = "file://" + urllib.quote(os.path.abspath(psetPath))
         configCache.addConfig(newConfig = psetPath, psetHash = None)
         configCache.save()
 

--- a/test/python/WMCore_t/ReqMgr_t/Service_t/Auxiliary_t.py
+++ b/test/python/WMCore_t/ReqMgr_t/Service_t/Auxiliary_t.py
@@ -1,8 +1,11 @@
 from __future__ import print_function
 
+from future import standard_library
+standard_library.install_aliases()
+
 import unittest
 import time
-from httplib import HTTPException
+from http.client import HTTPException
 
 from WMCore_t.ReqMgr_t.TestConfig import config
 from nose.plugins.attrib import attr

--- a/test/python/WMCore_t/Services_t/Requests_t.py
+++ b/test/python/WMCore_t/Services_t/Requests_t.py
@@ -5,7 +5,10 @@ Created on Aug 6, 2009
 
 @author: meloam
 '''
+
 from __future__ import print_function
+from future import standard_library
+standard_library.install_aliases()
 
 import json
 import os
@@ -13,7 +16,7 @@ import shutil
 import tempfile
 import time
 import unittest
-from httplib import HTTPException
+from http.client import HTTPException
 
 import nose
 

--- a/test/python/WMCore_t/Services_t/Service_t.py
+++ b/test/python/WMCore_t/Services_t/Service_t.py
@@ -1,5 +1,8 @@
 """
 """
+from future import standard_library
+standard_library.install_aliases()
+
 from io import BytesIO
 import logging
 import logging.config
@@ -9,8 +12,7 @@ import socket
 import tempfile
 import time
 import unittest
-from httplib import BadStatusLine, IncompleteRead
-from httplib import HTTPException
+from http.client import BadStatusLine, IncompleteRead, HTTPException
 
 import cherrypy
 from nose.plugins.attrib import attr

--- a/test/python/WMCore_t/Services_t/pycurlFileUpload_t.py
+++ b/test/python/WMCore_t/Services_t/pycurlFileUpload_t.py
@@ -1,7 +1,10 @@
+from future import standard_library
+standard_library.install_aliases()
+
 import logging
 import os
 import unittest
-from httplib import HTTPException
+from http.client import HTTPException
 
 from WMCore.Services.Requests import Requests
 from WMCore.WMBase import getTestBase

--- a/test/python/WMCore_t/WMRuntime_t/Scripts_t/UnpackUserTarball_t.py
+++ b/test/python/WMCore_t/WMRuntime_t/Scripts_t/UnpackUserTarball_t.py
@@ -6,6 +6,11 @@ Tests for the user tarball unpacker and additional file mover
 
 """
 
+from future import standard_library
+standard_library.install_aliases()
+
+import urllib
+
 import logging
 import os
 import subprocess
@@ -130,14 +135,14 @@ class UnpackUserTarballTest(unittest.TestCase):
 
     def testBadUrl(self):
         """
-        _testUrlSandbox_
+        _testBadUrl_
 
         Test a single sandbox that is a URL
 
         """
 
         sys.argv = ['scriptName','http://home.fnal.gov/~ewv/not-there.txt','']
-        self.assertRaises(RuntimeError, UnpackUserTarball)
+        self.assertRaises(urllib.error.HTTPError, UnpackUserTarball)
 
 
     def testFileAndURLSandbox(self):

--- a/test/python/WMCore_t/WebTools_t/Root_t.py
+++ b/test/python/WMCore_t/WebTools_t/Root_t.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 
+from future import standard_library
+standard_library.install_aliases()
+
 import unittest
 import logging
-import urllib2
+import urllib.request
 from WMCore.WebTools.Root import Root
 from WMCore.Configuration import Configuration
 from cherrypy import engine, tree
@@ -238,13 +241,13 @@ class RootTest():
 
         for instance in config.UnitTests.instances:
             url = 'http://127.0.0.1:%s/unittests/%s/test' % (cpconfig['server.socket_port'], instance)
-            html = urllib2.urlopen(url).read()
+            html = urllib.request.urlopen(url).read()
             self.assertEqual(html, instance)
             db_url = '%s/database' % url
-            html = urllib2.urlopen(db_url).read()
+            html = urllib.request.urlopen(db_url).read()
             self.assertEqual(html, db_instances.section_(instance).connectUrl)
             sec_url = '%s/security' % url
-            html = urllib2.urlopen(sec_url).read()
+            html = urllib.request.urlopen(sec_url).read()
             self.assertEqual(html, security_instances.section_(instance).sec_params)
         server.stop()
 


### PR DESCRIPTION
This PR is one of the PRs related to the issue #9761 .

#### Status

not-tested 

#### Description

This PR is about reducing the dependency of WMCore on python2 stdlib, by using specific futurize fixers that allow supporting python3 stdlib.

##### fixers

The stage2 fixers that have been applied are

* `libfuturize.fixes.fix_future_standard_library`
* `libfuturize.fixes.fix_future_standard_library_urllib`

(the complete list is available at http://python-future.org/automatic_conversion.html)

The urllib fixer selects the "easiest option" described in the [official futurize documentation](http://python-future.org/compatible_idioms.html#urllib-module).

We applied both the fixers at the same time because 
despite futurize having a separate fixer for urllib, it would have been impossible 
to completely decouple the two fixers.
If we run `fix_future_standard_library` on a module containing httplib
(that should be converted to http.client) that also contains
`import urlparse`, then `urlparse` is be translated to `urllib.parse`.

Hence, `fix_future_standard_library_urllib` fixers has been applied in the same
PR as `fix_future_standard_library`.

##### no cPickle for the time being

As discussed with Alan in #9735, no changes have been applied to cPickle for performance issues. More informations are available at https://cms-dmwm-test.docs.cern.ch/py2py3/porting/#pickle .
All the automatic changes applied by futurize that translate `cPickle` in `pickle` have been manually discarded.

Achtung! The file `./src/python/WMCore/WMSpec/Persistency.py` depends on both urllib and cPickle. 
No change has been applied to this module. If we want to update urllib to the python3 version while using python2 cPickle,
we could import urllib with

```python
from future.moves.urllib.parse import urlparse, urlencode
from future.moves.urllib.request import urlopen, Request
from future.moves.urllib.error import HTTPError
```

Since this is not consistent with how we imported urllib in other modules, this option has not been applied yet. 

##### log

The log of the PR will be available at https://cms-dmwm-test.docs.cern.ch/py2py3/porting_log/004_stdlib/ (right now no tests have been run and the log is pretty empty)

#### Is it backward compatible (if not, which system it affects?)

The purpose of the py2->py2py3 migration is to be as transparent as possible. However, some changes can have some pitfalls. 

The main change that can have some impact on client code is `urllib.urlopen`in py2 to `urllib.request.urlopen` in py2py3 with futurize. This affects the following files:

* src/python/WMCore/Cache/WMConfigCache.py
* src/python/WMCore/WMRuntime/Scripts/UnpackUserTarball.py

Since `urllib2.urlopen` in python2 behaves in the same way as `urllib.request.urlopen` in python3 (backported to python2 with futurize), then only these two modules may require changes on client code.

What to do if you rely on one of these files:

* check how you deal with HTTP error.  

This is because the python2 version of [urllib.urlopen](https://docs.python.org/2/library/urllib.html#urllib.urlopen) does not raise an exception in case of HTTP error, but it returns valid html containing the description of the error. The python3 version of [urllib.request.urlopen](https://docs.python.org/3.8/library/urllib.request.html#urllib.request.urlopen) raise a URLError in case of a HTTP error. The same behavior is replicated to the functions that are based on `urlopen`, such as `urlretrieve`. If you rely on a file or an string containing html returned from one of the aforementioned modules and you check for errors inspecting the return value, then you need to adapt the error checking with catching an exception, as we did in [this unit test](https://github.com/dmwm/WMCore/pull/9762/files#diff-42be78d8853c84d0c995ae1d05fd0a22). 



Do not hesitate to contact @mapellidario if something is not clear.

#### Related PRs

The related PRs are linked in #9761.

This PR partially supersedes #9735 , in particular in dealing with httplib -> http.client

#### External dependencies / deployment changes

It will be necessary to run the unit test in a python3 environment, too
