### PR TITLE
Datamap2

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+2.0.2.patch2 to 2.0.2.patch3:
+  - Check CMSSW version before getting sim-datatier map (germanfgv) #11118
+  - Fix redundant WHERE NOT EXISTS clause parameters for protecting from Unique constraints in ORACLE for DBS3Buffer/NewSubscriptions (Todor Ivanov) #11111
+
+
 2.0.2.patch1 to 2.0.2.patch2:
   - Update wmagent deploy script to add opportunistic resources one by one (Alan Malta Rodrigues) #11100
   - Support adding diskless resources into the database (Alan Malta Rodrigues) #11100

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+2.0.2.patch1 to 2.0.2.patch2:
+  - Update wmagent deploy script to add opportunistic resources one by one (Alan Malta Rodrigues) #11100
+  - Support adding diskless resources into the database (Alan Malta Rodrigues) #11100
+
+
 2.0.2 to 2.0.2.patch1:
   - Enhance logic to map ScramArch to OS (Alan Malta Rodrigues) #11090
   - When ScramArch is empty str/list/None, return any as required_os (Alan Malta Rodrigues) #11090

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,10 @@
+2.0.2 to 2.0.2.patch1:
+  - Enhance logic to map ScramArch to OS (Alan Malta Rodrigues) #11090
+  - When ScramArch is empty str/list/None, return any as required_os (Alan Malta Rodrigues) #11090
+  - If job requires rhel8 container, use slc7 python libraries (Alan Malta Rodrigues) #11090
+  - Assign the correct activity for Tape_Test RSEs (Jhonatan Amado) #11090
+
+
 2.0.2.pre4 to 2.0.2:
 
 

--- a/bin/wmagent-resource-control
+++ b/bin/wmagent-resource-control
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 wmagent-resource-control
 
@@ -64,6 +64,8 @@ def createOptionParser():
                              help="Add all of the CMS sites to resource control.")
     myOptParser.add_argument("--add-one-site", dest="addOneSite",
                              help="Specify site name you want to add")
+    myOptParser.add_argument("--opportunistic", dest="opportunistic", default=False, action="store_true",
+                             help="To be used with addOneSite, specifying to use the same CPU/storage name.")
     myOptParser.add_argument("--site-name", dest="siteName",
                              help="Specify the unique name of the location")
     myOptParser.add_argument("--pending-slots", dest="pendingSlots",
@@ -345,7 +347,11 @@ else:
                  options.pendingSlots, options.runningSlots, state=options.state)
         addPNNs(myResourceControl, pattern=pattern)
     elif options.addOneSite:
-        oneSite = getCMSSiteInfo(options.addOneSite)
+        if options.opportunistic:
+            # it's a dict key'ed by the CPU resource and value is the storage name
+            oneSite = {options.addOneSite: [options.addOneSite]}
+        else:
+            oneSite = getCMSSiteInfo(options.addOneSite)
         addSites(myResourceControl, oneSite, options.ceName, options.plugin,
                  options.pendingSlots, options.runningSlots, state=options.state)
     elif options.siteName is None:

--- a/etc/submit_py3.sh
+++ b/etc/submit_py3.sh
@@ -54,6 +54,7 @@ PY3_FUTURE_VERSION=0.18.2
 # Saving START_TIME and when job finishes END_TIME.
 WMA_MIN_JOB_RUNTIMESECS=300
 START_TIME=$(date +%s)
+WMA_DEFAULT_OS=rhel7
 # assign arguments
 SANDBOX=$1
 INDEX=$2
@@ -132,20 +133,17 @@ echo "======== WMAgent COMP Python bootstrap starting at $(TZ=GMT date) ========
 # slc6_ppc64le_gcc493 (from CMSSW): py2-future/0.18.2 python/2.7.15 py3-future/0.18.2 python3/3.8.2
 #
 # NOTE: all the ppc64le ScramArchs are actually pointing to: slc7_ppc64le_gcc820
+### UPDATE on 11 April, 2022: See a new map of CVMFS packages in:
+# https://github.com/dmwm/WMCore/pull/11077#issuecomment-1094814966
+
 # First, decide which COMP ScramArch to use based on the required OS and Architecture
 THIS_ARCH=`uname -m`  # if it's PowerPC, it returns `ppc64le`
-if [ "$THIS_ARCH" = "x86_64" ]
+# if this job can run at any OS, then use rhel7 as default
+if [ "$REQUIRED_OS" = "any" ]
 then
-    THIS_ARCH="amd64"
-fi
-if [ "$REQUIRED_OS" = "rhel7" ]
-then
-    WMA_SCRAM_ARCH=slc7_${THIS_ARCH}_gcc630
-elif [ "$THIS_ARCH" = "amd64" ]
-then
-    WMA_SCRAM_ARCH=slc6_${THIS_ARCH}_gcc700
+    WMA_SCRAM_ARCH=${WMA_DEFAULT_OS}_${THIS_ARCH}
 else
-    WMA_SCRAM_ARCH=slc6_${THIS_ARCH}_gcc493
+    WMA_SCRAM_ARCH=${REQUIRED_OS}_${THIS_ARCH}
 fi
 echo "Job requires OS: $REQUIRED_OS, thus setting ScramArch to: $WMA_SCRAM_ARCH"
 

--- a/src/python/WMComponent/DBS3Buffer/Oracle/NewSubscription.py
+++ b/src/python/WMComponent/DBS3Buffer/Oracle/NewSubscription.py
@@ -30,6 +30,5 @@ class NewSubscription(MySQLNewSubscription):
                  AND custodial = :custodial
                  AND auto_approve = :auto_approve
                  AND move = :move
-                 AND priority = :priority
-                 AND dataset_lifetime = :dataset_lifetime )
+                 AND priority = :priority )
              """

--- a/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
+++ b/src/python/WMComponent/RucioInjector/RucioInjectorPoller.py
@@ -465,7 +465,7 @@ class RucioInjectorPoller(BaseWorkerThread):
                               grouping="ALL",
                               comment=ruleComment,
                               meta=self.metaData)
-            if not rseName.endswith("_Tape"):
+            if not rseName.endswith(("_Tape", "_Tape_Test")):
                 # add extra parameters to the Disk rule as defined in the component configuration
                 ruleKwargs.update(self.containerDiskRuleParams)
 
@@ -529,7 +529,7 @@ class RucioInjectorPoller(BaseWorkerThread):
         """
         if not self.isT0agent and not rseName.endswith("_Tape"):
             return "Production Output"
-        elif self.isT0agent and rseName.endswith("_Tape"):
+        elif self.isT0agent and rseName.endswith(("_Tape", "_Tape_Test")):
             return "T0 Tape"
         elif self.isT0agent:
             return "T0 Export"

--- a/src/python/WMCore/BossAir/Plugins/BasePlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/BasePlugin.py
@@ -6,7 +6,7 @@ Base class for BossAir plugins
 """
 
 from builtins import object, str, bytes
-from future.utils import viewitems, viewvalues
+from future.utils import viewvalues
 
 from Utils.Utilities import decodeBytesToUnicode
 from WMCore.WMException import WMException
@@ -130,27 +130,25 @@ class BasePlugin(object):
     @staticmethod
     def scramArchtoRequiredOS(scramArch=None):
         """
+        Matches a ScramArch - or a list of it - against a map of Scram
+        to Operating System
 
-        Args:
-            scramArch: string or list of scramArches that are acceptable for the job
-
-        Returns:
-            string to be matched for OS requirements for job
+        :param scramArch: string or list of scramArches defined for a given job
+        :return: a string with the required OS to use
         """
-        requiredOSes = set()
+        defaultValue = 'any'
         if not scramArch:
-            requiredOSes.add('any')
-        elif isinstance(scramArch, (str, bytes)):
-            for arch, validOSes in viewitems(ARCH_TO_OS):
-                if arch in scramArch:
-                    requiredOSes.update(validOSes)
-        elif isinstance(scramArch, list):
-            for validArch in scramArch:
-                for arch, validOSes in viewitems(ARCH_TO_OS):
-                    if arch in validArch:
-                        requiredOSes.update(validOSes)
-        else:
-            requiredOSes.add('any')
+            return defaultValue
+
+        requiredOSes = set()
+        if isinstance(scramArch, (str, bytes)):
+            scramArch = [scramArch]
+        elif not isinstance(scramArch, (list, tuple)):
+            return defaultValue
+
+        for validArch in scramArch:
+            scramOS = validArch.split("_")[0]
+            requiredOSes.update(ARCH_TO_OS.get(scramOS, []))
 
         return ','.join(sorted(requiredOSes))
 

--- a/src/python/WMCore/BossAir/Plugins/BasePlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/BasePlugin.py
@@ -138,7 +138,7 @@ class BasePlugin(object):
             string to be matched for OS requirements for job
         """
         requiredOSes = set()
-        if scramArch is None:
+        if not scramArch:
             requiredOSes.add('any')
         elif isinstance(scramArch, (str, bytes)):
             for arch, validOSes in viewitems(ARCH_TO_OS):

--- a/src/python/WMCore/Services/WMArchive/DataMap.py
+++ b/src/python/WMCore/Services/WMArchive/DataMap.py
@@ -6,6 +6,7 @@ from future.utils import viewitems, listvalues, listitems
 import copy
 import socket
 from collections import defaultdict
+import logging
 
 # From top level
 
@@ -270,16 +271,21 @@ def convertStepValue(stepValue):
         if not stepValue['input']:
             # if empty convert to list from {}
             stepValue['input'] = []
-
-        elif len(stepValue['input']) > 1:
-            # assume only one input value
-            raise Exception("more than one input value %s" % list(stepValue['input']))
-
-        elif list(stepValue['input'].keys())[0] in input_keys:
-            stepValue['input'] = convertInput(stepValue['input'][list(stepValue['input'])[0]])
-
         else:
-            raise Exception("Unknow iput key %s" % list(stepValue['input']))
+            if len(stepValue['input']) > 1:
+                # skip input values that are not in input_keys
+                # to work around issue #11168
+                for key in list(stepValue['input']):
+                    if key not in input_keys:
+                        del stepValue['input'][key]
+                if len(stepValue['input']) > 1:
+                    raise Exception("more than one input value %s" % list(stepValue['input']))
+                else:
+                    logging.info("Input values with empty tags found. They will be ignored.")
+            if list(stepValue['input'].keys())[0] in input_keys:
+                stepValue['input'] = convertInput(stepValue['input'][list(stepValue['input'])[0]])
+            else:
+                raise Exception("Unknow iput key %s" % list(stepValue['input']))
 
     if "output" in stepValue:
         # remove output module name layer

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -14,6 +14,7 @@ import json
 from Utils.PythonVersion import PY3
 from Utils.Utilities import decodeBytesToUnicodeConditional
 from Utils.Utilities import makeList, makeNonEmptyList, strToBool, safeStr
+from WMCore.WMRuntime.Tools.Scram import isCMSSWSupported
 from WMCore.Cache.WMConfigCache import ConfigCache, ConfigCacheException
 from WMCore.Lexicon import (couchurl, procstring, activity, procversion, primdataset,
                             gpuParameters, lfnBase, identifier, acqname, cmsname,
@@ -160,7 +161,7 @@ class StdBase(object):
         command += "cd %s\n" % scramBaseDirs[0]
         command += "eval `scramv1 runtime -sh`\n"
 
-        if PY3:
+        if isCMSSWSupported(cmsswVersion, "CMSSW_10_3_0"):
             command += """python3 -c 'from Configuration.StandardSequences.Skims_cff import getSkimDataTier\n"""
         else:
             command += """python -c 'from Configuration.StandardSequences.Skims_cff import getSkimDataTier\n"""

--- a/src/python/WMCore/__init__.py
+++ b/src/python/WMCore/__init__.py
@@ -6,5 +6,5 @@ Core libraries for Workload Management Packages
 
 """
 
-__version__ = '2.0.2.patch2'
+__version__ = '2.0.2.patch3'
 __all__ = []

--- a/src/python/WMCore/__init__.py
+++ b/src/python/WMCore/__init__.py
@@ -6,5 +6,5 @@ Core libraries for Workload Management Packages
 
 """
 
-__version__ = '2.0.2'
+__version__ = '2.0.2.patch1'
 __all__ = []

--- a/src/python/WMCore/__init__.py
+++ b/src/python/WMCore/__init__.py
@@ -6,5 +6,5 @@ Core libraries for Workload Management Packages
 
 """
 
-__version__ = '2.0.2.patch1'
+__version__ = '2.0.2.patch2'
 __all__ = []


### PR DESCRIPTION
Fixes #11168 
For branch 2.0.4 (since we a re still getting workflows injected with this buggy CMSSW version)

From the agent side at least, by ignoring wrongly created entries in the XML framework job report (with empty tags) from some 12.x CMSSW releases but still accounting for the good ones.

Status
ready
Tested on vocms0283 which uses 2.0.2.patch1

Description
If input.source has inputs with empty tags (produced by CMSSW releases without this patch: https://github.com/cms-sw/cmssw/pull/38019), we ignore those keys, but continue with the good ones.

Is it backward compatible (if not, which system it affects?)
YES

Related PRs
https://github.com/dmwm/WMCore/pull/11198

https://github.com/cms-sw/cmssw/pull/38019
This is the final fix from CMSSW. These are applied by CMSSW releases CMSSW_12_2_4_patch1 and older and they don't present this bug in the XML job reports. The work around here is for earlier releases when used.

External dependencies / deployment changes
<Does it require deployment changes? Does it rely on third-party libraries?>