### PR TITLE
Add TapeRulesStatus to the alarm message && Decrease alarm severity.

### DIFF
--- a/src/python/WMCore/MicroService/MSRuleCleaner/MSRuleCleaner.py
+++ b/src/python/WMCore/MicroService/MSRuleCleaner/MSRuleCleaner.py
@@ -308,14 +308,14 @@ class MSRuleCleaner(MSCore):
             msg = "Skipping workflow: %s - 'ParentageResolved' flag set to false." % wflow['RequestName']
             msg += " Will retry again in the next cycle."
             self.logger.info(msg)
-            self.alertStatusAdvanceExpired(wflow, additionalInfo=msg)
+            self._checkStatusAdvanceExpired(wflow, additionalInfo=msg)
         elif wflow['RequestStatus'] == 'announced' and not wflow['TransferDone']:
             # NOTE: We skip workflows which have not yet finalised their TransferStatus
             #       in MSOutput, but we still need some proper logging for them.
             msg = "Skipping workflow: %s - 'TransferStatus' is 'pending' or 'TransferInfo' is missing in MSOutput." % wflow['RequestName']
             msg += " Will retry again in the next cycle."
             self.logger.info(msg)
-            self.alertStatusAdvanceExpired(wflow, additionalInfo=msg)
+            self._checkStatusAdvanceExpired(wflow, additionalInfo=msg)
         elif wflow['RequestStatus'] == 'announced' and not wflow['TransferTape']:
             # NOTE: We skip workflows which have not yet finalised their tape transfers.
             #       (i.e. even if a single output which is supposed to be covered
@@ -325,7 +325,7 @@ class MSRuleCleaner(MSCore):
             msg = "Skipping workflow: %s - tape transfers are not yet completed." % wflow['RequestName']
             msg += " Will retry again in the next cycle."
             self.logger.info(msg)
-            self.alertStatusAdvanceExpired(wflow, additionalInfo=msg)
+            self._checkStatusAdvanceExpired(wflow, additionalInfo=msg)
         elif wflow['RequestStatus'] in ['announced', 'rejected', 'aborted-completed']:
             for pline in self.cleanuplines:
                 try:
@@ -334,13 +334,13 @@ class MSRuleCleaner(MSCore):
                     msg = "%s: Parentage Resolve Error: %s. " % (pline.name, str(ex))
                     msg += "Will retry again in the next cycle."
                     self.logger.error(msg)
-                    self.alertStatusAdvanceExpired(wflow, additionalInfo=msg)
+                    self._checkStatusAdvanceExpired(wflow, additionalInfo=msg)
                     continue
                 except Exception as ex:
                     msg = "%s: General error from pipeline. Workflow: %s. Error:  \n%s. " % (pline.name, wflow['RequestName'], str(ex))
                     msg += "\nWill retry again in the next cycle."
                     self.logger.exception(msg)
-                    self.alertStatusAdvanceExpired(wflow, additionalInfo=msg)
+                    self._checkStatusAdvanceExpired(wflow, additionalInfo=msg)
                     continue
                 if wflow['CleanupStatus'][pline.name]:
                     self.wfCounters['cleaned'][pline.name] += 1
@@ -412,13 +412,14 @@ class MSRuleCleaner(MSCore):
             self.logger.error("Missing or broken status transition history for %s", wflow['RequestName'])
             return None
 
-    def _isStatusAdvanceExpired(self, wflow):
+    def _checkStatusAdvanceExpired(self, wflow, additionalInfo=""):
         """
         A method to check if a given status transition has timed out e.g. before
         an alarm being set. The timeout should be configurable and hence taken
-        from the instance attributes.
-        :param wflow:  A MSRuleCleanerWorkflow instance
-        :return:       Bool: True if status alarm time has expired False otherwise
+        from the instance attributes. Preserve any additional info inside the wflow object.
+        :param wflow:          A MSRuleCleanerWorkflow instance
+        :param additionalInfo: A string with additional info to be preserved within the workflow for later use by the alarm itself. (Default: "")
+        :return:               Bool: True if status alarm time has expired False otherwise
         """
         statusAdvanceExpired = False
         currentTime = int(time.time())
@@ -427,6 +428,9 @@ class MSRuleCleaner(MSCore):
 
         if transitionTime and (currentTime - transitionTime) > alarmThreshold:
             statusAdvanceExpired = True
+            if wflow['StatusAdvanceExpiredMsg']:
+                wflow['StatusAdvanceExpiredMsg'] += "\n"
+            wflow['StatusAdvanceExpiredMsg'] += additionalInfo
         return statusAdvanceExpired
 
     def _checkClean(self, wflow):
@@ -567,15 +571,18 @@ class MSRuleCleaner(MSCore):
         # Make all the needed checks before trying to archive
         if not (wflow['IsClean'] or wflow['ForceArchive']):
             msg = "Not properly cleaned workflow: %s" % wflow['RequestName']
-            self.alertStatusAdvanceExpired(wflow, additionalInfo=msg)
+            if self._checkStatusAdvanceExpired(wflow, additionalInfo=msg):
+                self.alertStatusAdvanceExpired(wflow)
             raise MSRuleCleanerArchivalSkip(msg)
         if not wflow['TargetStatus']:
             msg = "Could not determine which archival status to target for workflow: %s" % wflow['RequestName']
-            self.alertStatusAdvanceExpired(wflow, additionalInfo=msg)
+            if self._checkStatusAdvanceExpired(wflow, additionalInfo=msg):
+                self.alertStatusAdvanceExpired(wflow)
             raise MSRuleCleanerArchivalError(msg)
         if not wflow['IsLogDBClean']:
             msg = "LogDB records have not been cleaned for workflow: %s" % wflow['RequestName']
-            self.alertStatusAdvanceExpired(wflow, additionalInfo=msg)
+            if self._checkStatusAdvanceExpired(wflow, additionalInfo=msg):
+                self.alertStatusAdvanceExpired(wflow)
             raise MSRuleCleanerArchivalSkip(msg)
         if not wflow['IsArchivalDelayExpired']:
             msg = "Archival delay period has not yet expired for workflow: %s." % wflow['RequestName']
@@ -634,13 +641,14 @@ class MSRuleCleaner(MSCore):
             for mapRecord in transferInfo['OutputMap']:
                 if not mapRecord['TapeRuleID']:
                     continue
+
                 rucioRule = self.rucio.getRule(mapRecord['TapeRuleID'])
                 if not rucioRule:
-                    tapeRulesStatusList.append(False)
                     msg = "Tape rule: %s not found for workflow: %s "
                     msg += "Possible server side error."
                     self.logger.error(msg, mapRecord['TapeRuleID'], wflow['RequestName'])
-                    continue
+                    rucioRule = {'state': 'Missing'}
+
                 if rucioRule['state'] == 'OK':
                     tapeRulesStatusList.append(True)
                     msg = "Tape rule: %s in final state: %s for workflow: %s"
@@ -649,6 +657,9 @@ class MSRuleCleaner(MSCore):
                     tapeRulesStatusList.append(False)
                     msg = "Tape rule: %s in non final state: %s for workflow: %s"
                     self.logger.info(msg, mapRecord['TapeRuleID'], rucioRule['state'], wflow['RequestName'])
+
+                wflow['TapeRulesStatus'].append((mapRecord['TapeRuleID'], rucioRule['state'], mapRecord['Dataset']))
+
             if all(tapeRulesStatusList):
                 wflow['TransferTape'] = True
 
@@ -771,25 +782,26 @@ class MSRuleCleaner(MSCore):
         self.logger.info('  retrieved %s requests in status: %s', len(requests), reqStatus)
         return requests
 
-    def alertStatusAdvanceExpired(self, wflow, additionalInfo=None):
+    def alertStatusAdvanceExpired(self, wflow):
         """
         Send alert notifying that a workflow has spend too much time in a given status
         :param wflow: MSRuleCleanerWorkflow instance
         :additionalInfo: String with additional information.
         :return: none
         """
-        # Check if alarm threshold has expired:
-        if not self._isStatusAdvanceExpired(wflow):
-            return
         lastTransitionTime = self._getLastStatusTransitionTime(wflow)
         alertName = "{}: Not archived workflow: {}".format(self.alertServiceName, wflow['RequestName'])
-        alertSeverity = "high"
+        alertSeverity = "medium"
         alertDescription = "Found a workflow not archived since {}.".format(time.ctime(lastTransitionTime))
-        alertDescription += "\nWorkflow: {}".format(wflow['RequestName'])
+        alertDescription += "\nWorkflow: \n{}".format(pformat({wfKey: wflow[wfKey] for wfKey in ['RequestName',
+                                                                                                 'ParentageResolved',
+                                                                                                 'TransferDone',
+                                                                                                 'TransferTape',
+                                                                                                 'TapeRulesStatus']}))
         alertDescription += "\nHas exceeded the Status Advance Timeout of: {} hours".format(self.msConfig['archiveAlarmHours'])
         alertDescription += " for its current status: {}.".format(wflow['RequestStatus'])
-        if additionalInfo:
-            alertDescription += "\nAdditional info: {}".format(additionalInfo)
+        if wflow['StatusAdvanceExpiredMsg']:
+            alertDescription += "\nAdditional info: \n{}".format(wflow['StatusAdvanceExpiredMsg'])
         alertDescription += "\nActions need to be taken!"
         alertSummary = "[MSRuleCleaner] Found workflow: {} not archived since {}.".format(wflow['RequestName'], time.ctime(lastTransitionTime))
 

--- a/src/python/WMCore/MicroService/MSRuleCleaner/MSRuleCleanerWflow.py
+++ b/src/python/WMCore/MicroService/MSRuleCleaner/MSRuleCleanerWflow.py
@@ -182,6 +182,8 @@ class MSRuleCleanerWflow(dict):
                               'plineAgentBlock': False},
             "TransferDone": False  # information - returned by the MSOutput REST call.
             "TransferTape": False  # information - fetched by Rucio about tape rules completion
+            "TapeRulesStatus": [('36805b823062415c8ee60300b0e60378', 'OK', '/AToZHToLLTTbar_MA-1900_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL16RECO-106X_mcRun2_asymptotic_v13-v2/AODSIM'),
+                                ('5b75fb7503524449b0f304ea0e52f0de', 'STUCK', '/AToZHToLLTTbar_MA-1900_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM')]
             'TargetStatus': 'normal-archived' || 'rejected-achived' || 'aborted-archived',
             'ParentageResolved': Bool,
             'PlineMarkers': None,
@@ -206,6 +208,7 @@ class MSRuleCleanerWflow(dict):
             ('CleanupStatus', {}, dict),
             ('TransferDone', False, bool),
             ('TransferTape', False, bool),
+            ('TapeRulesStatus', [], list),
             ('TargetStatus', None, (bytes, str)),
             ('ParentageResolved', True, bool),
             ('PlineMarkers', None, list),
@@ -216,7 +219,8 @@ class MSRuleCleanerWflow(dict):
             ('RequestTransition', [], list),
             ('IncludeParents', False, bool),
             ('InputDataset', None, (bytes, str)),
-            ('ParentDataset', None, (bytes, str))]
+            ('ParentDataset', None, (bytes, str)),
+            ('StatusAdvanceExpiredMsg', "", str)]
 
         # NOTE: ParentageResolved is set by default to True it will be False only if:
         #       - RequestType is StepChain

--- a/test/python/WMCore_t/MicroService_t/MSRuleCleaner_t/MSRuleCleanerWflow_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSRuleCleaner_t/MSRuleCleanerWflow_t.py
@@ -31,17 +31,17 @@ class MSRuleCleanerWflowTest(unittest.TestCase):
         self.includeParentsFile = getTestFile('data/ReqMgr/requests/Static/IncludeParentsRequestDump.json')
         self.multiPUFile = getTestFile('data/ReqMgr/requests/Static/MultiPURequestDump.json')
         self.reqRecordsFile = getTestFile('data/ReqMgr/requests/Static/BatchRequestsDump.json')
-        with open(self.reqRecordsFile) as fd:
+        with open(self.reqRecordsFile, encoding="utf8") as fd:
             self.reqRecords = json.load(fd)
-        with open(self.taskChainFile) as fd:
+        with open(self.taskChainFile, encoding="utf8") as fd:
             self.taskChainReq = json.load(fd)
-        with open(self.stepChainFile) as fd:
+        with open(self.stepChainFile, encoding="utf8") as fd:
             self.stepChainReq = json.load(fd)
-        with open(self.reRecoFile) as fd:
+        with open(self.reRecoFile, encoding="utf8") as fd:
             self.reRecoReq = json.load(fd)
-        with open(self.includeParentsFile) as fd:
+        with open(self.includeParentsFile, encoding="utf8") as fd:
             self.includeParentsReq = json.load(fd)
-        with open(self.multiPUFile) as fd:
+        with open(self.multiPUFile, encoding="utf8") as fd:
             self.multiPUReq = json.load(fd)
         super(MSRuleCleanerWflowTest, self).setUp()
 
@@ -69,6 +69,8 @@ class MSRuleCleanerWflowTest(unittest.TestCase):
         self.assertEqual(wflow['IncludeParents'], False)
         self.assertEqual(wflow['InputDataset'], None)
         self.assertEqual(wflow['ParentDataset'], [])
+        self.assertEqual(wflow['TapeRulesStatus'], [])
+        self.assertEqual(wflow['StatusAdvanceExpiredMsg'], "")
 
     def testTaskChain(self):
         # Test Taskchain:
@@ -76,41 +78,43 @@ class MSRuleCleanerWflowTest(unittest.TestCase):
         expectedWflow = {'CleanupStatus': {},
                          'ForceArchive': False,
                          'IncludeParents': False,
-                         'InputDataset': u'/JetHT/Run2012C-v1/RAW',
+                         'InputDataset': '/JetHT/Run2012C-v1/RAW',
                          'IsArchivalDelayExpired': False,
                          'IsClean': False,
                          'IsLogDBClean': False,
                          'OutputDatasets': [
-                             u'/JetHT/CMSSW_7_2_0-RECODreHLT_TaskChain_LumiMask_multiRun_HG2011_Val_Todor_v1-v11/RECO',
-                             u'/JetHT/CMSSW_7_2_0-RECODreHLT_TaskChain_LumiMask_multiRun_HG2011_Val_Todor_v1-v11/DQMIO',
-                             u'/JetHT/CMSSW_7_2_0-SiStripCalMinBias-RECODreHLT_TaskChain_LumiMask_multiRun_HG2011_Val_Todor_v1-v11/ALCARECO',
-                             u'/JetHT/CMSSW_7_2_0-SiStripCalZeroBias-RECODreHLT_TaskChain_LumiMask_multiRun_HG2011_Val_Todor_v1-v11/ALCARECO',
-                             u'/JetHT/CMSSW_7_2_0-TkAlMinBias-RECODreHLT_TaskChain_LumiMask_multiRun_HG2011_Val_Todor_v1-v11/ALCARECO'],
+                             '/JetHT/CMSSW_7_2_0-RECODreHLT_TaskChain_LumiMask_multiRun_HG2011_Val_Todor_v1-v11/RECO',
+                             '/JetHT/CMSSW_7_2_0-RECODreHLT_TaskChain_LumiMask_multiRun_HG2011_Val_Todor_v1-v11/DQMIO',
+                             '/JetHT/CMSSW_7_2_0-SiStripCalMinBias-RECODreHLT_TaskChain_LumiMask_multiRun_HG2011_Val_Todor_v1-v11/ALCARECO',
+                             '/JetHT/CMSSW_7_2_0-SiStripCalZeroBias-RECODreHLT_TaskChain_LumiMask_multiRun_HG2011_Val_Todor_v1-v11/ALCARECO',
+                             '/JetHT/CMSSW_7_2_0-TkAlMinBias-RECODreHLT_TaskChain_LumiMask_multiRun_HG2011_Val_Todor_v1-v11/ALCARECO'],
                          'ParentDataset': [],
                          'ParentageResolved': True,
                          'PlineMarkers': None,
-                         'RequestName': u'TaskChain_LumiMask_multiRun_HG2011_Val_201029_112735_5891',
-                         'RequestStatus': u'announced',
-                         'RequestTransition': [{u'DN': u'',
-                                                u'Status': u'new',
-                                                u'UpdateTime': 1606723304},
-                                               {u'DN': u'', u'Status': u'assignment-approved',
-                                                u'UpdateTime': 1606723305},
-                                               {u'DN': u'', u'Status': u'assigned', u'UpdateTime': 1606723306},
-                                               {u'DN': u'', u'Status': u'staging', u'UpdateTime': 1606723461},
-                                               {u'DN': u'', u'Status': u'staged', u'UpdateTime': 1606723590},
-                                               {u'DN': u'', u'Status': u'acquired', u'UpdateTime': 1606723968},
-                                               {u'DN': u'', u'Status': u'running-open', u'UpdateTime': 1606724572},
-                                               {u'DN': u'', u'Status': u'running-closed', u'UpdateTime': 1606724573},
-                                               {u'DN': u'', u'Status': u'completed', u'UpdateTime': 1607018413},
-                                               {u'DN': u'', u'Status': u'closed-out', u'UpdateTime': 1607347706},
-                                               {u'DN': u'', u'Status': u'announced', u'UpdateTime': 1607359514}],
-                         'RequestType': u'TaskChain',
-                         'SubRequestType': u'',
+                         'RequestName': 'TaskChain_LumiMask_multiRun_HG2011_Val_201029_112735_5891',
+                         'RequestStatus': 'announced',
+                         'RequestTransition': [{'DN': '',
+                                                'Status': 'new',
+                                                'UpdateTime': 1606723304},
+                                               {'DN': '', 'Status': 'assignment-approved',
+                                                'UpdateTime': 1606723305},
+                                               {'DN': '', 'Status': 'assigned', 'UpdateTime': 1606723306},
+                                               {'DN': '', 'Status': 'staging', 'UpdateTime': 1606723461},
+                                               {'DN': '', 'Status': 'staged', 'UpdateTime': 1606723590},
+                                               {'DN': '', 'Status': 'acquired', 'UpdateTime': 1606723968},
+                                               {'DN': '', 'Status': 'running-open', 'UpdateTime': 1606724572},
+                                               {'DN': '', 'Status': 'running-closed', 'UpdateTime': 1606724573},
+                                               {'DN': '', 'Status': 'completed', 'UpdateTime': 1607018413},
+                                               {'DN': '', 'Status': 'closed-out', 'UpdateTime': 1607347706},
+                                               {'DN': '', 'Status': 'announced', 'UpdateTime': 1607359514}],
+                         'RequestType': 'TaskChain',
+                         'SubRequestType': '',
                          'RulesToClean': {},
                          'TargetStatus': None,
                          'TransferDone': False,
-                         'TransferTape': False}
+                         'TransferTape': False,
+                         'TapeRulesStatus': [],
+                         'StatusAdvanceExpiredMsg': ""}
         self.assertDictEqual(wflow, expectedWflow)
 
     def testReReco(self):
@@ -119,40 +123,42 @@ class MSRuleCleanerWflowTest(unittest.TestCase):
         expectedWflow = {'CleanupStatus': {},
                          'ForceArchive': False,
                          'IncludeParents': False,
-                         'InputDataset': u'/SingleElectron/Run2017F-v1/RAW',
+                         'InputDataset': '/SingleElectron/Run2017F-v1/RAW',
                          'IsArchivalDelayExpired': False,
                          'IsClean': False,
                          'IsLogDBClean': False,
-                         'OutputDatasets': [u'/SingleElectron/Run2017F-09Aug2019_UL2017_EcalRecovery-v1/MINIAOD',
-                                            u'/SingleElectron/Run2017F-EcalUncalWElectron-09Aug2019_UL2017_EcalRecovery-v1/ALCARECO',
-                                            u'/SingleElectron/Run2017F-EcalUncalZElectron-09Aug2019_UL2017_EcalRecovery-v1/ALCARECO',
-                                            u'/SingleElectron/Run2017F-09Aug2019_UL2017_EcalRecovery-v1/AOD',
-                                            u'/SingleElectron/Run2017F-EcalESAlign-09Aug2019_UL2017_EcalRecovery-v1/ALCARECO',
-                                            u'/SingleElectron/Run2017F-09Aug2019_UL2017_EcalRecovery-v1/DQMIO',
-                                            u'/SingleElectron/Run2017F-HcalCalIterativePhiSym-09Aug2019_UL2017_EcalRecovery-v1/ALCARECO'],
+                         'OutputDatasets': ['/SingleElectron/Run2017F-09Aug2019_UL2017_EcalRecovery-v1/MINIAOD',
+                                            '/SingleElectron/Run2017F-EcalUncalWElectron-09Aug2019_UL2017_EcalRecovery-v1/ALCARECO',
+                                            '/SingleElectron/Run2017F-EcalUncalZElectron-09Aug2019_UL2017_EcalRecovery-v1/ALCARECO',
+                                            '/SingleElectron/Run2017F-09Aug2019_UL2017_EcalRecovery-v1/AOD',
+                                            '/SingleElectron/Run2017F-EcalESAlign-09Aug2019_UL2017_EcalRecovery-v1/ALCARECO',
+                                            '/SingleElectron/Run2017F-09Aug2019_UL2017_EcalRecovery-v1/DQMIO',
+                                            '/SingleElectron/Run2017F-HcalCalIterativePhiSym-09Aug2019_UL2017_EcalRecovery-v1/ALCARECO'],
                          'ParentDataset': [],
                          'ParentageResolved': True,
                          'PlineMarkers': None,
-                         'RequestName': u'pdmvserv_Run2017F-v1_SingleElectron_09Aug2019_UL2017_EcalRecovery_200506_120455_3146',
-                         'RequestStatus': u'completed',
-                         'RequestTransition': [{u'DN': u'',
-                                                u'Status': u'new',
-                                                u'UpdateTime': 1588759495},
-                                               {u'DN': u'', u'Status': u'assignment-approved',
-                                                u'UpdateTime': 1588759500},
-                                               {u'DN': u'', u'Status': u'assigned', u'UpdateTime': 1588760963},
-                                               {u'DN': u'', u'Status': u'staging', u'UpdateTime': 1588761258},
-                                               {u'DN': u'', u'Status': u'staged', u'UpdateTime': 1588761688},
-                                               {u'DN': u'', u'Status': u'acquired', u'UpdateTime': 1588762166},
-                                               {u'DN': u'', u'Status': u'running-open', u'UpdateTime': 1588763098},
-                                               {u'DN': u'', u'Status': u'running-closed', u'UpdateTime': 1588775354},
-                                               {u'DN': u'', u'Status': u'completed', u'UpdateTime': 1589041121}],
-                         'RequestType': u'ReReco',
-                         'SubRequestType': u'',
+                         'RequestName': 'pdmvserv_Run2017F-v1_SingleElectron_09Aug2019_UL2017_EcalRecovery_200506_120455_3146',
+                         'RequestStatus': 'completed',
+                         'RequestTransition': [{'DN': '',
+                                                'Status': 'new',
+                                                'UpdateTime': 1588759495},
+                                               {'DN': '', 'Status': 'assignment-approved',
+                                                'UpdateTime': 1588759500},
+                                               {'DN': '', 'Status': 'assigned', 'UpdateTime': 1588760963},
+                                               {'DN': '', 'Status': 'staging', 'UpdateTime': 1588761258},
+                                               {'DN': '', 'Status': 'staged', 'UpdateTime': 1588761688},
+                                               {'DN': '', 'Status': 'acquired', 'UpdateTime': 1588762166},
+                                               {'DN': '', 'Status': 'running-open', 'UpdateTime': 1588763098},
+                                               {'DN': '', 'Status': 'running-closed', 'UpdateTime': 1588775354},
+                                               {'DN': '', 'Status': 'completed', 'UpdateTime': 1589041121}],
+                         'RequestType': 'ReReco',
+                         'SubRequestType': '',
                          'RulesToClean': {},
                          'TargetStatus': None,
                          'TransferDone': False,
-                         'TransferTape': False}
+                         'TransferTape': False,
+                         'TapeRulesStatus': [],
+                         'StatusAdvanceExpiredMsg': ""}
         self.assertDictEqual(wflow, expectedWflow)
 
     def testIncludeParents(self):
@@ -161,37 +167,38 @@ class MSRuleCleanerWflowTest(unittest.TestCase):
         expectedWflow = {'CleanupStatus': {},
                          'ForceArchive': False,
                          'IncludeParents': True,
-                         'InputDataset': u'/Cosmics/Commissioning2015-PromptReco-v1/RECO',
+                         'InputDataset': '/Cosmics/Commissioning2015-PromptReco-v1/RECO',
                          'IsArchivalDelayExpired': False,
                          'IsClean': False,
                          'IsLogDBClean': False,
                          'OutputDatasets': [
-                             u'/Cosmics/Integ_Test-CosmicSP-StepChain_InclParents_HG2004_Val_Privv12-v11/RAW-RECO'],
+                             '/Cosmics/Integ_Test-CosmicSP-StepChain_InclParents_HG2004_Val_Privv12-v11/RAW-RECO'],
                          'ParentDataset': [],
                          'ParentageResolved': False,
                          'PlineMarkers': None,
-                         'RequestName': u'amaltaro_StepChain_InclParents_April2020_Val_200414_120713_81',
-                         'RequestStatus': u'completed',
-                         'RequestTransition': [{u'DN': u'',
-                                                u'Status': u'new',
-                                                u'UpdateTime': 1586858833},
-                                               {u'DN': u'', u'Status': u'assignment-approved',
-                                                u'UpdateTime': 1586858834},
-                                               {u'DN': u'', u'Status': u'assigned', u'UpdateTime': 1586858835},
-                                               {u'DN': u'', u'Status': u'staging', u'UpdateTime': 1586859358},
-                                               {u'DN': u'', u'Status': u'staged', u'UpdateTime': 1586859733},
-                                               {u'DN': u'', u'Status': u'acquired', u'UpdateTime': 1586860322},
-                                               {u'DN': u'', u'Status': u'running-open', u'UpdateTime': 1586860927},
-                                               {u'DN': u'', u'Status': u'running-closed', u'UpdateTime': 1586861535},
-                                               {u'DN': u'', u'Status': u'completed', u'UpdateTime': 1586863942}],
-                         'RequestType': u'StepChain',
-                         'SubRequestType': u'',
+                         'RequestName': 'amaltaro_StepChain_InclParents_April2020_Val_200414_120713_81',
+                         'RequestStatus': 'completed',
+                         'RequestTransition': [{'DN': '',
+                                                'Status': 'new',
+                                                'UpdateTime': 1586858833},
+                                               {'DN': '', 'Status': 'assignment-approved',
+                                                'UpdateTime': 1586858834},
+                                               {'DN': '', 'Status': 'assigned', 'UpdateTime': 1586858835},
+                                               {'DN': '', 'Status': 'staging', 'UpdateTime': 1586859358},
+                                               {'DN': '', 'Status': 'staged', 'UpdateTime': 1586859733},
+                                               {'DN': '', 'Status': 'acquired', 'UpdateTime': 1586860322},
+                                               {'DN': '', 'Status': 'running-open', 'UpdateTime': 1586860927},
+                                               {'DN': '', 'Status': 'running-closed', 'UpdateTime': 1586861535},
+                                               {'DN': '', 'Status': 'completed', 'UpdateTime': 1586863942}],
+                         'RequestType': 'StepChain',
+                         'SubRequestType': '',
                          'RulesToClean': {},
                          'TargetStatus': None,
                          'TransferDone': False,
-                         'TransferTape': False}
+                         'TransferTape': False,
+                         'TapeRulesStatus': [],
+                         'StatusAdvanceExpiredMsg': ""}
         self.assertDictEqual(wflow, expectedWflow)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/WMCore_t/MicroService_t/MSRuleCleaner_t/MSRuleCleaner_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSRuleCleaner_t/MSRuleCleaner_t.py
@@ -88,7 +88,7 @@ class MSRuleCleanerTest(unittest.TestCase):
 
     def testIsStatusAdvanceExpired(self):
         wflow = MSRuleCleanerWflow(self.taskChainReq)
-        self.assertTrue(self.msRuleCleaner._isStatusAdvanceExpired(wflow))
+        self.assertTrue(self.msRuleCleaner._checkStatusAdvanceExpired(wflow))
 
     def testPipelineAgentBlock(self):
         # Test plineAgentBlock:
@@ -129,7 +129,9 @@ class MSRuleCleanerTest(unittest.TestCase):
                          'RulesToClean': {'plineAgentBlock': []},
                          'TargetStatus': None,
                          'TransferDone': False,
-                         'TransferTape': False}
+                         'TransferTape': False,
+                         'TapeRulesStatus': [],
+                         'StatusAdvanceExpiredMsg': ""}
         self.assertDictEqual(wflow, expectedWflow)
 
     def testPipelineAgentCont(self):
@@ -171,7 +173,9 @@ class MSRuleCleanerTest(unittest.TestCase):
                          'RulesToClean': {'plineAgentCont': []},
                          'TargetStatus': None,
                          'TransferDone': False,
-                         'TransferTape': False}
+                         'TransferTape': False,
+                         'TapeRulesStatus': [],
+                         'StatusAdvanceExpiredMsg': ""}
         self.assertDictEqual(wflow, expectedWflow)
 
     def testPipelineMSTrBlock(self):
@@ -215,7 +219,9 @@ class MSRuleCleanerTest(unittest.TestCase):
                          'RulesToClean': {'plineMSTrBlock': []},
                          'TargetStatus': None,
                          'TransferDone': False,
-                         'TransferTape': False}
+                         'TransferTape': False,
+                         'TapeRulesStatus': [],
+                         'StatusAdvanceExpiredMsg': ""}
         self.assertDictEqual(wflow, expectedWflow)
 
     def testPipelineMSTrCont(self):
@@ -259,7 +265,9 @@ class MSRuleCleanerTest(unittest.TestCase):
                          'RulesToClean': {'plineMSTrCont': []},
                          'TargetStatus': None,
                          'TransferDone': False,
-                         'TransferTape': False}
+                         'TransferTape': False,
+                         'TapeRulesStatus': [],
+                         'StatusAdvanceExpiredMsg': ""}
         self.assertDictEqual(wflow, expectedWflow)
 
     def testPipelineArchive(self):
@@ -315,7 +323,9 @@ class MSRuleCleanerTest(unittest.TestCase):
                          'RulesToClean': {'plineAgentBlock': [], 'plineAgentCont': []},
                          'TargetStatus': 'normal-archived',
                          'TransferDone': False,
-                         'TransferTape': False}
+                         'TransferTape': False,
+                         'TapeRulesStatus': [],
+                         'StatusAdvanceExpiredMsg': "Not properly cleaned workflow: TaskChain_LumiMask_multiRun_HG2011_Val_201029_112735_5891"}
         self.assertDictEqual(wflow, expectedWflow)
 
         # Try archival of an uncleaned workflow


### PR DESCRIPTION
Fixes #11456 

#### Status
ready

#### Description
With the current PR we are decreasing the alarm severity for all workflows stuck in the system unarchived for more than a month and we also add the list of `TapeRulesStatus` and the flag `ParentageResolved` to the alarm message, because those are the two most probable reasons for getting a workflow stuck into the system.   

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None 

#### External dependencies / deployment changes
No