### PR TITLE
Fix values for the "submitted" key in JobSummary

### DIFF
--- a/src/python/WMCore/Services/WMStats/DataStruct/RequestInfoCollection.py
+++ b/src/python/WMCore/Services/WMStats/DataStruct/RequestInfoCollection.py
@@ -1,33 +1,34 @@
-
 from builtins import object
-from future.utils import viewitems, viewvalues, listvalues
+from future.utils import viewitems, viewvalues
+
 
 class JobSummary(object):
     """
     job summary data structure from job format in couchdb
     """
-    def __init__(self , jobStatus = None):
+
+    def __init__(self, jobStatus=None):
         self.jobStatus = {
-                 "success": 0,
-                 "canceled": 0,
-                 "transition": 0,
-                 "queued": {"first": 0, "retry": 0},
-                 "submitted": {"first": 0, "retry": 0, "pending": 0, "running": 0},
-                 "failure": {"create": 0, "submit": 0, "exception": 0},
-                 "cooloff": {"create": 0, "submit": 0, "job": 0},
-                 "paused": {"create": 0, "submit": 0, "job": 0},
-         }
+            "success": 0,
+            "canceled": 0,
+            "transition": 0,
+            "queued": {"first": 0, "retry": 0},
+            "submitted": {"first": 0, "retry": 0, "pending": 0, "running": 0},
+            "failure": {"create": 0, "submit": 0, "exception": 0},
+            "cooloff": {"create": 0, "submit": 0, "job": 0},
+            "paused": {"create": 0, "submit": 0, "job": 0},
+        }
         if jobStatus != None:
             self.addJobStatusInfo(jobStatus)
 
     def addJobStatusInfo(self, jobStatus):
 
-        #TODO need to validate the structure.
+        # TODO need to validate the structure.
         for key, value in viewitems(self.jobStatus):
             if isinstance(value, int):
                 self.jobStatus[key] += jobStatus.get(key, 0)
             elif isinstance(value, dict):
-                for secondKey, secondValue in viewitems(value):
+                for secondKey in value:
                     if key in jobStatus and secondKey in jobStatus[key]:
                         self.jobStatus[key][secondKey] += jobStatus[key][secondKey]
 
@@ -37,7 +38,7 @@ class JobSummary(object):
     def getTotalJobs(self):
         return (self.getSuccess() +
                 self.jobStatus["canceled"] +
-                self.jobStatus[ "transition"] +
+                self.jobStatus["transition"] +
                 self.getFailure() +
                 self.getCooloff() +
                 self.getPaused() +
@@ -62,20 +63,20 @@ class JobSummary(object):
                 self.jobStatus["submitted"]["retry"])
 
     def getRunning(self):
-        return self.jobStatus["submitted"]["running"];
+        return self.jobStatus["submitted"]["running"]
 
     def getPending(self):
-        return self.jobStatus["submitted"]["pending"];
+        return self.jobStatus["submitted"]["pending"]
 
     def getCooloff(self):
         return (self.jobStatus["cooloff"]["create"] +
                 self.jobStatus["cooloff"]["submit"] +
-                self.jobStatus["cooloff"]["job"]);
+                self.jobStatus["cooloff"]["job"])
 
     def getPaused(self):
         return (self.jobStatus["paused"]["create"] +
                 self.jobStatus["paused"]["submit"] +
-                self.jobStatus["paused"]["job"]);
+                self.jobStatus["paused"]["job"])
 
     def getQueued(self):
         return (self.jobStatus["queued"]["first"] +
@@ -92,26 +93,28 @@ class JobSummary(object):
                 'created': self.getTotalJobs()
                 }
 
+
 class ProgressSummary(object):
 
-    def __init__(self , progressReport = None):
+    def __init__(self, progressReport=None):
         self.progress = {
-                 "totalLumis": 0,
-                 "events": 0,
-                 "size": 0
-         }
+            "totalLumis": 0,
+            "events": 0,
+            "size": 0
+        }
 
         if progressReport != None:
             self.addProgressReport(progressReport)
 
     def addProgressReport(self, progressReport):
 
-        #TODO need to validate the structure.
+        # TODO need to validate the structure.
         for key in self.progress:
             self.progress[key] += progressReport.get(key, 0)
 
     def getReport(self):
         return self.progress
+
 
 class TaskInfo(object):
 
@@ -122,12 +125,11 @@ class TaskInfo(object):
         self.jobSummary = JobSummary(data.get('status', {}))
 
     def addTaskInfo(self, taskInfo):
-
         if not (self.requestName == taskInfo.requestName and
                 self.taskName == taskInfo.taskName):
-            msg =  "%s: %s, %s: %s, %s: %s" % (self.requestName, taskInfo.requestName,
-                                               self.taskName, taskInfo.taskName,
-                                               self.taskType, taskInfo.taskType)
+            msg = "%s: %s, %s: %s, %s: %s" % (self.requestName, taskInfo.requestName,
+                                              self.taskName, taskInfo.taskName,
+                                              self.taskType, taskInfo.taskType)
             raise Exception("task doesn't match %s" % msg)
 
         self.jobSummary.addJobSummary(taskInfo.jobSummary)
@@ -162,9 +164,8 @@ class RequestInfo(object):
         """
         self.setData(data)
 
-
     def setData(self, data):
-        #If RequestName doesn't exist, try legacy format (workflow)
+        # If RequestName doesn't exist, try legacy format (workflow)
         if 'RequestName' in data:
             self.requestName = data['RequestName']
         else:
@@ -192,17 +193,15 @@ class RequestInfo(object):
     def getJobSummary(self):
         return self.jobSummary
 
-    def getJobSummaryByAgent(self, agentUrl = None):
+    def getJobSummaryByAgent(self, agentUrl=None):
         if agentUrl:
             return self.jobSummaryByAgent[agentUrl]
-        else:
-            return self.jobSummaryByAgent
+        return self.jobSummaryByAgent
 
-    def getTasksByAgent(self, agentUrl = None):
+    def getTasksByAgent(self, agentUrl=None):
         if agentUrl:
             return self.tasksByAgent[agentUrl]
-        else:
-            return self.tasksByAgent
+        return self.tasksByAgent
 
     def getTasks(self):
         return self.tasks
@@ -227,10 +226,10 @@ class RequestInfo(object):
         """
         check sampleResult.json for datastructure
         """
-        datasets = {};
+        datasets = {}
 
         if "AgentJobInfo" not in self.data:
-            #ther is no report yet (no agent has reported)
+            # ther is no report yet (no agent has reported)
             return datasets
 
         for agentRequestInfo in viewvalues(self.data["AgentJobInfo"]):
@@ -239,7 +238,7 @@ class RequestInfo(object):
             for task in tasks:
                 for site in tasks[task].get("sites", []):
                     for outputDS in tasks[task]["sites"][site].get("dataset", {}):
-                        #TODO: need update the record instead of replacing.
+                        # TODO: need update the record instead of replacing.
                         datasets.setdefault(outputDS, ProgressSummary())
                         datasets[outputDS].addProgressReport(tasks[task]["sites"][site]["dataset"][outputDS])
 
@@ -248,16 +247,13 @@ class RequestInfo(object):
     def filterRequest(self, conditionFunc):
         return conditionFunc(self.data)
 
-
     def getRequestTransition(self):
         return self.data["request_status"]
 
-    def getRequestStatus(self, timeFlag = False):
-
+    def getRequestStatus(self, timeFlag=False):
         if timeFlag:
             return self.data["request_status"][-1]
-        else:
-            return self.data["request_status"][-1]['status']
+        return self.data["request_status"][-1]['status']
 
     def isWorkflowFinished(self):
         """
@@ -266,13 +262,14 @@ class RequestInfo(object):
             It can't detect complete status.
             If the one of the task doesn't contain any jobs, it will return False
         """
-        if len(self.tasks) == 0:
+        if not self.tasks:
             return False
 
         for taskInfo in viewvalues(self.tasks):
             if not taskInfo.isTaskCompleted():
                 return False
         return True
+
 
 class RequestInfoCollection(object):
 
@@ -299,6 +296,5 @@ class RequestInfoCollection(object):
         for requestInfo in viewvalues(self.collection):
             result[requestInfo.requestName] = {}
             for agentUrl, jobSummary in viewitems(requestInfo.getJobSummaryByAgent()):
-                result[requestInfo.requestName][agentUrl]= jobSummary.getJSONStatus()
+                result[requestInfo.requestName][agentUrl] = jobSummary.getJSONStatus()
         return result
-

--- a/src/python/WMCore/Services/WMStats/DataStruct/RequestInfoCollection.py
+++ b/src/python/WMCore/Services/WMStats/DataStruct/RequestInfoCollection.py
@@ -12,8 +12,7 @@ class JobSummary(object):
                  "canceled": 0,
                  "transition": 0,
                  "queued": {"first": 0, "retry": 0},
-                 "submitted": {"first": 0, "retry": 0},
-                 "submitted": {"pending": 0, "running": 0},
+                 "submitted": {"first": 0, "retry": 0, "pending": 0, "running": 0},
                  "failure": {"create": 0, "submit": 0, "exception": 0},
                  "cooloff": {"create": 0, "submit": 0, "job": 0},
                  "paused": {"create": 0, "submit": 0, "job": 0},
@@ -83,7 +82,7 @@ class JobSummary(object):
                 self.jobStatus["queued"]["retry"])
 
     def getJSONStatus(self):
-        return {'sucess': self.getSuccess(),
+        return {'success': self.getSuccess(),
                 'failure': self.getFailure(),
                 'cooloff': self.getCooloff(),
                 'running': self.getRunning(),
@@ -182,13 +181,13 @@ class RequestInfo(object):
 
                 if 'tasks' in agentRequestInfo:
                     self.tasksByAgent[agentUrl] = {}
-                    for taskName, data in viewitems(agentRequestInfo['tasks']):
+                    for taskName, taskData in viewitems(agentRequestInfo['tasks']):
                         if taskName not in self.tasks:
-                            self.tasks[taskName] = TaskInfo(self.requestName, taskName, data)
+                            self.tasks[taskName] = TaskInfo(self.requestName, taskName, taskData)
                         else:
-                            self.tasks[taskName].addTaskInfo(TaskInfo(self.requestName, taskName, data))
+                            self.tasks[taskName].addTaskInfo(TaskInfo(self.requestName, taskName, taskData))
                         # only one task by one agent - don't need to combine
-                        self.tasksByAgent[agentUrl][taskName] = TaskInfo(self.requestName, taskName, data)
+                        self.tasksByAgent[agentUrl][taskName] = TaskInfo(self.requestName, taskName, taskData)
 
     def getJobSummary(self):
         return self.jobSummary

--- a/test/python/WMCore_t/Services_t/WMStats_t/DataStructs_t/RequestInfoCollection_t.py
+++ b/test/python/WMCore_t/Services_t/WMStats_t/DataStructs_t/RequestInfoCollection_t.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python
+"""
+Unittests for the RequestInfoCollection WMStats module
+"""
+from __future__ import division, print_function
+
+import unittest
+
+from future.utils import viewvalues
+
+from WMCore.Services.WMStats.DataStruct.RequestInfoCollection import (JobSummary, ProgressSummary,
+                                                                      TaskInfo, RequestInfo)
+
+
+class DummyTask(object):
+    """
+    Dummy object carrying some needed attributes for TaskInfo
+    """
+
+    def __init__(self, reqName, taskName, taskType):
+        self.requestName = reqName
+        self.taskName = taskName
+        self.taskType = taskType
+        self.jobSummary = {}
+
+    def setJobSummary(self, jobSum):
+        self.jobSummary = jobSum
+
+
+class MyTestCase(unittest.TestCase):
+
+    def testJobSummary(self):
+        """some very basic unit tests for the JobSummary class"""
+        jobSumKeys = ["success", "canceled", "transition", "queued",
+                      "submitted", "failure", "cooloff", "paused"]
+        jsonStatusKeys = ["success", "failure", "cooloff", "running",
+                          "queued", "pending", "paused", "created"]
+
+        # default object
+        jobSumObj = JobSummary()
+        self.assertItemsEqual(list(jobSumObj.jobStatus), jobSumKeys)
+        self.assertItemsEqual(list(jobSumObj.getJSONStatus()), jsonStatusKeys)
+        self.assertEqual(jobSumObj.getTotalJobs(), 0)
+        self.assertEqual(sum(viewvalues(jobSumObj.getJSONStatus())), 0)
+
+        # update with no content, thus, do nothing!
+        jobSumObj.addJobStatusInfo({})
+        self.assertItemsEqual(list(jobSumObj.jobStatus), jobSumKeys)
+        self.assertItemsEqual(list(jobSumObj.getJSONStatus()), jsonStatusKeys)
+        self.assertEqual(jobSumObj.getTotalJobs(), 0)
+        self.assertEqual(sum(viewvalues(jobSumObj.getJSONStatus())), 0)
+
+        # passing an invalid key/status
+        jobSumObj.addJobStatusInfo({"bad_status_key": 10})
+        self.assertItemsEqual(list(jobSumObj.jobStatus), jobSumKeys)
+        self.assertEqual(jobSumObj.getTotalJobs(), 0)
+
+        # updating a simple integer status
+        jobSumObj.addJobStatusInfo({"success": 10})
+        self.assertItemsEqual(list(jobSumObj.jobStatus), jobSumKeys)
+        self.assertEqual(jobSumObj.getTotalJobs(), 10)
+        self.assertEqual(jobSumObj.getSuccess(), 10)
+        # getJSONStatus considers success jobs as success and as created,
+        # thus double counting
+        self.assertEqual(sum(viewvalues(jobSumObj.getJSONStatus())), 20)
+
+        # updating a dictionary status
+        jobSumObj.addJobStatusInfo({"submitted": {"pending": 2, "running": 4}})
+        self.assertItemsEqual(list(jobSumObj.jobStatus), jobSumKeys)
+        self.assertItemsEqual(list(jobSumObj.getJSONStatus()), jsonStatusKeys)
+        self.assertEqual(jobSumObj.getTotalJobs(), 16)
+        self.assertEqual(jobSumObj.getSuccess(), 10)
+        # Submitted only considers first/retry states
+        self.assertEqual(jobSumObj.getSubmitted(), 0)
+        self.assertEqual(jobSumObj.getPending(), 2)
+        self.assertEqual(jobSumObj.getRunning(), 4)
+        self.assertEqual(sum(viewvalues(jobSumObj.getJSONStatus())), 32)
+
+    def testProgressSummary(self):
+        """some very basic unit tests for the ProgressSummary class"""
+        progSumKeys = ["totalLumis", "events", "size"]
+
+        # default object
+        progSumObj = ProgressSummary()
+        self.assertItemsEqual(list(progSumObj.getReport()), progSumKeys)
+        self.assertEqual(sum(viewvalues(progSumObj.getReport())), 0)
+
+        # update with no content, thus, do nothing!
+        progSumObj.addProgressReport({})
+        self.assertItemsEqual(list(progSumObj.getReport()), progSumKeys)
+        self.assertEqual(sum(viewvalues(progSumObj.getReport())), 0)
+
+        # passing an invalid key/status
+        progSumObj.addProgressReport({"bad_status_key": 10})
+        self.assertItemsEqual(list(progSumObj.getReport()), progSumKeys)
+        self.assertEqual(sum(viewvalues(progSumObj.getReport())), 0)
+
+        # now passing some valid information
+        progSumObj.addProgressReport({"totalLumis": 10, "events": 1000})
+        self.assertItemsEqual(list(progSumObj.getReport()), progSumKeys)
+        self.assertEqual(sum(viewvalues(progSumObj.getReport())), 1010)
+
+    def testTaskInfo(self):
+        """some very basic unit tests for the TaskInfo class"""
+        reqName = "test_request_name"
+        taskName = "test_task_name"
+
+        # default object
+        taskSumObj = TaskInfo(reqName, taskName, {})
+        self.assertEqual(taskSumObj.getRequestName(), reqName)
+        self.assertEqual(taskSumObj.getTaskName(), taskName)
+        self.assertEqual(taskSumObj.getTaskType(), "N/A")
+        self.assertIsInstance(taskSumObj.getJobSummary(), JobSummary)
+        self.assertFalse(taskSumObj.isTaskCompleted())
+
+        # try to add an invalid task info object
+        with self.assertRaises(Exception):
+            taskSumObj.addTaskInfo("blah")
+
+        # and again, with valid attributes but invalid values
+        with self.assertRaises(Exception):
+            dummyTask = DummyTask("req", "task", "type")
+            taskSumObj.addTaskInfo(dummyTask)
+
+        # now with all valid, but invalid JobSummary object
+        dummyTask = DummyTask(reqName, taskName, "dummy_task_type")
+        with self.assertRaises(AttributeError):
+            taskSumObj.addTaskInfo(dummyTask)
+
+        # now update it with some valid content
+        dummyTask.setJobSummary(JobSummary())
+        taskSumObj.addTaskInfo(dummyTask)
+        self.assertFalse(taskSumObj.isTaskCompleted())
+
+        # now complete this task
+        # now update it with some valid content
+        dummyTask.setJobSummary(JobSummary({"success": 10}))
+        taskSumObj.addTaskInfo(dummyTask)
+        self.assertTrue(taskSumObj.isTaskCompleted())
+
+    def testRequestInfo(self):
+        """some very basic unit tests for the RequestInfo class"""
+        reqName = "test_request_name"
+        taskName = "test_task_name"
+        agentName = "test_agent_name"
+
+        # default object
+        defaultDict = {"RequestName": reqName,
+                       "AgentJobInfo": {}}
+        reqInfoObj = RequestInfo(defaultDict)
+        self.assertItemsEqual(reqInfoObj.getTasks(), {})
+        self.assertEqual(reqInfoObj.getTotalTopLevelJobs(), "N/A")
+        self.assertEqual(reqInfoObj.getTotalInputLumis(), "N/A")
+        self.assertEqual(reqInfoObj.getTotalInputEvents(), "N/A")
+        self.assertEqual(reqInfoObj.getTotalTopLevelJobsInWMBS(), 0)
+        self.assertItemsEqual(reqInfoObj.getJobSummaryByAgent(), {})
+        self.assertItemsEqual(reqInfoObj.getTasksByAgent(), {})
+        self.assertFalse(reqInfoObj.isWorkflowFinished())
+
+        # with some useful content now
+        defaultDict = {"RequestName": reqName,
+                       "total_jobs": 10,
+                       "input_lumis": 100,
+                       "input_events": 1000,
+                       "AgentJobInfo": {agentName: {"status": {"success": 10, "inWMBS": 10},
+                                                    "tasks": {taskName: {"status": {"success": 10}}}}}}
+        reqInfoObj = RequestInfo(defaultDict)
+        self.assertItemsEqual(list(reqInfoObj.getTasks()), [taskName])
+        self.assertEqual(reqInfoObj.getTotalTopLevelJobs(), 10)
+        self.assertEqual(reqInfoObj.getTotalInputLumis(), 100)
+        self.assertEqual(reqInfoObj.getTotalInputEvents(), 1000)
+        self.assertEqual(reqInfoObj.getTotalTopLevelJobsInWMBS(), 10)
+        self.assertIsInstance(reqInfoObj.getJobSummaryByAgent(), dict)
+        self.assertTrue(agentName in reqInfoObj.getJobSummaryByAgent())
+        self.assertIsInstance(reqInfoObj.getJobSummaryByAgent(agentName), JobSummary)
+        self.assertIsInstance(reqInfoObj.getTasksByAgent(), dict)
+        self.assertTrue(agentName in reqInfoObj.getTasksByAgent())
+        self.assertIsInstance(reqInfoObj.getTasksByAgent(agentName), dict)
+        self.assertTrue(taskName in reqInfoObj.getTasksByAgent(agentName))
+        self.assertTrue(reqInfoObj.isWorkflowFinished())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #10324 

#### Status
ready

#### Description
This PR was meant to fix the duplicate `submitted` dictionary key, but it also fixes two other issues.
* `success` key misspelled (even though I believe this one is harmless)
* argument redefinition in nested for loop (oh well...)

Second commit brings in a bunch of automatic code refactoring, pylint fixes and some basic unit tests. 

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
