### PR TITLE
Remove status 'completed' from msOutput.

### DIFF
--- a/src/python/WMCore/MicroService/Unified/MSManager.py
+++ b/src/python/WMCore/MicroService/Unified/MSManager.py
@@ -92,7 +92,7 @@ class MSManager(object):
 
         # initialize output module
         if 'output' in self.services:
-            reqStatus = ['completed', 'closed-out', 'announced']
+            reqStatus = ['closed-out', 'announced']
 
             thname = 'MSOutputConsumer'
             self.msOutputConsumer = MSOutput(self.msConfig, mode=thname, logger=self.logger)


### PR DESCRIPTION
Fixes #9757

#### Status
not-tested 

#### Description
Remove status 'completed' from the list of statuses to be considered by the msOutput module.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
No

#### External dependencies / deployment changes
No
