### PR TITLE
Substitute curl with svn in gitHUb actions

### DIFF
--- a/.github/workflows/docker_images_template.yaml
+++ b/.github/workflows/docker_images_template.yaml
@@ -25,7 +25,8 @@ jobs:
 
       - name: Build image
         run: |
-          curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/pypi/${{inputs.wmcore_component}}/Dockerfile
+          svn checkout https://github.com/dmwm/CMSKubernetes/trunk/docker/pypi/${{inputs.wmcore_component}}
+          cd ${{inputs.wmcore_component}}
           sed -i -e "s,ENV TAG=.*,ENV TAG=${{steps.get-ref.outputs.tag}},g" Dockerfile
           cat Dockerfile
           echo "Sleeping 5min to ensure that PyPi packages are available..."


### PR DESCRIPTION
Fixes #8797 
Substitutes #11638 and https://github.com/dmwm/CMSKubernetes/pull/1394

#### Status
ready

#### Description
With the current PR only the broken GitHub action is fixed. Which is - the lack of sub directory structure during the docker build process for all images in our CI?CD pipeline.  

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None