### PR TITLE
Fix JobAccountant missing parent dbsbuffer file

### DIFF
--- a/src/python/WMComponent/JobAccountant/AccountantWorker.py
+++ b/src/python/WMComponent/JobAccountant/AccountantWorker.py
@@ -379,11 +379,12 @@ class AccountantWorker(WMConnectionBase):
                                                        conn=self.getDBConn(),
                                                        transaction=self.existingTransaction())
         newParents = set()
+        logging.debug("Found %d potential parents for lfn: %s", len(parentsInfo), lfn)
         for parentInfo in parentsInfo:
             # This will catch straight to merge files that do not have redneck
             # parents.  We will mark the straight to merge file from the job
             # as a child of the merged parent.
-            if int(parentInfo["merged"]) == 1:
+            if int(parentInfo["merged"]) == 1 and not parentInfo["lfn"].startswith("/store/unmerged/"):
                 newParents.add(parentInfo["lfn"])
 
             elif parentInfo['gpmerged'] is None:
@@ -393,7 +394,7 @@ class AccountantWorker(WMConnectionBase):
             # children.  We have to setup parentage and then check on whether or
             # not this file has any redneck children and update their parentage
             # information.
-            elif int(parentInfo["gpmerged"]) == 1:
+            elif int(parentInfo["gpmerged"]) == 1 and not parentInfo["gplfn"].startswith("/store/unmerged/"):
                 newParents.add(parentInfo["gplfn"])
 
             # If that didn't work, we've reached the great-grandparents
@@ -906,8 +907,7 @@ class AccountantWorker(WMConnectionBase):
 
         # Now all the parents should exist
         # Commit them to DBSBuffer
-        logging.info("About to commit all DBSBuffer Heritage information")
-        logging.info(len(bindList))
+        logging.info("About to commit DBSBuffer heritage information for: %d binds", len(bindList))
 
         if bindList:
             try:

--- a/src/python/WMCore/WMBS/MySQL/Jobs/LoadForErrorHandler.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/LoadForErrorHandler.py
@@ -38,7 +38,7 @@ class LoadForErrorHandler(DBFormatter):
     parentSQL = """SELECT parent.lfn AS lfn, wfp.child AS id
                      FROM wmbs_file_parent wfp
                      INNER JOIN wmbs_file_details parent ON parent.id = wfp.parent
-                     WHERE wfp.child = :fileid """
+                     WHERE wfp.child = :fileid AND parent.merged = 1"""
 
     runLumiSQL = """SELECT fileid, run, lumi, num_events FROM wmbs_file_runlumi_map
                      WHERE fileid = :fileid"""
@@ -52,6 +52,9 @@ class LoadForErrorHandler(DBFormatter):
         Fetch run/lumi/events information for each file and append Run objects
         to the files information.
         """
+        if not fileBinds:
+            return
+
         lumiResult = self.dbi.processData(self.runLumiSQL, fileBinds, conn=conn,
                                           transaction=transaction)
         lumiList = self.formatDict(lumiResult)
@@ -80,8 +83,7 @@ class LoadForErrorHandler(DBFormatter):
                 f['newRuns'].append(newRun)
         return
 
-    def execute(self, jobID, fileSelection=None,
-                conn=None, transaction=False):
+    def execute(self, jobID, fileSelection=None, conn=None, transaction=False):
         """
         _execute_
 
@@ -101,31 +103,31 @@ class LoadForErrorHandler(DBFormatter):
         result = self.dbi.processData(self.sql, binds, conn=conn,
                                       transaction=transaction)
         jobList = self.formatDict(result)
-        for entry in jobList:
-            entry.setdefault('input_files', [])
 
         filesResult = self.dbi.processData(self.fileSQL, binds, conn=conn,
                                            transaction=transaction)
         fileList = self.formatDict(filesResult)
 
-        noDuplicateFiles = {}
-        fileBinds = []
+        # special case for skipped files
         if fileSelection:
             fileList = [x for x in fileList if x['lfn'] in fileSelection[x['jobid']]]
+
+        noDuplicateFiles = {}
+        fileBinds = []
         for x in fileList:
             # Assemble unique list of binds
             if {'fileid': x['id']} not in fileBinds:
                 fileBinds.append({'fileid': x['id']})
                 noDuplicateFiles[x['id']] = x
 
+        # only upload to not duplicate files to prevent excessive memory
+        self.getRunLumis(fileBinds, noDuplicateFiles.values(), conn, transaction)
+
         parentList = []
-        if len(fileBinds) > 0:
+        if fileBinds:
             parentResult = self.dbi.processData(self.parentSQL, fileBinds, conn=conn,
                                                 transaction=transaction)
             parentList = self.formatDict(parentResult)
-
-            # only upload to not duplicate files to prevent excessive memory
-            self.getRunLumis(fileBinds, noDuplicateFiles.values(), conn, transaction)
 
         filesForJobs = {}
         for f in fileList:
@@ -145,12 +147,14 @@ class LoadForErrorHandler(DBFormatter):
                     if entry['id'] == f['id']:
                         wmbsFile['parents'].add(entry['lfn'])
                 wmbsFile.pop('pnn', None)  # not needed for anything, just remove it
+                wmbsFile.pop('newlocations', None)  # not needed for anything, just remove it
                 filesForJobs[jobid][f['id']] = wmbsFile
             elif f['pnn']:
                 # If the file is there and it has a location, just add it
                 filesForJobs[jobid][f['id']]['locations'].add(f['pnn'])
 
         for j in jobList:
+            j.setdefault('input_files', [])
             if j['id'] in filesForJobs.keys():
                 j['input_files'] = filesForJobs[j['id']].values()
 

--- a/src/python/WMCore/WMBS/Oracle/Jobs/LoadForErrorHandler.py
+++ b/src/python/WMCore/WMBS/Oracle/Jobs/LoadForErrorHandler.py
@@ -19,3 +19,8 @@ class LoadForErrorHandler(MySQLLoadForErrorHandler):
                    LEFT OUTER JOIN wmbs_file_location wfl ON wfd.id = wfl.fileid
                    LEFT OUTER JOIN wmbs_pnns wpnn ON wpnn.id = wfl.pnn
                  WHERE wja.job = :jobid"""
+
+    parentSQL = """SELECT parent.lfn AS lfn, wfp.child AS id
+                     FROM wmbs_file_parent wfp
+                     INNER JOIN wmbs_file_details parent ON parent.id = wfp.parent
+                     WHERE wfp.child = :fileid AND parent.merged = '1'"""


### PR DESCRIPTION
Fixes #9456 

#### Status
In development

#### Description
From the GH issue, there are cases where an ACDC collection has the incorrect information regarding the parent files.
This PR provides two level of protection (still missing the root cause though, likely on the ErrorHandler component):
* when inserting files into WMBS (from the ACDC collection), go through all the files listed in the `parents` parameter, and only add those that will be actually referenced as a parent
* when searching for parent files in JobAccountant, in addition to checking the `merged` flag, also check the lfn name

UPDATE:
Second commit will ensure that we only provide parent files that have been merged (thus, only parent files that are needed in the execution of the ACDC workflow, to track the output parentage).

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
