### PR TITLE
Replace dash in exporter name

### DIFF
--- a/src/python/Utils/CPMetrics.py
+++ b/src/python/Utils/CPMetrics.py
@@ -195,6 +195,9 @@ def promMetrics(data, exporter):
     """
     Provide cherrypy stats prometheus metrics for given exporter name.
     """
+    # exporter name should not contain dashes, see
+    # https://its.cern.ch/jira/browse/CMSMONIT-514
+    exporter = exporter.replace("-", "_")
     metrics = flattenStats(data)
     if isinstance(metrics, str):
         metrics = json.loads(metrics)

--- a/test/python/Utils_t/CPMetrics_t.py
+++ b/test/python/Utils_t/CPMetrics_t.py
@@ -39,10 +39,10 @@ class CPMetricsTests(unittest.TestCase):
         """
         Test the flattenStats function
         """
-        data = promMetrics(self.testData, 'test')
+        data = promMetrics(self.testData, 'test-exporter')
         self.assertEqual("# HELP" in data, True)
         self.assertEqual("# TYPE" in data, True)
-        self.assertEqual("test_cherrypy_app_bytes_read_request" in data, True)
+        self.assertEqual("test_exporter_cherrypy_app_bytes_read_request" in data, True)
         self.assertEqual("bla-bla" in data, False)
 
 


### PR DESCRIPTION
Fixes #11380 

#### Status
ready

#### Description
Replace dash in exporter name with underscore.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs

#### External dependencies / deployment changes
