### PR TITLE
 [py2py3] Fix potential bug in WMException

### DIFF
--- a/test/python/WMCore_t/WMException_t.py
+++ b/test/python/WMCore_t/WMException_t.py
@@ -7,6 +7,8 @@ General test for WMException
 
 """
 from __future__ import print_function, division
+from builtins import str, bytes
+
 import logging
 import unittest
 from WMCore.WMException import WMException
@@ -21,13 +23,29 @@ class WMExceptionTest(unittest.TestCase):
         setup log file output.
         """
         logging.basicConfig(level=logging.NOTSET,
-            format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
-            datefmt='%m-%d %H:%M',
-            filename='%s.log' % __file__,
-            filemode='w')
+                            format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
+                            datefmt='%m-%d %H:%M',
+                            filename='%s.log' % __file__,
+                            filemode='w')
 
         self.logger = logging.getLogger('WMExceptionTest')
 
+        self.test_data = {
+            'key-ascii': 'value-1',       # unicode (ascii): unicode (ascii)
+            'key-ascii-b': '√@ʟυℯ-1',     # unicode (ascii): unicode (non-ascii)
+            'key-ascii-c': u'√@ʟυℯ-1',    # unicode (ascii): unicode (non-ascii)
+            'key-ascii-d': bytes('√@ʟυℯ-1', 'utf-8'),    # unicode (ascii): bytes (of non-ascii)
+            'ḱℯƴ-unicode-a': 'ṽ@łυ℮-2',   # unicode (non-ascii): unicode (non-ascii)
+            u'ḱℯƴ-unicode-b': 'ṽ@łυ℮-2',  # unicode (non-ascii): unicode (non-ascii)
+            bytes('ḱℯƴ-unicode-c', 'utf-8'): 'ṽ@łυ℮-2',  # bytes (of non-ascii): unicode (non-ascii)
+            'ḱℯƴ-unicode-d': 'value-\x95',  # unicode (of non-ascii): unicode (invalid byte)
+            'key-\x95': 'ṽ@łυ℮-2',  # unicode (invalid byte): unicode (non-ascii)
+            'key3': 3.14159,
+            # This would break WMException, but should not happen
+            # 'key4': {
+            #     b'ḱℯƴ-unicode-c': 'ṽ@łυ℮-2',  # bytes (of unicode): unicode
+            # }
+            }
 
     def tearDown(self):
         """
@@ -38,33 +56,37 @@ class WMExceptionTest(unittest.TestCase):
 
     def testException(self):
         """
-        create an exception and do some tests.
+        create an exception and do some tests (only ascii chars)
         """
 
         exception = WMException("an exception message with nr. 100", 100)
-        self.logger.debug("String version of exception: " + str(exception))
-        self.logger.debug("XML version of exception: " + exception.xml())
+        self.logger.debug("String version of exception: %s", str(exception))
+        self.logger.debug("XML version of exception: %s", exception.xml())
         self.logger.debug("Adding data")
         data = {}
         data['key1'] = 'value1'
-        data['key2'] = 'data2'
+        data['key2'] = 3.14159
         exception.addInfo(**data)
-        self.logger.debug("String version of exception: " + str(exception))
+        self.logger.debug("String version of exception: %s", str(exception))
 
-    def testExceptionUnicode(self):
+    def testExceptionUnicode0(self):
         """
-        create an exception with non-ascii characters and do some tests.
+        create an exception with non-ascii chars in message and test WMException.addInfo().
         """
 
         exception = WMException("an exception message with nr. 100 and some non-ascii characters: ₩♏ℭ☺яε", 100)
-        self.logger.debug("String version of exception: " + str(exception))
-        self.logger.debug("XML version of exception: " + exception.xml())
-        self.logger.debug("Adding data")
-        data = {}
-        data['key1'] = 'value1'
-        data['key2'] = 'data2'
-        exception.addInfo(**data)
-        self.logger.debug("String version of exception: " + str(exception))
+        exception.addInfo(**self.test_data)
+        self.logger.debug("XML version of exception: %s", exception.xml())
+        self.logger.debug("String version of exception: %s", str(exception))
+
+    def testExceptionUnicode1(self):
+        """
+        create an exception with non-ascii chars in message and test WMException constructor
+        """
+
+        exception = WMException("an exception message with nr. 100 and some non-ascii characters: ₩♏ℭ☺яε", 100, **self.test_data)
+        self.logger.debug("XML version of exception: %s", exception.xml())
+        self.logger.debug("String version of exception: %s", str(exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #10173 

#### Status

In development. Solution to current problem found, but more investigation and more unit tests are necessary.

#### Description

`WMException` 

* implementing unicode sandwich: convert to unicode all the incoming data, such as `message` and `data`.
* `pylint --py3k` warning addressed in #10168 (next PR to review ;) )
* "fixes for newer python3 idioms" addressed in #10172 (the Pr that should be review after #10168)

`WMException_t` 

* `from builtins import str, bytes`
* Tries to instantiate the exception object with as much unicode characters as possible, in exception message and data (both in keys and values)

#### Is it backward compatible (if not, which system it affects?)

As always, it is intended to be, but it impossible to guarantee that these chagnes are perfect. We will list here what we think can cause problems.

#### Related PRs

This work was initially inside #10172 , but has been split from because

* #10172 is intended to contain straightforward changes (pre-py2.6 idioms, from futurize stage 1) on  broad range of file
* this PR involves strings (not a straightforward change)
* #10173 is direct consequence of some negligence in #9868 , which has been discovered by chance while working on #10172 

#### External dependencies / deployment changes

This PR requires python-future
