### PR TITLE
Revert "Temporary fix to let CouchDB replications go through the standard port - wmagent"

### DIFF
--- a/src/python/Utils/PortForward.py
+++ b/src/python/Utils/PortForward.py
@@ -51,12 +51,12 @@ def portForward(port):
             forwarded = False
             try:
                 if isinstance(url, str):
-                    urlToMangle = u'https://cmsweb'
+                    urlToMangle = u'https://tivanov'
                     if url.startswith(urlToMangle):
                         newUrl = url.replace(u'.cern.ch/', u'.cern.ch:%d/' % port, 1)
                         forwarded = True
                 elif isinstance(url, bytes):
-                    urlToMangle = b'https://cmsweb'
+                    urlToMangle = b'https://tivanov'
                     if url.startswith(urlToMangle):
                         newUrl = url.replace(b'.cern.ch/', b'.cern.ch:%d/' % port, 1)
                         forwarded = True

--- a/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
+++ b/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
@@ -14,6 +14,7 @@ import threading
 from pprint import pformat
 from Utils.Timers import timeFunction
 from Utils.Utilities import numberCouchProcess
+from Utils.PortForward import PortForward
 from WMComponent.AgentStatusWatcher.DrainStatusPoller import DrainStatusPoller
 from WMComponent.AnalyticsDataCollector.DataCollectAPI import WMAgentDBData, initAgentInfo
 from WMCore.Credential.Proxy import Proxy
@@ -54,6 +55,9 @@ class AgentStatusPoller(BaseWorkerThread):
         self.credThresholds = {'proxy': {'error': 3, 'warning': 5},
                                'certificate': {'error': 10, 'warning': 20}}
 
+        # create a portForwarder to be used for rerouting the replication process
+        self.portForwarder = PortForward(8443)
+
         # Monitoring setup
         self.userAMQ = getattr(config.AgentStatusWatcher, "userAMQ", None)
         self.passAMQ = getattr(config.AgentStatusWatcher, "passAMQ", None)
@@ -77,6 +81,7 @@ class AgentStatusPoller(BaseWorkerThread):
         # set up common replication code
         wmstatsSource = self.config.JobStateMachine.jobSummaryDBName
         wmstatsTarget = self.config.General.centralWMStatsURL
+        wmstatsTarget = self.portForwarder(wmstatsTarget)
 
         self.replicatorDocs.append({'source': wmstatsSource, 'target': wmstatsTarget,
                                     'filter': "WMStatsAgent/repfilter"})
@@ -89,7 +94,9 @@ class AgentStatusPoller(BaseWorkerThread):
             # set up workqueue replication
             wqfilter = 'WorkQueue/queueFilter'
             parentQURL = self.config.WorkQueueManager.queueParams["ParentQueueCouchUrl"]
+            parentQURL = self.portForwarder(parentQURL)
             childURL = self.config.WorkQueueManager.queueParams["QueueURL"]
+            childURL = self.portForwarder(childURL)
             query_params = {'childUrl': childURL, 'parentUrl': sanitizeURL(parentQURL)['url']}
             localQInboxURL = "%s_inbox" % self.config.AnalyticsDataCollector.localQueueURL
             self.replicatorDocs.append({'source': sanitizeURL(parentQURL)['url'], 'target': localQInboxURL,


### PR DESCRIPTION
This reverts commit 0741ac1f4e00a17f1f1f7861332a6b8012986797.

Fixes #10452 

#### Status
Testing 

#### Description
While testing the migration of all machine generated  traffic to port 8443 for WMAgent we noticed that the CouchDB replication was broken for WMAgent. I remember previously this was properly solved with those changes in my environment, so my suspicion is this may turn out to be either a deployment procedure issue, like a need of port 8443 to be manually opened on the central services side of the developers' testing deployment or we simply miss another spot in the code that the forwarding also needs to happen. 

I need the current PR in order to be able to deploy an agent (by patching it at deployment time) with the supposedly broken piece of  code, so I can observe where it breaks.

#### Is it backward compatible (if not, which system it affects?)
NO

#### Related PRs
https://github.com/dmwm/WMCore/pull/10453

#### External dependencies / deployment changes
Still to be added here.
