### PR TITLE
Set request_GPUs classad according to RequiresGPU

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -558,7 +558,12 @@ class SimpleCondorPlugin(BasePlugin):
             ad['My.Requestioslots'] = str(1 if job['task_type'] in ["Merge", "Cleanup", "LogCollect"] else 0)
             # GPU resource handling
             # while we do not support a third option for RequiresGPU, make a binary decision
-            ad['My.RequiresGPU'] = "1" if job['requiresGPU'] == "required" else "0"
+            if job['requiresGPU'] == "required":
+                ad['My.RequiresGPU'] = "1"
+                ad['request_GPUs'] = "1"
+            else:
+                ad['My.RequiresGPU'] = "0"
+                ad['request_GPUs'] = "0"
             if job.get('gpuRequirements', None):
                 ad['My.GPUMemoryMB'] = str(job['gpuRequirements']['GPUMemoryMB'])
                 cudaCapabilities = ','.join(sorted(job['gpuRequirements']['CUDACapabilities']))


### PR DESCRIPTION
Fixes #10848 

#### Status
ready

#### Description
Define a compulsory GPU classad `request_GPUs` to be able to run on GPU resources. Right now, it's hard-wired to 1, thus requesting 1 GPU, but in the future we will refactor it such that it requests the number of GPUs defined at the high level description of the workflow/task.

Note that it's tightly coupled to `RequiresGPU`, and it's set to `1` only when a job requires GPUs.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Complement for https://github.com/dmwm/WMCore/pull/10811

#### External dependencies / deployment changes
None