### PR TITLE
McM client

### DIFF
--- a/src/python/WMCore/Services/McM/McM.py
+++ b/src/python/WMCore/Services/McM/McM.py
@@ -6,15 +6,15 @@ an SSO cookie since it sits behind CERN SSO
 """
 
 from builtins import str, object
-
 import json
 import os
 import pycurl
 import subprocess
-
+import logging
+from typing import List
 from io import BytesIO
-
 from WMCore.WMException import WMException
+
 
 class McMNoDataError(WMException):
     """
@@ -25,6 +25,7 @@ class McMNoDataError(WMException):
     def __init__(self):
         WMException.__init__(self, 'McM responded correctly but has no data')
 
+
 class McM(object):
     """
     A service class for retrieving data from McM using
@@ -32,21 +33,15 @@ class McM(object):
     'key' must be unencrypted
     """
 
-    def __init__(self, cert, key, url='https://cms-pdmv.cern.ch/mcm', tmpDir='/tmp'):
+    def __init__(self, url='https://cms-pdmv.cern.ch/mcm', tmpDir='/tmp'):
         self.url = url
         self.tmpDir = tmpDir
-        self.cert = cert
-        self.key = key
+        self.logger = self._get_logger()
         self.cookieFile = None
 
     def __enter__(self):
-        self.cookieFile = os.path.join(self.tmpDir, 'ssoCookie.txt')
-        process = subprocess.Popen(["cern-get-sso-cookie", "--cert", self.cert, "--key", self.key,
-                                    "-u", self.url, "-o", self.cookieFile],
-                                   stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=False)
-        strout = process.communicate()[0]
-        if process.returncode != 0:
-            raise RuntimeError(" FATAL -- could not generate SSO cookie\nError msg: %s" % (str(strout)))
+        self._krb_ticket()
+        self._get_cookie()
         return self
 
     def __exit__(self, exception_type, exception_value, traceback):
@@ -56,6 +51,61 @@ class McM(object):
             except OSError:
                 return
         return
+
+    def _get_logger(self) -> logging.Logger:
+        """
+        Create a logger for McM client
+        """
+        logger: logging.Logger = logging.getLogger("mcm_client")
+        date_format: str = "%Y-%m-%d %H:%M:%S %z"
+        format: str = "[%(levelname)s][%(name)s][%(asctime)s]: %(message)s"
+        formatter: logging.Formatter = logging.Formatter(fmt=format, datefmt=date_format)
+        handler: logging.StreamHandler = logging.StreamHandler()
+
+        handler.setLevel(logging.INFO)
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        return logger
+
+    def _krb_ticket(self) -> None:
+        """
+        Check there is a valid Kerberos ticket for requesting a SSO
+        cookie. Raise a RuntimeError if there is not one.
+        """
+        process = subprocess.Popen(["klist", "-f"],
+                                   stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=False)
+        stdout: str = process.communicate()[0].decode("utf-8")
+        if process.returncode != 0:
+            msg: str = ("There is no valid Kerberos ticket for requesting a SSO cookie. "
+                        "Please make sure to provide one for your runtime environment"
+                        )
+            self.logger.error(msg)
+            raise RuntimeError("FATAL -- %s\nError msg: %s" % (msg, stdout))
+
+    def _get_cookie(self) -> None:
+        """
+        Request a SSO cookie to authenticate to McM.
+        """
+        self.cookieFile = os.path.join(self.tmpDir, 'ssoCookie.txt')
+        command: List[str] = ["auth-get-sso-cookie", "-u", self.url, "-o", self.cookieFile, "-vv"]
+        callback_not_invoked: str = "DEBUG: Not automatically redirected: trying SAML authentication"
+        cookie_stored: str = "INFO: Saving cookies"
+
+        process = subprocess.Popen(command, stdout=subprocess.PIPE,
+                                   stderr=subprocess.STDOUT, shell=False)
+        stdout: str = process.communicate()[0].decode("utf-8")
+        stdout_list: List[str] = stdout.strip().split("\n")
+        if process.returncode != 0:
+            raise RuntimeError("FATAL -- Error requesting SSO cookie\nError msg: %s" % (stdout))
+
+        if callback_not_invoked in stdout:
+            callback_idx: int = stdout_list.index(callback_not_invoked)
+            stored_after_issue: bool = cookie_stored in stdout_list[callback_idx + 1]
+            if stored_after_issue:
+                msg: str = ("Callback method was not invoked. "
+                            "Please make sure the provided Kerberos ticket is not linked to an account with 2FA"
+                            )
+                raise RuntimeError(msg)
 
     def _getURL(self, extendURL):
         """
@@ -101,7 +151,7 @@ class McM(object):
         try:
             url = 'search?db_name=batches&contains=%s&get_raw' % prepID
             res = self._getURL(url)
-            history = res['rows'][0]['doc']['history']
+            history = res.get("results", [])[0].get("history", [])
             return history
         except IndexError:
             raise McMNoDataError
@@ -116,7 +166,8 @@ class McM(object):
         res = self._getURL(url)
         return res['results']
 
+
 if __name__ == '__main__':
-    with McM(cert='.globus/usercert.pem', key='.globus/nopasskey.pem') as mcm:
-        history = mcm.getHistory(prepID = 'BTV-Upg2023SHCAL14DR-00002')
-        request = mcm.getRequest(prepID = 'BTV-Upg2023SHCAL14DR-00002')
+    with McM() as mcm:
+        history = mcm.getHistory(prepID='BTV-Upg2023SHCAL14DR-00002')
+        request = mcm.getRequest(prepID='BTV-Upg2023SHCAL14DR-00002')

--- a/test/python/WMCore_t/Services_t/McM_t/McM_t.py
+++ b/test/python/WMCore_t/Services_t/McM_t/McM_t.py
@@ -4,15 +4,10 @@ Test case for McM service
 """
 
 import unittest
-
 from nose.plugins.attrib import attr
-
 from WMCore.Services.McM.McM import McM
 
 prepID = 'BTV-Upg2023SHCAL14DR-00002'
-
-cert = 'This must be a X509 certificate registered with CERN SSO with access to McM'
-key = 'This must be the corresponding key unprotected by a password'
 
 
 class McMTest(unittest.TestCase):
@@ -27,7 +22,7 @@ class McMTest(unittest.TestCase):
         """
 
         history = None
-        with McM(cert=cert, key=key) as mcm:
+        with McM() as mcm:
             history = mcm.getHistory(prepID=prepID)
 
         isAnnounced = False
@@ -43,7 +38,41 @@ class McMTest(unittest.TestCase):
         Test that the request URL is working
         """
         request = None
-        with McM(cert=cert, key=key) as mcm:
+        with McM() as mcm:
+            request = mcm.getRequest(prepID=prepID)
+
+        self.assertTrue('total_events' in request)
+
+    @attr("integration")
+    def testHistoryDevelopmentEnv(self):
+        """
+        Test that the history URL is working.
+        McM Development has been migrated to the new SSO
+        (Keycloak)
+        """
+
+        history = None
+        development_url: str = "https://cms-pdmv-dev.cern.ch/mcm"
+        with McM(url=development_url) as mcm:
+            history = mcm.getHistory(prepID=prepID)
+
+        isAnnounced = False
+        for entry in history:
+            if entry['action'] == 'set status' and entry['step'] == 'announced':
+                isAnnounced = True
+
+        self.assertTrue(isAnnounced)
+
+    @attr("integration")
+    def testRequestDevelopmentEnv(self):
+        """
+        Test that the request URL is working.
+        McM Development has been migrated to the new SSO
+        (Keycloak)
+        """
+        request = None
+        development_url: str = "https://cms-pdmv-dev.cern.ch/mcm"
+        with McM(url=development_url) as mcm:
             request = mcm.getRequest(prepID=prepID)
 
         self.assertTrue('total_events' in request)


### PR DESCRIPTION
Fixes #11671

#### Status
not-tested

#### Description
Updates McM client module to request SSO cookies for both SSO components

#### Is it backward compatible (if not, which system it affects?)
NO

There are some changes to McM client constructor method that bring breaking changes. Also, it is required to have a valid Kerberos ticket available in the runtime environment.

#### External dependencies / deployment changes
- auth-get-sso-cookie
- Kerberos

Please make sure that the “auth-get-sso-cookie” package is available in your runtime environment. If you require to install it, please see the following [documentation](https://auth.docs.cern.ch/applications/command-line-tools/)
