### PR TITLE
[CouchDB] Bundle of fixes required for migration to CouchDB 3.x

### DIFF
--- a/src/couchapps/WorkQueue/filters/queueFilter.js
+++ b/src/couchapps/WorkQueue/filters/queueFilter.js
@@ -1,5 +1,5 @@
 function(doc, req) {
-	if (doc._deleted){
+    if (doc._deleted){
        return false;
     }
     

--- a/src/python/WMCore/Services/RequestDB/RequestDBReader.py
+++ b/src/python/WMCore/Services/RequestDB/RequestDBReader.py
@@ -21,7 +21,10 @@ class RequestDBReader(object):
             self.dbName = self.couchDB.name
             self.couchServer = CouchServer(self.couchURL)
         else:
-            couchURL = sanitizeURL(couchURL)['url']
+            # NOTE: starting in CouchDB 3.x, we need to provide the couch credentials in
+            # order to be able to write to the database, thus a RequestDBWriter object
+            if isinstance(self.__class__, RequestDBReader):
+                couchURL = sanitizeURL(couchURL)['url']
             self.couchURL, self.dbName = splitCouchServiceURL(couchURL)
             self.couchServer = CouchServer(self.couchURL)
             self.couchDB = self.couchServer.connectDatabase(self.dbName, False)

--- a/src/python/WMCore/Services/Requests.py
+++ b/src/python/WMCore/Services/Requests.py
@@ -100,6 +100,8 @@ class Requests(dict):
         urlComponent = sanitizeURL(url)
         if urlComponent['username'] is not None:
             self.addBasicAuth(urlComponent['username'], urlComponent['password'])
+            # CouchDB 3.x requires user/passwd in the source/target of replication docs
+            # More info in: https://github.com/dmwm/WMCore/pull/11001
             url = urlComponent['url']  # remove user, password from url
 
         self.setdefault("host", url)

--- a/src/python/WMCore/WorkQueue/WorkQueueBackend.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueBackend.py
@@ -76,43 +76,46 @@ class WorkQueueBackend(object):
         self.db = self.server.connectDatabase(db_name, create=False, size=10000)
         self.hostWithAuth = db_url
         self.inbox = self.server.connectDatabase(inbox_name, create=False, size=10000)
+        self.queueUrlWithAuth = queueUrl or (db_url + '/' + db_name)
         self.queueUrl = sanitizeURL(queueUrl or (db_url + '/' + db_name))['url']
         self.eleKey = 'WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement'
 
     def forceQueueSync(self):
-        """Force a blocking replication - used only in tests"""
-        self.pullFromParent(continuous=False)
-        self.sendToParent(continuous=False)
+        """Setup CouchDB replications - used only in tests"""
+        self.pullFromParent(continuous=True)
+        self.sendToParent(continuous=True)
 
     def pullFromParent(self, continuous=True, cancel=False):
         """Replicate from parent couch - blocking: used only int test"""
         try:
-            if self.parentCouchUrl and self.queueUrl:
+            if self.parentCouchUrlWithAuth and self.queueUrlWithAuth:
                 self.logger.info("Forcing pullFromParent from parentCouch: %s to queueUrl %s/%s",
-                                 self.parentCouchUrl, self.queueUrl, self.inbox.name)
-                self.server.replicate(source=self.parentCouchUrl,
+                                 self.parentCouchUrlWithAuth, self.queueUrlWithAuth, self.inbox.name)
+                self.server.replicate(source=self.parentCouchUrlWithAuth,
                                       destination="%s/%s" % (self.hostWithAuth, self.inbox.name),
                                       filter='WorkQueue/queueFilter',
-                                      query_params={'childUrl': self.queueUrl, 'parentUrl': self.parentCouchUrl},
+                                      query_params={'childUrl': self.queueUrl,
+                                                    'parentUrl': self.parentCouchUrl},
                                       continuous=continuous,
                                       cancel=cancel)
         except Exception as ex:
-            self.logger.warning('Replication from %s failed: %s' % (self.parentCouchUrl, str(ex)))
+            self.logger.warning('Replication from %s failed: %s' % (self.parentCouchUrlWithAuth, str(ex)))
 
     def sendToParent(self, continuous=True, cancel=False):
         """Replicate to parent couch - blocking: used only int test"""
         try:
-            if self.parentCouchUrl and self.queueUrl:
+            if self.parentCouchUrlWithAuth and self.queueUrlWithAuth:
                 self.logger.info("Forcing sendToParent from queueUrl %s/%s to parentCouch: %s",
-                                 self.queueUrl, self.inbox.name, self.parentCouchUrl)
+                                 self.queueUrlWithAuth, self.inbox.name, self.parentCouchUrlWithAuth)
                 self.server.replicate(source="%s" % self.inbox.name,
                                       destination=self.parentCouchUrlWithAuth,
                                       filter='WorkQueue/queueFilter',
-                                      query_params={'childUrl': self.queueUrl, 'parentUrl': self.parentCouchUrl},
+                                      query_params={'childUrl': self.queueUrl,
+                                                    'parentUrl': self.parentCouchUrl},
                                       continuous=continuous,
                                       cancel=cancel)
         except Exception as ex:
-            self.logger.warning('Replication to %s failed: %s' % (self.parentCouchUrl, str(ex)))
+            self.logger.warning('Replication to %s failed: %s' % (self.parentCouchUrlWithAuth, str(ex)))
 
     def getElementsForSplitting(self):
         """Returns the elements from the inbox that need to be split,

--- a/test/python/WMCore_t/DataStructs_t/MathStructs_t/ContinuousSummaryHistogram_t.py
+++ b/test/python/WMCore_t/DataStructs_t/MathStructs_t/ContinuousSummaryHistogram_t.py
@@ -14,6 +14,7 @@ from __future__ import division
 from builtins import range
 from future.utils import viewvalues
 
+import os
 import unittest
 import random
 
@@ -35,7 +36,7 @@ class ContinuousSummaryHistogramTest(unittest.TestCase):
         self.testInit.setLogging()
         self.testInit.setupCouch("histogram_dump_t")
         random.seed()
-        self.histogramDB = Database(dbname = "histogram_dump_t")
+        self.histogramDB = Database(url=os.getenv("COUCHURL"), dbname="histogram_dump_t")
 
     def tearDown(self):
         """

--- a/test/python/WMCore_t/DataStructs_t/MathStructs_t/DiscreteSummaryHistogram_t.py
+++ b/test/python/WMCore_t/DataStructs_t/MathStructs_t/DiscreteSummaryHistogram_t.py
@@ -13,6 +13,7 @@ Created on Nov 20, 2012
 
 from builtins import range
 import unittest
+import os
 
 from WMCore.DataStructs.MathStructs.DiscreteSummaryHistogram import DiscreteSummaryHistogram
 from WMCore.Database.CMSCouch import Database
@@ -31,7 +32,7 @@ class DiscreteSummaryHistogramTest(unittest.TestCase):
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
         self.testInit.setupCouch("histogram_dump_t")
-        self.histogramDB = Database(dbname = "histogram_dump_t")
+        self.histogramDB = Database(url=os.getenv("COUCHURL") ,dbname = "histogram_dump_t")
 
     def tearDown(self):
         """

--- a/test/python/WMCore_t/Database_t/RotatingDatabase_t.py
+++ b/test/python/WMCore_t/Database_t/RotatingDatabase_t.py
@@ -14,16 +14,7 @@ class RotatingDatabaseTest(unittest.TestCase):
     def setUp(self):
         self.couchURL = os.getenv("COUCHURL")
         self.server = CouchServer(self.couchURL)
-        # Kill off any databases left over from previous runs
-        # In python 3 the variables defined inside a comprehension are deteled
-        # outside the comprehension. See: pylint W1662 comprehension-escape
-        dbs = [db for db in self.server.listDatabases() if db.startswith('rotdb_unittest_')]
-        for db in dbs:
-            try:
-                self.server.deleteDatabase(db)
-            except:
-                pass
-        # Create a database, drop an existing one first
+
         testname = self.id().split('.')[-1].lower()
         self.dbname = 'rotdb_unittest_%s' % testname
         self.arcname = 'rotdb_unittest_%s_archive' % testname
@@ -35,16 +26,14 @@ class RotatingDatabaseTest(unittest.TestCase):
                                    archivename = self.arcname, timing = self.timing)
 
     def tearDown(self):
-        testname = self.id().split('.')[-1].lower()
-        if sys.exc_info()[0] == None:
-            # This test has passed, clean up after it
-            to_go = [db for db in self.server.listDatabases() if db.startswith('rotdb_unittest_%s' % testname)]
-            for dbname in to_go:
-                try:
-                    self.server.deleteDatabase(dbname)
-                except CouchNotFoundError:
-                    # db has already gone
-                    pass
+        """Delete all the test couchdb databases"""
+        to_go = [db for db in self.server.listDatabases() if db.startswith('rotdb_unittest_')]
+        for dbname in to_go:
+            try:
+                self.server.deleteDatabase(dbname)
+            except CouchNotFoundError:
+                # db has already gone
+                pass
 
     def testRotate(self):
         """

--- a/test/python/WMCore_t/JobStateMachine_t/Couchapp_t.py
+++ b/test/python/WMCore_t/JobStateMachine_t/Couchapp_t.py
@@ -9,26 +9,26 @@ know what they're doing, and for couchapps that will never need
 to be altered
 """
 import os
-import unittest
 import threading
+import unittest
+
+from WMCore_t.WMSpec_t.TestSpec import testWorkload
 
 import WMCore.WMBase
-
-from WMCore.WMBS.File                   import File
-from WMCore.WMBS.Fileset                import Fileset
-from WMCore.WMBS.Workflow               import Workflow
-from WMCore.WMBS.Subscription           import Subscription
-from WMCore.WMBS.JobGroup               import JobGroup
-from WMCore.WMBS.Job                    import Job
-from WMCore.DataStructs.Run             import Run
-from WMCore.Database.CMSCouch           import CouchServer
+from WMCore.DataStructs.Run import Run
+from WMCore.Database.CMSCouch import CouchServer
+from WMCore.FwkJobReport.Report import Report
 from WMCore.JobStateMachine.ChangeState import ChangeState
-from WMCore.WMSpec.Makers.TaskMaker     import TaskMaker
-from WMCore.Services.UUIDLib               import makeUUID
-from WMCore.FwkJobReport.Report         import Report
-from WMQuality.TestInitCouchApp         import TestInitCouchApp as TestInit
+from WMCore.Services.UUIDLib import makeUUID
+from WMCore.WMBS.File import File
+from WMCore.WMBS.Fileset import Fileset
+from WMCore.WMBS.Job import Job
+from WMCore.WMBS.JobGroup import JobGroup
+from WMCore.WMBS.Subscription import Subscription
+from WMCore.WMBS.Workflow import Workflow
+from WMCore.WMSpec.Makers.TaskMaker import TaskMaker
+from WMQuality.TestInitCouchApp import TestInitCouchApp as TestInit
 
-from WMCore_t.WMSpec_t.TestSpec     import testWorkload
 
 class CouchappTest(unittest.TestCase):
 
@@ -38,10 +38,9 @@ class CouchappTest(unittest.TestCase):
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
         self.testInit.setDatabaseConnection()
-        self.testInit.setSchema(customModules = ["WMCore.WMBS"],
-                                useDefault = False)
+        self.testInit.setSchema(customModules=["WMCore.WMBS"],
+                                useDefault=False)
         self.databaseName = "couchapp_t_0"
-
 
         # Setup config for couch connections
         config = self.testInit.getConfiguration()
@@ -52,14 +51,14 @@ class CouchappTest(unittest.TestCase):
         self.testInit.setupCouch(config.JobStateMachine.summaryStatsDBName, "SummaryStats")
 
         # Create couch server and connect to databases
-        self.couchdb      = CouchServer(config.JobStateMachine.couchurl)
+        self.couchdb = CouchServer(config.JobStateMachine.couchurl)
         self.jobsdatabase = self.couchdb.connectDatabase("%s/jobs" % config.JobStateMachine.couchDBName)
         self.fwjrdatabase = self.couchdb.connectDatabase("%s/fwjrs" % config.JobStateMachine.couchDBName)
         self.statsumdatabase = self.couchdb.connectDatabase(config.JobStateMachine.summaryStatsDBName)
 
         # Create changeState
         self.changeState = ChangeState(config)
-        self.config      = config
+        self.config = config
 
         # Create testDir
         self.testDir = self.testInit.generateWorkDir()
@@ -68,14 +67,13 @@ class CouchappTest(unittest.TestCase):
 
     def tearDown(self):
 
-        self.testInit.clearDatabase(modules = ["WMCore.WMBS"])
+        self.testInit.clearDatabase(modules=["WMCore.WMBS"])
         self.testInit.tearDownCouch()
         self.testInit.delWorkDir()
-        #self.testInit.tearDownCouch()
+        # self.testInit.tearDownCouch()
         return
 
-
-    def createWorkload(self, workloadName = 'Test', emulator = True):
+    def createWorkload(self, workloadName='Test', emulator=True):
         """
         _createTestWorkload_
 
@@ -92,9 +90,9 @@ class CouchappTest(unittest.TestCase):
 
         return workload
 
-    def createTestJobGroup(self, name = "TestWorkthrough",
-                           specLocation = "spec.xml", error = False,
-                           task = "/TestWorkload/ReReco", nJobs = 10):
+    def createTestJobGroup(self, name="TestWorkthrough",
+                           specLocation="spec.xml", error=False,
+                           task="/TestWorkload/ReReco", nJobs=10):
         """
         _createTestJobGroup_
 
@@ -103,18 +101,18 @@ class CouchappTest(unittest.TestCase):
 
         myThread = threading.currentThread()
 
-        testWorkflow = Workflow(spec = specLocation, owner = "Simon",
-                                name = name, task = task)
+        testWorkflow = Workflow(spec=specLocation, owner="Simon",
+                                name=name, task=task)
         testWorkflow.create()
 
-        testWMBSFileset = Fileset(name = name)
+        testWMBSFileset = Fileset(name=name)
         testWMBSFileset.create()
 
-        testFileA = File(lfn = makeUUID(), size = 1024, events = 10)
+        testFileA = File(lfn=makeUUID(), size=1024, events=10)
         testFileA.addRun(Run(10, *[12312]))
         testFileA.setLocation('malpaquet')
 
-        testFileB = File(lfn = makeUUID(), size = 1024, events = 10)
+        testFileB = File(lfn=makeUUID(), size=1024, events=10)
         testFileB.addRun(Run(10, *[12312]))
         testFileB.setLocation('malpaquet')
 
@@ -126,32 +124,32 @@ class CouchappTest(unittest.TestCase):
         testWMBSFileset.commit()
         testWMBSFileset.markOpen(0)
 
-        testSubscription = Subscription(fileset = testWMBSFileset,
-                                        workflow = testWorkflow)
+        testSubscription = Subscription(fileset=testWMBSFileset,
+                                        workflow=testWorkflow)
         testSubscription.create()
 
-        testJobGroup = JobGroup(subscription = testSubscription)
+        testJobGroup = JobGroup(subscription=testSubscription)
         testJobGroup.create()
 
         for i in range(0, nJobs):
-            testJob = Job(name = makeUUID())
+            testJob = Job(name=makeUUID())
             testJob.addFile(testFileA)
             testJob.addFile(testFileB)
             testJob['retry_count'] = 1
             testJob['retry_max'] = 10
-            testJob['mask'].addRunAndLumis(run = 10, lumis = [12312, 12313])
+            testJob['mask'].addRunAndLumis(run=10, lumis=[12312, 12313])
             testJobGroup.add(testJob)
 
         testJobGroup.commit()
 
         report = Report()
         if error:
-            path   = os.path.join(WMCore.WMBase.getTestBase(),
-                                  "WMComponent_t/JobAccountant_t/fwjrs", "badBackfillJobReport.pkl")
+            path = os.path.join(WMCore.WMBase.getTestBase(),
+                                "WMComponent_t/JobAccountant_t/fwjrs", "badBackfillJobReport.pkl")
         else:
             path = os.path.join(WMCore.WMBase.getTestBase(),
                                 "WMComponent_t/JobAccountant_t/fwjrs", "PerformanceReport2.pkl")
-        report.load(filename = path)
+        report.load(filename=path)
 
         self.changeState.propagate(testJobGroup.jobs, 'created', 'new')
         self.changeState.propagate(testJobGroup.jobs, 'executing', 'created')

--- a/test/python/WMCore_t/Services_t/Requests_t.py
+++ b/test/python/WMCore_t/Services_t/Requests_t.py
@@ -246,7 +246,8 @@ class testJSONRequests(unittest.TestCase):
     def testSpecialCharacterPasswords(self):
         url = 'http://username:p@ssw:rd@localhost:6666'
         req = JSONRequests(url)
-        self.assertEqual(req['host'], 'http://localhost:6666')
+        # the url is sanitized before persisted in the object
+        self.assertEqual(req['host'], "http://localhost:6666")
         self.assertEqual(req.additionalHeaders['Authorization'], 'Basic dXNlcm5hbWU6cEBzc3c6cmQ=')
 
 

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
@@ -82,14 +82,13 @@ def syncQueues(queue, skipWMBS=False):
     """Sync parent & local queues and split work
         Workaround having to wait for couchdb replication and splitting polling
     """
-
     queue.backend.forceQueueSync()
-    time.sleep(2)
+    time.sleep(1)
     work = queue.processInboundWork()
     queue.performQueueCleanupActions(skipWMBS=skipWMBS)
-    queue.backend.forceQueueSync()
+    # queue.backend.forceQueueSync() ## FIXME TODO: AMR, maybe revert it
     # after replication need to wait a while to update result
-    time.sleep(2)
+    time.sleep(1)
     return work
 
 
@@ -319,27 +318,6 @@ class WorkQueueTest(WorkQueueTestCase):
         super(WorkQueueTest, self).tearDown()
         # Delete WMBSAgent config file
         EmulatorSetup.deleteConfig(self.configFile)
-
-    def createWQReplication(self, parentQURL, childURL):
-        wqfilter = 'WorkQueue/queueFilter'
-        query_params = {'childUrl': childURL, 'parentUrl': sanitizeURL(parentQURL)['url']}
-        localQInboxURL = "%s_inbox" % childURL
-        replicatorDocs = []
-        replicatorDocs.append({'source': sanitizeURL(parentQURL)['url'], 'target': localQInboxURL,
-                               'filter': wqfilter, 'query_params': query_params})
-        replicatorDocs.append({'source': sanitizeURL(localQInboxURL)['url'], 'target': parentQURL,
-                               'filter': wqfilter, 'query_params': query_params})
-
-        for rp in replicatorDocs:
-            self.localCouchMonitor.couchServer.replicate(
-                rp['source'], rp['target'], filter=rp['filter'],
-                query_params=rp.get('query_params', False),
-                continuous=False)
-        return
-
-    def pullWorkWithReplication(self, localQ, resources):
-        localQ.pullWork(resources)
-        self.createWQReplication(localQ.params['ParentQueueCouchUrl'], localQ.params['QueueURL'])
 
     def createResubmitSpec(self, serverUrl, couchDB, parentage=False):
         """
@@ -1249,7 +1227,7 @@ class WorkQueueTest(WorkQueueTestCase):
         self.assertEqual(0, len(self.queue.getWork({'T2_XX_SiteA': 1000}, {})))
 
     def testWMBSInjectionStatus(self):
-
+        syncQueues(self.localQueue)
         self.globalQueue.queueWork(self.spec.specUrl())
         processingSpec = self.setupReReco(assignArgs={'SiteWhitelist': ["T2_XX_SiteA"]})
         self.globalQueue.queueWork(processingSpec.specUrl())
@@ -1265,7 +1243,6 @@ class WorkQueueTest(WorkQueueTestCase):
                          [{'testProcessing': False}, {'testProduction': False}])
         self.assertEqual(self.localQueue.getWMBSInjectionStatus(self.spec.name()),
                          False)
-        syncQueues(self.localQueue)
         self.localQueue.processInboundWork()
         self.localQueue.updateLocationInfo()
         self.localQueue.getWork({'T2_XX_SiteA': 1000},
@@ -1277,11 +1254,10 @@ class WorkQueueTest(WorkQueueTestCase):
 
         # update parents status but is still running open since it is the default
         self.localQueue.performQueueCleanupActions()
-        self.localQueue.backend.sendToParent(continuous=False)
+        # NOTE: these 2 assertions below are different when running from local docker container
         self.assertEqual(self.localQueue.getWMBSInjectionStatus(),
                          [{'testProcessing': False}, {'testProduction': False}])
-        self.assertEqual(self.localQueue.getWMBSInjectionStatus(self.spec.name()),
-                         False)
+        self.assertEqual(self.localQueue.getWMBSInjectionStatus(self.spec.name()), False)
 
         # close the global inbox elements, they won't be split anymore
         #self.globalQueue.closeWork(['testProcessing', 'testProduction'])
@@ -1360,16 +1336,23 @@ class WorkQueueTest(WorkQueueTestCase):
         # FIXME: This does not work currently because we don't actually have 0 event blocks.
 
         Globals.GlobalParams.setNumOfEventsPerFile(0)
+        syncQueues(self.localQueue)
+
         processingSpec = self.setupReReco(assignArgs={'SiteWhitelist': ["T2_XX_SiteA"]})
         processingSpec.setStartPolicy('Block', SliceType='NumberOfEvents')
         processingSpec.save(processingSpec.specUrl())
         self.globalQueue.queueWork(processingSpec.specUrl())
-        # all blocks pulled as each has 0 jobs
+        # pulls one block from global queue to local queue inbox
         self.assertEqual(self.localQueue.pullWork({'T2_XX_SiteA': 1}), 1)
-        syncQueues(self.localQueue)
-        self.assertEqual(len(self.localQueue.status()), 1)
-        self.assertEqual(len(self.localQueue.getWork({'T2_XX_SiteA': 1},
-                                                     {})), 1)
+        time.sleep(1)
+        # now we should have 1 element in the local inbox and 0 in local queue
+        self.assertEqual(len(self.localQueue.statusInbox()), 1)
+        self.assertEqual(len(self.localQueue.status()), 0)
+
+        self.localQueue.processInboundWork()
+        time.sleep(1)
+        # now acquire the local inbox element (create it in the local queue)
+        self.assertEqual(len(self.localQueue.getWork({'T2_XX_SiteA': 1}, {})), 1)
         for element in self.localQueue.status():
             # check files added and subscription made
             self.assertEqual(element['NumOfFilesAdded'], 1)


### PR DESCRIPTION
Partially fixes #8853 

#### Status
ready

#### Description
This PR provides almost all the necessary changes to switch CouchDB from version 1.6.1 to 3.1.2 (in addition to https://github.com/dmwm/WMCore/pull/11011).

Summary of changes are:
* a few minor enhancements here and there (like less calls to the `_dbs` API)
* it looks like replication in CouchDB 3.x isn't triggered right after the document is created, but there is a daemon scheduling replications, thus sometimes we cannot find the expected documents in the target database until we give it enough time to get triggered - add a small - configurable - delay after creating replication docs to allow unit tests to succeed
* CouchDB replication no longer supports (since 2.x) short names for source/target, we need to provide the full URLs and also credentials, even if replication is localhost only. Also change replication for tests to continuous mode
* ensure `RequestDBWriter` has the correct url+credentials to avoid authz errors
* report more information when a couch http operation fails.
* created new exception for CouchDB error status `410 - Gone`
* replace temporary views by standard design document (with "permanent" views)
* fixed the CMSCouch RotatingDatabase class
* added a very basic safeguard mechanism to avoid deletion of databases hosted in CMSWEB
* made replication deletion/creation in AgentStatusWatcher more verbose

In terms of tests, these are the changes:
* fixed setUp/tearDown methods for CMSCouch_t.py (and a few unit tests)
* fixed couch url for ContinuousSummaryHistogram_t.py and DiscreteSummaryHistogram_t.py
* fixed a few unit tests for WorkQueue_t.py
* fixed unit tests for Couchapp_t.py, including pylint reformat
* fixed unit test for Requests_t.py
* properly setUp and tearDown RotatingDatabase_t.py tests 
* removed unused replication code in WorkQueue_t

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
To go after https://github.com/dmwm/WMCore/pull/11011

#### External dependencies / deployment changes
cmsdist changes: https://github.com/cms-sw/cmsdist/pull/7218
Deployment changes: https://github.com/dmwm/deployment/pull/1088