### PR TITLE
Support manual insertion of diskless resources into the database

### DIFF
--- a/bin/wmagent-resource-control
+++ b/bin/wmagent-resource-control
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 wmagent-resource-control
 
@@ -64,6 +64,8 @@ def createOptionParser():
                              help="Add all of the CMS sites to resource control.")
     myOptParser.add_argument("--add-one-site", dest="addOneSite",
                              help="Specify site name you want to add")
+    myOptParser.add_argument("--opportunistic", dest="opportunistic", default=False, action="store_true",
+                             help="To be used with addOneSite, specifying to use the same CPU/storage name.")
     myOptParser.add_argument("--site-name", dest="siteName",
                              help="Specify the unique name of the location")
     myOptParser.add_argument("--pending-slots", dest="pendingSlots",
@@ -345,7 +347,11 @@ else:
                  options.pendingSlots, options.runningSlots, state=options.state)
         addPNNs(myResourceControl, pattern=pattern)
     elif options.addOneSite:
-        oneSite = getCMSSiteInfo(options.addOneSite)
+        if options.opportunistic:
+            # it's a dict key'ed by the CPU resource and value is the storage name
+            oneSite = {options.addOneSite: [options.addOneSite]}
+        else:
+            oneSite = getCMSSiteInfo(options.addOneSite)
         addSites(myResourceControl, oneSite, options.ceName, options.plugin,
                  options.pendingSlots, options.runningSlots, state=options.state)
     elif options.siteName is None:


### PR DESCRIPTION
Fixes #11072 

#### Status
ready

#### Description
Adds a new option to this script, called `--opportunistic`, which allows the CRIC call to be bypassed, thus allowing resources to be added to the agent resource-control, even if those resources don't show up in the CRIC `data-processing` API.

Note that this options has to be used with a specific site name, thus together with `--add-one-site` option.

To add a standard (with CPU and RSE/PNN) resource, we run this command:
```
$manage execute-agent wmagent-resource-control --plugin=SimpleCondorPlugin --pending-slots=100 --running-slots=200 --add-one-site T3_US_Colorado
```

and to add an opportunistic resource - which does not have an RSE/PNN associated to it, we need to run:
```
$manage execute-agent wmagent-resource-control --plugin=SimpleCondorPlugin --pending-slots=2000 --running-slots=3000 --add-one-site T3_ES_PIC_BSC --opportunistic
```

which will skip the CRIC call and instead will use the site name as site and storage (PSN and RSE/PNN).

In addition to this, I also updated the deploy-wmagent script to start adding BSC to every single agent; the T3 US opportunistic resources have been added there as well (deprecating the standalone script).

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
