### PR TITLE
use is_alive with thread objs (isAlive deprecated)

### DIFF
--- a/src/python/WMCore/WMRuntime/Startup.py
+++ b/src/python/WMCore/WMRuntime/Startup.py
@@ -47,6 +47,6 @@ if __name__ == '__main__':
     logging.info("Shutting down monitor")
     os.fchmod(1, 0o664)
     os.fchmod(2, 0o664)
-    if monitor.isAlive():
+    if monitor.is_alive():
         monitor.shutdown()
     sys.exit(finalReport.getExitCode())

--- a/src/python/WMCore/WorkerThreads/WorkerThreadManager.py
+++ b/src/python/WMCore/WorkerThreads/WorkerThreadManager.py
@@ -146,7 +146,7 @@ class WorkerThreadManager(object):
                 for slavename in self.slavelist:
                     found = False
                     for threadobj in threadlist:
-                        if hasattr(threadobj, 'name') and (slavename == threadobj.name) and (threadobj.isAlive()):
+                        if hasattr(threadobj, 'name') and (slavename == threadobj.name) and (threadobj.is_alive()):
                             found = True
                     if found is False:
                         # the slave we wanted wasn't running


### PR DESCRIPTION
Fixes #11297 

#### Status
not-tested

#### Description
python threads isAlive method disappeared in 3.9 after deprecation. is_alive should be use now.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
