### PR TITLE
Deprecate useRucio parameter within MicroServices; remove PhEDEx logic from MSOutput/MSMonitor

### DIFF
--- a/src/python/WMCore/MicroService/Unified/MSCore.py
+++ b/src/python/WMCore/MicroService/Unified/MSCore.py
@@ -9,7 +9,6 @@ from __future__ import division, print_function
 from WMCore.MicroService.Unified.Common import getMSLogger
 from WMCore.Services.ReqMgr.ReqMgr import ReqMgr
 from WMCore.Services.ReqMgrAux.ReqMgrAux import ReqMgrAux
-from WMCore.Services.PhEDEx.PhEDEx import PhEDEx
 from WMCore.Services.Rucio.Rucio import Rucio
 
 
@@ -29,7 +28,6 @@ class MSCore(object):
             skipReqMgr: boolean to skip ReqMgr initialization
             skipReqMgrAux: boolean to skip ReqMgrAux initialization
             skipRucio: boolean to skip Rucio initialization
-            skipPhEDEx: boolean to skip PhEDEx initialization
         """
         self.logger = getMSLogger(getattr(msConfig, 'verbose', False), kwargs.get("logger"))
         self.msConfig = msConfig
@@ -43,15 +41,11 @@ class MSCore(object):
 
         self.phedex = None
         self.rucio = None
-        if self.msConfig.get('useRucio', False) and not kwargs.get("skipRucio", False):
+        if not kwargs.get("skipRucio", False):
             self.rucio = Rucio(acct=self.msConfig['rucioAccount'],
                                hostUrl=self.msConfig['rucioUrl'],
                                authUrl=self.msConfig['rucioAuthUrl'],
                                configDict={"logger": self.logger, "user_agent": "wmcore-microservices"})
-        elif not kwargs.get("skipPhEDEx", False):
-            # hard code it to production DBS otherwise PhEDEx subscribe API fails to match TMDB data
-            dbsUrl = "https://cmsweb.cern.ch/dbs/prod/global/DBSReader"
-            self.phedex = PhEDEx(httpDict={'cacheduration': 0.5}, dbsUrl=dbsUrl, logger=self.logger)
 
     def unifiedConfig(self):
         """

--- a/src/python/WMCore/MicroService/Unified/MSManager.py
+++ b/src/python/WMCore/MicroService/Unified/MSManager.py
@@ -144,7 +144,6 @@ class MSManager(object):
 
         self.msConfig = {}
         self.msConfig.update(config.dictionary_())
-        self.msConfig.setdefault("useRucio", False)
 
         self.msConfig['reqmgrCacheUrl'] = self.msConfig['reqmgr2Url'].replace('reqmgr2',
                                                                               'couchdb/reqmgr_workload_cache')


### PR DESCRIPTION
Fixes #10093 
Fixes #10052
Fixes #9996

#### Status
not-tested

#### Description
As the title says, no longer verify which Data Management system to be used, Rucio becomes the only option now.
In addition to this, removed all the DDM/PhEDEx base code from the MicroServices (MSCore/MSMonitor/MSOutput).

#### Is it backward compatible (if not, which system it affects?)
no, in the sense of no longer supporting PhEDEx.

#### Related PRs
none

#### External dependencies / deployment changes
Deployment changes: https://github.com/dmwm/deployment/pull/991
