### PR TITLE
Final tweaks to MSPileup

### DIFF
--- a/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupTasks_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupTasks_t.py
@@ -30,6 +30,7 @@ class TestRucioClient(Client):
             self.logger = logger
         else:
             self.logger = getMSLogger(False)
+        self.rses = ['rse1', 'rse2', 'T2_XX_CERN']
         self.state = state
         self.doc = {'id': '123', 'rse_expression': 'T2_XX_CERN', 'state': self.state}
 
@@ -62,7 +63,7 @@ class TestRucioClient(Client):
 
     def list_rses(self, rseExpression):
         """Immitate get list_rses Rucio client API"""
-        for rse in ['rse1', 'rse2', 'T2_XX_CERN']:
+        for rse in self.rses:
             yield {'rse': rse}
 
     def get_rse_usage(self, rse):
@@ -74,6 +75,16 @@ class TestRucioClient(Client):
                'total': 440245583794751, 'files': 138519,
                'rse': rse}
         yield doc
+
+    def listDataRules(self, pname, **kwargs):
+        """Mock the Rucio wrapper listDataRules API"""
+        self.logger.info("%s: mocking listDataRules.", self.__class__.__name__)
+        return self.list_replication_rules(kwargs)
+
+    def evaluateRSEExpression(self, expr):
+        """Mock the Rucio wrapper evaluateRSEExpression API"""
+        self.logger.info("%s: mocking evaluateRSEExpression.", self.__class__.__name__)
+        return self.rses
 
 
 class MSPileupTasksTest(EmulatedUnitTestCase):


### PR DESCRIPTION
Fixes #11525 

#### Status
ready

#### Description
Changes so far are:
* if we fail to resolve the container size, don't preset it to 0 in the database
* fix log record syntax
* skip pileups without a valid pileup size (0 or None) in the active task
* fix data structure to receive Rucio token

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
Test services_config changes: https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/200
Preprod: https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/201
Prod: https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/202
