### PR TITLE
[py2py3] Adapt to renaming of assertItemsEqual to assertCountEqual in py3

### DIFF
--- a/test/python/Utils_t/MemoryCache_t.py
+++ b/test/python/Utils_t/MemoryCache_t.py
@@ -16,53 +16,57 @@ class MemoryCacheTest(unittest.TestCase):
     unittest for MemoryCache functions
     """
 
+    def setUp(self):
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
+
     def testBasics(self):
         cache = MemoryCache(1, [])
-        self.assertCountEqual(cache.getCache(), []) if PY3 else self.assertItemsEqual(cache.getCache(), [])
+        self.assertItemsEqual(cache.getCache(), [])
         cache.setCache(["item1", "item2"])
-        self.assertCountEqual(cache.getCache(), ["item1", "item2"]) if PY3 else self.assertItemsEqual(cache.getCache(), ["item1", "item2"])
+        self.assertItemsEqual(cache.getCache(), ["item1", "item2"])
         # wait for cache to expiry, wait for 2 secs
         sleep(2)
         self.assertRaises(MemoryCacheException, cache.getCache)
         cache.setCache(["item4"])
         # and the cache is alive again
-        self.assertCountEqual(cache.getCache(), ["item4"]) if PY3 else self.assertItemsEqual(cache.getCache(), ["item4"])
+        self.assertItemsEqual(cache.getCache(), ["item4"])
 
     def testCacheSet(self):
         cache = MemoryCache(2, set())
-        self.assertCountEqual(cache.getCache(), set()) if PY3 else self.assertItemsEqual(cache.getCache(), set())
+        self.assertItemsEqual(cache.getCache(), set())
         cache.setCache(set(["item1", "item2"]))
-        self.assertCountEqual(cache.getCache(), ["item1", "item2"]) if PY3 else self.assertItemsEqual(cache.getCache(), ["item1", "item2"])
+        self.assertItemsEqual(cache.getCache(), ["item1", "item2"])
         cache.addItemToCache("item3")
-        self.assertCountEqual(cache.getCache(), ["item1", "item2", "item3"]) if PY3 else self.assertItemsEqual(cache.getCache(), ["item1", "item2", "item3"])
+        self.assertItemsEqual(cache.getCache(), ["item1", "item2", "item3"])
         cache.addItemToCache(["item4"])
-        self.assertCountEqual(cache.getCache(), ["item1", "item2", "item3", "item4"]) if PY3 else self.assertItemsEqual(cache.getCache(), ["item1", "item2", "item3", "item4"])
+        self.assertItemsEqual(cache.getCache(), ["item1", "item2", "item3", "item4"])
         cache.addItemToCache(set(["item5"]))
-        self.assertCountEqual(cache.getCache(), ["item1", "item2", "item3", "item4", "item5"]) if PY3 else self.assertItemsEqual(cache.getCache(), ["item1", "item2", "item3", "item4", "item5"])
+        self.assertItemsEqual(cache.getCache(), ["item1", "item2", "item3", "item4", "item5"])
         self.assertTrue("item2" in cache)
         self.assertFalse("item222" in cache)
 
     def testCacheList(self):
         cache = MemoryCache(2, [])
-        self.assertCountEqual(cache.getCache(), []) if PY3 else self.assertItemsEqual(cache.getCache(), [])
+        self.assertItemsEqual(cache.getCache(), [])
         cache.setCache(["item1", "item2"])
-        self.assertCountEqual(cache.getCache(), ["item1", "item2"]) if PY3 else self.assertItemsEqual(cache.getCache(), ["item1", "item2"])
+        self.assertItemsEqual(cache.getCache(), ["item1", "item2"])
         cache.addItemToCache("item3")
-        self.assertCountEqual(cache.getCache(), ["item1", "item2", "item3"]) if PY3 else self.assertItemsEqual(cache.getCache(), ["item1", "item2", "item3"])
+        self.assertItemsEqual(cache.getCache(), ["item1", "item2", "item3"])
         cache.addItemToCache(["item4"])
-        self.assertCountEqual(cache.getCache(), ["item1", "item2", "item3", "item4"]) if PY3 else self.assertItemsEqual(cache.getCache(), ["item1", "item2", "item3", "item4"])
+        self.assertItemsEqual(cache.getCache(), ["item1", "item2", "item3", "item4"])
         cache.addItemToCache(set(["item5"]))
-        self.assertCountEqual(cache.getCache(), ["item1", "item2", "item3", "item4", "item5"]) if PY3 else self.assertItemsEqual(cache.getCache(), ["item1", "item2", "item3", "item4", "item5"])
+        self.assertItemsEqual(cache.getCache(), ["item1", "item2", "item3", "item4", "item5"])
         self.assertTrue("item2" in cache)
         self.assertFalse("item222" in cache)
 
     def testCacheDict(self):
         cache = MemoryCache(2, {})
-        self.assertCountEqual(cache.getCache(), {}) if PY3 else self.assertItemsEqual(cache.getCache(), {})
+        self.assertItemsEqual(cache.getCache(), {})
         cache.setCache({"item1": 11, "item2": 22})
-        self.assertCountEqual(cache.getCache(), {"item1": 11, "item2": 22}) if PY3 else self.assertItemsEqual(cache.getCache(), {"item1": 11, "item2": 22})
+        self.assertItemsEqual(cache.getCache(), {"item1": 11, "item2": 22})
         cache.addItemToCache({"item3": 33})
-        self.assertCountEqual(cache.getCache(), {"item1": 11, "item2": 22, "item3": 33}) if PY3 else self.assertItemsEqual(cache.getCache(), {"item1": 11, "item2": 22, "item3": 33})
+        self.assertItemsEqual(cache.getCache(), {"item1": 11, "item2": 22, "item3": 33})
         self.assertTrue("item2" in cache)
         self.assertFalse("item222" in cache)
         # test exceptions
@@ -71,7 +75,7 @@ class MemoryCacheTest(unittest.TestCase):
 
     def testSetDiffTypes(self):
         cache = MemoryCache(2, set())
-        self.assertCountEqual(cache.getCache(), set()) if PY3 else self.assertItemsEqual(cache.getCache(), set())
+        self.assertItemsEqual(cache.getCache(), set())
         cache.setCache({"item1", "item2"})
         self.assertRaises(TypeError, cache.setCache, ["item3"])
 

--- a/test/python/WMComponent_t/ErrorHandler_t/ErrorHandler_t.py
+++ b/test/python/WMComponent_t/ErrorHandler_t/ErrorHandler_t.py
@@ -13,6 +13,8 @@ import threading
 import time
 import unittest
 
+from Utils.PythonVersion import PY3
+
 from WMCore_t.WMSpec_t.TestSpec import testWorkload
 from nose.plugins.attrib import attr
 
@@ -69,6 +71,9 @@ class ErrorHandlerTest(EmulatedUnitTestCase):
 
         self.dataCS = DataCollectionService(url=self.testInit.couchUrl,
                                             database="errorhandler_t")
+
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
         return
 

--- a/test/python/WMComponent_t/JobCreator_t/JobCreator_t.py
+++ b/test/python/WMComponent_t/JobCreator_t/JobCreator_t.py
@@ -16,6 +16,8 @@ import threading
 import time
 import unittest
 
+from Utils.PythonVersion import PY3
+
 from WMCore_t.WMSpec_t.TestSpec import testWorkload
 from nose.plugins.attrib import attr
 
@@ -91,6 +93,9 @@ class JobCreatorTest(EmulatedUnitTestCase):
         self.componentName = 'JobCreator'
         self.heartbeatAPI = HeartbeatAPI(self.componentName)
         self.heartbeatAPI.registerComponent()
+
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
         return
 

--- a/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
+++ b/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
@@ -16,6 +16,8 @@ import threading
 import time
 import unittest
 
+from Utils.PythonVersion import PY3
+
 from WMCore_t.WMSpec_t.TestSpec import testWorkload
 from nose.plugins.attrib import attr
 
@@ -82,6 +84,10 @@ class JobSubmitterTest(EmulatedUnitTestCase):
         config = self.getConfig()
         myThread.logdbClient = MockLogDB(config.General.central_logdb_url,
                                          config.Agent.hostName, logger=None)
+
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
+
         return
 
     def tearDown(self):

--- a/test/python/WMComponent_t/RucioInjector_t/RucioInjectorPoller_t.py
+++ b/test/python/WMComponent_t/RucioInjector_t/RucioInjectorPoller_t.py
@@ -8,6 +8,8 @@ from __future__ import division
 import threading
 import unittest
 
+from Utils.PythonVersion import PY3
+
 from WMComponent.DBS3Buffer.DBSBufferBlock import DBSBufferBlock
 from WMComponent.DBS3Buffer.DBSBufferFile import DBSBufferFile
 from WMComponent.RucioInjector.RucioInjectorPoller import RucioInjectorPoller, RucioInjectorException
@@ -50,6 +52,9 @@ class RucioInjectorPollerTest(EmulatedUnitTestCase):
         self.testFilesB = []
         self.testDatasetA = "/SampleA/PromptReco-v1/RECO"
         self.testDatasetB = "/SampleB/CRUZET11-v1/RAW"
+
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
         return
 

--- a/test/python/WMCore_t/ACDC_t/DataCollectionService_t.py
+++ b/test/python/WMCore_t/ACDC_t/DataCollectionService_t.py
@@ -10,6 +10,8 @@ Copyright (c) 2010 Fermilab. All rights reserved.
 from builtins import range
 import unittest
 
+from Utils.PythonVersion import PY3
+
 from nose.plugins.attrib import attr
 
 from WMCore.ACDC.DataCollectionService import DataCollectionService, mergeFilesInfo
@@ -30,6 +32,10 @@ class DataCollectionService_t(unittest.TestCase):
         self.testInit.setSchema(customModules=["WMCore.WMBS"],
                                 useDefault=False)
         self.testInit.setupCouch("wmcore-acdc-datacollectionsvc", "GroupUser", "ACDC")
+
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
+
         return
 
     def tearDown(self):

--- a/test/python/WMCore_t/Agent_t/Heartbeat_t.py
+++ b/test/python/WMCore_t/Agent_t/Heartbeat_t.py
@@ -9,6 +9,8 @@ from __future__ import print_function
 import time
 import unittest
 
+from Utils.PythonVersion import PY3
+
 from WMCore.Agent.HeartbeatAPI import HeartbeatAPI
 from WMQuality.TestInit import TestInit
 
@@ -27,6 +29,9 @@ class HeartbeatTest(unittest.TestCase):
         self.testInit.setDatabaseConnection()
         self.testInit.setSchema(customModules=["WMCore.Agent.Database"],
                                 useDefault=False)
+
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
     def tearDown(self):
         """

--- a/test/python/WMCore_t/BossAir_t/RunJob_t.py
+++ b/test/python/WMCore_t/BossAir_t/RunJob_t.py
@@ -8,6 +8,8 @@ from builtins import range
 import threading
 import unittest
 
+from Utils.PythonVersion import PY3
+
 from WMCore.BossAir.RunJob import RunJob
 from WMCore.DAOFactory import DAOFactory
 from WMCore.ResourceControl.ResourceControl import ResourceControl
@@ -56,7 +58,8 @@ class RunJobTest(unittest.TestCase):
         newuser = wmbsFactory(classname = "Users.New")
         newuser.execute(dn = "mnorman", group_name = "phgroup", role_name = "cmsrole")
 
-
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
     def tearDown(self):
         """

--- a/test/python/WMCore_t/Cache_t/GenericDataCache_t.py
+++ b/test/python/WMCore_t/Cache_t/GenericDataCache_t.py
@@ -7,6 +7,9 @@ from __future__ import print_function, division
 
 import unittest
 import time
+
+from Utils.PythonVersion import PY3
+
 from WMCore.Cache.GenericDataCache import GenericDataCache, CacheExistException, \
                           CacheWithWrongStructException, MemoryCacheStruct
 
@@ -17,6 +20,10 @@ class Foo(object):
 
 
 class GenericDataCacheTest(unittest.TestCase):
+
+    def setUp(self):
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
     def testBasic(self):
         """

--- a/test/python/WMCore_t/DataStructs_t/File_t.py
+++ b/test/python/WMCore_t/DataStructs_t/File_t.py
@@ -12,6 +12,8 @@ Unittest for the WMCore.DataStructs.File class
 
 import unittest
 
+from Utils.PythonVersion import PY3
+
 from WMCore.DataStructs.File import File
 from WMCore.DataStructs.Run import Run
 
@@ -21,6 +23,10 @@ class FileTest(unittest.TestCase):
     _FileTest_
 
     """
+
+    def setUp(self):
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
     def testDefinition(self):
         """

--- a/test/python/WMCore_t/DataStructs_t/WorkUnit_t.py
+++ b/test/python/WMCore_t/DataStructs_t/WorkUnit_t.py
@@ -11,6 +11,8 @@ from __future__ import absolute_import, division, print_function
 import json
 import unittest
 
+from Utils.PythonVersion import PY3
+
 from WMCore.DataStructs.Run import Run
 from WMCore.DataStructs.WorkUnit import WorkUnit
 
@@ -25,6 +27,9 @@ class WorkUnitTest(unittest.TestCase):
     """
     _WorkUnitTest_
     """
+    def setUp(self):
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
     def testWorkUnitDefinitionDefault(self):
         """

--- a/test/python/WMCore_t/FwkJobReport_t/Report_t.py
+++ b/test/python/WMCore_t/FwkJobReport_t/Report_t.py
@@ -14,6 +14,8 @@ import time
 import unittest
 
 from Utils import FileTools
+from Utils.PythonVersion import PY3
+
 from WMCore.Configuration import ConfigSection
 from WMCore.FwkJobReport.Report import Report
 from WMCore.WMBase import getTestBase
@@ -50,6 +52,10 @@ class ReportTest(unittest.TestCase):
         self.noLocationReport = os.path.join(testData, "Report.0.pkl")
 
         self.testDir = self.testInit.generateWorkDir()
+
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
+
         return
 
     def tearDown(self):

--- a/test/python/WMCore_t/JobSplitting_t/EventAwareLumiByWork_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/EventAwareLumiByWork_t.py
@@ -14,6 +14,8 @@ import logging
 import unittest
 from collections import Counter
 
+from Utils.PythonVersion import PY3
+
 from WMCore.DataStructs.File import File
 from WMCore.DataStructs.Fileset import Fileset
 from WMCore.DataStructs.LumiList import LumiList
@@ -44,6 +46,9 @@ class EventAwareLumiByWorkTest(unittest.TestCase):
 
         logging.basicConfig()
         logging.getLogger().setLevel(logging.DEBUG)
+
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
         return
 

--- a/test/python/WMCore_t/MicroService_t/MSManager_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSManager_t.py
@@ -8,6 +8,8 @@ from __future__ import division, print_function
 
 import unittest
 
+from Utils.PythonVersion import PY3
+
 from WMCore.Agent.Configuration import Configuration
 from WMCore.MicroService.MSManager import MSManager
 
@@ -43,6 +45,9 @@ class MSManagerTest(unittest.TestCase):
         data.limitRequestsPerCycle = 50
         data.enableDataTransfer = True
         self.mgr_trans = MSManager(data)
+
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
     def tearDown(self):
         "Tear down MSManager"

--- a/test/python/WMCore_t/MicroService_t/MSOutput_t/MSOutputTemplate_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSOutput_t/MSOutputTemplate_t.py
@@ -8,6 +8,8 @@ from copy import deepcopy
 
 from builtins import range
 
+from Utils.PythonVersion import PY3
+
 from WMCore.MicroService.MSOutput.MSOutputTemplate import MSOutputTemplate
 
 
@@ -87,6 +89,10 @@ class MSOutputTemplateTest(unittest.TestCase):
 
     outputMapKeys = ["Campaign", "Copies", "Dataset", "DatasetSize", "DiskDestination",
                      "DiskRuleID", "TapeDestination", "TapeRuleID"]
+
+    def setUp(self):
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
     def testTaskChainSpec(self):
         """

--- a/test/python/WMCore_t/MicroService_t/MSTransferor_t/MSTransferor_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSTransferor_t/MSTransferor_t.py
@@ -11,6 +11,7 @@ import os
 import unittest
 
 # WMCore modules
+from Utils.PythonVersion import PY3
 from WMCore.MicroService.MSTransferor.MSTransferor import MSTransferor
 from WMQuality.Emulators.EmulatedUnitTestCase import EmulatedUnitTestCase
 
@@ -48,6 +49,8 @@ class TransferorTest(EmulatedUnitTestCase):
         self.taskChainTempl = getTestFile('data/ReqMgr/requests/Integration/TaskChain_Prod.json')
         self.stepChainTempl = getTestFile('data/ReqMgr/requests/Integration/SC_LumiMask_PhEDEx.json')
         super(TransferorTest, self).setUp()
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
     def testGetPNNsFromPSNs(self):
         """Test MSTransferor private method _getPNNsFromPSNs()"""

--- a/test/python/WMCore_t/MicroService_t/MSTransferor_t/Workflow_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSTransferor_t/Workflow_t.py
@@ -5,6 +5,8 @@ from __future__ import division, print_function
 
 import unittest
 
+from Utils.PythonVersion import PY3
+
 from WMCore.MicroService.MSTransferor.Workflow import Workflow
 
 
@@ -12,6 +14,10 @@ class WorkflowTest(unittest.TestCase):
     """
     Test the very basic functionality of the Workflow module
     """
+
+    def setUp(self):
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
     def testCampaignMap(self):
         """

--- a/test/python/WMCore_t/MicroService_t/Tools_t/PycurlRucio_t.py
+++ b/test/python/WMCore_t/MicroService_t/Tools_t/PycurlRucio_t.py
@@ -7,6 +7,8 @@ from builtins import str
 
 import unittest
 
+from Utils.PythonVersion import PY3
+
 from WMCore.MicroService.Tools.PycurlRucio import (getRucioToken, parseNewLineJson,
                                                    getPileupContainerSizesRucio, listReplicationRules,
                                                    getBlocksAndSizeRucio, stringDateToEpoch)
@@ -28,6 +30,8 @@ class PycurlRucioTests(unittest.TestCase):
         self.rucioScope = "cms"
         #self.rucioToken, self.tokenValidity = getRucioToken(self.rucioAuthUrl, self.rucioAccount)
         self.badDID = "/wrong/did/name"
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
     def testParseNewLineJson(self):
         """

--- a/test/python/WMCore_t/ReqMgr_t/DataStructs_t/Request_t.py
+++ b/test/python/WMCore_t/ReqMgr_t/DataStructs_t/Request_t.py
@@ -8,6 +8,8 @@ from __future__ import division, print_function
 import unittest
 from copy import deepcopy
 
+from Utils.PythonVersion import PY3
+
 from WMCore.ReqMgr.DataStructs.Request import initialize_clone, RequestInfo
 from WMCore.WMSpec.StdSpecs.ReReco import ReRecoWorkloadFactory
 from WMCore.WMSpec.StdSpecs.StepChain import StepChainWorkloadFactory
@@ -56,6 +58,10 @@ class RequestTests(unittest.TestCase):
     """
     unittest for ReqMgr DataStructs Request functions.
     """
+
+    def setUp(self):
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
     def testInvalidKeys_initialize_clone(self):
         """

--- a/test/python/WMCore_t/ReqMgr_t/Service_t/Auxiliary_t.py
+++ b/test/python/WMCore_t/ReqMgr_t/Service_t/Auxiliary_t.py
@@ -11,6 +11,8 @@ from http.client import HTTPException
 from WMCore_t.ReqMgr_t.TestConfig import config
 from nose.plugins.attrib import attr
 
+from Utils.PythonVersion import PY3
+
 import WMCore
 from WMQuality.REST.RESTBaseUnitTestWithDBBackend import RESTBaseUnitTestWithDBBackend
 
@@ -23,6 +25,8 @@ class AuxiliaryTest(RESTBaseUnitTestWithDBBackend):
                           (config.views.data.couch_reqmgr_aux_db, "ReqMgrAux")])
         self.setSchemaModules([])
         RESTBaseUnitTestWithDBBackend.setUp(self)
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
     def tearDown(self):
         RESTBaseUnitTestWithDBBackend.tearDown(self)

--- a/test/python/WMCore_t/Services_t/CRIC_t/CRIC_t.py
+++ b/test/python/WMCore_t/Services_t/CRIC_t/CRIC_t.py
@@ -8,6 +8,8 @@ import unittest
 
 from nose.plugins.attrib import attr
 
+from Utils.PythonVersion import PY3
+
 from WMCore.Services.CRIC.CRIC import CRIC
 from WMQuality.Emulators.EmulatedUnitTestCase import EmulatedUnitTestCase
 
@@ -26,6 +28,8 @@ class CRICTest(EmulatedUnitTestCase):
         """
         super(CRICTest, self).setUp()
         self.myCRIC = CRIC()
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
     def testConfig(self):
         """

--- a/test/python/WMCore_t/Services_t/DBS_t/DBSReader_t.py
+++ b/test/python/WMCore_t/Services_t/DBS_t/DBSReader_t.py
@@ -7,6 +7,8 @@ Unit test for the DBS helper class.
 
 import unittest
 
+from Utils.PythonVersion import PY3
+
 from WMCore.Services.DBS.DBS3Reader import getDataTiers, DBS3Reader as DBSReader
 from WMCore.Services.DBS.DBSErrors import DBSReaderError
 from WMQuality.Emulators.EmulatedUnitTestCase import EmulatedUnitTestCase
@@ -36,6 +38,8 @@ class DBSReaderTest(EmulatedUnitTestCase):
         self.endpoint = 'https://cmsweb-prod.cern.ch/dbs/prod/global/DBSReader'
         self.dbs = None
         super(DBSReaderTest, self).setUp()
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
         return
 
     def tearDown(self):

--- a/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
+++ b/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
@@ -12,6 +12,8 @@ import os
 from nose.plugins.attrib import attr
 from rucio.client import Client as testClient
 
+from Utils.PythonVersion import PY3
+
 from WMCore.Services.Rucio import Rucio
 from WMQuality.Emulators.EmulatedUnitTestCase import EmulatedUnitTestCase
 
@@ -74,6 +76,8 @@ class RucioTest(EmulatedUnitTestCase):
                                  auth_type=self.defaultArgs['auth_type'],
                                  creds=self.defaultArgs['creds'],
                                  timeout=self.defaultArgs['timeout'])
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
     def tearDown(self):
         """

--- a/test/python/WMCore_t/Services_t/TagCollector_t/XMLUtils_t.py
+++ b/test/python/WMCore_t/Services_t/TagCollector_t/XMLUtils_t.py
@@ -7,6 +7,8 @@ from __future__ import division, print_function
 
 import unittest
 
+from Utils.PythonVersion import PY3
+
 from WMCore.Services.TagCollector.XMLUtils import xml_parser
 
 
@@ -14,6 +16,10 @@ class XMLUtilsTest(unittest.TestCase):
     """
     unittest for XMLUtils functions
     """
+
+    def setUp(self):
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
     def testParser(self):
         """

--- a/test/python/WMCore_t/Services_t/WMStats_t/DataStructs_t/RequestInfoCollection_t.py
+++ b/test/python/WMCore_t/Services_t/WMStats_t/DataStructs_t/RequestInfoCollection_t.py
@@ -8,6 +8,8 @@ import unittest
 
 from future.utils import viewvalues
 
+from Utils.PythonVersion import PY3
+
 from WMCore.Services.WMStats.DataStruct.RequestInfoCollection import (JobSummary, ProgressSummary,
                                                                       TaskInfo, RequestInfo)
 
@@ -28,6 +30,10 @@ class DummyTask(object):
 
 
 class MyTestCase(unittest.TestCase):
+
+    def setUp(self):
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
     def testJobSummary(self):
         """some very basic unit tests for the JobSummary class"""

--- a/test/python/WMCore_t/Services_t/WorkQueue_t/WorkQueue_t.py
+++ b/test/python/WMCore_t/Services_t/WorkQueue_t/WorkQueue_t.py
@@ -3,6 +3,8 @@ from __future__ import print_function, division
 import unittest
 import time
 
+from Utils.PythonVersion import PY3
+
 from WMCore.WorkQueue.WorkQueue import globalQueue
 from WMCore.WorkQueue.WorkQueue import localQueue
 from WMCore.Services.WorkQueue.WorkQueue import WorkQueue as WorkQueueDS
@@ -49,6 +51,9 @@ class WorkQueueTest(EmulatedUnitTestCase):
         self.queueParams['rucioAccount'] = "wma_test"
         self.queueParams['rucioAuthUrl'] = "http://cmsrucio-int.cern.ch"
         self.queueParams['rucioUrl'] = "https://cmsrucio-auth-int.cern.ch"
+
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
     def tearDown(self):
         """

--- a/test/python/WMCore_t/WMBS_t/File_t.py
+++ b/test/python/WMCore_t/WMBS_t/File_t.py
@@ -9,6 +9,8 @@ import logging
 import threading
 import unittest
 
+from Utils.PythonVersion import PY3
+
 from WMCore.DAOFactory import DAOFactory
 from WMCore.DataStructs.File import File as WMFile
 from WMCore.DataStructs.Run import Run
@@ -44,6 +46,9 @@ class FileTest(unittest.TestCase):
         locationAction = self.daofactory(classname="Locations.New")
         locationAction.execute(siteName="site1", pnn="T1_US_FNAL_Disk")
         locationAction.execute(siteName="site2", pnn="T2_CH_CERN")
+
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
         return
 

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/EventAwareLumiByWork_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/EventAwareLumiByWork_t.py
@@ -13,6 +13,8 @@ import threading
 import unittest
 from collections import Counter
 
+from Utils.PythonVersion import PY3
+
 from WMCore.DAOFactory import DAOFactory
 from WMCore.DataStructs.LumiList import LumiList
 from WMCore.DataStructs.Run import Run
@@ -62,6 +64,9 @@ class EventAwareLumiByWorkTest(unittest.TestCase):
         # dummy workflow
         self.testWorkflow = Workflow(spec="spec.xml", owner="dmwm", name="testWorkflow", task="Test")
         self.testWorkflow.create()
+
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
         return
 

--- a/test/python/WMCore_t/WMRuntime_t/Tools_t/Scram_t.py
+++ b/test/python/WMCore_t/WMRuntime_t/Tools_t/Scram_t.py
@@ -10,8 +10,10 @@ Copyright (c) 2012 evansde77. All rights reserved.
 import unittest
 import os
 import tempfile
+
 from WMQuality.TestInit import TestInit
 from Utils.TemporaryEnvironment import tmpEnv
+from Utils.PythonVersion import PY3
 from WMCore.WMRuntime.Tools.Scram import (Scram, OS_TO_ARCH, ARCH_TO_OS, getSingleScramArch,
                                           isCMSSWSupported, isEnforceGUIDInFileNameSupported)
 
@@ -22,6 +24,8 @@ class Scram_t(unittest.TestCase):
         self.testInit.setLogging()
         self.testDir = self.testInit.generateWorkDir()
         self.oldCwd = os.getcwd()
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
     def tearDown(self):
         self.testInit.delWorkDir()

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/DQMHarvest_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/DQMHarvest_t.py
@@ -9,6 +9,8 @@ import os
 import threading
 import unittest
 
+from Utils.PythonVersion import PY3
+
 from WMCore.DAOFactory import DAOFactory
 from WMCore.Database.CMSCouch import CouchServer, Document
 from WMCore.WMSpec.StdSpecs.DQMHarvest import DQMHarvestWorkloadFactory
@@ -77,7 +79,8 @@ class DQMHarvestTests(EmulatedUnitTestCase):
         self.listTasksByWorkflow = self.daoFactory(classname="Workflow.LoadFromName")
         self.listFilesets = self.daoFactory(classname="Fileset.List")
         self.listSubsMapping = self.daoFactory(classname="Subscriptions.ListSubsAndFilesetsFromWorkflow")
-
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
         return
 
     def tearDown(self):

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Express_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Express_t.py
@@ -12,6 +12,8 @@ import threading
 import unittest
 from copy import deepcopy
 
+from Utils.PythonVersion import PY3
+
 from WMCore.DAOFactory import DAOFactory
 from WMCore.WMBS.Fileset import Fileset
 from WMCore.WMBS.Subscription import Subscription
@@ -76,7 +78,8 @@ class ExpressTest(unittest.TestCase):
         self.listTasksByWorkflow = self.daoFactory(classname="Workflow.LoadFromName")
         self.listFilesets = self.daoFactory(classname="Fileset.List")
         self.listSubsMapping = self.daoFactory(classname="Subscriptions.ListSubsAndFilesetsFromWorkflow")
-
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
         return
 
     def tearDown(self):

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/PromptReco_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/PromptReco_t.py
@@ -13,6 +13,8 @@ import os
 import threading
 import unittest
 
+from Utils.PythonVersion import PY3
+
 from WMCore.Configuration import ConfigSection
 from WMCore.DAOFactory import DAOFactory
 from WMCore.Database.CMSCouch import CouchServer
@@ -49,7 +51,8 @@ class PromptRecoTest(unittest.TestCase):
         self.listFilesets = self.daoFactory(classname="Fileset.List")
         self.listSubsMapping = self.daoFactory(classname="Subscriptions.ListSubsAndFilesetsFromWorkflow")
         self.promptSkim = None
-
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
         return
 
     def tearDown(self):

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/ReReco_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/ReReco_t.py
@@ -11,6 +11,8 @@ import os
 import threading
 import unittest
 
+from Utils.PythonVersion import PY3
+
 from WMCore.DAOFactory import DAOFactory
 from WMCore.Database.CMSCouch import CouchServer, Document
 from WMCore.WMBS.Fileset import Fileset
@@ -46,7 +48,8 @@ class ReRecoTest(unittest.TestCase):
         self.listTasksByWorkflow = self.daoFactory(classname="Workflow.LoadFromName")
         self.listFilesets = self.daoFactory(classname="Fileset.List")
         self.listSubsMapping = self.daoFactory(classname="Subscriptions.ListSubsAndFilesetsFromWorkflow")
-
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
         return
 
     def tearDown(self):

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Repack_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Repack_t.py
@@ -12,6 +12,8 @@ import threading
 import unittest
 from copy import deepcopy
 
+from Utils.PythonVersion import PY3
+
 from WMCore.DAOFactory import DAOFactory
 from WMCore.WMBS.Fileset import Fileset
 from WMCore.WMBS.Subscription import Subscription
@@ -67,7 +69,8 @@ class RepackTests(unittest.TestCase):
         self.listTasksByWorkflow = self.daoFactory(classname="Workflow.LoadFromName")
         self.listFilesets = self.daoFactory(classname="Fileset.List")
         self.listSubsMapping = self.daoFactory(classname="Subscriptions.ListSubsAndFilesetsFromWorkflow")
-
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
         return
 
     def tearDown(self):

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
@@ -17,6 +17,8 @@ import unittest
 from copy import deepcopy
 from hashlib import md5
 
+from Utils.PythonVersion import PY3
+
 from WMCore.DAOFactory import DAOFactory
 from WMCore.DataStructs.Mask import Mask
 from WMCore.Database.CMSCouch import CouchServer, Document
@@ -230,7 +232,8 @@ class StepChainTests(EmulatedUnitTestCase):
         self.listTasksByWorkflow = self.daoFactory(classname="Workflow.LoadFromName")
         self.listFilesets = self.daoFactory(classname="Fileset.List")
         self.listSubsMapping = self.daoFactory(classname="Subscriptions.ListSubsAndFilesetsFromWorkflow")
-
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
         return
 
     def tearDown(self):

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StoreResults_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StoreResults_t.py
@@ -10,6 +10,8 @@ from future.utils import viewitems
 import threading
 import unittest
 
+from Utils.PythonVersion import PY3
+
 from WMCore.DAOFactory import DAOFactory
 from WMCore.WMBS.Fileset import Fileset
 from WMCore.WMBS.Subscription import Subscription
@@ -40,7 +42,8 @@ class StoreResultsTest(unittest.TestCase):
         self.listTasksByWorkflow = self.daoFactory(classname="Workflow.LoadFromName")
         self.listFilesets = self.daoFactory(classname="Fileset.List")
         self.listSubsMapping = self.daoFactory(classname="Subscriptions.ListSubsAndFilesetsFromWorkflow")
-
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
         return
 
     def tearDown(self):

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
@@ -20,6 +20,8 @@ import unittest
 from copy import deepcopy
 from hashlib import md5
 
+from Utils.PythonVersion import PY3
+
 from WMCore.DAOFactory import DAOFactory
 from WMCore.DataStructs.Mask import Mask
 from WMCore.Database.CMSCouch import CouchServer, Document
@@ -453,7 +455,8 @@ class TaskChainTests(EmulatedUnitTestCase):
         self.listTasksByWorkflow = self.daoFactory(classname="Workflow.LoadFromName")
         self.listFilesets = self.daoFactory(classname="Fileset.List")
         self.listSubsMapping = self.daoFactory(classname="Subscriptions.ListSubsAndFilesetsFromWorkflow")
-
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
         return
 
     def tearDown(self):

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Fetchers_t/PileupFetcher_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Fetchers_t/PileupFetcher_t.py
@@ -12,6 +12,8 @@ import os
 import unittest
 from json import JSONDecoder
 
+from Utils.PythonVersion import PY3
+
 import WMCore.WMSpec.WMStep as WMStep
 import WMCore.WMSpec.WMTask as WMTask
 from WMCore.Database.CMSCouch import CouchServer, Document
@@ -43,6 +45,8 @@ class PileupFetcherTest(EmulatedUnitTestCase):
         self.configDatabase = couchServer.connectDatabase("pileupfetcher_t")
         self.testDir = self.testInit.generateWorkDir()
         self.rucioAcct = "wmcore_transferor"
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
     def tearDown(self):
         """

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Templates_t/CMSSWTemplate_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Templates_t/CMSSWTemplate_t.py
@@ -9,6 +9,8 @@ Copyright (c) 2010 Fermilab. All rights reserved.
 
 import unittest
 
+from Utils.PythonVersion import PY3
+
 from WMCore.WMSpec.Steps.Templates.CMSSW import CMSSW as CMSSWTemplate
 from WMCore.WMSpec.WMWorkload import newWorkload
 from WMCore.WMSpec.WMStep import makeWMStep
@@ -22,6 +24,9 @@ class CMSSWTemplateTest(unittest.TestCase):
     Tests the helper methods
 
     """
+    def setUp(self):
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
     def testA(self):
         """

--- a/test/python/WMCore_t/WMSpec_t/WMTask_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMTask_t.py
@@ -9,6 +9,8 @@ from future.utils import viewitems
 
 import unittest
 
+from Utils.PythonVersion import PY3
+
 import WMCore.WMSpec.Steps.StepFactory as StepFactory
 from WMCore.DataStructs.LumiList import LumiList
 from WMCore.WMSpec.WMStep import makeWMStep
@@ -18,7 +20,8 @@ from WMCore.WMSpec.WMWorkloadTools import parsePileupConfig
 
 class WMTaskTest(unittest.TestCase):
     def setUp(self):
-        pass
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
     def tearDown(self):
         pass

--- a/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
@@ -12,6 +12,9 @@ import unittest
 
 import WMCore_t.WMSpec_t.TestWorkloads as TestSpecs
 from copy import copy
+
+from Utils.PythonVersion import PY3
+
 from WMCore.WMSpec.WMSpecErrors import WMSpecFactoryException
 from WMCore.WMSpec.WMTask import WMTask, WMTaskHelper
 from WMCore.WMSpec.WMWorkload import WMWorkload, WMWorkloadHelper
@@ -24,6 +27,8 @@ class WMWorkloadTest(unittest.TestCase):
 
         """
         self.persistFile = "%s/WMWorkloadPersistencyTest.pkl" % os.getcwd()
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
         return
 
     def tearDown(self):

--- a/test/python/WMCore_t/WMStats_t/DataStructs_t/DataCache_t.py
+++ b/test/python/WMCore_t/WMStats_t/DataStructs_t/DataCache_t.py
@@ -6,6 +6,7 @@ import json
 import os
 import unittest
 
+from Utils.PythonVersion import PY3
 from WMCore.WMStats.DataStructs.DataCache import DataCache
 
 
@@ -19,6 +20,8 @@ class DataCacheTests(unittest.TestCase):
         with open(self.fileCache) as jo:
             data = json.load(jo)
         DataCache().setlatestJobData(data)
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
     def tearDown(self):
         pass

--- a/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Block_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Block_t.py
@@ -10,6 +10,8 @@ import unittest
 from WMCore_t.WMSpec_t.samples.MultiTaskProcessingWorkload import workload as MultiTaskProcessingWorkload
 from WMCore_t.WorkQueue_t.WorkQueue_t import getFirstTask
 
+from Utils.PythonVersion import PY3
+
 from WMCore.DataStructs.LumiList import LumiList
 from WMCore.Services.DBS.DBSErrors import DBSReaderError
 from WMCore.Services.DBS.DBSReader import DBSReader
@@ -45,6 +47,8 @@ class BlockTestCase(EmulatedUnitTestCase):
 
     def setUp(self):
         super(BlockTestCase, self).setUp()
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
     def tearDown(self):
         super(BlockTestCase, self).tearDown()

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
@@ -17,6 +17,8 @@ import logging
 
 from retry import retry
 
+from Utils.PythonVersion import PY3
+
 from WMCore.WMBase import getTestBase
 from WMCore.ACDC.DataCollectionService import DataCollectionService
 from WMCore.Configuration import Configuration
@@ -283,6 +285,9 @@ class WorkQueueTest(WorkQueueTestCase):
                                     dbinterface=threading.currentThread().dbi)
             addLocation = daofactory(classname="Locations.New")
             addLocation.execute(siteName=site, pnn=se)
+
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
 
     def setupReReco(self, assignArgs=None, **kwargs):
         # Sample Tier1 ReReco spec


### PR DESCRIPTION
Fixes #10514 

#### Status
Ready

#### Description
`assertItemsEqual` has been renamed `assertCountEqual` in py3. Sometimes it's possible to use alternatives, such as `assertListEqual`, but that is not always the case. 

I changed my mind: there are too many occurrences of `assertItemsEqual`, it would take a superlong time to fix them all, we can just use

```python
# ../Module_t.py
class ModuleTest(unittest.TestCase):
    def setUp(self):
    ...
        if PY3:
            self.assertItemsEqual = self.assertCountEqual
```

and we should be good to go

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
This changes have already been carried out in some other PRs related to #10422, but i do not have a list of them yet

#### External dependencies / deployment changes
nope
