### PR TITLE
Add leading zeros to adler32 checksum to ensure 8 chars length

### DIFF
--- a/src/python/Utils/FileTools.py
+++ b/src/python/Utils/FileTools.py
@@ -49,7 +49,7 @@ def calculateChecksums(filename):
     if len(cksumStdout) != 2 or int(cksumStdout[1]) != filesize:
         raise RuntimeError("Something went wrong with the cksum calculation !")
 
-    return ("%x" % (adler32Checksum & 0xffffffff), "%s" % cksumStdout[0])
+    return (format(adler32Checksum & 0xffffffff, '08x'), "%s" % cksumStdout[0])
 
 
 def tail(filename, nLines=20):

--- a/test/python/Utils_t/FileTools_t.py
+++ b/test/python/Utils_t/FileTools_t.py
@@ -68,9 +68,8 @@ class testFileTools(unittest.TestCase):
         silly = "This is a rather ridiculous string"
         filename = os.path.join(self.testDir, 'fileInfo.test')
 
-        f = open(filename, 'w')
-        f.write(silly)
-        f.close()
+        with open(filename, 'w') as fObj:
+            fObj.write(silly)
 
         info = FileTools.getFileInfo(filename=filename)
         self.assertEqual(info['Name'], filename)
@@ -83,6 +82,27 @@ class testFileTools(unittest.TestCase):
         self.assertIsNotNone(fullPath)
         fullPath = FileTools.getFullPath("this_shouldnt_be")
         self.assertEqual(fullPath, None)
+
+    def testChecksum(self):
+        """
+        Test file checksums calculation
+        """
+        filename = os.path.join(self.testDir, 'fileInfo.test')
+        with open(filename, 'w') as fObj:
+            fObj.write("")
+
+        (adler32, cksum) = FileTools.calculateChecksums(filename=filename)
+        self.assertEqual(adler32, "00000001")
+        self.assertEqual(cksum, "4294967295")
+
+        silly = "This is a rather ridiculous string"
+        with open(filename, 'w') as fObj:
+            fObj.write(silly * 100001)
+        (adler32, cksum) = FileTools.calculateChecksums(filename=filename)
+        self.assertEqual(adler32, "827db5b1")
+        self.assertEqual(cksum, "3774692924")
+        return
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #9763

#### Status
not-tested

#### Description
Apparently there are cases that adler32 checksum does not result in 8 chars length word. This fix will pad it with zeros and ensure it's always a 8 chars string.

Note: for files already
#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none