### PR TITLE
Add getTransferInfo to MSOutput and info request to MSManager.

### DIFF
--- a/src/python/WMCore/MicroService/Unified/MSManager.py
+++ b/src/python/WMCore/MicroService/Unified/MSManager.py
@@ -231,6 +231,8 @@ class MSManager(object):
                 transferDoc = self.msMonitor.reqmgrAux.getTransferInfo(reqName)
             elif 'transferor' in self.services:
                 transferDoc = self.msTransferor.reqmgrAux.getTransferInfo(reqName)
+            elif 'output' in self.services:
+                transferDoc = self.msOutputProducer.getTransferInfo(reqName)
             if transferDoc:
                 # it's always a single document in Couch
                 data['transferDoc'] = transferDoc[0]

--- a/src/python/WMCore/MicroService/Unified/MSOutput.py
+++ b/src/python/WMCore/MicroService/Unified/MSOutput.py
@@ -1018,7 +1018,31 @@ class MSOutput(MSCore):
                 self.logger.exception(msg)
                 raise ex
         else:
-            self.logger.info("Query: '%s' did not return any records from MongoDB", mQueryDict)
+            self.logger.info("%s Query: '%s' did not return any records from MongoDB", dbColl.name, mQueryDict)
+
+    def getTransferInfo(self, reqName):
+        """
+        Searches and reads a document from MongoDB in all collections related to
+        the MSOutput service. It is supposed to be called only by MSManager e.g.:
+           transferDoc = self.msOutputProducer.getTransferInfo(reqName)
+        And the output to be served to the REST interface, so that all request
+        transfer records can be tracked.
+        :param reqName: The name of the request to be searched for
+        :return: a list of all msOutDocs with the record if it exists or None otherwise
+        """
+
+        mQueryDict = {'RequestName': reqName}
+        result = []
+        stripKeys = ['_id']
+
+        for dbColl in [self.msOutNonRelValColl, self.msOutRelValColl]:
+            doc = dbColl.find_one(mQueryDict)
+            if doc:
+                for key in stripKeys:
+                    doc.pop(key, None)
+                result.append(doc)
+                break
+        return result
 
     def docCleaner(self, doc):
         """


### PR DESCRIPTION
Fixes #9613 

#### Status
ready

#### Description
Provides the function `getTransferInfo`, which searches and reads a document from MongoDB in all collections related to MSOUtput Service. It is called only from MSManager in order to serve the `info?request=...` API for the service.  In this way the full information recorded into MongoDB related to a request is provided and so that all request transfer records can be tracked.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
N/A

#### External dependencies / deployment changes
N/A