### PR TITLE
Missed one set_opts use for PyCurl multirequest

### DIFF
--- a/src/python/WMCore/Services/pycurl_manager.py
+++ b/src/python/WMCore/Services/pycurl_manager.py
@@ -383,9 +383,8 @@ class RequestHandler(object):
                     if ret != pycurl.E_CALL_MULTI_PERFORM:
                         break
             dummyNumq, response, dummyErr = multi.info_read()
-            for dummyCobj in response:
-                headers = self.parse_header(decodeBytesToUnicode(hbuf.getvalue()))
-                data = decompress(decodeBytesToUnicode(bbuf.getvalue()), headers)
+            for _respItem in response:
+                data = decodeBytesToUnicode(bbuf.getvalue())
                 data = json.loads(data)
                 if isinstance(data, dict):
                     data.update(params)


### PR DESCRIPTION
Fixes #11066 
Complement to https://github.com/dmwm/WMCore/pull/11069

#### Status
ready

#### Description
The `multirequest` method also relies on `set_opts`, meaning that the response object will be automatically decoded and we should not have the home-made decompress logic called.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Complement for: https://github.com/dmwm/WMCore/pull/11069

#### External dependencies / deployment changes
None
