### PR TITLE
Add partial pileup placement logic

### DIFF
--- a/src/python/WMCore/MicroService/MSPileup/DataStructs/MSPileupObj.py
+++ b/src/python/WMCore/MicroService/MSPileup/DataStructs/MSPileupObj.py
@@ -30,7 +30,6 @@ The data flow should be done via list of objects, e.g.
 
 # system modules
 import json
-import time
 
 # WMCore modules
 from Utils.Timers import gmtimeSeconds
@@ -114,6 +113,11 @@ class MSPileupObj():
                 self.logger.error(msg)
                 return False, msg
             if key == 'pileupName' or (key == 'customName' and val != ''):
+                if key == 'customName':
+                    # we may have additional suffix which we should strip off
+                    # before validation, see customDID definition in
+                    # WMCore/MicroService/MSPileup/MSPileupData.py
+                    val = val.split('-V')[:-1][0]
                 try:
                     dataset(val)
                 except AssertionError:
@@ -161,7 +165,7 @@ class MSPileupObj():
                     self.logger.error("key '%s' is not present in transition record %s", key, record)
                     return False
                 val = record[key]
-                if key == 'updateTime' and (val < pdoc['insertTime'] or val > time.time()):
+                if key == 'updateTime' and (val < pdoc['insertTime'] or val > gmtimeSeconds()):
                     # the update time should be in range between pileup insert time and now
                     self.logger.error("wrong value '%s' for updateTime in transition record %s", val, record)
                     return False

--- a/src/python/WMCore/MicroService/MSPileup/MSPileup.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileup.py
@@ -113,17 +113,8 @@ class MSPileup(MSCore):
         :return: results of MSPileup data layer (list of dicts)
         """
         self.authMgr.authorizeApiAccess('ms-pileup', 'update')
-        # fetch pileup doc and update it
-        records = self.queryDatabase({'pileupName': pdict['pileupName']})
-        if len(records) != 1:
-            err = MSPileupNoKeyFoundError(pdict, f'No document found for {pdict} query')
-            return [err.error()]
-        doc = records[0]
-
-        # update pilup data
-        doc.update(pdict)
         rseNames = self.rucio.evaluateRSEExpression(self.diskRSEExpr, useCache=True)
-        return self.dataMgr.updatePileup(doc, rseNames, validate=True, userDN=self.userDN())
+        return self.dataMgr.updatePileup(pdict, rseNames, validate=True, userDN=self.userDN())
 
     def deletePileup(self, spec):
         """

--- a/src/python/WMCore/MicroService/MSPileup/MSPileupData.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupData.py
@@ -185,7 +185,6 @@ class MSPileupData():
             self.logger.error(err)
             return [err.error()]
 
-
         # it is replaced with partial pileup placement one, see
         # https://gist.github.com/amaltaro/b4f9bafc0b58c10092a0735c635538b5
 
@@ -232,14 +231,12 @@ class MSPileupData():
         dbDoc.update(doc)
         if validate:
             try:
-                # when input doc spec is partial pileup we do not have rseList
+                # NOTE: MSPileupObj calls validate in its ctor with provided validRSEs
+                # therefore, for partial pileup we take expectedRSEs for validation
+                # while for generic update case we use rseList passed to this API as is
                 if partialPileupSpec:
                     rseList = dbDoc['expectedRSEs']
-                    self.logger.info("#### partialPileupSpec obj")
-                    obj = MSPileupObj(dbDoc, validRSEs=rseList)
-                else:
-                    self.logger.info("#### full pileup obj")
-                    obj = MSPileupObj(dbDoc, validRSEs=rseList)
+                obj = MSPileupObj(dbDoc, validRSEs=rseList)
                 doc = obj.getPileupData()
             except Exception as exp:
                 msg = f"Failed to update MSPileupObj, {exp}"

--- a/src/python/WMCore/MicroService/MSPileup/MSPileupError.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupError.py
@@ -19,6 +19,7 @@ MSPILEUP_NOTFOUND_ERROR = 4
 MSPILEUP_DATABASE_ERROR = 5
 MSPILEUP_UNIQUE_ERROR = 6
 MSPILEUP_SCHEMA_ERROR = 7
+MSPILEUP_FRACTION_ERROR = 8
 
 
 class MSPileupError(WMException):
@@ -86,6 +87,16 @@ class MSPileupSchemaError(MSPileupError):
         super().__init__(data, msg)
         msg = self.msg if self.msg else "schema error"
         self.assign(msg=msg, code=MSPILEUP_SCHEMA_ERROR)
+
+
+class MSPileupFractionError(MSPileupError):
+    """
+    Schema MSPileup exception
+    """
+    def __init__(self, data, msg=""):
+        super().__init__(data, msg)
+        msg = self.msg if self.msg else "container fraction error"
+        self.assign(msg=msg, code=MSPILEUP_FRACTION_ERROR)
 
 
 class MSPileupInvalidDataError(MSPileupError):

--- a/src/python/WMCore/MicroService/MSPileup/MSPileupTaskManager.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupTaskManager.py
@@ -69,6 +69,8 @@ class MSPileupTaskManager(MSCore):
             self.mgr.activeTask(marginSpace=self.marginSpace)
         with CodeTimer("### inactiveTask", logger=self.logger):
             self.mgr.inactiveTask()
+        with CodeTimer("### partialPileupTask", logger=self.logger):
+            self.mgr.partialPileupTask()
         with CodeTimer("### cleanupTask", logger=self.logger):
             self.mgr.cleanupTask(self.cleanupDaysThreshold)
         with CodeTimer("### cmsMonitTask", logger=self.logger):

--- a/src/python/WMCore/MicroService/MSPileup/MSPileupTasks.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupTasks.py
@@ -177,9 +177,8 @@ class MSPileupTasks():
             # c) depending on increasing/decreasing, we will likely have to call this attachment twice.
             #    i) for blocks that we know their current location/RSE;
             #    ii) for blocks that are potentially nowhere on Disk (hence, rse=None).
+            self.rucioClient.attachDIDs(None, doc['customName'], portion, scope=self.customRucioScope)
             for rse in doc['currentRSEs']:
-                self.rucioClient.attachDIDs(rse, doc['customName'], portion, scope=self.customRucioScope)
-
                 # create new rule for custom DID using pileup document rse
                 newRules += self.rucioClient.createReplicationRule(doc['customName'], rse)
 

--- a/src/python/WMCore/MicroService/MSPileup/MSPileupTasks.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupTasks.py
@@ -135,7 +135,8 @@ class MSPileupTasks():
         customBlocks = self.rucioClient.getBlocksInContainer(cname)
         portion = math.ceil(fraction * len(totalBlocks))
         blockList = customBlocks + [b for b in totalBlocks if b not in customBlocks]
-        self.logger.info("increase scenario: use %d blocks out of %d custom blocks from %s and %d from %s", len(blockList), len(customBlocks), cname, len(totalBlocks), pname)
+        self.logger.info("increase scenario: use %d blocks out of %d custom blocks from %s and %d from %s",
+                         len(blockList), len(customBlocks), cname, len(totalBlocks), pname)
         return blockList[:portion]
 
     def getDecreasingBlocks(self, doc, fraction):
@@ -153,10 +154,12 @@ class MSPileupTasks():
         totalBlocks = self.rucioClient.getBlocksInContainer(pname)
         portion = math.ceil(fraction * len(totalBlocks))
         if cname == '':
-            self.logger.info("decrease scenario: use %d blocks out of pileup %s with %d blocks", len(totalBlocks[:portion]), pname, len(totalBlocks))
+            self.logger.info("decrease scenario: use %d blocks out of pileup %s with %d blocks",
+                             len(totalBlocks[:portion]), pname, len(totalBlocks))
             return totalBlocks[:portion]
         customBlocks = self.rucioClient.getBlocksInContainer(cname)
-        self.logger.info("decrease scenario: use %d blocks out of custom container %s", len(customBlocks[:portion]), cname)
+        self.logger.info("decrease scenario: use %d blocks out of custom container %s",
+                         len(customBlocks[:portion]), cname)
         return customBlocks[:portion]
 
     def partialPileupTask(self):
@@ -199,7 +202,6 @@ class MSPileupTasks():
 
             # usage of block names defined in this logic:
             # https://github.com/dmwm/WMCore/pull/11807#pullrequestreview-1786778783
-            pname = doc['pileupName']
             customBlocks = self.getPileupBlocks(doc, previousFraction, fraction)
 
             # create new container DID in Rucio for our custom name
@@ -213,7 +215,8 @@ class MSPileupTasks():
                 # create new rule for custom DID using pileup document rse
                 newRules += self.rucioClient.createReplicationRule(doc['customName'], rse)
 
-            self.logger.info("Custom pileup: %s has the following new rules created: %s for RSEs: %s", doc['customName'], newRules)
+            self.logger.info("Custom pileup: %s has the following new rules created: %s for RSEs: %s",
+                             doc['customName'], newRules, doc['expectedRSEs'])
             # set expiration date (to be 24h) for already existing ruleIds from pileup document
             for rid in doc['ruleIds']:
                 # set expiration date to be 24h ahead of right now

--- a/src/python/WMCore/Services/Rucio/Rucio.py
+++ b/src/python/WMCore/Services/Rucio/Rucio.py
@@ -221,7 +221,7 @@ class Rucio(object):
                 for item in self.cli.list_dataset_replicas(kwargs["scope"], did["name"], deep=kwargs['deep']):
                     resultDict.setdefault(item['name'], [])
                     if item['state'].upper() == 'AVAILABLE':
-                        resultDict[item['name']].append(item['rse'])            
+                        resultDict[item['name']].append(item['rse'])
         else:
             for item in self.cli.list_dataset_replicas_bulk(inputDids):
                 resultDict.setdefault(item['name'], [])
@@ -244,7 +244,7 @@ class Rucio(object):
         See here for documentation of the upstream Rucio API: https://rucio.readthedocs.io/en/latest/api/rse.html
         :param site: a Rucio RSE, i.e. a site name in standard CMS format like 'T1_UK_RAL_Disk' or  'T2_CH_CERN'
         :param lfns: one LFN or a list of LFN's, does not need to correspond to actual files and could be a top level directory
-                      like ['/store/user/rucio/jdoe','/store/data',...] or the simple '/store/data' 
+                      like ['/store/user/rucio/jdoe','/store/data',...] or the simple '/store/data'
         :param protocol: If the RSE supports multiple access protocols, a preferred protocol can be selected via this,
                          otherwise the default one for the site will be selected. Example: 'gsiftp' or 'davs'
                          this is what is called "scheme" in the RUCIO API (we think protocol is more clear)
@@ -663,6 +663,22 @@ class Rucio(object):
             self.logger.error("Exception getting rule id: %s. Error: %s", ruleId, str(ex))
         return res
 
+    def updateRule(self, ruleId, opts):
+        """
+        Update rule information for a given rule id
+        :param ruleId: string with the rule id
+        :param opts: dictionary, rule id options passed to Rucio
+        :return: boolean status of update call
+        """
+        status = None
+        try:
+            status = self.cli.update_replication_rule(ruleId, opts)
+        except RuleNotFound:
+            self.logger.error("Cannot find any information for rule id: %s", ruleId)
+        except Exception as ex:
+            self.logger.error("Exception updating rule id: %s. Error: %s", ruleId, str(ex))
+        return status
+
     def deleteRule(self, ruleId, purgeReplicas=False):
         """
         _deleteRule_
@@ -757,7 +773,6 @@ class Rucio(object):
             msg = "Error retrieving attributes for RSE: {}. Error: {}".format(rse, str(exc))
             raise WMRucioException(msg)
         return attrs.get('requires_approval', False)
-
 
     def isContainer(self, didName, scope='cms'):
         """
@@ -925,17 +940,17 @@ class Rucio(object):
         rsesByBlocks = {}
         for block in blockNames:
             rsesByBlocks.setdefault(block, set())
-            ### FIXME: feature request made to the Rucio team to support bulk operations:
-            ### https://github.com/rucio/rucio/issues/3982
+            # FIXME: feature request made to the Rucio team to support bulk operations:
+            # https://github.com/rucio/rucio/issues/3982
             for blockLock in self.cli.get_dataset_locks(kwargs['scope'], block):
                 if not returnTape and isTapeRSE(blockLock['rse']):
                     continue
                 if blockLock['state'] == 'OK' and blockLock['rule_id'] in multiRSERules:
                     rsesByBlocks[block].add(blockLock['rse'])
 
-        ### The question now is:
-        ###   1. do we want to have a full copy of the container in the same RSEs (grouping=A)
-        ###   2. or we want all locations holding at least one block of the container (grouping=D)
+        # The question now is:
+        #   1. do we want to have a full copy of the container in the same RSEs (grouping=A)
+        #   2. or we want all locations holding at least one block of the container (grouping=D)
         if kwargs.get('grouping') == 'A':
             firstRun = True
             for _block, rses in viewitems(rsesByBlocks):
@@ -1219,7 +1234,7 @@ class Rucio(object):
         else:
             finalRSEs = list(finalRSEs)
         self.logger.info("Container: %s with block-based location at: %s, and final location: %s",
-                          kwargs['name'], commonBlockRSEs, finalRSEs)
+                         kwargs['name'], commonBlockRSEs, finalRSEs)
         return finalRSEs
 
     def getRSEUsage(self, rse):

--- a/src/python/WMQuality/Emulators/RucioClient/MockRucioApi.py
+++ b/src/python/WMQuality/Emulators/RucioClient/MockRucioApi.py
@@ -140,12 +140,12 @@ class MockRucioApi(object):
         logging.info("%s attachDID rse=%s, suportDID=%s, portion=%s, scope=%s", cname, rse, superDID, portion, scope)
         return True
 
-    def createReplicationRules(self, portion, rseExpression):
+    def createReplicationRule(self, portion, rseExpression):
         """
-        Emulate createReplicationRules Rucio API
+        Emulate createReplicationRule Rucio API
         """
         cname = self.__class__.__name__
-        logging.info("%s createReplicationRules portion=%s, rseExpression=%s", cname, portion, rseExpression)
+        logging.info("%s createReplicationRule portion=%s, rseExpression=%s", cname, portion, rseExpression)
         return [rseExpression]
 
     def updateRule(self, rid, opts):

--- a/src/python/WMQuality/Emulators/RucioClient/MockRucioApi.py
+++ b/src/python/WMQuality/Emulators/RucioClient/MockRucioApi.py
@@ -106,6 +106,56 @@ class MockRucioApi(object):
 
         return genericLookup
 
+    def getBlocksInContainer(self, container, scope='cms'):
+        """
+        Returns list of block names for given container
+        """
+        cname = self.__class__.__name__
+        blockNames = [container + '#123', container + '#456']
+        logging.info("%s getBlocksInContainer %s", cname, blockNames)
+        return blockNames
+
+    def listDataRules(self, name, **kwargs):
+        """
+        Emulate listDataRules Rucio API
+        :return: list of dictionary records
+        """
+        cname = self.__class__.__name__
+        logging.info("%s listDataRules name=%s kwargs=%s", cname, name, kwargs)
+        return [{'rse_expression': 'T1_XX_ABC', 'id': 123, 'state': 'OK'}]
+
+    def createContainer(self, name, scope='cms', **kwargs):
+        """
+        Create a CMS dataset (Rucio container) in a given scope.
+        """
+        cname = self.__class__.__name__
+        logging.info("%s createContainer for name=%s scope=%s", cname, name, scope)
+        return True
+
+    def attachDIDs(self, rse, superDID, portion, scope='cms'):
+        """
+        Emulate attachDIDs Rucio API
+        """
+        cname = self.__class__.__name__
+        logging.info("%s attachDID rse=%s, suportDID=%s, portion=%s, scope=%s", cname, rse, superDID, portion, scope)
+        return True
+
+    def createReplicationRules(self, portion, rseExpression):
+        """
+        Emulate createReplicationRules Rucio API
+        """
+        cname = self.__class__.__name__
+        logging.info("%s createReplicationRules portion=%s, rseExpression=%s", cname, portion, rseExpression)
+        return [rseExpression]
+
+    def updateRule(self, rid, opts):
+        """
+        Emulate updateRule(rid, opts) Rucio API
+        """
+        cname = self.__class__.__name__
+        logging.info("%s updateRule rid=%s, opts=%s", cname, rid, opts)
+        return True
+
     def getReplicaInfoForBlocks(self, **args):
         """
         Returns a mocked location for data.

--- a/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupData_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupData_t.py
@@ -21,7 +21,7 @@ class MSPileupTest(unittest.TestCase):
         """setup unit test class"""
         self.validRSEs = ['rse1']
         msConfig = {'reqmgr2Url': 'http://localhost',
-                    'rucioAccount': 'wmcore_mspileup',
+                    'rucioAccount': 'wmcore_pileup',
                     'rucioUrl': 'http://cms-rucio-int.cern.ch',
                     'rucioAuthUrl': 'https://cms-rucio-auth-int.cern.ch',
                     'validRSEs': self.validRSEs,

--- a/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupTasks_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupTasks_t.py
@@ -98,7 +98,7 @@ class MSPileupTasksTest(EmulatedUnitTestCase):
         self.logger = logging.getLogger()
 
         # setup rucio client
-        self.rucioAccount = 'ms-pileup'
+        self.rucioAccount = 'wmcore-pileup'
         self.hostUrl = 'http://cms-rucio.cern.ch'
         self.authUrl = 'https://cms-rucio-auth.cern.ch'
         creds = {"client_cert": os.getenv("X509_USER_CERT", "Unknown"),
@@ -114,7 +114,7 @@ class MSPileupTasksTest(EmulatedUnitTestCase):
 
         # setup pileup data manager
         msConfig = {'reqmgr2Url': 'http://localhost',
-                    'rucioAccount': 'wmcore_mspileup',
+                    'rucioAccount': 'wmcore_pileup',
                     'rucioUrl': 'http://cms-rucio-int.cern.ch',
                     'rucioAuthUrl': 'https://cms-rucio-auth-int.cern.ch',
                     'mongoDB': 'msPileupDB',

--- a/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileup_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileup_t.py
@@ -25,7 +25,7 @@ class MSPileupTest(EmulatedUnitTestCase):
         self.validRSEs = ['rse1', 'rse2']
         msConfig = {'reqmgr2Url': 'http://localhost',
                     'authz_key': '123',
-                    'rucioAccount': 'wmcore_mspileup',
+                    'rucioAccount': 'wmcore_pileup',
                     'rucioUrl': 'http://cms-rucio-int.cern.ch',
                     'rucioAuthUrl': 'https://cms-rucio-auth-int.cern.ch',
                     'mongoDB': 'msPileupDB',

--- a/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileup_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileup_t.py
@@ -10,8 +10,11 @@ import unittest
 
 # WMCore modules
 from WMCore.MicroService.MSPileup.MSPileup import MSPileup
+from WMCore.MicroService.MSPileup.MSPileupData import customDID
 from WMCore.MicroService.MSPileup.DataStructs.MSPileupObj import MSPileupObj
+from WMCore.MicroService.Tools.Common import getMSLogger
 from WMQuality.Emulators.EmulatedUnitTestCase import EmulatedUnitTestCase
+from Utils.Timers import gmtimeSeconds
 
 
 class MSPileupTest(EmulatedUnitTestCase):
@@ -20,6 +23,7 @@ class MSPileupTest(EmulatedUnitTestCase):
         """
         set up unit test generic objects
         """
+        self.logger = getMSLogger(False)
         super(MSPileupTest, self).setUp()
         cherrypy.request.user = "test"
         self.validRSEs = ['rse1', 'rse2']
@@ -100,12 +104,68 @@ class MSPileupTest(EmulatedUnitTestCase):
         # update doc
         doc = dict(self.doc)
         doc["pileupType"] = "premix"
+        # add transition record as it now requires for update API
+        customName = customDID(doc['pileupName'])
+        trec = {'DN': 'localhost-test', 'containerFraction': 1, 'customDID': customName, 'updateTime': gmtimeSeconds()}
+        doc.update({'transition': [trec]})
+
         res = self.mgr.updatePileup(doc)
         self.assertEqual(len(res), 0)
 
         # get doc
         res = self.mgr.getPileup(**self.spec)
         self.assertEqual(res[0]['pileupType'], "premix")
+
+    def testMSPileupUpdateTransition(self):
+        """Test MSPileup updatePileup API with transition logic"""
+        self.assertEqual(len(self.createDoc()), 0)
+        self.assertEqual(self.doc['pileupType'], "classic")
+
+        # update doc
+        doc = dict(self.doc)
+        doc["pileupType"] = "premix"
+        # add transition record as it now requires for update API
+        # note: for first transition record we do not change custom name
+        # see https://gist.github.com/amaltaro/b4f9bafc0b58c10092a0735c635538b5
+        customName = doc['pileupName']
+        trec = {'DN': 'localhost-test', 'containerFraction': 1, 'customDID': customName, 'updateTime': gmtimeSeconds()}
+        doc.update({'transition': [trec]})
+
+        res = self.mgr.updatePileup(doc)
+        self.assertEqual(len(res), 0)
+        self.logger.info("updatePileup %s", res)
+
+        # get doc
+        res = self.mgr.getPileup(**self.spec)
+        self.assertEqual(res[0]['pileupType'], "premix")
+        self.logger.info("getPileup %s", res)
+
+        # now we'll perform check for transition records according to logic outlined in
+        # https://gist.github.com/amaltaro/b4f9bafc0b58c10092a0735c635538b5
+        # Please note: we can only change steps 1-5 since there is no MSPileupTasks is involved
+
+        # add new spec with transition change
+        spec = {'pileupName': doc['pileupName'], 'containerFraction': 0.5}
+        res = self.mgr.updatePileup(spec)
+        self.logger.info("updatePileup %s", res)
+        self.assertEqual(len(res), 0)
+
+        # get doc
+        res = self.mgr.getPileup(**self.spec)
+        self.assertEqual(res[0]['pileupType'], "premix")
+        self.logger.info("getPileup %s", res)
+        record = res[0]
+        self.assertEqual(len(record['transition']), 2)
+        self.assertEqual(record['customName'], '')
+
+        # check transition records
+        for idx, rec in enumerate(record['transition']):
+            if idx == 0:
+                self.assertEqual(rec['customDID'], doc['pileupName'])
+                self.assertEqual(rec['containerFraction'], 1.0)
+            elif idx == 1:
+                self.assertEqual(rec['customDID'], doc['pileupName'] + '-V1')
+                self.assertEqual(rec['containerFraction'], 1.0)
 
     def testMSPileupDelete(self):
         """Test MSPileup createPileup and deletePileup API"""


### PR DESCRIPTION
Fixes #11621 

#### Status
ready

#### Description
Introduce partial pileup placement logic described in #11621 It involves the following:
- user place a request in form of `{containerFraction: <float>, 'pileupName': <string>}`
- request is placed via PUT HTTP call to MSPileup data-service
- MSPileup data service calls `updatePileup` API which by itself pass the call to `MSPileupData` manage and calls its `updatePileup`API
- the `updatePileup` API performs necessary checks, creates `cusomDID` and creates new `transition` record with the following structure:
```
{containerFraction: float,
 customDID: string,
 updateTime: GMTimeInSeconds,
 DN: string}
```

In addition, we provide `partialPileupTask` in MSPileupTask class which is used during each polling cycle. This method performs transition logic outlined in the following [gist](https://gist.github.com/amaltaro/b4f9bafc0b58c10092a0735c635538b5)
- it fetches pileup documents from MongoDB
- it identifies the slope of container fraction
- get rucio DIDs for our pileup document
- get portion of DIDs based on `ceil(containerFraction * num_rucio_datasets)` formula
- create new container DID in Rucio
- call attachDIDs Rucio wrapper API with our set of DIDs and rses from pileup document
- create new rules for custom DID
- set expiration date (to be 24h) for already existing ruleIds from pileup document
- add new ruleIds to pileup document


**TODO:** 

Further actions:
- we may need to implement separation of validation step from constructor of MSPileupObj, see https://github.com/dmwm/WMCore/issues/11863
- based on introduction of `transition` record at creation of pileup document and requirements that update API must have the transition record we should update all existing pileup documents in MongoDB (both production and testbed) to introduce `transition` records in existing documents, see https://github.com/dmwm/WMCore/issues/11867

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs

#### External dependencies / deployment changes
