### PR TITLE
check for skipped steps in cmsRun exit code chirp, fixes #9769

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
@@ -51,10 +51,13 @@ class CMSSW(Executor):
         """
         Set return code.
         """
-        self.setCondorChirpAttrDelayed('Chirp_WMCore_cmsRun_ExitCode', returnCode)
+        currentReturnCode = self.getCondorChirpAttrDelayed('Chirp_WMCore_cmsRun_ExitCode')
+        if currentReturnCode is None or currentReturnCode == 0:
+            self.setCondorChirpAttrDelayed('Chirp_WMCore_cmsRun_ExitCode', returnCode)
         self.setCondorChirpAttrDelayed('Chirp_WMCore_%s_ExitCode' % self.stepName, returnCode)
         if returnMessage and returnCode != 0:
-            self.setCondorChirpAttrDelayed('Chirp_WMCore_cmsRun_Exception_Message', returnMessage, compress=True)
+            if currentReturnCode is None or currentReturnCode == 0:
+                self.setCondorChirpAttrDelayed('Chirp_WMCore_cmsRun_Exception_Message', returnMessage, compress=True)
             self.setCondorChirpAttrDelayed('Chirp_WMCore_%s_Exception_Message' % self.stepName, returnMessage, compress=True)
         self.step.execution.exitStatus = returnCode
 


### PR DESCRIPTION
Fixes #9769 

#### Status
not-tested

#### Description
Check the overall (aggregate) cmsRun exit code chirp for previously chirped exit codes. If the exit code is already set to a non-zero value, don't do the chirp. This way we keep as the overall (aggregate) value the last meaningful exit code. Same logic for the overall (aggregate) exception message. 

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
Only affects job runtime behavior and values reported to job monitoring.
