### PR TITLE
Add alert to MSRuleCleaner for not archived workflows.

### DIFF
--- a/test/python/WMCore_t/MicroService_t/MSRuleCleaner_t/MSRuleCleaner_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSRuleCleaner_t/MSRuleCleaner_t.py
@@ -46,6 +46,7 @@ class MSRuleCleanerTest(unittest.TestCase):
                          "logDBUrl": "https://cmsweb-testbed.cern.ch/couchdb/wmstats_logdb",
                          'logDBReporter': 'reqmgr2ms_ruleCleaner',
                          'archiveDelayHours': 8,
+                         'archiveAlarmHours': 30 * 24,
                          'enableRealMode': False}
 
         self.creds = {"client_cert": os.getenv("X509_USER_CERT", "Unknown"),


### PR DESCRIPTION
Fixes #11094 
Supersedes  #11299

#### Status
Ready

#### Description
With the current PR an alarm is added  to MSRuleCleaner for throwing an alert for workflows stuck and not archived for more than a configurable amount of time. The configurable parameter should be read from `msConfig['archiveAlarmHours']`. The check should be performed only for workflows sitting in `announced`.  

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
`service_config` related changes:

https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/174
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/175
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/176

#### External dependencies / deployment changes
None