### PR TITLE
Bug on maxSecondsUntilRampdown missing a parenthesis during pset tweaking

### DIFF
--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -815,7 +815,7 @@ class SetupCMSSWPset(ScriptInterface):
         # limit run time if desired
         if hasattr(self.step.data.application.configuration, "maxSecondsUntilRampdown"):
             self.tweak.addParameter("process.maxSecondsUntilRampdown.input",
-                "customTypeCms.untracked.PSet(input=cms.untracked.int32(%s)" % self.step.data.application.configuration.maxSecondsUntilRampdown)
+                "customTypeCms.untracked.PSet(input=cms.untracked.int32(%s))" % self.step.data.application.configuration.maxSecondsUntilRampdown)
 
         # accept an overridden TFC from the step
         if hasattr(self.step.data.application, 'overrideCatalog'):


### PR DESCRIPTION
Fixes #10770

#### Status
ready

#### Description
Add missing parenthesis to code

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
#10179

#### External dependencies / deployment changes
None