### PR TITLE
Avoid passing unicode strings to FWCore.ParameterSet function

### DIFF
--- a/src/python/PSetTweaks/WMTweak.py
+++ b/src/python/PSetTweaks/WMTweak.py
@@ -313,6 +313,9 @@ def applyTweak(process, tweak, fixup=None):
     making sure all the necessary PSets and configuration values exist).
     """
     for param, value in tweak:
+        if isinstance(value, type(u'')) and hasattr(value, "encode"):
+            logging.info("Found unicode parameter type for param: %s, with value: %s", param, value)
+            value = value.encode("utf-8")
         if fixup and param in fixup:
             fixup[param](process)
 


### PR DESCRIPTION
Fixes #9923

#### Status
not-tested

#### Description
Python2 based workflows do not support unicode strings to be set in the PSet file (through CMSSW FWCore.ParameterSet).

This is a workaround until we can finally decouple PSet/Job tweak from the WMCore environment during runtime.

See the original issue for further details.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
This will have the real and long term fix: https://github.com/dmwm/WMCore/pull/9905

#### External dependencies / deployment changes
none