### PR TITLE
Fix buildrelease for when there are no changes between releases

### DIFF
--- a/bin/buildrelease.sh
+++ b/bin/buildrelease.sh
@@ -72,6 +72,10 @@ echo "" >> $TMP_HASHES_SUBJ_AUTHOR
 # Use github public API to fetch pull request # from commit hash
 
 cat $TMP_HASHES_SUBJ_AUTHOR | while read commitline; do
+  if [ -z "$commitline" ]
+  then
+      continue  # line is empty
+  fi
   HASH_ID=$(echo $commitline | awk '{print $1}')
   PR=$(curl -s https://api.github.com/repos/dmwm/WMCore/commits/$HASH_ID/pulls | grep -Po '\"html_url\": \"https://github.com/dmwm/WMCore/pull/\K[0-9]+' | sort | uniq)
   # remove hash_id from the commit line


### PR DESCRIPTION
Fixes #11640 

#### Status
ready

#### Description
Fixes an issue introduced with https://github.com/dmwm/WMCore/pull/11645
Whenever we cut a new release on top of another one, without any commits in between, the script was crashing with:
```
$ ./bin/buildrelease.sh -t 2.2.2rc7
Checking out branch: master
Already on 'master'
Building new release of WMCore 2.2.2rc7 on master
Updating version string ...
Generating CHANGES file
sed: -e expression #1, char 0: no previous regular expression
```

So here we check whether there is an actual commit line to be checked.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Fix bug introduced with https://github.com/dmwm/WMCore/pull/11645

#### External dependencies / deployment changes
None
