### PR TITLE
Update GH action for docker image to use a build argument

### DIFF
--- a/.github/workflows/docker_images_template.yaml
+++ b/.github/workflows/docker_images_template.yaml
@@ -24,14 +24,16 @@ jobs:
           head_ref: ${{ github.head_ref }}
 
       - name: Build image
+        env:
+          PYPI_TAG: ${{steps.get-ref.outputs.tag}}
         run: |
+          echo "Building service: ${{inputs.wmcore_component}}, with tag: ${PYPI_TAG}"
           svn checkout https://github.com/dmwm/CMSKubernetes/trunk/docker/pypi/${{inputs.wmcore_component}}
           cd ${{inputs.wmcore_component}}
-          sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile
           cat Dockerfile
           echo "Sleeping 5min to ensure that PyPi packages are available..."
           sleep 300
-          docker build --tag registry.cern.ch/cmsweb/${{inputs.wmcore_component}}:${{steps.get-ref.outputs.tag}} .
+          docker build --build-arg TAG=${PYPI_TAG} --tag registry.cern.ch/cmsweb/${{inputs.wmcore_component}}:${PYPI_TAG} .
 
       - name: Images
         run: |


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/11646 (while before it was supposed to address #8797) 

#### Status
not-tested

#### Description
Instead of replacing string in place in the Dockerfile (sed command), we can use the docker build argument to pass the tag that we want to be built within github actions.

It depends on the 2nd commit provided in this PR:
https://github.com/dmwm/CMSKubernetes/pull/1394

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
CMSKubernetes: https://github.com/dmwm/CMSKubernetes/pull/1397
