### PR TITLE
Fix issue with broken authentication of users in REST module

### DIFF
--- a/test/python/WMCore_t/MicroService_t/MSCore_t/MSAuth_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSCore_t/MSAuth_t.py
@@ -29,9 +29,9 @@ class MSAuthTest(unittest.TestCase):
         # REST/Auth.py module calculates checksum based on provided hmac
         # for instnace for self.hmac we will expect self.chkSum
         # with all CMS headers we setup below
-        # d357b299194ec4bed4e4fc73fc9ceab10139c16f vs. 4311773080ea12f4ea31a096da49de105083bb9e
-        self.hmac = 'd357b299194ec4bed4e4fc73fc9ceab10139c16f'
-        self.chkSum = '4311773080ea12f4ea31a096da49de105083bb9e'
+        # ERROR: authz hmac mismatch, 169d02b96265caf05894b526f99a22549dcd38ed vs. d357b299194ec4bed4e4fc73fc9ceab10139c16f
+        self.hmac = '169d02b96265caf05894b526f99a22549dcd38ed'
+        self.chkSum = 'd357b299194ec4bed4e4fc73fc9ceab10139c16f'
         self.fname = '/tmp/ms-authz.json'
 
         # for testing purposes we need to setup cherrypy headers

--- a/test/python/WMCore_t/REST_t/RestAuth_t.py
+++ b/test/python/WMCore_t/REST_t/RestAuth_t.py
@@ -1,0 +1,83 @@
+"""
+Unit tests for REST/Auth.py module
+Author: Valentin Kuznetsov <vkuznet [AT] gmail [DOT] com>
+"""
+
+# system modules
+import logging
+import unittest
+
+# third party modules
+import cherrypy
+
+# WMCore modules
+from WMCore.REST.Auth import user_info_from_headers
+
+
+class RESTAuthTest(unittest.TestCase):
+    "Unit test for RESTAuth module"
+
+    def setUp(self):
+        """
+        setup necessary data for unit test usage
+        """
+        self.logger = logging.getLogger('rest_auth')
+
+        # REST/Auth.py module calculates checksum based on provided hmac
+        # for instnace for self.hmac we will expect self.chkSum
+        # with all CMS headers
+
+        # let's create set of different conditions
+        self.user_groups = []
+        self.hmacs = []
+        self.chkSums = []
+
+        # for group:users group:admin
+        user_groups = 'group:users group:admin'
+        hmac = '169d02b96265caf05894b526f99a22549dcd38ed'
+        chkSum = 'd357b299194ec4bed4e4fc73fc9ceab10139c16f'
+        self.user_groups.append(user_groups)
+        self.hmacs.append(hmac)
+        self.chkSums.append(chkSum)
+
+        # let's reverse order of user groups
+        user_groups = 'group:admin group:users'
+        self.user_groups.append(user_groups)
+        self.hmacs.append(hmac)
+        self.chkSums.append(chkSum)
+
+        # for group:admin group:users iam_group:test site:T1_XX_YYYY
+        user_groups = 'group:admin group:users iam_group:test site:T1_XX_YYYY'
+        hmac = '57ea0f58134aa079972da30a8fc2bf81853c949b'
+        chkSum = 'd357b299194ec4bed4e4fc73fc9ceab1013'
+        self.user_groups.append(user_groups)
+        self.hmacs.append(hmac)
+        self.chkSums.append(chkSum)
+
+    def testRESTAuth(self):
+        "test RESTAuth methods"
+        for idx in range(len(self.user_groups)):
+            user_groups = self.user_groups[idx]
+            hmac = self.hmacs[idx]
+            chkSum = self.chkSums[idx]
+
+            # for testing purposes we need to setup cherrypy headers
+            # cms-auth-status, cms-authn, cms-authz, cms-authn-hmac, cms-authn-name, cms-authn-dn
+            cherrypy.request.headers = {
+                'cms-auth-status': 'OK',
+                'cms-authn': 'fake',
+                'cms-authz-user': user_groups,
+                'cms-authn-hmac': hmac,
+                'cms-authn-name': 'test',
+                'cms-authn-dn': 'dn'}
+
+            authzKey = bytes(chkSum, 'UTF-8')
+            user = user_info_from_headers(key=authzKey)
+            self.logger.info(f"user_groups {user_groups}")
+            self.logger.info(f"hmac {hmac}")
+            self.logger.info(f"chkSum {chkSum}")
+            self.logger.info(f"user {user}")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #11495 

#### Status
ready

#### Description
Provide robust implementation for calculating checksum based on sorted list of groups. Also, account for new groups if they will be added into CRIC system. In other words, new code can handle any set of groups, e.g. group:user or iam_group:test or site:T1_XX_YYYY or their combination or any other group.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs

#### External dependencies / deployment changes
