### PR TITLE
Fix redundant WHERE NOT EXISTS clause parameters for protecting from Unique constraints in ORACLE for DBS3Buffer/NewSubscriptions

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/Oracle/NewSubscription.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/NewSubscription.py
@@ -30,6 +30,5 @@ class NewSubscription(MySQLNewSubscription):
                  AND custodial = :custodial
                  AND auto_approve = :auto_approve
                  AND move = :move
-                 AND priority = :priority
-                 AND dataset_lifetime = :dataset_lifetime )
+                 AND priority = :priority )
              """


### PR DESCRIPTION
wmagent branch only fix for #11108 

#### Status
ready

#### Description
This is a quick bug fix on the above issue which is actually a two fold problem:
 * Having a unique constraint in the database schema with one set of parameters and having a protection Where clause  in the insert statement using a different set of parameters. More precisely the newlly added field of `dataset_lifetime`. The long explanation is in this comment here:  https://github.com/dmwm/WMCore/issues/11108#issuecomment-1106461797 
 * Lack of strict data type checks for all values entering the database queries and so protecting in our won code from deviating  from the so defined database schema.

The current fix addresses only the first out of those two. And is considered to be temporary, because it is fixing currently existing only for the production system and needs to be properly tested and addressed for T0 replays and workflows too.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None