### PR TITLE
Apply utf-8 encoding when converting unicode to byte strings in the DBFormatter

### DIFF
--- a/src/python/Utils/Utilities.py
+++ b/src/python/Utils/Utilities.py
@@ -15,6 +15,9 @@ import sys
 from types import ModuleType, FunctionType
 from gc import get_referents
 
+### Flag reporting whether we are running under a python3 interpreter or not
+PY3 = sys.version_info[0] == 3
+
 
 def lowerCmsHeaders(headers):
     """
@@ -221,6 +224,27 @@ def decodeBytesToUnicode(value, errors="strict"):
     """
     if isinstance(value, bytes):
         return value.decode("utf-8", errors)
+    return value
+
+
+def encodeToString(value, errors="strict"):
+    """
+    This function encodes a sequence of unicode code points, or a sequence
+    of bytes (bytes type) to a sequence of byte strings under the str type.
+
+    py2:
+    - "errors" can be: "strict", "ignore", "replace",
+    - ref: https://docs.python.org/2/howto/unicode.html#the-unicode-type
+    py3:
+    - "errors" can be: "strict", "ignore", "replace", "backslashreplace"
+    - ref: https://docs.python.org/3/howto/unicode.html#the-string-type
+    """
+    if PY3:
+        if isinstance(value, bytes):
+            return str(value, 'utf-8', errors)
+    else:
+        # then encode either bytes / str / unicode to string
+        return value.encode('utf-8', errors)
     return value
 
 

--- a/src/python/WMCore/Database/DBFormatter.py
+++ b/src/python/WMCore/Database/DBFormatter.py
@@ -6,12 +6,12 @@ Holds a bunch of helper methods to format input and output of sql
 interactions.
 """
 
-from builtins import str, bytes, zip, range
+from builtins import str, zip, range
 
 import datetime
 import time
 import types
-
+from Utils.Utilities import encodeToString
 from WMCore.DataStructs.WMObject import WMObject
 
 
@@ -78,7 +78,7 @@ class DBFormatter(WMObject):
                 for index in range(0, len(descriptions)):
                     # WARNING: Oracle returns table names in CAP!
                     if isinstance(i[index], str):
-                        entry[str(descriptions[index].lower())] = bytes(i[index], "utf-8")
+                        entry[str(descriptions[index].lower())] = encodeToString(i[index])
                     else:
                         entry[str(descriptions[index].lower())] = i[index]
 
@@ -99,7 +99,7 @@ class DBFormatter(WMObject):
             for i in r.fetchall():
                 for index in range(0, len(descriptions)):
                     if isinstance(i[index], str):
-                        listOut.append(bytes(i[index], "utf-8"))
+                        listOut.append(encodeToString(i[index]))
                     else:
                         listOut.append(i[index])
             r.close()

--- a/src/python/WMCore/Database/DBFormatter.py
+++ b/src/python/WMCore/Database/DBFormatter.py
@@ -78,7 +78,7 @@ class DBFormatter(WMObject):
                 for index in range(0, len(descriptions)):
                     # WARNING: Oracle returns table names in CAP!
                     if isinstance(i[index], str):
-                        entry[str(descriptions[index].lower())] = bytes(i[index])
+                        entry[str(descriptions[index].lower())] = bytes(i[index], "utf-8")
                     else:
                         entry[str(descriptions[index].lower())] = i[index]
 
@@ -99,7 +99,7 @@ class DBFormatter(WMObject):
             for i in r.fetchall():
                 for index in range(0, len(descriptions)):
                     if isinstance(i[index], str):
-                        listOut.append(bytes(i[index]))
+                        listOut.append(bytes(i[index], "utf-8"))
                     else:
                         listOut.append(i[index])
             r.close()


### PR DESCRIPTION
Fixes #10235 

#### Status
not-tested

#### Description
We need to provide which codec to be used when converting unicode strings to the bytes sequence string, thus this PR sets it to `utf-8`.

#### Is it backward compatible (if not, which system it affects?)
Yes

#### Related PRs
Follow up / bugfix for https://github.com/dmwm/WMCore/pull/10057

#### External dependencies / deployment changes
none