### PR TITLE
Fix python version in subprocess call for inject-test-wfs

### DIFF
--- a/test/data/ReqMgr/inject-test-wfs.py
+++ b/test/data/ReqMgr/inject-test-wfs.py
@@ -216,9 +216,12 @@ def main():
     tmpFile = '/tmp/%s.json' % pwd.getpwuid(os.getuid()).pw_name
     wfCounter = 0
 
+    # figure out which python version it is
+    pythonCmd = "python3" if sys.version_info[0] == 3 else "python"
+
     for fname in templates:
         logger.info("Processing template: %s", fname)
-        strComand = "python %s -u %s -f %s -i " % (reqMgrCommand, args.url, tmpFile)
+        strComand = "%s %s -u %s -f %s -i " % (pythonCmd, reqMgrCommand, args.url, tmpFile)
 
         # read the original json template
         with open(wmcorePath + fname) as fo:


### PR DESCRIPTION
Fixes #10846 

#### Status
ready

#### Description
Execute the subprocess call with the correct python binary.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
None

#### External dependencies / deployment changes
None