### PR TITLE
Add support to gzip response at the REST layer - take2

### DIFF
--- a/src/python/WMCore/REST/Format.py
+++ b/src/python/WMCore/REST/Format.py
@@ -1,6 +1,8 @@
 from __future__ import print_function
 
+import gzip
 from builtins import str, bytes, object
+
 from Utils.PythonVersion import PY3
 from Utils.Utilities import encodeUnicodeToBytes, encodeUnicodeToBytesConditional
 from future.utils import viewitems
@@ -486,10 +488,19 @@ def _stream_compress_deflate(reply, compress_level, max_chunk):
     if npending:
         yield z.compress(encodeUnicodeToBytes("".join(pending))) + z.flush(zlib.Z_FINISH)
 
+def _stream_compress_gzip(reply, compress_level, max_chunk):
+    """Streaming compressor for the 'gzip' method. Generates output that
+    is guaranteed to expand at the exact same chunk boundaries as original
+    reply stream."""
+    for chunk in reply:
+        yield gzip.compress(encodeUnicodeToBytes(chunk), compress_level)
+
+
 # : Stream compression methods.
 _stream_compressor = {
   'identity': _stream_compress_identity,
-  'deflate': _stream_compress_deflate
+  'deflate': _stream_compress_deflate,
+  'gzip': _stream_compress_gzip
 }
 
 def stream_compress(reply, available, compress_level, max_chunk):

--- a/src/python/WMCore/REST/Server.py
+++ b/src/python/WMCore/REST/Server.py
@@ -36,7 +36,8 @@ _RX_CENSOR = re.compile(r"(identified by) \S+", re.I)
 _COMPRESSIBLE = ['text/html', 'text/html; charset=utf-8',
                  'text/plain', 'text/plain; charset=utf-8',
                  'text/css', 'text/css; charset=utf-8',
-                 'text/javascript', 'text/javascript; charset=utf-8']
+                 'text/javascript', 'text/javascript; charset=utf-8',
+                 'application/json']
 
 #: Type alias for arguments passed to REST validation methods, consisting
 #: of `args`, the additional path arguments, and `kwargs`, the query
@@ -649,7 +650,7 @@ class MiniRESTApi(object):
         self.etag_limit = 8 * 1024 * 1024
         self.compression_level = 9
         self.compression_chunk = 64 * 1024
-        self.compression = ['deflate']
+        self.compression = ['deflate', 'gzip']
         self.formats = [('application/json', JSONFormat()),
                         ('application/xml', XMLFormat(self.app.appname))]
         self.methods = {}

--- a/src/python/WMCore/Services/pycurl_manager.py
+++ b/src/python/WMCore/Services/pycurl_manager.py
@@ -274,6 +274,8 @@ class RequestHandler(object):
         # specific encoding, will fallback to gzip content
         thisHeaders.setdefault("Accept-Encoding", "gzip")
         curl.setopt(pycurl.HTTPHEADER, [encodeUnicodeToBytes("%s: %s" % (k, v)) for k, v in viewitems(thisHeaders)])
+        alan = [encodeUnicodeToBytes("%s: %s" % (k, v)) for k, v in viewitems(thisHeaders)]
+        print(f"AMR setting request headers: {alan}")
 
         bbuf = BytesIO()
         hbuf = BytesIO()

--- a/src/python/WMCore/Services/pycurl_manager.py
+++ b/src/python/WMCore/Services/pycurl_manager.py
@@ -70,18 +70,20 @@ def decompress(body, headers):
     :param headers: dict
     :return: decode body
     """
-    print(f"AMR header content {headers}")
+    print(f"AMR header content {headers} and body {body}")
     encoding = ""
     for header, value in headers.items():
         if header.lower() == 'content-encoding' and 'gzip' in value.lower():
             encoding = 'gzip'
             break
     if encoding != 'gzip':
+        print(f"AMR untouched body {body}")
         return body
 
     try:
-        print("AMR decompressing body")
-        return gzip.decompress(body)
+        data = gzip.decompress(body)
+        print(f"AMR decompress body {data}")
+        return data
     except Exception as exc:
         logger = logging.getLogger()
         msg = "While processing decompress function with headers: %s, " % headers


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/11082
Superseeds https://github.com/dmwm/WMCore/pull/11247

#### Status
In development

#### Description
Trying an slightly different variation of https://github.com/dmwm/WMCore/pull/11343

`Accept-Encoding` feature from libcurl has to be disabled because I've been getting this error in a few unittests:
```
# WMCore_t.MicroService_t.MicroService_t.MicroServiceTest:testPostCall changed from success to error

  File "/build/cmsbld/jenkins/workspace/DMWM-WMCorePy3-PR-unittests/SLICE/2/label/cms-dmwm-cc7/code/src/python/WMCore/Services/pycurl_manager.py", line 329, in request
    curl.perform()
(23, '')
``` 
which is basically this error: https://curl.se/libcurl/c/libcurl-errors.html#CURLE_WRITE_ERROR , but there is no extra information to debug it!

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
