### PR TITLE
Fix if statement for CMS_CampaignName classad

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -541,9 +541,9 @@ class SimpleCondorPlugin(BasePlugin):
             else:
                 ad['My.CMS_extendedJobType'] = classad.quote(job['task_type'])
             if job.get('campaignName') is None:
-                ad['My.CMS_CampaignName'] = classad.quote(job['campaignName'])
-            else:
                 ad['My.CMS_CampaignName'] = undefined
+            else:
+                ad['My.CMS_CampaignName'] = classad.quote(job['campaignName'])
 
             # Handling for AWS, cloud and opportunistic resources
             ad['My.AllowOpportunistic'] = str(job.get('allowOpportunistic', False))


### PR DESCRIPTION
Fixes #11759 
Part of the meta-issue: https://github.com/dmwm/WMCore/issues/10914

#### Status
ready

#### Description
Simple logic switch for the `CMS_CampaignName` job classad.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None