### PR TITLE
Add crt/key path resolution during service creation

### DIFF
--- a/src/python/WMCore/Services/Requests.py
+++ b/src/python/WMCore/Services/Requests.py
@@ -118,9 +118,21 @@ class Requests(dict):
             cache_dir = (self.cachePath(idict.get('cachepath'), idict.get('service_name')))
             self["cachepath"] = cache_dir
             self["req_cache_path"] = os.path.join(cache_dir, '.cache')
+
+        # Try to resolve the key/cert pair path in the constructor:
+        # NOTE: Calling self.getKeyCert() assures that if the pair is already provided by
+        #       the caller (e.g. the higher level Service class) through the `idict' argument
+        #       during construction time, no additional os.environ calls would be made.
+        #       If the pair is not provided anywhere: not by the higher level class
+        #       nor from the environment, Exception will be raised early during construction
+        #       time rather than later during an internel method call.
         self.setdefault("cert", None)
         self.setdefault("key", None)
+        self['key'], self['cert'] = self.getKeyCert()
+
         self.setdefault('capath', None)
+        self['capath'] = self.getCAPath()
+
         self.setdefault("timeout", 300)
         self.setdefault("logger", logging)
 


### PR DESCRIPTION
Fixes #11397 

#### Status
ready

#### Description
With the current change the path of the `cert/key` pair for the `RucioConMon` service object at `MSUnmerged`   is added to the object during creation time. This avoids consecutive path resolutions on every HTTP call during service's cache refresh. 

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
