### PR TITLE
Initial MongoDB setup for MSUnmerged.

### DIFF
--- a/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
+++ b/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
@@ -27,6 +27,9 @@ except ImportError:
     # in case we do not have gfal2 installed
     print("FAILED to import gfal2. Use it only in emulateGfal2=True mode!!!")
     gfal2 = None
+
+from pymongo import IndexModel
+
 # WMCore modules
 from WMCore.MicroService.DataStructs.DefaultStructs import UNMERGED_REPORT
 from WMCore.MicroService.MSCore import MSCore
@@ -34,6 +37,7 @@ from WMCore.MicroService.MSUnmerged.MSUnmergedRSE import MSUnmergedRSE
 from WMCore.Services.RucioConMon.RucioConMon import RucioConMon
 from WMCore.Services.WMStatsServer.WMStatsServer import WMStatsServer
 # from WMCore.Services.AlertManager.AlertManagerAPI import AlertManagerAPI
+from WMCore.Database.MongoDB import MongoDB
 from WMCore.WMException import WMException
 from Utils.Pipeline import Pipeline, Functor
 from Utils.TwPrint import twFormat
@@ -95,12 +99,30 @@ class MSUnmerged(MSCore):
         self.msConfig.setdefault("skipRSEs", [])
         self.msConfig.setdefault("rseExpr", "*")
         self.msConfig.setdefault("enableRealMode", False)
-        self.msConfig.setdefault("dumpRSE", False)
+        self.msConfig.setdefault("fullRSEToDB", False)
         self.msConfig.setdefault("gfalLogLevel", 'normal')
         self.msConfig.setdefault("dirFilterIncl", [])
         self.msConfig.setdefault("dirFilterExcl", [])
         self.msConfig.setdefault("emulateGfal2", False)
         self.msConfig.setdefault("filesToDeleteSliceSize", 100)
+
+        self.msConfig.setdefault("mongoDBUrl", 'mongodb://localhost')
+        self.msConfig.setdefault("mongoDBPort", 27017)
+        self.msConfig.setdefault("mongoDB", 'msUnmergedDB')
+
+        msUnmergedIndex = IndexModel('name', unique=True)
+        msUnmergedDBConfig = {
+            'database': self.msConfig['mongoDB'],
+            'server': self.msConfig['mongoDBUrl'],
+            'port': self.msConfig['mongoDBPort'],
+            'logger': self.logger,
+            'create': True,
+            'collections': [('msUnmergedColl', msUnmergedIndex)]}
+
+        mongoClt = MongoDB(**msUnmergedDBConfig)
+        self.msUnmergedDB = getattr(mongoClt, self.msConfig['mongoDB'])
+        self.msUnmergedColl = self.msUnmergedDB['msUnmergedColl']
+
         if self.msConfig['emulateGfal2'] is False and gfal2 is None:
             msg = "Failed to import gfal2 library while it's not "
             msg += "set to emulate it. Crashing the service!"
@@ -118,7 +140,8 @@ class MSUnmerged(MSCore):
         # Building all the Pipelines:
         pName = 'plineUnmerged'
         self.plineUnmerged = Pipeline(name=pName,
-                                      funcLine=[Functor(self.updateRSETimestamps, start=True, end=False),
+                                      funcLine=[Functor(self.getRSEFromMongoDB),
+                                                Functor(self.updateRSETimestamps, start=True, end=False),
                                                 Functor(self.consRecordAge),
                                                 Functor(self.getUnmergedFiles),
                                                 Functor(self.filterUnmergedFiles),
@@ -126,7 +149,8 @@ class MSUnmerged(MSCore):
                                                 Functor(self.cleanRSE),
                                                 Functor(self.updateRSECounters, pName),
                                                 Functor(self.updateRSETimestamps, start=False, end=True),
-                                                Functor(self.purgeRseObj, dumpRSE=self.msConfig['dumpRSE'])])
+                                                Functor(self.uploadRSEToMongoDB),
+                                                Functor(self.purgeRseObj)])
         # Initialization of the deleted files counters:
         self.rseCounters = {}
         self.plineCounters = {}
@@ -584,17 +608,18 @@ class MSUnmerged(MSCore):
         return rse
 
     # @profile
-    def purgeRseObj(self, rse, dumpRSE=False):
+    def purgeRseObj(self, rse, dumpRSEtoLog=False):
         """
         Cleaning all the records in an RSE object. The final method to be used
         before an RSE exits a pipeline.
         :param rse: The RSE to be checked
+        :param dumpRSEToLog: Dump the whole RSEobject into the service log.
         :return:    rse
         """
         msg = "\n----------------------------------------------------------"
         msg += "\nMSUnmergedRSE: \n%s"
         msg += "\n----------------------------------------------------------"
-        if dumpRSE:
+        if dumpRSEtoLog:
             self.logger.debug(msg, pformat(rse))
         else:
             self.logger.debug(msg, twFormat(rse, maxLength=6))
@@ -611,17 +636,22 @@ class MSUnmerged(MSCore):
         rseName = rse['name']
         currTime = time()
 
+        # Initialize the timestamps in both MSUnmerged and MSUnmergedRSE objects
         if rseName not in self.rseTimestamps:
-            self.rseTimestamps[rseName] = {'prevStartTime': 0.0,
-                                           'startTime': 0.0,
-                                           'prevEndtime': 0.0,
-                                           'endTime': 0.0}
+            # NOTE: Reading the timestamps from the rse for the first time.
+            #       This will reset them if no previous record for the RSE in MongoDB
+            #       or will set them to the values fetched from MongoDB, provided
+            #       that the RSE object has been updated from the database.
+            self.rseTimestamps[rseName] = rse['timestamps']
+
+        # Update the timestamps:
         if start:
             self.rseTimestamps[rseName]['prevStartTime'] = self.rseTimestamps[rseName]['startTime']
             self.rseTimestamps[rseName]['startTime'] = currTime
         if end:
             self.rseTimestamps[rseName]['prevEndtime'] = self.rseTimestamps[rseName]['endTime']
             self.rseTimestamps[rseName]['endtime'] = currTime
+        rse['timestamps'] = self.rseTimestamps[rseName]
         return rse
 
     def updateRSECounters(self, rse, pName):
@@ -689,6 +719,24 @@ class MSUnmerged(MSCore):
             self.plineCounters[plineName]['rsesProcessed'] = 0
             self.plineCounters[plineName]['rsesCleaned'] = 0
         return
+
+    def getRSEFromMongoDB(self, rse):
+        """
+        Updates the record for an RSE from MongoDB
+        :param rse: The RSE object to work on
+        :return:    rse
+        """
+        rse.readRSEFromMongoDB(self.msUnmergedColl)
+        return rse
+
+    def uploadRSEToMongoDB(self, rse, fullRSEToDB=False, overwrite=True):
+        """
+        Updates the record for an RSE at MongoDB
+        :param rse: The RSE object to work on
+        :return:    rse
+        """
+        rse.writeRSEToMongoDB(self.msUnmergedColl, fullRSEToDB=fullRSEToDB, overwrite=overwrite)
+        return rse
 
     # @profile
     def getRSEList(self):

--- a/src/python/WMCore/MicroService/MSUnmerged/MSUnmergedRSE.py
+++ b/src/python/WMCore/MicroService/MSUnmerged/MSUnmergedRSE.py
@@ -3,6 +3,9 @@ File       : MSUnmergedRSE.py
 Description: Provides a document Template for the MSUnmerged MicroServices
 """
 
+from pymongo import ReturnDocument
+# from pymongo.results import results as MongoResults
+
 
 class MSUnmergedRSE(dict):
     """
@@ -25,11 +28,14 @@ class MSUnmergedRSE(dict):
         #          '/store/unmerged/Run2018B/TOTEM42/MINIAOD/22Feb2019-v1': <filter at 0x7f3699d93208>,
         #          '/store/unmerged/Run2018B/TOTEM21/AOD/22Feb2019-v1': <filter at 0x7f3699d93128>,
         #          '/store/unmerged/Run2018D/MuonEG/RAW-RECO/TopMuEG-12Nov2019_UL2018-v1': <filter at 0x7f3699d93668>}
-        self.allUnmerged = []
         myDoc = {
             "name": rseName,
             "pfnPrefix": None,
             "isClean": False,
+            "timestamps": {'prevStartTime': 0.0,
+                           'startTime': 0.0,
+                           'prevEndtime': 0.0,
+                           'endTime': 0.0},
             "counters": {"totalNumFiles": 0,
                          "dirsToDeleteAll": 0,
                          "dirsToDelete": 0,
@@ -43,6 +49,99 @@ class MSUnmergedRSE(dict):
                       "deletedFail": []},
             "dirs": {"allUnmerged": set(),
                      "toDelete": set(),
-                     "protected": set(),
-                     "empty": []}}
+                     "protected": set()}
+        }
         self.update(myDoc)
+        self.mongoFilter = {'name': self['name']}
+
+    def buildMongoProjection(self, fullRSEToDB=False):
+        """
+        Returns the correct mongoProjection based on the `fullRSEToDB` flag passed
+        :param fullRSEToDB: Flag to decide whether the whole RSE object is to be
+                        included in the projection ergo saved into the database.
+        :return:        A dictionary type MongoDB Projection
+        """
+        mongoProjection = {
+            "_id": False,
+            "name": True,
+            "pfnPrefix": True,
+            "isClean" : True,
+            "timestamps": True,
+            "counters": True,
+            "files": False,
+            "dirs": True}
+        if fullRSEToDB:
+            mongoProjection.update({"files": True})
+        return mongoProjection
+
+    def readRSEFromMongoDB(self, collection):
+        """
+        A method to read the RSE object from Database and update it's fields.
+        :param collection: The MongoDB collection to read from
+        :return:           True if read and update were both successful, False otherwise.
+        """
+        mongoRecord = collection.find_one(self.mongoFilter)
+
+        # update the list fields read from MongoDB back to strictly pythonic `set`s
+        if mongoRecord:
+            for dirKey, dirList in mongoRecord['dirs'].items():
+                mongoRecord['dirs'][dirKey] = set(dirList)
+            self.update(mongoRecord)
+            return True
+        else:
+            return False
+
+    def writeRSEToMongoDB(self, collection, fullRSEToDB=False, overwrite=False):
+        """
+        A method to write/update the RSE at the Database from the current object.
+        :param collection: The MonogoDB collection to write on
+        :param fullRSEToDB:    Bool flag, used to trigger dump of the whole RSE object to
+                           the database with the `files` section (excluding the generator objects)
+                           NOTE: if fullRSEToDB=False and a previous record for the RSE already exists
+                                 the fields missing from the projection won't be updated
+                                 during this write operation but will preserver their values.
+                                 To completely refresh and RSE record in the database use
+                                 self.purgeRSEAtMongoDB first.
+        :param overwrite:  A flag to note if the currently existing document into
+                           the database is about to be completely replaced or just
+                           fields update is to happen.
+        :return:           True if update was successful, False otherwise.
+        """
+        # NOTE: The fields to be manipulated are only those which are compatible
+        #       with MongoDB (i.e. here we avoid any field holding a strictly
+        #       pythonic objects, like generators etc.)
+
+        updateFields = {}
+        mongoProjection = self.buildMongoProjection(fullRSEToDB)
+        for field in mongoProjection:
+            if mongoProjection[field]:
+                # convert back the strictly pythonic `set`s && `generators` to Json compatible lists
+                if field == 'dirs':
+                    updateFields[field] = {}
+                    for dirKey, dirSet in self[field].items():
+                        updateFields[field][dirKey] = list(dirSet)
+                elif field == 'files':
+                    updateFields[field] = {}
+                    for fileKey, fileSet in self[field].items():
+                        if isinstance(self[field][fileKey], dict):
+                            updateFields[field][fileKey] = list(self[field][fileKey])
+                        else:
+                            updateFields[field][fileKey] = self[field][fileKey]
+                else:
+                    updateFields[field] = self[field]
+
+        updateOps = {'$set': updateFields}
+        if overwrite:
+            result = collection.replace_one(self.mongoFilter,
+                                            updateFields,
+                                            upsert=True)
+        else:
+            result = collection.update_one(self.mongoFilter,
+                                           updateOps,
+                                           upsert=True)
+        # NOTE: If and `upsert` took place the modified_count for both operations is 0
+        #       because no modification took place  but rather an insertion.
+        if result.modified_count or result.upserted_id:
+            return True
+        else:
+            return False


### PR DESCRIPTION
Fixes #10798 

#### Status
Ready

#### Description
This PR is providing the basic functionalities we need to be able to write the proper structure to MongoDB for the MSUnmerged micro service.

#### Is it backward compatible (if not, which system it affects?)
NO, once we have that merged we  need to have a MongoDB instance configured and running. It will also break several stuff related to the microservice work itself:
 * We may no longer rely on refreshing the timers from memory, since we are about to be preserving those in the database
 * We will keep accumulating garbage records in the fields  of the RSE object if we just update and never clean the RSE record at the database upon refresh of the RSE read on the RucioConMon side  

#### Related PRs
Here are the configuration commits related to the initial MongoDb setup [1]. We are using the MongoDB as a service instance so far and distinguishing between service instances by database names (fetched from service_config).

[1]
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/121/diffs
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/122/diffs

#### External dependencies / deployment changes
We need to propagate the correct passwords in the relevant password file (this is happening in a private mode with the cmsweb Team)