### PR TITLE
Properly provide error message

### DIFF
--- a/src/python/WMCore/MicroService/MSPileup/MSPileupError.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupError.py
@@ -74,7 +74,8 @@ class MSPileupGenericError(MSPileupError):
     """
     def __init__(self, data, msg=""):
         super().__init__(data, msg)
-        self.assign(msg="generic error", code=MSPILEUP_GENERIC_ERROR)
+        msg = self.msg if self.msg else "generic error"
+        self.assign(msg=msg, code=MSPILEUP_GENERIC_ERROR)
 
 
 class MSPileupSchemaError(MSPileupError):
@@ -83,7 +84,8 @@ class MSPileupSchemaError(MSPileupError):
     """
     def __init__(self, data, msg=""):
         super().__init__(data, msg)
-        self.assign(msg="schema error", code=MSPILEUP_SCHEMA_ERROR)
+        msg = self.msg if self.msg else "schema error"
+        self.assign(msg=msg, code=MSPILEUP_SCHEMA_ERROR)
 
 
 class MSPileupInvalidDataError(MSPileupError):
@@ -92,7 +94,8 @@ class MSPileupInvalidDataError(MSPileupError):
     """
     def __init__(self, data, msg=""):
         super().__init__(data, msg)
-        self.assign(msg="invalid data", code=MSPILEUP_INVALID_ERROR)
+        msg = self.msg if self.msg else "invalid data"
+        self.assign(msg=msg, code=MSPILEUP_INVALID_ERROR)
 
 
 class MSPileupDuplicateDocumentError(MSPileupError):

--- a/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupData_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupData_t.py
@@ -108,7 +108,8 @@ class MSPileupTest(unittest.TestCase):
         out = self.mgr.createPileup(pdict, ['rse2'])[0]
         self.assertEqual(out['error'], "MSPileupError")
         self.assertEqual(out['code'], 7)
-        self.assertEqual(out['message'], "schema error")
+        expect = "Failed to create MSPileupObj, MSPileup input is invalid, expectedRSEs value ['rse1'] is not in validRSEs ['rse2']"
+        self.assertEqual(out['message'], expect)
 
         spec = {'pileupName': pname}
         results = self.mgr.getPileup(spec)


### PR DESCRIPTION
Fixes #11511 

#### Status
ready

#### Description
Fix issue with incorrect error message. Here the client side:
```
scurl -X POST -H "Accept: application/json" -H "Content-type: application/json" -d '{"pileupName":"/Test/Test-Alan-v1/PREMIX", "pileupType": "wrong", "active": false, "expectedRSEs": ["T2_CH_CERN"]}' http://localhost:8241/ms-pileup/data/pileup
...
        <h2>400 Bad Request</h2>
        <p>MSPileupError: Failed to create MSPileupObj, MSPileup input is invalid, pileupType value wrong is neither of ['classic', 'premix'], code: 7</p>
```

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs

#### External dependencies / deployment changes
