### PR TITLE
MSOutput: use different lifetime configuration for RelVal Disk rules

### DIFF
--- a/src/python/WMCore/MicroService/Unified/MSOutput.py
+++ b/src/python/WMCore/MicroService/Unified/MSOutput.py
@@ -336,6 +336,9 @@ class MSOutput(MSCore):
                          'comment': 'WMCore MSOutput output data placement'}
             # add a configurable weight value
             ruleAttrs["weight"] = self.msConfig['rucioDiskRuleWeight']
+            # and RelVals have a different lifetime setting
+            if workflow['IsRelVal']:
+                ruleAttrs["lifetime"] = self.msConfig['ruleLifetimeRelVal']
 
             # if anything fail along the way, set it back to "pending"
             transferStatus = "done"


### PR DESCRIPTION
Fixes #10039 

#### Status
not-tested

#### Description
Use a new MS configuration parameter `ruleLifetimeRelVal` to define the lifetime for container-level rules created for RelVal containers, against Disk RSEs. Default settings define it to 12 months.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
Deployment changes: https://github.com/dmwm/deployment/pull/971
