### PR TITLE
Refactor docker build/push workflow action

### DIFF
--- a/.github/workflows/docker_images_template.yaml
+++ b/.github/workflows/docker_images_template.yaml
@@ -15,6 +15,8 @@ on:
 jobs:
   build_images_from_template:
     runs-on: ubuntu-latest
+    env:
+      SERVICE_NAME: ${{inputs.wmcore_component}}
     steps:
       - name: Get the Ref
         id: get-ref
@@ -23,22 +25,6 @@ jobs:
           ref: ${{ github.ref }}
           head_ref: ${{ github.head_ref }}
 
-      - name: Build image
-        env:
-          PYPI_TAG: ${{steps.get-ref.outputs.tag}}
-        run: |
-          echo "Building service: ${{inputs.wmcore_component}}, with tag: ${PYPI_TAG}"
-          svn checkout https://github.com/dmwm/CMSKubernetes/trunk/docker/pypi/${{inputs.wmcore_component}}
-          cd ${{inputs.wmcore_component}}
-          cat Dockerfile
-          echo "Sleeping 5min to ensure that PyPi packages are available..."
-          sleep 300
-          docker build --build-arg TAG=${PYPI_TAG} --tag registry.cern.ch/cmsweb/${{inputs.wmcore_component}}:${PYPI_TAG} .
-
-      - name: Images
-        run: |
-          docker images
-
       - name: Login to registry.cern.ch
         uses: docker/login-action@v2
         with:
@@ -46,14 +32,20 @@ jobs:
           username: ${{ secrets.cern_user }}
           password: ${{ secrets.cern_token }}
 
-      - name: Publish image to registry.cern.ch
-        uses: docker/build-push-action@v1
-        with:
-          path: ${{inputs.wmcore_component}}
-          build_args: |
-            TAG=${{steps.get-ref.outputs.tag}}
-          registry: registry.cern.ch
-          username: ${{ secrets.cern_user }}
-          password: ${{ secrets.cern_token }}
-          repository: cmsweb/${{inputs.wmcore_component}}
-          tag_with_ref: true
+      - name: Build and publish docker image
+        env:
+          PYPI_TAG: ${{steps.get-ref.outputs.tag}}
+          CERN_REGISTRY: registry.cern.ch
+        run: |
+          echo "Building service: ${SERVICE_NAME}, with tag: ${PYPI_TAG}"
+          svn checkout https://github.com/dmwm/CMSKubernetes/trunk/docker/pypi/${SERVICE_NAME}
+          cd ${SERVICE_NAME}
+          echo "Retrieved Dockerfile with content:"
+          cat Dockerfile
+          echo "Sleeping 5min to ensure that PyPi packages are available..."
+          sleep 300
+          docker build --build-arg TAG=${PYPI_TAG} --tag ${CERN_REGISTRY}/cmsweb/${SERVICE_NAME}:${PYPI_TAG} .
+          echo "Image build process completed. Current images are:"
+          docker images
+          echo "Now push new image to the CERN registry"
+          docker push ${CERN_REGISTRY}/cmsweb/${SERVICE_NAME}:${PYPI_TAG}


### PR DESCRIPTION
Fixes #11646 

#### Status
ready

#### Description
I created a new repository and tested these changes to make sure that we can now build at least `reqmgr2ms-unmerged` package, which was failing for the last couple of tags.

Summary of changes is:
* removed dependency on `docker/build-push-action@v1`, instead, push the docker image in the same step as we build it.
* removed the Images step, instead simply added it to the same step building and publishing the image
*  created a `SERVICE_NAME` job wide environment variable with the WMCore component to be built/published.
* created a `CERN_REGISTRY` step wide environment variable (all my attempts to set it job wide failed, either with only $, or with ${ or with ${{).

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Resolving unresolved issues from:
https://github.com/dmwm/WMCore/pull/11638
https://github.com/dmwm/WMCore/pull/11651

#### External dependencies / deployment changes
None