### PR TITLE
Format REST response to bytes in Python3

### DIFF
--- a/src/python/WMCore/REST/Format.py
+++ b/src/python/WMCore/REST/Format.py
@@ -2,12 +2,11 @@ from __future__ import print_function
 
 from builtins import str, bytes, object
 from Utils.PythonVersion import PY3
-from Utils.Utilities import encodeUnicodeToBytes
+from Utils.Utilities import encodeUnicodeToBytes, encodeUnicodeToBytesConditional
 from future.utils import viewitems
 
 import hashlib
 import json
-import types
 import xml.sax.saxutils
 import zlib
 from traceback import format_exc
@@ -616,6 +615,8 @@ def stream_maybe_etag(size_limit, etag, reply):
     res.headers['Content-Length'] = size
     # TODO investigate why `result` is a list of bytes strings in py3
     # The current solution seems to work in both py2 and py3
-    result = b"".join(result) if PY3 else "".join(result)
-    assert len(result) == size
-    return result
+    resp = b"" if PY3 else ""
+    for item in result:
+        resp += encodeUnicodeToBytesConditional(item, condition=PY3)
+    assert len(resp) == size
+    return resp


### PR DESCRIPTION
Fixes #10587 

#### Status
ready

#### Description
Most of the Format.py issues have been solved by Dario (thanks!!!) in this PR:
https://github.com/dmwm/WMCore/pull/10590

but we still had a problem with bytes vs text strings in the REST/Format response for a call like [1], which was giving a 500 Internal Server Error.

This PR keeps returning a byte string as a result of the call, and also casts the internal list items to bytes, if needed (only in PY3).

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Follow up of: https://github.com/dmwm/WMCore/pull/10590

#### External dependencies / deployment changes
And now it goes through:
[1]
curl --cert $X509_USER_CERT --key $X509_USER_KEY https://alancc7-cloud2.cern.ch/reqmgr2/data/info
{"result": [
 {
  "wmcore_reqmgr_version": "1.5.0.pre2",
  "reqmgr_db_info": {
    "db_name": "reqmgr_workload_cache",
    "doc_count": 1,
    "doc_del_count": 0,
    "update_seq": 1,
    "purge_seq": 0,
    "compact_running": false,
    "disk_size": 8290,
    "data_size": 5465,
    "instance_start_time": "1623830168072244",
    "disk_format_version": 6,
    "committed_update_seq": 1,
    "reqmgr_couch_url": "https://alancc7-cloud2.cern.ch/couchdb"
  },
  "reqmgr_last_injected_request": {
    "total_rows": 0,
    "offset": 0,
    "rows": []
  }
}]}