### PR TITLE
[py2py3] new variables Utils.PythonVersion.PY2/3

### DIFF
--- a/src/python/Utils/FileTools.py
+++ b/src/python/Utils/FileTools.py
@@ -11,9 +11,9 @@ import stat
 import subprocess
 import time
 import zlib
-import sys
 
 from Utils.Utilities import decodeBytesToUnicode
+from Utils.PythonVersion import PY3
 
 
 def calculateChecksums(filename):
@@ -52,7 +52,7 @@ def calculateChecksums(filename):
     if len(cksumStdout) != 2 or int(cksumStdout[1]) != filesize:
         raise RuntimeError("Something went wrong with the cksum calculation !")
 
-    if sys.version_info[0] == 3:
+    if PY3:
         # using native-string approach. convert from bytes to unicode in
         # python 3 only.
         cksumStdout[0] = decodeBytesToUnicode(cksumStdout[0])

--- a/src/python/Utils/PythonVersion.py
+++ b/src/python/Utils/PythonVersion.py
@@ -1,0 +1,10 @@
+"""
+Easily get the version of the python interpreter at runtime
+"""
+
+from __future__ import division # Jenkins CI
+
+import sys
+
+PY3 = sys.version_info[0] == 3
+PY2 = sys.version_info[0] == 2

--- a/src/python/WMCore/Configuration.py
+++ b/src/python/WMCore/Configuration.py
@@ -11,10 +11,9 @@ Module dealing with Configuration file in python format
 
 import imp
 import os
-import sys
 import traceback
 
-PY3 = sys.version_info[0] == 3
+from Utils.PythonVersion import PY3
 
 # PY3 compatibility (can be removed once python2 gets dropped)
 if PY3:

--- a/src/python/WMCore/Database/DBFormatter.py
+++ b/src/python/WMCore/Database/DBFormatter.py
@@ -6,14 +6,14 @@ Holds a bunch of helper methods to format input and output of sql
 interactions.
 """
 
-from builtins import str, bytes, zip, range
+from builtins import str, zip, range
 
 import datetime
 import time
 import types
-import sys
 
 from WMCore.DataStructs.WMObject import WMObject
+from Utils.PythonVersion import PY2
 
 
 class DBFormatter(WMObject):
@@ -78,7 +78,7 @@ class DBFormatter(WMObject):
                 entry = {}
                 for index in range(0, len(descriptions)):
                     # WARNING: Oracle returns table names in CAP!
-                    if isinstance(i[index], str) and sys.version_info[0] == 2:
+                    if isinstance(i[index], str) and PY2:
                         entry[str(descriptions[index].lower())] = i[index].encode("utf-8")
                     else:
                         entry[str(descriptions[index].lower())] = i[index]

--- a/src/python/WMCore/REST/Main.py
+++ b/src/python/WMCore/REST/Main.py
@@ -39,6 +39,7 @@ from cherrypy.lib import profiler
 import WMCore.REST.Tools
 from WMCore.Configuration import ConfigSection, loadConfigurationFile
 from Utils.Utilities import lowerCmsHeaders
+from Utils.PythonVersion import PY2
 
 #: Terminal controls to switch to "OK" status message colour.
 COLOR_OK = "\033[0;32m"
@@ -434,7 +435,7 @@ class RESTDaemon(RESTMain):
             self.run()
         except Exception as e:
             error = True
-            if sys.version_info[0] == 2:
+            if PY2:
                 trace = BytesIO()
             else:
                 trace = StringIO()

--- a/src/python/WMQuality/Emulators/DBSClient/MockDbsApi.py
+++ b/src/python/WMQuality/Emulators/DBSClient/MockDbsApi.py
@@ -11,12 +11,12 @@ from future.utils import viewitems
 import copy
 import json
 import os
-import sys
 
 from RestClient.ErrorHandling.RestClientExceptions import HTTPError
 from WMCore.Services.DBS.DBSErrors import DBSReaderError
 from WMCore.WMBase import getTestBase
 
+from Utils.PythonVersion import PY2
 
 # Read in the data just once so that we don't have to do it for every test (in __init__)
 
@@ -44,7 +44,7 @@ def _unicode(data):
     by unicode (as u"hello worls") and future.types.newstr (as "hello world")
     https://github.com/dmwm/WMCore/pull/10299#issuecomment-781600773
     """
-    if sys.version_info[0] == 2:
+    if PY2:
         return unicode(data)
     else:
         return str(data)

--- a/src/python/WMQuality/Emulators/RucioClient/MockRucioApi.py
+++ b/src/python/WMQuality/Emulators/RucioClient/MockRucioApi.py
@@ -10,12 +10,13 @@ from future.utils import listitems
 import json
 import logging
 import os
-import sys
 
 from WMCore.Services.DBS.DBS3Reader import DBS3Reader, DBSReaderError
 from WMCore.Services.Rucio.Rucio import WMRucioException, WMRucioDIDNotFoundException
 from WMCore.WMBase import getTestBase
 from WMQuality.Emulators.DataBlockGenerator.DataBlockGenerator import DataBlockGenerator
+
+from Utils.PythonVersion import PY2
 
 PROD_DBS = 'https://cmsweb-prod.cern.ch/dbs/prod/global/DBSReader'
 
@@ -44,7 +45,7 @@ def _unicode(data):
     by unicode (as u"hello worls") and future.types.newstr (as "hello world")
     https://github.com/dmwm/WMCore/pull/10299#issuecomment-781600773
     """
-    if sys.version_info[0] == 2:
+    if PY2:
         return unicode(data)
     else:
         return str(data)


### PR DESCRIPTION
Fixes #10509 

#### Status
Ready

#### Description
As Alan suggested: I added a new module under Utils which provides two booleans `PY2` and `PY3`.

TODO
- [ ] we should make sure that in the Release Changelog we specify that we no longer provide the variable `PY3` from `Configuration.py` but from `Utils.PythonVersion`. Maybe someone else is using it.

#### Is it backward compatible (if not, which system it affects?)
YES

#### External dependencies / deployment changes
Nope
