### PR TITLE
Skip Custodial and make generic Disk NonCustodial data placement in RucioInjector

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -373,6 +373,8 @@ config.RucioInjector.RSEPostfix = False  # enable it to append _Test to the RSE 
 config.RucioInjector.metaDIDProject = "Production"
 config.RucioInjector.listTiersToInject = []  # ["NANOAOD", "NANOAODSIM"]
 config.RucioInjector.skipRulesForTiers = []  # ["NANOAOD", "NANOAODSIM"]
+config.RucioInjector.containerDiskRuleParams = {"weight": "ddm_quota", "copies": 2, "grouping": "DATASET"}
+config.RucioInjector.containerDiskRuleRSEExpr = "(tier=2|tier=1)&cms_type=real&rse_type=DISK"
 config.RucioInjector.rucioAccount = "OVER_WRITE_BY_SECRETS"
 config.RucioInjector.rucioUrl = "OVER_WRITE_BY_SECRETS"
 config.RucioInjector.rucioAuthUrl = "OVER_WRITE_BY_SECRETS"


### PR DESCRIPTION
Fixes #9639 

#### Status
ready

#### Description
Summary of changes is:
* created two new RucioInjector component configuration parameters:
  * `containerDiskRuleParams`: additional parameters overriding the default container-level rule attributes, only for Disk data placement
  * `containerDiskRuleRSEExpr`: very generic RSE expression to be used for container-level Disk rules
* if it's a T0 agent, then proceed with standard output data placement; otherwise, proceed with central production data placement, which has the following peculiarities:
  * Custodial data placement is bypassed and the container is marked as subscribed in the relational database;
  * NonCustodial data placement overrides settings at the workflow spec, where destination is set to any T1+T2 real Disk endpoint;  number of copies is set to 2, with a grouping=DATASET, and a rule weight is added as well (with "ddm_quota" value).

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
To be merged after: https://github.com/dmwm/WMCore/pull/9988

#### External dependencies / deployment changes
None
