### PR TITLE
Convert Campaign pileup data location to PSNs to match against the SiteWhitelist

### DIFF
--- a/src/python/WMCore/Services/CRIC/CRIC.py
+++ b/src/python/WMCore/Services/CRIC/CRIC.py
@@ -202,7 +202,7 @@ class CRIC(Service):
         """
         Given a PSN regex pattern, return a map of PSN to PNNs
         :param psnPattern: a pattern string
-        :return: a dictionary of PNNs list keyed by their PSN
+        :return: a dictionary key'ed by PSN names, with sets of PNNs as values
         """
         if not isinstance(psnPattern, basestring):
             raise TypeError('psnPattern argument must be of type basestring')
@@ -214,4 +214,22 @@ class CRIC(Service):
         for entry in results:
             if psnPattern.match(entry['psn_name']):
                 mapping.setdefault(entry['psn_name'], set()).add(entry['phedex_name'])
+        return mapping
+
+    def PNNtoPSNMap(self, pnnPattern=''):
+        """
+        Given a PNN regex pattern, return a map of PNN to PSNs
+        :param pnnPattern: a pattern string
+        :return: a dictionary key'ed by PNN names, with sets of PSNs as values
+        """
+        if not isinstance(pnnPattern, basestring):
+            raise TypeError('pnnPattern argument must be of type basestring')
+
+        results = self._CRICSiteQuery(callname='data-processing')
+        mapping = {}
+
+        pnnPattern = re.compile(pnnPattern)
+        for entry in results:
+            if pnnPattern.match(entry['phedex_name']):
+                mapping.setdefault(entry['phedex_name'], set()).add(entry['psn_name'])
         return mapping

--- a/test/python/WMCore_t/MicroService_t/Unified_t/MSTransferor_t.py
+++ b/test/python/WMCore_t/MicroService_t/Unified_t/MSTransferor_t.py
@@ -28,13 +28,19 @@ class TransferorTest(EmulatedUnitTestCase):
 
     def setUp(self):
         "init test class"
-        self.msConfig = {'verbose': False,
-                         'group': 'DataOps',
+        self.msConfig = {'services': ['transferor'],
+                         'verbose': False,
                          'interval': 1 * 60,
                          'enableStatusTransition': True,
-                         'reqmgrUrl': 'https://cmsweb-testbed.cern.ch/reqmgr2',
+                         'enableDataTransfer': False,
+                         'reqmgr2Url': 'https://cmsweb-testbed.cern.ch/reqmgr2',
                          'reqmgrCacheUrl': 'https://cmsweb-testbed.cern.ch/couchdb/reqmgr_workload_cache',
-                         'phedexUrl': 'https://cmsweb-testbed.cern.ch/phedex/datasvc/json/prod',
+                         'quotaUsage': 0.9,
+                         'rucioAccount': 'wma_test',  # it should be wmcore_transferor
+                         # 'rucioAuthUrl': 'https://cms-rucio-auth.cern.ch',
+                         # 'rucioUrl': 'http://cms-rucio.cern.ch',
+                         'rucioAuthUrl': 'https://cmsrucio-auth-int.cern.ch',
+                         'rucioUrl': 'http://cmsrucio-int.cern.ch',
                          'dbsUrl': 'https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader'}
 
         self.msTransferor = MSTransferor(self.msConfig)
@@ -42,6 +48,63 @@ class TransferorTest(EmulatedUnitTestCase):
         self.taskChainTempl = getTestFile('data/ReqMgr/requests/Integration/TaskChain_Prod.json')
         self.stepChainTempl = getTestFile('data/ReqMgr/requests/Integration/SC_LumiMask_PhEDEx.json')
         super(TransferorTest, self).setUp()
+
+    def testGetPNNsFromPSNs(self):
+        """Test MSTransferor private method _getPNNsFromPSNs()"""
+        self.assertItemsEqual(self.msTransferor.psn2pnnMap, {})
+
+        # now fill up the cache
+        self.msTransferor.psn2pnnMap = self.msTransferor.cric.PSNtoPNNMap()
+
+        self.assertItemsEqual(self.msTransferor._getPNNsFromPSNs([]), set())
+        pnns = self.msTransferor._getPNNsFromPSNs(["T1_IT_CNAF", "T1_IT_CNAF_Disk"])
+        self.assertItemsEqual(pnns, set(["T1_IT_CNAF_Disk"]))
+
+        # dropping T3s and CERNBOX
+        pnns = self.msTransferor._getPNNsFromPSNs(["T1_US_FNAL", "T2_CH_CERN_HLT"])
+        self.assertItemsEqual(pnns, set(["T1_US_FNAL_Disk", "T2_CH_CERN"]))
+
+        # testing with non-existant PSNs
+        psns = self.msTransferor._getPNNsFromPSNs(["T1_US_FNAL_Disk", "T2_CH_CERNBOX"])
+        self.assertItemsEqual(psns, set())
+
+    def testGetPSNsFromPNNs(self):
+        """Test MSTransferor private method _getPSNsFromPNNs()"""
+        self.assertItemsEqual(self.msTransferor.pnn2psnMap, {})
+
+        # now fill up the cache
+        self.msTransferor.pnn2psnMap = self.msTransferor.cric.PNNtoPSNMap()
+
+        self.assertItemsEqual(self.msTransferor._getPSNsFromPNNs([]), set())
+        psns = self.msTransferor._getPSNsFromPNNs(["T1_IT_CNAF", "T1_IT_CNAF_Disk"])
+        self.assertItemsEqual(psns, set(["T1_IT_CNAF"]))
+
+        # test dropping T3s
+        psns = self.msTransferor._getPSNsFromPNNs(["T2_UK_SGrid_RALPP"])
+        self.assertItemsEqual(psns, set(["T2_UK_SGrid_RALPP"]))
+
+        # testing with non-existant PNNs
+        psns = self.msTransferor._getPSNsFromPNNs(["T1_US_FNAL", "T2_CH_CERN_HLT"])
+        self.assertItemsEqual(psns, set())
+
+    def testDiskPNNs(self):
+        """Test MSTransferor private method _diskPNNs()"""
+        # empty list of pnns
+        self.assertItemsEqual(self.msTransferor._diskPNNs([]), set())
+
+        # only PNNs that will be dropped
+        pnns = self.msTransferor._diskPNNs(["T1_US_FNAL_Tape", "T1_US_FNAL_MSS",
+                                            "T2_CH_CERNBOX", "T0_CH_CERN_Export"])
+        self.assertItemsEqual(pnns, set())
+
+        # valid PNNs that can receive data
+        pnns = self.msTransferor._diskPNNs(["T1_US_FNAL_Disk", "T2_CH_CERN", "T2_DE_DESY"])
+        self.assertItemsEqual(pnns, set(["T1_US_FNAL_Disk", "T2_CH_CERN", "T2_DE_DESY"]))
+
+        # finally, a mix of valid and invalid PNNs
+        pnns = self.msTransferor._diskPNNs(["T1_US_FNAL_Disk", "T1_US_FNAL_MSS", "T1_US_FNAL_Tape",
+                                            "T2_CH_CERN", "T2_DE_DESY"])
+        self.assertItemsEqual(pnns, set(["T1_US_FNAL_Disk", "T2_CH_CERN", "T2_DE_DESY"]))
 
     def notestRequestRecord(self):
         """

--- a/test/python/WMCore_t/Services_t/CRIC_t/CRIC_t.py
+++ b/test/python/WMCore_t/Services_t/CRIC_t/CRIC_t.py
@@ -239,6 +239,55 @@ class CRICTest(EmulatedUnitTestCase):
 
         return
 
+    def testPNNtoPSNMap(self):
+        """
+        Test API to get a map of PSNs to PNNs
+        """
+        with self.assertRaises(TypeError):
+            self.myCRIC.PNNtoPSNMap(1)
+        with self.assertRaises(TypeError):
+            self.myCRIC.PNNtoPSNMap({'config': 'blah'})
+        with self.assertRaises(TypeError):
+            self.myCRIC.PNNtoPSNMap(['blah'])
+
+        result = self.myCRIC.PNNtoPSNMap()
+        self.assertTrue([psn for psn in result.keys() if psn.startswith('T1_')])
+        self.assertTrue([psn for psn in result.keys() if psn.startswith('T2_')])
+        self.assertTrue([psn for psn in result.keys() if psn.startswith('T3_')])
+        self.assertTrue(len(result) > 50)
+
+        result = self.myCRIC.PNNtoPSNMap(pnnPattern='T1.*')
+        self.assertFalse([psn for psn in result.keys() if not psn.startswith('T1_')])
+        self.assertTrue(len(result) < 10)
+
+        result = self.myCRIC.PNNtoPSNMap(pnnPattern='T2.*')
+        self.assertFalse([psn for psn in result.keys() if not psn.startswith('T2_')])
+        self.assertTrue(len(result) > 10)
+
+        result = self.myCRIC.PNNtoPSNMap(pnnPattern='T3.*')
+        self.assertFalse([psn for psn in result.keys() if not psn.startswith('T3_')])
+        self.assertTrue(len(result) > 10)
+
+        result = self.myCRIC.PNNtoPSNMap('T2_CH_CERN$')
+        self.assertItemsEqual(result.keys(), ['T2_CH_CERN'])
+        self.assertItemsEqual(result['T2_CH_CERN'], ['T2_CH_CERN_HLT', 'T2_CH_CERN'])
+
+        # test a exact site name, which is treated as a regex and yields a confusing result!!!
+        result = self.myCRIC.PNNtoPSNMap('T2_CH_CERN')
+        self.assertItemsEqual(result.keys(), ['T2_CH_CERN', 'T2_CH_CERNBOX'])
+        self.assertItemsEqual(result['T2_CH_CERN'], ['T2_CH_CERN_HLT', 'T2_CH_CERN'])
+        self.assertItemsEqual(result['T2_CH_CERNBOX'], ['T2_CH_CERN'])
+
+        result = self.myCRIC.PNNtoPSNMap('T2_CH_CERN_HLT')
+        self.assertItemsEqual(result, {})
+
+        result = self.myCRIC.PNNtoPSNMap('T1_US_FNAL')
+        self.assertItemsEqual(result.keys(), ['T1_US_FNAL_Disk'])
+        self.assertItemsEqual(result['T1_US_FNAL_Disk'], ['T1_US_FNAL'])
+
+        return
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #10233 

#### Status
ready

#### Description
Summary of changes provided with this PR is:
* a new CRIC API to make a map of PNN to PSN: `PNNtoPSNMap`
* bugfix for MSTransferor, such that when it compares the secondary data location - provided within the Unified campaign configuration - with the SiteWhitelist, it converts those data location (PNNs) to PSNs

It also brings some basic unit tests for MSTransferor.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none