### PR TITLE
Update pylint version required from 2.6.0 to 2.7.0

### DIFF
--- a/requirements_py3.txt
+++ b/requirements_py3.txt
@@ -26,7 +26,7 @@ nose2==0.10.0
 nose==1.3.7
 pep8==1.7.1
 psutil==5.8.0
-pylint==2.6.0
+pylint==2.7.0
 pymongo==3.10.1
 retry==0.9.2
 Sphinx==4.0.3


### PR DESCRIPTION
Superseeds https://github.com/dmwm/WMCore/pull/10892

#### Status
ready

#### Description
This new version of pylint is required to fix two security vulnerabilities, as listed by this automatic Snyk PR:
https://github.com/dmwm/WMCore/pull/10892

I am not adding the `urllib3` dependency because none of the WMCore services has a direct dependency on that library, besides, we are already using a version that contains that fix (1.26.6).

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
cmsdist spec: https://github.com/cms-sw/cmsdist/pull/7494
