### PR TITLE
Fixing unittests in WMCore_t/Services_t/pycurlFileUpload_t.py and WebTools_t/REST_t.py

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/MockPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/MockPlugin.py
@@ -62,7 +62,7 @@ def processWorker(myinput, tmp):
             report.task = "/" + taskName + "/Production"
 
             #pickle the report again
-            with open(outfile, 'w') as f:
+            with open(outfile, 'wb') as f:
                 logging.debug('Process worker is dumping the report to ' + f.name)
                 pickle.dump(report, f)
     except Exception as ex:

--- a/src/python/WMCore/Services/Requests.py
+++ b/src/python/WMCore/Services/Requests.py
@@ -464,6 +464,8 @@ class Requests(dict):
     def uploadFile(self, fileName, url, fieldName='file1', params=[], verb='POST'):
         """
         Upload a file with curl streaming it directly from disk
+
+        :rtype: bytes (both py2 and py3)
         """
         ckey, cert = self.getKeyCert()
         capath = self.getCAPath()

--- a/src/python/WMCore/WebTools/RESTFormatter.py
+++ b/src/python/WMCore/WebTools/RESTFormatter.py
@@ -20,9 +20,10 @@ from WMCore.Wrappers.JsonWrapper.JSONThunker import JSONThunker
 
 class RESTFormatter(TemplatedPage):
     def __init__(self, config):
-        self.supporttypes = {'application/xml': self.xml,
+        self.supporttypes = {
+                    'text/json': self.json,
+                    'application/xml': self.xml,
                    'application/atom+xml': self.atom,
-                   'text/json': self.json,
                    'text/x-json': self.json,
                    'application/json': self.json,
                    'text/html': self.to_string,

--- a/src/python/WMCore/WebTools/RESTModel.py
+++ b/src/python/WMCore/WebTools/RESTModel.py
@@ -6,7 +6,8 @@ Rest Model abstract implementation
 """
 from builtins import str, bytes
 
-from Utils.Utilities import encodeUnicodeToBytes
+from Utils.Utilities import decodeBytesToUnicode, encodeUnicodeToBytes
+from Utils.PythonVersion import PY3
 
 from functools import wraps
 from WMCore.Lexicon import check
@@ -266,12 +267,12 @@ class RESTModel(WebAPI):
         for a in self.methods[verb][method]['args']:
             if a in input_kwargs:
                 v = input_kwargs[a]
-                input_data[a] = encodeUnicodeToBytes(v)
+                input_data[a] = decodeBytesToUnicode(v) if PY3 else encodeUnicodeToBytes(v)
                 input_kwargs.pop(a)
             else:
                 if len(input_args):
                     v = input_args.pop(0)
-                    input_data[a] = encodeUnicodeToBytes(v)
+                    input_data[a] = decodeBytesToUnicode(v) if PY3 else encodeUnicodeToBytes(v)
         if input_kwargs:
             raise HTTPError(400, 'Invalid input: Input arguments failed sanitation.')
         self.debug('%s raw data: %s' % (method, {'args': input_args, 'kwargs': input_kwargs}))

--- a/src/python/WMQuality/WebTools/RESTClientAPI.py
+++ b/src/python/WMQuality/WebTools/RESTClientAPI.py
@@ -9,11 +9,18 @@ import urllib.parse
 
 from http.client import HTTPConnection
 
+from Utils.Utilities import decodeBytesToUnicodeConditional, encodeUnicodeToBytesConditional
+from Utils.PythonVersion import PY3
+
 from WMCore.WebTools.Page import make_rfc_timestamp
 
 
 def makeRequest(url, values=None, verb='GET', accept="text/plain",
                 contentType=None, secure=False, secureParam={}):
+    """
+    :rtype: (bytes (both py2 and py3), int, str (native), 
+            (instance httplib.HTTPResponse in py2, 'http.client.HTTPResponse' in py3))
+    """
     headers = {}
     contentType = contentType or "application/x-www-form-urlencoded"
     headers = {"content-type": contentType,
@@ -73,10 +80,12 @@ def methodTest(verb, url, request_input={}, accept='text/json', contentType=None
                                                      accept, contentType,
                                                      secure, secureParam)
 
+    data = decodeBytesToUnicodeConditional(data, condition=PY3)
+
     keyMap = {'code': code, 'data': data, 'type': content_type, 'response': response}
     for key, value in viewitems(output):
         msg = 'Got a return %s != %s (got %s, type %s) (expected %s, type %s)' \
-              % (keyMap[key], value, keyMap[key], type(keyMap[key]), data, type(data))
+              % (keyMap[key], value, keyMap[key], type(keyMap[key]), value, type(value))
         assert keyMap[key] == value, msg
 
     expires = response.getheader('Expires')

--- a/test/etc/UnstableTests.txt
+++ b/test/etc/UnstableTests.txt
@@ -6,7 +6,6 @@ WMCore_t.Storage_t.Execute_t.ExecuteTest:testRunCommandWithOutput_error
 WMCore_t.Storage_t.Execute_t.ExecuteTest:testRunCommand_error
 WMCore_t.WebTools_t.NestedModel_t.NestedModelTest:testInnerPingPass
 WMCore_t.WebTools_t.NestedModel_t.NestedModelTest:testOuterFooPass
-WMCore_t.WebTools_t.REST_t.RESTTest:testPing
 WMCore_t.WorkQueue_t.Policy_t.Start_t.Block_t.BlockTestCase:testWhiteBlackLists
 WMCore_t.WorkQueue_t.WorkQueue_t.WorkQueueTest:testQueueChaining
 WMCore_t.WorkQueue_t.WorkQueue_t.WorkQueueTest:testResetWork

--- a/test/python/WMCore_t/Services_t/PyCurlRESTModel.py
+++ b/test/python/WMCore_t/Services_t/PyCurlRESTModel.py
@@ -48,9 +48,8 @@ class PyCurlRESTModel(RESTModel):
         Saves the file passed by the client in the current directory
         """
         try:
-            f = open('UploadedFile.txt', 'wt')
-            f.write( file1.file.read() )
-            f.close()
+            with open('UploadedFile.txt', 'wb') as f:
+                f.write( file1.file.read() )
         except Exception as e:
             logging.exception(e)
 

--- a/test/python/WMCore_t/Services_t/pycurlFileUpload_t.py
+++ b/test/python/WMCore_t/Services_t/pycurlFileUpload_t.py
@@ -44,7 +44,7 @@ class PyCurlRESTServer(RESTBaseUnitTest):
         self.assertEqual(open(uploadedFilename).read(), open(fileName).read())
         # delete the uploaded file
         os.remove(uploadedFilename)
-        self.assertTrue('Success' in res)
+        self.assertTrue(b'Success' in res)
 
     def testFailingFileUpload(self):
         """

--- a/test/python/WMCore_t/WebTools_t/RESTFormat_t.py
+++ b/test/python/WMCore_t/WebTools_t/RESTFormat_t.py
@@ -18,6 +18,8 @@ from WMQuality.WebTools.RESTBaseUnitTest import RESTBaseUnitTest
 from WMQuality.WebTools.RESTClientAPI import methodTest
 from WMQuality.WebTools.RESTServerSetup import DefaultConfig
 
+from Utils.PythonVersion import PY3
+
 class RESTFormatTest(RESTBaseUnitTest):
 
     def initialize(self):
@@ -74,7 +76,9 @@ class RESTFormatTest(RESTBaseUnitTest):
                          output={'code':200, 'data':'{"a": "a%", "b": "b"}'})
 
         url = self.urlbase + 'list?input_int=a&input_str=a'
-        expected_data = '''{"exception": 400, "message": "Invalid input: Input data failed validation.", "type": "HTTPError"}'''
+        expected_data_py2 = '{"exception": 400, "message": "Invalid input: Input data failed validation.", "type": "HTTPError"}'
+        expected_data_py3 = '{"exception": 400, "type": "HTTPError", "message": "Invalid input: Input data failed validation."}'
+        expected_data = expected_data_py3 if PY3 else expected_data_py2
         methodTest('GET', url, accept=return_type,
                          output={'code':400, 'data':expected_data})
 
@@ -84,7 +88,9 @@ class RESTFormatTest(RESTBaseUnitTest):
         """
         return_type = 'application/json'
         url = self.urlbase + 'list1?int=a'
-        expected_data = """{"exception": 400, "message": "Invalid input: Arguments added where none allowed", "type": "HTTPError"}"""
+        expected_data_py2 = '{"exception": 400, "message": "Invalid input: Arguments added where none allowed", "type": "HTTPError"}'
+        expected_data_py3 = '{"exception": 400, "type": "HTTPError", "message": "Invalid input: Arguments added where none allowed"}'
+        expected_data = expected_data_py3 if PY3 else expected_data_py2
         methodTest('GET', url, accept=return_type, output={'code':400, 'data':expected_data})
 
     def testGenerator(self):

--- a/test/python/WMCore_t/WebTools_t/REST_t.py
+++ b/test/python/WMCore_t/WebTools_t/REST_t.py
@@ -360,7 +360,7 @@ class RESTTest(RESTBaseUnitTest):
         # 2 positional args (e.g. url/arg1/arg2)
         url = self.urlbase + 'listTypeArgs?aList=1'
         response = makeRequest(url=url)
-        assert response[1] == 200 and response[0] == "[1]", \
+        assert response[1] == 200 and response[0] == b"[1]", \
                  'list args failed: ' +\
                  '. Got a return code != 200 (got %s)' % response[1] +\
                  '. Returned data: %s' % response[0]
@@ -369,7 +369,7 @@ class RESTTest(RESTBaseUnitTest):
         # 2 values with the same keywords (e.g. url/arg1/arg2)
         url = self.urlbase + 'listTypeArgs?aList=1&aList=2'
         response = makeRequest(url=url)
-        assert response[1] == 200 and response[0] == "[1, 2]", \
+        assert response[1] == 200 and response[0] == b"[1, 2]", \
                  'list args failed: ' +\
                  '. Got a return code != 200 (got %s)' % response[1] +\
                  '. Returned data: %s' % response[0]


### PR DESCRIPTION
Related to #10422 

#### Status
ready

#### Description
Fixing unittests in 

- [x] test/python/WMCore_t/Services_t/pycurlFileUpload_t.py
  - ACHTUNG: in py3 we get bytes back, not unicode
  - [x] the response contains bytes, not unicode. is this going to be a problem for us? (we should discuss). -> updated docstring
- [x] test/python/WMCore_t/BossAir_t/MockPlugin_t.py
- [x] test/python/WMCore_t/WebTools_t/REST_t.py
  - [x] testGoodEcho
  - [x] testDAOBased
  - [x] testException
    - caused by https://github.com/dmwm/WMCore/blob/8c73e7073fd8928326884e3d32fd9c806dcb7429/src/python/WMCore/WebTools/RESTApi.py#L147 not picking https://github.com/dmwm/WMCore/blob/8c73e7073fd8928326884e3d32fd9c806dcb7429/src/python/WMCore/WebTools/RESTFormatter.py#L25, but picking xml instead
    - breakpoints: RESTApi.py: L115, L150. RESTFormatter.py L92, RESTModel.py L285.
  - [x] testList 
    - (simply undoing some of the changes made in debugging)
  - [x] testListTypeArgs
    - ACHTUNG: in py3 we get bytes back, not unicode 
    - [x] the response contains bytes, not unicode. is this going to be a problem for us? (we should discuss) -> updated docstring
  - [x] testSanitisePass
  - [x] testSanitisePassHTTP
  - [x] testPing: i run it 100 times on my machine and every time it passed. removing from unstable list
- [x] test/python/WMCore_t/WebTools_t/RESTFormat_t.py
  - [x] WMCore_t.WebTools_t.RESTFormat_t.RESTFormatTest.testGenerator
  - [x] WMCore_t.WebTools_t.RESTFormat_t.RESTFormatTest.testNoArgMethods
    - [ ] hacky solution, but real solution would require much moer effort and i am not sure it is worth the time right now
  - [x] WMCore_t.WebTools_t.RESTFormat_t.RESTFormatTest.testReturnFormat
    - [ ] hacky solution, but real solution would require much moer effort and i am not sure it is worth the time right now

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
nope

#### External dependencies / deployment changes
nope
