### PR TITLE
[py2py3] Migration at level scr/python/A/B/C - slice 13

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/BuildMaster.py
+++ b/src/python/WMCore/WMSpec/Steps/BuildMaster.py
@@ -10,6 +10,7 @@ for each step
 
 
 
+from builtins import object
 import os
 
 import WMCore.WMSpec.Steps.StepFactory as StepFactory
@@ -59,7 +60,7 @@ def initialiseWMTaskSpace(directory, taskName):
 
 
 
-class BuildMaster:
+class BuildMaster(object):
     """
     _BuildMaster_
 

--- a/src/python/WMCore/WMSpec/Steps/BuildTools.py
+++ b/src/python/WMCore/WMSpec/Steps/BuildTools.py
@@ -7,14 +7,15 @@ Utils to assist in the build process
 
 """
 
+from builtins import object
+from future.utils import viewvalues
+
 import os
 import logging
 from WMCore.WMSpec.ConfigSectionTree import nodeName
 
 
-
-
-class File:
+class File(object):
     """
     _File_
 
@@ -61,7 +62,7 @@ class File:
 
 
 
-class Directory:
+class Directory(object):
     """
     _Directory_
 
@@ -143,18 +144,18 @@ class Directory:
         logging.info("create(%s)" % newDir)
         if not os.path.exists(newDir):
             os.makedirs(newDir)
-        for f in self.files.values():
+        for f in viewvalues(self.files):
             f.fetch(newDir)
 
-        for child in self.children.values():
+        for child in viewvalues(self.children):
             child.create(newDir)
         return
 
     def __str__(self):
         result = "%s\n" % self.path()
-        for f in self.files.values():
+        for f in viewvalues(self.files):
             result += "%s ==> %s\n" % (f.path(), f.source)
-        for d in self.children.values():
+        for d in viewvalues(self.children):
             result += str(d)
 
         return result

--- a/src/python/WMCore/WMSpec/Steps/Builder.py
+++ b/src/python/WMCore/WMSpec/Steps/Builder.py
@@ -7,6 +7,7 @@ Interface definition for Step Builder implementations
 """
 from __future__ import print_function
 
+from builtins import object
 import logging
 
 import WMCore.WMSpec.Steps.BuildTools as BuildTools

--- a/src/python/WMCore/WMSpec/Steps/Diagnostic.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostic.py
@@ -7,6 +7,7 @@ Interface and base class for step specific diagnostic handlers
 
 
 """
+from builtins import object
 
 from WMCore.FwkJobReport.Report import FwkJobReportException
 

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/AlcaHarvest.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/AlcaHarvest.py
@@ -7,6 +7,7 @@ Diagnostic implementation for a AlcaHarvest job
 
 """
 
+from builtins import range
 import os
 
 from WMCore.WMSpec.Steps.Diagnostic import Diagnostic, DiagnosticHandler

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/CMSSW.py
@@ -10,7 +10,7 @@ Diagnostic implementation for a CMSSW job
 """
 from __future__ import print_function
 
-from builtins import str
+from builtins import range, str
 
 import logging
 import os.path

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/DQMUpload.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/DQMUpload.py
@@ -7,6 +7,7 @@ Diagnostic implementation for a job DQMUpload
 
 """
 
+from builtins import range
 import os
 
 from WMCore.WMSpec.Steps.Diagnostic import Diagnostic, DiagnosticHandler

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/DeleteFiles.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/DeleteFiles.py
@@ -7,8 +7,7 @@ Diagnostic implementation for a job's DeleteFiles step
 
 """
 
-
-
+from builtins import range
 
 import os
 from WMCore.WMSpec.Steps.Diagnostic import Diagnostic, DiagnosticHandler

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/LogArchive.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/LogArchive.py
@@ -5,6 +5,7 @@ _LogArchive_
 Diagnostic implementation for a job's LogArchive step
 """
 
+from builtins import range
 import os
 
 from WMCore.WMSpec.Steps.Diagnostic import Diagnostic, DiagnosticHandler

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/LogCollect.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/LogCollect.py
@@ -10,6 +10,7 @@ Diagnostic implementation for a job's LogCollect step
 
 
 
+from builtins import range
 import os
 from WMCore.WMSpec.Steps.Diagnostic import Diagnostic, DiagnosticHandler
 

--- a/src/python/WMCore/WMSpec/Steps/Diagnostics/StageOut.py
+++ b/src/python/WMCore/WMSpec/Steps/Diagnostics/StageOut.py
@@ -7,6 +7,7 @@ Diagnostic implementation for a job StageOut
 
 """
 
+from builtins import range
 import os
 from WMCore.WMSpec.Steps.Diagnostic import Diagnostic, DiagnosticHandler
 

--- a/src/python/WMCore/WMSpec/Steps/Emulator.py
+++ b/src/python/WMCore/WMSpec/Steps/Emulator.py
@@ -8,7 +8,8 @@ Define the Interface for a Step Emulator
 """
 
 
-class Emulator:
+from builtins import object
+class Emulator(object):
     """
     _Emulator_
 

--- a/src/python/WMCore/WMSpec/Steps/ExecuteMaster.py
+++ b/src/python/WMCore/WMSpec/Steps/ExecuteMaster.py
@@ -9,6 +9,8 @@ for each step
 
 """
 
+from builtins import object
+
 import logging
 import os
 import threading

--- a/src/python/WMCore/WMSpec/Steps/Executor.py
+++ b/src/python/WMCore/WMSpec/Steps/Executor.py
@@ -7,6 +7,7 @@ Interface definition for a step executor
 
 """
 from __future__ import absolute_import
+from builtins import object
 
 import json
 import logging
@@ -34,7 +35,7 @@ def getStepSpace(stepName):
 
     """
     modName = "WMTaskSpace"
-    if modName in sys.modules.keys():
+    if modName in sys.modules:
         taskspace = sys.modules[modName]
     else:
         try:

--- a/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
@@ -7,6 +7,8 @@ Implementation of an Executor for a DQMUpload step
 """
 from __future__ import print_function
 
+from future.utils import viewitems
+
 import logging
 import os
 import sys
@@ -191,12 +193,12 @@ class DQMUpload(Executor):
         """
         boundary = '----------=_DQM_FILE_BOUNDARY_=-----------'
         (body, crlf) = ('', '\r\n')
-        for (key, value) in args.items():
+        for (key, value) in viewitems(args):
             payload = str(value)
             body += '--' + boundary + crlf
             body += ('Content-Disposition: form-data; name="%s"' % key) + crlf
             body += crlf + payload + crlf
-        for (key, filename) in files.items():
+        for (key, filename) in viewitems(files):
             body += '--' + boundary + crlf
             body += ('Content-Disposition: form-data; name="%s"; filename="%s"'
                      % (key, os.path.basename(filename))) + crlf

--- a/src/python/WMCore/WMSpec/Steps/Executors/DeleteFiles.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/DeleteFiles.py
@@ -8,6 +8,8 @@ Implementation of an Executor for a Delete step
 """
 from __future__ import print_function
 
+from future.utils import viewitems
+
 import signal
 
 from WMCore.Storage.DeleteMgr import DeleteMgr, DeleteMgrError
@@ -62,7 +64,7 @@ class DeleteFiles(Executor):
         overrides.setdefault('waitTime', 300)
 
         self.logger.info("Step with the following overrides:")
-        for keyName, value in overrides.items():
+        for keyName, value in viewitems(overrides):
             self.logger.info("    %s : %s", keyName, value)
 
         # Pull out StageOutMgr Overrides
@@ -110,7 +112,7 @@ class DeleteFiles(Executor):
         # Alan: I do not get why we would have two sets of files to be deleted!
         if hasattr(self.step, 'filesToDelete'):
             # files from the configTree to be deleted
-            for k, v in self.step.filesToDelete.dictionary_().iteritems():
+            for k, v in viewitems(self.step.filesToDelete.dictionary_()):
                 if k.startswith('file'):
                     self.logger.info("Deleting LFN: %s", v)
                     fileForTransfer = {'LFN': v,

--- a/src/python/WMCore/WMSpec/Steps/Executors/LogArchive.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/LogArchive.py
@@ -4,6 +4,7 @@ _Step.Executor.LogArchive_
 
 Implementation of an Executor for a LogArchive step
 """
+from __future__ import division
 
 import logging
 import os
@@ -22,7 +23,7 @@ from WMCore.WMException import WMException
 from WMCore.WMSpec.Steps.Executor import Executor
 from WMCore.WMSpec.Steps.WMExecutionFailure import WMExecutionFailure
 
-lfnGroup = lambda j: str(j.get("counter", 0) / 1000).zfill(4)
+lfnGroup = lambda j: str(j.get("counter", 0) // 1000).zfill(4)
 
 
 class LogArchive(Executor):

--- a/src/python/WMCore/WMSpec/Steps/Fetchers/FetcherInterface.py
+++ b/src/python/WMCore/WMSpec/Steps/Fetchers/FetcherInterface.py
@@ -3,6 +3,7 @@
 
 
 
+from builtins import object
 class FetcherInterface(object):
     """
     _FetcherInterface_

--- a/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
+++ b/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
@@ -5,6 +5,8 @@ of pileup files in the job sandbox for the dataset.
 """
 from __future__ import print_function
 
+from future.utils import viewitems
+
 import datetime
 import os
 import shutil
@@ -77,7 +79,7 @@ class PileupFetcher(FetcherInterface):
         :return: update blockDict in place
         """
         blockReplicas = self.rucio.getPileupLockedAndAvailable(dset, account=self.rucioAcct)
-        for blockName, blockLocation in blockReplicas.viewitems():
+        for blockName, blockLocation in viewitems(blockReplicas):
             try:
                 blockDict[blockName]['PhEDExNodeNames'] = list(blockLocation)
             except KeyError:

--- a/src/python/WMCore/WMSpec/Steps/TaskEmulator.py
+++ b/src/python/WMCore/WMSpec/Steps/TaskEmulator.py
@@ -6,11 +6,12 @@ Top level emulator controller
 
 """
 
+from builtins import object
 from WMCore.WMSpec.WMStep import WMStepHelper
 import WMCore.WMSpec.Steps.StepFactory as StepFactory
 
 
-class TaskEmulator:
+class TaskEmulator(object):
     """
     _TaskEmulator_
 

--- a/src/python/WMCore/WMSpec/Steps/Template.py
+++ b/src/python/WMCore/WMSpec/Steps/Template.py
@@ -6,6 +6,7 @@ Template class for all Step Template implementations to inherit and implement
 the API
 
 """
+from builtins import object
 import os
 
 from WMCore.WMSpec.WMStep import WMStepHelper
@@ -115,7 +116,7 @@ class CoreHelper(WMStepHelper):
         """
         return self.data.build.directories
 
-class Template:
+class Template(object):
     """
     _Template_
 

--- a/src/python/WMCore/WMSpec/Steps/Templates/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Templates/CMSSW.py
@@ -8,6 +8,8 @@ Template for a CMSSW Step
 
 import pickle
 
+from future.utils import viewitems
+
 from WMCore.WMSpec.ConfigSectionTree import nodeName
 from WMCore.WMSpec.Steps.Template import CoreHelper, Template
 
@@ -90,7 +92,7 @@ class CMSSWStepHelper(CoreHelper):
             modules.section_(moduleName)
         module = getattr(modules, moduleName)
 
-        for key, value in details.items():
+        for key, value in viewitems(details):
             setattr(module, key, value)
 
         return
@@ -103,7 +105,7 @@ class CMSSWStepHelper(CoreHelper):
 
         """
         if hasattr(self.data.output, "modules"):
-            return self.data.output.modules.dictionary_().keys()
+            return list(self.data.output.modules.dictionary_())
 
         return []
 
@@ -151,7 +153,7 @@ class CMSSWStepHelper(CoreHelper):
         # at pickledarguments anyways
         try:
             self.data.application.configuration.section_('arguments')
-            [setattr(self.data.application.configuration.arguments, k, v) for k, v in args.items()]
+            [setattr(self.data.application.configuration.arguments, k, v) for k, v in viewitems(args)]
         except Exception:
             pass
         self.data.application.configuration.pickledarguments = pickle.dumps(args)
@@ -174,7 +176,7 @@ class CMSSWStepHelper(CoreHelper):
         softwareEnvironment - setup command to bootstrap scram,defaults to None
         """
         self.data.application.setup.cmsswVersion = cmsswVersion
-        for k, v in options.items():
+        for k, v in viewitems(options):
             setattr(self.data.application.setup, k, v)
         return
 
@@ -334,7 +336,7 @@ class CMSSWStepHelper(CoreHelper):
         # self.data.pileup.comics.dataset = "/some/cosmics/dataset"
         # self.data.pileup.minbias.dataset = "/some/minbias/dataset"
         self.data.section_("pileup")
-        for pileupType, dataset in pileupConfig.items():
+        for pileupType, dataset in viewitems(pileupConfig):
             self.data.pileup.section_(pileupType)
             setattr(getattr(self.data.pileup, pileupType), "dataset", dataset)
         setattr(self.data, "dbsUrl", dbsUrl)

--- a/src/python/WMCore/WMSpec/Steps/Templates/LogCollect.py
+++ b/src/python/WMCore/WMSpec/Steps/Templates/LogCollect.py
@@ -8,7 +8,7 @@ Mostly borrowed from StageOut since they share a similar function
 
 """
 
-
+from future.utils import viewitems
 
 
 from WMCore.WMSpec.Steps.Template import Template
@@ -51,7 +51,7 @@ class LogCollectStepHelper(CoreHelper):
         softwareEnvironment - setup command to bootstrap scram,defaults to None
         """
         self.data.application.setup.cmsswVersion = cmsswVersion
-        for k, v in options.items():
+        for k, v in viewitems(options):
             setattr(self.data.application.setup, k, v)
         return
 

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/LogArch_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/LogArch_t.py
@@ -5,6 +5,14 @@ Created on Jun 18, 2009
 """
 from __future__ import print_function
 
+try:
+    # https://pylint.pycqa.org/en/latest/technical_reference/features.html
+    # W1626: the `reload` built-in function is missing in python3
+    # we can use imp.reload (deprecated) or importlib.reload
+    from importlib import reload
+except:
+    pass
+
 import copy
 import logging
 import os
@@ -69,7 +77,7 @@ class LogArchiveTest(unittest.TestCase):
         # not sure what happens if you delete from
         # an arrey you're iterating over. doing it in
         # two steps
-        for modname in sys.modules.keys():
+        for modname in sys.modules:
             # need to blow away things in sys.modules, otherwise
             # they are cached and we look at old taskspaces
             if modname.startswith('WMTaskSpace'):
@@ -133,7 +141,7 @@ class LogArchiveTest(unittest.TestCase):
         # not sure what happens if you delete from
         # an arrey you're iterating over. doing it in
         # two steps
-        for modname in sys.modules.keys():
+        for modname in sys.modules:
             # need to blow away things in sys.modules, otherwise
             # they are cached and we look at old taskspaces
             if modname.startswith('WMTaskSpace'):
@@ -238,7 +246,7 @@ class otherLogArchiveTexst(unittest.TestCase):
         # not sure what happens if you delete from
         # an arrey you're iterating over. doing it in
         # two steps
-        for modname in sys.modules.keys():
+        for modname in sys.modules:
             # need to blow away things in sys.modules, otherwise
             # they are cached and we look at old taskspaces
             if modname.startswith('WMTaskSpace'):
@@ -302,7 +310,7 @@ class otherLogArchiveTexst(unittest.TestCase):
         # not sure what happens if you delete from
         # an arrey you're iterating over. doing it in
         # two steps
-        for modname in sys.modules.keys():
+        for modname in sys.modules:
             # need to blow away things in sys.modules, otherwise
             # they are cached and we look at old taskspaces
             if modname.startswith('WMTaskSpace'):

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/StageOut_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/StageOut_t.py
@@ -5,6 +5,15 @@ Created on Jun 18, 2009
 """
 from __future__ import print_function
 
+try:
+    # https://pylint.pycqa.org/en/latest/technical_reference/features.html
+    # W1626: the `reload` built-in function is missing in python3
+    # we can use imp.reload (deprecated) or importlib.reload
+    from importlib import reload
+except:
+    pass
+
+
 import copy
 import logging
 import os
@@ -69,7 +78,7 @@ class StageOutTest(unittest.TestCase):
         # not sure what happens if you delete from
         # an arrey you're iterating over. doing it in
         # two steps
-        for modname in sys.modules.keys():
+        for modname in sys.modules:
             # need to blow away things in sys.modules, otherwise
             # they are cached and we look at old taskspaces
             if modname.startswith('WMTaskSpace'):
@@ -133,7 +142,7 @@ class StageOutTest(unittest.TestCase):
         # not sure what happens if you delete from
         # an arrey you're iterating over. doing it in
         # two steps
-        for modname in sys.modules.keys():
+        for modname in sys.modules:
             # need to blow away things in sys.modules, otherwise
             # they are cached and we look at old taskspaces
             if modname.startswith('WMTaskSpace'):
@@ -239,7 +248,7 @@ class otherStageOutTexst(unittest.TestCase):
         # not sure what happens if you delete from
         # an arrey you're iterating over. doing it in
         # two steps
-        for modname in sys.modules.keys():
+        for modname in sys.modules:
             # need to blow away things in sys.modules, otherwise
             # they are cached and we look at old taskspaces
             if modname.startswith('WMTaskSpace'):
@@ -303,7 +312,7 @@ class otherStageOutTexst(unittest.TestCase):
         # not sure what happens if you delete from
         # an arrey you're iterating over. doing it in
         # two steps
-        for modname in sys.modules.keys():
+        for modname in sys.modules:
             # need to blow away things in sys.modules, otherwise
             # they are cached and we look at old taskspaces
             if modname.startswith('WMTaskSpace'):

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Fetchers_t/PileupFetcher_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Fetchers_t/PileupFetcher_t.py
@@ -6,6 +6,8 @@ The test instantiates a MC worklow and calls the PileupFetcher on its generation
 """
 from __future__ import print_function
 
+from future.utils import viewitems
+
 import os
 import unittest
 from json import JSONDecoder
@@ -84,7 +86,7 @@ class PileupFetcherTest(EmulatedUnitTestCase):
 
         # now query DBS and compare the blocks and files from DBS
         # against those returned by the PileupFetcher
-        for pileupType, datasets in pileupConfig.items():
+        for pileupType, datasets in viewitems(pileupConfig):
             # this is from the pileup configuration produced by PileupFetcher
             blockDict = pileupDict[pileupType]
 
@@ -97,7 +99,7 @@ class PileupFetcherTest(EmulatedUnitTestCase):
                 self.assertItemsEqual(list(blockDict), dbsBlocks)
                 self.assertItemsEqual(list(blockDict), list(rucioBlocksLocation))
                 # now validate the block location between Rucio and PileupFetcher
-                for block, blockLocation in blockDict.iteritems():
+                for block, blockLocation in viewitems(blockDict):
                     self.assertItemsEqual(blockLocation['PhEDExNodeNames'], rucioBlocksLocation[block])
 
                     # finally, validate the files


### PR DESCRIPTION
Fixes #10137 

#### Status
ready

#### Related PRs

* Previous migration PR: #10307 (slice12, issue #10136  )
* Next migration PR: #10313  (slice14, issue #10138 )

#### Description

Run futurize and some manual changes on the first batch of src/python/A/B/C.

Kept back:
- `src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py` has been mostly kepy back, because #9926 and #9934 are the correct places to address how DQMupload uses with urllib

#### Is it backward compatible (if not, which system it affects?)

It should be. (Any possible cause for errors will we reported here)

#### External dependencies / deployment changes

Requires python-future in both py2 and py3 environments.
