### PR TITLE
Switch MSOutput to use MongoDB As A Service.

### DIFF
--- a/bin/adhoc-scripts/mongoInit.py
+++ b/bin/adhoc-scripts/mongoInit.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Script to connect to a MongoDB instance based on a set of parameters given at runtime
+Usage:
+      source /data/srv/current/apps/reqmgr2ms/etc/profile.d/init.sh
+      python3 -i -- mongoInit.py -c $WMCORE_SERVICE_CONFIG/reqmgr2ms-output/config-output.py
+"""
+
+import sys
+import logging
+import argparse
+
+from WMCore.Database.MongoDB import MongoDB
+
+from WMCore.Configuration import Configuration, loadConfigurationFile
+
+if __name__ == '__main__':
+
+    FORMAT = "%(asctime)s:%(levelname)s:%(module)s:%(funcName)s(): %(message)s"
+    logging.basicConfig(stream=sys.stdout, format=FORMAT, level=logging.INFO)
+    logger = logging.getLogger(__name__)
+
+    parser = argparse.ArgumentParser(
+        prog='MongoInit',
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=__doc__)
+
+    parser.add_argument('-c', '--config', required=True,
+                        help="""\
+                        The path to MSCONFIG to be used, e.g.
+                        for production: /data/srv/current/config/reqmgr2ms/config-output.py
+                        """)
+    args = parser.parse_args()
+
+    logger.info("Loading configFile: %s", args.config)
+    config = loadConfigurationFile(args.config)
+
+    msConfig = config.section_('views').section_('data').dictionary_()
+
+    msConfig.setdefault("mongoDBUrl", 'mongodb://localhost')
+    msConfig.setdefault("mongoDBPort", 27017)
+    msConfig.setdefault("mongoDB", 'mongoDBNull')
+    msConfig.setdefault("mongoDBRetryCount", 3)
+    msConfig.setdefault("mongoDBReplicaset", None)
+    msConfig.setdefault("mockMongoDB", False)
+    msConfig.setdefault("collection", None)
+
+    mongoDBConfig = {
+        'database': msConfig['mongoDB'],
+        'server': msConfig['mongoDBUrl'],
+        'port': msConfig['mongoDBPort'],
+        'replicaset': msConfig['mongoDBReplicaset'],
+        'logger': logger,
+        'create': False,
+        'mockMongoDB': msConfig['mockMongoDB']}
+
+    mongoClt = MongoDB(**mongoDBConfig)
+    mongoDB = getattr(mongoClt, msConfig['mongoDB'])
+    mongoColl = mongoDB[msConfig['collection']] if msConfig['collection'] else None

--- a/bin/adhoc-scripts/mongoInit.py
+++ b/bin/adhoc-scripts/mongoInit.py
@@ -14,7 +14,7 @@ import argparse
 
 from WMCore.Database.MongoDB import MongoDB
 
-from WMCore.Configuration import Configuration, loadConfigurationFile
+from WMCore.Configuration import loadConfigurationFile
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
Fixes #11020 

#### Status
ready

#### Description
With the current PR we provide the set of changes needed for switching MSOutput from local MongoDB instance  to MongoDB As A Service. 

The Database configuration is now read from `msConfig` instead of being hardwired in the service code. The `replicaset` is also configurable through the service config, with a default value of `None`.  

**TODO:** 
 * We need to test/implement the repeated write checks because of we are about to connect to a cluster of servers now instead of a single instance. 
 * We need to double check for incompatibility with previous MongoDB versions. 

In addition we provide a generic script for testing only the service configuration parameters and by creating a test MongoDB connection based on those parameters. This one may be used for any service using MongoDB both local or As A Service. 

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/158
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/159
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/160


#### External `dependencies` / deployment changes

**NOTE:**
We need to migrate the whole database from the previous K8 instance to the new one. And this needs to happen during the regular monthly upgrade

**MongoDB migration instructions:**

For this migration we need to be on a node which has two things:
* access to the database itself (in the case with the current MSOutput this needs to be the node/cluster where the `ms-output-mongo` pod is running or the pod itself) 
* access to a shared file system which would be accessible later from the node/cluster where MongoDBAaS is running


***Dumping the old database*** 
(should be connected to `ms-output-mongo....` pod and dump the database from there)
```
# connect to lxplus
ssh lxplus8.cern.ch

# setup the K8 environment I use an alias command for that:
k8init preprod

# login to the pod
kubectl exec -it ms-output-mongo-859b4f5cf6-999wq  bash -n dmwm

# dump the database
mkdir -p /data/mongodb/backup/

mongodump --port=8230 --out=/data/mongodb/backup/ --db=msOutDB  

```

***Restore/rename the database on `MongoDBAaS`***
(could be done from any node and anyone who has connection details, such as username, passowrd, cluster url, replicaset etc.)


* if we are about to do it from the same pod where we used to export the databse:

```
# login to the pod
kubectl exec -it ms-output-mongo-859b4f5cf6-999wq  bash -n dmwm

# test what  is about to be done in dryRun mode
mongorestore -vvv --host='cms-db/mongodb-cms.cern.ch' --dryRun --authenticationDatabase='admin'   --port=27017 --username='<USERNAME>' --password='<PASSWORD>'  --db=msOutputDBPreProd /data/mongodb/backup/msOutDB/

# restore the database:
mongorestore -vvv --host='cms-db/mongodb-cms.cern.ch'  --authenticationDatabase='admin'   --port=27017 --username='<USERNAME>' --password='<PASSWORD>'  --db=msOutputDBPreProd /data/mongodb/backup/msOutDB/
```


* if we are about to do it from lxplus:
```
# login to vocms0750
ssh vocms0750

# check if the database dump is visible at the shared file system mount point ( NOTE: the actual destination is not agreed upon yet )
ls -la  /cephfs/testbed/mongodb/backup

# test what  is about to be done in dryRun mode
mongorestore -vvv --host='cms-db/mongodb-cms.cern.ch' --dryRun --authenticationDatabase='admin'   --port=27017 --username='<USERNAME>' --password='<PASSWORD>'  --db=msOutputDBPreProd /cephfs/testbed/mongodb/backup

# restore the database
mongorestore -vvv --host='cms-db/mongodb-cms.cern.ch' --authenticationDatabase='admin'   --port=27017 --username='<USERNAME>' --password='<PASSWORD>'  --db=msOutputDBPreProd /cephfs/testbed/mongodb/backup
```

**NOTE:**
Notice the difference of the following parameters between the dump and the restore commands:
* ` --port=8230`  vs. `--port=27017` we have a different port to connect to
* `--db=msOutDB` vs. `--db=msOutputDBPreProd` ( we need to rename it to the relevant name depending on the database we migrate - `prod`, `preprod` or `dev`)

* More detailed instructions can be found here: [MongoDB backup && restore](https://www.mongodb.com/docs/manual/tutorial/backup-and-restore-tools/)