### PR TITLE
Improve py2 compatibility of WMException __init__

### DIFF
--- a/src/python/WMCore/WMException.py
+++ b/src/python/WMCore/WMException.py
@@ -6,7 +6,7 @@ General Exception class for WM modules
 
 """
 
-from builtins import str
+from builtins import bytes
 from future.utils import viewitems
 
 import inspect
@@ -29,7 +29,7 @@ class WMException(Exception):
 
     def __init__(self, message, errorNo=None, **data):
         self.name = str(self.__class__.__name__)
-        if hasattr(message, "decode"):
+        if type(message) == bytes:
             # Fix for the unicode encoding issue, see #8056 and #8403
             # interprets this string using utf-8 codec and ignoring any errors
             message = message.decode('utf-8', 'ignore')
@@ -153,7 +153,7 @@ class WMException(Exception):
         strg += self.traceback
         strg += '\n'
         strg += WMEXCEPTION_END_STR
-        if hasattr(strg, "decode"):
+        if type(strg) == bytes:
             # Fix for the unicode encoding issue, #8043
             strg = strg.decode('utf-8', 'ignore')
         return strg

--- a/test/python/WMCore_t/WMException_t.py
+++ b/test/python/WMCore_t/WMException_t.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
 """
 _WMException_t_
 
@@ -49,6 +50,22 @@ class WMExceptionTest(unittest.TestCase):
         data['key2'] = 'data2'
         exception.addInfo(**data)
         self.logger.debug("String version of exception: " + str(exception))
+
+    def testExceptionUnicode(self):
+        """
+        create an exception with non-ascii characters and do some tests.
+        """
+
+        exception = WMException("an exception message with nr. 100 and some non-ascii characters: ₩♏ℭ☺яε", 100)
+        self.logger.debug("String version of exception: " + str(exception))
+        self.logger.debug("XML version of exception: " + exception.xml())
+        self.logger.debug("Adding data")
+        data = {}
+        data['key1'] = 'value1'
+        data['key2'] = 'data2'
+        exception.addInfo(**data)
+        self.logger.debug("String version of exception: " + str(exception))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #9862 

#### Status
ready

#### Description

Small change to `WMException.__init__` in order to improve its handling of unicode error messages in python2

#### Is it backward compatible (if not, which system it affects?)
yes

#### External dependencies / deployment changes
This makes WMException depend on python future
