### PR TITLE
[py2py3] fix unittests from  WMCore/Algorithms in py3

### DIFF
--- a/src/python/WMCore/Algorithms/SubprocessAlgos.py
+++ b/src/python/WMCore/Algorithms/SubprocessAlgos.py
@@ -17,6 +17,8 @@ import subprocess
 
 from WMCore.Algorithms.Alarm import Alarm, alarmHandler
 from WMCore.WMException      import WMException
+from Utils.Utilities import decodeBytesToUnicode
+from Utils.PythonVersion import PY3
 
 class SubprocessAlgoException(WMException):
     """
@@ -110,6 +112,9 @@ def runCommand(cmd, shell = True, timeout = None):
         pipe = subprocess.Popen(cmd, stdout = subprocess.PIPE,
                                 stderr = subprocess.PIPE, shell = shell)
         stdout, stderr = pipe.communicate()
+        if PY3:
+            stdout = decodeBytesToUnicode(stdout)
+            stderr = decodeBytesToUnicode(stderr)
         returnCode     = pipe.returncode
     except Alarm:
         msg =  "Alarm sounded while running command after %s seconds.\n" % timeout


### PR DESCRIPTION
Fixes #10530

#### Status
Ready

#### Description

`src/python/WMCore/Algorithms/SubprocessAlgos.py`
- [x] `suboprocess.communicate()` returns stdout and stderr as byte strings. In order to keep the interface to `SubProcesAlgo.runCommand` identical in both py2 and py3, we use `decodeBytesToUnicode` in py3 only.

The failing unittests are unstable unittests in py3, as lisetd [at this page](https://github.com/dmwm/WMCore/wiki/setup-wmcore-unittest#unstable-tests-in-py3) of the dmwm/WMCore docs.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
This is a folowup to #10011 

#### External dependencies / deployment changes
nope
