### PR TITLE
Add support to EL8 jobs

### DIFF
--- a/src/python/WMCore/WMRuntime/Tools/Scram.py
+++ b/src/python/WMCore/WMRuntime/Tools/Scram.py
@@ -39,7 +39,10 @@ from Utils.PythonVersion import PY3
 from Utils.Utilities import encodeUnicodeToBytesConditional, decodeBytesToUnicodeConditional
 
 SCRAM_TO_ARCH = {'amd64': 'X86_64', 'aarch64': 'aarch64', 'ppc64le': 'ppc64le'}
-ARCH_TO_OS = {'slc5': ['rhel6'], 'slc6': ['rhel6'], 'slc7': ['rhel7']}
+ARCH_TO_OS = {'slc5': ['rhel6'],
+              'slc6': ['rhel6'],
+              'slc7': ['rhel7'],
+              'cc8': ['rhel8'], 'cs8': ['rhel8'], 'alma8': ['rhel8']}
 OS_TO_ARCH = {}
 for arch, oses in viewitems(ARCH_TO_OS):
     for osName in oses:

--- a/test/python/WMCore_t/WMRuntime_t/Tools_t/Scram_t.py
+++ b/test/python/WMCore_t/WMRuntime_t/Tools_t/Scram_t.py
@@ -107,7 +107,10 @@ class Scram_t(unittest.TestCase):
     def testArchMap(self):
         self.assertItemsEqual(OS_TO_ARCH['rhel6'], ['slc5', 'slc6'])
         self.assertItemsEqual(OS_TO_ARCH['rhel7'], ['slc7'])
+        self.assertItemsEqual(OS_TO_ARCH['rhel8'], ['cc8', 'cs8', 'alma8'])
         self.assertItemsEqual(ARCH_TO_OS['slc6'], ['rhel6'])
+        self.assertEqual(len(ARCH_TO_OS), 6)
+        self.assertItemsEqual(ARCH_TO_OS['slc7'], ['rhel7'])
         self.assertItemsEqual(ARCH_TO_OS['slc7'], ['rhel7'])
 
     def testScramArchParsing(self):


### PR DESCRIPTION
Fixes #11051 

#### Status
ready

#### Description
Provides a map of ScramArch to OS for the EL8 flavors.

For completeness, this map is consumed in this BossAir base class:
https://github.com/dmwm/WMCore/blob/fa033faa8ef12bc4f218433d8b3f5346a50d4d74/src/python/WMCore/BossAir/Plugins/BasePlugin.py#L131

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
