### PR TITLE
Use siteLocalConfig in logCollect jobs to specify output site

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
@@ -22,6 +22,7 @@ from WMCore.Storage.StageOutMgr import StageOutMgr
 from WMCore.WMRuntime.Tools.Scram import Scram, getSingleScramArch, isCMSSWSupported
 from WMCore.WMSpec.Steps.Executor import Executor
 from WMCore.WMSpec.Steps.WMExecutionFailure import WMExecutionFailure
+from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig
 
 
 class LogCollect(Executor):
@@ -65,6 +66,9 @@ class LogCollect(Executor):
         overrides = {}
         if hasattr(self.step, 'override'):
             overrides = self.step.override.dictionary_()
+            if overrides.get('logRedirectSiteLocalConfig', None):
+                siteCfg = loadSiteLocalConfig()
+                overrides.update(siteCfg.localStageOut)
 
         # Set wait to over an hour
         waitTime = overrides.get('waitTime', 3600 + (self.step.retryDelay * self.step.retryCount))


### PR DESCRIPTION
Fixes #10903

#### Status
ready

#### Description
Add possibility of specifying stage out parameters via siteLocalConfig.
Add setters and getters for steps override section

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs


#### External dependencies / deployment changes

