### PR TITLE
Create the MariaDB wmcore unittest database with the current unix user

### DIFF
--- a/test/deploy/deploy_unittest.sh
+++ b/test/deploy/deploy_unittest.sh
@@ -67,16 +67,18 @@ then
     source ./env_unittest.sh
     update_src $REPOSITORY $BRANCH
 else
-    echo "--- deploying agent $VERSION"
+    echo "--- deploying agent $VERSION with local user $USER"
     # deploy agent
     deploy_agent $VERSION
-    echo "--- updating agent source repository $REPOSITORY,  branch $BRANCH"
+    echo "--- updating agent source repository $REPOSITORY, branch $BRANCH"
     # checkout test source
     setup_test_src $REPOSITORY $BRANCH
 
     # swap the source code from deployed one test source
     source ./env_unittest.sh
+    echo "--- starting services"
     $manage start-services
 
-    mysql -u unittestagent --sock $INSTALL_DIR/current/install/mysql/logs/mysql.sock --execute "create database wmcore_unittest"
+    echo "--- creating MariaDB database"
+    mysql -u $USER --socket=$INSTALL_DIR/current/install/mysql/logs/mysql.sock --execute "create database wmcore_unittest"
 fi

--- a/test/deploy/deploy_unittest_py3.sh
+++ b/test/deploy/deploy_unittest_py3.sh
@@ -77,16 +77,18 @@ then
     source ./env_unittest_py3.sh
     update_src $REPOSITORY $BRANCH
 else
-    echo "--- deploying agent $VERSION"
+    echo "--- deploying agent $VERSION with local user $USER"
     # deploy agent
     deploy_agent $VERSION
-    echo "--- updating agent source repository $REPOSITORY,  branch $BRANCH"
+    echo "--- updating agent source repository $REPOSITORY, branch $BRANCH"
     # checkout test source
     setup_test_src $REPOSITORY $BRANCH
 
     # swap the source code from deployed one test source
     source ./env_unittest_py3.sh
+    echo "--- starting services"
     $manage start-services
 
-    mysql -u unittestagent --sock $INSTALL_DIR/current/install/mysql/logs/mysql.sock --execute "create database wmcore_unittest"
+    echo "--- creating MariaDB database"
+    mysql -u $USER --socket=$INSTALL_DIR/current/install/mysql/logs/mysql.sock --execute "create database wmcore_unittest"
 fi


### PR DESCRIPTION
Fixes #10926 

#### Status
ready

#### Description
From the docker build log:
```
Info: Using unique option prefix 'sock' is error-prone and can break in the future. Please use the full name 'socket' instead.
ERROR 1044 (42000) at line 1: Access denied for user ''@'localhost' to database 'wmcore_unittest'
```
there is something strange with the command above. 

The unittest user name is explicitly passed in the command line, still it sees nothing (maybe the `sock` command...) anyhow, since this is all executed during the deployment, we can simply modify it to use the current unix user (`$USER).

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Yes, trying to fix:
https://github.com/dmwm/deployment/pull/1117
then
https://github.com/dmwm/WMCore/pull/10932

#### External dependencies / deployment changes
Deployment changes coming up soon: 
