### PR TITLE
Load workload pickle object during runtime in binary mode

### DIFF
--- a/src/python/WMCore/WMRuntime/Bootstrap.py
+++ b/src/python/WMCore/WMRuntime/Bootstrap.py
@@ -168,7 +168,7 @@ def loadWorkload():
     """
     sandboxLoc = locateWMSandbox()
     workloadPcl = "%s/WMWorkload.pkl" % sandboxLoc
-    with open(workloadPcl, 'r') as handle:
+    with open(workloadPcl, 'rb') as handle:
         wmWorkload = pickle.load(handle)
 
     return WMWorkloadHelper(wmWorkload)

--- a/src/python/WMCore/WMRuntime/Startup.py
+++ b/src/python/WMCore/WMRuntime/Startup.py
@@ -21,6 +21,8 @@ if __name__ == '__main__':
     # WMAgent log has to be written to the pilot area in order to be transferred back
     Bootstrap.setupLogging(os.path.join(os.getcwd(), '../'))
     logging.info("Process id: %s\tCurrent working directory: %s", os.getpid(), os.getcwd())
+    logging.info("Python version: %s", sys.version)
+    logging.info("Python path: %s", sys.path)
 
     logging.info("Loading job definition")
     job = Bootstrap.loadJobDefinition()


### PR DESCRIPTION
Fixes #10728 

#### Status
ready

#### Description
The following couple of changes are provided:
* open the workload pickle object in binary mode
* record the python version and python path used to execute the WMCore runtime code from within the Startup.py module

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
None

#### External dependencies / deployment changes
None
