### PR TITLE
[py2py3] Modernization of last files left out up to now

### DIFF
--- a/src/python/WMCore/WorkerThreads/BaseWorkerThread.py
+++ b/src/python/WMCore/WorkerThreads/BaseWorkerThread.py
@@ -204,8 +204,8 @@ class BaseWorkerThread(object):
                             # force entire component to terminate
                             try:
                                 self.component.prepareToStop()
-                            except Exception as ex:
-                                logging.error("Failed to halt component after worker crash: %s", str(ex))
+                            except Exception as ex1:
+                                logging.error("Failed to halt component after worker crash: %s", str(ex1))
                             raise ex
                         # Put the thread to sleep
                         self.sleepThread()

--- a/test/python/WMComponent_t/DBS3Buffer_t/DBSUpload_t.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/DBSUpload_t.py
@@ -6,6 +6,8 @@
 DBSUpload test TestDBSUpload module and the harness
 
 """
+from __future__ import division
+
 import json
 import os
 import threading

--- a/test/python/WMCore_t/BossAir_t/MockPlugin_t.py
+++ b/test/python/WMCore_t/BossAir_t/MockPlugin_t.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import unittest
 from WMCore.BossAir.Plugins.MockPlugin import MockPlugin
 from WMCore.BossAir.Plugins.BasePlugin import BossAirPluginException

--- a/test/python/WMCore_t/Misc_t/WMAgent_t.py
+++ b/test/python/WMCore_t/Misc_t/WMAgent_t.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__  import division
 
 import os
 import time

--- a/test/python/WMCore_t/REST_t/Daemon_t.py
+++ b/test/python/WMCore_t/REST_t/Daemon_t.py
@@ -1,4 +1,7 @@
+# python-future
 from __future__ import print_function
+from builtins import range
+
 # system modules
 import cherrypy
 from multiprocessing import Process
@@ -36,7 +39,7 @@ class Task(Thread):
         """Get the daemon status. Returns dictionary of time stamps of the
         the last hundred times this thread last did 'work'."""
         with self._cv:
-            return dict((k, v) for k, v in self._status.iteritems())
+            return dict((k, v) for k, v in self._status.items())
 
     def stop(self):
         """Tell the task thread to quit."""
@@ -89,7 +92,7 @@ class TaskAPI(RESTApi):
     def __init__(self, app, config, mount):
         RESTApi.__init__(self, app, config, mount)
         print("AMR mounting RESTApi app: %s, config: %s, mount: %s" % (app, config, mount))
-        tasks = [Task() for _ in xrange(0, 10)]
+        tasks = [Task() for _ in range(0, 10)]
         self._add({ "status": Status(app, self, config, mount, tasks) })
         print("AMR done mounting the 'status' API")
 
@@ -112,7 +115,7 @@ class TaskTest(webtest.WebCase):
         print("AMR headers: %s" % h)
         print(self.getPage("/test", headers=h))
         print(self.getPage("/test/status", headers=h))
-        for _ in xrange(0, 10):
+        for _ in range(0, 10):
             self.getPage("/test/status", headers=h)
             print(self.bodyY)
             time.sleep(.3)

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/FixedDelay_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/FixedDelay_t.py
@@ -5,6 +5,8 @@ _FixedDelay_t_
 Fixed delay job splitting.
 """
 
+from __future__ import division
+
 import unittest
 import os
 import threading

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/RunBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/RunBased_t.py
@@ -5,7 +5,7 @@ _EventBased_t_
 Event based splitting test.
 """
 
-
+from __future__ import division
 
 
 import unittest


### PR DESCRIPTION
Fixes #10150

#### Status
ready

#### Description
I used `pylint --py3k` to scan whole `dmwm/WMCore` and find what have been left out up to now.

There is one thing that pylint is complaining about, that i did not update in this 
PR is
- [x]  Module src.python.WMCore.Configuration src/python/WMCore/Configuration.py:74:0: W1641: `Implementing __eq__ without also implementing __hash__ (eq-without-hash)`. 
  - The issue description contains the motivation for not changing anything related to this

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
nope

#### External dependencies / deployment changes
nope
