### PR TITLE
Remove _id attribute from pileup mongo objects

### DIFF
--- a/src/python/WMCore/MicroService/MSPileup/MSPileupData.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupData.py
@@ -224,6 +224,7 @@ class MSPileupData():
             return results
 
         for doc in self.dbColl.find(spec, projection):
+            doc = stripKeys(doc, ['_id'])
             results.append(doc)
         return results
 


### PR DESCRIPTION
Fixes #11525 

#### Status
ready

#### Description
It looks like the MongoDB `_id` attribute is not JSON serializable, meaning that we fail to serve pileup objects through the REST API in a JSON format.
This PR adds back the `stripKeys()` call that was in place before, such that `_id` is removed from each document before being served back to the client.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Actually fixing a bug inserted with: https://github.com/dmwm/WMCore/pull/11529

#### External dependencies / deployment changes
None
