### PR TITLE
Define gzip encoding by default in the headers; properly decompress it

### DIFF
--- a/test/python/WMCore_t/Services_t/pycurl_manager_t.py
+++ b/test/python/WMCore_t/Services_t/pycurl_manager_t.py
@@ -4,10 +4,12 @@ Unit test for pycurl_manager module.
 
 from __future__ import division
 
+import gzip
 import tempfile
 import unittest
 from Utils.CertTools import getKeyCertFromEnv
-from WMCore.Services.pycurl_manager import RequestHandler, ResponseHeader, getdata, cern_sso_cookie
+from WMCore.Services.pycurl_manager import \
+        RequestHandler, ResponseHeader, getdata, cern_sso_cookie, decompress
 
 
 class PyCurlManager(unittest.TestCase):
@@ -24,6 +26,21 @@ class PyCurlManager(unittest.TestCase):
         self.cricheader = 'Date: Tue, 06 Nov 2018 14:50:29 GMT\r\nServer: Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips mod_wsgi/3.4 Python/2.7.5 mod_gridsite/2.3.4\r\nVary: Cookie\r\nX-Frame-Options: SAMEORIGIN\r\nSet-Cookie: sessionid=bc1xu8zi5rbbsd5fgjuklb2tk2r3f6tw; expires=Sun, 11-Nov-2018 14:50:29 GMT; httponly; Max-Age=432000; Path=/\r\nContent-Length: 32631\r\nContent-Type: application/json\r\n\r\n'
         self.dbsheader = 'Date: Tue, 06 Nov 2018 14:39:07 GMT\r\nServer: Apache\r\nCMS-Server-Time: D=1503 t=1541515147806112\r\nTransfer-Encoding: chunked\r\nContent-Type: text/html\r\n\r\n'
         self.HTTPheader = 'Date: Tue, 06 Nov 2018 14:50:29 GMT\r\nServer: Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips mod_wsgi/3.4 Python/2.7.5 mod_gridsite/2.3.4\r\nVary: Cookie\r\nX-Frame-Options: SAMEORIGIN\r\nSet-Cookie: GRIDHTTP_PASSCODE=2c6da9c96efa2ad0farhda; domain=cms-cric.cern.ch; path=/; secure\r\nContent-Length: 32631\r\nContent-Type: application/json\r\n\r\n'
+
+    def testDecompress(self):
+        """
+        Test decompress function
+        """
+        body = "bla"
+        headers = {}
+        data = decompress(body, headers)
+        self.assertEqual(data, body)
+
+        # gzip body
+        gzipBody = gzip.compress(bytes(body, 'utf-8'))
+        headers = {'Content-Encoding': 'gzip'}
+        data = decompress(gzipBody, headers)
+        self.assertEqual(data, bytes(body, 'utf-8'))
 
     def testMulti(self):
         """


### PR DESCRIPTION
Fixes #10451 

#### Status
In development

#### Description
Provides changes to request and accept gzip encoding from upstream server. The changes are applied to pucurl manager only which is suppose to be used across all WMCore projects.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
#10872 , #10451 , https://github.com/dmwm/dasgoclient/issues/34

#### External dependencies / deployment changes
NO