### PR TITLE
fix uninitialized templates variable in workflow injection script

### DIFF
--- a/test/data/ReqMgr/inject-test-wfs.py
+++ b/test/data/ReqMgr/inject-test-wfs.py
@@ -196,6 +196,7 @@ def main():
             templates = [args.filename]
         else:
             logger.info("File %s not found.", wmcorePath + args.filename)
+            templates = []
     else:
         templates = os.listdir(wmcorePath)
 


### PR DESCRIPTION
Fixes #11003

#### Status
tested

#### Description
Just added a one-liner to initialize templates in the affected code path
