### PR TITLE
fix traceback for REST/Main

### DIFF
--- a/src/python/WMCore/REST/Main.py
+++ b/src/python/WMCore/REST/Main.py
@@ -20,7 +20,7 @@ import thread
 import time
 import traceback
 from argparse import ArgumentParser
-from io import StringIO
+from io import BytesIO, StringIO
 from glob import glob
 from subprocess import Popen, PIPE
 from pprint import pformat
@@ -422,7 +422,7 @@ class RESTDaemon(RESTMain):
             self.run()
         except Exception as e:
             error = True
-            trace = StringIO()
+            trace = BytesIO()
             traceback.print_exc(file=trace)
             cherrypy.log("ERROR: terminating due to error: %s" % trace.getvalue())
 


### PR DESCRIPTION
@amaltaro this PR backports to crab branch part of the fixes done to Main.py in master for py2/3 compatibility, just enough that it prints the traceback when REST startup fails.
There is therefore no need to make a PR for master, but I'd like to have it merged in the CRAB branch and get a new tag.
If you prefer that I take care, I think I have can... but this is your repository !
Yes, we are almost ready to start working on porting CRAB to py3.

PS.: similar changes as those provided in: https://github.com/dmwm/WMCore/pull/9871 