### PR TITLE
WMCore/Configuration.py - sys.version_info compatible with py2.6

### DIFF
--- a/src/python/WMCore/Configuration.py
+++ b/src/python/WMCore/Configuration.py
@@ -14,7 +14,7 @@ import os
 import sys
 import traceback
 
-PY3 = sys.version_info.major == 3
+PY3 = sys.version_info[0] == 3
 
 # PY3 compatibility (can be removed once python2 gets dropped)
 if PY3:


### PR DESCRIPTION
Fixes #9896 

#### Status
Ready

#### Description

Backport the check of python interpreter version in `WMCore/Configuration.py` in branch `1.3.6_crab` as requested by @belforte and @amaltaro , as already done [in this commit](https://github.com/dmwm/WMCore/commit/4ec90a8d7f2e1902e37003f9391252cab43f08bc#diff-35b2d48eaf9f595cbd8b5a31931cb2cf) of PR #9839 for `dmwm/WMCore` branch `master`.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs

Backport of #9839 

#### External dependencies / deployment changes
No change in external dependencies
