### PR TITLE
Use dataset_locks to find pileup block locations in WMAgent

### DIFF
--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -444,7 +444,7 @@ class SetupCMSSWPset(ScriptInterface):
                 inputTypeAttrib.fileNames = cms.untracked.vstring()
                 if pileupType == requestedPileupType:
                     eventsAvailable = 0
-                    useAAA = True if getattr(self.jobBag, 'trustPUSitelists', False) else False
+                    useAAA = False
                     self.logger.info("Pileup set to read data remotely: %s", useAAA)
                     for blockName in sorted(pileupDict[pileupType].keys()):
                         blockDict = pileupDict[pileupType][blockName]


### PR DESCRIPTION
Hack PR to allow P&R team to run some I/O tests with only a sub-set of the pileup blocks locally available.
So, this changes the current behaviour which is based only on the container level rules, to also consider all the dataset_locks for every single block in the pileup container.

This patch is getting applied to the `backfill` agent (vocms0285).