### PR TITLE
Give enough time for replication to complete in unit tests

### DIFF
--- a/src/python/WMCore/WorkQueue/WorkQueueBackend.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueBackend.py
@@ -86,7 +86,7 @@ class WorkQueueBackend(object):
         self.sendToParent(continuous=True)
 
     def pullFromParent(self, continuous=True, cancel=False):
-        """Replicate from parent couch - blocking: used only int test"""
+        """Replicate from parent couch - blocking: used only in unit tests"""
         try:
             if self.parentCouchUrlWithAuth and self.queueUrlWithAuth:
                 self.logger.info("Forcing pullFromParent from parentCouch: %s to queueUrl %s/%s",
@@ -97,7 +97,8 @@ class WorkQueueBackend(object):
                                       query_params={'childUrl': self.queueUrl,
                                                     'parentUrl': self.parentCouchUrl},
                                       continuous=continuous,
-                                      cancel=cancel)
+                                      cancel=cancel,
+                                      sleepSecs=6)
         except Exception as ex:
             self.logger.warning('Replication from %s failed: %s' % (self.parentCouchUrlWithAuth, str(ex)))
 


### PR DESCRIPTION
Complement to #11001

#### Status
ready

#### Description
The original changes provided in #11001 were missing this extra function used to create CouchDB replication task in the unit tests. Pass a 6 seconds sleep to ensure that the task is triggered and that documents get to the expected destination in unit tests.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Complement to #11001 

#### External dependencies / deployment changes
None
