### PR TITLE
Stop trying to resolve StepChain parentage for workflows in normal-archived

### DIFF
--- a/src/python/WMCore/ReqMgr/CherryPyThreads/StepChainParentageFixTask.py
+++ b/src/python/WMCore/ReqMgr/CherryPyThreads/StepChainParentageFixTask.py
@@ -36,7 +36,7 @@ class StepChainParentageFixTask(CherryPyPeriodicTask):
         super(StepChainParentageFixTask, self).__init__(config)
         self.reqmgrDB = RequestDBWriter(config.reqmgrdb_url)
         self.dbsSvc = DBS3Reader(config.dbs_url, logger=self.logger)
-        self.statusToCheck = ["closed-out", "announced", "normal-archived"]
+        self.statusToCheck = ["closed-out", "announced"]
 
     def setConcurrentTasks(self, config):
         """


### PR DESCRIPTION
Fixes #10199 

#### Status
ready

#### Description
The title says it all, stop checking whether stepchain parentage is resolved for workflows in `normal-archived` status. MSRuleCleaner will start ensuring that is the case in the upcoming production deployment, on Jan 12th.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
