### PR TITLE
Implement py3 sorting for JobSplitting

### DIFF
--- a/src/python/WMCore/JobSplitting/JobFactory.py
+++ b/src/python/WMCore/JobSplitting/JobFactory.py
@@ -8,6 +8,7 @@ from builtins import range
 
 import logging
 import threading
+import operator
 
 from WMCore.DAOFactory import DAOFactory
 from WMCore.DataStructs.WMObject import WMObject
@@ -242,7 +243,11 @@ class JobFactory(WMObject):
             logging.debug("About to load files by DAO")
             fileset = self.subscription.availableFiles(limit=self.limit, doingJobSplitting=True)
 
-        for fileInfo in fileset:
+        # Reverse sorting this set by location is required to match how sorting was done in py2
+        # Unittests that rely on this sorting method
+        # - WMCore_t.WMBS_t.JobSplitting_t.FileBased_t.FileBasedTest:testSiteWhiteBlacklist
+        # - WMCore_t.WMBS_t.JobSplitting_t.FileBased_t.FileBasedTest:testLocationSplit
+        for fileInfo in sorted(fileset, key=operator.itemgetter('locations'), reverse=True):
 
             if self.trustSitelists:
                 locSet = frozenset(set(['AAA']))

--- a/src/python/WMCore/JobSplitting/ParentlessMergeBySize.py
+++ b/src/python/WMCore/JobSplitting/ParentlessMergeBySize.py
@@ -8,6 +8,7 @@ from __future__ import division
 
 import time
 import threading
+from functools import cmp_to_key
 
 from WMCore.WMBS.File import File
 from WMCore.DataStructs.Run import Run
@@ -78,7 +79,7 @@ class ParentlessMergeBySize(JobFactory):
             self.newGroup()
 
         self.newJob(name = self.getJobName())
-        mergeFiles.sort(fileCompare)
+        mergeFiles.sort(key=cmp_to_key(fileCompare))
 
         jobSize = 0
         largestFile = 0
@@ -123,7 +124,7 @@ class ParentlessMergeBySize(JobFactory):
         mergeJobFiles    = []
         earliestInsert   = 999999999999999
 
-        mergeableFiles.sort(fileCompare)
+        mergeableFiles.sort(key=cmp_to_key(fileCompare))
 
         for mergeableFile in mergeableFiles:
             if mergeableFile["file_size"] > self.maxMergeSize or \

--- a/src/python/WMCore/JobSplitting/SplitFileBased.py
+++ b/src/python/WMCore/JobSplitting/SplitFileBased.py
@@ -9,6 +9,7 @@ single job for each merge unit.
 """
 
 import threading
+from functools import cmp_to_key
 
 from WMCore.DAOFactory import DAOFactory
 from WMCore.DataStructs.Run import Run
@@ -58,12 +59,10 @@ def sortedFilesFromMergeUnits(mergeUnits):
     Given a list of merge units sort them and the files that they contain.
     Return a list of sorted WMBS File structures.
     """
-    mergeUnits.sort(mergeUnitCompare)
-
+    mergeUnits.sort(key=cmp_to_key(mergeUnitCompare))
     sortedFiles = []
     for mergeUnit in mergeUnits:
-        mergeUnit["files"].sort(fileCompare)
-
+        mergeUnit["files"].sort(key=cmp_to_key(fileCompare))
         for file in mergeUnit["files"]:
             newFile = File(id=file["file_id"], lfn=file["file_lfn"],
                            events=file["file_events"])
@@ -171,7 +170,7 @@ class SplitFileBased(JobFactory):
 
         mergeUnits = self.defineMergeUnits(mergeableFiles)
         for runNumber in mergeUnits:
-            mergeUnits[runNumber].sort(mergeUnitCompare)
+            mergeUnits[runNumber].sort(key=cmp_to_key(mergeUnitCompare))
             self.createProcJobs(mergeUnits[runNumber])
 
         return self.jobGroups

--- a/src/python/WMCore/JobSplitting/WMBSMergeBySize.py
+++ b/src/python/WMCore/JobSplitting/WMBSMergeBySize.py
@@ -7,6 +7,7 @@ been split up honoring the original file boundaries.
 """
 
 import threading
+from functools import cmp_to_key
 
 from WMCore.DAOFactory import DAOFactory
 from WMCore.DataStructs.Run import Run
@@ -55,11 +56,11 @@ def sortedFilesFromMergeUnits(mergeUnits):
     Given a list of merge units sort them and the files that they contain.
     Return a list of sorted WMBS File structures.
     """
-    mergeUnits.sort(mergeUnitCompare)
+    mergeUnits.sort(key=cmp_to_key(mergeUnitCompare))
 
     sortedFiles = []
     for mergeUnit in mergeUnits:
-        mergeUnit["files"].sort(fileCompare)
+        mergeUnit["files"].sort(key=cmp_to_key(fileCompare))
 
         for file in mergeUnit["files"]:
             newFile = File(id=file["file_id"], lfn=file["file_lfn"],

--- a/test/etc/UnstableTests.txt
+++ b/test/etc/UnstableTests.txt
@@ -27,8 +27,5 @@ WMCore_t.MicroService_t.MSRuleCleaner_t.MSRuleCleanerWflow_t.MSRuleCleanerWflowT
 WMCore_t.Services_t.LogDB_t.LogDB_t.LogDBTest:test_heartbeat
 WMCore_t.Services_t.Requests_t.testRepeatCalls:testRecoveryFromConnRefused_with_pycur
 WMCore_t.Services_t.Requests_t.testRepeatCalls:test10Calls
-WMCore_t.WMBS_t.JobSplitting_t.EventBased_t.EventBasedTest:test100EventMultipleSite
-WMCore_t.WMBS_t.JobSplitting_t.FileBased_t.FileBasedTest:testSiteWhiteBlacklist
 WMCore_t.WMBS_t.JobSplitting_t.RunBased_t.EventBasedTest:testMultipleRunsCombine
-WMCore_t.WMBS_t.JobSplitting_t.FileBased_t.FileBasedTest:testLocationSplit
 WMCore_t.WorkQueue_t.Policy_t.Start_t.Block_t.BlockTestCase:testPileupData


### PR DESCRIPTION
Fixes #10627

#### Status
ready

#### Description
Implements the necessary changes to allow for python3 sorting based on comparison functions

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
NA

#### External dependencies / deployment changes
NA