### PR TITLE
Changes to support gzip compression in REST APIs

### DIFF
--- a/src/python/WMCore/REST/Server.py
+++ b/src/python/WMCore/REST/Server.py
@@ -36,7 +36,8 @@ _RX_CENSOR = re.compile(r"(identified by) \S+", re.I)
 _COMPRESSIBLE = ['text/html', 'text/html; charset=utf-8',
                  'text/plain', 'text/plain; charset=utf-8',
                  'text/css', 'text/css; charset=utf-8',
-                 'text/javascript', 'text/javascript; charset=utf-8']
+                 'text/javascript', 'text/javascript; charset=utf-8',
+                 'application/json']
 
 #: Type alias for arguments passed to REST validation methods, consisting
 #: of `args`, the additional path arguments, and `kwargs`, the query
@@ -836,6 +837,8 @@ class MiniRESTApi(object):
         # Format the response.
         response.headers['X-REST-Status'] = 100
         response.headers['Content-Type'] = format
+        if cherrypy.request.headers.get('Accept-Encoding', '') == 'gzip':
+            return obj
         etagger = apiobj.get('etagger', None) or SHA1ETag()
         reply = stream_compress(fmthandler(obj, etagger),
                                 apiobj.get('compression', self.compression),

--- a/test/python/WMCore_t/MicroService_t/MicroService_t.py
+++ b/test/python/WMCore_t/MicroService_t/MicroService_t.py
@@ -83,6 +83,10 @@ class MicroServiceTest(unittest.TestCase):
         url = '%s/%s' % (self.url, api)
         params = {}
         data = self.mgr.getdata(url, params=params, encode=True, decode=True)
+        if isinstance(data, bytes):
+            data = data.decode("utf-8")
+            print("### data=", data, "type(data)=", type(data))
+            data = json.loads(data)
         if 'result' in data:
             self.assertEqual(data['result'][0]['microservice'], self.managerName)
             self.assertEqual(data['result'][0]['api'], api)
@@ -107,6 +111,10 @@ class MicroServiceTest(unittest.TestCase):
         url = '%s/%s' % (self.url, api)
         params = {}
         data = self.mgr.getdata(url, params=params, encode=True, decode=True)
+        if isinstance(data, bytes):
+            data = data.decode("utf-8")
+            print("### data=", data, "type(data)=", type(data))
+            data = json.loads(data)
         if 'result' in data:
             self.assertEqual(data['result'][0]['microservice'], self.managerName)
             self.assertEqual(data['result'][0]['api'], api)

--- a/test/python/WMCore_t/MicroService_t/MicroService_t.py
+++ b/test/python/WMCore_t/MicroService_t/MicroService_t.py
@@ -7,6 +7,8 @@ Author: Valentin Kuznetsov <vkuznet [AT] gmail [DOT] com>
 from __future__ import division, print_function
 
 import unittest
+import json
+import gzip
 
 import cherrypy
 from WMCore_t.MicroService_t import TestConfig
@@ -80,28 +82,86 @@ class MicroServiceTest(unittest.TestCase):
         api = "status"
         url = '%s/%s' % (self.url, api)
         params = {}
-        data = self.mgr.getdata(url, params=params, encode=True, decode=True)
-        self.assertEqual(data['result'][0]['microservice'], self.managerName)
-        self.assertEqual(data['result'][0]['api'], api)
+        # perform check with and without gzip encoding
+        for hdr in ['', 'gzip']:
+            headers = {'Accept-Encoding': hdr}
+            data = self.mgr.getdata(url, params=params, headers=headers, encode=True, decode=True)
+            # check if our data is returned as bytes (gzip encoding)
+            if isinstance(data, bytes) and hdr == 'gzip':
+                data = gzip.decompress(data)
+                if isinstance(data, bytes):
+                    data = data.decode("utf-8")
+                data = json.loads(data)
+            print("### testGetStatus, headers=", headers, "data=", data, type(data))
+            # check that result key is present in data
+            if 'result' in data:
+                self.assertEqual(data['result'][0]['microservice'], self.managerName)
+                self.assertEqual(data['result'][0]['api'], api)
+            else:
+                print("### result is not present in data")
+                print(data)
+                self.assertEqual('result' in data, True)
 
-        params = {"service": "transferor"}
-        data = self.mgr.getdata(url, params=params, encode=True, decode=True)
-        self.assertEqual(data['result'][0]['microservice'], self.managerName)
-        self.assertEqual(data['result'][0]['api'], api)
+            params = {"service": "transferor"}
+            data = self.mgr.getdata(url, params=params, headers=headers, encode=True, decode=True)
+            # check if our data is returned as bytes (gzip encoding)
+            if isinstance(data, bytes) and hdr == 'gzip':
+                data = gzip.decompress(data)
+                if isinstance(data, bytes):
+                    data = data.decode("utf-8")
+                data = json.loads(data)
+            print("### testGetStatus, headers=", headers, "data=", data, type(data))
+            # check that result key is present in data
+            if 'result' in data:
+                self.assertEqual(data['result'][0]['microservice'], self.managerName)
+                self.assertEqual(data['result'][0]['api'], api)
+            else:
+                print("### result is not present in data")
+                print(data)
+                self.assertEqual('result' in data, True)
 
     def testGetInfo(self):
         "Test function for getting state of the MicroService"
         api = "status"
         url = '%s/%s' % (self.url, api)
         params = {}
-        data = self.mgr.getdata(url, params=params, encode=True, decode=True)
-        self.assertEqual(data['result'][0]['microservice'], self.managerName)
-        self.assertEqual(data['result'][0]['api'], api)
+        # perform check with and without gzip encoding
+        for hdr in ['', 'gzip']:
+            headers = {'Accept-Encoding': hdr}
+            data = self.mgr.getdata(url, params=params, headers=headers, encode=True, decode=True)
+            # check if our data is returned as bytes (gzip encoding)
+            if isinstance(data, bytes) and hdr == 'gzip':
+                data = gzip.decompress(data)
+                if isinstance(data, bytes):
+                    data = data.decode("utf-8")
+                data = json.loads(data)
+            print("### testGetInfo, headers=", headers, "data=", data, type(data))
+            # check that result key is present in data
+            if 'result' in data:
+                self.assertEqual(data['result'][0]['microservice'], self.managerName)
+                self.assertEqual(data['result'][0]['api'], api)
+            else:
+                print("### result is not present in data")
+                print(data)
+                self.assertEqual('result' in data, True)
 
-        params = {"request": "fake_request_name"}
-        data = self.mgr.getdata(url, params=params, encode=True, decode=True)
-        self.assertEqual(data['result'][0]['microservice'], self.managerName)
-        self.assertEqual(data['result'][0]['api'], api)
+            params = {"request": "fake_request_name"}
+            data = self.mgr.getdata(url, params=params, headers=headers, encode=True, decode=True)
+            # check if our data is returned as bytes (gzip encoding)
+            if isinstance(data, bytes) and hdr == 'gzip':
+                data = gzip.decompress(data)
+                if isinstance(data, bytes):
+                    data = data.decode("utf-8")
+                data = json.loads(data)
+            print("### testGetInfo, headers=", headers, "data=", data, type(data))
+            # check that result key is present in data
+            if 'result' in data:
+                self.assertEqual(data['result'][0]['microservice'], self.managerName)
+                self.assertEqual(data['result'][0]['api'], api)
+            else:
+                print("### result is not present in data")
+                print(data)
+                self.assertEqual('result' in data, True)
 
     def testPostCall(self):
         "Test function for getting state of the MicroService"

--- a/test/python/WMCore_t/MicroService_t/MicroService_t.py
+++ b/test/python/WMCore_t/MicroService_t/MicroService_t.py
@@ -82,11 +82,9 @@ class MicroServiceTest(unittest.TestCase):
         api = "status"
         url = '%s/%s' % (self.url, api)
         params = {}
-
-        # we should explicitly set Accept-Encoding to nil since
+        data = self.mgr.getdata(url, params=params, encode=True, decode=True)
         # pycurl_manager sets it by default to gzip, see
         # https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/Services/pycurl_manager.py#L226
-        data = self.mgr.getdata(url, params=params, encode=True, decode=True)
         if isinstance(data, bytes):
             data = gzip.decompress(data)
             if isinstance(data, bytes):
@@ -97,6 +95,13 @@ class MicroServiceTest(unittest.TestCase):
 
         params = {"service": "transferor"}
         data = self.mgr.getdata(url, params=params, encode=True, decode=True)
+        # pycurl_manager sets it by default to gzip, see
+        # https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/Services/pycurl_manager.py#L226
+        if isinstance(data, bytes):
+            data = gzip.decompress(data)
+            if isinstance(data, bytes):
+                data = data.decode("utf-8")
+            data = json.loads(data)
         self.assertEqual(data['result'][0]['microservice'], self.managerName)
         self.assertEqual(data['result'][0]['api'], api)
 
@@ -105,11 +110,9 @@ class MicroServiceTest(unittest.TestCase):
         api = "status"
         url = '%s/%s' % (self.url, api)
         params = {}
-
-        # we should explicitly set Accept-Encoding to nil since
+        data = self.mgr.getdata(url, params=params, encode=True, decode=True)
         # pycurl_manager sets it by default to gzip, see
         # https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/Services/pycurl_manager.py#L226
-        data = self.mgr.getdata(url, params=params, encode=True, decode=True)
         if isinstance(data, bytes):
             data = gzip.decompress(data)
             if isinstance(data, bytes):
@@ -120,6 +123,13 @@ class MicroServiceTest(unittest.TestCase):
 
         params = {"request": "fake_request_name"}
         data = self.mgr.getdata(url, params=params, encode=True, decode=True)
+        # pycurl_manager sets it by default to gzip, see
+        # https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/Services/pycurl_manager.py#L226
+        if isinstance(data, bytes):
+            data = gzip.decompress(data)
+            if isinstance(data, bytes):
+                data = data.decode("utf-8")
+            data = json.loads(data)
         self.assertEqual(data['result'][0]['microservice'], self.managerName)
         self.assertEqual(data['result'][0]['api'], api)
 

--- a/test/python/WMCore_t/MicroService_t/MicroService_t.py
+++ b/test/python/WMCore_t/MicroService_t/MicroService_t.py
@@ -83,8 +83,13 @@ class MicroServiceTest(unittest.TestCase):
         url = '%s/%s' % (self.url, api)
         params = {}
         data = self.mgr.getdata(url, params=params, encode=True, decode=True)
-        self.assertEqual(data['result'][0]['microservice'], self.managerName)
-        self.assertEqual(data['result'][0]['api'], api)
+        if 'result' in data:
+            self.assertEqual(data['result'][0]['microservice'], self.managerName)
+            self.assertEqual(data['result'][0]['api'], api)
+        else:
+            print("### data=", data, "type(data)=", type(data))
+            # we should not be here, let's assert
+            self.assertEqul(True, False)
 
         params = {"service": "transferor"}
         data = self.mgr.getdata(url, params=params, encode=True, decode=True)
@@ -102,8 +107,13 @@ class MicroServiceTest(unittest.TestCase):
         url = '%s/%s' % (self.url, api)
         params = {}
         data = self.mgr.getdata(url, params=params, encode=True, decode=True)
-        self.assertEqual(data['result'][0]['microservice'], self.managerName)
-        self.assertEqual(data['result'][0]['api'], api)
+        if 'result' in data:
+            self.assertEqual(data['result'][0]['microservice'], self.managerName)
+            self.assertEqual(data['result'][0]['api'], api)
+        else:
+            print("### data=", data, "type(data)=", type(data))
+            # we should not be here, let's assert
+            self.assertEqul(True, False)
 
         params = {"request": "fake_request_name"}
         data = self.mgr.getdata(url, params=params, encode=True, decode=True)

--- a/test/python/WMCore_t/MicroService_t/MicroService_t.py
+++ b/test/python/WMCore_t/MicroService_t/MicroService_t.py
@@ -88,8 +88,13 @@ class MicroServiceTest(unittest.TestCase):
 
         params = {"service": "transferor"}
         data = self.mgr.getdata(url, params=params, encode=True, decode=True)
-        self.assertEqual(data['result'][0]['microservice'], self.managerName)
-        self.assertEqual(data['result'][0]['api'], api)
+        if 'result' in data:
+            self.assertEqual(data['result'][0]['microservice'], self.managerName)
+            self.assertEqual(data['result'][0]['api'], api)
+        else:
+            print("### data=", data, "type(data)=", type(data))
+            # we should not be here, let's assert
+            self.assertEqul(True, False)
 
     def testGetInfo(self):
         "Test function for getting state of the MicroService"
@@ -102,8 +107,13 @@ class MicroServiceTest(unittest.TestCase):
 
         params = {"request": "fake_request_name"}
         data = self.mgr.getdata(url, params=params, encode=True, decode=True)
-        self.assertEqual(data['result'][0]['microservice'], self.managerName)
-        self.assertEqual(data['result'][0]['api'], api)
+        if 'result' in data:
+            self.assertEqual(data['result'][0]['microservice'], self.managerName)
+            self.assertEqual(data['result'][0]['api'], api)
+        else:
+            print("### data=", data, "type(data)=", type(data))
+            # we should not be here, let's assert
+            self.assertEqul(True, False)
 
     def testGetStatusGzip(self):
         "Test function for getting state of the MicroService"
@@ -125,8 +135,9 @@ class MicroServiceTest(unittest.TestCase):
             self.assertEqual(data['result'][0]['microservice'], self.managerName)
             self.assertEqual(data['result'][0]['api'], api)
         else:
-            print("### result is not present in data")
-            print(data)
+            print("### data=", data, "type(data)=", type(data))
+            # we should not be here, let's assert
+            self.assertEqul(True, False)
 
         params = {"service": "transferor"}
         data = self.mgr.getdata(url, params=params, headers=headers, encode=True, decode=True)
@@ -142,8 +153,9 @@ class MicroServiceTest(unittest.TestCase):
             self.assertEqual(data['result'][0]['microservice'], self.managerName)
             self.assertEqual(data['result'][0]['api'], api)
         else:
-            print("### result is not present in data")
-            print(data)
+            print("### data=", data, "type(data)=", type(data))
+            # we should not be here, let's assert
+            self.assertEqul(True, False)
 
     def testGetInfoGzip(self):
         "Test function for getting state of the MicroService"

--- a/test/python/WMCore_t/MicroService_t/MicroService_t.py
+++ b/test/python/WMCore_t/MicroService_t/MicroService_t.py
@@ -86,8 +86,12 @@ class MicroServiceTest(unittest.TestCase):
         # we should explicitly set Accept-Encoding to nil since
         # pycurl_manager sets it by default to gzip, see
         # https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/Services/pycurl_manager.py#L226
-        headers = {'Accept-Encoding': ''}
-        data = self.mgr.getdata(url, params=params, headers=headers, encode=True, decode=True)
+        data = self.mgr.getdata(url, params=params, encode=True, decode=True)
+        if isinstance(data, bytes):
+            data = gzip.decompress(data)
+            if isinstance(data, bytes):
+                data = data.decode("utf-8")
+            data = json.loads(data)
         self.assertEqual(data['result'][0]['microservice'], self.managerName)
         self.assertEqual(data['result'][0]['api'], api)
 
@@ -105,8 +109,12 @@ class MicroServiceTest(unittest.TestCase):
         # we should explicitly set Accept-Encoding to nil since
         # pycurl_manager sets it by default to gzip, see
         # https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/Services/pycurl_manager.py#L226
-        headers = {'Accept-Encoding': ''}
-        data = self.mgr.getdata(url, params=params, headers=headers, encode=True, decode=True)
+        data = self.mgr.getdata(url, params=params, encode=True, decode=True)
+        if isinstance(data, bytes):
+            data = gzip.decompress(data)
+            if isinstance(data, bytes):
+                data = data.decode("utf-8")
+            data = json.loads(data)
         self.assertEqual(data['result'][0]['microservice'], self.managerName)
         self.assertEqual(data['result'][0]['api'], api)
 
@@ -147,7 +155,7 @@ class MicroServiceTest(unittest.TestCase):
             if isinstance(data, bytes):
                 data = data.decode("utf-8")
             data = json.loads(data)
-        print("### testGetStatus, headers=", headers, "data=", data, type(data))
+        print("### testGetStatusGzip, headers=", headers, "data=", data, type(data))
         # check that result key is present in data
         if 'result' in data:
             self.assertEqual(data['result'][0]['microservice'], self.managerName)
@@ -171,7 +179,7 @@ class MicroServiceTest(unittest.TestCase):
             if isinstance(data, bytes):
                 data = data.decode("utf-8")
             data = json.loads(data)
-        print("### testGetInfo, headers=", headers, "data=", data, type(data))
+        print("### testGetInfoGZip, headers=", headers, "data=", data, type(data))
         # check that result key is present in data
         if 'result' in data:
             self.assertEqual(data['result'][0]['microservice'], self.managerName)

--- a/test/python/WMCore_t/MicroService_t/MicroService_t.py
+++ b/test/python/WMCore_t/MicroService_t/MicroService_t.py
@@ -82,86 +82,110 @@ class MicroServiceTest(unittest.TestCase):
         api = "status"
         url = '%s/%s' % (self.url, api)
         params = {}
-        # perform check with and without gzip encoding
-        for hdr in ['', 'gzip']:
-            headers = {'Accept-Encoding': hdr}
-            data = self.mgr.getdata(url, params=params, headers=headers, encode=True, decode=True)
-            # check if our data is returned as bytes (gzip encoding)
-            if isinstance(data, bytes) and hdr == 'gzip':
-                data = gzip.decompress(data)
-                if isinstance(data, bytes):
-                    data = data.decode("utf-8")
-                data = json.loads(data)
-            print("### testGetStatus, headers=", headers, "data=", data, type(data))
-            # check that result key is present in data
-            if 'result' in data:
-                self.assertEqual(data['result'][0]['microservice'], self.managerName)
-                self.assertEqual(data['result'][0]['api'], api)
-            else:
-                print("### result is not present in data")
-                print(data)
-                self.assertEqual('result' in data, True)
+        data = self.mgr.getdata(url, params=params, encode=True, decode=True)
+        self.assertEqual(data['result'][0]['microservice'], self.managerName)
+        self.assertEqual(data['result'][0]['api'], api)
 
-            params = {"service": "transferor"}
-            data = self.mgr.getdata(url, params=params, headers=headers, encode=True, decode=True)
-            # check if our data is returned as bytes (gzip encoding)
-            if isinstance(data, bytes) and hdr == 'gzip':
-                data = gzip.decompress(data)
-                if isinstance(data, bytes):
-                    data = data.decode("utf-8")
-                data = json.loads(data)
-            print("### testGetStatus, headers=", headers, "data=", data, type(data))
-            # check that result key is present in data
-            if 'result' in data:
-                self.assertEqual(data['result'][0]['microservice'], self.managerName)
-                self.assertEqual(data['result'][0]['api'], api)
-            else:
-                print("### result is not present in data")
-                print(data)
-                self.assertEqual('result' in data, True)
+        params = {"service": "transferor"}
+        data = self.mgr.getdata(url, params=params, encode=True, decode=True)
+        self.assertEqual(data['result'][0]['microservice'], self.managerName)
+        self.assertEqual(data['result'][0]['api'], api)
 
     def testGetInfo(self):
         "Test function for getting state of the MicroService"
         api = "status"
         url = '%s/%s' % (self.url, api)
         params = {}
-        # perform check with and without gzip encoding
-        for hdr in ['', 'gzip']:
-            headers = {'Accept-Encoding': hdr}
-            data = self.mgr.getdata(url, params=params, headers=headers, encode=True, decode=True)
-            # check if our data is returned as bytes (gzip encoding)
-            if isinstance(data, bytes) and hdr == 'gzip':
-                data = gzip.decompress(data)
-                if isinstance(data, bytes):
-                    data = data.decode("utf-8")
-                data = json.loads(data)
-            print("### testGetInfo, headers=", headers, "data=", data, type(data))
-            # check that result key is present in data
-            if 'result' in data:
-                self.assertEqual(data['result'][0]['microservice'], self.managerName)
-                self.assertEqual(data['result'][0]['api'], api)
-            else:
-                print("### result is not present in data")
-                print(data)
-                self.assertEqual('result' in data, True)
+        data = self.mgr.getdata(url, params=params, encode=True, decode=True)
+        self.assertEqual(data['result'][0]['microservice'], self.managerName)
+        self.assertEqual(data['result'][0]['api'], api)
 
-            params = {"request": "fake_request_name"}
-            data = self.mgr.getdata(url, params=params, headers=headers, encode=True, decode=True)
-            # check if our data is returned as bytes (gzip encoding)
-            if isinstance(data, bytes) and hdr == 'gzip':
-                data = gzip.decompress(data)
-                if isinstance(data, bytes):
-                    data = data.decode("utf-8")
-                data = json.loads(data)
-            print("### testGetInfo, headers=", headers, "data=", data, type(data))
-            # check that result key is present in data
-            if 'result' in data:
-                self.assertEqual(data['result'][0]['microservice'], self.managerName)
-                self.assertEqual(data['result'][0]['api'], api)
-            else:
-                print("### result is not present in data")
-                print(data)
-                self.assertEqual('result' in data, True)
+        params = {"request": "fake_request_name"}
+        data = self.mgr.getdata(url, params=params, encode=True, decode=True)
+        self.assertEqual(data['result'][0]['microservice'], self.managerName)
+        self.assertEqual(data['result'][0]['api'], api)
+
+    def testGetStatusGzip(self):
+        "Test function for getting state of the MicroService"
+        api = "status"
+        url = '%s/%s' % (self.url, api)
+        params = {}
+        # perform check with and without gzip encoding
+        headers = {'Accept-Encoding': 'gzip'}
+        data = self.mgr.getdata(url, params=params, headers=headers, encode=True, decode=True)
+        # check if our data is returned as bytes (gzip encoding)
+        if isinstance(data, bytes):
+            data = gzip.decompress(data)
+            if isinstance(data, bytes):
+                data = data.decode("utf-8")
+            data = json.loads(data)
+        print("### testGetStatus, headers=", headers, "data=", data, type(data))
+        # check that result key is present in data
+        if 'result' in data:
+            self.assertEqual(data['result'][0]['microservice'], self.managerName)
+            self.assertEqual(data['result'][0]['api'], api)
+        else:
+            print("### result is not present in data")
+            print(data)
+
+        params = {"service": "transferor"}
+        data = self.mgr.getdata(url, params=params, headers=headers, encode=True, decode=True)
+        # check if our data is returned as bytes (gzip encoding)
+        if isinstance(data, bytes):
+            data = gzip.decompress(data)
+            if isinstance(data, bytes):
+                data = data.decode("utf-8")
+            data = json.loads(data)
+        print("### testGetStatus, headers=", headers, "data=", data, type(data))
+        # check that result key is present in data
+        if 'result' in data:
+            self.assertEqual(data['result'][0]['microservice'], self.managerName)
+            self.assertEqual(data['result'][0]['api'], api)
+        else:
+            print("### result is not present in data")
+            print(data)
+
+    def testGetInfoGzip(self):
+        "Test function for getting state of the MicroService"
+        api = "status"
+        url = '%s/%s' % (self.url, api)
+        params = {}
+        # perform check with and without gzip encoding
+        headers = {'Accept-Encoding': 'gzip'}
+        data = self.mgr.getdata(url, params=params, headers=headers, encode=True, decode=True)
+        # check if our data is returned as bytes (gzip encoding)
+        if isinstance(data, bytes):
+            data = gzip.decompress(data)
+            if isinstance(data, bytes):
+                data = data.decode("utf-8")
+            data = json.loads(data)
+        print("### testGetInfo, headers=", headers, "data=", data, type(data))
+        # check that result key is present in data
+        if 'result' in data:
+            self.assertEqual(data['result'][0]['microservice'], self.managerName)
+            self.assertEqual(data['result'][0]['api'], api)
+        else:
+            print("### result is not present in data")
+            print(data)
+            self.assertEqual('result' in data, True)
+
+        params = {"request": "fake_request_name"}
+        data = self.mgr.getdata(url, params=params, headers=headers, encode=True, decode=True)
+        # check if our data is returned as bytes (gzip encoding)
+        if isinstance(data, bytes):
+            data = gzip.decompress(data)
+            if isinstance(data, bytes):
+                data = data.decode("utf-8")
+            data = json.loads(data)
+        print("### testGetInfo, headers=", headers, "data=", data, type(data))
+        # check that result key is present in data
+        if 'result' in data:
+            self.assertEqual(data['result'][0]['microservice'], self.managerName)
+            self.assertEqual(data['result'][0]['api'], api)
+        else:
+            print("### result is not present in data")
+            print(data)
+            self.assertEqual('result' in data, True)
 
     def testPostCall(self):
         "Test function for getting state of the MicroService"

--- a/test/python/WMCore_t/MicroService_t/MicroService_t.py
+++ b/test/python/WMCore_t/MicroService_t/MicroService_t.py
@@ -82,56 +82,38 @@ class MicroServiceTest(unittest.TestCase):
         api = "status"
         url = '%s/%s' % (self.url, api)
         params = {}
-        data = self.mgr.getdata(url, params=params, encode=True, decode=True)
-        if isinstance(data, bytes):
-            data = data.decode("utf-8")
-            print("### data=", data, "type(data)=", type(data))
-            data = json.loads(data)
-        if 'result' in data:
-            self.assertEqual(data['result'][0]['microservice'], self.managerName)
-            self.assertEqual(data['result'][0]['api'], api)
-        else:
-            print("### data=", data, "type(data)=", type(data))
-            # we should not be here, let's assert
-            self.assertEqul(True, False)
+
+        # we should explicitly set Accept-Encoding to nil since
+        # pycurl_manager sets it by default to gzip, see
+        # https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/Services/pycurl_manager.py#L226
+        headers = {'Accept-Encoding': ''}
+        data = self.mgr.getdata(url, params=params, headers=headers, encode=True, decode=True)
+        self.assertEqual(data['result'][0]['microservice'], self.managerName)
+        self.assertEqual(data['result'][0]['api'], api)
 
         params = {"service": "transferor"}
         data = self.mgr.getdata(url, params=params, encode=True, decode=True)
-        if 'result' in data:
-            self.assertEqual(data['result'][0]['microservice'], self.managerName)
-            self.assertEqual(data['result'][0]['api'], api)
-        else:
-            print("### data=", data, "type(data)=", type(data))
-            # we should not be here, let's assert
-            self.assertEqul(True, False)
+        self.assertEqual(data['result'][0]['microservice'], self.managerName)
+        self.assertEqual(data['result'][0]['api'], api)
 
     def testGetInfo(self):
         "Test function for getting state of the MicroService"
         api = "status"
         url = '%s/%s' % (self.url, api)
         params = {}
-        data = self.mgr.getdata(url, params=params, encode=True, decode=True)
-        if isinstance(data, bytes):
-            data = data.decode("utf-8")
-            print("### data=", data, "type(data)=", type(data))
-            data = json.loads(data)
-        if 'result' in data:
-            self.assertEqual(data['result'][0]['microservice'], self.managerName)
-            self.assertEqual(data['result'][0]['api'], api)
-        else:
-            print("### data=", data, "type(data)=", type(data))
-            # we should not be here, let's assert
-            self.assertEqul(True, False)
+
+        # we should explicitly set Accept-Encoding to nil since
+        # pycurl_manager sets it by default to gzip, see
+        # https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/Services/pycurl_manager.py#L226
+        headers = {'Accept-Encoding': ''}
+        data = self.mgr.getdata(url, params=params, headers=headers, encode=True, decode=True)
+        self.assertEqual(data['result'][0]['microservice'], self.managerName)
+        self.assertEqual(data['result'][0]['api'], api)
 
         params = {"request": "fake_request_name"}
         data = self.mgr.getdata(url, params=params, encode=True, decode=True)
-        if 'result' in data:
-            self.assertEqual(data['result'][0]['microservice'], self.managerName)
-            self.assertEqual(data['result'][0]['api'], api)
-        else:
-            print("### data=", data, "type(data)=", type(data))
-            # we should not be here, let's assert
-            self.assertEqul(True, False)
+        self.assertEqual(data['result'][0]['microservice'], self.managerName)
+        self.assertEqual(data['result'][0]['api'], api)
 
     def testGetStatusGzip(self):
         "Test function for getting state of the MicroService"


### PR DESCRIPTION
Fixes #11082 

#### Status
ready

#### Description
Added gzip compression of result object returned by REST GET/POST APIs. Therefore, it will provide gzip encoding if requested by a client to all GET/POST APIs. I expect that with this change any inherited REST server will enable this functionality, e.g. MS services, ReqMgr2, CRAB, etc.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs

#### External dependencies / deployment changes

#### Test procedure
Since I'm not aware of integrated REST server unit test procedure I tested the changes using manual setup. Here I present its details:
- Start REST server with ms config as following
```
# use MS configuration to setup REST server on port 8247
# start the REST server as following
wmc-httpd $PWD/ms_config.py
```
- Run client curl call to request gzip encoded content
```
# request info API object using gzip encoding
curl -v -H "Accept-Encoding: gzip" http://localhost:8247/ms/data/info --output res.bin

> GET /ms/data/info HTTP/1.1
> Host: localhost:8247
> User-Agent: curl/7.84.0
> Accept: */*
> Accept-Type: application/json
> Accept-Encoding: gzip
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: text/plain;charset=utf-8
< Server: CherryPy/18.3.0
< Date: Thu, 18 Aug 2022 13:17:03 GMT
< Content-Encoding: gzip
< Vary: Accept
< Pragma: no-cache
< Expires: Sun, 19 Nov 1978 05:00:00 GMT
< Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
< X-Rest-Status: 100
< X-Rest-Time: 283.003 us
< Transfer-Encoding: chunked
<
{ [116 bytes data]
100   110    0   110    0     0   3791      0 --:--:-- --:--:-- --:--:-- 18333
* Connection #0 to host localhost left intact
```
At this point the `curl` fetched our API object in gzip encoding and stored it into `res.bin` file.
- check that returned object is indeed gzip object
```
zcat res.bin
[{"wmcore_version": "2.0.3.pre6", "microservice_version": "2.0.3.pre6", "microservice": "MSManager", "request": null, "transferDoc": null}]
```