### PR TITLE
Substitute pretty function from IPython.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,3 @@ Sphinx==1.3.5                 # wmagent,reqmgr2,acdcserver,global-workqueue,reqm
 SQLAlchemy==1.3.3             # wmagent
 stomp.py==4.1.15              # wmagent
 CMSCouchapp==1.2.10           # wmagent
-IPython==5.10.0               # reqmgr2ms

--- a/requirements_py3.txt
+++ b/requirements_py3.txt
@@ -32,4 +32,3 @@ retry==0.9.2
 sphinx==1.6.3
 CMSMonitoring==0.3.4
 CMSCouchapp==1.3.2
-IPython==7.25.0

--- a/src/python/Utils/TwPrint.py
+++ b/src/python/Utils/TwPrint.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""
+File       : TwPrint.py
+
+Description:
+
+A simple textwrap based printer for nested dictionaries.
+
+"""
+from textwrap import TextWrapper
+from collections import OrderedDict
+
+
+def twClosure(replace_whitespace=False,
+              break_long_words=False,
+              maxWidth=120,
+              maxLength=-1,
+              maxDepth=-1,
+              initial_indent=''):
+    """
+    Deals with indentation of dictionaries with very long key, value pairs.
+    replace_whitespace: Replace each whitespace character with a single space.
+    break_long_words: If True words longer than width will be broken.
+    width: The maximum length of wrapped lines.
+    initial_indent: String that will be prepended to the first line of the output
+
+    Wraps all strings for both keys and values to 120 chars.
+    Uses 4 spaces indentation for both keys and values.
+    Nested dictionaries and lists go to next line.
+    """
+    twr = TextWrapper(replace_whitespace=replace_whitespace,
+                      break_long_words=break_long_words,
+                      width=maxWidth,
+                      initial_indent=initial_indent)
+
+    def twEnclosed(obj, ind='', depthReached=0, reCall=False):
+        """
+        The inner function of the closure
+        ind: Initial indentation for the single output string
+        reCall: Flag to indicate a recursive call (should not be used outside)
+        """
+        output = ''
+        if isinstance(obj, dict):
+            obj = OrderedDict(sorted(obj.items(),
+                                     key=lambda t: t[0],
+                                     reverse=False))
+            if reCall:
+                output += '\n'
+            ind += '    '
+            depthReached += 1
+            lengthReached = 0
+            for key, value in obj.items():
+                lengthReached += 1
+                if lengthReached > maxLength and maxLength >= 0:
+                    output += "%s...\n" % ind
+                    break
+                if depthReached <= maxDepth or maxDepth < 0:
+                    output += "%s%s: %s" % (ind,
+                                            ''.join(twr.wrap(key)),
+                                            twEnclosed(value, ind, depthReached=depthReached, reCall=True))
+
+        elif isinstance(obj, (list, set)):
+            if reCall:
+                output += '\n'
+            ind += '    '
+            lengthReached = 0
+            for value in obj:
+                lengthReached += 1
+                if lengthReached > maxLength and maxLength >= 0:
+                    output += "%s...\n" % ind
+                    break
+                if depthReached <= maxDepth or maxDepth < 0:
+                    output += "%s%s" % (ind, twEnclosed(value, ind, depthReached=depthReached, reCall=True))
+        else:
+            output += "%s\n" % str(obj)  # join(twr.wrap(str(obj)))
+        return output
+
+    return twEnclosed
+
+
+def twPrint(obj, maxWidth=120, maxLength=-1, maxDepth=-1):
+    """
+    A simple caller of twClosure (see docstring for twClosure)
+    """
+    twPrinter = twClosure(maxWidth=maxWidth,
+                          maxLength=maxLength,
+                          maxDepth=maxDepth)
+    print(twPrinter(obj))
+
+
+def twFormat(obj, maxWidth=120, maxLength=-1, maxDepth=-1):
+    """
+    A simple caller of twClosure (see docstring for twClosure)
+    """
+    twFormatter = twClosure(maxWidth=maxWidth,
+                            maxLength=maxLength,
+                            maxDepth=maxDepth)
+    return twFormatter(obj)

--- a/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
+++ b/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
@@ -13,7 +13,6 @@ RSE basis.
 from __future__ import division, print_function
 
 from pprint import pformat
-from IPython.lib.pretty import pretty
 from time import time
 
 import random
@@ -33,6 +32,7 @@ from WMCore.Services.WMStatsServer.WMStatsServer import WMStatsServer
 # from WMCore.Services.AlertManager.AlertManagerAPI import AlertManagerAPI
 from WMCore.WMException import WMException
 from Utils.Pipeline import Pipeline, Functor
+from Utils.TwPrint import twFormat
 
 # from memory_profiler import profile
 
@@ -517,12 +517,12 @@ class MSUnmerged(MSCore):
         :return:    rse
         """
         msg = "\n----------------------------------------------------------"
-        msg += "\nMSUnmergedRSE: %s"
+        msg += "\nMSUnmergedRSE: \n%s"
         msg += "\n----------------------------------------------------------"
         if dumpRSE:
             self.logger.debug(msg, pformat(rse))
         else:
-            self.logger.debug(msg, pretty(rse, max_seq_length=6))
+            self.logger.debug(msg, twFormat(rse, maxLength=6))
         rse.clear()
         return rse
 


### PR DESCRIPTION
Fixes #10678 

#### Status
Ready

#### Description
In order to get rid of the dependency of the IPython.lib library we had to remake a simple method for iteration through nested dictionaries so that  we  can limit the depth and length of each nested object to be printed/formatted. 

#### Is it backward compatible (if not, which system it affects?)
YES 

#### Related PRs
No

#### External dependencies / deployment changes
<Does it require deployment changes? Does it rely on third-party libraries?>
