### PR TITLE
Fix missing sub level areas of packages in the wmc-database module

### DIFF
--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -36,7 +36,7 @@ dependencies = {
         'systems': ['wmc-base']
     },
     'wmc-database': {
-        'packages': ['WMCore.Wrappers+', 'WMCore.GroupUser', 'WMCore.DataStructs', 'WMCore.Database',
+        'packages': ['WMCore.Wrappers+', 'WMCore.GroupUser', 'WMCore.DataStructs+', 'WMCore.Database+',
                      'WMCore.Algorithms', 'WMCore.Services'],
         'modules': ['WMCore.WMConnectionBase', 'WMCore.DAOFactory', 'WMCore.WMInit'],
         'systems': ['wmc-base']


### PR DESCRIPTION
Fixes #11591 

#### Status
ready

#### Description
With the current PR we are fixing the missing sub level areas of the `wmc-database` package. We start including everything under the packages' directories recursively.   

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
