### PR TITLE
Convert a WorkQueueManagerCleaner log info to debug

### DIFF
--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -719,7 +719,7 @@ class WorkQueue(WorkQueueBase):
                                          **filters)
 
         if wmbsInfo:
-            self.logger.info("Syncing element statuses with WMBS for workflow: %s", filters.get("RequestName"))
+            self.logger.debug("Syncing element statuses with WMBS for workflow: %s", filters.get("RequestName"))
             for item in items:
                 for wmbs in wmbsInfo:
                     if item['SubscriptionId'] == wmbs['subscription_id']:


### PR DESCRIPTION
Fixes #8477 (actually, a complement to #10695)

#### Status
ready

#### Description
The info log level makes it too verbose and we get the very same information every 3min; it will also make debugging of WorkQueueManager more challenging. So we better have that line as a debug level.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Complement to https://github.com/dmwm/WMCore/pull/10695

#### External dependencies / deployment changes
None
