### PR TITLE
Deprecate TFC override for multi-step jobs

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
@@ -116,6 +116,7 @@ class LogCollect(Executor):
 
         # setup Scram needed to run edmCopyUtil
         if useEdmCopyUtil:
+            logging.info("Creating software area for %s under %s", cmsswVersion, scramArch)
             scram = Scram(
                     command=scramCommand,
                     version=cmsswVersion,

--- a/test/python/WMCore_t/WMRuntime_t/Scripts_t/SetupCMSSWPset_t.py
+++ b/test/python/WMCore_t/WMRuntime_t/Scripts_t/SetupCMSSWPset_t.py
@@ -169,14 +169,8 @@ class SetupCMSSWPsetTest(unittest.TestCase):
         fixedPSet = self.loadProcessFromPSet(setupScript.stepSpace.location)
 
         # test if the overriden TFC is right
-        print("DEBUG override: {0}".format(setupScript.step.data.application.overrideCatalog))
-        self.assertTrue(hasattr(setupScript.step.data.application, "overrideCatalog"),
-                        "Error: overriden TFC was not set")
-        tfc = loadTFC(setupScript.step.data.application.overrideCatalog)
-        inputFile = "../my_first_step/my_input_module.root"
-        self.assertEqual(tfc.matchPFN("direct", inputFile), inputFile)
-        self.assertEqual(tfc.matchLFN("direct", inputFile), inputFile)
-        self.assertTrue(hasattr(fixedPSet.source, 'fileNames'))
+        self.assertFalse(hasattr(setupScript.step.data.application, "overrideCatalog"),
+                        "We no longer override the TFC, instead only make a PSet tweak!")
 
 
     def testPileupSetup(self):


### PR DESCRIPTION
Fixes #11472 

#### Status
not-tested

#### Description
This changes how multi-step jobs are tweaked in the worker node, such that an override catalog is no longer created; instead we tweak the next PSet configuration to consider a file in the localhost (job scratch area).

In addition to that, I am also trying to recover the log records for this module (which I am pretty sure they used to work in a not so far past). Current changes will spit records out to stdout (which I believe will also show up in the wmagentJob.log log).

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
