### PR TITLE
Adopt wmcore_pileup Rucio account in workqueue

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -151,7 +151,9 @@ config.WorkQueueManager.queueParams["QueueDepth"] = 0.5  # pull work from GQ for
 config.WorkQueueManager.queueParams["RowsPerSlice"] = 2500
 # maximum number of available elements rows to be evaluated when acquiring GQ to LQ work
 config.WorkQueueManager.queueParams["MaxRowsPerCycle"] = 50000
-config.WorkQueueManager.queueParams["rucioAccount"] = "wmcore_transferor"  # account for data locks
+# Rucio accounts for input data locks and secondary data locks
+config.WorkQueueManager.queueParams["rucioAccount"] = "wmcore_transferor"
+config.WorkQueueManager.queueParams["rucioAccountPU"] = "wmcore_pileup"
 
 
 config.component_("DBS3Upload")

--- a/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
+++ b/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
@@ -35,7 +35,7 @@ class PileupFetcher(FetcherInterface):
         """
         super(PileupFetcher, self).__init__()
         # FIXME: find a way to pass the Rucio account name to this fetcher module
-        self.rucioAcct = "wmcore_transferor"
+        self.rucioAcct = "wmcore_pileup"
         self.rucio = None
 
     def _queryDbsAndGetPileupConfig(self, stepHelper, dbsReader):

--- a/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
@@ -42,6 +42,7 @@ class StartPolicyInterface(PolicyInterface):
         self.cric = CRIC()
         # FIXME: for the moment, it will always use the default value
         self.rucioAcct = self.args.get("rucioAcct", "wmcore_transferor")
+        self.rucioAcctPU = self.args.get("rucioAcctPU", "wmcore_pileup")
         if not self.rucio:
             self.rucio = Rucio(self.rucioAcct, configDict={'logger': self.logger})
 
@@ -256,7 +257,7 @@ class StartPolicyInterface(PolicyInterface):
         for dbsUrl in datasets:
             for datasetPath in datasets[dbsUrl]:
                 locations = self.rucio.getDataLockedAndAvailable(name=datasetPath,
-                                                                 account=self.rucioAcct)
+                                                                 account=self.rucioAcctPU)
                 result[datasetPath] = self.cric.PNNstoPSNs(locations)
         return result
 

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Fetchers_t/PileupFetcher_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Fetchers_t/PileupFetcher_t.py
@@ -44,7 +44,7 @@ class PileupFetcherTest(EmulatedUnitTestCase):
         couchServer = CouchServer(os.environ["COUCHURL"])
         self.configDatabase = couchServer.connectDatabase("pileupfetcher_t")
         self.testDir = self.testInit.generateWorkDir()
-        self.rucioAcct = "wmcore_transferor"
+        self.rucioAcct = "wmcore_pileup"
         if PY3:
             self.assertItemsEqual = self.assertCountEqual
 


### PR DESCRIPTION
Fixes #11669 

#### Status
Not tested

#### Description
This pull request changes the Rucio account used for secondary input data location, using `wmcore_pileup` instead of `wmcore_transferor` account.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
Depends on the following services_config (for prod, preprod and test branches):
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/226
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/227
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/228
