### PR TITLE
Allow MongoDB to be instantiated without mongomock library

### DIFF
--- a/src/python/WMCore/Database/MongoDB.py
+++ b/src/python/WMCore/Database/MongoDB.py
@@ -5,28 +5,24 @@ Description: Provides a wrapper class for MongoDB
 
 # futures
 from __future__ import division, print_function
-
 from builtins import str, object
 
+try:
+    import mongomock
+except ImportError:
+    # this library should only be required by unit tests
+    mongomock = None
+
 from pymongo import MongoClient, errors, IndexModel
-import mongomock
 
 
 class MongoDB(object):
     """
     A simple wrapper class for creating a connection to a MongoDB instance
     """
-    def __init__(self,
-                 database=None,
-                 server=None,
-                 port=None,
-                 replicaset=None,
-                 create=False,
-                 collections=None,
-                 testIndexes=False,
-                 logger=None,
-                 mockMongoDB=False,
-                 **kwargs):
+    def __init__(self, database=None, server=None, port=None, replicaset=None,
+                 create=False, collections=None, testIndexes=False,
+                 logger=None, mockMongoDB=False, **kwargs):
         """
         :databases:   A database Name to connect to
         :server:      The server url (see https://docs.mongodb.com/manual/reference/connection-string/)
@@ -44,6 +40,10 @@ class MongoDB(object):
         self.port = port # 8230
         self.logger = logger
         self.mockMongoDB = mockMongoDB
+        if mockMongoDB and mongomock is None:
+            msg = "You are trying to mock MongoDB, but you do not have mongomock in the python path."
+            self.logger.critical(msg)
+            raise ImportError(msg)
         try:
             if mockMongoDB:
                 self.client = mongomock.MongoClient()


### PR DESCRIPTION
Fixes #11022 

#### Status
ready

#### Description
Don't crash the service that is importing MongoDB if it does not have the `mongomock` library in the path, which is actually only needed for unit tests.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Complement for: https://github.com/dmwm/WMCore/pull/11007

#### External dependencies / deployment changes
None
