### PR TITLE
Encode CMSSW picklearguments to bytes before loading it

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Templates/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Templates/CMSSW.py
@@ -10,6 +10,7 @@ import pickle
 
 from future.utils import viewitems
 
+from Utils.Utilities import encodeUnicodeToBytes
 from WMCore.WMSpec.ConfigSectionTree import nodeName
 from WMCore.WMSpec.Steps.Template import CoreHelper, Template
 
@@ -208,7 +209,7 @@ class CMSSWStepHelper(CoreHelper):
 
         args = {}
         if hasattr(self.data.application.configuration, "pickledarguments"):
-            args = pickle.loads(self.data.application.configuration.pickledarguments)
+            args = pickle.loads(encodeUnicodeToBytes(self.data.application.configuration.pickledarguments))
         args['globalTag'] = globalTag
         # FIXME: once both central services and WMAgent are in Py3, we can remove protocol=0
         self.data.application.configuration.pickledarguments = pickle.dumps(args, protocol=0)
@@ -225,7 +226,8 @@ class CMSSWStepHelper(CoreHelper):
             if hasattr(self.data.application.configuration.arguments, "globalTag"):
                 return self.data.application.configuration.arguments.globalTag
 
-        return pickle.loads(self.data.application.configuration.pickledarguments)['globalTag']
+        pickledArgs = encodeUnicodeToBytes(self.data.application.configuration.pickledarguments)
+        return pickle.loads(pickledArgs)['globalTag']
 
     def setDatasetName(self, datasetName):
         """
@@ -238,7 +240,7 @@ class CMSSWStepHelper(CoreHelper):
 
         args = {}
         if hasattr(self.data.application.configuration, "pickledarguments"):
-            args = pickle.loads(self.data.application.configuration.pickledarguments)
+            args = pickle.loads(encodeUnicodeToBytes(self.data.application.configuration.pickledarguments))
         args['datasetName'] = datasetName
         # FIXME: once both central services and WMAgent are in Py3, we can remove protocol=0
         self.data.application.configuration.pickledarguments = pickle.dumps(args, protocol=0)


### PR DESCRIPTION
Fixes #10647 

#### Status
not-tested

#### Description
If the pickledarguments has been previously created by Python2 services, it could be that that object - already in the spec pickled file - is of the type `str`. With this patch, we first convert that object to bytes, and only then try to pickle.load it.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Not really related, but worth mentioning this PR: https://github.com/dmwm/WMCore/pull/10628

#### External dependencies / deployment changes
none
