### PR TITLE
Couple pileup activatedOn/deactivatedOn to its active state change

### DIFF
--- a/src/python/WMCore/MicroService/MSPileup/MSPileupData.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupData.py
@@ -45,6 +45,21 @@ def stripKeys(docs, skeys=None):
     return docs
 
 
+def getNewTimestamp(doc):
+    """
+    Given a pileup doc - or a subset of it - return a dictionary
+    with a couple timestamp attributes that need to be updated.
+    :param doc: a python dictionary representing the pileup information
+    :return: a python dictionary to update the pileup object
+    """
+    subDoc = {'lastUpdateTime': gmtimeSeconds()}
+    if "active" in doc and doc['active'] is True:
+        subDoc['activatedOn'] = gmtimeSeconds()
+    elif "active" in doc and doc['active'] is False:
+        subDoc['deactivatedOn'] = gmtimeSeconds()
+    return subDoc
+
+
 class MSPileupData():
     """
     MSPileupData provides logic behind data used and stored by MSPileup module
@@ -164,7 +179,8 @@ class MSPileupData():
                 self.logger.error(err)
                 return [err.error()]
 
-        doc['lastUpdateTime'] = gmtimeSeconds()
+        # mandatory timestamp updates
+        doc.update(getNewTimestamp(doc))
         # we do not need to create MSPileupObj and validate it since our doc comes directly from DB
         try:
             self.dbColl.update_one(spec, {"$set": doc})


### PR DESCRIPTION
Fixes #11546 

#### Status
not-tested

#### Description
This PR provides an extra feature to the pileup update function, such that it also updates the relevant timestamp - either activatedOn or deactivatedOn - whenever a pileup object gets its `active` state updated, such as:
* if pileup is set to `active=True`, then update the `activatedOn` timestamp; else
* if pileup is set to `active=False`, then update the `deactivatedOn` timestamp

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
