### PR TITLE
Update requirements.txt and PyPI build scripts for py3 stack

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,32 +1,43 @@
 # All dependencies needed to run WMCore software
+#
 # This file is parsed by tools/build_pypi_packages.sh to create requirements.txt
 # files for each piece of software built from WMCore and uploaded to PyPI
 # Format:
 # PackageName==X.Y.Z          # <comma separated list of WMCore software needing the package>
+#
+# Different version specifiers are used to ensure compatibility and to avoid potential python conficts
+# == when exact version of the package is required
+# >= when a newer version of the package is required
+# ~= when we need compatibility of the version, e.g. stay within major version of the package
+# for more details please refer to official Python documentation, see
+# https://www.python.org/dev/peps/pep-0440/#version-specifiers
 
-Cheetah==2.4.0                # wmagent,reqmgr2,reqmon
-CherryPy==17.4.0              # wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms
-CMSMonitoring>=0.3.4          # wmagent,reqmgr2,reqmon,reqmgr2ms
-coverage==4.5.4               # wmagent
-cx-Oracle==5.2.1              # wmagent
-dbs-client==3.13.1            # wmagent,reqmgr2,reqmon,global-workqueue
-decorator==3.4.2              # wmagent
-funcsigs==1.0.2               # wmagent
-future==0.18.2                # wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms
-httplib2==0.19.0              # wmagent,reqmgr2,reqmon,acdcserver,global-workqueue,reqmgr2ms
-Markdown==3.0.1               # wmagent
-mock==2.0.0                   # wmagent
-MySQL-python==1.2.5           # wmagent
-nose2==0.9.2                  # wmagent
-psutil==5.6.6                 # wmagent,reqmgr2,reqmon,global-workqueue
-pycurl==7.43.0.3              # wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms
-pymongo==3.10.1               # reqmgr2ms
-pyOpenSSL==18.0.0             # wmagent
-pyzmq==17.1.2                 # wmagent
-retry==0.9.1                  # wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms
-rucio-clients==1.23.0         # wmagent,global-workqueue,reqmgr2ms
-setuptools==39.2.0            # wmagent
-Sphinx==1.3.5                 # wmagent,reqmgr2,acdcserver,global-workqueue,reqmgr2ms
-SQLAlchemy==1.3.3             # wmagent
-stomp.py==4.1.15              # wmagent
-CMSCouchapp==1.2.10           # wmagent
+Cheetah3~=3.2.6.post2         # wmagent,reqmgr2,reqmon
+CherryPy~=17.4.0              # wmagent,wmagent-devtools,reqmgr2,reqmon,global-workqueue,reqmgr2ms
+CMSCouchapp~=1.3.4            # wmagent
+CMSMonitoring~=0.3.4          # wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms
+coverage~=5.4                 # wmagent,wmagent-devtools
+cx-Oracle~=7.3.0              # wmagent
+dbs3-client~=4.0.7            # wmagent,reqmgr2,reqmon,global-workqueue
+future~=0.18.2                # wmagent,wmagent-devtools,reqmgr2,reqmon,acdcserver,global-workqueue,reqmgr2ms
+gfal2-python~=1.11.0.post3    # reqmgr2ms
+httplib2~=0.19.0              # wmagent,reqmgr2,reqmon,acdcserver,global-workqueue,reqmgr2ms
+htcondor~=8.9.7               # wmagent
+Jinja2~=3.0.1                 # wmagent
+memory-profiler~=0.58.0       # wmagent-devtools
+mock~=4.0.3                   # wmagent,wmagent-devtools
+mox3~=1.1.0                   # wmagent-devtools
+mysqlclient~=2.0.3            # wmagent
+nose~=1.3.7                   # wmagent-devtools
+nose2~=0.10.0                 # wmagent-devtools
+pep8~=1.7.1                   # wmagent-devtools
+psutil~=5.8.0                 # wmagent,wmagent-devtools,reqmgr2,reqmon,global-workqueue
+pycurl~=7.43.0.6              # wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms
+pylint~=2.7.0                 # wmagent-devtools
+pymongo~=3.10.1               # wmagent-devtools,reqmgr2ms
+pyOpenSSL~=18.0.0             # wmagent
+pyzmq~=19.0.2                 # wmagent
+retry~=0.9.2                  # wmagent,wmagent-devtools,reqmgr2,reqmon,global-workqueue,reqmgr2ms
+rucio-clients~=1.25.5         # wmagent,global-workqueue,reqmgr2ms
+Sphinx~=4.0.3                 # wmagent,wmagent-devtools,reqmgr2,reqmon,acdcserver,global-workqueue,reqmgr2ms
+SQLAlchemy~=1.3.3             # wmagent

--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -62,6 +62,28 @@ dependencies = {
                     'etc+'
                     ],
     },
+    'wmagent-devtools': {
+        'packages': ['WMCore+',
+                     'WMComponent+',
+                     'WMQuality+',
+                     'PSetTweaks+',
+                     'Utils+'],
+        'modules': [],
+        'systems': [],
+        'statics': ['src/couchapps+',
+                    'src/css+',
+                    'src/html+',
+                    'src/javascript+',
+                    'src/templates+',
+                    'bin+',
+                    'deploy+',
+                    'doc+',
+                    'etc+',
+                    'test+',
+                    'standards+'
+                    'tools+'
+                    ],
+    },
     'reqmgr2': {
         'packages': ['WMCore.ReqMgr+',
                      'WMCore.Services+',

--- a/tools/build_pypi_packages.sh
+++ b/tools/build_pypi_packages.sh
@@ -14,7 +14,7 @@ set -x
 # package passed as parameter, can be one of PACKAGES or "all"
 TOBUILD=$1
 # list of packages that can be built and uploaded to pypi
-PACKAGES="wmagent wmcore reqmon reqmgr2 reqmgr2ms global-workqueue acdcserver"
+PACKAGES="wmagent wmagent-devtools wmcore reqmon reqmgr2 reqmgr2ms global-workqueue acdcserver"
 PACKAGE_REGEX="^($(echo $PACKAGES | sed 's/\ /|/g')|all)$"
 
 if [[ -z $TOBUILD ]]; then


### PR DESCRIPTION
Fixes #10955 

#### Status
In development

#### Description
This PR updates requirements.txt to include only requirements needed for py3 WMCore services and the new `wmagent-devtools` package. It also updates build_pypi_packages.sh to build the packages.

* Updated operators from `==` to `~=`.
* Removed `dbs3-pycurl` since it is a dependency of `dbs3-client`. 
* Removed `dbs3-client` as a dependency for wmagent-devtools since it was not in the [spec](https://github.com/cms-sw/cmsdist/blob/comp_gcc630/wmcorepy3-devtools.spec).
* Added `gfal2-python` for reqmgr2ms since it was in the [spec](https://github.com/cms-sw/cmsdist/blob/comp_gcc630/reqmgr2ms.spec)
* Added `mysqlclient` for wmagent since it was in the [spec](https://github.com/cms-sw/cmsdist/blob/comp_gcc630/py3-mysqlclient.spec) 

#### Is it backward compatible (if not, which system it affects?)
NO, cannot build py2 PyPI packages for any WMCore service after merge.

#### Related PRs
None

#### External dependencies / deployment changes
None