### PR TITLE
Fix NameError in Server.py when database tracing is enabled

### DIFF
--- a/src/python/WMCore/REST/Server.py
+++ b/src/python/WMCore/REST/Server.py
@@ -1491,7 +1491,7 @@ class DBConnectionPool(Thread):
         dbh, err = None, None
 
         # If tracing, issue log line that identifies this connection series.
-        trace = s["trace"] and ("RESTSQL:" + "".join(random.sample(string.ascii_letters, 12)))
+        trace = s["trace"] and ("RESTSQL:" + "".join(random.sample(letters, 12)))
         trace and cherrypy.log("%s ENTER %s@%s %s (%s) inuse=%d idle=%d" %
                                (trace, s["user"], s["dsn"], self.id, req["id"],
                                 len(self.inuse), len(self.idle)))


### PR DESCRIPTION
Fix https://github.com/dmwm/WMCore/issues/11484

#### Status
ready (deployed on testbed)

#### Description
Fix `NameError` in Server.py when database tracing is enabled.
I am not sure why Valentin change it from `import string` to `from string import ascii_letters as letters` because it does not use anywhere in commit [d36294b](https://github.com/dmwm/WMCore/commit/d36294b7f9727935b1cda513ba4c9ec958a8eca4).


#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
