### PR TITLE
Characterization and propagation of task type based on cmsDriver steps

### DIFF
--- a/src/python/WMComponent/JobCreator/JobCreatorPoller.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorPoller.py
@@ -145,6 +145,7 @@ def saveJob(job, thisJobNumber, **kwargs):
     job['requiresGPU'] = kwargs['requiresGPU']
     job['gpuRequirements'] = kwargs['gpuRequirements']
     job['requestType'] = kwargs['requestType']
+    job['physicsTaskType'] = kwargs['physicsTaskType']
     job['campaignName'] = kwargs['campaignName']
 
     with open(os.path.join(cacheDir, 'job.pkl'), 'wb') as output:
@@ -540,8 +541,9 @@ class JobCreatorPoller(BaseWorkerThread):
                                'scramArch': wmTask.getScramArch(),
                                'agentNumber': self.agentNumber,
                                'agentName': self.agentName,
+                               'allowOpportunistic': allowOpport,
                                'campaignName': wmTask.getCampaignName(),
-                               'allowOpportunistic': allowOpport,}
+                               'physicsTaskType': wmTask.getPhysicsTaskType()}
 
                 tempSubscription = Subscription(id=wmbsSubscription['id'])
 

--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -409,6 +409,7 @@ class JobSubmitterPoller(BaseWorkerThread):
                        'gpuRequirements': loadedJob.get('gpuRequirements', None),
                        'campaignName': loadedJob.get('campaignName', None),
                        'requestType': loadedJob['requestType'],
+                       'physicsTaskType': loadedJob.get('physicsTaskType', None)
                        }
             # then update it with the info retrieved from the database
             jobInfo.update(newJob)

--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -536,6 +536,10 @@ class SimpleCondorPlugin(BasePlugin):
             ad['My.CMS_JobType'] = classad.quote(job['task_type'])
             ad['My.CMS_Type'] = classad.quote(activityToType(job['activity']))
             ad['My.CMS_RequestType'] = classad.quote(job['requestType'])
+            if job.get('physicsTaskType', None):
+                ad['My.CMS_extendedJobType'] = classad.quote(job['physicsTaskType'])
+            else:
+                ad['My.CMS_extendedJobType'] = classad.quote(job['task_type'])
             if job.get('campaignName') is None:
                 ad['My.CMS_CampaignName'] = classad.quote(job['campaignName'])
             else:

--- a/src/python/WMCore/BossAir/RunJob.py
+++ b/src/python/WMCore/BossAir/RunJob.py
@@ -70,6 +70,7 @@ class RunJob(dict):
         self.setdefault('gpuRequirements', None)
         self.setdefault('campaignName', None)
         self.setdefault('requestType', None)
+        self.setdefault('physicsTaskType', None)
 
         return
 

--- a/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
@@ -346,7 +346,9 @@ class StepChainWorkloadFactory(StdBase):
             parentCmsswStepHelper.keepOutput(parentKeepOutput)
             childKeepOutput = strToBool(taskConf.get('KeepOutput', True))
             currentCmsswStepHelper.keepOutput(childKeepOutput)
-            self.setupOutputModules(task, taskConf, currentCmsRun, childKeepOutput)
+            configCache = self.loadCouchID(taskConf["ConfigCacheID"], self.configCacheUrl, self.couchDBName)
+            self.setupOutputModules(task, taskConf, currentCmsRun, childKeepOutput, configCache)
+            currentCmsswStepHelper.setPhysicsType(configCache)
 
             # Get and append campaign name for each step
             if taskConf.get("Campaign", None) is not None:
@@ -358,6 +360,8 @@ class StepChainWorkloadFactory(StdBase):
 
         # Closing out the task configuration. The last step output must be saved/merged
         currentCmsswStepHelper.keepOutput(True)
+        # Since we added more cmssw steps to the task, update physics task type
+        task.setPhysicsTaskType()
 
         # Set campaign name
         if campaignNames:
@@ -381,20 +385,21 @@ class StepChainWorkloadFactory(StdBase):
         else:
             return topLevelValue
 
-    def setupOutputModules(self, task, taskConf, stepCmsRun, keepOutput):
+    def setupOutputModules(self, task, taskConf, stepCmsRun, keepOutput, configCache):
         """
-        _setupOutputModules_
-
         Retrieves the outputModules from the step configuration and sets up
         a merge task for them. Only when KeepOutput is set to True.
+        :param task: WMTask object
+        :param taskConf: dict with task parameters
+        :param stepCmsRun: cms step name
+        :param keepOutput: bool
+        :param configCache: configCache object
         """
         taskConf = taskConf or {}
 
         outputMods = {}
+        configOutput = self.determineOutputModules(configCache=configCache)
 
-        configOutput = self.determineOutputModules(configDoc=taskConf["ConfigCacheID"],
-                                                   configCacheUrl=self.configCacheUrl,
-                                                   couchDBName=self.couchDBName)
         for outputModuleName in configOutput:
             outputModule = self.addOutputModule(task, outputModuleName,
                                                 self.inputPrimaryDataset,
@@ -617,9 +622,8 @@ class StepChainWorkloadFactory(StdBase):
                                                getOutputModules=False)
             # we cannot save output of two steps using the same output module and datatier(s)
             if strToBool(step.get("KeepOutput", True)):
-                configOutput = self.determineOutputModules(configDoc=step["ConfigCacheID"],
-                                                           configCacheUrl=schema['ConfigCacheUrl'],
-                                                           couchDBName=schema["CouchDBName"])
+                configCache = self.loadCouchID(step["ConfigCacheID"], schema['ConfigCacheUrl'], schema["CouchDBName"])
+                configOutput = self.determineOutputModules(configCache=configCache)
                 for modName, values in viewitems(configOutput):
                     thisOutput = (modName, values['dataTier'])
                     if thisOutput in outputModTier:

--- a/src/python/WMCore/WMSpec/Steps/Templates/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Templates/CMSSW.py
@@ -13,6 +13,8 @@ from future.utils import viewitems
 from Utils.Utilities import encodeUnicodeToBytes
 from WMCore.WMSpec.ConfigSectionTree import nodeName
 from WMCore.WMSpec.Steps.Template import CoreHelper, Template
+from WMCore.Cache.WMConfigCache import ConfigCacheException
+import shlex
 
 
 class CMSSWStepHelper(CoreHelper):
@@ -417,6 +419,116 @@ class CMSSWStepHelper(CoreHelper):
         """
         return (self.data.application.gpu.gpuRequired,
                 self.data.application.gpu.gpuRequirements)
+
+    def getPhysicsTypeFromStepsArg(self, stepsArg, hasPileup=False, hasDatamix=False):
+        """
+        Get information about the step physics type, based on the
+        cmsDriver command line --steps argument
+        Reference: https://github.com/cms-sw/cmssw/issues/42587
+        :param stepsArg: str with the cmsDriver step arguments
+        :param hasPileup: bool, cmsDriver option
+        :param hasDatamix: bool, cmsDriver option
+        :return: str with all physics types, comman separated
+        """
+        physicsTypes = {"GEN":"GEN", "SIM":"SIM", "DIGI":"DIGI", "RECO":"RECO", "PAT":"MINIAOD", "NANO":"NANOAOD", "ALL":"GEN,SIM,DIGI,RECO"}
+        stepTypes = []
+        for stepType in physicsTypes.keys():
+            for step in stepsArg.split(","):
+                # Steps like DIGI could come in the form of DIGI:pdigi_valid
+                step = step.split(':')[0]
+                if step == stepType:
+                    physicsType = physicsTypes.get(stepType)
+                    if step == "DIGI":
+                        if hasPileup:
+                            if hasDatamix: 
+                                physicsType = "DIGI_premix"
+                            else:
+                                physicsType = "DIGI_classicalmix"
+                        else:
+                            physicsType = "DIGI_nopileup"
+                    stepTypes.append(physicsType)
+        if not stepTypes:
+            stepTypes.append("UNKNOWN")
+
+        return ",".join(stepTypes)
+
+    def getCmsDriverCommandLineArgs(self, conf):
+        """
+        Find the command line arguments in a pset config file
+        :param conf: config document from configCache object
+        :return: str with the cmsDriver command line arguments
+        """
+        # First, split all new lines
+        conf = conf.split('\n')
+        # Comment line 4 usually has the command line arguments
+        # but find it otherwise (from the comment lines in the conf)
+        cmdPattern = "# with command line options:"
+        cmd = None
+        if conf[4].startswith(cmdPattern):
+            cmd = conf[4]
+        else:
+            for line in conf:
+                if line.startswith(cmdPattern):
+                    cmd = line
+                elif not line.startswith('#'):
+                    break
+        # Replace "=" with spaces
+        # E.g.: --step=DIGI -> --step DIGI
+        if cmd:
+            cmd = cmd.replace("=", " ")
+    
+        return cmd
+
+    def determinePhysicsType(self, configCache=None):
+        """
+        Get information about the step physics type
+        :param configCache: configCache object
+        :return: str with the physics types, command separated.
+        """
+        hasPileup = False
+        hasDatamix = False
+        try:
+            if configCache:
+                # command arguments are in line 4
+                myconf = configCache.getConfig()
+                if myconf == None:
+                    return "UNKNOWN"
+                cmd = self.getCmsDriverCommandLineArgs(myconf)
+                cmd = shlex.split(cmd)
+                # If we are processing data,
+                # just return "DataProcessing"
+                if "--data" in cmd:
+                    return "DataProcessing"
+                # The command step arg is either '--step' or '-s'
+                # Check for premixing and pileup parameters
+                if "--pileup_input" in cmd:
+                    hasPileup = True
+                if "--datamix" in cmd:
+                    hasDatamix = True
+                try:
+                    stepsArg = cmd[cmd.index("--step")+1]
+                except ValueError:
+                    stepsArg = cmd[cmd.index("-s")+1]
+            else:
+                stepsArg = "UNKNOWN"
+        except (ConfigCacheException, AttributeError, ValueError) as ex:
+            stepsArg = "UNKNOWN"
+
+        return self.getPhysicsTypeFromStepsArg(stepsArg, hasPileup, hasDatamix)
+
+    def getPhysicsType(self):
+        """
+        Set the physics type of the step
+        :return: str
+        """
+        return getattr(self.data, "stepPhysicsType", None)
+
+    def setPhysicsType(self, configCache=None):
+        """
+        Set the physics type of the step.
+        :param configCache: configCache object
+        """
+        self.data.stepPhysicsType = self.determinePhysicsType(configCache)
 
 
 class CMSSW(Template):

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -1325,6 +1325,53 @@ class WMTaskHelper(TreeHelper):
                 IDs.append(ID)
         return IDs
 
+    def getPhysicsTaskType(self):
+        """
+        Return the physics Task type
+        :return: str
+        """
+        return getattr(self.data, 'physicsTaskType', None)
+
+    def getStepPhysicsTypes(self):
+        """
+        Get the physics types for all cmsRun steps
+        :return: list
+        """
+        types = []
+        for stepName in self.listAllStepNames(cmsRunOnly=True):
+           stepHelper = self.getStepHelper(stepName)
+           stepType = stepHelper.getPhysicsType()
+           if stepType:
+               types.append(stepType)
+           else:
+               types.append("UNKNOWN")
+        return types
+
+    def setPhysicsTaskType(self):
+        """
+        Set the physics task type based on the steps parameter
+        for a step.
+        We basically expand the standard "Production/Processing" taskType to
+        detail the process better. 
+        For MC: "Production" or "Processing" to ["GENSIM", "GEN", "DIGI", "RECO", "DIGIRECO", "MINIAOD"]
+        For Data: "Processing" to "Dataprocessing"
+        :return: str
+        """
+        physicsTaskType = "UNKNOWN"
+        if self.taskType() in ("Processing", "Production"):
+            stepTypes = self.getStepPhysicsTypes()
+            if "DataProcessing" in stepTypes:
+                # For data, return a single DataProcessing step
+                physicsTaskType = "DataProcessing"
+            else:
+                # For MC, join all physics steps
+                physicsTaskType = ",".join(stepTypes)
+        else:
+            # Other task types are not physics types
+            physicsTaskType = None
+
+        self.data.physicsTaskType = physicsTaskType
+
     def setProcessingVersion(self, procVer, parentProcessingVersion=0, stepChainMap=False):
         """
         _setProcessingVersion_

--- a/src/python/WMQuality/Emulators/WMSpecGenerator/Samples/BasicProductionWorkload.py
+++ b/src/python/WMQuality/Emulators/WMSpecGenerator/Samples/BasicProductionWorkload.py
@@ -108,6 +108,10 @@ class TestTaskChainFactory(TaskChainWorkloadFactory):
         "Don't talk to couch"
         return {}
 
+    def loadCouchID(self, *args, **kwargs):
+        "Don't talk to couch"
+        return None
+
 def taskChainWorkload(workloadName, arguments):
     """
     _monteCarloWorkload_

--- a/test/python/WMComponent_t/JobCreator_t/JobCreator_t.py
+++ b/test/python/WMComponent_t/JobCreator_t/JobCreator_t.py
@@ -343,6 +343,48 @@ class JobCreatorTest(EmulatedUnitTestCase):
 
         return
 
+    def testPhysicsType(self):
+        """
+        Test physics type is written into job pickle file
+        """
+        myThread = threading.currentThread()
+
+        config = self.getConfig()
+
+        name = makeUUID()
+        nSubs = 1
+        nFiles = 1
+        workloadName = 'TestWorkload'
+
+        dummyWorkload = self.createWorkload(workloadName=workloadName)
+        workloadPath = os.path.join(self.testDir, 'workloadTest', 'TestWorkload', 'WMSandbox', 'WMWorkload.pkl')
+
+        self.createJobCollection(name=name, nSubs=nSubs, nFiles=nFiles, workflowURL=workloadPath)
+
+        testJobCreator = JobCreatorPoller(config=config)
+
+        # First, can we run once without everything crashing?
+        testJobCreator.algorithm()
+
+        getJobsAction = self.daoFactory(classname="Jobs.GetAllJobs")
+        result = getJobsAction.execute(state='Created', jobType="Processing")
+
+        # Find the test directory
+        testDirectory = os.path.join(self.testDir, 'jobCacheDir', 'TestWorkload', 'ReReco')
+        groupDirectory = os.path.join(testDirectory, 'JobCollection_1_0')
+
+        # Get job pickle file
+        jobDir = os.listdir(groupDirectory)[0]
+        jobFile = os.path.join(groupDirectory, jobDir, 'job.pkl')
+        self.assertTrue(os.path.isfile(jobFile))
+        with open(jobFile, 'rb') as f:
+            job = pickle.load(f)
+
+        # Attribute campaign name should exist
+        # but be set to the default value: None
+        self.assertEqual(job['physicsTaskType'], None)
+
+        return
     @attr('performance', 'integration')
     def testProfilePoller(self):
         """

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
@@ -2643,10 +2643,10 @@ class StepChainTests(EmulatedUnitTestCase):
 
         factory = StepChainWorkloadFactory()
         testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
-
         testArguments['Step1'].update({"Campaign": "Campaign"})
         testArguments['Step2'].update({"Campaign": "Campaign"})
         testArguments['Step3'].update({"Campaign": "Campaign"})
+
         factory = StepChainWorkloadFactory()
         testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
         task = testWorkload.getTask(taskName=testArguments['Step1']['StepName'])
@@ -2676,6 +2676,29 @@ class StepChainTests(EmulatedUnitTestCase):
         task = testWorkload.getTask(taskName=testArguments['Step1']['StepName'])
 
         self.assertEqual(task.getCampaignName(), "TaskForceUnitTest")
+
+        return
+
+    def testSetPhysicsType(self):
+        """
+        Check step physics type is properly set at step level and reported
+        in WMTask
+        """
+        testArguments = StepChainWorkloadFactory.getTestArguments()
+        testArguments.update(deepcopy(REQUEST))
+
+        configDocs = injectStepChainConfigMC(self.configDatabase)
+        for s in ['Step1', 'Step2', 'Step3']:
+            testArguments[s]['ConfigCacheID'] = configDocs[s]
+        testArguments['Step2']['KeepOutput'] = False
+
+        factory = StepChainWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
+
+        factory = StepChainWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
+        task = testWorkload.getTask(taskName=testArguments['Step1']['StepName'])
+        self.assertEqual(task.getPhysicsTaskType(), "UNKNOWN,UNKNOWN,UNKNOWN")
 
         return
 

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
@@ -2510,5 +2510,25 @@ class TaskChainTests(EmulatedUnitTestCase):
         taskObj = testWorkload.getTaskByName("RECO")
         self.assertEqual(taskObj.getCampaignName(), "Campaign_RECO")
 
+    def testSetPhysicsTypeTaskChainTasks(self):
+        """
+        Test campaign names in tasks
+        """
+        processorDocs = makeProcessingConfigs(self.configDatabase)
+
+        arguments = TaskChainWorkloadFactory.getTestArguments()
+        arguments.update(deepcopy(REQUEST_INPUT))
+        arguments['Task1']['ConfigCacheID'] = processorDocs['DigiHLT']
+        arguments['Task2']['ConfigCacheID'] = processorDocs['Reco']
+        factory = TaskChainWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("PullingTheChain", arguments)
+
+        taskObj = testWorkload.getTaskByName("DIGI")
+        taskObj.data.physicsTaskType = "DIGI"
+        self.assertEqual(taskObj.getPhysicsTaskType(), "DIGI")
+        taskObj = testWorkload.getTaskByName("RECO")
+        taskObj.data.physicsTaskType = "RECO"
+        self.assertEqual(taskObj.getPhysicsTaskType(), "RECO")
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Templates_t/CMSSWTemplate_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Templates_t/CMSSWTemplate_t.py
@@ -182,6 +182,28 @@ class CMSSWTemplateTest(unittest.TestCase):
         self.assertEqual(helper.getGPURequired(), "required")
         self.assertItemsEqual(helper.getGPURequirements(), {"key1": "value1", "key2": "value2"})
 
+    def testGetPhysicsTypeFromStepsArgs(self):
+        """
+        Test characterization of physics types from steps args at CMSSW template level
+        """
+        workload = newWorkload("UnitTests")
+        task = workload.newTask("CMSSWTemplate")
+        stepHelper = task.makeStep("TemplateTest")
+        step = stepHelper.data
+        template = CMSSWTemplate()
+        template(step)
+
+        helper = template.helper(step)
+        steps = "LHE,GEN,SIM"
+        self.assertEqual(helper.getPhysicsTypeFromStepsArg(steps), "GEN,SIM")
+        steps = "DIGI,DATAMIX,L1,DIGI2RAW,HLT:2022v14"
+        self.assertEqual(helper.getPhysicsTypeFromStepsArg(steps), "DIGI_nopileup")
+        self.assertEqual(helper.getPhysicsTypeFromStepsArg(steps, hasPileup=True,hasDatamix=True), "DIGI_premix")
+        self.assertEqual(helper.getPhysicsTypeFromStepsArg(steps, hasPileup=True,hasDatamix=False), "DIGI_classicalmix")
+        steps = "RAW2DIGI,L1Reco,RECO,RECOSIM"
+        self.assertEqual(helper.getPhysicsTypeFromStepsArg(steps), "RECO")
+        steps = "PAT,NANO"
+        self.assertEqual(helper.getPhysicsTypeFromStepsArg(steps), "MINIAOD,NANOAOD")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #11712

#### Status
Ready for review

#### Description
Parse the job PSet configuration and extract relevant fields of the cmsDriver command to map them to a given physics type.

A detailed view of the changes provided in this PR is:
* job creator now dumps `physicsTaskType` attribute as well; later used by JobSubmitter and SimpleCondorPlugin
* new `CMS_extendedJobType` condor classad is provided, being a comma separated list of physics task type
* StdSpecs: change how the configCache is loaded and output modules determined.
* provide physics type getter/setter methods for both WMTask and CMSSW (WMStep) modules 

#### Is it backward compatible (if not, which system it affects?)
NO

#### Related PRs
https://github.com/dmwm/cms-htcondor-es/pull/206/files

#### External dependencies / deployment changes
None
