### PR TITLE
Bump deployment example to patch3 and a new cmsweb tag

### DIFF
--- a/deploy/deploy-wmagent.sh
+++ b/deploy/deploy-wmagent.sh
@@ -25,8 +25,8 @@
 ### Usage:               -c <central_services> Url to central services hosting central couchdb (e.g. alancc7-cloud1.cern.ch)
 ### Usage:
 ### Usage: deploy-wmagent.sh -w <wma_version> -d <deployment_tag> -t <team_name> [-s <scram_arch>] [-r <repository>] [-n <agent_number>] [-c <central_services_url>]
-### Usage: Example: sh deploy-wmagent.sh -w 1.4.1.patch1 -d HG2010h -t production -n 30
-### Usage: Example: sh deploy-wmagent.sh -w 1.4.1.patch1 -d HG2010h -t testbed-vocms001 -p "9963 9959" -r comp=comp.amaltaro -c cmsweb-testbed.cern.ch
+### Usage: Example: sh deploy-wmagent.sh -w 1.4.1.patch3 -d HG2011a -t production -n 30
+### Usage: Example: sh deploy-wmagent.sh -w 1.4.1.patch3 -d HG2011a -t testbed-vocms001 -p "9963 9959" -r comp=comp.amaltaro -c cmsweb-testbed.cern.ch
 ### Usage:
 
 IAM=`whoami`


### PR DESCRIPTION
No issue created

#### Status
ready

#### Description
Just updating the latest stable WMAgent release and which CMSWEB deployment tag **must** be used.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none