### PR TITLE
Fix object type passed to time.mktime

### DIFF
--- a/src/python/WMCore/ReqMgr/Web/ReqMgrService.py
+++ b/src/python/WMCore/ReqMgr/Web/ReqMgrService.py
@@ -120,7 +120,9 @@ def request_attr(doc, attrs=None):
                 if isinstance(tval, list):
                     while len(tval) < 9:
                         tval.append(0)
-                    gmt = time.gmtime(time.mktime(tval))
+                    # we do not know if dayling savings time was in effect or not
+                    tval[-1] = -1
+                    gmt = time.gmtime(time.mktime(tuple(tval)))
                     rdict[key] = time.strftime("%Y-%m-%d %H:%M:%S GMT", gmt)
                 else:
                     rdict[key] = tval


### PR DESCRIPTION
Fixes #10661 

#### Status
ready

#### Description
It looks like python3 enforces the input parameter to the `time.mktime` function to be of the type tuple or struct_time (list is no longer accepted, as it used to be in python2). Also fix the previous code, which always assumed Daylight Savings time to be not in effect (-1 let it figure it out by itself). Some documentation can be found here:
https://docs.python.org/3.8/library/time.html#time.struct_time

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
I'm considering to create a patch release and push it to CMSWEB on Monday.
