### PR TITLE
Only add replicas if parent block has been properly added/attached into Rucio

### DIFF
--- a/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
+++ b/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
@@ -317,6 +317,10 @@ class RucioInjectorPoller(BaseWorkerThread):
             rseName = "%s_Test" % location if self.testRSEs else location
             for container in uninjectedData[location]:
                 for block in uninjectedData[location][container]:
+                    if block not in self.blocksCache:
+                        logging.warning("Skipping %d file injection for block that failed to be added into Rucio: %s",
+                                        len(uninjectedData[location][container][block]['files']), block)
+                        continue
                     injectData = []
                     listLfns = []
                     for fileInfo in uninjectedData[location][container][block]['files']:

--- a/src/python/WMCore/Services/Rucio/Rucio.py
+++ b/src/python/WMCore/Services/Rucio/Rucio.py
@@ -414,8 +414,17 @@ class Rucio(object):
         try:
             # add_replicas(rse, files, ignore_availability=True)
             response = self.cli.add_replicas(rse, files, ignoreAvailability)
-        except Exception as ex:
-            self.logger.error("Failed to add replicas for: %s and block: %s. Error: %s", files, block, str(ex))
+        except DataIdentifierAlreadyExists as exc:
+            if len(files) == 1:
+                self.logger.debug("File replica already exists in Rucio: %s", files[0]['name'])
+                response = True
+            else:
+                # FIXME: I think we would have to iterate over every single file and add then one by one
+                errorMsg = "Failed to insert replicas for: {} and block: {}".format(files, block)
+                errorMsg += " Some/all DIDs already exist in Rucio. Error: {}".format(str(exc))
+                self.logger.error(errorMsg)
+        except Exception as exc:
+            self.logger.error("Failed to add replicas for: %s and block: %s. Error: %s", files, block, str(exc))
 
         if response:
             files = [item['name'] for item in files]


### PR DESCRIPTION
Fixes #10022 

#### Status
ready

#### Description
Only inject a file replica into Rucio if the parent block (block which the file belongs to) has been successfully inserted into Rucio AND attached to its parent container. Which means, if the block name is in our memory cache, block has been successfully inserted and we can insert its files as well.

#### Is it backward compatible (if not, which system it affects?)
yes (but we need to assess the damage already made and recover those)

#### Related PRs
None

#### External dependencies / deployment changes
None
