### PR TITLE
[py2py3] WMQuality.TestInit - Remove dependency on MySQL-python

### DIFF
--- a/src/python/WMQuality/TestInit.py
+++ b/src/python/WMQuality/TestInit.py
@@ -20,8 +20,6 @@ import tempfile
 import threading
 import traceback
 
-from _mysql_exceptions import OperationalError
-
 from WMCore.Agent.Configuration import Configuration
 from WMCore.Agent.Configuration import loadConfigurationFile
 from WMCore.WMException import WMException
@@ -157,8 +155,9 @@ class TestInit(object):
         # If the database is not empty when we go to set the schema, abort!
         try:
             result = self.init.checkDatabaseContents()
-        except OperationalError:
+        except Exception as e:
             logging.debug("Error checking DB contents, assume DB does not exist")
+            logging.debug(str(e))
             return
         if len(result) > 0:
             msg = "Database not empty, cannot set schema !\n"


### PR DESCRIPTION
#### Status
ready

#### Description
This is related to #9805

We want not to depend anymore on MySQL-python, since it does
not support python3.

This is the only occurrence of this package left in dmwm/WMCore

We used this library only to import a MySQL specific exception. The specific exception is being replaced by a more generic one.

#### Is it backward compatible (if not, which system it affects?)
YES

#### External dependencies / deployment changes

This make dmwm/WMCore not dependent on `MySQL-python`
