### PR TITLE
Update Py3 CMSMonitoring to version 0.6.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@
 Cheetah3~=3.2.6.post1         # wmcore,wmagent,reqmgr2,reqmon
 CherryPy~=18.8.0              # wmcore,wmagent,wmagent-devtools,reqmgr2,reqmon,global-workqueue,reqmgr2ms
 CMSCouchapp~=1.3.4            # wmcore,wmagent
-CMSMonitoring~=0.6.7          # wmcore,wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms
+CMSMonitoring~=0.6.8          # wmcore,wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms
 coverage~=5.4                 # wmcore,wmagent,wmagent-devtools
 cx-Oracle~=8.3.0              # wmcore,wmagent
 dbs3-client~=4.0.10           # wmcore,wmagent,reqmgr2,reqmon,global-workqueue


### PR DESCRIPTION
Fixes #11281 

#### Status
ready

#### Description
This version contains a workaround for `stomp.py` log verbosity.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
CMSMonitoring changes in:
https://github.com/dmwm/CMSMonitoring/pull/164

#### External dependencies / deployment changes
Spec/cmsdist changes in: https://github.com/cms-sw/cmsdist/pull/8085
