### PR TITLE
Fix regexp for enable cherrypy threads && Fix file permissions for dmwm-service-key.pem

### DIFF
--- a/deploy/deploy-centralvm.sh
+++ b/deploy/deploy-centralvm.sh
@@ -186,8 +186,8 @@ enableCherrypy()
     read x && [[ $x =~ (n|N) ]] && exit 1
     echo  "..."
 
-    sed -i "s/or HOST.startswith(\"vocms0127\"):/or HOST.startswith(\"vocms0127\") or HOST.startswith(\"$vmName\"):/g" cfg/{reqmgr2,reqmon,workqueue}/config.py
-    grep 'HOST.startswith("vocms0127").*'  cfg/{reqmgr2,reqmon,workqueue}/config.py
+    sed -i "s/or HOST.startswith(\"vocms0117\"):/or HOST.startswith(\"vocms0117\") or HOST.startswith(\"$vmName\"):/g" cfg/{reqmgr2,reqmon,workqueue}/config.py
+    grep 'HOST.startswith("vocms0117").*'  cfg/{reqmgr2,reqmon,workqueue}/config.py
 }
 
 patchDep()
@@ -249,6 +249,9 @@ updateCert()
     sudo cp /data/auth/dmwm-service-key.pem /data/srv/current/auth/t0_reqmon/dmwm-service-key.pem
     sudo cp /data/auth/dmwm-service-key.pem /data/srv/current/auth/reqmgr2ms/dmwm-service-key.pem
     sudo chmod 440 /data/srv/current/auth/{reqmgr2,workqueue,acdcserver,reqmon,t0_reqmon,reqmgr2ms}/dmwm-service-{cert,key}.pem
+    sudo chmod 400 /data/srv/current/auth/{workqueue,reqmgr2ms}/dmwm-service-key.pem
+    sudo chown _reqmgr2ms:_config /data/srv/current/auth/reqmgr2ms/dmwm-service-key.pem
+    sudo chown _workqueue:_config /data/srv/current/auth/workqueue/dmwm-service-key.pem
 }
 
 patchService()


### PR DESCRIPTION
Fixes #10154 

#### Status
ready

#### Description
   * Fixes the Regular expression used to enable the cherrypy threads during the deployment procedure followed by the `deploy-centravm.sh` script
   * Fixes the file permissions for dmwm-service-key.pem - up to now we were able to use the 440 file permissions for the certificate key file and let the whole group woning the file to be able to read it. Now the permissions are fixed to be 400.

#### Is it backward compatible (if not, which system it affects?)
NO
You cannot deploy any tag prior to HG2012* using this version of the script.

#### Related PRs
NO

#### External dependencies / deployment changes
NO