### PR TITLE
Replace built-in hash function by hashlib.sha1

### DIFF
--- a/src/python/WMCore/DataStructs/WorkUnit.py
+++ b/src/python/WMCore/DataStructs/WorkUnit.py
@@ -11,9 +11,11 @@ from __future__ import absolute_import, division, print_function
 from future.utils import listitems
 
 import sys
+import hashlib
 import time
 from functools import total_ordering
 
+from Utils.Utilities import encodeUnicodeToBytes
 from WMCore.DataStructs.WMObject import WMObject
 
 
@@ -71,8 +73,16 @@ class WorkUnit(WMObject, dict):
         """
         Hash function for this dict.
         """
-
-        return hash(frozenset(listitems(self)))
+        # Generate an immutable sorted string representing this object
+        # NOTE: the run object needs to be hashed
+        immutableSelf = []
+        for keyName in sorted(self):
+            if keyName == "run_lumi":
+                immutableSelf.append((keyName, hash(self[keyName])))
+            else:
+                immutableSelf.append((keyName, self[keyName]))
+        hashValue = hashlib.sha1(encodeUnicodeToBytes(str(immutableSelf)))
+        return int(hashValue.hexdigest()[:15], 16)
 
     def json(self, thunker=None):
         """

--- a/src/python/WMCore/WMRuntime/Scripts/UnpackUserTarball.py
+++ b/src/python/WMCore/WMRuntime/Scripts/UnpackUserTarball.py
@@ -6,10 +6,14 @@ Unpack the user tarball and put it's contents in the right place
 """
 from __future__ import print_function
 from future import standard_library
+
+from Utils.Utilities import encodeUnicodeToBytes
+
 standard_library.install_aliases()
 
 import logging
 import os
+import hashlib
 import re
 import shutil
 import subprocess
@@ -35,7 +39,8 @@ def setHttpProxy(url):
 
     proxyList = re.findall('\(proxyurl=([\w\d\.\-\:\/]+)\)', output)
     if 'loadbalance=proxies' in output:
-        proxy = proxyList[hash(url) % len(proxyList)]
+        urlHash = int(hashlib.sha1(encodeUnicodeToBytes(url)).hexdigest()[:15], 16)
+        proxy = proxyList[urlHash % len(proxyList)]
     else:
         proxy = proxyList[0]
     os.environ['http_proxy'] = proxy

--- a/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
+++ b/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
@@ -9,11 +9,13 @@ from future.utils import viewitems
 
 import datetime
 import os
+import hashlib
 import shutil
 import time
 import logging
 from json import JSONEncoder
 import WMCore.WMSpec.WMStep as WMStep
+from Utils.Utilities import encodeUnicodeToBytes
 from WMCore.Services.DBS.DBSReader import DBSReader
 from WMCore.Services.Rucio.Rucio import Rucio
 from WMCore.WMSpec.Steps.Fetchers.FetcherInterface import FetcherInterface
@@ -91,10 +93,10 @@ class PileupFetcher(FetcherInterface):
         fileName = ""
         for pileupType in stepHelper.data.pileup.listSections_():
             datasets = getattr(getattr(stepHelper.data.pileup, pileupType), "dataset")
-            fileName += ("_").join(datasets)
+            fileName += "_".join(datasets)
         # TODO cache is not very effective if the dataset combination is different between workflow
-        # here is possibility of hash value collision
-        cacheFile = "%s/pileupconf-%s.json" % (self.cacheDirectory(), hash(fileName))
+        cacheHash = hashlib.sha1(encodeUnicodeToBytes(fileName)).hexdigest()
+        cacheFile = "%s/pileupconf-%s.json" % (self.cacheDirectory(), cacheHash)
         return cacheFile
 
     def _getStepFilePath(self, stepHelper):

--- a/src/python/WMQuality/Emulators/RucioClient/MockRucioApi.py
+++ b/src/python/WMQuality/Emulators/RucioClient/MockRucioApi.py
@@ -4,19 +4,19 @@
 Version of WMCore/Services/Rucio intended to be used with mock or unittest.mock
 """
 from __future__ import print_function, division
-from future.utils import listitems
 # from builtins import object # avoid importing this, it beraks things
 
 import json
 import logging
 import os
+import hashlib
 
 from WMCore.Services.DBS.DBS3Reader import DBS3Reader, DBSReaderError
 from WMCore.Services.Rucio.Rucio import WMRucioException, WMRucioDIDNotFoundException
 from WMCore.WMBase import getTestBase
 from WMQuality.Emulators.DataBlockGenerator.DataBlockGenerator import DataBlockGenerator
 
-from Utils.PythonVersion import PY2
+from Utils.PythonVersion import PY2, PY3
 from Utils.Utilities import encodeUnicodeToBytesConditional
 
 PROD_DBS = 'https://cmsweb-prod.cern.ch/dbs/prod/global/DBSReader'
@@ -58,9 +58,12 @@ class MockRucioApi(object):
         :return: a fake list of sites where the data is
         """
         logging.info("%s: Calling mock sitesByBlock", self.__class__.__name__)
-        if hash(block) % 3 == 0:
+        block = encodeUnicodeToBytesConditional(block, condition=PY3)
+        # this algorithm gives same results in both python versions
+        blockHash = int(hashlib.sha1(block).hexdigest()[:8], 16)
+        if blockHash % 3 == 0:
             sites = ['T2_XX_SiteA']
-        elif hash(block) % 3 == 1:
+        elif blockHash % 3 == 1:
             sites = ['T2_XX_SiteA', 'T2_XX_SiteB']
         else:
             sites = ['T2_XX_SiteA', 'T2_XX_SiteB', 'T2_XX_SiteC']

--- a/test/python/WMCore_t/DataStructs_t/Run_t.py
+++ b/test/python/WMCore_t/DataStructs_t/Run_t.py
@@ -200,6 +200,15 @@ class RunTest(unittest.TestCase):
         s.add(run9)
         s.add(run10)
         s.add(run11)
+        self.assertEqual(run7, run8)
+        self.assertNotEqual(run7, run9)
+        self.assertNotEqual(run7, run10)
+
+    def testNewHash(self):
+        run1 = Run(1, 1, 2, 3)
+        self.assertEqual(hash(run1), 79038151938585768)
+        run666 = Run(666, [(1, 111), (3, 33), (2, 22)])
+        self.assertEqual(hash(run666), 21721583371131476)
 
 
 if __name__ == '__main__':

--- a/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Block_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Block_t.py
@@ -440,7 +440,7 @@ class BlockTestCase(EmulatedUnitTestCase):
             for unit in units:
                 pileupData = unit["PileupData"]
                 self.assertEqual(len(pileupData), 1)
-                self.assertItemsEqual(listvalues(pileupData)[0], ['T2_XX_SiteA', 'T2_XX_SiteB'])
+                self.assertItemsEqual(listvalues(pileupData)[0], ['T2_XX_SiteA', 'T2_XX_SiteB', 'T2_XX_SiteC'])
         return
 
     def testWithMaskedBlocks(self):

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
@@ -497,16 +497,16 @@ class WorkQueueTest(WorkQueueTestCase):
         processedBlocks += len(work)
         for element in work:
             processedFiles += element["NumOfFilesAdded"]
-        self.assertEqual(processedBlocks, 17)
-        self.assertEqual(processedFiles, 22)
+        self.assertEqual(processedBlocks, 9)
+        self.assertEqual(processedFiles, 14)
 
         # Get the rest the of work available at site B
         work = self.queue.getWork({'T2_XX_SiteB': 1000}, {})
         processedBlocks += len(work)
         for element in work:
             processedFiles += element["NumOfFilesAdded"]
-        self.assertEqual(processedBlocks, 17 + 19)
-        self.assertEqual(processedFiles, 22 + 35)
+        self.assertEqual(processedBlocks, 31)
+        self.assertEqual(processedFiles, 52)
 
         # Make sure no work left for B or C
         work = self.queue.getWork({'T2_XX_SiteB': 1000, 'T2_XX_SiteC': 1000}, {})
@@ -543,7 +543,7 @@ class WorkQueueTest(WorkQueueTestCase):
 
         # T2_XX_SiteB can run most blocks
         work = self.queue.getWork({'T2_XX_SiteB': 1000}, {})
-        self.assertEqual(len(work), 17 + 19)
+        self.assertEqual(len(work), 31)
 
     def testWhiteList(self):
         """
@@ -563,7 +563,7 @@ class WorkQueueTest(WorkQueueTestCase):
 
         # Site B can run
         work = self.queue.getWork({'T2_XX_SiteB': 1000, 'T2_XX_SiteAA': 1000}, {})
-        self.assertEqual(len(work), 17 + 19)
+        self.assertEqual(len(work), 31)
 
     def testQueueChaining(self):
         """
@@ -1423,8 +1423,8 @@ class WorkQueueTest(WorkQueueTestCase):
         # Now pull the new work to the local queue
         self.localQueue.pullWork({'T2_XX_SiteB': 1000, 'T2_XX_SiteC': 1000})
         syncQueues(self.localQueue)
-        self.assertEqual(len(self.localQueue), 35)
-        self.assertEqual(len(self.globalQueue), NBLOCKS_HICOMM - 35 - 1)
+        self.assertEqual(len(self.localQueue), 30)
+        self.assertEqual(len(self.globalQueue), NBLOCKS_HICOMM - 30 - 1)
 
         # FIXME: for some reason, it tries to reinsert all those elements again
         # however, if we call it again, it won't retry anything


### PR DESCRIPTION
Fixes #10543 
Fixes #10160

#### Status
ready

#### Description
This PR contains 3 different changes:
* `WorkQueueBackend`: given that we sort the workqueue elements being acquired - by creation time, then by priority - multiple times, I decided to put that in a separate function such that it's easier to test that functionality (and avoid surprises as we upgrade the python version)
* second change deals with the different behavior of the built-in `hash()` function between python2 and python3. Without investigating much, we decided to adopt `hashlib.sha1()` which is a reliable, reproducible in both python versions, and reasonably cheap (still more expensive than the previous hash function though).
* third change is touching the unit tests only

NOTE: the `MockPhEDExApi.py` module wasn't touched because it's supposed to be removed very soon (or is no longer used).

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
None

#### External dependencies / deployment changes
None
