### PR TITLE
Initial implementation for WorkflowUpdater component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 WMCORE_JENKINS_REPLACEMENT_SOURCE.tar.gz
 .noseids
 *.patch
-
+.vscode/
 .idea/
 .project
 .pydevproject

--- a/bin/wmagent-mod-config
+++ b/bin/wmagent-mod-config
@@ -288,6 +288,13 @@ def modifyConfiguration(config, **args):
     if hasattr(config, "ArchiveDataReporter"):
         config.ArchiveDataReporter.WMArchiveURL = args["wmarchive_url"]
 
+        # custom WMArchiveReporter
+    if hasattr(config, "WorkflowUpdater"):
+        config.WorkflowUpdater.rucioUrl = args["rucio_host"]
+        config.WorkflowUpdater.rucioAuthUrl = args["rucio_auth"]
+        if args.get("mspileup_url", None):
+            config.WorkflowUpdater.msPileupUrl = args["mspileup_url"]
+
     return config
 
 
@@ -315,7 +322,7 @@ def main(argv=None):
                                          "reqmgr2_url=", "acdc_url=", "amq_auth_file=", "dbs3_url=",
                                          "dqm_url=", "grafana_token=", "requestcouch_url=", "central_logdb_url=",
                                          "wmarchive_url=", "amq_credentials=",
-                                         "rucio_account=", "rucio_host=", "rucio_auth="])
+                                         "rucio_account=", "rucio_host=", "rucio_auth=", "mspileup_url="])
 
         except getopt.error as msg:
             raise Usage(msg)
@@ -339,7 +346,7 @@ def main(argv=None):
                           '--amq_auth_file', '--dbs3_url', '--dqm_url',
                           '--grafana_token', '--requestcouch_url', '--central_logdb_url',
                           '--wmarchive_url', '--amq_credentials',
-                          '--rucio_account', '--rucio_host', '--rucio_auth'):
+                          '--rucio_account', '--rucio_host', '--rucio_auth', '--mspileup_url'):
                 parameters[option[2:]] = value
 
 

--- a/deploy/WMAgent.production
+++ b/deploy/WMAgent.production
@@ -27,3 +27,4 @@ RUCIO_HOST=http://cms-rucio.cern.ch
 RUCIO_AUTH=https://cms-rucio-auth.cern.ch
 TEAMNAME=
 AGENT_NUMBER=
+MSPILEUP_URL=https://cmsweb.cern.ch/ms-pileup/data/pileup

--- a/deploy/WMAgent.testbed
+++ b/deploy/WMAgent.testbed
@@ -27,3 +27,4 @@ RUCIO_HOST=http://cms-rucio-int.cern.ch
 RUCIO_AUTH=https://cms-rucio-auth-int.cern.ch
 TEAMNAME=
 AGENT_NUMBER=
+MSPILEUP_URL=https://cmsweb-testbed.cern.ch/ms-pileup/data/pileup

--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -385,3 +385,13 @@ config.RucioInjector.containerDiskRuleRSEExpr = "(tier=2|tier=1)&cms_type=real&r
 config.RucioInjector.rucioAccount = "OVER_WRITE_BY_SECRETS"
 config.RucioInjector.rucioUrl = "OVER_WRITE_BY_SECRETS"
 config.RucioInjector.rucioAuthUrl = "OVER_WRITE_BY_SECRETS"
+
+config.component_("WorkflowUpdater")
+config.WorkflowUpdater.namespace = "WMComponent.WorkflowUpdater.WorkflowUpdater"
+config.WorkflowUpdater.componentDir = config.General.workDir + "/WorkflowUpdater"
+config.WorkflowUpdater.logLevel = globalLogLevel
+config.WorkflowUpdater.pollInterval = 8 * 60 * 60  # every 8 hours
+config.WorkflowUpdater.rucioAccount = "wmcore_pileup"
+config.WorkflowUpdater.rucioUrl = "OVER_WRITE_BY_SECRETS"
+config.WorkflowUpdater.rucioAuthUrl = "OVER_WRITE_BY_SECRETS"
+config.WorkflowUpdater.msPileupUrl = "OVER_WRITE_BY_SECRETS"

--- a/src/python/WMComponent/WorkflowUpdater/WorkflowUpdater.py
+++ b/src/python/WMComponent/WorkflowUpdater/WorkflowUpdater.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+"""
+Component responsible for locally updating workflow specs and sandboxes.
+"""
+
+import logging
+import threading
+from pprint import pformat
+
+from WMComponent.WorkflowUpdater.WorkflowUpdaterPoller import WorkflowUpdaterPoller
+from WMCore.Agent.Harness import Harness
+
+
+class WorkflowUpdater(Harness):
+    """
+    Create a WorkflowUpdaterPoller component as a daemon
+    """
+
+    def __init__(self, config):
+        """
+        Initialize it with the agent configuration parameters.
+        :param config: a Configuration object with the component configuration
+        """
+        # call the base class
+        Harness.__init__(self, config)
+
+    def preInitialization(self):
+        """
+        Step that actually adds the worker thread properly
+        """
+        pollInterval = self.config.WorkflowUpdater.pollInterval
+        logging.info("Starting %s with configuration:\n%s", self.__class__.__name__,
+                     pformat(self.config.WorkflowUpdaterPoller.dictionary_()))
+
+        myThread = threading.currentThread()
+        myThread.workerThreadManager.addWorker(WorkflowUpdaterPoller(self.config),
+                                               pollInterval)

--- a/src/python/WMComponent/WorkflowUpdater/WorkflowUpdaterPoller.py
+++ b/src/python/WMComponent/WorkflowUpdater/WorkflowUpdaterPoller.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python
+"""
+The WorkflowUpdater poller component.
+Among the actions performed by this component, we can list:
+* find active workflows in the agent
+* filter those that require pileup dataset
+* find out the current location for the pileup datasets
+* get a list of blocks available and locked by WM
+* match those blocks with the current pileup config json file. In other words,
+  blocks that are no longer locked and/or available need to be removed from the
+  json file.
+* update this json in the workflow sandbox
+"""
+
+import logging
+import threading
+
+from Utils.CertTools import cert, ckey
+from Utils.IteratorTools import flattenList
+from Utils.Timers import timeFunction, CodeTimer
+from WMCore.Services.Rucio.Rucio import Rucio
+from WMCore.Services.pycurl_manager import RequestHandler
+from WMCore.WMException import WMException
+from WMCore.WMSpec.WMWorkload import WMWorkloadHelper
+from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
+from WMCore.DAOFactory import DAOFactory
+
+
+class WorkflowUpdaterException(WMException):
+    """
+    Specific WorkflowUpdaterPoller exception handling.
+    """
+
+
+class WorkflowUpdaterPoller(BaseWorkerThread):
+    """
+    Poller that does the actual work for updating workflows.
+    """
+
+    def __init__(self, config):
+        """
+        Initialize WorkflowUpdaterPoller object
+        :param config: a Configuration object with the component configuration
+        """
+        BaseWorkerThread.__init__(self)
+
+        myThread = threading.currentThread()
+        self.daoFactory = DAOFactory(package="WMCore.WMBS",
+                                     logger=myThread.logger,
+                                     dbinterface=myThread.dbi)
+        self.listActiveWflows = self.daoFactory(classname="Workflow.GetUnfinishedWorkflows")
+
+        # parse mandatory attributes from the configuration
+        self.config = config
+        self.rucioAcct = getattr(config.WorkflowUpdater, "rucioAccount")
+        self.rucioUrl = getattr(config.WorkflowUpdater, "rucioUrl")
+        self.rucioAuthUrl = getattr(config.WorkflowUpdater, "rucioAuthUrl")
+        self.rucioCustomScope = getattr(config.WorkflowUpdater, "rucioCustomScope",
+                                        "group.wmcore")
+        self.msPileupUrl = getattr(config.WorkflowUpdater, "msPileupUrl")
+
+        self.userCert = cert()
+        self.userKey = ckey()
+        self.rucio = Rucio(acct=self.rucioAcct,
+                           hostUrl=self.rucioUrl,
+                           authUrl=self.rucioAuthUrl)
+                           # configDict={'logger': self.logger})
+
+    @timeFunction
+    def algorithm(self, parameters=None):
+        """
+        Executed in every polling cycle. The actual logic of the component is:
+          1. find active workflows in the agent
+          2. check if those active workflows are using pileup data
+        :param parameters: not really used. But keeping same signature as
+            the one defined in the super class.
+        :return: only what is returned by the decorator
+        """
+        logging.info("Running Workflow updater injector poller algorithm...")
+        try:
+            # retrieve list of workflows with unfinished Production
+            # or Processing subscriptions
+            wflowSpecs = self.listActiveWflows.execute()
+            if not wflowSpecs:
+                logging.info("Agent has no active workflows at the moment")
+                return
+
+            # figure out workflows that have pileup
+            puWflows = self.findWflowsWithPileup(wflowSpecs)
+            if not puWflows:
+                logging.info("Agent has no active workflows with pileup at the moment")
+                return
+            # resolve unique active pileup dataset names
+            uniqueActivePU = flattenList([item['pileup'] for item in puWflows])
+
+            # otherwise, move on retrieving pileups
+            msPileupList = self.getPileupDocs()
+
+            # and resolve blocks in each container being used by workflows
+            # considerations for 2024 are around 100 pileups each taking 2 seconds in Rucio
+            with CodeTimer("Rucio block resolution", logger=logging):
+                self.findRucioBlocks(uniqueActivePU, msPileupList)
+
+            # TODO in future tickets: find the json files in the spec/sandbox area and tweak them
+
+        except Exception as ex:
+            msg = f"Caught unexpected exception in WorkflowUpdater. Details:\n{str(ex)}"
+            logging.exception(msg)
+            raise WorkflowUpdaterException(msg) from None
+
+    def getPileupDocs(self):
+        """
+        Fetch all pileup documents from MSPileup and preprocess the data.
+
+        Note that the 'blocks' field is for the moment just a placeholder,
+        as it will be populated in a later stage,
+
+        :return: a list of dictionaries in the following format:
+          {"pileupName": string with pileup name,
+           "customName": string with custom pileup name - if any,
+           "rses": list of RSE names,
+           "blocks": list of block names}
+        """
+        mgr = RequestHandler()
+        headers = {'Content-Type': 'application/json'}
+        data = mgr.getdata(self.msPileupUrl, params={}, headers=headers, verb='GET',
+                           ckey=self.userKey, cert=self.userCert, encode=True, decode=True)
+        if data and data.get("result", []):
+            if "error" in data["result"][0]:
+                msg = f"Failed to retrieve MSPileup documents. Error: {data}"
+                raise WorkflowUpdaterException(msg)
+
+        logging.info("A total of %d pileup documents have been retrieved.", len(data["result"]))
+        pileupMapList = []
+        for puItem in data["result"]:
+            logging.info("Pileup: %s, custom name: %s, expected at: %s, but currently available at: %s",
+                         puItem['pileupName'], puItem['customName'],
+                         puItem['expectedRSEs'], puItem['currentRSEs'])
+            thisPU = {"pileupName": puItem['pileupName'],
+                      "customName": puItem['customName'],
+                      "rses": puItem['currentRSEs'],
+                      "blocks": []}
+            pileupMapList.append(thisPU)
+        return pileupMapList
+
+    def findWflowsWithPileup(self, listSpecs):
+        """
+        Given a list of workflow names and their respective specs, load each
+        one of them and filter out those that don't require any pileup dataset.
+        :param listSpecs: a list of dictionary with workflow name and spec path
+        :return: a list of dictionaries with workflow name, spec path and list
+            of pileup datasets being used, e.g.:
+            {"name": string with workflow name,
+             "spec": string with spec path,
+             "pileup": list of strings with pileup names}
+        """
+        wflowsWithPU = []
+        for wflowSpec in listSpecs:
+            try:
+                workloadHelper = WMWorkloadHelper()
+                workloadHelper.load(wflowSpec['spec'])
+                pileupSpecs = workloadHelper.listPileupDatasets()
+                if pileupSpecs:
+                    wflowSpec['pileup'] = pileupSpecs.values()
+                    logging.info("Workflow: %s requires pileup dataset(s): %s",
+                                 wflowSpec['name'], wflowSpec['pileup'])
+                    wflowsWithPU.append(wflowSpec)
+                else:
+                    logging.info("Workflow: %s does not require any pileup", wflowSpec['name'])
+            except Exception as ex:
+                msg = f"Failed to load spec file for: {wflowSpec['spec']}. Details: {str(ex)}"
+                logging.error(msg)
+        logging.info("There are %d pileup workflows out of %d active workflows.",
+                     len(wflowsWithPU), len(listSpecs))
+        return wflowsWithPU
+
+    def findRucioBlocks(self, uniquePUList, msPileupList):
+        """
+        Given a list of unique pileup dataset names, list all of
+        their blocks in Rucio. Note that if a pileup document contains
+        a customName dataset, then we need to resolve the blocks for that
+        instead.
+        :param uniquePUList: a list with pileup names
+        :param msPileupList: a list with dictionaries from MSPileup
+        :return: update the msPileupList object in place, by populating
+            the 'block' field with a list of block names
+        """
+        for pileupItem in msPileupList:
+            if pileupItem["pileupName"] not in uniquePUList:
+                # no active workflow requires this pileup
+                continue
+
+            if pileupItem["customName"]:
+                logging.info("Fetching blocks for custom pileup container: %s", pileupItem["customName"])
+                pileupItem["blocks"] = self.rucio.getBlocksInContainer(pileupItem["customName"],
+                                                                       scope=self.rucioCustomScope)
+            else:
+                logging.info("Fetching blocks for pileup container: %s", pileupItem["pileupName"])
+                pileupItem["blocks"] = self.rucio.getBlocksInContainer(pileupItem["pileupName"], scope='cms')

--- a/src/python/WMCore/WMBS/MySQL/Workflow/GetUnfinishedWorkflows.py
+++ b/src/python/WMCore/WMBS/MySQL/Workflow/GetUnfinishedWorkflows.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+"""
+Module for finding out workflows with open subscriptions
+for production and/or processing tasks.
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+
+class GetUnfinishedWorkflows(DBFormatter):
+    """
+    If a workflow has any production or processing type subscriptions
+    still unfinished, then it is considered an unfinished/active workflow.
+    """
+
+    sql = """SELECT wmbs_workflow.name, wmbs_workflow.spec
+               FROM wmbs_workflow
+               INNER JOIN wmbs_subscription ON wmbs_subscription.workflow = wmbs_workflow.id
+               INNER JOIN wmbs_sub_types ON wmbs_sub_types.id = wmbs_subscription.subtype
+               WHERE wmbs_subscription.finished = 0
+                 AND wmbs_sub_types.name IN ('Processing', 'Production') 
+               GROUP BY wmbs_workflow.name, wmbs_workflow.spec"""
+
+    def execute(self, conn=None, transaction=False):
+        """
+        Executes the SQL statement above.
+        :param conn: connection object to the database
+        :param transaction: boolean defining whether it's part of a transaction or not
+        :return: a list of dictionary elements
+        """
+        result = self.dbi.processData(self.sql, conn=conn, transaction=transaction)
+        return self.formatDict(result)

--- a/src/python/WMCore/WMBS/Oracle/Workflow/GetUnfinishedWorkflows.py
+++ b/src/python/WMCore/WMBS/Oracle/Workflow/GetUnfinishedWorkflows.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+"""
+Oracle implementation of Workflow.GetUnfinishedWorkflows
+"""
+
+from WMCore.WMBS.MySQL.Workflow.GetUnfinishedWorkflows import \
+    GetUnfinishedWorkflows as MySQLGetUnfinishedWorkflows
+
+
+class GetUnfinishedWorkflows(MySQLGetUnfinishedWorkflows):
+    pass

--- a/test/python/WMComponent_t/ErrorHandler_t/ErrorHandler_t.py
+++ b/test/python/WMComponent_t/ErrorHandler_t/ErrorHandler_t.py
@@ -15,7 +15,7 @@ import unittest
 
 from Utils.PythonVersion import PY3
 
-from WMCore_t.WMSpec_t.TestSpec import testWorkload
+from WMCore_t.WMSpec_t.TestSpec import createTestWorkload
 from nose.plugins.attrib import attr
 
 import WMCore.WMBase
@@ -130,12 +130,10 @@ class ErrorHandlerTest(EmulatedUnitTestCase):
 
     def createWorkload(self, workloadName='Test'):
         """
-        _createTestWorkload_
-
         Creates a test workload for us to run on, hold the basic necessities.
         """
 
-        workload = testWorkload(workloadName)
+        workload = createTestWorkload(workloadName)
 
         # Add RequestManager stuff
         workload.data.request.section_('schema')
@@ -266,7 +264,7 @@ class ErrorHandlerTest(EmulatedUnitTestCase):
                 self.assertTrue(f['lfn'] in ["/this/is/a/lfnA", "/this/is/a/lfnB"])
                 self.assertEqual(f['events'], 10)
                 self.assertEqual(f['size'], 1024)
-                self.assertEqual(f['parents'], [u'/this/is/a/parent'])
+                self.assertEqual(f['parents'], ['/this/is/a/parent'])
                 self.assertTrue(f['runs'][0]['run_number'] == 10)
                 if f['lfn'] == "/this/is/a/lfnA":
                     self.assertItemsEqual(f['runs'][0]['lumis'], [12312])

--- a/test/python/WMComponent_t/JobCreator_t/JobCreator_t.py
+++ b/test/python/WMComponent_t/JobCreator_t/JobCreator_t.py
@@ -18,7 +18,7 @@ import unittest
 
 from Utils.PythonVersion import PY3
 
-from WMCore_t.WMSpec_t.TestSpec import testWorkload
+from WMCore_t.WMSpec_t.TestSpec import createTestWorkload
 from nose.plugins.attrib import attr
 
 from WMComponent.JobCreator.JobCreatorPoller import JobCreatorPoller, capResourceEstimates
@@ -160,12 +160,10 @@ class JobCreatorTest(EmulatedUnitTestCase):
 
     def createWorkload(self, workloadName='Test'):
         """
-        _createTestWorkload_
-
         Creates a test workload for us to run on, hold the basic necessities.
         """
 
-        workload = testWorkload(workloadName)
+        workload = createTestWorkload(workloadName)
         rereco = workload.getTask("ReReco")
         seederDict = {"generator.initialSeed": 1001, "evtgenproducer.initialSeed": 1001}
         rereco.addGenerator("PresetSeeder", **seederDict)

--- a/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
+++ b/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
@@ -18,7 +18,7 @@ import unittest
 
 from Utils.PythonVersion import PY3
 
-from WMCore_t.WMSpec_t.TestSpec import testWorkload
+from WMCore_t.WMSpec_t.TestSpec import createTestWorkload
 from nose.plugins.attrib import attr
 
 from WMComponent.JobSubmitter.JobSubmitterPoller import JobSubmitterPoller
@@ -307,14 +307,12 @@ class JobSubmitterTest(EmulatedUnitTestCase):
 
         return config
 
-    def createTestWorkload(self, name='workloadTest'):
+    def setupTestWorkload(self, name='workloadTest'):
         """
-        _createTestWorkload_
-
         Creates a test workload for us to run on, hold the basic necessities.
         """
 
-        workload = testWorkload()
+        workload = createTestWorkload()
 
         taskMaker = TaskMaker(workload, os.path.join(self.testDir, name))
         taskMaker.skipSubscription = True
@@ -330,7 +328,7 @@ class JobSubmitterTest(EmulatedUnitTestCase):
         Check to see that all the jobs were "submitted",
         don't care about thresholds
         """
-        workload = self.createTestWorkload()
+        workload = self.setupTestWorkload()
         config = self.getConfig()
         changeState = ChangeState(config)
 
@@ -409,7 +407,7 @@ class JobSubmitterTest(EmulatedUnitTestCase):
         this requires checks on pending/running jobs globally
         at a site and per task/site
         """
-        workload = self.createTestWorkload()
+        workload = self.setupTestWorkload()
         config = self.getConfig()
         changeState = ChangeState(config)
 
@@ -530,10 +528,10 @@ class JobSubmitterTest(EmulatedUnitTestCase):
         Test whether the correct job type, workflow and task id priorities
         are respected in the DAO
         """
-        workload1 = self.createTestWorkload(name='testWorkload1')
-        workload2 = self.createTestWorkload(name='testWorkload2')
-        workload3 = self.createTestWorkload(name='testWorkload3')
-        workload4 = self.createTestWorkload(name='testWorkload4')
+        workload1 = self.setupTestWorkload(name='testWorkload1')
+        workload2 = self.setupTestWorkload(name='testWorkload2')
+        workload3 = self.setupTestWorkload(name='testWorkload3')
+        workload4 = self.setupTestWorkload(name='testWorkload4')
 
         config = self.getConfig()
         changeState = ChangeState(config)
@@ -642,7 +640,7 @@ class JobSubmitterTest(EmulatedUnitTestCase):
 
         Check that jobs are prioritized by job type and by oldest workflow
         """
-        workload = self.createTestWorkload()
+        workload = self.setupTestWorkload()
         config = self.getConfig()
         changeState = ChangeState(config)
 
@@ -740,7 +738,7 @@ class JobSubmitterTest(EmulatedUnitTestCase):
 
         Check if jobs without a possible site to run at go to SubmitFailed
         """
-        workload = self.createTestWorkload()
+        workload = self.setupTestWorkload()
         config = self.getConfig()
         changeState = ChangeState(config)
 
@@ -772,7 +770,7 @@ class JobSubmitterTest(EmulatedUnitTestCase):
         Test the behavior of the submitter in response to the different
         states of the sites
         """
-        workload = self.createTestWorkload()
+        workload = self.setupTestWorkload()
         config = self.getConfig()
         changeState = ChangeState(config)
         nSubs = 1
@@ -874,7 +872,7 @@ class JobSubmitterTest(EmulatedUnitTestCase):
 
         Test the behavior of jobs pending to a single site that is in drain mode
         """
-        workload = self.createTestWorkload()
+        workload = self.setupTestWorkload()
         config = self.getConfig()
         jobSubmitter = JobSubmitterPoller(config=config)
         myResourceControl = ResourceControl(config)
@@ -937,7 +935,7 @@ class JobSubmitterTest(EmulatedUnitTestCase):
         them to actually be submitted
         """
 
-        workload = self.createTestWorkload()
+        workload = self.setupTestWorkload()
         config = self.getConfig()
         changeState = ChangeState(config)
 
@@ -991,7 +989,7 @@ class JobSubmitterTest(EmulatedUnitTestCase):
         code has to be updated with decorators.
         NOTE: Never run it on jenkins
         """
-        workload = self.createTestWorkload()
+        workload = self.setupTestWorkload()
         config = self.getConfig()
         changeState = ChangeState(config)
         # myResourceControl = ResourceControl(config)

--- a/test/python/WMComponent_t/TaskArchiver_t/TaskArchiver_t.py
+++ b/test/python/WMComponent_t/TaskArchiver_t/TaskArchiver_t.py
@@ -16,7 +16,7 @@ import threading
 import time
 import unittest
 
-from WMCore_t.WMSpec_t.TestSpec import testWorkload
+from WMCore_t.WMSpec_t.TestSpec import createTestWorkload
 from nose.plugins.attrib import attr
 
 import WMCore.WMBase
@@ -175,12 +175,10 @@ class TaskArchiverTest(EmulatedUnitTestCase):
 
     def createWorkload(self, workloadName):
         """
-        _createTestWorkload_
-
         Creates a test workload for us to run on, hold the basic necessities.
         """
 
-        workload = testWorkload(workloadName)
+        workload = createTestWorkload(workloadName)
 
         taskMaker = TaskMaker(workload, os.path.join(self.testDir, 'workloadTest'))
         taskMaker.skipSubscription = True

--- a/test/python/WMComponent_t/WorkflowUpdater_t/WorkflowUpdater_t.py
+++ b/test/python/WMComponent_t/WorkflowUpdater_t/WorkflowUpdater_t.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python
+
+import os
+import threading
+import unittest
+
+from WMCore_t.WMSpec_t.TestSpec import createTestWorkload
+from WMComponent.WorkflowUpdater.WorkflowUpdaterPoller import WorkflowUpdaterPoller
+from WMCore.Agent.HeartbeatAPI import HeartbeatAPI
+from WMCore.DAOFactory import DAOFactory
+from WMCore.DataStructs.Run import Run
+from WMCore.Services.UUIDLib import makeUUID
+from WMCore.WMBS.File import File
+from WMCore.WMBS.Fileset import Fileset
+from WMCore.WMBS.Subscription import Subscription
+from WMCore.WMBS.Workflow import Workflow
+from WMCore.WMSpec.Makers.TaskMaker import TaskMaker
+from WMQuality.Emulators import EmulatorSetup
+from WMQuality.Emulators.EmulatedUnitTestCase import EmulatedUnitTestCase
+from WMQuality.TestInitCouchApp import TestInitCouchApp as TestInit
+
+
+class WorkflowUpdaterTest(EmulatedUnitTestCase):
+    """
+    Test case for the WorkflowUpdater
+    """
+
+    def setUp(self):
+        """
+        Setup the database and logging connection. Try to create all of the
+        WMBS tables.
+        """
+        super(WorkflowUpdaterTest, self).setUp()
+
+        self.testInit = TestInit(__file__)
+        self.testInit.setLogging()
+        self.testInit.setDatabaseConnection(destroyAllDatabase=True)
+
+        self.testInit.setSchema(customModules=['WMCore.WMBS', 'WMCore.Agent.Database'],
+                                useDefault=False)
+
+        self.configFile = EmulatorSetup.setupWMAgentConfig()
+
+        myThread = threading.currentThread()
+        self.daoFactory = DAOFactory(package="WMCore.WMBS",
+                                     logger=myThread.logger,
+                                     dbinterface=myThread.dbi)
+        self.listActiveWflows = self.daoFactory(classname="Workflow.GetUnfinishedWorkflows")
+
+        self.testDir = self.testInit.generateWorkDir()
+        self.cwd = os.getcwd()
+
+        # Set heartbeat
+        self.componentName = 'WorkflowUpdater'
+        self.heartbeatAPI = HeartbeatAPI(self.componentName)
+        self.heartbeatAPI.registerComponent()
+
+        # don't execute tearDown because it hangs
+        # self._teardown = False
+
+        return
+
+    def tearDown(self):
+        """
+        Drop all of the non-sql and sql databases
+        """
+        self.testInit.clearDatabase(modules=['WMCore.WMBS', 'WMCore.Agent.Database'])
+        self.testInit.delWorkDir()
+        self.testInit.tearDownCouch()
+        EmulatorSetup.deleteConfig(self.configFile)
+
+    def getConfig(self):
+        """
+        Creates a common config.
+        """
+        config = self.testInit.getConfiguration()
+        self.testInit.generateWorkDir(config)
+
+        # First the general stuff
+        config.section_("General")
+        config.General.workDir = os.getenv("TESTDIR", os.getcwd())
+        config.section_("Agent")
+        config.Agent.componentName = self.componentName
+
+        # Now the CoreDatabase information
+        # This should be the dialect, dburl, etc
+        config.section_("CoreDatabase")
+        config.CoreDatabase.connectUrl = os.getenv("DATABASE")
+        config.CoreDatabase.socket = os.getenv("DBSOCK")
+
+        config.component_("WorkflowUpdater")
+        config.WorkflowUpdater.namespace = 'WMComponent.WorkflowUpdater.WorkflowUpdater'
+        config.WorkflowUpdater.logLevel = 'INFO'
+        config.WorkflowUpdater.componentDir = self.testDir
+        config.WorkflowUpdater.rucioAccount = "wma_test"
+        config.WorkflowUpdater.rucioUrl = "http://cms-rucio-int.cern.ch"
+        config.WorkflowUpdater.rucioAuthUrl = "https://cms-rucio-auth-int.cern.ch"
+        config.WorkflowUpdater.msPileupUrl = "https://cmsweb-testbed.cern.ch/ms-pileup/data/pileup"
+
+        return config
+
+    def createWorkload(self, workloadName='Test'):
+        """
+        Creates a test workload for us to run on.
+        """
+        workload = createTestWorkload(workloadName)
+        rereco = workload.getTask("ReReco")
+        seederDict = {"generator.initialSeed": 1001, "evtgenproducer.initialSeed": 1001}
+        rereco.addGenerator("PresetSeeder", **seederDict)
+
+        taskMaker = TaskMaker(workload, os.path.join(self.testDir, 'workloadTest'))
+        # taskMaker.skipSubscription = False
+        taskMaker.processWorkload()
+
+        return workload
+
+    def stuffWMBS(self, workflowURL, name):
+        """
+        Insert some dummy jobs, jobgroups, filesets, files and subscriptions
+        into WMBS to test job creation.  Three completed job groups each
+        containing several files are injected.  Another incomplete job group is
+        also injected.  Also files are added to the "Mergeable" subscription as
+        well as to the output fileset for their jobgroups.
+        """
+        testSite = "T2_CH_CERN"
+        locationAction = self.daoFactory(classname="Locations.New")
+        locationAction.execute(siteName=testSite, pnn=testSite)
+
+        mergeFileset = Fileset(name="mergeFileset")
+        mergeFileset.create()
+        bogusFileset = Fileset(name="bogusFileset")
+        bogusFileset.create()
+
+        mergeWorkflow = Workflow(spec=workflowURL, name=name, task="/TestWorkload/ReReco")
+        mergeWorkflow.create()
+
+        mergeSubscription = Subscription(fileset=mergeFileset,
+                                         workflow=mergeWorkflow,
+                                         split_algo="ParentlessMergeBySize")
+        mergeSubscription.create()
+        dummySubscription = Subscription(fileset=bogusFileset,
+                                         workflow=mergeWorkflow,
+                                         split_algo="ParentlessMergeBySize")
+
+        fileObjList = []
+        for idx, fName in enumerate(["file1", "file2", "file3", "file4"]):
+            testFile = File(lfn=fName, size=1024, events=1024, first_event=1024 * idx, locations={testSite})
+            testFile.addRun(Run(1, *[45]))
+            testFile.create()
+            fileObjList.append(testFile)
+        for idx, fName in enumerate(["fileA", "fileB", "fileC"]):
+            testFile = File(lfn=fName, size=1024, events=1024, first_event=1024 * idx, locations={testSite})
+            testFile.addRun(Run(1, *[46]))
+            testFile.create()
+            fileObjList.append(testFile)
+        for idx, fName in enumerate(["fileI", "fileII", "fileIII", "fileIV"]):
+            testFile = File(lfn=fName, size=1024, events=1024, first_event=1024 * idx, locations={testSite})
+            testFile.addRun(Run(2, *[46]))
+            testFile.create()
+            fileObjList.append(testFile)
+
+        for fileObj in fileObjList:
+            mergeFileset.addFile(fileObj)
+            bogusFileset.addFile(fileObj)
+
+        mergeFileset.commit()
+        bogusFileset.commit()
+
+        return
+
+    def testVerySimpleTest(self):
+        """
+        Inject a workflow into the database and run WorkflowUpdater algorithm
+        """
+        # populate the database
+        workloadName = 'TestWorkload'
+        _dummyWorkload = self.createWorkload(workloadName=workloadName)
+        workloadPath = os.path.join(self.testDir, 'workloadTest', 'TestWorkload', 'WMSandbox', 'WMWorkload.pkl')
+        self.stuffWMBS(workflowURL=workloadPath, name=makeUUID())
+
+        myThread = threading.currentThread()
+
+        config = self.getConfig()
+        testWflowUpdater = WorkflowUpdaterPoller(config=config)
+        testWflowUpdater.algorithm()
+        # self.assertFalse(True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/python/WMCore_t/BossAir_t/BossAir_t.py
+++ b/test/python/WMCore_t/BossAir_t/BossAir_t.py
@@ -29,7 +29,7 @@ from WMCore.WMBS.JobGroup import JobGroup
 from WMCore.WMBS.Job import Job
 from WMCore.BossAir.BossAirAPI import BossAirAPI, BossAirException
 
-from WMCore_t.WMSpec_t.TestSpec import testWorkload
+from WMCore_t.WMSpec_t.TestSpec import createTestWorkload
 from WMQuality.TestInitCouchApp import TestInitCouchApp as TestInit
 
 
@@ -202,12 +202,10 @@ class BossAirTest(unittest.TestCase):
 
     def createTestWorkload(self, workloadName='Test', emulator=True):
         """
-        _createTestWorkload_
-
         Creates a test workload for us to run on, hold the basic necessities.
         """
 
-        workload = testWorkload("Tier1ReReco")
+        workload = createTestWorkload("Tier1ReReco")
         rereco = workload.getTask("ReReco")
 
         taskMaker = TaskMaker(workload, os.path.join(self.testDir, 'workloadTest'))

--- a/test/python/WMCore_t/Misc_t/Runtime_t.py
+++ b/test/python/WMCore_t/Misc_t/Runtime_t.py
@@ -16,7 +16,7 @@ import sys
 import unittest
 
 # from WMCore.WMSpec.StdSpecs.ReReco  import rerecoWorkload, getTestArguments
-from WMCore_t.WMSpec_t.TestSpec import testWorkload
+from WMCore_t.WMSpec_t.TestSpec import createTestWorkload
 from nose.plugins.attrib import attr
 
 import WMCore.WMBase
@@ -131,10 +131,8 @@ class RuntimeTest(unittest.TestCase):
 
         return
 
-    def createTestWorkload(self, workloadName='Test', emulator=True):
+    def setupTestWorkload(self, workloadName='Test', emulator=True):
         """
-        _createTestWorkload_
-
         Creates a test workload for us to run on, hold the basic necessities.
         """
 
@@ -145,7 +143,7 @@ class RuntimeTest(unittest.TestCase):
         # workload = rerecoWorkload("Tier1ReReco", arguments)
         # rereco = workload.getTask("ReReco")
 
-        workload = testWorkload(emulation=emulator)
+        workload = createTestWorkload(emulation=emulator)
         rereco = workload.getTask("ReReco")
 
         # Set environment and site-local-config
@@ -334,7 +332,7 @@ class RuntimeTest(unittest.TestCase):
         """
 
         workloadName = 'basicWorkload'
-        workload = self.createTestWorkload(workloadName=workloadName)
+        workload = self.setupTestWorkload(workloadName=workloadName)
 
         self.createWMBSComponents(workload=workload)
 
@@ -387,7 +385,6 @@ class RuntimeTest(unittest.TestCase):
         # And we're done.
         # Assume if we got this far everything is good
 
-
         # At the end, copy the directory
         # if os.path.exists('tmpDir'):
         #    shutil.rmtree('tmpDir')
@@ -407,7 +404,7 @@ class RuntimeTest(unittest.TestCase):
 
         # Assume all this works, because we tested it in testA
         workloadName = 'basicWorkload'
-        workload = self.createTestWorkload(workloadName=workloadName)
+        workload = self.setupTestWorkload(workloadName=workloadName)
 
         self.createWMBSComponents(workload=workload)
 
@@ -423,7 +420,7 @@ class RuntimeTest(unittest.TestCase):
 
         # Now validate the report
         self.assertEqual(report.getSiteName(), {})
-        #self.assertEqual(report.data.hostName, socket.gethostname())
+        # self.assertEqual(report.data.hostName, socket.gethostname())
         self.assertTrue(report.data.completed)
 
         # Should have status 0 (emulator job)
@@ -437,7 +434,6 @@ class RuntimeTest(unittest.TestCase):
         self.assertEqual(cmsReport.output.TestOutputModule.files.fileCount, 1)
 
         # So, um, I guess we're done
-
 
         # At the end, copy the directory
         # if os.path.exists('tmpDir'):

--- a/test/python/WMCore_t/Misc_t/WMAgent_t.py
+++ b/test/python/WMCore_t/Misc_t/WMAgent_t.py
@@ -1,60 +1,48 @@
 #!/usr/bin/env python
 
-from __future__  import division
+from __future__ import division
 
-import os
-import time
-import shutil
-import random
 import os.path
+
 import getpass
-import unittest
-import threading
-
-from subprocess import Popen, PIPE
+import os
 import pickle
+import random
+import shutil
+import threading
+import time
+import unittest
+from WMCore_t.WMSpec_t.TestSpec import createTestWorkload
+from subprocess import Popen, PIPE
 
-# Imports for testing
-from WMQuality.TestInit import TestInit
-from WMQuality.Emulators import EmulatorSetup
-from WMCore.DAOFactory import DAOFactory
-from WMCore.WMInit import getWMBASE
-
-
-
-# Component imports
-from WMComponent.JobCreator.JobCreatorPoller       import JobCreatorPoller
-from WMComponent.JobSubmitter.JobSubmitterPoller   import JobSubmitterPoller
-from WMComponent.JobTracker.JobTrackerPoller       import JobTrackerPoller
 from WMComponent.JobAccountant.JobAccountantPoller import JobAccountantPoller
-from WMComponent.JobArchiver.JobArchiverPoller     import JobArchiverPoller
-from WMComponent.TaskArchiver.TaskArchiverPoller   import TaskArchiverPoller
-from WMComponent.RetryManager.RetryManagerPoller   import RetryManagerPoller
-from WMComponent.ErrorHandler.ErrorHandlerPoller   import ErrorHandlerPoller
-
-
-# WMBS Objects
-from WMCore.WMBS.Job          import Job
-from WMCore.WMBS.File         import File
-from WMCore.WMBS.Fileset      import Fileset
-from WMCore.WMBS.Workflow     import Workflow
-from WMCore.WMBS.Subscription import Subscription
-
+from WMComponent.JobArchiver.JobArchiverPoller import JobArchiverPoller
+# Component imports
+from WMComponent.JobCreator.JobCreatorPoller import JobCreatorPoller
+from WMComponent.JobSubmitter.JobSubmitterPoller import JobSubmitterPoller
+from WMComponent.JobTracker.JobTrackerPoller import JobTrackerPoller
+from WMComponent.TaskArchiver.TaskArchiverPoller import TaskArchiverPoller
 # Agent imports
-from WMCore.Agent.HeartbeatAPI              import HeartbeatAPI
-from WMCore.Agent.Configuration             import Configuration
-
+from WMCore.Agent.HeartbeatAPI import HeartbeatAPI
+from WMCore.DAOFactory import DAOFactory
+from WMCore.FwkJobReport.Report import Report
 # WMCore library imports
-from WMCore.ResourceControl.ResourceControl  import ResourceControl
-from WMCore.FwkJobReport.Report              import Report
-
+from WMCore.ResourceControl.ResourceControl import ResourceControl
+from WMCore.WMBS.File import File
+from WMCore.WMBS.Fileset import Fileset
+# WMBS Objects
+from WMCore.WMBS.Job import Job
+from WMCore.WMBS.Subscription import Subscription
+from WMCore.WMBS.Workflow import Workflow
+from WMCore.WMInit import getWMBASE
 # WMSpec stuff
 from WMCore.WMSpec.Makers.TaskMaker import TaskMaker
-from WMCore_t.WMSpec_t.TestSpec     import testWorkload
+from WMQuality.Emulators import EmulatorSetup
+# Imports for testing
+from WMQuality.TestInit import TestInit
 
 
-
-def getCondorRunningJobs(user = None):
+def getCondorRunningJobs(user=None):
     """
     _getCondorRunningJobs_
 
@@ -64,7 +52,7 @@ def getCondorRunningJobs(user = None):
         user = getpass.getuser()
 
     command = ['condor_q', user]
-    pipe = Popen(command, stdout = PIPE, stderr = PIPE, shell = False)
+    pipe = Popen(command, stdout=PIPE, stderr=PIPE, shell=False)
     stdout, error = pipe.communicate()
 
     output = stdout.split('\n')[-2]
@@ -73,12 +61,13 @@ def getCondorRunningJobs(user = None):
 
     return nJobs
 
-def condorRM(user = None):
+
+def condorRM(user=None):
     # Now clean-up
     if not user:
         user = getpass.getuser()
     command = ['condor_rm', user]
-    pipe = Popen(command, stdout = PIPE, stderr = PIPE, shell = False)
+    pipe = Popen(command, stdout=PIPE, stderr=PIPE, shell=False)
     pipe.communicate()
     return
 
@@ -108,37 +97,31 @@ class WMAgentTest(unittest.TestCase):
         self.testInit = TestInit(__file__)
         self.testInit.setLogging()
         self.testInit.setDatabaseConnection()
-        self.testInit.setSchema(customModules = ["WMCore.WMBS",'WMCore.MsgService',
-                                                 'WMCore.ResourceControl', 'WMCore.ThreadPool',
-                                                 'WMCore.Agent.Database'],
-                                useDefault = False)
+        self.testInit.setSchema(customModules=["WMCore.WMBS", 'WMCore.MsgService',
+                                               'WMCore.ResourceControl', 'WMCore.ThreadPool',
+                                               'WMCore.Agent.Database'],
+                                useDefault=False)
 
         myThread = threading.currentThread()
-        self.daoFactory = DAOFactory(package = "WMCore.WMBS",
-                                     logger = myThread.logger,
-                                     dbinterface = myThread.dbi)
+        self.daoFactory = DAOFactory(package="WMCore.WMBS",
+                                     logger=myThread.logger,
+                                     dbinterface=myThread.dbi)
 
-
-
-        locationAction = self.daoFactory(classname = "Locations.New")
-        pendingSlots  = self.daoFactory(classname = "Locations.SetPendingSlots")
-
+        locationAction = self.daoFactory(classname="Locations.New")
+        pendingSlots = self.daoFactory(classname="Locations.SetPendingSlots")
 
         for site in self.sites:
-            locationAction.execute(siteName = site, pnn = 'se.%s' % (site), ceName = site)
-            pendingSlots.execute(siteName = site, pendingSlots = 1000)
+            locationAction.execute(siteName=site, pnn='se.%s' % (site), ceName=site)
+            pendingSlots.execute(siteName=site, pendingSlots=1000)
 
-
-        #Create sites in resourceControl
+        # Create sites in resourceControl
         resourceControl = ResourceControl()
         for site in self.sites:
-            resourceControl.insertSite(siteName = site, pnn = 'se.%s' % (site), ceName = site)
-            resourceControl.insertThreshold(siteName = site, taskType = 'Processing', \
-                                            maxSlots = 10000, pendingSlots = 10000)
-
+            resourceControl.insertSite(siteName=site, pnn='se.%s' % (site), ceName=site)
+            resourceControl.insertThreshold(siteName=site, taskType='Processing', \
+                                            maxSlots=10000, pendingSlots=10000)
 
         self.testDir = self.testInit.generateWorkDir()
-
 
         # Set heartbeat
         for component in self.components:
@@ -148,7 +131,6 @@ class WMAgentTest(unittest.TestCase):
         self.configFile = EmulatorSetup.setupWMAgentConfig()
 
         return
-
 
     def tearDown(self):
         """
@@ -165,20 +147,14 @@ class WMAgentTest(unittest.TestCase):
 
         return
 
-
-
-
-    def createTestWorkload(self, workloadName = 'Test', emulator = True):
+    def setupTestWorkload(self, workloadName='Test', emulator=True):
         """
-        _createTestWorkload_
 
         Creates a test workload for us to run on, hold the basic necessities.
         """
 
-
-        workload = testWorkload("TestWorkload")
+        workload = createTestWorkload("TestWorkload")
         rereco = workload.getTask("ReReco")
-
 
         taskMaker = TaskMaker(workload, os.path.join(self.testDir, 'workloadTest'))
         taskMaker.skipSubscription = True
@@ -188,9 +164,6 @@ class WMAgentTest(unittest.TestCase):
 
         return workload
 
-
-
-
     def getConfig(self):
         """
         _getConfig_
@@ -198,15 +171,12 @@ class WMAgentTest(unittest.TestCase):
         This is the global test configuration object
         """
 
-
-
         config = self.testInit.getConfiguration()
 
         config.component_("Agent")
         config.Agent.WMSpecDirectory = self.testDir
-        config.Agent.agentName       = 'testAgent'
-        config.Agent.componentName   = 'test'
-
+        config.Agent.agentName = 'testAgent'
+        config.Agent.componentName = 'test'
 
         # First the general stuff
         config.section_("General")
@@ -217,102 +187,83 @@ class WMAgentTest(unittest.TestCase):
 
         config.section_("CoreDatabase")
         config.CoreDatabase.connectUrl = os.getenv("DATABASE")
-        config.CoreDatabase.socket     = os.getenv("DBSOCK")
-
-
+        config.CoreDatabase.socket = os.getenv("DBSOCK")
 
         # JobCreator
         config.component_("JobCreator")
         config.JobCreator.namespace = 'WMComponent.JobCreator.JobCreator'
-        config.JobCreator.logLevel  = 'DEBUG'
-        config.JobCreator.maxThreads                = 1
+        config.JobCreator.logLevel = 'DEBUG'
+        config.JobCreator.maxThreads = 1
         config.JobCreator.UpdateFromResourceControl = True
-        config.JobCreator.pollInterval              = 10
-        config.JobCreator.jobCacheDir               = self.testDir
-        config.JobCreator.defaultJobType            = 'processing' #Type of jobs that we run, used for resource control
-        config.JobCreator.workerThreads             = 2
-        config.JobCreator.componentDir              = os.path.join(os.getcwd(), 'Components')
-
-
+        config.JobCreator.pollInterval = 10
+        config.JobCreator.jobCacheDir = self.testDir
+        config.JobCreator.defaultJobType = 'processing'  # Type of jobs that we run, used for resource control
+        config.JobCreator.workerThreads = 2
+        config.JobCreator.componentDir = os.path.join(os.getcwd(), 'Components')
 
         # JobSubmitter
         config.component_("JobSubmitter")
-        config.JobSubmitter.namespace     = 'WMComponent.JobSubmitter.JobSubmitter'
-        config.JobSubmitter.logLevel      = 'INFO'
-        config.JobSubmitter.maxThreads    = 1
-        config.JobSubmitter.pollInterval  = 10
-        config.JobSubmitter.pluginName    = 'CondorGlobusPlugin'
-        config.JobSubmitter.pluginDir     = 'JobSubmitter.Plugins'
-        config.JobSubmitter.submitDir     = os.path.join(self.testDir, 'submit')
-        config.JobSubmitter.submitNode    = os.getenv("HOSTNAME", 'badtest.fnal.gov')
-        config.JobSubmitter.submitScript  = os.path.join(getWMBASE(),
-                                                         'test/python/WMComponent_t/JobSubmitter_t',
-                                                         'submit.sh')
-        config.JobSubmitter.componentDir  = os.path.join(os.getcwd(), 'Components')
+        config.JobSubmitter.namespace = 'WMComponent.JobSubmitter.JobSubmitter'
+        config.JobSubmitter.logLevel = 'INFO'
+        config.JobSubmitter.maxThreads = 1
+        config.JobSubmitter.pollInterval = 10
+        config.JobSubmitter.pluginName = 'CondorGlobusPlugin'
+        config.JobSubmitter.pluginDir = 'JobSubmitter.Plugins'
+        config.JobSubmitter.submitDir = os.path.join(self.testDir, 'submit')
+        config.JobSubmitter.submitNode = os.getenv("HOSTNAME", 'badtest.fnal.gov')
+        config.JobSubmitter.submitScript = os.path.join(getWMBASE(),
+                                                        'test/python/WMComponent_t/JobSubmitter_t',
+                                                        'submit.sh')
+        config.JobSubmitter.componentDir = os.path.join(os.getcwd(), 'Components')
         config.JobSubmitter.workerThreads = 2
         config.JobSubmitter.jobsPerWorker = 200
 
-
-
-
         # JobTracker
         config.component_("JobTracker")
-        config.JobTracker.logLevel      = 'DEBUG'
-        config.JobTracker.pollInterval  = 10
-        config.JobTracker.trackerName   = 'CondorTracker'
-        config.JobTracker.pluginDir     = 'WMComponent.JobTracker.Plugins'
-        config.JobTracker.componentDir  = os.path.join(os.getcwd(), 'Components')
-        config.JobTracker.runTimeLimit  = 7776000 #Jobs expire after 90 days
+        config.JobTracker.logLevel = 'DEBUG'
+        config.JobTracker.pollInterval = 10
+        config.JobTracker.trackerName = 'CondorTracker'
+        config.JobTracker.pluginDir = 'WMComponent.JobTracker.Plugins'
+        config.JobTracker.componentDir = os.path.join(os.getcwd(), 'Components')
+        config.JobTracker.runTimeLimit = 7776000  # Jobs expire after 90 days
         config.JobTracker.idleTimeLimit = 7776000
         config.JobTracker.heldTimeLimit = 7776000
         config.JobTracker.unknTimeLimit = 7776000
-
-
 
         # JobAccountant
         config.component_("JobAccountant")
         config.JobAccountant.pollInterval = 60
         config.JobAccountant.componentDir = os.path.join(os.getcwd(), 'Components')
-        config.JobAccountant.logLevel     = 'INFO'
-
-
+        config.JobAccountant.logLevel = 'INFO'
 
         # JobArchiver
         config.component_("JobArchiver")
-        config.JobArchiver.pollInterval          = 60
-        config.JobArchiver.logLevel              = 'INFO'
-        config.JobArchiver.logDir                = os.path.join(self.testDir, 'logs')
-        config.JobArchiver.componentDir          = os.path.join(os.getcwd(), 'Components')
+        config.JobArchiver.pollInterval = 60
+        config.JobArchiver.logLevel = 'INFO'
+        config.JobArchiver.logDir = os.path.join(self.testDir, 'logs')
+        config.JobArchiver.componentDir = os.path.join(os.getcwd(), 'Components')
         config.JobArchiver.numberOfJobsToCluster = 1000
-
-
 
         # Task Archiver
         config.component_("TaskArchiver")
-        config.TaskArchiver.componentDir    = self.testInit.generateWorkDir()
+        config.TaskArchiver.componentDir = self.testInit.generateWorkDir()
         config.TaskArchiver.WorkQueueParams = {}
-        config.TaskArchiver.pollInterval    = 60
-        config.TaskArchiver.logLevel        = 'INFO'
-        config.TaskArchiver.timeOut         = 0
-
-
+        config.TaskArchiver.pollInterval = 60
+        config.TaskArchiver.logLevel = 'INFO'
+        config.TaskArchiver.timeOut = 0
 
         # JobStateMachine
         config.component_('JobStateMachine')
-        config.JobStateMachine.couchurl        = os.getenv('COUCHURL',
-                                                           'mnorman:theworst@cmssrv52.fnal.gov:5984')
-        config.JobStateMachine.couchDBName     = "mnorman_test"
-
+        config.JobStateMachine.couchurl = os.getenv('COUCHURL',
+                                                    'mnorman:theworst@cmssrv52.fnal.gov:5984')
+        config.JobStateMachine.couchDBName = "mnorman_test"
 
         # Needed, because this is a test
         os.makedirs(config.JobSubmitter.submitDir)
 
-
         return config
 
-
-
-    def createFileCollection(self, name, nSubs, nFiles, workflowURL = 'test', site = None):
+    def createFileCollection(self, name, nSubs, nFiles, workflowURL='test', site=None):
         """
         _createFileCollection_
 
@@ -321,15 +272,15 @@ class WMAgentTest(unittest.TestCase):
 
         myThread = threading.currentThread()
 
-        testWorkflow = Workflow(spec = workflowURL, owner = "mnorman",
-                                name = name, task="/TestWorkload/ReReco")
+        testWorkflow = Workflow(spec=workflowURL, owner="mnorman",
+                                name=name, task="/TestWorkload/ReReco")
         testWorkflow.create()
 
         for sub in range(nSubs):
 
             nameStr = '%s-%i' % (name, sub)
 
-            testFileset = Fileset(name = nameStr)
+            testFileset = Fileset(name=nameStr)
             testFileset.create()
 
             for f in range(nFiles):
@@ -338,46 +289,39 @@ class WMAgentTest(unittest.TestCase):
                     tmpSite = 'se.%s' % (random.choice(self.sites))
                 else:
                     tmpSite = 'se.%s' % (site)
-                testFile = File(lfn = "/lfn/%s/%i" % (nameStr, f), size = 1024, events = 10)
+                testFile = File(lfn="/lfn/%s/%i" % (nameStr, f), size=1024, events=10)
                 testFile.setLocation(tmpSite)
                 testFile.create()
                 testFileset.addFile(testFile)
 
             testFileset.commit()
-            testFileset.markOpen(isOpen = 0)
-            testSubscription = Subscription(fileset = testFileset,
-                                            workflow = testWorkflow,
-                                            type = "Processing",
-                                            split_algo = "FileBased")
+            testFileset.markOpen(isOpen=0)
+            testSubscription = Subscription(fileset=testFileset,
+                                            workflow=testWorkflow,
+                                            type="Processing",
+                                            split_algo="FileBased")
             testSubscription.create()
-
 
         return
 
-
-
-    def createReports(self, jobs, retryCount = 0):
+    def createReports(self, jobs, retryCount=0):
         """
         _createReports_
 
         Create some dummy job reports for each job
         """
 
-
         report = Report()
         report.addStep('testStep', 0)
 
         for job in jobs:
-            #reportPath = os.path.join(job['cache_dir'], 'Report.%i.pkl' % (retryCount))
+            # reportPath = os.path.join(job['cache_dir'], 'Report.%i.pkl' % (retryCount))
             reportPath = job['fwjr_path']
             if os.path.exists(reportPath):
                 os.remove(reportPath)
             report.save(reportPath)
 
-
         return
-
-
 
     def testA_StraightThrough(self):
         """
@@ -390,47 +334,40 @@ class WMAgentTest(unittest.TestCase):
         self.assertEqual(nRunning, 0, "User currently has %i running jobs.  Test will not continue" % (nRunning))
 
         myThread = threading.currentThread()
-        workload = self.createTestWorkload()
-        config   = self.getConfig()
+        workload = self.setupTestWorkload()
+        config = self.getConfig()
 
-
-        name         = 'WMAgent_Test1'
-        site         = self.sites[0]
-        nSubs        = 5
-        nFiles       = 10
+        name = 'WMAgent_Test1'
+        site = self.sites[0]
+        nSubs = 5
+        nFiles = 10
         workloadPath = os.path.join(self.testDir, 'workloadTest',
                                     'TestWorkload', 'WMSandbox',
                                     'WMWorkload.pkl')
 
         # Create a collection of files
-        self.createFileCollection(name = name, nSubs = nSubs,
-                                  nFiles = nFiles,
-                                  workflowURL = workloadPath,
-                                  site = site)
-
-
+        self.createFileCollection(name=name, nSubs=nSubs,
+                                  nFiles=nFiles,
+                                  workflowURL=workloadPath,
+                                  site=site)
 
         ############################################################
         # Test the JobCreator
 
-
         config.Agent.componentName = 'JobCreator'
-        testJobCreator = JobCreatorPoller(config = config)
+        testJobCreator = JobCreatorPoller(config=config)
 
         testJobCreator.algorithm()
         time.sleep(5)
 
-
         # Did all jobs get created?
-        getJobsAction = self.daoFactory(classname = "Jobs.GetAllJobs")
-        result = getJobsAction.execute(state = 'Created', jobType = "Processing")
-        self.assertEqual(len(result), nSubs*nFiles)
-
+        getJobsAction = self.daoFactory(classname="Jobs.GetAllJobs")
+        result = getJobsAction.execute(state='Created', jobType="Processing")
+        self.assertEqual(len(result), nSubs * nFiles)
 
         # Count database objects
         result = myThread.dbi.processData('SELECT * FROM wmbs_sub_files_acquired')[0].fetchall()
         self.assertEqual(len(result), nSubs * nFiles)
-
 
         # Find the test directory
         testDirectory = os.path.join(self.testDir, 'TestWorkload', 'ReReco')
@@ -446,64 +383,46 @@ class WMAgentTest(unittest.TestCase):
         with open(jobFile, 'rb') as f:
             job = pickle.load(f)
 
-
         self.assertEqual(job['workflow'], name)
         self.assertEqual(len(job['input_files']), 1)
         self.assertEqual(os.path.basename(job['sandbox']), 'TestWorkload-Sandbox.tar.bz2')
-
-
-
-
-
-
-
-
-
 
         ###############################################################
         # Now test the JobSubmitter
 
         config.Agent.componentName = 'JobSubmitter'
-        testJobSubmitter = JobSubmitterPoller(config = config)
-
+        testJobSubmitter = JobSubmitterPoller(config=config)
 
         testJobSubmitter.algorithm()
 
-
         # Check that jobs are in the right state
-        result = getJobsAction.execute(state = 'Created', jobType = "Processing")
+        result = getJobsAction.execute(state='Created', jobType="Processing")
         self.assertEqual(len(result), 0)
-        result = getJobsAction.execute(state = 'Executing', jobType = "Processing")
+        result = getJobsAction.execute(state='Executing', jobType="Processing")
         self.assertEqual(len(result), nSubs * nFiles)
 
-
-
         # Check assigned locations
-        getLocationAction = self.daoFactory(classname = "Jobs.GetLocation")
+        getLocationAction = self.daoFactory(classname="Jobs.GetLocation")
         for id in result:
-            loc = getLocationAction.execute(jobid = id)
+            loc = getLocationAction.execute(jobid=id)
             self.assertEqual(loc, [[site]])
-
 
         # Check to make sure we have running jobs
         nRunning = getCondorRunningJobs()
         self.assertEqual(nRunning, nFiles * nSubs)
 
-
         #################################################################
         # Now the JobTracker
 
-
         config.Agent.componentName = 'JobTracker'
-        testJobTracker = JobTrackerPoller(config = config)
+        testJobTracker = JobTrackerPoller(config=config)
         testJobTracker.setup()
 
         testJobTracker.algorithm()
 
         # Running the algo without removing the jobs should do nothing
-        result = getJobsAction.execute(state = 'Executing', jobType = "Processing")
+        result = getJobsAction.execute(state='Executing', jobType="Processing")
         self.assertEqual(len(result), nSubs * nFiles)
-
 
         condorRM()
         time.sleep(1)
@@ -512,120 +431,83 @@ class WMAgentTest(unittest.TestCase):
         nRunning = getCondorRunningJobs()
         self.assertEqual(nRunning, 0)
 
-
         testJobTracker.algorithm()
         time.sleep(5)
 
         # Running the algo without removing the jobs should do nothing
-        result = getJobsAction.execute(state = 'Executing', jobType = "Processing")
+        result = getJobsAction.execute(state='Executing', jobType="Processing")
         self.assertEqual(len(result), 0)
-        result = getJobsAction.execute(state = 'Complete', jobType = "Processing")
+        result = getJobsAction.execute(state='Complete', jobType="Processing")
         self.assertEqual(len(result), nSubs * nFiles)
-
-
-
 
         #################################################################
         # Now the JobAccountant
 
         # First you need to load all jobs
 
-
-        self.getFWJRAction = self.daoFactory(classname = "Jobs.GetFWJRByState")
-        completeJobs       = self.getFWJRAction.execute(state = "complete")
-
+        self.getFWJRAction = self.daoFactory(classname="Jobs.GetFWJRByState")
+        completeJobs = self.getFWJRAction.execute(state="complete")
 
         # Create reports for all jobs
-        self.createReports(jobs = completeJobs, retryCount = 0)
-
-
-
-
-
+        self.createReports(jobs=completeJobs, retryCount=0)
 
         config.Agent.componentName = 'JobAccountant'
-        testJobAccountant = JobAccountantPoller(config = config)
+        testJobAccountant = JobAccountantPoller(config=config)
         testJobAccountant.setup()
-
 
         # It should do something with the jobs
         testJobAccountant.algorithm()
 
-
         # All the jobs should be done now
-        result = getJobsAction.execute(state = 'Complete', jobType = "Processing")
+        result = getJobsAction.execute(state='Complete', jobType="Processing")
         self.assertEqual(len(result), 0)
-        result = getJobsAction.execute(state = 'Success', jobType = "Processing")
+        result = getJobsAction.execute(state='Success', jobType="Processing")
         self.assertEqual(len(result), nSubs * nFiles)
-
-
 
         #######################################################################
         # Now the JobArchiver
 
-
         config.Agent.componentName = 'JobArchiver'
-        testJobArchiver = JobArchiverPoller(config = config)
-
+        testJobArchiver = JobArchiverPoller(config=config)
 
         testJobArchiver.algorithm()
 
         # All the jobs should be cleaned up
-        result = getJobsAction.execute(state = 'Success', jobType = "Processing")
+        result = getJobsAction.execute(state='Success', jobType="Processing")
         self.assertEqual(len(result), 0)
-        result = getJobsAction.execute(state = 'Cleanout', jobType = "Processing")
+        result = getJobsAction.execute(state='Cleanout', jobType="Processing")
         self.assertEqual(len(result), nSubs * nFiles)
-
 
         logDir = os.path.join(self.testDir, 'logs')
 
         for job in completeJobs:
             self.assertFalse(os.path.exists(job['fwjr_path']))
             jobFolder = 'JobCluster_%i' \
-                    % (int(job['id']/config.JobArchiver.numberOfJobsToCluster))
-            jobPath = os.path.join(logDir, jobFolder, 'Job_%i.tar' %(job['id']))
+                        % (int(job['id'] / config.JobArchiver.numberOfJobsToCluster))
+            jobPath = os.path.join(logDir, jobFolder, 'Job_%i.tar' % (job['id']))
             self.assertTrue(os.path.isfile(jobPath))
             self.assertTrue(os.path.getsize(jobPath) > 0)
-
-
-
 
         ###########################################################################
         # Now the TaskAchiver
 
-
         config.Agent.componentName = 'TaskArchiver'
-        testTaskArchiver = TaskArchiverPoller(config = config)
-
+        testTaskArchiver = TaskArchiverPoller(config=config)
 
         testTaskArchiver.algorithm()
 
-
-        result = getJobsAction.execute(state = 'Cleanout', jobType = "Processing")
+        result = getJobsAction.execute(state='Cleanout', jobType="Processing")
         self.assertEqual(len(result), 0)
 
-
         for jdict in completeJobs:
-            job = Job(id = jdict['id'])
+            job = Job(id=jdict['id'])
             self.assertFalse(job.exists())
-
-
-
-
 
         if os.path.isdir('testDir'):
             shutil.rmtree('testDir')
-        shutil.copytree('%s' %self.testDir, os.path.join(os.getcwd(), 'testDir'))
-
-
-
+        shutil.copytree('%s' % self.testDir, os.path.join(os.getcwd(), 'testDir'))
 
         return
-
-
-
-
-
 
 
 if __name__ == "__main__":

--- a/test/python/WMCore_t/WMSpec_t/TestSpec.py
+++ b/test/python/WMCore_t/WMSpec_t/TestSpec.py
@@ -5,10 +5,8 @@ _TestSpec_
 Test spec with known output modules used for testing.
 """
 
-
-
-
 from WMCore.WMSpec.WMWorkload import newWorkload
+
 
 class TestWorkloadFactory(object):
     """
@@ -16,6 +14,7 @@ class TestWorkloadFactory(object):
 
     Stamp out test workfloads.
     """
+
     def createWorkload(self):
         """
         _createWorkload_
@@ -24,7 +23,7 @@ class TestWorkloadFactory(object):
         """
         workload = newWorkload("TestWorkload")
         workload.setOwner("sfoulkes@fnal.gov")
-        workload.setStartPolicy("DatasetBlock", SliceType = "NumberOfFiles", SliceSize = 1)
+        workload.setStartPolicy("DatasetBlock", SliceType="NumberOfFiles", SliceSize=1)
         workload.setEndPolicy("SingleShot")
         workload.setAcquisitionEra("WMAgentCommissioning10")
         return workload
@@ -56,21 +55,21 @@ class TestWorkloadFactory(object):
 
         procTaskCmsswHelper = procTaskCmssw.getTypeHelper()
         procTaskCmsswHelper.setGlobalTag("TestGlobalTag::All")
-        procTaskCmsswHelper.cmsswSetup("CMSSW_3_5_8_patch3", softwareEnvironment = "",
-                                       scramArch = "slc5_amd64_gcc434")
+        procTaskCmsswHelper.cmsswSetup("CMSSW_3_5_8_patch3", softwareEnvironment="",
+                                       scramArch="slc5_amd64_gcc434")
 
         procTaskCmsswHelper.setDataProcessingConfig("cosmics", "PromptReco")
 
         if self.emulation:
             procTaskStageOutHelper = procTaskStageOut.getTypeHelper()
-            procTaskLogArchHelper  = procTaskLogArch.getTypeHelper()
+            procTaskLogArchHelper = procTaskLogArch.getTypeHelper()
             procTaskCmsswHelper.data.emulator.emulatorName = "CMSSW"
             procTaskStageOutHelper.data.emulator.emulatorName = "StageOut"
             procTaskLogArchHelper.data.emulator.emulatorName = "LogArchive"
 
         return procTask
 
-    def addLogCollectTask(self, parentTask, taskName = "LogCollect"):
+    def addLogCollectTask(self, parentTask, taskName="LogCollect"):
         """
         _addLogCollecTask_
 
@@ -81,11 +80,11 @@ class TestWorkloadFactory(object):
         logCollectStep = logCollectTask.makeStep("logCollect1")
         logCollectStep.setStepType("LogCollect")
         logCollectTask.applyTemplates()
-        logCollectTask.setSplittingAlgorithm("MinFileBased", files_per_job = 500)
+        logCollectTask.setSplittingAlgorithm("MinFileBased", files_per_job=500)
         logCollectTask.setTaskType("LogCollect")
 
         parentTaskLogArch = parentTask.getStep("logArch1")
-        logCollectTask.setInputReference(parentTaskLogArch, outputModule = "logArchive")
+        logCollectTask.setInputReference(parentTaskLogArch, outputModule="logArchive")
         return
 
     def addOutputModule(self, parentTask, outputModuleName, dataTier, filterName):
@@ -100,26 +99,26 @@ class TestWorkloadFactory(object):
         cmsswStep = parentTask.getStep("cmsRun1")
         cmsswStepHelper = cmsswStep.getTypeHelper()
         cmsswStepHelper.addOutputModule(outputModuleName,
-                                        primaryDataset = "MinimumBias",
-                                        processedDataset = "Commissioning10-v4",
-                                        dataTier = "RAW",
-                                        lfnBase = "/store/temp/WMAgent/unmerged",
-                                        mergedLFNBase = "/store/temp/WMAgent/merged")
+                                        primaryDataset="MinimumBias",
+                                        processedDataset="Commissioning10-v4",
+                                        dataTier="RAW",
+                                        lfnBase="/store/temp/WMAgent/unmerged",
+                                        mergedLFNBase="/store/temp/WMAgent/merged")
         cmsswStepHelper.addOutputModule(outputModuleName,
-                                        primaryDataset = "MinimumBias",
-                                        processedDataset = "Commissioning10-v4",
-                                        dataTier = "RECO",
-                                        lfnBase = "/store/temp/WMAgent/unmerged",
-                                        mergedLFNBase = "/store/temp/WMAgent/merged")
+                                        primaryDataset="MinimumBias",
+                                        processedDataset="Commissioning10-v4",
+                                        dataTier="RECO",
+                                        lfnBase="/store/temp/WMAgent/unmerged",
+                                        mergedLFNBase="/store/temp/WMAgent/merged")
         cmsswStepHelper.addOutputModule(outputModuleName,
-                                        primaryDataset = "MinimumBias",
-                                        processedDataset = "Commissioning10-v4",
-                                        dataTier = "DQM",
-                                        lfnBase = "/store/temp/WMAgent/unmerged",
-                                        mergedLFNBase = "/store/temp/WMAgent/merged")
+                                        primaryDataset="MinimumBias",
+                                        processedDataset="Commissioning10-v4",
+                                        dataTier="DQM",
+                                        lfnBase="/store/temp/WMAgent/unmerged",
+                                        mergedLFNBase="/store/temp/WMAgent/merged")
         return
 
-    def __call__(self, emulation = False):
+    def __call__(self, emulation=False):
         """
         _call_
 
@@ -136,14 +135,14 @@ class TestWorkloadFactory(object):
         self.addOutputModule(procTask, "TestOutputModule", "RECO", "SomeFilter")
         return workload
 
-def testWorkload(emulation = False):
-    """
-    _testWorkflow_
 
+def createTestWorkload(emulation=False):
+    """
     Instantiate the TestWorkloadFactory and create a workload.
     """
     myTestWorkloadFactory = TestWorkloadFactory()
-    return myTestWorkloadFactory(emulation = emulation)
+    return myTestWorkloadFactory(emulation=emulation)
+
 
 if __name__ == "__main__":
-    testWorkload()
+    createTestWorkload()


### PR DESCRIPTION
Fixes #11733 

#### Status
Ready

#### Description
This pull request provides the foundation of a new component called `WorkflowUpdater`. Further details are:
* component connects to the same Rucio instance as the one used in WorkQueueManager, using the the usual WMAgent account (either wma_test or wma_prod) account
* component talks to MSPileup to retrieve a snapshot of the pileups in the system
* component talks to Rucio to retrieve a list of blocks for a given container name
* it fetches a list of active workflows in the agent, based on wmbs_subscriptions and matching only Production/Processing jobs.
* load the active workflows spec to see which one is requesting pileup or not
* to be implemented: update the workflow sandbox with the relevant pileup information

In addition, there are deployment changes and it also requires changes to the secrets file with new urls.

Extra, tell git to ignore `.vscode` directory/files in the repository (for VSCode users).

NOTE that this component is expected to be functional, but still missing its real functionality as other tickets still need to be addressed.

#### Is it backward compatible (if not, which system it affects?)
NO, new component!

#### Related PRs
None

#### External dependencies / deployment changes
It has 3 dependencies so far:
1. A new secrets parameter called `MSPILEUP_URL`
2. Depends on this deployment update: https://github.com/dmwm/deployment/pull/1293
3. And the new pileup data structure using `customName`, provided in: https://github.com/dmwm/WMCore/pull/11765