### PR TITLE
Add support and validation to GPU in StdBase/ReReco

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/ReReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/ReReco.py
@@ -5,6 +5,9 @@ _ReReco_
 Standard ReReco workflow.
 """
 from __future__ import division
+
+import json
+
 from future.utils import viewitems
 
 from Utils.Utilities import makeList
@@ -273,3 +276,10 @@ class ReRecoWorkloadFactory(DataProcessing):
             if diffSet:
                 self.raiseValidationException(
                     msg="A transient output module was specified but no skim was defined for it")
+
+        # Validate GPU-related spec parameters
+        if schema["RequiresGPU"] in ("optional", "required"):
+            if not json.loads(schema["GPUParams"]):
+                msg = "Request is set with RequiresGPU={}, ".format(schema["RequiresGPU"])
+                msg += "but GPUParams schema is not provided or correct."
+                self.raiseValidationException(msg)

--- a/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
@@ -133,12 +133,19 @@ class CMSSW(Executor):
 
         scramArch = getSingleScramArch(scramArch)
 
-        multicoreSettings = self.step.application.multicore
         try:
+            multicoreSettings = self.step.application.multicore
             logging.info("CMSSW configured for %s cores and %s event streams",
                          multicoreSettings.numberOfCores, multicoreSettings.eventStreams)
         except AttributeError:
             logging.info("No value set for multicore numberOfCores or eventStreams")
+
+        try:
+            gpuSettings = self.step.application.gpu
+            logging.info("CMSSW configured for GPU required: %s, with these settings: %s",
+                         gpuSettings.gpuRequired, gpuSettings.gpuRequirements)
+        except AttributeError:
+            logging.info("No value set for GPU gpuRequired and/or gpuRequirements")
 
         logging.info("Executing CMSSW step")
 

--- a/src/python/WMCore/WMSpec/Steps/Templates/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Templates/CMSSW.py
@@ -400,6 +400,14 @@ class CMSSWStepHelper(CoreHelper):
         """
         return self.data.application.multicore.eventStreams
 
+    def setGPUSettings(self, requiresGPU, gpuParams):
+        """
+        Set whether this CMSSW step should require GPUs and if so, which
+        setup should be allowed and/or used
+        """
+        self.data.application.gpu.gpuRequired = requiresGPU
+        self.data.application.gpu.gpuRequirements = gpuParams
+
 
 class CMSSW(Template):
     """
@@ -465,6 +473,11 @@ class CMSSW(Template):
         step.application.section_("multicore")
         step.application.multicore.numberOfCores = 1
         step.application.multicore.eventStreams = 0
+
+        # support for GPU in CMSSW (using defaults from StdBase)
+        step.application.section_("gpu")
+        step.application.gpu.gpuRequired = "forbidden"
+        step.application.gpu.gpuRequirements = None
 
     def helper(self, step):
         """

--- a/src/python/WMCore/WMSpec/WMStep.py
+++ b/src/python/WMCore/WMSpec/WMStep.py
@@ -65,6 +65,22 @@ class WMStepHelper(TreeHelper):
         except Exception:
             return 0
 
+    def getGPURequired(self):
+        """
+        Return whether GPU is required or not for this step object
+        """
+        if hasattr(self.data.application.gpu, "gpuRequired"):
+            return self.data.application.gpu.gpuRequired
+        return None
+
+    def getGPURequirements(self):
+        """
+        Return the GPU requirements for this step object
+        """
+        if hasattr(self.data.application.gpu, "gpuRequirements"):
+            return self.data.application.gpu.gpuRequirements
+        return None
+
     def addStep(self, stepName):
         """
         _addStep_

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -851,6 +851,31 @@ class WMWorkloadHelper(PersistencyHelper):
 
         return
 
+    def setGPUSettings(self, requiresGPU, gpuParams, initialTask=None):
+        """
+        Setter method for the workload GPU parameters.
+        It's responsible for setting whether GPUs are required or not; and
+        which GPU parameters to be used for that. This is done for every
+        task of this spec.
+        :param requiresGPU: string defining whether GPUs are needed. For TaskChains, it
+            could be a dictionary key'ed by the taskname.
+        :param gpuParams: GPU settings. A JSON encoded object, from either a None object
+            or a dictionary. For TaskChains, it could be a dictionary key'ed by the taskname
+        :param initialTask: parent task object
+        """
+        if not requiresGPU:
+            return
+
+        if initialTask:
+            taskIterator = initialTask.childTaskIterator()
+        else:
+            taskIterator = self.taskIterator()
+
+        for task in taskIterator:
+            task.setTaskGPUSettings(requiresGPU, gpuParams)
+            self.setGPUSettings(requiresGPU, gpuParams, task)
+        return
+
     def setMemory(self, memory, initialTask=None):
         """
         _setMemory_

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Templates_t/CMSSWTemplate_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Templates_t/CMSSWTemplate_t.py
@@ -10,10 +10,9 @@ Copyright (c) 2010 Fermilab. All rights reserved.
 import unittest
 
 from Utils.PythonVersion import PY3
-
 from WMCore.WMSpec.Steps.Templates.CMSSW import CMSSW as CMSSWTemplate
-from WMCore.WMSpec.WMWorkload import newWorkload
 from WMCore.WMSpec.WMStep import makeWMStep
+from WMCore.WMSpec.WMWorkload import newWorkload
 
 
 class CMSSWTemplateTest(unittest.TestCase):
@@ -24,6 +23,7 @@ class CMSSWTemplateTest(unittest.TestCase):
     Tests the helper methods
 
     """
+
     def setUp(self):
         if PY3:
             self.assertItemsEqual = self.assertCountEqual
@@ -55,9 +55,9 @@ class CMSSWTemplateTest(unittest.TestCase):
 
         # TODO: Check the step has the appropriate attributes expected for CMSSW
         self.assertTrue(
-            hasattr(step, "application"))
+                hasattr(step, "application"))
         self.assertTrue(
-            hasattr(step.application, "setup"))
+                hasattr(step.application, "setup"))
 
     def testB(self):
         """
@@ -80,10 +80,10 @@ class CMSSWTemplateTest(unittest.TestCase):
 
         helper.cmsswSetup("CMSSW_X_Y_Z", scramArch="slc5_ia32_gcc443")
         helper.addOutputModule(
-            "outputModule1", primaryDataset="Primary",
-            processedDataset='Processed',
-            dataTier='Tier',
-            lfnBase="/store/unmerged/whatever"
+                "outputModule1", primaryDataset="Primary",
+                processedDataset='Processed',
+                dataTier='Tier',
+                lfnBase="/store/unmerged/whatever"
         )
 
     def testMulticoreSettings(self):
@@ -159,6 +159,28 @@ class CMSSWTemplateTest(unittest.TestCase):
         self.assertEqual(helper.getProcVer(), 111)
         self.assertEqual(helper.getPrepId(), "TestPrepId")
         self.assertItemsEqual(helper.listOutputModules(), ["Merged"])
+
+    def testGPUSettings(self):
+        """
+        Test GPU methods at CMSSW template level
+        """
+        workload = newWorkload("UnitTests")
+        task = workload.newTask("CMSSWTemplate")
+        stepHelper = task.makeStep("TemplateTest")
+        step = stepHelper.data
+        template = CMSSWTemplate()
+        template(step)
+
+        helper = template.helper(step)
+
+        self.assertEqual(helper.getGPURequired(), "forbidden")
+        self.assertIsNone(helper.getGPURequirements())
+        helper.setGPUSettings("optional", "test 1 2 3")
+        self.assertEqual(helper.getGPURequired(), "optional")
+        self.assertItemsEqual(helper.getGPURequirements(), "test 1 2 3")
+        helper.setGPUSettings("required", {"key1": "value1", "key2": "value2"})
+        self.assertEqual(helper.getGPURequired(), "required")
+        self.assertItemsEqual(helper.getGPURequirements(), {"key1": "value1", "key2": "value2"})
 
 
 if __name__ == '__main__':

--- a/test/python/WMCore_t/WMSpec_t/WMStep_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMStep_t.py
@@ -3,8 +3,10 @@
 Unittest for WMStep
 """
 
-
 import unittest
+
+import WMCore.WMSpec.Steps.StepFactory as StepFactory
+from Utils.PythonVersion import PY3
 from WMCore.WMSpec.WMStep import WMStep, makeWMStep
 
 
@@ -12,6 +14,16 @@ class WMStepTest(unittest.TestCase):
     """
     TestCase for WMStep class
     """
+
+    def setUp(self):
+        """set up"""
+        if PY3:
+            self.assertItemsEqual = self.assertCountEqual
+
+    def tearDown(self):
+        """clean up"""
+        pass
+
     def testA(self):
         """instantiation"""
 
@@ -28,8 +40,6 @@ class WMStepTest(unittest.TestCase):
             msg = "Failed to instantiate WMStep via makeWMStep:\n"
             msg += str(ex)
             self.fail(msg)
-
-
 
     def testB(self):
         """tree building"""
@@ -72,19 +82,17 @@ class WMStepTest(unittest.TestCase):
                      'TYPE3', 'TYPE8', 'TYPE9', 'TYPE10', 'TYPE4',
                      'TYPE11', 'TYPE12', 'TYPE13']
 
-        checkType = [ x.stepType for x in wmStep1.nodeIterator()]
-        checkOrder = [ x._internal_name for x in wmStep1.nodeIterator()]
+        checkType = [x.stepType for x in wmStep1.nodeIterator()]
+        checkOrder = [x._internal_name for x in wmStep1.nodeIterator()]
 
         self.assertEqual(nameOrder, checkOrder)
         self.assertEqual(typeOrder, checkType)
-
 
     def testC_testGetSetOverrides(self):
         """
         Test whether we can use the override manipulation tools in StepTypeHelper
 
         """
-
 
         wmStep = makeWMStep("step2")
 
@@ -93,7 +101,7 @@ class WMStepTest(unittest.TestCase):
         # This should be empty since we haven't put anything in it
         self.assertEqual(output, {})
 
-        wmStep.addOverride(override = 'test', overrideValue = 'nonsense')
+        wmStep.addOverride(override='test', overrideValue='nonsense')
 
         self.assertTrue(hasattr(wmStep.data, 'override'))
         self.assertTrue(hasattr(wmStep.data.override, 'test'))
@@ -104,7 +112,6 @@ class WMStepTest(unittest.TestCase):
         self.assertEqual(output, {'test': 'nonsense'})
 
         return
-
 
     def testD_getOutputModule(self):
         """
@@ -118,7 +125,7 @@ class WMStepTest(unittest.TestCase):
         wmStep.data.output.modules.section_('test')
         setattr(wmStep.data.output.modules.test, 'tester', 'nonsense')
 
-        testModule = wmStep.getOutputModule(moduleName = 'test')
+        testModule = wmStep.getOutputModule(moduleName='test')
 
         self.assertEqual(testModule.tester, 'nonsense')
 
@@ -135,7 +142,7 @@ class WMStepTest(unittest.TestCase):
 
         # errorDestinatio
         self.assertEqual(wmStep.getErrorDestinationStep(), None)
-        wmStep.setErrorDestinationStep(stepName = 'testStep')
+        wmStep.setErrorDestinationStep(stepName='testStep')
         self.assertEqual(wmStep.getErrorDestinationStep(), 'testStep')
 
         self.assertEqual(wmStep.getConfigInfo(), (None, None, None))
@@ -145,6 +152,33 @@ class WMStepTest(unittest.TestCase):
         wmStep.data.application.configuration.configId = 'test3'
 
         self.assertEqual(wmStep.getConfigInfo(), ('test1', 'test2', 'test3'))
+        return
+
+    def testGPUSettings(self):
+        """
+        Test GPU settings and the 'getGPURequired' and 'getGPURequirements' methods
+        """
+        # create a standard step object - without the CMSSW template applied
+        wmStep = makeWMStep("step1")
+        self.assertIsNone(wmStep.stepType())
+        self.assertFalse(hasattr(wmStep.data, "gpu"))
+        with self.assertRaises(AttributeError):
+            wmStep.getGPURequired()
+
+        # now apply the CMSSW template
+        wmStep.setStepType("CMSSW")
+        self.assertEqual(wmStep.stepType(), "CMSSW")
+        template = StepFactory.getStepTemplate("CMSSW")
+        template(wmStep.data)
+        wmStepHelper = wmStep.getTypeHelper()
+        self.assertEqual(wmStepHelper.getGPURequired(), "forbidden")
+        self.assertIsNone(wmStepHelper.getGPURequirements())
+
+        gpuParams = {"GPUMemoryMB": 1234, "CUDARuntime": "11.2.3", "CUDACapabilities": ["7.5", "8.0"]}
+        wmStepHelper.setGPUSettings("required", gpuParams)
+        self.assertEqual(wmStepHelper.getGPURequired(), "required")
+        self.assertItemsEqual(wmStepHelper.getGPURequirements(), gpuParams)
+
         return
 
 


### PR DESCRIPTION
Fixes #10388 

#### Status
ready

#### Description
This PR implements GPU functionality within WMCore (only at the request-level, job level will be done in a different issue/PR).
Summary of changes is:
*  New request spec parameters called 'RequiresGPU' and 'GPUParams', where:
  * `RequiresGPU`: can be one of these values `("forbidden", "optional", "required")`, with default value to `forbidden`, thus not using GPUs
  * `GPUParams`: a dictionary JSON encoded, with a default value to None JSON encoded. It must be provided if RequiresGPU=optional or RequiresGPU=required.

List of **mandatory** parameters within `GPUParams` is:
* `GPUMemoryMB` (renamed from GPUMemory !): integer greater than 0
* `CUDACapabilities`: a list of string values. Each value must match the `CUDA_VERSION_REGEX` regular expression and max length.
* `CUDARuntime`: a string value matching the `CUDA_VERSION_REGEX` constraints.

And a list of the 3 **optional** parameters is:
* `GPUName`: a string value with less than 100 chars
* `CUDADriverVersion`: a string value matching the `CUDA_VERSION_REGEX` constraints.
* `CUDARuntimeVersion`: a string value matching the `CUDA_VERSION_REGEX` constraints.

NOTE: full support in TaskChain and StepChain is going to be done in a different GH issue/pull request, but the bulk of the development is already provided in this PR.

#### Is it backward compatible (if not, which system it affects?)
NO (new feature!)

#### Related PRs
None

#### External dependencies / deployment changes
None
