### PR TITLE
Use is_alive instead of the deprecated isAlive

### DIFF
--- a/bin/HWMon/wmcore-SysStat
+++ b/bin/HWMon/wmcore-SysStat
@@ -217,7 +217,7 @@ def isWMComponentRunning(wmcomponent):
         return False, 0
         
     daemon = Details(daemonXml)
-    if daemon.isAlive():
+    if daemon.is_alive():
         return True, int(daemon['ProcessID'])
     else:
         return False, 0

--- a/bin/wmcoreD
+++ b/bin/wmcoreD
@@ -229,7 +229,7 @@ def startup(configFile):
         daemonXML = os.path.join( compDir, "Daemon.xml")
         if os.path.exists(daemonXML):
             daemon = Details(daemonXML)
-            if not daemon.isAlive():         
+            if not daemon.is_alive():
                 print("Error: Component %s Did not start properly..." % component)
                 print("Check component log to see why")
                 sys.exit(1)
@@ -268,7 +268,7 @@ def shutdown(configFile):
             print("Unable to shut it down")
         else:
             daemon = Details(daemonXml)
-            if not daemon.isAlive():
+            if not daemon.is_alive():
                 print("Component %s with process id %s is not running" % (
                     component, daemon['ProcessID'],
                     ))
@@ -326,7 +326,7 @@ def status(configFile):
             print("Component:%s Not Running" % component)
             continue
         daemon = Details(daemonXml)
-        if not daemon.isAlive():
+        if not daemon.is_alive():
             print("Component:%s Not Running" % component)
         else:
             print("Component:%s Running:%s" % (component, daemon['ProcessID']))

--- a/src/python/WMComponent/AnalyticsDataCollector/DataCollectAPI.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/DataCollectAPI.py
@@ -257,7 +257,7 @@ class WMAgentDBData(object):
                 downFlag = True
             else:
                 daemon = Details(daemonXml)
-                if not daemon.isAlive():
+                if not daemon.is_alive():
                     downFlag = True
             if downFlag and component not in agentInfo['down_components']:
                 agentInfo['status'] = 'down'

--- a/src/python/WMCore/Agent/Daemon/Details.py
+++ b/src/python/WMCore/Agent/Daemon/Details.py
@@ -73,9 +73,9 @@ class Details(dict):
                     value = childNode.getAttribute("Value")
                     self[name] = int(value)
 
-    def isAlive(self):
+    def is_alive(self):
         """
-        _isAlive_
+        _is_alive_
 
         Is the process still running?
         """
@@ -85,6 +85,12 @@ class Details(dict):
         if rc != 0:
             return False
         return True
+
+    def isAlive(self):
+        """
+        Deprecated. See is_alive()
+        """
+        return self.isAlive()
 
     def kill(self, signal=15):
         """
@@ -109,7 +115,7 @@ class Details(dict):
         os.killpg(self['ProcessGroupID'], signal)
         for dummycount in range(0, 3):
             time.sleep(1)
-            if not self.isAlive():
+            if not self.is_alive():
                 self.removeAndBackupDaemonFile()
                 return
             continue

--- a/src/python/WMCore/MicroService/TaskManager.py
+++ b/src/python/WMCore/MicroService/TaskManager.py
@@ -201,6 +201,10 @@ class TaskManager(object):
         """Check worker queue if given pid of the process is still running"""
         return pid in self.pids
 
+    def isAlive(self, pid):
+        """Deprecated. See is_alive"""
+        return self.is_alive(pid)
+
     def clear(self, tasks):
         """
         Clear all tasks in a queue. It allows current jobs to run, but will

--- a/src/python/WMCore/WMRuntime/Startup.py
+++ b/src/python/WMCore/WMRuntime/Startup.py
@@ -47,6 +47,6 @@ if __name__ == '__main__':
     logging.info("Shutting down monitor")
     os.fchmod(1, 0o664)
     os.fchmod(2, 0o664)
-    if monitor.isAlive():
+    if monitor.is_alive():
         monitor.shutdown()
     sys.exit(finalReport.getExitCode())

--- a/src/python/WMCore/WebTools/Root.py
+++ b/src/python/WMCore/WebTools/Root.py
@@ -471,7 +471,7 @@ if __name__ == "__main__":
     if opts.status:
         daemon = Details('%s/Daemon.xml' % workdir)
 
-        if not daemon.isAlive():
+        if not daemon.is_alive():
             print("Component:%s Not Running" % component)
         else:
             print("Component:%s Running:%s" % (component, daemon['ProcessID']))

--- a/src/python/WMCore/WorkerThreads/WorkerThreadManager.py
+++ b/src/python/WMCore/WorkerThreads/WorkerThreadManager.py
@@ -146,7 +146,7 @@ class WorkerThreadManager(object):
                 for slavename in self.slavelist:
                     found = False
                     for threadobj in threadlist:
-                        if hasattr(threadobj, 'name') and (slavename == threadobj.name) and (threadobj.isAlive()):
+                        if hasattr(threadobj, 'name') and (slavename == threadobj.name) and (threadobj.is_alive()):
                             found = True
                     if found is False:
                         # the slave we wanted wasn't running

--- a/test/python/WMCore_t/Agent_t/Harness_t.py
+++ b/test/python/WMCore_t/Agent_t/Harness_t.py
@@ -101,7 +101,7 @@ class HarnessTest(unittest.TestCase):
         time.sleep(2)
         daemonFile = os.path.join(config.TestComponent.componentDir, "Daemon.xml")
         details = Details(daemonFile)
-        print('Is component alive: ' + str(details.isAlive()))
+        print('Is component alive: ' + str(details.is_alive()))
         time.sleep(2)
         details.killWithPrejudice()
         print('Daemon killed')
@@ -123,7 +123,7 @@ class HarnessTest(unittest.TestCase):
         time.sleep(2)
         daemonFile = os.path.join(config.TestComponent.componentDir, "Daemon.xml")
         details = Details(daemonFile)
-        print('Is component alive: ' + str(details.isAlive()))
+        print('Is component alive: ' + str(details.is_alive()))
 
         # create msgService to send stop message.
         myThread = threading.currentThread()
@@ -142,7 +142,7 @@ class HarnessTest(unittest.TestCase):
 
         msgService.finish()
 
-        while details.isAlive():
+        while details.is_alive():
             print('Component has not received stop message')
             time.sleep(2)
         print('Daemon shutdown gracefully')

--- a/test/python/WMCore_t/Misc_t/Runtime_t.py
+++ b/test/python/WMCore_t/Misc_t/Runtime_t.py
@@ -76,7 +76,7 @@ def miniStartup(thisDir=os.getcwd()):
     task.completeTask(jobLocation=os.path.join(thisDir, 'WMTaskSpace'),
                       reportName="Report.0.pkl")
 
-    if monitor.isAlive():
+    if monitor.is_alive():
         monitor.shutdown()
 
     return


### PR DESCRIPTION

#### Status
tested only locally with docker unit tests

#### Description
Updates the deprecated isAlive() method to is_alive().

#### Is it backward compatible (if not, which system it affects?)
Yes, is_alive has been available since python2.6 Available in all python3.

#### Related PRs
None

#### External dependencies / deployment changes
None
