### PR TITLE
Fix indentation in WebTools/Root

### DIFF
--- a/src/python/WMCore/WebTools/Root.py
+++ b/src/python/WMCore/WebTools/Root.py
@@ -96,16 +96,17 @@ class WTLogger(LogManager):
         if not rbytes:
             try:
                 # request.rfile.rfile.bytes_read is a custom CMS web
-                #  cherrypy patch not always available, hence the test
-                rbytes = (getattr(request.rfile, 'rfile', None)
-                        and getattr(request.rfile.rfile, "bytes_read", None)
-                        and request.rfile.rfile.bytes_read) or "-"
+                # cherrypy patch not always available, hence the test
+                if request.rfile.rfile.bytes_read:
+                    rbytes = request.rfile.rfile.bytes_read
+                else:
+                    rbytes = "-"
             except:
                 try:
                     # this will work only when body is read from request
                     rbytes = cherrypy.request.body.fp.bytes_read
                 except:
-                    rbytes = "-"        
+                    rbytes = "-"
         msg = ('%(t)s %(H)s %(h)s "%(r)s" %(s)s'
                + ' [data: %(i)s in %(b)s out %(T).0f us ]'
                + ' [auth: %(AS)s "%(AU)s" "%(AC)s" ]'

--- a/test/python/WMCore_t/MicroService_t/MicroService_t.py
+++ b/test/python/WMCore_t/MicroService_t/MicroService_t.py
@@ -8,11 +8,7 @@ from __future__ import division, print_function
 from future.utils import viewitems
 
 import unittest
-import time
-import random
 import cherrypy
-import gzip
-import json
 from WMCore_t.MicroService_t import TestConfig
 from WMCore.MicroService.Service.RestApiHub import RestApiHub
 from WMCore.MicroService.Tools.Common import cert, ckey
@@ -91,13 +87,11 @@ class MicroServiceTest(unittest.TestCase):
         url = '%s/%s' % (self.url, api)
         params = {}
         data = self.mgr.getdata(url, params=params, headers=self.noEncHeader, encode=True, decode=True)
-        data = gzipDecompress(data)
         self.assertEqual(data['result'][0]['microservice'], self.managerName)
         self.assertEqual(data['result'][0]['api'], api)
 
         params = {"service": "transferor"}
         data = self.mgr.getdata(url, params=params, headers=self.noEncHeader, encode=True, decode=True)
-        data = gzipDecompress(data)
         self.assertEqual(data['result'][0]['microservice'], self.managerName)
         self.assertEqual(data['result'][0]['api'], api)
 
@@ -121,13 +115,11 @@ class MicroServiceTest(unittest.TestCase):
         url = '%s/%s' % (self.url, api)
         params = {}
         data = self.mgr.getdata(url, params=params, encode=True, decode=True)
-        data = gzipDecompress(data)
         self.assertEqual(data['result'][0]['microservice'], self.managerName)
         self.assertEqual(data['result'][0]['api'], api)
 
         params = {"request": "fake_request_name"}
         data = self.mgr.getdata(url, params=params, encode=True, decode=True)
-        data = gzipDecompress(data)
         self.assertEqual(data['result'][0]['microservice'], self.managerName)
         self.assertEqual(data['result'][0]['api'], api)
 
@@ -139,13 +131,11 @@ class MicroServiceTest(unittest.TestCase):
         # headers = {'Content-Type': 'application/json', 'Accept-Encoding': 'gzip'}
         data = self.mgr.getdata(url, params=params, headers=self.gzipEncHeader, encode=True, decode=True)
         # data = self.mgr.getdata(url, params=params, encode=True, decode=False)
-        # data = gzipDecompress(data)
         self.assertEqual(data['result'][0]['microservice'], self.managerName)
         self.assertEqual(data['result'][0]['api'], api)
 
         params = {"request": "fake_request_name"}
         data = self.mgr.getdata(url, params=params, headers=self.gzipEncHeader, encode=True, decode=True)
-        # data = gzipDecompress(data)
         self.assertEqual(data['result'][0]['microservice'], self.managerName)
         self.assertEqual(data['result'][0]['api'], api)
         cherrypy.engine.exit()

--- a/test/python/WMCore_t/MicroService_t/MicroService_t.py
+++ b/test/python/WMCore_t/MicroService_t/MicroService_t.py
@@ -81,10 +81,10 @@ class MicroServiceTest(unittest.TestCase):
     def tearDown(self):
         "Tear down MicroService"
         cherrypy.engine.stop()
-        cherrypy.engine.exit()
+        #cherrypy.engine.exit()
 
     def testGetStatus(self):
-        "Test function for getting state of the MicroService"
+        "Test function for getting status of the MicroService"
         api = "status"
         url = '%s/%s' % (self.url, api)
         params = {}
@@ -148,7 +148,7 @@ class MicroServiceTest(unittest.TestCase):
         self.assertEqual(data['result'][0]['api'], api)
 
     def testPostCall(self):
-        "Test function for getting state of the MicroService"
+        "Test function for getting status of a request from the MicroService"
         api = "status"
         url = self.url + "/%s" % api
         params = {"request": "fake_request_name"}

--- a/test/python/WMCore_t/MicroService_t/MicroService_t.py
+++ b/test/python/WMCore_t/MicroService_t/MicroService_t.py
@@ -7,8 +7,8 @@ Author: Valentin Kuznetsov <vkuznet [AT] gmail [DOT] com>
 from __future__ import division, print_function
 
 import unittest
-
 import time
+import random
 import cherrypy
 import gzip
 import json
@@ -66,7 +66,7 @@ class MicroServiceTest(unittest.TestCase):
         config.manager = manager
         mount = '/microservice/data'
         self.mgr = RequestHandler()
-        self.port = config.main.port
+        self.port = config.main.port + random.randint(5000, 6000)
         self.url = 'http://localhost:%s%s' % (self.port, mount)
         cherrypy.config["server.socket_port"] = self.port
         self.app = ServiceManager(config)
@@ -83,7 +83,6 @@ class MicroServiceTest(unittest.TestCase):
 
     def tearDown(self):
         "Tear down MicroService"
-        time.sleep(5)
         print("AMR: going to stop cherrypy engine")
         cherrypy.engine.stop()
         print("AMR: going to exit cherrypy engine")

--- a/test/python/WMCore_t/MicroService_t/MicroService_t.py
+++ b/test/python/WMCore_t/MicroService_t/MicroService_t.py
@@ -123,6 +123,8 @@ class MicroServiceTest(unittest.TestCase):
         data = self.mgr.getdata(url, params=params, headers=self.identityEncHeader, encode=True, decode=True)
         self.assertEqual(data['result'][0]['microservice'], self.managerName)
         self.assertEqual(data['result'][0]['api'], api)
+        cherrypy.engine.exit()
+        cherrypy.engine.stop()
 
     def testGetInfo(self):
         "Test function for getting state of the MicroService"
@@ -157,6 +159,8 @@ class MicroServiceTest(unittest.TestCase):
         # data = gzipDecompress(data)
         self.assertEqual(data['result'][0]['microservice'], self.managerName)
         self.assertEqual(data['result'][0]['api'], api)
+        cherrypy.engine.exit()
+        cherrypy.engine.stop()
 
     def testPostCall(self):
         "Test function for getting status of a request from the MicroService"
@@ -177,6 +181,8 @@ class MicroServiceTest(unittest.TestCase):
         data = self.mgr.getdata(url, params=params, headers=headers, verb='POST',
                                 cert=cert(), ckey=ckey(), encode=True, decode=True)
         self.assertDictEqual(data['result'][0], {'status': 'OK', 'api': 'info'})
+        cherrypy.engine.exit()
+        cherrypy.engine.stop()
 
 
 if __name__ == '__main__':

--- a/test/python/WMCore_t/MicroService_t/MicroService_t.py
+++ b/test/python/WMCore_t/MicroService_t/MicroService_t.py
@@ -17,16 +17,7 @@ from WMCore_t.MicroService_t import TestConfig
 from WMCore.MicroService.Service.RestApiHub import RestApiHub
 from WMCore.MicroService.Tools.Common import cert, ckey
 from WMCore.Services.pycurl_manager import RequestHandler
-from Utils.Utilities import decodeBytesToUnicode
-
-
-def gzipDecompress(payload):
-    """Util to Gzip decompress a given data object"""
-    if isinstance(payload, bytes):
-        payload = gzip.decompress(payload)
-        payload = decodeBytesToUnicode(payload)
-        return json.loads(payload)
-    return payload
+from nose.plugins.attrib import attr
 
 
 class ServiceManager(object):
@@ -162,6 +153,7 @@ class MicroServiceTest(unittest.TestCase):
         cherrypy.engine.exit()
         cherrypy.engine.stop()
 
+    @attr("integration")
     def testPostCall(self):
         "Test function for getting status of a request from the MicroService"
         api = "status"

--- a/test/python/WMCore_t/MicroService_t/MicroService_t.py
+++ b/test/python/WMCore_t/MicroService_t/MicroService_t.py
@@ -7,6 +7,8 @@ Author: Valentin Kuznetsov <vkuznet [AT] gmail [DOT] com>
 from __future__ import division, print_function
 
 import unittest
+
+import time
 import cherrypy
 import gzip
 import json
@@ -70,6 +72,7 @@ class MicroServiceTest(unittest.TestCase):
         self.app = ServiceManager(config)
         self.server = RestApiHub(self.app, config, mount)
         cherrypy.tree.mount(self.server, mount)
+        print("AMR: going to start cherrypy engine")
         cherrypy.engine.start()
         # implicitly request data compressed with gzip (default in RequestHandler class)
         self.noEncHeader = {'Accept': 'application/json'}
@@ -80,8 +83,11 @@ class MicroServiceTest(unittest.TestCase):
 
     def tearDown(self):
         "Tear down MicroService"
+        time.sleep(5)
+        print("AMR: going to stop cherrypy engine")
         cherrypy.engine.stop()
-        #cherrypy.engine.exit()
+        print("AMR: going to exit cherrypy engine")
+        cherrypy.engine.exit()
 
     def testGetStatus(self):
         "Test function for getting status of the MicroService"

--- a/test/python/WMCore_t/MicroService_t/MicroService_t.py
+++ b/test/python/WMCore_t/MicroService_t/MicroService_t.py
@@ -86,7 +86,7 @@ class MicroServiceTest(unittest.TestCase):
             del cherrypy.servers[name]
 
     def testGetStatus(self):
-        "Test function for getting status of the MicroService"
+        """Test the GET RESTful APIs: status and info"""
         api = "status"
         url = '%s/%s' % (self.url, api)
         params = {}
@@ -114,8 +114,6 @@ class MicroServiceTest(unittest.TestCase):
         data = self.mgr.getdata(url, params=params, headers=self.identityEncHeader, encode=True, decode=True)
         self.assertEqual(data['result'][0]['microservice'], self.managerName)
         self.assertEqual(data['result'][0]['api'], api)
-        cherrypy.engine.exit()
-        cherrypy.engine.stop()
 
     def testGetInfo(self):
         "Test function for getting state of the MicroService"

--- a/test/python/WMCore_t/MicroService_t/MicroService_t.py
+++ b/test/python/WMCore_t/MicroService_t/MicroService_t.py
@@ -66,13 +66,13 @@ class MicroServiceTest(unittest.TestCase):
         config.manager = manager
         mount = '/microservice/data'
         self.mgr = RequestHandler()
-        self.port = config.main.port + random.randint(5000, 6000)
+        self.port = config.main.port + random.randint(0, 5)
         self.url = 'http://localhost:%s%s' % (self.port, mount)
         cherrypy.config["server.socket_port"] = self.port
         self.app = ServiceManager(config)
         self.server = RestApiHub(self.app, config, mount)
         cherrypy.tree.mount(self.server, mount)
-        print("AMR: going to start cherrypy engine")
+        print("AMR: going to start cherrypy engine on url: %s", self.url)
         cherrypy.engine.start()
         # implicitly request data compressed with gzip (default in RequestHandler class)
         self.noEncHeader = {'Accept': 'application/json'}

--- a/test/python/WMCore_t/MicroService_t/TestConfig.py
+++ b/test/python/WMCore_t/MicroService_t/TestConfig.py
@@ -16,7 +16,7 @@ main = config.section_("main")
 srv = main.section_("server")
 srv.thread_pool = 30
 main.application = "microservice"
-main.port = 9100  # main application port it listens on
+main.port = 8080 # 9100  # main application port it listens on
 main.index = 'ui' # Configuration requires index attribute
 # Security configuration
 #main.authz_defaults = {"role": None, "group": None, "site": None}

--- a/test/python/WMCore_t/MicroService_t/TestConfig.py
+++ b/test/python/WMCore_t/MicroService_t/TestConfig.py
@@ -16,7 +16,7 @@ main = config.section_("main")
 srv = main.section_("server")
 srv.thread_pool = 30
 main.application = "microservice"
-main.port = 8833  # main application port it listens on
+main.port = 9100  # main application port it listens on
 main.index = 'ui' # Configuration requires index attribute
 # Security configuration
 #main.authz_defaults = {"role": None, "group": None, "site": None}


### PR DESCRIPTION
Fixes #10207 

#### Status
not-tested

#### Description
Fix indentation and also make that rbytes assignment more clear, to me at least.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
