### PR TITLE
Fix missing exceptions module in python3

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/Oracle/ListRunsWorkflow.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/ListRunsWorkflow.py
@@ -8,7 +8,6 @@ For a given workflow, list the processed runs according to DBSBUFFER tables
 from future.utils import viewvalues
 
 import threading
-import exceptions
 
 from WMCore.Database.DBFormatter import DBFormatter
 

--- a/src/python/WMCore/Services/DBS/ProdException.py
+++ b/src/python/WMCore/Services/DBS/ProdException.py
@@ -8,9 +8,14 @@ General Exception class for Prod modules
 
 from future.utils import viewitems
 
-import exceptions
+try:
+    import exceptions
+except ImportError:
+    import builtins as exceptions
+
 import inspect
 import logging
+
 
 class ProdException(exceptions.Exception):
     """

--- a/src/python/WMCore/WMSpec/Makers/Handlers/MakeJob.py
+++ b/src/python/WMCore/WMSpec/Makers/Handlers/MakeJob.py
@@ -11,7 +11,6 @@ __all__ = []
 from WMCore.Agent.BaseHandler import BaseHandler
 from WMCore.ThreadPool.ThreadPool import ThreadPool
 
-import exceptions
 import threading
 
 

--- a/src/python/WMCore/WMSpec/Makers/Handlers/MakeJobSlave.py
+++ b/src/python/WMCore/WMSpec/Makers/Handlers/MakeJobSlave.py
@@ -26,7 +26,6 @@ from WMCore.WMSpec.Makers.Interface.CreateWorkArea import CreateWorkArea
 import os
 import string
 import logging
-import exceptions
 import time
 import threading
 


### PR DESCRIPTION
Fixes #10513 

#### Status
ready

#### Description
In python3 there is no `exception` module, but `Exception` class is part of the `builtins` module itself. So in order to fix the issue without changing the code the easiest way is to import `builtins` as `exceptions` in `python3`  

p.s. Once this issue has been overcome I have faced another one with the Rucio client. For which a separate issue is about to be created.

#### Is it backward compatible (if not, which system it affects?)
YES 

#### Related PRs

#### External dependencies / deployment changes
