### PR TITLE
added getAccountLimits method to the Rucio wrapper

### DIFF
--- a/src/python/WMCore/Services/Rucio/Rucio.py
+++ b/src/python/WMCore/Services/Rucio/Rucio.py
@@ -132,6 +132,19 @@ class Rucio(object):
             self.logger.error("Failed to get account information from Rucio. Error: %s", str(ex))
         return res
 
+    def getAccountLimits(self, acct):
+        """
+        Provided an account name, fetch the storage quota for all RSEs
+        :param acct: a string with the rucio account name
+        :return: a dictionary of RSE name and quota in bytes.
+        """
+        res = {}
+        try:
+            res = self.cli.get_local_account_limits(acct)
+        except AccountNotFound as ex:
+            self.logger.error("Account: %s not found in the Rucio Server. Error: %s", acct, str(ex))
+        return res
+
     def getAccountUsage(self, acct, rse=None):
         """
         _getAccountUsage_

--- a/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
+++ b/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
@@ -101,7 +101,7 @@ class RucioTest(EmulatedUnitTestCase):
 
     def testGetAccountUsage(self):
         """
-        Test whether we can fetch data about a specific rucio account
+        Test whether we can fetch the data usage for a given rucio account
         """
         # test against a specific RSE
         res = list(self.client.get_local_account_usage(self.acct, rse="T1_US_FNAL_Disk"))
@@ -124,6 +124,25 @@ class RucioTest(EmulatedUnitTestCase):
         # now test against an account that either does not exist or that we cannot access
         res = self.myRucio.getAccountUsage("admin")
         self.assertIsNone(res)
+
+    def testGetAccountLimits(self):
+        """
+        Test whether we can fetch the data quota for a given rucio account
+        """
+        res = self.client.get_local_account_limits(self.acct)
+        res2 = self.myRucio.getAccountLimits(self.acct)
+        self.assertTrue(len(res) > 10)
+        self.assertTrue(len(res2) > 10)
+        #print(res)
+        self.assertEqual(res["T1_US_FNAL_Disk"], res2["T1_US_FNAL_Disk"])
+
+        # test an account that we have no access to
+        res = self.myRucio.getAccountLimits("wma_prod")
+        self.assertEqual(res, {})
+
+        # finally, test an account that does not exist
+        res = self.myRucio.getAccountLimits("any_random_account")
+        self.assertEqual(res, {})
 
     # @attr('integration')
     def testWhoAmI(self):


### PR DESCRIPTION
Fixes #9856 

#### Status
ready

#### Description
Added `getAccountLimits` to our Rucio wrapper service module, which uses the underlying`get_local_account_limits` Rucio python client API.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Stripping parts of #9759

#### External dependencies / deployment changes
none
