### PR TITLE
Gracefully parse cpu performance metrics in SummaryDB

### DIFF
--- a/src/python/WMCore/JobStateMachine/SummaryDB.py
+++ b/src/python/WMCore/JobStateMachine/SummaryDB.py
@@ -83,12 +83,13 @@ def fwjr_parser(doc):
                             cmsRunCPUPerformance=pdict)
         if key.startswith('cmsRun'):
             perf = val['performance']
-            pdict['totalJobCPU'] += float(perf['cpu']['TotalJobCPU'])
-            pdict['totalJobTime'] += float(perf['cpu']['TotalJobTime'])
+            perf.setdefault('cpu', {})
+            pdict['totalJobCPU'] += float(perf['cpu'].get('TotalJobCPU', 0))
+            pdict['totalJobTime'] += float(perf['cpu'].get('TotalJobTime', 0))
             if 'TotalEventCPU' in perf['cpu']:
                 pdict['totalEventCPU'] += float(perf['cpu']['TotalEventCPU'])
             else:
-                pdict['totalEventCPU'] += float(perf['cpu']['TotalLoopCPU'])
+                pdict['totalEventCPU'] += float(perf['cpu'].get('TotalLoopCPU', 0))
 
             odict = val['output']
             for kkk, vvv in viewitems(odict):


### PR DESCRIPTION
Fixes #11275 

#### Status
not-tested

#### Description
After re-discussing this issue with German, we concluded that there are 2 scenarios where we miss job information in WMStats:
1) for FJR documents that are too large (larger than the configured CouchDB limit)
2) when parsing FJR metrics for jobs that didn't generate one (for instance, jobs hitting seg fault)

This PR is supposed to fix the 2) issue, dealing with dictionaries in a safe way.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
