### PR TITLE
Fix /proc/<pid>/smaps parsing && Avoid summing Pss_Dirty pages

### DIFF
--- a/src/python/WMCore/WMRuntime/Monitors/PerformanceMonitor.py
+++ b/src/python/WMCore/WMRuntime/Monitors/PerformanceMonitor.py
@@ -85,7 +85,7 @@ class PerformanceMonitor(WMRuntimeMonitor):
         self.pid = None
         self.uid = os.getuid()
         self.monitorBase = "ps -p %i -o pid,ppid,rss,pcpu,pmem,cmd -ww | grep %i"
-        self.pssMemoryCommand = "awk '/^Pss/ {pss += $2} END {print pss}' /proc/%i/smaps"
+        self.pssMemoryCommand = "awk '/^Pss:/ {pss += $2} END {print pss}' /proc/%i/smaps"
         self.monitorCommand = None
         self.currentStepSpace = None
         self.currentStepName = None


### PR DESCRIPTION
Fixes #11667 

#### Status
ready

#### Description
The issue #11667 can be solved in 3 different ways. This is the **first** out of 3 suggested fixes. 
* The current one just fixes the parsing of `/proc/<pid>/smaps` file to avoid including `Pss_Dirty` memory pages in the calculation of `Pss` , which may wrongly increase the accounting of total PSS memory pages (which already  includes `Pss_Dirty`)   

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None