### PR TITLE
Define funcName variable in the right place

### DIFF
--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -672,10 +672,9 @@ class SetupCMSSWPset(ScriptInterface):
         self.scram = self.createScramEnv()
 
         scenario = getattr(self.step.data.application.configuration, "scenario", None)
+        funcName = getattr(self.step.data.application.configuration, "function", None)
         if scenario is not None and scenario != "":
-            self.logger.info("DEBUG: I'm in scenario")
             self.logger.info("Setting up job scenario/process")
-            funcName = getattr(self.step.data.application.configuration, "function", None)
             if getattr(self.step.data.application.configuration, "pickledarguments", None) is not None:
                 funcArgs = pickle.loads(self.step.data.application.configuration.pickledarguments)
             else:


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/pull/10593

#### Status
ready

#### Description
And it looks like I missed applying #10593 to my previous tests earlier this week, reason why this bug [1] went in.
This PR should fix the `funcName` initialization.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Complement to #10593

#### External dependencies / deployment changes
None

[1]
```
Traceback (most recent call last):
  File "/srv/job/WMCore.zip/WMCore/WMRuntime/ScriptInvoke.py", line 110, in <module>
  File "/srv/job/WMCore.zip/WMCore/WMRuntime/ScriptInvoke.py", line 81, in invoke
  File "/srv/job/WMCore.zip/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py", line 762, in __call__
UnboundLocalError: local variable 'funcName' referenced before assignment

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/cvmfs/cms.cern.ch/slc6_amd64_gcc700/external/python3/3.6.4/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/cvmfs/cms.cern.ch/slc6_amd64_gcc700/external/python3/3.6.4/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/srv/job/WMCore.zip/WMCore/WMRuntime/ScriptInvoke.py", line 118, in <module>
RuntimeError: Error invoking script for step WMTaskSpace.cmsRun1
withe Script module: SetupCMSSWPset
local variable 'funcName' referenced before assignmentDetails:
  File "/srv/job/WMCore.zip/WMCore/WMRuntime/ScriptInvoke.py", line 110, in <module>
  File "/srv/job/WMCore.zip/WMCore/WMRuntime/ScriptInvoke.py", line 81, in invoke
  File "/srv/job/WMCore.zip/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py", line 762, in __call__
    if funcName == 'merge':
```
