### PR TITLE
Split Deletable Blocks checks in two stages.

### DIFF
--- a/src/python/WMComponent/RucioInjector/Database/MySQL/GetCompletedBlocks.py
+++ b/src/python/WMComponent/RucioInjector/Database/MySQL/GetCompletedBlocks.py
@@ -85,12 +85,12 @@ class GetCompletedBlocks(DBFormatter):
 
         # NOTE: We need to rename all the keys to follow the cammelCase standard. And also to comply
         #       with the key names as expected from the rest of the already existing python code
-        keyMap={'blockname': 'blockName',
-                'name': 'workflowName',
-                'pnn': 'location',
-                'site': 'sites',
-                'path': 'dataset',
-                'create_time': 'blockCreateTime'}
+        keyMap = {'blockname': 'blockName',
+                  'name': 'workflowName',
+                  'pnn': 'location',
+                  'site': 'sites',
+                  'path': 'dataset',
+                  'create_time': 'blockCreateTime'}
 
         dictResults = DBFormatter.formatDict(self, result)
         for record in dictResults:

--- a/src/python/WMComponent/RucioInjector/Database/MySQL/GetCompletedBlocks.py
+++ b/src/python/WMComponent/RucioInjector/Database/MySQL/GetCompletedBlocks.py
@@ -1,0 +1,117 @@
+"""
+_GetCompletedBlocks_
+
+MySQL implementation of RucioInjector.GetClompletedBlocks
+
+Retrieve a list of blocks that are complete,
+including their location and the sites they
+are subscribed too
+
+"""
+
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+
+class GetCompletedBlocks(DBFormatter):
+    """
+    Retrieves a list of blocks that are closed but NOT sure yet if they are deleteable:
+      - The workflows for all files in the block need to be completed (This relates only to the
+        workflows directly producing the files and does not track child workflows completion)
+      - The subscription made for dataset is copy+delete
+      - A subscription has been made at the Data Management system
+      - The blocks hasn't been deleted yet
+    """
+    sql = """SELECT dbsbuffer_block.blockname,
+                    dbsbuffer_location.pnn,
+                    dbsbuffer_dataset.path,
+                    dbsbuffer_dataset_subscription.site,
+                    dbsbuffer_workflow.name,
+                    dbsbuffer_block.create_time
+             FROM dbsbuffer_dataset_subscription
+             INNER JOIN dbsbuffer_dataset ON
+               dbsbuffer_dataset.id = dbsbuffer_dataset_subscription.dataset_id
+             INNER JOIN dbsbuffer_block ON
+               dbsbuffer_block.dataset_id = dbsbuffer_dataset_subscription.dataset_id
+             INNER JOIN dbsbuffer_file ON
+               dbsbuffer_file.block_id = dbsbuffer_block.id
+             INNER JOIN dbsbuffer_workflow ON
+               dbsbuffer_workflow.id = dbsbuffer_file.workflow
+             INNER JOIN dbsbuffer_location ON
+               dbsbuffer_location.id = dbsbuffer_block.location
+             WHERE dbsbuffer_dataset_subscription.delete_blocks = 1
+               AND dbsbuffer_dataset_subscription.subscribed = 1
+               AND dbsbuffer_block.status = 'Closed'
+               AND dbsbuffer_block.deleted = 0
+             GROUP BY dbsbuffer_block.blockname,
+                      dbsbuffer_location.pnn,
+                      dbsbuffer_dataset.path,
+                      dbsbuffer_dataset_subscription.site,
+                      dbsbuffer_workflow.name,
+                      dbsbuffer_block.create_time
+             HAVING COUNT(*) = SUM(dbsbuffer_workflow.completed)
+             """
+
+    def format(self, result):
+        """
+        _format_
+
+        Format the query results into the proper dictionary expected at the upper layer Python code.
+        The input should be a list of database objects each representing a line returned from the database
+        with key names matching the column names from the sql query
+        The result should be a list of dictionaries one record per line returned from the database
+        with key names mapped to the python code expected structures.
+
+        e.g.
+        [{'blockName': '/Cosmics/Tier0_REPLAY_2022-v425/RAW#aa3dbb67-dab0-4671-a550-711bdf9f4b08',
+          'workflowName': 'Repack_Run351572_StreamPhysics_Tier0_REPLAY_2022_ID220513161632_v425_220514_2038',
+          'location': 'T0_CH_CERN_Disk',
+          'site': {'T0_CH_CERN_Disk'},
+          'dataset': '/Cosmics/Tier0_REPLAY_2022-v425/RAW'},
+         {'blockName': '/NoBPTX/Tier0_REPLAY_2022-v425/RAW#6b8e95c3-656b-4302-8265-275df1195f4c',
+          'workflowName': 'Repack_Run351572_StreamPhysics_Tier0_REPLAY_2022_ID220513161632_v425_220514_2038',
+          'location': 'T0_CH_CERN_Disk',
+          'site': {'T0_CH_CERN_Disk'},
+          'dataset': '/NoBPTX/Tier0_REPLAY_2022-v425/RAW'}]
+
+
+        NOTE:
+         * location: Means where the output block has been created
+         * site(s):  Means where the dataset gets a container-level rule
+
+        :param result: The result as returned by the mysql query execution.
+        :return:       List of dictionaries
+        """
+
+        # NOTE: We need to rename all the keys to follow the cammelCase standard. And also to comply
+        #       with the key names as expected from the rest of the already existing python code
+        keyMap={'blockname': 'blockName',
+                'name': 'workflowName',
+                'pnn': 'location',
+                'site': 'sites',
+                'path': 'dataset',
+                'create_time': 'blockCreateTime'}
+
+        dictResults = DBFormatter.formatDict(self, result)
+        for record in dictResults:
+            for dbKey, pyKey in keyMap.items():
+                if dbKey == 'site':
+                    sites = record.pop(dbKey)
+                    record[pyKey] = set()
+                    record[pyKey].add(sites)
+                else:
+                    record[pyKey] = record.pop(dbKey)
+
+        return dictResults
+
+    def execute(self, conn=None, transaction=False, returnCursor=False):
+        """
+        Executing the current sql query.
+        :param conn:        A current database connection to be used if existing
+        :param transaction: A current database transaction to be used if existing
+        :return:            A list of dictionaries one record for each database line returned
+        """
+        results = self.dbi.processData(self.sql, conn=conn,
+                                       transaction=transaction)
+
+        return self.format(results)

--- a/src/python/WMComponent/RucioInjector/Database/Oracle/GetCompletedBlocks.py
+++ b/src/python/WMComponent/RucioInjector/Database/Oracle/GetCompletedBlocks.py
@@ -1,0 +1,15 @@
+"""
+_GetCompletedBlocks_
+
+Oracle implementation of RucioInjector.GetComletedBlocks
+
+"""
+
+from __future__ import division
+from __future__ import print_function
+
+from WMComponent.RucioInjector.Database.MySQL.GetCompletedBlocks import GetCompletedBlocks as MySQLGetCompletedBlocks
+
+
+class GetCompletedBlocks(MySQLGetCompletedBlocks):
+    pass

--- a/src/python/WMComponent/RucioInjector/Database/Oracle/GetCompletedBlocks.py
+++ b/src/python/WMComponent/RucioInjector/Database/Oracle/GetCompletedBlocks.py
@@ -5,8 +5,6 @@ Oracle implementation of RucioInjector.GetComletedBlocks
 
 """
 
-from __future__ import division
-from __future__ import print_function
 
 from WMComponent.RucioInjector.Database.MySQL.GetCompletedBlocks import GetCompletedBlocks as MySQLGetCompletedBlocks
 

--- a/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
+++ b/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
@@ -339,7 +339,7 @@ class RucioInjectorPoller(BaseWorkerThread):
 
         # in short, dbsbuffer_file.in_phedex = 1 AND dbsbuffer_block.status = 'InDBS'
         migratedBlocks = self.getMigrated.execute()
-        ### FIXME the data format returned by this DAO
+        # FIXME the data format returned by this DAO
         for location in migratedBlocks:
             for container in migratedBlocks[location]:
                 for block in migratedBlocks[location][container]:
@@ -383,7 +383,7 @@ class RucioInjectorPoller(BaseWorkerThread):
         blockDict = {}
         for block in completedBlocksList:
             if block['workflowName'] in deletableWfsDict and \
-             now - block['blockCreateTime'] > self.blockDeletionDelaySeconds:
+               now - block['blockCreateTime'] > self.blockDeletionDelaySeconds:
                 blockDict[block['blockName']] = block
 
         logging.info("Found %d final candidate blocks for rule deletion", len(blockDict))
@@ -452,7 +452,6 @@ class RucioInjectorPoller(BaseWorkerThread):
                     if deletedRules == len(rules):
                         binds.append({'DELETED': 1, 'BLOCKNAME': block})
                         logging.info("Successfully deleted all rules for block %s.", block)
-
 
             self.markBlocksDeleted.execute(binds)
             logging.info("Marked %d blocks as deleted in the database", len(binds))
@@ -523,7 +522,7 @@ class RucioInjectorPoller(BaseWorkerThread):
                     ruleKwargs['lifetime'] = lifetime
                 if self.testRSEs:
                     rseName = "%s_Test" % rseName
-                #Checking whether we need to ask for rule approval
+                # Checking whether we need to ask for rule approval
                 try:
                     if self.rucio.requiresApproval(rseName):
                         ruleKwargs['ask_approval'] = True


### PR DESCRIPTION
Fixes #11042 

#### Status
ready 

#### Description
With the current PR we split the deletableBlocks checks from RucioInjector in two steps - first we fetch all the block in closed state as usual, but we do not require the whole workflow information to be cleaned from WMBS. In the following step we fetch another list of workflows which are suitable for deletion, but will eventually fall under the conditions ruled by the `archiveDelayHours` configuration parameter. Upon that we check for which of the so found blocks actually have been produced by an already 'deletable' workflow. Once the intersection between those two lists is made the final set of blocks to be deleted is provided to the rest of the code as before. 

During the above check we also apply  another requirement for the block. Before we add it for deletion we check if its lifetime is bigger than a certain configurable value. We set that from the agent configuration with:
`config.RucioInjector.blockDeletionDelayHours` and the clock for measuring the block lifetime is started with the `blockCreateTime`. It would have been better to have this started with the workflow completion instead, but there is no cheap way of fetching that information from `RucioInjector` or from the agent as a whole actually.     


#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

We do have a new configuration variable  introduced with the PR:
`config.RucioInjector.blockDeletionDelayHours`
But this one is to be provided from the agent configuration, so no service_config PR has been created for it.

#### External dependencies / deployment changes
None