### PR TITLE
Workaround for tweaking MergeDQM and Harvesting jobs for RelVal

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -562,7 +562,14 @@ class SimpleCondorPlugin(BasePlugin):
             ad['My.EstimatedSingleCoreMins'] = str(estimatedMinsSingleCore)
             ad['My.OriginalMaxWallTimeMins'] = str(estimatedMins)
             ad['My.MaxWallTimeMins'] = 'WMCore_ResizeJob ? (EstimatedSingleCoreMins/RequestCpus + 15) : OriginalMaxWallTimeMins'
-            requestMemory = int(job['estimatedMemoryUsage']) if job.get('estimatedMemoryUsage', None) else 1000
+
+            ### adapt memory requirement here as well
+            if job['task_type'] == "Merge" and "MergeDQMoutput" in job['task_name']:
+                requestMemory = 4000
+            elif job['task_type'] == "Harvesting":
+                requestMemory = 4000
+            else:
+                requestMemory = int(job['estimatedMemoryUsage']) if job.get('estimatedMemoryUsage', None) else 1000
             ad['My.OriginalMemory'] = str(requestMemory)
             ad['My.ExtraMemory'] = str(self.extraMem)
             ad['request_memory'] = 'OriginalMemory + ExtraMemory * (WMCore_ResizeJob ? (RequestCpus-OriginalCpus) : 0)'


### PR DESCRIPTION
Fixes #9829 

#### Status
not-tested

#### Description
Workaround to be applied on the RelVal agent, to address the ROOT memory issues in the late CMSSW_11_1_x releases.
In short:
* it will update the memory requirements and PSS watchdog for *harvesting jobs* to 8.5GB
* it will update the memory requirements and PSS watchdog for *MergeDQM jobs* to 8.5GB

Once the patch is applied to the agent, we need to restart WorkQueueManager. BTW, it only applies to new workflows (when the sandbox gets created in the agent.

UPDATE: Merge and Harvesting job splitting algorithms do not set job resource requirements, so we need to orchestrate the SimpleCondorPlugin to add the memory requirements to the job classad as well.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
