### PR TITLE
Ramp up Rucio Client vesion

### DIFF
--- a/requirements_py3.txt
+++ b/requirements_py3.txt
@@ -12,7 +12,7 @@ pyOpenSSL==18.0.0
 pycurl==7.43.0.3
 pyzmq==19.0.2
 retry==0.9.2
-rucio-clients==1.24.2.post1
+rucio-clients==1.25.5
 sphinx==1.6.3
 Cheetah3==3.2.6.post2
 ### dependencies on the wmcorepy3-devtools spec


### PR DESCRIPTION
Fixes #10566 

#### Status
ready

#### Description
Ramping up Rucio Client version to 1.25.5

#### Is it backward compatible (if not, which system it affects?)
YES 

#### Related PRs

#### External dependencies / deployment changes

