### PR TITLE
Consistent return data type for closing workqueue elements

### DIFF
--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -869,15 +869,16 @@ class WorkQueue(WorkQueueBase):
 
         :return: list of workqueue_inbox elements that have been closed
         """
+        workflowsToClose = []
         if self.params['LocalQueueFlag']:
-            return  # GlobalQueue-only service
+            # this is a Global WorkQueue only functionality
+            return workflowsToClose
         if not self.backend.isAvailable():
             self.logger.warning('Backend busy or down: Can not close work at this time')
-            return
+            return workflowsToClose
 
         workflowsToCheck = self.backend.getInboxElements(OpenForNewData=True)
         self.logger.info("Retrieved a list of %d open workflows", len(workflowsToCheck))
-        workflowsToClose = []
         currentTime = time.time()
         for element in workflowsToCheck:
             # fetch attributes from the inbox workqueue element

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueue_t.py
@@ -86,9 +86,8 @@ def syncQueues(queue, skipWMBS=False):
     time.sleep(1)
     work = queue.processInboundWork()
     queue.performQueueCleanupActions(skipWMBS=skipWMBS)
-    # queue.backend.forceQueueSync() ## FIXME TODO: AMR, maybe revert it
     # after replication need to wait a while to update result
-    time.sleep(1)
+    time.sleep(3)
     return work
 
 
@@ -814,6 +813,8 @@ class WorkQueueTest(WorkQueueTestCase):
         # self.globalQueue.updateLocationInfo()
         self.assertEqual(self.localQueue.pullWork({'T2_XX_SiteA': 1000}), totalSpec)
         syncQueues(self.localQueue)
+        # give a few extra seconds for work to move between local/global queues
+        time.sleep(2)
         self.assertEqual(len(self.localQueue.status(status='Available')), totalSpec)
         self.assertEqual(len(self.globalQueue.status(status='Acquired')), totalSpec)
         self.localQueue.updateLocationInfo()


### PR DESCRIPTION
Fixes #11187 

#### Status
ready

#### Description
Make the data type returned by this `closeWork` method consistent, always a list. Otherwise the caller might be getting length of a None object (which raises an exception!).

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
