### PR TITLE
Deal with EventStreams=None in StepChain step level

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
@@ -321,7 +321,7 @@ class StepChainWorkloadFactory(StdBase):
             eventStreams = self.eventStreams
             if taskConf['Multicore'] > 0:
                 multicore = taskConf['Multicore']
-            if taskConf.get('EventStreams') > 0:
+            if taskConf.get("EventStreams") is not None and taskConf['EventStreams'] >= 0:
                 eventStreams = taskConf['EventStreams']
 
             currentCmsswStepHelper.setNumberOfCores(multicore, eventStreams)


### PR DESCRIPTION
Complement to #10588 

#### Status
ready

#### Description
Apparently I missed running the StepChain_t unit tests after removing the EventStreams default value in a Step/Task dictionary.
This PR fixes the StepChain creation and properly set the EventStreams value in the workflow steps.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Complement/bugfix for https://github.com/dmwm/WMCore/pull/10588

#### External dependencies / deployment changes
none
