### PR TITLE
Add PyPI support for reqmon, reqmgr2ms, global-workqueue, acdcserver

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,32 +4,29 @@
 # Format:
 # PackageName==X.Y.Z          # <comma separated list of WMCore software needing the package>
 
-Cheetah==2.4.0                # wmagent,reqmgr2
-CherryPy==17.4.0              # wmagent,reqmgr2
-Markdown==3.0.1               # wmagent
-MySQL-python==1.2.5           # wmagent
-SQLAlchemy==1.3.3             # wmagent
-Sphinx==1.3.5                 # wmagent,reqmgr2
-cx-Oracle==5.2.1              # wmagent
-dbs-client==3.13.1            # wmagent,reqmgr2
-decorator==3.4.2              # wmagent
-future==0.18.2                # wmagent,reqmgr2
-nose2==0.9.2                  # wmagent
-mock==2.0.0                   # wmagent
+Cheetah==2.4.0                # wmagent,reqmgr2,reqmon
+CherryPy==17.4.0              # wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms
+CMSMonitoring>=0.3.4          # wmagent,reqmgr2,reqmon,reqmgr2ms
 coverage==4.5.4               # wmagent
+cx-Oracle==5.2.1              # wmagent
+dbs-client==3.13.1            # wmagent,reqmgr2,reqmon,global-workqueue
+decorator==3.4.2              # wmagent
 funcsigs==1.0.2               # wmagent
-httplib2==0.18.0              # wmagent,reqmgr2
-psutil==5.6.6                 # wmagent,reqmgr2
+future==0.18.2                # wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms
+httplib2==0.18.0              # wmagent,reqmgr2,reqmon,acdcserver,global-workqueue,reqmgr2ms
+Markdown==3.0.1               # wmagent
+mock==2.0.0                   # wmagent
+MySQL-python==1.2.5           # wmagent
+nose2==0.9.2                  # wmagent
+psutil==5.6.6                 # wmagent,reqmgr2,reqmon,global-workqueue
 py==1.7.0                     # wmagent
-pyOpenSSL==18.0.0             # wmagent
-pycurl-client==3.13.1         # wmagent
-pycurl==7.43.0.3              # wmagent,reqmgr2
-python-cjson==1.2.1           # wmagent
-pyzmq==17.1.2                 # wmagent
-retry==0.9.1                  # wmagent,reqmgr2
-setuptools==39.2.0            # wmagent
-stomp.py==4.1.15              # wmagent
-rucio-clients==1.23.0         # wmagent
-CMSMonitoring>=0.3.4          # wmagent,reqmgr2
+pycurl==7.43.0.3              # wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms
 pymongo==3.10.1               # reqmgr2ms
-
+pyOpenSSL==18.0.0             # wmagent
+pyzmq==17.1.2                 # wmagent
+retry==0.9.1                  # wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms
+rucio-clients==1.23.0         # wmagent,global-workqueue,reqmgr2ms
+setuptools==39.2.0            # wmagent
+Sphinx==1.3.5                 # wmagent,reqmgr2,acdcserver,global-workqueue,reqmgr2ms
+SQLAlchemy==1.3.3             # wmagent
+stomp.py==4.1.15              # wmagent

--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -92,7 +92,7 @@ dependencies = {
         'systems': ['wmc-rest', 'wmc-runtime', 'wmc-database'],
         'statics': [],
     },
-    'workqueue': {
+    'global-workqueue': {
         'packages': ['WMCore.GlobalWorkQueue+', 'WMCore.WorkQueue+',
                      'WMCore.Wrappers+', 'WMCore.Services+',
                      'WMCore.WMSpec', 'WMCore.WMSpec.Steps', 'WMCore.WMSpec.Steps.Templates',
@@ -115,7 +115,7 @@ dependencies = {
                      'WMCore.JobSplitting+', 'WMCore.ProcessPool',
                      'WMCore.Services+', 'WMCore.WMSpec+',
                      'WMCore.WMBS+', 'WMCore.ResourceControl+'],
-        'systems': ['wmc-web', 'wmc-database', 'workqueue', 'wmc-runtime'],
+        'systems': ['wmc-web', 'wmc-database', 'global-workqueue', 'wmc-runtime'],
         'statics': ['src/javascript/WMCore/WebTools/Agent',
                     'src/javascript/WMCore/WebTools/WMBS',
                     'src/javascript/external/graphael',
@@ -207,7 +207,7 @@ dependencies = {
                     'WMCore.WMException',
                     'WMCore.Lexicon',
                     'WMCore.WMBS.File'],
-        'systems': ['wmc-web', 'wmc-database', 'wmc-runtime', 'workqueue'],
+        'systems': ['wmc-web', 'wmc-database', 'wmc-runtime', 'global-workqueue'],
         'statics': ['src/javascript/external/graphael',
                     'src/couchapps/FWJRDump+',
                     'src/couchapps/T0Request+',

--- a/tools/build_pypi_packages.sh
+++ b/tools/build_pypi_packages.sh
@@ -2,68 +2,64 @@
 #
 # Script used to build each application from the WMCore repo and upload to pypi.
 #
-# Usage:
-# sh tools/build_pypi_packages.sh <wmagent|wmcore|all>
+# Usage
+# Build a single package:
+# sh tools/build_pypi_packages.sh <package name>
+# Build all WMCore packages:
+# sh tools/build_pypi_packages.sh all
 #
 
+set -x
 
-wmcore=false
-wmagent=false
-reqmgr2=false
+# package passed as parameter, can be one of PACKAGES or "all"
 TOBUILD=$1
+# list of packages that can be built and uploaded to pypi
+PACKAGES="wmagent wmcore reqmon reqmgr2 reqmgr2ms global-workqueue acdcserver"
+PACKAGE_REGEX="^($(echo $PACKAGES | sed 's/\ /|/g')|all)$"
 
-case $TOBUILD in
-    wmagent)
-      echo "Building wmagent package"
-      wmagent=true
-      ;;
-    wmcore)
-      echo "Building wmcore package"
-      wmcore=true
-      ;;
-    reqmgr2)
-      echo "Building wmcore package"
-      reqmgr2=true
-      ;;
-    all)
-      echo "Building wmagent package"
-      echo "Building wmcore package"
-      wmcore=true
-      wmagent=true
-      reqmgr2=true
-      ;;
-    *)
-      echo "Please enter one of the following arguments."
-      echo "  all       Build all WMCore packages"
-      echo "  wmagent   Build wmagent package"
-      echo "  wmcore    Build wmcore package"
-      echo "  reqmgr2   Build reqmgr2 package"
-      exit 1
-esac
-
-# make a copy of requirements.txt to reference for each build
-cp requirements.txt requirements.wmcore.txt
-
-if $wmagent
-  then
-    sed 's/PACKAGE_TO_BUILD/wmagent/' setup_template.py > setup.py
-    awk '/wmagent/ {print $1}' requirements.wmcore.txt > requirements.txt
-    python setup.py clean sdist
-    twine upload dist/wmagent-*
+if [[ -z $TOBUILD ]]; then
+  echo "Usage: sh tools/build_pypi_packages.sh <package name>"
+  echo "Usage: sh tools/build_pypi_packages.sh all"
+  exit 1
 fi
 
-if $wmcore
-  then
-    sed 's/PACKAGE_TO_BUILD/wmcore/' setup_template.py > setup.py
-    awk '/wmcore/ {print $1}' requirements.wmcore.txt > requirements.txt
-    python setup.py clean sdist
-    twine upload dist/wmcore-*
+
+# check to make sure a valid package name was passed
+if [[ ! $TOBUILD =~ $PACKAGE_REGEX ]]; then
+  echo "$TOBUILD is not a valid package name"
+  echo "Supported packages are $PACKAGES"
+  exit 1
 fi
 
-if $reqmgr2
-  then
-    sed 's/PACKAGE_TO_BUILD/reqmgr2/' setup_template.py > setup.py
-    awk '/reqmgr2/ {print $1}' requirements.wmcore.txt > requirements.txt
-    python setup.py clean sdist
-    twine upload dist/reqmgr2-*
+# update package list when building all packages
+if [[ $TOBUILD == "all" ]]; then
+  TOBUILD=$PACKAGES
 fi
+
+# loop through packages to build
+for package in $TOBUILD; do
+  # make a copy of requirements.txt to reference for each build
+  cp requirements.txt requirements.wmcore.txt
+
+  # update the setup script template with package name
+  sed "s/PACKAGE_TO_BUILD/$package/" setup_template.py > setup.py
+
+  # build requirements.txt file
+  awk "/($package$)|($package,)/ {print \$1}" requirements.wmcore.txt > requirements.txt
+
+  # build the package
+  python setup.py clean sdist
+  if [[ $? -ne 0 ]]; then
+    echo "Error building package $package"
+    exit 1
+  fi
+  
+  # upload the package to pypi
+  echo "Uploading package $package to PyPI"
+  twine upload dist/$package-*
+  
+  # replace requirements.txt contents
+  cp requirements.wmcore.txt requirements.txt
+done
+
+


### PR DESCRIPTION
Fixes #9823 #9820 #9828 #9821 

#### Status
Ready

#### Description
Updated the pypi build script and requirements.txt file to include reqmon, reqmgr2ms, workqueue, acdcserver. 

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
NA

#### External dependencies / deployment changes
cms-dist dependency: https://github.com/cms-sw/cmsdist/pull/6442
