### PR TITLE
Check that sdir exists on a file system

### DIFF
--- a/src/python/WMCore/ReqMgr/Web/ReqMgrService.py
+++ b/src/python/WMCore/ReqMgr/Web/ReqMgrService.py
@@ -413,9 +413,10 @@ class ReqMgrService(TemplatedPage):
     def update_scripts(self, force=False):
         "Update scripts dict"
         if force or abs(time.time() - self.sdict['ts']) > self.sdict_thr:
-            for item in os.listdir(self.sdir):
-                with open(os.path.join(self.sdir, item), 'r') as istream:
-                    self.sdict[item.split('.')[0]] = istream.read()
+            if os.path.isdir(self.sdir):
+                for item in os.listdir(self.sdir):
+                    with open(os.path.join(self.sdir, item), 'r') as istream:
+                        self.sdict[item.split('.')[0]] = istream.read()
             self.sdict['ts'] = time.time()
 
     def abs_page(self, tmpl, content):


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/10941

#### Status
ready

#### Description
during testing reqmgr service within local environment I found that code tries to access non-existing area. To protect it from failure I patched the code to check that such area exists.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs

#### External dependencies / deployment changes
