### PR TITLE
Fix string format for DBS mock calls; fixed WorkQueue_t unit test

### DIFF
--- a/src/python/WMCore/Services/Requests.py
+++ b/src/python/WMCore/Services/Requests.py
@@ -300,13 +300,13 @@ class Requests(dict):
     def decodeResult(self, result, decoder):
         """
         Decode the http/pycurl request result
+        NOTE: if decoder is provided with a False value, then it means no
+        decoding is applied on the results at all
         """
         if isinstance(decoder, (types.MethodType, types.FunctionType)):
             result = decoder(result)
         elif decoder is not False:
             result = self.decode(result)
-        if PY3:
-            result = decodeBytesToUnicode(result)
         return result
 
     def encode(self, data):
@@ -319,6 +319,8 @@ class Requests(dict):
         """
         decode data to some appropriate format, for now make it a string...
         """
+        if PY3:
+            return decodeBytesToUnicode(data)
         return data.__str__()
 
     def cachePath(self, given_path, service_name):

--- a/src/python/WMCore/WMSpec/Persistency.py
+++ b/src/python/WMCore/WMSpec/Persistency.py
@@ -74,11 +74,8 @@ class PersistencyHelper(object):
             # use own request class so we get authentication if needed
             from WMCore.Services.Requests import Requests
             request = Requests(filename)
-            data = request.makeRequest('', incoming_headers={"Accept": "*/*"})
+            data = request.makeRequest('', incoming_headers={"Accept": "*/*"}, decoder=False)
             self.data = pickle.loads(data[0])
-
-        # TODO: use different encoding scheme for different extension
-        # extension = filename.split(".")[-1].lower()
 
         return
 

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -394,7 +394,7 @@ class StdBase(object):
         eventStreams = self.eventStreams
         if 'Multicore' in taskConf and taskConf['Multicore'] > 0:
             multicore = taskConf['Multicore']
-        if 'EventStreams' in taskConf and taskConf['EventStreams'] >= 0:
+        if taskConf.get("EventStreams") is not None and taskConf['EventStreams'] >= 0:
             eventStreams = taskConf['EventStreams']
         procTaskCmsswHelper.setNumberOfCores(multicore, eventStreams)
 
@@ -1051,7 +1051,7 @@ class StdBase(object):
                      "ProcessingVersion": {"default": 1, "type": int, "validate": procversion},
                      "Memory": {"default": 2300.0, "type": float, "validate": lambda x: x > 0},
                      "Multicore": {"default": 1, "type": int, "validate": lambda x: x > 0},
-                     "EventStreams": {"type": int, "validate": lambda x: x >= 0, "null": True},
+                     "EventStreams": {"type": int, "default": 0, "validate": lambda x: x >= 0, "null": True},
                      "MergedLFNBase": {"default": "/store/data"},
                      "UnmergedLFNBase": {"default": "/store/unmerged"},
                      "DeleteFromSource": {"default": False, "type": strToBool},
@@ -1098,7 +1098,7 @@ class StdBase(object):
                      "ProcessingVersion": {"type": int, "validate": procversion, "assign_optional": True},
                      "Memory": {"type": float, "validate": lambda x: x > 0},
                      "Multicore": {"type": int, "validate": lambda x: x > 0},
-                     "EventStreams": {"type": int, "validate": lambda x: x >= 0, "null": True},
+                     "EventStreams": {"null": True, "default": 0, "type": int, "validate": lambda x: x >= 0},
 
                      "SiteBlacklist": {"default": [], "type": makeList,
                                        "validate": lambda x: all([cmsname(y) for y in x])},
@@ -1180,6 +1180,7 @@ class StdBase(object):
                      'ConfigCacheID': {'optional': False, 'type': str},
                      'DataPileup': {'default': None, 'null': False, 'optional': True, 'type': str,
                                     'validate': dataset},
+                     # for task/step level, the default EventStreams value (0) comes from the top level
                      'EventStreams': {'null': True, 'type': int, 'validate': lambda x: x >= 0},
                      'EventsPerJob': {'null': True, 'type': int, 'validate': lambda x: x > 0},
                      'EventsPerLumi': {'default': None, 'null': True, 'optional': True, 'type': int,

--- a/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
@@ -321,7 +321,7 @@ class StepChainWorkloadFactory(StdBase):
             eventStreams = self.eventStreams
             if taskConf['Multicore'] > 0:
                 multicore = taskConf['Multicore']
-            if taskConf.get('EventStreams') >= 0:
+            if taskConf.get('EventStreams') > 0:
                 eventStreams = taskConf['EventStreams']
 
             currentCmsswStepHelper.setNumberOfCores(multicore, eventStreams)

--- a/src/python/WMCore/WorkQueue/WMBSHelper.py
+++ b/src/python/WMCore/WorkQueue/WMBSHelper.py
@@ -32,13 +32,12 @@ from WMCore.WMRuntime.SandboxCreator import SandboxCreator
 
 
 def wmbsSubscriptionStatus(logger, dbi, conn, transaction):
-    """Function to return status of wmbs subscriptions
     """
-    action = DAOFactory(package='WMBS',
-                        logger=logger,
-                        dbinterface=dbi)('Monitoring.SubscriptionStatus')
-    return action.execute(conn=conn,
-                          transaction=transaction)
+    Function to return status of wmbs subscriptions
+    """
+    daoFactory = DAOFactory(package='WMCore.WMBS', logger=logger, dbinterface=dbi)
+    action = daoFactory(classname='Monitoring.SubscriptionStatus')
+    return action.execute(conn=conn, transaction=transaction)
 
 
 class WorkQueueWMBSException(WMException):

--- a/test/python/WMCore_t/Services_t/Requests_t.py
+++ b/test/python/WMCore_t/Services_t/Requests_t.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: ISO-8859-1 -*-
-'''n
+"""
 Created on Aug 6, 2009
 
 @author: meloam
-'''
-
+"""
 from __future__ import print_function
 from future import standard_library
 standard_library.install_aliases()
@@ -120,7 +119,7 @@ class testRepeatCalls(RESTBaseUnitTest):
             time.sleep(i)
             print('test %s starting at %s' % (i, time.time()))
             try:
-                result = req.get('/', incoming_headers={'Cache-Control': 'no-cache'}, decode=False)
+                result = req.get('/', incoming_headers={'Cache-Control': 'no-cache'}, decode=True)
                 self.assertEqual(False, result[3])
                 self.assertEqual(200, result[1])
             except HTTPException as he:
@@ -154,11 +153,11 @@ class testRepeatCalls(RESTBaseUnitTest):
         idict = {'req_cache_path': self.cache_path, 'pycurl': 1}
         req = Requests.Requests(self.urlbase, idict)
         headers = {'Cache-Control': 'no-cache'}
-        self.assertRaises(pycurl.error, req.get, '/', incoming_headers=headers, decode=False)
+        self.assertRaises(pycurl.error, req.get, '/', incoming_headers=headers, decode=True)
 
         # now restart server and hope we can connect
         self.rt.start(blocking=False)
-        result = req.get('/', incoming_headers=headers, decode=False)
+        result = req.get('/', incoming_headers=headers, decode=True)
         self.assertEqual(result[3], False)
         self.assertEqual(result[1], 200)
 
@@ -296,7 +295,7 @@ class TestRequests(unittest.TestCase):
         if not isinstance(json.loads(out[0]), dict):
             msg = 'wrong data type'
             raise Exception(msg)
-        out = req.makeRequest('/auth/trouble', decoder=False)
+        out = req.makeRequest('/auth/trouble', decoder=True)
         self.assertEqual(out[1], 200)
         self.assertNotEqual(out[0].find('passed basic validation'), -1)
         self.assertNotEqual(out[0].find('certificate is a proxy'), -1)
@@ -312,7 +311,7 @@ class TestRequests(unittest.TestCase):
     def testSecureNoAuth_with_pycurl(self):
         """https with no client authentication"""
         req = Requests.Requests('https://cmsweb.cern.ch', {'pycurl': 1})
-        out = req.makeRequest('', decoder=False)
+        out = req.makeRequest('', decoder=True)
         self.assertEqual(out[1], 200)
         # we should get an html page in response
         self.assertNotEqual(out[0].find('html'), -1)
@@ -341,14 +340,14 @@ class TestRequests(unittest.TestCase):
         os.environ.pop('X509_USER_CERT', None)
         os.environ.pop('X509_USER_KEY', None)
         req = Requests.Requests('https://cmsweb.cern.ch:443', {'pycurl': 1})
-        out = req.makeRequest('/auth/trouble', decoder=False)
+        out = req.makeRequest('/auth/trouble', decoder=True)
         self.assertEqual(out[1], 200)
         self.assertNotEqual(out[0].find('passed basic validation'), -1)
 
     def testNoCache(self):
         """Cache disabled"""
         req = Requests.Requests('https://cmssdt.cern.ch/SDT/', {'cachepath': None})
-        out = req.makeRequest('/', decoder=False)
+        out = req.makeRequest('/', decoder=True)
         self.assertEqual(out[3], False)
         self.assertTrue('html' in out[0])
 

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
@@ -1057,7 +1057,7 @@ class TaskChainTests(EmulatedUnitTestCase):
         processorDocs = makeProcessingConfigs(self.configDatabase)
 
         arguments = TaskChainWorkloadFactory.getTestArguments()
-        arguments.update(REQUEST_INPUT)
+        arguments.update(deepcopy(REQUEST_INPUT))
         arguments['Task1']['ConfigCacheID'] = processorDocs['DigiHLT']
         arguments['Task2']['ConfigCacheID'] = processorDocs['Reco']
 
@@ -1088,7 +1088,7 @@ class TaskChainTests(EmulatedUnitTestCase):
         processorDocs = makeProcessingConfigs(self.configDatabase)
 
         testArguments = TaskChainWorkloadFactory.getTestArguments()
-        testArguments.update(REQUEST_INPUT)
+        testArguments.update(deepcopy(REQUEST_INPUT))
         testArguments['Task1']['ConfigCacheID'] = processorDocs['DigiHLT']
         testArguments['Task2']['ConfigCacheID'] = processorDocs['Reco']
 
@@ -2297,7 +2297,7 @@ class TaskChainTests(EmulatedUnitTestCase):
         processorDocs = makeProcessingConfigs(self.configDatabase)
 
         arguments = TaskChainWorkloadFactory.getTestArguments()
-        arguments.update(REQUEST_INPUT)
+        arguments.update(deepcopy(REQUEST_INPUT))
         arguments['Task1']['ConfigCacheID'] = processorDocs['DigiHLT']
         arguments['Task2']['ConfigCacheID'] = processorDocs['Reco']
         arguments['Task2']['KeepOutput'] = False


### PR DESCRIPTION
Fixes #10586 
Fixes https://github.com/dmwm/WMCore/issues/10589

#### Status
In development

#### Description
Given that the args/kwargs of the DBS mock calls are used as a dictionary key when looking up for the call signature, we need to make sure the string we pass matches the string expected in the json mock data. Here, we ensure that we won't pass an unicode string in python2.

Also fixed the `WorkQueue_t.testGlobalDatasetSplitting` unit test. Following up the logs, I agree that the actual expected amount of work was 1.

Changes to StdBase/StepChain, with regards to `EventStreams`, weere needed to change a comparison of (None and Int) to always (Int and Int). This is done by explicitly defining default `0` for EventStreams at the workload level (not inside the Task/Step).

Some changes to how HTTP responses are decoded, especially in cases where no decoding is wanted (besides the casting to string).
* in `CMSCouch`, `decode=False` meant plain string in PY2, but byte string in PY3. I changed it to always be unicode/text string (using `decode=decodeBytesToUnicode`). Not sure it's the best approach though...
* changed the behaviour of the response decoding in the base class `Requests`. When there is no specific function/method to decode our data, it will return a plain string in PY2, and unicode in PY3. `decoder=False` can be used when no decoding at all is wanted.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Complement to https://github.com/dmwm/WMCore/pull/10580

#### External dependencies / deployment changes
none
