### PR TITLE
[py2py3] Migration at level scr/python/A/B/C - slice 19

### DIFF
--- a/src/python/WMComponent/AgentStatusWatcher/DrainStatusPoller.py
+++ b/src/python/WMComponent/AgentStatusWatcher/DrainStatusPoller.py
@@ -5,6 +5,8 @@ to be shutdown and a new version be put in place.
 """
 from __future__ import division
 
+from future.utils import viewitems
+
 __all__ = []
 
 import logging
@@ -155,7 +157,7 @@ class DrainStatusPoller(BaseWorkerThread):
         if self.agentConfig.get("SpeedDrainMode"):
             self.agentConfig['SpeedDrainMode'] = False
             speedDrainConfig = self.agentConfig.get("SpeedDrainConfig")
-            for key, v in speedDrainConfig.items():
+            for key, v in viewitems(speedDrainConfig):
                 if key in self.validSpeedDrainConfigKeys and v['Enabled']:
                     speedDrainConfig[key]['Enabled'] = False
 
@@ -179,7 +181,7 @@ class DrainStatusPoller(BaseWorkerThread):
             return []
 
         # loop through the speed drain configuration and make a list of what thresholds have been hit
-        for k, v in speedDrainConfig.items():
+        for k, v in viewitems(speedDrainConfig):
             # make sure keys in the speed drain config are valid
             if k in self.validSpeedDrainConfigKeys and isinstance(v['Threshold'], int) and isinstance(v['Enabled'], bool):
                 # we always want to apply the condor priority change if the threshold is hit

--- a/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
+++ b/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
@@ -1,6 +1,8 @@
 """
 Perform cleanup actions
 """
+from __future__ import division
+
 __all__ = []
 
 import logging
@@ -201,8 +203,8 @@ class ResourceControlUpdater(BaseWorkerThread):
         for site in set(infoRC).intersection(set(infoSSB)):
             if self.tier0Mode and site.startswith('T1_'):
                 # T1 cores utilization for Tier0
-                infoSSB[site]['slotsCPU'] *= self.t1SitesCores / 100
-                infoSSB[site]['slotsIO'] *= self.t1SitesCores / 100
+                infoSSB[site]['slotsCPU'] *= self.t1SitesCores // 100
+                infoSSB[site]['slotsIO'] *= self.t1SitesCores // 100
             else:
                 # round very small sites to the bare minimum
                 infoSSB[site]['slotsCPU'] = max(infoSSB[site]['slotsCPU'], self.minCPUSlots)

--- a/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
@@ -24,6 +24,8 @@ that is not in DBS, decide whether its components are in DBS,
 add them, and then add the files.  This is why everything is
 so convoluted.
 """
+from builtins import range
+from future.utils import viewvalues
 from future import standard_library
 standard_library.install_aliases()
 
@@ -445,7 +447,7 @@ class DBSUploadPoller(BaseWorkerThread):
             fileDict = sortListByKey(loadedFiles, 'locations')
 
             # Now add each file
-            for location in fileDict.keys():
+            for location in fileDict:
 
                 files = fileDict.get(location)
 
@@ -492,7 +494,7 @@ class DBSUploadPoller(BaseWorkerThread):
         Mark Open blocks as Pending if they have timed out or their workflows have completed
         """
         completedWorkflows = self.dbsUtil.getCompletedWorkflows()
-        for block in self.blockCache.values():
+        for block in viewvalues(self.blockCache):
             if block.status == "Open":
                 if (block.getTime() > block.getMaxBlockTime()) or any(
                         key in completedWorkflows for key in block.workflows):
@@ -539,7 +541,7 @@ class DBSUploadPoller(BaseWorkerThread):
         """
         datasetpath = newFile["datasetPath"]
 
-        for block in self.blockCache.values():
+        for block in viewvalues(self.blockCache):
             if datasetpath == block.getDatasetPath() and location == block.getLocation():
                 if not self.isBlockOpen(newFile=newFile, block=block) and not skipOpenCheck:
                     # Block isn't open anymore.  Mark it as pending so that it gets uploaded.
@@ -587,7 +589,7 @@ class DBSUploadPoller(BaseWorkerThread):
         createInDBS = []
         createInDBSBuffer = []
         updateInDBSBuffer = []
-        for block in self.blockCache.values():
+        for block in viewvalues(self.blockCache):
             if block.getName() in self.queuedBlocks:
                 # Block is already being dealt with by another process.  We'll
                 # ignore it here.

--- a/src/python/WMComponent/JobArchiver/JobArchiverPoller.py
+++ b/src/python/WMComponent/JobArchiver/JobArchiverPoller.py
@@ -2,6 +2,8 @@
 """
 The actual jobArchiver algorithm
 """
+from __future__ import division
+
 import logging
 import os
 import os.path

--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -8,6 +8,8 @@ _JobSubmitterPoller_t_
 Submit jobs for execution.
 """
 from __future__ import print_function, division
+from builtins import range
+from future.utils import viewitems
 
 import logging
 import os.path
@@ -206,7 +208,7 @@ class JobSubmitterPoller(BaseWorkerThread):
         jobPackage[loadedJob["id"]] = loadedJob.getDataStructsJob()
         batchDir = jobPackage['directory']
 
-        if len(jobPackage.keys()) == self.packageSize:
+        if len(jobPackage) == self.packageSize:
             if not os.path.exists(batchDir):
                 os.makedirs(batchDir)
 
@@ -222,7 +224,7 @@ class JobSubmitterPoller(BaseWorkerThread):
 
         Write any jobs packages to disk that haven't been written out already.
         """
-        workflowNames = self.jobsToPackage.keys()
+        workflowNames = list(self.jobsToPackage)
         for workflowName in workflowNames:
             jobPackage = self.jobsToPackage[workflowName]["package"]
             batchDir = jobPackage['directory']
@@ -452,7 +454,7 @@ class JobSubmitterPoller(BaseWorkerThread):
     def removeAbortedForceCompletedWorkflowFromCache(self):
         abortedAndForceCompleteRequests = self.abortedAndForceCompleteWorkflowCache.getData()
         jobIDsToPurge = set()
-        for jobID, jobInfo in self.jobDataCache.iteritems():
+        for jobID, jobInfo in viewitems(self.jobDataCache):
             if (jobInfo['request_name'] in abortedAndForceCompleteRequests) and \
                     (jobInfo['task_type'] not in ['LogCollect', "Cleanup"]):
                 jobIDsToPurge.add(jobID)
@@ -529,7 +531,7 @@ class JobSubmitterPoller(BaseWorkerThread):
 
         rcThresholds = self.resourceControl.listThresholdsForSubmit()
 
-        for siteName in rcThresholds.keys():
+        for siteName in rcThresholds:
             # Add threshold if we don't have it already
             state = rcThresholds[siteName]["state"]
 
@@ -736,7 +738,7 @@ class JobSubmitterPoller(BaseWorkerThread):
             logging.debug("There are no packages to submit.")
             return
 
-        for package in jobsToSubmit.keys():
+        for package in jobsToSubmit:
             jobs = jobsToSubmit.get(package, [])
             for job in jobs:
                 job['location'], job['plugin'], job['site_cms_name'] = self.getSiteInfo(job['custom']['location'])
@@ -774,7 +776,7 @@ class JobSubmitterPoller(BaseWorkerThread):
         This is how you get the name of a CE and the plugin for a job
         """
 
-        if jobSite not in self.locationDict.keys():
+        if jobSite not in self.locationDict:
             siteInfo = self.locationAction.execute(siteName=jobSite)
             self.locationDict[jobSite] = siteInfo[0]
         return (self.locationDict[jobSite].get('ce_name'),

--- a/src/python/WMCore/WMRuntime/TaskSpace.py
+++ b/src/python/WMCore/WMRuntime/TaskSpace.py
@@ -8,6 +8,7 @@ Runtime utils for a Task
 
 """
 
+from builtins import object
 import os
 import sys
 import inspect
@@ -31,7 +32,7 @@ def preloadWorkload(x):
         return x(self)
     return wrapper
 
-class TaskSpace:
+class TaskSpace(object):
     """
     _TaskSpace_
 
@@ -118,7 +119,7 @@ class TaskSpace:
 
         """
         modName = "WMTaskSpace.%s" % stepName
-        if modName in sys.modules.keys():
+        if modName in sys.modules:
             space = sys.modules[modName]
         else:
             try:


### PR DESCRIPTION
Fixes #10143 

#### Status
In development 

#### Related PRs

* Previous migration PR: #10331  (slice18, issue #10142 )
* Next migration PR: #10349 (slice20, issue #10144  )

#### Description

Run futurize and some manual changes on the first batch of src/python/A/B/C.

No need to change `test/python` in this slice!

Did not modernize, kept back: likely deprecated:
- `src/python/WMCore/WMSpec/DashboardInterface.py`
- `src/python/WMComponent/PhEDExInjector/PhEDExInjectorPoller.py`

"Ntive String" approach
- `src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py`: `str()` used to format argument in `wmcoreStatus = self.getState(str(ssbStatus))`. This will very likely not require any change. 
- `src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py`: here `str()` is used to look for known string patterns in a `str(ex)` message in `isPassiveError(exception)`. If we do not change where this function is called, we will not have troubles!

Division
- `src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py`: this may be impacted by new division. I tried to be as transparent as possible, but some checks may be necessary. Tracked in #10397 
- `src/python/WMComponent/JobArchiver/JobArchiverPoller.py`: same as file above. Tracked in #10397 


#### Is it backward compatible (if not, which system it affects?)

It should be. (Any possible cause for errors will we reported here)

#### External dependencies / deployment changes

Requires python-future in both py2 and py3 environments.
