### PR TITLE
If job requires rhel8 container, use slc7 python libraries

### DIFF
--- a/etc/submit_py3.sh
+++ b/etc/submit_py3.sh
@@ -54,6 +54,7 @@ PY3_FUTURE_VERSION=0.18.2
 # Saving START_TIME and when job finishes END_TIME.
 WMA_MIN_JOB_RUNTIMESECS=300
 START_TIME=$(date +%s)
+WMA_DEFAULT_OS=rhel7
 # assign arguments
 SANDBOX=$1
 INDEX=$2
@@ -132,20 +133,17 @@ echo "======== WMAgent COMP Python bootstrap starting at $(TZ=GMT date) ========
 # slc6_ppc64le_gcc493 (from CMSSW): py2-future/0.18.2 python/2.7.15 py3-future/0.18.2 python3/3.8.2
 #
 # NOTE: all the ppc64le ScramArchs are actually pointing to: slc7_ppc64le_gcc820
+### UPDATE on 11 April, 2022: See a new map of CVMFS packages in:
+# https://github.com/dmwm/WMCore/pull/11077#issuecomment-1094814966
+
 # First, decide which COMP ScramArch to use based on the required OS and Architecture
 THIS_ARCH=`uname -m`  # if it's PowerPC, it returns `ppc64le`
-if [ "$THIS_ARCH" = "x86_64" ]
+# if this job can run at any OS, then use rhel7 as default
+if [ "$REQUIRED_OS" = "any" ]
 then
-    THIS_ARCH="amd64"
-fi
-if [ "$REQUIRED_OS" = "rhel7" ]
-then
-    WMA_SCRAM_ARCH=slc7_${THIS_ARCH}_gcc630
-elif [ "$THIS_ARCH" = "amd64" ]
-then
-    WMA_SCRAM_ARCH=slc6_${THIS_ARCH}_gcc700
+    WMA_SCRAM_ARCH=${WMA_DEFAULT_OS}_${THIS_ARCH}
 else
-    WMA_SCRAM_ARCH=slc6_${THIS_ARCH}_gcc493
+    WMA_SCRAM_ARCH=${REQUIRED_OS}_${THIS_ARCH}
 fi
 echo "Job requires OS: $REQUIRED_OS, thus setting ScramArch to: $WMA_SCRAM_ARCH"
 


### PR DESCRIPTION
Fixes #11051 
Complement to https://github.com/dmwm/WMCore/pull/11060 and https://github.com/dmwm/WMCore/pull/11062

#### Status
ready

#### Description
We do not have a build of COMP in EL8, so for jobs requesting `rhel8`, use our slc7_* python libraries.

We might consider using python and future library from one of the EL8 CMSSW releases as well, still unsure whether that would work out of the box though.

UPDATE: these changes triggered a discussion with the SI team, and they actually updated the container to be used for `REQUIRED_OS=any` from `rhel6` to `rhel7`, on April 11, 2022. We need to check whether current production agents will behave properly.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Complement to https://github.com/dmwm/WMCore/pull/11060 and https://github.com/dmwm/WMCore/pull/11062

#### External dependencies / deployment changes
None
