### PR TITLE
Inherit siteLists from upper level task while creating WMBS subscriptions

### DIFF
--- a/src/python/WMComponent/JobCreator/JobCreatorPoller.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorPoller.py
@@ -688,8 +688,8 @@ class JobCreatorPoller(BaseWorkerThread):
         fjrsToSave = []
         for failedJob in createFailedJobs:
             report = Report()
-            report.addError("CreationFailure", 99305, "CreationFailure",
-                            failedJob.get("failedReason", WM_JOB_ERROR_CODES[99305]))
+            report.addError("CreationFailure", failedJob["failedErrCode"], "CreationFailure",
+                            failedJob.get("failedReason", WM_JOB_ERROR_CODES[failedJob["failedErrCode"]]))
             jobCache = failedJob.getCache()
             try:
                 fjrPath = os.path.join(jobCache, "Report.0.pkl")

--- a/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
+++ b/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
@@ -264,7 +264,7 @@ class EventAwareLumiBased(JobFactory):
                                 msg += "with too many events %d and it woud take %d sec to run" \
                                        % (f['events'], timePerLumi)
                             self.lumiChecker.closeJob(self.currentJob)
-                            self.newJob(name=self.getJobName(), failedJob=failNextJob, failedReason=msg)
+                            self.newJob(name=self.getJobName(), failedJob=failNextJob, failedReason=msg, failedErrCode=99305)
                             if deterministicPileup:
                                 skipEvents = (self.nJobs - 1) * lumisPerJob * eventsPerLumiInDataset
                                 self.currentJob.addBaggageParameter("skipPileupEvents", skipEvents)

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -693,12 +693,12 @@ class WMWorkloadHelper(PersistencyHelper):
         """
         _setSiteBlacklist_
 
-        Set the site black list for the top level tasks in the workload.
+        Set the site black list for all tasks in the workload.
         """
         if not isinstance(siteBlacklist, type([])):
             siteBlacklist = [siteBlacklist]
 
-        taskIterator = self.taskIterator()
+        taskIterator = self.getAllTasks(cpuOnly=False)
 
         for task in taskIterator:
             task.setSiteBlacklist(siteBlacklist)

--- a/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
@@ -397,7 +397,7 @@ class WMWorkloadTest(unittest.TestCase):
         for task in [mergeTestTask, weirdTestTask]:
             self.assertEqual(len(task.siteWhitelist()), 0,
                              "Error: Wrong number of sites in white list.")
-            self.assertEqual(len(task.siteBlacklist()), 0,
+            self.assertEqual(len(task.siteBlacklist()), 1,
                              "Error: Wrong number of sites in black list.")
 
         for task in [procTestTask, weirdTestTask]:


### PR DESCRIPTION
Fixes #10270 

#### Status
Ready

#### Description
With the current PR we suggest a change in the way how we propagate tasks' Site lists during the creation of the respective subscriptions in wmbs. 

Here, very important is to remember what the definition of a subscription is: 
```
wmbs_subscription = wmbs_workflow + fileset
```  
The change here would make the child tasks to inherit their respective site lists from the upper level tasks. This by itslef would trigger a record in the  the `wmbs_subscription_validation` table per every subscription related  to the child task in question, exactly as it is done for the upper level task. Bellow I put some example records at the WMBS tables reflecting the current situation:
* Here are few subscriptions as created for one workflow: 
```
MariaDB [wmagent]> select * from wmbs_subscription;
+----+---------+----------+------------------------+---------+-------------+----------+
| id | fileset | workflow | split_algo             | subtype | last_update | finished |
+----+---------+----------+------------------------+---------+-------------+----------+
|  1 |       1 |        1 | EventBased             |       7 |  1694173451 |        0 |
|  2 |       2 |        2 | SiblingProcessingBased |       4 |  1694173451 |        0 |
|  3 |       2 |        3 | ParentlessMergeBySize  |       2 |  1694173451 |        0 |
|  4 |       4 |        4 | MinFileBased           |       5 |  1694173451 |        0 |
|  5 |       5 |        5 | SiblingProcessingBased |       4 |  1694173451 |        0 |
|  6 |       5 |        6 | ParentlessMergeBySize  |       2 |  1694173451 |        0 |
|  7 |       6 |        7 | EventAwareLumiBased    |       1 |  1694173451 |        0 |
|  8 |       7 |        8 | SiblingProcessingBased |       4 |  1694173451 |        0 |
|  9 |       7 |        9 | EventAwareLumiBased    |       1 |  1694173451 |        0 |
| 10 |       8 |       10 | SiblingProcessingBased |       4 |  1694173451 |        0 |
| 11 |       8 |       11 | EventAwareLumiBased    |       1 |  1694173451 |        0 |
| 12 |       9 |       12 | SiblingProcessingBased |       4 |  1694173451 |        0 |
...
```  
As we  already said the combination between a `fileset` and a `wmbs_workflow` uniquely  describes a subscription.

* Here are few of the `filesets` created for this workflow:
```
MariaDB [wmagent]> select id, name from wmbs_fileset order by id;
+----+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| id | name                                                                                                                                                                                                                 |
+----+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|  1 | tivanov_TaskChain_Prod_SiteBlockedList_v1_230908_100533_7777-myTask1-6c605b7b6d0f6ffc065207a050d08263                                                                                                                |
|  2 | /tivanov_TaskChain_Prod_SiteBlockedList_v1_230908_100533_7777/myTask1/unmerged-LHEoutputLHE                                                                                                                          |
|  3 | /tivanov_TaskChain_Prod_SiteBlockedList_v1_230908_100533_7777/myTask1/myTask1MergeLHEoutput/merged-MergedLHE                                                                                                         |
|  4 | /tivanov_TaskChain_Prod_SiteBlockedList_v1_230908_100533_7777/myTask1/myTask1MergeLHEoutput/merged-logArchive                                                                                                        |
|  5 | /tivanov_TaskChain_Prod_SiteBlockedList_v1_230908_100533_7777/myTask1/unmerged-RAWSIMoutputGEN                                                                                                                       |
|  6 | /tivanov_TaskChain_Prod_SiteBlockedList_v1_230908_100533_7777/myTask1/myTask1MergeRAWSIMoutput/merged-MergedGEN                                                                                                      |
|  7 | /tivanov_TaskChain_Prod_SiteBlockedList_v1_230908_100533_7777/myTask1/myTask1MergeRAWSIMoutput/myTask2/unmerged-RAWSIMoutputGEN-SIM                                                                                  |
|  8 | /tivanov_TaskChain_Prod_SiteBlockedList_v1_230908_100533_7777/myTask1/myTask1MergeRAWSIMoutput/myTask2/myTask3/unmerged-PREMIXRAWoutputGEN-SIM-DIGI                                                                  |
|  9 | /tivanov_TaskChain_Prod_SiteBlockedList_v1_230908_100533_7777/myTask1/myTask1MergeRAWSIMoutput/myTask2/myTask3/myTask4/unmerged-RAWSIMoutputGEN-SIM-RAW                                                              |
| 10 | /tivanov_TaskChain_Prod_SiteBlockedList_v1_230908_100533_7777/myTask1/myTask1MergeRAWSIMoutput/myTask2/myTask3/myTask4/myTask4MergeRAWSIMoutput/merged-MergedGEN-SIM-RAW             
...
```

* Here are few of the `wmbs_workflow` records created for this workflow:
```
MariaDB [wmagent]> select id, task from wmbs_workflow order by id;
+----+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| id | task                                                                                                                                                                                                                                |
+----+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|  1 | /tivanov_TaskChain_Prod_SiteBlockedList_v1_230908_100533_7777/myTask1                                                                                                                                                               |
|  2 | /tivanov_TaskChain_Prod_SiteBlockedList_v1_230908_100533_7777/myTask1/myTask1CleanupUnmergedLHEoutput                                                                                                                               |
|  3 | /tivanov_TaskChain_Prod_SiteBlockedList_v1_230908_100533_7777/myTask1/myTask1MergeLHEoutput                                                                                                                                         |
|  4 | /tivanov_TaskChain_Prod_SiteBlockedList_v1_230908_100533_7777/myTask1/myTask1MergeLHEoutput/myTask1LHEoutputMergeLogCollect                                                                                                         |
|  5 | /tivanov_TaskChain_Prod_SiteBlockedList_v1_230908_100533_7777/myTask1/myTask1CleanupUnmergedRAWSIMoutput                                                                                                                            |
|  6 | /tivanov_TaskChain_Prod_SiteBlockedList_v1_230908_100533_7777/myTask1/myTask1MergeRAWSIMoutput                                                                                                                                      |
|  7 | /tivanov_TaskChain_Prod_SiteBlockedList_v1_230908_100533_7777/myTask1/myTask1MergeRAWSIMoutput/myTask2                                                                                                                              |
|  8 | /tivanov_TaskChain_Prod_SiteBlockedList_v1_230908_100533_7777/myTask1/myTask1MergeRAWSIMoutput/myTask2/myTask2CleanupUnmergedRAWSIMoutput                                                                                           |
|  9 | /tivanov_TaskChain_Prod_SiteBlockedList_v1_230908_100533_7777/myTask1/myTask1MergeRAWSIMoutput/myTask2/myTask3                                                                                                                      |
| 10 | /tivanov_TaskChain_Prod_SiteBlockedList_v1_230908_100533_7777/myTask1/myTask1MergeRAWSIMoutput/myTask2/myTask3/myTask3CleanupUnmergedPREMIXRAWoutput                                                                                |
| 11 | /tivanov_TaskChain_Prod_SiteBlockedList_v1_230908_100533_7777/myTask1/myTask1MergeRAWSIMoutput/myTask2/myTask3/myTask4                                                     
```   

* And finally here are ALL the records in the `wmbs_subscription_validation` table, which defines  where a given `wmbs_workflow/task` is allowed to run or not:
```
MariaDB [wmagent]> SELECT wmbs_subscription_validation.subscription_id, wmbs_location.site_name, wmbs_subscription_validation.valid   FROM wmbs_location INNER JOIN wmbs_subscription_validation ON wmbs_location.id = wmbs_subscription_validation.location_id;
+-----------------+----------------+-------+
| subscription_id | site_name      | valid |
+-----------------+----------------+-------+
|               1 | T2_CH_CERN_HLT |     0 |
|               1 | T2_CH_CERN     |     1 |
|               1 | T1_US_FNAL     |     1 |
+-----------------+----------------+-------+

``` 

As one can see we have records related  only to `subscription_id = 1`. Which is the combination only between the top level  `task` and the top level `fileset` as they have been created by the local workqueu at the agent:
```
wmbs_workflow=/tivanov_TaskChain_Prod_SiteBlockedList_v1_230908_100533_7777/myTask1  + fileset=tivanov_TaskChain_Prod_SiteBlockedList_v1_230908_100533_7777-myTask1-6c605b7b6d0f6ffc065207a050d08263
```

With the current change I'd expect to have those created  for all the rest of the workflow's subscriptions in WMBS

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None