### PR TITLE
Building the MSUnmerged construction around functional pipelines and configurable RSE lists.

### DIFF
--- a/src/python/WMCore/MicroService/MSManager.py
+++ b/src/python/WMCore/MicroService/MSManager.py
@@ -50,11 +50,11 @@ def daemon(func, reqStatus, interval, logger):
         sleep(interval)
 
 
-def daemonOpt(func, interval, logger):
+def daemonOpt(func, interval, logger, *args, **kwargs):
     "Daemon to perform given function action for all request in our store"
     while True:
         try:
-            func()
+            func(*args, **kwargs)
         except Exception as exc:
             logger.exception("MS daemon error: %s", str(exc))
         sleep(interval)
@@ -251,7 +251,7 @@ class MSManager(object):
         self.logger.info("Total ruleCleaner execution time: %d secs", res['execution_time'])
         self.statusRuleCleaner = res
 
-    def unmerged(self):
+    def unmerged(self, *args, **kwargs):
         """
         MSManager unmerged function.
         It cleans the Unmerged area of the CMS LFN Namespace

--- a/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
+++ b/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
@@ -11,11 +11,15 @@ RSE basis.
 # futures
 from __future__ import division, print_function
 
+from pprint import pformat
+
 # WMCore modules
 from WMCore.MicroService.DataStructs.DefaultStructs import UNMERGED_REPORT
 from WMCore.MicroService.MSCore import MSCore
+from WMCore.MicroService.MSUnmerged.MSUnmergedRSE import MSUnmergedRSE
 # from WMCore.Services.AlertManager.AlertManagerAPI import AlertManagerAPI
 from WMCore.WMException import WMException
+from Utils.Pipeline import Pipeline, Functor
 
 
 class MSUnmergedException(WMException):
@@ -42,12 +46,21 @@ class MSUnmerged(MSCore):
 
         self.msConfig.setdefault("verbose", True)
         self.msConfig.setdefault("interval", 60)
-        self.msConfig.setdefault('limitRSEsPerInstance', 100)
-        self.msConfig.setdefault('limitTiersPerInstance', ['T1', 'T2', 'T3'])
-        self.msConfig.setdefault("rucioAccount", "FIXME_RUCIO_ACCT")
-        self.alertServiceName = "ms-unmerged"
+        # self.msConfig.setdefault('limitRSEsPerInstance', 100)
+        # self.msConfig.setdefault('limitTiersPerInstance', ['T1', 'T2', 'T3'])
+        # self.msConfig.setdefault("rucioAccount", "FIXME_RUCIO_ACCT")
+        self.msConfig.setdefault("rseExpr", "*")
         # TODO: Add 'alertManagerUrl' to msConfig'
+        # self.alertServiceName = "ms-unmerged"
         # self.alertManagerAPI = AlertManagerAPI(self.msConfig.get("alertManagerUrl", None), logger=logger)
+
+        # Building all the Pipelines:
+        pName = 'plineUnmerged'
+        self.plineUnmerged = Pipeline(name=pName,
+                                      funcLine=[Functor(self.cleanFiles)])
+        # Initialization of the deleted files counters:
+        self.rseCounters = {}
+        self.plineCounters = {}
 
     def execute(self):
         """
@@ -57,6 +70,8 @@ class MSUnmerged(MSCore):
         # start threads in MSManager which should call this method
         summary = dict(UNMERGED_REPORT)
 
+        self.resetCounters()
+
         try:
             rseList = self.getRSEList()
             self.updateReportDict(summary, "total_num_rses", len(rseList))
@@ -64,20 +79,123 @@ class MSUnmerged(MSCore):
             msg += "Service set to process up to %s RSEs per instance." % self.msConfig["limitRSEsPerInstance"]
             self.logger.info(msg)
         except Exception as err:  # general error
-            msg = "Unknown exception while fetching RSEs from CRIC. Error: %s", str(err)
+            msg = "Unknown exception while trying to estimate the final RSEs to work on. Error: %s", str(err)
             self.logger.exception(msg)
             self.updateReportDict(summary, "error", msg)
 
-        # this one is put here just for example.
-        self.updateReportDict(summary, "error", 42)
+        try:
+            totalNumRses, totalNumFiles, numRsesCleaned, numFilesDeleted = self._execute(rseList)
+            msg = "\nTotal number of processed RSEs: %s."
+            msg += "\nTotal number of files to be deleted: %s."
+            msg += "\nNumber of RSEs cleaned: %s."
+            msg += "\nNumber of files deleted: %s."
+            self.logger.info(msg,
+                             totalNumRses,
+                             totalNumFiles,
+                             numRsesCleaned,
+                             numFilesDeleted)
+            self.updateReportDict(summary, "total_num_rses", totalNumRses)
+            self.updateReportDict(summary, "total_num_files", totalNumFiles)
+            self.updateReportDict(summary, "num_rses_cleaned", numRsesCleaned)
+            self.updateReportDict(summary, "num_files_deleted", numFilesDeleted)
+        except Exception as ex:
+            msg = "Unknown exception while running MSUnmerged thread Error: %s"
+            self.logger.exception(msg, str(ex))
+            self.updateReportDict(summary, "error", msg)
+
         return summary
+
+    def _execute(self, rseList):
+        """
+        Executes the MSUnmerged pipelines
+        :param rseList: A list of RSEs to work on
+        :return:        a tuple with:
+                            total number of RSEs
+                            total number of files found for deletion
+                            number of RSEs cleaned
+                            number of files deleted
+        """
+        totalNumRses = 0
+        totalNumFiles = 0
+        numRsesCleaned = 0
+        numFilesDeleted = 0
+
+        # Call the workflow dispatcher:
+        for rse in rseList:
+            try:
+                rse = MSUnmergedRSE(rse)
+                self.plineUnmerged.run(rse)
+                msg = "\n----------------------------------------------------------"
+                msg += "\nMSUnmergedRSE: %s"
+                msg += "\n----------------------------------------------------------"
+                self.logger.debug(msg, pformat(rse))
+                totalNumRses += 1
+                if rse['isClean']:
+                    numRsesCleaned += 1
+                totalNumFiles += rse['counters']['totalNumFiles']
+                numFilesDeleted += rse['counters']['numFilesDeleted']
+            except Exception as ex:
+                msg = "%s: General error from pipeline. RSE: %s. Error:  \n%s. "
+                msg += "\nWill retry again in the next cycle."
+                self.logger.exception(msg, self.plineUnmerged.name, rse['rse'], str(ex))
+                continue
+        return totalNumRses, totalNumFiles, numRsesCleaned, numFilesDeleted
+
+    def cleanFiles(self, rse):
+        """
+        The method to implement the actual deletion of files for an RSE.
+        :param rse: MSUnmergedRSE object to be cleaned
+        :return:    The MSUnmergedRSE object
+        """
+        try:
+            # for fileUnmerged in rse['files']['toDelete']:
+            #     try:
+            #         self.gfalCommand(rse['delInterface'], fileUnmerged)
+            #         rse['counters']['numFilesDeleted'] += 1
+            #         rse['files']['deletedSuccess'].append(fileUnmerged)
+            #     except Exception as ex:
+            #         rse['files']['deletedFail'].append(fileUnmerged)
+            #         msg = "Error while trying to delete file: %s for RSE: %s"
+            #         msg += "Will retry in the next cycle. Err: %s"
+            #         self.logger.debug(msg, fileUnmerged, rse['name'], str(ex))
+            rse['isClean'] = self._checkClean(rse)
+        except Exception as ex:
+            msg = "Error while cleaning RSE: %s"
+            msg += "Will retry in the next cycle. Err: %s"
+            self.logger.debug(msg, rse['name'], str(ex))
+
+        return rse
+
+    def _checkClean(self, rse):
+        """
+        A simple function to check if every file in an RSE's unmerged area have
+        been deleted
+        :param rse: The RSE to be checked
+        :return:    Bool: True if all files found have been deleted, False otherwise
+        """
+        return rse['counters']['totalNumFiles'] == rse['counters']['numFilesDeleted']
+
+    def resetCounters(self):
+        """
+        A simple function for zeroing the deleted files counters.
+        """
+
+        for rse in self.rseCounters:
+            self.rseCounters[rse]['deletedSuccess'] = 0
+            self.rseCounters[rse]['deletedFail'] = 0
+
+        for pline in self.plineCounters:
+            self.plineCounters[pline.name]['deletedSuccess'] = 0
+            self.plineCounters[pline.name]['deletedFail'] = 0
 
     def getRSEList(self):
         """
-        Queries CRIC for the proper RSE lists to iterate through.
-        return: List of RSEs.
+        Queries Rucio for the proper RSE list to iterate through.
+        :return: List of RSE names.
         """
-        # NOTE: To filter out the granularity (Tier*) level.
-        rseList = []
-
+        try:
+            rseList = self.rucio.evaluateRSEExpression(self.msConfig['rseExpr'])
+        except Exception as ex:
+            msg = "Unknown exception while trying to fetch the initial list of RSEs to work on. Err: %s"
+            self.logger.exception(msg, str(ex))
         return rseList

--- a/src/python/WMCore/MicroService/MSUnmerged/MSUnmergedRSE.py
+++ b/src/python/WMCore/MicroService/MSUnmerged/MSUnmergedRSE.py
@@ -1,0 +1,34 @@
+"""
+File       : MSUnmergedRSE.py
+Description: Provides a document Template for the MSUnmerged MicroServices
+"""
+
+
+class MSUnmergedRSE(dict):
+    """
+    A minimal RSE information representation to serve the needs
+    of the MSUnmerged Micro Service.
+    """
+    def __init__(self, rseName, **kwargs):
+        super(MSUnmergedRSE, self).__init__(**kwargs)
+
+        # NOTE: totalNumFiles reflects the total number of files eligible for deletion
+        #       once the relevant protected files have been filtered out, rather
+        #       than the total number of files found at the RSE
+        myDoc = {
+            "name": rseName,
+            "delInterface": "",
+            "isClean": False,
+            "counters": {"totalNumFiles" : 0,
+                         "numFilesDeleted" : 0},
+            "files": {"allUnmerged": [],
+                      "toDelete": [],
+                      "protected": [],
+                      "deletedSuccess": [],
+                      "deletedFail": []},
+            "dirs":  {"allUnmerged": [],
+                      "protected": [],
+                      "nonEmpty": [],
+                      "empty": []}
+        }
+        self.update(myDoc)


### PR DESCRIPTION
Fixes #10599 

#### Status
ready

#### Description
In order to achieve the scalability goals we have put for the service we need to split the initial list of RSEs to work on by Pod. So we  decided to have the that as a per K8 pod configurable `rseExpression` which is supposed to produce the desired subset of RSEs when executed in a call to Rucio. For this `rseExpression` we have prepared a placeholder in the MSConfig, which is supposed to be substituted with the `rseExppression` provided by the .yaml file for the pod at run time right before service execution. 

This PRalso provides  the basic logic for running the load through a functional pipeline, while accumulating counters and providing summary at the end of the service polling cycle     

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
https://github.com/dmwm/CMSKubernetes/pull/612
https://github.com/dmwm/deployment/pull/1059/commits
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/89
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/90


#### External dependencies / deployment changes
We depend on the rest of the construction of the K8 pods and their setup. 