### PR TITLE
Only create Rucio connection in PileupFetcher if there is a pileup dataset

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
+++ b/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
@@ -15,7 +15,6 @@ import logging
 from json import JSONEncoder
 import WMCore.WMSpec.WMStep as WMStep
 from WMCore.Services.DBS.DBSReader import DBSReader
-from WMCore.Services.PhEDEx.PhEDEx import PhEDEx
 from WMCore.Services.Rucio.Rucio import Rucio
 from WMCore.WMSpec.Steps.Fetchers.FetcherInterface import FetcherInterface
 
@@ -35,7 +34,7 @@ class PileupFetcher(FetcherInterface):
         super(PileupFetcher, self).__init__()
         # FIXME: find a way to pass the Rucio account name to this fetcher module
         self.rucioAcct = "wmcore_transferor"
-        self.rucio = Rucio(self.rucioAcct)
+        self.rucio = None
 
     def _queryDbsAndGetPileupConfig(self, stepHelper, dbsReader):
         """
@@ -78,6 +77,8 @@ class PileupFetcher(FetcherInterface):
         :param blockDict: dictionary with DBS summary info
         :return: update blockDict in place
         """
+        # initialize Rucio here to avoid this authentication on T0-WMAgent
+        self.rucio = Rucio(self.rucioAcct)
         blockReplicas = self.rucio.getPileupLockedAndAvailable(dset, account=self.rucioAcct)
         for blockName, blockLocation in viewitems(blockReplicas):
             try:


### PR DESCRIPTION
Fixes #10466 
#### Status
ready

#### Description
PileupFetcher is initialized (and called) for every single workflow, regardless whether there is a pileup dataset configured in the workflow or not.
This causes an error in the T0WMAgent, since the agent tries to authenticate to Rucio with the `wmcore_transferor` account.

This PR changes the Rucio object initialization/authentication a bit lower in the chain, only creating it if there is actually a pileup dataset defined in the workflow (which should not happen for T0 agents).

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
None (in the future, we need to find a way to pass a Rucio account to these fetchers though)

#### External dependencies / deployment changes
None
