### PR TITLE
Set output datasets to VALID in DBS3 before announcing a standard workflow

### DIFF
--- a/src/python/WMCore/MicroService/MSOutput/MSOutput.py
+++ b/src/python/WMCore/MicroService/MSOutput/MSOutput.py
@@ -260,8 +260,8 @@ class MSOutput(MSCore):
             msg += "It needs to be of type: MSOutputTemplate"
             raise UnsupportedError(msg)
 
-        dbsWriteUrl = self.msConfig["dbsWriteUrl"]
-        dbs3Writer = DBS3Writer(dbsWriteUrl)
+        dbs3Writer = DBS3Writer(url=self.msConfig["dbsReadUrl"],
+                                writeUrl=self.msConfig["dbsWriteUrl"])
 
         # if anything fail along the way, set it back to "pending"
         dbsUpdateStatus = "done"

--- a/src/python/WMCore/MicroService/MSOutput/MSOutputTemplate.py
+++ b/src/python/WMCore/MicroService/MSOutput/MSOutputTemplate.py
@@ -102,6 +102,7 @@ class MSOutputTemplate(dict):
                            'Copies': 1,
                            ...}],
                     "TransferStatus": "pending"|"done,
+                    "DBSUpdateStatus": "pending"|"done,
             "RequestType": ""
             }
         :return: a list of tuples
@@ -116,7 +117,8 @@ class MSOutputTemplate(dict):
             ('IsRelVal', False, bool),
             ('OutputDatasets', [], list),
             ('OutputMap', [], list),
-            ('TransferStatus', "pending", (bytes, str))]
+            ('TransferStatus', "pending", (bytes, str)),
+            ('DBSUpdateStatus', "pending", (bytes, str))]
         return docTemplate
 
     def outputMapSchema(self):
@@ -135,7 +137,8 @@ class MSOutputTemplate(dict):
              'DiskDestination': "",
              'TapeDestination': "",
              'DiskRuleID': "",
-             'TapeRuleID': ""}
+             'TapeRuleID': "",
+             'DBSStatus': ""}
         :return: a list of tuples
         """
         outMapTemplate = [
@@ -146,7 +149,8 @@ class MSOutputTemplate(dict):
             ('DiskDestination', "", (bytes, str)),
             ('TapeDestination', "", (bytes, str)),
             ('DiskRuleID', "", (bytes, str)),
-            ('TapeRuleID', "", (bytes, str))]
+            ('TapeRuleID', "", (bytes, str)),
+            ('DBSStatus', "", (bytes, str))]
         return outMapTemplate
 
     def _checkAttr(self, myDoc, update=False, throw=False, **kwargs):

--- a/src/python/WMCore/MicroService/MSOutput/MSOutputTemplate.py
+++ b/src/python/WMCore/MicroService/MSOutput/MSOutputTemplate.py
@@ -102,7 +102,7 @@ class MSOutputTemplate(dict):
                            'Copies': 1,
                            ...}],
                     "TransferStatus": "pending"|"done,
-                    "DBSUpdateStatus": "pending"|"done,
+                    "DBSUpdateStatus": False|True,
             "RequestType": ""
             }
         :return: a list of tuples
@@ -118,7 +118,7 @@ class MSOutputTemplate(dict):
             ('OutputDatasets', [], list),
             ('OutputMap', [], list),
             ('TransferStatus', "pending", (bytes, str)),
-            ('DBSUpdateStatus', "pending", (bytes, str))]
+            ('DBSUpdateStatus', False, bool)]
         return docTemplate
 
     def outputMapSchema(self):

--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -979,12 +979,11 @@ class DBS3Reader(object):
         :return: DBS status of the given dataset
         """
 
-        dbsApi = DbsApi(url=self.dbsURL)
         allowedDbsStatuses = ["VALID", "INVALID", "PRODUCTION"]
 
         response = None
         try:
-            response = dbsApi.listDatasets(dataset=dataset, dataset_access_type='*', detail=True)
+            response = self.dbs.listDatasets(dataset=dataset, dataset_access_type='*', detail=True)
         except Exception as ex:
             msg = "Exception while getting the status of following dataset on DBS: {} ".format(dataset)
             msg += "Error: {}".format(str(ex))
@@ -995,6 +994,7 @@ class DBS3Reader(object):
             isAllowedStatus = dbsStatus in allowedDbsStatuses
 
             if isAllowedStatus:
+                self.logger.info("%s is %s", dataset, dbsStatus)
                 return dbsStatus
             else:
                 raise Exception("This is not an allowed DBS status: {}".format(str(dbsStatus)))

--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -971,3 +971,32 @@ class DBS3Reader(object):
                     frozenKey = frozenset(runLumiPair)
                     parentFrozenData[frozenKey] = fileId
         return parentFrozenData
+
+    def getDBSStatus(self, dataset):
+        """
+        The function to get the DBS status of outputs
+        :param dataset: dataset name
+        :return: DBS status of the given dataset
+        """
+
+        dbsApi = DbsApi(url=self.dbsURL)
+        allowedDbsStatuses = ["VALID", "INVALID", "PRODUCTION"]
+
+        response = None
+        try:
+            response = dbsApi.listDatasets(dataset=dataset, dataset_access_type='*', detail=True)
+        except Exception as ex:
+            msg = "Exception while getting the status of following dataset on DBS: {} ".format(dataset)
+            msg += "Error: {}".format(str(ex))
+            self.logger.exception(msg)
+
+        if response:
+            dbsStatus = response[0]['dataset_access_type']
+            isAllowedStatus = dbsStatus in allowedDbsStatuses
+
+            if isAllowedStatus:
+                return dbsStatus
+            else:
+                raise Exception("This is not an allowed DBS status: {}".format(str(dbsStatus)))
+        else:
+            return None

--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -979,8 +979,6 @@ class DBS3Reader(object):
         :return: DBS status of the given dataset
         """
 
-        allowedDbsStatuses = ["VALID", "INVALID", "PRODUCTION"]
-
         response = None
         try:
             response = self.dbs.listDatasets(dataset=dataset, dataset_access_type='*', detail=True)
@@ -991,12 +989,7 @@ class DBS3Reader(object):
 
         if response:
             dbsStatus = response[0]['dataset_access_type']
-            isAllowedStatus = dbsStatus in allowedDbsStatuses
-
-            if isAllowedStatus:
-                self.logger.info("%s is %s", dataset, dbsStatus)
-                return dbsStatus
-            else:
-                raise Exception("This is not an allowed DBS status: {}".format(str(dbsStatus)))
+            self.logger.info("%s is %s", dataset, dbsStatus)
+            return dbsStatus
         else:
             return None

--- a/src/python/WMCore/Services/DBS/DBS3Writer.py
+++ b/src/python/WMCore/Services/DBS/DBS3Writer.py
@@ -41,18 +41,13 @@ class DBS3Writer(DBS3Reader):
         :param dataset: Dataset name
         :return: True if operation is successful, False otherwise
         """
-
         try:
+            # This API call returns None if successful, throws exception o/w
             self.dbs.updateDatasetType(dataset=dataset,
-                                     dataset_access_type=status)
+                                       dataset_access_type=status)
+            return True
         except Exception as ex:
             msg = "Exception while setting the status of following dataset on DBS: {} ".format(dataset)
             msg += "Error: {}".format(str(ex))
             self.logger.exception(msg)
-
-        dbsStatus = super(DBS3Writer, self).getDBSStatus(dataset)
-
-        if dbsStatus == status:
-            return True
-        else:
             return False

--- a/src/python/WMCore/Services/DBS/DBS3Writer.py
+++ b/src/python/WMCore/Services/DBS/DBS3Writer.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+"""
+_DBSReader_
+
+Read/Write DBS Interface
+
+"""
+from __future__ import print_function, division
+from builtins import str
+import logging
+
+from dbs.apis.dbsClient import DbsApi
+from dbs.exceptions.dbsClientException import dbsClientException
+
+from WMCore.Services.DBS.DBSErrors import DBSWriterError, formatEx3
+from WMCore.Services.DBS.DBS3Reader import DBS3Reader
+
+
+class DBS3Writer(DBS3Reader):
+    """
+    _DBSReader_
+
+    General API for writing data to DBS
+    """
+
+    def __init__(self, url, logger=None, **contact):
+
+        # instantiate dbs api object
+        try:
+            self.dbsWriteUrl = url
+            self.dbs = DbsApi(url, **contact)
+            self.logger = logger or logging.getLogger(self.__class__.__name__)
+        except dbsClientException as ex:
+            msg = "Error in DBSWriter with DbsApi\n"
+            msg += "%s\n" % formatEx3(ex)
+            raise DBSWriterError(msg)
+
+    def setDBSStatus(self, dataset, status):
+        """
+        The function to set the DBS status of an output dataset
+        :param dataset: Dataset name
+        :return: True if operation is successful, False otherwise
+        """
+
+        dbsApi = DbsApi(url=self.dbsWriteUrl)
+
+        try:
+            dbsApi.updateDatasetType(dataset=dataset,
+                                     dataset_access_type=status)
+        except Exception as ex:
+            msg = "Exception while setting the status of following dataset on DBS: {} ".format(dataset)
+            msg += "Error: {}".format(str(ex))
+            self.logger.exception(msg)
+
+        dbsStatus = self.getDBSStatus(dataset)
+
+        if dbsStatus == status:
+            return True
+        else:
+            return False

--- a/src/python/WMCore/Services/DBS/DBS3Writer.py
+++ b/src/python/WMCore/Services/DBS/DBS3Writer.py
@@ -23,12 +23,12 @@ class DBS3Writer(DBS3Reader):
     General API for writing data to DBS
     """
 
-    def __init__(self, url, logger=None, **contact):
+    def __init__(self, url, writeUrl, logger=None, **contact):
 
         # instantiate dbs api object
         try:
-            self.dbsWriteUrl = url
-            self.dbs = DbsApi(url, **contact)
+            super(DBS3Writer, self).__init__(url=url)
+            self.dbs = DbsApi(writeUrl, **contact)
             self.logger = logger or logging.getLogger(self.__class__.__name__)
         except dbsClientException as ex:
             msg = "Error in DBSWriter with DbsApi\n"
@@ -42,17 +42,15 @@ class DBS3Writer(DBS3Reader):
         :return: True if operation is successful, False otherwise
         """
 
-        dbsApi = DbsApi(url=self.dbsWriteUrl)
-
         try:
-            dbsApi.updateDatasetType(dataset=dataset,
+            self.dbs.updateDatasetType(dataset=dataset,
                                      dataset_access_type=status)
         except Exception as ex:
             msg = "Exception while setting the status of following dataset on DBS: {} ".format(dataset)
             msg += "Error: {}".format(str(ex))
             self.logger.exception(msg)
 
-        dbsStatus = self.getDBSStatus(dataset)
+        dbsStatus = super(DBS3Writer, self).getDBSStatus(dataset)
 
         if dbsStatus == status:
             return True

--- a/src/python/WMQuality/Emulators/DBSClient/MockedDBSGlobalCalls.py
+++ b/src/python/WMQuality/Emulators/DBSClient/MockedDBSGlobalCalls.py
@@ -84,6 +84,10 @@ calls = [['listDataTiers'],
           {'block_name': '/Cosmics/Commissioning2015-PromptReco-v1/RECO#004ac3ba-d09e-11e4-afad-001e67ac06a0'}],
          ['listBlockParents',
           {'block_name': '/Cosmics/Commissioning2015-v1/RAW#942d76fe-cf0e-11e4-afad-001e67ac06a0'}],
+         ['listDatasets',
+          {'dataset_access_type': '*',
+           'dataset': '/ggXToJPsiJPsi_JPsiToMuMu_M6p2_JPCZeroMinusPlus_TuneCP5_13TeV-pythia8-JHUGen/RunIIFall17pLHE-93X_mc2017_realistic_v3-v2/LHE',
+           'detail': True}],
 
          # Exception throwing calls
 

--- a/src/python/WMQuality/Emulators/DBSClient/MockedDBSGlobalCalls.py
+++ b/src/python/WMQuality/Emulators/DBSClient/MockedDBSGlobalCalls.py
@@ -88,6 +88,11 @@ calls = [['listDataTiers'],
           {'dataset_access_type': '*',
            'dataset': '/ggXToJPsiJPsi_JPsiToMuMu_M6p2_JPCZeroMinusPlus_TuneCP5_13TeV-pythia8-JHUGen/RunIIFall17pLHE-93X_mc2017_realistic_v3-v2/LHE',
            'detail': True}],
+         ['listDatasets',
+          {'dataset_access_type': '*',
+           'dataset': '/DYToEE_M-50_NNPDF31_TuneCP5_14TeV-powheg-pythia8/Run3Summer19DRPremix-BACKFILL_2024Scenario_106X_mcRun3_2024_realistic_v4-v6/GEN-SIM-RAW',
+           'detail': True}],
+
 
          # Exception throwing calls
 

--- a/test/python/WMCore_t/MicroService_t/MSOutput_t/MSOutputTemplate_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSOutput_t/MSOutputTemplate_t.py
@@ -81,12 +81,14 @@ class MSOutputTemplateTest(unittest.TestCase):
                                'DiskDestination': "",
                                'TapeDestination': "",
                                'DiskRuleID': "",
-                               'TapeRuleID': ""}],
-                "TransferStatus": "pending"
+                               'TapeRuleID': "",
+                               'DBSStatus': ""}],
+                "TransferStatus": "pending",
+                "DBSUpdateStatus": "pending"
                 }
 
     outputMapKeys = ["Campaign", "Copies", "Dataset", "DatasetSize", "DiskDestination",
-                     "DiskRuleID", "TapeDestination", "TapeRuleID"]
+                     "DiskRuleID", "TapeDestination", "TapeRuleID", "DBSStatus"]
 
     def testTaskChainSpec(self):
         """
@@ -98,6 +100,7 @@ class MSOutputTemplateTest(unittest.TestCase):
         self.assertIsNone(msOutDoc["LastUpdate"])
         self.assertFalse(msOutDoc["IsRelVal"])
         self.assertEqual(msOutDoc["TransferStatus"], "pending")
+        self.assertEqual(msOutDoc["DBSUpdateStatus"], "pending")
         self.assertEqual(msOutDoc["Campaign"], self.taskchainSpec["Campaign"])
         self.assertEqual(msOutDoc["OutputDatasets"], self.taskchainSpec["OutputDatasets"])
         self.assertEqual(msOutDoc["RequestName"], self.taskchainSpec["RequestName"])
@@ -118,6 +121,7 @@ class MSOutputTemplateTest(unittest.TestCase):
             self.assertEqual(msOutDoc["OutputMap"][idx]["DiskRuleID"], "")
             self.assertEqual(msOutDoc["OutputMap"][idx]["TapeDestination"], "")
             self.assertEqual(msOutDoc["OutputMap"][idx]["TapeRuleID"], "")
+            self.assertEqual(msOutDoc["OutputMap"][idx]["DBSStatus"], "")
 
     def testStepChainSpec(self):
         """
@@ -129,6 +133,7 @@ class MSOutputTemplateTest(unittest.TestCase):
         self.assertIsNone(msOutDoc["LastUpdate"])
         self.assertFalse(msOutDoc["IsRelVal"])
         self.assertEqual(msOutDoc["TransferStatus"], "pending")
+        self.assertEqual(msOutDoc["DBSUpdateStatus"], "pending")
         self.assertEqual(msOutDoc["Campaign"], self.stepchainSpec["Campaign"])
         self.assertEqual(msOutDoc["OutputDatasets"], self.stepchainSpec["OutputDatasets"])
         self.assertEqual(msOutDoc["RequestName"], self.stepchainSpec["RequestName"])
@@ -155,6 +160,7 @@ class MSOutputTemplateTest(unittest.TestCase):
         self.assertIsNone(msOutDoc["LastUpdate"])
         self.assertFalse(msOutDoc["IsRelVal"])
         self.assertEqual(msOutDoc["TransferStatus"], "pending")
+        self.assertEqual(msOutDoc["DBSUpdateStatus"], "pending")
         self.assertEqual(msOutDoc["Campaign"], self.rerecoSpec["Campaign"])
         self.assertEqual(msOutDoc["OutputDatasets"], self.rerecoSpec["OutputDatasets"])
         self.assertEqual(msOutDoc["RequestName"], self.rerecoSpec["RequestName"])
@@ -176,6 +182,7 @@ class MSOutputTemplateTest(unittest.TestCase):
         self.assertFalse(msOutDoc["IsRelVal"])
 
         self.assertEqual(msOutDoc["TransferStatus"], "pending")
+        self.assertEqual(msOutDoc["DBSUpdateStatus"], "pending")
         self.assertEqual(msOutDoc["CreationTime"], self.mongoDoc["CreationTime"])
         self.assertEqual(msOutDoc["LastUpdate"], self.mongoDoc["LastUpdate"])
 
@@ -190,10 +197,11 @@ class MSOutputTemplateTest(unittest.TestCase):
         self.assertTrue(msOutDoc["OutputMap"][0]["DatasetSize"] in [123, 456])
 
         newDoc = deepcopy(self.mongoDoc)
-        newDoc.update({"IsRelVal": True, "TransferStatus": "done", "LastUpdate": 333})
+        newDoc.update({"IsRelVal": True, "TransferStatus": "done", "LastUpdate": 333, "DBSUpdateStatus": "done"})
         msOutDoc = MSOutputTemplate(newDoc, producerDoc=False)
         self.assertTrue(msOutDoc["IsRelVal"])
         self.assertEqual(msOutDoc["TransferStatus"], "done")
+        self.assertEqual(msOutDoc["DBSUpdateStatus"], "done")
         self.assertEqual(msOutDoc["LastUpdate"], 333)
 
     def testSetters(self):

--- a/test/python/WMCore_t/MicroService_t/MSOutput_t/MSOutputTemplate_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSOutput_t/MSOutputTemplate_t.py
@@ -84,7 +84,7 @@ class MSOutputTemplateTest(unittest.TestCase):
                                'TapeRuleID': "",
                                'DBSStatus': ""}],
                 "TransferStatus": "pending",
-                "DBSUpdateStatus": "pending"
+                "DBSUpdateStatus": False
                 }
 
     outputMapKeys = ["Campaign", "Copies", "Dataset", "DatasetSize", "DiskDestination",
@@ -100,7 +100,7 @@ class MSOutputTemplateTest(unittest.TestCase):
         self.assertIsNone(msOutDoc["LastUpdate"])
         self.assertFalse(msOutDoc["IsRelVal"])
         self.assertEqual(msOutDoc["TransferStatus"], "pending")
-        self.assertEqual(msOutDoc["DBSUpdateStatus"], "pending")
+        self.assertEqual(msOutDoc["DBSUpdateStatus"], False)
         self.assertEqual(msOutDoc["Campaign"], self.taskchainSpec["Campaign"])
         self.assertEqual(msOutDoc["OutputDatasets"], self.taskchainSpec["OutputDatasets"])
         self.assertEqual(msOutDoc["RequestName"], self.taskchainSpec["RequestName"])
@@ -133,7 +133,7 @@ class MSOutputTemplateTest(unittest.TestCase):
         self.assertIsNone(msOutDoc["LastUpdate"])
         self.assertFalse(msOutDoc["IsRelVal"])
         self.assertEqual(msOutDoc["TransferStatus"], "pending")
-        self.assertEqual(msOutDoc["DBSUpdateStatus"], "pending")
+        self.assertEqual(msOutDoc["DBSUpdateStatus"], False)
         self.assertEqual(msOutDoc["Campaign"], self.stepchainSpec["Campaign"])
         self.assertEqual(msOutDoc["OutputDatasets"], self.stepchainSpec["OutputDatasets"])
         self.assertEqual(msOutDoc["RequestName"], self.stepchainSpec["RequestName"])
@@ -160,7 +160,7 @@ class MSOutputTemplateTest(unittest.TestCase):
         self.assertIsNone(msOutDoc["LastUpdate"])
         self.assertFalse(msOutDoc["IsRelVal"])
         self.assertEqual(msOutDoc["TransferStatus"], "pending")
-        self.assertEqual(msOutDoc["DBSUpdateStatus"], "pending")
+        self.assertEqual(msOutDoc["DBSUpdateStatus"], False)
         self.assertEqual(msOutDoc["Campaign"], self.rerecoSpec["Campaign"])
         self.assertEqual(msOutDoc["OutputDatasets"], self.rerecoSpec["OutputDatasets"])
         self.assertEqual(msOutDoc["RequestName"], self.rerecoSpec["RequestName"])
@@ -182,7 +182,7 @@ class MSOutputTemplateTest(unittest.TestCase):
         self.assertFalse(msOutDoc["IsRelVal"])
 
         self.assertEqual(msOutDoc["TransferStatus"], "pending")
-        self.assertEqual(msOutDoc["DBSUpdateStatus"], "pending")
+        self.assertEqual(msOutDoc["DBSUpdateStatus"], False)
         self.assertEqual(msOutDoc["CreationTime"], self.mongoDoc["CreationTime"])
         self.assertEqual(msOutDoc["LastUpdate"], self.mongoDoc["LastUpdate"])
 
@@ -197,11 +197,11 @@ class MSOutputTemplateTest(unittest.TestCase):
         self.assertTrue(msOutDoc["OutputMap"][0]["DatasetSize"] in [123, 456])
 
         newDoc = deepcopy(self.mongoDoc)
-        newDoc.update({"IsRelVal": True, "TransferStatus": "done", "LastUpdate": 333, "DBSUpdateStatus": "done"})
+        newDoc.update({"IsRelVal": True, "TransferStatus": "done", "LastUpdate": 333, "DBSUpdateStatus": True})
         msOutDoc = MSOutputTemplate(newDoc, producerDoc=False)
         self.assertTrue(msOutDoc["IsRelVal"])
         self.assertEqual(msOutDoc["TransferStatus"], "done")
-        self.assertEqual(msOutDoc["DBSUpdateStatus"], "done")
+        self.assertEqual(msOutDoc["DBSUpdateStatus"], True)
         self.assertEqual(msOutDoc["LastUpdate"], 333)
 
     def testSetters(self):

--- a/test/python/WMCore_t/Services_t/DBS_t/DBSReader_t.py
+++ b/test/python/WMCore_t/Services_t/DBS_t/DBSReader_t.py
@@ -26,7 +26,6 @@ PARENT_FILE = '/store/data/ComissioningHI/Cosmics/RAW/v1/000/181/369/662EAD44-30
 
 DATASET_INVALID = '/ggXToJPsiJPsi_JPsiToMuMu_M6p2_JPCZeroMinusPlus_TuneCP5_13TeV-pythia8-JHUGen/RunIIFall17pLHE-93X_mc2017_realistic_v3-v2/LHE'
 
-
 class DBSReaderTest(EmulatedUnitTestCase):
     def setUp(self):
         """
@@ -310,7 +309,6 @@ class DBSReaderTest(EmulatedUnitTestCase):
         """getDBSStatus gets DBS Status of a dataset"""
         self.dbs = DBSReader(self.endpoint)
         self.assertEqual(self.dbs.getDBSStatus(DATASET_INVALID), 'INVALID')
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/WMCore_t/Services_t/DBS_t/DBSReader_t.py
+++ b/test/python/WMCore_t/Services_t/DBS_t/DBSReader_t.py
@@ -24,6 +24,8 @@ PARENT_DATASET = '/Cosmics/ComissioningHI-v1/RAW'
 PARENT_BLOCK = PARENT_DATASET + '#929366bc-0c31-11e1-b764-003048caaace'
 PARENT_FILE = '/store/data/ComissioningHI/Cosmics/RAW/v1/000/181/369/662EAD44-300C-E111-A709-BCAEC518FF62.root'
 
+DATASET_INVALID = '/ggXToJPsiJPsi_JPsiToMuMu_M6p2_JPCZeroMinusPlus_TuneCP5_13TeV-pythia8-JHUGen/RunIIFall17pLHE-93X_mc2017_realistic_v3-v2/LHE'
+
 
 class DBSReaderTest(EmulatedUnitTestCase):
     def setUp(self):
@@ -303,6 +305,11 @@ class DBSReaderTest(EmulatedUnitTestCase):
         self.dbs = DBSReader(self.endpoint)
         self.assertEqual(self.dbs.blockToDatasetPath(BLOCK), DATASET)
         self.assertRaises(DBSReaderError, self.dbs.blockToDatasetPath, BLOCK + 'asas')
+
+    def testGetDBSStatus(self):
+        """getDBSStatus gets DBS Status of a dataset"""
+        self.dbs = DBSReader(self.endpoint)
+        self.assertEqual(self.dbs.getDBSStatus(DATASET_INVALID), 'INVALID')
 
 
 if __name__ == '__main__':

--- a/test/python/WMCore_t/Services_t/DBS_t/DBSWriter_t.py
+++ b/test/python/WMCore_t/Services_t/DBS_t/DBSWriter_t.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+"""
+_DBSWriter_t_
+
+Unit test for the DBS Writer class.
+"""
+
+import unittest
+
+from WMCore.Services.DBS.DBS3Reader import DBS3Reader as DBSReader
+from WMCore.Services.DBS.DBS3Writer import DBS3Writer as DBS3Writer
+from WMQuality.Emulators.EmulatedUnitTestCase import EmulatedUnitTestCase
+
+# A dummy dataset to play with
+DUMMY_DATASET = '/RelValDarkSUSY_14TeV/DMWM_Test-TC_LHE_PFN_Mar2021_Val_Alanv5-v11/GEN-SIM'
+
+class DBSWriterTest(EmulatedUnitTestCase):
+    def setUp(self):
+        """
+        _setUp_
+
+        Initialize the API to point at the test server.
+        """
+
+        self.dbsReaderUrl = 'https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/'
+        self.dbsWriterUrl = 'https://cmsweb-testbed.cern.ch/dbs/int/global/DBSWriter/'
+        self.dbsReader = None
+        self.dbsWriter = None
+        super(DBSWriterTest, self).setUp()
+        return
+
+    def tearDown(self):
+        """
+        _tearDown_
+
+        """
+
+        super(DBSWriterTest, self).tearDown()
+        return
+
+    def testSetDBSStatus(self):
+        self.dbsReader = DBSReader(self.dbsReaderUrl)
+        self.dbsWriter = DBS3Writer(self.dbsWriterUrl)
+
+        res = self.dbsWriter.setDBSStatus(DUMMY_DATASET, "VALID")
+        self.assertTrue(res)
+        status = self.dbsReader.getDBSStatus(DUMMY_DATASET)
+        self.assertEqual(status,"VALID")
+
+        res = self.dbsWriter.setDBSStatus(DUMMY_DATASET, "INVALID")
+        self.assertTrue(res)
+        status = self.dbsReader.getDBSStatus(DUMMY_DATASET)
+        self.assertEqual(status, "INVALID")
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/WMCore_t/Services_t/DBS_t/DBSWriter_t.py
+++ b/test/python/WMCore_t/Services_t/DBS_t/DBSWriter_t.py
@@ -7,12 +7,12 @@ Unit test for the DBS Writer class.
 
 import unittest
 
-from WMCore.Services.DBS.DBS3Reader import DBS3Reader as DBSReader
 from WMCore.Services.DBS.DBS3Writer import DBS3Writer as DBS3Writer
 from WMQuality.Emulators.EmulatedUnitTestCase import EmulatedUnitTestCase
 
 # A dummy dataset to play with
-DUMMY_DATASET = '/RelValDarkSUSY_14TeV/DMWM_Test-TC_LHE_PFN_Mar2021_Val_Alanv5-v11/GEN-SIM'
+DUMMY_DATASET = '/DYToEE_M-50_NNPDF31_TuneCP5_14TeV-powheg-pythia8/Run3Summer19DRPremix-BACKFILL_2024Scenario_106X_mcRun3_2024_realistic_v4-v6/GEN-SIM-RAW'
+
 
 class DBSWriterTest(EmulatedUnitTestCase):
     def setUp(self):
@@ -22,8 +22,8 @@ class DBSWriterTest(EmulatedUnitTestCase):
         Initialize the API to point at the test server.
         """
 
-        self.dbsReaderUrl = 'https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/'
-        self.dbsWriterUrl = 'https://cmsweb-testbed.cern.ch/dbs/int/global/DBSWriter/'
+        self.dbsReaderUrl = 'https://cmsweb-prod.cern.ch/dbs/prod/global/DBSReader/'
+        self.dbsWriterUrl = 'https://cmsweb-prod.cern.ch/dbs/prod/global/DBSWriter/'
         self.dbsReader = None
         self.dbsWriter = None
         super(DBSWriterTest, self).setUp()
@@ -39,19 +39,15 @@ class DBSWriterTest(EmulatedUnitTestCase):
         return
 
     def testSetDBSStatus(self):
-        self.dbsReader = DBSReader(self.dbsReaderUrl)
-        self.dbsWriter = DBS3Writer(self.dbsWriterUrl)
+        self.dbsWriter = DBS3Writer(url=self.dbsReaderUrl,
+                                    writeUrl=self.dbsWriterUrl)
 
+        res = self.dbsWriter.setDBSStatus(DUMMY_DATASET, "PRODUCTION")
+        self.assertTrue(res)
         res = self.dbsWriter.setDBSStatus(DUMMY_DATASET, "VALID")
         self.assertTrue(res)
-        status = self.dbsReader.getDBSStatus(DUMMY_DATASET)
-        self.assertEqual(status,"VALID")
-
         res = self.dbsWriter.setDBSStatus(DUMMY_DATASET, "INVALID")
         self.assertTrue(res)
-        status = self.dbsReader.getDBSStatus(DUMMY_DATASET)
-        self.assertEqual(status, "INVALID")
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #9837 

#### Status
DBS API calls are tested locally in a WMAgent env. (1.4.3.patch2), however the rest of the changes is not tested

#### Description
This PR includes the migration of one feature from Unified to WMCore: Setting output datasets to VALID in DBS3 before announcing a standard workflow.

This feature is implemented as a part of the MSOutput pipeline. In this PR `setDBSStatus` is the first step of the pipeline (before making actual output data placement) and also note that this functionality works for both RelVal and non-RelVal workflows.

Check https://github.com/dmwm/deployment/pull/1044  for the configuration of this feature. Note that `enableDbsStatusChange` is False, right now. Because, we need to coordinate for disabling the feature in Unified and enabling in WMCore. Soon, I'll come up a PR to disable it in Unified.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Not for now - soon a related PR in https://github.com/CMSCompOps/WmAgentScripts will come.

#### External dependencies / deployment changes
DBS

@amaltaro @todor-ivanov As I mentioned, the feature is not tested properly, it would be great if you can help me testing it.
