### PR TITLE
Make container level data placement for DQMHarvest; update Start.Policy.Dataset to container too

### DIFF
--- a/src/python/WMCore/MicroService/MSTransferor/DataStructs/DQMHarvestWorkflow.py
+++ b/src/python/WMCore/MicroService/MSTransferor/DataStructs/DQMHarvestWorkflow.py
@@ -20,12 +20,13 @@ class DQMHarvestWorkflow(Workflow):
         Returns all the primary data that has to be locked and
         transferred with Rucio.
 
-        :return: a list of unique block names and an integer
-                 with their total size
+        :return: a tuple with a list of block names and an integer
+                with their total size in bytes
         """
-        blockList = list(self.getPrimaryBlocks())
+        inputContainer = [self.getInputDataset()]
         totalBlockSize = sum([blockInfo['blockSize'] for blockInfo in self.getPrimaryBlocks().values()])
-        return blockList, totalBlockSize
+        # the whole container must be locked
+        return inputContainer, totalBlockSize
 
     def getRucioGrouping(self):
         """

--- a/src/python/WMCore/WorkQueue/Policy/Start/Dataset.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/Dataset.py
@@ -80,7 +80,6 @@ class Dataset(StartPolicyInterface):
         datasetPath = task.getInputDatasetPath()
         Lexicon.dataset(datasetPath)  # check dataset name
         validBlocks = []
-        locations = None
 
         blockWhiteList = task.inputBlockWhitelist()
         blockBlackList = task.inputBlockBlacklist()
@@ -166,11 +165,6 @@ class Dataset(StartPolicyInterface):
                 blockSummary['NumberOfRuns'] = runs
 
             validBlocks.append(blockSummary)
-            blockLocation = set(self.blockLocationRucioPhedex(blockName))
-            if locations is None:
-                locations = blockLocation
-            else:
-                locations = locations.intersection(blockLocation)
 
         # all needed blocks present at these sites
         if task.getTrustSitelists().get('trustlists'):
@@ -178,7 +172,9 @@ class Dataset(StartPolicyInterface):
             siteBlacklist = task.siteBlacklist()
             self.sites = makeLocationsList(siteWhitelist, siteBlacklist)
             self.data[datasetPath] = self.sites
-        elif locations:
+        else:
+            # as the container is dealt as a whole, resolve the container location
+            locations = set(self.blockLocationRucioPhedex(datasetPath))
             self.data[datasetPath] = list(set(self.cric.PNNstoPSNs(locations)))
 
         return validBlocks

--- a/test/python/WMCore_t/MicroService_t/MSTransferor_t/DataStructs_t/DQMHarvestWorkflow_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSTransferor_t/DataStructs_t/DQMHarvestWorkflow_t.py
@@ -65,8 +65,8 @@ class DQMHarvestWorkflowTest(unittest.TestCase):
         wflow = DQMHarvestWorkflow(self.dqmSpec['RequestName'], deepcopy(self.dqmSpec))
         wflow.setPrimaryBlocks(self.primaryDict)
         inputBlocks, blockSize = wflow.getInputData()
-        self.assertEqual(len(inputBlocks), 2)
-        self.assertCountEqual(inputBlocks, list(self.primaryDict))
+        # this MSTransferor policy deals with the whole container
+        self.assertEqual(inputBlocks, [self.dqmSpec["InputDataset"]])
         self.assertEqual(blockSize, 3)
 
     def testGetRucioGrouping(self):


### PR DESCRIPTION
Fixes #11892 

#### Status
ready

#### Description
As the title says, it provides a change for MSTransferor and the relevant update to GlobalWorkqueue as well, such as:
* MSTransferor: when dealing with DQMHarvest workflows, make a Rucio rule for the whole input container.
* Global WorkQueue: the Dataset policy will resolve input location based on the container instead of each block (which could be falling back to the container level, but in an inefficient way)

#### Is it backward compatible (if not, which system it affects?)
YES (but DQMHarvest workflows stuck in the system might have to be aborted/recreated)

#### Related PRs
None

#### External dependencies / deployment changes
None