### PR TITLE
Add dbs3-pycurl client dependency

### DIFF
--- a/requirements_py3.txt
+++ b/requirements_py3.txt
@@ -32,3 +32,5 @@ retry==0.9.2
 Sphinx==4.0.3
 CMSMonitoring==0.3.4
 CMSCouchapp==1.3.4
+dbs3-pycurl>=3.17.7
+dbs3-client>=4.0.4


### PR DESCRIPTION
Required for https://github.com/dmwm/WMCore/pull/10911

#### Status
ready

#### Description
WMCore code relies on RestClient from DBS:
```
src/python/WMCore/Services/DBS/DBS3Reader.py
18:from RestClient.ErrorHandling.RestClientExceptions import HTTPError

src/python/WMQuality/Emulators/DBSClient/MockDbsApi.py
15:from RestClient.ErrorHandling.RestClientExceptions import HTTPError

src/python/WMQuality/Emulators/DBSClient/MakeDBSMockFiles.py
19:from RestClient.ErrorHandling.RestClientExceptions import HTTPError

src/python/WMQuality/Emulators/CRICClient/MockCRICApi.py
14:from RestClient.ErrorHandling.RestClientExceptions import HTTPError
```
As such it should have it in its dependencies

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs

#### External dependencies / deployment changes
