### PR TITLE
Minor comment update on requirements for python3 stack

### DIFF
--- a/requirements_py3.txt
+++ b/requirements_py3.txt
@@ -1,4 +1,5 @@
-# Dependencies needed to run WMAgent(-dev) on a python3 stack
+# Dependencies needed to run WMAgent(-dev)
+# on a python3 stack
 
 ### dependencies on the wmagentpy3 spec
 Jinja2==2.11.3


### PR DESCRIPTION
Fixes #10267 

#### Status
not-tested

#### Description
 It looks like requirements_py3.txt file is tagged as a python file because it has the word `python` in its very first line.
Giving it a try.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
