### PR TITLE
[py2py3] fix unittests from WMCoreConfigCache

### DIFF
--- a/src/python/WMCore/Cache/WMConfigCache.py
+++ b/src/python/WMCore/Cache/WMConfigCache.py
@@ -19,6 +19,8 @@ from contextlib import closing
 
 import WMCore.GroupUser.Decorators as Decorators
 from Utils.Patterns import Singleton
+from Utils.Utilities import decodeBytesToUnicode
+from Utils.PythonVersion import PY3
 from WMCore.DataStructs.WMObject import WMObject
 from WMCore.Database.CMSCouch import CouchNotFoundError
 from WMCore.Database.CMSCouch import CouchServer, Document
@@ -439,6 +441,8 @@ class ConfigCache(WMObject):
         with closing(urllib.request.urlopen(newConfig)) as f:
             configString = f.read(-1)
         configMD5 = hashlib.md5(configString).hexdigest()
+        if PY3:
+            configString = decodeBytesToUnicode(configString)
 
         self.document['md5_hash'] = configMD5
         self.document['pset_hash'] = psetHash

--- a/src/python/WMCore/Lexicon.py
+++ b/src/python/WMCore/Lexicon.py
@@ -14,8 +14,6 @@ from builtins import str
 from future.utils import viewvalues
 
 import io
-import logging
-import mmap
 import re
 
 from urllib.parse import urlparse, urlunparse
@@ -727,11 +725,5 @@ def getStringsBetween(start, end, source):
 
 def getIterMatchObjectOnRegexp(filePath, regexp):
     with io.open(filePath, 'r', encoding='utf8', errors='ignore') as f:
-        try:
-            mm = mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ)
-        except ValueError:
-            logging.warning("Cannot mmap empty file: %s", filePath)
-        else:
-            for m in re.finditer(regexp, mm):
-                yield m
-            mm.close()
+        for m in re.finditer(regexp, f.read()):
+            yield m

--- a/src/python/WMCore/Services/Requests.py
+++ b/src/python/WMCore/Services/Requests.py
@@ -12,9 +12,6 @@ from __future__ import division, print_function
 from future import standard_library
 standard_library.install_aliases()
 
-from future import standard_library
-standard_library.install_aliases()
-
 from builtins import str, bytes, object
 from future.utils import viewvalues
 
@@ -24,7 +21,6 @@ import os
 import shutil
 import socket
 import stat
-import sys
 import tempfile
 import traceback
 import types
@@ -36,6 +32,7 @@ from json import JSONEncoder, JSONDecoder
 
 from Utils.CertTools import getKeyCertFromEnv, getCAPathFromEnv
 from Utils.Utilities import encodeUnicodeToBytes, decodeBytesToUnicode
+from Utils.PythonVersion import PY3
 from WMCore.Algorithms import Permissions
 from WMCore.Lexicon import sanitizeURL
 from WMCore.WMException import WMException
@@ -308,6 +305,8 @@ class Requests(dict):
             result = decoder(result)
         elif decoder is not False:
             result = self.decode(result)
+        if PY3:
+            result = decodeBytesToUnicode(result)
         return result
 
     def encode(self, data):
@@ -418,7 +417,7 @@ class Requests(dict):
         password = encodeUnicodeToBytes(password)
         encodedauth = base64.encodestring(b'%s:%s' % (
             username, password)).strip()
-        if sys.version_info[0] == 3:
+        if PY3:
             encodedauth = decodeBytesToUnicode(encodedauth)
         auth_string = "Basic %s" % encodedauth
         self.additionalHeaders["Authorization"] = auth_string
@@ -568,7 +567,7 @@ class JSONRequests(Requests):
         if data:
             decoder = JSONDecoder()
             thunker = JSONThunker()
-            if sys.version_info[0] == 3:
+            if PY3:
                 data = decodeBytesToUnicode(data)
             data = decoder.decode(data)
             unthunked = thunker.unthunk(data)

--- a/src/python/WMCore/Wrappers/JsonWrapper/JSONThunker.py
+++ b/src/python/WMCore/Wrappers/JsonWrapper/JSONThunker.py
@@ -2,9 +2,11 @@ from __future__ import print_function
 
 from builtins import str, bytes, int
 from future.utils import viewitems
+from Utils.PythonVersion import PY2
 
 import sys
 import types
+
 
 class _EmptyClass(object):
     pass
@@ -264,7 +266,7 @@ class JSONThunker(object):
         """
         _unthunk - does the actual work for unthunk
         """
-        if type(jsondata) is str:
+        if PY2 and type(jsondata) is str:
             return jsondata.encode("utf-8")
         if type(jsondata) is dict:
             if 'thunker_encoded_json' in jsondata:

--- a/test/python/WMCore_t/Cache_t/GenericDataCache_t.py
+++ b/test/python/WMCore_t/Cache_t/GenericDataCache_t.py
@@ -10,6 +10,7 @@ import time
 from WMCore.Cache.GenericDataCache import GenericDataCache, CacheExistException, \
                           CacheWithWrongStructException, MemoryCacheStruct
 
+from Utils.PythonVersion import PY3
 
 class Foo(object):
     pass
@@ -58,7 +59,7 @@ class GenericDataCacheTest(unittest.TestCase):
         mc2 = MemoryCacheStruct(0, lambda x: x, {}, kwargs={'x': {'one':1, 'two':2}})
         self.assertEqual(mc2.data, {})
         after = mc2.getData()
-        self.assertItemsEqual(after.keys(), ['one', 'two'])
+        self.assertCountEqual(after.keys(), ['one', 'two']) if PY3 else self.assertItemsEqual(after.keys(), ['one', 'two'])
 
         return
 

--- a/test/python/WMCore_t/Database_t/CMSCouch_t.py
+++ b/test/python/WMCore_t/Database_t/CMSCouch_t.py
@@ -17,6 +17,8 @@ import time
 from WMCore.Database.CMSCouch import (CouchServer, Document, Database,
                         CouchInternalServerError, CouchNotFoundError)
 
+from Utils.Utilities import encodeUnicodeToBytes
+
 class CMSCouchTest(unittest.TestCase):
 
     test_counter = 0
@@ -176,7 +178,7 @@ class CMSCouchTest(unittest.TestCase):
         attachment4 = "Lovely weather we're having"
         attachment5 = "Goodbye"
         keyhash = hashlib.md5()
-        keyhash.update(attachment5)
+        keyhash.update(encodeUnicodeToBytes(attachment5))
         attachment5_md5 = keyhash.digest()
         attachment5_md5 = base64.b64encode(attachment5_md5)
         attachment6 = "Good day to you, sir!"

--- a/test/python/WMCore_t/Lexicon_t.py
+++ b/test/python/WMCore_t/Lexicon_t.py
@@ -845,6 +845,10 @@ class LexiconTest(unittest.TestCase):
         self.assertEqual(result, 'T2_US_Florida')
 
     def testGetIterMatchObjectOnRegex(self):
+        logPath = os.path.join(getTestBase(), "WMCore_t/test_empty.log")
+        for mo in getIterMatchObjectOnRegexp(logPath, WMEXCEPTION_REGEXP):
+            pass
+
         count = 0
         ecount = 0
         logPath = os.path.join(getTestBase(), "WMCore_t/test_condor.log")

--- a/test/python/WMCore_t/Services_t/Requests_t.py
+++ b/test/python/WMCore_t/Services_t/Requests_t.py
@@ -181,7 +181,7 @@ class testJSONRequests(unittest.TestCase):
     def roundTripLax(self, data):
         encoded = self.request.encode(data)
         decoded = self.request.decode(encoded)
-        datakeys = data.keys()
+        datakeys = list(data.keys())
 
         for k in decoded.keys():
             assert k in datakeys
@@ -351,7 +351,6 @@ class TestRequests(unittest.TestCase):
         out = req.makeRequest('/', decoder=False)
         self.assertEqual(out[3], False)
         self.assertTrue('html' in out[0])
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/WMCore_t/WMException_py2py3_t.py
+++ b/test/python/WMCore_t/WMException_py2py3_t.py
@@ -42,14 +42,20 @@ class WMExceptionTest(unittest.TestCase):
             'key-ascii-d': bytes('√@ʟυℯ-1', 'utf-8'),    # unicode (ascii): bytes (of non-ascii)
             'ḱℯƴ-unicode-a': 'ṽ@łυ℮-2',   # unicode (non-ascii): unicode (non-ascii)
             u'ḱℯƴ-unicode-b': 'ṽ@łυ℮-2',  # unicode (non-ascii): unicode (non-ascii)
-            bytes('ḱℯƴ-unicode-c', 'utf-8'): 'ṽ@łυ℮-2',  # bytes (of non-ascii): unicode (non-ascii)
             'ḱℯƴ-unicode-d': 'value-\x95',  # unicode (of non-ascii): unicode (invalid byte)
             'key-\x95': 'ṽ@łυ℮-2',  # unicode (invalid byte): unicode (non-ascii)
             'key3': 3.14159,
+
+            # The following line breaks py3 with
+            #   TypeError: addInfo() keywords must be strings
+            #   when using exception.addInfo(**data)
+            # 'ḱℯƴ-unicode-c'.encode('utf-8'): 'ṽ@łυ℮-2',  # bytes (of non-ascii): unicode (non-ascii)
+
             # This would break WMException, but should not happen
             # 'key4': {
             #     b'ḱℯƴ-unicode-c': 'ṽ@łυ℮-2',  # bytes (of unicode): unicode
             # }
+
             }
 
     def tearDown(self):
@@ -94,7 +100,10 @@ class WMExceptionTest(unittest.TestCase):
         self.logger.debug("String version of exception: %s", str(exception))
         self.logger.debug("exception.__str__(): %s", type(exception.__str__()))  # from py2 interpreter: <class 'future.types.newbytes.newbytes'>
         self.logger.debug("str(exception): %s", type(str(exception)))  # <class 'future.types.newstr.newstr'>
-        self.logger.debug("bytes(exception): %s", type(bytes(exception)))  # <class 'future.types.newbytes.newbytes'>
+
+        # The following line breaks python3 with
+        #   in __getitem__; return self.data[key]; KeyError: 0
+        # self.logger.debug("bytes(exception): %s", type(bytes(exception)))  # <class 'future.types.newbytes.newbytes'>
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix #10528

#### Status
Ready

#### Related PRs
This is the first of a (hopefully not too long) series of PRs for closing #10422 .

This is a followup of #9818 

#### Description

##### open questions

`Lexicon.py`
- [ ] we load log files in memory, then we scan them looking for patterns
https://github.com/dmwm/WMCore/blob/50f6097838bd5b6591551fe9b006e06086083af5/src/python/WMCore/Lexicon.py#L728-L737
  - we use [mmap](https://docs.python.org/3/library/mmap.html) to load the file, which behaves like a stream of bytes.  However, we expect to extract native strings (bytes in py2, unicode in py3) from the logs https://github.com/dmwm/WMCore/blob/50f6097838bd5b6591551fe9b006e06086083af5/test/python/WMCore_t/Lexicon_t.py#L873
  - is it there any reason for using `mmap`? can we use a `io.StringIO` buffer in py3? is it enough to use the std lib to load the fle to memory? I opted for the latter option (std library file `.read()`)

##### comments

The py3 unittests that fail are either changes from error to failure and vice versa (not really a problem now, i guess) or unstable unittests. Some of these instabilities derive from the fact that we take for granted the order of some lists in the unittest itself, so they should be easy to fix. Some other are a bit more tricky to fix. In any case, we list there the list of unstable unittests in python3 at [this page](https://github.com/dmwm/WMCore/wiki/setup-wmcore-unittest#unstable-tests-in-py3) of the dmwm/WMCore documentation.


Summary of the changes, grouped by file.

`src/python/WMCore/Database/CMSCouch.py`
- [x] Changed internal working of `Database.addAttachment`. The problem arises from `base64.b64encode()` that returns bytes in both py2 and py3 -> this does not allow the use of "native string" approach. we had to decode its result to unicode only in py3. We decided to change `CMSCouch` in such a way that `CMSCouch_t` required no change, so that all the code that calls `CMSCouch` does not need to do the decoding in py3 and need no change.

WMExceptions_t
- [x] commented some lines, because
  - in python3 keywords of function arguments must be (unicode) strings. bytes are not allowed.
  - `bytes(my_exception)` unexpectedly calls `exception__getitem__()`
  - no impact on our code, just updated the unittest, so that the WMException API has a py3-compatible showcase
 
JSONThunker
- [x] in `_unthunk`, convert unicode to bytes only in py2

`src/python/WMCore/Services/Requests.py`
- [x] `Requests.decodeResult` now decodes bytes strings to unicode in py3. The effect is that `Requests.makeRequest`'s first return value now is a unicode string, as expected by unittest https://github.com/dmwm/WMCore/blob/50f6097838bd5b6591551fe9b006e06086083af5/test/python/WMCore_t/Services_t/Requests_t.py#L353
  - make sure to communicate this change in the API for CRAB and others that use this module.

WMConfigCache
- [x] in PY3, `ConfigCache.addConfig()` stores the string that holds the config file as a unicode string, and not as a bytes string

#### Is it backward compatible (if not, which system it affects?)
Yes

#### External dependencies / deployment changes
nope
