### PR TITLE
Validate/fail workflow assignment for improper use of TrustSitelists/TrustPUSitelists

### DIFF
--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -1870,6 +1870,12 @@ class WMWorkloadHelper(PersistencyHelper):
         it affects where secondary jobs are meant to run.
         The pileup flag has to be set for all the tasks in the workload.
         """
+        if inputFlag is True and not self.listInputDatasets():
+            msg = "Setting TrustSitelists=True for workflows without input dataset is forbidden!"
+            raise RuntimeError(msg)
+        if pileupFlag is True and not self.listPileupDatasets():
+            msg = "Setting TrustPUSitelists=True for workflows without pileup dataset is forbidden!"
+            raise RuntimeError(msg)
         for task in self.getAllTasks(cpuOnly=True):
             if task.isTopOfTree():
                 task.setTrustSitelists(inputFlag, pileupFlag)

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
@@ -327,7 +327,17 @@ class StepChainTests(EmulatedUnitTestCase):
         outputDsets = [x['outputDataset'] for x in task.listOutputDatasetsAndModules()]
         self.assertItemsEqual(outputDsets, outDsets)
 
-        return
+        print(testArguments)
+        # test assignment with wrong Trust flags
+        assignDict = {"SiteWhitelist": ["T2_US_Nebraska"], "Team": "The-A-Team",
+                      "RequestStatus": "assigned",
+                      "TrustSitelists": False, "TrustPUSitelists": True
+                      }
+        with self.assertRaises(RuntimeError):
+            testWorkload.updateArguments(assignDict)
+        # now with correct flags
+        assignDict['TrustPUSitelists'] = False
+        testWorkload.updateArguments(assignDict)
 
     def testStepChainMC(self):
         """
@@ -481,8 +491,6 @@ class StepChainTests(EmulatedUnitTestCase):
         self.assertEqual(step.data.application.setup.cmsswVersion, testArguments['Step3']["CMSSWVersion"])
         self.assertEqual(step.data.application.setup.scramArch, testArguments['Step3']["ScramArch"])
 
-        return
-
     def testPileupWithoutInputData(self):
         """
         Test whether we can properly setup the Pileup information even
@@ -517,6 +525,17 @@ class StepChainTests(EmulatedUnitTestCase):
         stepHelper = task.getStepHelper('cmsRun1')
         puConfig = stepHelper.getPileup()
         self.assertItemsEqual([testArguments['Step1']["MCPileup"]], puConfig.mc.dataset)
+
+        # test assignment with wrong Trust flags
+        assignDict = {"SiteWhitelist": ["T2_US_Nebraska"], "Team": "The-A-Team",
+                      "RequestStatus": "assigned",
+                      "TrustSitelists": True, "TrustPUSitelists": True
+                      }
+        with self.assertRaises(RuntimeError):
+            testWorkload.updateArguments(assignDict)
+        # now with correct flags
+        assignDict['TrustSitelists'] = False
+        testWorkload.updateArguments(assignDict)
 
     def testMultiplePileupDsets(self):
         """


### PR DESCRIPTION
Fixes #6999 

#### Status
tested

#### Description
This contains the ReqMgr2-side changes for a proper evaluation of the Trust flags during the workflow assignment.
In short:
* if the workflow does not have an input dataset, then `TrustSitelists` cannot be set to True (workflow assignment will fail otherwise)
* if the workflow does not have a pileup dataset, then `TrustPUSitelists` cannot be set to True (also failing the workflow assignment otherwise)

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
