### PR TITLE
Trap DBS3Upload exceptions when fetching child/parent info from wmstats

### DIFF
--- a/test/python/WMComponent_t/DBS3Buffer_t/DBSUpload_t.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/DBSUpload_t.py
@@ -22,7 +22,7 @@ from WMComponent.DBS3Buffer.DBSBufferBlock import DBSBufferBlock
 from WMComponent.DBS3Buffer.DBSBufferDataset import DBSBufferDataset
 from WMComponent.DBS3Buffer.DBSBufferFile import DBSBufferFile
 from WMComponent.DBS3Buffer.DBSBufferUtil import DBSBufferUtil
-from WMComponent.DBS3Buffer.DBSUploadPoller import DBSUploadPoller, isPassiveError, parseDBSException
+from WMComponent.DBS3Buffer.DBSUploadPoller import DBSUploadPoller, parseDBSException
 from WMCore.DAOFactory import DAOFactory
 from WMCore.DataStructs.Run import Run
 from WMCore.Services.UUIDLib import makeUUID
@@ -622,21 +622,6 @@ class DBSUploadTest(unittest.TestCase):
             # We don't trust anyone else with _exit
             del os.environ["DONT_TRAP_EXIT"]
         return
-
-    def testPassiveExceptions(self):
-        """
-        Ensure we are properly evaluating passive/hard exceptions in the
-        `isPassiveError` function.
-        """
-        # hard errors
-        for errMessage in ["Unknown exception", "Proxy WRONG Error", None]:
-            self.assertIs(isPassiveError(MyTestException(errMessage)), False)
-        # soft errors
-        for errMessage in ['Service Unavailable', 'Service Temporarily Unavailable',
-                           'Proxy Error', 'Error reading from remote server',
-                           'Connection refused', 'timed out', 'Could not resolve',
-                           'OpenSSL SSL_connect: SSL_ERROR_SYSCALL']:
-            self.assertIs(isPassiveError(MyTestException(errMessage)), True)
 
     def testParseDBSException(self):
         """


### PR DESCRIPTION
Fixes #9123 

#### Status
not-tested

#### Description
Instead of verifying all the possible failures that might have happened when calling the `wmstatsserver.getChildParentDatasetMap` API, and deciding whether a soft or hard failure needs to get propagated in the component; this PR encapsulates such problems such that the component does not stop its execution.

Error is still reported in the logs and it's also visible through LogDB (through WMStats "error logs" tab).

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
