### PR TITLE
Retry svn checkout in the CD pipeline up to 5 times

### DIFF
--- a/.github/workflows/docker_images_template.yaml
+++ b/.github/workflows/docker_images_template.yaml
@@ -38,7 +38,14 @@ jobs:
           CERN_REGISTRY: registry.cern.ch
         run: |
           echo "Building service: ${SERVICE_NAME}, with tag: ${PYPI_TAG}"
-          svn checkout https://github.com/dmwm/CMSKubernetes/trunk/docker/pypi/${SERVICE_NAME}
+          for i in 1 2 3 4 5; do
+            svn checkout https://github.com/dmwm/CMSKubernetes/trunk/docker/pypi/${SERVICE_NAME}
+            if [ $? -eq 0 ]; then
+              break
+            fi
+            echo "Retry $i: SVN failed to fetch files. Sleeping 60 seconds..."
+            sleep 60
+          done
           cd ${SERVICE_NAME}
           echo "Retrieved Dockerfile with content:"
           cat Dockerfile


### PR DESCRIPTION
Fixes #11748 

#### Status
not-tested

#### Description
Given that `svn checkout` has been unstable this week, I am trying a first easy approach which is to retry it.
Retry up to 5 times, sleeping 60 seconds between retries. 

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
