### PR TITLE
Update WMAgent script example and test campaign names

### DIFF
--- a/bin/adhoc-scripts/parseUnifiedCampaigns.py
+++ b/bin/adhoc-scripts/parseUnifiedCampaigns.py
@@ -285,9 +285,9 @@ def insertTestCampaigns(mgr):
     testCamp = ("CMSSW_10_6_1_patch1_Step1", "CMSSW_10_6_1_patch1_Step2",
                 "CMSSW_7_3_2__test2inwf-1510737328", "CMSSW_11_2_0_pre6__fullsim_noPU_2021_14TeV-1599843628",
                 "RelVal_Generic_Campaign", "DMWM_Test",
-                "Agent204_Val", "Agent211_Val", "Agent213_Val", "Agent215_Val",
-                "Jun2022_Val", "Jul2022_Val", "Aug2022_Val", "Sept2022_Val", "Oct2022_Val",
-                "HG2206_Val", "HG2207_Val", "HG2208_Val", "HG2209_Val", "HG2210_Val")
+                "Agent212_Val", "Agent214_Val", "Agent216_Val",
+                "Sept2022_Val", "Oct2022_Val", "Nov2022_Val", "Dec2022_Val", "Jan2023_Val",
+                "HG2209_Val", "HG2210_Val", "HG2211_Val", "HG2212_Val", "HG2301_Val")
     for campName in testCamp:
         defaultCamp['CampaignName'] = campName
         upload(mgr, defaultCamp)

--- a/deploy/deploy-wmagent.sh
+++ b/deploy/deploy-wmagent.sh
@@ -24,8 +24,8 @@
 ### Usage:               -n <agent_number> Agent number to be set when more than 1 agent connected to the same team (defaults to 0)
 ### Usage:
 ### Usage: deploy-wmagent.sh -w <wma_version> -d <deployment_tag> -t <team_name> [-s <scram_arch>] [-r <repository>] [-n <agent_number>]
-### Usage: Example: sh deploy-wmagent.sh -w 2.0.4.patch1 -d HG2207c -t production -n 30
-### Usage: Example: sh deploy-wmagent.sh -w 2.0.4-b954b0745339a347ea28afd5b5767db4 -d HG2206e -t testbed-vocms001 -p "11001" -r comp=comp.amaltaro
+### Usage: Example: sh deploy-wmagent.sh -w 2.1.2 -d HG2209d -t production -n 30
+### Usage: Example: sh deploy-wmagent.sh -w 2.1.2-b954b0745339a347ea28afd5b5767db4 -d HG2209d -t testbed-vocms001 -p "11001" -r comp=comp.amaltaro
 ### Usage:
 
 IAM=`whoami`


### PR DESCRIPTION
Fixes #11226 

#### Status
ready

#### Description
This PR updates the shell script for deploying WMAgent, providing the latest stable WMAgent version and the CMSWEB deployment tag to be used.

In addition to that, I also provide a few test campaigns that will be needed to have in cmsweb-testbed for upcoming monthly/release validations.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
Requires a new RPM from this PR: https://github.com/cms-sw/cmsdist/pull/8076