### PR TITLE
Fix Multicore/EventStreams override in Resubmission of StepChains

### DIFF
--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Resubmission_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Resubmission_t.py
@@ -370,11 +370,12 @@ class ResubmissionTests(EmulatedUnitTestCase):
                 perfParams = taskObj.jobSplittingParameters()['performance']
                 print("Task: {}, type: {}, perf: {}".format(taskObj.name(), taskObj.taskType(), perfParams))
                 if taskObj.taskType() in ('Production', 'Processing'):
-                    for step in ('cmsRun1', 'cmsRun2'):
-                        stepHelper = taskObj.getStepHelper(step)
-                        # FIXME: these 2 lines below are wrong, see GH issue #10791
-                        self.assertEqual(stepHelper.getNumberOfCores(), acdcArgs["Multicore"]["RecoPU_2021PU"])
-                        self.assertEqual(stepHelper.getNumberOfStreams(), acdcArgs["EventStreams"]["RecoPU_2021PU"])
+                    stepHelper = taskObj.getStepHelper("cmsRun1")
+                    self.assertEqual(stepHelper.getNumberOfCores(), acdcArgs["Multicore"]["RecoPU_2021PU"])
+                    self.assertEqual(stepHelper.getNumberOfStreams(), acdcArgs["EventStreams"]["RecoPU_2021PU"])
+                    stepHelper = taskObj.getStepHelper("cmsRun2")
+                    self.assertEqual(stepHelper.getNumberOfCores(), acdcArgs["Multicore"]["Nano_2021PU"])
+                    self.assertEqual(stepHelper.getNumberOfStreams(), acdcArgs["EventStreams"]["Nano_2021PU"])
                     for step in ('stageOut1', 'logArch1'):
                         stepHelper = taskObj.getStepHelper(step)
                         self.assertEqual(stepHelper.getNumberOfCores(), 1)
@@ -436,7 +437,6 @@ class ResubmissionTests(EmulatedUnitTestCase):
                 if taskObj.taskType() in ('Production', 'Processing'):
                     for step in ('cmsRun1', 'cmsRun2'):
                         stepHelper = taskObj.getStepHelper(step)
-                        # FIXME: these 2 lines below are wrong, see GH issue #10791
                         self.assertEqual(stepHelper.getNumberOfCores(), acdcArgs["Multicore"])
                         self.assertEqual(stepHelper.getNumberOfStreams(), acdcArgs["EventStreams"])
                     for step in ('stageOut1', 'logArch1'):


### PR DESCRIPTION
Fixes #10791 

#### Status
ready

#### Description
This PR provides a fix for Resubmission of StepChains, when Multicore and/or EventStreams are provided as a dictionary key'ed after the StepName. With this, we can now properly update the `cmsRun` steps with key/value pairs overriding the original request being ACDC'ed.

Note that this is sole scenario with changes. The rest of the use cases have not been touched here.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
