### PR TITLE
Add args for rucio get pfn

### DIFF
--- a/src/python/WMCore/Services/Rucio/Rucio.py
+++ b/src/python/WMCore/Services/Rucio/Rucio.py
@@ -282,7 +282,7 @@ class Rucio(object):
 
         return result
 
-    def getPFN(self, site, lfns, protocol=None, protocol_domain='All', operation=None):
+    def getPFN(self, site, lfns, protocol=None, protocol_domain='ALL', operation=None):
         """
         returns a list of PFN(s) for a list of LFN(s) and one site
         Note: same function implemented for PhEDEx accepted a list of sites, but semantic was obscure and actual need


### PR DESCRIPTION
Fixes #10056 (when applied to master branch as well)

#### Status
 ready

#### Description
introduce new optional parameters for Rucio.client.getPFN
to be able to use all functionalities of Rucio python lnfs2pfns API as per
https://rucio.readthedocs.io/en/latest/api/rse.html

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
will need to make a PR for Master branch as well, but I could only test in 1.3.6.crab

#### External dependencies / deployment changes
None
