### PR TITLE
Prevent excessive calls for agent config from ReqMgrAux database

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -91,6 +91,8 @@ config.General.logdb_name = logDBName
 config.General.central_logdb_url = "need to get from secrets file"
 config.General.ReqMgr2ServiceURL = "ReqMgr2 rest service"
 config.General.centralWMStatsURL = "Central WMStats URL"
+# ReqMgrAux disk cache duration (in hours), set to 5 minutes: 5 / 60 = 0.083
+config.General.ReqMgrAuxCacheDuration = 0.083
 
 config.section_("JobStateMachine")
 config.JobStateMachine.couchurl = couchURL

--- a/src/python/WMComponent/AgentStatusWatcher/DrainStatusPoller.py
+++ b/src/python/WMComponent/AgentStatusWatcher/DrainStatusPoller.py
@@ -36,7 +36,8 @@ class DrainStatusPoller(BaseWorkerThread):
         self.agentConfig = {}
         self.previousConfig = {}
         self.validSpeedDrainConfigKeys = ['CondorPriority', 'NoJobRetries', 'EnableAllSites']
-        self.reqAuxDB = ReqMgrAux(self.config.General.ReqMgr2ServiceURL)
+        cacheduration = getattr(self.config.General, "ReqMgrAuxCacheDuration", 5 / 60)  # 5 minutes
+        self.reqAuxDB = ReqMgrAux(self.config.General.ReqMgr2ServiceURL, httpDict={'cacheduration': cacheduration})
         self.emailAlert = EmailAlert(config.EmailAlert.dictionary_())
         self.condorStates = ("Running", "Idle")
 

--- a/src/python/WMComponent/ErrorHandler/ErrorHandlerPoller.py
+++ b/src/python/WMComponent/ErrorHandler/ErrorHandlerPoller.py
@@ -73,7 +73,8 @@ class ErrorHandlerPoller(BaseWorkerThread):
             self.reqAuxDB = None
             self.maxRetries = self.config.ErrorHandler.maxRetries
         else:
-            self.reqAuxDB = ReqMgrAux(self.config.General.ReqMgr2ServiceURL)
+            cacheduration = getattr(self.config.General, "ReqMgrAuxCacheDuration", 5 / 60)  # 5 minutes
+            self.reqAuxDB = ReqMgrAux(self.config.General.ReqMgr2ServiceURL, httpDict={'cacheduration': cacheduration})
 
         self.exitCodesNoRetry = []
         self.maxProcessSize = getattr(self.config.ErrorHandler, 'maxProcessSize', 250)

--- a/src/python/WMComponent/JobArchiver/JobArchiverPoller.py
+++ b/src/python/WMComponent/JobArchiver/JobArchiverPoller.py
@@ -300,11 +300,14 @@ class JobArchiverPoller(BaseWorkerThread):
         markAction = self.daoFactory(classname="Workflow.MarkInjectedWorkflows")
         result = getAction.execute()
 
+        # Get the drain mode status
+        drainMode = isDrainMode(self.config)
+
         # Check each result to see if it is injected:
         injected = []
         for name in result:
             try:
-                if self.workQueue.getWMBSInjectionStatus(name, isDrainMode(self.config)):
+                if self.workQueue.getWMBSInjectionStatus(name, drainMode):
                     injected.append(name)
             except WorkQueueNoMatchingElements:
                 # workflow not known - free to cleanup

--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -137,7 +137,8 @@ class JobSubmitterPoller(BaseWorkerThread):
             # only set up this when reqmgr is used (not Tier0)
             self.reqmgr2Svc = ReqMgr(self.config.General.ReqMgr2ServiceURL)
             self.abortedAndForceCompleteWorkflowCache = self.reqmgr2Svc.getAbortedAndForceCompleteRequestsFromMemoryCache()
-            self.reqAuxDB = ReqMgrAux(self.config.General.ReqMgr2ServiceURL)
+            cacheduration = getattr(self.config.General, "ReqMgrAuxCacheDuration", 5 / 60)  # 5 minutes
+            self.reqAuxDB = ReqMgrAux(self.config.General.ReqMgr2ServiceURL, httpDict={'cacheduration': cacheduration})
         else:
             # Tier0 Case - just for the clarity (This private variable shouldn't be used
             self.abortedAndForceCompleteWorkflowCache = None

--- a/src/python/WMCore/Services/ReqMgrAux/ReqMgrAux.py
+++ b/src/python/WMCore/Services/ReqMgrAux/ReqMgrAux.py
@@ -35,7 +35,7 @@ class ReqMgrAux(Service):
         # This is only for the unittest: never set it true unless it is unittest
         self._noStale = False
 
-    def _getResult(self, callname, clearCache=True, args=None, verb="GET",
+    def _getResult(self, callname, clearCache=False, args=None, verb="GET",
                    encoder=json.loads, decoder=json.loads, contentType=None):
         """
         _getResult_


### PR DESCRIPTION
Fixes #10860 

#### Status
Tested

#### Description
Updates the `_getResult` method of the ReqMgrAux API to not clear its disk cache by default. Also, sets a 5 minute cache duration for agent polling threads to prevent multiple queries.

Reduces queries for the agent configuration by ~30% for an empty agent over a 10 minute period. Unknown how this translates to an agent filled with jobs. 

Also moves calls to `isDrainMode` from inside a for loop in JobArchiverPoller. This is likely the largest cause of excessive calls from agents full of work.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
NA

#### External dependencies / deployment changes
NA