### PR TITLE
Manage rule approval requirements for tape sites

### DIFF
--- a/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
+++ b/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
@@ -539,6 +539,16 @@ class RucioInjectorPoller(BaseWorkerThread):
             elif self.testRSEs:
                 rseName = "%s_Test" % rseName
 
+            #Checking whether we need to ask for rule approval
+            try:
+                if self.rucio.requiresApproval(rseName):
+                    ruleKwargs['ask_approval'] = True
+            except WMRucioException as exc:
+                msg = str(exc)
+                msg += "\nUnable to check approval requirements. Will retry again in the next cycle."
+                logging.error(msg)
+                continue
+
             logging.info("Creating container rule for %s against RSE %s", container, rseName)
             logging.debug("Container rule will be created with keyword args: %s", ruleKwargs)
             try:

--- a/src/python/WMCore/Services/Rucio/Rucio.py
+++ b/src/python/WMCore/Services/Rucio/Rucio.py
@@ -13,7 +13,7 @@ from copy import deepcopy
 from rucio.client import Client
 from rucio.common.exception import (AccountNotFound, DataIdentifierNotFound, AccessDenied, DuplicateRule,
                                     DataIdentifierAlreadyExists, DuplicateContent, InvalidRSEExpression,
-                                    UnsupportedOperation, FileAlreadyExists, RuleNotFound)
+                                    UnsupportedOperation, FileAlreadyExists, RuleNotFound, RSENotFound)
 from Utils.MemoryCache import MemoryCache
 from WMCore.WMException import WMException
 
@@ -788,6 +788,22 @@ class Rucio(object):
 
         choice = weightedChoice(rsesWithWeights)
         return choice
+
+    def requiresApproval(self, rse):
+        """
+        _requiresApproval_
+
+        Returns wether or not the specified RSE requires rule approval.
+        :param res: string containing the Rucio RSE name
+        :returns: True if the RSE requires approval to write (rule property)
+        """
+        try:
+            attrs = self.cli.list_rse_attributes(rse)
+        except RSENotFound as exc:
+            msg = "Error retrieving attributes for RSE: {}. Error: {}".format(rse, str(exc))
+            raise WMRucioException(msg)
+        return attrs.get('requires_approval', False)
+
 
     def isContainer(self, didName, scope='cms'):
         """

--- a/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
+++ b/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
@@ -439,6 +439,15 @@ class RucioTest(EmulatedUnitTestCase):
         self.assertTrue(len(resp) == 2)
         self.assertTrue(resp[1] is True or resp[1] is False)
 
+    def testRequiresApproval(self):
+        """
+        Test the `pickRSE` method
+        """
+        resp = self.myRucio.requiresApproval("T1_UK_RAL_Tape_Test")
+        self.assertTrue(resp)
+        resp = self.myRucio.requiresApproval("T1_FR_CCIN2P3_Tape_Test")
+        self.assertFalse(resp)
+
     def testIsTapeRSE(self):
         """
         Test the `isTapeRSE` utilitarian function


### PR DESCRIPTION
Fixes #10104 

#### Status
ready

#### Description
Adds requireApproval method to Rucio wrapper. This method returns whether a site needs rule approval according to site attributes. RucioInjector uses this new method during the container rule creation process to add the --ask-approval flag to according to site needs.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Builds upon #10006 

#### External dependencies / deployment changes

