### PR TITLE
Python3 workflow test templates

### DIFF
--- a/test/data/ReqMgr/requests/DMWM/TC_PY3_ProdTTbar.json
+++ b/test/data/ReqMgr/requests/DMWM/TC_PY3_ProdTTbar.json
@@ -1,0 +1,127 @@
+{
+    "assignRequest": {
+        "AcquisitionEra": {
+            "Digi_2021": "AcquisitionEra-OVERRIDE-ME", 
+            "GenSimFull": "AcquisitionEra-OVERRIDE-ME", 
+            "Reco_2021": "AcquisitionEra-OVERRIDE-ME"
+        }, 
+        "Dashboard": "Dashboard-OVERRIDE-ME", 
+        "GracePeriod": 300, 
+        "MergedLFNBase": "/store/backfill/1", 
+        "Override": {
+            "eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/TESTBED"
+        }, 
+        "ProcessingString": {
+            "Digi_2021": "ProcessingString-OVERRIDE-ME", 
+            "GenSimFull": "ProcessingString-OVERRIDE-ME", 
+            "Reco_2021": "ProcessingString-OVERRIDE-ME"
+        }, 
+        "ProcessingVersion": {
+            "GenSimFull": 18, 
+            "Digi_2021": 19, 
+            "Reco_2021": 20
+        }, 
+        "SiteBlacklist": [], 
+        "SiteWhitelist": [
+            "SiteWhitelist-OVERRIDE-ME"
+        ], 
+        "SoftTimeout": 129600, 
+        "Team": "Team-OVERRIDE-ME", 
+        "UnmergedLFNBase": "/store/unmerged"
+    }, 
+    "createRequest": {
+        "AcquisitionEra": "DEFAULT_AcqEra", 
+        "CMSSWVersion": "CMSSW_11_3_0_pre2_PY3", 
+        "Campaign": "Campaign-OVERRIDE-ME", 
+        "Comments": {
+            "CheckList": ["TaskChain python3 workflow; TaskChain MC from scratch; TaskChain with diff AcqEra/ProcStr/ProcVer",
+                          "Correct EventBased and EventAwareLumiBased splitting"],
+            "WorkFlowDesc": ["TaskChain python3 workflow from scratch without PU; Given 100EpL for Task1, set EpJ/EpL to 41",
+                             "Task2 and Task3 EventAwareLumiBased with 800 and 900 EpJob; Diff AcqEra/ProcStr/ProcVer"]
+        }, 
+        "ConfigCacheUrl": "https://cmsweb-testbed.cern.ch/couchdb", 
+        "CouchDBName": "reqmgr_config_cache", 
+        "DQMConfigCacheID": "e7b57c02d21317e8837dd8868c08bbe3", 
+        "DQMHarvestUnit": "byRun", 
+        "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev", 
+        "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/", 
+        "EnableHarvesting": true, 
+        "GlobalTag": "113X_mcRun3_2021_realistic_v2", 
+        "IncludeParents": false, 
+        "Memory": 3000, 
+        "Multicore": 1, 
+        "PrepID": "TEST-CMSSW_11_3_0_pre2_PY3__FullSim_PY3_TESTbyCA-TTbar_14TeV-00001", 
+        "ProcessingString": "DEFAULT_ProcStr", 
+        "ProcessingVersion": 1, 
+        "RequestPriority": 600000, 
+        "RequestString": "RequestString-OVERRIDE-ME", 
+        "RequestType": "TaskChain", 
+        "ScramArch": [
+            "slc7_amd64_gcc900"
+        ], 
+        "SizePerEvent": 1, 
+        "SubRequestType": "RelVal", 
+        "Task1": {
+            "AcquisitionEra": "CMSSW_11_3_0_pre1", 
+            "CMSSWVersion": "CMSSW_11_3_0_pre2_PY3", 
+            "Campaign": "RelVal_Generic_Campaign", 
+            "ConfigCacheID": "e7b57c02d21317e8837dd8868c084692", 
+            "EventStreams": 2, 
+            "EventsPerLumi": 100, 
+            "GlobalTag": "113X_mcRun3_2021_realistic_v2", 
+            "KeepOutput": true, 
+            "Memory": 1500,
+            "Multicore": 4,
+            "PrimaryDataset": "RelValTTbar_14TeV", 
+            "ProcessingString": "Task1_WMCore_TEST", 
+            "RequestNumEvents": 4000, 
+            "ScramArch": [
+                "slc7_amd64_gcc900"
+            ], 
+            "Seeding": "AutomaticSeeding", 
+            "SplittingAlgo": "EventBased", 
+            "TimePerEvent": 700,
+            "TaskName": "GenSimFull"
+        }, 
+        "Task2": {
+            "AcquisitionEra": "CMSSW_11_3_0_pre2", 
+            "CMSSWVersion": "CMSSW_11_3_0_pre2_PY3", 
+            "Campaign": "RelVal_Generic_Campaign", 
+            "ConfigCacheID": "e7b57c02d21317e8837dd8868c08721e", 
+            "EventStreams": 2, 
+            "GlobalTag": "113X_mcRun3_2021_realistic_v2", 
+            "InputFromOutputModule": "FEVTDEBUGoutput", 
+            "InputTask": "GenSimFull", 
+            "KeepOutput": true, 
+            "Memory": 4000,
+            "Multicore": 4,
+            "ProcessingString": "Task2_WMCore_TEST", 
+            "ScramArch": [
+                "slc7_amd64_gcc900"
+            ], 
+            "TimePerEvent": 36,
+            "TaskName": "Digi_2021"
+        }, 
+        "Task3": {
+            "AcquisitionEra": "CMSSW_11_3_0_pre2_PY3", 
+            "CMSSWVersion": "CMSSW_11_3_0_pre2_PY3", 
+            "Campaign": "RelVal_Generic_Campaign", 
+            "ConfigCacheID": "e7b57c02d21317e8837dd8868c08aab3", 
+            "EventStreams": 2, 
+            "GlobalTag": "113X_mcRun3_2021_realistic_v2", 
+            "InputFromOutputModule": "FEVTDEBUGHLToutput", 
+            "InputTask": "Digi_2021", 
+            "KeepOutput": true, 
+            "Memory": 6000,
+            "Multicore": 4,
+            "ProcessingString": "Task3_WMCore_TEST", 
+            "ScramArch": [
+                "slc7_amd64_gcc900"
+            ], 
+            "TimePerEvent": 32,
+            "TaskName": "Reco_2021"
+        }, 
+        "TaskChain": 3, 
+        "TimePerEvent": 1
+    }
+}

--- a/test/data/ReqMgr/requests/Integration/SC_PY3_PURecyc.json
+++ b/test/data/ReqMgr/requests/Integration/SC_PY3_PURecyc.json
@@ -1,0 +1,98 @@
+{
+    "assignRequest": {
+        "AcquisitionEra": {
+            "DigiPU_2021PU": "AcquisitionEra-OVERRIDE-ME", 
+            "RecoPU_2021PU": "AcquisitionEra-OVERRIDE-ME"
+        }, 
+        "Dashboard": "Dashboard-OVERRIDE-ME", 
+        "GracePeriod": 300, 
+        "MergedLFNBase": "/store/backfill/1", 
+        "Override": {
+            "eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/TESTBED"
+        }, 
+        "ProcessingString": {
+            "DigiPU_2021PU": "ProcessingString-OVERRIDE-ME", 
+            "RecoPU_2021PU": "ProcessingString-OVERRIDE-ME"
+        }, 
+        "ProcessingVersion": 19, 
+        "SiteBlacklist": [], 
+        "SiteWhitelist": [
+            "SiteWhitelist-OVERRIDE-ME"
+        ], 
+        "SoftTimeout": 129600, 
+        "Team": "Team-OVERRIDE-ME", 
+        "UnmergedLFNBase": "/store/unmerged"
+    }, 
+    "createRequest": {
+        "AcquisitionEra": "DEFAULT_AcqEra", 
+        "CMSSWVersion": "CMSSW_11_3_0_pre2_PY3", 
+        "Campaign": "Campaign-OVERRIDE-ME", 
+        "Comments": {
+            "CheckList": "StepChain python3 workflow; StepChain with input and pileup; StepChain harvesting", 
+            "WorkFlowDesc": "StepChain python3 workflow; with input and pileup; harvesting enabled; 3 LpJ; 8CPU/9GB"
+        }, 
+        "ConfigCacheUrl": "https://cmsweb-testbed.cern.ch/couchdb", 
+        "CouchDBName": "reqmgr_config_cache", 
+        "DQMConfigCacheID": "e7b57c02d21317e8837dd8868c153bb1", 
+        "DQMHarvestUnit": "byRun", 
+        "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev", 
+        "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/", 
+        "DeterministicPileup": false, 
+        "EnableHarvesting": true, 
+        "GlobalTag": "113X_mcRun3_2021_realistic_v2", 
+        "IncludeParents": false, 
+        "Memory": 12000, 
+        "Multicore": 1, 
+        "PrepID": "TEST-TEST-CMSSW_11_3_0_pre2_PY3__FullSim_PY3_TESTbyCA-ZMM_14-00001", 
+        "ProcessingString": "DEFAULT_ProcStr",
+        "ProcessingVersion": 1, 
+        "RequestPriority": 600000, 
+        "RequestString": "RequestString-OVERRIDE-ME", 
+        "RequestType": "StepChain", 
+        "ScramArch": [
+            "slc7_amd64_gcc900"
+        ], 
+        "SizePerEvent": 1, 
+        "Step1": {
+            "AcquisitionEra": "CMSSW_11_3_0_pre2_PY3", 
+            "CMSSWVersion": "CMSSW_11_3_0_pre2_PY3", 
+            "Campaign": "RelVal_Generic_Campaign",
+            "ConfigCacheID": "e7b57c02d21317e8837dd8868c14fd8b", 
+            "EventStreams": 2, 
+            "GlobalTag": "113X_mcRun3_2021_realistic_v2", 
+            "InputDataset": "/RelValZMM_14/CMSSW_11_3_0_pre5-113X_mcRun3_2021_realistic_v7-v1/GEN-SIM", 
+            "KeepOutput": false, 
+            "LumisPerJob": 3, 
+            "MCPileup": "/RelValMinBias_14TeV/CMSSW_11_3_0_pre5-113X_mcRun3_2021_realistic_v7-v1/GEN-SIM", 
+            "Memory": 9000,
+            "Multicore": 8, 
+            "ProcessingString": "Step1_WMCore_TEST", 
+            "ScramArch": [
+                "slc7_amd64_gcc900"
+            ], 
+            "SplittingAlgo": "LumiBased", 
+            "StepName": "DigiPU_2021PU"
+        }, 
+        "Step2": {
+            "AcquisitionEra": "CMSSW_11_3_0_pre2_PY3", 
+            "CMSSWVersion": "CMSSW_11_3_0_pre2_PY3", 
+            "Campaign": "RelVal_Generic_Campaign",
+            "ConfigCacheID": "e7b57c02d21317e8837dd8868c151910", 
+            "EventStreams": 2, 
+            "GlobalTag": "113X_mcRun3_2021_realistic_v2", 
+            "InputFromOutputModule": "FEVTDEBUGHLToutput", 
+            "InputStep": "DigiPU_2021PU", 
+            "KeepOutput": true, 
+            "MCPileup": "/RelValMinBias_14TeV/CMSSW_11_3_0_pre5-113X_mcRun3_2021_realistic_v7-v1/GEN-SIM", 
+            "Memory": 9000,
+            "Multicore": 8, 
+            "ProcessingString": "Step2_WMCore_TEST", 
+            "ScramArch": [
+                "slc7_amd64_gcc900"
+            ], 
+            "StepName": "RecoPU_2021PU"
+        }, 
+        "StepChain": 2, 
+        "TimePerEvent": 1
+    }
+}

--- a/test/data/ReqMgr/requests/Integration/TC_PY3_Data_LumiList.json
+++ b/test/data/ReqMgr/requests/Integration/TC_PY3_Data_LumiList.json
@@ -1,0 +1,98 @@
+{
+    "assignRequest": {
+        "AcquisitionEra": {
+            "HLTDR2_2018": "AcquisitionEra-OVERRIDE-ME", 
+            "RECODR2_2018reHLT_Prompt": "AcquisitionEra-OVERRIDE-ME"
+        }, 
+        "Dashboard": "Dashboard-OVERRIDE-ME", 
+        "GracePeriod": 300, 
+        "MergedLFNBase": "/store/backfill/1", 
+        "Override": {
+            "eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/TESTBED"
+        }, 
+        "ProcessingString": {
+            "HLTDR2_2018": "ProcessingString-OVERRIDE-ME", 
+            "RECODR2_2018reHLT_Prompt": "ProcessingString-OVERRIDE-ME"
+        }, 
+        "ProcessingVersion": 19, 
+        "SiteBlacklist": [], 
+        "SiteWhitelist": [
+            "SiteWhitelist-OVERRIDE-ME"
+        ], 
+        "SoftTimeout": 129600, 
+        "Team": "Team-OVERRIDE-ME", 
+        "UnmergedLFNBase": "/store/unmerged"
+    }, 
+    "createRequest": {
+        "AcquisitionEra": "DEFAULT_AcqEra", 
+        "CMSSWVersion": "CMSSW_11_3_0_pre2_PY3", 
+        "Campaign": "Campaign-OVERRIDE-ME", 
+        "Comments": {
+            "CheckList": "TaskChain python3 workflow; TaskChain data with 2 tasks; TaskChain with LumiList",
+            "WorkFlowDesc": ["TaskChain python3 workflow, with real data and 2 tasks, LumiList with 1 run and 50 lumis;",
+                             "Task1 with 2LpJ, task2 with 1LpJ; 8 CPU, diff RAM"]
+        }, 
+        "ConfigCacheUrl": "https://cmsweb-testbed.cern.ch/couchdb", 
+        "CouchDBName": "reqmgr_config_cache", 
+        "DQMConfigCacheID": "e7b57c02d21317e8837dd8868c08a1e6", 
+        "DQMHarvestUnit": "byRun", 
+        "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev", 
+        "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/", 
+        "EnableHarvesting": true, 
+        "GlobalTag": "103X_dataRun2_HLT_relval_v10", 
+        "IncludeParents": false, 
+        "Memory": 3000, 
+        "Multicore": 1, 
+        "PrepID": "TEST-CMSSW_11_3_0_pre2_PY3__Data_PY3_TESTbyCA-RunDoubleMuon2018D-00001", 
+        "ProcessingString": "DEFAULT_ProcStr", 
+        "ProcessingVersion": 1, 
+        "RequestPriority": 600000, 
+        "RequestString": "RequestString-OVERRIDE-ME", 
+        "RequestType": "TaskChain", 
+        "ScramArch": [
+            "slc7_amd64_gcc900"
+        ], 
+        "SizePerEvent": 1, 
+        "SubRequestType": "RelVal", 
+        "Task1": {
+            "AcquisitionEra": "CMSSW_11_3_0_pre2_PY3", 
+            "CMSSWVersion": "CMSSW_11_3_0_pre2_PY3", 
+            "Campaign": "RelVal_Generic_Campaign",
+            "ConfigCacheID": "e7b57c02d21317e8837dd8868c08502f", 
+            "GlobalTag": "103X_dataRun2_HLT_relval_v10", 
+            "InputDataset": "/DoubleMuon/Run2018D-v1/RAW", 
+            "KeepOutput": true, 
+            "LumiList": {"320822": [[1, 25], [50, 74]]},
+            "LumisPerJob": 2,
+            "Memory": 2000,
+            "Multicore": 8, 
+            "ProcessingString": "Task1_WMCore_TEST", 
+            "ScramArch": [
+                "slc7_amd64_gcc900"
+            ], 
+            "SplittingAlgo": "LumiBased", 
+            "TaskName": "HLTDR2_2018"
+        }, 
+        "Task2": {
+            "AcquisitionEra": "CMSSW_11_3_0_pre2_PY3", 
+            "CMSSWVersion": "CMSSW_11_3_0_pre2_PY3", 
+            "Campaign": "RelVal_Generic_Campaign",
+            "ConfigCacheID": "e7b57c02d21317e8837dd8868c0899b7", 
+            "GlobalTag": "113X_dataRun2_v1", 
+            "InputFromOutputModule": "FEVTDEBUGHLToutput", 
+            "InputTask": "HLTDR2_2018", 
+            "KeepOutput": true, 
+            "LumisPerJob": 1, 
+            "Memory": 7000,
+            "Multicore": 8, 
+            "ProcessingString": "Task2_WMCore_TEST", 
+            "ScramArch": [
+                "slc7_amd64_gcc900"
+            ], 
+            "SplittingAlgo": "LumiBased", 
+            "TaskName": "RECODR2_2018reHLT_Prompt"
+        }, 
+        "TaskChain": 2, 
+        "TimePerEvent": 1
+    }
+}

--- a/test/data/ReqMgr/requests/Integration/TC_PY3_TTbarPU.json
+++ b/test/data/ReqMgr/requests/Integration/TC_PY3_TTbarPU.json
@@ -1,0 +1,126 @@
+{
+    "assignRequest": {
+        "AcquisitionEra": {
+            "DigiPU_2021PU": "AcquisitionEra-OVERRIDE-ME", 
+            "GenSimFull": "AcquisitionEra-OVERRIDE-ME", 
+            "RecoPU_2021PU": "AcquisitionEra-OVERRIDE-ME"
+        }, 
+        "Dashboard": "Dashboard-OVERRIDE-ME", 
+        "GracePeriod": 300, 
+        "MergedLFNBase": "/store/backfill/1", 
+        "Override": {
+            "eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/TESTBED"
+        }, 
+        "ProcessingString": {
+            "DigiPU_2021PU": "ProcessingString-OVERRIDE-ME", 
+            "GenSimFull": "ProcessingString-OVERRIDE-ME", 
+            "RecoPU_2021PU": "ProcessingString-OVERRIDE-ME"
+        }, 
+        "ProcessingVersion": 19, 
+        "SiteBlacklist": [], 
+        "SiteWhitelist": [
+            "SiteWhitelist-OVERRIDE-ME"
+        ], 
+        "SoftTimeout": 129600, 
+        "Team": "Team-OVERRIDE-ME", 
+        "UnmergedLFNBase": "/store/unmerged"
+    }, 
+    "createRequest": {
+        "AcquisitionEra": "DEFAULT_AcqEra", 
+        "CMSSWVersion": "CMSSW_11_3_0_pre2_PY3", 
+        "Campaign": "Campaign-OVERRIDE-ME", 
+        "Comments": {
+            "CheckList": "TaskChain python3 workflow; TaskChain PU from scratch; TaskChain mc harvesting", 
+            "WorkFlowDesc": ["TaskChain python3 workflow without input, with PU; Task1 200EpJ/2LpJ; Task2 5LpJ",
+                             "Task3 4LpJ; drop DIGI output; Task1/2/3 with 6/7/8 CPUs, 2/3/4 Streams, diff RAM"]
+        }, 
+        "ConfigCacheUrl": "https://cmsweb-testbed.cern.ch/couchdb", 
+        "CouchDBName": "reqmgr_config_cache", 
+        "DQMConfigCacheID": "e7b57c02d21317e8837dd8868c09f8fb", 
+        "DQMHarvestUnit": "byRun", 
+        "DQMUploadUrl": "https://cmsweb-testbed.cern.ch/dqm/dev", 
+        "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader/", 
+        "EnableHarvesting": true, 
+        "GlobalTag": "113X_mcRun3_2021_realistic_v2", 
+        "IncludeParents": false, 
+        "Memory": 3000, 
+        "Multicore": 1, 
+        "PrepID": "TEST-CMSSW_11_3_0_pre2_PY3__FullSim_PY3_TESTbyCA-TTbar_14TeV-00002", 
+        "ProcessingString": "DEFAULT_ProcStr", 
+        "ProcessingVersion": 1, 
+        "RequestPriority": 600000, 
+        "RequestString": "RequestString-OVERRIDE-ME", 
+        "RequestType": "TaskChain", 
+        "ScramArch": [
+            "slc7_amd64_gcc900"
+        ], 
+        "SizePerEvent": 1, 
+        "SubRequestType": "RelVal", 
+        "Task1": {
+            "AcquisitionEra": "CMSSW_11_3_0_pre2_PY3", 
+            "CMSSWVersion": "CMSSW_11_3_0_pre2_PY3", 
+            "Campaign": "RelVal_Generic_Campaign",
+            "ConfigCacheID": "e7b57c02d21317e8837dd8868c09b813", 
+            "EventStreams": 2, 
+            "EventsPerJob": 200, 
+            "EventsPerLumi": 100, 
+            "GlobalTag": "113X_mcRun3_2021_realistic_v2", 
+            "KeepOutput": true, 
+            "Memory": 1500,
+            "Multicore": 6,
+            "PrimaryDataset": "RelValTTbar_14TeV", 
+            "ProcessingString": "Task1_WMCore_TEST", 
+            "RequestNumEvents": 5000,
+            "ScramArch": [
+                "slc7_amd64_gcc900"
+            ], 
+            "Seeding": "AutomaticSeeding", 
+            "SplittingAlgo": "EventBased", 
+            "TaskName": "GenSimFull"
+        }, 
+        "Task2": {
+            "AcquisitionEra": "CMSSW_11_3_0_pre2_PY3", 
+            "CMSSWVersion": "CMSSW_11_3_0_pre2_PY3", 
+            "Campaign": "RelVal_Generic_Campaign",
+            "ConfigCacheID": "e7b57c02d21317e8837dd8868c09c267", 
+            "EventStreams": 3, 
+            "GlobalTag": "113X_mcRun3_2021_realistic_v2", 
+            "InputFromOutputModule": "FEVTDEBUGoutput", 
+            "InputTask": "GenSimFull", 
+            "KeepOutput": true, 
+            "LumisPerJob": 5,
+            "MCPileup": "/RelValMinBias_14TeV/CMSSW_11_3_0_pre5-113X_mcRun3_2021_realistic_v7-v1/GEN-SIM", 
+            "Memory": 7000,
+            "Multicore": 7,
+            "ProcessingString": "Task2_WMCore_TEST", 
+            "ScramArch": [
+                "slc7_amd64_gcc900"
+            ], 
+            "SplittingAlgo": "LumiBased", 
+            "TaskName": "DigiPU_2021PU"
+        }, 
+        "Task3": {
+            "AcquisitionEra": "CMSSW_11_3_0_pre2_PY3", 
+            "CMSSWVersion": "CMSSW_11_3_0_pre2_PY3", 
+            "Campaign": "RelVal_Generic_Campaign",
+            "ConfigCacheID": "e7b57c02d21317e8837dd8868c09e3b9", 
+            "EventStreams": 4, 
+            "GlobalTag": "113X_mcRun3_2021_realistic_v2", 
+            "InputFromOutputModule": "FEVTDEBUGHLToutput", 
+            "InputTask": "DigiPU_2021PU", 
+            "KeepOutput": true, 
+            "LumisPerJob": 4,
+            "MCPileup": "/RelValMinBias_14TeV/CMSSW_11_3_0_pre5-113X_mcRun3_2021_realistic_v7-v1/GEN-SIM", 
+            "Memory": 12000, 
+            "Multicore": 8, 
+            "ProcessingString": "Task3_WMCore_TEST", 
+            "ScramArch": [
+                "slc7_amd64_gcc900"
+            ], 
+            "SplittingAlgo": "LumiBased", 
+            "TaskName": "RecoPU_2021PU"
+        }, 
+        "TaskChain": 3, 
+        "TimePerEvent": 1
+    }
+}


### PR DESCRIPTION
Fixes #9598 

#### Status
ready

#### Description
This pull request provides 4 json workflow templates made with python3 (including their PSet configurations). It covers:
* workflow processing data + harvesting
* workflow MC production from scratch without pileup + harvesting
* workflow MC from scratch with pileup + harvesting
* workflow MC with input and pileup + harvesting

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
Requires WMAgent patched with: https://github.com/dmwm/WMCore/pull/10179
