### PR TITLE
Ensure dataset_lifetime bind is defined for DBS3Buffer/NewSubscription

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/MySQL/NewSubscription.py
+++ b/src/python/WMComponent/DBS3Buffer/MySQL/NewSubscription.py
@@ -39,6 +39,8 @@ class NewSubscription(DBFormatter):
 
         # DeleteFromSource is not supported for move subscriptions
         delete_blocks = None
+        # if None, force it to 0 as per the table schema
+        dataLifetime = subscriptionInfo.get('DatasetLifetime', 0) or 0
         if custodialFlag:
             sites = subscriptionInfo['CustodialSites']
             phedex_group = subscriptionInfo['CustodialGroup']
@@ -59,9 +61,8 @@ class NewSubscription(DBFormatter):
                     'move': isMove,
                     'priority': subscriptionInfo['Priority'],
                     'phedex_group': phedex_group,
-                    'delete_blocks': delete_blocks}
-            if subscriptionInfo['DatasetLifetime'] is not None:
-                bind.update(dict(dataset_lifetime=subscriptionInfo['DatasetLifetime']))
+                    'delete_blocks': delete_blocks,
+                    'dataset_lifetime': dataLifetime}
             binds.append(bind)
         return binds
 


### PR DESCRIPTION
Fixes #11178 

#### Status
ready

#### Description
Make sure that bind `dataset_lifetime` is created when the SQL statement is executed. In case it's not defined, default to the same default value defined in the table schema creation (integer 0). 

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Fixes a bug added in https://github.com/dmwm/WMCore/pull/11115

#### External dependencies / deployment changes
None
