### PR TITLE
WMAgent 1.4.7 patch for workflow specs made in python3

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -16,6 +16,7 @@ import htcondor
 
 from Utils import FileTools
 from Utils.IteratorTools import grouper
+from Utils.Utilities import encodeUnicodeToBytes
 from WMCore.BossAir.Plugins.BasePlugin import BasePlugin
 from WMCore.Credential.Proxy import Proxy
 from WMCore.DAOFactory import DAOFactory
@@ -538,7 +539,7 @@ class SimpleCondorPlugin(BasePlugin):
             # Handling for AWS, cloud and opportunistic resources
             ad['My.AllowOpportunistic'] = str(job.get('allowOpportunistic', False))
             if job.get('inputDataset'):
-                ad['My.DESIRED_CMSDataset'] = classad.quote(job['inputDataset'])
+                ad['My.DESIRED_CMSDataset'] = classad.quote(encodeUnicodeToBytes(job['inputDataset']))
             else:
                 ad['My.DESIRED_CMSDataset'] = undefined
             if job.get('inputDatasetLocations'):
@@ -603,9 +604,9 @@ class SimpleCondorPlugin(BasePlugin):
             ad['My.PostJobPrio2'] = str(int(-1 * job['task_id']))
             # Add OS requirements for jobs
             requiredOSes = self.scramArchtoRequiredOS(job.get('scramArch'))
-            ad['My.REQUIRED_OS'] = classad.quote(requiredOSes)
+            ad['My.REQUIRED_OS'] = classad.quote(encodeUnicodeToBytes(requiredOSes))
             cmsswVersions = ','.join(job.get('swVersion'))
-            ad['My.CMSSW_Versions'] = classad.quote(cmsswVersions)
+            ad['My.CMSSW_Versions'] = classad.quote(encodeUnicodeToBytes(cmsswVersions))
      
             jobParameters.append(ad)    
              

--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -16,7 +16,7 @@ import socket
 import re
 
 import FWCore.ParameterSet.Config as cms
-
+from Utils.Utilities import encodeUnicodeToBytes
 from PSetTweaks.PSetTweak import PSetTweak
 from PSetTweaks.WMTweak import applyTweak, makeJobTweak, makeOutputTweak, makeTaskTweak, resizeResources
 from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig
@@ -353,14 +353,14 @@ class SetupCMSSWPset(ScriptInterface):
         # first, create an instance of TrivialFileCatalog to override
         tfc = TrivialFileCatalog()
         # check the jobs input files
-        inputFile = ("../%s/%s.root" % (self.step.data.input.inputStepName,
-                                        self.step.data.input.inputOutputModule))
+        inputFile = "../%s/%s.root" % (self.step.data.input.inputStepName,
+                                       self.step.data.input.inputOutputModule)
         tfc.addMapping("direct", inputFile, inputFile, mapping_type="lfn-to-pfn")
         tfc.addMapping("direct", inputFile, inputFile, mapping_type="pfn-to-lfn")
 
         fixupFileNames(self.process)
         fixupMaxEvents(self.process)
-        self.process.source.fileNames.setValue([inputFile])
+        self.process.source.fileNames.setValue([encodeUnicodeToBytes(inputFile)])
         self.process.maxEvents.input.setValue(-1)
 
         tfcName = "override_catalog.xml"
@@ -559,7 +559,7 @@ class SetupCMSSWPset(ScriptInterface):
                     datasetName = datasetName.rsplit('/', 1)
                     datasetName[0] += runLimits
                     datasetName = "/".join(datasetName)
-                self.process.dqmSaver.workflow = cms.untracked.string(datasetName)
+                self.process.dqmSaver.workflow = cms.untracked.string(encodeUnicodeToBytes(datasetName))
         return
 
     def handleLHEInput(self):
@@ -638,7 +638,7 @@ class SetupCMSSWPset(ScriptInterface):
         if isCMSSWSupported(self.getCmsswVersion(), "CMSSW_7_6_0"):
             self.logger.info("Tag chirp updates from CMSSW with step %s", self.step.data._internal_name)
             self.process.add_(cms.Service("CondorStatusService",
-                                          tag=cms.untracked.string("_%s_" % self.step.data._internal_name)))
+                                          tag=cms.untracked.string("_%s_" % encodeUnicodeToBytes(self.step.data._internal_name))))
 
         return
 


### PR DESCRIPTION
Does not fix any issue, but it's required for https://github.com/dmwm/WMCore/pull/10628

#### Status
not-tested

#### Description
Even though we kept the same protocol=0 for the workload spec pickling, there seems to have still some differences between a Python2 vs Python3 made spec pickle (classical issues with bytes / strings / unicode).

So, this `1.4.7_wmagent` branch patch is required before we upgrade central services to Python3. I expect it to be "harmless" for the current python2-made specs that we have in the system; while it would be a must for specs still to be created by python3 services.

UPDATE: there are fixes for the DQMSaver and also chainedProcessing (StepChain), where Python3-made spec files come with unicode strings instead of byte strings.

NOTE: we cannot yet say whether this same fix is required against the master branch.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
None

#### External dependencies / deployment changes
Production agents must be patched before #10628 gets deployed in CMSWEB.
