### PR TITLE
 [py2py3] Fix unittests from Slice 17 in py3  

### DIFF
--- a/src/python/WMCore/WorkQueue/WMBSHelper.py
+++ b/src/python/WMCore/WorkQueue/WMBSHelper.py
@@ -365,7 +365,7 @@ class WMBSHelper(WMConnectionBase):
         if not locations:
             msg = 'No locations to inject Monte Carlo work to, unable to proceed'
             raise WorkQueueWMBSException(msg)
-        mcFakeFileName = ("MCFakeFile-%s" % self.topLevelFileset.name).encode('ascii', 'ignore')
+        mcFakeFileName = "MCFakeFile-%s" % self.topLevelFileset.name
         wmbsFile = File(lfn=mcFakeFileName,
                         first_event=self.mask['FirstEvent'],
                         last_event=self.mask['LastEvent'],

--- a/test/python/WMCore_t/ResourceControl_t/ResourceControl_t.py
+++ b/test/python/WMCore_t/ResourceControl_t/ResourceControl_t.py
@@ -13,6 +13,8 @@ import sys
 import threading
 import unittest
 
+from Utils.PythonVersion import PY3
+
 from WMCore.Agent.Configuration import Configuration
 from WMCore.BossAir.RunJob import RunJob
 from WMCore.DAOFactory import DAOFactory
@@ -678,7 +680,10 @@ class ResourceControlTest(EmulatedUnitTestCase):
         resControlPath = os.path.join(getTestBase(), "../../bin/wmagent-resource-control")
         env = os.environ
         env['PYTHONPATH'] = ":".join(sys.path)
-        cmdline = [resControlPath, "--add-Test"]
+        if PY3:
+            cmdline = ["python3", resControlPath, "--add-Test"]
+        else:
+            cmdline = [resControlPath, "--add-Test"]
         retval = subprocess.Popen(cmdline,
                                   stdout=subprocess.PIPE,
                                   stderr=subprocess.STDOUT,

--- a/test/python/WMCore_t/WMRuntime_t/SandboxCreator_t.py
+++ b/test/python/WMCore_t/WMRuntime_t/SandboxCreator_t.py
@@ -57,10 +57,10 @@ class SandboxCreator_t(unittest.TestCase):
         # Test that zipimport works on the dummy module that SandboxCreator inserts
         output = subprocess.check_output(['python', '-m', 'WMCore.ZipImportTestModule'],
                                          env={'PYTHONPATH': os.path.join(extractDir, 'WMCore.zip')})
-        self.assertIn('ZIPIMPORTTESTOK', output)
+        self.assertIn(b'ZIPIMPORTTESTOK', output)
 
         # make sure the pickled file is the same
-        pickleHandle = open( extractDir + "/WMSandbox/WMWorkload.pkl")
+        pickleHandle = open( extractDir + "/WMSandbox/WMWorkload.pkl", "rb")
         pickledWorkload = pickle.load( pickleHandle )
         self.assertEqual( workload.data, pickledWorkload )
         self.assertEqual( pickledWorkload.sandbox, boxpath )

--- a/test/python/WMCore_t/WMRuntime_t/Scripts_t/SetupCMSSWPset_t.py
+++ b/test/python/WMCore_t/WMRuntime_t/Scripts_t/SetupCMSSWPset_t.py
@@ -91,7 +91,7 @@ class SetupCMSSWPsetTest(unittest.TestCase):
 
         if psetPath is None:
             psetPath = self.testDir
-        with open(os.path.join(psetPath, "PSet.pkl")) as f:
+        with open(os.path.join(psetPath, "PSet.pkl"), "rb") as f:
             pset = Unpickler(f).load()
 
         os.chdir(currentPath)

--- a/test/python/WMCore_t/WMRuntime_t/Tools_t/Scram_t.py
+++ b/test/python/WMCore_t/WMRuntime_t/Tools_t/Scram_t.py
@@ -117,8 +117,8 @@ class Scram_t(unittest.TestCase):
         try:
             os.chdir(self.testDir)
             with tempfile.NamedTemporaryFile() as tf:
-                tf.write('GLIDEIN_REQUIRED_OS = "rhel6" \n')
-                tf.write('Memory = 2048\n')
+                tf.write(b'GLIDEIN_REQUIRED_OS = "rhel6" \n')
+                tf.write(b'Memory = 2048\n')
                 tf.flush()
                 with tmpEnv(_CONDOR_MACHINE_AD=tf.name):
                     self.assertEqual(getSingleScramArch('slc6_blah_blah'), 'slc6_blah_blah')
@@ -129,8 +129,8 @@ class Scram_t(unittest.TestCase):
                                       'slc6_blah_blah')
                     self.assertEqual(getSingleScramArch(['slc7_blah_blah', 'slc8_blah_blah']), None)
             with tempfile.NamedTemporaryFile() as tf:
-                tf.write('GLIDEIN_REQUIRED_OS = "rhel7" \n')
-                tf.write('Memory = 2048\n')
+                tf.write(b'GLIDEIN_REQUIRED_OS = "rhel7" \n')
+                tf.write(b'Memory = 2048\n')
                 tf.flush()
                 with tmpEnv(_CONDOR_MACHINE_AD=tf.name):
                     self.assertEqual(getSingleScramArch('slc6_blah_blah'), 'slc6_blah_blah')


### PR DESCRIPTION
Fixes #10548 

#### Status
Ready 

#### Description


##### fixed

- [x] `test/python/WMCore_t/ResourceControl_t/ResourceControl_t.py`: required changing how we run scripts from python3

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
#10329

#### External dependencies / deployment changes
nope
