### PR TITLE
Rename build_args in GH action workflow

### DIFF
--- a/.github/workflows/docker_images_template.yaml
+++ b/.github/workflows/docker_images_template.yaml
@@ -50,7 +50,7 @@ jobs:
         uses: docker/build-push-action@v1
         with:
           path: ${{inputs.wmcore_component}}
-          build-args: |
+          build_args: |
             TAG=${{steps.get-ref.outputs.tag}}
           registry: registry.cern.ch
           username: ${{ secrets.cern_user }}


### PR DESCRIPTION
Fixes #11646 

#### Status
not-tested

#### Description
The argument name in the `v1` container is actually `build_args`, not `build-args` (as it is expected in the v4).

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Fix #11638 and https://github.com/dmwm/WMCore/pull/11651

#### External dependencies / deployment changes
None
