### PR TITLE
First implementation of MSPileup data placement logic via MSPileupTasks class

### DIFF
--- a/src/python/WMCore/MicroService/MSPileup/DataStructs/MSPileupObj.py
+++ b/src/python/WMCore/MicroService/MSPileup/DataStructs/MSPileupObj.py
@@ -4,21 +4,21 @@ Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
 Description: MSPileupObj module provides MSPileup data structure:
 
 {
-    "pileupName": string with the pileup dataset
-    "pileupType": string with a constant value
-    "insertTime": int, seconds since epoch in GMT timezone
-    "lastUpdateTime": int, seconds since epoch in GMT timezone
-    "expectedRSEs": ["Disk1", "Disk2", etc],  # these values need to be validated against Rucio
-    "currentRSEs": ["Disk1", "Disk3"],  # values provided by the MS itself
-    "fullReplicas": integer,  # total number of replicas to keep on Disk
-    "campaigns": [ "name", ... ] # list of workflow campaigns using this pileup
-    "containerFraction": real number with the container fraction to be distributed (TBFD)
-    "replicationGrouping": string with a constant value (DATASET or ALL, to be in sync with Rucio)
-    "activatedOn": int, seconds since epoch in GMT timezone
-    "deactivatedOn": int, seconds since epoch in GMT timezone
-    "active": boolean,
-    "pileupSizeGB": integer, current size of the pileup in GB (integer)
-    "rulesList: list of strings (rules) used to lock the pileup id
+    "pileupName": string with the pileup dataset (madatory)
+    "pileupType": string with a constant value (mandatory)
+    "insertTime": int, seconds since epoch in GMT timezone (service-based)
+    "lastUpdateTime": int, seconds since epoch in GMT timezone (service-based)
+    "expectedRSEs": ["Disk1", "Disk2", etc], a non-empty list of strings with the RSE names (mandatory)
+    "currentRSEs": ["Disk1", "Disk3"], a list of strings with the RSE names (service-based)
+    "fullReplicas": integer,  # total number of replicas to keep on Disk (optional)
+    "campaigns": [ "name", ... ] # list of workflow campaigns using this pileup (optional)
+    "containerFraction": real number with the container fraction to be distributed (optional)
+    "replicationGrouping": string with a constant value (DATASET or ALL, (optional)
+    "activatedOn": int, seconds since epoch in GMT timezone (service-based)
+    "deactivatedOn": int, seconds since epoch in GMT timezone (service-based)
+    "active": boolean, (mandatory)
+    "pileupSize": integer, current size of the pileup in bytes (service-based)
+    "ruleIds: list of strings (rules) used to lock the pileup id (service-based)
 }
 
 The data flow should be done via list of objects, e.g.
@@ -29,12 +29,12 @@ The data flow should be done via list of objects, e.g.
 import json
 
 # WMCore modules
+from Utils.Timers import gmtimeSeconds
 from WMCore.MicroService.Tools.Common import getMSLogger
 from WMCore.Lexicon import dataset
-from Utils.Timers import gmtimeSeconds
 
 
-class MSPileupObj(object):
+class MSPileupObj():
     """
     MSPileupObj defines MSPileup data stucture
     """
@@ -44,22 +44,27 @@ class MSPileupObj(object):
             validRSEs = []
         self.validRSEs = validRSEs
 
+        expectedRSEs = pdict['expectedRSEs']
+        if len(expectedRSEs) == 0:
+            msg = 'MSPileup document require non-empty list of expectedRSEs'
+            raise Exception(msg)
+
         self.data = {
-            'pileupName': pdict.get('pileupName', ''),
-            'pileupType': pdict.get('pileupType', ''),
+            'pileupName': pdict['pileupName'],
+            'pileupType': pdict['pileupType'],
             'insertTime': pdict.get('insertTime', gmtimeSeconds()),
             'lastUpdateTime': pdict.get('lastUpdateTime', gmtimeSeconds()),
-            'expectedRSEs': pdict.get('expectedRSEs', []),
+            'expectedRSEs': expectedRSEs,
             'currentRSEs': pdict.get('currentRSEs', []),
-            'fullReplicas': pdict.get('fullReplicas', 0),
+            'fullReplicas': pdict.get('fullReplicas', 1),
             'campaigns': pdict.get('campaigns', []),
             'containerFraction': pdict.get('containerFraction', 1.0),
-            'replicationGrouping': pdict.get('replicationGrouping', ""),
+            'replicationGrouping': pdict.get('replicationGrouping', 'ALL'),
             'activatedOn': pdict.get('activatedOn', gmtimeSeconds()),
             'deactivatedOn': pdict.get('deactivatedOn', gmtimeSeconds()),
             'active': pdict.get('active', False),
             'pileupSize': pdict.get('pileupSize', 0),
-            'ruleList': pdict.get('ruleList', [])}
+            'ruleIds': pdict.get('ruleIds', [])}
         valid, msg = self.validate(self.data)
         if not valid:
             msg = f'MSPileup input is invalid, {msg}'
@@ -126,7 +131,7 @@ class MSPileupObj(object):
                 msg = f"containerFraction value {val} outside [0,1] range"
                 self.logger.error(msg)
                 return False, msg
-            if (key == 'expectedRSEs' or key == 'currentRSEs') and not self.validateRSEs(val):
+            if key in ('expectedRSEs', 'currentRSEs') and not self.validateRSEs(val):
                 msg = f"{key} value {val} is not in validRSEs {self.validRSEs}"
                 self.logger.error(msg)
                 return False, msg
@@ -170,5 +175,5 @@ def schema():
            'deactivatedOn': (0, int),
            'active': (False, bool),
            'pileupSize': (0, int),
-           'ruleList': ([], list)}
+           'ruleIds': ([], list)}
     return doc

--- a/src/python/WMCore/MicroService/MSPileup/MSPileupReport.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupReport.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+"""
+File       : MSPileupReport.py
+Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
+Description: MSPileup report module
+"""
+
+# WMCore modules
+from Utils.Timers import gmtimeSeconds, encodeTimestamp
+
+
+class MSPileupReport():
+    """
+    MSPileupReport class represents MSPileup report object(s)
+    """
+    def __init__(self, autoExpire=3600, autoCleanup=False):
+        """
+        Constructor for MSPileup object
+        """
+        self.docs = []
+        self.autoExpire = autoExpire
+        self.autoCleanup = autoCleanup
+
+    def addEntry(self, task, uuid, entry):
+        """
+        Add new entry into MSPileup documents
+
+        :param task: task name
+        :param uuid: unique id of the entry
+        :param entry: entry message or any other object to store
+        """
+        if self.autoCleanup:
+            self.purgeExpired()
+        gmtime = gmtimeSeconds()
+        report = {'gmtime': gmtime, 'uuid': uuid,
+                  'timestamp': encodeTimestamp(gmtime),
+                  'entry': entry, 'task': task}
+        self.docs.append(report)
+
+    def purgeExpired(self):
+        """
+        Purge expired records from internal docs
+        """
+        gmtime = gmtimeSeconds()
+        for entry in list(self.docs):
+            if gmtime - entry['gmtime'] > self.autoExpire:
+                self.docs.remove(entry)
+
+    def getDocuments(self):
+        """
+        Return report documents
+        """
+        if self.autoCleanup:
+            self.purgeExpired()
+        return self.docs
+
+    def getReportByUuid(self):
+        """
+        Return report documents in dictonary form with uuid's as keys
+        """
+        if self.autoCleanup:
+            self.purgeExpired()
+        rdict = {}
+        for doc in self.docs:
+            uuid = doc['uuid']
+            timestamp = doc['timestamp']
+            entry = doc['entry']
+            task = doc['task']
+            record = f"{timestamp} {task} task {uuid} {entry}"
+            rdict.setdefault(uuid, []).append(record)
+        return rdict

--- a/src/python/WMCore/MicroService/MSPileup/MSPileupTaskManager.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupTaskManager.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+"""
+File       : MSPileupTaskManager.py
+Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
+Description: MSPileupTaskManager handles MSPileupTasks
+
+In particular, it perform the following tasks each polling cycle:
+    - fetches pileup sizes for all pileup documents in database back-end
+    - update RSE quotas
+    - perform monitoring task
+    - perform task for active pileups using up-to-date RSE quotas
+    - perform task for inactive pileups
+"""
+
+# system modules
+import os
+from threading import current_thread
+
+# WMCore modules
+from WMCore.MicroService.MSCore.MSCore import MSCore
+from WMCore.MicroService.DataStructs.DefaultStructs import PILEUP_REPORT
+from WMCore.MicroService.MSPileup.MSPileupData import MSPileupData
+from WMCore.MicroService.MSPileup.MSPileupTasks import MSPileupTasks
+from WMCore.MicroService.MSTransferor.DataStructs.RSEQuotas import RSEQuotas
+from WMCore.MicroService.Tools.PycurlRucio import getPileupContainerSizesRucio, getRucioToken
+from WMCore.Services.Rucio.Rucio import Rucio
+
+
+class MSPileupTaskManager(MSCore):
+    """
+    MSPileupTaskManager handles MSPileup tasks
+    """
+
+    def __init__(self, msConfig, **kwargs):
+        super().__init__(msConfig, **kwargs)
+        self.marginSpace = msConfig.get('marginSpace', 1024**4)
+        self.rucioAccount = msConfig.get('rucioAccount', 'ms-pileup')
+        self.rucioUrl = msConfig.get('rucioHost', 'http://cms-rucio.cern.ch')
+        self.rucioAuthUrl = msConfig.get('authHost', 'https://cms-rucio-auth.cern.ch')
+        creds = {"client_cert": os.getenv("X509_USER_CERT", "Unknown"),
+                 "client_key": os.getenv("X509_USER_KEY", "Unknown")}
+        configDict = {'rucio_host': self.rucioUrl, 'auth_host': self.rucioAuthUrl,
+                      'creds': creds, 'auth_type': 'x509'}
+        self.rucioClient = Rucio(self.rucioAccount, configDict=configDict)
+        self.dataManager = MSPileupData(msConfig)
+        self.mgr = MSPileupTasks(self.dataManager, self.logger,
+                                 self.rucioAccount, self.rucioClient)
+        self.rseQuotas = RSEQuotas(self.rucioAccount, msConfig["quotaUsage"],
+                                   minimumThreshold=msConfig["minimumThreshold"],
+                                   verbose=msConfig['verbose'], logger=self.logger)
+
+    def status(self):
+        """
+        Provide MSPileupTaskManager status API.
+
+        :return: status dictionary
+        """
+        summary = dict(PILEUP_REPORT)
+        summary.update({'thread_id': current_thread().name})
+        summary.update({'tasks': self.msg.getReport())
+        return summary
+
+    def executeCycle(self):
+        """
+        execute MSPileupTasks polling cycle
+        """
+        # get pileup sizes and update them in DB
+        spec = {}
+        docs = self.dataManager.getPileup(spec)
+        rucioToken = getRucioToken(self.rucioAuthUrl, self.rucioAccount)
+        containers = [r['pileupName'] for r in docs]
+        datasetSizes = getPileupContainerSizesRucio(containers, self.rucioUrl, rucioToken)
+        for doc in docs:
+            pileupSize = datasetSizes.get(doc['pileupName'], 0)
+            doc['pileupSize'] = pileupSize
+            self.dataManager.updatePileup(doc)
+
+        # fetch all rse quotas
+        self.rseQuotas.fetchStorageUsage(self.rucioClient)
+        nodeUsage = self.rseQuotas.getNodeUsage()
+
+        # execute all tasks
+        self.mgr.monitoringTask()
+        self.mgr.activeTask(nodeUsage=nodeUsage, marginSpace=self.marginSpace)
+        self.mgr.inactiveTask()

--- a/test/data/Mock/RucioMockData.json
+++ b/test/data/Mock/RucioMockData.json
@@ -1392,6 +1392,19 @@
   "scope": "cms",
   "type": "CONTAINER"
  },
+ "listDataRules:[('account', 'ms-pileup'), ('scope', 'cms')]": [{
+  "state": "OK",
+  "id": "123",
+  "rse_expression": "T2_XX_CERN",
+  "locks_ok_cnt": 2,
+  "locks_replicating_cnt": 2,
+  "locks_stuck_cnt": 2,
+  "scope": "cms",
+  "name": "/MinimumBias/ComissioningHI-v1/RAW",
+  "account": "ms-pileup"
+ }],
+ "evaluateRSEExpression": ["T2_XX_CERN"],
+ "deleteRule": true,
  "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#00ad285a-0d7b-11e1-9b6c-003048caaace')]": false,
  "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#14ad7dfe-0acf-11e1-8347-003048caaace')]": false,
  "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#1bb7b9b6-0d95-11e1-9b6c-003048caaace')]": false,

--- a/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupData_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupData_t.py
@@ -19,10 +19,12 @@ class MSPileupTest(unittest.TestCase):
 
     def setUp(self):
         """setup unit test class"""
+        self.validRSEs = ['rse1']
         msConfig = {'reqmgr2Url': 'http://localhost',
                     'rucioAccount': 'wmcore_mspileup',
                     'rucioUrl': 'http://cms-rucio-int.cern.ch',
                     'rucioAuthUrl': 'https://cms-rucio-auth-int.cern.ch',
+                    'validRSEs': self.validRSEs,
                     'mongoDB': 'msPileupDB',
                     'mongoDBCollection': 'msPileupDBCollection',
                     'mongoDBServer': 'mongodb://localhost',
@@ -74,10 +76,10 @@ class MSPileupTest(unittest.TestCase):
         skeys = ['_id']
         pname = '/skldjflksdjf/skldfjslkdjf/PREMIX'
         now = int(time.mktime(time.gmtime()))
-        expectedRSEs = []
+        expectedRSEs = self.validRSEs
         fullReplicas = 1
         pileupSize = 1
-        ruleList = []
+        ruleIds = []
         campaigns = []
         containerFraction = 0.0
         replicationGrouping = "ALL"
@@ -97,7 +99,7 @@ class MSPileupTest(unittest.TestCase):
             'deactivatedOn': now,
             'active': True,
             'pileupSize': pileupSize,
-            'ruleList': ruleList}
+            'ruleIds': ruleIds}
 
         out = self.mgr.createPileup(pdict)
         self.assertEqual(len(out), 0)

--- a/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupObj_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupObj_t.py
@@ -39,7 +39,7 @@ class MSPileupObjTest(unittest.TestCase):
             'replicationGrouping': "ALL",
             'active': True,
             'pileupSize': 0,
-            'ruleList': []}
+            'ruleIds': []}
         obj = MSPileupObj(data, validRSEs=expectedRSEs)
         for key in ['insertTime', 'lastUpdateTime', 'activatedOn', 'deactivatedOn']:
             self.assertNotEqual(obj.data[key], 0)
@@ -90,7 +90,7 @@ class MSPileupObjTest(unittest.TestCase):
             'replicationGrouping': "",
             'active': True,
             'pileupSize': 0,
-            'ruleList': []}
+            'ruleIds': []}
         try:
             MSPileupObj(data)
             self.assertIsNone(1, msg="MSPileupObj should not be created")

--- a/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupReport_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupReport_t.py
@@ -1,0 +1,50 @@
+"""
+File       : MSPileupTasks_t.py
+Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
+Description: Unit tests for MicorService/MSPileup/MSPileupReport.py module
+"""
+
+# system modules
+import unittest
+
+# WMCore modules
+from WMCore.MicroService.MSPileup.MSPileupReport import MSPileupReport
+
+
+class MSPileupReportTest(unittest.TestCase):
+    """Unit test for MSPileupTasks module"""
+
+    def testMSPileupReport(self):
+        """
+        Test MSPileup report functionality
+        """
+        mgr = MSPileupReport(autoCleanup=True)
+        entry = 'test'
+        task = 'tast'
+        uuid = '123'
+        mgr.addEntry(task, uuid, entry)
+
+        # check documents functionality
+        docs = mgr.getDocuments()
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0]['entry'], entry)
+        self.assertEqual(docs[0]['task'], task)
+        self.assertEqual(docs[0]['uuid'], uuid)
+
+        # check dictionary funtionality
+        rdict = mgr.getReportByUuid()
+        self.assertEqual(uuid in rdict, True)
+        self.assertEqual(len(rdict[uuid]), 1)
+        self.assertEqual(entry in rdict[uuid][0], True)
+        self.assertEqual(uuid in rdict[uuid][0], True)
+        self.assertEqual(task in rdict[uuid][0], True)
+
+        # test purge functionality
+        mgr = MSPileupReport(autoExpire=-1, autoCleanup=True)
+        mgr.addEntry(task, uuid, entry)
+        docs = mgr.getDocuments()
+        self.assertEqual(len(docs), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupTasks_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupTasks_t.py
@@ -1,0 +1,233 @@
+"""
+File       : MSPileupTasks_t.py
+Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
+Description: Unit tests for MicorService/MSPileup/MSPileupTasks.py module
+"""
+
+# system modules
+import os
+import logging
+import unittest
+
+# rucio modules
+from rucio.client import Client
+
+# WMCore modules
+from WMQuality.Emulators.RucioClient.MockRucioApi import MockRucioApi
+from WMQuality.Emulators.EmulatedUnitTestCase import EmulatedUnitTestCase
+from WMCore.MicroService.MSPileup.MSPileupTasks import MSPileupTasks
+from WMCore.MicroService.MSPileup.MSPileupData import MSPileupData
+from WMCore.MicroService.Tools.Common import getMSLogger
+from WMCore.Services.Rucio.Rucio import Rucio
+
+
+class TestRucioClient(Client):
+    """Fake implementation for Rucio client"""
+    def __init__(self, account='test', logger=None, state='OK'):
+        self.account = 'test'
+        if logger:
+            self.logger = logger
+        else:
+            self.logger = getMSLogger(False)
+        self.state = state
+        self.doc = {'id': '123', 'rse_expression': 'T2_XX_CERN', 'state': self.state}
+
+    def list_replication_rules(self, kwargs):
+        """Immitate list_replication_rules Rucio client API"""
+        # we will mock rucio doc based on provided state
+        # the states are: OK, REPLICATING, STUCK, SUSPENDED, WAITING_APPROVAL, INJECT
+        doc = dict(self.doc)
+        if self.state != 'OK':
+            doc['locks_ok_cnt'] = 2
+            doc['locks_replicating_cnt'] = 2
+            doc['locks_stuck_cnt'] = 2
+        for key, val in kwargs.items():
+            doc[key] = val
+        docs = [doc]
+        self.logger.info("### TestRucioClient docs %s", docs)
+        if 'Exception' in self.state:
+            raise Exception(self.state)
+        return docs
+
+    def delete_replication_rule(self, rid):
+        """Immidate delete replication_rule Rucio client API"""
+        msg = f"delete rule ID {rid}"
+        self.logger.info(msg)
+
+    def add_replication_rule(self, dids, copies, rses, **kwargs):
+        """Immitate add replication rule Rucio client API"""
+        msg = f"add replication rule for {dids}, copies {copies} rses {rses}"
+        self.logger.info(msg)
+
+    def list_rses(self, rseExpression):
+        """Immitate get list_rses Rucio client API"""
+        for rse in ['rse1', 'rse2', 'T2_XX_CERN']:
+            yield {'rse': rse}
+
+    def get_rse_usage(self, rse):
+        """Immitate get rse usage Rucio client API"""
+        # it is a generator which provides information about given RSE
+        doc = {'id': '123', 'source': 'unavailable',
+               'used': 440245583794751,
+               'free': None,
+               'total': 440245583794751, 'files': 138519,
+               'rse': rse}
+        yield doc
+
+
+class MSPileupTasksTest(EmulatedUnitTestCase):
+    """Unit test for MSPileupTasks module"""
+
+    def setUp(self):
+        """
+        setup Unit tests
+        """
+        # we will define log stream to capture everything that goes to the log stream
+        self.logger = logging.getLogger()
+
+        # setup rucio client
+        self.rucioAccount = 'ms-pileup'
+        self.hostUrl = 'http://cms-rucio.cern.ch'
+        self.authUrl = 'https://cms-rucio-auth.cern.ch'
+        creds = {"client_cert": os.getenv("X509_USER_CERT", "Unknown"),
+                 "client_key": os.getenv("X509_USER_KEY", "Unknown")}
+        configDict = {'rucio_host': self.hostUrl, 'auth_host': self.authUrl,
+                      'creds': creds, 'auth_type': 'x509'}
+
+        # setup rucio wrapper
+        testRucioClient = TestRucioClient(logger=self.logger, state='OK')
+        self.rucioClient = Rucio(self.rucioAccount, configDict=configDict, client=testRucioClient)
+
+        expectedRSEs = ['rse1', 'rse2']
+
+        # setup pileup data manager
+        msConfig = {'reqmgr2Url': 'http://localhost',
+                    'validRSEs': expectedRSEs,
+                    'rucioAccount': 'wmcore_mspileup',
+                    'rucioUrl': 'http://cms-rucio-int.cern.ch',
+                    'rucioAuthUrl': 'https://cms-rucio-auth-int.cern.ch',
+                    'mongoDB': 'msPileupDB',
+                    'mongoDBCollection': 'msPileupDBCollection',
+                    'mongoDBServer': 'mongodb://localhost',
+                    'mongoDBReplicaSet': '',
+                    'mongoDBUser': None,
+                    'mongoDBPassword': None,
+                    'mockMongoDB': True}
+        self.mgr = MSPileupData(msConfig, skipRucio=True)
+
+        # setup our pileup data
+        self.pname = '/primary/processed/PREMIX'
+        pname = self.pname
+        fullReplicas = 3
+        campaigns = ['c1', 'c2']
+        data = {
+            'pileupName': pname,
+            'pileupType': 'classic',
+            'expectedRSEs': expectedRSEs,
+            'currentRSEs': expectedRSEs,
+            'fullReplicas': fullReplicas,
+            'campaigns': campaigns,
+            'containerFraction': 0.0,
+            'replicationGrouping': "ALL",
+            'active': True,
+            'pileupSize': 0,
+            'ruleIds': ['rse1']}
+        self.data = data
+
+        self.mgr.createPileup(data)
+
+        # add more docs similar in nature but with different size
+        data['pileupName'] = pname.replace('processed', 'processed-2')
+        self.mgr.createPileup(data)
+        data['pileupName'] = pname.replace('processed', 'processed-3')
+        self.mgr.createPileup(data)
+
+    def testMSPileupTasks(self):
+        """
+        Unit test for MSPileupTasks
+        """
+        self.logger.info("---------- CHECK for state=OK -----------")
+
+        obj = MSPileupTasks(self.mgr, self.logger, self.rucioAccount, self.rucioClient)
+        obj.monitoringTask()
+
+        # we added three pileup documents and should have update at least one of them
+        # in our report, so we check for update pileup message in report
+        report = obj.getReport()
+        found = False
+        for doc in report.getDocuments():
+            if 'update pileup' in doc['entry']:
+                found = True
+        self.assertEqual(found, True)
+
+        # at this step the T2_XX_CERN should be added to currentRSEs as it is provided
+        # by TestRucioClient class via list_replication_rules
+        spec = {'pileupName': self.pname}
+        results = self.mgr.getPileup(spec)
+        self.assertEqual(len(results), 1)
+        doc = results[0]
+        self.assertEqual('T2_XX_CERN' in doc['currentRSEs'], True)
+        obj.activeTask()
+        obj.inactiveTask()
+
+        # get report documents and log them accordingly
+        report = obj.getReport()
+        for uuid, entries in report.getReportByUuid().items():
+            msg = f"-------- task {uuid} --------"
+            self.logger.info(msg)
+            for item in entries:
+                self.logger.info(item)
+
+        # now we can test non OK state in Rucio
+        self.logger.info("---------- CHECK for state=STUCK -----------")
+        self.rucioClient = TestRucioClient(logger=self.logger, state='STUCK')
+        obj = MSPileupTasks(self.mgr, self.logger, self.rucioAccount, self.rucioClient)
+        obj.monitoringTask()
+        # at this step the T2_XX_CERN should NOT be added to currentRSEs
+        spec = {'pileupName': self.pname}
+        results = self.mgr.getPileup(spec)
+        self.assertEqual(len(results), 1)
+        doc = results[0]
+        self.assertEqual('T2_XX_CERN' in doc['currentRSEs'], False)
+        obj.activeTask()
+        obj.inactiveTask()
+
+        # now we can test how our code will behave with rucio exceptions
+        self.logger.info("---------- CHECK for state=CustomException -----------")
+
+        # we use CustomException for state to check how our code will
+        # handle Rucio API exceptions
+        self.rucioClient = TestRucioClient(logger=self.logger, state='CustomException')
+        obj = MSPileupTasks(self.mgr, self.logger, self.rucioAccount, self.rucioClient)
+        obj.monitoringTask()
+
+    def testMSPileupTasksWithMockApi(self):
+        """
+        Unit test for MSPileupTasks with RucioMockApi
+        """
+        # we may take some mock data from
+        # https://github.com/dmwm/WMCore/blob/master/test/data/Mock/RucioMockData.json
+        # e.g. /MinimumBias/ComissioningHI-v1/RAW' dataset
+        pname = '/MinimumBias/ComissioningHI-v1/RAW'
+        data = dict(self.data)
+        data['pileupName'] = pname
+        self.mgr.createPileup(data)
+
+        # now create mock rucio client
+        rucioClient = MockRucioApi(self.rucioAccount, hostUrl=self.hostUrl, authUrl=self.authUrl)
+        obj = MSPileupTasks(self.mgr, self.logger, self.rucioAccount, rucioClient)
+        obj.monitoringTask()
+        obj.activeTask()
+        obj.inactiveTask()
+
+        # we added new pileup document and should have update pileup message in report
+        report = obj.getReport()
+        found = False
+        for doc in report.getDocuments():
+            if 'update pileup' in doc['entry']:
+                found = True
+        self.assertEqual(found, True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileup_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileup_t.py
@@ -35,7 +35,6 @@ class MSPileupTest(unittest.TestCase):
                     'mockMongoDB': True}
         self.mgr = MSPileup(msConfig)
 
-
         self.pname = '/lksjdflksdjf/kljsdklfjsldfj/PREMIX'
         expectedRSEs = self.validRSEs
         fullReplicas = 0
@@ -51,7 +50,7 @@ class MSPileupTest(unittest.TestCase):
             'replicationGrouping': "ALL",
             'active': True,
             'pileupSize': 0,
-            'ruleList': []}
+            'ruleIds': []}
 
         obj = MSPileupObj(data, validRSEs=self.validRSEs)
         for key in ['insertTime', 'lastUpdateTime', 'activatedOn', 'deactivatedOn']:


### PR DESCRIPTION
Fixes #11426 

#### Status
In development

#### Description
First implementation of MSPileup data placement logic via MSPileupTasks class. It is based on python `asyncio` module used for concurrent execution of individual tasks. The logic implemented in this class follows this [wiki](https://github.com/dmwm/WMCore/wiki/ReqMgr2-MicroService-Pileup)

This PR contains the following changes:
- `MSPilupeTaskManager.py` module contains `MSPileupTaskManager` class which can be used in MSPileup service
- `MSPileupTasks.py` module which contains business logic of individual MSPileup tasks, e.g. monitoring, inactive, active tasks. Each task is implemented as `asyncio` task and within each task all docs are updated concurrently.
- `MSPileupReport.py` module which implements structure of report documents for MSPileup tasks. These documents are created and updated each time individual task make a change to MSPileup document, or place/delete rucio rules/data.
 - Changes to Rucio module (to ass external optional client, useful for unit tests)
 - update of mock-up data

##### Technical details, MSPileupTaskManager and MSPIleupTasks
The data placement logic in MSPileupTaskManager` has the following logic
```
 # initializeMSpileupData manager
 self.mgr = MSPileupData(msConfig)

 # create MSPileupTasks using MSPileup data manager
 obj = MSPileupTasks(self.mgr, self.logger)

 # update pileup size of all MSPileup documents
 ...

 # fetches RSEQuotas info
 nodeUsage = ...

 # now we can execute specific tasks in order, please note due to asyncio module
 # the individual tasks will be executed in parallel within each tasks
 obj.monitoringTask()
 obj.activeTask(nodeUsage, marginSpace)
 obj.inactiveTask()
```

##### MSPileup reports
There is a new module `MSPileupReport` which is updated when every individual task is updating the documents. It holds individual records where each record has the following schema:
```
        report = {'gmtime': gmtime, 'uuid': uuid,
                  'timestamp': encodeTimestamp(gmtime),
                  'entry': entry, 'task': task}
```
The gmtime is GMT time in seconds, the timestamp is human readable timestamp, the task is corresponding task name, e.g. monitoring, inactive, active, and uuid is unique ID of the task. The class provides several methods to fetch reports as list of report dicts, or one dict with uuid's as keys and can be used to organize report view based on different sort procedure. For example, here is a code snapshot how to use report records and organize its output by UUID
```
        # get report documents and log them accordingly
        report = obj.getReport()
        for uuid, entries in report.getDictionary().items():
            self.logger.info(f"-------- task {uuid} --------")
            for item in entries:
                self.logger.info(item)
```
And, here is how individual report for specific UUID will looks like in a log output:
```
2023-02-22 13:44:27,411:INFO:MSPileupTasks_t: -------- task 80c4ca87-da2f-4833-b109-2aa2c2468a34 --------
2023-02-22 13:44:27,411:INFO:MSPileupTasks_t: 2023-02-22T23:44:27Z inactive task 80c4ca87-da2f-4833-b109-2aa2c2468a34 starts
2023-02-22 13:44:27,412:INFO:MSPileupTasks_t: 2023-02-22T23:44:27Z inactive task 80c4ca87-da2f-4833-b109-2aa2c2468a34 remove rse rse1
2023-02-22 13:44:27,412:INFO:MSPileupTasks_t: 2023-02-22T23:44:27Z inactive task 80c4ca87-da2f-4833-b109-2aa2c2468a34 remove rse rse2
2023-02-22 13:44:27,412:INFO:MSPileupTasks_t: 2023-02-22T23:44:27Z inactive task 80c4ca87-da2f-4833-b109-2aa2c2468a34 remove rse NewRSE
2023-02-22 13:44:27,412:INFO:MSPileupTasks_t: 2023-02-22T23:44:27Z inactive task 80c4ca87-da2f-4833-b109-2aa2c2468a34 update pileup /primary/processed/PREMIX
2023-02-22 13:44:27,412:INFO:MSPileupTasks_t: 2023-02-22T23:44:27Z inactive task 80c4ca87-da2f-4833-b109-2aa2c2468a34 ends, elapsed time 0.00 (sec)
```
The report includes timestamp of when report record was create, the task name, task UUID and action message which was recorded.

This PR also provides corresponding unit tests which can demonstrate the logic and usage of asyncio module.

Please note, this PR also changes `rulesList`, `ruleList` to be `ruleIds` in MSPIleup object (this includes changes to `MSPilupObj.py` and all relevant places, including unit tests).

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
#11425 , #11424 

#### External dependencies / deployment changes
