### PR TITLE
Add el8 flavor to the list of rhel8 container jobs

### DIFF
--- a/src/python/WMCore/WMRuntime/Tools/Scram.py
+++ b/src/python/WMCore/WMRuntime/Tools/Scram.py
@@ -42,7 +42,7 @@ SCRAM_TO_ARCH = {'amd64': 'X86_64', 'aarch64': 'aarch64', 'ppc64le': 'ppc64le'}
 ARCH_TO_OS = {'slc5': ['rhel6'],
               'slc6': ['rhel6'],
               'slc7': ['rhel7'],
-              'cc8': ['rhel8'], 'cs8': ['rhel8'], 'alma8': ['rhel8']}
+              'el8': ['rhel8'], 'cc8': ['rhel8'], 'cs8': ['rhel8'], 'alma8': ['rhel8']}
 OS_TO_ARCH = {}
 for arch, oses in viewitems(ARCH_TO_OS):
     for osName in oses:

--- a/test/python/WMCore_t/WMRuntime_t/Tools_t/Scram_t.py
+++ b/test/python/WMCore_t/WMRuntime_t/Tools_t/Scram_t.py
@@ -107,9 +107,9 @@ class Scram_t(unittest.TestCase):
     def testArchMap(self):
         self.assertItemsEqual(OS_TO_ARCH['rhel6'], ['slc5', 'slc6'])
         self.assertItemsEqual(OS_TO_ARCH['rhel7'], ['slc7'])
-        self.assertItemsEqual(OS_TO_ARCH['rhel8'], ['cc8', 'cs8', 'alma8'])
+        self.assertItemsEqual(OS_TO_ARCH['rhel8'], ['el8', 'cc8', 'cs8', 'alma8'])
         self.assertItemsEqual(ARCH_TO_OS['slc6'], ['rhel6'])
-        self.assertEqual(len(ARCH_TO_OS), 6)
+        self.assertEqual(len(ARCH_TO_OS), 7)
         self.assertItemsEqual(ARCH_TO_OS['slc7'], ['rhel7'])
         self.assertItemsEqual(ARCH_TO_OS['slc7'], ['rhel7'])
 


### PR DESCRIPTION
Fixes #11051 

#### Status
ready

#### Description
Add one more possible scramArch that could use the `rhel8` container for executing EL8 jobs.
Required complement for: https://github.com/dmwm/WMCore/pull/11060

#### Is it backward compatible (if not, which system it affects?)
YES, in some sense

#### Related PRs
Complement to: https://github.com/dmwm/WMCore/pull/11060

#### External dependencies / deployment changes
None
