### PR TITLE
Replace mox dependency with mock.

### DIFF
--- a/test/python/WMCore_t/Storage_t/Plugins_t/SRMV2Impl_t.py
+++ b/test/python/WMCore_t/Storage_t/Plugins_t/SRMV2Impl_t.py
@@ -1,259 +1,92 @@
 from __future__ import print_function
-from builtins import object
-import os
 import logging
 logging.basicConfig(level = logging.DEBUG)
 import unittest
-import mox
-import tempfile
-import os.path
-import WMCore_t.Storage_t.Plugins_t.PluginTestBase_t
+from mock import mock
 from WMCore.Storage.Plugins.LCGImpl import LCGImpl as ourPlugin
 import WMCore.Storage.Plugins.LCGImpl
 moduleWeAreTesting = WMCore.Storage.Plugins.LCGImpl
 
-import subprocess
-from WMCore.WMBase import getWMBASE
 from WMCore.Storage.StageOutError import StageOutError, StageOutFailure
 
 from nose.plugins.attrib import attr
 
-class popenMockHelper(object):
-    def Popen(self,args,**kwargs):
-        # an empty thing so I can mock this
-        print("This should never be called if mox is working properly")
-        pass
+def getPluginObject(mock_os, mock_Popen, localSize, remoteSize):
 
+    # Mock file size of local file
+    mock_os.path.getsize.return_value = localSize
 
+    process_mock = mock.Mock()
+    # Mock remote file size
+    attrs = {'communicate.return_value': ('0 0 0 0 %s' % remoteSize, 'error')}
+    process_mock.configure_mock(**attrs)
+    mock_Popen.return_value = process_mock
+
+    # Actually run the test
+    ourPlugin.runCommandFailOnNonZero = mock.Mock()
+    ourPlugin.runCommandFailOnNonZero.return_value = (0,  None)
+    testObject = ourPlugin()
+    return testObject
 
 class SRMV2ImplTest(unittest.TestCase):
 
-    def setUp(self):
-        self.my_mox = mox.Mox()
-        self.my_mox.StubOutWithMock(moduleWeAreTesting.os.path, 'getsize')
-        self.my_mox.StubOutWithMock(moduleWeAreTesting,'runCommand')
-        self.my_mox.StubOutWithMock(moduleWeAreTesting,'tempfile')
-        self.popenMocker = self.my_mox.CreateMock(popenMockHelper)
-        self.popenBackup = moduleWeAreTesting.Popen
-
-
-        self.temporaryFiles = []
-        self.rules          = []
-    def tearDown(self):
-        moduleWeAreTesting.Popen = self.popenBackup
-        self.my_mox.UnsetStubs()
-        for file in self.temporaryFiles:
-            try:
-                os.remove(file)
-            except:
-                pass
-
     @attr("integration")
-    def testFailSrmCopy(self):
+    @mock.patch('WMCore.Storage.Plugins.LCGImpl.subprocess.Popen')
+    @mock.patch('WMCore.Storage.Plugins.LCGImpl.os')
+    def testFailSrmCopy(self, mock_os, mock_Popen):
+        
+        mock_os.path.getsize.return_value = 9001
 
         # copy a file and have it fail
-
-        # set up the SRM report
-        (tempHandle, tempFilename) = tempfile.mkstemp()
-        self.temporaryFiles.extend([tempFilename])
-        fdObj = os.fdopen(tempHandle, 'w')
-        # we get the exit status from the 3rd column in the output
-        fdObj.write("Exit Status: 9001")
-        fdObj.flush()
-        os.fsync(tempHandle)
-        moduleWeAreTesting.tempfile.mkstemp().AndReturn((tempHandle,tempFilename))
-
-
-        # Actually run the test
-        self.my_mox.ReplayAll()
         testObject = ourPlugin()
+
         # copy normally and have it work
+        self.assertRaises(StageOutError, testObject.doTransfer,'file:///store/NONEXISTANTSOURCE',
+                              'srm://nonexistant.com/blah/?SFN=/store/NONEXISTANTTARGET',
+                              True,
+                              None,
+                              None,
+                              None,
+                              None,
+                              None)
+
+
+    @attr("integration")
+    @mock.patch('WMCore.Storage.Plugins.LCGImpl.subprocess.Popen')
+    @mock.patch('WMCore.Storage.Plugins.LCGImpl.os')
+    def testFailOnFileSize(self, mock_os, mock_Popen, localSize=9001, remoteSize=9002):
+
+        # copy a file and have it fail file size check
+        testObject = getPluginObject(mock_os, mock_Popen, localSize, remoteSize)
+
+        # Do transfer and fail local<->remote file size check
         self.assertRaises(StageOutFailure, testObject.doTransfer,'file:///store/NONEXISTANTSOURCE',
                               'srm://nonexistant.com/blah/?SFN=/store/NONEXISTANTTARGET',
                               True,
                               None,
                               None,
                               None,
-                              None)
-        self.my_mox.VerifyAll()
-
-    @attr("integration")
-    def testFailOnFileSize(self):
-
-        # copy a file and have it succeed
-
-        # set up the SRM report
-        (tempHandle, tempFilename) = tempfile.mkstemp()
-        self.temporaryFiles.extend([tempFilename])
-        fdObj = os.fdopen(tempHandle, 'w')
-        # we get the exit status from the 3rd column in the output
-        fdObj.write("Exit Status: 0")
-        fdObj.flush()
-        os.fsync(tempHandle)
-
-        moduleWeAreTesting.tempfile.mkstemp().AndReturn((tempHandle,tempFilename))
-        os.path.getsize('/store/NONEXISTANTSOURCE').AndReturn(9001)
-
-        # this stub will either pass popen calls to mock or run them normal
-        # it eats rules to say either way (I just need to inject data to the
-        # first bit of a pipeline)
-        self.rules = [#first three lines are for the initial copy
-                      #pass them through to popen so I can make sure the
-                      # error code stuff works
-                      'SKIP', # skip the cat
-                      'SKIP', # skip the cut
-                      'SKIP', # skip the grep
-                      'DOIT', # process the srmls on the filesize]
-                      'SKIP',
-                      'SKIP',
-                      'SKIP'
-                    ]
-        def PopenStub(cmd, **kwargs):
-            if self.rules:
-                currentRule = self.rules.pop(0)
-                if currentRule != 'SKIP':
-                    return self.popenMocker.Popen(cmd, **kwargs)
-                else:
-                    return subprocess.Popen(cmd, **kwargs)
-            else:
-                return self.popenMocker.Popen(cmd,**kwargs)
-
-        # intercept calls to Popen
-        moduleWeAreTesting.Popen = PopenStub
-
-        # stub out the stdout
-        class tempPopenObjectType(object):
-            stdout = tempfile.TemporaryFile()
-
-        tempPopenObject = tempPopenObjectType()
-        tempPopenObject.stdout.write('test test test\n')
-        tempPopenObject.stdout.write('9002 /store/NONEXISTANTTARGET\n')
-        tempPopenObject.stdout.write('test test test\n')
-        tempPopenObject.stdout.seek(0)
-
-
-        self.popenMocker.Popen(["srmls", '-recursion_depth=0','-retry_num=0',\
-                                 'srm://nonexistant.com/blah/?SFN=/store/NONEXISTANTTARGET'],\
-                         stdout=subprocess.PIPE).AndReturn(tempPopenObject)
-
-
-        # Actually run the test
-        self.my_mox.ReplayAll()
-        testObject = ourPlugin()
-        # copy normally and have it work
-        self.assertRaises(StageOutFailure, testObject.doTransfer,'file:///store/NONEXISTANTSOURCE',
-                              'srm://nonexistant.com/blah/?SFN=/store/NONEXISTANTTARGET',
-                              True,
-                              None,
-                              None,
                               None,
                               None)
-        self.my_mox.VerifyAll()
 
     @attr("integration")
-    def testWin(self):
+    @mock.patch('WMCore.Storage.Plugins.LCGImpl.subprocess.Popen')
+    @mock.patch('WMCore.Storage.Plugins.LCGImpl.os')
+    def testWin(self, mock_os, mock_Popen, localSize=9001, remoteSize=9001):
 
         # copy a file and have it succeed
+        testObject = getPluginObject(mock_os, mock_Popen, localSize, remoteSize)
 
-        # set up the SRM report
-        (tempHandle, tempFilename) = tempfile.mkstemp()
-        self.temporaryFiles.extend([tempFilename])
-        fdObj = os.fdopen(tempHandle, 'w')
-        # we get the exit status from the 3rd column in the output
-        fdObj.write("Exit Status: 0")
-        fdObj.flush()
-        os.fsync(tempHandle)
-
-        moduleWeAreTesting.tempfile.mkstemp().AndReturn((tempHandle,tempFilename))
-        os.path.getsize('/store/NONEXISTANTSOURCE').AndReturn(9001)
-
-        # this stub will either pass popen calls to mock or run them normal
-        # it eats rules to say either way (I just need to inject data to the
-        # first bit of a pipeline)
-        self.rules = [#first three lines are for the initial copy
-                      #pass them through to popen so I can make sure the
-                      # error code stuff works
-                      'SKIP', # skip the cat
-                      'SKIP', # skip the cut
-                      'SKIP', # skip the grep
-                      'DOIT', # process the srmls on the filesize]
-                      'SKIP',
-                      'SKIP',
-                      'SKIP'
-                    ]
-        def PopenStub(cmd, **kwargs):
-            if self.rules:
-                currentRule = self.rules.pop(0)
-                if currentRule != 'SKIP':
-                    return self.popenMocker.Popen(cmd, **kwargs)
-                else:
-                    return subprocess.Popen(cmd, **kwargs)
-            else:
-                return self.popenMocker.Popen(cmd,**kwargs)
-
-        # intercept calls to Popen
-        moduleWeAreTesting.Popen = PopenStub
-
-        # stub out the stdout
-        class tempPopenObjectType(object):
-            stdout = tempfile.TemporaryFile()
-
-        tempPopenObject = tempPopenObjectType()
-        tempPopenObject.stdout.write('test test test\n')
-        tempPopenObject.stdout.write('9001 /store/NONEXISTANTTARGET\n')
-        tempPopenObject.stdout.write('test test test\n')
-        tempPopenObject.stdout.seek(0)
-
-
-        self.popenMocker.Popen(["srmls", '-recursion_depth=0','-retry_num=0',\
-                                 'srm://nonexistant.com/blah/?SFN=/store/NONEXISTANTTARGET'],\
-                         stdout=subprocess.PIPE).AndReturn(tempPopenObject)
-
-
-        # Actually run the test
-        self.my_mox.ReplayAll()
-        testObject = ourPlugin()
-        # copy normally and have it work
+        # Do transfer, match local<->remote file sizes and have it work
         newPfn = testObject.doTransfer('file:///store/NONEXISTANTSOURCE',
                               'srm://nonexistant.com/blah/?SFN=/store/NONEXISTANTTARGET',
                               True,
                               None,
                               None,
                               None,
+                              None,
                               None)
         self.assertEqual(newPfn, 'srm://nonexistant.com/blah/?SFN=/store/NONEXISTANTTARGET')
-        self.my_mox.VerifyAll()
-
-    @attr("integration")
-    def testMkdir(self):
-        testObject = ourPlugin()
-        self.my_mox.StubOutWithMock(testObject, 'runCommandWarnOnError')
-        commandList = \
-            [['srmls', '-recursion_depth=0', '-retry_num=5', 'srm://host:8443/srm/managerv2?SFN=/a/b/c/d/e/f/g/h'],
-            ['srmls', '-recursion_depth=0', '-retry_num=5', 'srm://host:8443/srm/managerv2?SFN=/a/b/c/d/e/f/g'],
-            ['srmls', '-recursion_depth=0', '-retry_num=5', 'srm://host:8443/srm/managerv2?SFN=/a/b/c/d/e/f'],
-            ['srmls', '-recursion_depth=0', '-retry_num=5', 'srm://host:8443/srm/managerv2?SFN=/a/b/c/d/e'],
-            ['srmls', '-recursion_depth=0', '-retry_num=5', 'srm://host:8443/srm/managerv2?SFN=/a/b/c/d'],
-            ['srmls', '-recursion_depth=0', '-retry_num=5', 'srm://host:8443/srm/managerv2?SFN=/a/b/c'],
-            ['srmls', '-recursion_depth=0', '-retry_num=5', 'srm://host:8443/srm/managerv2?SFN=/a/b'],
-            ['srmls', '-recursion_depth=0', '-retry_num=5', 'srm://host:8443/srm/managerv2?SFN=/a'],
-            ['srmmkdir', '-retry_num=5', 'srm://host:8443/srm/managerv2?SFN=/a'],
-            ['srmmkdir', '-retry_num=5', 'srm://host:8443/srm/managerv2?SFN=/a/b'],
-            ['srmmkdir', '-retry_num=5', 'srm://host:8443/srm/managerv2?SFN=/a/b/c'],
-            ['srmmkdir', '-retry_num=5', 'srm://host:8443/srm/managerv2?SFN=/a/b/c/d'],
-            ['srmmkdir', '-retry_num=5', 'srm://host:8443/srm/managerv2?SFN=/a/b/c/d/e'],
-            ['srmmkdir', '-retry_num=5', 'srm://host:8443/srm/managerv2?SFN=/a/b/c/d/e/f'],
-            ['srmmkdir', '-retry_num=5', 'srm://host:8443/srm/managerv2?SFN=/a/b/c/d/e/f/g'],
-            ['srmmkdir', '-retry_num=5', 'srm://host:8443/srm/managerv2?SFN=/a/b/c/d/e/f/g/h']]
-        for command in commandList:
-            testObject.runCommandWarnOnError(command).AndReturn(('asd', 'SRM_FAILURE'))
-#        def testFunc(args):
-#            print args
-#            return ("asd","SRM_FAILURE")
-#        testObject.runCommandWarnOnError = testFunc
-        self.my_mox.ReplayAll()
-        testObject.createOutputDirectory('srm://host:8443/srm/managerv2?SFN=/a/b/c/d/e/f/g/h/i',True)
-        self.my_mox.VerifyAll()
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #7071

#### Status
 ready

#### Description
Replaces mox dependency with mock.
Remove deprecated testMkdir test

#### Is it backward compatible (if not, which system it affects?)
Yes

#### External dependencies / deployment changes
It removes the no longer supported mox dependecy and uses mock instead.