### PR TITLE
MSRuleCleaner: initialize transferInfo local var

### DIFF
--- a/src/python/WMCore/MicroService/MSRuleCleaner/MSRuleCleaner.py
+++ b/src/python/WMCore/MicroService/MSRuleCleaner/MSRuleCleaner.py
@@ -625,6 +625,7 @@ class MSRuleCleaner(MSCore):
             data = json.loads(res)['result'][0]
             transferInfo = data['transferDoc']
         except Exception as ex:
+            transferInfo = None
             msg = "General exception while fetching TransferInfo from MSOutput for %s. "
             msg += "Error: %s"
             self.logger.exception(msg, wflow['RequestName'], str(ex))


### PR DESCRIPTION
Fixes #11469 

#### Status
ready

#### Description
Ensure `transferInfo` has been initialized before referencing it in the if statement a few lines below.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
