### PR TITLE
[py2py3] fix  unittests from Slice 3 in py3

### DIFF
--- a/src/python/WMCore/REST/Test.py
+++ b/src/python/WMCore/REST/Test.py
@@ -61,7 +61,7 @@ def fake_authz_key_file(delete=True):
     :returns: Instance of :class:`~.NamedTemporaryFile`, whose *data*
       attribute contains the HMAC signing binary key."""
     t = NamedTemporaryFile(delete=delete)
-    with open("/dev/urandom") as fd:
+    with open("/dev/urandom", "rb") as fd:
         t.data = fd.read(20)
     t.write(t.data)
     t.seek(0)

--- a/src/python/WMCore/WebTools/Root.py
+++ b/src/python/WMCore/WebTools/Root.py
@@ -224,6 +224,7 @@ class Root(Harness):
             'tools.etags.on': True,
             'tools.etags.autotags': True,
             'tools.encode.on': True,
+            'tools.encode.text_only': False,
             'tools.gzip.on': True,
         })
 


### PR DESCRIPTION
Fixes #10534

#### Status
Ready

#### Description

`src/python/WMCore/WebTools/Root.py`
- [x] changes configuration of cherrypy so that py2 and py3 interfaces are equivalent
  - source: [stackoverflow](https://stackoverflow.com/a/55039512/5313348)
  - some more info for future-us: `'tools.encode.encoding': 'utf-8',` may be necessary in the future if we have problems with encodings in cherrypy

`src/python/WMCore/REST/Test.py`
- [x] force `/dev/urandom` to be read as bytes in py3, too

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
This is a followup to #10117 

#### External dependencies / deployment changes
nope
