### PR TITLE
Fix issue with merge process and output labels (Merged and MergedError)

### DIFF
--- a/src/python/PSetTweaks/PSetTweak.py
+++ b/src/python/PSetTweaks/PSetTweak.py
@@ -421,6 +421,16 @@ class PSetTweak(object):
             for param, value in viewitems(jsoniser.parameters):
                 self.addParameter(param , value)
 
+    def reset(self):
+        """
+        _reset_
+
+        Reset pset holder process
+
+        """
+        del self.process
+        self.process = PSetHolder("process")
+
 
 def makeTweakFromJSON(jsonDictionary):
     """

--- a/src/python/PSetTweaks/WMTweak.py
+++ b/src/python/PSetTweaks/WMTweak.py
@@ -516,7 +516,7 @@ def makeOutputTweak(outMod, job, result):
 
     """
     # output filenames
-    modName = str(getattr(outMod, "_internal_name"))
+    modName = outMod.getInternalName()
     logging.info("modName = %s", modName)
     fileName = "%s.root" % modName
 

--- a/src/python/WMCore/Configuration.py
+++ b/src/python/WMCore/Configuration.py
@@ -357,6 +357,15 @@ class ConfigSection(object):
         comps = self._internal_settings
         return list(comps)
 
+    def getInternalName(self):
+        """
+        _getInternalName_
+
+        Return the internal name
+
+        """
+        return self._internal_name
+
 
 class Configuration(object):
     # pylint: disable=protected-access

--- a/test/python/WMCore_t/Configuration_t.py
+++ b/test/python/WMCore_t/Configuration_t.py
@@ -327,5 +327,15 @@ class ConfigurationTest(unittest.TestCase):
         self.assertEqual(d["Task1"]["subSection"]["value3"], "MyValue3")
 
 
+    def testI_testGetInternalName(self):
+        """
+        Test we properly retrieve the internal name of the configuration object
+
+        """
+        config = ConfigSection("config")
+        name = config.getInternalName()
+        self.assertEqual(name, "config")
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #10592

#### Status
not-tested

#### Description
This solution avoids tweaking both `Merged` and `MergedError` output labels, but only one of them, depending on whether `--useErrorDataset` was used or not when creating the process.

#### Is it backward compatible (if not, which system it affects?)
YES
