### PR TITLE
Fix WMAgent component Daemon read/write operations

### DIFF
--- a/src/python/WMCore/Agent/Daemon/Create.py
+++ b/src/python/WMCore/Agent/Daemon/Create.py
@@ -27,7 +27,7 @@ import os
 import sys
 import time
 from logging.handlers import RotatingFileHandler
-from xml.dom.minidom import Document, Element
+from xml.dom.minidom import Document
 
 # File mode creation mask of the daemon.
 UMASK = 0o022
@@ -91,37 +91,36 @@ def daemonize(stdout='/dev/null', stderr=None, stdin='/dev/null',
         # the parent, so we give the child complete control over permissions.
         os.umask(UMASK)
 
-        daemon = Element("Daemon")
-        processId = Element("ProcessID")
+        xmlDoc = Document()
+        daemon = xmlDoc.createElement("Daemon")
+        processId = xmlDoc.createElement("ProcessID")
         processId.setAttribute("Value", str(os.getpid()))
         daemon.appendChild(processId)
 
-        parentProcessId = Element("ParentProcessID")
+        parentProcessId = xmlDoc.createElement("ParentProcessID")
         parentProcessId.setAttribute("Value", str(os.getppid()))
         daemon.appendChild(parentProcessId)
 
-        processGroupId = Element("ProcessGroupID")
+        processGroupId = xmlDoc.createElement("ProcessGroupID")
         processGroupId.setAttribute("Value", str(os.getpgrp()))
         daemon.appendChild(processGroupId)
 
-        userId = Element("UserID")
+        userId = xmlDoc.createElement("UserID")
         userId.setAttribute("Value", str(os.getuid()))
         daemon.appendChild(userId)
 
-        effectiveUserId = Element("EffectiveUserID")
+        effectiveUserId = xmlDoc.createElement("EffectiveUserID")
         effectiveUserId.setAttribute("Value", str(os.geteuid()))
         daemon.appendChild(effectiveUserId)
 
-        groupId = Element("GroupID")
+        groupId = xmlDoc.createElement("GroupID")
         groupId.setAttribute("Value", str(os.getgid()))
         daemon.appendChild(groupId)
 
-        effectiveGroupId = Element("EffectiveGroupID")
+        effectiveGroupId = xmlDoc.createElement("EffectiveGroupID")
         effectiveGroupId.setAttribute("Value", str(os.getegid()))
         daemon.appendChild(effectiveGroupId)
 
-        dom = Document()
-        dom.appendChild(daemon)
         with open("Daemon.xml", "w") as props:
             props.write(daemon.toprettyxml())
 

--- a/src/python/WMCore/Agent/Daemon/Details.py
+++ b/src/python/WMCore/Agent/Daemon/Details.py
@@ -19,6 +19,9 @@ import time
 # FIXME: needs to be replaced with persistent backend.
 from xml.dom.minidom import parse
 
+from Utils.PythonVersion import PY3
+from Utils.Utilities import encodeUnicodeToBytesConditional
+
 
 def run(command):
     proc = subprocess.Popen(
@@ -28,7 +31,7 @@ def run(command):
         stdin=subprocess.PIPE,
         )
 
-    proc.stdin.write(command)
+    proc.stdin.write(encodeUnicodeToBytesConditional(command, condition=PY3))
     stdout, stderr = proc.communicate()
     rc = proc.returncode
 


### PR DESCRIPTION
Fixes #10631 

#### Status
ready

#### Description
Make WMComponent Daemon.xml xml creation compatible with Python3 xml minidom library. Also fixes how that same file is read back to evaluate whether the component is properly running or not.

Tested with a python3 agent.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Similar issue as faced and fixed by Todor in this PR: https://github.com/dmwm/WMCore/pull/10571

#### External dependencies / deployment changes
none
