### PR TITLE
[py2py3] pycurl_manager - better handling of curl.setopts() input arguments

### DIFF
--- a/src/python/Utils/Utilities.py
+++ b/src/python/Utils/Utilities.py
@@ -224,6 +224,34 @@ def decodeBytesToUnicode(value, errors="strict"):
     return value
 
 
+def encodeUnicodeToBytes(value, errors="strict"):
+    """
+    Accepts an input "value" of generic type.
+
+    If "value" is a string of type sequence of unicode (i.e. in py2 `unicode` or
+    `future.types.newstr.newstr`, in py3 `str`), then it is converted to
+    a sequence of bytes.
+
+    This function is useful for encoding output data when using the
+    "unicode sandwich" approach, which involves converting unicode (i.e. strings
+    of type sequence of unicode codepoints) to bytes (i.e. strings of type
+    sequence of bytes, in py2 `str` or `future.types.newbytes.newbytes`,
+    in py3 `bytes`) as late as possible when passing a string to a third-party
+    function that only accepts bytes as input (pycurl's curl.setop is an
+    example).
+    py2:
+    - "errors" can be: "strict", "ignore", "replace", "xmlcharrefreplace"
+    - ref: https://docs.python.org/2/howto/unicode.html#the-unicode-type
+    py3:
+    - "errors" can be: "strict", "ignore", "replace", "backslashreplace", 
+      "xmlcharrefreplace", "namereplace"
+    - ref: https://docs.python.org/3/howto/unicode.html#the-string-type
+    """
+    if isinstance(value, str):
+        return value.encode("utf-8", errors)
+    return value
+
+
 # TODO: remove this function once we have completely migrated to Rucio
 def usingRucio():
     """

--- a/src/python/WMCore/Services/pycurl_manager.py
+++ b/src/python/WMCore/Services/pycurl_manager.py
@@ -44,6 +44,7 @@ from builtins import str, range, object
 from past.builtins import basestring
 from future.utils import viewitems
 
+
 # system modules
 import json
 import logging
@@ -55,6 +56,8 @@ import pycurl
 from io import BytesIO
 import http.client
 from urllib.parse import urlencode
+
+from Utils.Utilities import encodeUnicodeToBytes
 
 class ResponseHeader(object):
     """ResponseHeader parses HTTP response header"""
@@ -214,10 +217,10 @@ class RequestHandler(object):
         # we must pass url as a string data-type, otherwise pycurl will fail with error
         # TypeError: invalid arguments to setopt
         # see https://curl.haxx.se/mail/curlpython-2007-07/0001.html
-        curl.setopt(pycurl.URL, str(url))
+        curl.setopt(pycurl.URL, encodeUnicodeToBytes(url))
         if headers:
             curl.setopt(pycurl.HTTPHEADER, \
-                    ["%s: %s" % (k, v) for k, v in viewitems(headers)])
+                [encodeUnicodeToBytes("%s: %s" % (k, v)) for k, v in viewitems(headers)])
         bbuf = BytesIO()
         hbuf = BytesIO()
         curl.setopt(pycurl.WRITEFUNCTION, bbuf.write)

--- a/test/python/WMCore_t/Services_t/pycurl_manager_t.py
+++ b/test/python/WMCore_t/Services_t/pycurl_manager_t.py
@@ -50,10 +50,11 @@ class PyCurlManager(unittest.TestCase):
         # test RequestHandler
         url = "https://cms-gwmsmon.cern.ch/prodview/json/site_summary"
         params = {}
+        headers = {"Cache-Control": "no-cache"}
         tfile = tempfile.NamedTemporaryFile()
         cern_sso_cookie(url, tfile.name, self.cert, self.ckey)
         cookie = {url: tfile.name}
-        header, _ = self.mgr.request(url, params, cookie=cookie)
+        header, _ = self.mgr.request(url, params, headers, cookie=cookie)
         self.assertTrue(header.status, 200)
 
     def testContinue(self):


### PR DESCRIPTION
Fixes #10249 

#### Status
ready

#### Description

Quickly encode the `url` variable if it is a futurized string (if it is unicode, then) before passing it to `curl.setopt()`.

#### Is it backward compatible (if not, which system it affects?)
Should be better backwrd compatible than what we have now, which breaks old pycurl versions and urls that contain non-ascii characters.

#### External dependencies / deployment changes
Same as before
