### PR TITLE
[py2py3] Migration at level scr/python/A/B/C - slice 18

### DIFF
--- a/src/python/WMComponent/AgentStatusWatcher/DrainStatusAPI.py
+++ b/src/python/WMComponent/AgentStatusWatcher/DrainStatusAPI.py
@@ -3,6 +3,8 @@ API for querying the status of agent drain process
 """
 
 from __future__ import division
+from builtins import object
+
 from WMComponent.DBS3Buffer.DBSBufferUtil import DBSBufferUtil
 from WMCore.Services.PyCondor.PyCondorAPI import PyCondorAPI
 from WMCore.WorkQueue.WorkQueueBackend import WorkQueueBackend

--- a/src/python/WMComponent/AnalyticsDataCollector/DataCollectAPI.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/DataCollectAPI.py
@@ -2,6 +2,8 @@
 Provide functions to collect data and upload data
 """
 from __future__ import division
+from builtins import object
+from future.utils import viewitems
 
 import os
 import time
@@ -303,7 +305,7 @@ def combineAnalyticsData(a, b, combineFunc=None):
     """
     result = {}
     result.update(a)
-    for key, value in b.items():
+    for key, value in viewitems(b):
         if key not in result:
             result[key] = value
         else:
@@ -319,7 +321,7 @@ def convertToRequestCouchDoc(combinedRequests, fwjrInfo, finishedTasks,
                              skippedInfoFromCouch, agentInfo,
                              uploadTime, summaryLevel):
     requestDocs = []
-    for request, status in combinedRequests.items():
+    for request, status in viewitems(combinedRequests):
         doc = {}
         doc['_id'] = '%s-%s' % (agentInfo['agent_url'], request)
         doc.update(agentInfo)
@@ -386,11 +388,11 @@ def _setMultiLevelStatus(statusData, status, value):
 
 
 def _combineJobsForStatusAndSite(requestData, data):
-    for status, siteJob in requestData.items():
+    for status, siteJob in viewitems(requestData):
         if not isinstance(siteJob, dict):
             _setMultiLevelStatus(data['status'], status, siteJob)
         else:
-            for site, job in siteJob.items():
+            for site, job in viewitems(siteJob):
                 _setMultiLevelStatus(data['status'], status, int(job))
                 if site != 'Agent':
                     if site is None:
@@ -419,7 +421,7 @@ def _convertToStatusSiteFormat(requestData, summaryLevel=None):
 
     if summaryLevel is not None and summaryLevel == 'task':
         data['tasks'] = {}
-        for task, taskData in requestData.items():
+        for task, taskData in viewitems(requestData):
             data['tasks'][task] = _convertToStatusSiteFormat(taskData)
             _combineJobsForStatusAndSite(taskData, data)
     else:

--- a/src/python/WMComponent/JobAccountant/AccountantWorker.py
+++ b/src/python/WMComponent/JobAccountant/AccountantWorker.py
@@ -729,7 +729,7 @@ class AccountantWorker(WMConnectionBase):
             if selfChecksums:
                 # If we have checksums we have to create a bind
                 # For each different checksum
-                for entry in selfChecksums.keys():
+                for entry in selfChecksums:
                     dbsCksumBinds.append({'lfn': lfn, 'cksum': selfChecksums[entry],
                                           'cktype': entry})
 
@@ -816,7 +816,7 @@ class AccountantWorker(WMConnectionBase):
             if selfChecksums:
                 # If we have checksums we have to create a bind
                 # For each different checksum
-                for entry in selfChecksums.keys():
+                for entry in selfChecksums:
                     fileCksumBinds.append({'lfn': lfn, 'cksum': selfChecksums[entry],
                                            'cktype': entry})
 

--- a/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
+++ b/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
@@ -12,6 +12,9 @@ Created on Sep 25, 2012
 @author: dballest
 """
 
+from __future__ import division
+from builtins import int
+
 import logging
 import math
 import operator
@@ -106,7 +109,7 @@ class EventAwareLumiBased(JobFactory):
             return
 
         locationDict = {}
-        for key in lDict.keys():
+        for key in lDict:
             newlist = []
             # First we need to load the data
             if self.loadRunLumi:
@@ -116,7 +119,7 @@ class EventAwareLumiBased(JobFactory):
                                     self.subscription.workflowName(), self.subscription['id'])
                 for f in lDict[key]:
                     lumiDict = fileLumis.get(f['id'], {})
-                    for run in lumiDict.keys():
+                    for run in lumiDict:
                         f.addRun(run=Run(run, *lumiDict[run]))
 
             for f in lDict[key]:
@@ -131,7 +134,7 @@ class EventAwareLumiBased(JobFactory):
 
                 # Do average event per lumi calculation
                 if f['lumiCount']:
-                    f['avgEvtsPerLumi'] = round(float(f['events']) / f['lumiCount'])
+                    f['avgEvtsPerLumi'] = int(round(f['events'] / f['lumiCount']))
                     if deterministicPileup:
                         # We assume that all lumis are equal in the dataset
                         eventsPerLumiInDataset = f['avgEvtsPerLumi']

--- a/src/python/WMCore/JobSplitting/FileBased.py
+++ b/src/python/WMCore/JobSplitting/FileBased.py
@@ -6,6 +6,10 @@ File based splitting algorithm that will chop a fileset into
 a set of jobs based on file boundaries
 """
 
+from __future__ import division
+from future.utils import viewvalues
+from builtins import int
+
 from WMCore.JobSplitting.JobFactory import JobFactory
 from WMCore.WMBS.File import File
 from WMCore.WMSpec.WMTask import buildLumiMask
@@ -59,14 +63,14 @@ class FileBased(JobFactory):
                     if f['lumiCount'] == 0:
                         continue
                     ## Do average event per lumi calculation.
-                    f['avgEvtsPerLumi'] = round(float(f['events']) / f['lumiCount'])
+                    f['avgEvtsPerLumi'] = int(round(f['events'] / f['lumiCount']))
                 newlist.append(f)
             locationDict[key] = sorted(newlist, key = lambda f: f['lfn'])
 
         ## Make a list with all the files, sorting them by LFN. Remove from the list all
         ## the files filtered out by the lumi-mask (if there is one).
         files = []
-        for filesPerLocSet in locationDict.values():
+        for filesPerLocSet in viewvalues(locationDict):
             for f in filesPerLocSet:
                 files.append(f)
         if len(files):
@@ -92,11 +96,11 @@ class FileBased(JobFactory):
             removedFiles = files[totalFiles:]
             files = files[:totalFiles]
             for f in removedFiles:
-                for locSet in locationDict.keys():
+                for locSet in locationDict:
                     if f in locationDict[locSet]:
                         locationDict[locSet].remove(f)
 
-        for locSet in locationDict.keys():
+        for locSet in locationDict:
             #Now we have all the files in a certain location set
             fileList = locationDict[locSet]
             filesInJob  = 0

--- a/src/python/WMCore/JobSplitting/Harvest.py
+++ b/src/python/WMCore/JobSplitting/Harvest.py
@@ -3,6 +3,8 @@
 _Harvest_
 
 """
+from future.utils import viewitems
+
 import threading
 import logging
 
@@ -60,7 +62,7 @@ class Harvest(JobFactory):
                 logging.error("File %s has no run information!", fileInfo['lfn'])
 
             # Populate a dictionary with [location][run] so we can split jobs according to those different combinations
-            if locSet not in locationDict.keys():
+            if locSet not in locationDict:
                 locationDict[locSet] = {}
 
             fileInfo['runs'] = set()
@@ -70,7 +72,7 @@ class Harvest(JobFactory):
                 for run in runSet:
                     if run.run in goodRunList:
                         runDict[fileInfo['lfn']].add(run)
-                        if run.run in locationDict[locSet].keys():
+                        if run.run in locationDict[locSet]:
                             locationDict[locSet][run.run].append(fileInfo)
                         else:
                             locationDict[locSet][run.run] = [fileInfo]
@@ -92,7 +94,7 @@ class Harvest(JobFactory):
                     maskedRun = Run(run.run, *maskedLumis)
                     newRunSet.append(maskedRun)
 
-                    if run.run in locationDict[locSet].keys():
+                    if run.run in locationDict[locSet]:
                         locationDict[locSet][run.run].append(fileInfo)
                     else:
                         locationDict[locSet][run.run] = [fileInfo]
@@ -102,7 +104,7 @@ class Harvest(JobFactory):
                 # no LumiList and no run white or black list
                 runDict[fileInfo['lfn']] = runSet
                 for run in runSet:
-                    if run.run in locationDict[locSet].keys():
+                    if run.run in locationDict[locSet]:
                         locationDict[locSet][run.run].append(fileInfo)
                     else:
                         locationDict[locSet][run.run] = [fileInfo]
@@ -118,7 +120,7 @@ class Harvest(JobFactory):
         else:
             harvestType = "Periodic"
 
-        for location in locationDict.keys():
+        for location in locationDict:
 
             if dqmHarvestUnit == "byRun":
                 self.createJobByRun(locationDict, location, baseName, harvestType, runDict, endOfRun)
@@ -134,7 +136,7 @@ class Harvest(JobFactory):
         Creates one job per run for all files available at the same location.
         """
 
-        for run in locationDict[location].keys():
+        for run in locationDict[location]:
             # Should create at least one job for every location/run, putting this here will do
             self.jobCount += 1
             self.newJob(name="%s-%s-Harvest-%i" % (baseName, harvestType, self.jobCount))
@@ -188,7 +190,7 @@ class Harvest(JobFactory):
 
         Merges the interesection of lumi ranges.
         """
-        for run, lumis in runLumis.iteritems():
+        for run, lumis in viewitems(runLumis):
             lumis.sort(key=lambda sublist: sublist[0])
             fixedLumis = [lumis[0]]
             for lumi in lumis:

--- a/src/python/WMCore/REST/CherryPyPeriodicTask.py
+++ b/src/python/WMCore/REST/CherryPyPeriodicTask.py
@@ -4,11 +4,14 @@ Created on Jul 31, 2014
 @author: sryu
 '''
 from __future__ import print_function, division
+from builtins import object
+
 import cherrypy
 import traceback
+from threading import Thread, Condition
+
 from WMCore.WMLogging import getTimeRotatingLogger
 
-from threading import Thread, Condition
 
 class CherryPyPeriodicTask(object):
 

--- a/src/python/WMCore/ReqMgr/ReqMgrCouch.py
+++ b/src/python/WMCore/ReqMgr/ReqMgrCouch.py
@@ -1,3 +1,4 @@
+from builtins import object
 import cherrypy
 from WMCore.Database.CMSCouch import Database, CouchError
 from WMCore.ReqMgr.DataStructs.ReqMgrConfigDataCache import ReqMgrConfigDataCache

--- a/src/python/WMCore/Storage/StoreFail.py
+++ b/src/python/WMCore/Storage/StoreFail.py
@@ -8,6 +8,7 @@ namespace
 
 """
 from __future__ import print_function
+from builtins import object
 
 from WMCore.Storage.StageOutError import StageOutFailure
 from WMCore.Storage.StageOutMgr import StageOutMgr
@@ -28,7 +29,7 @@ def modifyLFN(inputLfn):
     return newLfn
 
 
-class StoreFailMgr:
+class StoreFailMgr(object):
     """
     _StoreFailMgr_
 

--- a/src/python/WMCore/WMBS/Oracle/Jobs/LoadFiles.py
+++ b/src/python/WMCore/WMBS/Oracle/Jobs/LoadFiles.py
@@ -32,7 +32,7 @@ class LoadFiles(LoadFilesMySQL):
         dictResults = []
         for formattedResult in formattedResults:
             dictResult = {}
-            if "fileid" in formattedResult.keys():
+            if "fileid" in formattedResult:
                 dictResult["id"] = int(formattedResult["fileid"])
                 dictResults.append(dictResult)
 

--- a/src/python/WMCore/WMBS/Oracle/Masks/Save.py
+++ b/src/python/WMCore/WMBS/Oracle/Masks/Save.py
@@ -45,7 +45,7 @@ class Save(SaveMasksMySQL):
                      'lastlumi': mask['LastLumi'], 'inclusivemask': inclusiveMask}
 
             fail = True
-            for key in binds.keys():
+            for key in binds:
                 if key != 'jobid' and key != 'inclusivemask' and binds[key] != None:
                     # At least one of the keys contains something
                     fail = False

--- a/src/python/WMCore/WMStats/DataStructs/DataCache.py
+++ b/src/python/WMCore/WMStats/DataStructs/DataCache.py
@@ -1,3 +1,6 @@
+from builtins import object, str, bytes
+from future.utils import viewitems
+
 import time
 from WMCore.ReqMgr.DataStructs.Request import RequestInfo, protectedLFNs
 
@@ -46,7 +49,7 @@ class DataCache(object):
     def filterData(filterDict, maskList):
         reqData = DataCache.getlatestJobData()
 
-        for _, reqInfo in reqData.iteritems():
+        for _, reqInfo in viewitems(reqData):
             reqData = RequestInfo(reqInfo)
             if reqData.andFilterCheck(filterDict):
                 for prop in maskList:
@@ -63,12 +66,12 @@ class DataCache(object):
         reqData = DataCache.getlatestJobData()
 
         if maskList is not None:
-            if isinstance(maskList, basestring):
+            if isinstance(maskList, (str, bytes)):
                 maskList = [maskList]
             if "RequestName" not in maskList:
                 maskList.append("RequestName")
 
-        for _, reqDict in reqData.iteritems():
+        for _, reqDict in viewitems(reqData):
             reqInfo = RequestInfo(reqDict)
             if reqInfo.andFilterCheck(filterDict):
 
@@ -84,6 +87,6 @@ class DataCache(object):
     def getProtectedLFNs():
         reqData = DataCache.getlatestJobData()
 
-        for _, reqInfo in reqData.iteritems():
+        for _, reqInfo in viewitems(reqData):
             for dirPath in protectedLFNs(reqInfo):
                 yield dirPath

--- a/src/python/WMCore/WorkQueue/WorkQueueReqMgrInterface.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueReqMgrInterface.py
@@ -2,6 +2,9 @@
 """
 Helper class for RequestManager interaction
 """
+from builtins import object
+from future.utils import viewvalues
+
 import os
 import socket
 import threading
@@ -214,7 +217,7 @@ class WorkQueueReqMgrInterface(object):
         tempResults = self.reqMgr2.getRequestByStatus("staged")
         filteredResults = []
         for requests in tempResults:
-            for request in requests.values():
+            for request in viewvalues(requests):
                 filteredResults.append(request)
         filteredResults.sort(key=itemgetter('RequestPriority'), reverse=True)
         filteredResults.sort(key=lambda r: r["Team"])

--- a/src/python/WMCore/WorkerThreads/BaseWorkerThread.py
+++ b/src/python/WMCore/WorkerThreads/BaseWorkerThread.py
@@ -8,6 +8,7 @@ Deriving classes should override algorithm, and optionally setup and terminate
 to perform thread-specific setup and clean-up operations
 """
 
+from builtins import object
 import logging
 import sys
 import threading

--- a/src/python/WMQuality/Emulators/RucioClient/MockRucioApi.py
+++ b/src/python/WMQuality/Emulators/RucioClient/MockRucioApi.py
@@ -5,6 +5,7 @@ Version of WMCore/Services/Rucio intended to be used with mock or unittest.mock
 """
 from __future__ import print_function, division
 from future.utils import listitems
+# from builtins import object # avoid importing this, it beraks things
 
 import json
 import logging

--- a/test/python/WMCore_t/JobSplitting_t/EventAwareLumiBased_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/EventAwareLumiBased_t.py
@@ -10,6 +10,9 @@ Created on Sep 25, 2012
 
 @author: dballest
 """
+from builtins import range
+from future.utils import viewvalues
+
 import unittest
 
 from WMCore.DataStructs.File import File
@@ -557,15 +560,15 @@ class EventAwareLumiBasedTest(unittest.TestCase):
         for i in range(0, 3):
             self.assertTrue(jobs[i]['failedOnCreation'], "It should have been marked as failed")
 
-            runNums = jobs[i]['mask']['runAndLumis'].keys()
+            runNums = list(jobs[i]['mask']['runAndLumis'])
             self.assertEqual(len(runNums), 1)
 
-            lumiNums = jobs[i]['mask']['runAndLumis'].values()[0]
+            lumiNums = next(iter(viewvalues(jobs[i]['mask']['runAndLumis'])))
             self.assertEqual(len(lumiNums), 1)
 
             finalLumi = []
             for pair in lumiNums:
-                finalLumi.extend(range(pair[0], pair[1] + 1))
+                finalLumi.extend(list(range(pair[0], pair[1] + 1)))
             self.assertEqual(len(finalLumi), 1)
 
             self.assertEqual(jobs[i]['failedReason'],

--- a/test/python/WMCore_t/JobSplitting_t/FileBased_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/FileBased_t.py
@@ -8,6 +8,7 @@ File based splitting test.
 
 
 
+from builtins import range
 import unittest
 
 from WMCore.DataStructs.File import File
@@ -49,7 +50,7 @@ class FileBasedTest(unittest.TestCase):
         self.singleFileFileset = Fileset(name = "TestFileset2")
         newFile = File("/some/file/name", size = 1000, events = 100)
         newFile.setLocation('blenheim')
-        lumis = range(50,60) + range(70,80)
+        lumis = list(range(50,60)) + list(range(70,80))
         newFile.addRun(Run(13, *lumis))
         self.singleFileFileset.addFile(newFile)
 

--- a/test/python/WMCore_t/JobSplitting_t/Harvest_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/Harvest_t.py
@@ -6,6 +6,8 @@ Harvest job splitting test
 
 """
 
+from builtins import str, range
+
 import unittest
 import threading
 import logging
@@ -374,7 +376,7 @@ class HarvestTest(unittest.TestCase):
             self.assertEqual(len(runs), 1, "Job has more than one run configured")
             ll = LumiList(compactList={1: [[1, 1], [3, 7], [2, 2], [8, 8]],
                                        2: [[1, 2], [4, 7], [3, 3], [8, 8]]})
-            run = runs.keys()[0]
+            run = next(iter(runs))
             for lumiPair in runs[run]:
                 for lumi in range(lumiPair[0], lumiPair[1] + 1):
                     self.assertTrue((str(run), lumi) in ll, "All of %s not in %s" % (lumiPair, ll))
@@ -382,7 +384,7 @@ class HarvestTest(unittest.TestCase):
         self.finishJobs(jobGroups, harvestSub)
 
         newFile = File("/some/file/test3", size=1000, events=100)
-        newFile.addRun(Run(1, *range(9, 15)))
+        newFile.addRun(Run(1, *list(range(9, 15))))
         newFile.setLocation('T2_CH_CERN')
         multipleFilesFileset.addFile(newFile)
         multipleFilesFileset.commit()
@@ -398,7 +400,7 @@ class HarvestTest(unittest.TestCase):
             self.assertEqual(len(runs), 1, "Job has more than one run configured")
             ll = LumiList(compactList={1: [[1, 1], [3, 7], [2, 2], [8, 8], [9, 14]],
                                        2: [[1, 2], [4, 7], [3, 3], [8, 8]]})
-            run = runs.keys()[0]
+            run = next(iter(runs))
             for lumiPair in runs[run]:
                 for lumi in range(lumiPair[0], lumiPair[1] + 1):
                     self.assertTrue((run, lumi) in ll, "All of %s not in %s" % (lumiPair, ll))
@@ -433,7 +435,7 @@ class HarvestTest(unittest.TestCase):
             self.assertEqual(len(runs), 1, "Job has more than one run configured")
             ll = LumiList(compactList={1: [[1, 1], [3, 7], [2, 2], [8, 8], [9, 14]],
                                        2: [[1, 2], [4, 7], [3, 3], [8, 8]]})
-            run = runs.keys()[0]
+            run = next(iter(runs))
             for lumiPair in runs[run]:
                 for lumi in range(lumiPair[0], lumiPair[1] + 1):
                     self.assertTrue((run, lumi) in ll, "All of %s not in %s" % (lumiPair, ll))

--- a/test/python/WMCore_t/JobSplitting_t/LumiBased_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/LumiBased_t.py
@@ -6,6 +6,8 @@ Lumi based splitting tests, using the DataStructs classes.
 See WMCore/WMBS/JobSplitting/ for the WMBS (SQL database) version.
 """
 
+from builtins import next, range
+
 import unittest
 
 from WMCore.DataStructs.File import File

--- a/test/python/WMCore_t/WMStats_t/DataStructs_t/DataCache_t.py
+++ b/test/python/WMCore_t/WMStats_t/DataStructs_t/DataCache_t.py
@@ -31,11 +31,11 @@ class DataCacheTests(unittest.TestCase):
 
     def testLatestJobData(self):
         self.assertEqual(20, len(DataCache.getlatestJobData()))
-        self.assertItemsEqual(['time', 'data'], DataCache._lastedActiveDataFromAgent.keys())
+        self.assertItemsEqual(['time', 'data'], list(DataCache._lastedActiveDataFromAgent))
 
         DataCache.setlatestJobData("ALAN")
         self.assertEqual("ALAN", DataCache.getlatestJobData())
-        self.assertItemsEqual(['time', 'data'], DataCache._lastedActiveDataFromAgent.keys())
+        self.assertItemsEqual(['time', 'data'], list(DataCache._lastedActiveDataFromAgent))
 
     def testLatestJobDataExpired(self):
         self.assertFalse(DataCache.islatestJobDataExpired())
@@ -70,7 +70,7 @@ class DataCacheTests(unittest.TestCase):
     def testFilterDataByRequest(self):
         data = list(DataCache.filterDataByRequest(filterDict={}, maskList='RequestType'))
         self.assertEqual(20, len(data))
-        self.assertItemsEqual(['RequestName', 'RequestType'], data[0].keys())
+        self.assertItemsEqual(['RequestName', 'RequestType'], list(data[0]))
         reqTypes = [item['RequestType'] for item in data]
         self.assertItemsEqual(['ReReco', 'MonteCarlo', 'StepChain', 'MonteCarloFromGEN',
                                'ReDigi', 'TaskChain', 'DQMHarvest'], set(list(reqTypes)))


### PR DESCRIPTION
Fixes #10142 


#### Status

Ready 

#### Related PRs

* Previous migration PR: #10329  (slice17, issue #10141 )
* Next migration PR: #10348 (slice19, issue #10143  )

#### Description

Run futurize and some manual changes on the first batch of src/python/A/B/C.

Did not modernize, kept back: likely deprecated
- `src/python/WMQuality/Emulators/PhEDExClient/MockPhEDExApi.py`
- `src/python/WMCore/WMRuntime/DashboardInterface.py`


"Native String" approach
- `src/python/WMCore/JobSplitting/LumiBased.py`: here `str` is used to create dictionary keys. This will likely need to be changed / checked with a python3 env. Tracked #10377 
- `src/python/WMCore/WMBS/Oracle/Fileset/List.py`: `str()` used to format result from db. likely not necessary to change this. Tracked #10399 

`object`:
- `src/python/WMQuality/Emulators/RucioClient/MockRucioApi.py`: did not import `newobject` from future, it broke a ton of unit tests. to be investigated
  - [future/builtins](https://github.com/PythonCharmers/python-future/blob/master/src/future/builtins/__init__.py)
  - [future/types/newobject](https://github.com/PythonCharmers/python-future/blob/master/src/future/types/newobject.py)


Warnings from `pylint --py3k`: they have been taken care of in the code(`round()`->`int(round())`). since pylint continues to warn us, I would consider those 3 warnings about `round` as a false positive

This PR include changes to some `oracle` related files. I run the unit tests on my VM and dit not spot any problem that is not present in master also. I would categorize these changes as "work in my VM".

#### Is it backward compatible (if not, which system it affects?)

It should be. (Any possible cause for errors will we reported here)

#### External dependencies / deployment changes

Requires python-future in both py2 and py3 environments.
