### PR TITLE
MSOutput: support custodial/tape data placement

### DIFF
--- a/src/python/WMCore/MicroService/DataStructs/DefaultStructs.py
+++ b/src/python/WMCore/MicroService/DataStructs/DefaultStructs.py
@@ -49,22 +49,12 @@ TRANSFER_RECORD = dict(dataset="",
 
 # summary metrics for the MSOutput thread
 # (also available through the `info` REST API)
-OUTPUT_PRODUCER_REPORT = dict(thread_id="",
-                              start_time=0,
-                              end_time=0,
-                              execution_time=0,
-                              error="",
-                              total_num_requests=0,
-                              total_num_campaigns=0,
-                              num_datasets_subscribed=0,
-                              num_data_requests=0)
-
-OUTPUT_CONSUMER_REPORT = dict(thread_id="",
-                              start_time=0,
-                              end_time=0,
-                              execution_time=0,
-                              error="",
-                              total_num_requests=0,
-                              total_num_campaigns=0,
-                              num_datasets_subscribed=0,
-                              num_data_requests=0)
+OUTPUT_REPORT = dict(thread_id="",
+                     start_time=0,
+                     end_time=0,
+                     execution_time=0,
+                     error="",
+                     total_num_requests=0,
+                     total_num_campaigns=0,
+                     num_datasets_subscribed=0,
+                     num_data_requests=0)

--- a/src/python/WMCore/MicroService/Unified/MSManager.py
+++ b/src/python/WMCore/MicroService/Unified/MSManager.py
@@ -168,14 +168,14 @@ class MSManager(object):
 
     def outputConsumer(self, reqStatus):
         """
-        MSManager Output Dataplacement function.
+        MSManager Output Data Placement function.
         It subscribes the output datasets to the Data Management System.
         For references see
         https://github.com/dmwm/WMCore/wiki/ReqMgr2-MicroService-Output
         reqStatus: Status of requests to work on
         """
         startTime = datetime.utcnow()
-        self.logger.info("Starting the output thread...")
+        self.logger.info("Starting the outputConsumer thread...")
         res = self.msOutputConsumer.execute(reqStatus)
         endTime = datetime.utcnow()
         self.updateTimeUTC(res, startTime, endTime)
@@ -191,7 +191,7 @@ class MSManager(object):
         reqStatus: Status of requests to work on
         """
         startTime = datetime.utcnow()
-        self.logger.info("Starting the output thread...")
+        self.logger.info("Starting the outputProducer thread...")
         res = self.msOutputProducer.execute(reqStatus)
         endTime = datetime.utcnow()
         self.updateTimeUTC(res, startTime, endTime)


### PR DESCRIPTION
Fixes #9842 

#### Status
ready

#### Description
This PR makes MSOutput able to also perform the custodial (tape) data placement. Features in place are:
* tape dataset placement supports PhEDEx and Rucio;
* dataset placement is skipped if the tier is blacklisted in the MicroService configuration;
* dataset placement is skipped for tiers blacklisted in the Unified configuration;
* transfer request / rule creation is always made against a single RSE/node (with a single copy)
  * the same RSE endpoint gets used by the other datasets within the same workflow
* a workflow is only completely done once all the Disk + Tape placement has succeeded
* dry-run mode supported as well;
* service summary report unified (data structures were the same anyways);
* update the local caches for both MSOutput threads (Consumer and Producer);
* removed `"&cms_type=real&rse_type=DISK"` from the RelVal RSE expression. We always set the specific RSE name anyways, so that expression won't make any difference;
* FIXME: tape destination placeholder created (and hardcoded to FNAL). To be fixed in #9841 

#### Is it backward compatible (if not, which system it affects?)
no, new feature

#### Related PRs
none

#### External dependencies / deployment changes
none