### PR TITLE
Make WMException handle unicode messages in 1.3.6_wmagent

### DIFF
--- a/src/python/WMCore/WMException.py
+++ b/src/python/WMCore/WMException.py
@@ -27,7 +27,7 @@ class WMException(exceptions.Exception):
 
     def __init__(self, message, errorNo=None, **data):
         self.name = str(self.__class__.__name__)
-        if hasattr(message, "decode"):
+        if type(message) == str:
             # Fix for the unicode encoding issue, see #8056 and #8403
             # interprets this string using utf-8 codec and ignoring any errors
             message = message.decode('utf-8', 'ignore')
@@ -144,16 +144,16 @@ class WMException(exceptions.Exception):
         # WARNING: Do not change this string - it is used to extract error from log
         strg = WMEXCEPTION_START_STR
         strg += "\nException Class: %s\n" % self.name
-        strg += "Message: %s\n" % self._message
+        strg += "Message: %s\n" % self._message.encode('utf-8')
         for key, value in self.data.items():
             strg += "\t%s : %s\n" % (key, value,)
         strg += "\nTraceback: \n"
         strg += self.traceback
         strg += '\n'
         strg += WMEXCEPTION_END_STR
-        if hasattr(strg, "decode"):
-            # Fix for the unicode encoding issue, #8043
-            strg = strg.decode('utf-8', 'ignore')
+        # if type(strg) == str:
+        #     # Fix for the unicode encoding issue, #8403
+        #     strg = strg.decode('utf-8', 'ignore')
         return strg
 
     def message(self):

--- a/test/python/WMCore_t/WMException_t.py
+++ b/test/python/WMCore_t/WMException_t.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
 """
 _WMException_t_
 
@@ -49,6 +50,22 @@ class WMExceptionTest(unittest.TestCase):
         data['key2'] = 'data2'
         exception.addInfo(**data)
         self.logger.debug("String version of exception: " + str(exception))
+
+    def testExceptionUnicode(self):
+        """
+        create an exception with non-ascii characters and do some tests.
+        """
+
+        exception = WMException("an exception message with nr. 100 and some non-ascii characters: ₩♏ℭ☺яε", 100)
+        self.logger.debug("String version of exception: " + str(exception))
+        self.logger.debug("XML version of exception: " + exception.xml())
+        self.logger.debug("Adding data")
+        data = {}
+        data['key1'] = 'value1'
+        data['key2'] = 'data2'
+        exception.addInfo(**data)
+        self.logger.debug("String version of exception: " + str(exception))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #9885 

#### Status
In development

#### Description
Assumption: this only has to work in python2. I do not use python-future.

I am not sure yet where the bug comes from, so I just made WMException more consistent.
Now `str(myexception)` always return `str`, so that 

```python
# python2 only
"this is a bytes string in py2" + str(myexception)
```

is always concatenation of two bytes strings.

The argument `message` is converted into unicode in `__init__()`, `self._message` is always unicode, `self._message()` is converted back to bytes str when `__str__()` is called.

This is a test, I would like to see if this breaks any unit test not directly related to WMException. Meanwhile, I continue investigating the bug. With the new unit test we may spot the error with Jenkins, or use it to run a program that is supposed to failed in the incriminated node in case this is an environment error and not an error in our code.

#### Is it backward compatible (if not, which system it affects?)
YES

#### External dependencies / deployment changes
Right now, this does not requires any new external dependency
