### PR TITLE
Dont cross check location when data is reported without location

### DIFF
--- a/src/python/WMCore/ACDC/DataCollectionService.py
+++ b/src/python/WMCore/ACDC/DataCollectionService.py
@@ -328,15 +328,14 @@ class DataCollectionService(CouchService):
         files = self._getFilesetInfo(collectionName, filesetName, chunkOffset, chunkSize)
 
         totalFiles = 0
-        currentLocation = None
+        currentLocation = set()
         numFilesInBlock = 0
         numLumisInBlock = 0
         numEventsInBlock = 0
 
         for fileInfo in files:
-            if currentLocation is None:
-                currentLocation = fileInfo["locations"]
-
+            # locations is a list
+            currentLocation.update(fileInfo["locations"])
             numFilesInBlock += 1
             lumis = 0
             for runLumi in fileInfo["runs"]:
@@ -346,7 +345,7 @@ class DataCollectionService(CouchService):
 
         return {"offset": totalFiles, "files": numFilesInBlock,
                 "events": numEventsInBlock, "lumis": numLumisInBlock,
-                "locations": currentLocation}
+                "locations": list(currentLocation)}
 
     @CouchUtils.connectToCouch
     def getChunkFiles(self, collectionName, filesetName, chunkOffset, chunkSize=100):

--- a/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
@@ -138,11 +138,9 @@ class StartPolicyInterface(PolicyInterface):
         ele = WorkQueueElement(**args)
         for data, sites in viewitems(ele['Inputs']):
             if not sites:
-                # make call to rucio to get list of replicas for this input data
-                locations = self.getDatasetLocations(data, account=self.rucioAcct)
                 # we comment out raising exception due to issue-11784 and allow WQ element creation
                 # but we would like to monitor when and how often it happens
-                self.logger.warning('Input data has no location, spec=%s, data=%s, locations=%s', self.wmspec, data, locations)
+                self.logger.warning('Input data has no location, spec=%s, data=%s', self.wmspec, data)
                 # raise WorkQueueWMSpecError(self.wmspec, 'Input data has no locations "%s"' % data)
 
         # catch infinite splitting loops

--- a/test/python/WMCore_t/ACDC_t/DataCollectionService_t.py
+++ b/test/python/WMCore_t/ACDC_t/DataCollectionService_t.py
@@ -145,7 +145,7 @@ class DataCollectionService_t(unittest.TestCase):
             self.assertEqual(chunkMetaData["files"], chunk["files"])
             self.assertEqual(chunkMetaData["lumis"], chunk["lumis"])
             self.assertEqual(chunkMetaData["events"], chunk["events"])
-            self.assertEqual(chunkMetaData["locations"], chunk["locations"])
+            self.assertItemsEqual(chunkMetaData["locations"], chunk["locations"])
 
             self.assertTrue(chunk["files"] in goldenMetaData, "Error: Extra chunk found.")
             self.assertEqual(chunk["lumis"], goldenMetaData[chunk["files"]]["lumis"],


### PR DESCRIPTION
Fixes #11877

#### Status
ready

#### Description
Fixes an issue inserted with: https://github.com/dmwm/WMCore/pull/11810
where input for ACDC workflows might be checked against Rucio, which is wrong, given that ACDC workflows don't have real data as input, but they actually use a collection of data from the ACDC server.

I am just ditching that extra check against Rucio and leaving this update to the DataLocationUpdater WorkQueueManager thread, which is supposed to continuously update input/pileup data location.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Complement to https://github.com/dmwm/WMCore/pull/11810

#### External dependencies / deployment changes
None
