### PR TITLE
Add GPU support to the StepChain spec

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Templates/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Templates/CMSSW.py
@@ -408,6 +408,16 @@ class CMSSWStepHelper(CoreHelper):
         self.data.application.gpu.gpuRequired = requiresGPU
         self.data.application.gpu.gpuRequirements = gpuParams
 
+    def getGPUSettings(self):
+        """
+        Return the GPU configuration for this CMSSW step
+        :return: a tuple with:
+          * string whether GPU is required or not
+          * dictionary with the GPU requirements (or None)
+        """
+        return (self.data.application.gpu.gpuRequired,
+                self.data.application.gpu.gpuRequirements)
+
 
 class CMSSW(Template):
     """

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
@@ -5,6 +5,8 @@ _StepChain_t_
 """
 from __future__ import print_function
 
+import json
+
 from future.utils import viewitems, listvalues
 
 from builtins import range
@@ -2417,6 +2419,163 @@ class StepChainTests(EmulatedUnitTestCase):
         factory = StepChainWorkloadFactory()
         with self.assertRaises(WMSpecFactoryException):
             factory.factoryWorkloadConstruction("TestWorkload", arguments)
+
+    def testGPUStepChains(self):
+        """
+        Test GPU support in StepChains, top level settings only
+        """
+        testArguments = StepChainWorkloadFactory.getTestArguments()
+        testArguments.update(deepcopy(REQUEST))
+
+        configDocs = injectStepChainConfigMC(self.configDatabase)
+        for s in ['Step1', 'Step2', 'Step3']:
+            testArguments[s]['ConfigCacheID'] = configDocs[s]
+        testArguments['Step2']['KeepOutput'] = False
+
+        factory = StepChainWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
+        self.assertIsNone(testArguments['RequiresGPU'])
+        self.assertEqual(testArguments['GPUParams'], json.dumps(None))
+        for stepKey in ['Step1', 'Step2', 'Step3']:
+            self.assertTrue("RequiresGPU" not in testArguments[stepKey])
+            self.assertTrue("GPUParams" not in testArguments[stepKey])
+
+        for taskName in testWorkload.listAllTaskNames():
+            taskObj = testWorkload.getTaskByName(taskName)
+            for stepName in taskObj.listAllStepNames():
+                stepHelper = taskObj.getStepHelper(stepName)
+                if stepHelper.stepType() == "CMSSW":
+                    self.assertEqual(stepHelper.data.application.gpu.gpuRequired, "forbidden")
+                    self.assertIsNone(stepHelper.data.application.gpu.gpuRequirements)
+                else:
+                    self.assertFalse(hasattr(stepHelper.data.application, "gpu"))
+
+        # test assignment with wrong Trust flags
+        assignDict = {"SiteWhitelist": ["T2_US_Nebraska"], "Team": "The-A-Team",
+                      "RequestStatus": "assigned"}
+        testWorkload.updateArguments(assignDict)
+
+        self.assertIsNone(testArguments['RequiresGPU'])
+        self.assertEqual(testArguments['GPUParams'], json.dumps(None))
+        for stepKey in ['Step1', 'Step2', 'Step3']:
+            self.assertTrue("RequiresGPU" not in testArguments[stepKey])
+            self.assertTrue("GPUParams" not in testArguments[stepKey])
+
+        for taskName in testWorkload.listAllTaskNames():
+            taskObj = testWorkload.getTaskByName(taskName)
+            for stepName in taskObj.listAllStepNames():
+                stepHelper = taskObj.getStepHelper(stepName)
+                if stepHelper.stepType() == "CMSSW":
+                    self.assertEqual(stepHelper.data.application.gpu.gpuRequired, "forbidden")
+                    self.assertIsNone(stepHelper.data.application.gpu.gpuRequirements)
+                else:
+                    self.assertFalse(hasattr(stepHelper.data.application, "gpu"))
+
+        # last but not least, test a failing case
+        testArguments['RequiresGPU'] = "required"
+        testArguments['GPUParams'] = json.dumps(None)
+        with self.assertRaises(WMSpecFactoryException):
+            factory.factoryWorkloadConstruction("PullingTheChain", testArguments)
+
+    def testGPUStepChainsTasks(self):
+        """
+        Test GPU support in StepChains, with task-level settings
+        """
+        testArguments = StepChainWorkloadFactory.getTestArguments()
+        testArguments.update(deepcopy(REQUEST))
+
+        configDocs = injectStepChainConfigMC(self.configDatabase)
+        for s in ['Step1', 'Step2', 'Step3']:
+            testArguments[s]['ConfigCacheID'] = configDocs[s]
+        testArguments['Step2']['KeepOutput'] = False
+
+        gpuParams = {"GPUMemoryMB": 1234, "CUDARuntime": "11.2.3", "CUDACapabilities": ["7.5", "8.0"]}
+        testArguments['Step1'].update({"RequiresGPU": "optional", "GPUParams": json.dumps(gpuParams)})
+        testArguments['Step2'].update({"RequiresGPU": "required", "GPUParams": json.dumps(gpuParams)})
+        factory = StepChainWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
+
+        # validate requires GPU
+        self.assertIsNone(testArguments['RequiresGPU'])
+        self.assertEqual(testArguments["Step1"]['RequiresGPU'], "optional")
+        self.assertEqual(testArguments["Step2"]['RequiresGPU'], "required")
+        self.assertTrue("RequiresGPU" not in testArguments["Step3"])
+
+        # validate GPU parameters
+        self.assertEqual(testArguments['GPUParams'], json.dumps(None))
+        self.assertEqual(testArguments["Step1"]['GPUParams'], json.dumps(gpuParams))
+        self.assertEqual(testArguments["Step2"]['GPUParams'], json.dumps(gpuParams))
+        self.assertTrue("GPUParams" not in testArguments["Step3"])
+
+        for taskName in testWorkload.listAllTaskNames():
+            taskObj = testWorkload.getTaskByName(taskName)
+            for stepName in taskObj.listAllStepNames():
+                stepHelper = taskObj.getStepHelper(stepName)
+                if taskObj.taskType() in ["Merge", "Harvesting", "Cleanup", "LogCollect"]:
+                    if stepHelper.stepType() == "CMSSW":
+                        self.assertEqual(stepHelper.data.application.gpu.gpuRequired, "forbidden")
+                        self.assertIsNone(stepHelper.data.application.gpu.gpuRequirements)
+                    else:
+                        self.assertFalse(hasattr(stepHelper.data.application, "gpu"))
+                elif stepHelper.stepType() == "CMSSW" and taskName == "GENSIM":
+                    if stepHelper.name() == "cmsRun1":
+                        self.assertEqual(stepHelper.data.application.gpu.gpuRequired, testArguments["Step1"]['RequiresGPU'])
+                        self.assertItemsEqual(stepHelper.data.application.gpu.gpuRequirements, gpuParams)
+                    elif stepHelper.name() == "cmsRun2":
+                        self.assertEqual(stepHelper.data.application.gpu.gpuRequired, testArguments["Step2"]['RequiresGPU'])
+                        self.assertItemsEqual(stepHelper.data.application.gpu.gpuRequirements, gpuParams)
+                    elif stepHelper.name() == "cmsRun3":
+                        self.assertEqual(stepHelper.data.application.gpu.gpuRequired, "forbidden")
+                        self.assertIsNone(stepHelper.data.application.gpu.gpuRequirements)
+                elif stepHelper.stepType() == "CMSSW":
+                    raise RuntimeError("Should not reach this code")
+                else:
+                    self.assertFalse(hasattr(stepHelper.data.application, "gpu"))
+
+        prodTask = testWorkload.getTask('GENSIM')
+        gpuRequired, gpuRequirements = prodTask.getStepHelper('cmsRun1').getGPUSettings()
+        self.assertEqual(gpuRequired, testArguments["Step1"]['RequiresGPU'])
+        self.assertItemsEqual(gpuRequirements, gpuParams)
+
+        gpuRequired, gpuRequirements = prodTask.getStepHelper('cmsRun2').getGPUSettings()
+        self.assertEqual(gpuRequired, testArguments["Step2"]['RequiresGPU'])
+        self.assertItemsEqual(gpuRequirements, gpuParams)
+
+        gpuRequired, gpuRequirements = prodTask.getStepHelper('cmsRun3').getGPUSettings()
+        self.assertEqual(gpuRequired, testArguments["Step3"].get('RequiresGPU', "forbidden"))
+        self.assertIsNone(gpuRequirements)
+
+
+
+        # test assignment with wrong Trust flags
+        assignDict = {"SiteWhitelist": ["T2_US_Nebraska"], "Team": "The-A-Team",
+                      "RequestStatus": "assigned"}
+        testWorkload.updateArguments(assignDict)
+
+        # validate requires GPU
+        self.assertIsNone(testArguments['RequiresGPU'])
+        self.assertEqual(testArguments["Step1"]['RequiresGPU'], "optional")
+        self.assertEqual(testArguments["Step2"]['RequiresGPU'], "required")
+        self.assertTrue("RequiresGPU" not in testArguments["Step3"])
+
+        # validate GPU parameters
+        self.assertEqual(testArguments['GPUParams'], json.dumps(None))
+        self.assertEqual(testArguments["Step1"]['GPUParams'], json.dumps(gpuParams))
+        self.assertEqual(testArguments["Step2"]['GPUParams'], json.dumps(gpuParams))
+        self.assertTrue("GPUParams" not in testArguments["Step3"])
+
+        prodTask = testWorkload.getTask('GENSIM')
+        gpuRequired, gpuRequirements = prodTask.getStepHelper('cmsRun1').getGPUSettings()
+        self.assertEqual(gpuRequired, testArguments["Step1"]['RequiresGPU'])
+        self.assertItemsEqual(gpuRequirements, gpuParams)
+
+        gpuRequired, gpuRequirements = prodTask.getStepHelper('cmsRun2').getGPUSettings()
+        self.assertEqual(gpuRequired, testArguments["Step2"]['RequiresGPU'])
+        self.assertItemsEqual(gpuRequirements, gpuParams)
+
+        gpuRequired, gpuRequirements = prodTask.getStepHelper('cmsRun3').getGPUSettings()
+        self.assertEqual(gpuRequired, testArguments["Step3"].get('RequiresGPU', "forbidden"))
+        self.assertIsNone(gpuRequirements)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #10401 

#### Status
ready

#### Description
With this PR we will be able to execute StepChain GPU workflows. A few important remarks about this PR are:
* configuration parameters are supported at Step level (similar to TaskChain).
* jobs will request GPUs based on this logic: https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/WMSpec/WMTask.py#L1500 (hence, if any step requires GPU, the whole job will require it!)
* we assume that the GPU parameters will be the same if multiple steps can use - or need to - GPUs. In other words, saying that Step1 requires CUDARuntime A while Step2 requires CUDARuntime B is not supported. 

#### Is it backward compatible (if not, which system it affects?)
NO (new feature)

#### Related PRs
Definition of parameters and supported values are provided in this very first GH issue: https://github.com/dmwm/WMCore/issues/10388

#### External dependencies / deployment changes
Even though it is a Request Manager change, I suspect that WMAgent will need to have the relevant WMTask/WMStep/CMSSW changes in.
