### PR TITLE
Provide uniform way to handle DBS server errors

### DIFF
--- a/src/python/WMQuality/Emulators/DBSClient/DBS3API.py
+++ b/src/python/WMQuality/Emulators/DBSClient/DBS3API.py
@@ -54,9 +54,11 @@ class DbsApi(object):
             currentInfo.append(blockDump)
             json.dump(currentInfo, outFileHandle)
 
-        randomNumber = random()
-        if randomNumber < 0.2:
-            raise Exception("Proxy Error, this is a mock proxy error.")
+        # VK: once we introduced parseDBSException function we do not need to simulate Proxy Error
+        # see https://github.com/dmwm/WMCore/pull/11176#issuecomment-1158758332
+        # randomNumber = random()
+        # if randomNumber < 0.2:
+        #     raise Exception("Proxy Error, this is a mock proxy error.")
 
         return
 

--- a/test/python/WMComponent_t/DBS3Buffer_t/DBSUpload_t.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/DBSUpload_t.py
@@ -638,6 +638,21 @@ class DBSUploadTest(unittest.TestCase):
                            'OpenSSL SSL_connect: SSL_ERROR_SYSCALL']:
             self.assertIs(isPassiveError(MyTestException(errMessage)), True)
 
+    def testParseDBSException(self):
+        """
+        test parseDBSException function to parse DBS Go-based server exception message
+        """
+        exc = """[{"error":{"reason":"DBSError Code:110 Description:DBS DB insert record error Function:dbs.bulkblocks.insertFilesViaChunks Message: Error: concurrency error","message":"7cf3dee6307fdaa1f72d0dc03551fd0e6665f32114d752c37819c238cef7a231 unable to insert files, error DBSError Code:110 Description:DBS DB insert record error Function:dbs.bulkblocks.insertFilesViaChunks Message: Error: concurrency error","function":"dbs.bulkblocks.InsertBulkBlocksConcurrently","code":110},"http":{"method":"POST","code":400,"timestamp":"2022-05-27 19:21:45.67710595 +0000 UTC m=+191328.489143316","path":"/dbs/prod/global/DBSWriter/bulkblocks","user_agent":"DBSClient/Unknown/","x_forwarded_host":"dbs-prod.cern.ch","x_forwarded_for":"137.138.157.32","remote_addr":"137.138.63.204:39950"},"exception":400,"type":"HTTPError","message":"DBSError Code:110 Description:DBS DB insert record error Function:dbs.bulkblocks.InsertBulkBlocksConcurrently Message:7cf3dee6307fdaa1f72d0dc03551fd0e6665f32114d752c37819c238cef7a231 unable to insert files, error DBSError Code:110 Description:DBS DB insert record error Function:dbs.bulkblocks.insertFilesViaChunks Message: Error: concurrency error Error: nested DBSError Code:110 Description:DBS DB insert record error Function:dbs.bulkblocks.insertFilesViaChunks Message: Error: concurrency error"}]"""
+        data = parseDBSException(exc)
+        expect = 'DBSError Code:110 Description:DBS DB insert record error Function:dbs.bulkblocks.insertFilesViaChunks Message: Error: concurrency error'
+        self.assertEqual(data, expect)
+
+        # test another type of exception
+        exc = Exception()
+        data = parseDBSException(exc)
+        self.assertEqual(data, exc)
+        self.assertIs(isinstance(exc, Exception), True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/WMComponent_t/DBS3Buffer_t/DBSUpload_t.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/DBSUpload_t.py
@@ -22,7 +22,7 @@ from WMComponent.DBS3Buffer.DBSBufferBlock import DBSBufferBlock
 from WMComponent.DBS3Buffer.DBSBufferDataset import DBSBufferDataset
 from WMComponent.DBS3Buffer.DBSBufferFile import DBSBufferFile
 from WMComponent.DBS3Buffer.DBSBufferUtil import DBSBufferUtil
-from WMComponent.DBS3Buffer.DBSUploadPoller import DBSUploadPoller, isPassiveError
+from WMComponent.DBS3Buffer.DBSUploadPoller import DBSUploadPoller, isPassiveError, parseDBSException
 from WMCore.DAOFactory import DAOFactory
 from WMCore.DataStructs.Run import Run
 from WMCore.Services.UUIDLib import makeUUID


### PR DESCRIPTION
Fixes #11167 

#### Status
in development

#### Description
Provide parser function for DBS Go-based exception. If it successfully parsed the exception message it will return concise message (DBS Go server `reason`), otherwise it returns original exception message

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
<If it's a follow up work; or porting a fix from a different branch, please mention them here.>

#### External dependencies / deployment changes
<Does it require deployment changes? Does it rely on third-party libraries?>
