### PR TITLE
Fix to open logfile in unbuffered in python3

### DIFF
--- a/src/python/WMCore/REST/Main.py
+++ b/src/python/WMCore/REST/Main.py
@@ -403,7 +403,7 @@ class RESTDaemon(RESTMain):
                                 bufsize=0, close_fds=True, shell=False)
                 logger = subproc.stdin
             elif isinstance(self.logfile, str):
-                logger = open(self.logfile, "a+", 0)
+                logger = open(self.logfile, "a+b", 0)
             else:
                 raise TypeError("'logfile' must be a string or array")
             os.dup2(logger.fileno(), sys.stdout.fileno())


### PR DESCRIPTION
Fixes https://github.com/dmwm/CRABServer/issues/7463

#### Status
Ready

#### Description
Fix write logs to file mode in python3.

When supplying arguments to make WMCore/REST writing logs to a file, it will get the error `ValueError: can't have unbuffered text I/O`. Because in python3, it tries to open the file with TextIOWrapper, which is not allowed to operate in unbuffered mode.
To fix it, open it in binary mode which use FileIO instead.
We use this to streaming logs to the named pipe and print to PID 1 stdout as explained in [dmwm/CRABServer#7463 (comment)](https://github.com/dmwm/CRABServer/issues/7463#issuecomment-1344306384)


#### Is it backward compatible (if not, which system it affects?)
YES. 
I think it is safe for python2 because we only open the file to get the file descriptor. But I cannot test because we only have CRAB REST that uses WMCore/REST, and it already runs in python3

#### Related PRs
None

#### External dependencies / deployment changes
NO
