### PR TITLE
Created generic function to sort list of dicts; make list.sort compatible with Python3

### DIFF
--- a/src/python/Utils/Utilities.py
+++ b/src/python/Utils/Utilities.py
@@ -2,18 +2,20 @@
 
 from __future__ import division, print_function
 from future.utils import viewitems
-
 from builtins import str, bytes
 from past.builtins import basestring
 
-import subprocess
+import base64
 import os
 import re
-import zlib
-import base64
+import subprocess
 import sys
-from types import ModuleType, FunctionType
 from gc import get_referents
+from types import ModuleType, FunctionType
+
+import zlib
+
+
 
 def lowerCmsHeaders(headers):
     """
@@ -21,13 +23,14 @@ def lowerCmsHeaders(headers):
     code check only cms headers in lower case, e.g. cms-xxx-yyy.
     """
     lheaders = {}
-    for hkey, hval in viewitems(headers): # perform lower-case
+    for hkey, hval in viewitems(headers):  # perform lower-case
         # lower header keys since we check lower-case in headers
         if hkey.startswith('Cms-') or hkey.startswith('CMS-'):
             lheaders[hkey.lower()] = hval
         else:
             lheaders[hkey] = hval
     return lheaders
+
 
 def makeList(stringList):
     """
@@ -45,6 +48,22 @@ def makeList(stringList):
             return []
         return [str(tok.strip(' \'"')) for tok in toks]
     raise ValueError("Can't convert to list %s" % stringList)
+
+
+def multiKeySorting(iterObj, orderedKeys):
+    """
+    This function can be used to sort an iterable object of
+    dictionary objects by using multiple key names
+    :param iterObj: iterable object (list, set, tuple)
+    :param orderedKeys: a list of ordered key names of the dict object
+    :return: nothing, iterable object is updated in place
+    """
+    if not orderedKeys:
+        raise RuntimeError("No key names passed to the iterMultiKeySorting function")
+    if not isinstance(iterObj, (list, set)):
+        raise RuntimeError("Passed a wrong data type for orderedKeys in the iterMultiKeySorting function")
+    for keyName in orderedKeys:
+        iterObj.sort(key=lambda item: item[keyName])
 
 
 def makeNonEmptyList(stringList):
@@ -180,7 +199,7 @@ def getSize(obj):
     BLACKLIST = type, ModuleType, FunctionType
 
     if isinstance(obj, BLACKLIST):
-        raise TypeError('getSize() does not take argument of type: '+ str(type(obj)))
+        raise TypeError('getSize() does not take argument of type: ' + str(type(obj)))
     seen_ids = set()
     size = 0
     objects = [obj]
@@ -226,6 +245,7 @@ def decodeBytesToUnicode(value, errors="strict"):
         return value.decode("utf-8", errors)
     return value
 
+
 def decodeBytesToUnicodeConditional(value, errors="ignore", condition=True):
     """
     if *condition*, then call decodeBytesToUnicode(*value*, *errors*),
@@ -246,6 +266,7 @@ def decodeBytesToUnicodeConditional(value, errors="ignore", condition=True):
     if condition:
         return decodeBytesToUnicode(value, errors)
     return value
+
 
 def encodeUnicodeToBytes(value, errors="strict"):
     """
@@ -273,6 +294,7 @@ def encodeUnicodeToBytes(value, errors="strict"):
     if isinstance(value, str):
         return value.encode("utf-8", errors)
     return value
+
 
 def encodeUnicodeToBytesConditional(value, errors="ignore", condition=True):
     """

--- a/src/python/WMCore/JobSplitting/ParentlessMergeBySize.py
+++ b/src/python/WMCore/JobSplitting/ParentlessMergeBySize.py
@@ -8,31 +8,13 @@ from __future__ import division
 
 import time
 import threading
-
+from Utils.Utilities import multiKeySorting
 from WMCore.WMBS.File import File
 from WMCore.DataStructs.Run import Run
 
 from WMCore.DAOFactory import DAOFactory
 from WMCore.JobSplitting.JobFactory import JobFactory
 
-def fileCompare(a, b):
-    """
-    _fileCompare_
-
-    Compare two files based on their "file_first_event" attribute.
-    """
-    if a["file_run"] > b["file_run"]:
-        return 1
-    elif a["file_run"] == b["file_run"]:
-        if a["file_lumi"] > b["file_lumi"]:
-            return 1
-        elif a["file_lumi"] == b["file_lumi"]:
-            if a["file_first_event"] > b["file_first_event"]:
-                return 1
-            if a["file_first_event"] == b["file_first_event"]:
-                return 0
-
-    return -1
 
 class ParentlessMergeBySize(JobFactory):
     def defineFileGroups(self, mergeableFiles):
@@ -78,7 +60,7 @@ class ParentlessMergeBySize(JobFactory):
             self.newGroup()
 
         self.newJob(name = self.getJobName())
-        mergeFiles.sort(fileCompare)
+        multiKeySorting(mergeFiles, orderedKeys=["file_run", "file_lumi", "file_first_event"])
 
         jobSize = 0
         largestFile = 0
@@ -123,7 +105,7 @@ class ParentlessMergeBySize(JobFactory):
         mergeJobFiles    = []
         earliestInsert   = 999999999999999
 
-        mergeableFiles.sort(fileCompare)
+        multiKeySorting(mergeableFiles, orderedKeys=["file_run", "file_lumi", "file_first_event"])
 
         for mergeableFile in mergeableFiles:
             if mergeableFile["file_size"] > self.maxMergeSize or \


### PR DESCRIPTION
Fixes #10505 

#### Status
In development

#### Description
Summary of changes is:
* first commit provides a generic function under `Utils.Utilities` to be used to sort an iterable of dictionary objects with multiple keys
* second commit fixes a JobSplitting algorithm that was using `list.sort` not compatible with python3

TODO: scan the rest of the repo and convert the remaining list.sort to python3 compatible

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None