### PR TITLE
Skip ErrorHandler cycle if agent configuration fails to be retrieved

### DIFF
--- a/src/python/WMComponent/ErrorHandler/ErrorHandlerPoller.py
+++ b/src/python/WMComponent/ErrorHandler/ErrorHandlerPoller.py
@@ -396,6 +396,11 @@ class ErrorHandlerPoller(BaseWorkerThread):
         """
         logging.debug("Running error handling algorithm")
         self.setupComponentParam()
+        if not self.maxRetries:
+            msg = "Component failed to retrieve agent configuration from central ReqMgr Aux DB."
+            msg += " Skipping this cycle."
+            logging.error(msg)
+            return
 
         try:
             myThread = threading.currentThread()


### PR DESCRIPTION
Fixes #10778 

#### Status
ready

#### Description
If `maxRetries` is not in the format of a dictionary, that means the component failed to retrieve the agent configuration from central couch reqmgr_auxiliary db. In such cases, which have been sporadically happening, we should skip the component cycle to avoid a comparison of different data types (which is no longer a valid case in Python3, and an exception is raised).

We still need to think about an alarm system for all these components, and which conditions to trigger them, but that is for the future in their own GH issues.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
