### PR TITLE
Properly update workqueue elements from JobUpdater

### DIFF
--- a/src/python/WMComponent/JobUpdater/JobUpdaterPoller.py
+++ b/src/python/WMComponent/JobUpdater/JobUpdaterPoller.py
@@ -58,7 +58,7 @@ class JobUpdaterPoller(BaseWorkerThread):
 
         self.listWorkflowsDAO = self.daoFactory(classname="Workflow.ListForJobUpdater")
         self.updateWorkflowPrioDAO = self.daoFactory(classname="Workflow.UpdatePriority")
-        self.executingJobsDAO = self.daoFactory(classname="Jobs.GetNumberOfJobsForWorkflowTaskStatus")
+        self.executingJobsDAO = self.daoFactory(classname="Jobs.GetNumberOfJobsForWorkflowStatus")
 
     def setup(self, parameters=None):
         """
@@ -109,6 +109,22 @@ class JobUpdaterPoller(BaseWorkerThread):
                 logging.exception(msg)
                 raise JobUpdaterException(msg)
 
+    def getWorkflowPrio(self, wflowName):
+        """
+        Given a request name, it fetches data from ReqMgr2 and returns
+        the request priority
+        :param wflowName: string with the request name
+        :return: integer with the request priority
+        """
+        result = None
+        try:
+            result = self.reqmgr2.getRequestByNames(wflowName)[0]
+            result = int(result[wflowName]['RequestPriority'])
+        except Exception as ex:
+            logging.error("Couldn't retrieve the priority of request %s", wflowName)
+            logging.error("Error: %s", str(ex))
+        return result
+
     def synchronizeJobPriority(self):
         """
         _synchronizeJobPriority_
@@ -121,49 +137,43 @@ class JobUpdaterPoller(BaseWorkerThread):
         # Update the priority of workflows that are not in WMBS and just in local queue
         priorityCache = {}
         workflowsToUpdate = {}
-        workflowsToCheck = [x for x in self.workqueue.getAvailableWorkflows()]
-        for workflow, priority in workflowsToCheck:
+        # this call returns workflows that only have Available elements in local queue
+        workflowsToCheck = self.workqueue.getAvailableWorkflows()
+        for workflow, workqueuePrio in workflowsToCheck:
             if workflow not in priorityCache:
-                try:
-                    result = self.reqmgr2.getRequestByNames(workflow)[0]
-                    priorityCache[workflow] = result[workflow]['RequestPriority']
-                except Exception as ex:
-                    logging.error("Couldn't retrieve the priority of request %s", workflow)
-                    logging.error("Error: %s", str(ex))
+                requestPrio = self.getWorkflowPrio(workflow)
+                if requestPrio is None:
                     continue
-            if priority != priorityCache[workflow]:
-                workflowsToUpdate[workflow] = priorityCache[workflow]
-        logging.info("Found %d workflows to update in workqueue", len(workflowsToUpdate))
-        for workflow in workflowsToUpdate:
-            self.workqueue.updatePriority(workflow, workflowsToUpdate[workflow])
+
+                priorityCache[workflow] = requestPrio
+                if workqueuePrio != priorityCache[workflow]:
+                    logging.info("Updating workqueue elements priority for request: %s", workflow)
+                    self.workqueue.updatePriority(workflow, priorityCache[workflow])
 
         # Check the workflows in WMBS
-        priorityCache = {}
         workflowsToUpdateWMBS = {}
         workflowsToCheck = self.listWorkflowsDAO.execute()
-        updatedRequest = []
+        # this loop contains multiple entries for the same workflow
         for workflowEntry in workflowsToCheck:
             workflow = workflowEntry['name']
+            wmbsPrio = int(workflowEntry['workflow_priority'])
             if workflow not in priorityCache:
-                try:
-                    result = self.reqmgr2.getRequestByNames(workflow)[0]
-                    priorityCache[workflow] = result[workflow]['RequestPriority']
-                except Exception as ex:
-                    logging.error("Couldn't retrieve the priority of request %s", workflow)
-                    logging.error("Error: %s", str(ex))
+                requestPrio = self.getWorkflowPrio(workflow)
+                if requestPrio is None:
                     continue
-            requestPriority = int(priorityCache[workflow])
-            if requestPriority != int(workflowEntry['workflow_priority']):
-                # Update the workqueue priority for the Available elements
-                self.workqueue.updatePriority(workflow, requestPriority)
-                # Check if there are executing jobs for this particular task
-                if self.executingJobsDAO.execute(workflow, workflowEntry['task']) > 0:
-                    # Only update once per request workflow
-                    if workflow not in updatedRequest:
-                        updatedRequest.append(workflow)
+
+                priorityCache[workflow] = requestPrio
+                if wmbsPrio != priorityCache[workflow]:
+                    logging.info("Updating workqueue elements priority for request: %s", workflow)
+                    self.workqueue.updatePriority(workflow, priorityCache[workflow])
+
+                    # if there are jobs in wmbs executing state, update their prio in condor
+                    if self.executingJobsDAO.execute(workflow) > 0:
+                        logging.info("Updating condor jobs priority for request: %s", workflow)
                         self.bossAir.updateJobInformation(workflow,
                                                           requestPriority=priorityCache[workflow])
-                workflowsToUpdateWMBS[workflow] = priorityCache[workflow]
+                    workflowsToUpdateWMBS[workflow] = priorityCache[workflow]
+
         if workflowsToUpdateWMBS:
-            logging.info("Updating %d workflows in WMBS.", len(workflowsToUpdateWMBS))
+            logging.info("Updating WMBS workflow priority for %d workflows.", len(workflowsToUpdateWMBS))
             self.updateWorkflowPrioDAO.execute(workflowsToUpdateWMBS)

--- a/src/python/WMCore/WMBS/MySQL/Jobs/GetNumberOfJobsForWorkflowStatus.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/GetNumberOfJobsForWorkflowStatus.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+MySQL implementation for retrieving the total number of jobs
+for a given workflow in a given wmbs status
+"""
+from __future__ import print_function, division
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+
+class GetNumberOfJobsForWorkflowStatus(DBFormatter):
+    """
+    Get the number of jobs for a workflow/task combination
+    in a given job status.
+    """
+
+    sql = """SELECT COUNT(*) FROM wmbs_job
+             INNER JOIN wmbs_jobgroup ON wmbs_job.jobgroup = wmbs_jobgroup.id
+             INNER JOIN wmbs_subscription ON wmbs_subscription.id = wmbs_jobgroup.subscription
+             INNER JOIN wmbs_workflow ON wmbs_subscription.workflow = wmbs_workflow.id
+             WHERE wmbs_workflow.name = :workflow AND
+                   wmbs_job.state = (SELECT id FROM wmbs_job_state WHERE name = :status)
+               """
+
+    def execute(self, workflow, status='executing', conn=None, transaction=False):
+        """
+        Execute the SQL and return the number of jobs
+
+        :param workflow: string with the workflow name
+        :param status: string with the wmbs state
+        :param conn: database connection object
+        :param transaction: boolean to use or not a transaction
+        :return: integer with the total number of jobs
+        """
+        binds = {'workflow': workflow, 'status': status}
+        result = self.dbi.processData(self.sql, binds, conn=conn, transaction=transaction)
+
+        return self.format(result)[0][0]

--- a/src/python/WMCore/WMBS/Oracle/Jobs/GetNumberOfJobsForWorkflowStatus.py
+++ b/src/python/WMCore/WMBS/Oracle/Jobs/GetNumberOfJobsForWorkflowStatus.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Oracle implementation for retrieving the total number of jobs
+for a given workflow in a given wmbs status
+"""
+
+from __future__ import print_function, division
+
+from WMCore.WMBS.MySQL.Jobs.GetNumberOfJobsForWorkflowStatus import GetNumberOfJobsForWorkflowStatus \
+    as MySQLGetNumberOfJobsForWorkflowStatus
+
+
+class GetNumberOfJobsForWorkflowStatus(MySQLGetNumberOfJobsForWorkflowStatus):
+    """
+    Exactly the same implementation as of the MySQL one
+    """
+    pass


### PR DESCRIPTION
Fixes #10943 

#### Status
ready

#### Description
This pull request provides:
* a new DAO to get the total number of jobs for a given workflow in a given WMBS status (with no need to pass in a task name as well)
* update the request priority cache more efficiently (from ReqMgr2)
* update local workqueue elements **only once** for each workflow
* before updating condor job priorities, check if the workflow has any jobs in WMBS executing state

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Complement to: https://github.com/dmwm/WMCore/pull/10812

#### External dependencies / deployment changes
None