### PR TITLE
Remove threadlocal parameter for SQLAlchemy as it is deprecated in new release

### DIFF
--- a/src/python/WMCore/Database/DBFactory.py
+++ b/src/python/WMCore/Database/DBFactory.py
@@ -12,7 +12,6 @@ class DBFactory(object):
     # class variable
     _engineMap = {}
     _defaultEngineParams = {"convert_unicode" : True,
-                            "strategy": "threadlocal",
                             "pool_recycle": 7200}
 
     def __init__(self, logger, dburl=None, options={}):


### PR DESCRIPTION
Fixes #11205 

#### Status
not-tested

#### Description
Remove threadlocal parameter as it is deprecated in new SQLAlchemy version

#### Is it backward compatible (if not, which system it affects?)
MAYBE

#### Related PRs
https://github.com/dmwm/WMCore/pull/11256/

#### External dependencies / deployment changes
