### PR TITLE
Add replicaset opotion to the MongoDB wrapper.

### DIFF
--- a/src/python/WMCore/Database/MongoDB.py
+++ b/src/python/WMCore/Database/MongoDB.py
@@ -19,10 +19,12 @@ class MongoDB(object):
                  database=None,
                  server=None,
                  port=None,
+                 replicaset=None,
                  create=False,
                  collections=None,
                  testIndexes=False,
-                 logger=None):
+                 logger=None,
+                 **kwargs):
         """
         :databases:   A database Name to connect to
         :server:      The server url (see https://docs.mongodb.com/manual/reference/connection-string/)
@@ -40,7 +42,10 @@ class MongoDB(object):
         self.port = port # 8230
         self.logger = logger
         try:
-            self.client = MongoClient(self.server, self.port)
+            if replicaset:
+                self.client = MongoClient(self.server, self.port, replicaset=replicaset, **kwargs )
+            else:
+                self.client = MongoClient(self.server, self.port, **kwargs)
             self.client.server_info()
         except Exception as ex:
             msg = "Could not connect to MongoDB server: %s\n%s" % (self.server, str(ex))

--- a/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
+++ b/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
@@ -109,12 +109,14 @@ class MSUnmerged(MSCore):
         self.msConfig.setdefault("mongoDBUrl", 'mongodb://localhost')
         self.msConfig.setdefault("mongoDBPort", 27017)
         self.msConfig.setdefault("mongoDB", 'msUnmergedDB')
+        self.msConfig.setdefault("mongoDBReplicaset", None)
 
         msUnmergedIndex = IndexModel('name', unique=True)
         msUnmergedDBConfig = {
             'database': self.msConfig['mongoDB'],
             'server': self.msConfig['mongoDBUrl'],
             'port': self.msConfig['mongoDBPort'],
+            'replicaset': self.msConfig['mongoDBReplicaset'],
             'logger': self.logger,
             'create': True,
             'collections': [('msUnmergedColl', msUnmergedIndex)]}


### PR DESCRIPTION
Fixes #10907 

#### Status
ready

#### Description
With the current PR we add the ability to connect to a named replicaset instead to a single MongoDB server. as explained in the issue we have two options of doing this either describing the whole cluster server by server in the MongoDB url as:
```
client = MongoClient('mongodb://localhost:27017,localhost:27018/?replicaSet=replicaset')
```
or just connecting to the load balanced name and provide the replicaset name so that  in case the connection has happened to a secondary instead of a primary backend server, the MonogoDB client may resolve the situation during write operations:
```
client = MongoClient(server, port, replicaset=replicaset)
```  

#### Is it backward compatible (if not, which system it affects?)
YES
#### Related PRs
The commits to service configuration for adding the option for MSUnmerged: 
[preprod](https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/123/diffs?commit_id=f7d7118623aefe1f70e13f15900166355cfe7892)
and 
[prod](https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/122/diffs?commit_id=781b8294bb740c520261b6654d9d6be93ccac167)
 

#### External dependencies / deployment changes
None
