### PR TITLE
Update ParentageResolved flag for StepChains without parent as well

### DIFF
--- a/src/python/WMCore/ReqMgr/CherryPyThreads/StepChainParentageFixTask.py
+++ b/src/python/WMCore/ReqMgr/CherryPyThreads/StepChainParentageFixTask.py
@@ -21,9 +21,8 @@ def getChildDatasetsForStepChainMissingParent(reqmgrDB, status):
     for reqName, info in results.items():
 
         for dsInfo in info.values():
-            if dsInfo["ParentDset"]:
-                for childDS in dsInfo["ChildDsets"]:
-                    requestsByChildDataset[childDS].add(reqName)
+            for childDS in dsInfo["ChildDsets"]:
+                requestsByChildDataset[childDS].add(reqName)
     return requestsByChildDataset
 
 


### PR DESCRIPTION
Fixes #9864 

#### Status
ready

#### Description
Make sure every single StepChain workflow gets updated once they reach a status beyond `closed-out`, even if their output datasets do not have a parent dataset.

With this change, the number of DBS queries will increase (by a few hundred a day), because it has to ask DBS for the parent dataset. It will then print a warning like:
```
2020-08-11 15:51:17,986:WARNING:DBS3Reader:No parent dataset found for child dataset /TWZToLL_thad_Wlept_5f_DR_TuneCP5_PSweights_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM
```
and move on with the request spec update.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
This needs to get deployed in CMSWEB.