### PR TITLE
Suport Rucio-based data location in local workqueue - wmagent branch

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -135,6 +135,7 @@ config.WorkQueueManager.queueParams["ParentQueueCouchUrl"] = "https://cmsweb.cer
 config.WorkQueueManager.queueParams["QueueURL"] = "http://%s:5984" % (config.Agent.hostName)
 config.WorkQueueManager.queueParams["WorkPerCycle"] = 200  # don't pull more than this number of elements per cycle
 config.WorkQueueManager.queueParams["QueueDepth"] = 0.5  # pull work from GQ for only half of the resources
+config.WorkQueueManager.queueParams["rucioAccount"] = "wmcore_transferor"  # TODO FIXME: apply manually!
 
 config.component_("DBS3Upload")
 config.DBS3Upload.namespace = "WMComponent.DBS3Buffer.DBS3Upload"

--- a/src/python/Utils/MemoryCache.py
+++ b/src/python/Utils/MemoryCache.py
@@ -11,6 +11,8 @@ data type.
 """
 
 from __future__ import (print_function, division)
+
+from copy import copy
 from time import time
 
 
@@ -42,6 +44,27 @@ class MemoryCache(object):
         """
         return item in self._cache
 
+    def __getitem__(self, keyName):
+        """
+        If the cache is a dictionary, return that item from the cache. Else, raise an exception.
+        :param keyName: the key name from the dictionary
+        """
+        if isinstance(self._cache, dict):
+            return copy(self._cache.get(keyName))
+        else:
+            raise MemoryCacheException("Cannot retrieve an item from a non-dict MemoryCache object: {}".format(self._cache))
+
+    def reset(self):
+        """
+        Resets the cache to its current data type
+        """
+        if isinstance(self._cache, (dict, set)):
+            self._cache.clear()
+        elif isinstance(self._cache, list):
+            del self._cache[:]
+        else:
+            raise MemoryCacheException("The cache needs to be reset manually, data type unknown")
+
     def isCacheExpired(self):
         """
         Evaluate whether the cache has already expired, returning
@@ -68,6 +91,7 @@ class MemoryCache(object):
         if not isinstance(self._cache, type(inputData)):
             raise TypeError("Current cache data type: %s, while new value is: %s" %
                             (type(self._cache), type(inputData)))
+        self.reset()
         self.lastUpdate = int(time())
         self._cache = inputData
 

--- a/src/python/WMCore/Services/PhEDEx/PhEDEx.py
+++ b/src/python/WMCore/Services/PhEDEx/PhEDEx.py
@@ -30,6 +30,9 @@ class PhEDEx(Service):
         httpDict.setdefault('cacheduration', 0)
 
         Service.__init__(self, httpDict)
+        # NOTE: it looks like PhEDEx returns these weird data locations since ever.
+        # Why don't we deal with it as close as possible to the PhEDEx service then...
+        self.nodeFilter = set(['UNKNOWN', None])
 
     def _getResult(self, callname, clearCache=False,
                    args=None, verb="POST"):
@@ -435,7 +438,6 @@ class PhEDEx(Service):
 
         Returns a dictionary with se names per block
         """
-
         callname = 'blockreplicas'
         response = self._getResult(callname, args=kwargs)
 
@@ -449,7 +451,7 @@ class PhEDEx(Service):
             nodes = set()
             for replica in blockInfo['replica']:
                 nodes.add(replica['node'])
-            blockNodes[blockInfo['name']] = list(nodes)
+            blockNodes[blockInfo['name']] = list(nodes - self.nodeFilter)
 
         return blockNodes
 

--- a/src/python/WMCore/Services/PhEDEx/XMLDrop.py
+++ b/src/python/WMCore/Services/PhEDEx/XMLDrop.py
@@ -249,8 +249,7 @@ def makePhEDExDrop(dbsUrl, datasetPath, *blockNames):
 
     for block in blockNames:
         blockContent = reader.getFileBlock(block)
-        isOpen = reader.blockIsOpen(block)
-        if isOpen:
+        if blockContent['IsOpen']:
             xmlBlock = dataset.getFileblock(block, "y")
         else:
             xmlBlock = dataset.getFileblock(block, "n")

--- a/src/python/WMCore/Services/Rucio/Rucio.py
+++ b/src/python/WMCore/Services/Rucio/Rucio.py
@@ -8,15 +8,14 @@ CMS Workload Management system (and migration from PhEDEx).
 from __future__ import division, print_function, absolute_import
 
 import logging
+import random
 from copy import deepcopy
-from pprint import pformat
-
 from rucio.client import Client
 from rucio.common.exception import (AccountNotFound, DataIdentifierNotFound, AccessDenied, DuplicateRule,
-                                    DataIdentifierAlreadyExists, DuplicateContent,
+                                    DataIdentifierAlreadyExists, DuplicateContent, InvalidRSEExpression,
                                     UnsupportedOperation, FileAlreadyExists, RuleNotFound)
+from Utils.MemoryCache import MemoryCache
 from WMCore.WMException import WMException
-
 
 RUCIO_VALID_PROJECT = ("Production", "RelVal", "Tier0", "Test", "User")
 
@@ -47,6 +46,46 @@ def validateMetaData(did, metaDict, logger):
     return False
 
 
+def weightedChoice(choices):
+    # from https://stackoverflow.com/questions/3679694/a-weighted-version-of-random-choice
+    # Python 3.6 includes something like this in the random library itself
+
+    total = sum(w for c, w in choices)
+    r = random.uniform(0, total)
+    upto = 0
+    for c, w in choices:
+        if upto + w >= r:
+            return c
+        upto += w
+    assert False, "Shouldn't get here"
+
+
+def isTapeRSE(rseName):
+    """
+    Given an RSE name, return True if it's a Tape RSE (rse_type=TAPE), otherwise False
+    :param rseName: string with the RSE name
+    :return: True or False
+    """
+    # NOTE: a more reliable - but more expensive - way to know that would be
+    # to query `get_rse` and evaluate the rse_type parameter
+    return rseName.endswith("_Tape")
+
+
+def dropTapeRSEs(listRSEs):
+    """
+    Method to parse a list of RSE names and return only those that
+    are not a rse_type=TAPE, so in general only Disk endpoints
+    :param listRSEs: list with the RSE names
+    :return: a new list with only DISK RSE names
+    """
+    diskRSEs = []
+    for rse in listRSEs:
+        if rse.endswith("_Tape"):
+            continue
+        diskRSEs.append(rse)
+    return diskRSEs
+
+
 class Rucio(object):
     """
     Service class providing additional Rucio functionality on top of the
@@ -72,6 +111,8 @@ class Rucio(object):
         :param configDict: dictionary with extra parameters
         """
         configDict = configDict or {}
+        # default RSE data caching to 12h
+        rseCacheExpiration = configDict.pop('cacheExpiration', 12 * 60 * 60)
         self.logger = configDict.pop("logger", logging.getLogger())
 
         self.rucioParams = deepcopy(configDict)
@@ -87,9 +128,7 @@ class Rucio(object):
         # yield output compatible with the PhEDEx service class
         self.phedexCompat = self.rucioParams.get("phedexCompatible", True)
 
-        msg = "WMCore Rucio initialization with acct: %s, host: %s, auth: %s" % (acct, hostUrl, authUrl)
-        msg += " and these extra parameters: %s" % self.rucioParams
-        self.logger.info(msg)
+        self.logger.info("WMCore Rucio initialization parameters: %s", self.rucioParams)
         self.cli = Client(rucio_host=hostUrl, auth_host=authUrl, account=acct,
                           ca_cert=self.rucioParams['ca_cert'], auth_type=self.rucioParams['auth_type'],
                           creds=self.rucioParams['creds'], timeout=self.rucioParams['timeout'],
@@ -98,7 +137,10 @@ class Rucio(object):
         for k in ("host", "auth_host", "auth_type", "account", "user_agent",
                   "ca_cert", "creds", "timeout", "request_retries"):
             clientParams[k] = getattr(self.cli, k)
-        self.logger.info("Rucio client initialization with: %s", clientParams)
+        self.logger.info("Rucio client initialization parameters: %s", clientParams)
+
+        # keep a map of rse expression to RSE names mapped for some time
+        self.cachedRSEs = MemoryCache(rseCacheExpiration, {})
 
     def pingServer(self):
         """
@@ -132,6 +174,19 @@ class Rucio(object):
             self.logger.error("Failed to get account information from Rucio. Error: %s", str(ex))
         return res
 
+    def getAccountLimits(self, acct):
+        """
+        Provided an account name, fetch the storage quota for all RSEs
+        :param acct: a string with the rucio account name
+        :return: a dictionary of RSE name and quota in bytes.
+        """
+        res = {}
+        try:
+            res = self.cli.get_local_account_limits(acct)
+        except AccountNotFound as ex:
+            self.logger.error("Account: %s not found in the Rucio Server. Error: %s", acct, str(ex))
+        return res
+
     def getAccountUsage(self, acct, rse=None):
         """
         _getAccountUsage_
@@ -145,7 +200,7 @@ class Rucio(object):
         """
         res = None
         try:
-            res = list(self.cli.get_account_usage(acct, rse=rse))
+            res = list(self.cli.get_local_account_usage(acct, rse=rse))
         except (AccountNotFound, AccessDenied) as ex:
             self.logger.error("Failed to get account usage information from Rucio. Error: %s", str(ex))
         return res
@@ -160,14 +215,9 @@ class Rucio(object):
         :return: a list of block names
         """
         blockNames = []
-        try:
-            response = self.cli.get_did(scope=scope, name=container)
-        except DataIdentifierNotFound:
-            self.logger.warning("Cannot find a data identifier for: %s", container)
-            return blockNames
-
-        if response['type'].upper() != 'CONTAINER':
+        if not self.isContainer(container):
             # input container wasn't really a container
+            self.logger.warning("Provided DID name is not a CONTAINER type: %s", container)
             return blockNames
 
         response = self.cli.list_content(scope=scope, name=container)
@@ -184,42 +234,11 @@ class Rucio(object):
         Get block replica information.
         It mimics the same API available in the PhEDEx Service module.
 
-        kwargs originally available for PhEDEx are:
-        - dataset       dataset name, can be multiple (*)
-        - block         block name, can be multiple (*)
-        - node          node name, can be multiple (*)
-        - se            storage element name, can be multiple (*)
-        - update_since  unix timestamp, only return replicas updated since this time
-        - create_since  unix timestamp, only return replicas created since this time
-        - complete      y or n, whether or not to require complete or incomplete blocks.
-                        Default is to return either
-        - subscribed    y or n, filter for subscription. default is to return either.
-        - custodial     y or n. filter for custodial responsibility.
-                        Default is to return either.
-        - group         group name. Default is to return replicas for any group.
-
-        kwargs supported by Rucio are:
-        - dids             The list of data identifiers (DIDs) like : [{'scope': <scope1>, 'name': <name1>},
-                           {'scope': <scope2>, 'name': <name2>}, ...]
-        - schemes          A list of schemes to filter the replicas. (e.g. file, http, ...)
-        - unavailable      Also include unavailable replicas in the list. Default to False
-        - metalink         False (default) retrieves as JSON, True retrieves as metalink4+xml.
-        - rse_expression   The RSE expression to restrict replicas on a set of RSEs.
-        - client_location  Client location dictionary for PFN modification {'ip', 'fqdn', 'site'}
-        - sort             Sort the replicas:
-                           geoip - based on src/dst IP topographical distance
-                           closeness - based on src/dst closeness
-                           dynamic - Rucio Dynamic Smart Sort (tm)
-        - domain           Define the domain. None is fallback to 'wan', otherwise 'wan', 'lan', or 'all'
-        - resolve_archives When set to True, find archives which contain the replicas.
-        - resolve_parents  When set to True, find all parent datasets which contain the replicas.
-
         :kwargs: either a dataset or a block name has to be provided. Not both!
         :return: a list of dictionaries with replica information; or a dictionary
         compatible with PhEDEx.
         """
         kwargs.setdefault("scope", "cms")
-        kwargs.setdefault("deep", False)  # lookup at the file level, probably not needed...
 
         blockNames = []
         result = []
@@ -229,31 +248,37 @@ class Rucio(object):
         elif 'block' in kwargs:
             blockNames = [kwargs['block']]
 
-        # FIXME: make bulk requests once https://github.com/rucio/rucio/issues/2459 gets fixed
         if isinstance(kwargs.get('dataset', None), (list, set)):
             for datasetName in kwargs['dataset']:
                 blockNames.extend(self.getBlocksInContainer(datasetName, scope=kwargs['scope']))
         elif 'dataset' in kwargs:
             blockNames.extend(self.getBlocksInContainer(kwargs['dataset'], scope=kwargs['scope']))
 
-        for blockName in blockNames:
-            replicas = []
-            response = self.cli.list_dataset_replicas(kwargs['scope'], blockName,
-                                                      deep=kwargs['deep'])
-            for item in response:
-                # same as complete='y' used for PhEDEx (which is always set within WMCore)
-                if item['state'].upper() == 'AVAILABLE':
-                    replicas.append(item['rse'])
-            result.append({'name': blockName, 'replica': list(set(replicas))})
+        inputDids = []
+        for block in blockNames:
+            inputDids.append({"scope": kwargs["scope"], "type": "DATASET", "name": block})
+
+        resultDict = {}
+        for item in self.cli.list_dataset_replicas_bulk(inputDids):
+            resultDict.setdefault(item['name'], [])
+            if item['state'].upper() == 'AVAILABLE':
+                resultDict[item['name']].append(item['rse'])
 
         if self.phedexCompat:
-            # convert plain node list to list of nodes dict
-            for block in result:
-                replicas = []
-                for node in block['replica']:
-                    replicas.append({'node': node})
-                block['replica'] = replicas
+            # then we need to convert it to a format like:
+            # {"phedex": {"block": [{"name": "block_A", "replica": [{"node": "nodeA"}, {"node": "nodeB"}]},
+            #                        etc etc
+            #                        }}
+            for blockName, rses in resultDict.viewitems():
+                replicas = [{"node": rse} for rse in rses]
+                result.append({"name": blockName, "replica": replicas})
             result = {'phedex': {'block': result}}
+        else:
+            # then a list of dictionaries sounds right, e.g.:
+            # [{"name": "block_A", "replica": ["nodeA", "nodeB"]},
+            #  {"name": "block_B", etc etc}]
+            for blockName, rses in resultDict.viewitems():
+                result.append({"name": blockName, "replica": list(set(rses))})
 
         return result
 
@@ -385,7 +410,6 @@ class Rucio(object):
         for item in files:
             item['scope'] = scope
 
-        # TODO: test to make sure 'state' is a valid argument
         response = False
         try:
             # add_replicas(rse, files, ignore_availability=True)
@@ -462,15 +486,16 @@ class Rucio(object):
         """
         kwargs.setdefault('grouping', 'ALL')
         kwargs.setdefault('account', self.rucioParams.get('account'))
+        kwargs.setdefault('lifetime', None)
         kwargs.setdefault('locked', False)
         kwargs.setdefault('notify', 'N')
         kwargs.setdefault('purge_replicas', False)
         kwargs.setdefault('ignore_availability', False)
         kwargs.setdefault('ask_approval', False)
-        kwargs.setdefault('asynchronous', False)
+        kwargs.setdefault('asynchronous', True)
         kwargs.setdefault('priority', 3)
 
-        if not isinstance(names, list):
+        if not isinstance(names, (list, set)):
             names = [names]
         dids = [{'scope': scope, 'name': did} for did in names]
 
@@ -489,35 +514,23 @@ class Rucio(object):
             #    a duplicate rule. In this case all the rest of the Dids will be
             #    ignored, which in general should be addressed by Rucio. But since
             #    it is not, we should break the list of Dids and proceed one by one
-            # NOTE:
-            #    This thing here may be slow, because it will wait for Rucio to
-            #    return the history of rules per every Did, but no shorter path exists
-            msg = "A duplicate rule for: \naccount: %s \ndids: %s \nrseExpression: %s.\n"
-            self.logger.info(msg,
-                             kwargs['account'],
-                             pformat(dids),
-                             rseExpression)
+            self.logger.warning("Resolving duplicate rules and separating every DID in a new rule...")
 
             ruleIds = []
-            didsDup = []
+            # now try creating a new rule for every single DID in a separated call
             for did in dids:
                 try:
                     response = self.cli.add_replication_rule([did], copies, rseExpression, **kwargs)
-                    for ruleId in response:
-                        ruleIds.append(ruleId)
-                    self.logger.debug("Per did ruleIds: %s", ruleIds)
+                    ruleIds.extend(response)
                 except DuplicateRule:
-                    didsDup.append(did)
-
-            ruleHistory = self.listRuleHistory(didsDup)
-            self.logger.debug("Rule History: %s\n", pformat(ruleHistory))
-
-            for did in ruleHistory:
-                for didHist in did['did_hist']:
-                    ruleIds.append(didHist['rule_id'])
-            ruleIds = list(set(ruleIds))
-            self.logger.debug("ruleIds: %s\n", ruleIds)
-            return ruleIds
+                    self.logger.warning("Found duplicate rule for account: %s\n, rseExp: %s\ndids: %s",
+                                        kwargs['account'], rseExpression, dids)
+                    # Well, then let us find which rule_id is already in the system
+                    for rule in self.listDataRules(did['name'], did['scope']):
+                        if rule['account'] == kwargs['account'] and rule['rse_expression'] == rseExpression:
+                            # then this is the duplicate rule!
+                            ruleIds.append(rule['id'])
+            return list(set(ruleIds))
         except Exception as ex:
             self.logger.error("Exception creating rule replica for data: %s. Error: %s", names, str(ex))
         return response
@@ -605,6 +618,23 @@ class Rucio(object):
             self.logger.error("Exception listing rules history for data: %s. Error: %s", name, str(ex))
         return list(res)
 
+    def listParentDIDs(self, name, scope='cms'):
+        """
+        _listParentDID__
+
+        List the parent block/container of the specified DID.
+        :param name: data identifier (either a block or a file name)
+        :param scope: string with the scope name
+        :return: a list with dictionary items
+        """
+        res = []
+        try:
+            res = self.cli.list_parent_dids(scope, name)
+        except Exception as ex:
+            self.logger.error("Exception listing parent DIDs for data: %s. Error: %s", name, str(ex))
+        return list(res)
+
+
     def getRule(self, ruleId, estimatedTtc=False):
         """
         _getRule_
@@ -641,3 +671,510 @@ class Rucio(object):
             self.logger.error("Exception deleting rule id: %s. Error: %s", ruleId, str(ex))
             res = False
         return res
+
+    def evaluateRSEExpression(self, rseExpr, useCache=True, returnTape=True):
+        """
+        Provided an RSE expression, resolve it and return a flat list of RSEs
+        :param rseExpr: an RSE expression (which could be the RSE itself...)
+        :param useCache: boolean defining whether cached data is meant to be used or not
+        :param returnTape: boolean to also return Tape RSEs from the RSE expression result
+        :return: a list of RSE names
+        """
+        if self.cachedRSEs.isCacheExpired():
+            self.cachedRSEs.reset()
+        if useCache and rseExpr in self.cachedRSEs:
+            if returnTape:
+                return self.cachedRSEs[rseExpr]
+            return dropTapeRSEs(self.cachedRSEs[rseExpr])
+        else:
+            matchingRSEs = []
+            try:
+                for item in self.cli.list_rses(rseExpr):
+                    matchingRSEs.append(item['rse'])
+            except InvalidRSEExpression as exc:
+                msg = "Provided RSE expression is considered invalid: {}. Error: {}".format(rseExpr, str(exc))
+                raise WMRucioException(msg)
+        # add this key/value pair to the cache
+        self.cachedRSEs.addItemToCache({rseExpr: matchingRSEs})
+        if returnTape:
+            return matchingRSEs
+        return dropTapeRSEs(matchingRSEs)
+
+    def pickRSE(self, rseExpression='rse_type=TAPE\cms_type=test', rseAttribute='ddm_quota', minNeeded=0):
+        """
+        _pickRSE_
+
+        Use a weighted random selection algorithm to pick an RSE for a dataset based on an attribute
+        The attribute should correlate to space available.
+        :param rseExpression: Rucio RSE expression to pick RSEs (defaults to production Tape RSEs)
+        :param rseAttribute: The RSE attribute to use as a weight. Must be a number
+        :param minNeeded: If the RSE attribute is less than this number, the RSE will not be considered.
+
+        Returns: A tuple of the chosen RSE and if the chosen RSE requires approval to write (rule property)
+        """
+        matchingRSEs = self.evaluateRSEExpression(rseExpression)
+        rsesWithWeights = []
+
+        for rse in matchingRSEs:
+            attrs = self.cli.list_rse_attributes(rse)
+            if rseAttribute:
+                try:
+                    quota = float(attrs.get(rseAttribute, 0))
+                except (TypeError, KeyError):
+                    quota = 0
+            else:
+                quota = 1
+            requiresApproval = attrs.get('requires_approval', False)
+            if quota > minNeeded:
+                rsesWithWeights.append(((rse, requiresApproval), quota))
+
+        choice = weightedChoice(rsesWithWeights)
+        return choice
+
+    def isContainer(self, didName, scope='cms'):
+        """
+        Checks whether the DID name corresponds to a container type or not.
+        :param didName: string with the DID name
+        :param scope: string containing the Rucio scope (defaults to 'cms')
+        :return: True if the DID is a container, else False
+        """
+        try:
+            response = self.cli.get_did(scope=scope, name=didName)
+        except DataIdentifierNotFound as exc:
+            msg = "Data identifier not found in Rucio: {}. Error: {}".format(didName, str(exc))
+            raise WMRucioException(msg)
+        return response['type'].upper() == 'CONTAINER'
+
+    def getDID(self, didName, dynamic=True, scope='cms'):
+        """
+        Retrieves basic information for a single data identifier.
+        :param didName: string with the DID name
+        :param dynamic: boolean to dynamically calculate the DID size (default to True)
+        :param scope: string containing the Rucio scope (defaults to 'cms')
+        :return: a dictionary with basic DID information
+        """
+        try:
+            response = self.cli.get_did(scope=scope, name=didName, dynamic=dynamic)
+        except DataIdentifierNotFound as exc:
+            response = dict()
+            self.logger.error("Data identifier not found in Rucio: %s. Error: %s", didName, str(exc))
+        return response
+
+    # FIXME we can likely delete this method (replaced by another implementation)
+    def getDataLockedAndAvailable_old(self, **kwargs):
+        """
+        This method retrieves all the locations where a given DID is
+        currently available and locked. It can be used for the data
+        location logic in global and local workqueue.
+
+        Logic is as follows:
+        1. look for all replication rules matching the provided keyword args
+        2. location of single RSE rules and in state OK are set as a location
+        3.a. if the input DID name is a block, get all the locks AVAILABLE for that block
+          and compare the rule ID against the multi RSE rules. Keep the RSE if it matches
+        3.b. otherwise - if it's a container - method `_getContainerLockedAndAvailable`
+          gets called to resolve all the blocks and locks
+        4. union of the single RSEs and the matched multi RSEs is returned as the
+        final location of the provided DID
+
+        :param kwargs: key/value pairs to filter out the rules. Most common filters are likely:
+            scope: string with the scope name
+            name: string with the DID name
+            account: string with the rucio account name
+            state: string with the state name
+            grouping: string with the grouping name
+        :param returnTape: boolean to return Tape RSEs in the output, if any
+        :return: a flat list with the RSE names locking and holding the input DID
+
+        NOTE: some of the supported values can be looked up at:
+        https://github.com/rucio/rucio/blob/master/lib/rucio/db/sqla/constants.py#L184
+        """
+        msg = "This method `getDataLockedAndAvailable_old` is getting deprecated "
+        msg += "and it will be removed in future releases."
+        self.logger.warning(msg)
+        returnTape = kwargs.pop("returnTape", False)
+        if 'name' not in kwargs:
+            raise WMRucioException("A DID name must be provided to the getDataLockedAndAvailable API")
+        if 'grouping' in kwargs:
+            # long strings seem not to be working, like ALL / DATASET
+            if kwargs['grouping'] == "ALL":
+                kwargs['grouping'] = "A"
+            elif kwargs['grouping'] == "DATASET":
+                kwargs['grouping'] = "D"
+
+        kwargs.setdefault("scope", "cms")
+
+        multiRSERules = []
+        finalRSEs = set()
+
+        # First, find all the rules and where data is supposed to be locked
+        rules = self.cli.list_replication_rules(kwargs)
+        for rule in rules:
+            # now resolve the RSE expressions
+            rses = self.evaluateRSEExpression(rule['rse_expression'], returnTape=returnTape)
+            if rule['copies'] == len(rses) and rule['state'] == "OK":
+                # then we can guarantee that data is locked and available on these RSEs
+                finalRSEs.update(set(rses))
+            else:
+                multiRSERules.append(rule['id'])
+        self.logger.debug("Data location for %s from single RSE locks and available at: %s",
+                          kwargs['name'], list(finalRSEs))
+        if not multiRSERules:
+            # then that is it, we can return the current RSEs holding and locking this data
+            return list(finalRSEs)
+
+        # At this point, we might already have some of the RSEs where the data is available and locked
+        # Now check dataset locks and compare those rules against our list of multi RSE rules
+        if self.isContainer(kwargs['name']):
+            # It's a container! Find what those RSEs are and add them to the finalRSEs set
+            rseLocks = self._getContainerLockedAndAvailable(multiRSERules, returnTape=returnTape, **kwargs)
+            self.logger.debug("Data location for %s from multiple RSE locks and available at: %s",
+                              kwargs['name'], list(rseLocks))
+        else:
+            # It's a single block! Find what those RSEs are and add them to the finalRSEs set
+            rseLocks = set()
+            for blockLock in self.cli.get_dataset_locks(kwargs['scope'], kwargs['name']):
+                if blockLock['state'] == 'OK' and blockLock['rule_id'] in multiRSERules:
+                    rseLocks.add(blockLock['rse'])
+            self.logger.debug("Data location for %s from multiple RSE locks and available at: %s",
+                              kwargs['name'], list(rseLocks))
+
+        finalRSEs = list(finalRSEs | rseLocks)
+        return finalRSEs
+
+    # FIXME we can likely delete this method
+    def _getContainerLockedAndAvailable_old(self, multiRSERules, **kwargs):
+        """
+        This method is only supposed to be called internally (private method),
+        because it won't consider the container level rules.
+
+        This method retrieves all the locations where a given container DID is
+        currently available and locked. It can be used for the data
+        location logic in global and local workqueue.
+
+        Logic is as follows:
+        1. find all the blocks in the provided container name
+        2. loop over all the block names and fetch their locks AVAILABLE
+        2.a. compare the rule ID against the multi RSE rules. Keep the RSE if it matches
+        3.a. if keyword argument grouping is ALL, returns an intersection of all blocks RSEs
+        3.b. else - grouping DATASET - returns an union of all blocks RSEs
+
+        :param multiRSERules: list of container level rules to be matched against
+        :param kwargs: key/value pairs to filter out the rules. Most common filters are likely:
+            scope: string with the scope name
+            name: string with the DID name
+            account: string with the rucio account name
+            state: string with the state name
+            grouping: string with the grouping name
+        :param returnTape: boolean to return Tape RSEs in the output, if any
+        :return: a set with the RSE names locking and holding this input DID
+
+        NOTE: some of the supported values can be looked up at:
+        https://github.com/rucio/rucio/blob/master/lib/rucio/db/sqla/constants.py#L184
+        """
+        msg = "This method `_getContainerLockedAndAvailable_old` is getting deprecated "
+        msg += "and it will be removed in future releases."
+        self.logger.warning(msg)
+        returnTape = kwargs.pop("returnTape", False)
+        finalRSEs = set()
+        blockNames = self.getBlocksInContainer(kwargs['name'])
+        self.logger.debug("Container: %s contains %d blocks. Querying dataset_locks ...",
+                          kwargs['name'], len(blockNames))
+
+        rsesByBlocks = {}
+        for block in blockNames:
+            rsesByBlocks.setdefault(block, set())
+            ### FIXME: feature request made to the Rucio team to support bulk operations:
+            ### https://github.com/rucio/rucio/issues/3982
+            for blockLock in self.cli.get_dataset_locks(kwargs['scope'], block):
+                if not returnTape and isTapeRSE(blockLock['rse']):
+                    continue
+                if blockLock['state'] == 'OK' and blockLock['rule_id'] in multiRSERules:
+                    rsesByBlocks[block].add(blockLock['rse'])
+
+        ### The question now is:
+        ###   1. do we want to have a full copy of the container in the same RSEs (grouping=A)
+        ###   2. or we want all locations holding at least one block of the container (grouping=D)
+        if kwargs.get('grouping') == 'A':
+            firstRun = True
+            for _block, rses in rsesByBlocks.viewitems():
+                if firstRun:
+                    finalRSEs = rses
+                    firstRun = False
+                else:
+                    finalRSEs = finalRSEs & rses
+        else:
+            for _block, rses in rsesByBlocks.viewitems():
+                finalRSEs = finalRSEs | rses
+        return finalRSEs
+
+    def getPileupLockedAndAvailable(self, container, account, scope="cms"):
+        """
+        Method to resolve where the pileup container (and all its blocks)
+        is locked and available.
+
+        Pileup location resolution involves the following logic:
+        1. find replication rules at the container level
+          * if num of copies is equal to num of rses, and state is Ok, use
+          those RSEs as container location (thus, every single block)
+          * elif there are more rses than copies, keep that rule id for the next step
+        2. discover all the blocks in the container
+        3. if there are no multi RSEs rules, just build the block location map and return
+        3. otherwise, for every block, list their current locks and if they are in state=OK
+           and they belong to one of our multiRSEs rule, use that RSE as block location
+        :param container: string with the container name
+        :param account: string with the account name
+        :param scope: string with the scope name (default is "cms")
+        :return: a flat dictionary where the keys are the block names, and the value is
+          a set with the RSE locations
+
+        NOTE: This is somewhat complex, so I decided to make it more readable with
+        a specific method for this process, even though that adds some code duplication.
+        """
+        result = dict()
+        if not self.isContainer(container):
+            raise WMRucioException("Pileup location needs to be resolved for a container DID type")
+
+        multiRSERules = []
+        finalRSEs = set()
+        kargs = dict(name=container, account=account, scope=scope)
+
+        # First, find all the rules and where data is supposed to be locked
+        for rule in self.cli.list_replication_rules(kargs):
+            rses = self.evaluateRSEExpression(rule['rse_expression'], returnTape=False)
+            if rses and rule['copies'] == len(rses) and rule['state'] == "OK":
+                # then we can guarantee that data is locked and available on these RSEs
+                finalRSEs.update(set(rses))
+            # it could be that the rule was made against Tape only, so check
+            elif rses:
+                multiRSERules.append(rule['id'])
+        self.logger.info("Pileup container location for %s from single RSE locks at: %s",
+                         kargs['name'], list(finalRSEs))
+
+        # Second, find all the blocks in this pileup container and assign the container
+        # level locations to them
+        for blockName in self.getBlocksInContainer(kargs['name']):
+            result.update({blockName: finalRSEs})
+        if not multiRSERules:
+            # then that is it, we can return the current RSEs holding and locking this data
+            return result
+
+        # if we got here, then there is a third step to be done.
+        # List every single block lock and check if the rule belongs to the WMCore system
+        for blockName in result:
+            for blockLock in self.cli.get_dataset_locks(scope, blockName):
+                if isTapeRSE(blockLock['rse']):
+                    continue
+                if blockLock['state'] == 'OK' and blockLock['rule_id'] in multiRSERules:
+                    result[blockName].add(blockLock['rse'])
+        return result
+
+    def getParentContainerRules(self, **kwargs):
+        """
+        This method takes a DID - such as a file or block - and it resolves its parent
+        DID(s). Then it loops over all parent DIDs and - according to the filters
+        provided in the kwargs - it lists all their rules.
+        :param kwargs: key/value filters supported by list_replication_rules Rucio API, such as:
+          * name: string with the DID name (mandatory)
+          * scope: string with the scope name (optional)
+          * account: string with the rucio account name (optional)
+          * state: string with the state name (optional)
+          * grouping: string with the grouping name (optional)
+          * did_type: string with the DID type (optional)
+          * created_before: an RFC-1123 compliant date string (optional)
+          * created_after: an RFC-1123 compliant date string (optional)
+          * updated_before: an RFC-1123 compliant date string (optional)
+          * updated_after: an RFC-1123 compliant date string (optional)
+          * and any of the other supported query arguments from the ReplicationRule class, see:
+          https://github.com/rucio/rucio/blob/master/lib/rucio/db/sqla/models.py#L884
+        :return: a list of rule ids made against the parent DIDs
+        """
+        if 'name' not in kwargs:
+            raise WMRucioException("A DID name must be provided to the getParentContainerLocation API")
+        if 'grouping' in kwargs:
+            # long strings seem not to be working, like ALL / DATASET. Make it short!
+            kwargs['grouping'] = kwargs['grouping'][0]
+        kwargs.setdefault("scope", "cms")
+        didName = kwargs['name']
+
+        listOfRules = []
+        for parentDID in self.listParentDIDs(kwargs['name']):
+            kwargs['name'] = parentDID['name']
+            for rule in self.cli.list_replication_rules(kwargs):
+                listOfRules.append(rule['id'])
+        # revert the original DID name, in case the client will keep using this dict...
+        kwargs['name'] = didName
+        return listOfRules
+
+    def getDataLockedAndAvailable(self, **kwargs):
+        """
+        This method retrieves all the locations where a given DID is
+        currently available and locked (note that, by default, it will not
+        return any Tape RSEs). The logic is as follows:
+          1. if DID is a container, then return the result from `getContainerLockedAndAvailable`
+          2. resolve the parent DID(s), if any
+          3. list all the replication rule ids for the parent DID(s), if any
+          4. then lists all the replication rules for this specific DID
+          5. then check where blocks are locked and available (state=OK), matching
+             one of the replication rule ids discovered in the previous steps
+        :param kwargs: key/value filters supported by list_replication_rules Rucio API, such as:
+          * name: string with the DID name (mandatory)
+          * scope: string with the scope name (optional)
+          * account: string with the rucio account name (optional)
+          * state: string with the state name (optional)
+          * grouping: string with the grouping name (optional)
+          * did_type: string with the DID type (optional)
+          * created_before: an RFC-1123 compliant date string (optional)
+          * created_after: an RFC-1123 compliant date string (optional)
+          * updated_before: an RFC-1123 compliant date string (optional)
+          * updated_after: an RFC-1123 compliant date string (optional)
+          * and any of the other supported query arguments from the ReplicationRule class, see:
+          https://github.com/rucio/rucio/blob/master/lib/rucio/db/sqla/models.py#L884
+        :param returnTape: boolean to return Tape RSEs in the output, if any
+        :return: a flat list with the RSE names locking and holding the input DID
+
+        NOTE: some of the supported values can be looked up at:
+        https://github.com/rucio/rucio/blob/master/lib/rucio/db/sqla/constants.py#L184
+        """
+        if 'name' not in kwargs:
+            raise WMRucioException("A DID name must be provided to the getBlockLockedAndAvailable API")
+        if self.isContainer(kwargs['name']):
+            # then resolve it at container level and all its blocks
+            return self.getContainerLockedAndAvailable(**kwargs)
+
+        if 'grouping' in kwargs:
+            # long strings seem not to be working, like ALL / DATASET. Make it short!
+            kwargs['grouping'] = kwargs['grouping'][0]
+        kwargs.setdefault("scope", "cms")
+        returnTape = kwargs.pop("returnTape", False)
+
+        finalRSEs = set()
+        # first, fetch the rules locking the - possible - parent DIDs
+        allRuleIds = self.getParentContainerRules(**kwargs)
+
+        # then lists all the rules for this specific DID
+        for rule in self.cli.list_replication_rules(kwargs):
+            allRuleIds.append(rule['id'])
+
+        # now with all the rules in hands, we can start checking block locks
+        for blockLock in self.cli.get_dataset_locks(kwargs['scope'], kwargs['name']):
+            if blockLock['state'] == 'OK' and blockLock['rule_id'] in allRuleIds:
+                finalRSEs.add(blockLock['rse'])
+        if not returnTape:
+            finalRSEs = dropTapeRSEs(finalRSEs)
+        else:
+            finalRSEs = list(finalRSEs)
+        return finalRSEs
+
+    def getContainerLockedAndAvailable(self, **kwargs):
+        """
+        This method retrieves all the locations where a given container DID is
+        currently available and locked (note that, by default, it will not
+        return any Tape RSEs). The logic is as follows:
+          1. for each container-level replication rule, check
+            i. if the rule state=OK and if the number of copies is equals to
+             the number of RSEs. If so, that is one of the container locations
+            ii. elif the rule state=OK, then consider that rule id (and its RSEs) to
+             be evaluated against the dataset locks
+            iii. otherwise, don't use the container rule
+          2. if there were no rules with multiple RSEs, then return the RSEs from step 1
+          3. else, retrieve all the blocks in the container and build a block-based dictionary
+            by listing all the dataset_locks for all the blocks:
+            i. if the lock state=OK and the rule_id belongs to one of those multiple RSE locks
+             from step-1, then use that block location
+            ii. else, the location can't be used
+          5. finally, build the final container location based on the input `grouping` parameter
+           specified, such as:
+            i. grouping=ALL triggers an intersection (AND) of all blocks location, which gets added
+             to the already discovered container-level location
+            ii. other grouping values (like DATASET) triggers an union of all blocks location (note
+             that it only takes one block location to consider it as a final location), and a final
+             union of this list with the container-level location is made
+        :param kwargs: key/value filters supported by list_replication_rules Rucio API, such as:
+          * name: string with the DID name (mandatory)
+          * scope: string with the scope name (optional)
+          * account: string with the rucio account name (optional)
+          * state: string with the state name (optional)
+          * grouping: string with the grouping name (optional)
+          * did_type: string with the DID type (optional)
+          * created_before: an RFC-1123 compliant date string (optional)
+          * created_after: an RFC-1123 compliant date string (optional)
+          * updated_before: an RFC-1123 compliant date string (optional)
+          * updated_after: an RFC-1123 compliant date string (optional)
+          * and any of the other supported query arguments from the ReplicationRule class, see:
+          https://github.com/rucio/rucio/blob/master/lib/rucio/db/sqla/models.py#L884
+        :param returnTape: boolean to return Tape RSEs in the output, if any
+        :return: a flat list with the RSE names locking and holding the input DID
+
+        NOTE-1: this is not a full scan of data locking and availability because it does
+        not list the replication rules for blocks!!!
+
+        NOTE-2: some of the supported values can be looked up at:
+        https://github.com/rucio/rucio/blob/master/lib/rucio/db/sqla/constants.py#L184
+        """
+        if 'name' not in kwargs:
+            raise WMRucioException("A DID name must be provided to the getContainerLockedAndAvailable API")
+        if 'grouping' in kwargs:
+            # long strings seem not to be working, like ALL / DATASET. Make it short!
+            kwargs['grouping'] = kwargs['grouping'][0]
+        kwargs.setdefault("scope", "cms")
+        returnTape = kwargs.pop("returnTape", False)
+
+        finalRSEs = set()
+        multiRSERules = []
+        # first, find all the rules locking this container matching the kwargs
+        for rule in self.cli.list_replication_rules(kwargs):
+            # now resolve the RSE expressions
+            rses = self.evaluateRSEExpression(rule['rse_expression'])
+            if rule['copies'] == len(rses) and rule['state'] == "OK":
+                # then we can guarantee that data is locked and available on these RSEs
+                finalRSEs.update(set(rses))
+            elif rule['state'] == "OK":
+                if returnTape:
+                    multiRSERules.append(rule['id'])
+                elif dropTapeRSEs(rses):
+                    # if it's not a tape-only rule, use it
+                    multiRSERules.append(rule['id'])
+            else:
+                self.logger.debug("Container rule: %s not yet satisfied. State: %s", rule['id'], rule['state'])
+        self.logger.info("Container: %s with container-based location at: %s",
+                         kwargs['name'], finalRSEs)
+        if not multiRSERules:
+            return list(finalRSEs)
+
+        # second, find all the blocks in this container and loop over all of them,
+        # checking where they are locked and available
+        locationByBlock = dict()
+        for block in self.getBlocksInContainer(kwargs['name']):
+            locationByBlock.setdefault(block, set())
+            for blockLock in self.cli.get_dataset_locks(kwargs['scope'], block):
+                if blockLock['state'] == 'OK' and blockLock['rule_id'] in multiRSERules:
+                    locationByBlock[block].add(blockLock['rse'])
+
+        # lastly, the final list of RSEs will depend on data grouping requested
+        # ALL --> container location is an intersection of each block location
+        # DATASET --> container location is the union of each block location.
+        #   Note that a block without any location will not affect the final result.
+        commonBlockRSEs = set()
+        if kwargs.get('grouping') == 'A':
+            firstRun = True
+            for rses in locationByBlock.viewvalues():
+                if firstRun:
+                    commonBlockRSEs = set(rses)
+                    firstRun = False
+                else:
+                    commonBlockRSEs = commonBlockRSEs & set(rses)
+            # finally, append the block based location to the container rule location
+            finalRSEs.update(commonBlockRSEs)
+        else:
+            for rses in locationByBlock.viewvalues():
+                commonBlockRSEs = commonBlockRSEs | set(rses)
+            finalRSEs = finalRSEs | commonBlockRSEs
+
+        if not returnTape:
+            finalRSEs = dropTapeRSEs(finalRSEs)
+        else:
+            finalRSEs = list(finalRSEs)
+        self.logger.info("Container: %s with block-based location at: %s, and final location: %s",
+                          kwargs['name'], commonBlockRSEs, finalRSEs)
+        return finalRSEs

--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -452,7 +452,7 @@ class SetupCMSSWPset(ScriptInterface):
                             eventsAvailable += int(blockDict.get('NumberOfEvents', 0))
                             for fileLFN in blockDict["FileList"]:
                                 # vstring does not support unicode
-                                inputTypeAttrib.fileNames.append(str(fileLFN['logical_file_name']))
+                                inputTypeAttrib.fileNames.append(str(fileLFN))
                     if requestedPileupType == 'data':
                         if getattr(self.jobBag, 'skipPileupEvents', None) is not None:
                             # For deterministic pileup, we want to shuffle the list the

--- a/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
+++ b/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
@@ -33,32 +33,24 @@ class PileupFetcher(FetcherInterface):
         """
         super(PileupFetcher, self).__init__()
         if usingRucio():
-            # Too much work to pass the rucio account name all the way to here
-            # just use the production rucio account for resolving pileup location
-            self.rucio = Rucio("wma_prod", configDict={'phedexCompatible': False})
+            # FIXME: find a way to pass the Rucio account name to this fetcher module
+            self.rucioAcct = "wmcore_transferor"
+            self.rucio = Rucio(self.rucioAcct)
         else:
             self.phedex = PhEDEx()  # this will go away eventually
 
     def _queryDbsAndGetPileupConfig(self, stepHelper, dbsReader):
         """
         Method iterates over components of the pileup configuration input
-        and queries DBS. Then iterates over results from DBS.
+        and queries DBS for valid files in the dataset, plus some extra
+        information about each file.
 
-        There needs to be a list of files and their locations for each
-        dataset name.
-        Use dbsReader
-        the result data structure is a Python dict following dictionary:
-            FileList is a list of LFNs
+        Information is organized at block level, listing all its files,
+        number of events in the block, and its data location (to be resolved
+        by a different method using either PhEDEx or Rucio), such as:
 
-        {"pileupTypeA": {"BlockA": {"FileList": [], "PhEDExNodeNames": []},
+        {"pileupTypeA": {"BlockA": {"FileList": [], "PhEDExNodeNames": [], "NumberOfEvents": 123},
                          "BlockB": {"FileList": [], "PhEDExNodeName": []}, ....}
-
-        this structure preserves knowledge of where particular files of dataset
-        are physically (list of PNNs) located. DBS only lists sites which
-        have all files belonging to blocks but e.g. BlockA of dataset DS1 may
-        be located at site1 and BlockB only at site2 - it's possible that only
-        a subset of the blocks in a dataset will be at a site.
-
         """
         resultDict = {}
         # iterate over input pileup types (e.g. "cosmics", "minbias")
@@ -69,14 +61,11 @@ class PileupFetcher(FetcherInterface):
             blockDict = {}
             for dataset in datasets:
 
-                blockFileInfo = dbsReader.getFileListByDataset(dataset=dataset, detail=True)
-
-                for fileInfo in blockFileInfo:
+                for fileInfo in dbsReader.getFileListByDataset(dataset=dataset, detail=True):
                     blockDict.setdefault(fileInfo['block_name'], {'FileList': [],
                                                                   'NumberOfEvents': 0,
                                                                   'PhEDExNodeNames': []})
-                    blockDict[fileInfo['block_name']]['FileList'].append(
-                        {'logical_file_name': fileInfo['logical_file_name']})
+                    blockDict[fileInfo['block_name']]['FileList'].append(fileInfo['logical_file_name'])
                     blockDict[fileInfo['block_name']]['NumberOfEvents'] += fileInfo['event_count']
 
                 self._getDatasetLocation(dataset, blockDict)
@@ -91,25 +80,18 @@ class PileupFetcher(FetcherInterface):
         :param blockDict: dictionary with DBS summary info
         :return: update blockDict in place
         """
-        node_filter = set(['UNKNOWN', None])
-
-        if hasattr(self, "rucio"):
-            # then it's Rucio!!
-            blockReplicasInfo = self.rucio.getReplicaInfoForBlocks(dataset=dset)
-            for item in blockReplicasInfo:
-                block = item['name']
+        if usingRucio():
+            blockReplicas = self.rucio.getPileupLockedAndAvailable(dset, account=self.rucioAcct)
+            for blockName, blockLocation in blockReplicas.viewitems():
                 try:
-                    blockDict[block]['PhEDExNodeNames'] = item['replica']
-                    blockDict[block]['FileList'] = sorted(blockDict[block]['FileList'])
+                    blockDict[blockName]['PhEDExNodeNames'] = list(blockLocation)
                 except KeyError:
-                    logging.warning("Block '%s' does not have any complete Rucio replica", block)
+                    logging.warning("Block '%s' present in Rucio but not in DBS", blockName)
         else:
             blockReplicasInfo = self.phedex.getReplicaPhEDExNodesForBlocks(dataset=dset, complete='y')
             for block in blockReplicasInfo:
-                nodes = set(blockReplicasInfo[block]) - node_filter
                 try:
-                    blockDict[block]['PhEDExNodeNames'] = list(nodes)
-                    blockDict[block]['FileList'] = sorted(blockDict[block]['FileList'])
+                    blockDict[block]['PhEDExNodeNames'] = list(blockReplicasInfo[block])
                 except KeyError:
                     logging.warning("Block '%s' does not have any complete PhEDEx replica", block)
 

--- a/src/python/WMCore/WorkQueue/Policy/Start/Block.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Block.py
@@ -7,6 +7,7 @@ from __future__ import print_function, division
 
 import logging
 from math import ceil
+
 from WMCore.WorkQueue.Policy.Start.StartPolicyInterface import StartPolicyInterface
 from WMCore.WorkQueue.WorkQueueExceptions import WorkQueueWMSpecError
 from WMCore.WorkQueue.WorkQueueUtils import makeLocationsList
@@ -38,11 +39,13 @@ class Block(StartPolicyInterface):
             # TODO this is slow process needs to change in DBS3
             if self.initialTask.parentProcessingFlag():
                 parentFlag = True
-                for dbsBlock in dbs.listBlockParents(block["block"]):
+                parentBlocks = dbs.listBlockParents(block["block"])
+                for blockName in parentBlocks:
                     if self.initialTask.getTrustSitelists().get('trustlists'):
-                        parentList[dbsBlock["Name"]] = self.sites
+                        parentList[blockName] = self.sites
                     else:
-                        parentList[dbsBlock["Name"]] = self.cric.PNNstoPSNs(dbsBlock['PhEDExNodeList'])
+                        blockLocations = self.blockLocationRucioPhedex(blockName)
+                        parentList[blockName] = self.cric.PNNstoPSNs(blockLocations)
 
             # there could be 0 event files in that case we can't estimate the number of jobs created.
             # We set Jobs to 1 for that case.
@@ -189,7 +192,8 @@ class Block(StartPolicyInterface):
             if task.getTrustSitelists().get('trustlists'):
                 self.data[block['block']] = self.sites
             else:
-                self.data[block['block']] = self.cric.PNNstoPSNs(dbs.listFileBlockLocation(block['block']))
+                blockLocations = self.blockLocationRucioPhedex(block['block'])
+                self.data[block['block']] = self.cric.PNNstoPSNs(blockLocations)
 
             # TODO: need to decide what to do when location is no find.
             # There could be case for network problem (no connection to dbs, phedex)

--- a/src/python/WMCore/WorkQueue/Policy/Start/Dataset.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Dataset.py
@@ -166,11 +166,11 @@ class Dataset(StartPolicyInterface):
                 blockSummary['NumberOfRuns'] = runs
 
             validBlocks.append(blockSummary)
-
+            blockLocation = set(self.blockLocationRucioPhedex(blockName))
             if locations is None:
-                locations = set(dbs.listFileBlockLocation(blockName))
+                locations = blockLocation
             else:
-                locations = locations.intersection(dbs.listFileBlockLocation(blockName))
+                locations = locations.intersection(blockLocation)
 
         # all needed blocks present at these sites
         if task.getTrustSitelists().get('trustlists'):

--- a/src/python/WMCore/WorkQueue/WorkQueueUtils.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueUtils.py
@@ -89,7 +89,6 @@ def queueConfigFromConfigObject(config):
         wqManager.queueParams = {}
     qConfig = wqManager.queueParams
 
-    qConfig['rucioAccount'] = getattr(config.General, "rucioAccount", "")
     if hasattr(wqManager, 'couchurl'):
         qConfig['CouchUrl'] = wqManager.couchurl
     if hasattr(wqManager, 'dbname'):


### PR DESCRIPTION
Fixes #9964

#### Status
not-tested

#### Description
Hard backport of (cherrypick would not work for most of those, so I fetched the master version for most of them):
* Rucio wrapper API to find where data is locked and available #9889 
* Decouple PhEDEx from the DBS3Reader wrapper module #9927 
* Fix Rucio data location method; support dropping Tape RSEs #9936 
* Construct the PU location via rucio considering MSTransferor locks #9930 
* Support caching of RSE expressions in the Rucio wrapper #9892

such that local workqueue is able to resolve data location in the current (1.3.6) agents up&running in production.
In addition to that, update the PileupFetcher such that pileup data location can also be resolved through Rucio.

#### Is it backward compatible (if not, which system it affects?)
no

#### Related PRs
Already mentioned above

#### External dependencies / deployment changes
none
