### PR TITLE
Fix manage path in the restartComponent script

### DIFF
--- a/deploy/deploy-wmagent.sh
+++ b/deploy/deploy-wmagent.sh
@@ -24,7 +24,7 @@
 ### Usage:               -n <agent_number> Agent number to be set when more than 1 agent connected to the same team (defaults to 0)
 ### Usage:
 ### Usage: deploy-wmagent.sh -w <wma_version> -t <team_name> [-s <scram_arch>] [-r <repository>] [-n <agent_number>]
-### Usage: Example: sh deploy-wmagent.sh -w 2.1.6.1 -t production -n 30
+### Usage: Example: sh deploy-wmagent.sh -w 2.2.0.4 -t production -n 30
 ### Usage: Example: sh deploy-wmagent.sh -w 2.1.4-b954b0745339a347ea28afd5b5767db4 -t testbed-vocms001 -p "11001" -r comp=comp.amaltaro
 ### Usage:
 
@@ -427,7 +427,7 @@ else
   echo "55 */6 * * * /data/admin/wmagent/renew_proxy.sh"
   echo "58 */12 * * * python /data/admin/wmagent/checkProxy.py --proxy /data/certs/myproxy.pem --time 150 --send-mail True --mail alan.malta@cern.ch"
   echo "#workaround for the ErrorHandler silence issue"
-  echo "*/15 * * * *  /data/admin/wmagent/restartComponent.sh > /dev/null"
+  echo "*/15 * * * *  /data/admin/wmagent/restartComponent.sh ErrorHandler JobSubmitter AgentStatusWatcher > /dev/null"
   ) | crontab -
 fi
 echo "Done!" && echo

--- a/deploy/restartComponent.sh
+++ b/deploy/restartComponent.sh
@@ -1,18 +1,22 @@
 #!/bin/sh
+## Pass the component names as command line arguments, e.g.:
+## ./restartComponent.sh ErrorHandler JobSubmitter AgentStatusWatcher
 
 HOST=`hostname`
 DATENOW=`date +%s`
 
+# Get a few environment variables in, like $install and $manage
+source /data/admin/wmagent/env.sh
+
 # Figure whether it's a python2 or python3 agent
-if [ -d "/data/srv/wmagent/current/install/wmagent" ]; then
-  WMA_PATH="/data/srv/wmagent/current/install/wmagent"
-else
-  WMA_PATH="/data/srv/wmagent/current/install/wmagentpy3"
+if [ ! -d "$install" ]; then
+  install="/data/srv/wmagent/current/install/wmagentpy3"
 fi
 
-COMPONENTS="ErrorHandler JobSubmitter AgentStatusWatcher"
-for comp in $COMPONENTS; do
-  COMPLOG=$WMA_PATH/$comp/ComponentLog
+echo "List of components to be monitored: $@"
+for comp in $@; do
+  COMPLOG=$install/$comp/ComponentLog
+  echo "Checking logs from: $COMPLOG"
   LASTCHANGE=`stat -c %Y $COMPLOG`
   INTERVAL=`expr $DATENOW - $LASTCHANGE`
   if (("$INTERVAL" >= 1800)); then
@@ -22,9 +26,8 @@ for comp in $COMPONENTS; do
       exit 1
     fi
 
-    . /data/admin/wmagent/env.sh
     TAIL_LOG=`tail -n100 $COMPLOG`
-    $WMA_PATH/manage execute-agent wmcoreD --restart --components=$comp
+    $manage execute-agent wmcoreD --restart --components=$comp
     echo -e "ComponentLog quiet for $INTERVAL secs\n\nTail of the log is:\n$TAIL_LOG" |
       mail -s "$HOST : $comp restarted" alan.malta@cern.ch,todor.trendafilov.ivanov@cern.ch
   fi


### PR DESCRIPTION
Fixes #11492 
Superseeds https://github.com/dmwm/WMCore/pull/11493

#### Status
ready

#### Description
Instead of redefining variables to be used in this script, just use those already defined in the `env.sh` script.
Fix the `$install` variable if needed (artifact from python2 vs python3 WMAgent).

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
