### PR TITLE
Create alert for pileup containers eligible for rule deletion

### DIFF
--- a/src/python/WMCore/MicroService/MSOutput/MSOutput.py
+++ b/src/python/WMCore/MicroService/MSOutput/MSOutput.py
@@ -27,7 +27,6 @@ from WMCore.Database.MongoDB import MongoDB
 from WMCore.MicroService.MSOutput.MSOutputTemplate import MSOutputTemplate
 from WMCore.MicroService.MSOutput.RelValPolicy import RelValPolicy
 from WMCore.WMException import WMException
-from WMCore.Services.AlertManager.AlertManagerAPI import AlertManagerAPI
 
 
 class MSOutputException(WMException):
@@ -105,7 +104,6 @@ class MSOutput(MSCore):
         self.uConfig = {}
         # service name used to route alerts via AlertManager
         self.alertServiceName = "ms-output"
-        self.alertManagerAPI = AlertManagerAPI(self.msConfig.get("alertManagerUrl", None), logger=logger)
 
         # RelVal output data placement policy from the service configuration
         self.msConfig.setdefault("dbsUrl", "https://cmsweb-prod.cern.ch/dbs/prod/global/DBSReader")

--- a/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
+++ b/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
@@ -29,7 +29,7 @@ from WMCore.MicroService.MSCore import MSCore
 from WMCore.MicroService.MSTransferor.RequestInfo import RequestInfo
 from WMCore.MicroService.MSTransferor.DataStructs.RSEQuotas import RSEQuotas
 from WMCore.Services.CRIC.CRIC import CRIC
-from WMCore.Services.AlertManager.AlertManagerAPI import AlertManagerAPI
+
 
 def newTransferRec(dataIn):
     """
@@ -105,8 +105,6 @@ class MSTransferor(MSCore):
         self.blockCounter = 0
         # service name used to route alerts via AlertManager
         self.alertServiceName = "ms-transferor"
-        self.alertManagerUrl = self.msConfig.get("alertManagerUrl", None)
-        self.alertManagerApi = AlertManagerAPI(self.alertManagerUrl, logger=logger)
 
     @retry(tries=3, delay=2, jitter=2)
     def updateCaches(self):
@@ -557,17 +555,6 @@ class MSTransferor(MSCore):
             msg = "DRY-RUN: making Rucio rule for workflow: %s, dids: %s, rse: %s, kwargs: %s"
             self.logger.info(msg, wflow.getName(), dids, rseExpr, ruleAttrs)
         return success, transferId
-
-    def sendAlert(self, alertName, severity, summary, description, service, endSecs=1 * 60 * 60):
-        """
-        Send alert to Prometheus, wrap function in a try-except clause
-        """
-        try:
-            # alert to expiry in an hour from now
-            self.alertManagerApi.sendAlert(alertName, severity, summary, description,
-                                           service, endSecs=endSecs)
-        except Exception as ex:
-            self.logger.exception("Failed to send alert to %s. Error: %s", self.alertManagerUrl, str(ex))
 
     def alertPUMisconfig(self, workflowName):
         """

--- a/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
+++ b/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
@@ -36,7 +36,6 @@ from WMCore.MicroService.MSCore import MSCore
 from WMCore.MicroService.MSUnmerged.MSUnmergedRSE import MSUnmergedRSE
 from WMCore.Services.RucioConMon.RucioConMon import RucioConMon
 from WMCore.Services.WMStatsServer.WMStatsServer import WMStatsServer
-# from WMCore.Services.AlertManager.AlertManagerAPI import AlertManagerAPI
 from WMCore.Database.MongoDB import MongoDB
 from WMCore.WMException import WMException
 from Utils.Pipeline import Pipeline, Functor
@@ -133,10 +132,6 @@ class MSUnmerged(MSCore):
             msg = "Failed to import gfal2 library while it's not "
             msg += "set to emulate it. Crashing the service!"
             raise ImportError(msg)
-
-        # TODO: Add 'alertManagerUrl' to msConfig'
-        # self.alertServiceName = "ms-unmerged"
-        # self.alertManagerAPI = AlertManagerAPI(self.msConfig.get("alertManagerUrl", None), logger=logger)
 
         # Instantiating the Rucio Consistency Monitor Client
         self.rucioConMon = RucioConMon(self.msConfig['rucioConMon'], logger=self.logger)


### PR DESCRIPTION
Fixes #11216 

#### Status
not-tested

#### Description
This PR provides the following changes:
* pileup container rules are no longer removed by MSRuleCleaner
* instead, it will create a new alert - to be routed to Slack and email - mentioning that workflow AAA has a container BBB eligible for deletion, also providing a list of rule ids. This alert is supposed to expiry within 2 days.
* in addition to that, the AlertManager object has been moved to the super class (MSCore), avoiding code duplicating in the microservices.

#### Is it backward compatible (if not, which system it affects?)
Other than the new alert, yes.

#### Related PRs
None

#### External dependencies / deployment changes
Configuration services_config changes:
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/155
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/156
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/157
