### PR TITLE
Parse /proc/<pid>/smaps_rollup if present && Reduce string concatenaion operations

### DIFF
--- a/src/python/WMCore/WMRuntime/Monitors/PerformanceMonitor.py
+++ b/src/python/WMCore/WMRuntime/Monitors/PerformanceMonitor.py
@@ -84,8 +84,8 @@ class PerformanceMonitor(WMRuntimeMonitor):
 
         self.pid = None
         self.uid = os.getuid()
-        self.monitorBase = "ps -p %i -o pid,ppid,rss,pcpu,pmem,cmd -ww | grep %i"
-        self.pssMemoryCommand = "awk '/^Pss/ {pss += $2} END {print pss}' /proc/%i/smaps"
+        self.monitorBase = "pid=%i; ps -p $pid -o pid,ppid,rss,pcpu,pmem,cmd -ww | grep $pid"
+        self.pssMemoryCommand = "pid=%i; awk '/^Pss:/ {print $2}' /proc/$pid/smaps_rollup 2>/dev/null || awk '/^Pss:/ {pss += $2} END {print pss}' /proc/$pid/smaps"
         self.monitorCommand = None
         self.currentStepSpace = None
         self.currentStepName = None
@@ -210,7 +210,7 @@ class PerformanceMonitor(WMRuntimeMonitor):
 
         # Now we run the ps monitor command and collate the data
         # Gathers RSS, %CPU and %MEM statistics from ps
-        ps_cmd = self.monitorBase % (stepPID, stepPID)
+        ps_cmd = self.monitorBase % (stepPID)
         stdout, _stderr, _retcode = subprocessAlgos.runCommand(ps_cmd)
 
         ps_output = stdout.split()


### PR DESCRIPTION
Fixes #11667 

#### Status
ready

#### Description

The issue https://github.com/dmwm/WMCore/issues/11667 can be solved in 3 different ways. This is the **second** out of 3 suggested fixes.
* The current one parses `/proc/<pid>/smaps_rollup` file if present, (we need a kernel version 4.+ for this), and falls back to parsing `/proc/<pid>/smaps` file if the accumulated statistics file is missing. 

According to the Linux kernel documentation [page](https://www.kernel.org/doc/Documentation/filesystems/proc.rst) about `/proc` file system:   

```
 smaps_rollup	Accumulated smaps stats for all mappings of the process.  This
		can be derived from smaps, but is faster and more convenient
```

Since this is a direct command execution at runtime, I was able to check the result directly line by line:
Here follows the full test I did manually for this change:
```
$ ipython 
Python 3.9.14 (main, Jan  9 2023, 00:00:00) 
Type 'copyright', 'credits' or 'license' for more information
IPython 8.13.2 -- An enhanced Interactive Python. Type '?' for help.
%reload_ext autoreload
%autoreload 2

In [1]: import os

In [2]: import WMCore.Algorithms.SubprocessAlgos as subprocessAlgos

In [3]: monitorBase = "pid=%i; ps -p $pid -o pid,ppid,rss,pcpu,pmem,cmd -ww | grep $pid"

In [4]: pssMemoryCommand = "pid=%i; awk '/^Pss:/ {print $2}' /proc/$pid/smaps_rollup 2>/dev/null || awk '/^Pss:/ {pss += $2} END {print pss}' /proc/$pid/smaps"

In [5]: subprocessAlgos.runCommand(monitorBase % os.getpid())
Out[5]: 
('   4044    2855 58376  1.4  3.6 /data/WMCore.venv3/bin/python /data/WMCore.venv3/bin/ipython\n',
 '',
 0)

In [6]: subprocessAlgos.runCommand(pssMemoryCommand % os.getpid())
Out[6]: ('51534\n', '', 0)

```

As one can see the so modified `monitorBase` and `pssMemoryCommand` lines, return exactly the same tuples as output, just like the original code, but are using the accumulated process statistics file instead. I have checked the values returned multiple time - they were the same regardless of which file we use.  

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
No
