### PR TITLE
[py2py3] fix all pylint --py3k issues and warnings

### DIFF
--- a/src/python/WMCore/Agent/Database/DestroyAgentBase.py
+++ b/src/python/WMCore/Agent/Database/DestroyAgentBase.py
@@ -9,7 +9,6 @@ from __future__ import absolute_import
 
 
 import threading
-import string
 
 from WMCore.Database.DBCreator import DBCreator
 
@@ -38,5 +37,5 @@ class DestroyAgentBase(DBCreator):
         for requiredTable in orderedTables:
             i += 1
             tableName = requiredTable[2:]
-            prefix = string.zfill(i, 2)
+            prefix = str.zfill(str(i), 2)
             self.create[prefix + tableName] = "DROP TABLE %s" % tableName

--- a/src/python/WMCore/JobSplitting/EventAwareLumiByWork.py
+++ b/src/python/WMCore/JobSplitting/EventAwareLumiByWork.py
@@ -324,7 +324,7 @@ class EventAwareLumiByWork(JobFactory):
                     for lumi in runLumi.lumis:
                         if (runLumi.run, lumi) in lumiList:
                             self.filesByLumi[run][lumi].append(fileObj)
-                            eventsByLumi[run][lumi] = round(eventsInFile / lumisInFile)
+                            eventsByLumi[run][lumi] = int(round(eventsInFile / lumisInFile))
 
         return lumisByFile, eventsByLumi
 

--- a/src/python/WMCore/REST/Server.py
+++ b/src/python/WMCore/REST/Server.py
@@ -254,7 +254,7 @@ class RESTFrontPage(object):
                     raise HTTPError(404, "No such file")
                 try:
                     mtime = max(mtime, os.stat(fpath).st_mtime)
-                    data = file(fpath).read()
+                    data = open(fpath).read()
                 except:
                     cherrypy.log("ERROR: front-page '%s' failed to retrieve file" % item)
                     raise HTTPError(404, "No such file")
@@ -287,7 +287,7 @@ class RESTFrontPage(object):
                                 raise HTTPError(404, "No such file")
                             try:
                                 mtime = max(mtime, os.stat(fpath).st_mtime)
-                                value += file(fpath).read().strip()
+                                value += open(fpath).read().strip()
                             except:
                                 cherrypy.log("ERROR: embedded '%s' file '%s' failed to"
                                              " retrieve file" % (var, fpath))
@@ -1466,7 +1466,7 @@ class DBConnectionPool(Thread):
         dbh, err = None, None
 
         # If tracing, issue log line that identifies this connection series.
-        trace = s["trace"] and ("RESTSQL:" + "".join(random.sample(string.letters, 12)))
+        trace = s["trace"] and ("RESTSQL:" + "".join(random.sample(string.ascii_letters, 12)))
         trace and cherrypy.log("%s ENTER %s@%s %s (%s) inuse=%d idle=%d" %
                                (trace, s["user"], s["dsn"], self.id, req["id"],
                                 len(self.inuse), len(self.idle)))

--- a/src/python/WMCore/ResourceControl/ResourceControl.py
+++ b/src/python/WMCore/ResourceControl/ResourceControl.py
@@ -5,6 +5,8 @@ _ResourceControl_
 Library from manipulating and querying the resource control database.
 """
 
+from builtins import str, bytes
+
 import time
 from WMCore.BossAir.BossAirAPI import BossAirAPI
 from WMCore.DAOFactory import DAOFactory
@@ -163,7 +165,7 @@ class ResourceControl(WMConnectionBase):
 
         subTypeAction = self.wmbsDAOFactory(classname="Subscriptions.InsertType")
         insertAction = self.daofactory(classname="InsertThreshold")
-        if isinstance(taskType, basestring):
+        if isinstance(taskType, (str, bytes)):
             taskType = [taskType]
         for singleTask in taskType:
             subTypeAction.execute(subType=singleTask,

--- a/src/python/WMCore/Services/LogDB/LogDBBackend.py
+++ b/src/python/WMCore/Services/LogDB/LogDBBackend.py
@@ -180,7 +180,7 @@ class LogDBBackend(object):
         This is done via tstamp view end endkey, e.g.
         curl "http://127.0.0.1:5984/logdb/_design/LogDB/_view/tstamp?endkey=1427912282"
         """
-        cutoff = round(time.time()-thr)
+        cutoff = int(round(time.time()-thr))
         #docs = self.db.allDocs() # may need another view to look-up old docs
         spec = {'endkey':cutoff, 'reduce':False}
         docs = self.db.loadView(self.design, self.tsview, spec)

--- a/src/python/WMCore/WebTools/Masthead.py
+++ b/src/python/WMCore/WebTools/Masthead.py
@@ -44,7 +44,7 @@ class Masthead(TemplatedPage, Controllers):
         for f in files:
             filename = "%s/css/%s" % (path, f)
             if os.path.exists(filename):
-                lines = file(filename).readlines()
+                lines = open(filename).readlines()
                 for l in lines:
                     data = data + l
 
@@ -60,7 +60,7 @@ class Masthead(TemplatedPage, Controllers):
         for f in files:
             filename = "%s/css/%s" % (path, f)
             if os.path.exists(filename):
-                lines = file(filename).readlines()
+                lines = open(filename).readlines()
                 for l in lines:
                     data = data + l
 

--- a/test/python/Utils_t/IteratorTools_t.py
+++ b/test/python/Utils_t/IteratorTools_t.py
@@ -5,6 +5,7 @@ Unittests for IteratorTools functions
 
 from __future__ import division, print_function
 
+from builtins import range
 import itertools
 import unittest
 
@@ -22,9 +23,9 @@ class IteratorToolsTest(unittest.TestCase):
         """
 
         listChunks = [i for i in grouper(list(range(0, 7)), 3)]  # Want list(range) for python 3
-        iterChunks = [i for i in grouper(xrange(0, 7), 3)]  # xrange becomes range in python 3
+        iterChunks = [i for i in grouper(range(0, 7), 3)]  # xrange becomes range in python 3
 
-        for a, b in itertools.izip_longest(listChunks, iterChunks):
+        for a, b in itertools.zip_longest(listChunks, iterChunks):
             self.assertEqual(a, b)
 
         self.assertEqual(listChunks[-1], [6])
@@ -34,7 +35,7 @@ class IteratorToolsTest(unittest.TestCase):
         Test the flattenList function (returns a flat list out
         of a list of lists)
         """
-        doubleList = [range(1, 4), range(10, 11), range(15, 18)]
+        doubleList = [list(range(1, 4)), list(range(10, 11)), list(range(15, 18))]
         flatList = flattenList(doubleList)
         self.assertEqual(len(flatList), 7)
         self.assertEqual(set(flatList), set([1, 2, 3, 10, 15, 16, 17]))

--- a/test/python/Utils_t/Utilities_t.py
+++ b/test/python/Utils_t/Utilities_t.py
@@ -5,6 +5,7 @@ Unittests for Utilities functions
 
 from __future__ import division, print_function
 
+from builtins import object
 import os
 import unittest
 
@@ -47,7 +48,7 @@ class UtilitiesTests(unittest.TestCase):
         self.assertEqual(lheaders['CAPITAL'], 1)
         self.assertEqual(lheaders['Camel'], 1)
         self.assertEqual(lheaders[val], val)
-        self.assertEqual(len(lheaders.keys()), 3)
+        self.assertEqual(len(lheaders), 3)
 
     def testMakeNonEmptyList(self):
         """
@@ -144,14 +145,25 @@ cms::Exception caught in CMS.EventProcessor and rethrown
         with self.assertRaises(TypeError):
             getSize(zipEncodeStr)
 
-        class TestClass():
+        class TestClass1():
             def __init__(self):
                 self.data = "blah"
 
-        cls = TestClass()
-        print(getSize(cls))
-        self.assertTrue(getSize(cls) > 1000)
+        cls1 = TestClass1()
+        print(getSize(cls1)) # 1129
+        self.assertTrue(getSize(cls1) > 1000)
 
+        class TestClass2(object):
+            """
+            In python2, classes that inherit from `object` have a smaller
+            memory footprint
+            """
+            def __init__(self):
+                self.data = "blah"
+
+        cls2 = TestClass2()
+        print(getSize(cls2)) # 426
+        self.assertTrue(getSize(cls2) > 400)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/WMCore_t/BossAir_t/SimpleCondorPlugin_t.py
+++ b/test/python/WMCore_t/BossAir_t/SimpleCondorPlugin_t.py
@@ -7,6 +7,8 @@ SimpleCondorPlugin unittests
 """
 from __future__ import division, print_function
 
+from future.utils import viewitems
+
 import os.path
 import re
 import threading
@@ -445,7 +447,7 @@ class SimpleCondorPluginTest(BossAirTest):
                            'BPH': 'pdmvserv_BPH-Summer12-00208_00263_v1__160726_025423_731',
                            'undefined': 'amaltaro_TaskChain_MC_DMWM_Test_July_Patches_160727_234956_6253'}
 
-        for group, request in mapGroupReqName.iteritems():
+        for group, request in viewitems(mapGroupReqName):
             match = GROUP_NAME_RE.match(request)
             matchedGroup = match.groups()[0] if match else 'undefined'
             self.assertEqual(group, matchedGroup)

--- a/test/python/WMCore_t/Cache_t/WMConfigCache_t.py
+++ b/test/python/WMCore_t/Cache_t/WMConfigCache_t.py
@@ -5,11 +5,14 @@ _WMConfigCache_t_
 Test class for the WMConfigCache
 """
 
+from future import standard_library
+standard_library.install_aliases()
+import urllib.parse
+
 import os
 import unittest
 import tempfile
 import subprocess
-import urllib
 
 from WMCore.Agent.Configuration import Configuration
 from WMCore.Cache.WMConfigCache import ConfigCache, ConfigCacheException
@@ -95,7 +98,7 @@ class testWMConfigCache(unittest.TestCase):
         configCache.setPSetTweaks(PSetTweak = PSetTweak)
         configCache.attachments['attach1'] = attach
         psetPath = os.path.join(getTestBase(), "WMCore_t/Cache_t/PSet.txt")
-        psetPath = "file://" + urllib.quote(os.path.abspath(psetPath))
+        psetPath = "file://" + urllib.parse.quote(os.path.abspath(psetPath))
         configCache.addConfig(newConfig = psetPath, psetHash = None)
 
         configCache.setLabel("sample-label")
@@ -131,7 +134,7 @@ class testWMConfigCache(unittest.TestCase):
         configCache.attachments['attach1'] = attach
         configCache.document['md5_hash'] = "somemd5"
         psetPath = os.path.join(getTestBase(), "WMCore_t/Cache_t/PSet.txt")
-        psetPath = "file://" + urllib.quote(os.path.abspath(psetPath))
+        psetPath = "file://" + urllib.parse.quote(os.path.abspath(psetPath))
         configCache.addConfig(newConfig = psetPath, psetHash = None)
         configCache.save()
 
@@ -204,7 +207,7 @@ class testWMConfigCache(unittest.TestCase):
 
         configs = configCacheA.listAllConfigsByLabel()
 
-        self.assertEqual(len(configs.keys()), 2,
+        self.assertEqual(len(configs), 2,
                          "Error: There should be two configs")
         self.assertEqual(configs["labelA"], configCacheA.getCouchID(),
                          "Error: Label A is wrong.")

--- a/test/python/WMCore_t/Database_t/RotatingDatabase_t.py
+++ b/test/python/WMCore_t/Database_t/RotatingDatabase_t.py
@@ -1,3 +1,4 @@
+from builtins import range
 import unittest
 import os
 import sys
@@ -14,7 +15,10 @@ class RotatingDatabaseTest(unittest.TestCase):
         self.couchURL = os.getenv("COUCHURL")
         self.server = CouchServer(self.couchURL)
         # Kill off any databases left over from previous runs
-        for db in [db for db in self.server.listDatabases() if db.startswith('rotdb_unittest_')]:
+        # In python 3 the variables defined inside a comprehension are deteled
+        # outside the comprehension. See: pylint W1662 comprehension-escape
+        dbs = [db for db in self.server.listDatabases() if db.startswith('rotdb_unittest_')]
+        for db in dbs:
             try:
                 self.server.deleteDatabase(db)
             except:

--- a/test/python/WMCore_t/FwkJobReport_t/ReportIntegration_t.py
+++ b/test/python/WMCore_t/FwkJobReport_t/ReportIntegration_t.py
@@ -216,14 +216,14 @@ class ReportIntegrationTest(unittest.TestCase):
                    "Error: Output file has wrong size: %s, %s" % \
                    (outputFile["size"], fwkJobReportFile["size"])
 
-            for ckType in fwkJobReportFile["checksums"].keys():
-                assert ckType in outputFile["checksums"].keys(), \
+            for ckType in fwkJobReportFile["checksums"]:
+                assert ckType in outputFile["checksums"], \
                        "Error: Output file is missing checksums: %s" % ckType
                 assert outputFile["checksums"][ckType] == fwkJobReportFile["checksums"][ckType], \
                        "Error: Checksums don't match."
 
-            assert len(fwkJobReportFile["checksums"].keys()) == \
-                   len(outputFile["checksums"].keys()), \
+            assert len(fwkJobReportFile["checksums"]) == \
+                   len(outputFile["checksums"]), \
                    "Error: Wrong number of checksums."
 
             jobType = self.getJobTypeAction.execute(jobID = jobID)
@@ -263,7 +263,7 @@ class ReportIntegrationTest(unittest.TestCase):
                 if len(fwjrRuns[run.run]) == 0:
                     del fwjrRuns[run.run]
 
-            assert len(fwjrRuns.keys()) == 0, \
+            assert len(fwjrRuns) == 0, \
                    "Error: Missing runs, lumis: %s" % fwjrRuns
 
             testJobGroup = JobGroup(id = testJob["jobgroup"])

--- a/test/python/WMCore_t/Services_t/CRIC_t/CRIC_t.py
+++ b/test/python/WMCore_t/Services_t/CRIC_t/CRIC_t.py
@@ -217,21 +217,21 @@ class CRICTest(EmulatedUnitTestCase):
         self.assertTrue(len(result) > 10)
 
         result = self.myCRIC.PSNtoPNNMap('T2_CH_CERN$')
-        self.assertItemsEqual(result.keys(), ['T2_CH_CERN'])
+        self.assertItemsEqual(list(result), ['T2_CH_CERN'])
         self.assertItemsEqual(result['T2_CH_CERN'], ['T2_CH_CERNBOX', 'T2_CH_CERN'])
 
         # test a exact site name, which is treated as a regex and yields a confusing result!!!
         result = self.myCRIC.PSNtoPNNMap('T2_CH_CERN')
-        self.assertItemsEqual(result.keys(), ['T2_CH_CERN', 'T2_CH_CERN_HLT'])
+        self.assertItemsEqual(list(result), ['T2_CH_CERN', 'T2_CH_CERN_HLT'])
         self.assertItemsEqual(result['T2_CH_CERN'], ['T2_CH_CERNBOX', 'T2_CH_CERN'])
         self.assertItemsEqual(result['T2_CH_CERN_HLT'], ['T2_CH_CERN'])
 
         result = self.myCRIC.PSNtoPNNMap('T2_CH_CERN_HLT')
-        self.assertItemsEqual(result.keys(), ['T2_CH_CERN_HLT'])
+        self.assertItemsEqual(list(result), ['T2_CH_CERN_HLT'])
         self.assertItemsEqual(result['T2_CH_CERN_HLT'], ['T2_CH_CERN'])
 
         result = self.myCRIC.PSNtoPNNMap('T1_US_FNAL')
-        self.assertItemsEqual(result.keys(), ['T1_US_FNAL'])
+        self.assertItemsEqual(list(result), ['T1_US_FNAL'])
         self.assertItemsEqual(result['T1_US_FNAL'], ['T1_US_FNAL_Disk', 'T3_US_FNALLPC'])
 
         # test a PNN as input, expecting nothing mapped to it
@@ -269,12 +269,12 @@ class CRICTest(EmulatedUnitTestCase):
         self.assertTrue(len(result) > 10)
 
         result = self.myCRIC.PNNtoPSNMap('T2_CH_CERN$')
-        self.assertItemsEqual(result.keys(), ['T2_CH_CERN'])
+        self.assertItemsEqual(list(result), ['T2_CH_CERN'])
         self.assertItemsEqual(result['T2_CH_CERN'], ['T2_CH_CERN_HLT', 'T2_CH_CERN'])
 
         # test a exact site name, which is treated as a regex and yields a confusing result!!!
         result = self.myCRIC.PNNtoPSNMap('T2_CH_CERN')
-        self.assertItemsEqual(result.keys(), ['T2_CH_CERN', 'T2_CH_CERNBOX'])
+        self.assertItemsEqual(list(result), ['T2_CH_CERN', 'T2_CH_CERNBOX'])
         self.assertItemsEqual(result['T2_CH_CERN'], ['T2_CH_CERN_HLT', 'T2_CH_CERN'])
         self.assertItemsEqual(result['T2_CH_CERNBOX'], ['T2_CH_CERN'])
 
@@ -282,7 +282,7 @@ class CRICTest(EmulatedUnitTestCase):
         self.assertItemsEqual(result, {})
 
         result = self.myCRIC.PNNtoPSNMap('T1_US_FNAL')
-        self.assertItemsEqual(result.keys(), ['T1_US_FNAL_Disk'])
+        self.assertItemsEqual(list(result), ['T1_US_FNAL_Disk'])
         self.assertItemsEqual(result['T1_US_FNAL_Disk'], ['T1_US_FNAL'])
 
         return

--- a/test/python/WMCore_t/WMBS_t/CursorLeak_t.py
+++ b/test/python/WMCore_t/WMBS_t/CursorLeak_t.py
@@ -5,6 +5,7 @@ _File_t_
 Unit tests for the WMBS File class.
 """
 
+from builtins import range
 import threading
 import unittest
 
@@ -102,13 +103,13 @@ class CursorLeakTest(unittest.TestCase):
                          checksums={"cksum": "1"}, locations="se1.fnal.gov")
         testFileA.create()
 
-        for i in xrange(15):
+        for i in range(15):
             testParent = File(lfn=makeUUID(), size=1024, events=10,
                               checksums={"cksum": "1"}, locations="se1.fnal.gov")
             testParent.create()
             testFileA.addParent(testParent["lfn"])
 
-            for i in xrange(100):
+            for i in range(100):
                 testGParent = File(lfn=makeUUID(), size=1024, events=10,
                                    checksums={"cksum": "1"}, locations="se1.fnal.gov")
                 testGParent.create()

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/EventBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/EventBased_t.py
@@ -4,8 +4,9 @@ _EventBased_t_
 
 Event based splitting test.
 """
-from __future__ import print_function
+from __future__ import print_function, division
 
+from builtins import range
 import os
 import random
 import threading
@@ -161,12 +162,12 @@ class EventBasedTest(unittest.TestCase):
                                 merged=False, first_event=firstEvent)
                 if acdcVer == 2:
                     # lumi range is really inclusive (process first and last lumi)
-                    run = Run(1, *range(1 + j * lumisPerJob + (i * lumisPerFile),
-                                        1 + (j + 1) * lumisPerJob + (i * lumisPerFile)))
+                    run = Run(1, *list(range(1 + j * lumisPerJob + (i * lumisPerFile),
+                                        1 + (j + 1) * lumisPerJob + (i * lumisPerFile))))
                 else:
                     # bigger lumi range, LastLumi is in most of the cases not processed
-                    run = Run(1, *range(1 + j * lumisPerJob + (i * lumisPerFile),
-                                        2 + (j + 1) * lumisPerJob + (i * lumisPerFile)))
+                    run = Run(1, *list(range(1 + j * lumisPerJob + (i * lumisPerFile),
+                                        2 + (j + 1) * lumisPerJob + (i * lumisPerFile))))
 
                 acdcFile.addRun(run)
                 acdcDoc = {"collection_name": workflowName,
@@ -198,18 +199,18 @@ class EventBasedTest(unittest.TestCase):
             acdcFile = File(lfn=lfn, size=1024, events=eventsPerJob, locations=self.validLocations,
                             merged=False, first_event=firstEvent)
             if acdcVer == 2:
-                run = Run(1, *range(lumi, lumi + 1))
+                run = Run(1, *list(range(lumi, lumi + 1)))
             else:
-                run = Run(1, *range(lumi, lumi + 2))
+                run = Run(1, *list(range(lumi, lumi + 2)))
             acdcFile.addRun(run)
             acdcFiles.append(acdcFile)
         # create one last entry with more lumis
         acdcFile = File(lfn=lfn, size=1024, events=eventsPerJob, locations=self.validLocations,
                         merged=False, first_event=firstEvent)
         if acdcVer == 2:
-            run = Run(1, *range(277, 277 + 4))
+            run = Run(1, *list(range(277, 277 + 4)))
         else:
-            run = Run(1, *range(277, 277 + 5))
+            run = Run(1, *list(range(277, 277 + 5)))
         acdcFile.addRun(run)
         acdcFiles.append(acdcFile)
 
@@ -238,7 +239,7 @@ class EventBasedTest(unittest.TestCase):
         newFile = File("MCFakeFile-some-hash-%s" % str(index).zfill(5), size=1000,
                        events=numEvents,
                        locations=set(["T1_US_FNAL_Disk"]))
-        newFile.addRun(Run(1, *range(firstLumi, lastLumi + 1)))
+        newFile.addRun(Run(1, *list(range(firstLumi, lastLumi + 1))))
         newFile["first_event"] = firstEvent
         newFile["last_event"] = lastEvent
         newFile.create()

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/LumiBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/LumiBased_t.py
@@ -7,6 +7,7 @@ Test lumi based splitting.
 
 from __future__ import division
 
+from builtins import range
 import threading
 import unittest
 import random
@@ -480,7 +481,7 @@ class LumiBasedTest(unittest.TestCase):
         self.assertEqual(len(jobs), 10)
         for j in jobs:
             runs = j['mask'].getRunAndLumis()
-            for r in runs.keys():
+            for r in runs:
                 self.assertEqual(len(runs[r]), 2)
                 for l in runs[r]:
                     # Each run should have two lumis

--- a/test/python/WMCore_t/WebTools_t/DummyRESTModel.py
+++ b/test/python/WMCore_t/WebTools_t/DummyRESTModel.py
@@ -1,3 +1,5 @@
+from builtins import map, range, object, str, bytes
+
 from WMCore.WebTools.RESTModel import RESTModel, restexpose
 from cherrypy import HTTPError
 
@@ -5,21 +7,21 @@ DUMMY_ROLE = "dummy"
 DUMMY_GROUP = "dummies"
 DUMMY_SITE = "dummyHome"
 
-class DummyDAO1:
+class DummyDAO1(object):
     """
     A DAO that has no arguments and does nothing but return 123
     """
     def execute(self):
         return 123
 
-class DummyDAO2:
+class DummyDAO2(object):
     """
     A DAO that takes a single argument
     """
     def execute(self, num):
         return {'num': num}
 
-class DummyDAO3:
+class DummyDAO3(object):
     """
     A DAO with keyword arguments
     TODO: use this
@@ -27,7 +29,7 @@ class DummyDAO3:
     def execute(self, num, thing=None):
         return {'num': num, 'thing': thing}
 
-class DummyDAOFac:
+class DummyDAOFac(object):
     """
     Something that replicates a Factory that loads our dummy DAO classes
     """
@@ -141,7 +143,7 @@ class DummyRESTModel(RESTModel):
         if not isinstance(request_input["aList"], list):
             request_input["aList"] = [int(request_input["aList"])]
         else:
-            request_input["aList"] = map(int, request_input["aList"])
+            request_input["aList"] = list(map(int, request_input["aList"]))
         return request_input
 
     def val_0(self, request_input):
@@ -168,7 +170,7 @@ class DummyRESTModel(RESTModel):
     def val_2(self, request_input):
         # Checks its second request_input is a string
         try:
-            assert isinstance(request_input['input_str'], basestring)
+            assert isinstance(request_input['input_str'], (str, bytes))
         except AssertionError:
             raise HTTPError(400, 'val_2 failed: %s not string or unicode' % type(request_input['input_str']))
         return request_input


### PR DESCRIPTION
Fixes #10440 

#### Status
Ready

#### Description

The changes are summarized here

* [x] PsetTweaks, #9739, #9740
* [x] Utils, #9730, #9731
* [x] WMConfigCache, #9806, #9818
* [x] WMCore/WMFactory - #9970, #9971
* [x] WMQuality/CherrypyTestInit - #9972
* [ ] WMCore/Configuration - #9973, #9974
  - This is not ok because the PRs for this component is still open
* [x] WMCore/Credential - #10007, #10008
* [x] WMCore/Algorithms - #10009, #10011
* [ ] WMCore/DataStructs - #10010, #10012
  - This is not fixed, but we have a specific issue to deal with this: #10169 
* [x] slice 1 - #10055, #10057
* [ ] slice 2 - #10098, #10103
  - This is not fixed, but we have the following issues that should deal with this: #9960 #9926 should fix warnings about `src.python.WMCore.Services.HTTPS.HTTPSAuthHandler`
* [x] slice 3 - #10114, #10117 
   - `src/python/WMCore/WebTools/Masthead.py`
* [x] slice 4 - #10115, #10165 
* [x] slice 5 - #10116, #10262 
* [x] slice 6 - #10127, #10277 
* [x] slice 7 - #10131, #10284 
  - use of `round` in `src.python.WMCore.JobSplitting.EventAwareLumiByWork`: `round()`->`float(round())` (py3 behaves like py2) or `round()`->`int(round())` (py2 behaves like py3, same option adopted in slice 18 #10331 ) ? we prefer the latter
  - eventually testing this change will be done in #10354
* [x] slice 8 - #10132, #10289 
* [x] slice 9 - #10133, #10290
* [x] slice 10 - #10134, #10295
  - use of `round` in `src.python.WMCore.Services.LogDB.LogDBBackend`: `round()`->`float(round())` or `round()`->`int(round())`? we prefer the latter
  - eventually testing this change will be done in #10354 
* [x] slice 11 - #10135, #10299
* [x] slice 12 - #10136, #10307
* [ ] slice 13 - #10137, #10310 
  - This is not fixed, but we have the following issues that should deal with this: : #9926 and #9960 shopuld fix warnings about `src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py`
* [x] slice 14 - #10138, #10313
* [x] slice 15 - #10139, #10319
* [x] slice 16 - #10140, #10321
* [x] slice 17 - #10141, #10329
* [x] slice 18 - #10142, #10331
* [x] slice 19 - #10143, #10348
* [x] slice 20 - #10144, #10349
* [x] slice 21 - #10145, #10361
* [x] slice 22 - #10146, #10362
* [x] slice 23 - #10147, #10363 
* [x] slice 24 - #10148, #10371 
* [x] slice 25 - #10149, #10379 
* [ ] slice 26 - #10150, 

Some PRs are not ticked because there is some follow-up work that needs to be done, this is the best that we can do here at the moment.

The remaining warnings from `pylint --py3k` are ok and considered false positives

Deprecation: modules that I did not touch because have been deprecated
- `WMCore_t.Services_t.PhEDEx_t.PhEDEx_t`

#### Is it backward compatible (if not, which system it affects?)
Yes

#### Related PRs
(see "description" section)

#### External dependencies / deployment changes
Does not require any change
