### PR TITLE
Use dataset_replicas for the container data location

### DIFF
--- a/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
+++ b/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
@@ -386,11 +386,16 @@ class RucioTest(EmulatedUnitTestCase):
         newParams = {"host": 'http://cms-rucio.cern.ch',
                      "auth_host": 'https://cms-rucio-auth.cern.ch',
                      "auth_type": "x509", "account": "wmcore_transferor",
-                     "ca_cert": False, "timeout": 5}
+                     "ca_cert": False, "timeout": 50}
         prodRucio = Rucio.Rucio(newParams['account'],
                                 hostUrl=newParams['host'],
                                 authUrl=newParams['auth_host'],
                                 configDict=newParams)
+
+        # This is a very heavy check, with ~25k blocks
+        # PUDSET = "/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW"
+        # resp = prodRucio.getDataLockedAndAvailable(name=PUDSET)
+        # self.assertItemsEqual(resp, ['T1_US_FNAL_Disk'])
 
         # matches rules for this container and transfer_ops account, returns an union of the blocks RSEs
         resp = prodRucio.getDataLockedAndAvailable(name=DSET2, account="transfer_ops")


### PR DESCRIPTION
Fixes #9953

#### Status
not-tested

#### Description
Remake once again the container data location logic to use `list_dataset_replicas_bulk` instead of `get_dataset_locks` API,
which gives us a speed up by a factor of 3 or 4 (when there are multiple RSE rules), still very expensive though, went down from ~450secs to ~120secs for a large premix container (25k blocks / 125k files).
In case there are no multiple RSE rules, the speed up is by two orders of magnitude.

The possible flaw on this logic is that we no longer match dataset_locks rules against the container level rules; instead we match dataset_replicas RSEs against the RSEs from multiple RSE container-level rules. In other words, there is a chance that we use a given RSE as data location, but it's actually not locked by WMCore... I guess.

The docstrings explains every single detail of this logic.

Just a note, we might have to make the same changes for the pileup data location from WMAgent, which right now uses a different Rucio wrapper method and still relies on the heavy dataset_locks

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Change the logic implemented here: https://github.com/dmwm/WMCore/pull/9936

#### External dependencies / deployment changes
none
