### PR TITLE
Rename t0 package for pypi (to t0-agent)

### DIFF
--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -235,7 +235,7 @@ dependencies = {
         'statics': ['src/couchapps/ACDC+',
                     'src/couchapps/GroupUser+']
     },
-    't0': {
+    't0-agent': {
         'packages': ['WMCore.Agent+', 'WMCore.Algorithms+',
                      'WMCore.JobStateMachine', 'WMComponent+',
                      'WMCore.ThreadPool', 'WMCore.WorkerThreads',


### PR DESCRIPTION
Fixes #11341

#### Status
Testing needed

#### Description
This renames the t0 package for pypi support.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs

#### External dependencies / deployment changes
The following repository would need to make the new `t0-agent` uploaded to pypi a dependency in their requirements.txt file
https://github.com/dmwm/T0/ 

Note:
For the moment (while we still use RPM based deployment) , once this is merged and makes it into a release version that we are planning to use in cmsdist, we would need to modify the spec to rename t0 -> t0-agent in the line below, with that new release version of WMCore:
https://github.com/cms-sw/cmsdist/blob/comp_gcc630/t0.spec#L37