### PR TITLE
Create symbolic links in deploy-wmagent

### DIFF
--- a/deploy/deploy-wmagent.sh
+++ b/deploy/deploy-wmagent.sh
@@ -277,9 +277,7 @@ set +e
 
 echo -e "\n*** Creating wmagent symlinks ***"
 cd $CURRENT_DIR
-
-[[ sw${REPO##comp=comp} != sw ]] && [[ -d sw${REPO##comp=comp} ]] &&  ln -s sw${REPO##comp=comp} sw
-ln -s ../sw/${WMA_ARCH}/cms/${RPM_NAME}/${WMA_TAG} apps/wmagent
+ln -s ../sw${REPO##comp=comp}/${WMA_ARCH}/cms/${RPM_NAME}/${WMA_TAG} apps/wmagent
 ln -s ../config/${RPM_NAME} config/wmagent
 
 cd -

--- a/deploy/deploy-wmagent.sh
+++ b/deploy/deploy-wmagent.sh
@@ -275,9 +275,13 @@ for step in prep sw post; do
 done
 set +e
 
-echo -e "\n*** Creating wmagent symlink ***"
+echo -e "\n*** Creating wmagent symlinks ***"
 cd $CURRENT_DIR
+
+[[ sw${REPO##comp=comp} != sw ]] && [[ -d sw${REPO##comp=comp} ]] &&  ln -s sw${REPO##comp=comp} sw
 ln -s ../sw/${WMA_ARCH}/cms/${RPM_NAME}/${WMA_TAG} apps/wmagent
+ln -s ../config/${RPM_NAME} config/wmagent
+
 cd -
 echo "Done!" && echo
 


### PR DESCRIPTION
Fixes #9805 

#### Status
ready

#### Description
In order to be able to test different combinations of rpm packages and dependencies, we need to have the ability to build and upload them in our personal repositories in `cmsrep` [1]. While deploying from such a repository (adding the option `-r comp=comp.<user>` to the deployment script) the deployment area changes from `/data/srv/wmagent/current/sw` to /data/srv/wmagent/current/sw.<user>`, this needs to be properly reflected in the set of symbolic links we create during the installation process. 

Another change that this PR introduces is a symbolic link fixing the different path to the manage script embedded in the `$manage` variable when it comes to deployment  of the `wmagentpy3` package (adding the option `--py3` to the deployment script)

[1]
http://cmsrep.cern.ch/cgi-bin/repos/comp.tivanov/slc7_amd64_gcc630

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
<If it's a follow up work; or porting a fix from a different branch, please mention them here.>

#### External dependencies / deployment changes
<Does it require deployment changes? Does it rely on third-party libraries?>
