### PR TITLE
Add zeroCounters() function.

### DIFF
--- a/src/python/WMCore/MicroService/Unified/MSRuleCleaner.py
+++ b/src/python/WMCore/MicroService/Unified/MSRuleCleaner.py
@@ -108,8 +108,14 @@ class MSRuleCleaner(MSCore):
         # Initialization of the 'cleaned' and 'archived' counters:
         self.wfCounters = {'cleaned': {},
                            'archived': 0}
+
+    def resetCounters(self):
+        """
+        A simple function for zeroing the cleaned and archived counters.
+        """
         for pline in self.cleanuplines:
             self.wfCounters['cleaned'][pline.name] = 0
+        self.wfCounters['archived'] = 0
 
     def execute(self, reqStatus):
         """
@@ -122,6 +128,7 @@ class MSRuleCleaner(MSCore):
         self.currThread = current_thread()
         self.currThreadIdent = self.currThread.name
         self.updateReportDict(summary, "thread_id", self.currThreadIdent)
+        self.resetCounters()
 
         self.logger.info("MSRuleCleaner is running in mode: %s.", self.mode)
 

--- a/test/python/WMCore_t/MicroService_t/Unified_t/MSRuleCleaner_t.py
+++ b/test/python/WMCore_t/MicroService_t/Unified_t/MSRuleCleaner_t.py
@@ -58,6 +58,7 @@ class MSRuleCleanerTest(unittest.TestCase):
 
         self.reqStatus = ['announced', 'aborted-completed', 'rejected']
         self.msRuleCleaner = MSRuleCleaner(self.msConfig)
+        self.msRuleCleaner.resetCounters()
         self.msRuleCleaner.rucio = Rucio.Rucio(self.msConfig['rucioAccount'],
                                                hostUrl=self.rucioConfigDict['rucio_host'],
                                                authUrl=self.rucioConfigDict['auth_host'],


### PR DESCRIPTION
Fixes #10078 

#### Status
ready

#### Description
The current change introduces  a simple function which should be called from the execute method so that the counters can be zeroed on every pulling cycle. 

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
NO

#### External dependencies / deployment changes
NO
