### PR TITLE
Add initial draft for building WMCore images via CI/CD

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -47,6 +47,13 @@ jobs:
         cat Dockerfile
         docker build . --tag registry.cern.ch/cmsweb/t0_reqmon
 
+    - name: Build reqmgr2 image
+      run: |
+        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/reqmgr2/Dockerfile
+        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile
+        cat Dockerfile
+        docker build . --tag registry.cern.ch/cmsweb/reqmgr2
+
     - name: Build reqmgr2ms-output image
       run: |
         curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/reqmgr2ms-output/Dockerfile

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -22,72 +22,72 @@ jobs:
 
     - name: Build wmagent image
       run: |
-        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/wmagent/Dockerfile
-        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile
-        cat Dockerfile
+        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/wmagent/Dockerfile.dist
+        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile.dist
+        cat Dockerfile.dist
         docker build . --tag registry.cern.ch/cmsweb/wmagent
 
     - name: Build workqueue image
       run: |
-        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/workqueue/Dockerfile
-        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile
-        cat Dockerfile
+        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/workqueue/Dockerfile.dist
+        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile.dist
+        cat Dockerfile.dist
         docker build . --tag registry.cern.ch/cmsweb/workqueue
 
     - name: Build reqmon image
       run: |
-        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/reqmon/Dockerfile
-        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile
-        cat Dockerfile
+        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/reqmon/Dockerfile.dist
+        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile.dist
+        cat Dockerfile.dist
         docker build . --tag registry.cern.ch/cmsweb/reqmon
 
     - name: Build t0_reqmon image
       run: |
-        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/t0_reqmon/Dockerfile
-        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile
-        cat Dockerfile
+        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/t0_reqmon/Dockerfile.dist
+        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile.dist
+        cat Dockerfile.dist
         docker build . --tag registry.cern.ch/cmsweb/t0_reqmon
 
     - name: Build reqmgr2 image
       run: |
-        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/reqmgr2/Dockerfile
-        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile
-        cat Dockerfile
+        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/reqmgr2/Dockerfile.dist
+        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile.dist
+        cat Dockerfile.dist
         docker build . --tag registry.cern.ch/cmsweb/reqmgr2
 
     - name: Build reqmgr2ms-output image
       run: |
-        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/reqmgr2ms-output/Dockerfile
-        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile
-        cat Dockerfile
+        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/reqmgr2ms-output/Dockerfile.dist
+        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile.dist
+        cat Dockerfile.dist
         docker build . --tag registry.cern.ch/cmsweb/reqmgr2ms-output
 
     - name: Build reqmgr2ms-rulecleaner image
       run: |
-        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/reqmgr2ms-rulecleaner/Dockerfile
-        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile
-        cat Dockerfile
+        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/reqmgr2ms-rulecleaner/Dockerfile.dist
+        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile.dist
+        cat Dockerfile.dist
         docker build . --tag registry.cern.ch/cmsweb/reqmgr2ms-rulecleaner
 
     - name: Build reqmgr2ms-transferor image
       run: |
-        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/reqmgr2ms-transferor/Dockerfile
-        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile
-        cat Dockerfile
+        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/reqmgr2ms-transferor/Dockerfile.dist
+        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile.dist
+        cat Dockerfile.dist
         docker build . --tag registry.cern.ch/cmsweb/reqmgr2ms-transferor
 
     - name: Build reqmgr2ms-monitor image
       run: |
-        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/reqmgr2ms-monitor/Dockerfile
-        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile
-        cat Dockerfile
+        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/reqmgr2ms-monitor/Dockerfile.dist
+        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile.dist
+        cat Dockerfile.dist
         docker build . --tag registry.cern.ch/cmsweb/reqmgr2ms-monitor
 
     - name: Build reqmgr2ms-unmerged image
       run: |
-        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/reqmgr2ms-unmerged/Dockerfile
-        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile
-        cat Dockerfile
+        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/reqmgr2ms-unmerged/Dockerfile.dist
+        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile.dist
+        cat Dockerfile.dist
         docker build . --tag registry.cern.ch/cmsweb/reqmgr2ms-unmerged
 
 #     - name: Login to registry.cern.ch

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -43,28 +43,28 @@ jobs:
     - name: Build reqmgr2ms-rulecleaner image
       run: |
         curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/reqmgr2ms-rulecleaner/Dockerfile
-        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.rulecleaners.tag}},g" Dockerfile
+        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile
         cat Dockerfile
         docker build . --tag registry.cern.ch/cmsweb/reqmgr2ms-rulecleaner
 
     - name: Build reqmgr2ms-transferor image
       run: |
         curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/reqmgr2ms-transferor/Dockerfile
-        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.transferors.tag}},g" Dockerfile
+        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile
         cat Dockerfile
         docker build . --tag registry.cern.ch/cmsweb/reqmgr2ms-transferor
 
     - name: Build reqmgr2ms-monitor image
       run: |
         curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/reqmgr2ms-monitor/Dockerfile
-        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.monitors.tag}},g" Dockerfile
+        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile
         cat Dockerfile
         docker build . --tag registry.cern.ch/cmsweb/reqmgr2ms-monitor
 
     - name: Build reqmgr2ms-unmerged image
       run: |
         curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/reqmgr2ms-unmerged/Dockerfile
-        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.unmergeds.tag}},g" Dockerfile
+        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile
         cat Dockerfile
         docker build . --tag registry.cern.ch/cmsweb/reqmgr2ms-unmerged
 

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -3,7 +3,8 @@ name: Build
 on:
   push:
     tags:
-      - '*.*.*'
+      - '*'
+      - '!JENKINS*'
 
 jobs:
 

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -26,12 +26,26 @@ jobs:
         cat Dockerfile
         docker build . --tag registry.cern.ch/cmsweb/wmagent
 
+    - name: Build workqueue image
+      run: |
+        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/workqueue/Dockerfile
+        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile
+        cat Dockerfile
+        docker build . --tag registry.cern.ch/cmsweb/workqueue
+
     - name: Build reqmon image
       run: |
         curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/reqmon/Dockerfile
         sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile
         cat Dockerfile
         docker build . --tag registry.cern.ch/cmsweb/reqmon
+
+    - name: Build t0_reqmon image
+      run: |
+        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/t0_reqmon/Dockerfile
+        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile
+        cat Dockerfile
+        docker build . --tag registry.cern.ch/cmsweb/t0_reqmon
 
     - name: Build reqmgr2ms-output image
       run: |

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -1,0 +1,107 @@
+name: Build
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Get the Ref
+      id: get-ref
+      uses: ankitvgupta/ref-to-tag-action@master
+      with:
+        ref: ${{ github.ref }}
+        head_ref: ${{ github.head_ref }}
+
+    - name: Build wmagent image
+      run: |
+        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/wmagent/Dockerfile
+        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile
+        cat Dockerfile
+        docker build . --tag registry.cern.ch/cmsweb/wmagent
+
+    - name: Build reqmon image
+      run: |
+        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/reqmon/Dockerfile
+        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile
+        cat Dockerfile
+        docker build . --tag registry.cern.ch/cmsweb/reqmon
+
+    - name: Build reqmgr2ms-output image
+      run: |
+        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/reqmgr2ms-output/Dockerfile
+        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile
+        cat Dockerfile
+        docker build . --tag registry.cern.ch/cmsweb/reqmgr2ms-output
+
+    - name: Build reqmgr2ms-rulecleaner image
+      run: |
+        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/reqmgr2ms-rulecleaner/Dockerfile
+        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.rulecleaners.tag}},g" Dockerfile
+        cat Dockerfile
+        docker build . --tag registry.cern.ch/cmsweb/reqmgr2ms-rulecleaner
+
+    - name: Build reqmgr2ms-transferor image
+      run: |
+        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/reqmgr2ms-transferor/Dockerfile
+        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.transferors.tag}},g" Dockerfile
+        cat Dockerfile
+        docker build . --tag registry.cern.ch/cmsweb/reqmgr2ms-transferor
+
+    - name: Build reqmgr2ms-monitor image
+      run: |
+        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/reqmgr2ms-monitor/Dockerfile
+        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.monitors.tag}},g" Dockerfile
+        cat Dockerfile
+        docker build . --tag registry.cern.ch/cmsweb/reqmgr2ms-monitor
+
+    - name: Build reqmgr2ms-unmerged image
+      run: |
+        curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/reqmgr2ms-unmerged/Dockerfile
+        sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.unmergeds.tag}},g" Dockerfile
+        cat Dockerfile
+        docker build . --tag registry.cern.ch/cmsweb/reqmgr2ms-unmerged
+
+#     - name: Login to registry.cern.ch
+#       uses: docker/login-action@v1.6.0
+#       with:
+#         registry: registry.cern.ch
+#         username: ${{ secrets.CERN_LOGIN }}
+#         password: ${{ secrets.CERN_TOKEN }}
+
+#     - name: Publish image to registry.cern.ch
+#       uses: docker/build-push-action@v1
+#       with:
+#         username: ${{ secrets.CERN_LOGIN }}
+#         password: ${{ secrets.CERN_TOKEN }}
+#         registry: registry.cern.ch
+#         repository: cmsweb/wmarchive
+#         tag_with_ref: true
+
+#     - name: Login to docker github registry
+#       uses: docker/login-action@v1.6.0
+#       with:
+#         registry: docker.pkg.github.com
+#         username: ${{ github.actor }}
+#         password: ${{ secrets.GITHUB_TOKEN }}
+
+#     - name: Login to Registry
+#       uses: docker/login-action@v1.6.0
+#       with:
+#         registry: docker.pkg.github.com
+#         username: ${{ github.actor }}
+#         password: ${{ secrets.GITHUB_TOKEN }}
+
+#     - name: Push new image to k8s
+#       run: |
+#         curl -ksLO https://raw.githubusercontent.com/vkuznet/imagebot/main/imagebot.sh
+#         sed -i -e "s,COMMIT,${{github.sha}},g" -e "s,REPOSITORY,${{github.repository}},g" -e "s,NAMESPACE,wma,g" -e "s,TAG,${{steps.get-ref.outputs.tag}},g" -e "s,IMAGE,registry.cern.ch/cmsweb/wmarchive,g" -e "s,SERVICE,wmarchive,g" -e "s,HOST,${{secrets.IMAGEBOT_URL}},g" imagebot.sh
+#         chmod +x imagebot.sh
+#         cat imagebot.sh
+#         sh ./imagebot.sh


### PR DESCRIPTION
Fixes #10921 

#### Status
In development

#### Description
Add new CI/CD workflow to build WMCore images

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
https://github.com/dmwm/WMCore/pull/11318

#### External dependencies / deployment changes
GitHub Actions workflow