### PR TITLE
MSTransferor: resolve RSE expression for pileup location

### DIFF
--- a/src/python/WMCore/MicroService/Unified/MSTransferor.py
+++ b/src/python/WMCore/MicroService/Unified/MSTransferor.py
@@ -89,7 +89,7 @@ class MSTransferor(MSCore):
         self.rseQuotas = RSEQuotas(quotaAccount, self.msConfig["quotaUsage"],
                                    minimumThreshold=self.msConfig["minimumThreshold"],
                                    verbose=self.msConfig['verbose'], logger=logger)
-        self.reqInfo = RequestInfo(self.msConfig, self.logger)
+        self.reqInfo = RequestInfo(self.msConfig, self.rucio, self.logger)
 
         self.cric = CRIC(logger=self.logger)
         self.inputMap = {"InputDataset": "primary",


### PR DESCRIPTION
Fixes #10038 
Fixes #9969 (not really a fix though, more like a minor enhancement)

#### Status
ready

#### Description
* Improved logging for pileup rules evaluated by MSTransferor;
* STUCK rules with NO_SOURCES are never used as a valid location;
* Resolve the pileup RSE expressions in MSTransferor by using the MSTransferor Rucio object, which has an in-memory cache for 12h.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
