### PR TITLE
[py2py3] Fix potential bug in WMException - No modernization of WMException

### DIFF
--- a/src/python/Utils/Utilities.py
+++ b/src/python/Utils/Utilities.py
@@ -3,8 +3,9 @@
 from __future__ import division, print_function
 from future.utils import viewitems
 
-from builtins import str
+from builtins import str, bytes
 from past.builtins import basestring
+
 import subprocess
 import os
 import re
@@ -189,6 +190,38 @@ def getSize(obj):
                 need_referents.append(obj)
         objects = get_referents(*need_referents)
     return size
+
+
+def decodeBytesToUnicode(value, errors="strict"):
+    """
+    Accepts an input "value" of generic type.
+
+    If "value" is a string of type sequence of bytes (i.e. in py2 `str` or
+    `future.types.newbytes.newbytes`, in py3 `bytes`), then it is converted to
+    a sequence of unicode codepoints.
+
+    This function is useful for cleaning input data when using the
+    "unicode sandwich" approach, which involves converting bytes (i.e. strings
+    of type sequence of bytes) to unicode (i.e. strings of type sequence of
+    unicode codepoints, in py2 `unicode` or `future.types.newstr.newstr`,
+    in py3 `str` ) as soon as possible when recieving input data, and
+    converting unicode back to bytes as late as possible.
+    achtung!:
+    - converting unicode back to bytes is not covered by this function
+    - converting unicode back to bytes is not always necessary. when in doubt,
+      do not do it.
+    Reference: https://nedbatchelder.com/text/unipain.html
+
+    py2:
+    - "errors" can be: "strict", "ignore", "replace",
+    - ref: https://docs.python.org/2/howto/unicode.html#the-unicode-type
+    py3:
+    - "errors" can be: "strict", "ignore", "replace", "backslashreplace"
+    - ref: https://docs.python.org/3/howto/unicode.html#the-string-type
+    """
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors)
+    return value
 
 
 # TODO: remove this function once we have completely migrated to Rucio

--- a/src/python/WMCore/WMException.py
+++ b/src/python/WMCore/WMException.py
@@ -156,7 +156,7 @@ class WMException(Exception):
         logging.error(strg)
         return strg
 
-    def __str__(self):
+    def __unicode__(self):
         """create a string rep of this exception"""
         # WARNING: Do not change this string - it is used to extract error from log
         strg = WMEXCEPTION_START_STR

--- a/src/python/WMCore/WMException.py
+++ b/src/python/WMCore/WMException.py
@@ -14,8 +14,11 @@ import logging
 import sys
 import traceback
 
-WMEXCEPTION_START_STR = "<@========== WMException Start ==========@>"
-WMEXCEPTION_END_STR = "<@---------- WMException End ----------@>"
+from Utils.Utilities import decodeBytesToUnicode
+from WMCore.Configuration import PY3
+
+WMEXCEPTION_START_STR = str("<@========== WMException Start ==========@>")
+WMEXCEPTION_END_STR = str("<@---------- WMException End ----------@>")
 
 
 class WMException(Exception):
@@ -29,12 +32,11 @@ class WMException(Exception):
 
     def __init__(self, message, errorNo=None, **data):
         self.name = str(self.__class__.__name__)
-        if isinstance(message, bytes):
-            # Fix for the unicode encoding issue, see #8056 and #8403
-            # interprets this string using utf-8 codec and ignoring any errors
-            # unicode sandwich: convert sequence of bytes strings to
-            # unicode codepoints strings as soon as possible
-            message = message.decode('utf-8', 'ignore')
+
+        # Fix for the unicode encoding issue, see #8056 and #8403
+        # interprets this string using utf-8 codec and ignoring any errors.
+        # using unicode sandwich pattern
+        message = decodeBytesToUnicode(message, "ignore")
 
         Exception.__init__(self, self.name, message)
 
@@ -95,6 +97,8 @@ class WMException(Exception):
             self.traceback = "\n".join(traceback.format_tb(sys.exc_info()[2]))
         except Exception:
             self.traceback = "WMException error: Couldn't get traceback\n"
+        # using unicode sandwich pattern
+        self.traceback = decodeBytesToUnicode(self.traceback, "ignore")
 
     def __getitem__(self, key):
         """
@@ -106,12 +110,9 @@ class WMException(Exception):
         """
         make exception look like a dictionary
         """
-        # unicode sandwich: convert sequence of bytes strings to
-        # unicode codepoints strings as soon as possible
-        if isinstance(key, bytes):
-            key = key.decode("utf-8", "ignore")
-        if isinstance(value, bytes):
-            value = value.decode("utf-8", "ignore")
+        # using unicode sandwich pattern
+        key = decodeBytesToUnicode(key, "ignore")
+        value = decodeBytesToUnicode(value, "ignore")
         self.data[key] = value
 
     def addInfo(self, **data):
@@ -122,14 +123,11 @@ class WMException(Exception):
         exception instance
         """
         for key, value in viewitems(data):
-            # unicode sandwich: convert sequence of bytes strings to
-            # unicode codepoints strings as soon as possible
             # assumption: value is not iterable (list, dict, tuple, ...)
-            if isinstance(key, bytes):
-                key = key.decode("utf-8", "ignore")
-            if isinstance(value, bytes):
-                value = value.decode("utf-8", "ignore")
-            self[key] = value
+            # using unicode sandwich pattern
+            key = decodeBytesToUnicode(key, "ignore")
+            value = decodeBytesToUnicode(value, "ignore")
+            self.data[key] = value
         return
 
     def xml(self):
@@ -156,7 +154,7 @@ class WMException(Exception):
         logging.error(strg)
         return strg
 
-    def __unicode__(self):
+    def __as_unicode(self):
         """create a string rep of this exception"""
         # WARNING: Do not change this string - it is used to extract error from log
         strg = WMEXCEPTION_START_STR
@@ -168,10 +166,18 @@ class WMException(Exception):
         strg += self.traceback
         strg += '\n'
         strg += WMEXCEPTION_END_STR
-        if isinstance(strg, bytes):
-            # Fix for the unicode encoding issue, #8043
-            strg = strg.decode('utf-8', 'ignore')
         return strg
+
+    def __as_bytes(self):
+        return self.__as_unicode().encode("utf-8")
+    
+    if PY3:
+        __str__ = __as_unicode
+    else:
+        __str__ = __as_bytes
+    __unicode__ = __as_unicode
+    __repr__ = __str__
+
 
     def message(self):
         return self._message

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/CMSSW.py
@@ -10,6 +10,8 @@ Diagnostic implementation for a CMSSW job
 """
 from __future__ import print_function
 
+from builtins import str
+
 import logging
 import os.path
 import socket

--- a/test/python/WMCore_t/WMException_py2_t.py
+++ b/test/python/WMCore_t/WMException_py2_t.py
@@ -3,11 +3,15 @@
 """
 _WMException_t_
 
-General test for WMException
+General test for WMException, intended to simulate code
+
+- run from a py2 interpreter
+- without any modernization to strings, such as
+  - no `from builtins import str`
+  - no `from builtins import bytes`
 
 """
 from __future__ import print_function, division
-from builtins import str, bytes
 
 import logging
 import unittest
@@ -34,10 +38,10 @@ class WMExceptionTest(unittest.TestCase):
             'key-ascii': 'value-1',       # unicode (ascii): unicode (ascii)
             'key-ascii-b': '√@ʟυℯ-1',     # unicode (ascii): unicode (non-ascii)
             'key-ascii-c': u'√@ʟυℯ-1',    # unicode (ascii): unicode (non-ascii)
-            'key-ascii-d': bytes('√@ʟυℯ-1', 'utf-8'),    # unicode (ascii): bytes (of non-ascii)
+            'key-ascii-d': b'√@ʟυℯ-1',    # unicode (ascii): bytes (of non-ascii)
             'ḱℯƴ-unicode-a': 'ṽ@łυ℮-2',   # unicode (non-ascii): unicode (non-ascii)
             u'ḱℯƴ-unicode-b': 'ṽ@łυ℮-2',  # unicode (non-ascii): unicode (non-ascii)
-            bytes('ḱℯƴ-unicode-c', 'utf-8'): 'ṽ@łυ℮-2',  # bytes (of non-ascii): unicode (non-ascii)
+            b'ḱℯƴ-unicode-c': 'ṽ@łυ℮-2',  # bytes (of non-ascii): unicode (non-ascii)
             'ḱℯƴ-unicode-d': 'value-\x95',  # unicode (of non-ascii): unicode (invalid byte)
             'key-\x95': 'ṽ@łυ℮-2',  # unicode (invalid byte): unicode (non-ascii)
             'key3': 3.14159,
@@ -54,31 +58,6 @@ class WMExceptionTest(unittest.TestCase):
 
         pass
 
-    def testException(self):
-        """
-        create an exception and do some tests (only ascii chars)
-        """
-
-        exception = WMException("an exception message with nr. 100", 100)
-        self.logger.debug("String version of exception: %s", str(exception))
-        self.logger.debug("XML version of exception: %s", exception.xml())
-        self.logger.debug("Adding data")
-        data = {}
-        data['key1'] = 'value1'
-        data['key2'] = 3.14159
-        exception.addInfo(**data)
-        self.logger.debug("String version of exception: %s", str(exception))
-
-    def testExceptionUnicode0(self):
-        """
-        create an exception with non-ascii chars in message and test WMException.addInfo().
-        """
-
-        exception = WMException("an exception message with nr. 100 and some non-ascii characters: ₩♏ℭ☺яε", 100)
-        exception.addInfo(**self.test_data)
-        self.logger.debug("XML version of exception: %s", exception.xml())
-        self.logger.debug("String version of exception: %s", str(exception))
-
     def testExceptionUnicode1(self):
         """
         create an exception with non-ascii chars in message and test WMException constructor
@@ -86,7 +65,11 @@ class WMExceptionTest(unittest.TestCase):
 
         exception = WMException("an exception message with nr. 100 and some non-ascii characters: ₩♏ℭ☺яε", 100, **self.test_data)
         self.logger.debug("XML version of exception: %s", exception.xml())
+        self.logger.debug("String version of exception: %s", unicode(exception))
         self.logger.debug("String version of exception: %s", str(exception))
+        self.logger.debug("exception.__str__(): %s", type(exception.__str__()))  # <class 'future.types.newbytes.newbytes'>
+        self.logger.debug("str(exception): %s", type(str(exception)))  # <class 'future.types.newbytes.newbytes'>
+        self.logger.debug("unicode(exception): %s", type(unicode(exception)))  # <class 'future.types.newstr.newstr'>
 
 
 if __name__ == "__main__":

--- a/test/python/WMCore_t/WMException_py2py3_t.py
+++ b/test/python/WMCore_t/WMException_py2py3_t.py
@@ -1,0 +1,101 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""
+_WMException_t_
+
+General test for WMException, intended to simulate code
+
+- run from a py2 interpreter
+- with modernization to strings, such as
+  - with `from builtins import str`
+  - with `from builtins import bytes`
+
+"""
+from __future__ import print_function, division
+from builtins import str, bytes
+
+import logging
+import unittest
+from WMCore.WMException import WMException
+
+
+class WMExceptionTest(unittest.TestCase):
+    """
+    A test of a generic exception class
+    """
+    def setUp(self):
+        """
+        setup log file output.
+        """
+        logging.basicConfig(level=logging.NOTSET,
+                            format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
+                            datefmt='%m-%d %H:%M',
+                            filename='%s.log' % __file__,
+                            filemode='w')
+
+        self.logger = logging.getLogger('WMExceptionTest')
+
+        self.test_data = {
+            'key-ascii': 'value-1',       # unicode (ascii): unicode (ascii)
+            'key-ascii-b': '√@ʟυℯ-1',     # unicode (ascii): unicode (non-ascii)
+            'key-ascii-c': u'√@ʟυℯ-1',    # unicode (ascii): unicode (non-ascii)
+            'key-ascii-d': bytes('√@ʟυℯ-1', 'utf-8'),    # unicode (ascii): bytes (of non-ascii)
+            'ḱℯƴ-unicode-a': 'ṽ@łυ℮-2',   # unicode (non-ascii): unicode (non-ascii)
+            u'ḱℯƴ-unicode-b': 'ṽ@łυ℮-2',  # unicode (non-ascii): unicode (non-ascii)
+            bytes('ḱℯƴ-unicode-c', 'utf-8'): 'ṽ@łυ℮-2',  # bytes (of non-ascii): unicode (non-ascii)
+            'ḱℯƴ-unicode-d': 'value-\x95',  # unicode (of non-ascii): unicode (invalid byte)
+            'key-\x95': 'ṽ@łυ℮-2',  # unicode (invalid byte): unicode (non-ascii)
+            'key3': 3.14159,
+            # This would break WMException, but should not happen
+            # 'key4': {
+            #     b'ḱℯƴ-unicode-c': 'ṽ@łυ℮-2',  # bytes (of unicode): unicode
+            # }
+            }
+
+    def tearDown(self):
+        """
+        nothing to tear down
+        """
+
+        pass
+
+    def testException(self):
+        """
+        create an exception and do some tests (only ascii chars)
+        """
+
+        exception = WMException("an exception message with nr. 100", 100)
+        self.logger.debug("String version of exception: %s", str(exception))
+        self.logger.debug("XML version of exception: %s", exception.xml())
+        self.logger.debug("Adding data")
+        data = {}
+        data['key1'] = 'value1'
+        data['key2'] = 3.14159
+        exception.addInfo(**data)
+        self.logger.debug("String version of exception: %s", str(exception))
+
+    def testExceptionUnicode0(self):
+        """
+        create an exception with non-ascii chars in message and test WMException.addInfo().
+        """
+
+        exception = WMException("an exception message with nr. 100 and some non-ascii characters: ₩♏ℭ☺яε", 100)
+        exception.addInfo(**self.test_data)
+        self.logger.debug("XML version of exception: %s", exception.xml())
+        self.logger.debug("String version of exception: %s", str(exception))
+
+    def testExceptionUnicode1(self):
+        """
+        create an exception with non-ascii chars in message and test WMException constructor
+        """
+
+        exception = WMException("an exception message with nr. 100 and some non-ascii characters: ₩♏ℭ☺яε", 100, **self.test_data)
+        self.logger.debug("XML version of exception: %s", exception.xml())
+        self.logger.debug("String version of exception: %s", str(exception))
+        self.logger.debug("exception.__str__(): %s", type(exception.__str__()))  # <class 'future.types.newbytes.newbytes'>
+        self.logger.debug("str(exception): %s", type(str(exception)))  # <class 'future.types.newstr.newstr'>
+        self.logger.debug("unicode(exception): %s", type(unicode(exception)))  # <class 'future.types.newstr.newstr'>
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #10173

#### Status

Ready

#### Related PRs

This PR is an alternative to #10187, which is preferred to this PR.

This PR also supersedes #10168 , since this involve `self[key]` -> `self.data[key]` (it is not compulsory to have this change in this PR, we can keep this in a separate PR)

#### Is it backward compatible (if not, which system it affects?)

_Pro_

This PR strives to be as backward compatible as possible

_Cons_

WMException would not be modernized and will not run in python 3. This PR is intended to be a temporary patch only.

#### Description

1. the first commit is a cherry-pick of the first commit of #10187, it is about new tests for `WMException.py` to check how it handles exceptions raised by both modules compatible with py2 only and modules modernized to py2py3.
    - the test `test/python/WMCore_t/WMException_py2_t.py` fails (in accordance to Alan's observations in #10152 ).
2. The second commit is an alternative to the second commit of #10187. This commit does not modernize WMException, but makes it compatible with both modules that are modernized and modules that support py2 only.
    - the test `test/python/WMCore_t/WMException_py2_t.py` succeeds again, `test/python/WMCore_t/WMException_py2py3_t.py` does not fail, `test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/CMSSW_t.py` tests do not fail. Everything is fine.
3. The third commit will **not** be needed if and when merging this PR, but it is a test. Following the schema presented in [this comment](https://github.com/dmwm/WMCore/pull/10187#issuecomment-746711709), it mimics migrating `B2` (that we called slice 2) before migrating `A` (that we called slice 1).
    - no tests fail at this stage
 4. The fourth commit is the full modernization of `WMException`. This will **not** be needed if and when merging this PR. It mimics the modernization of `A` after having modernized `B2`. 
     - no tests fail at this stage. Or better , some code that depends on WMException and that is not covered by unit tests may break, but no unit tests in the scope our experiment break, which mean that `test/python/WMCore_t/WMException_*_t.py` and `test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/CMSSW_t.py` do not fail.

This a new approach to the migration:
- when we find a bug in a module that supports py2 only, we fix the bug keeping the support for py2 only
- we start the migration from the last slice, in our case from the 26th
- then we proceed with the previous one, and so on.

This has the following advantages:
- keeping the code fully py2 compatible (or at least it should be, but there is no evidence at this moment that would suggest me otherwise) so that we can keep running our code in py2 while we modernize WMCore
- by updating before the "client" code and only then the more "basic"/"core" one, we should not encounter errors such as in #10187 .

This new approach does not have any evident drawback. 

#### External dependencies / deployment changes

This PR requires python-future only, no changes are required.
