### PR TITLE
Decouple PhEDEx from the DBS3Reader wrapper module

### DIFF
--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -17,7 +17,6 @@ from retry import retry
 
 from Utils.IteratorTools import grouper
 from WMCore.Services.DBS.DBSErrors import DBSReaderError, formatEx3
-from WMCore.Services.PhEDEx.PhEDEx import PhEDEx
 
 
 ### Needed for the pycurl comment, leave it out for now
@@ -79,9 +78,6 @@ class DBS3Reader(object):
             msg = "Error in DBSReader with DbsApi\n"
             msg += "%s\n" % formatEx3(ex)
             raise DBSReaderError(msg)
-
-        # connection to PhEDEx (Use default endpoint url)
-        self.phedex = PhEDEx(responseType="json", dbsUrl=self.dbsURL)
 
     def _getLumiList(self, blockName=None, lfns=None, validFileOnly=1):
         """
@@ -383,35 +379,6 @@ class DBS3Reader(object):
         result['block'] = block if block else ''
         return result
 
-    def getFileBlocksInfo(self, dataset, onlyClosedBlocks=False,
-                          blockName=None, locations=True):
-        """
-        """
-        self.checkDatasetPath(dataset)
-        args = {'dataset': dataset, 'detail': True}
-        if blockName:
-            args['block_name'] = blockName
-        try:
-            blocks = self.dbs.listBlocks(**args)
-        except Exception as ex:
-            msg = "Error in DBSReader.getFileBlocksInfo(%s)\n" % dataset
-            msg += "%s\n" % formatEx3(ex)
-            raise DBSReaderError(msg)
-
-        blocks = [remapDBS3Keys(block, stringify=True, block_name='Name') for block in blocks]
-        # only raise if blockName not specified - mimic dbs2 error handling
-        if not blocks and not blockName:
-            msg = "DBSReader.getFileBlocksInfo(%s, %s): No matching data"
-            raise DBSReaderError(msg % (dataset, blockName))
-        if locations:
-            for block in blocks:
-                block['PhEDExNodeList'] = [{'Name': x} for x in self.listFileBlockLocation(block['Name'])]
-
-        if onlyClosedBlocks:
-            return [x for x in blocks if str(x['OpenForWriting']) != "1"]
-
-        return blocks
-
     def listFileBlocks(self, dataset, onlyClosedBlocks=False, blockName=None):
         """
         _listFileBlocks_
@@ -602,7 +569,7 @@ class DBS3Reader(object):
             msg += "%s\n" % formatEx3(ex)
             raise DBSReaderError(msg)
 
-    def listFileBlockLocation(self, fileBlockNames, dbsOnly=False):
+    def listFileBlockLocation(self, fileBlockNames):
         """
         _listFileBlockLocation_
 
@@ -621,25 +588,17 @@ class DBS3Reader(object):
         locations = {}
         node_filter = set(['UNKNOWN', None])
 
-        if dbsOnly:
-            blocksInfo = {}
-            try:
-                for block in fileBlockNames:
-                    blocksInfo.setdefault(block, [])
-                    # there should be only one element with a single origin site string ...
-                    for blockInfo in self.dbs.listBlockOrigin(block_name=block):
-                        blocksInfo[block].append(blockInfo['origin_site_name'])
-            except dbsClientException as ex:
-                msg = "Error in DBS3Reader: self.dbs.listBlockOrigin(block_name=%s)\n" % fileBlockNames
-                msg += "%s\n" % formatEx3(ex)
-                raise DBSReaderError(msg)
-        else:
-            try:
-                blocksInfo = self.phedex.getReplicaPhEDExNodesForBlocks(block=fileBlockNames, complete='y')
-            except Exception as ex:
-                msg = "Error while getting block location from PhEDEx for block_name=%s)\n" % fileBlockNames
-                msg += "%s\n" % str(ex)
-                raise Exception(msg)
+        blocksInfo = {}
+        try:
+            for block in fileBlockNames:
+                blocksInfo.setdefault(block, [])
+                # there should be only one element with a single origin site string ...
+                for blockInfo in self.dbs.listBlockOrigin(block_name=block):
+                    blocksInfo[block].append(blockInfo['origin_site_name'])
+        except dbsClientException as ex:
+            msg = "Error in DBS3Reader: self.dbs.listBlockOrigin(block_name=%s)\n" % fileBlockNames
+            msg += "%s\n" % formatEx3(ex)
+            raise DBSReaderError(msg)
 
         for block in fileBlockNames:
             valid_nodes = set(blocksInfo.get(block, [])) - node_filter
@@ -651,50 +610,32 @@ class DBS3Reader(object):
 
         return locations
 
-    def getFileBlock(self, fileBlockName, dbsOnly=False):
+    def getFileBlock(self, fileBlockName):
         """
-        _getFileBlock_
+        Retrieve a list of files in the block; a flag whether the
+        block is still open or not; and it used to resolve the block
+        location via PhEDEx.
 
-        dbsOnly flag is mostly meant for StoreResults, since there is no
-        data in TMDB.
-
-        return a dictionary:
-        { blockName: {
-             "PhEDExNodeNames" : [<pnn list>],
+        :return: a dictionary in the format of:
+            {"PhEDExNodeNames" : [],
              "Files" : { LFN : Events },
-             }
-        }
-
-
+             "IsOpen" : True|False}
         """
-        # Pointless code in python3
-        if isinstance(fileBlockName, str):
-            fileBlockName = unicode(fileBlockName)
-        if not self.blockExists(fileBlockName):
-            msg = "DBSReader.getFileBlock(%s): No matching data"
-            raise DBSReaderError(msg % fileBlockName)
-
-        result = {fileBlockName: {
-            "PhEDExNodeNames": self.listFileBlockLocation(fileBlockName, dbsOnly),
-            "Files": self.listFilesInBlock(fileBlockName),
-            "IsOpen": self.blockIsOpen(fileBlockName)
-        }
-        }
+        result = {"PhEDExNodeNames": [],  # FIXME: we better get rid of this line!
+                  "Files": self.listFilesInBlock(fileBlockName),
+                  "IsOpen": self.blockIsOpen(fileBlockName)}
         return result
 
     def getFileBlockWithParents(self, fileBlockName):
         """
-        _getFileBlockWithParents_
+        Retrieve a list of parent files in the block; a flag whether the
+        block is still open or not; and it used to resolve the block
+        location via PhEDEx.
 
-        return a dictionary:
-        { blockName: {
-             "PhEDExNodeNames" : [<pnn list>],
-             "Files" : dictionaries representing each file
-             }
-        }
-
-        files
-
+        :return: a dictionary in the format of:
+            {"PhEDExNodeNames" : [],
+             "Files" : { LFN : Events },
+             "IsOpen" : True|False}
         """
         if isinstance(fileBlockName, str):
             fileBlockName = unicode(fileBlockName)
@@ -703,40 +644,20 @@ class DBS3Reader(object):
             msg = "DBSReader.getFileBlockWithParents(%s): No matching data"
             raise DBSReaderError(msg % fileBlockName)
 
-        result = {fileBlockName: {
-            "PhEDExNodeNames": self.listFileBlockLocation(fileBlockName),
-            "Files": self.listFilesInBlockWithParents(fileBlockName),
-            "IsOpen": self.blockIsOpen(fileBlockName)
-        }
-        }
-        return result
-
-    def getFiles(self, dataset, onlyClosedBlocks=False):
-        """
-        _getFiles_
-
-        Returns a dictionary of block names for the dataset where
-        each block constists of a dictionary containing the PhEDExNodeNames
-        for that block and the files in that block by LFN mapped to NEvents
-
-        """
-        result = {}
-        blocks = self.listFileBlocks(dataset, onlyClosedBlocks)
-
-        for x in blocks:
-            result.update(self.getFileBlock(x))
-
+        result = {"PhEDExNodeNames": [],  # FIXME: we better get rid of this line!
+                  "Files": self.listFilesInBlockWithParents(fileBlockName),
+                  "IsOpen": self.blockIsOpen(fileBlockName)}
         return result
 
     def listBlockParents(self, blockName):
-        """Get parent blocks for block"""
+        """
+        Return a list of parent blocks for a given child block name
+        """
+        # FIXME: note the different returned data structure
         result = []
         self.checkBlockName(blockName)
         blocks = self.dbs.listBlockParents(block_name=blockName)
-        for block in blocks:
-            toreturn = {'Name': block['parent_block_name']}
-            toreturn['PhEDExNodeList'] = self.listFileBlockLocation(toreturn['Name'])
-            result.append(toreturn)
+        result = [block['parent_block_name'] for block in blocks]
         return result
 
     def blockIsOpen(self, blockName):
@@ -782,7 +703,7 @@ class DBS3Reader(object):
         pathname = blocks[-1].get('dataset', None)
         return pathname
 
-    def listDatasetLocation(self, datasetName, dbsOnly=False):
+    def listDatasetLocation(self, datasetName):
         """
         _listDatasetLocation_
 
@@ -792,33 +713,20 @@ class DBS3Reader(object):
         self.checkDatasetPath(datasetName)
 
         locations = set()
+        try:
+            blocksInfo = self.dbs.listBlockOrigin(dataset=datasetName)
+        except dbsClientException as ex:
+            msg = "Error in DBSReader: dbsApi.listBlocks(dataset=%s)\n" % datasetName
+            msg += "%s\n" % formatEx3(ex)
+            raise DBSReaderError(msg)
 
-        if dbsOnly:
-            try:
-                blocksInfo = self.dbs.listBlockOrigin(dataset=datasetName)
-            except dbsClientException as ex:
-                msg = "Error in DBSReader: dbsApi.listBlocks(dataset=%s)\n" % datasetName
-                msg += "%s\n" % formatEx3(ex)
-                raise DBSReaderError(msg)
+        if not blocksInfo:  # no data location from dbs
+            return list()
 
-            if not blocksInfo:  # no data location from dbs
-                return list()
+        for blockInfo in blocksInfo:
+            locations.update(blockInfo['origin_site_name'])
 
-            for blockInfo in blocksInfo:
-                locations.update(blockInfo['origin_site_name'])
-
-            locations.difference_update(['UNKNOWN', None])  # remove entry when SE name is 'UNKNOWN'
-        else:
-            try:
-                blocksInfo = self.phedex.getReplicaPhEDExNodesForBlocks(dataset=[datasetName], complete='y')
-            except Exception as ex:
-                msg = "Error while getting block location from PhEDEx for dataset=%s)\n" % datasetName
-                msg += "%s\n" % str(ex)
-                raise Exception(msg)
-
-            if blocksInfo:
-                for blockSites in blocksInfo.values():
-                    locations.update(blockSites)
+        locations.difference_update(['UNKNOWN', None])  # remove entry when SE name is 'UNKNOWN'
 
         return list(locations)
 

--- a/src/python/WMCore/Services/PhEDEx/PhEDEx.py
+++ b/src/python/WMCore/Services/PhEDEx/PhEDEx.py
@@ -30,6 +30,9 @@ class PhEDEx(Service):
         httpDict.setdefault('cacheduration', 0)
 
         Service.__init__(self, httpDict)
+        # NOTE: it looks like PhEDEx returns these weird data locations since ever.
+        # Why don't we deal with it as close as possible to the PhEDEx service then...
+        self.nodeFilter = set(['UNKNOWN', None])
 
     def _getResult(self, callname, clearCache=False,
                    args=None, verb="POST"):
@@ -435,7 +438,6 @@ class PhEDEx(Service):
 
         Returns a dictionary with se names per block
         """
-
         callname = 'blockreplicas'
         response = self._getResult(callname, args=kwargs)
 
@@ -449,7 +451,7 @@ class PhEDEx(Service):
             nodes = set()
             for replica in blockInfo['replica']:
                 nodes.add(replica['node'])
-            blockNodes[blockInfo['name']] = list(nodes)
+            blockNodes[blockInfo['name']] = list(nodes - self.nodeFilter)
 
         return blockNodes
 

--- a/src/python/WMCore/Services/PhEDEx/XMLDrop.py
+++ b/src/python/WMCore/Services/PhEDEx/XMLDrop.py
@@ -249,8 +249,7 @@ def makePhEDExDrop(dbsUrl, datasetPath, *blockNames):
 
     for block in blockNames:
         blockContent = reader.getFileBlock(block)
-        isOpen = reader.blockIsOpen(block)
-        if isOpen:
+        if blockContent['IsOpen']:
             xmlBlock = dataset.getFileblock(block, "y")
         else:
             xmlBlock = dataset.getFileblock(block, "n")

--- a/src/python/WMCore/Services/Rucio/Rucio.py
+++ b/src/python/WMCore/Services/Rucio/Rucio.py
@@ -208,36 +208,6 @@ class Rucio(object):
         Get block replica information.
         It mimics the same API available in the PhEDEx Service module.
 
-        kwargs originally available for PhEDEx are:
-        - dataset       dataset name, can be multiple (*)
-        - block         block name, can be multiple (*)
-        - node          node name, can be multiple (*)
-        - se            storage element name, can be multiple (*)
-        - update_since  unix timestamp, only return replicas updated since this time
-        - create_since  unix timestamp, only return replicas created since this time
-        - complete      y or n, whether or not to require complete or incomplete blocks.
-                        Default is to return either
-        - subscribed    y or n, filter for subscription. default is to return either.
-        - custodial     y or n. filter for custodial responsibility.
-                        Default is to return either.
-        - group         group name. Default is to return replicas for any group.
-
-        kwargs supported by Rucio are:
-        - dids             The list of data identifiers (DIDs) like : [{'scope': <scope1>, 'name': <name1>},
-                           {'scope': <scope2>, 'name': <name2>}, ...]
-        - schemes          A list of schemes to filter the replicas. (e.g. file, http, ...)
-        - unavailable      Also include unavailable replicas in the list. Default to False
-        - metalink         False (default) retrieves as JSON, True retrieves as metalink4+xml.
-        - rse_expression   The RSE expression to restrict replicas on a set of RSEs.
-        - client_location  Client location dictionary for PFN modification {'ip', 'fqdn', 'site'}
-        - sort             Sort the replicas:
-                           geoip - based on src/dst IP topographical distance
-                           closeness - based on src/dst closeness
-                           dynamic - Rucio Dynamic Smart Sort (tm)
-        - domain           Define the domain. None is fallback to 'wan', otherwise 'wan', 'lan', or 'all'
-        - resolve_archives When set to True, find archives which contain the replicas.
-        - resolve_parents  When set to True, find all parent datasets which contain the replicas.
-
         :kwargs: either a dataset or a block name has to be provided. Not both!
         :return: a list of dictionaries with replica information; or a dictionary
         compatible with PhEDEx.

--- a/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
+++ b/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
@@ -91,8 +91,6 @@ class PileupFetcher(FetcherInterface):
         :param blockDict: dictionary with DBS summary info
         :return: update blockDict in place
         """
-        node_filter = set(['UNKNOWN', None])
-
         if hasattr(self, "rucio"):
             # then it's Rucio!!
             blockReplicasInfo = self.rucio.getReplicaInfoForBlocks(dataset=dset)
@@ -106,9 +104,8 @@ class PileupFetcher(FetcherInterface):
         else:
             blockReplicasInfo = self.phedex.getReplicaPhEDExNodesForBlocks(dataset=dset, complete='y')
             for block in blockReplicasInfo:
-                nodes = set(blockReplicasInfo[block]) - node_filter
                 try:
-                    blockDict[block]['PhEDExNodeNames'] = list(nodes)
+                    blockDict[block]['PhEDExNodeNames'] = list(blockReplicasInfo[block])
                     blockDict[block]['FileList'] = sorted(blockDict[block]['FileList'])
                 except KeyError:
                     logging.warning("Block '%s' does not have any complete PhEDEx replica", block)

--- a/src/python/WMCore/WorkQueue/Policy/Start/Block.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Block.py
@@ -7,6 +7,7 @@ from __future__ import print_function, division
 
 import logging
 from math import ceil
+
 from WMCore.WorkQueue.Policy.Start.StartPolicyInterface import StartPolicyInterface
 from WMCore.WorkQueue.WorkQueueExceptions import WorkQueueWMSpecError
 from WMCore.WorkQueue.WorkQueueUtils import makeLocationsList
@@ -38,11 +39,13 @@ class Block(StartPolicyInterface):
             # TODO this is slow process needs to change in DBS3
             if self.initialTask.parentProcessingFlag():
                 parentFlag = True
-                for dbsBlock in dbs.listBlockParents(block["block"]):
+                parentBlocks = dbs.listBlockParents(block["block"])
+                for blockName in parentBlocks:
                     if self.initialTask.getTrustSitelists().get('trustlists'):
-                        parentList[dbsBlock["Name"]] = self.sites
+                        parentList[blockName] = self.sites
                     else:
-                        parentList[dbsBlock["Name"]] = self.cric.PNNstoPSNs(dbsBlock['PhEDExNodeList'])
+                        blockLocations = self.blockLocationRucioPhedex(blockName)
+                        parentList[blockName] = self.cric.PNNstoPSNs(blockLocations)
 
             # there could be 0 event files in that case we can't estimate the number of jobs created.
             # We set Jobs to 1 for that case.
@@ -189,7 +192,8 @@ class Block(StartPolicyInterface):
             if task.getTrustSitelists().get('trustlists'):
                 self.data[block['block']] = self.sites
             else:
-                self.data[block['block']] = self.cric.PNNstoPSNs(dbs.listFileBlockLocation(block['block']))
+                blockLocations = self.blockLocationRucioPhedex(block['block'])
+                self.data[block['block']] = self.cric.PNNstoPSNs(blockLocations)
 
             # TODO: need to decide what to do when location is no find.
             # There could be case for network problem (no connection to dbs, phedex)

--- a/src/python/WMCore/WorkQueue/Policy/Start/Dataset.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Dataset.py
@@ -166,11 +166,11 @@ class Dataset(StartPolicyInterface):
                 blockSummary['NumberOfRuns'] = runs
 
             validBlocks.append(blockSummary)
-
+            blockLocation = set(self.blockLocationRucioPhedex(blockName))
             if locations is None:
-                locations = set(dbs.listFileBlockLocation(blockName))
+                locations = blockLocation
             else:
-                locations = locations.intersection(dbs.listFileBlockLocation(blockName))
+                locations = locations.intersection(blockLocation)
 
         # all needed blocks present at these sites
         if task.getTrustSitelists().get('trustlists'):

--- a/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
@@ -261,3 +261,19 @@ class StartPolicyInterface(PolicyInterface):
                         locations.update(blockSites)
                 result[datasetPath] = self.cric.PNNstoPSNs(locations)
         return result
+
+    def blockLocationRucioPhedex(self, blockName):
+        """
+        Wrapper around Rucio and PhEDEx systems.
+        Fetch the current location of the block name (if Rucio,
+        also consider the locks made on that block)
+        :param blockName: string with the block name
+        :return: a list of RSEs
+        """
+        if hasattr(self, "rucio"):
+            location = self.rucio.getDataLockedAndAvailable(name=blockName,
+                                                            account=self.args['rucioAcct'])
+        else:
+            location = self.phedex.getReplicaPhEDExNodesForBlocks(block=[blockName],
+                                                                  complete='y')[blockName]
+        return location

--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -184,14 +184,17 @@ class WorkQueue(WorkQueueBase):
                 raise RuntimeError('Only blocks can be released on location')
 
         self.params.setdefault('rucioAccount', "wmcore_transferor")
+        # FIXME remove these attributes initialized to None
         if usingRucio():
-            # FIXME: rename this attribute once PhEDEx is gone
-            self.phedexService = Rucio(self.params['rucioAccount'], configDict=dict(logger=self.logger))
+            self.phedexService = None
+            self.rucio = Rucio(self.params['rucioAccount'], configDict=dict(logger=self.logger))
         else:
+            self.rucio = None
             self.phedexService = PhEDEx()
 
         self.dataLocationMapper = WorkQueueDataLocationMapper(self.logger, self.backend,
                                                               phedex=self.phedexService,
+                                                              rucio=self.rucio,
                                                               cric=self.cric,
                                                               locationFrom=self.params['TrackLocationOrSubscription'],
                                                               incompleteBlocks=self.params['ReleaseIncompleteBlocks'],
@@ -379,6 +382,23 @@ class WorkQueue(WorkQueueBase):
             return self.dbses[dbsUrl]
         return DBSReader(dbsUrl)
 
+    def _blockLocationRucioPhedex(self, blockName):
+        """
+        Wrapper around Rucio and PhEDEx systems.
+        Fetch the current location of the block name (if Rucio,
+        also consider the locks made on that block)
+        :param blockName: string with the block name
+        :return: a list of RSEs
+        """
+        if self.rucio:
+            # then it's Rucio
+            location = self.rucio.getDataLockedAndAvailable(name=blockName,
+                                                            account=self.params['rucioAccount'])
+        else:
+            location = self.phedexService.getReplicaPhEDExNodesForBlocks(block=[blockName],
+                                                                         complete='y')[blockName]
+        return location
+
     def _getDBSDataset(self, match):
         """Get DBS info for this dataset"""
         tmpDsetDict = {}
@@ -387,7 +407,9 @@ class WorkQueue(WorkQueueBase):
 
         blocks = dbs.listFileBlocks(datasetName, onlyClosedBlocks=True)
         for blockName in blocks:
-            tmpDsetDict.update(dbs.getFileBlock(blockName))
+            blockSummary = dbs.getFileBlock(blockName)
+            blockSummary['PhEDExNodeNames'] = self._blockLocationRucioPhedex(blockName)
+            tmpDsetDict[blockName] = blockSummary
 
         dbsDatasetDict = {'Files': [], 'IsOpen': False, 'PhEDExNodeNames': []}
         dbsDatasetDict['Files'] = [f for block in tmpDsetDict.values() for f in block['Files']]
@@ -417,12 +439,15 @@ class WorkQueue(WorkQueueBase):
             dbs = self._getDbs(match['Dbs'])
             if wmspec.getTask(match['TaskName']).parentProcessingFlag():
                 dbsBlockDict = dbs.getFileBlockWithParents(blockName)
+                dbsBlockDict['PhEDExNodeNames'] = self._blockLocationRucioPhedex(blockName)
             elif wmspec.getRequestType() == 'StoreResults':
-                dbsBlockDict = dbs.getFileBlock(blockName, dbsOnly=True)
+                dbsBlockDict = dbs.getFileBlock(blockName)
+                dbsBlockDict['PhEDExNodeNames'] = dbs.listFileBlockLocation(blockName)
             else:
                 dbsBlockDict = dbs.getFileBlock(blockName)
+                dbsBlockDict['PhEDExNodeNames'] = self._blockLocationRucioPhedex(blockName)
 
-        return blockName, dbsBlockDict[blockName]
+        return blockName, dbsBlockDict
 
     def _wmbsPreparation(self, match, wmspec, blockName, dbsBlock):
         """Inject data into wmbs and create subscription. """

--- a/src/python/WMQuality/Emulators/DBSClient/MakeDBSMockFiles.py
+++ b/src/python/WMQuality/Emulators/DBSClient/MakeDBSMockFiles.py
@@ -59,10 +59,9 @@ for endpoint, outFile, calls, datasets in INSTANCES:
             calls.append(['listFileLumis', {'block_name': unicode(block['block_name']), 'validFileOnly': 1}])
             calls.append(['listFileArray', {'block_name': unicode(block['block_name']),
                                             'detail': True, 'validFileOnly': 1}])
-            calls.append(['listFileSummaries', {'block_name': unicode(block['block_name']), 'validFileOnly': 1}])
-            calls.append(['listFileSummaries', {'block_name': str(block['block_name']), 'validFileOnly': 1}])
-            calls.append(['listRuns', {'block_name': unicode(block['block_name'])}])
-            calls.append(['listFileParents', {'block_name': unicode(block['block_name'])}])
+            calls.append(['listFileSummaries', {'block_name': block['block_name'], 'validFileOnly': 1}])
+            calls.append(['listRuns', {'block_name': block['block_name']}])
+            calls.append(['listFileParents', {'block_name': block['block_name']}])
             files = realDBS.listFiles(block_name=block['block_name'])
             for dbsFile in files:
                 lfn = unicode(dbsFile['logical_file_name'])

--- a/src/python/WMQuality/Emulators/DBSClient/MakeDBSMockFiles.py
+++ b/src/python/WMQuality/Emulators/DBSClient/MakeDBSMockFiles.py
@@ -49,22 +49,22 @@ for endpoint, outFile, calls, datasets in INSTANCES:
         calls.append(['listBlocks', {'detail': True, 'dataset': dataset}])
         calls.append(['listFileSummaries', {'validFileOnly': 1, 'dataset': dataset}])
         calls.append(['listFileArray', {'dataset': dataset, 'detail': True, 'validFileOnly': 1}])
-        calls.append(['listRuns', {'dataset': unicode(dataset)}])
+        calls.append(['listRuns', {'dataset': dataset}])
         blocks = realDBS.listBlocks(dataset=dataset)
         for block in blocks:
-            calls.append(['listBlocks', {'block_name': unicode(block['block_name'])}])
-            calls.append(['listBlocks', {'block_name': unicode(block['block_name']), 'detail': True}])
+            calls.append(['listBlocks', {'block_name': block['block_name']}])
+            calls.append(['listBlocks', {'block_name': block['block_name'], 'detail': True}])
             calls.append(['listBlockParents', {'block_name': str(block['block_name'])}])
-            calls.append(['listFileLumis', {'block_name': unicode(block['block_name'])}])
-            calls.append(['listFileLumis', {'block_name': unicode(block['block_name']), 'validFileOnly': 1}])
-            calls.append(['listFileArray', {'block_name': unicode(block['block_name']),
+            calls.append(['listFileLumis', {'block_name': block['block_name']}])
+            calls.append(['listFileLumis', {'block_name': block['block_name'], 'validFileOnly': 1}])
+            calls.append(['listFileArray', {'block_name': block['block_name'],
                                             'detail': True, 'validFileOnly': 1}])
             calls.append(['listFileSummaries', {'block_name': block['block_name'], 'validFileOnly': 1}])
             calls.append(['listRuns', {'block_name': block['block_name']}])
             calls.append(['listFileParents', {'block_name': block['block_name']}])
             files = realDBS.listFiles(block_name=block['block_name'])
             for dbsFile in files:
-                lfn = unicode(dbsFile['logical_file_name'])
+                lfn = dbsFile['logical_file_name']
                 calls.append(['listFileArray', {'logical_file_name': [lfn], 'detail': True}])
                 calls.append(['listFileArray', {'logical_file_name': [lfn]}])
                 calls.append(['listFileLumiArray', {'logical_file_name': [lfn]}])

--- a/src/python/WMQuality/Emulators/DBSClient/MockedDBSphys03Calls.py
+++ b/src/python/WMQuality/Emulators/DBSClient/MockedDBSphys03Calls.py
@@ -8,6 +8,9 @@ datasets = []
 
 calls = [
     ['listBlockOrigin', {'block_name': '/HighPileUp/Run2011A-v1/RAW#fabf118a-cbbf-11e0-80a9-003048caabcd'}],
+    ['listBlockOrigin', {'block_name': '/HighPileUp/Run2011A-v1/RAW#fabf118a-cbbf-11e0-80a9-003048caaace'}],
+    ['listBlockOrigin', {'block_name': '/HighPileUp/Run2011A-v1/RAW#6021175e-cbfb-11e0-80a9-003048caaace'}],
+    ['listBlockOrigin', {'block_name': '/HighPileUp/Run2011A-v1/RAW#fabf118a-cbbf-11e0-80a9-003048caabcdabcd'}],
     ['listBlockOrigin', {
         'block_name': '/GenericTTbar/hernan-140317_231446_crab_JH_ASO_test_T2_ES_CIEMAT_5000_100_140318_0014-ea0972193530f531086947d06eb0f121/USER#fb978442-a61b-413a-b4f4-526e6cdb142e'}],
     ['listBlockOrigin', {

--- a/src/python/WMQuality/Emulators/DataBlockGenerator/DataBlockGenerator.py
+++ b/src/python/WMQuality/Emulators/DataBlockGenerator/DataBlockGenerator.py
@@ -98,9 +98,6 @@ class DataBlockGenerator(object):
         except NoDatasetError:
             return []
 
-    def getFiles(self, block, parentFlag = False):
-        return self._fileGenerator(block, parentFlag)
-
     def getLocation(self, block):
         return Globals.getSites(block)
 

--- a/src/python/WMQuality/Emulators/EmulatedUnitTestCase.py
+++ b/src/python/WMQuality/Emulators/EmulatedUnitTestCase.py
@@ -52,16 +52,17 @@ class EmulatedUnitTestCase(unittest.TestCase):
         """
 
         if self.mockDBS:
-            self.dbsPatcher1 = mock.patch('dbs.apis.dbsClient.DbsApi', new=MockDbsApi)
-            self.dbsPatcher2 = mock.patch('WMCore.Services.DBS.DBS3Reader.DbsApi', new=MockDbsApi)
-            self.inUseDbsApi = self.dbsPatcher1.start()
-            self.inUseDbsApi = self.dbsPatcher2.start()
-            self.addCleanup(self.dbsPatcher1.stop)
-            self.addCleanup(self.dbsPatcher2.stop)
+            self.dbsPatchers = []
+            patchDBSAt = ["dbs.apis.dbsClient.DbsApi",
+                          "WMCore.Services.DBS.DBS3Reader.DbsApi"]
+            for module in patchDBSAt:
+                self.dbsPatchers.append(mock.patch(module, new=MockDbsApi))
+                self.dbsPatchers[-1].start()
+                self.addCleanup(self.dbsPatchers[-1].stop)
 
         if self.mockPhEDEx:
             self.phedexPatchers = []
-            patchPhedexAt = ['WMCore.Services.PhEDEx.PhEDEx.PhEDEx', 'WMCore.Services.DBS.DBS3Reader.PhEDEx',
+            patchPhedexAt = ['WMCore.Services.PhEDEx.PhEDEx.PhEDEx',
                              'WMCore.WorkQueue.WorkQueue.PhEDEx',
                              'WMCore.WorkQueue.Policy.Start.StartPolicyInterface.PhEDEx',
                              'WMComponent.PhEDExInjector.PhEDExInjectorPoller.PhEDEx']

--- a/test/data/Mock/DBSMockData03.json
+++ b/test/data/Mock/DBSMockData03.json
@@ -27,5 +27,8 @@
    "origin_site_name": "T2_ES_CIEMAT"
   }
  ],
- "listBlockOrigin:[('block_name', '/HighPileUp/Run2011A-v1/RAW#fabf118a-cbbf-11e0-80a9-003048caabcd')]": []
+ "listBlockOrigin:[('block_name', '/HighPileUp/Run2011A-v1/RAW#6021175e-cbfb-11e0-80a9-003048caaace')]": [],
+ "listBlockOrigin:[('block_name', '/HighPileUp/Run2011A-v1/RAW#fabf118a-cbbf-11e0-80a9-003048caaace')]": [],
+ "listBlockOrigin:[('block_name', '/HighPileUp/Run2011A-v1/RAW#fabf118a-cbbf-11e0-80a9-003048caabcd')]": [],
+ "listBlockOrigin:[('block_name', '/HighPileUp/Run2011A-v1/RAW#fabf118a-cbbf-11e0-80a9-003048caabcdabcd')]": []
 }

--- a/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Block_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Block_t.py
@@ -69,7 +69,7 @@ class BlockTestCase(EmulatedUnitTestCase):
                 self.assertTrue(1 <= unit['NumberOfFiles'])
                 self.assertTrue(0 <= unit['NumberOfEvents'])
             self.assertEqual(len(units),
-                             len(dbs[inputDataset.dbsurl].getFileBlocksInfo(dataset)))
+                             len(dbs[inputDataset.dbsurl].listFileBlocks(dataset)))
 
     def testMultiTaskProcessingWorkload(self):
         """Multi Task Processing Workflow"""
@@ -92,7 +92,7 @@ class BlockTestCase(EmulatedUnitTestCase):
                 self.assertEqual(MultiTaskProcessingWorkload, unit['WMSpec'])
                 self.assertEqual(task, unit['Task'])
             self.assertEqual(len(units),
-                             len(dbs[inputDataset.dbsurl].getFileBlocksInfo(datasets[0])))
+                             len(dbs[inputDataset.dbsurl].listFileBlocks(datasets[0])))
             count += 1
         self.assertEqual(tasks, count)
 
@@ -239,7 +239,7 @@ class BlockTestCase(EmulatedUnitTestCase):
                 self.assertEqual(Tier1ReRecoWorkload, unit['WMSpec'])
                 self.assertEqual(task, unit['Task'])
             self.assertNotEqual(len(units),
-                                len(dbs[inputDataset.dbsurl].getFileBlocksInfo(dataset)))
+                                len(dbs[inputDataset.dbsurl].listFileBlocks(dataset)))
 
     def testLumiSplitTier1ReRecoWorkload(self):
         """Tier1 Re-reco workflow"""
@@ -347,7 +347,7 @@ class BlockTestCase(EmulatedUnitTestCase):
                 self.assertEqual(True, unit['ParentFlag'])
                 self.assertEqual(1, len(unit['ParentData']))
             self.assertEqual(len(units),
-                             len(dbs[inputDataset.dbsurl].getFileBlocksInfo(dataset)))
+                             len(dbs[inputDataset.dbsurl].listFileBlocks(dataset)))
 
     def testIgnore0SizeBlocks(self):
         """Ignore blocks with 0 files"""
@@ -386,7 +386,7 @@ class BlockTestCase(EmulatedUnitTestCase):
                 self.assertTrue(1 <= unit['NumberOfFiles'])
                 self.assertTrue(0 <= unit['NumberOfEvents'])
             self.assertEqual(len(units),
-                             len(dbs[inputDataset.dbsurl].getFileBlocksInfo(dataset)))
+                             len(dbs[inputDataset.dbsurl].listFileBlocks(dataset)))
 
         # Modify the spec and task, get first a fresh policy instance
         policyInstance = Block(**self.splitArgs)

--- a/test/python/WMCore_t/WorkQueue_t/WMBSHelper_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WMBSHelper_t.py
@@ -15,6 +15,8 @@ from WMCore.DAOFactory import DAOFactory
 from WMCore.DataStructs.Mask import Mask
 from WMCore.ResourceControl.ResourceControl import ResourceControl
 from WMCore.Services.DBS.DBSReader import DBSReader
+### FIXME mock PhEDEx (or Rucio?)
+from WMCore.Services.PhEDEx.PhEDEx import PhEDEx
 from WMCore.WMBS.File import File
 from WMCore.WMBS.Fileset import Fileset
 from WMCore.WMBS.Job import Job
@@ -22,8 +24,8 @@ from WMCore.WMBS.JobGroup import JobGroup
 from WMCore.WMBS.Subscription import Subscription
 from WMCore.WMBS.Workflow import Workflow
 from WMCore.WMBase import getTestBase
-from WMCore.WMSpec.StdSpecs.TaskChain import TaskChainWorkloadFactory
 from WMCore.WMSpec.StdSpecs.ReReco import ReRecoWorkloadFactory
+from WMCore.WMSpec.StdSpecs.TaskChain import TaskChainWorkloadFactory
 from WMCore.WMSpec.WMWorkload import WMWorkload, WMWorkloadHelper
 from WMCore.WorkQueue.WMBSHelper import WMBSHelper
 from WMCore.WorkQueue.WMBSHelper import killWorkflow
@@ -75,6 +77,7 @@ class WMBSHelperTest(EmulatedUnitTestCase):
         self.inputDataset = self.topLevelTask.inputDataset()
         self.dataset = self.topLevelTask.getInputDatasetPath()
         self.dbs = DBSReader(self.inputDataset.dbsurl)
+        self.phedex = PhEDEx()
         self.daoFactory = DAOFactory(package="WMCore.WMBS",
                                      logger=threading.currentThread().logger,
                                      dbinterface=threading.currentThread().dbi)
@@ -537,10 +540,15 @@ class WMBSHelperTest(EmulatedUnitTestCase):
         wmbs = WMBSHelper(wmspec, topLevelTask.name(), block, mask, cachepath=self.workDir,
                           commonLocation=commonLocation)
         if block:
+            blockName = block
             if parentFlag:
-                block = self.dbs.getFileBlockWithParents(block)[block]
+                block = self.dbs.getFileBlockWithParents(blockName)
+                location = self.phedex.getReplicaPhEDExNodesForBlocks(block=[blockName], complete='y')
+                block['PhEDExNodeNames'] = location[blockName]
             else:
-                block = self.dbs.getFileBlock(block)[block]
+                block = self.dbs.getFileBlock(blockName)
+                location = self.phedex.getReplicaPhEDExNodesForBlocks(block=[blockName], complete='y')
+                block['PhEDExNodeNames'] = location[blockName]
         sub, files = wmbs.createSubscriptionAndAddFiles(block=block)
         if detail:
             return wmbs, sub, files
@@ -823,8 +831,8 @@ class WMBSHelperTest(EmulatedUnitTestCase):
         # create workflow
         block = self.dataset + "#" + BLOCK1
         wmbs = self.createWMBSHelperWithTopTask(self.wmspec, block)
-        files = wmbs.validFiles(self.dbs.getFileBlock(block))
-        self.assertEqual(len(files), 1)
+        files = wmbs.validFiles(self.dbs.getFileBlock(block)['Files'])
+        self.assertEqual(len(files), 5)
 
     def testReRecoBlackRunRestriction(self):
         """ReReco workflow with Run restrictions"""
@@ -832,14 +840,14 @@ class WMBSHelperTest(EmulatedUnitTestCase):
         self.topLevelTask.setInputRunBlacklist([181183])  # Set run blacklist to only run in the block
         wmbs = self.createWMBSHelperWithTopTask(self.wmspec, block)
 
-        files = wmbs.validFiles(self.dbs.getFileBlock(block)[block]['Files'])
+        files = wmbs.validFiles(self.dbs.getFileBlock(block)['Files'])
         self.assertEqual(len(files), 0)
 
     def testReRecoWhiteRunRestriction(self):
         block = self.dataset + "#" + BLOCK2
         self.topLevelTask.setInputRunWhitelist([181183])  # Set run whitelist to only run in the block
         wmbs = self.createWMBSHelperWithTopTask(self.wmspec, block)
-        files = wmbs.validFiles(self.dbs.getFileBlock(block)[block]['Files'])
+        files = wmbs.validFiles(self.dbs.getFileBlock(block)['Files'])
         self.assertEqual(len(files), 1)
 
     def testLumiMaskRestrictionsOK(self):
@@ -847,7 +855,7 @@ class WMBSHelperTest(EmulatedUnitTestCase):
         self.wmspec.getTopLevelTask()[0].data.input.splitting.runs = ['181367']
         self.wmspec.getTopLevelTask()[0].data.input.splitting.lumis = ['57,80']
         wmbs = self.createWMBSHelperWithTopTask(self.wmspec, block)
-        files = wmbs.validFiles(self.dbs.getFileBlock(block)[block]['Files'])
+        files = wmbs.validFiles(self.dbs.getFileBlock(block)['Files'])
         self.assertEqual(len(files), 1)
 
     def testLumiMaskRestrictionsKO(self):
@@ -855,7 +863,7 @@ class WMBSHelperTest(EmulatedUnitTestCase):
         self.wmspec.getTopLevelTask()[0].data.input.splitting.runs = ['123454321']
         self.wmspec.getTopLevelTask()[0].data.input.splitting.lumis = ['123,123']
         wmbs = self.createWMBSHelperWithTopTask(self.wmspec, block)
-        files = wmbs.validFiles(self.dbs.getFileBlock(block)[block]['Files'])
+        files = wmbs.validFiles(self.dbs.getFileBlock(block)['Files'])
         self.assertEqual(len(files), 0)
 
     def testDuplicateFileInsert(self):
@@ -865,7 +873,7 @@ class WMBSHelperTest(EmulatedUnitTestCase):
         wmbs.topLevelFileset.loadData()
         numOfFiles = len(wmbs.topLevelFileset.files)
         # check initially inserted files.
-        dbsFiles = self.dbs.getFileBlock(block)[block]['Files']
+        dbsFiles = self.dbs.getFileBlock(block)['Files']
         self.assertEqual(numOfFiles, len(dbsFiles))
         firstFileset = wmbs.topLevelFileset
         wmbsDao = wmbs.daofactory(classname="Files.InFileset")
@@ -879,14 +887,16 @@ class WMBSHelperTest(EmulatedUnitTestCase):
         dbs = self.getDBS(wmspec)
         wmbs = self.createWMBSHelperWithTopTask(wmspec, block)
         # check duplicate insert
-        dbsFiles = dbs.getFileBlock(block)[block]['Files']
-        numOfFiles = wmbs.addFiles(dbs.getFileBlock(block)[block])
+        dbsFiles = dbs.getFileBlock(block)
+        location = self.phedex.getReplicaPhEDExNodesForBlocks(block=[block], complete='y')
+        dbsFiles['PhEDExNodeNames'] = location[block]
+        numOfFiles = wmbs.addFiles(dbsFiles)
         self.assertEqual(numOfFiles, 0)
         secondFileset = wmbs.topLevelFileset
 
         wmbsDao = wmbs.daofactory(classname="Files.InFileset")
         numOfFiles = len(wmbsDao.execute(secondFileset.id))
-        self.assertEqual(numOfFiles, len(dbsFiles))
+        self.assertEqual(numOfFiles, len(dbsFiles['Files']))
 
         self.assertNotEqual(firstFileset.id, secondFileset.id)
 
@@ -902,7 +912,7 @@ class WMBSHelperTest(EmulatedUnitTestCase):
         subId = wmbs.topLevelSubscription['id']
 
         # check initially inserted files.
-        dbsFiles = self.dbs.getFileBlock(block)[block]['Files']
+        dbsFiles = self.dbs.getFileBlock(block)['Files']
         self.assertEqual(numOfFiles, len(dbsFiles))
 
         # Not clear what's supposed to happen here, 2nd test is completely redundant


### PR DESCRIPTION
Fixes #9869 

#### Status
ready

#### Description
In short, remove PhEDEx dependency from the DBS3Reader Services module; and update all the code that was relying on those DBS APIs interfacing with PhEDEx.

In details, changes are:
* `getFileBlocksInfo` DBS3Reader API has been removed (no usage found)
* signature change for `listFileBlockLocation` DBS3Reader API. It also no longer calls PhEDEx under the hood
* signature change for `getFileBlock` DBS3Reader API. It returns an empty list for the PNNs and a flat dictionary now.
* `getFileBlockWithParents` DBS3Reader API now returns an empty list for the PNNs and a flat dictionary
* `getFiles` DBS3Reader API has been removed (no usage found)
* `listBlockParents` DBS3Reader API now returns a flat list with the parent block names
* signature change for `listDatasetLocation` DBS3Reader API. It also no longer calls PhEDEx under the hood
* PhEDEx `getReplicaPhEDExNodesForBlocks` API now filters those weird and unwanted eventual nodes
* XMLDrop checks if a block is open only once (it was calling the same API twice)
* created a wrapper API around Rucio and PhEDEx to fetch the block data location (and locking, if needed): `blockLocationRucioPhedex`. To be used in the WorkQueue/Policy/Start package.

#### Is it backward compatible (if not, which system it affects?)
No, some possibly breaking changes like different return structure, different method signature, etc.

#### Related PRs
Partially a follow up work for: https://github.com/dmwm/WMCore/pull/9889

#### External dependencies / deployment changes
none
