### PR TITLE
add WMBS to crabtaskworker dependencies

### DIFF
--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -119,15 +119,6 @@ dependencies = {
                     'src/javascript/external/graphael',
                     'src/templates/WMCore/WebTools/WMBS'],
     },
-    'asyncstageout': {
-        'packages': ['WMCore.Agent+', 'WMCore.Storage+',
-                     'WMCore.Credential', 'WMCore.WorkerThreads',
-                     'WMCore.Services+'],
-        'modules': ['WMQuality.TestInitCouchApp', 'WMCore.Services.Service',
-                    'WMCore.Services.pycurl_manager', 'WMComponent.__init__'],
-        'systems': ['wmc-database'],
-        'statics': ['src/couchapps/Agent+'],
-    },
     'crabcache': {
         'packages': ['WMCore.Wrappers+', 'WMCore.Services.UserFileCache+'],
         'systems': ['wmc-rest'],
@@ -150,6 +141,7 @@ dependencies = {
         'packages': ['WMCore.Credential', 'WMCore.Algorithms+', 'WMCore.WMSpec+',
                      'WMCore.JobSplitting', 'WMCore.Services+', 'Utils+'],
         'systems': ['wmc-database', 'wmc-runtime'],
+        'modules': ['WMCore.WMBS.File', 'WMCore.WMBS.WMBSBase', 'WMCore.WMBS.__init__'],
     },
     'wmclient': {
         'systems': ['wmc-runtime', 'wmc-database']


### PR DESCRIPTION
#### Status
Ready

#### Description
adds WMBS to crabtaskworker dependencies since now Splitter needs it.
And remove `asyncstageout` from the list of dependencies.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
Will add WMCore/WMBS python files to crabtaskworker rpms
