### PR TITLE
[py2py3] Migrate WMCore/WMFactory

### DIFF
--- a/src/python/WMCore/WMFactory.py
+++ b/src/python/WMCore/WMFactory.py
@@ -6,6 +6,7 @@ caches them (or not). It is a generalized factory object. If needed this class
 can be made threadsafe.
 """
 
+from builtins import object
 import threading
 
 


### PR DESCRIPTION
Fixes #9970

#### Status
not-tested

#### Description
Run futurize on WMCore/WMFactory

#### Is it backward compatible (if not, which system it affects?)
It should be. However, any bug would affect directly

```
'WMComponent_TaskArchiver',
'WMComponent_RetryManager',
'WMCore_ThreadPool',
'WMCore_BossAir',
'WMCore_JobSplitting',
'WMCore_WMInit',
'WMCore_WebTools',
'WMComponent_DBS3Buffer',
'WMCore_ProcessPool',
'WMCore_WorkQueue',
'WMCore_ReqMgr',
'WMCore_WMSpec',
'WMCore_Storage',
'WMComponent_AnalyticsDataCollector',
'WMCore_WMRuntime'
```

#### External dependencies / deployment changes
requires python-future
