### PR TITLE
[py2py3] Migration at level scr/python/A/B/C - slice 15

### DIFF
--- a/src/python/WMCore/MicroService/Unified/Common.py
+++ b/src/python/WMCore/MicroService/Unified/Common.py
@@ -8,6 +8,8 @@ Original code: https://github.com/CMSCompOps/WmAgentScripts/Unified
 # futures
 from __future__ import division, print_function, absolute_import
 
+from future.utils import viewitems
+
 from future import standard_library
 standard_library.install_aliases()
 
@@ -377,13 +379,13 @@ def workflowsInfo(workflows):
     "Return minimum info about workflows in flat format"
     winfo = {}
     for wflow in workflows:
-        for key, val in wflow.iteritems():
+        for key, val in viewitems(wflow):
             datasets = set()
             pileups = set()
             selist = []
             priority = 0
             campaign = ''
-            for kkk, vvv in val.iteritems():
+            for kkk, vvv in viewitems(val):
                 if STEP_PAT.match(kkk) or TASK_PAT.match(kkk):
                     dataset = vvv.get('InputDataset', '')
                     pileup = vvv.get('MCPileup', '')

--- a/src/python/WMCore/MicroService/Unified/Injector.py
+++ b/src/python/WMCore/MicroService/Unified/Injector.py
@@ -8,6 +8,7 @@ Description: UnifiedInjectorManager class provides full functionality of the Uni
 from __future__ import division
 
 # system modules
+from builtins import object
 import time
 
 # Unified modules

--- a/src/python/WMCore/MicroService/Unified/MSCore.py
+++ b/src/python/WMCore/MicroService/Unified/MSCore.py
@@ -6,6 +6,7 @@ Description: MSCore class provides core functionality of the MS.
 # futures
 from __future__ import division, print_function
 
+from builtins import object
 from WMCore.MicroService.Unified.Common import getMSLogger
 from WMCore.Services.ReqMgr.ReqMgr import ReqMgr
 from WMCore.Services.ReqMgrAux.ReqMgrAux import ReqMgrAux

--- a/src/python/WMCore/MicroService/Unified/MSManager.py
+++ b/src/python/WMCore/MicroService/Unified/MSManager.py
@@ -25,6 +25,7 @@ used in service config.py as following
 from __future__ import division, print_function
 
 # system modules
+from builtins import object
 from time import sleep
 from datetime import datetime
 from collections import deque

--- a/src/python/WMCore/MicroService/Unified/MSOutput.py
+++ b/src/python/WMCore/MicroService/Unified/MSOutput.py
@@ -7,6 +7,7 @@ the Output data placement in WMCore MicroServices.
 
 # futures
 from __future__ import division, print_function
+from future.utils import viewitems, viewvalues
 
 # system modules
 from http.client import HTTPException
@@ -103,7 +104,7 @@ class MSOutput(MSCore):
         self.requestNamesCached = reqCache
 
         self.tapeStatus = dict()
-        for endpoint, quota in self.msConfig['tapePledges'].viewitems():
+        for endpoint, quota in viewitems(self.msConfig['tapePledges']):
             self.tapeStatus[endpoint] = dict(quota=quota, usage=0, remaining=0)
 
         msOutIndex = IndexModel('RequestName', unique=True)
@@ -535,7 +536,7 @@ class MSOutput(MSCore):
         # TODO:
         #    To generate the object from within the Function scope see above.
         counter = 0
-        for _, request in requestRecords.viewitems():
+        for request in viewvalues(requestRecords):
             if request['RequestName'] in self.requestNamesCached:
                 # if it's cached, then it's already in MongoDB, no need to redo this thing!
                 continue
@@ -591,7 +592,7 @@ class MSOutput(MSCore):
         A function used to update one or few particular fields in a document
         :**kwargs: The keys/value pairs to be updated (will be tested against MSOutputTemplate)
         """
-        for key, value in kwargs.items():
+        for key, value in viewitems(kwargs):
             try:
                 msOutDoc.setKey(key, value)
                 msOutDoc.updateTime()

--- a/src/python/WMCore/MicroService/Unified/MSOutputStreamer.py
+++ b/src/python/WMCore/MicroService/Unified/MSOutputStreamer.py
@@ -8,6 +8,7 @@ placement service in WMCore MicroServices.
 # futures
 from __future__ import division, print_function
 
+from builtins import object
 import json
 # from itertools import islice
 # from collections import deque

--- a/src/python/WMCore/MicroService/Unified/MSRuleCleaner.py
+++ b/src/python/WMCore/MicroService/Unified/MSRuleCleaner.py
@@ -14,6 +14,8 @@ workflows remain.
 
 # futures
 from __future__ import division, print_function
+from future.utils import viewvalues
+
 import json
 import re
 import time
@@ -248,7 +250,7 @@ class MSRuleCleaner(MSCore):
         totalNumRequests = 0
 
         # Call the workflow dispatcher:
-        for _, req in reqRecords.items():
+        for req in viewvalues(reqRecords):
             wflow = MSRuleCleanerWflow(req)
             self._dispatchWflow(wflow)
             msg = "\n----------------------------------------------------------"
@@ -325,7 +327,7 @@ class MSRuleCleaner(MSCore):
                 except MSRuleCleanerResolveParentError as ex:
                     msg = "%s: Parentage Resolve Error: %s. "
                     msg += "Will retry again in the next cycle."
-                    self.logger.error(msg, pline.name, ex.message())
+                    self.logger.error(msg, pline.name, str(ex))
                     continue
                 except Exception as ex:
                     msg = "%s: General error from pipeline. Workflow: %s. Error:  \n%s. "
@@ -350,11 +352,11 @@ class MSRuleCleaner(MSCore):
         except MSRuleCleanerArchivalSkip as ex:
             msg = "%s: Proper conditions not met: %s. "
             msg += "Skipping archival in the current cycle."
-            self.logger.info(msg, wflow['PlineMarkers'][-1], ex.message())
+            self.logger.info(msg, wflow['PlineMarkers'][-1], str(ex))
         except MSRuleCleanerArchivalError as ex:
             msg = "%s: Archival Error: %s. "
             msg += "Will retry again in the next cycle."
-            self.logger.error(msg, wflow['PlineMarkers'][-1], ex.message())
+            self.logger.error(msg, wflow['PlineMarkers'][-1], str(ex))
         except Exception as ex:
             msg = "%s General error from pipeline. Workflow: %s. Error: \n%s. "
             msg += "\nWill retry again in the next cycle."
@@ -405,7 +407,7 @@ class MSRuleCleaner(MSCore):
         # Build a list of bool flags based on the mask of PlineMarkers
         cleanFlagsList = [wflow['CleanupStatus'][key]
                           for key in wflow['PlineMarkers']
-                          if key in wflow['CleanupStatus'].keys()]
+                          if key in wflow['CleanupStatus']]
 
         # If no one have worked on the workflow set the clean status to false
         if not wflow['PlineMarkers']:

--- a/src/python/WMCore/MicroService/Unified/MSTransferor.py
+++ b/src/python/WMCore/MicroService/Unified/MSTransferor.py
@@ -10,6 +10,7 @@ tasks might be extended to multi-threading in the future.
 """
 # futures
 from __future__ import division, print_function
+from future.utils import viewitems, listvalues
 from future import standard_library
 standard_library.install_aliases()
 
@@ -259,7 +260,7 @@ class MSTransferor(MSCore):
         # we need to first put these requests in order of priority, as done for GQ...
         orderedRequests = []
         for requests in reqData:
-            orderedRequests = requests.values()
+            orderedRequests = listvalues(requests)
         orderedRequests.sort(key=itemgetter('RequestPriority'), reverse=True)
 
         return orderedRequests
@@ -325,7 +326,7 @@ class MSTransferor(MSCore):
             self.logger.info("Request %s has %d initial blocks from %s",
                              wflow.getName(), len(inputBlocks), methodName)
 
-            for block, blockDict in inputBlocks.items():
+            for block, blockDict in viewitems(inputBlocks):
                 blockLocation = self._diskPNNs(blockDict['locations'])
                 if primaryAAA and blockLocation:
                     msg = "Primary/parent block %s already in place (via AAA): %s" % (block, blockLocation)
@@ -365,7 +366,7 @@ class MSTransferor(MSCore):
             self.logger.info("Request %s has %d initial blocks from %s",
                              wflow.getName(), len(inputBlocks), methodName)
 
-            for block, blockDict in inputBlocks.items():
+            for block, blockDict in viewitems(inputBlocks):
                 blockLocation = self._diskPNNs(blockDict['locations'])
                 commonLocation = wflowPnns & set(blockLocation)
                 if not commonLocation:
@@ -376,7 +377,7 @@ class MSTransferor(MSCore):
         maxSize = 0
         finalPNN = set()
         self.logger.info("Primary/parent data volume currently available:")
-        for pnn, size in volumeByPNN.items():
+        for pnn, size in viewitems(volumeByPNN):
             self.logger.info("  PNN: %s\t\tData volume: %s GB", pnn, gigaBytes(size))
             if size > maxSize:
                 maxSize = size
@@ -416,7 +417,7 @@ class MSTransferor(MSCore):
 
         if secondaryAAA:
             # what matters is to have pileup dataset(s) available in ANY disk storage
-            for dset, dsetDict in pileupInput.items():
+            for dset, dsetDict in viewitems(pileupInput):
                 datasetLocation = self._diskPNNs(dsetDict['locations'])
                 msg = "it has secondary: %s, total size: %s GB, disk locations: %s"
                 self.logger.info(msg, dset, gigaBytes(dsetDict['dsetSize']), datasetLocation)
@@ -428,7 +429,7 @@ class MSTransferor(MSCore):
                     self.logger.info("secondary dataset %s not available even through AAA", dset)
         else:
             if len(pileupInput) == 1:
-                for dset, dsetDict in pileupInput.items():
+                for dset, dsetDict in viewitems(pileupInput):
                     datasetLocation = self._diskPNNs(dsetDict['locations'])
                     msg = "it has secondary: %s, total size: %s GB, current disk locations: %s"
                     self.logger.info(msg, dset, gigaBytes(dsetDict['dsetSize']), datasetLocation)
@@ -446,7 +447,7 @@ class MSTransferor(MSCore):
                 # Note: avoid transferring the biggest one
                 largestSize = 0
                 largestDset = ""
-                for dset, dsetDict in pileupInput.items():
+                for dset, dsetDict in viewitems(pileupInput):
                     if dsetDict['dsetSize'] > largestSize:
                         largestSize = dsetDict['dsetSize']
                         largestDset = dset
@@ -463,7 +464,7 @@ class MSTransferor(MSCore):
                 else:
                     self.logger.info("Largest secondary dataset %s not available in a common location. This is BAD!")
                 # now iterate normally through the pileup datasets
-                for dset, dsetDict in pileupInput.items():
+                for dset, dsetDict in viewitems(pileupInput):
                     datasetLocation = self._diskPNNs(dsetDict['locations'])
                     msg = "it has secondary: %s, total size: %s GB, current disk locations: %s"
                     self.logger.info(msg, dset, gigaBytes(dsetDict['dsetSize']), datasetLocation)

--- a/src/python/WMCore/MicroService/Unified/RSEQuotas.py
+++ b/src/python/WMCore/MicroService/Unified/RSEQuotas.py
@@ -4,7 +4,9 @@ required for automatic data placement.
 It uses Rucio for checking quota available and data usage
 """
 from __future__ import division, print_function
+from builtins import str as newstr, bytes, object
 from future.utils import viewitems
+
 from WMCore.MicroService.Unified.Common import getMSLogger, gigaBytes, teraBytes
 
 
@@ -130,7 +132,7 @@ class RSEQuotas(object):
         self.availableRSEs.clear()
         self.outOfSpaceNodes.clear()
         # given a configurable sub-fraction of our quota, recalculate how much storage is left
-        for rse, info in self.nodeUsage.items():
+        for rse, info in viewitems(self.nodeUsage):
             quotaAvail = info['quota'] * self.quotaFraction
             info['quota_avail'] = min(quotaAvail, info['bytes_remaining'])
             if info['quota_avail'] < self.minimumSpace:
@@ -164,7 +166,7 @@ class RSEQuotas(object):
         :param dataSize: integer with the amount of bytes allocated
         :return: nothing. updates nodeUsage cache
         """
-        if isinstance(node, basestring):
+        if isinstance(node, (newstr, bytes)):
             node = [node]
         if not isinstance(dataSize, int):
             self.logger.error("dataSize needs to be integer, not '%s'!", type(dataSize))

--- a/src/python/WMCore/MicroService/Unified/SiteInfo.py
+++ b/src/python/WMCore/MicroService/Unified/SiteInfo.py
@@ -7,6 +7,7 @@ Original code: https://github.com/CMSCompOps/WmAgentScripts/Unified
 
 # futures
 from __future__ import division
+from future.utils import viewitems
 
 # syste modules
 import json
@@ -145,11 +146,11 @@ def agentsSites(url):
         if team != 'production':
             continue
         agents.setdefault(team, []).append(r)
-    for team, agents in agents.items():
+    for team, agents in viewitems(agents):
         for agent in agents:
             if agent['status'] != 'ok':
                 continue
-            for site, sinfo in agent['WMBS_INFO']['thresholds'].iteritems():
+            for site, sinfo in viewitems(agent['WMBS_INFO']['thresholds']):
                 if sinfo['state'] in ['Normal']:
                     sites_ready_in_agent.add(site)
     return sites_ready_in_agent
@@ -283,7 +284,7 @@ class SiteInfo(with_metaclass(Singleton, object)):
                 sites_space_override=sites_space_override)
 
         ## transform no disks in veto transfer
-        for dse, free in self.disk.items():
+        for dse, free in viewitems(self.disk):
             if free <= 0:
                 if not dse in self.sites_veto_transfer:
                     self.sites_veto_transfer.append(dse)
@@ -297,7 +298,7 @@ class SiteInfo(with_metaclass(Singleton, object)):
             self.logger.debug("no memory information from glidein mon")
             return None
         allowed = set()
-        for site, slots in self.sites_memory.items():
+        for site, slots in viewitems(self.sites_memory):
             if any([slot['MaxMemMB'] >= maxMem and \
                     slot['MaxCpus'] >= maxCore for slot in slots]):
                 allowed.add(site)
@@ -326,7 +327,7 @@ class SiteInfo(with_metaclass(Singleton, object)):
     def fetch_glidein_info(self):
         "Fetch Glidein information"
         self.sites_memory = self.siteCache.get('gwmsmon_totals', {})
-        for site in self.sites_memory.keys():
+        for site in self.sites_memory:
             if not site in self.sites_ready:
                 self.sites_memory.pop(site)
         
@@ -407,7 +408,7 @@ class SiteInfo(with_metaclass(Singleton, object)):
             }
 
         _info_by_site = {}
-        for name, column in columns.items():
+        for name, column in viewitems(columns):
             all_data = []
             try:
                 ssb_data = self.siteCache.get('ssb_%d' % column, [])
@@ -432,8 +433,8 @@ class SiteInfo(with_metaclass(Singleton, object)):
             self.logger.debug('document %s', json.dumps(_info_by_site, indent=2))
 
         if talk:
-            self.logger.debug('disk keys: %s', self.disk.keys())
-        for site, info in _info_by_site.items():
+            self.logger.debug('disk keys: %s', list(self.disk))
+        for site, info in viewitems(_info_by_site):
             if talk:
                 self.logger.debug("Site: %s", site)
             ssite = self.ce2SE(site)

--- a/src/python/WMCore/MicroService/Unified/Stageout.py
+++ b/src/python/WMCore/MicroService/Unified/Stageout.py
@@ -8,6 +8,7 @@ Description: UnifiedStageoutManager class provides full functionality of the Uni
 from __future__ import division
 
 
+from builtins import object
 class UnifiedStageoutManager(object):
     """
     Initialize UnifiedStageoutManager class

--- a/src/python/WMCore/MicroService/Unified/TaskManager.py
+++ b/src/python/WMCore/MicroService/Unified/TaskManager.py
@@ -5,6 +5,9 @@ Author: Valentin Kuznetsov <vkuznet [AT] gmail [DOT] com>
 """
 # futures
 from __future__ import division
+
+from builtins import range, object
+
 from future import standard_library
 standard_library.install_aliases()
 
@@ -17,7 +20,7 @@ from queue import Queue
 
 # WMCore modules
 from WMCore.MicroService.Unified.Common import getMSLogger
-
+from Utils.Utilities import encodeUnicodeToBytes
 
 def genkey(query):
     """
@@ -28,9 +31,11 @@ def genkey(query):
         record = dict(query)
         query = json.JSONEncoder(sort_keys=True).encode(record)
     keyhash = hashlib.md5()
+    query = encodeUnicodeToBytes(query)
     try:
         keyhash.update(query)
     except TypeError: # python3
+        # this may be avoided if we use encodeUnicodeToBytes(query) above
         keyhash.update(query.encode('ascii'))
     return keyhash.hexdigest()
 
@@ -83,7 +88,7 @@ class UidSet(object):
         "Add given uid or increment uid occurence in a set"
         if  not uid:
             return
-        if  uid in self.set.keys():
+        if  uid in self.set:
             self.set[uid] += 1
         else:
             self.set[uid] = 1

--- a/test/python/WMCore_t/MicroService_t/Unified_t/MSMonitor_t.py
+++ b/test/python/WMCore_t/MicroService_t/Unified_t/MSMonitor_t.py
@@ -5,6 +5,8 @@ Author: Valentin Kuznetsov <vkuznet [AT] gmail [DOT] com>
 """
 from __future__ import division, print_function
 
+from future.utils import viewitems
+
 import time
 # system modules
 import unittest
@@ -48,7 +50,7 @@ class MSMonitorTest(EmulatedUnitTestCase):
         self.assertTrue(time.time() > transfersDocs[0]['lastUpdate'], 1)
 
         self.assertNotEqual(campaigns, [])
-        for cname, cdict in campaigns.items():
+        for cname, cdict in viewitems(campaigns):
             self.assertEqual(cname, cdict['CampaignName'])
             self.assertEqual(isinstance(cdict, dict), True)
             self.assertNotEqual(cdict.get('CampaignName', {}), {})

--- a/test/python/WMCore_t/MicroService_t/Unified_t/TaskManager_t.py
+++ b/test/python/WMCore_t/MicroService_t/Unified_t/TaskManager_t.py
@@ -5,6 +5,9 @@ Author: Valentin Kuznetsov <vkuznet [AT] gmail [DOT] com>
 """
 from __future__ import division, print_function
 
+from builtins import str as newstr
+from future.utils import listvalues
+
 import time
 import unittest
 
@@ -44,22 +47,26 @@ class TaskManagerTest(unittest.TestCase):
         args1 = (1, results)
         args2 = (2, results)
         args3 = (3, results)
+        args4 = (4, results)
         pid1 = genkey(str(args1) + str(kwds))
         pid2 = genkey(str(args2) + str(kwds))
         pid3 = genkey(str(args3) + str(kwds))
+        pid4 = genkey(newstr(args4) + newstr(kwds))
 
         jobs.append(mgr.spawn(myFunc, *args1))
         jobs.append(mgr.spawn(myFunc, *args2))
         jobs.append(mgr.spawn(myFunc, *args3))
+        jobs.append(mgr.spawn(myFunc, *args4))
 
         self.assertEqual(True, mgr.is_alive(pid1))
         self.assertEqual(True, mgr.is_alive(pid2))
         self.assertEqual(True, mgr.is_alive(pid3))
+        self.assertEqual(True, mgr.is_alive(pid4))
 
         mgr.joinall(jobs)
 
-        self.assertEqual(sorted(results.keys()), [1, 2, 3])
-        self.assertEqual(results.values(), ['ok_1', 'ok_2', 'ok_3'])
+        self.assertEqual(sorted(results.keys()), [1, 2, 3, 4])
+        self.assertEqual(listvalues(results), ['ok_1', 'ok_2', 'ok_3', 'ok_4'])
 
         self.assertEqual(False, mgr.is_alive(pid1))
         self.assertEqual(False, mgr.is_alive(pid2))


### PR DESCRIPTION
Fixes #10139 

#### Status
Ready

#### Related PRs

* Previous migration PR: #10313  (slice14, issue #10138 )
* Next migration PR: #10321 (slice16, issue #10140  )

#### Description

Run futurize and some manual changes on the first batch of src/python/A/B/C.

Notable changes:
* `src/python/WMCore/MicroService/Unified/TaskManager.py`: `str()` is used both for formatting error/exception messages and for converting to a type that can be used as argument for `hashlib.md5.update()`. This required encoding unicode strings to bytes and can make a `try-except` obsolete. Cleaning tracked in #10322 
* `src/python/WMCore/MicroService/Unified/RequestInfo.py`: used "native string" approach and did not imoprt str from builtins. This is unlikely to be problematic, but it may be useful to point out for future-me

`pylint --py3k`: the report warn us about the use of `round`, but it is unlikely that it is going to create problems for us. I consider the two warnings as false positives and I am happy with that report! :)

#### Is it backward compatible (if not, which system it affects?)

It should be. (Any possible cause for errors will we reported here)

#### External dependencies / deployment changes

Requires python-future in both py2 and py3 environments.