### PR TITLE
Assign the correct activity for Tape_Test RSEs

### DIFF
--- a/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
+++ b/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
@@ -465,7 +465,7 @@ class RucioInjectorPoller(BaseWorkerThread):
                               grouping="ALL",
                               comment=ruleComment,
                               meta=self.metaData)
-            if not rseName.endswith("_Tape"):
+            if not rseName.endswith(("_Tape", "_Tape_Test")):
                 # add extra parameters to the Disk rule as defined in the component configuration
                 ruleKwargs.update(self.containerDiskRuleParams)
 
@@ -529,7 +529,7 @@ class RucioInjectorPoller(BaseWorkerThread):
         """
         if not self.isT0agent and not rseName.endswith("_Tape"):
             return "Production Output"
-        elif self.isT0agent and rseName.endswith("_Tape"):
+        elif self.isT0agent and rseName.endswith(("_Tape", "_Tape_Test")):
             return "T0 Tape"
         elif self.isT0agent:
             return "T0 Export"


### PR DESCRIPTION
Fixes #11046 

#### Status
Tested with a replay


#### Description
Add the proper activity for the T0-Agent when is subscribing data to Tape_Test rses. Small changes on how this code recognize a Tape_Test RSE. With this changes, the rule replica subscribed to T0_CH_CERN_Tape_Test gives the following:

```
rucio rule-info 0035c69b588045769195f241df939406
Id:                         0035c69b588045769195f241df939406
Account:                    tier0_replay
Scope:                      cms
Name:                       /ExpressCosmics/Tier0_REPLAY_2022-v98/RAW
RSE Expression:             T0_CH_CERN_Tape_Test
Copies:                     1
State:                      REPLICATING
Locks OK/REPLICATING/STUCK: 0/1/0
Grouping:                   ALL
Expires at:                 None
Locked:                     True
Weight:                     None
Created at:                 2022-04-05 03:33:03
Updated at:                 2022-04-05 03:33:55
Error:                      None
Subscription Id:            None
Source replica expression:  None
Activity:                   T0 Tape
Comment:                    T0 WMAgent automatic container rule
Ignore Quota:               False
Ignore Availability:        False
Purge replicas:             False
Notification:               NO
End of life:                None
Child Rule Id:              None
```

#### Is it backward compatible (if not, which system it affects?)
Maybe

#### Related PRs
None

#### External dependencies / deployment changes
None