### PR TITLE
[py2py3] modernize use of mylist.sort() in REST/Server.py

### DIFF
--- a/src/python/WMCore/REST/Server.py
+++ b/src/python/WMCore/REST/Server.py
@@ -188,7 +188,7 @@ class RESTFrontPage(object):
         if instances:
             instances = [dict(id=k, title=v[".title"], order=v[".order"])
                          for k, v in viewitems(instances())]
-            instances.sort(lambda a, b: a["order"] - b["order"])
+            instances.sort(key=lambda x: x["order"])
             self._preamble += (", REST_INSTANCES = %s" % json.dumps(instances))
 
         self._preamble += ";\n%s" % (preamble or "")


### PR DESCRIPTION
Related to #10505

#### Status
Ready

#### Description

Used a lambda to get the sorting key. I conducted some tests to ensure that the same ordering is preserved [1]

#### Is it backward compatible (if not, which system it affects?)
yes, it should work in python2 too

#### Related PRs
together with #10720, this should fix #10505

#### External dependencies / deployment changes
nope

#### further information

[1]

Given the example data

```python
dict_list = {'F4CS33L9A69O600': {'.title': '81K6QBGEGPM1DUP', '.order': 98},
 '7ZNTF44YIT9ET23': {'.title': 'PJUXKTS80BLH5DU', '.order': 2},
 'LCA3883IS48B4GC': {'.title': 'L809751QQ51BLUJ', '.order': 508},
 'Y34A18YSUHBTCX9': {'.title': 'GE6ZT21YZ8PCVB3', '.order': 650},
 'RQTNLCIS7NZKLPJ': {'.title': 'GF5E4T9K7FCVR3L', '.order': 897},
 'F8Q7CNFHU58DOAQ': {'.title': 'CBL2D2UYS0TNPJD', '.order': 1948},
 'ZVLAF4F98YD59HQ': {'.title': 'GZMUFA31O6ZE8H8', '.order': 1422},
 'P097JZAUXORVOTO': {'.title': '5HHMFUEEH21MQF0', '.order': 586},
 'XCV0XPRM4KW0RZ0': {'.title': 'G07KH9MTPHCCE3U', '.order': 656},
 'KA3SALANIRU2N0Z': {'.title': 'O63BJENQSHZ48P8', '.order': 326},
 '1GAKZ4KQS7I1K49': {'.title': 'F286NYWL0O3VGY9', '.order': 1794},
 '4FXDJVRZW37HA33': {'.title': 'FRJQAGINBPKRA4L', '.order': 1488},
 'ZCTCVWYYT0Q87A5': {'.title': '92FH8HGHJQ7373G', '.order': 1915},
 'ZALYIQQ1FJZIZET': {'.title': 'GRRDYALZOEB5ILD', '.order': 911},
 'BCV5QJPLWBJDQBZ': {'.title': 'ZN07KT484J68RHY', '.order': 418},
 'ISMTPO27Z6ET18O': {'.title': 'X6QJVJBDT9EFKKA', '.order': 1017},
 '0ML0BYEIGG3VOIO': {'.title': 'LZ0CDITRLT8Y8I2', '.order': 1888},
 '9X3GH2J7MZGU4H2': {'.title': '19R2AT0GAPOWAKU', '.order': 1874},
 '4EMBMHGLIZBQFDI': {'.title': '52RS78KDZHT693W', '.order': 347},
 'Y77WKU3CYFM7YGY': {'.title': '66GP8D3LWVOP3O6', '.order': 1022}}
```

I created the list of dictionaries in the same way as in out source code

```python
instances = [dict(id=k, title=v[".title"], order=v[".order"])
             for k, v in dict_list.items()]
```

Py2 sorting gives

```
instances.sort(lambda a, b: a["order"] - b["order"])

[{'id': '7ZNTF44YIT9ET23', 'order': 2, 'title': 'PJUXKTS80BLH5DU'},
 {'id': 'F4CS33L9A69O600', 'order': 98, 'title': '81K6QBGEGPM1DUP'},
 {'id': 'KA3SALANIRU2N0Z', 'order': 326, 'title': 'O63BJENQSHZ48P8'},
 {'id': '4EMBMHGLIZBQFDI', 'order': 347, 'title': '52RS78KDZHT693W'},
 {'id': 'BCV5QJPLWBJDQBZ', 'order': 418, 'title': 'ZN07KT484J68RHY'},
 {'id': 'LCA3883IS48B4GC', 'order': 508, 'title': 'L809751QQ51BLUJ'},
 {'id': 'P097JZAUXORVOTO', 'order': 586, 'title': '5HHMFUEEH21MQF0'},
 {'id': 'Y34A18YSUHBTCX9', 'order': 650, 'title': 'GE6ZT21YZ8PCVB3'},
 {'id': 'XCV0XPRM4KW0RZ0', 'order': 656, 'title': 'G07KH9MTPHCCE3U'},
 {'id': 'RQTNLCIS7NZKLPJ', 'order': 897, 'title': 'GF5E4T9K7FCVR3L'},
 {'id': 'ZALYIQQ1FJZIZET', 'order': 911, 'title': 'GRRDYALZOEB5ILD'},
 {'id': 'ISMTPO27Z6ET18O', 'order': 1017, 'title': 'X6QJVJBDT9EFKKA'},
 {'id': 'Y77WKU3CYFM7YGY', 'order': 1022, 'title': '66GP8D3LWVOP3O6'},
 {'id': 'ZVLAF4F98YD59HQ', 'order': 1422, 'title': 'GZMUFA31O6ZE8H8'},
 {'id': '4FXDJVRZW37HA33', 'order': 1488, 'title': 'FRJQAGINBPKRA4L'},
 {'id': '1GAKZ4KQS7I1K49', 'order': 1794, 'title': 'F286NYWL0O3VGY9'},
 {'id': '9X3GH2J7MZGU4H2', 'order': 1874, 'title': '19R2AT0GAPOWAKU'},
 {'id': '0ML0BYEIGG3VOIO', 'order': 1888, 'title': 'LZ0CDITRLT8Y8I2'},
 {'id': 'ZCTCVWYYT0Q87A5', 'order': 1915, 'title': '92FH8HGHJQ7373G'},
 {'id': 'F8Q7CNFHU58DOAQ', 'order': 1948, 'title': 'CBL2D2UYS0TNPJD'}]
```

and py2-py3 compatible sorting gives

```
instances.sort(key=lambda x: x["order"])

[{'id': '7ZNTF44YIT9ET23', 'title': 'PJUXKTS80BLH5DU', 'order': 2},
 {'id': 'F4CS33L9A69O600', 'title': '81K6QBGEGPM1DUP', 'order': 98},
 {'id': 'KA3SALANIRU2N0Z', 'title': 'O63BJENQSHZ48P8', 'order': 326},
 {'id': '4EMBMHGLIZBQFDI', 'title': '52RS78KDZHT693W', 'order': 347},
 {'id': 'BCV5QJPLWBJDQBZ', 'title': 'ZN07KT484J68RHY', 'order': 418},
 {'id': 'LCA3883IS48B4GC', 'title': 'L809751QQ51BLUJ', 'order': 508},
 {'id': 'P097JZAUXORVOTO', 'title': '5HHMFUEEH21MQF0', 'order': 586},
 {'id': 'Y34A18YSUHBTCX9', 'title': 'GE6ZT21YZ8PCVB3', 'order': 650},
 {'id': 'XCV0XPRM4KW0RZ0', 'title': 'G07KH9MTPHCCE3U', 'order': 656},
 {'id': 'RQTNLCIS7NZKLPJ', 'title': 'GF5E4T9K7FCVR3L', 'order': 897},
 {'id': 'ZALYIQQ1FJZIZET', 'title': 'GRRDYALZOEB5ILD', 'order': 911},
 {'id': 'ISMTPO27Z6ET18O', 'title': 'X6QJVJBDT9EFKKA', 'order': 1017},
 {'id': 'Y77WKU3CYFM7YGY', 'title': '66GP8D3LWVOP3O6', 'order': 1022},
 {'id': 'ZVLAF4F98YD59HQ', 'title': 'GZMUFA31O6ZE8H8', 'order': 1422},
 {'id': '4FXDJVRZW37HA33', 'title': 'FRJQAGINBPKRA4L', 'order': 1488},
 {'id': '1GAKZ4KQS7I1K49', 'title': 'F286NYWL0O3VGY9', 'order': 1794},
 {'id': '9X3GH2J7MZGU4H2', 'title': '19R2AT0GAPOWAKU', 'order': 1874},
 {'id': '0ML0BYEIGG3VOIO', 'title': 'LZ0CDITRLT8Y8I2', 'order': 1888},
 {'id': 'ZCTCVWYYT0Q87A5', 'title': '92FH8HGHJQ7373G', 'order': 1915},
 {'id': 'F8Q7CNFHU58DOAQ', 'title': 'CBL2D2UYS0TNPJD', 'order': 1948}]
```