### PR TITLE
New MSAuth module for authorization with MS services

### DIFF
--- a/src/python/WMCore/MicroService/MSCore/MSAuth.py
+++ b/src/python/WMCore/MicroService/MSCore/MSAuth.py
@@ -1,0 +1,114 @@
+"""
+File       : MSAuth.py
+Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
+Description: MSAuth class provides auth/authz functionality for micro-services
+
+The auth/authz schema is defined in JSON data-format as list of records, e.g.
+[ record1, record2, ...] where individual record has the following structure
+{"role": string, "group": string, "service": string, "action": string, "method": [string, string]}
+where
+- role defines authorization role, e.g. admin
+- group defines specific group, e.g. reqmgr
+- service identifies MS service, e.g. ms-pileup
+- actions refers to a specific API or action, e.g. create
+- method contains list of allowed HTTP methods, e.g. ["POST", "PUT"]
+
+For example, here is a possible list of authz rules for MSPileup service
+
+authz_rules = \
+    [{"role": "admin", "group": "reqmgr", "service": "ms-pileup", "action": "create", "method": ["POST"]},
+     {"role": "production-operator", "group": "dataops", "service": "ms-pileup", "action": "create", "method": ["POST"]},
+
+     {"role": "admin", "group": "reqmgr", "service": "ms-pileup", "action": "create", "method": ["DELETE"]},
+     {"role": "production-operator", "group": "dataops", "service": "ms-pileup", "action": "create", "method": ["DELETE"]},
+
+     {"role": "admin", "group": "reqmgr", "service": "ms-pileup", "action": "update", "method": ["PUT"]},
+     {"role": "production-operator", "group": "dataops", "service": "ms-pileup", "action": "update", "method": ["PUT"]}]
+"""
+
+# system modules
+import os
+import json
+
+# third party modules
+import cherrypy
+
+# WMCore modules
+from WMCore.MicroService.Tools.Common import getMSLogger
+from WMCore.REST.Auth import user_info_from_headers
+
+
+def readAuthzRules(entry):
+    """
+    Return authz rules from given entry
+    :param entry: either file name or list of authz rules, see docstring of this module
+    :return: list of authz rules
+    """
+    rules = []
+    if entry is None:
+        return rules
+    # of provided is a list data-type it may contaisn our rules
+    if isinstance(entry, list) and len(entry) > 0:
+        if isinstance(entry[0], dict):
+            return entry
+    # check if entry is a file name
+    if os.path.exists(entry):
+        with open(entry, 'r', encoding="utf-8") as fstream:
+            rules = json.load(fstream)
+            return rules
+    msg = f"Unable to read {entry} as authz rules"
+    raise Exception(msg)
+
+
+class MSAuth():
+    """
+    This class provides auth/authz functionality for micro-services
+    """
+
+    def __init__(self, msConfig, **kwargs):
+        """
+        Provides a basic setup for all the microservices
+
+        :param msConfig: MS service configuration
+        :param kwargs: optional parameters
+        """
+        self.logger = getMSLogger(getattr(msConfig, 'verbose', False), kwargs.get("logger"))
+        self.msConfig = msConfig
+        self.logger.info("Configuration including default values:\n%s", self.msConfig)
+
+        # load auth/authz configuration
+        self.authzRules = readAuthzRules(msConfig.get('authz_rules', None))
+        self.authzKey = msConfig['authz_key']  # hmac key of front-end
+
+    def authorizeApiAccess(self, service, action, method=None):
+        """
+        Check auth role.
+        :return: boolean
+        """
+        # get user information
+        user = user_info_from_headers(key=self.authzKey)
+
+        # CMS AUTH headers
+        # cms-auth-status, cms-authn, cms-authz, cms-authn-hmac, cms-authn-name, cms-authn-dn
+        for entry in self.authzRules:
+            # check that user method is allowed
+            if method and method not in entry['method']:
+                continue
+            userMethod = user.get('method', None)
+            if userMethod and userMethod not in entry['method']:
+                continue
+
+            # check if entry service and action matches
+            if entry['service'] == service and entry['action'] == action:
+                # if we have match for service and action we'll check used roles
+                # 'roles': {'fake': {'site': set(['fake']), 'group': set(['fake'])}}
+                for role, obj in user['roles'].items():
+                    if role != entry['role']:
+                        continue
+                    for group in obj['group']:
+                        if group == entry['group']:
+                            return
+
+        # if we reach this place we did not match anything and should through exception
+        self.logger.error("ERROR: not authorized access to %s method %s", service, action)
+        raise cherrypy.HTTPError(403, "You are not authorized to access this resource.")

--- a/test/python/WMCore_t/MicroService_t/MSCore_t/MSAuth_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSCore_t/MSAuth_t.py
@@ -1,0 +1,76 @@
+"""
+Unit tests for MSAuth.py module
+
+Author: Valentin Kuznetsov <vkuznet [AT] gmail [DOT] com>
+"""
+
+# system modules
+import os
+import json
+import unittest
+
+# third party modules
+import cherrypy
+
+# WMCore modules
+from WMCore.MicroService.MSCore.MSAuth import readAuthzRules, MSAuth
+
+
+class MSAuthTest(unittest.TestCase):
+    "Unit test for MSAuth module"
+
+    def setUp(self):
+        """
+        setup necessary data for unit test usage
+        """
+        self.rules = [
+            {"role": "admin", "group": "reqmgr", "service": "ms-pileup", "action": "create", "method": ["POST"]},
+            {"role": "user", "group": "admin", "service": "ms-pileup", "action": "create", "method": ["POST"]}]
+        # REST/Auth.py module calculates checksum based on provided hmac
+        # for instnace for self.hmac we will expect self.chkSum
+        # with all CMS headers we setup below
+        # d357b299194ec4bed4e4fc73fc9ceab10139c16f vs. 4311773080ea12f4ea31a096da49de105083bb9e
+        self.hmac = 'd357b299194ec4bed4e4fc73fc9ceab10139c16f'
+        self.chkSum = '4311773080ea12f4ea31a096da49de105083bb9e'
+        self.fname = '/tmp/ms-authz.json'
+
+        # for testing purposes we need to setup cherrypy headers
+        # cms-auth-status, cms-authn, cms-authz, cms-authn-hmac, cms-authn-name, cms-authn-dn
+        cherrypy.request.headers = {
+            'cms-auth-status': 'OK',
+            'cms-authn': 'fake',
+            'cms-authz-user': 'group:users group:admin',
+            'cms-authn-hmac': self.hmac,
+            'cms-authn-name': 'test',
+            'cms-authn-dn': 'dn'}
+
+    def tearDown(self):
+        """Clean-up method for unit test"""
+        if os.path.exists(self.fname):
+            os.remove(self.fname)
+
+    def testReadAuthzRules(self):
+        "test MSAuth methods"
+        rules = readAuthzRules(self.rules)
+        self.assertCountEqual(self.rules, rules)
+
+        with open(self.fname, 'w', encoding="utf-8") as ostream:
+            ostream.write(json.dumps(self.rules))
+        rules = readAuthzRules(self.fname)
+        self.assertCountEqual(self.rules, rules)
+
+    def testMSAuth(self):
+        "test MSAuth methods"
+        msConfig = {'authz_rules': self.rules, 'authz_key': bytes(self.chkSum, 'UTF-8')}
+        mgr = MSAuth(msConfig)
+        mgr.authorizeApiAccess('ms-pileup', 'create')
+
+        # now let's try to check if we are not authorized
+        with self.assertRaises(cherrypy.HTTPError):
+            mgr.authorizeApiAccess('ms-pileup', 'wrong-method')
+        with self.assertRaises(cherrypy.HTTPError):
+            mgr.authorizeApiAccess('wrong-service', 'create')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #11465 

#### Status
ready

#### Description
Based on proposed schema in #11465 I implemented required class called `MSAuth` in place it in `MSCore` module. This class is integrated with CMSWEB headers and `REST/Auth.py` module. In order to use it we need to provide the following:
- authorization rules, either in form of a file or as defined in schema via MS configuration, i.e. in MS configuration you may specify either file name or provide a list of rules
- we should provide CMSWEB hmac key to allow proper check of user credentials in CMSWEB headers

Once initialized it can be used as following:
```
mgr = MSAuth(msConfig)
mgr.authorizeApiAccess('ms-pileup', 'create')
```
The `MSAuth` class so far defines only one API `authorizeApiAccess` which accepts service name, action and optional HTTP method. This information is checked against authorization rules of the class and if user info (which is provided via CMS headers based on CRIC) matches the user is allowed to use the resource, otherwise proper HTTP authorization error is thrown, please see corresponding unit test.


#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
#11424 , #11475, #11443

#### External dependencies / deployment changes
