### PR TITLE
Fix missing job report error codes

### DIFF
--- a/src/python/WMComponent/JobAccountant/AccountantWorker.py
+++ b/src/python/WMComponent/JobAccountant/AccountantWorker.py
@@ -634,7 +634,7 @@ class AccountantWorker(WMConnectionBase):
         path location.
         """
         report = Report()
-        report.addError("cmsRun1", 84, errorCode, errorDescription)
+        report.addError("cmsRun1", errorCode, "MissingJobReport", errorDescription)
         report.data.cmsRun1.status = "Failed"
         return report
 


### PR DESCRIPTION
Fixes #9534 
#### Status
Not tested (not sure how to test)

#### Description
Fixes reporting of error codes when job reports are missing.

#### Is it backward compatible (if not, which system it affects?)
Yes

#### Related PRs
None

#### External dependencies / deployment changes
None
