### PR TITLE
[CouchDB] Do not sanitize couch url at the component layer

### DIFF
--- a/src/python/WMComponent/JobAccountant/AccountantWorker.py
+++ b/src/python/WMComponent/JobAccountant/AccountantWorker.py
@@ -23,7 +23,6 @@ from WMCore.DAOFactory import DAOFactory
 from WMCore.Database.CMSCouch import CouchServer
 from WMCore.FwkJobReport.Report import Report
 from WMCore.JobStateMachine.ChangeState import ChangeState
-from WMCore.Lexicon import sanitizeURL
 from WMCore.Services.WMStats.WMStatsWriter import WMStatsWriter
 from WMCore.WMBS.File import File
 from WMCore.WMBS.Job import Job
@@ -104,9 +103,8 @@ class AccountantWorker(WMConnectionBase):
         self.dataCollection = DataCollectionService(url=config.ACDC.couchurl,
                                                     database=config.ACDC.database)
 
-        jobDBurl = sanitizeURL(config.JobStateMachine.couchurl)['url']
         self.jobDBName = config.JobStateMachine.couchDBName
-        self.jobCouchdb = CouchServer(jobDBurl)
+        self.jobCouchdb = CouchServer(config.JobStateMachine.couchurl)
         self.fwjrCouchDB = None
         self.localWMStats = WMStatsWriter(config.TaskArchiver.localWMStatsURL, appName="WMStatsAgent")
 

--- a/src/python/WMComponent/TaskArchiver/CleanCouchPoller.py
+++ b/src/python/WMComponent/TaskArchiver/CleanCouchPoller.py
@@ -121,24 +121,23 @@ class CleanCouchPoller(BaseWorkerThread):
             self.centralRequestDBWriter = RequestDBWriter(self.config.AnalyticsDataCollector.localT0RequestDBURL,
                                                           couchapp=self.config.AnalyticsDataCollector.RequestCouchApp)
 
-        jobDBurl = sanitizeURL(self.config.JobStateMachine.couchurl)['url']
         jobDBName = self.config.JobStateMachine.couchDBName
-        workDBName = getattr(self.config.TaskArchiver, 'workloadSummaryCouchDBName',
-                             'workloadsummary')
-        workDBurl = getattr(self.config.TaskArchiver, 'workloadSummaryCouchURL')
-
-        self.jobCouchdb = CouchServer(jobDBurl)
+        self.jobCouchdb = CouchServer(self.config.JobStateMachine.couchurl)
         self.jobsdatabase = self.jobCouchdb.connectDatabase("%s/jobs" % jobDBName)
         self.fwjrdatabase = self.jobCouchdb.connectDatabase("%s/fwjrs" % jobDBName)
         self.fwjrService = FWJRDBAPI(self.fwjrdatabase)
 
+        workDBName = getattr(self.config.TaskArchiver, 'workloadSummaryCouchDBName',
+                             'workloadsummary')
+        workDBurl = getattr(self.config.TaskArchiver, 'workloadSummaryCouchURL')
         self.workCouchdb = CouchServer(workDBurl)
         self.workdatabase = self.workCouchdb.connectDatabase(workDBName)
 
         statSummaryDBName = self.config.JobStateMachine.summaryStatsDBName
         self.statsumdatabase = self.jobCouchdb.connectDatabase(statSummaryDBName)
 
-        logging.debug("Using url %s/%s for job", jobDBurl, jobDBName)
+        logging.debug("Using url %s/%s for job",
+                      sanitizeURL(self.config.JobStateMachine.couchurl)['url'], jobDBName)
         logging.debug("Writing to  %s/%s for workloadSummary", sanitizeURL(workDBurl)['url'], workDBName)
 
     @timeFunction

--- a/src/python/WMCore/Database/CMSCouch.py
+++ b/src/python/WMCore/Database/CMSCouch.py
@@ -124,6 +124,7 @@ class CouchDBRequests(JSONRequests):
         TODO: set caching in the calling methods.
         """
         incoming_headers = incoming_headers or {}
+        incoming_headers.update(self.additionalHeaders)
         try:
             if not cache:
                 incoming_headers.update({'Cache-Control': 'no-cache'})

--- a/src/python/WMCore/WorkQueue/WorkQueueBackend.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueBackend.py
@@ -142,7 +142,7 @@ class WorkQueueBackend(object):
     def getWMSpec(self, name):
         """Get the spec"""
         wmspec = WMWorkloadHelper()
-        wmspec.load(self.db['host'] + "/%s/%s/spec" % (self.db.name, name))
+        wmspec.load(self.hostWithAuth + "/%s/%s/spec" % (self.db.name, name))
         return wmspec
 
     def insertElements(self, units, parent=None):


### PR DESCRIPTION
Fixes #11044 

#### Status
ready

#### Description
The `CouchServer` class inheritance is very large, ending up with the `Requests` class. So, instead of doing the URL sanitization at the sub-class level, leave it to be done by the parent class (Requests), such that we also get the additional header `Authorization` defined in the object and pass along in the HTTP requests.

This also applies when loading the spec file at the WorkQueueBackend level, where we let the `Requests` class take care of the sanitization and auth header (current 3rd commit).

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
It's part of a series of fixes / feature changes required for the migration to CouchDB 3.x, such as:
https://github.com/dmwm/WMCore/pull/11011
https://github.com/dmwm/WMCore/pull/11001
https://github.com/dmwm/WMCore/pull/11039

#### External dependencies / deployment changes
No hard dependencies, but it's a required change for CouchDB 3.x. So to come with:
* deployment changes: https://github.com/dmwm/deployment/pull/1088
* cmsdist changes: https://github.com/cms-sw/cmsdist/pull/7218
