### PR TITLE
Refactor TFC override for multi-step jobs; adopt SITECONF_PATH during runtime - wmagent branch

### DIFF
--- a/src/python/WMCore/Storage/SiteLocalConfig.py
+++ b/src/python/WMCore/Storage/SiteLocalConfig.py
@@ -23,7 +23,7 @@ def loadSiteLocalConfig():
 
     Runtime Accessor for the site local config.
 
-    Requires that CMS_PATH is defined as an environment variable
+    Requires that SITECONFIG_PATH is defined as an environment variable
 
     """
     overVarName = "WMAGENT_SITE_CONFIG_OVERRIDE"
@@ -39,11 +39,11 @@ def loadSiteLocalConfig():
             msg = "%s env. var. provided but not pointing to an existing file, ignoring." % overVarName
             logging.log(logging.ERROR, msg)
 
-    defaultPath = "$CMS_PATH/SITECONF/local/JobConfig/site-local-config.xml"
+    defaultPath = "$SITECONFIG_PATH/JobConfig/site-local-config.xml"
     actualPath = os.path.expandvars(defaultPath)
-    if os.environ.get("CMS_PATH", None) is None:
+    if os.environ.get("SITECONFIG_PATH", None) is None:
         msg = "Unable to find site local config file:\n"
-        msg += "CMS_PATH variable is not defined."
+        msg += "SITECONFIG_PATH variable is not defined."
         raise SiteConfigError(msg)
 
     if not os.path.exists(actualPath):

--- a/src/python/WMCore/WMRuntime/Tools/Scram.py
+++ b/src/python/WMCore/WMRuntime/Tools/Scram.py
@@ -385,8 +385,12 @@ class Scram(object):
             self.procWriter(proc, 'export VO_CMS_SW_DIR=%s\n' % os.environ['VO_CMS_SW_DIR'])
         if os.environ.get('OSG_APP', None) is not None:
             self.procWriter(proc, 'export VO_CMS_SW_DIR=%s/cmssoft/cms\n' % os.environ['OSG_APP'])
+        # In general, CMSSW releases <= 12_6_0 will use CMS_PATH, while anything beyond that
+        # requires the SITECONFIG_PATH variable to properly load storage.xml/json file.
         if os.environ.get('CMS_PATH', None) is not None:
             self.procWriter(proc, 'export CMS_PATH=%s\n' % os.environ['CMS_PATH'])
+        if os.environ.get('SITECONFIG_PATH', None) is not None:
+            self.procWriter(proc, 'export SITECONFIG_PATH=%s\n' % os.environ['SITECONFIG_PATH'])
         if os.environ.get('_CONDOR_JOB_AD'):
             self.procWriter(proc, 'export _CONDOR_JOB_AD=%s\n' % os.environ['_CONDOR_JOB_AD'])
         if os.environ.get('_CONDOR_MACHINE_AD'):

--- a/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/LogCollect.py
@@ -116,6 +116,7 @@ class LogCollect(Executor):
 
         # setup Scram needed to run edmCopyUtil
         if useEdmCopyUtil:
+            logging.info("Creating software area for %s under %s", cmsswVersion, scramArch)
             scram = Scram(
                     command=scramCommand,
                     version=cmsswVersion,


### PR DESCRIPTION
2.1.6_wmagent branch version of:
* Deprecate TFC override for multi-step jobs #11473 
* Adopt CMS_PATH and SITECONFIG_PATH to locate the site catalog #11481 