### PR TITLE
Avoid failing MSTransferor cycle if Campaigns are misconfigured

### DIFF
--- a/src/python/WMCore/MicroService/Unified/MSTransferor.py
+++ b/src/python/WMCore/MicroService/Unified/MSTransferor.py
@@ -534,6 +534,7 @@ class MSTransferor(MSCore):
                 dsetName = dataIn["name"]
                 campConfig = self.campaigns[dataIn['campaign']]
 
+                commonPsns = set()
                 # if the dataset has a location list, use solely that one
                 if campConfig['Secondaries'].get(dsetName, []):
                     commonPsns = set(psns) & set(campConfig['Secondaries'][dsetName])


### PR DESCRIPTION
Fixes #9908 

#### Status
not-tested

#### Description
This exception only happened in testbed because the test campaign was misconfigured (no Secondaries, no SiteWhitelist, no SiteBlacklist).
Anyhow, this one line change will make sure the code doesn't break for multiple pileup workflows with misconfigured campaign.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none