### PR TITLE
Set rseList for RelVal workflows

### DIFF
--- a/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
+++ b/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
@@ -411,6 +411,9 @@ class MSTransferor(MSCore):
             if not isRelVal(wflow.data):
                 # enforce RSE quota
                 rses = list(set(rseList) & self.rseQuotas.getAvailableRSEs())
+            else:
+                rses = rseList
+
             if not rses:
                 msg = f"Workflow: {wflow.getName()} could have data placed at: {rseList}, "
                 msg += "but those are all out of quota. Skipping it till next cycle"


### PR DESCRIPTION
Fixes #11541 

#### Status
ready

#### Description
Always calling  `_getValidSites` method for RelVal workflows from inside `_makeTransferRequest` fixes the problem with the `Unbound local variable` exception for RelVals with input data.

I did test  it by directly patching one of the pods in testbed and the result is: [1], in contrast to what it was before [2]  
[1]
```
2023-04-12 13:38:01,642:INFO:MSTransferor: RelVal workflow '***_TC_PY3_Data_LumiList_Apr2023_Val_Val_230407_165853_5503' ignores sites out of quota
2023-04-12 13:38:01,642:INFO:MSTransferor: Creating rule for workflow ***_TC_PY3_Data_LumiList_Apr2023_Val_Val_230407_165853_5503 with 1 DIDs in container /DoubleMuon/Run2018D-v1/RAW, RSEs: T2_CH_CERN|T1_US_FNAL_Disk, grouping: ALL
2023-04-12 13:38:01,736:WARNING:Rucio: Resolving duplicate rules and separating every DID in a new rule...
2023-04-12 13:38:01,795:WARNING:Rucio: Found duplicate rule for account: wmcore_transferor
, rseExp: T2_CH_CERN|T1_US_FNAL_Disk
dids: [{'scope': 'cms', 'name': '/DoubleMuon/Run2018D-v1/RAW#93e06ee0-b249-4e73-8fe2-040c2b85461c'}]
2023-04-12 13:38:01,815:INFO:MSTransferor: Rules successful created for /DoubleMuon/Run2018D-v1/RAW : ['43802556ae134347b5df53f012bcaf96']
2023-04-12 13:38:01,816:INFO:MSTransferor: Transfer requests successful for ***_TC_PY3_Data_LumiList_Apr2023_Val_Val_230407_165853_5503. Summary: [{'campaignName': 'RelVal_Generic_Campaign',
  'completion': [0.0],
  'dataType': 'primary',
  'dataset': '/DoubleMuon/Run2018D-v1/RAW',
  'transferIDs': ['43802556ae134347b5df53f012bcaf96']}]

```

[2]
```
2023-04-12 13:27:51,715:INFO:MSTransferor: Handling data subscriptions for request: *****_TC_PY3_Data_LumiList_Apr2023_Val_Val_230407_165853_5503
2023-04-12 13:27:51,719:ERROR:MSTransferor: 	Error: local variable 'rses' referenced before assignment
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/WMCore/MicroService/MSTransferor/MSTransferor.py", line 214, in execute
    success, transfers = self.makeTransferRequest(wflow, rseList)
  File "/usr/local/lib/python3.8/site-packages/WMCore/MicroService/MSTransferor/MSTransferor.py", line 414, in makeTransferRequest
    if not rses:
UnboundLocalError: local variable 'rses' referenced before assignment
```

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None