### PR TITLE
Make ResourceControlUpdater to continuously update PNNs in the database

### DIFF
--- a/bin/wmagent-resource-control
+++ b/bin/wmagent-resource-control
@@ -207,7 +207,7 @@ def updateSiteInfo(resourceControl, siteName, pendingSlots=None,
     Add a site to the resource control database if it doesn't exist.  Update
     information about sites in the database if it already exists.
     """
-    if resourceControl.listSiteInfo(siteName) is None:
+    if not resourceControl.listSiteInfo(siteName):
         if pendingSlots is None or runningSlots is None or ceName is None or pnn is None or plugin is None:
             print("You must specify the number of pending or running slots, the SE name,")
             print("the CE name and a plugin when adding a site.")
@@ -257,7 +257,7 @@ def updateThresholdInfo(resourceControl, siteName, taskType, maxSlots=None, pend
 
     Add or update a task threshold in the database.
     """
-    if resourceControl.listSiteInfo(siteName) is None:
+    if not resourceControl.listSiteInfo(siteName):
         print("You must add the site to the database before you can add")
         print("thresholds.")
         print("Type --help for more information.")
@@ -294,7 +294,7 @@ def setSiteState(resourceControl, siteName, state):
 
     Set an specific state to a site
     """
-    if resourceControl.listSiteInfo(siteName) is None:
+    if not resourceControl.listSiteInfo(siteName):
         print("You must add the site to the database before you can change its state")
         print("Type --help for more information.")
         sys.exit(1)

--- a/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
+++ b/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
@@ -246,21 +246,21 @@ class ResourceControlUpdater(BaseWorkerThread):
         ssbSiteSlots = {}
         for site in infoCpu:
             if infoCpu[site]['core_cpu_intensive'] is None:
-                logging.warn('Site %s has invalid CPU thresholds in SSB. Taking no action', site)
+                logging.warning('Site %s has invalid CPU thresholds in SSB. Taking no action', site)
             else:
                 ssbSiteSlots[site] = {'slotsCPU': int(infoCpu[site]['core_cpu_intensive'])}
 
         # then iterate over the IO slots
         for site in infoIo:
             if infoIo[site]['core_io_intensive'] is None:
-                logging.warn('Site %s has invalid IO thresholds in SSB. Taking no action', site)
+                logging.warning('Site %s has invalid IO thresholds in SSB. Taking no action', site)
             else:
                 ssbSiteSlots[site]['slotsIO'] = int(infoIo[site]['core_io_intensive'])
 
         # Before proceeding, remove sites without both metrics
         for site in list(ssbSiteSlots):
             if len(ssbSiteSlots[site]) != 2:
-                logging.warn("Site: %s has incomplete SSB metrics, see %s", site, ssbSiteSlots[site])
+                logging.warning("Site: %s has incomplete SSB metrics, see %s", site, ssbSiteSlots[site])
                 ssbSiteSlots.pop(site)
 
         return ssbSiteSlots

--- a/src/python/WMCore/ResourceControl/ResourceControl.py
+++ b/src/python/WMCore/ResourceControl/ResourceControl.py
@@ -114,28 +114,18 @@ class ResourceControl(WMConnectionBase):
                                      transaction=self.existingTransaction())
         return results
 
-    def listSiteInfo(self, siteName):
+    def listSiteInfo(self, siteName=None):
         """
-        _listSiteInfo_
-
         List the site name, SE name, CE name, pending and running slots,
         plugin, cms name and state for a given site.
+        :param siteName: a string with the site name
+        :return: a list of dictionaries with site information
         """
         listAction = self.wmbsDAOFactory(classname="Locations.GetSiteInfo")
         results = listAction.execute(siteName=siteName,
                                      conn=self.getDBConn(),
                                      transaction=self.existingTransaction())
-        if len(results) == 0:
-            return None
-
-        # We get a row back for every single SE.  Return a single dict with a
-        # list in the SE field.
-        pnns = []
-        for result in results:
-            pnns.append(result["pnn"])
-
-        results[0]["pnn"] = pnns
-        return results[0]
+        return results
 
     def changeTaskPriority(self, taskType, priority):
         """

--- a/src/python/WMCore/WMBS/MySQL/Locations/GetSiteInfo.py
+++ b/src/python/WMCore/WMBS/MySQL/Locations/GetSiteInfo.py
@@ -29,4 +29,31 @@ class GetSiteInfo(DBFormatter):
             sql = self.sql + " WHERE wl.site_name = :site"
             results = self.dbi.processData(sql, {'site': siteName},
                                        conn=conn, transaction=transaction)
-        return self.formatDict(results)
+        return self.format(results)
+
+    def format(self, result):
+        """
+        Format the DB results in a plain list of dictionaries, with one
+        dictionary for each site name, thus with a list of PNNs.
+        :param result: DBResult object
+        :return: a list of dictionaries
+        """
+        # first create a dictionary to make key look-up easier
+        resp = {}
+        for thisItem in DBFormatter.format(self, result):
+            # note that each item has 7 columns returned from the database
+            siteName = thisItem[0]
+            resp.setdefault(siteName, dict())
+            siteInfo = resp[siteName]
+            siteInfo['site_name'] = siteName
+            siteInfo.setdefault('pnn', [])
+            if thisItem[1] not in siteInfo['pnn']:
+                siteInfo['pnn'].append(thisItem[1])
+            siteInfo['ce_name'] = thisItem[2]
+            siteInfo['pending_slots'] = thisItem[3]
+            siteInfo['running_slots'] = thisItem[4]
+            siteInfo['plugin'] = thisItem[5]
+            siteInfo['cms_name'] = thisItem[6]
+            siteInfo['state'] = thisItem[7]
+        # now return a flat list of dictionaries
+        return list(resp.values())

--- a/src/python/WMCore/WorkQueue/WMBSHelper.py
+++ b/src/python/WMCore/WorkQueue/WMBSHelper.py
@@ -364,8 +364,7 @@ class WMBSHelper(WMConnectionBase):
         siteInfo = self.getLocationInfo.execute(conn=self.getDBConn(),
                                                 transaction=self.existingTransaction())
         for site in siteInfo:
-            if site['pnn'] in self.commonLocation:
-                locations.add(site['pnn'])
+            locations.update(set(site['pnn']) & set(self.commonLocation))
 
         if not locations:
             msg = 'No locations to inject Monte Carlo work to, unable to proceed'

--- a/src/python/WMQuality/Emulators/EmulatedUnitTestCase.py
+++ b/src/python/WMQuality/Emulators/EmulatedUnitTestCase.py
@@ -103,7 +103,8 @@ class EmulatedUnitTestCase(unittest.TestCase):
             patchCRICAt = ['WMCore.ReqMgr.Tools.cms.CRIC',
                            'WMCore.WorkQueue.WorkQueue.CRIC',
                            'WMCore.WorkQueue.WorkQueueUtils.CRIC',
-                           'WMCore.WorkQueue.Policy.Start.StartPolicyInterface.CRIC']
+                           'WMCore.WorkQueue.Policy.Start.StartPolicyInterface.CRIC',
+                           'WMComponent.AgentStatusWatcher.ResourceControlUpdater.CRIC']
             for module in patchCRICAt:
                 self.cricPatchers.append(mock.patch(module, new=MockCRICApi))
                 self.cricPatchers[-1].start()

--- a/test/python/WMCore_t/ResourceControl_t/ResourceControl_t.py
+++ b/test/python/WMCore_t/ResourceControl_t/ResourceControl_t.py
@@ -463,6 +463,8 @@ class ResourceControlTest(EmulatedUnitTestCase):
         myResourceControl.insertSite("testSite2", 100, 200, "testSE2", "testCE2")
 
         siteInfo = myResourceControl.listSiteInfo("testSite1")
+        self.assertEqual(len(siteInfo), 1)
+        siteInfo = siteInfo[0]
 
         self.assertEqual(siteInfo["site_name"], "testSite1",
                          "Error: Site name is wrong.")
@@ -491,28 +493,32 @@ class ResourceControlTest(EmulatedUnitTestCase):
         myResourceControl.insertSite("testSite1", 10, 20, "testSE1", "testCE1")
 
         siteInfo = myResourceControl.listSiteInfo("testSite1")
+        self.assertEqual(len(siteInfo), 1)
 
-        self.assertEqual(siteInfo["pending_slots"], 10, "Error: Pending slots is wrong.")
-        self.assertEqual(siteInfo["running_slots"], 20, "Error: Running slots is wrong.")
+        self.assertEqual(siteInfo[0]["pending_slots"], 10, "Error: Pending slots is wrong.")
+        self.assertEqual(siteInfo[0]["running_slots"], 20, "Error: Running slots is wrong.")
 
         myResourceControl.setJobSlotsForSite("testSite1", pendingJobSlots=20)
 
         siteInfo = myResourceControl.listSiteInfo("testSite1")
+        self.assertEqual(len(siteInfo), 1)
 
-        self.assertEqual(siteInfo["pending_slots"], 20, "Error: Pending slots is wrong.")
+        self.assertEqual(siteInfo[0]["pending_slots"], 20, "Error: Pending slots is wrong.")
 
         myResourceControl.setJobSlotsForSite("testSite1", runningJobSlots=40)
 
         siteInfo = myResourceControl.listSiteInfo("testSite1")
+        self.assertEqual(len(siteInfo), 1)
 
-        self.assertEqual(siteInfo["running_slots"], 40, "Error: Running slots is wrong.")
+        self.assertEqual(siteInfo[0]["running_slots"], 40, "Error: Running slots is wrong.")
 
         myResourceControl.setJobSlotsForSite("testSite1", 5, 10)
 
         siteInfo = myResourceControl.listSiteInfo("testSite1")
+        self.assertEqual(len(siteInfo), 1)
 
-        self.assertEqual(siteInfo["pending_slots"], 5, "Error: Pending slots is wrong.")
-        self.assertEqual(siteInfo["running_slots"], 10, "Error: Running slots is wrong.")
+        self.assertEqual(siteInfo[0]["pending_slots"], 5, "Error: Pending slots is wrong.")
+        self.assertEqual(siteInfo[0]["running_slots"], 10, "Error: Running slots is wrong.")
 
         return
 
@@ -704,7 +710,8 @@ class ResourceControlTest(EmulatedUnitTestCase):
 
         # Verify that sites with more than one SE were added correctly.
         cernInfo = myResourceControl.listSiteInfo("CERN")
-        self.assertTrue(len(cernInfo["pnn"]) == 2)
+        self.assertTrue(len(cernInfo) == 1)
+        self.assertTrue(len(cernInfo[0]["pnn"]) == 2)
         return
 
 

--- a/test/python/WMCore_t/WMBS_t/Locations_t.py
+++ b/test/python/WMCore_t/WMBS_t/Locations_t.py
@@ -224,7 +224,7 @@ class LocationsTest(unittest.TestCase):
         result = locationInfo.execute(siteName="Choshu")
 
         self.assertEqual(result[0]['ce_name'], 'Choshu')
-        self.assertEqual(result[0]['pnn'], 'Choshu')
+        self.assertEqual(result[0]['pnn'], ['Choshu'])
         self.assertEqual(result[0]['site_name'], 'Choshu')
         self.assertEqual(result[0]['pending_slots'], 20)
         self.assertEqual(result[0]['running_slots'], 50)


### PR DESCRIPTION
Fixes #11596 

#### Status
ready

#### Description
This PR provides the following:
* fix `GetSiteInfo` DAO which was broken when no site name was provided
  * also update its return data type to always be a list (list of dictionaries)
*  support in ResourceControl listSiteInfo to list all resources in a single command
  * also change its return data type to be more consistent
* finally, implement in ResourceControlUpdater an extra method to continuously compare CRIC vs local database; 
  * in case of differences, insert the new PNN(s) into the database and make the relevant PSN association 

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
