### PR TITLE
Validate status transition for cascade option

### DIFF
--- a/src/couchapps/ReqMgr/views/childresubmissionrequests/map.js
+++ b/src/couchapps/ReqMgr/views/childresubmissionrequests/map.js
@@ -5,6 +5,6 @@
  */
 function(doc){
     if(doc.InitialTaskPath){
-        emit(doc.InitialTaskPath.split("/")[1], null);
+        emit(doc.InitialTaskPath.split("/")[1], doc.RequestStatus);
     }
 }


### PR DESCRIPTION
Fixes #10217 

#### Status
ready

#### Description
This PR provides the following changes:
* update a ReqMgr2 CouchDB view (need to make sure it gets properly pushed in in CMSWEB, after the migration to k8s)
* before updating the children workflows status, check whether the status transition is allowed. If not, create a record in the logs and move to the next workflow.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
