### PR TITLE
Create workload sandbox efficiently

### DIFF
--- a/src/python/WMCore/WorkQueue/WMBSHelper.py
+++ b/src/python/WMCore/WorkQueue/WMBSHelper.py
@@ -267,15 +267,18 @@ class WMBSHelper(WMConnectionBase):
 
         return
 
-    def _createSubscriptionsInWMBS(self, task, fileset, alternativeFilesetClose=False):
+    def _createSubscriptionsInWMBS(self, task, fileset, alternativeFilesetClose=False,
+                                   createSandbox=True):
         """
         __createSubscriptionsInWMBS_
 
         Create subscriptions in WMBS for all the tasks in the spec.  This
         includes filesets, workflows and the output map for each task.
+        :param createSandbox: boolean flag to skip (re-)creation of the workload sandbox
         """
         # create runtime sandbox for workflow
-        self.createSandbox()
+        if createSandbox:
+            self.createSandbox()
 
         # FIXME: Let workflow put in values if spec is missing them
         workflow = Workflow(spec=self.wmSpec.specUrl(), owner=self.wmSpec.getOwner()["name"],
@@ -336,7 +339,8 @@ class WMBSHelper(WMConnectionBase):
                             if primaryDataset is not None:
                                 self.mergeOutputMapping[mergedOutputFileset.id] = primaryDataset
 
-                        self._createSubscriptionsInWMBS(childTask, outputFileset, alternativeFilesetClose)
+                        self._createSubscriptionsInWMBS(childTask, outputFileset,
+                                                        alternativeFilesetClose, createSandbox=False)
 
                 if mergedOutputFileset is None:
                     workflow.addOutput(outputModuleName + dataTier, outputFileset,


### PR DESCRIPTION
Fixes #10611 

#### Status
ready

#### Description
This will ensure that we call the sandbox creation, for a given workflow, only once. Thus saving some CPU cycles and a couple of syscalls.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Changes already in in https://github.com/dmwm/WMCore/pull/10610 , but I'd like to get this one merged first.

#### External dependencies / deployment changes
none
