### PR TITLE
Make WMAgent job wrapper slightly more verbose; fix one error message

### DIFF
--- a/etc/submit.sh
+++ b/etc/submit.sh
@@ -96,19 +96,23 @@ echo -e "======== WMAgent validate arguments finished at $(TZ=GMT date) ========
 echo "======== WMAgent CMS environment load starting at $(TZ=GMT date) ========"
 if [ -f "$VO_CMS_SW_DIR"/cmsset_default.sh ]
 then  #   LCG style --
+    echo "WN with a LCG style environment, thus using VO_CMS_SW_DIR=$VO_CMS_SW_DIR"
     . $VO_CMS_SW_DIR/cmsset_default.sh
 elif [ -f "$OSG_APP"/cmssoft/cms/cmsset_default.sh ]
 then  #   OSG style --
+    echo "WN with an OSG style environment, thus using OSG_APP=$OSG_APP"
     . $OSG_APP/cmssoft/cms/cmsset_default.sh CMSSW_3_3_2
 elif [ -f "$CVMFS"/cms.cern.ch/cmsset_default.sh ]
 then
+    echo "WN with CVMFS environment, thus using CVMFS=$CVMFS"
     . $CVMFS/cms.cern.ch/cmsset_default.sh
 elif [ -f /cvmfs/cms.cern.ch/cmsset_default.sh ]
 then  # ok, lets call it CVMFS then
     export CVMFS=/cvmfs/cms.cern.ch
+    echo "WN missing VO_CMS_SW_DIR/OSG_APP/CVMFS environment variable, forcing it to CVMFS=$CVMFS"
     . $CVMFS/cmsset_default.sh
 else
-    echo "Error during job bootstrap: VO_CMS_SW_DIR, OSG_APP, CVMFS  or /cvmfs were not found." >&2
+    echo "Error during job bootstrap: VO_CMS_SW_DIR, OSG_APP, CVMFS or /cvmfs were not found." >&2
     echo "  Because of this, we can't load CMSSW. Not good." >&2
     exit 11003
 fi
@@ -137,8 +141,8 @@ elif [ -d "$CVMFS"/COMP/"$WMA_SCRAM_ARCH"/external/python ]
 then
     prefix="$CVMFS"/COMP/"$WMA_SCRAM_ARCH"/external/python
 else
-    echo "Error during job bootstrap: job environment does not contain the init.sh script." >&2
-    echo "  Because of this, we can't load CMSSW. Not good." >&2
+    echo "Failed to find a COMP python installation in the worker node setup." >&2
+    echo "  Without a known python, there is nothing else we can do with this job. Quiting!" >&2
     exit 11004
 fi
 


### PR DESCRIPTION
Fixes #10259 

#### Status
ready

#### Description
Be explicit on the worker node setup style that the job is running on (LCG, OSG, CVMFS) and create a record in the log for that.
In addition to that, fix the error message in case a python installation area cannot be located.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
