### PR TITLE
Necessary changes  to allow T0 to use T0 storage with T2 CPUs

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
@@ -60,6 +60,7 @@ class LogCollect(Executor):
         scramCommand = self.step.application.setup.scramCommand
         cmsswVersion = self.step.application.setup.cmsswVersion
         scramArch = getSingleScramArch(self.step.application.setup.scramArch)
+        overrideCatalog = getattr(self.step.application, 'overrideCatalog', None)
 
         overrides = {}
         if hasattr(self.step, 'override'):
@@ -158,6 +159,11 @@ class LogCollect(Executor):
         for logs in grouper(self.job["input_files"], numberOfFilesPerCopy):
 
             copyCommand = "env X509_USER_PROXY=%s edmCopyUtil" % os.environ.get('X509_USER_PROXY', None)
+
+            # specify TFC if necessary
+            if overrideCatalog:
+                copyCommand += " -c %s" % overrideCatalog
+
             for log in logs:
                 copyCommand += " %s" % log['lfn']
             copyCommand += " %s" % self.step.builder.workingDir

--- a/src/python/WMCore/WMSpec/Steps/Template.py
+++ b/src/python/WMCore/WMSpec/Steps/Template.py
@@ -62,6 +62,21 @@ class CoreHelper(WMStepHelper):
         """
         return self.data.environment
 
+    def setOverrideCatalog(self, overrideCatalog):
+        """
+        _setOverrideCatalog_
+        set the override catalog needed at least at CERN to use production castor pools
+        """
+        if overrideCatalog is not None:
+            self.data.application.overrideCatalog = overrideCatalog
+
+    def getOverrideCatalog(self):
+        """
+        _getOverrideCatalog_
+        return the TFC specified in overrideCatalog.
+        """
+        return getattr(self.data.application, "overrideCatalog", None)
+
     def addDirectory(self, dirName):
         """
         _addDirectory_

--- a/src/python/WMCore/WMSpec/Steps/Templates/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Templates/CMSSW.py
@@ -341,18 +341,6 @@ class CMSSWStepHelper(CoreHelper):
             setattr(getattr(self.data.pileup, pileupType), "dataset", dataset)
         setattr(self.data, "dbsUrl", dbsUrl)
 
-    def setOverrideCatalog(self, overrideCatalog):
-        """
-        _setOverrideCatalog_
-
-        set the override catalog
-
-        needed at least at CERN to use production castor pools
-
-        """
-        if overrideCatalog != None:
-            self.data.application.overrideCatalog = overrideCatalog
-
     def setEventsPerLumi(self, eventsPerLumi):
         """
         _setEventsPerLumi_

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -26,6 +26,7 @@ from WMCore.Lexicon import lfnBase
 from WMCore.WMSpec.ConfigSectionTree import ConfigSectionTree, TreeHelper
 from WMCore.WMSpec.Steps.BuildMaster import BuildMaster
 from WMCore.WMSpec.Steps.ExecuteMaster import ExecuteMaster
+from WMCore.WMSpec.Steps.Template import CoreHelper
 from WMCore.WMSpec.WMStep import WMStep, WMStepHelper
 
 
@@ -330,6 +331,40 @@ class WMTaskHelper(TreeHelper):
         master = BuildMaster(workingDir)
         master(self)
         return
+
+    def addEnvironmentVariables(self, envDict):
+        """
+        _addEnvironmentVariables_
+
+        add a key = value style setting to the environment for this task and all
+        its children
+        """
+        for key, value in viewitems(envDict):
+            setattr(self.data.environment, key, value)
+        for task in self.childTaskIterator():
+            task.addEnvironmentVariables(envDict)
+        return
+
+    def setOverrideCatalog(self, tfcFile):
+        """
+        _setOverrideCatalog_
+
+        Used for setting overrideCatalog option for each step in the task.
+        """
+        for step in self.steps().nodeIterator():
+            step = CoreHelper(step)
+            step.setOverrideCatalog(tfcFile)
+        for task in self.childTaskIterator():
+            task.setOverrideCatalog(tfcFile)
+        return
+
+    def getEnvironmentVariables(self):
+        """
+        _getEnvironmentVariables_
+
+        Retrieve a dictionary with all environment variables defined for this task
+        """
+        return self.data.environment.dictionary_()
 
     def setupEnvironment(self):
         """
@@ -1792,6 +1827,7 @@ class WMTask(ConfigSectionTree):
         self.section_("input")
         self.section_("notifications")
         self.section_("subscriptions")
+        self.section_("environment")
         self.notifications.targets = []
         self.input.sandbox = None
         self.input.section_("splitting")

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -126,6 +126,29 @@ class WMWorkloadHelper(PersistencyHelper):
 
         return
 
+    def setTaskEnvironmentVariables(self, envDict):
+        """
+        _setTaskEnvironmentVariables_
+
+        Used for setting environment variables for each task in a request.
+        """
+        if not isinstance(envDict, dict):
+            return
+
+        for task in self.taskIterator():
+            task.addEnvironmentVariables(envDict)
+        return
+
+    def setOverrideCatalog(self, tfcFile):
+        """
+        _setOverrideCatalog_
+
+        Used for setting overrideCatalog option for each step in the workload.
+        """
+        for task in self.taskIterator():
+            task.setOverrideCatalog(tfcFile)
+        return
+
     def setStepMapping(self, mapping):
         """
         _setStepMapping_

--- a/test/python/WMCore_t/WMSpec_t/WMTask_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMTask_t.py
@@ -108,6 +108,46 @@ class WMTaskTest(unittest.TestCase):
         self.assertEqual(task1.listNodes(), ['task1', 'task2a', 'task3', 'task2b', 'task2c'])
         return
 
+    def testAddEnvironmentVariables(self):
+        """
+        _testAddEnvironmentVariables_
+        Verify that methods for setting and retrieving task environment variables.
+        """
+        testTask = makeWMTask("TestTask")
+        testDict = {
+            "VAR0":"Value0",
+            "VAR1":"Value1",
+            "VAR2":"Value2",
+            "VAR3":"Value3",
+            }
+
+        testTask.addEnvironmentVariables(testDict)
+        retrievedDict = testTask.getEnvironmentVariables()
+
+        self.assertEqual(retrievedDict, testDict,
+                "Error: Env variables dict doesn't match with test dict")
+
+        return
+
+    def testSetOverrideCatalog(self):
+        """
+        _testSetStepOverrideCatalog_
+
+        Verify methods for setting and retrieving overrideCatalog option.
+        """
+        testTask = makeWMTask("TestTask")
+        testTask = makeWMTask("MultiTask")
+
+        taskCmssw = testTask.makeStep("cmsRun1")
+        taskCmssw.setStepType("CMSSW")
+
+        testCatalog = "trivialcatalog_file:/test/catalog/file.xml?protocol=eos"
+        testTask.setOverrideCatalog(testCatalog)
+
+        self.assertEqual(taskCmssw.getTypeHelper().getOverrideCatalog(),testCatalog,
+                        "Error: Wrong overrideCatalog value for step taskCmssw")
+        return
+
     def testSiteWhiteBlacklists(self):
         """
         _testSiteWhiteBlacklists_

--- a/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
@@ -429,6 +429,54 @@ class WMWorkloadTest(unittest.TestCase):
 
         return
 
+    def testAddEnvironmentVariables(self):
+        """
+        _testAddEnvironmentVariables_
+
+        Verify that the setTaskEnvironmentVariables() method updates the environment 
+        for all tasks.
+        """
+        workload = WMWorkloadHelper(WMWorkload("workload1"))
+        testDict = {
+            "VAR0":"Value0"
+            }
+        workload.newTask("task1")
+        workload.newTask("task2")
+        workload.newTask("task3")
+        workload.newTask("task4")
+
+        workload.setTaskEnvironmentVariables(testDict)
+
+        for task in workload.getAllTasks():
+            taskDict = task.getEnvironmentVariables()
+            self.assertEqual(testDict,taskDict,
+                         "Error: Task dictionary should be the same as test dictionary.")
+        return
+
+    def testSetStepOverrideCatalog(self):
+        """
+        _testSetStepOverrideCatalog_
+
+        Verify that the setStepOverrideCatalog() method sets the TFC for  
+        all steps.
+        """
+        (testWorkload, procTaskCMSSWHelper,
+         mergeTaskCMSSWHelper, skimTaskCMSSWHelper,
+         harvestTaskCMSSWHelper) = self.makeTestWorkload()
+        testCatalog = "trivialcatalog_file:/test/catalog/file.xml?protocol=eos"
+        testWorkload.setOverrideCatalog(testCatalog)
+
+        self.assertEqual(procTaskCMSSWHelper.getOverrideCatalog(),testCatalog,
+                        "Error: Wrong overrideCatalog value for step procTaskCMSSWHelper")
+        self.assertEqual(mergeTaskCMSSWHelper.getOverrideCatalog(),testCatalog,
+                        "Error: Wrong overrideCatalog value for step mergeTaskCMSSWHelper")
+        self.assertEqual(skimTaskCMSSWHelper.getOverrideCatalog(),testCatalog,
+                        "Error: Wrong overrideCatalog value for step skimTaskCMSSWHelper")
+        self.assertEqual(harvestTaskCMSSWHelper.getOverrideCatalog(),testCatalog,
+                        "Error: Wrong overrideCatalog value for step harvestTaskCMSSWHelper")
+
+        return
+
     def testUpdatingMergeParameters(self):
         """
         _testUpdatingMergeParameters_


### PR DESCRIPTION
Fixes #10460 

#### Status
Tested wtih T0 Replay

#### Description
Set of changes necessary to allow T0 to used dedicated storage T0_CH_CERN, while using T2 computational resources. changes are:
- Add environment  section to WMTask and addEnvironmentVariable() to WMTaskHelper
--  Allows to specify environment variables to be load in worker node.
- Add setTaskEnvironmentVariables() to WMWorkload
-- Adds a method to WMWorkloadHelper that allows to set environment variables for every task in the workload. Environment variables must be provided as a dictionary.
- Add setStepCatalogOverride to WMWorkload
-- Adds a method to WMWorkloadHelper that allows to set `overrideCatalog` option for every step in the workload
- Add support for the overrideCatalog in LogCollect Tasks
-- If LogCollect is using `overrideCatalog`, then add the `--catalog` to the `edmCopyUtil` command

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
T0 PR making use of this changes: [T04566]( https://github.com/dmwm/T0/pull/4566)
JIRA ticket: https://its.cern.ch/jira/browse/CMSTZ-898

#### External dependencies / deployment changes
No
