### PR TITLE
Adjust couchapp push command to match CMSCouchapp

### DIFF
--- a/bin/wmagent-couchapp-init
+++ b/bin/wmagent-couchapp-init
@@ -6,6 +6,7 @@ wmagent-couchapp-init
 from __future__ import print_function, division
 
 from future import standard_library
+
 standard_library.install_aliases()
 
 import argparse

--- a/bin/wmagent-couchapp-init
+++ b/bin/wmagent-couchapp-init
@@ -16,9 +16,7 @@ import tempfile
 import urllib
 
 from urllib.parse import urlsplit
-
 from couchapp.commands import push as couchapppush
-from couchapp.config import Config
 
 from WMCore.Configuration import loadConfigurationFile
 from WMCore.Lexicon import splitCouchServiceURL
@@ -45,14 +43,20 @@ def installCouchApp(couchUrl, couchDBName, couchAppName, basePath=None):
     Install the given couch app on the given server in the given database.  If
     the database already exists it will be deleted.
     """
+    # set of options required by the couchapp push command
+    # from collections import namedtuple
+    # couchOpts = namedtuple("opts", ["export", "output", "force", "no_atomic"])
+    # for attribute in ["export", "output", "force", "no_atomic"]:
+    #     setattr(couchOpts, attribute, False)
+    ### AMR debugging workqueue couchapps, remove it later ###
+    #couchOpts.export = True
+    #couchOpts.output = "/data/WorkQueue.json"
+    ##########################################################
     if not basePath:
         basePath = couchAppRoot(couchAppName)
     print("Installing %s into %s" % (couchAppName, urllib.unquote_plus(couchDBName)))
 
-    couchappConfig = Config()
-
-    couchapppush(couchappConfig, "%s/%s" % (basePath, couchAppName),
-                 "%s/%s" % (couchUrl, couchDBName))
+    couchapppush("%s/%s" % (basePath, couchAppName), "%s/%s" % (couchUrl, couchDBName))
     return
 
 

--- a/src/python/WMQuality/TestInitCouchApp.py
+++ b/src/python/WMQuality/TestInitCouchApp.py
@@ -13,6 +13,7 @@ Copyright (c) 2010 Fermilab. All rights reserved.
 
 from builtins import object
 from future import standard_library
+
 standard_library.install_aliases()
 
 import os
@@ -23,6 +24,7 @@ from WMCore.Database.CMSCouch import CouchServer
 
 from WMQuality.TestInit import TestInit
 
+
 class CouchAppTestHarness(object):
     """
     Test Harness for installing a couch database instance with several couchapps
@@ -30,7 +32,8 @@ class CouchAppTestHarness(object):
 
 
     """
-    def __init__(self, dbName, couchUrl = None):
+
+    def __init__(self, dbName, couchUrl=None):
         self.couchUrl = os.environ.get("COUCHURL", couchUrl)
         self.dbName = dbName
         if self.couchUrl == None:
@@ -40,11 +43,10 @@ class CouchAppTestHarness(object):
             raise RuntimeError("COUCHURL env var shouldn't end with /")
         self.couchServer = CouchServer(self.couchUrl)
 
-
     def create(self, dropExistingDb=True):
         """create couch db instance"""
-        #import pdb
-        #pdb.set_trace()
+        # import pdb
+        # pdb.set_trace()
         if self.dbName in self.couchServer.listDatabases():
             if not dropExistingDb:
                 return
@@ -60,7 +62,7 @@ class CouchAppTestHarness(object):
         """
         push a list of couchapps to the database
         """
-        for couchappdir in  couchappdirs:
+        for couchappdir in couchappdirs:
             couchapppush(couchappdir, "%s/%s" % (self.couchUrl, urllib.parse.quote_plus(self.dbName)))
 
 
@@ -102,8 +104,7 @@ class TestInitCouchApp(TestInit):
         self.couch.create(dropExistingDb=self.dropExistingDb)
         # just create the db is couchapps are not specified
         if len(couchapps) > 0:
-            self.couch.pushCouchapps(*[os.path.join(self.couchAppRoot(couchapp), couchapp) for couchapp in couchapps ])
-
+            self.couch.pushCouchapps(*[os.path.join(self.couchAppRoot(couchapp), couchapp) for couchapp in couchapps])
 
     couchUrl = property(lambda x: x.couch.couchUrl)
     couchDbName = property(lambda x: x.couch.dbName)

--- a/src/python/WMQuality/TestInitCouchApp.py
+++ b/src/python/WMQuality/TestInitCouchApp.py
@@ -19,7 +19,6 @@ import os
 import urllib.parse
 
 from couchapp.commands import push as couchapppush
-from couchapp.config import Config
 from WMCore.Database.CMSCouch import CouchServer
 
 from WMQuality.TestInit import TestInit
@@ -40,7 +39,6 @@ class CouchAppTestHarness(object):
         if self.couchUrl.endswith('/'):
             raise RuntimeError("COUCHURL env var shouldn't end with /")
         self.couchServer = CouchServer(self.couchUrl)
-        self.couchappConfig = Config()
 
 
     def create(self, dropExistingDb=True):
@@ -63,7 +61,7 @@ class CouchAppTestHarness(object):
         push a list of couchapps to the database
         """
         for couchappdir in  couchappdirs:
-            couchapppush(self.couchappConfig, couchappdir, "%s/%s" % (self.couchUrl, urllib.parse.quote_plus(self.dbName)))
+            couchapppush(couchappdir, "%s/%s" % (self.couchUrl, urllib.parse.quote_plus(self.dbName)))
 
 
 class TestInitCouchApp(TestInit):

--- a/test/data/WMStats/generator.py
+++ b/test/data/WMStats/generator.py
@@ -6,7 +6,6 @@ import time
 from argparse import ArgumentParser
 
 from couchapp.commands import push as couchapppush
-from couchapp.config import Config
 
 from WMCore.Database.CMSCouch import CouchServer
 from WMCore.Lexicon import splitCouchServiceURL
@@ -39,11 +38,7 @@ def installCouchApp(couchUrl, couchDBName, couchAppName, basePath=None):
         basePath = couchAppRoot()
     print("Installing %s into %s" % (couchAppName, couchDBName))
 
-    couchServer = CouchServer(couchUrl)
-    couchappConfig = Config()
-
-    couchapppush(couchappConfig, "%s/%s" % (basePath, couchAppName),
-                 "%s/%s" % (couchUrl, couchDBName))
+    couchapppush("%s/%s" % (basePath, couchAppName), "%s/%s" % (couchUrl, couchDBName))
     return
 
 


### PR DESCRIPTION
Part of the needed work for fixing #10303 and https://github.com/dmwm/WMCore/issues/10076

#### Status
ready

#### Description
As we migrate to a home-maintained python couchapp library:
https://pypi.org/project/CMSCouchapp/

there has been a few changes to some API signatures. 

This PR provides the necessary changes to be able to deploy CouchDB applications with the new `CMSCouchapp` dependency, which is still to be inserted into our cmsdist spec files.

#### Is it backward compatible (if not, which system it affects?)
no

#### Related PRs
none

#### External dependencies / deployment changes
cmsdist spec changes: https://github.com/cms-sw/cmsdist/pull/6892
With this, a new WMAgent docker image can be created.
