### PR TITLE
Add support to GPUs in TaskChain spec 

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/ReReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/ReReco.py
@@ -256,6 +256,8 @@ class ReRecoWorkloadFactory(DataProcessing):
                 instanceArguments[realArg] = skimArguments[argument]
             try:
                 validateArgumentsCreate(skimSchema, instanceArguments)
+                # Validate GPU-related spec parameters
+                DataProcessing.validateGPUSettings(schema)
             except Exception as ex:
                 self.raiseValidationException(str(ex))
 
@@ -276,10 +278,3 @@ class ReRecoWorkloadFactory(DataProcessing):
             if diffSet:
                 self.raiseValidationException(
                     msg="A transient output module was specified but no skim was defined for it")
-
-        # Validate GPU-related spec parameters
-        if schema["RequiresGPU"] in ("optional", "required"):
-            if not json.loads(schema["GPUParams"]):
-                msg = "Request is set with RequiresGPU={}, ".format(schema["RequiresGPU"])
-                msg += "but GPUParams schema is not provided or correct."
-                self.raiseValidationException(msg)

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StdBase_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StdBase_t.py
@@ -7,9 +7,11 @@ Created on Jun 14, 2013
 """
 from __future__ import print_function
 
+import json
 import unittest
 
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
+from WMCore.WMSpec.WMSpecErrors import WMSpecFactoryException
 
 
 class StdBaseTest(unittest.TestCase):
@@ -75,7 +77,25 @@ class StdBaseTest(unittest.TestCase):
         self.assertEqual((15000, 100), StdBase.calcEvtsPerJobLumi(None, 100, 1, requestedEvents=15000))
         self.assertEqual((15000, 15000), StdBase.calcEvtsPerJobLumi(None, None, 1, requestedEvents=15000))
 
-        return
+    def testValidateGPUSettings(self):
+        """
+        Test the 'validateGPUSettings' StdBase method.
+        """
+        with self.assertRaises(WMSpecFactoryException):
+            StdBase.validateGPUSettings({"RequiresGPU": "optional"})
+        with self.assertRaises(WMSpecFactoryException):
+            StdBase.validateGPUSettings({"RequiresGPU": "required"})
+        with self.assertRaises(WMSpecFactoryException):
+            StdBase.validateGPUSettings({"RequiresGPU": "optional", "GPUParams": json.dumps("")})
+        with self.assertRaises(WMSpecFactoryException):
+            StdBase.validateGPUSettings({"RequiresGPU": "required", "GPUParams": json.dumps(None)})
+
+        # now input that passes the validation
+        self.assertTrue(StdBase.validateGPUSettings({"RequiresGPU": "forbidden"}))
+        self.assertTrue(StdBase.validateGPUSettings({"RequiresGPU": "optional",
+                                                     "GPUParams": json.dumps("blah")}))
+        self.assertTrue(StdBase.validateGPUSettings({"RequiresGPU": "required",
+                                                     "GPUParams": json.dumps({"Key1": "value1"})}))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #10400 

#### Status
ready

#### Description
As a follow up of: https://github.com/dmwm/WMCore/pull/10799

this PR enabled GPU support in the TaskChain spec, thus, supporting it inside each Task definition as well.

Note that for `TaskChain` workflows, there is the same default values as those for top level, thus:
* RequiresGPU : forbidden
* GPUParams: json.dumps(None)
and the top level arguments will have
* RequiresGPU: None

#### Is it backward compatible (if not, which system it affects?)
YES (new arguments were made optional)

#### Related PRs
Complement to: https://github.com/dmwm/WMCore/pull/10799

#### External dependencies / deployment changes
None
