### PR TITLE
Switch validation script to Rucio; rollback py3 changes

### DIFF
--- a/bin/adhoc-scripts/checkDsetFileCount.py
+++ b/bin/adhoc-scripts/checkDsetFileCount.py
@@ -1,139 +1,114 @@
 #!/usr/bin/env python
 """
-Script meant to be used to check the status of a dataset (or lfn) against DBS
-and PhEDEx. It also prints any discrepancy between those 2 data management tools.
+Script meant to fetch the number of blocks and files for a given dataset,
+using both DBS and Rucio services. It prints any inconsistency among
+those two.
 """
 from __future__ import print_function, division
-from future import standard_library
-standard_library.install_aliases()
 
-import http.client
-import json
-import os
+import logging
 import sys
-import urllib.request, urllib.parse
-from urllib.error import HTTPError, URLError
-from argparse import ArgumentParser
+from collections import Counter
 
-main_url = "https://cmsweb.cern.ch"
-phedex_url = main_url + "/phedex/datasvc/json/prod/"
-dbs_url = main_url + "/dbs/prod/global/DBSReader/"
+from future.utils import viewkeys, viewvalues
 
+from WMCore.Services.DBS.DBS3Reader import DBS3Reader
+from WMCore.Services.Rucio.Rucio import Rucio
 
-class HTTPSClientAuthHandler(urllib.request.HTTPSHandler):
-    def __init__(self):
-        urllib.request.HTTPSHandler.__init__(self)
-        self.key = os.getenv("X509_USER_PROXY")
-        self.cert = os.getenv("X509_USER_PROXY")
-
-    def https_open(self, req):
-        return self.do_open(self.getConnection, req)
-
-    def getConnection(self, host, timeout=300):
-        return http.client.HTTPSConnection(host, key_file=self.key, cert_file=self.cert)
+RUCIO_ACCT = "wma_prod"
+RUCIO_HOST = "http://cms-rucio.cern.ch"
+RUCIO_AUTH = "https://cms-rucio-auth.cern.ch"
+DBS_URL = "https://cmsweb.cern.ch/dbs/prod/global/DBSReader/"
 
 
-def get_content(url, params=None):
-    opener = urllib.request.build_opener(HTTPSClientAuthHandler())
-    try:
-        if params:
-            response = opener.open(url, params)
-            output = response.read()
-        else:
-            response = opener.open(url)
-            output = response.read()
-    except HTTPError as e:
-        print('The server couldn\'t fulfill the request. Erro code: ', e.code)
+def loggerSetup(logLevel=logging.INFO):
+    """
+    Return a logger which writes everything to stdout.
+    """
+    logger = logging.getLogger(__name__)
+    outHandler = logging.StreamHandler(sys.stdout)
+    outHandler.setFormatter(logging.Formatter("%(asctime)s:%(levelname)s:%(module)s: %(message)s"))
+    outHandler.setLevel(logLevel)
+    logger.addHandler(outHandler)
+    logger.setLevel(logLevel)
+    return logger
+
+
+def getFromRucio(dataset, logger):
+    """
+    Using the WMCore Rucio object and fetch all the blocks and files
+    for a given container.
+    Returns a dictionary key'ed by the block name, value is the amount of files.
+    """
+    rucio = Rucio(acct=RUCIO_ACCT,
+                  hostUrl=RUCIO_HOST,
+                  authUrl=RUCIO_AUTH,
+                  configDict={'logger': logger, 'phedexCompatible': False})
+
+    result = dict()
+    for block in rucio.getBlocksInContainer(dataset):
+        data = rucio.getDID(block)
+        result.setdefault(block, data['length'])
+    return result
+
+
+def getFromDBS(dataset, logger):
+    """
+    Uses the WMCore DBS3Reader object to fetch all the blocks and files
+    for a given container.
+    Returns a dictionary key'ed by the block name, and an inner dictionary
+    with the number of valid and invalid files. It also returns a total counter
+    for the number of valid and invalid files in the dataset.
+    """
+    dbsReader = DBS3Reader(DBS_URL, logger)
+
+    result = dict()
+    dbsFilesCounter = Counter({'valid': 0, 'invalid': 0})
+    blocks = dbsReader.listFileBlocks(dataset)
+    for block in blocks:
+        data = dbsReader.dbs.listFileArray(block_name=block, validFileOnly=0, detail=True)
+        result.setdefault(block, Counter({'valid': 0, 'invalid': 0}))
+        for fileInfo in data:
+            if fileInfo['is_file_valid'] == 1:
+                result[block]['valid'] += 1
+                dbsFilesCounter['valid'] += 1
+            else:
+                result[block]['invalid'] += 1
+                dbsFilesCounter['invalid'] += 1
+    return result, dbsFilesCounter
+
+
+def main():
+    """
+    Expects a dataset name as input argument.
+    It then queries Rucio and DBS and compare their blocks and
+    number of files.
+    """
+    if len(sys.argv) != 2:
+        print("A dataset name must be provided in the command line")
         sys.exit(1)
-    except URLError as e:
-        print('Failed to reach server. Reason:', e.reason)
-        sys.exit(1)
-    return output
+    datasetName = sys.argv[1]
 
+    logger = loggerSetup(logging.INFO)
 
-def phedex_info(dataset):
-    """
-    Query blockreplicas PhEDEx API to retrieve detailed information
-    for a specific dataset
-    """
-    api_url = phedex_url + "blockreplicas" + "?" + urllib.parse.urlencode([('dataset', dataset)])
-    phedex_summary = json.loads(get_content(api_url))
-    return phedex_summary
+    rucioOutput = getFromRucio(datasetName, logger)
+    dbsOutput, dbsFilesCounter = getFromDBS(datasetName, logger)
 
+    logger.info("*** Dataset: %s", datasetName)
+    logger.info("Rucio file count : %s", sum(viewvalues(rucioOutput)))
+    logger.info("DBS file count   : %s", dbsFilesCounter['valid'] + dbsFilesCounter['invalid'])
+    logger.info(" - valid files   : %s", dbsFilesCounter['valid'])
+    logger.info(" - invalid files : %s", dbsFilesCounter['invalid'])
+    logger.info("Blocks in Rucio but not in DBS: %s", set(viewkeys(rucioOutput)) - set(viewkeys(dbsOutput)))
+    logger.info("Blocks in DBS but not in Rucio: %s", set(viewkeys(dbsOutput)) - set(viewkeys(rucioOutput)))
 
-def dbs_info(dataset):
-    """
-    Queries 2 DBS APIs to get both summary and detailed information
-    """
-    dbs_out = {}
-    api_url = dbs_url + "blocksummaries" + "?" + urllib.parse.urlencode({'dataset': dataset})
-    dbs_out['blocksummaries'] = json.loads(get_content(api_url))
-    api_url = dbs_url + "files" + "?" + urllib.parse.urlencode({'dataset': dataset}) + "&detail=1"
-    dbs_out['files'] = json.loads(get_content(api_url))
-    return dbs_out
-
-
-def main(argv=None):
-    """
-    Receive either a dataset name or a logical file name
-    and proxy location. Then it queries the following data
-    services:
-     - phedex : gets number of files
-     - dbs    : gets the number of valid, invalid and total files
-
-    It returns the number of files for this dataset/lfn available
-    in PhEDEx and DBS
-    """
-    usage = "usage: %prog -d dataset_name"
-    parser = ArgumentParser(usage=usage)
-    parser.add_argument('-d', '--dataset', help='Dataset name', dest='dataset')
-    parser.add_argument('-l', '--lfn', help='Logical file name', dest='lfn')
-    options = parser.parse_args()
-    if not (options.dataset or options.lfn):
-        parser.error("Please supply either dataset name or file name \
-                      and certificate location")
-        sys.exit(1)
-    if options.dataset:
-        dataset = options.dataset
-    if options.lfn:
-        lfn = options.lfn
-        lfnAux = lfn.split('/')
-        dataset = '/' + lfnAux[4] + '/' + lfnAux[3] + '-' + lfnAux[6] + '/' + lfnAux[5]
-
-    print("Dataset: %s" % dataset)
-
-    phedex_out = phedex_info(dataset)
-    dbs_out = dbs_info(dataset)
-    phedex_files = 0
-    phedex_blocks = {}
-    for item in phedex_out["phedex"]["block"]:
-        phedex_files += item['files']
-        phedex_blocks.setdefault(item['name'], item['files'])
-
-    dbs_files = dbs_out['blocksummaries'][0]['num_file']
-    dbs_blocks = {}
-    dbs_file_valid = 0
-    dbs_file_invalid = 0
-    for item in dbs_out['files']:
-        dbs_blocks.setdefault(item['block_name'], 0)
-        dbs_blocks[item['block_name']] += 1
-        if item['is_file_valid']:
-            dbs_file_valid += 1
-        else:
-            dbs_file_invalid += 1
-
-    print("Phedex file count : ", phedex_files)
-    print("DBS file count    : ", dbs_files)
-    print(" - valid files    : ", dbs_file_valid)
-    print(" - invalid files  : ", dbs_file_invalid)
-    print(" - valid+invalid  : ", (dbs_file_valid + dbs_file_invalid))
-    print("Blocks in PhEDEx but not in DBS: ", set(phedex_blocks.keys()) - set(dbs_blocks.keys()))
-    print("Blocks in DBS but not in PhEDEx: ", set(dbs_blocks.keys()) - set(phedex_blocks.keys()))
-
-    for blockname in phedex_blocks:
-        if phedex_blocks[blockname] != dbs_blocks.get(blockname):
-            print("Block with file mismatch: %s" % blockname)
-            print("\tPhEDEx: %s\t\tDBS: %s" % (phedex_blocks.get(blockname), dbs_blocks.get(blockname)))
+    for blockname in rucioOutput:
+        if blockname not in dbsOutput:
+            logger.error("This block does not exist in DBS: %s", blockname)
+            continue
+        if rucioOutput[blockname] != sum(viewvalues(dbsOutput[blockname])):
+            logger.warning("Block with file mismatch: %s", blockname)
+            logger.warning("\tRucio: %s\t\tDBS: %s", rucioOutput[blockname], sum(viewvalues(dbsOutput[blockname])))
 
 
 if __name__ == "__main__":

--- a/test/data/ReqMgr/validate-test-wfs.py
+++ b/test/data/ReqMgr/validate-test-wfs.py
@@ -1,21 +1,21 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
-from future import standard_library
-standard_library.install_aliases()
-
 import argparse
-import http.client
+import getpass
+import httplib
 import json
 import os
 import pwd
 import sys
-import urllib.request, urllib.parse
-from urllib.error import HTTPError, URLError
-import re
-from textwrap import TextWrapper
+import urllib
+import urllib2
 from collections import OrderedDict
+from textwrap import TextWrapper
+from urllib import quote_plus
+from urllib2 import HTTPError, URLError
 
+from future.utils import viewitems
 
 # table parameters
 SEPARATELINE = "|" + "-" * 51 + "|"
@@ -28,13 +28,13 @@ CLIENT_ID = 'validate-test-wfs/1.2::python/%s.%s' % sys.version_info[:2]
 cachedDqmgui = None
 
 
-class HTTPSClientAuthHandler(urllib.request.HTTPSHandler):
+class HTTPSClientAuthHandler(urllib2.HTTPSHandler):
     """
     Basic HTTPS class
     """
 
     def __init__(self, key, cert):
-        urllib.request.HTTPSHandler.__init__(self)
+        urllib2.HTTPSHandler.__init__(self)
         self.key = key
         self.cert = cert
 
@@ -45,32 +45,44 @@ class HTTPSClientAuthHandler(urllib.request.HTTPSHandler):
         return self.do_open(self.getConnection, req)
 
     def getConnection(self, host, timeout=290):
-        return http.client.HTTPSConnection(host, key_file=self.key, cert_file=self.cert)
+        return httplib.HTTPSConnection(host, key_file=self.key, cert_file=self.cert)
 
 
 def getX509():
     "Helper function to get x509 from env or tmp file"
+    certFile = os.environ.get('X509_USER_CERT', '')
+    keyFile = os.environ.get('X509_USER_KEY', '')
+    if certFile and keyFile:
+        return certFile, keyFile
+
     proxy = os.environ.get('X509_USER_PROXY', '')
     if not proxy:
         proxy = '/tmp/x509up_u%s' % pwd.getpwuid(os.getuid()).pw_uid
         if not os.path.isfile(proxy):
-            return ''
-    return proxy
+            return '', ''
+    return proxy, proxy
 
 
-def getContent(url, params=None):
-    cert = getX509()
+def getContent(url, params=None, headers=None):
+    certFile, keyFile = getX509()
     client = '%s (%s)' % (CLIENT_ID, os.environ.get('USER', ''))
-    handler = HTTPSClientAuthHandler(cert, cert)
-    opener = urllib.request.build_opener(handler)
-    opener.addheaders = [("User-Agent", client),
-                         ("Accept", "application/json")]
+    handler = HTTPSClientAuthHandler(keyFile, certFile)
+    opener = urllib2.build_opener(handler)
+    if headers:
+        opener.addheaders = headers
+    else:
+        opener.addheaders = [("User-Agent", client),
+                             ("Accept", "application/json")]
+
     try:
         response = opener.open(url, params)
-        output = response.read()
+        if "auth/x509" in url:
+            output = response.headers.getheader('X-Rucio-Auth-Token')
+        else:
+            output = response.read()
     except HTTPError as e:
         print("The server couldn't fulfill the request at %s" % url)
-        print("Error code: ", e.code)
+        print("Error: {}".format(e))
         output = '{}'
         # sys.exit(1)
     except URLError as e:
@@ -78,6 +90,109 @@ def getContent(url, params=None):
         print('Reason: ', e.reason)
         sys.exit(2)
     return output
+
+
+def getRucioToken(rucioUrl):
+    """
+    Get a Rucio token for this account
+    """
+    mapHosts = {"http://cmsrucio-int.cern.ch": "https://cmsrucio-auth-int.cern.ch",
+                "http://cms-rucio.cern.ch": "https://cms-rucio-auth.cern.ch"}
+
+    rucioAuth = None
+    for hostUrl, authUrl in viewitems(mapHosts):
+        if hostUrl == rucioUrl:
+            rucioAuth = authUrl
+            rucioAcct = getpass.getuser()
+    if not rucioAuth:
+        print("Failed to parse Rucio URL.")
+        sys.exit(10)
+
+    rucioAuth = '%s/auth/x509' % rucioAuth
+    token = getContent(rucioAuth, headers=[("X-Rucio-Account", rucioAcct)])
+    print("Retrieved token for account: {}, token is: {}".format(rucioAcct, token))
+    return token
+
+
+def getDID(rucioUrl, token, dataId):
+    """
+    Retrieve basic information for a given data identifier (likely a container)
+    """
+    headers = [("X-Rucio-Auth-Token", token),
+               ("Content-type", "application/json"),
+               ("Accept", "application/json")]
+
+    rucioUrl = '{}/dids/cms/{}?dynamic=anything'.format(rucioUrl, dataId)
+    data = json.loads(getContent(rucioUrl, headers=headers))
+    # DEBUG print("Container data retrieved:\n%s" % data)
+    return data
+
+
+def getBlocks(rucioUrl, token, dataId):
+    """
+    Retrieve information for a CMS block identifier
+    """
+    headers = [("X-Rucio-Auth-Token", token)]
+    # Server doesn't accept these headers below ..
+    #           ("Content-type", "application/json"),
+    #           ("Accept", "application/json")]
+    rucioUrl = '{}/dids/cms/{}/dids'.format(rucioUrl, dataId)
+    data = getContent(rucioUrl, headers=headers)
+    # DEBUG print("Block data retrieved:\n%s" % data)
+    return data
+
+
+def getBlockMeta(rucioUrl, token, dataId):
+    """
+    Retrieve the CMS block metadata (like whether the block is opened or not, etc).
+    """
+    headers = [("X-Rucio-Auth-Token", token),
+               ("Content-type", "application/json"),
+               ("Accept", "application/json")]
+
+    rucioUrl = '{}/dids/cms/{}/meta'.format(rucioUrl, quote_plus(dataId))
+    data = json.loads(getContent(rucioUrl, headers=headers))
+    # DEBUG print("Block meta data retrieved:\n%s" % data)
+    return data
+
+
+def getReplicas(rucioUrl, token, dataId):
+    """
+    Retrieve all the replicas in a given CMS block identifier
+    """
+    headers = [("X-Rucio-Auth-Token", token)]
+    # Here it accepts, but then it returns the wrong response!!!
+    #           ("Content-type", "application/json"),
+    #           ("Accept", "application/json")]
+
+    rucioUrl = '{}/replicas/cms/{}/datasets'.format(rucioUrl, quote_plus(dataId))
+    data = getContent(rucioUrl, headers=headers)
+    # DEBUG print("Replicas data retrieved:\n%s" % data)
+    return data
+
+
+def getDIDRules(rucioUrl, token, dataId):
+    """
+    Retrieve all the rules for a given data identifier
+    """
+    headers = [("X-Rucio-Auth-Token", token)]
+    # Server doesn't accept these headers below ..
+    #           ("Content-type", "application/json"),
+    #           ("Accept", "application/json")]
+
+    rucioUrl = '{}/dids/cms/{}/rules'.format(rucioUrl, dataId)
+    data = getContent(rucioUrl, headers=headers)
+    # DEBUG print("getDIDRules data retrieved:\n%s" % data)
+    return data
+
+
+def reader(stream):
+    """
+    Home-made function to consume newline delimited json streaming data
+    """
+    for line in stream.split("\n"):
+        if line:
+            yield json.loads(line)
 
 
 def getCouchSummary(reqName, baseUrl):
@@ -103,17 +218,6 @@ def getReqMgrCache(reqName, baseUrl):
     return reqmgrOutput
 
 
-def getPhedexInfo(dataset, baseUrl):
-    """
-    Queries blockreplicas PhEDEx API to retrieve general information needed
-    """
-    phedexOutput = {}
-    queryParams = urllib.parse.urlencode({'dataset': dataset})
-    phedexUrl = baseUrl + "/phedex/datasvc/json/prod/" + "blockreplicas"
-    phedexOutput = json.loads(getContent(phedexUrl, queryParams))
-    return phedexOutput["phedex"]["block"]
-
-
 def getDbsInfo(dataset, baseUrl):
     """
     Queries 3 DBS APIs to get all general information needed
@@ -126,12 +230,12 @@ def getDbsInfo(dataset, baseUrl):
     dbsOutput = {}
     dbsOutput[dataset] = {"blockorigin": [], "filesummaries": [], "outputconfigs": []}
     for api in dbsOutput[dataset]:
-        fullUrl = dbsUrl + api + "?" + urllib.parse.urlencode({'dataset': dataset})
+        fullUrl = dbsUrl + api + "?" + urllib.urlencode({'dataset': dataset})
         data = json.loads(getContent(fullUrl))
         dbsOutput[dataset][api] = data
 
     # Separate query for prep_id, since we want any access_type
-    fullUrl = dbsUrl + "datasets?" + urllib.parse.urlencode({'dataset': dataset})
+    fullUrl = dbsUrl + "datasets?" + urllib.urlencode({'dataset': dataset})
     fullUrl += "&dataset_access_type=*&detail=True"
     data = json.loads(getContent(fullUrl))
     dbsOutput[dataset]["prep_id"] = data[0]["prep_id"] if data else ''
@@ -289,8 +393,9 @@ def twClosure(replace_whitespace=False,
             for value in obj:
                 output += "%s%s" % (ind, twEnclosed(value, ind, reCall=True))
         else:
-            output += "%s\n" % str(obj)# join(twr.wrap(str(obj)))
+            output += "%s\n" % str(obj)  # join(twr.wrap(str(obj)))
         return output
+
     return twEnclosed
 
 
@@ -400,33 +505,46 @@ def handleCouch(reqName, reqmgrUrl, reqmgrOutDsets):
     return couchOutDsets
 
 
-def handlePhedex(reqmgrOutDsets, cmswebUrl):
+def handleRucio(rucioToken, reqmgrOutDsets, rucioUrl):
     """
-    Query PhEDEx and performs all the processing and dirty keys
+    Query Rucio and performs all the processing and dirty keys
     manipulation.
     """
-    phedexInfo = {}
+    rucioInfo = {}
+    if not rucioToken:
+        return rucioInfo
 
     for dset in reqmgrOutDsets:
-        # Get general phedex info, number of files and size of dataset
-        phedexOutput = getPhedexInfo(dset, cmswebUrl)
-        phedexInfo.setdefault(dset, {})
-        phedexInfo[dset].setdefault('numFiles', 0)
-        phedexInfo[dset].setdefault('dsetSize', 0)
-        phedexInfo[dset].setdefault('numBlocks', 0)
-        for item in phedexOutput:
-            phedexInfo[dset]['numFiles'] += item['files']
-            phedexInfo[dset]['dsetSize'] += item['bytes']
-            phedexInfo[dset]['numBlocks'] += 1
-            phedexInfo[dset].setdefault(item['name'], {})
-            phedexInfo[dset][item['name']] = {'numFiles': item['files'],
-                                              'isOpen': item['is_open'],
-                                              'PNN': item['replica'][0]['node'],
-                                              'SE': item['replica'][0]['se'],
-                                              'custodial': item['replica'][0]['custodial'],
-                                              'complete': item['replica'][0]['complete'],
-                                              'subscribed': item['replica'][0]['subscribed']}
-    return phedexInfo
+        rucioInfo.setdefault(dset, {})
+        rucioInfo[dset].setdefault('dsetSize', 0)
+        rucioInfo[dset].setdefault('numBlocks', 0)
+        rucioInfo[dset].setdefault('numFiles', 0)
+        containerData = getDID(rucioUrl, rucioToken, dset)
+        if not containerData:
+            continue
+        rucioInfo[dset]['dsetSize'] = containerData['bytes']
+        # FIXME should length be the number of blocks?!?
+        # rucioInfo[dset]['numBlocks'] = containerData['length']
+
+        rucioInfo[dset].setdefault('rules', [])
+        for rule in reader(getDIDRules(rucioUrl, rucioToken, dset)):
+            rucioInfo[dset]['rules'].append(rule['id'])
+
+        for block in reader(getBlocks(rucioUrl, rucioToken, containerData['name'])):
+            rucioInfo[dset]['numBlocks'] += 1
+            blockMeta = getBlockMeta(rucioUrl, rucioToken, block['name'])
+            rucioInfo[dset]['numFiles'] += blockMeta['length']
+
+            rucioInfo[dset].setdefault(block['name'], {})
+            rucioInfo[dset][block['name']]['numFiles'] = blockMeta['length']
+            rucioInfo[dset][block['name']]['is_open'] = blockMeta['is_open']
+            rucioInfo[dset][block['name']]['project'] = blockMeta['project']
+            for replica in reader(getReplicas(rucioUrl, rucioToken, block['name'])):
+                # Look only at the first replica
+                rucioInfo[dset][block['name']]['state'] = replica['state']
+                rucioInfo[dset][block['name']]['PNN'] = replica['rse'].replace("_Test", "")
+
+    return rucioInfo
 
 
 def handleDBS(reqmgrOutDsets, cmswebUrl):
@@ -457,33 +575,33 @@ def handleDBS(reqmgrOutDsets, cmswebUrl):
     return dbsInfo
 
 
-def validateAll(reqmgrInputDset, couchInfo, phedexInfo, dbsInfo):
+def validateAll(reqmgrInputDset, couchInfo, rucioInfo, dbsInfo):
     """
     Now that we have all the necessary information, we can start performing some
     x-checks. Test cases are:
-      1. output dataset name in workload_cache, workloadSummary, phedex and dbs
-      2. output dataset size in workloadSummary, phedex and dbs
-      3. output number of blocks in phedex and dbs
-      4. output number of files in workloadSummary, phedex and dbs
+      1. output dataset name in workload_cache, workloadSummary, rucio and dbs
+      2. output dataset size in workloadSummary, rucio and dbs
+      3. output number of blocks in rucio and dbs
+      4. output number of files in workloadSummary, rucio and dbs
       5. output number of events in workloadSummary and dbs
       6. output number of lumis in the workload_cache and dbs
-      7. output PNN in phedex and dbs
+      7. output PNN in rucio and dbs
       8. whether blocks are closed
     """
     print('' + SPLITLINE)
-    print('|' + ' ' * 25 + '| CouchDB | PhEDEx | DBS  |')
+    print('|' + ' ' * 25 + '| CouchDB | Rucio  | DBS  |')
     print(SEPARATELINE)
 
-    compRes = compareLists(couchInfo.keys(), phedexInfo.keys(), dbsInfo.keys())
+    compRes = compareLists(couchInfo.keys(), rucioInfo.keys(), dbsInfo.keys())
     print('| Same dataset name       | {compRes:7s} | {compRes:6s} | {compRes:4s} |'.format(compRes=compRes))
 
-    compRes = compareLists(couchInfo, phedexInfo, dbsInfo, key='dsetSize')
+    compRes = compareLists(couchInfo, rucioInfo, dbsInfo, key='dsetSize')
     print('| Same dataset size       | {compRes:7s} | {compRes:6s} | {compRes:4s} | '.format(compRes=compRes))
 
-    compRes = compareLists(phedexInfo, dbsInfo, key='numBlocks')
+    compRes = compareLists(rucioInfo, dbsInfo, key='numBlocks')
     print('| Same number of blocks   | %-7s | %-6s | %-4s |' % ('--', compRes, compRes))
 
-    compRes = compareLists(couchInfo, phedexInfo, dbsInfo, key='numFiles')
+    compRes = compareLists(couchInfo, rucioInfo, dbsInfo, key='numFiles')
     print('| Same number of files    | {compRes:7s} | {compRes:6s} | {compRes:4s} | '.format(compRes=compRes))
 
     compRes = compareLists(couchInfo, dbsInfo, key='events')
@@ -492,8 +610,8 @@ def validateAll(reqmgrInputDset, couchInfo, phedexInfo, dbsInfo):
     compRes = compareSpecial(reqmgrInputDset, dbsInfo, key='lumis')
     print('| Same number of lumis    | %-7s | %-6s | %-4s |' % (compRes, '--', compRes))
 
-    compRes = compareSpecial(phedexInfo, dbsInfo, key='PNN')
-    print('| Same PhEDEx Node Name   | %-7s | %-6s | %-4s |' % ('--', compRes, compRes))
+    compRes = compareSpecial(rucioInfo, dbsInfo, key='PNN')
+    print('| Same RSE                | %-7s | %-6s | %-4s |' % ('--', compRes, compRes))
 
     print(SPLITLINE)
 
@@ -505,16 +623,17 @@ def main():
 
     Receive a workflow name in order to fetch the following information:
      - from couchdb: gets the output datasets and spec file
-     - from phedex: gets dataset, block, files information
+     - from rucio: gets dataset, block, files information
      - from dbs: gets dataset, block and files information
     """
     parser = argparse.ArgumentParser(description="Validate workflow input, output and config")
     group = parser.add_mutually_exclusive_group()
     group.add_argument('-w', '--workflow', help='A single workflow name')
     group.add_argument('-i', '--inputFile', help='Plain text file containing request names (one per line)')
-    parser.add_argument('-c', '--cms', help='CMSWEB url to talk to DBS/PhEDEx. E.g: cmsweb.cern.ch')
+    parser.add_argument('-c', '--cms', help='CMSWEB url to talk to DBS. E.g: cmsweb.cern.ch')
     parser.add_argument('-r', '--reqmgr', help='Request Manager URL. Example: couch-dev1.cern.ch')
     parser.add_argument('-v', '--verbose', help='Increase output verbosity', action="store_true")
+    parser.add_argument('-x', '--rucio', help='Rucio url', default='cmsrucio-int.cern.ch')
     args = parser.parse_args()
 
     if args.workflow:
@@ -529,6 +648,9 @@ def main():
     verbose = True if args.verbose else False
     cmswebUrl = "https://" + args.cms if args.cms else "https://cmsweb-testbed.cern.ch"
     reqmgrUrl = "https://" + args.reqmgr if args.reqmgr else "https://cmsweb-testbed.cern.ch"
+    rucioUrl = "http://" + args.rucio if args.rucio else "http://cmsrucio-int.cern.ch"
+
+    rucioToken = getRucioToken(rucioUrl)
 
     for reqName in listRequests:
         print("\n----------------------------------------------------")
@@ -541,14 +663,14 @@ def main():
         # Retrieve and process CouchDB information
         couchInfo = handleCouch(reqName, reqmgrUrl, reqmgrOutDsets)
 
-        # Retrieve and process PhEDEx information
-        phedexInfo = handlePhedex(reqmgrOutDsets, cmswebUrl)
+        # Retrieve and process Rucio information
+        rucioInfo = handleRucio(rucioToken, reqmgrOutDsets, rucioUrl)
 
         # Retrieve and process DBS information
         dbsInfo = handleDBS(reqmgrOutDsets, cmswebUrl)
 
         # Perform all the possible common validations
-        validateAll(reqmgrInputDset, couchInfo, phedexInfo, dbsInfo)
+        validateAll(reqmgrInputDset, couchInfo, rucioInfo, dbsInfo)
 
         # Starts VERBOSE mode for the information retrieved so far
         if verbose:
@@ -560,8 +682,8 @@ def main():
             twPrint(couchInfo)
             print("\n======> DBS info: ")
             twPrint(dbsInfo)
-            print("\n======> PhEDEx info: ")
-            twPrint(phedexInfo)
+            print("\n======> Rucio info: ")
+            twPrint(rucioInfo)
         print("\n----------------------------------------------------")
 
     sys.exit(0)


### PR DESCRIPTION
Fixes #9620

#### Status
ready

#### Description
In addition to rolling back some of the python3 modernization changes provided here (which broke the HTTP calls):
https://github.com/dmwm/WMCore/pull/9762

this PR provides the following:
* `checkDsetFileCount.py` now compares DBS data against Rucio instead of PhEDEx. It also uses the WMCore/Services modules to talk to the data-services (instead of https/urllib/etc);
* `workflowCompletion.py` simply reverted some of the python3 related changes;
* `validate-test-wfs.py` replaced PhEDEx by Rucio functionality - without using any of the WMCore libraries, so through their RESTful APIs- and some of the python3 changes have been reverted as well.

#### Is it backward compatible (if not, which system it affects?)
no

#### Related PRs
none

#### External dependencies / deployment changes
none
