### PR TITLE
Fix #11239: Replaced instances of logging.warn to logging.warning

### DIFF
--- a/src/python/WMComponent/JobUpdater/JobUpdaterPoller.py
+++ b/src/python/WMComponent/JobUpdater/JobUpdaterPoller.py
@@ -103,7 +103,7 @@ class JobUpdaterPoller(BaseWorkerThread):
         except Exception as ex:
             errorStr = str(ex)
             if 'Connection refused' in errorStr or "timed out" in errorStr:
-                logging.warn("Failed to sync priorities. Trying in the next cycle")
+                logging.warning("Failed to sync priorities. Trying in the next cycle")
             else:
                 msg = "Caught unexpected exception in JobUpdater: %s\n" % errorStr
                 logging.exception(msg)

--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -439,7 +439,7 @@ class SimpleCondorPlugin(BasePlugin):
         try:
             schedd.act(htcondor.JobAction.Remove, gridIds)
         except RuntimeError:
-            logging.warn("Error while killing jobs on the schedd: %s", gridIds)
+            logging.warning("Error while killing jobs on the schedd: %s", gridIds)
             if raiseEx:
                 raise
 
@@ -458,7 +458,7 @@ class SimpleCondorPlugin(BasePlugin):
         try:
             schedd.act(htcondor.JobAction.Remove, "WMAgent_RequestName == %s" % classad.quote(str(workflow)))
         except RuntimeError:
-            logging.warn("Error while killing jobs on the schedd: WMAgent_RequestName=%s", workflow)
+            logging.warning("Error while killing jobs on the schedd: WMAgent_RequestName=%s", workflow)
 
         return
 

--- a/src/python/WMCore/Services/Requests.py
+++ b/src/python/WMCore/Services/Requests.py
@@ -244,7 +244,7 @@ class Requests(dict):
             setattr(e, 'result', str(ex))
             raise e from None
         except (socket.error, AttributeError):
-            self['logger'].warn("Http request failed, retrying once again..")
+            self['logger'].warning("Http request failed, retrying once again..")
             # AttributeError implies initial connection error - need to close
             # & retry. httplib2 doesn't clear httplib state before next request
             # if this is threaded this may spoil things

--- a/src/python/WMCore/Storage/Plugins/Examples/SRMV2Impl.py
+++ b/src/python/WMCore/Storage/Plugins/Examples/SRMV2Impl.py
@@ -138,7 +138,7 @@ class SRMV2Impl(StageOutImplV2):
                 invalidPathCount = p2.communicate()[0]
                 logging.info("got this for SRM_INVALID_PATH: %s" % invalidPathCount)
                 if (invalidPathCount and (exitCode == '')):
-                    logging.warn("Directory doesn't exist in srmv2 stageout...creating and retrying")
+                    logging.warning("Directory doesn't exist in srmv2 stageout...creating and retrying")
                     self.createOutputDirectory(toPfn,stageOut)
                     continue
                 elif ( str(exitCode) != "0" ):

--- a/src/python/WMCore/WMRuntime/Bootstrap.py
+++ b/src/python/WMCore/WMRuntime/Bootstrap.py
@@ -59,7 +59,7 @@ def getSyncCE():
             host = host.split(":")[0]
             result = host
         except Exception:
-            logging.warn("Failed to extract SynCE from globus")
+            logging.warning("Failed to extract SynCE from globus")
         return result
 
     if 'NORDUGRID_CE' in os.environ:

--- a/test/data/ReqMgr/reqmgr2.py
+++ b/test/data/ReqMgr/reqmgr2.py
@@ -413,7 +413,7 @@ def process_request_args(input_config_file, command_line_json, logger):
             if k in cli_json:
                 request_args[k].update(cli_json[k])
     else:
-        logger.warn("No request arguments to override (--json)? Some values will be wrong.")
+        logger.warning("No request arguments to override (--json)? Some values will be wrong.")
 
     # iterate over all items recursively and warn about those ending with
     # OVERRIDE-ME, hence not overridden


### PR DESCRIPTION
Fixes #11239 

#### Status
Ready

#### Description
Since logging.warn is deprecated, instances of logging.warn have been replaced with logging.warning.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
N/A

#### External dependencies / deployment changes
No
