### PR TITLE
Increase JobSubmitter queue size from 50k to 100k

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -215,7 +215,7 @@ config.JobSubmitter.pollInterval = 120
 config.JobSubmitter.workerThreads = 1
 config.JobSubmitter.jobsPerWorker = 100
 config.JobSubmitter.maxJobsPerPoll = 1000
-config.JobSubmitter.maxJobsToCache = 50000
+config.JobSubmitter.maxJobsToCache = 100000  # used to be 50k
 config.JobSubmitter.cacheRefreshSize = 30000  # set -1 if cache need to refresh all the time.
 config.JobSubmitter.skipRefreshCount = 20  # (If above the threshold meet, cache will updates every 20 polling cycle) 120 * 20 = 40 minutes
 config.JobSubmitter.submitScript = os.path.join(os.environ["WMCORE_ROOT"], submitScript)


### PR DESCRIPTION
Fixes #11888 

#### Status
ready

#### Description
The title says it all, increase the JobSubmitter queue size from 50k to 100k jobs.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
