### PR TITLE
[py2py3] Migration at level scr/python/A/B/C - slice 23

### DIFF
--- a/src/python/WMComponent/AnalyticsDataCollector/Plugins/PluginInterface.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/Plugins/PluginInterface.py
@@ -6,6 +6,7 @@ Base class for AnalyticsDataCollector plug-ins
 
 """
 
+from builtins import object
 class PluginInterface(object):
     """Interface for policies"""
     def __init__(self, **args):

--- a/src/python/WMComponent/AnalyticsDataCollector/Plugins/Tier0Plugin.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/Plugins/Tier0Plugin.py
@@ -10,6 +10,8 @@ Created on Nov 2, 2012
 @author: dballest
 """
 
+from builtins import filter
+
 import re
 import threading
 import traceback
@@ -225,7 +227,7 @@ class Tier0Plugin(PluginInterface):
         clean unused task lists
         """
         self.logger.debug('Cleaning up task cache')
-        for workflow in self.taskCache.keys():
+        for workflow in list(self.taskCache):
             if workflow not in reportedWorkflows:
                 self.taskCache.pop(workflow)
         return

--- a/src/python/WMComponent/JobCreator/JobCreatorPoller.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorPoller.py
@@ -2,6 +2,9 @@
 """
 The JobCreator Poller for the JSM
 """
+
+from builtins import next
+
 __all__ = []
 
 import logging

--- a/src/python/WMComponent/RetryManager/PlugIns/RetryAlgoBase.py
+++ b/src/python/WMComponent/RetryManager/PlugIns/RetryAlgoBase.py
@@ -7,6 +7,7 @@ RetryAlgoBase
 This is the base class for Retry Algos
 """
 
+from builtins import object
 import time
 import datetime
 import logging

--- a/src/python/WMCore/BossAir/Plugins/BasePlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/BasePlugin.py
@@ -5,6 +5,9 @@ _BasePlugin_
 Base class for BossAir plugins
 """
 
+from builtins import object, str, bytes
+from future.utils import viewitems, viewvalues
+
 from WMCore.WMException import WMException
 from WMCore.WMRuntime.Tools.Scram import ARCH_TO_OS
 
@@ -37,7 +40,7 @@ class BasePlugin(object):
         """
         Verify state of map values
         """
-        for state in stateMap.values():
+        for state in viewvalues(stateMap):
             if state not in BasePlugin.globalState:
                 raise BossAirPluginException("not valid state %s" % state)
         return stateMap
@@ -57,7 +60,7 @@ class BasePlugin(object):
 
         # NOTE: Don't overwrite this.
         # However stateMap should be implemented in child class.
-        self.states = self.stateMap().keys()
+        self.states = list(self.stateMap())
 
 
 
@@ -136,13 +139,13 @@ class BasePlugin(object):
         requiredOSes = set()
         if scramArch is None:
             requiredOSes.add('any')
-        elif isinstance(scramArch, basestring):
-            for arch, validOSes in ARCH_TO_OS.iteritems():
+        elif isinstance(scramArch, (str, bytes)):
+            for arch, validOSes in viewitems(ARCH_TO_OS):
                 if arch in scramArch:
                     requiredOSes.update(validOSes)
         elif isinstance(scramArch, list):
             for validArch in scramArch:
-                for arch, validOSes in ARCH_TO_OS.iteritems():
+                for arch, validOSes in viewitems(ARCH_TO_OS):
                     if arch in validArch:
                         requiredOSes.update(validOSes)
         else:

--- a/src/python/WMCore/BossAir/Plugins/LsfPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/LsfPlugin.py
@@ -98,13 +98,13 @@ class LsfPlugin(BasePlugin):
         submitDict = {}
         for job in jobs:
             sandbox = job['sandbox']
-            if not sandbox in submitDict.keys():
+            if sandbox not in submitDict:
                 submitDict[sandbox] = []
             submitDict[sandbox].append(job)
 
 
         # Now submit the bastards
-        for sandbox in submitDict.keys():
+        for sandbox in submitDict:
             jobList = submitDict.get(sandbox, [])
             while len(jobList) > 0:
                 jobsReady = jobList[:self.config.JobSubmitter.jobsPerWorker]

--- a/src/python/WMCore/BossAir/Plugins/MockPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/MockPlugin.py
@@ -4,6 +4,8 @@ _BossAirPlugin_
 
 Base class for BossAir plugins
 """
+from __future__ import division
+from builtins import range
 
 import os
 import logging
@@ -218,7 +220,7 @@ class MockPlugin(BasePlugin):
         else:
             nowt = datetime.now()
         #Compute some random (between 0 and 20% of the total running time)
-        randlen = randint(0, self.jobRunTime*20/100)
+        randlen = randint(0, int(self.jobRunTime * 20 / 100))
         totlen = randlen + self.jobRunTime
         self.jobsScheduledEnd[job['id']] = nowt + timedelta(minutes = totlen)
         logging.debug('Scheduled end time of job %s to %s' % (job['id'], self.jobsScheduledEnd[job['id']]))

--- a/src/python/WMCore/JobSplitting/Generators/GeneratorInterface.py
+++ b/src/python/WMCore/JobSplitting/Generators/GeneratorInterface.py
@@ -6,6 +6,9 @@ API definition for Generator objects
 
 """
 
+from builtins import object
+
+
 class GeneratorInterface(object):
     """
     _GeneratorInterface_

--- a/src/python/WMCore/JobSplitting/Generators/GeneratorManager.py
+++ b/src/python/WMCore/JobSplitting/Generators/GeneratorManager.py
@@ -7,12 +7,15 @@ and then apply them to job groups
 
 """
 
+from builtins import map, object
+from future.utils import viewvalues
+
 from WMCore.JobSplitting.Generators.GeneratorFactory import GeneratorFactory
 
 from WMCore.WMSpec.WMTask import WMTask, WMTaskHelper
 from WMCore.WMSpec.ConfigSectionTree import *
 
-class GeneratorManager:
+class GeneratorManager(object):
     """
     _GeneratorManager_
 
@@ -67,7 +70,7 @@ class GeneratorManager:
         job group provided
 
         """
-        [ list(map(generator, jobGroup.jobs)) for generator in self.generators.values()]
+        [list(map(generator, jobGroup.jobs)) for generator in viewvalues(self.generators)]
         return
 
 
@@ -79,7 +82,7 @@ class GeneratorManager:
         """
         generatorList = []
 
-        for name in self.generators.keys():
-            generatorList.append(self.generators[name])
+        for generator in viewvalues(self.generators):
+            generatorList.append(generator)
 
         return generatorList

--- a/src/python/WMCore/JobSplitting/Generators/PresetSeeder.py
+++ b/src/python/WMCore/JobSplitting/Generators/PresetSeeder.py
@@ -20,5 +20,5 @@ class PresetSeeder(GeneratorInterface):
 
     def __call__(self, wmbsJob):
         baggage = wmbsJob.getBaggage()
-        for x in self.options.keys():
+        for x in self.options:
             wmbsJob.addBaggageParameter("PresetSeeder.%s" %(x), self.options[x])

--- a/src/python/WMCore/JobSplitting/Generators/RandomSeeder.py
+++ b/src/python/WMCore/JobSplitting/Generators/RandomSeeder.py
@@ -21,5 +21,5 @@ class RandomSeeder(GeneratorInterface):
 
     def __call__(self, wmbsJob):
         baggage = wmbsJob.getBaggage()
-        for x in self.options.keys():
+        for x in self.options:
             wmbsJob.addBaggageParameter("RandomSeeder.%s" %(x), random.randint(1, self._MAXINT))

--- a/src/python/WMCore/JobSplitting/Generators/ReproducibleSeeding.py
+++ b/src/python/WMCore/JobSplitting/Generators/ReproducibleSeeding.py
@@ -40,7 +40,7 @@ class ReproducibleSeeding(GeneratorInterface):
         confCache.load()
         seeds = confCache.document[u'pset_tweak_details'][u'process'][u'RandomNumberGeneratorService']
         self.seedTable = []
-        for k in seeds.keys():
+        for k in seeds:
             if k == u"parameters_" : continue
             self.seedTable.append("process.RandomNumberGeneratorService.%s.initialSeed" % k)
 

--- a/src/python/WMCore/WMRuntime/Monitors/WMRuntimeMonitor.py
+++ b/src/python/WMCore/WMRuntime/Monitors/WMRuntimeMonitor.py
@@ -9,6 +9,7 @@ This is the base class for monitors
 
 
 
+from builtins import object
 import threading
 import os
 
@@ -27,7 +28,7 @@ class WMRuntimeMonitorException(WMException):
     """
     pass
 
-class WMRuntimeMonitor:
+class WMRuntimeMonitor(object):
 
 
     def __init__(self):

--- a/src/python/WMCore/WMSpec/Makers/Interface/CreateWorkArea.py
+++ b/src/python/WMCore/WMSpec/Makers/Interface/CreateWorkArea.py
@@ -2,6 +2,9 @@
 
 
 
+from __future__ import division
+from builtins import object
+
 import os
 import os.path
 import threading
@@ -23,7 +26,7 @@ from WMCore.WMSpec.WMTask                   import WMTask, WMTaskHelper
 #I'm wondering if it's better to multithread in a different way
 
 
-class CreateScript:
+class CreateScript(object):
     """
     Simple class for creating file objects
 
@@ -100,7 +103,7 @@ class CreateScript:
             fd.write(self.script)
         return
 
-class CreateWorkArea:
+class CreateWorkArea(object):
     """
     Basic class for doing the JobMaker dirty work
 
@@ -285,7 +288,7 @@ class CreateWorkArea:
         Create a sub-directory to allow storage of large jobs
         """
 
-        value = jobCounter/1000
+        value = jobCounter // 1000
         jobCollDir = '%s/JobCollection_%i_%i' %(taskDir, self.jobGroup.id, value)
         #Set this to a global variable
         self.collectionDir = jobCollDir

--- a/src/python/WMCore/WMSpec/Makers/TaskMaker.py
+++ b/src/python/WMCore/WMSpec/Makers/TaskMaker.py
@@ -9,6 +9,7 @@ to start as a proper job.
 """
 from __future__ import print_function
 
+from builtins import object
 import logging
 import os.path
 import threading
@@ -28,7 +29,7 @@ from WMCore.WMSpec.WMWorkload import WMWorkload, WMWorkloadHelper
 #
 
 
-class TaskMaker:
+class TaskMaker(object):
     """
     Class for separating and starting all tasks in a WMWorkload
 
@@ -115,7 +116,7 @@ class TaskMaker:
         for toptask in self.workload.taskIterator():
             # for each task, build sandbox, register, and subscribe
             for task in toptask.taskIterator():
-                if task.name() in self.workflowDict.keys():
+                if task.name() in self.workflowDict:
                     raise Exception(
                         'Duplicate task name for workload %s, task %s' % (self.workload.name(), task.name()))
 
@@ -155,7 +156,7 @@ class TaskMaker:
             dummyStepName = task.inputReference().inputStep.split('/')[-1]
             taskName = task.inputReference().inputStep.split('/')[-2]
             outputModule = task.inputReference().outputModule
-            if taskName not in self.workflowDict.keys():
+            if taskName not in self.workflowDict:
                 raise Exception('I am being asked to chain output for a task %s which does not yet exist' % taskName)
             outputWorkflow = self.workflowDict[taskName]
             outputWorkflow.addOutput(outputModule, fileSet)

--- a/src/python/WMCore/WMStats/Service/RequestInfo.py
+++ b/src/python/WMCore/WMStats/Service/RequestInfo.py
@@ -124,4 +124,4 @@ class TeamInfo(RESTEntity):
     @tools.expires(secs=-1)
     def get(self):
         result = self.wmstats.agentsByTeam(filterDrain=False)
-        return rows(result.keys())
+        return rows(result)

--- a/src/python/WMQuality/Emulators/WMSpecGenerator/ReqMgrDocGenerator.py
+++ b/src/python/WMQuality/Emulators/WMSpecGenerator/ReqMgrDocGenerator.py
@@ -1,4 +1,6 @@
 from __future__ import (print_function, division)
+from builtins import range
+
 import time
 import random
 
@@ -31,7 +33,7 @@ def generate_reqmgr_schema(number=NUM_OF_REQUEST):
     #doc['team'] = schema['team']
     """
     docs = []
-    for i in xrange(number):
+    for i in range(number):
         doc = {"RequestName": "test_workflow_%s" % i,
                "InputDataset": "/Photon/Run2011A-v1/RAW",
                "Group": "cmsdataops",
@@ -83,7 +85,7 @@ def generate_reqmgr_requests(number=NUM_OF_REQUEST):
     }
     """
     docs = []
-    for i in xrange(number):
+    for i in range(number):
         doc = {"_id": "test_workflow_%s" % i,
                "inputdataset": "/Photon/Run2011A-v1/RAW",
                "group": "cmsdataops",
@@ -135,8 +137,8 @@ def generate_agent_requests(number=NUM_OF_REQUEST, iterations=ITERATIONS):
     """
     current_time = int(time.time())
     docs = []
-    for cycle in xrange(iterations):
-        for i in xrange(number):
+    for cycle in range(iterations):
+        for i in range(number):
             doc = {"status": {"inWMBS": 12,
                               "submitted": {"retry": 2, "running": 2, "pending": 2, "first": 2},
                               "failure": {"exception": 2, "create": 2, "submit": 2},
@@ -216,7 +218,7 @@ def generate_jobsummary(request, number=NUM_OF_JOBS_PER_REQUEST):
      'jobfailed', 'createcooloff',  'submitcooloff', 'jobcooloff', 'success',
      'exhausted', 'killed']
 
-    for i in xrange(number):
+    for i in range(number):
         status = statusList[random.randint(0, len(statusList)-1)]
         errmsgs = {}
         if status.find("failed"):

--- a/src/python/WMQuality/Emulators/WMSpecGenerator/WMSpecGenerator.py
+++ b/src/python/WMQuality/Emulators/WMSpecGenerator/WMSpecGenerator.py
@@ -2,8 +2,9 @@
 """
     WorkQueue tests
 """
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
+from builtins import range, object
+
 import os
 import shutil
 import tempfile

--- a/test/python/WMComponent_t/AnalyticsDataCollector_t/Plugins_t/Tier0Plugin_t.py
+++ b/test/python/WMComponent_t/AnalyticsDataCollector_t/Plugins_t/Tier0Plugin_t.py
@@ -7,6 +7,8 @@ Created on Nov 7, 2012
 
 @author: dballest
 """
+from __future__ import division
+from builtins import range
 
 import os
 import unittest
@@ -274,11 +276,11 @@ class Tier0PluginTest(unittest.TestCase):
         """
 
         for idx in range(0, len(self.orderedStates) * 2):
-            nextState = self.orderedStates[idx / 2]
-            if (idx / 2) == 0:
+            nextState = self.orderedStates[idx // 2]
+            if (idx // 2) == 0:
                 currentState = 'Closed'
             else:
-                currentState = self.orderedStates[idx / 2 - 1]
+                currentState = self.orderedStates[idx // 2 - 1]
             if idx % 2 == 0:
                 for transitionObject in self.stateMap[nextState][:-1]:
                     method = getattr(transitionObject, transitionMethod)

--- a/test/python/WMCore_t/JobSplitting_t/Generators_t/Seeders_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/Generators_t/Seeders_t.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+from __future__ import division
+from builtins import range
+
 import unittest
 
 
@@ -122,7 +125,7 @@ class SeederTest(unittest.TestCase):
                 self.assertEqual(hasattr(conf.RandomSeeder.evtgenproducer, 'initialSeed'), True)
                 self.assertEqual(hasattr(conf.RandomSeeder.generator, 'initialSeed'), True)
                 self.assertEqual(job["mask"]["FirstLumi"], count%11)
-                self.assertEqual(job["mask"]["FirstRun"],  (count/11) + 1)
+                self.assertEqual(job["mask"]["FirstRun"],  (count // 11) + 1)
                 count += 1
 
         return


### PR DESCRIPTION
Fixes #10147 

#### Status
In development 

#### Related PRs

* Previous migration PR: #10362  (slice22, issue #10146 )
* Next migration PR: #10371 (slice24, issue #10148 )

#### Description

Run futurize and some manual changes on the first batch of src/python/A/B/C.

"Native String" approach (use `str` in both py2 and py3, hoping that it stays consistent within the same runtime):
- `src/python/WMCore/BossAir/Plugins/MockPlugin.py`: using `jobid = str(jj['id'])` to append a str to `tmpname = report.cmsRun1.output.output.files.file0.lfn.split('.root')[0]`. Not a problem if it is kept as a `str` in both py2 and py3
- `src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py`: 
  - format input of `classad.quote(input)`, which should accept a `str` input in py3 as well [as they claim](https://htcondor.readthedocs.io/en/latest/apis/python-bindings/api/classad.html#classad.quote), but better be safe than sorry and check this.
  - format a ton of keys of a dict that is appended to `JobParameters`, such as `ad['My.OriginalCpus'] = str(origCores)`. If this is used only by us in `SimpleCondorPlugin.createSubmitRequest` and not by WMCore clients, we may be in a good spot.
  - tracked in #10378


#### Is it backward compatible (if not, which system it affects?)

It should be. (Any possible cause for errors will we reported here)

#### External dependencies / deployment changes

Requires python-future in both py2 and py3 environments.
