### PR TITLE
Adapt MSUnmerged to sync RSE data with MongoDB properly

### DIFF
--- a/src/python/WMCore/MicroService/MSUnmerged/MSUnmergedRSE.py
+++ b/src/python/WMCore/MicroService/MSUnmerged/MSUnmergedRSE.py
@@ -3,7 +3,6 @@ File       : MSUnmergedRSE.py
 Description: Provides a document Template for the MSUnmerged MicroServices
 """
 
-from pymongo import ReturnDocument
 from pymongo.errors  import NotMasterError
 # from pymongo.results import results as MongoResults
 

--- a/src/python/WMCore/MicroService/MSUnmerged/MSUnmergedRSE.py
+++ b/src/python/WMCore/MicroService/MSUnmerged/MSUnmergedRSE.py
@@ -4,6 +4,7 @@ Description: Provides a document Template for the MSUnmerged MicroServices
 """
 
 from pymongo import ReturnDocument
+from pymongo.errors  import NotMasterError
 # from pymongo.results import results as MongoResults
 
 
@@ -15,6 +16,15 @@ class MSUnmergedRSE(dict):
     def __init__(self, rseName, **kwargs):
         super(MSUnmergedRSE, self).__init__(**kwargs)
 
+        self.rseName = rseName
+        self.update(self.defaultDoc())
+        self.mongoFilter = {'name': self['name']}
+
+    def defaultDoc(self):
+        """
+        Returns the data schema for a record in MongoDB.
+        :return: A simple dictionary populated with default values
+        """
         # NOTE: totalNumFiles reflects the total number of files at the RSE as
         #       fetched from the Rucio Consistency Monitor. Once the relevant
         #       protected paths have been filtered out and the path been cut to the
@@ -28,13 +38,14 @@ class MSUnmergedRSE(dict):
         #          '/store/unmerged/Run2018B/TOTEM42/MINIAOD/22Feb2019-v1': <filter at 0x7f3699d93208>,
         #          '/store/unmerged/Run2018B/TOTEM21/AOD/22Feb2019-v1': <filter at 0x7f3699d93128>,
         #          '/store/unmerged/Run2018D/MuonEG/RAW-RECO/TopMuEG-12Nov2019_UL2018-v1': <filter at 0x7f3699d93668>}
-        myDoc = {
-            "name": rseName,
+        defaultDoc = {
+            "name": self.rseName,
             "pfnPrefix": None,
             "isClean": False,
-            "timestamps": {'prevStartTime': 0.0,
+            "timestamps": {'rseConsStatTime': 0.0,
+                           'prevStartTime': 0.0,
                            'startTime': 0.0,
-                           'prevEndtime': 0.0,
+                           'prevEndTime': 0.0,
                            'endTime': 0.0},
             "counters": {"totalNumFiles": 0,
                          "dirsToDeleteAll": 0,
@@ -51,8 +62,7 @@ class MSUnmergedRSE(dict):
                      "toDelete": set(),
                      "protected": set()}
         }
-        self.update(myDoc)
-        self.mongoFilter = {'name': self['name']}
+        return defaultDoc
 
     def buildMongoProjection(self, fullRSEToDB=False):
         """
@@ -74,13 +84,19 @@ class MSUnmergedRSE(dict):
             mongoProjection.update({"files": True})
         return mongoProjection
 
-    def readRSEFromMongoDB(self, collection):
+    def readRSEFromMongoDB(self, collection, useProjection=False):
         """
         A method to read the RSE object from Database and update it's fields.
         :param collection: The MongoDB collection to read from
+        :param useProjection: Use the projection returned by self.buildProjection()
+                              while reading from MongoDB
         :return:           True if read and update were both successful, False otherwise.
         """
-        mongoRecord = collection.find_one(self.mongoFilter)
+        if useProjection:
+            mongoProjection = self.buildMongoProjection()
+            mongoRecord = collection.find_one(self.mongoFilter, projection=mongoProjection)
+        else:
+            mongoRecord = collection.find_one(self.mongoFilter)
 
         # update the list fields read from MongoDB back to strictly pythonic `set`s
         if mongoRecord:
@@ -91,21 +107,26 @@ class MSUnmergedRSE(dict):
         else:
             return False
 
-    def writeRSEToMongoDB(self, collection, fullRSEToDB=False, overwrite=False):
+    def writeRSEToMongoDB(self, collection, fullRSEToDB=False, overwrite=False, retryCount=0):
         """
         A method to write/update the RSE at the Database from the current object.
-        :param collection: The MonogoDB collection to write on
+        :param collection:     The MonogoDB collection to write on
         :param fullRSEToDB:    Bool flag, used to trigger dump of the whole RSE object to
-                           the database with the `files` section (excluding the generator objects)
-                           NOTE: if fullRSEToDB=False and a previous record for the RSE already exists
-                                 the fields missing from the projection won't be updated
-                                 during this write operation but will preserver their values.
-                                 To completely refresh and RSE record in the database use
-                                 self.purgeRSEAtMongoDB first.
-        :param overwrite:  A flag to note if the currently existing document into
-                           the database is about to be completely replaced or just
-                           fields update is to happen.
-        :return:           True if update was successful, False otherwise.
+                               the database with the `files` section (excluding the generator objects)
+                               NOTE: if fullRSEToDB=False and a previous record for the RSE already exists
+                                     the fields missing from the projection won't be updated
+                                     during this write operation but will preserver their values.
+                                     To completely refresh and RSE record in the database use
+                                     self.purgeRSEAtMongoDB first.
+        :param overwrite:      A flag to note if the currently existing document into
+                               the database is about to be completely replaced or just
+                               fields update is to happen.
+        :param retryCount:     The number of retries for the write operation if failed due to
+                               `NotMasterError. Possible values:
+                               0   - the write operation will be tried exactly once and no retries will happen
+                               > 0 - the write operation will be retried this number of times
+                               < 0 - the write operation will never be tried
+        :return:               True if update was successful, False otherwise.
         """
         # NOTE: The fields to be manipulated are only those which are compatible
         #       with MongoDB (i.e. here we avoid any field holding a strictly
@@ -124,24 +145,58 @@ class MSUnmergedRSE(dict):
                     updateFields[field] = {}
                     for fileKey, fileSet in self[field].items():
                         if isinstance(self[field][fileKey], dict):
-                            updateFields[field][fileKey] = list(self[field][fileKey])
+                            # Iterating through the filterNames here, and recording only empty lists for filter values
+                            # NOTE: We can either execute the filter and write every single file in the database
+                            #       or if we need it we may simply use the filterName to recreate it.
+                            updateFields[field][fileKey] = dict([(filterName, []) for filterName in list(self[field][fileKey])])
                         else:
                             updateFields[field][fileKey] = self[field][fileKey]
                 else:
                     updateFields[field] = self[field]
 
         updateOps = {'$set': updateFields}
-        if overwrite:
-            result = collection.replace_one(self.mongoFilter,
-                                            updateFields,
-                                            upsert=True)
-        else:
-            result = collection.update_one(self.mongoFilter,
-                                           updateOps,
-                                           upsert=True)
+        # NOTE: NotMasterError is a recoverable error, caused by a session to a
+        #       non primary backend part of a replicaset.
+        while retryCount >= 0:
+            try:
+                if overwrite:
+                    result = collection.replace_one(self.mongoFilter, updateFields, upsert=True)
+                else:
+                    result = collection.update_one(self.mongoFilter, updateOps, upsert=True)
+                break
+            except NotMasterError:
+                if retryCount:
+                    msg = "Failed write operation to MongoDB. %s retries left."
+                    self.logger.warning(msg, retryCount)
+                    retryCount -= 1
+                else:
+                    msg = "Failed write operation to MongoDB. All retries exhausted."
+                    self.logger.warning(msg, retryCount)
+                    raise
+
         # NOTE: If and `upsert` took place the modified_count for both operations is 0
         #       because no modification took place  but rather an insertion.
         if result.modified_count or result.upserted_id:
             return True
         else:
             return False
+
+    def resetRSE(self, collection, keepTimestamps=False, keepCounters=False, retryCount=0):
+        """
+        Resets all records of the RSE object to default values  and write the
+        document to MongoDB
+        :param keepTimestamps: Bool flag to keep the timestamps
+        :param keepCounters:   Bool flag to keep the counters
+        :param retryCount:     The number of retries for the write operation if failed due to `NotMasterError.
+        :return:               True if operation succeeded.
+        """
+        resetDoc = self.defaultDoc()
+
+        if keepTimestamps:
+            resetDoc['timestamps'] = self['timestamps']
+        if keepCounters:
+            resetDoc['counters'] = self['counters']
+
+        self.update(resetDoc)
+        writeResult = self.writeRSEToMongoDB(collection, fullRSEToDB=True, overwrite=True, retryCount=retryCount)
+        return writeResult


### PR DESCRIPTION
Fixes #10797 

#### Status
ready

#### Description
The current PR is supposed to resolve few  issues which were introduced with adding MongoDB as a backend database for the service, which are making the service not backward compatible:
 * After preserving the timestamps into the database we are getting into the situation that a RSE would be retried only once in a through out a span of a single Rucio Consistency Monitor poling cycle. now we should be able to retry the RSE in case it was not previously completely cleaned
 * If we have a fresh new record for the RSE in the Rucio Consistency Monitor and we do not wipe out all the provious file records for that RSE in MongoDB, then we are about to start accumulating old records. With this PR we are resetting the object if a brand new record is present in Rucio Consistency Monitor.

#### Is it backward compatible (if not, which system it affects?)
NO

#### Related PRs
No additional configurations PRs are required, but it is worth mentioning the previous PR:
https://github.com/dmwm/WMCore/pull/10895

#### External dependencies / deployment changes
<Does it require deployment changes? Does it rely on third-party libraries?>
