### PR TITLE
CouchDB 3 Migration: Remove all_or_nothing flag

### DIFF
--- a/src/python/WMCore/WorkQueue/WorkQueueBackend.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueBackend.py
@@ -174,7 +174,7 @@ class WorkQueueBackend(object):
             else:
                 newUnitsInserted.append(unit)
             unit.save()
-            unit._couch.commit(all_or_nothing=True)
+            unit._couch.commit()
 
         return newUnitsInserted
 

--- a/test/python/WMCore_t/Database_t/CMSCouch_t.py
+++ b/test/python/WMCore_t/Database_t/CMSCouch_t.py
@@ -283,10 +283,9 @@ class CMSCouchTest(unittest.TestCase):
         self.assertEqual(answer[0]['ok'], True)
         self.assertEqual(answer[1]['error'], 'conflict')
 
-        # all_or_nothing mode ignores conflicts
         self.db.queue(Document(id = "2", inputDict = doc))
         self.db.queue(Document(id = "2", inputDict = {'foo':1234, 'bar':456}))
-        answer = self.db.commit(all_or_nothing = True)
+        answer = self.db.commit()
         self.assertEqual(2, len(answer))
         self.assertEqual(answer[0].get('error'), None)
         self.assertEqual(answer[0].get('error'), None)


### PR DESCRIPTION
#### Status
not-tested

#### Description
As part of the CouchDB Migration to 3.x ( #8853 ), the `all_or_nothing` flag has to be removed because 
it's no longer present (see https://github.com/apache/couchdb/issues/1235 for a discussion).

#### Is it backward compatible (if not, which system it affects?)
NO

#### Related PRs


#### External dependencies / deployment changes
It depends on CouchDB 3.x
