### PR TITLE
[MSTransferor] Create rule for each pileup location

### DIFF
--- a/src/python/WMCore/MicroService/MSTransferor/DataStructs/DQMHarvestWorkflow.py
+++ b/src/python/WMCore/MicroService/MSTransferor/DataStructs/DQMHarvestWorkflow.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Workflow object representing how DQMHarvest workflows have to be dealt
+with in the input data placement (MSTransferor)
+"""
+
+from WMCore.MicroService.MSTransferor.DataStructs.Workflow import Workflow
+from WMCore.Services.Rucio.Rucio import GROUPING_ALL
+
+
+class DQMHarvestWorkflow(Workflow):
+    """
+    Class to represent a DQMHarvest workflow in the context
+    of input data placement in MSTransferor
+    """
+
+    def getInputData(self):
+        """
+        Returns all the primary data that has to be locked and
+        transferred with Rucio.
+
+        :return: a list of unique block names and an integer
+                 with their total size
+        """
+        blockList = list(self.getPrimaryBlocks())
+        totalBlockSize = sum([blockInfo['blockSize'] for blockInfo in self.getPrimaryBlocks().values()])
+        return blockList, totalBlockSize
+
+    def getRucioGrouping(self):
+        """
+        Returns the rucio rule grouping for DQMHarvest workflows,
+        which must hold all the input data under the same RSE in
+        order to harvest full stats.
+
+        :return: a string with the required DID grouping
+        """
+        return GROUPING_ALL

--- a/src/python/WMCore/MicroService/MSTransferor/DataStructs/GrowingWorkflow.py
+++ b/src/python/WMCore/MicroService/MSTransferor/DataStructs/GrowingWorkflow.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Workflow object representing how growing workflows have to be dealt
+with in the input data placement (MSTransferor)
+"""
+
+from WMCore.MicroService.MSTransferor.DataStructs.Workflow import Workflow
+from WMCore.Services.Rucio.Rucio import GROUPING_DSET
+
+
+class GrowingWorkflow(Workflow):
+    """
+    Class to represent a Growing workflow in the context
+    of input data placement in MSTransferor
+    """
+
+    def getInputData(self):
+        """
+        Returns the primary dataset name to be locked and
+        transferred with Rucio, instead of a list of blocks.
+
+        :return: a list of unique block names and an integer
+                 with their total size
+        """
+        inputContainer = [self.getInputDataset()]
+        totalBlockSize = sum([blockInfo['blockSize'] for blockInfo in self.getPrimaryBlocks().values()])
+
+        # the whole container must be locked
+        return inputContainer, totalBlockSize
+
+    def getRucioGrouping(self):
+        """
+        Returns the rucio rule grouping for growing workflows.
+        Input blocks can be scattered all over the provided
+        RSE expression.
+
+        :return: a string with the required DID grouping
+        """
+        return GROUPING_DSET

--- a/src/python/WMCore/MicroService/MSTransferor/DataStructs/RSEQuotas.py
+++ b/src/python/WMCore/MicroService/MSTransferor/DataStructs/RSEQuotas.py
@@ -111,7 +111,7 @@ class RSEQuotas(object):
                           "bytes": amount of bytes currently used/archived,
                           "bytes_remaining": space remaining for the acct/group}
         """
-        self.logger.debug("Using Rucio for storage usage, with acct: %s", self.dataAcct)
+        self.logger.info("Using Rucio for storage usage, with acct: %s", self.dataAcct)
         for item in dataSvcObj.getAccountUsage(self.dataAcct):
             if item['rse'] not in self.nodeUsage:
                 self.logger.warning("Rucio RSE: %s has data usage but no quota available.", item['rse'])
@@ -149,11 +149,11 @@ class RSEQuotas(object):
         for node in sorted(self.nodeUsage.keys()):
             msg = "  %s:\t\tbytes_limit: %.2f, bytes_used: %.2f, bytes_remaining: %.2f, "
             msg += "quota: %.2f, quota_avail: %.2f"
-            self.logger.debug(msg, node, teraBytes(self.nodeUsage[node]['bytes_limit']),
-                              teraBytes(self.nodeUsage[node]['bytes']),
-                              teraBytes(self.nodeUsage[node]['bytes_remaining']),
-                              teraBytes(self.nodeUsage[node]['quota']),
-                              teraBytes(self.nodeUsage[node]['quota_avail']))
+            self.logger.info(msg, node, teraBytes(self.nodeUsage[node]['bytes_limit']),
+                             teraBytes(self.nodeUsage[node]['bytes']),
+                             teraBytes(self.nodeUsage[node]['bytes_remaining']),
+                             teraBytes(self.nodeUsage[node]['quota']),
+                             teraBytes(self.nodeUsage[node]['quota_avail']))
         self.logger.info("List of RSE's out of quota: %s", self.outOfSpaceNodes)
 
     def updateNodeUsage(self, node, dataSize):

--- a/src/python/WMCore/MicroService/MSTransferor/DataStructs/RelValWorkflow.py
+++ b/src/python/WMCore/MicroService/MSTransferor/DataStructs/RelValWorkflow.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Workflow object representing how Release Validation workflows
+have to be dealt with in the input data placement (MSTransferor)
+"""
+
+from WMCore.MicroService.MSTransferor.DataStructs.Workflow import Workflow
+from WMCore.Services.Rucio.Rucio import GROUPING_ALL
+
+
+class RelValWorkflow(Workflow):
+    """
+    Class to represent a RelVal workflow in the context
+    of input data placement in MSTransferor
+    """
+
+    def getRucioGrouping(self):
+        """
+        Returns the rucio rule grouping for RelVal workflows,
+        which must hold all the input data under the same RSE in
+        order to harvest full stats.
+
+        :return: a string with the required DID grouping
+        """
+        return GROUPING_ALL

--- a/src/python/WMCore/MicroService/MSTransferor/DataStructs/Workflow.py
+++ b/src/python/WMCore/MicroService/MSTransferor/DataStructs/Workflow.py
@@ -9,7 +9,8 @@ from future.utils import viewitems, viewvalues, listvalues
 
 from copy import copy, deepcopy
 from WMCore.DataStructs.LumiList import LumiList
-from WMCore.MicroService.Tools.Common import getMSLogger, gigaBytes
+from WMCore.MicroService.Tools.Common import getMSLogger
+from WMCore.Services.Rucio.Rucio import GROUPING_DSET
 
 
 class Workflow(object):
@@ -337,101 +338,6 @@ class Workflow(object):
         """
         return self.childToParentBlocks
 
-    # TODO: all this chunk logic is no longer needed for Rucio
-    # Maybe, in the future, we might need to do data management
-    # for primary + parent cases, I hope not!
-    def getChunkBlocks(self, numChunks=1):
-        """
-        Break down the input and parent blocks by a given number
-        of chunks (usually the amount of sites available for data
-        placement).
-        :param numChunks: integer representing the number of chunks to be created
-        :return: it returns a list with unique block names and an integer
-            with total size in bytes
-        """
-        if numChunks == 1:
-            thisChunk = set()
-            thisChunk.update(list(self.getPrimaryBlocks()))
-            thisChunkSize = sum([blockInfo['blockSize'] for blockInfo in viewvalues(self.getPrimaryBlocks())])
-            if self.getParentDataset():
-                thisChunk.update(list(self.getParentBlocks()))
-                thisChunkSize += sum([blockInfo['blockSize'] for blockInfo in viewvalues(self.getParentBlocks())])
-            # keep same data structure as multiple chunks, so list of lists
-            return thisChunk, thisChunkSize
-
-        # create a descendant list of blocks according to their sizes
-        sortedPrimary = sorted(viewitems(self.getPrimaryBlocks()), key=lambda item: item[1]['blockSize'], reverse=True)
-        if len(sortedPrimary) < numChunks:
-            msg = "There are less blocks than chunks to create. "
-            msg += "Reducing numChunks from %d to %d" % (numChunks, len(sortedPrimary))
-            self.logger.info(msg)
-            numChunks = len(sortedPrimary)
-        chunkSize = sum(item[1]['blockSize'] for item in sortedPrimary) // numChunks
-
-        self.logger.info("Found %d blocks and the avg chunkSize is: %s GB",
-                         len(sortedPrimary), gigaBytes(chunkSize))
-        # list of sets with the block names
-        blockChunks = []
-        # list of integers with the total block sizes in each chunk (same order as above)
-        sizeChunks = []
-        for i in range(numChunks):
-            thisChunk = set()
-            thisChunkSize = 0
-            idx = 0
-            while True:
-                self.logger.debug("Chunk: %d and idx: %s and length: %s", i, idx, len(sortedPrimary))
-                if not sortedPrimary or idx >= len(sortedPrimary):
-                    # then all blocks have been distributed
-                    break
-                elif not thisChunkSize:
-                    # then this site/chunk is empty, assign a block to it
-                    thisChunk.add(sortedPrimary[idx][0])
-                    thisChunkSize += sortedPrimary[idx][1]['blockSize']
-                    sortedPrimary.pop(idx)
-                elif thisChunkSize + sortedPrimary[idx][1]['blockSize'] <= chunkSize:
-                    thisChunk.add(sortedPrimary[idx][0])
-                    thisChunkSize += sortedPrimary[idx][1]['blockSize']
-                    sortedPrimary.pop(idx)
-                else:
-                    idx += 1
-            if thisChunk:
-                blockChunks.append(thisChunk)
-                sizeChunks.append(thisChunkSize)
-
-        # now take care of the leftovers... in a round-robin style....
-        while sortedPrimary:
-            for chunkNum in range(numChunks):
-                blockChunks[chunkNum].add(sortedPrimary[0][0])
-                sizeChunks[chunkNum] += sortedPrimary[0][1]['blockSize']
-                sortedPrimary.pop(0)
-                if not sortedPrimary:
-                    break
-        self.logger.info("Created %d primary data chunks out of %d chunks",
-                         len(blockChunks), numChunks)
-        self.logger.info("    with chunk size distribution: %s", sizeChunks)
-
-        if not self.getParentDataset():
-            return blockChunks, sizeChunks
-
-        # now add the parent blocks, considering that input blocks were evenly
-        # distributed, I'd expect the same to automatically happen to the parents...
-        childParent = self.getChildToParentBlocks()
-        parentsSize = self.getParentBlocks()
-        for chunkNum in range(numChunks):
-            parentSet = set()
-            for child in blockChunks[chunkNum]:
-                parentSet.update(childParent[child])
-
-            # now with the final list of parents in hand, update the list
-            # of blocks within the chunk and update the chunk size as well
-            blockChunks[chunkNum].update(parentSet)
-            for parent in parentSet:
-                sizeChunks[chunkNum] += parentsSize[parent]['blockSize']
-        self.logger.info("Created %d primary+parent data chunks out of %d chunks",
-                         len(blockChunks), numChunks)
-        self.logger.info("    with chunk size distribution: %s", sizeChunks)
-        return blockChunks, sizeChunks
-
     def _getValue(self, keyName, defaultValue=None):
         """
         Provide a property/keyName, return its valid value if any
@@ -484,3 +390,33 @@ class Workflow(object):
         :return: an integer with the amount of secs
         """
         return self.data.get("OpenRunningTimeout", 0)
+
+    def getInputData(self):
+        """
+        Returns all the primary and parent data that has to be locked
+        and transferred with Rucio
+        :return: a list of unique block names and an integer
+                 with their total size
+        """
+        blockList = list(self.getPrimaryBlocks())
+        totalBlockSize = sum([blockInfo['blockSize'] for blockInfo in self.getPrimaryBlocks().values()])
+
+        # if it has parent blocks, add all of them as well
+        if self.getParentDataset():
+            blockList.extend(list(self.getParentBlocks()))
+            totalBlockSize += sum([blockInfo['blockSize'] for blockInfo in viewvalues(self.getParentBlocks())])
+        return blockList, totalBlockSize
+
+    def getRucioGrouping(self):
+        """
+        Returns the rucio rule grouping to be defined for a primary
+        and/or parent input data placement, where:
+            * ALL: all CMS blocks are placed under the same RSE
+            * DATASET: CMS blocks can be scattered in multiple RSEs
+
+        NOTE that this does not apply to secondary data placement,
+        which is always "ALL" (whole container in the same RSE).
+
+        :return: a string with the required DID grouping
+        """
+        return GROUPING_DSET

--- a/src/python/WMCore/MicroService/MSTransferor/RequestInfo.py
+++ b/src/python/WMCore/MicroService/MSTransferor/RequestInfo.py
@@ -16,7 +16,10 @@ from pprint import pformat
 from copy import deepcopy
 from Utils.IteratorTools import grouper
 from WMCore.DataStructs.LumiList import LumiList
-from WMCore.MicroService.MSTransferor.Workflow import Workflow
+from WMCore.MicroService.MSTransferor.DataStructs.DQMHarvestWorkflow import DQMHarvestWorkflow
+from WMCore.MicroService.MSTransferor.DataStructs.GrowingWorkflow import GrowingWorkflow
+from WMCore.MicroService.MSTransferor.DataStructs.RelValWorkflow import RelValWorkflow
+from WMCore.MicroService.MSTransferor.DataStructs.Workflow import Workflow
 from WMCore.MicroService.Tools.PycurlRucio import (getRucioToken, getPileupContainerSizesRucio,
                                                    listReplicationRules, getBlocksAndSizeRucio)
 from WMCore.MicroService.Tools.Common import (elapsedTime, findBlockParents,
@@ -41,6 +44,7 @@ class RequestInfo(MSCore):
         self.rucio = rucioObj
         self.rucioToken = None
         self.tokenValidity = None
+        self.openRunning = self.msConfig["openRunning"]
 
     def __call__(self, reqRecords):
         """
@@ -55,21 +59,43 @@ class RequestInfo(MSCore):
             return []
         self.logger.info("Going to process %d requests.", len(reqRecords))
 
-        # create a Workflow object representing the request
-        workflows = []
-        for record in reqRecords:
-            wflow = Workflow(record['RequestName'], record, logger=self.logger)
-            workflows.append(wflow)
-            msg = "Processing request: %s, with campaigns: %s, " % (wflow.getName(),
-                                                                    wflow.getCampaigns())
-            msg += "and input data as:\n%s" % pformat(wflow.getDataCampaignMap())
-            self.logger.info(msg)
+        # create a Workflow object representing the request, matching
+        # against some specific templates
+        workflows = self.classifyWorkflows(reqRecords)
 
         # setup the Rucio token
         self.setupRucio()
         # get complete requests information (based on Unified Transferor logic)
         self.unified(workflows)
 
+        return workflows
+
+    def classifyWorkflows(self, reqRecords):
+        """
+        This method classifies the provided workflows into their
+        respective MS templates. Making it easier to retrieve
+        input data and parameters for input data placement.
+
+        :param reqRecords: list of workflow dictionaries (from ReqMgr2)
+        :return: a custom python object for the workflow type
+        """
+        workflows = []
+        for record in reqRecords:
+            if record.get("SubRequestType") in ['RelVal', 'HIRelVal']:
+                wflow = RelValWorkflow(record['RequestName'], record, logger=self.logger)
+            elif record.get("RequestType") == "DQMHarvest":
+                wflow = DQMHarvestWorkflow(record['RequestName'], record, logger=self.logger)
+            elif record.get("OpenRunningTimeout", 0) > self.openRunning:
+                wflow = GrowingWorkflow(record['RequestName'], record, logger=self.logger)
+            else:
+                wflow = Workflow(record['RequestName'], record, logger=self.logger)
+
+            workflows.append(wflow)
+            msg = f"Processing request: {wflow.getName()}, "
+            msg += f"with transferor template: {wflow.__class__.__name__}, "
+            msg += f"with campaigns: {wflow.getCampaigns()} and "
+            msg += f"input data as:\n{pformat(wflow.getDataCampaignMap())}"
+            self.logger.info(msg)
         return workflows
 
     def setupRucio(self):
@@ -104,27 +130,27 @@ class RequestInfo(MSCore):
         time0 = time.time()
         parentMap = self.getParentDatasets(workflows)
         self.setParentDatasets(workflows, parentMap)
-        self.logger.debug(elapsedTime(time0, "### getParentDatasets"))
+        self.logger.info(elapsedTime(time0, "### getParentDatasets"))
 
         # then check the secondary dataset sizes and locations
         time0 = time.time()
         sizeByDset, locationByDset = self.getSecondaryDatasets(workflows)
         locationByDset = self.resolveSecondaryRSEs(locationByDset)
         self.setSecondaryDatasets(workflows, sizeByDset, locationByDset)
-        self.logger.debug(elapsedTime(time0, "### getSecondaryDatasets"))
+        self.logger.info(elapsedTime(time0, "### getSecondaryDatasets"))
 
         # get final primary and parent list of valid blocks,
         # considering run, block and lumi lists
         time0 = time.time()
         blocksByDset = self.getInputDataBlocks(workflows)
         self.setInputDataBlocks(workflows, blocksByDset)
-        self.logger.debug(elapsedTime(time0, "### getInputDataBlocks"))
+        self.logger.info(elapsedTime(time0, "### getInputDataBlocks"))
 
         # get a final list of parent blocks
         time0 = time.time()
         parentageMap = self.getParentChildBlocks(workflows)
         self.setParentChildBlocks(workflows, parentageMap)
-        self.logger.debug(elapsedTime(time0, "### getParentChildBlocks"))
+        self.logger.info(elapsedTime(time0, "### getParentChildBlocks"))
         self.logger.info(elapsedTime(orig, '### total time for unified method'))
         self.logger.info("Unified method successfully processed %d requests", len(workflows))
 
@@ -224,7 +250,7 @@ class RequestInfo(MSCore):
         if retryDatasets:
             for wflow in workflows:
                 for pileup in wflow.getPileupDatasets():
-                    if pileup in  retryDatasets:
+                    if pileup in retryDatasets:
                         retryWorkflows.append(wflow)
             # remove workflows that failed one or more of the bulk queries to the data-service
             self._workflowRemoval(workflows, retryWorkflows)

--- a/src/python/WMCore/MicroService/MSTransferor/Workflow.py
+++ b/src/python/WMCore/MicroService/MSTransferor/Workflow.py
@@ -337,17 +337,17 @@ class Workflow(object):
         """
         return self.childToParentBlocks
 
+    # TODO: all this chunk logic is no longer needed for Rucio
+    # Maybe, in the future, we might need to do data management
+    # for primary + parent cases, I hope not!
     def getChunkBlocks(self, numChunks=1):
         """
         Break down the input and parent blocks by a given number
         of chunks (usually the amount of sites available for data
         placement).
         :param numChunks: integer representing the number of chunks to be created
-        :return: it returns two lists:
-          * a list of sets, where each set corresponds to a set of blocks to be
-            transferred to a single location;
-          * and a list integers, which references the total size of each chunk in
-            the list above (same order).
+        :return: it returns a list with unique block names and an integer
+            with total size in bytes
         """
         if numChunks == 1:
             thisChunk = set()
@@ -357,7 +357,7 @@ class Workflow(object):
                 thisChunk.update(list(self.getParentBlocks()))
                 thisChunkSize += sum([blockInfo['blockSize'] for blockInfo in viewvalues(self.getParentBlocks())])
             # keep same data structure as multiple chunks, so list of lists
-            return [thisChunk], [thisChunkSize]
+            return thisChunk, thisChunkSize
 
         # create a descendant list of blocks according to their sizes
         sortedPrimary = sorted(viewitems(self.getPrimaryBlocks()), key=lambda item: item[1]['blockSize'], reverse=True)

--- a/src/python/WMCore/Services/Rucio/Rucio.py
+++ b/src/python/WMCore/Services/Rucio/Rucio.py
@@ -22,6 +22,10 @@ from Utils.MemoryCache import MemoryCache
 from WMCore.WMException import WMException
 
 RUCIO_VALID_PROJECT = ("Production", "RelVal", "Tier0", "Test", "User")
+# grouping values are extracted from:
+# https://github.com/rucio/rucio/blob/master/lib/rucio/common/schema/cms.py#L117
+GROUPING_DSET = "DATASET"
+GROUPING_ALL = "ALL"
 
 
 class WMRucioException(WMException):

--- a/test/python/WMCore_t/MicroService_t/MSTransferor_t/DataStructs_t/DQMHarvestWorkflow_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSTransferor_t/DataStructs_t/DQMHarvestWorkflow_t.py
@@ -1,0 +1,83 @@
+"""
+Unit tests for the WMCore/MicroService/DataStructs/DQMHarvestWorkflow module
+"""
+from __future__ import division, print_function
+
+import unittest
+from copy import deepcopy
+
+from WMCore.MicroService.MSTransferor.DataStructs.DQMHarvestWorkflow import DQMHarvestWorkflow
+
+
+class DQMHarvestWorkflowTest(unittest.TestCase):
+    """
+    Test the very basic functionality of the DQMHarvestWorkflow module
+    """
+
+    def setUp(self):
+        """
+        Defined some basic data structs to use in the unit tests
+        """
+        self.primaryDict = {"block_A": {"blockSize": 1, "locations": ["Site_A", "Site_B"]},
+                            "block_B": {"blockSize": 2, "locations": ["Site_B", "Site_C"]}}
+        self.dqmSpec = {"RequestType": "ReReco",
+                        "InputDataset": "/rereco/input-dataset/tier",
+                        "Campaign": "any-campaign",
+                        "RequestName": "whatever_name",
+                        "DbsUrl": "a_dbs_url",
+                        "SiteWhitelist": ["Site_A", "Site_B", "Site_C"],
+                        "SiteBlacklist": ["Site_B"]}
+
+    def tearDown(self):
+        pass
+
+    def testInstance(self):
+        """
+        Test object instance type
+        """
+        wflow = DQMHarvestWorkflow(self.dqmSpec['RequestName'], deepcopy(self.dqmSpec))
+        self.assertIsInstance(wflow, DQMHarvestWorkflow)
+
+    def testDQMHarvestWflow(self):
+        """
+        Test loading a DQMHarvest like request into Workflow object
+        """
+        wflow = DQMHarvestWorkflow(self.dqmSpec['RequestName'], deepcopy(self.dqmSpec))
+        self.assertEqual(wflow.getName(), self.dqmSpec['RequestName'])
+        self.assertEqual(wflow.getDbsUrl(), self.dqmSpec['DbsUrl'])
+        self.assertCountEqual(wflow.getSitelist(), ["Site_A", "Site_C"])
+        self.assertCountEqual(wflow.getCampaigns(), [self.dqmSpec["Campaign"]])
+        self.assertEqual(wflow.getInputDataset(), self.dqmSpec["InputDataset"])
+        self.assertCountEqual(wflow.getPileupDatasets(), set())
+        self.assertFalse(wflow.hasParents())
+        self.assertEqual(wflow.getParentDataset(), "")
+        self.assertEqual(wflow.getPrimaryBlocks(), {})
+        self.assertEqual(wflow.getSecondarySummary(), {})
+        self.assertEqual(wflow.getParentBlocks(), {})
+        self.assertEqual(wflow._getValue("NoKey"), None)
+        self.assertEqual(len(wflow.getDataCampaignMap()), 1)
+
+    def testGetInputData(self):
+        """
+        Test the `getInputData` method for this template, which
+        is supposed to return a list of input blocks
+        """
+        wflow = DQMHarvestWorkflow(self.dqmSpec['RequestName'], deepcopy(self.dqmSpec))
+        wflow.setPrimaryBlocks(self.primaryDict)
+        inputBlocks, blockSize = wflow.getInputData()
+        self.assertEqual(len(inputBlocks), 2)
+        self.assertCountEqual(inputBlocks, list(self.primaryDict))
+        self.assertEqual(blockSize, 3)
+
+    def testGetRucioGrouping(self):
+        """
+        Test the `getRucioGrouping` method, which is supposed to return
+        a basic string with the Rucio grouping for this template (static
+        output).
+        """
+        wflow = DQMHarvestWorkflow(self.dqmSpec['RequestName'], deepcopy(self.dqmSpec))
+        self.assertEqual(wflow.getRucioGrouping(), "ALL")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/WMCore_t/MicroService_t/MSTransferor_t/DataStructs_t/GrowingWorkflow_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSTransferor_t/DataStructs_t/GrowingWorkflow_t.py
@@ -1,0 +1,117 @@
+"""
+Unit tests for the WMCore/MicroService/DataStructs/GrowingWorkflow module
+"""
+from __future__ import division, print_function
+
+import unittest
+from copy import deepcopy
+
+from WMCore.MicroService.MSTransferor.DataStructs.GrowingWorkflow import GrowingWorkflow
+
+
+class GrowingWorkflowTest(unittest.TestCase):
+    """
+    Test the very basic functionality of the GrowingWorkflow module
+    """
+
+    def setUp(self):
+        """
+        Defined some basic data structs to use in the unit tests
+        :return: None
+        """
+        self.primaryDict = {"block_A": {"blockSize": 1, "locations": ["Site_A", "Site_B"]},
+                            "block_B": {"blockSize": 2, "locations": ["Site_B", "Site_C"]}}
+        self.taskSpec = {"RequestType": "TaskChain",
+                         "SubRequestType": "ReReco",
+                         "TaskChain": 2,
+                         "Campaign": "top-campaign",
+                         "RequestName": "whatever_name",
+                         "DbsUrl": "a_dbs_url",
+                         "SiteWhitelist": ["Site_A", "Site_B", "Site_C"],
+                         "SiteBlacklist": [],
+                         "Task1": {"InputDataset": "/task1/input-dataset/tier",
+                                   "Campaign": "task1-campaign"},
+                         "Task2": {"Campaign": "task2-campaign"},
+                         }
+        self.rerecoSpec = {"RequestType": "ReReco",
+                           "InputDataset": "/rereco/input-dataset/tier",
+                           "Campaign": "any-campaign",
+                           "RequestName": "whatever_name",
+                           "DbsUrl": "a_dbs_url",
+                           "SiteWhitelist": ["Site_A", "Site_B", "Site_C"],
+                           "SiteBlacklist": ["Site_B"]}
+
+    def tearDown(self):
+        pass
+
+    def testInstance(self):
+        """
+        Test object instance type
+        """
+        wflow = GrowingWorkflow(self.taskSpec['RequestName'], deepcopy(self.taskSpec))
+        self.assertIsInstance(wflow, GrowingWorkflow)
+
+    def testGrowingTaskChainWflow(self):
+        """
+        Test loading a growing TaskChain workflow
+        """
+        expCampaigns = {'task2-campaign', 'task1-campaign'}
+
+        wflow = GrowingWorkflow(self.taskSpec['RequestName'], self.taskSpec)
+        self.assertEqual(wflow.getName(), self.taskSpec['RequestName'])
+        self.assertEqual(wflow.getDbsUrl(), self.taskSpec['DbsUrl'])
+        self.assertCountEqual(wflow.getSitelist(), self.taskSpec["SiteWhitelist"])
+        self.assertCountEqual(wflow.getCampaigns(), expCampaigns)
+        self.assertEqual(wflow.getInputDataset(), self.taskSpec["Task1"].get("InputDataset", ""))
+        self.assertCountEqual(wflow.getPileupDatasets(), [])
+        self.assertFalse(wflow.hasParents())
+        self.assertEqual(wflow.getParentDataset(), "")
+        self.assertEqual(wflow.getPrimaryBlocks(), {})
+        self.assertEqual(wflow.getSecondarySummary(), {})
+        self.assertEqual(wflow.getParentBlocks(), {})
+        self.assertEqual(wflow._getValue("NoKey"), None)
+
+    def testGrowingReRecoWflow(self):
+        """
+        Test loading a growing ReReco workflow
+        """
+        wflow = GrowingWorkflow(self.rerecoSpec['RequestName'], self.rerecoSpec)
+        self.assertEqual(wflow.getName(), self.rerecoSpec['RequestName'])
+        self.assertEqual(wflow.getDbsUrl(), self.rerecoSpec['DbsUrl'])
+        self.assertCountEqual(wflow.getSitelist(), ["Site_A", "Site_C"])
+        self.assertCountEqual(wflow.getCampaigns(), [self.rerecoSpec["Campaign"]])
+        self.assertEqual(wflow.getInputDataset(), self.rerecoSpec.get("InputDataset", ""))
+        self.assertCountEqual(wflow.getPileupDatasets(), [])
+        self.assertFalse(wflow.hasParents())
+        self.assertEqual(wflow.getParentDataset(), "")
+        self.assertEqual(wflow.getPrimaryBlocks(), {})
+        self.assertEqual(wflow.getSecondarySummary(), {})
+        self.assertEqual(wflow.getParentBlocks(), {})
+        self.assertEqual(wflow._getValue("NoKey"), None)
+
+    def testGetInputData(self):
+        """
+        Test the `getInputData` method for this template, which
+        is supposed to return a list of input blocks
+        """
+        wflow = GrowingWorkflow(self.rerecoSpec['RequestName'], deepcopy(self.rerecoSpec))
+        wflow.setPrimaryBlocks(self.primaryDict)
+        inputBlocks, blockSize = wflow.getInputData()
+        print(inputBlocks)
+        self.assertEqual(len(inputBlocks), 1)
+        # note that it returns the input container name!
+        self.assertCountEqual(inputBlocks, [self.rerecoSpec['InputDataset']])
+        self.assertEqual(blockSize, 3)
+
+    def testGetRucioGrouping(self):
+        """
+        Test the `getRucioGrouping` method, which is supposed to return
+        a basic string with the Rucio grouping for this template (static
+        output).
+        """
+        wflow = GrowingWorkflow(self.rerecoSpec['RequestName'], deepcopy(self.rerecoSpec))
+        self.assertEqual(wflow.getRucioGrouping(), "DATASET")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/WMCore_t/MicroService_t/MSTransferor_t/DataStructs_t/RelValWorkflow_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSTransferor_t/DataStructs_t/RelValWorkflow_t.py
@@ -1,0 +1,267 @@
+"""
+Unit tests for the WMCore/MicroService/DataStructs/RelValWorkflow module
+"""
+from __future__ import division, print_function
+
+import unittest
+from copy import deepcopy
+
+from WMCore.MicroService.MSTransferor.DataStructs.RelValWorkflow import RelValWorkflow
+
+
+class RelValWorkflowTest(unittest.TestCase):
+    """
+    Test the very basic functionality of the RelValWorkflow module
+    """
+
+    def setUp(self):
+        """
+        Defined some basic data structs to use in the unit tests
+        :return: None
+        """
+        self.primaryDict = {"block_A": {"blockSize": 1, "locations": ["Site_A", "Site_B"]},
+                            "block_B": {"blockSize": 2, "locations": ["Site_B", "Site_C"]}}
+        self.parentDict = {"parent_A": {"blockSize": 11, "locations": ["Site_A"]},
+                           "parent_B": {"blockSize": 12, "locations": ["Site_B"]}}
+        self.relvalSpec = {"RequestType": "TaskChain",
+                           "SubRequestType": "RelVal",
+                           "TaskChain": 3,
+                           "Campaign": "top-campaign",
+                           "RequestName": "whatever_name",
+                           "DbsUrl": "a_dbs_url",
+                           "SiteWhitelist": ["Site_A", "Site_B", "Site_C"],
+                           "SiteBlacklist": [],
+                           "Task1": {"Campaign": "task1-campaign"},
+                           "Task2": {"Campaign": "task2-campaign"},
+                           "Task3": {"Campaign": "task3-campaign"},
+                           }
+        self.relvalNoInputPU = {"Task1": {"Campaign": "task1-campaign"},
+                                "Task2": {"MCPileup": "/task1/mc-pileup/tier",
+                                          "Campaign": "task2-campaign"},
+                                "Task3": {"Campaign": "task3-campaign"}}
+        self.relvalInputNoPU = {"Task1": {"InputDataset": "/task1/input-dataset/tier",
+                                          "Campaign": "task1-campaign"},
+                                "Task2": {"Campaign": "task2-campaign"},
+                                "Task3": {"Campaign": "task3-campaign"}}
+        self.relvalInputPU = {"Task1": {"InputDataset": "/task1/input-dataset/tier",
+                                        "Campaign": "task1-campaign"},
+                              "Task2": {"MCPileup": "/task2/mc-pileup/tier",
+                                        "Campaign": "task2-campaign"},
+                              "Task3": {"Campaign": "task3-campaign"}}
+        self.relvalInputDualPU = {"Task1": {"InputDataset": "/task1/input-dataset/tier",
+                                            "Campaign": "task1-campaign"},
+                                  "Task2": {"MCPileup": "/task2/mc-pileup/tier",
+                                            "Campaign": "task2-campaign"},
+                                  "Task3": {"MCPileup": "/task3/mc-pileup/tier",
+                                            "Campaign": "task3-campaign"}}
+
+    def tearDown(self):
+        pass
+
+    def testInstance(self):
+        """
+        Test object instance type
+        """
+        wflow = RelValWorkflow(self.relvalSpec['RequestName'], deepcopy(self.relvalSpec))
+        self.assertIsInstance(wflow, RelValWorkflow)
+
+    def testRelValWflowNoInputNoPU(self):
+        """
+        Test loading a RelVal like request without any input and pileup
+        """
+        expCampaigns = {'task2-campaign', 'task1-campaign', 'task3-campaign'}
+        wflow = RelValWorkflow(self.relvalSpec['RequestName'], deepcopy(self.relvalSpec))
+        self.assertEqual(wflow.getName(), self.relvalSpec['RequestName'])
+        self.assertEqual(wflow.getDbsUrl(), self.relvalSpec['DbsUrl'])
+        self.assertCountEqual(wflow.getSitelist(), self.relvalSpec["SiteWhitelist"])
+        self.assertCountEqual(wflow.getCampaigns(), expCampaigns)
+        self.assertEqual(wflow.getInputDataset(), self.relvalSpec["Task1"].get("InputDataset", ""))
+        self.assertCountEqual(wflow.getPileupDatasets(), set())
+        self.assertFalse(wflow.hasParents())
+        self.assertEqual(wflow.getParentDataset(), "")
+        self.assertEqual(wflow.getPrimaryBlocks(), {})
+        self.assertEqual(wflow.getSecondarySummary(), {})
+        self.assertEqual(wflow.getParentBlocks(), {})
+        self.assertEqual(wflow._getValue("NoKey"), None)
+
+    def testRelValWflowNoInputWithPU(self):
+        """
+        Test loading a RelVal like request without input but with pileup
+        """
+        expCampaigns = {'task2-campaign', 'task1-campaign', 'task3-campaign'}
+        specDict = deepcopy(self.relvalSpec)
+        specDict.update(deepcopy(self.relvalNoInputPU))
+
+        wflow = RelValWorkflow(self.relvalSpec['RequestName'], specDict)
+        self.assertEqual(wflow.getName(), specDict['RequestName'])
+        self.assertEqual(wflow.getDbsUrl(), specDict['DbsUrl'])
+        self.assertCountEqual(wflow.getSitelist(), specDict["SiteWhitelist"])
+        self.assertCountEqual(wflow.getCampaigns(), expCampaigns)
+        self.assertEqual(wflow.getInputDataset(), specDict["Task1"].get("InputDataset", ""))
+        self.assertCountEqual(wflow.getPileupDatasets(), [specDict["Task2"].get("MCPileup", "")])
+        self.assertFalse(wflow.hasParents())
+        self.assertEqual(wflow.getParentDataset(), "")
+        self.assertEqual(wflow.getPrimaryBlocks(), {})
+        self.assertEqual(wflow.getSecondarySummary(), {})
+        self.assertEqual(wflow.getParentBlocks(), {})
+        self.assertEqual(wflow._getValue("NoKey"), None)
+
+    def testRelValWflowInputNoPU(self):
+        """
+        Test loading a RelVal like request with input but no pileup
+        """
+        expCampaigns = {'task2-campaign', 'task1-campaign', 'task3-campaign'}
+        specDict = deepcopy(self.relvalSpec)
+        specDict.update(deepcopy(self.relvalInputNoPU))
+
+        wflow = RelValWorkflow(self.relvalSpec['RequestName'], specDict)
+        self.assertEqual(wflow.getName(), specDict['RequestName'])
+        self.assertEqual(wflow.getDbsUrl(), specDict['DbsUrl'])
+        self.assertCountEqual(wflow.getSitelist(), specDict["SiteWhitelist"])
+        self.assertCountEqual(wflow.getCampaigns(), expCampaigns)
+        self.assertEqual(wflow.getInputDataset(), specDict["Task1"].get("InputDataset", ""))
+        self.assertCountEqual(wflow.getPileupDatasets(), [])
+        self.assertFalse(wflow.hasParents())
+        self.assertEqual(wflow.getParentDataset(), "")
+        self.assertEqual(wflow.getPrimaryBlocks(), {})
+        self.assertEqual(wflow.getSecondarySummary(), {})
+        self.assertEqual(wflow.getParentBlocks(), {})
+        self.assertEqual(wflow._getValue("NoKey"), None)
+
+    def testRelValWflowInputPU(self):
+        """
+        Test loading a RelVal like request with input and pileup
+        """
+        expCampaigns = {'task2-campaign', 'task1-campaign', 'task3-campaign'}
+        specDict = deepcopy(self.relvalSpec)
+        specDict.update(deepcopy(self.relvalInputPU))
+        puName = specDict["Task2"].get("MCPileup", "")
+
+        wflow = RelValWorkflow(self.relvalSpec['RequestName'], specDict)
+        self.assertEqual(wflow.getName(), specDict['RequestName'])
+        self.assertEqual(wflow.getDbsUrl(), specDict['DbsUrl'])
+        self.assertCountEqual(wflow.getSitelist(), specDict["SiteWhitelist"])
+        self.assertCountEqual(wflow.getCampaigns(), expCampaigns)
+        self.assertEqual(wflow.getInputDataset(), specDict["Task1"].get("InputDataset", ""))
+        self.assertCountEqual(wflow.getPileupDatasets(), [puName])
+        self.assertFalse(wflow.hasParents())
+        self.assertEqual(wflow.getParentDataset(), "")
+        self.assertEqual(wflow.getParentBlocks(), {})
+        self.assertEqual(wflow._getValue("NoKey"), None)
+        self.assertEqual(wflow.getPrimaryBlocks(), {})
+
+        # checking pileup data
+        self.assertEqual(wflow.getSecondarySummary(), {})
+        wflow.setSecondarySummary(puName, dsetSize=123, locations=["Site_B"])
+        self.assertCountEqual(list(wflow.getSecondarySummary()), [puName])
+        self.assertEqual(wflow.getSecondarySummary()[puName]["dsetSize"], 123)
+        self.assertCountEqual(wflow.getSecondarySummary()[puName]["locations"], ["Site_B"])
+
+    def testRelValWflowWithParent(self):
+        """
+        Test loading a RelVal like request with input and parent data
+        """
+        expCampaigns = {'task2-campaign', 'task1-campaign', 'task3-campaign'}
+        specDict = deepcopy(self.relvalSpec)
+        specDict.update(deepcopy(self.relvalInputNoPU))
+        specDict["Task1"].update(dict(IncludeParents=True))
+
+        wflow = RelValWorkflow(self.relvalSpec['RequestName'], specDict)
+        self.assertEqual(wflow.getName(), specDict['RequestName'])
+        self.assertEqual(wflow.getDbsUrl(), specDict['DbsUrl'])
+        self.assertCountEqual(wflow.getSitelist(), specDict["SiteWhitelist"])
+        self.assertCountEqual(wflow.getCampaigns(), expCampaigns)
+        self.assertEqual(wflow.getInputDataset(), specDict["Task1"].get("InputDataset", ""))
+        self.assertCountEqual(wflow.getPileupDatasets(), [])
+        self.assertTrue(wflow.hasParents())
+        self.assertEqual(wflow.getParentDataset(), "")
+        self.assertEqual(wflow.getParentBlocks(), {})
+        self.assertEqual(wflow._getValue("NoKey"), None)
+        self.assertEqual(wflow.getPrimaryBlocks(), {})
+
+        wflow.setParentBlocks(self.parentDict)
+        wflow.setPrimaryBlocks(self.primaryDict)
+        self.assertCountEqual(list(wflow.getPrimaryBlocks()), ["block_A", "block_B"])
+        self.assertCountEqual(list(wflow.getParentBlocks()), ["parent_A", "parent_B"])
+
+    def testRelValWflowDualPU(self):
+        """
+        Test loading a RelVal like request with input and two pileups
+        """
+        expCampaigns = {'task2-campaign', 'task1-campaign', 'task3-campaign'}
+        specDict = deepcopy(self.relvalSpec)
+        specDict.update(deepcopy(self.relvalInputDualPU))
+        puName1 = specDict["Task2"].get("MCPileup", "")
+        puName2 = specDict["Task3"].get("MCPileup", "")
+
+        wflow = RelValWorkflow(self.relvalSpec['RequestName'], specDict)
+        self.assertEqual(wflow.getName(), specDict['RequestName'])
+        self.assertEqual(wflow.getDbsUrl(), specDict['DbsUrl'])
+        self.assertCountEqual(wflow.getSitelist(), specDict["SiteWhitelist"])
+        self.assertCountEqual(wflow.getCampaigns(), expCampaigns)
+        self.assertEqual(wflow.getInputDataset(), specDict["Task1"].get("InputDataset", ""))
+        self.assertCountEqual(wflow.getPileupDatasets(), [puName1, puName2])
+        self.assertFalse(wflow.hasParents())
+        self.assertEqual(wflow.getParentDataset(), "")
+        self.assertEqual(wflow.getParentBlocks(), {})
+        self.assertEqual(wflow._getValue("NoKey"), None)
+        self.assertEqual(wflow.getPrimaryBlocks(), {})
+
+        # checking pileup data
+        self.assertEqual(wflow.getSecondarySummary(), {})
+        wflow.setSecondarySummary(puName1, dsetSize=123, locations=["Site_B"])
+        self.assertCountEqual(list(wflow.getSecondarySummary()), [puName1])
+        self.assertEqual(wflow.getSecondarySummary()[puName1]["dsetSize"], 123)
+        self.assertCountEqual(wflow.getSecondarySummary()[puName1]["locations"], ["Site_B"])
+
+        # now set the second pileup
+        wflow.setSecondarySummary(puName2, dsetSize=12, locations=["Site_C"])
+        self.assertCountEqual(list(wflow.getSecondarySummary()), [puName1, puName2])
+        self.assertEqual(wflow.getSecondarySummary()[puName1]["dsetSize"], 123)
+        self.assertEqual(wflow.getSecondarySummary()[puName2]["dsetSize"], 12)
+        self.assertCountEqual(wflow.getSecondarySummary()[puName1]["locations"], ["Site_B"])
+        self.assertCountEqual(wflow.getSecondarySummary()[puName2]["locations"], ["Site_C"])
+
+    def testGetInputData(self):
+        """
+        Test the `getInputData` method for this template, which
+        is supposed to return a list of input blocks
+        """
+        wflow = RelValWorkflow(self.relvalSpec['RequestName'], deepcopy(self.relvalSpec))
+        wflow.setPrimaryBlocks(self.primaryDict)
+        inputBlocks, blockSize = wflow.getInputData()
+        self.assertEqual(len(inputBlocks), 2)
+        self.assertCountEqual(inputBlocks, list(self.primaryDict))
+        self.assertEqual(blockSize, 3)
+
+    def testGetInputDataParent(self):
+        """
+        Test the `getInputData` method for this template, which
+        is supposed to return a list of input blocks
+        """
+        specDict = deepcopy(self.relvalSpec)
+        specDict.update(deepcopy(self.relvalInputNoPU))
+        specDict["Task1"].update(dict(IncludeParents=True))
+        wflow = RelValWorkflow(specDict['RequestName'], deepcopy(specDict))
+
+        wflow.setPrimaryBlocks(self.primaryDict)
+        wflow.setParentDataset("parent_dset")
+        wflow.setParentBlocks(self.parentDict)
+
+        inputBlocks, blockSize = wflow.getInputData()
+        self.assertEqual(len(inputBlocks), 4)
+        self.assertCountEqual(inputBlocks, list(self.primaryDict) + list(self.parentDict))
+        self.assertEqual(blockSize, 26)
+
+    def testGetRucioGrouping(self):
+        """
+        Test the `getRucioGrouping` method, which is supposed to return
+        a basic string with the Rucio grouping for this template (static
+        output).
+        """
+        wflow = RelValWorkflow(self.relvalSpec['RequestName'], deepcopy(self.relvalSpec))
+        self.assertEqual(wflow.getRucioGrouping(), "ALL")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/WMCore_t/MicroService_t/MSTransferor_t/DataStructs_t/Workflow_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSTransferor_t/DataStructs_t/Workflow_t.py
@@ -7,7 +7,7 @@ import unittest
 
 from Utils.PythonVersion import PY3
 
-from WMCore.MicroService.MSTransferor.Workflow import Workflow
+from WMCore.MicroService.MSTransferor.DataStructs.Workflow import Workflow
 
 
 class WorkflowTest(unittest.TestCase):
@@ -252,80 +252,10 @@ class WorkflowTest(unittest.TestCase):
         wflow.setChildToParentBlocks(parentage)
         self.assertItemsEqual(wflow.getChildToParentBlocks(), parentage)
 
-    def testGetChunkBlocks1(self):
+    def testGetInputData(self):
         """
-        Perform single chunk tests on the `getChunkBlocks` method.
-        """
-        primDict = {"block_A": {"blockSize": 1, "locations": ["Site_A", "Site_B"]}}
-        parentDict = {"parent_A": {"blockSize": 11, "locations": ["Site_A", "Site_B"]},
-                      "parent_B": {"blockSize": 8, "locations": []}}
-        wflow = Workflow("workflow_1", {"RequestType": "TaskChain",
-                                        "InputDataset": "Dataset_name_XXX",
-                                        "DbsUrl": "a_dbs_url"})
-        wflow.setPrimaryBlocks(primDict)
-        blockChunks, sizeChunks = wflow.getChunkBlocks(1)
-        self.assertEqual(len(blockChunks), 1)
-        self.assertItemsEqual(blockChunks[0], {"block_A"})
-        self.assertEqual(len(sizeChunks), 1)
-        self.assertEqual(sizeChunks[0], 1)
-
-        # now set a parent
-        wflow.setParentDataset("Parent_dataset_XXX")
-        wflow.setParentBlocks(parentDict)
-        blockChunks, sizeChunks = wflow.getChunkBlocks(1)
-        self.assertEqual(len(blockChunks), 1)
-        self.assertItemsEqual(blockChunks[0], {"block_A", "parent_A", "parent_B"})
-        self.assertEqual(len(sizeChunks), 1)
-        self.assertEqual(sizeChunks[0], 20)
-
-    def testGetChunkBlocks2(self):
-        """
-        Perform block distribution among many chunks, testing the `getChunkBlocks` method.
-        """
-        primDict = {"block_A": {"blockSize": 1, "locations": ["Site_A"]},
-                    "block_B": {"blockSize": 2, "locations": ["Site_B"]}}
-        wflow = Workflow("workflow_1", {"RequestType": "TaskChain",
-                                        "InputDataset": "Dataset_name_XXX",
-                                        "DbsUrl": "a_dbs_url"})
-        wflow.setPrimaryBlocks(primDict)
-
-        # same number of chunks and primary blocks
-        blockChunks, sizeChunks = wflow.getChunkBlocks(2)
-        self.assertEqual(len(blockChunks), 2)
-        self.assertItemsEqual(blockChunks[0], {"block_B"})
-        self.assertItemsEqual(blockChunks[1], {"block_A"})
-        self.assertEqual(len(sizeChunks), 2)
-        self.assertEqual(sizeChunks[0], 2)
-        self.assertEqual(sizeChunks[1], 1)
-
-        # more chunks than blocks
-        blockChunks, sizeChunks = wflow.getChunkBlocks(5)
-        self.assertEqual(len(blockChunks), 2)
-        self.assertItemsEqual(blockChunks[0], {"block_B"})
-        self.assertItemsEqual(blockChunks[1], {"block_A"})
-        self.assertEqual(len(sizeChunks), 2)
-        self.assertEqual(sizeChunks[0], 2)
-        self.assertEqual(sizeChunks[1], 1)
-
-        # more blocks than chunks
-        primDict.update({"block_C": {"blockSize": 3, "locations": ["Site_C"]},
-                         "block_D": {"blockSize": 4, "locations": ["Site_D"]},
-                         "block_E": {"blockSize": 5, "locations": ["Site_E"]}})
-        wflow.setPrimaryBlocks(primDict)
-        blockChunks, sizeChunks = wflow.getChunkBlocks(3)
-        self.assertEqual(len(blockChunks), 3)
-        self.assertItemsEqual(blockChunks[0], {"block_E"})
-        self.assertItemsEqual(blockChunks[1], {"block_D", "block_A"})
-        self.assertItemsEqual(blockChunks[2], {"block_C", "block_B"})
-        self.assertEqual(len(sizeChunks), 3)
-        self.assertEqual(sizeChunks[0], 5)
-        self.assertEqual(sizeChunks[1], 5)
-        self.assertEqual(sizeChunks[2], 5)
-
-    def testGetChunkBlocks3(self):
-        """
-        Test the `getChunkBlocks` method and especially the parent/child
-        relationship
+        Test the `getInputData` method both with input primary and
+        parent blocks
         """
         primDict = {"block_A": {"blockSize": 1, "locations": ["Site_A"]},
                     "block_B": {"blockSize": 2, "locations": ["Site_B"]}}
@@ -338,25 +268,23 @@ class WorkflowTest(unittest.TestCase):
                                         "InputDataset": "Dataset_name_XXX",
                                         "DbsUrl": "a_dbs_url"})
 
+        wflow.setPrimaryBlocks(primDict)
+        blockChunks, sizeChunks = wflow.getInputData()
+        self.assertEqual(len(blockChunks), 2)
+        self.assertItemsEqual(blockChunks, {"block_A", "block_B"})
+        self.assertEqual(sizeChunks, 3)
+
         # now set a parent
         wflow.setParentDataset("Parent_dataset_XXX")
         wflow.setPrimaryBlocks(primDict)
         wflow.setParentBlocks(parentDict)
         wflow.setChildToParentBlocks(parentage)
 
-        blockChunks, sizeChunks = wflow.getChunkBlocks(1)
-        self.assertEqual(len(blockChunks), 1)
-        self.assertItemsEqual(blockChunks[0], {"block_A", "block_B", "parent_A", "parent_B", "parent_C"})
-        self.assertEqual(len(sizeChunks), 1)
-        self.assertEqual(sizeChunks[0], 39)
+        blockChunks, sizeChunks = wflow.getInputData()
+        self.assertEqual(len(blockChunks), 5)
+        self.assertItemsEqual(blockChunks, {"block_A", "block_B", "parent_A", "parent_B", "parent_C"})
+        self.assertEqual(sizeChunks, 39)
 
-        blockChunks, sizeChunks = wflow.getChunkBlocks(2)
-        self.assertEqual(len(blockChunks), 2)
-        self.assertItemsEqual(blockChunks[0], {"block_B", "parent_A", "parent_C"})
-        self.assertItemsEqual(blockChunks[1], {"block_A", "parent_B"})
-        self.assertEqual(len(sizeChunks), 2)
-        self.assertEqual(sizeChunks[0], 26)
-        self.assertEqual(sizeChunks[1], 13)
 
     def testIsRelVal(self):
         """


### PR DESCRIPTION
Fixes #10975 

#### Status
ready

#### Description
The initial objective with this PR was the following:
* enforce the campaign pileup configuration, such that each location defined there gets a rucio rule for the whole container (grouping=ALL).
* secondary AAA can trigger secondary input data location as well, in case a location defined in the campaign does not have a rule locking it
* for workflows with multiple pileup datasets, use an intersection of their location defined in the campaign configuration for the primary/parent data placement
* as before, the pileup location defines the workflow sitelist (for primary and parent data placement). If secondary is enabled, then primary/parent can go to other locations as defined in the sitelist.
* special handling for RelVal, which do not define secondaries in the campaign, in that case simply use the workflow sitelist as candidate location for the pileup dataset(s)

However, I decided to refactor many things that were in place to deal with the old PhEDEx-based data placement. A summary of those changes are:
* no longer increment RSE usage within our own cache, instead only rely on what Rucio provides
* no longer create chunks of primary/parent input blocks, simply place all the blocks with grouping=DATASET against a logical OR of the final RSEs
* DQMHarvest workflows will keep getting their input blocks locked with grouping=ALL against a logical OR of the final RSEs (we no longer pick 1 RSE for that)
* workflows with OpenRunningTimeout will get a rule locking the whole input dataset with grouping=DATASET against a logical OR of the final RSEs
* workflows with primary and parent dataset will get a rule locking all the input blocks together, thus grouping=ALL against a logical OR of the final RSEs
* completely remove the logic to find the best RSE, let Rucio take care of that.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Given that it modifies a recent feature introduced with: https://github.com/dmwm/WMCore/pull/11141
it needs to be properly tested again.

#### External dependencies / deployment changes
Service configuration disabling verbose logs:
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/147
and
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/148
