### PR TITLE
Adds WMCMSSWSubprocess metrics to FJR document

### DIFF
--- a/src/python/WMCore/FwkJobReport/Report.py
+++ b/src/python/WMCore/FwkJobReport/Report.py
@@ -221,6 +221,7 @@ class Report(object):
         jsonReport["Campaign"] = self.getCampaign()
         jsonReport["PrepID"] = self.getPrepID()
         jsonReport["EOSLogURL"] = self.getLogURL()
+        jsonReport["WMTiming"] = self.getWMTiming()
 
         for stepName in self.listSteps():
             reportStep = self.retrieveStep(stepName)
@@ -266,6 +267,7 @@ class Report(object):
             jsonStep["site"] = self.getSiteName()
             jsonStep["analysis"] = {}
             jsonStep["logs"] = {}
+            jsonStep["WMCMSSWSubprocess"] = self.getWMCMSSWSubprocess(stepName)
             jsonReport["steps"][stepName] = jsonStep
 
         return jsonReport
@@ -300,6 +302,18 @@ class Report(object):
         for stepName in self.listSteps():
             returnCodes.update(self.getStepExitCodes(stepName=stepName))
         return returnCodes
+
+    def getWMCMSSWSubprocess(self, stepName):
+        """
+        Returns a WMCMSSWSubprocess metrics for given step
+        :param stepName: string representing step name, e.g. cmsRun1
+        :return: dictionary of WMCMSSWSubprocess metrics
+        """
+        reportStep = self.retrieveStep(stepName)
+        data = getattr(reportStep, 'WMCMSSWSubprocess', {})
+        if isinstance(data, dict):
+            return data
+        return data.dictionary_()
 
     def getStepExitCodes(self, stepName):
         """
@@ -1409,6 +1423,16 @@ class Report(object):
          Return the PrepID
         """
         return getattr(self.data, 'prep_id', "")
+
+    def getWMTiming(self):
+        """
+        Returns a WMTiming metrics
+        :return: dictionary of WMTiming metrics
+        """
+        data = getattr(self.data, 'WMTiming', {})
+        if isinstance(data, dict):
+            return data
+        return data.dictionary_()
 
     def setConfigURL(self, configURL):
         """

--- a/src/python/WMCore/Services/WMArchive/DataMap.py
+++ b/src/python/WMCore/Services/WMArchive/DataMap.py
@@ -61,7 +61,6 @@ TOP_LEVEL_STEP_DEFAULT = {'analysis': {},
                           'input': [],
                           'output': [],
                           'WMCMSSWSubprocess': {},
-                          'WMTiming': {},
                           'performance': {}
                           }
 
@@ -113,7 +112,6 @@ STEP_DEFAULT = {  # 'name': '',
         # 'StageOutCommand': ''
     }],
     'WMCMSSWSubprocess': {},
-    'WMTiming': {},
     'performance': {'cpu': {},
                     'memory': {},
                     'multicore': {},

--- a/test/python/WMCore_t/FwkJobReport_t/Report_t.py
+++ b/test/python/WMCore_t/FwkJobReport_t/Report_t.py
@@ -1028,6 +1028,25 @@ class ReportTest(unittest.TestCase):
         self.assertItemsEqual(fileList[1]['locations'], {"T2_CH_CSCS"})
         self.assertEqual(fileList[1]['outputModule'], "logArchive")
 
+    def testWMTiming(self):
+        """
+        test WMTiming metrics from FJR report
+        """
+        jobReport = Report()
+        data = jobReport.getWMTiming()
+        self.assertTrue(isinstance(data, dict))
+
+    def testWMCMSSWSubprocess(self):
+        """
+        test WMCMSSWSubprocess metrics from FJR report
+        """
+        xmlPath = os.path.join(getTestBase(),
+                               "WMCore_t/FwkJobReport_t/CMSSWMultipleInput.xml")
+        jobReport = Report("cmsRun1")
+        jobReport.parse(xmlPath)
+        data = jobReport.getWMCMSSWSubprocess("cmsRun1")
+        self.assertTrue(isinstance(data, dict))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #11660
Complement to #11665 

#### Status
ready

#### Description
Add `WMCMSSWSubproces` metrics to WMCore FJR stored in WMAgent local CouchDB. Full procedure is described in the following [wiki](https://github.com/dmwm/WMCore/wiki/FJR-metrics-data-flow-to-WMArchive).

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
#11692 

#### External dependencies / deployment changes
