### PR TITLE
MSRuleCleaner: properly evaluate tape transfers

### DIFF
--- a/src/python/WMCore/MicroService/MSRuleCleaner/MSRuleCleaner.py
+++ b/src/python/WMCore/MicroService/MSRuleCleaner/MSRuleCleaner.py
@@ -593,15 +593,18 @@ class MSRuleCleaner(MSCore):
         if transferInfo is None:
             msg = f"Workflow {wflow['RequestName']} is still missing the output transfer document."
             self.logger.warning(msg)
+        elif transferInfo['TransferStatus'] == 'pending':
+            msg = f"Workflow {wflow['RequestName']} is still pending the output data placement."
+            self.logger.warning(msg)
         elif transferInfo['TransferStatus'] == 'done':
             # Set Transfer status - information fetched from MSOutput only
             wflow['TransferDone'] = True
-        elif transferInfo['OutputMap']:
+
             # Set Tape rules status - information fetched from Rucio (tape rule ids from MSOutput)
-            tapeRulesStatusList = []
             # For setting 'TransferTape' = True we require either no tape rules for the
             # workflow have been created or all existing tape rules to be in status 'OK',
             # so every empty TapeRuleID we consider as completed.
+            tapeRulesStatusList = []
             for mapRecord in transferInfo['OutputMap']:
                 if not mapRecord['TapeRuleID']:
                     continue


### PR DESCRIPTION
Fixes #11363

#### Status
ready

#### Description
As it can be seen in the code changes, the reason we were accumulating workflows in non-archived status comes from the fact that we were never executing the block of code that evaluates output tape transfers, thus always mapping them to incomplete.

These changes have been directly made to the MSRuleCleaner pod (ms-rulecleaner-78d7c79d8-nsqf8) and I can confirm that workflows started getting properly archived once again.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
This bug has been inserted less than a month ago with the changes that I provided here:
https://github.com/dmwm/WMCore/pull/11357
I am very sorry about that!

#### External dependencies / deployment changes
None
