### PR TITLE
Change setup.cfg to use pycodestyle

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pep8]
+[pycodestyle]
 format=pylint 
 hang-closing=True
 max-line-length = 160


### PR DESCRIPTION
Fixes #10559

#### Status
In development

#### Description
Changes pep8 to pycodestyle in setup.cfg. After the new Docker image for linting is finished and Jenkins tests are updated, this would be the final configuration step to move from pep8 to pycodestyle.

#### Is it backward compatible (if not, which system it affects?)
NO

#### Related PRs
NA

#### External dependencies / deployment changes
Jenkins test updates. New Docker image for lint checks.
