### PR TITLE
Update buildrelease.sh to consider release-candidate tags

### DIFF
--- a/bin/buildrelease.sh
+++ b/bin/buildrelease.sh
@@ -31,8 +31,8 @@ if [ -z $TAG ]; then
 fi
 
 # Check whether this git branch is allowed to be tagged
-if ! echo ${GITBRANCH} | egrep -iq 'master|_wmagent|_crab|_cmsweb|_dbs' ; then
-  echo "ABORTING - Can only release from master / _crab / _dbs / _wmagent / _cmsweb branches: ${GITBRANCH}"
+if ! echo ${GITBRANCH} | egrep -iq 'master|_wmagent|_crab|_cmsweb' ; then
+  echo "ABORTING - Can only release from master / _crab / _wmagent / _cmsweb branches: ${GITBRANCH}"
   exit 4
 fi
 
@@ -56,7 +56,7 @@ echo "Updating version string ..."
 perl -p -i -e "s{__version__ =.*}{__version__ = '$TAG'}g" src/python/WMCore/__init__.py
 
 echo "Generating CHANGES file"
-LASTCOMMITLINE=$(git log -n1 --oneline -E --grep="^[0-9]+\.[0-9]+\.[0-9]+\.*(pre|patch)*[0-9]*$")
+LASTCOMMITLINE=$(git log -n1 --oneline -E --grep="^[0-9]+\.[0-9]+\.[0-9]+\.*(rc|patch)*[0-9]*$")
 LASTCOMMIT=$(echo ${LASTCOMMITLINE} | awk '{print $1}')
 LASTVERSION=$(echo ${LASTCOMMITLINE} | awk '{print $2}')
 


### PR DESCRIPTION
Fixes #11369 

#### Status
ready

#### Description
Updates the buildrelease.sh script such that it does a diff of commits between the correct tags (now including release candidate and 4-digit versions).

It has been tested between 2.1.5rc1 and 2.1.5rc2 and the release notes (CHANGES) have been correctly updated.

#### Is it backward compatible (if not, which system it affects?)
NO

#### Related PRs
None

#### External dependencies / deployment changes
Documentation updated in: https://github.com/dmwm/WMCore/wiki/TaggingAndReleasing#new-tagging-convention
