### PR TITLE
Flag to disable PhEDExInjector; setup to enable all datatiers in RucioInjector

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -162,6 +162,7 @@ config.PhEDExInjector.namespace = "WMComponent.PhEDExInjector.PhEDExInjector"
 config.PhEDExInjector.componentDir = config.General.workDir + "/PhEDExInjector"
 config.PhEDExInjector.logLevel = globalLogLevel
 config.PhEDExInjector.maxThreads = 1
+config.PhEDExInjector.enabled = True
 config.PhEDExInjector.subscribeDatasets = True
 config.PhEDExInjector.safeMode = False
 # phedex address "https://cmsweb.cern.ch/phedex/datasvc/json/prod/"

--- a/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
+++ b/src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py
@@ -101,6 +101,8 @@ class PhEDExInjectorPoller(BaseWorkerThread):
         Initialise class members
         """
         BaseWorkerThread.__init__(self)
+
+        self.enabled = getattr(config.PhEDExInjector, "enabled", True)
         self.dbsUrl = config.DBSInterface.globalDBSUrl
         self.phedexGroup = config.PhEDExInjector.phedexGroup
 
@@ -191,6 +193,10 @@ class PhEDExInjectorPoller(BaseWorkerThread):
         Poll the database for uninjected files and attempt to inject them into
         PhEDEx.
         """
+        if not self.enabled:
+            logging.info("PhEDExInjector component is disabled in the configuration, exiting.")
+            return
+
         logging.info("Running PhEDEx injector poller algorithm...")
         self.pollCounter += 1
 


### PR DESCRIPTION
Fixes #9946


#### Status
ready

#### Description
This PR provides:
* a PhEDExInjector parameter to disable the component: `enabled` (default to `True`). If the component is disabled, it keeps running but not doing anything (returning on the 1st line of the algorithm method)
* change how `listTiersToInject` parameter is handled in RucioInjector. If the component is enabled, and that list is empty, then it means the component is supposed to inject every single data produced by the agent against the Rucio system.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
