### PR TITLE
Aggregate DBS results from Go server

### DIFF
--- a/test/python/WMCore_t/MicroService_t/Tools_t/Common_t.py
+++ b/test/python/WMCore_t/MicroService_t/Tools_t/Common_t.py
@@ -7,7 +7,8 @@ from __future__ import division, print_function
 
 import unittest
 
-from WMCore.MicroService.Tools.Common import dbsInfo, getEventsLumis, findParent
+from WMCore.MicroService.Tools.Common import \
+        dbsInfo, getEventsLumis, findParent, isEmptyResults
 
 
 class CommonTest(unittest.TestCase):
@@ -47,6 +48,19 @@ class CommonTest(unittest.TestCase):
         parents = findParent(self.child, self.dbsUrl)
         self.assertEqual(parents[self.child[0]], '/SingleElectron/Run2016B-v2/RAW')
 
+    def test_isEmptyResults(self):
+        row = {'code': 200, 'data': None}
+        result = isEmptyResults(row)
+        self.assertEqual(result, True)
+        row = {'code': 200, 'data': []}
+        result = isEmptyResults(row)
+        self.assertEqual(result, True)
+        row = {'code': 400, 'data': None}
+        result = isEmptyResults(row)
+        self.assertEqual(result, False)
+        row = {'code': 400, 'data': []}
+        result = isEmptyResults(row)
+        self.assertEqual(result, False)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #10956

#### Status
ready

#### Description
Use DBSClient aggregators to aggregate relevant parts from DBS Go server APIs.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
<If it's a follow up work; or porting a fix from a different branch, please mention them here.>

#### External dependencies / deployment changes
new changes depends on DBSClient. If it is not desired we can take appropriate functions from it and put to WMCore. So far changes are minimal and since WMCore relies on DBSClient it should not be a problem with this dependency.
