### PR TITLE
Add campaign names support for stepchain workflows

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StepChain.py
@@ -285,7 +285,7 @@ class StepChainWorkloadFactory(StdBase):
         chain the output between all three steps.
         """
         self.stepParentageMapping.setdefault(origArgs['Step1']['StepName'], {})
-
+        campaignNames = []
         for i in range(2, self.stepChain + 1):
             currentStepNumber = "Step%d" % i
             currentCmsRun = "cmsRun%d" % i
@@ -348,8 +348,26 @@ class StepChainWorkloadFactory(StdBase):
             currentCmsswStepHelper.keepOutput(childKeepOutput)
             self.setupOutputModules(task, taskConf, currentCmsRun, childKeepOutput)
 
+            # Get and append campaign name for each step
+            if taskConf.get("Campaign", None) is not None:
+                campaignNames.append(taskConf.get("Campaign"))
+            else:
+                # check if workload has a campaign name
+                if self.workload.getCampaign() is not None:
+                    campaignNames.append(self.workload.getCampaign())
+
         # Closing out the task configuration. The last step output must be saved/merged
         currentCmsswStepHelper.keepOutput(True)
+
+        # Set campaign name
+        if campaignNames:
+            # Add first task campaign name if it exists
+            if task.getCampaignName() is not None:
+                campaignNames = [task.getCampaignName()] + campaignNames
+            # Report only unique values and preserve original content order 
+            seen = set()
+            uniqueCampaignNames = [x for x in campaignNames if not (x in seen or seen.add(x))]
+            task.setCampaignName(",".join(uniqueCampaignNames))
 
         return
 

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
@@ -2577,6 +2577,107 @@ class StepChainTests(EmulatedUnitTestCase):
         self.assertEqual(gpuRequired, testArguments["Step3"].get('RequiresGPU', "forbidden"))
         self.assertIsNone(gpuRequirements)
 
+    def testCampaignNamesCaseA(self):
+        """
+        Check campaign names are properly set when al Steps have a campaign
+        """
+        testArguments = StepChainWorkloadFactory.getTestArguments()
+        testArguments.update(deepcopy(REQUEST))
+
+        configDocs = injectStepChainConfigMC(self.configDatabase)
+        for s in ['Step1', 'Step2', 'Step3']:
+            testArguments[s]['ConfigCacheID'] = configDocs[s]
+        testArguments['Step2']['KeepOutput'] = False
+
+        factory = StepChainWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
+
+        testArguments['Step1'].update({"Campaign": "Campaign1"})
+        testArguments['Step2'].update({"Campaign": "Campaign2"})
+        testArguments['Step3'].update({"Campaign": "Campaign3"})
+        factory = StepChainWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
+        task = testWorkload.getTask(taskName=testArguments['Step1']['StepName'])
+
+        self.assertEqual(task.getCampaignName(), "Campaign1,Campaign2,Campaign3")
+
+        return
+
+    def testCampaignNamesCaseB(self):
+        """
+        Check campaign names are properly set when the workload not all steps
+        have a campaign defined (hence defaulting to the workload campaign)
+        """
+        testArguments = StepChainWorkloadFactory.getTestArguments()
+        testArguments.update(deepcopy(REQUEST))
+
+        configDocs = injectStepChainConfigMC(self.configDatabase)
+        for s in ['Step1', 'Step2', 'Step3']:
+            testArguments[s]['ConfigCacheID'] = configDocs[s]
+        testArguments['Step2']['KeepOutput'] = False
+
+        factory = StepChainWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
+
+        testArguments['Step1'].update({"Campaign": "Campaign1"})
+        testArguments['Step3'].update({"Campaign": "Campaign3"})
+        factory = StepChainWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
+        task = testWorkload.getTask(taskName=testArguments['Step1']['StepName'])
+
+        self.assertEqual(task.getCampaignName(), "Campaign1,TaskForceUnitTest,Campaign3")
+
+        return
+
+    def testCampaignNamesCaseC(self):
+        """
+        Check campaign names are properly set when all step campaigns are the same
+        """
+        testArguments = StepChainWorkloadFactory.getTestArguments()
+        testArguments.update(deepcopy(REQUEST))
+
+        configDocs = injectStepChainConfigMC(self.configDatabase)
+        for s in ['Step1', 'Step2', 'Step3']:
+            testArguments[s]['ConfigCacheID'] = configDocs[s]
+        testArguments['Step2']['KeepOutput'] = False
+
+        factory = StepChainWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
+
+        testArguments['Step1'].update({"Campaign": "Campaign"})
+        testArguments['Step2'].update({"Campaign": "Campaign"})
+        testArguments['Step3'].update({"Campaign": "Campaign"})
+        factory = StepChainWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
+        task = testWorkload.getTask(taskName=testArguments['Step1']['StepName'])
+
+        self.assertEqual(task.getCampaignName(), "Campaign")
+
+        return
+
+    def testCampaignNamesCaseD(self):
+        """
+        Check campaign names are properly set to workload request campaign when
+        no steps have a campaign
+        """
+        testArguments = StepChainWorkloadFactory.getTestArguments()
+        testArguments.update(deepcopy(REQUEST))
+
+        configDocs = injectStepChainConfigMC(self.configDatabase)
+        for s in ['Step1', 'Step2', 'Step3']:
+            testArguments[s]['ConfigCacheID'] = configDocs[s]
+        testArguments['Step2']['KeepOutput'] = False
+
+        factory = StepChainWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
+
+        factory = StepChainWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
+        task = testWorkload.getTask(taskName=testArguments['Step1']['StepName'])
+
+        self.assertEqual(task.getCampaignName(), "TaskForceUnitTest")
+
+        return
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #11706

#### Status
Ready

#### Description
For each step, look for the campaign attribute in the workflow description and append this information in the campaign name at the task level. All step campaign names are appended to the task level campaign name with a comma. When there is no campaign attribute for a campaign, this defaults to the workload base campaign name. At the end, all unique campaigns are reported, this means if all steps have the same campaign name, this will be reported only once.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
<If it's a follow up work; or porting a fix from a different branch, please mention them here.>

#### External dependencies / deployment changes
<Does it require deployment changes? Does it rely on third-party libraries?>
