### PR TITLE
Remove leading ../../ from logArchive tarballs

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Executors/LogArchive.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/LogArchive.py
@@ -181,9 +181,9 @@ class LogArchive(Executor):
         tarName = 'logArchive.tar.gz'
         tarBallLocation = os.path.join(self.stepSpace.location, tarName)
         with tarfile.open(tarBallLocation, 'w:gz') as tarBall:
-            for f in logFilesToArchive:
-                tarBall.add(name=f,
-                            arcname=f.replace(self.stepSpace.taskSpace.location, '', 1).lstrip('/'))
+            for fName in logFilesToArchive:
+                altName = fName.replace(pilotScratchDir, '', 1)
+                tarBall.add(name=fName, arcname=altName)
 
         fileInfo = {'LFN': self.getLFN(tarName),
                     'PFN': tarBallLocation,


### PR DESCRIPTION
Fixes #10867 

#### Status
ready

#### Description
The `arcname` option allow us to specify an alternative name for the file in the tarball archive. It turns out we were removing only part of the initial path, instead of removing the `../../` as well.

With this change, files inside the tarball should all be set as a top level/directory.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
