### PR TITLE
Get block replicas info using the Rucio bulk API

### DIFF
--- a/src/python/WMCore/Services/Rucio/Rucio.py
+++ b/src/python/WMCore/Services/Rucio/Rucio.py
@@ -253,31 +253,37 @@ class Rucio(object):
         elif 'block' in kwargs:
             blockNames = [kwargs['block']]
 
-        # FIXME: make bulk requests once https://github.com/rucio/rucio/issues/2459 gets fixed
         if isinstance(kwargs.get('dataset', None), (list, set)):
             for datasetName in kwargs['dataset']:
                 blockNames.extend(self.getBlocksInContainer(datasetName, scope=kwargs['scope']))
         elif 'dataset' in kwargs:
             blockNames.extend(self.getBlocksInContainer(kwargs['dataset'], scope=kwargs['scope']))
 
-        for blockName in blockNames:
-            replicas = []
-            response = self.cli.list_dataset_replicas(kwargs['scope'], blockName,
-                                                      deep=kwargs['deep'])
-            for item in response:
-                # same as complete='y' used for PhEDEx (which is always set within WMCore)
-                if item['state'].upper() == 'AVAILABLE':
-                    replicas.append(item['rse'])
-            result.append({'name': blockName, 'replica': list(set(replicas))})
+        inputDids = []
+        for block in blockNames:
+            inputDids.append({"scope": kwargs["scope"], "type": "DATASET", "name": block})
+
+        resultDict = {}
+        for item in self.cli.list_dataset_replicas_bulk(inputDids):
+            resultDict.setdefault(item['name'], [])
+            if item['state'].upper() == 'AVAILABLE':
+                resultDict[item['name']].append(item['rse'])
 
         if self.phedexCompat:
-            # convert plain node list to list of nodes dict
-            for block in result:
-                replicas = []
-                for node in block['replica']:
-                    replicas.append({'node': node})
-                block['replica'] = replicas
+            # then we need to convert it to a format like:
+            # {"phedex": {"block": [{"name": "block_A", "replica": [{"node": "nodeA"}, {"node": "nodeB"}]},
+            #                        etc etc
+            #                        }}
+            for blockName, rses in resultDict.viewitems():
+                replicas = [{"node": rse} for rse in rses]
+                result.append({"name": blockName, "replica": replicas})
             result = {'phedex': {'block': result}}
+        else:
+            # then a list of dictionaries sounds right, e.g.:
+            # [{"name": "block_A", "replica": ["nodeA", "nodeB"]},
+            #  {"name": "block_B", etc etc}]
+            for blockName, rses in resultDict.viewitems():
+                result.append({"name": blockName, "replica": list(set(rses))})
 
         return result
 
@@ -715,7 +721,11 @@ class Rucio(object):
         :param scope: string containing the Rucio scope (defaults to 'cms')
         :return: True if the DID is a container, else False
         """
-        response = self.cli.get_did(scope=scope, name=didName)
+        try:
+            response = self.cli.get_did(scope=scope, name=didName)
+        except DataIdentifierNotFound as exc:
+            msg = "Data identifier not found in Rucio: {}. Error: {}".format(didName, str(exc))
+            raise WMRucioException(msg)
         return response['type'].upper() == 'CONTAINER'
 
     def getDataLockedAndAvailable(self, **kwargs):

--- a/src/python/WMCore/Services/Rucio/Rucio.py
+++ b/src/python/WMCore/Services/Rucio/Rucio.py
@@ -243,7 +243,6 @@ class Rucio(object):
         compatible with PhEDEx.
         """
         kwargs.setdefault("scope", "cms")
-        kwargs.setdefault("deep", False)  # lookup at the file level, probably not needed...
 
         blockNames = []
         result = []

--- a/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
+++ b/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
@@ -8,7 +8,7 @@ import os
 
 from rucio.client import Client as testClient
 
-from WMCore.Services.Rucio.Rucio import Rucio, validateMetaData, RUCIO_VALID_PROJECT
+from WMCore.Services.Rucio.Rucio import Rucio, validateMetaData, RUCIO_VALID_PROJECT, WMRucioException
 from WMQuality.Emulators.EmulatedUnitTestCase import EmulatedUnitTestCase
 
 DSET = "/SingleElectron/Run2017F-17Nov2017-v1/MINIAOD"
@@ -169,8 +169,8 @@ class RucioTest(EmulatedUnitTestCase):
         inside a container.
         """
         # test a CMS dataset that does not exist
-        res = self.myRucio.getBlocksInContainer("Alan")
-        self.assertEqual(res, [])
+        with self.assertRaises(WMRucioException):
+            self.myRucio.getBlocksInContainer("Alan")
 
         # provide a CMS block instead of a dataset
         res = self.myRucio.getBlocksInContainer(BLOCK)


### PR DESCRIPTION
Fixes #9893 

#### Status
tested

#### Description
Summary of changes is:
* `getReplicaInfoForBlocks` method no longer supports the `deep` parameter (even though nothing will fail)
* when fetching blocks in a container, there is an extra call to check whether the input DID is a container or not
  * and this `isContainer` method now raises a `WMRucioException` exception if the DID is unknown to Rucio
* listing dataset replicas (our `getReplicaInfoForBlocks` wrapper method) does this operation in bulk now, single API call with all the block names (using `list_dataset_replicas_bulk`)
NOTE: It requires rucio-clients >= 1.23.0
#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
