### PR TITLE
Fix GH action to build/push docker image

### DIFF
--- a/.github/workflows/docker_images_template.yaml
+++ b/.github/workflows/docker_images_template.yaml
@@ -50,6 +50,8 @@ jobs:
         uses: docker/build-push-action@v1
         with:
           path: ${{inputs.wmcore_component}}
+          build-args: |
+            TAG=${{steps.get-ref.outputs.tag}}
           registry: registry.cern.ch
           username: ${{ secrets.cern_user }}
           password: ${{ secrets.cern_token }}


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/11646

#### Status
not-tested

#### Description
Fix - hopefully - bug introduced with: https://github.com/dmwm/WMCore/pull/11638

The last step in the docker workflow (re)tries to build the image once again, so we need to ensure that the expected TAG is set in there as well.

I was going to upgrade the GH action container to v4, but I am not 100% confident with the necessary changes. I think it would be a matter of:
```
-          repository: cmsweb/${{inputs.wmcore_component}}
+          tags: cmsweb/${{inputs.wmcore_component}}:${{steps.get-ref.outputs.tag}}
```

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Bug introduced with https://github.com/dmwm/WMCore/pull/11638

#### External dependencies / deployment changes
None
