### PR TITLE
Put jobs from older workflows first for JobSubmitter

### DIFF
--- a/src/python/WMCore/WMBS/MySQL/Jobs/ListForSubmitter.py
+++ b/src/python/WMCore/WMBS/MySQL/Jobs/ListForSubmitter.py
@@ -9,6 +9,12 @@ from WMCore.Database.DBFormatter import DBFormatter
 
 
 class ListForSubmitter(DBFormatter):
+    """
+    _ListForSubmitter_
+
+    List the available jobs in WMBS order by descending subscription priority,
+    descending workflow priority, and ascending workflow ID.
+    """
     sql = """SELECT wmbs_job.id AS id,
                     wmbs_job.name AS name,
                     wmbs_job.cache_dir AS cache_dir,
@@ -34,7 +40,7 @@ class ListForSubmitter(DBFormatter):
              ORDER BY
                wmbs_sub_types.priority DESC,
                wmbs_workflow.priority DESC,
-               wmbs_workflow.id DESC"""
+               wmbs_workflow.id ASC"""
 
     limit_sql = " limit %d"
 

--- a/src/python/WMCore/WMBS/Oracle/Jobs/ListForSubmitter.py
+++ b/src/python/WMCore/WMBS/Oracle/Jobs/ListForSubmitter.py
@@ -35,6 +35,6 @@ class ListForSubmitter(MySQLListForSubmitter):
                ORDER BY
                  wmbs_sub_types.priority DESC,
                  wmbs_workflow.priority DESC,
-                 wmbs_workflow.id DESC)"""
+                 wmbs_workflow.id ASC)"""
 
     limit_sql = " WHERE ROWNUM <= %d"


### PR DESCRIPTION
Fixes #11772 

#### Status
ready

#### Description
Changes `ListForSubmitter` query to return jobs from older workflows first, both in MySQL and ORACLE DBs

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs

#### External dependencies / deployment changes
