### PR TITLE
Catch UnboundLocalError exception when EmailAlert fails connecting to the SMTP server

### DIFF
--- a/src/python/Utils/EmailAlert.py
+++ b/src/python/Utils/EmailAlert.py
@@ -25,10 +25,8 @@ class EmailAlert(object):
     def send(self, subject, message):
         """
         Send an email
-
         :param subject: Email subject
         :param message: Email body
-
         """
         msg = self.EMAIL_HEADER % (self.fromAddr, subject, ", ".join(self.toAddr))
         msg += message
@@ -38,7 +36,11 @@ class EmailAlert(object):
             smtp.sendmail(self.fromAddr, self.toAddr, msg)
         except Exception as ex:
             logging.exception("Error sending alert email.\nDetails: %s", str(ex))
-        finally:
+
+        try:
             # clean up smtp connection
             smtp.quit()
+        except UnboundLocalError:
+            # it means our client failed connecting to the SMTP server
+            pass
 


### PR DESCRIPTION
Fixes #10234 

#### Status
ready

#### Description
This PR fixes a bug where the SMTP server connection call:
```
smtplib.SMTP(self.serverName)
```

fails, leaving the `smtp` variable unassigned, which then raises an exception in the `finally` block.
In short, make sure the smtp connection is properly cleared.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
