### PR TITLE
MSOutput: create Disk rules with an weight attr, default to ddm_quota

### DIFF
--- a/src/python/WMCore/MicroService/Unified/MSOutput.py
+++ b/src/python/WMCore/MicroService/Unified/MSOutput.py
@@ -91,6 +91,7 @@ class MSOutput(MSCore):
         self.msConfig.setdefault("excludeDataTier", [])
         self.msConfig.setdefault("rucioAccount", 'wmcore_transferor')
         self.msConfig.setdefault("rucioRSEAttribute", 'ddm_quota')
+        self.msConfig.setdefault("rucioDiskRuleWeight", 'ddm_quota')
         self.msConfig.setdefault("rucioTapeExpression", 'rse_type=TAPE\cms_type=test')
         self.msConfig.setdefault("mongoDBUrl", 'mongodb://localhost')
         self.msConfig.setdefault("mongoDBPort", 8230)
@@ -333,6 +334,9 @@ class MSOutput(MSCore):
                          'account': self.msConfig['rucioAccount'],
                          'grouping': "ALL",
                          'comment': 'WMCore MSOutput output data placement'}
+            # add a configurable weight value
+            ruleAttrs["weight"] = self.msConfig['rucioDiskRuleWeight']
+
             # if anything fail along the way, set it back to "pending"
             transferStatus = "done"
             for dMap in workflow['OutputMap']:


### PR DESCRIPTION
Fixes #9987 

#### Status
ready

#### Description
Two changes:
* added a new MicroService MSOutput configuration parameter: `rucioDiskRuleWeight`, which defaults to `ddm_quota`
* when creating Disk rules, add this key/value pair to the rule configuration.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
Deployment changes: https://github.com/dmwm/deployment/pull/965
