### PR TITLE
Add lifetime to datasets

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/MySQL/Create.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/Create.py
@@ -49,8 +49,9 @@ class Create(DBCreator):
                  subscribed             INTEGER      DEFAULT 0,
                  phedex_group           VARCHAR(100),
                  delete_blocks          INTEGER,
+                 dataset_lifetime           INTEGER      DEFAULT 0,
                  PRIMARY KEY (id),
-                 CONSTRAINT uq_dbs_dat_sub UNIQUE (dataset_id, site, custodial, auto_approve, move, priority))"""
+                 CONSTRAINT uq_dbs_dat_sub UNIQUE (dataset_id, site, custodial, auto_approve, move, priority, dataset_lifetime))"""
 
         self.create[len(self.create)] = \
             """CREATE TABLE dbsbuffer_algo (

--- a/src/python/WMComponent/DBS3Buffer/MySQL/NewSubscription.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/NewSubscription.py
@@ -19,8 +19,8 @@ class NewSubscription(DBFormatter):
     """
 
     sql = """INSERT IGNORE INTO dbsbuffer_dataset_subscription
-            (dataset_id, site, custodial, auto_approve, move, priority, subscribed, phedex_group, delete_blocks)
-            VALUES (:id, :site, :custodial, :auto_approve, :move, :priority, 0, :phedex_group, :delete_blocks)
+            (dataset_id, site, custodial, auto_approve, move, priority, subscribed, phedex_group, delete_blocks, dataset_lifetime)
+            VALUES (:id, :site, :custodial, :auto_approve, :move, :priority, 0, :phedex_group, :delete_blocks, :dataset_lifetime)
           """
 
     def _createPhEDExSubBinds(self, datasetID, subscriptionInfo, custodialFlag):
@@ -47,6 +47,7 @@ class NewSubscription(DBFormatter):
                           'move': isMove,
                           'priority': subscriptionInfo['Priority'],
                           'phedex_group': phedex_group,
+                          'dataset_lifetime': subscriptionInfo['DatasetLifetimeDisk'],
                           'delete_blocks': delete_blocks})
         return binds
 

--- a/src/python/WMComponent/DBS3Buffer/Oracle/Create.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/Create.py
@@ -49,8 +49,9 @@ class Create(DBCreator):
                  subscribed         INTEGER      DEFAULT 0,
                  phedex_group       VARCHAR(100),
                  delete_blocks      INTEGER,
+                 dataset_lifetime       INTEGER      DEFAULT 0,
                  PRIMARY KEY (id),
-                 CONSTRAINT uq_dbs_dat_sub UNIQUE (dataset_id, site, custodial, auto_approve, move, priority)
+                 CONSTRAINT uq_dbs_dat_sub UNIQUE (dataset_id, site, custodial, auto_approve, move, priority, dataset_lifetime)
                )"""
 
         self.create[len(self.create)] = \

--- a/src/python/WMComponent/DBS3Buffer/Oracle/NewSubscription.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/NewSubscription.py
@@ -18,9 +18,9 @@ class NewSubscription(MySQLNewSubscription):
     """
 
     sql = """INSERT INTO dbsbuffer_dataset_subscription
-             (id, dataset_id, site, custodial, auto_approve, move, priority, subscribed, phedex_group, delete_blocks)
+             (id, dataset_id, site, custodial, auto_approve, move, priority, subscribed, phedex_group, delete_blocks, dataset_lifetime)
              SELECT dbsbuffer_dataset_sub_seq.nextval, :id, :site, :custodial, :auto_approve,
-                    :move, :priority, 0, :phedex_group, :delete_blocks
+                    :move, :priority, 0, :phedex_group, :delete_blocks, :dataset_lifetime
              FROM DUAL
              WHERE NOT EXISTS
                ( SELECT *
@@ -30,5 +30,6 @@ class NewSubscription(MySQLNewSubscription):
                  AND custodial = :custodial
                  AND auto_approve = :auto_approve
                  AND move = :move
-                 AND priority = :priority )
+                 AND priority = :priority
+                 AND dataset_lifetime = :dataset_lifetime)
              """

--- a/src/python/WMComponent/RucioInjector/Database/MySQL/GetUnsubscribedDatasets.py
+++ b/src/python/WMComponent/RucioInjector/Database/MySQL/GetUnsubscribedDatasets.py
@@ -23,7 +23,8 @@ class GetUnsubscribedDatasets(DBFormatter):
                              dbsbuffer_dataset_subscription.auto_approve,
                              dbsbuffer_dataset_subscription.move,
                              dbsbuffer_dataset_subscription.priority,
-                             dbsbuffer_dataset_subscription.phedex_group
+                             dbsbuffer_dataset_subscription.phedex_group,
+                             dbsbuffer_dataset_subscription.dataset_lifetime
                FROM dbsbuffer_dataset_subscription
                INNER JOIN dbsbuffer_dataset ON
                    dbsbuffer_dataset.id = dbsbuffer_dataset_subscription.dataset_id
@@ -54,6 +55,7 @@ class GetUnsubscribedDatasets(DBFormatter):
                 else:
                     entry[key] = 'n'
             entry['priority'] = entry['priority'].lower()
+
         return result
 
     def execute(self, conn=None, transaction=False):

--- a/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
+++ b/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
@@ -436,6 +436,7 @@ class RucioInjectorPoller(BaseWorkerThread):
         for subInfo in unsubscribedDatasets:
             rseName = subInfo['site'].replace("_MSS", "_Tape")
             container = subInfo['path']
+            lifetime = subInfo['dataset_lifetime']
             # Skip central production Tape rules
             if not self.isT0agent and rseName.endswith("_Tape"):
                 logging.info("Bypassing Production container Tape data placement for container: %s and RSE: %s",
@@ -465,6 +466,9 @@ class RucioInjectorPoller(BaseWorkerThread):
             else:
                 # then it's a T0 container placement
                 ruleKwargs['priority'] = 4
+                if not rseName.endswith("_Tape"):
+                    #Assign lifetime to container rules shipping to Disk sites
+                    ruleKwargs['lifetime'] = lifetime
                 if self.testRSEs:
                     rseName = "%s_Test" % rseName
                 #Checking whether we need to ask for rule approval

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -1143,6 +1143,8 @@ class StdBase(object):
                      "SubscriptionPriority": {"default": "Low", "assign_optional": True,
                                               "validate": lambda x: x.lower() in PhEDEx_VALID_SUBSCRIPTION_PRIORITIES},
                      "DeleteFromSource": {"default": False, "type": strToBool},
+                     # Rucio rules subscription information
+                     "DatasetLifetimeDisk": {"type": int, "validate": lambda x: x > 0 }, #used by T0
                      # merge settings
                      "UnmergedLFNBase": {"assign_optional": True},
                      "MergedLFNBase": {"assign_optional": True},

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -990,7 +990,7 @@ class WMTaskHelper(TreeHelper):
                                    custodialGroup="DataOps", nonCustodialGroup="DataOps",
                                    priority="Low", primaryDataset=None,
                                    useSkim=False, isSkim=False,
-                                   dataTier=None, deleteFromSource=False):
+                                   dataTier=None, deleteFromSource=False, dataset_lifetime=None):
         """
         _setSubscriptionsInformation_
 
@@ -1050,6 +1050,7 @@ class WMTaskHelper(TreeHelper):
             outputSection.nonCustodialGroup = nonCustodialGroup
             outputSection.priority = priority
             outputSection.deleteFromSource = deleteFromSource
+            outputSection.dataset_lifetime = dataset_lifetime
 
         return
 
@@ -1082,6 +1083,7 @@ class WMTaskHelper(TreeHelper):
                                        "NonCustodialSites": outputSection.nonCustodialSites,
                                        "AutoApproveSites": outputSection.autoApproveSites,
                                        "Priority": outputSection.priority,
+                                       "DatasetLifetimeDisk": outputSection.dataset_lifetime,
                                        # These might not be present in all specs
                                        "CustodialGroup": getattr(outputSection, "custodialGroup", "DataOps"),
                                        "NonCustodialGroup": getattr(outputSection, "nonCustodialGroup",

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -1483,7 +1483,7 @@ class WMWorkloadHelper(PersistencyHelper):
                                    custodialGroup="DataOps", nonCustodialGroup="DataOps",
                                    priority="Low", primaryDataset=None,
                                    useSkim=False, isSkim=False,
-                                   dataTier=None, deleteFromSource=False):
+                                   dataTier=None, deleteFromSource=False, datasetLifetime=None):
         """
         _setSubscriptionInformation_
 
@@ -1510,7 +1510,7 @@ class WMWorkloadHelper(PersistencyHelper):
                                             custodialGroup, nonCustodialGroup,
                                             priority, primaryDataset,
                                             useSkim, isSkim,
-                                            dataTier, deleteFromSource)
+                                            dataTier, deleteFromSource, datasetLifetime)
             self.setSubscriptionInformation(task,
                                             custodialSites, nonCustodialSites,
                                             autoApproveSites,
@@ -1518,7 +1518,7 @@ class WMWorkloadHelper(PersistencyHelper):
                                             custodialGroup, nonCustodialGroup,
                                             priority, primaryDataset,
                                             useSkim, isSkim,
-                                            dataTier, deleteFromSource)
+                                            dataTier, deleteFromSource, datasetLifetime)
 
         return
 
@@ -1573,6 +1573,7 @@ class WMWorkloadHelper(PersistencyHelper):
                     subInfo[dataset]["NonCustodialGroup"] = solveGroupConflicts(
                         taskSubInfo[dataset]["NonCustodialGroup"],
                         subInfo[dataset]["NonCustodialGroup"])
+                    subInfo[dataset]["DatasetLifetimeDisk"] = solveGroupConflicts(taskSubInfo[dataset]["DatasetLifetimeDisk"], subInfo[dataset]["DatasetLifetimeDisk"])
                 else:
                     subInfo[dataset] = taskSubInfo[dataset]
                 subInfo[dataset]["CustodialSites"] = list(


### PR DESCRIPTION
Add lifetime to dataset shipping to disk sites

Fixes #10746 

#### Status
Tested with a replay

#### Description
For a given dataset  processed by Tier0 and shipping to disk sites, add a new attribute of lifetime to the rucio container rule.

#### Is it backward compatible (if not, which system it affects?)
MAYBE. Needs to be properly evaluated due that this PR creates a new column in the oracle/mysql database.

#### Related PRs
The following PR in dmwm/T0 [#4601](https://github.com/dmwm/T0/pull/4601)

#### External dependencies / deployment changes
No
