### PR TITLE
Enforce dataset_lifetime column to be integer and not null

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/MySQL/Create.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/Create.py
@@ -49,7 +49,7 @@ class Create(DBCreator):
                  subscribed             INTEGER      DEFAULT 0,
                  phedex_group           VARCHAR(100),
                  delete_blocks          INTEGER,
-                 dataset_lifetime       INTEGER     DEFAULT 0,
+                 dataset_lifetime       INTEGER      DEFAULT 0 NOT NULL,
                  PRIMARY KEY (id),
                  CONSTRAINT uq_dbs_dat_sub UNIQUE (dataset_id, site, custodial, auto_approve, move, priority))"""
 

--- a/src/python/WMComponent/DBS3Buffer/Oracle/Create.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/Create.py
@@ -49,7 +49,7 @@ class Create(DBCreator):
                  subscribed         INTEGER      DEFAULT 0,
                  phedex_group       VARCHAR(100),
                  delete_blocks      INTEGER,
-                 dataset_lifetime   INTEGER     DEFAULT 0,
+                 dataset_lifetime   INTEGER      DEFAULT 0 NOT NULL,
                  PRIMARY KEY (id),
                  CONSTRAINT uq_dbs_dat_sub UNIQUE (dataset_id, site, custodial, auto_approve, move, priority)
                )"""


### PR DESCRIPTION
Fixes #11108 
Alternative to https://github.com/dmwm/WMCore/pull/11111

#### Status
ready

#### Description
This change will ensure that:
* the database won't accept `None` as input for the `dataset_lifetime` column
* that we properly convert None to 0 whenever needed, before creating a record in the database.

#### Is it backward compatible (if not, which system it affects?)
NO (database schema change)

#### Related PRs
If this proposal is acceptable and correct, we might want to merge this in master only; backport and merge #11111 to the 2.0.2_wmagent branch and create a new patch release.

#### External dependencies / deployment changes
None
