### PR TITLE
Add reqmgr2ms-pileup service

### DIFF
--- a/.github/workflows/pypi_build_and_images.yaml
+++ b/.github/workflows/pypi_build_and_images.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         target: [wmagent, wmagent-devtools, wmcore, reqmon, reqmgr2, global-workqueue, acdcserver, reqmgr2ms-unmerged,
-                 reqmgr2ms-output, reqmgr2ms-rulecleaner, reqmgr2ms-transferor, reqmgr2ms-monitor]
+                 reqmgr2ms-output, reqmgr2ms-pileup, reqmgr2ms-rulecleaner, reqmgr2ms-transferor, reqmgr2ms-monitor]
     uses: ./.github/workflows/pypi_build_publish_template.yaml
     with:
       wmcore_component: ${{ matrix.target }}
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         target: [wmagent, reqmon, t0_reqmon, reqmgr2, reqmgr2ms-unmerged, global-workqueue,
-                 reqmgr2ms-output, reqmgr2ms-rulecleaner, reqmgr2ms-transferor, reqmgr2ms-monitor]
+                 reqmgr2ms-output, reqmgr2ms-pileup, reqmgr2ms-rulecleaner, reqmgr2ms-transferor, reqmgr2ms-monitor]
     uses: ./.github/workflows/docker_images_template.yaml
     with:
       wmcore_component: ${{ matrix.target }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,15 +13,15 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 
 Cheetah3~=3.2.6.post1         # wmcore,wmagent,reqmgr2,reqmon
-CherryPy~=18.8.0              # wmcore,wmagent,wmagent-devtools,reqmgr2,reqmon,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner
+CherryPy~=18.8.0              # wmcore,wmagent,wmagent-devtools,reqmgr2,reqmon,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-pileup,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner
 CMSCouchapp~=1.3.4            # wmcore,wmagent
-CMSMonitoring~=0.6.10         # wmcore,wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner
+CMSMonitoring~=0.6.10         # wmcore,wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-pileup,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner
 coverage~=5.4                 # wmcore,wmagent,wmagent-devtools
 cx-Oracle~=8.3.0              # wmcore,wmagent
 dbs3-client~=4.0.12           # wmcore,wmagent,reqmgr2,reqmon,global-workqueue
 future~=0.18.2                # wmcore,wmagent,wmagent-devtools,reqmgr2,reqmon,acdcserver,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner
 gfal2-python~=1.11.0.post3    # wmcore,reqmgr2ms-unmerged
-httplib2~=0.20.4              # wmcore,wmagent,reqmgr2,reqmon,acdcserver,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner
+httplib2~=0.20.4              # wmcore,wmagent,reqmgr2,reqmon,acdcserver,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-pileup,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner
 htcondor~=8.9.7               # wmcore,wmagent
 Jinja2~=3.1.2                 # wmcore,wmagent
 memory-profiler~=0.60.0       # wmcore,wmagent-devtools
@@ -32,13 +32,13 @@ nose~=1.3.7                   # wmcore,wmagent-devtools
 nose2~=0.12.0                 # wmcore,wmagent-devtools
 pycodestyle~=2.8.0            # wmcore,wmagent-devtools
 psutil~=5.9.1                 # wmcore,wmagent,wmagent-devtools,reqmgr2,reqmon,global-workqueue
-pycurl~=7.45.1                # wmcore,wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner
+pycurl~=7.45.1                # wmcore,wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-pileup,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner
 pylint~=2.14.5                # wmcore,wmagent-devtools
-pymongo~=4.2.0                # wmcore,wmagent-devtools,reqmgr2ms-unmerged,reqmgr2ms-output
+pymongo~=4.2.0                # wmcore,wmagent-devtools,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-pileup
 pyOpenSSL~=18.0.0             # wmcore,wmagent
 pyzmq~=23.2.1                 # wmcore,wmagent
-retry~=0.9.2                  # wmcore,wmagent,wmagent-devtools,reqmgr2,reqmon,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner
-rucio-clients~=1.29.10        # wmcore,wmagent,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner
+retry~=0.9.2                  # wmcore,wmagent,wmagent-devtools,reqmgr2,reqmon,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-pileup,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner
+rucio-clients~=1.29.10        # wmcore,wmagent,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-pileup,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner
 Sphinx~=5.1.1                 # wmcore,wmagent,wmagent-devtools,reqmgr2,reqmon,acdcserver,global-workqueue
 SQLAlchemy~=1.4.40            # wmcore,wmagent
-PyJWT~=2.4.0                  # wmcore,wmagent,wmagent-devtools,reqmgr2,reqmon,acdcserver,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner
+PyJWT~=2.4.0                  # wmcore,wmagent,wmagent-devtools,reqmgr2,reqmon,acdcserver,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-pileup,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner

--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -148,6 +148,10 @@ dependencies = {
         'packages': ['WMCore.MicroService.MSOutput+'],
         'systems': ['reqmgr2ms-core'],
     },
+    'reqmgr2ms-pileup': {
+        'packages': ['WMCore.MicroService.MSPileup+'],
+        'systems': ['reqmgr2ms-core'],
+    },
     'reqmgr2ms-transferor': {
         'packages': ['WMCore.MicroService.MSTransferor+'],
         'systems': ['reqmgr2ms-core'],

--- a/src/python/WMCore/MicroService/MSCore/MSCore.py
+++ b/src/python/WMCore/MicroService/MSCore/MSCore.py
@@ -17,7 +17,7 @@ from WMCore.Services.AlertManager.AlertManagerAPI import AlertManagerAPI
 class MSCore(object):
     """
     This class provides core functionality for
-    MSTransferor, MSMonitor, MSOutput, MSRuleCleaner, MSUnmerged classes.
+    MSTransferor, MSMonitor, MSOutput, MSPileup, MSRuleCleaner, MSUnmerged classes.
     """
 
     def __init__(self, msConfig, **kwargs):

--- a/src/python/WMCore/MicroService/MSPileup/MSPileup.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileup.py
@@ -1,0 +1,19 @@
+"""
+File       : MSPileup.py
+Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
+Description: MSPileup class provide whole logic behind
+the pileup WMCore module.
+"""
+
+# WMCore modules
+from WMCore.MicroService.MSCore.MSCore import MSCore
+
+
+class MSPileup(MSCore):
+    """
+    MSPileup class provide whole logic behind
+    the pileup WMCore module.
+    """
+
+    def __init__(self, msConfig, logger=None, **kwargs):
+        super(MSPileup, self).__init__(msConfig, **kwargs)


### PR DESCRIPTION
Fixes #11423 

#### Status
in development

#### Description
First draft for MSPileup service

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
- [Dockerfile](https://github.com/dmwm/CMSKubernetes/blob/master/docker/pypi/reqmgr2ms-pileup/Dockerfile)
- [apache frontend rules](https://github.com/dmwm/deployment/pull/1230)
- reqmgr2ms-pileup configuration draft can be found in this [config.py](https://gitlab.cern.ch/cmsweb-k8s/services_config/-/blob/test/reqmgr2ms-pileup/config.py)
- [reqmgr2ms-pileup.yaml](https://github.com/dmwm/CMSKubernetes/blob/master/kubernetes/cmsweb/services/reqmgr2ms-pileup.yaml) k8s manifest file to deploy service to k8s cluster
- reqmgr2ms-pileup configuration draft can be found in gitlab [services_configs/reqmgr2ms-pileup/config.py](https://gitlab.cern.ch/cmsweb-k8s/services_config/-/blob/test/reqmgr2ms-pileup/config.py) repo
I used port 8249 as new port number for this service

The service skeleton is also tested with local setup using curl. see https://github.com/dmwm/WMCore/pull/11430#issuecomment-1376324420

Additional changes made by @arooshap :
- For the cmsweb cluster: [services_config/frontend-ds](https://gitlab.cern.ch/cmsweb-k8s/services_config/-/commit/ce8c18838e7dcd22162aaf61834ea48c64a48dd7).
- For the preprod cluster: [services_config/frontend-ds](https://gitlab.cern.ch/cmsweb-k8s/services_config/-/commit/fa4cd17cd67e8d26b5b46916fab145e4171ca288).
- and for the test cluster: [services_config/frontend-ds](https://gitlab.cern.ch/cmsweb-k8s/services_config/-/commit/bd07af9c422fc2dd3cd45428d7fec7eb1ca3badf).

#### External dependencies / deployment changes
