### PR TITLE
 [py2py3] Check unittests from Slice 20 in py3 #10551 

### DIFF
--- a/test/python/WMComponent_t/JobSubmitter_t/JobSubmitterCaching_t.py
+++ b/test/python/WMComponent_t/JobSubmitter_t/JobSubmitterCaching_t.py
@@ -142,7 +142,7 @@ class JobSubmitterCachingTest(EmulatedUnitTestCase):
             newJobA["type"] = "Processing"
             newJobA.create(testGroupA)
 
-            jobHandle = open(os.path.join(jobCacheDir, "job.pkl"), "w")
+            jobHandle = open(os.path.join(jobCacheDir, "job.pkl"), "wb")
             pickle.dump(newJobA, jobHandle)
             jobHandle.close()
 
@@ -160,7 +160,7 @@ class JobSubmitterCachingTest(EmulatedUnitTestCase):
             newJobB["type"] = "Processing"
             newJobB.create(testGroupB)
 
-            jobHandle = open(os.path.join(jobCacheDir, "job.pkl"), "w")
+            jobHandle = open(os.path.join(jobCacheDir, "job.pkl"), "wb")
             pickle.dump(newJobB, jobHandle)
             jobHandle.close()
 

--- a/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
+++ b/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
@@ -232,7 +232,7 @@ class JobSubmitterTest(EmulatedUnitTestCase):
             testJob['cache_dir'] = jobCache
             testJob.save()
             jobGroup.add(testJob)
-            output = open(os.path.join(jobCache, 'job.pkl'), 'w')
+            output = open(os.path.join(jobCache, 'job.pkl'), 'wb')
             pickle.dump(testJob, output)
             output.close()
 


### PR DESCRIPTION
Fixes #10551

#### Status
ready

#### Description

Most of the failures have been fixed by #10636! (I realized only after having seen my commit disappear after a rebase onto master. always do a rebase before work, not after)

I changed here only a couple of things in the unittests themselves.

##### open

empty


##### fixed

###### 1. `JobSubmitter_t`
- [x] usual change mode opening pickle file
- [x] broken `test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py:JobSubmitterTest.testA_BasicTest`
  - see comment https://github.com/dmwm/WMCore/pull/10608#issuecomment-865108401
  - some logs at https://github.com/mapellidario/WMCore/compare/10551-fix...mapellidario:10551-debug

- [x] `test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py:JobSubmitterTest.testB_thresholdTest` changed from error to failure
- [x] `test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py:JobSubmitterTest.testC_prioritization` changed from error to failure
- [x] `test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py:JobSubmitterTest.testE_SiteModesTest` changed from error to failure
- [x] `test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py:JobSubmitterTest.testJobSiteDrain` changed from error to failure

###### 2. `JobSubmitterCaching_t`

- [x] `test/python/WMComponent_t/JobSubmitter_t/JobSubmitterCaching_t.py`

###### 3. `Repack_t.py`
not broken in jenkins

- [x] `test/python/WMCore_t/WMSpec_t/StdSpecs_t/Repack_t.py:RepackTests.testFilesets` changed from success to failure


###### 4. `./test/python/WMComponent_t/DBS3Buffer_t/DBSUpload_t.py`
not broken in jenkins
- [x] check why this is failing in my docker, but nothing is reported by jenkins. seems like a connection problem


#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
follow up to #10349 

#### External dependencies / deployment changes
nope
