### PR TITLE
Fix MSTransferor typo calling getName method

### DIFF
--- a/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
+++ b/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
@@ -199,7 +199,7 @@ class MSTransferor(MSCore):
                 self.checkPUDataLocation(wflow)
                 if wflow.getSecondarySummary() and not wflow.getPURSElist():
                     # then we still have pileup to be transferred, but with incorrect locations
-                    self.alertPUMisconfig(wflow.getname())
+                    self.alertPUMisconfig(wflow.getName())
                     # FIXME: this needs to be logged somewhere and workflow be set to failed
                     counterProblematicRequests += 1
                     continue
@@ -225,7 +225,7 @@ class MSTransferor(MSCore):
                         counterSuccessRequests += 1
                     else:
                         counterFailedRequests += 1
-                        self.alertTransferCouchDBError(wflow.getname())
+                        self.alertTransferCouchDBError(wflow.getName())
                 else:
                     counterFailedRequests += 1
             # it can go slightly beyond the limit. It's evaluated for every slice


### PR DESCRIPTION
Fixes #11030 

#### Status
ready

#### Description
The title says it all, correct the method name called for the `Workflow` object, which should be `getName()`.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Complement to https://github.com/dmwm/WMCore/pull/10959

#### External dependencies / deployment changes
None
