### PR TITLE
[py2py3] Fix pre-python2.6 idiom: use "isinstance()" instead of "type() == " 

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/SetBlock.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/SetBlock.py
@@ -18,7 +18,7 @@ class SetBlock(DBFormatter):
 
         """
 
-        if type(lfn) == list:
+        if isinstance(lfn, list):
             binds = []
             for entry in lfn:
                 binds.append({'block': blockName, 'filelfn': entry})

--- a/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/SetStatus.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/DBSBufferFiles/SetStatus.py
@@ -14,7 +14,7 @@ class SetStatus(DBFormatter):
     sql = "UPDATE dbsbuffer_file SET status = :status WHERE lfn = :lfn"
 
     def execute(self, lfns, status, conn = None, transaction = None):
-        if type(lfns) != list:
+        if not isinstance(lfns, list):
             lfns = [lfns]
 
         bindVars = []

--- a/src/python/WMCore/BossAir/MySQL/NewState.py
+++ b/src/python/WMCore/BossAir/MySQL/NewState.py
@@ -28,7 +28,7 @@ class NewState(DBFormatter):
         """
 
         binds = []
-        if type(states) == str:
+        if isinstance(states, str):
             binds = {'name': states}
         for state in states:
             binds.append({'name': state})

--- a/src/python/WMCore/Services/PhEDEx/DataStructs/PhEDExDeletion.py
+++ b/src/python/WMCore/Services/PhEDEx/DataStructs/PhEDExDeletion.py
@@ -22,9 +22,9 @@ class PhEDExDeletion(object):
         """
         Initialize PhEDEx deletion with default values
         """
-        if type(datasetPathList) == str:
+        if isinstance(datasetPathList, str):
             datasetPathList = [datasetPathList]
-        if type(nodeList) == str:
+        if isinstance(nodeList, str):
             nodeList = [nodeList]
 
         self.datasetPaths = set(datasetPathList)

--- a/src/python/WMCore/WMBS/MySQL/Files/DeleteCheck.py
+++ b/src/python/WMCore/WMBS/MySQL/Files/DeleteCheck.py
@@ -18,7 +18,7 @@ class DeleteCheck(DBFormatter):
 
 
     def execute(self, file = None, fileset = None, conn = None, transaction = False):
-        if type(file) == list:
+        if isinstance(file, list):
             if len(file) < 1:
                 return
             binds = []

--- a/src/python/WMCore/WMBS/MySQL/Files/DeleteParentCheck.py
+++ b/src/python/WMCore/WMBS/MySQL/Files/DeleteParentCheck.py
@@ -18,7 +18,7 @@ class DeleteParentCheck(DBFormatter):
 
 
     def execute(self, file, fileset, conn = None, transaction = False):
-        if type(file) == list:
+        if isinstance(file, list):
             if len(file) < 1:
                 # Then we have nothing
                 return

--- a/src/python/WMCore/WMBS/MySQL/Files/GetByID.py
+++ b/src/python/WMCore/WMBS/MySQL/Files/GetByID.py
@@ -60,7 +60,7 @@ class GetByID(DBFormatter):
 
         #Making some modifications to allow it to load a whole list of files
         #This DAO object should be called directly, not through WMBSFile
-        if type(file) == list:
+        if isinstance(file, list):
             #Then we have a list of the form [fileid, fileid, etc.]
             if len(file) == 0:
                 #Ignore empty lists

--- a/src/python/WMCore/WMBS/MySQL/Files/GetChecksum.py
+++ b/src/python/WMCore/WMBS/MySQL/Files/GetChecksum.py
@@ -26,7 +26,7 @@ class GetChecksum(DBFormatter):
         formattedResult = {}
 
         dictVersion = DBFormatter.formatDict(self, result)
-        if type(dictVersion) == type([]):
+        if isinstance(dictVersion, list):
             if len(dictVersion) == 0:
                 #Then it's empty
                 return None

--- a/src/python/WMCore/WMBS/MySQL/Files/GetChildIDsByID.py
+++ b/src/python/WMCore/WMBS/MySQL/Files/GetChildIDsByID.py
@@ -25,7 +25,7 @@ class GetChildIDsByID(DBFormatter):
     def format(self, result):
         out = set()
         for r in result:
-            if type(1) == type(r):
+            if isinstance(r, int):
                 # deal with crappy mysql implementation
                 out.add(int(r))
             else:

--- a/src/python/WMCore/WMBS/MySQL/Files/GetParentIDsByID.py
+++ b/src/python/WMCore/WMBS/MySQL/Files/GetParentIDsByID.py
@@ -25,7 +25,7 @@ class GetParentIDsByID(DBFormatter):
     def format(self, result):
         out = set()
         for r in result:
-            if type(1) == type(r):
+            if isinstance(r, int):
                 # deal with crappy mysql implementation
                 out.add(int(r))
             else:

--- a/src/python/WMCore/WMBS/MySQL/Jobs/CompleteInput.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/CompleteInput.py
@@ -55,7 +55,7 @@ class CompleteInput(DBFormatter):
                """
 
     def execute(self, id, lfnsToSkip = None, conn = None, transaction = False):
-        if type(id) == list:
+        if isinstance(id, list):
             binds = []
             for singleID in id:
                 binds.append({"jobid": singleID})

--- a/src/python/WMCore/WMBS/MySQL/Jobs/GetCouchID.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/GetCouchID.py
@@ -40,7 +40,7 @@ class GetCouchID(DBFormatter):
         Execute the SQL for the given job ID and then format and return
         the result.
         """
-        if type(jobID) == list:
+        if isinstance(jobID, list):
             if len(jobID) == 0:
                 return {}
             binds = []

--- a/src/python/WMCore/WMBS/MySQL/Jobs/GetLocation.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/GetLocation.py
@@ -45,7 +45,7 @@ class GetLocation(DBFormatter):
         the result.
         """
 
-        if type(jobid) == list:
+        if isinstance(jobid, list):
             result = self.dbi.processData(self.bulkSQL, jobid, conn = conn, transaction = transaction)
             tmp = self.formatDict(result)
             return tmp

--- a/src/python/WMCore/WMBS/MySQL/Jobs/GetType.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/GetType.py
@@ -27,7 +27,7 @@ class GetType(DBFormatter):
              WHERE wmbs_job.id = :jobid"""
 
     def execute(self, jobID, conn = None, transaction = False):
-        isList = type(jobID) == type([])
+        isList = isinstance(jobID, list)
         if isList:
             binds = []
             for job in jobID:

--- a/src/python/WMCore/WMBS/MySQL/Jobs/LoadForTaskArchiver.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/LoadForTaskArchiver.py
@@ -38,7 +38,7 @@ class LoadForTaskArchiver(DBFormatter):
         the result.
         """
 
-        if type(jobID) != list:
+        if not isinstance(jobID, list):
             jobID = [jobID]
 
         binds = [{"jobid": x} for x in jobID]

--- a/src/python/WMCore/WMBS/MySQL/Jobs/New.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/New.py
@@ -57,7 +57,7 @@ class New(DBFormatter):
     def execute(self, jobgroup = None, name = None, couch_record = None, location = None, cache_dir = None,
                 outcome = None, fwjr = None, conn = None, transaction = False, jobList = None):
 
-        if outcome == None or type(outcome) != str:
+        if outcome == None or not isinstance(outcome, str):
             outcome = 'failure'
         elif outcome.lower() == 'success':
             boolOutcome = 1

--- a/src/python/WMCore/WMBS/MySQL/Jobs/SetCouchID.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/SetCouchID.py
@@ -26,7 +26,7 @@ class SetCouchID(DBFormatter):
         Update the location of the couch record for the job.
         """
 
-        if type(bulkList) == list:
+        if isinstance(bulkList, list):
             binds = bulkList
         else:
             binds = {"jobid": jobID, "couchid": couchID}

--- a/src/python/WMCore/WMBS/MySQL/Masks/Save.py
+++ b/src/python/WMCore/WMBS/MySQL/Masks/Save.py
@@ -21,7 +21,7 @@ class Save(DBFormatter):
     """
 
     def execute(self, jobid, mask, conn = None, transaction = False):
-        if type(mask) == list:
+        if isinstance(mask, list):
             # Bulk commit
             # Hope you didn't send us a list of empty masks
             binds = []

--- a/src/python/WMCore/WMBS/MySQL/Subscriptions/AcquireFiles.py
+++ b/src/python/WMCore/WMBS/MySQL/Subscriptions/AcquireFiles.py
@@ -17,7 +17,7 @@ class AcquireFiles(DBFormatter):
 
     def execute(self, subscription = None, file = None, conn = None,
                 transaction = False):
-        if type(file) == type([]):
+        if isinstance(file, list):
             binds = []
             for fileid in file:
                 binds.append({"subscription": subscription, "fileid": fileid})

--- a/src/python/WMCore/WMBS/MySQL/Subscriptions/GetCompletedByFileList.py
+++ b/src/python/WMCore/WMBS/MySQL/Subscriptions/GetCompletedByFileList.py
@@ -24,7 +24,7 @@ class GetCompletedByFileList(DBFormatter):
     def format(self, result):
         out = []
         for r in result:
-            if type(1) == type(r):
+            if isinstance(r, int):
                 # deal with crappy mysql implementation
                 out.append(int(r))
             else:

--- a/src/python/WMCore/WMBS/MySQL/Subscriptions/GetSubTypes.py
+++ b/src/python/WMCore/WMBS/MySQL/Subscriptions/GetSubTypes.py
@@ -34,7 +34,7 @@ class GetSubTypes(DBFormatter):
         final = []
 
         for item in res:
-            if type(item) == list:
+            if isinstance(item, list):
                 final.extend(item)
 
 

--- a/src/python/WMCore/WMBS/MySQL/Subscriptions/MarkFinishedSubscriptions.py
+++ b/src/python/WMCore/WMBS/MySQL/Subscriptions/MarkFinishedSubscriptions.py
@@ -36,7 +36,7 @@ class MarkFinishedSubscriptions(DBFormatter):
             finished = 0
 
         #Make sure it's a list of IDs
-        if type(ids) != list:
+        if not isinstance(ids, list):
             ids = [ids]
 
         binds = []

--- a/src/python/WMCore/WMBS/MySQL/Workflow/GetSpecAndNameFromTask.py
+++ b/src/python/WMCore/WMBS/MySQL/Workflow/GetSpecAndNameFromTask.py
@@ -27,7 +27,7 @@ class GetSpecAndNameFromTask(DBFormatter):
         Runs the query
         """
 
-        if type(tasks) != list:
+        if not isinstance(tasks, list):
             tasks = [tasks]
 
         binds = []

--- a/src/python/WMCore/WMRuntime/ProcessMonitor.py
+++ b/src/python/WMCore/WMRuntime/ProcessMonitor.py
@@ -123,7 +123,7 @@ class ExecProcess(ChildProcess):
             Either accepts a list of arguments which are passed to execvp
             OR     accepts a string which is passed to bash and shell-expanded
         """
-        if (type(arguments) != type.ListType):
+        if not isinstance(arguments, list):
             # we got passed a string, pass it to a shell
             self.args[0] = 'bash'
             self.args[1] = '-c'
@@ -145,9 +145,8 @@ class PythonProcess(ChildProcess):
     def __init__(self):
         self.target = None
 
-    def setTarget(self,newtarget):
-        if ((type(newtarget) != FunctionType) and
-            (type(newtarget) != LambdaType)):
+    def setTarget(self, newtarget):
+        if not isinstance(newtarget, (FunctionType, LambdaType)):
             raise RuntimeError("PythonProcess requires a function for target")
 
         self.target = newtarget

--- a/src/python/WMCore/WMSpec/ConfigSectionTree.py
+++ b/src/python/WMCore/WMSpec/ConfigSectionTree.py
@@ -227,7 +227,7 @@ def format(value):
     format a value as python
     keep parameters simple, trust python...
     """
-    if type(value) == str:
+    if isinstance(value, str):
         value = "\'%s\'" % value
     return str(value)
 
@@ -238,14 +238,14 @@ def formatNative(value):
     Like the format function, but allowing passing of ints, floats, etc.
     """
 
-    if type(value) == int:
+    if isinstance(value, int):
         return value
-    if type(value) == float:
+    if isinstance(value, float):
         return value
-    if type(value) == list:
+    if isinstance(value, list):
         return value
-    if type(value) == dict:
-        return dict
+    if isinstance(value, dict):
+        return value
     else:
         return format(value)
 
@@ -398,7 +398,7 @@ class TreeHelper(object):
         adds an arbitrary value as a dictionary.  Can have multiple values
         """
 
-        if not type(value) == dict:
+        if not isinstance(value, dict):
             raise Exception("TreeHelper.addValue passed a value that was not a dictionary")
 
         for key in value:

--- a/src/python/WMCore/WMSpec/Steps/BuildTools.py
+++ b/src/python/WMCore/WMSpec/Steps/BuildTools.py
@@ -175,7 +175,7 @@ def processDir( cfgSect, parent):
     """
     for setting in cfgSect._internal_settings:
         value = getattr(cfgSect, setting)
-        if type(value) != type(dict()): continue
+        if not isinstance(value, dict): continue
         parent.addFile(value['Source'], value['Target'])
 
     for subdir in cfgSect._internal_children:

--- a/src/python/WMCore/WebTools/WebAPI.py
+++ b/src/python/WMCore/WebTools/WebAPI.py
@@ -73,7 +73,7 @@ class WebAPI(DatabasePage):
 #            dict = self.runMethod(args[0], kwargs)
 #            return dict
             res = self.runMethod(args[0], kwargs)
-            if  type(res) is str:
+            if  isinstance(res, str):
                 res = eval(res)
             return res
         else:
@@ -122,7 +122,7 @@ class WebAPI(DatabasePage):
         """
         try:
             res = self.runMethod(args[0], kwargs)
-            if  type(res) is str:
+            if  isinstance(res, str):
                 res = eval(res)
             return res
         except:
@@ -138,7 +138,7 @@ class WebAPI(DatabasePage):
 #            dict = self.runMethod(args[0], kwargs)
 #            return dict
             res = self.runMethod(args[0], kwargs)
-            if  type(res) is str:
+            if  isinstance(res, str):
                 res = eval(res)
             return res
         else:


### PR DESCRIPTION
Fixes #10171 

#### Status

Ready

#### Related PR

This PR is independent form other PRs

#### Description

Run `futurize -f idioms` on `src/python`.

Manual changes

* `type([])` changed to `list`
* `type(1)` changed to `int`
* `type.ListType` changed to `list`

Changes involving `type(dict)`, which can cause problems (despite no problem has been caught by jenkins CI)
* `src/python/WMCore/WMSpec/Steps/BuildTools.py`
* `src/python/WMCore/WMSpec/ConfigSectionTree.py`

##### What has been kept back and not included in this PR

* `JSONThunker` had some problems in the past with this fixers. Moreover, #9852 is still open.
* `WMException`: this change caused a dramatic change in behavior that is being addressed in separate PRs, such as #10174, #10187, #10189

#### Is it backward compatible (if not, which system it affects?)

Yes, it should be. any possibly breaking changes will be reported here.

#### External dependencies / deployment changes

This does not rely on third party libraries
