### PR TITLE
[py3] REST/Server.py - encode to bytes input of hashlib.sha1

### DIFF
--- a/src/python/WMCore/REST/Server.py
+++ b/src/python/WMCore/REST/Server.py
@@ -19,6 +19,8 @@ from WMCore.REST.Error import *
 from WMCore.REST.Format import *
 from WMCore.REST.Validation import validate_no_more_input
 
+from Utils.Utilities import encodeUnicodeToBytes
+
 try:
     from cherrypy.lib import httputil
 except:
@@ -312,7 +314,7 @@ class RESTFrontPage(object):
         response.headers['Content-Type'] = ctype
         response.headers['Last-Modified'] = httputil.HTTPDate(mtime)
         response.headers['Cache-Control'] = "public, max-age=%d" % 86400
-        response.headers['ETag'] = '"%s"' % hashlib.sha1(result).hexdigest()
+        response.headers['ETag'] = '"%s"' % hashlib.sha1(encodeUnicodeToBytes(result)).hexdigest()
         cherrypy.lib.cptools.validate_since()
         cherrypy.lib.cptools.validate_etags()
         return result


### PR DESCRIPTION
Fixes #10916

#### Status

Ready, tested in CRABServer test and preprod instances 

This webpage https://cmsweb-testbed.cern.ch/crabserver/ui/ is being server by a build of CRABserver that contiains this fix: https://github.com/mapellidario/WMCore/releases/tag/py3.211209

Since we are building CRABServer against our private repo, which contains this fix, we do not have any hurry in mergins this PR.

#### Description

Make sure that the input of `hashlib.sha1()` is bytes.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none
