### PR TITLE
Fix pileup data location in global workqueue

### DIFF
--- a/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
@@ -252,7 +252,7 @@ class StartPolicyInterface(PolicyInterface):
         for dbsUrl in datasets:
             for datasetPath in datasets[dbsUrl]:
                 if hasattr(self, "rucio"):
-                    locations = self.rucio.getDataLockedAndAvailable(name=datasetPath, grouping="DATASET",
+                    locations = self.rucio.getDataLockedAndAvailable(name=datasetPath,
                                                                      account=self.args['rucioAcct'])
                 else:
                     locations = set()


### PR DESCRIPTION
Fixes #10040 

#### Status
ready

#### Description
MSTransferor does not make pileup container level rules with grouping=DATASET, thus when a workqueue element is getting created, pileups always have an empty location until the LocationUpdateTask thread kicks in and update those elements (that thread does not filter by grouping type!).

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
