### PR TITLE
[py2py3] Fix AgentStatusWatcher subprocess.Popen calls 

### DIFF
--- a/src/python/Utils/Utilities.py
+++ b/src/python/Utils/Utilities.py
@@ -93,7 +93,8 @@ def diskUse():
     """
     diskPercent = []
     df = subprocess.Popen(["df", "-klP"], stdout=subprocess.PIPE)
-    output = df.communicate()[0].split("\n")
+    output = df.communicate()[0]
+    output = decodeBytesToUnicode(output).split("\n")
     for x in output:
         split = x.split()
         if split != [] and split[0] != 'Filesystem':
@@ -107,7 +108,8 @@ def numberCouchProcess():
     This returns the number of couch process
     """
     ps = subprocess.Popen(["ps", "-ef"], stdout=subprocess.PIPE)
-    process = ps.communicate()[0].count('couchjs')
+    process = ps.communicate()[0]
+    process = decodeBytesToUnicode(process).count('couchjs')
 
     return process
 

--- a/test/python/Utils_t/Utilities_t.py
+++ b/test/python/Utils_t/Utilities_t.py
@@ -11,7 +11,7 @@ import unittest
 
 from Utils.Utilities import makeList, makeNonEmptyList, strToBool, \
     safeStr, rootUrlJoin, zipEncodeStr, lowerCmsHeaders, getSize, \
-    encodeUnicodeToBytes
+    encodeUnicodeToBytes, diskUse, numberCouchProcess
 
 
 class UtilitiesTests(unittest.TestCase):
@@ -166,6 +166,23 @@ cms::Exception caught in CMS.EventProcessor and rethrown
         cls2 = TestClass2()
         print(getSize(cls2)) # py2: 426, py3: 205
         self.assertTrue(getSize(cls2) > 200)
+
+    def testDiskUse(self):
+        """
+        Test the `diskUse` function.
+        """
+        data = diskUse()
+        # assuming nodes will always have at least 3 partitions/mount points
+        self.assertTrue(len(data) > 2)
+
+    def testNumberCouchProcess(self):
+        """
+        Test the `numberCouchProcess` function.
+        """
+        data = numberCouchProcess()
+        # there should be at least one process, but who knows...
+        self.assertTrue(data >= 0)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #10634 

#### Status
ready

#### Description
In python3, subprocess.Popen returns a byte-like object. With this PR, we convert that output to unicode and then do the required string parsing.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
