### PR TITLE
Define pylint message template in the pylintrc file

### DIFF
--- a/standards/.pylintrc
+++ b/standards/.pylintrc
@@ -34,6 +34,13 @@ comment=no
 # Include message's id in output
 include-id=no
 
+[REPORTS]
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template='[{msg_id} {symbol}] {msg} File: {path}, line {line}, in {obj}'
+msg-template='{msg_id} L{line}: {msg} ({symbol})'
+
+
 [MESSAGES CONTROL]
 # disable F0401 - could not import module
 # disable E1103 - Allows attachment of dbi, logger to threading.currentThread()


### PR DESCRIPTION
Fixes #10775 

#### Status
ready

#### Description
As the title says, define a message template (used for the line by line output messages from pylint) such that we have a consistent output between python2 and python3.

The defined template is very similar to what python2 is currently providing, with the following changes:
* prefix the line number by an `L`;
* removed the column number (I do not think it's a useful information)

(UPDATED from the discussion below) So, here is a sample of the output with these changes in:
```
(PY3) AlanNewMacPro:WMCore amaltaro$ pylt src/python/Utils/IteratorTools.py
************* Module src.python.Utils.IteratorTools
(PY3) AlanNewMacPro:WMCore amaltaro$ pylt src/python/Utils/IteratorTools.py
************* Module src.python.Utils.IteratorTools
C0114 L1: Missing module docstring (missing-module-docstring)
R1705 L47: Unnecessary "elif" after "return" (no-else-return)
C0411 L5: standard import "from builtins import str, map" should be placed before "from future.utils import viewitems" (wrong-import-order)
C0411 L6: standard import "import collections" should be placed before "from future.utils import viewitems" (wrong-import-order)
C0411 L7: standard import "from itertools import islice, chain" should be placed before "from future.utils import viewitems" (wrong-import-order)
```

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
