### PR TITLE
Refactor StepChainParentage thread to resolve by workflow

### DIFF
--- a/bin/adhoc-scripts/fixWorkflowParentage.py
+++ b/bin/adhoc-scripts/fixWorkflowParentage.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This script runs the same logic as the one executed by the StepChainParentage
+CherryPy thread, available under:
+https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/ReqMgr/CherryPyThreads/StepChainParentageFixTask.py
+
+However, it takes a workflow name as input and performs the parentage fix only
+against that one workflow.
+Use case for this is on workflows that require a very large memory footprint.
+"""
+import time
+import logging
+import os
+import sys
+import psutil
+
+from WMCore.Services.DBS.DBS3Reader import DBS3Reader
+from WMCore.Services.RequestDB.RequestDBWriter import RequestDBWriter
+
+
+REQMGR_URL = 'https://cmsweb.cern.ch/couchdb/reqmgr_workload_cache'
+DBS_URL = 'https://cmsweb.cern.ch/dbs/prod/global/DBSWriter'
+
+
+def getChildDatasetsForStepChainMissingParent(reqmgrDB, wflowName):
+    """
+    Similar to the method implemented in the CherryPy thread.
+    :param reqmgrDB: object to the RequestDBWriter class
+    :param wflowName: string with the workflow name
+    :return: a dictionaries with request name and children datasets
+    """
+    data = reqmgrDB.getRequestByNames(wflowName)
+    for reqName, info in data.items():
+        childrenDsets = []
+        for _stepNum, dsetDict in info.get("ChainParentageMap", {}).items():
+            childrenDsets.extend(dsetDict['ChildDsets'])
+        wflowChildrenDsets = {"workflowName": reqName, "childrenDsets": childrenDsets}
+    return wflowChildrenDsets
+
+
+def updateParentageFlag(reqName, reqmgrDB, logger):
+    """
+    Given a workflow name, update its ParentageResolved flag in
+    ReqMgr2.
+    :param reqName: string with the workflow name
+    :return: none
+    """
+    try:
+        reqmgrDB.updateRequestProperty(reqName, {"ParentageResolved": True})
+        logger.info("  Marked ParentageResolved=True for request: %s", reqName)
+    except Exception as exc:
+        logger.error("  Failed to update 'ParentageResolved' flag to True for request: %s", reqName)
+
+
+def main():
+    """Executes everything"""
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+    logging.basicConfig()
+
+    if len(sys.argv) != 2:
+        logger.error("Please provide the workflow name as argument.")
+        logger.error("E.g.: python fixWorkflowParentage.py my_workflow_name")
+        sys.exit(1)
+
+    wflowName = sys.argv[1]
+    reqmgrDB = RequestDBWriter(REQMGR_URL)
+    dbsSvc = DBS3Reader(DBS_URL, logger=logger)
+
+    # memory usage before starting the actual processing
+    thisPID = os.getpid()
+    thisProc = psutil.Process(thisPID)
+    with thisProc.oneshot():
+        logger.info(f"Initial memory info: {thisProc.memory_full_info()}")
+        logger.info(f"Initial memory info: {thisProc.cpu_times()}")
+
+    # retrieve request from ReqMgr2
+    wflowData = getChildDatasetsForStepChainMissingParent(reqmgrDB, wflowName)
+
+    # measure time taken to fix the actual workflow parentage
+    start = time.time()
+    parentageResolved = True
+    for childDS in wflowData["childrenDsets"]:
+        logger.info("  Handling parentage for child dataset: %s", childDS)
+        try:
+            failedBlocks = dbsSvc.fixMissingParentageDatasets(childDS, insertFlag=True)
+        except Exception as exc:
+            logger.exception("  Failed to resolve parentage data for dataset: %s. Error: %s", childDS, str(exc))
+            parentageResolved = False
+        else:
+            if failedBlocks:
+                logger.warning("  These blocks failed to be resolved and will be retried later: %s", failedBlocks)
+                parentageResolved = False
+            else:
+                logger.info("  Parentage for '%s' successfully updated.", childDS)
+    timeTaken = time.time() - start
+    logger.info(f"  time spent with workflow {wflowData['workflowName']} is: {timeTaken} secs")
+    if parentageResolved:
+        # then we can update the request flag
+        updateParentageFlag(wflowData['workflowName'], reqmgrDB=reqmgrDB, logger=logger)
+    else:
+        logger.warning(f" Workflow {wflowData['workflowName']} will be retried in the next cycle")
+
+    with thisProc.oneshot():
+        memUsed = thisProc.memory_full_info()
+        logger.info(f"Final memory info: {memUsed} with PSS: {memUsed.pss / (1024 **2)} MB")
+        logger.info(f"Final memory info: {thisProc.cpu_times()}")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/python/WMCore/ReqMgr/CherryPyThreads/StepChainParentageFixTask.py
+++ b/src/python/WMCore/ReqMgr/CherryPyThreads/StepChainParentageFixTask.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
-from __future__ import (division, print_function)
-from future.utils import viewitems, viewvalues
-
 import time
-from collections import defaultdict
 
 from WMCore.REST.CherryPyPeriodicTask import CherryPyPeriodicTask
 from WMCore.Services.DBS.DBS3Reader import DBS3Reader
@@ -12,24 +8,24 @@ from WMCore.Services.RequestDB.RequestDBWriter import RequestDBWriter
 
 def getChildDatasetsForStepChainMissingParent(reqmgrDB, status):
     """
-    :param status: workflow status
-    :return: set of child dataset
+    Fetches data from ReqMgr2/CouchDB for workflows that need to
+    have their parentage information fixed.
+    :param status: string with the workflow status
+    :return: a flat list of dictionaries with request name and children datasets
     """
     results = reqmgrDB.getStepChainDatasetParentageByStatus(status)
-
-    requestsByChildDataset = defaultdict(set)
-
-    for reqName, info in viewitems(results):
-
-        for dsInfo in viewvalues(info):
-            for childDS in dsInfo["ChildDsets"]:
-                requestsByChildDataset[childDS].add(reqName)
-    return requestsByChildDataset
+    wflowChildrenDsets = []
+    for reqName, info in results.items():
+        childrenDsets = []
+        for _stepNum, dsetDict in info.items():
+            childrenDsets.extend(dsetDict['ChildDsets'])
+        wflowChildrenDsets.append({"workflowName": reqName, "childrenDsets": childrenDsets})
+    return wflowChildrenDsets
 
 
 class StepChainParentageFixTask(CherryPyPeriodicTask):
     """
-    Upldates StepChain parentage periodically
+    Updates StepChain parentage periodically
     """
 
     def __init__(self, rest, config):
@@ -51,52 +47,57 @@ class StepChainParentageFixTask(CherryPyPeriodicTask):
         Fix the StepChain parentage and update the ParentageResolved flag to True
         """
         self.logger.info("Running fixStepChainParentage thread for statuses: %s", self.statusToCheck)
-        childDatasets = set()
-        requests = set()
-        requestsByChildDataset = {}
+        fixedCount = 0
         for status in self.statusToCheck:
-            reqByChildDS = getChildDatasetsForStepChainMissingParent(self.reqmgrDB, status)
-            self.logger.info("Retrieved %d datasets to fix parentage, in status: %s",
-                             len(reqByChildDS), status)
-            childDatasets = childDatasets.union(set(reqByChildDS.keys()))
-            # We need to just get one of the StepChain workflow if multiple workflow contains the same datasets. (i.e. ACDC)
-            requestsByChildDataset.update(reqByChildDS)
+            listWflowChildren = getChildDatasetsForStepChainMissingParent(self.reqmgrDB, status)
+            msg = f"Retrieved {len(listWflowChildren)} workflows to fix parentage in status {status}"
+            self.logger.info(msg)
 
-            for wfs in viewvalues(reqByChildDS):
-                requests = requests.union(wfs)
-
-        failedRequests = set()
-        totalChildDS = len(childDatasets)
-        fixCount = 0
-        for childDS in childDatasets:
-            self.logger.info("Resolving parentage for dataset: %s", childDS)
-            start = time.time()
-            try:
-                failedBlocks = self.dbsSvc.fixMissingParentageDatasets(childDS, insertFlag=True)
-            except Exception as exc:
-                self.logger.exception("Failed to resolve parentage data for dataset: %s. Error: %s",
-                                      childDS, str(exc))
-                failedRequests = failedRequests.union(requestsByChildDataset[childDS])
-            else:
-                if failedBlocks:
-                    self.logger.warning("These blocks failed to be resolved and will be retried later: %s",
-                                        failedBlocks)
-                    failedRequests = failedRequests.union(requestsByChildDataset[childDS])
+            # now resolve every dataset parentage for each workflow
+            while listWflowChildren:
+                wflowData = listWflowChildren.pop()
+                msg = f'Resolving parentage for workflow {wflowData["workflowName"]} '
+                msg += f'with a total of {len(wflowData["childrenDsets"])} datasets. '
+                msg += f'Still {len(listWflowChildren)} workflows left to be resolved.'
+                self.logger.info(msg)
+                # measure time taken to fix a workflow parentage
+                start = time.time()
+                parentageResolved = True
+                for childDS in wflowData["childrenDsets"]:
+                    self.logger.info("  Handling parentage for child dataset: %s", childDS)
+                    try:
+                        failedBlocks = self.dbsSvc.fixMissingParentageDatasets(childDS, insertFlag=True)
+                    except Exception as exc:
+                        self.logger.exception("  Failed to resolve parentage data for dataset: %s. Error: %s",
+                                              childDS, str(exc))
+                        parentageResolved = False
+                    else:
+                        if failedBlocks:
+                            self.logger.warning("  These blocks failed to be resolved and will be retried later: %s",
+                                                failedBlocks)
+                            parentageResolved = False
+                        else:
+                            self.logger.info("  Parentage for '%s' successfully updated.", childDS)
+                timeTaken = time.time() - start
+                self.logger.info(f"  time spent with workflow {wflowData['workflowName']} is: {timeTaken} secs")
+                if parentageResolved:
+                    fixedCount += 1
+                    # then we can update the request flag
+                    self.updateParentageFlag(wflowData['workflowName'])
                 else:
-                    fixCount += 1
-                    self.logger.info("Parentage for '%s' successfully updated. Processed %s out of %s datasets.",
-                                     childDS, fixCount, totalChildDS)
-            timeTaken = time.time() - start
-            self.logger.info("    spent %s secs on this dataset: %s", timeTaken, childDS)
+                    self.logger.warning(f" Workflow {wflowData['workflowName']} will be retried in the next cycle")
 
-        requestsToUpdate = requests - failedRequests
+        self.logger.info(f"Resolved a total of {fixedCount} workflows in this cycle\n")
 
-        for request in requestsToUpdate:
-            try:
-                self.reqmgrDB.updateRequestProperty(request, {"ParentageResolved": True})
-                self.logger.info("Marked ParentageResolved=True for request: %s", request)
-            except Exception as exc:
-                self.logger.error("Failed to update 'ParentageResolved' flag to True for request: %s", request)
-
-        msg = "A total of %d requests have been processed, where %d will have to be retried in the next cycle."
-        self.logger.info(msg, len(requestsToUpdate), len(failedRequests))
+    def updateParentageFlag(self, reqName):
+        """
+        Given a workflow name, update its ParentageResolved flag in
+        ReqMgr2.
+        :param reqName: string with the workflow name
+        :return: none
+        """
+        try:
+            self.reqmgrDB.updateRequestProperty(reqName, {"ParentageResolved": True})
+            self.logger.info("  Marked ParentageResolved=True for request: %s", reqName)
+        except Exception as exc:
+            self.logger.error("  Failed to update 'ParentageResolved' flag to True for request: %s", reqName)

--- a/src/python/WMCore/ReqMgr/CherryPyThreads/StepChainParentageFixTask.py
+++ b/src/python/WMCore/ReqMgr/CherryPyThreads/StepChainParentageFixTask.py
@@ -10,6 +10,7 @@ def getChildDatasetsForStepChainMissingParent(reqmgrDB, status):
     """
     Fetches data from ReqMgr2/CouchDB for workflows that need to
     have their parentage information fixed.
+    :param reqmgrDB: object instance of the RequestDBWriter class
     :param status: string with the workflow status
     :return: a flat list of dictionaries with request name and children datasets
     """


### PR DESCRIPTION
Fixes #11693 

#### Status
ready

#### Description
Refactor how data is organized in the StepChainParentageFix cherrypy thread, such that it goes through each workflow at a time; instead of aggregating all of the datasets that require parentage fix, dealing with all of them, and only then making the status transition.

With these changes, we have a smaller memory footprint but a larger number of HTTP calls to the DBS server, as multiple workflows could have the same input and/or output dataset names.

In addition, an standalone script is provided to fix the parentage information for any given single workflow. Script is called `fixWorkflowParentage.py` and by default it will use production ReqMgr2 and DBS Server. 

Note-1: spike in memory can still occur, whenever a large workflow needs to have its parentage fixed (e.g.: cmsunified_task_SMP-RunIISummer20UL18wmLHEGEN-00542__v1_T_230314_093054_8766).
Note-2: the parentage resolution logic has not been changed at all. Only the order of datasets and reqmgr2 updates.
Note-3: the "hack" commit has been removed. Here is its reference though: https://github.com/dmwm/WMCore/pull/11694/commits/1961d252015665d8a702b08271a997e1065b9e0c

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None