### PR TITLE
Fix broken syntax for the f-string in DBSUploadPoller

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
@@ -114,7 +114,7 @@ def uploadWorker(workInput, results, dbsUrl, gzipEncoding=False):
                 logging.error(msg)
                 results.put({'name': name, 'success': "error", 'error': msg})
         except Exception as ex:
-            msg = f"Hit a general exception while inserting block {name. Error: {str(ex}}"
+            msg = f"Hit a general exception while inserting block {name}. Error: {str(ex)}"
             logging.exception(msg)
             results.put({'name': name, 'success': "error", 'error': msg})
     return


### PR DESCRIPTION
Fixes #11436 

#### Status
ready

#### Description
Fix the f-string syntax.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Complement to https://github.com/dmwm/WMCore/pull/11173

#### External dependencies / deployment changes
None
