### PR TITLE
Script to parse campaigns and extract pileup configuration

### DIFF
--- a/bin/adhoc-scripts/createPileupObjects.py
+++ b/bin/adhoc-scripts/createPileupObjects.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This script can be used to parse the WMCore campaign documents
+and extract the equivalent pileup configuration.
+
+Attributes that are used from the campaign documents are:
+ * CampaignName: to be defined under the pileup "campaignName" attr
+ * Secondaries: to fetch the pileup dataset name, type and expected location
+
+where the pileup document minimal schema is:
+{
+    'pileupName': "",
+    'pileupType': "",
+    'expectedRSEs': [],
+    'campaigns': [],
+    'active': False
+}
+
+Example usage is:
+==> Construct pileup documents from the production campaigns
+python3 createPileupObjects.py --url=https://cmsweb.cern.ch --fout=alan.json
+
+==> Inject the previous pileup doc dump into your test cluster
+python3 createPileupObjects.py --url=https://cmsweb-test9.cern.ch --fin=alan.json --inject
+"""
+import argparse
+import json
+import logging
+import os
+import sys
+from pprint import pprint
+
+try:
+    from WMCore.Services.pycurl_manager import RequestHandler
+except ImportError:
+    print("WMCore/RequestHandler environment not set. Faking it")
+    RequestHandler = None
+try:
+    from WMCore.Services.ReqMgrAux.ReqMgrAux import ReqMgrAux
+except ImportError:
+    print("WMCore/ReqMgrAux environment not found. Faking it")
+    ReqMgrAux = None
+
+
+class OptionParser():
+    """Class to parse the command line arguments"""
+
+    def __init__(self):
+        "User based option parser"
+        self.parser = argparse.ArgumentParser(prog='PROG')
+        self.parser.add_argument("--fin", action="store",
+                                 dest="fin", default="", help="Input file")
+        self.parser.add_argument("--fout", action="store",
+                                 dest="fout", default="",
+                                 help="Output json file with all the pileup configurations created")
+        self.parser.add_argument("--url", action="store",
+                                 dest="url", default="https://cmsweb-testbed.cern.ch",
+                                 help="Server url to fetch and create pileup configurations")
+        self.parser.add_argument("--inject", action="store_true",
+                                 dest="inject", default=False,
+                                 help="Inject pileup documents for real")
+
+
+def getPUSchema(pileupName, pileupDocs, logger):
+    """
+    Get a minimalistic pileup data schema, or return an
+    existent pileup object.
+
+    :param pileupName: string with the pileup name
+    :param pileupDocs: list of pileup documents
+    :return: a dictionary with the pileup configuration
+    """
+    for doc in pileupDocs:
+        if pileupName == doc["pileupName"]:
+            logger.warning("Reusing pileup configuration for pileup: %s", pileupName)
+            return doc
+    pileupDoc = {
+        'pileupName': "",
+        'pileupType': "",
+        'expectedRSEs': [],
+        'campaigns': [],
+        'active': False}
+    return pileupDoc
+
+
+def parseCampaigns(campDocs, logger):
+    """
+    Parse campaigns from WMCore and convert them into
+    Pileup documents, where:
+     * campaigns: is a union of all campaigns using a given pileup.
+     * expectedRSEs: is a union of all RSEs across different campaigns.
+    """
+    pileupDocs = []
+    for camp in campDocs:
+        # for each secondary dataset, create one pileup document
+        for puName, puRSEs in camp.get("Secondaries", {}).items():
+            puDoc = getPUSchema(puName, pileupDocs, logger)
+            puType = "premix" if puName.split("/")[-1] == "PREMIX" else "classic"
+            puDoc["pileupName"] = puName
+            puDoc["pileupType"] = puType
+            puDoc["expectedRSEs"].extend(puRSEs)
+            if camp.get("CampaignName", ""):
+                puDoc["campaigns"].append(camp["CampaignName"])
+            # make some of these values unique
+            puDoc["expectedRSEs"] = list(set(puDoc["expectedRSEs"]))
+            puDoc["campaigns"] = list(set(puDoc.get("campaigns", [])))
+            pileupDocs.append(puDoc)
+    logger.info("Created %d pileup docs out of %d campaigns.", len(pileupDocs), len(campDocs))
+    return pileupDocs
+
+
+def writePileupDocs(mspileupUrl, puDocs, certDict, logger):
+    """
+    Create pileup documents in MSPileup
+    :param mspileupUrl: string with the MSPileup url
+    :param puDocs: list with pileup documents
+    :param certDict: dictionary with cert and key reference
+    :param logger: logger object
+    :return: None
+    """
+    url = mspileupUrl + "/ms-pileup/data/pileup"
+    mgr = RequestHandler()
+    headers = {'Content-Type': 'application/json'}
+    for doc in puDocs:
+        logger.info("Injecting against %s document: %s", url, doc)
+        resp = mgr.getdata(url, doc, headers, verb='POST', encode=True, decode=True,
+                           ckey=certDict['key'], cert=certDict['cert'])
+
+        logger.debug("Response: %s", resp)
+        if resp and resp.get("result", []):
+            msg = f"Failed to inject pileup document for {doc['pileupName']}. Error: {resp}"
+            logger.critical(msg)
+
+
+def main():
+    """Executes everything"""
+    optmgr = OptionParser()
+    opts = optmgr.parser.parse_args()
+    logger = logging.getLogger('createPileupObjects')
+    logger.setLevel(logging.INFO)
+    logging.basicConfig()
+
+    # setup proxy/cert
+    cert = os.getenv('X509_USER_CERT', '')
+    key = os.getenv('X509_USER_KEY', '')
+    proxy = os.getenv('X509_USER_PROXY', '')
+    if not cert and not proxy:
+        logger.error("You need to define the X509 user cert/key or user proxy variables")
+        sys.exit(1)
+    if not cert and proxy:
+        cert = proxy
+        key = proxy
+    hdict = {'cert': cert, 'key': key, 'pycurl': True}
+
+    if opts.fin:
+        fin = opts.fin
+        logger.info(f"Reading pileup configuration from file: {fin}")
+        with open(fin, 'r') as istream:
+            puDocs = json.load(istream)
+            logger.info(f"Found {len(puDocs)} pileup objects in the input file.")
+    else:
+        logger.info("Parsing/fetching pileup objects from ReqMgrAux")
+        reqAux = ReqMgrAux(opts.url + "/reqmgr2", hdict, logger=logger)
+        campDocs = reqAux.getCampaignConfig("ALL_DOCS")
+        logger.info("Retrieved %d campaigns from ReqMgr.", len(campDocs))
+        puDocs = parseCampaigns(campDocs, logger)
+    if opts.fout:
+        logger.info("Saving all %d pileup documents into file: %s", len(puDocs), opts.fout)
+        with open(opts.fout, "w") as jo:
+            json.dump(puDocs, jo, indent=2)
+
+    if opts.inject:
+        logger.info("Going to inject %d pileup documents into: %s", len(puDocs), opts.url)
+        writePileupDocs(opts.url, puDocs, hdict, logger)
+    else:
+        logger.info("DRY-RUN: not injecting any pileup documents in MSPileup.")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/python/WMCore/MicroService/DataStructs/pileups.json
+++ b/src/python/WMCore/MicroService/DataStructs/pileups.json
@@ -1,0 +1,1639 @@
+[
+  {
+    "pileupName": "/MinBias_TuneCP5_13p6TeV-pythia8/Commission22GS-125X_mcRun3_2022_realistic_v3-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_DE_KIT_Disk",
+      "T1_US_FNAL_Disk",
+      "T2_CH_CERN"
+    ],
+    "campaigns": [
+      "Commission22DR"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_Hydjet_Drum5F_2018_5p02TeV/HINPbPbAutumn18GS-103X_upgrade2018_realistic_HI_v11-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_RU_JINR_Disk",
+      "T1_FR_CCIN2P3_Disk"
+    ],
+    "campaigns": [
+      "HINPbPbAutumn18DR",
+      "HINPbPbAutumn18wmLHEGSHIMix",
+      "HINPbPbAutumn18GSHIMix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_Hydjet_Drum5F_2018_5p02TeV/HINPbPbAutumn18GS-103X_upgrade2018_realistic_HI_v11-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_RU_JINR_Disk",
+      "T1_FR_CCIN2P3_Disk"
+    ],
+    "campaigns": [
+      "HINPbPbAutumn18DR",
+      "HINPbPbAutumn18wmLHEGSHIMix",
+      "HINPbPbAutumn18GSHIMix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_Hydjet_Drum5F_2018_5p02TeV/HINPbPbAutumn18GS-103X_upgrade2018_realistic_HI_v11-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_RU_JINR_Disk",
+      "T1_FR_CCIN2P3_Disk"
+    ],
+    "campaigns": [
+      "HINPbPbAutumn18DR",
+      "HINPbPbAutumn18wmLHEGSHIMix",
+      "HINPbPbAutumn18GSHIMix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Hydjet_Quenched_Cymbal5Ev8_PbPbMinBias_5020GeV/HiFall15-75X_mcRun2_HeavyIon_v14_75X_mcRun2_HeavyIon_v14-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_RU_JINR_Disk",
+      "T2_ES_CIEMAT"
+    ],
+    "campaigns": [
+      "HINPbPbWinter16DR",
+      "HINPbPbWinter16wmLHEGSHIMix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Hydjet_Quenched_Cymbal5Ev8_PbPbMinBias_5020GeV/HiFall15-75X_mcRun2_HeavyIon_v14_75X_mcRun2_HeavyIon_v14-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_RU_JINR_Disk",
+      "T2_ES_CIEMAT"
+    ],
+    "campaigns": [
+      "HINPbPbWinter16DR",
+      "HINPbPbWinter16wmLHEGSHIMix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_14TeV-pythia8/Phase2Fall22GS-HCalDetIDFix_125X_mcRun4_realistic_v2-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T2_CH_CERN"
+    ],
+    "campaigns": [
+      "Phase2Fall22DRMiniAOD"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_14TeV-pythia8/Phase2HLTTDRWinter20GS-BSzpz35_110X_mcRun4_realistic_v3_ext4-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_ES_PIC_Disk",
+      "T1_RU_JINR_Disk"
+    ],
+    "campaigns": [
+      "Phase2HLTTDRWinter20DIGI"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_14TeV-pythia8/Phase2HLTTDRWinter20GS-110X_mcRun4_realistic_v3_ext1-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_RU_JINR_Disk"
+    ],
+    "campaigns": [
+      "Phase2HLTTDRWinter20DIGI"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/RelValMinBias_14TeV/CMSSW_11_1_2_patch3-110X_mcRun4_realistic_v3_2026D49noPU_BSzpz35-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_DE_KIT_Disk",
+      "T2_US_Florida"
+    ],
+    "campaigns": [
+      "Phase2HLTTDRWinter20DIGI"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_14TeV-pythia8/Phase2D76Spring21GS-113X_mcRun4_realistic_v7-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_DE_KIT_Disk",
+      "T1_US_FNAL_Disk"
+    ],
+    "campaigns": [
+      "Phase2Spring21DRMiniAOD"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_14TeV-pythia8/Phase2D80Spring21GS-113X_mcRun4_realistic_T25_v1-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T2_IT_Pisa",
+      "T2_US_Nebraska"
+    ],
+    "campaigns": [
+      "Phase2Spring21DRMiniAOD"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_14TeV-pythia8/Phase2D81Spring21GS-113X_mcRun4_realistic_T26_v1-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_DE_KIT_Disk",
+      "T2_US_Wisconsin"
+    ],
+    "campaigns": [
+      "Phase2Spring21DRMiniAOD"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_14TeV-pythia8/PhaseIISpring22GS-123X_mcRun4_realistic_v11-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T2_CH_CERN"
+    ],
+    "campaigns": [
+      "PhaseIISpring22DRMiniAOD"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_14TeV-pythia8/Run3Summer21GS-120X_mcRun3_2021_realistic_v5-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_DE_KIT_Disk",
+      "T1_US_FNAL_Disk"
+    ],
+    "campaigns": [
+      "Run3Summer21DR",
+      "Run3Summer21PrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/Run3Summer21PrePremix-120X_mcRun3_2021_realistic_v6-v2/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T1_DE_KIT_Disk",
+      "T1_US_FNAL_Disk"
+    ],
+    "campaigns": [
+      "Run3Summer21DRPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_14TeV-pythia8/Run3Summer21GS-120X_mcRun3_2021_realistic_v5-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_DE_KIT_Disk",
+      "T1_US_FNAL_Disk"
+    ],
+    "campaigns": [
+      "Run3Summer21DR",
+      "Run3Summer21PrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13p6TeV-pythia8/Run3Winter22GS-122X_mcRun3_2021_realistic_v9-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_ES_PIC_Disk",
+      "T1_US_FNAL_Disk"
+    ],
+    "campaigns": [
+      "Run3Winter22DR",
+      "Run3Summer21PrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13p6TeV-pythia8/Run3Winter23GS-126X_mcRun3_2023_forPU65_v1-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T2_CH_CERN"
+    ],
+    "campaigns": [
+      "Run3Summer21PrePremix",
+      "Run3Winter23Digi"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13p6TeV-pythia8/Run3Summer22GS-124X_mcRun3_2022_realistic_v10-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T2_CH_CERN"
+    ],
+    "campaigns": [
+      "Run3Summer22DR",
+      "Run3Summer22EEDR",
+      "Run3Summer21PrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13p6TeV-pythia8/Run3Summer22GS-124X_mcRun3_2022_realistic_v10-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T2_CH_CERN"
+    ],
+    "campaigns": [
+      "Run3Summer22DR",
+      "Run3Summer22EEDR",
+      "Run3Summer21PrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/Run3Summer21PrePremix-Summer22_124X_mcRun3_2022_realistic_v11-v2/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T2_CH_CERN"
+    ],
+    "campaigns": [
+      "Run3Summer22DRPremix",
+      "Run3Summer22EEDRPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13p6TeV-pythia8/Run3Summer22GS-124X_mcRun3_2022_realistic_v10-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T2_CH_CERN"
+    ],
+    "campaigns": [
+      "Run3Summer22DR",
+      "Run3Summer22EEDR",
+      "Run3Summer21PrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/Run3Summer21PrePremix-Summer22_124X_mcRun3_2022_realistic_v11-v2/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T2_CH_CERN"
+    ],
+    "campaigns": [
+      "Run3Summer22DRPremix",
+      "Run3Summer22EEDRPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_14TeV-pythia8/Run3Winter20GS-110X_mcRun3_2021_realistic_v6-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_ES_PIC_Disk",
+      "T1_US_FNAL_Disk",
+      "T1_UK_RAL_Disk"
+    ],
+    "campaigns": [
+      "Run3Winter20DRMiniAOD",
+      "RunIISummer17PrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_14TeV-pythia8/Run3Winter21GS-112X_mcRun3_2021_realistic_v15-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T1_UK_RAL_Disk"
+    ],
+    "campaigns": [
+      "Run3Winter21DRMiniAOD"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13p6TeV-pythia8/Run3Winter22GS-122X_mcRun3_2021_realistic_v9-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_ES_PIC_Disk",
+      "T1_US_FNAL_Disk"
+    ],
+    "campaigns": [
+      "Run3Winter22DR",
+      "Run3Summer21PrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/Run3Summer21PrePremix-Winter22_122X_mcRun3_2021_realistic_v9-v1/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T2_CH_CERN"
+    ],
+    "campaigns": [
+      "Run3Winter22DRPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_Hydjet_Drum5F_5p02TeV/Run3Winter22PbPbNoMixGS-122X_mcRun3_2021_realistic_HI_v10-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_IT_CNAF_Disk",
+      "T2_US_Florida"
+    ],
+    "campaigns": [
+      "Run3Winter22PbPbDIGI",
+      "Run3Winter22PbPbGS"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_Hydjet_Drum5F_5p02TeV/Run3Winter22PbPbNoMixGS-122X_mcRun3_2021_realistic_HI_v10-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_IT_CNAF_Disk",
+      "T2_US_Florida"
+    ],
+    "campaigns": [
+      "Run3Winter22PbPbDIGI",
+      "Run3Winter22PbPbGS"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13p6TeV-pythia8/Run3Winter23GS-126X_mcRun3_2023_forPU65_v1-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T2_CH_CERN"
+    ],
+    "campaigns": [
+      "Run3Summer21PrePremix",
+      "Run3Winter23Digi"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP1_13TeV-pythia8/RunIIFall18GS-102X_upgrade2018_realistic_v11-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [],
+    "campaigns": [
+      "RunIIAutumn18DR"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIIFall18GS-IdealGeometry_102X_upgrade2018_design_v9-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk"
+    ],
+    "campaigns": [
+      "RunIIAutumn18DR"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV_NeutronHP-pythia8/RunIIFall18GS-SNB_102X_upgrade2018_realistic_v17-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T2_US_Nebraska"
+    ],
+    "campaigns": [
+      "RunIIAutumn18DR"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8_Fall18/RunIIFall18GS-102X_upgrade2018_realistic_v11-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_IT_CNAF_Disk"
+    ],
+    "campaigns": [
+      "RunIIAutumn18DR"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIIFall18GS-newECALCrystalGeometryFor2016_102X_mcRun2_asymptotic_v5-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk"
+    ],
+    "campaigns": [
+      "RunIIAutumn18DR"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIIFall18GS-102X_upgrade2018_realistic_v9-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T2_US_MIT",
+      "T2_DE_DESY"
+    ],
+    "campaigns": [
+      "RunIIAutumn18DR",
+      "RunIISummer17PrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV_NeutronXS-pythia8/RunIIFall18GS-SNB_102X_upgrade2018_realistic_v17-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_ES_PIC_Disk"
+    ],
+    "campaigns": [
+      "RunIIAutumn18DR"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIIFall18GS-newECALCrystalGeometryFor2017_102X_mc2017_realistic_v5-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_DE_KIT_Disk"
+    ],
+    "campaigns": [
+      "RunIIAutumn18DR"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIISummer17PrePremix-PUAutumn18_102X_upgrade2018_realistic_v15-v1/GEN-SIM-DIGI-RAW",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk"
+    ],
+    "campaigns": [
+      "RunIIAutumn18DRPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUMoriond18_102X_upgrade2018_realistic_v15-v2/GEN-SIM-DIGI-RAW",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_DE_KIT_Disk",
+      "T1_US_FNAL_Disk",
+      "T1_RU_JINR_Disk",
+      "T2_US_Nebraska"
+    ],
+    "campaigns": [
+      "RunIIAutumn18FSPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIISummer17PrePremix-MCv2_correctPU_94X_mc2017_realistic_v9-v1/GEN-SIM-DIGI-RAW",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk"
+    ],
+    "campaigns": [
+      "RunIIFall17DRPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_inelasticON_13TeV-pythia8/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_DE_KIT_Disk",
+      "T1_FR_CCIN2P3_Disk"
+    ],
+    "campaigns": [
+      "RunIIFall17DRStdmix",
+      "RunIISummer17PrePremix",
+      "RunIILowPUSpring18DR"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8_Fall17/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_DE_KIT_Disk",
+      "T1_IT_CNAF_Disk"
+    ],
+    "campaigns": [
+      "RunIIFall17DRStdmix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP1_13TeV-pythia8/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_DE_KIT_Disk",
+      "T1_IT_CNAF_Disk"
+    ],
+    "campaigns": [
+      "RunIIFall17DRStdmix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP2_13TeV-pythia8/RunIISpring21UL18FSGSPremix-PUFSUL18_106X_upgrade2018_realistic_v16-v1/GEN-SIM-RECO",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_FR_CCIN2P3_Disk"
+    ],
+    "campaigns": [
+      "RunIIFall17FSPrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP2_13TeV-pythia8/RunIISpring21UL17FSGSPremix-PUFSUL17_106X_mc2017_realistic_v9-v1/GEN-SIM-RECO",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_ES_PIC_Disk"
+    ],
+    "campaigns": [
+      "RunIIFall17FSPrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL18FSGSPremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/GEN-SIM-RECO",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T1_RU_JINR_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring21UL18FSGSDR",
+      "RunIISpring21UL18FSSIMDR",
+      "RunIIFall17FSPrePremix",
+      "RunIISpring21UL18FSwmLHEGSDR"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP2_13TeV-pythia8/RunIISpring21UL16FSGSPremix-PUFSUL16_106X_mcRun2_asymptotic_v16-v1/GEN-SIM-RECO",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T2_US_Purdue"
+    ],
+    "campaigns": [
+      "RunIIFall17FSPrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL16FSGSPremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/GEN-SIM-RECO",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_RU_JINR_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring21UL16FSGSDR",
+      "RunIISpring21UL16FSSIMDR",
+      "RunIISpring21UL16FSwmLHEGSDR",
+      "RunIIFall17FSPrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL17FSGSPremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v1/GEN-SIM-RECO",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_DE_KIT_Disk",
+      "T1_RU_JINR_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring21UL17FSSIMDR",
+      "RunIISpring21UL17FSGSDR",
+      "RunIISpring21UL17FSwmLHEGSDR",
+      "RunIIFall17FSPrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUMoriond17_94X_mc2017_realistic_v15-v1/GEN-SIM-DIGI-RAW",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T2_CH_CERN"
+    ],
+    "campaigns": [
+      "RunIIFall17FSPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_inelasticON_13TeV-pythia8/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_DE_KIT_Disk",
+      "T1_FR_CCIN2P3_Disk"
+    ],
+    "campaigns": [
+      "RunIIFall17DRStdmix",
+      "RunIISummer17PrePremix",
+      "RunIILowPUSpring18DR"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL17SIM-106X_mc2017_realistic_v6-v2/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T1_IT_CNAF_Disk"
+    ],
+    "campaigns": [
+      "RunIISummer20ULPrePremix",
+      "RunIILowPUSummer20UL17DR",
+      "RunIISummer20UL17DIGI"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIISummer16FSPremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v4-v1/GEN-SIM-DIGI-RAW",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_DE_KIT_Disk",
+      "T2_US_Purdue"
+    ],
+    "campaigns": [
+      "RunIISpring16FSSIMDRPremix",
+      "RunIISummer16FSPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL16FSGSPremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/GEN-SIM-RECO",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_RU_JINR_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring21UL16FSGSDR",
+      "RunIISpring21UL16FSSIMDR",
+      "RunIISpring21UL16FSwmLHEGSDR",
+      "RunIIFall17FSPrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL16_106X_mcRun2_asymptotic_v16-v1/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T1_ES_PIC_Disk",
+      "T1_US_FNAL_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring21UL16FSwmLHEGSPremix",
+      "RunIISpring21UL16FSGSPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T1_RU_JINR_Disk",
+      "T1_US_FNAL_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring21UL16FSwmLHEGSPremix",
+      "RunIISpring22UL16FSwmLHEGSPremix",
+      "RunIISpring21UL16FSGSPremixLLPBugFix",
+      "RunIISpring21UL16FSGSPremix",
+      "RunIISpring21UL16FSSIMDRPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T1_RU_JINR_Disk",
+      "T1_US_FNAL_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring21UL16FSwmLHEGSPremix",
+      "RunIISpring22UL16FSwmLHEGSPremix",
+      "RunIISpring21UL16FSGSPremixLLPBugFix",
+      "RunIISpring21UL16FSGSPremix",
+      "RunIISpring21UL16FSSIMDRPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL16FSGSPremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/GEN-SIM-RECO",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_RU_JINR_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring21UL16FSGSDR",
+      "RunIISpring21UL16FSSIMDR",
+      "RunIISpring21UL16FSwmLHEGSDR",
+      "RunIIFall17FSPrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T1_RU_JINR_Disk",
+      "T1_US_FNAL_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring21UL16FSwmLHEGSPremix",
+      "RunIISpring22UL16FSwmLHEGSPremix",
+      "RunIISpring21UL16FSGSPremixLLPBugFix",
+      "RunIISpring21UL16FSGSPremix",
+      "RunIISpring21UL16FSSIMDRPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL16FSGSPremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/GEN-SIM-RECO",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_RU_JINR_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring21UL16FSGSDR",
+      "RunIISpring21UL16FSSIMDR",
+      "RunIISpring21UL16FSwmLHEGSDR",
+      "RunIIFall17FSPrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL16_106X_mcRun2_asymptotic_v16-v1/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T1_ES_PIC_Disk",
+      "T1_US_FNAL_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring21UL16FSwmLHEGSPremix",
+      "RunIISpring21UL16FSGSPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T1_RU_JINR_Disk",
+      "T1_US_FNAL_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring21UL16FSwmLHEGSPremix",
+      "RunIISpring22UL16FSwmLHEGSPremix",
+      "RunIISpring21UL16FSGSPremixLLPBugFix",
+      "RunIISpring21UL16FSGSPremix",
+      "RunIISpring21UL16FSSIMDRPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/RelValFS_PREMIXUP15_PU25/CMSSW_10_6_22-PU_106X_mcRun2_asymptotic_v16_FastSim-v1/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T2_CH_CERN"
+    ],
+    "campaigns": [
+      "RunIISpring21UL16FSwmLHEGSPremixAPV"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL17FSGSPremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v1/GEN-SIM-RECO",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_DE_KIT_Disk",
+      "T1_RU_JINR_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring21UL17FSSIMDR",
+      "RunIISpring21UL17FSGSDR",
+      "RunIISpring21UL17FSwmLHEGSDR",
+      "RunIIFall17FSPrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v2/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T1_DE_KIT_Disk",
+      "T1_US_FNAL_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring22UL17FSwmLHEGSPremix",
+      "RunIISpring21UL17FSSIMDRPremix",
+      "RunIISpring21UL17FSwmLHEGSPremix",
+      "RunIISpring21UL17FSGSPremixLLPBugFix",
+      "RunIISpring21UL17FSGSPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v2/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T1_DE_KIT_Disk",
+      "T1_US_FNAL_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring22UL17FSwmLHEGSPremix",
+      "RunIISpring21UL17FSSIMDRPremix",
+      "RunIISpring21UL17FSwmLHEGSPremix",
+      "RunIISpring21UL17FSGSPremixLLPBugFix",
+      "RunIISpring21UL17FSGSPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL17FSGSPremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v1/GEN-SIM-RECO",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_DE_KIT_Disk",
+      "T1_RU_JINR_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring21UL17FSSIMDR",
+      "RunIISpring21UL17FSGSDR",
+      "RunIISpring21UL17FSwmLHEGSDR",
+      "RunIIFall17FSPrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v2/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T1_DE_KIT_Disk",
+      "T1_US_FNAL_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring22UL17FSwmLHEGSPremix",
+      "RunIISpring21UL17FSSIMDRPremix",
+      "RunIISpring21UL17FSwmLHEGSPremix",
+      "RunIISpring21UL17FSGSPremixLLPBugFix",
+      "RunIISpring21UL17FSGSPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL17FSGSPremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v1/GEN-SIM-RECO",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_DE_KIT_Disk",
+      "T1_RU_JINR_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring21UL17FSSIMDR",
+      "RunIISpring21UL17FSGSDR",
+      "RunIISpring21UL17FSwmLHEGSDR",
+      "RunIIFall17FSPrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v2/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T1_DE_KIT_Disk",
+      "T1_US_FNAL_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring22UL17FSwmLHEGSPremix",
+      "RunIISpring21UL17FSSIMDRPremix",
+      "RunIISpring21UL17FSwmLHEGSPremix",
+      "RunIISpring21UL17FSGSPremixLLPBugFix",
+      "RunIISpring21UL17FSGSPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL18FSGSPremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/GEN-SIM-RECO",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T1_RU_JINR_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring21UL18FSGSDR",
+      "RunIISpring21UL18FSSIMDR",
+      "RunIIFall17FSPrePremix",
+      "RunIISpring21UL18FSwmLHEGSDR"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T1_FR_CCIN2P3_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring21UL18FSwmLHEGSPremix",
+      "RunIISpring22UL18FSwmLHEGSPremix",
+      "RunIISpring21UL18FSGSPremixLLPBugFix",
+      "RunIISpring21UL18FSGSPremix",
+      "RunIISpring21UL18FSSIMDRPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL18_106X_upgrade2018_realistic_v16-v1/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T1_IT_CNAF_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring21UL18FSwmLHEGSPremix",
+      "RunIISpring21UL18FSGSPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T1_FR_CCIN2P3_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring21UL18FSwmLHEGSPremix",
+      "RunIISpring22UL18FSwmLHEGSPremix",
+      "RunIISpring21UL18FSGSPremixLLPBugFix",
+      "RunIISpring21UL18FSGSPremix",
+      "RunIISpring21UL18FSSIMDRPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL18FSGSPremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/GEN-SIM-RECO",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T1_RU_JINR_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring21UL18FSGSDR",
+      "RunIISpring21UL18FSSIMDR",
+      "RunIIFall17FSPrePremix",
+      "RunIISpring21UL18FSwmLHEGSDR"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T1_FR_CCIN2P3_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring21UL18FSwmLHEGSPremix",
+      "RunIISpring22UL18FSwmLHEGSPremix",
+      "RunIISpring21UL18FSGSPremixLLPBugFix",
+      "RunIISpring21UL18FSGSPremix",
+      "RunIISpring21UL18FSSIMDRPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL18FSGSPremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/GEN-SIM-RECO",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T1_RU_JINR_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring21UL18FSGSDR",
+      "RunIISpring21UL18FSSIMDR",
+      "RunIIFall17FSPrePremix",
+      "RunIISpring21UL18FSwmLHEGSDR"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T1_FR_CCIN2P3_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring21UL18FSwmLHEGSPremix",
+      "RunIISpring22UL18FSwmLHEGSPremix",
+      "RunIISpring21UL18FSGSPremixLLPBugFix",
+      "RunIISpring21UL18FSGSPremix",
+      "RunIISpring21UL18FSSIMDRPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL18_106X_upgrade2018_realistic_v16-v1/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T1_IT_CNAF_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring21UL18FSwmLHEGSPremix",
+      "RunIISpring21UL18FSGSPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T1_RU_JINR_Disk",
+      "T1_US_FNAL_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring21UL16FSwmLHEGSPremix",
+      "RunIISpring22UL16FSwmLHEGSPremix",
+      "RunIISpring21UL16FSGSPremixLLPBugFix",
+      "RunIISpring21UL16FSGSPremix",
+      "RunIISpring21UL16FSSIMDRPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v2/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T1_DE_KIT_Disk",
+      "T1_US_FNAL_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring22UL17FSwmLHEGSPremix",
+      "RunIISpring21UL17FSSIMDRPremix",
+      "RunIISpring21UL17FSwmLHEGSPremix",
+      "RunIISpring21UL17FSGSPremixLLPBugFix",
+      "RunIISpring21UL17FSGSPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T1_FR_CCIN2P3_Disk"
+    ],
+    "campaigns": [
+      "RunIISpring21UL18FSwmLHEGSPremix",
+      "RunIISpring22UL18FSwmLHEGSPremix",
+      "RunIISpring21UL18FSGSPremixLLPBugFix",
+      "RunIISpring21UL18FSGSPremix",
+      "RunIISpring21UL18FSSIMDRPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCUETP8M1_13TeV-pythia8/RunIISummer15GS-MCRUN2_71_V1_ext1-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T2_US_Nebraska"
+    ],
+    "campaigns": [
+      "RunIISummer16DR80"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T1_RU_JINR_Disk"
+    ],
+    "campaigns": [
+      "RunIISummer16DR80Premix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIISummer16FSPremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v4-v1/GEN-SIM-DIGI-RAW",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_DE_KIT_Disk",
+      "T2_US_Purdue"
+    ],
+    "campaigns": [
+      "RunIISpring16FSSIMDRPremix",
+      "RunIISummer16FSPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_14TeV-pythia8/Run3Winter20GS-110X_mcRun3_2021_realistic_v6-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_ES_PIC_Disk",
+      "T1_US_FNAL_Disk",
+      "T1_UK_RAL_Disk"
+    ],
+    "campaigns": [
+      "Run3Winter20DRMiniAOD",
+      "RunIISummer17PrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIIWinter19PFCalib17GS-105X_mc2017_realistic_v5_ext1-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_FR_CCIN2P3_Disk",
+      "T1_IT_CNAF_Disk"
+    ],
+    "campaigns": [
+      "RunIISummer17PrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_14TeV-pythia8/PhaseIITDRSpring19GS-106X_upgrade2023_realistic_v2_ext1-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T2_US_Florida"
+    ],
+    "campaigns": [
+      "RunIISummer19ULPrePremix",
+      "RunIISummer17PrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIIWinter19PFCalib16GS-105X_mcRun2_asymptotic_v2-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_FR_CCIN2P3_Disk",
+      "T2_IT_Legnaro"
+    ],
+    "campaigns": [
+      "RunIISummer17PrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIIFall18GS-102X_upgrade2018_realistic_v9-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T2_US_MIT",
+      "T2_DE_DESY"
+    ],
+    "campaigns": [
+      "RunIIAutumn18DR",
+      "RunIISummer17PrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIIWinter19PFCalib18GS-105X_upgrade2018_realistic_v4-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T2_US_Florida"
+    ],
+    "campaigns": [
+      "RunIISummer17PrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP2_13TeV-pythia8/RunIIFall17FSPremix-PUMoriond17_94X_mc2017_realistic_v11-v1/GEN-SIM-RECO",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T2_US_MIT",
+      "T2_DE_DESY"
+    ],
+    "campaigns": [
+      "RunIISummer17PrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring18GS-100X_upgrade2018_realistic_v9-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T2_DE_RWTH"
+    ],
+    "campaigns": [
+      "RunIISummer17PrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_inelasticON_13TeV-pythia8/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_DE_KIT_Disk",
+      "T1_FR_CCIN2P3_Disk"
+    ],
+    "campaigns": [
+      "RunIIFall17DRStdmix",
+      "RunIISummer17PrePremix",
+      "RunIILowPUSpring18DR"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCUETP8M1_13TeV-pythia8/RunIISummer17GS-92X_upgrade2017_realistic_v2-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T2_US_MIT",
+      "T1_IT_CNAF_Disk"
+    ],
+    "campaigns": [
+      "RunIISummer17PrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer19UL16SIM-106X_mcRun2_asymptotic_v3-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T1_UK_RAL_Disk"
+    ],
+    "campaigns": [
+      "RunIISummer19ULPrePremix",
+      "RunIISummer19UL16DIGI"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP1_13TeV-pythia8/RunIISummer19UL16SIM-106X_mcRun2_asymptotic_v10-v2/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_FR_CCIN2P3_Disk"
+    ],
+    "campaigns": [
+      "RunIISummer19UL16DIGI"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIISummer19ULPrePremix-UL17_106X_mc2017_realistic_v6-v1/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk"
+    ],
+    "campaigns": [
+      "RunIISummer19UL17DIGIPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer19UL17SIM-106X_mc2017_realistic_v3-v2/SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_UK_RAL_Disk"
+    ],
+    "campaigns": [
+      "RunIISummer19ULPrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer19UL16SIM-106X_mcRun2_asymptotic_v3-v1/SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_UK_RAL_Disk"
+    ],
+    "campaigns": [
+      "RunIISummer19ULPrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer19UL18SIM-106X_upgrade2018_realistic_v4-v1/SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T2_US_Nebraska",
+      "T1_UK_RAL_Disk"
+    ],
+    "campaigns": [
+      "RunIISummer19ULPrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer19UL16SIM-106X_mcRun2_asymptotic_v3-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T1_UK_RAL_Disk"
+    ],
+    "campaigns": [
+      "RunIISummer19ULPrePremix",
+      "RunIISummer19UL16DIGI"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_14TeV-pythia8/PhaseIITDRSpring19GS-106X_upgrade2023_realistic_v2_ext1-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T2_US_Florida"
+    ],
+    "campaigns": [
+      "RunIISummer19ULPrePremix",
+      "RunIISummer17PrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL16SIM-106X_mcRun2_asymptotic_v13-v2/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T1_IT_CNAF_Disk"
+    ],
+    "campaigns": [
+      "RunIISummer20UL16DIGI",
+      "RunIISummer20UL16DIGIAPV",
+      "RunIISummer20ULPrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL16SIM-106X_mcRun2_asymptotic_v13-v2/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T1_IT_CNAF_Disk"
+    ],
+    "campaigns": [
+      "RunIISummer20UL16DIGI",
+      "RunIISummer20UL16DIGIAPV",
+      "RunIISummer20ULPrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL16_106X_mcRun2_asymptotic_v13-v1/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T2_CH_CERN"
+    ],
+    "campaigns": [
+      "RunIISummer20UL16DIGIPremix",
+      "RunIISummer20UL16DIGIPremixAPV"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL16_106X_mcRun2_asymptotic_v13-v1/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T2_CH_CERN"
+    ],
+    "campaigns": [
+      "RunIISummer20UL16DIGIPremix",
+      "RunIISummer20UL16DIGIPremixAPV"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL17SIM-106X_mc2017_realistic_v6-v2/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T1_IT_CNAF_Disk"
+    ],
+    "campaigns": [
+      "RunIISummer20ULPrePremix",
+      "RunIILowPUSummer20UL17DR",
+      "RunIISummer20UL17DIGI"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL17_106X_mc2017_realistic_v6-v3/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T2_CH_CERN"
+    ],
+    "campaigns": [
+      "RunIISummer20UL17DIGIPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_5TeV-pythia8/RunIISummer20UL17pp5TeVGS-106X_mc2017_realistic_forppRef5TeV_v3-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T2_US_Nebraska",
+      "T2_CH_CERN",
+      "T2_DE_DESY"
+    ],
+    "campaigns": [
+      "RunIISummer20UL17pp5TeVDIGI",
+      "RunIISummer20UL17pp5TeVDR"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_5TeV-pythia8/RunIISummer20UL17pp5TeVGS-106X_mc2017_realistic_forppRef5TeV_v3-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T2_US_Nebraska",
+      "T2_CH_CERN",
+      "T2_DE_DESY"
+    ],
+    "campaigns": [
+      "RunIISummer20UL17pp5TeVDIGI",
+      "RunIISummer20UL17pp5TeVDR"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL18SIM-106X_upgrade2018_realistic_v11_L1v1-v2/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_IT_CNAF_Disk",
+      "T2_CH_CERN"
+    ],
+    "campaigns": [
+      "RunIISummer20UL18DIGI",
+      "RunIISummer20ULPrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL18_106X_upgrade2018_realistic_v11_L1v1-v2/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": [
+      "T2_CH_CERN",
+      "T1_US_FNAL_Disk",
+      "T1_IT_CNAF_Disk"
+    ],
+    "campaigns": [
+      "RunIISummer20UL18DIGIPremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL17SIM-106X_mc2017_realistic_v6-v2/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T1_IT_CNAF_Disk"
+    ],
+    "campaigns": [
+      "RunIISummer20ULPrePremix",
+      "RunIILowPUSummer20UL17DR",
+      "RunIISummer20UL17DIGI"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL18SIM-106X_upgrade2018_realistic_v11_L1v1-v2/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_IT_CNAF_Disk",
+      "T2_CH_CERN"
+    ],
+    "campaigns": [
+      "RunIISummer20UL18DIGI",
+      "RunIISummer20ULPrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL16SIM-106X_mcRun2_asymptotic_v13-v2/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_US_FNAL_Disk",
+      "T1_IT_CNAF_Disk"
+    ],
+    "campaigns": [
+      "RunIISummer20UL16DIGI",
+      "RunIISummer20UL16DIGIAPV",
+      "RunIISummer20ULPrePremix"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCUETP8M1_2017_5p02TeV-pythia8/RunIIpp5Spring18GS-94X_mc2017_realistic_v10For2017G_v3-v2/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T2_US_MIT"
+    ],
+    "campaigns": [
+      "RunIIpp5Spring18DR"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/MinBias_TuneCUETP8M1_5p02TeV-pythia8/HINppWinter17GS-92X_upgrade2017_realistic_v11-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T2_US_MIT"
+    ],
+    "campaigns": [
+      "RunIIpp5Spring18DR"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/ReggeGribovPartonMC_EposLHC_PbP_4080_4080_DataBS/pPb816Spring16GS-MB_80X_mcRun2_pA_v4-v2/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_IT_CNAF_Disk"
+    ],
+    "campaigns": [
+      "pPb816Spring16GS",
+      "pPb816Summer16DR"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/ReggeGribovPartonMC_EposLHC_pPb_4080_4080/pPb816Spring16GS-80X_mcRun2_asymptotic_v17-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T2_IT_Pisa",
+      "T1_IT_CNAF_Disk"
+    ],
+    "campaigns": [
+      "pPb816Spring16GS"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/ReggeGribovPartonMC_EposLHC_pPb_4080_4080_DataBS/pPb816Spring16GS-MB_80X_mcRun2_pA_v4-v2/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_FR_CCIN2P3_Disk",
+      "T2_US_MIT"
+    ],
+    "campaigns": [
+      "pPb816Spring16GS",
+      "pPb816Summer16DR"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/ReggeGribovPartonMC_EposLHC_PbP_4080_4080_DataBS/pPb816Spring16GS-MB_80X_mcRun2_pA_v4-v2/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_IT_CNAF_Disk"
+    ],
+    "campaigns": [
+      "pPb816Spring16GS",
+      "pPb816Summer16DR"
+    ],
+    "active": false
+  },
+  {
+    "pileupName": "/ReggeGribovPartonMC_EposLHC_pPb_4080_4080_DataBS/pPb816Spring16GS-MB_80X_mcRun2_pA_v4-v2/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": [
+      "T1_FR_CCIN2P3_Disk",
+      "T2_US_MIT"
+    ],
+    "campaigns": [
+      "pPb816Spring16GS",
+      "pPb816Summer16DR"
+    ],
+    "active": false
+  }
+]

--- a/src/python/WMCore/MicroService/DataStructs/pileups_dev.json
+++ b/src/python/WMCore/MicroService/DataStructs/pileups_dev.json
@@ -1,0 +1,37 @@
+[
+  {
+    "pileupName": "/MinBias_TuneCP5_14TeV-pythia8/PhaseIITDRSpring19GS-106X_upgrade2023_realistic_v2_ext1-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": ["T1_US_FNAL_Disk", "T2_CH_CERN"],
+    "campaigns": ["Apr2023_Val"],
+    "active": true
+  },
+  {
+    "pileupName": "/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL16_106X_mcRun2_asymptotic_v13-v1/PREMIX",
+    "pileupType": "premix",
+    "expectedRSEs": ["T2_CH_CERN"],
+    "campaigns": ["Apr2023_Val"],
+    "active": true
+  },
+  {
+    "pileupName": "/RelValMinBias_14TeV/CMSSW_10_6_1-106X_mcRun3_2021_realistic_v1_rsb-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": ["T1_US_FNAL_Disk", "T2_CH_CERN"],
+    "campaigns": ["Apr2023_Val"],
+    "active": true
+  },
+  {
+    "pileupName": "/RelValMinBias_14TeV/CMSSW_11_2_0_pre8-112X_mcRun3_2024_realistic_v10_forTrk-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": ["T2_CH_CERN"],
+    "campaigns": ["Apr2023_Val"],
+    "active": true
+  },
+  {
+    "pileupName": "/RelValMinBias_14TeV/CMSSW_12_0_0_pre4-120X_mcRun3_2021_realistic_v2-v1/GEN-SIM",
+    "pileupType": "classic",
+    "expectedRSEs": ["T2_CH_CERN"],
+    "campaigns": ["Apr2023_Val"],
+    "active": true
+  }
+]


### PR DESCRIPTION
Fixes #11522

#### Status
ready

#### Description
This script can be used to:
* parse the WMCore campaigns and construct the pileup documents
* pileup documents can be either dumped in a json file or injected into MSPileup
* read a json document as input and inject its pileup configurations into MSPileup

Second commit also provides a dump of the current pileup dataset configuration, extracted from production WMCore campaigns.

NOTE-1: by default, pileup documents will be marked as `active=false`
NOTE-2: in order to inject them into the system, you need to explicitly pass `--inject` option in.

TODO: The original issue asks for a refactoring of the campaign documents, which will be done in a later stage.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
