### PR TITLE
MSUnmerged: make rucioConMon parameter mandatory

### DIFF
--- a/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
+++ b/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
@@ -93,7 +93,6 @@ class MSUnmerged(MSCore):
         self.msConfig.setdefault("limitFilesPerRSE", 200)
         self.msConfig.setdefault("skipRSEs", [])
         self.msConfig.setdefault("rseExpr", "*")
-        self.msConfig.setdefault("rucioConMon", "https://cmsweb-testbed.cern.ch/rucioconmon/")
         self.msConfig.setdefault("enableRealMode", False)
         self.msConfig.setdefault("dumpRSE", False)
         self.msConfig.setdefault("gfalLogLevel", 'normal')


### PR DESCRIPTION
Fixes #10714 

#### Status
ready

#### Description
To avoid possible mistakes with the Rucio ConMon url, I have made that parameter mandatory in the unmerged microservice.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
Deployment changes: https://github.com/dmwm/deployment/pull/1082
