### PR TITLE
Integrate shellcheck as a github action

### DIFF
--- a/.github/actions/check_shell_script.yml
+++ b/.github/actions/check_shell_script.yml
@@ -1,0 +1,20 @@
+name: Check Shell Script Syntax
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2.2.0
+    - name: Get Diff Action
+      uses: technote-space/get-diff-action@v1.2.8
+    - name: Install ShellCheck
+      run: |
+        sudo apt-get install shellcheck
+      if: env.GIT_DIFF
+    - name: Lint with ShellCheck
+      run: |
+        shellcheck --shell=bash -x ${{ env.GIT_DIFF }}
+      if: env.GIT_DIFF

--- a/deploy/deploy-wmagent.sh
+++ b/deploy/deploy-wmagent.sh
@@ -25,8 +25,8 @@
 ### Usage:               -c <central_services> Url to central services hosting central couchdb (e.g. alancc7-cloud1.cern.ch)
 ### Usage:
 ### Usage: deploy-wmagent.sh -w <wma_version> -d <deployment_tag> -t <team_name> [-s <scram_arch>] [-r <repository>] [-n <agent_number>] [-c <central_services_url>]
-### Usage: Example: sh deploy-wmagent.sh -w 1.3.3 -d HG2005b -t production -n 30
-### Usage: Example: sh deploy-wmagent.sh -w 1.3.3 -d HG2005b -t testbed-vocms001 -p "9643" -r comp=comp.amaltaro -c cmsweb-testbed.cern.ch
+### Usage: Example: sh deploy-wmagent.sh -w 1.3.3.patch4 -d HG2005b -t production -n 30
+### Usage: Example: sh deploy-wmagent.sh -w 1.3.3.patch4 -d HG2005b -t testbed-vocms001 -p "9643" -r comp=comp.amaltaro -c cmsweb-testbed.cern.ch
 ### Usage:
 
 IAM=`whoami`


### PR DESCRIPTION
Fixes #9787 

#### Status
not-tested

#### Description
This action will get triggered for every single pull request created. It performs a shellcheck on the files
changed within the PR. AFAIK, it won't cause problems if we pass a non-shell script as input to the
shellcheck, to be tested though.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
All the credits go to Ishan: https://github.com/CMSCompOps/WmAgentScripts/pull/597

#### External dependencies / deployment changes
none
