### PR TITLE
[py2py3] Properly deal with strings location in the File module

### DIFF
--- a/src/python/WMCore/WMBS/File.py
+++ b/src/python/WMCore/WMBS/File.py
@@ -5,7 +5,7 @@ _File_
 A simple object representing a file in WMBS.
 """
 
-from builtins import next
+from builtins import next, str, bytes
 
 import logging
 import threading
@@ -30,7 +30,7 @@ class File(WMBSBase, WMFile):
         if locations is None:
             self.setdefault("newlocations", set())
         else:
-            if isinstance(locations, str):
+            if isinstance(locations, (str, bytes)):
                 self.setdefault("newlocations", set())
                 self['newlocations'].add(locations)
             else:
@@ -399,7 +399,7 @@ class File(WMBSBase, WMFile):
         locations could be added - confusing when file requires locations on its
         first creation (breaks transaction model in Fileset commits etc)
         """
-        if isinstance(pnn, str):
+        if isinstance(pnn, (str, bytes)):
             self['newlocations'].add(pnn)
             self['locations'].add(pnn)
         else:


### PR DESCRIPTION
Fixes #10721 

#### Status
ready

#### Description
The current code is actually updating a set with a string, thus making a mess of the file location. E.g.:
```
In [1]: aaa = set()

In [2]: aaa.update("Alan")

In [3]: aaa
Out[3]: {'A', 'a', 'l', 'n'}
```

With this PR, we ensure byte/unicode strings are always added to a set.

NOTE: this is only needed if we are running this code in Python2.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None