### PR TITLE
Fix T0Request update function to avoid unneeded documents update

### DIFF
--- a/src/couchapps/T0Request/updates/updaterequest.js
+++ b/src/couchapps/T0Request/updates/updaterequest.js
@@ -36,11 +36,11 @@ function(doc, req)
     function updateTransition(newStatus) {
     	
     	if (allowedStates.indexOf(newStatus) === -1) {
-    		return "not allowed state " + newStatus;
+    		return "Not allowed state: '" + newStatus + "'";
     	}
     	if (doc.RequestStatus && !isAllowedTransiton(doc.RequestStatus, newStatus)) {
     		// don't update the status just ignore
-    		return "not allowed transition " + doc.RequestStatus + " to " + newStatus;
+    		return "Not allowed transition, from: '" + doc.RequestStatus + "' to '" + newStatus + "'";
     	}
     	doc.RequestStatus = newStatus;
     	
@@ -70,6 +70,10 @@ function(doc, req)
     	}
 
     }
-    
-    return [doc, message];
+    if (message == "OK") {
+        return [doc, message];
+    } else {
+        // then do not change anything in the document
+        return [null, message];
+    }
 }

--- a/src/python/WMComponent/TaskArchiver/TaskArchiverPoller.py
+++ b/src/python/WMComponent/TaskArchiver/TaskArchiverPoller.py
@@ -95,10 +95,12 @@ class TaskArchiverPoller(BaseWorkerThread):
 
         if not self.useReqMgrForCompletionCheck:
             # sets the local monitor summary couch db
+            self.tier0CompletedState = "completed"
             self.requestLocalCouchDB = RequestDBWriter(self.config.AnalyticsDataCollector.localT0RequestDBURL,
                                                        couchapp=self.config.AnalyticsDataCollector.RequestCouchApp)
             self.centralCouchDBWriter = self.requestLocalCouchDB
         else:
+            self.tier0CompletedState = None
             self.centralCouchDBWriter = RequestDBWriter(self.config.AnalyticsDataCollector.centralRequestDBURL)
 
             self.reqmgr2Svc = ReqMgr(self.config.General.ReqMgr2ServiceURL)
@@ -235,8 +237,9 @@ class TaskArchiverPoller(BaseWorkerThread):
 
                     # Tier-0 case, the agent has to mark it completed
                     if not self.useReqMgrForCompletionCheck:
-                        self.requestLocalCouchDB.updateRequestStatus(workflow, "completed")
-                        logging.info("status updated to completed %s", workflow)
+                        resp = self.requestLocalCouchDB.updateRequestStatus(workflow, self.tier0CompletedState)
+                        logging.info("Workflow %s updated to status '%s'. Response: %s",
+                                     workflow, self.tier0CompletedState, resp)
 
                     completedWorkflowsDAO.execute([workflow])
 

--- a/test/python/WMCore_t/Services_t/RequestDB_t/T0RequestDB_t.py
+++ b/test/python/WMCore_t/Services_t/RequestDB_t/T0RequestDB_t.py
@@ -7,9 +7,11 @@ from WMCore.Services.RequestDB.RequestDBWriter import RequestDBWriter
 from WMQuality.TestInitCouchApp import TestInitCouchApp
 from WMCore_t.Services_t.WMStats_t.WMStatsDocGenerator import generate_reqmgr_schema
 
+
 class T0RequestDBTest(unittest.TestCase):
     """
     """
+
     def setUp(self):
         """
         _setUp_
@@ -19,8 +21,8 @@ class T0RequestDBTest(unittest.TestCase):
         self.testInit = TestInitCouchApp('RequestDBServiceTest')
         self.testInit.setLogging()
         self.testInit.setDatabaseConnection()
-        self.testInit.setSchema(customModules = self.schema,
-                                useDefault = False)
+        self.testInit.setSchema(customModules=self.schema,
+                                useDefault=False)
         dbName = 't0_requsetdb_t'
         self.testInit.setupCouch(dbName, *self.couchApps)
         reqDBURL = "%s/%s" % (self.testInit.couchUrl, dbName)
@@ -41,31 +43,30 @@ class T0RequestDBTest(unittest.TestCase):
     def testRequestDBWriter(self):
         # test getWork
         schema = generate_reqmgr_schema()
-        result =  self.requestWriter.insertGenericRequest(schema[0])
+        result = self.requestWriter.insertGenericRequest(schema[0])
 
         self.assertEqual(len(result), 1, 'insert fail');
 
         result = self.requestWriter.updateRequestStatus(schema[0]['RequestName'], "assigned")
 
-        self.assertEqual(result, 'not allowed state assigned', 'update fail')
+        self.assertEqual(result, "Not allowed state: 'assigned'", 'update fail')
         self.assertEqual(self.requestWriter.updateRequestStatus("not_exist_schema", "new"),
-                          'Error: document not found')
+                         'Error: document not found')
 
         allowedStates = ["Closed", "Merge", "AlcaSkim", "Harvesting",
                          "Processing Done", "completed"]
         for state in allowedStates:
             self.assertEqual(self.requestWriter.updateRequestStatus(schema[0]['RequestName'], state),
-                          'OK')
+                             'OK')
 
         self.assertEqual(self.requestWriter.updateRequestStatus(schema[0]['RequestName'], "Processing Done"),
-                          'not allowed transition completed to Processing Done')
+                         "Not allowed transition, from: 'completed' to 'Processing Done'")
 
         self.assertEqual(self.requestWriter.updateRequestStatus(schema[0]['RequestName'], "normal-archived"),
-                          'OK')
+                         'OK')
         result = self.requestWriter.getRequestByStatus(["normal-archived"], False, 1)
         self.assertEqual(len(result), 1, "should be 1 but %s" % result)
 
 
 if __name__ == '__main__':
-
     unittest.main()


### PR DESCRIPTION
Fixes #11304 

#### Status
ready

#### Description
This PR fixes the T0Request couchapp update function, ensuring that documents transitioning from/to the same request status are not updated. In other words, if a workflow needs to be updated from status AAA to AAA, the update function will simply skip the document update (hence, the document will keep the same revision number as it had before the update call).

In addition to that, improve the TaskArchiver log record such that we can see what was the outcome of the update call. 

Documentation: https://docs.couchdb.org/en/3.2.2-docs/ddocs/ddocs.html#update-functions

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
In order to apply this patch to the T0 agent, the following set of commands is required:
1. Patch the couchapps area:
```
curl https://patch-diff.githubusercontent.com/raw/dmwm/WMCore/pull/11353.patch | patch -d apps/t0/data/couchapps/ -p 3
```
2. Patch the python code area
```
curl https://patch-diff.githubusercontent.com/raw/dmwm/WMCore/pull/11353.patch | patch -d apps/t0/lib/python3.8/site-packages/ -p 3
```
3. Push the up-to-date CouchApps (before starting all the components, but with CouchDB running):
```
$manage execute-agent wmagent-couchapp-init
```