### PR TITLE
Reuse Rucio object in WorkQueue start policy modules; mock Rucio data

### DIFF
--- a/bin/wmagent-mod-config
+++ b/bin/wmagent-mod-config
@@ -243,6 +243,8 @@ def modifyConfiguration(config, **args):
         config.WorkQueueManager.queueParams['RequestDBURL'] = args["requestcouch_url"]
         config.WorkQueueManager.queueParams['central_logdb_url'] = config.General.central_logdb_url
         config.WorkQueueManager.queueParams['log_reporter'] = config.Agent.hostName
+        config.WorkQueueManager.rucioUrl = args["rucio_host"]
+        config.WorkQueueManager.rucioAuthUrl = args["rucio_auth"]
 
     # custom AnalyticsDataCollector
     if hasattr(config, "AnalyticsDataCollector"):

--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -128,6 +128,8 @@ config.WorkQueueManager.pollInterval = 180  # 3 min
 config.WorkQueueManager.couchurl = couchURL
 config.WorkQueueManager.dbname = workqueueDBName
 config.WorkQueueManager.inboxDatabase = workqueueInboxDbName
+config.WorkQueueManager.rucioUrl = "OVER_WRITE_BY_SECRETS"
+config.WorkQueueManager.rucioAuthUrl = "OVER_WRITE_BY_SECRETS"
 config.WorkQueueManager.queueParams = {}
 config.WorkQueueManager.queueParams["ParentQueueCouchUrl"] = "https://cmsweb.cern.ch/couchdb/workqueue"
 # this has to be unique for different work queue. This is just place holder

--- a/src/python/WMCore/GlobalWorkQueue/CherryPyThreads/CleanUpTask.py
+++ b/src/python/WMCore/GlobalWorkQueue/CherryPyThreads/CleanUpTask.py
@@ -9,6 +9,7 @@ class CleanUpTask(CherryPyPeriodicTask):
     def __init__(self, rest, config):
 
         super(CleanUpTask, self).__init__(config)
+        self.globalQ = globalQueue(logger=self.logger, **config.queueParams)
 
     def setConcurrentTasks(self, config):
         """
@@ -18,14 +19,11 @@ class CleanUpTask(CherryPyPeriodicTask):
 
     def cleanUpAndSyncCanceledElements(self, config):
         """
-
         1. deleted the wqe in end states
         2. synchronize cancelled elements.
         We can also make this in the separate thread
         """
-        start = int(time())
-        globalQ = globalQueue(**config.queueParams)
-        globalQ.performQueueCleanupActions(skipWMBS=True)
-        end = int(time())
-        self.logger.info("%s executed in %d secs.", self.__class__.__name__, end - start)
+        tStart = time()
+        self.globalQ.performQueueCleanupActions(skipWMBS=True)
+        self.logger.info("%s executed in %.3f secs.", self.__class__.__name__, time() - tStart)
         return

--- a/src/python/WMCore/GlobalWorkQueue/CherryPyThreads/LocationUpdateTask.py
+++ b/src/python/WMCore/GlobalWorkQueue/CherryPyThreads/LocationUpdateTask.py
@@ -8,6 +8,7 @@ class LocationUpdateTask(CherryPyPeriodicTask):
     def __init__(self, rest, config):
 
         super(LocationUpdateTask, self).__init__(config)
+        self.globalQ = globalQueue(logger=self.logger, **config.queueParams)
 
     def setConcurrentTasks(self, config):
         """
@@ -20,10 +21,8 @@ class LocationUpdateTask(CherryPyPeriodicTask):
         gather active data statistics
         """
         tStart = time()
-        globalQ = globalQueue(**config.queueParams)
-        res = globalQ.updateLocationInfo()
-        tEnd = time()
-        self.logger.info("LocationUpdateTask took %.3f secs and updated %d non-unique elements",
-                         tEnd - tStart, res)
+        res = self.globalQ.updateLocationInfo()
+        self.logger.info("%s executed in %.3f secs and updated %d non-unique elements",
+                         self.__class__.__name__, time() - tStart, res)
 
         return

--- a/src/python/WMCore/GlobalWorkQueue/CherryPyThreads/ReqMgrInteractionTask.py
+++ b/src/python/WMCore/GlobalWorkQueue/CherryPyThreads/ReqMgrInteractionTask.py
@@ -30,5 +30,6 @@ class ReqMgrInteractionTask(CherryPyPeriodicTask):
         tStart = time()
         self.logger.info("Executing WorkQueue/ReqMgr thread thread")
         self.reqMgrInt(self.globalQ)
-        self.logger.info("ReqMgrInteractionTask took %.3f secs to run.", time() - tStart)
+        self.logger.info("%s executed in %.3f secs.", self.__class__.__name__, time() - tStart)
+
         return

--- a/src/python/WMCore/GlobalWorkQueue/CherryPyThreads/ReqMgrInteractionTask.py
+++ b/src/python/WMCore/GlobalWorkQueue/CherryPyThreads/ReqMgrInteractionTask.py
@@ -1,14 +1,18 @@
 from __future__ import (division, print_function)
 
+from time import time
+
 from WMCore.REST.CherryPyPeriodicTask import CherryPyPeriodicTask
 from WMCore.WorkQueue.WorkQueue import globalQueue
 from WMCore.WorkQueue.WorkQueueReqMgrInterface import WorkQueueReqMgrInterface
 
+
 class ReqMgrInteractionTask(CherryPyPeriodicTask):
 
     def __init__(self, rest, config):
-
         super(ReqMgrInteractionTask, self).__init__(config)
+        self.globalQ = globalQueue(logger=self.logger, **config.queueParams)
+        self.reqMgrInt = WorkQueueReqMgrInterface(logger=self.logger, **config.reqMgrConfig)
 
     def setConcurrentTasks(self, config):
         """
@@ -18,15 +22,13 @@ class ReqMgrInteractionTask(CherryPyPeriodicTask):
 
     def interactWithReqmgr(self, config):
         """
-
         1. pull new work
         2. add the new element from running-open request
         3. report element status to reqmgr (need to be removed and set as reqmgr task)
         4. record this activity
         """
-
-        globalQ = globalQueue(**config.queueParams)
-        reqMgrInt = WorkQueueReqMgrInterface(**config.reqMgrConfig)
-        reqMgrInt(globalQ)
-
+        tStart = time()
+        self.logger.info("Executing WorkQueue/ReqMgr thread thread")
+        self.reqMgrInt(self.globalQ)
+        self.logger.info("ReqMgrInteractionTask took %.3f secs to run.", time() - tStart)
         return

--- a/src/python/WMCore/WorkQueue/Policy/Start/__init__.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/__init__.py
@@ -9,7 +9,7 @@ from WMCore.WMFactory import WMFactory
 startFac = WMFactory(__name__, __name__)
 
 
-def startPolicy(name, startMap, rucioAcct, logger=None):
+def startPolicy(name, startMap, rucioObj, logger=None):
     """Load a start policy"""
     # Take splitting policy from workload & load specific policy for this queue
     # Workload may also directly specify specific splitter implementation
@@ -23,7 +23,7 @@ def startPolicy(name, startMap, rucioAcct, logger=None):
         args = deepcopy(startMap[name]['args'])
     except IndexError:
         args = {}
-    args['rucioAcct'] = rucioAcct
+    args['rucioObject'] = rucioObj
     args['logger'] = logger
     return startFac.loadObject(policyName,
                                args,

--- a/src/python/WMCore/WorkQueue/WorkQueueUtils.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueUtils.py
@@ -89,6 +89,12 @@ def queueConfigFromConfigObject(config):
         wqManager.queueParams = {}
     qConfig = wqManager.queueParams
 
+    # Rucio-related config
+    if hasattr(wqManager, 'rucioUrl'):
+        qConfig['rucioUrl'] = wqManager.rucioUrl
+    if hasattr(wqManager, 'rucioAuthUrl'):
+        qConfig['rucioAuthUrl'] = wqManager.rucioAuthUrl
+
     if hasattr(wqManager, 'couchurl'):
         qConfig['CouchUrl'] = wqManager.couchurl
     if hasattr(wqManager, 'dbname'):

--- a/src/python/WMQuality/Emulators/EmulatedUnitTestCase.py
+++ b/src/python/WMQuality/Emulators/EmulatedUnitTestCase.py
@@ -19,6 +19,7 @@ from WMQuality.Emulators.PhEDExClient.MockPhEDExApi import MockPhEDExApi
 from WMQuality.Emulators.PyCondorAPI.MockPyCondorAPI import MockPyCondorAPI
 from WMQuality.Emulators.ReqMgrAux.MockReqMgrAux import MockReqMgrAux
 from WMQuality.Emulators.SiteDBClient.MockSiteDBApi import mockGetJSON
+from WMQuality.Emulators.RucioClient.MockRucioApi import MockRucioApi
 
 
 class EmulatedUnitTestCase(unittest.TestCase):
@@ -30,7 +31,7 @@ class EmulatedUnitTestCase(unittest.TestCase):
     def __init__(self, methodName='runTest', mockDBS=True, mockPhEDEx=True,
                  mockSiteDB=True, mockReqMgrAux=True, mockLogDB=True,
                  mockApMon=True, mockMemoryCache=True, mockPyCondor=True,
-                 mockCRIC=True):
+                 mockCRIC=True, mockRucio=True):
         self.mockDBS = mockDBS
         self.mockPhEDEx = mockPhEDEx
         self.mockSiteDB = mockSiteDB
@@ -40,6 +41,7 @@ class EmulatedUnitTestCase(unittest.TestCase):
         self.mockMemoryCache = mockMemoryCache
         self.mockPyCondor = mockPyCondor
         self.mockCRIC = mockCRIC
+        self.mockRucio = mockRucio
         super(EmulatedUnitTestCase, self).__init__(methodName)
 
     def setUp(self):
@@ -69,6 +71,16 @@ class EmulatedUnitTestCase(unittest.TestCase):
                 self.phedexPatchers.append(mock.patch(module, new=MockPhEDExApi))
                 self.phedexPatchers[-1].start()
                 self.addCleanup(self.phedexPatchers[-1].stop)
+
+        if self.mockRucio:
+            self.rucioPatchers = []
+            patchRucioAt = ['WMCore.WorkQueue.WorkQueue.Rucio',
+                            'WMCore.WorkQueue.WorkQueueReqMgrInterface.Rucio',
+                            'WMCore.WorkQueue.Policy.Start.StartPolicyInterface.Rucio']
+            for module in patchRucioAt:
+                self.rucioPatchers.append(mock.patch(module, new=MockRucioApi))
+                self.rucioPatchers[-1].start()
+                self.addCleanup(self.rucioPatchers[-1].stop)
 
         if self.mockSiteDB:
             self.siteDBPatcher = mock.patch.object(SiteDBAPI, 'getJSON', new=mockGetJSON)

--- a/src/python/WMQuality/Emulators/EmulatedUnitTestCase.py
+++ b/src/python/WMQuality/Emulators/EmulatedUnitTestCase.py
@@ -64,7 +64,6 @@ class EmulatedUnitTestCase(unittest.TestCase):
             self.phedexPatchers = []
             patchPhedexAt = ['WMCore.Services.PhEDEx.PhEDEx.PhEDEx',
                              'WMCore.WorkQueue.WorkQueue.PhEDEx',
-                             'WMCore.WorkQueue.Policy.Start.StartPolicyInterface.PhEDEx',
                              'WMComponent.PhEDExInjector.PhEDExInjectorPoller.PhEDEx']
             for module in patchPhedexAt:
                 self.phedexPatchers.append(mock.patch(module, new=MockPhEDExApi))

--- a/src/python/WMQuality/Emulators/RucioClient/MockRucioApi.py
+++ b/src/python/WMQuality/Emulators/RucioClient/MockRucioApi.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Version of WMCore/Services/Rucio intended to be used with mock or unittest.mock
+"""
+from __future__ import print_function, division
+
+from RestClient.ErrorHandling.RestClientExceptions import HTTPError
+
+from WMCore.Services.DBS.DBS3Reader import DBS3Reader, DBSReaderError
+from WMCore.Services.Rucio.Rucio import WMRucioException, WMRucioDIDNotFoundException
+from WMQuality.Emulators.DataBlockGenerator.DataBlockGenerator import DataBlockGenerator
+
+PROD_DBS = 'https://cmsweb.cern.ch/dbs/prod/global/DBSReader'
+
+NOT_EXIST_DATASET = 'thisdoesntexist'
+PILEUP_DATASET = '/HighPileUp/Run2011A-v1/RAW'
+
+SITES = ['T2_XX_SiteA', 'T2_XX_SiteB', 'T2_XX_SiteC']
+_BLOCK_LOCATIONS = {}
+
+BLOCKS_PER_DATASET = 2
+FILES_PER_BLOCK = 5
+FILES_PER_DATASET = BLOCKS_PER_DATASET * FILES_PER_BLOCK
+
+MOCK_DATA = {}
+
+
+class MockRucioApi(object):
+    """
+    Version of WMCore/Services/Rucio intended to be used with mock or unittest.mock
+    """
+
+    def __init__(self, acct, hostUrl=None, authUrl=None, configDict=None):
+        print("Using MockRucioApi: acct={}, url={}, authUrl={}".format(acct, hostUrl, authUrl))
+        configDict = configDict or {}
+        self.dataBlocks = DataBlockGenerator()
+        self.subRequests = {}
+
+    def sitesByBlock(self, block):
+        """
+        Centralize the algorithm to decide where a block is based on the hash name
+        :param block: the name of the block
+        :return: a fake list of sites where the data is
+        """
+        if hash(block) % 3 == 0:
+            sites = ['T2_XX_SiteA']
+        elif hash(block) % 3 == 1:
+            sites = ['T2_XX_SiteA', 'T2_XX_SiteB']
+        else:
+            sites = ['T2_XX_SiteA', 'T2_XX_SiteB', 'T2_XX_SiteC']
+        return sites
+
+    # TODO: not sure this wrapper is actually needed
+    def __getattr__(self, item):
+        """
+        __getattr__ gets called in case lookup of the actual method fails. We use this to return data based on
+        a lookup table
+
+        :param item: The method name the user is trying to call
+        :return: The generic lookup function
+        """
+
+        def genericLookup(*args, **kwargs):
+            """
+            This function returns the mocked DBS data
+
+            :param args: positional arguments it was called with
+            :param kwargs: named arguments it was called with
+            :return: the dictionary that DBS would have returned
+            """
+
+            if kwargs:
+                signature = '%s:%s' % (item, sorted(kwargs.items()))
+            else:
+                signature = item
+
+            try:
+                if MOCK_DATA[self.url][signature] == 'Raises HTTPError':
+                    raise HTTPError
+                else:
+                    return MOCK_DATA[self.url][signature]
+            except KeyError:
+                raise KeyError("Rucio mock API could not return data for method %s, args=%s, and kwargs=%s (URL %s)." %
+                               (item, args, kwargs, self.url))
+
+        return genericLookup
+
+    def getDataLockedAndAvailable(self, **kwargs):
+        """
+        Mock the method to discover where data is locked and available.
+        Note that, by default, it will not return any Tape RSEs.
+        :return: a unique list of RSEs
+        """
+        if 'name' not in kwargs:
+            raise WMRucioException("A DID name must be provided to the getBlockLockedAndAvailable API")
+        if self.isContainer(kwargs['name']):
+            # then resolve it at container level and all its blocks
+            return self.getContainerLockedAndAvailable(**kwargs)
+
+        if 'grouping' in kwargs:
+            # long strings seem not to be working, like ALL / DATASET. Make it short!
+            kwargs['grouping'] = kwargs['grouping'][0]
+        # TODO: either grouping or returnTape should change this response...
+        returnTape = kwargs.pop("returnTape", False)
+
+        rses = set()
+        if kwargs['name'].split('#')[0] == PILEUP_DATASET:
+            # Pileup is at a single site
+            sites = ['T2_XX_SiteC']
+            _BLOCK_LOCATIONS[kwargs['name']] = sites
+        else:
+            sites = self.sitesByBlock(block=kwargs['name'])
+            _BLOCK_LOCATIONS[kwargs['name']] = sites
+        rses.update(sites)
+        return list(rses)
+
+
+    def getContainerLockedAndAvailable(self, **kwargs):
+        """
+        Mock the method to discover where container data is locked and available.
+        Note that, by default, it will not return any Tape RSEs.
+        :return: a unique list of RSEs
+        """
+        if 'name' not in kwargs:
+            raise WMRucioException("A DID name must be provided to the getContainerLockedAndAvailable API")
+        kwargs.setdefault("scope", "cms")
+        if 'grouping' in kwargs:
+            # long strings seem not to be working, like ALL / DATASET. Make it short!
+            kwargs['grouping'] = kwargs['grouping'][0]
+        # TODO: either grouping or returnTape should change this response...
+        returnTape = kwargs.pop("returnTape", False)
+
+        if kwargs['name'] == PILEUP_DATASET:
+            return ['T2_XX_SiteA', 'T2_XX_SiteB', 'T2_XX_SiteC']
+        try:
+            DBS3Reader(PROD_DBS).checkDatasetPath(kwargs['name'])
+            blocks = DBS3Reader(PROD_DBS).dbs.listBlocks(dataset=kwargs['name'])
+            singleBlock = blocks[0]['block_name']
+            return self.sitesByBlock(singleBlock)
+        except DBSReaderError:
+            return []
+
+    def isContainer(self, didName, scope='cms'):
+        """
+        Checks whether the DID name corresponds to a container type or not.
+        :param didName: string with the DID name
+        :param scope: string containing the Rucio scope (defaults to 'cms')
+        :return: True if the DID is a container, else False
+        """
+        # TODO: figure use cases where we need to raise this exception
+        if didName == "a bad DID name yet to be defined":
+            msg = "Data identifier not found in MockRucio: {}".format(didName)
+            raise WMRucioDIDNotFoundException(msg)
+        return "#" not in didName

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
@@ -1264,7 +1264,7 @@ class WorkQueueTest(WorkQueueTestCase):
                          False)
 
         # close the global inbox elements, they won't be split anymore
-        self.globalQueue.closeWork('testProcessing', 'testProduction')
+        self.globalQueue.closeWork(['testProcessing', 'testProduction'])
         self.localQueue.getWMBSInjectionStatus()
         time.sleep(1)
         # There are too many jobs to pull down for testProcessing still has element not in WMBS


### PR DESCRIPTION
Fixes #9952 
Fixes #10166
Fixes https://github.com/dmwm/WMCore/issues/9072

#### Status
ready

#### Description
I started this PR with the intent to reuse Rucio objects, but it required several other changes and it became quite bigger.
Summary of changes is the following:
* 3rd commit provides a mocking module for Rucio, recycling the PhEDEx DataGenerator module. Note that we are not yet mocking all the Rucio calls in WMCore, but mostly those related to WorkQueue and StartPolicy;
* 2nd commit creates the Global WorkQueue instance at the thread creation, instead of every thread execution.
  * In addition to that, it is now supposed to use the correct logging file (logger object);
  * and it now passes the Rucio Url and Auth Url, such that we NO longer use what's set in the `rucio.cfg` file
* finally, 1st commit sets two new parameters for the `WorkQueueManager` configuration section, with the correct Rucio urls to be used for input data location.
  * use Rucio as a default DMS in the StartPolicyInterface (PhEDEx code dropped);
  * when calling the Start policy object factory, pass a Rucio instance as argument (to avoid its recreation);
  * pass the rucio object to many other methods, mostly called from different threads;
  * `WorkQueueUtils` will add the Rucio urls to the `queueParams`, during WorkQueue object creation;

Note: this PR should ensure that the same Rucio instance (WorkQueue -> self.rucio) is not going to be used by multiple threads, especially on the agent side. It should give preference to the object created within each thread.

#### Is it backward compatible (if not, which system it affects?)
yes, even though there is a new optional parameter

#### Related PRs
none

#### External dependencies / deployment changes
Deployment changes: https://github.com/dmwm/deployment/pull/1009
