### PR TITLE
Bump deployment example to 1.4.1.patch1

### DIFF
--- a/deploy/deploy-wmagent.sh
+++ b/deploy/deploy-wmagent.sh
@@ -25,8 +25,8 @@
 ### Usage:               -c <central_services> Url to central services hosting central couchdb (e.g. alancc7-cloud1.cern.ch)
 ### Usage:
 ### Usage: deploy-wmagent.sh -w <wma_version> -d <deployment_tag> -t <team_name> [-s <scram_arch>] [-r <repository>] [-n <agent_number>] [-c <central_services_url>]
-### Usage: Example: sh deploy-wmagent.sh -w 1.3.6.patch1 -d HG2007h -t production -n 30
-### Usage: Example: sh deploy-wmagent.sh -w 1.3.7.pre1 -d HG2007h -t testbed-vocms001 -p "9643" -r comp=comp.amaltaro -c cmsweb-testbed.cern.ch
+### Usage: Example: sh deploy-wmagent.sh -w 1.4.1.patch1 -d HG2010h -t production -n 30
+### Usage: Example: sh deploy-wmagent.sh -w 1.4.1.patch1 -d HG2010h -t testbed-vocms001 -p "9963 9959" -r comp=comp.amaltaro -c cmsweb-testbed.cern.ch
 ### Usage:
 
 IAM=`whoami`


### PR DESCRIPTION
No issue created

#### Status
ready

#### Description
Bump the deployment command line example to use the latest WMAgent production release with the correct CMSWEB tag.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
