### PR TITLE
Add reqmgr2ms-pileup-tasks build

### DIFF
--- a/.github/workflows/pypi_build_and_images.yaml
+++ b/.github/workflows/pypi_build_and_images.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         target: [wmagent, wmagent-devtools, wmcore, reqmon, reqmgr2, global-workqueue, acdcserver, reqmgr2ms-unmerged,
-                 reqmgr2ms-output, reqmgr2ms-pileup, reqmgr2ms-rulecleaner, reqmgr2ms-transferor, reqmgr2ms-monitor]
+                 reqmgr2ms-output, reqmgr2ms-pileup, reqmgr2ms-pileup-tasks, reqmgr2ms-rulecleaner, reqmgr2ms-transferor, reqmgr2ms-monitor]
     uses: ./.github/workflows/pypi_build_publish_template.yaml
     with:
       wmcore_component: ${{ matrix.target }}
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         target: [wmagent, reqmon, t0_reqmon, reqmgr2, reqmgr2ms-unmerged, global-workqueue,
-                 reqmgr2ms-output, reqmgr2ms-pileup, reqmgr2ms-rulecleaner, reqmgr2ms-transferor, reqmgr2ms-monitor]
+                 reqmgr2ms-output, reqmgr2ms-pileup, reqmgr2ms-pileup-tasks, reqmgr2ms-rulecleaner, reqmgr2ms-transferor, reqmgr2ms-monitor]
     uses: ./.github/workflows/docker_images_template.yaml
     with:
       wmcore_component: ${{ matrix.target }}


### PR DESCRIPTION
Fixes #11506 

#### Status
ready

#### Description
Add reqmgr2ms-pileup-tasks into CI/CD yaml

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs

#### External dependencies / deployment changes
