### PR TITLE
make sure proxy is 2048 bit. Fix #11005

### DIFF
--- a/src/python/WMCore/Credential/Proxy.py
+++ b/src/python/WMCore/Credential/Proxy.py
@@ -698,7 +698,7 @@ class Proxy(Credential):
         cmdList = []
         cmdList.append('env')
         cmdList.append('X509_USER_PROXY=%s' % proxy)
-        cmdList.append('voms-proxy-init -noregen -voms %s -out %s -bits 1024 -valid %s %s'
+        cmdList.append('voms-proxy-init -noregen -voms %s -out %s -bits 2048 -valid %s %s'
                        % (voAttribute, proxy, vomsValid, '-rfc' if isRFC  else ''))
         cmd = ' '.join(cmdList)
         msg, _, retcode = execute_command(self.setEnv(cmd), self.logger, self.commandTimeout)


### PR DESCRIPTION
Fixes #11005

#### Status
ready

#### Description
will call `voms-proxy-init` with `-bit 2048` option (default is 1024).
with reference to discussion in https://cms-talk.web.cern.ch/t/repost-fts-proxy-issues-it-uses-1024-bits/6827
I have tested the -bits 2048 option in CRAB TaskWorker and works as expected. As noted in that CMSTalks thread, this makes no difference in the end for CRAB since HTCondor creates new proxies on sched and WN's and makes them 2048 bits already, but it will help mind sanity to have all proxy files with same key length.

FWIW, in my testing myproxy-logon creates a 2048-bity proxy

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
