### PR TITLE
Add T3_US_Lancium to resource-control.

### DIFF
--- a/deploy/addUSOpportunistic.sh
+++ b/deploy/addUSOpportunistic.sh
@@ -3,7 +3,7 @@ PEND_JOBS=3000
 RUNN_JOBS=3000
 # default manage location
 manage=/data/srv/wmagent/current/config/wmagent/manage
-for site in {T3_US_NERSC,T3_US_OSG,T3_US_PSC,T3_US_SDSC,T3_US_TACC,T3_US_Anvil};
+for site in {T3_US_NERSC,T3_US_OSG,T3_US_PSC,T3_US_SDSC,T3_US_TACC,T3_US_Anvil,T3_US_Lancium};
 do
   echo "Adding site: $site into the resource-control with $PEND_JOBS pending and $RUNN_JOBS running slots"
   $manage execute-agent wmagent-resource-control --site-name=$site --cms-name=$site --ce-name=$site --pnn=$site --plugin=SimpleCondorPlugin  --pending-slots=1000 --running-slots=1000;

--- a/deploy/deploy-wmagent.sh
+++ b/deploy/deploy-wmagent.sh
@@ -374,7 +374,7 @@ echo "Done!" && echo
 echo "*** Setting up US opportunistic resources ***"
 if [[ "$HOSTNAME" == *fnal.gov ]]; then
   sed -i "s+forceSiteDown = \[\]+forceSiteDown = \[$FORCEDOWN\]+" $MANAGE_DIR/config.py
-  for resourceName in {T3_US_NERSC,T3_US_OSG,T3_US_PSC,T3_US_SDSC,T3_US_TACC,T3_US_Anvil,T3_ES_PIC_BSC};
+  for resourceName in {T3_US_NERSC,T3_US_OSG,T3_US_PSC,T3_US_SDSC,T3_US_TACC,T3_US_Anvil,T3_US_Lancium,T3_ES_PIC_BSC};
   do
     ./manage execute-agent wmagent-resource-control --plugin=SimpleCondorPlugin --opportunistic \
       --pending-slots=$HPC_PEND_JOBS --running-slots=$HPC_RUNN_JOBS --add-one-site $resourceName


### PR DESCRIPTION
Fixes #11125 

#### Status
ready

#### Description
Adding T3_US_Lancium to the list of resources in the `addUSOpportunistic.sh`. 


#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
