### PR TITLE
Fix manage path in the restartComponent script (add amtool)

### DIFF
--- a/deploy/deploy-wmagent.sh
+++ b/deploy/deploy-wmagent.sh
@@ -427,7 +427,7 @@ else
   echo "55 */6 * * * /data/admin/wmagent/renew_proxy.sh"
   echo "58 */12 * * * python /data/admin/wmagent/checkProxy.py --proxy /data/certs/myproxy.pem --time 150 --send-mail True --mail alan.malta@cern.ch"
   echo "#workaround for the ErrorHandler silence issue"
-  echo "*/15 * * * *  /data/admin/wmagent/restartComponent.sh > /dev/null"
+  echo "*/15 * * * *  /data/admin/wmagent/restartComponent.sh ErrorHandler JobSubmitter AgentStatusWatcher > /dev/null"
   ) | crontab -
 fi
 echo "Done!" && echo

--- a/deploy/deploy-wmagent.sh
+++ b/deploy/deploy-wmagent.sh
@@ -181,6 +181,25 @@ check_oracle()
   rm -rf $tmpdir
 }
 
+setup_amtool()
+{
+  local pkg_version=0.25.0
+  local pkg_name=alertmanager-${pkg_version}.linux-amd64
+  echo -n "Setting up amtool prometheus alert manager ..."
+  cd $ADMIN_DIR
+  curl -ksLO https://github.com/prometheus/alertmanager/releases/download/v${pkg_version}/${pkg_name}.tar.gz
+  if [ ! -f ${pkg_name}.tar.gz ]; then
+    echo -e "  FAILED to download Prometheus alertmanager."
+    exit 10
+  fi
+  tar xfz ${pkg_name}.tar.gz ${pkg_name}/amtool
+  mv ${pkg_name}/amtool .
+  ./amtool --version
+  rm -f ${pkg_name}.tar.gz
+  cd -
+  echo -e "  OK!\n"
+}
+
 for arg; do
   case $arg in
     -h) help ;;
@@ -408,12 +427,13 @@ echo "Done!" && echo
 # set scripts and specific cronjobs
 ###
 echo "*** Downloading utilitarian scripts ***"
-cd /data/admin/wmagent
+cd $ADMIN_DIR
 wget -nv https://raw.githubusercontent.com/dmwm/WMCore/master/deploy/checkProxy.py -O checkProxy.py
 wget -nv https://raw.githubusercontent.com/dmwm/WMCore/master/deploy/restartComponent.sh -O restartComponent.sh
 wget -nv https://raw.githubusercontent.com/dmwm/WMCore/master/deploy/renew_proxy.sh -O renew_proxy.sh
 chmod +x renew_proxy.sh restartComponent.sh
-sed -i "s+CREDNAME+$MYPROXY_CREDNAME+" /data/admin/wmagent/renew_proxy.sh
+sed -i "s+CREDNAME+$MYPROXY_CREDNAME+" $ADMIN_DIR/renew_proxy.sh
+setup_amtool
 echo "Done!" && echo
 
 ### Populating cronjob with utilitarian scripts

--- a/deploy/restartComponent.sh
+++ b/deploy/restartComponent.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+## Pass the component names as command line arguments, e.g.:
+## ./restartComponent.sh ErrorHandler JobSubmitter AgentStatusWatcher
 
 HOST=`hostname`
 DATENOW=`date +%s`
@@ -11,9 +13,10 @@ if [ ! -d "$install" ]; then
   install="/data/srv/wmagent/current/install/wmagentpy3"
 fi
 
-COMPONENTS="ErrorHandler JobSubmitter AgentStatusWatcher"
-for comp in $COMPONENTS; do
+echo "List of components to be monitored: $@"
+for comp in $@; do
   COMPLOG=$install/$comp/ComponentLog
+  echo "Checking logs from: $COMPLOG"
   LASTCHANGE=`stat -c %Y $COMPLOG`
   INTERVAL=`expr $DATENOW - $LASTCHANGE`
   if (("$INTERVAL" >= 1800)); then

--- a/deploy/restartComponent.sh
+++ b/deploy/restartComponent.sh
@@ -3,16 +3,17 @@
 HOST=`hostname`
 DATENOW=`date +%s`
 
+# Get a few environment variables in, like $install and $manage
+source /data/admin/wmagent/env.sh
+
 # Figure whether it's a python2 or python3 agent
-if [ -d "/data/srv/wmagent/current/install/wmagent" ]; then
-  WMA_PATH="/data/srv/wmagent/current/install/wmagent"
-else
-  WMA_PATH="/data/srv/wmagent/current/install/wmagentpy3"
+if [ ! -d "$install" ]; then
+  install="/data/srv/wmagent/current/install/wmagentpy3"
 fi
 
 COMPONENTS="ErrorHandler JobSubmitter AgentStatusWatcher"
 for comp in $COMPONENTS; do
-  COMPLOG=$WMA_PATH/$comp/ComponentLog
+  COMPLOG=$install/$comp/ComponentLog
   LASTCHANGE=`stat -c %Y $COMPLOG`
   INTERVAL=`expr $DATENOW - $LASTCHANGE`
   if (("$INTERVAL" >= 1800)); then
@@ -22,9 +23,8 @@ for comp in $COMPONENTS; do
       exit 1
     fi
 
-    . /data/admin/wmagent/env.sh
     TAIL_LOG=`tail -n100 $COMPLOG`
-    $WMA_PATH/manage execute-agent wmcoreD --restart --components=$comp
+    $manage execute-agent wmcoreD --restart --components=$comp
     echo -e "ComponentLog quiet for $INTERVAL secs\n\nTail of the log is:\n$TAIL_LOG" |
       mail -s "$HOST : $comp restarted" alan.malta@cern.ch,todor.trendafilov.ivanov@cern.ch
   fi

--- a/deploy/restartComponent.sh
+++ b/deploy/restartComponent.sh
@@ -4,10 +4,16 @@
 
 HOST=`hostname`
 DATENOW=`date +%s`
+AMTOOL=/data/admin/wmagent/amtool
+AMURL=http://cms-monitoring.cern.ch:30093
+EXPIRE=`date -d '+5 min' --rfc-3339=ns | tr ' ' 'T'`
+if [ ! -f "$AMTOOL" ]; then
+  echo "Could not find amtool at path: ${$AMTOOL}"
+  exit 1
+fi
 
 # Get a few environment variables in, like $install and $manage
 source /data/admin/wmagent/env.sh
-
 # Figure whether it's a python2 or python3 agent
 if [ ! -d "$install" ]; then
   install="/data/srv/wmagent/current/install/wmagentpy3"
@@ -23,13 +29,21 @@ for comp in $@; do
     OTHERS=`ps aux | grep wmcore | grep -v grep`
     if [[ -z "$OTHERS" ]]; then
       echo "Since the agent is not running, don't do anything ..."
-      exit 1
+      exit 2
     fi
 
-    TAIL_LOG=`tail -n100 $COMPLOG`
+    TAIL_LOG=`tail -n 50 $COMPLOG`
+    echo -e "ComponentLog for $comp quiet for $INTERVAL secs\n"
     $manage execute-agent wmcoreD --restart --components=$comp
-    echo -e "ComponentLog quiet for $INTERVAL secs\n\nTail of the log is:\n$TAIL_LOG" |
-      mail -s "$HOST : $comp restarted" alan.malta@cern.ch,todor.trendafilov.ivanov@cern.ch
+    ALERT_NAME="WMAgent_${HOST}_${comp}"
+    ${AMTOOL} alert add wmagent_component_alert \
+      alertname=${ALERT_NAME} severity=medium tag=wmagent alert=amtool \
+      --annotation=summary="Component ${comp} was quiet for ${INTERVAL} seconds. Restarted." \
+      --annotation=date="${DATENOW}" \
+      --annotation=hostname="${HOST}" \
+      --annotation=log="${TAIL_LOG}" \
+      --end="${EXPIRE}" \
+      --alertmanager.url="${AMURL}"
   fi
 done
 


### PR DESCRIPTION
Fixes #11492 

#### Status
ready

#### Description
Use whatever variables we have defined in the env.sh script.
Note that `install` actually points to the `wmagent` directory, which does not exist neither in the CERN nor in the FNAL agents. Maybe something to be properly corrected in the future...

The addition of `amtool` Prometheus AlertManager tool will route requests to the `alerts-wmagent` CMSMonitoring Slack channel. Note however that it only works within the CERN network and we need to find a different solution.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
