### PR TITLE
Skip Tape (too) data placement for Resubmission workflows

### DIFF
--- a/src/python/WMCore/MicroService/Unified/MSOutput.py
+++ b/src/python/WMCore/MicroService/Unified/MSOutput.py
@@ -915,6 +915,9 @@ class MSOutput(MSCore):
         # it - for the moment - at least.
         if workflow['IsRelVal'] and not self.msConfig['enableRelValCustodial']:
             return False
+        if workflow['RequestType'] == "Resubmission":
+            # their parent/original workflow will take care of all the data placement
+            return False
 
         if dataItem['TapeRuleID']:
             msg = "Output dataset: {} from workflow: {} ".format(dataItem['Dataset'], workflow['RequestName'])


### PR DESCRIPTION
Fixes #9982

#### Status
ready

#### Description
Tape data placement does not depend on the mongodb record `Copies`, that's why we could be making multiple tape data placements for some datasets (those produced by ACDC workflows).
This fix will make sure that, in addition to skipping Disk data placement, Tape will also be skipped for `Resubmission` workflows.
 
#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none