### PR TITLE
[py2py3] Migration at level scr/python/A/B/C - slice 12

### DIFF
--- a/src/python/WMCore/MicroService/DataStructs/MSOutputTemplate.py
+++ b/src/python/WMCore/MicroService/DataStructs/MSOutputTemplate.py
@@ -6,6 +6,9 @@ Description: Provides a document Template for MSOutput MicroServices
 # futures
 from __future__ import division, print_function
 
+from future.utils import viewitems
+from builtins import str, bytes
+
 from time import time
 from copy import deepcopy
 
@@ -104,16 +107,16 @@ class MSOutputTemplate(dict):
         :return: a list of tuples
         """
         docTemplate = [
-            ('_id', None, (str, unicode)),
-            ('RequestName', None, (str, unicode)),
-            ('RequestType', "", (str, unicode)),
-            ('Campaign', [], (str, unicode)),
+            ('_id', None, (bytes, str)),
+            ('RequestName', None, (bytes, str)),
+            ('RequestType', "", (bytes, str)),
+            ('Campaign', [], (bytes, str)),
             ('CreationTime', int(time()), int),
             ('LastUpdate', None, int),
             ('IsRelVal', False, bool),
             ('OutputDatasets', [], list),
             ('OutputMap', [], list),
-            ('TransferStatus', "pending", (str, unicode))]
+            ('TransferStatus', "pending", (bytes, str))]
         return docTemplate
 
     def outputMapSchema(self):
@@ -136,14 +139,14 @@ class MSOutputTemplate(dict):
         :return: a list of tuples
         """
         outMapTemplate = [
-            ('Campaign', "", (str, unicode)),
-            ('Dataset', "", (str, unicode)),
+            ('Campaign', "", (bytes, str)),
+            ('Dataset', "", (bytes, str)),
             ('DatasetSize', 0, int),
             ('Copies', 1, int),
-            ('DiskDestination', "", (str, unicode)),
-            ('TapeDestination', "", (str, unicode)),
-            ('DiskRuleID', "", (str, unicode)),
-            ('TapeRuleID', "", (str, unicode))]
+            ('DiskDestination', "", (bytes, str)),
+            ('TapeDestination', "", (bytes, str)),
+            ('DiskRuleID', "", (bytes, str)),
+            ('TapeRuleID', "", (bytes, str))]
         return outMapTemplate
 
     def _checkAttr(self, myDoc, update=False, throw=False, **kwargs):
@@ -162,7 +165,7 @@ class MSOutputTemplate(dict):
         """
 
         # check if we can fit all the arguments provided through **kwargs
-        for kw in kwargs.keys():
+        for kw in kwargs:
             found = False
             typeok = False
             for tup in self.docSchema():
@@ -207,14 +210,14 @@ class MSOutputTemplate(dict):
         valid = []
         missing = []
         for mandField in self.required:
-            if mandField in myDoc.keys() and myDoc[mandField]:
+            if mandField in myDoc and myDoc[mandField]:
                 valid.append(True)
             else:
                 valid.append(False)
                 missing.append(mandField)
 
         for mandField in self.allowEmpty:
-            if mandField in myDoc.keys():
+            if mandField in myDoc:
                 valid.append(True)
             else:
                 valid.append(False)
@@ -299,7 +302,7 @@ class MSOutputTemplate(dict):
         """
         outputMap = []
         campaignMap = self._getCampMap(reqDoc)
-        for camp, dsets in campaignMap.viewitems():
+        for camp, dsets in viewitems(campaignMap):
             for outDset in dsets:
                 dsetMap = {tuple[0]:tuple[1] for tuple in self.outputMapSchema()}
                 dsetMap['Campaign'] = camp

--- a/src/python/WMCore/MicroService/DataStructs/MSRuleCleanerWflow.py
+++ b/src/python/WMCore/MicroService/DataStructs/MSRuleCleanerWflow.py
@@ -5,6 +5,8 @@ Description: Provides a document Template for the MSRuleCleaner MicroServices
 
 # futures
 from __future__ import division, print_function
+from builtins import object, str, bytes
+from future.utils import viewitems
 
 from copy import deepcopy
 from Utils.IteratorTools import flattenList
@@ -57,10 +59,10 @@ class WfParser(object):
             for value in wfObj:
                 self._paramFinder(value)
         if isinstance(wfObj, dict):
-            for key, value in wfObj.items():
+            for key, value in viewitems(wfObj):
                 self._paramFinder(value)
-            for key in self.extDoc.keys():
-                if key in wfObj.keys():
+            for key in self.extDoc:
+                if key in wfObj:
                     self.extDoc[key]['values'].append(deepcopy(wfObj[key]))
 
     def _wfParse(self):
@@ -99,7 +101,7 @@ class WfParser(object):
         """
 
         # Convert back the so aggregated extDoc to the original structure:
-        for keyName, data in self.extDoc.items():
+        for keyName, data in viewitems(self.extDoc):
             if len(data['values']) == 0:
                 self.extDoc[keyName] = deepcopy(data['default'])
             elif len(data['values']) == 1:
@@ -120,8 +122,8 @@ class WfParser(object):
                     self.extDoc[keyName] = {}
                     for item in data['values']:
                         self.extDoc[keyName].update(item)
-                elif (isinstance(data['type'], tuple) and (str in data['type'] or unicode in data['type'])) or \
-                     (data['type'] is str or data['type'] is unicode):
+                elif (isinstance(data['type'], tuple) and (bytes in data['type'] or str in data['type'])) or \
+                     (data['type'] is bytes or data['type'] is str):
                     data['values'] = list(set(data['values']))
                     if len(data['values']) == 1:
                         self.extDoc[keyName] = deepcopy(data['values'][0])
@@ -195,14 +197,14 @@ class MSRuleCleanerWflow(dict):
         :return: a list of tuples
         """
         docTemplate = [
-            ('RequestName', None, (str, unicode)),
-            ('RequestType', None, (str, unicode)),
-            ('RequestStatus', None, (str, unicode)),
+            ('RequestName', None, (bytes, str)),
+            ('RequestType', None, (bytes, str)),
+            ('RequestStatus', None, (bytes, str)),
             ('OutputDatasets', [], list),
             ('RulesToClean', {}, dict),
             ('CleanupStatus', {}, dict),
             ('TransferDone', False, bool),
-            ('TargetStatus', None, (str, unicode)),
+            ('TargetStatus', None, (bytes, str)),
             ('ParentageResolved', True, bool),
             ('PlineMarkers', None, list),
             ('IsClean', False, bool),
@@ -211,10 +213,10 @@ class MSRuleCleanerWflow(dict):
             ('ForceArchive', False, bool),
             ('RequestTransition', [], list),
             ('IncludeParents', False, bool),
-            ('DataPileup', None, (str, unicode)),
-            ('MCPileup', None, (str, unicode)),
-            ('InputDataset', None, (str, unicode)),
-            ('ParentDataset', None, (str, unicode))]
+            ('DataPileup', None, (bytes, str)),
+            ('MCPileup', None, (bytes, str)),
+            ('InputDataset', None, (bytes, str)),
+            ('ParentDataset', None, (bytes, str))]
 
         # NOTE: ParentageResolved is set by default to True it will be False only if:
         #       - RequestType is StepChain

--- a/src/python/WMCore/MicroService/DataStructs/Workflow.py
+++ b/src/python/WMCore/MicroService/DataStructs/Workflow.py
@@ -4,6 +4,9 @@ required by MS Transferor
 """
 from __future__ import division, print_function
 
+from builtins import range, object
+from future.utils import viewitems, viewvalues, listvalues
+
 import operator
 from copy import copy, deepcopy
 from WMCore.DataStructs.LumiList import LumiList
@@ -163,7 +166,7 @@ class Workflow(object):
             if "Campaign" in item and item["Campaign"]:
                 self.campaigns.add(item["Campaign"])
 
-        self.dataCampaignMap = data.values()
+        self.dataCampaignMap = listvalues(data)
 
     def getDataCampaignMap(self):
         """
@@ -312,7 +315,7 @@ class Workflow(object):
         # flat list with the final parent blocks
         parentBlocks = set()
         # remove parent blocks without any valid replica (only invalid files)
-        for child, parents in blocksDict.items():
+        for child, parents in viewitems(blocksDict):
             for parent in list(parents):
                 if parent not in self.getParentBlocks():
                     # then drop this block
@@ -345,16 +348,16 @@ class Workflow(object):
         """
         if numChunks == 1:
             thisChunk = set()
-            thisChunk.update(self.getPrimaryBlocks().keys())
-            thisChunkSize = sum([blockInfo['blockSize'] for blockInfo in self.getPrimaryBlocks().values()])
+            thisChunk.update(list(self.getPrimaryBlocks()))
+            thisChunkSize = sum([blockInfo['blockSize'] for blockInfo in viewvalues(self.getPrimaryBlocks())])
             if self.getParentDataset():
-                thisChunk.update(self.getParentBlocks().keys())
-                thisChunkSize += sum([blockInfo['blockSize'] for blockInfo in self.getParentBlocks().values()])
+                thisChunk.update(list(self.getParentBlocks()))
+                thisChunkSize += sum([blockInfo['blockSize'] for blockInfo in viewvalues(self.getParentBlocks())])
             # keep same data structure as multiple chunks, so list of lists
             return [thisChunk], [thisChunkSize]
 
         # create a descendant list of blocks according to their sizes
-        sortedPrimary = sorted(self.getPrimaryBlocks().items(), key=operator.itemgetter(1), reverse=True)
+        sortedPrimary = sorted(viewitems(self.getPrimaryBlocks()), key=operator.itemgetter(1), reverse=True)
         if len(sortedPrimary) < numChunks:
             msg = "There are less blocks than chunks to create. "
             msg += "Reducing numChunks from %d to %d" % (numChunks, len(sortedPrimary))

--- a/test/python/WMCore_t/MicroService_t/DataStructs_t/MSOutputTemplate_t.py
+++ b/test/python/WMCore_t/MicroService_t/DataStructs_t/MSOutputTemplate_t.py
@@ -3,6 +3,7 @@ Unit tests for the WMCore/MicroService/DataStructs/MSOutputTemplate.py module
 """
 from __future__ import division, print_function
 
+from builtins import range
 import unittest
 from copy import deepcopy
 
@@ -102,7 +103,7 @@ class MSOutputTemplateTest(unittest.TestCase):
         self.assertEqual(msOutDoc["RequestType"], self.taskchainSpec["RequestType"])
         self.assertEqual(msOutDoc["_id"], self.taskchainSpec["_id"])
         self.assertEqual(len(msOutDoc["OutputMap"]), 2)
-        self.assertItemsEqual(msOutDoc["OutputMap"][0].viewkeys(), self.outputMapKeys)
+        self.assertItemsEqual(list(msOutDoc["OutputMap"][0]), self.outputMapKeys)
         for idx in range(2):
             self.assertEqual(msOutDoc["OutputMap"][idx]["DatasetSize"], 0)
             if msOutDoc["OutputMap"][idx]["Campaign"] == self.taskchainSpec["Task1"]["Campaign"]:
@@ -133,7 +134,7 @@ class MSOutputTemplateTest(unittest.TestCase):
         self.assertEqual(msOutDoc["RequestType"], self.stepchainSpec["RequestType"])
         self.assertEqual(msOutDoc["_id"], self.stepchainSpec["_id"])
         self.assertEqual(len(msOutDoc["OutputMap"]), 2)
-        self.assertItemsEqual(msOutDoc["OutputMap"][0].viewkeys(), self.outputMapKeys)
+        self.assertItemsEqual(list(msOutDoc["OutputMap"][0]), self.outputMapKeys)
         for idx in range(2):
             self.assertEqual(msOutDoc["OutputMap"][idx]["DatasetSize"], 0)
             if msOutDoc["OutputMap"][idx]["Campaign"] == self.stepchainSpec["Step1"]["Campaign"]:
@@ -160,7 +161,7 @@ class MSOutputTemplateTest(unittest.TestCase):
         self.assertEqual(msOutDoc["_id"], self.rerecoSpec["_id"])
         self.assertEqual(len(msOutDoc["OutputMap"]), 2)
         self.assertEqual(msOutDoc["OutputMap"][0]["DatasetSize"], 0)
-        self.assertItemsEqual(msOutDoc["OutputMap"][0].viewkeys(), self.outputMapKeys)
+        self.assertItemsEqual(list(msOutDoc["OutputMap"][0]), self.outputMapKeys)
         self.assertEqual(msOutDoc["OutputMap"][0]["Campaign"], self.rerecoSpec["Campaign"])
         self.assertEqual(msOutDoc["OutputMap"][1]["Campaign"], self.rerecoSpec["Campaign"])
         self.assertItemsEqual([msOutDoc["OutputMap"][0]["Dataset"], msOutDoc["OutputMap"][1]["Dataset"]],

--- a/test/python/WMCore_t/MicroService_t/DataStructs_t/Workflow_t.py
+++ b/test/python/WMCore_t/MicroService_t/DataStructs_t/Workflow_t.py
@@ -233,11 +233,11 @@ class WorkflowTest(unittest.TestCase):
 
         self.assertEqual(wflow.getPrimaryBlocks(), {})
         wflow.setPrimaryBlocks(primDict)
-        self.assertItemsEqual(wflow.getPrimaryBlocks().keys(), ["block_A", "block_B"])
+        self.assertItemsEqual(list(wflow.getPrimaryBlocks()), ["block_A", "block_B"])
 
         self.assertEqual(wflow.getParentBlocks(), {})
         wflow.setParentBlocks(parentDict)
-        self.assertItemsEqual(wflow.getParentBlocks().keys(), ["parent_A", "parent_B", "parent_C"])
+        self.assertItemsEqual(list(wflow.getParentBlocks()), ["parent_A", "parent_B", "parent_C"])
 
         self.assertEqual(wflow.getChildToParentBlocks(), {})
         wflow.setChildToParentBlocks(parentage)

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
@@ -6,6 +6,9 @@ WorkQueue tests
 """
 from __future__ import print_function
 
+from builtins import next, range
+from future.utils import viewitems
+
 import os
 import threading
 import time
@@ -273,7 +276,7 @@ class WorkQueueTest(WorkQueueTestCase):
         # create relevant sites in wmbs
         rc = ResourceControl()
         site_se_mapping = {'T2_XX_SiteA': 'T2_XX_SiteA', 'T2_XX_SiteB': 'T2_XX_SiteB'}
-        for site, se in site_se_mapping.iteritems():
+        for site, se in viewitems(site_se_mapping):
             rc.insertSite(site, 100, 200, se, cmsName=site, plugin="MockPlugin")
             daofactory = DAOFactory(package="WMCore.WMBS",
                                     logger=threading.currentThread().logger,
@@ -1514,13 +1517,13 @@ class WorkQueueTest(WorkQueueTestCase):
         expectedMetrics = ('workByStatus', 'workByStatusAndPriority', 'workByAgentAndStatus',
                            'workByAgentAndPriority', 'uniqueJobsPerSiteAAA', 'possibleJobsPerSiteAAA',
                            'uniqueJobsPerSite', 'possibleJobsPerSite', 'total_query_time')
-        self.assertItemsEqual(metrics.keys(), expectedMetrics)
+        self.assertItemsEqual(list(metrics), expectedMetrics)
 
-        self.assertItemsEqual(metrics['workByStatus'].keys(), STATES)
+        self.assertItemsEqual(list(metrics['workByStatus']), STATES)
         self.assertEqual(metrics['workByStatus']['Available']['sum_jobs'], 678)
         self.assertEqual(metrics['workByStatus']['Acquired'], {})
 
-        self.assertItemsEqual(metrics['workByStatusAndPriority'].keys(), STATES)
+        self.assertItemsEqual(list(metrics['workByStatusAndPriority']), STATES)
         prios = [item['priority'] for item in metrics['workByStatusAndPriority']['Available']]
         self.assertItemsEqual(prios, [8000, 999998])
         self.assertEqual(metrics['workByStatusAndPriority']['Acquired'], [])
@@ -1534,10 +1537,10 @@ class WorkQueueTest(WorkQueueTestCase):
         self.assertEqual([item['priority'] for item in metrics['workByAgentAndPriority']], [8000, 999998])
 
         for met in ('uniqueJobsPerSiteAAA', 'possibleJobsPerSiteAAA', 'uniqueJobsPerSite', 'possibleJobsPerSite'):
-            self.assertItemsEqual(metrics[met].keys(), initialStatus)
+            self.assertItemsEqual(list(metrics[met]), initialStatus)
             self.assertEqual(len(metrics[met]['Available']), 2)
             self.assertEqual(len(metrics[met]['Acquired']), 0)
-            self.assertItemsEqual(metrics[met]['Available'].keys(), ['T2_XX_SiteA', 'T2_XX_SiteB'])
+            self.assertItemsEqual(list(metrics[met]['Available']), ['T2_XX_SiteA', 'T2_XX_SiteB'])
 
         self.assertTrue(metrics['total_query_time'] >= 0)
 
@@ -1572,11 +1575,11 @@ class WorkQueueTest(WorkQueueTestCase):
         self.assertItemsEqual(prios, [8000, 999998])
 
         for met in ('uniqueJobsPerSiteAAA', 'possibleJobsPerSiteAAA', 'uniqueJobsPerSite', 'possibleJobsPerSite'):
-            self.assertItemsEqual(metrics[met].keys(), initialStatus)
+            self.assertItemsEqual(list(metrics[met]), initialStatus)
             self.assertEqual(len(metrics[met]['Available']), 2)
             self.assertEqual(len(metrics[met]['Acquired']), 2)
-            self.assertItemsEqual(metrics[met]['Available'].keys(), ['T2_XX_SiteA', 'T2_XX_SiteB'])
-            self.assertItemsEqual(metrics[met]['Acquired'].keys(), ['T2_XX_SiteA', 'T2_XX_SiteB'])
+            self.assertItemsEqual(list(metrics[met]['Available']), ['T2_XX_SiteA', 'T2_XX_SiteB'])
+            self.assertItemsEqual(list(metrics[met]['Acquired']), ['T2_XX_SiteA', 'T2_XX_SiteB'])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #10136 

#### Status

ready

#### Related PRs

* Previous migration PR: #10299  (slice11, issue #10135 )
* Next migration PR: #10310  (slice13, issue #10137  )

#### Description

Run futurize and some manual changes on the first batch of src/python/A/B/C.

Other changes that require some comments:

- `src/python/WMCore/WorkQueue/WorkQueue.py`: here `str()` is used extensively in py2 to simply format log messages, so I would like to use the "native string" approach and not touch it. However, we also need to compare a variable with both unicode and bytes strings types. This is why I decided to decouple the import `from builtins import str as newstr, bytes` to use `(newstr, bytes)` instead of `basestring`, but without affecting all the extensive use of `str()` that likely will not require any change when switching to py3


#### Is it backward compatible (if not, which system it affects?)

It should be. However,
- `src/python/WMCore/MicroService/DataStructs/MSRuleCleanerWflow.py` checks if the python2 types `str` or `unicode` are in a list. If the list is not built properly, this is likely to fail. There is no workaround, we can only modernize this code and fix accordingly where the list `data['type']` is built from. This may require some testing that goes beyond unit tests.
  - tracked in #10323 

#### External dependencies / deployment changes

Requires python-future in both py2 and py3 environments.
