### PR TITLE
[py2py3] Migration at level scr/python/A/B/C - slice 17

### DIFF
--- a/src/python/WMComponent/JobCreator/CreateWorkArea.py
+++ b/src/python/WMComponent/JobCreator/CreateWorkArea.py
@@ -10,6 +10,9 @@ _CreateWorkArea_
 Class(es) that create the work area for each jobGroup
 Used in JobCreator
 """
+from __future__ import division
+
+from builtins import object
 
 import logging
 import os
@@ -111,7 +114,7 @@ class CreateWorkAreaException(WMException):
     pass
 
 
-class CreateWorkArea:
+class CreateWorkArea(object):
     """
     Basic class for doing the JobMaker dirty work
 
@@ -284,7 +287,7 @@ class CreateWorkArea:
         Create a sub-directory to allow storage of large jobs
         """
 
-        value = jobCounter / 1000
+        value = int(jobCounter // 1000)
         jobCollDir = '%s/JobCollection_%i_%i' % (taskDir, self.jobGroup.id, value)
         # Set this to a global variable
         self.collectionDir = jobCollDir

--- a/src/python/WMCore/Configuration.py
+++ b/src/python/WMCore/Configuration.py
@@ -14,6 +14,8 @@ import os
 import sys
 import traceback
 
+from Utils.Utilities import encodeUnicodeToBytes
+
 PY3 = sys.version_info[0] == 3
 
 # PY3 compatibility (can be removed once python2 gets dropped)
@@ -138,7 +140,9 @@ class ConfigSection(object):
             return
 
         if isinstance(value, unicode):
-            value = str(value)
+            # We should not use "ignore" in this case
+            # if this failed before, it is better to have it fail also now.
+            value = encodeUnicodeToBytes(value)
 
         # for backward compatibility use getattr and sure to work if the
         # _internal_skipChecks flag is not set

--- a/src/python/WMCore/Storage/StageOutMgr.py
+++ b/src/python/WMCore/Storage/StageOutMgr.py
@@ -8,6 +8,8 @@ Based of RuntimeStageOut.StageOutManager, that should probably eventually
 use this class as a basic API
 """
 from __future__ import print_function
+from builtins import object
+from future.utils import viewitems
 
 import logging
 # If we don't import them, they cannot be ever used (bad PyCharm!)
@@ -25,7 +27,7 @@ from WMCore.WMException import WMException
 # If we don't import them, they cannot be ever used (bad PyCharm!)
 
 
-class StageOutMgr:
+class StageOutMgr(object):
     """
     _StageOutMgr_
 
@@ -44,7 +46,7 @@ class StageOutMgr:
             logging.info("StageOutMgr::__init__(): Override: %s", overrideParams)
             checkParams = ["command", "option", "phedex-node", "lfn-prefix"]
             for param in checkParams:
-                if param in self.overrideConf.keys():
+                if param in self.overrideConf:
                     self.override = True
             if not self.override:
                 logging.info("=======StageOut Override: These are not the parameters you are looking for")
@@ -173,7 +175,7 @@ class StageOutMgr:
                 overrideParams['option'] = ""
 
         msg = "=======StageOut Override Initialised:================\n"
-        for key, val in overrideParams.items():
+        for key, val in viewitems(overrideParams):
             msg += " %s : %s\n" % (key, val)
         msg += "=====================================================\n"
         logging.info(msg)
@@ -188,7 +190,7 @@ class StageOutMgr:
         Use call to invoke transfers
 
         """
-        lastException = ""
+        lastException = Exception("empty exception")
 
         logging.info("==>Working on file: %s", fileToStage['LFN'])
         lfn = fileToStage['LFN']
@@ -339,7 +341,7 @@ class StageOutMgr:
 
 
         """
-        for lfn, fileInfo in self.completedFiles.items():
+        for lfn, fileInfo in viewitems(self.completedFiles):
             pfn = fileInfo['PFN']
             command = fileInfo['StageOutCommand']
             msg = "Cleaning out file: %s\n" % lfn

--- a/src/python/WMCore/WMRuntime/SandboxCreator.py
+++ b/src/python/WMCore/WMRuntime/SandboxCreator.py
@@ -5,6 +5,8 @@
     Given a path, workflow and task, create a sandbox within the path
 """
 
+from builtins import map, object
+
 from future import standard_library
 standard_library.install_aliases()
 
@@ -36,7 +38,7 @@ def tarFilter(tarinfo):
         return tarinfo
 
 
-class SandboxCreator:
+class SandboxCreator(object):
     def __init__(self):
         self.packageWMCore = True
 

--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -5,6 +5,7 @@ Create a CMSSW PSet suitable for running a WMAgent job.
 
 """
 from __future__ import print_function
+from future.utils import viewitems
 
 import json
 import logging
@@ -271,7 +272,7 @@ class SetupCMSSWPset(ScriptInterface):
         #   dataset.dataTier
         #   dataset.filterName
         if hasattr(self.process, "outputModules"):
-            outputModuleNames = self.process.outputModules.keys()
+            outputModuleNames = list(self.process.outputModules)
         else:
             outputModuleNames = self.process.outputModules_()
         for outMod in outputModuleNames:
@@ -485,7 +486,7 @@ class SetupCMSSWPset(ScriptInterface):
         prodsAndFilters = {}
         prodsAndFilters.update(self.process.producers)
         prodsAndFilters.update(self.process.filters)
-        for key, value in prodsAndFilters.items():
+        for key, value in viewitems(prodsAndFilters):
             if value.type_() in ["MixingModule", "DataMixingModule", "PreMixingModule"]:
                 mixModules.append(value)
             if value.type_() == "DataMixingModule":

--- a/src/python/WMCore/WMRuntime/Tools/Scram.py
+++ b/src/python/WMCore/WMRuntime/Tools/Scram.py
@@ -25,6 +25,9 @@ sample usage:
 
 """
 
+from builtins import range, object
+from future.utils import viewitems
+
 import logging
 import os
 import os.path
@@ -36,7 +39,7 @@ from PSetTweaks.WMTweak import readAdValues
 ARCH_TO_OS = {'slc5': ['rhel6'], 'slc6': ['rhel6'], 'slc7': ['rhel7']}
 
 OS_TO_ARCH = {}
-for arch, oses in ARCH_TO_OS.iteritems():
+for arch, oses in viewitems(ARCH_TO_OS):
     for osName in oses:
         if osName not in OS_TO_ARCH:
             OS_TO_ARCH[osName] = []

--- a/src/python/WMCore/WMRuntime/Watchdog.py
+++ b/src/python/WMCore/WMRuntime/Watchdog.py
@@ -7,6 +7,7 @@ This cleverly named object is the thread that handles the monitoring of individu
 """
 from __future__ import division
 from __future__ import print_function
+from future.utils import viewitems
 
 import logging
 import os
@@ -104,7 +105,7 @@ class Watchdog(threading.Thread):
                         args['maxPSS'] = resources['memory'] - 50
 
                 logging.info("Watchdog modified: %s. Final settings:", changedCores)
-                for k, v in args.iteritems():
+                for k, v in viewitems(args):
                     logging.info("  %s: %r", k, v)
             # Actually initialize the monitor variables
             mon.initMonitor(task=task, job=wmbsJob,

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -7,6 +7,9 @@ of related tasks.
 """
 from __future__ import print_function
 
+from builtins import next, range
+from future.utils import viewitems, viewvalues
+
 from Utils.Utilities import strToBool
 from WMCore.Configuration import ConfigSection
 from WMCore.Lexicon import sanitizeURL
@@ -217,7 +220,7 @@ class WMWorkloadHelper(PersistencyHelper):
 
         newMap = {}
         if chainMap:
-            for _, cData in chainMap.items():
+            for cData in viewvalues(chainMap):
                 cNum = cData.get('TaskNumber', cData.get('StepNumber'))
                 newMap[cNum] = {'ParentDset': cData['ParentDataset'],
                                 'ChildDsets': []}
@@ -239,7 +242,7 @@ class WMWorkloadHelper(PersistencyHelper):
             return
 
         parentMap = self.getStepParentageMapping()
-        listOfStepNames = parentMap.keys()
+        listOfStepNames = list(parentMap)
         for stepName in listOfStepNames:
             if parentMap[stepName]['OutputDatasetMap']:
                 # then there is output dataset, let's update it
@@ -273,7 +276,7 @@ class WMWorkloadHelper(PersistencyHelper):
         """
         taskMap = self.getTaskParentageMapping()
 
-        for tName in taskMap.keys():
+        for tName in taskMap:
             if not taskMap[tName]['OutputDatasetMap']:
                 continue
 
@@ -288,7 +291,7 @@ class WMWorkloadHelper(PersistencyHelper):
                     continue
                 oldOutputDset = taskMap[tName]['OutputDatasetMap'][outInfo['outputModule']]
                 taskMap[tName]['OutputDatasetMap'][outInfo['outputModule']] = outInfo['outputDataset']
-                for tt in taskMap.keys():
+                for tt in taskMap:
                     if taskMap[tt]['ParentDataset'] == oldOutputDset:
                         taskMap[tt]['ParentDataset'] = outInfo['outputDataset']
 
@@ -366,7 +369,7 @@ class WMWorkloadHelper(PersistencyHelper):
         if not isinstance(ownerProperties, dict):
             raise Exception("Someone is trying to setOwner without a dictionary")
 
-        for key in ownerProperties.keys():
+        for key in ownerProperties:
             setattr(self.data.owner, key, ownerProperties[key])
 
         return
@@ -384,7 +387,7 @@ class WMWorkloadHelper(PersistencyHelper):
 
         if not isinstance(ownerProperties, dict):
             raise Exception("Someone is trying to setOwnerDetails without a dictionary")
-        for key in ownerProperties.keys():
+        for key in ownerProperties:
             setattr(self.data.owner, key, ownerProperties[key])
         return
 
@@ -422,7 +425,7 @@ class WMWorkloadHelper(PersistencyHelper):
         Set the Start policy and its parameters
         """
         self.data.policies.start.policyName = policyName
-        for key, val in params.iteritems():
+        for key, val in viewitems(params):
             setattr(self.data.policies.start, key, val)
 
     def startPolicy(self):
@@ -449,7 +452,7 @@ class WMWorkloadHelper(PersistencyHelper):
         Set the End policy and its parameters
         """
         self.data.policies.end.policyName = policyName
-        for key, val in params.iteritems():
+        for key, val in viewitems(params):
             setattr(self.data.policies.end, key, val)
 
     def endPolicy(self):
@@ -1355,7 +1358,7 @@ class WMWorkloadHelper(PersistencyHelper):
         for task in taskIterator:
             for stepName in task.listAllStepNames():
                 outModule = task.getOutputModulesForStep(stepName)
-                for module in outModule.dictionary_().values():
+                for module in viewvalues(outModule.dictionary_()):
                     lfnBase = getattr(module, "lfnBase", "")
                     if not onlyUnmerged and lfnBase:
                         listLFNBases.add(lfnBase)
@@ -1550,10 +1553,10 @@ class WMWorkloadHelper(PersistencyHelper):
                 for stepName in task.listAllStepNames():
                     stepHelper = task.getStepHelper(stepName)
                     if stepHelper.stepType() == "LogArchive":
-                        for key, value in overrides.items():
+                        for key, value in viewitems(overrides):
                             stepHelper.addOverride(key, value)
             # save it at workload level as well
-            for key, value in overrides.items():
+            for key, value in viewitems(overrides):
                 setattr(self.data.overrides, key, value)
 
         return

--- a/src/python/WMCore/WorkQueue/WMBSHelper.py
+++ b/src/python/WMCore/WorkQueue/WMBSHelper.py
@@ -5,6 +5,9 @@ _WMBSHelper_
 Use WMSpecParser to extract information for creating workflow, fileset, and subscription
 """
 
+from builtins import next, str as newstr, bytes, zip, range
+from future.utils import viewitems
+
 import logging
 import threading
 from collections import defaultdict
@@ -105,7 +108,7 @@ def killWorkflow(workflowName, jobCouchConfig, bossAirConfig=None):
         liveWMBSJob.update(liveJob)
         liveWMBSJobs[liveJob["state"]].append(liveWMBSJob)
 
-    for state, jobsByState in liveWMBSJobs.items():
+    for state, jobsByState in viewitems(liveWMBSJobs):
         if len(jobsByState) > 100 and state != "executing":
             # if there are to many jobs skip the couch and dashboard update
             # TODO: couch and dashboard need to be updated or parallel.
@@ -127,7 +130,7 @@ def freeSlots(multiplier=1.0, minusRunning=False, allowedStates=None, knownCmsSi
     rc_sites = ResourceControl().listThresholdsForCreate()
     thresholds = defaultdict(lambda: 0)
     jobCounts = defaultdict(dict)
-    for name, site in rc_sites.items():
+    for name, site in viewitems(rc_sites):
         if not site.get('cms_name'):
             logging.warning("Not fetching work for %s, cms_name not defined", name)
             continue
@@ -370,7 +373,7 @@ class WMBSHelper(WMConnectionBase):
                         )
 
         if self.mask:
-            lumis = range(self.mask['FirstLumi'], self.mask['LastLumi'] + 1)  # inclusive range
+            lumis = list(range(self.mask['FirstLumi'], self.mask['LastLumi'] + 1))  # inclusive range
             wmbsFile.addRun(Run(self.mask['FirstRun'], *lumis))  # assume run number static
         else:
             wmbsFile.addRun(Run(1, 1))
@@ -560,7 +563,7 @@ class WMBSHelper(WMConnectionBase):
             if selfChecksums:
                 # If we have checksums we have to create a bind
                 # For each different checksum
-                for entry in selfChecksums.keys():
+                for entry in selfChecksums:
                     dbsCksumBinds.append({'lfn': lfn, 'cksum': selfChecksums[entry],
                                           'cktype': entry})
 
@@ -739,7 +742,7 @@ class WMBSHelper(WMConnectionBase):
 
         results = []
         for f in files:
-            if isinstance(f, basestring) or "LumiList" not in f:
+            if isinstance(f, (newstr, bytes)) or "LumiList" not in f:
                 results.append(f)
                 continue
 

--- a/test/python/WMCore_t/ResourceControl_t/ResourceControl_t.py
+++ b/test/python/WMCore_t/ResourceControl_t/ResourceControl_t.py
@@ -5,6 +5,8 @@ _ResourceControl_t_
 Unit tests for ResourceControl.
 """
 
+from future.utils import viewitems
+
 import os
 import subprocess
 import sys
@@ -223,13 +225,13 @@ class ResourceControlTest(EmulatedUnitTestCase):
 
         createThresholds = myResourceControl.listThresholdsForCreate()
 
-        self.assertEqual(len(createThresholds.keys()), 2,
+        self.assertEqual(len(createThresholds), 2,
                          "Error: Wrong number of site in Resource Control DB")
 
-        self.assertTrue("testSite1" in createThresholds.keys(),
+        self.assertTrue("testSite1" in createThresholds,
                         "Error: Test Site 1 missing from thresholds.")
 
-        self.assertTrue("testSite2" in createThresholds.keys(),
+        self.assertTrue("testSite2" in createThresholds,
                         "Error: Test Site 2 missing from thresholds.")
 
         self.assertEqual(createThresholds["testSite1"]["total_slots"], 10,
@@ -247,13 +249,13 @@ class ResourceControlTest(EmulatedUnitTestCase):
 
         thresholds = myResourceControl.listThresholdsForSubmit()
 
-        self.assertEqual(len(thresholds.keys()), 2,
+        self.assertEqual(len(thresholds), 2,
                          "Error: Wrong number of sites in Resource Control DB")
 
-        self.assertTrue("testSite1" in thresholds.keys(),
+        self.assertTrue("testSite1" in thresholds,
                         "Error: testSite1 missing from thresholds.")
 
-        self.assertTrue("testSite2" in thresholds.keys(),
+        self.assertTrue("testSite2" in thresholds,
                         "Error: testSite2 missing from thresholds.")
 
         site1Info = thresholds["testSite1"]
@@ -265,12 +267,12 @@ class ResourceControlTest(EmulatedUnitTestCase):
         procThreshold2 = None
         mergeThreshold1 = None
         mergeThreshold2 = None
-        for taskType, threshold in site1Thresholds.items():
+        for taskType, threshold in viewitems(site1Thresholds):
             if taskType == "Merge":
                 mergeThreshold1 = threshold
             elif taskType == "Processing":
                 procThreshold1 = threshold
-        for taskType, threshold in site2Thresholds.items():
+        for taskType, threshold in viewitems(site2Thresholds):
             if taskType == "Merge":
                 mergeThreshold2 = threshold
             elif taskType == "Processing":
@@ -380,7 +382,7 @@ class ResourceControlTest(EmulatedUnitTestCase):
         createThresholds = myResourceControl.listThresholdsForCreate()
         submitThresholds = myResourceControl.listThresholdsForSubmit()
 
-        self.assertEqual(len(createThresholds.keys()), 2,
+        self.assertEqual(len(createThresholds), 2,
                          "Error: Wrong number of sites in create thresholds")
 
         self.assertEqual(createThresholds["testSite1"]["total_slots"], 10,
@@ -409,12 +411,12 @@ class ResourceControlTest(EmulatedUnitTestCase):
         procThreshold1 = None
         procThreshold2 = None
         self.assertEqual(set(submitThresholds.keys()), set(["testSite1", "testSite2"]))
-        for taskType, threshold in submitThresholds["testSite1"]["thresholds"].items():
+        for taskType, threshold in viewitems(submitThresholds["testSite1"]["thresholds"]):
             if taskType == "Merge":
                 mergeThreshold1 = threshold
             elif taskType == "Processing":
                 procThreshold1 = threshold
-        for taskType, threshold in submitThresholds["testSite2"]["thresholds"].items():
+        for taskType, threshold in viewitems(submitThresholds["testSite2"]["thresholds"]):
             if taskType == "Merge":
                 mergeThreshold2 = threshold
             elif taskType == "Processing":
@@ -690,7 +692,7 @@ class ResourceControlTest(EmulatedUnitTestCase):
             self.assertEqual(len(result[x]['thresholds']), 7)
             self.assertEqual(result[x]['total_pending_slots'], 500)
             self.assertEqual(result[x]['total_running_slots'], 1)
-            for taskType, thresh in result[x]['thresholds'].items():
+            for taskType, thresh in viewitems(result[x]['thresholds']):
                 if taskType == 'Processing':
                     self.assertEqual(thresh['priority'], 0)
                     self.assertEqual(thresh['max_slots'], 1)

--- a/test/python/WMCore_t/WMRuntime_t/Scripts_t/SetupCMSSWPset_t.py
+++ b/test/python/WMCore_t/WMRuntime_t/Scripts_t/SetupCMSSWPset_t.py
@@ -7,6 +7,9 @@ Tests for the PSet configuration code.
 """
 from __future__ import print_function
 
+from future.utils import viewvalues
+from builtins import zip
+
 import imp
 import unittest
 import os
@@ -298,7 +301,7 @@ class SetupCMSSWPsetTest(unittest.TestCase):
         """
         # consider only locally available files
         filesInConfigDict = []
-        for v in pileupSubDict.values():
+        for v in viewvalues(pileupSubDict):
             if seLocalName in v["phedexNodeNames"]:
                 filesInConfigDict.extend(v["FileList"])
 

--- a/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
@@ -5,6 +5,8 @@ _WMWorkload_t_
 Unittest for WMWorkload class
 """
 
+from future.utils import viewitems
+
 import os
 import unittest
 
@@ -314,7 +316,7 @@ class WMWorkloadTest(unittest.TestCase):
         workload.setOwnerDetails(name="Mobutu", group="DMWM", ownerProperties=ownerProps)
         result = workload.getOwner()
 
-        for key in ownerProps.keys():
+        for key in ownerProps:
             self.assertEqual(result[key], ownerProps[key])
 
     def testDbsUrl(self):
@@ -485,7 +487,7 @@ class WMWorkloadTest(unittest.TestCase):
         testWorkload.setMergeParameters(minSize=10, maxSize=100, maxEvents=1000)
 
         procSplitParams = procTask.jobSplittingParameters(performance=False)
-        self.assertEqual(len(procSplitParams.keys()), 6,
+        self.assertEqual(len(procSplitParams), 6,
                          "Error: Wrong number of params for proc task.")
         self.assertEqual(procSplitParams["algorithm"], "FileBased",
                          "Error: Wrong job splitting algo for proc task.")
@@ -497,7 +499,7 @@ class WMWorkloadTest(unittest.TestCase):
                          "Error: Site black list was updated.")
 
         skimSplitParams = skimTask.jobSplittingParameters(performance=False)
-        self.assertEqual(len(skimSplitParams.keys()), 7,
+        self.assertEqual(len(skimSplitParams), 7,
                          "Error: Wrong number of params for skim task.")
         self.assertEqual(skimSplitParams["algorithm"], "FileBased",
                          "Error: Wrong job splitting algo for skim task.")
@@ -511,7 +513,7 @@ class WMWorkloadTest(unittest.TestCase):
                          "Error: Site black list was updated.")
 
         mergeSplitParams = mergeTask.jobSplittingParameters(performance=False)
-        self.assertEqual(len(mergeSplitParams.keys()), 8,
+        self.assertEqual(len(mergeSplitParams), 8,
                          "Error: Wrong number of params for merge task.")
         self.assertEqual(mergeSplitParams["algorithm"], "WMBSMergeBySize",
                          "Error: Wrong job splitting algo for merge task.")
@@ -527,7 +529,7 @@ class WMWorkloadTest(unittest.TestCase):
                          "Error: Site black list was updated.")
 
         mergeDQMSplitParams = mergeDQMTask.jobSplittingParameters(performance=False)
-        self.assertEqual(len(mergeDQMSplitParams.keys()), 8,
+        self.assertEqual(len(mergeDQMSplitParams), 8,
                          "Error: Wrong number of params for merge task.")
         self.assertEqual(mergeDQMSplitParams["algorithm"], "WMBSMergeBySize",
                          "Error: Wrong job splitting algo for merge task.")
@@ -834,7 +836,7 @@ class WMWorkloadTest(unittest.TestCase):
 
         # step level checks
         for stepObj in (procTaskCMSSWHelper, procTaskCMSSW2Helper, procTaskCMSSW3Helper):
-            taskName = [k for k, values in stepMap.items() if values[1] == stepObj.name()][0]
+            taskName = [k for k, values in viewitems(stepMap) if values[1] == stepObj.name()][0]
             self.assertEqual(stepObj.getAcqEra(), acqEra[taskName])
             self.assertEqual(stepObj.getProcStr(), procStr[taskName])
             # FIXME: maybe we don't set ProcVer at step level
@@ -1280,7 +1282,7 @@ class WMWorkloadTest(unittest.TestCase):
         self.assertFalse("SubSliceSize" in testWorkload.startPolicyParameters(),
                          "Error: Shouldn't have sub-slice size.")
         procSplitParams = procTask.jobSplittingParameters(performance=False)
-        self.assertEqual(len(procSplitParams.keys()), 7,
+        self.assertEqual(len(procSplitParams), 7,
                          "Error: Wrong number of params for proc task.")
         self.assertEqual(procSplitParams["algorithm"], "FileBased",
                          "Error: Wrong job splitting algo for proc task.")
@@ -1298,7 +1300,7 @@ class WMWorkloadTest(unittest.TestCase):
                          "Error: Wrong min merge size: %s" % stepHelper.minMergeSize())
 
         skimSplitParams = skimTask.jobSplittingParameters(performance=False)
-        self.assertEqual(len(skimSplitParams.keys()), 8,
+        self.assertEqual(len(skimSplitParams), 8,
                          "Error: Wrong number of params for skim task.")
         self.assertEqual(skimSplitParams["algorithm"], "RunBased",
                          "Error: Wrong job splitting algo for skim task.")
@@ -1314,7 +1316,7 @@ class WMWorkloadTest(unittest.TestCase):
                          "Error: Site black list was updated.")
 
         mergeSplitParams = mergeTask.jobSplittingParameters(performance=False)
-        self.assertEqual(len(mergeSplitParams.keys()), 8,
+        self.assertEqual(len(mergeSplitParams), 8,
                          "Error: Wrong number of params for merge task.")
         self.assertEqual(mergeSplitParams["algorithm"], "ParentlessMergeBySize",
                          "Error: Wrong job splitting algo for merge task.")
@@ -1344,7 +1346,7 @@ class WMWorkloadTest(unittest.TestCase):
                          "Error: Wrong min merge size.")
 
         mergeSplitParams = mergeTask.jobSplittingParameters(performance=False)
-        self.assertEqual(len(mergeSplitParams.keys()), 8,
+        self.assertEqual(len(mergeSplitParams), 8,
                          "Error: Wrong number of params for merge task.")
         self.assertEqual(mergeSplitParams["algorithm"], "WMBSMergeBySize",
                          "Error: Wrong job splitting algo for merge task.")
@@ -1420,7 +1422,7 @@ class WMWorkloadTest(unittest.TestCase):
         self.assertEqual(testWorkload.startPolicyParameters()["SubSliceSize"],
                          15, "Error: Wrong sub-slice size.")
         prodSplitParams = prodTask.jobSplittingParameters(performance=False)
-        self.assertEqual(len(prodSplitParams.keys()), 7,
+        self.assertEqual(len(prodSplitParams), 7,
                          "Error: Wrong number of params for proc task.")
         self.assertEqual(prodSplitParams["algorithm"], "EventBased",
                          "Error: Wrong job splitting algo for proc task.")
@@ -1442,7 +1444,7 @@ class WMWorkloadTest(unittest.TestCase):
                          "Error: Wrong min merge size: %s" % stepHelper.minMergeSize())
 
         mergeSplitParams = mergeTask.jobSplittingParameters(performance=False)
-        self.assertEqual(len(mergeSplitParams.keys()), 8,
+        self.assertEqual(len(mergeSplitParams), 8,
                          "Error: Wrong number of params for merge task.")
         self.assertEqual(mergeSplitParams["algorithm"], "ParentlessMergeBySize",
                          "Error: Wrong job splitting algo for merge task.")
@@ -1489,13 +1491,13 @@ class WMWorkloadTest(unittest.TestCase):
 
         results = testWorkload.listJobSplittingParametersByTask(performance=False)
 
-        self.assertEqual(len(results.keys()), 3, \
+        self.assertEqual(len(results), 3, \
                          "Error: Wrong number of tasks.")
-        self.assertTrue("/TestWorkload/ProcessingTask" in results.keys(),
+        self.assertTrue("/TestWorkload/ProcessingTask" in results,
                         "Error: Task is missing.")
-        self.assertTrue("/TestWorkload/ProcessingTask/MergeTask" in results.keys(),
+        self.assertTrue("/TestWorkload/ProcessingTask/MergeTask" in results,
                         "Error: Task is missing.")
-        self.assertTrue("/TestWorkload/ProcessingTask/MergeTask/SkimTask" in results.keys(),
+        self.assertTrue("/TestWorkload/ProcessingTask/MergeTask/SkimTask" in results,
                         "Error: Task is missing.")
         self.assertEqual(results["/TestWorkload/ProcessingTask"], {"files_per_job": 2,
                                                                    "algorithm": "FileBased",

--- a/test/python/WMCore_t/WorkQueue_t/WMBSHelper_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WMBSHelper_t.py
@@ -5,6 +5,7 @@ _WMBSHelper_t_
 Unit tests for the WMBSHelper class.
 """
 
+from builtins import next
 import os
 import threading
 import unittest
@@ -605,7 +606,7 @@ class WMBSHelperTest(EmulatedUnitTestCase):
         self.assertEqual(procWorkflow.spec, os.path.join(self.workDir, procWorkflow.name,
                                                          "WMSandbox", "WMWorkload.pkl"),
                          "Error: Wrong spec URL")
-        self.assertEqual(len(procWorkflow.outputMap.keys()), 1,
+        self.assertEqual(len(procWorkflow.outputMap), 1,
                          "Error: Wrong number of WF outputs.")
         mergedProcOutput = procWorkflow.outputMap["OutputADataTierA"][0]["merged_output_fileset"]
         unmergedProcOutput = procWorkflow.outputMap["OutputADataTierA"][0]["output_fileset"]
@@ -626,7 +627,7 @@ class WMBSHelperTest(EmulatedUnitTestCase):
         self.assertEqual(mergeWorkflow.spec, os.path.join(self.workDir, mergeWorkflow.name,
                                                           "WMSandbox", "WMWorkload.pkl"),
                          "Error: Wrong spec URL")
-        self.assertEqual(len(mergeWorkflow.outputMap.keys()), 1,
+        self.assertEqual(len(mergeWorkflow.outputMap), 1,
                          "Error: Wrong number of WF outputs.")
 
         cleanupWorkflow = Workflow(name="TestWorkload",
@@ -638,7 +639,7 @@ class WMBSHelperTest(EmulatedUnitTestCase):
         self.assertEqual(cleanupWorkflow.spec, os.path.join(self.workDir, cleanupWorkflow.name,
                                                             "WMSandbox", "WMWorkload.pkl"),
                          "Error: Wrong spec URL")
-        self.assertEqual(len(cleanupWorkflow.outputMap.keys()), 0,
+        self.assertEqual(len(cleanupWorkflow.outputMap), 0,
                          "Error: Wrong number of WF outputs.")
 
         unmergedMergeOutput = mergeWorkflow.outputMap["MergedDataTierA"][0]["output_fileset"]
@@ -656,7 +657,7 @@ class WMBSHelperTest(EmulatedUnitTestCase):
         self.assertEqual(skimWorkflow.spec, os.path.join(self.workDir, skimWorkflow.name,
                                                          "WMSandbox", "WMWorkload.pkl"),
                          "Error: Wrong spec URL")
-        self.assertEqual(len(skimWorkflow.outputMap.keys()), 2,
+        self.assertEqual(len(skimWorkflow.outputMap), 2,
                          "Error: Wrong number of WF outputs.")
 
         mergedSkimOutputA = skimWorkflow.outputMap["SkimOutputADataTierA"][0]["merged_output_fileset"]
@@ -758,8 +759,7 @@ class WMBSHelperTest(EmulatedUnitTestCase):
         self.assertEqual(mergeWorkflow.spec, os.path.join(self.workDir, mergeWorkflow.name,
                                                           "WMSandbox", "WMWorkload.pkl"),
                          "Error: Wrong spec URL")
-        self.assertEqual(len(mergeWorkflow.outputMap.keys()), 1,
-                         "Error: Wrong number of WF outputs.")
+        self.assertEqual(len(mergeWorkflow.outputMap), 1, "Error: Wrong number of WF outputs.")
 
         unmergedMergeOutput = mergeWorkflow.outputMap["MergedDataTierA"][0]["output_fileset"]
         unmergedMergeOutput.loadData()
@@ -776,7 +776,7 @@ class WMBSHelperTest(EmulatedUnitTestCase):
         self.assertEqual(skimWorkflow.spec, os.path.join(self.workDir, skimWorkflow.name,
                                                          "WMSandbox", "WMWorkload.pkl"),
                          "Error: Wrong spec URL")
-        self.assertEqual(len(skimWorkflow.outputMap.keys()), 2,
+        self.assertEqual(len(skimWorkflow.outputMap), 2,
                          "Error: Wrong number of WF outputs.")
 
         mergedSkimOutputA = skimWorkflow.outputMap["SkimOutputADataTierA"][0]["merged_output_fileset"]


### PR DESCRIPTION
Fixes #10141 

#### Status

Ready 

#### Related PRs

* Previous migration PR: #10321  (slice16, issue #10140)
* Next migration PR: #10331  (slice18, issue #10142  )

#### Description

Run futurize and some manual changes on the first batch of src/python/A/B/C.

"native string" approach
- `src/python/WMCore/FwkJobReport/Report.py`: imported str from builtins, but used only in a narrow case. 
  - `addError`: refactored. See #8403 for previous work
  - refactored heavily
- `src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.p`: there is only one line where this may be problematic: `inputTypeAttrib.fileNames.append(str(fileLFN))`, but I do not think that there is any incentive to try to change it at this stage. tracked at #10323 

#### Is it backward compatible (if not, which system it affects?)

It should be. (Any possible cause for errors will we reported here)

#### External dependencies / deployment changes

Requires python-future in both py2 and py3 environments.