### PR TITLE
Update rucio-clients version from 1.25.5 to 1.29.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@
 Cheetah3~=3.2.6.post1         # wmcore,wmagent,reqmgr2,reqmon
 CherryPy~=18.8.0              # wmcore,wmagent,wmagent-devtools,reqmgr2,reqmon,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner
 CMSCouchapp~=1.3.4            # wmcore,wmagent
-CMSMonitoring~=0.6.9          # wmcore,wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner
+CMSMonitoring~=0.6.10         # wmcore,wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner
 coverage~=5.4                 # wmcore,wmagent,wmagent-devtools
 cx-Oracle~=8.3.0              # wmcore,wmagent
 dbs3-client~=4.0.12           # wmcore,wmagent,reqmgr2,reqmon,global-workqueue
@@ -38,7 +38,7 @@ pymongo~=4.2.0                # wmcore,wmagent-devtools,reqmgr2ms-unmerged,reqmg
 pyOpenSSL~=18.0.0             # wmcore,wmagent
 pyzmq~=23.2.1                 # wmcore,wmagent
 retry~=0.9.2                  # wmcore,wmagent,wmagent-devtools,reqmgr2,reqmon,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner
-rucio-clients~=1.25.5         # wmcore,wmagent,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner
+rucio-clients~=1.29.10        # wmcore,wmagent,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner
 Sphinx~=5.1.1                 # wmcore,wmagent,wmagent-devtools,reqmgr2,reqmon,acdcserver,global-workqueue
 SQLAlchemy~=1.4.40            # wmcore,wmagent
 PyJWT~=2.4.0                  # wmcore,wmagent,wmagent-devtools,reqmgr2,reqmon,acdcserver,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner


### PR DESCRIPTION
Fixes #11359

#### Status
not-tested

#### Description
This pull request updates the python `rucio-clients` package to the latest stable release, `1.29.10`.
It also brings in `cmsmonitoring` from 0.6.9 to 0.6.10 (to resolve a dependency conflict with jsonschema)

As usual, a few inter-dependent libraries get updated as well.

#### Is it backward compatible (if not, which system it affects?)
MAYBE

#### Related PRs
None

#### External dependencies / deployment changes
cmsdist spec: https://github.com/cms-sw/cmsdist/pull/8196

UPDATE: there are hard dependencies on the cryptography library and changes to the manage script are required, please see https://github.com/dmwm/WMCore/issues/11378#issuecomment-1331938834 for further details.
