### PR TITLE
Remove repack slots flag

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -551,9 +551,8 @@ class SimpleCondorPlugin(BasePlugin):
                 ad['My.DESIRED_CMSPileups'] = classad.quote(str(cmsPileups))
             else:
                 ad['My.DESIRED_CMSPileups'] = undefined
-            # HighIO and repack jobs
+            # HighIO
             ad['My.Requestioslots'] = str(1 if job['task_type'] in ["Merge", "Cleanup", "LogCollect"] else 0)
-            ad['My.RequestRepackslots'] = str(1 if job['task_type'] == 'Repack' else 0)
             # Performance and resource estimates (including JDL magic tweaks)
             origCores = job.get('numberOfCores', 1)
             estimatedMins = int(job['estimatedJobTime'] / 60.0) if job.get('estimatedJobTime') else 12 * 60


### PR DESCRIPTION
Fixes #10630 

#### Status
ready

#### Description
Eliminates the `Repack` condor flag from `SimpleCondorPlugin`. This was tested in T0 Large scale test during Data Challenge 2021.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs


#### External dependencies / deployment changes

