### PR TITLE
Deal with partial block in the parentage fix - change to API

### DIFF
--- a/src/python/Utils/IteratorTools.py
+++ b/src/python/Utils/IteratorTools.py
@@ -2,7 +2,7 @@
 
 from builtins import str, map
 import collections
-from itertools import islice, chain
+from itertools import islice, chain, groupby
 
 def grouper(iterable, n):
     """
@@ -23,6 +23,7 @@ def flattenList(doubleList):
     Make flat a list of lists.
     """
     return list(chain.from_iterable(doubleList))
+
 
 def nestedDictUpdate(d, u):
     """
@@ -50,3 +51,18 @@ def convertFromUnicodeToBytes(data):
         return type(data)(list(map(convertFromUnicodeToBytes, data)))
     else:
         return data
+
+
+def makeListElementsUnique(listObj):
+    """
+    Given a list of lists or a list of tuples, find all duplicate elements
+    and make them unique.
+    :param listObj: an unsorted list of lists or a list of tuples, e.g.:
+        [[1, 1], [1, 5], [1, 1]]; or
+        [(1, 1), (1, 5), (1, 1)]
+    :return: the same list object but with no duplicates
+
+    Source: https://stackoverflow.com/questions/2213923/removing-duplicates-from-a-list-of-lists
+    """
+    listObj.sort()
+    return list(k for k, _ in groupby(listObj))

--- a/src/python/WMQuality/Emulators/DBSClient/MockedDBSGlobalCalls.py
+++ b/src/python/WMQuality/Emulators/DBSClient/MockedDBSGlobalCalls.py
@@ -90,6 +90,9 @@ calls = [['listDataTiers'],
           {'block_name': '/Cosmics/Commissioning2015-PromptReco-v1/RECO#004ac3ba-d09e-11e4-afad-001e67ac06a0'}],
          ['listBlockParents',
           {'block_name': '/Cosmics/Commissioning2015-v1/RAW#942d76fe-cf0e-11e4-afad-001e67ac06a0'}],
+         ['listParentDSTrio', {'dataset': '/HToAATo4L_H5000A10_TuneCP5_13TeV-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM'}],
+         ['listBlockTrio',
+          {'block_name': '/HToAATo4L_H5000A10_TuneCP5_13TeV-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM#bf137a20-65c5-4927-8f62-7733c3d9e017'}],
 
          # Exception throwing calls
 

--- a/test/python/Utils_t/IteratorTools_t.py
+++ b/test/python/Utils_t/IteratorTools_t.py
@@ -7,7 +7,7 @@ from builtins import range
 import itertools
 import unittest
 
-from Utils.IteratorTools import grouper, flattenList
+from Utils.IteratorTools import grouper, flattenList, makeListElementsUnique
 
 
 class IteratorToolsTest(unittest.TestCase):
@@ -37,6 +37,41 @@ class IteratorToolsTest(unittest.TestCase):
         flatList = flattenList(doubleList)
         self.assertEqual(len(flatList), 7)
         self.assertEqual(set(flatList), set([1, 2, 3, 10, 15, 16, 17]))
+
+    def testNoDupListOfLists(self):
+        """
+        Test the `makeListElementsUnique` function (which returns a list with
+        unique elements)
+        """
+        expRes = [[1], [2], [3], [4]]
+        inputTest = [[1], [2], [3], [4]]
+        self.assertListEqual(expRes, makeListElementsUnique(inputTest))
+
+        inputTest = [[1], [2], [3], [4], [1]]
+        self.assertListEqual(expRes, makeListElementsUnique(inputTest))
+
+        inputTest = [[1], [2], [3], [4], [1], [1], [2], [3]]
+        self.assertListEqual(expRes, makeListElementsUnique(inputTest))
+
+        # trying a different data type
+        expRes = [[2, 20], [4, 40], [4, 41], [5, 40]]
+        inputTest = [[2, 20], [4, 40], [4, 41], [5, 40], [4, 40], [4, 41]]
+        self.assertListEqual(expRes, makeListElementsUnique(inputTest))
+
+        inputTest = [[5, 40], [2, 20], [4, 40], [4, 41], [5, 40], [4, 40], [4, 41]]
+        self.assertListEqual(expRes, makeListElementsUnique(inputTest))
+
+        # and now with strings
+        expRes = [["2", "20"], ["4", "40"], ["4", "41"], ["5", "40"]]
+        inputTest = [["2", "20"], ["4", "40"], ["4", "41"], ["5", "40"], ["4", "40"], ["4", "41"]]
+        self.assertListEqual(expRes, makeListElementsUnique(inputTest))
+
+        inputTest = [["5", "40"], ["2", "20"], ["4", "40"], ["4", "41"], ["5", "40"], ["4", "40"], ["4", "41"]]
+        self.assertListEqual(expRes, makeListElementsUnique(inputTest))
+
+        # now test with a list of tuples
+        data = [(1, 2), (1, 3), (2, 4), (2, 5), (1, 3), (2, 5)]
+        self.assertListEqual([(1, 2), (1, 3), (2, 4), (2, 5)], makeListElementsUnique(data))
 
 
 if __name__ == '__main__':

--- a/test/python/WMCore_t/Services_t/DBS_t/DBSReader_t.py
+++ b/test/python/WMCore_t/Services_t/DBS_t/DBSReader_t.py
@@ -440,6 +440,22 @@ class DBSReaderTest(EmulatedUnitTestCase):
         self.assertTrue((180851, 1) in results)
         self.assertEqual(int(results[(180851, 1)]), 36092526)
 
+    def testCompileParentageList(self):
+        """Test the _compileParentageList method"""
+        self.dbs = DBSReader(self.endpoint)
+        # it contains 3 files
+        childDset = "/HToAATo4L_H5000A10_TuneCP5_13TeV-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM"
+        childBlock = "/HToAATo4L_H5000A10_TuneCP5_13TeV-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM#bf137a20-65c5-4927-8f62-7733c3d9e017"
+        parentRunLumi = self.dbs.getParentDatasetTrio(childDset)
+
+        expectRes = [['4013778997', '4005114237'], ['4013778997', '4005114277'], ['4013778997', '4005114357'],
+                     ['4013778997', '4005114397'], ['4013779037', '4005114157'], ['4013779037', '4005114197'],
+                     ['4013779037', '4005114317'], ['4013779037', '4005114357'], ['4013779077', '4005114437'],
+                     ['4013779077', '4005114477'], ['4013779077', '4005114517']]
+        childParent, missingFiles = self.dbs._compileParentageList(childBlock, parentRunLumi)
+        self.assertItemsEqual(expectRes, childParent)
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #11715 

#### Status
ready

#### Description
The following is provided with this PR:
* create a separate method in DBS3Reader to resolve the list of child/parent file ids (making it easier to code unit tests for)
* whenever a given run/lumi does not have a match in the parent file, skip that file id tuple, set the parent file to `-1`
* calculate the number of missing parents (child files with no parentage relationship) and provide it to the dbs3-client `insertFileParents` API
* lastly on DBS3Reader, make the list of child/parent ids unique before passing it over to the DBS server (through a new Utils function called `makeListElementsUnique`)
* added some verbose logging records (at DEBUG level)

In addition, a couple of extra data is mocked in DBS and the json dump has been updated as well.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
Changes are being made to the DBS Server: https://github.com/dmwm/dbs2go/pull/101
