### PR TITLE
[py2py3] Apply changes from pylint --py3k to files involved in #10012

### DIFF
--- a/src/python/WMCore/DataStructs/File.py
+++ b/src/python/WMCore/DataStructs/File.py
@@ -87,15 +87,6 @@ class File(WMObject, dict):
         if pnn:
             self['locations'] = self['locations'] | set(self.makelist(pnn))
 
-    def __cmp__(self, rhs):
-        """
-        Sort files in run number and lumi section order
-        """
-        # if self['run'] == rhs['run']:
-        #    return cmp(self['lumi'], rhs['lumi'])
-
-        return self.__eq__(rhs)
-
     def __eq__(self, rhs):
         """
         File is equal if it has the same name

--- a/src/python/WMCore/DataStructs/Run.py
+++ b/src/python/WMCore/DataStructs/Run.py
@@ -18,6 +18,11 @@ class Run(WMObject):
     _Run_
 
     Run container, is a list of lumi sections with associate event counts
+
+    TODO 
+    - use the decorator `from functools import total_ordering` after
+      dropping support for python 2.6
+    - then, drop __ne__, __le__, __gt__, __ge__
     """
 
     def __init__(self, runNumber=None, *newLumis):
@@ -29,6 +34,19 @@ class Run(WMObject):
     def __str__(self):
         return "Run%s:%s" % (self.run, self.eventsPerLumi)
 
+    def __eq__(self, rhs):
+        """
+        Check equality of run numbers and then underlying lumi/event dicts
+        """
+        if not isinstance(rhs, Run):
+            return False
+        if self.run != rhs.run:
+            return False
+        return self.eventsPerLumi == rhs.eventsPerLumi
+
+    def __ne__(self, rhs):
+        return not self.__eq__(rhs)
+
     def __lt__(self, rhs):
         """
         Compare on run # first, then by lumis as a list is compared
@@ -39,15 +57,14 @@ class Run(WMObject):
             return sorted(self.eventsPerLumi.keys()) < sorted(rhs.eventsPerLumi.keys())
         return self.eventsPerLumi < rhs.eventsPerLumi
 
-    def __gt__(self, rhs):
-        """
-        Compare on run # first, then by lumis as a list is compared
-        """
-        if self.run != rhs.run:
-            return self.run > rhs.run
-        if sorted(self.eventsPerLumi.keys()) != sorted(rhs.eventsPerLumi.keys()):
-            return sorted(self.eventsPerLumi.keys()) > sorted(rhs.eventsPerLumi.keys())
-        return self.eventsPerLumi > rhs.eventsPerLumi
+    def __le__(self, other):
+        return self.__lt__(other) or self.__eq__(other)
+
+    def __gt__(self, other):
+        return not self.__le__(other)
+
+    def __ge__(self, other):
+        return not self.__lt__(other)
 
     def extend(self, items):
         """
@@ -55,9 +72,6 @@ class Run(WMObject):
         """
         self.extendLumis(items)
         return
-
-    def __cmp__(self, rhs):
-        return (self > rhs) - (self < rhs)  # Python3 equivalent of cmp()
 
     def __add__(self, rhs):
         """
@@ -113,19 +127,6 @@ class Run(WMObject):
             del self.eventsPerLumi[oldLumi]  # Delete it
         except IndexError:
             pass
-
-    def __eq__(self, rhs):
-        """
-        Check equality of run numbers and then underlying lumi/event dicts
-        """
-        if not isinstance(rhs, Run):
-            return False
-        if self.run != rhs.run:
-            return False
-        return self.eventsPerLumi == rhs.eventsPerLumi
-
-    def __ne__(self, rhs):
-        return not self.__eq__(rhs)
 
     def __hash__(self):
         """

--- a/test/python/WMCore_t/DataStructs_t/File_t.py
+++ b/test/python/WMCore_t/DataStructs_t/File_t.py
@@ -80,6 +80,42 @@ class FileTest(unittest.TestCase):
 
         return
 
+    def testComparison(self):
+        """
+        testComparison
+
+        tests that File.__eq__() works properly
+        ACHTUNG! File.__eq__() focuses only on self['lfn'], 
+                 it does not check for any other key/property
+        """
+
+        testFile1 = File(lfn="lfn")
+        testFile1_bis = File(lfn="lfn")
+        self.assertEqual(testFile1, testFile1_bis)
+        self.assertTrue(testFile1 == testFile1_bis)
+        self.assertTrue(testFile1 is testFile1)
+        self.assertTrue(testFile1 is not testFile1_bis)
+        self.assertEqual(testFile1, "lfn")
+        self.assertTrue(testFile1 == "lfn")
+        self.assertEqual("lfn", testFile1)
+        self.assertTrue("lfn" == testFile1)
+
+        testFile2 = File(lfn="lfn-2")
+        self.assertNotEqual(testFile1, testFile2)
+        self.assertTrue(testFile1 != testFile2)
+        self.assertNotEqual(testFile1, "lfn-2")
+        self.assertTrue(testFile1 != "lfn-2")
+        self.assertNotEqual("lfn-2", testFile1)
+        self.assertTrue("lfn-2" != testFile1)
+
+        # The following two comparisons work in py2 (File.File inherits __cmp__ 
+        # from dict), but in py3 fail with
+        # TypeError: '<' not supported between instances of 'dict' and 'dict'
+        # self.assertFalse(testFile1 > testFile2)
+        # self.assertTrue(testFile1 < testFile2)
+
+        return
+
     def testSaveAndLoad(self):
         """
         This tests the save and load code of a DataStructs File object

--- a/test/python/WMCore_t/DataStructs_t/Run_t.py
+++ b/test/python/WMCore_t/DataStructs_t/Run_t.py
@@ -111,6 +111,16 @@ class RunTest(unittest.TestCase):
         self.assertEqual(runlist[1], run2)
         self.assertEqual(runlist[2], run3)
 
+        comparisons_0 = [
+            run1 < run2, run1 <= run2,
+            run1 == run2, run1 != run2,
+            run1 > run2, run1 >= run2,
+            ]
+        self.assertListEqual(comparisons_0,
+                             [True, True,
+                              False, True,
+                              False, False])
+
         run4 = Run(4, 1, 2, 3)
         run5 = Run(4, 4, 5, 6)
         run6 = Run(4, 7, 8, 9)
@@ -140,6 +150,34 @@ class RunTest(unittest.TestCase):
         self.assertEqual(runlist[2], run9)
         self.assertEqual(runlist[3], run10)
         self.assertEqual(runlist[4], run11)
+
+        comparisons_1 = [
+            run10 < run11, run10 <= run11,
+            run10 == run11, run10 != run11,
+            run10 > run11, run10 >= run11,
+            ]
+        self.assertListEqual(comparisons_1,
+                             [True, True,
+                              False, True,
+                              False, False])
+        comparisons_2_same = [
+            run7 < run7, run7 <= run7,
+            run7 == run7, run7 != run7,
+            run7 > run7, run7 >= run7,
+            ]
+        self.assertListEqual(comparisons_2_same,
+                             [False, True,
+                              True, False,
+                              False, True])
+        comparisons_3_same = [
+            run7 < run8, run7 <= run8,
+            run7 == run8, run7 != run8,
+            run7 > run8, run7 >= run8,
+            ]
+        self.assertListEqual(comparisons_3_same,
+                             [False, True,
+                              True, False,
+                              False, True])
 
     def testD(self):
         """


### PR DESCRIPTION
Fixes #10169 

#### Status
In development 

#### Description

We need to modernize how we do comparisons and ordering in `DataStructs/Run.py` and `DataStructs/File.py` because python3 does not honor anymore the dunder method `__cmp__`.

(details will be updated)

- `src/python/WMCore/DataStructs/Run.py`
- `src/python/WMCore/DataStructs/File.py`

Reference: https://portingguide.readthedocs.io/en/latest/comparisons.html

Examples and some testing
- https://cms-dmwm-test.docs.cern.ch/py2py3/porting/comparisons_py2/
- https://cms-dmwm-test.docs.cern.ch/py2py3/porting/comparisons_py3/

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
This is a follow-up to #10441 

#### External dependencies / deployment changes
nope
