### PR TITLE
Fetch valid RSEs and keep it up-to-date in MSPileup

### DIFF
--- a/src/python/WMCore/MicroService/MSPileup/MSPileupTasks.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupTasks.py
@@ -57,7 +57,7 @@ class MSPileupTasks():
             for doc in docs:
                 pileupSize = datasetSizes.get(doc['pileupName'], 0)
                 doc['pileupSize'] = pileupSize
-                self.mgr.updatePileup(doc)
+                self.mgr.updatePileup(doc, validate=False)
         except Exception as exp:
             msg = f"MSPileup pileup size task failed with error {exp}"
             self.logger.exception(msg)
@@ -222,7 +222,7 @@ def monitoringTask(doc, spec):
     # persist an up-to-date version of the pileup data structure in MongoDB
     if modify:
         logger.info(f"monitoring task {uuid}, update {pname}")
-        mgr.updatePileup(doc)
+        mgr.updatePileup(doc, validate=False)
         msg = f"update pileup {pname}"
         report.addEntry('monitoring', uuid, msg)
     else:
@@ -278,7 +278,7 @@ def inactiveTask(doc, spec):
     # persist an up-to-date version of the pileup data structure in MongoDB
     if modify:
         logger.info(f"inactive task {uuid}, update {pname}")
-        mgr.updatePileup(doc)
+        mgr.updatePileup(doc, validate=False)
         msg = f"update pileup {pname}"
         report.addEntry('inactive', uuid, msg)
 
@@ -387,7 +387,7 @@ def activeTask(doc, spec):
     # persist an up-to-date version of the pileup data structure in MongoDB
     if modify:
         logger.info(f"active task {uuid} update {pname}")
-        mgr.updatePileup(doc)
+        mgr.updatePileup(doc, validate=False)
         msg = f"update pileup {pname}"
         report.addEntry('active', uuid, msg)
     else:

--- a/src/python/WMCore/Services/Rucio/Rucio.py
+++ b/src/python/WMCore/Services/Rucio/Rucio.py
@@ -704,8 +704,9 @@ class Rucio(object):
             except InvalidRSEExpression as exc:
                 msg = "Provided RSE expression is considered invalid: {}. Error: {}".format(rseExpr, str(exc))
                 raise WMRucioException(msg)
-        # add this key/value pair to the cache
-        self.cachedRSEs.addItemToCache({rseExpr: matchingRSEs})
+        if useCache:
+            # add this key/value pair to the cache
+            self.cachedRSEs.addItemToCache({rseExpr: matchingRSEs})
         if returnTape:
             return matchingRSEs
         return dropTapeRSEs(matchingRSEs)

--- a/src/python/WMQuality/Emulators/EmulatedUnitTestCase.py
+++ b/src/python/WMQuality/Emulators/EmulatedUnitTestCase.py
@@ -45,7 +45,7 @@ class EmulatedUnitTestCase(unittest.TestCase):
 
         TODO: parameters to turn off emulators individually
         """
-
+        print(f"Running setUp with emulated services. ")
         if self.mockDBS:
             self.dbsPatchers = []
             patchDBSAt = ["dbs.apis.dbsClient.DbsApi",
@@ -60,6 +60,7 @@ class EmulatedUnitTestCase(unittest.TestCase):
             patchRucioAt = ['WMCore.WorkQueue.WorkQueue.Rucio',
                             'WMCore.WorkQueue.WorkQueueReqMgrInterface.Rucio',
                             'WMCore.WorkQueue.Policy.Start.StartPolicyInterface.Rucio',
+                            'WMCore.MicroService.MSCore.MSCore.Rucio',
                             'WMComponent.RucioInjector.RucioInjectorPoller.Rucio',
                             'WMCore.WMSpec.Steps.Fetchers.PileupFetcher.Rucio',
                             'WMCore_t.WMSpec_t.Steps_t.Fetchers_t.PileupFetcher_t.Rucio',

--- a/test/data/Mock/RucioMockData.json
+++ b/test/data/Mock/RucioMockData.json
@@ -1404,6 +1404,7 @@
   "account": "ms-pileup"
  }],
  "evaluateRSEExpression": ["T2_XX_CERN"],
+ "evaluateRSEExpression:[('useCache', True)]": ["rse1", "rse2"],
  "deleteRule": true,
  "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#00ad285a-0d7b-11e1-9b6c-003048caaace')]": false,
  "isContainer:[('didName', '/Cosmics/ComissioningHI-PromptReco-v1/RECO#14ad7dfe-0acf-11e1-8347-003048caaace')]": false,

--- a/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupData_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupData_t.py
@@ -101,8 +101,14 @@ class MSPileupTest(unittest.TestCase):
             'pileupSize': pileupSize,
             'ruleIds': ruleIds}
 
-        out = self.mgr.createPileup(pdict)
+        out = self.mgr.createPileup(pdict, self.validRSEs)
         self.assertEqual(len(out), 0)
+
+        # now fail the RSE validation
+        out = self.mgr.createPileup(pdict, ['rse2'])[0]
+        self.assertEqual(out['error'], "MSPileupError")
+        self.assertEqual(out['code'], 7)
+        self.assertEqual(out['message'], "schema error")
 
         spec = {'pileupName': pname}
         results = self.mgr.getPileup(spec)
@@ -111,7 +117,7 @@ class MSPileupTest(unittest.TestCase):
         self.assertDictEqual(pdict, doc)
 
         doc.update({'pileupSize': 2})
-        out = self.mgr.updatePileup(doc)
+        out = self.mgr.updatePileup(doc, self.validRSEs)
         self.assertEqual(len(out), 0)
         results = self.mgr.getPileup(spec)
         doc = results[0]

--- a/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupTasks_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupTasks_t.py
@@ -98,11 +98,10 @@ class MSPileupTasksTest(EmulatedUnitTestCase):
         testRucioClient = TestRucioClient(logger=self.logger, state='OK')
         self.rucioClient = Rucio(self.rucioAccount, configDict=configDict, client=testRucioClient)
 
-        expectedRSEs = ['rse1', 'rse2']
+        self.validRSEs = ['rse1', 'rse2']
 
         # setup pileup data manager
         msConfig = {'reqmgr2Url': 'http://localhost',
-                    'validRSEs': expectedRSEs,
                     'rucioAccount': 'wmcore_mspileup',
                     'rucioUrl': 'http://cms-rucio-int.cern.ch',
                     'rucioAuthUrl': 'https://cms-rucio-auth-int.cern.ch',
@@ -123,8 +122,8 @@ class MSPileupTasksTest(EmulatedUnitTestCase):
         data = {
             'pileupName': pname,
             'pileupType': 'classic',
-            'expectedRSEs': expectedRSEs,
-            'currentRSEs': expectedRSEs,
+            'expectedRSEs': self.validRSEs,
+            'currentRSEs': self.validRSEs,
             'fullReplicas': fullReplicas,
             'campaigns': campaigns,
             'containerFraction': 0.0,
@@ -134,13 +133,13 @@ class MSPileupTasksTest(EmulatedUnitTestCase):
             'ruleIds': ['rse1']}
         self.data = data
 
-        self.mgr.createPileup(data)
+        self.mgr.createPileup(data, self.validRSEs)
 
         # add more docs similar in nature but with different size
         data['pileupName'] = pname.replace('processed', 'processed-2')
-        self.mgr.createPileup(data)
+        self.mgr.createPileup(data, self.validRSEs)
         data['pileupName'] = pname.replace('processed', 'processed-3')
-        self.mgr.createPileup(data)
+        self.mgr.createPileup(data, self.validRSEs)
 
     def testMSPileupTasks(self):
         """
@@ -211,7 +210,7 @@ class MSPileupTasksTest(EmulatedUnitTestCase):
         pname = '/MinimumBias/ComissioningHI-v1/RAW'
         data = dict(self.data)
         data['pileupName'] = pname
-        self.mgr.createPileup(data)
+        self.mgr.createPileup(data, self.validRSEs)
 
         # now create mock rucio client
         rucioClient = MockRucioApi(self.rucioAccount, hostUrl=self.hostUrl, authUrl=self.authUrl)

--- a/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileup_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileup_t.py
@@ -11,14 +11,16 @@ import unittest
 # WMCore modules
 from WMCore.MicroService.MSPileup.MSPileup import MSPileup
 from WMCore.MicroService.MSPileup.DataStructs.MSPileupObj import MSPileupObj
+from WMQuality.Emulators.EmulatedUnitTestCase import EmulatedUnitTestCase
 
 
-class MSPileupTest(unittest.TestCase):
+class MSPileupTest(EmulatedUnitTestCase):
     "Unit test for MSPileup module"
     def setUp(self):
         """
         set up unit test generic objects
         """
+        super(MSPileupTest, self).setUp()
         cherrypy.request.user = "test"
         self.validRSEs = ['rse1', 'rse2']
         msConfig = {'reqmgr2Url': 'http://localhost',
@@ -36,12 +38,14 @@ class MSPileupTest(unittest.TestCase):
                     'mockMongoDB': True}
         self.mgr = MSPileup(msConfig)
 
-        self.pname = '/lksjdflksdjf/kljsdklfjsldfj/PREMIX'
+        pname = '/lksjdflksdjf/kljsdklfjsldfj/PREMIX'
+        self.spec = {'pileupName': pname}
+
         expectedRSEs = self.validRSEs
         fullReplicas = 0
         campaigns = ['c1', 'c2']
         data = {
-            'pileupName': self.pname,
+            'pileupName': pname,
             'pileupType': 'classic',
             'expectedRSEs': expectedRSEs,
             'currentRSEs': expectedRSEs,
@@ -61,39 +65,59 @@ class MSPileupTest(unittest.TestCase):
         self.assertEqual(obj.data['campaigns'], campaigns)
         self.doc = obj.getPileupData()
 
-    def testMSPileupHTTPApis(self):
-        "test MSPileup HTTP APIs"
+    def createDoc(self):
+        """Creates a pileup object in the database"""
+        return self.mgr.createPileup(self.doc)
 
-        # create doc
-        res = self.mgr.createPileup(self.doc)
-        self.assertEqual(len(res), 0)
+    def testMSPileupStatus(self):
+        """Test MSPileup status API"""
+        res = self.mgr.status()
+        self.assertEqual(res['error'], '')
+        self.assertEqual(res['thread_id'], 'MainThread')
+
+    def testMSPileupGet(self):
+        """Test MSPileup createPileup and getPileup API"""
+        self.assertEqual(len(self.createDoc()), 0)
 
         # get doc
-        spec = {'pileupName': self.pname}
-        res = self.mgr.getPileup(**spec)
+        res = self.mgr.getPileup(**self.spec)
         self.assertEqual(len(res), 1)
-        # self.assertDictEqual(res[0], self.doc)
+
+    def testMSPileupQuery(self):
+        """Test MSPileup createPileup and queryDatabase API"""
+        self.assertEqual(len(self.createDoc()), 0)
 
         # query doc
         projection = ["pileupType"]
-        res = self.mgr.queryDatabase(spec, projection)
+        res = self.mgr.queryDatabase(self.spec, projection)
         self.assertEqual(len(res), 1)
-        # self.assertEqual(res[0], ["classic"])
+
+    def testMSPileupUpdate(self):
+        """Test MSPileup createPileup and updatePileup API"""
+        self.assertEqual(len(self.createDoc()), 0)
+        self.assertEqual(self.doc['pileupType'], "classic")
 
         # update doc
         doc = dict(self.doc)
-        doc["pileupType"] = "new"
+        doc["pileupType"] = "premix"
         res = self.mgr.updatePileup(doc)
         self.assertEqual(len(res), 0)
 
-        # query doc
-        res = self.mgr.queryDatabase(spec, projection)
-        self.assertEqual(len(res), 1)
-        # self.assertEqual(res[0], ["new"])
+        # get doc
+        res = self.mgr.getPileup(**self.spec)
+        self.assertEqual(res[0]['pileupType'], "premix")
+
+    def testMSPileupDelete(self):
+        """Test MSPileup createPileup and deletePileup API"""
+        self.assertEqual(len(self.createDoc()), 0)
 
         # delete doc
-        res = self.mgr.deletePileup(spec)
+        res = self.mgr.deletePileup(self.spec)
         self.assertEqual(len(res), 0)
+
+        # get doc - already deleted
+        res = self.mgr.getPileup(**self.spec)
+        self.assertEqual(res, [])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #11498 (sort of!)

#### Status
In development

#### Description
This PR provides the following:
* reads a configurable rudio Disk expression `rucioDiskExpression` to be used to find valid and allowed Rucio RSEs from Rucio (which relies on a memory cache set to expiry every 12h, by default)
* it enforces RSE validation when creating a new pileup document
* when user updates a pileup object, validation of the parameters will be performed as well
* when MSPileupTasks updates a pileup object, validation of the document is skipped (given that it's already loaded from the database)

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
