### PR TITLE
PhysicsSkim issue

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -142,7 +142,7 @@ class StdBase(object):
         import subprocess
 
         p = subprocess.Popen("/cvmfs/cms.cern.ch/common/cmsos", stdout=subprocess.PIPE, shell=True)
-        cmsos = p.communicate()[0].strip()
+        cmsos = p.communicate()[0].decode('utf-8').strip()
 
         scramBaseDirs = glob.glob("/cvmfs/cms.cern.ch/%s*/cms/cmssw/%s" % (cmsos, cmsswVersion))
         if not scramBaseDirs:
@@ -154,12 +154,13 @@ class StdBase(object):
         command += "cd %s\n" % scramBaseDirs[0]
         command += "eval `scramv1 runtime -sh`\n"
 
-        command += """python -c 'from Configuration.StandardSequences.Skims_cff import getSkimDataTier\n"""
+        command += """python3 -c 'from Configuration.StandardSequences.Skims_cff import getSkimDataTier\n"""
         command += """dataTier = getSkimDataTier("%s")\n""" % skim
-        command += """if dataTier:\n\tprint dataTier.value()'"""
+        command += """if dataTier:\n\tprint (dataTier.value())'"""
 
+        logging.info("command= %s" % command)
         p = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True)
-        dataTier = p.communicate()[0].strip()
+        dataTier = p.communicate()[0].decode('utf-8').strip()
 
         if dataTier == "None":
             dataTier = None


### PR DESCRIPTION
Fixes #10806 

#### Status
Tested with a replay

#### Description
During the final step of migrating the T0 agent to python3 and based on WMCore agent 1.5.2, The replay fails due that Tier0Feeder was not able to find physics_skims associated to CMSSW. The changes are basically two. One related to the `subprocess.Popen` due that in python3 is needed to decode the bytes from standard output to strings. Also to use CMSSW 12_X_X is needed to modify the `command` to use and get proper results from `getSkimDataTier`

#### Is it backward compatible (if not, which system it affects?)
MAYBE. Need clarification if this PR will break dual-stack for other DMWM services

#### Related PRs
No

#### External dependencies / deployment changes
No
