### PR TITLE
Avoid resolving container location with the dataset_locks, whenever possible

### DIFF
--- a/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
+++ b/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
@@ -386,11 +386,16 @@ class RucioTest(EmulatedUnitTestCase):
         newParams = {"host": 'http://cms-rucio.cern.ch',
                      "auth_host": 'https://cms-rucio-auth.cern.ch',
                      "auth_type": "x509", "account": "wmcore_transferor",
-                     "ca_cert": False, "timeout": 5}
+                     "ca_cert": False, "timeout": 50}
         prodRucio = Rucio.Rucio(newParams['account'],
                                 hostUrl=newParams['host'],
                                 authUrl=newParams['auth_host'],
                                 configDict=newParams)
+
+        # This is a very heavy check, with ~25k blocks
+        PUDSET = "/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW"
+        resp = prodRucio.getDataLockedAndAvailable(name=PUDSET)
+        self.assertItemsEqual(resp, ['T1_US_FNAL_Disk'])
 
         # matches rules for this container and transfer_ops account, returns an union of the blocks RSEs
         resp = prodRucio.getDataLockedAndAvailable(name=DSET2, account="transfer_ops")


### PR DESCRIPTION
Fixes #9953
Superseeds #9954 (even though that might still be useful)

#### Status
ready

#### Description
The docstring provides a very detailed explanation.
In short, this PR changes the logic for container data location such that it tries to figure the container location by simply looking at the rules, in case there are rules where len(copies) == len(rses), we use that RSE as a container location.
If rules are made against many RSEs, then we need to list all the blocks in the container and ask for their dataset_locks, which is the heavy operation we must avoid as much as possible.

Important note: this will change the current behaviour of pileup input, in the sense that only container-wide location will be considered. Thus, transferring a single block to a given location will not be enough to unstuck a GQE waiting for the pileup to be available!

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
First attempt to fix it in (still under scrutiny): https://github.com/dmwm/WMCore/pull/9954

#### External dependencies / deployment changes
none
