### PR TITLE
[py2py3] make WMCore/Configuration.py suitable for CRABClient

### DIFF
--- a/src/python/Utils/Utilities.py
+++ b/src/python/Utils/Utilities.py
@@ -6,6 +6,8 @@ from future.utils import viewitems
 from builtins import str, bytes
 from past.builtins import basestring
 
+from Utils.PythonVersion import PY3
+
 import subprocess
 import os
 import re
@@ -294,3 +296,29 @@ def encodeUnicodeToBytesConditional(value, errors="ignore", condition=True):
     if condition:
         return encodeUnicodeToBytes(value, errors)
     return value
+
+
+# listvalues and listitems definitions from Nick Coghlan's (withdrawn)
+# PEP 496:
+try:
+    dict.iteritems
+except AttributeError:
+    # Python 3
+    def listvalues(d):
+        return list(d.values())
+    def listitems(d):
+        return list(d.items())
+else:
+    # Python 2
+    def listvalues(d):
+        return d.values()
+    def listitems(d):
+        return d.items()
+
+
+if PY3:
+    newstr = str
+    newbytes = bytes
+else:
+    newstr = unicode
+    newbytes = str

--- a/src/python/WMCore/Configuration.py
+++ b/src/python/WMCore/Configuration.py
@@ -9,14 +9,11 @@ Module dealing with Configuration file in python format
 
 """
 
-from builtins import object, int, str as newstr, bytes as newbytes
-
-from future.utils import listvalues
-
+from Utils.PythonVersion import PY3
+from Utils.Utilities import listvalues, newstr, newbytes
+        
 import os
 import traceback
-
-from Utils.PythonVersion import PY3
 
 import imp
 


### PR DESCRIPTION
Investigation related to https://github.com/dmwm/CRABClient/issues/4974

#### Status
In development

#### Description

CRABClient needs to be shipped with CMSSW environment that do not ship `python-future`, and CRABClient relies on `WMCore.Configuration`. I am investigating if it is feasible to remove the dependency on python-future from WMCore.Configuration. I do not think this is the correct way to go, i am opening this PR just to have an opinion from jenkins. After it, we can discuss this approach openly. A full run of jenkins unittests is worth 100h of speculation.

#### Is it backward compatible (if not, which system it affects?)
As always: it should be, but we will only discover with certainty after we tested it

#### Related PRs
not yet

#### External dependencies / deployment changes
nope (WMCore in general will continue to depend on `python-future`!)
