### PR TITLE
Make MSPileupTasks log more friendly and start tracking already existent rules

### DIFF
--- a/src/python/WMCore/MicroService/MSPileup/MSPileupTaskManager.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupTaskManager.py
@@ -16,6 +16,7 @@ In particular, it perform the following tasks each polling cycle:
 from threading import current_thread
 
 # WMCore modules
+from Utils.Timers import CodeTimer
 from WMCore.MicroService.MSCore.MSCore import MSCore
 from WMCore.MicroService.DataStructs.DefaultStructs import PILEUP_REPORT
 from WMCore.MicroService.MSPileup.MSPileupData import MSPileupData
@@ -58,9 +59,15 @@ class MSPileupTaskManager(MSCore):
         """
         execute MSPileupTasks polling cycle
         """
-        self.mgr.pileupSizeTask()
-        self.mgr.monitoringTask()
-        self.mgr.activeTask(marginSpace=self.marginSpace)
-        self.mgr.inactiveTask()
-        self.mgr.cleanupTask(self.cleanupDaysThreshold)
-        self.mgr.cmsMonitTask()
+        with CodeTimer("### pileupSizeTask", logger=self.logger):
+            self.mgr.pileupSizeTask()
+        with CodeTimer("### monitoringTask", logger=self.logger):
+            self.mgr.monitoringTask()
+        with CodeTimer("### activeTask", logger=self.logger):
+            self.mgr.activeTask(marginSpace=self.marginSpace)
+        with CodeTimer("### inactiveTask", logger=self.logger):
+            self.mgr.inactiveTask()
+        with CodeTimer("### cleanupTask", logger=self.logger):
+            self.mgr.cleanupTask(self.cleanupDaysThreshold)
+        with CodeTimer("### cmsMonitTask", logger=self.logger):
+            self.mgr.cmsMonitTask()

--- a/src/python/WMCore/MicroService/MSPileup/MSPileupTasks.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupTasks.py
@@ -42,11 +42,14 @@ class MSPileupTasks():
         self.rucioClient = rucioClient
         self.report = MSPileupReport()
         self.dryRun = dryRun
+        if dryRun:
+            self.logger.info("MSPileupTasks is set to DRY-RUN mode!")
 
     def pileupSizeTask(self):
         """
         Execute pileup size update task
         """
+        self.logger.info("====> Executing pileupSizeTask method...")
         try:
             # get pileup sizes and update them in DB
             spec = {}
@@ -81,6 +84,7 @@ class MSPileupTasks():
 
         :param timeThreshold: time threshold in days which will determine document clean-up readiness
         """
+        self.logger.info("====> Executing cleanupTask method...")
         spec = {'active': False}
         docs = self.mgr.getPileup(spec)
         deleteDocs = 0
@@ -102,10 +106,10 @@ class MSPileupTasks():
         2. Flatten all docs
         3. Submit flatten docs to CMS MONIT
         """
+        self.logger.info("====> Executing cmsMonitTask method...")
         if not self.monitManager.userAMQ or not self.monitManager.passAMQ:
             self.logger.info("MSPileupMonitoring has no AMQ credentials, will skip the upload to MONIT")
             return
-        startTime = time.time()
         spec = {}
         msPileupDocs = self.mgr.getPileup(spec)
         docs = []
@@ -113,18 +117,15 @@ class MSPileupTasks():
             for flatDoc in flatDocuments(doc):
                 docs.append(flatDoc)
         results = self.monitManager.uploadToAMQ(docs)
-        endTime = time.time()
-        elapsedTime = endTime - startTime
         if results and isinstance(results, dict):
             success = results['success']
             failures = results['failures']
             msg = f"MSPileup CMS MONIT task fetched {len(msPileupDocs)} docs from MSPileup backend DB"
             msg += f", and sent {len(docs)} flatten docs to MONIT"
             msg += f", number of success docs {success} and failures {failures},"
-            msg += " in %.2f secs" % elapsedTime
             self.logger.info(msg)
         else:
-            self.logger.error("MSPileup CMS MONIT task failed, execution time %.2f secs", elapsedTime)
+            self.logger.error("MSPileup CMS MONIT task failed!")
 
     def monitoringTask(self):
         """
@@ -139,6 +140,7 @@ class MSPileupTasks():
         3. now that all the known rules have been inspected, persist the up-to-date
         pileup doc in MongoDB
         """
+        self.logger.info("====> Executing monitoringTask method...")
         spec = {'active': True}
         docs = self.mgr.getPileup(spec)
         taskSpec = self.getTaskSpec()
@@ -167,6 +169,7 @@ class MSPileupTasks():
         4. once all the relevant rules have been removed, persist an up-to-date
         version of the pileup data structure in MongoDB
         """
+        self.logger.info("====> Executing inactiveTask method...")
         spec = {'active': False}
         docs = self.mgr.getPileup(spec)
         taskSpec = self.getTaskSpec()
@@ -208,6 +211,7 @@ class MSPileupTasks():
         or if there was any changes to the pileup object,
         persist an up-to-date version of the pileup data structure in MongoDB
         """
+        self.logger.info("====> Executing activeTask method...")
         spec = {'active': True}
         docs = self.mgr.getPileup(spec)
         taskSpec = self.getTaskSpec()
@@ -400,6 +404,8 @@ def activeTask(doc, spec):
                     # upon successful rule deletion, also remove the RSE name from currentRSEs
                     if not dryRun:
                         rucioClient.deleteRule(rid)
+                    else:
+                        logger.info(f"DRY-RUN: rule id '{rid}' should have been deleted.")
                     if rse in doc['currentRSEs']:
                         doc['currentRSEs'].remove(rse)
                         modify = True
@@ -437,9 +443,12 @@ def activeTask(doc, spec):
                 msg = f"active task {uuid}, for dids {dids} there is enough space at RSE {rse}"
                 logger.warning(msg)
                 # create the rule and append the rule id to ruleIds
-                if dryRun:
+                if not dryRun:
+                    rids = rucioClient.createReplicationRule(pname, rse, **kwargs)
+                else:
+                    msg = f"DRY-RUN: rule for pileup {pname} and rse {rse} should have been created"
+                    logger.info(msg)
                     continue
-                rids = rucioClient.createReplicationRule(pname, rse, **kwargs)
                 # add new ruleId to document ruleIds
                 for rid in rids:
                     if rid not in doc['ruleIds']:

--- a/src/python/WMCore/MicroService/MSPileup/MSPileupTasks.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupTasks.py
@@ -287,6 +287,14 @@ def monitoringTask(doc, spec):
                     msg = f"delete rse {rse} from currentRSEs"
                     report.addEntry('monitoring', uuid, msg)
 
+        # now keep track of this rule id in the pileup document
+        for rse in rses:
+            if rse in doc['expectedRSEs'] and rid not in doc['ruleIds']:
+                logger.info(f"Tracking rule id {rid} that was not created by MSPileup")
+                doc['ruleIds'].append(rid)
+                modify = True
+                break
+
     # persist an up-to-date version of the pileup data structure in MongoDB
     if modify:
         logger.info(f"monitoring task {uuid}, update {pname}")


### PR DESCRIPTION
Fixes #11544 

#### Status
ready

#### Description
First commit is simply making the MSPileupTasks logs more readable, such that we can easily spot which task is being executed and also have a clear message of what should have happened if the service was not in dry-run mode.

Second commit actually tracks relevant rules created by an external source, appending them to the pileup document `ruleIds` field.

Third commit actually fixes a bug in the `inactiveTask`, which would delete a Rucio rule even in `dryRun` mode(!) The dryRun mode option was added to the pileup document deletion as well (in the cleanup task)

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
