### PR TITLE
Fix MSPileup APIs

### DIFF
--- a/src/python/WMCore/MicroService/MSPileup/DataStructs/MSPileupObj.py
+++ b/src/python/WMCore/MicroService/MSPileup/DataStructs/MSPileupObj.py
@@ -89,7 +89,7 @@ class MSPileupObj(object):
         msg = ""
         if not pdict:
             pdict = self.data
-        docSchema = self.schema()
+        docSchema = schema()
         if set(pdict) != set(docSchema):
             pkeys = set(pdict.keys())
             skeys = set(docSchema.keys())
@@ -146,28 +146,29 @@ class MSPileupObj(object):
                 return False
         return True
 
-    def schema(self):
-        """
-        Return the data schema for a record in MongoDB.
-        It's a dictionary where:
-        - key is schema attribute name
-        - a value is a tuple of (default value, expected data type)
 
-        :return: a dictionary
-        """
-        doc = {'pileupName': ('', str),
-               'pileupType': ('', str),
-               'insertTime': (0, int),
-               'lastUpdateTime': (0, int),
-               'expectedRSEs': ([], list),
-               'currentRSEs': ([], list),
-               'fullReplicas': (0, int),
-               'campaigns': ([], list),
-               'containerFraction': (1.0, float),
-               'replicationGrouping': ('', str),
-               'activatedOn': (0, int),
-               'deactivatedOn': (0, int),
-               'active': (False, bool),
-               'pileupSize': (0, int),
-               'ruleList': ([], list)}
-        return doc
+def schema():
+    """
+    Return the data schema for a record in MongoDB.
+    It's a dictionary where:
+    - key is schema attribute name
+    - a value is a tuple of (default value, expected data type)
+
+    :return: a dictionary
+    """
+    doc = {'pileupName': ('', str),
+           'pileupType': ('', str),
+           'insertTime': (0, int),
+           'lastUpdateTime': (0, int),
+           'expectedRSEs': ([], list),
+           'currentRSEs': ([], list),
+           'fullReplicas': (0, int),
+           'campaigns': ([], list),
+           'containerFraction': (1.0, float),
+           'replicationGrouping': ('', str),
+           'activatedOn': (0, int),
+           'deactivatedOn': (0, int),
+           'active': (False, bool),
+           'pileupSize': (0, int),
+           'ruleList': ([], list)}
+    return doc

--- a/src/python/WMCore/MicroService/MSPileup/MSPileup.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileup.py
@@ -7,9 +7,6 @@ Description: MSPileup provides logic behind the pileup WMCore module.
 # system modules
 from threading import current_thread
 
-# 3rd party modules
-import cherrypy
-
 # WMCore modules
 from WMCore.REST.Auth import authz_match
 from WMCore.MicroService.MSCore.MSCore import MSCore
@@ -55,9 +52,9 @@ class MSPileup(MSCore):
         :return: results of MSPileup data layer (list of dicts)
         """
         spec = {}  # (get all full docs) retrieve a list with the full documentation of all the pileups
-        if 'spec' in kwargs:
+        if 'query' in kwargs:
             # use specific spec (JSON query)
-            spec = kwargs['spec']
+            spec = kwargs['query']
         elif 'pileupName' in kwargs:
             # get docs for given pileupName
             spec = {'pileupName': kwargs['pileupName']}
@@ -76,13 +73,21 @@ class MSPileup(MSCore):
 
         return results
 
-    def queryDatabase(self, spec, projection=None):
+    def queryDatabase(self, query, projection=None):
         """
         MSPileup query database API querying the data in underlying data layer.
 
-        :param spec: provide query JSON spec to MSPileup data layer
+        :param query: provide query JSON spec to MSPileup data layer
         :return: results of MSPileup data layer (list of dicts)
         """
+        spec = {}  # (get all full docs) retrieve a list with the full documentation of all the pileups
+        if 'query' in query:
+            # use specific spec (JSON query)
+            spec = query['query']
+        # check if filters are present and use it as projection fields
+        projection = {}
+        for key in query.get('filters', []):
+            projection[key] = 1
         return self.mgr.getPileup(spec, projection)
 
     def createPileup(self, pdict):

--- a/src/python/WMCore/MicroService/MSPileup/MSPileupError.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupError.py
@@ -18,6 +18,7 @@ MSPILEUP_DUPLICATE_ERROR = 3
 MSPILEUP_NOTFOUND_ERROR = 4
 MSPILEUP_DATABASE_ERROR = 5
 MSPILEUP_UNIQUE_ERROR = 6
+MSPILEUP_SCHEMA_ERROR = 7
 
 
 class MSPileupError(WMException):
@@ -74,6 +75,15 @@ class MSPileupGenericError(MSPileupError):
     def __init__(self, data, msg=""):
         super().__init__(data, msg)
         self.assign(msg="generic error", code=MSPILEUP_GENERIC_ERROR)
+
+
+class MSPileupSchemaError(MSPileupError):
+    """
+    Schema MSPileup exception
+    """
+    def __init__(self, data, msg=""):
+        super().__init__(data, msg)
+        self.assign(msg="schema error", code=MSPILEUP_SCHEMA_ERROR)
 
 
 class MSPileupInvalidDataError(MSPileupError):

--- a/src/python/WMCore/MicroService/Service/Data.py
+++ b/src/python/WMCore/MicroService/Service/Data.py
@@ -15,12 +15,12 @@ curl -X POST -H "Content-type: application/json" -d '{"request":{"spec":"spec"}}
 
 # MSPileup get APIs
 # spec.json will contains spec query to delete MSPileup document, e.g.
-# {"pileupName": "bla-bla-bla"} or {"campaignName":"campaign"}
+# {"query": {"pileupName": "bla-bla-bla"}}
 curl -X POST -H "Content-type: application/json" -d@./spec.json http://lhost:port/ms-pileup/data
 
 or we will use dedicated end-point, e.g. data
-curl -X GET http://lhost:port/ms-pileup/data?pileupName=bla-bla-bla
-curl -X GET http://lhost:port/ms-pileup/data?campaign=campaign
+curl -X GET http://lhost:port/ms-pileup/data/pileup?pileupName=bla
+curl -X GET http://lhost:port/ms-pileup/data/pileup?campaign=campaign
 
 # MSPileup create APIs
 # doc.json contains new MSPileup document

--- a/src/python/WMCore/REST/Server.py
+++ b/src/python/WMCore/REST/Server.py
@@ -749,6 +749,8 @@ class MiniRESTApi(object):
             return self._call(RESTArgs(list(args), kwargs))
         except HTTPRedirect:
             raise
+        except cherrypy.HTTPError:
+            raise
         except Exception as e:
             report_rest_error(e, format_exc(), True)
         finally:

--- a/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupData_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupData_t.py
@@ -10,6 +10,7 @@ import unittest
 
 # WMCore modules
 from WMCore.MicroService.MSPileup.MSPileupData import MSPileupData, stripKeys
+from WMCore.MicroService.MSPileup.MSPileupError import MSPILEUP_SCHEMA_ERROR
 from Utils.Timers import encodeTimestamp, decodeTimestamp
 
 
@@ -119,6 +120,26 @@ class MSPileupTest(unittest.TestCase):
         self.assertEqual(len(out), 0)
         results = self.mgr.getPileup(spec)
         self.assertEqual(len(results), 0)
+
+    def testMSPileupQuery(self):
+        "test MSPileup query API"
+        pname = '/skldjflksdjf/skldfjslkdjf/PREMIX'
+        spec = {"pileupName": pname}
+        res = self.mgr.getPileup(spec)
+        self.assertEqual(len(res), 0)
+
+        spec = {"bla": 1}
+        res = self.mgr.sanitizeQuery(spec)
+        # validate should return list of single dictionary
+        # [{'data': {'bla': 1}, 'message': 'schema error', 'code': 7, 'error': 'MSPileupError'}]
+        self.assertEqual(len(res), 1)
+        err = res[0]
+        self.assertEqual(err.get('error'), 'MSPileupError')
+        self.assertEqual(err.get('code'), MSPILEUP_SCHEMA_ERROR)
+
+        # and we should get zero results
+        res = self.mgr.getPileup(spec)
+        self.assertEqual(len(res), 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #11425 

#### Status
ready

#### Description
Fix several issues with MSPileup HTTP APIs:
- Fix MSPileup query logic, commit 73c3d81e4ee72decc2db4bd244cb5c41cc3fa82d
- remove REST `API` key about API (it is not used by MSPIleup data logic), commit 5828f2252070f168318d791eabbce7ed62f7f36b
- Adjust docstring to represent current end-point, commit bfd09cec9e764efd63805b3660f410eb61a870bc
- Fix `REST/Format.py` module where I defined `obj` used in exception, and add `cherrypy.HTTPError` exception which can be thrown by underlying service, commit e0fdd133fe2008fc6b0981162eb2972884cb234a
- Fix `REST/Server.py` module to add missing `cherrypy.HTTPError` exception, commit 9c5130df871ad0b57c3d30dd8f3fd1d2444fb330
All aforementioned errors were found during validation tests of MSPileup service. In particular, the REST modules error revealed long standing issue of Python exception error, when lower module exception was not propagated to the client since another exception was thrown. In particular here is an example of such multi-thrown exception:
```
# client made a POST HTTP request to MSPileup
curl -X POST -H "Content-type: application/json" -d@./tmp/pileup/bad.json "http://localhost:8249/ms-pileup/data/pileup"

# It received the following error (only shown relevant part of HTTP response):
...
        <h2>500 Internal Server Error</h2>
        <p>Execution error</p>
        <pre id="traceback"></pre>
...

# while on server side it was shown as following:
2023-02-06 18:18:07,134:ERROR:MSPileupObj: pileupType value BAD is neither of ['classic', 'premix']
2023-02-06 18:18:07,134:ERROR:MSPileupData: Failed to create MSPileupObj, MSPileup input is invalid, pileupType value BAD
is neither of ['classic', 'premix']
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/WMCore/MicroService/MSPileup/MSPileupData.py", line 94, in createPileup
    obj = MSPileupObj(pdict, validRSEs=self.validRSEs)
  File "/usr/local/lib/python3.8/site-packages/WMCore/MicroService/MSPileup/DataStructs/MSPileupObj.py", line 66, in __ini
t__
    raise Exception(msg)
Exception: MSPileup input is invalid, pileupType value BAD is neither of ['classic', 'premix']
2023-02-06 18:18:07,177:ERROR:MSPileupData: {
    "data": {
        "pileupName": "/sdkjfhsdkf/klsjdflksdj/PREMIX",
        "pileupType": "BAD",
        "expectedRSEs": [],
        "currentRSEs": [],
        "fullReplicas": 1,
        "campaigns": [
            "test"
        ],
        "containerFraction": 0.5,
        "replicationGrouping": "ALL",
        "active": true,
        "pileupSizeGB": 123,
        "rulesList": []
    },
    "message": "Failed to create MSPileupObj, MSPileup input is invalid, pileupType value BAD is neither of ['classic', 'premix']",
    "code": 3,
    "error": "MSPileupError"
}
[06/Feb/2023:18:18:07]  SERVER REST ERROR WMCore.REST.Error.ExecutionError 46bde58da62d83ecf9a8aca3e9731dd0 (Execution error)
[06/Feb/2023:18:18:07]    Traceback (most recent call last):
[06/Feb/2023:18:18:07]      File "/usr/local/lib/python3.8/site-packages/WMCore/REST/Format.py", line 251, in stream_chunked
[06/Feb/2023:18:18:07]        for obj in stream:
[06/Feb/2023:18:18:07]      File "/usr/local/lib/python3.8/site-packages/WMCore/MicroService/Service/Data.py", line 165, in post
[06/Feb/2023:18:18:07]        mspileupError(doc)
[06/Feb/2023:18:18:07]      File "/usr/local/lib/python3.8/site-packages/WMCore/MicroService/Service/Data.py", line 73, in mspileupError
[06/Feb/2023:18:18:07]        raise cherrypy.HTTPError(400, msg) from None
[06/Feb/2023:18:18:07]    cherrypy._cperror.HTTPError: (400, "MSPileupError: Failed to create MSPileupObj, MSPileup input is invalid, pileupType value BAD is neither of ['classic', 'premix'], code: 3")
[06/Feb/2023:18:18:07]
[06/Feb/2023:18:18:07]    During handling of the above exception, another exception occurred:
[06/Feb/2023:18:18:07]
[06/Feb/2023:18:18:07]    Traceback (most recent call last):
[06/Feb/2023:18:18:07]      File "/usr/local/lib/python3.8/site-packages/WMCore/REST/Format.py", line 262, in stream_chunked
[06/Feb/2023:18:18:07]        % (obj, type(obj), str(exp)))
[06/Feb/2023:18:18:07]    UnboundLocalError: local variable 'obj' referenced before assignment
[06/Feb/2023:18:18:07]  SERVER HTTP ERROR cherrypy._cperror.HTTPError e69e87f9bdaa36c8802815848c49f0cb ((500, 'Execution error'))
[06/Feb/2023:18:18:07]    Traceback (most recent call last):
[06/Feb/2023:18:18:07]      File "/usr/local/lib/python3.8/site-packages/WMCore/REST/Server.py", line 749, in default
[06/Feb/2023:18:18:07]        return self._call(RESTArgs(list(args), kwargs))
[06/Feb/2023:18:18:07]      File "/usr/local/lib/python3.8/site-packages/WMCore/REST/Server.py", line 865, in _call
[06/Feb/2023:18:18:07]        return stream_maybe_etag(apiobj.get('etag_limit', self.etag_limit), etagger, reply)
[06/Feb/2023:18:18:07]      File "/usr/local/lib/python3.8/site-packages/WMCore/REST/Format.py", line 619, in stream_maybe_etag
[06/Feb/2023:18:18:07]        raise cherrypy.HTTPError(int(err), message)
[06/Feb/2023:18:18:07]    cherrypy._cperror.HTTPError: (500, 'Execution error')
[06/Feb/2023:18:18:07] ms-pileup-595657876c-dj7j5 188.185.65.135 "POST /ms-pileup/data/pileup HTTP/1.1" 500 Internal Server Error [data: 4573 in 745 out 45056 us ] [auth: OK "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=valya/CN=443502/CN=Valentin Y Kuznetsov" "" ] [ref: "" "curl/7.61.1" ]
```

The issue in this error is two-fold:
- missing object definition in `REST/Format.py` module caused the following error: `UnboundLocalError: local variable 'obj' referenced before assignment`
- while, `REST/Server.py` were missing handling of `cherrypy.HTTPError` exception too which caused its substitution with `cherrypy._cperror.HTTPError: (500, 'Execution error')`error returned to the client

With provided change the actual error returned to the client is this one:
```
...
        <h2>400 Bad Request</h2>
        <p>MSPileupError: Failed to create MSPileupObj, MSPileup input is invalid, pileupType value BAD is neither of ['classic', 'premix'], code: 3</p>
        <pre id="traceback"></pre>
...
```
and we do have proper error in a server log too:
```
2023-02-06 15:48:00,289:ERROR:MSPileupObj: pileupType value BAD is neither of ['classic', 'premix']
2023-02-06 15:48:00,289:ERROR:MSPileupData: Failed to create MSPileupObj, MSPileup input is invalid, pileupType value BAD is neither of ['classic', 'premix']
Traceback (most recent call last):
  File "/Users/vk/CMS/DMWM/GIT/WMCore/src/python/WMCore/MicroService/MSPileup/MSPileupData.py", line 94, in createPileup
    obj = MSPileupObj(pdict, validRSEs=self.validRSEs)
  File "/Users/vk/CMS/DMWM/GIT/WMCore/src/python/WMCore/MicroService/MSPileup/DataStructs/MSPileupObj.py", line 66, in __init__
    raise Exception(msg)
Exception: MSPileup input is invalid, pileupType value BAD is neither of ['classic', 'premix']
2023-02-06 15:48:00,482:ERROR:MSPileupData: {
    "data": {
        "pileupName": "/sdkjfhsdkf/klsjdflksdj/PREMIX",
        "pileupType": "BAD",
        "expectedRSEs": [],
        "currentRSEs": [],
        "fullReplicas": 1,
        "campaigns": [
            "test"
        ],
        "containerFraction": 0.5,
        "replicationGrouping": "ALL",
        "active": true,
        "pileupSizeGB": 123,
        "rulesList": []
    },
    "message": "Failed to create MSPileupObj, MSPileup input is invalid, pileupType value BAD is neither of ['classic', 'premix']",
    "code": 3,
    "error": "MSPileupError"
}
[06/Feb/2023:15:48:00] vkair 127.0.0.1 "POST /ms-pileup/data/pileup HTTP/1.1" 400 Bad Request [data: 449 in 847 out 195507 us ] [auth: - "" "" ] [ref: "" "curl/7.87.0" ]
```

With all of these fixes now MSPIleup perform correctly the following operations:
- create new (correct) document via HTTP POST
- query existing document via GET HTTP request and via POST HTTP API call
   - for POST HTTP API call we can use the following query
```
# make query spec, e.g. cat spec.json
{"query": {"pileupType": "classic"}}

# query service
curl -X POST -H "Content-type: application/json" -d@./tmp/pileup/spec.json "http://localhost:8249/ms-pileup/data/pileup"
```
- and, if we post bad MSPileup doc, e.g. of the the fields is not validated our client gets proper HTTP error:
```
# place bad json (which contains wrong value for pileupType
curl -X POST -H "Content-type: application/json" -d@./tmp/pileup/bad.json "http://localhost:8249/ms-pileup/data/pileup"

# client will get the following response:
...
        <h2>400 Bad Request</h2>
        <p>MSPileupError: Failed to create MSPileupObj, MSPileup input is invalid, pileupType value BAD is neither of ['classic', 'premix'], code: 3</p>
        <pre id="traceback"></pre>
...
```

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
#11443 

#### External dependencies / deployment changes
