### PR TITLE
Do not validate Trust flags for ACDC workflows

### DIFF
--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -1861,19 +1861,25 @@ class WMWorkloadHelper(PersistencyHelper):
 
     def setTrustLocationFlag(self, inputFlag=False, pileupFlag=False):
         """
-        _setTrustLocationFlag_
-
         Set the input and the pileup flags in the top level tasks
         indicating that site lists should be used as location data
 
         The input data flag has to be set only for top level tasks, otherwise
         it affects where secondary jobs are meant to run.
         The pileup flag has to be set for all the tasks in the workload.
+
+        Validate these parameters to make sure they are only set for workflows
+        that require those type of input datasets (ACDCs are not validated)
         """
-        if inputFlag is True and not self.listInputDatasets():
+        isACDCWorkflow = False
+        for task in self.taskIterator():
+            if task.getInputACDC():
+                isACDCWorkflow = True
+
+        if inputFlag is True and isACDCWorkflow is False and not self.listInputDatasets():
             msg = "Setting TrustSitelists=True for workflows without input dataset is forbidden!"
             raise RuntimeError(msg)
-        if pileupFlag is True and not self.listPileupDatasets():
+        if pileupFlag is True and isACDCWorkflow is False and not self.listPileupDatasets():
             msg = "Setting TrustPUSitelists=True for workflows without pileup dataset is forbidden!"
             raise RuntimeError(msg)
         for task in self.getAllTasks(cpuOnly=True):


### PR DESCRIPTION
Fixes #9792 

#### Status
tested

#### Description
Do not validate the Trust* flags during assignment if the workflow is an ACDC (Resubmission).

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Complement to: https://github.com/dmwm/WMCore/pull/9770

#### External dependencies / deployment changes
none
