### PR TITLE
Open REST-based file in append mode, update deactivated

### DIFF
--- a/src/python/WMCore/REST/Main.py
+++ b/src/python/WMCore/REST/Main.py
@@ -403,7 +403,9 @@ class RESTDaemon(RESTMain):
                                 bufsize=0, close_fds=True, shell=False)
                 logger = subproc.stdin
             elif isinstance(self.logfile, str):
-                logger = open(self.logfile, "a+")
+                # if a unix pipe is set as the logfile, it must be opened to append to the end of the file
+                # if file/pipe does not exist, create it
+                logger = open(self.logfile, "a")
             else:
                 raise TypeError("'logfile' must be a string or array")
             os.dup2(logger.fileno(), sys.stdout.fileno())


### PR DESCRIPTION
Fixes #11459 

#### Status
ready

#### Description
According to the python3.8 documentation:
* `a`: option to open file in append mode (to the end of the file)
* `+`: option for updating file (changes to any point of the file?)

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Complement to https://github.com/dmwm/WMCore/pull/11455

#### External dependencies / deployment changes
None
