### PR TITLE
Disable PhEDExInjector; Enable all tiers to be injected in Rucio

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -162,7 +162,7 @@ config.PhEDExInjector.namespace = "WMComponent.PhEDExInjector.PhEDExInjector"
 config.PhEDExInjector.componentDir = config.General.workDir + "/PhEDExInjector"
 config.PhEDExInjector.logLevel = globalLogLevel
 config.PhEDExInjector.maxThreads = 1
-config.PhEDExInjector.enabled = True
+config.PhEDExInjector.enabled = False
 config.PhEDExInjector.subscribeDatasets = True
 config.PhEDExInjector.safeMode = False
 # phedex address "https://cmsweb.cern.ch/phedex/datasvc/json/prod/"
@@ -371,7 +371,7 @@ config.RucioInjector.cacheExpiration = 2 * 24 * 60 * 60  # two days
 config.RucioInjector.createBlockRules = True
 config.RucioInjector.RSEPostfix = False  # enable it to append _Test to the RSE names
 config.RucioInjector.metaDIDProject = "Production"
-config.RucioInjector.listTiersToInject = ["NANOAOD", "NANOAODSIM"]  # []
+config.RucioInjector.listTiersToInject = []  # ["NANOAOD", "NANOAODSIM"]
 config.RucioInjector.skipRulesForTiers = ["NANOAOD", "NANOAODSIM"]
 config.RucioInjector.rucioAccount = "OVER_WRITE_BY_SECRETS"
 config.RucioInjector.rucioUrl = "OVER_WRITE_BY_SECRETS"


### PR DESCRIPTION
No issue created

#### Status
ready

#### Description
This changes the default Data Management system for output data, allowing all the datatiers to be injected into Rucio; at same time completely disabling PhEDExInjector (component still running, but not taking any actions).

Note that this configuration remains:
```
config.RucioInjector.skipRulesForTiers = ["NANOAOD", "NANOAODSIM"]
```
meaning, the agent is not allowed to create container-level rules - if specified in the workflow - for those 2 datatiers.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none