### PR TITLE
Switch mongo client to connect to a fully defined replicaset.

### DIFF
--- a/src/python/WMCore/Database/MongoDB.py
+++ b/src/python/WMCore/Database/MongoDB.py
@@ -221,18 +221,18 @@ class MongoDB(object):
                 try:
                     # self._dbCreate(getattr(self, db))
                     self._dbCreate(db)
-                except Exception as ex:
-                    msg = "Could not create MongoDB databases: %s\n%s\n" % (db, str(ex))
+                except Exception as exc:
+                    msg = "Could not create MongoDB databases: %s\n%s\n" % (db, str(exc))
                     msg += "Giving up Now."
                     self.logger.error(msg)
-                    raise ex
+                    raise exc
                 try:
                     self._dbTest(db)
-                except Exception as ex:
-                    msg = "Second failure while testing %s\n%s\n" % (db, str(ex))
+                except Exception as exc:
+                    msg = "Second failure while testing %s\n%s\n" % (db, str(exc))
                     msg += "Giving up Now."
                     self.logger.error(msg)
-                    raise ex
+                    raise exc
                 msg = "Database %s successfully created" % db
                 self.logger.error(msg)
         except Exception as ex:

--- a/src/python/WMCore/Database/MongoDB.py
+++ b/src/python/WMCore/Database/MongoDB.py
@@ -14,19 +14,19 @@ except ImportError:
     mongomock = None
 
 from pymongo import MongoClient, errors, IndexModel
+from pymongo.errors import ConnectionFailure
 
 
 class MongoDB(object):
     """
     A simple wrapper class for creating a connection to a MongoDB instance
     """
-    def __init__(self, database=None, server=None, port=None, replicaset=None,
+    def __init__(self, database=None, server=None,
                  create=False, collections=None, testIndexes=False,
                  logger=None, mockMongoDB=False, **kwargs):
         """
         :databases:   A database Name to connect to
-        :server:      The server url (see https://docs.mongodb.com/manual/reference/connection-string/)
-        :port:        Server port
+        :server:      The server url or a list of (server:port) pairs (see https://docs.mongodb.com/manual/reference/connection-string/)
         :create:      A flag to trigger a database creation (if missing) during
                       object construction, together with collections if present.
         :collections: A list of tuples describing collections with indexes -
@@ -34,30 +34,73 @@ class MongoDB(object):
                       the rest elements are considered as indexes
         :testIndexes: A flag to trigger index test and eventually to create them
                       if missing (TODO)
+        :mockMongoDB: A flag to trigger a database simulation instead of trying
+                      to connect to a real database server.
         :logger:      Logger
+
+        Here follows a short list of usefull optional parameters accepted by the
+        MongoClient which may be passed as keyword arguments to the current module:
+
+        :replicaSet:       The name of the replica set to connect to. The driver will verify
+                           that all servers it connects to match this name. Implies that the
+                           hosts specified are a seed list and the driver should attempt to
+                           find all members of the set. Defaults to None.
+        :port:             The port number on which to connect. It is overwritten by the ports
+                           defined in the Url string or from the tuples listed in the server list
+        :connect:          If True, immediately begin connecting to MongoDB in the background.
+                           Otherwise connect on the first operation.
+        :directConnection: If True, forces the client to connect directly to the specified MongoDB
+                           host as a standalone. If False, the client connects to the entire
+                           replica set of which the given MongoDB host(s) is a part.
+                           If this is True and a mongodb+srv:// URI or a URI containing multiple
+                           seeds is provided, an exception will be raised.
+        :username:         A string
+        :password:         A string
+                           Although username and password must be percent-escaped in a MongoDB URI,
+                           they must not be percent-escaped when passed as parameters. In this example,
+                           both the space and slash special characters are passed as-is:
+                           MongoClient(username="user name", password="pass/word")
         """
-        self.server = server # '127.0.0.1'
-        self.port = port # 8230
+        self.server = server
         self.logger = logger
         self.mockMongoDB = mockMongoDB
         if mockMongoDB and mongomock is None:
             msg = "You are trying to mock MongoDB, but you do not have mongomock in the python path."
             self.logger.critical(msg)
             raise ImportError(msg)
+
+        # NOTE: We need to explicitely check for server availiability.
+        #       From pymongo Documentation: https://pymongo.readthedocs.io/en/stable/api/pymongo/mongo_client.html
+        #       """
+        #           ...
+        #           Starting with version 3.0 the :class:`MongoClient`
+        #           constructor no longer blocks while connecting to the server or
+        #           servers, and it no longer raises
+        #           :class:`~pymongo.errors.ConnectionFailure` if they are
+        #           unavailable, nor :class:`~pymongo.errors.ConfigurationError`
+        #           if the user's credentials are wrong. Instead, the constructor
+        #           returns immediately and launches the connection process on
+        #           background threads.
+        #           ...
+        #       """
         try:
             if mockMongoDB:
                 self.client = mongomock.MongoClient()
                 self.logger.info("NOTICE: MongoDB is set to use mongomock, instead of real database.")
-            elif replicaset:
-                self.client = MongoClient(self.server, self.port, replicaset=replicaset, **kwargs )
             else:
-                self.client = MongoClient(self.server, self.port, **kwargs)
+                self.client = MongoClient(host=self.server, **kwargs)
             self.client.server_info()
-        except Exception as ex:
-            msg = "Could not connect to MongoDB server: %s\n%s" % (self.server, str(ex))
+            self.client.admin.command('ping')
+        except ConnectionFailure as ex:
+            msg = "Could not connect to MongoDB server: %s. Server not available. \n"
             msg += "Giving up Now."
-            self.logger.error(msg)
-            raise ex
+            self.logger.error(msg, self.server)
+            raise ex from None
+        except Exception as ex:
+            msg = "Could not connect to MongoDB server: %s. Due to unknown reason: %s\n"
+            msg += "Giving up Now."
+            self.logger.error(msg, self.server, str(ex))
+            raise ex from None
         self.create = create
         self.testIndexes = testIndexes
         self.dbName = database

--- a/src/python/WMCore/MicroService/MSOutput/MSOutput.py
+++ b/src/python/WMCore/MicroService/MSOutput/MSOutput.py
@@ -117,23 +117,31 @@ class MSOutput(MSCore):
         self.psn2pnnMap = {}
 
         self.msConfig.setdefault("mongoDBRetryCount", 3)
-        self.msConfig.setdefault("mongoDBReplicaset", None)
+        self.msConfig.setdefault("mongoDBReplicaSet", None)
+        self.msConfig.setdefault("mongoDBPort", None)
         self.msConfig.setdefault("mockMongoDB", False)
 
         msOutIndex = IndexModel('RequestName', unique=True)
+
+        # NOTE: A full set of valid database connection parameters can be found at:
+        #       https://pymongo.readthedocs.io/en/stable/api/pymongo/mongo_client.html
         msOutDBConfig = {
             'database': self.msConfig['mongoDB'],
-            'server': self.msConfig['mongoDBUrl'],
+            'server': self.msConfig['mongoDBServer'],
+            'replicaSet': self.msConfig['mongoDBReplicaSet'],
             'port': self.msConfig['mongoDBPort'],
+            'username': self.msConfig['mongoDBUser'],
+            'password': self.msConfig['mongoDBPassword'],
+            'connect': True,
+            'directConnection': False,
             'logger': self.logger,
             'create': True,
-            'replicaset': self.msConfig['mongoDBReplicaset'],
             'collections': [
                 ('msOutRelValColl', msOutIndex),
                 ('msOutNonRelValColl', msOutIndex)]}
 
-        mongoClt = MongoDB(**msOutDBConfig)
-        self.msOutDB = getattr(mongoClt, self.msConfig['mongoDB'])
+        mongoDB = MongoDB(**msOutDBConfig)
+        self.msOutDB = getattr(mongoDB, self.msConfig['mongoDB'])
         self.msOutRelValColl = self.msOutDB['msOutRelValColl']
         self.msOutNonRelValColl = self.msOutDB['msOutNonRelValColl']
         self.currThread = None

--- a/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
+++ b/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
@@ -197,11 +197,11 @@ class MSUnmerged(MSCore):
                 msg = "WMStatsServer.getProtectedLFNs for T0 is not yet implemented."
                 raise NotImplementedError(msg)
                 # protectedLFNs = set(self.wmstatsSvcT0.getProtectedLFNs())
-                if not protectedLFNsT0:
-                    msg = "Could not fetch the protectedLFNs list from T0 WMStatServer. "
-                    msg += "Skipping the current run."
-                    self.logger.error(msg)
-                    return summary
+                # if not protectedLFNsT0:
+                #     msg = "Could not fetch the protectedLFNs list from T0 WMStatServer. "
+                #     msg += "Skipping the current run."
+                #     self.logger.error(msg)
+                #     return summary
 
             self.protectedLFNs = self.protectedLFNs | protectedLFNsT0
 
@@ -316,7 +316,7 @@ class MSUnmerged(MSCore):
             msg = "RSE: %s, Failed to create gfal2 Context object. " % rse['name']
             msg += "Skipping it in the current run."
             self.logger.exception(msg)
-            raise MSUnmergedPlineExit(msg)
+            raise MSUnmergedPlineExit(msg) from ex
 
         filesToDeleteCurrRSE = 0
 
@@ -534,7 +534,7 @@ class MSUnmerged(MSCore):
                 msg = "Could not reset RSE to MongoDB for the maximum of %s mongoDBRetryCounts configured." % self.msConfig['mongoDBRetryCount']
                 msg += "Giving up now. The whole cleanup process will be retried for this RSE on the next run."
                 msg += "Duplicate deletion retries may cause error messages from false positives and wrong counters during next polling cycle."
-                raise MSUnmergedPlineExit(msg)
+                raise MSUnmergedPlineExit(msg) from None
 
         # Before returning the RSE update Consistency StatTime:
         rse['timestamps']['rseConsStatTime'] = self.rseConsStats[rseName]['end_time']
@@ -803,7 +803,7 @@ class MSUnmerged(MSCore):
         :param rse: The RSE object to work on
         :return:    rse
         """
-        self.logger.info("RSE: %s Reading rse data from MongoDB." % rse['name'])
+        self.logger.info("RSE: %s Reading rse data from MongoDB.", rse['name'])
         rse.readRSEFromMongoDB(self.msUnmergedColl)
         return rse
 
@@ -814,13 +814,13 @@ class MSUnmerged(MSCore):
         :return:    rse
         """
         try:
-            self.logger.info("RSE: %s Writing rse data to MongoDB." % rse['name'])
+            self.logger.info("RSE: %s Writing rse data to MongoDB.", rse['name'])
             rse.writeRSEToMongoDB(self.msUnmergedColl, fullRSEToDB=fullRSEToDB, overwrite=overwrite, retryCount=self.msConfig['mongoDBRetryCount'])
         except NotPrimaryError:
             msg = "Could not write RSE to MongoDB for the maximum of %s mongoDBRetryCounts configured." % self.msConfig['mongoDBRetryCount']
             msg += "Giving up now. The whole cleanup process will be retried for this RSE on the next run."
             msg += "Duplicate deletion retries may cause error messages from false positives and wrong counters during next polling cycle."
-            raise MSUnmergedPlineExit(msg)
+            raise MSUnmergedPlineExit(msg) from None
         return rse
 
     def getStatsFromMongoDB(self, detail=False, **kwargs):

--- a/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
+++ b/src/python/WMCore/MicroService/MSUnmerged/MSUnmerged.py
@@ -106,26 +106,31 @@ class MSUnmerged(MSCore):
         self.msConfig.setdefault("emulateGfal2", False)
         self.msConfig.setdefault("filesToDeleteSliceSize", 100)
 
-        self.msConfig.setdefault("mongoDBUrl", 'mongodb://localhost')
-        self.msConfig.setdefault("mongoDBPort", 27017)
-        self.msConfig.setdefault("mongoDB", 'msUnmergedDB')
         self.msConfig.setdefault("mongoDBRetryCount", 3)
-        self.msConfig.setdefault("mongoDBReplicaset", None)
+        self.msConfig.setdefault("mongoDBReplicaSet", None)
+        self.msConfig.setdefault("mongoDBPort", None)
         self.msConfig.setdefault("mockMongoDB", False)
 
         msUnmergedIndex = IndexModel('name', unique=True)
+
+        # NOTE: A full set of valid database connection parameters can be found at:
+        #       https://pymongo.readthedocs.io/en/stable/api/pymongo/mongo_client.html
         msUnmergedDBConfig = {
             'database': self.msConfig['mongoDB'],
-            'server': self.msConfig['mongoDBUrl'],
+            'server': self.msConfig['mongoDBServer'],
             'port': self.msConfig['mongoDBPort'],
-            'replicaset': self.msConfig['mongoDBReplicaset'],
+            'replicaSet': self.msConfig['mongoDBReplicaSet'],
+            'username': self.msConfig['mongoDBUser'],
+            'password': self.msConfig['mongoDBPassword'],
+            'connect': True,
+            'directConnection': False,
             'logger': self.logger,
             'create': True,
             'mockMongoDB': self.msConfig['mockMongoDB'],
             'collections': [('msUnmergedColl', msUnmergedIndex)]}
 
-        mongoClt = MongoDB(**msUnmergedDBConfig)
-        self.msUnmergedDB = getattr(mongoClt, self.msConfig['mongoDB'])
+        mongoDB = MongoDB(**msUnmergedDBConfig)
+        self.msUnmergedDB = getattr(mongoDB, self.msConfig['mongoDB'])
         self.msUnmergedColl = self.msUnmergedDB['msUnmergedColl']
 
         if self.msConfig['emulateGfal2'] is False and gfal2 is None:

--- a/test/python/WMCore_t/MicroService_t/MSUnmerged_t/MSUnmerged_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSUnmerged_t/MSUnmerged_t.py
@@ -33,9 +33,9 @@ class RucioConMonEmul(object):
 
         self.rseUnmergedDumpFile = getTestFile('data/WMCore/MicroService/MSUnmerged/rseUnmergedDump.json')
         self.rseConsStatsDumpFile = getTestFile('data/WMCore/MicroService/MSUnmerged/rseConsStatsDump.json')
-        with open(self.rseUnmergedDumpFile) as fd:
+        with open(self.rseUnmergedDumpFile, encoding="utf-8") as fd:
             self.rseUnmergedDump = json.load(fd)
-        with open(self.rseConsStatsDumpFile) as fd:
+        with open(self.rseConsStatsDumpFile, encoding="utf-8") as fd:
             self.rseConsStatsDump = json.load(fd)
 
     def getRSEStats(self):
@@ -89,7 +89,7 @@ class WMStatsServerEmul(object):
         super(WMStatsServerEmul, self).__init__()
 
         self.protectedLFNsDumpFile = getTestFile('data/WMCore/MicroService/MSUnmerged/protectedLFNsDump.json')
-        with open(self.protectedLFNsDumpFile) as fd:
+        with open(self.protectedLFNsDumpFile, encoding="utf-8") as fd:
             self.protectedLFNsDump = json.load(fd)
 
     def getProtectedLFNs(self):
@@ -128,7 +128,11 @@ class MSUnmergedTest(unittest.TestCase):
                          'dirFilterIncl': [],
                          'dirFilterExcl': [],
                          'emulateGfal2': True,
-                         'mockMongoDB': True}
+                         'mockMongoDB': True,
+                         'mongoDB': 'msUnmergedDBUnit',
+                         'mongoDBServer': 'mongodb://localhost',
+                         'mongoDBUser': None,
+                         'mongoDBPassword': None}
 
         self.creds = {"client_cert": os.getenv("X509_USER_CERT", "Unknown"),
                       "client_key": os.getenv("X509_USER_KEY", "Unknown")}


### PR DESCRIPTION
Fixes #11210 

#### Status
Ready

#### Description

With the MongoDBAsAService configuration that we were having so far in production, for the sake of simplicity and stability (not having volatile names of a set of pods to connect to), we were relying on a DNS loadbalancer setup in front of the pods serving the database. That way we were having a single entry point. While being quite comfortable for us, this was causing some additional work and effort for CMSWEB team and we were also having some retried writes when we were to stumble on the situation of not having a session with the replicaset master. This was due to the fact that the loadbalancer in front of the replicaset was choosing randomly the hostname from the backends to connect to, rather than letting the full client/server communication to take place and have the proper discovery of the replica master among all the participating pods in the replicaset. This is easily avoidable if we have a hostname alias set in the pod's setup itslef (as it is now  for the test MongoDBAsAService cluster)  and have the pods serving the replicaset always been named as e.g. `mongodb-test.cern.ch`. In that case on our end we may have the mongo client pointing not to a fully constructed and "percent-escaped"  `MongoDB URI` of the kind:  
```
mongodb://UNAME:PASSWD@mongodb-test.cern.ch
``` 
with a single port, but rather having all `hostname:ports` tuples listed in the connection configuration and avoiding any `urllib` escaping for the `password` and `username` strings. This makes things much more reliable but was requiring the code changes from this PR on our end.     

#### Is it backward compatible (if not, which system it affects?)
YES
BUT strongly depends on the `services_config` changes in the `prod` branch and the production MongoDB cluster setup.

#### Related PRs
Her to be added the relative `services_config` PRs:
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/171
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/173
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/172

**NOTE:**
Similarly, we also need the same changes for MSUnmerged configuration and for all branches `prod`, `preprod`, `test`

#### External dependencies / deployment changes
**NOTE:**
We need to test if this connection is properly working with the current production cluster of MongoDBAsAService setup such that  we can connect to the cluster skipping the DNS loadbalancer and avoiding any additional change in this setup.    