### PR TITLE
Update CMSMonitoring module version to use StompAMQ7 with latest stomp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@
 Cheetah3~=3.2.6.post1         # wmcore,wmagent,reqmgr2,reqmon
 CherryPy~=17.4.0              # wmcore,wmagent,wmagent-devtools,reqmgr2,reqmon,global-workqueue,reqmgr2ms
 CMSCouchapp~=1.3.4            # wmcore,wmagent
-CMSMonitoring~=0.3.4          # wmcore,wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms
+CMSMonitoring~=0.6.4          # wmcore,wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms
 coverage~=5.4                 # wmcore,wmagent,wmagent-devtools
 cx-Oracle~=7.3.0              # wmcore,wmagent
 dbs3-client~=4.0.8            # wmcore,wmagent,reqmgr2,reqmon,global-workqueue

--- a/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
+++ b/src/python/WMComponent/AgentStatusWatcher/AgentStatusPoller.py
@@ -26,7 +26,7 @@ from WMCore.WorkQueue.DataStructs.WorkQueueElementsSummary import getGlobalSiteS
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 
 # CMSMonitoring modules
-from CMSMonitoring.StompAMQ import StompAMQ
+from CMSMonitoring.StompAMQ7 import StompAMQ7 as StompAMQ
 
 
 class AgentStatusPoller(BaseWorkerThread):
@@ -570,8 +570,8 @@ class AgentStatusPoller(BaseWorkerThread):
                                 logger=logging)
 
             for doc in docs:
-                singleNotif, _, _ = stompSvc.make_notification(payload=doc, docType=docType,
-                                                               ts=timeS, dataSubfield="payload")
+                singleNotif, _, _ = stompSvc.make_notification(payload=doc, doc_type=docType,
+                                                               ts=timeS, data_subfield="payload")
                 notifications.append(singleNotif)
 
             failures = stompSvc.send(notifications)

--- a/src/python/WMCore/REST/HeartbeatMonitorBase.py
+++ b/src/python/WMCore/REST/HeartbeatMonitorBase.py
@@ -5,7 +5,7 @@ from WMCore.REST.CherryPyPeriodicTask import CherryPyPeriodicTask
 from WMCore.Services.WMStats.WMStatsWriter import WMStatsWriter, convertToServiceCouchDoc
 
 # CMSMonitoring modules
-from CMSMonitoring.StompAMQ import StompAMQ
+from CMSMonitoring.StompAMQ7 import StompAMQ7 as StompAMQ
 
 
 class HeartbeatMonitorBase(CherryPyPeriodicTask):
@@ -76,8 +76,8 @@ class HeartbeatMonitorBase(CherryPyPeriodicTask):
                                 logger=self.logger)
 
             for doc in docs:
-                singleNotif, _, _ = stompSvc.make_notification(payload=doc, docType=self.docTypeAMQ,
-                                                               ts=ts, dataSubfield="payload")
+                singleNotif, _, _ = stompSvc.make_notification(payload=doc, doc_type=self.docTypeAMQ,
+                                                               ts=ts, data_subfield="payload")
                 notifications.append(singleNotif)
 
             failures = stompSvc.send(notifications)


### PR DESCRIPTION
Fixes #11180

#### Status
ready

#### Description
CMSMonitoring module pypi version is upgraded with the new release which uses latest stomp.py version (>=6.1.1,<8.0.0)

#### Is it backward compatible (if not, which system it affects?)
NO . 
Affected: `HeartBeatMonitor.py`, `AgentStatusPoller.py`
Reason: new StompAMQ7 does not use camel case parameters

#### Related PRs
[dmwm/CMSMonitoring/pull/146](https://github.com/dmwm/CMSMonitoring/pull/146)

#### External dependencies / deployment changes
`CMSMonitoring~=0.6.2` applied in requirements.txt


@amaltaro I could not test with the `wmagent`AMQ  producer because of a credential issue. MONIT uses a different flume agent for WMA and I could not understand which producer should I use to test. Since I don't want to take your time by asking more details, I created this PR to be able test. New StompAMQ changes are applied. If it is possible, could you please deploy this PR to test and then we can check data in ES.

fyi @vkuznet 