### PR TITLE
Fix python version evaluation in Configuration module

### DIFF
--- a/src/python/WMCore/Configuration.py
+++ b/src/python/WMCore/Configuration.py
@@ -14,8 +14,10 @@ import os
 import sys
 import traceback
 
-# PY3 compatibility
-if sys.version_info == 3:  # PY3 Remove when python 3 transition complete
+PY3 = sys.version_info.major == 3
+
+# PY3 compatibility (can be removed once python2 gets dropped)
+if PY3:
     basestring = str
     unicode = str
     long = int


### PR DESCRIPTION
Fixes #9765 

#### Status
ready

#### Description
And this is what happens when you do not have a python3 environment while porting your code to python3...
Thanks to @belforte for catching this issue.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
