### PR TITLE
Remove python2 compatibility for WMRuntime package

### DIFF
--- a/src/python/WMCore/WMRuntime/Monitors/PerformanceMonitor.py
+++ b/src/python/WMCore/WMRuntime/Monitors/PerformanceMonitor.py
@@ -7,7 +7,7 @@ Monitor object which checks the job to ensure it is working inside
 the agreed limits of virtual memory and wallclock time, and terminate it
 if it exceeds them.
 """
-from __future__ import division
+
 
 import logging
 import os

--- a/src/python/WMCore/WMRuntime/Monitors/TestMonitor.py
+++ b/src/python/WMCore/WMRuntime/Monitors/TestMonitor.py
@@ -5,7 +5,7 @@ _TestMonitor_
 
 This is the test class for monitors
 """
-from __future__ import print_function
+
 
 import os.path
 import time

--- a/src/python/WMCore/WMRuntime/ProcessMonitor.py
+++ b/src/python/WMCore/WMRuntime/ProcessMonitor.py
@@ -3,7 +3,7 @@ Created on Jun 16, 2009
 
 @author: meloam
 '''
-from __future__ import print_function
+
 import os
 import sys
 from types import *

--- a/src/python/WMCore/WMRuntime/SandboxCreator.py
+++ b/src/python/WMCore/WMRuntime/SandboxCreator.py
@@ -7,12 +7,7 @@
 
 from builtins import map, object
 
-from future import standard_library
-
-from Utils.PythonVersion import PY2
 from Utils.Utilities import encodeUnicodeToBytes
-
-standard_library.install_aliases()
 
 import logging
 import os

--- a/src/python/WMCore/WMRuntime/ScriptInvoke.py
+++ b/src/python/WMCore/WMRuntime/ScriptInvoke.py
@@ -12,7 +12,7 @@ environment in which the Runtime Script implementation needs to be called.
 
 """
 
-from __future__ import print_function
+
 
 from builtins import object
 import logging

--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -4,7 +4,7 @@ _SetupCMSSWPset_
 Create a CMSSW PSet suitable for running a WMAgent job.
 
 """
-from __future__ import print_function
+
 from builtins import next, object
 
 import json
@@ -14,9 +14,8 @@ import pickle
 import socket
 
 from PSetTweaks.PSetTweak import PSetTweak
-from PSetTweaks.WMTweak import  makeJobTweak, makeOutputTweak, makeTaskTweak, resizeResources
-from Utils.PythonVersion import PY3
-from Utils.Utilities import decodeBytesToUnicode, encodeUnicodeToBytesConditional
+from PSetTweaks.WMTweak import makeJobTweak, makeOutputTweak, makeTaskTweak, resizeResources
+from Utils.Utilities import decodeBytesToUnicode, encodeUnicodeToBytes
 from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig
 from WMCore.Storage.TrivialFileCatalog import TrivialFileCatalog
 from WMCore.WMRuntime.ScriptInterface import ScriptInterface
@@ -488,8 +487,7 @@ class SetupCMSSWPset(ScriptInterface):
             os.path.join(self.stepSpace.location, self.configPickle))
 
         if hasattr(self.step.data.application.configuration, "pickledarguments"):
-            pklArgs = encodeUnicodeToBytesConditional(self.step.data.application.configuration.pickledarguments,
-                                                      condition=PY3)
+            pklArgs = encodeUnicodeToBytes(self.step.data.application.configuration.pickledarguments)
             args = pickle.loads(pklArgs)
             datasetName = args.get('datasetName', None)
         if datasetName:
@@ -684,8 +682,7 @@ class SetupCMSSWPset(ScriptInterface):
         if scenario is not None and scenario != "":
             self.logger.info("Setting up job scenario/process")
             if getattr(self.step.data.application.configuration, "pickledarguments", None) is not None:
-                pklArgs = encodeUnicodeToBytesConditional(self.step.data.application.configuration.pickledarguments,
-                                                          condition=PY3)
+                pklArgs = encodeUnicodeToBytes(self.step.data.application.configuration.pickledarguments)
                 funcArgs = pickle.loads(pklArgs)
             else:
                 funcArgs = {}

--- a/src/python/WMCore/WMRuntime/Startup.py
+++ b/src/python/WMCore/WMRuntime/Startup.py
@@ -8,7 +8,7 @@ Just a FYI, there are basically 3 important directories:
  2. the job space area, where the sandbox and the runtime log is created
  3. the task space area, where the steps and cmsRun logs are
 """
-from __future__ import print_function
+
 
 import logging
 import os

--- a/src/python/WMCore/WMRuntime/Tools/Scram.py
+++ b/src/python/WMCore/WMRuntime/Tools/Scram.py
@@ -26,7 +26,6 @@ sample usage:
 """
 
 from builtins import range, object
-from future.utils import viewitems
 
 import logging
 import os
@@ -36,18 +35,17 @@ import sys
 import platform
 
 from PSetTweaks.WMTweak import readAdValues
-from Utils.PythonVersion import PY3
-from Utils.Utilities import encodeUnicodeToBytesConditional, decodeBytesToUnicodeConditional, decodeBytesToUnicode
+from Utils.Utilities import encodeUnicodeToBytes, decodeBytesToUnicode
 
 SCRAM_TO_ARCH = {'amd64': 'X86_64', 'aarch64': 'aarch64', 'ppc64le': 'ppc64le'}
 # Scram arch to platform machine values above are unique, so we can reverse the mapping
-ARCH_TO_SCRAM = {arch:scram for scram, arch in SCRAM_TO_ARCH.items()}
+ARCH_TO_SCRAM = {arch:scram for scram, arch in list(SCRAM_TO_ARCH.items())}
 ARCH_TO_OS = {'slc5': ['rhel6'],
               'slc6': ['rhel6'],
               'slc7': ['rhel7'],
               'el8': ['rhel8'], 'cc8': ['rhel8'], 'cs8': ['rhel8'], 'alma8': ['rhel8']}
 OS_TO_ARCH = {}
-for arch, oses in viewitems(ARCH_TO_OS):
+for arch, oses in ARCH_TO_OS.items():
     for osName in oses:
         if osName not in OS_TO_ARCH:
             OS_TO_ARCH[osName] = []
@@ -189,7 +187,7 @@ def testWriter(func, *args):
 #  //
 # // Interceptable function to push commands to the subshell, used to
 # //  enable test mode.
-procWriter = lambda s, l: s.stdin.write(encodeUnicodeToBytesConditional(l, condition=PY3))
+procWriter = lambda s, l: s.stdin.write(encodeUnicodeToBytes(l))
 
 
 class Scram(object):
@@ -318,8 +316,8 @@ class Scram(object):
         self.procWriter(proc, "eval `%s ru -sh`\n" % self.command)
 
         self.stdout, self.stderr = proc.communicate()
-        self.stdout = decodeBytesToUnicodeConditional(self.stdout, condition=PY3)
-        self.stderr = decodeBytesToUnicodeConditional(self.stderr, condition=PY3)
+        self.stdout = decodeBytesToUnicode(self.stdout)
+        self.stderr = decodeBytesToUnicode(self.stderr)
         if proc.returncode == 0:
             for l in self.stdout.split(";\n"):
                 if l.strip() == "":

--- a/src/python/WMCore/WMRuntime/Unpacker.py
+++ b/src/python/WMCore/WMRuntime/Unpacker.py
@@ -18,7 +18,7 @@ This will then do the following:
 - set everything up so that you can just add the job dir to the pythonpath and then call the runtime startup for the WMCore/WMRuntime stuff
 
 """
-from __future__ import print_function
+
 
 import getopt
 import logging
@@ -134,7 +134,7 @@ def runUnpacker(sandbox, package, jobIndex, jobname):
 if __name__ == '__main__':
 
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "", options.keys())
+        opts, args = getopt.getopt(sys.argv[1:], "", list(options.keys()))
     except getopt.GetoptError as ex:
         msg = "Error processing commandline args:\n"
         msg += str(ex)

--- a/src/python/WMCore/WMRuntime/Watchdog.py
+++ b/src/python/WMCore/WMRuntime/Watchdog.py
@@ -5,9 +5,6 @@ _Watchdog_
 
 This cleverly named object is the thread that handles the monitoring of individual jobs
 """
-from __future__ import division
-from __future__ import print_function
-from future.utils import viewitems
 
 import logging
 import os
@@ -105,7 +102,7 @@ class Watchdog(threading.Thread):
                         args['maxPSS'] = resources['memory'] - 50
 
                 logging.info("Watchdog modified: %s. Final settings:", changedCores)
-                for k, v in viewitems(args):
+                for k, v in args.items():
                     logging.info("  %s: %r", k, v)
             # Actually initialize the monitor variables
             mon.initMonitor(task=task, job=wmbsJob,

--- a/test/python/WMCore_t/WMRuntime_t/Scripts_t/FWCore/ParameterSet/Config.py
+++ b/test/python/WMCore_t/WMRuntime_t/Scripts_t/FWCore/ParameterSet/Config.py
@@ -126,7 +126,7 @@ def PSet(**attributes):
     Create a new PSet with the given attributes.
     """
     newPSet = Container()
-    for attributeName in attributes.keys():
+    for attributeName in list(attributes.keys()):
         setattr(newPSet, attributeName, attributes[attributeName])
 
     return newPSet

--- a/test/python/WMCore_t/WMRuntime_t/Scripts_t/SetupCMSSWPset_t.py
+++ b/test/python/WMCore_t/WMRuntime_t/Scripts_t/SetupCMSSWPset_t.py
@@ -5,9 +5,8 @@ _SetupCMSSWPset_t.py
 Tests for the PSet configuration code.
 
 """
-from __future__ import print_function
 
-from future.utils import viewvalues
+
 from builtins import zip
 
 import imp
@@ -285,7 +284,7 @@ class SetupCMSSWPsetTest(unittest.TestCase):
         """
         # consider only locally available files
         filesInConfigDict = []
-        for v in viewvalues(pileupSubDict):
+        for v in pileupSubDict.values():
             if seLocalName in v["phedexNodeNames"]:
                 filesInConfigDict.extend(v["FileList"])
 

--- a/test/python/WMCore_t/WMRuntime_t/Tools_t/Scram_t.py
+++ b/test/python/WMCore_t/WMRuntime_t/Tools_t/Scram_t.py
@@ -13,7 +13,6 @@ import tempfile
 
 from WMQuality.TestInit import TestInit
 from Utils.TemporaryEnvironment import tmpEnv
-from Utils.PythonVersion import PY3
 from WMCore.WMRuntime.Tools.Scram import (Scram, OS_TO_ARCH, ARCH_TO_OS, getSingleScramArch,
                                           isCMSSWSupported, isEnforceGUIDInFileNameSupported)
 
@@ -24,8 +23,6 @@ class Scram_t(unittest.TestCase):
         self.testInit.setLogging()
         self.testDir = self.testInit.generateWorkDir()
         self.oldCwd = os.getcwd()
-        if PY3:
-            self.assertItemsEqual = self.assertCountEqual
 
     def tearDown(self):
         self.testInit.delWorkDir()
@@ -105,13 +102,13 @@ class Scram_t(unittest.TestCase):
         self.assertEqual(s.lastExecuted, comm)
 
     def testArchMap(self):
-        self.assertItemsEqual(OS_TO_ARCH['rhel6'], ['slc5', 'slc6'])
-        self.assertItemsEqual(OS_TO_ARCH['rhel7'], ['slc7'])
-        self.assertItemsEqual(OS_TO_ARCH['rhel8'], ['el8', 'cc8', 'cs8', 'alma8'])
-        self.assertItemsEqual(ARCH_TO_OS['slc6'], ['rhel6'])
+        self.assertCountEqual(OS_TO_ARCH['rhel6'], ['slc5', 'slc6'])
+        self.assertCountEqual(OS_TO_ARCH['rhel7'], ['slc7'])
+        self.assertCountEqual(OS_TO_ARCH['rhel8'], ['el8', 'cc8', 'cs8', 'alma8'])
+        self.assertCountEqual(ARCH_TO_OS['slc6'], ['rhel6'])
         self.assertEqual(len(ARCH_TO_OS), 7)
-        self.assertItemsEqual(ARCH_TO_OS['slc7'], ['rhel7'])
-        self.assertItemsEqual(ARCH_TO_OS['slc7'], ['rhel7'])
+        self.assertCountEqual(ARCH_TO_OS['slc7'], ['rhel7'])
+        self.assertCountEqual(ARCH_TO_OS['slc7'], ['rhel7'])
 
     def testScramArchParsing(self):
         """


### PR DESCRIPTION
Fixes #11407 

#### Status
not-tested

#### Description
Remove the python2 compatibility for the WMRuntime package, making it a python3-only code and no longer requiring the `future` library.

I performed the following 3 checks:
1. `2to3 src/python/WMCore/WMRuntime/ -w -n` --> to remove dependency on `__future__`
2. `egrep -rI 'PY2|PY3|python' src/python/WMCore/WMRuntime/* | grep -v 'env python'` --> to find usage of version-specific python
3. `grep -I -r 'from future' src/python/WMCore/WMRuntime/` --> to find other use of the `future` library, like dicts and other aliases.

Same needs to be done for the unit tests.

#### Is it backward compatible (if not, which system it affects?)
YES (for a python3 environment)

#### Related PRs
None

#### External dependencies / deployment changes
None
