### PR TITLE
Remove verbose=True from getMSLogger calls

### DIFF
--- a/src/python/WMCore/MicroService/TaskManager.py
+++ b/src/python/WMCore/MicroService/TaskManager.py
@@ -110,7 +110,7 @@ class UidSet(object):
 class Worker(threading.Thread):
     """Thread executing worker from a given tasks queue"""
     def __init__(self, name, taskq, pidq, uidq, logger=None):
-        self.logger = getMSLogger(verbose=True, logger=logger)
+        self.logger = getMSLogger(logger=logger)
         threading.Thread.__init__(self, name=name)
         self.exit = 0
         self.tasks = taskq
@@ -160,7 +160,7 @@ class TaskManager(object):
 
     """
     def __init__(self, nworkers=10, name='TaskManager', logger=None):
-        self.logger = getMSLogger(verbose=True, logger=logger)
+        self.logger = getMSLogger(logger=logger)
         self.name = name
         self.pids = set()
         self.uids = UidSet()

--- a/src/python/WMCore/MicroService/Tools/Common.py
+++ b/src/python/WMCore/MicroService/Tools/Common.py
@@ -400,7 +400,7 @@ def getEventsLumis(dataset, dbsUrl, blocks=None, eventsLumis=None):
 
 def getComputingTime(workflow, eventsLumis=None, unit='h', dbsUrl=None, logger=None):
     "Return computing time per give workflow"
-    logger = getMSLogger(verbose=True, logger=logger)
+    logger = getMSLogger(logger=logger)
     cput = None
 
     if 'InputDataset' in workflow:


### PR DESCRIPTION
Fixes #10317

#### Status
need confirmation from @amaltaro 

#### Description
remove `verbose=True` in getMSLogger, the level should be applied by passing proper logger instance.

#### Is it backward compatible (if not, which system it affects?)
MAYBE

#### Related PRs
https://github.com/dmwm/deployment/pull/1124

#### External dependencies / deployment changes
