### PR TITLE
CouchDB 3: Add new Error HTTP Status Codes to CMSCouch.py

### DIFF
--- a/src/python/WMCore/Database/CMSCouch.py
+++ b/src/python/WMCore/Database/CMSCouch.py
@@ -152,10 +152,16 @@ class CouchDBRequests(JSONRequests):
             raise CouchNotFoundError(reason, data, result)
         elif status == 405:
             raise CouchNotAllowedError(reason, data, result)
+        elif status == 406:
+            raise CouchNotAcceptableError(reason, data, result)
         elif status == 409:
             raise CouchConflictError(reason, data, result)
         elif status == 412:
             raise CouchPreconditionFailedError(reason, data, result)
+        elif status == 416:
+            raise CouchRequestedRangeNotSatisfiableError(reason, data, result)
+        elif status == 417:
+            raise CouchExpectationFailedError(reason, data, result)
         elif status == 500:
             raise CouchInternalServerError(reason, data, result)
         elif status in [502, 503, 504]:
@@ -1098,17 +1104,30 @@ class CouchNotAllowedError(CouchError):
         CouchError.__init__(self, reason, data, result)
         self.type = "CouchNotAllowedError"
 
+class CouchNotAcceptableError(CouchError):
+    def __init__(self, reason, data, result):
+        CouchError.__init__(self, reason, data, result)
+        self.type = "CouchNotAcceptableError"
 
 class CouchConflictError(CouchError):
     def __init__(self, reason, data, result):
         CouchError.__init__(self, reason, data, result)
         self.type = "CouchConflictError"
 
-
 class CouchPreconditionFailedError(CouchError):
     def __init__(self, reason, data, result):
         CouchError.__init__(self, reason, data, result)
         self.type = "CouchPreconditionFailedError"
+
+class CouchExpectationFailedError(CouchError):
+    def __init__(self, reason, data, result):
+        CouchError.__init__(self, reason, data, result)
+        self.type = "CouchExpectationFailedError"
+
+class CouchRequestedRangeNotSatisfiableError(CouchError):
+    def __init__(self, reason, data, result):
+        CouchError.__init__(self, reason, data, result)
+        self.type = "CouchRequestedRangeNotSatisfiableError"
 
 
 class CouchInternalServerError(CouchError):


### PR DESCRIPTION
Fixes #10784

#### Status
not-tested

#### Description
For reference: https://docs.couchdb.org/en/3.1.1/api/basics.html#errors

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
CouchDB 3 Migration

#### External dependencies / deployment changes
CouchDB 3
