### PR TITLE
Keep buffering enabled when creating a component daemon

### DIFF
--- a/src/python/WMCore/Agent/Daemon/Create.py
+++ b/src/python/WMCore/Agent/Daemon/Create.py
@@ -77,7 +77,7 @@ def daemonize(stdout='/dev/null', stderr=None, stdin='/dev/null',
         stderr = stdout
     si = open(stdin, 'r')
     so = open(stdout, 'a+')
-    se = open(stderr, 'a+', 0)
+    se = open(stderr, 'a+')
     pid = str(os.getpid())
     sys.stderr.write("\n%s\n" % startmsg % pid)
     sys.stderr.flush()


### PR DESCRIPTION
Complement to https://github.com/dmwm/WMCore/pull/10632

#### Status
ready

#### Description
It looks like I forgot migrating my local changes into the PR https://github.com/dmwm/WMCore/pull/10632, which causes this error to show up [1].

So, this PR no longer disables buffering when opening an stderr descriptor. This is required because Python3 only supports `buffering=0` for a binary mode file object, as one can read in the python documentation:
https://docs.python.org/3/library/functions.html#open

#### Is it backward compatible (if not, which system it affects?)
Yes, it should.

#### Related PRs
This fix should have been part of https://github.com/dmwm/WMCore/pull/10632

#### External dependencies / deployment changes
[1]
```
Waiting 1 seconds, to ensure daemon file is created
Traceback (most recent call last):
  File "/data/srv/wmagent/v1.5.0.pre5/sw.amaltaro/slc7_amd64_gcc630/cms/wmagentpy3/1.5.0.pre5/bin/wmcoreD", line 349, in <module>
    startup(config)
  File "/data/srv/wmagent/v1.5.0.pre5/sw.amaltaro/slc7_amd64_gcc630/cms/wmagentpy3/1.5.0.pre5/bin/wmcoreD", line 223, in startup
    componentObject.startDaemon(keepParent = True)
  File "/data/srv/wmagent/v1.5.0.pre5/sw.amaltaro/slc7_amd64_gcc630/cms/wmagentpy3/1.5.0.pre5/lib/python3.8/site-packages/WMCore/Agent/Harness.py", line 396, in startDaemon
    pid = createDaemon(compSect.componentDir, keepParent)
  File "/data/srv/wmagent/v1.5.0.pre5/sw.amaltaro/slc7_amd64_gcc630/cms/wmagentpy3/1.5.0.pre5/lib/python3.8/site-packages/WMCore/Agent/Daemon/Create.py", line 183, in createDaemon
    return daemonize(workdir=workdir, startmsg=startmsg, keepParent=keepParent)
  File "/data/srv/wmagent/v1.5.0.pre5/sw.amaltaro/slc7_amd64_gcc630/cms/wmagentpy3/1.5.0.pre5/lib/python3.8/site-packages/WMCore/Agent/Daemon/Create.py", line 80, in daemonize
    se = open(stderr, 'a+', 0)
ValueError: can't have unbuffered text I/O
Path for daemon file does not exist!
```