### PR TITLE
Define cms_type=int for rucio rules created against Rucio Int

### DIFF
--- a/bin/wmagent-mod-config
+++ b/bin/wmagent-mod-config
@@ -260,6 +260,9 @@ def modifyConfiguration(config, **args):
         config.RucioInjector.rucioAccount = args["rucio_account"]
         config.RucioInjector.rucioUrl = args["rucio_host"]
         config.RucioInjector.rucioAuthUrl = args["rucio_auth"]
+        # define a different expression for container rule replication in testbed
+        if "-int.cern.ch" in args["rucio_host"]:
+            config.RucioInjector.containerDiskRuleRSEExpr = "(tier=2|tier=1)&cms_type=int&rse_type=DISK"
 
     # custom AgentStatusWatcher
     if hasattr(config, "AgentStatusWatcher"):

--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -361,6 +361,7 @@ config.RucioInjector.createBlockRules = True
 config.RucioInjector.RSEPostfix = False  # enable it to append _Test to the RSE names
 config.RucioInjector.metaDIDProject = "Production"
 config.RucioInjector.containerDiskRuleParams = {"weight": "ddm_quota", "copies": 2, "grouping": "DATASET"}
+# this RSEExpr below might be updated by wmagent-mod-config script
 config.RucioInjector.containerDiskRuleRSEExpr = "(tier=2|tier=1)&cms_type=real&rse_type=DISK"
 config.RucioInjector.rucioAccount = "OVER_WRITE_BY_SECRETS"
 config.RucioInjector.rucioUrl = "OVER_WRITE_BY_SECRETS"


### PR DESCRIPTION
Fixes #10478 

#### Status
ready

#### Description
If RucioInjector is configured to inject data against Rucio Integration, update the default Disk RSE expression such that the component is able to create container rules (instead of failing to resolve the RSEs with 0 matches).

NOTE: hopefully the integration server url won't be changing for a few years, because this PR depends on a match against `-int.cern.ch`.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
