### PR TITLE
Account for failed deletions on a per directory basis

### DIFF
--- a/test/python/WMCore_t/MicroService_t/MSUnmerged_t/MSUnmergedRSE_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSUnmerged_t/MSUnmergedRSE_t.py
@@ -1,0 +1,68 @@
+"""
+Unit tests for MicorService/MSUnmerged/MSUnmergedRSE.py module
+
+"""
+from __future__ import division, print_function
+
+import json
+import os
+import unittest
+import mongomock
+
+from pymongo import IndexModel
+
+from WMCore.MicroService.MSUnmerged.MSUnmerged import MSUnmerged, MSUnmergedRSE
+
+
+class MSUnmergedRSETest(unittest.TestCase):
+    """ Unit test for MSUnmergedRSE module """
+
+    def setUp(self):
+        """ init test class """
+
+        self.maxDiff = None
+
+        msUnmergedIndex = IndexModel('name', unique=True)
+        self.msUnmergedColl = mongomock.MongoClient().msUnmergedDB.msUnmergedColl
+        self.msUnmergedColl.create_indexes([msUnmergedIndex])
+
+        self.expectedRSE = {'name': 'T2_US_Wisconsin',
+                            'pfnPrefix': None,
+                            'isClean': False,
+                            'timestamps': {'rseConsStatTime': 0.0,
+                                           'prevStartTime': 0.0,
+                                           'startTime': 0.0,
+                                           'prevEndTime': 0.0,
+                                           'endTime': 0.0},
+                            'counters': {'totalNumFiles': 0,
+                                         'totalNumDirs': 0,
+                                         'dirsToDelete': 0,
+                                         'filesToDelete': 0,
+                                         'filesDeletedSuccess': 0,
+                                         'filesDeletedFail': 0,
+                                         'dirsDeletedSuccess': 0,
+                                         'dirsDeletedFail': 0,
+                                         'gfalErrors': {}},
+                            'files': {'allUnmerged': [],
+                                      'toDelete': {},
+                                      'protected': {},
+                                      'deletedSuccess': set(),
+                                      'deletedFail': set()},
+                            'dirs': {'allUnmerged': set(),
+                                     'toDelete': set(),
+                                     'protected': set(),
+                                     'deletedSuccess': set(),
+                                     'deletedFail': set()}}
+
+        super(MSUnmergedRSETest, self).setUp()
+
+    def testCreateRSE(self):
+        rse = MSUnmergedRSE('T2_US_Wisconsin')
+        self.assertDictEqual(rse, self.expectedRSE)
+
+    def testRSEReadWrite(self):
+        rse = MSUnmergedRSE('T2_US_Wisconsin')
+        rse.writeRSEToMongoDB(self.msUnmergedColl)
+        rse.readRSEFromMongoDB(self.msUnmergedColl)
+        rse.pop('_id', None)
+        self.assertDictEqual(rse, self.expectedRSE)


### PR DESCRIPTION
Fixes #10686 
Fixes #10933

#### Status
Ready

#### Description
With the current PR we are trying to improve the accounting for failed deletions, while at the same time not increase the amount  of log lines, which is already too high.  

Here are some of the most important changes which it introduces:

 * Handle exceptions per slice instead of the whole RSE - which avoids a single exception from one deletion slice to interrupt the cleaning of the whole RSE && 
 * Count gfall Errors per run - This would provide us with a good summary of what are the most common errors an RSE is experiencying so we can try to address them through GGUS tickets to the site or some other way && 
 * Keep list of deleted success dir - this improves the accounting of already deleted directories && 
 * Do not retry successfully deleted dirs  - Fixes broken counters and minimizes the unneeded operations per RSE per iteration && 
 * Add baseDirPfn check  - this way we avoid errors related to files existing at the toplevel of the current directory which could be the case with files in the following path  `/store/unmerged/SAM/ `  (we may also think of excluding this path too) && 
 * Fix exception handling during recursive iteration in _purgeTree().
 
Because this PR introduces quite  some new fields in the RSE record in the database before deploying we will have to wipe out all the records otherwise we will experience a long series of exceptions because of the missing keys in the old RSE records. And this would continue at least until the next Rucio Consistency Monitor poling cycle when the records for all RSE would be refreshed anyways. 
 
And here is how would look like the output of the info REST API for an RSE which is having all those new fields: [1]  [2]


[1]
https://cmsweb-testbed.cern.ch/ms-unmerged/data/info?rse=T2_US_Florida&detail=True

[2]
https://cmsweb-testbed.cern.ch/ms-unmerged/data/info?rse=T2_RU_INR&detail=True

```
{"result": [
 {
  "wmcore_version": "1.5.7.pre5",
  "microservice_version": "1.5.7.pre5",
  "microservice": "MSManager",
  "query": "rse=T2_RU_INR&detail=True",
  "rseData": [
    {
      "name": "T2_RU_INR",
      "pfnPrefix": "srm://grse001.inr.troitsk.ru:8446/srm/managerv2?SFN=/dpm/inr.troitsk.ru/home/cms",
      "isClean": false,
      "timestamps": {
        "rseConsStatTime": 0.0,
        "prevStartTime": 1642773881.8954148,
        "startTime": 1642778382.9562628,
        "prevEndTime": 1642773882.0129983,
        "endTime": 1642778541.2820504
      },
      "counters": {
        "totalNumFiles": 76,
        "totalNumDirs": 26,
        "dirsToDelete": 2,
        "filesToDelete": 0,
        "filesDeletedSuccess": 0,
        "filesDeletedFail": 0,
        "dirsDeletedSuccess": 0,
        "dirsDeletedFail": 2,
        "gfalErrors": {
          "No such file or directory": 3
        }
      },
      "dirs": {
        "allUnmerged": [],
        "toDelete": [
          "/store/unmerged/SAM/se_gsiftp_20220111_193202_etf-01.wrt",
          "/store/unmerged/SAM/testSRM/SAM-grse001.inr.troitsk.ru/lcg-util"
        ],
        "protected": [
          "/store/unmerged/RunIISummer20UL16NanoAODAPVv9/TTGamma_Dilept_TuneCP5CR2_13TeV-madgraph-pythia8/NANOAODSIM/106X_mcRun2_asymptotic_preVFP_v11-v2",
          "/store/unmerged/RunIISummer20UL16NanoAODv2/GluGluToHiggs0Mf05ph0continToZZTo2e2nu_M125_10GaSM_TuneCP5_13TeV-mcfm701-pythia8/NANOAODSIM/106X_mcRun2_asymptotic_v15-v1",
          "/store/unmerged/RunIISummer20UL18NanoAODv2/GluGluToHiggs0Mf05ph0continToZZTo2mu2tau_M125_GaSM_TuneCP5_13TeV-mcfm701-pythia8/NANOAODSIM/106X_upgrade2018_realistic_v15_L1v1-v1",
          "/store/unmerged/RunIISummer20UL16NanoAODAPVv9/QCD_HT300to500_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8/NANOAODSIM/106X_mcRun2_asymptotic_preVFP_v11-v2",
          "/store/unmerged/RunIISummer20UL17NanoAODv2/HToSSTo2Mu2Hadrons_MH125_MS0p6_ctauS100_TuneCP2_13TeV-powheg-pythia8/NANOAODSIM/106X_mc2017_realistic_v8-v1",
          "/store/unmerged/RunIISummer20UL16MiniAODv2/HbToJPsiMuMu_3MuFilter_TuneCP5_13TeV-pythia8-evtgen/MINIAODSIM/106X_mcRun2_asymptotic_v17-v2",
          "/store/unmerged/RunIISummer20UL16MiniAODAPVv2/QCD_HT300to500_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8/MINIAODSIM/106X_mcRun2_asymptotic_preVFP_v11-v2",
          "/store/unmerged/RunIISummer20UL16NanoAODv2/HbToJPsiMuMu_TuneCP5_13TeV-pythia8-evtgen/NANOAODSIM/106X_mcRun2_asymptotic_v15-v1",
          "/store/unmerged/RunIISummer20UL16MiniAODv2/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV-pythia8/MINIAODSIM/106X_mcRun2_asymptotic_v17-v2",
          "/store/unmerged/RunIISummer20UL16NanoAODv9/QCD_HT300to500_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8/NANOAODSIM/106X_mcRun2_asymptotic_v17-v1",
          "/store/unmerged/RunIISummer20UL17MiniAODv2/GluGluToHiggs0PHToZZTo2e2nu_M125_GaSM_TuneCP5_13TeV-mcfm701-pythia8/MINIAODSIM/106X_mc2017_realistic_v9-v2",
          "/store/unmerged/RunIISummer20UL16NanoAODAPVv2/QCD_Pt-1000_MuEnrichedPt5_TuneCP5_13TeV-pythia8/NANOAODSIM/106X_mcRun2_asymptotic_preVFP_v9-v1",
          "/store/unmerged/RunIISummer20UL16NanoAODv2/VBF_LFV_HToEMu_M125_TuneCH3_13TeV_powheg_herwig7/NANOAODSIM/106X_mcRun2_asymptotic_v15_ext1-v1",
          "/store/unmerged/RunIISummer20UL16NanoAODv9/HbToJPsiMuMu_3MuFilter_TuneCP5_13TeV-pythia8-evtgen/NANOAODSIM/106X_mcRun2_asymptotic_v17-v2",
          "/store/unmerged/RunIISummer20UL18NanoAODv9/HbToJPsiMuMu_3MuFilter_TuneCP5_13TeV-pythia8-evtgen/NANOAODSIM/106X_upgrade2018_realistic_v16_L1v1_ext1-v1",
          "/store/unmerged/RunIISummer20UL18NanoAODv9/TT_Mtt-700to1000_TuneCP5_13TeV-powheg-pythia8/NANOAODSIM/20UL18JMENano_106X_upgrade2018_realistic_v16_L1v1-v1",
          "/store/unmerged/RunIISummer20UL17NanoAODv9/GluGluToHiggs0PHToZZTo2e2nu_M125_GaSM_TuneCP5_13TeV-mcfm701-pythia8/NANOAODSIM/106X_mc2017_realistic_v9-v2",
          "/store/unmerged/RunIISummer20UL16MiniAODAPVv2/TTGamma_Dilept_TuneCP5CR2_13TeV-madgraph-pythia8/MINIAODSIM/106X_mcRun2_asymptotic_preVFP_v11-v2",
          "/store/unmerged/RunIISummer20UL16MiniAODAPVv2/QCD_Pt-20To30_MuEnrichedPt5_TuneCP5_13TeV-pythia8/MINIAODSIM/106X_mcRun2_asymptotic_preVFP_v11-v2",
          "/store/unmerged/RunIISummer20UL17NanoAODv9/GluGluToRadionToHHTo2G2ZTo2G4Q_M-600_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/NANOAODSIM/106X_mc2017_realistic_v9-v1",
          "/store/unmerged/RunIISummer20UL18NanoAODv9/TT_Mtt-700to1000_TuneCP5_13TeV-powheg-pythia8/NANOAODSIM/106X_upgrade2018_realistic_v16_L1v1-v1",
          "/store/unmerged/RunIISummer20UL16NanoAODAPVv9/QCD_Pt-20To30_MuEnrichedPt5_TuneCP5_13TeV-pythia8/NANOAODSIM/106X_mcRun2_asymptotic_preVFP_v11-v2",
          "/store/unmerged/RunIISummer20UL17NanoAODv9/XtoAAto4G_X400A6_TuneCP5_13TeV-madgraphMLM-pythia8/NANOAODSIM/106X_mc2017_realistic_v9-v1",
          "/store/unmerged/RunIISummer20UL16NanoAODv9/QCD_Pt-20to30_EMEnriched_TuneCP5_13TeV-pythia8/NANOAODSIM/106X_mcRun2_asymptotic_v17-v2"
        ],
        "deletedSuccess": [],
        "deletedFail": [
          "/store/unmerged/SAM/se_gsiftp_20220111_193202_etf-01.wrt",
          "/store/unmerged/SAM/testSRM/SAM-grse001.inr.troitsk.ru/lcg-util"
        ]
      }
    }
  ]
}]}

```

#### Is it backward compatible (if not, which system it affects?)
NO

#### Related PRs
None

#### External dependencies / deployment changes
Needs complete refresh/deletion of the MSUnmerged MongoDBCollection  
