### PR TITLE
Open parsed file in bytes.

### DIFF
--- a/src/python/WMCore/Algorithms/ParseXMLFile.py
+++ b/src/python/WMCore/Algorithms/ParseXMLFile.py
@@ -61,7 +61,7 @@ def xmlFileToNode(reportFile):
 
     """
     node = Node("JobReports", {})
-    expat_parse(open(reportFile, 'r'),
+    expat_parse(open(reportFile, 'rb'),
                 build(node))
     return node
 
@@ -76,7 +76,9 @@ def expat_parse(f, target):
     parser = xml.parsers.expat.ParserCreate()
     #parser.buffer_size = 65536
     parser.buffer_text = True
-    parser.returns_unicode = False
+
+    # a leftover from the py2py3 migration - TO BE REMOVED
+    # parser.returns_unicode = False
     parser.StartElementHandler = \
        lambda name,attrs: target.send(('start',(name,attrs)))
     parser.EndElementHandler = \

--- a/src/python/WMCore/Storage/TrivialFileCatalog.py
+++ b/src/python/WMCore/Storage/TrivialFileCatalog.py
@@ -35,7 +35,7 @@ import os
 import re
 
 from urllib.parse import urlsplit
-from xml.dom.minidom import Element
+from xml.dom.minidom import Document
 
 from WMCore.Algorithms.ParseXMLFile import xmlFileToNode
 
@@ -142,15 +142,17 @@ class TrivialFileCatalog(dict):
         """
 
         def _getElementForMappingEntry(entry, mappingStyle):
-            e = Element(mappingStyle)
+            xmlDocTmp = Document()
+            element = xmlDocTmp.createElement(mappingStyle)
             for k, v in viewitems(entry):
                 # ignore empty, None or compiled regexp items into output
                 if not v or (k == "path-match-expr"):
                     continue
-                e.setAttribute(k, str(v))
-            return e
+                element.setAttribute(k, str(v))
+            return element
 
-        root = Element("storage-mapping")  # root element name
+        xmlDoc = Document()
+        root = xmlDoc.createElement("storage-mapping")  # root element name
         for mappingStyle, mappings in viewitems(self):
             for mapping in mappings:
                 mapElem = _getElementForMappingEntry(mapping, mappingStyle)


### PR DESCRIPTION
Fixes #10533

#### Status
ready

#### Description
Working on the unit tests errors for Slice2.
The current PR solves only the issue with the py2-py3 conversion of the test/python/WMCore_t/Storage_t/TrivialFileCatalog_t.py test from https://github.com/dmwm/WMCore/issues/10533

#### Is it backward compatible (if not, which system it affects?)
YES 

#### Related PRs


#### External dependencies / deployment changes

