### PR TITLE
MSOutput: only produce documents for workflows not yet in the database

### DIFF
--- a/src/python/WMCore/MicroService/MSManager.py
+++ b/src/python/WMCore/MicroService/MSManager.py
@@ -28,7 +28,6 @@ from __future__ import division, print_function
 from builtins import object
 from time import sleep
 from datetime import datetime
-from collections import deque
 
 # WMCore modules
 from WMCore.MicroService.Tools.Common import getMSLogger
@@ -107,12 +106,9 @@ class MSManager(object):
         if 'output' in self.services:
             from WMCore.MicroService.MSOutput.MSOutput import MSOutput
             reqStatus = ['closed-out', 'announced']
-            # thread safe cache to keep the last X requests processed in MSOutput
-            requestNamesCached = deque(maxlen=self.msConfig.get("cacheRequestSize", 10000))
 
             thname = 'MSOutputConsumer'
-            self.msOutputConsumer = MSOutput(self.msConfig, mode=thname,
-                                             reqCache=requestNamesCached, logger=self.logger)
+            self.msOutputConsumer = MSOutput(self.msConfig, mode=thname, logger=self.logger)
             # set the consumer to run twice faster than the producer
             consumerInterval = self.msConfig['interval'] // 2
             self.outputConsumerThread = start_new_thread(thname, daemon,
@@ -123,8 +119,7 @@ class MSManager(object):
             self.logger.info("=== Running %s thread %s", thname, self.outputConsumerThread.running())
 
             thname = 'MSOutputProducer'
-            self.msOutputProducer = MSOutput(self.msConfig, mode=thname,
-                                             reqCache=requestNamesCached, logger=self.logger)
+            self.msOutputProducer = MSOutput(self.msConfig, mode=thname, logger=self.logger)
             self.outputProducerThread = start_new_thread(thname, daemon,
                                                          (self.outputProducer,
                                                           reqStatus,


### PR DESCRIPTION
Fixes #10722 

#### Status
ready

#### Description
Refactored how the **producer** thread of MSOutput process workflows eligible for output data placement. Instead of relying on an in-memory cache and in the MongoDB mechanism to check for unique document ids, changed it to actually fetch all the requests (only their names) inserted in MongoDB in the last X secs (default to last 6 months, to have a very relaxed value and give people enough time to spot workflows stuck being produced by MSOutput). We filter those out and then only produce mongo records for workflows not yet in the database.

Second commit is actually removing the memory cache mechanism that had been initially implemented. But I think we will squash those commits before merging it.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
