### PR TITLE
Fix path for Py2/Py3 WMAgent component logs in the restart script

### DIFF
--- a/deploy/restartComponent.sh
+++ b/deploy/restartComponent.sh
@@ -2,9 +2,17 @@
 
 HOST=`hostname`
 DATENOW=`date +%s`
+
+# Figure whether it's a python2 or python3 agent
+if [ -d "/data/srv/wmagent/current/install/wmagent" ]; then
+  WMA_PATH="/data/srv/wmagent/current/install/wmagent"
+else
+  WMA_PATH="/data/srv/wmagent/current/install/wmagentpy3"
+fi
+
 COMPONENTS="ErrorHandler JobSubmitter AgentStatusWatcher"
 for comp in $COMPONENTS; do
-  COMPLOG=/data/srv/wmagent/current/install/wmagent/$comp/ComponentLog
+  COMPLOG=$WMA_PATH/$comp/ComponentLog
   LASTCHANGE=`stat -c %Y $COMPLOG`
   INTERVAL=`expr $DATENOW - $LASTCHANGE`
   if (("$INTERVAL" >= 1800)); then
@@ -16,7 +24,7 @@ for comp in $COMPONENTS; do
 
     . /data/admin/wmagent/env.sh
     TAIL_LOG=`tail -n100 $COMPLOG`
-    /data/srv/wmagent/current/config/wmagent/manage execute-agent wmcoreD --restart --components=$comp
+    $WMA_PATH/manage execute-agent wmcoreD --restart --components=$comp
     echo -e "ComponentLog quiet for $INTERVAL secs\n\nTail of the log is:\n$TAIL_LOG" |
       mail -s "$HOST : $comp restarted" alan.malta@cern.ch,todor.trendafilov.ivanov@cern.ch
   fi


### PR DESCRIPTION
Fixes #10896 

#### Status
ready

#### Description
Checks which agent we have deployed and use the proper path to the manage script and component logs.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
