### PR TITLE
Hack: Use dataset_locks to find pileup block locations in WMAgent

### DIFF
--- a/src/python/WMCore/Services/Rucio/Rucio.py
+++ b/src/python/WMCore/Services/Rucio/Rucio.py
@@ -1009,7 +1009,6 @@ class Rucio(object):
         if not self.isContainer(container):
             raise WMRucioException("Pileup location needs to be resolved for a container DID type")
 
-        multiRSERules = []
         finalRSEs = set()
         kargs = dict(name=container, account=account, scope=scope)
 
@@ -1019,28 +1018,19 @@ class Rucio(object):
             if rses and rule['copies'] == len(rses) and rule['state'] == "OK":
                 # then we can guarantee that data is locked and available on these RSEs
                 finalRSEs.update(set(rses))
-            # it could be that the rule was made against Tape only, so check
-            elif rses:
-                multiRSERules.append(rule['id'])
         self.logger.info("Pileup container location for %s from single RSE locks at: %s",
                          kargs['name'], list(finalRSEs))
 
-        # Second, find all the blocks in this pileup container and assign the container
-        # level locations to them
-        for blockName in self.getBlocksInContainer(kargs['name']):
-            result.update({blockName: finalRSEs})
-        if not multiRSERules:
-            # then that is it, we can return the current RSEs holding and locking this data
-            return result
-
         # if we got here, then there is a third step to be done.
         # List every single block lock and check if the rule belongs to the WMCore system
-        for blockName in result:
+        for blockName in self.getBlocksInContainer(kargs['name']):
+            blockRSEs = set()
             for blockLock in self.cli.get_dataset_locks(scope, blockName):
                 if isTapeRSE(blockLock['rse']):
                     continue
-                if blockLock['state'] == 'OK' and blockLock['rule_id'] in multiRSERules:
-                    result[blockName].add(blockLock['rse'])
+                if blockLock['state'] == 'OK':
+                    blockRSEs.add(blockLock['rse'])
+            result[blockName] = finalRSEs | blockRSEs
         return result
 
     def getParentContainerRules(self, **kwargs):

--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -444,7 +444,7 @@ class SetupCMSSWPset(ScriptInterface):
                 inputTypeAttrib.fileNames = cms.untracked.vstring()
                 if pileupType == requestedPileupType:
                     eventsAvailable = 0
-                    useAAA = True if getattr(self.jobBag, 'trustPUSitelists', False) else False
+                    useAAA = False
                     self.logger.info("Pileup set to read data remotely: %s", useAAA)
                     for blockName in sorted(pileupDict[pileupType].keys()):
                         blockDict = pileupDict[pileupType][blockName]


### PR DESCRIPTION
Superseeds https://github.com/dmwm/WMCore/pull/10051

1.4.3 wmagent branch specific hack to allow only a sub-set of the pileup blocks locally available to be used.
Required by the P&R team to run some site I/O tests.

So, this changes the current behaviour which is based only on the container level rules, to also consider all the dataset_locks for every single block in the pileup container.

Applying this patch to vocms0285 (the backfill agent).