### PR TITLE
fix unittest pycurl_manager_t.PyCurlManager:testHeadRequest

### DIFF
--- a/test/python/WMCore_t/Services_t/pycurl_manager_t.py
+++ b/test/python/WMCore_t/Services_t/pycurl_manager_t.py
@@ -149,7 +149,7 @@ class PyCurlManager(unittest.TestCase):
         self.assertTrue(len(res.getHeader()) > 10)
         # Kubernetes cluster responds with a different Server header
         serverHeader = res.getHeaderKey("Server")
-        self.assertTrue(serverHeader.startswith("CherryPy/") or serverHeader.startswith("openresty/"))
+        self.assertTrue(serverHeader.startswith("nginx/") or serverHeader.startswith("CherryPy/") or serverHeader.startswith("openresty/"))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #10517 

#### Status
ready

#### Description

In our current docker env the serverHeader is
- py3: <class 'str'> nginx/1.17.10
- py2: <type 'unicode'>, u'nginx/1.17.10'

Fixing the assertion accordingly.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
nope

#### External dependencies / deployment changes
nope
