### PR TITLE
[py2py3] Migration at level scr/python/A/B/C - slice 22

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/DataProcessing.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/DataProcessing.py
@@ -4,6 +4,8 @@ _DataProcessing_
 
 Base module for workflows with input.
 """
+from __future__ import division
+
 from Utils.Utilities import makeList
 from WMCore.Lexicon import dataset, block, primdataset
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase

--- a/src/python/WMCore/WMSpec/StdSpecs/Express.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Express.py
@@ -13,6 +13,8 @@ express processing -> FEVT/RAW/RECO/whatever -> express merge
 
 from __future__ import division
 
+from future.utils import viewitems
+
 import WMCore.WMSpec.Steps.StepFactory as StepFactory
 from Utils.Utilities import makeList, makeNonEmptyList
 from WMCore.Lexicon import procstringT0
@@ -106,7 +108,7 @@ class ExpressWorkloadFactory(StdBase):
                                                          forceUnmerged=True)
 
             # there is only one
-            conversionOutLabel = conversionOutMods.keys()[0]
+            conversionOutLabel = next(iter(conversionOutMods))
 
             # everything coming after should use the reco CMSSW version and Scram Arch
             self.frameworkVersion = self.recoFrameworkVersion
@@ -145,7 +147,7 @@ class ExpressWorkloadFactory(StdBase):
             configOutput = self.determineOutputModules(scenarioFunc, scenarioArgs)
 
             expressOutMods = {}
-            for outputModuleName in configOutput.keys():
+            for outputModuleName in configOutput:
                 outputModule = self.addOutputModule(expressTask,
                                                     outputModuleName,
                                                     configOutput[outputModuleName]['primaryDataset'],
@@ -169,7 +171,7 @@ class ExpressWorkloadFactory(StdBase):
 
         self.addLogCollectTask(expressTask, taskName="ExpressLogCollect")
 
-        for expressOutLabel, expressOutInfo in expressOutMods.items():
+        for expressOutLabel, expressOutInfo in viewitems(expressOutMods):
 
             if expressOutInfo['dataTier'] == "ALCARECO":
 
@@ -209,7 +211,7 @@ class ExpressWorkloadFactory(StdBase):
                 self.addLogCollectTask(alcaSkimTask, taskName="AlcaSkimLogCollect")
                 self.addCleanupTask(expressTask, expressOutLabel, dataTier=expressOutInfo['dataTier'])
 
-                for alcaSkimOutLabel, alcaSkimOutInfo in alcaSkimOutMods.items():
+                for alcaSkimOutLabel, alcaSkimOutInfo in viewitems(alcaSkimOutMods):
 
                     if alcaSkimOutInfo['dataTier'] == "ALCAPROMPT" and \
                             (self.alcaHarvestCondLFNBase is not None or self.alcaHarvestLumiURL is not None):

--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -4,6 +4,8 @@ _PromptReco_
 
 Standard PromptReco workflow.
 """
+from __future__ import division
+from future.utils import viewitems
 
 from Utils.Utilities import makeList, strToBool
 from WMCore.Lexicon import procstringT0
@@ -76,7 +78,7 @@ class PromptRecoWorkloadFactory(DataProcessing):
             self.addLogCollectTask(recoTask)
 
         recoMergeTasks = {}
-        for recoOutLabel, recoOutInfo in recoOutMods.items():
+        for recoOutLabel, recoOutInfo in viewitems(recoOutMods):
             if recoOutInfo['dataTier'] != "ALCARECO":
                 mergeTask = self.addMergeTask(recoTask, self.procJobSplitAlgo, recoOutLabel,
                                               doLogCollect=self.doLogCollect)

--- a/src/python/WMCore/WMSpec/StdSpecs/ReReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/ReReco.py
@@ -4,6 +4,9 @@ _ReReco_
 
 Standard ReReco workflow.
 """
+from __future__ import division
+from future.utils import viewitems
+
 from Utils.Utilities import makeList
 from WMCore.WMSpec.StdSpecs.DataProcessing import DataProcessing
 from WMCore.WMSpec.WMWorkloadTools import validateArgumentsCreate
@@ -232,13 +235,13 @@ class ReRecoWorkloadFactory(DataProcessing):
         Check for required fields, and some skim facts
         """
         DataProcessing.validateSchema(self, schema)
-        mainOutputModules = self.validateConfigCacheExists(configID=schema["ConfigCacheID"],
+        mainOutputModules = list(self.validateConfigCacheExists(configID=schema["ConfigCacheID"],
                                                            configCacheUrl=schema['ConfigCacheUrl'],
                                                            couchDBName=schema["CouchDBName"],
-                                                           getOutputModules=True).keys()
+                                                           getOutputModules=True))
 
         # Skim facts have to be validated outside the usual master validation
-        skimSchema = {k: v for (k, v) in schema.iteritems() if k.startswith("Skim")}
+        skimSchema = {k: v for (k, v) in viewitems(schema) if k.startswith("Skim")}
         skimArguments = self.getSkimArguments()
         skimIndex = 1
         skimInputs = set()

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -5,6 +5,9 @@ _StdBase_
 Base class with helper functions for standard WMSpec files.
 """
 from __future__ import division
+from future.utils import viewitems
+from builtins import range, object
+
 import logging
 
 from Utils.Utilities import makeList, makeNonEmptyList, strToBool, safeStr
@@ -332,7 +335,7 @@ class StdBase(object):
         procTask.setTaskLogBaseLFN(self.unmergedLFNBase)
 
         newSplitArgs = {}
-        for argName in splitArgs.keys():
+        for argName in splitArgs:
             newSplitArgs[str(argName)] = splitArgs[argName]
 
         procTask.setSplittingAlgorithm(splitAlgo, **newSplitArgs)
@@ -425,7 +428,7 @@ class StdBase(object):
                                                    configDoc, couchDBName,
                                                    configCacheUrl, cmsswVersion)
         outputModules = {}
-        for outputModuleName in configOutput.keys():
+        for outputModuleName in configOutput:
             outputModule = self.addOutputModule(procTask,
                                                 outputModuleName,
                                                 configOutput[outputModuleName].get('primaryDataset',
@@ -826,7 +829,7 @@ class StdBase(object):
         pileupConfig has the following data structure:
             {'mc': ['/mc_pd/procds/tier'], 'data': ['/data_pd/procds/tier']}
         """
-        for puType, puList in pileupConfig.items():
+        for puType, puList in viewitems(pileupConfig):
             task.setInputPileupDatasets(puList)
 
         if stepName:

--- a/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
@@ -13,6 +13,10 @@ It also assumes all the intermediate steps output are transient and do not need
 to be staged out and registered in DBS/PhEDEx. Only the last step output will be
 made available.
 """
+from __future__ import division
+from future.utils import viewitems
+from builtins import range
+
 from Utils.Utilities import strToBool
 import WMCore.WMSpec.Steps.StepFactory as StepFactory
 from WMCore.Lexicon import primdataset, taskStepName
@@ -69,7 +73,7 @@ class StepChainWorkloadFactory(StdBase):
 
         # Update the task configuration
         taskConf = {}
-        for k, v in arguments["Step1"].iteritems():
+        for k, v in viewitems(arguments["Step1"]):
             taskConf[k] = v
         self.modifyTaskConfiguration(taskConf, True, 'InputDataset' not in taskConf)
 
@@ -285,7 +289,7 @@ class StepChainWorkloadFactory(StdBase):
             currentStepNumber = "Step%d" % i
             currentCmsRun = "cmsRun%d" % i
             taskConf = {}
-            for k, v in origArgs[currentStepNumber].items():
+            for k, v in viewitems(origArgs[currentStepNumber]):
                 taskConf[k] = v
 
             parentStepNumber = self.stepMapping.get(taskConf['InputStep'])[0]
@@ -364,7 +368,7 @@ class StepChainWorkloadFactory(StdBase):
         configOutput = self.determineOutputModules(configDoc=taskConf["ConfigCacheID"],
                                                    configCacheUrl=self.configCacheUrl,
                                                    couchDBName=self.couchDBName)
-        for outputModuleName in configOutput.keys():
+        for outputModuleName in configOutput:
             outputModule = self.addOutputModule(task, outputModuleName,
                                                 self.inputPrimaryDataset,
                                                 configOutput[outputModuleName]["dataTier"],
@@ -389,7 +393,7 @@ class StepChainWorkloadFactory(StdBase):
         if not taskConf.get('PrepID'):
             taskConf['PrepID'] = self.prepID
 
-        for outputModuleName in outputMods.keys():
+        for outputModuleName in outputMods:
             dummyTask = self.addMergeTask(task, self.splittingAlgo, outputModuleName, stepCmsRun,
                                           cmsswVersion=frameworkVersion, scramArch=scramArch,
                                           forceTaskName=taskConf.get('StepName'), taskConf=taskConf)
@@ -571,7 +575,7 @@ class StepChainWorkloadFactory(StdBase):
                 configOutput = self.determineOutputModules(configDoc=step["ConfigCacheID"],
                                                            configCacheUrl=schema['ConfigCacheUrl'],
                                                            couchDBName=schema["CouchDBName"])
-                for modName, values in configOutput.items():
+                for modName, values in viewitems(configOutput):
                     thisOutput = (modName, values['dataTier'])
                     if thisOutput in outputModTier:
                         msg = "StepChain cannot save output of different steps using "

--- a/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
@@ -84,6 +84,9 @@ Example initial processing task
  },
 """
 from __future__ import division
+from builtins import range, object
+from future.utils import viewitems
+
 from Utils.Utilities import makeList, strToBool
 from WMCore.Lexicon import primdataset, taskStepName
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
@@ -227,19 +230,19 @@ class TaskChainWorkloadFactory(StdBase):
                 origTpe = 1.0
             sumTpe = 0
             tpeCount = 0
-            for i in xrange(1, self.taskChain + 1):
+            for i in range(1, self.taskChain + 1):
                 if 'TimePerEvent' in arguments["Task%d" % i]:
                     sumTpe += arguments["Task%d" % i]['TimePerEvent']
                     tpeCount += 1
             if tpeCount > 0:
                 blowupFactor = sumTpe / origTpe
 
-        for i in xrange(1, self.taskChain + 1):
+        for i in range(1, self.taskChain + 1):
 
             originalTaskConf = arguments["Task%d" % i]
             taskConf = {}
             # Make a shallow copy of the taskConf
-            for k, v in originalTaskConf.items():
+            for k, v in viewitems(originalTaskConf):
                 taskConf[k] = v
             parent = taskConf.get("InputTask", None)
 
@@ -524,10 +527,10 @@ class TaskChainWorkloadFactory(StdBase):
         If not merged then only a cleanup task is created.
         """
         modulesToMerge = []
-        unmergedModules = outputModules.keys()
+        unmergedModules = list(outputModules)
         if keepOutput:
-            unmergedModules = [x for x in outputModules.keys() if x in transientOutputModules]
-            modulesToMerge = [x for x in outputModules.keys() if x not in transientOutputModules]
+            unmergedModules = [x for x in outputModules if x in transientOutputModules]
+            modulesToMerge = [x for x in outputModules if x not in transientOutputModules]
 
         procMergeTasks = {}
         for outputModuleName in modulesToMerge:
@@ -683,7 +686,7 @@ class TaskChainWorkloadFactory(StdBase):
             self.raiseValidationException(msg=msg)
 
         transientMapping = {}
-        for i in xrange(1, numTasks + 1):
+        for i in range(1, numTasks + 1):
             taskNumber = "Task%s" % i
             if taskNumber not in schema:
                 msg = "Task '%s' not present in the request schema." % taskNumber

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Express_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Express_t.py
@@ -6,6 +6,7 @@ Unit tests for the Express workflow.
 """
 
 from __future__ import division, print_function
+from future.utils import viewitems
 
 import threading
 import unittest
@@ -111,13 +112,13 @@ class ExpressTest(unittest.TestCase):
         expressWorkflow = Workflow(name="TestWorkload",
                                    task="/TestWorkload/Express")
         expressWorkflow.load()
-        self.assertEqual(len(expressWorkflow.outputMap.keys()), len(testArguments["Outputs"]) + 1,
+        self.assertEqual(len(expressWorkflow.outputMap), len(testArguments["Outputs"]) + 1,
                          "Error: Wrong number of WF outputs in the Express WF.")
 
         goldenOutputMods = {"write_PrimaryDataset1_FEVT": "FEVT",
                             "write_StreamExpress_ALCARECO": "ALCARECO",
                             "write_StreamExpress_DQMIO": "DQMIO"}
-        for goldenOutputMod, tier in goldenOutputMods.items():
+        for goldenOutputMod, tier in viewitems(goldenOutputMods):
             fset = goldenOutputMod + tier
             mergedOutput = expressWorkflow.outputMap[fset][0]["merged_output_fileset"]
             unmergedOutput = expressWorkflow.outputMap[fset][0]["output_fileset"]
@@ -144,12 +145,12 @@ class ExpressTest(unittest.TestCase):
         alcaSkimWorkflow = Workflow(name="TestWorkload",
                                     task="/TestWorkload/Express/ExpressAlcaSkimwrite_StreamExpress_ALCARECO")
         alcaSkimWorkflow.load()
-        self.assertEqual(len(alcaSkimWorkflow.outputMap.keys()), len(testArguments["AlcaSkims"]) + 1,
+        self.assertEqual(len(alcaSkimWorkflow.outputMap), len(testArguments["AlcaSkims"]) + 1,
                          "Error: Wrong number of WF outputs in the AlcaSkim WF.")
 
         goldenOutputMods = {"ALCARECOStreamPromptCalibProd": "ALCAPROMPT",
                             "ALCARECOStreamTkAlMinBias": "ALCARECO"}
-        for goldenOutputMod, tier in goldenOutputMods.items():
+        for goldenOutputMod, tier in viewitems(goldenOutputMods):
             fset = goldenOutputMod + tier
             mergedOutput = alcaSkimWorkflow.outputMap[fset][0]["merged_output_fileset"]
             unmergedOutput = alcaSkimWorkflow.outputMap[fset][0]["output_fileset"]
@@ -196,12 +197,12 @@ class ExpressTest(unittest.TestCase):
 
         goldenOutputMods = {"write_PrimaryDataset1_FEVT": "FEVT",
                             "write_StreamExpress_DQMIO": "DQMIO"}
-        for goldenOutputMod, tier in goldenOutputMods.items():
+        for goldenOutputMod, tier in viewitems(goldenOutputMods):
             mergeWorkflow = Workflow(name="TestWorkload",
                                      task="/TestWorkload/Express/ExpressMerge%s" % goldenOutputMod)
             mergeWorkflow.load()
 
-            self.assertEqual(len(mergeWorkflow.outputMap.keys()), 2,
+            self.assertEqual(len(mergeWorkflow.outputMap), 2,
                              "Error: Wrong number of WF outputs.")
 
             mergedMergeOutput = mergeWorkflow.outputMap["Merged%s" % tier][0]["merged_output_fileset"]
@@ -265,7 +266,7 @@ class ExpressTest(unittest.TestCase):
 
         unmergedOutputs = {"write_PrimaryDataset1_FEVT": "FEVT",
                            "write_StreamExpress_DQMIO": "DQMIO"}
-        for unmergedOutput, tier in unmergedOutputs.items():
+        for unmergedOutput, tier in viewitems(unmergedOutputs):
             fset = unmergedOutput + tier
             unmergedDataTier = Fileset(name="/TestWorkload/Express/unmerged-%s" % fset)
             unmergedDataTier.loadData()
@@ -283,7 +284,7 @@ class ExpressTest(unittest.TestCase):
         goldenOutputMods = {"write_PrimaryDataset1_FEVT": "FEVT",
                             "write_StreamExpress_ALCARECO": "ALCARECO",
                             "write_StreamExpress_DQMIO": "DQMIO"}
-        for goldenOutputMod, tier in goldenOutputMods.items():
+        for goldenOutputMod, tier in viewitems(goldenOutputMods):
             fset = goldenOutputMod + tier
             unmergedFileset = Fileset(name="/TestWorkload/Express/unmerged-%s" % fset)
             unmergedFileset.loadData()

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/PromptReco_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/PromptReco_t.py
@@ -7,6 +7,7 @@ _PromptReco_t_
 Unit tests for the new Tier1 PromptReconstruction workflow.
 """
 from __future__ import print_function
+from future.utils import viewitems
 
 import os
 import threading
@@ -105,11 +106,11 @@ class PromptRecoTest(unittest.TestCase):
         recoWorkflow = Workflow(name="TestWorkload",
                                 task="/TestWorkload/Reco")
         recoWorkflow.load()
-        self.assertEqual(len(recoWorkflow.outputMap.keys()), len(testArguments["WriteTiers"]) + 1,
+        self.assertEqual(len(recoWorkflow.outputMap), len(testArguments["WriteTiers"]) + 1,
                          "Error: Wrong number of WF outputs in the Reco WF.")
 
         goldenOutputMods = {"write_RECO": "RECO", "write_ALCARECO": "ALCARECO", "write_AOD": "AOD", "write_DQM": "DQM"}
-        for goldenOutputMod, tier in goldenOutputMods.items():
+        for goldenOutputMod, tier in viewitems(goldenOutputMods):
             fset = goldenOutputMod + tier
             mergedOutput = recoWorkflow.outputMap[fset][0]["merged_output_fileset"]
             unmergedOutput = recoWorkflow.outputMap[fset][0]["output_fileset"]
@@ -136,7 +137,7 @@ class PromptRecoTest(unittest.TestCase):
         alcaSkimWorkflow = Workflow(name="TestWorkload",
                                     task="/TestWorkload/Reco/AlcaSkim")
         alcaSkimWorkflow.load()
-        self.assertEqual(len(alcaSkimWorkflow.outputMap.keys()), len(testArguments["AlcaSkims"]) + 1,
+        self.assertEqual(len(alcaSkimWorkflow.outputMap), len(testArguments["AlcaSkims"]) + 1,
                          "Error: Wrong number of WF outputs in the AlcaSkim WF.")
 
         goldenOutputMods = []
@@ -182,13 +183,13 @@ class PromptRecoTest(unittest.TestCase):
                          "Error: LogArchive output fileset is wrong.")
 
         goldenOutputMods = {"write_RECO": "RECO", "write_AOD": "AOD", "write_DQM": "DQM"}
-        for goldenOutputMod, tier in goldenOutputMods.items():
+        for goldenOutputMod, tier in viewitems(goldenOutputMods):
             fset = goldenOutputMod + tier
             mergeWorkflow = Workflow(name="TestWorkload",
                                      task="/TestWorkload/Reco/RecoMerge%s" % goldenOutputMod)
             mergeWorkflow.load()
 
-            self.assertEqual(len(mergeWorkflow.outputMap.keys()), 2,
+            self.assertEqual(len(mergeWorkflow.outputMap), 2,
                              "Error: Wrong number of WF outputs.")
 
             mergedMergeOutput = mergeWorkflow.outputMap["Merged%s" % tier][0]["merged_output_fileset"]
@@ -224,8 +225,8 @@ class PromptRecoTest(unittest.TestCase):
                                      task="/TestWorkload/Reco/AlcaSkim/AlcaSkimMerge%s" % goldenOutputMod)
             mergeWorkflow.load()
 
-            self.assertEqual(len(mergeWorkflow.outputMap.keys()), 2,
-                             "Error: Wrong number of WF outputs %d." % len(mergeWorkflow.outputMap.keys()))
+            self.assertEqual(len(mergeWorkflow.outputMap), 2,
+                             "Error: Wrong number of WF outputs %d." % len(mergeWorkflow.outputMap))
 
             mergedMergeOutput = mergeWorkflow.outputMap["MergedALCARECO"][0]["merged_output_fileset"]
             unmergedMergeOutput = mergeWorkflow.outputMap["MergedALCARECO"][0]["output_fileset"]
@@ -286,7 +287,7 @@ class PromptRecoTest(unittest.TestCase):
                          "Error: Wrong split algo.")
 
         unmergedOutputs = {"write_RECO": "RECO", "write_AOD": "AOD", "write_DQM": "DQM"}
-        for unmergedOutput, tier in unmergedOutputs.items():
+        for unmergedOutput, tier in viewitems(unmergedOutputs):
             fset = unmergedOutput + tier
             unmergedDataTier = Fileset(name="/TestWorkload/Reco/unmerged-%s" % fset)
             unmergedDataTier.loadData()
@@ -318,7 +319,7 @@ class PromptRecoTest(unittest.TestCase):
                              "Error: Wrong split algorithm. %s" % mergeSubscription["split_algo"])
 
         goldenOutputMods = {"write_RECO": "RECO", "write_AOD": "AOD", "write_DQM": "DQM"}
-        for goldenOutputMod, tier in goldenOutputMods.items():
+        for goldenOutputMod, tier in viewitems(goldenOutputMods):
             fset = goldenOutputMod + tier
             unmergedFileset = Fileset(name="/TestWorkload/Reco/unmerged-%s" % fset)
             unmergedFileset.loadData()

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/ReReco_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/ReReco_t.py
@@ -5,6 +5,7 @@ _ReReco_t_
 Unit tests for the ReReco workflow.
 """
 from __future__ import print_function
+from future.utils import viewitems
 
 import os
 import threading
@@ -154,11 +155,11 @@ class ReRecoTest(unittest.TestCase):
                                 task="/TestWorkload/DataProcessing")
         procWorkflow.load()
 
-        self.assertEqual(len(procWorkflow.outputMap.keys()), 3,
+        self.assertEqual(len(procWorkflow.outputMap), 3,
                          "Error: Wrong number of WF outputs.")
 
         goldenOutputMods = {"RECOoutput": "RECO", "DQMoutput": "DQM"}
-        for goldenOutputMod, tier in goldenOutputMods.items():
+        for goldenOutputMod, tier in viewitems(goldenOutputMods):
             fset = goldenOutputMod + tier
             mergedOutput = procWorkflow.outputMap[fset][0]["merged_output_fileset"]
             unmergedOutput = procWorkflow.outputMap[fset][0]["output_fileset"]
@@ -182,12 +183,12 @@ class ReRecoTest(unittest.TestCase):
         self.assertEqual(unmergedLogArchOutput.name, "/TestWorkload/DataProcessing/unmerged-logArchive",
                          "Error: LogArchive output fileset is wrong.")
 
-        for goldenOutputMod, tier in goldenOutputMods.items():
+        for goldenOutputMod, tier in viewitems(goldenOutputMods):
             mergeWorkflow = Workflow(name="TestWorkload",
                                      task="/TestWorkload/DataProcessing/DataProcessingMerge%s" % goldenOutputMod)
             mergeWorkflow.load()
 
-            self.assertEqual(len(mergeWorkflow.outputMap.keys()), 2,
+            self.assertEqual(len(mergeWorkflow.outputMap), 2,
                              "Error: Wrong number of WF outputs.")
 
             mergedMergeOutput = mergeWorkflow.outputMap["Merged%s" % tier][0]["merged_output_fileset"]
@@ -254,7 +255,7 @@ class ReRecoTest(unittest.TestCase):
         self.assertEqual(mergeSubscription["split_algo"], "ParentlessMergeBySize",
                          "Error: Wrong split algo.")
 
-        for goldenOutputMod, tier in goldenOutputMods.items():
+        for goldenOutputMod, tier in viewitems(goldenOutputMods):
             fset = goldenOutputMod + tier
             unmerged = Fileset(name="/TestWorkload/DataProcessing/unmerged-%s" % fset)
             unmerged.loadData()
@@ -312,11 +313,11 @@ class ReRecoTest(unittest.TestCase):
                                 task="/TestWorkload/DataProcessing/DataProcessingMergeRECOoutput/SomeSkim")
         skimWorkflow.load()
 
-        self.assertEqual(len(skimWorkflow.outputMap.keys()), 3,
+        self.assertEqual(len(skimWorkflow.outputMap), 3,
                          "Error: Wrong number of WF outputs.")
 
         goldenOutputMods = {"SkimA": "RAW-RECO", "SkimB": "USER"}
-        for goldenOutputMod, tier in goldenOutputMods.items():
+        for goldenOutputMod, tier in viewitems(goldenOutputMods):
             fset = goldenOutputMod + tier
             mergedOutput = skimWorkflow.outputMap[fset][0]["merged_output_fileset"]
             unmergedOutput = skimWorkflow.outputMap[fset][0]["output_fileset"]
@@ -344,12 +345,12 @@ class ReRecoTest(unittest.TestCase):
                          "/TestWorkload/DataProcessing/DataProcessingMergeRECOoutput/SomeSkim/unmerged-logArchive",
                          "Error: LogArchive output fileset is wrong.")
 
-        for goldenOutputMod, tier in goldenOutputMods.items():
+        for goldenOutputMod, tier in viewitems(goldenOutputMods):
             mergeWorkflow = Workflow(name="TestWorkload",
                                      task="/TestWorkload/DataProcessing/DataProcessingMergeRECOoutput/SomeSkim/SomeSkimMerge%s" % goldenOutputMod)
             mergeWorkflow.load()
 
-            self.assertEqual(len(mergeWorkflow.outputMap.keys()), 2,
+            self.assertEqual(len(mergeWorkflow.outputMap), 2,
                              "Error: Wrong number of WF outputs.")
 
             mergedMergeOutput = mergeWorkflow.outputMap["Merged%s" % tier][0]["merged_output_fileset"]
@@ -390,7 +391,7 @@ class ReRecoTest(unittest.TestCase):
         self.assertEqual(skimSubscription["split_algo"], "FileBased",
                          "Error: Wrong split algo.")
 
-        for goldenOutputMod, tier in goldenOutputMods.items():
+        for goldenOutputMod, tier in viewitems(goldenOutputMods):
             fset = goldenOutputMod + tier
             unmerged = Fileset(
                 name="/TestWorkload/DataProcessing/DataProcessingMergeRECOoutput/SomeSkim/unmerged-%s" % fset)
@@ -406,7 +407,7 @@ class ReRecoTest(unittest.TestCase):
             self.assertEqual(mergeSubscription["split_algo"], "ParentlessMergeBySize",
                              "Error: Wrong split algo.")
 
-        for goldenOutputMod, tier in goldenOutputMods.items():
+        for goldenOutputMod, tier in viewitems(goldenOutputMods):
             fset = goldenOutputMod + tier
             unmerged = Fileset(
                 name="/TestWorkload/DataProcessing/DataProcessingMergeRECOoutput/SomeSkim/unmerged-%s" % fset)
@@ -520,11 +521,11 @@ class ReRecoTest(unittest.TestCase):
                                 task="/TestWorkload/DataProcessing/SomeSkim")
         skimWorkflow.load()
 
-        self.assertEqual(len(skimWorkflow.outputMap.keys()), 3,
+        self.assertEqual(len(skimWorkflow.outputMap), 3,
                          "Error: Wrong number of WF outputs.")
 
         goldenOutputMods = {"SkimA": "RAW-RECO", "SkimB": "USER"}
-        for goldenOutputMod, tier in goldenOutputMods.items():
+        for goldenOutputMod, tier in viewitems(goldenOutputMods):
             fset = goldenOutputMod + tier
             mergedOutput = skimWorkflow.outputMap[fset][0]["merged_output_fileset"]
             unmergedOutput = skimWorkflow.outputMap[fset][0]["output_fileset"]
@@ -549,12 +550,12 @@ class ReRecoTest(unittest.TestCase):
         self.assertEqual(unmergedLogArchOutput.name, "/TestWorkload/DataProcessing/SomeSkim/unmerged-logArchive",
                          "Error: LogArchive output fileset is wrong.")
 
-        for goldenOutputMod, tier in goldenOutputMods.items():
+        for goldenOutputMod, tier in viewitems(goldenOutputMods):
             mergeWorkflow = Workflow(name="TestWorkload",
                                      task="/TestWorkload/DataProcessing/SomeSkim/SomeSkimMerge%s" % goldenOutputMod)
             mergeWorkflow.load()
 
-            self.assertEqual(len(mergeWorkflow.outputMap.keys()), 2,
+            self.assertEqual(len(mergeWorkflow.outputMap), 2,
                              "Error: Wrong number of WF outputs.")
 
             mergedMergeOutput = mergeWorkflow.outputMap["Merged%s" % tier][0]["merged_output_fileset"]
@@ -595,7 +596,7 @@ class ReRecoTest(unittest.TestCase):
         self.assertEqual(skimSubscription["split_algo"], "FileBased",
                          "Error: Wrong split algo.")
 
-        for skimOutput, tier in goldenOutputMods.items():
+        for skimOutput, tier in viewitems(goldenOutputMods):
             fset = skimOutput + tier
             unmerged = Fileset(name="/TestWorkload/DataProcessing/SomeSkim/unmerged-%s" % fset)
             unmerged.loadData()
@@ -610,7 +611,7 @@ class ReRecoTest(unittest.TestCase):
             self.assertEqual(mergeSubscription["split_algo"], "ParentlessMergeBySize",
                              "Error: Wrong split algo.")
 
-        for skimOutput, tier in goldenOutputMods.items():
+        for skimOutput, tier in viewitems(goldenOutputMods):
             fset = skimOutput + tier
             unmerged = Fileset(name="/TestWorkload/DataProcessing/SomeSkim/unmerged-%s" % fset)
             unmerged.loadData()

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Repack_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Repack_t.py
@@ -6,6 +6,7 @@ Unit tests for the Tier0 Repack workflow.
 """
 
 from __future__ import division, print_function
+from future.utils import viewitems
 
 import threading
 import unittest
@@ -101,11 +102,11 @@ class RepackTests(unittest.TestCase):
         repackWorkflow = Workflow(name="TestWorkload",
                                   task="/TestWorkload/Repack")
         repackWorkflow.load()
-        self.assertEqual(len(repackWorkflow.outputMap.keys()), len(testArguments["Outputs"]) + 1,
+        self.assertEqual(len(repackWorkflow.outputMap), len(testArguments["Outputs"]) + 1,
                          "Error: Wrong number of WF outputs in the Repack WF.")
 
         goldenOutputMods = {"write_PrimaryDataset1_RAW": "RAW", "write_PrimaryDataset2_RAW": "RAW"}
-        for goldenOutputMod, tier in goldenOutputMods.items():
+        for goldenOutputMod, tier in viewitems(goldenOutputMods):
             fset = goldenOutputMod + tier
             mergedOutput = repackWorkflow.outputMap[fset][0]["merged_output_fileset"]
             unmergedOutput = repackWorkflow.outputMap[fset][0]["output_fileset"]
@@ -129,12 +130,12 @@ class RepackTests(unittest.TestCase):
         self.assertEqual(unmergedLogArchOutput.name, "/TestWorkload/Repack/unmerged-logArchive",
                          "Error: LogArchive output fileset is wrong.")
 
-        for goldenOutputMod, tier in goldenOutputMods.items():
+        for goldenOutputMod, tier in viewitems(goldenOutputMods):
             mergeWorkflow = Workflow(name="TestWorkload",
                                      task="/TestWorkload/Repack/RepackMerge%s" % goldenOutputMod)
             mergeWorkflow.load()
 
-            self.assertEqual(len(mergeWorkflow.outputMap.keys()), 3,
+            self.assertEqual(len(mergeWorkflow.outputMap), 3,
                              "Error: Wrong number of WF outputs.")
 
             mergedMergeOutput = mergeWorkflow.outputMap["Merged%s" % tier][0]["merged_output_fileset"]
@@ -174,7 +175,7 @@ class RepackTests(unittest.TestCase):
                          "Error: Wrong split algorithm. %s" % repackSubscription["split_algo"])
 
         unmergedOutputs = {"write_PrimaryDataset1_RAW": "RAW", "write_PrimaryDataset2_RAW": "RAW"}
-        for unmergedOutput, tier in unmergedOutputs.items():
+        for unmergedOutput, tier in viewitems(unmergedOutputs):
             fset = unmergedOutput + tier
             unmergedDataTier = Fileset(name="/TestWorkload/Repack/unmerged-%s" % fset)
             unmergedDataTier.loadData()
@@ -189,7 +190,7 @@ class RepackTests(unittest.TestCase):
             self.assertEqual(mergeSubscription["split_algo"], "RepackMerge",
                              "Error: Wrong split algorithm. %s" % mergeSubscription["split_algo"])
 
-        for goldenOutputMod, tier in goldenOutputMods.items():
+        for goldenOutputMod, tier in viewitems(goldenOutputMods):
             fset = goldenOutputMod + tier
             unmergedFileset = Fileset(name="/TestWorkload/Repack/unmerged-%s" % fset)
             unmergedFileset.loadData()
@@ -217,7 +218,7 @@ class RepackTests(unittest.TestCase):
         self.assertEqual(logCollectSub["split_algo"], "MinFileBased",
                          "Error: Wrong split algorithm.")
 
-        for goldenOutputMod, tier in goldenOutputMods.items():
+        for goldenOutputMod, tier in viewitems(goldenOutputMods):
             repackMergeLogCollect = Fileset(
                 name="/TestWorkload/Repack/RepackMerge%s/merged-logArchive" % goldenOutputMod)
             repackMergeLogCollect.loadData()

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
@@ -5,6 +5,12 @@ _StepChain_t_
 """
 from __future__ import print_function
 
+from future.utils import viewitems, listvalues
+
+from builtins import range
+from builtins import str, bytes
+
+
 import os
 import threading
 import unittest
@@ -312,7 +318,7 @@ class StepChainTests(EmulatedUnitTestCase):
         self.assertFalse(task.getInputStep(), "Wrong input step")
         # task level checks for output data
         outModDict = task.getOutputModulesForTask(cmsRunOnly=True)[0].dictionary_()  # only 1 cmsRun process
-        self.assertItemsEqual(outModDict.keys(), outMods.keys())
+        self.assertItemsEqual(list(outModDict), list(outMods))
         for modName in outModDict:
             self._validateOutputModule(modName, outModDict[modName], outMods[modName])
 
@@ -513,7 +519,7 @@ class StepChainTests(EmulatedUnitTestCase):
         # workload level check
         self.assertEqual(testWorkload.getDashboardActivity(), "production")
         self.assertEqual(testWorkload.listInputDatasets(), [])
-        pileups = testWorkload.listPileupDatasets().values()
+        pileups = listvalues(testWorkload.listPileupDatasets())
         pileups = [item for puSet in pileups for item in puSet]
         self.assertItemsEqual(pileups, [testArguments['Step1']['MCPileup']])
 
@@ -555,7 +561,7 @@ class StepChainTests(EmulatedUnitTestCase):
         testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
 
         # workload level check
-        pileups = testWorkload.listPileupDatasets().values()
+        pileups = listvalues(testWorkload.listPileupDatasets())
         pileups = [item for puSet in pileups for item in puSet]
         self.assertIn(testArguments['Step2']['MCPileup'], pileups)
         self.assertIn(testArguments['Step3']['MCPileup'], pileups)
@@ -875,18 +881,18 @@ class StepChainTests(EmulatedUnitTestCase):
             outDsets = [dset.replace(tp[0], tp[1]) for dset in outDsets]
             outputLFNBases = [lfn.replace(tp[0], tp[1]) for lfn in outputLFNBases]
             for mod in outMods:
-                outMods[mod] = {k: (v.replace(tp[0], tp[1]) if isinstance(v, basestring) else v)
-                                for k, v in outMods[mod].items()}
-            transientMod['RAWSIMoutput'] = {k: (v.replace(tp[0], tp[1]) if isinstance(v, basestring) else v)
-                                            for k, v in transientMod['RAWSIMoutput'].items()}
+                outMods[mod] = {k: (v.replace(tp[0], tp[1]) if isinstance(v, (str, bytes)) else v)
+                                for k, v in viewitems(outMods[mod])}
+            transientMod['RAWSIMoutput'] = {k: (v.replace(tp[0], tp[1]) if isinstance(v, (str, bytes)) else v)
+                                            for k, v in viewitems(transientMod['RAWSIMoutput'])}
         for tp in [("v1", "v41"), ("v2", "v42"), ("v3", "v43"), ("/store/data", "/store/mc")]:
             outDsets = [dset.replace(tp[0], tp[1]) for dset in outDsets]
             outputLFNBases = [lfn.replace(tp[0], tp[1]) for lfn in outputLFNBases]
             for mod in outMods:
-                outMods[mod] = {k: (v.replace(tp[0], tp[1]) if isinstance(v, basestring) else v)
-                                for k, v in outMods[mod].items()}
-            transientMod['RAWSIMoutput'] = {k: (v.replace(tp[0], tp[1]) if isinstance(v, basestring) else v)
-                                            for k, v in transientMod['RAWSIMoutput'].items()}
+                outMods[mod] = {k: (v.replace(tp[0], tp[1]) if isinstance(v, (str, bytes)) else v)
+                                for k, v in viewitems(outMods[mod])}
+            transientMod['RAWSIMoutput'] = {k: (v.replace(tp[0], tp[1]) if isinstance(v, (str, bytes)) else v)
+                                            for k, v in viewitems(transientMod['RAWSIMoutput'])}
 
         mergedMods = deepcopy(outMods)
         mergedMods['RAWSIMoutput'].update({'transient': False, 'lfnBase': outputLFNBases[0 + 1]})
@@ -992,22 +998,22 @@ class StepChainTests(EmulatedUnitTestCase):
             outputLFNBases = [lfn.replace(tp[0], tp[1]) for lfn in outputLFNBases]
             for mod in outMods:
                 if isinstance(outMods[mod], dict):
-                    outMods[mod] = {k: (v.replace(tp[0], tp[1]) if isinstance(v, basestring) else v)
-                                    for k, v in outMods[mod].items()}
+                    outMods[mod] = {k: (v.replace(tp[0], tp[1]) if isinstance(v, (str, bytes)) else v)
+                                    for k, v in viewitems(outMods[mod])}
                 else:
                     outMods[mod] = [
-                        {k: (v.replace(tp[0], tp[1]) if isinstance(v, basestring) else v) for k, v in out.items()} for
+                        {k: (v.replace(tp[0], tp[1]) if isinstance(v, (str, bytes)) else v) for k, v in viewitems(out)} for
                         out in outMods[mod]]
         for tp in [("v1", "v41"), ("v2", "v42"), ("v3", "v43"), ("/store/data", "/store/mc")]:
             outDsets = [dset.replace(tp[0], tp[1]) for dset in outDsets]
             outputLFNBases = [lfn.replace(tp[0], tp[1]) for lfn in outputLFNBases]
             for mod in outMods:
                 if isinstance(outMods[mod], dict):
-                    outMods[mod] = {k: (v.replace(tp[0], tp[1]) if isinstance(v, basestring) else v)
-                                    for k, v in outMods[mod].items()}
+                    outMods[mod] = {k: (v.replace(tp[0], tp[1]) if isinstance(v, (str, bytes)) else v)
+                                    for k, v in viewitems(outMods[mod])}
                 else:
                     outMods[mod] = [
-                        {k: (v.replace(tp[0], tp[1]) if isinstance(v, basestring) else v) for k, v in out.items()} for
+                        {k: (v.replace(tp[0], tp[1]) if isinstance(v, (str, bytes)) else v) for k, v in viewitems(out)} for
                         out in outMods[mod]]
         mergedMods = deepcopy(outMods)
         mergedMods['RAWSIMoutput'][0].update({'transient': False, 'lfnBase': outputLFNBases[0 + 1]})
@@ -1502,7 +1508,7 @@ class StepChainTests(EmulatedUnitTestCase):
         def _checkInputData(workload, sitewhitelist=None):
             "Validate input data/block/run/step/PU for the 4-tasks request"
             sitewhitelist = sitewhitelist or []
-            self.assertEqual(workload.listPileupDatasets().values(), [{testArguments['Step2']['MCPileup']}])
+            self.assertEqual(listvalues(workload.listPileupDatasets()), [{testArguments['Step2']['MCPileup']}])
 
             task = workload.getTaskByName(testArguments['Step1']['StepName'])
             self.assertEqual(task.taskType(), "Production")
@@ -2139,12 +2145,12 @@ class StepChainTests(EmulatedUnitTestCase):
             self.assertEqual(stepNumber, parentageMapping[stepName]['StepNumber'])
             self.assertEqual(cmsRunNumber, parentageMapping[stepName]['StepCmsRun'])
             self.assertEqual(testArguments[stepNumber].get('InputStep'), parentageMapping[stepName]['ParentStepName'])
-            self.assertItemsEqual(outDsets[stepNumber], parentageMapping[stepName]['OutputDatasetMap'].values())
+            self.assertItemsEqual(outDsets[stepNumber], listvalues(parentageMapping[stepName]['OutputDatasetMap']))
             # request does not have InputDataset and we keep the output of the last step only
             self.assertEqual(None, parentageMapping[stepName]['ParentDataset'])
 
         self.assertItemsEqual(['AODSIMoutput', 'RECOSIMoutput', 'DQMoutput'],
-                              parentageMapping['RECO']['OutputDatasetMap'].keys())
+                              list(parentageMapping['RECO']['OutputDatasetMap']))
 
     def testStepParentageMapping2(self):
         """
@@ -2200,12 +2206,12 @@ class StepChainTests(EmulatedUnitTestCase):
             self.assertEqual(stepNumber, parentageMapping[stepName]['StepNumber'])
             self.assertEqual(cmsRunNumber, parentageMapping[stepName]['StepCmsRun'])
             self.assertEqual(testArguments[stepNumber].get('InputStep'), parentageMapping[stepName]['ParentStepName'])
-            self.assertItemsEqual(outDsets[stepNumber], parentageMapping[stepName]['OutputDatasetMap'].values())
+            self.assertItemsEqual(outDsets[stepNumber], listvalues(parentageMapping[stepName]['OutputDatasetMap']))
             self.assertEqual('/BprimeJetToBZ_M800GeV_Tune4C_13TeV-madgraph-tauola/Fall13-POSTLS162_V1-v1/GEN-SIM',
                              parentageMapping[stepName]['ParentDataset'])
 
         self.assertItemsEqual(['AODSIMoutput', 'RECOSIMoutput', 'DQMoutput'],
-                              parentageMapping['RECO']['OutputDatasetMap'].keys())
+                              list(parentageMapping['RECO']['OutputDatasetMap']))
 
     def testStepParentageMapping3(self):
         """
@@ -2259,7 +2265,7 @@ class StepChainTests(EmulatedUnitTestCase):
             self.assertEqual(stepNumber, parentageMapping[stepName]['StepNumber'])
             self.assertEqual(cmsRunNumber, parentageMapping[stepName]['StepCmsRun'])
             self.assertEqual(testArguments[stepNumber].get('InputStep'), parentageMapping[stepName]['ParentStepName'])
-            self.assertItemsEqual(outDsets[stepNumber], parentageMapping[stepName]['OutputDatasetMap'].values())
+            self.assertItemsEqual(outDsets[stepNumber], listvalues(parentageMapping[stepName]['OutputDatasetMap']))
 
         # test parentage dataset
         self.assertEqual(None, parentageMapping['GENSIM']['ParentDataset'])
@@ -2269,10 +2275,10 @@ class StepChainTests(EmulatedUnitTestCase):
         self.assertEqual(parentDset, parentageMapping['RECO']['ParentDataset'])
 
         # test output modules, only Step2 not saving the output
-        self.assertEqual(['RAWSIMoutput'], parentageMapping['GENSIM']['OutputDatasetMap'].keys())
-        self.assertEqual(['RAWSIMoutput'], parentageMapping['DIGI2']['OutputDatasetMap'].keys())
+        self.assertEqual(['RAWSIMoutput'], list(parentageMapping['GENSIM']['OutputDatasetMap']))
+        self.assertEqual(['RAWSIMoutput'], list(parentageMapping['DIGI2']['OutputDatasetMap']))
         self.assertItemsEqual(['AODSIMoutput', 'RECOSIMoutput', 'DQMoutput'],
-                              parentageMapping['RECO']['OutputDatasetMap'].keys())
+                              list(parentageMapping['RECO']['OutputDatasetMap']))
 
     def testStepParentageMapping4(self):
         """
@@ -2337,7 +2343,7 @@ class StepChainTests(EmulatedUnitTestCase):
             self.assertEqual(stepNumber, parentageMapping[stepName]['StepNumber'])
             self.assertEqual(cmsRunNumber, parentageMapping[stepName]['StepCmsRun'])
             self.assertEqual(testArguments[stepNumber].get('InputStep'), parentageMapping[stepName]['ParentStepName'])
-            self.assertItemsEqual(outDsets[stepNumber], parentageMapping[stepName]['OutputDatasetMap'].values())
+            self.assertItemsEqual(outDsets[stepNumber], listvalues(parentageMapping[stepName]['OutputDatasetMap']))
 
         # test parentage dataset
         self.assertEqual(None, parentageMapping['GENSIM']['ParentDataset'])
@@ -2347,10 +2353,10 @@ class StepChainTests(EmulatedUnitTestCase):
         self.assertEqual(parentDset, parentageMapping['RECO']['ParentDataset'])
 
         # test output modules, only Step2 not saving the output
-        self.assertEqual(['RAWSIMoutput'], parentageMapping['GENSIM']['OutputDatasetMap'].keys())
-        self.assertEqual(['RAWSIMoutput'], parentageMapping['DIGI2']['OutputDatasetMap'].keys())
+        self.assertEqual(['RAWSIMoutput'], list(parentageMapping['GENSIM']['OutputDatasetMap']))
+        self.assertEqual(['RAWSIMoutput'], list(parentageMapping['DIGI2']['OutputDatasetMap']))
         self.assertItemsEqual(['AODSIMoutput', 'RECOSIMoutput', 'DQMoutput'],
-                              parentageMapping['RECO']['OutputDatasetMap'].keys())
+                              list(parentageMapping['RECO']['OutputDatasetMap']))
 
     def testTooManySteps(self):
         """

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StoreResults_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StoreResults_t.py
@@ -5,6 +5,7 @@ _StoreResults_t_
 Unit tests for the StoreResults workflow.
 """
 from __future__ import print_function
+from future.utils import viewitems
 
 import threading
 import unittest
@@ -72,10 +73,10 @@ class StoreResultsTest(unittest.TestCase):
                                 task="/TestWorkload/StoreResults")
         testWorkflow.load()
 
-        self.assertEqual(len(testWorkflow.outputMap.keys()), 2,
+        self.assertEqual(len(testWorkflow.outputMap), 2,
                          "Error: Wrong number of WF outputs.")
         goldenOutputMods = {"Merged": "USER"}
-        for goldenOutputMod, tier in goldenOutputMods.items():
+        for goldenOutputMod, tier in viewitems(goldenOutputMods):
             fset = goldenOutputMod + tier
             mergedOutput = testWorkflow.outputMap[fset][0]["merged_output_fileset"]
             unmergedOutput = testWorkflow.outputMap[fset][0]["output_fileset"]


### PR DESCRIPTION
Fixes #10146 

#### Status
In development 

#### Related PRs

* Previous migration PR: #10361  (slice21, issue #10145)
* Next migration PR: #10363 (slice23, issue #10147  )

#### Description

Run futurize and some manual changes on the first batch of src/python/A/B/C.

"Native String" approach:
- `src/python/WMCore/WMSpec/StdSpecs/ReReco.py`: here we use `str()` to format an object to a string and then replace it into a string, `realArg = argument.replace("#N", str(skimIndex))`. This should be mostly safe!
- `src/python/WMCore/WMSpec/StdSpecs/StdBase.py`:  Some problems may arise here. `str()` use to format the keys of a dictionary (tracked in #10377).

    ```python
        newSplitArgs = {}
        for argName in splitArgs:
            newSplitArgs[str(argName)] = splitArgs[argName]
        procTask.setSplittingAlgorithm(splitAlgo, **newSplitArgs)
    ```
    and it is also used to format a string that is then looped through:

   ```python
    stringRunNumber = str(self.runNumber).zfill(9)
    runSections = [stringRunNumber[i:i + 3] for i in range(0, 9, 3)]
    ```

- `src/python/WMCore/WMSpec/StdSpecs/TaskChain.py`:  Some problems may arise here. `str()` use to format the keys of a dictionary (tracked in #10377).

    ```python
        procMergeTasks = {}
        for outputModuleName in modulesToMerge:
            ...
            procMergeTasks[str(outputModuleName)] = mergeTask
    ```

`pylint --py3k` report:
- warn us about the use of `round`. we have `multiplier = int(round(ePerJob / ePerLumi))`, so we should be safe here. I consider this warning as a false positive

#### Is it backward compatible (if not, which system it affects?)

It should be. (Any possible cause for errors will we reported here)

#### External dependencies / deployment changes

Requires python-future in both py2 and py3 environments.
