### PR TITLE
Make RSE expression configurable when picking a Tape RSE

### DIFF
--- a/src/python/WMCore/MicroService/Unified/MSOutput.py
+++ b/src/python/WMCore/MicroService/Unified/MSOutput.py
@@ -91,6 +91,7 @@ class MSOutput(MSCore):
         self.msConfig.setdefault("excludeDataTier", ['NANOAOD', 'NANOAODSIM'])
         self.msConfig.setdefault("rucioAccount", 'wmcore_transferor')
         self.msConfig.setdefault("rucioRSEAttribute", 'ddm_quota')
+        self.msConfig.setdefault("rucioTapeExpression", 'rse_type=TAPE\cms_type=test')
         self.msConfig.setdefault("mongoDBUrl", 'mongodb://localhost')
         self.msConfig.setdefault("mongoDBPort", 8230)
         self.msConfig.setdefault("sendNotification", False)
@@ -515,7 +516,9 @@ class MSOutput(MSCore):
         """
         if self.msConfig.get('useRucio'):
             # This API returns a tuple with the RSE name and whether it requires approval
-            return self.rucio.pickRSE(rseAttribute=self.msConfig["rucioRSEAttribute"], minNeeded=dataSize)
+            return self.rucio.pickRSE(rseExpression=self.msConfig["rucioTapeExpression"],
+                                      rseAttribute=self.msConfig["rucioRSEAttribute"],
+                                      minNeeded=dataSize)
 
         # well, then it's PhEDEx
         res = self.phedex.getGroupUsage(node=self.tapeStatus.keys(), group=self.msConfig['defaultGroup'])


### PR DESCRIPTION
Fixes #9956 

#### Status
ready

#### Description
As discussed this week, T0_CH_CERN_Tape is not ready yet to receive custodial output data placement.
Make the `rseExpression` attribute configurable such that we can remove the T0 ban with a simple configuration change. 

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
None

#### External dependencies / deployment changes
Deployment changes: https://github.com/dmwm/deployment/pull/960