### PR TITLE
Update CMSCouchapp version for python3 stack

### DIFF
--- a/requirements_py3.txt
+++ b/requirements_py3.txt
@@ -31,4 +31,4 @@ pymongo==3.10.1
 retry==0.9.2
 Sphinx==4.0.3
 CMSMonitoring==0.3.4
-CMSCouchapp==1.3.2
+CMSCouchapp==1.3.4


### PR DESCRIPTION
Fixes #10909

#### Status
ready

#### Description
Update the requirements list of python packages for our python3 stack. We are already using the CMSCouchapp version 1.3.4, which has a more relaxed dependency on the requests library. See:
https://github.com/cms-sw/cmsdist/blob/comp_gcc630/py3-cmscouchapp.spec#L1

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
