### PR TITLE
Add uploaderName as DBS3Upload config parameter

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -161,6 +161,7 @@ config.DBS3Upload.primaryDatasetType = "mc"
 config.DBS3Upload.dumpBlockJsonFor = ""
 # set DbsApi requests to use gzip enconding, thus sending compressed data
 config.DBS3Upload.gzipEncoding = True
+config.DBS3Upload.uploaderName = "WMAgent"
 
 config.section_("DBSInterface")
 config.DBSInterface.DBSUrl = globalDBSUrl

--- a/src/python/WMComponent/DBS3Buffer/DBSBufferBlock.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSBufferBlock.py
@@ -31,7 +31,7 @@ class DBSBufferBlock(object):
 
     """
 
-    def __init__(self, name, location, datasetpath):
+    def __init__(self, name, location, datasetpath, uploader="WMAgent"):
         """
         Just the necessary objects
 
@@ -41,33 +41,34 @@ class DBSBufferBlock(object):
         """
 
 
-        self.data      = {'dataset_conf_list':    [],   # List of dataset configurations
-                          'file_conf_list':       [],   # List of files, the configuration for each
-                          'files':                [],   # List of file objects
-                          'block':                {},   # Dict of block info
-                          'processing_era':       {},   # Dict of processing era info
-                          'acquisition_era':      {},   # Dict of acquisition era information
-                          'primds':               {},   # Dict of primary dataset info
-                          'dataset':              {},   # Dict of processed dataset info
-                          'file_parent_list':     [],   # List of file parents
-                          'dataset_parent_list':  [],   # List of parent datasets (DBS requires this as list although it only allows one parent)
-                          'close_settings':       {}}   # Dict of info about block close settings
+        self.data = {'dataset_conf_list':[],   # List of dataset configurations
+                     'file_conf_list':[],      # List of files, the configuration for each
+                     'files':[],               # List of file objects
+                      'block':{},              # Dict of block info
+                      'processing_era':{},     # Dict of processing era info
+                      'acquisition_era':{},    # Dict of acquisition era information
+                      'primds':{},             # Dict of primary dataset info
+                      'dataset':{},            # Dict of processed dataset info
+                      'file_parent_list':[],   # List of file parents
+                      'dataset_parent_list':[],# List of parent datasets (DBS requires this as list although it only allows one parent)
+                      'close_settings':{}}     # Dict of info about block close settings
 
-        self.files        = []
-        self.encoder      = JSONRequests()
-        self.status       = 'Open'
-        self.inBuff       = False
-        self.startTime    = time.time()
-        self.name         = name
-        self.location     = location
+        self.files = []
+        self.encoder = JSONRequests()
+        self.status = 'Open'
+        self.inBuff = False
+        self.startTime = time.time()
+        self.name = name
+        self.location = location
         self.datasetpath  = datasetpath
-        self.workflows    = set()
+        self.workflows = set()
+        self.uploader = uploader
 
-        self.data['block']['block_name']       = name
+        self.data['block']['block_name'] = name
         self.data['block']['origin_site_name'] = location
         self.data['block']['open_for_writing'] = 1
 
-        self.data['block']['create_by'] = "WMAgent"
+        self.data['block']['create_by'] = self.uploader
         self.data['block']['creation_date'] = int(time.time())
         self.data['block']['block_size'] = 0
         self.data['block']['file_count'] = 0
@@ -125,7 +126,7 @@ class DBSBufferBlock(object):
         fileDict['logical_file_name']      = dbsFile['lfn']
         fileDict['file_size']              = dbsFile['size']
         fileDict['event_count']            = dbsFile['events']
-        fileDict['last_modified_by'] = "WMAgent"
+        fileDict['last_modified_by'] = self.uploader
         fileDict['last_modification_date'] = int(time.time())
         fileDict['auto_cross_section'] = 0.0
 
@@ -232,7 +233,7 @@ class DBSBufferBlock(object):
                     % (procVer, type(procVer))
             raise TypeError(msg) from None
         self.data["processing_era"]["processing_version"] = pver
-        self.data["processing_era"]["create_by"] = "WMAgent"
+        self.data["processing_era"]["create_by"] = self.uploader
         self.data["processing_era"]["description"] = ""
         return
 
@@ -292,7 +293,7 @@ class DBSBufferBlock(object):
         # Do the primary dataset
         self.data['primds']['primary_ds_name'] = primary
         self.data['primds']['primary_ds_type'] = primaryType
-        self.data['primds']['create_by'] = "WMAgent"
+        self.data['primds']['create_by'] = self.uploader
         self.data['primds']['creation_date'] = int(time.time())
 
         # Do the processed
@@ -303,8 +304,8 @@ class DBSBufferBlock(object):
         self.data['dataset']['dataset']             = datasetName
         self.data['dataset']['prep_id'] = prep_id
         # Add misc meta data.
-        self.data['dataset']['create_by'] = "WMAgent"
-        self.data['dataset']['last_modified_by'] = "WMAgent"
+        self.data['dataset']['create_by'] = self.uploader
+        self.data['dataset']['last_modified_by'] = self.uploader
         self.data['dataset']['creation_date'] = int(time.time())
         self.data['dataset']['last_modification_date'] = int(time.time())
         return

--- a/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
+++ b/src/python/WMComponent/DBS3Buffer/DBSUploadPoller.py
@@ -189,6 +189,10 @@ class DBSUploadPoller(BaseWorkerThread):
         self.physicsGroup = getattr(self.config.DBS3Upload, "physicsGroup", "NoGroup")
         self.datasetType = getattr(self.config.DBS3Upload, "datasetType", "PRODUCTION")
         self.primaryDatasetType = getattr(self.config.DBS3Upload, "primaryDatasetType", "mc")
+        self.uploaderName = getattr(self.config.DBS3Upload, "uploaderName", "WMAgent")
+        if self.uploaderName not in ("WMAgent", "T0Prod", "T0Replay"):
+            raise DBSUploadException(f"Invalid value for attribute uploaderName: {self.uploaderName}")
+
         self.blockCount = 0
         self.gzipEncoding = getattr(self.config.DBS3Upload, 'gzipEncoding', False)
         self.dbsApi = DbsApi(url=self.dbsUrl)
@@ -382,7 +386,8 @@ class DBSUploadPoller(BaseWorkerThread):
         for blockInfo in loadedBlocks:
             block = DBSBufferBlock(name=blockInfo['block_name'],
                                    location=blockInfo['origin_site_name'],
-                                   datasetpath=blockInfo['datasetpath'])
+                                   datasetpath=blockInfo['datasetpath'],
+                                   uploader=self.uploaderName)
 
             parent = self.datasetParentageCache.get(blockInfo['datasetpath'])
             if parent:
@@ -552,7 +557,8 @@ class DBSUploadPoller(BaseWorkerThread):
         blockname = "%s#%s" % (datasetpath, makeUUID())
         newBlock = DBSBufferBlock(name=blockname,
                                   location=location,
-                                  datasetpath=datasetpath)
+                                  datasetpath=datasetpath,
+                                  uploader=self.uploaderName)
         # Now we load the dataset information
         self.setDatasetInfo(newBlock)
 

--- a/test/python/WMComponent_t/DBS3Buffer_t/DBSBufferFile_t.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/DBSBufferFile_t.py
@@ -582,7 +582,8 @@ class DBSBufferFileTest(unittest.TestCase):
 
         newBlock = DBSBufferBlock(name="someblockname",
                                   location="se1.cern.ch",
-                                  datasetpath=None)
+                                  datasetpath=None,
+                                  uploader="WMAgent")
         newBlock.setDataset(dataset, 'data', 'VALID')
 
         createAction.execute(blocks=[newBlock])

--- a/test/python/WMComponent_t/DBS3Buffer_t/DBSUpload_t.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/DBSUpload_t.py
@@ -120,6 +120,7 @@ class DBSUploadTest(unittest.TestCase):
         config.DBS3Upload.nProcesses = 1
         config.DBS3Upload.dbsWaitTime = 0.1
         config.DBS3Upload.datasetType = "VALID"
+        config.DBS3Upload.uploaderName = "WMAgent"
 
         # added to skip the StepChain parentage setting test
         config.component_("Tier0Feeder")
@@ -414,7 +415,8 @@ class DBSUploadTest(unittest.TestCase):
             blockName = parentFiles[0]["datasetPath"] + "#" + makeUUID()
             dbsBlock = DBSBufferBlock(blockName,
                                       location="malpaquet",
-                                      datasetpath=None)
+                                      datasetpath=None,
+                                      uploader=config.uploaderName)
             dbsBlock.status = "Open"
             dbsBlock.setDataset(parentFiles[0]["datasetPath"], 'data', 'VALID')
             dbsUtil.createBlocks([dbsBlock])
@@ -431,7 +433,8 @@ class DBSUploadTest(unittest.TestCase):
         blockName = childFiles[0]["datasetPath"] + "#" + makeUUID()
         dbsBlock = DBSBufferBlock(blockName,
                                   location="malpaquet",
-                                  datasetpath=None)
+                                  datasetpath=None,
+                                  uploader=config.uploaderName)
         dbsBlock.status = "InDBS"
         dbsBlock.setDataset(childFiles[0]["datasetPath"], 'data', 'VALID')
         dbsUtil.createBlocks([dbsBlock])

--- a/test/python/WMComponent_t/RucioInjector_t/RucioInjectorPoller_t.py
+++ b/test/python/WMComponent_t/RucioInjector_t/RucioInjectorPoller_t.py
@@ -181,13 +181,15 @@ class RucioInjectorPollerTest(EmulatedUnitTestCase):
         # create and insert blocks into dbsbuffer table
         newBlockA = DBSBufferBlock(name=self.blockAName,
                                    location="T2_CH_CERN",
-                                   datasetpath=None)
+                                   datasetpath=None,
+                                   uploader="WMAgent")
         newBlockA.setDataset(self.testDatasetA, 'data', 'VALID')
         newBlockA.status = 'Closed'
 
         newBlockB = DBSBufferBlock(name=self.blockBName,
                                    location="T1_US_FNAL_Disk",
-                                   datasetpath=None)
+                                   datasetpath=None,
+                                   uploader="WMAgent")
         newBlockB.setDataset(self.testDatasetB, 'data', 'VALID')
         newBlockB.status = 'Closed'
 


### PR DESCRIPTION
Fixes #11494 

#### Status
ready

#### Description
Add uploaderName as DBS3Upload config parameter. This is used in DBSBufferBlock to fill the `create_by` and `last_modified_by` attributes in DBS files and datasets

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs

#### External dependencies / deployment changes
