### PR TITLE
Make task GPU lookup backwards compatible

### DIFF
--- a/src/python/WMCore/WMSpec/WMStep.py
+++ b/src/python/WMCore/WMSpec/WMStep.py
@@ -69,16 +69,18 @@ class WMStepHelper(TreeHelper):
         """
         Return whether GPU is required or not for this step object
         """
-        if hasattr(self.data.application.gpu, "gpuRequired"):
-            return self.data.application.gpu.gpuRequired
+        if hasattr(self.data.application, "gpu"):
+            if hasattr(self.data.application.gpu, "gpuRequired"):
+                return self.data.application.gpu.gpuRequired
         return None
 
     def getGPURequirements(self):
         """
         Return the GPU requirements for this step object
         """
-        if hasattr(self.data.application.gpu, "gpuRequirements"):
-            return self.data.application.gpu.gpuRequirements
+        if hasattr(self.data.application, "gpu"):
+            if hasattr(self.data.application.gpu, "gpuRequirements"):
+                return self.data.application.gpu.gpuRequirements
         return None
 
     def addStep(self, stepName):

--- a/test/python/WMCore_t/WMSpec_t/WMStep_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMStep_t.py
@@ -162,8 +162,7 @@ class WMStepTest(unittest.TestCase):
         wmStep = makeWMStep("step1")
         self.assertIsNone(wmStep.stepType())
         self.assertFalse(hasattr(wmStep.data, "gpu"))
-        with self.assertRaises(AttributeError):
-            wmStep.getGPURequired()
+        self.assertIsNone(wmStep.getGPURequired())
 
         # now apply the CMSSW template
         wmStep.setStepType("CMSSW")

--- a/test/python/WMCore_t/WMSpec_t/WMTask_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMTask_t.py
@@ -867,9 +867,9 @@ class WMTaskTest(unittest.TestCase):
                     self.assertEqual(stepHelper.getGPURequired(), "forbidden")
                     self.assertIsNone(stepHelper.getGPURequirements())
                 else:
-                    # AttributeError: 'ConfigSection' object has no attribute 'gpu'
-                    with self.assertRaises(AttributeError):
-                        stepHelper.getGPURequired()
+                    # 'ConfigSection' object has no attribute 'gpu'
+                    self.assertIsNone(stepHelper.getGPURequired())
+
 
         ### Now set a single value for both tasks
         gpuParams = {"GPUMemoryMB": 1234, "CUDARuntime": "11.2.3", "CUDACapabilities": ["7.5", "8.0"]}
@@ -893,6 +893,11 @@ class WMTaskTest(unittest.TestCase):
             taskName = taskObj.name()
             self.assertEqual(taskObj.getRequiresGPU(), gpuRequired[taskName])
             self.assertItemsEqual(taskObj.getGPURequirements(), gpuParams[taskName])
+
+        # Now delete the "gpu" ConfigSection to make sure we can deal with older workloads/tasks
+        for taskObj in task1.taskIterator():
+            delattr(taskObj.data.steps.cmsRun1.application, "gpu")
+            self.assertEqual(taskObj.getRequiresGPU(), "forbidden")
 
     def testGPUTaskSettingsMultiStep(self):
         """


### PR DESCRIPTION
Fixes #10865 

#### Status
ready

#### Description
Given that the system has a mix of non-GPU and GPU-aware workflows, we need to make sure the GPU configuration lookup is backwards compatible. Otherwise JobCreator is the first component to crash in case a `gpu` ConfigSection cannot be found.

When that section is not available, simply return the default values, which are:
* RequiresGPU: forbidden
* GPUParams: {}

TODO: need to check how verbose that logging.info is going to be...

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
