### PR TITLE
Add mockMongoDB to MSUnmerged and MongoDB Class init optoins

### DIFF
--- a/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
+++ b/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
@@ -112,6 +112,7 @@ class MSUnmerged(MSCore):
         self.msConfig.setdefault("mongoDB", 'msUnmergedDB')
         self.msConfig.setdefault("mongoDBRetryCount", 3)
         self.msConfig.setdefault("mongoDBReplicaset", None)
+        self.msConfig.setdefault("mockMongoDB", False)
 
         msUnmergedIndex = IndexModel('name', unique=True)
         msUnmergedDBConfig = {
@@ -121,6 +122,7 @@ class MSUnmerged(MSCore):
             'replicaset': self.msConfig['mongoDBReplicaset'],
             'logger': self.logger,
             'create': True,
+            'mockMongoDB': self.msConfig['mockMongoDB'],
             'collections': [('msUnmergedColl', msUnmergedIndex)]}
 
         mongoClt = MongoDB(**msUnmergedDBConfig)


### PR DESCRIPTION
Fixes #10978 

#### Status
Ready

#### Description
With the current PR, we add one additional option to both MSUnmerged and MongoDB classes so that we can request the creation of a mocked MongoDB client for the Services' unit tests. The default value for this parameter is set to `False`. 

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
UPDATE: depends on this new spec: https://github.com/cms-sw/cmsdist/pull/7598
