### PR TITLE
Update CMSMonitoring version in the requirements file to 0.6.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@
 Cheetah3~=3.2.6.post1         # wmcore,wmagent,reqmgr2,reqmon
 CherryPy~=17.4.0              # wmcore,wmagent,wmagent-devtools,reqmgr2,reqmon,global-workqueue,reqmgr2ms
 CMSCouchapp~=1.3.4            # wmcore,wmagent
-CMSMonitoring~=0.6.4          # wmcore,wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms
+CMSMonitoring~=0.6.5          # wmcore,wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms
 coverage~=5.4                 # wmcore,wmagent,wmagent-devtools
 cx-Oracle~=7.3.0              # wmcore,wmagent
 dbs3-client~=4.0.8            # wmcore,wmagent,reqmgr2,reqmon,global-workqueue


### PR DESCRIPTION
Fixes #11215 

#### Status
ready

#### Description
I update the spec in cmsdist and closed the relevant #11215 issue, but forgot to update it in the list of requirements.txt.
So, here is a bump of the CMSMonitoring package to version 0.6.5

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
See issue for CMSMonitoring related PR.

#### External dependencies / deployment changes
None
