### PR TITLE
Exclude GH actions to match with tags starting with JENKINS

### DIFF
--- a/.github/workflows/pypy_build_publish.yaml
+++ b/.github/workflows/pypy_build_publish.yaml
@@ -5,6 +5,7 @@ on:
   push:
     tags:
       - '*'
+      - '!JENKINS*'
 
 jobs:
   build_and_publish_services:


### PR DESCRIPTION
Fixes #11336

#### Status
ready

#### Description
These change exclude github actions to match with tags starting with `JENKINS`

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
#11318
