### PR TITLE
[py2py3] Check unittests from Slice 8 in py3

### DIFF
--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -10,7 +10,7 @@ from __future__ import print_function, division
 from builtins import object, str, bytes
 from future.utils import viewitems
 
-from Utils.Utilities import encodeUnicodeToBytes, decodeBytesToUnicode
+from Utils.Utilities import encodeUnicodeToBytesConditional, decodeBytesToUnicode
 
 import logging
 from collections import defaultdict
@@ -21,6 +21,7 @@ from dbs.exceptions.dbsClientException import dbsClientException
 from retry import retry
 
 from Utils.IteratorTools import grouper
+from Utils.PythonVersion import PY2
 from WMCore.Services.DBS.DBSErrors import DBSReaderError, formatEx3
 
 
@@ -42,7 +43,7 @@ def remapDBS3Keys(data, stringify=False, **others):
                'block_name': 'BlockName', 'lumi_section_num': 'LumiSectionNumber'}
 
     mapping.update(others)
-    formatFunc = lambda x: encodeUnicodeToBytes(x) if stringify else x
+    formatFunc = lambda x: encodeUnicodeToBytesConditional(x, condition=PY2 and stringify)
     for name, newname in viewitems(mapping):
         if name in data:
             data[newname] = formatFunc(data[name])

--- a/src/python/WMQuality/Emulators/DBSClient/MockDbsApi.py
+++ b/src/python/WMQuality/Emulators/DBSClient/MockDbsApi.py
@@ -132,5 +132,5 @@ class MockDbsApi(object):
             else:
                 return mockData[self.url][signature]
         except KeyError:
-            raise KeyError("DBS mock API could not return data for method %s, args=%s, and kwargs=%s (URL %s)." %
-                           (self.item, args, kwargs, self.url))
+            raise KeyError("DBS mock API could not return data for method %s, args=%s, and kwargs=%s (URL %s) (Signature: %s)" %
+                           (self.item, args, kwargs, self.url, signature))

--- a/src/python/WMQuality/Emulators/DBSClient/MockDbsApi.py
+++ b/src/python/WMQuality/Emulators/DBSClient/MockDbsApi.py
@@ -16,6 +16,7 @@ from RestClient.ErrorHandling.RestClientExceptions import HTTPError
 from WMCore.Services.DBS.DBSErrors import DBSReaderError
 from WMCore.WMBase import getTestBase
 
+from Utils.Utilities import encodeUnicodeToBytes
 from Utils.PythonVersion import PY2
 
 # Read in the data just once so that we don't have to do it for every test (in __init__)
@@ -37,17 +38,6 @@ except IOError:
 
 mockData['https://cmsweb-prod.cern.ch/dbs/prod/global/DBSReader'] = mockDataGlobal
 mockData['https://cmsweb-prod.cern.ch/dbs/prod/phys03/DBSReader'] = mockData03
-
-def _unicode(data):
-    """
-    Temporary workaround for problem with how unicode strings are represented
-    by unicode (as u"hello worls") and future.types.newstr (as "hello world")
-    https://github.com/dmwm/WMCore/pull/10299#issuecomment-781600773
-    """
-    if PY2:
-        return unicode(data)
-    else:
-        return str(data)
 
 class MockDbsApi(object):
     def __init__(self, url):
@@ -76,7 +66,7 @@ class MockDbsApi(object):
             origArgs = copy.deepcopy(kwargs)
             returnDicts = []
             for lfn in kwargs['logical_file_name']:
-                origArgs.update({'logical_file_name': [_unicode(lfn)]})
+                origArgs.update({'logical_file_name': [str(lfn)]})
                 returnDicts.extend(self.genericLookup(**origArgs))
             return returnDicts
         else:
@@ -99,7 +89,7 @@ class MockDbsApi(object):
             origArgs = copy.deepcopy(kwargs)
             returnDicts = []
             for lfn in kwargs['logical_file_name']:
-                origArgs.update({'logical_file_name': [_unicode(lfn)]})
+                origArgs.update({'logical_file_name': [str(lfn)]})
                 returnDicts.extend(self.genericLookup(**origArgs))
             return returnDicts
         else:
@@ -129,6 +119,9 @@ class MockDbsApi(object):
             raise DBSReaderError("Mock DBS emulator knows nothing about instance %s" % self.url)
 
         if kwargs:
+            if PY2:
+                for k in kwargs:
+                    kwargs[k] = encodeUnicodeToBytes(kwargs[k])
             signature = '%s:%s' % (self.item, sorted(viewitems(kwargs)))
         else:
             signature = self.item


### PR DESCRIPTION
Fixes #10539 

#### Status

There is a broken PR, but we decided to merge this anyways 

#### Description

##### open questions

- [ ] open problem with `test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py:WorkQueueTest.testGlobalDatasetSplitting` in py2
  - caused by my new json file. Maybe I should ask Alan to provide me with a new one

##### changes


`DBSReader_t`
- [x] `nosetests test/python/WMCore_t/Services_t/DBS_t/DBSReader_t.py:DBSReaderTest.testListFilesInBlockWithParents` fails in py3, because in `mockData[self.url][signature]` looks for a `signature` that is the srting `listFileArray:[('detail', True), ('logical_file_name', ['/store/data/Commissioning2015/Cosmics/RAW/v1/000/238/545/00000/C47FDF25-2ECF-E411-A8E2-02163E011839.root']`, while in DBSMockData.json we have keys like `"listFileArray:[('detail', True), ('logical_file_name', [u'/store/data/Commissioning2015/Cosmics/RAW/v1/000/238/545/00000/C47FDF25-2ECF-E411-A8E2-02163E011839.root'])]":`. Notice that the only difference is that the file path is prepended with a `u''`
  - is this a problem of the DsbMockApi only or would this be the behaviour of DBS too? 

`src/python/WMCore/ProcessPool/ProcessPool.py`
- [x] fixed some problems with strings that caused ` nosetests test/python/WMCore_t/ProcessPool_t/ProcessPool_t.py:ProcessPoolTest.testA_ProcessPool` to fail immediatly
- [x]  understand why it fails with `ImportError: No module named builtins`

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
This is follow-up to #10289 

#### External dependencies / deployment changes
nope
