### PR TITLE
Add check for None dataContainer.

### DIFF
--- a/src/python/WMCore/MicroService/Unified/MSRuleCleaner.py
+++ b/src/python/WMCore/MicroService/Unified/MSRuleCleaner.py
@@ -622,6 +622,8 @@ class MSRuleCleaner(MSCore):
         for dataType in mapRuleType[rucioAcct]:
             dataList = wflow[dataType] if isinstance(wflow[dataType], list) else [wflow[dataType]]
             for dataCont in dataList:
+                if dataCont is None:
+                    continue
                 self.logger.debug("getRucioRules: dataCont: %s", pformat(dataCont))
                 if checkGlobalLocks and dataCont in self.globalLocks:
                     msg = "Found dataset: %s in GlobalLocks. NOT considering it for filling the "


### PR DESCRIPTION
Fixes #10318 

#### Status
 ready

#### Description
Since we want to keep the data type for `InputDataset` as a string (because we want to express the fact that this can never be more than a single dataset per workflow), we may end up with a list of datasets containing a `None` value for its only element in the pipelines related to cleaning rules from `MSTralnsferor`. 

While this may result only in an additional empty call to Rucio while cleaning container level rules, when it comes to block level rules it actually calls `rucio.getBlocksInContainer()` with `None` value and this breaks the whole chain - the workflow is never marked clean from block level rules (even though it may have none such rules) and it is blocked and never goes for archiving.   

#### Is it backward compatible (if not, which system it affects?)
YES 

#### Related PRs
No

#### External dependencies / deployment changes
No