### PR TITLE
Check if DID exists before creating a replication rule

### DIFF
--- a/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
+++ b/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
@@ -287,6 +287,10 @@ class RucioInjectorPoller(BaseWorkerThread):
             if not self._isBlockTierAllowed(item['blockname']):
                 logging.debug("Component configured to skip block rule for: %s", item['blockname'])
                 continue
+            # first, check if the block has already been created in Rucio
+            if not self.rucio.didExist(item['blockname']):
+                logging.warning("Block: %s not yet in Rucio. Retrying later..", item['blockname'])
+                continue
             kwargs = dict(activity="Production Output", account=self.rucioAcct,
                           grouping="DATASET", comment="WMAgent automatic container rule",
                           ignore_availability=True, meta=self.metaData)
@@ -518,6 +522,10 @@ class RucioInjectorPoller(BaseWorkerThread):
                 logging.info("Bypassing Production container Tape data placement for container: %s and RSE: %s",
                              container, rseName)
                 subscriptionsMade.append(subInfo['id'])
+                continue
+            # then check if the container has already been created in Rucio
+            if not self.rucio.didExist(container):
+                logging.warning("Container: %s not yet in Rucio. Retrying later..", container)
                 continue
 
             ruleKwargs = dict(ask_approval=False,

--- a/src/python/WMCore/Services/Rucio/Rucio.py
+++ b/src/python/WMCore/Services/Rucio/Rucio.py
@@ -842,6 +842,19 @@ class Rucio(object):
             self.logger.error("Data identifier not found in Rucio: %s. Error: %s", didName, str(exc))
         return response
 
+    def didExist(self, didName, scope='cms'):
+        """
+        Provided a given DID, check whether it's already in the Rucio server.
+        Any kind of exception will return False (thus, data not yet in Rucio).
+        :param didName: a string with the DID name (container, block, or file)
+        :return: True if DID has been found, False otherwise
+        """
+        try:
+            response = self.cli.get_did(scope=scope, name=didName)
+        except Exception:
+            response = dict()
+        return response.get("name") == didName
+
     # FIXME we can likely delete this method (replaced by another implementation)
     def getDataLockedAndAvailable_old(self, **kwargs):
         """


### PR DESCRIPTION
Fixes #10245 

#### Status
ready

#### Description
There are many cases in the production agents where RucioInjector component fails to inject a block or container into Rucio, but later in the same cycle, it attempts to create a replication rule for those same DID.

With this PR, we make an extra call to the Rucio server - for every container/block - and check if Rucio server knows anything about then, if so, we then proceed with the rule creation.

Having too many error records in the logs is just not the way to run production services, thus getting it fixed now for the new release.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
