### PR TITLE
[py2py3] Migration at level scr/python/A/B/C - slice 3

### DIFF
--- a/src/python/WMComponent/AnalyticsDataCollector/DataCollectorEmulatorSwitch.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/DataCollectorEmulatorSwitch.py
@@ -1,6 +1,7 @@
 """
 Use this for only unit test
 """
+from builtins import object
 import os
 import sys
 import logging
@@ -78,7 +79,7 @@ def emulatorHook(cls):
     This is used as decorator to switch between Emulator and real Class
     on instance creation.
     """
-    class EmulatorWrapper:
+    class EmulatorWrapper(object):
         def __init__(self, *args, **kwargs):
             aClass = EmulatorHelper.getClass(cls)
             self.wrapped = aClass(*args, **kwargs)

--- a/src/python/WMComponent/AnalyticsDataCollector/DataCollectorEmulatorSwitch.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/DataCollectorEmulatorSwitch.py
@@ -2,11 +2,6 @@
 Use this for only unit test
 """
 from builtins import object
-import os
-import sys
-import logging
-
-from WMCore.Configuration import Configuration, saveConfigurationFile
 
 class EmulatorHelper(object):
     """

--- a/src/python/WMComponent/DBS3Buffer/DBSBufferBlock.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSBufferBlock.py
@@ -5,6 +5,7 @@ DBSBufferBlock
 This is a block object which will be uploaded to DBS
 """
 
+from builtins import object
 import time
 import logging
 import copy
@@ -24,7 +25,7 @@ class DBSBufferBlockException(WMException):
 
 
 
-class DBSBufferBlock:
+class DBSBufferBlock(object):
     """
     _DBSBufferBlock_
 
@@ -129,7 +130,7 @@ class DBSBufferBlock:
         fileDict['auto_cross_section'] = 0.0
 
         # Do the checksums
-        for cktype in dbsFile['checksums'].keys():
+        for cktype in dbsFile['checksums']:
             cksum = dbsFile['checksums'][cktype]
             if cktype.lower() == 'cksum':
                 fileDict['check_sum'] = cksum
@@ -455,14 +456,14 @@ class DBSBufferBlock:
         self.startTime = blockInfo.get('creation_date')
         self.inBuff    = True
 
-        if 'status' in blockInfo.keys():
+        if 'status' in blockInfo:
             self.status = blockInfo['status']
             if self.status == "Pending":
                 self.data['block']['open_for_writing'] = 0
 
             del blockInfo['status']
 
-        for key in blockInfo.keys():
+        for key in blockInfo:
             self.data['block'][key] = blockInfo.get(key)
 
     def convertToDBSBlock(self):
@@ -489,7 +490,7 @@ class DBSBufferBlock:
         for key in self.data:
             if key in keyToRemove:
                 continue
-            elif key in dbsBufferToDBSBlockKey.keys():
+            elif key in dbsBufferToDBSBlockKey:
                 block[dbsBufferToDBSBlockKey[key]] = copy.deepcopy(self.data[key])
             else:
                 block[key] = copy.deepcopy(self.data[key])

--- a/src/python/WMComponent/DBS3Buffer/DBSBufferBlock.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSBufferBlock.py
@@ -103,9 +103,9 @@ class DBSBufferBlock(object):
             msg =  "Duplicate file inserted into DBSBufferBlock: %i\n" % (dbsFile['id'])
             msg += "Ignoring this file for now!\n"
             logging.error(msg)
-            logging.debug("Block length: %i" % len(self.files))
+            logging.debug("Block length: %i", len(self.files))
             l = sorted([x['id'] for x in self.files])
-            logging.debug("First file: %s    Last file: %s" % (l[0], l[-1]))
+            logging.debug("First file: %s    Last file: %s", l[0], l[-1])
             return
 
         for setting in self.data['close_settings']:
@@ -299,7 +299,7 @@ class DBSBufferBlock(object):
 
         try:
             if datasetName[0] == '/':
-                junk, primary, processed, tier = datasetName.split('/')
+                _, primary, processed, tier = datasetName.split('/')
             else:
                 primary, processed, tier = datasetName.split('/')
         except Exception:

--- a/src/python/WMCore/Agent/Flow/Generate.py
+++ b/src/python/WMCore/Agent/Flow/Generate.py
@@ -13,6 +13,9 @@ from __future__ import print_function
 
 
 
+from builtins import str, object
+from future.utils import viewvalues
+
 import os
 import sys
 try:
@@ -23,7 +26,7 @@ except ImportError:
 from WMCore.Agent.Configuration import loadConfigurationFile
 
 
-class Generate:
+class Generate(object):
     """
     Generate
 
@@ -125,7 +128,7 @@ class %sTest(unittest.TestCase):
 if __name__ == '__main__':
     unittest.main()
 """
-        for componentName in self.components.keys():
+        for componentName in self.components:
             print('Creating test dir for:'+componentName)
             self.currentDir = os.path.join(self.config.General.testDir, \
                 componentName+'_t')
@@ -155,7 +158,7 @@ if __name__ == '__main__':
         with open(os.path.join(self.currentDir,'defaultTest.py'), 'w') as stfile:
             stfile.write("#!/usr/bin/env python\n")
             stfile.write("from WMQuality.Test import Test\n\n\n")
-            for componentName in self.components.keys():
+            for componentName in self.components:
                 msg = "from "+self.config.General.pythonTestPrefix+"."+componentName+'_t.'+componentName+'_t import '+componentName+'Test'
                 stfile.write(msg+'\n')
             stfile.write('\n\n\n')
@@ -190,7 +193,7 @@ test = Test(tests,'failures3.log')
 test.run()
 test.summaryText()
 """
-        for componentName in self.components.keys():
+        for componentName in self.components:
             stfile.write(msg1 % (componentName, componentName))
             stfile.write(msg2)
 
@@ -199,7 +202,7 @@ test.summaryText()
         Generates the component stubs.
         """
 
-        for componentName in self.components.keys():
+        for componentName in self.components:
             print('Creating component dir for:'+componentName)
             self.currentDir = os.path.join(self.config.General.srcDir, \
                 componentName)
@@ -216,7 +219,7 @@ test.summaryText()
             stfile.write("from WMCore.Agent.Harness import Harness\n\n")
             importFact = False
             try:
-                for handlerName in self.components[componentName].keys():
+                for handlerName in self.components[componentName]:
                     handler = self.components[componentName][handlerName]
                     if 'configurable' in handler and handler['configurable'] == 'yes':
                         if not importFact:
@@ -248,7 +251,7 @@ class %s(Harness):
                 stfile.write('        # use a factory to dynamically load handlers.\n')
                 stfile.write("        factory = WMFactory('generic')\n")
             try:
-                for handlerName in self.components[componentName].keys():
+                for handlerName in self.components[componentName]:
                     handler = self.components[componentName][handlerName]
                     if 'configurable' in handler and \
                         handler['configurable'] == 'yes':
@@ -293,14 +296,14 @@ config.%s.logLevel = "INFO"
         stfile.write(msg)
         # check if we need a thread parameter
         threadParam = False
-        for handler in self.components[componentName].values():
+        for handler in viewvalues(self.components[componentName]):
             if 'threading' in handler and handler['threading'] == 'yes':
                 threadParam = True
         if threadParam:
             stfile.write('# maximum number of threads we want to deal\n')
             stfile.write('# with messages per pool.\n')
             stfile.write('config.'+componentName+'.maxThreads = 30\n')
-        for handlerName in self.components[componentName].keys():
+        for handlerName in self.components[componentName]:
             handler = self.components[componentName][handlerName]
             if 'configurable' in handler and handler['configurable'] == 'yes':
                 stfile.write('config.'+componentName+'.'+self.convert(handlerName)+'Handler =\\\n')
@@ -322,7 +325,7 @@ config.%s.logLevel = "INFO"
             pass
         with open(os.path.join(handlerDir, '__init__.py'), 'w') as stfile:
             stfile.write('#!/usr/bin/env python\n')
-        for handlerName in self.components[componentName].keys():
+        for handlerName in self.components[componentName]:
             # check if we need to create a threaded version
             handler = self.components[componentName][handlerName]
             threaded = False

--- a/src/python/WMCore/REST/Main.py
+++ b/src/python/WMCore/REST/Main.py
@@ -6,8 +6,10 @@
 Manages a web server application. Loads configuration and all views, starting
 up an appropriately configured CherryPy instance. Views are loaded dynamically
 and can be turned on/off via configuration file."""
-from __future__ import print_function
 
+from __future__ import print_function
+from builtins import object
+from future.utils import viewitems
 from future import standard_library
 standard_library.install_aliases()
 
@@ -222,9 +224,9 @@ class RESTMain(object):
                         'server', 'tools', 'wsgi', 'checker'):
             if not hasattr(self.srvconfig, section):
                 continue
-            for opt, value in getattr(self.srvconfig, section).dictionary_().iteritems():
+            for opt, value in viewitems(getattr(self.srvconfig, section).dictionary_()):
                 if isinstance(value, ConfigSection):
-                    for xopt, xvalue in value.dictionary_().iteritems():
+                    for xopt, xvalue in viewitems(value.dictionary_()):
                         cpconfig.update({"%s.%s.%s" % (section, opt, xopt): xvalue})
                 elif isinstance(value, str) or isinstance(value, int):
                     cpconfig.update({"%s.%s" % (section, opt): value})

--- a/src/python/WMCore/Services/McM/McM.py
+++ b/src/python/WMCore/Services/McM/McM.py
@@ -5,6 +5,8 @@ A service class for retrieving data from McM using
 an SSO cookie since it sits behind CERN SSO
 """
 
+from builtins import str, object
+
 import json
 import os
 import pycurl

--- a/src/python/WMCore/Services/MonIT/Grafana.py
+++ b/src/python/WMCore/Services/MonIT/Grafana.py
@@ -5,6 +5,7 @@ Wrapper class, based on the PyCuRL module, providing an interface
 to CERN MonIT Grafana APIs
 """
 from __future__ import division, print_function, absolute_import
+from builtins import str, object
 from future import standard_library
 standard_library.install_aliases()
 

--- a/src/python/WMCore/WebTools/SecureDocumentation.py
+++ b/src/python/WMCore/WebTools/SecureDocumentation.py
@@ -1,3 +1,5 @@
+from future.utils import viewitems
+
 import cherrypy
 from os import listdir
 
@@ -26,7 +28,7 @@ class SecureDocumentation(TemplatedPage):
         index += "<li>Your <b>Authn Method</b>: %s</li>\n" % user['method']
         index += "<li>Your roles:\n"
         index += "<ul>\n"
-        for k, v in user['roles'].iteritems():
+        for k, v in viewitems(user['roles']):
             for t in ['group', 'site']:
                 for n in v[t]:
                     index += "<li><b>%s</b>: %s=%s</li>\n" % (k, t, n)

--- a/src/python/WMQuality/Emulators/AnalyticsDataCollector/DataCollectorAPI.py
+++ b/src/python/WMQuality/Emulators/AnalyticsDataCollector/DataCollectorAPI.py
@@ -3,6 +3,8 @@ Provide functions to collect data and upload data
 """
 from __future__ import print_function
 
+from builtins import range, object
+
 import logging
 
 from WMCore.Lexicon import splitCouchServiceURL
@@ -26,7 +28,7 @@ COUCH_JOB_STATUS = ['queued_first', 'queued_retry', 'cooloff', 'submitted_first'
 QUEUE_JOB_STATUS = ['inQueue', 'inWMBS']
 BATCH_JOB_STATUS = ['submitted_pending', 'submitted_running']
 
-class LocalCouchDBData():
+class LocalCouchDBData(object):
 
     def __init__(self, couchURL, statSummaryDB, summaryLevel, ):
         # set the connection for local couchDB call
@@ -80,7 +82,7 @@ class LocalCouchDBData():
         return {}
 
 
-class ReqMonDBData():
+class ReqMonDBData(object):
 
     def __init__(self, couchURL):
         # set the connection for local couchDB call
@@ -92,7 +94,7 @@ class ReqMonDBData():
         """
         return {'status':'ok'}
 
-class WMAgentDBData():
+class WMAgentDBData(object):
 
     def __init__(self, summaryLevel, dbi, logger):
 

--- a/src/python/WMQuality/WebTools/RESTClientAPI.py
+++ b/src/python/WMQuality/WebTools/RESTClientAPI.py
@@ -1,6 +1,8 @@
 from future import standard_library
 standard_library.install_aliases()
 
+from future.utils import viewitems
+
 import hashlib
 import hmac
 import urllib.parse
@@ -70,7 +72,7 @@ def methodTest(verb, url, request_input={}, accept='text/json', contentType=None
                                                      secure, secureParam)
 
     keyMap = {'code': code, 'data': data, 'type': content_type, 'response': response}
-    for key, value in output.items():
+    for key, value in viewitems(output):
         msg = 'Got a return %s != %s (got %s, type %s) (data %s, type %s)' \
               % (keyMap[key], value, keyMap[key], type(keyMap[key]), data, type(data))
         assert keyMap[key] == value, msg


### PR DESCRIPTION
Fixes #10114 

#### Status

Ready

#### Related PRs

This PR is rebased on `master`

* Previous migration PR: #10103 (slice2, issue #10098 ). 
* Next migration PR: #10165 (slice4, issue #10115 )

#### Description

This needs to be merged _after_ #10103 (slice2, issue #10098) , as it is rebased upon the branch used in that PR.

Run futurize and some manual changes on the first batch of src/python/A/B/C.

Notable changes: 
- `src/python/WMCore/REST/Format.py`
  * it uses xml.sax.saxutils [py2 doc](https://docs.python.org/2/library/xml.sax.utils.html) [py 3.8 doc](https://docs.python.org/3.8/library/xml.sax.utils.html), this requires some care with strings management
  * it uses `types.FileType`, which is not available in python3 anymore. Our solution is: instead of checking if `stream` is a file, we can check if `stream` has the desired property that we need. In this case, `stream` is passed as an argument to [cherrypy.lib.file_generator](https://github.com/cherrypy/cherrypy/blob/2a8aaccd649eb1011382c39f5cd93f76f980c0b1/cherrypy/lib/__init__.py#L64), which only uses `file.read()`, so instead of checking if `stream` is a file, we can check if `stream` as a `.read()` attribute. (suggestion from [stackoverflow](https://stackoverflow.com/a/59506892) )

- `src/python/WMCore/REST/Format.py`
  - some changes on how strings are handled was necessary. This can cause problems that are very hard to catch with jenkins CI only and will require extensive tests in testbed.

No changes to `test/python/*`

#### Is it backward compatible (if not, which system it affects?)

It should be. (Any possible cause for errors will we reported here)

#### Related PRs

This PR should be merged after #10098 

#### External dependencies / deployment changes

Requires python-future in both py2 and py3 environments.
