### PR TITLE
Convert bin/ scripts to python3-only

### DIFF
--- a/bin/HWMon/wmcore-SysStat
+++ b/bin/HWMon/wmcore-SysStat
@@ -5,8 +5,6 @@ wmcore-SysStat
 
 Hardware monitoring utility for launched sensor daemons.
 """
-from __future__ import print_function
-
 import sys
 import os
 import getopt

--- a/bin/adhoc-scripts/ParseSpecCmsswdist.py
+++ b/bin/adhoc-scripts/ParseSpecCmsswdist.py
@@ -104,7 +104,7 @@ but it can help identifying show-stoppers for the migration.
 
 """
 
-from __future__ import division  # Jenkins CI
+  # Jenkins CI
 
 import argparse
 import os

--- a/bin/adhoc-scripts/checkDsetFileCount.py
+++ b/bin/adhoc-scripts/checkDsetFileCount.py
@@ -4,13 +4,11 @@ Script meant to fetch the number of blocks and files for a given dataset,
 using both DBS and Rucio services. It prints any inconsistency among
 those two.
 """
-from __future__ import print_function, division
+
 
 import logging
 import sys
 from collections import Counter
-
-from future.utils import viewkeys, viewvalues
 
 from WMCore.Services.DBS.DBS3Reader import DBS3Reader
 from WMCore.Services.Rucio.Rucio import Rucio
@@ -95,20 +93,20 @@ def main():
     dbsOutput, dbsFilesCounter = getFromDBS(datasetName, logger)
 
     logger.info("*** Dataset: %s", datasetName)
-    logger.info("Rucio file count : %s", sum(viewvalues(rucioOutput)))
+    logger.info("Rucio file count : %s", sum(rucioOutput.values()))
     logger.info("DBS file count   : %s", dbsFilesCounter['valid'] + dbsFilesCounter['invalid'])
     logger.info(" - valid files   : %s", dbsFilesCounter['valid'])
     logger.info(" - invalid files : %s", dbsFilesCounter['invalid'])
-    logger.info("Blocks in Rucio but not in DBS: %s", set(viewkeys(rucioOutput)) - set(viewkeys(dbsOutput)))
-    logger.info("Blocks in DBS but not in Rucio: %s", set(viewkeys(dbsOutput)) - set(viewkeys(rucioOutput)))
+    logger.info("Blocks in Rucio but not in DBS: %s", set(rucioOutput.keys()) - set(dbsOutput.keys()))
+    logger.info("Blocks in DBS but not in Rucio: %s", set(dbsOutput.keys()) - set(rucioOutput.keys()))
 
     for blockname in rucioOutput:
         if blockname not in dbsOutput:
             logger.error("This block does not exist in DBS: %s", blockname)
             continue
-        if rucioOutput[blockname] != sum(viewvalues(dbsOutput[blockname])):
+        if rucioOutput[blockname] != sum(dbsOutput[blockname].values()):
             logger.warning("Block with file mismatch: %s", blockname)
-            logger.warning("\tRucio: %s\t\tDBS: %s", rucioOutput[blockname], sum(viewvalues(dbsOutput[blockname])))
+            logger.warning("\tRucio: %s\t\tDBS: %s", rucioOutput[blockname], sum(dbsOutput[blockname].values()))
 
 
 if __name__ == "__main__":

--- a/bin/adhoc-scripts/checkStuckLQE.py
+++ b/bin/adhoc-scripts/checkStuckLQE.py
@@ -8,10 +8,9 @@ Provided a workflow name in the command line, it will find all the
 local workqueue elements and print a summary of work/data location
 for the elements sitting in the Available status
 """
-from __future__ import print_function, division
+
 
 from builtins import next
-from future.utils import viewvalues, listvalues
 
 import sys
 import os
@@ -58,14 +57,14 @@ def commonDataLocation(element):
     """
     commonLoc = set()
     if element['PileupData']:
-        commonLoc = set(next(iter(viewvalues(element['PileupData']))))
+        commonLoc = set(next(iter(element['PileupData'].values())))
     if element['Inputs']:
         if commonLoc:
-            commonLoc = commonLoc & set(next(iter(viewvalues(element['Inputs']))))
+            commonLoc = commonLoc & set(next(iter(element['Inputs'].values())))
         else:
             commonLoc = set(list(element['Inputs'].values())[0])
     if element['ParentData']:
-        tempLoc = listvalues(element['ParentData'])
+        tempLoc = list(element['ParentData'].values())
         parentLoc = set(tempLoc[0])
         for temp in tempLoc:
             parentLoc = parentLoc & set(temp)

--- a/bin/adhoc-scripts/drainAgent.py
+++ b/bin/adhoc-scripts/drainAgent.py
@@ -15,10 +15,9 @@ thread as well. It checks status of:
 NOTE: you need to source the agent environment:
 source apps/wmagent/etc/profile.d/init.sh
  """
-from __future__ import print_function, division
+
 
 from builtins import range, str, bytes
-from future.utils import viewitems
 
 import argparse
 import logging
@@ -165,7 +164,7 @@ def getDsetAndWf(lfns, wfsDict):
 
     match = []
     for dset in uniqDsets:
-        for wf, values in viewitems(wfsDict):
+        for wf, values in wfsDict.items():
             if dset in values['OutputDatasets']:
                 match.append((wf, values['RequestStatus'], dset))
     if match:

--- a/bin/adhoc-scripts/getWQStatusByWorkflow.py
+++ b/bin/adhoc-scripts/getWQStatusByWorkflow.py
@@ -12,7 +12,7 @@ and prints a summary of them
 NOTE: you need to source the agent environment:
 source apps/wmagent/etc/profile.d/init.sh
 """
-from __future__ import print_function, division
+
 
 import os
 import sys

--- a/bin/adhoc-scripts/parseUnifiedCampaigns.py
+++ b/bin/adhoc-scripts/parseUnifiedCampaigns.py
@@ -45,10 +45,9 @@ to the WMCore schema:
 python parseUnifiedCampaigns.py --fin=wmcore_campaign.json --url=https://alancc7-cloud2.cern.ch/reqmgr2
          --verbose=10 --testcamp
 """
-from __future__ import print_function, division
+
 
 from builtins import object
-from future.utils import viewitems
 
 import argparse
 import json
@@ -128,7 +127,7 @@ def getSecondaryAAA(initialValue, uniRecord):
       * under the secondaries dictionary.
     If it appears multiple times, we make an OR of the values.
     """
-    for _, innerDict in viewitems(uniRecord.get("secondaries", {})):
+    for _, innerDict in uniRecord.get("secondaries", {}).items():
         if "secondary_AAA" in innerDict:
             print("Found internal secondary_AAA for campaign: %s" % uniRecord['name'])
             initialValue = initialValue or innerDict["secondary_AAA"]
@@ -161,7 +160,7 @@ def getSecondaryLocation(initialValue, uniRecord):
       * under the secondaries dictionary.
     If it appears multiple times, we make an intersection of the values.
     """
-    for _, innerDict in viewitems(uniRecord.get("secondaries", {})):
+    for _, innerDict in uniRecord.get("secondaries", {}).items():
         if "SecondaryLocation" in innerDict:
             print("Found internal SecondaryLocation for campaign: %s" % uniRecord['name'])
             initialValue = intersect(initialValue, innerDict["SecondaryLocation"])
@@ -178,7 +177,7 @@ def getSecondaries(initialValue, uniRecord):
       * taken from the SiteWhitelist key or
       * taken from the SecondaryLocation one
     """
-    for dset, innerDict in viewitems(uniRecord.get("secondaries", {})):
+    for dset, innerDict in uniRecord.get("secondaries", {}).items():
         print("Found secondaries for campaign: %s" % uniRecord['name'])
         initialValue[dset] = intersect(innerDict.get("SiteWhitelist", []),
                                        innerDict.get("SecondaryLocation", []))
@@ -224,7 +223,7 @@ def parse(istream, verbose=0):
         conf = dict(confRec)
         # Set default value from top level campaign configuration
         # or use the default values defined above
-        for uniKey, wmKey in viewitems(remap):
+        for uniKey, wmKey in remap.items():
             conf[wmKey] = rec.get(uniKey, conf[wmKey])
 
         conf['SiteWhiteList'] = getSiteList("SiteWhitelist", conf['SiteWhiteList'], rec)
@@ -330,7 +329,7 @@ def main():
             campData = json.load(istream)
             if isinstance(campData, dict):
                 # then it's a Unified-like campaign schema
-                for key, val in viewitems(campData):
+                for key, val in campData.items():
                     rec = {'name': key}
                     rec.update(val)
                     data.append(rec)

--- a/bin/adhoc-scripts/setrequeststatus.py
+++ b/bin/adhoc-scripts/setrequeststatus.py
@@ -2,10 +2,7 @@
 """
 This script can be used to update the status of a request in ReqMgr2.
 """
-from __future__ import print_function, division
 
-from future import standard_library
-standard_library.install_aliases()
 import http.client
 import json
 import os

--- a/bin/adhoc-scripts/summaryWMStatsFailures.py
+++ b/bin/adhoc-scripts/summaryWMStatsFailures.py
@@ -4,12 +4,7 @@ This script queries the WMStats server and creates a summary of success, failure
 type of failures, files skipped per agent; as well as an overview of failures
 per task
 """
-from __future__ import print_function, division
 
-from future.utils import viewitems
-
-from future import standard_library
-standard_library.install_aliases()
 import http.client
 import json
 import os
@@ -47,7 +42,7 @@ def main():
         print("  Skipped files: %s" % pformat(data[agent]['skipped']))
         print("  Overall agent status:\t\t %s" % data[agent]['status'])
 
-        for task, values in viewitems(data[agent]['tasks']):
+        for task, values in data[agent]['tasks'].items():
             if values['jobtype'] not in ['Production', 'Processing', 'Merge', 'Harvest']:
                 # print("Skipping task type %s, for %s" % (values['jobtype'], task))
                 continue

--- a/bin/adhoc-scripts/updateTotalStats.py
+++ b/bin/adhoc-scripts/updateTotalStats.py
@@ -109,7 +109,7 @@ def main():
     msDbg = MSDbg(msConfig, logger=logger)
 
     badWfList = []
-    reqList = msDbg.getRequestRecords(reqStatus).values()
+    reqList = list(msDbg.getRequestRecords(reqStatus).values())
 
     allReqTypes = {req['RequestType'] for req in reqList}
     logger.info("All possible request types: \n%s", pformat(allReqTypes))
@@ -120,7 +120,7 @@ def main():
 
     for wflow in reqList:
         # First  check if the current workflwo suffers the issue:
-        if not keySetToCheck < wflow.keys():
+        if not keySetToCheck < list(wflow.keys()):
             # Create a `tmp` key to fill in all the information we'll need in the follwoing steps.
             wflow['tmp'] = {}
 

--- a/bin/check-ACDC-parentage
+++ b/bin/check-ACDC-parentage
@@ -1,18 +1,9 @@
 #!/usr/bin/env python
-from __future__ import print_function, division
-from future import standard_library
-standard_library.install_aliases()
-from future.utils import viewitems
 
 import json
-import time
 import http.client
 import os
 
-from pprint import pprint
-from collections import defaultdict
-
-from dbs.apis.dbsClient import DbsApi
 
 def callRESTAPI(restURL, url="cmsweb.cern.ch"):
     conn = http.client.HTTPSConnection(url, cert_file=os.getenv('X509_USER_CERT'),
@@ -35,7 +26,7 @@ def investigateACDCCollection(workflow):
     if "rows" in result:
         if result["rows"]:
             for row in result["rows"]:
-                for inFile, value in viewitems(row["doc"]["files"]):
+                for inFile, value in row["doc"]["files"].items():
                     if not value["merged"] or value["merged"] == "0":
                         if value["parents"] and "/unmerged/" in value["parents"][0]:
                             missingFiles.add(inFile)

--- a/bin/check-phedex-dbs-status
+++ b/bin/check-phedex-dbs-status
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import (print_function, division)
 
 from WMComponent.DBS3Buffer.DBSBufferUtil  import DBSBufferUtil
 from WMCore.WMInit import connectToDB

--- a/bin/check-request-wq-status
+++ b/bin/check-request-wq-status
@@ -1,7 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function, division
-
-from future.utils import viewvalues
 
 import os
 from argparse import ArgumentParser
@@ -34,14 +31,14 @@ def getAcceptableSites(ele):
 
     if ele['Inputs']:
         if commonSites:
-            commonSites = commonSites & set([y for x in viewvalues(ele['Inputs']) for y in x])
+            commonSites = commonSites & set([y for x in ele['Inputs'].values() for y in x])
         else:
-            commonSites = set([y for x in viewvalues(ele['Inputs']) for y in x])
+            commonSites = set([y for x in ele['Inputs'].values() for y in x])
     if ele['PileupData']:
         if commonSites:
-            commonSites = commonSites & set([y for x in viewvalues(ele['PileupData']) for y in x])
+            commonSites = commonSites & set([y for x in ele['PileupData'].values() for y in x])
         else:
-            commonSites = set([y for x in viewvalues(ele['PileupData']) for y in x])
+            commonSites = set([y for x in ele['PileupData'].values() for y in x])
 
     return commonSites
 

--- a/bin/combineMinifyWMStats.py
+++ b/bin/combineMinifyWMStats.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 from glob import iglob
 import shutil
 import os

--- a/bin/couch_archiver.py
+++ b/bin/couch_archiver.py
@@ -4,7 +4,7 @@ _couch_archiver_
 
 Replicate an agent's jobdump to another couch machine.
 """
-from __future__ import print_function
+
 
 import os
 import sys

--- a/bin/createStoreResults.py
+++ b/bin/createStoreResults.py
@@ -19,11 +19,6 @@ Expected input json file like:
 
 """
 
-from __future__ import print_function, division
-
-from future import standard_library
-standard_library.install_aliases()
-
 import http.client
 import json
 import os

--- a/bin/dbsbuffer-file-fix.py
+++ b/bin/dbsbuffer-file-fix.py
@@ -1,15 +1,10 @@
 """
 """
-from __future__ import print_function
-
-from future.utils import listvalues
 
 import logging
 import os
-import sys
 import threading
 
-from WMCore.Database.CMSCouch import Database
 from WMCore.Database.DBFormatter import DBFormatter
 from WMCore.WMInit import connectToDB
 
@@ -38,7 +33,7 @@ def fixDBSmissingFileAssoc():
     print("trimed %s lenth" % len(result))
     insertSQL = """INSERT INTO dbsbuffer_file_location (filename, location)
                VALUES (:fileid, :seid)"""
-    done = formatter.dbi.processData(insertSQL, listvalues(result))
+    done = formatter.dbi.processData(insertSQL, list(result.values()))
     print("inserted %s" % done)
 
 if __name__ == '__main__':

--- a/bin/fix-dbs-parentage
+++ b/bin/fix-dbs-parentage
@@ -41,8 +41,6 @@ $manage execute-agent fix-dbs-parentage -p --insert -d /SingleMuon/Run2016D-03Fe
 
 """
 
-from __future__ import print_function, division
-
 from builtins import input
 import time
 import datetime

--- a/bin/inject-to-config-cache
+++ b/bin/inject-to-config-cache
@@ -4,7 +4,6 @@ _inject-to-config-cache_
 
 Add a config and it's meta data to the config cache.
 """
-from __future__ import print_function
 
 import os
 import sys

--- a/bin/kill-workflow-in-agent
+++ b/bin/kill-workflow-in-agent
@@ -4,9 +4,9 @@ Script for killing a workflow: delete from LQ, delete in WMBS and set cancelled 
 This has to be executed in each agent the workflow is running in (Agent Level)
 
 """
-from __future__ import print_function
 from builtins import str
-import os, sys
+import os
+import sys
 from WMCore.Configuration import loadConfigurationFile
 from WMCore.WorkQueue.WorkQueueBackend import WorkQueueBackend
 from WMCore.WMInit import connectToDB

--- a/bin/kill-workflow-in-global
+++ b/bin/kill-workflow-in-global
@@ -10,7 +10,6 @@ This script will mark the global workqueue elements - for a given
 workflow - as CancelRequested, such that the agents can proceed
 and acknowledge it, moving elements to status Canceled.
 """
-from __future__ import print_function
 
 import os
 import sys

--- a/bin/outputmodules-from-config
+++ b/bin/outputmodules-from-config
@@ -4,10 +4,6 @@ _outputmodules-from-config_
 
 Pull output module metadata from a CMSSW config.
 """
-from __future__ import print_function
-
-from future import standard_library
-standard_library.install_aliases()
 import urllib.request
 
 import imp

--- a/bin/paused-jobs
+++ b/bin/paused-jobs
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
 
 from builtins import input, object
 

--- a/bin/purgeDeletedCouchDoc.py
+++ b/bin/purgeDeletedCouchDoc.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 
 from argparse import ArgumentParser
 

--- a/bin/reqmgr-put-default-config
+++ b/bin/reqmgr-put-default-config
@@ -7,9 +7,6 @@ documents in the ReqMgr Auxiliary DB.
 It's supposed to be called at every ReqMgr2 deployment, such that the splitting,
 permissions, etc are always up-to-date
 """
-from __future__ import print_function, division
-from future import standard_library
-standard_library.install_aliases()
 
 import http.client
 import json

--- a/bin/reqmgr-sw-update
+++ b/bin/reqmgr-sw-update
@@ -12,7 +12,6 @@ to retrieve data asynchronously into a private ReqMgr database. Rather
 than consult TC at every request injection.
 
 """
-from __future__ import print_function
 
 import sys
 import os

--- a/bin/vaildateCMSSWMergeVersion
+++ b/bin/vaildateCMSSWMergeVersion
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
-from __future__ import (division, print_function)
-
 from builtins import range, str, bytes
-from future.utils import viewitems
 
 from pprint import pprint
 from WMCore.WMSpec.WMWorkload import WMWorkloadHelper
@@ -23,7 +20,7 @@ print("List of tasks which merge task has different cmssw versions than processi
 print("NOVERSION could mean it is defined in workflow level not task level. so not necessary error case")
 print("Request Name | status | task name | correct cmssw vereion | current merge cmssw version")
 for item in r:
-    for req, reqInfo in viewitems(item):
+    for req, reqInfo in item.items():
         cmssw = reqInfo.get("CMSSWVersion", [])
         status = reqInfo.get("RequestStatus", [])
         if not isinstance(cmssw, (str, bytes)) and len(cmssw) > 1:

--- a/bin/wmagent-couchapp-init
+++ b/bin/wmagent-couchapp-init
@@ -3,11 +3,6 @@
 wmagent-couchapp-init
 
 """
-from __future__ import print_function, division
-
-from future import standard_library
-
-standard_library.install_aliases()
 
 import argparse
 import os

--- a/bin/wmagent-delete-couchdb-workflow
+++ b/bin/wmagent-delete-couchdb-workflow
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
 
 from builtins import input
 

--- a/bin/wmagent-mod-config
+++ b/bin/wmagent-mod-config
@@ -9,10 +9,6 @@ Copyright (c) 2011 Fermilab. All rights reserved.
 Note: this script is also used by ASO deployment, see:
 https://github.com/dmwm/deployment/blob/master/asyncstageout/manage#L246
 """
-from __future__ import print_function
-from future import standard_library
-standard_library.install_aliases()
-from future.utils import viewitems
 
 import getopt
 import imp
@@ -81,7 +77,7 @@ def modifyConfiguration(config, **args):
         "working_dir": [("General", "workDir")],
     }
 
-    for k, v in viewitems(args):
+    for k, v in args.items():
         parameters = mapping.get(k, [])
         for p in parameters:
             if hasattr(config, p[0]):

--- a/bin/wmagent-resource-control
+++ b/bin/wmagent-resource-control
@@ -4,9 +4,6 @@ wmagent-resource-control
 
 Utility script for manipulating resource control.
 """
-from __future__ import print_function
-
-from future.utils import viewitems
 
 import os
 import sys
@@ -189,7 +186,7 @@ def printThresholds(resourceControl, desiredSiteName):
         print("%s - %d running, %d pending, %d running slots total, %d pending slots total%s:" % (
             siteName, runningJobs, pendingJobs, runningSlots, pendingSlots, stateMsg))
 
-        for task, thres in viewitems(siteThresholds['thresholds']):
+        for task, thres in siteThresholds['thresholds'].items():
             print("  %s - %d running, %d pending, %d max running, %d max pending, priority %s" %
                   (task, thres["task_running_jobs"], thres['task_pending_jobs'], thres["max_slots"],
                    thres["pending_slots"], str(thres.get("priority", 1))))

--- a/bin/wmagent-unregister-wmstats
+++ b/bin/wmagent-unregister-wmstats
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
 
 from builtins import input
 import os

--- a/bin/wmagent-upload-config
+++ b/bin/wmagent-upload-config
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import division, print_function
 
 import os
 import sys

--- a/bin/wmagent-workqueue
+++ b/bin/wmagent-workqueue
@@ -4,7 +4,6 @@ wmagent-workqueue
 
 Utility script for manipulating workqueue.
 """
-from __future__ import print_function
 
 import os
 import sys

--- a/bin/wmcore-db-init
+++ b/bin/wmcore-db-init
@@ -3,7 +3,6 @@
 Commands for initializing the proper database tables
 or cleaning the database.
 """
-from __future__ import print_function
 
 from builtins import input
 

--- a/bin/wmcore-new-config
+++ b/bin/wmcore-new-config
@@ -7,8 +7,6 @@ directory. This command retrieves all of them and merges them
 together into one big configuration file that operators can then
 edit.
 """
-from __future__ import print_function
-
 __revision__ = "$Id: wmcore-new-config,v 1.5 2010/01/22 22:08:32 sryu Exp $"
 __version__ = "$Revision: 1.5 $"
 __author__ = "fvlingen@caltech.edu"

--- a/bin/wmcore-new-flow
+++ b/bin/wmcore-new-flow
@@ -4,7 +4,6 @@
 Generates components, handlers and threadpools from 
 a specification. It sets up the skeleton for development.
 """
-from __future__ import print_function
 
 __revision__ = "$Id: wmcore-new-flow,v 1.1 2009/01/14 12:31:22 fvlingen Exp $"
 __version__ = "$Revision: 1.1 $"

--- a/bin/wmcoreD
+++ b/bin/wmcoreD
@@ -28,7 +28,6 @@ wmcoreD --restart --config=WMCoreConfig.py
 wmcoreD --shutdown --config=WMCoreConfig.py --cleanup-all
 
 """
-from __future__ import print_function
 
 from builtins import str
 __revision__ = "$Id: wmcoreD,v 1.16 2010/05/26 21:09:35 sfoulkes Exp $"

--- a/test/data/ReqMgr/inject-test-wfs.py
+++ b/test/data/ReqMgr/inject-test-wfs.py
@@ -12,10 +12,9 @@ It will:
  4. assign workflows during creation time (also based on the parameters
  provided in command line)
 """
-from __future__ import print_function
+
 
 from builtins import range, str as newstr, bytes as newbytes
-from future.utils import viewitems
 
 import sys
 import os
@@ -145,7 +144,7 @@ def handleAssignment(args, fname, jsonData):
         # always overwrite it as provided in the command line and task/step name
         if 'ProcessingString' in assignDict and isinstance(assignDict['ProcessingString'], dict):
             assignRequest['ProcessingString'] = assignDict['ProcessingString']
-            for task, _ in viewitems(assignRequest['ProcessingString']):
+            for task, _ in assignRequest['ProcessingString'].items():
                 assignRequest['ProcessingString'][task] = task + '_' + tmpProcStr
 
         # also reuse values as provided in the request schema at creation level

--- a/test/data/ReqMgr/reqmgr2.py
+++ b/test/data/ReqMgr/reqmgr2.py
@@ -14,13 +14,9 @@ Production ConfigCache: https://cmsweb.cern.ch/couchdb/reqmgr_config_cache/
 Note: tests for checking data directly in CouchDB in ReqMgr1 test script:
     WMCore/test/data/ReqMgr/reqmgr.py
 """
-from __future__ import print_function
+
 
 from builtins import object, str as newstr, bytes as newbytes, next
-from future.utils import viewitems
-
-from future import standard_library
-standard_library.install_aliases()
 
 import json
 import logging
@@ -424,11 +420,11 @@ def process_request_args(input_config_file, command_line_json, logger):
     def check(items):
         for k, v in items:
             if isinstance(v, dict):
-                check(viewitems(v))
+                check(v.items())
             if isinstance(v, newstr) and v.endswith("OVERRIDE-ME"):
                 logger.warning("Not properly set: %s: %s", k, v)
 
-    check(viewitems(request_args))
+    check(request_args.items())
     return request_args
 
 

--- a/test/data/ReqMgr/validate-test-wfs.py
+++ b/test/data/ReqMgr/validate-test-wfs.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
-from future.utils import viewitems
-
 import argparse
 import getpass
 import json
@@ -11,38 +8,17 @@ import sys
 from collections import OrderedDict
 from textwrap import TextWrapper
 
-try:
-    # python2
-    import urllib2
-    HTTPError = urllib2.HTTPError
-    URLError = urllib2.URLError
-    build_opener = urllib2.build_opener
-    HTTPSHandler = urllib2.HTTPSHandler
-    import urllib
-    urlencode = urllib.urlencode
-    quote_plus = urllib.quote_plus
-    import httplib
-    HTTPSConnection = httplib.HTTPSConnection
-except:
-    # python3
-    import urllib.error
-    HTTPError = urllib.error.HTTPError, 
-    URLError = urllib.error.URLError
-    import urllib.request
-    build_opener = urllib.request.build_opener
-    HTTPSHandler = urllib.request.HTTPSHandler
-    import urllib.parse
-    urlencode = urllib.parse.urlencode
-    quote_plus = urllib.parse.quote_plus
-    import http.client
-    HTTPSConnection = http.client.HTTPSConnection
+from urllib.error import HTTPError, URLError
+from urllib.request import build_opener, HTTPSHandler
+from urllib.parse import urlencode, quote_plus
+from http.client import HTTPSConnection
 
 # table parameters
 SEPARATELINE = "|" + "-" * 51 + "|"
 SPLITLINE = "|" + "*" * 51 + "|"
 
 # ID for the User-Agent
-CLIENT_ID = 'validate-test-wfs/1.2::python/%s.%s' % sys.version_info[:2]
+CLIENT_ID = 'validate-test-wfs/1.3::python/%s.%s' % sys.version_info[:2]
 
 # Cached DQMGui data
 cachedDqmgui = None
@@ -121,7 +97,7 @@ def getRucioToken(rucioUrl):
                 "http://cms-rucio.cern.ch": "https://cms-rucio-auth.cern.ch"}
 
     rucioAuth = None
-    for hostUrl, authUrl in viewitems(mapHosts):
+    for hostUrl, authUrl in mapHosts.items():
         if hostUrl == rucioUrl:
             rucioAuth = authUrl
             rucioAcct = getpass.getuser()
@@ -359,7 +335,7 @@ def compareSpecial(d1, d2, key=None):
 
         if key == 'PNN':
             for dset in d2:
-                for block, value in viewitems(d2[dset]):
+                for block, value in d2[dset].items():
                     if isinstance(value, dict):
                         if d1[dset][block][key] != d2[dset][block][key]:
                             return outcome
@@ -403,7 +379,7 @@ def twClosure(replace_whitespace=False,
             if reCall:
                 output += '\n'
             ind += '    '
-            for key, value in viewitems(obj):
+            for key, value in obj.items():
                 output += "%s%s: %s" % (ind,
                                         ''.join(twr.wrap(key)),
                                         twEnclosed(value, ind, reCall=True))


### PR DESCRIPTION
Fixes #11065 

#### Status
ready

#### Description
Remove dependency on the third-party library `future` for the bin/* scripts.

For further reference, conversion made with the `2to3` tool, with a command line like:
```
2to3 bin/ -w -n
```

in addition, some scripts that do not have the .py extension had to be manually updated. I also grepped for the following patterns and modified everything that was matching it:
```
egrep -rI 'PY2|PY3|python' bin/* | grep -v 'env python'
grep -I -r 'from future' bin/*
grep -I -r 'from __future' bin/*
```

UPDATE: Tested a few scripts and those under the test/data/ReqMgr directory.

#### Is it backward compatible (if not, which system it affects?)
YES (for python3 environment)

#### Related PRs
None

#### External dependencies / deployment changes
None
