### PR TITLE
MS: Track Rucio rule progress in MSMonitor

### DIFF
--- a/src/python/WMCore/Services/Rucio/Rucio.py
+++ b/src/python/WMCore/Services/Rucio/Rucio.py
@@ -87,9 +87,7 @@ class Rucio(object):
         # yield output compatible with the PhEDEx service class
         self.phedexCompat = self.rucioParams.get("phedexCompatible", True)
 
-        msg = "WMCore Rucio initialization with acct: %s, host: %s, auth: %s" % (acct, hostUrl, authUrl)
-        msg += " and these extra parameters: %s" % self.rucioParams
-        self.logger.info(msg)
+        self.logger.info("WMCore Rucio initialization parameters: %s", self.rucioParams)
         self.cli = Client(rucio_host=hostUrl, auth_host=authUrl, account=acct,
                           ca_cert=self.rucioParams['ca_cert'], auth_type=self.rucioParams['auth_type'],
                           creds=self.rucioParams['creds'], timeout=self.rucioParams['timeout'],
@@ -98,7 +96,7 @@ class Rucio(object):
         for k in ("host", "auth_host", "auth_type", "account", "user_agent",
                   "ca_cert", "creds", "timeout", "request_retries"):
             clientParams[k] = getattr(self.cli, k)
-        self.logger.info("Rucio client initialization with: %s", clientParams)
+        self.logger.info("Rucio client initialization parameters: %s", clientParams)
 
     def pingServer(self):
         """
@@ -398,7 +396,6 @@ class Rucio(object):
         for item in files:
             item['scope'] = scope
 
-        # TODO: test to make sure 'state' is a valid argument
         response = False
         try:
             # add_replicas(rse, files, ignore_availability=True)

--- a/test/python/WMCore_t/MicroService_t/Unified_t/MSManager_t.py
+++ b/test/python/WMCore_t/MicroService_t/Unified_t/MSManager_t.py
@@ -24,7 +24,9 @@ class MSManagerTest(unittest.TestCase):
         data.quotaUsage = 0.8
         data.quotaAccount = "DataOps"
         data.enableStatusTransition = True
-        data.rucioAccount = "test"
+        data.rucioAccount = "wma_test"
+        data.rucioUrl = "http://cmsrucio-int.cern.ch"
+        data.rucioAuthUrl = "https://cmsrucio-auth-int.cern.ch"
         data.phedexUrl = "https://cmsweb.cern.ch/phedex/datasvc/json/prod"
         data.dbsUrl = "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader"
         data.smtpServer = "localhost"

--- a/test/python/WMCore_t/MicroService_t/Unified_t/MSMonitor_t.py
+++ b/test/python/WMCore_t/MicroService_t/Unified_t/MSMonitor_t.py
@@ -29,7 +29,10 @@ class MSMonitorTest(EmulatedUnitTestCase):
                          'reqmgr2Url': 'https://cmsweb-testbed.cern.ch/reqmgr2',
                          'reqmgrCacheUrl': 'https://cmsweb-testbed.cern.ch/couchdb/reqmgr_workload_cache',
                          'phedexUrl': 'https://cmsweb-testbed.cern.ch/phedex/datasvc/json/prod',
-                         'dbsUrl': 'https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader'}
+                         'dbsUrl': 'https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader',
+                         'rucioAccount': "wma_test",
+                         'rucioUrl': "http://cmsrucio-int.cern.ch",
+                         'rucioAuthUrl': "https://cmsrucio-auth-int.cern.ch"}
 
         self.ms = MSMonitor(self.msConfig)
         self.ms.reqmgrAux = MockReqMgrAux()
@@ -89,7 +92,7 @@ class MSMonitorTest(EmulatedUnitTestCase):
         Test the updateTransferInfo method
         """
         _, transferRecords = self.ms.updateCaches()
-        failed = self.ms.updateTransferDocs(transferRecords)
+        failed = self.ms.updateTransferDocs(transferRecords, workflowsToSkip=[])
         self.assertEqual(len(failed), len(transferRecords))
 
 


### PR DESCRIPTION
Fixes #9851 

#### Status
ready

#### Description
This PR provides the ability to track Rucio rule progress. The logic for the rucio rule is basically:
* if state == OK, then the rule progress is 100% (all files are where they are meant to be)
* else, progress depends on locks count such as: `locks_ok / total_files_to_be_locked`

In addition to that, it brings:
* skip workflow from the current cycle if the DM system request failed or if an invalid response was received (workflow progress update is retried in the next cycle)
* some logging improvements

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
Yes, the following deployment/configuration changes:
https://github.com/dmwm/deployment/pull/939
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/21
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/22