### PR TITLE
[py2py3] Migrate WMCore/DataStructs

### DIFF
--- a/src/python/WMCore/DataStructs/DASDocument.py
+++ b/src/python/WMCore/DataStructs/DASDocument.py
@@ -13,7 +13,7 @@ class DASDocument(dict):
         """
         Make an empty dictionary representing a DAS document
         """
-        dict = {"request_timestamp": 0,
+        dasdoc = {"request_timestamp": 0,
                 "request_url": "",
                 "request_method": "GET",
                 "request_params": {},
@@ -22,8 +22,8 @@ class DASDocument(dict):
                 "response_checksum": "",
                 "request_api": "",
                 "call_time": 0}
-        self.keys = dict.keys()
-        self.setdefault(service, dict)
+        self.keys = list(dasdoc)
+        self.setdefault(service, dasdoc)
 
     def compare(self, dict):
         """

--- a/src/python/WMCore/DataStructs/File.py
+++ b/src/python/WMCore/DataStructs/File.py
@@ -5,6 +5,7 @@ _File_
 Data object that contains details for a single file
 
 """
+from past.builtins import basestring
 __all__ = []
 
 from WMCore.DataStructs.Run import Run

--- a/src/python/WMCore/DataStructs/Fileset.py
+++ b/src/python/WMCore/DataStructs/Fileset.py
@@ -7,6 +7,8 @@ Data object that contains a set of files
 """
 
 from __future__ import print_function
+from builtins import str, map
+
 from operator import itemgetter
 from WMCore.DataStructs.WMObject import WMObject
 __all__ = []

--- a/src/python/WMCore/DataStructs/Job.py
+++ b/src/python/WMCore/DataStructs/Job.py
@@ -6,6 +6,8 @@ Data object that describes a job
 
 """
 
+from builtins import map, range
+
 __all__ = []
 
 

--- a/src/python/WMCore/DataStructs/JobGroup.py
+++ b/src/python/WMCore/DataStructs/JobGroup.py
@@ -128,9 +128,7 @@ class JobGroup(WMObject):
         """
         This just gets a length for either dict or list objects
         """
-        if isinstance(obj, dict):
-            return len(obj.keys())
-        elif isinstance(obj, list):
+        if isinstance(obj, (dict, list)):
             return len(obj)
         else:
             return 0

--- a/src/python/WMCore/DataStructs/LumiList.py
+++ b/src/python/WMCore/DataStructs/LumiList.py
@@ -13,6 +13,10 @@ This code began life in COMP/CRAB/python/LumiList.py
 """
 
 
+from builtins import zip, range, next, str, object
+
+from future.utils import viewitems
+
 from future import standard_library
 standard_library.install_aliases()
 
@@ -77,12 +81,12 @@ class LumiList(object):
         if isinstance(runsAndLumis, list):
             queued = {}
             for runLumiList in runsAndLumis:
-                for run, lumis in runLumiList.items():
+                for run, lumis in viewitems(runLumiList):
                     queued.setdefault(run, []).extend(lumis)
             runsAndLumis = queued
 
         if runsAndLumis:
-            for run in runsAndLumis.keys():
+            for run in runsAndLumis:
                 runString = str(run)
                 lastLumi = -1000
                 lumiList = runsAndLumis[run]
@@ -104,7 +108,7 @@ class LumiList(object):
                 self.compactList[runString] = [[1, 0xFFFFFFF]]
 
         if compactList:
-            for run in compactList.keys():
+            for run in compactList:
                 runString = str(run)
                 if compactList[run]:
                     self.compactList[runString] = compactList[run]
@@ -124,9 +128,9 @@ class LumiList(object):
             if len(runs) <= 0 or len(lumis) != len(runs):
                 raise RuntimeError('Improper format for wmagentFormat. # of lumi lists must match # of runs')
 
-            for run, lumiString in itertools.izip(runs, lumis):
+            for run, lumiString in zip(runs, lumis):
                 runLumis = lumiString.split(',')
-                if not str(run) in self.compactList:
+                if str(run) not in self.compactList:
                     self.compactList[str(run)] = []
                 if len(runLumis) % 2:
                     raise RuntimeError('Improper format for wmagentFormat. Lumis must be in pairs')
@@ -139,7 +143,7 @@ class LumiList(object):
 
         # Compact each run and make it unique
 
-        for run in self.compactList.keys():
+        for run in self.compactList:
             newLumis = []
             for lumi in sorted(self.compactList[run]):
                 # If the next lumi starts inside or just after the last just change the endpoint of the first
@@ -210,8 +214,8 @@ class LumiList(object):
 
     def __or__(self, other):
         result = {}
-        aruns = self.compactList.keys()
-        bruns = other.compactList.keys()
+        aruns = list(self.compactList)
+        bruns = list(other.compactList)
         runs = set(aruns + bruns)
         for run in runs:
             overlap = sorted(self.compactList.get(run, []) + other.compactList.get(run, []))
@@ -274,7 +278,7 @@ class LumiList(object):
         Return the list of pairs representation
         """
         theList = []
-        runs = self.compactList.keys()
+        runs = list(self.compactList)
         runs.sort(key=int)
         for run in runs:
             lumis = self.compactList[run]
@@ -299,7 +303,7 @@ class LumiList(object):
         """
 
         parts = []
-        runs = self.compactList.keys()
+        runs = list(self.compactList)
         runs.sort(key=int)
         for run in runs:
             lumis = self.compactList[run]
@@ -361,7 +365,7 @@ class LumiList(object):
         Selects only runs from runList in collection
         '''
         runsToDelete = []
-        for run in self.compactList.keys():
+        for run in list(self.compactList):
             if int(run) not in runList and run not in runList:
                 runsToDelete.append(run)
 

--- a/src/python/WMCore/DataStructs/Mask.py
+++ b/src/python/WMCore/DataStructs/Mask.py
@@ -10,6 +10,7 @@ job in two ways:
 
 """
 
+from builtins import range
 from WMCore.DataStructs.Run import Run
 
 
@@ -139,7 +140,7 @@ class Mask(dict):
         if not isinstance(lumis, list):
             lumis = list(lumis)
 
-        if not run in self['runAndLumis'].keys():
+        if run not in self['runAndLumis']:
             self['runAndLumis'][run] = []
 
         self['runAndLumis'][run].append([min(lumis), max(lumis)])
@@ -167,7 +168,7 @@ class Mask(dict):
             # ALWAYS TRUE
             return True
 
-        if not run in self['runAndLumis'].keys():
+        if run not in self['runAndLumis']:
             return False
 
         for pair in self['runAndLumis'][run]:
@@ -208,7 +209,7 @@ class Mask(dict):
                 if pair[0] == pair[1]:
                     maskLumis.add(pair[0])
                 else:
-                    maskLumis = maskLumis.union(range(pair[0], pair[1] + 1))
+                    maskLumis = maskLumis.union(list(range(pair[0], pair[1] + 1)))
 
             filteredLumis = set(runDict[runNumber].lumis).intersection(maskLumis)
             if len(filteredLumis) > 0:

--- a/src/python/WMCore/DataStructs/MathStructs/ContinuousSummaryHistogram.py
+++ b/src/python/WMCore/DataStructs/MathStructs/ContinuousSummaryHistogram.py
@@ -8,6 +8,7 @@ Created on Nov 20, 2012
 
 @author: dballest
 """
+from __future__ import division
 import math
 
 from WMCore.DataStructs.MathStructs.SummaryHistogram import SummaryHistogram

--- a/src/python/WMCore/DataStructs/MathStructs/SummaryHistogram.py
+++ b/src/python/WMCore/DataStructs/MathStructs/SummaryHistogram.py
@@ -8,6 +8,7 @@ Created on Nov 16, 2012
 
 @author: dballest
 """
+from builtins import str
 from WMCore.DataStructs.WMObject import WMObject
 
 class SummaryHistogram(WMObject):

--- a/src/python/WMCore/DataStructs/Run.py
+++ b/src/python/WMCore/DataStructs/Run.py
@@ -8,6 +8,8 @@ container representing a run, and its constituent lumi sections and event counts
 
 from __future__ import print_function
 
+from future.utils import viewitems, listitems
+
 from WMCore.DataStructs.WMObject import WMObject
 
 
@@ -66,7 +68,7 @@ class Run(WMObject):
             msg += "Run %s does not equal Run %s" % (self.run, rhs.run)
             raise RuntimeError(msg)
 
-        for lumi, events in rhs.eventsPerLumi.iteritems():
+        for lumi, events in viewitems(rhs.eventsPerLumi):
             if lumi not in self.eventsPerLumi or not self.eventsPerLumi[lumi]:  # Either doesn't exist, 0, or None
                 self.eventsPerLumi[lumi] = events
             else:
@@ -130,7 +132,7 @@ class Run(WMObject):
         Calculate the value of the hash
         """
         value = self.run.__hash__()
-        value += hash(frozenset(self.eventsPerLumi.items()))  # Hash that represents the dictionary
+        value += hash(frozenset(listitems(self.eventsPerLumi)))  # Hash that represents the dictionary
         return value
 
     @property
@@ -218,7 +220,7 @@ class Run(WMObject):
         """
         self.run = jsondata["Run"]
         self.eventsPerLumi = {}
-        for lumi, events in jsondata["Lumis"].iteritems():
+        for lumi, events in viewitems(jsondata["Lumis"]):
             self.eventsPerLumi[int(lumi)] = events  # Make the keys integers again
 
         return self

--- a/src/python/WMCore/DataStructs/Subscription.py
+++ b/src/python/WMCore/DataStructs/Subscription.py
@@ -5,6 +5,7 @@ _Subscription_
 workflow + fileset = subscription
 """
 
+from builtins import range
 import copy
 
 from WMCore.DataStructs.Pickleable import Pickleable

--- a/src/python/WMCore/DataStructs/WorkUnit.py
+++ b/src/python/WMCore/DataStructs/WorkUnit.py
@@ -8,6 +8,8 @@ Data object that contains details for a single work unit
 
 from __future__ import absolute_import, division, print_function
 
+from future.utils import listitems
+
 import sys
 import time
 from functools import total_ordering
@@ -70,7 +72,7 @@ class WorkUnit(WMObject, dict):
         Hash function for this dict.
         """
 
-        return hash(frozenset(self.items()))
+        return hash(frozenset(listitems(self)))
 
     def json(self, thunker=None):
         """

--- a/src/python/WMCore/DataStructs/Workflow.py
+++ b/src/python/WMCore/DataStructs/Workflow.py
@@ -5,6 +5,7 @@ _Workflow_
 A class that describes some work to be undertaken on some files
 """
 
+from builtins import str
 from WMCore.DataStructs.Pickleable import Pickleable
 
 class Workflow(Pickleable):

--- a/test/python/WMCore_t/DataStructs_t/Fileset_t.py
+++ b/test/python/WMCore_t/DataStructs_t/Fileset_t.py
@@ -5,6 +5,7 @@ _Fileset_t_
 Testcase for Fileset
 
 """
+from builtins import range
 import logging
 import random
 import unittest

--- a/test/python/WMCore_t/DataStructs_t/JobPackage_t.py
+++ b/test/python/WMCore_t/DataStructs_t/JobPackage_t.py
@@ -5,6 +5,7 @@ _JobPackage_
 Unittests for JobPackage persistency mechanism
 """
 
+from builtins import range
 import os
 import unittest
 
@@ -42,7 +43,7 @@ class JobPackageTest(unittest.TestCase):
             package[i] = newJob
 
         # There is an extra key for the directory the package is stored in.
-        assert len(package.keys()) == 101, \
+        assert len(package) == 101, \
                "Error: Wrong number of jobs in package."
 
         for i in range(100):
@@ -76,7 +77,7 @@ class JobPackageTest(unittest.TestCase):
         newPackage.load(self.persistFile)
 
         # There is an extra key for the directory the package is stored in.
-        assert len(newPackage.keys()) == 101, \
+        assert len(newPackage) == 101, \
                "Error: Wrong number of jobs in package."
 
         for i in range(100):
@@ -117,7 +118,7 @@ class JobPackageTest(unittest.TestCase):
         newPackage.load(self.persistFile)
 
         # There is an extra key for the directory the package is stored in.
-        assert len(newPackage.keys()) == 101, \
+        assert len(newPackage) == 101, \
                "Error: Wrong number of jobs in package."
 
         for i in range(100):

--- a/test/python/WMCore_t/DataStructs_t/Job_t.py
+++ b/test/python/WMCore_t/DataStructs_t/Job_t.py
@@ -5,6 +5,7 @@ _Job_t_
 Testcase for the Job class.
 """
 
+from builtins import range
 import unittest, logging, random, time
 
 from WMCore.DataStructs.Job import Job

--- a/test/python/WMCore_t/DataStructs_t/LumiList_t.py
+++ b/test/python/WMCore_t/DataStructs_t/LumiList_t.py
@@ -1,5 +1,8 @@
 #! /usr/bin/env python
 
+from builtins import zip, str, range
+from future.utils import viewitems
+
 import unittest
 
 # import FWCore.ParameterSet.Config as cms
@@ -345,14 +348,14 @@ class LumiListTest(unittest.TestCase):
     def testLumisWithEvents(self):
         """Make sure that runs and lumis with event counts as used in CRAB3 works
         """
-        clumis = {'1': range(2, 20) + range(31, 39) + range(45, 49),
-                  '2': range(6, 20) + range(30, 40),
-                  '3': range(10, 20) + range(30, 40) + range(50, 60),
-                  '4': range(1, 100),
+        clumis = {'1': list(range(2, 20)) + list(range(31, 39)) + list(range(45, 49)),
+                  '2': list(range(6, 20)) + list(range(30, 40)),
+                  '3': list(range(10, 20)) + list(range(30, 40)) + list(range(50, 60)),
+                  '4': list(range(1, 100)),
                   }
         # create a lumilist like {'21' : {'2':None ...} ...}
         lumis = {}
-        for run, ls in clumis.items():
+        for run, ls in viewitems(clumis):
             newrun = str(int(run) + 20)
             lumis[newrun] = {str(l): None for l in ls}
 

--- a/test/python/WMCore_t/DataStructs_t/MathStructs_t/ContinuousSummaryHistogram_t.py
+++ b/test/python/WMCore_t/DataStructs_t/MathStructs_t/ContinuousSummaryHistogram_t.py
@@ -10,6 +10,10 @@ Created on Nov 20, 2012
 
 @author: dballest
 """
+from __future__ import division
+from builtins import range
+from future.utils import viewvalues
+
 import unittest
 import random
 
@@ -175,7 +179,7 @@ class ContinuousSummaryHistogramTest(unittest.TestCase):
         self.assertAlmostEqual(jsonHistogram["stdDev"], 1.0, places = 0)
         self.assertEqual(len(jsonHistogram["data"]), 16)
         self.assertEqual(jsonHistogram["internalData"]["nPoints"], 1000)
-        pointsInHistogram = sum([x for x in jsonHistogram["data"].values()])
+        pointsInHistogram = sum([x for x in viewvalues(jsonHistogram["data"])])
 
         # With high probability we must have chopped at least one point
         self.assertTrue(pointsInHistogram < 1000)

--- a/test/python/WMCore_t/DataStructs_t/MathStructs_t/DiscreteSummaryHistogram_t.py
+++ b/test/python/WMCore_t/DataStructs_t/MathStructs_t/DiscreteSummaryHistogram_t.py
@@ -11,6 +11,7 @@ Created on Nov 20, 2012
 @author: dballest
 """
 
+from builtins import range
 import unittest
 
 from WMCore.DataStructs.MathStructs.DiscreteSummaryHistogram import DiscreteSummaryHistogram

--- a/test/python/WMCore_t/DataStructs_t/Subscription_t.py
+++ b/test/python/WMCore_t/DataStructs_t/Subscription_t.py
@@ -5,6 +5,8 @@ _Subscription_t_
 Testcase for the Subscription class
 """
 
+from builtins import str, range
+
 import random
 import unittest
 


### PR DESCRIPTION
Fixes #10010 

#### Status

- src: ready
- test: ready

#### Description

Run futurize on WMCore/DataStructs and applied some manual changes.

Since WMCore/DataStructs depends on WMCore/Algorithms. this PR is continuously rebases onto #10011 .

Open questions

DASDocument
- `dict` keyword abused?

Canges

[make a list of dictionary keys](http://python-future.org/compatible_idioms.html#dict-keys-values-items-as-a-list)
- src/python/WMCore/DataStructs/DASDocument.py
- src/python/WMCore/DataStructs/JobGroup.py
- src/python/WMCore/DataStructs/LumiList.py

[iterate over dictionary items and values](http://python-future.org/compatible_idioms.html#iterating-through-dict-keys-values-items):
- src/python/WMCore/DataStructs/LumiList.py
- src/python/WMCore/DataStructs/Run.py
- test/python/WMCore_t/DataStructs_t/LumiList_t.py
- test/python/WMCore_t/DataStructs_t/MathStructs_t/ContinuousSummaryHistogram_t.py

[list of dictionary items](http://python-future.org/compatible_idioms.html#dict-keys-values-items-as-a-list)
- src/python/WMCore/DataStructs/Run.py
- src/python/WMCore/DataStructs/WorkUnit.py

basestring: ` from past.builtins import basestring `
- src/python/WMCore/DataStructs/File.py

str: `from builtins import str,`
- src/python/WMCore/DataStructs/Fileset.py
- src/python/WMCore/DataStructs/LumiList.py
- src/python/WMCore/DataStructs/MathStructs/SummaryHistogram.py
- src/python/WMCore/DataStructs/Workflow.py
- test/python/WMCore_t/DataStructs_t/Fileset_t.py
- test/python/WMCore_t/DataStructs_t/LumiList_t.py
- test/python/WMCore_t/DataStructs_t/Subscription_t.py

[list and iterators](http://python-future.org/compatible_idioms.html#lists-versus-iterators): map, range, zip
- src/python/WMCore/DataStructs/Fileset.py
- src/python/WMCore/DataStructs/Job.py
- src/python/WMCore/DataStructs/LumiList.py
- src/python/WMCore/DataStructs/Mask.py
- src/python/WMCore/DataStructs/Subscription.py
- test/python/WMCore_t/DataStructs_t/JobPackage_t.py
- test/python/WMCore_t/DataStructs_t/Job_t.py
- test/python/WMCore_t/DataStructs_t/LumiList_t.py
- test/python/WMCore_t/DataStructs_t/MathStructs_t/ContinuousSummaryHistogram_t.py
- test/python/WMCore_t/DataStructs_t/MathStructs_t/DiscreteSummaryHistogram_t.py
- test/python/WMCore_t/DataStructs_t/Subscription_t.py

division: old_div
- src/python/WMCore/DataStructs/MathStructs/ContinuousSummaryHistogram.py
- test/python/WMCore_t/DataStructs_t/MathStructs_t/ContinuousSummaryHistogram_t.py

File
- `from past.builtins import basestring`

Fileset
- from builtins import str, map

Job
- from builtins import map, range

JobPackage
- migration from cPickle to pickle have been set back

LumiList
- dictionaries http://python-future.org/compatible_idioms.html#iterating-through-dict-keys-values-items and http://python-future.org/compatible_idioms.html#dict-keys-values-items-as-a-list
- list and iterators: zip, range: http://python-future.org/compatible_idioms.html#lists-versus-iterators
- from builtins import str
- from builtins import object
- from builtins import next

Mask
- dict iteration
- from bultins import range + list(range()) : http://python-future.org/compatible_idioms.html#range

Run
- viewitems
- dictionary items as list: http://python-future.org/compatible_idioms.html#dict-keys-values-items-as-a-list

Subscription
- range

Workflow
- from builtins import str

WorkUnit
- from future.utils import listitems - TODO investigate `listitmes(self)`

ContinuousSummary
- keep `old_div` not to break anything

Summary histogram
- from builtins import str

#### Is it backward compatible (if not, which system it affects?)

It should be. However, as obtained from the [direct dependency graph](https://cms-dmwm-test.docs.cern.ch/py2py3/data/wmcore_gznzsw1eblR_direct_group_l2.txt), any bug would affect directly

```
 'WMCore_DataStructs': ['WMComponent_TaskArchiver',
                        'WMCore_WMBS',
                        'WMComponent_JobSubmitter',
                        'WMCore_JobStateMachine',
                        'WMCore_JobSplitting',
                        'WMCore_WebTools',
                        'WMCore_DataStructs',
                        'WMCore_Cache',
                        'WMComponent_DBS3Buffer',
                        'WMCore_FwkJobReport',
                        'WMCore_WorkQueue',
                        'WMCore_MicroService',
                        'WMCore_ACDC',
                        'WMCore_Database',
                        'WMCore_WMSpec',
                        'WMCore_Services',
                        'WMCore_WMRuntime'],
```

#### External dependencies / deployment changes

requires python-future
