### PR TITLE
[py2py3] Migration at level src/python/A/B/C - start

### DIFF
--- a/src/python/WMComponent/TaskArchiver/DataCache.py
+++ b/src/python/WMComponent/TaskArchiver/DataCache.py
@@ -1,4 +1,5 @@
 from __future__ import (print_function, division)
+from builtins import object
 
 class DataCache(object):
     _finishedWFs = {} # Global cache holding workflow lists

--- a/src/python/WMComponent/TaskArchiver/DataCache.py
+++ b/src/python/WMComponent/TaskArchiver/DataCache.py
@@ -6,8 +6,8 @@ class DataCache(object):
 
     @staticmethod
     def getFinishedWorkflows():
-        return DataCache._finishedWFs;
+        return DataCache._finishedWFs
 
     @staticmethod
     def setFinishedWorkflows(workflowLists):
-        DataCache._finishedWFs = workflowLists;
+        DataCache._finishedWFs = workflowLists

--- a/src/python/WMCore/Agent/BaseHandler.py
+++ b/src/python/WMCore/Agent/BaseHandler.py
@@ -4,15 +4,12 @@ A base handler from which all handlers inherit from.
 Handlers are mapped to messages in the component.
 """
 
-
-
-
-
+from builtins import str, object
 
 import logging
 
 
-class BaseHandler:
+class BaseHandler(object):
     """
     A base handler from which all handlers inherit from.
     Handlers are mapped to messages in the component.

--- a/src/python/WMCore/Agent/Daemon/Create.py
+++ b/src/python/WMCore/Agent/Daemon/Create.py
@@ -21,6 +21,7 @@
 """
 from __future__ import print_function
 
+from builtins import str
 import logging
 import os
 import sys
@@ -74,14 +75,14 @@ def daemonize(stdout='/dev/null', stderr=None, stdin='/dev/null',
     # Open file descriptors and print start message
     if not stderr:
         stderr = stdout
-    si = file(stdin, 'r')
-    so = file(stdout, 'a+')
-    se = file(stderr, 'a+', 0)
+    si = open(stdin, 'r')
+    so = open(stdout, 'a+')
+    se = open(stderr, 'a+', 0)
     pid = str(os.getpid())
     sys.stderr.write("\n%s\n" % startmsg % pid)
     sys.stderr.flush()
     if workdir:
-        # file(pidfile,'w+').write("%s\n" % pid)
+        # open(pidfile,'w+').write("%s\n" % pid)
         # Since the current working directory may be a mounted filesystem, we
         # avoid the issue of not being able to unmount the filesystem at
         # shutdown time by changing it to the root directory.
@@ -149,7 +150,7 @@ def test():
     c = 0
     while True:
         sys.stdout.write('%d: %s\n' % (c, time.ctime(time.time())))
-        logging.info('%d: %s\n' % (c, time.ctime(time.time())))
+        logging.info('%d: %s\n', c, time.ctime(time.time()))
         sys.stdout.flush()
         c = c + 1
         time.sleep(1)
@@ -165,7 +166,7 @@ def createDaemon(workdir, keepParent=False):
     pidfile = os.path.join(workdir, 'Daemon.xml')
     startmsg = 'started with pid %s'
     try:
-        pf = file(pidfile, 'r')
+        pf = open(pidfile, 'r')
         pid = (pf.read().strip())
         pf.close()
     except IOError:

--- a/src/python/WMCore/Agent/Daemon/Details.py
+++ b/src/python/WMCore/Agent/Daemon/Details.py
@@ -10,6 +10,8 @@ Also, provides utils to shutdown the daemon process
 """
 from __future__ import print_function
 
+from builtins import str, range
+
 import os
 import subprocess
 import shutil
@@ -24,7 +26,7 @@ def run(command):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         stdin=subprocess.PIPE,
-    )
+        )
 
     proc.stdin.write(command)
     stdout, stderr = proc.communicate()

--- a/src/python/WMCore/Database/ConfigDBMap.py
+++ b/src/python/WMCore/Database/ConfigDBMap.py
@@ -1,3 +1,6 @@
+from builtins import object
+
+
 class ConfigDBMapInterface(object):
     """
     Interface for converting the configuration to

--- a/src/python/WMCore/Database/DBExceptionHandler.py
+++ b/src/python/WMCore/Database/DBExceptionHandler.py
@@ -1,5 +1,6 @@
 from __future__ import division, print_function
 
+from builtins import str
 from functools import wraps
 import logging
 import threading

--- a/src/python/WMCore/Database/DBFormatter.py
+++ b/src/python/WMCore/Database/DBFormatter.py
@@ -6,6 +6,8 @@ Holds a bunch of helper methods to format input and output of sql
 interactions.
 """
 
+from builtins import str, bytes, zip, range
+
 import datetime
 import time
 import types
@@ -73,10 +75,10 @@ class DBFormatter(WMObject):
                 # WARNING: this can generate errors for some stupid reason
                 # in both oracle and mysql.
                 entry = {}
-                for index in xrange(0, len(descriptions)):
+                for index in range(0, len(descriptions)):
                     # WARNING: Oracle returns table names in CAP!
-                    if isinstance(i[index], unicode):
-                        entry[str(descriptions[index].lower())] = str(i[index])
+                    if isinstance(i[index], str):
+                        entry[str(descriptions[index].lower())] = bytes(i[index])
                     else:
                         entry[str(descriptions[index].lower())] = i[index]
 
@@ -95,9 +97,9 @@ class DBFormatter(WMObject):
         for r in result:
             descriptions = r.keys
             for i in r.fetchall():
-                for index in xrange(0, len(descriptions)):
-                    if isinstance(i[index], unicode):
-                        listOut.append(str(i[index]))
+                for index in range(0, len(descriptions)):
+                    if isinstance(i[index], str):
+                        listOut.append(bytes(i[index]))
                     else:
                         listOut.append(i[index])
             r.close()
@@ -126,7 +128,7 @@ class DBFormatter(WMObject):
 
         """
         if isinstance(cursor.keys, types.MethodType):
-            keys = [x.lower() for x in cursor.keys()]
+            keys = [x.lower() for x in cursor.keys()]  # warning: do not modernize this line.
         else:
             keys = [x.lower() for x in cursor.keys]
         result = []
@@ -146,7 +148,7 @@ class DBFormatter(WMObject):
 
     def getBinds(self, **kwargs):
         binds = {}
-        for i in kwargs.keys():
+        for i in kwargs:
             binds = self.dbi.buildbinds(self.dbi.makelist(kwargs[i]), i, binds)
         return binds
 

--- a/src/python/WMCore/Database/MongoDB.py
+++ b/src/python/WMCore/Database/MongoDB.py
@@ -6,6 +6,8 @@ Description: Provides a wrapper class for MongoDB
 # futures
 from __future__ import division, print_function
 
+from builtins import str, object
+
 from pymongo import MongoClient, errors, IndexModel
 
 

--- a/src/python/WMCore/Database/ResultSet.py
+++ b/src/python/WMCore/Database/ResultSet.py
@@ -6,12 +6,11 @@ SQLAlchemy result sets (aka cursors) can be closed. Make this class look as much
 like the SQLAlchemy class to minimise the impact of adding this class.
 """
 
-
-
-
+from builtins import object
 import threading
 
-class ResultSet:
+
+class ResultSet(object):
     def __init__(self):
         self.data = []
         self.keys = []
@@ -37,7 +36,9 @@ class ResultSet:
         elif resultproxy.returns_rows:
             for r in resultproxy:
                 if len(self.keys) == 0:
-                    self.keys.extend(r.keys())
+                    # do not modernize next line. 
+                    # r is a `sqlalchemy.engine.result.RowProxy`, not a `dict`
+                    self.keys.extend(r.keys()) 
                 self.data.append(r)
 
         return

--- a/src/python/WMCore/JobStateMachine/Transitions.py
+++ b/src/python/WMCore/JobStateMachine/Transitions.py
@@ -5,6 +5,9 @@ _Transitions_
 Controls what state transitions are allowed.
 """
 
+from future.utils import viewvalues
+
+
 class Transitions(dict):
     """
     All allowed state transitions in the JSM.
@@ -37,7 +40,7 @@ class Transitions(dict):
         states other than cleanout.
         """
         knownstates = set(self.keys())
-        for possiblestates in self.values():
+        for possiblestates in viewvalues(self):
             for i in possiblestates:
                 knownstates.add(i)
         return list(knownstates)

--- a/src/python/WMCore/REST/Auth.py
+++ b/src/python/WMCore/REST/Auth.py
@@ -1,3 +1,6 @@
+from builtins import map, str, bytes
+from future.utils import viewitems
+
 import cherrypy
 import hashlib
 import hmac
@@ -42,7 +45,7 @@ def user_info_from_headers(key, verbose=False):
             if hk.startswith("cms-authn"):
                 val = headers[hk]
                 if hk in ("cms-authn-name", "cms-authn-dn"):
-                    val = unicode(val, "utf-8")
+                    val = str(val, "utf-8")
                 user[hkname] = val
             if hk.startswith("cms-authz"):
                 user['roles'][hkname] = {'site': set(), 'group': set()}
@@ -76,9 +79,9 @@ def authz_match(role=None, group=None, site=None, verbose=False):
     log = cherrypy.log
 
     # If role, group or site are strings, convert to list first.
-    role = (role and isinstance(role, str) and [role]) or role
-    group = (group and isinstance(group, str) and [group]) or group
-    site = (site and isinstance(site, str) and [site]) or site
+    role = (role and isinstance(role, bytes) and [role]) or role
+    group = (group and isinstance(group, bytes) and [group]) or group
+    site = (site and isinstance(site, bytes) and [site]) or site
 
     # Reformat all items into canonical format.
     role = role and list(map(authz_canonical, role))
@@ -92,7 +95,7 @@ def authz_match(role=None, group=None, site=None, verbose=False):
         return
 
     # Otherwise determine set intersection of requirements.
-    for r, authz in ((user and user['roles']) or {}).iteritems():
+    for r, authz in viewitems((user and user['roles']) or {}):
         if (not role) or (r in role):
             if not (group or site):
                 if verbose:

--- a/src/python/WMCore/REST/Error.py
+++ b/src/python/WMCore/REST/Error.py
@@ -1,3 +1,4 @@
+from builtins import str
 import random, cherrypy
 
 class RESTError(Exception):

--- a/src/python/WMCore/REST/Validation.py
+++ b/src/python/WMCore/REST/Validation.py
@@ -1,5 +1,9 @@
+from builtins import str, bytes
+from past.builtins import basestring
+
 from WMCore.REST.Error import *
-import math, re
+import math
+import re
 import numbers
 
 def return_message(main_err, custom_err):
@@ -26,22 +30,22 @@ def _check_rx(argname, val, custom_err = None):
 
 def _check_str(argname, val, rx, custom_err = None):
     """
-    convert unicode to str first to support cherrypy 3.2.2
+    convert unicode to str (bytes) first to support cherrypy 3.2.2
     This is not really check val is ASCII.
     """
-    if isinstance(val, unicode):
+    if isinstance(val, str):
         try:
-            val = str(val)
+            val = bytes(val, "utf-8")
         except:
-            raise InvalidParameter(return_message("Invalid '%s' parameter" % argname, custom_err))
+            raise InvalidParameter(return_message("Invalid '%s' parameter %s %s" % (argname, val, type(val)), custom_err))
     if not isinstance(val, basestring) or not rx.match(val):
         raise InvalidParameter(return_message("Incorrect '%s' parameter" % argname, custom_err))
     return val
 
 def _check_ustr(argname, val, rx, custom_err = None):
-    if isinstance(val, str):
+    if isinstance(val, bytes):
         try:
-            val = unicode(val, "utf-8")
+            val = str(val, "utf-8")
         except:
             raise InvalidParameter(return_message("Incorrect '%s' parameter" % argname, custom_err))
     if not isinstance(val, basestring) or not rx.match(val):

--- a/src/python/WMCore/Services/PyCondor/PyCondorAPI.py
+++ b/src/python/WMCore/Services/PyCondor/PyCondorAPI.py
@@ -6,6 +6,8 @@ Class used to interact with Condor daemons on the agent
 
 from __future__ import print_function, division
 
+from builtins import str, object
+from past.builtins import basestring
 import logging
 
 try:

--- a/src/python/WMCore/Services/PyCondor/PyCondorUtils.py
+++ b/src/python/WMCore/Services/PyCondor/PyCondorUtils.py
@@ -1,5 +1,9 @@
 from __future__ import print_function, division
 
+from builtins import str, object
+
+from future.utils import viewitems
+
 import logging
 import os
 import pickle
@@ -21,7 +25,7 @@ class OutputObj(object):
         self.outputMessage = outputMessage
         self.outputObj = outputObj
         self.environmentStr = ""
-        for key, val in os.environ.iteritems():
+        for key, val in viewitems(os.environ):
             self.environmentStr += "%s=%s\n" % (key, val)
 
 

--- a/src/python/WMCore/Services/UUIDLib.py
+++ b/src/python/WMCore/Services/UUIDLib.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from builtins import str
 import uuid
 
 

--- a/src/python/WMCore/ThreadPool/ThreadPool.py
+++ b/src/python/WMCore/ThreadPool/ThreadPool.py
@@ -218,7 +218,7 @@ class ThreadPool(Queue):
                 self.callQueue -= 1
                 exceptCount = 0
             except Exception as ex:
-                logging.error("Problem with retrieving work : "+str(ex))
+                logging.error("Problem with retrieving work : %s", str(ex))
                 logging.error("Trying to salvage it")
                 slaveServer.sane = False
                 exceptCount += 1

--- a/src/python/WMCore/ThreadPool/ThreadPool.py
+++ b/src/python/WMCore/ThreadPool/ThreadPool.py
@@ -11,6 +11,8 @@ To use this you need to use the ThreadSlave class
 
 
 
+from builtins import str
+
 import base64
 import logging
 import random

--- a/src/python/WMCore/ThreadPool/WorkQueue.py
+++ b/src/python/WMCore/ThreadPool/WorkQueue.py
@@ -29,6 +29,7 @@ function. This helps the caller to determine which function
 
 """
 
+from builtins import object
 from future import standard_library
 standard_library.install_aliases()
 

--- a/src/python/WMCore/WMRuntime/Sandbox.py
+++ b/src/python/WMCore/WMRuntime/Sandbox.py
@@ -11,10 +11,11 @@ the module tree imposed by it
 
 """
 
+from builtins import object
 import os
 import inspect
 
-class Sandbox:
+class Sandbox(object):
     """
     _Sandbox_
 

--- a/src/python/WMCore/WMRuntime/ScriptFactory.py
+++ b/src/python/WMCore/WMRuntime/ScriptFactory.py
@@ -6,6 +6,7 @@ WMFactory for instantiating runtime implementations of the ScriptInterface
 
 """
 
+from builtins import str
 from WMCore.WMFactory import WMFactory
 from WMCore.WMException import WMException
 

--- a/src/python/WMCore/WMRuntime/ScriptInterface.py
+++ b/src/python/WMCore/WMRuntime/ScriptInterface.py
@@ -7,9 +7,10 @@ API definition for RuntimeScripts that will be called in the job area.
 
 
 """
+from builtins import object
 
 
-class ScriptInterface:
+class ScriptInterface(object):
     """
     _ScriptInterface_
 

--- a/src/python/WMCore/WMRuntime/StepSpace.py
+++ b/src/python/WMCore/WMRuntime/StepSpace.py
@@ -5,11 +5,12 @@ _StepSpace_
 Frontend module for setting up StepSpace areas within a job.
 
 """
+from builtins import object
 import os
 import inspect
 from WMCore.WMRuntime.Sandbox import Sandbox
 
-class StepSpace:
+class StepSpace(object):
     """
     _StepSpace_
 

--- a/src/python/WMQuality/Emulators/Cache/MockMemoryCacheStruct.py
+++ b/src/python/WMQuality/Emulators/Cache/MockMemoryCacheStruct.py
@@ -1,4 +1,5 @@
 from __future__ import (division, print_function)
+from builtins import object
 
 
 class MockMemoryCacheStruct(object):

--- a/src/python/WMQuality/Emulators/DashboardApMon/MockApMon.py
+++ b/src/python/WMQuality/Emulators/DashboardApMon/MockApMon.py
@@ -1,4 +1,5 @@
 from __future__ import (division, print_function)
+from builtins import object
 
 
 class MockApMon(object):

--- a/src/python/WMQuality/Emulators/LogDB/MockLogDB.py
+++ b/src/python/WMQuality/Emulators/LogDB/MockLogDB.py
@@ -1,4 +1,5 @@
 from __future__ import (division, print_function)
+from builtins import object
 
 class MockLogDB(object):
     """

--- a/src/python/WMQuality/Emulators/PyCondorAPI/MockPyCondorAPI.py
+++ b/src/python/WMQuality/Emulators/PyCondorAPI/MockPyCondorAPI.py
@@ -1,4 +1,5 @@
 from __future__ import (division, print_function)
+from builtins import object
 
 
 class MockPyCondorAPI(object):

--- a/test/python/WMCore_t/Agent_t/Configuration_t.py
+++ b/test/python/WMCore_t/Agent_t/Configuration_t.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #pylint: disable=E1101,C0103,R0902
 
+from builtins import str, range, object
+
 import unittest
 import os
 import tempfile
@@ -107,7 +109,7 @@ class ConfigurationTest(unittest.TestCase):
         self.assertEqual(config.Section2.Tuple,
                          ("string", 123, 123.456, False))
 
-        class DummyObject:
+        class DummyObject(object):
             pass
         # unsupported parameter type
         self.assertRaises(

--- a/test/python/WMCore_t/Database_t/DBFormatter_t.py
+++ b/test/python/WMCore_t/Database_t/DBFormatter_t.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 _DBFormatterTest_
 
@@ -7,6 +8,7 @@ Unit tests for the DBFormatter class
 """
 from __future__ import print_function
 
+from builtins import str
 import threading
 import unittest
 
@@ -41,8 +43,8 @@ create table test (bind1 varchar(20), bind2 varchar(20)) ENGINE=InnoDB """
         myThread.insert = """
 insert into test (bind1, bind2) values (:bind1, :bind2) """
         myThread.insert_binds = \
-            [{'bind1': 'value1a', 'bind2': 'value2a'}, \
-             {'bind1': 'value1b', 'bind2': 'value2b'}, \
+            [{'bind1': 'value1aà', 'bind2': u'value2aà'},
+             {'bind1': 'value1b', 'bind2': 'value2b'},
              {'bind1': 'value1c', 'bind2': 'value2d'}]
         myThread.select = "select * from test"
 
@@ -69,7 +71,6 @@ insert into test (bind1, bind2) values (:bind1, :bind2) """
         """
         Test various formats
         """
-
         myThread = threading.currentThread()
         dbformatter = DBFormatter(myThread.logger, myThread.dbi)
         myThread.transaction.begin()

--- a/test/python/WMCore_t/Database_t/ResultSet_t.py
+++ b/test/python/WMCore_t/Database_t/ResultSet_t.py
@@ -10,10 +10,10 @@ Unit tests for the Database/ResultSet class
 #Written to test the ResultSet class initially by mnorman
 #Dependent on DBCore, specifically DBCore.processData()
 
+from builtins import str, range
+
 import unittest
-import logging
 import threading
-import os
 
 from WMCore.WMFactory import WMFactory
 from WMCore.Database.ResultSet import ResultSet

--- a/test/python/WMCore_t/Services_t/UUID_t.py
+++ b/test/python/WMCore_t/Services_t/UUID_t.py
@@ -5,10 +5,9 @@
 
 
 from __future__ import print_function
+from builtins import str
+
 import unittest
-import os
-import logging
-import socket
 import time
 
 from WMCore.Services.UUIDLib import makeUUID

--- a/test/python/WMCore_t/ThreadPool_t/ThreadPool_t.py
+++ b/test/python/WMCore_t/ThreadPool_t/ThreadPool_t.py
@@ -12,13 +12,12 @@ from __future__ import print_function
 
 
 
+from builtins import str, range
 import unittest
 import threading
 import time
-import os
 
 from WMCore.ThreadPool.ThreadPool import ThreadPool
-from WMCore.WMFactory             import WMFactory
 
 from WMQuality.TestInit import TestInit
 
@@ -72,7 +71,7 @@ class ThreadPoolTest(unittest.TestCase):
         component.config = config
 
         threadPools = []
-        for i in xrange(0, ThreadPoolTest._nrOfPools):
+        for i in range(0, ThreadPoolTest._nrOfPools):
             threadPool = ThreadPool("WMCore.ThreadPool.ThreadSlave", \
                 component, 'MyPool_'+str(i), ThreadPoolTest._nrOfThreads)
             threadPools.append(threadPool)
@@ -82,14 +81,14 @@ class ThreadPoolTest(unittest.TestCase):
         # it is dispatched, otherwise it is stored in the trheadpool.
         # make the number of tasks bigger than number of threads to tesT
         # the persistent queue.
-        for i in xrange(0, ThreadPoolTest._nrOfThreads*10):
+        for i in range(0, ThreadPoolTest._nrOfThreads*10):
             event = 'eventNr_'+str(i)
             payload = 'payloadNr_'+str(i)
             # normally you would have different events per threadpool and
             # even different objects per pool. the payload part will be
             # pickled into the database enabling flexibility in passing
             # information.
-            for j in xrange(0, ThreadPoolTest._nrOfPools):
+            for j in range(0, ThreadPoolTest._nrOfPools):
                 threadPools[j].enqueue(event, \
                     {'event' : event, 'payload' : payload})
 
@@ -102,24 +101,24 @@ class ThreadPoolTest(unittest.TestCase):
         currenttime = 0
         while not finished:
             print('waiting for threads to finishs. Work left:')
-            for j in xrange(0, ThreadPoolTest._nrOfPools):
+            for j in range(0, ThreadPoolTest._nrOfPools):
                 print('pool_'+str(j)+ ':' + str(threadPools[j].callQueue))
             time.sleep(1)
             finished = True
             currenttime += 1
             if (timeout == currenttime):
                 raise RuntimeError
-            for j in xrange(0, ThreadPoolTest._nrOfPools):
+            for j in range(0, ThreadPoolTest._nrOfPools):
                 if (len(threadPools[j].resultsQueue) < ThreadPoolTest._nrOfThreads*10):
                     finished = False
                     break
         # check if the tables are really empty and all messages
         # have been processed.
-        for j in xrange(0, ThreadPoolTest._nrOfPools):
+        for j in range(0, ThreadPoolTest._nrOfPools):
             assert len(threadPools[j].resultsQueue) == \
                 ThreadPoolTest._nrOfThreads*10
         myThread.transaction.begin()
-        for j in xrange(0, ThreadPoolTest._nrOfPools):
+        for j in range(0, ThreadPoolTest._nrOfPools):
             self.assertEqual( threadPools[j].countMessages() ,  0 )
         myThread.transaction.commit()
 


### PR DESCRIPTION
Fixes #10055

#### Status

Ready


#### Related PRs

* Next migration PR: #10103 (slice2, issue #10098  )

#### Description

Run futurize and some manual changes on the first batch of src/python/A/B/C.

Overview of the changes:
- ` from builtins import str `
- ` from builtins import object `
- iterate over dictionary valus and items : `viewitems`, `viewvalues`

Overview based on file:
* `src/python/WMCore/Database/ResultSet.py`
  * L39, `r.keys()`:  `r` is not a dict, it is of type `sqlalchemy.engine.result.RowProxy` -> list(r) does not return a list of keys. Do not change that line with futurize!

#### Is it backward compatible (if not, which system it affects?)

It should be. Possible causes of errors:

* `src/python/WMCore/Services/UUIDLib.py` returns a `future.types.newstr.newstr` instead of a py2 `str`. The test `test/python/WMCore_t/Services_t/UUID_t.py` has been updated accordingly

#### External dependencies / deployment changes

requires python-future

#### Open questions (to be addressed in follow up work)

`src/python/WMCore/REST/Validation.py `

- is `_check_str` still needed? the docstring states "convert unicode to str (bytes) first to support cherrypy 3.2.2"