### PR TITLE
Corrected GQ -> LQ data acquisition in slices

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -141,6 +141,10 @@ config.WorkQueueManager.queueParams["ParentQueueCouchUrl"] = "https://cmsweb.cer
 config.WorkQueueManager.queueParams["QueueURL"] = "http://%s:5984" % (config.Agent.hostName)
 config.WorkQueueManager.queueParams["WorkPerCycle"] = 200  # don't pull more than this number of elements per cycle
 config.WorkQueueManager.queueParams["QueueDepth"] = 0.5  # pull work from GQ for only half of the resources
+# number of available elements to be retrieved within a single CouchDB http request
+config.WorkQueueManager.queueParams["RowsPerSlice"] = 2500
+# maximum number of available elements rows to be evaluated when acquiring GQ to LQ work
+config.WorkQueueManager.queueParams["MaxRowsPerCycle"] = 50000
 config.WorkQueueManager.queueParams["rucioAccount"] = "wmcore_transferor"  # account for data locks
 
 


### PR DESCRIPTION
Fixes #11452 

#### Status
not-tested

#### Description
Iterate through all the available elements, in slices of 2.5k docs, until the configured number of elements (200 atm) has been successfully acquired - or until all rows have been exhausted. This PR adds two new WorkQueueManager configuration parameters:
* `RowsPerSlice`: defining the slice size, i.e., how many rows/elements can be retrieved from workqueue within a single HTTP request;
* `MaxRowsPerCycle`: maximum number of rows/elements to be queried in workqueue. Currently 50k, meaning that if there are more than 50k elements in Available status, those won't be considered for data acquisition (they are, of course, ordered by priority though). 

An element "succcessfully" acquired means that:
* it passes all the work [restrictions](https://github.com/dmwm/WMCore/blob/master/src/couchapps/WorkQueue/lists/workRestrictions.js), especially matching the resources available
* and, during post processing in WorkQueueManager, that it has a priority higher than the workflows already in the queue. 

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
