### PR TITLE
Properly handle OpenRunningTimeout in WorkQueue

### DIFF
--- a/src/python/WMCore/GlobalWorkQueue/CherryPyThreads/ReqMgrInteractionTask.py
+++ b/src/python/WMCore/GlobalWorkQueue/CherryPyThreads/ReqMgrInteractionTask.py
@@ -28,8 +28,8 @@ class ReqMgrInteractionTask(CherryPyPeriodicTask):
         4. record this activity
         """
         tStart = time()
-        self.logger.info("Executing WorkQueue/ReqMgr thread thread")
+        self.logger.info("Executing WorkQueue/ReqMgr thread")
         self.reqMgrInt(self.globalQ)
-        self.logger.info("%s executed in %.3f secs.", self.__class__.__name__, time() - tStart)
+        self.logger.info("%s executed in %.3f secs.\n", self.__class__.__name__, time() - tStart)
 
         return

--- a/src/python/WMCore/WorkQueue/DataStructs/WorkQueueElement.py
+++ b/src/python/WMCore/WorkQueue/DataStructs/WorkQueueElement.py
@@ -5,7 +5,7 @@ A dictionary based object meant to represent a WorkQueue element
 """
 
 from future.utils import viewitems, viewvalues
-
+import time
 from hashlib import md5
 
 from Utils.Utilities import encodeUnicodeToBytesConditional
@@ -98,16 +98,16 @@ class WorkQueueElement(dict):
         self.setdefault('NumOfFilesAdded', 0)
         # Mask used to constrain MC run/lumi ranges
         self.setdefault('Mask', None)
-        # is new data being added to the inputs i.e. open block with new files or dataset with new closed blocks?
+        # is new data being added to the workflow (e.g., growing input datasets)
         self.setdefault('OpenForNewData', False)
-        # When was the last time we found new data (not the same as when new data was split), e.g. An open block was found
-        self.setdefault('TimestampFoundNewData', 0)
+        # EPOCH time for when the last block was found and added to the workflow
+        self.setdefault('TimestampFoundNewData', int(time.time()))
         # Trust initial input dataset location only or not
         self.setdefault('NoInputUpdate', False)
         # Trust initial pileup dataset location only or not
         self.setdefault('NoPileupUpdate', False)
-        # set the creation time for wq element, need for sorting
-        self.setdefault('CreationTime', 0)
+        # EPOCH time with the creation time for this wq element, needed for sorting
+        self.setdefault('CreationTime', int(time.time()))
         # set to true when updated from a WorkQueueElementResult
         self.modified = False
 

--- a/src/python/WMCore/WorkQueue/Policy/Start/Block.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Block.py
@@ -231,15 +231,13 @@ class Block(StartPolicyInterface):
 
     def modifyPolicyForWorkAddition(self, inboxElement):
         """
-            A block blacklist modifier will be created,
-            this policy object will split excluding the blocks in both the spec
-            blacklist and the blacklist modified
+        A block blacklist modifier will be created,
+        this policy object will split excluding the blocks in both the spec
+        blacklist and the blacklist modified
         """
         # Get the already processed input blocks from the inbox element
-        existingBlocks = inboxElement.get('ProcessedInputs', [])
-        self.blockBlackListModifier = existingBlocks
+        self.blockBlackListModifier = inboxElement.get('ProcessedInputs', [])
         self.blockBlackListModifier.extend(inboxElement.get('RejectedInputs', []))
-        return
 
     def newDataAvailable(self, task, inbound):
         """
@@ -255,6 +253,6 @@ class Block(StartPolicyInterface):
     @staticmethod
     def supportsWorkAddition():
         """
-            Block start policy supports continuous addition of work
+        Block start policy supports continuous addition of work
         """
         return True

--- a/src/python/WMCore/WorkQueue/WorkQueueBackend.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueBackend.py
@@ -187,7 +187,7 @@ class WorkQueueBackend(object):
                        'RequestName': spec.name(),
                        'StartPolicy': spec.startPolicyParameters(),
                        'EndPolicy': spec.endPolicyParameters(),
-                       'OpenForNewData': False
+                       'OpenForNewData': True
                        })
         unit = CouchWorkQueueElement(self.inbox, elementParams=kwargs)
         unit.id = spec.name()

--- a/src/python/WMCore/WorkQueue/WorkQueueReqMgrInterface.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueReqMgrInterface.py
@@ -5,15 +5,15 @@ Helper class for RequestManager interaction
 from builtins import object
 from future.utils import viewvalues
 
+import logging
 import os
 import socket
 import threading
-import time
 import traceback
 from operator import itemgetter
 
 from WMCore import Lexicon
-from WMCore.Database.CMSCouch import CouchError
+from WMCore.Database.CMSCouch import CouchError, CouchNotFoundError
 from WMCore.Database.CouchUtils import CouchConnectionError
 from WMCore.ReqMgr.DataStructs.RequestStatus import REQUEST_STATE_LIST
 from WMCore.Services.LogDB.LogDB import LogDB
@@ -27,7 +27,6 @@ class WorkQueueReqMgrInterface(object):
 
     def __init__(self, **kwargs):
         if not kwargs.get('logger'):
-            import logging
             kwargs['logger'] = logging
         self.logger = kwargs['logger']
         self.rucio = Rucio(kwargs.get("rucioAccount", "wmcore_transferor"),
@@ -48,48 +47,53 @@ class WorkQueueReqMgrInterface(object):
 
     def __call__(self, queue):
         """Synchronize WorkQueue and RequestManager"""
+        # ensure log records go to the correct logger object
+        queue.logger = self.logger
         msg = ''
-        try:  # pull in new work
-            self.logger.info("queueing new work")
-            work = self.queueNewRequests(queue)
-            msg += "New Work: %d\n" % work
-        except Exception as ex:
-            errorMsg = "Error caught during RequestManager pull"
-            self.logger.exception("%s: %s", errorMsg, str(ex))
-
-        try:  # get additional open-running work
-            self.logger.info("adding new element to open requests")
-            extraWork = self.addNewElementsToOpenRequests(queue)
-            msg += "Work added: %d\n" % extraWork
-        except Exception as ex:
-            errorMsg = "Error caught during RequestManager split"
-            self.logger.exception("%s: %s", errorMsg, str(ex))
-
-        try:  # report back to ReqMgr
-            self.logger.info("cancel aborted requests")
+        try:  # Fetch data from ReqMgr and propagate work cancellation to workqueue
+            self.logger.info("Canceling aborted and force-completed requests")
             count = self.cancelWork(queue)
-            self.logger.info("finished canceling requests")
-            msg += "Work canceled: %s " % count
+            msg += "Work canceled: %s, " % count
         except Exception as ex:
-            errorMsg = "Error caught during canceling the request"
-            self.logger.exception("%s: %s", errorMsg, str(ex))
+            self.logger.exception("Generic error while canceling work. Details: %s", str(ex))
 
+        try:  # Close requests that no longer need to be open for new data
+            self.logger.info("Closing open requests")
+            workClosed = queue.closeWork()
+            msg += "Work closed: %d, " % len(workClosed)
+        except Exception as ex:
+            errorMsg = "Generic error while closing open requests. Details: %s"
+            self.logger.exception(errorMsg, str(ex))
+
+        try:  # Try to create new work elements for open requests
+            self.logger.info("Adding new elements to open requests")
+            extraWork = self.addNewElementsToOpenRequests(queue)
+            msg += "Work added: %d, " % extraWork
+        except Exception as ex:
+            errorMsg = "Generic error while adding work to open requests. Details: %s"
+            self.logger.exception(errorMsg, str(ex))
+
+        try:  # Pull in work for new requests
+            self.logger.info("Queuing work for new requests")
+            work = self.queueNewRequests(queue)
+            msg += "New Work: %d" % work
+        except Exception as ex:
+            errorMsg = "Generic error while queuing work for new requests. Details: %s"
+            self.logger.exception(errorMsg, str(ex))
+
+        self.logger.info("Summary of %s: %s", self.__class__.__name__, msg)
         queue.backend.recordTaskActivity('reqmgr_sync', msg)
 
     def queueNewRequests(self, queue):
         """Get requests from regMgr and queue to workqueue"""
-        self.logger.info("Contacting Request manager for more work")
-        work = 0
-        workLoads = []
-
         try:
             workLoads = self.getAvailableRequests()
-        except Exception as ex:
-            traceMsg = traceback.format_exc()
-            msg = "Error contacting RequestManager: %s" % traceMsg
-            self.logger.warning(msg)
+        except Exception as exc:
+            msg = "Error contacting RequestManager. Details: %s" % str(exc)
+            self.logger.exception(msg)
             return 0
 
+        work = 0
         for team, reqName, workLoadUrl in workLoads:
             try:
                 try:
@@ -105,7 +109,7 @@ class WorkQueueReqMgrInterface(object):
                 self.logdb.delete(reqName, "error", this_thread=True, agent=False)
             except TERMINAL_EXCEPTIONS as ex:
                 # fatal error - report back to ReqMgr
-                self.logger.error('Permanent failure processing request "%s": %s' % (reqName, str(ex)))
+                self.logger.critical('Permanent failure processing request "%s": %s' % (reqName, str(ex)))
                 self.logger.info("Marking request %s as failed in ReqMgr" % reqName)
                 self.reportRequestStatus(reqName, 'Failed', message=str(ex))
                 continue
@@ -113,7 +117,7 @@ class WorkQueueReqMgrInterface(object):
                 # temporary problem - try again later
                 msg = 'Error processing request "%s": will try again later.' % reqName
                 msg += '\nError: "%s"' % str(ex)
-                self.logger.info(msg)
+                self.logger.error(msg)
                 self.logdb.post(reqName, msg, 'error')
                 continue
             except Exception as ex:
@@ -127,7 +131,7 @@ class WorkQueueReqMgrInterface(object):
             self.logger.info('%s units(s) queued for "%s"' % (units, reqName))
             work += units
 
-            self.logger.info("%s element(s) obtained from RequestManager" % work)
+        self.logger.info("Total of %s element(s) queued for new requests", work)
         return work
 
     def cancelWork(self, queue):
@@ -137,69 +141,13 @@ class WorkQueueReqMgrInterface(object):
             try:
                 queue.cancelWork(req)
                 count += 1
+            except CouchNotFoundError as exc:
+                msg = 'Failed to cancel workflow: {} because elements are no '.format(req)
+                msg += 'longer exist in CouchDB. Details: {}'.format(str(exc))
             except Exception as ex:
                 msg = 'Error to cancel the request "%s": %s' % (req, str(ex))
                 self.logger.exception(msg)
         return count
-
-    def report(self, queue):
-        """Report queue status to ReqMgr."""
-        new_state = {}
-        uptodate_elements = []
-        now = time.time()
-
-        elements = queue.statusInbox(dictKey="RequestName")
-        if not elements:
-            return new_state
-
-        for ele in elements:
-            ele = elements[ele][0]  # 1 element tuple
-            try:
-                request = self.reqMgr2.getRequestByNames(ele['RequestName'])
-                if not request:
-                    msg = 'Failed to get request "%s" from ReqMgr2. Will try again later.' % ele['RequestName']
-                    self.logger.warning(msg)
-                    continue
-                request = request[0][ele['RequestName']]
-                if request['RequestStatus'] in ('failed', 'completed', 'announced',
-                                                'closed-out', 'rejected'):
-                    # requests can be done in reqmgr but running in workqueue
-                    # if request has been closed but agent cleanup actions
-                    # haven't been run (or agent has been retired)
-                    # Prune out obviously too old ones to avoid build up
-                    if queue.params.get('reqmgrCompleteGraceTime', -1) > 0:
-                        if (now - float(ele.updatetime)) > queue.params['reqmgrCompleteGraceTime']:
-                            # have to check all elements are at least running and are old enough
-                            request_elements = queue.statusInbox(WorkflowName=request['RequestName'])
-                            if not any(
-                                    [x for x in request_elements if x['Status'] != 'Running' and not x.inEndState()]):
-                                last_update = max([float(x.updatetime) for x in request_elements])
-                                if (now - last_update) > queue.params['reqmgrCompleteGraceTime']:
-                                    self.logger.info(
-                                        "Finishing request %s as it is done in reqmgr" % request['RequestName'])
-                                    queue.doneWork(WorkflowName=request['RequestName'])
-                                    continue
-                    else:
-                        pass  # assume workqueue status will catch up later
-                elif request['RequestStatus'] in ['aborted', 'force-complete']:
-                    queue.cancelWork(WorkflowName=request['RequestName'])
-                # Check consistency of running-open/closed and the element closure status
-                elif request['RequestStatus'] == 'running-open' and not ele.get('OpenForNewData', False):
-                    self.reportRequestStatus(ele['RequestName'], 'running-closed')
-                elif request['RequestStatus'] == 'running-closed' and ele.get('OpenForNewData', False):
-                    queue.closeWork(ele['RequestName'], rucioObj=self.rucio)
-                # we do not want to move the request to 'failed' status
-                elif ele['Status'] == 'Failed':
-                    continue
-                elif ele['Status'] not in self._reqMgrToWorkQueueStatus(request['RequestStatus']):
-                    self.reportElement(ele)
-
-                uptodate_elements.append(ele)
-            except Exception as ex:
-                msg = 'Error talking to ReqMgr about request "%s": %s' % (ele['RequestName'], str(ex))
-                self.logger.exception(msg)
-
-        return uptodate_elements
 
     def deleteFinishedWork(self, queue, elements):
         """Delete work from queue that is finished in ReqMgr"""
@@ -214,7 +162,9 @@ class WorkQueueReqMgrInterface(object):
         Get available requests and sort by team and priority
         returns [(team, request_name, request_spec_url)]
         """
-        tempResults = self.reqMgr2.getRequestByStatus("staged")
+        thisStatus = "staged"
+        self.logger.info("Contacting ReqMgr for workflows in status: %s", thisStatus)
+        tempResults = self.reqMgr2.getRequestByStatus(thisStatus)
         filteredResults = []
         for requests in tempResults:
             for request in viewvalues(requests):
@@ -284,51 +234,45 @@ class WorkQueueReqMgrInterface(object):
         self.reportRequestStatus(element['RequestName'], element['Status'])
 
     def addNewElementsToOpenRequests(self, queue):
-        """Add new elements to open requests which are in running-open state, only works adding new blocks from the input dataset"""
-        self.logger.info("Checking Request Manager for open requests and closing old ones")
-
-        work = 0
-        requests = []
+        """
+        Add new elements to open requests according to their
+        workqueue_inbox element.
+        """
+        self.logger.info("Fetching open requests from WorkQueue")
 
         try:
-            requests = self.reqMgr2.getRequestByStatus("running-open", detail=False)
-        except Exception as ex:
-            traceMsg = traceback.format_exc()
-            msg = "Error contacting RequestManager: %s" % traceMsg
-            self.logger.warning(msg)
+            workInbox = queue.backend.getInboxElements(OpenForNewData=True, loadSpec=True)
+        except Exception as exc:
+            self.logger.exception("Error retrieving open inbox elements. Details: %s", str(exc))
             return 0
 
-        for reqName in requests:
+        self.logger.info("Retrieved %d inbox elements open for new data", len(workInbox))
+        work = 0
+        for elem in workInbox:
             try:
-                self.logger.info("Processing request %s" % (reqName))
-                units = queue.addWork(requestName=reqName, rucioObj=self.rucio)
-                self.logdb.delete(reqName, 'error', True, agent=False)
+                units = queue.addWork(elem, rucioObj=self.rucio)
+                self.logdb.delete(elem['RequestName'], 'error', True, agent=False)
             except (WorkQueueWMSpecError, WorkQueueNoWorkError) as ex:
                 # fatal error - but at least it was split the first time. Log and skip.
-                msg = 'Error adding further work to request "%s". Will try again later' % reqName
-                msg += '\nError: "%s"' % str(ex)
-                self.logger.info(msg)
-                self.logdb.post(reqName, msg, 'error')
-                continue
+                msg = 'Error adding further work to request "%s". ' % elem['RequestName']
+                msg += 'Will try again later.\nError: "%s"' % str(ex)
+                self.logger.error(msg)
+                self.logdb.post(elem['RequestName'], msg, 'error')
             except (IOError, socket.error, CouchError, CouchConnectionError) as ex:
                 # temporary problem - try again later
-                msg = 'Error processing request "%s": will try again later.' % reqName
+                msg = 'Error processing request "%s": will try again later.' % elem['RequestName']
                 msg += '\nError: "%s"' % str(ex)
-                self.logger.info(msg)
-                self.logdb.post(reqName, msg, 'error')
-                continue
+                self.logger.error(msg)
+                self.logdb.post(elem['RequestName'], msg, 'error')
             except Exception as ex:
                 # Log exception as it isnt a communication problem
-                msg = 'Error processing request "%s": will try again later.' % reqName
-                msg += '\nSee log for details.\nError: "%s"' % str(ex)
-                traceMsg = traceback.format_exc()
-                msg = "%s\n%s" % (msg, traceMsg)
-                self.logger.exception('Unknown error processing %s' % reqName)
-                self.logdb.post(reqName, msg, 'error')
-                continue
-
-            self.logger.info('%s units(s) queued for "%s"' % (units, reqName))
-            work += units
+                msg = 'Error processing request "%s". Will try again later. ' % elem['RequestName']
+                msg += 'See log for details.\nError: "%s"' % str(ex)
+                msg += '\nTraceback: %s' % traceback.format_exc()
+                self.logger.exception('Unknown error processing %s' % elem['RequestName'])
+                self.logdb.post(elem['RequestName'], msg, 'error')
+            else:
+                work += units
 
         self.logger.info("%s element(s) added to open requests" % work)
         return work

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
@@ -1284,7 +1284,8 @@ class WorkQueueTest(WorkQueueTestCase):
                          False)
 
         # close the global inbox elements, they won't be split anymore
-        self.globalQueue.closeWork(['testProcessing', 'testProduction'])
+        #self.globalQueue.closeWork(['testProcessing', 'testProduction'])
+        self.globalQueue.closeWork()
         self.localQueue.getWMBSInjectionStatus()
         time.sleep(1)
         # There are too many jobs to pull down for testProcessing still has element not in WMBS
@@ -1395,7 +1396,9 @@ class WorkQueueTest(WorkQueueTestCase):
 
         # Try adding work, no change in blocks available. No work should be added
         logging.info("Adding work - already added - for spec name: %s", processingSpec.name())
-        self.assertEqual(0, self.globalQueue.addWork(processingSpec.name()))
+        workInbox = self.globalQueue.backend.getInboxElements(WorkflowName=processingSpec.name(),
+                                                              loadSpec=True)
+        self.assertEqual(0, self.globalQueue.addWork(workInbox[0]))
         self.assertEqual(NBLOCKS_HICOMM, len(self.globalQueue))
 
         # Now pull work from the global to the local queue
@@ -1412,10 +1415,8 @@ class WorkQueueTest(WorkQueueTestCase):
         syncQueues(self.localQueue)
         syncQueues(self.globalQueue)
 
-        # FIXME: for some reason, it tries to reinsert all those elements again
-        # however, if we call it again, it won't retry anything
-        self.assertEqual(47, self.globalQueue.addWork(processingSpec.name()))
-        self.assertEqual(0, self.globalQueue.addWork(processingSpec.name()))
+        workInbox = self.globalQueue.backend.getInboxElements(status="Running", loadSpec=True)
+        self.assertEqual(0, self.globalQueue.addWork(workInbox[0]))
 
         self.assertEqual(NBLOCKS_HICOMM - 1, len(self.globalQueue))
         self.assertEqual(len(self.globalQueue.backend.getInboxElements(status="Running")), 1)
@@ -1426,10 +1427,8 @@ class WorkQueueTest(WorkQueueTestCase):
         self.assertEqual(len(self.localQueue), 30)
         self.assertEqual(len(self.globalQueue), NBLOCKS_HICOMM - 30 - 1)
 
-        # FIXME: for some reason, it tries to reinsert all those elements again
-        # however, if we call it again, it won't retry anything
-        self.assertEqual(47, self.globalQueue.addWork(processingSpec.name()))
-        self.assertEqual(0, self.globalQueue.addWork(processingSpec.name()))
+        workInbox = self.globalQueue.backend.getInboxElements(WorkflowName=processingSpec.name(), loadSpec=True)
+        self.assertEqual(0, self.globalQueue.addWork(workInbox[0]))
 
         return
 


### PR DESCRIPTION
Fixes #11048 

#### Status
ready

#### Description
This pull request provides all the pieces to support OpenRunningTimeout workflows in GQ, allowing freshly created input blocks to be created as workqueue elements in GQ.

A detailed description of the changes provided here is:
* overall improvements to log records
* default GQ inbox elements (1 per workflow) to be OpenForNewData=True
* default workqueue elements `CreationTime` and `TimestampFoundNewData` to use the current time (instead of 0)
* encapsulates work cancelation in try/except (since there is another thread doing the cleanup)
* `closeWork` method refactored to only close inbox work (now used only in GQ), according to:
  * if inbox element has OpenRunningTimeout=0, it gets closed
  * if it's been more than X secs since the last element has been discovered, it gets closed too
  * no longer takes a specific workflow as input, but lists all workflows open for new data and verify each one of them
  * no longer look for open blocks in DBS
* `addWork` method refactored to add new elements to workflows with workqueue inbox opened for new data (only used by GQ)

In the module WorkQueue/WorkQueueReqMgrInterface.py, changes are:
* reorganized tasks executed in the __call__ method, such that:
  * first it cancels elements for aborted/force-completed workflows
  * secondly, it closes requests with open inbox elements (if constraints are fulfilled)
  * third, it tries to add new work to open requests
  * fourth, it splits/queues work for new requests (workflows sitting in staged status)
* removed `report` method, which was already no longer used (since we started making status transition only in the ReqMgr2 cherrypy thread)

TODO: fix input data placement in MSTransferor such that the whole container has a rule. But there is a separate issue for that.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
