### PR TITLE
Backport of wmcore_pileup changes for MSPileup and Global WorkQueue

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -151,7 +151,9 @@ config.WorkQueueManager.queueParams["QueueDepth"] = 0.5  # pull work from GQ for
 config.WorkQueueManager.queueParams["RowsPerSlice"] = 2500
 # maximum number of available elements rows to be evaluated when acquiring GQ to LQ work
 config.WorkQueueManager.queueParams["MaxRowsPerCycle"] = 50000
-config.WorkQueueManager.queueParams["rucioAccount"] = "wmcore_transferor"  # account for data locks
+# Rucio accounts for input data locks and secondary data locks
+config.WorkQueueManager.queueParams["rucioAccount"] = "wmcore_transferor"
+config.WorkQueueManager.queueParams["rucioAccountPU"] = "wmcore_pileup"
 
 
 config.component_("DBS3Upload")

--- a/src/python/WMCore/MicroService/MSPileup/MSPileupTaskManager.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupTaskManager.py
@@ -32,7 +32,7 @@ class MSPileupTaskManager(MSCore):
     def __init__(self, msConfig, **kwargs):
         super().__init__(msConfig, **kwargs)
         self.marginSpace = msConfig.get('marginSpace', 1024**4)
-        self.rucioAccount = msConfig.get('rucioAccount', 'wmcore_transferor')
+        self.rucioAccount = msConfig.get('rucioAccount', 'wmcore_pileup')
         self.rucioUrl = msConfig['rucioUrl']  # aligned with MSCore init
         self.rucioAuthUrl = msConfig['rucioAuthUrl']  # aligned with MSCore init
         self.cleanupDaysThreshold = msConfig.get('cleanupDaysThreshold', 15)

--- a/src/python/WMCore/MicroService/MSPileup/MSPileupTasks.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupTasks.py
@@ -257,7 +257,7 @@ def monitoringTask(doc, spec):
     modify = False
 
     if not rules:
-        logger.info(f"Did not find any wmcore_transferor rules for container: {pname}.")
+        logger.info(f"Did not find any {rucioAccount} rules for container: {pname}.")
         if not doc['expectedRSEs']:
             logger.warning(f"Container: {pname} is active but has no expected RSEs.")
         elif doc['currentRSEs'] or doc['ruleIds']:

--- a/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
+++ b/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
@@ -35,7 +35,7 @@ class PileupFetcher(FetcherInterface):
         """
         super(PileupFetcher, self).__init__()
         # FIXME: find a way to pass the Rucio account name to this fetcher module
-        self.rucioAcct = "wmcore_transferor"
+        self.rucioAcct = "wmcore_pileup"
         self.rucio = None
 
     def _queryDbsAndGetPileupConfig(self, stepHelper, dbsReader):

--- a/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
@@ -42,6 +42,7 @@ class StartPolicyInterface(PolicyInterface):
         self.cric = CRIC()
         # FIXME: for the moment, it will always use the default value
         self.rucioAcct = self.args.get("rucioAcct", "wmcore_transferor")
+        self.rucioAcctPU = self.args.get("rucioAcctPU", "wmcore_pileup")
         if not self.rucio:
             self.rucio = Rucio(self.rucioAcct, configDict={'logger': self.logger})
 
@@ -256,7 +257,7 @@ class StartPolicyInterface(PolicyInterface):
         for dbsUrl in datasets:
             for datasetPath in datasets[dbsUrl]:
                 locations = self.rucio.getDataLockedAndAvailable(name=datasetPath,
-                                                                 account=self.rucioAcct)
+                                                                 account=self.rucioAcctPU)
                 result[datasetPath] = self.cric.PNNstoPSNs(locations)
         return result
 


### PR DESCRIPTION
Backport of wmcore_pileup changes for 2.2.2_cmsweb, from the following 2 PRs:
* Update default rucio account for MSPileUp service #11673 
* Adopt wmcore_pileup Rucio account in workqueue #11670 