### PR TITLE
Bump dbs3-client to 4.0.6

### DIFF
--- a/requirements_py3.txt
+++ b/requirements_py3.txt
@@ -33,4 +33,4 @@ Sphinx==4.0.3
 CMSMonitoring==0.3.4
 CMSCouchapp==1.3.4
 dbs3-pycurl>=3.17.7
-dbs3-client>=4.0.5
+dbs3-client>=4.0.6


### PR DESCRIPTION
Fixes #10983 

#### Status
ready

#### Description
Update version for dbs3-client in our python3 stack (which has a fix for the `listFileLumiArray` API/aggregation).

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
