### PR TITLE
Fix typo in WorkflowUpdater module

### DIFF
--- a/src/python/WMComponent/WorkflowUpdater/WorkflowUpdater.py
+++ b/src/python/WMComponent/WorkflowUpdater/WorkflowUpdater.py
@@ -30,7 +30,7 @@ class WorkflowUpdater(Harness):
         """
         pollInterval = self.config.WorkflowUpdater.pollInterval
         logging.info("Starting %s with configuration:\n%s", self.__class__.__name__,
-                     pformat(self.config.WorkflowUpdaterPoller.dictionary_()))
+                     pformat(self.config.WorkflowUpdater.dictionary_()))
 
         myThread = threading.currentThread()
         myThread.workerThreadManager.addWorker(WorkflowUpdaterPoller(self.config),


### PR DESCRIPTION
Fixes #11733 (complement to https://github.com/dmwm/WMCore/pull/11795)

#### Status
ready

#### Description
Now that I could test the new component, I see I made a mistake in the attribute name, which caused this error:
```
2024-01-10 21:02:32,435:139750050441024:CRITICAL:Harness:PostMortem: choked when initializing with error: 'Configuration' object has no attribute 'WorkflowUpdaterPoller'
```

while the correct attribute section is `WorkflowUpdater`, fixed in this PR.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Fixes a mistake added in https://github.com/dmwm/WMCore/pull/11795

#### External dependencies / deployment changes
None
