### PR TITLE
Revert temporary fix for CouchDB port forwarding.

### DIFF
--- a/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
+++ b/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
@@ -14,6 +14,7 @@ import threading
 from pprint import pformat
 from Utils.Timers import timeFunction
 from Utils.Utilities import numberCouchProcess
+from Utils.PortForward import PortForward
 from WMComponent.AgentStatusWatcher.DrainStatusPoller import DrainStatusPoller
 from WMComponent.AnalyticsDataCollector.DataCollectAPI import WMAgentDBData, initAgentInfo
 from WMCore.Credential.Proxy import Proxy
@@ -54,6 +55,9 @@ class AgentStatusPoller(BaseWorkerThread):
         self.credThresholds = {'proxy': {'error': 3, 'warning': 5},
                                'certificate': {'error': 10, 'warning': 20}}
 
+        # create a portForwarder to be used for rerouting the replication process
+        self.portForwarder = PortForward(8443)
+
         # Monitoring setup
         self.userAMQ = getattr(config.AgentStatusWatcher, "userAMQ", None)
         self.passAMQ = getattr(config.AgentStatusWatcher, "passAMQ", None)
@@ -77,6 +81,8 @@ class AgentStatusPoller(BaseWorkerThread):
         # set up common replication code
         wmstatsSource = self.config.JobStateMachine.jobSummaryDBName
         wmstatsTarget = self.config.General.centralWMStatsURL
+        wmstatsTarget = self.portForwarder(wmstatsTarget)
+
         self.replicatorDocs.append({'source': wmstatsSource, 'target': wmstatsTarget,
                                     'filter': "WMStatsAgent/repfilter"})
         if self.isT0agent:
@@ -88,7 +94,9 @@ class AgentStatusPoller(BaseWorkerThread):
             # set up workqueue replication
             wqfilter = 'WorkQueue/queueFilter'
             parentQURL = self.config.WorkQueueManager.queueParams["ParentQueueCouchUrl"]
+            parentQURL = self.portForwarder(parentQURL)
             childURL = self.config.WorkQueueManager.queueParams["QueueURL"]
+            childURL = self.portForwarder(childURL)
             query_params = {'childUrl': childURL, 'parentUrl': sanitizeURL(parentQURL)['url']}
             localQInboxURL = "%s_inbox" % self.config.AnalyticsDataCollector.localQueueURL
             self.replicatorDocs.append({'source': sanitizeURL(parentQURL)['url'], 'target': localQInboxURL,


### PR DESCRIPTION
Fixes #10452 

#### Status
In development
DO NOT MERGE YET

#### Description
While reading the history of the whole saga with the CouchDB port forwarding to pot  8443 I figured out there should be nothing more than what was already done on the client side so that the CouchDB sessions  to be rerouted to port 8443. The only place  we should look at is the server side. So what we suspect is an eventual reply from the server side by  default to port 443. For that purpose we need to:
 * Revert the temporary fix provided with this PR https://github.com/dmwm/WMCore/pull/10453
 * Redeploy an agent patched with the current PR 
 * Increase the CouchDB log level on the server side so that we can take a better look at the server logs: https://github.com/dmwm/deployment/blob/master/couchdb/local.ini

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
N/A

#### External dependencies / deployment changes
To be estimated on a later stage.