### PR TITLE
Update deploy-wmagent script to latest production tag: 1.5.2

### DIFF
--- a/deploy/deploy-wmagent.sh
+++ b/deploy/deploy-wmagent.sh
@@ -25,8 +25,8 @@
 ### Usage:               -3|--py3  Uses the python3 stack WMAgent package
 ### Usage:
 ### Usage: deploy-wmagent.sh -w <wma_version> -d <deployment_tag> -t <team_name> [-s <scram_arch>] [-r <repository>] [-n <agent_number>]
-### Usage: Example: sh deploy-wmagent.sh -w 1.4.7.patch2 -d HG2104e -t production -n 30
-### Usage: Example: sh deploy-wmagent.sh -w 1.4.7.patch2 -d HG2104e -t testbed-vocms001 -p "10179" -r comp=comp.amaltaro --py3
+### Usage: Example: sh deploy-wmagent.sh -w 1.5.2 -d HG2108h -t production -n 30 --py3
+### Usage: Example: sh deploy-wmagent.sh -w 1.5.2 -d HG2108h -t testbed-vocms001 -p "10179" -r comp=comp.amaltaro --py3
 ### Usage:
 
 IAM=`whoami`


### PR DESCRIPTION
No issue created

#### Status
ready

#### Description
Updating the WMCore tag to `1.5.2` and the deployment one to `HG2108h`. Also update both examples to python3 agent.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
