### PR TITLE
Skip RSE quota check for RelVal input data placement; added rule meta data

### DIFF
--- a/src/python/WMCore/MicroService/DataStructs/Workflow.py
+++ b/src/python/WMCore/MicroService/DataStructs/Workflow.py
@@ -453,3 +453,21 @@ class Workflow(object):
                 newItem = dict(type="parent", name=parentName, campaign=item["campaign"])
                 break
         self.dataCampaignMap.append(newItem)
+
+    def isRelVal(self):
+        """
+        Helper function to evaluate whether this workflow corresponds to
+        a RelVal workflow or not.
+        """
+        return self.data.get('SubRequestType') in ['RelVal', 'HIRelVal']
+
+    def getWorkflowGroup(self):
+        """
+        Defines a workflow according to its group/activity, such as:
+          *) release validation workflows
+          *) standard central production workflows
+        :return: a string with the workflow class: relval, processing
+        """
+        if self.isRelVal():
+            return "relval"
+        return "production"

--- a/src/python/WMCore/MicroService/Unified/MSTransferor.py
+++ b/src/python/WMCore/MicroService/Unified/MSTransferor.py
@@ -597,7 +597,7 @@ class MSTransferor(MSCore):
                 # secondary already in place
                 continue
 
-            if wflow.getPURSElist():
+            if wflow.getPURSElist() and not wflow.isRelVal():
                 # then the whole workflow is very much limited to a single site
                 nodes = list(wflow.getPURSElist() & self.rseQuotas.getAvailableRSEs())
                 if not nodes:
@@ -675,6 +675,7 @@ class MSTransferor(MSCore):
                 'lifetime': self.msConfig['rulesLifetime'],
                 'account': self.msConfig['rucioAccount'],
                 'grouping': subLevel,
+                'meta': {'workflow_group': wflow.getWorkflowGroup()},
                 'comment': 'WMCore MSTransferor input data placement'}
 
         if wflow.getParentDataset():
@@ -773,6 +774,10 @@ class MSTransferor(MSCore):
 
         self.logger.info("  final list of PSNs to be use: %s", psns)
         pnns = self._getPNNsFromPSNs(psns)
+
+        if wflow.isRelVal():
+            self.logger.info("RelVal workflow '%s' ignores sites out of quota", wflow.getName())
+            return list(pnns)
 
         self.logger.info("List of out-of-space RSEs dropped for '%s' is: %s",
                          wflow.getName(), pnns & self.rseQuotas.getOutOfSpaceRSEs())

--- a/src/python/WMCore/Services/Rucio/Rucio.py
+++ b/src/python/WMCore/Services/Rucio/Rucio.py
@@ -10,6 +10,7 @@ from __future__ import division, print_function, absolute_import
 from builtins import str, object
 from future.utils import viewitems, viewvalues
 
+import json
 import logging
 import random
 from copy import deepcopy
@@ -534,6 +535,8 @@ class Rucio(object):
         kwargs.setdefault('ask_approval', False)
         kwargs.setdefault('asynchronous', True)
         kwargs.setdefault('priority', 3)
+        if isinstance(kwargs.get('meta'), dict):
+            kwargs['meta'] = json.dumps(kwargs['meta'])
 
         if not isinstance(names, (list, set)):
             names = [names]

--- a/test/python/WMCore_t/MicroService_t/DataStructs_t/Workflow_t.py
+++ b/test/python/WMCore_t/MicroService_t/DataStructs_t/Workflow_t.py
@@ -346,5 +346,41 @@ class WorkflowTest(unittest.TestCase):
         self.assertEqual(sizeChunks[0], 26)
         self.assertEqual(sizeChunks[1], 13)
 
+    def testIsRelVal(self):
+        """
+        Test the `isRelVal` method functionality
+        """
+        requestTypes = ("StepChain", "TaskChain", "ReReco")
+        for wflowType in requestTypes:
+            wflowObj = Workflow("wflow_test", {"RequestType": wflowType})
+            self.assertFalse(wflowObj.isRelVal())
+
+            wflowObj = Workflow("wflow_test", {"RequestType": wflowType, "SubRequestType": "ReDigi"})
+            self.assertFalse(wflowObj.isRelVal())
+
+        for wflowType in requestTypes:
+            wflowObj = Workflow("wflow_test", {"RequestType": wflowType, "SubRequestType": "RelVal"})
+            self.assertTrue(wflowObj.isRelVal())
+
+            wflowObj = Workflow("wflow_test", {"RequestType": wflowType, "SubRequestType": "HIRelVal"})
+            self.assertTrue(wflowObj.isRelVal())
+
+    def testGetWorkflowGroup(self):
+        """
+        Test the `getWorkflowGroup` method functionality
+        """
+        requestTypes = ("StepChain", "TaskChain", "ReReco")
+        for wflowType in requestTypes:
+            wflowObj = Workflow("wflow_test", {"RequestType": wflowType})
+            self.assertEqual(wflowObj.getWorkflowGroup(), "production")
+
+            wflowObj = Workflow("wflow_test", {"RequestType": wflowType, "SubRequestType": "ReDigi"})
+            self.assertEqual(wflowObj.getWorkflowGroup(), "production")
+
+        for wflowType in requestTypes:
+            wflowObj = Workflow("wflow_test", {"RequestType": wflowType, "SubRequestType": "RelVal"})
+            self.assertEqual(wflowObj.getWorkflowGroup(), "relval")
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #10274 

#### Status
not-tested

#### Description
Summary of changes provided in this PR are:
* a couple more helper functions for MSTransferor Workflow object, to identify RelVal workflows;
* rules created by MSTransferor will now carry a `workflow_group` meta data, which can be either `relval` or `production` (where `production` is anything in central production which is different than release validation workflows)
* Rucio wrapper `createReplicationRule` method now accepts a python dictionary for the `meta` rule argument, which is then serialized as a json string (json.dumps) before making the final call to the Rucio server.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
