### PR TITLE
[py2py3] Fix unittest in test/python/Utils_t

### DIFF
--- a/src/python/Utils/ExtendedUnitTestCase.py
+++ b/src/python/Utils/ExtendedUnitTestCase.py
@@ -31,13 +31,19 @@ class ExtendedUnitTestCase(unittest.TestCase):
                     traverse_list(value)
             return
 
+        def get_dict_sortkey(x):
+            if isinstance(x, dict):
+                return list(x.keys())
+            else:
+                return x
+
         def traverse_list(theList):
             for value in theList:
                 if isinstance(value, dict):
                     traverse_dict(value)
                 elif isinstance(value, list):
                     traverse_list(value)
-            theList.sort()
+            theList.sort(key=get_dict_sortkey)
             return
 
         if not isinstance(expected_obj, type(actual_obj)):

--- a/src/python/Utils/FileTools.py
+++ b/src/python/Utils/FileTools.py
@@ -15,7 +15,6 @@ import zlib
 from Utils.Utilities import decodeBytesToUnicode
 from Utils.PythonVersion import PY3
 
-
 def calculateChecksums(filename):
     """
     _calculateChecksums_

--- a/src/python/Utils/Utilities.py
+++ b/src/python/Utils/Utilities.py
@@ -136,6 +136,7 @@ def zipEncodeStr(message, maxLen=5120, compressLevel=9, steps=100, truncateIndic
     truncate message until zip/encoded version
     is within the limits allowed.
     """
+    message = encodeUnicodeToBytes(message)
     encodedStr = zlib.compress(message, compressLevel)
     encodedStr = base64.b64encode(encodedStr)
     if len(encodedStr) < maxLen or maxLen == -1:
@@ -146,6 +147,7 @@ def zipEncodeStr(message, maxLen=5120, compressLevel=9, steps=100, truncateIndic
     # Estimate new length for message zip/encoded version
     # to be less than maxLen.
     # Also, append truncate indicator to message.
+    truncateIndicator = encodeUnicodeToBytes(truncateIndicator)
     strLen = int((maxLen - len(truncateIndicator)) / compressRate)
     message = message[:strLen] + truncateIndicator
 

--- a/test/python/Utils_t/MathUtils_t.py
+++ b/test/python/Utils_t/MathUtils_t.py
@@ -32,3 +32,7 @@ class MathUtilsTest(unittest.TestCase):
 
         self.assertRaises(ValueError, quantize, 1, [50])
         self.assertRaises(ValueError, quantize, 1, {50})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/python/Utils_t/MemoryCache_t.py
+++ b/test/python/Utils_t/MemoryCache_t.py
@@ -9,7 +9,7 @@ import unittest
 from time import sleep
 
 from Utils.MemoryCache import MemoryCache, MemoryCacheException
-
+from Utils.PythonVersion import PY3
 
 class MemoryCacheTest(unittest.TestCase):
     """
@@ -18,51 +18,51 @@ class MemoryCacheTest(unittest.TestCase):
 
     def testBasics(self):
         cache = MemoryCache(1, [])
-        self.assertItemsEqual(cache.getCache(), [])
+        self.assertCountEqual(cache.getCache(), []) if PY3 else self.assertItemsEqual(cache.getCache(), [])
         cache.setCache(["item1", "item2"])
-        self.assertItemsEqual(cache.getCache(), ["item1", "item2"])
+        self.assertCountEqual(cache.getCache(), ["item1", "item2"]) if PY3 else self.assertItemsEqual(cache.getCache(), ["item1", "item2"])
         # wait for cache to expiry, wait for 2 secs
         sleep(2)
         self.assertRaises(MemoryCacheException, cache.getCache)
         cache.setCache(["item4"])
         # and the cache is alive again
-        self.assertItemsEqual(cache.getCache(), ["item4"])
+        self.assertCountEqual(cache.getCache(), ["item4"]) if PY3 else self.assertItemsEqual(cache.getCache(), ["item4"])
 
     def testCacheSet(self):
         cache = MemoryCache(2, set())
-        self.assertItemsEqual(cache.getCache(), set())
+        self.assertCountEqual(cache.getCache(), set()) if PY3 else self.assertItemsEqual(cache.getCache(), set())
         cache.setCache(set(["item1", "item2"]))
-        self.assertItemsEqual(cache.getCache(), ["item1", "item2"])
+        self.assertCountEqual(cache.getCache(), ["item1", "item2"]) if PY3 else self.assertItemsEqual(cache.getCache(), ["item1", "item2"])
         cache.addItemToCache("item3")
-        self.assertItemsEqual(cache.getCache(), ["item1", "item2", "item3"])
+        self.assertCountEqual(cache.getCache(), ["item1", "item2", "item3"]) if PY3 else self.assertItemsEqual(cache.getCache(), ["item1", "item2", "item3"])
         cache.addItemToCache(["item4"])
-        self.assertItemsEqual(cache.getCache(), ["item1", "item2", "item3", "item4"])
+        self.assertCountEqual(cache.getCache(), ["item1", "item2", "item3", "item4"]) if PY3 else self.assertItemsEqual(cache.getCache(), ["item1", "item2", "item3", "item4"])
         cache.addItemToCache(set(["item5"]))
-        self.assertItemsEqual(cache.getCache(), ["item1", "item2", "item3", "item4", "item5"])
+        self.assertCountEqual(cache.getCache(), ["item1", "item2", "item3", "item4", "item5"]) if PY3 else self.assertItemsEqual(cache.getCache(), ["item1", "item2", "item3", "item4", "item5"])
         self.assertTrue("item2" in cache)
         self.assertFalse("item222" in cache)
 
     def testCacheList(self):
         cache = MemoryCache(2, [])
-        self.assertItemsEqual(cache.getCache(), [])
+        self.assertCountEqual(cache.getCache(), []) if PY3 else self.assertItemsEqual(cache.getCache(), [])
         cache.setCache(["item1", "item2"])
-        self.assertItemsEqual(cache.getCache(), ["item1", "item2"])
+        self.assertCountEqual(cache.getCache(), ["item1", "item2"]) if PY3 else self.assertItemsEqual(cache.getCache(), ["item1", "item2"])
         cache.addItemToCache("item3")
-        self.assertItemsEqual(cache.getCache(), ["item1", "item2", "item3"])
+        self.assertCountEqual(cache.getCache(), ["item1", "item2", "item3"]) if PY3 else self.assertItemsEqual(cache.getCache(), ["item1", "item2", "item3"])
         cache.addItemToCache(["item4"])
-        self.assertItemsEqual(cache.getCache(), ["item1", "item2", "item3", "item4"])
+        self.assertCountEqual(cache.getCache(), ["item1", "item2", "item3", "item4"]) if PY3 else self.assertItemsEqual(cache.getCache(), ["item1", "item2", "item3", "item4"])
         cache.addItemToCache(set(["item5"]))
-        self.assertItemsEqual(cache.getCache(), ["item1", "item2", "item3", "item4", "item5"])
+        self.assertCountEqual(cache.getCache(), ["item1", "item2", "item3", "item4", "item5"]) if PY3 else self.assertItemsEqual(cache.getCache(), ["item1", "item2", "item3", "item4", "item5"])
         self.assertTrue("item2" in cache)
         self.assertFalse("item222" in cache)
 
     def testCacheDict(self):
         cache = MemoryCache(2, {})
-        self.assertItemsEqual(cache.getCache(), {})
+        self.assertCountEqual(cache.getCache(), {}) if PY3 else self.assertItemsEqual(cache.getCache(), {})
         cache.setCache({"item1": 11, "item2": 22})
-        self.assertItemsEqual(cache.getCache(), {"item1": 11, "item2": 22})
+        self.assertCountEqual(cache.getCache(), {"item1": 11, "item2": 22}) if PY3 else self.assertItemsEqual(cache.getCache(), {"item1": 11, "item2": 22})
         cache.addItemToCache({"item3": 33})
-        self.assertItemsEqual(cache.getCache(), {"item1": 11, "item2": 22, "item3": 33})
+        self.assertCountEqual(cache.getCache(), {"item1": 11, "item2": 22, "item3": 33}) if PY3 else self.assertItemsEqual(cache.getCache(), {"item1": 11, "item2": 22, "item3": 33})
         self.assertTrue("item2" in cache)
         self.assertFalse("item222" in cache)
         # test exceptions
@@ -71,6 +71,10 @@ class MemoryCacheTest(unittest.TestCase):
 
     def testSetDiffTypes(self):
         cache = MemoryCache(2, set())
-        self.assertItemsEqual(cache.getCache(), set())
+        self.assertCountEqual(cache.getCache(), set()) if PY3 else self.assertItemsEqual(cache.getCache(), set())
         cache.setCache({"item1", "item2"})
         self.assertRaises(TypeError, cache.setCache, ["item3"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/python/Utils_t/PortForward_t.py
+++ b/test/python/Utils_t/PortForward_t.py
@@ -64,14 +64,14 @@ class PortForwardTests(unittest.TestCase):
         self.urlResultList = []
         for url in self.urlTestList:
             self.urlResultList.append(requesHandler.request(url))
-        self.assertItemsEqual(self.urlResultList, self.urlExpectedtList)
+        self.assertListEqual(self.urlResultList, self.urlExpectedtList)
 
     def testCallClass(self):
         portForwarder = PortForward(8443)
         self.urlResultList = []
         for url in self.urlTestList:
             self.urlResultList.append(portForwarder(url))
-        self.assertItemsEqual(self.urlResultList, self.urlExpectedtList)
+        self.assertListEqual(self.urlResultList, self.urlExpectedtList)
 
 
 if __name__ == '__main__':

--- a/test/python/Utils_t/Utilities_t.py
+++ b/test/python/Utils_t/Utilities_t.py
@@ -10,7 +10,8 @@ import os
 import unittest
 
 from Utils.Utilities import makeList, makeNonEmptyList, strToBool, \
-    safeStr, rootUrlJoin, zipEncodeStr, lowerCmsHeaders, getSize
+    safeStr, rootUrlJoin, zipEncodeStr, lowerCmsHeaders, getSize, \
+    encodeUnicodeToBytes
 
 
 class UtilitiesTests(unittest.TestCase):
@@ -26,14 +27,14 @@ class UtilitiesTests(unittest.TestCase):
         self.assertEqual(makeList(""), [])
         self.assertEqual(makeList(['123']), ['123'])
         self.assertEqual(makeList([456]), [456])
-        self.assertItemsEqual(makeList(['123', 456, '789']), ['123', 456, '789'])
+        self.assertListEqual(makeList(['123', 456, '789']), ['123', 456, '789'])
 
         self.assertEqual(makeList('123'), ['123'])
         self.assertEqual(makeList(u'123'), [u'123'])
-        self.assertItemsEqual(makeList('123,456'), ['123', '456'])
-        self.assertItemsEqual(makeList(u'123,456'), [u'123', u'456'])
-        self.assertItemsEqual(makeList('["aa","bb","cc"]'), ['aa', 'bb', 'cc'])
-        self.assertItemsEqual(makeList(u' ["aa", "bb", "cc"] '), ['aa', 'bb', 'cc'])
+        self.assertListEqual(makeList('123,456'), ['123', '456'])
+        self.assertListEqual(makeList(u'123,456'), [u'123', u'456'])
+        self.assertListEqual(makeList('["aa","bb","cc"]'), ['aa', 'bb', 'cc'])
+        self.assertListEqual(makeList(u' ["aa", "bb", "cc"] '), ['aa', 'bb', 'cc'])
 
         self.assertRaises(ValueError, makeList, 123)
         self.assertRaises(ValueError, makeList, 123.456)
@@ -57,10 +58,10 @@ class UtilitiesTests(unittest.TestCase):
         for empty list or string.
         """
         self.assertEqual(makeList(['123']), makeNonEmptyList(['123']))
-        self.assertItemsEqual(makeList(['123', 456, '789']), makeNonEmptyList(['123', 456, '789']))
+        self.assertListEqual(makeList(['123', 456, '789']), makeNonEmptyList(['123', 456, '789']))
 
-        self.assertItemsEqual(makeList(u'123,456'), makeNonEmptyList(u'123, 456'))
-        self.assertItemsEqual(makeList('["aa","bb","cc"]'), makeNonEmptyList('["aa", "bb", "cc"]'))
+        self.assertListEqual(makeList(u'123,456'), makeNonEmptyList(u'123, 456'))
+        self.assertListEqual(makeList('["aa","bb","cc"]'), makeNonEmptyList('["aa", "bb", "cc"]'))
 
         self.assertRaises(ValueError, makeNonEmptyList, [])
         self.assertRaises(ValueError, makeNonEmptyList, "")
@@ -127,6 +128,7 @@ cms::Exception caught in CMS.EventProcessor and rethrown
 """
         encodedMessage = \
             'eNp1j8FqwzAMhu95Cl0G2yEhaXvyrU3dkkFHqfcCnq02hkQOtlz6+HM2MrbDdBLS9/1CxdNJHcsI7UnJh8GJnScBsL0yhoMbEOpV+ZqoXNVNDc1GrBuxWUMr1TucfWRJ9pKoMGMU4scHo9OtZ3C5G+O8L3OBvCPxOXiDMfpw0G5IAWEnj91b8Xvn6KbYTxPab0+ZHm0aUD7QpDn/r/qP1dFdD85e8IoBySz0Ts+j1md9y4zjxMAebGYWTsMCGE+sHeVk0JS/+Qqc79lkuNtDryN8IBLAc1VVL5+o0W8i'
+        encodedMessage = encodeUnicodeToBytes(encodedMessage)
         self.assertEqual(zipEncodeStr(message, maxLen=300, compressLevel=9, steps=10, truncateIndicator=" (...)"),
                          encodedMessage)
         # Test different maximum lengths
@@ -150,8 +152,8 @@ cms::Exception caught in CMS.EventProcessor and rethrown
                 self.data = "blah"
 
         cls1 = TestClass1()
-        print(getSize(cls1)) # 1129
-        self.assertTrue(getSize(cls1) > 1000)
+        print(getSize(cls1)) # py2: 1129, py3: 205
+        self.assertTrue(getSize(cls1) > 200)
 
         class TestClass2(object):
             """
@@ -162,8 +164,8 @@ cms::Exception caught in CMS.EventProcessor and rethrown
                 self.data = "blah"
 
         cls2 = TestClass2()
-        print(getSize(cls2)) # 426
-        self.assertTrue(getSize(cls2) > 400)
+        print(getSize(cls2)) # py2: 426, py3: 205
+        self.assertTrue(getSize(cls2) > 200)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Part of the effort for tackling #10422 

#### Status
Ready

- [x] Rebase on master after #10503 is merged
- [x] Rebase on master after #10518 is merged

#### Related PRs
This is the first of a (hopefully not too long) series of PRs for closing #10422 .
- Previous: __no previous__
- Next: #10522

#### Description

##### Open questions

I need external help to find a proper solution: none

##### I found a proper solution, but your insight may foresee some problems that I ignored. 

Some comments or validation is required

`Utils/UItilities.py`
- [x] the size of the classes in py3 is lower than in py2. I had to change the sizes in `Utils_t/Utilities_t.py:UtilitiesTests.testGetSize`
- [x] `zlib.compress(message)` requires `message` to be `bytes`. This forces the output of `Utilities.zipEncoderStr` to be bytes. This function is only used in `src/python/WMCore/WMSpec/Steps/Executor.py.Executor.setCondorChirpAttrDelayed`. Is it a problem if we pass a bytes string in python3 also? Investigate, or open an issue to investigate this
- [x] in python3 we do not have [assertItemsEquals](https://docs.python.org/2.7/library/unittest.html#unittest.TestCase.assertItemsEqual) anymore. It has been renamed [assertCountEqual](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertCountEqual). Since we already had to rename this, I think we can be more stringent here and use [assertListEqual](https://docs.python.org/3.9/library/unittest.html#unittest.TestCase.assertListEqual) instead

`Utils/MemoryCache_t.py`
- [x] `assertCountEqual` if py3 else `assertItemsEqual` 
  - do you like the "style"? do you have any preferences?
  - I chose this approach because when abandoning py2 it is clear which lines should be affected and how. This comes at the expense of temporarily long lines (>>80 chars). I did not want to create two separate files and did not want to duplicate test class or test functions.

`Utils/FileTools.py`
- [x] calculateChecksums should return `cksum` as native string or unicode? The first is the preferred choice if the FileReport ends up in a db or in a file, the later is better if we consume FileReport internally before sending/saving it.


`Utils/ExtendedUnitTestCase.py`
- [x] problem with `assertContentsEqual`.
  - in py3 `dict < dict` is not valid, so we need to change https://github.com/dmwm/WMCore/blob/521bb57f9d974145aad28a8804100c1b682c6f86/src/python/Utils/ExtendedUnitTestCase.py#L40
  - Replicate with `python3 setup.py test --buildBotMode=true --reallyDeleteMyDatabaseAfterEveryTest=true --testCertainPath=test/python/Utils_t/ExtendedUnitTestCase_t.py`
  - solved with last commit

#### Is it backward compatible (if not, which system it affects?)
YES



#### External dependencies / deployment changes
No change
