### PR TITLE
[py2py3] Do not convert unicode to bytes when parsing data from Databases

### DIFF
--- a/src/python/WMCore/Database/DBFormatter.py
+++ b/src/python/WMCore/Database/DBFormatter.py
@@ -11,6 +11,7 @@ from builtins import str, bytes, zip, range
 import datetime
 import time
 import types
+import sys
 
 from WMCore.DataStructs.WMObject import WMObject
 
@@ -77,7 +78,7 @@ class DBFormatter(WMObject):
                 entry = {}
                 for index in range(0, len(descriptions)):
                     # WARNING: Oracle returns table names in CAP!
-                    if isinstance(i[index], str):
+                    if isinstance(i[index], str) and sys.version_info[0] == 2:
                         entry[str(descriptions[index].lower())] = i[index].encode("utf-8")
                     else:
                         entry[str(descriptions[index].lower())] = i[index]


### PR DESCRIPTION
Fixes #10502 

#### Status
ready - validation required

#### Description

In py2 we converted unicode coming from the DB to bytes string. This is causing problems such as #10502. The proposed solution is not to convert unicode to bytes in py3.

Validation
- [ ] make sure that not converting unicode to bytes is not causing problems in py3

Other
- [ ] commit message is not the best, i can happily change it

#### Is it backward compatible (if not, which system it affects?)
YES

#### External dependencies / deployment changes
nope
