### PR TITLE
Load credentials when saving spec file in local workqueue

### DIFF
--- a/src/python/WMCore/Services/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/Services/WorkQueue/WorkQueue.py
@@ -239,7 +239,7 @@ class WorkQueue(object):
         # Update the spec, if it exists
         if self.db.documentExists(wf):
             wmspec = WMWorkloadHelper()
-            wmspec.load(self.db['host'] + "/%s/%s/spec" % (self.db.name, wf))
+            wmspec.load(self.hostWithAuth + "/%s/%s/spec" % (self.db.name, wf))
             wmspec.setPriority(priority)
             dummy_values = {'name': wmspec.name()}
             wmspec.saveCouch(self.hostWithAuth, self.db.name, dummy_values)


### PR DESCRIPTION
Fixes #11203 

#### Status
ready

#### Description
We create a brand new object of `CouchServer` in the call to `wmspec.load()`. So make sure that credentials are passed to that method when creating it, otherwise it fails to write to the localhost database.

#### Is it backward compatible (if not, which system it affects?)
YES (but should be tested in central services as well)

#### Related PRs
Complement to https://github.com/dmwm/WMCore/issues/11044

#### External dependencies / deployment changes
None
