### PR TITLE
[py2py3] Modernize all code in WMCore around new pickle API

### DIFF
--- a/src/python/PSetTweaks/PSetTweak.py
+++ b/src/python/PSetTweaks/PSetTweak.py
@@ -367,7 +367,7 @@ class PSetTweak(object):
             with open(filename, "w") as handle:
                 handle.write(self.jsonise())
         if formatting == "pickle":
-            with open(filename, "w") as handle:
+            with open(filename, "wb") as handle:
                 pickle.dump(self, handle)
         if formatting == "simplejson":
             with open(filename, "w") as handle:
@@ -396,7 +396,7 @@ class PSetTweak(object):
             raise RuntimeError(msg)
 
         if formatting == "pickle":
-            with open(filename, 'r') as handle:
+            with open(filename, 'rb') as handle:
                 unpickle = pickle.load(handle)
             self.process.__dict__.update(unpickle.__dict__)
 

--- a/src/python/WMCore/BossAir/Plugins/MockPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/MockPlugin.py
@@ -37,7 +37,7 @@ def processWorker(myinput, tmp):
             if jj['cache_dir'].count("Production/LogCollect") > 0:
                 if lcreport is not None:
                     lcreport.task = "/" + taskName + "/Production/LogCollect"
-                    with open(outfile, 'w') as f:
+                    with open(outfile, 'wb') as f:
                         logging.debug('Process worker is dumping the LogCollect report to ' + f.name)
                         pickle.dump(lcreport, f)
                     continue
@@ -164,12 +164,12 @@ class MockPlugin(BasePlugin):
             self.start( self.myinput )
 
         #for each job we will need to modify the default Report (the output of each job).
-        with open(self.fakeReport) as f:
+        with open(self.fakeReport, "rb") as f:
             report = pickle.load(f)
 
         lcreport = getattr(self.config.BossAir.MockPlugin, 'lcFakeReport', None)
         if lcreport != None:
-            with open(lcreport) as f:
+            with open(lcreport, "rb") as f:
                 lcreport = pickle.load(f)
 
         for jj in jobs:

--- a/src/python/WMCore/ThreadPool/ThreadPool.py
+++ b/src/python/WMCore/ThreadPool/ThreadPool.py
@@ -18,6 +18,7 @@ import logging
 import random
 import threading
 import time
+from Utils.Utilities import encodeUnicodeToBytes
 try:
     import cPickle as pickle
 except ImportError:
@@ -25,6 +26,8 @@ except ImportError:
 
 from WMCore.ThreadPool.WorkQueue import ThreadPool as Queue
 from WMCore.WMFactory import WMFactory
+
+from Utils.PythonVersion import PY3
 
 class ThreadPool(Queue):
     """
@@ -144,9 +147,10 @@ class ThreadPool(Queue):
 
         """
         self.lock.acquire()
-        args = {'event': str(key), \
-                'component' : self.component.config.Agent.componentName, \
-                'payload' : base64.encodestring(pickle.dumps(parameters)), \
+        base64_encoder = base64.encodebytes if PY3 else base64.encodestring
+        args = {'event': str(key),
+                'component' : self.component.config.Agent.componentName,
+                'payload' : base64_encoder(encodeUnicodeToBytes(pickle.dumps(parameters))),
                 'thread_pool_id' : self.threadPoolId}
         myThread = threading.currentThread()
         myThread.transaction.begin()

--- a/src/python/WMCore/ThreadPool/ThreadSlave.py
+++ b/src/python/WMCore/ThreadPool/ThreadSlave.py
@@ -32,6 +32,9 @@ except ImportError:
 from WMCore.Database.Transaction import Transaction
 from WMCore.WMFactory import WMFactory
 
+from Utils.PythonVersion import PY3
+from Utils.Utilities import encodeUnicodeToBytes
+
 class ThreadSlave(object):
     """
     __ThreadSlave__
@@ -173,7 +176,8 @@ class ThreadSlave(object):
         # we commit here because if the component crashes this is where
         # if will look for lost threads (the ones that are in the process state
         myThread.transaction.commit()
-        return (result[1], pickle.loads(base64.decodestring(result[2])))
+        base64_decoder = base64.decodebytes if PY3 else base64.decodestring
+        return (result[1], pickle.loads(base64_decoder(encodeUnicodeToBytes(result[2]))))
 
     def removeWork(self):
         """

--- a/test/python/WMCore_t/BossAir_t/BossAir_t.py
+++ b/test/python/WMCore_t/BossAir_t/BossAir_t.py
@@ -315,9 +315,8 @@ class BossAirTest(unittest.TestCase):
             testJob['cache_dir'] = jobCache
             testJob.save()
             jobGroup.add(testJob)
-            output = open(os.path.join(jobCache, 'job.pkl'), 'w')
-            pickle.dump(testJob, output)
-            output.close()
+            with open(os.path.join(jobCache, 'job.pkl'), 'wb') as output:
+                pickle.dump(testJob, output)
 
         return testJob, testFile
 

--- a/test/python/WMCore_t/Misc_t/WMAgent_t.py
+++ b/test/python/WMCore_t/Misc_t/WMAgent_t.py
@@ -445,9 +445,8 @@ class WMAgentTest(unittest.TestCase):
         self.assertTrue('job_1' in os.listdir(groupDirectory))
         jobFile = os.path.join(groupDirectory, 'job_1', 'job.pkl')
         self.assertTrue(os.path.isfile(jobFile))
-        f = open(jobFile, 'r')
-        job = pickle.load(f)
-        f.close()
+        with open(jobFile, 'rb') as f:
+            job = pickle.load(f)
 
 
         self.assertEqual(job['workflow'], name)


### PR DESCRIPTION
Fixes #10732

#### Status
Ready

#### Description

The changes fall into two categories:

- make sure that when loading a pickle, we read from a bytes stream in both py2 and py3. make sure that when dumping a pickle, we write to a bytes stream in both py2 and py3. We are lucky, we are only reading/writing to files (no bytesio streams, for example), so this was as easy as using `"wb"`/`"rb"` where neeeded.

- make sure that who used the result of `pickle.dumps` is expecting bytes. make sure that the input of `pickle.loads` is bytes. This was down to checking the input/output types of `pickle` and `base64` loader/dumper encoder/decoder.

#### Is it backward compatible (if not, which system it affects?)
yes, it should continue behaving as expected in py2

#### Related PRs
We already make changes related to pickle, but this is the first extensive search into what we missed

#### External dependencies / deployment changes
nope
