### PR TITLE
Add CMSCouchapp dependency to the requirements files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ setuptools==39.2.0            # wmagent
 Sphinx==1.3.5                 # wmagent,reqmgr2,acdcserver,global-workqueue,reqmgr2ms
 SQLAlchemy==1.3.3             # wmagent
 stomp.py==4.1.15              # wmagent
+CMSCouchapp==1.2.10           # wmagent

--- a/requirements_py3.txt
+++ b/requirements_py3.txt
@@ -31,3 +31,4 @@ pymongo==3.10.1
 retry==0.9.2
 sphinx==1.6.3
 CMSMonitoring==0.3.4
+CMSCouchapp==1.3.2


### PR DESCRIPTION
Fixes #10303 

#### Status
ready

#### Description
Added the `CMSCouchapp` python library dependency to our python2 and python3 requirements list files.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
