### PR TITLE
Explicitly enabled verbose and abort on failure for GFAL2 plugin

### DIFF
--- a/src/python/WMCore/Storage/Backends/GFAL2Impl.py
+++ b/src/python/WMCore/Storage/Backends/GFAL2Impl.py
@@ -27,6 +27,8 @@ class GFAL2Impl(StageOutImpl):
         self.setups = "env -i X509_USER_PROXY=$X509_USER_PROXY JOBSTARTDIR=$JOBSTARTDIR bash -c '%s'"
         self.removeCommand = self.setups % '. $JOBSTARTDIR/startup_environment.sh; date; gfal-rm -t 600 %s '
         self.copyCommand = self.setups % '. $JOBSTARTDIR/startup_environment.sh; date; gfal-copy -t 2400 -T 2400 -p %(checksum)s %(options)s %(source)s %(destination)s'
+        self.copyOpts = '-t 2400 -T 2400 -p -v --abort-on-failure %(checksum)s %(options)s %(source)s %(destination)s'
+        self.copyCommand = self.setups % ('. $JOBSTARTDIR/startup_environment.sh; date; gfal-copy ' + self.copyOpts)
 
     def createFinalPFN(self, pfn):
         """
@@ -87,6 +89,8 @@ class GFAL2Impl(StageOutImpl):
           -T   global timeout for the transfer operation
           -p   if the destination directory does not exist, create it
           -K   checksum algorithm to use, or algorithm:value
+          -v   enable the verbose mode (-v for warning level)
+          --abort-on-failure  abort the whole copy as soon as one failure is encountered
         """
         result = "#!/bin/bash\n"
 

--- a/test/python/WMCore_t/Storage_t/Backends_t/GFAL2Impl_t.py
+++ b/test/python/WMCore_t/Storage_t/Backends_t/GFAL2Impl_t.py
@@ -17,8 +17,8 @@ class GFAL2ImplTest(unittest.TestCase):
         removeCommand = "env -i X509_USER_PROXY=$X509_USER_PROXY JOBSTARTDIR=$JOBSTARTDIR bash -c " \
                         "'. $JOBSTARTDIR/startup_environment.sh; date; gfal-rm -t 600 %s '"
         copyCommand = "env -i X509_USER_PROXY=$X509_USER_PROXY JOBSTARTDIR=$JOBSTARTDIR bash -c '" \
-                      ". $JOBSTARTDIR/startup_environment.sh; date; gfal-copy -t 2400 -T 2400 " \
-                      "-p %(checksum)s %(options)s %(source)s %(destination)s'"
+                      ". $JOBSTARTDIR/startup_environment.sh; date; gfal-copy -t 2400 -T 2400 -p " \
+                      "-v --abort-on-failure %(checksum)s %(options)s %(source)s %(destination)s'"
         self.assertEqual(removeCommand, testGFAL2Impl.removeCommand)
         self.assertEqual(copyCommand, testGFAL2Impl.copyCommand)
 


### PR DESCRIPTION
Fixes #11556 
Might superseed https://github.com/dmwm/WMCore/pull/11626

#### Status
ready

#### Description
This is a less intrusive potential fix for the GFAL2 issues seen during stage out (alternative to what is provided in https://github.com/dmwm/WMCore/pull/11626).

In short, it provides 2 new options to the `gfal-copy` command:
* `-v`: enable warning verbose mode
* `--abort-on-failure`: abort the whole copy process as soon as there is a failure

Given that we see an "internal" error in the gfal-copy command that does not propagate all the way to the final exit code of the command, I would expect it to be resolved with the `--abort-on-failure` option. 

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
