### PR TITLE
Bundle of WMAgent patches for WMAgent 2.2.0.x

### DIFF
--- a/deploy/deploy-wmagent.sh
+++ b/deploy/deploy-wmagent.sh
@@ -24,7 +24,7 @@
 ### Usage:               -n <agent_number> Agent number to be set when more than 1 agent connected to the same team (defaults to 0)
 ### Usage:
 ### Usage: deploy-wmagent.sh -w <wma_version> -t <team_name> [-s <scram_arch>] [-r <repository>] [-n <agent_number>]
-### Usage: Example: sh deploy-wmagent.sh -w 2.1.6.1 -t production -n 30
+### Usage: Example: sh deploy-wmagent.sh -w 2.2.0.4 -t production -n 30
 ### Usage: Example: sh deploy-wmagent.sh -w 2.1.4-b954b0745339a347ea28afd5b5767db4 -t testbed-vocms001 -p "11001" -r comp=comp.amaltaro
 ### Usage:
 
@@ -427,7 +427,7 @@ else
   echo "55 */6 * * * /data/admin/wmagent/renew_proxy.sh"
   echo "58 */12 * * * python /data/admin/wmagent/checkProxy.py --proxy /data/certs/myproxy.pem --time 150 --send-mail True --mail alan.malta@cern.ch"
   echo "#workaround for the ErrorHandler silence issue"
-  echo "*/15 * * * *  /data/admin/wmagent/restartComponent.sh > /dev/null"
+  echo "*/15 * * * *  /data/admin/wmagent/restartComponent.sh ErrorHandler JobSubmitter AgentStatusWatcher > /dev/null"
   ) | crontab -
 fi
 echo "Done!" && echo

--- a/deploy/restartComponent.sh
+++ b/deploy/restartComponent.sh
@@ -1,18 +1,22 @@
 #!/bin/sh
+## Pass the component names as command line arguments, e.g.:
+## ./restartComponent.sh ErrorHandler JobSubmitter AgentStatusWatcher
 
 HOST=`hostname`
 DATENOW=`date +%s`
 
+# Get a few environment variables in, like $install and $manage
+source /data/admin/wmagent/env.sh
+
 # Figure whether it's a python2 or python3 agent
-if [ -d "/data/srv/wmagent/current/install/wmagent" ]; then
-  WMA_PATH="/data/srv/wmagent/current/install/wmagent"
-else
-  WMA_PATH="/data/srv/wmagent/current/install/wmagentpy3"
+if [ ! -d "$install" ]; then
+  install="/data/srv/wmagent/current/install/wmagentpy3"
 fi
 
-COMPONENTS="ErrorHandler JobSubmitter AgentStatusWatcher"
-for comp in $COMPONENTS; do
-  COMPLOG=$WMA_PATH/$comp/ComponentLog
+echo "List of components to be monitored: $@"
+for comp in $@; do
+  COMPLOG=$install/$comp/ComponentLog
+  echo "Checking logs from: $COMPLOG"
   LASTCHANGE=`stat -c %Y $COMPLOG`
   INTERVAL=`expr $DATENOW - $LASTCHANGE`
   if (("$INTERVAL" >= 1800)); then
@@ -22,9 +26,8 @@ for comp in $COMPONENTS; do
       exit 1
     fi
 
-    . /data/admin/wmagent/env.sh
     TAIL_LOG=`tail -n100 $COMPLOG`
-    $WMA_PATH/manage execute-agent wmcoreD --restart --components=$comp
+    $manage execute-agent wmcoreD --restart --components=$comp
     echo -e "ComponentLog quiet for $INTERVAL secs\n\nTail of the log is:\n$TAIL_LOG" |
       mail -s "$HOST : $comp restarted" alan.malta@cern.ch,todor.trendafilov.ivanov@cern.ch
   fi

--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -99,6 +99,12 @@ config.JobStateMachine.couchurl = couchURL
 config.JobStateMachine.couchDBName = jobDumpDBName
 config.JobStateMachine.jobSummaryDBName = jobSummaryDBName
 config.JobStateMachine.summaryStatsDBName = summaryStatsDBName
+# Amount of documents allowed in the ChangeState module for bulk commits
+config.JobStateMachine.maxBulkCommitDocs = 250
+# total allowed serialized size for the FJR document that is uploaded to wmagent_jobdump/fwjrs
+# NOTE: this needs to be in sync with CouchDB couchdb.max_document_size parameter
+# see: https://docs.couchdb.org/en/latest/config/couchdb.html#couchdb/max_document_size
+config.JobStateMachine.fwjrLimitSize = 8 * 1000**2  # default: 8 million bytes (not 8MB!!!)
 
 config.section_("ACDC")
 config.ACDC.couchurl = "https://cmsweb.cern.ch/couchdb"

--- a/src/python/WMCore/MicroService/MSPileup/MSPileupMonitoring.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupMonitoring.py
@@ -57,9 +57,8 @@ class MSPileupMonitoring():
         """
         self.userAMQ = msConfig.get('user_amq', None)
         self.passAMQ = msConfig.get('pass_amq', None)
-        self.postToAMQ = msConfig.get('post_to_amq', False)
         self.topicAMQ = msConfig.get('topic_amq', None)
-        self.docTypeAMQ = msConfig.get('doc_type_amg', 'cms-ms-pileup')
+        self.docTypeAMQ = msConfig.get('doc_type_amq', 'cms-ms-pileup')
         self.hostPortAMQ = msConfig.get('host_port_amq', None)
         self.producer = msConfig.get('producer', 'cms-ms-pileup')
         self.logger = msConfig.get('logger', getMSLogger(False))
@@ -103,7 +102,7 @@ class MSPileupMonitoring():
             msg = "%i out of %i documents successfully sent to AMQ" % (len(notifications) - len(failures),
                                                                        len(notifications))
             self.logger.info(msg)
-            return {"success": len(notifications)-len(failures), "failures": len(failures)}
+            return {"success": len(notifications) - len(failures), "failures": len(failures)}
         except Exception as ex:
             self.logger.exception("Failed to send data to StompAMQ. Error %s", str(ex))
         return {}


### PR DESCRIPTION
Backport of the following PRs for `2.2.0.2_wmagent` branch:
* Remove postToAMQ (post_to_amq) and fix typo in doc_type_amq #11573 
* Fix manage path in the restartComponent script #11572 
* Add new CMSCouch exception for Request Entity Too Large #11502 