### PR TITLE
ad-hoc fix for failed workflow while creating WQEs

### DIFF
--- a/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Block_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Block_t.py
@@ -421,8 +421,7 @@ class BlockTestCase(EmulatedUnitTestCase):
                                              assignArgs={'SiteWhitelist': ['T2_XX_SiteA']})
         for task in Tier1ReRecoWorkload.taskIterator():
             policyInstance(Tier1ReRecoWorkload, task)
-            outputs = policyInstance.getDatasetLocations(
-                {'https://cmsweb-prod.cern.ch/dbs/prod/global/DBSReader': Tier1ReRecoWorkload.listInputDatasets()})
+            outputs = policyInstance.getDatasetLocations(Tier1ReRecoWorkload.listInputDatasets())
             for dataset in outputs:
                 self.assertItemsEqual(outputs[dataset], ['T2_XX_SiteA', 'T2_XX_SiteB'])
         return


### PR DESCRIPTION
Fixes #11784 

#### Status
ready

#### Description
This is ad-hoc patch rather an actual fix for issue #11784. So far it only disables exception before create of WQE when there is no Input data placement present in a given spec (which may be the case when data is on tape). Instead we would like to have logging warnings to monitor and further understand the situation.

#### Is it backward compatible (if not, which system it affects?)
MAYBE

#### Related PRs

#### External dependencies / deployment changes
