### PR TITLE
Add temporary fix for T1_US_FNAL in both wmbsFile and dbsFile creation.

### DIFF
--- a/src/python/WMComponent/JobAccountant/AccountantWorker.py
+++ b/src/python/WMComponent/JobAccountant/AccountantWorker.py
@@ -364,7 +364,11 @@ class AccountantWorker(WMConnectionBase):
         dbsFile['task'] = task
         dbsFile['runs'] = jobReportFile['runs']
 
-        dbsFile.setLocation(pnn=list(jobReportFile["locations"])[0], immediateSave=False)
+        if list(jobReportFile["locations"])[0] == "T1_US_FNAL":
+            pnnFixed = "T1_US_FNAL_Disk"
+        else:
+            pnnFixed = list(jobReportFile["locations"])[0]
+        dbsFile.setLocation(pnn=pnnFixed, immediateSave=False)
         self.dbsFilesToCreate.append(dbsFile)
         return
 
@@ -715,12 +719,15 @@ class AccountantWorker(WMConnectionBase):
             lfn = dbsFile['lfn']
             selfChecksums = dbsFile['checksums']
             jobLocation = dbsFile.getLocations()[0]
+            if jobLocation == "T1_US_FNAL":
+                jobLocation = "T1_US_FNAL_Disk"
             jobLocations.add(jobLocation)
             dbsFileTuples.append((lfn, dbsFile['size'],
                                   dbsFile['events'], assocID,
                                   dbsFile['status'], workflowID, dbsFile['in_phedex']))
 
             dbsFileLoc.append({'lfn': lfn, 'pnn': jobLocation})
+
             if dbsFile['runs']:
                 runLumiBinds.append({'lfn': lfn, 'runs': dbsFile['runs']})
 
@@ -887,6 +894,8 @@ class AccountantWorker(WMConnectionBase):
         wmbsFile["locations"] = set()
 
         if pnn != None:
+            if pnn == "T1_US_FNAL":
+                pnn = "T1_US_FNAL_Disk"
             wmbsFile.setLocation(pnn=pnn, immediateSave=False)
         wmbsFile['jid'] = jobID
 

--- a/src/python/WMComponent/JobAccountant/AccountantWorker.py
+++ b/src/python/WMComponent/JobAccountant/AccountantWorker.py
@@ -896,6 +896,9 @@ class AccountantWorker(WMConnectionBase):
         if pnn != None:
             if pnn == "T1_US_FNAL":
                 pnn = "T1_US_FNAL_Disk"
+                msg = "Found job with wrong PNN T1_US_FNAL. JobID: %i." % jobID
+                msg += "Swapping with PNN T1_US_FNAL_Disk"
+                logging.warning(msg)
             wmbsFile.setLocation(pnn=pnn, immediateSave=False)
         wmbsFile['jid'] = jobID
 


### PR DESCRIPTION
Fixes #11287 

#### Status
not-tested 

#### Description
Because of a recent change at FNAL the jobs started to read the new `site-local-config` for `T1_US_FNAL` instead of `T1_US_FNAL_Disk`. in the new  one there was  an error pointing `T1_US_FNAL` as the default PNN for the site instead of the `T1_US_FNAL_Disk`. The configuration has been reverted while waiting for a proper fix, however we need to add the protection on our side, such that  we  never persist records with the broken PNN for the site in the relational database for both WMBS and DBSBuffer tables. 

The current change adds a temporary fix such that  this is avoided at the creatin time for both objects `wmbsFile` and `dbsFile`.   

#### Is it backward compatible (if not, which system it affects?)
NO 

#### Related PRs
None

#### External dependencies / deployment changes
None
