### PR TITLE
Force pickle protocol=0 for the spec creation to be compatible with Py2/Py3

### DIFF
--- a/src/python/WMCore/DataStructs/JobPackage.py
+++ b/src/python/WMCore/DataStructs/JobPackage.py
@@ -37,7 +37,7 @@ class JobPackage(WMObject, dict):
         Pickle this object and save it to disk.
         """
         with open(fileName, 'wb') as fileHandle:
-            pickle.dump(self, fileHandle, -1)
+            pickle.dump(self, fileHandle, protocol=pickle.HIGHEST_PROTOCOL)
         return
 
     def load(self, fileName):

--- a/src/python/WMCore/WMSpec/Persistency.py
+++ b/src/python/WMCore/WMSpec/Persistency.py
@@ -46,7 +46,8 @@ class PersistencyHelper(object):
         with open(filename, 'wb') as handle:
             # TODO: use different encoding scheme for different extension
             # extension = filename.split(".")[-1].lower()
-            pickle.dump(self.data, handle)
+            # FIXME: once both central services and WMAgent are in Py3, we can remove protocol=0
+            pickle.dump(self.data, handle, protocol=0)
         return
 
     def load(self, filename):
@@ -99,7 +100,8 @@ class PersistencyHelper(object):
             rev = doc['_rev']
 
         # specuriwrev = specuri + '?rev=%s' % rev
-        workloadString = pickle.dumps(self.data)
+        # FIXME: once both central services and WMAgent are in Py3, we can remove protocol=0
+        workloadString = pickle.dumps(self.data, protocol=0)
         # result = database.put(specuriwrev, workloadString, contentType='application/text')
         retval = database.addAttachment(name, rev, workloadString, 'spec')
         if retval.get('ok', False) is not True:

--- a/src/python/WMCore/WMSpec/Steps/Templates/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Templates/CMSSW.py
@@ -156,7 +156,8 @@ class CMSSWStepHelper(CoreHelper):
             [setattr(self.data.application.configuration.arguments, k, v) for k, v in viewitems(args)]
         except Exception:
             pass
-        self.data.application.configuration.pickledarguments = pickle.dumps(args)
+        # FIXME: once both central services and WMAgent are in Py3, we can remove protocol=0
+        self.data.application.configuration.pickledarguments = pickle.dumps(args, protocol=0)
         return
 
     def cmsswSetup(self, cmsswVersion, **options):
@@ -209,7 +210,8 @@ class CMSSWStepHelper(CoreHelper):
         if hasattr(self.data.application.configuration, "pickledarguments"):
             args = pickle.loads(self.data.application.configuration.pickledarguments)
         args['globalTag'] = globalTag
-        self.data.application.configuration.pickledarguments = pickle.dumps(args)
+        # FIXME: once both central services and WMAgent are in Py3, we can remove protocol=0
+        self.data.application.configuration.pickledarguments = pickle.dumps(args, protocol=0)
 
         return
 
@@ -238,7 +240,8 @@ class CMSSWStepHelper(CoreHelper):
         if hasattr(self.data.application.configuration, "pickledarguments"):
             args = pickle.loads(self.data.application.configuration.pickledarguments)
         args['datasetName'] = datasetName
-        self.data.application.configuration.pickledarguments = pickle.dumps(args)
+        # FIXME: once both central services and WMAgent are in Py3, we can remove protocol=0
+        self.data.application.configuration.pickledarguments = pickle.dumps(args, protocol=0)
 
         return
 


### PR DESCRIPTION
Superseeds https://github.com/dmwm/WMCore/pull/10619 (please see whole discussion/investigation in this PR)
Fixes #10609 

#### Status
Ready

#### Description
As discussed with Dario this morning, trying a variation of the current implementation in #10619
If it passes the unit tests, then we can run some real tests within WMCore.

NOTE: this patch is required for the Python2 `1.4.7.patchX` agents:
```
cmst1@vocms0262:/data/srv/wmagent/current $ diff -rup /data/srv/wmagent/v1.4.7.patch3/sw/slc7_amd64_gcc630/cms/wmagent/1.4.7.patch3/lib/python2.7/site-packages/WMCore/BossAir/Plugins/SimpleCondorPlugin.py{.bkp,}
--- /data/srv/wmagent/v1.4.7.patch3/sw/slc7_amd64_gcc630/cms/wmagent/1.4.7.patch3/lib/python2.7/site-packages/WMCore/BossAir/Plugins/SimpleCondorPlugin.py.bkp	2021-06-24 19:30:23.860759021 +0200
+++ /data/srv/wmagent/v1.4.7.patch3/sw/slc7_amd64_gcc630/cms/wmagent/1.4.7.patch3/lib/python2.7/site-packages/WMCore/BossAir/Plugins/SimpleCondorPlugin.py	2021-06-24 19:31:50.394372378 +0200
@@ -605,7 +605,7 @@ class SimpleCondorPlugin(BasePlugin):
             requiredOSes = self.scramArchtoRequiredOS(job.get('scramArch'))
             ad['My.REQUIRED_OS'] = classad.quote(requiredOSes)
             cmsswVersions = ','.join(job.get('swVersion'))
-            ad['My.CMSSW_Versions'] = classad.quote(cmsswVersions)
+            ad['My.CMSSW_Versions'] = classad.quote(str(cmsswVersions))
```

#### Is it backward compatible (if not, which system it affects?)
yes, hopefully!

#### Related PRs
none

#### External dependencies / deployment changes
none