### PR TITLE
Fix clean-up query

### DIFF
--- a/src/python/WMCore/MicroService/MSPileup/MSPileupData.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupData.py
@@ -224,7 +224,6 @@ class MSPileupData():
             return results
 
         for doc in self.dbColl.find(spec, projection):
-            doc = stripKeys(doc, ['_id'])
             results.append(doc)
         return results
 

--- a/src/python/WMCore/MicroService/MSPileup/MSPileupTasks.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupTasks.py
@@ -88,7 +88,7 @@ class MSPileupTasks():
         for doc in docs:
             if not doc['ruleIds'] and not doc['currentRSEs'] and \
                     doc['deactivatedOn'] + seconds > time.time():
-                spec = {'_id': doc['_id']}
+                spec = {'pileupName': doc['pileupName']}
                 self.logger.info("Cleanup task delete pileup %s", doc['pileupName'])
                 self.mgr.deletePileup(spec)
                 deleteDocs += 1


### PR DESCRIPTION

Fixes #11525 

#### Status
ready

#### Description
Do not strip anything from MSPileup docs when fetching them and use pileupName for query in clean-up task

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs

#### External dependencies / deployment changes
