### PR TITLE
Remove py package from the requirements list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,6 @@ mock==2.0.0                   # wmagent
 MySQL-python==1.2.5           # wmagent
 nose2==0.9.2                  # wmagent
 psutil==5.6.6                 # wmagent,reqmgr2,reqmon,global-workqueue
-py==1.7.0                     # wmagent
 pycurl==7.43.0.3              # wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms
 pymongo==3.10.1               # reqmgr2ms
 pyOpenSSL==18.0.0             # wmagent


### PR DESCRIPTION
Fixes #10461 
Superseeds https://github.com/dmwm/WMCore/pull/10459

#### Status
ready

#### Description
After grepping our spec files under cmsdist/comp_gcc630, I fail to see any WMCore dependency on the python `py` package, so I'm removing it from the requirements.txt

For the record, the only package depending on that is the `py2-pytest`, which dqmgui.spec depends on.
 
#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none