### PR TITLE
[py2py3] pycurl_manager: converting response to unicode before parsing

### DIFF
--- a/src/python/WMCore/Services/pycurl_manager.py
+++ b/src/python/WMCore/Services/pycurl_manager.py
@@ -57,7 +57,7 @@ from io import BytesIO
 import http.client
 from urllib.parse import urlencode
 
-from Utils.Utilities import encodeUnicodeToBytes
+from Utils.Utilities import encodeUnicodeToBytes, decodeBytesToUnicode
 from Utils.PortForward import portForward, PortForward
 
 
@@ -76,6 +76,8 @@ class ResponseHeader(object):
         startRegex = r"^HTTP/\d.\d \d{3}"
         continueRegex = r"^HTTP/\d.\d 100"  # Continue: client should continue its request
         replaceRegex = r"^HTTP/\d.\d"
+
+        response = decodeBytesToUnicode(response)
 
         for row in response.split('\r'):
             row = row.replace('\n', '')


### PR DESCRIPTION
Fixes #10333 

#### Status
Ready

#### Description
I did something similar to one of the first suggestions by Todor: convert to unicode string the response before parsing. The only difference is that Todor used

```python
response = str(response)
```

Which unfortunately may have some unintended behavior, like [1]

I used the the usual `Utils.Utilities.decodeBytesToUnicode`, which effectively decodes `response` to unicode if and only if it is a bytes string

```python
    if isinstance(response, bytes):
        response = response.decode("utf-8")
```

Unit tests are looking good in both py2 and py3, but I have to ask both @amaltaro and @todor-ivanov to check if this approach 
- [ ] works for your use cases, aka fixes the problems you are having
- [ ] does not break something down the line. 

My worry is that saving the headers as unicode strings may cause some troubles when using those again for another http call later (i do not know, is this even something we do? are the parsed headers ever used again for making new calls?). In this case we may need to use `Utils.Utilities.encodeUnicodeToBytes` right before making the new calls.

Pedantic corner: This is an example of the "unicode sandwich" approach. When we have to deal with bytes string, it's always easier to convert bytes to unicode as soon as possible, deal with only unicode internally, then convert unicode back to bytes as late as possible, only if strictly needed.

[1]

```plaintext
In [2]: response
Out[2]: b'HTTP/1.1 200 OK\r\nDate: Sat, 06 Mar 2021 00:56:24 GMT\r\nServer: CherryPy/17.4.0\r\nContent-Length: 18\r\nContent-Encoding: deflate\r\nX-Rest-Time: 21893.024 us\r\nX-Rest-Status: 100\r\nVary: Accept,Accept-Encoding\r\nEtag: "9c66ca948c2c34405e231689f5286bb9b0cc7c20"\r\nCache-Control: max-age=3600\r\nContent-Type: application/json\r\nCMS-Server-Time: D=37110 t=1614992184222564\r\n\r\n'

In [3]: response = str(response)

In [4]: response
Out[4]: 'b\'HTTP/1.1 200 OK\\r\\nDate: Sat, 06 Mar 2021 00:56:24 GMT\\r\\nServer: CherryPy/17.4.0\\r\\nContent-Length: 18\\r\\nContent-Encoding: deflate\\r\\nX-Rest-Time: 21893.024 us\\r\\nX-Rest-Status: 100\\r\\nVary: Accept,Accept-Encoding\\r\\nEtag: "9c66ca948c2c34405e231689f5286bb9b0cc7c20"\\r\\nCache-Control: max-age=3600\\r\\nContent-Type: application/json\\r\\nCMS-Server-Time: D=37110 t=1614992184222564\\r\\n\\r\\n\''
```

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
not yet

#### External dependencies / deployment changes
no change
