### PR TITLE
Fix use of input function in unregister-wmstats script

### DIFF
--- a/bin/wmagent-unregister-wmstats
+++ b/bin/wmagent-unregister-wmstats
@@ -24,9 +24,8 @@ if __name__ == "__main__":
     else:
         agentUrl = args[0]
 
-    msg = "Are you sure you want to remove agent info record for %s from wmstats? Type 'yes' or 'no' (type quotes too!): "
-    answer = eval(input(msg % agentUrl))
-    if answer != "yes":
+    answer = input(f"Remove agent info record from wmstats for {agentUrl}? [y/n] ")
+    if answer.lower() not in ["y", "yes"]:
         print("Aborting... no changes were made.")
         sys.exit(1)
 


### PR DESCRIPTION
Fixes #11065 (belated complement)

#### Status
ready

#### Description
Just changing how we have to type in our answer when deleting an agent document from WMStats. Now there is no need anymore for typing quotes as well :)

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Complement to https://github.com/dmwm/WMCore/pull/11419

#### External dependencies / deployment changes
No
