### PR TITLE
Adjust couchapp push command to match CMSCouchapp

### DIFF
--- a/bin/wmagent-couchapp-init
+++ b/bin/wmagent-couchapp-init
@@ -16,9 +16,7 @@ import tempfile
 import urllib
 
 from urllib.parse import urlsplit
-
 from couchapp.commands import push as couchapppush
-from couchapp.config import Config
 
 from WMCore.Configuration import loadConfigurationFile
 from WMCore.Lexicon import splitCouchServiceURL
@@ -45,14 +43,20 @@ def installCouchApp(couchUrl, couchDBName, couchAppName, basePath=None):
     Install the given couch app on the given server in the given database.  If
     the database already exists it will be deleted.
     """
+    # set of options required by the couchapp push command
+    # from collections import namedtuple
+    # couchOpts = namedtuple("opts", ["export", "output", "force", "no_atomic"])
+    # for attribute in ["export", "output", "force", "no_atomic"]:
+    #     setattr(couchOpts, attribute, False)
+    ### AMR debugging workqueue couchapps, remove it later ###
+    #couchOpts.export = True
+    #couchOpts.output = "/data/WorkQueue.json"
+    ##########################################################
     if not basePath:
         basePath = couchAppRoot(couchAppName)
     print("Installing %s into %s" % (couchAppName, urllib.unquote_plus(couchDBName)))
 
-    couchappConfig = Config()
-
-    couchapppush(couchappConfig, "%s/%s" % (basePath, couchAppName),
-                 "%s/%s" % (couchUrl, couchDBName))
+    couchapppush("%s/%s" % (basePath, couchAppName), "%s/%s" % (couchUrl, couchDBName))
     return
 
 

--- a/src/python/WMQuality/TestInitCouchApp.py
+++ b/src/python/WMQuality/TestInitCouchApp.py
@@ -19,7 +19,6 @@ import os
 import urllib.parse
 
 from couchapp.commands import push as couchapppush
-from couchapp.config import Config
 from WMCore.Database.CMSCouch import CouchServer
 
 from WMQuality.TestInit import TestInit
@@ -40,7 +39,6 @@ class CouchAppTestHarness(object):
         if self.couchUrl.endswith('/'):
             raise RuntimeError("COUCHURL env var shouldn't end with /")
         self.couchServer = CouchServer(self.couchUrl)
-        self.couchappConfig = Config()
 
 
     def create(self, dropExistingDb=True):
@@ -63,7 +61,7 @@ class CouchAppTestHarness(object):
         push a list of couchapps to the database
         """
         for couchappdir in  couchappdirs:
-            couchapppush(self.couchappConfig, couchappdir, "%s/%s" % (self.couchUrl, urllib.parse.quote_plus(self.dbName)))
+            couchapppush(couchappdir, "%s/%s" % (self.couchUrl, urllib.parse.quote_plus(self.dbName)))
 
 
 class TestInitCouchApp(TestInit):

--- a/test/data/WMStats/generator.py
+++ b/test/data/WMStats/generator.py
@@ -6,7 +6,6 @@ import time
 from argparse import ArgumentParser
 
 from couchapp.commands import push as couchapppush
-from couchapp.config import Config
 
 from WMCore.Database.CMSCouch import CouchServer
 from WMCore.Lexicon import splitCouchServiceURL
@@ -39,11 +38,7 @@ def installCouchApp(couchUrl, couchDBName, couchAppName, basePath=None):
         basePath = couchAppRoot()
     print("Installing %s into %s" % (couchAppName, couchDBName))
 
-    couchServer = CouchServer(couchUrl)
-    couchappConfig = Config()
-
-    couchapppush(couchappConfig, "%s/%s" % (basePath, couchAppName),
-                 "%s/%s" % (couchUrl, couchDBName))
+    couchapppush("%s/%s" % (basePath, couchAppName), "%s/%s" % (couchUrl, couchDBName))
     return
 
 


### PR DESCRIPTION
wmagent 1.4.7 branch version of https://github.com/dmwm/WMCore/pull/10485
Needed because the RPM we built yesterday, is actually using the new couchdb spec (with new cmscouchapp python library), so we need to backport this bin changes to this branch as well, in order to have a clean deployment.