### PR TITLE
[py2py3] fix issue #10398

### DIFF
--- a/test/python/WMCore_t/Database_t/DBCore_t.py
+++ b/test/python/WMCore_t/Database_t/DBCore_t.py
@@ -61,7 +61,7 @@ class DBCoreTest(unittest.TestCase):
 
         for i in range(len(files)):
             self.assertEqual(binds[i][seqname], files[i])
-            self.assertEqual(binds[i][dictbinds.keys()[0]], dictbinds[dictbinds.keys()[0]])
+            self.assertEqual(binds[i][next(iter(dictbinds))], dictbinds[next(iter(dictbinds))])
 
 
         return


### PR DESCRIPTION
Fixes #10398 

#### Status
Ready

#### Description
Using `next(iter(dictbinds))` instead of `dictbinds.keys()[0]` in `test/python/WMCore_t/Database_t/DBCore_t.py`/

#### Is it backward compatible (if not, which system it affects?)
Yes

#### Related PRs
Follow-up to #10262 

#### External dependencies / deployment changes
No change
