### PR TITLE
Keep workflows in running-open if they still have WQEs to be pulled by the agents

### DIFF
--- a/src/python/WMCore/ReqMgr/CherryPyThreads/StatusChangeTasks.py
+++ b/src/python/WMCore/ReqMgr/CherryPyThreads/StatusChangeTasks.py
@@ -56,6 +56,11 @@ def moveForwardStatus(reqmgrSvc, wfStatusDict, logger):
                 reqmgrSvc.updateRequestStatus(wf, stateFromGQ)
                 logger.info("%s in %s moved to %s", wf, status, stateFromGQ)
                 continue
+            # FIXME: remove this elif once the current active workflows are out
+            # of the system. January 2022 should be good (HG2201)
+            elif stateFromGQ == "running-open" and status == "running-closed":
+                logger.warning("%s in %s, but it should actually be in %s", wf, status, stateFromGQ)
+                continue
 
             try:
                 i = nextStatus.index(stateFromGQ)


### PR DESCRIPTION
Fixes #10656 

#### Status
ready

#### Description
This PR provides a change of the `running-open` and `running-closed` request status definition (not sure whether I should call it a bug or not), where the current behaviour is:
* `running-open`: as long as a workflow has at least one WQE in `Acquired` status, the workflow would remain in `running-open`. Regardless of whether all the rest is still Available, or it's all Done. In other words, at least one WQE is yet to be processed.
* `running-closed`: if the `running-open` case above is not fulfilled... as long as a workflow has at least one WQE in `Running` status, the workflow would remain in `running-closed`. Regardless of whether all the rest is still Available, or it's all Done. In other words, at least 1 WQEs is being processed.

and the new behaviour - with these changes - will be:
* `running-open`: if at least one GQE has been already pulled by an agent (thus, in Acquired or beyond) AND there are still WQEs waiting in GQ (Available/Negotiating/Acquired, thus not yet in WMBS).
* `running-closed`: when all of the workqueue elements are at least in Running status, thus no workqueue elements left in GQ (Available/Negotiating/Acquired).

NOTE: second commit has a temporary fix to avoid attempts from `running-closed` to `running-open` (transition would not happen, but we would see tons of exceptions in the logs), which will happen to many active workflows in the production system. That workaround should be removed in ~6 months from now (mentioned in the code as well)

TODO: wiki https://github.com/dmwm/WMCore/wiki/Request-Status needs to be updated

#### Is it backward compatible (if not, which system it affects?)
No, in the sense that some workflows currently in `running-closed` status would actually be considered as `running-open`, according to the new logic.

#### Related PRs
none

#### External dependencies / deployment changes
none
