### PR TITLE
Add new exception/error code for jobs removed by condor 

### DIFF
--- a/src/python/WMCore/WMExceptions.py
+++ b/src/python/WMCore/WMExceptions.py
@@ -160,6 +160,7 @@ WM_JOB_ERROR_CODES = {-1: "Error return without specification.",
                       50662: "Application terminated by wrapper because using too much disk.",  # (CRAB3)
                       50664: "Application terminated by wrapper because using too much Wall Clock time.",  # (WMA, CRAB3)
                       50665: "Application terminated by wrapper because it stay idle too long.",  # (CRAB3)
+                      50666: "Job removed by condor for unknown reasons.", # (WMA, CRAB3)
                       50669: "Application terminated by wrapper for not defined reason.",  # (CRAB3)
                       60302: "Output file(s) not found.",  # (CRAB3)
                       60307: "General failure during files stage out.",  # (WMA, CRAB3)


### PR DESCRIPTION
Fixes #11614

#### Status
 ready

#### Description
The following change documents the error code propagated in monit by the spider, when there is no exit code classads due to the job being removed by condor for X reason.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
https://github.com/dmwm/cms-htcondor-es/pull/209
https://github.com/dmwm/cms-htcondor-es/pull/210

#### External dependencies / deployment changes
https://github.com/dmwm/cms-htcondor-es/issues/208