### PR TITLE
Remove MS/DataPileup from MSRuleCleanerWflow && Remove Pilup logic from MSRuleCleaner

### DIFF
--- a/src/python/WMCore/MicroService/MSRuleCleaner/MSRuleCleaner.py
+++ b/src/python/WMCore/MicroService/MSRuleCleaner/MSRuleCleaner.py
@@ -34,7 +34,7 @@ from WMCore.ReqMgr.DataStructs import RequestStatus
 from WMCore.WMException import WMException
 from WMCore.Services.LogDB.LogDB import LogDB
 from WMCore.Services.WMStatsServer.WMStatsServer import WMStatsServer
-from WMCore.MicroService.Tools.Common import findParent, isRelVal
+from WMCore.MicroService.Tools.Common import findParent
 from Utils.Pipeline import Pipeline, Functor
 from Utils.CertTools import ckey, cert
 
@@ -703,8 +703,7 @@ class MSRuleCleaner(MSCore):
 
         # Create the container list to the rucio account map and set the checkGlobalLocks flag.
         mapRuleType = {self.msConfig['rucioWmaAccount']: ["OutputDatasets"],
-                       self.msConfig['rucioMStrAccount']: ["InputDataset", "MCPileup",
-                                                           "DataPileup", "ParentDataset"]}
+                       self.msConfig['rucioMStrAccount']: ["InputDataset", "ParentDataset"]}
         if rucioAcct == self.msConfig['rucioMStrAccount']:
             checkGlobalLocks = True
         else:
@@ -724,13 +723,7 @@ class MSRuleCleaner(MSCore):
                     continue
                 if gran == 'container':
                     ruleIds = [rule['id'] for rule in self.rucio.listDataRules(dataCont, account=rucioAcct)]
-                    if ruleIds and dataType in ("MCPileup", "DataPileup"):
-                        msg = "Pileup container %s has the following container-level rules to be removed: %s."
-                        msg += " However, this component is no longer removing pileup rules."
-                        self.logger.info(msg, dataCont, ruleIds)
-                        if not isRelVal(wflow):
-                            self.alertDeletablePU(wflow['RequestName'], dataCont, ruleIds)
-                    elif ruleIds:
+                    if ruleIds:
                         wflow['RulesToClean'][currPline].extend(ruleIds)
                         msg = "Container %s has the following container-level rules to be removed: %s"
                         self.logger.info(msg, dataCont, ruleIds)
@@ -790,28 +783,6 @@ class MSRuleCleaner(MSCore):
             requests = result[0]
         self.logger.info('  retrieved %s requests in status: %s', len(requests), reqStatus)
         return requests
-
-    def alertDeletablePU(self, workflowName, containerName, ruleList):
-        """
-        Send alert notifying that there is a pileup dataset eligible for rule removal
-        :param workflowName: string with the workflow name
-        :param containerName: string with the container name
-        :param ruleList: list of strings with the rule ids
-        :return: none
-        """
-        alertName = "{}: PU eligible for deletion: {}".format(self.alertServiceName, containerName)
-        alertSeverity = "high"
-        alertSummary = "[MSRuleCleaner] Found pileup container no longer locked and available for rule deletion."
-        alertDescription = "Workflow: {} has the following pileup container ".format(workflowName)
-        alertDescription += "\n{}\n no longer in the global locks. ".format(containerName)
-        alertDescription += "These rules\n{}\nare eligible for deletion.".format(ruleList)
-
-        # Check if alarms are enabled for this service
-        # Alert expiration time defaults to 2 days
-        if self.msConfig["sendNotification"]:
-            self.sendAlert(alertName, alertSeverity, alertSummary, alertDescription,
-                           service=self.alertServiceName, endSecs=self.alertExpiration)
-        self.logger.critical(alertDescription)
 
     def alertStatusAdvanceExpired(self, wflow, additionalInfo=None):
         """

--- a/src/python/WMCore/MicroService/MSRuleCleaner/MSRuleCleanerWflow.py
+++ b/src/python/WMCore/MicroService/MSRuleCleaner/MSRuleCleanerWflow.py
@@ -148,7 +148,7 @@ class MSRuleCleanerWflow(dict):
         # NOTE: Those are fields defined as strings in the original workflow
         #       representation, but may turn into lists during the recursive
         #       search and we will use them as lists for the rest of the code.
-        for key in ['DataPileup', 'MCPileup', 'ParentDataset']:
+        for key in ['ParentDataset']:
             if not isinstance(myDoc[key], list):
                 if myDoc[key] is None:
                     myDoc[key] = []
@@ -191,8 +191,6 @@ class MSRuleCleanerWflow(dict):
             'ForceArchive': False,
             'RequestTransition': [],
             'IncludeParents': False
-            'DataPileup': [],
-            'MCPileup': [],
             'InputDataset': None,
             'ParentDataset': []
             }
@@ -217,8 +215,6 @@ class MSRuleCleanerWflow(dict):
             ('ForceArchive', False, bool),
             ('RequestTransition', [], list),
             ('IncludeParents', False, bool),
-            ('DataPileup', None, (bytes, str)),
-            ('MCPileup', None, (bytes, str)),
             ('InputDataset', None, (bytes, str)),
             ('ParentDataset', None, (bytes, str))]
 

--- a/test/python/WMCore_t/MicroService_t/MSRuleCleaner_t/MSRuleCleanerWflow_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSRuleCleaner_t/MSRuleCleanerWflow_t.py
@@ -67,8 +67,6 @@ class MSRuleCleanerWflowTest(unittest.TestCase):
         self.assertEqual(wflow["ForceArchive"], False)
         self.assertEqual(wflow["RequestTransition"], [])
         self.assertEqual(wflow['IncludeParents'], False)
-        self.assertEqual(wflow['DataPileup'], [])
-        self.assertEqual(wflow['MCPileup'], [])
         self.assertEqual(wflow['InputDataset'], None)
         self.assertEqual(wflow['ParentDataset'], [])
 
@@ -76,14 +74,12 @@ class MSRuleCleanerWflowTest(unittest.TestCase):
         # Test Taskchain:
         wflow = MSRuleCleanerWflow(self.taskChainReq)
         expectedWflow = {'CleanupStatus': {},
-                         'DataPileup': [],
                          'ForceArchive': False,
                          'IncludeParents': False,
                          'InputDataset': u'/JetHT/Run2012C-v1/RAW',
                          'IsArchivalDelayExpired': False,
                          'IsClean': False,
                          'IsLogDBClean': False,
-                         'MCPileup': [],
                          'OutputDatasets': [
                              u'/JetHT/CMSSW_7_2_0-RECODreHLT_TaskChain_LumiMask_multiRun_HG2011_Val_Todor_v1-v11/RECO',
                              u'/JetHT/CMSSW_7_2_0-RECODreHLT_TaskChain_LumiMask_multiRun_HG2011_Val_Todor_v1-v11/DQMIO',
@@ -121,14 +117,12 @@ class MSRuleCleanerWflowTest(unittest.TestCase):
         # Test ReReco workflow:
         wflow = MSRuleCleanerWflow(self.reRecoReq)
         expectedWflow = {'CleanupStatus': {},
-                         'DataPileup': [],
                          'ForceArchive': False,
                          'IncludeParents': False,
                          'InputDataset': u'/SingleElectron/Run2017F-v1/RAW',
                          'IsArchivalDelayExpired': False,
                          'IsClean': False,
                          'IsLogDBClean': False,
-                         'MCPileup': [],
                          'OutputDatasets': [u'/SingleElectron/Run2017F-09Aug2019_UL2017_EcalRecovery-v1/MINIAOD',
                                             u'/SingleElectron/Run2017F-EcalUncalWElectron-09Aug2019_UL2017_EcalRecovery-v1/ALCARECO',
                                             u'/SingleElectron/Run2017F-EcalUncalZElectron-09Aug2019_UL2017_EcalRecovery-v1/ALCARECO',
@@ -165,14 +159,12 @@ class MSRuleCleanerWflowTest(unittest.TestCase):
         # Test include parents::
         wflow = MSRuleCleanerWflow(self.includeParentsReq)
         expectedWflow = {'CleanupStatus': {},
-                         'DataPileup': [],
                          'ForceArchive': False,
                          'IncludeParents': True,
                          'InputDataset': u'/Cosmics/Commissioning2015-PromptReco-v1/RECO',
                          'IsArchivalDelayExpired': False,
                          'IsClean': False,
                          'IsLogDBClean': False,
-                         'MCPileup': [],
                          'OutputDatasets': [
                              u'/Cosmics/Integ_Test-CosmicSP-StepChain_InclParents_HG2004_Val_Privv12-v11/RAW-RECO'],
                          'ParentDataset': [],
@@ -192,48 +184,6 @@ class MSRuleCleanerWflowTest(unittest.TestCase):
                                                {u'DN': u'', u'Status': u'running-open', u'UpdateTime': 1586860927},
                                                {u'DN': u'', u'Status': u'running-closed', u'UpdateTime': 1586861535},
                                                {u'DN': u'', u'Status': u'completed', u'UpdateTime': 1586863942}],
-                         'RequestType': u'StepChain',
-                         'SubRequestType': u'',
-                         'RulesToClean': {},
-                         'TargetStatus': None,
-                         'TransferDone': False,
-                         'TransferTape': False}
-        self.assertDictEqual(wflow, expectedWflow)
-
-    def testMultiPU(self):
-        # Test workflow with multiple pileups::
-        wflow = MSRuleCleanerWflow(self.multiPUReq)
-        expectedWflow = {'CleanupStatus': {},
-                         'DataPileup': [],
-                         'ForceArchive': False,
-                         'IncludeParents': False,
-                         'InputDataset': None,
-                         'IsArchivalDelayExpired': False,
-                         'IsClean': False,
-                         'IsLogDBClean': False,
-                         'MCPileup': [u'/MinBias_TuneCUETP8M1_13TeV-pythia8/RunIIWinter15GS-MCRUN2_71_V1-v1/GEN-SIM',
-                                      u'/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW'],
-                         'OutputDatasets': [
-                             u'/DYJetsToLL_Pt-50To100_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/DMWM_Test-SC_MultiPU_HG2002_Val_Todor_v13-v20/GEN-SIM',
-                             u'/DYJetsToLL_Pt-50To100_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/DMWM_Test-SC_MultiPU_HG2002_Val_Todor_v13-v20/LHE',
-                             u'/DYJetsToLL_Pt-50To100_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/DMWM_Test-SC_MultiPU_HG2002_Val_Todor_v13-v20/GEN-SIM-RAW'],
-                         'ParentDataset': [],
-                         'ParentageResolved': False,
-                         'PlineMarkers': None,
-                         'RequestName': u'tivanov_SC_MultiPU_HG2002_Val_200121_043659_4925',
-                         'RequestStatus': u'completed',
-                         'RequestTransition': [{u'DN': u'',
-                                                u'Status': u'new',
-                                                u'UpdateTime': 1579577819},
-                                               {u'DN': u'', u'Status': u'assignment-approved',
-                                                u'UpdateTime': 1579577822},
-                                               {u'DN': u'', u'Status': u'assigned', u'UpdateTime': 1579577822},
-                                               {u'DN': u'', u'Status': u'staging', u'UpdateTime': 1579577895},
-                                               {u'DN': u'', u'Status': u'staged', u'UpdateTime': 1579578050},
-                                               {u'DN': u'', u'Status': u'acquired', u'UpdateTime': 1579578770},
-                                               {u'DN': u'', u'Status': u'running-open', u'UpdateTime': 1579578770},
-                                               {u'DN': u'', u'Status': u'running-closed', u'UpdateTime': 1579579378},
-                                               {u'DN': u'', u'Status': u'completed', u'UpdateTime': 1579587203}],
                          'RequestType': u'StepChain',
                          'SubRequestType': u'',
                          'RulesToClean': {},

--- a/test/python/WMCore_t/MicroService_t/MSRuleCleaner_t/MSRuleCleaner_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSRuleCleaner_t/MSRuleCleaner_t.py
@@ -95,14 +95,12 @@ class MSRuleCleanerTest(unittest.TestCase):
         wflow = MSRuleCleanerWflow(self.taskChainReq)
         self.msRuleCleaner.plineAgentBlock.run(wflow)
         expectedWflow = {'CleanupStatus': {'plineAgentBlock': True},
-                         'DataPileup': [],
                          'ForceArchive': False,
                          'IncludeParents': False,
                          'InputDataset': '/JetHT/Run2012C-v1/RAW',
                          'IsArchivalDelayExpired': False,
                          'IsClean': False,
                          'IsLogDBClean': False,
-                         'MCPileup': [],
                          'OutputDatasets': [
                              '/JetHT/CMSSW_7_2_0-RECODreHLT_TaskChain_LumiMask_multiRun_HG2011_Val_Todor_v1-v11/RECO',
                              '/JetHT/CMSSW_7_2_0-RECODreHLT_TaskChain_LumiMask_multiRun_HG2011_Val_Todor_v1-v11/DQMIO',
@@ -139,14 +137,12 @@ class MSRuleCleanerTest(unittest.TestCase):
         wflow = MSRuleCleanerWflow(self.taskChainReq)
         self.msRuleCleaner.plineAgentCont.run(wflow)
         expectedWflow = {'CleanupStatus': {'plineAgentCont': True},
-                         'DataPileup': [],
                          'ForceArchive': False,
                          'IncludeParents': False,
                          'InputDataset': '/JetHT/Run2012C-v1/RAW',
                          'IsArchivalDelayExpired': False,
                          'IsClean': False,
                          'IsLogDBClean': False,
-                         'MCPileup': [],
                          'OutputDatasets': [
                              '/JetHT/CMSSW_7_2_0-RECODreHLT_TaskChain_LumiMask_multiRun_HG2011_Val_Todor_v1-v11/RECO',
                              '/JetHT/CMSSW_7_2_0-RECODreHLT_TaskChain_LumiMask_multiRun_HG2011_Val_Todor_v1-v11/DQMIO',
@@ -183,14 +179,12 @@ class MSRuleCleanerTest(unittest.TestCase):
         wflow = MSRuleCleanerWflow(self.taskChainReq)
         self.msRuleCleaner.plineMSTrBlock.run(wflow)
         expectedWflow = {'CleanupStatus': {'plineMSTrBlock': True},
-                         'DataPileup': [],
                          'ForceArchive': False,
                          'IncludeParents': False,
                          'InputDataset': '/JetHT/Run2012C-v1/RAW',
                          'IsArchivalDelayExpired': False,
                          'IsClean': False,
                          'IsLogDBClean': False,
-                         'MCPileup': [],
                          'OutputDatasets': [
                              '/JetHT/CMSSW_7_2_0-RECODreHLT_TaskChain_LumiMask_multiRun_HG2011_Val_Todor_v1-v11/RECO',
                              '/JetHT/CMSSW_7_2_0-RECODreHLT_TaskChain_LumiMask_multiRun_HG2011_Val_Todor_v1-v11/DQMIO',
@@ -229,14 +223,12 @@ class MSRuleCleanerTest(unittest.TestCase):
         wflow = MSRuleCleanerWflow(self.taskChainReq)
         self.msRuleCleaner.plineMSTrCont.run(wflow)
         expectedWflow = {'CleanupStatus': {'plineMSTrCont': True},
-                         'DataPileup': [],
                          'ForceArchive': False,
                          'IncludeParents': False,
                          'InputDataset': '/JetHT/Run2012C-v1/RAW',
                          'IsArchivalDelayExpired': False,
                          'IsClean': False,
                          'IsLogDBClean': False,
-                         'MCPileup': [],
                          'OutputDatasets': [
                              '/JetHT/CMSSW_7_2_0-RECODreHLT_TaskChain_LumiMask_multiRun_HG2011_Val_Todor_v1-v11/RECO',
                              '/JetHT/CMSSW_7_2_0-RECODreHLT_TaskChain_LumiMask_multiRun_HG2011_Val_Todor_v1-v11/DQMIO',
@@ -286,14 +278,12 @@ class MSRuleCleanerTest(unittest.TestCase):
         with self.assertRaises(MSRuleCleanerArchivalSkip):
             self.msRuleCleaner.plineArchive.run(wflow)
         expectedWflow = {'CleanupStatus': {'plineAgentBlock': True, 'plineAgentCont': True},
-                         'DataPileup': [],
                          'ForceArchive': False,
                          'IncludeParents': False,
                          'InputDataset': '/JetHT/Run2012C-v1/RAW',
                          'IsArchivalDelayExpired': True,
                          'IsClean': True,
                          'IsLogDBClean': True,
-                         'MCPileup': [],
                          'OutputDatasets': [
                              '/JetHT/CMSSW_7_2_0-RECODreHLT_TaskChain_LumiMask_multiRun_HG2011_Val_Todor_v1-v11/RECO',
                              '/JetHT/CMSSW_7_2_0-RECODreHLT_TaskChain_LumiMask_multiRun_HG2011_Val_Todor_v1-v11/DQMIO',


### PR DESCRIPTION
Fixes #11428 

#### Status
Ready

#### Description
With the current PR, we are removing all the Pileup rules cleanup logic from MSRuleCleaner due to the newly developed micro service MSPileup, which is supposed to handle all PU related actions. The change affects both the schema for documents uploaded to the background database and the logic to search and fill in all rules for deletion. Nothing from the rest  of the service logic had to be touched.      

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
All other PRs related to the meta issue used to track the MSPilup developments:
https://github.com/dmwm/WMCore/issues/9779


#### External dependencies / deployment changes
None
