### PR TITLE
Rucio wrapper API to find where data is locked and available

### DIFF
--- a/bin/wmagent-mod-config
+++ b/bin/wmagent-mod-config
@@ -111,8 +111,6 @@ def modifyConfiguration(config, **args):
     if hasattr(config, "General"):
         config.General.central_logdb_url = args["central_logdb_url"]
         config.General.centralWMStatsURL = args["wmstats_url"]
-        # Both PhEDExInjector and WorkQueueManager use it, so we better make it general
-        config.General.rucioAccount = args["rucio_account"]
         # t0 agent doesn't have reqmgr2_url
         if "reqmgr2_url" in args:
             config.General.ReqMgr2ServiceURL = args["reqmgr2_url"]

--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -88,7 +88,6 @@ config.General.logdb_name = logDBName
 config.General.central_logdb_url = "need to get from secrets file"
 config.General.ReqMgr2ServiceURL = "ReqMgr2 rest service"
 config.General.centralWMStatsURL = "Central WMStats URL"
-config.General.rucioAccount = "OVERWRITE_BY_SECRETS"
 
 config.section_("JobStateMachine")
 config.JobStateMachine.couchurl = couchURL
@@ -135,6 +134,8 @@ config.WorkQueueManager.queueParams["ParentQueueCouchUrl"] = "https://cmsweb.cer
 config.WorkQueueManager.queueParams["QueueURL"] = "http://%s:5984" % (config.Agent.hostName)
 config.WorkQueueManager.queueParams["WorkPerCycle"] = 200  # don't pull more than this number of elements per cycle
 config.WorkQueueManager.queueParams["QueueDepth"] = 0.5  # pull work from GQ for only half of the resources
+config.WorkQueueManager.queueParams["rucioAccount"] = "wmcore_transferor"  # account for data locks
+
 
 config.component_("DBS3Upload")
 config.DBS3Upload.namespace = "WMComponent.DBS3Buffer.DBS3Upload"

--- a/src/python/WMCore/MicroService/Unified/MSTransferor.py
+++ b/src/python/WMCore/MicroService/Unified/MSTransferor.py
@@ -629,7 +629,11 @@ class MSTransferor(MSCore):
                 if not blocks and dataIn["type"] == "primary":
                     # no valid files in any blocks, it will likely fail in global workqueue
                     return success, response
-                if blocks:
+                if wflow.getReqType() == "DQMHarvest":
+                    # enforce a dataset level PhEDEx subscription / container-level Rucio rule
+                    subLevel = "dataset"
+                    dataBlocks = None
+                elif blocks:
                     subLevel = "block"
                     dataBlocks = {dataIn['name']: blocks}
                 else:
@@ -876,6 +880,10 @@ class MSTransferor(MSCore):
 
         ### NOTE: data placement done in a block basis
         if dataIn["type"] == "primary":
+            # Except for DQMHarvest workflows, which must have a data placement of the
+            # whole dataset within the same location
+            if wflow.getReqType() == "DQMHarvest":
+                numNodes = 1
             # if we are using Rucio and there is no parent dataset, just put all
             # the data in a single rule for all RSEs and let Rucio decide where data will land
             if self.msConfig['useRucio'] and not wflow.getParentBlocks():

--- a/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
@@ -37,7 +37,7 @@ class StartPolicyInterface(PolicyInterface):
         self.pileupData = {}
         self.cric = CRIC()
         if usingRucio():
-            self.rucio = Rucio(self.args['rucioAcct'], configDict={'phedexCompatible': False})
+            self.rucio = Rucio(self.args['rucioAcct'], configDict={'logger': self.logger})
         else:
             self.phedex = PhEDEx()  # this will go away eventually
 
@@ -241,16 +241,21 @@ class StartPolicyInterface(PolicyInterface):
         raise NotImplementedError("This can't be called on a base StartPolicyInterface object")
 
     def getDatasetLocations(self, datasets):
-        """Returns a dictionary with the location of the datasets according to DBS"""
+        """
+        Returns a dictionary with the location of the datasets according to Rucio
+        The definition of "location" here is a union of all sites holding at least
+        part of the dataset (defined by the DATASET grouping).
+        :param datasets: dictionary with a list of dataset names (key'ed by the DBS URL)
+        :return: a dictionary of dataset locations, key'ed by the dataset name
+        """
         result = {}
         for dbsUrl in datasets:
             for datasetPath in datasets[dbsUrl]:
-                locations = set()
                 if hasattr(self, "rucio"):
-                    resp = self.rucio.getReplicaInfoForBlocks(dataset=datasetPath)
-                    for item in resp:
-                        locations.update(item['replica'])
+                    locations = self.rucio.getDataLockedAndAvailable(name=datasetPath, grouping="DATASET",
+                                                                     account=self.args['rucioAcct'])
                 else:
+                    locations = set()
                     resp = self.phedex.getReplicaPhEDExNodesForBlocks(dataset=[datasetPath], complete='y')
                     for blockSites in resp.values():
                         locations.update(blockSites)

--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -183,9 +183,10 @@ class WorkQueue(WorkQueueBase):
             if self.params['SplittingMapping']['DatasetBlock']['name'] != 'Block':
                 raise RuntimeError('Only blocks can be released on location')
 
-        self.params.setdefault('rucioAccount', "wma_prod")
+        self.params.setdefault('rucioAccount', "wmcore_transferor")
         if usingRucio():
-            self.phedexService = Rucio(self.params['rucioAccount'])
+            # FIXME: rename this attribute once PhEDEx is gone
+            self.phedexService = Rucio(self.params['rucioAccount'], configDict=dict(logger=self.logger))
         else:
             self.phedexService = PhEDEx()
 

--- a/src/python/WMCore/WorkQueue/WorkQueueUtils.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueUtils.py
@@ -89,7 +89,6 @@ def queueConfigFromConfigObject(config):
         wqManager.queueParams = {}
     qConfig = wqManager.queueParams
 
-    qConfig['rucioAccount'] = getattr(config.General, "rucioAccount", "")
     if hasattr(wqManager, 'couchurl'):
         qConfig['CouchUrl'] = wqManager.couchurl
     if hasattr(wqManager, 'dbname'):


### PR DESCRIPTION
Fixes #9888
Fixes #9895

#### Status
ready

#### Description

Summary of changes is:
* moved the `rucioAccount` attribute from config.General to config.WorkQueueManager.queueParams
* updated agent rucio account to: `wmcore_transferor` (RucioInjector keeps using the wma_* accts)
* DQMHarvest workflows will have the whole input dataset placed under the same destination (at dataset/container level)
* Rucio wrapper API to check whether a DID is a container or not
* Rucio wrapper API to perform the data location and locking (tightly coupled to rules created by MSTransferor)
* updated WorkQueue DataLocationMapper thread to properly use the Rucio object for workqueue elements data location
* update StartPolicyInterface to properly build container-level location with Rucio

Description of the 3 most important use cases is:
**Use case 1:** my workqueue element contains an input block, I need to find out in which RSEs this block is currently available, AND which RSEs have this block locked by my MSTransferor rucio account.
**Use case 2:** my workqueue element contains a pileup dataset, so I need to find all RSEs hosting at least one block of the pileup, AND which RSEs have this block locked by my MSTransferor rucio account.
**Use case 3:** my workqueue element contains a DQM/DQMIO dataset (container), I need to find which RSE contains the whole container (all blocks), AND which RSEs have this container locked by MSTransferor rucio account.
  * for DQM/DQMIO, we could change how the rule is created and make rules on the container DID, instead of passing all the blocks DID to the rule

The logic implemented is as follows (using the `getDataLockedAndAvailable` method):
**For a block:**
1. list all its replication rules, provided a DID + SCOPE + GROUPING + ACCOUNT
2. single RSE rules (state=OK), are considered a valid location
3. for multi RSE rules, we keep the rule_id in a list and check `get_dataset_locks` output, data AVAILABLE under one of those rule IDs is considered as a valid location
4. **FIXME**: should we get the parent of this block and check for container level rules?

**For a container:**
1. same steps 1) and 2) above
2. if there are multi RSE rules, call `_getContainerLockedAndAvailable`. Which discover all the block names in that container
3. then for each block in the container, perform step 3) above
4. depending on the grouping required, deal different with the list of RSEs for each block
   1. ALL: we want to have the whole dataset in the same location (like Harvesting workflows, DQM/DQMIO containers)
   2. DATASET: we only want to know which RSEs contain at least one block of the container (workflows reading secondary data)


#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
