### PR TITLE
Do not send parent/child data to DBS if there is nothing to be fixed

### DIFF
--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -965,7 +965,7 @@ class DBS3Reader(object):
                     mapChildParent.setdefault(childFileID, set())
                     mapChildParent[childFileID].add(parentId)
 
-        if insertFlag:
+        if insertFlag and mapChildParent:
             # convert dictionary to list of unique childID, parentID tuples
             listChildParent = []
             for childID in mapChildParent:


### PR DESCRIPTION
Fixes #9760 

#### Status
ready

#### Description
In case a run/lumi tuple has no match in the parent dataset, don't even try to post that empty list (as a parentage/child map) to DBS. Just skip that file/block and keep fixing the parentage information.

Note, those workflows that were failing to get fixed for the last many weeks have already been sorted. There should be no errors in the cherrypy logs as of now.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
