### PR TITLE
Add CMSMonitoring dependency for ReqMgr2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,6 @@ retry==0.9.1                  # wmagent,reqmgr2
 setuptools==39.2.0            # wmagent
 stomp.py==4.1.15              # wmagent
 rucio-clients==1.23.0         # wmagent
-CMSMonitoring>=0.3.4          # wmagent
+CMSMonitoring>=0.3.4          # wmagent,reqmgr2
 pymongo==3.10.1               # reqmgr2ms
 


### PR DESCRIPTION
Fixes #10001 

#### Status
Ready

#### Description
Add CMSMonitoring dependency for ReqMgr2 

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
#9874 

#### External dependencies / deployment changes
NA
