### PR TITLE
[py2py3] Configuration - sys.version_info compatible with py2.6

### DIFF
--- a/src/python/WMCore/Configuration.py
+++ b/src/python/WMCore/Configuration.py
@@ -14,7 +14,7 @@ import os
 import sys
 import traceback
 
-PY3 = sys.version_info.major == 3
+PY3 = sys.version_info[0] == 3
 
 # PY3 compatibility (can be removed once python2 gets dropped)
 if PY3:


### PR DESCRIPTION
Fixes #9835
#### Status
ready

#### Description
Change how major python version is checked in Configuration.py so that it is compatible with py2.6

#### Is it backward compatible (if not, which system it affects?)
yes
