### PR TITLE
Increase polling cycle for WorkQueueManagerLocationPoller to 1h

### DIFF
--- a/src/python/WMComponent/WorkQueueManager/WorkQueueManager.py
+++ b/src/python/WMComponent/WorkQueueManager/WorkQueueManager.py
@@ -5,17 +5,17 @@ WorkQueuemanager component
 Runs periodic tasks for WorkQueue
 """
 from __future__ import print_function
+
 import threading
 
-from WMCore.Agent.Harness import Harness
-
-from WMComponent.WorkQueueManager.WorkQueueManagerWorkPoller import WorkQueueManagerWorkPoller
-from WMComponent.WorkQueueManager.WorkQueueManagerReqMgrPoller import WorkQueueManagerReqMgrPoller
-from WMComponent.WorkQueueManager.WorkQueueManagerLocationPoller import WorkQueueManagerLocationPoller
 from WMComponent.WorkQueueManager.WorkQueueManagerCleaner import WorkQueueManagerCleaner
+from WMComponent.WorkQueueManager.WorkQueueManagerLocationPoller import WorkQueueManagerLocationPoller
+from WMComponent.WorkQueueManager.WorkQueueManagerReqMgrPoller import WorkQueueManagerReqMgrPoller
 from WMComponent.WorkQueueManager.WorkQueueManagerWMBSFileFeeder import WorkQueueManagerWMBSFileFeeder
-
+from WMComponent.WorkQueueManager.WorkQueueManagerWorkPoller import WorkQueueManagerWorkPoller
+from WMCore.Agent.Harness import Harness
 from WMCore.WorkQueue.WorkQueueUtils import queueFromConfig, queueConfigFromConfigObject
+
 
 class WorkQueueManager(Harness):
     """WorkQueuemanager component
@@ -27,7 +27,6 @@ class WorkQueueManager(Harness):
         # call the base class
         Harness.__init__(self, config)
         self.config = queueConfigFromConfigObject(config)
-
 
     def preInitialization(self):
         print("WorkQueueManager.preInitialization")
@@ -42,40 +41,40 @@ class WorkQueueManager(Harness):
 
             # Get work from ReqMgr, report back & delete finished requests
             myThread.workerThreadManager.addWorker(
-                                WorkQueueManagerReqMgrPoller(
-                                        queueFromConfig(self.config),
-                                        getattr(self.config.WorkQueueManager,
-                                                'reqMgrConfig', {})
-                                        ),
-                                 pollInterval)
+                    WorkQueueManagerReqMgrPoller(
+                            queueFromConfig(self.config),
+                            getattr(self.config.WorkQueueManager,
+                                    'reqMgrConfig', {})
+                    ),
+                    pollInterval)
 
         ### local queue special function
         elif self.config.WorkQueueManager.level == 'LocalQueue':
 
             # pull work from parent queue
             myThread.workerThreadManager.addWorker(
-                                WorkQueueManagerWorkPoller(queueFromConfig(self.config),
-                                                           self.config),
-                                pollInterval)
+                    WorkQueueManagerWorkPoller(queueFromConfig(self.config),
+                                               self.config),
+                    pollInterval)
 
             # inject acquired work into wmbs
             myThread.workerThreadManager.addWorker(
-                                WorkQueueManagerWMBSFileFeeder(queueFromConfig(self.config),
-                                                               self.config),
-                                pollInterval)
+                    WorkQueueManagerWMBSFileFeeder(queueFromConfig(self.config),
+                                                   self.config),
+                    pollInterval)
 
         ### general functions
 
         # Data location updates
         myThread.workerThreadManager.addWorker(
-                                    WorkQueueManagerLocationPoller(queueFromConfig(self.config),
-                                                                   self.config),
-                                    dataLocationInterval)
+                WorkQueueManagerLocationPoller(queueFromConfig(self.config),
+                                               self.config),
+                dataLocationInterval)
 
         # Clean finished work & apply end policies
         myThread.workerThreadManager.addWorker(
-                                WorkQueueManagerCleaner(queueFromConfig(self.config),
-                                                        self.config),
-                                pollInterval)
+                WorkQueueManagerCleaner(queueFromConfig(self.config),
+                                        self.config),
+                pollInterval)
 
         return

--- a/src/python/WMComponent/WorkQueueManager/WorkQueueManager.py
+++ b/src/python/WMComponent/WorkQueueManager/WorkQueueManager.py
@@ -35,6 +35,7 @@ class WorkQueueManager(Harness):
         # Add event loop to worker manager
         myThread = threading.currentThread()
         pollInterval = self.config.WorkQueueManager.pollInterval
+        dataLocationInterval = getattr(self.config.WorkQueueManager, "dataLocationInterval", 1 * 60 * 60)
 
         ### Global queue special functions
         if self.config.WorkQueueManager.level == 'GlobalQueue':
@@ -69,7 +70,7 @@ class WorkQueueManager(Harness):
         myThread.workerThreadManager.addWorker(
                                     WorkQueueManagerLocationPoller(queueFromConfig(self.config),
                                                                    self.config),
-                                    pollInterval)
+                                    dataLocationInterval)
 
         # Clean finished work & apply end policies
         myThread.workerThreadManager.addWorker(


### PR DESCRIPTION
Fixes #9979 

#### Status
ready

#### Description
Make a new component configuration attribute `dataLocationInterval` to set a different polling cycle for the `WorkQueueManagerLocationPoller` thread, changing it from 3min to 1h.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none