### PR TITLE
Build docker image for t0_reqmon

### DIFF
--- a/.github/workflows/pypi_build_and_images.yaml
+++ b/.github/workflows/pypi_build_and_images.yaml
@@ -41,7 +41,7 @@ jobs:
     needs: [build_and_publish_services]
     strategy:
       matrix:
-        target: [wmagent, reqmon, reqmgr2, reqmgr2ms-unmerged, global-workqueue,
+        target: [wmagent, reqmon, t0_reqmon, reqmgr2, reqmgr2ms-unmerged, global-workqueue,
                  reqmgr2ms-output, reqmgr2ms-rulecleaner, reqmgr2ms-transferor, reqmgr2ms-monitor]
     uses: ./.github/workflows/docker_images_template.yaml
     with:


### PR DESCRIPTION
Fixes #11390 

#### Status
ready

#### Description
The title says it all. With this PR, we will automatically build a docker image for the `t0_reqmon`  as well.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None