### PR TITLE
Skip input values with empty tags - wmagent branch

### DIFF
--- a/src/python/WMCore/Services/WMArchive/DataMap.py
+++ b/src/python/WMCore/Services/WMArchive/DataMap.py
@@ -6,6 +6,7 @@ from future.utils import viewitems, listvalues, listitems
 import copy
 import socket
 from collections import defaultdict
+import logging
 
 # From top level
 
@@ -270,16 +271,21 @@ def convertStepValue(stepValue):
         if not stepValue['input']:
             # if empty convert to list from {}
             stepValue['input'] = []
-
-        elif len(stepValue['input']) > 1:
-            # assume only one input value
-            raise Exception("more than one input value %s" % list(stepValue['input']))
-
-        elif list(stepValue['input'].keys())[0] in input_keys:
-            stepValue['input'] = convertInput(stepValue['input'][list(stepValue['input'])[0]])
-
         else:
-            raise Exception("Unknow iput key %s" % list(stepValue['input']))
+            if len(stepValue['input']) > 1:
+                # skip input values that are not in input_keys
+                # to work around issue #11168
+                for key in list(stepValue['input']):
+                    if key not in input_keys:
+                        del stepValue['input'][key]
+                if len(stepValue['input']) > 1:
+                    raise Exception("more than one input value %s" % list(stepValue['input']))
+                else:
+                    logging.info("Input values with empty tags found. They will be ignored.")
+            if list(stepValue['input'].keys())[0] in input_keys:
+                stepValue['input'] = convertInput(stepValue['input'][list(stepValue['input'])[0]])
+            else:
+                raise Exception("Unknow iput key %s" % list(stepValue['input']))
 
     if "output" in stepValue:
         # remove output module name layer


### PR DESCRIPTION
Fixes #11168 
From the agent side at least, by ignoring wrongly created entries in the XML framework job report (with empty tags) from some 12.x CMSSW releases but still accounting for the good ones.

#### Status
ready
Tested on vocms0283 which uses 2.0.2.patch1

#### Description
If input.source has inputs with empty tags (produced by CMSSW releases without this patch: https://github.com/cms-sw/cmssw/pull/38019), we ignore those keys, but continue with the good ones.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
https://github.com/cms-sw/cmssw/pull/38019
This is the final fix from CMSSW. These are applied by CMSSW releases CMSSW_12_2_4_patch1 and older and they don't present this bug in the XML job reports. The work around here is for earlier releases when used.

#### External dependencies / deployment changes
<Does it require deployment changes? Does it rely on third-party libraries?>
