### PR TITLE
Add transition attribute to MSPIleup document

### DIFF
--- a/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupData_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupData_t.py
@@ -81,7 +81,7 @@ class MSPileupTest(unittest.TestCase):
         pileupSize = 1
         ruleIds = []
         campaigns = []
-        containerFraction = 0.0
+        containerFraction = 1.0
         replicationGrouping = "ALL"
 
         pdict = {
@@ -100,6 +100,7 @@ class MSPileupTest(unittest.TestCase):
             'active': True,
             'pileupSize': pileupSize,
             'customName': '',
+            'transition': [],
             'ruleIds': ruleIds}
 
         out = self.mgr.createPileup(pdict, self.validRSEs)

--- a/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupMonitoring_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupMonitoring_t.py
@@ -25,7 +25,7 @@ class MSPileupMonitoringTest(unittest.TestCase):
             'currentRSEs': rses,
             'fullReplicas': 1,
             'campaigns': campaigns,
-            'containerFraction': 0.0,
+            'containerFraction': 1.0,
             'replicationGrouping': "ALL",
             'active': True,
             'pileupSize': 0,

--- a/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupObj_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupObj_t.py
@@ -5,6 +5,7 @@ Description: Unit tests for MicorService/MSPileup/DataStructs/MSPileupObj.py mod
 """
 
 # system modules
+import time
 import unittest
 
 # WMCore modules
@@ -35,11 +36,12 @@ class MSPileupObjTest(unittest.TestCase):
             'currentRSEs': expectedRSEs,
             'fullReplicas': fullReplicas,
             'campaigns': campaigns,
-            'containerFraction': 0.0,
+            'containerFraction': 1.0,
             'replicationGrouping': "ALL",
             'active': True,
             'pileupSize': 0,
             'customName': '',
+            'transition': [],
             'ruleIds': []}
         obj = MSPileupObj(data, validRSEs=expectedRSEs)
         for key in ['insertTime', 'lastUpdateTime', 'activatedOn', 'deactivatedOn']:
@@ -77,6 +79,69 @@ class MSPileupObjTest(unittest.TestCase):
         except Exception as exp:
             self.logger.warning("expected exception %s", str(exp))
 
+    def testTransitionRecord(self):
+        """
+        Unit test for transition record in MSPileupObj data
+        """
+        expectedRSEs = ['rse1', 'rse2']
+        fullReplicas = 0
+        campaigns = ['c1', 'c2']
+        data = {
+            'pileupName': '/lksjdfkls/lkjaslkdjlas/PREFIX',
+            'pileupType': 'classic',
+            'expectedRSEs': expectedRSEs,
+            'currentRSEs': expectedRSEs,
+            'fullReplicas': fullReplicas,
+            'campaigns': campaigns,
+            'containerFraction': 1.0,
+            'replicationGrouping': "ALL",
+            'active': True,
+            'pileupSize': 0,
+            'customName': '',
+            'transition': [{'bla': 1}],
+            'ruleIds': []}
+        # test incorrect transition record
+        try:
+            MSPileupObj(data, validRSEs=expectedRSEs)
+            self.assertIsNone(1, msg="MSPileupObj should not be created")
+        except Exception as exp:
+            self.logger.warning("expected exception %s", str(exp))
+
+        # test incorrect value in transition record
+        trec = {'DN': 'bla', 'containerFraction': 0, 'customDID': 'customDID', 'updateTime': int(time.time())}
+        data.update({'transition': [trec]})
+        try:
+            MSPileupObj(data, validRSEs=expectedRSEs)
+            self.assertIsNone(1, msg="MSPileupObj should not be created")
+        except Exception as exp:
+            self.logger.warning("expected exception %s", str(exp))
+
+        # test incorrect value in transition record
+        trec = {'DN': 123, 'containerFraction': 0.1, 'customDID': 'customDID', 'updateTime': int(time.time())}
+        data.update({'transition': [trec]})
+        try:
+            MSPileupObj(data, validRSEs=expectedRSEs)
+            self.assertIsNone(1, msg="MSPileupObj should not be created")
+        except Exception as exp:
+            self.logger.warning("expected exception %s", str(exp))
+
+        # test incorrect value in transition record
+        trec = {'DN': 'dn', 'containerFraction': 0.1, 'customDID': 'customDID', 'updateTime': 123}
+        data.update({'transition': [trec]})
+        try:
+            MSPileupObj(data, validRSEs=expectedRSEs)
+            self.assertIsNone(1, msg="MSPileupObj should not be created")
+        except Exception as exp:
+            self.logger.warning("expected exception %s", str(exp))
+
+        # test correct record
+        trec = {'DN': 'bla', 'containerFraction': 0.5, 'customDID': 'customDID', 'updateTime': int(time.time())}
+        data.update({'transition': [trec]})
+        try:
+            MSPileupObj(data, validRSEs=expectedRSEs)
+        except Exception as exp:
+            self.logger.warning("expected exception %s", str(exp))
+
     def testWrongMSPileupObj(self):
         """
         Unit test for incorrect MSPileupObj data
@@ -87,7 +152,7 @@ class MSPileupObjTest(unittest.TestCase):
             'expectedRSEs': 'expectedRSEs',
             'fullReplicas': 'fullReplicas',
             'campaigns': 'campaigns',
-            'containerFraction': 0,
+            'containerFraction': 1,
             'replicationGrouping': "",
             'active': True,
             'pileupSize': 0,

--- a/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupTasks_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupTasks_t.py
@@ -139,7 +139,7 @@ class MSPileupTasksTest(EmulatedUnitTestCase):
             'currentRSEs': self.validRSEs,
             'fullReplicas': fullReplicas,
             'campaigns': campaigns,
-            'containerFraction': 0.0,
+            'containerFraction': 1.0,
             'replicationGrouping': "ALL",
             'active': True,
             'pileupSize': 0,
@@ -258,7 +258,7 @@ class MSPileupTasksTest(EmulatedUnitTestCase):
         # e.g. /Cosmics/ComissioningHI-PromptReco-v1/RECO dataset
         pname = '/Cosmics/ComissioningHI-PromptReco-v1/RECO'
         data = dict(self.data)
-        data['pileupName'] = self.pname+'CUSTOM'
+        data['pileupName'] = self.pname + 'CUSTOM'
         data['customName'] = pname
         self.mgr.createPileup(data, self.validRSEs)
 

--- a/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileup_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileup_t.py
@@ -51,7 +51,7 @@ class MSPileupTest(EmulatedUnitTestCase):
             'currentRSEs': expectedRSEs,
             'fullReplicas': fullReplicas,
             'campaigns': campaigns,
-            'containerFraction': 0.0,
+            'containerFraction': 1.0,
             'replicationGrouping': "ALL",
             'active': True,
             'pileupSize': 0,


### PR DESCRIPTION
Fixes #11801 

#### Status
ready

#### Description
1. Provide new `transition` attribute to MSPileup document
2. Adjusted validation of `contrainerFraction` to be in `(0,1]` range

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs

#### External dependencies / deployment changes
We will need to update MSPileup documents in testbed cluster