### PR TITLE
Remove wmarchive dependency

### DIFF
--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -11,12 +11,6 @@ dependencies = {
         'modules': ['WMCore.Configuration'],
         'systems': ['wmc-base']
     },
-    'wmc-wmarchive': {
-        'bin': ['wmc-dist-patch', 'wmc-dist-unpatch', 'wmc-httpd'],
-        'packages': ['WMCore.REST'],
-        'modules': ['WMCore.Configuration'],
-        'systems': ['wmc-base']
-    },
     'wmc-base': {
         'bin': ['wmc-dist-patch', 'wmc-dist-unpatch'],
         'packages': ['Utils', 'WMCore.DataStructs', 'WMCore.Cache'],


### PR DESCRIPTION
Fixes #9887 

#### Status

#### Description
Remove dependency for wmarchive in setup dependencies file

#### Is it backward compatible (if not, which system it affects?)
NO

#### Related PRs

#### External dependencies / deployment changes
