### PR TITLE
Enable compression of block data injected into DBSServer

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -155,8 +155,7 @@ config.DBS3Upload.dbsUrl = "OVERWRITE_BY_SECRETS"
 config.DBS3Upload.primaryDatasetType = "mc"
 config.DBS3Upload.dumpBlock = False  # to dump block meta-data into a json file
 # set DbsApi requests to use gzip enconding, thus sending compressed data
-# please change to True when new DBSWriter Go server will be in place
-config.DBS3Upload.gzipEncoding = False
+config.DBS3Upload.gzipEncoding = True
 
 config.section_("DBSInterface")
 config.DBSInterface.DBSUrl = globalDBSUrl


### PR DESCRIPTION
Fixes #11316 

#### Status
ready

#### Description
Enable DBS3Upload to send compressed data to the DBSServer (for the bulkblock insert API).

#### Is it backward compatible (if not, which system it affects?)
YES, but it requires dbs3-client >=4.0.7

#### Related PRs
None

#### External dependencies / deployment changes
None
