### PR TITLE
Add usage of gzip encoding in DBS3Buffer

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -152,6 +152,9 @@ config.DBS3Upload.pollInterval = 100
 config.DBS3Upload.dbsUrl = "OVERWRITE_BY_SECRETS"
 config.DBS3Upload.primaryDatasetType = "mc"
 config.DBS3Upload.dumpBlock = False  # to dump block meta-data into a json file
+# set DbsApi requests to use gzip enconding, thus sending compressed data
+# please change to True when new DBSWriter Go server will be in place
+config.DBS3Upload.gzipEncoding = False
 
 config.section_("DBSInterface")
 config.DBSInterface.DBSUrl = globalDBSUrl

--- a/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
@@ -50,17 +50,22 @@ from WMCore.WMException import WMException
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 
 
-def uploadWorker(workInput, results, dbsUrl):
+def uploadWorker(workInput, results, dbsUrl, gzipEncoding=False):
     """
     _uploadWorker_
 
     Put JSONized blocks in the workInput
     Get confirmation in the output
+
+    :param workInput: work input data
+    :param results: output results dictionary
+    :param dbsUrl: url of DBS server to use
+    :param gzipEncoding: specify if we should use gzipEncoding
     """
 
     # Init DBS Stuff
     logging.debug("Creating dbsAPI with address %s", dbsUrl)
-    dbsApi = DbsApi(url=dbsUrl)
+    dbsApi = DbsApi(url=dbsUrl, useGzip=gzipEncoding)
 
     while True:
 
@@ -191,6 +196,7 @@ class DBSUploadPoller(BaseWorkerThread):
         self.datasetType = getattr(self.config.DBS3Upload, "datasetType", "PRODUCTION")
         self.primaryDatasetType = getattr(self.config.DBS3Upload, "primaryDatasetType", "mc")
         self.blockCount = 0
+        self.gzipEncoding = getattr(self.config.DBS3Upload, 'gzipEncoding', False)
         self.dbsApi = DbsApi(url=self.dbsUrl)
 
         # List of blocks currently in processing
@@ -233,7 +239,8 @@ class DBSUploadPoller(BaseWorkerThread):
             p = multiprocessing.Process(target=uploadWorker,
                                         args=(self.workInput,
                                               self.workResult,
-                                              self.dbsUrl))
+                                              self.dbsUrl,
+                                              self.gzipEncoding))
             p.start()
             self.pool.append(p)
 

--- a/src/python/WMQuality/Emulators/DBSClient/DBS3API.py
+++ b/src/python/WMQuality/Emulators/DBSClient/DBS3API.py
@@ -21,11 +21,16 @@ class DbsApi(object):
     Replacement DbsApi implementing the required
     functions for the DBS3 upload poller.
     """
-    def __init__(self, url):
+    def __init__(self, url, **kwds):
         """
         _init_
 
         Store the url where this dbs is "located"
+
+        :param url: url of the DBS server
+        :param kwds: optional DBSApi keyword arguments which are irrelevant
+        for mocking but should be presented nevertheless for compatibility with
+        actual DBSApi class
         """
         self.dbsPath = url
 


### PR DESCRIPTION
Fixes #11055

#### Status
not-tested

#### Description
Add ability to use gzip encoding when uploading data to DBS server

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
<If it's a follow up work; or porting a fix from a different branch, please mention them here.>

#### External dependencies / deployment changes
Requires new DBSClient, version 4.0.7 or above.