### PR TITLE
Force HEPCloud resources to be down in the CERN agents

### DIFF
--- a/deploy/deploy-wmagent.sh
+++ b/deploy/deploy-wmagent.sh
@@ -211,7 +211,7 @@ fi
 
 if [[ "$HOSTNAME" == *cern.ch ]]; then
   MYPROXY_CREDNAME="amaltaroCERN"
-  FORCEDOWN="'T3_US_NERSC'"
+  FORCEDOWN="'T3_US_NERSC', 'T3_US_SDSC', 'T3_US_ANL', 'T3_US_TACC', 'T3_US_PSC'"
 elif [[ "$HOSTNAME" == *fnal.gov ]]; then
   MYPROXY_CREDNAME="amaltaroFNAL"
   FORCEDOWN=""


### PR DESCRIPTION
Fixes #9814 
Superseeds https://github.com/dmwm/WMCore/pull/9830

#### Status
ready

#### Description
List of T3_US resources that still depend on FNAL schedds to be able to flock to the HEPCloud resources.
It includes the latest updates provided by Dirk, such as:
* T3_US_OSG has been integrated into the global pool, so any schedd should be able to run jobs there
* T3_US_ANL, a new site being commissioned

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Initial implementation here: https://github.com/dmwm/WMCore/pull/9830

#### External dependencies / deployment changes
none
