### PR TITLE
Changes in Slice 17 are causing #10381

### DIFF
--- a/src/python/WMCore/Configuration.py
+++ b/src/python/WMCore/Configuration.py
@@ -14,8 +14,6 @@ import os
 import sys
 import traceback
 
-from Utils.Utilities import encodeUnicodeToBytes
-
 PY3 = sys.version_info[0] == 3
 
 # PY3 compatibility (can be removed once python2 gets dropped)
@@ -140,9 +138,7 @@ class ConfigSection(object):
             return
 
         if isinstance(value, unicode):
-            # We should not use "ignore" in this case
-            # if this failed before, it is better to have it fail also now.
-            value = encodeUnicodeToBytes(value)
+            value = str(value)
 
         # for backward compatibility use getattr and sure to work if the
         # _internal_skipChecks flag is not set


### PR DESCRIPTION
Fixes #10381 

#### Status
ready

#### Description
Revert changes to `src/python/WMCore/Configuration.py` from slice 17.

I do not remember why I made those changes, I need the unit tests to check that this rollback is safe

#### Is it backward compatible (if not, which system it affects?)
As always, it should be

#### Related PRs

Slice 17: #10141

#### External dependencies / deployment changes
Should not change anything
