### PR TITLE
added Cheetah3 to requirements_py3.txt

### DIFF
--- a/requirements_py3.txt
+++ b/requirements_py3.txt
@@ -14,6 +14,7 @@ pyzmq==19.0.2
 retry==0.9.2
 rucio-clients==1.24.2.post1
 sphinx==1.6.3
+Cheetah3==3.2.6.post2
 ### dependencies on the wmcorepy3-devtools spec
 CherryPy==17.4.0
 coverage==5.4


### PR DESCRIPTION
Related to #6460 

#### Status
Ready

#### Description
Reflecting https://github.com/cms-sw/cmsdist/pull/6898/ in dmwm/WMCore `requirements_py.txt`

#### Is it backward compatible (if not, which system it affects?)
YES

