### PR TITLE
Add try/except block for fetching PartialCopy parameter from campaign configuration.

### DIFF
--- a/src/python/WMCore/MicroService/MSMonitor/MSMonitor.py
+++ b/src/python/WMCore/MicroService/MSMonitor/MSMonitor.py
@@ -230,9 +230,18 @@ class MSMonitor(MSCore):
             # check completion of all transfers
             statuses = []
             for transfer in record['transfers']:
-                cdict = campaigns[transfer['campaignName']]
+                try:
+                    cdict = campaigns[transfer['campaignName']]
+                    partialCopy = cdict['PartialCopy']
+                except Exception as ex:
+                    # Just log the error and stop checking any further transfers for the current request.
+                    status = 0
+                    statuses.append(status)
+                    msg = "Missing or broken campaign configuration at ReqMgr for request: %s. Error: %s"
+                    self.logger.exception(msg, reqName, str(ex))
+                    break
                 # compare against the last completion number, which is from the last cycle execution
-                if transfer['completion'][-1] >= cdict['PartialCopy'] * 100:
+                if transfer['completion'][-1] >= partialCopy * 100:
                     status = 1
                 else:
                     status = 0


### PR DESCRIPTION
Fixes #11386 

#### Status
ready

#### Description
When a compaign configuration for a given workflow transfer is missing at `ReqMgr`, `MSMonitor` breaks the execution of the polling cycle, but not the service. In order to prevent the service from skipping all the workflows from the current polling cycle due to a single transfer error, with the  current PR we add a try/except block around the step at which a the campaign parameters for the transfer are obtained.  

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None