### PR TITLE
Rucio pick site

### DIFF
--- a/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
+++ b/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
@@ -282,3 +282,11 @@ class RucioTest(EmulatedUnitTestCase):
         # now an invalid "project" meta data
         response = validateMetaData("any_DID_name", dict(project="mistake"), self.myRucio.logger)
         self.assertFalse(response)
+
+    def testPickRSE(self):
+        """
+        Test the `pickRSE` method
+        """
+        resp = self.myRucio.pickRSE(rseExpression="ddm_quota>0", rseAttribute="ddm_quota")
+        self.assertTrue(len(resp) == 2)
+        self.assertTrue(resp[1] is True or resp[1] is False)


### PR DESCRIPTION
Fixes #9841 (or part of it)

#### Status
Ready

#### Description
Pick a custodial site. This does work against production which has quota values set on Disk sites. It can also work anywhere with equal weights when setting rseAttribute=None

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
No. When transition to python3 is done, a function can be remove
