### PR TITLE
Remove files from mongoProjection

### DIFF
--- a/src/python/WMCore/MicroService/MSUnmerged/MSUnmergedRSE.py
+++ b/src/python/WMCore/MicroService/MSUnmerged/MSUnmergedRSE.py
@@ -82,7 +82,6 @@ class MSUnmergedRSE(dict):
             "isClean" : True,
             "timestamps": True,
             "counters": True,
-            "files": False,
             "dirs": True}
         if fullRSEToDB:
             mongoProjection.update({"files": True})


### PR DESCRIPTION
Fixes #10981

#### Status
Ready

#### Description
We are fixing the  `OperationFailure: Cannot do exclusion on field files in inclusion projection` by simply removing the `'files:' False`  field from the mongo projection. It will be added few lines bellow for the cases when it is needed. 

#### Is it backward compatible (if not, which system it affects?)
YES 

#### Related PRs
None

#### External dependencies / deployment changes
None
