### PR TITLE
Incomplete list of sites in Forcedown for US opportunistic sites.

### DIFF
--- a/deploy/deploy-wmagent.sh
+++ b/deploy/deploy-wmagent.sh
@@ -211,7 +211,7 @@ fi
 
 if [[ "$HOSTNAME" == *cern.ch ]]; then
   MYPROXY_CREDNAME="amaltaroCERN"
-  FORCEDOWN="'T3_US_NERSC'"
+  FORCEDOWN="'T3_US_NERSC', 'T3_US_SDSC', 'T3_US_OSG', 'T3_US_TACC', 'T3_US_PSC'"
 elif [[ "$HOSTNAME" == *fnal.gov ]]; then
   MYPROXY_CREDNAME="amaltaroFNAL"
   FORCEDOWN=""


### PR DESCRIPTION
Fixes #9814 

#### Status
not-tested 

#### Description
Adding all the T3_US_ opportunistic sites in the FORCEDOWN list in the wmagent deployment script.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs


#### External dependencies / deployment changes

