### PR TITLE
[CouchDB] Remove CouchDB all_or_nothing option for bulk API

### DIFF
--- a/src/python/WMCore/Database/CMSCouch.py
+++ b/src/python/WMCore/Database/CMSCouch.py
@@ -279,7 +279,7 @@ class Database(CouchDBRequests):
         its internal retval
 
         key, value pairs can be used to pass extra parameters to the bulk doc api
-        See http://wiki.apache.org/couchdb/HTTP_Bulk_Document_API
+        See https://docs.couchdb.org/en/latest/api/database/bulk-api.html#db-bulk-docs
 
         TODO: restore support for returndocs and viewlist
 

--- a/src/python/WMCore/WorkQueue/WorkQueueBackend.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueBackend.py
@@ -158,7 +158,6 @@ class WorkQueueBackend(object):
         self.insertWMSpec(units[0]['WMSpec'])
         newUnitsInserted = []
         for unit in units:
-
             # cast to couch
             if not isinstance(unit, CouchWorkQueueElement):
                 unit = CouchWorkQueueElement(self.db, elementParams=dict(unit))
@@ -171,10 +170,11 @@ class WorkQueueBackend(object):
             if unit._couch.documentExists(unit.id):
                 self.logger.info('Element "%s" already exists, skip insertion.' % unit.id)
                 continue
-            else:
-                newUnitsInserted.append(unit)
+
+            newUnitsInserted.append(unit)
             unit.save()
-            unit._couch.commit(all_or_nothing=True)
+            # FIXME: this is not performing bulk request, but single document commits(!)
+            unit._couch.commit()
 
         return newUnitsInserted
 


### PR DESCRIPTION
Fixes #11009 
Superseeds https://github.com/dmwm/WMCore/pull/10780

#### Status
ready

#### Description
CouchDB `all_or_nothing` option is no longer available for bulk APIs. This PR stops using that option.
Note that if there is a conflict with one or more of the documents being updated, the conflict is only resolved if a callback function is passed over.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Superseeds https://github.com/dmwm/WMCore/pull/10780
by adding a few extra checks in the tests and other minor improvements.

Many other changes have been provided in this PR: https://github.com/dmwm/WMCore/pull/11001

#### External dependencies / deployment changes
Changes required for CouchDB 3.x, but can also be merged while we are at CouchDB 1.6.