### PR TITLE
Allow list of multiple architectures

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/BasePlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/BasePlugin.py
@@ -155,9 +155,7 @@ class BasePlugin(object):
     @staticmethod
     def scramArchtoRequiredArch(scramArch=None):
         """
-        Converts a given ScramArch to a unique target CPU architecture.
-        Note that an architecture precedence is enforced in case there are
-        multiple matches.
+        Converts a given ScramArch to a list of target CPU architectures.
         In case no scramArch is defined, leave the architecture undefined.
         :param scramArch: can be either a string or a list of ScramArchs
         :return: a string with the matched architecture
@@ -177,14 +175,9 @@ class BasePlugin(object):
                 raise BossAirPluginException(msg)
             requiredArchs.add(SCRAM_TO_ARCH.get(arch))
 
-        # now we have the final list of architectures, return only 1 of them
-        if len(requiredArchs) == 1:
-            return requiredArchs.pop()
-        elif "X86_64" in requiredArchs:
-            return "X86_64"
-        elif "ppc64le" in requiredArchs:
-            return "ppc64le"
-        elif "aarch64" in requiredArchs:
-            return "aarch64"
-        else:  # should never get here!
-            return defaultArch
+        # now we have the final list of architectures
+        archs = ",".join(requiredArchs)
+        if archs == '':
+            archs = defaultArch
+
+        return archs

--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -628,11 +628,11 @@ class SimpleCondorPlugin(BasePlugin):
             ad['My.REQUIRED_OS'] = classad.quote(encodeUnicodeToBytesConditional(requiredOSes, condition=PY2))
             cmsswVersions = ','.join(job.get('swVersion'))
             ad['My.CMSSW_Versions'] = classad.quote(encodeUnicodeToBytesConditional(cmsswVersions, condition=PY2))
-            requiredArch = self.scramArchtoRequiredArch(job.get('scramArch'))
-            if not requiredArch:  # only Cleanup jobs should not have ScramArch defined
+            requiredArchs = self.scramArchtoRequiredArch(job.get('scramArch'))
+            if not requiredArchs:  # only Cleanup jobs should not have ScramArch defined
                 ad['Requirements'] = '(TARGET.Arch =!= Undefined)'
             else:
-                ad['Requirements'] = '(TARGET.Arch =?= "{}")'.format(requiredArch)
+                ad['Requirements'] = 'stringListMember(TARGET.Arch, %s)' % classad.quote(str(requiredArchs))
 
             jobParameters.append(ad)    
              

--- a/test/python/WMCore_t/BossAir_t/BasePlugin_t.py
+++ b/test/python/WMCore_t/BossAir_t/BasePlugin_t.py
@@ -66,10 +66,15 @@ class BasePluginTest(BossAirTest):
             bp.scramArchtoRequiredArch("slc7_BLAH_gcc700")
 
         self.assertEqual(bp.scramArchtoRequiredArch(['slc5_amd64_gcc481', 'slc6_amd64_gcc630']), 'X86_64')
-        self.assertEqual(bp.scramArchtoRequiredArch(['slc7_amd64_gcc10', 'slc7_aarch64_gcc700']), 'X86_64')
-        self.assertEqual(bp.scramArchtoRequiredArch(
-                ['slc7_amd64_gcc10', 'slc7_aarch64_gcc700', 'slc7_ppc64le_gcc9']), 'X86_64')
-        self.assertEqual(bp.scramArchtoRequiredArch(['slc7_aarch64_gcc700', 'slc7_ppc64le_gcc9']), 'ppc64le')
+        test = (bp.scramArchtoRequiredArch(['slc7_amd64_gcc10', 'slc7_aarch64_gcc700'])).split(',')
+        test.sort()
+        self.assertEqual(test, ['X86_64','aarch64'])
+        test = (bp.scramArchtoRequiredArch(['slc7_amd64_gcc10', 'slc7_aarch64_gcc700', 'slc7_ppc64le_gcc9'])).split(',')
+        test.sort()
+        self.assertEqual(test, ['X86_64','aarch64','ppc64le'])
+        test = (bp.scramArchtoRequiredArch(['slc7_aarch64_gcc700', 'slc7_ppc64le_gcc9'])).split(',')
+        test.sort()
+        self.assertEqual(test, ['aarch64', 'ppc64le'])
 
         return
 


### PR DESCRIPTION
Fixes #10674

#### Status
In development

#### Description
- Modify condor requirements to allow multiple architectures
- Modify Scram class so that  executors match the target architecture
#### Is it backward compatible (if not, which system it affects?)
YES