### PR TITLE
[py2py3] Fix possible bug in ConfigSectionTree.format()

### DIFF
--- a/src/python/WMCore/WMSpec/ConfigSectionTree.py
+++ b/src/python/WMCore/WMSpec/ConfigSectionTree.py
@@ -10,7 +10,7 @@ of ConfigSections
 
 
 
-from builtins import str, object
+from builtins import str, bytes, object
 
 from WMCore.Configuration import ConfigSection
 
@@ -227,7 +227,7 @@ def format(value):
     format a value as python
     keep parameters simple, trust python...
     """
-    if isinstance(value, str):
+    if isinstance(value, (str, bytes)):
         value = "\'%s\'" % value
     return str(value)
 


### PR DESCRIPTION
Fixes #10218 

#### Status

ready

#### Related PRs

Since #10172 has been merger, it is ok to merge this PR now

#### Description

In `src/python/WMCore/WMSpec/ConfigSectionTree.py` before #10103 we used

```python
def format(value):
    if isinstance(value, str):
        value = "\'%s\'" % value
    return str(value)
```

Then we added `from builtins import str` and it changes the behavior of this function, surrounding only unicode strings and returning unicode strings.

As discussed in #10218, we sould like to surround both unicode and bytes strings, and to return unicode strings. This is the best option among the ones presented in #10218 based on what we know now.

#### Is it backward compatible (if not, which system it affects?)

It should be. However it is possible that some module rely on the return value of `ConfigSectionTree.format()` to be exactly a string of type bytes and not unicode. We will have to wait for a testbed / pre-production environment for the hard truth!

#### External dependencies / deployment changes
no changes in external dependencies
