### PR TITLE
Add Docker context path to docker/build-push-action@v1

### DIFF
--- a/.github/workflows/docker_images_template.yaml
+++ b/.github/workflows/docker_images_template.yaml
@@ -47,6 +47,7 @@ jobs:
       - name: Publish image to registry.cern.ch
         uses: docker/build-push-action@v1
         with:
+          path: ${{inputs.wmcore_component}}
           registry: registry.cern.ch
           username: ${{ secrets.cern_user }}
           password: ${{ secrets.cern_token }}


### PR DESCRIPTION
Fixes #11641 
#### Status
ready

#### Description
Adding a context path to the predefined `docker/build-push-action@v1` GHAction. 

**NOTE:** the so added option named `path` here differes between the module's  versions. In `v2` and beyond it is called `context` instead. I currently use `v1`. I did not update the version, because of the following WARING: we get:
```
Warning: Input 'repository' has been deprecated with message: v2 is now available through docker/build-push-action@v2
```
Which basically tells us, the `repository` option we use to tag those images is about to be deprecated in `v2` and later. Which means it will affect  how we are about to be setting our tags. This is something that did not want to get into in this very moment, so did not upgrade the module version we are using for this GHAction.  

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
