### PR TITLE
Bundle of patches for WMAgent 2.2.3.2

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -151,7 +151,9 @@ config.WorkQueueManager.queueParams["QueueDepth"] = 0.5  # pull work from GQ for
 config.WorkQueueManager.queueParams["RowsPerSlice"] = 2500
 # maximum number of available elements rows to be evaluated when acquiring GQ to LQ work
 config.WorkQueueManager.queueParams["MaxRowsPerCycle"] = 50000
-config.WorkQueueManager.queueParams["rucioAccount"] = "wmcore_transferor"  # account for data locks
+# Rucio accounts for input data locks and secondary data locks
+config.WorkQueueManager.queueParams["rucioAccount"] = "wmcore_transferor"
+config.WorkQueueManager.queueParams["rucioAccountPU"] = "wmcore_pileup"
 
 
 config.component_("DBS3Upload")

--- a/src/python/WMCore/WMRuntime/Monitors/PerformanceMonitor.py
+++ b/src/python/WMCore/WMRuntime/Monitors/PerformanceMonitor.py
@@ -84,8 +84,8 @@ class PerformanceMonitor(WMRuntimeMonitor):
 
         self.pid = None
         self.uid = os.getuid()
-        self.monitorBase = "ps -p %i -o pid,ppid,rss,pcpu,pmem,cmd -ww | grep %i"
-        self.pssMemoryCommand = "awk '/^Pss/ {pss += $2} END {print pss}' /proc/%i/smaps"
+        self.monitorBase = "pid=%i; ps -p $pid -o pid,ppid,rss,pcpu,pmem,cmd -ww | grep $pid"
+        self.pssMemoryCommand = "pid=%i; awk '/^Pss:/ {print $2}' /proc/$pid/smaps_rollup 2>/dev/null || awk '/^Pss:/ {pss += $2} END {print pss}' /proc/$pid/smaps"
         self.monitorCommand = None
         self.currentStepSpace = None
         self.currentStepName = None
@@ -210,7 +210,7 @@ class PerformanceMonitor(WMRuntimeMonitor):
 
         # Now we run the ps monitor command and collate the data
         # Gathers RSS, %CPU and %MEM statistics from ps
-        ps_cmd = self.monitorBase % (stepPID, stepPID)
+        ps_cmd = self.monitorBase % (stepPID)
         stdout, _stderr, _retcode = subprocessAlgos.runCommand(ps_cmd)
 
         ps_output = stdout.split()

--- a/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
+++ b/src/python/WMCore/WMSpec/Steps/Fetchers/PileupFetcher.py
@@ -35,7 +35,7 @@ class PileupFetcher(FetcherInterface):
         """
         super(PileupFetcher, self).__init__()
         # FIXME: find a way to pass the Rucio account name to this fetcher module
-        self.rucioAcct = "wmcore_transferor"
+        self.rucioAcct = "wmcore_pileup"
         self.rucio = None
 
     def _queryDbsAndGetPileupConfig(self, stepHelper, dbsReader):

--- a/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
@@ -42,6 +42,7 @@ class StartPolicyInterface(PolicyInterface):
         self.cric = CRIC()
         # FIXME: for the moment, it will always use the default value
         self.rucioAcct = self.args.get("rucioAcct", "wmcore_transferor")
+        self.rucioAcctPU = self.args.get("rucioAcctPU", "wmcore_pileup")
         if not self.rucio:
             self.rucio = Rucio(self.rucioAcct, configDict={'logger': self.logger})
 
@@ -256,7 +257,7 @@ class StartPolicyInterface(PolicyInterface):
         for dbsUrl in datasets:
             for datasetPath in datasets[dbsUrl]:
                 locations = self.rucio.getDataLockedAndAvailable(name=datasetPath,
-                                                                 account=self.rucioAcct)
+                                                                 account=self.rucioAcctPU)
                 result[datasetPath] = self.cric.PNNstoPSNs(locations)
         return result
 


### PR DESCRIPTION
Backported version for `2.2.3_wmagent` for:
* Parse /proc/<pid>/smaps_rollup if present && Reduce string concatenaion operations #11676 
* Adopt wmcore_pileup Rucio account in workqueue #11670 