### PR TITLE
Copy DQM ROOT file to EOS and register entry in DQMUpload executor

### DIFF
--- a/src/python/WMCore/WMExceptions.py
+++ b/src/python/WMCore/WMExceptions.py
@@ -184,7 +184,12 @@ WM_JOB_ERROR_CODES = {-1: "Error return without specification.",
                       60409: "Timeout in stage out of log files during log collection (WMAgent).",  # (WMA)
                       60450: "No output files present in the report",  # (WMA)
                       60451: "Output file lacked adler32 checksum (WMAgent).",  # (WMA)
+                      70317: "Indefinite hangout while staging out DQM root file to EOS",  # (WMA)
                       70318: "Failure in DQM upload.",
+                      70319: "HTTP POST to DQM register url failed.",  # (WMA)
+                      70320: "Error while retrieving run number from job definition.",  # (WMA)
+                      70321: "Indefinite hang while deleting file from EOS.",  # (WMA)
+                      70322: "General failure while deleting file from EOS.",  # (WMA)
                       70452: "No run/lumi information in file (WMAgent).",
                       71101: "No sites are available to submit the job because the location of its input(s) do not pass the site whitelist/blacklist restrictions (WMAgent).",
                       71102: "The job can only run at a site that is currently in Aborted state (WMAgent).",

--- a/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
@@ -12,6 +12,8 @@ from future.utils import viewitems
 import logging
 import os
 import sys
+import pickle
+import json
 from io import BytesIO
 from functools import reduce
 from gzip import GzipFile
@@ -40,7 +42,11 @@ from WMCore.FwkJobReport.Report import Report
 from WMCore.Services.HTTPS.HTTPSAuthHandler import HTTPSAuthHandler
 from WMCore.WMSpec.Steps.Executor import Executor
 from WMCore.WMSpec.Steps.WMExecutionFailure import WMExecutionFailure
-
+from WMCore.Algorithms.Alarm import Alarm, alarmHandler
+from WMCore.Storage.DeleteMgr import DeleteMgr, DeleteMgrError
+from WMCore.Storage.FileManager import DeleteMgr as NewDeleteMgr
+import WMCore.Storage.StageOutMgr as StageOutMgr
+import WMCore.WMRuntime.Bootstrap as Bootstrap
 
 class DQMUpload(Executor):
     """
@@ -49,6 +55,14 @@ class DQMUpload(Executor):
     Execute a DQMUpload Step
 
     """
+
+    def __init__(self):
+        super(DQMUpload, self).__init__()
+        self.retryDelay = 300
+        self.retryCount = 3
+        self.registerLFNBase = '/store/unmerged/DQMGUI'
+        self.registerEOSPrefix = '/eos/cms'
+        self.registerURL = 'https://cmsweb-testbed.cern.ch/dqm/offline-test-new/api/v1/register'
 
     def pre(self, emulator=None):
         """
@@ -110,9 +124,11 @@ class DQMUpload(Executor):
             for analysisFile in analysisFiles:
                 # only deal with DQM files
                 if analysisFile.FileClass == "DQM":
-                    # uploading file to the server
+                    # uploading file to the server (old visDQMUpload method)
                     self.httpPost(os.path.join(stepLocation,
                                                os.path.basename(analysisFile.fileName)))
+                    # Upload to EOS and register (new method)
+                    self.uploadToEOSAndRegister(step, stepLocation, analysisFile)
 
             # Am DONE with report
             # Persist it
@@ -293,3 +309,229 @@ class DQMUpload(Executor):
             data = GzipFile(fileobj=BytesIO(data)).read()
 
         return (result.headers, data)
+
+    def _uploadToEOS(self, analysisFile, stepLocation):
+        """
+        upload  an analysis file to EOS
+        :return: boolean with upload status
+        """
+        overrides = {}
+        if hasattr(self.step, 'override'):
+            overrides = self.step.override.dictionary_()
+        eosStageOutParams = {}
+        eosStageOutParams['command'] = overrides.get('command', "xrdcp")
+        eosStageOutParams['option'] = overrides.get('option', "--wma-disablewriterecovery")
+        eosStageOutParams['phedex-node'] = overrides.get('eos-phedex-node', "T2_CH_CERN")
+        eosStageOutParams['lfn-prefix'] = overrides.get('eos-lfn-prefix',
+                                                         "root://eoscms.cern.ch/%s" % self.registerEOSPrefix)
+
+        # Switch between old and newstageOut manager.
+        # Use old by default
+        useNewStageOutCode = False
+        if 'newStageOut' in overrides and overrides.get('newStageOut'):
+            useNewStageOutCode = True
+
+        if not useNewStageOutCode:
+            # old style
+            eosmanager = StageOutMgr.StageOutMgr(**eosStageOutParams)
+            eosmanager.numberOfRetries = self.retryCount
+            eosmanager.retryPauseTime = self.retryDelay
+        else:
+            # new style
+            logging.info("DQMUpload is using new StageOut code for EOS Copy")
+            eosmanager = WMCore.Storage.FileManager.StageOutMgr(
+                    retryPauseTime=self.retryDelay,
+                    numberOfRetries=self.retryCount,
+                    **eosStageOutParams)
+
+        eosFileInfo = {'LFN': self.getAnalysisFileLFN(analysisFile),
+                       'PFN': os.path.join(stepLocation, 
+                                           os.path.basename(analysisFile.fileName)),
+                       'PNN': None,
+                       'GUID': None
+                       }
+
+        msg = "Writing DQM root files to CERN EOS with retries: %s and retry pause: %s"
+        logging.info(msg, eosmanager.numberOfRetries, eosmanager.retryPauseTime)
+        try:
+            eosmanager(eosFileInfo)
+        except Alarm:
+            msg = "Indefinite hangout while staging out to EOS"
+            logging.error(msg)
+            raise WMExecutionFailure(70317, "DQMUploadStageOutTimeout", msg)
+        except Exception as ex:
+            msg = "EOS copy failed, lfn: %s. Error: %s" % (eosFileInfo['LFN'], str(ex))
+            logging.exception(msg)
+            raise WMExecutionFailure(70318, "DQMUploadFailure", msg)
+
+        return eosFileInfo['LFN']
+
+    def getAnalysisFileLFN(self, analysisFile):
+        """
+        Construct an LFN for an analysisFile
+        """
+        # If lfn start with '/', make it relative to it
+        lfnFile = os.path.relpath(analysisFile.lfn, start='/')
+        lfn = os.path.join(self.registerLFNBase, lfnFile)
+    
+        return lfn
+
+    def _register(self, registerURL, args):
+        """
+        POST request to register URL
+        """
+
+        ident = "WMAgent python/%d.%d.%d" % sys.version_info[:3]
+        uploadProxy = self.step.upload.proxy or os.environ.get('X509_USER_PROXY', None)
+        logging.info("Using proxy file: %s", uploadProxy)
+        logging.info("Using CA certificate path: %s", os.environ.get('X509_CERT_DIR'))
+
+        msg = "HTTP Register POST arguments: %s\n" % args
+        logging.info(msg)
+
+        handler = HTTPSAuthHandler(key=uploadProxy, cert=uploadProxy)
+        opener = OpenerDirector()
+        opener.add_handler(handler)
+
+        # setup the request object
+        url = decodeBytesToUnicode(registerURL)
+        datareq = Request(url)
+        datareq.add_header('Accept-encoding', 'gzip')
+        datareq.add_header('User-agent', ident)
+        datareq.data = encodeUnicodeToBytes(json.dumps(args))
+
+        if 'https://' in url:
+            result = opener.open(datareq)
+        else:
+            opener.add_handler(ProxyHandler({}))
+            result = opener.open(datareq)
+
+        return result
+    
+    def _registerAnalysisFile(self, stepName, analysisFile):
+        """
+        Register a file to new DQM GUi
+        - https://github.com/cms-DQM/dqmgui
+        HTTP request body:
+            [{"dataset": "/a/b/c", "run": "123456", "lumi": "0", "file": "/eos/cms/store/group/comm_dqm/DQMGUI_data/location/file.root", "fileformat": 1}]
+        Set lumis to 0, as this is reproducing current per Run based root files
+        - https://github.com/dmwm/WMCore/issues/10287#issuecomment-1052558061
+        DQM root files produced by Harvesting prosessing are type 1 (plain ROOT)
+        - https://github.com/cms-DQM/dqmgui#file-formats
+        """
+        # Get task description
+        job = Bootstrap.loadJobDefinition()
+        jobBag = job.getBaggage()
+        datasetName = job.get('inputDataset', None)
+
+        # Get runNumber, depending on the harvesting job mode (byRun vs multiRun)
+        multiRun = getattr(jobBag, "multiRun", False)
+        forceRunNumber = getattr(jobBag, "forceRunNumber", 999999)
+        if multiRun:
+            runNumber = forceRunNumber
+        else:
+            try:
+                runNumber = list(job['mask']['runAndLumis'].keys())[0]
+            except Exception as ex:
+                msg = "Error while retrieving run number from job definition:\n %s" % str(ex)
+                raise WMExecutionFailure(70320, "DQMUploadFailure", msg)    
+
+        args = {}
+        args['file'] = self.registerEOSPrefix + \
+                self.getAnalysisFileLFN(analysisFile)
+        args['dataset'] = datasetName
+        args['run'] = runNumber
+        args['lumi'] = 0
+        args['fileformat'] = 1
+
+        msg = "HTTP Upload is about to start:\n"
+        msg += " => URL: %s\n" % self.registerURL
+        msg += " => Filename: %s\n" % args['file']
+        logging.info(msg)
+
+        try:
+            logException = True
+            for registerURL in self.registerURL.split(';'):
+                result = self._register(registerURL, [args])
+                msg = '  Status code: %s\n' % result.getcode()
+                if result.getcode() >= 400 or result.getcode() is None:
+                    logException = False
+                    raise Exception(msg)
+                else:
+                    msg = 'HTTP POST to register url finished succesfully with response:\n' + msg
+                    logging.info(msg)
+        except Exception as ex:
+            msg = 'HTTP POST to register url failed! Error:\n%s' % str(ex)
+            if logException:
+                logging.exception(msg)
+            else:
+                logging.error(msg)
+            raise WMExecutionFailure(70319, "DQMUploadFailure", msg)
+
+        return
+
+    def _deleteFromEOS(self, eosFileLFN):
+        """
+        Delete a file uploaded to EOS.
+        I.e.: If we upload a DQM root file but registration failed for some reason
+        """
+        overrides = {}
+        if hasattr(self.step, 'override'):
+            overrides = self.step.override.dictionary_()
+
+        # Note "xrdcp" here will basically map to the XRDCPImpl storage backend
+        # The actual delete command is set in the backend
+        eosStageOutParams = {}
+        eosStageOutParams['command'] = overrides.get('command', "xrdcp")
+        eosStageOutParams['phedex-node'] = overrides.get('eos-phedex-node', "T2_CH_CERN")
+        eosStageOutParams['lfn-prefix'] = overrides.get('eos-lfn-prefix',
+                                                         "root://eoscms.cern.ch/%s" % self.registerEOSPrefix)
+
+        # Switch between old and new stageOut manager.
+        # Use old by default
+        useNewStageOutCode = False
+        if 'newStageOut' in overrides and overrides.get('newStageOut'):
+            useNewStageOutCode = True
+
+        if not useNewStageOutCode:
+            # old style
+            manager = DeleteMgr(**eosStageOutParams)
+            manager.numberOfRetries = self.retryCount
+            manager.retryPauseTime = self.retryDelay
+        else:
+            # new style
+            logging.info("DQMUpload is using new StageOut code to delete files from EOS")
+            manager = NewDeleteMgr(retryPauseTime=self.retryDelay,
+                                   numberOfRetries=self.retryCount,
+                                   **eosStageOutParams)
+
+        logging.info("Deleting LFN: %s", eosFileLFN)
+        eosFileInfo = {'LFN': eosFileLFN,
+                           'PFN': None, # PFNs are assigned in the Delete Manager
+                           'PNN': None, # PNNs are assigned in the Delete Manager
+                           'StageOutCommand': None}
+        try:
+            manager(fileToDelete=eosFileInfo)
+        except Alarm:
+            msg = "Indefinite hang while deleting file from EOS"
+            logging.error(msg)
+            raise WMExecutionFailure(70321, "DQMUploadStageOutTimeout", msg)
+        except Exception as ex:
+            msg = "General failure while deleting file. Error: %s" % str(ex)
+            logging.error(msg)
+            raise WMExecutionFailure(70322, "DQMUploadFailure", msg)
+
+        return
+
+    def uploadToEOSAndRegister(self, stepName, stepLocation, analysisFile):
+        """
+        Copy DQM Root files to EOS and register files to new DQMGUI
+        """
+        eosFileLFN = self._uploadToEOS(analysisFile, stepLocation)
+        try:
+            self._registerAnalysisFile(stepName, analysisFile)
+        except:
+            # If we fail to register, delete uploaded file
+            self._deleteFromEOS(eosFileLFN)
+            raise
+        return


### PR DESCRIPTION
Fixes #10287

#### Status
New changes being tested

#### Description
This implements the new DQM Gui method described in #10287

- Copy DQM root file to EOS
- Register entry to new DQMGUI: Note this does not upload any files. It registers one root file per call, right after the file has been uploaded to EOS.  
- Delete files uploaded to EOS if registration fails
- Use value of forceRunNumber for multiRun, to replicate current behavior by old visDQMGUI

#### Is it backward compatible (if not, which system it affects?)
YES