### PR TITLE
Add validation to the SubRequestType parameter

### DIFF
--- a/src/python/WMCore/Lexicon.py
+++ b/src/python/WMCore/Lexicon.py
@@ -702,6 +702,15 @@ def primaryDatasetType(candidate):
     raise AssertionError("Invalid primary dataset type : %s should be 'mc' or 'data' or 'test'" % candidate)
 
 
+def subRequestType(candidate):
+    subTypes = ["MC", "ReDigi", "Pilot", "RelVal", "HIRelVal", "ReReco", ""]
+    if candidate in subTypes:
+        return True
+    # to sync with the check() exception when it doesn't match
+    msg = "Invalid SubRequestType value: '{}'. Allowed values are: {}".format(candidate, subTypes)
+    raise AssertionError(msg)
+
+
 def activity(candidate):
     dashboardActivities = ['reprocessing', 'production', 'relval', 'tier0', 't0',
                            'harvesting', 'storeresults', 'integration',

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -15,8 +15,9 @@ from Utils.PythonVersion import PY3
 from Utils.Utilities import decodeBytesToUnicodeConditional
 from Utils.Utilities import makeList, makeNonEmptyList, strToBool, safeStr
 from WMCore.Cache.WMConfigCache import ConfigCache, ConfigCacheException
-from WMCore.Lexicon import couchurl, procstring, activity, procversion, primdataset, gpuParameters
-from WMCore.Lexicon import lfnBase, identifier, acqname, cmsname, dataset, block, campaign
+from WMCore.Lexicon import (couchurl, procstring, activity, procversion, primdataset,
+                            gpuParameters, lfnBase, identifier, acqname, cmsname,
+                            dataset, block, campaign, subRequestType)
 from WMCore.ReqMgr.DataStructs.RequestStatus import REQUEST_START_STATE
 from WMCore.ReqMgr.Tools.cms import releases, architectures
 from WMCore.Services.PhEDEx.DataStructs.SubscriptionList import PhEDEx_VALID_SUBSCRIPTION_PRIORITIES
@@ -1052,7 +1053,7 @@ class StdBase(object):
                      "RunNumber": {"default": 0, "type": int},
                      "RobustMerge": {"default": True, "type": strToBool},
                      "Comments": {"default": ""},
-                     "SubRequestType": {"default": ""},  # used only(?) for RelVals
+                     "SubRequestType": {"default": "", "validate": subRequestType},
                      "RequiresGPU": {"default": "forbidden",
                                      "validate": lambda x: x in ("forbidden", "optional", "required")},
                      "GPUParams": {"default": json.dumps(None), "validate": gpuParameters},

--- a/test/python/WMCore_t/Lexicon_t.py
+++ b/test/python/WMCore_t/Lexicon_t.py
@@ -1023,6 +1023,20 @@ class LexiconTest(unittest.TestCase):
         self.assertTrue(_gpuInternalParameters({"GPUMemoryMB": 12345, "CUDACapabilities": ["1.2", "2.3", "2.3.4"],
                                                 "CUDARuntime": "2.3.4"}))
 
+    def testSubRequestType(self):
+        """
+        Test some task and step names
+        """
+        # valid values
+        for cand in ["MC", "ReDigi", "Pilot", "RelVal", "HIRelVal", "ReReco", ""]:
+            self.assertTrue(subRequestType(cand))
+
+        # now invalid ones
+        self.assertRaises(AssertionError, subRequestType, None)
+        self.assertRaises(AssertionError, subRequestType, "test")
+        self.assertRaises(AssertionError, subRequestType, ["blah"])
+        self.assertRaises(AssertionError, subRequestType, 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #10282 

#### Status
ready

#### Description
The `SubRequestType` base spec parameter has been adopted already by a couple of Microservices, and we are going to extend its use in the framework, so we better start validating these values to make sure that the expected values are provided.

If request is created with an invalid value, it fails workflow creation.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None