### PR TITLE
[MSTransferor] Lock the whole input container for growing workflows

### DIFF
--- a/src/python/WMCore/MicroService/MSTransferor/Workflow.py
+++ b/src/python/WMCore/MicroService/MSTransferor/Workflow.py
@@ -477,3 +477,10 @@ class Workflow(object):
         if self.isRelVal():
             return "relval"
         return "production"
+
+    def getOpenRunningTimeout(self):
+        """
+        Retrieve the OpenRunningTimeout parameter for this workflow
+        :return: an integer with the amount of secs
+        """
+        return self.data.get("OpenRunningTimeout", 0)


### PR DESCRIPTION
Fixes #11130 

#### Status
ready

#### Description
With this PR, we have:
* a new microservice configuration called `openRunning`, used to define when to consider a workflow with growing input dataset or not (default value has been set to 7 days)
* when an open running workflow is found, make a Rucio rule for the whole input container with grouping DATASET, with a single copy, at a logical OR of all the RSEs matching the workflow+campaign+quota

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
Configuration changes in:
Prod: https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/145
Preprod: https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/146
