### PR TITLE
Adding --deep option to getReplicaInfoForBlocks

### DIFF
--- a/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
+++ b/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
@@ -21,6 +21,7 @@ from WMCore.DAOFactory import DAOFactory
 from WMCore.Services.Rucio.Rucio import Rucio, WMRucioException, RUCIO_VALID_PROJECT
 from WMCore.WMException import WMException
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
+from Utils.IteratorTools import grouper
 
 
 class RucioInjectorException(WMException):
@@ -77,6 +78,9 @@ class RucioInjectorPoller(BaseWorkerThread):
                            hostUrl=config.RucioInjector.rucioUrl,
                            authUrl=config.RucioInjector.rucioAuthUrl,
                            configDict={'logger': self.logger})
+
+        self.useDsetReplicaDeep = getattr(config.RucioInjector, "useDsetReplicaDeep", False)
+        self.delBlockSlicesize = getattr(config.RucioInjector, "delBlockSlicesize", 100)
 
         # metadata dictionary information to be added to block/container rules
         # cannot be a python dictionary, but a JSON string instead
@@ -341,69 +345,74 @@ class RucioInjectorPoller(BaseWorkerThread):
 
         logging.info("Found %d candidate blocks for rule deletion", len(blockDict))
 
-        blocksToDelete = []
-        containerDict = {}
-        # Populate containerDict, assigning each block to its correspondant container
-        for blockName in blockDict:
-            container = blockDict[blockName]['dataset']
-            # If the container is not in the dictionary, create a new entry for it
-            if container not in containerDict:
-                # Set of sites to which the container needs to be transferred
-                sites = set(x.replace("_MSS", "_Tape") for x in blockDict[blockName]['sites'])
-                containerDict[container] = {'blocks': [], 'rse': sites}
-            containerDict[container]['blocks'].append(blockName)
+        for blocksSlice in grouper(blockDict, self.delBlockSlicesize):
+            logging.info("Handeling %d candidate blocks", len(blocksSlice))
+            containerDict = {}
+            # Populate containerDict, assigning each block to its correspondant container
+            for blockName in blocksSlice:
+                container = blockDict[blockName]['dataset']
+                # If the container is not in the dictionary, create a new entry for it
+                if container not in containerDict:
+                    # Set of sites to which the container needs to be transferred
+                    sites = set(x.replace("_MSS", "_Tape") for x in blockDict[blockName]['sites'])
+                    containerDict[container] = {'blocks': [], 'rse': sites}
+                containerDict[container]['blocks'].append(blockName)
 
-        for contName in containerDict:
-            cont = containerDict[contName]
+            blocksToDelete = []
+            for contName in containerDict:
+                cont = containerDict[contName]
 
-            # Checks if the container is not requested in any sites.
-            # This should never be triggered, but better safe than sorry
-            if not cont['rse']:
-                logging.warning("No rules for container: %s. Its blocks won't be deleted.", contName)
-                continue
-
-            try:
-                # Get RSE in which each block is available
-                availableRSEs = self.rucio.getReplicaInfoForBlocks(block=cont['blocks'])
-            except Exception as exc:
-                msg = "Failed to get replica info for blocks in container: %s.\n" % contName
-                msg += "Will retry again in the next cycle. Error: %s" % str(exc)
-                logging.error(msg)
-                continue
-
-            for blockRSEs in availableRSEs:
-                # If block is available at every RSE its container needs to be transferred, the block can be deleted
-                blockSites = set(blockRSEs['replica'])
-                if cont['rse'].issubset(blockSites):
-                    blocksToDelete.append(blockRSEs['name'])
-
-        # Delete agent created rules locking the block
-        binds = []
-        logging.info("Going to delete %d block rules", len(blocksToDelete))
-        for block in blocksToDelete:
-            try:
-                rules = self.rucio.listDataRules(block, scope=self.scope, account=self.rucioAcct)
-            except WMRucioException as exc:
-                logging.warning("Unable to retrieve replication rules for block: %s. Will retry in the next cycle.", block)
-            else:
-                if not rules:
-                    logging.info("Block rule for: %s has been deleted by previous cycles", block)
-                    binds.append({'DELETED': 1, 'BLOCKNAME': block})
+                # Checks if the container is not requested in any sites.
+                # This should never be triggered, but better safe than sorry
+                if not cont['rse']:
+                    logging.warning("No rules for container: %s. Its blocks won't be deleted.", contName)
                     continue
-                for rule in rules:
-                    deletedRules = 0
-                    if self.rucio.deleteRule(rule['id'], purgeReplicas=True):
-                        logging.info("Successfully deleted rule: %s, for block %s.", rule['id'], block)
-                        deletedRules += 1
-                    else:
-                        logging.warning("Failed to delete rule: %s, for block %s. Will retry in the next cycle.", rule['id'], block)
-                if deletedRules == len(rules):
-                    binds.append({'DELETED': 1, 'BLOCKNAME': block})
-                    logging.info("Successfully deleted all rules for block %s.", block)
+
+                try:
+                    # Get RSE in which each block is available
+                    availableRSEs = self.rucio.getReplicaInfoForBlocks(block=cont['blocks'], deep=self.useDsetReplicaDeep)
+                except Exception as exc:
+                    msg = "Failed to get replica info for blocks in container: %s.\n" % contName
+                    msg += "Will retry again in the next cycle. Error: %s" % str(exc)
+                    logging.error(msg)
+                    continue
+
+                for blockRSEs in availableRSEs:
+                    # If block is available at every RSE its container needs to be transferred, the block can be deleted
+                    blockSites = set(blockRSEs['replica'])
+                    logging.debug("BlockName: %s", blockRSEs['name'])
+                    logging.debug("Needed: %s / Available: %s", str(cont['rse']), str(blockSites))
+                    if cont['rse'].issubset(blockSites):
+                        blocksToDelete.append(blockRSEs['name'])
+
+            # Delete agent created rules locking the block
+            binds = []
+            logging.info("Going to delete %d block rules", len(blocksToDelete))
+            for block in blocksToDelete:
+                try:
+                    rules = self.rucio.listDataRules(block, scope=self.scope, account=self.rucioAcct)
+                except WMRucioException as exc:
+                    logging.warning("Unable to retrieve replication rules for block: %s. Will retry in the next cycle.", block)
+                else:
+                    if not rules:
+                        logging.info("Block rule for: %s has been deleted by previous cycles", block)
+                        binds.append({'DELETED': 1, 'BLOCKNAME': block})
+                        continue
+                    for rule in rules:
+                        deletedRules = 0
+                        if self.rucio.deleteRule(rule['id'], purgeReplicas=True):
+                            logging.info("Successfully deleted rule: %s, for block %s.", rule['id'], block)
+                            deletedRules += 1
+                        else:
+                            logging.warning("Failed to delete rule: %s, for block %s. Will retry in the next cycle.", rule['id'], block)
+                    if deletedRules == len(rules):
+                        binds.append({'DELETED': 1, 'BLOCKNAME': block})
+                        logging.info("Successfully deleted all rules for block %s.", block)
 
 
-        self.markBlocksDeleted.execute(binds)
-        logging.info("Marked %d blocks as deleted in the database", len(binds))
+            self.markBlocksDeleted.execute(binds)
+            logging.info("Marked %d blocks as deleted in the database", len(binds))
+
         return
 
     def insertContainerRules(self):

--- a/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
+++ b/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
@@ -224,6 +224,15 @@ class RucioTest(EmulatedUnitTestCase):
         for item in res:
             self.assertTrue(len(item['replica']) > 0)
 
+        #Setting  deep=True should yield the same results
+        res = self.myRucio.getReplicaInfoForBlocks(dataset=DSET, deep=True)
+        self.assertTrue(isinstance(res, list))
+        self.assertTrue(len(res) >= 1)  # Again, there are 11 replicas
+        blocks = [item['name'] for item in res]
+        self.assertTrue(BLOCK in blocks)
+        for item in res:
+            self.assertTrue(len(item['replica']) > 0)
+
     def testGetPFN(self):
         """
         Test `getPFN` method


### PR DESCRIPTION
Fixes #10901 

#### Status
ready

#### Description
Added `deep` option to  [Rucio.getReplicaInfoForBlocks()](https://github.com/dmwm/WMCore/blob/4b6676a4350addd15b6e9abe48a4e41e5217d920/src/python/WMCore/Services/Rucio/Rucio.py#L239). The value of the flag can be changed in RucioInjector config.

Also added slicing to [RucioInjectorPooler.deleteBlocks()](https://github.com/dmwm/WMCore/blob/4b6676a4350addd15b6e9abe48a4e41e5217d920/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py#L325) to avoid  problems in case of a high number of deletable datasets.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
NO

#### External dependencies / deployment changes
NO
