### PR TITLE
Fix rule progress calculation in MSMonitor

### DIFF
--- a/src/python/WMCore/MicroService/Unified/MSMonitor.py
+++ b/src/python/WMCore/MicroService/Unified/MSMonitor.py
@@ -260,9 +260,9 @@ class MSMonitor(MSCore):
                 lockCompletion = 100.0
             else:
                 totalLocks = data['locks_ok_cnt'] + data['locks_replicating_cnt'] + data['locks_stuck_cnt']
-                lockCompletion = data['locks_ok_cnt'] / totalLocks
-            completion.append(lockCompletion * 100)
-            self.logger.info("Rule ID: %s has a completion rate of: %s", ruleID, lockCompletion)
+                lockCompletion = (data['locks_ok_cnt'] / totalLocks) * 100
+            completion.append(lockCompletion)
+            self.logger.info("Rule ID: %s has a completion rate of: %s%%", ruleID, lockCompletion)
             self.logger.debug("Rule ID: %s, DID: %s, state: %s, grouping: %s, rse_expression: %s",
                               ruleID, data['name'], data['state'], data['grouping'], data['rse_expression'])
         if not completion:


### PR DESCRIPTION
Fixes #9898 

#### Status
ready

#### Description
Use percentage (0 - 100) for rucio rule progress.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
