### PR TITLE
remove unneeded ImportError for py2/py3

### DIFF
--- a/src/python/WMCore/Storage/Plugins/FNALImpl.py
+++ b/src/python/WMCore/Storage/Plugins/FNALImpl.py
@@ -6,6 +6,7 @@ Implementation of StageOutImpl interface for FNAL
 
 """
 from future import standard_library
+
 standard_library.install_aliases()
 
 import logging
@@ -13,12 +14,7 @@ import os
 
 from WMCore.Storage.Plugins.LCGImpl import LCGImpl
 from WMCore.Storage.StageOutImplV2 import StageOutImplV2
-
-try:
-    from subprocess import getoutput
-except ImportError:
-    # python3
-    from subprocess import getoutput
+from subprocess import getoutput
 
 _CheckExitCodeOption = True
 checkPathsCount = 5
@@ -178,9 +174,7 @@ class FNALImpl(StageOutImplV2):
         elif method == 'dccp':
             logging.info("Translating PFN for dcache: %s", pfn)
             pfn = pfn.split("/store/")[1]
-            dcacheDoor = getoutput(
-                ". " + envScript + "\n" + \
-                "/opt/d-cache/dcap/bin/select_RdCapDoor.sh")
+            dcacheDoor = getoutput(". " + envScript + "\n" + "/opt/d-cache/dcap/bin/select_RdCapDoor.sh")
             pfn = "%s%s" % (dcacheDoor, pfn)
             logging.info("  Translated PFN: %s", pfn)
         elif method == 'lustre':


### PR DESCRIPTION
Fixes #9762

#### Status
ready

#### Description
Minor enhancement for the PR: https://github.com/dmwm/WMCore/pull/9762
which made usage of futurize to keep the same aliases in the path (between py2 and py3). Thus, catching that `ImportError` exception is no longer needed.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
https://github.com/dmwm/WMCore/pull/9762

#### External dependencies / deployment changes
none
