### PR TITLE
Delay local CouchDB cleanup for Archived workflows for T0

### DIFF
--- a/src/python/WMComponent/TaskArchiver/CleanCouchPoller.py
+++ b/src/python/WMComponent/TaskArchiver/CleanCouchPoller.py
@@ -197,10 +197,15 @@ class CleanCouchPoller(BaseWorkerThread):
                 # NOTE: For T0 just update the request status in central CouchDB - t0_request
                 #       and let cleanAlreadyArchivedWorkflows do the actual couchdb cleaning
                 #       after config.TaskArchiver.cleanCouchDelayHours for the current workflow
+                msg = "Setting T0 workflow: %s to status: %s at central CouchDB."
+                msg += "Local CouchDB data will be cleaned after %s hours."
+                self.logger.debug(msg, workflowName, archiveState, self.config.TaskArchiver.cleanCouchDelayHours)
                 self.centralRequestDBWriter.updateRequestStatus(workflowName, archiveState)
                 updated += 1
                 continue
             if self.cleanAllLocalCouchDB(workflowName):
+                msg = "Local CouchDB data has been properly cleaned for: %s and status: %s."
+                self.logger.debug(msg, workflowName, archiveState)
                 updated += 1
         return updated
 

--- a/src/python/WMComponent/TaskArchiver/CleanCouchPoller.py
+++ b/src/python/WMComponent/TaskArchiver/CleanCouchPoller.py
@@ -376,6 +376,7 @@ class CleanCouchPoller(BaseWorkerThread):
                     workflowList.append(self.centralRequestDBReader.getRequestByStatusAndStartTime(status, startTime=startTime, detail=False))
                 for request in workflowList:
                     self.cleanAllLocalCouchDB(request)
+                    numDeletedRequests += 1
             else:
                 # NOTE: For the rest follow the normal logic:
                 workflowDict = self.centralRequestDBReader.getStatusAndTypeByRequest(requestNames)

--- a/src/python/WMCore/ReqMgr/DataStructs/RequestStatus.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/RequestStatus.py
@@ -85,6 +85,10 @@ ACTIVE_STATUS = ["new",
                  "aborted-completed",
                  "rejected"]
 
+ARCHIVED_STATUS = ["normal-archived",
+                   "rejected-archived",
+                   "aborted-archived"]
+
 ### WMSTATS_JOB_INFO + WMSTATS_NO_JOB_INFO is meant to be equal to ACTIVE_STATUS
 WMSTATS_JOB_INFO = ["running-open",
                     "running-closed",

--- a/src/python/WMCore/Services/WMStats/WMStatsReader.py
+++ b/src/python/WMCore/Services/WMStats/WMStatsReader.py
@@ -332,6 +332,24 @@ class WMStatsReader(object):
 
         return results
 
+    def getRequestByStatusAndStartTime(self, status, detail=False, startTime=0):
+        """
+        This is just a wrapper method to call getRequestByStatusAndStartTime from
+        request DB. It queries for requests that are in a specific status since startTime.
+        For this one to work we need reqDBURL to be set and reqDB object created.
+        :param detail: Bool flag to state if request details need to be included in the result
+        :param startTime: unix start timestamp
+        :return: A list of workflow names if details=False or a dictionary with workflow details otherwise.
+        """
+        if not self.reqDB:
+            msg = "We cannot fetch requests list for status: %s and startTime: %s."
+            msg += "Service has not been set properly, reqDBURL is missing."
+            self.logger.error(msg, status, startTime)
+            # NOTE: We may consider raising an error from here.
+            return []
+        result = self.reqDB.getRequestByStatusAndStartTime(status, detail=detail, startTime=startTime)
+        return result
+
     def getRequestSummaryWithJobInfo(self, requestName):
         """
         get request info with job status

--- a/src/python/WMCore/WMStats/CherryPyThreads/CleanUpTask.py
+++ b/src/python/WMCore/WMStats/CherryPyThreads/CleanUpTask.py
@@ -31,12 +31,8 @@ class CleanUpTask(CherryPyPeriodicTask):
         """
         self.logger.info("getting archived data")
         if self.cleanCouchDelayHours > 0:
-            requestNames = []
             satartTime = int(time.time()) - int(self.cleanCouchDelayHours * 60 * 60)
-            for status in ARCHIVED_STATUS:
-                msg = "Getting requests in status: %s, since: %s"
-                self.logger.info(msg, status, time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(startTime)))
-                requestNames.append(self.wmstatsDB.getRequestByStatusAndStartTime(status, startTime=startTime, detail=False))
+            requestNames = self.wmstatsDB.getRequestByStatusAndStartTime(ARCHIVED_STATUS, startTime=startTime, detail=False, jobInfoFlag=False)
         else:
             requestNames = self.wmstatsDB.getArchivedRequests()
         self.logger.info("archived list %s", requestNames)

--- a/src/python/WMCore/WMStats/T0/CherryPyThreads/T0DataCacheUpdate.py
+++ b/src/python/WMCore/WMStats/T0/CherryPyThreads/T0DataCacheUpdate.py
@@ -3,6 +3,7 @@
 '''
 from __future__ import (division, print_function)
 
+import time
 from WMCore.REST.CherryPyPeriodicTask import CherryPyPeriodicTask
 from WMCore.WMStats.DataStructs.DataCache import DataCache
 from WMCore.Services.WMStats.WMStatsReader import WMStatsReader
@@ -12,12 +13,14 @@ class T0DataCacheUpdate(CherryPyPeriodicTask):
     def __init__(self, rest, config):
 
         CherryPyPeriodicTask.__init__(self, config)
+        self.cleanCouchDelayHours = getattr(config, "cleanCouchDelayHours", 0)
 
     def setConcurrentTasks(self, config):
         """
         sets the list of functions which
         """
-        self.concurrentTasks = [{'func': self.gatherT0ActiveDataStats, 'duration': 300}]
+        self.concurrentTasks = [{'func': self.gatherT0ActiveDataStats, 'duration': 300},
+                                {'func': self.gatherT0ArchivedDataStats, 'duration': 300}]
 
     def gatherT0ActiveDataStats(self, config):
         """
@@ -29,7 +32,23 @@ class T0DataCacheUpdate(CherryPyPeriodicTask):
                                           reqdbCouchApp = "T0Request")
                 jobData = wmstatsDB.getT0ActiveData(jobInfoFlag = True)
                 DataCache.setlatestJobData(jobData)
-                self.logger.info("DataCache is updated: %s", len(jobData))
+                self.logger.info("DataCache is updated with T0 active Data. Number of records: %s", len(jobData))
+        except Exception as ex:
+            self.logger.error(str(ex))
+        return
+
+    def gatherT0ArchivedDataStats(self, config):
+        """
+        gather active data statistics
+        """
+        try:
+            if DataCache.islatestJobDataExpired():
+                wmstatsDB = WMStatsReader(config.wmstats_url, reqdbURL=config.reqmgrdb_url,
+                                          reqdbCouchApp = "T0Request")
+                startTime = int(time.time()) - int(self.cleanCouchDelayHours * 60 * 60)
+                jobData = wmstatsDB.getT0ArchivedData(jobInfoFlag = True, startTime=startTime)
+                DataCache.setlatestJobData(jobData)
+                self.logger.info("DataCache is updated with T0 archived Data. Number of records: %s", len(jobData))
         except Exception as ex:
             self.logger.error(str(ex))
         return


### PR DESCRIPTION
Fixes #10904

#### Status
 not-tested

#### Description
With the current PR we try to mark all workflows as  archived but not cleaning the local couchdb data at the agent durinng archival time, but we let the cleanup function do the job later, based on a configurable delay time. the change is valid only for T0 which we distinguish by the configuration flag: `config.TaskArchiver.useReqMgrForCompletionCheck` which is set to `False`  for T0. The parameter we use for delaying the cleanup is: `config.TaskArchiver.cleanCouchDelayHours`.

#### Is it backward compatible (if not, which system it affects?)
NO

#### Related PRs
We do not need additional PR for `service_config` so far since the new parameter is only for the agent configuration, but once/if we need to deal with central couchDB we will have to propagate it to `t0_reqmon` configuration as well.

#### External dependencies / deployment changes
No, but requires patching the agents
