### PR TITLE
Add nose2 to the wmagent requirements file

### DIFF
--- a/requirements.wmagent.txt
+++ b/requirements.wmagent.txt
@@ -9,6 +9,7 @@ dbs-client==3.7.8
 decorator==3.4.2
 future==0.16.0
 httplib2==0.18.0
+nose2==0.9.2
 psutil==5.6.6
 py==1.7.0
 pyOpenSSL==18.0.0


### PR DESCRIPTION
Fixes #9777

#### Status
ready

#### Description
Added nose2 to the list of python packages that WMAgent depends on.
Library still not used anywhere, only to be shipped with the wmagent-dev docker image.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
https://github.com/cms-sw/cmsdist/pull/6003

#### External dependencies / deployment changes
yes, https://github.com/cms-sw/cmsdist/pull/6003
