### PR TITLE
 [py2py3] Fix potential bug in WMException - again

### DIFF
--- a/src/python/Utils/Utilities.py
+++ b/src/python/Utils/Utilities.py
@@ -3,8 +3,9 @@
 from __future__ import division, print_function
 from future.utils import viewitems
 
-from builtins import str
+from builtins import str, bytes
 from past.builtins import basestring
+
 import subprocess
 import os
 import re
@@ -189,6 +190,38 @@ def getSize(obj):
                 need_referents.append(obj)
         objects = get_referents(*need_referents)
     return size
+
+
+def decodeBytesToUnicode(value, errors="strict"):
+    """
+    Accepts an input "value" of generic type.
+
+    If "value" is a string of type sequence of bytes (i.e. in py2 `str` or
+    `future.types.newbytes.newbytes`, in py3 `bytes`), then it is converted to
+    a sequence of unicode codepoints.
+
+    This function is useful for cleaning input data when using the
+    "unicode sandwich" approach, which involves converting bytes (i.e. strings
+    of type sequence of bytes) to unicode (i.e. strings of type sequence of
+    unicode codepoints, in py2 `unicode` or `future.types.newstr.newstr`,
+    in py3 `str` ) as soon as possible when recieving input data, and
+    converting unicode back to bytes as late as possible.
+    achtung!:
+    - converting unicode back to bytes is not covered by this function
+    - converting unicode back to bytes is not always necessary. when in doubt,
+      do not do it.
+    Reference: https://nedbatchelder.com/text/unipain.html
+
+    py2:
+    - "errors" can be: "strict", "ignore", "replace",
+    - ref: https://docs.python.org/2/howto/unicode.html#the-unicode-type
+    py3:
+    - "errors" can be: "strict", "ignore", "replace", "backslashreplace"
+    - ref: https://docs.python.org/3/howto/unicode.html#the-string-type
+    """
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors)
+    return value
 
 
 # TODO: remove this function once we have completely migrated to Rucio

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/CMSSW.py
@@ -10,6 +10,8 @@ Diagnostic implementation for a CMSSW job
 """
 from __future__ import print_function
 
+from builtins import str
+
 import logging
 import os.path
 import socket

--- a/test/python/WMCore_t/WMException_py2_t.py
+++ b/test/python/WMCore_t/WMException_py2_t.py
@@ -3,11 +3,15 @@
 """
 _WMException_t_
 
-General test for WMException
+General test for WMException, intended to simulate code
+
+- run from a py2 interpreter
+- without any modernization to strings, such as
+  - no `from builtins import str`
+  - no `from builtins import bytes`
 
 """
 from __future__ import print_function, division
-from builtins import str, bytes
 
 import logging
 import unittest
@@ -34,10 +38,10 @@ class WMExceptionTest(unittest.TestCase):
             'key-ascii': 'value-1',       # unicode (ascii): unicode (ascii)
             'key-ascii-b': '√@ʟυℯ-1',     # unicode (ascii): unicode (non-ascii)
             'key-ascii-c': u'√@ʟυℯ-1',    # unicode (ascii): unicode (non-ascii)
-            'key-ascii-d': bytes('√@ʟυℯ-1', 'utf-8'),    # unicode (ascii): bytes (of non-ascii)
+            'key-ascii-d': b'√@ʟυℯ-1',    # unicode (ascii): bytes (of non-ascii)
             'ḱℯƴ-unicode-a': 'ṽ@łυ℮-2',   # unicode (non-ascii): unicode (non-ascii)
             u'ḱℯƴ-unicode-b': 'ṽ@łυ℮-2',  # unicode (non-ascii): unicode (non-ascii)
-            bytes('ḱℯƴ-unicode-c', 'utf-8'): 'ṽ@łυ℮-2',  # bytes (of non-ascii): unicode (non-ascii)
+            b'ḱℯƴ-unicode-c': 'ṽ@łυ℮-2',  # bytes (of non-ascii): unicode (non-ascii)
             'ḱℯƴ-unicode-d': 'value-\x95',  # unicode (of non-ascii): unicode (invalid byte)
             'key-\x95': 'ṽ@łυ℮-2',  # unicode (invalid byte): unicode (non-ascii)
             'key3': 3.14159,
@@ -54,31 +58,6 @@ class WMExceptionTest(unittest.TestCase):
 
         pass
 
-    def testException(self):
-        """
-        create an exception and do some tests (only ascii chars)
-        """
-
-        exception = WMException("an exception message with nr. 100", 100)
-        self.logger.debug("String version of exception: %s", str(exception))
-        self.logger.debug("XML version of exception: %s", exception.xml())
-        self.logger.debug("Adding data")
-        data = {}
-        data['key1'] = 'value1'
-        data['key2'] = 3.14159
-        exception.addInfo(**data)
-        self.logger.debug("String version of exception: %s", str(exception))
-
-    def testExceptionUnicode0(self):
-        """
-        create an exception with non-ascii chars in message and test WMException.addInfo().
-        """
-
-        exception = WMException("an exception message with nr. 100 and some non-ascii characters: ₩♏ℭ☺яε", 100)
-        exception.addInfo(**self.test_data)
-        self.logger.debug("XML version of exception: %s", exception.xml())
-        self.logger.debug("String version of exception: %s", str(exception))
-
     def testExceptionUnicode1(self):
         """
         create an exception with non-ascii chars in message and test WMException constructor
@@ -86,7 +65,11 @@ class WMExceptionTest(unittest.TestCase):
 
         exception = WMException("an exception message with nr. 100 and some non-ascii characters: ₩♏ℭ☺яε", 100, **self.test_data)
         self.logger.debug("XML version of exception: %s", exception.xml())
+        self.logger.debug("String version of exception: %s", unicode(exception))
         self.logger.debug("String version of exception: %s", str(exception))
+        self.logger.debug("exception.__str__(): %s", type(exception.__str__()))  # <class 'future.types.newbytes.newbytes'>
+        self.logger.debug("str(exception): %s", type(str(exception)))  # <class 'future.types.newbytes.newbytes'>
+        self.logger.debug("unicode(exception): %s", type(unicode(exception)))  # <class 'future.types.newstr.newstr'>
 
 
 if __name__ == "__main__":

--- a/test/python/WMCore_t/WMException_py2py3_t.py
+++ b/test/python/WMCore_t/WMException_py2py3_t.py
@@ -1,0 +1,101 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""
+_WMException_t_
+
+General test for WMException, intended to simulate code
+
+- run from a py2 interpreter
+- with modernization to strings, such as
+  - with `from builtins import str`
+  - with `from builtins import bytes`
+
+"""
+from __future__ import print_function, division
+from builtins import str, bytes
+
+import logging
+import unittest
+from WMCore.WMException import WMException
+
+
+class WMExceptionTest(unittest.TestCase):
+    """
+    A test of a generic exception class
+    """
+    def setUp(self):
+        """
+        setup log file output.
+        """
+        logging.basicConfig(level=logging.NOTSET,
+                            format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
+                            datefmt='%m-%d %H:%M',
+                            filename='%s.log' % __file__,
+                            filemode='w')
+
+        self.logger = logging.getLogger('WMExceptionTest')
+
+        self.test_data = {
+            'key-ascii': 'value-1',       # unicode (ascii): unicode (ascii)
+            'key-ascii-b': '√@ʟυℯ-1',     # unicode (ascii): unicode (non-ascii)
+            'key-ascii-c': u'√@ʟυℯ-1',    # unicode (ascii): unicode (non-ascii)
+            'key-ascii-d': bytes('√@ʟυℯ-1', 'utf-8'),    # unicode (ascii): bytes (of non-ascii)
+            'ḱℯƴ-unicode-a': 'ṽ@łυ℮-2',   # unicode (non-ascii): unicode (non-ascii)
+            u'ḱℯƴ-unicode-b': 'ṽ@łυ℮-2',  # unicode (non-ascii): unicode (non-ascii)
+            bytes('ḱℯƴ-unicode-c', 'utf-8'): 'ṽ@łυ℮-2',  # bytes (of non-ascii): unicode (non-ascii)
+            'ḱℯƴ-unicode-d': 'value-\x95',  # unicode (of non-ascii): unicode (invalid byte)
+            'key-\x95': 'ṽ@łυ℮-2',  # unicode (invalid byte): unicode (non-ascii)
+            'key3': 3.14159,
+            # This would break WMException, but should not happen
+            # 'key4': {
+            #     b'ḱℯƴ-unicode-c': 'ṽ@łυ℮-2',  # bytes (of unicode): unicode
+            # }
+            }
+
+    def tearDown(self):
+        """
+        nothing to tear down
+        """
+
+        pass
+
+    def testException(self):
+        """
+        create an exception and do some tests (only ascii chars)
+        """
+
+        exception = WMException("an exception message with nr. 100", 100)
+        self.logger.debug("String version of exception: %s", str(exception))
+        self.logger.debug("XML version of exception: %s", exception.xml())
+        self.logger.debug("Adding data")
+        data = {}
+        data['key1'] = 'value1'
+        data['key2'] = 3.14159
+        exception.addInfo(**data)
+        self.logger.debug("String version of exception: %s", str(exception))
+
+    def testExceptionUnicode0(self):
+        """
+        create an exception with non-ascii chars in message and test WMException.addInfo().
+        """
+
+        exception = WMException("an exception message with nr. 100 and some non-ascii characters: ₩♏ℭ☺яε", 100)
+        exception.addInfo(**self.test_data)
+        self.logger.debug("XML version of exception: %s", exception.xml())
+        self.logger.debug("String version of exception: %s", str(exception))
+
+    def testExceptionUnicode1(self):
+        """
+        create an exception with non-ascii chars in message and test WMException constructor
+        """
+
+        exception = WMException("an exception message with nr. 100 and some non-ascii characters: ₩♏ℭ☺яε", 100, **self.test_data)
+        self.logger.debug("XML version of exception: %s", exception.xml())
+        self.logger.debug("String version of exception: %s", str(exception))
+        self.logger.debug("exception.__str__(): %s", type(exception.__str__()))  # from py2 interpreter: <class 'future.types.newbytes.newbytes'>
+        self.logger.debug("str(exception): %s", type(str(exception)))  # <class 'future.types.newstr.newstr'>
+        self.logger.debug("bytes(exception): %s", type(bytes(exception)))  # <class 'future.types.newbytes.newbytes'>
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #10173 

#### Status
ready

#### Related PRs

This PR completes the work started in #10174.

This PR also supersedes #10168 , since this involve `self[key]` -> `self.data[key]` (it is not compulsory to have this change in this PR, we can keep this in a separate PR)

An alternative to this PR is #10189 

#### Is it backward compatible (if not, which system it affects?)

*Cons*

This PR will likely be not backward compatible. Some changes like in https://github.com/dmwm/WMCore/commit/04b7b03e1d025a9ce595f1d29b49cde62468ab36 will be needed. We fixed all the problems that were caught by unit tests, but it is possible that some other problems will be discovered in testbed only.

*Pro*

This PR makes WMException ready to run in py3

#### Description

In #10174 we focused only on how to get WMException work for modernized code. But WMCore is not fully modernized yet, and it can break if it is called from non-modernized code. We have to follow a different approach. 

The problem arises since in python2 
- `str()` asks for a string of type sequence of bytes (non-modernized code)
- while if we use `from builtins import str`, then `str()` asks for a string of type sequence of unicode codepoints. (modernized code)

Since our current `__str__()` returns unicode codepoints, due to this line,

https://github.com/dmwm/WMCore/blob/08c1eea1a3245ebf956438e0a1ab1b79e338ff40/src/python/WMCore/WMException.py#L173

when we call `str(myexception)` from non-modernized python2 code `str()` tries to encode the unicode string with the default encoding (which is `ascii` by default) and it breaks. We would need to force `utf-8` encoding when `str()` is called from a non-modernized py2 module, but this would require changing some environment variable and would be time-consuming to deploy and check. 

When we use a modernized py2 module, `str()` expects that `__str__` returns a unicode string, so everything works.

The solution to make WMException compatible with both modernized and non-modernized code has been inspired from [stackoverflow](https://stackoverflow.com/a/57485167) and involves a careful separation of `__str__`, `__unicode__` and `__repr__`. Moreover, this solution seems to be python3-compatible.

#### External dependencies / deployment changes
This PR requires python-future
