### PR TITLE
Remove secondary data placement from MSTransferor

### DIFF
--- a/src/python/Utils/Timers.py
+++ b/src/python/Utils/Timers.py
@@ -6,6 +6,7 @@ Utilities related to timing and performance testing
 from __future__ import print_function, division, absolute_import
 
 from builtins import object
+import logging
 import time
 import calendar
 from datetime import tzinfo, timedelta
@@ -73,18 +74,18 @@ class CodeTimer(object):
         do_something()
     """
 
-    def __init__(self, label='The function'):
+    def __init__(self, label='The function', logger=None):
         self.start = time.time()
         self.label = label
+        self.logger = logger or logging.getLogger()
 
     def __enter__(self):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         end = time.time()
-        runtime = end - self.start
-        msg = '{label} took {time} seconds to complete'
-        print(msg.format(label=self.label, time=runtime))
+        runtime = round((end - self.start), 3)
+        self.logger.info(f"{self.label} took {runtime} seconds to complete")
 
 
 class LocalTimezone(tzinfo):

--- a/src/python/WMCore/MicroService/DataStructs/DefaultStructs.py
+++ b/src/python/WMCore/MicroService/DataStructs/DefaultStructs.py
@@ -31,6 +31,7 @@ TRANSFEROR_REPORT = dict(start_time=0,
                          success_request_transition=0,
                          failed_request_transition=0,
                          problematic_requests=0,
+                         total_num_active_pileups=0,
                          num_datasets_subscribed=0,
                          num_blocks_subscribed=0)
 

--- a/src/python/WMCore/MicroService/MSTransferor/DataStructs/Workflow.py
+++ b/src/python/WMCore/MicroService/MSTransferor/DataStructs/Workflow.py
@@ -41,7 +41,7 @@ class Workflow(object):
         self.parentBlocks = {}
         # sort of duplicate info, but we need to have a way to link input to parent block(s)
         self.childToParentBlocks = {}
-        # pileup don't need to get resolved into blocks, store only their total size and location
+        # pileup don't need to get resolved into blocks, store only their location
         self.secondarySummaries = {}
 
         self.setDataCampaignMap()
@@ -270,19 +270,16 @@ class Workflow(object):
         """
         return self.primaryBlocks
 
-    def setSecondarySummary(self, dsetName, dsetSize, locations=None):
+    def setSecondarySummary(self, dsetName, locations=None):
         """
         Create a summary of the pileup dataset, with its total data size
         and locations where the whole dataset is subscribed and available
         :param dsetName: string with the secondary dataset name
-        :param dsetSize: integer with the secondary dataset size
         :param locations: locations hosting this dataset in full (and subscribed)
         Data is in the form of:
-        {"dataset_name": {"dsetSize": 1234,
-                          "locations": [list of locations]}}
+        {"dataset_name": {"locations": [list of locations]}}
         """
         self.secondarySummaries.setdefault(dsetName, {})
-        self.secondarySummaries[dsetName]['dsetSize'] = dsetSize
         self.secondarySummaries[dsetName]['locations'] = locations or []
 
     def getSecondarySummary(self):

--- a/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
+++ b/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
@@ -24,11 +24,12 @@ from copy import deepcopy
 from Utils.IteratorTools import grouper
 from WMCore.MicroService.DataStructs.DefaultStructs import TRANSFEROR_REPORT,\
     TRANSFER_RECORD, TRANSFER_COUCH_DOC
-from WMCore.MicroService.Tools.Common import gigaBytes, teraBytes, isRelVal
+from WMCore.MicroService.Tools.Common import (teraBytes, isRelVal, getPileupDocs)
 from WMCore.MicroService.MSCore.MSCore import MSCore
 from WMCore.MicroService.MSTransferor.RequestInfo import RequestInfo
 from WMCore.MicroService.MSTransferor.DataStructs.RSEQuotas import RSEQuotas
 from WMCore.Services.CRIC.CRIC import CRIC
+from WMCore.Services.Rucio.RucioUtils import GROUPING_ALL
 
 
 def newTransferRec(dataIn):
@@ -85,6 +86,9 @@ class MSTransferor(MSCore):
         # make a container level rule for the whole container whenever the open running
         # timeout is larger than what is configured (or the default of 7 days below)
         self.msConfig.setdefault("openRunning", 7 * 24 * 60 * 60)
+        # define the pileup query to be executed through MSPileup
+        self.pileupQuery = self.msConfig.get("pileupQuery",
+                                             {"query": {"active": True}, "filters": ["expectedRSEs", "pileupName"]})
 
         quotaAccount = self.msConfig["rucioAccount"]
 
@@ -94,9 +98,7 @@ class MSTransferor(MSCore):
         self.reqInfo = RequestInfo(self.msConfig, self.rucio, self.logger)
 
         self.cric = CRIC(logger=self.logger)
-        self.inputMap = {"InputDataset": "primary",
-                         "MCPileup": "secondary",
-                         "DataPileup": "secondary"}
+        self.pileupDocs = []
         self.uConfig = {}
         self.campaigns = {}
         self.psn2pnnMap = {}
@@ -126,6 +128,7 @@ class MSTransferor(MSCore):
         self.logger.info("Updating all local caches...")
         self.dsetCounter = 0
         self.blockCounter = 0
+        self.pileupDocs = getPileupDocs(self.msConfig['mspileupUrl'], self.pileupQuery)
         self.uConfig = self.unifiedConfig()
         campaigns = self.reqmgrAux.getCampaignConfig("ALL_DOCS")
         self.psn2pnnMap = self.cric.PSNtoPNNMap()
@@ -168,6 +171,7 @@ class MSTransferor(MSCore):
 
         try:
             self.updateCaches()
+            self.updateReportDict(summary, "total_num_active_pileups", len(self.pileupDocs))
             self.updateReportDict(summary, "total_num_campaigns", len(self.campaigns))
             self.updateReportDict(summary, "nodes_out_of_space", list(self.rseQuotas.getOutOfSpaceRSEs()))
         except RuntimeWarning as ex:
@@ -186,9 +190,8 @@ class MSTransferor(MSCore):
         for reqSlice in grouper(requestRecords, 100):
             self.logger.info("Processing workflows from %d to %d.",
                              counterWorkflows + 1, counterWorkflows + len(reqSlice))
-            # get complete requests information
-            # based on Unified Transferor logic
-            reqResults = self.reqInfo(reqSlice)
+            # execute data discovery
+            reqResults = self.reqInfo(reqSlice, self.pileupDocs)
             self.logger.info("%d requests information completely processed.", len(reqResults))
 
             for wflow in reqResults:
@@ -196,19 +199,19 @@ class MSTransferor(MSCore):
                     counterProblematicRequests += 1
                     continue
 
-                # first, check whether any pileup dataset is already in place
-                self.checkPUDataLocation(wflow)
-                if wflow.getSecondarySummary() and not wflow.getPURSElist():
-                    # then we still have pileup to be transferred, but with incorrect locations
+                if not self.passSecondaryCheck(wflow):
                     self.alertPUMisconfig(wflow.getName())
                     counterProblematicRequests += 1
                     continue
 
+                # find accepted RSEs for the workflow
+                rseList = self.getAcceptedRSEs(wflow)
+
                 # now check where input primary and parent blocks will need to go
-                self.checkDataLocation(wflow)
+                self.checkDataLocation(wflow, rseList)
 
                 try:
-                    success, transfers = self.makeTransferRequest(wflow)
+                    success, transfers = self.makeTransferRequest(wflow, rseList)
                 except Exception as ex:
                     success = False
                     self.alertUnknownTransferError(wflow.getName())
@@ -271,20 +274,57 @@ class MSTransferor(MSCore):
 
     def verifyCampaignExist(self, wflow):
         """
-        Check whether the campaigns associated to all the input datasets
-        exist in the database.
+        Check whether there is a campaign for the primary dataset.
         :param wflow: a workflow object
         :return: True if campaigns exist, False otherwise
         """
         for dataIn in wflow.getDataCampaignMap():
-            if dataIn['campaign'] not in self.campaigns:
-                msg = "Workflow: %s has to transfer dataset: %s under the campaign: %s. "
-                msg += "This campaign does not exist and needs to be created. Skipping this workflow!"
-                self.logger.warning(msg, wflow.getName(), dataIn['name'], dataIn['campaign'])
+            if dataIn["type"] == "primary":
+                if dataIn['campaign'] not in self.campaigns:
+                    msg = "Workflow: %s has to transfer dataset: %s under the campaign: %s. "
+                    msg += "This campaign does not exist and needs to be created. Skipping this workflow!"
+                    self.logger.warning(msg, wflow.getName(), dataIn['name'], dataIn['campaign'])
+                    return False
+        return True
+
+    def passSecondaryCheck(self, wflow):
+        """
+        Check if the workflow uses active pileup and with valid location.
+        :param wflow: workflow object
+        :return: boolean whether the workflow is good to go or not
+        """
+        pileupInput = wflow.getSecondarySummary()
+        if not pileupInput:
+            # nothing to be done here
+            return True
+        for puName, puData in pileupInput.items():
+            if puData['locations'] == []:
+                msg = f"Workflow {wflow.getName()} requires pileup dataset {puName} "
+                msg += "which is either not active or does not exist in MSPileup."
+                self.logger.warning(msg)
                 return False
         return True
 
-    def checkDataLocation(self, wflow):
+    def getAcceptedRSEs(self, wflow):
+        """
+        Given a workflow object, find it's final accepted list of
+        RSEs for input data placement. This is based on:
+         * TrustSitelists and TrustPUSitelists;
+         * Workflow SiteWhitelist and SiteBlacklist
+         * Pileup location(s)
+        Note that it does NOT account for RSEs out of quota.
+        :param wflow: wflow object
+        :return: a list with unique RSE names
+        """
+        # workflow level site lists. In case there is no pileup or SecAAA=True
+        wflowRSEs = self._getPNNsFromPSNs(wflow.getSitelist())
+        if wflow.getPileupDatasets() and not wflow.getReqParam("TrustPUSitelists"):
+            # otherwise, data needs to be placed where pileup is
+            wflowRSEs = wflowRSEs & wflow.getPURSElist()
+
+        return list(wflowRSEs)
+
+    def checkDataLocation(self, wflow, rseList):
         """
         Check which data is already in place (according to the site lists
         and pileup data location) and remove them from the data placement
@@ -292,17 +332,18 @@ class MSTransferor(MSCore):
         If workflow has XRootD/AAA enabled, data location can be outside of
         the SiteWhitelist.
         :param wflow: workflow object
+        :param rseList: list of RSE names allowed for a given workflow
         :return: None
         """
         if not wflow.getInputDataset():
             return
 
-        wflowPnns = self._getPNNsFromPSNs(wflow.getSitelist())
-        primaryAAA = wflow.getReqParam("TrustSitelists")
-        msg = "Checking data location for request: %s, TrustSitelists: %s, request white/black list PNNs: %s"
-        self.logger.info(msg, wflow.getName(), primaryAAA, wflowPnns)
-
-        wflowPnns = wflow.getPURSElist()
+        primAAA = wflow.getReqParam("TrustSitelists")
+        secAAA = wflow.getReqParam("TrustPUSitelists")
+        msg = f"Checking data location for request: {wflow.getName()}, "
+        msg += f"TrustSitelists: {primAAA}, TrustPUSitelists: {secAAA}, "
+        msg += f"and final accepted RSEs: {rseList}"
+        self.logger.info(msg)
 
         for methodName in ("getPrimaryBlocks", "getParentBlocks"):
             inputBlocks = getattr(wflow, methodName)()
@@ -311,100 +352,25 @@ class MSTransferor(MSCore):
 
             for block, blockDict in listitems(inputBlocks):  # dict can change size here
                 blockLocation = self._diskPNNs(blockDict['locations'])
-                if primaryAAA and blockLocation:
+                if not blockLocation:
+                    self.logger.info("Primary/parent block %s not available in any disk storage", block)
+                elif primAAA:
                     msg = "Primary/parent block %s already in place (via AAA): %s" % (block, blockLocation)
                     self.logger.info(msg)
                     inputBlocks.pop(block)
-                elif blockLocation:
-                    commonLocation = wflowPnns & set(blockLocation)
+                else:
+                    commonLocation = set(blockLocation) & rseList
                     if commonLocation:
                         self.logger.info("Primary/parent block %s already in place: %s", block, commonLocation)
                         inputBlocks.pop(block)
                     else:
                         self.logger.info("block: %s will need data placement!!!", block)
-                else:
-                    self.logger.info("Primary/parent block %s not available in any disk storage", block)
 
             self.logger.info("Request %s has %d final blocks from %s",
                              wflow.getName(), len(getattr(wflow, methodName)()), methodName)
 
-    def checkPUDataLocation(self, wflow):
-        """
-        Check the workflow pileup current location, compare it to what is defined
-        in the campaign configuration and ensure that each location defined in the
-        campaign gets a rule created, regardless whether AAA is enabled or not.
 
-        Use the workflow sitelists and the expected pileup(s) location(s) to decide
-        where primary and parent data must be placed.
-
-        :param wflow: workflow object
-        :return: None
-        """
-        pileupInput = wflow.getSecondarySummary()
-        if not pileupInput:
-            # nothing to be done here
-            return
-
-        psns = wflow.getSitelist()
-        wflowPnns = self._getPNNsFromPSNs(psns)
-        secAAA = wflow.getReqParam("TrustPUSitelists")
-        msg = "Checking secondary data location for request: {}, ".format(wflow.getName())
-        msg += "TrustPUSitelists: {}, request white/black list PNNs: {}".format(secAAA, wflowPnns)
-        self.logger.info(msg)
-
-        # this variable will contain a set of each pileup location, according
-        # to what has been defined in the campaign configuration. In the end,
-        # their intersection will be the final location for primary and parents
-        campBasedLocation = []
-        for dataIn in wflow.getDataCampaignMap():
-            if dataIn["type"] == "secondary":
-                dsetName = dataIn["name"]
-                campConfig = self.campaigns[dataIn['campaign']]
-                secSize = pileupInput[dsetName]['dsetSize']
-                secLocation = pileupInput[dsetName]['locations']
-                # and a special case for RelVal workflows, which do not define
-                # secondary datasets and their location
-                if isRelVal(wflow.data):
-                    campSecLocations = wflowPnns
-                else:
-                    campSecLocations = campConfig['Secondaries'].get(dsetName, [])
-                campBasedLocation.append(set(campSecLocations))
-
-                if not campSecLocations:
-                    msg = "Workflow has been incorrectly assigned: %s. The secondary dataset: %s, "
-                    msg += "belongs to the campaign: %s, which does not define the secondary "
-                    msg += "dataset or it has defined an empty location list."
-                    self.logger.error(msg, wflow.getName(), dsetName, dataIn['campaign'])
-                    return
-
-                # compare the expected locations against the current availability
-                missingDestinations = list(set(campSecLocations) - set(secLocation))
-                msg = "it has secondary pileup: %s, with a total size of: %s GB, "
-                msg += "currently at: %s, campaign expected at: %s and missing replicas at: %s"
-                self.logger.info(msg, dsetName, gigaBytes(secSize), secLocation,
-                                 campSecLocations, missingDestinations)
-                if missingDestinations:
-                    # then update this pileup location to get rule(s) on it
-                    self.logger.info("pileup %s will get container rules on: %s", dsetName, missingDestinations)
-                    pileupInput[dsetName]['locations'] = missingDestinations
-                else:
-                    self.logger.info("pileup %s already available at the expected locations", dsetName)
-                    # then remove it from the samples to get a data placement rule
-                    pileupInput.pop(dsetName)
-
-        # consider the workflow sitelist for this final location
-        if len(campBasedLocation) == 1:
-            # then there is only one pileup dataset in the workflow
-            wflowFinalLocation = campBasedLocation[0] & wflowPnns
-        else:
-            # then there are multiple pileups, meaning possibly different
-            # campaigns and expected locations. Use their location
-            # intersection as final workflow destination
-            wflowFinalLocation = campBasedLocation[0].intersection(*campBasedLocation)
-        self.logger.info("Final location for workflow: %s is: %s", wflow.getName(), wflowFinalLocation)
-        wflow.setPURSElist(wflowFinalLocation)
-
-    def makeTransferRequest(self, wflow):
+    def makeTransferRequest(self, wflow, rseList):
         """
         Checks which input data has to be transferred, select the final destination if needed,
         create the transfer record to be stored in Couch, and create the DM placement request.
@@ -422,56 +388,45 @@ class MSTransferor(MSCore):
           6. re-evaluate nodes with quota exceeded
           7. return the transfer record, with a list of transfer IDs
         :param wflow: workflow object
+        :param rseList: list of RSE names allowed for a given workflow
         :return: boolean whether it succeeded or not, and a list of transfer records
         """
         response = []
         success = True
-        if not (wflow.getParentBlocks() or wflow.getPrimaryBlocks() or wflow.getSecondarySummary()):
+        if not (wflow.getParentBlocks() or wflow.getPrimaryBlocks()):
             self.logger.info("Request %s does not have any further data to transfer", wflow.getName())
             return success, response
 
         self.logger.info("Handling data subscriptions for request: %s", wflow.getName())
 
         for dataIn in wflow.getDataCampaignMap():
-            dsetName = dataIn['name']
             if dataIn["type"] == "parent":
-                msg = "Skipping 'parent' data subscription (done with the 'primary' data), for: %s" % dataIn
+                msg = "Skipping 'parent' data placement (done with the 'primary' data), for: %s" % dataIn
                 self.logger.info(msg)
                 continue
-            elif dataIn["type"] == "secondary" and dsetName not in wflow.getSecondarySummary():
-                # secondary already in place
+            elif dataIn["type"] == "secondary":
+                # already performed by MSPileup
                 continue
 
-            if wflow.getPURSElist() and not isRelVal(wflow.data):
-                rses = list(wflow.getPURSElist() & self.rseQuotas.getAvailableRSEs())
-            else:
-                rses = self._getValidSites(wflow, dataIn)
+            if not isRelVal(wflow.data):
+                # enforce RSE quota
+                rses = list(set(rseList) & self.rseQuotas.getAvailableRSEs())
             if not rses:
-                msg = "Workflow: %s can only run in RSEs with no available space: %s. "
-                msg += "Skipping this workflow until space gets released"
-                self.logger.warning(msg, wflow.getName(), wflow.getPURSElist())
+                msg = f"Workflow: {wflow.getName()} could have data placed at: {rseList}, "
+                msg += "but those are all out of quota. Skipping it till next cycle"
+                self.logger.warning(msg)
                 return False, response
 
             # create a transfer record data structure
             transRec = newTransferRec(dataIn)
             # figure out dids, number of copies and which grouping to use
-            if dataIn["type"] == "primary":
-                dids, didsSize = wflow.getInputData()
-                grouping = wflow.getRucioGrouping()
-                copies = wflow.getReplicaCopies()
-                if not dids:
-                    # no valid files in any blocks, it will likely fail in global workqueue
-                    self.logger.warning("  found 0 primary/parent blocks for dataset: %s, moving on...", dataIn['name'])
-                    return success, response
-            # then it's secondary type
-            else:
-                # we can have multiple pileup datasets
-                puSummary = wflow.getSecondarySummary()
-                dids = [dsetName]
-                didsSize = puSummary[dsetName]['dsetSize']
-                grouping = "ALL"
-                # one replica for each RSE
-                copies = len(rses)
+            dids, didsSize = wflow.getInputData()
+            grouping = wflow.getRucioGrouping()
+            copies = wflow.getReplicaCopies()
+            if not dids:
+                # no valid files in any blocks, it will likely fail in global workqueue
+                self.logger.warning("  found 0 primary/parent blocks for dataset: %s, moving on...", dataIn['name'])
+                return success, response
 
             success, transferId = self.makeTransferRucio(wflow, dataIn, dids, didsSize,
                                                          grouping, copies, rses)
@@ -487,7 +442,7 @@ class MSTransferor(MSCore):
                     transRec['transferIDs'].add(transferId)
 
             # and update some instance caches
-            if dataIn["type"] == "secondary":
+            if grouping == GROUPING_ALL:
                 self.dsetCounter += 1
             else:
                 self.blockCounter += len(dids)

--- a/src/python/WMCore/MicroService/Tools/Common.py
+++ b/src/python/WMCore/MicroService/Tools/Common.py
@@ -106,6 +106,26 @@ def dbsInfo(datasets, dbsUrl):
     return datasetBlocks, datasetSizes, datasetTransfers
 
 
+def getPileupDocs(mspileupUrl, queryDict):
+    """
+    Fetch documents from MSPileup according to the query passed in.
+    :param mspileupUrl: string with the MSPileup url
+    :param queryDict: dictionary with the MongoDB query to run
+    :return: returns a list with all the pileup objects, or raises
+        an exception in case of failure
+    """
+    mgr = RequestHandler()
+    headers = {'Content-Type': 'application/json'}
+    data = mgr.getdata(mspileupUrl, queryDict, headers, verb='POST',
+                       ckey=ckey(), cert=cert(), encode=True, decode=True)
+    if data and data.get("result", []):
+        if "error" in data["result"][0]:
+            msg = f"Failed to retrieve MSPileup documents with query: {queryDict}"
+            msg += f" and error message: {data}"
+            raise RuntimeError(msg)
+    return data["result"]
+
+
 def getPileupDatasetSizes(datasets, phedexUrl):
     """
     Given a list of datasets, find all their blocks with replicas

--- a/test/python/WMCore_t/MicroService_t/MSTransferor_t/DataStructs_t/RelValWorkflow_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSTransferor_t/DataStructs_t/RelValWorkflow_t.py
@@ -152,9 +152,8 @@ class RelValWorkflowTest(unittest.TestCase):
 
         # checking pileup data
         self.assertEqual(wflow.getSecondarySummary(), {})
-        wflow.setSecondarySummary(puName, dsetSize=123, locations=["Site_B"])
+        wflow.setSecondarySummary(puName, locations=["Site_B"])
         self.assertCountEqual(list(wflow.getSecondarySummary()), [puName])
-        self.assertEqual(wflow.getSecondarySummary()[puName]["dsetSize"], 123)
         self.assertCountEqual(wflow.getSecondarySummary()[puName]["locations"], ["Site_B"])
 
     def testRelValWflowWithParent(self):
@@ -209,16 +208,13 @@ class RelValWorkflowTest(unittest.TestCase):
 
         # checking pileup data
         self.assertEqual(wflow.getSecondarySummary(), {})
-        wflow.setSecondarySummary(puName1, dsetSize=123, locations=["Site_B"])
+        wflow.setSecondarySummary(puName1, locations=["Site_B"])
         self.assertCountEqual(list(wflow.getSecondarySummary()), [puName1])
-        self.assertEqual(wflow.getSecondarySummary()[puName1]["dsetSize"], 123)
         self.assertCountEqual(wflow.getSecondarySummary()[puName1]["locations"], ["Site_B"])
 
         # now set the second pileup
-        wflow.setSecondarySummary(puName2, dsetSize=12, locations=["Site_C"])
+        wflow.setSecondarySummary(puName2, locations=["Site_C"])
         self.assertCountEqual(list(wflow.getSecondarySummary()), [puName1, puName2])
-        self.assertEqual(wflow.getSecondarySummary()[puName1]["dsetSize"], 123)
-        self.assertEqual(wflow.getSecondarySummary()[puName2]["dsetSize"], 12)
         self.assertCountEqual(wflow.getSecondarySummary()[puName1]["locations"], ["Site_B"])
         self.assertCountEqual(wflow.getSecondarySummary()[puName2]["locations"], ["Site_C"])
 

--- a/test/python/WMCore_t/MicroService_t/MSTransferor_t/RequestInfo_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSTransferor_t/RequestInfo_t.py
@@ -3,7 +3,7 @@ Unit tests for the WMCore/MicroService/DataStructs/NanoWorkflow module
 """
 import unittest
 
-from WMCore.MicroService.MSTransferor.RequestInfo import isNanoWorkflow
+from WMCore.MicroService.MSTransferor.RequestInfo import isNanoWorkflow, rsesIntersection
 
 
 class RequestInfoTest(unittest.TestCase):
@@ -43,6 +43,22 @@ class RequestInfoTest(unittest.TestCase):
         self.assertFalse(isNanoWorkflow(testDict))
         testDict = {'RequestType': 'StepChain', 'Step1': {'InputDataset': '/PrimDset/AcqEra-ProcStr/MINIAODSIM'}}
         self.assertTrue(isNanoWorkflow(testDict))
+
+    def testrsesIntersection(self):
+        """
+        Test the rsesIntersection function
+        """
+        rses = []
+        self.assertEqual(rses, rsesIntersection(rses))
+
+        rses = [['aaa', 'bbb', 'ccc']]
+        self.assertEqual(rses[0], rsesIntersection(rses))
+
+        rses = [['aaa', 'bbb', 'ccc'], ['bbb', 'ccc'], ['ccc']]
+        self.assertEqual(rses[2], rsesIntersection(rses))
+
+        rses = [['aaa', 'bbb', 'ccc'], ['ddd']]
+        self.assertEqual([], rsesIntersection(rses))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #11427 

#### Status
ready

#### Description
Along the way of removing the secondary data placement logic from MSTransferor, given that MSPileup will own all of that logic, this PR also provides the following:
1) allow `CodeTimer` Util class to get a logger object
2) minor refactoring of the `Workflow` object, such that it finds the intersection of RSEs (provided through getter/setter)
3) Implemented a function in Tools/Common to retrieve pileup objects from MSPileup
4) MSTransferor: 
   * get a new service configuration with the MSPileup query/filter to execute `pileupQuery`
   * skip data placement if pileup config does not exist or is inactive
5) RequestInfo:
   * calculate elapsed time with the CodeTimer context manager
   * requires a list of pileup documents durint `__call__` execution
   * no longer resolve pileup size and location through Rucio (just use pileup docs instead)
   *  set `setPURSElist` according to the intersection of multiple pileup datasets requested in the workflow

#### Is it backward compatible (if not, which system it affects?)
NO (in the sense that MSTransferor now depends on MSPileup data)

#### Related PRs
I described the MSTransferor input data placement logic in: https://github.com/dmwm/WMCore/wiki/ReqMgr2-MicroService-Transferor#mstransferor-logic

#### External dependencies / deployment changes
Service configuration updates are together with MSPileup, in this test MR:
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/200
Preprod: https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/201
Prod: https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/202