### PR TITLE
Cast SQLAlchemy RMKeyView object to list

### DIFF
--- a/src/python/WMCore/JobSplitting/JobFactory.py
+++ b/src/python/WMCore/JobSplitting/JobFactory.py
@@ -335,10 +335,8 @@ class JobFactory(WMObject):
         if isinstance(resultProxy.keys, list):
             keys = resultProxy.keys
         else:
-            keys = resultProxy.keys()  # do not futurize this!
-            if isinstance(keys, set):
-                # If it's a set, handle it
-                keys = list(keys)
+            # the object below is of the type: sqlalchemy.engine.result.RMKeyView
+            keys = list(resultProxy.keys())
         files = set()
 
         while len(rawResults) < size and len(self.proxies) > 0:


### PR DESCRIPTION
Fixes #11267 

#### Status
ready

#### Description
The previous SQLAlchemy object no longer returns a list of the results, instead if returns a `RMKeyView`. So before we try to access it with indexes, cast it to a list.

This change is required by SQLAlchemy 1.4.x

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Relevant SQLAlchemy commit (in 1.4.x series): https://github.com/zzzeek/sqlalchemy/commit/aded39f68c29e44a50c85be1ddb370d3d1affe9d

#### External dependencies / deployment changes
None
