### PR TITLE
Add lifetime to RucioContainers shipping to disk sites

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/MySQL/Create.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/Create.py
@@ -49,6 +49,7 @@ class Create(DBCreator):
                  subscribed             INTEGER      DEFAULT 0,
                  phedex_group           VARCHAR(100),
                  delete_blocks          INTEGER,
+                 dataset_lifetime       INTEGER     DEFAULT 0,
                  PRIMARY KEY (id),
                  CONSTRAINT uq_dbs_dat_sub UNIQUE (dataset_id, site, custodial, auto_approve, move, priority))"""
 

--- a/src/python/WMComponent/DBS3Buffer/MySQL/NewSubscription.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/NewSubscription.py
@@ -19,8 +19,8 @@ class NewSubscription(DBFormatter):
     """
 
     sql = """INSERT IGNORE INTO dbsbuffer_dataset_subscription
-            (dataset_id, site, custodial, auto_approve, move, priority, subscribed, phedex_group, delete_blocks)
-            VALUES (:id, :site, :custodial, :auto_approve, :move, :priority, 0, :phedex_group, :delete_blocks)
+            (dataset_id, site, custodial, auto_approve, move, priority, subscribed, phedex_group, delete_blocks, dataset_lifetime)
+            VALUES (:id, :site, :custodial, :auto_approve, :move, :priority, 0, :phedex_group, :delete_blocks, :dataset_lifetime)
           """
 
     def _createPhEDExSubBinds(self, datasetID, subscriptionInfo, custodialFlag):
@@ -47,7 +47,8 @@ class NewSubscription(DBFormatter):
                           'move': isMove,
                           'priority': subscriptionInfo['Priority'],
                           'phedex_group': phedex_group,
-                          'delete_blocks': delete_blocks})
+                          'delete_blocks': delete_blocks,
+                          'dataset_lifetime': subscriptionInfo['DatasetLifetime']})
         return binds
 
     def execute(self, datasetID, subscriptionInfo, conn=None, transaction=False):

--- a/src/python/WMComponent/DBS3Buffer/Oracle/Create.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/Create.py
@@ -49,6 +49,7 @@ class Create(DBCreator):
                  subscribed         INTEGER      DEFAULT 0,
                  phedex_group       VARCHAR(100),
                  delete_blocks      INTEGER,
+                 dataset_lifetime   INTEGER     DEFAULT 0,
                  PRIMARY KEY (id),
                  CONSTRAINT uq_dbs_dat_sub UNIQUE (dataset_id, site, custodial, auto_approve, move, priority)
                )"""

--- a/src/python/WMComponent/DBS3Buffer/Oracle/NewSubscription.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/NewSubscription.py
@@ -18,9 +18,9 @@ class NewSubscription(MySQLNewSubscription):
     """
 
     sql = """INSERT INTO dbsbuffer_dataset_subscription
-             (id, dataset_id, site, custodial, auto_approve, move, priority, subscribed, phedex_group, delete_blocks)
+             (id, dataset_id, site, custodial, auto_approve, move, priority, subscribed, phedex_group, delete_blocks, dataset_lifetime)
              SELECT dbsbuffer_dataset_sub_seq.nextval, :id, :site, :custodial, :auto_approve,
-                    :move, :priority, 0, :phedex_group, :delete_blocks
+                    :move, :priority, 0, :phedex_group, :delete_blocks, :dataset_lifetime
              FROM DUAL
              WHERE NOT EXISTS
                ( SELECT *
@@ -30,5 +30,6 @@ class NewSubscription(MySQLNewSubscription):
                  AND custodial = :custodial
                  AND auto_approve = :auto_approve
                  AND move = :move
-                 AND priority = :priority )
+                 AND priority = :priority
+                 AND dataset_lifetime = :dataset_lifetime )
              """

--- a/src/python/WMComponent/RucioInjector/Database/MySQL/GetUnsubscribedDatasets.py
+++ b/src/python/WMComponent/RucioInjector/Database/MySQL/GetUnsubscribedDatasets.py
@@ -23,7 +23,8 @@ class GetUnsubscribedDatasets(DBFormatter):
                              dbsbuffer_dataset_subscription.auto_approve,
                              dbsbuffer_dataset_subscription.move,
                              dbsbuffer_dataset_subscription.priority,
-                             dbsbuffer_dataset_subscription.phedex_group
+                             dbsbuffer_dataset_subscription.phedex_group,
+                             dbsbuffer_dataset_subscription.dataset_lifetime
                FROM dbsbuffer_dataset_subscription
                INNER JOIN dbsbuffer_dataset ON
                    dbsbuffer_dataset.id = dbsbuffer_dataset_subscription.dataset_id

--- a/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
+++ b/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
@@ -445,6 +445,7 @@ class RucioInjectorPoller(BaseWorkerThread):
         for subInfo in unsubscribedDatasets:
             rseName = subInfo['site'].replace("_MSS", "_Tape")
             container = subInfo['path']
+            lifetime = subInfo['dataset_lifetime']
             # Skip central production Tape rules
             if not self.isT0agent and rseName.endswith("_Tape"):
                 logging.info("Bypassing Production container Tape data placement for container: %s and RSE: %s",
@@ -474,6 +475,8 @@ class RucioInjectorPoller(BaseWorkerThread):
             else:
                 # then it's a T0 container placement
                 ruleKwargs['priority'] = 4
+                if not rseName.endswith("_Tape") and lifetime > 0:
+                    ruleKwargs['lifetime'] = lifetime
                 if self.testRSEs:
                     rseName = "%s_Test" % rseName
                 #Checking whether we need to ask for rule approval

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -1174,6 +1174,8 @@ class StdBase(object):
                      # set to "" string or None for eos-lfn-prefix if you don't want to save the log in eos
                      "Override": {"default": {"eos-lfn-prefix": "root://eoscms.cern.ch//eos/cms/store/logs/prod/recent/PRODUCTION"},
                                   "type": dict},
+                     # Rucio rule subscription lifetime (used in ContainerRules by T0)
+                     "DatasetLifetime": {"default": 0, "type": int, "assign_optional": True, "validate": lambda x: x >= 0},
                      }
         # Set defaults for the argument specification
         StdBase.setDefaultArgumentsProperty(arguments)

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -990,7 +990,8 @@ class WMTaskHelper(TreeHelper):
                                    custodialGroup="DataOps", nonCustodialGroup="DataOps",
                                    priority="Low", primaryDataset=None,
                                    useSkim=False, isSkim=False,
-                                   dataTier=None, deleteFromSource=False):
+                                   dataTier=None, deleteFromSource=False,
+                                   datasetLifetime=None):
         """
         _setSubscriptionsInformation_
 
@@ -1050,6 +1051,7 @@ class WMTaskHelper(TreeHelper):
             outputSection.nonCustodialGroup = nonCustodialGroup
             outputSection.priority = priority
             outputSection.deleteFromSource = deleteFromSource
+            outputSection.datasetLifetime = datasetLifetime
 
         return
 
@@ -1090,7 +1092,9 @@ class WMTaskHelper(TreeHelper):
                                        # Specs assigned before HG1303 don't have the CustodialSubtype
                                        "CustodialSubType": getattr(outputSection, "custodialSubType", "Replica"),
                                        "NonCustodialSubType": getattr(outputSection, "nonCustodialSubType",
-                                                                      "Replica")}
+                                                                      "Replica"),
+                                      # Spec assigned for T0 ContainerRules
+                                      "DatasetLifetime": getattr(outputSection, "datasetLifetime", 0)}
         return subInformation
 
     def parentProcessingFlag(self):

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -1485,7 +1485,8 @@ class WMWorkloadHelper(PersistencyHelper):
                                    custodialGroup="DataOps", nonCustodialGroup="DataOps",
                                    priority="Low", primaryDataset=None,
                                    useSkim=False, isSkim=False,
-                                   dataTier=None, deleteFromSource=False):
+                                   dataTier=None, deleteFromSource=False,
+                                   datasetLifetime=None):
         """
         _setSubscriptionInformation_
 
@@ -1512,7 +1513,8 @@ class WMWorkloadHelper(PersistencyHelper):
                                             custodialGroup, nonCustodialGroup,
                                             priority, primaryDataset,
                                             useSkim, isSkim,
-                                            dataTier, deleteFromSource)
+                                            dataTier, deleteFromSource,
+                                            datasetLifetime)
             self.setSubscriptionInformation(task,
                                             custodialSites, nonCustodialSites,
                                             autoApproveSites,
@@ -1520,7 +1522,8 @@ class WMWorkloadHelper(PersistencyHelper):
                                             custodialGroup, nonCustodialGroup,
                                             priority, primaryDataset,
                                             useSkim, isSkim,
-                                            dataTier, deleteFromSource)
+                                            dataTier, deleteFromSource,
+                                            datasetLifetime)
 
         return
 
@@ -1575,6 +1578,7 @@ class WMWorkloadHelper(PersistencyHelper):
                     subInfo[dataset]["NonCustodialGroup"] = solveGroupConflicts(
                         taskSubInfo[dataset]["NonCustodialGroup"],
                         subInfo[dataset]["NonCustodialGroup"])
+
                 else:
                     subInfo[dataset] = taskSubInfo[dataset]
                 subInfo[dataset]["CustodialSites"] = list(

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
@@ -727,7 +727,8 @@ class StepChainTests(EmulatedUnitTestCase):
                             'NonCustodialGroup': 'AnalysisOps',
                             'NonCustodialSites': ['T1_US_FNAL_Disk'],
                             'NonCustodialSubType': 'Move',
-                            'Priority': 'High'}
+                            'Priority': 'High',
+                            'DatasetLifetime': None}
         assignDict = {"SiteWhitelist": ["T2_US_Nebraska", "T2_IT_Rome"], "Team": "The-A-Team",
                       "RequestStatus": "assigned", "RequestPriority": 111,
                       "CustodialSites": subscriptionInfo['CustodialSites'],
@@ -737,7 +738,8 @@ class StepChainTests(EmulatedUnitTestCase):
                       "CustodialSubType": subscriptionInfo['CustodialSubType'],
                       "NonCustodialSubType": subscriptionInfo['NonCustodialSubType'],
                       "CustodialGroup": subscriptionInfo['CustodialGroup'],
-                      "NonCustodialGroup": subscriptionInfo['NonCustodialGroup']
+                      "NonCustodialGroup": subscriptionInfo['NonCustodialGroup'],
+                      "DatasetLifetime": subscriptionInfo['DatasetLifetime']
                       }
 
         testArguments = StepChainWorkloadFactory.getTestArguments()

--- a/test/python/WMCore_t/WMSpec_t/WMTask_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMTask_t.py
@@ -625,7 +625,8 @@ class WMTaskTest(unittest.TestCase):
                                             nonCustodialGroup="AnalysisOps",
                                             priority="Normal",
                                             deleteFromSource=True,
-                                            primaryDataset="OneParticle")
+                                            primaryDataset="OneParticle",
+                                            datasetLifetime=None)
         subInfo = testTask.getSubscriptionInformation()
         outputRecoSubInfo = {"CustodialSites": ["mercury"],
                              "NonCustodialSites": ["mars", "earth"],
@@ -635,7 +636,8 @@ class WMTaskTest(unittest.TestCase):
                              "CustodialGroup": "DataOps",
                              "NonCustodialGroup": "AnalysisOps",
                              "Priority": "Normal",
-                             "DeleteFromSource": True}
+                             "DeleteFromSource": True,
+                             "DatasetLifetime": None}
 
         self.assertEqual(subInfo["/OneParticle/DawnOfAnEra-v1/RECO"], outputRecoSubInfo,
                          "The RECO subscription information is wrong")
@@ -655,7 +657,8 @@ class WMTaskTest(unittest.TestCase):
                             "CustodialGroup": "DataOps",
                             "NonCustodialGroup": "DataOps",
                             "Priority": "Low",
-                            "DeleteFromSource": False}
+                            "DeleteFromSource": False,
+                            "DatasetLifetime": None}
 
         self.assertEqual(subInfo["/OneParticle/DawnOfAnEra-v1/RECO"], outputRecoSubInfo,
                          "The RECO subscription information is wrong")
@@ -677,7 +680,8 @@ class WMTaskTest(unittest.TestCase):
                             "CustodialGroup": "DataOps",
                             "NonCustodialGroup": "DataOps",
                             "Priority": "Low",
-                            "DeleteFromSource": False}
+                            "DeleteFromSource": False,
+                            "DatasetLifetime": None}
 
         self.assertEqual(subInfo["/OneParticle/DawnOfAnEra-v1/RECO"], outputRecoSubInfo,
                          "The RECO subscription information is wrong")


### PR DESCRIPTION
Add a new lifetime parameter for each RucioContainer rule that is subscribed to disk site

Fixes #10746 

#### Status
Tested with a replay

#### Description
For a given dataset (Rucio Container rule) processed by Tier0 and shipping to disk sites, add a new attribute of lifetime to the rucio container rule only if its subscribed at Disk sites

#### Is it backward compatible (if not, which system it affects?)
MAYBE

#### Related PRs
First discussed in #10747 

#### External dependencies / deployment changes
No
