### PR TITLE
MSOutput: skip output data placement for Resubmission request type

### DIFF
--- a/src/python/WMCore/MicroService/Unified/MSOutput.py
+++ b/src/python/WMCore/MicroService/Unified/MSOutput.py
@@ -589,6 +589,12 @@ class MSOutput(MSCore):
         self.logger.info("Producing MongoDB record for workflow: %s", msOutDoc["RequestName"])
         updatedOutputMap = []
         for dataItem in msOutDoc['OutputMap']:
+            if msOutDoc['RequestType'] == "Resubmission":
+                # make sure not to subscribe the same datasets multiple times, even
+                # worse, to different locations! Initial workflow will take care of everything!
+                dataItem['Copies'] = 0
+                updatedOutputMap.append(dataItem)
+                continue
             if not self.canDatasetGoToDisk(dataItem, msOutDoc['IsRelVal']):
                 # nope, this dataset cannot proceed to Disk!!
                 dataItem['Copies'] = 0


### PR DESCRIPTION
Fixes #9870 

#### Status
not-tested

#### Description
Given that the Resubmission `OutputDatasets` will be either the same or a subset of the original/first/parent workflow, there is no need to perform output data placement for Resubmission (aka ACDC) workflows. Actually, it's even safer not to, otherwise we could end up with multiple dataset replicas, even though the goal was a single replica.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none