### PR TITLE
Account for tape rule status in MSRulecleaner.

### DIFF
--- a/src/python/WMCore/MicroService/MSRuleCleaner/MSRuleCleanerWflow.py
+++ b/src/python/WMCore/MicroService/MSRuleCleaner/MSRuleCleanerWflow.py
@@ -180,6 +180,7 @@ class MSRuleCleanerWflow(dict):
                               'plineAgentCont': False,
                               'plineAgentBlock': False},
             "TransferDone": False  # information - returned by the MSOutput REST call.
+            "TransferTape": False  # information - fetched by Rucio about tape rules completion
             'TargetStatus': 'normal-archived' || 'rejected-achived' || 'aborted-archived',
             'ParentageResolved': Bool,
             'PlineMarkers': None,
@@ -204,6 +205,7 @@ class MSRuleCleanerWflow(dict):
             ('RulesToClean', {}, dict),
             ('CleanupStatus', {}, dict),
             ('TransferDone', False, bool),
+            ('TransferTape', False, bool),
             ('TargetStatus', None, (bytes, str)),
             ('ParentageResolved', True, bool),
             ('PlineMarkers', None, list),

--- a/test/python/WMCore_t/MicroService_t/DataStructs_t/MSRuleCleanerWflow_t.py
+++ b/test/python/WMCore_t/MicroService_t/DataStructs_t/MSRuleCleanerWflow_t.py
@@ -108,7 +108,8 @@ class MSRuleCleanerWflowTest(unittest.TestCase):
                          'RequestType': u'TaskChain',
                          'RulesToClean': {},
                          'TargetStatus': None,
-                         'TransferDone': False}
+                         'TransferDone': False,
+                         'TransferTape': False}
         self.assertDictEqual(wflow, expectedWflow)
 
     def testReReco(self):
@@ -149,7 +150,8 @@ class MSRuleCleanerWflowTest(unittest.TestCase):
                          'RequestType': u'ReReco',
                          'RulesToClean': {},
                          'TargetStatus': None,
-                         'TransferDone': False}
+                         'TransferDone': False,
+                         'TransferTape': False}
         self.assertDictEqual(wflow, expectedWflow)
 
     def testIncludeParents(self):
@@ -184,7 +186,8 @@ class MSRuleCleanerWflowTest(unittest.TestCase):
                          'RequestType': u'StepChain',
                          'RulesToClean': {},
                          'TargetStatus': None,
-                         'TransferDone': False}
+                         'TransferDone': False,
+                         'TransferTape': False}
         self.assertDictEqual(wflow, expectedWflow)
 
     def testMultiPU(self):
@@ -222,7 +225,8 @@ class MSRuleCleanerWflowTest(unittest.TestCase):
                          'RequestType': u'StepChain',
                          'RulesToClean': {},
                          'TargetStatus': None,
-                         'TransferDone': False}
+                         'TransferDone': False,
+                         'TransferTape': False}
         self.assertDictEqual(wflow, expectedWflow)
 
 

--- a/test/python/WMCore_t/MicroService_t/Unified_t/MSRuleCleaner_t.py
+++ b/test/python/WMCore_t/MicroService_t/Unified_t/MSRuleCleaner_t.py
@@ -116,7 +116,8 @@ class MSRuleCleanerTest(unittest.TestCase):
                          'RequestType': u'TaskChain',
                          'RulesToClean': {'plineAgentBlock': []},
                          'TargetStatus': None,
-                         'TransferDone': False}
+                         'TransferDone': False,
+                         'TransferTape': False}
         self.assertDictEqual(wflow, expectedWflow)
 
     def testPipelineAgentCont(self):
@@ -156,7 +157,8 @@ class MSRuleCleanerTest(unittest.TestCase):
                          'RequestType': u'TaskChain',
                          'RulesToClean': {'plineAgentCont': []},
                          'TargetStatus': None,
-                         'TransferDone': False}
+                         'TransferDone': False,
+                         'TransferTape': False}
         self.assertDictEqual(wflow, expectedWflow)
 
     def testPipelineMSTrBlock(self):
@@ -198,7 +200,8 @@ class MSRuleCleanerTest(unittest.TestCase):
                          'RequestType': u'TaskChain',
                          'RulesToClean': {'plineMSTrBlock': []},
                          'TargetStatus': None,
-                         'TransferDone': False}
+                         'TransferDone': False,
+                         'TransferTape': False}
         self.assertDictEqual(wflow, expectedWflow)
 
     def testPipelineMSTrCont(self):
@@ -240,7 +243,8 @@ class MSRuleCleanerTest(unittest.TestCase):
                          'RequestType': u'TaskChain',
                          'RulesToClean': {'plineMSTrCont': []},
                          'TargetStatus': None,
-                         'TransferDone': False}
+                         'TransferDone': False,
+                         'TransferTape': False}
         self.assertDictEqual(wflow, expectedWflow)
 
     def testPipelineArchive(self):
@@ -294,7 +298,8 @@ class MSRuleCleanerTest(unittest.TestCase):
                          'RequestType': u'TaskChain',
                          'RulesToClean': {'plineAgentBlock': [], 'plineAgentCont': []},
                          'TargetStatus': 'normal-archived',
-                         'TransferDone': False}
+                         'TransferDone': False,
+                         'TransferTape': False}
         self.assertDictEqual(wflow, expectedWflow)
 
         # Try archival of an uncleaned workflow


### PR DESCRIPTION
Fixes #10027 

#### Status
ready

#### Description
Almost all workflows, which are having some output, need to have tape rule created by MSOutput (account: `wmcore_output`). Exceptions are:
   * RelVals
   * Workflows configured in Unified to not save output on tape 

Up to now we were not accounting for tape rule status in the process of cleaning the Rucio rules for a given workflow. With the current change the status of all tape rules is required to be in a final ('OK') state, or no tape rules to have ever been created for the workflow, in order for the cleaning process to start.     

#### Is it backward compatible (if not, which system it affects?)
YES 

#### Related PRs
NO

#### External dependencies / deployment changes
NO