### PR TITLE
Skip auth check in case of localhost usage

### DIFF
--- a/src/python/WMCore/REST/Auth.py
+++ b/src/python/WMCore/REST/Auth.py
@@ -25,6 +25,10 @@ def user_info_from_headers(key, verbose=False):
 
     # Reject if request was not authenticated.
     if 'cms-auth-status' not in headers:
+        if headers.get('Remote-Addr', '') == '127.0.0.1':
+            # since we are using localhost access we can skip authentication
+            log("DEBUG: non-authenticated request performed on localhost")
+            return
         log("ERROR: authz denied, front-end headers not present")
         raise cherrypy.HTTPError(403, "You are not allowed to access this resource.")
 

--- a/test/python/WMCore_t/REST_t/Simple_t.py
+++ b/test/python/WMCore_t/REST_t/Simple_t.py
@@ -40,7 +40,10 @@ class SimpleTest(webtest.WebCase):
 
     def test_basic_fail(self):
         self.getPage("/test")
-        self.assertStatus("403 Forbidden")
+        # we changed behaviour of REST server to bypass authz checks when RemoteAddr is localhost
+        # see src/python/WMCore/REST/Auth.py, therefore this test should be ok
+        # self.assertStatus("403 Forbidden")
+        self.assertStatus("200 OK")
 
     def test_basic_success(self):
         self.getPage("/test", headers = self.h)


### PR DESCRIPTION
Fixes #11461 

#### Status
ready

#### Description
Provide simple fix to check HTTP headers and skip authentication if localhost is used.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs

#### External dependencies / deployment changes
