### PR TITLE
Refactor Unified configuration; remove unused references

### DIFF
--- a/bin/adhoc-scripts/injectUnified.py
+++ b/bin/adhoc-scripts/injectUnified.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+"""
+This script can be used to create a default Unified configuration in central CouchDB
+"""
+import argparse
+import http.client
+import json
+import os
+import sys
+from pprint import pformat
+
+DOC = {"tiers_to_DDM": {"value": ["LHE", "GEN-SIM-DIGI-RAW-MINIAOD", "AODSIM", "MINIAODSIM", "GEN-SIM-RAW",
+                                  "GEN-SIM-RECO", "GEN-SIM-RECODEBUG", "AOD", "RECO", "MINIAOD", "ALCARECO",
+                                  "USER", "RAW-RECO", "RAWAODSIM", "NANOAOD", "NANOAODSIM", "FEVT", "PREMIX",
+                                  "GEN-SIM-DIGI-RAW-HLTDEBUG-RECO", "FEVTDEBUGHLT"],
+                        "description": "Datatiers that have a final MSOutput data placement"},
+       "tiers_no_DDM": {"value": ["GEN-SIM", "GEN", "SIM", "DQM", "DQMIO", "GEN-SIM-DIGI-RAW", "RAW",
+                                  "GEN-SIM-DIGI", "GEN-SIM-DIGI-RAW-HLTDEBUG"],
+                        "description": "Datatiers not meant to have a final MSOutput data placement"},
+       "tiers_with_no_custodial": {"value": ["DQM", "RECO", "RAWAODSIM", "FEVTDEBUGHLT"],
+                                   "description": "Datatiers not meant to have a Tape final MSOutput data placement. Can be overriden at campaign level"}
+       }
+
+
+def parseArgs():
+    """
+    Parse the command line arguments, or provide default values.
+    """
+    msg = "Script to resolve a workflow parentage information and insert it into the DBS server"
+    parser = argparse.ArgumentParser(description=msg)
+    parser.add_argument("-c", "--cmsweb_url", help="CMSWEB URL (default: cmsweb-testbed.cern.ch)",
+                        action="store", default='cmsweb-testbed.cern.ch')
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+
+    # parse the input arguments
+    args = parseArgs()
+    userCert = os.getenv('X509_USER_PROXY')
+    userKey = os.getenv('X509_USER_PROXY')
+    if not userCert:
+        print("Please set the environment variable X509_USER_PROXY with your user proxy.")
+        sys.exit(1)
+
+    headers = {"Content-type": "application/json", "Accept": "application/json"}
+    encodedParams = json.dumps(DOC)
+
+    print(f"Updating unified configuration in {args.cmsweb_url} with content: {pformat(DOC)}")
+    conn = http.client.HTTPSConnection(args.cmsweb_url, cert_file=userCert, key_file=userKey)
+    conn.request("PUT", "/reqmgr2/data/unifiedconfig/config", encodedParams, headers)
+    resp = conn.getresponse()
+    if resp.status != 200:
+        print("Response status: %s\tResponse reason: %s" % (resp.status, resp.reason))
+        if hasattr(resp.msg, "x-error-detail"):
+            print("Error message: %s" % resp.msg["x-error-detail"])
+    else:
+        print("  OK!")
+    conn.close()

--- a/src/python/WMCore/MicroService/MSCore/MSManager.py
+++ b/src/python/WMCore/MicroService/MSCore/MSManager.py
@@ -11,7 +11,7 @@ used in service config.py as following
     # REST interface
     data = views.section_('data')
     data.object = 'WMCore.MicroService.Service.RestApiHub.RestApiHub'
-    data.manager = 'WMCore.MicroService.Unified.MSManager.MSManager'
+    data.manager = 'WMCore.MicroService.MSManager.MSManager'
     data.reqmgr2Url = "%s/reqmgr2" % BASE_URL
     data.limitRequestsPerCycle = 500
     data.enableStatusTransition = False
@@ -217,8 +217,9 @@ class MSManager(object):
     def transferor(self, reqStatus):
         """
         MSManager transferor function.
-        It performs Unified logic for data subscription and
-        transfers requests from assigned to staging/staged state of ReqMgr2.
+        It performs input data placement logic for workflows that have
+        been assigned in the system. Successful workflows will be moved
+        to the staging status in ReqMgr2.
         For references see
         https://github.com/dmwm/WMCore/wiki/ReqMgr2-MicroService-Transferor
         """

--- a/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
+++ b/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
@@ -99,7 +99,6 @@ class MSTransferor(MSCore):
 
         self.cric = CRIC(logger=self.logger)
         self.pileupDocs = []
-        self.uConfig = {}
         self.campaigns = {}
         self.psn2pnnMap = {}
         self.pnn2psnMap = {}
@@ -129,13 +128,10 @@ class MSTransferor(MSCore):
         self.dsetCounter = 0
         self.blockCounter = 0
         self.pileupDocs = getPileupDocs(self.msConfig['mspileupUrl'], self.pileupQuery)
-        self.uConfig = self.unifiedConfig()
         campaigns = self.reqmgrAux.getCampaignConfig("ALL_DOCS")
         self.psn2pnnMap = self.cric.PSNtoPNNMap()
         self.pnn2psnMap = self.cric.PNNtoPSNMap()
-        if not self.uConfig:
-            raise RuntimeWarning("Failed to fetch the unified configuration")
-        elif not campaigns:
+        if not campaigns:
             raise RuntimeWarning("Failed to fetch the campaign configurations")
         elif not self.psn2pnnMap:
             raise RuntimeWarning("Failed to fetch PSN x PNN map from CRIC")

--- a/src/python/WMCore/MicroService/MSTransferor/RequestInfo.py
+++ b/src/python/WMCore/MicroService/MSTransferor/RequestInfo.py
@@ -95,11 +95,6 @@ class RequestInfo(MSCore):
             will be a subset of the input records.
         """
         self.pileupDocs = pileupDocs
-        # obtain new unified Configuration
-        uConfig = self.unifiedConfig()
-        if not uConfig:
-            self.logger.warning("Failed to fetch the latest unified config. Skipping this cycle")
-            return []
         self.logger.info("Going to process %d requests.", len(reqRecords))
 
         # create a Workflow object representing the request, matching

--- a/src/python/WMCore/REST/Error.py
+++ b/src/python/WMCore/REST/Error.py
@@ -226,6 +226,27 @@ class ExecutionError(RESTError):
     app_code = 403
     message = "Execution error"
 
+
+class MissingBodyData(RESTError):
+    """Exception for requests missing body data."""
+    http_code = 400
+    app_code = 1201
+
+    def __init__(self):
+        RESTError.__init__(self)
+        self.message = "User did not pass any body data with the request"
+
+
+class InvalidUnifiedSchema(RESTError):
+    """Exception for incorrect user data schema."""
+    http_code = 400
+    app_code = 1202
+
+    def __init__(self, message):
+        RESTError.__init__(self)
+        self.message = message
+
+
 def report_error_header(header, val):
     """If `val` is non-empty, set CherryPy response `header` to `val`.
     Replaces all newlines with "; " characters. If the resulting value is

--- a/src/python/WMCore/ReqMgr/CherryPyThreads/AuxCacheUpdateTasks.py
+++ b/src/python/WMCore/ReqMgr/CherryPyThreads/AuxCacheUpdateTasks.py
@@ -1,9 +1,6 @@
 """
 Created on May 19, 2015
 """
-
-from __future__ import (division, print_function)
-import json
 from WMCore.REST.CherryPyPeriodicTask import CherryPyPeriodicTask
 from WMCore.Services.ReqMgrAux.ReqMgrAux import ReqMgrAux
 from WMCore.Services.pycurl_manager import RequestHandler
@@ -15,7 +12,6 @@ class AuxCacheUpdateTasks(CherryPyPeriodicTask):
     """
 
     def __init__(self, rest, config):
-
         super(AuxCacheUpdateTasks, self).__init__(config)
         self.reqmgrAux = ReqMgrAux(config.reqmgr2_url, logger=self.logger)
         self.mgr = RequestHandler()
@@ -29,21 +25,7 @@ class AuxCacheUpdateTasks(CherryPyPeriodicTask):
     def updateAuxiliarDocs(self, config):
         """
         Update the central couch database with auxiliary documents
-        that need to be constanly updated whenever an update is
-        made at the data source
+        that need to be continuously updated
         """
-        self.logger.info("Updating auxiliary couch documents ...")
-
+        self.logger.info("Updating CMSSW document in Central Couch ...")
         self.reqmgrAux.populateCMSSWVersion(config.tagcollect_url, **config.tagcollect_args)
-
-        try:
-            data = self.mgr.getdata(config.unified_url, params={},
-                                    headers={'Accept': 'application/json'})
-            data = json.loads(data)
-        except Exception as ex:
-            msg = "Failed to retrieve unified configuration from github. Error: %s" % str(ex)
-            msg += "\nRetrying again in the next cycle"
-            self.logger.error(msg)
-            return
-
-        self.reqmgrAux.updateUnifiedConfig(data, docName="config")

--- a/src/python/WMCore/ReqMgr/Utils/AuxValidation.py
+++ b/src/python/WMCore/ReqMgr/Utils/AuxValidation.py
@@ -1,0 +1,53 @@
+"""
+Module with validation functions for the Auxiliary-based
+RESTful APIs, such as unifiedconfig, wmagentconfig, etc.
+"""
+
+
+def validateUnifiedConfig(data):
+    """
+    Function to validate content of the Unified configuration
+    before it gets persisted in the database.
+    :param data: dictionary with the Unified configuration
+    :return: raises an exception in case of problems, otherwise None
+    """
+    SUPPORTED_KEYS = {"tiers_to_DDM", "tiers_no_DDM", "tiers_with_no_custodial"}
+    NESTED_KEYS = {"value", "description"}
+    baseError = "Unified schema error."
+    if not isinstance(data, dict):
+        raise RuntimeError(f"{baseError} It needs to be a dictionary, not: {type(data)}")
+
+    # does user data contains all of the required top level parameters?
+    if not SUPPORTED_KEYS.issubset(set(data.keys())):
+        raise RuntimeError(f"{baseError} It is missing some of the required parameters: {SUPPORTED_KEYS}")
+
+    for keyAttr in data:
+        # is the user data parameter listed as a supported parameter?
+        if keyAttr not in SUPPORTED_KEYS:
+            raise RuntimeError(f"{baseError} It has unsupported parameter: {keyAttr}")
+
+        # does user data contains all of the internal keys within each top level parameter?
+        if not NESTED_KEYS.issubset(set(data.get(keyAttr, {}).keys())):
+            # are all elements of expected inner keys in data[keyAttr]?
+            msg = f"{baseError} Attribute '{keyAttr}' is missing "
+            msg += f"some of the nested required keys: {NESTED_KEYS}"
+            raise RuntimeError(msg)
+
+        # are the nested keys in the user data parameter provided supported in the schema?
+        for nestedAttr, nestedValue in data[keyAttr].items():
+            if nestedAttr not in NESTED_KEYS:
+                msg = f"{baseError} Attribute '{keyAttr}' has "
+                msg += f"unsupported nested key: {nestedAttr}"
+                raise RuntimeError(msg)
+            # then validate the value data type as well
+            if nestedAttr == "value":
+                if not isinstance(nestedValue, list):
+                    msg = f"{baseError} Data type of {keyAttr}.{nestedAttr} "
+                    msg =+ f"should be 'list', not '{type(nestedValue)}'"
+                    raise RuntimeError(msg)
+            elif nestedAttr == "description":
+                if not isinstance(nestedValue, str):
+                    msg = f"{baseError} Data type of {keyAttr}.{nestedAttr} "
+                    msg =+ f"should be 'str', not '{type(nestedValue)}'"
+                    raise RuntimeError(msg)
+    # if it got here, then everything is fine!

--- a/test/python/WMCore_t/ReqMgr_t/Utils_t/AuxValidation_t.py
+++ b/test/python/WMCore_t/ReqMgr_t/Utils_t/AuxValidation_t.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""
+Unittests for IteratorTools functions
+"""
+import unittest
+
+from WMCore.ReqMgr.Utils.AuxValidation import validateUnifiedConfig
+from WMCore.REST.Error import InvalidUnifiedSchema
+
+
+class AuxValidationTests(unittest.TestCase):
+    """
+    Unittests for ReqMgr Utils Validation functions
+    """
+
+    def test1ValidateUnifiedConfig(self):
+        """
+        Test the `validateUnifiedConfig` function with wrong input data
+        """
+        # bad data type
+        for wrongData in ["", [], 123, {}]:
+            with self.assertRaises(RuntimeError):
+                validateUnifiedConfig(wrongData)
+
+        # missing top level parameters
+        userD = {"tiers_to_DDM": {"value": ["LHE"], "description": "tiers to DDM"}}
+        with self.assertRaises(RuntimeError):
+            validateUnifiedConfig(userD)
+        userD = {"tiers_to_DDM": {"value": ["LHE"], "description": "tiers to DDM"},
+                 "tiers_no_DDM": {"value": ["GEN-SIM"], "description": "tiers no DDM"}}
+        with self.assertRaises(RuntimeError):
+            validateUnifiedConfig(userD)
+        userD = {"tiers_to_DDM": {"value": ["LHE"], "description": "tiers to DDM"},
+                 "tiers_with_no_custodial": {"value": ["DQM"], "description": "tiers no custodial"}}
+        with self.assertRaises(RuntimeError):
+            validateUnifiedConfig(userD)
+
+        # and now with 1 unsupported parameter
+        userD = {"tiers_to_DDM": {"value": ["LHE"], "description": "tiers to DDM"},
+                 "tiers_no_DDM": {"value": ["GEN-SIM"], "description": "tiers no DDM"},
+                 "tiers_with_no_custodial": {"value": ["DQM"], "description": "tiers no custodial"},
+                 "BAD_KEY": {"value": ["LHE"], "description": "unsupported parameter"}
+                 }
+        with self.assertRaises(RuntimeError):
+            validateUnifiedConfig(userD)
+
+    def test2ValidateUnifiedConfig(self):
+        """
+        Test the `validateUnifiedConfig` function with wrong
+        nested schema, but also with the correct and expected schema.
+        """
+        # missing nested keys
+        userD = {"tiers_to_DDM": {},
+                 "tiers_no_DDM": {},
+                 "tiers_with_no_custodial": {}}
+        with self.assertRaises(RuntimeError):
+            validateUnifiedConfig(userD)
+        userD = {"tiers_to_DDM": {"value": ["LHE"]},
+                 "tiers_no_DDM": {"value": ["GEN-SIM"]},
+                 "tiers_with_no_custodial": {"value": ["DQM"]}}
+        with self.assertRaises(RuntimeError):
+            validateUnifiedConfig(userD)
+        userD = {"tiers_to_DDM": {"description": "tiers to DDM"},
+                 "tiers_no_DDM": {"description": "tiers no DDM"},
+                 "tiers_with_no_custodial": {"description": "tiers no custodial"}}
+        with self.assertRaises(RuntimeError):
+            validateUnifiedConfig(userD)
+
+        # now with too many nested keys
+        userD = {"tiers_to_DDM": {"value": ["LHE"], "description": "tiers to DDM", "BAD_KEY": "blah"},
+                 "tiers_no_DDM": {"value": ["GEN-SIM"], "description": "tiers no DDM"},
+                 "tiers_with_no_custodial": {"value": ["DQM"], "description": "tiers no custodial"}}
+        with self.assertRaises(RuntimeError):
+            validateUnifiedConfig(userD)
+
+        # last but not least, a good looking and supported schema
+        userD = {"tiers_to_DDM": {"value": ["LHE"], "description": "tiers to DDM"},
+                 "tiers_no_DDM": {"value": ["GEN-SIM"], "description": "tiers no DDM"},
+                 "tiers_with_no_custodial": {"value": ["DQM"], "description": "tiers no custodial"}}
+        validateUnifiedConfig(userD)
+
+    def testInvalidUnifiedSchemaException(self):
+        """
+        Test the `InvalidUnifiedSchema` exception
+        """
+        errorMsg = ""
+        try:
+            try:
+                validateUnifiedConfig([])
+            except Exception as exc:
+                raise InvalidUnifiedSchema(str(exc)) from None
+        except InvalidUnifiedSchema as exc2:
+            errorMsg = str(exc2)
+        self.assertTrue("Unified schema error." in errorMsg)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #11695 

#### Status
ready

#### Description
List of changes is:
* added a bin/adhoc script to inject only the needed set of Unified configuration (current snapshot)
* simple aesthetic changes in MSManager
* remove Unified configuration from MSTransferor/RequestInfo, as it has apparently been deprecated for that service
* create a new exception for UnifiedSchema and move it under REST/Error
* stop fetching the Unified configuration in AuxCacheUpdateTasks ReqMgr2 CherryPy thread
* added validation on the server side for `unifiedconfig` endpoint. Plus moved a few other things around.
* provided a new function `validateUnifiedConfig` to validate user input when creating and/or updating the Unified configuration in central CouchDB

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
