### PR TITLE
Given a block name in DBS3Upload config, dump its info as json

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -153,7 +153,8 @@ config.DBS3Upload.pollInterval = 100
 # "https://cmsweb-prod.cern.ch/dbs/prod/global/DBSWriter" - production one
 config.DBS3Upload.dbsUrl = "OVERWRITE_BY_SECRETS"
 config.DBS3Upload.primaryDatasetType = "mc"
-config.DBS3Upload.dumpBlock = False  # to dump block meta-data into a json file
+# provided a block name, this will dump all the block info in a json file
+config.DBS3Upload.dumpBlockJsonFor = ""
 # set DbsApi requests to use gzip enconding, thus sending compressed data
 config.DBS3Upload.gzipEncoding = True
 

--- a/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
@@ -197,7 +197,7 @@ class DBSUploadPoller(BaseWorkerThread):
 
         self.filesToUpdate = []
 
-        self.produceCopy = getattr(self.config.DBS3Upload, 'dumpBlock', False)
+        self.dumpBlockJsonFor = getattr(self.config.DBS3Upload, 'dumpBlockJsonFor', "")
 
         self.copyPath = os.path.join(getattr(self.config.DBS3Upload, 'componentDir', '/data/srv/'),
                                      'dbsuploader_block.json')
@@ -694,7 +694,8 @@ class DBSUploadPoller(BaseWorkerThread):
             logging.info("Queueing block for insertion: %s", block.getName())
             self.workInput.put({'name': block.getName(), 'block': encodedBlock})
             self.blockCount += 1
-            if self.produceCopy:
+            if self.dumpBlockJsonFor and (self.dumpBlockJsonFor == block.getName()):
+                logging.info("Dumping '%s' information into %s", block.getName(), self.copyPath)
                 with open(self.copyPath, 'w') as jo:
                     json.dump(encodedBlock, jo, indent=2)
             self.queuedBlocks.append(block.getName())


### PR DESCRIPTION
Fixes #11358 

#### Status
ready

#### Description
Renamed the DBS3Upload `dumpBlock` attribute to `dumpBlockJsonFor`, such that now, whenever a block name string is provided for the component configuration, the component creates a json.dump of the same data that gets posted to the DBS server, through the client `insertBulkBlock` API.

#### Is it backward compatible (if not, which system it affects?)
NO (previous attribute is removed, a new one goes in)

#### Related PRs
None

#### External dependencies / deployment changes
None