### PR TITLE
[py2py3] Fix unittests from Slice 11 in py3

### DIFF
--- a/src/python/WMCore/Services/Service.py
+++ b/src/python/WMCore/Services/Service.py
@@ -57,9 +57,10 @@ import json
 import logging
 import os
 import time
-from io import BytesIO
+from io import BytesIO, StringIO
 from http.client import HTTPException
 
+from Utils.PythonVersion import PY3
 from WMCore.Services.Requests import Requests, JSONRequests
 from WMCore.WMException import WMException
 
@@ -177,7 +178,7 @@ class Service(dict):
         """
         # if not caching to disk return StringIO object
         if not self['cachepath'] or not cachefile:
-            return BytesIO()
+            return StringIO() if PY3 else BytesIO()
 
         inputdata = inputdata or {}
         if inputdata:

--- a/test/data/Mock/RucioMockData.json
+++ b/test/data/Mock/RucioMockData.json
@@ -1,112 +1,112 @@
 {
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#00ad285a-0d7b-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#14ad7dfe-0acf-11e1-8347-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#1bb7b9b6-0d95-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#1ef70b20-0da1-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#2587a5c4-0ca9-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#2b997cea-0df7-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#2c823cea-0d80-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#3551be9e-0d13-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#3870e3f0-0ca2-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#39b65052-0e59-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#42360832-0d8a-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#49e7f878-0d9a-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b4eea16-0af9-11e1-8347-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b6dc396-0e05-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b87a720-0af9-11e1-8347-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b89ba9c-0dbf-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b95df8e-0e05-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b9bf608-0af9-11e1-8347-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5bb19418-0af9-11e1-8347-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5c549320-0af9-11e1-8347-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5c9a0c66-0af9-11e1-8347-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5cefed16-0af9-11e1-8347-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5e222cf6-0d0d-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#61fac352-0e42-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#63a86a54-0de0-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#6891a3c4-0dee-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#68eaa208-0dee-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#7020873e-0dcd-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#71ba7b94-0e00-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#7514a55a-0ddb-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#77815e9a-0daa-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#77db9f74-0de4-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#7a184534-0cb4-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#7dde1288-0daf-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#898f9684-0df9-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#8aed6476-0d9e-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#92e3bfa8-0ca0-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#94cbbf8e-0d98-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#a430dd66-0d83-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#a7322fdc-0de3-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#a90e3738-0cc1-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#a971c7b6-0df3-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#a9e0db6a-0bfa-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#b25f5ad4-0b1c-11e1-8347-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#b5df650c-0962-11e1-8347-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#c4840d5c-0c9f-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#dbdd7ec0-0cb8-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#dccab25e-0dd9-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#dcd3fc0a-0dc1-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#dd5ceace-0dfd-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#dd71b9d6-0dfd-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#deacb51a-0d96-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#e2b0a74a-0bb9-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#e36667f6-0bb9-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#e3e96a36-0950-11e1-8347-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#e42b2f46-0ba0-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#eef15b3a-0cd1-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#fd290334-0db1-11e1-9b6c-003048caaace')]": true,
- "didExist:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#03fe83c2-0c23-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#04be2fcc-0b8f-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#217ea8d8-0c4f-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#219f2f58-0c2d-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#28315b28-0c5c-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#2949d00e-0c74-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#2baf819a-0c5b-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#2bda869c-0c5b-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#2ddb6462-0af7-11e1-8347-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#33168dd8-0cca-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#34646e74-0c6d-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#34f5ff9a-0b52-11e1-8347-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#372d624c-089d-11e1-8347-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#3861971e-0bef-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#3d9fa11a-0c46-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#4d418710-0c68-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#4f1cf90c-0b8c-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#4f205a20-0b8c-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#59477f38-0cae-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#5ac69eca-0c63-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#5b16394c-0b61-11e1-8347-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#5c53d062-0bed-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#5c8eb6e6-0c3d-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#61cbcdee-0bf5-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#6e1b7f22-0c04-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#6f6d60ae-0c11-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#789a7706-0c62-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#796abfd6-0c32-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#7ca5e2f6-0c6a-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#85e3e820-0c71-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#8751690a-0c4c-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#94d3bab4-0c0c-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#9cf7c56c-0b50-11e1-8347-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#a19beb7c-0c02-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#a34087a4-0ba2-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#a358bd92-0ba2-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#a8fb0a04-0bfa-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#a90bd6e6-0b5e-11e1-8347-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#adb27478-0b92-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#b334e4b0-0946-11e1-8347-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#b469f816-0946-11e1-8347-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#b5344df4-0c08-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#c5762ad0-0c1b-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#c5b07a28-0c1b-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#d0351502-0be5-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#e2ed5d7a-0c09-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#f29b82f0-0c50-11e1-b764-003048caaace')]": true,
- "didExist:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW')]": true,
- "getBlocksInContainer:[('container', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO')]": [
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#00ad285a-0d7b-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#14ad7dfe-0acf-11e1-8347-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#1bb7b9b6-0d95-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#1ef70b20-0da1-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#2587a5c4-0ca9-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#2b997cea-0df7-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#2c823cea-0d80-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#3551be9e-0d13-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#3870e3f0-0ca2-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#39b65052-0e59-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#42360832-0d8a-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#49e7f878-0d9a-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b4eea16-0af9-11e1-8347-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b6dc396-0e05-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b87a720-0af9-11e1-8347-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b89ba9c-0dbf-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b95df8e-0e05-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b9bf608-0af9-11e1-8347-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5bb19418-0af9-11e1-8347-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5c549320-0af9-11e1-8347-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5c9a0c66-0af9-11e1-8347-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5cefed16-0af9-11e1-8347-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5e222cf6-0d0d-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#61fac352-0e42-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#63a86a54-0de0-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#6891a3c4-0dee-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#68eaa208-0dee-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#7020873e-0dcd-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#71ba7b94-0e00-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#7514a55a-0ddb-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#77815e9a-0daa-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#77db9f74-0de4-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#7a184534-0cb4-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#7dde1288-0daf-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#898f9684-0df9-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#8aed6476-0d9e-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#92e3bfa8-0ca0-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#94cbbf8e-0d98-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#a430dd66-0d83-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#a7322fdc-0de3-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#a90e3738-0cc1-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#a971c7b6-0df3-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#a9e0db6a-0bfa-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#b25f5ad4-0b1c-11e1-8347-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#b5df650c-0962-11e1-8347-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#c4840d5c-0c9f-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#dbdd7ec0-0cb8-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#dccab25e-0dd9-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#dcd3fc0a-0dc1-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#dd5ceace-0dfd-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#dd71b9d6-0dfd-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#deacb51a-0d96-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#e2b0a74a-0bb9-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#e36667f6-0bb9-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#e3e96a36-0950-11e1-8347-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#e42b2f46-0ba0-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#eef15b3a-0cd1-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#fd290334-0db1-11e1-9b6c-003048caaace')]": true,
+ "didExist:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#03fe83c2-0c23-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#04be2fcc-0b8f-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#217ea8d8-0c4f-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#219f2f58-0c2d-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#28315b28-0c5c-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#2949d00e-0c74-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#2baf819a-0c5b-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#2bda869c-0c5b-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#2ddb6462-0af7-11e1-8347-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#33168dd8-0cca-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#34646e74-0c6d-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#34f5ff9a-0b52-11e1-8347-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#372d624c-089d-11e1-8347-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#3861971e-0bef-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#3d9fa11a-0c46-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#4d418710-0c68-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#4f1cf90c-0b8c-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#4f205a20-0b8c-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#59477f38-0cae-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#5ac69eca-0c63-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#5b16394c-0b61-11e1-8347-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#5c53d062-0bed-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#5c8eb6e6-0c3d-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#61cbcdee-0bf5-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#6e1b7f22-0c04-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#6f6d60ae-0c11-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#789a7706-0c62-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#796abfd6-0c32-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#7ca5e2f6-0c6a-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#85e3e820-0c71-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#8751690a-0c4c-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#94d3bab4-0c0c-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#9cf7c56c-0b50-11e1-8347-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#a19beb7c-0c02-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#a34087a4-0ba2-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#a358bd92-0ba2-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#a8fb0a04-0bfa-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#a90bd6e6-0b5e-11e1-8347-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#adb27478-0b92-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#b334e4b0-0946-11e1-8347-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#b469f816-0946-11e1-8347-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#b5344df4-0c08-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#c5762ad0-0c1b-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#c5b07a28-0c1b-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#d0351502-0be5-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#e2ed5d7a-0c09-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#f29b82f0-0c50-11e1-b764-003048caaace')]": true,
+ "didExist:[('didName', '/MinimumBias/ComissioningHI-v1/RAW')]": true,
+ "getBlocksInContainer:[('container', '/Cosmics/ComissioningHI-PromptReco-v1/RECO')]": [
   "/Cosmics/ComissioningHI-PromptReco-v1/RECO#00ad285a-0d7b-11e1-9b6c-003048caaace",
   "/Cosmics/ComissioningHI-PromptReco-v1/RECO#14ad7dfe-0acf-11e1-8347-003048caaace",
   "/Cosmics/ComissioningHI-PromptReco-v1/RECO#1bb7b9b6-0d95-11e1-9b6c-003048caaace",
@@ -166,7 +166,7 @@
   "/Cosmics/ComissioningHI-PromptReco-v1/RECO#eef15b3a-0cd1-11e1-b764-003048caaace",
   "/Cosmics/ComissioningHI-PromptReco-v1/RECO#fd290334-0db1-11e1-9b6c-003048caaace"
  ],
- "getBlocksInContainer:[('container', u'/MinimumBias/ComissioningHI-v1/RAW')]": [
+ "getBlocksInContainer:[('container', '/MinimumBias/ComissioningHI-v1/RAW')]": [
   "/MinimumBias/ComissioningHI-v1/RAW#03fe83c2-0c23-11e1-b764-003048caaace",
   "/MinimumBias/ComissioningHI-v1/RAW#04be2fcc-0b8f-11e1-b764-003048caaace",
   "/MinimumBias/ComissioningHI-v1/RAW#217ea8d8-0c4f-11e1-b764-003048caaace",
@@ -215,7 +215,7 @@
   "/MinimumBias/ComissioningHI-v1/RAW#e2ed5d7a-0c09-11e1-b764-003048caaace",
   "/MinimumBias/ComissioningHI-v1/RAW#f29b82f0-0c50-11e1-b764-003048caaace"
  ],
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#00ad285a-0d7b-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#00ad285a-0d7b-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 2723743913,
   "expired_at": null,
@@ -226,7 +226,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#14ad7dfe-0acf-11e1-8347-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#14ad7dfe-0acf-11e1-8347-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 883096,
   "expired_at": null,
@@ -237,7 +237,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#1bb7b9b6-0d95-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#1bb7b9b6-0d95-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 21688940103,
   "expired_at": null,
@@ -248,7 +248,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#1ef70b20-0da1-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#1ef70b20-0da1-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 2926817818,
   "expired_at": null,
@@ -259,7 +259,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#2587a5c4-0ca9-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#2587a5c4-0ca9-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 237702549,
   "expired_at": null,
@@ -270,7 +270,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#2b997cea-0df7-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#2b997cea-0df7-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 2648956210,
   "expired_at": null,
@@ -281,7 +281,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#2c823cea-0d80-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#2c823cea-0d80-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 2300311252,
   "expired_at": null,
@@ -292,7 +292,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#3551be9e-0d13-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#3551be9e-0d13-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 2976429517,
   "expired_at": null,
@@ -303,7 +303,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#3870e3f0-0ca2-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#3870e3f0-0ca2-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 2912565792,
   "expired_at": null,
@@ -314,7 +314,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#39b65052-0e59-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#39b65052-0e59-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 773962,
   "expired_at": null,
@@ -325,7 +325,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#42360832-0d8a-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#42360832-0d8a-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 1192335484,
   "expired_at": null,
@@ -336,7 +336,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#49e7f878-0d9a-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#49e7f878-0d9a-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 651264,
   "expired_at": null,
@@ -347,7 +347,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b4eea16-0af9-11e1-8347-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b4eea16-0af9-11e1-8347-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 1791176,
   "expired_at": null,
@@ -358,7 +358,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b6dc396-0e05-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b6dc396-0e05-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 1222294352,
   "expired_at": null,
@@ -369,7 +369,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b87a720-0af9-11e1-8347-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b87a720-0af9-11e1-8347-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 797891,
   "expired_at": null,
@@ -380,7 +380,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b89ba9c-0dbf-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b89ba9c-0dbf-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 28742211406,
   "expired_at": null,
@@ -391,7 +391,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b95df8e-0e05-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b95df8e-0e05-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 1579849175,
   "expired_at": null,
@@ -402,7 +402,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b9bf608-0af9-11e1-8347-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b9bf608-0af9-11e1-8347-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 6127017,
   "expired_at": null,
@@ -413,7 +413,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5bb19418-0af9-11e1-8347-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5bb19418-0af9-11e1-8347-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 1632012,
   "expired_at": null,
@@ -424,7 +424,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5c549320-0af9-11e1-8347-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5c549320-0af9-11e1-8347-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 1086576,
   "expired_at": null,
@@ -435,7 +435,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5c9a0c66-0af9-11e1-8347-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5c9a0c66-0af9-11e1-8347-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 764352,
   "expired_at": null,
@@ -446,7 +446,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5cefed16-0af9-11e1-8347-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5cefed16-0af9-11e1-8347-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 1286946,
   "expired_at": null,
@@ -457,7 +457,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5e222cf6-0d0d-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5e222cf6-0d0d-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 32737745482,
   "expired_at": null,
@@ -468,7 +468,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#61fac352-0e42-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#61fac352-0e42-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 1365492,
   "expired_at": null,
@@ -479,7 +479,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#63a86a54-0de0-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#63a86a54-0de0-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 8929898552,
   "expired_at": null,
@@ -490,7 +490,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#6891a3c4-0dee-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#6891a3c4-0dee-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 651264,
   "expired_at": null,
@@ -501,7 +501,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#68eaa208-0dee-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#68eaa208-0dee-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 651264,
   "expired_at": null,
@@ -512,7 +512,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#7020873e-0dcd-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#7020873e-0dcd-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 26984188878,
   "expired_at": null,
@@ -523,7 +523,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#71ba7b94-0e00-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#71ba7b94-0e00-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 731204338,
   "expired_at": null,
@@ -534,7 +534,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#7514a55a-0ddb-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#7514a55a-0ddb-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 474395677,
   "expired_at": null,
@@ -545,7 +545,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#77815e9a-0daa-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#77815e9a-0daa-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 23366882309,
   "expired_at": null,
@@ -556,7 +556,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#77db9f74-0de4-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#77db9f74-0de4-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 1195876470,
   "expired_at": null,
@@ -567,7 +567,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#7a184534-0cb4-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#7a184534-0cb4-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 11495668310,
   "expired_at": null,
@@ -578,7 +578,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#7dde1288-0daf-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#7dde1288-0daf-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 293486046,
   "expired_at": null,
@@ -589,7 +589,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#898f9684-0df9-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#898f9684-0df9-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 540458927,
   "expired_at": null,
@@ -600,7 +600,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#8aed6476-0d9e-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#8aed6476-0d9e-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 13456111837,
   "expired_at": null,
@@ -611,7 +611,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#92e3bfa8-0ca0-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#92e3bfa8-0ca0-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 571409512,
   "expired_at": null,
@@ -622,7 +622,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#94cbbf8e-0d98-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#94cbbf8e-0d98-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 3269852398,
   "expired_at": null,
@@ -633,7 +633,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#a430dd66-0d83-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#a430dd66-0d83-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 2939311290,
   "expired_at": null,
@@ -644,7 +644,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#a7322fdc-0de3-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#a7322fdc-0de3-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 5036297042,
   "expired_at": null,
@@ -655,7 +655,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#a90e3738-0cc1-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#a90e3738-0cc1-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 5590051551,
   "expired_at": null,
@@ -666,7 +666,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#a971c7b6-0df3-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#a971c7b6-0df3-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 6350484947,
   "expired_at": null,
@@ -677,7 +677,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#a9e0db6a-0bfa-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#a9e0db6a-0bfa-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 718226,
   "expired_at": null,
@@ -688,7 +688,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#b25f5ad4-0b1c-11e1-8347-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#b25f5ad4-0b1c-11e1-8347-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 15630653,
   "expired_at": null,
@@ -699,7 +699,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#b5df650c-0962-11e1-8347-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#b5df650c-0962-11e1-8347-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 662897,
   "expired_at": null,
@@ -710,7 +710,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#c4840d5c-0c9f-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#c4840d5c-0c9f-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 240922033,
   "expired_at": null,
@@ -721,7 +721,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#dbdd7ec0-0cb8-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#dbdd7ec0-0cb8-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 1174009186,
   "expired_at": null,
@@ -732,7 +732,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#dccab25e-0dd9-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#dccab25e-0dd9-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 29595109710,
   "expired_at": null,
@@ -743,7 +743,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#dcd3fc0a-0dc1-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#dcd3fc0a-0dc1-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 816254365,
   "expired_at": null,
@@ -754,7 +754,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#dd5ceace-0dfd-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#dd5ceace-0dfd-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 6441555635,
   "expired_at": null,
@@ -765,7 +765,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#dd71b9d6-0dfd-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#dd71b9d6-0dfd-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 1260198177,
   "expired_at": null,
@@ -776,7 +776,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#deacb51a-0d96-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#deacb51a-0d96-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 2970097727,
   "expired_at": null,
@@ -787,7 +787,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#e2b0a74a-0bb9-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#e2b0a74a-0bb9-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 672324,
   "expired_at": null,
@@ -798,7 +798,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#e36667f6-0bb9-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#e36667f6-0bb9-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 672329,
   "expired_at": null,
@@ -809,7 +809,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#e3e96a36-0950-11e1-8347-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#e3e96a36-0950-11e1-8347-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 7643761,
   "expired_at": null,
@@ -820,7 +820,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#e42b2f46-0ba0-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#e42b2f46-0ba0-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 671233,
   "expired_at": null,
@@ -831,7 +831,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#eef15b3a-0cd1-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#eef15b3a-0cd1-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 5270919248,
   "expired_at": null,
@@ -842,7 +842,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#fd290334-0db1-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#fd290334-0db1-11e1-9b6c-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 14823305818,
   "expired_at": null,
@@ -853,7 +853,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO'), ('dynamic', False)]": {
+ "getDID:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": null,
   "expired_at": null,
@@ -864,7 +864,7 @@
   "scope": "cms",
   "type": "CONTAINER"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#03fe83c2-0c23-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#03fe83c2-0c23-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 15486859522,
   "expired_at": null,
@@ -875,7 +875,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#04be2fcc-0b8f-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#04be2fcc-0b8f-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 216409591,
   "expired_at": null,
@@ -886,7 +886,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#217ea8d8-0c4f-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#217ea8d8-0c4f-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 4445699,
   "expired_at": null,
@@ -897,7 +897,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#219f2f58-0c2d-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#219f2f58-0c2d-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 429451965,
   "expired_at": null,
@@ -908,7 +908,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#28315b28-0c5c-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#28315b28-0c5c-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 93499,
   "expired_at": null,
@@ -919,7 +919,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#2949d00e-0c74-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#2949d00e-0c74-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 740884085,
   "expired_at": null,
@@ -930,7 +930,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#2baf819a-0c5b-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#2baf819a-0c5b-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 93499,
   "expired_at": null,
@@ -941,7 +941,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#2bda869c-0c5b-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#2bda869c-0c5b-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 20958481,
   "expired_at": null,
@@ -952,7 +952,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#2ddb6462-0af7-11e1-8347-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#2ddb6462-0af7-11e1-8347-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 46764115,
   "expired_at": null,
@@ -963,7 +963,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#33168dd8-0cca-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#33168dd8-0cca-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 34925351,
   "expired_at": null,
@@ -974,7 +974,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#34646e74-0c6d-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#34646e74-0c6d-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 25711543,
   "expired_at": null,
@@ -985,7 +985,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#34f5ff9a-0b52-11e1-8347-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#34f5ff9a-0b52-11e1-8347-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 22519884,
   "expired_at": null,
@@ -996,7 +996,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#372d624c-089d-11e1-8347-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#372d624c-089d-11e1-8347-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 110799,
   "expired_at": null,
@@ -1007,7 +1007,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#3861971e-0bef-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#3861971e-0bef-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 4825240093,
   "expired_at": null,
@@ -1018,7 +1018,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#3d9fa11a-0c46-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#3d9fa11a-0c46-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 10251204,
   "expired_at": null,
@@ -1029,7 +1029,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#4d418710-0c68-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#4d418710-0c68-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 1847026515,
   "expired_at": null,
@@ -1040,7 +1040,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#4f1cf90c-0b8c-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#4f1cf90c-0b8c-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 41486199,
   "expired_at": null,
@@ -1051,7 +1051,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#4f205a20-0b8c-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#4f205a20-0b8c-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 735915230,
   "expired_at": null,
@@ -1062,7 +1062,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#59477f38-0cae-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#59477f38-0cae-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 126820207,
   "expired_at": null,
@@ -1073,7 +1073,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#5ac69eca-0c63-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#5ac69eca-0c63-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 16767390,
   "expired_at": null,
@@ -1084,7 +1084,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#5b16394c-0b61-11e1-8347-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#5b16394c-0b61-11e1-8347-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 9916272,
   "expired_at": null,
@@ -1095,7 +1095,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#5c53d062-0bed-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#5c53d062-0bed-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 3273336374,
   "expired_at": null,
@@ -1106,7 +1106,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#5c8eb6e6-0c3d-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#5c8eb6e6-0c3d-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 15866541996,
   "expired_at": null,
@@ -1117,7 +1117,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#61cbcdee-0bf5-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#61cbcdee-0bf5-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 626157114,
   "expired_at": null,
@@ -1128,7 +1128,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#6e1b7f22-0c04-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#6e1b7f22-0c04-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 1719074854,
   "expired_at": null,
@@ -1139,7 +1139,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#6f6d60ae-0c11-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#6f6d60ae-0c11-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 12558663496,
   "expired_at": null,
@@ -1150,7 +1150,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#789a7706-0c62-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#789a7706-0c62-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 173141872,
   "expired_at": null,
@@ -1161,7 +1161,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#796abfd6-0c32-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#796abfd6-0c32-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 14643763627,
   "expired_at": null,
@@ -1172,7 +1172,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#7ca5e2f6-0c6a-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#7ca5e2f6-0c6a-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 723725963,
   "expired_at": null,
@@ -1183,7 +1183,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#85e3e820-0c71-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#85e3e820-0c71-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 37261072,
   "expired_at": null,
@@ -1194,7 +1194,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#8751690a-0c4c-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#8751690a-0c4c-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 228922380,
   "expired_at": null,
@@ -1205,7 +1205,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#94d3bab4-0c0c-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#94d3bab4-0c0c-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 1609235539,
   "expired_at": null,
@@ -1216,7 +1216,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#9cf7c56c-0b50-11e1-8347-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#9cf7c56c-0b50-11e1-8347-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 9269846,
   "expired_at": null,
@@ -1227,7 +1227,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#a19beb7c-0c02-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#a19beb7c-0c02-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 1570296623,
   "expired_at": null,
@@ -1238,7 +1238,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#a34087a4-0ba2-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#a34087a4-0ba2-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 1281915842,
   "expired_at": null,
@@ -1249,7 +1249,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#a358bd92-0ba2-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#a358bd92-0ba2-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 117962051,
   "expired_at": null,
@@ -1260,7 +1260,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#a8fb0a04-0bfa-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#a8fb0a04-0bfa-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 13647332997,
   "expired_at": null,
@@ -1271,7 +1271,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#a90bd6e6-0b5e-11e1-8347-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#a90bd6e6-0b5e-11e1-8347-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 110234117,
   "expired_at": null,
@@ -1282,7 +1282,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#adb27478-0b92-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#adb27478-0b92-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 3857395857,
   "expired_at": null,
@@ -1293,7 +1293,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#b334e4b0-0946-11e1-8347-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#b334e4b0-0946-11e1-8347-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 141908,
   "expired_at": null,
@@ -1304,7 +1304,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#b469f816-0946-11e1-8347-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#b469f816-0946-11e1-8347-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 110795,
   "expired_at": null,
@@ -1315,7 +1315,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#b5344df4-0c08-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#b5344df4-0c08-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 93499,
   "expired_at": null,
@@ -1326,7 +1326,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#c5762ad0-0c1b-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#c5762ad0-0c1b-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 8002686584,
   "expired_at": null,
@@ -1337,7 +1337,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#c5b07a28-0c1b-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#c5b07a28-0c1b-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 169101415,
   "expired_at": null,
@@ -1348,7 +1348,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#d0351502-0be5-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#d0351502-0be5-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 7487306257,
   "expired_at": null,
@@ -1359,7 +1359,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#e2ed5d7a-0c09-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#e2ed5d7a-0c09-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 7261569558,
   "expired_at": null,
@@ -1370,7 +1370,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#f29b82f0-0c50-11e1-b764-003048caaace'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#f29b82f0-0c50-11e1-b764-003048caaace'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": 2839472819,
   "expired_at": null,
@@ -1381,7 +1381,7 @@
   "scope": "cms",
   "type": "DATASET"
  },
- "getDID:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW'), ('dynamic', False)]": {
+ "getDID:[('didName', '/MinimumBias/ComissioningHI-v1/RAW'), ('dynamic', False)]": {
   "account": "sync_t0_ch_cern_tape",
   "bytes": null,
   "expired_at": null,
@@ -1392,111 +1392,111 @@
   "scope": "cms",
   "type": "CONTAINER"
  },
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#00ad285a-0d7b-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#14ad7dfe-0acf-11e1-8347-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#1bb7b9b6-0d95-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#1ef70b20-0da1-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#2587a5c4-0ca9-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#2b997cea-0df7-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#2c823cea-0d80-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#3551be9e-0d13-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#3870e3f0-0ca2-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#39b65052-0e59-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#42360832-0d8a-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#49e7f878-0d9a-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b4eea16-0af9-11e1-8347-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b6dc396-0e05-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b87a720-0af9-11e1-8347-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b89ba9c-0dbf-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b95df8e-0e05-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b9bf608-0af9-11e1-8347-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5bb19418-0af9-11e1-8347-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5c549320-0af9-11e1-8347-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5c9a0c66-0af9-11e1-8347-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5cefed16-0af9-11e1-8347-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#5e222cf6-0d0d-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#61fac352-0e42-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#63a86a54-0de0-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#6891a3c4-0dee-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#68eaa208-0dee-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#7020873e-0dcd-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#71ba7b94-0e00-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#7514a55a-0ddb-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#77815e9a-0daa-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#77db9f74-0de4-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#7a184534-0cb4-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#7dde1288-0daf-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#898f9684-0df9-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#8aed6476-0d9e-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#92e3bfa8-0ca0-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#94cbbf8e-0d98-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#a430dd66-0d83-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#a7322fdc-0de3-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#a90e3738-0cc1-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#a971c7b6-0df3-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#a9e0db6a-0bfa-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#b25f5ad4-0b1c-11e1-8347-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#b5df650c-0962-11e1-8347-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#c4840d5c-0c9f-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#dbdd7ec0-0cb8-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#dccab25e-0dd9-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#dcd3fc0a-0dc1-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#dd5ceace-0dfd-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#dd71b9d6-0dfd-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#deacb51a-0d96-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#e2b0a74a-0bb9-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#e36667f6-0bb9-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#e3e96a36-0950-11e1-8347-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#e42b2f46-0ba0-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#eef15b3a-0cd1-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO#fd290334-0db1-11e1-9b6c-003048caaace')]": false,
- "isContainer:[('didName', u'/Cosmics/ComissioningHI-PromptReco-v1/RECO')]": true,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#03fe83c2-0c23-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#04be2fcc-0b8f-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#217ea8d8-0c4f-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#219f2f58-0c2d-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#28315b28-0c5c-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#2949d00e-0c74-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#2baf819a-0c5b-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#2bda869c-0c5b-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#2ddb6462-0af7-11e1-8347-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#33168dd8-0cca-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#34646e74-0c6d-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#34f5ff9a-0b52-11e1-8347-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#372d624c-089d-11e1-8347-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#3861971e-0bef-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#3d9fa11a-0c46-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#4d418710-0c68-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#4f1cf90c-0b8c-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#4f205a20-0b8c-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#59477f38-0cae-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#5ac69eca-0c63-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#5b16394c-0b61-11e1-8347-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#5c53d062-0bed-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#5c8eb6e6-0c3d-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#61cbcdee-0bf5-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#6e1b7f22-0c04-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#6f6d60ae-0c11-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#789a7706-0c62-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#796abfd6-0c32-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#7ca5e2f6-0c6a-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#85e3e820-0c71-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#8751690a-0c4c-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#94d3bab4-0c0c-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#9cf7c56c-0b50-11e1-8347-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#a19beb7c-0c02-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#a34087a4-0ba2-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#a358bd92-0ba2-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#a8fb0a04-0bfa-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#a90bd6e6-0b5e-11e1-8347-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#adb27478-0b92-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#b334e4b0-0946-11e1-8347-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#b469f816-0946-11e1-8347-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#b5344df4-0c08-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#c5762ad0-0c1b-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#c5b07a28-0c1b-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#d0351502-0be5-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#e2ed5d7a-0c09-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW#f29b82f0-0c50-11e1-b764-003048caaace')]": false,
- "isContainer:[('didName', u'/MinimumBias/ComissioningHI-v1/RAW')]": true
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#00ad285a-0d7b-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#14ad7dfe-0acf-11e1-8347-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#1bb7b9b6-0d95-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#1ef70b20-0da1-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#2587a5c4-0ca9-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#2b997cea-0df7-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#2c823cea-0d80-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#3551be9e-0d13-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#3870e3f0-0ca2-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#39b65052-0e59-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#42360832-0d8a-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#49e7f878-0d9a-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b4eea16-0af9-11e1-8347-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b6dc396-0e05-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b87a720-0af9-11e1-8347-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b89ba9c-0dbf-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b95df8e-0e05-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5b9bf608-0af9-11e1-8347-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5bb19418-0af9-11e1-8347-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5c549320-0af9-11e1-8347-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5c9a0c66-0af9-11e1-8347-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5cefed16-0af9-11e1-8347-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#5e222cf6-0d0d-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#61fac352-0e42-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#63a86a54-0de0-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#6891a3c4-0dee-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#68eaa208-0dee-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#7020873e-0dcd-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#71ba7b94-0e00-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#7514a55a-0ddb-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#77815e9a-0daa-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#77db9f74-0de4-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#7a184534-0cb4-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#7dde1288-0daf-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#898f9684-0df9-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#8aed6476-0d9e-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#92e3bfa8-0ca0-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#94cbbf8e-0d98-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#a430dd66-0d83-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#a7322fdc-0de3-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#a90e3738-0cc1-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#a971c7b6-0df3-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#a9e0db6a-0bfa-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#b25f5ad4-0b1c-11e1-8347-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#b5df650c-0962-11e1-8347-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#c4840d5c-0c9f-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#dbdd7ec0-0cb8-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#dccab25e-0dd9-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#dcd3fc0a-0dc1-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#dd5ceace-0dfd-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#dd71b9d6-0dfd-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#deacb51a-0d96-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#e2b0a74a-0bb9-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#e36667f6-0bb9-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#e3e96a36-0950-11e1-8347-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#e42b2f46-0ba0-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#eef15b3a-0cd1-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#fd290334-0db1-11e1-9b6c-003048caaace')]": false,
+ "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO')]": true,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#03fe83c2-0c23-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#04be2fcc-0b8f-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#217ea8d8-0c4f-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#219f2f58-0c2d-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#28315b28-0c5c-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#2949d00e-0c74-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#2baf819a-0c5b-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#2bda869c-0c5b-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#2ddb6462-0af7-11e1-8347-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#33168dd8-0cca-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#34646e74-0c6d-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#34f5ff9a-0b52-11e1-8347-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#372d624c-089d-11e1-8347-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#3861971e-0bef-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#3d9fa11a-0c46-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#4d418710-0c68-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#4f1cf90c-0b8c-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#4f205a20-0b8c-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#59477f38-0cae-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#5ac69eca-0c63-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#5b16394c-0b61-11e1-8347-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#5c53d062-0bed-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#5c8eb6e6-0c3d-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#61cbcdee-0bf5-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#6e1b7f22-0c04-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#6f6d60ae-0c11-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#789a7706-0c62-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#796abfd6-0c32-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#7ca5e2f6-0c6a-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#85e3e820-0c71-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#8751690a-0c4c-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#94d3bab4-0c0c-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#9cf7c56c-0b50-11e1-8347-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#a19beb7c-0c02-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#a34087a4-0ba2-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#a358bd92-0ba2-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#a8fb0a04-0bfa-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#a90bd6e6-0b5e-11e1-8347-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#adb27478-0b92-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#b334e4b0-0946-11e1-8347-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#b469f816-0946-11e1-8347-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#b5344df4-0c08-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#c5762ad0-0c1b-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#c5b07a28-0c1b-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#d0351502-0be5-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#e2ed5d7a-0c09-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW#f29b82f0-0c50-11e1-b764-003048caaace')]": false,
+ "isContainer:[('didName', '/MinimumBias/ComissioningHI-v1/RAW')]": true
 }

--- a/test/python/WMCore_t/Storage_t/Backends_t/SRMV2Impl_t.py
+++ b/test/python/WMCore_t/Storage_t/Backends_t/SRMV2Impl_t.py
@@ -58,16 +58,14 @@ class SRMV2ImplTest(unittest.TestCase):
     @mock.patch('WMCore.Storage.Backends.SRMV2Impl.SRMV2Impl.run')
     def testCreateOutputDirectory_exitCode(self, mock_run):
         mock_run.return_value = (1, "test")
-        self.assertRaises(RuntimeError("ERROR creating directory, test"),
-                          self.SRMV2Impl.createOutputDirectory("/folder/test/test2/test3/test4/test5"))
+        self.assertIsNone(self.SRMV2Impl.createOutputDirectory("/folder/test/test2/test3/test4/test5"))
         calls = [call("srmls -recursion_depth=0 -retry_num=1 /folder/test/test2/test3/test4")]
         mock_run.assert_has_calls(calls)
 
     @mock.patch('WMCore.Storage.Backends.SRMV2Impl.SRMV2Impl.run')
     def testCreateOutputDirectory_exitCode2(self, mock_run):
         mock_run.side_effect = [(0, "SRM_FAILURE test"), (0, "SRM_FAILURE test"), (1, "test")]
-        self.assertRaises(RuntimeError("ERROR creating directory, test"),
-                          self.SRMV2Impl.createOutputDirectory("folder/test1/test2/test3/test4/test5/test6/test7"))
+        self.assertIsNone(self.SRMV2Impl.createOutputDirectory("folder/test1/test2/test3/test4/test5/test6/test7"))
         calls = [call("srmls -recursion_depth=0 -retry_num=1 folder/test1/test2/test3/test4/test5/test6"),
                  call("srmls -recursion_depth=0 -retry_num=1 folder/test1/test2/test3/test4/test5"),
                  call("srmmkdir -retry_num=0 folder/test1/test2/test3/test4/test5/test6")]


### PR DESCRIPTION
Fixes #10542

#### Status
In development

#### Description

##### open


##### fixed

`SRMV2Impl_t.py`
- [x] `test/python/WMCore_t/Storage_t/Backends_t/SRMV2Impl_t.py:SRMV2ImplTest.testCreateOutputDirectory_exitCode`
- [x] `test/python/WMCore_t/Storage_t/Plugins_t/SRMV2Impl_t.py` raises some warning realted to buffersize of `Popen`, but the uinittests pass and they are marked as integration anyways. Despite no changes have been made, i consider these "fixed"

`src/python/WMCore/Services/Requests.py`
- [x] fixes `test/python/WMCore_t/Services_t/TagCollector_t/TagCollector_t.py`
  - check if the unittest failure is caused by this change
- [x] `test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Block_t.py:BlockTestCase.testContinuousSplittingSupport`. Rucio mock data has a similar problems to DBS mock data, with `u''` in the key strings
  - implemented a first draft / proposal, by emulating what has been done by Alan with DBS mock data



#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
follow up to #10299 

#### External dependencies / deployment changes
nope
