### PR TITLE
[py2py3] WMCore/Algorithms - migration

### DIFF
--- a/src/python/WMCore/Algorithms/MathAlgos.py
+++ b/src/python/WMCore/Algorithms/MathAlgos.py
@@ -7,6 +7,8 @@ Simple mathematical tools and tricks that might prove to
 be useful.
 """
 from __future__ import print_function, division
+from builtins import str, range
+
 import math
 import decimal
 import logging

--- a/src/python/WMCore/Algorithms/MathAlgos.py
+++ b/src/python/WMCore/Algorithms/MathAlgos.py
@@ -53,7 +53,7 @@ def getAverageStdDev(numList):
             msg =  "Attempted to take average of non-numerical values.\n"
             msg += "Expected int or float, got %s: %s" % (value.__class__, value)
             logging.error(msg)
-            logging.debug("FullList: %s" % numList)
+            logging.debug("FullList: %s", numList)
             raise MathAlgoException(msg)
 
     length = len(numList) - skipped
@@ -138,15 +138,15 @@ def createHistogram(numList, nBins, limit):
                           'stdDev': 0.0,
                           'nEvents': 0})
 
-    for bin in histogram:
-        if bin['type'] != 'standard':
+    for bin_ in histogram:
+        if bin_['type'] != 'standard':
             continue
         binList = []
         for value in histEvents:
-            if value >= bin['lowerEdge'] and value <= bin['upperEdge']:
+            if value >= bin_['lowerEdge'] and value <= bin_['upperEdge']:
                 # Then we're in the bin
                 binList.append(value)
-            elif value > bin['upperEdge']:
+            elif value > bin_['upperEdge']:
                 # Because this is a sorted list we are now out of the bin range
                 # Calculate our values and break
                 break
@@ -160,9 +160,9 @@ def createHistogram(numList, nBins, limit):
             continue
 
         binAvg, binStdDev = getAverageStdDev(numList=binList)
-        bin['average'] = binAvg
-        bin['stdDev']  = binStdDev
-        bin['nEvents'] = len(binList)
+        bin_['average'] = binAvg
+        bin_['stdDev']  = binStdDev
+        bin_['nEvents'] = len(binList)
 
     return histogram
 

--- a/src/python/WMCore/Algorithms/MiscAlgos.py
+++ b/src/python/WMCore/Algorithms/MiscAlgos.py
@@ -21,7 +21,7 @@ def sortListByKey(data, key):
         if value == None:
             # Empty dict value?
             # This is an error, but we can't handle it here
-            logging.error("Found entry with no key in sortListByKey: %s" % entry)
+            logging.error("Found entry with no key in sortListByKey: %s", entry)
             logging.error("Skipping")
             continue
         if isinstance(value, set):
@@ -32,7 +32,7 @@ def sortListByKey(data, key):
             except KeyError:
                 # Set was empty?
                 # This is peculiar, we can't handle this.
-                logging.error("Found list entry with empty key set in sortListByKey: %s" % entry)
+                logging.error("Found list entry with empty key set in sortListByKey: %s", entry)
                 logging.error("Skipping")
                 continue
         if value not in final:

--- a/src/python/WMCore/Algorithms/MiscAlgos.py
+++ b/src/python/WMCore/Algorithms/MiscAlgos.py
@@ -35,7 +35,7 @@ def sortListByKey(data, key):
                 logging.error("Found list entry with empty key set in sortListByKey: %s" % entry)
                 logging.error("Skipping")
                 continue
-        if not value in final.keys():
+        if value not in final:
             final[value] = []
         final[value].append(entry)
 
@@ -54,13 +54,13 @@ def dict_diff(first, second):
     KEYNOTFOUND = '<KEYNOTFOUND>'
     diff = {}
     # Check all keys in first dict
-    for key in first.keys():
+    for key in first:
         if (key not in second):
             diff[key] = (first[key], KEYNOTFOUND)
         elif (first[key] != second[key]):
             diff[key] = (first[key], second[key])
     # Check all keys in second dict to find missing
-    for key in second.keys():
+    for key in second:
         if (key not in first):
             diff[key] = (KEYNOTFOUND, second[key])
     return diff

--- a/src/python/WMCore/Algorithms/ParseXMLFile.py
+++ b/src/python/WMCore/Algorithms/ParseXMLFile.py
@@ -11,13 +11,7 @@ Used for the expat xml parsers
 from builtins import next, str, object
 from future.utils import viewitems
 
-import os
-import re
 import xml.parsers.expat
-
-
-
-
 
 class Node(object):
     """

--- a/src/python/WMCore/Algorithms/ParseXMLFile.py
+++ b/src/python/WMCore/Algorithms/ParseXMLFile.py
@@ -8,6 +8,9 @@ Used for the expat xml parsers
 
 """
 
+from builtins import next, str, object
+from future.utils import viewitems
+
 import os
 import re
 import xml.parsers.expat
@@ -16,7 +19,7 @@ import xml.parsers.expat
 
 
 
-class Node:
+class Node(object):
     """
     _Node_
 
@@ -28,7 +31,8 @@ class Node:
         self.name = str(name)
         self.attrs = {}
         self.text = None
-        [ self.attrs.__setitem__(str(k), str(v)) for k,v in attrs.items()]
+        for k, v in viewitems(attrs):
+            self.attrs.__setitem__(str(k), str(v))
         self.children = []
 
     def __str__(self):

--- a/src/python/WMCore/Algorithms/Permissions.py
+++ b/src/python/WMCore/Algorithms/Permissions.py
@@ -17,11 +17,11 @@ def check_permissions(filehandle, permission, pass_stronger = False):
     else:
         assert filepermission == permission, "file does not have the correct permissions"
 
-def owner_readonly(file):
-    check_permissions(file, oct(0o400))
+def owner_readonly(file_):
+    check_permissions(file_, oct(0o400))
 
-def owner_readwrite(file):
-    check_permissions(file, oct(0o600))
+def owner_readwrite(file_):
+    check_permissions(file_, oct(0o600))
 
-def owner_readwriteexec(file):
-    check_permissions(file, oct(0o700))
+def owner_readwriteexec(file_):
+    check_permissions(file_, oct(0o700))

--- a/src/python/WMCore/Algorithms/Permissions.py
+++ b/src/python/WMCore/Algorithms/Permissions.py
@@ -5,6 +5,7 @@ be, or more restrictive.
 
 
 
+from builtins import oct
 import os
 import stat
 

--- a/src/python/WMCore/Algorithms/Singleton.py
+++ b/src/python/WMCore/Algorithms/Singleton.py
@@ -9,13 +9,14 @@ http://code.activestate.com/recipes/52558/
 
 
 
+from builtins import object
 class Singleton(object):
     """
     A python singleton
     """
 
 
-    class SingletonImplementation:
+    class SingletonImplementation(object):
         """
         Implementation of the singleton interface
         """

--- a/src/python/WMCore/Algorithms/SubprocessAlgos.py
+++ b/src/python/WMCore/Algorithms/SubprocessAlgos.py
@@ -72,16 +72,16 @@ def killProcessByName(name, user = os.getpid(), sig = None):
     return pids
 
 
-def tailNLinesFromFile(file, n):
+def tailNLinesFromFile(file_, n):
     """
     Loads the last N lines from a file
 
     """
 
-    if not os.path.isfile(file):
+    if not os.path.isfile(file_):
         return None
 
-    command = ['tail', '-n', str(n), file]
+    command = ['tail', '-n', str(n), file_]
 
     output = subprocess.Popen(command, stdout=subprocess.PIPE).communicate()[0]
 
@@ -102,7 +102,7 @@ def runCommand(cmd, shell = True, timeout = None):
     if timeout:
         if not isinstance(timeout, int):
             timeout = None
-            logging.error("SubprocessAlgo.runCommand expected int timeout, got %s" % timeout)
+            logging.error("SubprocessAlgo.runCommand expected int timeout, got %s", timeout)
         else:
             signal.signal(signal.SIGALRM, alarmHandler)
             signal.alarm(timeout)

--- a/src/python/WMCore/Algorithms/SubprocessAlgos.py
+++ b/src/python/WMCore/Algorithms/SubprocessAlgos.py
@@ -8,6 +8,7 @@ i.e., stand-ins for Linux command line functions
 
 """
 
+from builtins import str
 import os
 import re
 import signal
@@ -99,7 +100,7 @@ def runCommand(cmd, shell = True, timeout = None):
     """
 
     if timeout:
-        if type(timeout) != int:
+        if not isinstance(timeout, int):
             timeout = None
             logging.error("SubprocessAlgo.runCommand expected int timeout, got %s" % timeout)
         else:


### PR DESCRIPTION
Fixes #10009 

#### Status

- src: ready
- test: not necessary


#### Description

Run futurize on WMCore/Algorithms

Changes:

str: `from builtins import str` used in
- src/python/WMCore/Algorithms/MathAlgos.py: used in `decimal.Decimal(str(stdDev)).is_finite()`
- src/python/WMCore/Algorithms/SubprocessAlgos.py

list and iterators: range
- src/python/WMCore/Algorithms/MathAlgos.py

[Iterate over dictionariy keys](http://python-future.org/compatible_idioms.html#iterating-through-dict-keys-values-items) used in:
- src/python/WMCore/Algorithms/MiscAlgos.py

[iterate over dictionary items](http://python-future.org/compatible_idioms.html#iterating-through-dict-keys-values-items) used in:
- src/python/WMCore/Algorithms/ParseXMLFile.py

oct: `from builtins import oct`
- src/python/WMCore/Algorithms/Permissions.py

#### Is it backward compatible (if not, which system it affects?)

It should be. However, any bug would affect directly, 

```
'WMCore_Algorithms': ['WMComponent_TaskArchiver',
                       'WMCore_DataStructs',
                       'WMComponent_DBS3Buffer',
                       'WMCore_FwkJobReport',
                       'WMCore_WorkQueue',
                       'WMCore_ACDC',
                       'WMCore_Algorithms',
                       'WMCore_WMSpec',
                       'WMCore_Services',
                       'WMCore_Storage',
                       'WMCore_WMRuntime'],
```

#### External dependencies / deployment changes

requires python-future
