### PR TITLE
Purge data when deleting block-level rules. Fix naming of tape RSEs t…

### DIFF
--- a/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
+++ b/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
@@ -407,7 +407,7 @@ class RucioInjectorPoller(BaseWorkerThread):
             # If the container is not in the dictionary, create a new entry for it
             if container not in containerDict:
                 # Set of sites to which the container needs to be transferred
-                sites = blockDict[blockName]['sites']
+                sites = set(x.replace("_MSS", "_Tape") for x in blockDict[blockName]['sites'])
                 containerDict[container] = {'blocks': [], 'rse': sites}
             containerDict[container]['blocks'].append(blockName)
 
@@ -450,7 +450,7 @@ class RucioInjectorPoller(BaseWorkerThread):
                     continue
                 for rule in rules:
                     deletedRules = 0
-                    if self.rucio.deleteRule(rule['id']):
+                    if self.rucio.deleteRule(rule['id'], purgeReplicas=True):
                         logging.info("Successfully deleted rule: %s, for block %s.", rule['id'], block)
                         deletedRules += 1
                     else:


### PR DESCRIPTION
Purge data when deleting block-level rules. Fix naming of tape RSEs taken from database

#### Status
ready

#### Description
Tier0 needs data to be deleted as soon as possible. Because of this, the purge_replicas option is now used when deleting block-level rules. 

On the other hand,I added a naming fix, in case database uses `_MSS` as suffix for tape sites. The suffix will be replaced by `_Tape`.

#### Is it backward compatible (if not, which system it affects?)
YES 
#### Related PRs
This fixes an issue #9959

#### External dependencies / deployment changes
This does not require deployment changes
