### PR TITLE
Remove postToAMQ (post_to_amq) and fix typo in doc_type_amq

### DIFF
--- a/src/python/WMCore/MicroService/MSPileup/MSPileupMonitoring.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupMonitoring.py
@@ -57,9 +57,8 @@ class MSPileupMonitoring():
         """
         self.userAMQ = msConfig.get('user_amq', None)
         self.passAMQ = msConfig.get('pass_amq', None)
-        self.postToAMQ = msConfig.get('post_to_amq', False)
         self.topicAMQ = msConfig.get('topic_amq', None)
-        self.docTypeAMQ = msConfig.get('doc_type_amg', 'cms-ms-pileup')
+        self.docTypeAMQ = msConfig.get('doc_type_amq', 'cms-ms-pileup')
         self.hostPortAMQ = msConfig.get('host_port_amq', None)
         self.producer = msConfig.get('producer', 'cms-ms-pileup')
         self.logger = msConfig.get('logger', getMSLogger(False))
@@ -103,7 +102,7 @@ class MSPileupMonitoring():
             msg = "%i out of %i documents successfully sent to AMQ" % (len(notifications) - len(failures),
                                                                        len(notifications))
             self.logger.info(msg)
-            return {"success": len(notifications)-len(failures), "failures": len(failures)}
+            return {"success": len(notifications) - len(failures), "failures": len(failures)}
         except Exception as ex:
             self.logger.exception("Failed to send data to StompAMQ. Error %s", str(ex))
         return {}


### PR DESCRIPTION
Fixes https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/214
Related to https://github.com/dmwm/WMCore/issues/11429

#### Status
ready

#### Description
Removed `post_to_amq` configuration parameter and local variable `postToAMQ` since they are not used in a code and fixed typo `doc_to_amg` to `doc_to_amq` which is used in MSPIleup configuration.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
<If it's a follow up work; or porting a fix from a different branch, please mention them here.>

#### External dependencies / deployment changes
<Does it require deployment changes? Does it rely on third-party libraries?>
