### PR TITLE
Fix Issue creating tmp files

### DIFF
--- a/src/python/WMCore/Services/Service.py
+++ b/src/python/WMCore/Services/Service.py
@@ -294,11 +294,22 @@ class Service(dict):
                     cachefile.write(data)
                     cachefile.seek(0, 0)  # return to beginning of file
                 else:
-                    with open(cachefile, 'w') as f:
-                        if isinstance(data, dict) or isinstance(data, list):
-                            f.write(json.dumps(data))
-                        else:
-                            f.write(data)
+                    # Ensure that the path for /tmp file is created before
+                    # creating the file
+                    pathfile=cachefile.split("/")
+                    pathfile="/"+"/".join(pathfile[1:-1])
+                    if not os.path.exists(pathfile):
+                        os.makedirs(pathfile, exist_ok=True)
+                    try:
+                        # Raise excpetion if file/path is not created
+                        with open(cachefile, 'w') as f:
+                            if isinstance(data, dict) or isinstance(data, list):
+                                f.write(json.dumps(data))
+                            else:
+                                f.write(data)
+                    except EnvironmentError as EnvError:
+                        msg = ' raised a %s when accessed' % EnvError.__repr__()
+                        self['logger'].error(msg)
 
 
         except (IOError, HttpLib2Error, HTTPException) as he:


### PR DESCRIPTION
Fixes #10800 

#### Status
Tested with a Tier0-replay using WMCore agent 1.5.2

#### Description
While Tier0 started to test the new python3 version of WMCore, the component Tier0Feeder that is in charge of create the sandbox was not able to start properly. This due that the temp file within the following path `/tmp/cmst0/.wmcore_cache_xxxxxx was not created.

To guarantee that the file is properly created, the path where the file will be written needs to be create before creating the file. _My hypothesis is that file manipulation/creation changes from py2 to py3_ .

#### Is it backward compatible (if not, which system it affects?)
No. Dual stack DMWM services may be affected 

#### Related PRs
No

#### External dependencies / deployment changes
Relies on `pathlib` library from python3
