### PR TITLE
Removing file status condition from GetUnsubscribedDatasets query

### DIFF
--- a/src/python/WMComponent/RucioInjector/Database/MySQL/GetUnsubscribedDatasets.py
+++ b/src/python/WMComponent/RucioInjector/Database/MySQL/GetUnsubscribedDatasets.py
@@ -32,7 +32,6 @@ class GetUnsubscribedDatasets(DBFormatter):
                INNER JOIN dbsbuffer_file ON
                  dbsbuffer_algo_dataset_assoc.id = dbsbuffer_file.dataset_algo
              WHERE dbsbuffer_dataset_subscription.subscribed = 0 AND
-                   (dbsbuffer_file.status = 'GLOBAL' OR dbsbuffer_file.status = 'InDBS') AND
                    dbsbuffer_file.in_phedex = 1 AND
                    dbsbuffer_dataset.path != 'bogus'"""
 


### PR DESCRIPTION
Fixes #10064 >

#### Status
Ready

#### Description
As discussed in #10064, I removed the requirement for files to be uploaded to DBS from GetUnsubscribedDatasets query . This will allow to create container rules earlier. 

#### Is it backward compatible (if not, which system it affects?)
No, It is not compatible with systems that use PhEDEx injector (WMCore version < 1.4.1)

#### Related PRs
#10025 

#### External dependencies / deployment changes

