### PR TITLE
Fix checkStuckLGE script referencing unitialized variable

### DIFF
--- a/bin/adhoc-scripts/checkStuckLQE.py
+++ b/bin/adhoc-scripts/checkStuckLQE.py
@@ -53,6 +53,7 @@ def commonDataLocation(element):
     :param element: workqueue element object
     :return: list with the common **data** location
     """
+    commonLoc = set()
     if element['PileupData']:
         commonLoc = set(element['PileupData'].values()[0])
     if element['Inputs']:


### PR DESCRIPTION
No issue created.

#### Status
ready

#### Description
Variable referenced before assignment.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Complement to: https://github.com/dmwm/WMCore/pull/9863

#### External dependencies / deployment changes
none