### PR TITLE
Adding Null parentage information for RunLumi pairs missing at the parent Dataset

### DIFF
--- a/test/python/WMCore_t/Services_t/DBS_t/DBSReader_t.py
+++ b/test/python/WMCore_t/Services_t/DBS_t/DBSReader_t.py
@@ -435,10 +435,10 @@ class DBSReaderTest(EmulatedUnitTestCase):
         """Test the getParentDatasetTrio method"""
         self.dbs = DBSReader(self.endpoint)
         results = self.dbs.getParentDatasetTrio(DATASET_WITH_PARENTS)
-        self.assertTrue(frozenset({2, 180851}) in results)
-        self.assertEqual(int(results[frozenset({2, 180851})]), 36092526)
-        self.assertTrue(frozenset({1, 180851}) in results)
-        self.assertEqual(int(results[frozenset({2, 180851})]), 36092526)
+        self.assertTrue((180851, 2) in results)
+        self.assertEqual(int(results[(180851, 2)]), 36092526)
+        self.assertTrue((180851, 1) in results)
+        self.assertEqual(int(results[(180851, 1)]), 36092526)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #11260 

#### Status
Ready

#### Description
With the current PR we try to add  Null information for the RunLumi pairs that are missing at the parent dataset by adding the following improvements to the current code:
* Introduce a new data structure which is a `NamedTuple`  containing the triplet `fileId, run, lumi`
* Benefiting from set operations to create subsets of missing and resolved `run/lumi` pairs
* Adding the subset of unresolved `run/lumi` pairs with `Null` parentage information so that  the whole length of the block information uploaded to DBS to be pereserved

#### Is it backward compatible (if not, which system it affects?)
No

#### Related PRs
None

#### External dependencies / deployment changes
DBS needs  to change their code in order  to accept `blocks with partially resolved rentage information. 
The relevant DBS issue is:
https://github.com/dmwm/dbs2go/issues/94