### PR TITLE
Force cmsweb-prod in DBS3Reader

### DIFF
--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -76,8 +76,8 @@ class DBS3Reader(object):
 
         # instantiate dbs api object
         try:
-            self.dbsURL = url
-            self.dbs = DbsApi(url, **contact)
+            self.dbsURL = url.replace("cmsweb.cern.ch", "cmsweb-prod.cern.ch")
+            self.dbs = DbsApi(self.dbsURL, **contact)
             self.logger = logger or logging.getLogger(self.__class__.__name__)
         except dbsClientException as ex:
             msg = "Error in DBSReader with DbsApi\n"


### PR DESCRIPTION
Fixes #10248 

#### Status
not-tested

#### Description
We still see ~20 HTTP calls coming from the agents, hopefully this will fix those remaining calls still going through cmsweb instead of cmsweb-prod alias.

If `DBS3Reader` is instantiated with cmsweb.cern.ch, we replace that url in-place by cmsweb-prod and use that in the class.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Complement to https://github.com/dmwm/WMCore/pull/10269

#### External dependencies / deployment changes
none
