### PR TITLE
move ckey/cert functions to Utils.CertTools

### DIFF
--- a/src/python/Utils/CertTools.py
+++ b/src/python/Utils/CertTools.py
@@ -3,6 +3,18 @@ from builtins import str
 import os
 
 
+def ckey():
+    "Return user CA key either from proxy or userkey.pem"
+    pair = getKeyCertFromEnv()
+    return pair[0]
+
+
+def cert():
+    "Return user CA cert either from proxy or usercert.pem"
+    pair = getKeyCertFromEnv()
+    return pair[1]
+
+
 def getKeyCertFromEnv():
     """
     gets key and certificate from environment variables
@@ -16,29 +28,28 @@ def getKeyCertFromEnv():
                 ('X509_USER_KEY', 'X509_USER_CERT')]  # Third preference to User Cert/Proxy combinition
 
     for keyEnv, certEnv in envPairs:
-        key = os.environ.get(keyEnv)
-        cert = os.environ.get(certEnv)
-        if key and cert and os.path.exists(key) and os.path.exists(cert):
+        localKey = os.environ.get(keyEnv)
+        localCert = os.environ.get(certEnv)
+        if localKey and localCert and os.path.exists(localKey) and os.path.exists(localCert):
             # if it is found in env return key, cert
-            return key, cert
+            return localKey, localCert
 
     # TODO: only in linux, unix case, add other os case
     # look for proxy at default location /tmp/x509up_u$uid
-    key = cert = '/tmp/x509up_u' + str(os.getuid())
-    if os.path.exists(key):
-        return key, cert
+    localKey = localCert = '/tmp/x509up_u' + str(os.getuid())
+    if os.path.exists(localKey):
+        return localKey, localCert
 
     # Finary look for globaus location
     if (os.environ.get('HOME') and
         os.path.exists(os.environ['HOME'] + '/.globus/usercert.pem')  and
         os.path.exists(os.environ['HOME'] + '/.globus/userkey.pem')):
 
-        key = os.environ['HOME'] + '/.globus/userkey.pem'
-        cert = os.environ['HOME'] + '/.globus/usercert.pem'
-        return key, cert
-    else:
-        # couldn't find the key, cert files
-        return None, None
+        localKey = os.environ['HOME'] + '/.globus/userkey.pem'
+        localCert = os.environ['HOME'] + '/.globus/usercert.pem'
+        return localKey, localCert
+    # couldn't find the key, cert files
+    return None, None
 
 
 def getCAPathFromEnv():

--- a/src/python/WMCore/MicroService/Tools/Common.py
+++ b/src/python/WMCore/MicroService/Tools/Common.py
@@ -21,7 +21,7 @@ from urllib.parse import quote, unquote
 
 # WMCore modules
 from Utils.IteratorTools import grouper
-from Utils.CertTools import getKeyCertFromEnv
+from Utils.CertTools import ckey, cert
 from WMCore.Services.pycurl_manager import RequestHandler
 from WMCore.Services.pycurl_manager import getdata as multi_getdata
 
@@ -501,18 +501,6 @@ def teraBytes(size):
 def gigaBytes(size):
     "Return size in GB (Gigabytes), rounded to 2 digits"
     return round(size / (1000 ** 3), 2)
-
-
-def ckey():
-    "Return user CA key either from proxy or userkey.pem"
-    pair = getKeyCertFromEnv()
-    return pair[0]
-
-
-def cert():
-    "Return user CA cert either from proxy or usercert.pem"
-    pair = getKeyCertFromEnv()
-    return pair[1]
 
 
 def elapsedTime(time0, msg='Elapsed time', ndigits=1):

--- a/src/python/WMCore/MicroService/Tools/PycurlRucio.py
+++ b/src/python/WMCore/MicroService/Tools/PycurlRucio.py
@@ -20,25 +20,13 @@ import re
 
 from urllib.parse import quote, unquote
 
-from Utils.CertTools import getKeyCertFromEnv
+from Utils.CertTools import cert, ckey
 from WMCore.Services.pycurl_manager import RequestHandler
 from WMCore.Services.pycurl_manager import getdata as multi_getdata
 
 ### Amount of days that we wait for stuck rules to be sorted
 ### After that, the rule is not considered and a new rule is created
 STUCK_LIMIT = 7  # 7 days
-
-
-def ckey():
-    "Return user CA key either from proxy or userkey.pem"
-    pair = getKeyCertFromEnv()
-    return pair[0]
-
-
-def cert():
-    "Return user CA cert either from proxy or usercert.pem"
-    pair = getKeyCertFromEnv()
-    return pair[1]
 
 
 def parseNewLineJson(stream):


### PR DESCRIPTION
Partially Fixes #11098 (moving cert/ceky function will allow to share code between MicroServices and DBS services)

#### Status
ready

#### Description
Move functions `ckey` and `cert` into `Utils.CertTools` which is generic place to import from other places. This will allow to share and use this code in different Services, like MicroServices and DBS.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
See #11099 , if applied then I can safely remove these functions from #11099  and use common code.

#### External dependencies / deployment changes
