### PR TITLE
Change RucioConMon APIs' prefix.

### DIFF
--- a/src/python/WMCore/Services/RucioConMon/RucioConMon.py
+++ b/src/python/WMCore/Services/RucioConMon/RucioConMon.py
@@ -100,7 +100,7 @@ class RucioConMon(Service):
         update timestamps for all RSEs known to CMS Rucio
         :return: A dictionary
         """
-        uri = "/WM/stats"
+        uri = "stats"
         rseStats = self._getResult(uri, callname='stats')
         return rseStats
 
@@ -118,11 +118,11 @@ class RucioConMon(Service):
         #       reading/streaming from file. This will prevent any set arithmetic
         #       in the future.
         if not zipped:
-            uri = "WM/files?rse=%s&format=json" % rseName
+            uri = "files?rse=%s&format=json" % rseName
             rseUnmerged = self._getResult(uri, callname=rseName)
             return rseUnmerged
         else:
-            uri = "WM/files?rse=%s&format=raw" % rseName
+            uri = "files?rse=%s&format=raw" % rseName
             callname = '{}.zipped'.format(rseName)
             rseUnmerged = self._getResultZipped(uri,  callname=callname, clearCache=True)
             return rseUnmerged


### PR DESCRIPTION
Fixes #11388 

#### Status
ready

#### Description
With the current PR we are changing the API prefix of the RucioConMon Url. There has been a change/rearrangement of the APIs' paths on the Rucio Consistency Monitoring  side, which was not reflected in our code.  

#### Is it backward compatible (if not, which system it affects?)
NO

**NOTE:** We need to wait for confirmation from Rucio Team the change is about to be permanent, before we merge and patch our production services.

#### Related PRs
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/182
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/181
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/180

#### External dependencies / deployment changes
RucioConMon server