### PR TITLE
Construct the PU location via rucio considering MSTransferor locks

### DIFF
--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -452,7 +452,7 @@ class SetupCMSSWPset(ScriptInterface):
                             eventsAvailable += int(blockDict.get('NumberOfEvents', 0))
                             for fileLFN in blockDict["FileList"]:
                                 # vstring does not support unicode
-                                inputTypeAttrib.fileNames.append(str(fileLFN['logical_file_name']))
+                                inputTypeAttrib.fileNames.append(str(fileLFN))
                     if requestedPileupType == 'data':
                         if getattr(self.jobBag, 'skipPileupEvents', None) is not None:
                             # For deterministic pileup, we want to shuffle the list the

--- a/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
+++ b/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
@@ -33,32 +33,24 @@ class PileupFetcher(FetcherInterface):
         """
         super(PileupFetcher, self).__init__()
         if usingRucio():
-            # Too much work to pass the rucio account name all the way to here
-            # just use the production rucio account for resolving pileup location
-            self.rucio = Rucio("wma_prod", configDict={'phedexCompatible': False})
+            # FIXME: find a way to pass the Rucio account name to this fetcher module
+            self.rucioAcct = "wmcore_transferor"
+            self.rucio = Rucio(self.rucioAcct)
         else:
             self.phedex = PhEDEx()  # this will go away eventually
 
     def _queryDbsAndGetPileupConfig(self, stepHelper, dbsReader):
         """
         Method iterates over components of the pileup configuration input
-        and queries DBS. Then iterates over results from DBS.
+        and queries DBS for valid files in the dataset, plus some extra
+        information about each file.
 
-        There needs to be a list of files and their locations for each
-        dataset name.
-        Use dbsReader
-        the result data structure is a Python dict following dictionary:
-            FileList is a list of LFNs
+        Information is organized at block level, listing all its files,
+        number of events in the block, and its data location (to be resolved
+        by a different method using either PhEDEx or Rucio), such as:
 
-        {"pileupTypeA": {"BlockA": {"FileList": [], "PhEDExNodeNames": []},
+        {"pileupTypeA": {"BlockA": {"FileList": [], "PhEDExNodeNames": [], "NumberOfEvents": 123},
                          "BlockB": {"FileList": [], "PhEDExNodeName": []}, ....}
-
-        this structure preserves knowledge of where particular files of dataset
-        are physically (list of PNNs) located. DBS only lists sites which
-        have all files belonging to blocks but e.g. BlockA of dataset DS1 may
-        be located at site1 and BlockB only at site2 - it's possible that only
-        a subset of the blocks in a dataset will be at a site.
-
         """
         resultDict = {}
         # iterate over input pileup types (e.g. "cosmics", "minbias")
@@ -69,14 +61,11 @@ class PileupFetcher(FetcherInterface):
             blockDict = {}
             for dataset in datasets:
 
-                blockFileInfo = dbsReader.getFileListByDataset(dataset=dataset, detail=True)
-
-                for fileInfo in blockFileInfo:
+                for fileInfo in dbsReader.getFileListByDataset(dataset=dataset, detail=True):
                     blockDict.setdefault(fileInfo['block_name'], {'FileList': [],
                                                                   'NumberOfEvents': 0,
                                                                   'PhEDExNodeNames': []})
-                    blockDict[fileInfo['block_name']]['FileList'].append(
-                        {'logical_file_name': fileInfo['logical_file_name']})
+                    blockDict[fileInfo['block_name']]['FileList'].append(fileInfo['logical_file_name'])
                     blockDict[fileInfo['block_name']]['NumberOfEvents'] += fileInfo['event_count']
 
                 self._getDatasetLocation(dataset, blockDict)
@@ -91,22 +80,18 @@ class PileupFetcher(FetcherInterface):
         :param blockDict: dictionary with DBS summary info
         :return: update blockDict in place
         """
-        if hasattr(self, "rucio"):
-            # then it's Rucio!!
-            blockReplicasInfo = self.rucio.getReplicaInfoForBlocks(dataset=dset)
-            for item in blockReplicasInfo:
-                block = item['name']
+        if usingRucio():
+            blockReplicas = self.rucio.getPileupLockedAndAvailable(dset, account=self.rucioAcct)
+            for blockName, blockLocation in blockReplicas.viewitems():
                 try:
-                    blockDict[block]['PhEDExNodeNames'] = item['replica']
-                    blockDict[block]['FileList'] = sorted(blockDict[block]['FileList'])
+                    blockDict[blockName]['PhEDExNodeNames'] = list(blockLocation)
                 except KeyError:
-                    logging.warning("Block '%s' does not have any complete Rucio replica", block)
+                    logging.warning("Block '%s' present in Rucio but not in DBS", blockName)
         else:
             blockReplicasInfo = self.phedex.getReplicaPhEDExNodesForBlocks(dataset=dset, complete='y')
             for block in blockReplicasInfo:
                 try:
                     blockDict[block]['PhEDExNodeNames'] = list(blockReplicasInfo[block])
-                    blockDict[block]['FileList'] = sorted(blockDict[block]['FileList'])
                 except KeyError:
                     logging.warning("Block '%s' does not have any complete PhEDEx replica", block)
 

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Fetchers_t/PileupFetcher_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Fetchers_t/PileupFetcher_t.py
@@ -79,6 +79,7 @@ class PileupFetcherTest(EmulatedUnitTestCase):
 
         """
         reader = DBS3Reader(dbsUrl)
+        # FIXME: this will have to be converted to Rucio data location, eventually...
         phedex = PhEDEx()
 
         inputArgs = defaultArguments["PileupConfig"]
@@ -118,15 +119,13 @@ class PileupFetcherTest(EmulatedUnitTestCase):
                     self.assertEqual(set(blockDict[dbsFileBlockName]["PhEDExNodeNames"]), pnns, m)
                     m = ("FileList don't agree for pileup type '%s', dataset '%s' "
                          " in configuration: '%s'" % (pileupType, dataset, pileupDict))
-                    storedFileList = [item['logical_file_name'] for item in blockDict[dbsFileBlockName]["FileList"]]
-                    self.assertItemsEqual(storedFileList, fileList, m)
+                    self.assertItemsEqual(blockDict[dbsFileBlockName]["FileList"], fileList, m)
 
     def _queryPileUpConfigFile(self, defaultArguments, task, taskPath):
         """
         Query and compare contents of the the pileup JSON
         configuration files. Iterate over tasks's steps as
         it happens in the PileupFetcher.
-
         """
         for step in task.steps().nodeIterator():
             helper = WMStep.WMStepHelper(step)
@@ -137,10 +136,8 @@ class PileupFetcherTest(EmulatedUnitTestCase):
                 stepPath = "%s/%s" % (taskPath, helper.name())
                 pileupConfig = "%s/%s" % (stepPath, "pileupconf.json")
                 try:
-                    f = open(pileupConfig, 'r')
-                    json = f.read()
-                    pileupDict = decoder.decode(json)
-                    f.close()
+                    with open(pileupConfig) as fObj:
+                        pileupDict = decoder.decode(fObj.read())
                 except IOError:
                     m = "Could not read pileup JSON configuration file: '%s'" % pileupConfig
                     self.fail(m)


### PR DESCRIPTION
Fixes #9894 

#### Status
ready

#### Description
Previous logic in WMAgent for resolving the pileup location (the pileupconf.json construction) was simply relying on the current block location, without considering who locked the data.

This PR changes that functionality to something similar to what is done at WorkQueue level, such that we only use data that has been locked by MSTransferor.

I also have two somehow unrelated changes here:
* `FileList` will contain a flat list of file names (instead of {"logical_file_name": <the file name>})
* `FileList` is no longer sorted. I couldn't see any reason to sort it. Besides, at SetupCMSSWPSet level we shuffle all those files..

#### Is it backward compatible (if not, which system it affects?)
no, between old and new agents. But this isn't a valid use case.

#### Related PRs
none

#### External dependencies / deployment changes
none
