### PR TITLE
Ensure MSTransferor does not request more copies than RSEs available

### DIFF
--- a/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
+++ b/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
@@ -422,6 +422,13 @@ class MSTransferor(MSCore):
             dids, didsSize = wflow.getInputData()
             grouping = wflow.getRucioGrouping()
             copies = wflow.getReplicaCopies()
+            # we cannot ask Rucio to make more copies than the number of RSEs, so check first
+            if copies > len(rses):
+                msg = f"Found only {len(rses)} RSEs listed, hence we need to lower "
+                msg += f"the number of copies from {copies} to {len(rses)}"
+                self.logger.warning(msg)
+                copies = len(rses)
+
             if not dids:
                 # no valid files in any blocks, it will likely fail in global workqueue
                 self.logger.warning("  found 0 primary/parent blocks for dataset: %s, moving on...", dataIn['name'])


### PR DESCRIPTION
Fixes #11843 

#### Status
ready

#### Description
Some input data placement policies request more than 1 replica copies (e.g. NANOAOD workflows), hence we need to ensure that a rule does not request more copies than the actual number of RSEs listed in the RSE expression, otherwise Rucio will fail the rule creation request.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
