### PR TITLE
PY3: Pass byte string to subprocess.stdin in Scram runtime

### DIFF
--- a/src/python/WMCore/WMRuntime/ScriptInvoke.py
+++ b/src/python/WMCore/WMRuntime/ScriptInvoke.py
@@ -59,7 +59,7 @@ class ScriptInvoke(object):
         self.task = Bootstrap.loadTask(self.job)
 
         stepSpaceMod = __import__(self.stepModule,
-                                  globals(), locals(), ['stepSpace'], -1)
+                                  globals(), locals(), ['stepSpace'], 0)
 
         self.stepSpace = stepSpaceMod.stepSpace
 

--- a/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
@@ -12,6 +12,8 @@ import socket
 import subprocess
 import sys
 
+from Utils.PythonVersion import PY3
+from Utils.Utilities import encodeUnicodeToBytesConditional
 from WMCore.FwkJobReport.Report import addAttributesToFile
 from WMCore.WMExceptions import WM_JOB_ERROR_CODES
 from WMCore.WMRuntime.Tools.Scram import Scram
@@ -194,13 +196,12 @@ class CMSSW(Executor):
                 stdin=subprocess.PIPE,
             )
             # BADPYTHON
-            scriptProcess.stdin.write("export LD_LIBRARY_PATH=$LD_LIBRARY_PATH\n")
-            invokeCommand = "%s -m WMCore.WMRuntime.ScriptInvoke %s %s \n" % (
-                sys.executable,
-                stepModule,
-                script)
-            logging.info("    Invoking command: %s", invokeCommand)
-            scriptProcess.stdin.write(invokeCommand)
+            invokeCommand = "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH\n"
+            invokeCommand += "{} -m WMCore.WMRuntime.ScriptInvoke {} {} \n".format(sys.executable,
+                                                                                   stepModule,
+                                                                                   script)
+            logging.info("    Invoking command:\n%s", invokeCommand)
+            scriptProcess.stdin.write(encodeUnicodeToBytesConditional(invokeCommand, condition=PY3))
             stdout, stderr = scriptProcess.communicate()
             retCode = scriptProcess.returncode
             if retCode > 0:


### PR DESCRIPTION
Fixes #10734
Possibly #10735 as well

#### Status
ready

#### Description
This PR is also fixing multiple issues reported in the GH issue. Summary of changes is:
* write byte string objects to the subprocess stdin/command during job runtime, only enforced in Python3 though.
* fix parameter passed to the `__import__` built-in, which no longer accepts `-1` in Python3. Value `0` means absolute import only.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
