### PR TITLE
Add rse=ALL_DOCS to the MSUnmerged info REST API.

### DIFF
--- a/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
+++ b/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
@@ -822,21 +822,38 @@ class MSUnmerged(MSCore):
         data = {}
         if kwargs.get('rse'):
             data["query"] = 'rse=%s&detail=%s' % (kwargs['rse'], detail)
-            mongoProjection = {"_id": False,
-                               "name": True,
-                               "pfnPrefix": True,
-                               "rucioConMonStatus": True,
-                               "isClean": True,
-                               "timestamps": True,
-                               "counters": True}
-            if detail:
-                mongoProjection["dirs"]  = True
+            allDocs = (kwargs['rse'].lower() == "all_docs") if isinstance(kwargs['rse'], str) else False
 
-            rseList = kwargs['rse'] if isinstance(kwargs['rse'], list) else [kwargs['rse']]
-            data["rseData"] = []
-            for rseName in rseList:
-                mongoFilter = {'name': rseName}
-                data["rseData"].append(self.msUnmergedColl.find_one(mongoFilter, projection=mongoProjection))
+            if allDocs:
+                mongoProjection = {
+                    "_id": False,
+                    "name": True,
+                    "isClean": True,
+                    "rucioConMonStatus": True,
+                    "counters": {
+                        "gfalErrors": True,
+                        "dirsToDelete": True,
+                        "dirsDeletedSuccess": True,
+                        "dirsDeletedFail": True}}
+                mongoFilter = {}
+                data["rseData"] = list(self.msUnmergedColl.find(mongoFilter, projection=mongoProjection))
+            else:
+                mongoProjection = {
+                    "_id": False,
+                    "name": True,
+                    "isClean": True,
+                    "pfnPrefix": True,
+                    "rucioConMonStatus": True,
+                    "timestamps": True,
+                    "counters": True}
+                if detail:
+                    mongoProjection["dirs"]  = True
+
+                rseList = kwargs['rse'] if isinstance(kwargs['rse'], list) else [kwargs['rse']]
+                data["rseData"] = []
+                for rseName in rseList:
+                    mongoFilter = {'name': rseName}
+                    data["rseData"].append(self.msUnmergedColl.find_one(mongoFilter, projection=mongoProjection))
         return data
 
     # @profile


### PR DESCRIPTION
Fixes #10995 

#### Status
ready

#### Description
With the current PR we implement ad a simple addition of `rse=ALL_DOCS` to the info REST API for MSUnmerged, so that we can get the counters for all the RSEs with the `gfal` errors. 

**NOTE:**
This will not get the whole document stored in MongoDB. This interface is to serve only for collecting all `gfal` errors for all RSEs.    

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
