### PR TITLE
allow to run REST/Main in frontend via env.var. fix #10266

### DIFF
--- a/src/python/WMCore/REST/Main.py
+++ b/src/python/WMCore/REST/Main.py
@@ -387,41 +387,48 @@ class RESTDaemon(RESTMain):
 
     def start_daemon(self):
         """Start the deamon."""
+        # This REST server can be run in the frontend i.e. interactively (e.g. to use pdb)
+        # by setting an env. var. via: export DONT_DAEMONIZE_REST=True
+        # if the variable is missing or set to any other value, code starts normally as a daemon
+        daemonize = os.getenv('DONT_DAEMONIZE_REST', 'False') != 'True'
 
-        # Redirect all output to the logging daemon.
-        devnull = open(os.devnull, "w")
-        if isinstance(self.logfile, list):
-            subproc = Popen(self.logfile, stdin=PIPE, stdout=devnull, stderr=devnull,
-                            bufsize=0, close_fds=True, shell=False)
-            logger = subproc.stdin
-        elif isinstance(self.logfile, str):
-            logger = open(self.logfile, "a+", 0)
-        else:
-            raise TypeError("'logfile' must be a string or array")
-        os.dup2(logger.fileno(), sys.stdout.fileno())
-        os.dup2(logger.fileno(), sys.stderr.fileno())
-        os.dup2(devnull.fileno(), sys.stdin.fileno())
-        logger.close()
-        devnull.close()
-
-        # First fork. Discard the parent.
-        pid = os.fork()
-        if pid > 0:
-            os._exit(0)
-
-        # Establish as a daemon, set process group / session id.
         os.chdir(self.statedir)
-        os.setsid()
 
-        # Second fork. The child does the work, discard the second parent.
-        pid = os.fork()
-        if pid > 0:
-            os._exit(0)
+        if daemonize:
+            # Redirect all output to the logging daemon.
+            devnull = open(os.devnull, "w")
+            if isinstance(self.logfile, list):
+                subproc = Popen(self.logfile, stdin=PIPE, stdout=devnull, stderr=devnull,
+                                bufsize=0, close_fds=True, shell=False)
+                logger = subproc.stdin
+            elif isinstance(self.logfile, str):
+                logger = open(self.logfile, "a+", 0)
+            else:
+                raise TypeError("'logfile' must be a string or array")
+            os.dup2(logger.fileno(), sys.stdout.fileno())
+            os.dup2(logger.fileno(), sys.stderr.fileno())
+            os.dup2(devnull.fileno(), sys.stdin.fileno())
+            logger.close()
+            devnull.close()
 
-        # Save process group id to pid file, then run real worker.
-        with open(self.pidfile, "w") as pidObj:
-            pidObj.write("%d\n" % os.getpgid(0))
+            # First fork. Discard the parent.
+            pid = os.fork()
+            if pid > 0:
+                os._exit(0)
 
+            # Establish as a daemon, set process group / session id.
+            os.setsid()
+
+            # Second fork. The child does the work, discard the second parent.
+            pid = os.fork()
+            if pid > 0:
+                os._exit(0)
+
+            # Save process group id to pid file, then run real worker.
+            with open(self.pidfile, "w") as pidObj:
+                pidObj.write("%d\n" % os.getpgid(0))
+
+        # following code is executed both in daemon and not daemon mode
         error = False
         try:
             self.run()
@@ -449,34 +456,36 @@ class RESTDaemon(RESTMain):
         # to run the server proper.  The parent monitors the child, and if
         # it exits abnormally, restarts it, otherwise exits completely with
         # the child's exit code.
-        cherrypy.log("WATCHDOG: starting server daemon (pid %d)" % os.getpid())
-        while True:
-            serverpid = os.fork()
-            if not serverpid: break
-            signal.signal(signal.SIGINT, signal.SIG_IGN)
-            signal.signal(signal.SIGTERM, signal.SIG_IGN)
-            signal.signal(signal.SIGQUIT, signal.SIG_IGN)
-            (xpid, exitrc) = os.waitpid(serverpid, 0)
-            (exitcode, exitsigno, exitcore) = (exitrc >> 8, exitrc & 127, exitrc & 128)
-            retval = (exitsigno and ("signal %d" % exitsigno)) or str(exitcode)
-            retmsg = retval + ((exitcore and " (core dumped)") or "")
-            restart = (exitsigno > 0 and exitsigno not in (2, 3, 15))
-            cherrypy.log("WATCHDOG: server exited with exit code %s%s"
-                         % (retmsg, (restart and "... restarting") or ""))
+        daemonize = os.getenv('DONT_DAEMONIZE_REST', 'False') != 'True'
+        if daemonize:
+            cherrypy.log("WATCHDOG: starting server daemon (pid %d)" % os.getpid())
+            while True:
+                serverpid = os.fork()
+                if not serverpid: break
+                signal.signal(signal.SIGINT, signal.SIG_IGN)
+                signal.signal(signal.SIGTERM, signal.SIG_IGN)
+                signal.signal(signal.SIGQUIT, signal.SIG_IGN)
+                (xpid, exitrc) = os.waitpid(serverpid, 0)
+                (exitcode, exitsigno, exitcore) = (exitrc >> 8, exitrc & 127, exitrc & 128)
+                retval = (exitsigno and ("signal %d" % exitsigno)) or str(exitcode)
+                retmsg = retval + ((exitcore and " (core dumped)") or "")
+                restart = (exitsigno > 0 and exitsigno not in (2, 3, 15))
+                cherrypy.log("WATCHDOG: server exited with exit code %s%s"
+                             % (retmsg, (restart and "... restarting") or ""))
 
-            if not restart:
-                sys.exit((exitsigno and 1) or exitcode)
+                if not restart:
+                    sys.exit((exitsigno and 1) or exitcode)
 
-            for pidfile in glob("%s/*/*pid" % self.statedir):
-                if os.path.exists(pidfile):
-                    with open(pidfile) as fd:
-                        pid = int(fd.readline())
-                    os.remove(pidfile)
-                    cherrypy.log("WATCHDOG: killing slave server %d" % pid)
-                    try:
-                        os.kill(pid, 9)
-                    except:
-                        pass
+                for pidfile in glob("%s/*/*pid" % self.statedir):
+                    if os.path.exists(pidfile):
+                        with open(pidfile) as fd:
+                            pid = int(fd.readline())
+                        os.remove(pidfile)
+                        cherrypy.log("WATCHDOG: killing slave server %d" % pid)
+                        try:
+                            os.kill(pid, 9)
+                        except:
+                            pass
 
         # Run. Override signal handlers after CherryPy has itself started and
         # installed its own handlers. To achieve this we need to start the


### PR DESCRIPTION
Fixes #10266

#### Status
Ready. Tested and in use by Stefano for CRABServer debugging

#### Description
when the enviromental variable DONT_DAEMONIZE_REST is set and equal to "True" the REST will run in foreground with output to console. Otherwise it behaves exactly like now.

#### Is it backward compatible (if not, which system it affects?)
YES