### PR TITLE
[py2py3] Migrate WMCore/Credential

### DIFF
--- a/src/python/WMCore/Credential/Credential.py
+++ b/src/python/WMCore/Credential/Credential.py
@@ -4,7 +4,8 @@ _Credential_
 Parent of all credentials class.
 Childs class should implement methods of this class.
 """
-class Credential:
+from builtins import object
+class Credential(object):
     """
     An abstract credential
     """

--- a/src/python/WMCore/Credential/Proxy.py
+++ b/src/python/WMCore/Credential/Proxy.py
@@ -4,6 +4,9 @@ _Proxy_
 Wrap gLite proxy commands.
 """
 
+from __future__ import division
+from builtins import filter, str, range
+
 import contextlib
 import copy
 import os
@@ -64,7 +67,7 @@ def destroyListCred(credNameList=None, credTimeleftList=None, logger=None, timeo
     credTimeleftList = credTimeleftList or {}
     cleanCredCmdList = []
 
-    for credIdx in xrange(len(credNameList)):
+    for credIdx in range(len(credNameList)):
         hours, minutes, seconds = credTimeleftList[credIdx]
         timeleft = int(hours) * 3600 + int(minutes) * 60 + int(seconds)
         if timeleft == 0:
@@ -229,7 +232,7 @@ class Proxy(Credential):
         Uses openssl by default and fallback to voms-proxy-info in case of problems
         """
         timeleft = self.getUserCertTimeLeft(openSSL)
-        daystoexp = int(timeleft / (60. * 60 * 24))
+        daystoexp = int(timeleft // (60. * 60 * 24))
 
         return daystoexp
 
@@ -682,7 +685,7 @@ class Proxy(Credential):
 
         vomsValid = '00:00'
         if vomsTime > 0:
-            vomsValid = "%d:%02d" % (vomsTime / 3600, (vomsTime - (vomsTime / 3600) * 3600) / 60)
+            vomsValid = "%d:%02d" % (int(vomsTime // 3600), int((vomsTime % 3600) // 60))
         self.logger.debug('Requested voms validity: %s' % vomsValid)
 
         ## set environ and add voms extensions

--- a/src/python/WMCore/Credential/SimpleMyProxy.py
+++ b/src/python/WMCore/Credential/SimpleMyProxy.py
@@ -12,6 +12,7 @@
 # Mattia Cinquilli <mcinquil@cern.ch>
 # on 2013/04/14 for integration on CRAB services.
 
+from builtins import str
 import logging
 import re
 import socket

--- a/src/python/WMCore/Credential/SimpleMyProxy.py
+++ b/src/python/WMCore/Credential/SimpleMyProxy.py
@@ -280,5 +280,5 @@ if __name__ == '__main__':
             import traceback
 
             traceback.print_exc()
-        logger.error("Error:" + str(e))
+        logger.error("Error: %s", str(e))
         sys.exit(1)

--- a/test/python/WMCore_t/Credential_t/MyProxy_t.py
+++ b/test/python/WMCore_t/Credential_t/MyProxy_t.py
@@ -5,6 +5,7 @@ Test the basic MyProxy operations.
 You need to source your UI before running these tests.
 The user Proxy and MyProxy is initialized in testCreateMyProxy method and they are used by the remaining tests.
 """
+from __future__ import division
 
 import unittest
 import os
@@ -91,7 +92,7 @@ class MyProxyTest(unittest.TestCase):
         self.proxy.renewMyProxy( proxy = self.proxyPath )
         time.sleep( 5 )
         timeLeft = self.proxy.getMyProxyTimeLeft( proxy = self.proxyPath )
-        self.assertEqual(int(timeLeft) / 3600, 167)
+        self.assertEqual(int(int(timeLeft) // 3600), 167)
 
     @attr("integration")
     def testRenewMyProxyForServer( self ):
@@ -102,7 +103,7 @@ class MyProxyTest(unittest.TestCase):
         self.proxy.renewMyProxy( proxy = self.proxyPath, serverRenewer = True )
         time.sleep( 5 )
         timeLeft = self.proxy.getMyProxyTimeLeft( proxy = self.proxyPath, serverRenewer = True )
-        self.assertEqual(int(timeLeft) / 3600, 167)
+        self.assertEqual(int(int(timeLeft) // 3600), 167)
 
     @attr("integration")
     def testMyProxyEnvironment(self):

--- a/test/python/WMCore_t/Credential_t/MyProxy_t.py
+++ b/test/python/WMCore_t/Credential_t/MyProxy_t.py
@@ -11,10 +11,7 @@ import unittest
 import os
 import logging
 import logging.config
-import socket
 import time
-import tempfile
-import subprocess
 
 from nose.plugins.attrib import attr
 from WMCore.Credential.Proxy import Proxy, myProxyEnvironment

--- a/test/python/WMCore_t/Credential_t/Proxy_t.py
+++ b/test/python/WMCore_t/Credential_t/Proxy_t.py
@@ -13,9 +13,7 @@ import unittest
 import os
 import logging
 import logging.config
-import socket
 import time
-import tempfile
 import subprocess
 
 from nose.plugins.attrib import attr
@@ -68,7 +66,7 @@ class ProxyTest(unittest.TestCase):
         if vomsProxyInfoCall.wait() != 0:
             return None
 
-        (stdout, stderr) = vomsProxyInfoCall.communicate()
+        stdout, _ = vomsProxyInfoCall.communicate()
         return stdout[0:-1]
 
     def getUserAttributes(self):
@@ -82,7 +80,7 @@ class ProxyTest(unittest.TestCase):
         if vomsProxyInfoCall.wait() != 0:
             return None
 
-        (stdout, stderr) = vomsProxyInfoCall.communicate()
+        stdout, _ = vomsProxyInfoCall.communicate()
         return stdout[0:-1]
 
     @attr("integration")

--- a/test/python/WMCore_t/Credential_t/Proxy_t.py
+++ b/test/python/WMCore_t/Credential_t/Proxy_t.py
@@ -6,7 +6,9 @@ You need to source your UI before running these tests.
 Your proxy is initialized in testAAACreateProxy method and it is used by the remaining tests.
 """
 from __future__ import print_function
+from __future__ import division
 
+from past.utils import old_div
 import unittest
 import os
 import logging
@@ -111,7 +113,7 @@ class ProxyTest(unittest.TestCase):
         Test if getTimeLeft method returns correctly the proxy time left.
         """
         timeLeft = self.proxy.getTimeLeft()
-        self.assertEqual(int(timeLeft) / 3600, 191)
+        self.assertEqual(int(int(timeLeft) // 3600), 191)
 
     @attr("integration")
     def testRenewProxy( self ):
@@ -122,7 +124,7 @@ class ProxyTest(unittest.TestCase):
         self.proxy.renew()
         time.sleep( 10 )
         timeLeft = self.proxy.getTimeLeft()
-        self.assertEqual(int(timeLeft) / 3600, 191)
+        self.assertEqual(int(int(timeLeft) // 3600), 191)
 
     @attr("integration")
     def testDestroyProxy(self ):
@@ -185,7 +187,7 @@ class ProxyTest(unittest.TestCase):
         attribute = self.proxy.prepareAttForVomsRenewal( self.proxy.getAttributeFromProxy( proxyPath ) )
         self.proxy.vomsExtensionRenewal( proxyPath, attribute )
         vomsTimeLeft = self.proxy.getVomsLife( proxyPath )
-        self.assertEqual(int(vomsTimeLeft) / 3600, 191)
+        self.assertEqual(int(int(vomsTimeLeft) // 3600), 191)
 
     @attr("integration")
     def testElevateAttribute( self ):


### PR DESCRIPTION
Fixes #10007 

#### Status

- src: ready
- test: ready

#### Description

Run futurize and then apply manual changes to WMCore/Credential

Summary

- Division: keep an eye on `old_div`, it may be dropped in favor of `//`
  - src/python/WMCore/Credential/Proxy.py
  - test/python/WMCore_t/Credential_t/Proxy_t.py
  - test/python/WMCore_t/Credential_t/MyProxy_t.py

- str : `form builtins import str` is used extensivvely in this PR
  - src/python/WMCore/Credential/Proxy.py
  - src/python/WMCore/Credential/SimpleMyProxy.py

- list and iterators: using backported version of `filter` and `range`, as described in the [python future docs](http://python-future.org/compatible_idioms.html#lists-versus-iterators)
  - src/python/WMCore/Credential/Proxy.py


Missing
- grouping import from builtins

#### Is it backward compatible (if not, which system it affects?)

It should be. However, as obtained from the [direct dependency graph](https://cms-dmwm-test.docs.cern.ch/py2py3/data/wmcore_gznzsw1eblR_direct_group_l2.txt), any bug would affect directly

```
 'WMCore_Credential': ['WMCore_BossAir',
                       'WMCore_Credential',
                       'WMComponent_AgentStatusWatcher'],
```


#### External dependencies / deployment changes

This PR requires python-future
