### PR TITLE
Adopt CMS_PATH and SITECONFIG_PATH to locate the site catalog

### DIFF
--- a/src/python/WMCore/Storage/SiteLocalConfig.py
+++ b/src/python/WMCore/Storage/SiteLocalConfig.py
@@ -23,7 +23,7 @@ def loadSiteLocalConfig():
 
     Runtime Accessor for the site local config.
 
-    Requires that CMS_PATH is defined as an environment variable
+    Requires that SITECONFIG_PATH is defined as an environment variable
 
     """
     overVarName = "WMAGENT_SITE_CONFIG_OVERRIDE"
@@ -39,11 +39,11 @@ def loadSiteLocalConfig():
             msg = "%s env. var. provided but not pointing to an existing file, ignoring." % overVarName
             logging.log(logging.ERROR, msg)
 
-    defaultPath = "$CMS_PATH/SITECONF/local/JobConfig/site-local-config.xml"
+    defaultPath = "$SITECONFIG_PATH/JobConfig/site-local-config.xml"
     actualPath = os.path.expandvars(defaultPath)
-    if os.environ.get("CMS_PATH", None) is None:
+    if os.environ.get("SITECONFIG_PATH", None) is None:
         msg = "Unable to find site local config file:\n"
-        msg += "CMS_PATH variable is not defined."
+        msg += "SITECONFIG_PATH variable is not defined."
         raise SiteConfigError(msg)
 
     if not os.path.exists(actualPath):

--- a/src/python/WMCore/WMRuntime/Tools/Scram.py
+++ b/src/python/WMCore/WMRuntime/Tools/Scram.py
@@ -385,8 +385,12 @@ class Scram(object):
             self.procWriter(proc, 'export VO_CMS_SW_DIR=%s\n' % os.environ['VO_CMS_SW_DIR'])
         if os.environ.get('OSG_APP', None) is not None:
             self.procWriter(proc, 'export VO_CMS_SW_DIR=%s/cmssoft/cms\n' % os.environ['OSG_APP'])
+        # In general, CMSSW releases <= 12_6_0 will use CMS_PATH, while anything beyond that
+        # requires the SITECONFIG_PATH variable to properly load storage.xml/json file.
         if os.environ.get('CMS_PATH', None) is not None:
             self.procWriter(proc, 'export CMS_PATH=%s\n' % os.environ['CMS_PATH'])
+        if os.environ.get('SITECONFIG_PATH', None) is not None:
+            self.procWriter(proc, 'export SITECONFIG_PATH=%s\n' % os.environ['SITECONFIG_PATH'])
         if os.environ.get('_CONDOR_JOB_AD'):
             self.procWriter(proc, 'export _CONDOR_JOB_AD=%s\n' % os.environ['_CONDOR_JOB_AD'])
         if os.environ.get('_CONDOR_MACHINE_AD'):

--- a/test/python/WMCore_t/Storage_t/SiteLocalConfig_t.py
+++ b/test/python/WMCore_t/Storage_t/SiteLocalConfig_t.py
@@ -148,7 +148,7 @@ class SiteLocalConfigTest(unittest.TestCase):
         self.assertEqual(mySiteConfig.siteName, "T3_US_Vanderbilt",
                          "Error: Wrong site name.")
 
-
+    # this test requires access to CVMFS
     @attr("integration")
     def testSlcPhedexNodesEqualPhedexApiNodes(self):
         """
@@ -156,6 +156,7 @@ class SiteLocalConfigTest(unittest.TestCase):
         site-local-config.xml is the same as the one returned by the PhEDEx api.
         """
         os.environ["CMS_PATH"] = "/cvmfs/cms.cern.ch"
+        os.environ["SITECONFIG_PATH"] = "/cvmfs/cms.cern.ch/SITECONF/local"
 
         nodes = ['FIXME']
 

--- a/test/python/WMCore_t/Storage_t/StageOutMgr_t.py
+++ b/test/python/WMCore_t/Storage_t/StageOutMgr_t.py
@@ -13,6 +13,7 @@ class StageOutMgrTest(unittest.TestCase):
     def setUp(self):
         # shut up SiteLocalConfig
         os.putenv('CMS_PATH', os.getcwd())
+        os.putenv('SITECONFIG_PATH', os.getcwd())
 
     def testName(self):
         pass

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/LogArch_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/LogArch_t.py
@@ -46,6 +46,7 @@ class LogArchiveTest(unittest.TestCase):
 
         # shut up SiteLocalConfig
         os.environ['CMS_PATH'] = os.getcwd()
+        os.environ['SITECONFIG_PATH'] = os.getcwd()
         workload = copy.deepcopy(testWorkloads.workload)
         task = workload.getTask("Production")
         step = task.getStep("stageOut1")

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/StageOut_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/StageOut_t.py
@@ -47,6 +47,7 @@ class StageOutTest(unittest.TestCase):
 
         # shut up SiteLocalConfig
         os.environ['CMS_PATH'] = os.getcwd()
+        os.environ['SITECONFIG_PATH'] = os.getcwd()
         workload = copy.deepcopy(testWorkloads.workload)
         task = workload.getTask("Production")
         step = task.getStep("stageOut1")


### PR DESCRIPTION
Fixes #11449 

#### Status
not-tested

#### Description
In light of the migration from storage.xml to storage.json, CMSSW went through some modifications to support those catalogs, in short:
* any releases made before 12_6_0_pre2 will support storage.xml (through CMS_PATH environment variable)
* any releases starting in 12_6_0_pre3 (exception to 12_6_3) will support only storage.json (through SITECONF_PATH environment variable).

That means, our Scram module needs to keep explicitly defining those variables in the CMSSW environment. As confirmed by Matti below, it should not be a problem to have both variables defined.

#### Is it backward compatible (if not, which system it affects?)
YES (to the best of my knowledge)

#### Related PRs
Somehow related to https://github.com/dmwm/WMCore/issues/11472

#### External dependencies / deployment changes
None
