### PR TITLE
Keep all relval output datatiers on disk ( Bypass unified tiers_no_DDM configuration )

### DIFF
--- a/src/python/WMCore/MicroService/MSOutput/MSOutput.py
+++ b/src/python/WMCore/MicroService/MSOutput/MSOutput.py
@@ -707,6 +707,9 @@ class MSOutput(MSCore):
         :param isRelVal: boolean flag identifying if dataset belongs to a RelVal request
         :return: True if the dataset is allowed to pass, False otherwise
         """
+        # Bypass every configuration for RelVals, keep everything on disk
+        if isRelVal:
+            return True
         dataTier = dataItem['Dataset'].split('/')[-1]
         if dataTier in self.msConfig['excludeDataTier']:
             self.logger.warning("Skipping dataset: %s because it's excluded in the MS configuration",


### PR DESCRIPTION
Fixes #10668 

#### Status
not tested

#### Description
This PR bypasses all MSOutput configurations (Unified `tiers_no_DDM` configuration and MS configuration), thus makes MSOutput create rules for all RelVal outputs.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
None

#### External dependencies / deployment changes
None
