### PR TITLE
Evaluate all WQEs when local resources are available

### DIFF
--- a/bin/check-request-wq-status
+++ b/bin/check-request-wq-status
@@ -120,7 +120,7 @@ def checkLQPullStatusFromGQ(localQ, request, possibleSites):
         print("Error: Failed to pull elements from GQ")
         return
 
-    resources, jobCounts = localQ.freeResouceCheck(printFlag=True)
+    resources, jobCounts = localQ.freeResouceCheck()
     jobSiteSummary(localQ, request, possibleSites, resources, jobCounts, flag="LQ")
     return
 

--- a/src/python/WMComponent/WorkQueueManager/WorkQueueManagerWorkPoller.py
+++ b/src/python/WMComponent/WorkQueueManager/WorkQueueManagerWorkPoller.py
@@ -49,7 +49,8 @@ class WorkQueueManagerWorkPoller(BaseWorkerThread):
     def algorithm(self, parameters):
         """
         Pull in work
-            """
+        """
+        self.logger.info("Starting WorkQueueManagerWorkPoller thread ...")
         try:
             self.pullWork()
         except Exception as ex:
@@ -71,27 +72,24 @@ class WorkQueueManagerWorkPoller(BaseWorkerThread):
         For now, it only checks whether the agent is in drain mode or
         MAX_JOBS_PER_OWNER is reached or if the condor schedd is overloaded.
         """
-
         passCond = "OK"
         myThread = threading.currentThread()
         if isDrainMode(self.config):
-            passCond = "No work will be pulled: Agent is in drain"
+            passCond = "agent is in drain mode"
         elif availableScheddSlots(myThread.dbi) <= 0:
-            passCond = "No work will be pulled: schedd slot is maxed: MAX_JOBS_PER_OWNER"
+            passCond = "schedd slot is maxed: MAX_JOBS_PER_OWNER"
         elif self.condorAPI.isScheddOverloaded():
-            passCond = "No work will be pulled: schedd is overloaded"
+            passCond = "schedd is overloaded"
         else:
             subscriptions = self.listSubsWithoutJobs.execute()
             if subscriptions:
-                passCond = "No work will be pulled: "
-                passCond += "JobCreator hasn't created jobs for subscriptions %s" % subscriptions
+                passCond = "JobCreator hasn't created jobs for subscriptions %s" % subscriptions
 
         return passCond
 
     def pullWork(self):
         """Get work from parent"""
         self.queue.logger.info("Pulling work from %s" % self.queue.parent_queue.queueUrl)
-        work = 0
 
         myThread = threading.currentThread()
 
@@ -99,9 +97,10 @@ class WorkQueueManagerWorkPoller(BaseWorkerThread):
             cond = self.passRetrieveCondition()
             if cond == "OK":
                 work = self.queue.pullWork()
+                self.queue.logger.info("Obtained %s unit(s) of work", work)
                 myThread.logdbClient.delete("LocalWorkQueue_pullWork", "warning", this_thread=True)
             else:
-                self.queue.logger.warning(cond)
+                self.queue.logger.warning("No work will be pulled, reason: %s", cond)
                 myThread.logdbClient.post("LocalWorkQueue_pullWork", cond, "warning")
         except IOError as ex:
             self.queue.logger.error("Error opening connection to work queue: %s \n%s" %
@@ -109,8 +108,6 @@ class WorkQueueManagerWorkPoller(BaseWorkerThread):
         except Exception as ex:
             self.queue.logger.error("Unable to pull work from parent Error: %s\n%s"
                                     % (str(ex), traceback.format_exc()))
-        self.queue.logger.info("Obtained %s unit(s) of work" % work)
-        return work
 
     def processWork(self):
         """Process new work"""

--- a/src/python/WMComponent/WorkQueueManager/WorkQueueManagerWorkPoller.py
+++ b/src/python/WMComponent/WorkQueueManager/WorkQueueManagerWorkPoller.py
@@ -5,22 +5,23 @@ _WorkQueueManagerPoller_
 Pull work out of the work queue.
 """
 import logging
-import time
 import random
-import traceback
 import threading
+import time
+
 from Utils.Timers import timeFunction
+from WMComponent.JobSubmitter.JobSubmitAPI import availableScheddSlots
 from WMCore.DAOFactory import DAOFactory
-from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 from WMCore.Services.PyCondor.PyCondorAPI import PyCondorAPI
 from WMCore.Services.ReqMgrAux.ReqMgrAux import isDrainMode
-from WMComponent.JobSubmitter.JobSubmitAPI import availableScheddSlots
+from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 
 
 class WorkQueueManagerWorkPoller(BaseWorkerThread):
     """
     Polls for Work
     """
+
     def __init__(self, queue, config):
         """
         Initialise class members
@@ -35,14 +36,13 @@ class WorkQueueManagerWorkPoller(BaseWorkerThread):
         self.daoFactory = DAOFactory(package="WMCore.WMBS", logger=logging, dbinterface=myThread.dbi)
         self.listSubsWithoutJobs = self.daoFactory(classname="Subscriptions.GetSubsWithoutJobGroup")
 
-
     def setup(self, parameters):
         """
         Called at startup - introduce random delay
              to avoid workers all starting at once
         """
         t = random.randrange(self.idleTime)
-        self.logger.info('Sleeping for %d seconds before 1st loop' % t)
+        self.logger.info('Sleeping for %d seconds before 1st loop', t)
         time.sleep(t)
 
     @timeFunction
@@ -54,13 +54,13 @@ class WorkQueueManagerWorkPoller(BaseWorkerThread):
         try:
             self.pullWork()
         except Exception as ex:
-            self.queue.logger.error("Error in work pull loop: %s" % str(ex))
+            self.queue.logger.error("Error in work pull loop: %s", str(ex))
         try:
             # process if we get work or not - we may have to split old work
             # i.e. if transient errors were seen during splitting
             self.processWork()
         except Exception as ex:
-            self.queue.logger.error("Error in new work split loop: %s" % str(ex))
+            self.queue.logger.error("Error in new work split loop: %s", str(ex))
         return
 
     def passRetrieveCondition(self):
@@ -89,7 +89,7 @@ class WorkQueueManagerWorkPoller(BaseWorkerThread):
 
     def pullWork(self):
         """Get work from parent"""
-        self.queue.logger.info("Pulling work from %s" % self.queue.parent_queue.queueUrl)
+        self.queue.logger.info("Pulling work from %s", self.queue.parent_queue.queueUrl)
 
         myThread = threading.currentThread()
 
@@ -103,11 +103,9 @@ class WorkQueueManagerWorkPoller(BaseWorkerThread):
                 self.queue.logger.warning("No work will be pulled, reason: %s", cond)
                 myThread.logdbClient.post("LocalWorkQueue_pullWork", cond, "warning")
         except IOError as ex:
-            self.queue.logger.error("Error opening connection to work queue: %s \n%s" %
-                                    (str(ex), traceback.format_exc()))
+            self.queue.logger.exception("Error opening connection to work queue: %s", str(ex))
         except Exception as ex:
-            self.queue.logger.error("Unable to pull work from parent Error: %s\n%s"
-                                    % (str(ex), traceback.format_exc()))
+            self.queue.logger.exception("Unable to pull work from parent Error: %s", str(ex))
 
     def processWork(self):
         """Process new work"""
@@ -115,6 +113,6 @@ class WorkQueueManagerWorkPoller(BaseWorkerThread):
         try:
             self.queue.processInboundWork()
         except Exception as ex:
-            self.queue.logger.exception('Error during split: %s' % str(ex))
+            self.queue.logger.exception('Error during split: %s', str(ex))
         self.logger.info('Splitting finished')
         return

--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -16,17 +16,18 @@ import os
 import threading
 import time
 from collections import defaultdict
+
 from Utils.Utilities import usingRucio
 from WMCore import Lexicon
 from WMCore.ACDC.DataCollectionService import DataCollectionService
 from WMCore.Database.CMSCouch import CouchInternalServerError, CouchNotFoundError
 from WMCore.Services.CRIC.CRIC import CRIC
-from WMCore.Services.LogDB.LogDB import LogDB
 from WMCore.Services.DBS.DBSReader import DBSReader
+from WMCore.Services.LogDB.LogDB import LogDB
 from WMCore.Services.PhEDEx.PhEDEx import PhEDEx
-from WMCore.Services.Rucio.Rucio import Rucio
 from WMCore.Services.ReqMgr.ReqMgr import ReqMgr
 from WMCore.Services.RequestDB.RequestDBReader import RequestDBReader
+from WMCore.Services.Rucio.Rucio import Rucio
 from WMCore.Services.WorkQueue.WorkQueue import WorkQueue as WorkQueueDS
 from WMCore.WMSpec.WMWorkload import WMWorkloadHelper, getWorkloadFromTask
 from WMCore.WorkQueue.DataLocationMapper import WorkQueueDataLocationMapper
@@ -415,7 +416,7 @@ class WorkQueue(WorkQueueBase):
         dbsDatasetDict = {'Files': [], 'IsOpen': False, 'PhEDExNodeNames': []}
         dbsDatasetDict['Files'] = [f for block in tmpDsetDict.values() for f in block['Files']]
         dbsDatasetDict['PhEDExNodeNames'].extend(
-            [f for block in tmpDsetDict.values() for f in block['PhEDExNodeNames']])
+                [f for block in tmpDsetDict.values() for f in block['PhEDExNodeNames']])
         dbsDatasetDict['PhEDExNodeNames'] = list(set(dbsDatasetDict['PhEDExNodeNames']))
 
         return datasetName, dbsDatasetDict
@@ -986,7 +987,8 @@ class WorkQueue(WorkQueueBase):
                 self.logger.debug("Queue %s status follows:", self.backend.queueUrl)
                 results = endPolicy(elements, parents, self.params['EndPolicySettings'])
                 for result in results:
-                    self.logger.debug("Request %s, Status %s, Full info: %s", result['RequestName'], result['Status'], result)
+                    self.logger.debug("Request %s, Status %s, Full info: %s",
+                                      result['RequestName'], result['Status'], result)
 
                     # check for cancellation requests (affects entire workflow)
                     if result['Status'] == 'CancelRequested':
@@ -1004,8 +1006,8 @@ class WorkQueue(WorkQueueBase):
 
                     if result.inEndState():
                         if elements:
-                            self.logger.debug(
-                                "Request %s finished (%s)", result['RequestName'], parent.statusMetrics())
+                            self.logger.debug("Request %s finished (%s)",
+                                              result['RequestName'], parent.statusMetrics())
                             finished_elements.extend(result['Elements'])
                         else:
                             parentQueueDeleted = False
@@ -1070,7 +1072,7 @@ class WorkQueue(WorkQueueBase):
                 raise RuntimeError("WMSpec doesn't define policyName, current value: '%s'" % policyName)
 
             policy = startPolicy(policyName, self.params['SplittingMapping'],
-                                 rucioAcct= self.params['rucioAccount'], logger=self.logger)
+                                 rucioAcct=self.params['rucioAccount'], logger=self.logger)
             if not policy.supportsWorkAddition() and continuous:
                 # Can't split further with a policy that doesn't allow it
                 continue

--- a/src/python/WMCore/WorkQueue/WorkQueueBackend.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueBackend.py
@@ -321,95 +321,55 @@ class WorkQueueBackend(object):
             except CouchNotFoundError:
                 pass
 
-    def availableWork(self, thresholds, siteJobCounts, team=None, wfs=None,
-                      excludeWorkflows=None, numElems=9999999):
+    def calculateAvailableWork(self, thresholds, siteJobCounts):
         """
-        Get work which is available to be run
-
-        Assume thresholds is a dictionary; keys are the site name, values are
-        the maximum number of running jobs at that site.
-
-        Assumes site_job_counts is a dictionary-of-dictionaries; keys are the site
-        name and task priorities.  The value is the number of jobs running at that
-        priority.
-
-        It will pull work until it reaches the number of elements configured (numElems).
-        Since it's also used for calculating free resources, default it to "infinity"
-
-        Note: this method will be called with no limit of work elements when it's simply
-        calculating the resources available (based on what is in LQ), before it gets work
-        from GQ
+        A short version of the `availableWork` method, which is used only to calculate
+        the amount of work already available at the local workqueue.
+        :param thresholds: a dictionary key'ed by the site name, values representing the
+            maximum number of jobs allowed at that site.
+        :param siteJobCounts: a dictionary-of-dictionaries key'ed by the site name; value
+            is a dictionary with the number of jobs running at a given priority.
+        :return: a tuple with the elements accepted and an overview of job counts per site
         """
-        self.logger.info("Getting up to %d available work from %s", numElems, self.queueUrl)
-        self.logger.info("  for team name: %s", team)
-        self.logger.info("  for wfs: %s", wfs)
-        self.logger.info("  with excludeWorkflows: %s", excludeWorkflows)
-        self.logger.info("  for thresholds: %s", thresholds)
-
-        excludeWorkflows = excludeWorkflows or []
+        # NOTE: this method can be less verbose as well
         elements = []
-        sortedElements = []
-
-        # We used to pre-filter sites, looking to see if there are idle job slots
-        # We don't do this anymore, as we may over-allocate
-        # jobs to sites if the new jobs have a higher priority.
-
         # If there are no sites, punt early.
         if not thresholds:
             self.logger.error("No thresholds is set: Please check")
-            return elements, thresholds, siteJobCounts
+            return elements, siteJobCounts
+
+        self.logger.info("Calculating available work from queue %s", self.queueUrl)
 
         options = {}
         options['include_docs'] = True
         options['descending'] = True
-        options['num_elem'] = numElems
         options['resources'] = thresholds
-        if team:
-            options['team'] = team
-        if wfs:
-            result = []
-            for i in xrange(0, len(wfs), 20):
-                options['wfs'] = wfs[i:i + 20]
-                data = self.db.loadList('WorkQueue', 'workRestrictions', 'availableByPriority', options)
-                result.extend(json.loads(data))
-        else:
-            result = self.db.loadList('WorkQueue', 'workRestrictions', 'availableByPriority', options)
-            result = json.loads(result)
-            if not result:
-                self.logger.info("No available work or it did not pass work/data restrictions for: %s ",
-                                 self.queueUrl)
-            else:
-                self.logger.info("Retrieved %d elements from workRestrictions list for: %s",
-                                 len(result), self.queueUrl)
+        options['num_elem'] = 9999999  # magic number!
+        result = self.db.loadList('WorkQueue', 'workRestrictions', 'availableByPriority', options)
+        result = json.loads(result)
+        self.logger.info("Retrieved %d elements from workRestrictions list for: %s",
+                         len(result), self.queueUrl)
 
-        # Iterate through the results; apply whitelist / blacklist / data
-        # locality restrictions.  Only assign jobs if they are high enough
-        # priority.
-        for i in result:
-            element = CouchWorkQueueElement.fromDocument(self.db, i)
-            # make sure not to acquire work for aborted or force-completed workflows
-            if element['RequestName'] in excludeWorkflows:
-                msg = "Skipping aborted/force-completed workflow: %s, work id: %s"
-                self.logger.info(msg, element['RequestName'], element._id)
-            else:
-                sortedElements.append(element)
-        # sort elements to get them in priority first and timestamp order
+        # Convert python dictionary into Couch WQE objects
+        # And sort them by creation time and priority, such that highest priority and
+        # oldest elements come first in the list
+        sortedElements = []
+        for item in result:
+            element = CouchWorkQueueElement.fromDocument(self.db, item)
+            sortedElements.append(element)
         sortedElements.sort(key=lambda element: element['CreationTime'])
-        sortedElements.sort(key=lambda x: x['Priority'], reverse=True)
-
-        sites = thresholds.keys()
-        self.logger.info("Current siteJobCounts:")
-        for site, jobsByPrio in siteJobCounts.items():
-            self.logger.info("    %s : %s", site, jobsByPrio)
+        sortedElements.sort(key=lambda element: element['Priority'], reverse=True)
 
         for element in sortedElements:
             commonSites = possibleSites(element)
             prio = element['Priority']
+            # shuffle list of common sites all the time to give everyone the same chance
+            random.shuffle(commonSites)
             possibleSite = None
-            random.shuffle(sites)
-            for site in sites:
-                if site in commonSites:
-                    # Count the number of jobs currently running of greater priority
+            for site in commonSites:
+                if site in thresholds:
+                    # Count the number of jobs currently running of greater priority, if they
+                    # are less than the site thresholds, then accept this element
                     curJobCount = sum([x[1] if x[0] >= prio else 0 for x in siteJobCounts.get(site, {}).items()])
                     self.logger.debug("Job Count: %s, site: %s thresholds: %s" % (curJobCount, site, thresholds[site]))
                     if curJobCount < thresholds[site]:
@@ -417,16 +377,141 @@ class WorkQueueBackend(object):
                         break
 
             if possibleSite:
+                self.logger.debug("Meant to accept workflow: %s, with prio: %s, element id: %s, for site: %s",
+                                  element['RequestName'], prio, element.id, possibleSite)
                 elements.append(element)
                 siteJobCounts.setdefault(possibleSite, {})
                 siteJobCounts[possibleSite][prio] = siteJobCounts[possibleSite].setdefault(prio, 0) + \
                                                     element['Jobs'] * element.get('blowupFactor', 1.0)
             else:
-                self.logger.debug("No available resources for %s with doc id %s", element['RequestName'], element.id)
+                self.logger.debug("No available resources for %s with localdoc id %s",
+                                  element['RequestName'], element.id)
 
         self.logger.info("And %d elements passed location and siteJobCounts restrictions for: %s",
                          len(elements), self.queueUrl)
-        return elements, thresholds, siteJobCounts
+        return elements, siteJobCounts
+
+    def availableWork(self, thresholds, siteJobCounts, team=None,
+                      excludeWorkflows=None, numElems=9999999):
+        """
+        Get work - either from local or global queue - which is available to be run.
+
+        :param thresholds: a dictionary key'ed by the site name, values representing the
+            maximum number of jobs allowed at that site.
+        :param siteJobCounts: a dictionary-of-dictionaries key'ed by the site name; value
+            is a dictionary with the number of jobs running at a given priority.
+        :param team: a string with the team name we want to pull work for
+        :param excludeWorkflows: list of (aborted) workflows that should not be accepted
+        :param numElems: integer with the maximum number of elements to be accepted (default
+            to a very large number when pulling work from local queue, read unlimited)
+        :return: a tuple with the elements accepted and an overview of job counts per site
+        """
+        excludeWorkflows = excludeWorkflows or []
+        elements = []
+        # If there are no sites, punt early.
+        if not thresholds:
+            self.logger.error("No thresholds is set: Please check")
+            return elements, siteJobCounts
+
+        self.logger.info("Current siteJobCounts:")
+        for site, jobsByPrio in siteJobCounts.items():
+            self.logger.info("    %s : %s", site, jobsByPrio)
+
+        self.logger.info("Getting up to %d available work from %s", numElems, self.queueUrl)
+        self.logger.info("  for team name: %s", team)
+        self.logger.info("  with excludeWorkflows: %s", excludeWorkflows)
+        self.logger.info("  for thresholds: %s", thresholds)
+
+        # FIXME: magic numbers
+        docsSliceSize = 1000
+        options = {}
+        options['include_docs'] = True
+        options['descending'] = True
+        options['resources'] = thresholds
+        options['limit'] = docsSliceSize
+        # FIXME: num_elem option can likely be deprecated, but it needs synchronization
+        # between agents and global workqueue... for now, make sure it can return the slice size
+        options['num_elem'] = docsSliceSize
+        if team:
+            options['team'] = team
+
+        # Fetch workqueue elements in slices, using the CouchDB "limit" and "skip"
+        # options for couch views. Conditions to stop this loop are:
+        #  a) have a hard stop at 50k+1 (we might have to make this configurable)
+        #  b) stop as soon as an empty slice is returned by Couch (thus all docs have
+        #     already been retrieve)
+        #  c) or, once "numElems" elements have been accepted
+        numSkip = 0
+        breakOut = False
+        while True:
+            if breakOut:
+                # then we have reached the maximum number of elements to be accepted
+                break
+            self.logger.info("  with limit docs: %s, and skip first %s docs", docsSliceSize, numSkip)
+            options['skip'] = numSkip
+
+            result = self.db.loadList('WorkQueue', 'workRestrictions', 'availableByPriority', options)
+            result = json.loads(result)
+            if result:
+                self.logger.info("Retrieved %d elements from workRestrictions list for: %s",
+                                 len(result), self.queueUrl)
+            else:
+                self.logger.info("All the workqueue elements have been exhausted for: %s ", self.queueUrl)
+                break
+            # update number of documents to skip in the next cycle
+            numSkip += docsSliceSize
+
+            # Convert python dictionary into Couch WQE objects, skipping aborted workflows
+            # And sort them by creation time and priority, such that highest priority and
+            # oldest elements come first in the list
+            sortedElements = []
+            for i in result:
+                element = CouchWorkQueueElement.fromDocument(self.db, i)
+                # make sure not to acquire work for aborted or force-completed workflows
+                if element['RequestName'] in excludeWorkflows:
+                    msg = "Skipping aborted/force-completed workflow: %s, work id: %s"
+                    self.logger.info(msg, element['RequestName'], element._id)
+                else:
+                    sortedElements.append(element)
+            sortedElements.sort(key=lambda element: element['CreationTime'])
+            sortedElements.sort(key=lambda element: element['Priority'], reverse=True)
+
+            for element in sortedElements:
+                if numElems <= 0:
+                    msg = "Reached maximum number of elements to be accepted, "
+                    msg += "configured to: {}, from queue: {}".format(len(elements), self.queueUrl)
+                    self.logger.info(msg)
+                    breakOut = True  # get out of the outer loop as well
+                    break
+                commonSites = possibleSites(element)
+                prio = element['Priority']
+                # shuffle list of common sites all the time to give everyone the same chance
+                random.shuffle(commonSites)
+                possibleSite = None
+                for site in commonSites:
+                    if site in thresholds:
+                        # Count the number of jobs currently running of greater priority, if they
+                        # are less than the site thresholds, then accept this element
+                        curJobCount = sum([x[1] if x[0] >= prio else 0 for x in siteJobCounts.get(site, {}).items()])
+                        self.logger.debug("Job Count: %s, site: %s thresholds: %s" % (curJobCount, site, thresholds[site]))
+                        if curJobCount < thresholds[site]:
+                            possibleSite = site
+                            break
+
+                if possibleSite:
+                    self.logger.info("Accepting workflow: %s, with prio: %s, element id: %s, for site: %s",
+                                     element['RequestName'], prio, element.id, possibleSite)
+                    numElems -= 1
+                    elements.append(element)
+                    siteJobCounts.setdefault(possibleSite, {})
+                    siteJobCounts[possibleSite][prio] = siteJobCounts[possibleSite].setdefault(prio, 0) + \
+                                                        element['Jobs'] * element.get('blowupFactor', 1.0)
+                else:
+                    self.logger.debug("No available resources for %s with doc id %s", element['RequestName'], element.id)
+
+        self.logger.info("And %d elements passed location and siteJobCounts restrictions for: %s",
+                         len(elements), self.queueUrl)
+        return elements, siteJobCounts
 
     def getActiveData(self):
         """Get data items we have work in the queue for"""

--- a/src/python/WMCore/WorkQueue/WorkQueueBackend.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueBackend.py
@@ -194,8 +194,8 @@ class WorkQueueBackend(object):
 
         if elementIDs:
             if elementFilters or status or returnIdOnly:
-                raise ValueError(
-                    "Can't specify extra filters (or return id's) when using element id's with getElements()")
+                msg = "Can't specify extra filters (or return id's) when using element id's with getElements()"
+                raise ValueError(msg)
             elements = [CouchWorkQueueElement(db, i).load() for i in elementIDs]
         else:
             options = {'include_docs': True, 'filter': elementFilters, 'idOnly': returnIdOnly, 'reduce': False}
@@ -371,7 +371,7 @@ class WorkQueueBackend(object):
                     # Count the number of jobs currently running of greater priority, if they
                     # are less than the site thresholds, then accept this element
                     curJobCount = sum([x[1] if x[0] >= prio else 0 for x in siteJobCounts.get(site, {}).items()])
-                    self.logger.debug("Job Count: %s, site: %s thresholds: %s" % (curJobCount, site, thresholds[site]))
+                    self.logger.debug("Job Count: %s, site: %s thresholds: %s", curJobCount, site, thresholds[site])
                     if curJobCount < thresholds[site]:
                         possibleSite = site
                         break
@@ -493,7 +493,8 @@ class WorkQueueBackend(object):
                         # Count the number of jobs currently running of greater priority, if they
                         # are less than the site thresholds, then accept this element
                         curJobCount = sum([x[1] if x[0] >= prio else 0 for x in siteJobCounts.get(site, {}).items()])
-                        self.logger.debug("Job Count: %s, site: %s thresholds: %s" % (curJobCount, site, thresholds[site]))
+                        self.logger.debug(
+                            "Job Count: %s, site: %s thresholds: %s" % (curJobCount, site, thresholds[site]))
                         if curJobCount < thresholds[site]:
                             possibleSite = site
                             break
@@ -507,7 +508,8 @@ class WorkQueueBackend(object):
                     siteJobCounts[possibleSite][prio] = siteJobCounts[possibleSite].setdefault(prio, 0) + \
                                                         element['Jobs'] * element.get('blowupFactor', 1.0)
                 else:
-                    self.logger.debug("No available resources for %s with doc id %s", element['RequestName'], element.id)
+                    self.logger.debug("No available resources for %s with doc id %s",
+                                      element['RequestName'], element.id)
 
         self.logger.info("And %d elements passed location and siteJobCounts restrictions for: %s",
                          len(elements), self.queueUrl)
@@ -569,7 +571,7 @@ class WorkQueueBackend(object):
         result = set([x['key'] for x in self.db.loadView('WorkQueue', 'elementsByWorkflow', {'group': True})['rows']])
         if includeInbox:
             result = result | set(
-                [x['key'] for x in self.inbox.loadView('WorkQueue', 'elementsByWorkflow', {'group': True})['rows']])
+                    [x['key'] for x in self.inbox.loadView('WorkQueue', 'elementsByWorkflow', {'group': True})['rows']])
         if includeSpecs:
             result = result | set([x['key'] for x in self.db.loadView('WorkQueue', 'specsByWorkflow')['rows']])
         return list(result)


### PR DESCRIPTION
Fixes #10066 

#### Status
tested

#### Description
In very short, this fixes an issue where a low priority workflow doesn't manage to run, even though it's assigned to resources that have free resources in the agents.

In more details, this PR provides:
* clear distinction between fetching LQE to be processed from fetching LQE to calculate the resources available/allocated (freeResouceCheck + calculateAvailableWork)
* `calculateAvailableWork()` fetches all the local workqueue elements in a single call. Removed most of its logging and unneeded complexity
* `availableWork()` fetches global workqueue elements in slices of 1k elements, until all the elements have been exhausted, or until the component has accepted the configured number of elements (default=200). Example, if we have 2500 elements in Available status, we would:
  *) make first HTTP request and retrieve elements in the range of [0, 1000]
  *) then make another HTTP request and retrieve elements in the range of [1000, 2000]
  *) then make a third HTTP request and retrieve elements in the range of [2000, 3000] (actually [2000, 2500]
  *) and a final HTTP request is made, to retrieve elements in the range of [3000, 4000], which would return an empty list and exit the loop.

In addition to that:
* stop returning the threshold from `availableWork`, it is anyways unchanged between the method call and response
* removed unused `wfs` parameter from `availableWork` method
* log when an element is being accepted, and against which "site" it was (even though it can spawns jobs against multiple sites)
* rest of the logic is untouched, higher priority elements that have been created first, go first!

#### Is it backward compatible (if not, which system it affects?)
YES (but could be made incompatible with the javascript code...)

#### Related PRs
none

#### External dependencies / deployment changes
For reference, CouchDB documentation for couch views:
https://docs.couchdb.org/en/1.6.1/api/ddoc/views.html?highlight=views%20stale