### PR TITLE
Add leading zeros to adler32 checksum to ensure 8 chars length - wma branch

### DIFF
--- a/src/python/Utils/FileTools.py
+++ b/src/python/Utils/FileTools.py
@@ -49,7 +49,7 @@ def calculateChecksums(filename):
     if len(cksumStdout) != 2 or int(cksumStdout[1]) != filesize:
         raise RuntimeError("Something went wrong with the cksum calculation !")
 
-    return ("%x" % (adler32Checksum & 0xffffffff), "%s" % cksumStdout[0])
+    return (format(adler32Checksum & 0xffffffff, '08x'), "%s" % cksumStdout[0])
 
 
 def tail(filename, nLines=20):

--- a/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
+++ b/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
@@ -306,7 +306,7 @@ class RucioInjectorPoller(BaseWorkerThread):
                         listLfns.append(fileInfo['lfn'])
                         injectData.append(dict(name=fileInfo['lfn'], scope=self.scope,
                                                bytes=fileInfo['size'], state="A",
-                                               adler32=fileInfo['checksum']['adler32']))
+                                               adler32=fileInfo['checksum']['adler32'].zfill(8)))
 
                     if self.rucio.createReplicas(rse=rseName, files=injectData, block=block):
                         logging.info("Successfully inserted %d files on block %s", len(listLfns), block)


### PR DESCRIPTION
wmagent branch version of https://github.com/dmwm/WMCore/pull/9809

Plus, a second fix to the RucioInjector, for cases where the file information has already been persisted in the database with an adler32 value that does not match this Rucio server regex:
`'^[a-fA-F\\d]{8}$'`

I tested some print-statement only in one of the production agents, and it seems to do the trick:
```
2020-07-08 17:59:12,790:140568300840704:INFO:RucioInjectorPoller:AMR current adler32 37cc05 and new adler32 0037cc05
2020-07-08 17:59:12,790:140568300840704:INFO:RucioInjectorPoller:AMR current adler32 499110dc and new adler32 499110dc
...
2020-07-08 17:59:12,805:140568300840704:INFO:RucioInjectorPoller:AMR current adler32 995c1a90 and new adler32 995c1a90
2020-07-08 17:59:12,805:140568300840704:INFO:RucioInjectorPoller:AMR current adler32 5e3a80 and new adler32 005e3a80
2020-07-08 17:59:12,805:140568300840704:INFO:RucioInjectorPoller:AMR current adler32 61cdb8e1 and new adler32 61cdb8e1
2020-07-08 17:59:12,805:140568300840704:INFO:RucioInjectorPoller:AMR current adler32 655dc518 and new adler32 655dc518
```