### PR TITLE
MSTransferor: fix positional and kwargs passed to sendAlert API

### DIFF
--- a/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
+++ b/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
@@ -739,14 +739,14 @@ class MSTransferor(MSCore):
             self.logger.info(msg, wflow.getName(), dids, rseExpr, ruleAttrs)
         return success, transferId
 
-    def sendAlert(self, alertName, severity, summary, description, service, endSecs = 1 * 60 * 60):
+    def sendAlert(self, alertName, severity, summary, description, service, endSecs=1 * 60 * 60):
         """
         Send alert to Prometheus, wrap function in a try-except clause
         """
         try:
             # alert to expiry in an hour from now
             self.alertManagerApi.sendAlert(alertName, severity, summary, description,
-                                           service, endSecs)
+                                           service, endSecs=endSecs)
         except Exception as ex:
             self.logger.exception("Failed to send alert to %s. Error: %s", self.alertManagerUrl, str(ex))
 


### PR DESCRIPTION
Fixes #11031
Actually, it fixes the error reported in this comment: https://github.com/dmwm/WMCore/pull/11031#issuecomment-1064014828

#### Status
ready

#### Description
The current code was actually assigning `endSecs` to the `tag` kwarg in the method definition:
https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/Services/AlertManager/AlertManagerAPI.py#L32

with this fix, we pass `endSecs` as a keyword argument such that parameters are properly passed through.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
