### PR TITLE
MSOutput: new DatasetSize param for the mongo record; fetch container size from DM systems

### DIFF
--- a/src/python/WMCore/MicroService/DataStructs/MSOutputTemplate.py
+++ b/src/python/WMCore/MicroService/DataStructs/MSOutputTemplate.py
@@ -127,6 +127,7 @@ class MSOutputTemplate(dict):
         Template format:
             {'Campaign': u'RunIIAutumn18DRPremix',
              'Dataset': u'/Pseudoscalar2HDM_MonoZLL_mScan_mH-500_ma-300/DMWM-TC_PreMix_khurtado_TC_PreMix-v11/AODSIM',
+             'DatasetSize': 0,
              'Copies': 1,
              'DiskDestination': "",
              'TapeDestination': "",
@@ -137,6 +138,7 @@ class MSOutputTemplate(dict):
         outMapTemplate = [
             ('Campaign', "", (str, unicode)),
             ('Dataset', "", (str, unicode)),
+            ('DatasetSize', 0, int),
             ('Copies', 1, int),
             ('DiskDestination', "", (str, unicode)),
             ('TapeDestination', "", (str, unicode)),

--- a/src/python/WMCore/Services/Rucio/Rucio.py
+++ b/src/python/WMCore/Services/Rucio/Rucio.py
@@ -727,6 +727,21 @@ class Rucio(object):
             raise WMRucioException(msg)
         return response['type'].upper() == 'CONTAINER'
 
+    def getDID(self, didName, dynamic=True, scope='cms'):
+        """
+        Retrieves basic information for a single data identifier.
+        :param didName: string with the DID name
+        :param dynamic: boolean to dynamically calculate the DID size (default to True)
+        :param scope: string containing the Rucio scope (defaults to 'cms')
+        :return: a dictionary with basic DID information
+        """
+        try:
+            response = self.cli.get_did(scope=scope, name=didName, dynamic=dynamic)
+        except DataIdentifierNotFound as exc:
+            response = dict()
+            self.logger.error("Data identifier not found in Rucio: %s. Error: %s", didName, str(exc))
+        return response
+
     def getDataLockedAndAvailable(self, **kwargs):
         """
         This method retrieves all the locations where a given DID is

--- a/test/python/WMCore_t/MicroService_t/DataStructs_t/MSOutputTemplate_t.py
+++ b/test/python/WMCore_t/MicroService_t/DataStructs_t/MSOutputTemplate_t.py
@@ -66,6 +66,7 @@ class MSOutputTemplateTest(unittest.TestCase):
                 "OutputDatasets": ["output-dataset-1", "output-dataset-2"],
                 "OutputMap": [{'Campaign': 'campaign-1',
                                'Dataset': 'output-dataset-1',
+                               'DatasetSize': 123,
                                'Copies': 1,
                                'DiskDestination': "",
                                'TapeDestination': "",
@@ -73,6 +74,7 @@ class MSOutputTemplateTest(unittest.TestCase):
                                'TapeRuleID': ""},
                               {'Campaign': 'campaign-2',
                                'Dataset': 'output-dataset-2',
+                               'DatasetSize': 456,
                                'Copies': 0,
                                'DiskDestination': "",
                                'TapeDestination': "",
@@ -81,8 +83,8 @@ class MSOutputTemplateTest(unittest.TestCase):
                 "TransferStatus": "pending"
                 }
 
-    outputMapKeys = ["Campaign", "Copies", "Dataset", "DiskDestination", "DiskRuleID",
-                     "TapeDestination", "TapeRuleID"]
+    outputMapKeys = ["Campaign", "Copies", "Dataset", "DatasetSize", "DiskDestination",
+                     "DiskRuleID", "TapeDestination", "TapeRuleID"]
 
     def testTaskChainSpec(self):
         """
@@ -102,6 +104,7 @@ class MSOutputTemplateTest(unittest.TestCase):
         self.assertEqual(len(msOutDoc["OutputMap"]), 2)
         self.assertItemsEqual(msOutDoc["OutputMap"][0].viewkeys(), self.outputMapKeys)
         for idx in range(2):
+            self.assertEqual(msOutDoc["OutputMap"][idx]["DatasetSize"], 0)
             if msOutDoc["OutputMap"][idx]["Campaign"] == self.taskchainSpec["Task1"]["Campaign"]:
                 self.assertEqual(msOutDoc["OutputMap"][idx]["Dataset"], "output-dataset-1")
             else:
@@ -132,6 +135,7 @@ class MSOutputTemplateTest(unittest.TestCase):
         self.assertEqual(len(msOutDoc["OutputMap"]), 2)
         self.assertItemsEqual(msOutDoc["OutputMap"][0].viewkeys(), self.outputMapKeys)
         for idx in range(2):
+            self.assertEqual(msOutDoc["OutputMap"][idx]["DatasetSize"], 0)
             if msOutDoc["OutputMap"][idx]["Campaign"] == self.stepchainSpec["Step1"]["Campaign"]:
                 self.assertEqual(msOutDoc["OutputMap"][idx]["Dataset"], "output-dataset-1")
             else:
@@ -155,6 +159,7 @@ class MSOutputTemplateTest(unittest.TestCase):
         self.assertEqual(msOutDoc["RequestType"], self.rerecoSpec["RequestType"])
         self.assertEqual(msOutDoc["_id"], self.rerecoSpec["_id"])
         self.assertEqual(len(msOutDoc["OutputMap"]), 2)
+        self.assertEqual(msOutDoc["OutputMap"][0]["DatasetSize"], 0)
         self.assertItemsEqual(msOutDoc["OutputMap"][0].viewkeys(), self.outputMapKeys)
         self.assertEqual(msOutDoc["OutputMap"][0]["Campaign"], self.rerecoSpec["Campaign"])
         self.assertEqual(msOutDoc["OutputMap"][1]["Campaign"], self.rerecoSpec["Campaign"])
@@ -180,6 +185,7 @@ class MSOutputTemplateTest(unittest.TestCase):
         self.assertEqual(len(msOutDoc["OutputMap"]), 2)
         self.assertItemsEqual([msOutDoc["OutputMap"][0]["Dataset"], msOutDoc["OutputMap"][1]["Dataset"]],
                               self.mongoDoc["OutputDatasets"])
+        self.assertTrue(msOutDoc["OutputMap"][0]["DatasetSize"] in [123, 456])
 
         newDoc = deepcopy(self.mongoDoc)
         newDoc.update({"IsRelVal": True, "TransferStatus": "done", "LastUpdate": 333})


### PR DESCRIPTION
Fixes #9913 

#### Status
ready

#### Description
In short, adds the container size to the mongodb record, such that we can calculate the total number of bytes for all the output datasets to be pinned on a tape storage.
In more details:
* added `DatasetSize` to the `OutputMap` attribute of the mongodb records
* in the Producer thread, retrieve the container size either from Rucio or PhEDEx (sequentially, for now)
* in the Consumer thread, find all the output datasets that need to be transferred to tape, and sum up their sizes;
* once the workflow total size (in bytes) is known, pass it to the method picking the final custodial destination. If quota (or remaining space) is not enough to host all those containers, that RSE endpoint is dropped from the selection.

#### Is it backward compatible (if not, which system it affects?)
no, new mongodb parameter

#### Related PRs
none

#### External dependencies / deployment changes
none
