### PR TITLE
Fix file open issue

### DIFF
--- a/src/python/WMCore/REST/Main.py
+++ b/src/python/WMCore/REST/Main.py
@@ -403,7 +403,7 @@ class RESTDaemon(RESTMain):
                                 bufsize=0, close_fds=True, shell=False)
                 logger = subproc.stdin
             elif isinstance(self.logfile, str):
-                logger = open(self.logfile, "a+", 0)
+                logger = open(self.logfile, "a+")
             else:
                 raise TypeError("'logfile' must be a string or array")
             os.dup2(logger.fileno(), sys.stdout.fileno())


### PR DESCRIPTION
Fixes #11310

#### Status
ready

#### Description
on macOS and in k8s we experience the foilowing issue,
see https://github.com/dmwm/WMCore/issues/11310#issuecomment-1377213100
```
Traceback (most recent call last):
  File "/usr/local/bin/wmc-httpd", line 3, in <module>
    main()
  File "/usr/local/lib/python3.8/site-packages/WMCore/REST/Main.py", line 617, in main
    server.start_daemon()
  File "/usr/local/lib/python3.8/site-packages/WMCore/REST/Main.py", line 406, in start_daemon
    logger = open(self.logfile, "a+", 0)
ValueError: can't have unbuffered text I/O
```

<Description of the changes proposed.>
Use `b` flag when open log file

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs

#### External dependencies / deployment changes
Please see this stackoverflow discussion about this error https://stackoverflow.com/questions/45263064/how-can-i-fix-this-valueerror-cant-have-unbuffered-text-i-o-in-python-3