### PR TITLE
MSPileup service HTTP APIs

### DIFF
--- a/src/python/WMCore/MicroService/DataStructs/DefaultStructs.py
+++ b/src/python/WMCore/MicroService/DataStructs/DefaultStructs.py
@@ -59,6 +59,16 @@ OUTPUT_REPORT = dict(thread_id="",
                      num_datasets_subscribed=0,
                      num_data_requests=0)
 
+# summary metrics for the MSPileup thread
+# (also available through the `info` REST API)
+PILEUP_REPORT = dict(thread_id="",
+                     start_time=0,
+                     end_time=0,
+                     execution_time=0,
+                     error="",
+                     total_num_pileups=0,
+                     total_num_rules=0)
+
 # summary metrics for the MSRuleCleaner thread
 # (also available through the `info` REST API)
 RULECLEANER_REPORT = dict(thread_id="",

--- a/src/python/WMCore/MicroService/MSPileup/MSPileup.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileup.py
@@ -4,8 +4,29 @@ Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
 Description: MSPileup provides logic behind the pileup WMCore module.
 """
 
+# system modules
+from threading import current_thread
+
+# 3rd party modules
+import cherrypy
+
 # WMCore modules
+from WMCore.REST.Auth import authz_match
 from WMCore.MicroService.MSCore.MSCore import MSCore
+from WMCore.MicroService.DataStructs.DefaultStructs import PILEUP_REPORT
+from WMCore.MicroService.MSPileup.MSPileupData import MSPileupData
+
+
+def mspileupError(doc):
+    """
+    Check MSPileup record for error
+    :return: None or raise cherrypy.HTTPError
+    """
+    if 'error' in doc:
+        msg = doc['message']
+        code = doc['code']
+        msg = f'MSPileupError: {msg}, code: {code}'
+        raise cherrypy.HTTPError(400, msg) from None
 
 
 class MSPileup(MSCore):
@@ -13,5 +34,96 @@ class MSPileup(MSCore):
     MSPileup provides whole logic behind the pileup WMCore module.
     """
 
-    def __init__(self, msConfig, logger=None, **kwargs):
-        super(MSPileup, self).__init__(msConfig, **kwargs)
+    def __init__(self, msConfig, **kwargs):
+        # TODO: so far we are testing this service w/o Rucio access
+        super(MSPileup, self).__init__(msConfig, skipRucio=True)
+        # TODO: if more generic approach will be required we'll need to switch to
+        # super(MSPileup, self).__init__(msConfig, **kwargs)
+
+        # for authz we should provide relevant section in MS configuration
+        # if no role/group is provided then authz_match used in HTTP APIs
+        # will always return valid state. Therefore, for test purposes we can
+        # use empty role and group, while for production setup we should set thenm up
+        authzDefaults = msConfig.get('authz_defaults', {})
+        self.role = authzDefaults.get('role', [])
+        self.group = authzDefaults.get('group', [])
+        self.mgr = MSPileupData(msConfig)
+
+    def status(self):
+        """
+        Provide MSPileup status API. We should extend it to check DB connection, etc.
+
+        :return: status dictionary
+        """
+        summary = dict(PILEUP_REPORT)
+        summary.update({'thread_id': current_thread().name})
+        return summary
+
+    def getPileup(self, **kwargs):
+        """
+        MSPileup get API fetches the data from underlying database layer
+
+        :param **kwargs: provide key=value (or spec) input
+        :return: results of MSPileup data layer (list of dicts)
+        """
+        spec = {}  # (get all full docs) retrieve a list with the full documentation of all the pileups
+        if 'spec' in kwargs:
+            # use specific spec (JSON query)
+            spec = kwargs['spec']
+        elif 'pileupName' in kwargs:
+            # get docs for given pileupName
+            spec = {'pileupName': kwargs['pileupName']}
+        elif 'campaign' in kwargs:
+            # get docs for given campaign
+            spec = {'campaign': kwargs['campaign']}
+        else:
+            for key, val in kwargs.items():
+                spec[key] = val
+
+        # check if filters are present and use it as projection fields
+        projection = {}
+        for key in kwargs.get('filters', []):
+            projection[key] = 1
+        results = self.mgr.getPileup(spec, projection)
+
+        return results
+
+    def queryDatabase(self, spec, projection=None):
+        """
+        MSPileup query database API querying the data in underlying data layer.
+
+        :param spec: provide query JSON spec to MSPileup data layer
+        :return: results of MSPileup data layer (list of dicts)
+        """
+        return self.mgr.getPileup(spec, projection)
+
+    def createPileup(self, pdict):
+        """
+        MSPileup create pileup API to create appropriate pileup document
+        in underlying database.
+
+        :param pdict: input MSPilup data dictionary
+        :return: results of MSPileup data layer (list of dicts)
+        """
+        authz_match(self.role, self.group)
+        return self.mgr.createPileup(pdict)
+
+    def updatePileup(self, pdict):
+        """
+        MSPileup update API to update correspoding pileup document in data layer.
+
+        :param pdict: input MSPilup data dictionary
+        :return: results of MSPileup data layer (list of dicts)
+        """
+        authz_match(self.role, self.group)
+        return self.mgr.updatePileup(pdict)
+
+    def deletePileup(self, spec):
+        """
+        MSPileup delete API to delete corresponding pileup document in data layer.
+
+        :param pdict: input MSPilup data dictionary
+        :return: results of MSPileup data layer (list of dicts)
+        """
+        authz_match(self.role, self.group)
+        return self.mgr.deletePileup(spec)

--- a/src/python/WMCore/MicroService/MSPileup/MSPileupData.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupData.py
@@ -59,6 +59,7 @@ class MSPileupData():
         self.msConfig.setdefault("mongoDBReplicaSet", None)
         self.msConfig.setdefault("mongoDBPort", None)
         self.msConfig.setdefault("mockMongoDB", False)
+        self.validRSEs = self.msConfig.get('validRSEs', [])
 
         # A full set of valid database connection parameters can be found at:
         # https://pymongo.readthedocs.io/en/stable/api/pymongo/mongo_client.html
@@ -90,7 +91,7 @@ class MSPileupData():
         """
         # first, create MSPileupObj which will be validated against its schema
         try:
-            obj = MSPileupObj(pdict)
+            obj = MSPileupObj(pdict, validRSEs=self.validRSEs)
             doc = obj.getPileupData()
         except Exception as exp:
             msg = f"Failed to create MSPileupObj, {exp}"

--- a/src/python/WMCore/MicroService/Service/RestApiHub.py
+++ b/src/python/WMCore/MicroService/Service/RestApiHub.py
@@ -25,7 +25,8 @@ class RestApiHub(RESTApi):
         """
         :arg app: reference to application object; passed to all entities.
         :arg config: reference to configuration; passed to all entities.
-        :arg str mount: API URL mount point; passed to all entities."""
+        :arg str mount: is definition coming from configuration file to mount the app in REST server
+        """
 
         RESTApi.__init__(self, app, config, mount)
 
@@ -34,3 +35,8 @@ class RestApiHub(RESTApi):
 
         self._add({"status": Data(app, self, config, mount),
                    "info": Data(app, self, config, mount)})
+
+        # the mount point should match service configuration, e.g. in MSPileup we define
+        # mount point as /ms-pileup/data, e.g. http://.../ms-pileup/data
+        if 'ms-pileup' in mount:
+            self._add({"pileup": Data(app, self, config, mount)})

--- a/test/python/WMCore_t/MicroService_t/MSManager_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSManager_t.py
@@ -46,6 +46,17 @@ class MSManagerTest(unittest.TestCase):
         data.enableDataTransfer = True
         self.mgr_trans = MSManager(data)
 
+        # to create MSPileup we need MongoDB settings
+        data.services = ['pileup']
+        data.mongoDB = 'msPileupDB'
+        data.mongoDBCollection = 'msPileupDBCollection'
+        data.mongoDBServer = 'mongodb://localhost'
+        data.mongoDBReplicaSet = ''
+        data.mongoDBUser = None
+        data.mongoDBPassword = None
+        data.mockMongoDB = True
+        self.mgr_pileup = MSManager(data)
+
         if PY3:
             self.assertItemsEqual = self.assertCountEqual
 
@@ -63,6 +74,16 @@ class MSManagerTest(unittest.TestCase):
         self.assertEqual(hasattr(self.mgr, 'transfThread'), False)
         self.assertEqual(hasattr(self.mgr, 'msMonitor'), False)
         self.assertEqual(hasattr(self.mgr, 'monitThread'), False)
+        self.assertEqual(hasattr(self.mgr, 'pileupThread'), False)
+
+        # check self.mgr_pileup object attributes
+        self.assertEqual('pileup' in self.mgr_pileup.services, True)
+        self.assertEqual('transferor' in self.mgr_pileup.services, False)
+        self.assertEqual(hasattr(self.mgr_pileup, 'msTransferor'), False)
+        self.assertEqual(hasattr(self.mgr_pileup, 'transfThread'), False)
+        self.assertEqual(hasattr(self.mgr_pileup, 'msMonitor'), False)
+        self.assertEqual(hasattr(self.mgr_pileup, 'monitThread'), False)
+        self.assertEqual(hasattr(self.mgr_pileup, 'pileupThread'), True)
 
         # check self.mgr_trans object attributes
         self.assertEqual('monitor' in self.mgr_trans.services, False)
@@ -71,6 +92,7 @@ class MSManagerTest(unittest.TestCase):
         self.assertEqual(hasattr(self.mgr_trans, 'transfThread'), True)
         self.assertEqual(hasattr(self.mgr_trans, 'msMonitor'), False)
         self.assertEqual(hasattr(self.mgr_trans, 'monitThread'), False)
+        self.assertEqual(hasattr(self.mgr_trans, 'pileupThread'), False)
 
         # check self.mgr_monit object attributes
         self.assertEqual('monitor' in self.mgr_monit.services, True)
@@ -79,6 +101,7 @@ class MSManagerTest(unittest.TestCase):
         self.assertEqual(hasattr(self.mgr_monit, 'transfThread'), False)
         self.assertEqual(hasattr(self.mgr_monit, 'msMonitor'), True)
         self.assertEqual(hasattr(self.mgr_monit, 'monitThread'), True)
+        self.assertEqual(hasattr(self.mgr_monit, 'pileupThread'), False)
 
         # test a few configuration parameters as well
         self.assertEqual(self.mgr_trans.msConfig.get("limitRequestsPerCycle"), 50)

--- a/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileup_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileup_t.py
@@ -1,0 +1,109 @@
+"""
+Unit tests for MSPileup.py module
+
+Author: Valentin Kuznetsov <vkuznet [AT] gmail [DOT] com>
+"""
+
+# system modules
+import cherrypy
+import unittest
+
+# WMCore modules
+from WMCore.MicroService.MSPileup.MSPileup import MSPileup, mspileupError
+from WMCore.MicroService.MSPileup.DataStructs.MSPileupObj import MSPileupObj
+
+
+class MSPileupTest(unittest.TestCase):
+    "Unit test for MSPileup module"
+    def setUp(self):
+        """
+        set up unit test generic objects
+        """
+        cherrypy.request.user = "test"
+        self.validRSEs = ['rse1', 'rse2']
+        msConfig = {'reqmgr2Url': 'http://localhost',
+                    'rucioAccount': 'wmcore_mspileup',
+                    'rucioUrl': 'http://cms-rucio-int.cern.ch',
+                    'rucioAuthUrl': 'https://cms-rucio-auth-int.cern.ch',
+                    'mongoDB': 'msPileupDB',
+                    'mongoDBCollection': 'msPileupDBCollection',
+                    'mongoDBServer': 'mongodb://localhost',
+                    'mongoDBReplicaSet': '',
+                    'mongoDBUser': None,
+                    'mongoDBPassword': None,
+                    'validRSEs': self.validRSEs,
+                    'mockMongoDB': True}
+        self.mgr = MSPileup(msConfig)
+
+
+        self.pname = '/lksjdflksdjf/kljsdklfjsldfj/PREMIX'
+        expectedRSEs = self.validRSEs
+        fullReplicas = 0
+        campaigns = ['c1', 'c2']
+        data = {
+            'pileupName': self.pname,
+            'pileupType': 'classic',
+            'expectedRSEs': expectedRSEs,
+            'currentRSEs': expectedRSEs,
+            'fullReplicas': fullReplicas,
+            'campaigns': campaigns,
+            'containerFraction': 0.0,
+            'replicationGrouping': "ALL",
+            'active': True,
+            'pileupSize': 0,
+            'ruleList': []}
+
+        obj = MSPileupObj(data, validRSEs=self.validRSEs)
+        for key in ['insertTime', 'lastUpdateTime', 'activatedOn', 'deactivatedOn']:
+            self.assertNotEqual(obj.data[key], 0)
+        self.assertEqual(obj.data['expectedRSEs'], expectedRSEs)
+        self.assertEqual(obj.data['fullReplicas'], fullReplicas)
+        self.assertEqual(obj.data['campaigns'], campaigns)
+        self.doc = obj.getPileupData()
+
+    def testMSPileupHTTPApis(self):
+        "test MSPileup HTTP APIs"
+
+        # create doc
+        res = self.mgr.createPileup(self.doc)
+        self.assertEqual(len(res), 0)
+
+        # get doc
+        spec = {'pileupName': self.pname}
+        res = self.mgr.getPileup(**spec)
+        self.assertEqual(len(res), 1)
+        # self.assertDictEqual(res[0], self.doc)
+
+        # query doc
+        projection = ["pileupType"]
+        res = self.mgr.queryDatabase(spec, projection)
+        self.assertEqual(len(res), 1)
+        # self.assertEqual(res[0], ["classic"])
+
+        # update doc
+        doc = dict(self.doc)
+        doc["pileupType"] = "new"
+        res = self.mgr.updatePileup(doc)
+        self.assertEqual(len(res), 0)
+
+        # query doc
+        res = self.mgr.queryDatabase(spec, projection)
+        self.assertEqual(len(res), 1)
+        # self.assertEqual(res[0], ["new"])
+
+        # delete doc
+        res = self.mgr.deletePileup(spec)
+        self.assertEqual(len(res), 0)
+
+    def testMSPileupError(self):
+        "test mspileupError function"
+        doc = {'error': 'mspileup error', 'code': 123, 'message': 'msg'}
+        with self.assertRaises(cherrypy.HTTPError):
+            mspileupError(doc)
+        success = {}
+        res = mspileupError(success)
+        self.assertEqual(res, None)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #11425 

#### Status
in development

#### Description
The MSPileup service HTTP APIs

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
#11438 

#### External dependencies / deployment changes
The MSPileup HTTP service APIs follow the same MS implementation, i.e. the service is part of MSManager.py. But since it requires support of various HTTP methods, I enhanced MSManager functionality to support `POST, PUT, DELETE` HTTP methods. Due to various constrains of current REST layer, e.g. routes hierarchy, I was forced to introduce `access` end-point to support all HTTP methods. Here is how the end-points look like via curl call:
```
echo "HTTP GET API calls"
curl -v "http://localhost:8249/ms-pileup/data/access?pileupName=pileup"
curl -v "http://localhost:8249/ms-pileup/data/access?campaign=Campaign"
# and we can use filters to extract certain fields from the doc, e.g.
curl -v "http://localhost:8249/ms-pileup/data/access?pileupName=pileup&filters=["campaigns", "pileupType"]"


echo "HTTP POST API calls"
# first create document
curl -v -X POST -H "Content-type: application/json" -d '{"bla":1}' \
       http://localhost:8249/ms-pileup/data/access
# second, query the data via provided JSON query (spec)
curl -v -X POST -H "Content-type: application/json" \
       -d '{"query":{"pileupName":"bla"}}' \
       http://localhost:8249/ms-pileup/data/access
# third, use query and filters
curl -v -X POST -H "Content-type: application/json" \
       -d '{"query":{"pileupName": "bla"}, "filters":["campaigns"]}' \
        http://localhost:8249/ms-pileup/data/access

echo "HTTP PUT API call"
curl -v -X PUT -H "Content-type: application/json" -d '{"bla":1}' \
        http://localhost:8249/ms-pileup/data/access

echo "HTTP DELETE API calls"
curl -v -X DELETE -H "Content-type: application/json" -d '{"bla":1}' \
        http://localhost:8249/ms-pileup/data/access
curl -v -X DELETE -H "Content-type: application/json" -d '{"pileupName":"pileup"}' \
        http://localhost:8249/ms-pileup/data/access
```

Please note, that `POST` method has dual role. It can be used to create resources in MSPileup, or it can be used to fetch data for provided JSON query (spec). In latter case, the query should be constructed as `{'query': ...}` spec, i.e. it has `query` key.