### PR TITLE
Fix arguments for T0 workflows

### DIFF
--- a/src/python/WMCore/Services/Service.py
+++ b/src/python/WMCore/Services/Service.py
@@ -308,17 +308,27 @@ class Service(dict):
             # from a cachefile, and that cachefiles can be good/stale/dead.
             #
             if force_refresh or isfile(cachefile) or not os.path.exists(cachefile):
-                msg = 'The cachefile %s does not exist and the service at %s'
-                msg = msg % (cachefile, self["requests"]['host'] + url)
-                if hasattr(he, 'status') and hasattr(he, 'reason'):
-                    msg += ' is unavailable - it returned %s because %s' % (he.status,
-                                                                            he.reason)
-                    if hasattr(he, 'result'):
-                        msg += ' with result: %s\n' % he.result
-                else:
-                    msg += ' raised a %s when accessed' % he.__repr__()
-                self['logger'].warning(msg)
-                raise he
+                try:
+                    if not os.path.exists(cachefile):
+                        pathfile=cachefile.split("/")
+                        pathfile="/"+"/".join(pathfile[1:-1])
+                        os.makedirs(pathfile, exist_ok=True)
+                        with open(cachefile, 'w') as f:
+                            if isinstance(data, dict) or isinstance(data, list):
+                                f.write(json.dumps(data))
+                            else:
+                                f.write(data)
+                except:
+                    msg = 'The cachefile %s does not exist and the service at %s'
+                    msg = msg % (cachefile, self["requests"]['host'] + url)
+                    if hasattr(he, 'status') and hasattr(he, 'reason'):
+                        msg += ' is unavailable - it returned %s because %s' % (he.status,he.reason)
+                        if hasattr(he, 'result'):
+                            msg += ' with result: %s\n' % he.result
+                        else:
+                            msg += ' raised a %s when accessed' % he.__repr__()
+                        self['logger'].warning(msg)
+                        raise he
             else:
                 cache_dead = cache_expired(cachefile, delta=self["cacheduration"])
                 if cache_dead:

--- a/src/python/WMCore/WMSpec/StdSpecs/Express.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Express.py
@@ -17,7 +17,7 @@ from future.utils import viewitems
 
 import WMCore.WMSpec.Steps.StepFactory as StepFactory
 from Utils.Utilities import makeList, makeNonEmptyList
-from WMCore.Lexicon import procstringT0
+from WMCore.Lexicon import procstringT0, globalTag, validateUrl
 from WMCore.ReqMgr.Tools.cms import releases, architectures
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
 
@@ -470,29 +470,38 @@ class ExpressWorkloadFactory(StdBase):
     def getWorkloadCreateArgs():
         baseArgs = StdBase.getWorkloadCreateArgs()
         specArgs = {"RequestType": {"default": "Express"},
+                    "RequestString": {"default": "", "validate": procstringT0},
                     "ConfigCacheID": {"optional": True, "null": True},
-                    "Scenario": {"optional": False, "attr": "procScenario"},
+                    "Scenario": {"optional": False, "attr": "procScenario", "validate":lambda x: True if type(x) == str else False},
                     "RecoCMSSWVersion": {"validate": lambda x: x in releases(),
                                          "optional": False, "attr": "recoFrameworkVersion"},
                     "RecoScramArch": {"validate": lambda x: all([y in architectures() for y in x]),
                                       "optional": False, "type": makeNonEmptyList},
-                    "GlobalTag": {"optional": False},
-                    "GlobalTagTransaction": {"optional": False},
+                    "GlobalTag": {"optional": False, "validate": globalTag},
+                    "GlobalTagTransaction": {"optional": False,  "validate":procstringT0},#Needs proper validation in lexicon,
                     "ProcessingString": {"default": "", "validate": procstringT0},
-                    "StreamName": {"optional": False},
-                    "SpecialDataset": {"optional": False},
-                    "AlcaHarvestTimeout": {"type": int, "optional": False},
-                    "AlcaHarvestCondLFNBase": {"optional": False, "null": True},
-                    "AlcaHarvestLumiURL": {"optional": False, "null": True},
-                    "AlcaSkims": {"type": makeList, "optional": False},
-                    "DQMSequences": {"type": makeList, "attr": "dqmSequences", "optional": False},
-                    "Outputs": {"type": makeList, "optional": False},
-                    "MaxInputRate": {"type": int, "optional": False},
-                    "MaxInputEvents": {"type": int, "optional": False},
-                    "MaxInputSize": {"type": int, "optional": False},
-                    "MaxInputFiles": {"type": int, "optional": False},
-                    "MaxLatency": {"type": int, "optional": False},
-
+                    "StreamName": {"optional": False, "validate":procstringT0},
+                    "SpecialDataset": {"optional": False, "validate":procstringT0},
+                    "AlcaHarvestTimeout": {"type": int, "optional": False, "validate": lambda x: x >= 0},
+                    "AlcaHarvestCondLFNBase": {"optional": False, "null": True, "validate": lambda x: x in ("/store/unmerged/tier0_harvest/2021")},#Need proper validation in lexicon
+                    "AlcaHarvestLumiURL": {"optional": False, "null": True, "validate":lambda x: x in ("root://eoscms.cern.ch//eos/cms/store/unmerged/tier0_harvest/2021")},#Need proper validation in lexicon
+                    "AlcaSkims": {"type": makeList, "optional": False, "validate": lambda x: True if type(x) == list else False},
+                    "DQMSequences": {"type": makeList, "attr": "dqmSequences", "optional": False, "validate": lambda x: True if type(x) == list else False},
+                    "Outputs": {"type": makeList, "optional": False, "validate": lambda x: True if type(x) == list else False},
+                    "MaxInputRate": {"type": int, "optional": False, "validate": lambda x: x >= 0},
+                    "MaxInputEvents": {"type": int, "optional": False, "validate": lambda x: x >= 0},
+                    "MaxInputSize": {"type": int, "optional": False, "validate": lambda x: x >= 0},
+                    "MaxInputFiles": {"type": int, "optional": False, "validate": lambda x: x >= 0},
+                    "MaxLatency": {"type": int, "optional": False, "validate": lambda x: x >= 0},
+                    "GlobalTagConnect": {"null": True, "validate": lambda x: True if type(x) == str else False},#Needs proper validation function by Lexicon
+                    "DQMUploadUrl": {"default": "https://cmsweb.cern.ch/dqm/dev", "attr": "dqmUploadUrl", "validate":validateUrl},
+                    "MergedLFNBase": {"default": "/store/data", "validate": lambda x: x in ("/store/data","/store/backfill/1/data","/store/backfill/1/express")},#Needs proper validation function by Lexicon
+                    "UnmergedLFNBase": {"default": "/store/unmerged", "validate": lambda x: x in ("/store/unmerged","/store/unmerged/data","/store/unmerged/express")},#Needs proper validation function by Lexicon
+                    "Requestor": {"attr": "owner", "optional": False, "validate": lambda x: x in ("Tier0")},
+                    "RequestorDN": {"attr": "owner_dn", "optional": False, "null": False, "validate": lambda x: x in ("Tier0")},
+                    "RequestTransition": {"optional": False, "type": list, "validate": lambda x: True if type(x) == list else False},
+                    "PriorityTransition": {"optional": False, "type": list, "validate": lambda x: True if type(x) == list else False},
+                    "RequestDate": {"optional": False, "type": list, "validate": lambda x: True if type(x) == list else False},
                     }
         baseArgs.update(specArgs)
         StdBase.setDefaultArgumentsProperty(baseArgs)

--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -8,7 +8,7 @@ from __future__ import division
 from future.utils import viewitems
 
 from Utils.Utilities import makeList, strToBool
-from WMCore.Lexicon import procstringT0
+from WMCore.Lexicon import procstringT0, globalTag, validateUrl
 from WMCore.WMSpec.StdSpecs.DataProcessing import DataProcessing
 
 
@@ -169,16 +169,17 @@ class PromptRecoWorkloadFactory(DataProcessing):
     def getWorkloadCreateArgs():
         baseArgs = DataProcessing.getWorkloadCreateArgs()
         specArgs = {"RequestType": {"default": "PromptReco", "optional": True},
+                    "RequestString": {"default": "", "validate": procstringT0},
                     "ConfigCacheID": {"optional": True, "null": True},
                     "Scenario": {"default": None, "optional": False,
-                                 "attr": "procScenario", "null": False},
+                                 "attr": "procScenario", "null": False, "validate":lambda x: True if type(x) == str else False},#Need proper validation in lexicon
                     "ProcessingString": {"default": "", "validate": procstringT0},
                     "WriteTiers": {"default": ["RECO", "AOD", "DQM", "ALCARECO"],
-                                   "type": makeList, "optional": False, "null": False},
+                                   "type": makeList, "optional": False, "null": False, "validate": lambda x: True if type(x) == list else False},
                     "AlcaSkims": {"default": ["TkAlCosmics0T", "MuAlGlobalCosmics", "HcalCalHOCosmics"],
-                                  "type": makeList, "optional": False, "null": False},
+                                  "type": makeList, "optional": False, "null": False, "validate": lambda x: True if type(x) == list else False},
                     "PhysicsSkims": {"default": [], "type": makeList,
-                                     "optional": True, "null": False},
+                                     "optional": True, "null": False, "validate": lambda x: True if type(x) == list else False},
                     "InitCommand": {"default": None, "optional": True, "null": True},
                     "EnvPath": {"default": None, "optional": True, "null": True},
                     "BinPath": {"default": None, "optional": True, "null": True},
@@ -200,7 +201,21 @@ class PromptRecoWorkloadFactory(DataProcessing):
                                         "null": False},
                     "SkimFilesPerJob": {"default": 1, "type": int, "validate": lambda x: x > 0,
                                         "null": False},
+                    "GlobalTag": {"optional": False, "validate": globalTag},
+                    "GlobalTagConnect": {"null": True, "validate": lambda x: True if type(x) == str else False},#Needs proper validation function by Lexicon
+                    "DQMUploadUrl": {"default": "https://cmsweb.cern.ch/dqm/dev", "attr": "dqmUploadUrl", "validate":validateUrl},
+                    "DQMSequences": {"type": makeList, "attr": "dqmSequences", "optional": False, "validate": lambda x: True if type(x) == list else False},
+                    "EnableHarvesting": {"default": False, "type": strToBool, "validate": lambda x: True if type(x) == bool else False},
+                    "RobustMerge": {"default": True, "type": strToBool, "validate": lambda x: True if type(x) == bool else False},
+                    "Requestor": {"attr": "owner", "optional": False, "validate": lambda x: x in ("Tier0")},
+                    "RequestorDN": {"attr": "owner_dn", "optional": False, "null": False, "validate": lambda x: x in ("Tier0")},
+                    "RequestTransition": {"optional": False, "type": list, "validate": lambda x: True if type(x) == list else False},
+                    "PriorityTransition": {"optional": False, "type": list, "validate": lambda x: True if type(x) == list else False},
+                    "RequestDate": {"optional": False, "type": list, "validate": lambda x: True if type(x) == list else False},
+                    "MergedLFNBase": {"default": "/store/data", "validate": lambda x: x in ("/store/data","/store/backfill/1/data")},
+                    "UnmergedLFNBase": {"default": "/store/unmerged", "validate": lambda x: x in ("/store/unmerged","/store/unmerged/data")},
                     }
+
 
         baseArgs.update(specArgs)
         DataProcessing.setDefaultArgumentsProperty(baseArgs)

--- a/src/python/WMCore/WMSpec/StdSpecs/Repack.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Repack.py
@@ -11,7 +11,7 @@ repacking -> RAW -> optional merge
 from __future__ import division
 
 from Utils.Utilities import makeList
-from WMCore.Lexicon import procstringT0
+from WMCore.Lexicon import procstringT0, globalTag
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
 
 
@@ -184,20 +184,21 @@ class RepackWorkloadFactory(StdBase):
     def getWorkloadCreateArgs():
         baseArgs = StdBase.getWorkloadCreateArgs()
         specArgs = {"RequestType": {"default": "Repack"},
+                    "RequestString": {"default": "", "validate": procstringT0},
                     "ConfigCacheID": {"optional": True, "null": True},
-                    "Scenario": {"default": "fake", "attr": "procScenario"},
-                    "GlobalTag": {"default": "fake"},
+                    "Scenario": {"default": "fake", "attr": "procScenario", "validate":lambda x: True if type(x) == str else False},
+                    "GlobalTag": {"default": "fake", "validate": globalTag},
                     "ProcessingString": {"default": "", "validate": procstringT0},
-                    "Outputs": {"type": makeList, "optional": False},
-                    "MaxSizeSingleLumi": {"type": int, "optional": False},
-                    "MaxSizeMultiLumi": {"type": int, "optional": False},
-                    "MaxInputEvents": {"type": int, "optional": False},
-                    "MaxInputFiles": {"type": int, "optional": False},
-                    "MaxLatency": {"type": int, "optional": False},
-                    "MinInputSize": {"type": int, "optional": False},
-                    "MaxInputSize": {"type": int, "optional": False},
-                    "MaxEdmSize": {"type": int, "optional": False},
-                    "MaxOverSize": {"type": int, "optional": False},
+                    "Outputs": {"type": makeList, "optional": False, "validate": lambda x: True if type(x) == list else False},
+                    "MaxSizeSingleLumi": {"type": int, "optional": False, "validate": lambda x: x >= 0},
+                    "MaxSizeMultiLumi": {"type": int, "optional": False, "validate": lambda x: x >= 0},
+                    "MaxInputEvents": {"type": int, "optional": False, "validate": lambda x: x >= 0},
+                    "MaxInputFiles": {"type": int, "optional": False, "validate": lambda x: x >= 0},
+                    "MaxLatency": {"type": int, "optional": False, "validate": lambda x: x >= 0},
+                    "MinInputSize": {"type": int, "optional": False, "validate": lambda x: x >= 0},
+                    "MaxInputSize": {"type": int, "optional": False, "validate": lambda x: x >= 0},
+                    "MaxEdmSize": {"type": int, "optional": False, "validate": lambda x: x >= 0},
+                    "MaxOverSize": {"type": int, "optional": False, "validate": lambda x: x >= 0},
                     }
         baseArgs.update(specArgs)
         StdBase.setDefaultArgumentsProperty(baseArgs)

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -1050,7 +1050,7 @@ class StdBase(object):
                      "VoRole": {"default": "unknown", "attr": "owner_vorole"},
                      "ValidStatus": {"default": "PRODUCTION"},
                      "OverrideCatalog": {"null": True},
-                     "RunNumber": {"default": 0, "type": int},
+                     "RunNumber": {"default": 0, "type": int, "validate": lambda x: x > 0},
                      "RobustMerge": {"default": True, "type": strToBool},
                      "Comments": {"default": ""},
                      "SubRequestType": {"default": "", "validate": subRequestType},

--- a/src/python/WMCore/WMSpec/WMWorkloadTools.py
+++ b/src/python/WMCore/WMSpec/WMWorkloadTools.py
@@ -299,7 +299,7 @@ def validateArgumentsCreate(arguments, argumentDefinition, checkInputDset=True):
     otherwise returns None.
     """
     validateUnknownArgs(arguments, argumentDefinition)
-    _validateArgumentOptions(arguments, argumentDefinition, "optional")
+    _validateArgumentOptions(arguments, argumentDefinition, "optional")#Validation optional arg T0 workflows
     if checkInputDset:
         validateInputDatasSetAndParentFlag(arguments)
     return


### PR DESCRIPTION
Fix an issue with "missing" arguments for T0 Repack workflows that triggered a nested wmexceptions. Related to tmp wmcache file

Fixes #10800 

#### Status
Tested with T0 replay

#### Description
Digging within the nested wmexceptions after the warning
```
WARNING:Service:The cachefile /tmp/cmst0/.wmcore_cache_xlpsm5ls/cmssdt.cern.ch/-3895757188456107843_GET__SDT_cgi-bin_ReleasesXML_ does not exi
st and the service at https://cmssdt.cern.ch/SDT/cgi-bin/ReleasesXML/ raised a FileNotFoundError(2, 'No such file or directory') when accessed
```
The issue that triggers the chain is during the Repack workflow arguments validation. Checking StdSpecs/Repack.py all the arguments that are used on T0 agent are described in that piece of the code. But I found within StdSpecs that the function **factoryWorkloadConstruction**  is defined in StdBase.py and Resubmission.py and are kind of similar. 
The changes that I made was to retrieve some functions from Resubmission.py and  adapt those for the T0 agent.
Still,  is not clear to me why this validation of the repack arguments trigger the issue with the cache file,  and why this happened during the transition between  python2-wmcore-agent and python3-wmcore-agent due that this PR is not needed if a python2 T0 agent is created/deployed.
 
Also if production doesn't run Repack workflows that may be the cause that this issue did not affect the deployment of python3 version of WMAgent.

At least I believe this makes it clear that the problem is not due to the configuration of the T0 vms.

#### Is it backward compatible (if not, which system it affects?)
Maybe. 

#### Related PRs
Other proposal to fix #10800 is using #10801

#### External dependencies / deployment changes
No
