### PR TITLE
Upload to pypi using twine

### DIFF
--- a/tools/build_pypi_packages.sh
+++ b/tools/build_pypi_packages.sh
@@ -35,18 +35,23 @@ case $TOBUILD in
       exit 1
 esac
 
+# clean up any previous builds
+rm -fv dist/*
+
 if $wmagent
   then
   /bin/cp requirements.wmagent.txt requirements.txt
   /bin/cp setup_wmagent.py setup.py
-  python setup.py sdist upload
+  python setup.py sdist
+  twine upload dist/wmagent-*
 fi
 
 if $wmcore
   then
   /bin/cp requirements.wmcore.txt requirements.txt
   /bin/cp setup_wmcore.py setup.py
-  python setup.py sdist upload
+  python setup.py sdist
+  twine upload dist/wmcore-*
 fi
 
 


### PR DESCRIPTION
Fixes #9768 

#### Status
Ready

#### Description
Updates PyPI build scripts to use twine for upload. Allows for getting prompted for a password instead of having to supply one in clear text in .pypirc.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
