### PR TITLE
[py2py3] setup_test.py compatible with both py2 and py3

### DIFF
--- a/setup_test.py
+++ b/setup_test.py
@@ -1,5 +1,7 @@
 from __future__ import print_function
 
+from builtins import str as newstr, bytes as newbytes
+
 import atexit
 import hashlib
 import os
@@ -203,7 +205,7 @@ if can_nose:
                 print("Failed to collect TestCase IDs")
                 return retval
 
-            idhandle = open(".noseids", "r")
+            idhandle = open(".noseids", "rb")
             testIds = pickle.load(idhandle)['ids']
             idhandle.close()
 
@@ -223,6 +225,8 @@ if can_nose:
                                 print('%s needs own slice' % testIds[testID][1])
                                 continue
                             testName = "%s%s" % (testIds[testID][1], testIds[testID][2])
+                            if isinstance(testName, newstr):
+                                testName = testName.encode("utf-8")
                             testHash = hashlib.md5(testName).hexdigest()
                             hashSnip = testHash[:7]
                             hashInt = int(hashSnip, 16)


### PR DESCRIPTION
This is another step towards closing #10487 

#### Status
Ready

#### Description
Changed only `setup_test.py`. It now works with both py2 and py3. The following commands are now tested and working:

```bash
# py2 docker
# gitlab-registry.cern.ch/cmsdocks/dmwm:wmcore_tests
source env_unitest.sh
cd wmcore_unittest/WMCore/

python setup.py test \
--buildBotMode=true \
--reallyDeleteMyDatabaseAfterEveryTest=true \
--testCertainPath=test/python/Utils_t/Utilities_t.py

nosetests test/python/Utils_t/Utilities_t.py
```

and

```bash
# py3 docker
# gitlab-registry.cern.ch/dmapelli/dmwm:wmcorepy3_tests
source env_unitest_py3.sh
cd wmcore_unittest/WMCore/

python3 setup.py test \
--buildBotMode=true \
--reallyDeleteMyDatabaseAfterEveryTest=true \
--testCertainPath=test/python/Utils_t/Utilities_t.py

nosetests test/python/Utils_t/Utilities_t.py
```

Please, notice that `nosetests` selects the proper python runtime in both environments. In `wmcore_tests` it selects py2 and in `wmcorepy3_tests` it selects py3.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
In #10481 I should have fixed `setup_test.py`, but without a py3 env some troubles slip through the cracks.

#### External dependencies / deployment changes
No changes
