### PR TITLE
Add Keep-Alive HTTP header to all CouchDB requests

### DIFF
--- a/src/python/WMCore/Database/CMSCouch.py
+++ b/src/python/WMCore/Database/CMSCouch.py
@@ -125,6 +125,13 @@ class CouchDBRequests(JSONRequests):
         """
         incoming_headers = incoming_headers or {}
         incoming_headers.update(self.additionalHeaders)
+        # request to CouchDB should include keep-alive header to keep
+        # HTTP connection for requests which requires large data transfer
+        # see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Keep-Alive
+        if not ('keep-alive' in incoming_headers or 'Keep-Alive' in incoming_headers):
+            # we expect any request to complete in 2mins interval, therefore setup
+            # timeout=120 and max it to FE allowed one
+            incoming_headers.update({'Keep-Alive': 'timeout=120, max=300'})
         try:
             if not cache:
                 incoming_headers.update({'Cache-Control': 'no-cache'})


### PR DESCRIPTION
Fixes #11231 

#### Status
in development

#### Description
Since ReqMgr2 may request large chunk of data from CouchDB we should inform upstream server to keep alive HTTP connection, otherwise it may be closed by (I think) CherryPy server, see details in #11231 Therefore, I propose to setup `Keep-Alive` HTTP header for all CouchDB requests to some large meaningful interval. I do not know though how it may affect overall performance, but it should be fine if all connections are closed. If we have a leak of connections, then this may be a problem since we may end-up with open connection which may be accumulated under the high load. This should be verified during integration tests and by watching ReqMgr2 connection plots in ReqMgr2 monitoring [dashboard](https://monit-grafana.cern.ch/d/cmsweb_reqmgr/reqmgr2?orgId=11&refresh=1m).

#### Is it backward compatible (if not, which system it affects?)
MAYBE

#### Related PRs

#### External dependencies / deployment changes
