### PR TITLE
Bump rucio-clients from 1.22.2 to .1.23.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ pyzmq==17.1.2
 retry==0.9.1
 setuptools==39.2.0
 stomp.py==4.1.15
-rucio-clients==1.22.2
+rucio-clients==1.23.0
 CMSMonitoring>=0.3.4
 # All dependencies needed to run MicroServices
 pymongo==3.10.1

--- a/requirements.wmagent.txt
+++ b/requirements.wmagent.txt
@@ -22,4 +22,4 @@ python-cjson==1.2.1
 pyzmq==17.1.2
 retry==0.9.1
 stomp.py==4.1.15
-rucio-clients==1.22.2
+rucio-clients==1.23.0


### PR DESCRIPTION
Fixes #9843 

#### Status
not-tested

#### Description
This has some database schema changes, so it could be that one or another API will fail. I have quickly discussed it with Eric and it should work for CMS Rucio, let's see how it goes.

From the release notes page here: https://github.com/rucio/rucio/releases , it's worthy mentioning the following changes:
* Clients: Allow passing the dynamic parameter to get_did() : https://github.com/rucio/rucio/issues/3760
* Clients: Python 3 error with uploadclient json.dump : https://github.com/rucio/rucio/issues/3747
* Rules: List all rules does not have a python equivalent, only REST : https://github.com/rucio/rucio/issues/3666
* Authentication & Authorisation: OAuth2/OIDC: compatibility with Python3 (raw_input/input) : https://github.com/rucio/rucio/issues/3637
* Clients: Use quote_plus for rule client : https://github.com/rucio/rucio/issues/3135

#### Is it backward compatible (if not, which system it affects?)
Likely not, get_did API supports an extra parameter

#### Related PRs
none

#### External dependencies / deployment changes
cmsdist in: https://github.com/cms-sw/cmsdist/pull/6075
