### PR TITLE
Fix DID existence check in global workqueue

### DIFF
--- a/src/python/WMCore/WorkQueue/Policy/Start/Block.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Block.py
@@ -223,7 +223,7 @@ class Block(StartPolicyInterface):
             return dict()
         # blocks with 0 files in Rucio should be ignored as well
         blockRucio = self.rucio.getDID(didName=blockName, dynamic=False)
-        if not blockRucio['length']:
+        if not blockRucio.get('length'):
             logging.warning("Block %s being rejected for lack of files in Rucio to process", blockName)
             self.badWork.append(blockName)
             return dict()


### PR DESCRIPTION
Fixes #10510

#### Status
not-tested

#### Description
When a DID is not found in Rucio, an empty dictionary is returned. This fixes the way we access the `length` property, such that it defaults to None if not found and the block gets rejected as an input chunk of work.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Complement to https://github.com/dmwm/WMCore/pull/10342

#### External dependencies / deployment changes
none
