### PR TITLE
Add IPython dependency for reqmgr2ms.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ Sphinx==1.3.5                 # wmagent,reqmgr2,acdcserver,global-workqueue,reqm
 SQLAlchemy==1.3.3             # wmagent
 stomp.py==4.1.15              # wmagent
 CMSCouchapp==1.2.10           # wmagent
+IPython==5.10.0               # reqmgr2ms

--- a/requirements_py3.txt
+++ b/requirements_py3.txt
@@ -32,3 +32,4 @@ retry==0.9.2
 sphinx==1.6.3
 CMSMonitoring==0.3.4
 CMSCouchapp==1.3.2
+IPython==7.25.0


### PR DESCRIPTION
Fixes #10676 

#### Status
ready

#### Description
Adding dependency from IPython because of reqmgr2ms and more precisely MSUnmerged.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
https://github.com/cms-sw/cmsdist/pull/7148

#### External dependencies / deployment changes
Yes - it is needed because we use IPython.lib in one of our micro services. 
