### PR TITLE
Add MSRuleCleanerStandalone.py

### DIFF
--- a/bin/adhoc-scripts/MSRuleCleanerStandalone.py
+++ b/bin/adhoc-scripts/MSRuleCleanerStandalone.py
@@ -89,7 +89,7 @@ argParser.add_argument('-st', '--reqStatus',
                        default=[])
 
 argParser.add_argument('-erm', '--enableRealMode',
-                       type=bool,
+                       action='store_true',
                        required=False,
                        help="Enable RealRun mode",
                        dest='enableRealMode',

--- a/bin/adhoc-scripts/MSRuleCleanerStandalone.py
+++ b/bin/adhoc-scripts/MSRuleCleanerStandalone.py
@@ -1,7 +1,10 @@
+#!/usr/bin/python
+
 import sys
 import os
 import time
 import logging
+import argparse
 
 from pprint import pformat
 from itertools import izip
@@ -13,68 +16,158 @@ FORMAT = "%(asctime)s:%(levelname)s:%(module)s:%(funcName)s(): %(message)s"
 logging.basicConfig(stream=sys.stdout, format=FORMAT, level=logging.DEBUG)
 logger = logging.getLogger()
 
+# Default values:
+defaults = {'StartTimeStr': "Jun 9 00:00:00 2020",
+            'EndTimeStr': "Nov 25 00:00:00 2020",
+            'CentServices': "https://cmsweb-testbed.cern.ch",
+            'RucioMStrAccount': "wmcore_transferor",
+            'RucioWmaAccount': "wma_test",
+            'RucioUrl': 'http://cmsrucio-int.cern.ch',
+            'RucioAuthUrl': 'https://cmsrucio-auth-int.cern.ch',
+            'ReqStatus': ['aborted-archived',
+                          'rejected-archived',
+                          'normal-archived'],
+            'EnableRealMode': False}
+
+# Parse command line arguments:
+argParser = argparse.ArgumentParser()
+argParser.add_argument('-s', '--startTime',
+                       type=str,
+                       required=False,
+                       help="Start time for building the CouchDB view.",
+                       dest='startTimeStr',
+                       default=defaults['StartTimeStr'])
+
+argParser.add_argument('-e', '--endTime',
+                       type=str,
+                       required=False,
+                       help="End time for building the CouchDB view.",
+                       dest='endTimeStr',
+                       default=defaults['EndTimeStr'])
+
+argParser.add_argument('-c', '--centServices',
+                       type=str,
+                       required=False,
+                       help="Url to central services instance.",
+                       dest='centServices',
+                       default=defaults['CentServices'])
+
+argParser.add_argument('-rt', '--rucioMSTrAccount',
+                       type=str,
+                       required=False,
+                       help="Rucio MSTransferror account.",
+                       dest='rucioMStrAccount',
+                       default=defaults['RucioMStrAccount'])
+
+argParser.add_argument('-rw', '--rucioWmaAccount',
+                       type=str,
+                       required=False,
+                       help="Rucio WMAgent account.",
+                       dest='rucioWmaAccount',
+                       default=defaults['RucioWmaAccount'])
+
+argParser.add_argument('-ru', '--rucioUrl',
+                       type=str,
+                       required=False,
+                       help="Rucio URL.",
+                       dest='rucioUrl',
+                       default=defaults['RucioUrl'])
+
+argParser.add_argument('-ra', '--rucioAuthUrl',
+                       type=str,
+                       required=False,
+                       help="Rucio Authentication URL.",
+                       dest='rucioAuthUrl',
+                       default=defaults['RucioAuthUrl'])
+
+argParser.add_argument('-st', '--reqStatus',
+                       type=str,
+                       required=False,
+                       action='append',
+                       help="Request statuses to be worked on. (Needs to be called multiple times in order to build a list of statuses to be worked on).",
+                       dest='reqStatus',
+                       default=[])
+
+argParser.add_argument('-erm', '--enableRealMode',
+                       type=bool,
+                       required=False,
+                       help="Enable RealRun mode",
+                       dest='enableRealMode',
+                       default=defaults['EnableRealMode'])
+
+args = argParser.parse_args()
+
+# Fix forced empty list for reqStatus default value
+if not args.reqStatus:
+    for status in defaults['ReqStatus']:
+        argParser.parse_args(args=["--reqStatus", status], namespace=args)
+
+logger.info("args: %s", pformat(args))
+
 # Service config
-msConfig = {"enableRealMode": False,
+msConfig = {"enableRealMode": args.enableRealMode,
             "verbose": True,
             "interval": 1 *60,
             "services": ['ruleCleaner'],
-            "rucioWmaAcct": "wma_test",
-            "rucioMStrAccount": "wmcore_transferor",
+            "rucioWmaAccount": args.rucioWmaAccount,
+            "rucioMStrAccount": args.rucioMStrAccount,
             "useRucio": True,
-            "rucioAccount": "wma_test",
-            'reqmgr2Url': 'https://cmsweb-testbed.cern.ch/reqmgr2',
-            'MSOutputUrl': 'https://cmsweb-testbed.cern.ch/ms-output',
-            'reqmgrCacheUrl': 'https://cmsweb-testbed.cern.ch/couchdb/reqmgr_workload_cache',
-            'phedexUrl': 'https://cmsweb-testbed.cern.ch/phedex/datasvc/json/prod',
-            'dbsUrl': 'https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader',
-            'couchDBUrl': 'https://cmsweb-testbed.cern.ch/couchdb',
-            'rucioUrl': 'http://cmsrucio-int.cern.ch',
-            'rucioAuthUrl': 'https://cmsrucio-auth-int.cern.ch'}
+            "rucioAccount": args.rucioMStrAccount,
+            'reqmgr2Url': args.centServices + '/reqmgr2',
+            'MSOutputUrl': args.centServices + '/ms-output',
+            'reqmgrCacheUrl': args.centServices + '/couchdb/reqmgr_workload_cache',
+            'couchDBUrl': args.centServices + '/couchdb',
+            'rucioUrl': args.rucioUrl,
+            'rucioAuthUrl': args.rucioAuthUrl}
 
-# https://cmsweb-testbed.cern.ch/couchdb/reqmgr_workload_cache/_design/ReqMgr/_view/bystatusandtime?descending=false&startkey=%5B%22aborted-archived%22,1588338001%5D&endkey=%5B%22aborted-archived%22,1606224631%5D
 
-couchDB = CouchDB(dbname='reqmgr_workload_cache',
-                  url=msConfig['couchDBUrl'],
-                  size=100000,
-                  ckey=os.getenv("X509_USER_KEY", "Unknown"),
-                  cert=os.getenv("X509_USER_CERT", "Unknown"))
-timeFormat = "%b %d %H:%M:%S %Y"
-startTimeStr = "Jun 9 00:00:00 2020"
-endTimeStr = "Nov 25 00:00:00 2020"
-startTime = time.strptime(startTimeStr, timeFormat)
-endTime = time.strptime(endTimeStr, timeFormat)
-startTimeSec = int(time.mktime(startTime))
-endTimeSec = int(time.mktime(endTime))
-logger.info("\nstartTimeStr: %s\nstartTime: %s\nstartTimeSec: %s",
-            startTimeStr, startTime, startTimeSec)
-logger.info("\nendTimeStr: %s\nendTime: %s\nendTimeSec: %s",
-            endTimeStr, endTime, endTimeSec)
-reqStatus = ['aborted-archived', 'rejected-archived', 'normal-archived']
-try:
-    reqNames = []
-    reqList = []
-    reqRecords = {}
-    for status in reqStatus:
-        logger.info("Fetching requests in status: %s", status)
-        design = 'ReqMgr'
-        view = 'bystatusandtime?descending=false'
-        view += '&startkey=["%s",%s]' % (status, startTimeSec)
-        view += '&endkey=["%s",%s]' % (status, endTimeSec)
-        view += '&include_docs=true'
-        viewList = couchDB.loadView(design, view)['rows']
-        reqList.extend([req['doc'] for req in viewList])
-        reqNames.extend([req['id'] for req in viewList])
-        logger.info('  retrieved %s requests in status: %s', len(viewList), status)
-    logger.info("Building the final list of request records.")
-    logger.info("Requests retrieved in total: %s", len(reqNames))
-    reqRecords.update(dict(izip(reqNames, reqList)))
-    # logger.debug("reqRecords: %s", pformat(reqRecords))
-except Exception as err:  # general error
-    msg = "Unknown exception while fetching requests from ReqMgr2. Error: %s", str(err)
-    logger.exception(msg)
+def main():
+    # https://cmsweb-testbed.cern.ch/couchdb/reqmgr_workload_cache/_design/ReqMgr/_view/bystatusandtime?descending=false&startkey=%5B%22aborted-archived%22,1588338001%5D&endkey=%5B%22aborted-archived%22,1606224631%5D
 
-logger.info("################################################################")
-msRuleCleaner = MSRuleCleaner(msConfig)
-msRuleCleaner.resetCounters()
-result = msRuleCleaner._execute(reqRecords)
-logger.info('Execute result: %s', pformat(result))
+    couchDB = CouchDB(dbname='reqmgr_workload_cache',
+                      url=msConfig['couchDBUrl'],
+                      size=100000,
+                      ckey=os.getenv("X509_USER_KEY", "Unknown"),
+                      cert=os.getenv("X509_USER_CERT", "Unknown"))
+    timeFormat = "%b %d %H:%M:%S %Y"
+    startTime = time.strptime(args.startTimeStr, timeFormat)
+    endTime = time.strptime(args.endTimeStr, timeFormat)
+    startTimeSec = int(time.mktime(startTime))
+    endTimeSec = int(time.mktime(endTime))
+    logger.info("\nstartTimeStr: %s\nstartTime: %s\nstartTimeSec: %s",
+                args.startTimeStr, startTime, startTimeSec)
+    logger.info("\nendTimeStr: %s\nendTime: %s\nendTimeSec: %s",
+                args.endTimeStr, endTime, endTimeSec)
+    reqStatus = args.reqStatus
+    try:
+        reqNames = []
+        reqList = []
+        reqRecords = {}
+        for status in reqStatus:
+            logger.info("Fetching requests in status: %s", status)
+            design = 'ReqMgr'
+            view = 'bystatusandtime?descending=false'
+            view += '&startkey=["%s",%s]' % (status, startTimeSec)
+            view += '&endkey=["%s",%s]' % (status, endTimeSec)
+            view += '&include_docs=true'
+            viewList = couchDB.loadView(design, view)['rows']
+            reqList.extend([req['doc'] for req in viewList])
+            reqNames.extend([req['id'] for req in viewList])
+            logger.info('  retrieved %s requests in status: %s', len(viewList), status)
+        logger.info("Building the final list of request records.")
+        logger.info("Requests retrieved in total: %s", len(reqNames))
+        reqRecords.update(dict(izip(reqNames, reqList)))
+        # logger.debug("reqRecords: %s", pformat(reqRecords))
+    except Exception as err:  # general error
+        msg = "Unknown exception while fetching requests from ReqMgr2. Error: %s", str(err)
+        logger.exception(msg)
+
+    logger.info("################################################################")
+    msRuleCleaner = MSRuleCleaner(msConfig)
+    msRuleCleaner.resetCounters()
+    result = msRuleCleaner._execute(reqRecords)
+    logger.info('Execute result: %s', pformat(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/adhoc-scripts/MSRuleCleanerStandalone.py
+++ b/bin/adhoc-scripts/MSRuleCleanerStandalone.py
@@ -1,0 +1,77 @@
+import sys
+import os
+import time
+import logging
+
+from pprint import pformat
+from itertools import izip
+
+from WMCore.MicroService.Unified.MSRuleCleaner import MSRuleCleaner
+from WMCore.Database.CMSCouch import Database as CouchDB
+
+FORMAT = "%(asctime)s:%(levelname)s:%(module)s:%(funcName)s(): %(message)s"
+logging.basicConfig(stream=sys.stdout, format=FORMAT, level=logging.DEBUG)
+logger = logging.getLogger()
+
+# Service config
+msConfig = {"enableRealMode": False,
+            "verbose": True,
+            "interval": 1 *60,
+            "services": ['ruleCleaner'],
+            "rucioWmaAcct": "wma_test",
+            "rucioMStrAccount": "wmcore_transferor",
+            "useRucio": True,
+            "rucioAccount": "wma_test",
+            'reqmgr2Url': 'https://cmsweb-testbed.cern.ch/reqmgr2',
+            'MSOutputUrl': 'https://cmsweb-testbed.cern.ch/ms-output',
+            'reqmgrCacheUrl': 'https://cmsweb-testbed.cern.ch/couchdb/reqmgr_workload_cache',
+            'phedexUrl': 'https://cmsweb-testbed.cern.ch/phedex/datasvc/json/prod',
+            'dbsUrl': 'https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader',
+            'couchDBUrl': 'https://cmsweb-testbed.cern.ch/couchdb',
+            'rucioUrl': 'http://cmsrucio-int.cern.ch',
+            'rucioAuthUrl': 'https://cmsrucio-auth-int.cern.ch'}
+
+# https://cmsweb-testbed.cern.ch/couchdb/reqmgr_workload_cache/_design/ReqMgr/_view/bystatusandtime?descending=false&startkey=%5B%22aborted-archived%22,1588338001%5D&endkey=%5B%22aborted-archived%22,1606224631%5D
+
+couchDB = CouchDB(dbname='reqmgr_workload_cache',
+                  url=msConfig['couchDBUrl'],
+                  size=100000,
+                  ckey=os.getenv("X509_USER_KEY", "Unknown"),
+                  cert=os.getenv("X509_USER_CERT", "Unknown"))
+timeFormat = "%b %d %H:%M:%S %Y"
+startTimeStr = "May 1 15:00:00 2020"
+endTimeStr = "Nov 24 14:30:31 2020"
+startTime = time.strptime(startTimeStr, timeFormat)
+endTime = time.strptime(endTimeStr, timeFormat)
+startTimeSec = int(time.mktime(startTime))
+endTimeSec = int(time.mktime(endTime))
+logger.info("\nstartTimeStr: %s\nstartTime: %s\nstartTimeSec: %s",
+            startTimeStr, startTime, startTimeSec)
+logger.info("\nendTimeStr: %s\nendTime: %s\nendTimeSec: %s",
+            endTimeStr, endTime, endTimeSec)
+reqStatus = ['aborted-archived', 'rejected-archived', 'normal-archived']
+try:
+    reqNames = []
+    reqList = []
+    reqRecords = {}
+    for status in reqStatus:
+        logger.info("Fetching requests in status: %s", status)
+        design = 'ReqMgr'
+        view = 'bystatusandtime?descending=false'
+        view += '&startkey=["%s",%s]' % (status, startTimeSec)
+        view += '&endkey=["%s",%s]' % (status, endTimeSec)
+        view += '&include_docs=true'
+        reqList.extend([req['doc'] for req in couchDB.loadView(design, view)['rows']])
+        reqNames.extend([req['RequestName'] for req in reqList])
+    logger.info("Building the final list of request records.")
+    reqRecords.update(dict(izip(reqNames, reqList)))
+    # logger.debug("reqRecords: %s", pformat(reqRecords))
+except Exception as err:  # general error
+    msg = "Unknown exception while fetching requests from ReqMgr2. Error: %s", str(err)
+    logger.exception(msg)
+
+logger.info("################################################################")
+msRuleCleaner = MSRuleCleaner(msConfig)
+msRuleCleaner.resetCounters()
+result = msRuleCleaner._execute(reqRecords)
+logger.info('Execute result: %s', pformat(result))

--- a/bin/adhoc-scripts/MSRuleCleanerStandalone.py
+++ b/bin/adhoc-scripts/MSRuleCleanerStandalone.py
@@ -39,8 +39,8 @@ couchDB = CouchDB(dbname='reqmgr_workload_cache',
                   ckey=os.getenv("X509_USER_KEY", "Unknown"),
                   cert=os.getenv("X509_USER_CERT", "Unknown"))
 timeFormat = "%b %d %H:%M:%S %Y"
-startTimeStr = "May 1 15:00:00 2020"
-endTimeStr = "Nov 24 14:30:31 2020"
+startTimeStr = "Jun 9 00:00:00 2020"
+endTimeStr = "Nov 25 00:00:00 2020"
 startTime = time.strptime(startTimeStr, timeFormat)
 endTime = time.strptime(endTimeStr, timeFormat)
 startTimeSec = int(time.mktime(startTime))
@@ -61,9 +61,12 @@ try:
         view += '&startkey=["%s",%s]' % (status, startTimeSec)
         view += '&endkey=["%s",%s]' % (status, endTimeSec)
         view += '&include_docs=true'
-        reqList.extend([req['doc'] for req in couchDB.loadView(design, view)['rows']])
-        reqNames.extend([req['RequestName'] for req in reqList])
+        viewList = couchDB.loadView(design, view)['rows']
+        reqList.extend([req['doc'] for req in viewList])
+        reqNames.extend([req['id'] for req in viewList])
+        logger.info('  retrieved %s requests in status: %s', len(viewList), status)
     logger.info("Building the final list of request records.")
+    logger.info("Requests retrieved in total: %s", len(reqNames))
     reqRecords.update(dict(izip(reqNames, reqList)))
     # logger.debug("reqRecords: %s", pformat(reqRecords))
 except Exception as err:  # general error

--- a/bin/adhoc-scripts/MSRuleCleanerStandalone.py
+++ b/bin/adhoc-scripts/MSRuleCleanerStandalone.py
@@ -17,8 +17,8 @@ logging.basicConfig(stream=sys.stdout, format=FORMAT, level=logging.DEBUG)
 logger = logging.getLogger()
 
 # Default values:
-defaults = {'StartTimeStr': "Jun 9 00:00:00 2020",
-            'EndTimeStr': "Nov 25 00:00:00 2020",
+defaults = {'StartTimeStr': "Jun-9-00:00:00-2020",
+            'EndTimeStr': "Nov-25-00:00:00-2020",
             'CentServices': "https://cmsweb-testbed.cern.ch",
             'RucioMStrAccount': "wmcore_transferor",
             'RucioWmaAccount': "wma_test",
@@ -129,7 +129,7 @@ def main():
                       size=100000,
                       ckey=os.getenv("X509_USER_KEY", "Unknown"),
                       cert=os.getenv("X509_USER_CERT", "Unknown"))
-    timeFormat = "%b %d %H:%M:%S %Y"
+    timeFormat = "%b-%d-%H:%M:%S-%Y"
     startTime = time.strptime(args.startTimeStr, timeFormat)
     endTime = time.strptime(args.endTimeStr, timeFormat)
     startTimeSec = int(time.mktime(startTime))

--- a/src/python/WMCore/MicroService/Unified/MSRuleCleaner.py
+++ b/src/python/WMCore/MicroService/Unified/MSRuleCleaner.py
@@ -229,7 +229,7 @@ class MSRuleCleaner(MSCore):
             msg = "Skipping cleanup step for workflow: %s - RequestType is %s."
             msg += " Will try to archive it directly."
             self.logger.info(msg, wflow['RequestName'], wflow['RequestType'])
-        elif wflow['RequestStatus'] in ['rejected', 'aborted-completed']:
+        elif wflow['RequestStatus'] in ['rejected', 'aborted-completed', 'rejected-archived', 'aborted-archived']:
             # NOTE: We do not check the ParentageResolved flag for these
             #       workflows, but we do need to clean output data placement
             #       rules from the agents for them
@@ -243,19 +243,19 @@ class MSRuleCleaner(MSCore):
                     continue
                 if wflow['CleanupStatus'][pline.name]:
                     self.wfCounters['cleaned'][pline.name] += 1
-        elif wflow['RequestStatus'] == 'announced' and not wflow['ParentageResolved']:
+        elif wflow['RequestStatus'] in ['announced', 'normal-archived'] and not wflow['ParentageResolved']:
             # NOTE: We skip workflows which are not having 'ParentageResolved'
             #       flag, but we still need some proper logging for them.
             msg = "Skipping workflow: %s - 'ParentageResolved' flag set to false."
             msg += " Will retry again in the next cycle."
             self.logger.info(msg, wflow['RequestName'])
-        elif wflow['RequestStatus'] == 'announced' and not wflow['TransferDone']:
+        elif wflow['RequestStatus'] in ['announced', 'normal-archived'] and not wflow['TransferDone']:
             # NOTE: We skip workflows which have not yet finalised their TransferStatus
             #       in MSOutput, but we still need some proper logging for them.
             msg = "Skipping workflow: %s - 'TransferStatus' is 'pending' or 'TransferInfo' is missing in MSOutput."
             msg += " Will retry again in the next cycle."
             self.logger.info(msg, wflow['RequestName'])
-        elif wflow['RequestStatus'] == 'announced':
+        elif wflow['RequestStatus'] in ['announced', 'normal-archived']:
             for pline in self.cleanuplines:
                 try:
                     pline.run(wflow)

--- a/src/python/WMCore/MicroService/Unified/MSRuleCleaner.py
+++ b/src/python/WMCore/MicroService/Unified/MSRuleCleaner.py
@@ -242,6 +242,8 @@ class MSRuleCleaner(MSCore):
         #       in the logic of the _dispatcher() itself
         if wflow['RequestStatus'] == 'announced':
             self.getMSOutputTransferInfo(wflow)
+        elif wflow['RequestStatus'] == 'normal-archived':
+            wflow['TransferDone'] = True
 
         # Clean:
         # Do not clean any Resubmission, but still let them be archived


### PR DESCRIPTION
Fixes #10097 

#### Status
 ready

#### Description
Adds a new script which is supposed to be used for calling the MSRuleCleaner as a standalone executable in order to be used for cleaning all the old Rucio rules created by the agents during the transition period from Phedex to Rucio. We have  to fetch all the workflows in statuses `['abordet-archived', 'rejected-archived', 'normal-archived' ]`, and the list of workflows to work with needs to be build from the CouchDB views instead of reqmgr. We also need to add the equivalent `*-archived` statuses at the relevant places, so that the already existing logic in MSRulecleaner may cover the workflows which are already in archived state.  

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
NO

#### External dependencies / deployment changes
NO
