### PR TITLE
Fix undefined variable in MSTransferor

### DIFF
--- a/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
+++ b/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
@@ -160,6 +160,7 @@ class MSTransferor(MSCore):
             msg += "Service set to process up to %s requests per cycle." % self.msConfig["limitRequestsPerCycle"]
             self.logger.info(msg)
         except Exception as err:  # general error
+            requestRecords = []
             msg = "Unknown exception while fetching requests from ReqMgr2. Error: %s", str(err)
             self.logger.exception(msg)
             self.updateReportDict(summary, "error", msg)


### PR DESCRIPTION
Fixes #10705 

#### Status
ready

#### Description
In case it fails to retrieve workflows from reqmgr2, make sure `requestRecords` variable is properly initialized.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
None

#### External dependencies / deployment changes
None
