### PR TITLE
Cast performance values to float in MathAlgos

### DIFF
--- a/src/python/WMCore/Algorithms/MathAlgos.py
+++ b/src/python/WMCore/Algorithms/MathAlgos.py
@@ -193,7 +193,7 @@ def sortDictionaryListByKey(dictList, key, reverse=False):
     And not all histograms have the same value
     """
 
-    return sorted(dictList, key=lambda k: k.get(key, 0.0), reverse=reverse)
+    return sorted(dictList, key=lambda k: float(k.get(key, 0.0)), reverse=reverse)
 
 
 def getLargestValues(dictList, key, n=1):


### PR DESCRIPTION
Fixes #10748 

#### Status
ready

#### Description
Some of the performance attributes actually have a string data type, and if they are missing in the information retrieved from CouchDB, we actually default its value to `0.0`, which then fails with the already mentioned str x float comparison.
Here [1] is a sample of the debugging information I had in place, printing the row information collected from CouchDB

#### Is it backward compatible (if not, which system it affects?)
YEs

#### Related PRs
None

#### External dependencies / deployment changes
None

[1]
```
2021-08-13 10:48:25,856:140207990781696:INFO:CleanCouchPoller:AMR row: {'jobID': 34, 'retry_count': 0, 'taskName': '/amaltaro_TC_LHE_PFN_Aug2021_Val_210813_005734_1624/DarkSUSY_14TeV_2023D17_GenSimHLBeamSpotFull14', 'stepName': 'cmsRun1',
 'AvgEventTime': '36.8227', 'NumberOfThreads': '8', 'TotalJobCPU': '18250', 'EventThroughput': '0.193449', 'NumberOfStreams': '8', 'TotalJobTime': '2589.03', 'TotalLoopCPU': '18246.1', 'MinEventTime': '4.92921', 'MaxEventTime': '134.567',
 'PeakValueRss': '1468.88', 'PeakValueVsize': '2090.5', 'startTime': 1628811770, 'stopTime': 1628814482, 'readTotalMB': 2618.58, 'readPercentageOps': 1, 'readCachePercentageOps': 0, 'readTotalSecs': 0, 'writeTotalSecs': 0.465278, 'writeTo
talMB': 371.184, 'readAveragekB': 111726.08, 'readNumOps': 799319, 'readMBSec': 100.71655224138925, 'readMaxMSec': 2329.44}
2021-08-13 10:48:25,856:140207990781696:INFO:CleanCouchPoller:AMR row: {'jobID': 35, 'retry_count': 0, 'taskName': '/amaltaro_TC_LHE_PFN_Aug2021_Val_210813_005734_1624/DarkSUSY_14TeV_2023D17_GenSimHLBeamSpotFull14', 'stepName': 'cmsRun1',
 'startTime': 1628811772, 'stopTime': 1628812437}
```
