### PR TITLE
[py2py3] fix unittests from  WMCore/Datastructs in py3

### DIFF
--- a/src/python/WMCore/DataStructs/JobPackage.py
+++ b/src/python/WMCore/DataStructs/JobPackage.py
@@ -36,7 +36,7 @@ class JobPackage(WMObject, dict):
 
         Pickle this object and save it to disk.
         """
-        with open(fileName, 'w') as fileHandle:
+        with open(fileName, 'wb') as fileHandle:
             pickle.dump(self, fileHandle, -1)
         return
 
@@ -47,7 +47,7 @@ class JobPackage(WMObject, dict):
         Load a pickled JobPackage object.
         """
         self.clear()
-        with open(fileName, 'r') as fileHandle:
+        with open(fileName, 'rb') as fileHandle:
             loadedJobPackage = pickle.load(fileHandle)
         self.update(loadedJobPackage)
         return

--- a/src/python/WMCore/DataStructs/Run.py
+++ b/src/python/WMCore/DataStructs/Run.py
@@ -49,13 +49,24 @@ class Run(WMObject):
 
     def __lt__(self, rhs):
         """
-        Compare on run # first, then by lumis as a list is compared
+        Compare on run # first, then by lumis as a list, then by events in each lumi
         """
+        # check run number
         if self.run != rhs.run:
             return self.run < rhs.run
+        # if same run number, check list of lumi sections
         if sorted(self.eventsPerLumi.keys()) != sorted(rhs.eventsPerLumi.keys()):
             return sorted(self.eventsPerLumi.keys()) < sorted(rhs.eventsPerLumi.keys())
-        return self.eventsPerLumi < rhs.eventsPerLumi
+        # if same list of lumis, check events in each lumi section
+        for lumiNumber in sorted(self.eventsPerLumi):
+            if self.eventsPerLumi[lumiNumber] == rhs.eventsPerLumi.get(lumiNumber):
+                continue
+            else: 
+                return self.eventsPerLumi[lumiNumber] < rhs.eventsPerLumi.get(lumiNumber)
+        # if same run number, same lumi sections list, 
+        # same events in each lumi section:
+        # then the runs are equal and __lt__ should return false
+        return False
 
     def __le__(self, other):
         return self.__lt__(other) or self.__eq__(other)

--- a/test/python/WMCore_t/DataStructs_t/Run_t.py
+++ b/test/python/WMCore_t/DataStructs_t/Run_t.py
@@ -102,82 +102,74 @@ class RunTest(unittest.TestCase):
         comparision and sorting
 
         """
+        def cmp_runs(run_x, run_y):
+            return [
+                run_x < run_y, run_x <= run_y,
+                run_x == run_y, run_x != run_y,
+                run_x > run_y, run_x >= run_y,]
+
         run1 = Run(1, 1, 2, 3)
         run2 = Run(2, 4, 5, 6)
         run3 = Run(3, 7, 8, 9)
 
-        runlist = sorted([run2, run3, run1])
-        self.assertEqual(runlist[0], run1)
-        self.assertEqual(runlist[1], run2)
-        self.assertEqual(runlist[2], run3)
-
-        comparisons_0 = [
-            run1 < run2, run1 <= run2,
-            run1 == run2, run1 != run2,
-            run1 > run2, run1 >= run2,
-            ]
-        self.assertListEqual(comparisons_0,
-                             [True, True,
-                              False, True,
-                              False, False])
+        runlist = list(sorted([run2, run3, run1]))
+        self.assertListEqual(runlist, [run1, run2, run3])
+        self.assertListEqual(cmp_runs(run1, run2),
+                             [True, True, False, True, False, False])
 
         run4 = Run(4, 1, 2, 3)
         run5 = Run(4, 4, 5, 6)
         run6 = Run(4, 7, 8, 9)
 
-        runlist = sorted([run5, run6, run4])
-        self.assertEqual(runlist[0], run4)
-        self.assertEqual(runlist[1], run5)
-        self.assertEqual(runlist[2], run6)
+        runlist = list(sorted([run5, run6, run4]))
+        self.assertListEqual(runlist, [run4, run5, run6])
 
-        runlist = sorted([run5, run1, run3, run4, run6, run2])
-        self.assertEqual(runlist[0], run1)
-        self.assertEqual(runlist[1], run2)
-        self.assertEqual(runlist[2], run3)
-        self.assertEqual(runlist[3], run4)
-        self.assertEqual(runlist[4], run5)
-        self.assertEqual(runlist[5], run6)
+        runlist = list(sorted([run5, run1, run3, run4, run6, run2]))
+        self.assertListEqual(runlist, [run1, run2, run3, run4, run5, run6])
 
-        run7 = Run(9, 1, 2, 3)
-        run8 = Run(9, 1, 2, 3)
-        run9 = Run(9, 2)
-        run10 = Run(9, 3, 4, 5)
-        run11 = Run(9, 8, 9, 10)
+        run7  = Run(9, 1, 2)
+        run8  = Run(9, 1, 2, 3)
+        run9  = Run(9, 1, 2, 3)
+        run10 = Run(9, 1, 2, 3, 4)
+        run11 = Run(9, 1, 2, 4)
+        run12 = Run(9, 1, 4)
+        run13 = Run(9, 2)
+        run14 = Run(9, 3, 4, 5)
+        run15 = Run(9, 8, 9, 10)
 
-        runlist = sorted([run10, run8, run11, run7, run9])
-        self.assertEqual(runlist[0], run7)
-        self.assertEqual(runlist[1], run8)
-        self.assertEqual(runlist[2], run9)
-        self.assertEqual(runlist[3], run10)
-        self.assertEqual(runlist[4], run11)
+        runlist = list(sorted([run10, run15, run8,  run11, run13,
+                               run7,  run9,  run14, run12]))
+        self.assertListEqual(runlist,
+                            [run7, run8, run9, run10, run11,
+                             run12, run13, run14, run15])
 
-        comparisons_1 = [
-            run10 < run11, run10 <= run11,
-            run10 == run11, run10 != run11,
-            run10 > run11, run10 >= run11,
-            ]
-        self.assertListEqual(comparisons_1,
-                             [True, True,
-                              False, True,
-                              False, False])
-        comparisons_2_same = [
-            run7 < run7, run7 <= run7,
-            run7 == run7, run7 != run7,
-            run7 > run7, run7 >= run7,
-            ]
-        self.assertListEqual(comparisons_2_same,
-                             [False, True,
-                              True, False,
-                              False, True])
-        comparisons_3_same = [
-            run7 < run8, run7 <= run8,
-            run7 == run8, run7 != run8,
-            run7 > run8, run7 >= run8,
-            ]
-        self.assertListEqual(comparisons_3_same,
-                             [False, True,
-                              True, False,
-                              False, True])
+        self.assertListEqual(cmp_runs(run14, run15),
+                             [True, True, False, True, False, False])
+        self.assertListEqual(cmp_runs(run8, run8),
+                             [False, True, True, False, False, True])
+        self.assertListEqual(cmp_runs(run8, run9),
+                             [False, True, True, False, False, True])
+
+        run20 = Run(666, [(1, 11), (2, 22), (3, 33)])
+        run21 = Run(666, [(1, 11), (2, 22), (3, 33)])
+        run22 = Run(666, [(1, 11), (2, 22), (3, 32)])
+        run23 = Run(666, [(1, 11), (2, 22), (3, 34)])
+        run24 = Run(666, [(1, 11), (2, 21), (3, 33)])
+        run25 = Run(666, [(1, 11), (2, 21), (3, 34)])
+        run26 = Run(666, [(1, 11), (2, 23), (3, 32)])
+
+        self.assertListEqual(cmp_runs(run20, run21),
+                             [False, True, True, False, False, True])
+        self.assertListEqual(cmp_runs(run20, run22),
+                             [False, False, False, True, True, True])
+        self.assertListEqual(cmp_runs(run20, run23),
+                             [True, True, False, True, False, False])
+        self.assertListEqual(cmp_runs(run20, run24),
+                             [False, False, False, True, True, True])
+        self.assertListEqual(cmp_runs(run20, run25),
+                             [False, False, False, True, True, True])
+        self.assertListEqual(cmp_runs(run20, run26),
+                             [True, True, False, True, False, False])
 
     def testD(self):
         """

--- a/test/python/WMCore_t/DataStructs_t/WorkUnit_t.py
+++ b/test/python/WMCore_t/DataStructs_t/WorkUnit_t.py
@@ -45,7 +45,7 @@ class WorkUnitTest(unittest.TestCase):
         self.assertEqual(testWorkUnit['last_unit_count'], TEST_LAST_UNIT_COUNT)
         self.assertEqual(testWorkUnit['fileid'], TEST_FILEID)
         self.assertEqual(testWorkUnit['run_lumi'].run, TEST_RUN_NUMBER)
-        self.assertItemsEqual(testWorkUnit['run_lumi'].lumis, [TEST_LUMI])
+        self.assertCountEqual(testWorkUnit['run_lumi'].lumis, [TEST_LUMI]) if PY3 else self.assertItemsEqual(testWorkUnit['run_lumi'].lumis, [TEST_LUMI])
 
         # Test the defaults we did not set
         self.assertEqual(testWorkUnit['retry_count'], 0)
@@ -135,7 +135,7 @@ class WorkUnitTest(unittest.TestCase):
         self.assertEqual(info[2], TEST_LAST_UNIT_COUNT)
         self.assertEqual(info[7], TEST_FILEID)
         self.assertEqual(info[8].run, TEST_RUN_NUMBER)
-        self.assertItemsEqual(info[8].lumis, [TEST_LUMI])
+        self.assertCountEqual(info[8].lumis, [TEST_LUMI]) if PY3 else self.assertItemsEqual(info[8].lumis, [TEST_LUMI])
 
         # Test the defaults we did not set
         self.assertEqual(info[1], 0)


### PR DESCRIPTION
Fixes #10531 

#### Status
In development

#### Description

Changes
- [x] Again, another adjustment to how `WMCore.DataStructs.Run.Run`s are compared (i know that the motivations behind these changes may not be self-evident, I made a comment below with some investigations to justify these changes)
- [x] `pickle.dump()` and `pickle.load()` require the file object to be opened in `bytes` mode also in py3. (`JobPackage.py`)
- [x] minor changes to the unittests (usual `assertItemsEqual` -> `assertCountEqual`))

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
This is a follow-up of #10012 

#### External dependencies / deployment changes
nope
