### PR TITLE
Fix utf-8 encoding when converting unicode to byte strings in the DBFormatter

### DIFF
--- a/src/python/WMCore/Database/DBFormatter.py
+++ b/src/python/WMCore/Database/DBFormatter.py
@@ -78,7 +78,7 @@ class DBFormatter(WMObject):
                 for index in range(0, len(descriptions)):
                     # WARNING: Oracle returns table names in CAP!
                     if isinstance(i[index], str):
-                        entry[str(descriptions[index].lower())] = bytes(i[index])
+                        entry[str(descriptions[index].lower())] = i[index].encode("utf-8")
                     else:
                         entry[str(descriptions[index].lower())] = i[index]
 
@@ -99,7 +99,7 @@ class DBFormatter(WMObject):
             for i in r.fetchall():
                 for index in range(0, len(descriptions)):
                     if isinstance(i[index], str):
-                        listOut.append(bytes(i[index]))
+                        listOut.append(i[index].encode("utf-8"))
                     else:
                         listOut.append(i[index])
             r.close()


### PR DESCRIPTION
Fixes #10235 
Superseeds https://github.com/dmwm/WMCore/pull/10236

#### Status
ready

#### Description
In #10057, the modernization of DBFormatter was not correct. After investigation by Alan on oracle db and by myself on mysqldb (mariadb?) we came up with a simple solution that makes py2 work. 
python2 behavior:
- oracle: returns `unicode`
- mysqldb: returns `str` -> bytes
it is possible that the mysql library that we chose to use in py3 will return unicode in py3, hence I will postpone the search for a final solution to _after_ having chosen a mysql library for py3 and having a py3 env

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
alternative to #10236

#### External dependencies / deployment changes
nope
