### PR TITLE
Apply different rule lifetime for RelVal pre-release samples

### DIFF
--- a/src/python/WMCore/MicroService/MSOutput/RelValPolicy.py
+++ b/src/python/WMCore/MicroService/MSOutput/RelValPolicy.py
@@ -8,6 +8,7 @@ from __future__ import print_function, division
 
 from copy import deepcopy
 import json
+import re
 from WMCore.MicroService.Tools.Common import getMSLogger
 from WMCore.WMException import WMException
 
@@ -23,7 +24,9 @@ class RelValPolicyException(WMException):
 class RelValPolicy():
     """
     This module will contain the RelVal output data placement policy, where
-    destinations will be decided according to the dataset datatier.
+    destinations will be decided according to the dataset datatier and the
+    container lifetime will be decided based on the sample type (pre-release
+    or not).
 
     It's supposed to hold a policy driven by dataset datatier, and it's
     data structure looks like:
@@ -31,36 +34,50 @@ class RelValPolicy():
      {"datatier": "tier_2", "destinations": ["rse_name_2"]},
      {"datatier": "default", "destinations": ["rse_name_3"]}]
 
+    The lifetime policy data structure is something like:
+    [{"releaseType": "pre", "lifetimeSecs": 120},
+     {"releaseType": "default", "lifetimeSecs": 360}]
+
     the 'default' key matches the case where a datatier is not specified
     in the policy.
     """
 
-    def __init__(self, policyDesc, listDatatiers, listRSEs, logger=None):
+    def __init__(self, tierPolicy, lifetimeDesc, listDatatiers, listRSEs, logger=None):
         """
         Given a policy data structure - as a list of dictionaries - it
         will validate the policy, the datatiers and RSEs defined in it,
         and it will convert the policy into a flat dictionary for easier
         data lookup.
-        :param policyDesc: list of dictionary items with the output rules
+        :param tierPolicy: list of dictionary items with the output rules
+        :param lifetimeDesc: list of dictionary items with the output
+            lifetime rules
         :param listDatatiers: flat list of existent datatiers in DBS
         :param listRSEs: flat list of existent Disk RSEs in Rucio
         :param logger: logger object, if any
         """
-        self.origPolicy = deepcopy(policyDesc)
+        self.origTierPolicy = deepcopy(tierPolicy)
+        self.origLifetimePolicy = deepcopy(lifetimeDesc)
 
         self.logger = getMSLogger(verbose=False, logger=logger)
 
-        self._validatePolicy(policyDesc, listDatatiers, listRSEs)
-        self.dictPolicy = self._convertPolicy(policyDesc)
+        self._validateTierPolicy(tierPolicy, listDatatiers, listRSEs)
+        self.tierPolicy = self._convertTierPolicy(tierPolicy)
+
+        self._validateLifetimePolicy(lifetimeDesc)
+        self.lifeTPolicy = self._convertLifePolicy(lifetimeDesc)
+
+        # regex to match against CMSSW pre-releases only, e.g.: CMSSW_1_2_3_pre12
+        self.preRegex = re.compile(r'CMSSW(_\d+){3}_pre(\d+)$')
 
     def __str__(self):
         """
         Stringify this object, printing the original policy
         """
-        objectOut = dict(originalPolicy=self.origPolicy, mappedPolicy=self.dictPolicy)
+        objectOut = dict(originalTierPolicy=self.origTierPolicy, mappedTierPolicy=self.tierPolicy,
+                         originalLifetimePolicy=self.origLifetimePolicy, mappedLifetimePolicy=self.lifeTPolicy)
         return json.dumps(objectOut)
 
-    def _validatePolicy(self, policyDesc, validDBSTiers, validDiskRSEs):
+    def _validateTierPolicy(self, policyDesc, validDBSTiers, validDiskRSEs):
         """
         This method validates the overall policy data structure, including:
          * internal and external data types
@@ -102,15 +119,66 @@ class RelValPolicy():
             msg = "A 'default' key must be defined with default destinations."
             raise RelValPolicyException(msg) from None
 
-    def _convertPolicy(self, policyDesc):
+    def _validateLifetimePolicy(self, lifeTDesc):
         """
-        Maps the RelVal data policy to a flat dictionary key'ed by datatiers
-        :param policyDesc: list of dictionaries with the policy definition
-        :return: a dictionary with a map of the RelVal policy
+        This method validates the lifetime RelVal policy data structure.
+
+        [{"releaseType": "pre", "lifetimeSecs": 120},
+         {"releaseType": "default", "lifetimeSecs": 360}]
+        :param lifeTDesc: list of dictionaries with the lifetime policy definition
+        :return: nothing, but it will raise an exception if any validation fails
+        """
+        if not isinstance(lifeTDesc, list):
+            msg = "The RelVal lifetime output data placement policy is not in the expected data type. "
+            msg += "Type expected: list, while the current data type is: {}. ".format(type(lifeTDesc))
+            msg += "This critical ERROR must be fixed."
+            raise RelValPolicyException(msg) from None
+
+        # policy must have a default/fallback destination for non pre-releases
+        setRelTypes = set()
+        expRelTypesKeys = {"pre", "default"}
+        for item in lifeTDesc:
+            if not isinstance(item.get('releaseType', None), str):
+                msg = "The 'releaseType' parameter must be a string, not {}.".format(type(item['releaseType']))
+                raise RelValPolicyException(msg) from None
+            if item['releaseType'] not in expRelTypesKeys:
+                msg = "The 'releaseType' parameter does not match the expected values. "
+                msg += "Value provided '{}' not in {}.".format(item['releaseType'], expRelTypesKeys)
+                raise RelValPolicyException(msg) from None
+            if not isinstance(item['lifetimeSecs'], int):
+                msg = "The 'lifetimeSecs' parameter must be integer, not {}".format(type(item['lifetimeSecs']))
+                raise RelValPolicyException(msg) from None
+            if item['lifetimeSecs'] <= 0:
+                msg = "The 'lifetimeSecs' parameter cannot be 0 or negative"
+                raise RelValPolicyException(msg) from None
+            setRelTypes.add(item['releaseType'])
+
+        # last check, it must contain a policy for "pre" releases and "default"
+        if setRelTypes != expRelTypesKeys:
+            msg = "Policy must define rules for these 2 sample types: {}".format(expRelTypesKeys)
+            raise RelValPolicyException(msg) from None
+
+    def _convertTierPolicy(self, policyDesc):
+        """
+        Maps the RelVal tier data policy to a flat dictionary key'ed by datatiers
+        :param policyDesc: list of dictionaries with the tier policy definition
+        :return: a dictionary with a map of the RelVal tier policy
         """
         outputPolicy = dict()
         for item in policyDesc:
             outputPolicy.update({item['datatier']: item['destinations']})
+        return outputPolicy
+
+    def _convertLifePolicy(self, policyDesc):
+        """
+        Maps the RelVal lifetime data policy to a flat dictionary key'ed
+        by the release cycle type (only supports pre or anything else).
+        :param policyDesc: list of dictionaries with the lifetime policy definition
+        :return: a dictionary with a map of the RelVal lifetime policy
+        """
+        outputPolicy = dict()
+        for item in policyDesc:
+            outputPolicy.update({item['releaseType']: item['lifetimeSecs']})
         return outputPolicy
 
     def getDestinationByDataset(self, dsetName):
@@ -120,4 +188,29 @@ class RelValPolicy():
         :return: a list of locations
         """
         _, dsn, procString, dataTier = dsetName.split('/')
-        return self.dictPolicy.get(dataTier, self.dictPolicy['default'])
+        return self.tierPolicy.get(dataTier, self.tierPolicy['default'])
+
+    def _isPreRelease(self, dsetName):
+        """
+        Helper function to determine whether the provided dataset name
+        belongs to a pre-release or not.
+        :param dsetName: string with the dataset name
+        :return: boolean whether it's a pre-release sample or not.
+        """
+        try:
+            procString = dsetName.split('/')[2]
+            acqEra = procString.split('-')[0]
+        except Exception:
+            raise RuntimeError("RelVal dataset name invalid: {}".format(dsetName)) from None
+        return bool(self.preRegex.match(acqEra))
+
+    def getLifetimeByDataset(self, dsetName):
+        """
+        Provided a dataset name, return the rule lifetime defined for
+        this sample/release type.
+        :param dsetName: a string with the full dataset name
+        :return: an integer with the lifetime in seconds
+        """
+        if self._isPreRelease(dsetName):
+            return self.lifeTPolicy["pre"]
+        return self.lifeTPolicy["default"]

--- a/test/python/WMCore_t/MicroService_t/MSOutput_t/RelValPolicy_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSOutput_t/RelValPolicy_t.py
@@ -3,8 +3,9 @@ Unit tests for the WMCore/MicroService/MSOutput/RelValPolicy.py module
 """
 from __future__ import division, print_function
 
-import unittest
 import json
+import unittest
+
 from WMCore.MicroService.MSOutput.RelValPolicy import RelValPolicy, RelValPolicyException
 
 
@@ -19,45 +20,87 @@ class RelValPolicyTests(unittest.TestCase):
         """Basic tear down operation when leaving each unit test"""
         pass
 
-    def testBrokenPolicy(self):
-        """Tests for the RelValPolicy class with a broken policy"""
+    def testBrokenTierPolicy(self):
+        """Tests for the RelValPolicy class with a broken tier-based policy"""
         validDatatiers = ["GEN-SIM", "GEN", "SIM", "AOD"]
         validRSEs = ["rse_1", "rse_2", "rse_3"]
+        timePol = [{"releaseType": "pre", "lifetimeSecs": 1},
+                   {"releaseType": "default", "lifetimeSecs": 2}]
 
         # test output policies with a wrong data type
         for testPolicy in [None, {}, "blah", 123]:
             with self.assertRaises(RelValPolicyException):
-                RelValPolicy(testPolicy, validDatatiers, validRSEs)
+                RelValPolicy(testPolicy, timePol, validDatatiers, validRSEs)
 
         # test internal structure with wrong data type for datatier
         testPolicy = [{"datatier": ["tier1", "tier2"], "destinations": ["rse_1", "rse_2"]},
                       {"datatier": "default", "destinations": ["rse_1"]}]
         with self.assertRaises(RelValPolicyException):
-            RelValPolicy(testPolicy, validDatatiers, validRSEs)
+            RelValPolicy(testPolicy, timePol, validDatatiers, validRSEs)
 
         # test internal structure with wrong data type for destinations
         testPolicy = [{"datatier": "tier1", "destinations": "rse_1"},
                       {"datatier": "default", "destinations": ["rse_1"]}]
         with self.assertRaises(RelValPolicyException):
-            RelValPolicy(testPolicy, validDatatiers, validRSEs)
+            RelValPolicy(testPolicy, timePol, validDatatiers, validRSEs)
 
         # test internal structure missing the required "default" key/value pair
         testPolicy = [{"datatier": "GEN", "destinations": ["rse_1", "rse_2"]}]
         with self.assertRaises(RelValPolicyException):
-            RelValPolicy(testPolicy, validDatatiers, validRSEs)
+            RelValPolicy(testPolicy, timePol, validDatatiers, validRSEs)
+
+    def testBrokenLifePolicy(self):
+        """Tests for the RelValPolicy class with a broken lifetime-based policy"""
+        validDatatiers = ["GEN-SIM", "GEN", "SIM", "AOD"]
+        validRSEs = ["rse_1", "rse_2", "rse_3"]
+        tierPolicy = [{"datatier": "GEN", "destinations": ["rse_1"]},
+                      {"datatier": "default", "destinations": ["rse_2"]}]
+
+        # test output lifetime policy with a wrong data type
+        for testPolicy in [None, {}, "blah", 123]:
+            with self.assertRaises(RelValPolicyException):
+                RelValPolicy(tierPolicy, testPolicy, validDatatiers, validRSEs)
+
+        # test internal structure with wrong data type for releaseType
+        pol1 = [{"releaseType": 123, "lifetimeSecs": 1}]
+        pol2 = [{"releaseType": None, "lifetimeSecs": 1}]
+        pol3 = [{"releaseType": ["pre"], "lifetimeSecs": 1}, {"releaseType": "final", "lifetimeSecs": 2}]
+        for lifePol in (pol1, pol2, pol3):
+            with self.assertRaises(RelValPolicyException):
+                RelValPolicy(tierPolicy, lifePol, validDatatiers, validRSEs)
+
+        # test internal structure with wrong data type for lifetimeSecs
+        pol1 = [{"releaseType": "pre", "lifetimeSecs": 1.5}]
+        pol2 = [{"releaseType": "default", "lifetimeSecs": "1"}]
+        pol3 = [{"releaseType": "pre", "lifetimeSecs": None}, {"releaseType": "final", "lifetimeSecs": 2}]
+        pol4 = [{"releaseType": "pre", "lifetimeSecs": 0}, {"releaseType": "final", "lifetimeSecs": -10}]
+        for lifePol in (pol1, pol2, pol3, pol4):
+            with self.assertRaises(RelValPolicyException):
+                RelValPolicy(tierPolicy, lifePol, validDatatiers, validRSEs)
+
+        # test missing release type
+        pol1 = [{"releaseType": "pre", "lifetimeSecs": 1}]
+        pol2 = [{"releaseType": "default", "lifetimeSecs": 1}]
+        pol3 = [{"releaseType": "pre", "lifetimeSecs": 1}, {"releaseType": "final", "lifetimeSecs": 2}]
+        for lifePol in (pol1, pol2, pol3):
+            with self.assertRaises(RelValPolicyException):
+                RelValPolicy(tierPolicy, lifePol, validDatatiers, validRSEs)
 
     def testValidPolicy(self):
         """Tests for the RelValPolicy class with a valid policy"""
         validDatatiers = ["GEN-SIM", "GEN", "SIM", "AOD"]
         validRSEs = ["rse_1", "rse_2", "rse_3"]
 
-        testPolicy = [{"datatier": "SIM", "destinations": ["rse_1", "rse_2"]},
+        tierPolicy = [{"datatier": "SIM", "destinations": ["rse_1", "rse_2"]},
                       {"datatier": "GEN-SIM", "destinations": ["rse_1"]},
                       {"datatier": "default", "destinations": ["rse_2"]}]
-        policyObj = RelValPolicy(testPolicy, validDatatiers, validRSEs)
+        lifePolicy = [{"releaseType": "pre", "lifetimeSecs": 1},
+                      {"releaseType": "default", "lifetimeSecs": 2}]
+
+        policyObj = RelValPolicy(tierPolicy, lifePolicy, validDatatiers, validRSEs)
 
         # now test the method to get destinations for a given dataset (datatier)
-        for policyItem in testPolicy:
+        for policyItem in tierPolicy:
             resp = policyObj.getDestinationByDataset("/PD/ProcStr-v1/{}".format(policyItem['datatier']))
             self.assertEqual(resp, policyItem['destinations'])
 
@@ -65,18 +108,52 @@ class RelValPolicyTests(unittest.TestCase):
         resp = policyObj.getDestinationByDataset("/PD/ProcStr-v1/BLAH")
         self.assertEqual(resp, ["rse_2"])
 
+        # now test the release type lifetime policy using the default value
+        for dsetName in {"/PD/CMSSW_1_2_3_patch1-ProcStr-v1/TIER",
+                         "/PD/CMSSW_1_2_3_HLT1-ProcStr-v1/TIER",
+                         "/PD/CMSSW_1_2_3-ProcStr-v1/TIER"}:
+            self.assertEqual(policyObj.getLifetimeByDataset(dsetName), 2)
+        # and a pre-release
+        self.assertEqual(policyObj.getLifetimeByDataset("/PD/CMSSW_1_2_3_pre4-ProcStr-v1/TIER"), 1)
+
     def testStringification(self):
         """Test the stringification of the RelValPolicy object"""
         validDatatiers = []
         validRSEs = ["rse_2"]
         testPolicy = [{"datatier": "default", "destinations": ["rse_2"]}]
+        lifePolicy = [{"releaseType": "pre", "lifetimeSecs": 3},
+                      {"releaseType": "default", "lifetimeSecs": 12}]
 
-        policyObj = str(RelValPolicy(testPolicy, validDatatiers, validRSEs))
+        policyObj = str(RelValPolicy(testPolicy, lifePolicy, validDatatiers, validRSEs))
 
         self.assertTrue(isinstance(policyObj, str))
         policyObj = json.loads(policyObj)
-        self.assertCountEqual(policyObj["originalPolicy"], testPolicy)
-        self.assertCountEqual(policyObj["mappedPolicy"], {"default": ["rse_2"]})
+        self.assertCountEqual(policyObj["originalTierPolicy"], testPolicy)
+        self.assertCountEqual(policyObj["mappedTierPolicy"], {"default": ["rse_2"]})
+
+        self.assertCountEqual(policyObj["originalLifetimePolicy"], lifePolicy)
+        self.assertCountEqual(policyObj["mappedLifetimePolicy"], {"pre": 3, "default": 12})
+
+    def testIsPreRelease(self):
+        """Test the _isPreRelease method"""
+        tierPolicy = [{"datatier": "SIM", "destinations": ["rse_1"]},
+                      {"datatier": "default", "destinations": ["rse_1"]}]
+        lifePolicy = [{"releaseType": "pre", "lifetimeSecs": 3},
+                      {"releaseType": "default", "lifetimeSecs": 12}]
+
+        policyObj = RelValPolicy(tierPolicy, lifePolicy, ["SIM"], ["rse_1"])
+
+        # first test a broken dataset name
+        for dsetName in ("", None), 123:
+            with self.assertRaises(RuntimeError):
+                policyObj._isPreRelease(dsetName)
+
+        for dsetName in {"/PD/CMSSW_1_2_3_patch1-ProcStr-v1/TIER",
+                         "/PD/CMSSW_1_2_3_HLT1-ProcStr-v1/TIER",
+                         "/PD/CMSSW_1_2_3-ProcStr-v1/TIER",
+                         "/PD/AcqEra-ProcStr-v1/TIER"}:
+            self.assertFalse(policyObj._isPreRelease(dsetName))
+        self.assertTrue(policyObj._isPreRelease("/PD/CMSSW_1_2_3_pre4-ProcStr-v1/TIER"))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #11124 

#### Status
not-tested

#### Description
This PR starts using the service configuration `ruleLifetimeRelVal` attribute as an output lifetime structure policy, instead of having a single integer matching all the RelVal output samples.

Based on the RelVal output dataset name, identifies whether it belongs to a pre-release of CMSSW and apply a different rule lifetime value for the rules created by MSOutput. Note that, if the output dataset acquisition era does not match a pre-release, it defaults to a default value defined in the lifetime policy.

#### Is it backward compatible (if not, which system it affects?)
NO, in the sense that it adds a new feature

#### Related PRs
None

#### External dependencies / deployment changes
Gitlab service configuration:
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/143
and
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/144
