### PR TITLE
[py2py3] Migration at level scr/python/A/B/C - slice 4

### DIFF
--- a/src/python/WMCore/REST/Test.py
+++ b/src/python/WMCore/REST/Test.py
@@ -1,3 +1,6 @@
+
+from future.utils import viewitems, viewvalues, listitems
+
 import os, hmac, hashlib, cherrypy
 from tempfile import NamedTemporaryFile
 from WMCore.REST.Main import RESTMain
@@ -30,7 +33,7 @@ def fake_authz_headers(hmac_key, method = 'HNLogin',
     if dn:
         headers['cms-authn-dn'] = dn
 
-    for name, role in roles.items():
+    for name, role in viewitems(roles):
         name = 'cms-authz-' + authz_canonical(name)
         headers[name] = []
         for r in 'site', 'group':
@@ -39,7 +42,7 @@ def fake_authz_headers(hmac_key, method = 'HNLogin',
         headers[name] = " ".join(headers[name])
 
     prefix = suffix = ""
-    hkeys = headers.keys()
+    hkeys = list(headers)
     for hk in sorted(hkeys):
         if hk != 'cms-auth-status':
             prefix += "h%xv%x" % (len(hk), len(headers[hk]))
@@ -48,7 +51,7 @@ def fake_authz_headers(hmac_key, method = 'HNLogin',
     cksum = hmac.new(hmac_key, prefix + "#" + suffix, hashlib.sha1).hexdigest()
     headers['cms-authn-hmac'] = cksum
     if format == "list":
-        return headers.items()
+        return listitems(headers)
     else:
         return headers
 
@@ -102,7 +105,7 @@ def setup_dummy_server(module_name, class_name, app_name = None, authz_key_file=
     cherrypy.config.update({'server.socket_host': '127.0.0.1'})
     cherrypy.config.update({'request.show_tracebacks': True})
     cherrypy.config.update({'environment': 'test_suite'})
-    for app in cherrypy.tree.apps.values():
+    for app in viewvalues(cherrypy.tree.apps): 
         if '/' in app.config:
             app.config["/"]["request.show_tracebacks"] = True
 

--- a/src/python/WMCore/Services/Service.py
+++ b/src/python/WMCore/Services/Service.py
@@ -48,6 +48,7 @@ service cache   |    no    |   yes    |   yes    |     no     |
 result          |  cached  |  cached  |  cached  | not cached |
 """
 
+from builtins import str
 from future import standard_library
 standard_library.install_aliases()
 
@@ -113,7 +114,7 @@ class Service(dict):
         cfg_dict = cfg_dict or {}
         # The following should read the configuration class
         for a in ['endpoint']:
-            assert a in cfg_dict.keys(), "Can't have a service without a %s" % a
+            assert a in list(cfg_dict), "Can't have a service without a %s" % a
 
         # if end point ends without '/', add that
         if not cfg_dict['endpoint'].endswith('/'):
@@ -293,14 +294,14 @@ class Service(dict):
                 # Don't need to prepend the cachepath, the methods calling
                 # getData have done that for us
                 if isfile(cachefile):
-                    cachefile.write(str(data))
+                    cachefile.write(data)
                     cachefile.seek(0, 0)  # return to beginning of file
                 else:
                     with open(cachefile, 'w') as f:
                         if isinstance(data, dict) or isinstance(data, list):
                             f.write(json.dumps(data))
                         else:
-                            f.write(str(data))
+                            f.write(data)
 
 
         except (IOError, HttpLib2Error, HTTPException) as he:

--- a/src/python/WMCore/Services/WMStatsServer/WMStatsServer.py
+++ b/src/python/WMCore/Services/WMStatsServer/WMStatsServer.py
@@ -1,3 +1,6 @@
+from builtins import str, bytes
+from future.utils import viewitems
+
 import json
 import logging
 
@@ -57,8 +60,8 @@ class WMStatsServer(Service):
         :returns: url query string
         """
         args = ""
-        for name, values in queryDict.items():
-            if isinstance(values, (basestring, int)):
+        for name, values in viewitems(queryDict):
+            if isinstance(values, (str, bytes, int)):
                 values = [values]
             for val in values:
                 args += '%s=%s&' % (name, val)

--- a/src/python/WMCore/Storage/SiteLocalConfig.py
+++ b/src/python/WMCore/Storage/SiteLocalConfig.py
@@ -8,6 +8,8 @@ into an object with an API for getting info from it.
 """
 
 
+from builtins import next, str, object
+
 import os
 import logging
 

--- a/src/python/WMCore/WMConnectionBase.py
+++ b/src/python/WMCore/WMConnectionBase.py
@@ -8,6 +8,7 @@ Generic methods used by all of the WMBS classes.
 
 
 
+from builtins import object
 import threading
 import copy
 
@@ -19,7 +20,7 @@ try:
 except (ImportError, NameError):
     pass
 
-class WMConnectionBase:
+class WMConnectionBase(object):
     """
     Generic db connection and transaction methods used by all of the WMCore classes.
     """

--- a/src/python/WMQuality/REST/ServerSetup.py
+++ b/src/python/WMQuality/REST/ServerSetup.py
@@ -1,3 +1,6 @@
+from builtins import object
+from future.utils import viewitems, viewvalues
+
 import os
 import cherrypy
 import logging
@@ -44,7 +47,7 @@ class RESTMainTestServer(object):
         cherrypy.config.update({'server.thread_pool': 10})
         cherrypy.config.update({'server.accepted_queue_size': -1})
         cherrypy.config.update({'server.accepted_queue_timeout': 10})
-        for app in cherrypy.tree.apps.values():
+        for app in viewvalues(cherrypy.tree.apps):
             if '/' in app.config:
                 app.config["/"]["request.show_tracebacks"] = True
 
@@ -62,7 +65,7 @@ class RESTMainTestServer(object):
         cherrypy.engine.stop()
 
         # Ensure the next server that's started gets fresh objects
-        for name, server in getattr(cherrypy, 'servers', {}).items():
+        for name, server in viewitems(getattr(cherrypy, 'servers', {})):
             server.unsubscribe()
             del cherrypy.servers[name]
 

--- a/test/python/WMCore_t/REST_t/Server_t.py
+++ b/test/python/WMCore_t/REST_t/Server_t.py
@@ -1,3 +1,4 @@
+from builtins import object
 from WMCore.REST.Server import RESTFrontPage
 from WMCore.REST.Server import MiniRESTApi
 from WMCore.REST.Server import RESTApi
@@ -9,10 +10,10 @@ import os, threading
 srcfile = os.path.abspath(__file__).rsplit("/", 1)[-1].split(".")[0]
 dbspec = {}
 
-class FakeApp:
+class FakeApp(object):
     appname = "app"
 
-class FakeConf:
+class FakeConf(object):
     db = srcfile + ".dbspec"
 
 RESTFrontPage(None, None, "/", "/dev/null", {})

--- a/test/python/WMCore_t/Services_t/Service_t.py
+++ b/test/python/WMCore_t/Services_t/Service_t.py
@@ -1,5 +1,6 @@
 """
 """
+from builtins import object
 from future import standard_library
 standard_library.install_aliases()
 

--- a/test/python/WMCore_t/Storage_t/SiteLocalConfig_t.py
+++ b/test/python/WMCore_t/Storage_t/SiteLocalConfig_t.py
@@ -38,7 +38,7 @@ class SiteLocalConfigTest(unittest.TestCase):
         mySiteConfig = SiteLocalConfig(fnalConfigFileName)
 
         assert mySiteConfig.siteName == "T1_US_FNAL", "Error: Wrong site name."
-        assert len(mySiteConfig.eventData.keys()) == 1, "Error: Wrong number of event data keys."
+        assert len(list(mySiteConfig.eventData)) == 1, "Error: Wrong number of event data keys."
         assert mySiteConfig.eventData["catalog"] == "trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/T1_US_FNAL_Disk/PhEDEx/storage.xml?protocol=fallbackxrd", \
                "Eroror: Event data catalog is wrong."
 
@@ -92,7 +92,7 @@ class SiteLocalConfigTest(unittest.TestCase):
         assert mySiteConfig.siteName == "T3_US_Vanderbilt", \
                "Error: Wrong site name."
 
-        assert len(mySiteConfig.eventData.keys()) == 1, \
+        assert len(list(mySiteConfig.eventData)) == 1, \
                "Error: Wrong number of event data keys."
         assert mySiteConfig.eventData["catalog"] == "trivialcatalog_file://gpfs1/grid/grid-app/cmssoft/cms/SITECONF/local/PhEDEx/storage.xml?protocol=direct", \
                "Eroror: Event data catalog is wrong."


### PR DESCRIPTION
Fixes #10115 

#### Status

In development 

#### Related PRs

This PR is rebased on `master`

* Previous migration PR: #10117 (slice3, issue #10114  ). 
* Next migration PR: #10262 (slice5, issue #10116 )

#### Description

Run futurize and some manual changes on the first batch of src/python/A/B/C.

##### Notable change to `src/python/WMCore/Services/Service.py`

Simply adding `from builtins import str` breaks some unit tests in `test/python/WMCore_t/Services_t/Service_t.py`.

In particular the problems arise from the following lines combined with `from builtins import str`:

* https://github.com/dmwm/WMCore/blob/2e11c4ba1c280e448895dc5141e5903b647bca10/src/python/WMCore/Services/Service.py#L296
* https://github.com/dmwm/WMCore/blob/2e11c4ba1c280e448895dc5141e5903b647bca10/src/python/WMCore/Services/Service.py#L303

If I do not import `from builtins import str`, then everything is fine.

I checked the type of `data` in the unit tests and it is always py2 `str` (this means that it is a string composed of a sequence bytes) when it is not a dict/list, so doing `str(a)` in py2 has no effect. 
When I import `from builtins import str` it tries to convert a py2 `str` (sequence of bytes) to a py3 `str` (sequence of unicode codepoints), and in case the string contains non-ascii characters this conversion breaks. 

If I remove the conversion, then the unit test in py2 passes again. This should be a suitable solution for both py2 and py3. 

Only partially related: we should follow [futurize guide](https://python-future.org/compatible_idioms.html#file-io-with-open) to open files in a way that is compatible with both py2 and py3. [EDIT]


#### Is it backward compatible (if not, which system it affects?)

It should be. (Any possible cause for errors will we reported here)

#### External dependencies / deployment changes

Requires python-future in both py2 and py3 environments.
