### PR TITLE
Add parameters to rucio datasets (block-level rules)

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -361,6 +361,7 @@ config.RucioInjector.createBlockRules = True
 config.RucioInjector.RSEPostfix = False  # enable it to append _Test to the RSE names
 config.RucioInjector.metaDIDProject = "Production"
 config.RucioInjector.containerDiskRuleParams = {"weight": "ddm_quota", "copies": 2, "grouping": "DATASET"}
+config.RucioInjector.blockRuleParams = {}
 # this RSEExpr below might be updated by wmagent-mod-config script
 config.RucioInjector.containerDiskRuleRSEExpr = "(tier=2|tier=1)&cms_type=real&rse_type=DISK"
 config.RucioInjector.rucioAccount = "OVER_WRITE_BY_SECRETS"

--- a/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
+++ b/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
@@ -62,6 +62,7 @@ class RucioInjectorPoller(BaseWorkerThread):
         self.lastRulesExecTime = 0
         self.createBlockRules = config.RucioInjector.createBlockRules
         self.containerDiskRuleParams = config.RucioInjector.containerDiskRuleParams
+        self.blockRuleParams = config.RucioInjector.blockRuleParams
         self.containerDiskRuleRSEExpr = config.RucioInjector.containerDiskRuleRSEExpr
         if config.RucioInjector.metaDIDProject not in RUCIO_VALID_PROJECT:
             msg = "Component configured with an invalid 'project' DID: %s"
@@ -239,6 +240,7 @@ class RucioInjectorPoller(BaseWorkerThread):
                           ignore_availability=True, meta=self.metaData)
             rseName = "%s_Test" % item['pnn'] if self.testRSEs else item['pnn']
             # DATASET = replicates all files in the same block to the same RSE
+            kwargs.update(self.blockRuleParams)
             resp = self.rucio.createReplicationRule(item['blockname'],
                                                     rseExpression=rseName, **kwargs)
             if resp:

--- a/test/python/WMComponent_t/RucioInjector_t/RucioInjectorPoller_t.py
+++ b/test/python/WMComponent_t/RucioInjector_t/RucioInjectorPoller_t.py
@@ -77,6 +77,7 @@ class RucioInjectorPollerTest(EmulatedUnitTestCase):
         config.RucioInjector.RSEPostfix = False  # enable it to append _Test to the RSE names
         config.RucioInjector.metaDIDProject = "Production"
         config.RucioInjector.containerDiskRuleParams = {"weight": "ddm_quota", "copies": 2, "grouping": "DATASET"}
+        config.RucioInjector.blockRuleParams = {}
         config.RucioInjector.containerDiskRuleRSEExpr = "(tier=2|tier=1)&cms_type=real&rse_type=DISK"
         config.RucioInjector.rucioAccount = "wma_test"
         config.RucioInjector.rucioUrl = "http://cms-rucio-int.cern.ch"


### PR DESCRIPTION
Fixes #10558 

#### Status
Tested with a replay

#### Description
Add different parameters to rucio datasets via WMAgentConfig. This new parameter called `config.RucioInjector.datasetRuleParams` will allow T0 agent to modify as needed the attributes for block-level rules. Will be extremely useful for our account `tier0_replay` to add a lifetime parameter due that sometimes during our testing procedures with new configurations the block-level rules are not been deleted.
The T0 production agent will add the following entry to the config file `config.RucioInjector.datasetRuleParams = {}` while in our testing environment we will add `config.RucioInjector.datasetRuleParams = {'lifetime': 14 * 24 * 60 * 60}`. This will help the cleaning procedure in our operational site `T0_CH_CERN_Disk` from only replay data without affecting the logic of deleting block-level rules in production and its easy to overwrite this parameter using our usual deployment script.
As an example, the following two block-level rules. The first one as usual and the second one with the changes proposed in this PR
```
Id:                         8b7e5141e23c4388a7c97c30ecaea41a
Account:                    tier0_replay
Scope:                      cms
Name:                       /L1Accept/Tier0_REPLAY_2021-v1/RAW#965d5fe0-7117-47f0-a3df-b73cd439fe9e
RSE Expression:             T0_CH_CERN_Disk
Copies:                     1
State:                      OK
Locks OK/REPLICATING/STUCK: 10/0/0
Grouping:                   DATASET
Expires at:                 None
Locked:                     False
Weight:                     None
Created at:                 2022-02-10 15:11:51
Updated at:                 2022-02-10 15:17:00
Error:                      None
Subscription Id:            None
Source replica expression:  None
Activity:                   Production Output
Comment:                    WMAgent automatic container rule
Ignore Quota:               False
Ignore Availability:        True
Purge replicas:             False
Notification:               NO
End of life:                None
Child Rule Id:              None
```

```
Id:                         9a9d91b238de40f09fa794a3f23f0c60
Account:                    tier0_replay
Scope:                      cms
Name:                       /L1Accept/Tier0_REPLAY_2021-v1/RAW#e9aec287-c790-41bf-a6da-4d8fe5f991f7
RSE Expression:             T0_CH_CERN_Disk
Copies:                     1
State:                      OK
Locks OK/REPLICATING/STUCK: 10/0/0
Grouping:                   DATASET
Expires at:                 2022-02-17 05:27:48
Locked:                     False
Weight:                     None
Created at:                 2022-02-10 05:27:48
Updated at:                 2022-02-10 05:33:14
Error:                      None
Subscription Id:            None
Source replica expression:  None
Activity:                   Production Output
Comment:                    WMAgent automatic container rule
Ignore Quota:               False
Ignore Availability:        True
Purge replicas:             False
Notification:               NO
End of life:                None
Child Rule Id:              None
```

#### Is it backward compatible (if not, which system it affects?)
MAYBE

#### Related PRs
T0 PR https://github.com/dmwm/T0/pull/4643

#### External dependencies / deployment changes
None
