### PR TITLE
Fix data type passed in Global WorkQueue for getDatasetLocations()

### DIFF
--- a/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
@@ -264,8 +264,12 @@ class StartPolicyInterface(PolicyInterface):
         """
         if not account:
             account = self.rucioAcctPU
+        if isinstance(datasets, str):
+            datasets = [datasets]
         result = {}
         for datasetPath in datasets:
+            msg = f"Fetching Rucio locks for account: {account} and dataset: {datasetPath}"
+            self.logger.info(msg)
             locations = self.rucio.getDataLockedAndAvailable(name=datasetPath,
                                                              account=account)
             result[datasetPath] = self.cric.PNNstoPSNs(locations)


### PR DESCRIPTION
Fixes #11861 (complement to https://github.com/dmwm/WMCore/pull/11810)

#### Status
ready

#### Description
Cast simple string object to list in `getDatasetLocations` method, otherwise we iterate over each character instead of each dataset name

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Fixes a mistake from https://github.com/dmwm/WMCore/pull/11810

#### External dependencies / deployment changes
None
