### PR TITLE
[py2py3] Migrate WMCore/Cache/*

### DIFF
--- a/src/python/WMCore/Cache/GenericDataCache.py
+++ b/src/python/WMCore/Cache/GenericDataCache.py
@@ -1,4 +1,6 @@
 from __future__ import print_function, division
+from builtins import str
+from builtins import object
 import time
 import logging
 

--- a/src/python/WMCore/Cache/WMConfigCache.py
+++ b/src/python/WMCore/Cache/WMConfigCache.py
@@ -5,14 +5,16 @@ _WMConfigCache_
 Being in itself a wrapped class around a config cache
 """
 
-from future.utils import with_metaclass
 from future import standard_library
 standard_library.install_aliases()
+import urllib.request, urllib.parse, urllib.error
+from builtins import str
+from future.utils import with_metaclass
+from future.utils import viewkeys, viewvalues
 
 import hashlib
 import logging
 import traceback
-import urllib.request
 from contextlib import closing
 
 import WMCore.GroupUser.Decorators as Decorators
@@ -269,12 +271,12 @@ class ConfigCache(WMObject):
         """
         try:
             self.document = self.database.document(id=configID)
-            if 'owner' in self.document.keys():
+            if 'owner' in self.document:
                 self.connectUserGroup(groupname=self.document['owner'].get('group', None),
                                       username=self.document['owner'].get('user', None))
-            if '_attachments' in self.document.keys():
+            if '_attachments' in self.document:
                 # Then we need to load the attachments
-                for key in self.document['_attachments'].keys():
+                for key in viewkeys(self.document['_attachments']):
                     self.loadAttachment(name=key)
         except CouchNotFoundError as ex:
             msg = "Document with id %s not found in couch\n" % (configID)
@@ -301,7 +303,7 @@ class ConfigCache(WMObject):
         attach = self.database.getAttachment(self.document["_id"], name)
 
         if not overwrite:
-            if name in self.attachments.keys():
+            if name in self.attachments:
                 logging.info("Attachment already exists, so we're skipping")
                 return
 
@@ -400,7 +402,7 @@ class ConfigCache(WMObject):
         Retrieve the dataset information for the config in the ConfigCache.
         """
         psetTweaks = self.getPSetTweaks()
-        if not 'process' in psetTweaks.keys():
+        if 'process' not in psetTweaks:
             raise ConfigCacheException("Could not find process field in PSet while getting output modules!")
         try:
             outputModuleNames = psetTweaks["process"]["outputModules_"]
@@ -548,14 +550,14 @@ class ConfigCache(WMObject):
                 # Something's gone wrong with trying to open the configCache
                 msg = "Error in getting output modules from ConfigCache during workload validation.  Check ConfigCache formatting!"
                 raise ConfigCacheException("%s: %s" % (msg, str(ex)))
-            for outputModule in outputModuleInfo.values():
+            for outputModule in viewvalues(outputModuleInfo):
                 dataTier = outputModule.get('dataTier', None)
                 filterName = outputModule.get('filterName', None)
                 if not dataTier:
                     raise ConfigCacheException("No DataTier in output module.")
 
                 # Add dataTier to duplicate dictionary
-                if not dataTier in duplicateCheck.keys():
+                if dataTier not in duplicateCheck:
                     duplicateCheck[dataTier] = []
                 if filterName in duplicateCheck[dataTier]:
                     # Then we've seen this combination before

--- a/src/python/WMCore/DataStructs/WMObject.py
+++ b/src/python/WMCore/DataStructs/WMObject.py
@@ -5,6 +5,7 @@ _WMObject_
 Helper class that other objects should inherit from
 
 """
+from builtins import object
 __all__ = []
 
 

--- a/src/python/WMCore/Database/CMSCouch.py
+++ b/src/python/WMCore/Database/CMSCouch.py
@@ -12,6 +12,9 @@ from __future__ import print_function, division
 
 from future import standard_library
 standard_library.install_aliases()
+from builtins import str, object
+from future.utils import viewitems
+import urllib.request, urllib.parse, urllib.error
 
 import base64
 import hashlib
@@ -19,7 +22,6 @@ import logging
 import re
 import time
 import traceback
-import urllib.parse
 from datetime import datetime
 from http.client import HTTPException
 
@@ -201,7 +203,7 @@ class Database(CouchDBRequests):
             data[label] = int(time.time())
         else:
             for doc in data:
-                if label not in doc.keys():
+                if label not in doc:
                     doc[label] = int(time.time())
         return data
 
@@ -523,7 +525,7 @@ class Database(CouchDBRequests):
         options = options or {}
         keys = keys or []
         encodedOptions = {}
-        for k, v in options.iteritems():
+        for k, v in viewitems(options):
             # We can't encode the stale option, as it will be converted to '"ok"'
             # which couch barfs on.
             if k == "stale":
@@ -558,7 +560,7 @@ class Database(CouchDBRequests):
         options = options or {}
         keys = keys or []
         encodedOptions = {}
-        for k, v in options.iteritems():
+        for k, v in viewitems(options):
             encodedOptions[k] = self.encode(v)
 
         if keys:
@@ -600,7 +602,7 @@ class Database(CouchDBRequests):
         options = options or {}
         keys = keys or []
         encodedOptions = {}
-        for k, v in options.iteritems():
+        for k, v in viewitems(options):
             encodedOptions[k] = self.encode(v)
 
         if keys:

--- a/src/python/WMCore/GroupUser/CouchObject.py
+++ b/src/python/WMCore/GroupUser/CouchObject.py
@@ -8,6 +8,7 @@ Copyright (c) 2010 Fermilab. All rights reserved.
 """
 from __future__ import print_function
 
+from builtins import str
 import json as jsonlib
 
 import WMCore.Database.CMSCouch as CMSCouch

--- a/src/python/WMCore/Lexicon.py
+++ b/src/python/WMCore/Lexicon.py
@@ -10,6 +10,8 @@ from __future__ import print_function, division
 
 from future import standard_library
 standard_library.install_aliases()
+from builtins import str
+from future.utils import viewvalues
 
 import io
 import logging
@@ -258,7 +260,7 @@ def physicsgroup(candidate):
 def procversion(candidate):
     """ Integers """
     if isinstance(candidate, dict):
-        for candi in candidate.values():
+        for candi in viewvalues(candidate):
             check(r'^[0-9]+$', str(candi))
         return True
     else:
@@ -270,7 +272,7 @@ def procstring(candidate):
     if not candidate:
         raise AssertionError("ProcStr cannot be empty or None.")
     if isinstance(candidate, dict):
-        for candi in candidate.values():
+        for candi in viewvalues(candidate):
             check(r'[a-zA-Z0-9_]{1,100}$', candi)
         return True
     else:
@@ -282,7 +284,7 @@ def procstringT0(candidate):
     ProcessingString validation function for T0 specs
     """
     if isinstance(candidate, dict):
-        for candi in candidate.values():
+        for candi in viewvalues(candidate):
             check(r'^$|[a-zA-Z0-9_]{1,100}$', candi)
         return True
     else:
@@ -297,7 +299,7 @@ def acqname(candidate):
     if not candidate:
         raise AssertionError("AcqEra cannot be empty or None.")
     if isinstance(candidate, dict):
-        for candi in candidate.values():
+        for candi in viewvalues(candidate):
             check(r'[a-zA-Z][a-zA-Z0-9_]*$', candi)
         return True
     else:

--- a/src/python/WMCore/Services/pycurl_manager.py
+++ b/src/python/WMCore/Services/pycurl_manager.py
@@ -40,6 +40,10 @@ from __future__ import print_function
 from future import standard_library
 standard_library.install_aliases()
 
+from builtins import str, range, object
+from past.builtins import basestring
+from future.utils import viewitems
+
 # system modules
 import json
 import logging
@@ -51,7 +55,6 @@ import pycurl
 from io import BytesIO
 import http.client
 from urllib.parse import urlencode
-
 
 class ResponseHeader(object):
     """ResponseHeader parses HTTP response header"""
@@ -214,7 +217,7 @@ class RequestHandler(object):
         curl.setopt(pycurl.URL, str(url))
         if headers:
             curl.setopt(pycurl.HTTPHEADER, \
-                    ["%s: %s" % (k, v) for k, v in headers.items()])
+                    ["%s: %s" % (k, v) for k, v in viewitems(headers)])
         bbuf = BytesIO()
         hbuf = BytesIO()
         curl.setopt(pycurl.WRITEFUNCTION, bbuf.write)
@@ -411,14 +414,14 @@ def getdata(urls, ckey, cert, headers=None, options=None, num_conn=50, cookie=No
     for _ in range(num_conn):
         curl = pycurl.Curl()
         curl.fp = None
-        for key, val in options.items():
+        for key, val in viewitems(options):
             curl.setopt(getattr(pycurl, key), val)
         curl.setopt(pycurl.SSLKEY, ckey)
         curl.setopt(pycurl.SSLCERT, cert)
         mcurl.handles.append(curl)
         if headers:
             curl.setopt(pycurl.HTTPHEADER, \
-                        ["%s: %s" % (k, v) for k, v in headers.items()])
+                        ["%s: %s" % (k, v) for k, v in viewitems(headers)])
 
     # Main loop
     freelist = mcurl.handles[:]

--- a/src/python/WMCore/WMException.py
+++ b/src/python/WMCore/WMException.py
@@ -6,7 +6,9 @@ General Exception class for WM modules
 
 """
 
-import exceptions
+from builtins import str
+from future.utils import viewitems
+
 import inspect
 import logging
 import sys
@@ -16,7 +18,7 @@ WMEXCEPTION_START_STR = "<@========== WMException Start ==========@>"
 WMEXCEPTION_END_STR = "<@---------- WMException End ----------@>"
 
 
-class WMException(exceptions.Exception):
+class WMException(Exception):
     """
     _WMException_
 
@@ -32,7 +34,7 @@ class WMException(exceptions.Exception):
             # interprets this string using utf-8 codec and ignoring any errors
             message = message.decode('utf-8', 'ignore')
 
-        exceptions.Exception.__init__(self, self.name, message)
+        Exception.__init__(self, self.name, message)
 
         #  //
         # // Init data dictionary with defaults
@@ -111,7 +113,7 @@ class WMException(exceptions.Exception):
         Add key=value information pairs to an
         exception instance
         """
-        for key, value in data.items():
+        for key, value in viewitems(data):
             self[key] = value
         return
 
@@ -125,7 +127,7 @@ class WMException(exceptions.Exception):
         strg += self._message
         strg += "</Message>\n"
         strg += "<DataItems>\n"
-        for key, value in self.data.items():
+        for key, value in viewitems(self.data):
             strg += "<DataItem>\n"
             strg += "<Key>\n"
             strg += str(key)
@@ -145,7 +147,7 @@ class WMException(exceptions.Exception):
         strg = WMEXCEPTION_START_STR
         strg += "\nException Class: %s\n" % self.name
         strg += "Message: %s\n" % self._message
-        for key, value in self.data.items():
+        for key, value in viewitems(self.data):
             strg += "\t%s : %s\n" % (key, value,)
         strg += "\nTraceback: \n"
         strg += self.traceback


### PR DESCRIPTION
Fixes #9806 

#### Status

Done

ACHTUNG! Some of the changes in this PR will conflict with #9762. They are likely to be dealt with in #9762, since it has a lower priority and will likely be merged after this PR is done.

#### Description

Futurize is run on WMCore.Cache.WMConfigCache and the modules that it depends on.

Manual changes are applied to fix what futurize is not able to migrate:

1. Dictionaries

- replaced mydict.$operator() with view$operator(mydict)

  This is a temporary change and will not be needed anymore
  after dropping python2 support. This is used for performance
  reasons when running python2 with idioms that are compatibles
  with python3.

  Resources:
  * http://python-future.org/compatible_idioms.html#dictionaries
  * http://python-future.org/what_else.html#dict

- used a `iter*` operator only once in a loop in which the dictionary that was being looped over is updated

- used the guidelines at
  http://python-future.org/compatible_idioms.html#dict-keys-values-items-as-a-list
  for the cases in which we want to check if a string is
  among the **keys** of a dictionary. no need to use viewkeys for performance reasons.
  we can just use `list(mydict)` or `for key in mydict:` in both py2 and py3.

2. bytes and unicode strings

File: JSONThunker.py

- In python3 the meaning of `str()` in a return statement changed.
  The code now behaves in the same way as before, but the names
  used to check the string type have been updated to python3 nomenclature

3. urllib

File: WMConfigCache.py, `urllib.urlopen` changed to `urllib.request.urlopen` by futurize.

- `urllib.request.urlopen` behaves as `urllib2.urlopen`, throwing an
  exception in case of HTTP error, instead of simply returning valid
  data containing the details of the error.
  ACHTUNG! This may require changes to code that use
  `WMCore.Cache.WMConfigCache.ConfigCache.addConfig`
- `urllib.request.urlopen` behaves as `urllib2.urlopen`, requiring to
  specify the `file:` scheme if you want to open a file in a local
  filesystem. This required changing `WMConfigCache_t` unit tests.

Migration plan

step1
- [x] src/python/WMCore/WMException.py

step2
- [x] src/python/WMCore/Lexicon.py
- [x] src/python/WMCore/Algorithms/Permissions.py
- [x] src/python/WMCore/Wrappers/JsonWrapper/JSONThunker.py
- [x] src/python/WMCore/Services/pycurl_manager.py
- [x] src/python/Utils/CertTools.py

step 3
- [x] src/python/WMCore/Services/Requests.py

step 4
- [x] src/python/WMCore/Database/CMSCouch.py
- [x] src/python/WMCore/GroupUser/Decorators.py

step5
- [x] src/python/WMCore/GroupUser/CouchObject.py

step 6
- [x] src/python/WMCore/GroupUser/Group.py

step 7
- [x] src/python/WMCore/GroupUser/User.py
- [x] src/python/Utils/Patterns.py
- [x] src/python/WMCore/DataStructs/WMObject.py

step 8
- [x] src/python/WMCore/Cache/WMConfigCache.py

#### Is it backward compatible (if not, which system it affects?)
yes

#### External dependencies / deployment changes
requires python-future.org 
