### PR TITLE
MSPileup: fix logic for deleting old inactive pileup documents

### DIFF
--- a/src/python/WMCore/MicroService/MSPileup/MSPileupTasks.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupTasks.py
@@ -91,7 +91,7 @@ class MSPileupTasks():
         seconds = cleanupDaysThreshold * 24 * 60 * 60  # convert to second
         for doc in docs:
             if not doc['ruleIds'] and not doc['currentRSEs'] and \
-                    doc['deactivatedOn'] + seconds > time.time():
+                    time.time() > doc['deactivatedOn'] + seconds:
                 spec = {'pileupName': doc['pileupName']}
                 if not self.dryRun:
                     self.logger.info("Cleanup task deleting pileup %s", doc['pileupName'])


### PR DESCRIPTION
Fixes #11547 

#### Status
ready

#### Description
Only delete old inactive pileup documents in MongoDB if they have been deactivated (active=false) more than X days ago, where the production configuration defines X as:
```
data.cleanupDaysThreshold = 60
```

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
