### PR TITLE
WMAgent deploy script: use latest stable release 2.2.3.1

### DIFF
--- a/deploy/deploy-wmagent.sh
+++ b/deploy/deploy-wmagent.sh
@@ -24,7 +24,7 @@
 ### Usage:               -n <agent_number> Agent number to be set when more than 1 agent connected to the same team (defaults to 0)
 ### Usage:
 ### Usage: deploy-wmagent.sh -w <wma_version> -t <team_name> [-s <scram_arch>] [-r <repository>] [-n <agent_number>]
-### Usage: Example: sh deploy-wmagent.sh -w 2.2.0.4 -t production -n 30
+### Usage: Example: sh deploy-wmagent.sh -w 2.2.3.1 -t production -n 30
 ### Usage: Example: sh deploy-wmagent.sh -w 2.1.4-b954b0745339a347ea28afd5b5767db4 -t testbed-vocms001 -p "11001" -r comp=comp.amaltaro
 ### Usage:
 


### PR DESCRIPTION
Fixes #11557 

#### Status
ready

#### Description
There is nothing to be changed in the wmagent deploy script this cycle, other than the usage example pointing out to the latest stable release - to be deployed in production in the coming days.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None