### PR TITLE
Ignore availability for block level rules against the origin site/RSE

### DIFF
--- a/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
+++ b/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
@@ -289,7 +289,7 @@ class RucioInjectorPoller(BaseWorkerThread):
                 continue
             kwargs = dict(activity="Production Output", account=self.rucioAcct,
                           grouping="DATASET", comment="WMAgent automatic container rule",
-                          meta=self.metaData)
+                          ignore_availability=True, meta=self.metaData)
             rseName = "%s_Test" % item['pnn'] if self.testRSEs else item['pnn']
             # DATASET = replicates all files in the same block to the same RSE
             resp = self.rucio.createReplicationRule(item['blockname'],


### PR DESCRIPTION
Fixes #10030

#### Status
not-tested

#### Description
These block level rules are created to lock data that is getting produced at a given "origin" site/RSE. Which means, data is already available at the storage. So, ignore RSEs tagged as unavailable/downtime and make sure our block level rules can get created through the `ignore_availability=True`.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
