### PR TITLE
[py2py3] Fix some file-handling problems that arose with LogArch - src

### DIFF
--- a/src/python/WMCore/WMRuntime/SandboxCreator.py
+++ b/src/python/WMCore/WMRuntime/SandboxCreator.py
@@ -162,9 +162,9 @@ class SandboxCreator(object):
 
             # Add a dummy module for zipimport testing
             (handle, dummyModulePath) = tempfile.mkstemp()
-            os.write(handle, "#!/usr/bin/env python\n")
-            os.write(handle, "print('ZIPIMPORTTESTOK')\n")
-            os.close(handle)
+            with open(dummyModulePath, "w") as f_:
+                f_.write("#!/usr/bin/env python\n")
+                f_.write("print('ZIPIMPORTTESTOK')\n")
             zipFile.write(filename=dummyModulePath, arcname='WMCore/ZipImportTestModule.py')
 
             # Add the wmcore zipball to the sandbox

--- a/src/python/WMCore/WMSpec/Persistency.py
+++ b/src/python/WMCore/WMSpec/Persistency.py
@@ -43,7 +43,7 @@ class PersistencyHelper(object):
         Save data to a file
         Saved format is defined depending on the extension
         """
-        with open(filename, 'w') as handle:
+        with open(filename, 'wb') as handle:
             # TODO: use different encoding scheme for different extension
             # extension = filename.split(".")[-1].lower()
             pickle.dump(self.data, handle)


### PR DESCRIPTION
Fixes #10569

#### Status
in dev

#### Description
Some usual juggling with file opening
- [x] fixed `test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/LogArch_t.py:otherLogArchiveTexst.addLogArchiveFile`
- [ ] still broken: `test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/LogArch_t.py`

If this gets too complicated to fix right now, i will wait and postpone this up until its turn in the schedule #10422, which is #10544

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
nope

#### External dependencies / deployment changes
nope
