### PR TITLE
Fix strToBool validate function to fail on integer values

### DIFF
--- a/src/python/Utils/Utilities.py
+++ b/src/python/Utils/Utilities.py
@@ -63,11 +63,16 @@ def makeNonEmptyList(stringList):
 
 def strToBool(string):
     """
-    _strToBool_
-
-    Try to convert a string to boolean. i.e. "True" to python True
+    Try to convert different variations of True or False (including a string
+    type object) to a boolean value.
+    In short:
+     * True gets mapped from: True, "True", "true", "TRUE".
+     * False gets mapped from: False, "False", "false", "FALSE"
+     * anything else will fail
+    :param string: expects a boolean or a string, but it could be anything else
+    :return: a boolean value, or raise an exception if value passed in is not supported
     """
-    if string in [False, True]:
+    if string is False or string is True:
         return string
     elif string in ["True", "true", "TRUE"]:
         return True

--- a/test/python/Utils_t/Utilities_t.py
+++ b/test/python/Utils_t/Utilities_t.py
@@ -75,7 +75,7 @@ class UtilitiesTests(unittest.TestCase):
         for v in [False, "False", "FALSE", "false"]:
             self.assertFalse(strToBool(v))
 
-        for v in ["", "alan", [], [''], {'a': 123}]:
+        for v in [1, 0, "", "alan", [], [''], {'a': 123}]:
             self.assertRaises(ValueError, strToBool, v)
 
     def testSafeStr(self):


### PR DESCRIPTION
Fixes #11250 

#### Status
ready

#### Description
This change should now catch the case where an integer value is provided (which can match to true/false), making the http request to fail.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
