### PR TITLE
Do not duplicate error messages in DBS3Upload

### DIFF
--- a/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
@@ -104,7 +104,7 @@ def uploadWorker(workInput, results, dbsUrl, gzipEncoding=False):
             if srvCode == 128:
                 # block already exist
                 logging.warning("Block %s already exists. Marking it as uploaded.", name)
-                results.put({'name': name, 'success': "uploaded"})
+                results.put({'name': name, 'success': "check"})
             elif srvCode in [132, 133, 134, 135, 136, 137, 138, 139, 140]:
                 # racing conditions
                 logging.warning("Hit a transient data race condition injecting block %s, %s", name, msg)
@@ -766,11 +766,6 @@ class DBSUploadPoller(BaseWorkerThread):
             elif result["success"] == "check":
                 block = result["name"]
                 self.blocksToCheck.append(block)
-            else:
-                logging.error("Error found in multiprocess during process of block %s", result.get('name'))
-                logging.error(result['error'])
-                # Continue to the next block
-                # Block will remain in pending status until it is transferred
 
         if loadedBlocks:
             try:


### PR DESCRIPTION
Fixes #11365 

#### Status
ready

#### Description
This PR provides a complement to the changes that were merged with the following PR:
https://github.com/dmwm/WMCore/pull/11375

Changes are:
* when DBSServer returns a server code `128` (block already exists), mark that HTTP call with the `check` status for an explicit block existence check down in the chain (before marking it as upload)
* in the method parsing the multiprocessing response objects, do not log another error with the message that has been already recorded in the method `uploadWorker`

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
[<If it's a follow up work; or porting a fix from a different branch, please mention them here.>](https://github.com/dmwm/WMCore/pull/11375)

#### External dependencies / deployment changes
Here is an example of DBS3Upload log, before having this patch in:
```
2023-01-12 03:37:02,609:140553853286144:WARNING:DBSUploadPoller:Hit a transient data race condition injecting block /RelValWToLNu_14TeV/CMSSW_12_4_0_pre2-RecoNano_2021_SC_EL8_Agent216_Val_Alanv1-v11/GEN-SIM-RECO#61ce825f-bd67-4350-b6ef-817732b04875, DBSError code: 132, message: b8cc4358670288060dbd472c4f508f4ac450c701011ef1025a394c94ee0905e4 unable to find processed_ds_id for procDS='CMSSW_12_4_0_pre2-RecoNano_2021_SC_EL8_Agent216_Val_Alanv1-v11', reason: DBSError Code:110 Description:DBS DB insert record error Function:dbs.GetRecID Message: Error: nested DBSError Code:110 Description:DBS DB insert record error Function:dbs.processeddatasets.Insert Message: Error: ORA-00001: unique constraint (CMS_DBS3_K8S_GLOBAL_OWNER.TUC_PSDS_PROCESSED_DS_NAME) violated

2023-01-12 03:37:02,611:140553853286144:ERROR:DBSUploadPoller:Error found in multiprocess during process of block /RelValWToLNu_14TeV/CMSSW_12_4_0_pre2-RecoNano_2021_SC_EL8_Agent216_Val_Alanv1-v11/GEN-SIM-RECO#61ce825f-bd67-4350-b6ef-817732b04875
2023-01-12 03:37:02,611:140553853286144:ERROR:DBSUploadPoller:DBSError code: 132, message: b8cc4358670288060dbd472c4f508f4ac450c701011ef1025a394c94ee0905e4 unable to find processed_ds_id for procDS='CMSSW_12_4_0_pre2-RecoNano_2021_SC_EL8_Agent216_Val_Alanv1-v11', reason: DBSError Code:110 Description:DBS DB insert record error Function:dbs.GetRecID Message: Error: nested DBSError Code:110 Description:DBS DB insert record error Function:dbs.processeddatasets.Insert Message: Error: ORA-00001: unique constraint (CMS_DBS3_K8S_GLOBAL_OWNER.TUC_PSDS_PROCESSED_DS_NAME) violated
```
