### PR TITLE
reduce default number of pycurl connections to 50

### DIFF
--- a/src/python/WMCore/Services/pycurl_manager.py
+++ b/src/python/WMCore/Services/pycurl_manager.py
@@ -368,7 +368,7 @@ def cern_sso_cookie(url, fname, cert, ckey):
     proc.wait()
 
 
-def getdata(urls, ckey, cert, headers=None, options=None, num_conn=100, cookie=None):
+def getdata(urls, ckey, cert, headers=None, options=None, num_conn=50, cookie=None):
     """
     Get data for given list of urls, using provided number of connections
     and user credentials


### PR DESCRIPTION
Fixes #9752 

#### Status
ready

#### Description
Change the default number of concurrent requests to 50. Mostly because we want to avoid getting throttled by DBS.
Eventually, we should make it configurable in the MicroServices though...

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
