### PR TITLE
Fix spec validation for Multicore/Memory/Streams/TpE - cmsweb branch

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
@@ -21,7 +21,8 @@ from Utils.Utilities import strToBool
 import WMCore.WMSpec.Steps.StepFactory as StepFactory
 from WMCore.Lexicon import primdataset, taskStepName
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
-from WMCore.WMSpec.WMWorkloadTools import validateArgumentsCreate, parsePileupConfig
+from WMCore.WMSpec.WMWorkloadTools import (validateArgumentsCreate, parsePileupConfig,
+                                           checkMemCore, checkEventStreams, checkTimePerEvent)
 from WMCore.WMSpec.WMSpecErrors import WMSpecFactoryException
 
 # simple utils for data mining the request dictionary
@@ -482,6 +483,11 @@ class StepChainWorkloadFactory(StdBase):
                     "FirstLumi": {"default": 1, "type": int, "validate": lambda x: x > 0,
                                   "null": False},
                     "ParentageResolved": {"default": False, "type": strToBool, "null": False},
+                    ### Override StdBase parameter definition
+                    "TimePerEvent": {"default": 12.0, "type": float, "validate": checkTimePerEvent},
+                    "Memory": {"default": 2300.0, "type": float, "validate": checkMemCore},
+                    "Multicore": {"default": 1, "type": int, "validate": checkMemCore},
+                    "EventStreams": {"type": int, "null": True, "default": 0, "validate": checkEventStreams}
                    }
         baseArgs.update(specArgs)
         StdBase.setDefaultArgumentsProperty(baseArgs)
@@ -517,6 +523,10 @@ class StepChainWorkloadFactory(StdBase):
         baseArgs = StdBase.getWorkloadAssignArgs()
         specArgs = {
             "ChainParentageMap": {"default": {}, "type": dict},
+            ### Override StdBase assignment parameter definition
+            "Memory": {"type": float, "validate": checkMemCore},
+            "Multicore": {"type": int, "validate": checkMemCore},
+            "EventStreams": {"type": int, "validate": checkEventStreams},
         }
         baseArgs.update(specArgs)
         StdBase.setDefaultArgumentsProperty(baseArgs)

--- a/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
@@ -90,7 +90,8 @@ from future.utils import viewitems
 from Utils.Utilities import makeList, strToBool
 from WMCore.Lexicon import primdataset, taskStepName
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
-from WMCore.WMSpec.WMWorkloadTools import validateArgumentsCreate, parsePileupConfig
+from WMCore.WMSpec.WMWorkloadTools import (validateArgumentsCreate, parsePileupConfig,
+                                           checkMemCore, checkEventStreams, checkTimePerEvent)
 from WMCore.WMSpec.WMSpecErrors import WMSpecFactoryException
 
 #
@@ -619,8 +620,13 @@ class TaskChainWorkloadFactory(StdBase):
                                    "attr": "firstEvent", "null": False},
                     "FirstLumi": {"default": 1, "type": int,
                                   "optional": True, "validate": lambda x: x > 0,
-                                  "attr": "firstLumi", "null": False}
-                   }
+                                  "attr": "firstLumi", "null": False},
+                    ### Override StdBase parameter definition
+                    "TimePerEvent": {"default": 12.0, "type": float, "validate": checkTimePerEvent},
+                    "Memory": {"default": 2300.0, "type": float, "validate": checkMemCore},
+                    "Multicore": {"default": 1, "type": int, "validate": checkMemCore},
+                    "EventStreams": {"type": int, "null": True, "default": 0, "validate": checkEventStreams}
+                    }
         baseArgs.update(specArgs)
         StdBase.setDefaultArgumentsProperty(baseArgs)
         return baseArgs
@@ -656,6 +662,10 @@ class TaskChainWorkloadFactory(StdBase):
         baseArgs = StdBase.getWorkloadAssignArgs()
         specArgs = {
             "ChainParentageMap": {"default": {}, "type": dict},
+            ### Override StdBase assignment parameter definition
+            "Memory": {"type": float, "validate": checkMemCore},
+            "Multicore": {"type": int, "validate": checkMemCore},
+            "EventStreams": {"type": int, "validate": checkEventStreams},
         }
         baseArgs.update(specArgs)
         StdBase.setDefaultArgumentsProperty(baseArgs)

--- a/src/python/WMCore/WMSpec/WMWorkloadTools.py
+++ b/src/python/WMCore/WMSpec/WMWorkloadTools.py
@@ -9,7 +9,7 @@ Created on Jun 13, 2013
 @author: dballest
 """
 from builtins import str, bytes
-from future.utils import viewitems
+from future.utils import viewitems, viewvalues
 
 import json
 import re
@@ -19,6 +19,42 @@ from Utils.Utilities import makeList
 from WMCore.DataStructs.LumiList import LumiList
 from WMCore.WMSpec.WMSpecErrors import WMSpecFactoryException
 from WMCore.Services.PhEDEx.DataStructs.SubscriptionList import PhEDEx_VALID_SUBSCRIPTION_PRIORITIES
+
+
+def checkMemCore(paramInfo, minValue=1):
+    """
+    Spec validation function for the Memory/Multicore parameters
+    :param memInfo: memory provided by the user (can be an int/float/dict)
+    :param minValue: base value to be used to validate user's values
+    :return: True if validation is successful, raise an exception otherwise
+    """
+    try:
+        if isinstance(paramInfo, dict):
+            for value in viewvalues(paramInfo):
+                assert value >= minValue
+        else:
+            assert paramInfo >= minValue
+    except Exception:
+        return False
+    return True
+
+
+def checkEventStreams(streamsInfo):
+    """
+    Spec validation function for the EventStreams parameter
+    :param streamsInfo: event streams provided by the user (can be either int or a dict)
+    :return: True if validation is successful, raise an exception otherwise
+    """
+    return checkMemCore(streamsInfo, 0)
+
+
+def checkTimePerEvent(tpEvtInfo):
+    """
+    Spec validation function for the TimePerEvent parameter
+    :param tpEvtInfo: time per event provided by the user (can be either float or a dict)
+    :return: True if validation is successful, raise an exception otherwise
+    """
+    return checkMemCore(tpEvtInfo, 0)
 
 
 def makeLumiList(lumiDict):
@@ -114,7 +150,8 @@ def _validateArgumentOptions(arguments, argumentDefinition, optionKey=None):
     for arg, argDef in viewitems(argumentDefinition):
         optional = argDef.get(optionKey, True)
         if not optional and arg not in arguments:
-            msg = "Argument '%s' is mandatory! Its definition is:\n%s" % (arg, inspect.getsource(argDef))
+            msg = "Argument '{}' is mandatory and must be provided by the user.".format(arg)
+            msg += " Its definition is: {}".format(argDef)
             raise WMSpecFactoryException(msg)
         # specific case when user GUI returns empty string for optional arguments
         elif arg not in arguments:


### PR DESCRIPTION
1.5.1_cmsweb branch version for https://github.com/dmwm/WMCore/pull/10781 (1st commit only)

A new release needs to be made and pushed to CMSWEB production.

PS.: Note that the first commit was not enough to properly fix this issue, so the master PR provides a 2nd commit to be cherry-picked by another 1.5.1_cmsweb PR.