### PR TITLE
Explicitly create proxies with 2048 bits

### DIFF
--- a/deploy/renew_proxy.sh
+++ b/deploy/renew_proxy.sh
@@ -7,5 +7,5 @@ if [[ "$credname" == amaltaroCERN ]]; then
     source /data/srv/wmagent/current/apps/wmagent/etc/profile.d/init.sh
 fi
 myproxy-get-delegation -v -l amaltaro -t 168 -s 'myproxy.cern.ch' -k $credname -n \
-  -o /data/certs/mynewproxy.pem && voms-proxy-init -rfc -voms cms:/cms/Role=production -valid 168:00 \
+  -o /data/certs/mynewproxy.pem && voms-proxy-init -rfc -voms cms:/cms/Role=production -valid 168:00 -bits 2048 \
   -noregen -cert /data/certs/mynewproxy.pem -key /data/certs/mynewproxy.pem -out /data/certs/myproxy.pem


### PR DESCRIPTION
Fixes #11005 
Complement to https://github.com/dmwm/WMCore/pull/11006

#### Status
ready

#### Description
Ensure that proxies created in the WMAgent nodes are made with 2048 bits in key.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
https://github.com/dmwm/WMCore/pull/11006

#### External dependencies / deployment changes
None
