### PR TITLE
Deal with partial block in the parentage fix - take 2

### DIFF
--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -964,14 +964,19 @@ class DBS3Reader(object):
             parentFileId = parentRunLumi[runLumi]
             listChildParent.append([childFileId, parentFileId])
 
-        # the next for loop will finds all the children files with missing parents
-        # and set their parent file id to -1 instead.
+        # the next for loop will find all the children files with missing parents
+        # and set their parent file id to -1 instead, unless that child id already has
+        # a valid parent file for other lumi(s)
         missingParents = set()
         for runLumi in childFlatData.keys() - parentRunLumi.keys():
             childFileId = childFlatData[runLumi]
+            msg = "Child file id: %s, with run/lumi: %s, has no match in the parent dataset. "
+            if childFileId in withParents:
+                msg += "It does have parent files for other run/lumis though."
+                self.logger.warning(msg, childFileId, runLumi)
+                continue
             missingParents.add(childFileId)
             listChildParent.append([childFileId, -1])
-            msg = "Child file id: %s, with run/lumi: %s, has no match in the parent dataset."
             msg += "Adding it with -1 parentage information to DBS."
             self.logger.warning(msg, childFileId, runLumi)
         self.logger.debug("Files with parent: %s, without: %s, non-unique tuples: %d",


### PR DESCRIPTION
Fixes #11715 

#### Status
ready

#### Description
Complement to https://github.com/dmwm/WMCore/pull/11757

In the previous pull request, I missed one important use case, which is when a given child file has a matching parent id for some run/lumis but none for other run/lumi pairs. That means the same child file id can be used either with a valid (>0) and invalid (=-1) parent file id, e.g. `child_parent_id_list: [[3078470557, -1], [3078470557, 3078342877], ...`

With this pull request, we only add the `-1` tuple if the child file has NO parent file ids at all, such that the DBS server can correctly count the number of children files with missing parent. 

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Complement to https://github.com/dmwm/WMCore/pull/11757

#### External dependencies / deployment changes
None
