### PR TITLE
Update CMSMonitoring python library to 0.6.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@
 Cheetah3~=3.2.6.post1         # wmcore,wmagent,reqmgr2,reqmon
 CherryPy~=17.4.0              # wmcore,wmagent,wmagent-devtools,reqmgr2,reqmon,global-workqueue,reqmgr2ms
 CMSCouchapp~=1.3.4            # wmcore,wmagent
-CMSMonitoring~=0.6.5          # wmcore,wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms
+CMSMonitoring~=0.6.7          # wmcore,wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms
 coverage~=5.4                 # wmcore,wmagent,wmagent-devtools
 cx-Oracle~=7.3.0              # wmcore,wmagent
 dbs3-client~=4.0.8            # wmcore,wmagent,reqmgr2,reqmon,global-workqueue


### PR DESCRIPTION
Fixes #11254 

#### Status
ready

#### Description
Updates the requirements file with CMSMonitoring version `0.6.7`.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
CMSMonitoring fix: https://github.com/dmwm/CMSMonitoring/pull/161
Spec cmsdist update: https://github.com/cms-sw/cmsdist/pull/8036

#### External dependencies / deployment changes
Yes, specs.
