### PR TITLE
fix bug in selecting stagein for ul logcollect, fixes #10294

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
@@ -103,6 +103,11 @@ class LogCollect(Executor):
         useEdmCopyUtil = True
         if isCMSSWSupported(cmsswVersion, "CMSSW_10_4_0"):
             pass
+        elif scramArch.startswith('slc7_amd64_'):
+            msg = "CMSSW too old or not fully functional to support edmCopyUtil, using CMSSW_10_4_0 instead"
+            logging.warning(msg)
+            cmsswVersion = "CMSSW_10_4_0"
+            scramArch = "slc7_amd64_gcc820"
         elif scramArch.startswith('slc6_amd64_'):
             msg = "CMSSW too old or not fully functional to support edmCopyUtil, using CMSSW_10_4_0 instead"
             logging.warning(msg)


### PR DESCRIPTION
The detection logic when to use edmCopyUtil and when to use stageIn for LogCollect jobs has a hole for UL CMSSW releases, effect is that it uses stageIn when it really should be using edmCopyUtil.

Fixes #10294

#### Status
not-tested

#### Description
Adds check for older SL7 releases, fixes a bug introduced with the last change 2 years ago

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
