### PR TITLE
Set token file in the job classad

### DIFF
--- a/etc/submit_py3.sh
+++ b/etc/submit_py3.sh
@@ -192,6 +192,14 @@ else
 fi
 echo -e "======== WMAgent Python bootstrap finished at $(TZ=GMT date) ========\n"
 
+echo -e "======= WMAgent token verification at $(TZ=GMT date) ========\n"
+echo "Content under _CONDOR_CREDS: ${_CONDOR_CREDS}"
+ls -l ${_CONDOR_CREDS}
+export BEARER_TOKEN_FILE=${_CONDOR_CREDS}/cms.use
+# this tool needs to become available in the job images
+httokendecode ${BEARER_TOKEN_FILE}
+# Unset X509 only to test reading data from the storage with token
+#unset X509_USER_PROXY
 
 echo "======== WMAgent Unpack the job starting at $(TZ=GMT date) ========"
 # Should be ready to unpack and run this

--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -520,6 +520,9 @@ class SimpleCondorPlugin(BasePlugin):
                 ad['Requirements'] = self.reqStr
 
             ad['My.x509userproxy'] = classad.quote(self.x509userproxy)
+            # let HTCondor manage/transfer the token for us
+            ad['use_oauth_services'] = "cms"
+
             sites = ','.join(sorted(job.get('possibleSites')))
             ad['My.DESIRED_Sites'] = classad.quote(str(sites))
             sites = ','.join(sorted(job.get('potentialSites')))


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/11968

#### Status
Ready

#### Description
This investigation and development has been documented in https://gitlab.cern.ch/dmwm/wmcore-docs/-/merge_requests/6

In short, we need to have:
* environment variable `BEARER_TOKEN_FILE` for finding the token in the schedd and job payload
* e `use_oauth_services` condor job classad. Such that HTCondor can manage the token for us and keep it up-to-date inside the payloads.

NOTE: this setup has been tested in FNAL submit1 node.
#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
WMCore documentation at https://gitlab.cern.ch/dmwm/wmcore-docs/-/merge_requests/6

Further HTCondor setup is required and it needs to run the `condor_credmon_vault` daemon, to automatically fetch up-to-date token from the filesystem and push it to the job.
Note that currently the access token has 1h lifetime and it's meant to be refreshed every 15min.