### PR TITLE
[py2py3] Fix unittests from Slice 5 in py3

### DIFF
--- a/src/python/WMCore/DataStructs/File.py
+++ b/src/python/WMCore/DataStructs/File.py
@@ -5,7 +5,7 @@ _File_
 Data object that contains details for a single file
 
 """
-from past.builtins import basestring
+from builtins import str, bytes
 __all__ = []
 
 from WMCore.DataStructs.Run import Run
@@ -16,6 +16,11 @@ class File(WMObject, dict):
     """
     _File_
     Data object that contains details for a single file
+
+    TODO 
+    - use the decorator `from functools import total_ordering` after
+      dropping support for python 2.6
+    - then, drop __ne__, __le__, __gt__, __ge__
     """
 
     def __init__(self, lfn="", size=0, events=0, checksums=None,
@@ -94,7 +99,7 @@ class File(WMObject, dict):
         eq = False
         if isinstance(rhs, type(self)):
             eq = self['lfn'] == rhs['lfn']
-        elif isinstance(rhs, basestring):
+        elif isinstance(rhs, (str, bytes)):
             eq = self['lfn'] == rhs
         return eq
 
@@ -104,6 +109,27 @@ class File(WMObject, dict):
     def __hash__(self):
         thisHash = self['lfn'].__hash__()
         return thisHash
+
+    def __lt__(self, rhs):
+        """
+        Sort files based on lexicographical ordering of the value connected
+        to the 'lfn' key
+        """
+        eq = False
+        if isinstance(rhs, type(self)):
+            eq = self['lfn'] < rhs['lfn']
+        elif isinstance(rhs, (str, bytes)):
+            eq = self['lfn'] < rhs
+        return eq
+
+    def __le__(self, other):
+        return self.__lt__(other) or self.__eq__(other)
+
+    def __gt__(self, other):
+        return not self.__le__(other)
+
+    def __ge__(self, other):
+        return not self.__lt__(other)
 
     def json(self, thunker=None):
         """
@@ -125,7 +151,7 @@ class File(WMObject, dict):
                     "parents": []}
 
         for parent in self["parents"]:
-            if isinstance(parent, basestring):
+            if isinstance(parent, (str, bytes)):
                 # Then for some reason, we're passing strings
                 # Done specifically for ErrorHandler
                 fileDict['parents'].append(parent)

--- a/src/python/WMCore/Services/UserFileCache/UserFileCache.py
+++ b/src/python/WMCore/Services/UserFileCache/UserFileCache.py
@@ -14,6 +14,9 @@ import hashlib
 import tarfile
 import tempfile
 
+from Utils.Utilities import encodeUnicodeToBytesConditional
+from Utils.PythonVersion import PY3
+
 from WMCore.Services.Service import Service
 
 
@@ -60,7 +63,7 @@ def calculateChecksum(tarfile_, exclude=None):
         for tarmember in tar:
             if tarmember.name in excludeList:
                 continue
-            hasher.update(tarmember.name)
+            hasher.update(encodeUnicodeToBytesConditional(tarmember.name, condition=PY3))
             if tarmember.isfile() and tarmember.name.split('.')[-1]!='pkl':
                 tar.extractall(path=tmpDir, members=[tarmember])
                 fn = os.path.join(tmpDir, tarmember.name)

--- a/src/python/WMCore/Services/pycurl_manager.py
+++ b/src/python/WMCore/Services/pycurl_manager.py
@@ -291,8 +291,8 @@ class RequestHandler(object):
                 data = self.parse_body(bbuf.getvalue(), decode)
         else:
             data = bbuf.getvalue()
-            msg = 'url=%s, code=%s, reason=%s, headers=%s' \
-                  % (url, header.status, header.reason, header.header)
+            msg = 'url=%s, code=%s, reason=%s, headers=%s, result=%s' \
+                  % (url, header.status, header.reason, header.header, data)
             exc = http.client.HTTPException(msg)
             setattr(exc, 'req_data', params)
             setattr(exc, 'req_headers', headers)

--- a/src/python/WMCore/Storage/Execute.py
+++ b/src/python/WMCore/Storage/Execute.py
@@ -9,6 +9,7 @@ from __future__ import print_function
 
 from subprocess import Popen, PIPE
 
+from Utils.PythonVersion import PY3
 from WMCore.Storage.StageOutError import StageOutError
 
 def runCommand(command):
@@ -21,7 +22,11 @@ def runCommand(command):
 
     """
     # capture stdout and stderr from command
-    child = Popen(command, shell=True, bufsize=1, stdin=PIPE, close_fds=True)
+    if PY3:
+        # python2 pylint complains about `encoding` argument
+        child = Popen(command, shell=True, bufsize=1, stdin=PIPE, close_fds=True, encoding='utf8')
+    else:
+        child = Popen(command, shell=True, bufsize=1, stdin=PIPE, close_fds=True)
 
     child.communicate()
     retCode = child.returncode
@@ -39,7 +44,11 @@ def runCommandWithOutput(command):
 
     """
     # capture stdout and stderr from command
-    child = Popen(command, shell=True, bufsize=1, stdin=PIPE, stdout=PIPE, stderr=PIPE, close_fds=True)
+    if PY3:
+        # python2 pylint complains about `encoding` argument
+        child = Popen(command, shell=True, bufsize=1, stdin=PIPE, stdout=PIPE, stderr=PIPE, close_fds=True, encoding='utf8')
+    else:
+        child = Popen(command, shell=True, bufsize=1, stdin=PIPE, stdout=PIPE, stderr=PIPE, close_fds=True)
 
     sout, serr = child.communicate()
     retCode = child.returncode

--- a/src/python/WMCore/WMBS/WorkUnit.py
+++ b/src/python/WMCore/WMBS/WorkUnit.py
@@ -33,7 +33,7 @@ class WorkUnit(WMBSBase, DSWorkUnit):
         If id is given, check with id or check with taskid, fileid, run/lumi
         """
 
-        if self['id'] > 0:
+        if self['id'] and self['id'] > 0:
             action = self.daofactory(classname='WorkUnit.ExistsByID')
             result = action.execute(wuid=self['id'], conn=self.getDBConn(), transaction=self.existingTransaction())
         elif self['taskid'] and self['fileid'] and self['run_lumi']:
@@ -59,7 +59,7 @@ class WorkUnit(WMBSBase, DSWorkUnit):
         Load any meta data that is associated with a WorkUnit.
         """
 
-        if self['id'] > 0:
+        if self['id'] and self['id'] > 0:
             action = self.daofactory(classname="WorkUnit.GetByID")
             result = action.execute(self['id'], conn=self.getDBConn(), transaction=self.existingTransaction())
         elif self['taskid'] and self['fileid'] and self['run_lumi']:

--- a/test/etc/UnstableTests.txt
+++ b/test/etc/UnstableTests.txt
@@ -24,7 +24,6 @@ WMCore_t.ReqMgr_t.Service_t.Auxiliary_t.AuxiliaryTest:testAllTransferDocs
 ### Starting here, we have the Python3 unstable tests
 WMCore_t.JobSplitting_t.RunBased_t.RunBasedTest:testMultipleRunsCombine
 WMCore_t.MicroService_t.MSRuleCleaner_t.MSRuleCleanerWflow_t.MSRuleCleanerWflowTest:testMultiPU
-WMCore_t.ReqMgr_t.DataStructs_t.Request_t.RequestTests:testRequestInfoTaskChain
 WMCore_t.Services_t.LogDB_t.LogDB_t.LogDBTest:test_heartbeat
 WMCore_t.Services_t.Requests_t.testRepeatCalls:testRecoveryFromConnRefused_with_pycur
 WMCore_t.Services_t.Requests_t.testRepeatCalls:test10Calls

--- a/test/etc/UnstableTests.txt
+++ b/test/etc/UnstableTests.txt
@@ -31,3 +31,4 @@ WMCore_t.WMBS_t.JobSplitting_t.EventBased_t.EventBasedTest:test100EventMultipleS
 WMCore_t.WMBS_t.JobSplitting_t.FileBased_t.FileBasedTest:testSiteWhiteBlacklist
 WMCore_t.WMBS_t.JobSplitting_t.RunBased_t.EventBasedTest:testMultipleRunsCombine
 WMCore_t.WMBS_t.JobSplitting_t.FileBased_t.FileBasedTest:testLocationSplit
+WMCore_t.WMSpec_t.StdSpecs_t.ReReco_t.ReRecoTest:testFilesets 

--- a/test/python/WMCore_t/ReqMgr_t/DataStructs_t/Request_t.py
+++ b/test/python/WMCore_t/ReqMgr_t/DataStructs_t/Request_t.py
@@ -327,7 +327,7 @@ class RequestTests(unittest.TestCase):
         self.assertEqual(reqInfo.get(prop="AcquisitionEra"), ["ACQERA"])
         # NOTE: inner task properties have precedence over the top level ones.
         self.assertEqual(reqInfo.get(prop="ProcessingVersion"), [2])
-        self.assertEqual(reqInfo.get(prop="BlockWhitelist"), ["A", "B"])
+        self.assertItemsEqual(reqInfo.get(prop="BlockWhitelist"), ["A", "B"])
         self.assertItemsEqual(reqInfo.get(prop="ScramArch"), ['slc6_amd64_gcc481',
                                                               'slc6_amd64_gcc493', 'slc7_amd64_gcc630'])
 

--- a/test/python/WMCore_t/Services_t/ReqMgr_t/ReqMgr_t.py
+++ b/test/python/WMCore_t/Services_t/ReqMgr_t/ReqMgr_t.py
@@ -131,7 +131,7 @@ class ReqMgrTest(RESTBaseUnitTestWithDBBackend):
         self.assertEqual(len(response), 0)
         response = self.reqSvc.getRequestByStatus('assigned')
         self.assertEqual(len(response), 1)
-        self.assertEqual(response[0].values()[0]["SiteWhitelist"], ["T1_US_CBS"])
+        self.assertEqual(list(response[0].values())[0]["SiteWhitelist"], ["T1_US_CBS"])
 
         self.reqSvc.updateRequestStats(requestName, {'total_jobs': 100, 'input_lumis': 100,
                                'input_events': 100, 'input_num_files': 100})

--- a/test/python/WMCore_t/Storage_t/Execute_t.py
+++ b/test/python/WMCore_t/Storage_t/Execute_t.py
@@ -5,6 +5,8 @@ import unittest
 
 from mock import  mock
 
+from Utils.PythonVersion import PY3
+
 from WMCore.Storage.Execute import execute, runCommand, runCommandWithOutput
 from WMCore.Storage.StageOutError import StageOutError
 from WMCore.WMBase import getTestBase
@@ -12,6 +14,9 @@ from WMCore.WMBase import getTestBase
 
 class ExecuteTest(unittest.TestCase):
     base = os.path.join(getTestBase(), "WMCore_t/Storage_t/ExecutableCommands.py")
+
+    def setUp(self):
+        self.python_runtime = "python3" if PY3 else "python"
 
     @mock.patch('WMCore.Storage.Execute.runCommandWithOutput')
     def testExecute_exception(self, execute_runCommand):
@@ -30,16 +35,16 @@ class ExecuteTest(unittest.TestCase):
         execute_runCommand.assert_called_with("test")
 
     def testRunCommand_results(self):
-        self.assertEqual(1, runCommand("python %s -exit 0" % self.base))
-        self.assertEqual(1, runCommand("python %s -exit a" % self.base))
-        self.assertEqual(2, runCommand("python %s -text" % self.base))
-        self.assertEqual(0, runCommand("python %s -text a" % self.base))
+        self.assertEqual(1, runCommand("%s %s -exit 0" % (self.python_runtime, self.base)))
+        self.assertEqual(1, runCommand("%s %s -exit a" % (self.python_runtime, self.base)))
+        self.assertEqual(2, runCommand("%s %s -text" % (self.python_runtime, self.base)))
+        self.assertEqual(0, runCommand("%s %s -text a" % (self.python_runtime, self.base)))
 
     def testRunCommandWithOutput_results(self):
-        err, text = runCommandWithOutput("python %s -text" % self.base)
+        err, text = runCommandWithOutput("%s %s -text" % (self.python_runtime, self.base))
         self.assertEqual(2, err)
         self.assertTrue("ExecutableCommands.py: error" in text)
-        self.assertEqual((1, 'stdout: \nstderr: 0\n'), runCommandWithOutput("python %s -exit 0" % self.base))
-        self.assertEqual((1, 'stdout: \nstderr: a\n'), runCommandWithOutput("python %s -exit a" % self.base))
-        self.assertEqual((0, 'stdout: a\n\nstderr: '), runCommandWithOutput("python %s -text a" % self.base))
+        self.assertEqual((1, 'stdout: \nstderr: 0\n'), runCommandWithOutput("%s %s -exit 0" % (self.python_runtime, self.base)))
+        self.assertEqual((1, 'stdout: \nstderr: a\n'), runCommandWithOutput("%s %s -exit a" % (self.python_runtime, self.base)))
+        self.assertEqual((0, 'stdout: a\n\nstderr: '), runCommandWithOutput("%s %s -text a" % (self.python_runtime, self.base)))
 


### PR DESCRIPTION
Fixes #10536 

#### Status
ready - needs rebasing onto #10595 

#### Description

##### open

- [x] rebasing

##### fixed

- [x] `src/python/WMCore/Services/UserFileCache/UserFileCache.py`: convert to bytes input of hashlib
- [x] proposal for more useful logs from `pycurl_manager` when connections fails. useful in case of 500 errors.
- [x] `test/python/WMCore_t/WMBS_t/File_t.py:FileTest.testGetParentLFNs`: `TypeError: '<' not supported between instances of 'File' and 'File'`
  - based on `__eq__()`, built `__lt__()` and the other ordering operators for `src/python/WMCore/WMBS/File.py.File.getParentsLFNs()`
- [x]  `test/python/WMCore_t/Services_t/ReqMgr_t/ReqMgr_t.py` fixed with some changes (among cherrypicking some from #10595)

    however, this uinittest hangs in both py2 and py3 at the line https://github.com/dmwm/WMCore/blob/6cab2cbec356c63f9c175ac21995dc199ea0ad5d/test/python/WMCore_t/Services_t/ReqMgr_t/ReqMgr_t.py#L139

- [x] add again change (see comments below)
    ```diff
    -    result = "".join(result)
    +    result = b"".join(result)
    ```

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
follow up to #10262 

#### External dependencies / deployment changes
nope
