### PR TITLE
[py2py3] Apply changes from `pylint --py3k` to files involved in #9818

### DIFF
--- a/test/python/WMCore_t/WMException_py2py3_t.py
+++ b/test/python/WMCore_t/WMException_py2py3_t.py
@@ -72,7 +72,9 @@ class WMExceptionTest(unittest.TestCase):
         data['key1'] = 'value1'
         data['key2'] = 3.14159
         exception.addInfo(**data)
+        exception.addInfo(Protocol="myprotocol", LFN="lfn", TargetPFN="pfn")
         self.logger.debug("String version of exception: %s", str(exception))
+        self.logger.debug("XML version of exception: %s", exception.xml())
 
     def testExceptionUnicode0(self):
         """


### PR DESCRIPTION
Fixes #10167 

#### Status

ready

#### Related PRs

[EDIT]: since we are pushing #10187 forward, I would set this PR aside and close this without merging when we merge #10187

This PR should be merged **after** #10174 

This is a follow-up of #9818

#### Description

#9818 was not checked against pylint --py3k, whose report on the files changed by that PR is

```
************* Module src.python.WMCore.WMException
W:117,12: Indexing exceptions will not work on Python 3 (indexing-exception)
```

We should then modernize WMCore/WMException following pylint doc:

>    Indexing exceptions will not work on Python 3 Indexing exceptions will not work on Python 3. Use exception.args[index] instead.


#### Is it backward compatible (if not, which system it affects?)

yes

#### External dependencies / deployment changes

This does not require any change in external dependencies.
