### PR TITLE
Fix pileup location with multi-RSE rules

### DIFF
--- a/src/python/WMCore/Services/Rucio/Rucio.py
+++ b/src/python/WMCore/Services/Rucio/Rucio.py
@@ -1044,11 +1044,13 @@ class Rucio(object):
         # if we got here, then there is a third step to be done.
         # List every single block lock and check if the rule belongs to the WMCore system
         for blockName in result:
+            blockRSEs = set()
             for blockLock in self.cli.get_dataset_locks(scope, blockName):
                 if isTapeRSE(blockLock['rse']):
                     continue
                 if blockLock['state'] == 'OK' and blockLock['rule_id'] in multiRSERules:
-                    result[blockName].add(blockLock['rse'])
+                    blockRSEs.add(blockLock['rse'])
+            result[blockName] = finalRSEs | blockRSEs
         return result
 
     def getParentContainerRules(self, **kwargs):


### PR DESCRIPTION
Fixes #10193 

#### Status
ready

#### Description
This fixes the way blocks location were added to the `result` structure, avoiding to use the same memory reference (content) for every single block. Silly variable by value vs variable by reference mistake!

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
None

#### External dependencies / deployment changes
None
