### PR TITLE
Remove check of RSE dump root_failed attr in MSUnmerged

### DIFF
--- a/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
+++ b/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
@@ -403,8 +403,6 @@ class MSUnmerged(MSCore):
 
         isConsDone = self.rseConsStats[rseName]['status'] == 'done'
         isConsNewer = self.rseConsStats[rseName]['end_time'] > self.rseTimestamps[rseName]['prevStartTime']
-        isRootFailed = self.rseConsStats[rseName]['root_failed']
-
         if not isConsNewer:
             msg = "RSE: %s With old consistency record in Rucio Consistency Monitor. " % rseName
             msg += "Skipping it in the current run."
@@ -412,11 +410,6 @@ class MSUnmerged(MSCore):
             raise MSUnmergedPlineExit(msg)
         if not isConsDone:
             msg = "RSE: %s In non-final state in Rucio Consistency Monitor. " % rseName
-            msg += "Skipping it in the current run."
-            self.logger.warning(msg)
-            raise MSUnmergedPlineExit(msg)
-        if isRootFailed:
-            msg = "RSE: %s With failed root in Rucio Consistency Monitor. " % rseName
             msg += "Skipping it in the current run."
             self.logger.warning(msg)
             raise MSUnmergedPlineExit(msg)


### PR DESCRIPTION
Fixes #10893 

#### Status
ready

#### Description
Instead of using both `status` and `root_failed` to verify whether the RSE unmerged dump was successful or not, use only the `status` attribute.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
Deployment changes: https://github.com/dmwm/deployment/pull/1102
