### PR TITLE
Set processing version as integer

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/DBSBufferBlock.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSBufferBlock.py
@@ -232,10 +232,17 @@ class DBSBufferBlock(object):
         Set the block's processing version.
         """
         # compatibility statement for old style proc ver (still needed ?)
-        if procVer.count("-") == 1:
-            self.data["processing_era"]["processing_version"] = procVer.split("-v")[1]
+        pver = procVer
+        if isinstance(pver, str) or isinstance(pver, bytes):
+            procVer = int(pver)
+        elif isinstance(pver, int):
+            procVer = pver
+        elif pver == None:
+            procVer = 0
         else:
-            self.data["processing_era"]["processing_version"] = procVer
+            msg = "Provided procVer=%s of type %s cannot be converted to int" % (procVer, type(procVer))
+            raise Exception(msg)
+        self.data["processing_era"]["processing_version"] = procVer
 
         self.data["processing_era"]["create_by"] = "WMAgent"
         self.data["processing_era"]["description"] = ""

--- a/src/python/WMComponent/DBS3Buffer/DBSBufferFile.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSBufferFile.py
@@ -387,8 +387,16 @@ class DBSBufferFile(WMBSBase, WMFile):
 
         Set the era
         """
-
-        self['processingVer'] = ver
+        if isinstance(ver, str) or isinstance(ver, bytes):
+            procVer = int(ver)
+        elif isinstance(ver, int):
+            procVer = ver
+        elif ver == None:
+            procVer = 0
+        else:
+            msg = "Provided procVer=%s of type %s cannot be converted to int" % (ver, type(ver))
+            raise Exception(msg)
+        self['processingVer'] = procVer
         return
 
     def setAcquisitionEra(self, era):

--- a/src/python/WMComponent/DBS3Buffer/MySQL/FindDASToUpload.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/FindDASToUpload.py
@@ -45,10 +45,6 @@ class FindDASToUpload(DBFormatter):
         datasetalgos = []
         for result in results:
 
-            # compatibility statement for old style proc ver (still needed ?)
-            if result['procver'].count("-") == 1:
-                result['procver'] = result['procver'].split("-v")[1]
-
             datasetalgos.append( { 'DatasetPath' : result['datasetpath'],
                                    'AcquisitionEra' : result['acquera'],
                                    'ProcessingVer' : result['procver'] } )

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -949,6 +949,9 @@ class WMWorkloadHelper(PersistencyHelper):
 
         Change the processing version for all tasks in the spec and then update
         all of the output LFNs and datasets to use the new processing version.
+
+        :param processingVersions: can be any data-type but it is set from StdBase
+        which performs the input data sanitization/type already.
         """
         stepNameMapping = self.getStepMapping()
 
@@ -956,7 +959,15 @@ class WMWorkloadHelper(PersistencyHelper):
             task.setProcessingVersion(processingVersions, stepChainMap=stepNameMapping)
 
         self.updateLFNsAndDatasets()
-        self.data.properties.processingVersion = processingVersions
+        if isinstance(processingVersions, int):
+            procVer = processingVersions
+        elif isinstance(processingVersions, dict) or isinstance(processingVersions, list):
+            procVer = processingVersions
+        else:
+            msg = "Provided procVer=%s of type %s cannot be converted to int" \
+                    % (processingVersions, type(processingVersions))
+            raise Exception(msg)
+        self.data.properties.processingVersion = procVer
         return
 
     def setProcessingString(self, processingStrings):

--- a/test/python/WMComponent_t/DBS3Buffer_t/DBSBufferFile_t.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/DBSBufferFile_t.py
@@ -947,7 +947,7 @@ class DBSBufferFileTest(unittest.TestCase):
                                configContent="MOREGIBBERISH")
         testFileA.setDatasetPath("/Cosmics/CRUZET09-PromptReco-v1/RECO")
         testFileA.setValidStatus(validStatus="VALID")
-        testFileA.setProcessingVer(ver="ProcVer")
+        testFileA.setProcessingVer(ver="123")
         testFileA.setAcquisitionEra(era="AcqEra")
         testFileA.setGlobalTag(globalTag="GlobalTag")
         testFileA.setDatasetParent(datasetParent="Parent")


### PR DESCRIPTION
Fixes #10844 

#### Status
not-tested

#### Description
In DBS processing version is defined as integer. During WMA integration tests with new DBS Go server I identified the following error:
```
Go struct field ProcessingEra.processing_era.processing_version of type int64
```
which means that processing version was not passed as integer. Indeed, I found that in bulkblocks API call it passed as following:
```
"processing_era": {"processing_version": "11", "create_by": "WMAgent", "description": ""}
```
I looked up all possible `def setProcessingVer` functions and adjusted their code to ensure int data type. Unless if it is set by other method I think these changes should ensure that it is converted to integer data-type. Please note, I did not put any checks on provided values and therefore if `int(...)` function will fail it will cause the exception. We will need to run integration tests again to see if we either fixed the issue or will get an exception.

#### Is it backward compatible (if not, which system it affects?)
MAYBE

#### Related PRs
<If it's a follow up work; or porting a fix from a different branch, please mention them here.>

#### External dependencies / deployment changes
<Does it require deployment changes? Does it rely on third-party libraries?>
