### PR TITLE
Fix problem when creating T0 processes

### DIFF
--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -127,33 +127,23 @@ class SetupCMSSWPset(ScriptInterface):
         """
 
         procScript = "cmssw_wm_create_process.py"
-
-        processDic = {"scenario": scenario}
-        processJson = os.path.join(self.stepSpace.location, "process_scenario.json")
         funcArgsJson = os.path.join(self.stepSpace.location, "process_funcArgs.json")
 
-        if funcName == "merge" or funcName == "repack":
-            try:
-                with open(funcArgsJson, 'wb') as f:
-                    json.dump(funcArgs, f)
-            except Exception as ex:
-                self.logger.exception("Error writing out process funcArgs json")
-                raise ex
-            funcArgsParam = funcArgsJson
-        else:
-            try:
-                with open(processJson, 'wb') as f:
-                    json.dump(processDic, f)
-            except Exception as ex:
-                self.logger.exception("Error writing out process scenario json")
-                raise ex
-            funcArgsParam = processJson
+        if funcName not in ("merge", "repack"):
+            funcArgs['scenario'] = scenario
+
+        try:
+            with open(funcArgsJson, 'wb') as f:
+                json.dump(funcArgs, f)
+        except Exception as ex:
+            self.logger.exception("Error writing out process funcArgs json")
+            raise ex
 
         cmd = "%s --output_pkl %s --funcname %s --funcargs %s" % (
             procScript,
             os.path.join(self.stepSpace.location, self.configPickle),
             funcName,
-            funcArgsParam)
+            funcArgsJson)
 
         if funcName == "merge":
             if getattr(self.jobBag, "useErrorDataset", False):


### PR DESCRIPTION
Fixes #10526

#### Status
tested by T0 team 

#### Description
This solution makes sure all arguments are passed in the json expected by the [external script to create processes](https://github.com/cms-sw/cmssw-wm-tools/blob/master/bin/cmssw_wm_create_process.py) in cmssw-wm-tools

#### Is it backward compatible (if not, which system it affects?)
YES 