### PR TITLE
Propagate GPU requirements to job creation and submission

### DIFF
--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -406,7 +406,9 @@ class JobSubmitterPoller(BaseWorkerThread):
                        'inputDataset': loadedJob.get('inputDataset', None),
                        'inputDatasetLocations': loadedJob.get('inputDatasetLocations', None),
                        'inputPileup': loadedJob.get('inputPileup', None),
-                       'allowOpportunistic': loadedJob.get('allowOpportunistic', False)}
+                       'allowOpportunistic': loadedJob.get('allowOpportunistic', False),
+                       'requiresGPU': loadedJob.get('requiresGPU', "forbidden"),
+                       'gpuRequirements': loadedJob.get('gpuRequirements', None)}
             # then update it with the info retrieved from the database
             jobInfo.update(newJob)
 

--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -555,6 +555,18 @@ class SimpleCondorPlugin(BasePlugin):
                 ad['My.DESIRED_CMSPileups'] = undefined
             # HighIO
             ad['My.Requestioslots'] = str(1 if job['task_type'] in ["Merge", "Cleanup", "LogCollect"] else 0)
+            # GPU resource handling
+            # while we do not support a third option for RequiresGPU, make a binary decision
+            ad['My.RequiresGPU'] = "1" if job['requiresGPU'] == "required" else "0"
+            if job.get('gpuRequirements', None):
+                ad['My.GPUMemoryMB'] = str(job['gpuRequirements']['GPUMemoryMB'])
+                cudaCapabilities = ','.join(sorted(job['gpuRequirements']['CUDACapabilities']))
+                ad['My.CUDACapability'] = classad.quote(str(cudaCapabilities))
+                ad['My.CUDARuntime'] = classad.quote(job['gpuRequirements']['CUDARuntime'])
+            else:
+                ad['My.GPUMemoryMB'] = undefined
+                ad['My.CUDACapability'] = undefined
+                ad['My.CUDARuntime'] = undefined
             # Performance and resource estimates (including JDL magic tweaks)
             origCores = job.get('numberOfCores', 1)
             estimatedMins = int(job['estimatedJobTime'] / 60.0) if job.get('estimatedJobTime') else 12 * 60

--- a/src/python/WMCore/BossAir/RunJob.py
+++ b/src/python/WMCore/BossAir/RunJob.py
@@ -66,6 +66,8 @@ class RunJob(dict):
         self.setdefault('inputPileup', None)
         self.setdefault('allowOpportunistic', False)
         self.setdefault('activity', None)
+        self.setdefault('requiresGPU', 'forbidden')
+        self.setdefault('gpuRequirements', None)
 
         return
 


### PR DESCRIPTION
Fixes #10393 

#### Status
ready

#### Description
This PR implements the GPU handling on the WMAgent side, thus:
* fetch the workflow - actually the task - GPU requirements from the spec
* create the job pickle files with those GPU requirements in JobCreator
* load those GPU requirements in the JobSubmitter 
* define the necessary condor job classads in SimpleCondorPlugin

In terms of condor job description, it has been implemented as:
* `RequiresGPU`: a string that can have one of the following 3 values: ("forbidden", "optional", "required")
  * UPDATE: it will be an integer, either 1 (for required) or 0 (for optional/forbidden)
* `GPUMemoryMB`: undefined if not set in the workflow, otherwise a string object
* `CUDACapabilities`: undefined if not set in the workflow, otherwise a classad.quote object with capabilities comma-separated
  * UPDATE: Antonio suggested to use the default condor attribute, thus renamed to `CUDACapability`
* `CUDARuntime`: undefined if not set in the workflow, otherwise a classad.quote object

NOTE-1: note the custom logic for figuring out whether a task requires GPU or not (for cases with multiple cmsRun steps and with different settings). In short, `required` has precedence over `optional`, which has precedence over `forbidden`
NOTE-2: note that, if different GPUParams are specified for different steps in the same task; we will use the first one with valid key/value pairs (thus, which is not None).
NOTE-3: we are going to start supporting only the mandatory requirements. The remaining 3 optional arguments will be supported in the future, once we gather some experience with the current setup.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Workflow specification provided in: https://github.com/dmwm/WMCore/pull/10799

#### External dependencies / deployment changes
None
