### PR TITLE
Fix RucioConMon.rseUnmerged cache name && Logt full list of RSEs.

### DIFF
--- a/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
+++ b/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
@@ -152,10 +152,10 @@ class MSUnmerged(MSCore):
 
         try:
             rseList = self.getRSEList()
+            msg = "Retrieved list of %s RSEs: %s "
+            msg += "Service set to process up to %s RSEs per instance."
+            self.logger.info(msg, len(rseList), pformat(rseList), self.msConfig["limitRSEsPerInstance"])
             random.shuffle(rseList)
-            msg = "  retrieved %s RSEs. " % len(rseList)
-            msg += "Service set to process up to %s RSEs per instance." % self.msConfig["limitRSEsPerInstance"]
-            self.logger.info(msg)
         except Exception as err:  # general error
             msg = "Unknown exception while trying to estimate the final RSEs to work on. Error: %s", str(err)
             self.logger.exception(msg)

--- a/src/python/WMCore/Services/RucioConMon/RucioConMon.py
+++ b/src/python/WMCore/Services/RucioConMon/RucioConMon.py
@@ -100,7 +100,7 @@ class RucioConMon(Service):
         #       in the future.
         if not zipped:
             uri = "WM/files?rse=%s&format=json" % rseName
-            rseUnmerged = self._getResult(uri, callname='unmerged')
+            rseUnmerged = self._getResult(uri, callname=rseName)
             return rseUnmerged
         else:
             pass


### PR DESCRIPTION
Fixes #10688 

#### Status
ready

#### Description
In this PR we the bug about the stale RSE object contents is fixed. The problem was basically a hard coded name of the cache to be used for the RSET call. In the current fix the `callname` and hence the buffer name is set to be equal to the name of the RSE. 

#### Is it backward compatible (if not, which system it affects?)
YES 

#### Related PRs
None

#### External dependencies / deployment changes
None
