### PR TITLE
Stop using password for MariaDB localhost users

### DIFF
--- a/deploy/WMAgent.production
+++ b/deploy/WMAgent.production
@@ -1,9 +1,7 @@
 MYSQL_USER=
-MYSQL_PASS=
 #ORACLE_USER=
 #ORACLE_PASS=
 #ORACLE_TNS=
-GRAFANA_TOKEN=
 COUCH_USER=
 COUCH_PASS=
 COUCH_PORT=5984
@@ -23,6 +21,7 @@ REQMGR2_URL=https://cmsweb.cern.ch/reqmgr2
 CENTRAL_LOGDB_URL=https://cmsweb.cern.ch/couchdb/wmstats_logdb
 WMARCHIVE_URL=https://cmsweb.cern.ch/wmarchive
 AMQ_CREDENTIALS=
+GRAFANA_TOKEN=
 RUCIO_ACCOUNT=wma_prod
 RUCIO_HOST=http://cms-rucio.cern.ch
 RUCIO_AUTH=https://cms-rucio-auth.cern.ch

--- a/deploy/WMAgent.testbed
+++ b/deploy/WMAgent.testbed
@@ -1,9 +1,7 @@
 MYSQL_USER=
-MYSQL_PASS=
 #ORACLE_USER=
 #ORACLE_PASS=
 #ORACLE_TNS=
-GRAFANA_TOKEN=
 COUCH_USER=
 COUCH_PASS=
 COUCH_PORT=5984
@@ -23,6 +21,7 @@ REQMGR2_URL=https://cmsweb-testbed.cern.ch/reqmgr2
 CENTRAL_LOGDB_URL=https://cmsweb-testbed.cern.ch/couchdb/wmstats_logdb
 WMARCHIVE_URL=https://cmsweb-testbed.cern.ch/wmarchive
 AMQ_CREDENTIALS=
+GRAFANA_TOKEN=
 RUCIO_ACCOUNT=wma_test
 RUCIO_HOST=http://cms-rucio-int.cern.ch
 RUCIO_AUTH=https://cms-rucio-auth-int.cern.ch

--- a/deploy/deploy-wmagent.sh
+++ b/deploy/deploy-wmagent.sh
@@ -118,7 +118,6 @@ download_secrets_file(){
 update_secrets_file(){
   cd $ADMIN_DIR
   sed -i "s+MYSQL_USER=+MYSQL_USER=$IAM+" WMAgent.secrets
-  sed -i "s+MYSQL_PASS=+MYSQL_PASS=UPDATE-ME+" WMAgent.secrets
   sed -i "s+COUCH_USER=+COUCH_USER=$IAM+" WMAgent.secrets
   sed -i "s+COUCH_HOST=127.0.0.1+COUCH_HOST=$MY_IP+" WMAgent.secrets
   cd -

--- a/test/deploy/WMAgent_unittest.secrets
+++ b/test/deploy/WMAgent_unittest.secrets
@@ -1,5 +1,4 @@
 MYSQL_USER=unittestagent
-MYSQL_PASS=passwd
 COUCH_USER=unittestagent
 COUCH_PASS=passwd
 COUCH_PORT=6994

--- a/test/deploy/deploy_unittest.sh
+++ b/test/deploy/deploy_unittest.sh
@@ -78,5 +78,5 @@ else
     source ./env_unittest.sh
     $manage start-services
 
-    mysql -u unittestagent --password=passwd --sock $INSTALL_DIR/current/install/mysql/logs/mysql.sock --exec "create database wmcore_unittest"
+    mysql -u unittestagent --sock $INSTALL_DIR/current/install/mysql/logs/mysql.sock --execute "create database wmcore_unittest"
 fi

--- a/test/deploy/deploy_unittest_py3.sh
+++ b/test/deploy/deploy_unittest_py3.sh
@@ -88,5 +88,5 @@ else
     source ./env_unittest_py3.sh
     $manage start-services
 
-    mysql -u unittestagent --password=passwd --sock $INSTALL_DIR/current/install/mysql/logs/mysql.sock --exec "create database wmcore_unittest"
+    mysql -u unittestagent --sock $INSTALL_DIR/current/install/mysql/logs/mysql.sock --execute "create database wmcore_unittest"
 fi

--- a/test/deploy/env_unittest.sh
+++ b/test/deploy/env_unittest.sh
@@ -12,7 +12,7 @@ export ORG_SRC_PYTHON=$INSTALL_DIR/current/apps/wmagent/lib/python*/site-package
 export ORG_SRC_OTHER=$INSTALL_DIR/current/apps/wmagent/data
 export DBSOCK=$INSTALL_DIR/current/install/mysql/logs/mysql.sock
 
-export DATABASE=mysql://unittestagent:passwd@localhost/wmcore_unittest
+export DATABASE=mysql://unittestagent@localhost/wmcore_unittest
 export COUCHURL=http://unittestagent:passwd@localhost:6994
 export DIALECT=MySQL
 

--- a/test/deploy/env_unittest_py3.sh
+++ b/test/deploy/env_unittest_py3.sh
@@ -12,7 +12,7 @@ export ORG_SRC_PYTHON=$INSTALL_DIR/current/apps/wmagentpy3/lib/python3.8/site-pa
 export ORG_SRC_OTHER=$INSTALL_DIR/current/apps/wmagentpy3/data
 export DBSOCK=$INSTALL_DIR/current/install/mysql/logs/mysql.sock
 
-export DATABASE=mysql://unittestagent:passwd@localhost/wmcore_unittest
+export DATABASE=mysql://unittestagent@localhost/wmcore_unittest
 export COUCHURL=http://unittestagent:passwd@localhost:6994
 export DIALECT=MySQL
 


### PR DESCRIPTION
Fixes #10926 

#### Status
not-tested

#### Description
This PR removes the use of `MYSQL_PASS` within WMCore and unittest setup (docker image), such that database access is done via localhost passwordless.

#### Is it backward compatible (if not, which system it affects?)
NO

#### Related PRs
A complement for: https://github.com/dmwm/deployment/pull/1117

#### External dependencies / deployment changes
Required deployment changes: https://github.com/dmwm/deployment/pull/1119
