### PR TITLE
[py2py3] Scripts should support py3

### DIFF
--- a/bin/HWMon/wmcore-SysStat
+++ b/bin/HWMon/wmcore-SysStat
@@ -5,6 +5,7 @@ wmcore-SysStat
 
 Hardware monitoring utility for launched sensor daemons.
 """
+from __future__ import print_function
 
 import sys
 import os
@@ -26,7 +27,7 @@ def error(msg):
     General error handler.
     """
     
-    print "ERROR:", msg 
+    print("ERROR:", msg) 
     sys.exit(1)
     
 def warning(msg):
@@ -34,7 +35,7 @@ def warning(msg):
     General warning handler.
     """
     
-    print "WARNING:", msg
+    print("WARNING:", msg)
 
 def extractList(targetType, arg):
     """
@@ -157,7 +158,7 @@ def disks():
     """
     
     disks = os.popen('ls -1 /dev/?d[a-z]').readlines()
-    disks = map(lambda x: x.split('/')[2].rstrip(), disks)
+    disks = [x.split('/')[2].rstrip() for x in disks]
     return disks
 
 def loadConfiguration():
@@ -173,7 +174,7 @@ def loadConfiguration():
             
             if "HWMon" not in dir(config):
                 error("No 'HWMon' section found in WMCore configuration file! Please, check your configuration file.")
-    except ImportError, ex:
+    except ImportError as ex:
         error("Can no load configuration file! Please, check configuration file (" + os.path.abspath(configFile) + ")")
 
 def prepareList(targetType, arg):
@@ -197,7 +198,7 @@ def prepareList(targetType, arg):
         if targetType == ITEM_WMCOMPONENT:
             specifiedList[ITEM_WMCOMPONENT] = config.listComponents_()
         elif targetType == ITEM_SERVICE:
-            specifiedList[ITEM_SERVICE] = servicesList.keys()
+            specifiedList[ITEM_SERVICE] = list(servicesList)
         elif targetType == ITEM_RESOURCE:
             specifiedList[ITEM_RESOURCE] = resourcesList
         elif targetType == ITEM_DISK:
@@ -300,7 +301,7 @@ def kill(pid, signal):
     
     try:
         os.kill(int(pid), signal)
-    except OSError, ex:
+    except OSError as ex:
         err = str(err)
         if err.find("No such process") >= 0:
             pass
@@ -399,7 +400,7 @@ def start():
         for target in specifiedList[ttype]:
             statSensorDaemon = isSensorDaemonRunning(target)
             if statSensorDaemon[0]:
-                print "%-7s | Sensor daemon (pid: %s) is already running for %s %s." % (status[2], str(statSensorDaemon[1]), ITEM_TYPE[ttype], target)
+                print("%-7s | Sensor daemon (pid: %s) is already running for %s %s." % (status[2], str(statSensorDaemon[1]), ITEM_TYPE[ttype], target))
                 continue
             
             #statSensor = isSensorRunning(target)
@@ -408,11 +409,11 @@ def start():
             #    continue
               
             if ttype == ITEM_WMCOMPONENT and not isWMComponentRunning(target)[0]:
-                print "%-7s | %s %s is not running." % (status[2], ITEM_TYPE[ttype], target)
+                print("%-7s | %s %s is not running." % (status[2], ITEM_TYPE[ttype], target))
                 continue
                 
             if ttype == ITEM_SERVICE and not isServiceRunning(target)[0]:
-                print "%-7s | %s %s is not running." % (status[2], ITEM_TYPE[ttype], target)
+                print("%-7s | %s %s is not running." % (status[2], ITEM_TYPE[ttype], target))
                 continue
             
             cmd = ["wmcore-sensord"]
@@ -432,16 +433,16 @@ def start():
             
             if sensord.returncode == None:
                 if pid != 0:
-                    print "%-7s | Sensor daemon (pid: %s) for %s %s (pid: %s) started." \
-                          % (status[1], str(sensord.pid), ITEM_TYPE[ttype], target, pid)
+                    print("%-7s | Sensor daemon (pid: %s) for %s %s (pid: %s) started." \
+                          % (status[1], str(sensord.pid), ITEM_TYPE[ttype], target, pid))
                 else:
-                    print "%-7s | Sensor daemon (pid: %s) for %s %s started." \
-                          % (status[1], str(sensord.pid), ITEM_TYPE[ttype], target)
+                    print("%-7s | Sensor daemon (pid: %s) for %s %s started." \
+                          % (status[1], str(sensord.pid), ITEM_TYPE[ttype], target))
             else:                
                 if pid != 0:
-                    print "%-7s | Sensor daemon for %s %s (pid: %s) did not start." % (status[0], ITEM_TYPE[ttype], target, str(pid))
+                    print("%-7s | Sensor daemon for %s %s (pid: %s) did not start." % (status[0], ITEM_TYPE[ttype], target, str(pid)))
                 else:
-                    print "%-7s | Sensor daemon for %s %s did not start." % (status[0], ITEM_TYPE[ttype], target)
+                    print("%-7s | Sensor daemon for %s %s did not start." % (status[0], ITEM_TYPE[ttype], target))
     
 def shutdown():
     """
@@ -454,7 +455,7 @@ def shutdown():
         for target in specifiedList[ttype]:
             stat = isSensorDaemonRunning(target)
             if stat[0]:
-                print ">>> Shutting down sensor daemon (pid: %s) for %s %s" % (stat[1], ITEM_TYPE[ttype], target)
+                print(">>> Shutting down sensor daemon (pid: %s) for %s %s" % (stat[1], ITEM_TYPE[ttype], target))
                 kill(stat[1], signal.SIGTERM)
     
 def restart():
@@ -462,13 +463,13 @@ def restart():
     Restarts sensor daemons for specified targets.
     """
     
-    print ">>> Shutting down specified sensor daemons."
+    print(">>> Shutting down specified sensor daemons.")
     shutdown()
-    print ">>> Please wait 10 sec."
+    print(">>> Please wait 10 sec.")
     startTime = datetime.today()
     while (datetime.today() - startTime).seconds <= 10:
         time.sleep(1)
-    print ">>> Starting up specified sensor daemons."
+    print(">>> Starting up specified sensor daemons.")
     start()
 
 def status():
@@ -487,7 +488,7 @@ def status():
     status = ["\033[41m OFF  \033[m", "\033[42m  ON  \033[m", "\033[43m  NO  \033[m"]
     
     if len(specifiedList) == 0:
-        print "No information for specified targets."
+        print("No information for specified targets.")
         return
     
     data = {}
@@ -513,7 +514,7 @@ def status():
             data[ITEM_TYPE[ttype]][target]["DAEMON"] = [statSensorDaemon[0], statSensorDaemon[1]]
             data[ITEM_TYPE[ttype]][target]["SENSOR"] = [statSensor[0], statSensor[1]]
             
-    print formatOutput(CMD_STATUS, data)
+    print(formatOutput(CMD_STATUS, data))
 
 def prepareAvailableList(arg):
     """
@@ -530,7 +531,7 @@ def prepareAvailableList(arg):
     loadConfiguration()
     if len(arg) == 0:
         listAvail[ITEM_WMCOMPONENT] = config.listComponents_()
-        listAvail[ITEM_SERVICE] = servicesList.keys()
+        listAvail[ITEM_SERVICE] = list(servicesList)
         listAvail[ITEM_RESOURCE] = resourcesList
         listAvail[ITEM_DISK] = disks()
     else:    
@@ -543,7 +544,7 @@ def prepareAvailableList(arg):
                 if targetType == ITEM_WMCOMPONENT:
                     listAvail[ITEM_WMCOMPONENT] = config.listComponents_()
                 elif targetType == ITEM_SERVICE:
-                    listAvail[ITEM_SERVICE] = servicesList.keys()
+                    listAvail[ITEM_SERVICE] = list(servicesList)
                 elif targetType == ITEM_RESOURCE:
                     listAvail[ITEM_RESOURCE] = resourcesList
                 elif targetType == ITEM_DISK:
@@ -613,8 +614,8 @@ valid = ['config=', 'wmcomponents=', 'services=', 'resources=', 'disks=', 'list=
 
 try:
     opts, args = getopt.getopt(sys.argv[1:], "", valid)
-except getopt.GetoptError, ex:
-    print error(str(ex) + help())
+except getopt.GetoptError as ex:
+    print(error(str(ex) + help()))
 
 configFile    = None
 config        = None
@@ -626,7 +627,7 @@ debugMode     = False
 availableList = {}
 
 if len(opts) == 0:
-    print help()
+    print(help())
     sys.exit(0)
 
 if opts[0][0] != "--config":
@@ -707,7 +708,7 @@ if output == None:
 
 if loadDefaults == True:
     specifiedList[ITEM_WMCOMPONENT] = config.listComponents_()
-    specifiedList[ITEM_SERVICE] = servicesList.keys()
+    specifiedList[ITEM_SERVICE] = list(servicesList)
     specifiedList[ITEM_RESOURCE] = resourcesList
     specifiedList[ITEM_DISK] = disks()
 
@@ -726,8 +727,8 @@ elif command == CMD_RESTART:
     restart()
     sys.exit(0)
 elif command == CMD_HELP:
-    print help(short=False)
+    print(help(short=False))
     sys.exit(0)
 elif command == CMD_LIST:
-    print available()
+    print(available())
     sys.exit(0)

--- a/bin/adhoc-scripts/checkStuckLQE.py
+++ b/bin/adhoc-scripts/checkStuckLQE.py
@@ -10,6 +10,9 @@ for the elements sitting in the Available status
 """
 from __future__ import print_function, division
 
+from builtins import next
+from future.utils import viewvalues, listvalues
+
 import sys
 import os
 
@@ -55,14 +58,14 @@ def commonDataLocation(element):
     """
     commonLoc = set()
     if element['PileupData']:
-        commonLoc = set(element['PileupData'].values()[0])
+        commonLoc = set(next(iter(viewvalues(element['PileupData']))))
     if element['Inputs']:
         if commonLoc:
-            commonLoc = commonLoc & set(element['Inputs'].values()[0])
+            commonLoc = commonLoc & set(next(iter(viewvalues(element['Inputs']))))
         else:
-            commonLoc = set(element['Inputs'].values()[0])
+            commonLoc = set(list(element['Inputs'].values())[0])
     if element['ParentData']:
-        tempLoc = element['ParentData'].values()
+        tempLoc = listvalues(element['ParentData'])
         parentLoc = set(tempLoc[0])
         for temp in tempLoc:
             parentLoc = parentLoc & set(temp)

--- a/bin/adhoc-scripts/drainAgent.py
+++ b/bin/adhoc-scripts/drainAgent.py
@@ -17,6 +17,9 @@ source apps/wmagent/etc/profile.d/init.sh
  """
 from __future__ import print_function, division
 
+from builtins import range, str, bytes
+from future.utils import viewitems
+
 import argparse
 import logging
 import os
@@ -112,7 +115,7 @@ def lfn2dset(lfns):
     """
     Convert a LFN into a dataset name
     """
-    if isinstance(lfns, basestring):
+    if isinstance(lfns, (str, bytes)):
         lfns = [lfns]
 
     listDsets = set()
@@ -162,7 +165,7 @@ def getDsetAndWf(lfns, wfsDict):
 
     match = []
     for dset in uniqDsets:
-        for wf, values in wfsDict.iteritems():
+        for wf, values in viewitems(wfsDict):
             if dset in values['OutputDatasets']:
                 match.append((wf, values['RequestStatus'], dset))
     if match:
@@ -179,7 +182,7 @@ def fetchWorkflowsSpec(config, listOfWfs):
     Fetch the workload of a list of workflows. Filter out only a few
     usefull keys
     """
-    if isinstance(listOfWfs, basestring):
+    if isinstance(listOfWfs, (str, bytes)):
         listOfWfs = [listOfWfs]
 
     wfDBReader = RequestDBReader(config.AnalyticsDataCollector.centralRequestDBURL,

--- a/bin/adhoc-scripts/parseUnifiedCampaigns.py
+++ b/bin/adhoc-scripts/parseUnifiedCampaigns.py
@@ -47,6 +47,9 @@ python parseUnifiedCampaigns.py --fin=wmcore_campaign.json --url=https://alancc7
 """
 from __future__ import print_function, division
 
+from builtins import object
+from future.utils import viewitems
+
 import argparse
 import json
 import logging
@@ -125,7 +128,7 @@ def getSecondaryAAA(initialValue, uniRecord):
       * under the secondaries dictionary.
     If it appears multiple times, we make an OR of the values.
     """
-    for _, innerDict in uniRecord.get("secondaries", {}).items():
+    for _, innerDict in viewitems(uniRecord.get("secondaries", {})):
         if "secondary_AAA" in innerDict:
             print("Found internal secondary_AAA for campaign: %s" % uniRecord['name'])
             initialValue = initialValue or innerDict["secondary_AAA"]
@@ -158,7 +161,7 @@ def getSecondaryLocation(initialValue, uniRecord):
       * under the secondaries dictionary.
     If it appears multiple times, we make an intersection of the values.
     """
-    for _, innerDict in uniRecord.get("secondaries", {}).items():
+    for _, innerDict in viewitems(uniRecord.get("secondaries", {})):
         if "SecondaryLocation" in innerDict:
             print("Found internal SecondaryLocation for campaign: %s" % uniRecord['name'])
             initialValue = intersect(initialValue, innerDict["SecondaryLocation"])
@@ -175,7 +178,7 @@ def getSecondaries(initialValue, uniRecord):
       * taken from the SiteWhitelist key or
       * taken from the SecondaryLocation one
     """
-    for dset, innerDict in uniRecord.get("secondaries", {}).items():
+    for dset, innerDict in viewitems(uniRecord.get("secondaries", {})):
         print("Found secondaries for campaign: %s" % uniRecord['name'])
         initialValue[dset] = intersect(innerDict.get("SiteWhitelist", []),
                                        innerDict.get("SecondaryLocation", []))
@@ -221,7 +224,7 @@ def parse(istream, verbose=0):
         conf = dict(confRec)
         # Set default value from top level campaign configuration
         # or use the default values defined above
-        for uniKey, wmKey in remap.items():
+        for uniKey, wmKey in viewitems(remap):
             conf[wmKey] = rec.get(uniKey, conf[wmKey])
 
         conf['SiteWhiteList'] = getSiteList("SiteWhitelist", conf['SiteWhiteList'], rec)
@@ -330,7 +333,7 @@ def main():
             campData = json.load(istream)
             if isinstance(campData, dict):
                 # then it's a Unified-like campaign schema
-                for key, val in campData.items():
+                for key, val in viewitems(campData):
                     rec = {'name': key}
                     rec.update(val)
                     data.append(rec)

--- a/bin/adhoc-scripts/summaryWMStatsFailures.py
+++ b/bin/adhoc-scripts/summaryWMStatsFailures.py
@@ -6,6 +6,8 @@ per task
 """
 from __future__ import print_function, division
 
+from future.utils import viewitems
+
 from future import standard_library
 standard_library.install_aliases()
 import http.client
@@ -40,12 +42,12 @@ def main():
     data = data[wf]['AgentJobInfo']
 
     summary = {}
-    for agent in data.keys():
+    for agent in data:
         print("\nChecking AgentJobInfo for: %s" % agent)
         print("  Skipped files: %s" % pformat(data[agent]['skipped']))
         print("  Overall agent status:\t\t %s" % data[agent]['status'])
 
-        for task, values in data[agent]['tasks'].iteritems():
+        for task, values in viewitems(data[agent]['tasks']):
             if values['jobtype'] not in ['Production', 'Processing', 'Merge', 'Harvest']:
                 # print("Skipping task type %s, for %s" % (values['jobtype'], task))
                 continue

--- a/bin/check-ACDC-parentage
+++ b/bin/check-ACDC-parentage
@@ -2,6 +2,7 @@
 from __future__ import print_function, division
 from future import standard_library
 standard_library.install_aliases()
+from future.utils import viewitems
 
 import json
 import time
@@ -34,7 +35,7 @@ def investigateACDCCollection(workflow):
     if "rows" in result:
         if result["rows"]:
             for row in result["rows"]:
-                for inFile, value in row["doc"]["files"].items():
+                for inFile, value in viewitems(row["doc"]["files"]):
                     if not value["merged"] or value["merged"] == "0":
                         if value["parents"] and "/unmerged/" in value["parents"][0]:
                             missingFiles.add(inFile)

--- a/bin/check-request-wq-status
+++ b/bin/check-request-wq-status
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 from __future__ import print_function, division
 
+from future.utils import viewvalues
+
 import os
 from argparse import ArgumentParser
 from pprint import pformat
@@ -32,14 +34,14 @@ def getAcceptableSites(ele):
 
     if ele['Inputs']:
         if commonSites:
-            commonSites = commonSites & set([y for x in ele['Inputs'].values() for y in x])
+            commonSites = commonSites & set([y for x in viewvalues(ele['Inputs']) for y in x])
         else:
-            commonSites = set([y for x in ele['Inputs'].values() for y in x])
+            commonSites = set([y for x in viewvalues(ele['Inputs']) for y in x])
     if ele['PileupData']:
         if commonSites:
-            commonSites = commonSites & set([y for x in ele['PileupData'].values() for y in x])
+            commonSites = commonSites & set([y for x in viewvalues(ele['PileupData']) for y in x])
         else:
-            commonSites = set([y for x in ele['PileupData'].values() for y in x])
+            commonSites = set([y for x in viewvalues(ele['PileupData']) for y in x])
 
     return commonSites
 

--- a/bin/couch-thrash.py
+++ b/bin/couch-thrash.py
@@ -4,6 +4,7 @@ _couch-trash_
 
 """
 
+from builtins import range
 import os
 import random
 import time

--- a/bin/dbsbuffer-file-fix.py
+++ b/bin/dbsbuffer-file-fix.py
@@ -2,6 +2,8 @@
 """
 from __future__ import print_function
 
+from future.utils import listvalues
+
 import logging
 import os
 import sys
@@ -36,7 +38,7 @@ def fixDBSmissingFileAssoc():
     print("trimed %s lenth" % len(result))
     insertSQL = """INSERT INTO dbsbuffer_file_location (filename, location)
                VALUES (:fileid, :seid)"""
-    done = formatter.dbi.processData(insertSQL, result.values())
+    done = formatter.dbi.processData(insertSQL, listvalues(result))
     print("inserted %s" % done)
 
 if __name__ == '__main__':

--- a/bin/fix-dbs-parentage
+++ b/bin/fix-dbs-parentage
@@ -43,6 +43,7 @@ $manage execute-agent fix-dbs-parentage -p --insert -d /SingleMuon/Run2016D-03Fe
 
 from __future__ import print_function, division
 
+from builtins import input
 import time
 import datetime
 import argparse

--- a/bin/inject-to-config-cache
+++ b/bin/inject-to-config-cache
@@ -4,6 +4,7 @@ _inject-to-config-cache_
 
 Add a config and it's meta data to the config cache.
 """
+from __future__ import print_function
 
 import os
 import sys
@@ -19,7 +20,7 @@ def loadConfig(configPath):
 
     Import a config.
     """
-    print "Importing the config, this may take a while...",
+    print("Importing the config, this may take a while...", end=' ')
     sys.stdout.flush()
     cfgBaseName = os.path.basename(configPath).replace(".py", "")
     cfgDirName = os.path.dirname(configPath)
@@ -28,16 +29,16 @@ def loadConfig(configPath):
     loadedConfig = imp.load_module(cfgBaseName, modPath[0],
                                    modPath[1], modPath[2])
 
-    print "done."
+    print("done.")
     return loadedConfig
 
 if __name__ == "__main__":
     if len(sys.argv) != 8:
-        print "Usage: %s couchUrl database_name user_name group_name input_file label description" % sys.argv[0]
+        print("Usage: %s couchUrl database_name user_name group_name input_file label description" % sys.argv[0])
         sys.exit(1)
 
     if not os.path.exists(sys.argv[5]):
-        print "Error: Can't locate config file."
+        print("Error: Can't locate config file.")
         sys.exit(1)
 
     loadedConfig = loadConfig(sys.argv[5])
@@ -50,7 +51,7 @@ if __name__ == "__main__":
     configCache.setDescription(sys.argv[7])
     configCache.save()
 
-    print "Added file to the config cache:"
-    print "  DocID:    %s" % configCache.document["_id"]
-    print "  Revision: %s" % configCache.document["_rev"]
+    print("Added file to the config cache:")
+    print("  DocID:    %s" % configCache.document["_id"])
+    print("  Revision: %s" % configCache.document["_rev"])
     sys.exit(0)

--- a/bin/kill-workflow-in-agent
+++ b/bin/kill-workflow-in-agent
@@ -4,6 +4,8 @@ Script for killing a workflow: delete from LQ, delete in WMBS and set cancelled 
 This has to be executed in each agent the workflow is running in (Agent Level)
 
 """
+from __future__ import print_function
+from builtins import str
 import os, sys
 from WMCore.Configuration import loadConfigurationFile
 from WMCore.WorkQueue.WorkQueueBackend import WorkQueueBackend
@@ -15,7 +17,7 @@ def killWorkflowAgent(WorkflowName):
     Cancel work for a given workflow - delete in wmbs, delete from workqueue db, set canceled in inbox
     """    
     # get configuration file path
-    if not os.environ.has_key("WMAGENT_CONFIG"):
+    if "WMAGENT_CONFIG" not in os.environ:
         os.environ['WMAGENT_CONFIG'] = '/data/srv/wmagent/current/config/wmagent/config.py'
     
     # load config
@@ -38,13 +40,13 @@ def killWorkflowAgent(WorkflowName):
     # take wf from args in case no elements exist for workflow (i.e. work was negotiating)
     requestNames = set([x['RequestName'] for x in elements]) | set([wf for wf in [WorkflowName]])
     if not requestNames:
-        print 'Workflow is not at the backend'
+        print('Workflow is not at the backend')
     
     inbox_elements = []
     for wf in requestNames:
         inbox_elements.extend(backend.getInboxElements(WorkflowName = wf))
 
-    print "Canceling work for workflow: %s" % (requestNames)
+    print("Canceling work for workflow: %s" % (requestNames))
     for workflow in requestNames:
         try:
             connectToDB()
@@ -52,8 +54,8 @@ def killWorkflowAgent(WorkflowName):
             bossAirConfig = wmConfig
             killWorkflow(workflow, jobDumpConfig,
                             bossAirConfig)
-        except Exception, ex:
-            print 'Aborting %s wmbs subscription failed: %s' % (workflow, str(ex))
+        except Exception as ex:
+            print('Aborting %s wmbs subscription failed: %s' % (workflow, str(ex)))
         
     # Don't update as fails sometimes due to conflicts (#3856)
     [x.load().__setitem__('Status', 'Canceled') for x in inbox_elements if x['Status'] != 'Canceled']
@@ -61,13 +63,13 @@ def killWorkflowAgent(WorkflowName):
     # delete elements - no longer need them
     backend.deleteElements(*[x for x in elements if x['ParentQueueId'] in updated_inbox_ids])
 
-    print "Aborted worqueue elements:"
-    print [x.id for x in elements]
+    print("Aborted worqueue elements:")
+    print([x.id for x in elements])
 
 def main():
     args=sys.argv[1:]
     if not len(args)==1:
-        print "usage:killWorkflowAgent.py workflowname"
+        print("usage:killWorkflowAgent.py workflowname")
         sys.exit(0)
     workflow=args[0]
 

--- a/bin/outputmodules-from-config
+++ b/bin/outputmodules-from-config
@@ -4,12 +4,16 @@ _outputmodules-from-config_
 
 Pull output module metadata from a CMSSW config.
 """
+from __future__ import print_function
+
+from future import standard_library
+standard_library.install_aliases()
+import urllib.request
 
 import imp
 import os
 import sys
 import tempfile
-import urllib
 from json import JSONEncoder, JSONDecoder
 
 
@@ -36,7 +40,7 @@ def outputModulesFromConfig(configHandle):
     """
     outputModules = {}
     
-    for outputModuleName in configHandle.outputModules.keys():
+    for outputModuleName in list(configHandle.outputModules.keys()):
         outputModule = getattr(configHandle, outputModuleName)
         outputModules[outputModuleName] = {}
         if hasattr(outputModule, "dataset"):
@@ -63,35 +67,35 @@ if __name__ == "__main__":
         encodedConfig = sys.stdin.readline()
         config = jsonDecoder.decode(encodedConfig)
 
-        print "Config passed in from the spec: %s" % config
+        print("Config passed in from the spec: %s" % config)
 
         if config.get("configUrl", None):
-            print "Have a URL for a config, trying to download..."
+            print("Have a URL for a config, trying to download...")
             tempDir = tempfile.mkdtemp()
             configPath = os.path.join(tempDir, "cmsswConfig.py")
             compConfigPath = os.path.join(tempDir, "cmsswConfig.pyc")
-            configString = urllib.urlopen(config["configUrl"]).read(-1)
-            print "Config download successful.  Trying to open..."
+            configString = urllib.request.urlopen(config["configUrl"]).read(-1)
+            print("Config download successful.  Trying to open...")
             configFile = open(configPath, "w")
             configFile.write(configString)
             configFile.close()
             process = loadConfig(configPath).process
-            print "Opened config successfully, cleaning up..."
+            print("Opened config successfully, cleaning up...")
             os.remove(configPath)
             os.remove(compConfigPath)
             os.rmdir(tempDir)
         else:
-            print "Have a scenario for a Configuration.DataProcessing config, trying to create..."
+            print("Have a scenario for a Configuration.DataProcessing config, trying to create...")
             from WMCore.WMRuntime.Scripts.SetupCMSSWPset import SetupCMSSWPset
             mySetup = SetupCMSSWPset()
             mySetup.createProcess(config["scenarioName"], config["scenarioFunc"],
                                   config["scenarioArgs"])
             process = mySetup.process
-            print "Create successful..."
+            print("Create successful...")
 
-        print "Trying to determine output modules in the config..."
+        print("Trying to determine output modules in the config...")
         outputModules = outputModulesFromConfig(process)
-        print "Successfully determined output modules, saving..."
+        print("Successfully determined output modules, saving...")
         outputModulesJSON = jsonEncoder.encode(outputModules)
 
         outputHandle = open("outputModules.json", "w")
@@ -99,6 +103,6 @@ if __name__ == "__main__":
         outputHandle.close()
         
         sys.exit(0)
-    except Exception, ex:
-        print ex
+    except Exception as ex:
+        print(ex)
         sys.exit(1)

--- a/bin/paused-jobs
+++ b/bin/paused-jobs
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
+from builtins import input, object
+
 import os
 import re
 import sys
@@ -14,7 +16,7 @@ from WMCore.WMBS.Job import Job
 from WMCore.WMInit import connectToDB
 
 
-class PausedTool:
+class PausedTool(object):
     def __init__(self):
         # Connecting to DB
         myThread = threading.currentThread()
@@ -97,7 +99,7 @@ class PausedTool:
                 if self.jobId == str(jobID):
                     matchedJobs.append(jobID)
         else:
-            matchedJobs = jobs.keys()
+            matchedJobs = list(jobs)
 
         if not matchedJobs:
             return []
@@ -160,7 +162,7 @@ class PausedTool:
         if self.action == "resume":
             self.resumeJobs(jobs)
         elif self.action == "fail":
-            confirm = input("Are you sure you want to fail %d jobs? Type 'Y' or 'N' (type quotes too!) :\n" % len(jobs))
+            confirm = eval(input("Are you sure you want to fail %d jobs? Type 'Y' or 'N' (type quotes too!) :\n" % len(jobs)))
             if confirm == "Y":
                 print("Failing the jobs...")
                 self.failJobs(jobs)

--- a/bin/reqmgr-sw-update
+++ b/bin/reqmgr-sw-update
@@ -12,6 +12,7 @@ to retrieve data asynchronously into a private ReqMgr database. Rather
 than consult TC at every request injection.
 
 """
+from __future__ import print_function
 
 import sys
 import os

--- a/bin/vaildateCMSSWMergeVersion
+++ b/bin/vaildateCMSSWMergeVersion
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 from __future__ import (division, print_function)
 
+from builtins import range, str, bytes
+from future.utils import viewitems
+
 from pprint import pprint
 from WMCore.WMSpec.WMWorkload import WMWorkloadHelper
 from WMCore.Services.ReqMgr.ReqMgr import ReqMgr
@@ -20,10 +23,10 @@ print("List of tasks which merge task has different cmssw versions than processi
 print("NOVERSION could mean it is defined in workflow level not task level. so not necessary error case")
 print("Request Name | status | task name | correct cmssw vereion | current merge cmssw version")
 for item in r:
-    for req, reqInfo in item.iteritems():
+    for req, reqInfo in viewitems(item):
         cmssw = reqInfo.get("CMSSWVersion", [])
         status = reqInfo.get("RequestStatus", [])
-        if not isinstance(cmssw, basestring) and len(cmssw) > 1:
+        if not isinstance(cmssw, (str, bytes)) and len(cmssw) > 1:
             # print req
             # pprint(reqInfo)
             helper.loadSpecFromCouch(reqdb_url, req)

--- a/bin/wmagent-couchapp-init
+++ b/bin/wmagent-couchapp-init
@@ -13,7 +13,7 @@ import os
 import shutil
 import sys
 import tempfile
-import urllib
+import urllib.parse
 
 from urllib.parse import urlsplit
 
@@ -47,7 +47,7 @@ def installCouchApp(couchUrl, couchDBName, couchAppName, basePath=None):
     """
     if not basePath:
         basePath = couchAppRoot(couchAppName)
-    print("Installing %s into %s" % (couchAppName, urllib.unquote_plus(couchDBName)))
+    print("Installing %s into %s" % (couchAppName, urllib.parse.unquote_plus(couchDBName)))
 
     couchappConfig = Config()
 
@@ -106,8 +106,8 @@ def setupCron(couchUrl, couchDBName):
     quoted slash.
     """
     print("Setting up cron jobs for the job dump.")
-    fwjrDumpName = urllib.quote_plus("%s/fwjrs" % couchDBName).replace("%", "\\%")
-    jobDumpName = urllib.quote_plus("%s/jobs" % couchDBName).replace("%", "\\%")
+    fwjrDumpName = urllib.parse.quote_plus("%s/fwjrs" % couchDBName).replace("%", "\\%")
+    jobDumpName = urllib.parse.quote_plus("%s/jobs" % couchDBName).replace("%", "\\%")
 
     indexJobsUrl = "'%s/%s/_design/JobDump/_view/statusByWorkflowName?limit=1'" % (couchUrl, jobDumpName)
     indexFwjrUrl = "'%s/%s/_design/FWJRDump/_view/outputByJobID?limit=1'" % (couchUrl, fwjrDumpName)
@@ -287,8 +287,8 @@ if __name__ == "__main__":
     wmagentConfig = loadConfigurationFile(os.environ["WMAGENT_CONFIG"])
             
     if hasattr(wmagentConfig, "JobStateMachine") and hasattr(wmagentConfig.JobStateMachine, "couchDBName"):
-        fwjrDumpName = urllib.quote_plus("%s/fwjrs" % wmagentConfig.JobStateMachine.couchDBName)
-        jobDumpName = urllib.quote_plus("%s/jobs" % wmagentConfig.JobStateMachine.couchDBName)
+        fwjrDumpName = urllib.parse.quote_plus("%s/fwjrs" % wmagentConfig.JobStateMachine.couchDBName)
+        jobDumpName = urllib.parse.quote_plus("%s/jobs" % wmagentConfig.JobStateMachine.couchDBName)
         installCouchApp(wmagentConfig.JobStateMachine.couchurl, fwjrDumpName, "FWJRDump")
         installCouchApp(wmagentConfig.JobStateMachine.couchurl, jobDumpName, "JobDump")
         installCouchApp(wmagentConfig.JobStateMachine.couchurl, wmagentConfig.JobStateMachine.jobSummaryDBName, "WMStatsAgent")

--- a/bin/wmagent-delete-couchdb-workflow
+++ b/bin/wmagent-delete-couchdb-workflow
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
+from builtins import input
+
 import os
 import sys
 from argparse import ArgumentParser
@@ -51,7 +53,7 @@ def deleteWorkflowFromCouch(workflowName, jobsdatabase, fwjrdatabase):
 
 if __name__ == "__main__":
     print("Warning: This is irreversible. ")
-    answer = input("Are you sure you want to delete workflows? Type 'Y' or 'N' (type quotes too!): ")
+    answer = eval(input("Are you sure you want to delete workflows? Type 'Y' or 'N' (type quotes too!): "))
     if answer != "Y":
         print("Aborting... no changes were made.")
         sys.exit(1)

--- a/bin/wmagent-mod-config
+++ b/bin/wmagent-mod-config
@@ -12,6 +12,7 @@ https://github.com/dmwm/deployment/blob/master/asyncstageout/manage#L246
 from __future__ import print_function
 from future import standard_library
 standard_library.install_aliases()
+from future.utils import viewitems
 
 import getopt
 import imp
@@ -80,7 +81,7 @@ def modifyConfiguration(config, **args):
         "working_dir": [("General", "workDir")],
     }
 
-    for k, v in args.items():
+    for k, v in viewitems(args):
         parameters = mapping.get(k, [])
         for p in parameters:
             if hasattr(config, p[0]):

--- a/bin/wmagent-resource-control
+++ b/bin/wmagent-resource-control
@@ -6,6 +6,8 @@ Utility script for manipulating resource control.
 """
 from __future__ import print_function
 
+from future.utils import viewitems
+
 import os
 import sys
 from argparse import ArgumentParser
@@ -126,7 +128,7 @@ def addSites(resourceControl, allSites, ceName, plugin, pendingSlots, runningSlo
     else:
         runningSlots = runningSlots
 
-    for siteName in allSites.keys():
+    for siteName in allSites:
         updateSiteInfo(resourceControl, siteName, pendingSlots, runningSlots,
                        ceName or siteName, allSites[siteName], plugin, cmsName or siteName)
 
@@ -135,7 +137,7 @@ def addSites(resourceControl, allSites, ceName, plugin, pendingSlots, runningSlo
             updateThresholdInfo(resourceControl, siteName, task, runningSlots, pendingSlots)
 
     if state:
-        for siteName in allSites.keys():
+        for siteName in allSites:
             setSiteState(resourceControl, siteName, state)
 
     return
@@ -166,7 +168,7 @@ def printThresholds(resourceControl, desiredSiteName):
 
     thresholds = resourceControl.listThresholdsForSubmit()
 
-    for siteName in thresholds.keys():
+    for siteName in thresholds:
         if desiredSiteName and desiredSiteName != siteName:
             continue
         siteThresholds = thresholds[siteName]
@@ -185,7 +187,7 @@ def printThresholds(resourceControl, desiredSiteName):
         print("%s - %d running, %d pending, %d running slots total, %d pending slots total%s:" % (
             siteName, runningJobs, pendingJobs, runningSlots, pendingSlots, stateMsg))
 
-        for task, thres in siteThresholds['thresholds'].iteritems():
+        for task, thres in viewitems(siteThresholds['thresholds']):
             print("  %s - %d running, %d pending, %d max running, %d max pending, priority %s" %
                   (task, thres["task_running_jobs"], thres['task_pending_jobs'], thres["max_slots"],
                    thres["pending_slots"], str(thres.get("priority", 1))))

--- a/bin/wmagent-unregister-wmstats
+++ b/bin/wmagent-unregister-wmstats
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
+from builtins import input
 import os
 import sys
 from argparse import ArgumentParser
@@ -25,7 +26,7 @@ if __name__ == "__main__":
         agentUrl = args[0]
 
     msg = "Are you sure you want to remove agent info record for %s from wmstats? Type 'yes' or 'no' (type quotes too!): "
-    answer = input(msg % agentUrl)
+    answer = eval(input(msg % agentUrl))
     if answer != "yes":
         print("Aborting... no changes were made.")
         sys.exit(1)

--- a/bin/wmcore-db-init
+++ b/bin/wmcore-db-init
@@ -3,6 +3,9 @@
 Commands for initializing the proper database tables
 or cleaning the database.
 """
+from __future__ import print_function
+
+from builtins import input
 
 __revision__ = "$Id: wmcore-db-init,v 1.10 2010/07/05 03:05:32 meloam Exp $"
 __version__ = "$Revision: 1.10 $"
@@ -40,8 +43,8 @@ valid = ['config=', 'create', 'destroy', 'modules=']
 
 try:
     opts, args = getopt.getopt(sys.argv[1:], "", valid)
-except getopt.GetoptError, ex:
-    print str(ex)
+except getopt.GetoptError as ex:
+    print(str(ex))
     usage()
     sys.exit(1)
 
@@ -54,14 +57,14 @@ for opt, arg in opts:
         if command != None:
             msg = "Command specified twice:\n"
             msg += usage()
-            print msg
+            print(msg)
             sys.exit(1)
         command = "create"
     if opt == "--destroy":
         if command != None:
             msg = "Command specified twice:\n"
             msg += usage()
-            print msg
+            print(msg)
             sys.exit(1)
         command = "destroy"
     if opt == "--modules":
@@ -86,7 +89,7 @@ if config == None:
         sys.exit(1)
 
 if not os.path.exists(config):
-    print "Can't find config: %s" % config
+    print("Can't find config: %s" % config)
     sys.exit(1)
 
 # load the config file here.
@@ -102,7 +105,7 @@ def connectionTest(config):
     in the config file.
 
     """
-    print 'checking default database connection'
+    print('checking default database connection')
 
     (dialect, junk) = config.CoreDatabase.connectUrl.split(":", 1)
     socket = getattr(config.CoreDatabase, "socket", None)
@@ -112,13 +115,13 @@ def connectionTest(config):
        wmInit.setDatabaseConnection(dbConfig = config.CoreDatabase.connectUrl,
                                     dialect = dialect,
                                     socketLoc = socket)
-    except Exception, ex:
+    except Exception as ex:
         msg = "Unable to make connection to using \n"
         msg += "parameters provided in %s\n" % config.CoreDatabase.connectUrl
         msg += str(ex)
-        print msg
+        print(msg)
         raise ex
-    print 'default database connection tested'
+    print('default database connection tested')
 
 def create(config):
     params = {}
@@ -146,8 +149,8 @@ def executeCommand(command):
 def askConfirmation():
     while True:
         msg = "Are you sure you want to delete all the database? The operation is NOT reversible. (yes, no)"
-        print msg
-        answer = raw_input()
+        print(msg)
+        answer = input()
         if answer.upper() in ['YES', 'NO']:
             return answer
 
@@ -162,5 +165,5 @@ if command == "destroy":
         destroy(cfgObject)
         sys.exit(0)
     else:
-        print "Exiting without doing anything"
+        print("Exiting without doing anything")
 

--- a/bin/wmcore-new-config
+++ b/bin/wmcore-new-config
@@ -7,6 +7,7 @@ directory. This command retrieves all of them and merges them
 together into one big configuration file that operators can then
 edit.
 """
+from __future__ import print_function
 
 __revision__ = "$Id: wmcore-new-config,v 1.5 2010/01/22 22:08:32 sryu Exp $"
 __version__ = "$Revision: 1.5 $"
@@ -37,8 +38,8 @@ valid = ["roots=","output="]
 
 try:
     opts, args = getopt.getopt(sys.argv[1:], "", valid)
-except getopt.GetoptError, ex:
-    print str(ex)
+except getopt.GetoptError as ex:
+    print(str(ex))
     usage()
     sys.exit(1)
 

--- a/bin/wmcore-new-flow
+++ b/bin/wmcore-new-flow
@@ -4,6 +4,7 @@
 Generates components, handlers and threadpools from 
 a specification. It sets up the skeleton for development.
 """
+from __future__ import print_function
 
 __revision__ = "$Id: wmcore-new-flow,v 1.1 2009/01/14 12:31:22 fvlingen Exp $"
 __version__ = "$Revision: 1.1 $"
@@ -29,8 +30,8 @@ valid = ["config="]
 
 try:
     opts, args = getopt.getopt(sys.argv[1:], "", valid)
-except getopt.GetoptError, ex:
-    print str(ex)
+except getopt.GetoptError as ex:
+    print(str(ex))
     print(msg)
     sys.exit(1)
 

--- a/bin/wmcoreD
+++ b/bin/wmcoreD
@@ -28,7 +28,9 @@ wmcoreD --restart --config=WMCoreConfig.py
 wmcoreD --shutdown --config=WMCoreConfig.py --cleanup-all
 
 """
+from __future__ import print_function
 
+from builtins import str
 __revision__ = "$Id: wmcoreD,v 1.16 2010/05/26 21:09:35 sfoulkes Exp $"
 __version__ = "$Revision: 1.16 $"
 __author__ = "fvlingen@caltech.edu"
@@ -73,8 +75,8 @@ valid = ['config=', 'start', 'shutdown', 'status', 'restart',
 
 try:
     opts, args = getopt.getopt(sys.argv[1:], "", valid)
-except getopt.GetoptError, ex:
-    print str(ex)
+except getopt.GetoptError as ex:
+    print(str(ex))
     usage()
     sys.exit(1)
 
@@ -92,28 +94,28 @@ for opt, arg in opts:
         if command != None:
             msg = "Command specified twice:\n"
             msg += usage()
-            print msg
+            print(msg)
             sys.exit(1)
         command = "start"
     if opt == "--shutdown":
         if command != None:
             msg = "Command specified twice:\n"
             msg += usage()
-            print msg
+            print(msg)
             sys.exit(1)
         command = "shutdown"
     if opt == "--status":
         if command != None:
             msg = "Command specified twice:\n"
             msg += usage()
-            print msg
+            print(msg)
             sys.exit(1)
         command = "status"
     if opt == "--restart":
         if command != None:
             msg = "Command specified twice:\n"
             msg += usage()
-            print msg
+            print(msg)
             sys.exit(1)
         command = "restart"
     if opt == "--cleanup-logs":
@@ -145,7 +147,7 @@ if config == None:
         sys.exit(1)
 
 if not os.path.exists(config):
-    print "Can't find config: %s" % config
+    print("Can't find config: %s" % config)
     sys.exit(1)
 
 # load the config file here.
@@ -155,7 +157,7 @@ cfgObject = loadConfigurationFile(config)
 if componentsList != None:
     msg = "Components List Specified:\n"
     msg += str(componentsList).replace('\'', '')
-    print msg
+    print(msg)
     components = componentsList
 else:    
     components = cfgObject.listComponents_() + cfgObject.listWebapps_()
@@ -170,10 +172,10 @@ def connectionTest(configFile):
     """
     config = loadConfigurationFile(configFile)
     wmInit = WMInit()    
-    print "Checking default database connection...",
+    print("Checking default database connection...", end=' ')
 
     if not hasattr(config, "CoreDatabase"):
-        print "skipped."
+        print("skipped.")
         return
 
     (dialect, junk) = config.CoreDatabase.connectUrl.split(":", 1)
@@ -183,14 +185,14 @@ def connectionTest(configFile):
        wmInit.setDatabaseConnection(dbConfig = config.CoreDatabase.connectUrl,
                                     dialect = dialect,
                                     socketLoc = socket)
-    except Exception, ex:
+    except Exception as ex:
         msg = "Unable to make connection to using \n"
         msg += "parameters provided in %s\n" % config.CoreDatabase.connectUrl 
         msg += str(ex)
-        print msg
+        print(msg)
         raise ex
 
-    print "ok."
+    print("ok.")
     return
 
 def startup(configFile):
@@ -228,8 +230,8 @@ def startup(configFile):
         if os.path.exists(daemonXML):
             daemon = Details(daemonXML)
             if not daemon.isAlive():         
-                print "Error: Component %s Did not start properly..." % component
-                print "Check component log to see why"
+                print("Error: Component %s Did not start properly..." % component)
+                print("Check component log to see why")
                 sys.exit(1)
         else:
             print('Path for daemon file does not exist!')
@@ -262,14 +264,14 @@ def shutdown(configFile):
         compDir = os.path.expandvars(compDir)
         daemonXml = os.path.join(compDir, "Daemon.xml")
         if not os.path.exists(daemonXml):
-            print "Cannot find Daemon.xml for component:", component
-            print "Unable to shut it down"
+            print("Cannot find Daemon.xml for component:", component)
+            print("Unable to shut it down")
         else:
             daemon = Details(daemonXml)
             if not daemon.isAlive():
-                print "Component %s with process id %s is not running" % (
+                print("Component %s with process id %s is not running" % (
                     component, daemon['ProcessID'],
-                    )
+                    ))
                 daemon.removeAndBackupDaemonFile()
             else:
                 daemon.killWithPrejudice()
@@ -278,10 +280,10 @@ def shutdown(configFile):
             # // Log Cleanup
             #//
             msg = "Removing %s/ComponentLog" % compDir
-            print msg
+            print(msg)
             try:
                 os.remove("%s/ComponentLog" % compDir)
-            except StandardError, ex:
+            except Exception as ex:
                 msg = "Unable to cleanup Component Log: "
                 msg += "%s/ComponentLog\n" % compDir
                 msg += str(ex)
@@ -290,12 +292,12 @@ def shutdown(configFile):
             #  //
             # // Cleanout everything in ComponentDir
             #//  for this component
-            print "Removing %s\n" % compDir
+            print("Removing %s\n" % compDir)
             exitCode = subprocess.call(["rm", "-rf", "%s" % compDir])
             if exitCode:
                 msg = "Failed to clean up dir: %s\n" % compDir
                 msg += output
-                print msg
+                print(msg)
 
     return
 
@@ -321,13 +323,13 @@ def status(configFile):
         compDir = os.path.expandvars(compDir)
         daemonXml = os.path.join(compDir, "Daemon.xml")
         if not os.path.exists(daemonXml):
-            print "Component:%s Not Running" % component
+            print("Component:%s Not Running" % component)
             continue
         daemon = Details(daemonXml)
         if not daemon.isAlive():
-            print "Component:%s Not Running" % component
+            print("Component:%s Not Running" % component)
         else:
-            print "Component:%s Running:%s" % (component, daemon['ProcessID'])
+            print("Component:%s Running:%s" % (component, daemon['ProcessID']))
 
     sys.exit(0)
 

--- a/etc/dbsVerify.py
+++ b/etc/dbsVerify.py
@@ -66,7 +66,7 @@ dbsApi = DbsApi(args)
 
 badBlocks = []
 badFiles = []
-for blockName in blocks.keys():
+for blockName in blocks:
     print("%s:" % blockName)
     blockFiles = []
     try:

--- a/etc/phedexVerify.py
+++ b/etc/phedexVerify.py
@@ -59,7 +59,7 @@ for row in results:
 
 phedex = PhEDEx.PhEDEx({"endpoint": "https://cmsweb.cern.ch/phedex/datasvc/json/prod/"}, "json")
 
-for blockName in blocks.keys():
+for blockName in blocks:
     print("%s:" % blockName)
 
     args = {}

--- a/setup_build.py
+++ b/setup_build.py
@@ -28,15 +28,15 @@ def walk_dep_tree(system):
     statics = set()
     modules = set()
     bindir = set()
-    if 'bin' in system.keys():
+    if 'bin' in system:
         bindir = set(system.get('bin', set()))
-    if 'modules' in system.keys():
+    if 'modules' in system:
         modules = set(system.get('modules', set()))
-    if 'packages' in system.keys():
+    if 'packages' in system:
         packages = set(system.get('packages', set()))
-    if 'statics' in system.keys():
+    if 'statics' in system:
         statics = set(system.get('statics', set()))
-    if 'systems' in system.keys():
+    if 'systems' in system:
         for system in system['systems']:
             dependants = walk_dep_tree(dependencies[system])
             bindir = bindir | dependants.get('bin', set())
@@ -126,17 +126,17 @@ def check_system(command):
     """
     Check that the system being built is known, print an error message and exit if it's not.
     """
-    if command.system in dependencies.keys():
+    if command.system in dependencies:
         return
     elif command.system == None:
         msg = "System not specified: -s option for %s must be specified and provide one of:\n" % command.get_command_name()
-        msg += ", ".join(dependencies.keys())
+        msg += ", ".join(dependencies)
         print(msg)
         sys.exit(1)
     else:
         msg = "Specified system [%s] is unknown:" % command.system
         msg += " -s option for %s must be specified and provide one of:\n" % command.get_command_name()
-        msg += ", ".join(dependencies.keys())
+        msg += ", ".join(dependencies)
         print(msg)
         sys.exit(1)
 
@@ -202,7 +202,7 @@ class BuildCommand(Command):
     description = "to ensure a clean build of only the specified sub-system.\n\n"
     description += "\tAvailable sub-systems: \n"
     description += "\t["
-    description += ", ".join(dependencies.keys())
+    description += ", ".join(dependencies)
     description += "]\n"
 
     user_options = build.user_options
@@ -288,7 +288,7 @@ class InstallCommand(install):
     description = "to ensure a clean build of only the specified sub-system.\n\n"
     description += "\tAvailable sub-systems: \n"
     description += "\t["
-    description += ", ".join(dependencies.keys())
+    description += ", ".join(dependencies)
     description += "]\n"
 
     user_options = install.user_options

--- a/setup_test.py
+++ b/setup_test.py
@@ -214,7 +214,7 @@ if can_nose:
             # divide it up
             totalCases = len(testIds)
             myIds = []
-            for testID in testIds.keys():
+            for testID in testIds:
                 if int(testID) >= int(self.testMinimumIndex) and int(testID) <= int(self.testMaximumIndex):
                     # generate a stable ID for sorting
                     if int(self.testCurrentSlice) < int(self.testTotalSlices):  # testCurrentSlice is 0-indexed

--- a/src/html/WorkQueue/examples/PlotFairyBarChart.py
+++ b/src/html/WorkQueue/examples/PlotFairyBarChart.py
@@ -10,6 +10,7 @@ from __future__ import print_function
 #     -> this prints out html file, normally resulting html snippet will be used ...
 
 
+from builtins import range
 from future import standard_library
 standard_library.install_aliases()
 

--- a/src/html/WorkQueue/examples/PlotFairyLineChart.py
+++ b/src/html/WorkQueue/examples/PlotFairyLineChart.py
@@ -10,6 +10,7 @@ from __future__ import print_function
 #     -> this prints out html file, normally resulting html snippet will be used ...
 
 
+from builtins import range
 from future import standard_library
 standard_library.install_aliases()
 

--- a/test/data/ReqMgr/inject-test-wfs.py
+++ b/test/data/ReqMgr/inject-test-wfs.py
@@ -14,6 +14,9 @@ It will:
 """
 from __future__ import print_function
 
+from builtins import range, str as newstr, bytes as newbytes
+from future.utils import viewitems
+
 import sys
 import os
 import pwd
@@ -98,7 +101,7 @@ def parseArgs():
     args = parser.parse_args()
 
     # sites argument could be "T1_US_FNAL,T2_CH_CERN" ...
-    if isinstance(args.site, basestring):
+    if isinstance(args.site, (newstr, newbytes)):
         args.site = args.site.split(',')
 
     return args
@@ -142,7 +145,7 @@ def handleAssignment(args, fname, jsonData):
         # always overwrite it as provided in the command line and task/step name
         if 'ProcessingString' in assignDict and isinstance(assignDict['ProcessingString'], dict):
             assignRequest['ProcessingString'] = assignDict['ProcessingString']
-            for task, _ in assignRequest['ProcessingString'].iteritems():
+            for task, _ in viewitems(assignRequest['ProcessingString']):
                 assignRequest['ProcessingString'][task] = task + '_' + tmpProcStr
 
         # also reuse values as provided in the request schema at creation level

--- a/test/data/WMStats/doc_generator.py
+++ b/test/data/WMStats/doc_generator.py
@@ -1,3 +1,4 @@
+from builtins import range
 import random
 import time
 
@@ -45,7 +46,7 @@ def generate_reqmgr_requests(number=NUM_OF_REQUEST):
     }
     """
     docs = []
-    for i in xrange(number):
+    for i in range(number):
         doc = {"_id": "test_workflow_%s" % i,
                "inputdataset": "/Photon/Run2011A-v1/RAW",
                "group": "cmsdataops",
@@ -97,8 +98,8 @@ def generate_agent_requests(number=NUM_OF_REQUEST, iterations=ITERATIONS):
     """
     current_time = int(time.time())
     docs = []
-    for cycle in xrange(iterations):
-        for i in xrange(number):
+    for cycle in range(iterations):
+        for i in range(number):
             doc = {"status": {"inWMBS": 12,
                               "submitted": {"retry": 2, "running": 2, "pending": 2, "first": 2},
                               "failure": {"exception": 2, "create": 2, "submit": 2},
@@ -178,7 +179,7 @@ def generate_jobsummary(request, number=NUM_OF_JOBS_PER_REQUEST):
                   'jobfailed', 'createcooloff', 'submitcooloff', 'jobcooloff', 'success',
                   'exhausted', 'killed']
 
-    for i in xrange(number):
+    for i in range(number):
         status = statusList[random.randint(0, len(statusList) - 1)]
         errmsgs = {}
         if status.find("failed"):

--- a/test/data/WMStats/generator.py
+++ b/test/data/WMStats/generator.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+from builtins import range
 import os
 import random
 import time
@@ -140,7 +141,7 @@ def generate_reqmgr_requests(number=NUM_OF_REQUEST):
     }
     """
     docs = []
-    for i in xrange(number):
+    for i in range(number):
         doc = {"_id": "test_workflow_%s" % i,
                "inputdataset": "/Photon/Run2011A-v1/RAW",
                "group": "cmsdataops",
@@ -192,8 +193,8 @@ def generate_agent_requests(number=NUM_OF_REQUEST, iterations=ITERATIONS):
     """
     current_time = int(time.time())
     docs = []
-    for cycle in xrange(iterations):
-        for i in xrange(number):
+    for cycle in range(iterations):
+        for i in range(number):
             doc = {"status": {"inWMBS": 12,
                               "submitted": {"retry": 2, "running": 2, "pending": 2, "first": 2},
                               "failure": {"exception": 2, "create": 2, "submit": 2},
@@ -273,7 +274,7 @@ def generate_jobsummary(request, number=NUM_OF_JOBS_PER_REQUEST):
                   'jobfailed', 'createcooloff', 'submitcooloff', 'jobcooloff', 'success',
                   'exhausted', 'killed']
 
-    for i in xrange(number):
+    for i in range(number):
         status = statusList[random.randint(0, len(statusList) - 1)]
         errmsgs = {}
         if status.find("failed"):


### PR DESCRIPTION
Fixes #10481 
#### Status
In development

#### Description
Modernization of the following scripts / python modules that are not in `./src/python` or `./test/python` is required in order to complete the dmwm/WMCore modernization

- [x] `./bin/acdcserver-tools`
- [x] `./bin/adhoc-scripts/checkDsetFileCount.py`
- [x] `./bin/adhoc-scripts/checkStuckLQE.py`
- [x] `./bin/adhoc-scripts/drainAgent.py`
- [x] `./bin/adhoc-scripts/getWQStatusByWorkflow.py`
- [x] `./bin/adhoc-scripts/ParseSpecCmsswdist.py`
- [x] `./bin/adhoc-scripts/parseUnifiedCampaigns.py`
- [x] `./bin/adhoc-scripts/setrequeststatus.py`
- [x] `./bin/adhoc-scripts/summaryWMStatsFailures.py`
- [x] `./bin/adhoc-scripts/workflowCompletion.py`
  - httplib, urllib
  - This will require something similar to what we will use to address #9926
  - fixed in #10754 
- [x] `./bin/check-ACDC-parentage`
- [x] `./bin/check-phedex-dbs-status`
- [x] `./bin/check-request-wq-status`
- [x] `./bin/combineMinifyWMStats.py`
- [x] `./bin/couch_archiver.py`
- [x] `./bin/couch-thrash.py`
- [x] `./bin/createStoreResults.py`
- [x] `./bin/dbsbuffer-file-fix.py`
- [x] `./bin/fix-dbs-parentage`
- [x] `./bin/HWMon/wmcore-SysStat`
- [x] `./bin/inject-to-config-cache`
- [x] `./bin/kill-workflow-in-agent`
- [x] `./bin/outputmodules-from-config`
  - urllib.request
- [x] `./bin/paused-jobs`
- [x] `./bin/purgeDeletedCouchDoc.py`
- [x] `./bin/reqmgr-put-default-config`
- [x] `./bin/reqmgr-sw-update`
- [x] `./bin/vaildateCMSSWMergeVersion`
  - maybe rename to `validateCMSSWMergeVersion`
- [x] `./bin/wmagent-couchapp-init`
- [x] `./bin/wmagent-delete-couchdb-workflow`
- [x] `./bin/wmagent-mod-config`
- [x] `./bin/wmagent-resource-control`
- [x] `./bin/wmagent-unregister-wmstats`
- [x] `./bin/wmagent-upload-config`
- [x] `./bin/wmagent-workqueue`
- [x] `./bin/wmc-httpd`
- [x] `./bin/wmcoreD`
- [x] `./bin/wmcore-db-init`
- [x] `./bin/wmcore-new-config`
- [x] `./bin/wmcore-new-flow`
- [x] `./deploy/checkProxy.py`
- [x] `./doc/generate_modules.py`
- [x] `./doc/wmcore/conf.py`
- [x] `./etc/dbsVerify.py`
- [x] `./etc/EmulatorConfig.py`
- [x] `./etc/GlobalWorkQueueConfig.py`
- [x] `./etc/harvestingInjector.py`
- [x] `./etc/injectReRecoWorkflow.py`
- [x] `./etc/injectStoreResults.py`
- [x] `./etc/phedexVerify.py`
- [x] `./etc/WMAgentConfig.py`
- [x] `./setup_build.py`
- [x] `./setup_dependencies.py`
- [x] `./setup.py`
- [x] `./setup_template.py`
- [x] `./setup_test.py`
- [x] `./setup_wmcore.py`
- [x] `./src/html/WorkQueue/examples/PlotFairyBarChart.py`
- [x] `./src/html/WorkQueue/examples/PlotFairyLineChart.py`
- [x] `./src/html/WorkQueue/examples/PlotFairyPieChart.py`
- [x] `./src/__init__.py`
- [x] `./standards/checkOutputs.py`
- [x] `./standards/failAnalysis.py`
- [x] `./standards/wrapEnv.py`
- [x] `./test/data/Alerts/alerts-load_example_data.py`
- [x] `./test/data/configs/2011B_442p2_DataReprocessingBTagSkim.py`
- [x] `./test/data/configs/BdToMuMu_2MuPtFilter_7TeV-pythia6-evtgen-namedfilter.py`
- [x] `./test/data/configs/BdToMuMu_2MuPtFilter_7TeV-pythia6-evtgen.py`
- [x] `./test/data/configs/QCD_HT-1000ToInf_TuneZ2star_8TeV-madgraph-pythia6.py`
- [x] `./test/data/configs/RelValSet_CMSSW_6_0_0_pre11_1_15.0DIGI.py`
- [x] `./test/data/configs/RelValSet_CMSSW_6_0_0_pre11_1_15.0RECO.py`
- [x] `./test/data/configs/step1_Summer11_R1_namedfilter.py`
- [x] `./test/data/ReqMgr/inject-test-wfs.py`
- [x] `./test/data/ReqMgr/reqmgr2.py`
  - check this
- [x] `./test/data/ReqMgr/validate-test-wfs.py`
  - urllib
  - This will require something similar to what we will use to address #9926
  - This actually emerged in #9960 
  - fixed in #10754
- [x] `./test/data/WMStats/doc_generator.py`
- [x] `./test/data/WMStats/generator.py`
- [x] `./test/data/WMStats/manual_request_generator.py`
- [x] `./test/etc/Configuration_t.py`





#### Is it backward compatible (if not, which system it affects?)
As always, it should be. Any change that can be problematic will be reported here and followed up.

#### Related PRs

This may count as a continuation to the migration slices, but it is completely independent from those

#### External dependencies / deployment changes
These changes require `python-future`, which is already available in our environments

