### PR TITLE
Support a different Rucio account in WorkQueue

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -140,6 +140,7 @@ config.WorkQueueManager.queueParams["QueueURL"] = "http://%s:5984" % (config.Age
 config.WorkQueueManager.queueParams["WorkPerCycle"] = 200  # don't pull more than this number of elements per cycle
 config.WorkQueueManager.queueParams["QueueDepth"] = 0.5  # pull work from GQ for only half of the resources
 config.WorkQueueManager.queueParams["rucioAccount"] = "wmcore_transferor"  # account for data locks
+config.WorkQueueManager.queueParams["rucioAccountRelVal"] = "wmcore_transferor_relval"  # account for data locks
 
 
 config.component_("DBS3Upload")

--- a/src/python/WMCore/WorkQueue/WorkQueueReqMgrInterface.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueReqMgrInterface.py
@@ -90,7 +90,7 @@ class WorkQueueReqMgrInterface(object):
             self.logger.warning(msg)
             return 0
 
-        for team, reqName, workLoadUrl in workLoads:
+        for team, reqName, workLoadUrl, subReqType in workLoads:
             try:
                 try:
                     Lexicon.couchurl(workLoadUrl)
@@ -101,7 +101,7 @@ class WorkQueueReqMgrInterface(object):
                         raise error
 
                 self.logger.info("Processing request %s at %s" % (reqName, workLoadUrl))
-                units = queue.queueWork(workLoadUrl, request=reqName, team=team)
+                units = queue.queueWork(workLoadUrl, request=reqName, team=team, subRequestType=subReqType)
                 self.logdb.delete(reqName, "error", this_thread=True, agent=False)
             except TERMINAL_EXCEPTIONS as ex:
                 # fatal error - report back to ReqMgr
@@ -222,7 +222,7 @@ class WorkQueueReqMgrInterface(object):
         filteredResults.sort(key=itemgetter('RequestPriority'), reverse=True)
         filteredResults.sort(key=lambda r: r["Team"])
 
-        results = [(x["Team"], x["RequestName"], x["RequestWorkflow"]) for x in filteredResults]
+        results = [(x["Team"], x["RequestName"], x["RequestWorkflow"], x["SubRequestType"]) for x in filteredResults]
 
         return results
 


### PR DESCRIPTION
Fixes #10254 

#### Status
In development

#### Description
Work in progress for the input data placement/location separation in global and local workqueue.

#### Is it backward compatible (if not, which system it affects?)
no

#### Related PRs
None

#### External dependencies / deployment changes
Deployment changes
