### PR TITLE
PY3: Properly deal with strings in REST/Main

### DIFF
--- a/src/python/WMCore/REST/Main.py
+++ b/src/python/WMCore/REST/Main.py
@@ -20,7 +20,7 @@ import thread
 import time
 import traceback
 from argparse import ArgumentParser
-from io import StringIO
+from io import BytesIO, StringIO
 from glob import glob
 from subprocess import Popen, PIPE
 from pprint import pformat
@@ -422,7 +422,10 @@ class RESTDaemon(RESTMain):
             self.run()
         except Exception as e:
             error = True
-            trace = StringIO()
+            if sys.version_info[0] == 2:
+                trace = BytesIO()
+            else:
+                trace = StringIO()
             traceback.print_exc(file=trace)
             cherrypy.log("ERROR: terminating due to error: %s" % trace.getvalue())
 


### PR DESCRIPTION
Fixes #9794 

#### Status
ready

#### Description
I'm still debugging the rucio initialization problem, but there seems to be no issue.
This PR fixes the unicode / string issue reported in the traceback. The traceback is a python2 string, so we need to use BytesIO instead of StringIO.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
None

#### External dependencies / deployment changes
None
