### PR TITLE
Add all the subpackages for each microservice

### DIFF
--- a/setup_build.py
+++ b/setup_build.py
@@ -20,9 +20,11 @@ def walk_dep_tree(system):
     statics that the system depends on.
 
     system is a dict containing:
-        {'packages': ['Package'],
-         'systems':['foo'],
-         'statics': ['bar']}
+        {'bin': ['bin_script_A'],
+         'packages': ['package_name_A'],
+         'modules': ['module_name_A'],
+         'systems':['system_name_A'],
+         'statics': ['non_python_statics_A']}
     """
     packages = set()
     statics = set()
@@ -153,13 +155,12 @@ def things_to_build(command, pypi=False):
 
     # and the corresponding source directories and files
     package_src_dirs = []
-    module_src_files = []
     for package in dependency_tree['packages']:
         # Need to recurse packages
         recurse = package.endswith('+')
         print(package, recurse)
         package = package.rstrip('+')
-        src_path = '%s/src/python/%s' % (get_path_to_wmcore_root(), package.replace('.','/'))
+        src_path = '%s/src/python/%s' % (get_path_to_wmcore_root(), package.replace('.', '/'))
         package_src_dirs.extend(list_packages([src_path], recurse))
     return package_src_dirs, dependency_tree['modules']
 

--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python
 """
-Manage dependancies by declaring systems here.
-A system can depend on packages or other systems.
-If a package ends with a + include all subpackages.
+This data structure is consumed by the setup_build.py script, in order to add
+the required packages to each of the WMCore systems.
+
+It contains the name of the systems that can be built out of the WMCore
+repository, and their list of dependencies, which can be:
+ * bin: list with the name of executable scripts available in the root bin/ area
+ * packages: list with the name of a WMCore python packages (i.e. a directory
+   containing an __init__.py file)
+     * note that if it's suffixed with the '+' sign, subpackages will also be
+     recursively searched and added to the final system
+ * modules: list with the name of specific modules (a .py file) to be added.
+ * statics: list with the name of files classified as statics, e.g. css, templates,
+   javascript, etc.
+ * systems: list with WMCore system aliases (i.e., like a meta-package that can
+   be used by multiple WMCore systems).
 """
 dependencies = {
     'wmc-rest': {
@@ -129,23 +141,23 @@ dependencies = {
         'statics': [],
     },
     'reqmgr2ms-unmerged': {
-        'packages': ['WMCore.MicroService.MSUnmerged'],
+        'packages': ['WMCore.MicroService.MSUnmerged+'],
         'systems': ['reqmgr2ms-core'],
     },
     'reqmgr2ms-output': {
-        'packages': ['WMCore.MicroService.MSOutput'],
+        'packages': ['WMCore.MicroService.MSOutput+'],
         'systems': ['reqmgr2ms-core'],
     },
     'reqmgr2ms-transferor': {
-        'packages': ['WMCore.MicroService.MSTransferor'],
+        'packages': ['WMCore.MicroService.MSTransferor+'],
         'systems': ['reqmgr2ms-core'],
     },
     'reqmgr2ms-monitor': {
-        'packages': ['WMCore.MicroService.MSMonitor'],
+        'packages': ['WMCore.MicroService.MSMonitor+'],
         'systems': ['reqmgr2ms-core'],
     },
     'reqmgr2ms-rulecleaner': {
-        'packages': ['WMCore.MicroService.MSRuleCleaner'],
+        'packages': ['WMCore.MicroService.MSRuleCleaner+'],
         'systems': ['reqmgr2ms-core'],
     },
     'global-workqueue': {


### PR DESCRIPTION
Fixes #11391 

#### Status
not-tested

#### Description
Lack of subpackages has been tracked down to the setup_build.py script, which looks for the `+` sign in the package name to decide whether to recursively look for packages or not. I fixed only a couple of pylints on that one.

Real change has been made to the setup_dependencies module, where we list the required packages for each of the microservices.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None. However, a different way to fix it would be by enabling all the subpackages to be added by default. It might be less error prone in the future, but it would remove one level of freedom that we have right now...

#### External dependencies / deployment changes
New Pypi packages need to be rebuilt.
