### PR TITLE
a simple rucio.getPfn

### DIFF
--- a/src/python/WMCore/Services/Rucio/Rucio.py
+++ b/src/python/WMCore/Services/Rucio/Rucio.py
@@ -257,12 +257,41 @@ class Rucio(object):
 
         return result
 
-    def getPFN(self, nodes=None, lfns=None, destination=None, protocol='srmv2', custodial='n'):
+    def getPFN(self, site, lfns, protocol=None):
         """
-        Copy of the method from the PhEDEx service class
-        Used by CRABServer
+        returns a list of PFN(s) for a list of LFN(s) and one site
+        Note: same function implemented for PhEDEx accepted a list of sites, but semantic was obscure and actual need
+              unknown. So take this chance to make things simple.
+        :param site: a Rucio RSE, i.e. a site name in standard CMS format like 'T1_UK_RAL_Disk' or  'T2_CH_CERN'
+        :param lfns: a list of LFN's, does not need to correspond to actual files and could be a top level directory
+                      like ['/store/user/rucio/jdoe','/store',...] basically any string starting with '/' is
+                      accepted and LFN -> PFN translation is almost always a simple prefix
+        :param protocol: If the RSE supports multiple access protocols, a preferred protocol can be selected via this,
+                         otherwise the default one for the site will be selected. Example: 'gsiftp' or 'davs'
+        :return: a dictionary having the LFN's as keys and the corresponding PFN's as values.
+
+        Will raise a Rucio exception if input is wrong.
         """
-        raise NotImplementedError("Apparently not available in the Rucio client as well")
+
+        # allow for duck typing, if a single lfn was passed, make it a list
+        # avoid handling a string like a list of chars !
+        if not isinstance(lfns, (set, list)):
+            lfns = [lfns]
+
+        # add a scope to turn LFNs into Rucio DID syntax
+        dids = ['cms:' + lfn for lfn in lfns]
+
+        # Rucio's lfns2pfns returns a dictionary with did as key and pfn as value:
+        # {u'cms:/store/user/rucio': u'gsiftp://red-gridftp.unl.edu:2811/mnt/hadoop/user/uscms01/pnfs/unl.edu/data4/cms/store/user/rucio'}
+        didDict = self.cli.lfns2pfns(site, dids, scheme=protocol)
+
+        # convert to a more useful format for us with LFN's as keys
+        pfnDict = {}
+        for oldKey in didDict:
+            newKey = oldKey.lstrip('cms:')
+            pfnDict[newKey] = didDict[oldKey]
+
+        return pfnDict
 
     def createContainer(self, name, scope='cms', **kwargs):
         """


### PR DESCRIPTION
Fixes #9873 

#### Status
ready

#### Description
add a rucio.getPFN method for use by CRAB (which resolves an LFN to a PFN)

#### Is it backward compatible
Yes, it is new node. Nothing is removed.

#### Related PRs
#9977 earlier attempt by @dciangot to address same issue. To be closed.

#### External dependencies / deployment changes
None

#### References in CRAB repository
https://github.com/dmwm/CRABServer/issues/6102
