### PR TITLE
Bump WMAgent deployment example to the latest stable version

### DIFF
--- a/deploy/deploy-wmagent.sh
+++ b/deploy/deploy-wmagent.sh
@@ -24,8 +24,8 @@
 ### Usage:               -n <agent_number> Agent number to be set when more than 1 agent connected to the same team (defaults to 0)
 ### Usage:
 ### Usage: deploy-wmagent.sh -w <wma_version> -d <deployment_tag> -t <team_name> [-s <scram_arch>] [-r <repository>] [-n <agent_number>]
-### Usage: Example: sh deploy-wmagent.sh -w 1.5.7.patch1 -d HG2201e -t production -n 30
-### Usage: Example: sh deploy-wmagent.sh -w 1.5.7.patch1 -d HG2201e -t testbed-vocms001 -p "10853" -r comp=comp.amaltaro
+### Usage: Example: sh deploy-wmagent.sh -w 2.0.2.patch1 -d HG2204f -t production -n 30
+### Usage: Example: sh deploy-wmagent.sh -w 2.0.2.patch1 -d HG2204f -t testbed-vocms001 -p "10998" -r comp=comp.amaltaro
 ### Usage:
 
 IAM=`whoami`


### PR DESCRIPTION
Fixes #10946 

#### Status
ready

#### Description
Usual update to the deployment tags to be used when running the WMAgent deploy script, which now points to WMCore 2.0.2.patch1

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
