### PR TITLE
Update Rucio get_account_usage to get_local_account_usage API

### DIFF
--- a/src/python/WMCore/Services/Rucio/Rucio.py
+++ b/src/python/WMCore/Services/Rucio/Rucio.py
@@ -145,7 +145,7 @@ class Rucio(object):
         """
         res = None
         try:
-            res = list(self.cli.get_account_usage(acct, rse=rse))
+            res = list(self.cli.get_local_account_usage(acct, rse=rse))
         except (AccountNotFound, AccessDenied) as ex:
             self.logger.error("Failed to get account usage information from Rucio. Error: %s", str(ex))
         return res

--- a/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
+++ b/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
@@ -103,8 +103,21 @@ class RucioTest(EmulatedUnitTestCase):
         """
         Test whether we can fetch data about a specific rucio account
         """
-        res = list(self.client.get_account_usage(self.acct))
+        # test against a specific RSE
+        res = list(self.client.get_local_account_usage(self.acct, rse="T1_US_FNAL_Disk"))
+        res2 = self.myRucio.getAccountUsage(self.acct, rse="T1_US_FNAL_Disk")
+        self.assertEqual(res[0]["rse"], "T1_US_FNAL_Disk")
+        self.assertTrue(res[0]["files"] >= 1)
+        self.assertTrue(res[0]["bytes"] >= 1000)
+        self.assertTrue("bytes_remaining" in res[0])
+        self.assertTrue(res[0]["bytes_limit"] >= 0)
+        self.assertEqual(res, res2)
+
+        # test against all RSEs
+        res = list(self.client.get_local_account_usage(self.acct))
         res2 = self.myRucio.getAccountUsage(self.acct)
+        self.assertTrue(len(res) > 1)
+        self.assertTrue(len(res2) > 1)
         # I have manually created a rule for this account, so it will be there...
         self.assertEqual(res, res2)
 


### PR DESCRIPTION
Fixes #9786

#### Status
not-tested

#### Description
Replace the already deprecated `get_account_usage` client API by `get_local_account_usage`.
The output seems to be exactly the same, but I can't be sure because I no longer have the old rucio-clients version.

#### Is it backward compatible (if not, which system it affects?)
yes, in terms of response format. No, in terms of client API.

#### Related PRs
none

#### External dependencies / deployment changes
none
