### PR TITLE
Update Python3 requirements list with Sphinx and Jinja2

### DIFF
--- a/requirements_py3.txt
+++ b/requirements_py3.txt
@@ -2,7 +2,7 @@
 # on a python3 stack
 
 ### dependencies on the wmagentpy3 spec
-Jinja2==2.11.3
+Jinja2==3.0.1
 SQLAlchemy==1.3.3
 cx-Oracle==7.3.0
 future==0.18.2
@@ -13,7 +13,7 @@ pycurl==7.43.0.3
 pyzmq==19.0.2
 retry==0.9.2
 rucio-clients==1.25.5
-sphinx==1.6.3
+Sphinx==4.0.3
 Cheetah3==3.2.6.post2
 ### dependencies on the wmcorepy3-devtools spec
 CherryPy==17.4.0
@@ -29,6 +29,6 @@ psutil==5.8.0
 pylint==2.6.0
 pymongo==3.10.1
 retry==0.9.2
-sphinx==1.6.3
+Sphinx==4.0.3
 CMSMonitoring==0.3.4
 CMSCouchapp==1.3.2


### PR DESCRIPTION
Fixes #10793 

#### Status
ready

#### Description
The python3 cmsdist packages are being updated with this PR:
https://github.com/cms-sw/cmsdist/pull/7275

and this PR is simply updating our list of python3 required libraries and their versions.

#### Is it backward compatible (if not, which system it affects?)
Hopefully!

#### Related PRs
Spec PR: https://github.com/cms-sw/cmsdist/pull/7275

#### External dependencies / deployment changes
None
