### PR TITLE
Fix python version for patchComponent.sh

### DIFF
--- a/bin/patchComponent.sh
+++ b/bin/patchComponent.sh
@@ -6,7 +6,7 @@ usage()
     echo -ne "and to decrease the development && testing turnaround time.\n"
     echo -ne "Usage: \n"
     echo -ne "\t git diff --no-color | sudo ./patchComponent.sh (wmagent | reqmon | reqmgr2 | reqmgr2ms...)\n or:\n"
-    echo -ne "\t curl https://patch-diff.githubusercontent.com/raw/dmwm/deployment/pull/740.patch  | sudo ./patchComponent.sh (wmagent | reqmon | reqmgr2 | reqmgr2ms...)\n"
+    echo -ne "\t curl https://patch-diff.githubusercontent.com/raw/dmwm/WMCore/pull/11270.patch | sudo ./patchComponent.sh (wmagent | reqmon | reqmgr2 | reqmgr2ms...)\n"
     exit 1
 }
 
@@ -18,9 +18,9 @@ echo "Patching component: $component"
 
 if [[ $component == "wmagent" ]]
 then
-    rootDir=/data/srv/$component/current/apps.sw/$component/lib/python2.7/site-packages
+    rootDir=/data/srv/$component/current/apps.sw/$component/lib/python*/site-packages
 else
-    rootDir=/data/srv/current/apps.sw/$component/lib/python2.7/site-packages/
+    rootDir=/data/srv/current/apps.sw/$component/lib/python*/site-packages/
 fi
 
 stripLevel=3


### PR DESCRIPTION
Fixes #11271 

#### Status
ready

#### Description
Fixes old python version for `patchComponent.sh` auxiliary script, and also fixes the bad (deployment) patch in the usage example.

#### Is it backward compatible (if not, which system it affects?)
NO

#### Related PRs
None

#### External dependencies / deployment changes
None