### PR TITLE
PY3: Create job package with pickle protocol=4 for Python3 agents

### DIFF
--- a/src/python/Utils/PythonVersion.py
+++ b/src/python/Utils/PythonVersion.py
@@ -5,6 +5,13 @@ Easily get the version of the python interpreter at runtime
 from __future__ import division # Jenkins CI
 
 import sys
+import pickle
 
 PY3 = sys.version_info[0] == 3
 PY2 = sys.version_info[0] == 2
+
+# We need to keep compatibility between multiple python versions
+# Further details at: https://github.com/dmwm/WMCore/pull/10726
+# For PY2: set highest protocol to 2
+# For PY3: set highest protocol to 4 (compatible with python3.6 and python3.8)
+HIGHEST_PICKLE_PROTOCOL = pickle.HIGHEST_PROTOCOL if PY2 else 4

--- a/src/python/WMComponent/JobCreator/JobCreatorPoller.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorPoller.py
@@ -12,12 +12,14 @@ import os
 import os.path
 import threading
 
+
 try:
     import cPickle as pickle
 except ImportError:
     import pickle
 
 from Utils.Timers import timeFunction
+from Utils.PythonVersion import HIGHEST_PICKLE_PROTOCOL
 from Utils.MathUtils import quantize
 from WMComponent.JobCreator.CreateWorkArea import CreateWorkArea
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
@@ -156,7 +158,7 @@ def saveJob(job, workflow, sandbox, wmTask=None, jobNumber=0,
     job['allowOpportunistic'] = allowOpportunistic
 
     with open(os.path.join(cacheDir, 'job.pkl'), 'wb') as output:
-        pickle.dump(job, output, pickle.HIGHEST_PROTOCOL)
+        pickle.dump(job, output, HIGHEST_PICKLE_PROTOCOL)
 
     return
 

--- a/src/python/WMCore/DataStructs/JobPackage.py
+++ b/src/python/WMCore/DataStructs/JobPackage.py
@@ -4,12 +4,11 @@ _JobPackage_
 
 Data structure for storing and retreiving multiple job objects.
 """
-
 try:
     import cPickle as pickle
 except ImportError:
     import pickle
-
+from Utils.PythonVersion import HIGHEST_PICKLE_PROTOCOL
 from WMCore.DataStructs.WMObject import WMObject
 
 
@@ -37,7 +36,7 @@ class JobPackage(WMObject, dict):
         Pickle this object and save it to disk.
         """
         with open(fileName, 'wb') as fileHandle:
-            pickle.dump(self, fileHandle, protocol=pickle.HIGHEST_PROTOCOL)
+            pickle.dump(self, fileHandle, protocol=HIGHEST_PICKLE_PROTOCOL)
         return
 
     def load(self, fileName):


### PR DESCRIPTION
Fixes #10730 

#### Status
ready

#### Description
Be explicit with the pickle protocol used in JobCreator, which creates the job package pickle files. Such that:
* in a Py2 WMAgent, set it to protocol 2
* in a Py3 WMAgent, set it to protocol 4 (because runtime code might use python3.6 instead of python3.8)

Once we manage to move all the runtime code to python3.8+, we can remove this tweak and just use whatever is the HIGHEST_PROTOCOL.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Somehow related to this job wrapper implementation: https://github.com/dmwm/WMCore/pull/10726

#### External dependencies / deployment changes
None
