### PR TITLE
MSUnmerged basic skeleton.

### DIFF
--- a/src/python/WMCore/MicroService/DataStructs/DefaultStructs.py
+++ b/src/python/WMCore/MicroService/DataStructs/DefaultStructs.py
@@ -76,3 +76,15 @@ RULECLEANER_REPORT = dict(thread_id="",
                           failed_container_rules_deleted=0,
                           success_request_transition=0,
                           failed_request_transition=0)
+
+# summary metrics for the MSUnmerged thread
+# (also available through the `info` REST API)
+UNMERGED_REPORT = dict(thread_id="",
+                       start_time=0,
+                       end_time=0,
+                       execution_time=0,
+                       error="",
+                       total_num_rses=0,
+                       total_num_files=0,
+                       num_rses_cleaned=0,
+                       num_files_deleted=0)

--- a/src/python/WMCore/MicroService/MSCore.py
+++ b/src/python/WMCore/MicroService/MSCore.py
@@ -16,7 +16,7 @@ from WMCore.Services.Rucio.Rucio import Rucio
 class MSCore(object):
     """
     This class provides core functionality for
-    MSTransferor, MSMonitor, MSOutput. MSRuleCleaner classes.
+    MSTransferor, MSMonitor, MSOutput, MSRuleCleaner, MSUnmerged classes.
     """
 
     def __init__(self, msConfig, **kwargs):

--- a/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
+++ b/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
@@ -1,0 +1,83 @@
+"""
+File       : MSUnmerged.py
+
+Description:
+
+This MicroService is meant to remove all no longer needed files from the unmerged
+area of the CMS LFN Namespace. The cleanup process is supposed to happen on a per
+RSE basis.
+"""
+
+# futures
+from __future__ import division, print_function
+
+# WMCore modules
+from WMCore.MicroService.DataStructs.DefaultStructs import UNMERGED_REPORT
+from WMCore.MicroService.MSCore import MSCore
+# from WMCore.Services.AlertManager.AlertManagerAPI import AlertManagerAPI
+from WMCore.WMException import WMException
+
+
+class MSUnmergedException(WMException):
+    """
+    General Exception Class for MSUnmerged Module in WMCore MicroServices
+    """
+    def __init__(self, message):
+        self.myMessage = "MSUnmergedException: %s" % message
+        super(MSUnmergedException, self).__init__(self.myMessage)
+
+
+class MSUnmerged(MSCore):
+    """
+    MSUnmerged.py class provides the logic for cleaning the unmerged area of
+    the CMS LFN Namespace.
+    """
+
+    def __init__(self, msConfig, logger=None):
+        """
+        Runs the basic setup and initialization for the MSUnmerged module
+        :param msConfig: micro service configuration
+        """
+        super(MSUnmerged, self).__init__(msConfig, logger=logger)
+
+        self.msConfig.setdefault("verbose", True)
+        self.msConfig.setdefault("interval", 60)
+        self.msConfig.setdefault('limitRSEsPerInstance', 100)
+        self.msConfig.setdefault('limitTiersPerInstance', ['T1', 'T2', 'T3'])
+        self.msConfig.setdefault("rucioAccount", "FIXME_RUCIO_ACCT")
+        self.alertServiceName = "ms-unmerged"
+        # TODO: Add 'alertManagerUrl' to msConfig'
+        # self.alertManagerAPI = AlertManagerAPI(self.msConfig.get("alertManagerUrl", None), logger=logger)
+
+    def execute(self):
+        """
+        Executes the whole MSUnmerged logic
+        :return: summary
+        """
+        # start threads in MSManager which should call this method
+        summary = dict(UNMERGED_REPORT)
+
+        try:
+            rseList = self.getRSEList()
+            self.updateReportDict(summary, "total_num_rses", len(rseList))
+            msg = "  retrieved %s RSEs. " % len(rseList)
+            msg += "Service set to process up to %s RSEs per instance." % self.msConfig["limitRSEsPerInstance"]
+            self.logger.info(msg)
+        except Exception as err:  # general error
+            msg = "Unknown exception while fetching RSEs from CRIC. Error: %s", str(err)
+            self.logger.exception(msg)
+            self.updateReportDict(summary, "error", msg)
+
+        # this one is put here just for example.
+        self.updateReportDict(summary, "error", 42)
+        return summary
+
+    def getRSEList(self):
+        """
+        Queries CRIC for the proper RSE lists to iterate through.
+        return: List of RSEs.
+        """
+        # NOTE: To filter out the granularity (Tier*) level.
+        rseList = []
+
+        return rseList


### PR DESCRIPTION
Fixes #10402 

#### Status
ready

#### Description
Provides the basic skeleton for MSUnmerged

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
 * have a bare minimum functional microservice called MSUnmerged (without any service logic) - https://github.com/dmwm/WMCore/pull/10598
 * create the deployment scripts - https://github.com/dmwm/deployment/pull/1059
 * create the deployment frontend rules - https://github.com/dmwm/deployment/pull/1060
 * create the deployment scripts in services_config gitlab repository (preprod and prod branches, maybe test as well) -   
    * https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/89 
    * https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/90
 * create the CMSKubernetes yaml file  - https://github.com/dmwm/CMSKubernetes/pull/604



#### External dependencies / deployment changes

