### PR TITLE
Deal with invalid blocks in WMBS for Dataset start policy

### DIFF
--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -484,6 +484,7 @@ class DBS3Reader(object):
         We need to clean code up when dbs2 is completely deprecated.
         calling lumis for run number is expensive.
         """
+        result = []
         if not self.blockExists(fileBlockName):
             msg = "DBSReader.listFilesInBlock(%s): No matching data"
             raise DBSReaderError(msg % fileBlockName) from None
@@ -496,10 +497,13 @@ class DBS3Reader(object):
             msg += "%s\n" % formatEx3(ex)
             raise DBSReaderError(msg) from None
 
+        if not files:
+            # there are no valid files in this block, stop here!
+            return result
+
         if lumis:
             lumiDict = self._getLumiList(blockName=fileBlockName, validFileOnly=validFileOnly)
 
-        result = []
         for fileInfo in files:
             if lumis:
                 fileInfo["LumiList"] = lumiDict[fileInfo['logical_file_name']]


### PR DESCRIPTION
Fixes #11822 

#### Status
not-tested

#### Description
This PR fixes work acquisition from Local WorkQueue into WMBS in the case of an invalid block (a block with only invalid files). This fix applies to workflows with `Dataset` starting policy, i.e., workflows with a single workqueue element where the actual input is a dataset (instead of the usual block).

In addition, a performance improvement is provided to the `listFilesInBlock` DBSReader wrapper API, such that we don't try to resolve the lumis in a block with only invalid files. 

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
