### PR TITLE
Bump dbs3-client to 4.0.6 - cmsweb branch

### DIFF
--- a/requirements_py3.txt
+++ b/requirements_py3.txt
@@ -33,4 +33,4 @@ Sphinx==4.0.3
 CMSMonitoring==0.3.4
 CMSCouchapp==1.3.4
 dbs3-pycurl>=3.17.7
-dbs3-client>=4.0.5
+dbs3-client>=4.0.6


### PR DESCRIPTION
2.0.0_cmsweb branch version for https://github.com/dmwm/WMCore/pull/10984

A new WMCore tag needs to be created with this change in.