### PR TITLE
Add getStatsFromMongoDB to MSUnmerged.

### DIFF
--- a/src/python/WMCore/MicroService/MSManager.py
+++ b/src/python/WMCore/MicroService/MSManager.py
@@ -32,7 +32,7 @@ from datetime import datetime
 # WMCore modules
 from WMCore.MicroService.Tools.Common import getMSLogger
 from WMCore.MicroService.TaskManager import start_new_thread
-
+from Utils.Utilities import strToBool
 
 def daemon(func, reqStatus, interval, logger):
     "Daemon to perform given function action for all request in our store"
@@ -295,8 +295,7 @@ class MSManager(object):
         :param reqName: request name
         :param kwargs: other arguments that can be provided for different
             microservices. Examples:
-            rse_type: string with the type of the RSEs to fetch (MSUnmerged)
-                      Meaningful values at the moment are: "t1", "t2t3" and "t2t3us"
+            rse: string with the name of the RSE (e.g 'T2_DE_DESY')
         :return: data transfer information for this request
         """
         if 'ruleCleaner' in self.services or 'unmerged' in self.services:
@@ -317,8 +316,10 @@ class MSManager(object):
                 data['transferDoc'] = transferDoc[0]
 
         if 'unmerged' in self.services:
-            if kwargs.get("rse_type"):
-                data = {"rse_type": kwargs.get("rse_type")}
+            detail = strToBool(kwargs.get('detail', False))
+
+            if kwargs.get("rse"):
+                data = self.msUnmerged.getStatsFromMongoDB(detail=detail, rse=kwargs['rse'])
         return data
 
     def delete(self, request):

--- a/src/python/WMCore/MicroService/Service/Data.py
+++ b/src/python/WMCore/MicroService/Service/Data.py
@@ -32,7 +32,7 @@ from Utils.Patterns import Singleton
 from WMCore.REST.Server import RESTEntity, restcall
 from WMCore.REST.Tools import tools
 # from WMCore.REST.Validation import validate_rx, validate_str
-from WMCore.REST.Format import JSONFormat
+from WMCore.REST.Format import JSONFormat, PrettyJSONFormat
 
 
 def results(res):
@@ -79,7 +79,7 @@ class Data(with_metaclass(Singleton, RESTEntity, object)):
                 return False
         return True
 
-    @restcall(formats=[('application/json', JSONFormat())])
+    @restcall(formats=[('text/plain', PrettyJSONFormat()), ('application/json', JSONFormat())])
     @tools.expires(secs=-1)
     def get(self, **kwds):
         """


### PR DESCRIPTION
Fixes #10417 
#### Status
Ready

#### Description
With the current PR we are providing some additional interfaces to the service REST APIs in order to  expose aggregated data from MongoDB per RSE or per RSE Type. E.g. 

https://cmsweb-testbed.cern.ch/ms-unmerged/data/info?rse=T2_DE_DESY

or

https://cmsweb-testbed.cern.ch/ms-unmerged/data/info?rse_type=t1

Here follows a simple example of the output (the long lists in the dictionary are trimmed): 

```
"result": [
 {
  "wmcore_version": "1.5.6.pre1",
  "microservice_version": "1.5.6.pre1",
  "microservice": "MSManager",
  "query": "rse=T2_US_Wisconsin",
  "rseData": [{
    "name": "T2_US_Wisconsin",
    "pfnPrefix": "gsiftp://cms-lvs-gridftp.hep.wisc.edu:2811/hdfs/store/test/rucio/int",
    "isClean": false,
    "timestamps": {
      "rseConsStatTime": 0.0,
      "prevStartTime": 1639732931.3478053,
      "startTime": 1639734096.9867024,
      "prevEndTime": 1639732936.3460612,
      "endTime": 1639734102.1553724
    },
    "counters": {
      "totalNumFiles": 780538,
      "dirsToDeleteAll": 731,
      "dirsToDelete": 16082,
      "filesToDelete": 780538,
      "deletedSuccess": 0,
      "deletedFail": 0
    },
    "dirs": {
      "allUnmerged": [],
      "toDelete": [
        "/store/unmerged/RunIISummer20UL16wmLHEGENAPV/GJets_DoubleEMEnriched_PtG-20MGG-40To80_TuneCP5_13TeV-madgraphMLM-pythia8/GEN/106X_mcRun2_asymptotic_preVFP_v8-v1",
        "/store/unmerged/RunIISummer20UL16MiniAODAPVv2/WWTo4Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/106X_mcRun2_asymptotic_preVFP_v11-v2",
        "/store/unmerged/RunIISummer20UL16MiniAOD/HbToJPsiMuMu_3MuFilter_TuneCP5_13TeV-pythia8-evtgen/MINIAODSIM/106X_mcRun2_asymptotic_v13-v1",
        "/store/unmerged/RunIISummer20UL16RECOAPV/HbToJPsiMuMu_TuneCP5_13TeV-pythia8-evtgen/AODSIM/106X_mcRun2_asymptotic_preVFP_v8-v1",
        "/store/unmerged/RunIISummer20UL17MiniAODv2/TTToHminusToCS_M-155_TuneCP5_13TeV-amcatnlo-pythia8/MINIAODSIM/106X_mc2017_realistic_v9-v2",
        "/store/unmerged/RunIISummer20UL16MiniAODAPVv2/WJetsToLNu_0J_TuneCP5_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/106X_mcRun2_asymptotic_preVFP_v11-v1",
        ...
              ],
      "protected": []
    }]
  }
}]}
```


#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
