### PR TITLE
Implement support for gzipped stream for RucioConMon

### DIFF
--- a/test/python/WMCore_t/Services_t/Rucio_t/RucioConMon_t.py
+++ b/test/python/WMCore_t/Services_t/Rucio_t/RucioConMon_t.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+"""
+_RucioConMon_t_
+
+Unit tests for RucioConMon WMCore Service class
+"""
+
+import unittest
+
+from nose.plugins.attrib import attr
+
+from WMCore.Services.RucioConMon.RucioConMon import RucioConMon
+
+
+class RucioConMonTest(unittest.TestCase):
+    """
+    Unit tests for RucioConMon Service module
+    """
+
+    @attr("integration")
+    def testGetRSEUnmerged(self):
+        """
+        Test getRSEUnmerged method using both zipped and unzipped requests
+        This test uses specific rse name which can be changed to any other RSE.
+        """
+#         url = "https://cmsweb.cern.ch/rucioconmon/WM/files?rse=T2_TR_METU&format=raw"
+        mgr = RucioConMon("https://cmsweb.cern.ch/rucioconmon")
+        rseName = "T2_TR_METU"
+        dataUnzipped = mgr.getRSEUnmerged(rseName, zipped=False)
+        dataZipped = mgr.getRSEUnmerged(rseName, zipped=True)
+        self.assertTrue(dataUnzipped == dataZipped)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #11036 

#### Status
ready

#### Description
Implement support for zipped I/O while calling RucioConMon service. The changes required to introduce binary read/write mode operation on cache and properly read and write files in binary mode.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
It is similar in nature to #11041 (since it relies on `gzip` library) but it adjust WMCore service to properly handle binary content in its cache.

#### External dependencies / deployment changes
None