### PR TITLE
Add support to gzip response at the REST layer

### DIFF
--- a/src/python/WMCore/REST/Server.py
+++ b/src/python/WMCore/REST/Server.py
@@ -36,7 +36,8 @@ _RX_CENSOR = re.compile(r"(identified by) \S+", re.I)
 _COMPRESSIBLE = ['text/html', 'text/html; charset=utf-8',
                  'text/plain', 'text/plain; charset=utf-8',
                  'text/css', 'text/css; charset=utf-8',
-                 'text/javascript', 'text/javascript; charset=utf-8']
+                 'text/javascript', 'text/javascript; charset=utf-8',
+                 'application/json']
 
 #: Type alias for arguments passed to REST validation methods, consisting
 #: of `args`, the additional path arguments, and `kwargs`, the query
@@ -649,7 +650,7 @@ class MiniRESTApi(object):
         self.etag_limit = 8 * 1024 * 1024
         self.compression_level = 9
         self.compression_chunk = 64 * 1024
-        self.compression = ['deflate']
+        self.compression = ['deflate', 'gzip']
         self.formats = [('application/json', JSONFormat()),
                         ('application/xml', XMLFormat(self.app.appname))]
         self.methods = {}


### PR DESCRIPTION
Fixes #11082 
Superseeds https://github.com/dmwm/WMCore/pull/11247

#### Status
ready

#### Description
This PR implements the following changes:
* adds support to gzip content within the REST layer (i.e., whenever a client makes an HTTP request with `Accept-Encoding: gzip`, WMCore web-services will serve compressed body data, which needs then to be gzip decompressed on the client application)
* disabled automatic decompression mechanism within libcurl (ACCEPT_ENCODING pycurl attribute). For some obscure reason, with this feature enabled we were having around 18 unit tests failing while writting data to the pycurl buffer. More details in [1]

Some tests with curl have been performed - for reqmgr2, wmstatsserver and ms-transferor - and logs can be found here:
https://amaltaro.web.cern.ch/amaltaro/forWMCore/PR_11343/

If anyone wants to run further tests, services in my alancc7-cloud1 are still up.

NOTE-1: This of course adds an extra CPU load on the server application to compress data, but amount of data to be transferred is drastically lower.
NOTE-2: note that CouchDB is not able to serve compressed data, so any intermediate steps (e.g. ReqMgr2 fetching data from CouchDB) will still be dealt with as a python object or json, until it can be served to the end user.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None

[1]
 Example in:
```
# WMCore_t.MicroService_t.MicroService_t.MicroServiceTest:testPostCall changed from success to error

  File "/build/cmsbld/jenkins/workspace/DMWM-WMCorePy3-PR-unittests/SLICE/2/label/cms-dmwm-cc7/code/src/python/WMCore/Services/pycurl_manager.py", line 329, in request
    curl.perform()
(23, '')
``` 
which is basically this error: https://curl.se/libcurl/c/libcurl-errors.html#CURLE_WRITE_ERROR , but there is no extra information to debug it!