### PR TITLE
Update wmagent-deploy script to deploy Py3 WMAgent by default; update to cycle 1.5.4

### DIFF
--- a/bin/adhoc-scripts/parseUnifiedCampaigns.py
+++ b/bin/adhoc-scripts/parseUnifiedCampaigns.py
@@ -282,15 +282,11 @@ def insertTestCampaigns(mgr):
                    'SecondaryLocation': ["T1_US_FNAL", "T2_CH_CERN"],
                    'SiteBlackList': [], 'SiteWhiteList': ["T1_US_FNAL", "T2_CH_CERN"]}
 
-    testCamp = ("CMSSW_10_6_1_Step3", "CMSSW_10_6_1_patch1_Step1", "CMSSW_10_6_1_patch1_Step2",
+    testCamp = ("CMSSW_10_6_1_patch1_Step1", "CMSSW_10_6_1_patch1_Step2",
                 "CMSSW_7_3_2__test2inwf-1510737328", "CMSSW_11_2_0_pre6__fullsim_noPU_2021_14TeV-1599843628",
-                "RelVal_Generic_Campaign", "Agent145_Val", "Agent147_Val", "Agent149_Val",
-                "Jan2021_Val", "Feb2021_Val", "Mar2021_Val", "Apr2021_Val",
-                "May2021_Val", "Jun2021_Val", "Jul2021_Val", "Aug2021_Val",
-                "Sept2021_Val", "Oct2021_Val", "Nov2021_Val", "Dec2021_Val",
-                "HG2101_Val", "HG2102_Val", "HG2103_Val", "HG2104_Val",
-                "HG2105_Val", "HG2106_Val", "HG2107_Val", "HG2108_Val",
-                "HG2109_Val", "HG2110_Val", "HG2111_Val", "HG2112_Val")
+                "RelVal_Generic_Campaign", "Agent154_Val", "Agent156_Val", "Agent158_Val",
+                "Oct2021_Val", "Nov2021_Val", "Dec2021_Val", "Jan2022_Val", "Feb2022_Val",
+                "HG2110_Val", "HG2111_Val", "HG2112_Val", "HG2201_Val", "HG2202_Val")
     for campName in testCamp:
         defaultCamp['CampaignName'] = campName
         upload(mgr, defaultCamp)

--- a/deploy/deploy-wmagent.sh
+++ b/deploy/deploy-wmagent.sh
@@ -22,11 +22,11 @@
 ### Usage:               -r <repository>   Comp repository to look for the RPMs (defaults to comp=comp)
 ### Usage:               -p <patches>      List of PR numbers in double quotes and space separated (e.g., "5906 5934 5922")
 ### Usage:               -n <agent_number> Agent number to be set when more than 1 agent connected to the same team (defaults to 0)
-### Usage:               -3|--py3  Uses the python3 stack WMAgent package
+### Usage:               -2|--py2  Uses the python2 stack WMAgent package (soon to be deprecated)
 ### Usage:
 ### Usage: deploy-wmagent.sh -w <wma_version> -d <deployment_tag> -t <team_name> [-s <scram_arch>] [-r <repository>] [-n <agent_number>]
-### Usage: Example: sh deploy-wmagent.sh -w 1.5.2 -d HG2108h -t production -n 30 --py3
-### Usage: Example: sh deploy-wmagent.sh -w 1.5.2 -d HG2108h -t testbed-vocms001 -p "10179" -r comp=comp.amaltaro --py3
+### Usage: Example: sh deploy-wmagent.sh -w 1.5.4.patch3 -d HG2110b -t production -n 30
+### Usage: Example: sh deploy-wmagent.sh -w 1.5.4.patch3 -d HG2110b -t testbed-vocms001 -p "10853" -r comp=comp.amaltaro --py2
 ### Usage:
 
 IAM=`whoami`
@@ -46,7 +46,7 @@ WMA_ARCH=slc7_amd64_gcc630
 REPO="comp=comp"
 AG_NUM=0
 FLAVOR=mysql
-RPM_NAME=wmagent
+RPM_NAME=wmagentpy3
 
 ### Usage function: print the usage of the script
 usage()
@@ -190,7 +190,7 @@ for arg; do
     -r) REPO=$2; shift; shift ;;
     -p) PATCHES=$2; shift; shift ;;
     -n) AG_NUM=$2; shift; shift ;;
-    -3|--py3) RPM_NAME=wmagentpy3; shift;;
+    -2|--py2) RPM_NAME=wmagent; shift;;
     -*) usage ;;
   esac
 done


### PR DESCRIPTION
Fixes #10858 

#### Status
ready

#### Description
If someone wants to deploy WMAgent in python2 stack, a `--py2` option must be provided in the command line. Otherwise, it will deploy a Py3 WMAgent by default.

Also update the CMSWEB and WMCore tag to the latest stable release.

I would suggest to also apply the DBS3 client patch with the following command line:
```
curl https://patch-diff.githubusercontent.com/raw/dmwm/DBS/pull/655.patch | patch -p 4 -d sw/slc7_amd64_gcc630/cms/py3-dbs3-pycurl-client/3.16.2000/lib/python3.8/site-packages/
```

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
None

#### External dependencies / deployment changes
None
