### PR TITLE
Upload total Stats at workflow status transition.

### DIFF
--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -1135,6 +1135,8 @@ class WorkQueue(WorkQueueBase):
 
                     if not continuous:
                         # Update to Acquired when it's the first processing of inbound work
+                        if not self.params.get("UnittestFlag", False):
+                            self.reqmgrSvc.updateRequestStats(inbound['WMSpec'].name(), totalStats)
                         self.backend.updateInboxElements(inbound.id, Status='Acquired')
 
                     # store the inputs in the global queue inbox workflow element


### PR DESCRIPTION
Fixes #11183

#### Status
In development 

#### Description
The current PR is aiming to make the workflow status transition and workflow statistics upload to CouchDB an atomic action. We unfortunately cannot cover all the cases when the `processInboundWork` method  is called within a single step so that's why we need to perform the statistics upload twice, one of which needs to happen right before the workflow status update.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None