### PR TITLE
[MSTransferor] Define grouping=ALL for workflows with parents

### DIFF
--- a/src/python/WMCore/MicroService/MSTransferor/DataStructs/Workflow.py
+++ b/src/python/WMCore/MicroService/MSTransferor/DataStructs/Workflow.py
@@ -10,7 +10,7 @@ from future.utils import viewitems, viewvalues, listvalues
 from copy import copy, deepcopy
 from WMCore.DataStructs.LumiList import LumiList
 from WMCore.MicroService.Tools.Common import getMSLogger
-from WMCore.Services.Rucio.Rucio import GROUPING_DSET
+from WMCore.Services.Rucio.Rucio import GROUPING_DSET, GROUPING_ALL
 
 
 class Workflow(object):
@@ -419,4 +419,6 @@ class Workflow(object):
 
         :return: a string with the required DID grouping
         """
+        if self.getParentDataset():
+            return GROUPING_ALL
         return GROUPING_DSET

--- a/test/python/WMCore_t/MicroService_t/MSTransferor_t/DataStructs_t/Workflow_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSTransferor_t/DataStructs_t/Workflow_t.py
@@ -326,6 +326,26 @@ class WorkflowTest(unittest.TestCase):
                                                "DbsUrl": "a_dbs_url"})
             self.assertEqual(wflowObj.getWorkflowGroup(), "relval")
 
+    def testGetRucioGrouping(self):
+        """
+        Test the `getRucioGrouping` method, which is supposed to return
+        a basic string with the Rucio grouping for this template (static
+        output).
+        """
+        parentDset = "/rereco/parent-dataset/tier"
+        rerecoSpec = {"RequestType": "ReReco",
+                      "InputDataset": "/rereco/input-dataset/tier",
+                      "Campaign": "any-campaign",
+                      "RequestName": "whatever_name",
+                      "DbsUrl": "a_dbs_url",
+                      "SiteWhitelist": ["CERN", "FNAL", "DESY"],
+                      "SiteBlacklist": ["FNAL"]}
+        wflow = Workflow(rerecoSpec['RequestName'], rerecoSpec)
+        self.assertEqual(wflow.getRucioGrouping(), "DATASET")
+
+        wflow.setParentDataset(parentDset)
+        self.assertEqual(wflow.getRucioGrouping(), "ALL")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #11152 

#### Status
ready

#### Description
Ensure that workflows with parent datasets are locked in the same RSE, thus defining `grouping=ALL` for such workflows during the input data placement.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Flaw introduced with https://github.com/dmwm/WMCore/pull/11143

#### External dependencies / deployment changes
None
