### PR TITLE
If listDataRules API fail, raise a WMRucioException

### DIFF
--- a/src/python/WMCore/Services/Rucio/Rucio.py
+++ b/src/python/WMCore/Services/Rucio/Rucio.py
@@ -607,12 +607,13 @@ class Rucio(object):
         """
         kwargs["name"] = name
         kwargs.setdefault("scope", "cms")
-        res = []
         try:
             res = self.cli.list_replication_rules(kwargs)
-        except Exception as ex:
-            self.logger.error("Exception listing rules for data: %s and kwargs: %s. Error: %s",
-                              name, kwargs, str(ex))
+        except Exception as exc:
+            msg = "Exception listing rules for data: {} and kwargs: {}. Error: {}".format(name,
+                                                                                          kwargs,
+                                                                                          str(exc))
+            raise WMRucioException(msg)
         return list(res)
 
     def listDataRulesHistory(self, name, scope='cms'):


### PR DESCRIPTION
Fixes #9998

#### Status
not-tested

#### Description
It changes the behaviour of the `listDataRules` Rucio wrapper API, which used to always return a list type object. Now it can also raise a `WMRucioException` exception if the http request fails.

#### Is it backward compatible (if not, which system it affects?)
Yes, in general

#### Related PRs
none

#### External dependencies / deployment changes
none
