### PR TITLE
Remove obsolete estimate_ttc parameter to Rucio client calls.

### DIFF
--- a/src/python/WMCore/Services/Rucio/Rucio.py
+++ b/src/python/WMCore/Services/Rucio/Rucio.py
@@ -642,18 +642,17 @@ class Rucio(object):
             self.logger.error("Exception listing parent DIDs for data: %s. Error: %s", name, str(ex))
         return list(res)
 
-    def getRule(self, ruleId, estimatedTtc=False):
+    def getRule(self, ruleId):
         """
         _getRule_
 
         Retrieve rule information for a given rule id
         :param ruleId: string with the rule id
-        :param estimatedTtc: bool, if rule_info should return ttc information
         :return: a dictionary with the rule data (or empty if no rule can be found)
         """
         res = {}
         try:
-            res = self.cli.get_replication_rule(ruleId, estimate_ttc=estimatedTtc)
+            res = self.cli.get_replication_rule(ruleId)
         except RuleNotFound:
             self.logger.error("Cannot find any information for rule id: %s", ruleId)
         except Exception as ex:


### PR DESCRIPTION
Fixes #11382 

#### Status
ready

#### Description
With the current PR we remove the obsolete parameter ` estimate_ttc` from the call to the Rucio client's method ` 
get_replication_rule()` made by the WMCore Rucio wrapper. 

#### Is it backward compatible (if not, which system it affects?)
YES 

#### Related PRs
None

#### External dependencies / deployment changes
None
