### PR TITLE
When ScramArch is empty str/list/None, return any as required_os

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/BasePlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/BasePlugin.py
@@ -138,7 +138,7 @@ class BasePlugin(object):
             string to be matched for OS requirements for job
         """
         requiredOSes = set()
-        if scramArch is None:
+        if not scramArch:
             requiredOSes.add('any')
         elif isinstance(scramArch, (str, bytes)):
             for arch, validOSes in viewitems(ARCH_TO_OS):

--- a/test/python/WMCore_t/BossAir_t/BasePlugin_t.py
+++ b/test/python/WMCore_t/BossAir_t/BasePlugin_t.py
@@ -33,8 +33,14 @@ class BasePluginTest(BossAirTest):
         self.assertEqual(bp.scramArchtoRequiredOS('slc5_blah_blah'), 'rhel6')
         self.assertEqual(bp.scramArchtoRequiredOS('slc6_blah_blah'), 'rhel6')
         self.assertEqual(bp.scramArchtoRequiredOS('slc7_blah_blah'), 'rhel7')
+        self.assertEqual(bp.scramArchtoRequiredOS('cc8_blah_blah'), 'rhel8')
+        self.assertEqual(bp.scramArchtoRequiredOS('cs8_blah_blah'), 'rhel8')
+        self.assertEqual(bp.scramArchtoRequiredOS('alma8_blah_blah'), 'rhel8')
+        self.assertEqual(bp.scramArchtoRequiredOS('el88_blah_blah'), 'rhel8')
 
         self.assertEqual(bp.scramArchtoRequiredOS(None), 'any')
+        self.assertEqual(bp.scramArchtoRequiredOS(""), 'any')
+        self.assertEqual(bp.scramArchtoRequiredOS([]), 'any')
 
         self.assertEqual(bp.scramArchtoRequiredOS(['slc6_blah_blah', 'slc7_blah_blah']), 'rhel6,rhel7')
 


### PR DESCRIPTION
Fixes #11081 

#### Status
ready

#### Description
Apparently an empty list is the default value for the lack of ScramArch, so relax a bit the `any` case to evaluate it for anything that evaluates to false (like None, [], set(), "", False).

In short, ensure that Cleanup jobs define job classad with `REQUIRED_OS=any`.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Meant to go in with: https://github.com/dmwm/WMCore/pull/11077, but not a hard requirement.

#### External dependencies / deployment changes
None
