### PR TITLE
Pileup is transferred to a single location, do the same for input blocks

### DIFF
--- a/src/python/WMCore/MicroService/Unified/MSTransferor.py
+++ b/src/python/WMCore/MicroService/Unified/MSTransferor.py
@@ -16,7 +16,7 @@ from httplib import HTTPException
 from operator import itemgetter
 from pprint import pformat
 from retry import retry
-from random import randint
+from random import randint, choice
 from copy import deepcopy
 
 # WMCore modules
@@ -389,11 +389,14 @@ class MSTransferor(MSCore):
             elif size == maxSize:
                 finalPNN.add(pnn)
         self.logger.info("The PNN that would require less data to be transferred is: %s", finalPNN)
-        # TODO: 100GB is a magic number here. It really depends on how much CPU/h the
-        # workflow would require, and perhaps something else
-        if maxSize < 100 * 1024 ** 3:
-            finalPNN = set(volumeByPNN.keys())
-            self.logger.info("However, the available data volume is too small, so using all PNNs: %s", finalPNN)
+        if len(finalPNN) > 1:
+            # magically picks one site from the list. It could pick the one with highest
+            # available quota, but that might overload that one site...
+            # make sure it's a set object
+            finalPNN = choice(list(finalPNN))
+            finalPNN = {finalPNN}
+            self.logger.info("Randomly picked PNN: %s as final location", finalPNN)
+
         return finalPNN
 
     def checkPUDataLocation(self, wflow):


### PR DESCRIPTION
Fixes #9799 

#### Status
tested

#### Description
If we need to make a data placement for the pileup dataset, then a pre-selection of a **single** PNN has to happen, because we do not make multiple pileup data placement within the same workflow.
This means that, the primary/parent input blocks will have to go to the same location. 

Note-1: if the list of PNNs for the pileup has multiple PNNs, then that means we need to transfer the same amount of data to any of those sites. In this case, we randomly pick one of them.
Note-2: this can potentially subscribe too much data to a given site, but there isn't much do be done until we come up with a best schema for pileup usage..

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Complement (or bugfix) to: https://github.com/dmwm/WMCore/pull/9764

#### External dependencies / deployment changes
none
