### PR TITLE
[py2py3] fix JobCreator_t.py

### DIFF
--- a/test/python/WMComponent_t/JobCreator_t/JobCreator_t.py
+++ b/test/python/WMComponent_t/JobCreator_t/JobCreator_t.py
@@ -287,7 +287,7 @@ class JobCreatorTest(EmulatedUnitTestCase):
         jobDir = os.listdir(groupDirectory)[0]
         jobFile = os.path.join(groupDirectory, jobDir, 'job.pkl')
         self.assertTrue(os.path.isfile(jobFile))
-        f = open(jobFile, 'r')
+        f = open(jobFile, 'rb')
         job = pickle.load(f)
         f.close()
 


### PR DESCRIPTION
related to #10555 

#### Status
Ready

#### Description
This fixes a unittest from #10555, but should not close it because TaskArchiver_t has not been fied yet.

The solution was simply a quick change in how a pickle is loaded in the unittest itself, nothing serious.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
nope

#### External dependencies / deployment changes
nope
