### PR TITLE
Use mspileupError function in Data.py module

### DIFF
--- a/src/python/WMCore/MicroService/MSPileup/MSPileup.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileup.py
@@ -17,18 +17,6 @@ from WMCore.MicroService.DataStructs.DefaultStructs import PILEUP_REPORT
 from WMCore.MicroService.MSPileup.MSPileupData import MSPileupData
 
 
-def mspileupError(doc):
-    """
-    Check MSPileup record for error
-    :return: None or raise cherrypy.HTTPError
-    """
-    if 'error' in doc:
-        msg = doc['message']
-        code = doc['code']
-        msg = f'MSPileupError: {msg}, code: {code}'
-        raise cherrypy.HTTPError(400, msg) from None
-
-
 class MSPileup(MSCore):
     """
     MSPileup provides whole logic behind the pileup WMCore module.

--- a/src/python/WMCore/MicroService/Service/Data.py
+++ b/src/python/WMCore/MicroService/Service/Data.py
@@ -52,7 +52,18 @@ from WMCore.REST.Server import RESTEntity, restcall
 from WMCore.REST.Tools import tools
 # from WMCore.REST.Validation import validate_rx, validate_str
 from WMCore.REST.Format import JSONFormat, PrettyJSONFormat
-from WMCore.MicroService.MSPileup.MSPileup import mspileupError
+
+
+def mspileupError(doc):
+    """
+    Check MSPileup record for error
+    :return: None or raise cherrypy.HTTPError
+    """
+    if 'error' in doc:
+        msg = doc['message']
+        code = doc['code']
+        msg = f'MSPileupError: {msg}, code: {code}'
+        raise cherrypy.HTTPError(400, msg) from None
 
 
 def results(res):

--- a/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileup_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileup_t.py
@@ -9,7 +9,7 @@ import cherrypy
 import unittest
 
 # WMCore modules
-from WMCore.MicroService.MSPileup.MSPileup import MSPileup, mspileupError
+from WMCore.MicroService.MSPileup.MSPileup import MSPileup
 from WMCore.MicroService.MSPileup.DataStructs.MSPileupObj import MSPileupObj
 
 
@@ -94,15 +94,6 @@ class MSPileupTest(unittest.TestCase):
         # delete doc
         res = self.mgr.deletePileup(spec)
         self.assertEqual(len(res), 0)
-
-    def testMSPileupError(self):
-        "test mspileupError function"
-        doc = {'error': 'mspileup error', 'code': 123, 'message': 'msg'}
-        with self.assertRaises(cherrypy.HTTPError):
-            mspileupError(doc)
-        success = {}
-        res = mspileupError(success)
-        self.assertEqual(res, None)
 
 
 if __name__ == '__main__':

--- a/test/python/WMCore_t/MicroService_t/Service_t/Data_t.py
+++ b/test/python/WMCore_t/MicroService_t/Service_t/Data_t.py
@@ -1,0 +1,30 @@
+"""
+Unit tests for Service/Data.py module
+
+Author: Valentin Kuznetsov <vkuznet [AT] gmail [DOT] com>
+"""
+
+# system modules
+import unittest
+
+# third party modules
+import cherrypy
+
+# WMCore modules
+from WMCore.MicroService.Service.Data import mspileupError
+
+
+class ServiceData(unittest.TestCase):
+    "Unit test for Service/Data module"
+
+    def testMSPileupError(self):
+        "test mspileupError function"
+        doc = {'error': 'mspileup error', 'code': 123, 'message': 'msg'}
+        with self.assertRaises(cherrypy.HTTPError):
+            mspileupError(doc)
+        success = {}
+        mspileupError(success)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/11425#issuecomment-1414295752

#### Status
ready

#### Description
Move mspileupError function used in `Data.py` module to module itself to avoid import error when MSPileup module is not used by MS deployment.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
#11443

#### External dependencies / deployment changes
