### PR TITLE
Re-execute REST/Main with the correct python version

### DIFF
--- a/src/python/WMCore/REST/Main.py
+++ b/src/python/WMCore/REST/Main.py
@@ -512,7 +512,10 @@ def main():
     # when infrequently accessed server redirects output to 'rotatelogs'.
     if 'PYTHONUNBUFFERED' not in os.environ:
         os.environ['PYTHONUNBUFFERED'] = "1"
-        os.execvp("python", ["python"] + sys.argv)
+        if PY2:
+            os.execvp("python", ["python"] + sys.argv)
+        else:
+            os.execvp("python3", ["python3"] + sys.argv)
 
     opt = ArgumentParser(usage=__doc__)
     opt.add_argument("-q", "--quiet", action="store_true", dest="quiet", default=False,


### PR DESCRIPTION
Fixes #10572 

#### Status
ready

#### Description
Ensure the correct (upstream) python version is used when replacing the current REST process by a new one.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
none

#### External dependencies / deployment changes
none
