### PR TITLE
Fixing racing conditions in unit tests using CouchDB

### DIFF
--- a/src/python/WMQuality/TestInitCouchApp.py
+++ b/src/python/WMQuality/TestInitCouchApp.py
@@ -18,6 +18,7 @@ standard_library.install_aliases()
 
 import os
 import urllib.parse
+import logging
 
 from couchapp.commands import push as couchapppush
 from WMCore.Database.CMSCouch import CouchServer
@@ -33,37 +34,59 @@ class CouchAppTestHarness(object):
 
     """
 
-    def __init__(self, dbName, couchUrl=None):
+    def __init__(self, couchUrl=None, testClassName=None):
         self.couchUrl = os.environ.get("COUCHURL", couchUrl)
-        self.dbName = dbName
         if self.couchUrl == None:
             msg = "COUCHRURL env var not set..."
             raise RuntimeError(msg)
         if self.couchUrl.endswith('/'):
             raise RuntimeError("COUCHURL env var shouldn't end with /")
         self.couchServer = CouchServer(self.couchUrl)
+        self.testClassName = testClassName
+        self.logger = logging.getLogger()
 
-    def create(self, dropExistingDb=True):
-        """create couch db instance"""
+    def create(self, dbName, dropExistingDb=True):
+        """
+        create couch db instance
+
+        :param dbName: database name to create
+        :param dropExistingDb: flag to drop existing database name if it exists
+        """
         # import pdb
         # pdb.set_trace()
-        if self.dbName in self.couchServer.listDatabases():
+        databases = self.couchServer.listDatabases()
+        msg = f"Create {dbName} in {self.couchUrl}, existing DBs={databases}"
+        self.logger.info(msg)
+        if dbName in databases:
             if not dropExistingDb:
                 return
-            self.drop()
+            self.drop(dbName)
 
-        self.couchServer.createDatabase(self.dbName)
+        self.couchServer.createDatabase(dbName)
 
-    def drop(self):
-        """blow away the couch db instance"""
-        self.couchServer.deleteDatabase(self.dbName)
-
-    def pushCouchapps(self, *couchappdirs):
+    def drop(self, dbName):
         """
-        push a list of couchapps to the database
+        drop given database name from CouchDB
+
+        :param dbName: database name
+        """
+        databases = self.couchServer.listDatabases()
+        msg = f"Drop {dbName} in {self.couchUrl}, existing DBs={databases}"
+        self.logger.info(msg)
+        if dbName in databases:
+            self.couchServer.deleteDatabase(dbName)
+
+    def pushCouchapps(self, dbName, *couchappdirs):
+        """
+        push a list of couchapps to the given database
+
+        :param dbName: database name
+        :param couchappdirs: list of couch applications
         """
         for couchappdir in couchappdirs:
-            couchapppush(couchappdir, "%s/%s" % (self.couchUrl, urllib.parse.quote_plus(self.dbName)))
+            msg = f"Push {couchappdir} in {self.couchUrl} database {dbName}"
+            self.logger.info(msg)
+            couchapppush(couchappdir, "%s/%s" % (self.couchUrl, urllib.parse.quote_plus(dbName)))
 
 
 class TestInitCouchApp(TestInit):
@@ -74,14 +97,20 @@ class TestInitCouchApp(TestInit):
     def __init__(self, testClassName, dropExistingDb=True):
         TestInit.__init__(self, testClassName)
         self.databases = []
-        self.couch = None
+        self.couch = CouchAppTestHarness(testClassName=testClassName)
         # for experiments, after tests run, it's useful to have CouchDB
         # populated with the testing data - having tearDownCouch commented
         # out, this flag prevents from re-initializing the database
         self.dropExistingDb = dropExistingDb
+        self.couchUrl = self.couch.couchUrl
+        self.couchDbName = "Not set yet"
 
     def couchAppRoot(self, couchapp):
-        """Return parent path containing couchapp"""
+        """
+        Return parent path containing couchapp
+
+        :param couchapp: couch application to use
+        """
         wmcoreroot = os.path.normpath(os.path.join(self.init.getWMBASE(), '..', '..', '..'))
         develPath = os.path.join(self.init.getWMBASE(), "src", "couchapps")
         if os.path.exists(os.path.join(develPath, couchapp)):
@@ -98,16 +127,25 @@ class TestInitCouchApp(TestInit):
 
         Call in the setUp of your test to build a couch instance with the dbname provided
         and the required list of couchapps from WMCore/src/couchapps
+
+        :param dbName: database name
+        :param *couchapps: list of couch apps associated with given database
         """
-        self.databases.append(dbName)
-        self.couch = CouchAppTestHarness(dbName)
-        self.couch.create(dropExistingDb=self.dropExistingDb)
+        # this function performs two set of actions:
+        # 1. it creates given dbName
+        # 2. it registter given set of couchapps in that DB
+        # since those are independent operations we separate them here to avoid
+        # racing conditions on multiple setupCouch() calls with the same dbName but different apps, e.g.
+        # see test/python/WMCore_t/WMSpec_t/StdSpecs_t/Resubmission_t.py
+        #     self.testInit.setupCouch("resubmission_t", "ReqMgr")
+        #     self.testInit.setupCouch("resubmission_t", "ConfigCache")
+        if dbName not in self.databases:
+            self.databases.append(dbName)
+            self.couch.create(dbName, dropExistingDb=self.dropExistingDb)
         # just create the db is couchapps are not specified
         if len(couchapps) > 0:
-            self.couch.pushCouchapps(*[os.path.join(self.couchAppRoot(couchapp), couchapp) for couchapp in couchapps])
-
-    couchUrl = property(lambda x: x.couch.couchUrl)
-    couchDbName = property(lambda x: x.couch.dbName)
+            self.couch.pushCouchapps(dbName, *[os.path.join(self.couchAppRoot(couchapp), couchapp) for couchapp in couchapps])
+        self.couchDbName = dbName
 
     def tearDownCouch(self):
         """
@@ -116,8 +154,4 @@ class TestInitCouchApp(TestInit):
         call this in tearDown to erase all evidence of your couch misdemeanours
         """
         for database in self.databases:
-            couch = CouchAppTestHarness(database)
-            couch.drop()
-
-        self.couch = None
-        return
+            self.couch.drop(database)


### PR DESCRIPTION
Fixes #11194 

#### Status
ready

#### Description
I was able to confirm racing conditions when I created unique database names. For that I used `makeUUID()` function to append to provided `dbName` and I found that single unit tests can create the same database multiple times. Upon further investigation of codebase I found that `setupCouch` method of `TestInitCouchApp` class combine two actions: the database creation and uploading couch apps to it. This cause an issue with subsequent calls of this function in unit tests. I provided concrete example in this PR.

I provided code refactoring which fixes racing conditions in WMCore test using CouchDB. I transformed `CouchAppTestHarness` to be database stateless class and adjusted the code which creates or drops CouchDBs.

I also modernize the code which includes:
- update of docstrings
- proper logging
- adding `testClassName` to logging with explicit `dbName`  and existing CouchDB `databases`

I run several times the unit tests and so far did not observe racing conditions, but I did saw other unstable tests.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs

#### External dependencies / deployment changes
