### PR TITLE
DBS3Upload: check error message from the response body attribute

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
@@ -85,7 +85,7 @@ def uploadWorker(workInput, results, dbsUrl):
             dbsApi.insertBulkBlock(blockDump=block)
             results.put({'name': name, 'success': "uploaded"})
         except Exception as ex:
-            exString = str(ex)
+            exString = str(getattr(ex, "body", ex))
             if 'Block %s already exists' % name in exString:
                 # Then this is probably a duplicate
                 # Ignore this for now


### PR DESCRIPTION
Fixes #10960 

#### Status
ready

#### Description
It isn't clear why we have this new behaviour now, but it could be from the new version of dbs3-client/pycurl.

When looking up at the error message, use the `body` attribute of the HTTP response object, which would have something like:
```
{"exception": 400, "message": "DBSBlockInsert/insertBlock. Block /RelValProdMinBias/Agent157_Val-Agent157_Val_OLD_Alanv3-v22/GEN-SIM#d6eb571b-f65e-4fb3-af49-ceb16b55a14e already exists.", "type": "HTTPError"}
```

different than the stringyfication of the exception object, which was giving us only this message:
```
400: Bad Request
```

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None