### PR TITLE
Move some Rucio utils over to RucioUtils module

### DIFF
--- a/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
+++ b/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
@@ -18,7 +18,8 @@ from pprint import pformat
 from Utils.MemoryCache import MemoryCache
 from Utils.Timers import timeFunction
 from WMCore.DAOFactory import DAOFactory
-from WMCore.Services.Rucio.Rucio import Rucio, WMRucioException, RUCIO_VALID_PROJECT
+from WMCore.Services.Rucio.Rucio import Rucio, WMRucioException
+from WMCore.Services.Rucio.RucioUtils import RUCIO_VALID_PROJECT
 from WMCore.WMException import WMException
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 from Utils.IteratorTools import grouper

--- a/src/python/WMCore/MicroService/MSTransferor/DataStructs/DQMHarvestWorkflow.py
+++ b/src/python/WMCore/MicroService/MSTransferor/DataStructs/DQMHarvestWorkflow.py
@@ -6,7 +6,7 @@ with in the input data placement (MSTransferor)
 """
 
 from WMCore.MicroService.MSTransferor.DataStructs.Workflow import Workflow
-from WMCore.Services.Rucio.Rucio import GROUPING_ALL
+from WMCore.Services.Rucio.RucioUtils import GROUPING_ALL
 
 
 class DQMHarvestWorkflow(Workflow):

--- a/src/python/WMCore/MicroService/MSTransferor/DataStructs/GrowingWorkflow.py
+++ b/src/python/WMCore/MicroService/MSTransferor/DataStructs/GrowingWorkflow.py
@@ -6,7 +6,7 @@ with in the input data placement (MSTransferor)
 """
 
 from WMCore.MicroService.MSTransferor.DataStructs.Workflow import Workflow
-from WMCore.Services.Rucio.Rucio import GROUPING_DSET
+from WMCore.Services.Rucio.RucioUtils import GROUPING_DSET
 
 
 class GrowingWorkflow(Workflow):

--- a/src/python/WMCore/MicroService/MSTransferor/DataStructs/RelValWorkflow.py
+++ b/src/python/WMCore/MicroService/MSTransferor/DataStructs/RelValWorkflow.py
@@ -6,7 +6,7 @@ have to be dealt with in the input data placement (MSTransferor)
 """
 
 from WMCore.MicroService.MSTransferor.DataStructs.Workflow import Workflow
-from WMCore.Services.Rucio.Rucio import GROUPING_ALL
+from WMCore.Services.Rucio.RucioUtils import GROUPING_ALL
 
 
 class RelValWorkflow(Workflow):

--- a/src/python/WMCore/MicroService/MSTransferor/DataStructs/Workflow.py
+++ b/src/python/WMCore/MicroService/MSTransferor/DataStructs/Workflow.py
@@ -10,7 +10,7 @@ from future.utils import viewitems, viewvalues, listvalues
 from copy import copy, deepcopy
 from WMCore.DataStructs.LumiList import LumiList
 from WMCore.MicroService.Tools.Common import getMSLogger
-from WMCore.Services.Rucio.Rucio import GROUPING_DSET, GROUPING_ALL
+from WMCore.Services.Rucio.RucioUtils import GROUPING_DSET, GROUPING_ALL
 
 
 class Workflow(object):

--- a/src/python/WMCore/Services/Rucio/RucioUtils.py
+++ b/src/python/WMCore/Services/Rucio/RucioUtils.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This module contains a few basic WMCore-related utilitarian
+Rucio data structures and functions
+"""
+
+import random
+
+RUCIO_VALID_PROJECT = ("Production", "RelVal", "Tier0", "Test", "User")
+# grouping values are extracted from:
+# https://github.com/rucio/rucio/blob/master/lib/rucio/common/schema/cms.py#L117
+GROUPING_DSET = "DATASET"
+GROUPING_ALL = "ALL"
+
+
+def validateMetaData(did, metaDict, logger):
+    """
+    This function can be extended in the future, for now it will only
+    validate the DID creation metadata, more specifically only the
+    "project" parameter
+    :param did: the DID that will be inserted
+    :param metaDict: a dictionary with all the DID metadata data to be inserted
+    :param logger: a logger object
+    :return: False if validation fails, otherwise True
+    """
+    if metaDict.get("project", "Production") in RUCIO_VALID_PROJECT:
+        return True
+    msg = f"DID: {did} has an invalid 'project' meta-data value: {metaDict['project']}"
+    msg += f"The supported 'project' values are: {str(RUCIO_VALID_PROJECT)}"
+    logger.error(msg)
+    return False
+
+
+def weightedChoice(rses, rseWeights):
+    """
+    Given a list of items and their respective weights (quota in this case),
+    perform a weighted selection.
+    :param rses: a list of tuples with the RSE name and whether it requires approval
+    :param rseWeights: a list with RSE weights (quota)
+    :return: a tuple from the choices list
+    """
+    listChoice = random.choices(population=rses, weights=rseWeights, k=1)
+    # return only the tuple, not the list with a tuple item
+    return listChoice[0]
+
+
+def isTapeRSE(rseName):
+    """
+    Given an RSE name, return True if it's a Tape RSE (rse_type=TAPE), otherwise False
+    :param rseName: string with the RSE name
+    :return: True or False
+    """
+    # NOTE: a more reliable - but more expensive - way to know that would be
+    # to query `get_rse` and evaluate the rse_type parameter
+    return rseName.endswith("_Tape")
+
+
+def dropTapeRSEs(listRSEs):
+    """
+    Method to parse a list of RSE names and return only those that
+    are not a rse_type=TAPE, so in general only Disk endpoints
+    :param listRSEs: list with the RSE names
+    :return: a new list with only DISK RSE names
+    """
+    diskRSEs = []
+    for rse in listRSEs:
+        if isTapeRSE(rse):
+            continue
+        diskRSEs.append(rse)
+    return diskRSEs

--- a/test/python/WMCore_t/Services_t/Rucio_t/RucioUtils_t.py
+++ b/test/python/WMCore_t/Services_t/Rucio_t/RucioUtils_t.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+"""
+Unittests for ...
+"""
+import unittest
+
+class MyTestCase(unittest.TestCase):
+    def test_something(self):
+        self.assertEqual(True, False)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/WMCore_t/Services_t/Rucio_t/RucioUtils_t.py
+++ b/test/python/WMCore_t/Services_t/Rucio_t/RucioUtils_t.py
@@ -1,12 +1,85 @@
 #!/usr/bin/env python
 """
-Unittests for ...
+Unittests for the Services/Rucio/RucioUtils module
 """
+import logging
 import unittest
 
-class MyTestCase(unittest.TestCase):
-    def test_something(self):
-        self.assertEqual(True, False)
+from WMCore.Services.Rucio.RucioUtils import (RUCIO_VALID_PROJECT, validateMetaData,
+                                              isTapeRSE, dropTapeRSEs, weightedChoice)
+
+
+class RucioUtilsTest(unittest.TestCase):
+    """
+    Test class for the RucioUtils module
+    """
+
+    def setUp(self):
+        """
+        Setup for unit tests
+        """
+        self.logger = logging.getLogger()
+
+    def tearDown(self):
+        """
+        Nothing to be done for this case
+        """
+
+    def testMetaDataValidation(self):
+        """
+        Test the `validateMetaData` validation function
+        """
+        for thisProj in RUCIO_VALID_PROJECT:
+            response = validateMetaData("any_DID_name", dict(project=thisProj), self.logger)
+            self.assertTrue(response)
+
+        # test with no "project" meta data at all
+        response = validateMetaData("any_DID_name", {}, self.logger)
+        self.assertTrue(response)
+
+        # now an invalid "project" meta data
+        response = validateMetaData("any_DID_name", {"project": "mistake"}, self.logger)
+        self.assertFalse(response)
+
+    def testWeightedChoice(self):
+        """
+        Test the `weightedChoice` utilitarian function
+        """
+        pickDistr = {"CERN": 0, "FNAL": 0, "KIT": 0}
+        rsesWithApproval = []
+        rsesWeight = []
+        for idx, rseName in enumerate(pickDistr):
+            rsesWithApproval.append((rseName, False))
+            rsesWeight.append((idx * 10) + 10)
+
+        for _ in range(11):
+            rse = weightedChoice(rsesWithApproval, rsesWeight)[0]
+            pickDistr[rse] += 1
+        # it's not a reproducible distribution, so just assume
+        # that CERN is barely selected
+        self.assertTrue(pickDistr["CERN"] <= 2)
+
+    def testIsTapeRSE(self):
+        """
+        Test the `isTapeRSE` utilitarian function
+        """
+        self.assertTrue(isTapeRSE("T1_US_FNAL_Tape"))
+        self.assertFalse(isTapeRSE("T1_US_FNAL_Disk"))
+        self.assertFalse(isTapeRSE("T1_US_FNAL_Disk_Test"))
+        self.assertFalse(isTapeRSE("T1_US_FNAL_Tape_Test"))
+        self.assertFalse(isTapeRSE(""))
+
+    def testDropTapeRSEs(self):
+        """
+        Test the `dropTapeRSEs` utilitarian function
+        """
+        tapeOnly = ["T1_US_FNAL_Tape", "T1_ES_PIC_Tape"]
+        diskOnly = ["T1_US_FNAL_Disk", "T1_US_FNAL_Disk_Test", "T2_CH_CERN"]
+        mixed = ["T1_US_FNAL_Tape", "T1_US_FNAL_Disk", "T1_US_FNAL_Disk_Test", "T1_ES_PIC_Tape"]
+        self.assertCountEqual(dropTapeRSEs(tapeOnly), [])
+        self.assertCountEqual(dropTapeRSEs(diskOnly), diskOnly)
+        self.assertCountEqual(dropTapeRSEs(mixed), ["T1_US_FNAL_Disk", "T1_US_FNAL_Disk_Test"])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
+++ b/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
@@ -4,16 +4,14 @@ Test case for Rucio WMCore Service class
 """
 from __future__ import print_function, division, absolute_import
 
-from builtins import range
-from future.utils import viewitems
-
 import os
+from builtins import range
 
+from future.utils import viewitems
 from nose.plugins.attrib import attr
 from rucio.client import Client as testClient
 
 from Utils.PythonVersion import PY3
-
 from WMCore.Services.Rucio import Rucio
 from WMQuality.Emulators.EmulatedUnitTestCase import EmulatedUnitTestCase
 
@@ -224,7 +222,7 @@ class RucioTest(EmulatedUnitTestCase):
         for item in res:
             self.assertTrue(len(item['replica']) > 0)
 
-        #Setting  deep=True should yield the same results
+        # Setting  deep=True should yield the same results
         res = self.myRucio.getReplicaInfoForBlocks(dataset=DSET, deep=True)
         self.assertTrue(isinstance(res, list))
         self.assertTrue(len(res) >= 1)  # Again, there are 11 replicas
@@ -271,8 +269,8 @@ class RucioTest(EmulatedUnitTestCase):
         resp = self.myRucio.getPFN(site="T2_US_Nebraska", lfns=lfn1, protocol='gsiftp')
         self.assertEqual(resp[lfn1],
                          "gsiftp://red-gridftp.unl.edu:2811/mnt/hadoop/user/uscms01/pnfs/unl.edu/data4/cms/store/test/rucio/int" + lfn1)
-        #resp = self.myRucio.getPFN(site="T2_US_Nebraska", lfns=lfn1, protocol='xrootd')
-        #self.assertEqual(resp[lfn1], "davs://xrootd-local.unl.edu:1094/store/test/rucio/int" + lfn1)
+        # resp = self.myRucio.getPFN(site="T2_US_Nebraska", lfns=lfn1, protocol='xrootd')
+        # self.assertEqual(resp[lfn1], "davs://xrootd-local.unl.edu:1094/store/test/rucio/int" + lfn1)
 
     @attr('integration')
     def testProdGetPFN(self):
@@ -365,22 +363,6 @@ class RucioTest(EmulatedUnitTestCase):
         res = self.myRucio.getRule("eb4448a33f8f4c3e8d162be42e7a2eb1")
         self.assertTrue(res)
 
-    def testMetaDataValidation(self):
-        """
-        Test the `validateMetaData` validation function
-        """
-        for thisProj in Rucio.RUCIO_VALID_PROJECT:
-            response = Rucio.validateMetaData("any_DID_name", dict(project=thisProj), self.myRucio.logger)
-            self.assertTrue(response)
-
-        # test with no "project" meta data at all
-        response = Rucio.validateMetaData("any_DID_name", dict(), self.myRucio.logger)
-        self.assertTrue(response)
-
-        # now an invalid "project" meta data
-        response = Rucio.validateMetaData("any_DID_name", dict(project="mistake"), self.myRucio.logger)
-        self.assertFalse(response)
-
     def testListParentDIDs(self):
         """
         Test `listParentDIDs` method, which lists the parent DIDs
@@ -431,27 +413,6 @@ class RucioTest(EmulatedUnitTestCase):
         self.assertTrue(resp)
         resp = self.myRucio.requiresApproval("T1_IT_CNAF_Tape_Input")
         self.assertFalse(resp)
-
-    def testIsTapeRSE(self):
-        """
-        Test the `isTapeRSE` utilitarian function
-        """
-        self.assertTrue(Rucio.isTapeRSE("T1_US_FNAL_Tape"))
-        self.assertFalse(Rucio.isTapeRSE("T1_US_FNAL_Disk"))
-        self.assertFalse(Rucio.isTapeRSE("T1_US_FNAL_Disk_Test"))
-        self.assertFalse(Rucio.isTapeRSE("T1_US_FNAL_Tape_Test"))
-        self.assertFalse(Rucio.isTapeRSE(""))
-
-    def testDropTapeRSEs(self):
-        """
-        Test the `dropTapeRSEs` utilitarian function
-        """
-        tapeOnly = ["T1_US_FNAL_Tape", "T1_ES_PIC_Tape"]
-        diskOnly = ["T1_US_FNAL_Disk", "T1_US_FNAL_Disk_Test", "T2_CH_CERN"]
-        mixed = ["T1_US_FNAL_Tape", "T1_US_FNAL_Disk", "T1_US_FNAL_Disk_Test", "T1_ES_PIC_Tape"]
-        self.assertItemsEqual(Rucio.dropTapeRSEs(tapeOnly), [])
-        self.assertItemsEqual(Rucio.dropTapeRSEs(diskOnly), diskOnly)
-        self.assertItemsEqual(Rucio.dropTapeRSEs(mixed), ["T1_US_FNAL_Disk", "T1_US_FNAL_Disk_Test"])
 
     @attr('integration')  # jenkins cannot access this rucio account
     def testGetPileupLockedAndAvailable(self):
@@ -509,4 +470,3 @@ class RucioTest(EmulatedUnitTestCase):
         # there are no rules for the blocks, but 6 copies for the container level
         resp = prodRucio.getDataLockedAndAvailable(name=BLOCK2, account="transfer_ops", grouping="DATASET")
         self.assertItemsEqual(resp, [])
-


### PR DESCRIPTION
Fixes #11217 

#### Status
ready

#### Description
This PR does not add any new code and/or logic, it simply moves some constants and functions from Services/Rucio to Services/RucioUtils new module.

#### Is it backward compatible (if not, which system it affects?)
NO (external clients will need to update their import, if needed)

#### Related PRs
None

#### External dependencies / deployment changes
None
