### PR TITLE
Support to EL8 workflows/jobs - wmagent branch

### DIFF
--- a/etc/submit_py3.sh
+++ b/etc/submit_py3.sh
@@ -54,6 +54,7 @@ PY3_FUTURE_VERSION=0.18.2
 # Saving START_TIME and when job finishes END_TIME.
 WMA_MIN_JOB_RUNTIMESECS=300
 START_TIME=$(date +%s)
+WMA_DEFAULT_OS=rhel7
 # assign arguments
 SANDBOX=$1
 INDEX=$2
@@ -132,20 +133,17 @@ echo "======== WMAgent COMP Python bootstrap starting at $(TZ=GMT date) ========
 # slc6_ppc64le_gcc493 (from CMSSW): py2-future/0.18.2 python/2.7.15 py3-future/0.18.2 python3/3.8.2
 #
 # NOTE: all the ppc64le ScramArchs are actually pointing to: slc7_ppc64le_gcc820
+### UPDATE on 11 April, 2022: See a new map of CVMFS packages in:
+# https://github.com/dmwm/WMCore/pull/11077#issuecomment-1094814966
+
 # First, decide which COMP ScramArch to use based on the required OS and Architecture
 THIS_ARCH=`uname -m`  # if it's PowerPC, it returns `ppc64le`
-if [ "$THIS_ARCH" = "x86_64" ]
+# if this job can run at any OS, then use rhel7 as default
+if [ "$REQUIRED_OS" = "any" ]
 then
-    THIS_ARCH="amd64"
-fi
-if [ "$REQUIRED_OS" = "rhel7" ]
-then
-    WMA_SCRAM_ARCH=slc7_${THIS_ARCH}_gcc630
-elif [ "$THIS_ARCH" = "amd64" ]
-then
-    WMA_SCRAM_ARCH=slc6_${THIS_ARCH}_gcc700
+    WMA_SCRAM_ARCH=${WMA_DEFAULT_OS}_${THIS_ARCH}
 else
-    WMA_SCRAM_ARCH=slc6_${THIS_ARCH}_gcc493
+    WMA_SCRAM_ARCH=${REQUIRED_OS}_${THIS_ARCH}
 fi
 echo "Job requires OS: $REQUIRED_OS, thus setting ScramArch to: $WMA_SCRAM_ARCH"
 

--- a/src/python/WMCore/BossAir/Plugins/BasePlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/BasePlugin.py
@@ -6,7 +6,7 @@ Base class for BossAir plugins
 """
 
 from builtins import object, str, bytes
-from future.utils import viewitems, viewvalues
+from future.utils import viewvalues
 
 from Utils.Utilities import decodeBytesToUnicode
 from WMCore.WMException import WMException
@@ -130,27 +130,25 @@ class BasePlugin(object):
     @staticmethod
     def scramArchtoRequiredOS(scramArch=None):
         """
+        Matches a ScramArch - or a list of it - against a map of Scram
+        to Operating System
 
-        Args:
-            scramArch: string or list of scramArches that are acceptable for the job
-
-        Returns:
-            string to be matched for OS requirements for job
+        :param scramArch: string or list of scramArches defined for a given job
+        :return: a string with the required OS to use
         """
-        requiredOSes = set()
+        defaultValue = 'any'
         if not scramArch:
-            requiredOSes.add('any')
-        elif isinstance(scramArch, (str, bytes)):
-            for arch, validOSes in viewitems(ARCH_TO_OS):
-                if arch in scramArch:
-                    requiredOSes.update(validOSes)
-        elif isinstance(scramArch, list):
-            for validArch in scramArch:
-                for arch, validOSes in viewitems(ARCH_TO_OS):
-                    if arch in validArch:
-                        requiredOSes.update(validOSes)
-        else:
-            requiredOSes.add('any')
+            return defaultValue
+
+        requiredOSes = set()
+        if isinstance(scramArch, (str, bytes)):
+            scramArch = [scramArch]
+        elif not isinstance(scramArch, (list, tuple)):
+            return defaultValue
+
+        for validArch in scramArch:
+            scramOS = validArch.split("_")[0]
+            requiredOSes.update(ARCH_TO_OS.get(scramOS, []))
 
         return ','.join(sorted(requiredOSes))
 

--- a/src/python/WMCore/BossAir/Plugins/BasePlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/BasePlugin.py
@@ -138,7 +138,7 @@ class BasePlugin(object):
             string to be matched for OS requirements for job
         """
         requiredOSes = set()
-        if scramArch is None:
+        if not scramArch:
             requiredOSes.add('any')
         elif isinstance(scramArch, (str, bytes)):
             for arch, validOSes in viewitems(ARCH_TO_OS):

--- a/src/python/WMCore/WMRuntime/Tools/Scram.py
+++ b/src/python/WMCore/WMRuntime/Tools/Scram.py
@@ -39,7 +39,10 @@ from Utils.PythonVersion import PY3
 from Utils.Utilities import encodeUnicodeToBytesConditional, decodeBytesToUnicodeConditional
 
 SCRAM_TO_ARCH = {'amd64': 'X86_64', 'aarch64': 'aarch64', 'ppc64le': 'ppc64le'}
-ARCH_TO_OS = {'slc5': ['rhel6'], 'slc6': ['rhel6'], 'slc7': ['rhel7']}
+ARCH_TO_OS = {'slc5': ['rhel6'],
+              'slc6': ['rhel6'],
+              'slc7': ['rhel7'],
+              'cc8': ['rhel8'], 'cs8': ['rhel8'], 'alma8': ['rhel8']}
 OS_TO_ARCH = {}
 for arch, oses in viewitems(ARCH_TO_OS):
     for osName in oses:

--- a/src/python/WMCore/WMRuntime/Tools/Scram.py
+++ b/src/python/WMCore/WMRuntime/Tools/Scram.py
@@ -42,7 +42,7 @@ SCRAM_TO_ARCH = {'amd64': 'X86_64', 'aarch64': 'aarch64', 'ppc64le': 'ppc64le'}
 ARCH_TO_OS = {'slc5': ['rhel6'],
               'slc6': ['rhel6'],
               'slc7': ['rhel7'],
-              'cc8': ['rhel8'], 'cs8': ['rhel8'], 'alma8': ['rhel8']}
+              'el8': ['rhel8'], 'cc8': ['rhel8'], 'cs8': ['rhel8'], 'alma8': ['rhel8']}
 OS_TO_ARCH = {}
 for arch, oses in viewitems(ARCH_TO_OS):
     for osName in oses:


### PR DESCRIPTION
Backport for 1.5.7_wmagent branch for:
* Add support to EL8 jobs #11060
* Add el8 flavor to the list of rhel8 container jobs #11062

updated with:
* When ScramArch is empty str/list/None, return any as required_os #11083 
* If job requires rhel8 container, use slc7 python libraries #11077 
* Enhance logic to map ScramArch to OS #11088
* Enhance logic to map ScramArch to OS #11088 