### PR TITLE
Revert stage2 fixers on DQMUpload module

### DIFF
--- a/src/python/WMCore/Services/HTTPS/HTTPSAuthHandler.py
+++ b/src/python/WMCore/Services/HTTPS/HTTPSAuthHandler.py
@@ -5,16 +5,13 @@ See usage example in:
 src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
 """
 from __future__ import print_function, division
-from future import standard_library
-standard_library.install_aliases()
-
 import logging
-import urllib.request
-import http.client
+import urllib2
+import httplib
 import ssl
 
 
-class HTTPSAuthHandler(urllib.request.HTTPSHandler):
+class HTTPSAuthHandler(urllib2.HTTPSHandler):
     """
     HTTPS authentication class to provide a ssl context with the certificates.
     """
@@ -39,15 +36,15 @@ class HTTPSAuthHandler(urllib.request.HTTPSHandler):
             self.logger.info("  protocol : %s", self.ctx.protocol)  # default to 2 (PROTOCOL_SSLv23)
             self.logger.info("  verify_flags : %s", self.ctx.verify_flags)  # default to 0 (VERIFY_DEFAULT)
             self.logger.info("  verify_mode : %s", self.ctx.verify_mode)  # default to 2 (CERT_REQUIRED)
-            urllib.request.HTTPSHandler.__init__(self, debuglevel=level, context=self.ctx)
+            urllib2.HTTPSHandler.__init__(self, debuglevel=level, context=self.ctx)
         else:
             self.logger.info("Certificate not provided for HTTPSHandler")
-            urllib.request.HTTPSHandler.__init__(self, debuglevel=level)
+            urllib2.HTTPSHandler.__init__(self, debuglevel=level)
 
     def get_connection(self, host, **kwargs):
         if self.ctx:
-            return http.client.HTTPSConnection(host, context=self.ctx, **kwargs)
-        return http.client.HTTPSConnection(host)
+            return httplib.HTTPSConnection(host, context=self.ctx, **kwargs)
+        return httplib.HTTPSConnection(host)
 
     def https_open(self, req):
         """

--- a/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
@@ -6,13 +6,11 @@ Implementation of an Executor for a DQMUpload step
 
 """
 from __future__ import print_function
-from future import standard_library
-standard_library.install_aliases()
 
 import logging
 import os
 import sys
-import urllib.request, urllib.error
+import urllib2
 from io import BytesIO
 from functools import reduce
 from gzip import GzipFile
@@ -164,7 +162,7 @@ class DQMUpload(Executor):
                 else:
                     msg = 'HTTP upload finished succesfully with response:\n' + msg
                     logging.info(msg)
-        except urllib.error.HTTPError as ex:
+        except urllib2.HTTPError as ex:
             msg = 'HTTP upload failed with response:\n'
             msg += '  Status code: %s\n' % ex.hdrs.get("Dqm-Status-Code", None)
             msg += '  Message: %s\n' % ex.hdrs.get("Dqm-Status-Message", None)
@@ -240,11 +238,11 @@ class DQMUpload(Executor):
         logging.info(msg)
 
         handler = HTTPSAuthHandler(key=uploadProxy, cert=uploadProxy)
-        opener = urllib.request.OpenerDirector()
+        opener = urllib2.OpenerDirector()
         opener.add_handler(handler)
 
         # setup the request object
-        datareq = urllib.request.Request(url + '/data/put')
+        datareq = urllib2.Request(url + '/data/put')
         datareq.add_header('Accept-encoding', 'gzip')
         datareq.add_header('User-agent', ident)
         self.marshall(args, {'file': filename}, datareq)
@@ -252,7 +250,7 @@ class DQMUpload(Executor):
         if 'https://' in url:
             result = opener.open(datareq)
         else:
-            opener.add_handler(urllib.request.ProxyHandler({}))
+            opener.add_handler(urllib2.ProxyHandler({}))
             result = opener.open(datareq)
 
         data = result.read()


### PR DESCRIPTION
Workaround for #9926

#### Status
not-tested

#### Description
Revert python3 compatibility changes applied on Executors/DQMUpload.py module, as applied on this PR:
https://github.com/dmwm/WMCore/pull/9762

This is a temporary workaround such that we can move forward with a new agent release candidate, which will be required for the Rucio transition.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none