### PR TITLE
Add support for IAM token

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ retry~=0.9.2                  # wmcore,wmagent,wmagent-devtools,reqmgr2,reqmon,g
 rucio-clients~=1.25.5         # wmcore,wmagent,global-workqueue,reqmgr2ms
 Sphinx~=4.0.3                 # wmcore,wmagent,wmagent-devtools,reqmgr2,reqmon,acdcserver,global-workqueue,reqmgr2ms
 SQLAlchemy~=1.3.3             # wmcore,wmagent
+PyJWT~=2.3.0                  # wmagent,wmagent-devtools,reqmgr2,reqmon,acdcserver,global-workqueue,reqmgr2ms,wmcore

--- a/src/python/Utils/TokenManager.py
+++ b/src/python/Utils/TokenManager.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#pylint: disable=W0212
+"""
+File       : TokenManager.py
+Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
+Description: IAM token manager
+             by default it relies on the following environment/parameters:
+             - IAM_TOKEN is either file name or actual token value
+             - https://cms-auth.web.cern.ch/jwk is default CMS IAM provider
+             - https://wlcg.cern.ch/jwt/v1/any is default for audience parameter
+"""
+
+# system modules
+import os
+import ssl
+import time
+import logging
+import traceback
+
+# third part library
+try:
+    import jwt
+except ImportError:
+    traceback.print_exc()
+    jwt = None
+
+from Utils.Utilities import encodeUnicodeToBytes
+
+# prevent "SSL: CERTIFICATE_VERIFY_FAILED" error
+# this will cause pylint warning W0212, therefore we ignore it above
+ssl._create_default_https_context = ssl._create_unverified_context
+
+
+def readToken(name=None):
+    """
+    Read IAM token either from environment or file name
+    :param name: ether file name containing token or environment name which hold the token value.
+    If not provided it will be assumed to read token from IAM_TOKEN environment.
+    :return: token or None
+    """
+    if name and os.path.exists(name):
+        token = None
+        with open(name, 'r', encoding='utf-8') as istream:
+            token = istream.read()
+        return token
+    if name:
+        return os.environ.get(name)
+    return os.environ.get("IAM_TOKEN")
+
+
+def tokenData(token, url="https://cms-auth.web.cern.ch/jwk", audUrl="https://wlcg.cern.ch/jwt/v1/any"):
+    """
+    inspect and extract token data
+    :param token: token string
+    :param url: IAM provider URL
+    :param audUrl: audience string
+    """
+    if not token or not jwt:
+        return {}
+    if isinstance(token, str):
+        token = encodeUnicodeToBytes(token)
+    jwksClient = jwt.PyJWKClient(url)
+    signingKey = jwksClient.get_signing_key_from_jwt(token)
+    key = signingKey.key
+    headers = jwt.get_unverified_header(token)
+    alg = headers.get('alg', 'RS256')
+    data = jwt.decode(
+        token,
+        key,
+        algorithms=[alg],
+        audience=audUrl,
+        options={"verify_exp": True},
+        )
+    return data
+
+
+def isValidToken(token):
+    """
+    check if given token is valid or not
+
+    :param token: token string
+    :return: true or false
+    """
+    tokenDict = {}
+    tokenDict = tokenData(token)
+    exp = tokenDict.get('exp', 0)  # expire, seconds since epoch
+    if not exp or exp < time.time():
+        return False
+    return True
+
+
+class TokenManager():
+    """
+    TokenManager class handles IAM tokens
+    """
+
+    def __init__(self,
+                 name=None,
+                 url="https://cms-auth.web.cern.ch/jwk",
+                 audUrl="https://wlcg.cern.ch/jwt/v1/any",
+                 logger=None):
+        """
+        Token manager reads IAM tokens either from file or env.
+        It caches token along with expiration timestamp.
+        By default the env variable to use is IAM_TOKEN.
+        :param name: string representing either file or env where we should read token from
+        :param url: IAM provider URL
+        :param audUrl: audience string
+        :param logger: logger object or none to use default one
+        """
+        self.name = name
+        self.url = url
+        self.audUrl = audUrl
+        self.expire = 0
+        self.token = None
+        self.logger = logger if logger else logging.getLogger()
+        try:
+            self.token = self.getToken()
+        except Exception as exc:
+            self.logger.exception("Failed to get token. Details: %s", str(exc))
+
+    def getToken(self):
+        """
+        Return valid token and sets its expire timestamp
+        """
+        if not self.token or not isValidToken(self.token):
+            self.token = readToken(self.name)
+        tokenDict = {}
+        try:
+            tokenDict = tokenData(self.token, url=self.url, audUrl=self.audUrl)
+            self.logger.debug(tokenDict)
+        except Exception as exc:
+            self.logger.exception(str(exc))
+            raise
+        self.expire = tokenDict.get('exp', 0)
+        return self.token
+
+    def getLifetime(self):
+        """
+        Return reamaining lifetime of existing token
+        """
+        return self.expire - int(time.time())


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/10940

This PR provides support to include IAM token to HTTP requests. The token can be obtained via separate process, e.g. via curl, `create-iam-token.sh` script or [oidc-agent](https://indigo-iam.github.io/v/v1.7.0/docs/tasks/user/getting-a-token/), and then can be used by any HTTP client. We added appropriate `Authorization` HTTP header to `pycurl_manager`. The token itself can be provided either via file name or environment variable.

For more information please consult [Tokens in WMCore](https://github.com/dmwm/WMCore/wiki/Tokens-in-WMCore) wiki page.

#### Status
ready

#### Description
We provide a patch to pycurl manager to setup appropriate HTTP header if token is provided via configuration or environment. And, `TokenManager` module which provides different ways to obtain IAM token, either via `readToken` function or `TokenManager` class.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Here is PR for wmcore/wmagent specs: https://github.com/cms-sw/cmsdist/pull/7647

#### External dependencies / deployment changes
None