### PR TITLE
Add check and different path for wmagent component.

### DIFF
--- a/bin/patchComponent.sh
+++ b/bin/patchComponent.sh
@@ -5,8 +5,8 @@ usage()
     echo -ne "\nA simple script to facilitate component patching\n"
     echo -ne "and to decrease the development && testing turnaround time.\n"
     echo -ne "Usage: \n"
-    echo -ne "\t git diff --no-color | ./patchComponent.sh (reqmon | reqmgr2 | reqmgr2ms...)\n or:\n"
-    echo -ne "\t curl https://patch-diff.githubusercontent.com/raw/dmwm/deployment/pull/740.patch  | ./patchComponent.sh (reqmon | reqmgr2 | reqmgr2ms...)\n"
+    echo -ne "\t git diff --no-color | sudo ./patchComponent.sh (wmagent | reqmon | reqmgr2 | reqmgr2ms...)\n or:\n"
+    echo -ne "\t curl https://patch-diff.githubusercontent.com/raw/dmwm/deployment/pull/740.patch  | sudo ./patchComponent.sh (wmagent | reqmon | reqmgr2 | reqmgr2ms...)\n"
     exit 1
 }
 
@@ -16,8 +16,13 @@ component=$1
 
 echo "Patching component: $component"
 
-# TODO: To fix path differences for wmagents and central services
-rootDir=/data/srv/current/apps/$component/lib/python2.7/site-packages/
+if [[ $component == "wmagent" ]]
+then
+    rootDir=/data/srv/$component/current/apps.sw/$component/lib/python2.7/site-packages
+else
+    rootDir=/data/srv/current/apps.sw/$component/lib/python2.7/site-packages/
+fi
+
 stripLevel=3
 
 patch --verbose -b --version-control=numbered -d $rootDir -p$stripLevel


### PR DESCRIPTION
Fixes #10326 

#### Status
ready

#### Description
Adds a check if the current component to be patched is wmagent and if so applies the relevant changes to the `rootPath`

#### Is it backward compatible (if not, which system it affects?)
YES 

#### Related PRs
NO

#### External dependencies / deployment changes
NO
