### PR TITLE
Fix spec validation for Multicore/Memory/Streams/TpE

### DIFF
--- a/src/python/WMCore/ReqMgr/Utils/Validation.py
+++ b/src/python/WMCore/ReqMgr/Utils/Validation.py
@@ -157,7 +157,8 @@ def validate_resubmission_create_args(request_args, config, reqmgr_db_service, *
 
     specClass = loadSpecClassByType(request_args["RequestType"])
     spec = specClass()
-    workload = spec.factoryWorkloadConstruction(cloned_args["RequestName"], cloned_args)
+    workload = spec.factoryWorkloadConstruction(cloned_args["RequestName"],
+                                                cloned_args, request_args)
 
     return workload, cloned_args
 

--- a/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
@@ -21,7 +21,8 @@ from Utils.Utilities import strToBool
 import WMCore.WMSpec.Steps.StepFactory as StepFactory
 from WMCore.Lexicon import primdataset, taskStepName
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
-from WMCore.WMSpec.WMWorkloadTools import validateArgumentsCreate, parsePileupConfig
+from WMCore.WMSpec.WMWorkloadTools import (validateArgumentsCreate, parsePileupConfig,
+                                           checkMemCore, checkEventStreams, checkTimePerEvent)
 from WMCore.WMSpec.WMSpecErrors import WMSpecFactoryException
 
 # simple utils for data mining the request dictionary
@@ -482,6 +483,11 @@ class StepChainWorkloadFactory(StdBase):
                     "FirstLumi": {"default": 1, "type": int, "validate": lambda x: x > 0,
                                   "null": False},
                     "ParentageResolved": {"default": False, "type": strToBool, "null": False},
+                    ### Override StdBase parameter definition
+                    "TimePerEvent": {"default": 12.0, "type": float, "validate": checkTimePerEvent},
+                    "Memory": {"default": 2300.0, "type": float, "validate": checkMemCore},
+                    "Multicore": {"default": 1, "type": int, "validate": checkMemCore},
+                    "EventStreams": {"type": int, "null": True, "default": 0, "validate": checkEventStreams}
                    }
         baseArgs.update(specArgs)
         StdBase.setDefaultArgumentsProperty(baseArgs)
@@ -517,6 +523,10 @@ class StepChainWorkloadFactory(StdBase):
         baseArgs = StdBase.getWorkloadAssignArgs()
         specArgs = {
             "ChainParentageMap": {"default": {}, "type": dict},
+            ### Override StdBase assignment parameter definition
+            "Memory": {"type": float, "validate": checkMemCore},
+            "Multicore": {"type": int, "validate": checkMemCore},
+            "EventStreams": {"type": int, "validate": checkEventStreams},
         }
         baseArgs.update(specArgs)
         StdBase.setDefaultArgumentsProperty(baseArgs)

--- a/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
@@ -90,7 +90,8 @@ from future.utils import viewitems
 from Utils.Utilities import makeList, strToBool
 from WMCore.Lexicon import primdataset, taskStepName
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
-from WMCore.WMSpec.WMWorkloadTools import validateArgumentsCreate, parsePileupConfig
+from WMCore.WMSpec.WMWorkloadTools import (validateArgumentsCreate, parsePileupConfig,
+                                           checkMemCore, checkEventStreams, checkTimePerEvent)
 from WMCore.WMSpec.WMSpecErrors import WMSpecFactoryException
 
 #
@@ -619,8 +620,13 @@ class TaskChainWorkloadFactory(StdBase):
                                    "attr": "firstEvent", "null": False},
                     "FirstLumi": {"default": 1, "type": int,
                                   "optional": True, "validate": lambda x: x > 0,
-                                  "attr": "firstLumi", "null": False}
-                   }
+                                  "attr": "firstLumi", "null": False},
+                    ### Override StdBase parameter definition
+                    "TimePerEvent": {"default": 12.0, "type": float, "validate": checkTimePerEvent},
+                    "Memory": {"default": 2300.0, "type": float, "validate": checkMemCore},
+                    "Multicore": {"default": 1, "type": int, "validate": checkMemCore},
+                    "EventStreams": {"type": int, "null": True, "default": 0, "validate": checkEventStreams}
+                    }
         baseArgs.update(specArgs)
         StdBase.setDefaultArgumentsProperty(baseArgs)
         return baseArgs
@@ -656,6 +662,10 @@ class TaskChainWorkloadFactory(StdBase):
         baseArgs = StdBase.getWorkloadAssignArgs()
         specArgs = {
             "ChainParentageMap": {"default": {}, "type": dict},
+            ### Override StdBase assignment parameter definition
+            "Memory": {"type": float, "validate": checkMemCore},
+            "Multicore": {"type": int, "validate": checkMemCore},
+            "EventStreams": {"type": int, "validate": checkEventStreams},
         }
         baseArgs.update(specArgs)
         StdBase.setDefaultArgumentsProperty(baseArgs)

--- a/src/python/WMCore/WMSpec/WMWorkloadTools.py
+++ b/src/python/WMCore/WMSpec/WMWorkloadTools.py
@@ -9,7 +9,7 @@ Created on Jun 13, 2013
 @author: dballest
 """
 from builtins import str, bytes
-from future.utils import viewitems
+from future.utils import viewitems, viewvalues
 
 import json
 import re
@@ -19,6 +19,42 @@ from Utils.Utilities import makeList
 from WMCore.DataStructs.LumiList import LumiList
 from WMCore.WMSpec.WMSpecErrors import WMSpecFactoryException
 from WMCore.Services.PhEDEx.DataStructs.SubscriptionList import PhEDEx_VALID_SUBSCRIPTION_PRIORITIES
+
+
+def checkMemCore(paramInfo, minValue=1):
+    """
+    Spec validation function for the Memory/Multicore parameters
+    :param memInfo: memory provided by the user (can be an int/float/dict)
+    :param minValue: base value to be used to validate user's values
+    :return: True if validation is successful, raise an exception otherwise
+    """
+    try:
+        if isinstance(paramInfo, dict):
+            for value in viewvalues(paramInfo):
+                assert value >= minValue
+        else:
+            assert paramInfo >= minValue
+    except Exception:
+        return False
+    return True
+
+
+def checkEventStreams(streamsInfo):
+    """
+    Spec validation function for the EventStreams parameter
+    :param streamsInfo: event streams provided by the user (can be either int or a dict)
+    :return: True if validation is successful, raise an exception otherwise
+    """
+    return checkMemCore(streamsInfo, 0)
+
+
+def checkTimePerEvent(tpEvtInfo):
+    """
+    Spec validation function for the TimePerEvent parameter
+    :param tpEvtInfo: time per event provided by the user (can be either float or a dict)
+    :return: True if validation is successful, raise an exception otherwise
+    """
+    return checkMemCore(tpEvtInfo, 0)
 
 
 def makeLumiList(lumiDict):
@@ -114,7 +150,8 @@ def _validateArgumentOptions(arguments, argumentDefinition, optionKey=None):
     for arg, argDef in viewitems(argumentDefinition):
         optional = argDef.get(optionKey, True)
         if not optional and arg not in arguments:
-            msg = "Argument '%s' is mandatory! Its definition is:\n%s" % (arg, inspect.getsource(argDef))
+            msg = "Argument '{}' is mandatory and must be provided by the user.".format(arg)
+            msg += " Its definition is: {}".format(argDef)
             raise WMSpecFactoryException(msg)
         # specific case when user GUI returns empty string for optional arguments
         elif arg not in arguments:

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Resubmission_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Resubmission_t.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python
+"""
+Unittests for the Resubmission spec factory
+"""
+from __future__ import print_function
+
+import os
+import unittest
+
+import threading
+
+from Utils.PythonVersion import PY3
+from WMCore.DAOFactory import DAOFactory
+from WMCore.Database.CMSCouch import CouchServer
+from WMCore.WMSpec.StdSpecs.Resubmission import ResubmissionWorkloadFactory
+from WMCore.WMSpec.StdSpecs.TaskChain import TaskChainWorkloadFactory
+from WMQuality.Emulators.EmulatedUnitTestCase import EmulatedUnitTestCase
+from WMQuality.TestInitCouchApp import TestInitCouchApp
+
+
+class ResubmissionTests(EmulatedUnitTestCase):
+
+    def setUp(self):
+        """
+        _setUp_
+
+        Initialize the database and couch.
+        """
+        super(ResubmissionTests, self).setUp()
+        self.testInit = TestInitCouchApp(__file__)
+        self.testInit.setLogging()
+        self.testInit.setDatabaseConnection(destroyAllDatabase=True)
+        self.testInit.setupCouch("taskchain_t", "ConfigCache")
+        self.testInit.setupCouch("taskchain_t", "ReqMgr")
+        self.testInit.setupCouch("resubmission_t", "ConfigCache")
+        self.testInit.setSchema(customModules=["WMCore.WMBS"],
+                                useDefault=False)
+
+        couchServer = CouchServer(os.environ["COUCHURL"])
+        self.configDatabase = couchServer.connectDatabase("taskchain_t")
+        self.testInit.generateWorkDir()
+
+        myThread = threading.currentThread()
+        self.daoFactory = DAOFactory(package="WMCore.WMBS",
+                                     logger=myThread.logger,
+                                     dbinterface=myThread.dbi)
+        self.listTasksByWorkflow = self.daoFactory(classname="Workflow.LoadFromName")
+        self.listFilesets = self.daoFactory(classname="Fileset.List")
+        self.listSubsMapping = self.daoFactory(classname="Subscriptions.ListSubsAndFilesetsFromWorkflow")
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
+        return
+
+    def tearDown(self):
+        """
+        _tearDown_
+
+        Clear out the database.
+        """
+        self.testInit.clearDatabase()
+        self.testInit.delWorkDir()
+        super(ResubmissionTests, self).tearDown()
+
+    def testStandardACDC(self):
+        """
+        Creates a standard ACDC workflow with no parameter updates
+        """
+        testArguments = TaskChainWorkloadFactory.getTestArguments()
+        # use a workflow existent in cmsweb-testbed, not good, but better than nothing
+        acdcArgs = {"ACDCDatabase": "acdcserver",
+                    "ACDCServer": self.testInit.couchUrl,
+                    "CouchURL": "https://cmsweb-testbed.cern.ch/couchdb",
+                    "InitialTaskPath": "/amaltaro_TaskChain_LumiMask_multiRun_HG2108_Val_210731_182010_1852/HLTD",
+                    "OriginalRequestName": "amaltaro_TaskChain_LumiMask_multiRun_HG2108_Val_210731_182010_1852",
+                    "RequestString": "ACDC_UnitTest_TaskChain_LumiMask_multiRun",
+                    "RequestType": "Resubmission",
+                    "OriginalRequestType": "TaskChain"
+                    }
+        testArguments.update(acdcArgs)
+        factory = ResubmissionWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TaskChain_ACDC",
+                                                           testArguments, acdcArgs)
+
+        # now we can validate the new workload object
+        for topTask in testWorkload.taskIterator():
+            for taskObj in topTask.taskIterator():
+                perfParams = taskObj.jobSplittingParameters()['performance']
+                print("Task: {}, type: {}, perf: {}".format(taskObj.name(), taskObj.taskType(), perfParams))
+                if taskObj.taskType() in ('Production', 'Processing'):
+                    for step in ('cmsRun1', 'stageOut1', 'logArch1'):
+                        stepHelper = taskObj.getStepHelper(step)
+                        self.assertEqual(stepHelper.getNumberOfCores(), 1)
+                        self.assertEqual(stepHelper.getNumberOfStreams(), 0)
+                    self.assertEqual(perfParams['memoryRequirement'], 2400.0)
+                    self.assertEqual(perfParams['timePerEvent'], 0.8)
+                elif taskObj.taskType() == 'LogCollect':
+                    stepHelper = taskObj.getStepHelper('logCollect1')
+                    self.assertEqual(stepHelper.getNumberOfCores(), 1)
+                    self.assertEqual(stepHelper.getNumberOfStreams(), 0)
+                    self.assertEqual(perfParams, {})
+                elif taskObj.taskType() == 'Cleanup':
+                    for step in taskObj.listAllStepNames():
+                        stepHelper = taskObj.getStepHelper(step)
+                        self.assertEqual(stepHelper.getNumberOfCores(), 1)
+                        self.assertEqual(stepHelper.getNumberOfStreams(), 0)
+                    self.assertEqual(perfParams, {})
+
+    def testCustomACDC(self):
+        """
+        Creates a custom ACDC workflow overwriting some parameters
+        """
+        testArguments = TaskChainWorkloadFactory.getTestArguments()
+        # use a workflow existent in cmsweb-testbed, not good, but better than nothing
+        acdcArgs = {"ACDCDatabase": "acdcserver",
+                    "ACDCServer": self.testInit.couchUrl,
+                    "CouchURL": "https://cmsweb-testbed.cern.ch/couchdb",
+                    "InitialTaskPath": "/amaltaro_TaskChain_LumiMask_multiRun_HG2108_Val_210731_182010_1852/HLTD",
+                    "Memory": {"HLTD": 1950, "RECODreHLT": 2950.0},
+                    "Multicore": {"HLTD": 11, "RECODreHLT": 12},
+                    "EventStreams": {"HLTD": 21, "RECODreHLT": 22},
+                    "TimePerEvent": {"HLTD": 1.5, "RECODreHLT": 2.5},
+                    "OriginalRequestName": "amaltaro_TaskChain_LumiMask_multiRun_HG2108_Val_210731_182010_1852",
+                    "RequestString": "ACDC_UnitTest_TaskChain_LumiMask_multiRun",
+                    "RequestType": "Resubmission",
+                    "OriginalRequestType": "TaskChain"
+                    }
+        testArguments.update(acdcArgs)
+        factory = ResubmissionWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TaskChain_ACDC",
+                                                           testArguments, acdcArgs)
+
+        # now we can validate the new workload object
+        for topTask in testWorkload.taskIterator():
+            for taskObj in topTask.taskIterator():
+                taskName = taskObj.name()
+                perfParams = taskObj.jobSplittingParameters()['performance']
+                print("Task: {}, type: {}, perf: {}".format(taskName, taskObj.taskType(), perfParams))
+                if taskObj.taskType() in ('Production', 'Processing'):
+                    stepHelper = taskObj.getStepHelper('cmsRun1')
+                    self.assertEqual(stepHelper.getNumberOfCores(), acdcArgs['Multicore'][taskName])
+                    self.assertEqual(stepHelper.getNumberOfStreams(), acdcArgs['EventStreams'][taskName])
+                    for step in ('stageOut1', 'logArch1'):
+                        stepHelper = taskObj.getStepHelper(step)
+                        self.assertEqual(stepHelper.getNumberOfCores(), 1)
+                        self.assertEqual(stepHelper.getNumberOfStreams(), 0)
+                    self.assertEqual(perfParams['memoryRequirement'], acdcArgs['Memory'][taskName])
+                    self.assertEqual(perfParams['timePerEvent'], acdcArgs['TimePerEvent'][taskName])
+                elif taskObj.taskType() == 'LogCollect':
+                    stepHelper = taskObj.getStepHelper('logCollect1')
+                    self.assertEqual(stepHelper.getNumberOfCores(), 1)
+                    self.assertEqual(stepHelper.getNumberOfStreams(), 0)
+                    self.assertEqual(perfParams, {})
+                elif taskObj.taskType() == 'Cleanup':
+                    for step in taskObj.listAllStepNames():
+                        stepHelper = taskObj.getStepHelper(step)
+                        self.assertEqual(stepHelper.getNumberOfCores(), 1)
+                        self.assertEqual(stepHelper.getNumberOfStreams(), 0)
+                    self.assertEqual(perfParams, {})
+
+    def testCustomSimpleACDC(self):
+        """
+        Creates a custom ACDC workflow overwriting some parameters
+        """
+        testArguments = TaskChainWorkloadFactory.getTestArguments()
+        # use a workflow existent in cmsweb-testbed, not good, but better than nothing
+        acdcArgs = {"ACDCDatabase": "acdcserver",
+                    "ACDCServer": self.testInit.couchUrl,
+                    "CouchURL": "https://cmsweb-testbed.cern.ch/couchdb",
+                    "InitialTaskPath": "/amaltaro_TaskChain_LumiMask_multiRun_HG2108_Val_210731_182010_1852/HLTD",
+                    "Memory": 9999,
+                    "Multicore": 22,
+                    "EventStreams": 11,
+                    "TimePerEvent": 2.5,
+                    "OriginalRequestName": "amaltaro_TaskChain_LumiMask_multiRun_HG2108_Val_210731_182010_1852",
+                    "RequestString": "ACDC_UnitTest_TaskChain_LumiMask_multiRun",
+                    "RequestType": "Resubmission",
+                    "OriginalRequestType": "TaskChain"
+                    }
+        testArguments.update(acdcArgs)
+        factory = ResubmissionWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TaskChain_ACDC",
+                                                           testArguments, acdcArgs)
+
+        # now we can validate the new workload object
+        for topTask in testWorkload.taskIterator():
+            for taskObj in topTask.taskIterator():
+                taskName = taskObj.name()
+                perfParams = taskObj.jobSplittingParameters()['performance']
+                print("Task: {}, type: {}, perf: {}".format(taskName, taskObj.taskType(), perfParams))
+                if taskObj.taskType() in ('Production', 'Processing'):
+                    stepHelper = taskObj.getStepHelper('cmsRun1')
+                    self.assertEqual(stepHelper.getNumberOfCores(), acdcArgs['Multicore'])
+                    self.assertEqual(stepHelper.getNumberOfStreams(), acdcArgs['EventStreams'])
+                    for step in ('stageOut1', 'logArch1'):
+                        stepHelper = taskObj.getStepHelper(step)
+                        self.assertEqual(stepHelper.getNumberOfCores(), 1)
+                        self.assertEqual(stepHelper.getNumberOfStreams(), 0)
+                    self.assertEqual(perfParams['memoryRequirement'], acdcArgs['Memory'])
+                    self.assertEqual(perfParams['timePerEvent'], acdcArgs['TimePerEvent'])
+                elif taskObj.taskType() == 'LogCollect':
+                    stepHelper = taskObj.getStepHelper('logCollect1')
+                    self.assertEqual(stepHelper.getNumberOfCores(), 1)
+                    self.assertEqual(stepHelper.getNumberOfStreams(), 0)
+                    self.assertEqual(perfParams, {})
+                elif taskObj.taskType() == 'Cleanup':
+                    for step in taskObj.listAllStepNames():
+                        stepHelper = taskObj.getStepHelper(step)
+                        self.assertEqual(stepHelper.getNumberOfCores(), 1)
+                        self.assertEqual(stepHelper.getNumberOfStreams(), 0)
+                    self.assertEqual(perfParams, {})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
@@ -2309,6 +2309,29 @@ class TaskChainTests(EmulatedUnitTestCase):
         with self.assertRaises(WMSpecFactoryException):
             factory.factoryWorkloadConstruction("PullingTheChain", arguments)
 
+    def testResourcesOverride(self):
+        """
+        Test override of resource requirements during workflow assignment
+        """
+        processorDocs = makeProcessingConfigs(self.configDatabase)
+
+        arguments = TaskChainWorkloadFactory.getTestArguments()
+        arguments.update(deepcopy(REQUEST_INPUT))
+        arguments['Task1']['ConfigCacheID'] = processorDocs['DigiHLT']
+        arguments['Task2']['ConfigCacheID'] = processorDocs['Reco']
+        factory = TaskChainWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("PullingTheChain", arguments)
+
+        ### Now assign this workflow
+        assignDict = {"SiteWhitelist": ["T2_US_Nebraska"], "Team": "The-A-Team",
+                      "MergedLFNBase": "/store/data",
+                      "UnmergedLFNBase": "/store/unmerged",
+                      "TimePerEvent": {"DIGI": 1.5, "RECO": 2.5},
+                      "Memory": {"DIGI": 123, "RECO": 456},
+                      "Multicore": {"DIGI": 11, "RECO": 12},
+                      "EventStreams": {"DIGI": 21, "RECO": 22},
+                      }
+        testWorkload.updateArguments(assignDict)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/WMCore_t/WMSpec_t/WMWorkloadTools_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMWorkloadTools_t.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Unit tests for the WMWorkloadTools module
+"""
+from __future__ import print_function, division
+
+import unittest
+
+from Utils.PythonVersion import PY3
+from WMCore.WMSpec.WMWorkloadTools import checkMemCore, checkEventStreams, checkTimePerEvent
+
+
+class WMWorkloadToolsTest(unittest.TestCase):
+
+    def setUp(self):
+        """
+        Setup unit tests for this module
+        """
+        pass
+
+    def tearDown(self):
+        """
+        Cleanup after the unit tests
+        """
+        pass
+
+    def testCheckMemCore(self):
+        """
+        Tests for the function 'checkMemCore'
+        """
+        # input that fails validation
+        self.assertFalse(checkMemCore(-1))
+        self.assertFalse(checkMemCore(0))
+        self.assertFalse(checkMemCore(0.5, minValue=1))
+        self.assertFalse(checkMemCore(0, minValue=1))
+        # input that passes validation
+        self.assertTrue(checkMemCore(1))
+        self.assertTrue(checkMemCore(0, minValue=0))
+        self.assertTrue(checkMemCore(0.5, minValue=0))
+        self.assertTrue(checkMemCore(1.0, minValue=1))
+        self.assertTrue(checkMemCore(1, minValue=1))
+        self.assertTrue(checkMemCore({"Task1": 1, "Task2": 2, "Task3": 3.5}))
+        self.assertTrue(checkMemCore({"Task1": 1, "Task2": 2, "Task3": 3.5}, minValue=1))
+        self.assertTrue(checkMemCore({"Task1": 1, "Task2": 2, "Task3": 3.5}, minValue=0))
+        # tests with different behaviour depending on the python version
+        if PY3:
+            self.assertFalse(checkMemCore("-1"))
+            self.assertFalse(checkMemCore([1]))
+            self.assertFalse(checkMemCore((1, 2)))
+        else:
+            self.assertTrue(checkMemCore("-1"))
+            self.assertTrue(checkMemCore([1]))
+            self.assertTrue(checkMemCore((1, 2)))
+
+    def testCheckEventStreams(self):
+        """
+        Tests for the function 'checkEventStreams'
+        """
+        # input that fails validation
+        self.assertFalse(checkEventStreams(-1))
+        # input that passes validation
+        self.assertTrue(checkEventStreams(1))
+        self.assertTrue(checkEventStreams(0))
+        self.assertTrue(checkEventStreams(0.5))
+        self.assertTrue(checkEventStreams(1.0))
+        self.assertTrue(checkEventStreams(1))
+        self.assertTrue(checkEventStreams({"Task1": 1, "Task2": 2, "Task3": 3.5}))
+        self.assertTrue(checkEventStreams({"Task1": 1, "Task2": 2, "Task3": 3.5}))
+        self.assertTrue(checkEventStreams({"Task1": 1, "Task2": 2, "Task3": 3.5}))
+        # tests with different behaviour depending on the python version
+        if PY3:
+            self.assertFalse(checkEventStreams("-1"))
+            self.assertFalse(checkEventStreams([1]))
+            self.assertFalse(checkEventStreams((1, 2)))
+        else:
+            self.assertTrue(checkEventStreams("-1"))
+            self.assertTrue(checkEventStreams([1]))
+            self.assertTrue(checkEventStreams((1, 2)))
+
+
+    def testCheckTimePerEvent(self):
+        """
+        Tests for the function 'checkTimePerEvent'
+        """
+        # input that fails validation
+        self.assertFalse(checkTimePerEvent(-1))
+        # input that passes validation
+        self.assertTrue(checkTimePerEvent(1))
+        self.assertTrue(checkTimePerEvent(0))
+        self.assertTrue(checkTimePerEvent(0.5))
+        self.assertTrue(checkTimePerEvent(1.0))
+        self.assertTrue(checkTimePerEvent(1))
+        self.assertTrue(checkTimePerEvent({"Task1": 1, "Task2": 2, "Task3": 3.5}))
+        self.assertTrue(checkTimePerEvent({"Task1": 1, "Task2": 2, "Task3": 3.5}))
+        self.assertTrue(checkTimePerEvent({"Task1": 1, "Task2": 2, "Task3": 3.5}))
+        # tests with different behaviour depending on the python version
+        if PY3:
+            self.assertFalse(checkTimePerEvent("-1"))
+            self.assertFalse(checkTimePerEvent([1]))
+            self.assertFalse(checkTimePerEvent((1, 2)))
+        else:
+            self.assertTrue(checkTimePerEvent("-1"))
+            self.assertTrue(checkTimePerEvent([1]))
+            self.assertTrue(checkTimePerEvent((1, 2)))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #10741 

UPDATE:
* 1st commit has already been backported in this PR: https://github.com/dmwm/WMCore/pull/10783
* unfortunately it wasn't sufficient, so a 2nd commit was created to fix the remaining issues. It's been backported in this PR: https://github.com/dmwm/WMCore/pull/10787

#### Status
ready

#### Description
With the migration to python3, comparisons between dict and integer/float no longer work.

This PR refactors how `Multicore`, `Memory`, `EventStreams` and `TimePerEvent` are validated during workflow creation AND workflow assignment.

There are no changes to the format of data provided for those parameters, and their definition is made at the StdBase and it's overriden from the children classes when necessary. In short, we can provide a single value e.g.:
```
"Multicore": 4
```
or (for TaskChain/StepChain/Resubmission), we can also provide:
```
"Multicore": {"TaskName_1": 4, "TaskName_2": 16, etc etc}
```

When the former is provided in the creation of a Resubmission workflow (e.g Multicore=4), this will apply to all the tasks throughout the workflow.

NOTE: such settings provided at the Task or Step level (inner dict), take no effect! Only top level ones.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
