### PR TITLE
MSPileup: detect active containers with no wmcore_transferor rules

### DIFF
--- a/src/python/WMCore/MicroService/MSPileup/MSPileupTasks.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupTasks.py
@@ -256,6 +256,15 @@ def monitoringTask(doc, spec):
     rules = rucioClient.listDataRules(pname, **kwargs)
     modify = False
 
+    if not rules:
+        logger.info(f"Did not find any wmcore_transferor rules for container: {pname}.")
+        if not doc['expectedRSEs']:
+            logger.warning(f"Container: {pname} is active but has no expected RSEs.")
+        elif doc['currentRSEs'] or doc['ruleIds']:
+            doc['currentRSEs'].clear()
+            doc['ruleIds'].clear()
+            modify = True
+
     for rdoc in rules:
         rses = rucioClient.evaluateRSEExpression(rdoc['rse_expression'])
         rid = rdoc['id']


### PR DESCRIPTION
Fixes #11578

#### Status
not-tested

#### Description
Adds support to a specific use case in the `monitoringTask` task of the MSPileup, such that if a container is active but it has no `wmcore_transferor` rules, we will catch this case and update the pileup document accordingly, such that other tasks can properly act on it instead of leaving it in a stale state.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
