### PR TITLE
Add py3-cmsmonitoring to the list of python3 requirements

### DIFF
--- a/requirements_py3.txt
+++ b/requirements_py3.txt
@@ -29,3 +29,4 @@ pylint==2.6.0
 pymongo==3.10.1
 retry==0.9.2
 sphinx==1.6.3
+CMSMonitoring==0.3.4


### PR DESCRIPTION
Fixes #10305

#### Status
ready

#### Description
I just noticed our list of python3 packages didn't have the py3-cmsmonitoring dependency, so here it goes.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Complement to: https://github.com/cms-sw/cmsdist/pull/6714

#### External dependencies / deployment changes
none
