### PR TITLE
Change regex when building list of PR numbers in buildrelease

### DIFF
--- a/bin/buildrelease.sh
+++ b/bin/buildrelease.sh
@@ -77,7 +77,7 @@ echo "" >> $TMP_INFO
 
 # Use gitub public API to fetch pull request # from commit hash
 cat $TMP_COMMIT_HASHES | while read line; do
-  PR=$(curl -s https://api.github.com/search/issues?q=sha:$line | grep -Po '\"number\": \K[0-9]+')
+  PR=$(curl -s https://api.github.com/search/issues?q=sha:$line | grep -Po '\"html_url\": \"https://github.com/dmwm/WMCore/pull/\K[0-9]+' | sort | uniq)
   # Commits should have an associated PR, but just in case...
   if [[ $PR ]]
     then


### PR DESCRIPTION
Fixes #10288 

#### Status
ready

#### Description
Change the regex used to fetch a commit hash id such that it does not consider the github api contributor (Nicholas) which gets returned with that query. 

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
