### PR TITLE
Add campaign name attribute to base WMTask object and propagate it as a classad

### DIFF
--- a/src/python/WMComponent/JobCreator/JobCreatorPoller.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorPoller.py
@@ -145,6 +145,7 @@ def saveJob(job, thisJobNumber, **kwargs):
     job['requiresGPU'] = kwargs['requiresGPU']
     job['gpuRequirements'] = kwargs['gpuRequirements']
     job['requestType'] = kwargs['requestType']
+    job['campaignName'] = kwargs['campaignName']
 
     with open(os.path.join(cacheDir, 'job.pkl'), 'wb') as output:
         pickle.dump(job, output, HIGHEST_PICKLE_PROTOCOL)
@@ -539,7 +540,8 @@ class JobCreatorPoller(BaseWorkerThread):
                                'scramArch': wmTask.getScramArch(),
                                'agentNumber': self.agentNumber,
                                'agentName': self.agentName,
-                               'allowOpportunistic': allowOpport}
+                               'campaignName': wmTask.getCampaignName(),
+                               'allowOpportunistic': allowOpport,}
 
                 tempSubscription = Subscription(id=wmbsSubscription['id'])
 

--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -407,6 +407,7 @@ class JobSubmitterPoller(BaseWorkerThread):
                        'allowOpportunistic': loadedJob.get('allowOpportunistic', False),
                        'requiresGPU': loadedJob.get('requiresGPU', "forbidden"),
                        'gpuRequirements': loadedJob.get('gpuRequirements', None),
+                       'campaignName': loadedJob.get('campaignName', None),
                        'requestType': loadedJob['requestType'],
                        }
             # then update it with the info retrieved from the database

--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -536,6 +536,10 @@ class SimpleCondorPlugin(BasePlugin):
             ad['My.CMS_JobType'] = classad.quote(job['task_type'])
             ad['My.CMS_Type'] = classad.quote(activityToType(job['activity']))
             ad['My.CMS_RequestType'] = classad.quote(job['requestType'])
+            if job.get('campaignName') is None:
+                ad['My.CMS_CampaignName'] = classad.quote(job['campaignName'])
+            else:
+                ad['My.CMS_CampaignName'] = undefined
 
             # Handling for AWS, cloud and opportunistic resources
             ad['My.AllowOpportunistic'] = str(job.get('allowOpportunistic', False))

--- a/src/python/WMCore/BossAir/RunJob.py
+++ b/src/python/WMCore/BossAir/RunJob.py
@@ -68,6 +68,7 @@ class RunJob(dict):
         self.setdefault('activity', None)
         self.setdefault('requiresGPU', 'forbidden')
         self.setdefault('gpuRequirements', None)
+        self.setdefault('campaignName', None)
         self.setdefault('requestType', None)
 
         return

--- a/src/python/WMCore/JobStateMachine/ChangeState.py
+++ b/src/python/WMCore/JobStateMachine/ChangeState.py
@@ -349,7 +349,7 @@ class ChangeState(WMObject, WMConnectionBase):
                                                                  getDataFromSpecFile(
                                                                      self.getWorkflowSpecDAO.execute(job['task'])[
                                                                          job['task']]['spec']))
-                job['fwjr'].setCampaign(cachedByWorkflow.get('Campaign', ''))
+                job['fwjr'].setCampaign(job.get('campaignName', ''))
                 job['fwjr'].setPrepID(cachedByWorkflow.get(job['task'], ''))
                 # If there are too many input files, strip them out
                 # of the FWJR, as they should already

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -373,9 +373,11 @@ class StdBase(object):
         procStr = taskConf.get("ProcessingString") or self.processingString
         procVer = taskConf.get("ProcessingVersion") or self.processingVersion
         prepID = taskConf.get("PrepID") or self.prepID
+        campaignName = taskConf.get("Campaign") or self.campaign
         procTask.setAcquisitionEra(acqEra)
         procTask.setProcessingString(procStr)
         procTask.setProcessingVersion(procVer)
+        procTask.setCampaignName(campaignName)
 
         if taskType in ["Production", 'PrivateMC'] and totalEvents is not None:
             procTask.addGenerator(seeding)

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -1105,8 +1105,6 @@ class WMTaskHelper(TreeHelper):
 
     def setTaskType(self, taskType):
         """
-        _setTaskType_
-
         Set the type field of this task
         """
         self.data.taskType = taskType
@@ -1615,6 +1613,20 @@ class WMTaskHelper(TreeHelper):
         Get the task acquisition era.
         """
         return getattr(self.data.parameters, 'acquisitionEra', None)
+
+    def setCampaignName(self, campaign):
+        """
+        Set the campaign name of this task
+        :param campaign: str, name of the campaign to be defined
+        """
+        self.data.campaignName = campaign
+
+    def getCampaignName(self):
+        """
+        Get the task campaign name
+        :return: str, campaign name value
+        """
+        return getattr(self.data, 'campaignName', None)
 
     def setLumiMask(self, lumiMask=None, override=True):
         """

--- a/test/python/WMComponent_t/JobCreator_t/JobCreator_t.py
+++ b/test/python/WMComponent_t/JobCreator_t/JobCreator_t.py
@@ -300,6 +300,49 @@ class JobCreatorTest(EmulatedUnitTestCase):
 
         return
 
+    def testCampaignName(self):
+        """
+        Test campaign name is written into job pickle file
+        """
+        myThread = threading.currentThread()
+
+        config = self.getConfig()
+
+        name = makeUUID()
+        nSubs = 1
+        nFiles = 1
+        workloadName = 'TestWorkload'
+
+        dummyWorkload = self.createWorkload(workloadName=workloadName)
+        workloadPath = os.path.join(self.testDir, 'workloadTest', 'TestWorkload', 'WMSandbox', 'WMWorkload.pkl')
+
+        self.createJobCollection(name=name, nSubs=nSubs, nFiles=nFiles, workflowURL=workloadPath)
+
+        testJobCreator = JobCreatorPoller(config=config)
+
+        # First, can we run once without everything crashing?
+        testJobCreator.algorithm()
+
+        getJobsAction = self.daoFactory(classname="Jobs.GetAllJobs")
+        result = getJobsAction.execute(state='Created', jobType="Processing")
+
+        # Find the test directory
+        testDirectory = os.path.join(self.testDir, 'jobCacheDir', 'TestWorkload', 'ReReco')
+        groupDirectory = os.path.join(testDirectory, 'JobCollection_1_0')
+
+        # Get job pickle file
+        jobDir = os.listdir(groupDirectory)[0]
+        jobFile = os.path.join(groupDirectory, jobDir, 'job.pkl')
+        self.assertTrue(os.path.isfile(jobFile))
+        with open(jobFile, 'rb') as f:
+            job = pickle.load(f)
+
+        # Attribute campaign name should exist
+        # but be set to the default value: None
+        self.assertEqual(job['campaignName'], None)
+
+        return
+
     @attr('performance', 'integration')
     def testProfilePoller(self):
         """

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/ReReco_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/ReReco_t.py
@@ -884,5 +884,36 @@ class ReRecoTest(unittest.TestCase):
         self.assertItemsEqual(subscriptions, subMaps)
 
 
+    def testCampaignName(self):
+        """
+        Make sure the campaign name has been set in the processing task
+        """
+        skimConfig = self.injectSkimConfig()
+        recoConfig = self.injectReRecoConfig()
+        dataProcArguments = ReRecoWorkloadFactory.getTestArguments()
+        dataProcArguments["ConfigCacheID"] = recoConfig
+        dataProcArguments.update({"SkimName1": "SomeSkim",
+                                  "SkimInput1": "RECOoutput",
+                                  "Skim1ConfigCacheID": skimConfig})
+        dataProcArguments["CouchURL"] = os.environ["COUCHURL"]
+        dataProcArguments["CouchDBName"] = "rereco_t"
+        dataProcArguments["EnableHarvesting"] = True
+        dataProcArguments["DQMConfigCacheID"] = self.injectDQMHarvestConfig()
+
+        factory = ReRecoWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", dataProcArguments)
+
+        # test default values
+        taskPaths = {'/TestWorkload/DataProcessing': ['cmsRun1', 'stageOut1', 'logArch1'],
+                     '/TestWorkload/DataProcessing/DataProcessingMergeRECOoutput/SomeSkim': ['cmsRun1', 'stageOut1',
+                                                                                             'logArch1']}
+
+        # Check task object has campaign name method
+        for task in taskPaths:
+            taskObj = testWorkload.getTaskByPath(task)
+            self.assertEqual(taskObj.getCampaignName(), '')
+
+        return
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/TaskChain_t.py
@@ -2490,6 +2490,25 @@ class TaskChainTests(EmulatedUnitTestCase):
         with self.assertRaises(WMSpecFactoryException):
             factory.factoryWorkloadConstruction("PullingTheChain", arguments)
 
+    def testCampaignNameTaskChainTasks(self):
+        """
+        Test campaign names in tasks
+        """
+        processorDocs = makeProcessingConfigs(self.configDatabase)
+
+        arguments = TaskChainWorkloadFactory.getTestArguments()
+        arguments.update(deepcopy(REQUEST_INPUT))
+        arguments['Task1']['ConfigCacheID'] = processorDocs['DigiHLT']
+        arguments['Task2']['ConfigCacheID'] = processorDocs['Reco']
+        arguments['Task1'].update({"Campaign": "Campaign_DIGI"})
+        arguments['Task2'].update({"Campaign": "Campaign_RECO"})
+        factory = TaskChainWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("PullingTheChain", arguments)
+
+        taskObj = testWorkload.getTaskByName("DIGI")
+        self.assertEqual(taskObj.getCampaignName(), "Campaign_DIGI")
+        taskObj = testWorkload.getTaskByName("RECO")
+        self.assertEqual(taskObj.getCampaignName(), "Campaign_RECO")
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/WMCore_t/WMSpec_t/WMTask_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMTask_t.py
@@ -910,6 +910,17 @@ class WMTaskTest(unittest.TestCase):
             self.assertEqual(taskObj.getRequiresGPU(), "optional")
             self.assertItemsEqual(taskObj.getGPURequirements(), gpuParams["cmsRun1"])
 
+    def testSetCampaignName(self):
+        """
+        Test that we set the campaign name
+        """
+
+        testTask = makeWMTask("TestTask")
+        testTask.setCampaignName("Campaign1")
+
+        self.assertEqual(testTask.getCampaignName(), "Campaign1",
+                         "Wrong campaign name")
+        return
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #11704
Fixes #11705

#### Status
In development

#### Description
Add campaign name attribute to base WMTask object and propagate it as a classad. This should work for RERECO, not child tasks taken into account.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
