### PR TITLE
Add Timing section into FWJR JSON docs

### DIFF
--- a/test/python/WMCore_t/Services_t/WMArchive_t/DataMap_t.py
+++ b/test/python/WMCore_t/Services_t/WMArchive_t/DataMap_t.py
@@ -161,7 +161,9 @@ SAMPLE_FWJR = {'fallbackFiles': [],
                          'start': 1454569727,
                          'status': 0,
                          'stop': 1454569735}},
- 'task': '/sryu_TaskChain_Data_wq_testt_160204_061048_5587/RECOCOSD'}
+ 'task': '/sryu_TaskChain_Data_wq_testt_160204_061048_5587/RECOCOSD',
+ 'WMTiming': {'WMTotalWallClockTime': 10}
+ }
 
 class DataMap_t(unittest.TestCase):
 

--- a/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/ErrorCodeFail.json
+++ b/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/ErrorCodeFail.json
@@ -6,6 +6,7 @@
    "retrycount": 0,
    "fwjr": {
        "task": "/sryu_MonteCarlo_reqmgr1_160430_052119_387/Production",
+       "WMTiming": {"WMTotalWallClockTime": 10},
        "skippedFiles": [
        ],
        "fallbackFiles": [

--- a/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/FailedByAgent.json
+++ b/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/FailedByAgent.json
@@ -6,6 +6,7 @@
    "retrycount": 0,
    "fwjr": {
        "task": "/sryu_TaskChain_Task_Multicore_reqmgr1_160430_020832_2190/HLTD/HLTDMergeRAWoutput/RECODreHLT",
+       "WMTiming": {"WMTotalWallClockTime": 10},
        "skippedFiles": [
        ],
        "fallbackFiles": [

--- a/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/HarvestSuccessFwjr.json
+++ b/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/HarvestSuccessFwjr.json
@@ -6,6 +6,7 @@
    "retrycount": 0,
    "fwjr": {
        "task": "/sryu_DQMHarvesting_Sryu_reqmgr2_160318_050142_4405/EndOfRunDQMHarvest",
+       "WMTiming": {"WMTotalWallClockTime": 10},
        "skippedFiles": [
        ],
        "fallbackFiles": [

--- a/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/LogCollectFailedFwjr.json
+++ b/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/LogCollectFailedFwjr.json
@@ -6,6 +6,7 @@
    "retrycount": 0,
    "fwjr": {
        "task": "/sryu_MonteCarlo_PhEDEx_Sryu_reqmgr2_160318_050123_7744/Production/ProductionMergeLHEoutput/ProductionLHEoutputMergeLogCollect",
+       "WMTiming": {"WMTotalWallClockTime": 10},
        "skippedFiles": [
        ],
        "fallbackFiles": [

--- a/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/LogCollectSuccessFwjr.json
+++ b/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/LogCollectSuccessFwjr.json
@@ -6,6 +6,7 @@
    "retrycount": 0,
    "fwjr": {
        "task": "/sryu_DQMHarvesting_Sryu_reqmgr2_160318_050142_4405/EndOfRunDQMHarvest/EndOfRunDQMHarvestLogCollect",
+       "WMTiming": {"WMTotalWallClockTime": 10},
        "skippedFiles": [
        ],
        "fallbackFiles": [

--- a/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/MergeFailedFwjr.json
+++ b/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/MergeFailedFwjr.json
@@ -6,6 +6,7 @@
    "retrycount": 0,
    "fwjr": {
        "task": "/sryu_ReRecoSkim_Sryu_reqmgr2_160318_050217_7302/DataProcessing/DataProcessingMergeRECOoutput",
+       "WMTiming": {"WMTotalWallClockTime": 10},
        "skippedFiles": [
        ],
        "fallbackFiles": [

--- a/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/MergeSuccessFwjr.json
+++ b/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/MergeSuccessFwjr.json
@@ -6,6 +6,7 @@
    "retrycount": 0,
    "fwjr": {
        "task": "/sryu_MonteCarlo_eff_Sryu_reqmgr2_160317_161133_1935/Production/ProductionMergeRAWSIMoutput",
+       "WMTiming": {"WMTotalWallClockTime": 10},
        "skippedFiles": [
        ],
        "fallbackFiles": [

--- a/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/NoJobReportFail.json
+++ b/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/NoJobReportFail.json
@@ -6,6 +6,7 @@
    "retrycount": 0,
    "fwjr": {
        "task": "/sryu_TaskChain_Multicore_reqmgr1_160430_052131_7339/HLTD",
+       "WMTiming": {"WMTotalWallClockTime": 10},
        "skippedFiles": [
        ],
        "fallbackFiles": [

--- a/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/ProcessingFailedFwjr.json
+++ b/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/ProcessingFailedFwjr.json
@@ -6,6 +6,7 @@
    "retrycount": 0,
    "fwjr": {
        "task": "/sryu_ReDigi_3steps_Sryu_reqmgr2_160318_050052_982/StepOneProc/StepOneProcMergeRAWSIMoutput/StepTwoProc/StepTwoProcMergeAODSIMoutput/StepThreeProc",
+       "WMTiming": {"WMTotalWallClockTime": 10},
        "skippedFiles": [
        ],
        "fallbackFiles": [

--- a/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/ProcessingPerformanceFailed.json
+++ b/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/ProcessingPerformanceFailed.json
@@ -6,6 +6,7 @@
    "retrycount": 0,
    "fwjr": {
        "task": "/sryu_TaskChain_Task_Multicore_reqmgr1_160430_020832_2190/HLTD/HLTDMergeRAWoutput/RECODreHLT",
+       "WMTiming": {"WMTotalWallClockTime": 10},
        "skippedFiles": [
        ],
        "fallbackFiles": [

--- a/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/ProcessingSuccessFwjr.json
+++ b/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/ProcessingSuccessFwjr.json
@@ -6,6 +6,7 @@
    "retrycount": 0,
    "fwjr": {
        "task": "/sryu_ReDigi_3steps_Sryu_reqmgr2_160318_050052_982/StepOneProc",
+       "WMTiming": {"WMTotalWallClockTime": 10},
        "skippedFiles": [
        ],
        "fallbackFiles": [

--- a/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/ProductionFailedFwjr.json
+++ b/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/ProductionFailedFwjr.json
@@ -6,6 +6,7 @@
    "retrycount": 0,
    "fwjr": {
        "task": "/sryu_MonteCarlo_Sryu_reqmgr2_160318_050144_6584/Production",
+       "WMTiming": {"WMTotalWallClockTime": 10},
        "skippedFiles": [
        ],
        "fallbackFiles": [

--- a/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/ProductionSuccessFwjr.json
+++ b/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/ProductionSuccessFwjr.json
@@ -6,6 +6,7 @@
    "retrycount": 0,
    "fwjr": {
        "task": "/sryu_MonteCarlo_eff_Sryu_reqmgr2_160317_161133_1935/Production",
+       "WMTiming": {"WMTotalWallClockTime": 10},
        "skippedFiles": [
        ],
        "fallbackFiles": [

--- a/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/SkimSuccessFwjr.json
+++ b/test/python/WMCore_t/Services_t/WMArchive_t/FWJRSamples/SkimSuccessFwjr.json
@@ -6,6 +6,7 @@
    "retrycount": 0,
    "fwjr": {
        "task": "/sryu_ReRecoSkim_Sryu_reqmgr2_160318_050217_7302/DataProcessing/DataProcessingMergeRECOoutput/skim_2012A_BTag",
+       "WMTiming": {"WMTotalWallClockTime": 10},
        "skippedFiles": [
        ],
        "fallbackFiles": [


### PR DESCRIPTION
Fixes #11657 

#### Status
In development, we may drop this PR in favor of https://github.com/dmwm/WMCore/pull/11692 which adds `WMTIming` into json test files.

#### Description
Adjust all unit test FWJR json docs to include TIming section

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
#11656 

#### External dependencies / deployment changes
https://github.com/dmwm/WMArchive/pull/360