### PR TITLE
Add additional variables to WMAgent.secrets needed for the docker container intialization process

### DIFF
--- a/deploy/WMAgent.production
+++ b/deploy/WMAgent.production
@@ -1,4 +1,6 @@
 MYSQL_USER=
+MYSQL_PASS=
+MYSQL_HOST=127.0.0.1
 #ORACLE_USER=
 #ORACLE_PASS=
 #ORACLE_TNS=
@@ -23,3 +25,5 @@ GRAFANA_TOKEN=
 RUCIO_ACCOUNT=wma_prod
 RUCIO_HOST=http://cms-rucio.cern.ch
 RUCIO_AUTH=https://cms-rucio-auth.cern.ch
+TEAMNAME=
+AGENT_NUMBER=

--- a/deploy/WMAgent.testbed
+++ b/deploy/WMAgent.testbed
@@ -1,4 +1,6 @@
 MYSQL_USER=
+MYSQL_PASS=
+MYSQL_HOST=127.0.0.1
 #ORACLE_USER=
 #ORACLE_PASS=
 #ORACLE_TNS=
@@ -23,3 +25,5 @@ GRAFANA_TOKEN=
 RUCIO_ACCOUNT=wma_test
 RUCIO_HOST=http://cms-rucio-int.cern.ch
 RUCIO_AUTH=https://cms-rucio-auth-int.cern.ch
+TEAMNAME=
+AGENT_NUMBER=


### PR DESCRIPTION
Related to #11627 

#### Status
ready

#### Description
With this PR we are adding to the WMAgent.secrets templates all new variables needed  for the docker container initialization process.

UPDATE: Note that these new variables are not taken into consideration by the current deployment script (RPM based).
   
#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
https://github.com/dmwm/CMSKubernetes/pull/1410

#### External dependencies / deployment changes
None