### PR TITLE
first commit to enable archs != x86_64

### DIFF
--- a/etc/submit.sh
+++ b/etc/submit.sh
@@ -122,11 +122,19 @@ echo -e "======== WMAgent CMS environment load finished at $(TZ=GMT date) ======
 
 echo "======== WMAgent COMP Python bootstrap starting at $(TZ=GMT date) ========"
 # First, decide which COMP ScramArch to use based on the required OS
+myarch=`uname -m`
+if [ "$myarch" == "x86_64" ]
+then
+    myarch="amd64"
+fi
+
+
+
 if [ "$REQUIRED_OS" = "rhel7" ];
 then
-    WMA_SCRAM_ARCH=slc7_amd64_gcc630
+    WMA_SCRAM_ARCH=slc7_${myarch}_gcc630
 else
-    WMA_SCRAM_ARCH=slc6_amd64_gcc493
+    WMA_SCRAM_ARCH=slc6_${myarch}_gcc493
 fi
 echo "Job requires OS: $REQUIRED_OS, thus setting ScramArch to: $WMA_SCRAM_ARCH"
 
@@ -154,7 +162,7 @@ pythonCommand="python"${pythonMajorVersion}
 echo "WMAgent bootstrap: latest python release is: $latestPythonVersion"
 source "$prefix/$latestPythonVersion/$suffix"
 source "$compPythonPath/py2-future/$PY_FUTURE_VERSION/$suffix"
-
+echo "Using Python: $pythonCommand"
 command -v $pythonCommand > /dev/null
 rc=$?
 if [[ $rc != 0 ]]


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/10840

First attempt for supporting ARCHS != x86_64

See the presentations @ DRP: https://indico.cern.ch/event/1049288/

#### Status
tested on a local environment

#### Description
just 2 changes: 
- submit.sh: instead of using *_amd64_*. the middle part of the COMP repository is taken from `uname -m`
- SimpleCondorPlugin.py: for worker nodes NOT using x86_64, the ARCH requirement in Condor cannot be left blank (otherwise the WMA ARCH is used). A function to prepare the proper requirement is proposed. 

Please note that most probably this will not work with CMS@HOME on PPC (while the current behavior for cms@home on x86 should be ok) since in that case additional requirements are already present, and I did not want to touch them.



#### Is it backward compatible (if not, which system it affects?)
In my setup it is (based on 1.4.7.patch5). Should be checked for consistency on a release closer to master

#### Related PRs
None

#### External dependencies / deployment changes
no


PS: this is NOT including the changes needed for multi arch (running on x84 OR ppc, for example); this will be done later after discussions with the DMWM developers