### PR TITLE
[py2py3] More job runtime places to encode pickledarguments to bytes

### DIFF
--- a/src/python/PSetTweaks/WMTweak.py
+++ b/src/python/PSetTweaks/WMTweak.py
@@ -15,7 +15,8 @@ from future.utils import viewitems, viewkeys
 import logging
 import os
 import pickle
-
+from Utils.PythonVersion import PY3
+from Utils.Utilities import encodeUnicodeToBytesConditional
 from PSetTweaks.PSetTweak import PSetTweak
 
 # params to be extracted from an output module
@@ -388,7 +389,9 @@ def makeTaskTweak(stepSection, result):
     if hasattr(stepSection, "application"):
         if hasattr(stepSection.application, "configuration"):
             if hasattr(stepSection.application.configuration, "pickledarguments"):
-                args = pickle.loads(stepSection.application.configuration.pickledarguments)
+                pklArgs = encodeUnicodeToBytesConditional(stepSection.application.configuration.pickledarguments,
+                                                          condition=PY3)
+                args = pickle.loads(pklArgs)
                 if 'globalTag' in args:
                     result.addParameter("process.GlobalTag.globaltag",  "customTypeCms.string('%s')" % args['globalTag'])
                 if 'globalTagTransaction' in args:

--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -15,7 +15,8 @@ import socket
 
 from PSetTweaks.PSetTweak import PSetTweak
 from PSetTweaks.WMTweak import  makeJobTweak, makeOutputTweak, makeTaskTweak, resizeResources
-from Utils.Utilities import decodeBytesToUnicode
+from Utils.PythonVersion import PY3
+from Utils.Utilities import decodeBytesToUnicode, encodeUnicodeToBytesConditional
 from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig
 from WMCore.Storage.TrivialFileCatalog import TrivialFileCatalog
 from WMCore.WMRuntime.ScriptInterface import ScriptInterface
@@ -487,7 +488,9 @@ class SetupCMSSWPset(ScriptInterface):
             os.path.join(self.stepSpace.location, self.configPickle))
 
         if hasattr(self.step.data.application.configuration, "pickledarguments"):
-            args = pickle.loads(self.step.data.application.configuration.pickledarguments)
+            pklArgs = encodeUnicodeToBytesConditional(self.step.data.application.configuration.pickledarguments,
+                                                      condition=PY3)
+            args = pickle.loads(pklArgs)
             datasetName = args.get('datasetName', None)
         if datasetName:
             cmd += " --datasetName %s" % (datasetName)
@@ -681,7 +684,9 @@ class SetupCMSSWPset(ScriptInterface):
         if scenario is not None and scenario != "":
             self.logger.info("Setting up job scenario/process")
             if getattr(self.step.data.application.configuration, "pickledarguments", None) is not None:
-                funcArgs = pickle.loads(self.step.data.application.configuration.pickledarguments)
+                pklArgs = encodeUnicodeToBytesConditional(self.step.data.application.configuration.pickledarguments,
+                                                          condition=PY3)
+                funcArgs = pickle.loads(pklArgs)
             else:
                 funcArgs = {}
 


### PR DESCRIPTION
Fixes #10647 

#### Status
ready

#### Description
For workflows that have been created while ReqMgr2 was still running in Python2 (< July 2021), the CMSSW `pickledarguments` can be of string type, thus failing to be pickled loaded.

This patch will encode those native strings to bytes, if running with a Python3 interpreter.

#### Is it backward compatible (if not, which system it affects?)
YES (it should!)

#### Related PRs
Complement to: https://github.com/dmwm/WMCore/pull/10648

#### External dependencies / deployment changes
None
