### PR TITLE
Adds output module validation to Express and PromptReco workflows

### DIFF
--- a/src/python/WMCore/Lexicon.py
+++ b/src/python/WMCore/Lexicon.py
@@ -29,6 +29,7 @@ PROCESSED_DS = {'re': '[a-zA-Z0-9\.\-_]+', 'maxLength': 199}
 TIER = {'re': '[A-Z0-9\-_]+', 'maxLength': 99}
 BLOCK_STR = {'re': '#[a-zA-Z0-9\.\-_]+', 'maxLength': 100}
 
+
 lfnParts = {
     'era': '([a-zA-Z0-9\-_]+)',
     'primDS': '([a-zA-Z][a-zA-Z0-9\-_]*)',
@@ -191,6 +192,9 @@ def block(candidate):
     blockCheck = check(r"%s" % BLOCK_STR['re'], "#%s" % lastParts[1], BLOCK_STR['maxLength'])
     return (primDSCheck and procDSCheck and tierCheck and blockCheck)
 
+def outputModule(candidate):
+    """ Asserts if a valid output module name """
+    return check(r'[a-zA-Z0-9\s\.\-_:]{1,45}$', candidate)
 
 def identifier(candidate):
     """ letters, numbers, whitespace, periods, dashes, underscores """

--- a/src/python/WMCore/WMSpec/StdSpecs/Express.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Express.py
@@ -12,7 +12,6 @@ express processing -> FEVT/RAW/RECO/whatever -> express merge
 """
 
 from __future__ import division
-
 from future.utils import viewitems
 
 import WMCore.WMSpec.Steps.StepFactory as StepFactory
@@ -20,7 +19,7 @@ from Utils.Utilities import makeList, makeNonEmptyList
 from WMCore.Lexicon import procstringT0
 from WMCore.ReqMgr.Tools.cms import releases, architectures
 from WMCore.WMSpec.StdSpecs.StdBase import StdBase
-
+from WMCore.WMSpec.WMWorkloadTools import validateOutputModules
 
 class ExpressWorkloadFactory(StdBase):
     """
@@ -465,6 +464,14 @@ class ExpressWorkloadFactory(StdBase):
         self.alcaHarvestOutLabel = "Sqlite"
 
         return self.buildWorkload()
+
+    def validateWorkload(self, workload):
+        """
+        _validateWorkload_
+
+        Validation of output module names in the workflow
+        """        
+        validateOutputModules(workload)
 
     @staticmethod
     def getWorkloadCreateArgs():

--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -10,7 +10,7 @@ from future.utils import viewitems
 from Utils.Utilities import makeList, strToBool
 from WMCore.Lexicon import procstringT0
 from WMCore.WMSpec.StdSpecs.DataProcessing import DataProcessing
-
+from WMCore.WMSpec.WMWorkloadTools import validateOutputModules
 
 class PromptRecoWorkloadFactory(DataProcessing):
     """
@@ -164,6 +164,14 @@ class PromptRecoWorkloadFactory(DataProcessing):
                                                "include_parents": True})
 
         return self.buildWorkload()
+
+    def validateWorkload(self, workload):
+        """
+        _validateWorkload_
+
+        Validation of output module names in the workflow
+        """        
+        validateOutputModules(workload)
 
     @staticmethod
     def getWorkloadCreateArgs():

--- a/src/python/WMCore/WMSpec/WMWorkloadTools.py
+++ b/src/python/WMCore/WMSpec/WMWorkloadTools.py
@@ -16,6 +16,7 @@ import re
 import inspect
 
 from Utils.Utilities import makeList
+from WMCore.Lexicon import outputModule
 from WMCore.DataStructs.LumiList import LumiList
 from WMCore.WMSpec.WMSpecErrors import WMSpecFactoryException
 
@@ -323,7 +324,6 @@ def validateUnknownArgs(arguments, argumentDefinition):
             raise WMSpecFactoryException(msg)
     return
 
-
 def setArgumentsWithDefault(arguments, argumentDefinition):
     """
     Set arguments not provided by the user with a default spec value
@@ -349,6 +349,18 @@ def setAssignArgumentsWithDefault(arguments, argumentDefinition):
             arguments[argument] = argumentDefinition[argument]["default"]
 
     return
+
+def validateOutputModules(workload):
+    """
+    Makes sure all output modules comply with DBS restrictions
+    """
+    for task in workload.getAllTasks():
+        modules = task.getOutputModulesForTask()
+        for module in modules:
+            for modName in module._internal_children:
+                if not outputModule(modName):
+                    msg = "An output module name in your request is not valid: %s" % modName)
+                    raise WMSpecFactoryException(msg)
 
 def loadSpecClassByType(specType):
     factoryName = "%sWorkloadFactory" % specType


### PR DESCRIPTION
Fixes #11171 

#### Status
not-tested

#### Description
Adds output module validation for T0 workflows

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
