### PR TITLE
Switch microservices to use AlertManager

### DIFF
--- a/src/python/Utils/EmailAlert.py
+++ b/src/python/Utils/EmailAlert.py
@@ -1,5 +1,9 @@
 """
 EmailAlert - send alerts via email
+
+NOTICE:
+This class does not work from kubernetes pods. The AlertManagerAPI class should be used for alerting from k8s.
+More details at: https://github.com/dmwm/WMCore/issues/10234
 """
 
 from __future__ import division

--- a/src/python/WMCore/MicroService/Unified/MSRuleCleaner.py
+++ b/src/python/WMCore/MicroService/Unified/MSRuleCleaner.py
@@ -30,7 +30,6 @@ from WMCore.MicroService.Unified.Common import ckey, cert
 from WMCore.Services.pycurl_manager import RequestHandler
 from WMCore.Services.Rucio.Rucio import WMRucioDIDNotFoundException
 from WMCore.ReqMgr.DataStructs import RequestStatus
-from Utils.EmailAlert import EmailAlert
 from Utils.Pipeline import Pipeline, Functor
 from WMCore.WMException import WMException
 from WMCore.Services.LogDB.LogDB import LogDB
@@ -86,7 +85,6 @@ class MSRuleCleaner(MSCore):
         self.msConfig.setdefault('enableRealMode', False)
 
         self.mode = "RealMode" if self.msConfig['enableRealMode'] else "DryRunMode"
-        self.emailAlert = EmailAlert(self.msConfig)
         self.curlMgr = RequestHandler()
         self.targetStatusRegex = re.compile(r'.*archived')
         self.logDB = LogDB(self.msConfig["logDBUrl"],


### PR DESCRIPTION
Fixes #10341

#### Status
Not tested

#### Description
This PR switches alerts sent from microservices (ms-output, ms-transferor, ms-rulecleaner) from email to AlertManager

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Requires this PR to be merged as well: #10308 

#### External dependencies / deployment changes
Each MS service configuration in k8s (services_config) needs to have the alertmanager URL added to the config
Also need CMSWEB team to set up proper routes for the alert labels we use