### PR TITLE
Fix broken variable reference in TestMonitor

### DIFF
--- a/src/python/WMCore/WMRuntime/Monitors/TestMonitor.py
+++ b/src/python/WMCore/WMRuntime/Monitors/TestMonitor.py
@@ -152,7 +152,7 @@ class TestMonitor(WMRuntimeMonitor):
 
         # Check for events
         if self.cmsswFile:
-            run, event = searchForEvent(file)
+            run, event = searchForEvent(self.cmsswFile)
             if run and event:
                 # Then we actually found something, otherwise do nothing
                 # Right now I don't know what to do


### PR DESCRIPTION
Fixes #10448 

#### Status
ready

#### Description
The issue itself is well explained. This fixes a broken reference to a non-existent variable (or out of scope). The logical thing to me is to simply call it as provided in this PR.

Note, that this code is likely not being exercised, otherwise it would have broken long ago.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
