### PR TITLE
add support for rhel9. Fix #11895

### DIFF
--- a/src/python/WMCore/WMRuntime/Tools/Scram.py
+++ b/src/python/WMCore/WMRuntime/Tools/Scram.py
@@ -43,7 +43,9 @@ ARCH_TO_SCRAM = {arch:scram for scram, arch in list(SCRAM_TO_ARCH.items())}
 ARCH_TO_OS = {'slc5': ['rhel6'],
               'slc6': ['rhel6'],
               'slc7': ['rhel7'],
-              'el8': ['rhel8'], 'cc8': ['rhel8'], 'cs8': ['rhel8'], 'alma8': ['rhel8']}
+              'el8': ['rhel8'], 'cc8': ['rhel8'], 'cs8': ['rhel8'], 'alma8': ['rhel8'],
+              'el9': ['rhel9'], 'cs9': ['rhel9'],
+              }
 OS_TO_ARCH = {}
 for arch, oses in ARCH_TO_OS.items():
     for osName in oses:
@@ -328,7 +330,7 @@ class Scram(object):
                 try:
                     var, val = l.split("=", 1)
                 except ValueError as ex:
-                    raise ValueError("Couldn't split line: %s" % l)
+                    raise ValueError("Couldn't split line: %s" % l) from ex
 
                 self.runtimeEnv[var] = val
         if self.test_mode:

--- a/test/python/WMCore_t/WMRuntime_t/Tools_t/Scram_t.py
+++ b/test/python/WMCore_t/WMRuntime_t/Tools_t/Scram_t.py
@@ -105,8 +105,9 @@ class Scram_t(unittest.TestCase):
         self.assertCountEqual(OS_TO_ARCH['rhel6'], ['slc5', 'slc6'])
         self.assertCountEqual(OS_TO_ARCH['rhel7'], ['slc7'])
         self.assertCountEqual(OS_TO_ARCH['rhel8'], ['el8', 'cc8', 'cs8', 'alma8'])
+        self.assertCountEqual(OS_TO_ARCH['rhel9'], ['el9', 'cs9'])
         self.assertCountEqual(ARCH_TO_OS['slc6'], ['rhel6'])
-        self.assertEqual(len(ARCH_TO_OS), 7)
+        self.assertEqual(len(ARCH_TO_OS), 9)
         self.assertCountEqual(ARCH_TO_OS['slc7'], ['rhel7'])
         self.assertCountEqual(ARCH_TO_OS['slc7'], ['rhel7'])
 


### PR DESCRIPTION
Fixes #11895

#### Status
Ready

#### Description
Add matches for rhel9 in ARCH_TO_OS

#### Is it backward compatible (if not, which system it affects?)
YES 

#### Related PRs
None

#### External dependencies / deployment changes
None
