### PR TITLE
speed up listDatasetFileDetails API

### DIFF
--- a/src/python/WMCore/Services/DBS/DBSUtils.py
+++ b/src/python/WMCore/Services/DBS/DBSUtils.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+"""
+_DBSUtils_
+
+set of common utilities for DBS3Reader
+
+"""
+import json
+import urllib
+from urllib.parse import urlparse, parse_qs, quote_plus
+from collections import defaultdict
+
+from Utils.CertTools import cert, ckey
+from dbs.apis.dbsClient import aggFileLumis, aggFileParents
+from WMCore.Services.pycurl_manager import getdata as multi_getdata
+from Utils.PortForward import PortForward
+
+
+def dbsListFileParents(dbsUrl, blocks):
+    """
+    Concurrent counter part of DBS listFileParents API
+
+    :param dbsUrl: DBS URL
+    :param blocks: list of blocks
+    :return: list of file parents
+    """
+    urls = ['%s/fileparents?block_name=%s' % (dbsUrl, quote_plus(b)) for b in blocks]
+    func = aggFileParents
+    uKey = 'block_name'
+    return getUrls(urls, func, uKey)
+
+
+def dbsListFileLumis(dbsUrl, blocks):
+    """
+    Concurrent counter part of DBS listFileLumis API
+
+    :param dbsUrl: DBS URL
+    :param blocks: list of blocks
+    :return: list of file lumis
+    """
+    urls = ['%s/filelumis?block_name=%s' % (dbsUrl, quote_plus(b)) for b in blocks]
+    func = aggFileLumis
+    uKey = 'block_name'
+    return getUrls(urls, func, uKey)
+
+
+def dbsBlockOrigin(dbsUrl, blocks):
+    """
+    Concurrent counter part of DBS files API
+
+    :param dbsUrl: DBS URL
+    :param blocks: list of blocks
+    :return: list of block origins for a given parent lfns
+    """
+    urls = ['%s/blockorigin?block_name=%s' % (dbsUrl, quote_plus(b)) for b in blocks]
+    func = None
+    uKey = 'block_name'
+    return getUrls(urls, func, uKey)
+
+
+def dbsParentFilesGivenParentDataset(dbsUrl, parentDataset, fInfo):
+    """
+    Obtain parent files for given fileInfo object
+
+    :param dbsUrl: DBS URL
+    :param parentDataset: parent dataset name
+    :param fInfo: file info object
+    :return: list of parent files for given file info object
+    """
+    portForwarder = PortForward(8443)
+    urls = []
+    for fileInfo in fInfo:
+        run = fileInfo['run_num']
+        lumis = urllib.parse.quote_plus(str(fileInfo['lumi_section_num']))
+        url = f'{dbsUrl}/files?dataset={parentDataset}&run_num={run}&lumi_list={lumis}'
+        urls.append(portForwarder(url))
+    func = None
+    uKey = None
+    rdict = getUrls(urls, func, uKey)
+    parentFiles = defaultdict(set)
+    for fileInfo in fInfo:
+        run = fileInfo['run_num']
+        lumis = urllib.parse.quote_plus(str(fileInfo['lumi_section_num']))
+        url = f'{dbsUrl}/files?dataset={parentDataset}&run_num={run}&lumi_list={lumis}'
+        url = portForwarder(url)
+        if url in rdict:
+            pFileList = rdict[url]
+            pFiles = {x['logical_file_name'] for x in pFileList}
+            parentFiles[fileInfo['logical_file_name']] = \
+                parentFiles[fileInfo['logical_file_name']].union(pFiles)
+    return parentFiles
+
+
+def getUrls(urls, aggFunc, uKey=None):
+    """
+    Perform parallel DBS calls for given set of urls and apply given aggregation
+    function to the results.
+
+    :param urls: list of DBS urls to call
+    :param aggFunc: aggregation function
+    :param uKey: url parameter to use for final dictionary
+    :return: dictionary of resuls where keys are urls and values are obtained results
+    """
+    data = multi_getdata(urls, ckey(), cert())
+
+    rdict = {}
+    for row in data:
+        url = row['url']
+        code = int(row.get('code', 200))
+        error = row.get('error')
+        if code != 200:
+            msg = f"Fail to query {url}. Error: {code} {error}"
+            raise RuntimeError(msg)
+        if uKey:
+            key = urlParams(url).get(uKey)
+        else:
+            key = url
+        data = row.get('data', [])
+        res = json.loads(data)
+        if aggFunc:
+            rdict[key] = aggFunc(res)
+        else:
+            rdict[key] = res
+    return rdict
+
+
+def urlParams(url):
+    """
+    Return dictionary of URL parameters
+
+    :param url: URL link
+    :return: dictionary of URL parameters
+    """
+    parsedUrl = urlparse(url)
+    rdict = parse_qs(parsedUrl.query)
+    for key, vals in rdict.items():
+        if len(vals) == 1:
+            rdict[key] = vals[0]
+    return rdict

--- a/test/python/WMCore_t/Services_t/DBS_t/DBSUtils_t.py
+++ b/test/python/WMCore_t/Services_t/DBS_t/DBSUtils_t.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+"""
+_DBSUtils_t_
+
+Unit test for the DBSUtils module
+"""
+
+import time
+import unittest
+
+from nose.plugins.attrib import attr
+
+from WMCore.Services.DBS.DBSUtils import urlParams
+from WMCore.Services.DBS.DBS3Reader import DBS3Reader
+
+
+class DBSUtilsTest(unittest.TestCase):
+    """
+    DBSUtilsTest represent unit test class
+    """
+
+    def testUrlParams(self):
+        """
+        urlParams should return dictionary of URL parameters
+        """
+        url = 'http://a.b.com?d=1&f=bla'
+        results = urlParams(url)
+        self.assertCountEqual(results, {'d': '1', 'f': 'bla'})
+        self.assertTrue(results.get('d'), 1)
+        self.assertTrue(results.get('f'), 'bla')
+
+        url = 'http://a.b.com?d=1&f=bla&d=2'
+        results = urlParams(url)
+        self.assertCountEqual(results, {'d': ['1', '2'], 'f': 'bla'})
+
+    @attr("integration")
+    def testGetParallelListDatasetFileDetails(self):
+        """
+        test parallel execution of listDatasetFileDetails DBS API
+        We use small dataset with the following characteristics:
+
+                dasgoclient -query="dataset=/VBF1Parked/HIRun2013A-v1/RAW summary" | jq
+                [
+                  {
+                        "file_size": 6053097,
+                        "nblocks": 7,
+                        "nevents": 0,
+                        "nfiles": 7,
+                        "nlumis": 428,
+                        "num_block": 7,
+                        "num_event": 0,
+                        "num_file": 7,
+                        "num_lumi": 428
+                  }
+                ]
+
+                The parallel call should perform better then sequential while results
+        should remain the same.
+
+        """
+        url = "https://cmsweb.cern.ch/dbs/prod/global/DBSReader"
+        reader1 = DBS3Reader(url, logger=None, parallel=False, aggregate=True)
+        reader2 = DBS3Reader(url, logger=None, parallel=True, aggregate=True)
+        dataset = '/VBF1Parked/HIRun2013A-v1/RAW'
+        time0 = time.time()
+        res1 = reader1.listDatasetFileDetails(dataset)
+        time1 = time.time() - time0
+        self.assertTrue(time1 > 0)  # to avoid pyling complaining about not used varaiable
+        time0 = time.time()
+        res2 = reader2.listDatasetFileDetails(dataset)
+        time2 = time.time() - time0
+        self.assertTrue(time2 > 0)  # to avoid pyling complaining about not used varaiable
+        self.assertTrue(res1 == res2)
+
+    @attr("integration")
+    def testGetParallelListFileBlockLocation(self):
+        """
+        test parallel execution of listFileBlockLocation DBS API
+        We use small dataset with the following data:
+
+        dasgoclient -query="block dataset=/VBF1Parked/HIRun2013A-v1/RAW"
+
+        The parallel call should perform better then sequential while results
+        should remain the same.
+
+        """
+        url = "https://cmsweb.cern.ch/dbs/prod/global/DBSReader"
+        reader1 = DBS3Reader(url, logger=None, parallel=False, aggregate=True)
+        reader2 = DBS3Reader(url, logger=None, parallel=True, aggregate=True)
+        blocks = [
+            '/VBF1Parked/HIRun2013A-v1/RAW#52da10be-5c87-11e2-912f-842b2b4671d8',
+            '/VBF1Parked/HIRun2013A-v1/RAW#6861d50a-5c7f-11e2-912f-842b2b4671d8',
+            '/VBF1Parked/HIRun2013A-v1/RAW#6dd88910-5c80-11e2-912f-842b2b4671d8',
+            '/VBF1Parked/HIRun2013A-v1/RAW#6e258f12-5c80-11e2-912f-842b2b4671d8',
+            '/VBF1Parked/HIRun2013A-v1/RAW#fc64292c-5c81-11e2-912f-842b2b4671d8',
+            '/VBF1Parked/HIRun2013A-v1/RAW#fc87c8dc-5c81-11e2-912f-842b2b4671d8',
+            '/VBF1Parked/HIRun2013A-v1/RAW#fcd9876c-5c81-11e2-912f-842b2b4671d8'
+            ]
+        time0 = time.time()
+        res1 = reader1.listFileBlockLocation(blocks)
+        time1 = time.time() - time0
+        self.assertTrue(time1 > 0)  # to avoid pyling complaining about not used varaiable
+        time0 = time.time()
+        res2 = reader2.listFileBlockLocation(blocks)
+        time2 = time.time() - time0
+        self.assertTrue(time2 > 0)  # to avoid pyling complaining about not used varaiable
+        self.assertTrue(res1 == res2)
+
+    @attr("integration")
+    def testGetParallelGetParentFilesGivenParentDataset(self):
+        """
+        test parallel execution of getParentFilesGivenParentDataset DBS API
+        We use small the following data:
+
+        # find lfn for some dataset
+        dasgoclient -query="file dataset=/VBF1Parked/Run2012D-22Jan2013-v1/AOD"
+        ...
+        /store/data/Run2012D/VBF1Parked/AOD/22Jan2013-v1/120000/F64DFA15-15A8-E211-9277-80000048FE80.root
+
+        # find parent dataset
+        dasgoclient -query="parent dataset=/VBF1Parked/Run2012D-22Jan2013-v1/AOD"
+        /VBF1Parked/Run2012D-v1/RAW
+
+        The parallel call should perform better then sequential while results
+        should remain the same.
+
+        """
+        url = "https://cmsweb.cern.ch/dbs/prod/global/DBSReader"
+        reader1 = DBS3Reader(url, logger=None, parallel=False, aggregate=True)
+        reader2 = DBS3Reader(url, logger=None, parallel=True, aggregate=True)
+        parentDataset = '/VBF1Parked/Run2012D-v1/RAW'
+        childLFN = '/store/data/Run2012D/VBF1Parked/AOD/22Jan2013-v1/120000/F64DFA15-15A8-E211-9277-80000048FE80.root'
+        time0 = time.time()
+        res1 = reader1.getParentFilesGivenParentDataset(parentDataset, childLFN)
+        time1 = time.time() - time0
+        self.assertTrue(time1 > 0)  # to avoid pyling complaining about not used varaiable
+        time0 = time.time()
+        res2 = reader2.getParentFilesGivenParentDataset(parentDataset, childLFN)
+        time2 = time.time() - time0
+        self.assertTrue(time2 > 0)  # to avoid pyling complaining about not used varaiable
+        self.assertTrue(res1 == res2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #11098 

#### Status
ready

#### Description
Use concurrent features to speed up `listDatasetFileDetails` API. In my local setup I achieve speed up by factor of 5 or more for a specific dataset. Here are benchmark numbers for using `/VBF1Parked/Run2012D-v1/RAW` dataset. This dataset contains 594 blocks. The current codebase takes approximately 190 seconds to fetch its parents and file lumis. Using proposed solution I achieve the following numbers:
- 37 seconds using 50 concurrent tasks
- 41 seconds using 100 concurrent tasks
- 90 seconds using 10 concurrent tasks

Internally, I used `requests` python library instead of `pycurl_manager.py`. The latter is not suitable for concurrent execution since it is not thread safe as it holds global curl object. As such curl options are set on first tasks, but can't be changed (since code set them up) in others until first task is completed. The `requests` library does not depend on global curl object and curl library itself, and it is suitable for concurrent execution of multiple URL calls.

This PR only addresses speed up of single  `listDatasetFileDetails` DBS3Reader API but other APIs where multiple (sequential) calls to DBS are made can benefit from this approach.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
https://github.com/dmwm/dbs2go/issues/5

#### External dependencies / deployment changes
relies on Python `requests` library