### PR TITLE
MSOutput: use AlertManagerAPI from MSCore

### DIFF
--- a/src/python/WMCore/MicroService/MSRuleCleaner/MSRuleCleaner.py
+++ b/src/python/WMCore/MicroService/MSRuleCleaner/MSRuleCleaner.py
@@ -590,12 +590,14 @@ class MSRuleCleaner(MSCore):
             msg += "Error: %s"
             self.logger.exception(msg, wflow['RequestName'], str(ex))
 
-        # Set Transfer status - information fetched from MSOutput only
-        if transferInfo is not None and transferInfo['TransferStatus'] == 'done':
+        if transferInfo is None:
+            msg = f"Workflow {wflow['RequestName']} is still missing the output transfer document."
+            self.logger.warning(msg)
+        elif transferInfo['TransferStatus'] == 'done':
+            # Set Transfer status - information fetched from MSOutput only
             wflow['TransferDone'] = True
-
-        # Set Tape rules status - information fetched from Rucio (tape rule ids from MSOutput)
-        if transferInfo is not None and transferInfo['OutputMap']:
+        elif transferInfo['OutputMap']:
+            # Set Tape rules status - information fetched from Rucio (tape rule ids from MSOutput)
             tapeRulesStatusList = []
             # For setting 'TransferTape' = True we require either no tape rules for the
             # workflow have been created or all existing tape rules to be in status 'OK',


### PR DESCRIPTION
Fixes #11350 

#### Status
not-tested

#### Description
Move the MSOutput Prometheus alert to their own method and use the super class `sendAlert` method to actually create a prometheus alert. This change makes MSOutput more consistent with how the other microservices are implementing these alerts as well.

In addition to this, make a clear record in MSRuleCleaner whenever a workflow is missing its output transfer document.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
