### PR TITLE
Update job priority only for processing and production task types

### DIFF
--- a/src/python/WMCore/BossAir/BossAirAPI.py
+++ b/src/python/WMCore/BossAir/BossAirAPI.py
@@ -689,18 +689,18 @@ class BossAirAPI(WMConnectionBase):
 
         return results
 
-    def updateJobInformation(self, workflow, task, **kwargs):
+    def updateJobInformation(self, workflow, **kwargs):
         """
         _updateJobInformation_
 
-        Update the information of jobs in a particular workflow and task,
+        Update the information of jobs in a particular workflow,
         the data will be updated according the keyword arguments which
         will be interpreted by the individual plugins accordingly.
         """
         for plugin in self.plugins:
             try:
                 pluginInst = self.plugins[plugin]
-                pluginInst.updateJobInformation(workflow, task, **kwargs)
+                pluginInst.updateJobInformation(workflow, **kwargs)
             except WMException:
                 raise
             except Exception as ex:

--- a/src/python/WMCore/BossAir/Plugins/BasePlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/BasePlugin.py
@@ -108,7 +108,7 @@ class BasePlugin(object):
 
         pass
 
-    def updateJobInformation(self, workflow, task, **kwargs):
+    def updateJobInformation(self, workflow, **kwargs):
         """
         _updateJobInformation_
 


### PR DESCRIPTION
Fixes #10445

#### Status
 not-tested

#### Description
Update job priority only for processing/production types

#### Is it backward compatible (if not, which system it affects?)
YES
