### PR TITLE
[py2py3] Fix unittest from dmwm#10529, Proxy_t

### DIFF
--- a/src/python/WMCore/Credential/Proxy.py
+++ b/src/python/WMCore/Credential/Proxy.py
@@ -18,6 +18,8 @@ from hashlib import sha1
 
 from WMCore.Credential.Credential import Credential
 from WMCore.WMException import WMException
+from Utils.PythonVersion import PY3
+from Utils.Utilities import decodeBytesToUnicode
 
 
 def execute_command(command, logger, timeout, redirect=True):
@@ -50,6 +52,8 @@ def execute_command(command, logger, timeout, redirect=True):
         time.sleep(0.1)
 
     stdout, stderr = proc.communicate()
+    stdout = decodeBytesToUnicode(stdout) if PY3 else stdout
+    stderr = decodeBytesToUnicode(stderr) if PY3 else stderr
     rc = proc.returncode
 
     logger.debug('Executing : \n command : %s\n output : %s\n error: %s\n retcode : %s' % (command, stdout, stderr, rc))

--- a/test/python/WMCore_t/Credential_t/Proxy_t.py
+++ b/test/python/WMCore_t/Credential_t/Proxy_t.py
@@ -18,6 +18,8 @@ import subprocess
 
 from nose.plugins.attrib import attr
 from WMCore.Credential.Proxy import Proxy
+from Utils.PythonVersion import PY3
+from Utils.Utilities import decodeBytesToUnicode
 
 # You may have to set these environment variables to run in a local environment
 
@@ -67,6 +69,7 @@ class ProxyTest(unittest.TestCase):
             return None
 
         stdout, _ = vomsProxyInfoCall.communicate()
+        stdout = decodeBytesToUnicode(stdout) if PY3 else stdout
         return stdout[0:-1]
 
     def getUserAttributes(self):
@@ -81,6 +84,7 @@ class ProxyTest(unittest.TestCase):
             return None
 
         stdout, _ = vomsProxyInfoCall.communicate()
+        stdout = decodeBytesToUnicode(stdout) if PY3 else stdout
         return stdout[0:-1]
 
     @attr("integration")


### PR DESCRIPTION
Fixes the Proxy_t unittests from #10529

#### Status
Ready

#### Description
Does the proper bytes/string conversions needed for remove py3 related Errors from `Proxy_t` unittest.
  
#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
NA

#### External dependencies / deployment changes
NA