### PR TITLE
[py2py3] Migration at level scr/python/A/B/C - slice 5

### DIFF
--- a/src/python/WMCore/GroupUser/Interface.py
+++ b/src/python/WMCore/GroupUser/Interface.py
@@ -10,6 +10,8 @@ from __future__ import print_function
 
 
 
+from builtins import str, object
+
 import WMCore.Database.CMSCouch as CMSCouch
 
 class CouchConnectionError(Exception):
@@ -19,7 +21,7 @@ class CouchConnectionError(Exception):
         self.arg = arg
 
 
-class Interface:
+class Interface(object):
     def __init__(self, couchUrl, couchDatabase):
         self.cdb_url = couchUrl
         self.cdb_database = couchDatabase
@@ -63,7 +65,7 @@ class Interface:
         """
         updateUri = "/" + self.couch.name + "/_design/GroupUser/_update/"+ update + "/" + document
         argsstr = "?"
-        for k, v in args.items():
+        for k, v in list(args.items()):
             argsstr += "%s=%s&" % (k, v)
         updateUri += argsstr
         updateUri= updateUri[:-1]

--- a/src/python/WMCore/JobStateMachine/SummaryDB.py
+++ b/src/python/WMCore/JobStateMachine/SummaryDB.py
@@ -7,6 +7,8 @@ Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
 Description: Set of modules/functions to update WMAgent SummaryDB.
 """
 
+from future.utils import viewitems, viewvalues
+
 # system modules
 import logging
 from pprint import pformat
@@ -72,7 +74,7 @@ def fwjr_parser(doc):
     wrappedTotalJobTime = 0
     pdict = dict(totalJobCPU=0, totalJobTime=0, totalEventCPU=0)
     ddict = {}
-    for key, val in steps.items():
+    for key, val in viewitems(steps):
         if val['stop'] is not None and val['start'] is not None:
             wrappedTotalJobTime += val['stop'] - val['start']
         site_name = val['site']
@@ -89,14 +91,14 @@ def fwjr_parser(doc):
                 pdict['totalEventCPU'] += float(perf['cpu']['TotalLoopCPU'])
 
             odict = val['output']
-            for kkk, vvv in odict.items():
+            for kkk, vvv in viewitems(odict):
                 for row in vvv:
                     if row.get('merged', False):
                         prim = row['dataset']['primaryDataset']
                         proc = row['dataset']['processedDataset']
                         tier = row['dataset']['dataTier']
                         dataset = '/%s/%s/%s' % (prim, proc, tier)
-                        totalLumis = sum([len(r) for r in row['runs'].values()])
+                        totalLumis = sum([len(r) for r in viewvalues(row['runs'])])
                         dataset_summary = \
                             dict(size=row['size'], events=row['events'], totalLumis=totalLumis)
                         ddict[dataset] = dataset_summary
@@ -129,7 +131,7 @@ def merge_docs(doc1, doc2):
             del doc1[key]
         if key in doc2:
             del doc2[key]
-    for key, val in doc1.items():
+    for key, val in viewitems(doc1):
         if key not in doc2:
             return False
         if isinstance(val, dict):
@@ -142,9 +144,9 @@ def merge_docs(doc1, doc2):
 
 def update_tasks(old_tasks, new_tasks):
     "Update tasks dictionaries"
-    for task, tval in new_tasks.items():
+    for task, tval in viewitems(new_tasks):
         if task in old_tasks:
-            for site, sval in tval['sites'].items():
+            for site, sval in viewitems(tval['sites']):
                 if site in old_tasks[task]['sites']:
                     old_sdict = old_tasks[task]['sites'][site]
                     new_sdict = sval

--- a/src/python/WMCore/Services/CRIC/CRIC.py
+++ b/src/python/WMCore/Services/CRIC/CRIC.py
@@ -1,4 +1,7 @@
 from __future__ import (division, print_function)
+
+from builtins import zip, str, bytes
+
 from future import standard_library
 standard_library.install_aliases()
 
@@ -141,7 +144,7 @@ class CRIC(Service):
         nodeNames = [x['alias'] for x in sitenames if x['type'] == 'phedex']
         if excludeBuffer:
             nodeNames = [x for x in nodeNames if not x.endswith("_Buffer")]
-        if pattern and isinstance(pattern, basestring):
+        if pattern and isinstance(pattern, (str, bytes)):
             pattern = re.compile(pattern)
             nodeNames = [x for x in nodeNames if pattern.match(x)]
         return nodeNames
@@ -155,7 +158,7 @@ class CRIC(Service):
         """
         mapping = self._CRICSiteQuery(callname='data-processing')
 
-        if isinstance(pnns, basestring):
+        if isinstance(pnns, (str, bytes)):
             pnns = [pnns]
 
         psns = set()
@@ -180,7 +183,7 @@ class CRIC(Service):
         """
         mapping = self._CRICSiteQuery(callname='data-processing')
 
-        if isinstance(psns, basestring):
+        if isinstance(psns, (str, bytes)):
             psns = [psns]
 
         pnns = set()
@@ -204,8 +207,8 @@ class CRIC(Service):
         :param psnPattern: a pattern string
         :return: a dictionary key'ed by PSN names, with sets of PNNs as values
         """
-        if not isinstance(psnPattern, basestring):
-            raise TypeError('psnPattern argument must be of type basestring')
+        if not isinstance(psnPattern, (str, bytes)):
+            raise TypeError('psnPattern argument must be of type str or bytes')
 
         results = self._CRICSiteQuery(callname='data-processing')
         mapping = {}
@@ -222,8 +225,8 @@ class CRIC(Service):
         :param pnnPattern: a pattern string
         :return: a dictionary key'ed by PNN names, with sets of PSNs as values
         """
-        if not isinstance(pnnPattern, basestring):
-            raise TypeError('pnnPattern argument must be of type basestring')
+        if not isinstance(pnnPattern, (str, bytes)):
+            raise TypeError('pnnPattern argument must be of type str or bytes')
 
         results = self._CRICSiteQuery(callname='data-processing')
         mapping = {}

--- a/src/python/WMCore/Services/FWJRDB/FWJRDBAPI.py
+++ b/src/python/WMCore/Services/FWJRDB/FWJRDBAPI.py
@@ -1,8 +1,11 @@
 from __future__ import (division, print_function)
+
+from builtins import str, bytes, object
+
 from WMCore.Database.CMSCouch import CouchServer, Database
 from WMCore.Lexicon import splitCouchServiceURL
 
-class FWJRDBAPI():
+class FWJRDBAPI(object):
 
     def __init__(self, couchURL, dbName=None):
         """
@@ -43,7 +46,7 @@ class FWJRDBAPI():
 
         options = self.setDefaultStaleOptions(options)
 
-        if keys and isinstance(keys, basestring):
+        if keys and isinstance(keys, (str, bytes)):
             keys = [keys]
         return self.couchDB.loadView(self.couchapp, view, options, keys)
 
@@ -71,7 +74,7 @@ class FWJRDBAPI():
         if detail or returnDict:
             return result
         else:
-            return result.keys()
+            return list(result)
 
     def getFWJRByArchiveStatus(self, status, limit=None, skip=None):
         """

--- a/src/python/WMCore/Services/ReqMgr/ReqMgr.py
+++ b/src/python/WMCore/Services/ReqMgr/ReqMgr.py
@@ -1,3 +1,6 @@
+from builtins import str, bytes
+from future.utils import viewitems
+
 import json
 import logging
 
@@ -64,8 +67,8 @@ class ReqMgr(Service):
             args = "_nostale=true&"
         else:
             args = ""
-        for name, values in queryDict.items():
-            if isinstance(values, basestring) or isinstance(values, int):
+        for name, values in viewitems(queryDict):
+            if isinstance(values, (str, bytes, int)):
                 values = [values]
             for val in values:
                 args += '%s=%s&' % (name, val)

--- a/src/python/WMCore/Services/UserFileCache/UserFileCache.py
+++ b/src/python/WMCore/Services/UserFileCache/UserFileCache.py
@@ -5,6 +5,8 @@ _UserFileCache_
 API for UserFileCache service
 """
 
+from builtins import str, bytes
+
 import os
 import json
 import shutil
@@ -42,7 +44,7 @@ def calculateChecksum(tarfile_, exclude=None):
     hasher = hashlib.sha256()
 
     ## "massage" out the input parameters
-    if isinstance(tarfile_, basestring):
+    if isinstance(tarfile_, (str, bytes)):
         tar = tarfile.open(tarfile_, mode='r')
     else:
         tar = tarfile.open(fileobj=tarfile_, mode='r')

--- a/src/python/WMCore/Storage/Registry.py
+++ b/src/python/WMCore/Storage/Registry.py
@@ -9,6 +9,7 @@ rather than using the common implementation to avoid generating
 extra runtime dependencies.
 
 """
+from builtins import object
 import WMCore.WMFactory
 from WMCore.Storage.StageOutError import StageOutError
 from WMCore.Storage.StageOutImpl import StageOutImpl
@@ -23,7 +24,7 @@ class RegistryError(StageOutError):
     pass
 
 
-class Registry:
+class Registry(object):
     """
     _Registry_
 
@@ -45,7 +46,7 @@ def registerStageOutImpl(name, classRef):
     Register a StageOutImpl subclass with the name provided
 
     """
-    if name in Registry.StageOutImpl.keys():
+    if name in Registry.StageOutImpl:
         msg = "Duplicate StageOutImpl registered for name: %s\n" % name
         raise RegistryError(msg)
 

--- a/src/python/WMCore/Storage/StageInMgr.py
+++ b/src/python/WMCore/Storage/StageInMgr.py
@@ -9,6 +9,9 @@ Based on StageOutMgr class
 """
 from __future__ import print_function
 
+from builtins import object
+from future.utils import viewitems
+
 import os
 
 from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig
@@ -29,7 +32,7 @@ class StageInSuccess(Exception):
 
 
 
-class StageInMgr:
+class StageInMgr(object):
     """
     _StageInMgr_
 
@@ -143,7 +146,7 @@ class StageInMgr:
                 overrideParams['option'] = ""
 
         msg = "=======StageIn Override Initialised:================\n"
-        for key, val in overrideParams.items():
+        for key, val in viewitems(overrideParams):
             msg += " %s : %s\n" % (key, val)
         msg += "=====================================================\n"
         print(msg)

--- a/src/python/WMCore/Storage/StageOutImpl.py
+++ b/src/python/WMCore/Storage/StageOutImpl.py
@@ -8,6 +8,8 @@ inherit this object and implement the methods accordingly
 """
 from __future__ import print_function
 
+from builtins import range, object
+
 import logging
 import os
 import time

--- a/src/python/WMCore/Storage/StageOutImplV2.py
+++ b/src/python/WMCore/Storage/StageOutImplV2.py
@@ -7,12 +7,14 @@ inherit this object and implement the methods accordingly
 
 """
 
+from builtins import object
+
 from WMCore.Storage.Execute import runCommandWithOutput as runCommand
 from WMCore.Storage.StageOutError import StageOutError
 import logging
 import os
 
-class StageOutImplV2:
+class StageOutImplV2(object):
     """
     _StageOutImplV2_
 

--- a/src/python/WMCore/Storage/StageOutImplV2.py
+++ b/src/python/WMCore/Storage/StageOutImplV2.py
@@ -67,18 +67,18 @@ class StageOutImplV2(object):
             return pfn
 
     def runCommandFailOnNonZero(self, command):
-        logging.info("Executing %s" % command)
+        logging.info("Executing %s", command)
         (exitCode, output) = runCommand(command)
         if exitCode:
             logging.error("Error in file transfer:")
-            logging.error("  Command executed was: %s" % command )
-            logging.error("  Output was: %s" % output )
-            logging.error("  Exit code was: %s" % exitCode )
+            logging.error("  Command executed was: %s", command )
+            logging.error("  Output was: %s", output )
+            logging.error("  Exit code was: %s", exitCode )
             raise StageOutError("Transfer failure")
         return (exitCode, output)
 
     def runCommandWarnOnNonZero(self, command):
-        logging.info("Executing %s" % command)
+        logging.info("Executing %s", command)
         (exitCode, output) = runCommand(command)
         if exitCode:
             logging.error("Error in file transfer..ignoring:")

--- a/src/python/WMCore/WMBS/File.py
+++ b/src/python/WMCore/WMBS/File.py
@@ -5,6 +5,8 @@ _File_
 A simple object representing a file in WMBS.
 """
 
+from builtins import next
+
 import logging
 import threading
 
@@ -212,7 +214,7 @@ class File(WMBSBase, WMFile):
         runs = action.execute(self["lfn"], conn=self.getDBConn(),
                               transaction=self.existingTransaction())
 
-        [self.addRun(run=Run(r, *runs[r])) for r in runs.keys()]
+        [self.addRun(run=Run(r, *runs[r])) for r in runs]
 
         action = self.daofactory(classname="Files.GetLocation")
         self["locations"] = action.execute(self["lfn"], conn=self.getDBConn(),
@@ -277,7 +279,7 @@ class File(WMBSBase, WMFile):
         self.commitTransaction(existingTransaction)
         if self['checksums']:
             # Add a checksum
-            for entry in self['checksums'].keys():
+            for entry in self['checksums']:
                 self.setCksum(cksum=self['checksums'][entry], cktype=entry)
         return
 
@@ -355,7 +357,7 @@ class File(WMBSBase, WMFile):
                               transaction=self.existingTransaction())
 
         self["runs"].clear()
-        [self.addRun(run=Run(r, *runs[r])) for r in runs.keys()]
+        [self.addRun(run=Run(r, *runs[r])) for r in runs]
 
         self.commitTransaction(existingTransaction)
         return
@@ -573,7 +575,7 @@ def addFilesToWMBSInBulk(filesetId, workflowName, files, isDBS=True,
         if selfChecksums:
             # If we have checksums we have to create a bind
             # For each different checksum
-            for entry in selfChecksums.keys():
+            for entry in selfChecksums:
                 fileCksumBinds.append({'lfn': lfn, 'cksum': selfChecksums[entry],
                                        'cktype': entry})
 

--- a/src/python/WMCore/WMBS/Mask.py
+++ b/src/python/WMCore/WMBS/Mask.py
@@ -40,7 +40,7 @@ class Mask(WMBSBase, WMMask):
 
 
         returnDict = {}
-        for key in self.keys():
+        for key in self:
             returnDict[key] = self[key]
 
 
@@ -56,7 +56,7 @@ class Mask(WMBSBase, WMMask):
 
 
         maskList = []
-        for run in self['runAndLumis'].keys():
+        for run in self['runAndLumis']:
             for lumiPair in self['runAndLumis'][run]:
                 tmpMask = WMMask()
                 tmpMask['jobID']      = jobID
@@ -90,7 +90,7 @@ class Mask(WMBSBase, WMMask):
         existingTransaction = self.beginTransaction()
 
 
-        if len(self['runAndLumis'].keys()) == 0:
+        if len(self['runAndLumis']) == 0:
             # Then we have nothing out of the ordinary
 
             maskSaveAction.execute(jobid = jobID, mask = self,

--- a/src/python/WMCore/WMBS/Workflow.py
+++ b/src/python/WMCore/WMBS/Workflow.py
@@ -182,7 +182,7 @@ class Workflow(WMBSBase, WMWorkflow):
                                  transaction=self.existingTransaction())
 
         self.outputMap = {}
-        for outputID in results.keys():
+        for outputID in results:
             for outputMap in results[outputID]:
                 outputFileset = Fileset(id=outputMap["output_fileset"])
                 if outputMap["merged_output_fileset"] is not None:

--- a/src/python/WMCore/WMSpec/Persistency.py
+++ b/src/python/WMCore/WMSpec/Persistency.py
@@ -10,20 +10,18 @@ Placeholder for ideas at present....
 """
 from __future__ import print_function
 
-from urllib2 import urlopen, Request
+from future.moves.urllib.parse import urlparse
+from future.moves.urllib.request import urlopen, Request
 
-try:
-    from urlparse import urlparse
-except ImportError:
-    # PY3
-    from urllib.parse import urlparse
+from builtins import object
+
 try:
     import cPickle as pickle
 except ImportError:
     import pickle
 
 
-class PersistencyHelper:
+class PersistencyHelper(object):
     """
     _PersistencyHelper_
 

--- a/src/python/WMCore/WorkQueue/WorkQueueBase.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueBase.py
@@ -5,12 +5,11 @@ _WMBSBase_
 Generic methods used by all of the WMBS classes.
 """
 
-
-
+from builtins import object
 
 import threading
 
-class WorkQueueBase():
+class WorkQueueBase(object):
     """
     Generic methods used by all of the WMBS classes.
     """

--- a/src/python/WMQuality/Emulators/CRICClient/MockCRICApi.py
+++ b/src/python/WMQuality/Emulators/CRICClient/MockCRICApi.py
@@ -5,6 +5,8 @@ Version of Services/CRIC intended to be used with mock or unittest.mock
 """
 from __future__ import division, print_function
 
+from builtins import object, str, bytes
+
 import os
 import json
 import re
@@ -33,7 +35,7 @@ class MockCRICApi(object):
         :param callname: the CRIC REST API name
         :return: the dictionary that CRIC would have returned
         """
-        if callname not in mockData.keys():
+        if callname not in mockData:
             raise RuntimeError("Mock CRIC emulator knows nothing about API %s" % callname)
 
         if mockData[callname] == 'Raises HTTPError':
@@ -65,7 +67,7 @@ class MockCRICApi(object):
         nodeNames = [x['alias'] for x in sitenames if x['type'] == 'phedex']
         if excludeBuffer:
             nodeNames = [x for x in nodeNames if not x.endswith("_Buffer")]
-        if pattern and isinstance(pattern, basestring):
+        if pattern and isinstance(pattern, (str, bytes)):
             pattern = re.compile(pattern)
             nodeNames = [x for x in nodeNames if pattern.match(x)]
         return nodeNames
@@ -73,7 +75,7 @@ class MockCRICApi(object):
     def PNNstoPSNs(self, pnns):
         callname = 'data-processing'
         mapping = self.genericLookup(callname)
-        if isinstance(pnns, basestring):
+        if isinstance(pnns, (str, bytes)):
             pnns = [pnns]
 
         psns = set()
@@ -89,7 +91,7 @@ class MockCRICApi(object):
     def PSNstoPNNs(self, psns, allowPNNLess=False):
         callname = 'data-processing'
         mapping = self.genericLookup(callname)
-        if isinstance(psns, basestring):
+        if isinstance(psns, (str, bytes)):
             psns = [psns]
 
         pnns = set()
@@ -105,8 +107,8 @@ class MockCRICApi(object):
         return list(pnns)
 
     def PSNtoPNNMap(self, psnPattern=''):
-        if not isinstance(psnPattern, basestring):
-            raise TypeError('psnPattern argument must be of type basestring')
+        if not isinstance(psnPattern, (str, bytes)):
+            raise TypeError('psnPattern argument must be of type str or bytes')
 
         callname = 'data-processing'
         results = self.genericLookup(callname)

--- a/test/python/WMComponent_t/DBS3Buffer_t/DBSBufferFile_t.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/DBSBufferFile_t.py
@@ -5,6 +5,8 @@ _DBSBufferFile_t_
 Unit tests for the DBSBufferFile class.
 """
 
+from builtins import int
+
 import threading
 import unittest
 
@@ -244,18 +246,18 @@ class DBSBufferFileTest(unittest.TestCase):
         assert testFileA == testFileC, \
             "ERROR: File load by ID didn't work"
 
-        assert isinstance(testFileB["id"], int) or isinstance(testFileB["id"], long), \
+        assert isinstance(testFileB["id"], int), \
             "ERROR: File id is not an integer type."
-        assert isinstance(testFileB["size"], int) or isinstance(testFileB["size"], long), \
+        assert isinstance(testFileB["size"], int), \
             "ERROR: File size is not an integer type."
-        assert isinstance(testFileB["events"], int) or isinstance(testFileB["events"], long), \
+        assert isinstance(testFileB["events"], int), \
             "ERROR: File events is not an integer type."
 
-        assert isinstance(testFileC["id"], int) or isinstance(testFileC["id"], long), \
+        assert isinstance(testFileC["id"], int), \
             "ERROR: File id is not an integer type."
-        assert isinstance(testFileC["size"], int) or isinstance(testFileC["size"], long), \
+        assert isinstance(testFileC["size"], int), \
             "ERROR: File size is not an integer type."
-        assert isinstance(testFileC["events"], int) or isinstance(testFileC["events"], long), \
+        assert isinstance(testFileC["events"], int), \
             "ERROR: File events is not an integer type."
 
         testFileA.delete()

--- a/test/python/WMCore_t/Database_t/CouchUtils_t.py
+++ b/test/python/WMCore_t/Database_t/CouchUtils_t.py
@@ -7,6 +7,8 @@ Created by Dave Evans on 2010-10-04.
 Copyright (c) 2010 Fermilab. All rights reserved.
 """
 
+from builtins import object
+
 import unittest
 
 import WMCore.Database.CouchUtils as CouchUtils

--- a/test/python/WMCore_t/Database_t/DBCore_t.py
+++ b/test/python/WMCore_t/Database_t/DBCore_t.py
@@ -8,8 +8,9 @@ Unit tests for the DBInterface class
 
 
 
+from builtins import range
+
 import unittest
-import logging
 import threading
 
 from WMQuality.TestInit import TestInit

--- a/test/python/WMCore_t/GroupUser_t/Interface_t.py
+++ b/test/python/WMCore_t/GroupUser_t/Interface_t.py
@@ -7,8 +7,8 @@ Created by Dave Evans on 2010-07-29.
 Copyright (c) 2010 Fermilab. All rights reserved.
 """
 
+from builtins import range
 import unittest
-import os
 
 from WMCore.GroupUser.Interface import Interface
 from WMQuality.TestInitCouchApp import TestInitCouchApp

--- a/test/python/WMCore_t/WMBS_t/Workflow_t.py
+++ b/test/python/WMCore_t/WMBS_t/Workflow_t.py
@@ -5,6 +5,8 @@ _Workflow_t_
 Unit tests for the WMBS Workflow class.
 """
 
+from builtins import range
+
 import threading
 import unittest
 
@@ -278,7 +280,7 @@ class WorkflowTest(unittest.TestCase):
         testWorkflowB = Workflow(name="wf001", task='Test')
         testWorkflowB.load()
 
-        self.assertEqual(len(testWorkflowB.outputMap.keys()), 0,
+        self.assertEqual(len(testWorkflowB.outputMap), 0,
                          "ERROR: Output map exists before output is assigned")
 
         testWorkflowA.addOutput("outModOne", testFilesetA, testMergedFilesetA)
@@ -288,7 +290,7 @@ class WorkflowTest(unittest.TestCase):
         testWorkflowC = Workflow(name="wf001", task='Test')
         testWorkflowC.load()
 
-        self.assertEqual(len(testWorkflowC.outputMap.keys()), 2,
+        self.assertEqual(len(testWorkflowC.outputMap), 2,
                          "ERROR: Incorrect number of outputs in output map")
         self.assertTrue("outModOne" in testWorkflowC.outputMap.keys(),
                         "ERROR: Output modules missing from workflow output map")

--- a/test/python/WMCore_t/WMLogging_t.py
+++ b/test/python/WMCore_t/WMLogging_t.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
+from builtins import range
 import logging
 import unittest
 import os


### PR DESCRIPTION
Fixes #10116 

#### Status

Ready - waiting final green light

#### Related PRs

* Previous migration PR: #10165 (slice4, issue #10115  )
* Next migration PR: #10277 (slice6, issue  #10127 )

#### Is it backward compatible (if not, which system it affects?)

It should be!

#### External dependencies / deployment changes

no changes

#### Description

Run futurize and some manual changes on the first batch of src/python/A/B/C.

I decided to use the ["native string"](https://portingguide.readthedocs.io/en/latest/strings.html#the-native-string) approach and not force to use `from builtins import str` extensively when not needed. We will see how it goes. This has the advantage of reducing migration effort and without messing with strings when it is not really needed.
This may cause troubles only in:
* `src/python/WMCore/WMBS/Fileset.py ` 
  - did not use `from builtins import str`
  - to be tested in py3, to pen an issue to track this
  - [EDIT] This is not so likely yo cause problems, not opening any issue and hoping that nothing breaks
* `src/python/WMCore/GroupUser/Interface.py`: 
  - using of `from builtins import str`
  - despite it may not be necessary and it may break something
* `test/python/WMCore_t/Database_t/DBCore_t.py`: 
  - not using `from builtins import str`
  - but there is a slight chance that it may cause problems in py3

Dict
* `src/python/WMCore/JobStateMachine/SummaryDB.py`: dict updated in a loop, may be dangerous combined with `viewitems`. Tracked in #10446 

* `DBCore_t`: the following lines have not been changed

    ```python
    def testBuildBinds(self):
        ...
        dictbinds     = {'lumi':123, 'test':100}
        ....
        for i in range(len(files)):
            self.assertEqual(binds[i][seqname], files[i])
            self.assertEqual(binds[i][dictbinds.keys()[0]], dictbinds[dictbinds.keys()[0]])
   ```
   Despite the `pylint --py3k` report warnings
   ```plaintext
        test/python/WMCore_t/Database_t/DBCore_t.py
            W1655, line 64 in DBCoreTest.testBuildBinds: dict.keys referenced when not iterating
            W1655, line 64 in DBCoreTest.testBuildBinds: dict.keys referenced when not iterating
    ```
   A possible solution would be to use the `lumi` instead of `.keys()[0]`, but I would prefer to change the code as little as possible and live with some unharmful warnings, unless told otherwise.

[EDIT] We should fix this in #10398

#### jenkins report

* `pylint --py3k`: 2 warnings considered as false positives
* `pylint`: 24 errors, but i do not feel confident changing those, since it would involve changing interfaces
* `python3 compatibility`: complains about "requirements.txt", no problems in this PR
