### PR TITLE
Remake MSTransferor alert subject; increase alert expiration time to 1h

### DIFF
--- a/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
+++ b/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
@@ -746,18 +746,21 @@ class MSTransferor(MSCore):
         """
         # Warn about data transfer subscriptions going above some threshold
         if aboveWarningThreshold:
-            alertName = "ms-transferor: Transfer over threshold: {}".format(transferId)
+            alertName = "{}: input data transfer over threshold: {}".format(self.alertServiceName,
+                                                                            wflowName)
             alertSeverity = "high"
             alertSummary = "[MS] Large pending data transfer under request id: {}".format(transferId)
-            alertDescription = "Workflow: {}\nhas a large amount of ".format(wflowName)
-            alertDescription += "data subscribed: {} TB,\n".format(teraBytes(dataSize))
+            alertDescription = "Workflow: {} has a large amount of ".format(wflowName)
+            alertDescription += "data subscribed: {} TB, ".format(teraBytes(dataSize))
             alertDescription += "for {} data: {}.""".format(dataIn['type'], dataIn['name'])
 
             try:
-                self.alertManagerApi.sendAlert(alertName, alertSeverity, alertSummary, alertDescription, self.alertServiceName)
+                # alert to expiry in an hour from now
+                self.alertManagerApi.sendAlert(alertName, alertSeverity, alertSummary, alertDescription,
+                                               self.alertServiceName, endSecs=1 * 60 * 60)
             except Exception as ex:
                 self.logger.exception("Failed to send alert to %s. Error: %s", self.alertManagerUrl, str(ex))
-            self.logger.info(alertDescription)
+            self.logger.warning(alertDescription)
 
     def _getValidSites(self, wflow, dataIn):
         """


### PR DESCRIPTION
Fixes #10468 

#### Status
ready

#### Description
Instead of providing ALL the Rucio transfer ID in the email alert subject, provide only the workflow name.
Also removed the new lines `\n` from the description, they get escaped anyways in AlertManager.
Last but not least, increase their expiration time to 2 days (could be something configurable as well). such that the link from Slack to AM can bring us to real content.

UPDATE: expiration time set to only 1 hour, otherwise AM keeps sending a notification both via email and slack every 2h, until the alert is gone from the system.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
