### PR TITLE
Fix a typo in the XMLParser

### DIFF
--- a/src/python/WMCore/FwkJobReport/XMLParser.py
+++ b/src/python/WMCore/FwkJobReport/XMLParser.py
@@ -455,7 +455,7 @@ def perfStoreHandler():
                           storageValues.get("Timing-tstoragefile-read-numOperations", 0)
             readCachOps = storageValues.get("Timing-tstoragefile-readViaCache-numSuccessfulOperations", 0) / \
                           storageValues.get("Timing-tstoragefile-read-numOperations", 0)
-            readTotalT = storageValues.get("Timing-tstoragefile-read-totalMSecs", 0) / 1000
+            readTotalT = storageValues.get("Timing-tstoragefile-read-totalMsecs", 0) / 1000
             readNOps = storageValues.get("Timing-tstoragefile-read-numOperations", 0)
             writeTime = storageValues.get("Timing-tstoragefile-write-totalMsecs", 0) / 1000
             writeTotMB = storageValues.get("Timing-%s-write-totalMegabytes" % writeMethod, 0) \


### PR DESCRIPTION
Fixes #11531 

#### Status
ready

#### Description
Fixing a typo which is causing the following metric to be missing at the Job report:
```
    <Metric Name="Timing-tstoragefile-read-totalMsecs" Value="268.996"/>        
```
\* the value is taken from a random job

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None