### PR TITLE
Change github actions filter pattern

### DIFF
--- a/.github/workflows/pypy_build_publish.yaml
+++ b/.github/workflows/pypy_build_publish.yaml
@@ -4,8 +4,7 @@
 on:
   push:
     tags:
-      - '*'
-      - '!JENKINS*'
+      - '*.*.*'
 
 jobs:
   build_and_publish_services:


### PR DESCRIPTION
Fixes #11336

#### Status
ready

#### Description
This filter follows the filter patterns from:
(https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet)
It should match to the production tags in the form of X.Y.Z.something or just X.Y.Z
JENKINS tags do not follow this pattern and will be excluded.

#### Is it backward compatible (if not, which system it affects?)
YES 

#### Related PRs
Overwrites the changes in:
https://github.com/dmwm/WMCore/pull/11337
Since for some reason, JENKINS tags were still triggered with this one in the main repository (yet not on my tests on my fork)

#### External dependencies / deployment changes
GH actions
