### PR TITLE
Decouple CMSSW/WMAgent python versions from PSet tweaking step

### DIFF
--- a/src/python/PSetTweaks/PSetTweak.py
+++ b/src/python/PSetTweaks/PSetTweak.py
@@ -334,6 +334,20 @@ class PSetTweak(object):
         jsoniser(self.process)
         return jsoniser.json
 
+    def simplejsonise(self):
+        """
+        _simplejsonise_
+
+        return simple json format of this tweak
+        E.g.:
+        {"process.maxEvents.input": 1200, "process.source.firstRun": 1, "process.source.firstLuminosityBlock": 59965}
+
+        """
+        jsoniser = JSONiser()
+        jsoniser.dejson(self.jsondictionary())
+        result = json.dumps(jsoniser.parameters)
+        return result
+
 
     def persist(self, filename, formatting="python"):
         """
@@ -342,7 +356,7 @@ class PSetTweak(object):
         Save this object as either python, json or pickle
 
         """
-        if formatting not in ("python", "json", "pickle"):
+        if formatting not in ("python", "json", "pickle", "simplejson"):
             msg = "Unsupported Format: %s" % formatting
             raise RuntimeError(msg)
 
@@ -355,6 +369,9 @@ class PSetTweak(object):
         if formatting == "pickle":
             with open(filename, "w") as handle:
                 pickle.dump(self, handle)
+        if formatting == "simplejson":
+            with open(filename, "w") as handle:
+                handle.write(self.simplejsonise())
         return
 
     def unpersist(self, filename, formatting=None):

--- a/src/python/PSetTweaks/WMTweak.py
+++ b/src/python/PSetTweaks/WMTweak.py
@@ -527,10 +527,6 @@ def makeOutputTweak(outMod, job, result):
         lfn = "%s/%s/%s.root" % (lfnBase, lfnGroup(job), modName)
         result.addParameter("process.%s.logicalFileName" % modName, lfn)
 
-    # TODO: Nice standard way to meddle with the other parameters in the
-    #      output module based on the settings in the section
-    logging.info("mod result = {0}".format(result.jsondictionary()))
-
     return
 
 

--- a/src/python/PSetTweaks/WMTweak.py
+++ b/src/python/PSetTweaks/WMTweak.py
@@ -377,13 +377,12 @@ def decomposeConfigSection(csect):
     return decomposer.parameters
 
 
-def makeTaskTweak(stepSection):
+def makeTaskTweak(stepSection, result):
     """
     _makeTaskTweak_
 
     Create a tweak for options in the task that apply to all jobs.
     """
-    result = PSetTweak()
 
     # GlobalTag
     if hasattr(stepSection, "application"):
@@ -391,21 +390,20 @@ def makeTaskTweak(stepSection):
             if hasattr(stepSection.application.configuration, "pickledarguments"):
                 args = pickle.loads(stepSection.application.configuration.pickledarguments)
                 if 'globalTag' in args:
-                    result.addParameter("process.GlobalTag.globaltag", args['globalTag'])
+                    result.addParameter("process.GlobalTag.globaltag",  "customTypeCms.string('%s')" % args['globalTag'])
                 if 'globalTagTransaction' in args:
-                    result.addParameter("process.GlobalTag.DBParameters.transactionId", args['globalTagTransaction'])
+                    result.addParameter("process.GlobalTag.DBParameters.transactionId",  "customTypeCms.untracked.string('%s')" % args['globalTagTransaction'])
 
-    return result
+    return
 
 
-def makeJobTweak(job):
+def makeJobTweak(job, result):
     """
     _makeJobTweak_
 
     Convert information from a WMBS Job object into a PSetTweak
     that can be used to modify a CMSSW process.
     """
-    result = PSetTweak()
     baggage = job.getBaggage()
 
     # Check in the baggage if we are processing .lhe files
@@ -421,7 +419,7 @@ def makeJobTweak(job):
             if job['mask'].get('FirstLumi', None) != None:
                 logging.info("Setting 'firstLuminosityBlock' attr to: %s", job['mask']['FirstLumi'])
                 result.addParameter("process.source.firstLuminosityBlock",
-                                    job['mask']['FirstLumi'])
+                                    "customTypeCms.untracked.uint32(%s)" % job['mask']['FirstLumi'])
             else:
                 # We don't have lumi information in the mask, raise an exception
                 raise WMTweakMaskError(job['mask'],
@@ -435,16 +433,16 @@ def makeJobTweak(job):
     logging.info("Adding %d files to 'fileNames' attr", len(primaryFiles))
     logging.info("Adding %d files to 'secondaryFileNames' attr", len(secondaryFiles))
     if len(primaryFiles) > 0:
-        result.addParameter("process.source.fileNames", primaryFiles)
+        result.addParameter("process.source.fileNames", "customTypeCms.untracked.vstring(%s)" % primaryFiles)
         if len(secondaryFiles) > 0:
-            result.addParameter("process.source.secondaryFileNames", secondaryFiles)
+            result.addParameter("process.source.secondaryFileNames", "customTypeCms.untracked.vstring(%s)" % secondaryFiles)
     elif not lheInput:
         # First event parameter should be set from whatever the mask says,
         # That should have the added protection of not going over 2^32 - 1
         # If there is nothing in the mask, then we fallback to the counter method
         if job['mask'].get('FirstEvent', None) != None:
             logging.info("Setting 'firstEvent' attr to: %s", job['mask']['FirstEvent'])
-            result.addParameter("process.source.firstEvent", job['mask']['FirstEvent'])
+            result.addParameter("process.source.firstEvent", "customTypeCms.untracked.uint32(%s)" % job['mask']['FirstEvent'])
         else:
             # No first event information in the mask, raise and error
             raise WMTweakMaskError(job['mask'],
@@ -457,7 +455,7 @@ def makeJobTweak(job):
     if maxEvents is None:
         maxEvents = -1
     logging.info("Setting 'maxEvents.input' attr to: %s", maxEvents)
-    result.addParameter("process.maxEvents.input", maxEvents)
+    result.addParameter("process.maxEvents", "customTypeCms.untracked.PSet(input=cms.untracked.int32(%s))"% maxEvents)
 
     # We don't want to set skip events for MonteCarlo jobs which have
     # no input files.
@@ -465,18 +463,18 @@ def makeJobTweak(job):
     if firstEvent != None and firstEvent >= 0 and (len(primaryFiles) > 0 or lheInput):
         if lheInput:
             logging.info("Setting 'skipEvents' attr to: %s", firstEvent - 1)
-            result.addParameter("process.source.skipEvents", firstEvent - 1)
+            result.addParameter("process.source.skipEvents", "customTypeCms.untracked.uint32(%s)" % (firstEvent - 1))
         else:
             logging.info("Setting 'skipEvents' attr to: %s", firstEvent)
-            result.addParameter("process.source.skipEvents", firstEvent)
+            result.addParameter("process.source.skipEvents", "customTypeCms.untracked.uint32(%s)" % firstEvent)
 
     firstRun = mask['FirstRun']
     if firstRun != None:
-        result.addParameter("process.source.firstRun", firstRun)
+        result.addParameter("process.source.firstRun", "customTypeCms.untracked.uint32(%s)" % firstRun)
     elif not len(primaryFiles):
         # Then we have a MC job, we need to set firstRun to 1
         logging.debug("MCFakeFile initiated without job FirstRun - using one.")
-        result.addParameter("process.source.firstRun", 1)
+        result.addParameter("process.source.firstRun", "customTypeCms.untracked.uint32(1)")
 
     runs = mask.getRunAndLumis()
     lumisToProcess = []
@@ -490,7 +488,7 @@ def makeJobTweak(job):
 
     if len(lumisToProcess) > 0:
         logging.info("Adding %d run/lumis mask to 'lumisToProcess' attr", len(lumisToProcess))
-        result.addParameter("process.source.lumisToProcess", lumisToProcess)
+        result.addParameter("process.source.lumisToProcess", "customTypeCms.untracked.VLuminosityBlockRange(%s)" % lumisToProcess)
 
     # install any settings from the per job baggage
     procSection = getattr(baggage, "process", None)
@@ -499,21 +497,27 @@ def makeJobTweak(job):
 
     baggageParams = decomposeConfigSection(procSection)
     for k, v in viewitems(baggageParams):
+        if isinstance(v, str):
+            v =  "customTypeCms.untracked.string(%s)" % v
+        elif isinstance(v, int):
+            v =  "customTypeCms.untracked.uint32(%s)" % v
+        elif isinstance(v, list):
+            v =  "customTypeCms.untracked.vstring(%s)" % v
         result.addParameter(k, v)
 
-    return result
+    return
 
 
-def makeOutputTweak(outMod, job):
+def makeOutputTweak(outMod, job, result):
     """
     _makeOutputTweak_
 
     Make a PSetTweak for the output module and job instance provided
 
     """
-    result = PSetTweak()
     # output filenames
     modName = str(getattr(outMod, "_internal_name"))
+    logging.info("modName = %s", modName)
     fileName = "%s.root" % modName
 
     result.addParameter("process.%s.fileName" % modName, fileName)
@@ -525,8 +529,9 @@ def makeOutputTweak(outMod, job):
 
     # TODO: Nice standard way to meddle with the other parameters in the
     #      output module based on the settings in the section
+    logging.info("mod result = {0}".format(result.jsondictionary()))
 
-    return result
+    return
 
 
 def readAdValues(attrs, adname, castInt=False):

--- a/src/python/WMCore/WMRuntime/Tools/Scram.py
+++ b/src/python/WMCore/WMRuntime/Tools/Scram.py
@@ -244,7 +244,6 @@ class Scram(object):
         )
 
         # send commands to the subshell utilising the process writer method
-        self.procWriter(proc, self.library_path)
         self.procWriter(proc, self.preCommand())
         self.procWriter(proc, "%s --arch %s project CMSSW %s\n" % (self.command, self.architecture, self.version))
         self.procWriter(proc, """if [ "$?" -ne "0" ]; then exit 3; fi\n""")
@@ -319,7 +318,7 @@ class Scram(object):
         self.lastExecuted = "eval `%s ru -sh`" % self.command
         return proc.returncode
 
-    def __call__(self, command, hackLdLibPath=True, runtimeDir=None, cleanEnv=True):
+    def __call__(self, command, hackLdLibPath=False, runtimeDir=None, cleanEnv=True):
         """
         _operator(command)_
 
@@ -338,6 +337,7 @@ class Scram(object):
 
         bashcmd = "/bin/bash"
         if cleanEnv:
+            # Start with a clean environment
             bashcmd = "env - " + bashcmd
 
         logging.info("Creating a subprocess to run the PSet setup.")
@@ -359,11 +359,6 @@ class Scram(object):
                 rtCmsswBase = self.runtimeEnv[varName].replace('\"', '')
             if varName == "SCRAM_ARCH":
                 rtScramArch = self.runtimeEnv[varName].replace('\"', '')
-
-        # Make sure to pass PYTHONPATH env (with WMCore path) to CMSSW python
-        # Scram was modified in CMSSW_10_1_0 and it no longer returns this env var
-        if "PYTHONPATH" not in self.runtimeEnv:
-            self.procWriter(proc, 'export PYTHONPATH=%s\n' % os.environ['PYTHONPATH'])
 
         if os.environ.get('VO_CMS_SW_DIR', None) is not None:
             self.procWriter(proc, 'export VO_CMS_SW_DIR=%s\n' % os.environ['VO_CMS_SW_DIR'])

--- a/test/python/PSetTweaks_t/WMTweak_t.py
+++ b/test/python/PSetTweaks_t/WMTweak_t.py
@@ -8,6 +8,7 @@ import unittest
 
 import PSetTweaks.WMTweak as WMTweaks
 from PSetTweaks.WMTweak import WMTweakMaskError
+from PSetTweaks.PSetTweak import PSetTweak
 
 from WMCore.DataStructs.Mask import Mask
 from WMCore.DataStructs.Job import Job
@@ -40,7 +41,8 @@ class WMTweakTest(unittest.TestCase):
         job["input_files"] = [{"lfn": "bogusFile", "parents": []}]
         job["mask"] = Mask()
 
-        tweak = WMTweaks.makeJobTweak(job)
+        tweak = PSetTweak()
+        WMTweaks.makeJobTweak(job, tweak)
 
         self.assertFalse(hasattr(tweak.process.source, "skipEvents"),
                          "Error: There should be no skipEvents tweak.")
@@ -48,11 +50,12 @@ class WMTweakTest(unittest.TestCase):
                          "Error: There should be no firstEvent tweak.")
 
         job["mask"]["FirstEvent"] = 0
-        tweak = WMTweaks.makeJobTweak(job)
+        tweak = PSetTweak()
+        WMTweaks.makeJobTweak(job, tweak)
 
         self.assertTrue(hasattr(tweak.process.source, "skipEvents"),
                         "Error: There should be a skipEvents tweak.")
-        self.assertEqual(tweak.process.source.skipEvents, 0,
+        self.assertEqual(tweak.process.source.skipEvents, 'customTypeCms.untracked.uint32(0)',
                          "Error: The skipEvents tweak should be 0.")
         return
 
@@ -67,18 +70,19 @@ class WMTweakTest(unittest.TestCase):
         job["input_files"] = [{"lfn": "bogusFile", "parents": []}]
         job["mask"] = Mask()
 
-        tweak = WMTweaks.makeJobTweak(job)
+        tweak = PSetTweak()
+        WMTweaks.makeJobTweak(job, tweak)
 
         self.assertFalse(hasattr(tweak.process.source, "firstRun"),
                          "Error: There should be no firstRun tweak.")
 
         job["mask"]["FirstRun"] = 93
-        tweak = WMTweaks.makeJobTweak(job)
+        tweak = WMTweaks.makeJobTweak(job, tweak)
 
         self.assertTrue(hasattr(tweak.process.source, "firstRun"),
                         "Error: There should be a firstRun tweak.")
-        self.assertEqual(tweak.process.source.firstRun, 93,
-                         "Error: The skipEvents tweak should be 0.")
+        self.assertEqual(tweak.process.source.firstRun, 'customTypeCms.untracked.uint32(93)',
+                         "Error: The firstRun tweak should be 93.")
         return
 
     def testFirstEventMC(self):
@@ -96,18 +100,20 @@ class WMTweakTest(unittest.TestCase):
         job["mask"]["FirstLumi"] = 200
 
         try:
-            tweak = WMTweaks.makeJobTweak(job)
+            tweak = PSetTweak()
+            WMTweaks.makeJobTweak(job, tweak)
             self.assertRaises(WMTweakMaskError,  WMTweaks.makeJobTweak, job)
         except WMTweakMaskError:
             pass
 
         job["mask"]["FirstEvent"] = 100
-        tweak = WMTweaks.makeJobTweak(job)
+        tweak = PSetTweak()
+        WMTweaks.makeJobTweak(job, tweak)
         self.assertFalse(hasattr(tweak.process.source, "skipEvents"),
                         "Error: There should be no skipEvents tweak, it's MC.")
         self.assertTrue(hasattr(tweak.process.source, "firstEvent"),
                         "Error: There should be a first event tweak")
-        self.assertEqual(tweak.process.source.firstEvent, 100,
+        self.assertEqual(tweak.process.source.firstEvent, 'customTypeCms.untracked.uint32(100)',
                          "Error: The firstEvent tweak should be 100.")
         return
 
@@ -125,25 +131,28 @@ class WMTweakTest(unittest.TestCase):
         job["mask"]["FirstEvent"] = 100
 
         try:
-            tweak = WMTweaks.makeJobTweak(job)
+            tweak = PSetTweak()
+            WMTweaks.makeJobTweak(job, tweak)
             self.assertRaises(WMTweakMaskError,  WMTweaks.makeJobTweak, job)
         except WMTweakMaskError:
             pass
 
         job["mask"]["FirstLumi"] = 200
-        tweak = WMTweaks.makeJobTweak(job)
+        tweak =  PSetTweak()
+        WMTweaks.makeJobTweak(job, tweak)
 
         self.assertTrue(hasattr(tweak.process.source, "firstLuminosityBlock"),
                         "Error: There should be a first lumi tweak")
-        self.assertEqual(tweak.process.source.firstLuminosityBlock, 200,
-                       "Error: The first luminosity block should be 5")
+        self.assertEqual(tweak.process.source.firstLuminosityBlock, 'customTypeCms.untracked.uint32(200)',
+                       "Error: The first luminosity block should be 200")
 
         job["mask"]["FirstLumi"] = 10
-        tweak = WMTweaks.makeJobTweak(job)
+        tweak = PSetTweak()
+        WMTweaks.makeJobTweak(job, tweak)
 
         self.assertTrue(hasattr(tweak.process.source, "firstLuminosityBlock"),
                         "Error: There should be a first lumi tweak")
-        self.assertEqual(tweak.process.source.firstLuminosityBlock, 10,
+        self.assertEqual(tweak.process.source.firstLuminosityBlock, 'customTypeCms.untracked.uint32(10)',
                        "Error: The first luminosity block should be 10")
 
     def testFirstRunMC(self):
@@ -159,19 +168,21 @@ class WMTweakTest(unittest.TestCase):
         job["mask"]["FirstEvent"] = 100
         job["counter"] = 5
 
-        tweak = WMTweaks.makeJobTweak(job)
+        tweak = PSetTweak()
+        WMTweaks.makeJobTweak(job, tweak)
 
         self.assertTrue(hasattr(tweak.process.source, "firstRun"),
                         "Error: There should be a first run tweak")
-        self.assertEqual(tweak.process.source.firstRun, 1,
+        self.assertEqual(tweak.process.source.firstRun, 'customTypeCms.untracked.uint32(1)',
                        "Error: The first run should be 1")
 
         job["mask"]["FirstRun"] = 5
-        tweak = WMTweaks.makeJobTweak(job)
+        tweak = PSetTweak()
+        WMTweaks.makeJobTweak(job, tweak)
 
         self.assertTrue(hasattr(tweak.process.source, "firstRun"),
                         "Error: There should be a first run tweak")
-        self.assertEqual(tweak.process.source.firstRun, 5,
-                       "Error: The first run should be 1")
+        self.assertEqual(tweak.process.source.firstRun, 'customTypeCms.untracked.uint32(5)',
+                       "Error: The first run should be 5")
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/WMCore_t/WMRuntime_t/Scripts_t/WMTaskSpace/cmsRun1/PSet.py
+++ b/test/python/WMCore_t/WMRuntime_t/Scripts_t/WMTaskSpace/cmsRun1/PSet.py
@@ -4,68 +4,26 @@ _Pset_
 
 Bogus CMSSW PSet for testing runtime code.
 """
-
 import FWCore.ParameterSet.Config as cms
 
-class Container():
-    """
-    _Container_
+process = cms.Process('Test')
 
-    Empty class that we can use like a PSet.
-    """
-    pass
+# import of standard configurations for Services and mixing modules
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
-    def type_(self):
-        return "PoolSource"
+# Input source
+process.source = cms.Source("EmptySource")
+process.source.fileNames = cms.untracked.vstring()
+process.source.secondaryFileNames = cms.untracked.vstring()
+process.source.firstLuminosityBlock = cms.untracked.uint32(1)
 
-class Process():
-    """
-    _Process_
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10),
+    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
+)
 
-    Process class that has one output module.
-    """
-    outputRECORECO = Container()
-    source = Container()
-    services = {}
-    producers = {}
-    filters = {}
-
-    def __init__(self):
-        """
-        __init__
-
-        """
-        mixing1 = cms.PSet(input = cms.PSet(fileNames = cms.untracked.vstring()))
-        mixing1.setType("MixingModule")
-        mixing2 = cms.PSet(secsource = cms.PSet(fileNames = cms.untracked.vstring()))
-        mixing2.setType("MixingModule")
-        datamixing1 = cms.PSet(secsource = cms.PSet(fileNames = cms.untracked.vstring()))
-        datamixing1.setType("DataMixingModule")
-        datamixing2 = cms.PSet(input = cms.PSet(fileNames = cms.untracked.vstring()))
-        datamixing2.setType("DataMixingModule")
-
-        self.producers["mix1"] = mixing1
-        self.producers["datamix1"] = datamixing1
-        self.filters["mix2"] = mixing2
-        self.filters["datamix2"] = datamixing2
-
-    def outputModules_(self):
-        """
-        _outputModules_
-
-        Return a list of output modules.
-        """
-        return ["outputRECORECO"]
-
-    def add_(self, service):
-        """
-        _add__
-
-        Add a service to our services dict.
-        """
-        self.services[service.serviceName] = service
-        setattr(self, service.serviceName, service)
-        return
-
-
-process = Process()
+process.options = cms.untracked.PSet()
+process.options.numberOfThreads = 8
+process.options.numberOfStreams = 2

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/CMSSW_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/CMSSW_t.py
@@ -124,8 +124,8 @@ class CMSSW_t(unittest.TestCase):
             executor = CMSSWExecutor()
             executor.initialise(self.step, self.job)
             executor.pre()
-            # Remove the scram pre-script as it requires an actual SCRAM environment
-            executor.step.runtime.scramPreScripts.remove("SetupCMSSWPset")
+            # Remove the preScripts, as it is not needed for this test
+            executor.step.runtime.preScripts.remove("SetupCMSSWPset")
             executor.execute()
             executor.post()
             # Check that there were no errors
@@ -156,7 +156,7 @@ class CMSSW_t(unittest.TestCase):
             executor = StepFactory.getStepExecutor("CMSSW")
             executor.initialise(self.step, self.job)
             executor.pre()
-            executor.step.runtime.scramPreScripts.remove("SetupCMSSWPset")
+            executor.step.runtime.preScripts.remove("SetupCMSSWPset")
             try:
                 executor.execute()
                 self.fail("An exception should have been raised")
@@ -189,7 +189,7 @@ class CMSSW_t(unittest.TestCase):
             executor = StepFactory.getStepExecutor("CMSSW")
             executor.initialise(self.step, self.job)
             executor.pre()
-            executor.step.runtime.scramPreScripts.remove("SetupCMSSWPset")
+            executor.step.runtime.preScripts.remove("SetupCMSSWPset")
             try:
                 executor.execute()
                 self.fail("An exception should have been raised")
@@ -222,7 +222,7 @@ class CMSSW_t(unittest.TestCase):
             executor = StepFactory.getStepExecutor("CMSSW")
             executor.initialise(self.step, self.job)
             executor.pre()
-            executor.step.runtime.scramPreScripts.remove("SetupCMSSWPset")
+            executor.step.runtime.preScripts.remove("SetupCMSSWPset")
             executor.execute()
             executor.post()
             self.assertEqual(60450, executor.report.getExitCode())


### PR DESCRIPTION
Fixes #10181

#### Status
Ready for review

#### Description
This PR decouples CMSSW and WMCore python versions.
Short description:
This re-implements the pset tweaking step not to directly depend on the CMSSW framework (i.e.: importing FWCore), but rather makes external calls to scripts maintained in CMSSW in order to read and tweak the pset.

Long description: 
The Pset tweaking happens in the [SetupCMSSWPSet](https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py) pre-script, which will now run outside the Scram environment, using its own comp python version, rather than the CMSSW python version. Modifications to the Pset (direct or through a json dictionary) are done via external calls to scripts living in cmssw-wm-tools (see below for github repository link), which do use the CMSSW python version inside the scram environment (python 2 or 3).

For this, WMTweak adds the parameters to be changed using the cms types (originally as strings to save it in the json file, then evaluated to the actual cms types in cms-wm-tools, for the tweaks).
Methods that were changing the PSet directly here, are now done via several scripts supported by cmssw in cmssw-wm-tools too.
Dummy PSet for unit tests was changed in order to fix some unit tests that were broken after these changes. Some of the checks in the unit tests were changed a bit because now we have limitations reading the final PSet (since we run SetupCMSSWPSet outside the CMSSW environment), so we can check on standard types (e.g.: integers), but not cms types directly.

List of changes:
- PSetTweak: 
Added a "simplejson" format, which returns the json document in the following format:
```
{"process.maxEvents.input": 1200, "process.source.firstRun": 1, "process.source.firstLuminosityBlock": 59965}
```
- WMTweak:
Specifies cms types in the tweak json file, that are interpreted later by the cmssw-wm-tools scripts.
Additionally, the methods for creating the tweaks:  makeJobTweak, makeOutputTweak, makeTaskTweak now modify a tweak object, rather than returning a new one. 

- SetupCMSSWPSet
Calls external scripts in cmssw-wm-tools in order to modify the PSet.

- Scram
Make sure we don't pass WMAgent libraries when invoking CMSSW python.

- CMSSW Executor
Call the SetupCMSSWPset pre-script outside the scram environment (so, it's executed using the comp python version) instead.

Additional information here:
https://github.com/dmwm/WMCore/wiki/List-of-PSet-tweaks-applied-by-WMAgent-during-job-runtime

#### Is it backward compatible (if not, which system it affects?)
Yes

#### External dependencies / deployment changes
https://github.com/cms-sw/cmssw-wm-tools