### PR TITLE
Update CMSMonitoring python library version to 0.6.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@
 Cheetah3~=3.2.6.post1         # wmcore,wmagent,reqmgr2,reqmon
 CherryPy~=18.8.0              # wmcore,wmagent,wmagent-devtools,reqmgr2,reqmon,global-workqueue,reqmgr2ms
 CMSCouchapp~=1.3.4            # wmcore,wmagent
-CMSMonitoring~=0.6.8          # wmcore,wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms
+CMSMonitoring~=0.6.9          # wmcore,wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms
 coverage~=5.4                 # wmcore,wmagent,wmagent-devtools
 cx-Oracle~=8.3.0              # wmcore,wmagent
 dbs3-client~=4.0.10           # wmcore,wmagent,reqmgr2,reqmon,global-workqueue


### PR DESCRIPTION
Fixes #11289 

#### Status
ready

#### Description
This CMSMonitoring version properly closes socket connections, which was causing node/user resources to get exhausted.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Real fix: https://github.com/dmwm/CMSMonitoring/pull/167

#### External dependencies / deployment changes
Requires this cmsdist spec update: https://github.com/cms-sw/cmsdist/pull/8100
