### PR TITLE
[py2py3] migration of DQMUpload.py

### DIFF
--- a/src/python/WMCore/Services/HTTPS/HTTPSAuthHandler.py
+++ b/src/python/WMCore/Services/HTTPS/HTTPSAuthHandler.py
@@ -5,13 +5,24 @@ See usage example in:
 src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
 """
 from __future__ import print_function, division
+
 import logging
-import urllib2
-import httplib
 import ssl
+try:
+    # python2
+    import urllib2
+    import httplib
+    HTTPSHandler = urllib2.HTTPSHandler
+    HTTPSConnection = httplib.HTTPSConnection
+except:
+    # python3
+    import urllib.request
+    import http.client
+    HTTPSHandler = urllib.request.HTTPSHandler
+    HTTPSConnection = http.client.HTTPSConnection
 
 
-class HTTPSAuthHandler(urllib2.HTTPSHandler):
+class HTTPSAuthHandler(HTTPSHandler):
     """
     HTTPS authentication class to provide a ssl context with the certificates.
     """
@@ -36,15 +47,15 @@ class HTTPSAuthHandler(urllib2.HTTPSHandler):
             self.logger.info("  protocol : %s", self.ctx.protocol)  # default to 2 (PROTOCOL_SSLv23)
             self.logger.info("  verify_flags : %s", self.ctx.verify_flags)  # default to 0 (VERIFY_DEFAULT)
             self.logger.info("  verify_mode : %s", self.ctx.verify_mode)  # default to 2 (CERT_REQUIRED)
-            urllib2.HTTPSHandler.__init__(self, debuglevel=level, context=self.ctx)
+            HTTPSHandler.__init__(self, debuglevel=level, context=self.ctx)
         else:
             self.logger.info("Certificate not provided for HTTPSHandler")
-            urllib2.HTTPSHandler.__init__(self, debuglevel=level)
+            HTTPSHandler.__init__(self, debuglevel=level)
 
     def get_connection(self, host, **kwargs):
         if self.ctx:
-            return httplib.HTTPSConnection(host, context=self.ctx, **kwargs)
-        return httplib.HTTPSConnection(host)
+            return HTTPSConnection(host, context=self.ctx, **kwargs)
+        return HTTPSConnection(host)
 
     def https_open(self, req):
         """

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/DQMUpload_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/DQMUpload_t.py
@@ -1,0 +1,102 @@
+from __future__ import print_function
+import logging
+from future import standard_library
+standard_library.install_aliases()
+import urllib.request
+
+import unittest
+from nose.plugins.attrib import attr
+
+import os
+from functools import reduce
+from hashlib import md5
+
+from WMCore.WMSpec.Steps.Executors.DQMUpload import DQMUpload
+
+class StepPatch():
+    def __init__(self, upload=None):
+        self.upload = upload
+
+class UploadPatch():
+    def __init__(self):
+        self.proxy = False
+
+class DQMUpload_t(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    @attr("integration")
+    def test_upload(self):
+        """
+        test_upload
+
+        This unittest has been used to validate the modernization of DQMUpload.
+        If everything is ok, this unittest is expected to pass.
+
+        However, this unittest sends a 144MB root file to the DQM. We convened 
+        that it is a bit too much for multiple daily checks, so we mark this
+        as "integration". See discussion at:
+        https://github.com/dmwm/WMCore/pull/9934#issuecomment-898855725
+        """
+        filename = "DQM_V0001_R000000001__RelValH125GGgluonfusion_13__CMSSW_8_1_0-RecoFullPU_2017PU_TaskChain_PUMCRecyc_HG1705_Validation_TEST_Alan_v67-v11__DQMIO.root"
+        filepath = os.path.join("/tmp", filename)
+        if not os.path.isfile(filepath):
+            urllib.request.urlretrieve(
+                "http://amaltaro.web.cern.ch/amaltaro/forAlan/%s" % filename, 
+                filepath)
+
+        dqm = DQMUpload()
+        upload_patch = UploadPatch()
+        step_patch = StepPatch(upload_patch)
+        dqm.step = step_patch
+
+        args = {}
+        # Preparing a checksum
+        blockSize = 0x10000
+        def upd(m, data):
+            m.update(data)
+            return m
+        with open(filepath, 'rb') as fd:
+            contents = iter(lambda: fd.read(blockSize), b'')
+            m = reduce(upd, contents, md5())
+        args['checksum'] = 'md5:%s' % m.hexdigest()
+        args['size'] = os.path.getsize(filepath)
+        headers, data = dqm.upload(
+            "https://cmsweb-testbed.cern.ch/dqm/dev/", 
+            args,
+            filepath)
+
+        logging.debug("headers: %s %s", type(headers), headers)
+        logging.debug("data: %s %s", type(data), data)
+
+        # Dqm-Status-Code == 100 is considered good
+        # Dqm-Status-Code == 300 was related to " File name does not match the expected convention"
+        self.assertEqual(headers.get("Dqm-Status-Code", None), '100')
+
+    @attr("integration")
+    def test_httppost(self):
+        """
+        test_httppost
+
+        This unittest has been used to validate the modernization of DQMUpload.
+        If everything is ok, this unittest is expected to pass.
+        """
+        filename = "DQM_V0001_R000000001__RelValH125GGgluonfusion_13__CMSSW_8_1_0-RecoFullPU_2017PU_TaskChain_PUMCRecyc_HG1705_Validation_TEST_Alan_v67-v11__DQMIO.root"
+        filepath = os.path.join("/tmp", filename)
+        if not os.path.isfile(filepath):
+            urllib.request.urlretrieve(
+                "http://amaltaro.web.cern.ch/amaltaro/forAlan/%s" % filename, 
+                filepath)
+
+        dqm = DQMUpload()
+        upload_patch = UploadPatch()
+        step_patch = StepPatch(upload_patch)
+        dqm.step = step_patch
+        dqm.step.upload.URL = "https://cmsweb-testbed.cern.ch/dqm/dev/"
+        dqm.httpPost(filepath)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #9926

#### Status
Ready 

#### Description

I restarted the work on this topic, driven by investigations necessary for #10651. A lot of time passed, and with time we have a better insight of what is going on here:

- [x] #9926 is caused by python-future's backport of py3's urllib to py2. This can be avoided by simply continue using urllib2 in py2. See logs at [1]
- [x] #10651 fixed a problem that arises when using py3 central services and py2 wmagent. The `url` argument in `urllib2.Request(url)` ended up being of type unicode, which mixed the types in the httplib buffer, causing a the same problem seen in #9926
- [x] I added a unittest. ~~I am making it fail because `dqm.upload()` is returning http code 500. Maybe it's just a matter of chaning the filename, but i have not looked for what it should be, yet  See logs for~~
  - ~~[py2 logs](https://cmssdt.cern.ch/dmwm-jenkins/view/All/job/DMWM-WMCore-PR-test/12064/testReport/junit/WMCore_t.WMSpec_t.Steps_t.Executors_t.DQMUpload_t/DQMUpload_t/testA_Upload/) for `WMCore_t.WMSpec_t.Steps_t.Executors_t.DQMUpload_t.DQMUpload_t.testA_Upload`~~
  - ~~[py3 logs](https://cmssdt.cern.ch/dmwm-jenkins/view/All/job/DMWM-WMCore-PR-test/12064/testReport/junit/WMCore_t.WMSpec_t.Steps_t.Executors_t.DQMUpload_t/DQMUpload_t/testA_Upload_2/) for `WMCore_t.WMSpec_t.Steps_t.Executors_t.DQMUpload_t.DQMUpload_t.testA_Upload`~~
  - Thanks to @amaltaro for providing the fix! :).
  - Since this unittest uploads a  144MB root file coming directly from Alan's eos to the DQM every time we run this new unittest, we decided that it is better not to run this often. However it is good to keep this around in case of bugs -> we mark this unittest as integration

The solution was to avoid using in py2 the backport of py3 urllib provided by future, which is broken. So the only "quick" solution is to select at runtime with a `try/except` clause the proper classes and functions.

An alternative would be refactoring all these machinery and start using `request` instead, but it may not be worth the effort.

#### Is it backward compatible (if not, which system it affects?)
YES

#### External dependencies / deployment changes
DQMUpload.py will continue to depend on python-future
