### PR TITLE
Fix Unittests in Api_t.Tester

### DIFF
--- a/src/python/WMCore/REST/Error.py
+++ b/src/python/WMCore/REST/Error.py
@@ -1,4 +1,4 @@
-from builtins import str
+from builtins import str as newstr
 import random, cherrypy
 
 class RESTError(Exception):
@@ -258,11 +258,11 @@ def report_rest_error(err, trace, throw):
                      % (err.http_code, err.app_code, err.message,
                         getattr(err.errobj, "__module__", "__builtins__"),
                         err.errobj.__class__.__name__,
-                        err.errid, err.instance, str(err.errobj).rstrip(),
+                        err.errid, err.instance, newstr(err.errobj).rstrip(),
                         sql, binds, kwbinds, offset))
         for line in err.trace.rstrip().split("\n"): cherrypy.log("  " + line)
-        cherrypy.response.headers["X-REST-Status"] = str(err.app_code)
-        cherrypy.response.headers["X-Error-HTTP"] = str(err.http_code)
+        cherrypy.response.headers["X-REST-Status"] = newstr(err.app_code)
+        cherrypy.response.headers["X-Error-HTTP"] = newstr(err.http_code)
         cherrypy.response.headers["X-Error-ID"] = err.errid
         report_error_header("X-Error-Detail", err.message)
         report_error_header("X-Error-Info", err.info)
@@ -274,15 +274,15 @@ def report_rest_error(err, trace, throw):
                             err.errid, err.message,
                             getattr(err.errobj, "__module__", "__builtins__"),
                             err.errobj.__class__.__name__,
-                            str(err.errobj).rstrip()))
+                            newstr(err.errobj).rstrip()))
             trace = err.trace
         else:
             cherrypy.log("SERVER REST ERROR %s.%s %s (%s)"
                          % (err.__module__, err.__class__.__name__,
                             err.errid, err.message))
         for line in trace.rstrip().split("\n"): cherrypy.log("  " + line)
-        cherrypy.response.headers["X-REST-Status"] = str(err.app_code)
-        cherrypy.response.headers["X-Error-HTTP"] = str(err.http_code)
+        cherrypy.response.headers["X-REST-Status"] = newstr(err.app_code)
+        cherrypy.response.headers["X-Error-HTTP"] = newstr(err.http_code)
         cherrypy.response.headers["X-Error-ID"] = err.errid
         report_error_header("X-Error-Detail", err.message)
         report_error_header("X-Error-Info", err.info)
@@ -291,10 +291,10 @@ def report_rest_error(err, trace, throw):
         errid = "%032x" % random.randrange(1 << 128)
         cherrypy.log("SERVER HTTP ERROR %s.%s %s (%s)"
                      % (err.__module__, err.__class__.__name__,
-                        errid, str(err).rstrip()))
+                        errid, newstr(err).rstrip()))
         for line in trace.rstrip().split("\n"): cherrypy.log("  " + line)
-        cherrypy.response.headers["X-REST-Status"] = str(200)
-        cherrypy.response.headers["X-Error-HTTP"] = str(err.status)
+        cherrypy.response.headers["X-REST-Status"] = newstr(200)
+        cherrypy.response.headers["X-Error-HTTP"] = newstr(err.status)
         cherrypy.response.headers["X-Error-ID"] = errid
         report_error_header("X-Error-Detail", err._message)
         if throw: raise err
@@ -303,7 +303,7 @@ def report_rest_error(err, trace, throw):
         cherrypy.log("SERVER OTHER ERROR %s.%s %s (%s)"
                      % (getattr(err, "__module__", "__builtins__"),
                         err.__class__.__name__,
-                        errid, str(err).rstrip()))
+                        errid, newstr(err).rstrip()))
         for line in trace.rstrip().split("\n"): cherrypy.log("  " + line)
         cherrypy.response.headers["X-REST-Status"] = 400
         cherrypy.response.headers["X-Error-HTTP"] = 500

--- a/src/python/WMCore/REST/Format.py
+++ b/src/python/WMCore/REST/Format.py
@@ -537,10 +537,10 @@ def _etag_tail(head, tail, etag):
     Sets ETag header at the end to value of `etag` if it's defined and
     yields a value."""
     for chunk in head:
-        yield chunk
+        yield encodeUnicodeToBytes(chunk)
 
     for chunk in tail:
-        yield chunk
+        yield encodeUnicodeToBytes(chunk)
 
     etagval = (etag and etag.value())
     if etagval:

--- a/test/python/WMCore_t/REST_t/Api_t.py
+++ b/test/python/WMCore_t/REST_t/Api_t.py
@@ -1,3 +1,6 @@
+# python-future
+from builtins import range
+
 # system modules
 import json
 import re
@@ -17,9 +20,9 @@ from WMCore.REST.Error import InvalidObject
 from WMCore.REST.Format import RawFormat
 from WMCore.REST.Tools import tools
 
-gif_bytes = ('GIF89a\x01\x00\x01\x00\x82\x00\x01\x99"\x1e\x00\x00\x00\x00\x00'
-             '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-             '\x00,\x00\x00\x00\x00\x01\x00\x01\x00\x02\x03\x02\x08\t\x00;')
+gif_bytes = (b'GIF89a\x01\x00\x01\x00\x82\x00\x01\x99"\x1e\x00\x00\x00\x00\x00'
+             b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+             b'\x00,\x00\x00\x00\x00\x01\x00\x01\x00\x02\x03\x02\x08\t\x00;')
 
 FAKE_FILE = fake_authz_key_file()
 PORT = 8887
@@ -38,7 +41,7 @@ class Multi(RESTEntity):
         validate_num("lim", param, safe, bare=True, optional=True, minval=0, maxval=10)
 
     def _generate(self, lim):
-        for i in xrange(0, 10):
+        for i in range(0, 10):
             if i == lim:
                 raise InvalidObject("cut at %d" % i)
             yield ["row", i]
@@ -183,7 +186,7 @@ class Tester(webtest.WebCase):
         assert "result" in b
         assert isinstance(b["result"], list)
         assert len(b["result"]) == 10
-        for i in xrange(0, 10):
+        for i in range(0, 10):
             assert isinstance(b["result"][i], list)
             assert b["result"][i][0] == "row"
             assert b["result"][i][1] == i
@@ -211,7 +214,7 @@ class Tester(webtest.WebCase):
         assert "result" in b
         assert isinstance(b["result"], list)
         assert len(b["result"]) == 5
-        for i in xrange(0, 5):
+        for i in range(0, 5):
             assert isinstance(b["result"][i], list)
             assert b["result"][i][0] == "row"
             assert b["result"][i][1] == i
@@ -239,7 +242,7 @@ class Tester(webtest.WebCase):
         assert "result" in b
         assert isinstance(b["result"], list)
         assert len(b["result"]) == 10
-        for i in xrange(0, 10):
+        for i in range(0, 10):
             assert isinstance(b["result"][i], list)
             assert b["result"][i][0] == "row"
             assert b["result"][i][1] == i


### PR DESCRIPTION
Fixes #10719 

#### Status
problems solved. we should discuss if my current solutions are the best solutions possible

#### Description

##### status of this PR

I replicated the error reported by jenkins using the pdb debugger provided by vscode, when i use the docker environment directly from its shell i get a different failure. This was sort to be expected, since the error in jenkins emerges from `termios`. lets see what i can do.

- [x] REST/Format -> test_good_gif, test_good_gif2
  - this is caused by https://github.com/dmwm/WMCore/blob/88b70a21208c1b4b849a122336c600210a71c487/src/python/WMCore/REST/Format.py#L621
  - we expect the content of the request to be `'GIF89a\x01\x00\x01\x00\xc2\x82\x00\x01\xc2\x99"\x1e\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00,\x00\x00\x00\x00\x01\x00\x01\x00\x02\x03\x02\x08\t\x00;'`, whose `len()` is 53 and matches `Content-Length` http header says, but the content we retrieve contains twice the byte `\xc2`, making the length of the content that we retrieve longer, which fails the assertion.
  - The problem was that in `test/python/WMCore_t/REST_t/Api_t.py` we define `gif_bytes = ('some' 'thing')` (which becomes `'something'`). We are effectively chaining py3 `str`. but this should be bytes! defining instead `gif_bytes = (b'some' b'thing')` fixes the unittest. the two spurious bytes were added when converting (inadvertently, i am not even sure where this happened) gif_bytes from py3 str to py3 bytes.
- [x] REST/Validation -> test_multi_throw10, test_multi_throw5a
  1. [x] problem 1
    - this is caused by https://github.com/dmwm/WMCore/blob/88b70a21208c1b4b849a122336c600210a71c487/src/python/WMCore/REST/Validation.py#L41
    - `TypeError: cannot use a string pattern on a bytes-like object`
    - `_validate_one` is calling `_validate_str` (which expects bytes input), which calls `_check_str` where we match a bytes string with a str regex. This requires proper investigation
  2. [x] problem 2
    - Log: [1]
    - the solution is not so smooth as i would like.
    - Breakpoints for `pdb`: REST/Format.py L246, L542, L579, REST/Server.py L726, L842
    - Stacktrace: Server 726, Server 739->842, Format 549-> 579, (some logging stuff of cherrypy), Format 535->542  (yields first element for iteration at Format 239->246), if `chunk` at 543 is not bytes, then cherrypy crashes
    - eventually caused by https://github.com/dmwm/WMCore/blob/88b70a21208c1b4b849a122336c600210a71c487/src/python/WMCore/REST/Format.py#L543 retuurning a py3 `str` instead of `bytes` 
- [x] test_multi_nothrow and others unittests

##### How to investigate the failures

this is not trivial, since if we have a bug in the cherrypy server, if we assert the status of a request with `cheroot.test.webtest.WebCase.assertStatus` then it [calls termios.tcgetattr()](https://github.com/cherrypy/cheroot/blob/ba1bc4b0afc287de80b2b7449756e56f8a5e44dd/cheroot/test/webtest.py#L77). What happens in

1. jenkins: we get `termios.error:  (25, 'Inappropriate ioctl for device')` (because the shell that jenkins gives to cherrypy is not interactive and cherrypy can not get any key from it)
2. shell open in dev docker environment: cherrypy reports the stacktrace of the failure in its logs, but then hangs and it needs to be killed with something like `ps auc | grep python3 | awk '{print $2}' | xargs kill -9` from another shell opened in the same docker container.
3. using pdb through vscode inside the dev docker environment: same as jenkins.

In order to run the unittests ffrom you docker shell with for example `python3 setup.py test --buildBotMode=true --reallyDeleteMyDatabaseAfterEveryTest=true --testCertainPath=test/python/WMCore_t/REST_t/Api_t.py`, then you need to add `test/python/WMCore_t/REST_t/` to the pythonpath, because REST/Main.py imports Api_t.py. You can either change the shell environment v ariable `$PATH`, or you can append that directory into `sys.path`, as in [2].

moreover, if you need/want to use the vscode debugger, you need to make the unittests discoverable by vscode (by adding a properly placed `__init__` file), as in [2]. Beware! this change makes jenkins crash so badly that it does not even send the report in the comments and starts again the unittests. Use this change only on your local environment, do not push this!

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
nope

#### External dependencies / deployment changes
nope

#### other info

[1] 

```plaintext
[18/Aug/2021:16:22:37] ENGINE ValueError('WSGI Applications must yield bytes')
Traceback (most recent call last):
  File "/home/dmwm/unittestdeploy/wmagent/1.4.9.pre6-comp2/sw/slc7_amd64_gcc630/external/py3-cheroot/8.2.1/lib/python3.8/site-packages/cheroot/server.py", line 1280, in communicate
    req.respond()
  File "/home/dmwm/unittestdeploy/wmagent/1.4.9.pre6-comp2/sw/slc7_amd64_gcc630/external/py3-cheroot/8.2.1/lib/python3.8/site-packages/cheroot/server.py", line 1083, in respond
    self.server.gateway(self).respond()
  File "/home/dmwm/unittestdeploy/wmagent/1.4.9.pre6-comp2/sw/slc7_amd64_gcc630/external/py3-cheroot/8.2.1/lib/python3.8/site-packages/cheroot/wsgi.py", line 147, in respond
    raise ValueError('WSGI Applications must yield bytes')
ValueError: WSGI Applications must yield bytes
```

[2]

```diff
From 5894ae84c8a3211a9fd53623e3077b3d01c92edf Mon Sep 17 00:00:00 2001
From: Dario Mapelli <mapelli.dario@gmail.com>
Date: Tue, 17 Aug 2021 14:50:00 +0200
Subject: [PATCH] replicate in docker the unittest error reported by jenkins in
  WMCore_t/REST_t/Api_t.py

---
 test/python/WMCore_t/REST_t/Api_t.py    | 2 ++
 test/python/WMCore_t/REST_t/__init__.py | 0
 2 files changed, 2 insertions(+)
 create mode 100644 test/python/WMCore_t/REST_t/__init__.py

diff --git a/test/python/WMCore_t/REST_t/Api_t.py b/test/python/WMCore_t/REST_t/Api_t.py
index 1b88b29f80..85cb1e4674 100644
--- a/test/python/WMCore_t/REST_t/Api_t.py
+++ b/test/python/WMCore_t/REST_t/Api_t.py
@@ -3,6 +3,7 @@
 import re
 import zlib
 from multiprocessing import Process
+import sys
 
 import cherrypy
 from cherrypy import response
@@ -245,6 +246,7 @@ def test_multi_throw10(self):
             assert b["result"][i][1] == i
 
 def setup_server():
+    sys.path.append("/".join(__file__.split("/")[:-1]))
     srcfile = __file__.split("/")[-1].split(".py")[0]
     setup_dummy_server(srcfile, "Root", authz_key_file=FAKE_FILE, port=PORT)
 
diff --git a/test/python/WMCore_t/REST_t/__init__.py b/test/python/WMCore_t/REST_t/__init__.py
new file mode 100644
index 0000000000..e69de29bb2
```