### PR TITLE
New CouchDB view for WorkQueue OpenForNewData requests

### DIFF
--- a/src/couchapps/WorkQueue/views/openRequests/map.js
+++ b/src/couchapps/WorkQueue/views/openRequests/map.js
@@ -1,0 +1,6 @@
+function(doc) {
+    var ele = doc["WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement"];
+    if (ele && ele["OpenForNewData"] === true) {
+            emit(ele["RequestName"], null);
+    }
+}


### PR DESCRIPTION
Fixes #11385 

#### Status
Ready

#### Description
This PR provides a new CouchDB view function to retrieve requests that are still open for new data.

In addition, it changes the ReqMgr2 thread that advances workflow statuses such that open requests don't go into running-closed or completed prematurely. Of course we need to support workflow abortion/rejection and force-completion.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
Requires CouchDB couchapp update (push).
