### PR TITLE
PY3: Decode byte string to unicode for json.dumps

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Executor.py
+++ b/src/python/WMCore/WMSpec/Steps/Executor.py
@@ -16,7 +16,8 @@ import subprocess
 import sys
 
 from Utils.FileTools import getFullPath
-from Utils.Utilities import zipEncodeStr
+from Utils.PythonVersion import PY3
+from Utils.Utilities import zipEncodeStr, decodeBytesToUnicodeConditional
 from WMCore.FwkJobReport.Report import Report
 from WMCore.WMSpec.Steps.StepFactory import getStepEmulator
 from WMCore.WMSpec.WMStep import WMStepHelper
@@ -177,9 +178,12 @@ class Executor(object):
         Util to call condor_chirp and publish the key/value pair
 
         """
+
         if compress:
             value = zipEncodeStr(value, maxLen=maxLen)
 
+        # bytes object is not JSON serializable in Python3
+        value = decodeBytesToUnicodeConditional(value, condition=PY3)
         # construct condor_chirp binary location from CONDOR_CONFIG
         # Note: This works when we do not use containers.
         condor_chirp_bin = None


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/10735 

#### Status
ready

#### Description
This PR provides a fix to all the 3 issues reported. A summary is:
* pass a native/unicode string to the `setCondorChirpAttrDelayed` method, otherwise it would fail to JSON serialize a bytes like object in Python3.
* make a json dump of the pileup conf in native/unicode string as well, thus no longer opening the file descriptor in "b" mode
* same json dump fix for the CMSSW process object, remove the "b" mode and keep passing native/unicode strings to it.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
