### PR TITLE
Change fallback for missing system xrootd-client

### DIFF
--- a/test/python/WMCore_t/Storage_t/Backends_t/XRDCPImpl_t.py
+++ b/test/python/WMCore_t/Storage_t/Backends_t/XRDCPImpl_t.py
@@ -1,9 +1,9 @@
 from __future__ import (print_function, division)
 
 import unittest
+import os
 
 from mock import mock
-
 from WMCore.Storage.Backends.XRDCPImpl import XRDCPImpl
 
 
@@ -87,6 +87,9 @@ class XRDCPImplTest(unittest.TestCase):
             copyCommand += "echo \"Local File Size is: $LOCAL_SIZE\"\n"
             if copyCommandOptions:
                 targetPFN += "?svcClass=t0cms"
+        initFile = "/cvmfs/oasis.opensciencegrid.org/osg-software/osg-wn-client/current/el7-x86_64/setup.sh"
+        if not self.XRDCPImpl._checkXRDUtilsExist() and os.path.isfile(initFile):
+            copyCommand += "source {}\n".format(initFile)
         copyCommand += "xrdcp --force --nopbar "
         if unknow:
             copyCommand += "%s " % unknow


### PR DESCRIPTION
Fixes #10796 
Fixes https://github.com/dmwm/WMCore/issues/9108
Superseeds https://github.com/dmwm/WMCore/pull/10684

#### Status
ready

#### Description
This pull request updates the fallback XRootD mechanism used for stage out, no longer relying on a SLC6-based
ancient XRootD version (4.0.4) and instead trying to use an OSG-based EL7 newer version.

This, of course, won't work for non-OSG sites. However, this fallback is better than an ancient and not functional one (and needed for US HPC resources).

I also took the opportunity to remove the old `xrdcp-old` hack that was required many years ago for FNAL, where the XRDCP plugin option `--wma-old` was also removed. I checked SITECONF in CVMFS and I do not see that option being used, so it should be safe to remove it now. 

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Superseeds https://github.com/dmwm/WMCore/pull/10684 (please see some further input here as well)

#### External dependencies / deployment changes
None
