### PR TITLE
MSOutput: flag HIRelVal workflows as RelVal in the mongodb records

### DIFF
--- a/src/python/WMCore/MicroService/DataStructs/MSOutputTemplate.py
+++ b/src/python/WMCore/MicroService/DataStructs/MSOutputTemplate.py
@@ -245,7 +245,7 @@ class MSOutputTemplate(dict):
         Evaluates whether it's a release validation request, if so, set the flag to True
         :param myDoc: the request dictionary
         """
-        if myDoc.get('SubRequestType') == 'RelVal':
+        if myDoc.get('SubRequestType') in ['RelVal', 'HIRelVal']:
             self.setKey('IsRelVal', True)
 
     def setTransferStatus(self, newStatus):


### PR DESCRIPTION
Fixes #9917

#### Status
not-tested

#### Description
Release Validation requests can be marked - at ReqMgr2 level - with the following key/value pairs:
```
SubRequestType = RelVal
SubRequestType = HIRelVal
```

So, identify such requests in MSOutputTemplate as RelVals and carry out the normal Release Validation output data placement logic for their output datasets.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none