### PR TITLE
Add resilient options to the gfal-copy stageout command

### DIFF
--- a/src/python/WMCore/Storage/Backends/GFAL2Impl.py
+++ b/src/python/WMCore/Storage/Backends/GFAL2Impl.py
@@ -24,7 +24,7 @@ class GFAL2Impl(StageOutImpl):
         # GFAL2 is not build under COMP environment and it had failures with mixed environment.
         self.setups = "env -i X509_USER_PROXY=$X509_USER_PROXY JOBSTARTDIR=$JOBSTARTDIR bash -c '%s'"
         self.removeCommand = self.setups % '. $JOBSTARTDIR/startup_environment.sh; date; gfal-rm -t 600 %s '
-        self.copyOpts = ' -t 2400 -T 2400 -v -p --abort-on-failure %(checksum)s %(options)s %(source)s %(destination)s'
+        self.copyOpts = '-t 2400 -T 2400 -p -v --abort-on-failure %(checksum)s %(options)s %(source)s %(destination)s'
         self.copyCommand = self.setups % ('. $JOBSTARTDIR/startup_environment.sh; date; gfal-copy ' + self.copyOpts)
 
     def createFinalPFN(self, pfn):

--- a/src/python/WMCore/Storage/Backends/GFAL2Impl.py
+++ b/src/python/WMCore/Storage/Backends/GFAL2Impl.py
@@ -25,8 +25,7 @@ class GFAL2Impl(StageOutImpl):
         self.setups = "env -i X509_USER_PROXY=$X509_USER_PROXY JOBSTARTDIR=$JOBSTARTDIR bash -c '%s'"
         self.removeCommand = self.setups % '. $JOBSTARTDIR/startup_environment.sh; date; gfal-rm -t 600 %s '
         self.copyOpts = ' -t 2400 -T 2400 -v -p --abort-on-failure %(checksum)s %(options)s %(source)s %(destination)s'
-        self.copyCommand = self.setups % '. $JOBSTARTDIR/startup_environment.sh; date; gfal-copy '
-        self.copyCommand += self.copyOpts
+        self.copyCommand = self.setups % ('. $JOBSTARTDIR/startup_environment.sh; date; gfal-copy ' + self.copyOpts)
 
     def createFinalPFN(self, pfn):
         """

--- a/test/python/WMCore_t/Storage_t/Backends_t/GFAL2Impl_t.py
+++ b/test/python/WMCore_t/Storage_t/Backends_t/GFAL2Impl_t.py
@@ -18,7 +18,7 @@ class GFAL2ImplTest(unittest.TestCase):
                         "'. $JOBSTARTDIR/startup_environment.sh; date; gfal-rm -t 600 %s '"
         copyCommand = "env -i X509_USER_PROXY=$X509_USER_PROXY JOBSTARTDIR=$JOBSTARTDIR bash -c '" \
                       ". $JOBSTARTDIR/startup_environment.sh; date; gfal-copy -t 2400 -T 2400 " \
-                      "-p %(checksum)s %(options)s %(source)s %(destination)s'"
+                      "-p -v --abort-on-failure %(checksum)s %(options)s %(source)s %(destination)s'"
         self.assertEqual(removeCommand, testGFAL2Impl.removeCommand)
         self.assertEqual(copyCommand, testGFAL2Impl.copyCommand)
 
@@ -81,7 +81,7 @@ class GFAL2ImplTest(unittest.TestCase):
         mock_createRemoveFileCommand.return_value = "targetPFN2"
         result = self.GFAL2Impl.createStageOutCommand("sourcePFN", "targetPFN")
         expectedResult = self.getStageOutCommandResult(
-            self.getCopyCommandDict("-K adler32", "", "sourcePFN", "targetPFN"), "targetPFN2")
+            self.getCopyCommandDict("--checksum-mode both -K adler32", "", "sourcePFN", "targetPFN"), "targetPFN2")
         mock_createRemoveFileCommand.assert_called_with("targetPFN")
         self.assertEqual(expectedResult, result)
 
@@ -109,15 +109,15 @@ class GFAL2ImplTest(unittest.TestCase):
         result += copyCommand
 
         result += """
-            EXIT_STATUS=$?
-            echo "gfal-copy exit status: $EXIT_STATUS"
-            if [[ $EXIT_STATUS != 0 ]]; then
-               echo "ERROR: gfal-copy exited with $EXIT_STATUS"
-               echo "Cleaning up failed file:"
-               %s
-            fi
-            exit $EXIT_STATUS
-            """ % createRemoveFileCommandResult
+        EXIT_STATUS=$?
+        echo "gfal-copy exit status: $EXIT_STATUS"
+        if [[ $EXIT_STATUS != 0 ]]; then
+           echo "ERROR: gfal-copy exited with $EXIT_STATUS"
+           echo "Cleaning up failed file:"
+           %s
+        fi
+        exit $EXIT_STATUS
+        """ % createRemoveFileCommandResult
 
         return result
 


### PR DESCRIPTION
Fixes #11556 
Superseeds #11601

#### Status
not-tested

#### Description
This PR adds by default the following `gfal-copy` options:
* `-v`: enable warning verbose mode
* `--abort-on-failure`: abort the whole copy process as soon as there is a failure
* `--checksum-mode both`: calculate the adler32 checksum on both source and destination files (can be disabled by the site admin)

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
