### PR TITLE
new unittest deploy scripts for wmagentpy3

### DIFF
--- a/test/deploy/deploy_unittest_py3.sh
+++ b/test/deploy/deploy_unittest_py3.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+###
+# usage
+# deploy current version of wmagent external library and use the dmwm/master WMCore code to set up unittest
+# sh ./deploy_unittest.sh
+#
+# Also optional values can be specified. -v deploy agent version, -r git repository for code to test,
+# -b branch name of the repository.
+# following
+# i.e) sh ./deploy_unittest.sh -v 1.0.6 -r ticonaan -v 1.0.5_wmagent
+#
+# for running the test check the tutorial, https://github.com/dmwm/WMCore/wiki/Setup-wmcore-unittest
+###
+DMWM_ARCH=slc7_amd64_gcc630
+VERSION=$(curl -s "http://cmsrep.cern.ch/cgi-bin/repos/comp/$DMWM_ARCH?C=M;O=D" | grep -oP "(?<=>cms\+wmagentpy3-dev\+).*(?=-1-1)" | head -1)
+
+REPOSITORY=dmwm
+BRANCH=
+UPDATE=false
+
+deploy_agent() {
+
+    git clone https://github.com/dmwm/deployment.git
+    curl -s https://raw.githubusercontent.com/dmwm/WMCore/master/test/deploy/init.sh > init.sh
+    curl -s https://raw.githubusercontent.com/dmwm/WMCore/master/test/deploy/env_unittest_py3.sh > env_unittest_py3.sh
+    curl -s https://raw.githubusercontent.com/dmwm/WMCore/master/test/deploy/WMAgent_unittest.secrets > WMAgent_unittest.secrets
+    source ./init.sh
+    # set -e
+    for step in prep sw post; do
+        echo -e "\n*** Deploying WMAgent py3: running $step step ***"
+        $PWD/deployment/Deploy -R wmagentpy3-dev@$1 -r comp=comp -t $1 -A $DMWM_ARCH -s $step $INSTALL_DIR wmagentpy3/devtools
+        if [ $? -ne 0 ]; then
+            ls $INSTALL_DIR
+            cat $INSTALL_DIR/.deploy/*-$step.log
+            exit 1
+        fi
+    done
+    # set +e
+}
+
+setup_test_src() {
+    (
+     mkdir $TEST_DIR;
+     cd $TEST_DIR;
+     git clone https://github.com/$1/WMCore.git;
+     cd WMCore
+     # if branch is set check out the branch
+     if [ -n $2 ]
+     then
+        git checkout $2
+     fi;
+    )
+}
+
+update_src() {
+    (
+    rm -rf $TEST_DIR;
+    setup_test_src $1 $2
+    )
+}
+
+while [ $# -gt 0 ]
+do
+    case "$1" in
+        -v)  VERSION=$2; shift;;
+        -r)  REPOSITORY=$2; shift;;
+        -b)  BRANCH=$2; shift;;
+        -u)  UPDATE=true;;
+        *)  break;;	# terminate while loop
+    esac
+    shift
+done
+
+if [ $UPDATE = "true" ]
+then
+    source ./env_unittest_py3.sh
+    update_src $REPOSITORY $BRANCH
+else
+    echo "--- deploying agent $VERSION"
+    # deploy agent
+    deploy_agent $VERSION
+    echo "--- updating agent source repository $REPOSITORY,  branch $BRANCH"
+    # checkout test source
+    setup_test_src $REPOSITORY $BRANCH
+
+    # swap the source code from deployed one test source
+    source ./env_unittest_py3.sh
+    $manage start-services
+
+    mysql -u unittestagent --password=passwd --sock $INSTALL_DIR/current/install/mysql/logs/mysql.sock --exec "create database wmcore_unittest"
+fi

--- a/test/deploy/env_unittest_py3.sh
+++ b/test/deploy/env_unittest_py3.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+export USER=`whoami`
+export BASE_DIR=$PWD
+export TEST_DIR=$BASE_DIR/wmcore_unittest
+export TEST_SRC=$TEST_DIR/WMCore/src
+export TEST_SRC_PYTHON=$TEST_SRC/python
+export INSTALL_DIR=$BASE_DIR/unittestdeploy/wmagent
+export ADMIN_DIR=$BASE_DIR
+export CERT_DIR=$BASE_DIR/certs
+
+export ORG_SRC_PYTHON=$INSTALL_DIR/current/apps/wmagentpy3/lib/python3.8/site-packages/
+export ORG_SRC_OTHER=$INSTALL_DIR/current/apps/wmagentpy3/data
+export DBSOCK=$INSTALL_DIR/current/install/mysql/logs/mysql.sock
+
+export DATABASE=mysql://unittestagent:passwd@localhost/wmcore_unittest
+export COUCHURL=http://unittestagent:passwd@localhost:6994
+export DIALECT=MySQL
+
+rm -rf $ORG_SRC_PYTHON/*
+
+ln -s $TEST_SRC_PYTHON/WMCore/ $ORG_SRC_PYTHON
+ln -s $TEST_SRC_PYTHON/WMComponent/ $ORG_SRC_PYTHON
+ln -s $TEST_SRC_PYTHON/PSetTweaks/ $ORG_SRC_PYTHON
+ln -s $TEST_SRC_PYTHON/WMQuality/ $ORG_SRC_PYTHON
+ln -s $TEST_SRC_PYTHON/Utils/ $ORG_SRC_PYTHON
+
+rm -rf $ORG_SRC_OTHER/*
+
+ln -s $TEST_SRC/couchapps/ $ORG_SRC_OTHER
+ln -s $TEST_SRC/css/ $ORG_SRC_OTHER
+ln -s $TEST_SRC/html/ $ORG_SRC_OTHER
+ln -s $TEST_SRC/javascript/ $ORG_SRC_OTHER
+ln -s $TEST_SRC/template/ $ORG_SRC_OTHER
+
+export WMAGENT_SECRETS_LOCATION=$ADMIN_DIR/WMAgent_unittest.secrets
+export X509_HOST_CERT=$CERT_DIR/servicecert.pem
+export X509_HOST_KEY=$CERT_DIR/servicekey.pem
+export X509_USER_CERT=$CERT_DIR/servicecert.pem
+export X509_USER_KEY=$CERT_DIR/servicekey.pem
+
+export install=$INSTALL_DIR/current/install/wmagentpy3
+export config=$INSTALL_DIR/current/config/wmagentpy3
+export manage=$config/manage
+
+source $INSTALL_DIR/current/apps/wmagentpy3/etc/profile.d/init.sh
+source $INSTALL_DIR/current/apps/wmcorepy3-devtools/etc/profile.d/init.sh
+
+export PYTHONPATH=$TEST_SRC/../test/python:$PYTHONPATH
+
+### some Rucio setup needed for jenkins and docker unit tests
+# fetch the values defined in the secrets file and update rucio.cfg file
+export RUCIO_HOME=$config/../rucio/
+MATCH_RUCIO_HOST=`cat $WMAGENT_SECRETS_LOCATION | grep RUCIO_HOST | sed s/RUCIO_HOST=//`
+MATCH_RUCIO_AUTH=`cat $WMAGENT_SECRETS_LOCATION | grep RUCIO_AUTH | sed s/RUCIO_AUTH=//`
+sed -i "s+^rucio_host.*+rucio_host = $MATCH_RUCIO_HOST+" $RUCIO_HOME/etc/rucio.cfg
+sed -i "s+^auth_host.*+auth_host = $MATCH_RUCIO_AUTH+" $RUCIO_HOME/etc/rucio.cfg
+echo "Updated RUCIO_HOME file under: $RUCIO_HOME"


### PR DESCRIPTION
This PR is part of the effort to tackle #10487 

#### Status
Ready

**BUT**: I am still using this branch to perform some experiments. Right before merging I need to swap a couple of lines in `test/deploy/deploy_unittest_py3.sh` (I know, I am pretty lazy)

#### Description
Added a couple of scripts necessary to build the docker with the dev environment for wmcore with python3. 

This is not an elegant solution, it's a working solution. Maybe we will have to perform some deduplication in the future

#### Is it backward compatible (if not, which system it affects?)
yes, old deployment has not been touched

#### Related PRs
This PR required
- https://github.com/dmwm/deployment/pull/1053
- these scripts are used in: https://github.com/dmwm/Docker/pull/126, which is tested at https://gitlab.cern.ch/dmapelli/dmwm

#### External dependencies / deployment changes
nope
