### PR TITLE
MSUnmerged: support detail and rse_type in the RESTful APIs

### DIFF
--- a/src/python/WMCore/MicroService/MSRuleCleaner/MSRuleCleaner.py
+++ b/src/python/WMCore/MicroService/MSRuleCleaner/MSRuleCleaner.py
@@ -224,8 +224,8 @@ class MSRuleCleaner(MSCore):
             self.updateReportDict(summary, "normal_archived_num_requests", normalArchivedNumRequests)
             self.updateReportDict(summary, "force_archived_num_requests", forceArchivedNumRequests)
         except Exception as ex:
-            msg = "Unknown exception while running MSRuleCleaner thread Error: %s"
-            self.logger.exception(msg, str(ex))
+            msg = "Unknown exception while running MSRuleCleaner thread Error: {}".format(str(ex))
+            self.logger.exception(msg)
             self.updateReportDict(summary, "error", msg)
 
         return summary

--- a/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
+++ b/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
@@ -146,8 +146,8 @@ class MSUnmerged(MSCore):
                 self.updateReportDict(summary, "num_files_deleted", 0)
                 return summary
         except Exception as ex:
-            msg = "Unknown exception while running MSUnmerged thread Error: %s"
-            self.logger.exception(msg, str(ex))
+            msg = "Unknown exception while running MSUnmerged thread Error: {}".format(str(ex))
+            self.logger.exception(msg)
             self.updateReportDict(summary, "error", msg)
 
         try:
@@ -177,8 +177,8 @@ class MSUnmerged(MSCore):
             self.updateReportDict(summary, "num_rses_cleaned", numRsesCleaned)
             self.updateReportDict(summary, "num_files_deleted", numFilesDeleted)
         except Exception as ex:
-            msg = "Unknown exception while running MSUnmerged thread Error: %s"
-            self.logger.exception(msg, str(ex))
+            msg = "Unknown exception while running MSUnmerged thread Error: {}".format(str(ex))
+            self.logger.exception(msg)
             self.updateReportDict(summary, "error", msg)
 
         return summary

--- a/src/python/WMCore/MicroService/Service/Data.py
+++ b/src/python/WMCore/MicroService/Service/Data.py
@@ -90,12 +90,10 @@ class Data(with_metaclass(Singleton, RESTEntity, object)):
                'microservice': self.mgr.__class__.__name__}
 
         if kwds.get('API') == "status":
-            detail = kwds.get("detail", True)
-            if detail not in (True, "true", "True", "TRUE"):
-                detail = False
-            res.update(self.mgr.status(detail))
+            detail = True if kwds.pop("detail", True) in (True, "true", "True", "TRUE") else False
+            res.update(self.mgr.status(detail, **kwds))
         elif kwds.get('API') == "info":
-            res.update(self.mgr.info(kwds.get("request")))
+            res.update(self.mgr.info(kwds.pop("request", None), **kwds))
         return results(res)
 
     @restcall(formats=[('application/json', JSONFormat())])

--- a/test/python/WMCore_t/MicroService_t/MicroService_t.py
+++ b/test/python/WMCore_t/MicroService_t/MicroService_t.py
@@ -24,15 +24,21 @@ class ServiceManager(object):
         self.config = config
         self.appname = 'test'  # keep it since it is used by XMLFormat(self.app.appname))
 
-    def status(self, serviceName=None):
+    def status(self, serviceName=None, **kwargs):
         "Return current status about our service"
         print("### CALL status API with service name %s" % serviceName)
-        return {'status': "OK", "api": "status"}
+        data = {'status': "OK", "api": "status"}
+        if kwargs:
+            data.update(kwargs)
+        return data
 
-    def info(self, reqName):
+    def info(self, reqName, **kwargs):
         "Return current status about our service"
         print("### CALL info API with request name %s" % reqName)
-        return {'status': "OK", "api": "info"}
+        data = {'status': "OK", "api": "info"}
+        if kwargs:
+            data.update(kwargs)
+        return data
 
 
 class MicroServiceTest(unittest.TestCase):


### PR DESCRIPTION
Fixes #10692 

#### Status
ready

#### Description
This PR provides the following changes:
* fix `stop` call to the MSUnmerged thread
* affecting **all** microservices: support keyword args for the `info` API. For MSUnmerged, add `rse_type` key/value pair to the response, in case it was provided by the user.
* affecting **all** microservices: support keyword args for the `status` API. For MSUnmerged, add `rse_type` key/value pair to the response, in case it was provided by the user. If `detail=true` is provided, then also return a summary of the last MSUnmerged cycle results.

Second commit contains a fix for MSUnmerged and MSRuleCleaner error message reported through the `status` REST API.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
None

#### External dependencies / deployment changes
None
