### PR TITLE
 [py2py3] Fix unittests from Slice 12 in py3 

### DIFF
--- a/src/python/WMCore/Database/CMSCouch.py
+++ b/src/python/WMCore/Database/CMSCouch.py
@@ -70,7 +70,7 @@ class Document(dict):
         # https://issues.apache.org/jira/browse/COUCHDB-1141
         deletedDict = {'_id': self['_id'], '_rev': self['_rev'], '_deleted': True}
         self.update(deletedDict)
-        for key in self.keys():
+        for key in list(self.keys()):
             if key not in deletedDict:
                 del self[key]
 

--- a/src/python/WMCore/MicroService/MSTransferor/Workflow.py
+++ b/src/python/WMCore/MicroService/MSTransferor/Workflow.py
@@ -357,7 +357,7 @@ class Workflow(object):
             return [thisChunk], [thisChunkSize]
 
         # create a descendant list of blocks according to their sizes
-        sortedPrimary = sorted(viewitems(self.getPrimaryBlocks()), key=operator.itemgetter(1), reverse=True)
+        sortedPrimary = sorted(viewitems(self.getPrimaryBlocks()), key=lambda item: item[1]['blockSize'], reverse=True)
         if len(sortedPrimary) < numChunks:
             msg = "There are less blocks than chunks to create. "
             msg += "Reducing numChunks from %d to %d" % (numChunks, len(sortedPrimary))

--- a/test/etc/UnstableTests.txt
+++ b/test/etc/UnstableTests.txt
@@ -31,4 +31,6 @@ WMCore_t.WMBS_t.JobSplitting_t.EventBased_t.EventBasedTest:test100EventMultipleS
 WMCore_t.WMBS_t.JobSplitting_t.FileBased_t.FileBasedTest:testSiteWhiteBlacklist
 WMCore_t.WMBS_t.JobSplitting_t.RunBased_t.EventBasedTest:testMultipleRunsCombine
 WMCore_t.WMBS_t.JobSplitting_t.FileBased_t.FileBasedTest:testLocationSplit
+WMCore_t.WMSpec_t.StdSpecs_t.Express_t.ExpressTest:testFilesets
 WMCore_t.WMSpec_t.StdSpecs_t.ReReco_t.ReRecoTest:testFilesets 
+WMCore_t.WorkQueue_t.Policy_t.Start_t.Block_t.BlockTestCase:testPileupData


### PR DESCRIPTION
Related to #10543 (but not fixing)

#### Status

Ready

#### Description

##### open

These unittests are failing in `test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py`, but are not addressed here

```
test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py:WorkQueueTest.testWhiteList
test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py:WorkQueueTest.testProcessingWithContinuousSplitting
test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py:WorkQueueTest.testProcessing
test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py:WorkQueueTest.testBlackList
```

##### closed

- [x] `test/python/WMCore_t/MicroService_t/MSTransferor_t/Workflow_t.py:WorkflowTest.testGetChunkBlocks2`. comparison between dict
  - We have a dictionary of the form `{'block_A': <dict 1>, 'block_B': <dict 2>}`. We wanted to create a sorted list of tuples of the form `[('block_B', <dict 2>), ('block_A', <dict 1>)]`. In order to sort the items, we compared `<dict 1>` and `<dict 2>`. in py2 this was allowed, in py3 this is not allowed. I propose to simply compare the keys. Keys in dictionaries have to be hashable, so there is a high chance that they implement comparison operators, too. This approach does not seem to cause any problem in the unittests.

- [x] `test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py` - fixed bug in `src/python/WMCore/Database/CMSCouch.py` relaetd to dict changing size during for loop

The failing unittests are

- unstable
- related to assertion errors in `Workflow_t.py`

(in case i need pre-squashed commits: https://github.com/dmwm/WMCore/commit/eceea52bc929c3cd774c94e8e5ecde0697ce854e )

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
This is a folow up to #10307 

#### External dependencies / deployment changes
nope
