### PR TITLE
[py2py3] Open file in binary mode for pickle load/dump

### DIFF
--- a/src/python/WMComponent/JobCreator/JobCreatorPoller.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorPoller.py
@@ -155,7 +155,7 @@ def saveJob(job, workflow, sandbox, wmTask=None, jobNumber=0,
     job['inputPileup'] = inputPileup
     job['allowOpportunistic'] = allowOpportunistic
 
-    with open(os.path.join(cacheDir, 'job.pkl'), 'w') as output:
+    with open(os.path.join(cacheDir, 'job.pkl'), 'wb') as output:
         pickle.dump(job, output, pickle.HIGHEST_PROTOCOL)
 
     return

--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -315,7 +315,7 @@ class JobSubmitterPoller(BaseWorkerThread):
                 badJobs[71104].append(newJob)
                 continue
             try:
-                with open(pickledJobPath, 'r') as jobHandle:
+                with open(pickledJobPath, 'rb') as jobHandle:
                     loadedJob = pickle.load(jobHandle)
             except Exception as ex:
                 logging.warning("Failed to load job pickle object %s", pickledJobPath)


### PR DESCRIPTION
Fixes #10636 

#### Status
not-tested

#### Description
Open the job description pickle file - in JobCreator - in binary mode, for the pickle.dump.
This will cause an error in the JobSubmitter component [1], so I have also changed the access to that job.pkl file to binary mode in JobSubmitter

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
There are other candidate modules for making a similar change, but I'm trying to be conservative here.

#### External dependencies / deployment changes
none

[1]
```
2021-06-28 20:30:56,306:139920120297216:WARNING:JobSubmitterPoller:Failed to load job pickle object /data/srv/wmagent/v1.5.0.pre3/install/wmagentpy3/JobCreator/JobCache/amaltaro_TaskChain_ProdMinBias_June2021_Val_210628_152244_8881/ProdMinBias/JobCollection_3_0/job_633/job.pkl
```