### PR TITLE
MSUnmerged: support to inclusion/exclusion directory filters

### DIFF
--- a/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
+++ b/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
@@ -79,6 +79,8 @@ class MSUnmerged(MSCore):
         self.msConfig.setdefault("enableRealMode", False)
         self.msConfig.setdefault("dumpRSE", False)
         self.msConfig.setdefault("gfalLogLevel", 'normal')
+        self.msConfig.setdefault("dirFilterIncl", [])
+        self.msConfig.setdefault("dirFilterExcl", [])
         # TODO: Add 'alertManagerUrl' to msConfig'
         # self.alertServiceName = "ms-unmerged"
         # self.alertManagerAPI = AlertManagerAPI(self.msConfig.get("alertManagerUrl", None), logger=logger)
@@ -488,9 +490,32 @@ class MSUnmerged(MSCore):
                 if i.startswith(pattern):
                     yield i
 
+        # NOTE: If the 'dirFilterIncl' is non empty then the cleaning process will
+        #       be enclosed only in this part of the tree and will ignore anything
+        #       from /store/unmerged/ which does not belong to the included filter
+        # NOTE: 'dirFilterExcl' is always applied.
+
+        # Merge the additional filters into a final set to be applied:
+        dirFilterIncl = set(self.msConfig['dirFilterIncl'])
+        dirFilterExcl = set(self.msConfig['dirFilterExcl'])
+        dirFilterAll = dirFilterIncl - dirFilterExcl
+
         # Populate the filters:
         for dirName in rse['dirs']['toDelete']:
-            rse['files']['toDelete'][dirName] = genFunc(dirName, rse['files']['allUnmerged'])
+            # apply additional filters:
+            if dirFilterAll:
+                for dirFilter in dirFilterAll:
+                    if dirName.startswith(dirFilter):
+                        rse['files']['toDelete'][dirName] = genFunc(dirName, rse['files']['allUnmerged'])
+            else:
+                if dirFilterExcl:
+                    dirFilterExclMatch = []
+                    for dirFilter in dirFilterExcl:
+                        dirFilterExclMatch.append(dirName.startswith(dirFilter))
+                    if not any(dirFilterExclMatch):
+                        rse['files']['toDelete'][dirName] = genFunc(dirName, rse['files']['allUnmerged'])
+                else:
+                    rse['files']['toDelete'][dirName] = genFunc(dirName, rse['files']['allUnmerged'])
 
         # Update the counters:
         rse['counters']['dirsToDeleteAll'] = len(rse['files']['toDelete'])


### PR DESCRIPTION
Superseeds https://github.com/dmwm/WMCore/pull/10702
Fixes #10701 
Fixes #10703

#### Status
ready

#### Description
This PR adds the following:
* support to two new service configuration parameters:
 * `dirFilterIncl`: a list with explicit directories to be included by the service
 * `dirFilterExcl`: a list with explicit directories to be excluded by the service cleanup. If the same path is provided in the included and excluded, excluded always has higher precedence.
* made `gfal2` import optional. In case we do not have gfal2 in our stack, like in the unit tests, just set it to a None object and carry on with MSUnmerged tests
* created a new service configuration parameter `emulateGfal2` to be only used by unittests (allowing it to bypass ImportError exception with the gfal2 library)
* isolated gfal2 context creation to its own function
* fixed a mock import error

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none