### PR TITLE
Remove switch between Rucio and PhEDEx

### DIFF
--- a/src/python/Utils/Utilities.py
+++ b/src/python/Utils/Utilities.py
@@ -250,17 +250,3 @@ def encodeUnicodeToBytes(value, errors="strict"):
     if isinstance(value, str):
         return value.encode("utf-8", errors)
     return value
-
-
-# TODO: remove this function once we have completely migrated to Rucio
-def usingRucio():
-    """
-    Evaluates the environment variables and figure out whether we
-    need to use Rucio or not (thus PhEDEx)
-    :return: a boolean value
-    """
-    if str(os.getenv("WMAGENT_USE_RUCIO", 'false')).lower() == 'true':
-        return True
-    elif str(os.getenv("WMCORE_USE_RUCIO", 'false')).lower() == 'true':
-        return True
-    return False

--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -17,7 +17,6 @@ import threading
 import time
 from collections import defaultdict
 
-from Utils.Utilities import usingRucio
 from WMCore import Lexicon
 from WMCore.ACDC.DataCollectionService import DataCollectionService
 from WMCore.Database.CMSCouch import CouchInternalServerError, CouchNotFoundError
@@ -185,15 +184,12 @@ class WorkQueue(WorkQueueBase):
                 raise RuntimeError('Only blocks can be released on location')
 
         self.params.setdefault('rucioAccount', "wmcore_transferor")
-        # FIXME remove these attributes initialized to None
-        if usingRucio():
-            self.phedexService = None
-            self.rucio = Rucio(self.params['rucioAccount'],
-                               self.params['rucioUrl'], self.params['rucioAuthUrl'],
-                               configDict=dict(logger=self.logger))
-        else:
-            self.rucio = None
-            self.phedexService = PhEDEx()
+
+        self.phedexService = None
+        self.rucio = Rucio(self.params['rucioAccount'],
+                           self.params['rucioUrl'], self.params['rucioAuthUrl'],
+                           configDict=dict(logger=self.logger))
+
 
         self.dataLocationMapper = WorkQueueDataLocationMapper(self.logger, self.backend,
                                                               phedex=self.phedexService,

--- a/src/python/WMQuality/Emulators/DBSClient/MockedDBSGlobalCalls.py
+++ b/src/python/WMQuality/Emulators/DBSClient/MockedDBSGlobalCalls.py
@@ -8,6 +8,7 @@ endpoint = 'https://cmsweb-prod.cern.ch/dbs/prod/global/DBSReader'
 datasets = ['/HighPileUp/Run2011A-v1/RAW', '/MinimumBias/ComissioningHI-v1/RAW', '/Cosmics/ComissioningHI-v1/RAW',
             '/Cosmics/ComissioningHI-PromptReco-v1/RECO',
             '/SingleElectron/StoreResults-Run2011A-WElectron-PromptSkim-v4-ALCARECO-NOLC-36cfce5a1d3f3ab4df5bd2aa0a4fa380/USER',
+            '/GammaGammaToEE_Elastic_Pt15_8TeV-lpair/Summer12-START53_V7C-v1/GEN-SIM'
            ]
 
 calls = [['listDataTiers'],

--- a/src/python/WMQuality/Emulators/EmulatedUnitTestCase.py
+++ b/src/python/WMQuality/Emulators/EmulatedUnitTestCase.py
@@ -73,7 +73,9 @@ class EmulatedUnitTestCase(unittest.TestCase):
             self.rucioPatchers = []
             patchRucioAt = ['WMCore.WorkQueue.WorkQueue.Rucio',
                             'WMCore.WorkQueue.WorkQueueReqMgrInterface.Rucio',
-                            'WMCore.WorkQueue.Policy.Start.StartPolicyInterface.Rucio']
+                            'WMCore.WorkQueue.Policy.Start.StartPolicyInterface.Rucio',
+                            'WMCore.WMSpec.Steps.Fetchers.PileupFetcher.Rucio',
+                            'WMCore_t.WMSpec_t.Steps_t.Fetchers_t.PileupFetcher_t.Rucio']
             for module in patchRucioAt:
                 self.rucioPatchers.append(mock.patch(module, new=MockRucioApi))
                 self.rucioPatchers[-1].start()

--- a/test/python/Utils_t/Utilities_t.py
+++ b/test/python/Utils_t/Utilities_t.py
@@ -9,7 +9,7 @@ import os
 import unittest
 
 from Utils.Utilities import makeList, makeNonEmptyList, strToBool, \
-    safeStr, rootUrlJoin, zipEncodeStr, lowerCmsHeaders, getSize, usingRucio
+    safeStr, rootUrlJoin, zipEncodeStr, lowerCmsHeaders, getSize
 
 
 class UtilitiesTests(unittest.TestCase):
@@ -151,27 +151,6 @@ cms::Exception caught in CMS.EventProcessor and rethrown
         cls = TestClass()
         print(getSize(cls))
         self.assertTrue(getSize(cls) > 1000)
-
-    def testUsingRucio(self):
-        """
-        Test the usingRucio function.
-        """
-        self.assertFalse(usingRucio())
-
-        os.environ['WMAGENT_USE_RUCIO'] = 'FALSE'
-        self.assertFalse(usingRucio())
-
-        os.environ['WMAGENT_USE_RUCIO'] = 'TRUE'
-        self.assertTrue(usingRucio())
-
-        os.environ.pop('WMAGENT_USE_RUCIO')
-        self.assertFalse(usingRucio())
-
-        os.environ['WMCORE_USE_RUCIO'] = 'TRUE'
-        self.assertTrue(usingRucio())
-
-        os.environ.pop('WMCORE_USE_RUCIO')
-        self.assertFalse(usingRucio())
 
 
 if __name__ == '__main__':

--- a/test/python/WMCore_t/Services_t/WorkQueue_t/WorkQueue_t.py
+++ b/test/python/WMCore_t/Services_t/WorkQueue_t/WorkQueue_t.py
@@ -42,7 +42,13 @@ class WorkQueueTest(EmulatedUnitTestCase):
         self.testInit.setupCouch('local_workqueue_t', *self.couchApps)
         self.testInit.setupCouch('local_workqueue_t_inbox', *self.couchApps)
         self.testInit.generateWorkDir()
-        return
+
+        # setup rucio parameters for global/local queue
+        self.queueParams = {}
+        self.queueParams['log_reporter'] = "Services_WorkQueue_Unittest"
+        self.queueParams['rucioAccount'] = "wma_test"
+        self.queueParams['rucioAuthUrl'] = "http://cmsrucio-int.cern.ch"
+        self.queueParams['rucioUrl'] = "https://cmsrucio-auth-int.cern.ch"
 
     def tearDown(self):
         """
@@ -61,7 +67,8 @@ class WorkQueueTest(EmulatedUnitTestCase):
                                                       assignKwargs={'SiteWhitelist': ['T2_XX_SiteA']})
         globalQ = globalQueue(DbName='workqueue_t',
                               QueueURL=self.testInit.couchUrl,
-                              UnittestFlag=True)
+                              UnittestFlag=True,
+                              **self.queueParams)
         self.assertTrue(globalQ.queueWork(specUrl, specName, "teamA") > 0)
 
         wqApi = WorkQueueDS(self.testInit.couchUrl, 'workqueue_t')
@@ -96,13 +103,14 @@ class WorkQueueTest(EmulatedUnitTestCase):
                                                       assignKwargs={'SiteWhitelist':["T2_XX_SiteA"]})
         globalQ = globalQueue(DbName='workqueue_t',
                               QueueURL=self.testInit.couchUrl,
-                              UnittestFlag=True)
+                              UnittestFlag=True,
+                              **self.queueParams)
         localQ = localQueue(DbName='local_workqueue_t',
                             QueueURL=self.testInit.couchUrl,
                             CacheDir=self.testInit.testDir,
                             ParentQueueCouchUrl='%s/workqueue_t' % self.testInit.couchUrl,
-                            ParentQueueInboxCouchDBName='workqueue_t_inbox'
-                            )
+                            ParentQueueInboxCouchDBName='workqueue_t_inbox',
+                            **self.queueParams)
         # Try a full chain of priority update and propagation
         self.assertTrue(globalQ.queueWork(specUrl, "RerecoSpec", "teamA") > 0)
         globalApi = WorkQueueDS(self.testInit.couchUrl, 'workqueue_t')
@@ -148,7 +156,8 @@ class WorkQueueTest(EmulatedUnitTestCase):
 
         globalQ = globalQueue(DbName='workqueue_t',
                               QueueURL=self.testInit.couchUrl,
-                              UnittestFlag=True)
+                              UnittestFlag=True,
+                              **self.queueParams)
         self.assertTrue(globalQ.queueWork(specUrl, specName, "teamA") > 0)
 
         wqApi = WorkQueueDS(self.testInit.couchUrl, 'workqueue_t')

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
@@ -50,7 +50,7 @@ REQUEST = {
         "GlobalTag": "GT-Step2",
         "InputFromOutputModule": "RAWSIMoutput",
         "InputStep": "GENSIM",
-        "MCPileup": "/HighPileUp/Run2011A-v1/RAW",
+        "MCPileup": "/GammaGammaToEE_Elastic_Pt15_8TeV-lpair/Summer12-START53_V7C-v1/GEN-SIM",
         "PrepID": "PREP-Step2",
         "ScramArch": "slc6_amd64_gcc530",
         "SplittingAlgo": "EventAwareLumiBased",
@@ -549,7 +549,7 @@ class StepChainTests(EmulatedUnitTestCase):
         for s in ['Step1', 'Step2', 'Step3']:
             testArguments[s]['ConfigCacheID'] = configDocs[s]
         testArguments['Step2']['KeepOutput'] = False
-        testArguments['Step3']['MCPileup'] = "/Cosmics/ComissioningHI-PromptReco-v1/RECO"
+        testArguments['Step3']['MCPileup'] = "/WJetsToLNu_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18NanoAOD-102X_upgrade2018_realistic_v15-v1/NANOAODSIM"
 
         factory = StepChainWorkloadFactory()
         testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
@@ -605,7 +605,7 @@ class StepChainTests(EmulatedUnitTestCase):
         self.assertRaises(WMSpecFactoryException, factory.factoryWorkloadConstruction,
                           "TestWorkload", testArguments)
 
-        testArguments['Step1']["InputDataset"] = '/Cosmics/ComissioningHI-PromptReco-v1/RECO'
+        testArguments['Step1']["InputDataset"] = '/GammaGammaToEE_Elastic_Pt15_8TeV-lpair/Summer12-START53_V7C-v1/GEN-SIM'
         factory.factoryWorkloadConstruction("TestWorkload", testArguments)
 
         testArguments['Step1']["IncludeParents"] = False

--- a/test/python/WMCore_t/WorkQueue_t/LocalQueueProfile_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/LocalQueueProfile_t.py
@@ -33,12 +33,18 @@ class LocalWorkQueueProfileTest(WorkQueueTestCase):
         self.cacheDir = tempfile.mkdtemp()
         self.specGenerator = WMSpecGenerator(self.cacheDir)
         self.specs = self.createReRecoSpec(1, "file")
+        # setup rucio parameters for global/local queue
+        self.queueParams = {}
+        self.queueParams['log_reporter'] = "lq_profile_test"
+        self.queueParams['rucioAccount'] = "wma_test"
+        self.queueParams['rucioAuthUrl'] = "http://cmsrucio-int.cern.ch"
+        self.queueParams['rucioUrl'] = "https://cmsrucio-auth-int.cern.ch"
 
         # Create queues
         self.localQueue = localQueue(DbName=self.queueDB, InboxDbName=self.queueInboxDB,
                                      NegotiationTimeout=0, QueueURL='global.example.com', CacheDir=self.cacheDir,
                                      central_logdb_url="%s/%s" % (self.couchURL, self.logDBName),
-                                     log_reporter='lq_profile_test')
+                                     **self.queueParams)
 
 
     def tearDown(self):

--- a/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Block_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Block_t.py
@@ -434,7 +434,7 @@ class BlockTestCase(EmulatedUnitTestCase):
             for unit in units:
                 pileupData = unit["PileupData"]
                 self.assertEqual(len(pileupData), 1)
-                self.assertItemsEqual(pileupData.values()[0], ['T2_XX_SiteA', 'T2_XX_SiteB', 'T2_XX_SiteC'])
+                self.assertItemsEqual(pileupData.values()[0], ['T2_XX_SiteA', 'T2_XX_SiteB'])
         return
 
     def testWithMaskedBlocks(self):

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
@@ -36,7 +36,7 @@ from WMCore.WorkQueue.WorkQueueExceptions import (WorkQueueWMSpecError, WorkQueu
 from WMCore.WorkQueue.DataStructs.WorkQueueElement import STATES
 from WMQuality.Emulators import EmulatorSetup
 from WMQuality.Emulators.DataBlockGenerator import Globals
-from WMQuality.Emulators.PhEDExClient.MockPhEDExApi import PILEUP_DATASET
+from WMQuality.Emulators.RucioClient.MockRucioApi import PILEUP_DATASET
 from WMQuality.Emulators.WMSpecGenerator.WMSpecGenerator import createConfig
 
 from WMCore_t.WMSpec_t.samples.MultiTaskProductionWorkload \
@@ -101,6 +101,12 @@ class WorkQueueTest(WorkQueueTestCase):
 
     def __init__(self, methodName='runTest'):
         super(WorkQueueTest, self).__init__(methodName=methodName, mockDBS=True, mockPhEDEx=True)
+        self.queueParams = {}
+        self.queueParams['log_reporter'] = "WorkQueue_Unittest"
+        self.queueParams['rucioAccount'] = "wma_test"
+        self.queueParams['rucioAuthUrl'] = "http://cmsrucio-int.cern.ch"
+        self.queueParams['rucioUrl'] = "https://cmsrucio-auth-int.cern.ch"
+
 
     def setupConfigCacheAndAgrs(self):
         self.rerecoArgs = ReRecoWorkloadFactory.getTestArguments()
@@ -191,9 +197,9 @@ class WorkQueueTest(WorkQueueTestCase):
                                        InboxDbName=self.globalQInboxDB,
                                        QueueURL=globalCouchUrl,
                                        central_logdb_url=logdbCouchUrl,
-                                       log_reporter="WorkQueue_Unittest",
                                        UnittestFlag=True,
-                                       RequestDBURL=reqdbUrl)
+                                       RequestDBURL=reqdbUrl,
+                                       **self.queueParams)
         #        self.midQueue = WorkQueue(SplitByBlock = False, # mid-level queue
         #                            PopulateFilesets = False,
         #                            ParentQueue = self.globalQueue,
@@ -231,8 +237,8 @@ class WorkQueueTest(WorkQueueTestCase):
                                      BossAirConfig=bossAirConfig,
                                      CacheDir=self.workDir,
                                      central_logdb_url=logdbCouchUrl,
-                                     log_reporter="WorkQueue_Unittest",
-                                     RequestDBURL=reqdbUrl)
+                                     RequestDBURL=reqdbUrl,
+                                     **self.queueParams)
 
         self.localQueue2 = localQueue(DbName=self.localQDB2,
                                       InboxDbName=self.localQInboxDB2,
@@ -242,8 +248,8 @@ class WorkQueueTest(WorkQueueTestCase):
                                       BossAirConfig=bossAirConfig,
                                       CacheDir=self.workDir,
                                       central_logdb_url=logdbCouchUrl,
-                                      log_reporter="WorkQueue_Unittest",
-                                      RequestDBURL=reqdbUrl)
+                                      RequestDBURL=reqdbUrl,
+                                      **self.queueParams)
 
         # configuration for the Alerts messaging framework, work (alerts) and
         # control  channel addresses to which alerts
@@ -261,8 +267,8 @@ class WorkQueueTest(WorkQueueTestCase):
                                CacheDir=self.workDir,
                                config=config,
                                central_logdb_url=logdbCouchUrl,
-                               log_reporter="WorkQueue_Unittest",
-                               RequestDBURL=reqdbUrl)
+                               RequestDBURL=reqdbUrl,
+                               **self.queueParams)
 
         # create relevant sites in wmbs
         rc = ResourceControl()


### PR DESCRIPTION
Fixes #10095 

#### Status
ready

#### Description
Remove environment variables check for Rucio, thus setting all the data management functionality to use Rucio by default.
Not all the unit tests were set to use Rucio - I guess many were still using Phedex mock data- so I had to make changes to the EmulatedUnittests module, mock rucio data and APIs, and some unit tests.

Note: even though we apply a mock patch to the PileupFetcher, it still doesn't use the mock Rucio data. My suspicious is that we do not explicitly import that module from the top of the module, but instead we use the StepFactory to import modules from arguments...

#### Is it backward compatible (if not, which system it affects?)
yes (but no in the sense that we can no longer switch between PhEDEx and Rucio, not that that matters anymore!)

#### Related PRs
Initial mocking logic performed in https://github.com/dmwm/WMCore/pull/10099

#### External dependencies / deployment changes
Deployment changes in:
https://github.com/dmwm/deployment/pull/1033
K8s deployment changes (transparent/useless):
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/71
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/70
cms-bot changes applied to the jenkins job (DMWM-WMCore-PR):
https://github.com/cms-sw/cms-bot/pull/1491
