### PR TITLE
Integrate MSAuth into MSPileup

### DIFF
--- a/test/python/WMCore_t/MicroService_t/MSManager_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSManager_t.py
@@ -27,6 +27,7 @@ class MSManagerTest(unittest.TestCase):
         data.quotaUsage = 0.8
         data.quotaAccount = "DataOps"
         data.enableStatusTransition = True
+        data.authz_key = '123'
         data.rucioAccount = "wma_test"
         data.rucioUrl = "http://cms-rucio-int.cern.ch"
         data.rucioAuthUrl = "https://cms-rucio-auth-int.cern.ch"

--- a/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileup_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileup_t.py
@@ -22,6 +22,7 @@ class MSPileupTest(unittest.TestCase):
         cherrypy.request.user = "test"
         self.validRSEs = ['rse1', 'rse2']
         msConfig = {'reqmgr2Url': 'http://localhost',
+                    'authz_key': '123',
                     'rucioAccount': 'wmcore_mspileup',
                     'rucioUrl': 'http://cms-rucio-int.cern.ch',
                     'rucioAuthUrl': 'https://cms-rucio-auth-int.cern.ch',


### PR DESCRIPTION
Fixes #11465 

#### Status
ready

#### Description
Provide integration of MSAuth module into MSPileup

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
#11476 

#### External dependencies / deployment changes
- The changes to reqmgr2ms-pileup/config.py in test branch is provided over here: https://gitlab.cern.ch/cmsweb-k8s/services_config/-/blob/test/reqmgr2ms-pileup/config.py#L80-L94
- changes to preprod branch can be viewed in this PR: https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/193

Upon merging this PR we'll need to adjust accordingly MSPileup configuration file, e.g.
```
data.authz_key = '<hash>'  # or put file name here
data.authz_rules = \
    [{"role": "admin", "group": "reqmgr", "service": "ms-pileup",
      "action": "create", "method": ["POST"]},
     {"role": "production-operator", "group": "dataops", "service": "ms-pileup",
      "action": "create", "method": ["POST"]},
     {"role": "admin", "group": "reqmgr", "service": "ms-pileup",
      "action": "delete", "method": ["DELETE"]},
     {"role": "production-operator", "group": "dataops", "service": "ms-pileup",
      "action": "delete", "method": ["DELETE"]},
     {"role": "admin", "group": "reqmgr", "service": "ms-pileup",
      "action": "update", "method": ["PUT"]},
     {"role": "production-operator", "group": "dataops", "service": "ms-pileup",
      "action": "update", "method": ["PUT"]}]
```

#### Integration test
The integration tests are performed on test10 cluster with the following procedure:
- success auth response
```
# config changes, see group reqmgr (which I belong in CRIC)
data.authz_rules = \
    [{"role": "admin", "group": "reqmgr", "service": "ms-pileup",
      "action": "create", "method": ["POST"]},
      ...

# client
scurl -v -X POST -H "Content-type: application/json" -d '{"pileupName":"/Test/Test/PREMIX"}' https://cmsweb-test10.cern.ch:8443/ms-pileup/data/pileup

# server response correctly fails on data validation which means that request passed through authz layer
        <h2>400 Bad Request</h2>
        <p>MSPileupError: Failed to create MSPileupObj, 'pileupType', code: 3</p>
```

- failed auth response
```
# config changes, see group test (which does not exist in CRIC)
data.authz_rules = \
    [{"role": "admin", "group": "test", "service": "ms-pileup",
      "action": "create", "method": ["POST"]},
      ...

# client
scurl -v -X POST -H "Content-type: application/json" -d '{"pileupName":"/Test/Test/PREMIX"}' https://cmsweb-test10.cern.ch:8443/ms-pileup/data/pileup

# server correctly failed with authz
        <h2>403 Forbidden</h2>
        <p>You are not authorized to access this resource.</p>
```