### PR TITLE
Update workqueue stats as new blocks are added to the workflow

### DIFF
--- a/src/python/WMCore/ReqMgr/Tools/cms.py
+++ b/src/python/WMCore/ReqMgr/Tools/cms.py
@@ -117,7 +117,7 @@ def web_ui_names():
     "Return dict of web UI JSON naming conventions"
     maps = {
         "TimePerEvent": "TimePerEvent (seconds)",
-        "OpenRunningTimeout": "OpenRunningTimeout (deprecated)",
+        "OpenRunningTimeout": "OpenRunningTimeout (seconds)",
         "SizePerEvent": "SizePerEvent (KBytes)",
         "Memory": "Memory (MBytes)",
         "BlockCloseMaxSize": "BlockCloseMaxSize (Bytes)",

--- a/src/python/WMCore/Services/ReqMgr/ReqMgr.py
+++ b/src/python/WMCore/Services/ReqMgr/ReqMgr.py
@@ -202,7 +202,7 @@ class ReqMgr(Service):
                                'input_events': 100, 'input_num_files': 100}
         specific to ReqMgr app. not implemented for T0
         """
-        # TODO: add stats validation here
+        # this stats dict will be validated on the server side
         self.updateRequestProperty(request, stats)
 
     def updateRequestProperty(self, request, propDict):

--- a/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
@@ -101,7 +101,8 @@ class StepChainWorkloadFactory(StdBase):
         else:
             self.workload.setDashboardActivity("processing")
             self.workload.setWorkQueueSplitPolicy("Block", taskConf['SplittingAlgo'],
-                                                  taskConf['SplittingArguments'])
+                                                  taskConf['SplittingArguments'],
+                                                  OpenRunningTimeout=self.openRunningTimeout)
             self.setupTask(firstTask, taskConf)
 
         # Now modify this task to add the next steps

--- a/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
@@ -277,7 +277,8 @@ class TaskChainWorkloadFactory(StdBase):
                     # process an existing dataset
                     self.workload.setWorkQueueSplitPolicy("Block", taskConf['SplittingAlgo'],
                                                           taskConf['SplittingArguments'],
-                                                          blowupFactor=blowupFactor)
+                                                          blowupFactor=blowupFactor,
+                                                          OpenRunningTimeout=self.openRunningTimeout)
                     self.setupTask(task, taskConf)
             else:
                 # all subsequent tasks have to be processing tasks

--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -681,9 +681,8 @@ class WorkQueue(WorkQueueBase):
             # if global queue, then update workflow stats to request mgr couch doc
             # remove the "UnittestFlag" - need to create the reqmgrSvc emulator
             if not self.params.get("UnittestFlag", False):
-                # get statistics for the new work
+                # get statistics for the new work. It's already validated on the server side
                 totalStats = self._getTotalStats(newWork)
-                # FIXME TODO: stats need to be updated, not written only once!
                 self.reqmgrSvc.updateRequestStats(inboundElem['WMSpec'].name(), totalStats)
 
             if badWork:
@@ -882,7 +881,8 @@ class WorkQueue(WorkQueueBase):
         currentTime = time.time()
         for element in workflowsToCheck:
             # fetch attributes from the inbox workqueue element
-            openRunningTimeout = element.get('OpenRunningTimeout', 0)
+            startPol = element.get('StartPolicy', {})
+            openRunningTimeout = startPol.get('OpenRunningTimeout', 0)
             foundNewDataTime = element.get('TimestampFoundNewData', 0)
             if not openRunningTimeout:
                 self.logger.info("Workflow %s has no OpenRunningTimeout. Queuing to be closed.",

--- a/test/data/ReqMgr/requests/Integration/ReReco_LumiMask.json
+++ b/test/data/ReqMgr/requests/Integration/ReReco_LumiMask.json
@@ -22,8 +22,9 @@
         "CMSSWVersion": "CMSSW_10_6_12", 
         "Campaign": "Campaign-OVERRIDE-ME", 
         "Comments": {
-            "CheckList": "ReReco with LumiList", 
-            "WorkFlowDesc": "ReReco NanoAOD with LumiList, 3 runs and 46 lumis, bringing in 2 blocks; 2cores and 2GB; do not write logs to EOS"
+            "CheckList": "ReReco with LumiList; ReReco with growing dataset",
+            "WorkFlowDesc": ["ReReco NanoAOD with LumiList, 3 runs and 46 lumis, bringing in 2 blocks; 2cores and 2GB;",
+                            "do not write logs to EOS; keep WorkQueue inbox open for 2h"]
         }, 
         "ConfigCacheID": "6d0b906879c210bde4baecd2e78ded41", 
         "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb", 
@@ -34,6 +35,7 @@
         "LumiList": {"320836": [[1, 10], [16, 20]], "322605": [[264, 275]], "324841": [[560, 565], [855, 860], [920, 926]]},
         "Memory": 2000, 
         "Multicore": 2, 
+        "OpenRunningTimeout": 7200,
         "PrepID": "TEST-ReReco-Run2018D-NoBPTX-Nano02Dec2019-00001", 
         "ProcessingString": "Nano02Dec2019_12Nov2019_UL2018", 
         "ProcessingVersion": 2, 

--- a/test/data/ReqMgr/requests/Integration/SC_ReDigi_Harvest_Prod.json
+++ b/test/data/ReqMgr/requests/Integration/SC_ReDigi_Harvest_Prod.json
@@ -31,8 +31,8 @@
         "Campaign": "Campaign-OVERRIDE-ME", 
         "Comments": {
             "WorkFlowDesc": ["3 Steps with input data and same PU in Step1 and Step2; ~221EpJ / 2LpJ; Harvesting enabled; ",
-                             "Drop output of Step1 - GEN-SIM-DIGI-RAW; Assigned with diff AcqEra/ProcStr;"],
-	    "CheckList": ["SC ReDigi; SC with different AcqEra/ProcStr/ProcVer; SC harvesting"]
+                             "Drop output of Step1 - GEN-SIM-DIGI-RAW; Assigned with diff AcqEra/ProcStr; StepChain with growing dataset"],
+	        "CheckList": ["SC ReDigi; SC with different AcqEra/ProcStr/ProcVer; SC harvesting; keep WorkQueue inbox open for 2h"]
         },
         "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb", 
         "CouchDBName": "reqmgr_config_cache", 
@@ -44,7 +44,8 @@
         "GlobalTag": "112X_mcRun3_2024_realistic_v10", 
         "IncludeParents": false, 
         "Memory": 12000, 
-        "Multicore": 4, 
+        "Multicore": 4,
+        "OpenRunningTimeout": 7200,
         "PrepID": "TEST-CMSSW_11_2_0_pre8__PDMVRELVALS-100-TTbar_14TeV-00002", 
         "ProcessingString": "DEFAULT_ProcStr", 
         "ProcessingVersion": 1, 

--- a/test/data/ReqMgr/requests/Integration/TC_PY3_Data_LumiList.json
+++ b/test/data/ReqMgr/requests/Integration/TC_PY3_Data_LumiList.json
@@ -28,9 +28,9 @@
         "CMSSWVersion": "CMSSW_11_3_0_pre2_PY3", 
         "Campaign": "Campaign-OVERRIDE-ME", 
         "Comments": {
-            "CheckList": "TaskChain python3 workflow; TaskChain data with 2 tasks; TaskChain with LumiList",
+            "CheckList": "TaskChain python3 workflow; TaskChain data with 2 tasks; TaskChain with LumiList; TC with growing dataset",
             "WorkFlowDesc": ["TaskChain python3 workflow, with real data and 2 tasks, LumiList with 1 run and 50 lumis;",
-                             "Task1 with 2LpJ, task2 with 1LpJ; 8 CPU, diff RAM"]
+                             "Task1 with 2LpJ, task2 with 1LpJ; 8 CPU, diff RAM; keep WorkQueue inbox open for 2h"]
         }, 
         "ConfigCacheUrl": "https://cmsweb-testbed.cern.ch/couchdb", 
         "CouchDBName": "reqmgr_config_cache", 
@@ -42,7 +42,8 @@
         "GlobalTag": "103X_dataRun2_HLT_relval_v10", 
         "IncludeParents": false, 
         "Memory": 3000, 
-        "Multicore": 1, 
+        "Multicore": 1,
+        "OpenRunningTimeout": 7200,
         "PrepID": "TEST-CMSSW_11_3_0_pre2_PY3__Data_PY3_TESTbyCA-RunDoubleMuon2018D-00001", 
         "ProcessingString": "DEFAULT_ProcStr", 
         "ProcessingVersion": 1, 


### PR DESCRIPTION
Fixes #11129 

#### Status
testing

#### Description
Short description of the changes provided within this PR:
* growing global workqueue stats didn't need any modifications, it's supposed to do incremental stats already
* added support to `OpenRunningTimeout` for StepChain and TaskChain workflow specs
* fixed a mistake from the previous PR, properly retrieving the OpenRunningTimeout from the `StartPolicy` dictionary
* updated a few test workflow json templates to remain open for 2h (even though their input dataset is no growing).

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None