### PR TITLE
Provide in the FWJR the CPU and wallclock time for CMSSW subprocesses

### DIFF
--- a/src/python/WMCore/FwkJobReport/Report.py
+++ b/src/python/WMCore/FwkJobReport/Report.py
@@ -1323,6 +1323,21 @@ class Report(object):
 
         return
 
+    def updateSubprocessInfo(self, sysTime, userTime, startTime, endTime):
+        """
+        Add process information to WMCore FJR
+        :param sysTime: systtem time reported by subprocess job
+        :param userTime: user time reported by subprocess job
+        :param startTime: start time of subprocess (in seconds)
+        :param endTime: endtime time of subprocess (in seconds)
+        """
+        self.report.section_('WMCMSSWSubprocess')
+        self.report.WMCMSSWSubprocess.startTime = startTime
+        self.report.WMCMSSWSubprocess.endTime = endTime
+        self.report.WMCMSSWSubprocess.wallClockTime = endTime - startTime
+        self.report.WMCMSSWSubprocess.userTime = userTime
+        self.report.WMCMSSWSubprocess.sysTime = sysTime
+
     def setValidStatus(self, validStatus):
         """
         _setValidStatus_

--- a/test/python/WMCore_t/FwkJobReport_t/Report_t.py
+++ b/test/python/WMCore_t/FwkJobReport_t/Report_t.py
@@ -21,9 +21,6 @@ from WMCore.FwkJobReport.Report import Report
 from WMCore.WMBase import getTestBase
 from WMQuality.TestInitCouchApp import TestInitCouchApp
 
-# third-party modules
-import psutil
-
 
 class ReportTest(unittest.TestCase):
     """
@@ -471,15 +468,18 @@ class ReportTest(unittest.TestCase):
         Check CMSSW subprocess metrics
         """
         report = Report("cmsRun1")
-        process = psutil.Process(os.getpid())
-        elapsedTime = 1
-        report.updateSubprocessInfo(process, elapsedTime)
-        subinfo = report.retrieveStep("cmsRun1").CMSSWSubprocess
+        startTime = 0
+        endTime = 1
+        userTime = 1
+        sysTime = 1
+        report.updateSubprocessInfo(sysTime, userTime, startTime, endTime)
+        subinfo = report.retrieveStep("cmsRun1").WMCMSSWSubprocess
         sdict = subinfo.dictionary_()
-        self.assertEqual(sdict['elapsedTime'], 1)
-        self.assertEqual('cpu_user' in sdict, True)
-        self.assertEqual('mem_rss' in sdict, True)
-#         self.assertEqual('virt_used' in sdict, True)
+        self.assertEqual(sdict['startTime'], startTime)
+        self.assertEqual(sdict['endTime'], endTime)
+        self.assertEqual(sdict['wallClockTime'], endTime-startTime)
+        self.assertEqual(sdict['userTime'], userTime)
+        self.assertEqual(sdict['sysTime'], sysTime)
 
     def test_PerformanceReport(self):
         """

--- a/test/python/WMCore_t/FwkJobReport_t/Report_t.py
+++ b/test/python/WMCore_t/FwkJobReport_t/Report_t.py
@@ -21,6 +21,9 @@ from WMCore.FwkJobReport.Report import Report
 from WMCore.WMBase import getTestBase
 from WMQuality.TestInitCouchApp import TestInitCouchApp
 
+# third-party modules
+import psutil
+
 
 class ReportTest(unittest.TestCase):
     """
@@ -460,6 +463,23 @@ class ReportTest(unittest.TestCase):
         self.assertEqual(report.getJobID(), 100)
 
         return
+
+    def test_SubprocessInfo(self):
+        """
+        _SubprocessInfo_
+
+        Check CMSSW subprocess metrics
+        """
+        report = Report("cmsRun1")
+        process = psutil.Process(os.getpid())
+        elapsedTime = 1
+        report.updateSubprocessInfo(process, elapsedTime)
+        subinfo = report.retrieveStep("cmsRun1").CMSSWSubprocess
+        sdict = subinfo.dictionary_()
+        self.assertEqual(sdict['elapsedTime'], 1)
+        self.assertEqual('cpu_user' in sdict, True)
+        self.assertEqual('mem_rss' in sdict, True)
+#         self.assertEqual('virt_used' in sdict, True)
 
     def test_PerformanceReport(self):
         """


### PR DESCRIPTION
Fixes #11660 

#### Status
In development

#### Description
This PR provides a new FWJR section called `WMCMSSWSubprocess`, which contains the job start and end time (local time). In addition, it also provides wallclocktime, user and system time.

Note that this information is not yet propagated through WMArchive, which will be provided with this issue: https://github.com/dmwm/WMCore/issues/11657

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
#11656 , #11657,  #11663

#### External dependencies / deployment changes
None