### PR TITLE
Update setup dependencies for CRAB services

### DIFF
--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -122,7 +122,6 @@ dependencies = {
     'asyncstageout': {
         'packages': ['WMCore.Agent+', 'WMCore.Storage+',
                      'WMCore.Credential', 'WMCore.WorkerThreads',
-                     'WMCore.ACDC',
                      'WMCore.Services+'],
         'modules': ['WMQuality.TestInitCouchApp', 'WMCore.Services.Service',
                     'WMCore.Services.pycurl_manager', 'WMComponent.__init__'],
@@ -136,22 +135,20 @@ dependencies = {
                     'WMCore.Services.pycurl_manager', ],
     },
     'crabserver': {
-        'packages': ['WMCore.Credential', 'WMCore.Services+',
-                     'WMCore.WMSpec+', 'WMCore.ACDC'],
+        'packages': ['WMCore.Credential', 'WMCore.Services+', 'WMCore.WMSpec+'],
         'modules': ['WMCore.DataStructs.LumiList'],
         'systems': ['wmc-rest', 'wmc-database'],
     },
     'crabclient': {
-        'packages': ['WMCore.Wrappers+', 'WMCore.Credential', 'PSetTweaks', 'WMCore.Services.UserFileCache+',
-                     'WMCore.Services.PhEDEx+', 'WMCore.Services.DBS+'],
+        'packages': ['WMCore.Wrappers+', 'WMCore.Credential', 'PSetTweaks',
+                     'WMCore.Services.UserFileCache+', 'WMCore.Services.DBS+'],
         'systems': ['wmc-base'],
         'modules': ['WMCore.FwkJobReport.FileInfo', 'WMCore.Services.Requests', 'WMCore.DataStructs.LumiList',
                     'WMCore.Services.Service', 'WMCore.Services.pycurl_manager', ],
     },
     'crabtaskworker': {
-        'packages': ['WMCore.WorkQueue', 'WMCore.Credential', 'WMCore.Algorithms+', 'WMCore.WMSpec+',
+        'packages': ['WMCore.Credential', 'WMCore.Algorithms+', 'WMCore.WMSpec+',
                      'WMCore.JobSplitting', 'WMCore.Services+', 'Utils+'],
-        'modules': ['WMCore.WMBS.File', 'WMCore.WMBS.WMBSBase', 'WMCore.WMBS.__init__'],
         'systems': ['wmc-database', 'wmc-runtime'],
     },
     'wmclient': {

--- a/test/python/WMCore_t/Services_t/pycurl_manager_t.py
+++ b/test/python/WMCore_t/Services_t/pycurl_manager_t.py
@@ -146,8 +146,9 @@ class PyCurlManager(unittest.TestCase):
         res = self.mgr.getheader(url, params=params, headers=headers, ckey=self.ckey, cert=self.cert)
         self.assertEqual(res.getReason(), "OK")
         self.assertTrue(len(res.getHeader()) > 10)
-        self.assertTrue(res.getHeaderKey("Server").startswith("CherryPy/"))
-
+        # Kubernetes cluster responds with a different Server header
+        serverHeader = res.getHeaderKey("Server")
+        self.assertTrue(serverHeader.startswith("CherryPy/") or serverHeader.startswith("openresty/"))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #10083 

#### Status
ready

#### Description
Remove no longer required dependencies for CRAB* services. Those dependencies are packaged when building the correspondent services.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
