### PR TITLE
Build WMCore services and publish them to pypy, usinig to tag pushes

### DIFF
--- a/.github/workflows/pypy_build_publish.yaml
+++ b/.github/workflows/pypy_build_publish.yaml
@@ -1,0 +1,19 @@
+# This workflow will build and upload WMCore core services to the production PYPY
+# based on tag releases
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build_and_publish_services:
+    strategy:
+      matrix:
+        target: [wmagent, wmagent-devtools, wmcore, reqmon, reqmgr2, global-workqueue, acdcserver, reqmgr2ms-unmerged,
+                 reqmgr2ms-output, reqmgr2ms-rulecleaner, reqmgr2ms-transferor, reqmgr2ms-monitor]
+    uses: ./.github/workflows/pypy_build_publish_template.yaml
+    with:
+      wmcore_component: ${{ matrix.target }}
+    secrets:
+      pypy_token: ${{ secrets.PYPY_PRODUCTION }}

--- a/.github/workflows/pypy_build_publish_template.yaml
+++ b/.github/workflows/pypy_build_publish_template.yaml
@@ -1,0 +1,38 @@
+# Reusable workflow to setup a specific WMCore component for pip
+
+on:
+  workflow_call:
+    inputs:
+      wmcore_component:
+        required: true
+        type: string
+    secrets:
+      pypy_token:
+        required: true
+
+jobs:
+  build_and_publish_from_template:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup python 3.8
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.8"
+      - name: Upgrade pip3
+        run: |
+          python3 -m pip install --upgrade pip
+      - name: Update the setup script template with package name
+        run: |
+          sed "s/PACKAGE_TO_BUILD/${{ inputs.wmcore_component }}/" setup_template.py > setup.py
+      - name: Create requirements file
+        run: |
+          cp requirements.txt requirements.wmcore.txt
+          awk "/(${{ inputs.wmcore_component }}$)|(${{ inputs.wmcore_component }},)/ {print \$1}" requirements.wmcore.txt > requirements.txt
+      - name: Build sdist
+        run: python setup.py clean sdist
+      - name: Publish component
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.pypy_token }}


### PR DESCRIPTION
Fixes #11276

Notes:
Packages supported: `[wmagent, wmagent-devtools, wmcore, reqmon, reqmgr2, reqmgr2ms, global-workqueue, acdcserver]`

- t0-reqmon is the same as reqmon (when it comes to building the python package), so we are not building this
 Ref: 
https://github.com/cms-sw/cmsdist/blob/comp_gcc630/t0_reqmon.spec
https://github.com/cms-sw/cmsdist/blob/comp_gcc630/reqmon.spec
- t0 spec relies on 2 github repositories with packages that apparently have the same name. They are already uploading a t0 python package on pypy here: https://pypi.org/project/t0/
 https://github.com/cms-sw/cmsdist/blob/comp_gcc630/t0.spec
I'm not sure if we need to rename our package component or not, but this should be a different GH issue

#### Status
tested in a fork. 
We need to upload the pypy secret token inside the WMCore repository for this to work

#### Description
These changes create a set of github actions to automatically build and publish WMCore services (`[wmagent, wmagent-devtools, wmcore, reqmon, reqmgr2, reqmgr2ms, global-workqueue, acdcserver]`) to pypy: https://pypi.org/user/cms-oc-dmwm/

#### Is it backward compatible (if not, which system it affects?)
YES

#### External dependencies / deployment changes
https://github.com/dmwm/WMCore/pull/11324