### PR TITLE
Add new CMSCouch exception for Request Entity Too Large

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -99,6 +99,12 @@ config.JobStateMachine.couchurl = couchURL
 config.JobStateMachine.couchDBName = jobDumpDBName
 config.JobStateMachine.jobSummaryDBName = jobSummaryDBName
 config.JobStateMachine.summaryStatsDBName = summaryStatsDBName
+# Amount of documents allowed in the ChangeState module for bulk commits
+config.JobStateMachine.maxBulkCommitDocs = 250
+# total allowed serialized size for the FJR document that is uploaded to wmagent_jobdump/fwjrs
+# NOTE: this needs to be in sync with CouchDB couchdb.max_document_size parameter
+# see: https://docs.couchdb.org/en/latest/config/couchdb.html#couchdb/max_document_size
+config.JobStateMachine.fwjrLimitSize = 8 * 1000**2  # default: 8 million bytes (not 8MB!!!)
 
 config.section_("ACDC")
 config.ACDC.couchurl = "https://cmsweb.cern.ch/couchdb"


### PR DESCRIPTION
Fixes #11342 

#### Status
ready

#### Description
The current changes will ensure that the whole document is no longer dumped in the component log when the error is reported.
In addition to that, we JSON serialize it and calculate the total object size, which is then added to the error message, in addition to the result attribute, e.g.: `result=b'{"error":"document_too_large","reason":"4799572-0"}\n'`

Lastly, whenever it happens, we look into the database queue and reset the `fwjr` field of each of those jobs that exceed the size limit. Right now the limit is ~8MB, which matches the limit of CouchDB itself. It might be a good idea to actually create a component configuration parameter for that.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
Reference: https://docs.couchdb.org/en/3.2.2-docs/api/basics.html?highlight=Request%20Entity%20Too%20Large#http-status-codes
