### PR TITLE
Provide timestamps metrics about WM job

### DIFF
--- a/etc/submit_py3.sh
+++ b/etc/submit_py3.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+#
+# acquire initial timestamps for reporting in FJR
+timeStartSec=`date +%s`
+
 # On some sites we know there were some problems with environment cleaning
 # with using 'env -i'. To overcome this issue, whenever we start a job, we have
 # to save full current environment into file, and whenever it is needed we can load
@@ -207,6 +211,15 @@ $pythonCommand Startup.py
 jobrc=$?
 echo -e "======== WMAgent Run the job FINISH at $(TZ=GMT date) ========\n"
 
+echo "======== WMAgent add timestamps metrics to FJR $outputFile ========"
+timeEndSec=`date +%s`
+reportIn=$outputFile
+$pythonCommand Timestamps.py --reportFile=$outputFile --wmJobEnd=$timeEndSec --wmJobStart=$timeStartSec
+status=$?
+if [ "$status" != "0" ]; then
+    echo "WARNING: failed to update FJR with timestamps metrics, status=$status"
+fi
+echo -e "======== WMAgent finished adding timestamps metrics to FJR ========\n"
 
 echo "WMAgent bootstrap: WMAgent finished the job, it's copying the pickled report"
 set -x

--- a/src/python/WMCore/WMRuntime/Scripts/Timestamps.py
+++ b/src/python/WMCore/WMRuntime/Scripts/Timestamps.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+"""
+_Timestamps_ module designed to insert proper WM timing into WMCore FJR.
+Usage: python3 Timestamps.py --reportFile=$outputFile --wmJobStart=<sec> --wmJobEnd=<sec>
+where outputFile represents output FJR file, and wmJobStart/wmJobEnd represent
+start and end time of WM job, respectively.
+
+"""
+
+import getopt
+import logging
+import os
+import pickle
+import sys
+
+
+# script options
+options = {"reportFile=": "", "wmJobStart=": '', "wmJobEnd=": ''}
+
+
+def addTimestampMetrics(config, wmJobStart, wmJobEnd):
+    """
+    Adjust timestamp metrics of provied FJR data.
+
+    :param config: input FJR data
+    :param wmJobStart: start time of WM job in seconds
+    :param wmJobEnd: end time of WM job in seconds
+    """
+    wmTiming = config.section_('WMTiming')
+    wmTiming.WMJobStart = wmJobStart
+    wmTiming.WMJobEnd = wmJobEnd
+    wmTiming.WMTotalWallClockTime = wmJobEnd - wmJobStart
+
+
+def main():
+    """
+    Main function of the script performs business logic:
+    - parse input arguments
+    - read provided input FJR
+    - adjust timestamp metrics of FJR data
+    - write out FJR
+    """
+    try:
+        opts, _ = getopt.getopt(sys.argv[1:], "", list(options.keys()))
+    except getopt.GetoptError as ex:
+        msg = "Error processing commandline args:\n"
+        msg += str(ex)
+        logging.error(msg)
+        sys.exit(1)
+
+    for opt, arg in opts:
+        if opt == "--reportFile":
+            reportFile = arg
+        if opt == "--wmJobStart":
+            wmJobStart = float(arg)
+        if opt == "--wmJobEnd":
+            wmJobEnd = float(arg)
+
+    # read content of given FJR report file
+    data = {}
+    with open(reportFile, 'rb') as istream:
+        data = pickle.load(istream)
+
+    # adjust FJR data with provided metrics
+    addTimestampMetrics(data, wmJobStart, wmJobEnd)
+
+    # write content of FJR back to report file
+    reportOutFile = reportFile + ".new"
+    msg = f"Adding wmJobTime metric to {reportFile}"
+    with open(reportOutFile, 'wb') as ostream:
+        logging.info(msg)
+        pickle.dump(data, ostream)
+
+    # if we successfully wrote reportOutFile we can swap it with input one
+    sizeStatus = os.path.getsize(reportOutFile) > os.path.getsize(reportFile)
+    if os.path.isfile(reportOutFile) and sizeStatus:
+        os.rename(reportOutFile, reportFile)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/python/WMCore_t/WMRuntime_t/Scripts_t/Timestamps_t.py
+++ b/test/python/WMCore_t/WMRuntime_t/Scripts_t/Timestamps_t.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+"""
+_Timestamps_t_
+
+Tests timestamps metrics
+"""
+
+import unittest
+
+from WMCore.Configuration import Configuration
+from WMCore.WMRuntime.Scripts.Timestamps import addTimestampMetrics
+
+
+class TimestampsTest(unittest.TestCase):
+    """
+    Timestamps class provides unit tests for Timestamps module
+    """
+    def testAddTimestamps(self):
+        """
+        test timestamps metrics in configuration
+        """
+        config = Configuration()
+        wmJobStart = 1
+        wmJobEnd = 2
+        addTimestampMetrics(config, wmJobStart, wmJobEnd)
+        self.assertEqual(config.WMTiming.WMJobStart, wmJobStart)
+        self.assertEqual(config.WMTiming.WMJobEnd, wmJobEnd)
+        self.assertEqual(config.WMTiming.WMTotalWallClockTime, wmJobEnd - wmJobStart)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #11604 

#### Status
In development

#### Description
Provides timestamps metrics, job wall clock time, etc. (in GMT and UNIX since epochs data-format), to WMCore FJR (Report.pkl) file during job execution script

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
#11575 , https://github.com/dmwm/WMCore/pull/11659

#### External dependencies / deployment changes
