### PR TITLE
[py2py3] Migration at level scr/python/A/B/C - slice 6

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/DBSBufferUtil.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSBufferUtil.py
@@ -6,6 +6,8 @@ APIs related to using the DBSBuffer.
 """
 from __future__ import print_function
 
+from future.utils import viewitems
+
 import threading
 from collections import defaultdict
 
@@ -53,14 +55,14 @@ class DBSBufferUtil(WMConnectionBase):
             dbsFiles.append(dbsfile)
 
         for dbsfile in dbsFiles:
-            if 'runInfo' in dbsfile.keys():
+            if 'runInfo' in dbsfile:
                 # Then we have to replace it with a real run
-                for r in dbsfile['runInfo'].keys():
+                for r in dbsfile['runInfo']:
                     run = Run(runNumber=r)
                     run.extend(dbsfile['runInfo'][r])
                     dbsfile.addRun(run)
                 del dbsfile['runInfo']
-            if 'parentLFNs' in dbsfile.keys():
+            if 'parentLFNs' in dbsfile:
                 # Then we have some parents
                 for lfn in dbsfile['parentLFNs']:
                     newFile = DBSBufferFile(lfn=lfn)
@@ -139,14 +141,14 @@ class DBSBufferUtil(WMConnectionBase):
             dbsFiles.append(dbsfile)
 
         for dbsfile in dbsFiles:
-            if 'runInfo' in dbsfile.keys():
+            if 'runInfo' in dbsfile:
                 # Then we have to replace it with a real run
-                for r in dbsfile['runInfo'].keys():
+                for r in dbsfile['runInfo']:
                     run = Run(runNumber=r)
                     run.extendLumis(dbsfile['runInfo'][r])
                     dbsfile.addRun(run)
                 del dbsfile['runInfo']
-            if 'parentLFNs' in dbsfile.keys():
+            if 'parentLFNs' in dbsfile:
                 # Then we have some parents
                 for lfn in dbsfile['parentLFNs']:
                     newFile = DBSBufferFile(lfn=lfn)
@@ -173,14 +175,14 @@ class DBSBufferUtil(WMConnectionBase):
             dbsFiles.append(dbsfile)
 
         for dbsfile in dbsFiles:
-            if 'runInfo' in dbsfile.keys():
+            if 'runInfo' in dbsfile:
                 # Then we have to replace it with a real run
-                for r in dbsfile['runInfo'].keys():
+                for r in dbsfile['runInfo']:
                     run = Run(runNumber=r)
                     run.extendLumis(dbsfile['runInfo'][r])
                     dbsfile.addRun(run)
                 del dbsfile['runInfo']
-            if 'parentLFNs' in dbsfile.keys():
+            if 'parentLFNs' in dbsfile:
                 # Then we have some parents
                 for lfn in dbsfile['parentLFNs']:
                     newFile = DBSBufferFile(lfn=lfn)
@@ -220,7 +222,7 @@ class DBSBufferUtil(WMConnectionBase):
         returns dictionary with kew as workflow and containing dbs/phedex upload status
         """
         summary = defaultdict(dict)
-        for workflow, value in data.iteritems():
+        for workflow, value in viewitems(data):
             # only getting completed workflows
             summary[workflow]["Completed"] = True
 

--- a/src/python/WMCore/ACDC/CouchFileset.py
+++ b/src/python/WMCore/ACDC/CouchFileset.py
@@ -6,6 +6,9 @@ CouchFileset.py
 Created by Dave Evans on 2010-03-19.
 Copyright (c) 2010 Fermilab. All rights reserved.
 """
+
+from future.utils import viewvalues
+
 import time
 
 import WMCore.Database.CMSCouch as CMSCouch
@@ -185,7 +188,7 @@ class CouchFileset(Fileset):
                 raise RuntimeError(msg)
 
             files = doc["files"]
-            for d in files.values():
+            for d in viewvalues(files):
                 yield d
 
     @connectToCouch

--- a/src/python/WMCore/ACDC/CouchService.py
+++ b/src/python/WMCore/ACDC/CouchService.py
@@ -6,6 +6,7 @@ CouchService.py
 Created by Dave Evans on 2010-04-20.
 Copyright (c) 2010 Fermilab. All rights reserved.
 """
+from builtins import object
 from time import time
 
 import WMCore.Database.CouchUtils as CouchUtils

--- a/src/python/WMCore/Database/MySQLCore.py
+++ b/src/python/WMCore/Database/MySQLCore.py
@@ -73,7 +73,7 @@ class MySQLInterface(DBInterface):
         # variables: RELEASE_VERSION and RELEASE_VERSION_ID the former will
         # match against the latter, causing problems.  We'll sort the variable
         # names by length to guard against this.
-        bindVarNames = origBind.keys()
+        bindVarNames = list(origBind)
         bindVarNames.sort(stringLengthCompare)
 
         bindPositions = {}

--- a/src/python/WMCore/JobSplitting/JobFactory.py
+++ b/src/python/WMCore/JobSplitting/JobFactory.py
@@ -4,6 +4,8 @@ _JobFactory_
 
 """
 
+from builtins import range
+
 import logging
 import threading
 
@@ -88,13 +90,13 @@ class JobFactory(WMObject):
         module = __import__(module, globals(), locals(), [grouptype])
         self.groupInstance = getattr(module, grouptype.split('.')[-1])
 
-        list(map(lambda x: x.start(), self.generators))
+        list([x.start() for x in self.generators])
 
         self.limit = int(kwargs.get("file_load_limit", self.limit))
         self.algorithm(*args, **kwargs)
         self.commit()
 
-        list(map(lambda x: x.finish(), self.generators))
+        list([x.finish() for x in self.generators])
         return self.jobGroups
 
     def algorithm(self, *args, **kwargs):
@@ -115,7 +117,7 @@ class JobFactory(WMObject):
         """
         self.appendJobGroup()
         self.currentGroup = self.groupInstance(subscription=self.subscription)
-        list(map(lambda x: x.startGroup(self.currentGroup), self.generators))
+        list([x.startGroup(self.currentGroup) for x in self.generators])
         return
 
     def newJob(self, name=None, files=None, failedJob=False, failedReason=None):
@@ -157,7 +159,7 @@ class JobFactory(WMObject):
         """
 
         if self.currentGroup:
-            list(map(lambda x: x.finishGroup(self.currentGroup), self.generators))
+            list([x.finishGroup(self.currentGroup) for x in self.generators])
         if self.currentGroup:
             self.jobGroups.append(self.currentGroup)
             self.currentGroup = None
@@ -328,7 +330,7 @@ class JobFactory(WMObject):
         if isinstance(resultProxy.keys, list):
             keys = resultProxy.keys
         else:
-            keys = resultProxy.keys()
+            keys = resultProxy.keys()  # do not futurize this!
             if isinstance(keys, set):
                 # If it's a set, handle it
                 keys = list(keys)
@@ -463,7 +465,7 @@ class JobFactory(WMObject):
 
         if self.checkForAmountOfWork():
             # first, check whether we have enough files to reach the desired events_per_job
-            for sites in lDict.keys():
+            for sites in list(lDict):  # lDict changes size during for loop!
                 availableEventsPerLocation = sum([f['events'] for f in lDict[sites]])
                 if eventsPerJob > availableEventsPerLocation:
                     # then we don't split these files for the moment

--- a/src/python/WMCore/JobSplitting/MinFileBased.py
+++ b/src/python/WMCore/JobSplitting/MinFileBased.py
@@ -39,7 +39,7 @@ class MinFileBased(JobFactory):
         #Get a dictionary of sites, files
         locationDict = self.sortByLocation()
 
-        for location in locationDict.keys():
+        for location in locationDict:
             #Now we have all the files in a certain location
             fileList    = locationDict[location]
             filesInJob  = 0

--- a/src/python/WMCore/JobSplitting/ParentlessMergeBySize.py
+++ b/src/python/WMCore/JobSplitting/ParentlessMergeBySize.py
@@ -4,6 +4,8 @@ _ParentlessMergeBySize_
 
 WMBS merging that ignores file parents.
 """
+from __future__ import division
+
 import time
 import threading
 
@@ -203,11 +205,11 @@ class ParentlessMergeBySize(JobFactory):
 
         groupedFiles = self.defineFileGroups(mergeableFiles)
 
-        for pnn in groupedFiles.keys():
+        for pnn in groupedFiles:
             if self.mergeAcrossRuns:
                 self.defineMergeJobs(groupedFiles[pnn])
             else:
-                for runNumber in groupedFiles[pnn].keys():
+                for runNumber in groupedFiles[pnn]:
                     self.defineMergeJobs(groupedFiles[pnn][runNumber])
 
         return

--- a/src/python/WMCore/JobSplitting/RunBased.py
+++ b/src/python/WMCore/JobSplitting/RunBased.py
@@ -13,6 +13,7 @@ If file spans a run will need to create a mask for that file.
 
 
 
+from builtins import range
 from WMCore.JobSplitting.JobFactory import JobFactory
 from WMCore.DataStructs.Fileset import Fileset
 from WMCore.Services.UUIDLib import makeUUID
@@ -48,7 +49,7 @@ class RunBased(JobFactory):
 
         locationDict = self.sortByLocation()
 
-        for location in locationDict.keys():
+        for location in locationDict:
             fileList = locationDict[location]
             for f in fileList:
 
@@ -69,13 +70,13 @@ class RunBased(JobFactory):
                 run = min(runList)
 
                 #If we don't have the run, we need to add it
-                if not run in runDict.keys():
+                if run not in runDict:
                     runDict[run] = []
 
                 runDict[run].append(f)
 
 
-            for run in runDict.keys():
+            for run in runDict:
                 #Find the runs in the dictionary we assembled and split the files in them
 
                 self.newGroup()

--- a/src/python/WMCore/JobSplitting/SiblingProcessingBased.py
+++ b/src/python/WMCore/JobSplitting/SiblingProcessingBased.py
@@ -61,7 +61,7 @@ class SiblingProcessingBased(JobFactory):
 
             fileSites[completeFile["pnn"]].append(completeFile)
 
-        for siteName in fileSites.keys():
+        for siteName in fileSites:
             if len(fileSites[siteName]) < filesPerJob and not filesetClosed:
                 continue
 

--- a/src/python/WMCore/JobSplitting/SizeBased.py
+++ b/src/python/WMCore/JobSplitting/SizeBased.py
@@ -30,7 +30,7 @@ class SizeBased(JobFactory):
         sizePerJob = int(kwargs.get("size_per_job", 1000))
         locationDict = self.sortByLocation()
 
-        for location in locationDict.keys():
+        for location in locationDict:
             self.newGroup()
             fileList     = locationDict[location]
             self.newJob(name = makeUUID())

--- a/src/python/WMCore/JobSplitting/SplitFileBased.py
+++ b/src/python/WMCore/JobSplitting/SplitFileBased.py
@@ -105,7 +105,7 @@ class SplitFileBased(JobFactory):
 
         for mergeableFile in mergeableFiles:
             newMergeFile = {}
-            for key in mergeableFile.keys():
+            for key in mergeableFile:
                 newMergeFile[key] = mergeableFile[key]
 
             if newMergeFile["file_run"] not in mergeUnits:
@@ -170,7 +170,7 @@ class SplitFileBased(JobFactory):
         mergeableFiles = mergeDAO.execute(self.subscription["id"])
 
         mergeUnits = self.defineMergeUnits(mergeableFiles)
-        for runNumber in mergeUnits.keys():
+        for runNumber in mergeUnits:
             mergeUnits[runNumber].sort(mergeUnitCompare)
             self.createProcJobs(mergeUnits[runNumber])
 

--- a/src/python/WMCore/JobSplitting/TwoFileBased.py
+++ b/src/python/WMCore/JobSplitting/TwoFileBased.py
@@ -74,7 +74,7 @@ class TwoFileBased(JobFactory):
         #Get a dictionary of sites, files
         locationDict = self.sortByLocation()
 
-        for location in locationDict.keys():
+        for location in locationDict:
             #Now we have all the files in a certain location
             fileList    = locationDict[location]
             filesInJob  = 0

--- a/src/python/WMCore/JobSplitting/WMBSMergeBySize.py
+++ b/src/python/WMCore/JobSplitting/WMBSMergeBySize.py
@@ -103,7 +103,7 @@ class WMBSMergeBySize(JobFactory):
         for mergeableFile in mergeableFiles:
             newMergeFile = {}
 
-            for key in mergeableFile.keys():
+            for key in mergeableFile:
                 newMergeFile[key] = mergeableFile[key]
 
             if newMergeFile["pnn"] not in mergeUnits:
@@ -243,8 +243,8 @@ class WMBSMergeBySize(JobFactory):
 
         mergeUnits = self.defineMergeUnits(mergeableFiles)
 
-        for pnn in mergeUnits.keys():
-            for runNumber in mergeUnits[pnn].keys():
+        for pnn in mergeUnits:
+            for runNumber in mergeUnits[pnn]:
                 self.defineMergeJobs(mergeUnits[pnn][runNumber])
 
         return

--- a/src/python/WMCore/Storage/DeleteMgr.py
+++ b/src/python/WMCore/Storage/DeleteMgr.py
@@ -9,6 +9,9 @@ Based on StageOutMgr class
 """
 from __future__ import print_function
 
+from builtins import object
+from future.utils import viewitems
+
 import logging
 
 from WMCore.Storage.Registry import retrieveStageOutImpl
@@ -34,7 +37,7 @@ class DeleteMgrError(WMException):
         self.data.setdefault("ErrorType", self.__class__.__name__)
 
 
-class DeleteMgr:
+class DeleteMgr(object):
     """
     _DeleteMgr_
 
@@ -150,7 +153,7 @@ class DeleteMgr:
                 overrideParams['option'] = ""
 
         msg = "=======Delete Override Initialised:================\n"
-        for key, val in overrideParams.items():
+        for key, val in viewitems(overrideParams):
             msg += " %s : %s\n" % (key, val)
         msg += "=====================================================\n"
         self.logger.info(msg)

--- a/src/python/WMCore/WMBS/Job.py
+++ b/src/python/WMCore/WMBS/Job.py
@@ -16,6 +16,8 @@ responsible for updating their state (and name).
 
 from __future__ import print_function
 
+from builtins import int, str, bytes
+
 from WMCore.DataStructs.Job import Job as WMJob
 from WMCore.DataStructs.Mask import Mask as WMMask
 from WMCore.Services.UUIDLib import makeUUID
@@ -423,7 +425,7 @@ class Job(WMBSBase, WMJob):
         """
 
         if not fwjrPath:
-            if 'fwjr' in self.keys():
+            if 'fwjr' in self:
                 fwjrPath = self['fwjr']
             else:
                 return None
@@ -443,16 +445,15 @@ class Job(WMBSBase, WMJob):
         job = WMJob(name=self['name'])
 
         # Transfer all simple keys
-        for key in self.keys():
-            keyType = type(self.get(key))
-            if keyType in [str, long, int, float]:
+        for key in self:
+            if isinstance(self.get(key), (str, bytes, int, float)):
                 job[key] = self[key]
 
         for fileObj in self['input_files']:
             job['input_files'].append(fileObj.returnDataStructsFile())
 
         job['mask'] = WMMask()
-        for key in self["mask"].keys():
+        for key in self["mask"]:
             job["mask"][key] = self["mask"][key]
 
         job.baggage = self.baggage

--- a/src/python/WMCore/WMBS/Subscription.py
+++ b/src/python/WMCore/WMBS/Subscription.py
@@ -10,6 +10,8 @@ associated to a single fileset and a single workflow.
 """
 from __future__ import print_function
 
+from future.utils import listvalues
+
 import logging
 from collections import Counter
 
@@ -200,7 +202,7 @@ class Subscription(WMBSBase, WMSubscription):
             if loadChecksums:
                 fl.loadChecksum()
             fl.update(fileInfoDict[f['file']])
-            if 'locations' in f.keys():
+            if 'locations' in f:
                 fl.setLocation(f['locations'], immediateSave=False)
             files.add(fl)
 
@@ -324,9 +326,9 @@ class Subscription(WMBSBase, WMSubscription):
         """
         jobLocate = self.daofactory(classname="Subscriptions.GetNumberOfJobsPerSite")
 
-        result = jobLocate.execute(location=location,
-                                   subscription=self['id'],
-                                   state=state).values()[0]
+        result = listvalues(jobLocate.execute(location=location,
+                                              subscription=self['id'],
+                                              state=state))[0]
         return result
 
     def getJobGroups(self):
@@ -622,7 +624,7 @@ class Subscription(WMBSBase, WMSubscription):
         maskList = []
         for job in jobList:
             mask = job['mask']
-            if len(mask['runAndLumis'].keys()) > 0:
+            if len(list(mask['runAndLumis'].keys())) > 0:
                 # Then we have multiple binds
                 binds = mask.produceCommitBinds(jobID=job['id'])
                 maskList.extend(binds)

--- a/test/python/WMComponent_t/DBS3Buffer_t/DBSBufferUtil_t.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/DBSBufferUtil_t.py
@@ -5,6 +5,7 @@ _DBSBufferUtil_t_
 Unit tests for DBSBufferUtil class
 """
 
+from builtins import range
 import unittest
 import threading
 

--- a/test/python/WMCore_t/ACDC_t/CouchCollection_t.py
+++ b/test/python/WMCore_t/ACDC_t/CouchCollection_t.py
@@ -6,6 +6,7 @@ Created by Dave Evans on 2010-10-04.
 Copyright (c) 2010 Fermilab. All rights reserved.
 """
 
+from builtins import range
 import unittest
 import random
 
@@ -113,10 +114,10 @@ class CouchCollection_t(unittest.TestCase):
             if fileset["name"] == "TestFilesetC":
                 testFiles.extend(testFilesB)
 
-            self.assertEqual(len(testFiles), len(fileset.files.keys()),
+            self.assertEqual(len(testFiles), len(fileset.files),
                              "Error: Wrong number of files in fileset.")
             for testFile in testFiles:
-                self.assertTrue(testFile["lfn"] in fileset.files.keys(),
+                self.assertTrue(testFile["lfn"] in fileset.files,
                                 "Error: File is missing.")
                 self.assertEqual(testFile["events"],
                                  fileset.files[testFile["lfn"]]["events"],

--- a/test/python/WMCore_t/ACDC_t/CouchFileset_t.py
+++ b/test/python/WMCore_t/ACDC_t/CouchFileset_t.py
@@ -6,6 +6,7 @@ Created by Dave Evans on 2010-10-05.
 Copyright (c) 2010 Fermilab. All rights reserved.
 """
 
+from builtins import range
 import unittest
 import random
 
@@ -125,7 +126,7 @@ class CouchFileset_t(unittest.TestCase):
             testFileset.add([testFile])
 
         for file in testFileset.listFiles():
-            self.assertTrue(file["lfn"] in testFiles.keys(),
+            self.assertTrue(file["lfn"] in testFiles,
                             "Error: File missing.")
             self.assertEqual(file["events"], testFiles[file["lfn"]]["events"],
                              "Error: Wrong number of events.")
@@ -157,7 +158,7 @@ class CouchFileset_t(unittest.TestCase):
             testFileset.add([testFile])
 
         for file in testFileset.fileset().files:
-            self.assertTrue(file["lfn"] in testFiles.keys(),
+            self.assertTrue(file["lfn"] in testFiles,
                             "Error: File missing.")
             self.assertEqual(file["events"], testFiles[file["lfn"]]["events"],
                              "Error: Wrong number of events.")

--- a/test/python/WMCore_t/ACDC_t/CouchService_t.py
+++ b/test/python/WMCore_t/ACDC_t/CouchService_t.py
@@ -7,6 +7,7 @@ Created by Dave Evans on 2010-10-04.
 Copyright (c) 2010 Fermilab. All rights reserved.
 """
 
+from builtins import range
 import unittest
 import random
 import time

--- a/test/python/WMCore_t/JobSplitting_t/FixedDelay_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/FixedDelay_t.py
@@ -4,6 +4,9 @@ _FixedDelay_t_
 
 Fixed Delay splitting test.
 """
+from __future__ import division
+
+from builtins import range
 
 import unittest
 
@@ -39,7 +42,7 @@ class FixedDelayTest(unittest.TestCase):
         self.multipleFileLumiset = Fileset(name = "TestFileset3")
         for i in range(10):
             newFile = File(makeUUID(), size = 1000, events = 100)
-            newFile.addRun(Run(1, *[45+i/3]))
+            newFile.addRun(Run(1, *[45 + i // 3]))
             self.multipleFileLumiset.addFile(newFile)
 
         self.singleLumiFileset = Fileset(name = "TestFileset4")

--- a/test/python/WMCore_t/JobSplitting_t/RunBased_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/RunBased_t.py
@@ -4,9 +4,9 @@ _RunBased_t_
 
 RunBased splitting test.
 """
+from __future__ import division
 
-
-
+from builtins import range
 
 import unittest
 
@@ -43,7 +43,7 @@ class RunBasedTest(unittest.TestCase):
         self.multipleFileRunset = Fileset(name = "TestFileset3")
         for i in range(10):
             newFile = File(makeUUID(), size = 1000, events = 100, locations = set(["somese.cern.ch"]))
-            newFile.addRun(Run(i/3, *[45]))
+            newFile.addRun(Run(i//3, *[45]))
             self.multipleFileRunset.addFile(newFile)
 
         self.singleRunFileset = Fileset(name = "TestFileset4")

--- a/test/python/WMCore_t/JobSplitting_t/SizeBased_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/SizeBased_t.py
@@ -8,6 +8,7 @@ Size based splitting test.
 
 
 
+from builtins import range
 import unittest
 
 from WMCore.DataStructs.File import File

--- a/test/python/WMCore_t/WMBS_t/Job_t.py
+++ b/test/python/WMCore_t/WMBS_t/Job_t.py
@@ -6,6 +6,7 @@ Unit tests for the WMBS job class.
 """
 from __future__ import absolute_import
 
+from builtins import str
 import threading
 import unittest
 
@@ -908,7 +909,7 @@ class JobTest(JobTestBase):
         outputMapAction = self.daoFactory(classname="Jobs.GetOutputMap")
         outputMap = outputMapAction.execute(jobID=testJob["id"])
 
-        assert len(outputMap.keys()) == 3, \
+        assert len(outputMap) == 3, \
             "Error: Wrong number of outputs for primary workflow."
 
         goldenMap = {"output": (recoOutputFileset.id,
@@ -918,7 +919,7 @@ class JobTest(JobTestBase):
                      "DQM": (dqmOutputFileset.id,
                              mergedDqmOutputFileset.id)}
 
-        for outputID in outputMap.keys():
+        for outputID in outputMap:
             for outputFilesets in outputMap[outputID]:
                 if outputFilesets["merged_output_fileset"] is None:
                     self.assertEqual(outputFilesets["output_fileset"],
@@ -926,7 +927,7 @@ class JobTest(JobTestBase):
                                      "Error: Cleanup fileset is wrong.")
                     continue
 
-                self.assertTrue(outputID in goldenMap.keys(),
+                self.assertTrue(outputID in goldenMap,
                                 "Error: Output identifier is missing.")
                 self.assertEqual(outputFilesets["output_fileset"],
                                  goldenMap[outputID][0],
@@ -936,7 +937,7 @@ class JobTest(JobTestBase):
                                  "Error: Merged output fileset is wrong.")
                 del goldenMap[outputID]
 
-        self.assertEqual(len(goldenMap.keys()), 0,
+        self.assertEqual(len(goldenMap), 0,
                          "Error: Missing output maps.")
 
         return
@@ -982,7 +983,7 @@ class JobTest(JobTestBase):
         testJob.baggage.TestSection.test = 100
         finalJob = testJob.getDataStructsJob()
 
-        for key in finalJob.keys():
+        for key in finalJob:
             if key == 'input_files':
                 for inputFile in testJob['input_files']:
                     self.assertEqual(inputFile.returnDataStructsFile() in finalJob['input_files'], True)


### PR DESCRIPTION
Fixes #10127 

#### Status
In development

#### Related PRs

* Previous migration PR: #10262 (slice5, issue #10116)
* Next migration PR: #10284  (slice7, issue #10131 )

#### Description

Run futurize and some manual changes on the first batch of src/python/A/B/C.

Use of "native-string" strategy:
- `src/python/WMCore/JobSplitting/JobFactory.py`: no `from bultins import str` here

division:
- `src/python/WMCore/JobSplitting/ParentlessMergeBySize.py`: assuming that 
    ```python
    self.currentJob.addResourceEstimates(jobTime = jobTime, disk = (jobSize+largestFile)/1024)
    ```
    can accept float arguments




#### Is it backward compatible (if not, which system it affects?)

It should be. (Any possible cause for errors will we reported here)

#### External dependencies / deployment changes

Requires python-future in both py2 and py3 environments.
