### PR TITLE
Abandon storage.xml in favor of storage.json for stage-in and stage-out (after reverting merging #11816 to master)

### DIFF
--- a/src/python/WMCore/Storage/DeleteMgr.py
+++ b/src/python/WMCore/Storage/DeleteMgr.py
@@ -21,8 +21,8 @@ from WMCore.Storage.StageOutError import StageOutInitError
 from WMCore.WMException import WMException
 
 
-# from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig
-
+from WMCore.Storage.SiteLocalConfig import stageOutStr,loadSiteLocalConfig
+from WMCore.Storage.RucioFileCatalog import storageJsonPath,readRFC 
 
 class DeleteMgrError(WMException):
     """
@@ -47,35 +47,30 @@ class DeleteMgr(object):
     """
 
     def __init__(self, **overrideParams):
-        self.override = False
+        
         self.logger = overrideParams.pop("logger", logging.getLogger())
         self.overrideConf = overrideParams
-        if overrideParams != {}:
-            self.override = True
 
-        #  //
-        # // Try an get the TFC for the site
-        # //
-        self.tfc = None
-
-        from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig
-
+        self.bypassImpl = False
+        
+        #pairs of stageOut and Rucio file catalog: [(stageOut1,rfc1),(stageOut2,rfc2), ...]
+        #a "stageOut" corresponds to a entry in the <stage-out> block in the site-local-config.xml, for example <method volume="KIT_dCache" protocol="WebDAV"/>
+        #a "rfc" is the correponding RucioFileCatalog instance (RucioFileCatalog.py) of this "stageOut"
+        self.stageOuts_rfcs = []
         self.numberOfRetries = 3
         self.retryPauseTime = 600
-        self.pnn = None
-        self.fallbacks = []
 
         #  //
         # // If override isnt None, we dont need SiteCfg, if it is
         # //  then we need siteCfg otherwise we are dead.
 
-        if self.override == False:
+        if not self.overrideConf:
             self.siteCfg = loadSiteLocalConfig()
 
-        if self.override:
-            self.initialiseOverride()
-        else:
+        if not self.overrideConf:
             self.initialiseSiteConf()
+        else:
+            self.initialiseOverride()
 
     def initialiseSiteConf(self):
         """
@@ -84,43 +79,52 @@ class DeleteMgr(object):
         Extract required information from site conf and TFC
 
         """
+        
+        self.stageOuts = self.siteCfg.stageOuts
 
-        implName = self.siteCfg.localStageOut.get("command", None)
-        if implName == None:
-            msg = "Unable to retrieve local stage out command\n"
-            msg += "From site config file.\n"
-            msg += "Unable to perform StageOut operation"
-            raise StageOutInitError(msg)
-        msg = "Local Stage Out Implementation to be used is:"
-        msg += "%s\n" % implName
+        msg = ""
+        msg += "There are %s stage out definitions.\n" % len(self.stageOuts)
+        
+        for stageOut in self.stageOuts:
+            msg = ""
+            for k in ['phedex-node','command','storageSite','volume','protocol']:
+                v = stageOut.get(k)
+                if v is None:
+                    msg += "Unable to retrieve "+k+" of this stageOut: \n"
+                    msg += stageOutStr(stageOut) + "\n"
+                    msg += "From site config file.\n"
+                    msg += "Continue to the next stageOut.\n"
+                    logging.info(msg)
+                    continue
 
-        pnn = self.siteCfg.localStageOut.get("phedex-node", None)
-        if pnn == None:
-            msg = "Unable to retrieve local stage out phedex-node\n"
-            msg += "From site config file.\n"
-            msg += "Unable to perform StageOut operation"
-            raise StageOutInitError(msg)
-        msg += "Local Stage Out PNN to be used is %s\n" % pnn
-        catalog = self.siteCfg.localStageOut.get("catalog", None)
-        if catalog == None:
-            msg = "Unable to retrieve local stage out catalog\n"
-            msg += "From site config file.\n"
-            msg += "Unable to perform StageOut operation"
-            raise StageOutInitError(msg)
-        msg += "Local Stage Out Catalog to be used is %s\n" % catalog
+            storageSite = stageOut.get("storageSite")
+            volume = stageOut.get("volume")
+            protocol = stageOut.get("protocol")
+            command = stageOut.get("command")
+            pnn = stageOut.get("phedex-node")
+            
+            msg += "\tStage out to : %s using: %s \n" % (pnn, command)
+            
+            try:
+                aPath = storageJsonPath(self.siteCfg.siteName,self.siteCfg.subSiteName,storageSite)
+                rfc = readRFC(aPath,storageSite,volume,protocol)
+                self.stageOuts_rfcs.append((stageOut,rfc))
+                msg += "Rucio File Catalog has been loaded:\n"
+                msg += str(self.stageOuts_rfcs[-1][1])
+            except Exception as ex:
+                msg += "Unable to load Rucio File Catalog:\n"
+                msg += "This stage out will not be attempted:\n"
+                msg += stageOutStr(stageOut) + '\n'
+                msg += str(ex)
+                logging.info(msg)
+                continue
 
-        try:
-            self.tfc = self.siteCfg.trivialFileCatalog()
-            msg += "Trivial File Catalog has been loaded:\n"
-            msg += str(self.tfc)
-        except Exception as ex:
-            msg = "Unable to load Trivial File Catalog:\n"
-            msg += "Local stage out will not be attempted\n"
-            msg += str(ex)
+        #no Rucio file catalog is initialized
+        if not self.stageOuts_rfcs:
             raise StageOutInitError(msg)
 
         self.logger.info(msg)
-        self.pnn = pnn
+        
         return
 
     def initialiseOverride(self):
@@ -130,8 +134,8 @@ class DeleteMgr(object):
         Extract and verify that the Override parameters are all present
 
         """
-        overrideConf = self.overrideConf
-        overrideParams = {
+        
+        overrideConf = {
             "command": None,
             "option": None,
             "phedex-node": None,
@@ -139,26 +143,27 @@ class DeleteMgr(object):
         }
 
         try:
-            overrideParams['command'] = overrideConf['command']
-            overrideParams['phedex-node'] = overrideConf['phedex-node']
-            overrideParams['lfn-prefix'] = overrideConf['lfn-prefix']
+            overrideConf['command'] = self.overrideConf['command']
+            overrideConf['phedex-node'] = self.overrideConf['phedex-node']
+            overrideConf['lfn-prefix'] = self.overrideConf['lfn-prefix']
         except Exception as ex:
-            msg = "Unable to extract Override parameters from config:\n"
-            msg += str(overrideConf)
+            msg = "Unable to extract override parameters from config:\n"
+            msg += str(self.overrideConf)
             raise StageOutInitError(msg)
-        if 'option' in overrideConf:
-            if len(overrideConf['option']) > 0:
-                overrideParams['option'] = overrideConf['option']
+        if 'option' in self.overrideConf and self.overrideConf['option'] is not None:
+            if len(self.overrideConf['option']) > 0:
+                overrideConf['option'] = self.overrideConf['option']
             else:
-                overrideParams['option'] = ""
+                overrideConf['option'] = ""
+
+        self.overrideConf = overrideConf
 
         msg = "=======Delete Override Initialised:================\n"
-        for key, val in viewitems(overrideParams):
+        for key, val in viewitems(overrideConf):
             msg += " %s : %s\n" % (key, val)
         msg += "=====================================================\n"
         self.logger.info(msg)
-        self.fallbacks.append(overrideParams)
-        self.pnn = overrideParams['phedex-node']
+        
         return
 
     def __call__(self, fileToDelete):
@@ -171,34 +176,28 @@ class DeleteMgr(object):
         self.logger.info("==>Working on file: %s" % fileToDelete['LFN'])
 
         lfn = fileToDelete['LFN']
-        fileToDelete['PNN'] = self.pnn
 
         deleteSuccess = False
-
-        #  //
-        # // No override => use local-stage-out from site conf
-        # //  invoke for all files and check failures/successes
-        if not self.override:
-            self.logger.info("===> Attempting To Delete.")
+        
+        if not self.overrideConf:
+            logging.info("===> Attempting to delete with %s stage outs", len(self.stageOuts))
+            for stageOut_rfc in self.stageOuts_rfcs:
+                if not deleteSuccess:
+                    try:
+                        fileToDelete['PNN'] = stageOut_rfc[0]['phedex-node']
+                        fileToDelete['PFN'] = self.deleteLFN(lfn, stageOut_rfc)
+                        deleteSuccess = True
+                        break
+                    except Exception as ex:
+                        continue
+        else:
+            logging.info("===> Attempting stage outs from override")
             try:
+                fileToDelete['PNN'] = self.overrideConf['phedex-node']
                 fileToDelete['PFN'] = self.deleteLFN(lfn)
                 deleteSuccess = True
             except Exception as ex:
                 self.logger.error("===> Local file deletion failure. Exception:\n%s", str(ex))
-
-        if not deleteSuccess and len(self.fallbacks) > 0:
-            #  //
-            # // Still here => override start using the fallback stage outs
-            # //  If override is set, then that will be the only fallback available
-            self.logger.info("===> Attempting To Delete files with fallback.")
-            for fallback in self.fallbacks:
-                if not deleteSuccess:
-                    try:
-                        fileToDelete['PFN'] = self.deleteLFN(lfn, fallback)
-                        deleteSuccess = True
-                    except Exception as ex:
-                        continue
-
         if deleteSuccess:
             msg = "===> Delete Successful:\n"
             msg += "====> LFN: %s\n" % fileToDelete['LFN']
@@ -210,32 +209,40 @@ class DeleteMgr(object):
             msg = "Unable to delete file:\n"
             msg += fileToDelete['LFN']
             raise StageOutFailure(msg, **fileToDelete)
-
-    def deleteLFN(self, lfn, override=None):
+    
+    def deleteLFN(self, lfn, stageOut_rfc=None):
         """
         deleteLFN
-
-        Given the lfn and local stage out params, invoke the delete
-
-        if override is used the follwoing params should be defined:
-        command - the stage out impl plugin name to be used
-        option - the option values to be passed to that command (None is allowed)
-        lfn-prefix - the LFN prefix to generate the PFN
-        phedex-node - the Name of the PNN to which the file is being xferred
+        Given the lfn and an stageOut Rucio file catalog pair or override config, invoke the delete
+        lfn: logical file name
+        stageOut_rfc: a pair fo stageOut and correponding Rucio file catalog, required when no override provided 
+        self.overrideConf: the follwoing params should be defined for override
+            command - the stage out impl plugin name to be used
+            option - the option values to be passed to that command (None is allowed)
+            lfn-prefix - the LFN prefix to generate the PFN
+            phedex-node - the Name of the PNN to which the file is being xferred
         """
+        if not self.overrideConf:
+            from WMCore.Storage.StageOutMgr import searchRFC 
+            command = stageOut_rfc[0]['command']
+            pfn = searchRFC(stageOut_rfc[1],lfn)
 
-        if override:
-            command = override['command']
-            pfn = "%s%s" % (override['lfn-prefix'], lfn)
+            if pfn == None:
+                msg = "Unable to match lfn to pfn: \n  %s" % lfn
+                raise StageOutFailure(msg, LFN=lfn, STAGEOUT=stageOutStr(stageOut_rfc[0]))
+
+            return self.deletePFN(pfn, lfn, command)
         else:
-            command = self.siteCfg.localStageOut['command']
-            pfn = self.searchTFC(lfn)
+            command = self.overrideConf['command']
+            pfn = None
+            if self.overrideConf['lfn-prefix'] is not None:
+                pfn = "%s%s" % (self.overrideConf['lfn-prefix'], lfn)
 
-        if pfn == None:
-            msg = "Unable to match lfn to pfn: \n  %s" % lfn
-            raise StageOutFailure(msg, LFN=lfn, TFC=str(self.tfc))
+            if pfn is None:
+                msg = "Unable to match lfn to pfn using lfn-prefix: \n %s" % lfn
+                raise StageOutFailure(msg, LFN=lfn, LFNPREFIX=self.overrideConf['lfn-prefix'])
 
-        return self.deletePFN(pfn, lfn, command)
+            return self.deletePFN(pfn, lfn, command)
 
     def deletePFN(self, pfn, lfn, command):
         """
@@ -253,68 +260,11 @@ class DeleteMgr(object):
         impl.retryPause = self.retryPauseTime
 
         try:
-            impl.removeFile(pfn)
+            if not self.bypassImpl:
+                impl.removeFile(pfn)
         except Exception as ex:
             self.logger.error("Failed to delete file: %s", pfn)
             ex.addInfo(Protocol=command, LFN=lfn, TargetPFN=pfn)
             raise ex
 
         return pfn
-
-    #    def reportStageOutFailure(self, stageOutExcep):
-    #        """
-    #        _reportStageOutFailure_
-    #
-    #        When a stage out failure occurs, report it to the input
-    #        framework job report.
-    #
-    #        - *stageOutExcep* : Instance of on of the StageOutError derived classes
-    #
-    #        """
-    #        errStatus = stageOutExcep.data["ErrorCode"]
-    #        errType = stageOutExcep.data["ErrorType"]
-    #        desc = stageOutExcep.message
-    #
-    #        errReport = self.inputReport.addError(errStatus, errType)
-    #        errReport['Description'] = desc
-    #        return
-
-    def searchTFC(self, lfn):
-        """
-        _searchTFC_
-
-        Search the Trivial File Catalog for the lfn provided,
-        if a match is made, return the matched PFN
-
-        """
-        if self.tfc == None:
-            msg = "Trivial File Catalog not available to match LFN:\n"
-            msg += lfn
-            self.logger.error(msg)
-            return None
-        if self.tfc.preferredProtocol == None:
-            msg = "Trivial File Catalog does not have a preferred protocol\n"
-            msg += "which prevents local stage out for:\n"
-            msg += lfn
-            self.logger.error(msg)
-            return None
-
-        pfn = self.tfc.matchLFN(self.tfc.preferredProtocol, lfn)
-        if pfn == None:
-            msg = "Unable to map LFN to PFN:\n"
-            msg += "LFN: %s\n" % lfn
-            return None
-
-        msg = "LFN to PFN match made:\n"
-        msg += "LFN: %s\nPFN: %s\n" % (lfn, pfn)
-        self.logger.info(msg)
-        return pfn
-
-##if __name__ == '__main__':
-##    import StageOut.Impl
-##    mgr = StageOutMgr()
-##    pfn = "/home/evansde/work/PRODAGENT/work/JobCreator/RelValMinBias-170pre12/Processing/RelValMinBias-170pre12-Processing.tar.gz"
-##    lfn = "/store/unmerged/mc/2007/11/13/RelVal-RelValMinBias-1194987281/GEN-SIM-DIGI-RECO/0201/DCCP-FNAL-TEST.dat"
-
-##    mgr.searchTFC(lfn)
-##    mgr(LFN = lfn, PFN = pfn, GUID=None)

--- a/src/python/WMCore/Storage/RucioFileCatalog.py
+++ b/src/python/WMCore/Storage/RucioFileCatalog.py
@@ -40,10 +40,12 @@ class RucioFileCatalog(dict):
     def addMapping(self, protocol, match, result,
                    chain=None, mapping_type='lfn-to-pfn'):
         """
-        _addMapping_
-
         Add an lfn to pfn mapping to this instance
-
+        :param protocol: name of protocol, for example XRootD
+        :param match: regular expression string to perform path matching 
+        :param result: result of the path matching
+        :param chain: name of chained protocol
+        :param mapping_type: type of path matching
         """
         entry = {}
         entry.setdefault("protocol", protocol)
@@ -88,27 +90,27 @@ class RucioFileCatalog(dict):
 
     def matchLFN(self, protocol, lfn):
         """
-        _matchLFN_
-
         Return the result for the LFN provided if the LFN
         matches the path-match for that protocol
 
         Return None if no match
-
+        :param protocol: protocol name, for example XRootD
+        :param lfn: logical file name
         """
+
         result = self._doMatch(protocol, lfn, "lfn-to-pfn", self.matchLFN)
         return result
 
     def matchPFN(self, protocol, pfn):
         """
-        _matchPFN_
-
         Return the result for the LFN provided if the LFN
         matches the path-match for that protocol
 
         Return None if no match
-
+        :param protocol: protocol name, for example XRootD
+        :param pfn: physical file name
         """
+
         result = self._doMatch(protocol, pfn, "pfn-to-lfn", self.matchPFN)
         return result
 
@@ -161,11 +163,14 @@ def storageJsonPath(currentSite, currentSubsite, storageSite):
 
 def readRFC(filename, storageSite, volume, protocol):
     """
-    _readRFC_
-
     Read the provided storage.json and return a RucioFileCatalog
     instance containing the details found in it
+    :param filename: name including full path to storage description file (storage.json)
+    :param storageSite: name of site to store the output of stage out (where stage out goes to)
+    :param volume: the volume of storage elements
+    :param protocol: name of stage out protocol
     """
+
     rfcInstance = RucioFileCatalog()
     try:
         with open(filename,encoding="utf-8") as jsonFile:

--- a/src/python/WMCore/Storage/RucioFileCatalog.py
+++ b/src/python/WMCore/Storage/RucioFileCatalog.py
@@ -59,7 +59,8 @@ class RucioFileCatalog(dict):
 
     def _doMatch(self, protocol, path, style, caller):
         """
-        Generalised way of building up the mappings.         :param protocol: the name of a protocol, for example XRootD
+        Generalised way of building up the mappings.         
+        :param protocol: the name of a protocol, for example XRootD
         :path: a LFN path, for example /store/abc/xyz.root
         :style: type of conversion. lfn-to-pfn is to convert LFN to PFN and pfn-to-pfn is for PFN to LFN
         :caller is the method from there this method was called. It's used for resolving chained rules
@@ -179,36 +180,35 @@ def readRFC(filename, storageSite, volume, protocol):
     for jsElement in jsElements:
         #check to see if the storageSite and volume matchs with "site" and "volume" in storage.json
         if jsElement['site'] == storageSite and jsElement['volume'] == volume: 
-            #now loop over protocols
-            #!!!!!!!!!!!!!!Maybe save all protocols so that chain works
+            rfcInstance.preferredProtocol = protocol
+            #now loop over protocols to add all mappings (needed for chained rule cases)
             for prot in jsElement['protocols']:
-                #check found match
-                if prot['protocol'] == protocol:
-                    rfcInstance.preferredProtocol = protocol
-                    chain = prot['chain'] if 'chain' in prot.keys() else None
-                    #check if prefix is in protocol block
-                    if 'prefix' in prot.keys():
-                        #lfn-to-pfn
-                        match = '(.*)' #match all
-                        result = prot['prefix']+'/$1'
+                #check if prefix is in protocol block
+                if 'prefix' in prot.keys():
+                    #lfn-to-pfn
+                    match = '/(.*)' #match all
+                    result = prot['prefix']+'/$1'
+                    #prefix case should not be chained
+                    chain = None 
+                    rfcInstance.addMapping(str(prot['protocol']), str(match), str(result), chain, 'lfn-to-pfn')
+                    #pfn-to-lfn
+                    match = prot['prefix']+'/(.*)'
+                    result = '/$1'
+                    rfcInstance.addMapping(str(prot['protocol']), str(match), str(result), chain, 'pfn-to-lfn')
+                #here is rules  
+                else:
+                    #loop over rules
+                    for rule in prot['rules']:
+                        match = rule['lfn']
+                        result = rule['pfn']
+                        chain = rule['chain'] if 'chain' in rule.keys() else None
                         rfcInstance.addMapping(str(prot['protocol']), str(match), str(result), chain, 'lfn-to-pfn')
-                        #pfn-to-lfn
-                        match = prot['prefix']+'/(.*)'
-                        result = '/$1'
+                        #pfn-to-lfn: not sure about this!!!
+                        match = rule['pfn'].replace('$1','(.*)')
+                        result = rule['lfn'].replace('/+','/').replace('^/','/')
+                        #now replace anything inside () with $1, for example (.*) --> $1, (store/.*) --> $1
+                        result = re.sub('\(.*\)','$1',result)
                         rfcInstance.addMapping(str(prot['protocol']), str(match), str(result), chain, 'pfn-to-lfn')
-                    #here is rules  
-                    else:
-                        #loop over rules
-                        for rule in prot['rules']:
-                            match = rule['lfn']
-                            result = rule['pfn']
-                            rfcInstance.addMapping(str(prot['protocol']), str(match), str(result), chain, 'lfn-to-pfn')
-                            #pfn-to-lfn: not sure about this!!!
-                            match = rule['pfn'].replace('$1','(.*)')
-                            result = rule['lfn'].replace('/+','/').replace('^/','/')
-                            #now replace anything inside () with $1, for example (.*) --> $1, (store/.*) --> $1
-                            result = re.sub('\(.*\)','$1',result)
-                            rfcInstance.addMapping(str(prot['protocol']), str(match), str(result), chain, 'pfn-to-lfn')
     
     return rfcInstance
 

--- a/src/python/WMCore/Storage/RucioFileCatalog.py
+++ b/src/python/WMCore/Storage/RucioFileCatalog.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python
+"""
+_RucioFileCatalog_
+
+Object to contain LFN to PFN mappings from a Rucio File Catalog
+and provide functionality to match LFNs against them
+
+Usage:
+
+given a storage description file, storage.json, execute readRFC. This will return
+a RucioFileCatalog instance that can be used to match LFNs to PFNs.
+"""
+
+from builtins import next, str, range
+from future.utils import viewitems
+
+from future import standard_library
+standard_library.install_aliases()
+
+import os
+import re
+
+import json
+
+from urllib.parse import urlsplit
+from xml.dom.minidom import Document
+
+from WMCore.Algorithms.ParseXMLFile import xmlFileToNode
+
+class RucioFileCatalog(dict):
+    """
+    _RucioFileCatalog_
+
+    Object that can map LFNs to PFNs based on contents of a Rucio
+    File Catalog
+    """
+
+    def __init__(self):
+        dict.__init__(self)
+        self['lfn-to-pfn'] = []
+        self['pfn-to-lfn'] = []
+        self.preferredProtocol = None  # attribute for preferred protocol
+
+    def addMapping(self, protocol, match, result,
+                   chain=None, mapping_type='lfn-to-pfn'):
+        """
+        _addMapping_
+
+        Add an lfn to pfn mapping to this instance
+
+        """
+        entry = {}
+        entry.setdefault("protocol", protocol)
+        entry.setdefault("path-match-expr", re.compile(match))
+        entry.setdefault("path-match", match)
+        entry.setdefault("result", result)
+        entry.setdefault("chain", chain)
+        self[mapping_type].append(entry)
+
+    def _doMatch(self, protocol, path, style, caller):
+        """
+        Generalised way of building up the mappings.         :param protocol: the name of a protocol, for example XRootD
+        :path: a LFN path, for example /store/abc/xyz.root
+        :style: type of conversion. lfn-to-pfn is to convert LFN to PFN and pfn-to-pfn is for PFN to LFN
+        :caller is the method from there this method was called. It's used for resolving chained rules
+        """
+        for mapping in self[style]:
+            if mapping['protocol'] != protocol:
+                continue
+            if mapping['path-match-expr'].match(path) or mapping["chain"] != None:
+                if mapping["chain"] != None:
+                    oldpath = path
+                    path = caller(mapping["chain"], path)
+                    if not path:
+                        continue
+                splitList = []
+                if len(mapping['path-match-expr'].split(path, 1)) > 1:
+                    for split in range(len(mapping['path-match-expr'].split(path, 1))):
+                        s = mapping['path-match-expr'].split(path, 1)[split]
+                        if s:
+                            splitList.append(s)
+                else:
+                    path = oldpath
+                    continue
+                result = mapping['result']
+                for split in range(len(splitList)):
+                    result = result.replace("$" + str(split + 1), splitList[split])
+                return result
+
+        return None
+
+    def matchLFN(self, protocol, lfn):
+        """
+        _matchLFN_
+
+        Return the result for the LFN provided if the LFN
+        matches the path-match for that protocol
+
+        Return None if no match
+
+        """
+        result = self._doMatch(protocol, lfn, "lfn-to-pfn", self.matchLFN)
+        return result
+
+    def matchPFN(self, protocol, pfn):
+        """
+        _matchLFN_
+
+        Return the result for the LFN provided if the LFN
+        matches the path-match for that protocol
+
+        Return None if no match
+
+        """
+        result = self._doMatch(protocol, pfn, "pfn-to-lfn", self.matchPFN)
+        return result
+    def __str__(self):
+        result = ""
+        for mapping in ['lfn-to-pfn', 'pfn-to-lfn']:
+            for item in self[mapping]:
+                result += "\t%s: protocol=%s path-match-re=%s result=%s" % (
+                    mapping,
+                    item['protocol'],
+                    item['path-match-expr'].pattern,
+                    item['result'])
+                if item['chain'] != None:
+                    result += " chain=%s" % item['chain']
+                result += "\n"
+        return result
+
+
+def storageJsonPath(currentSite, currentSubsite, storageSite):
+    """
+    Return a path to storage.json from site names
+    :para currentSite and currentSubsite are the names of facilities where jobs will be executed, storageSite is the storage facility for a stage-out
+    :return /pathToStorageJson/storage.json
+    """
+    #get site config
+    siteConfigPath = os.getenv('SITECONFIG_PATH',None)
+    if not siteConfigPath:
+        raise RuntimeError('SITECONFIG_PATH is not defined')
+    subPath = ''
+    #the storage site is where jobs are executed so use local path given in SITECONFIG_PATH to locate storage.json
+    if currentSite == storageSite:
+        #it is a site (no defined subSite), storage.json is located at the path given in SITECONFIG_PATH
+        if currentSubsite is None:
+            subPath = siteConfigPath
+        #it is a subsite, move one level up
+        else:
+            subPath = siteConfigPath + '/..'
+    #cross site
+    else:
+        #it is a site (no defined subSite), move one level up
+        if currentSubsite is None:
+            subPath = siteConfigPath + '/../' + storageSite
+        #it is a subsite, move two levels up
+        else:
+            subPath = siteConfigPath + '/../../' + storageSite
+    pathToStorageDescription = subPath + '/storage.json'
+    pathToStorageDescription = os.path.normpath(os.path.realpath(pathToStorageDescription))#resolve symbolic link and relative path?
+    return pathToStorageDescription 
+
+def readRFC(filename, storageSite, volume, protocol):
+    """
+    _readRFC_
+
+    Read the provided storage.json and return a RucioFileCatalog
+    instance containing the details found in it
+    """
+    rfcInstance = RucioFileCatalog()
+    try:
+        jsonFile = open(filename,encoding="utf-8")
+        jsElements = json.load(jsonFile)
+    except Exception as ex:
+        msg = "Error reading storage description file: %s\n" % filename
+        msg += str(ex)
+        raise RuntimeError(msg)
+    #now loop over elements, select the right one and fill lfn-to-pfn
+    for jsElement in jsElements:
+        #check to see if the storageSite and volume matchs with "site" and "volume" in storage.json
+        if jsElement['site'] == storageSite and jsElement['volume'] == volume: 
+            #now loop over protocols
+            #!!!!!!!!!!!!!!Maybe save all protocols so that chain works
+            for prot in jsElement['protocols']:
+                #check found match
+                if prot['protocol'] == protocol:
+                    rfcInstance.preferredProtocol = protocol
+                    chain = prot['chain'] if 'chain' in prot.keys() else None
+                    #check if prefix is in protocol block
+                    if 'prefix' in prot.keys():
+                        #lfn-to-pfn
+                        match = '(.*)' #match all
+                        result = prot['prefix']+'/$1'
+                        rfcInstance.addMapping(str(prot['protocol']), str(match), str(result), chain, 'lfn-to-pfn')
+                        #pfn-to-lfn
+                        match = prot['prefix']+'/(.*)'
+                        result = '/$1'
+                        rfcInstance.addMapping(str(prot['protocol']), str(match), str(result), chain, 'pfn-to-lfn')
+                    #here is rules  
+                    else:
+                        #loop over rules
+                        for rule in prot['rules']:
+                            match = rule['lfn']
+                            result = rule['pfn']
+                            rfcInstance.addMapping(str(prot['protocol']), str(match), str(result), chain, 'lfn-to-pfn')
+                            #pfn-to-lfn: not sure about this!!!
+                            match = rule['pfn'].replace('$1','(.*)')
+                            result = rule['lfn'].replace('/+','/').replace('^/','/')
+                            #now replace anything inside () with $1, for example (.*) --> $1, (store/.*) --> $1
+                            result = re.sub('\(.*\)','$1',result)
+                            rfcInstance.addMapping(str(prot['protocol']), str(match), str(result), chain, 'pfn-to-lfn')
+    
+    return rfcInstance
+
+def rseName(currentSite,currentSubsite,storageSite,volume):
+    """
+    Return Rucio storage element name, for example https://gitlab.cern.ch/SITECONF/T1_DE_KIT/-/blob/master/storage.json?ref_type=heads#L39
+    :currentSite is the site where jobs are executing
+    :currentSubsite is the sub site if jobs are running here
+    :storageSite is the site for storage
+    :volume is the volume name, for example https://gitlab.cern.ch/SITECONF/T1_DE_KIT/-/blob/master/storage.json?ref_type=heads#L3
+    """
+    rse = None
+    storageJsonName = storageJsonPath(currentSite,currentSubsite,storageSite)
+    try:
+        with open(storageJsonName,encoding="utf-8") as jsonFile:
+            jsElements = json.load(jsonFile)
+    except Exception as ex:
+        msg = "RucioFileCatalog.py:rseName_rucio() Error reading storage.json: %s\n" % storageJsonName 
+        msg += str(ex)
+        raise RuntimeError(msg)
+    for jsElement in jsElements:
+        if jsElement['site'] == storageSite and jsElement['volume'] == volume:
+            rse = jsElement['rse']
+            break
+    return rse

--- a/src/python/WMCore/Storage/SiteLocalConfig.py
+++ b/src/python/WMCore/Storage/SiteLocalConfig.py
@@ -281,7 +281,8 @@ def processStageOut():
         for subnode in node.children:
             subSiteName = report['subSiteName'] if 'subSiteName' in report.keys() else None
             aStorageSite = subnode.attrs.get('site', None)
-            if aStorageSite is None: aStorageSite = report['siteName']
+            if aStorageSite is None:
+                aStorageSite = report['siteName']
             aProtocol = subnode.attrs.get('protocol', None)
             aVolume = subnode.attrs.get('volume', None)
             
@@ -289,7 +290,8 @@ def processStageOut():
             localReport['storageSite'] = aStorageSite
             localReport['command'] = subnode.attrs.get('command', None)
             #use default command='gfal2' when 'command' is not specified 
-            if localReport['command'] is None: localReport['command'] = 'gfal2'
+            if localReport['command'] is None:
+                localReport['command'] = 'gfal2'
             localReport['option'] = subnode.attrs.get('option', None)
             localReport['volume'] = aVolume 
             localReport['protocol'] = aProtocol 

--- a/src/python/WMCore/Storage/SiteLocalConfig.py
+++ b/src/python/WMCore/Storage/SiteLocalConfig.py
@@ -159,7 +159,7 @@ class SiteLocalConfig(object):
             raise SiteConfigError(msg)
 
         self.siteName             = nodeResult.get('siteName', None)
-        self.subsiteName          = nodeResult.get('subSiteName', None)
+        self.subSiteName          = nodeResult.get('subSiteName', None)
         self.eventData['catalog'] = nodeResult.get('catalog', None)
         self.localStageOut        = nodeResult.get('localStageOut', [])
         self.stageOuts            = nodeResult.get('stageOuts', [])

--- a/src/python/WMCore/Storage/StageInMgr.py
+++ b/src/python/WMCore/Storage/StageInMgr.py
@@ -48,9 +48,6 @@ class StageInMgr(object):
         if overrideParams != {}:
             self.override = True
         
-        #for testing only
-        self.bypassImpl = False 
-        
         #pairs of stageOut and Rucio file catalog
         self.stageOuts_rfcs = [] 
 
@@ -216,14 +213,14 @@ class StageInMgr(object):
     
     def stageIn(self, lfn, stageOut_rfc=None):
         """
-        _stageIn_
-
         Given the lfn and a pair of stage out and corresponding Rucio file catalog, stageOut_rfc, or override configuration invoke the stage in
         If use override configuration self.overrideConf should contain:
         command - the stage out impl plugin name to be used
         option - the option values to be passed to that command (None is allowed)
         lfn-prefix - the LFN prefix to generate the PFN
         phedex-node - the Name of the PNN to which the file is being xferred
+        :param lfn: logical file name
+        :param stageOut_rfc: a pair of stage out attributes and corresponding Rucio file catalog
         """
         localPfn = os.path.join(os.getcwd(), os.path.basename(lfn))
         if self.override:
@@ -259,8 +256,7 @@ class StageInMgr(object):
         impl.retryPause = self.retryPauseTime
 
         try:
-            if not self.bypassImpl:
-                impl(protocol, pfn, localPfn, options)
+            impl(protocol, pfn, localPfn, options)
         except Exception as ex:
             msg = "Failure for stage in:\n"
             msg += str(ex)

--- a/src/python/WMCore/Storage/StageInMgr.py
+++ b/src/python/WMCore/Storage/StageInMgr.py
@@ -63,11 +63,9 @@ class StageInMgr(object):
 
         if self.override == False:
             self.siteCfg = loadSiteLocalConfig()
-
-        if self.override:
-            self.initialiseOverride()
-        else:
             self.initialiseSiteConf()
+        else: 
+            self.initialiseOverride()
 
 
     def initialiseSiteConf(self):
@@ -82,6 +80,7 @@ class StageInMgr(object):
 
         msg = "\nThere are %s stage out definitions." % len(self.stageOuts)
         for stageOut in self.stageOuts:
+            foundNoneAttr = False
             for k in ['phedex-node','command','storageSite','volume','protocol']:
                 v = stageOut.get(k)
                 if v is None:
@@ -92,8 +91,9 @@ class StageInMgr(object):
                     amsg+= "Continue to the next stageOut.\n"
                     print(amsg)
                     msg += amsg
-                    continue
-
+                    foundNoneAttr = True
+                    break
+            if foundNoneAttr: continue
             storageSite = stageOut.get("storageSite")
             volume = stageOut.get("volume")
             protocol = stageOut.get("protocol")
@@ -230,9 +230,15 @@ class StageInMgr(object):
             pnn = self.overrideConf['phedex-node']
             command = self.overrideConf['command']
             options = self.overrideConf['option']
+            if self.overrideConf['lfn-prefix'] is None:
+                msg = "Unable to match lfn to pfn during stage in because override lfn-prefix is None: \n %s" % lfn
+                raise StageOutFailure(msg, LFN=lfn)
             pfn = "%s%s" % (self.overrideConf['lfn-prefix'], lfn)
             protocol = command
         else:
+            if stageOut_rfc is None:
+                msg = "Can not perform stage in for this lfn because of missing information (stageOut_rfc is None): \n %s" % lfn
+                raise StageOutFailure(msg, LFN=lfn)
             pnn = stageOut_rfc[0]['phedex-node']
             command = stageOut_rfc[0]['command']
             options = stageOut_rfc[0]['option']

--- a/src/python/WMCore/Storage/StageOutMgr.py
+++ b/src/python/WMCore/Storage/StageOutMgr.py
@@ -22,6 +22,9 @@ from WMCore.Storage.StageOutError import StageOutFailure
 from WMCore.Storage.StageOutError import StageOutInitError
 from WMCore.WMException import WMException
 
+from WMCore.Storage.SiteLocalConfig import stageOutStr
+from WMCore.Storage.RucioFileCatalog import storageJsonPath, readRFC 
+
 
 def stageoutPolicyReport(fileToStage, pnn, command, stageOutType, stageOutExit):
     """
@@ -42,12 +45,48 @@ def stageoutPolicyReport(fileToStage, pnn, command, stageOutType, stageOutExit):
     return fileToStage
 
 
+def searchRFC(rfc, lfn):
+    """
+    _searchRFC_
+
+    Search the Rucio File Catalog for the lfn provided,
+    if a match is made, return the matched PFN
+
+    """
+    if rfc == None:
+        msg = "Rucio File Catalog not available to match LFN:\n"
+        msg += lfn
+        logging.error(msg)
+        return None
+    if rfc.preferredProtocol == None:
+        msg = "Rucio File Catalog: "+str(rfc)+"does not have a preferred protocol\n"
+        msg += "which prevents stage out for:\n"
+        msg += lfn
+        logging.error(msg)
+        return None
+
+    pfn = rfc.matchLFN(rfc.preferredProtocol, lfn)
+    if pfn == None:
+        msg = "Unable to map LFN to PFN:\n"
+        msg += "LFN: %s\n" % lfn
+        msg += "using this Rucio File Catalog\n"
+        msg += str(rfc)
+        logging.error(msg)
+        return None 
+
+    msg = "LFN to PFN match made:\n"
+    msg += "LFN: %s\nPFN: %s\n" % (lfn, pfn)
+    logging.info(msg)
+    
+    return pfn
+
+
 class StageOutMgr(object):
     """
     _StageOutMgr_
 
     Object that can be used to stage out a set of files
-    using TFC or an override.
+    using RFC or an override.
 
     """
 
@@ -67,12 +106,8 @@ class StageOutMgr(object):
                 logging.info("=======StageOut Override: These are not the parameters you are looking for")
 
         self.substituteGUID = True
-        self.fallbacks = []
-
-        #  //
-        # // Try an get the TFC for the site
-        # //
-        self.tfc = None
+        
+        self.stageOuts_rfcs = [] #pairs of stageOut and Rucio file catalog
 
         self.numberOfRetries = 3
         self.retryPauseTime = 600
@@ -90,7 +125,8 @@ class StageOutMgr(object):
             self.initialiseOverride()
         else:
             self.initialiseSiteConf()
-
+        
+        self.bypassImpl = False
         self.failed = {}
         self.completedFiles = {}
         return
@@ -99,65 +135,55 @@ class StageOutMgr(object):
         """
         _initialiseSiteConf_
 
-        Extract required information from site conf and TFC
+        Extract required information from site conf and RFC
 
         """
+        self.stageOuts = self.siteCfg.stageOuts
 
-        implName = self.siteCfg.localStageOut.get("command", None)
-        if implName == None:
-            msg = "Unable to retrieve local stage out command\n"
-            msg += "From site config file.\n"
-            msg += "Unable to perform StageOut operation"
+        msg = "\nThere are %s stage out definitions." % len(self.stageOuts)
+        for stageOut in self.stageOuts:
+            for k in ['phedex-node','command','storageSite','volume','protocol']:
+                v = stageOut.get(k)
+                if v is None:
+                    amsg = ""
+                    amsg+= "Unable to retrieve "+k+" of this stageOut: \n"
+                    amsg+= stageOutStr(stageOut) + "\n"
+                    amsg+= "From site config file.\n"
+                    amsg+= "Continue to the next stageOut.\n"
+                    logging.info(amsg)
+                    msg += amsg
+                    continue
+
+            storageSite = stageOut.get("storageSite")
+            volume = stageOut.get("volume")
+            protocol = stageOut.get("protocol")
+            command = stageOut.get("command")
+            pnn = stageOut.get("phedex-node")
+            
+            msg += "\nStage out to : %s using: %s" % (pnn, command)
+            
+            try:
+                aPath = storageJsonPath(self.siteCfg.siteName,self.siteCfg.subSiteName,storageSite)
+                rfc = readRFC(aPath,storageSite,volume,protocol)
+                self.stageOuts_rfcs.append((stageOut,rfc))
+                msg += "\nRucio File Catalog has been loaded:"
+                msg += "\n"+str(rfc)
+            except Exception as ex:
+                amsg = "\nUnable to load Rucio File Catalog. This stage out will not be attempted:\n"
+                amsg += '\t'+stageOutStr(stageOut) + '\n'
+                amsg += str(ex)
+                msg += amsg
+                logging.info(amsg)
+                continue
+        
+        #no Rucio file catalog is initialized
+        if not self.stageOuts_rfcs:
             raise StageOutInitError(msg)
-        msg = "Local Stage Out Implementation to be used is: "
-        msg += "%s\n" % implName
-
-        pnn = self.siteCfg.localStageOut.get("phedex-node", None)
-        if pnn == None:
-            msg = "Unable to retrieve local stage out phedex-node\n"
-            msg += "From site config file.\n"
-            msg += "Unable to perform StageOut operation"
-            raise StageOutInitError(msg)
-        msg += "Local Stage Out PNN to be used is %s\n" % pnn
-        catalog = self.siteCfg.localStageOut.get("catalog", None)
-        if catalog == None:
-            msg = "Unable to retrieve local stage out catalog\n"
-            msg += "From site config file.\n"
-            msg += "Unable to perform StageOut operation"
-            raise StageOutInitError(msg)
-        msg += "Local Stage Out Catalog to be used is %s\n" % catalog
-
-        try:
-            self.tfc = self.siteCfg.trivialFileCatalog()
-            msg += "Trivial File Catalog has been loaded:\n"
-            msg += str(self.tfc)
-        except Exception as ex:
-            msg = "Unable to load Trivial File Catalog:\n"
-            msg += "Local stage out will not be attempted\n"
-            msg += str(ex)
-            raise StageOutInitError(msg)
-
-        self.fallbacks = self.siteCfg.fallbackStageOut
-
-        msg += "There are %s fallback stage out definitions.\n" % len(self.fallbacks)
-        for item in self.fallbacks:
-            pnn = item.get("phedex-node")
-            command = item.get("command")
-            if pnn is None:
-                msg = "Unable to retrieve fallback phedex-node\n"
-                msg += "From site config file.\n"
-                msg += "Unable to perform StageOut operation"
-                raise StageOutInitError(msg)
-            if command is None:
-                msg = "Unable to retrieve fallback command\n"
-                msg += "From site config file.\n"
-                msg += "Unable to perform StageOut operation"
-                raise StageOutInitError(msg)
-            msg += "\tFallback to : %s using: %s \n" % (pnn, command)
 
         logging.info("==== Stageout configuration start ====")
         logging.info(msg)
         logging.info("==== Stageout configuration finish ====")
+
         return
 
     def initialiseOverride(self):
@@ -167,35 +193,33 @@ class StageOutMgr(object):
         Extract and verify that the Override parameters are all present
 
         """
-        overrideConf = self.overrideConf
-        overrideParams = {
+        overrideConf = {
             "command": None,
             "option": None,
             "phedex-node": None,
             "lfn-prefix": None,
         }
-
         try:
-            overrideParams['command'] = overrideConf['command']
-            overrideParams['phedex-node'] = overrideConf['phedex-node']
-            overrideParams['lfn-prefix'] = overrideConf['lfn-prefix']
+            overrideConf['command'] = self.overrideConf['command']
+            overrideConf['phedex-node'] = self.overrideConf['phedex-node']
+            overrideConf['lfn-prefix'] = self.overrideConf['lfn-prefix']
         except Exception as ex:
-            msg = "Unable to extract Override parameters from config:\n"
+            msg = "Unable to extract override parameters from config:\n"
             msg += str(ex)
             raise StageOutInitError(msg)
-        if 'option' in overrideConf:
-            if len(overrideConf['option']) > 0:
-                overrideParams['option'] = overrideConf['option']
+        if 'option' in self.overrideConf and self.overrideConf['option'] is not None:
+            if len(self.overrideConf['option']) > 0:
+                overrideConf['option'] = self.overrideConf['option']
             else:
-                overrideParams['option'] = ""
+                overrideConf['option'] = ""
+
+        self.overrideConf = overrideConf
 
         msg = "=======StageOut Override Initialised:================\n"
-        for key, val in viewitems(overrideParams):
+        for key, val in viewitems(self.overrideConf):
             msg += " %s : %s\n" % (key, val)
         msg += "=====================================================\n"
         logging.info(msg)
-        self.fallbacks = []
-        self.fallbacks.append(overrideParams)
         return
 
     def __call__(self, fileToStage):
@@ -211,141 +235,137 @@ class StageOutMgr(object):
         lfn = fileToStage['LFN']
 
         fileToStage['StageOutReport'] = []
-        #  //
-        # // No override => use local-stage-out from site conf
-        # //  invoke for all files and check failures/successes
+        
+        # // No override => use stage-out from site conf
         if not self.override:
-            logging.info("===> Attempting Local Stage Out.")
-            try:
-                pfn = self.localStageOut(lfn, fileToStage['PFN'], fileToStage.get('Checksums'))
-                fileToStage['PFN'] = pfn
-                fileToStage['PNN'] = self.siteCfg.localStageOut['phedex-node']
-                fileToStage['StageOutCommand'] = self.siteCfg.localStageOut['command']
-                self.completedFiles[fileToStage['LFN']] = fileToStage
+            logging.info("===> Attempting %s Stage Outs", len(self.stageOuts))
+            for stageOut_rfc in self.stageOuts_rfcs:
+                try:
+                    pfn = self.stageOut(lfn, fileToStage['PFN'], fileToStage.get('Checksums'), stageOut_rfc)
+                    fileToStage['PFN'] = pfn
+                    fileToStage['PNN'] = stageOut_rfc[0]['phedex-node']
+                    fileToStage['StageOutCommand'] = stageOut_rfc[0]['command']
+                    logging.info("attempting stageOut")
+                    self.completedFiles[fileToStage['LFN']] = fileToStage
+                    if lfn in self.failed:
+                        del self.failed[lfn]
 
-                logging.info("===> Stage Out Successful: %s", fileToStage)
-                fileToStage = stageoutPolicyReport(fileToStage, None, None, 'LOCAL', 0)
-                return fileToStage
-            except WMException as ex:
-                lastException = ex
-                logging.info("===> Local Stage Out Failure for file:")
-                logging.info("======>  %s\n", fileToStage['LFN'])
-                fileToStage = stageoutPolicyReport(fileToStage, self.siteCfg.localStageOut.get('phedex-node', None),
-                                                   self.siteCfg.localStageOut['command'], 'LOCAL', 60311)
-            except Exception as ex:
-                lastException = StageOutFailure("Error during local stage out",
-                                                error=str(ex))
-                logging.info("===> Local Stage Out Failure for file:\n")
-                logging.info("======>  %s\n", fileToStage['LFN'])
-                fileToStage = stageoutPolicyReport(fileToStage, self.siteCfg.localStageOut.get('phedex-node', None),
-                                                   self.siteCfg.localStageOut['command'], 'LOCAL', 60311)
-
-        # //
-        # // Still here => failure, start using the fallback stage outs
-        # //  If override is set, then that will be the only fallback available
-        logging.info("===> Attempting %s Fallback Stage Outs", len(self.fallbacks))
-        for fallback in self.fallbacks:
+                    logging.info("===> Stage Out Successful: %s", fileToStage)
+                    fileToStage = stageoutPolicyReport(fileToStage, None, None, 'LOCAL', 0)
+                    return fileToStage
+                except WMException as ex:
+                    lastException = ex
+                    logging.info("===> Stage Out Failure for file:")
+                    logging.info("======>  %s\n", fileToStage['LFN'])
+                    logging.info("======>  %s\n using this stage out", stageOutStr(stageOut_rfc[0]))
+                    fileToStage = stageoutPolicyReport(fileToStage,stageOut_rfc[0]['phedex-node'],
+                                                      stageOut_rfc[0]['command'], 'LOCAL', 60311)
+                    continue
+                except Exception as ex:
+                    lastException = StageOutFailure("Error during local stage out",
+                                                    error=str(ex))
+                    logging.info("===> Stage Out Failure for file:\n")
+                    logging.info("======>  %s\n", fileToStage['LFN'])
+                    logging.info("======>  %s\n using this stage out", stageOutStr(stageOut_rfc[0]))
+                    fileToStage = stageoutPolicyReport(fileToStage, stageOut_rfc[0]['phedex-node'],
+                                                      stageOut_rfc[0]['command'], 'LOCAL', 60311)
+                    continue
+        
+        else:
+            logging.info("===> Attempting stage outs from override")
             try:
-                pfn = self.fallbackStageOut(lfn, fileToStage['PFN'],
-                                            fallback, fileToStage.get('Checksums'))
+                pfn = self.stageOut(lfn, fileToStage['PFN'], fileToStage.get('Checksums'))
                 fileToStage['PFN'] = pfn
-                fileToStage['PNN'] = fallback['phedex-node']
-                fileToStage['StageOutCommand'] = fallback['command']
-                logging.info("attempting fallback")
+                fileToStage['PNN'] = self.overrideConf['phedex-node']
+                fileToStage['StageOutCommand'] = self.overrideConf['command']
+                logging.info("attempting override stage out")
                 self.completedFiles[fileToStage['LFN']] = fileToStage
                 if lfn in self.failed:
                     del self.failed[lfn]
 
                 logging.info("===> Stage Out Successful: %s", fileToStage)
-                fileToStage = stageoutPolicyReport(fileToStage, None, None, 'FALLBACK', 0)
+                fileToStage = stageoutPolicyReport(fileToStage, None, None, 'OVERRIDE', 0)
                 return fileToStage
             except Exception as ex:
-                fileToStage = stageoutPolicyReport(fileToStage, fallback.get('phedex-node', None),
-                                                   fallback['command'], 'FALLBACK', 60310)
+                fileToStage = stageoutPolicyReport(fileToStage, self.overrideConf['phedex-node'],\
+                    self.overrideConf['command'], 'OVERRIDE', 60310)
                 lastException = ex
-                continue
 
         raise lastException
-
-    def fallbackStageOut(self, lfn, localPfn, fbParams, checksums):
+    
+    
+    def stageOut(self, lfn, localPfn, checksums, stageOut_rfc=None):
         """
-        _fallbackStageOut_
+        _stageOut_
 
-        Given the lfn and parameters for a fallback stage out, invoke it
-
-        parameters should contain:
-
+        Given the lfn and a pair of stage out and corresponding Rucio file catalog, stageOut_rfc, or override configuration invoke the stage out
+        If use override configuration self.overrideConf should contain:
         command - the stage out impl plugin name to be used
         option - the option values to be passed to that command (None is allowed)
         lfn-prefix - the LFN prefix to generate the PFN
         phedex-node - the Name of the PNN to which the file is being xferred
-
         """
-        pfn = "%s%s" % (fbParams['lfn-prefix'], lfn)
-
-        try:
-            impl = retrieveStageOutImpl(fbParams['command'])
-        except Exception as ex:
-            msg = "Unable to retrieve impl for fallback stage out:\n"
-            msg += "Error retrieving StageOutImpl for command named: "
-            msg += "%s\n" % fbParams['command']
-            raise StageOutFailure(msg, Command=fbParams['command'],
-                                  LFN=lfn, ExceptionDetail=str(ex))
-
-        impl.numRetries = self.numberOfRetries
-        impl.retryPause = self.retryPauseTime
-
-        try:
-            impl(fbParams['command'], localPfn, pfn, fbParams.get("option", None), checksums)
-        except Exception as ex:
-            msg = "Failure for fallback stage out:\n"
-            msg += str(ex)
-            raise StageOutFailure(msg, Command=fbParams['command'],
-                                  LFN=lfn, InputPFN=localPfn, TargetPFN=pfn)
-
-        return pfn
-
-    def localStageOut(self, lfn, localPfn, checksums):
-        """
-        _localStageOut_
-
-        Given the lfn and local stage out params, invoke the local stage out
-
-        """
-        command = self.siteCfg.localStageOut['command']
-        options = self.siteCfg.localStageOut.get('option', None)
-        pfn = self.searchTFC(lfn)
-        protocol = self.tfc.preferredProtocol
-        if pfn == None:
-            msg = "Unable to match lfn to pfn: \n  %s" % lfn
-            raise StageOutFailure(msg, LFN=lfn, TFC=str(self.tfc))
-
-        try:
-            impl = retrieveStageOutImpl(command)
-        except Exception as ex:
-            msg = "Unable to retrieve impl for local stage out:\n"
-            msg += "Error retrieving StageOutImpl for command named: %s\n" % (
-                command,)
-            raise StageOutFailure(msg, Command=command,
-                                  LFN=lfn, ExceptionDetail=str(ex))
-        impl.numRetries = self.numberOfRetries
-        impl.retryPause = self.retryPauseTime
-
-        try:
-            impl(protocol, localPfn, pfn, options, checksums)
-        except Exception as ex:
-            msg = "Failure for local stage out:\n"
-            msg += str(ex)
+        if not self.override:
+            command = stageOut_rfc[0]['command']
+            options = stageOut_rfc[0]['option']
+            pfn = searchRFC(stageOut_rfc[1],lfn)
+            protocol = stageOut_rfc[1].preferredProtocol
+            if pfn == None:
+                msg = "Unable to match lfn to pfn: \n  %s" % lfn
+                raise StageOutFailure(msg, LFN=lfn, StageOut=stageOutStr(stageOut_rfc[0]))
             try:
-                import traceback
-                msg += traceback.format_exc()
-            except AttributeError as ex:
-                msg += "Traceback unavailable\n"
-            raise StageOutFailure(msg, Command=command, Protocol=protocol,
-                                  LFN=lfn, InputPFN=localPfn, TargetPFN=pfn)
+                impl = retrieveStageOutImpl(command)
+            except Exception as ex:
+                msg = "Unable to retrieve impl for local stage out:\n"
+                msg += "Error retrieving StageOutImpl for command named: %s\n" % (
+                    command,)
+                raise StageOutFailure(msg, Command=command,
+                                      LFN=lfn, ExceptionDetail=str(ex))
+            impl.numRetries = self.numberOfRetries
+            impl.retryPause = self.retryPauseTime
 
-        return pfn
+            try:
+                if not self.bypassImpl:
+                    impl(protocol, localPfn, pfn, options, checksums)
+            except Exception as ex:
+                msg = "Failure for stage out:\n"
+                msg += str(ex)
+                try:
+                    import traceback
+                    msg += traceback.format_exc()
+                except AttributeError as ex:
+                    msg += "Traceback unavailable\n"
+                raise StageOutFailure(msg, Command=command, Protocol=protocol,
+                                      LFN=lfn, InputPFN=localPfn, TargetPFN=pfn)
+            return pfn
+      
+        else:
+          
+            pfn = "%s%s" % (self.overrideConf['lfn-prefix'], lfn)
 
+            try:
+                impl = retrieveStageOutImpl(self.overrideConf['command'])
+            except Exception as ex:
+                msg = "Unable to retrieve impl for override stage out:\n"
+                msg += "Error retrieving StageOutImpl for command named: "
+                msg += "%s\n" % self.overrideConf['command']
+                raise StageOutFailure(msg, Command=self.overrideConf['command'],
+                                      LFN=lfn, ExceptionDetail=str(ex))
+
+            impl.numRetries = self.numberOfRetries
+            impl.retryPause = self.retryPauseTime
+
+            try:
+                if not self.bypassImpl:
+                    impl(self.overrideConf['command'], localPfn, pfn, self.overrideConf["option"], checksums)
+            except Exception as ex:
+                msg = "Failure for override stage out:\n"
+                msg += str(ex)
+                raise StageOutFailure(msg, Command=self.overrideConf['command'],
+                                      LFN=lfn, InputPFN=localPfn, TargetPFN=pfn)
+
+            return pfn
+    
     def cleanSuccessfulStageOuts(self):
         """
         _cleanSucessfulStageOuts_
@@ -364,40 +384,10 @@ class StageOutMgr(object):
             msg += "Using command implementation: %s\n" % command
             logging.info(msg)
             delManager = DeleteMgr(**self.overrideConf)
+            delManager.bypassImpl = self.bypassImpl
             try:
                 delManager.deletePFN(pfn, lfn, command)
             except StageOutFailure as ex:
                 msg = "Failed to cleanup staged out file after error:"
                 msg += " %s\n%s" % (lfn, str(ex))
                 logging.error(msg)
-
-    def searchTFC(self, lfn):
-        """
-        _searchTFC_
-
-        Search the Trivial File Catalog for the lfn provided,
-        if a match is made, return the matched PFN
-
-        """
-        if self.tfc == None:
-            msg = "Trivial File Catalog not available to match LFN:\n"
-            msg += lfn
-            logging.error(msg)
-            return None
-        if self.tfc.preferredProtocol == None:
-            msg = "Trivial File Catalog does not have a preferred protocol\n"
-            msg += "which prevents local stage out for:\n"
-            msg += lfn
-            logging.error(msg)
-            return None
-
-        pfn = self.tfc.matchLFN(self.tfc.preferredProtocol, lfn)
-        if pfn == None:
-            msg = "Unable to map LFN to PFN:\n"
-            msg += "LFN: %s\n" % lfn
-            return None
-
-        msg = "LFN to PFN match made:\n"
-        msg += "LFN: %s\nPFN: %s\n" % (lfn, pfn)
-        logging.info(msg)
-        return pfn

--- a/test/python/WMCore_t/Misc_t/Runtime_t.py
+++ b/test/python/WMCore_t/Misc_t/Runtime_t.py
@@ -63,7 +63,6 @@ def miniStartup(thisDir=os.getcwd()):
     Or run this in subprocess
 
     """
-
     Bootstrap.setupLogging(thisDir)
     job = Bootstrap.loadJobDefinition()
     task = Bootstrap.loadTask(job)
@@ -151,6 +150,7 @@ class RuntimeTest(unittest.TestCase):
         if not os.path.exists(siteConfigPath):
             os.makedirs(siteConfigPath)
         shutil.copy(os.path.join(self.thisDirPath, 'site-local-config.xml'), siteConfigPath)
+        shutil.copy(os.path.join(self.thisDirPath, 'storage.json'), os.path.join(siteConfigPath,'..'))
         environment = rereco.data.section_('environment')
         environment.CMS_PATH = workloadDir
         environment.SITECONFIG_PATH = os.path.join(workloadDir, 'SITECONF/local')
@@ -304,7 +304,7 @@ class RuntimeTest(unittest.TestCase):
         for primeTask in workload.taskIterator():
             listOfTasks.append(primeTask)
             # Only run primeTasks for now
-
+        
         for task in listOfTasks:
             jobName = task.name()
             taskDir = os.path.join(self.unpackDir, jobName, 'job')
@@ -314,8 +314,9 @@ class RuntimeTest(unittest.TestCase):
             # Scream, run around in panic, blow up machine
             print("About to run jobs")
             print(taskDir)
+            #SITECONFIG_PATH is not available here so set it up so that site config can be loaded in Bootstrap.createInitialReport inside miniStartup
+            os.environ['SITECONFIG_PATH'] = os.path.realpath(os.path.join(taskDir,'../../../basicWorkload/SITECONF/local')) 
             miniStartup(thisDir=taskDir)
-
             # When exiting, go back to where you started
             os.chdir(self.initialDir)
             sys.path.remove(taskDir)
@@ -409,7 +410,7 @@ class RuntimeTest(unittest.TestCase):
         self.createWMBSComponents(workload=workload)
 
         self.unpackComponents(workload=workload)
-
+        
         self.runJobs(workload=workload)
 
         # Check the report
@@ -419,8 +420,8 @@ class RuntimeTest(unittest.TestCase):
         cmsReport = report.data.cmsRun1
 
         # Now validate the report
-        self.assertEqual(report.getSiteName(), {})
-        # self.assertEqual(report.data.hostName, socket.gethostname())
+        self.assertEqual(report.getSiteName(), 'T1_US_FNAL')
+        #self.assertEqual(report.data.hostName, socket.gethostname())
         self.assertTrue(report.data.completed)
 
         # Should have status 0 (emulator job)

--- a/test/python/WMCore_t/Misc_t/site-local-config.xml
+++ b/test/python/WMCore_t/Misc_t/site-local-config.xml
@@ -8,6 +8,11 @@
     <command value="test-copy"/>
     <catalog url="trivialcatalog_file:/uscmst1/prod/sw/cms/SITECONF/T1_US_FNAL/PhEDEx/storage.xml?protocol=dcap"/>
   </local-stage-out>
+  <stage-out>
+    <method volume="FNAL_dCache_EOS" protocol="XRootD" command="xrdcp" option="-p"/>
+    <method volume="FNAL_dCache_EOS" protocol="SRMv2"/>
+    <method volume="FNAL_dCache_EOS" protocol="WebDAV"/>
+  </stage-out>
   <calib-data>
     <frontier-connect>
       <load balance="proxies"/>

--- a/test/python/WMCore_t/Misc_t/storage.json
+++ b/test/python/WMCore_t/Misc_t/storage.json
@@ -1,0 +1,74 @@
+[
+   {  "site": "T1_US_FNAL",
+      "volume": "FNAL_dCache_EOS",
+      "protocols": [
+         {  "protocol": "xrootd",
+            "access": "global-ro",
+            "comment": "xrootd read via site redirector",
+            "prefix": "root://cmsxrootd-site.fnal.gov/"
+         },
+         {  "protocol": "XRootD",
+            "access": "global-rw",
+            "comment": "xrootd write to dCache/EOS endpoint directly",
+            "rules": [
+               {  "lfn": "/+store/temp/user/(.*)",
+                  "pfn": "root://cmseos.fnal.gov//eos/uscms/store/temp/user/$1"
+               },
+               {  "lfn": "/+store/(.*)",
+                  "pfn": "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/$1"
+               }
+            ]
+         },
+         {  "protocol": "SRMv2",
+            "access": "global-rw",
+            "rules": [
+               {  "lfn": "/+store/temp/user/(.*)",
+                  "pfn": "gsiftp://cmseos-gridftp.fnal.gov//eos/uscms/store/temp/user/$1"
+               },
+               {  "lfn": "/+store/(.*)",
+                  "pfn": "srm://cmsdcadisk.fnal.gov:8443/srm/managerv2?SFN=/dcache/uscmsdisk/store/$1"
+               }
+            ]
+         },
+         {   "protocol": "WebDAV",
+             "comment": "Ignoring CRAB stageout to EOS -- all disk dCache",
+             "access":   "global-rw",
+             "prefix":   "davs://cmsdcadisk.fnal.gov:2880/dcache/uscmsdisk"
+         }
+      ],
+      "type": "DISK",
+      "rse": "T1_US_FNAL_Disk",
+      "fts": [ "https://cmsfts3.fnal.gov:8446", "https://fts3-cms.cern.ch:8446" ],
+      "loadtest": true
+   },
+
+   {  "site": "T1_US_FNAL",
+      "volume": "FNAL_MSS",
+      "protocols": [
+         {  "protocol": "SRMv2",
+            "access": "global-rw",
+            "prefix": "srm://cmsdcatape.fnal.gov:8443/srm/managerv2?SFN=/11"
+         },
+         {   "protocol": "WebDAV",
+             "access":   "global-rw",
+             "prefix":   "davs://cmsdcatape.fnal.gov:2880/WAX/11"
+         }
+      ],
+      "type": "TAPE",
+      "rse": "T1_US_FNAL_Tape",
+      "fts": [ "https://cmsfts3.fnal.gov:8446", "https://fts3-cms.cern.ch:8446" ]
+   },
+
+   {  "site": "T1_US_FNAL",
+      "volume": "American_Federation",
+      "protocols": [
+         {  "protocol": "XRootD",
+            "access": "global-ro",
+            "prefix": "root://cmsxrootd.fnal.gov/"
+         }
+      ],
+      "type": "DISK",
+      "rse": null,
+      "fts": []
+   }
+]

--- a/test/python/WMCore_t/Storage_t/DeleteMgr_t.py
+++ b/test/python/WMCore_t/Storage_t/DeleteMgr_t.py
@@ -1,0 +1,67 @@
+'''
+Created on Jun 18, 2009
+
+@author: meloam
+
+Modified on Nov. 7, 2023 by Duong Nguyen
+'''
+import unittest
+import os
+
+from WMCore.WMBase import getTestBase
+#need this otherwise retrieveStageOutImpl fails
+from WMCore.Storage.Registry import retrieveStageOutImpl
+from WMCore.Storage.DeleteMgr import DeleteMgr
+from WMCore.Storage.SiteLocalConfig import SiteLocalConfig, SiteConfigError
+from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig
+
+class DeleteMgrTest(DeleteMgr):
+    def deletePFN(self, pfn, lfn, command):
+        """
+        Delete the given PFN. This method does not include the file removal execution (impl.removeFile). Remember to transfer new changes in deletePFN of DeleteMgr to here if you want to test them 
+        :param pfn: file physical file name
+        :param lfn: file logical file name 
+        :param command: command to be executed
+        """
+        try:
+            impl = retrieveStageOutImpl(command)
+        except Exception as ex:
+            msg = "Unable to retrieve impl for file deletion %s \n" % (pfn)
+            msg += "Error retrieving StageOutImpl for command named: %s\n" % (
+                command,)
+            raise StageOutFailure(msg, Command=command,
+                                  LFN=lfn, ExceptionDetail=str(ex))
+        impl.numRetries = self.numberOfRetries
+        impl.retryPause = self.retryPauseTime
+        
+        try:
+            pass
+        except Exception as ex:
+            self.logger.error("Failed to delete file: %s", pfn)
+            ex.addInfo(Protocol=command, LFN=lfn, TargetPFN=pfn)
+            raise ex
+
+        return pfn 
+
+class DeleteMgrUnitTest(unittest.TestCase):
+
+    def setUp(self):
+        # shut up SiteLocalConfig
+        os.putenv('CMS_PATH', os.getcwd())
+        os.putenv('SITECONFIG_PATH', os.getcwd())
+
+    def testDeleteMgr(self):
+        os.environ['SITECONFIG_PATH'] = '/cvmfs/cms.cern.ch/SITECONF/T1_US_FNAL'
+        deleteMgr = DeleteMgrTest()
+        #keep using 'phedex-node' for overrideParams (to be compatible with the whole DMWM structure?)
+        deleteMgr_override = DeleteMgrTest(**{"command":"gfal2","phedex-node":"T1_US_FNAL_Disk","lfn-prefix":"root://abc/xyz"})
+        fileToDelete = {'LFN':'/store/abc/xyz.root'}
+        deleteMgr(fileToDelete)
+        deleteMgr_override(fileToDelete)
+
+        return
+
+
+if __name__ == "__main__":
+    #import sys;sys.argv = ['', 'Test.testName']
+    unittest.main()

--- a/test/python/WMCore_t/Storage_t/DeleteMgr_t.py
+++ b/test/python/WMCore_t/Storage_t/DeleteMgr_t.py
@@ -8,41 +8,34 @@ Modified on Nov. 7, 2023 by Duong Nguyen
 import unittest
 import os
 
-from WMCore.WMBase import getTestBase
 #need this otherwise retrieveStageOutImpl fails
 from WMCore.Storage.Registry import retrieveStageOutImpl
 from WMCore.Storage.DeleteMgr import DeleteMgr
-from WMCore.Storage.SiteLocalConfig import SiteLocalConfig, SiteConfigError
-from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig
+from WMCore.Storage.StageOutError import StageOutFailure
 
 class DeleteMgrTest(DeleteMgr):
     def deletePFN(self, pfn, lfn, command):
         """
-        Delete the given PFN. This method does not include the file removal execution (impl.removeFile). Remember to transfer new changes in deletePFN of DeleteMgr to here if you want to test them 
-        :param pfn: file physical file name
-        :param lfn: file logical file name 
-        :param command: command to be executed
+        Delete the given PFN
         """
         try:
             impl = retrieveStageOutImpl(command)
         except Exception as ex:
-            msg = "Unable to retrieve impl for file deletion %s \n" % (pfn)
+            msg = "Unable to retrieve impl for file deletion in %s\n" % (pfn)
             msg += "Error retrieving StageOutImpl for command named: %s\n" % (
                 command,)
             raise StageOutFailure(msg, Command=command,
                                   LFN=lfn, ExceptionDetail=str(ex))
         impl.numRetries = self.numberOfRetries
         impl.retryPause = self.retryPauseTime
-        
+
         try:
             pass
         except Exception as ex:
-            self.logger.error("Failed to delete file: %s", pfn)
-            ex.addInfo(Protocol=command, LFN=lfn, TargetPFN=pfn)
+            self.logger.exception("Failed to delete file: %s", pfn)
             raise ex
 
-        return pfn 
-
+        return pfn
 class DeleteMgrUnitTest(unittest.TestCase):
 
     def setUp(self):

--- a/test/python/WMCore_t/Storage_t/SiteLocalConfig_t.py
+++ b/test/python/WMCore_t/Storage_t/SiteLocalConfig_t.py
@@ -29,11 +29,22 @@ class SiteLocalConfigTest(unittest.TestCase):
 
         Verify that the FNAL site config file is parsed correctly.
         """
+        os.environ['SITECONFIG_PATH'] = '/cvmfs/cms.cern.ch/SITECONF/T1_US_FNAL'
         fnalConfigFileName = os.path.join(getTestBase(),
                                           "WMCore_t/Storage_t",
                                           "T1_US_FNAL_SiteLocalConfig.xml")
-
+        #fnalConfigFileName = '/cvmfs/cms.cern.ch/SITECONF/T1_DE_KIT/KIT-HOREKA/JobConfig/site-local-config.xml'
+        #switch between old TFC and new Rucio data catalog by changing the last parameter, need to set SITECONFIG_PATH when this is False 
+        #mySiteConfig = SiteLocalConfig(fnalConfigFileName,False) #set False to use new Rucio storage descriptions with storage.json
+        print(">>>>>>>>>>>",fnalConfigFileName)
         mySiteConfig = SiteLocalConfig(fnalConfigFileName)
+        #print(mySiteConfig.localStageOut)
+        #print(mySiteConfig.fallbackStageOut)
+        #tfcInstance = mySiteConfig.trivialFileCatalog()
+        #print(tfcInstance)
+        #for mapping in ['lfn-to-pfn', 'pfn-to-lfn']:
+        #    for x in tfcInstance[mapping]:
+        #      print(x)
 
         assert mySiteConfig.siteName == "T1_US_FNAL", "Error: Wrong site name."
         assert len(list(mySiteConfig.eventData)) == 1, "Error: Wrong number of event data keys."
@@ -62,29 +73,46 @@ class SiteLocalConfigTest(unittest.TestCase):
             assert frontierProxy in goldenProxies, \
                    "Error: Unknown proxy: %s" % frontierProxy
             goldenProxies.remove(frontierProxy)
-
+        
         assert len(goldenProxies) == 0, \
                 "Error: Missing proxy servers."
-
-        assert mySiteConfig.localStageOut["command"] == "stageout-xrdcp-fnal", \
-               "Error: Wrong stage out command."
-        assert mySiteConfig.localStageOut["catalog"] == "trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/T1_US_FNAL_Disk/PhEDEx/storage.xml?protocol=writexrd", \
-               "Error: TFC catalog is not correct."
-
-        assert mySiteConfig.fallbackStageOut == [], \
-               "Error: Fallback config is incorrect."
+        
+        assert mySiteConfig.stageOuts[0]["command"] == "xrdcp", \
+                "Error: Wrong stage out command."
+        assert mySiteConfig.stageOuts[0]["protocol"] == "XRootD",\
+                "Error: Protocol is not correct."
+        assert mySiteConfig.stageOuts[0]["option"] == "-p",\
+                "Error: option is not correct."
+        '''
+        if mySiteConfig.useTFC:
+            assert mySiteConfig.localStageOut["command"] == "stageout-xrdcp-fnal", \
+                "Error: Wrong stage out command."
+            assert mySiteConfig.localStageOut["catalog"] == "trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/T1_US_FNAL_Disk/PhEDEx/storage.xml?protocol=writexrd", \
+                "Error: TFC catalog is not correct."
+            assert mySiteConfig.fallbackStageOut == [], \
+                "Error: Fallback config is incorrect."
+        else:
+            assert mySiteConfig.stageOuts[0]["command"] == "xrdcp", \
+                "Error: Wrong stage out command."
+            assert mySiteConfig.stageOuts[0]["protocol"] == "XRootD",\
+                "Error: Protocol is not correct."
+            assert mySiteConfig.stageOuts[0]["option"] == "-p",\
+                "Error: option is not correct."
+        '''          
+        #assert False
         return
-
+    #There is no T3_US_Vanderbilt so turn this test off
+    '''
     def testVanderbiltSiteLocalConfig(self):
         """
-        _testFNALSiteLocalConfig_
+        _testVanderbiltSiteLocalConfig_
 
         Verify that the FNAL site config file is parsed correctly.
         """
         vandyConfigFileName = os.path.join(getTestBase(),
                                            "WMCore_t/Storage_t",
                                            "T3_US_Vanderbilt_SiteLocalConfig.xml")
-
+        #still using legacy trivial catalog
         mySiteConfig = SiteLocalConfig(vandyConfigFileName)
 
         assert mySiteConfig.siteName == "T3_US_Vanderbilt", \
@@ -130,8 +158,7 @@ class SiteLocalConfigTest(unittest.TestCase):
         assert mySiteConfig.fallbackStageOut[0]["lfn-prefix"] == "srm://se1.accre.vanderbilt.edu:6288/srm/v2/server?SFN=", \
                "Error: Incorrect fallback LFN prefix."
         return
-
-
+    '''
     def testLoadingConfigFromOverridenEnvVarriable(self):
         """
         test SiteLocalConfig module method loadSiteLocalConfig when loading
@@ -141,11 +168,13 @@ class SiteLocalConfigTest(unittest.TestCase):
         """
         vandyConfigFileName = os.path.join(getTestBase(),
                                            "WMCore_t/Storage_t",
-                                           "T3_US_Vanderbilt_SiteLocalConfig.xml")
+                                           "T1_US_FNAL_SiteLocalConfig.xml")
         os.environ["WMAGENT_SITE_CONFIG_OVERRIDE"] = vandyConfigFileName
+        os.environ["SITECONFIG_PATH"] = "/cvmfs/cms.cern.ch/SITECONF/T1_US_FNAL"
 
+        #still using legacy trivial catalog
         mySiteConfig = loadSiteLocalConfig()
-        self.assertEqual(mySiteConfig.siteName, "T3_US_Vanderbilt",
+        self.assertEqual(mySiteConfig.siteName, "T1_US_FNAL",
                          "Error: Wrong site name.")
 
     # this test requires access to CVMFS
@@ -156,15 +185,16 @@ class SiteLocalConfigTest(unittest.TestCase):
         site-local-config.xml is the same as the one returned by the PhEDEx api.
         """
         os.environ["CMS_PATH"] = "/cvmfs/cms.cern.ch"
-        os.environ["SITECONFIG_PATH"] = "/cvmfs/cms.cern.ch/SITECONF/local"
 
         nodes = ['FIXME']
 
         for d in os.listdir("/cvmfs/cms.cern.ch/SITECONF/"):
             # Only T0_, T1_... folders are needed
             if d[0] == "T":
+                os.environ["SITECONFIG_PATH"] = "/cvmfs/cms.cern.ch/SITECONF/%s" % (d)
                 os.environ['WMAGENT_SITE_CONFIG_OVERRIDE'] ='/cvmfs/cms.cern.ch/SITECONF/%s/JobConfig/site-local-config.xml' % (d)
                 try:
+                    #still using legacy trivial catalog
                     slc = loadSiteLocalConfig()
                 except SiteConfigError as e:
                     print(e.args[0])

--- a/test/python/WMCore_t/Storage_t/SiteLocalConfig_t.py
+++ b/test/python/WMCore_t/Storage_t/SiteLocalConfig_t.py
@@ -33,18 +33,7 @@ class SiteLocalConfigTest(unittest.TestCase):
         fnalConfigFileName = os.path.join(getTestBase(),
                                           "WMCore_t/Storage_t",
                                           "T1_US_FNAL_SiteLocalConfig.xml")
-        #fnalConfigFileName = '/cvmfs/cms.cern.ch/SITECONF/T1_DE_KIT/KIT-HOREKA/JobConfig/site-local-config.xml'
-        #switch between old TFC and new Rucio data catalog by changing the last parameter, need to set SITECONFIG_PATH when this is False 
-        #mySiteConfig = SiteLocalConfig(fnalConfigFileName,False) #set False to use new Rucio storage descriptions with storage.json
-        print(">>>>>>>>>>>",fnalConfigFileName)
         mySiteConfig = SiteLocalConfig(fnalConfigFileName)
-        #print(mySiteConfig.localStageOut)
-        #print(mySiteConfig.fallbackStageOut)
-        #tfcInstance = mySiteConfig.trivialFileCatalog()
-        #print(tfcInstance)
-        #for mapping in ['lfn-to-pfn', 'pfn-to-lfn']:
-        #    for x in tfcInstance[mapping]:
-        #      print(x)
 
         assert mySiteConfig.siteName == "T1_US_FNAL", "Error: Wrong site name."
         assert len(list(mySiteConfig.eventData)) == 1, "Error: Wrong number of event data keys."

--- a/test/python/WMCore_t/Storage_t/StageInMgr_t.py
+++ b/test/python/WMCore_t/Storage_t/StageInMgr_t.py
@@ -4,13 +4,12 @@ Created on Nov. 7, 2023 by Duong Nguyen
 import unittest
 import os
 
-from WMCore.WMBase import getTestBase
-
 from WMCore.Storage.Registry import retrieveStageOutImpl
 from WMCore.Storage.StageOutMgr import searchRFC
 from WMCore.Storage.StageInMgr import StageInMgr
-from WMCore.Storage.SiteLocalConfig import SiteLocalConfig, SiteConfigError
-from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig
+from WMCore.Storage.SiteLocalConfig import stageOutStr
+from WMCore.Storage.StageOutError import StageOutFailure
+
 
 class StageInMgrTest(StageInMgr):
     def stageIn(self, lfn, stageOut_rfc=None):
@@ -35,8 +34,8 @@ class StageInMgrTest(StageInMgr):
             pfn = "%s%s" % (self.overrideConf['lfn-prefix'], lfn)
             protocol = command
         else:
-            if stageOut_rfc is None:
-                msg = "Can not perform stage in for this lfn because of missing information (stageOut_rfc is None): \n %s" % lfn
+            if not stageOut_rfc:
+                msg = "Can not perform stage in for this lfn because of missing information (stageOut_rfc is None or empty): \n %s" % lfn
                 raise StageOutFailure(msg, LFN=lfn)
             pnn = stageOut_rfc[0]['phedex-node']
             command = stageOut_rfc[0]['command']
@@ -65,7 +64,6 @@ class StageInMgrTest(StageInMgr):
             raise StageOutFailure(msg, Command=command, Protocol=protocol,
                                   LFN=lfn, InputPFN=localPfn, TargetPFN=pfn)
         return localPfn 
-
 class StageInMgrUnitTest(unittest.TestCase):
 
     def setUp(self):
@@ -81,7 +79,6 @@ class StageInMgrUnitTest(unittest.TestCase):
         fileToStage = {'LFN':'/store/abc/xyz.root','PFN':''}
         stageInMgr(**fileToStage)
         stageInMgr_override(**fileToStage)
-
         return
 
 

--- a/test/python/WMCore_t/Storage_t/StageInMgr_t.py
+++ b/test/python/WMCore_t/Storage_t/StageInMgr_t.py
@@ -1,0 +1,90 @@
+'''
+Created on Nov. 7, 2023 by Duong Nguyen
+'''
+import unittest
+import os
+
+from WMCore.WMBase import getTestBase
+
+from WMCore.Storage.Registry import retrieveStageOutImpl
+from WMCore.Storage.StageOutMgr import searchRFC
+from WMCore.Storage.StageInMgr import StageInMgr
+from WMCore.Storage.SiteLocalConfig import SiteLocalConfig, SiteConfigError
+from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig
+
+class StageInMgrTest(StageInMgr):
+    def stageIn(self, lfn, stageOut_rfc=None):
+        """
+        Given the lfn and a pair of stage out and corresponding Rucio file catalog, stageOut_rfc, or override configuration invoke the stage in
+        If use override configuration self.overrideConf should contain:
+        command - the stage out impl plugin name to be used
+        option - the option values to be passed to that command (None is allowed)
+        lfn-prefix - the LFN prefix to generate the PFN
+        phedex-node - the Name of the PNN to which the file is being xferred
+        :param lfn: logical file name
+        :param stageOut_rfc: a pair of stage out attributes and corresponding Rucio file catalog
+        """
+        localPfn = os.path.join(os.getcwd(), os.path.basename(lfn))
+        if self.override:
+            pnn = self.overrideConf['phedex-node']
+            command = self.overrideConf['command']
+            options = self.overrideConf['option']
+            if self.overrideConf['lfn-prefix'] is None:
+                msg = "Unable to match lfn to pfn during stage in because override lfn-prefix is None: \n %s" % lfn
+                raise StageOutFailure(msg, LFN=lfn)
+            pfn = "%s%s" % (self.overrideConf['lfn-prefix'], lfn)
+            protocol = command
+        else:
+            if stageOut_rfc is None:
+                msg = "Can not perform stage in for this lfn because of missing information (stageOut_rfc is None): \n %s" % lfn
+                raise StageOutFailure(msg, LFN=lfn)
+            pnn = stageOut_rfc[0]['phedex-node']
+            command = stageOut_rfc[0]['command']
+            options = stageOut_rfc[0]['option']
+            pfn = searchRFC(stageOut_rfc[1],lfn)
+            protocol = stageOut_rfc[1].preferredProtocol
+
+        if pfn == None:
+            msg = "Unable to match lfn to pfn: \n  %s" % lfn
+            raise StageOutFailure(msg, LFN=lfn, StageOut=stageOutStr(stageOut_rfc[0]))
+        try:
+            impl = retrieveStageOutImpl(command,stagein=True)
+        except Exception as ex:
+            msg = "Unable to retrieve impl for local stage in:\n"
+            msg += "Error retrieving StageOutImpl for command named: %s\n" % (command,)
+            raise StageOutFailure(msg, Command=command,
+                                  LFN=lfn, ExceptionDetail=str(ex))
+        impl.numRetries = self.numberOfRetries
+        impl.retryPause = self.retryPauseTime
+
+        try:
+            pass
+        except Exception as ex:
+            msg = "Failure for stage in:\n"
+            msg += str(ex)
+            raise StageOutFailure(msg, Command=command, Protocol=protocol,
+                                  LFN=lfn, InputPFN=localPfn, TargetPFN=pfn)
+        return localPfn 
+
+class StageInMgrUnitTest(unittest.TestCase):
+
+    def setUp(self):
+        # shut up SiteLocalConfig
+        os.putenv('CMS_PATH', os.getcwd())
+        os.putenv('SITECONFIG_PATH', os.getcwd())
+
+    def testStageInMgr(self):
+        os.environ['SITECONFIG_PATH'] = '/cvmfs/cms.cern.ch/SITECONF/T1_US_FNAL'
+        stageInMgr = StageInMgrTest()
+         #keep using 'phedex-node' for overrideParams (to be compatible with the whole DMWM structure?)
+        stageInMgr_override = StageInMgrTest(**{"command":"gfal2","phedex-node":"T1_US_FNAL_Disk","lfn-prefix":"root://abc/xyz"})
+        fileToStage = {'LFN':'/store/abc/xyz.root','PFN':''}
+        stageInMgr(**fileToStage)
+        stageInMgr_override(**fileToStage)
+
+        return
+
+
+if __name__ == "__main__":
+    #import sys;sys.argv = ['', 'Test.testName']
+    unittest.main()

--- a/test/python/WMCore_t/Storage_t/StageOutMgr_t.py
+++ b/test/python/WMCore_t/Storage_t/StageOutMgr_t.py
@@ -2,11 +2,18 @@
 Created on Jun 18, 2009
 
 @author: meloam
+
+Modified on Nov. 7, 2023 by Duong Nguyen
 '''
 import unittest
 import os
 
-import WMCore.Storage.StageOutMgr as StageOutMgr
+from WMCore.WMBase import getTestBase
+
+from WMCore.Storage.StageOutMgr import StageOutMgr
+from WMCore.Storage.SiteLocalConfig import SiteLocalConfig, SiteConfigError
+from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig
+
 
 class StageOutMgrTest(unittest.TestCase):
 
@@ -15,8 +22,19 @@ class StageOutMgrTest(unittest.TestCase):
         os.putenv('CMS_PATH', os.getcwd())
         os.putenv('SITECONFIG_PATH', os.getcwd())
 
-    def testName(self):
-        pass
+    def testStageOutMgr(self):
+        os.environ['SITECONFIG_PATH'] = '/cvmfs/cms.cern.ch/SITECONF/T1_US_FNAL'
+        stageOutMgr = StageOutMgr()
+        stageOutMgr.bypassImpl = True
+        stageOutMgr_override = StageOutMgr(**{"command":"gfal2","phedex-node":"T1_US_FNAL_Disk","lfn-prefix":"root://abc/xyz"})
+        stageOutMgr_override.bypassImpl = True
+        fileToStage = {'LFN':'/store/abc/xyz.root','PFN':''}
+        stageOutMgr(fileToStage)
+        stageOutMgr.cleanSuccessfulStageOuts()
+        stageOutMgr_override(fileToStage)
+        stageOutMgr_override.cleanSuccessfulStageOuts()
+
+        return
 
 
 if __name__ == "__main__":

--- a/test/python/WMCore_t/Storage_t/StageOutMgr_t.py
+++ b/test/python/WMCore_t/Storage_t/StageOutMgr_t.py
@@ -23,6 +23,10 @@ class StageOutMgrTest(unittest.TestCase):
         os.putenv('SITECONFIG_PATH', os.getcwd())
 
     def testStageOutMgr(self):
+        configFileName = os.path.join(getTestBase(),
+                                           "WMCore_t/Storage_t/T1_DE_KIT/JobConfig",
+                                           "site-local-config.xml")
+        os.environ["WMAGENT_SITE_CONFIG_OVERRIDE"] = configFileName
         os.environ['SITECONFIG_PATH'] = os.path.join(getTestBase(),
                                           "WMCore_t/Storage_t",
                                           "T1_DE_KIT")
@@ -61,6 +65,10 @@ class StageOutMgrTest(unittest.TestCase):
         stageOutMgr.cleanSuccessfulStageOuts()
         
         #test subsite
+        configFileName = os.path.join(getTestBase(),
+                                           "WMCore_t/Storage_t/T1_DE_KIT/KIT-T3/JobConfig",
+                                           "site-local-config.xml")
+        os.environ["WMAGENT_SITE_CONFIG_OVERRIDE"] = configFileName
         os.environ['SITECONFIG_PATH'] = os.path.join(getTestBase(),
                                           "WMCore_t/Storage_t",
                                           "T1_DE_KIT/KIT-T3")

--- a/test/python/WMCore_t/Storage_t/StageOutMgr_t.py
+++ b/test/python/WMCore_t/Storage_t/StageOutMgr_t.py
@@ -7,15 +7,121 @@ Modified on Nov. 7, 2023 by Duong Nguyen
 '''
 import unittest
 import os
+from future.utils import viewitems
+
+import logging
 
 from WMCore.WMBase import getTestBase
 
-from WMCore.Storage.StageOutMgr import StageOutMgr
+from WMCore.Storage.StageOutMgr import StageOutMgr,searchRFC
 from WMCore.Storage.SiteLocalConfig import SiteLocalConfig, SiteConfigError
 from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig
+from WMCore_t.Storage_t.DeleteMgr_t import DeleteMgrTest
+from WMCore.Storage.Registry import retrieveStageOutImpl
 
+class StageOutMgrTest(StageOutMgr):
+    def stageOut(self, lfn, localPfn, checksums, stageOut_rfc=None):
+        """
+        Given the lfn and a pair of stage out and corresponding Rucio file catalog, stageOut_rfc, or override configuration invoke the stage out
+        If use override configuration self.overrideConf should contain:
+        command - the stage out impl plugin name to be used
+        option - the option values to be passed to that command (None is allowed)
+        lfn-prefix - the LFN prefix to generate the PFN
+        phedex-node - the Name of the PNN to which the file is being xferred
+        :param lfn: logical file name 
+        :param localPfn: physical file name of file at local location (source) that will be staged out to another location (destination)
+        :param checksums: check sum of file
+        :param stageOut_rfc: a pair of stage out and corresponding Rucio file catalog
+        """
+        if not self.override:
+            if stageOut_rfc is None:
+                msg = "Can not perform stage out for this lfn because of missing stage out information (stageOut_rfc is None): \n %s" % lfn
+                raise StageOutFailure(msg, LFN=lfn)
+            command = stageOut_rfc[0]['command']
+            options = stageOut_rfc[0]['option']
+            pfn = searchRFC(stageOut_rfc[1],lfn)
+            protocol = stageOut_rfc[1].preferredProtocol
+            if pfn == None:
+                msg = "Unable to match lfn to pfn: \n  %s" % lfn
+                raise StageOutFailure(msg, LFN=lfn, StageOut=stageOutStr(stageOut_rfc[0]))
+            try:
+                impl = retrieveStageOutImpl(command)
+            except Exception as ex:
+                msg = "Unable to retrieve impl for local stage out:\n"
+                msg += "Error retrieving StageOutImpl for command named: %s\n" % (
+                    command,)
+                raise StageOutFailure(msg, Command=command,
+                                      LFN=lfn, ExceptionDetail=str(ex))
+            impl.numRetries = self.numberOfRetries
+            impl.retryPause = self.retryPauseTime
 
-class StageOutMgrTest(unittest.TestCase):
+            try:
+                pass
+            except Exception as ex:
+                msg = "Failure for stage out:\n"
+                msg += str(ex)
+                try:
+                    import traceback
+                    msg += traceback.format_exc()
+                except AttributeError as ex:
+                    msg += "Traceback unavailable\n"
+                raise StageOutFailure(msg, Command=command, Protocol=protocol,
+                                      LFN=lfn, InputPFN=localPfn, TargetPFN=pfn)
+            return pfn
+      
+        else:
+            if self.overrideConf['lfn-prefix'] is None:
+                msg = "Unable to match lfn to pfn during stage out because override lfn-prefix is None: \n %s" % lfn
+                raise StageOutFailure(msg, LFN=lfn)
+ 
+            pfn = "%s%s" % (self.overrideConf['lfn-prefix'], lfn)
+
+            try:
+                impl = retrieveStageOutImpl(self.overrideConf['command'])
+            except Exception as ex:
+                msg = "Unable to retrieve impl for override stage out:\n"
+                msg += "Error retrieving StageOutImpl for command named: "
+                msg += "%s\n" % self.overrideConf['command']
+                raise StageOutFailure(msg, Command=self.overrideConf['command'],
+                                      LFN=lfn, ExceptionDetail=str(ex))
+
+            impl.numRetries = self.numberOfRetries
+            impl.retryPause = self.retryPauseTime
+
+            try:
+                pass
+            except Exception as ex:
+                msg = "Failure for override stage out:\n"
+                msg += str(ex)
+                raise StageOutFailure(msg, Command=self.overrideConf['command'],
+                                      LFN=lfn, InputPFN=localPfn, TargetPFN=pfn)
+
+            return pfn
+
+    def cleanSuccessfulStageOuts(self):
+        """
+        In the event of a failed stage out, this method can be called to cleanup the
+        files that may have previously been staged out so that the job ends in a clear state
+        of failure, rather than a partial success
+        """
+        
+        for lfn, fileInfo in viewitems(self.completedFiles):
+            pfn = fileInfo['PFN']
+            command = fileInfo['StageOutCommand']
+            msg = "Cleaning out file: %s\n" % lfn
+            msg += "Removing PFN: %s" % pfn
+            msg += "Using command implementation: %s\n" % command
+            logging.info(msg)
+            #Need to use DeleteMgrTest so that the actual deletion will not proceed
+            delManager = DeleteMgrTest(**self.overrideConf)
+            try:
+                delManager.deletePFN(pfn, lfn, command)
+            except StageOutFailure as ex:
+                msg = "Failed to cleanup staged out file after error:"
+                msg += " %s\n%s" % (lfn, str(ex))
+                logging.error(msg)
+
+class StageOutMgrUnitTest(unittest.TestCase):
 
     def setUp(self):
         # shut up SiteLocalConfig
@@ -31,16 +137,14 @@ class StageOutMgrTest(unittest.TestCase):
                                           "WMCore_t/Storage_t",
                                           "T1_DE_KIT")
         os.system('cp $SITECONFIG_PATH/JobConfig/site-local-config-testStageOut-T1_DE_KIT.xml $SITECONFIG_PATH/JobConfig/site-local-config.xml')
-        stageOutMgr = StageOutMgr()
-        stageOutMgr.bypassImpl = True
+        stageOutMgr = StageOutMgrTest()
         fileToStage = {'LFN':'/store/abc/xyz.root','PFN':''}
         stageOutMgr(fileToStage)
         assert fileToStage['PFN']=="davs://cmswebdav-kit-disk.gridka.de:2880/pnfs/gridka.de/cms/disk-only/store/abc/xyz.root"
         stageOutMgr.cleanSuccessfulStageOuts()
         
         #test override
-        stageOutMgr_override = StageOutMgr(**{"command":"gfal2","phedex-node":"T1_US_FNAL_Disk","lfn-prefix":"root://abc/xyz"})
-        stageOutMgr_override.bypassImpl = True
+        stageOutMgr_override = StageOutMgrTest(**{"command":"gfal2","phedex-node":"T1_US_FNAL_Disk","lfn-prefix":"root://abc/xyz"})
         fileToStage = {'LFN':'/store/abc/xyz.root','PFN':''}
         stageOutMgr_override(fileToStage)
         assert fileToStage['PFN']=="root://abc/xyz/store/abc/xyz.root"
@@ -48,8 +152,7 @@ class StageOutMgrTest(unittest.TestCase):
         
         #test chained rules
         os.system('cp $SITECONFIG_PATH/JobConfig/site-local-config-testStageOut-chainedRules.xml $SITECONFIG_PATH/JobConfig/site-local-config.xml')
-        stageOutMgr = StageOutMgr()
-        stageOutMgr.bypassImpl = True
+        stageOutMgr = StageOutMgrTest()
         fileToStage = {'LFN':'/store/abc/xyz.root','PFN':''}
         stageOutMgr(fileToStage)
         assert fileToStage['PFN']=="davs://cmswebdav-kit-tape.gridka.de:2880/pnfs/gridka.de/cms/tape/store/abc/xyz.root"
@@ -57,8 +160,7 @@ class StageOutMgrTest(unittest.TestCase):
         
         #test stage-out to another site, T2_DE_DESY
         os.system('cp $SITECONFIG_PATH/JobConfig/site-local-config-testStageOut-T2_DE_DESY.xml $SITECONFIG_PATH/JobConfig/site-local-config.xml')
-        stageOutMgr = StageOutMgr()
-        stageOutMgr.bypassImpl = True
+        stageOutMgr = StageOutMgrTest()
         fileToStage = {'LFN':'/store/abc/xyz.root','PFN':''}
         stageOutMgr(fileToStage)
         assert fileToStage['PFN']=="davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2/store/abc/xyz.root"
@@ -73,8 +175,7 @@ class StageOutMgrTest(unittest.TestCase):
                                           "WMCore_t/Storage_t",
                                           "T1_DE_KIT/KIT-T3")
         os.system('cp $SITECONFIG_PATH/JobConfig/site-local-config-testStageOut-T1_DE_KIT.xml $SITECONFIG_PATH/JobConfig/site-local-config.xml')
-        stageOutMgr = StageOutMgr()
-        stageOutMgr.bypassImpl = True
+        stageOutMgr = StageOutMgrTest()
         fileToStage = {'LFN':'/store/abc/xyz.root','PFN':''}
         stageOutMgr(fileToStage)
         assert fileToStage['PFN']=="davs://cmswebdav-kit-disk.gridka.de:2880/pnfs/gridka.de/cms/disk-only/store/abc/xyz.root"
@@ -82,8 +183,7 @@ class StageOutMgrTest(unittest.TestCase):
         
         #test subsite with stage-out to another site T2_DE_DESY
         os.system('cp $SITECONFIG_PATH/JobConfig/site-local-config-testStageOut-T2_DE_DESY.xml $SITECONFIG_PATH/JobConfig/site-local-config.xml')
-        stageOutMgr = StageOutMgr()
-        stageOutMgr.bypassImpl = True
+        stageOutMgr = StageOutMgrTest()
         fileToStage = {'LFN':'/store/abc/xyz.root','PFN':''}
         stageOutMgr(fileToStage)
         assert fileToStage['PFN']=="davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2/store/abc/xyz.root"

--- a/test/python/WMCore_t/Storage_t/StageOutMgr_t.py
+++ b/test/python/WMCore_t/Storage_t/StageOutMgr_t.py
@@ -7,17 +7,17 @@ Modified on Nov. 7, 2023 by Duong Nguyen
 '''
 import unittest
 import os
+import logging
 from future.utils import viewitems
 
-import logging
 
-from WMCore.WMBase import getTestBase
-
-from WMCore.Storage.StageOutMgr import StageOutMgr,searchRFC
-from WMCore.Storage.SiteLocalConfig import SiteLocalConfig, SiteConfigError
-from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig
 from WMCore_t.Storage_t.DeleteMgr_t import DeleteMgrTest
+from WMCore.WMBase import getTestBase
+from WMCore.Storage.StageOutMgr import StageOutMgr,searchRFC
+from WMCore.Storage.SiteLocalConfig import stageOutStr
+from WMCore.Storage.StageOutError import StageOutFailure
 from WMCore.Storage.Registry import retrieveStageOutImpl
+
 
 class StageOutMgrTest(StageOutMgr):
     def stageOut(self, lfn, localPfn, checksums, stageOut_rfc=None):
@@ -33,9 +33,10 @@ class StageOutMgrTest(StageOutMgr):
         :param checksums: check sum of file
         :param stageOut_rfc: a pair of stage out and corresponding Rucio file catalog
         """
+        
         if not self.override:
-            if stageOut_rfc is None:
-                msg = "Can not perform stage out for this lfn because of missing stage out information (stageOut_rfc is None): \n %s" % lfn
+            if not stageOut_rfc:
+                msg = "Can not perform stage out for this lfn because of missing stage out information (stageOut_rfc is None or empty): \n %s" % lfn
                 raise StageOutFailure(msg, LFN=lfn)
             command = stageOut_rfc[0]['command']
             options = stageOut_rfc[0]['option']
@@ -63,7 +64,7 @@ class StageOutMgrTest(StageOutMgr):
                 try:
                     import traceback
                     msg += traceback.format_exc()
-                except AttributeError as ex:
+                except AttributeError:
                     msg += "Traceback unavailable\n"
                 raise StageOutFailure(msg, Command=command, Protocol=protocol,
                                       LFN=lfn, InputPFN=localPfn, TargetPFN=pfn)
@@ -188,6 +189,7 @@ class StageOutMgrUnitTest(unittest.TestCase):
         stageOutMgr(fileToStage)
         assert fileToStage['PFN']=="davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2/store/abc/xyz.root"
         stageOutMgr.cleanSuccessfulStageOuts()
+
         return
 
 if __name__ == "__main__":

--- a/test/python/WMCore_t/Storage_t/StageOutMgr_t.py
+++ b/test/python/WMCore_t/Storage_t/StageOutMgr_t.py
@@ -23,19 +23,64 @@ class StageOutMgrTest(unittest.TestCase):
         os.putenv('SITECONFIG_PATH', os.getcwd())
 
     def testStageOutMgr(self):
-        os.environ['SITECONFIG_PATH'] = '/cvmfs/cms.cern.ch/SITECONF/T1_US_FNAL'
+        os.environ['SITECONFIG_PATH'] = os.path.join(getTestBase(),
+                                          "WMCore_t/Storage_t",
+                                          "T1_DE_KIT")
+        os.system('cp $SITECONFIG_PATH/JobConfig/site-local-config-testStageOut-T1_DE_KIT.xml $SITECONFIG_PATH/JobConfig/site-local-config.xml')
         stageOutMgr = StageOutMgr()
         stageOutMgr.bypassImpl = True
+        fileToStage = {'LFN':'/store/abc/xyz.root','PFN':''}
+        stageOutMgr(fileToStage)
+        assert fileToStage['PFN']=="davs://cmswebdav-kit-disk.gridka.de:2880/pnfs/gridka.de/cms/disk-only/store/abc/xyz.root"
+        stageOutMgr.cleanSuccessfulStageOuts()
+        
+        #test override
         stageOutMgr_override = StageOutMgr(**{"command":"gfal2","phedex-node":"T1_US_FNAL_Disk","lfn-prefix":"root://abc/xyz"})
         stageOutMgr_override.bypassImpl = True
         fileToStage = {'LFN':'/store/abc/xyz.root','PFN':''}
-        stageOutMgr(fileToStage)
-        stageOutMgr.cleanSuccessfulStageOuts()
         stageOutMgr_override(fileToStage)
+        assert fileToStage['PFN']=="root://abc/xyz/store/abc/xyz.root"
         stageOutMgr_override.cleanSuccessfulStageOuts()
-
+        
+        #test chained rules
+        os.system('cp $SITECONFIG_PATH/JobConfig/site-local-config-testStageOut-chainedRules.xml $SITECONFIG_PATH/JobConfig/site-local-config.xml')
+        stageOutMgr = StageOutMgr()
+        stageOutMgr.bypassImpl = True
+        fileToStage = {'LFN':'/store/abc/xyz.root','PFN':''}
+        stageOutMgr(fileToStage)
+        assert fileToStage['PFN']=="davs://cmswebdav-kit-tape.gridka.de:2880/pnfs/gridka.de/cms/tape/store/abc/xyz.root"
+        stageOutMgr.cleanSuccessfulStageOuts()
+        
+        #test stage-out to another site, T2_DE_DESY
+        os.system('cp $SITECONFIG_PATH/JobConfig/site-local-config-testStageOut-T2_DE_DESY.xml $SITECONFIG_PATH/JobConfig/site-local-config.xml')
+        stageOutMgr = StageOutMgr()
+        stageOutMgr.bypassImpl = True
+        fileToStage = {'LFN':'/store/abc/xyz.root','PFN':''}
+        stageOutMgr(fileToStage)
+        assert fileToStage['PFN']=="davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2/store/abc/xyz.root"
+        stageOutMgr.cleanSuccessfulStageOuts()
+        
+        #test subsite
+        os.environ['SITECONFIG_PATH'] = os.path.join(getTestBase(),
+                                          "WMCore_t/Storage_t",
+                                          "T1_DE_KIT/KIT-T3")
+        os.system('cp $SITECONFIG_PATH/JobConfig/site-local-config-testStageOut-T1_DE_KIT.xml $SITECONFIG_PATH/JobConfig/site-local-config.xml')
+        stageOutMgr = StageOutMgr()
+        stageOutMgr.bypassImpl = True
+        fileToStage = {'LFN':'/store/abc/xyz.root','PFN':''}
+        stageOutMgr(fileToStage)
+        assert fileToStage['PFN']=="davs://cmswebdav-kit-disk.gridka.de:2880/pnfs/gridka.de/cms/disk-only/store/abc/xyz.root"
+        stageOutMgr.cleanSuccessfulStageOuts()
+        
+        #test subsite with stage-out to another site T2_DE_DESY
+        os.system('cp $SITECONFIG_PATH/JobConfig/site-local-config-testStageOut-T2_DE_DESY.xml $SITECONFIG_PATH/JobConfig/site-local-config.xml')
+        stageOutMgr = StageOutMgr()
+        stageOutMgr.bypassImpl = True
+        fileToStage = {'LFN':'/store/abc/xyz.root','PFN':''}
+        stageOutMgr(fileToStage)
+        assert fileToStage['PFN']=="davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2/store/abc/xyz.root"
+        stageOutMgr.cleanSuccessfulStageOuts()
         return
-
 
 if __name__ == "__main__":
     #import sys;sys.argv = ['', 'Test.testName']

--- a/test/python/WMCore_t/Storage_t/T1_DE_KIT/JobConfig/site-local-config-testStageOut-T1_DE_KIT.xml
+++ b/test/python/WMCore_t/Storage_t/T1_DE_KIT/JobConfig/site-local-config-testStageOut-T1_DE_KIT.xml
@@ -1,0 +1,55 @@
+<site-local-config>
+	<site name="T1_DE_KIT">
+		<event-data>
+			<catalog url="trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/local/PhEDEx/storage_disk.xml?protocol=xrootd"/>
+			<catalog url="trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/local/PhEDEx/storage_disk.xml?protocol=remote-xrootd"/>
+		</event-data>
+
+		<data-access>
+			<catalog volume="KIT_dCache" protocol="XRootD"/>
+			<catalog site="T1_IT_CNAF" volume="Eurasian_Federation" protocol="XRootD"/>
+		</data-access>
+
+		<source-config>
+			<cache-hint value="lazy-download" />
+			<read-hint value="read-ahead-buffered" />
+			<timeout-in-seconds value="10000" />
+			<statistics-destination name="cms-udpmon-collector.cern.ch:9331" />
+		</source-config>
+
+		<local-stage-out>
+			<command value="gfal2"/>
+			<catalog url="trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/local/PhEDEx/storage_disk.xml?protocol=davs"/>
+			<se-name value="cmswebdav-kit-disk.gridka.de"/>
+			<phedex-node value="T1_DE_KIT_Disk"/>
+		</local-stage-out>
+
+		<fallback-stage-out>
+			<command value="gfal2"/>
+			<option value=""/>
+			<lfn-prefix value="davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2"/>
+			<se-name value="dcache-se-cms.desy.de"/>
+			<phedex-node value="T2_DE_DESY"/>
+		</fallback-stage-out>
+
+		<stage-out>
+        <method volume="KIT_dCache" protocol="WebDAV"/>
+		</stage-out>
+
+		<calib-data>
+			<frontier-connect>
+				<load balance="proxies"/>
+				<proxy url="http://frontier-sq1.gridka.de:3128"/>
+				<proxy url="http://frontier-sq2.gridka.de:3128"/>
+				<proxy url="http://frontier-sq3.gridka.de:3128"/>
+				<backupproxy url="http://cmsbpfrontier.cern.ch:3128"/>
+				<backupproxy url="http://cmsbproxy.fnal.gov:3128"/>
+				<prefer ipfamily="6"/>
+				<server url="http://cmsfrontier.cern.ch:8000/FrontierInt"/>
+				<server url="http://cmsfrontier1.cern.ch:8000/FrontierInt"/>
+				<server url="http://cmsfrontier2.cern.ch:8000/FrontierInt"/>
+				<server url="http://cmsfrontier3.cern.ch:8000/FrontierInt"/>
+			</frontier-connect>
+		</calib-data>
+	</site>
+</site-local-config>

--- a/test/python/WMCore_t/Storage_t/T1_DE_KIT/JobConfig/site-local-config-testStageOut-T2_DE_DESY.xml
+++ b/test/python/WMCore_t/Storage_t/T1_DE_KIT/JobConfig/site-local-config-testStageOut-T2_DE_DESY.xml
@@ -1,0 +1,55 @@
+<site-local-config>
+	<site name="T1_DE_KIT">
+		<event-data>
+			<catalog url="trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/local/PhEDEx/storage_disk.xml?protocol=xrootd"/>
+			<catalog url="trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/local/PhEDEx/storage_disk.xml?protocol=remote-xrootd"/>
+		</event-data>
+
+		<data-access>
+			<catalog volume="KIT_dCache" protocol="XRootD"/>
+			<catalog site="T1_IT_CNAF" volume="Eurasian_Federation" protocol="XRootD"/>
+		</data-access>
+
+		<source-config>
+			<cache-hint value="lazy-download" />
+			<read-hint value="read-ahead-buffered" />
+			<timeout-in-seconds value="10000" />
+			<statistics-destination name="cms-udpmon-collector.cern.ch:9331" />
+		</source-config>
+
+		<local-stage-out>
+			<command value="gfal2"/>
+			<catalog url="trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/local/PhEDEx/storage_disk.xml?protocol=davs"/>
+			<se-name value="cmswebdav-kit-disk.gridka.de"/>
+			<phedex-node value="T1_DE_KIT_Disk"/>
+		</local-stage-out>
+
+		<fallback-stage-out>
+			<command value="gfal2"/>
+			<option value=""/>
+			<lfn-prefix value="davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2"/>
+			<se-name value="dcache-se-cms.desy.de"/>
+			<phedex-node value="T2_DE_DESY"/>
+		</fallback-stage-out>
+
+		<stage-out>
+        <method site="T2_DE_DESY" volume="DESY_dCache" protocol="WebDAV"/>
+		</stage-out>
+
+		<calib-data>
+			<frontier-connect>
+				<load balance="proxies"/>
+				<proxy url="http://frontier-sq1.gridka.de:3128"/>
+				<proxy url="http://frontier-sq2.gridka.de:3128"/>
+				<proxy url="http://frontier-sq3.gridka.de:3128"/>
+				<backupproxy url="http://cmsbpfrontier.cern.ch:3128"/>
+				<backupproxy url="http://cmsbproxy.fnal.gov:3128"/>
+				<prefer ipfamily="6"/>
+				<server url="http://cmsfrontier.cern.ch:8000/FrontierInt"/>
+				<server url="http://cmsfrontier1.cern.ch:8000/FrontierInt"/>
+				<server url="http://cmsfrontier2.cern.ch:8000/FrontierInt"/>
+				<server url="http://cmsfrontier3.cern.ch:8000/FrontierInt"/>
+			</frontier-connect>
+		</calib-data>
+	</site>
+</site-local-config>

--- a/test/python/WMCore_t/Storage_t/T1_DE_KIT/JobConfig/site-local-config-testStageOut-chainedRules.xml
+++ b/test/python/WMCore_t/Storage_t/T1_DE_KIT/JobConfig/site-local-config-testStageOut-chainedRules.xml
@@ -1,0 +1,55 @@
+<site-local-config>
+	<site name="T1_DE_KIT">
+		<event-data>
+			<catalog url="trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/local/PhEDEx/storage_disk.xml?protocol=xrootd"/>
+			<catalog url="trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/local/PhEDEx/storage_disk.xml?protocol=remote-xrootd"/>
+		</event-data>
+
+		<data-access>
+			<catalog volume="KIT_dCache" protocol="XRootD"/>
+			<catalog site="T1_IT_CNAF" volume="Eurasian_Federation" protocol="XRootD"/>
+		</data-access>
+
+		<source-config>
+			<cache-hint value="lazy-download" />
+			<read-hint value="read-ahead-buffered" />
+			<timeout-in-seconds value="10000" />
+			<statistics-destination name="cms-udpmon-collector.cern.ch:9331" />
+		</source-config>
+
+		<local-stage-out>
+			<command value="gfal2"/>
+			<catalog url="trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/local/PhEDEx/storage_disk.xml?protocol=davs"/>
+			<se-name value="cmswebdav-kit-disk.gridka.de"/>
+			<phedex-node value="T1_DE_KIT_Disk"/>
+		</local-stage-out>
+
+		<fallback-stage-out>
+			<command value="gfal2"/>
+			<option value=""/>
+			<lfn-prefix value="davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2"/>
+			<se-name value="dcache-se-cms.desy.de"/>
+			<phedex-node value="T2_DE_DESY"/>
+		</fallback-stage-out>
+
+		<stage-out>
+			<method volume="KIT_MSS" protocol="WebDAV"/>
+		</stage-out>
+
+		<calib-data>
+			<frontier-connect>
+				<load balance="proxies"/>
+				<proxy url="http://frontier-sq1.gridka.de:3128"/>
+				<proxy url="http://frontier-sq2.gridka.de:3128"/>
+				<proxy url="http://frontier-sq3.gridka.de:3128"/>
+				<backupproxy url="http://cmsbpfrontier.cern.ch:3128"/>
+				<backupproxy url="http://cmsbproxy.fnal.gov:3128"/>
+				<prefer ipfamily="6"/>
+				<server url="http://cmsfrontier.cern.ch:8000/FrontierInt"/>
+				<server url="http://cmsfrontier1.cern.ch:8000/FrontierInt"/>
+				<server url="http://cmsfrontier2.cern.ch:8000/FrontierInt"/>
+				<server url="http://cmsfrontier3.cern.ch:8000/FrontierInt"/>
+			</frontier-connect>
+		</calib-data>
+	</site>
+</site-local-config>

--- a/test/python/WMCore_t/Storage_t/T1_DE_KIT/KIT-T3/JobConfig/site-local-config-testStageOut-T1_DE_KIT.xml
+++ b/test/python/WMCore_t/Storage_t/T1_DE_KIT/KIT-T3/JobConfig/site-local-config-testStageOut-T1_DE_KIT.xml
@@ -1,0 +1,56 @@
+<site-local-config>
+	<site name="T1_DE_KIT">
+		<subsite name="KIT-T3"/>
+		<event-data>
+			<catalog url="trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/local/JobConfig/storage_disk.xml?protocol=xrootd"/>
+			<catalog url="trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/local/JobConfig/storage_disk.xml?protocol=remote-xrootd"/>
+		</event-data>
+
+		<data-access>
+			<catalog volume="KIT_dCache" protocol="XRootD"/>
+			<catalog site="T1_IT_CNAF" volume="Eurasian_Federation" protocol="XRootD"/>
+		</data-access>
+
+		<source-config>
+			<cache-hint value="lazy-download" />
+			<read-hint value="read-ahead-buffered" />
+			<timeout-in-seconds value="10000" />
+			<statistics-destination name="cms-udpmon-collector.cern.ch:9331" />
+		</source-config>
+
+		<local-stage-out>
+			<command value="gfal2"/>
+			<catalog url="trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/local/JobConfig/storage_disk.xml?protocol=davs"/>
+			<se-name value="cmswebdav-kit-disk.gridka.de"/>
+			<phedex-node value="T1_DE_KIT_Disk"/>
+		</local-stage-out>
+
+		<fallback-stage-out>
+			<command value="gfal2"/>
+			<option value=""/>
+			<lfn-prefix value="davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2"/>
+			<se-name value="dcache-se-cms.desy.de"/>
+			<phedex-node value="T2_DE_DESY"/>
+		</fallback-stage-out>
+
+		<stage-out>
+			<method volume="KIT_dCache" protocol="WebDAV"/>
+		</stage-out>
+
+		<calib-data>
+			<frontier-connect>
+				<load balance="proxies"/>
+				<proxy url="http://frontier-sq1.gridka.de:3128"/>
+				<proxy url="http://frontier-sq2.gridka.de:3128"/>
+				<proxy url="http://frontier-sq3.gridka.de:3128"/>
+				<backupproxy url="http://cmsbpfrontier.cern.ch:3128"/>
+				<backupproxy url="http://cmsbproxy.fnal.gov:3128"/>
+				<prefer ipfamily="6"/>
+				<server url="http://cmsfrontier.cern.ch:8000/FrontierInt"/>
+				<server url="http://cmsfrontier1.cern.ch:8000/FrontierInt"/>
+				<server url="http://cmsfrontier2.cern.ch:8000/FrontierInt"/>
+				<server url="http://cmsfrontier3.cern.ch:8000/FrontierInt"/>
+			</frontier-connect>
+		</calib-data>
+	</site>
+</site-local-config>

--- a/test/python/WMCore_t/Storage_t/T1_DE_KIT/KIT-T3/JobConfig/site-local-config-testStageOut-T2_DE_DESY.xml
+++ b/test/python/WMCore_t/Storage_t/T1_DE_KIT/KIT-T3/JobConfig/site-local-config-testStageOut-T2_DE_DESY.xml
@@ -1,0 +1,56 @@
+<site-local-config>
+	<site name="T1_DE_KIT">
+		<subsite name="KIT-T3"/>
+		<event-data>
+			<catalog url="trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/local/JobConfig/storage_disk.xml?protocol=xrootd"/>
+			<catalog url="trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/local/JobConfig/storage_disk.xml?protocol=remote-xrootd"/>
+		</event-data>
+
+		<data-access>
+			<catalog volume="KIT_dCache" protocol="XRootD"/>
+			<catalog site="T1_IT_CNAF" volume="Eurasian_Federation" protocol="XRootD"/>
+		</data-access>
+
+		<source-config>
+			<cache-hint value="lazy-download" />
+			<read-hint value="read-ahead-buffered" />
+			<timeout-in-seconds value="10000" />
+			<statistics-destination name="cms-udpmon-collector.cern.ch:9331" />
+		</source-config>
+
+		<local-stage-out>
+			<command value="gfal2"/>
+			<catalog url="trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/local/JobConfig/storage_disk.xml?protocol=davs"/>
+			<se-name value="cmswebdav-kit-disk.gridka.de"/>
+			<phedex-node value="T1_DE_KIT_Disk"/>
+		</local-stage-out>
+
+		<fallback-stage-out>
+			<command value="gfal2"/>
+			<option value=""/>
+			<lfn-prefix value="davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2"/>
+			<se-name value="dcache-se-cms.desy.de"/>
+			<phedex-node value="T2_DE_DESY"/>
+		</fallback-stage-out>
+
+		<stage-out>
+      <method site="T2_DE_DESY" volume="DESY_dCache" protocol="WebDAV"/>
+		</stage-out>
+
+		<calib-data>
+			<frontier-connect>
+				<load balance="proxies"/>
+				<proxy url="http://frontier-sq1.gridka.de:3128"/>
+				<proxy url="http://frontier-sq2.gridka.de:3128"/>
+				<proxy url="http://frontier-sq3.gridka.de:3128"/>
+				<backupproxy url="http://cmsbpfrontier.cern.ch:3128"/>
+				<backupproxy url="http://cmsbproxy.fnal.gov:3128"/>
+				<prefer ipfamily="6"/>
+				<server url="http://cmsfrontier.cern.ch:8000/FrontierInt"/>
+				<server url="http://cmsfrontier1.cern.ch:8000/FrontierInt"/>
+				<server url="http://cmsfrontier2.cern.ch:8000/FrontierInt"/>
+				<server url="http://cmsfrontier3.cern.ch:8000/FrontierInt"/>
+			</frontier-connect>
+		</calib-data>
+	</site>
+</site-local-config>

--- a/test/python/WMCore_t/Storage_t/T1_DE_KIT/storage.json
+++ b/test/python/WMCore_t/Storage_t/T1_DE_KIT/storage.json
@@ -1,0 +1,78 @@
+[
+   {  "site": "T1_DE_KIT",
+      "volume": "KIT_dCache",
+      "protocols": [
+         {  "protocol": "xrootd-module",
+            "access": "virtual",
+            "comment": "path translations for CMS xrootd module",
+            "rules": [
+               {  "lfn": "^/+store/test/xrootd/T1_DE_KIT/+(.*)",
+                  "pfn": "/pnfs/gridka.de/cms/disk-only/$1"
+               },
+               {  "lfn": "^/+(store/.*)",
+                  "pfn": "/pnfs/gridka.de/cms/disk-only/$1"
+               }
+            ]
+         },
+         {  "protocol": "XRootD",
+            "access": "global-ro",
+            "prefix": "root://cmsxrootd-kit-disk.gridka.de:1094/"
+         },
+         {  "protocol": "XRootDHoreKaGridKa",
+            "access": "global-ro",
+            "prefix": "root://172.26.19.197:1094//root://cmsxrootd-kit-disk.gridka.de:1094/"
+         },
+         {  "protocol": "XRootDHoreKaFallback",
+            "access": "global-ro",
+            "prefix": "root://172.26.19.197:1094//root://xrootd-cms.infn.it/"
+         },
+         {  "protocol": "WebDAV",
+            "access": "global-rw",
+            "prefix": "davs://cmswebdav-kit-disk.gridka.de:2880/pnfs/gridka.de/cms/disk-only"
+         }
+      ],
+      "type": "DISK",
+      "rse": "T1_DE_KIT_Disk",
+      "fts": [ "https://fts3-cms.cern.ch:8446", "https://lcgfts3.gridpp.rl.ac.uk:8446" ],
+      "loadtest": true
+   },
+
+   {  "site": "T1_DE_KIT",
+      "volume": "KIT_MSS",
+      "protocols": [
+         {  "protocol": "pnfs",
+            "access": "virtual",
+            "rules": [
+               {  "lfn": "/+(store/temp/user/.*)",
+                  "pfn": "/pnfs/gridka.de/cms/disk-only/$1"
+               },
+               {  "lfn": "/+(.*)",
+                  "pfn": "/pnfs/gridka.de/cms/tape/$1"
+               }
+            ],
+            "comment": "redirect temporary user files to disk instance"
+         },
+         {  "protocol": "SRMv2",
+            "access": "global-rw",
+            "rules": [
+               {  "lfn": "/+(.*)",
+                  "pfn": "srm://cmssrm-kit-tape.gridka.de:8443/srm/managerv2?SFN=/$1",
+                  "chain": "pnfs"
+               }
+            ]
+         },
+         {  "protocol": "WebDAV",
+            "access": "site-ro",
+            "rules": [
+               {  "lfn": "/+(.*)",
+                  "pfn": "davs://cmswebdav-kit-tape.gridka.de:2880/$1",
+                  "chain": "pnfs"
+               }
+            ]
+         }
+      ],
+      "type": "TAPE",
+      "rse": "T1_DE_KIT_Tape",
+      "fts": [ "https://fts3-cms.cern.ch:8446", "https://lcgfts3.gridpp.rl.ac.uk:8446" ]
+   }
+]

--- a/test/python/WMCore_t/Storage_t/T1_US_FNAL_SiteLocalConfig.xml
+++ b/test/python/WMCore_t/Storage_t/T1_US_FNAL_SiteLocalConfig.xml
@@ -13,6 +13,11 @@
     <catalog url="trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/T1_US_FNAL_Disk/PhEDEx/storage.xml?protocol=writexrd"/>
     <phedex-node value="T1_US_FNAL_Disk"/>
   </local-stage-out>
+  <stage-out>
+    <method volume="FNAL_dCache_EOS" protocol="XRootD" command="xrdcp" option="-p"/>
+    <method volume="FNAL_dCache_EOS" protocol="SRMv2"/>
+    <method volume="FNAL_dCache_EOS" protocol="WebDAV"/>
+  </stage-out>
   <calib-data>
     <frontier-connect>
       <load balance="proxies"/>

--- a/test/python/WMCore_t/Storage_t/T2_DE_DESY/storage.json
+++ b/test/python/WMCore_t/Storage_t/T2_DE_DESY/storage.json
@@ -1,0 +1,79 @@
+[
+   {  "site": "T2_DE_DESY",
+      "volume": "DESY_dCache",
+      "protocols": [
+         {  "protocol": "pnfs",
+            "access": "virtual",
+            "rules": [
+               {  "lfn": "/+store/unmerged/(.*)",
+                  "pfn": "/pnfs/desy.de/cms/tier2/unmerged/$1"
+               },
+               {  "lfn": "/+store/temp/(.*)",
+                  "pfn": "/pnfs/desy.de/cms/tier2/temp/$1"
+               },
+               {  "lfn": "/+(.*)",
+                  "pfn": "/pnfs/desy.de/cms/tier2/$1"
+               }
+            ]
+         },
+         {  "protocol": "gsidcap",
+            "access": "site-ro",
+            "rules": [
+               {  "lfn": "/+(.*)",
+                  "pfn": "gsidcap://dcache-cms-gsidcap.desy.de:22128/$1",
+                  "chain": "pnfs"
+               }
+            ]
+         },
+         {  "protocol": "dcap",
+            "access": "site-ro",
+            "rules": [
+               {  "lfn": "/+(.*)",
+                  "pfn": "dcap://dcache-cms-dcap.desy.de/$1",
+                  "chain": "pnfs"
+               }
+            ]
+         },
+         {  "protocol": "SRMv2",
+            "access": "global-rw",
+            "rules": [
+               {  "lfn": "/+(.*)",
+                  "pfn": "srm://dcache-se-cms.desy.de:8443/srm/managerv2?SFN=/$1",
+                  "chain": "pnfs"
+               }
+            ]
+         },
+         {  "protocol": "XRootD",
+            "access": "global-rw",
+            "rules": [
+               {  "lfn": "/+(.*)",
+                  "pfn": "root://dcache-cms-xrootd.desy.de:1094//$1"
+               }
+            ]
+         },
+         {  "protocol": "WebDAV",
+            "access": "global-rw",
+            "rules": [
+               {  "lfn": "/+(.*)",
+                  "pfn": "davs://dcache-cms-webdav-wan.desy.de:2880/$1",
+                  "chain": "pnfs"
+               }
+            ]
+         },
+         {  "protocol": "davs-lan",
+            "access": "global-rw",
+            "rules": [
+               {  "lfn": "/+(.*)",
+                  "pfn": "davs://dcache-cms-webdav-job.desy.de:2880/$1",
+                  "chain": "pnfs"
+               }
+            ]
+         }
+      ],
+      "type": "DISK",
+      "rse": "T2_DE_DESY",
+      "fts": [ "https://fts3-cms.cern.ch:8446", "https://lcgfts3.gridpp.rl.ac.uk:8446" ],
+      "loadtest": true
+   }
+]
+ 

--- a/test/python/WMCore_t/Storage_t/T3_US_Vanderbilt_SiteLocalConfig.xml
+++ b/test/python/WMCore_t/Storage_t/T3_US_Vanderbilt_SiteLocalConfig.xml
@@ -3,6 +3,11 @@
     <event-data>
       <catalog url="trivialcatalog_file://gpfs1/grid/grid-app/cmssoft/cms/SITECONF/local/PhEDEx/storage.xml?protocol=direct"/>
     </event-data>
+    
+    <stage-out>
+     <method volume="DUMMY" protocol="WebDAV" command="gfal2"/>
+    </stage-out>
+
     <local-stage-out>
       <command value="srmv2" />
       <option value="-debug" />


### PR DESCRIPTION
Fixes #11703

#### Status
In development

#### Description
These are changes to continue reviewing and testing for code changes to adapt stage-in and stage-out for new storage description in storage.json. The first merging to master of PR #11816 was reverted (#11857) to allow further reviewing and testing.

#### Is it backward compatible (if not, which system it affects?)
NO

#### Related PRs
Debug PR with failed workflow test #11790
First merged PR #11816 
Reverted PR #11857

