### PR TITLE
Python3 requirements for WMAgent and WMAgent-Dev

### DIFF
--- a/requirements_py3.txt
+++ b/requirements_py3.txt
@@ -1,0 +1,30 @@
+# Dependencies needed to run WMAgent(-dev) on a python3 stack
+
+### dependencies on the wmagentpy3 spec
+Jinja2==2.11.3
+SQLAlchemy==1.3.3
+cx-Oracle==7.3.0
+future==0.18.2
+httplib2==0.18.1
+psutil==5.8.0
+pyOpenSSL==18.0.0
+pycurl==7.43.0.3
+pyzmq==19.0.2
+retry==0.9.2
+rucio-clients==1.24.2.post1
+sphinx==1.6.3
+### dependencies on the wmcorepy3-devtools spec
+CherryPy==17.4.0
+coverage==5.4
+future==0.18.2
+memory-profiler==0.58.0
+mock==4.0.3
+mox3==1.1.0
+nose2==0.10.0
+nose==1.3.7
+pep8==1.7.1
+psutil==5.8.0
+pylint==2.6.0
+pymongo==3.10.1
+retry==0.9.2
+sphinx==1.6.3


### PR DESCRIPTION
Fixes #10043 

#### Status
ready

#### Description
A compilation list of the python3 dependencies that we have in the wmagentpy3 and wmcorepy3-devtools spec files.

Those specs can be found at:
* https://github.com/cms-sw/cmsdist/blob/comp_gcc630/wmagentpy3.spec ; and
* https://github.com/cms-sw/cmsdist/blob/comp_gcc630/wmcorepy3-devtools.spec

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none