### PR TITLE
Couple primary/parent block distribution to where the PU dataset is

### DIFF
--- a/src/python/WMCore/MicroService/DataStructs/DefaultStructs.py
+++ b/src/python/WMCore/MicroService/DataStructs/DefaultStructs.py
@@ -30,6 +30,7 @@ TRANSFEROR_REPORT = dict(start_time=0,
                          nodes_out_of_space=None,
                          success_request_transition=0,
                          failed_request_transition=0,
+                         problematic_requests=0,
                          num_datasets_subscribed=0,
                          num_blocks_subscribed=0)
 

--- a/src/python/WMCore/MicroService/DataStructs/Workflow.py
+++ b/src/python/WMCore/MicroService/DataStructs/Workflow.py
@@ -24,6 +24,7 @@ class Workflow(object):
         self.inputDataset = ""
         self.parentDataset = ""
         self.pileupDatasets = set()
+        self.pileupRSEList = set()
 
         self.campaigns = set()
         self.dataCampaignMap = []
@@ -80,6 +81,29 @@ class Workflow(object):
         Get the SiteWhitelist minus the black list for this request
         """
         return sorted(list(set(self.data['SiteWhitelist']) - set(self.data['SiteBlacklist'])))
+
+    def setPURSElist(self, rseSet):
+        """
+        Hook/hack to make sure that multiple pileup datasets are placed
+        in the same storage (unless secondaryAAA is enabled).
+        It will be used to place the primary/parent blocks under the same
+        location too (in case primaryAAA is enabled)
+        Set this location only once, any further updates should not work!
+        :param rseSet: a set of RSE names
+        """
+        if isinstance(rseSet, set):
+            self.pileupRSEList = rseSet
+        elif isinstance(rseSet, list):
+            self.pileupRSEList = set(rseSet)
+        else:
+            # assume it's a string
+            self.pileupRSEList = {rseSet}
+
+    def getPURSElist(self):
+        """
+        Retrieve the final list of RSEs where ALL the data needs to be placed
+        """
+        return self.pileupRSEList
 
     def getRunWhitelist(self):
         """

--- a/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
+++ b/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
@@ -33,8 +33,8 @@ class RucioTest(EmulatedUnitTestCase):
         self.creds = {"client_cert": os.getenv("X509_USER_CERT", "Unknown"),
                       "client_key": os.getenv("X509_USER_KEY", "Unknown")}
 
-        self.defaultArgs = {"host": 'http://cms-rucio-int.cern.ch',
-                            "auth_host": 'https://cms-rucio-auth-int.cern.ch',
+        self.defaultArgs = {"host": 'http://cmsrucio-int.cern.ch',
+                            "auth_host": 'https://cmsrucio-auth-int.cern.ch',
                             "auth_type": "x509", "account": self.acct,
                             "ca_cert": False, "timeout": 30, "request_retries": 3,
                             "creds": self.creds}


### PR DESCRIPTION
Fixes #9745 

#### Status
not-tested

#### Description
This changes the current data placement model we had implemented in MSTransferor, thus causing this large amount of changes, complex and delicate. Honestly, I don't like very much this implementation, it's very complicated!

In short, for workflows with pileup data, make sure that the input primary/parent blocks are placed under the same location hosting the pileup dataset(s) (unless AAA flags are enabled).

In plain english, these are the use cases:
1. no pileup dataset
	--> transfer primary within sitewhitelist
2. one pileup dataset
	--> transfer primary where the pileup is, within the sitewhitelist and campaign configuration
3. multiple pileup datasets
	--> all pileup datasets must be available in the same PNN within the sitewhitelist and campaign configuration
    --> we also try to transfer the smallest pileup sample over to where the largest one is already available
    --> then transfer all the input blocks to the same PNN
4. one pileup dataset with secondaryAAA
	--> if pileup is available in a disk PNN, do nothing; else, put it in 1 site within the sitewhitelist and campaign config
5. multiple pileup datasets with secondaryAAA
	--> both pileup datasets need to be available in a disk PNN; else, put it in 1 site within the sitewhitelist and campaign config

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
