### PR TITLE
Remove cPickle support

### DIFF
--- a/src/python/WMComponent/JobCreator/JobCreatorPoller.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorPoller.py
@@ -11,12 +11,7 @@ import logging
 import os
 import os.path
 import threading
-
-
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 from Utils.Timers import timeFunction
 from Utils.PythonVersion import HIGHEST_PICKLE_PROTOCOL

--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -17,10 +17,7 @@ import threading
 import json
 import time
 from collections import defaultdict, Counter
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 from Utils.Timers import timeFunction
 from WMCore.DAOFactory import DAOFactory

--- a/src/python/WMCore/Agent/Flow/DefaultFlow.py
+++ b/src/python/WMCore/Agent/Flow/DefaultFlow.py
@@ -12,10 +12,7 @@ Sample configuration for generating workflow.
 
 
 import os
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 from WMCore.Agent.Configuration import Configuration
 config = Configuration()

--- a/src/python/WMCore/Agent/Flow/Generate.py
+++ b/src/python/WMCore/Agent/Flow/Generate.py
@@ -18,10 +18,7 @@ from future.utils import viewvalues
 
 import os
 import sys
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 from WMCore.Agent.Configuration import loadConfigurationFile
 

--- a/src/python/WMCore/BossAir/Plugins/MockPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/MockPlugin.py
@@ -14,10 +14,7 @@ from datetime import datetime
 from datetime import timedelta
 from random import randint
 import multiprocessing
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 def processWorker(myinput, tmp):
     try:

--- a/src/python/WMCore/DataStructs/JobPackage.py
+++ b/src/python/WMCore/DataStructs/JobPackage.py
@@ -4,10 +4,7 @@ _JobPackage_
 
 Data structure for storing and retreiving multiple job objects.
 """
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 from Utils.PythonVersion import HIGHEST_PICKLE_PROTOCOL
 from WMCore.DataStructs.WMObject import WMObject
 

--- a/src/python/WMCore/FwkJobReport/Report.py
+++ b/src/python/WMCore/FwkJobReport/Report.py
@@ -25,10 +25,7 @@ from WMCore.FwkJobReport.FileInfo import FileInfo
 from WMCore.WMException import WMException
 from WMCore.WMExceptions import WM_JOB_ERROR_CODES
 
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 
 class FwkJobReportException(WMException):

--- a/src/python/WMCore/ProcessPool/ProcessPool.py
+++ b/src/python/WMCore/ProcessPool/ProcessPool.py
@@ -15,10 +15,7 @@ import logging
 import os
 import threading
 import traceback
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 from Utils.PythonVersion import PY3
 

--- a/src/python/WMCore/ThreadPool/ThreadPool.py
+++ b/src/python/WMCore/ThreadPool/ThreadPool.py
@@ -19,10 +19,7 @@ import random
 import threading
 import time
 from Utils.Utilities import encodeUnicodeToBytes
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 from WMCore.ThreadPool.WorkQueue import ThreadPool as Queue
 from WMCore.WMFactory import WMFactory

--- a/src/python/WMCore/ThreadPool/ThreadSlave.py
+++ b/src/python/WMCore/ThreadPool/ThreadSlave.py
@@ -24,10 +24,7 @@ import base64
 import logging
 import threading
 import os
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 from WMCore.Database.Transaction import Transaction
 from WMCore.WMFactory import WMFactory

--- a/src/python/WMCore/WMSpec/Makers/Handlers/MakeJobSlave.py
+++ b/src/python/WMCore/WMSpec/Makers/Handlers/MakeJobSlave.py
@@ -22,7 +22,6 @@ from WMCore.ThreadPool.ThreadSlave import ThreadSlave
 from WMCore.WMSpec.Makers.Interface.CreateWorkArea import CreateWorkArea
 
 
-#import cPickle
 import os
 import string
 import logging

--- a/src/python/WMCore/WMSpec/Persistency.py
+++ b/src/python/WMCore/WMSpec/Persistency.py
@@ -15,10 +15,7 @@ from future.moves.urllib.request import urlopen, Request
 
 from builtins import object
 
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 
 class PersistencyHelper(object):

--- a/test/python/WMCore_t/BossAir_t/BossAir_t.py
+++ b/test/python/WMCore_t/BossAir_t/BossAir_t.py
@@ -10,11 +10,7 @@ import os.path
 import subprocess
 import threading
 import unittest
-
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 from nose.plugins.attrib import attr
 

--- a/test/python/WMCore_t/Misc_t/WMAgent_t.py
+++ b/test/python/WMCore_t/Misc_t/WMAgent_t.py
@@ -12,10 +12,7 @@ import unittest
 import threading
 
 from subprocess import Popen, PIPE
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 # Imports for testing
 from WMQuality.TestInit import TestInit


### PR DESCRIPTION
Fixes #7110

#### Status
Not tested

#### Description
Since we no longer support python2, remove attempts to import cPickle and just import pickle.

#### Is it backward compatible (if not, which system it affects?)
Only works with python3!

#### Related PRs
NA

#### External dependencies / deployment changes
NA