### PR TITLE
Fix broken unit tests inserted by PR9770

### DIFF
--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
@@ -728,22 +728,22 @@ class TaskChainTests(EmulatedUnitTestCase):
             self.assertEqual(flags, [False, False])
 
         # set both flags to true now
-        workload.setTrustLocationFlag(True, True)
+        workload.setTrustLocationFlag(True, False)
         for task in workload.getAllTasks():
             flags = task.getTrustSitelists()
             if task.isTopOfTree():
-                self.assertEqual(flags.values(), [True, True])
+                self.assertItemsEqual(flags.values(), [True, False])
             elif task.taskType() in ["Cleanup", "LogCollect"]:
-                self.assertEqual(flags.values(), [False, False])
+                self.assertItemsEqual(flags.values(), [False, False])
             else:
                 self.assertFalse(flags['trustlists'])
-                self.assertTrue(flags['trustPUlists'])
+                self.assertFalse(flags['trustPUlists'])
 
         # set both to false now
         workload.setTrustLocationFlag(False, False)
         for task in workload.getAllTasks(cpuOnly=True):
             flags = task.getTrustSitelists().values()
-            self.assertEqual(flags, [False, False])
+            self.assertItemsEqual(flags, [False, False])
         return
 
     def testMultipleGlobalTags(self):

--- a/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
@@ -2016,24 +2016,34 @@ class WMWorkloadTest(unittest.TestCase):
         """
         testWorkload = self.makeTestWorkload()[0]
 
-        self.assertFalse(testWorkload.getTrustLocationFlag().get('trustlists'),
-                         "Should be False, I did not set you yet.")
-        self.assertFalse(testWorkload.getTrustLocationFlag().get('trustPUlists'),
-                         "Should be False, I did not set you yet.")
-        testWorkload.setTrustLocationFlag(inputFlag=True, pileupFlag=True)
-        self.assertTrue(testWorkload.getTrustLocationFlag().get('trustlists'), "Bad job!! You should be True now")
-        self.assertTrue(testWorkload.getTrustLocationFlag().get('trustPUlists'), "Bad job!! You should be True now")
+        self.assertFalse(testWorkload.getTrustLocationFlag().get('trustlists'))
+        self.assertFalse(testWorkload.getTrustLocationFlag().get('trustPUlists'))
+        with self.assertRaises(RuntimeError):
+            testWorkload.setTrustLocationFlag(inputFlag=True, pileupFlag=True)
+
+        # then add an input dataset
+        for task in testWorkload.taskIterator():
+            task.addInputDataset(name='/My/Dataset-name/TIER', primary="My",
+                                 processed="Dataset-name", tier="TIER")
+
         testWorkload.setTrustLocationFlag(inputFlag=False, pileupFlag=False)
-        self.assertFalse(testWorkload.getTrustLocationFlag().get('trustlists'), "Bad job!! You should be False now")
-        self.assertFalse(testWorkload.getTrustLocationFlag().get('trustPUlists'), "Bad job!! You should be False now")
-        testWorkload.setTrustLocationFlag(inputFlag=False, pileupFlag=True)
-        self.assertFalse(testWorkload.getTrustLocationFlag().get('trustlists'), "Bad job!! You should still be False")
-        self.assertTrue(testWorkload.getTrustLocationFlag().get('trustPUlists'),
-                        "Bad job!! You should be True once again")
+        self.assertFalse(testWorkload.getTrustLocationFlag().get('trustlists'))
+        self.assertFalse(testWorkload.getTrustLocationFlag().get('trustPUlists'))
         testWorkload.setTrustLocationFlag(inputFlag=True, pileupFlag=False)
-        self.assertTrue(testWorkload.getTrustLocationFlag().get('trustlists'),
-                        "Bad job!! You should be True once again")
-        self.assertFalse(testWorkload.getTrustLocationFlag().get('trustPUlists'), "Bad job!! You should be False again")
+        self.assertTrue(testWorkload.getTrustLocationFlag().get('trustlists'))
+        self.assertFalse(testWorkload.getTrustLocationFlag().get('trustPUlists'))
+
+        with self.assertRaises(RuntimeError):
+            testWorkload.setTrustLocationFlag(inputFlag=True, pileupFlag=True)
+
+        # then add a pileup dataset
+        for task in testWorkload.taskIterator():
+            stepHelper = task.getStepHelper("cmsRun1")
+            stepHelper.setupPileup(pileupConfig={"mc": "/My/Pileup-name/TIER"}, dbsUrl="any_dbs_url")
+
+        testWorkload.setTrustLocationFlag(inputFlag=True, pileupFlag=True)
+        self.assertTrue(testWorkload.getTrustLocationFlag().get('trustlists'))
+        self.assertTrue(testWorkload.getTrustLocationFlag().get('trustPUlists'))
         return
 
     def testOverrides(self):

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
@@ -337,9 +337,9 @@ class WorkQueueTest(WorkQueueTestCase):
         reco = workload.newTask("reco")
         workload.setOwnerDetails(name="evansde77", group="DMWM")
         workload.setSiteWhitelist(site)
-        workload.setTrustLocationFlag(inputFlag=True, pileupFlag=True)
         # first task uses the input dataset
-        reco.addInputDataset(primary="PRIMARY", processed="processed-v1", tier="TIERONE")
+        reco.addInputDataset(name="/PRIMARY/processed-v1/TIERONE",
+                             primary="PRIMARY", processed="processed-v1", tier="TIERONE")
         reco.data.input.splitting.algorithm = "File"
         reco.data.input.splitting.include_parents = parentage
         reco.setTaskType("Processing")
@@ -354,6 +354,7 @@ class WorkQueueTest(WorkQueueTestCase):
                                          lfnBase="/store/dunkindonuts",
                                          mergedLFNBase="/store/kfc")
 
+        workload.setTrustLocationFlag(inputFlag=True, pileupFlag=False)
         dcs = DataCollectionService(url=serverUrl, database=couchDB)
 
         def getJob(workload):
@@ -1156,7 +1157,7 @@ class WorkQueueTest(WorkQueueTestCase):
                                        acdcCouchDB)
         spec.setSpecUrl(os.path.join(self.workDir, 'resubmissionWorkflow.spec'))
         spec.setSiteWhitelist('T1_US_FNAL')
-        spec.setTrustLocationFlag(inputFlag=True, pileupFlag=True)
+        spec.setTrustLocationFlag(inputFlag=True, pileupFlag=False)
         spec.save(spec.specUrl())
         self.localQueue.params['Team'] = 'cmsdataops'
         self.globalQueue.queueWork(spec.specUrl(), "Resubmit_TestWorkload", team="cmsdataops")


### PR DESCRIPTION
Fixes #9770 

#### Status
ready

#### Description
Fixed unit tests that started failing with changes merged in 9770

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
#9770 

#### External dependencies / deployment changes
none
