### PR TITLE
[py2py3] Migration at level scr/python/A/B/C - slice 24 

### DIFF
--- a/src/python/WMComponent/TaskArchiver/CleanCouchPoller.py
+++ b/src/python/WMComponent/TaskArchiver/CleanCouchPoller.py
@@ -1,6 +1,10 @@
 """
 Perform cleanup actions
 """
+from __future__ import division
+from builtins import range
+from future.utils import viewitems
+
 from future import standard_library
 standard_library.install_aliases()
 
@@ -361,7 +365,7 @@ class CleanCouchPoller(BaseWorkerThread):
 
             workflowDict = self.centralRequestDBReader.getStatusAndTypeByRequest(requestNames)
 
-            for request, value in workflowDict.items():
+            for request, value in viewitems(workflowDict):
                 if value[0].endswith("-archived"):
                     self.cleanAllLocalCouchDB(request)
                     numDeletedRequests += 1
@@ -422,7 +426,7 @@ class CleanCouchPoller(BaseWorkerThread):
                 # Get the task-workflow ids, sort them by ID,
                 # higher ID first so we kill
                 # the leaves of the tree first, root last
-                workflowsIDs = workflows[workflow]["workflows"].keys()
+                workflowsIDs = list(workflows[workflow]["workflows"])
                 workflowsIDs.sort(reverse=True)
 
                 # Now go through all tasks and load the WMBS workflow objects
@@ -536,7 +540,7 @@ class CleanCouchPoller(BaseWorkerThread):
         for row in retryData:
             taskName = row['key'][2]
             count = str(row['key'][1])
-            if taskName not in workflowData['retryData'].keys():
+            if taskName not in workflowData['retryData']:
                 workflowData['retryData'][taskName] = {}
             workflowData['retryData'][taskName][count] = row['value']
 
@@ -561,7 +565,7 @@ class CleanCouchPoller(BaseWorkerThread):
         workflowData['performance'] = {}
         for key in perf:
             workflowData['performance'][key] = {}
-            for attr in perf[key].keys():
+            for attr in perf[key]:
                 workflowData['performance'][key][attr] = perf[key][attr]
 
         workflowData["_id"] = workflowName
@@ -583,7 +587,7 @@ class CleanCouchPoller(BaseWorkerThread):
             workflowData['output'][dataset]['nFiles'] = entry['count']
             workflowData['output'][dataset]['size'] = entry['size']
             workflowData['output'][dataset]['events'] = entry['events']
-            workflowData['output'][dataset]['tasks'] = outputList.get(dataset, {}).keys()
+            workflowData['output'][dataset]['tasks'] = list(outputList.get(dataset, {}))
 
         # If the workflow was aborted, then don't parse all the jobs, cut at 5k
         try:
@@ -650,15 +654,15 @@ class CleanCouchPoller(BaseWorkerThread):
                             'errorsBySite': DiscreteSummaryHistogram('Errors by site',
                                                                      'Site')}
                     errorsBySiteData = histograms['stepLevel'][task][step]['errorsBySite']
-                    if task not in workflowData['errors'].keys():
+                    if task not in workflowData['errors']:
                         workflowData['errors'][task] = {'failureTime': 0}
-                    if step not in workflowData['errors'][task].keys():
+                    if step not in workflowData['errors'][task]:
                         workflowData['errors'][task][step] = {}
                     workflowData['errors'][task]['failureTime'] += (stop - start)
                     stepFailures = workflowData['errors'][task][step]
                     for error in errors:
                         exitCode = str(error['exitCode'])
-                        if exitCode not in stepFailures.keys():
+                        if exitCode not in stepFailures:
                             stepFailures[exitCode] = {"errors": [],
                                                       "jobs": 0,
                                                       "input": [],
@@ -676,7 +680,7 @@ class CleanCouchPoller(BaseWorkerThread):
                                 stepFailures[exitCode]['input'].append(inputLFN)
                         # Add runs to structure
                         for run in runs:
-                            if str(run.run) not in stepFailures[exitCode]['runs'].keys():
+                            if str(run.run) not in stepFailures[exitCode]['runs']:
                                 stepFailures[exitCode]['runs'][str(run.run)] = []
                             logging.debug("number of lumis failed: %s", len(run.lumis))
                             nodupLumis = set(run.lumis)
@@ -772,16 +776,16 @@ class CleanCouchPoller(BaseWorkerThread):
         for row in perf:
             taskName = row['value']['taskName']
             stepName = row['value']['stepName']
-            if taskName not in taskList.keys():
+            if taskName not in taskList:
                 taskList[taskName] = {}
-            if stepName not in taskList[taskName].keys():
+            if stepName not in taskList[taskName]:
                 taskList[taskName][stepName] = []
             value = row['value']
             taskList[taskName][stepName].append(value)
 
-        for taskName in taskList.keys():
+        for taskName in taskList:
             final = {}
-            for stepName in taskList[taskName].keys():
+            for stepName in taskList[taskName]:
                 output = {'jobTime': []}
                 outputFailed = {'jobTime': []}  # This will be same, but only for failed jobs
                 final[stepName] = {}
@@ -791,10 +795,10 @@ class CleanCouchPoller(BaseWorkerThread):
                 # keyed by the name of the value
                 for row in taskList[taskName][stepName]:
                     masterList.append(row)
-                    for key in row.keys():
+                    for key in row:
                         if key in ['startTime', 'stopTime', 'taskName', 'stepName', 'jobID']:
                             continue
-                        if key not in output.keys():
+                        if key not in output:
                             output[key] = []
                             if len(failedJobs) > 0:
                                 outputFailed[key] = []
@@ -823,7 +827,7 @@ class CleanCouchPoller(BaseWorkerThread):
                         pass
 
                 # Now that we've sorted the data, we process it one key at a time
-                for key in output.keys():
+                for key in output:
                     final[stepName][key] = {}
                     # Assemble the 'worstOffenders'
                     # These are the top [self.nOffenders] in that particular category
@@ -994,14 +998,14 @@ class CleanCouchPoller(BaseWorkerThread):
             # Those should come from the config :
             if points[i] == 0:
                 continue
-            binSize = responseJSON["hist"]["xaxis"]["last"]["value"] / responseJSON["hist"]["xaxis"]["last"]["id"]
+            binSize = responseJSON["hist"]["xaxis"]["last"]["value"] // responseJSON["hist"]["xaxis"]["last"]["id"]
             # Fetching the important values
             instLuminosity = i * binSize
             timePerEvent = points[i]
 
             if instLuminosity > minLumi and instLuminosity < maxLumi:
                 worthPoints[instLuminosity] = timePerEvent
-        logging.debug("Got %d worthwhile performance points", len(worthPoints.keys()))
+        logging.debug("Got %d worthwhile performance points", len(worthPoints))
 
         return worthPoints
 

--- a/src/python/WMCore/BossAir/MySQL/Create.py
+++ b/src/python/WMCore/BossAir/MySQL/Create.py
@@ -96,7 +96,7 @@ class Create(DBCreator):
         everything is in place have the DBCreator make everything.
         """
         for requiredTable in self.requiredTables:
-            if requiredTable not in self.create.keys():
+            if requiredTable not in self.create:
                 raise WMException("The table '%s' is not defined." % \
                                   requiredTable, "WMCORE-2")
 

--- a/src/python/WMCore/BossAir/MySQL/JobStatusByLocation.py
+++ b/src/python/WMCore/BossAir/MySQL/JobStatusByLocation.py
@@ -5,6 +5,7 @@ _JobStatusByLocation_
 MySQL implementation for loading a job by scheduler status
 """
 
+from future.utils import viewitems, viewvalues
 
 from WMCore.Database.DBFormatter import DBFormatter
 
@@ -48,7 +49,7 @@ class JobStatusByLocation(DBFormatter):
                                 globals(), locals(), [data['plugin']])
             plugIn = getattr(module, data['plugin'])
 
-            for status in plugIn.stateMap().values():
+            for status in viewvalues(plugIn.stateMap()):
                 commonStates[data['site_name']].setdefault(status, 0)
 
             state = plugIn.stateMap().get(data['status'])
@@ -56,7 +57,7 @@ class JobStatusByLocation(DBFormatter):
             commonStates[data['site_name']]['pending_slots'] = data['pending_slots']
 
         results = []
-        for key, value in commonStates.items():
+        for key, value in viewitems(commonStates):
             reformedData = {'site_name': key}
             reformedData.update(value)
             results.append(reformedData)

--- a/src/python/WMCore/BossAir/MySQL/JobStatusForMonitoring.py
+++ b/src/python/WMCore/BossAir/MySQL/JobStatusForMonitoring.py
@@ -5,6 +5,7 @@ _JobStatusMonitoring_
 MySQL implementation for loading a job by scheduler status
 """
 
+from future.utils import viewitems
 
 from WMCore.Database.DBFormatter import DBFormatter
 
@@ -55,7 +56,7 @@ class JobStatusForMonitoring(DBFormatter):
             commonStates[data['workflow']][state] += data['num_jobs']
 
         results = []
-        for key, value in commonStates.items():
+        for key, value in viewitems(commonStates):
             reformedData = {'request_name': key}
             reformedData.update(value)
             results.append(reformedData)

--- a/src/python/WMCore/ReqMgr/Service/Auxiliary.py
+++ b/src/python/WMCore/ReqMgr/Service/Auxiliary.py
@@ -5,6 +5,7 @@ Teams, Groups, Software versions handling for ReqMgr.
 
 """
 from __future__ import print_function, division
+from future.utils import listvalues
 
 import json
 import cherrypy
@@ -195,7 +196,7 @@ class AuxBaseAPI(RESTEntity):
             cherrypy.log(msg)
             raise cherrypy.HTTPError(404, msg)
 
-        return allDocs.values()
+        return listvalues(allDocs)
 
     @restcall(formats=[('application/json', JSONFormat())])
     def post(self, subName=None):

--- a/src/python/WMCore/ReqMgr/Service/RequestAdditionalInfo.py
+++ b/src/python/WMCore/ReqMgr/Service/RequestAdditionalInfo.py
@@ -1,4 +1,5 @@
 from __future__ import (print_function, division)
+from future.utils import viewitems
 
 import json
 import traceback
@@ -27,7 +28,7 @@ def format_algo_web_list(task_name, task_type, split_param, algo_config):
 
     if default_algo in algo_list:
         new_param = {"algorithm": default_algo}
-        for key, value in split_param.items():
+        for key, value in viewitems(split_param):
             if key in algo_config["algo_params"][default_algo]:
                 new_param[key] = value
         param_list.append(new_param)

--- a/src/python/WMCore/ReqMgr/Service/RestApiHub.py
+++ b/src/python/WMCore/ReqMgr/Service/RestApiHub.py
@@ -5,6 +5,7 @@ Implementation of handles is in corresponding modules, not here.
 """
 from __future__ import print_function, division
 
+from builtins import object
 import cherrypy
 
 from WMCore.Configuration import Configuration

--- a/src/python/WMCore/ReqMgr/Utils/Validation.py
+++ b/src/python/WMCore/ReqMgr/Utils/Validation.py
@@ -3,6 +3,8 @@ ReqMgr request handling.
 
 """
 from __future__ import print_function
+from future.utils import viewitems, viewvalues
+
 from hashlib import md5
 from WMCore.Lexicon import procdataset
 from WMCore.REST.Auth import authz_match
@@ -123,7 +125,7 @@ def validate_resubmission_create_args(request_args, config, reqmgr_db_service, *
     *arg and **kwargs are only for the interface
     """
     response = reqmgr_db_service.getRequestByNames(request_args["OriginalRequestName"])
-    originalArgs = response.values()[0]
+    originalArgs = next(iter(viewvalues(response)))
 
     ### not a nice fix for #8245, but we cannot inherit the CollectionName attr
     originalArgs.pop("CollectionName", None)
@@ -165,7 +167,7 @@ def validate_clone_create_args(request_args, config, reqmgr_db_service, *args, *
     *arg and **kwargs are only for the interface
     """
     response = reqmgr_db_service.getRequestByNames(request_args.pop("OriginalRequestName"))
-    originalArgs = response.values()[0]
+    originalArgs = next(iter(viewvalues(response)))
 
     chainArgs = None
     specClass = loadSpecClassByType(originalArgs["RequestType"])
@@ -199,7 +201,7 @@ def validate_state_transition(reqmgr_db_service, request_name, new_state):
     requests = reqmgr_db_service.getRequestByNames(request_name)
     # generator object can't be subscribed: need to loop.
     # only one row should be returned
-    for request in requests.values():
+    for request in viewvalues(requests):
         current_state = request["RequestStatus"]
     if not check_allowed_transition(current_state, new_state):
         raise InvalidStateTransition(current_state, new_state)
@@ -208,7 +210,7 @@ def validate_state_transition(reqmgr_db_service, request_name, new_state):
 
 def create_json_template_spec(specArgs):
     template = {}
-    for key, prop in specArgs.items():
+    for key, prop in viewitems(specArgs):
 
         if key == "RequestorDN":
             # this will be automatically collected so skip it.

--- a/test/python/WMComponent_t/JobCreator_t/JobCreator_t.py
+++ b/test/python/WMComponent_t/JobCreator_t/JobCreator_t.py
@@ -5,6 +5,7 @@
 # E1103: Use thread members
 
 from __future__ import print_function
+from builtins import range, object
 
 import cProfile
 import os

--- a/test/python/WMComponent_t/TaskArchiver_t/TaskArchiver_t.py
+++ b/test/python/WMComponent_t/TaskArchiver_t/TaskArchiver_t.py
@@ -5,6 +5,9 @@ TaskArchiver test
 Tests both the archiving of tasks and the creation of the
 workloadSummary
 """
+from __future__ import division
+from builtins import range
+
 import json
 import logging
 import os.path
@@ -278,7 +281,7 @@ class TaskArchiverTest(EmulatedUnitTestCase):
         changer.propagate(testJobGroup.jobs, 'executing', 'created')
         changer.propagate(testJobGroup.jobs, 'complete', 'executing')
         for i in range(self.nJobs):
-            if i < self.nJobs / 2:
+            if i < self.nJobs // 2:
                 testJobGroup.jobs[i]['fwjr'] = report1
             else:
                 testJobGroup.jobs[i]['fwjr'] = report2
@@ -399,7 +402,7 @@ class TaskArchiverTest(EmulatedUnitTestCase):
             # Those should come from the config :
             if points[i] == 0:
                 continue
-            binSize = responseJSON["hist"]["xaxis"]["last"]["value"] / responseJSON["hist"]["xaxis"]["last"]["id"]
+            binSize = responseJSON["hist"]["xaxis"]["last"]["value"] // responseJSON["hist"]["xaxis"]["last"]["id"]
             # Fetching the important values
             instLuminosity = i * binSize
             timePerEvent = points[i]
@@ -526,7 +529,7 @@ class TaskArchiverTest(EmulatedUnitTestCase):
         self.assertEqual(workloadSummary['ACDCServer'], sanitizeURL(config.ACDC.couchurl)['url'])
 
         # Check the output
-        self.assertEqual(workloadSummary['output'].keys(), ['/Electron/MorePenguins-v0/RECO'])
+        self.assertEqual(list(workloadSummary['output']), ['/Electron/MorePenguins-v0/RECO'])
         self.assertEqual(sorted(workloadSummary['output']['/Electron/MorePenguins-v0/RECO']['tasks']),
                          ['/TestWorkload/ReReco', '/TestWorkload/ReReco/LogCollect'])
         # Check performance
@@ -564,7 +567,7 @@ class TaskArchiverTest(EmulatedUnitTestCase):
 
         # LogCollect task is made out of identical FWJRs
         # assert that it is identical
-        for x in workloadSummary['performance']['/TestWorkload/ReReco/LogCollect']['cmsRun1'].keys():
+        for x in workloadSummary['performance']['/TestWorkload/ReReco/LogCollect']['cmsRun1']:
             if x in config.TaskArchiver.histogramKeys:
                 continue
             for y in ['average', 'stdDev']:

--- a/test/python/WMCore_t/ReqMgr_t/Service_t/Auxiliary_t.py
+++ b/test/python/WMCore_t/ReqMgr_t/Service_t/Auxiliary_t.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+from builtins import range
 from future import standard_library
 standard_library.install_aliases()
 
@@ -29,7 +30,7 @@ class AuxiliaryTest(RESTBaseUnitTestWithDBBackend):
     def testProcStatus(self):
         """Test the `proc_status` REST API"""
         res = self.jsonSender.get("data/proc_status")
-        self.assertItemsEqual(res[0]["result"][0].keys(), ['server'])
+        self.assertItemsEqual(list(res[0]["result"][0]), ['server'])
 
     def testInfo(self):
         """Test the `info` REST API"""
@@ -68,7 +69,7 @@ class AuxiliaryTest(RESTBaseUnitTestWithDBBackend):
 
         res = self.jsonSender.get("data/cmsswversions")
         self.assertTrue(res[0]["result"][0]["ConfigType"] == "CMSSW_VERSIONS")
-        self.assertItemsEqual(res[0]["result"][0].keys(), ["slc6", "slc7", "ConfigType"])
+        self.assertItemsEqual(list(res[0]["result"][0]), ["slc6", "slc7", "ConfigType"])
 
     def testPutCMSSWVersions(self):
         """Test the `cmsswversions` REST API with PUT call"""
@@ -77,7 +78,7 @@ class AuxiliaryTest(RESTBaseUnitTestWithDBBackend):
         self.assertTrue(res)
 
         res = self.jsonSender.get("data/cmsswversions")
-        self.assertItemsEqual(res[0]["result"][0].keys(), ["slc6", "ConfigType"])
+        self.assertItemsEqual(list(res[0]["result"][0]), ["slc6", "ConfigType"])
 
     def testWMAgentConfig(self):
         """Test the `wmagentconfig` REST API"""
@@ -88,7 +89,7 @@ class AuxiliaryTest(RESTBaseUnitTestWithDBBackend):
 
         res = self.jsonSender.get("data/wmagentconfig/%s" % docName)
         self.assertTrue(res[0]["result"][0]["ConfigType"] == "WMAGENT_CONFIG")
-        self.assertItemsEqual(res[0]["result"][0].keys(), ["key1", "ConfigType"])
+        self.assertItemsEqual(list(res[0]["result"][0]), ["key1", "ConfigType"])
 
     @attr("integration")
     def testPutWMAgentConfig(self):
@@ -106,7 +107,7 @@ class AuxiliaryTest(RESTBaseUnitTestWithDBBackend):
 
         res = self.jsonSender.get("data/wmagentconfig/%s" % docName)
         self.assertTrue(res[0]["result"][0]["ConfigType"] == "WMAGENT_CONFIG")
-        self.assertItemsEqual(res[0]["result"][0].keys(), ["key2", "nono", "ConfigType"])
+        self.assertItemsEqual(list(res[0]["result"][0]), ["key2", "nono", "ConfigType"])
 
     def testCampaignConfig(self):
         """Test the `campaignconfig` REST API"""
@@ -117,7 +118,7 @@ class AuxiliaryTest(RESTBaseUnitTestWithDBBackend):
 
         res = self.jsonSender.get("data/campaignconfig/%s" % docName)
         self.assertTrue(res[0]["result"][0]["ConfigType"] == "CAMPAIGN_CONFIG")
-        self.assertItemsEqual(res[0]["result"][0].keys(), ["campName", "keyblah", "ConfigType"])
+        self.assertItemsEqual(list(res[0]["result"][0]), ["campName", "keyblah", "ConfigType"])
 
     @attr("integration")
     def testPutCampaignConfig(self):
@@ -135,7 +136,7 @@ class AuxiliaryTest(RESTBaseUnitTestWithDBBackend):
 
         res = self.jsonSender.get("data/campaignconfig/%s" % docName)
         self.assertTrue(res[0]["result"][0]["ConfigType"] == "CAMPAIGN_CONFIG")
-        self.assertItemsEqual(res[0]["result"][0].keys(), ["campName", "keyblah", "ConfigType"])
+        self.assertItemsEqual(list(res[0]["result"][0]), ["campName", "keyblah", "ConfigType"])
 
     def testUnifiedConfig(self):
         """Test the `unifiedconfig` REST API"""
@@ -146,7 +147,7 @@ class AuxiliaryTest(RESTBaseUnitTestWithDBBackend):
 
         res = self.jsonSender.get("data/unifiedconfig/%s" % docName)
         self.assertTrue(res[0]["result"][0]["ConfigType"] == "UNIFIED_CONFIG")
-        self.assertItemsEqual(res[0]["result"][0].keys(), ["key1", "ConfigType"])
+        self.assertItemsEqual(list(res[0]["result"][0]), ["key1", "ConfigType"])
 
     @attr("integration")
     def testPutUnifiedConfig(self):
@@ -163,7 +164,7 @@ class AuxiliaryTest(RESTBaseUnitTestWithDBBackend):
         self.assertTrue(res)
 
         res = self.jsonSender.get("data/unifiedconfig/%s" % docName)
-        self.assertItemsEqual(res[0]["result"][0].keys(), ["key2", "key3", "ConfigType"])
+        self.assertItemsEqual(list(res[0]["result"][0]), ["key2", "key3", "ConfigType"])
 
     def testTransferInfo(self):
         """Test the `transferinfo` REST API"""
@@ -174,7 +175,7 @@ class AuxiliaryTest(RESTBaseUnitTestWithDBBackend):
 
         res = self.jsonSender.get("data/transferinfo/%s" % docName)
         self.assertTrue(res[0]["result"][0]["ConfigType"] == "TRANSFER")
-        self.assertItemsEqual(res[0]["result"][0].keys(), ["key1", "ConfigType"])
+        self.assertItemsEqual(list(res[0]["result"][0]), ["key1", "ConfigType"])
 
     @attr("integration")
     def testPutTransferInfo(self):
@@ -191,7 +192,7 @@ class AuxiliaryTest(RESTBaseUnitTestWithDBBackend):
         self.assertTrue(res)
 
         res = self.jsonSender.get("data/transferinfo/%s" % docName)
-        self.assertItemsEqual(res[0]["result"][0].keys(), ["key2", "key3", "ConfigType"])
+        self.assertItemsEqual(list(res[0]["result"][0]), ["key2", "key3", "ConfigType"])
 
     def testAllTransferDocs(self):
         """Test the `transferinfo` REST API"""

--- a/test/python/WMCore_t/ReqMgr_t/Service_t/ReqMgr_t.py
+++ b/test/python/WMCore_t/ReqMgr_t/Service_t/ReqMgr_t.py
@@ -217,7 +217,7 @@ class ReqMgrTest(RESTBaseUnitTestWithDBBackend):
 
         response = self.getMultiRequestsWithAuth([requestName])
         self.assertEqual(self.resultLength(response), 1)
-        self.assertEqual(response[0]['result'][0].keys()[0], requestName)
+        self.assertEqual(list(response[0]['result'][0])[0], requestName)
 
         #response = self.cloneRequestWithAuth(requestName)
         #self.assertEqual(response[1], 200, "put request clone")


### PR DESCRIPTION
Fixes #10148 

#### Status
ready

#### Related PRs

* Previous migration PR: #10363  (slice23, issue #10147)
* Next migration PR: #10379  (slice25, issue #10149  )

#### Description

Run futurize and some manual changes on the first batch of src/python/A/B/C.

"Native string" approach:
- `src/python/WMComponent/TaskArchiver/CleanCouchPoller.py`: 
  - `str()` is used to format dict strings, such as `count = str(row['key'][1]) ; workflowData['retryData'][taskName][count] = row['value']` or `stepFailures[exitCode]['runs'][str(run.run)].append(l)`
  - this should not be a big problem, but we'd better check this: tracked in #10377
- `src/python/WMCore/ReqMgr/Service/RequestAdditionalInfo.py`: 
  - `str()` used in 
      ```python
      class WorkloadConfig(RESTEntity):
      ...
          @restcall(formats=[('text/plain', PrettyJSONFormat()), ('application/json', JSONFormat())])
          @tools.expires(secs=-1)
          def get(self, name):
              helper = WMWorkloadHelper()
              ...
              return str(helper.data)
      ```
      Which is directly used in `src/python/WMCore/ReqMgr/Service/RestApiHub.py`, which is not clear to me how it  works. It is possible that we need to return bytes at all costs here, we will have to check this.
  - tracked in #10376

Division:
- `src/python/WMComponent/TaskArchiver/CleanCouchPoller.py`: using the new division and it should be safe. 
    ```python
        summarySize = len(json.dumps(workflowData)) / 1024
        if summarySize > 6 * 1024:  # 6MB
            msg = "Workload summary for %s is too big: %d Kb. " % (workflowName, summarySize)
        ...
        logging.info("About to commit %d Kb of data for workflow summary for %s", summarySize, workflowName)

    ```
 
`pylint --py3k`: it complains about using `myexception.message` instead of `str(myexception)`. This is not a problem in this case, because `.message` is used only if `hasattr(myexception, "message")`. (I would rather refactor such behavior only if we spot an issue. Since this is not the case at the moment, I would not touch it)


#### Is it backward compatible (if not, which system it affects?)

It should be. (Any possible cause for errors will we reported here)

#### External dependencies / deployment changes

Requires python-future in both py2 and py3 environments.
