### PR TITLE
Override factoryWorkloadConstruction in the Resubmission spec

### DIFF
--- a/src/python/WMCore/ReqMgr/Utils/Validation.py
+++ b/src/python/WMCore/ReqMgr/Utils/Validation.py
@@ -157,7 +157,8 @@ def validate_resubmission_create_args(request_args, config, reqmgr_db_service, *
 
     specClass = loadSpecClassByType(request_args["RequestType"])
     spec = specClass()
-    workload = spec.factoryWorkloadConstruction(cloned_args["RequestName"], cloned_args)
+    workload = spec.factoryWorkloadConstruction(cloned_args["RequestName"],
+                                                cloned_args, request_args)
 
     return workload, cloned_args
 


### PR DESCRIPTION
1.5.1_cmsweb branch version for https://github.com/dmwm/WMCore/pull/10781 (2nd commit only)
Complements https://github.com/dmwm/WMCore/pull/10783

A new release needs to be made and pushed to CMSWEB production.

PS.: Note that the first commit was not enough to properly fix this issue, so the master PR provides 2 commits and this backport corresponds to the 2nd one.