### PR TITLE
Fix 11619 alan

### DIFF
--- a/src/python/Utils/FileTools.py
+++ b/src/python/Utils/FileTools.py
@@ -6,12 +6,44 @@ Utilities related to file handling
 
 import io
 import os
+import glob
 import stat
 import subprocess
 import time
 import zlib
 
 from Utils.Utilities import decodeBytesToUnicode
+
+
+def findFiles(path, pat):
+    """
+    Find files within given path and matching given pattern.
+    :param path: starting directory path (string)
+    :param pat: match pattern (string), e.g. *.py or name of the file
+    :return: matched file names
+    """
+    files = []
+    for idir, _, _ in os.walk(path):
+        files.extend(glob.glob(os.path.join(idir, pat)))
+    return files
+
+
+def tarMode(tfile, opMode):
+    """
+    Extract proper mode of operation for given tar file. For instance,
+    if op='r' and tfile name is file.tar.gz we should get 'r:gz',
+    while if tfile name is file.tar.bz2 we should get 'r':bz2', while
+    if tfile name is file.tar we should get 'r', etc.
+    :param opMode: mode of operation (string), e.g. 'r', or 'w'
+    :param tfile: sandbox tar file name (string)
+    :return: mode of operation
+    """
+    ext = tfile.split(".")[-1]
+    if ext == 'tar':
+        return opMode
+    mode = opMode + ':' + ext
+    return mode
+
 
 def calculateChecksums(filename):
     """
@@ -107,6 +139,7 @@ def findMagicStr(filename, matchString):
         for line in logfile:
             if matchString in line:
                 yield line
+
 
 def getFullPath(name, envPath="PATH"):
     """

--- a/src/python/WMComponent/WorkflowUpdater/WorkflowUpdaterPoller.py
+++ b/src/python/WMComponent/WorkflowUpdater/WorkflowUpdaterPoller.py
@@ -12,11 +12,16 @@ Among the actions performed by this component, we can list:
 * update this json in the workflow sandbox
 """
 
+import os
+import json
 import logging
+import tarfile
+import tempfile
 import threading
 
 from Utils.CertTools import cert, ckey
 from Utils.IteratorTools import flattenList
+from Utils.FileTools import tarMode, findFiles
 from Utils.Timers import timeFunction, CodeTimer
 from WMCore.Services.Rucio.Rucio import Rucio
 from WMCore.Services.pycurl_manager import RequestHandler
@@ -24,6 +29,153 @@ from WMCore.WMException import WMException
 from WMCore.WMSpec.WMWorkload import WMWorkloadHelper
 from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 from WMCore.DAOFactory import DAOFactory
+
+
+def findJsonSandboxFiles(tfile):
+    """
+    Find location of sandbox JSON files
+    :param tfile: sandbox tar file
+    :return: list of file names
+    """
+    files = []
+    mode = tarMode(tfile, 'r')
+    with tarfile.open(tfile, mode, encoding='utf-8') as tar:
+        for tarInfo in tar.getmembers():
+            if tarInfo.name.endswith("pileupconf.json"):
+                files.append(tarInfo.name)
+    return files
+
+
+def extractPileupconf(tfile, fname):
+    """
+    Extract content of given file name from sandbox tar file
+    :param tfile: sandbox tar file
+    :param fname: name of the file to extract
+    :return: content of file
+    """
+    mode = tarMode(tfile, 'r')
+    with tarfile.open(tfile, mode, encoding='utf-8') as tar:
+        f = tar.extractfile(fname)
+        data = f.read()
+        # convert our data bytes into JSON object
+        return json.loads(data)
+
+
+def blockLocations(jdoc):
+    """
+    Return dict block names and their location from provided json sandbox file.
+
+    json structure is
+    {"<type: mc>": {"<blockName>": {"FileList" [], "NumberOfEvents":1, "PhEDExNodeNames": []},
+                    "<blockName>": {"FileList" [], "NumberOfEvents":1, "PhEDExNodeNames": []}, ...}
+
+    :param jdoc: JSON document
+    :return: dict {'blockName': [rses], ...}
+    """
+    bdict = {}
+    for rec in jdoc.values():
+        for key in rec.keys():
+            doc = rec[key]
+            bdict[key] = doc['PhEDExNodeNames']
+    return bdict
+
+
+def rucioBlockLocations(rucio, blocks):
+    """
+    Return dictionary in form: {"path-to-json1": jdoc1, "path-to-json2": jdoc2}
+    :param rucio: rucio client
+    :param blocks: list of blocks
+    :return: directionary
+    """
+    # rucio returns: [{"name": blockName, "replica": list(set(rses))}, ...]
+    rucioList = rucio.getReplicaInfoForBlocks(block=blocks)
+    bdict = {}
+    for item in rucioList:
+        bdict[item['name']] = item['replica']
+    return bdict
+
+
+def checkChanges(rdict, bdict):
+    """
+    Compare if provided rucio block locations are different from block locations presented
+    in pileup configuration JSON file.
+    :param rdict: dict of blocks locations from rucio
+    :param bdict: dict of blocks locations from pileupconf.json sandbox file
+    :return: boolean (i.e. if there are changes or not)
+    """
+    # compare block names
+    if len(rdict) != len(bdict):
+        return True
+
+    # compare locations
+    for key in rdict.keys():
+        if sorted(rdict.get(key, [])) != sorted(bdict.get(key, [])):
+            return True
+    return False
+
+
+def updateBlockInfo(jdoc, rdict):
+    """
+    Discard given pileup names from JSON sandbox and return new dict.
+    NOTE: this function may consume lots of memory due to jdoc structure which
+    we need to parse and create new dict since we can't discard keys in place
+    of jdoc internal dictionary, i.e.
+
+    jdoc structure is
+    {"<type: mc>": {"<block>": {"FileList" [], "NumberOfEvents":1, "PhEDExNodeNames": []},
+                    "<block>": {"FileList" [], "NumberOfEvents":1, "PhEDExNodeNames": []}, ...}
+    and we need to discard block names. They are located in internal dictionary
+    and in place pop-up of jdoc is not allowed since it will change size of internal dictionary.
+    Therefore, to overcome this obstacles we need to copy relevant pileupName key:values
+    into new dict structure and return new dict.
+
+    :param jdoc: JSON sandbox dictionary
+    :param rdict: dict of blocks locations from rucio
+    :return: newly constructed dict
+    """
+    returnDict = {}
+    for puType in jdoc:
+        newDict = {}
+        for blockName in list(jdoc[puType].keys()):
+            if blockName in rdict.keys():
+                newDict[blockName] = jdoc[puType][blockName]
+        returnDict[puType] = newDict
+    return returnDict
+
+
+def writePileupJson(tfile, jdict, dest=None):
+    """
+    Write pileup JSON sandbox files back to file system
+    :param tfile: tar ball file name
+    :param jdict: JSON sandbox dictionary in form: {"path-to-json1": jdoc1, "path-to-json2": jdoc2}
+    :param dest: optional destination parameter to write final tar ball (use for unit tests)
+    :return: nothing
+    """
+    bname = os.path.basename(tfile)
+    dname = os.path.dirname(tfile)
+    ofile = f"{dname}/new-{bname}"
+    with tempfile.TemporaryDirectory() as tmpDir:
+        # extract tar ball content into temporary directory
+        with tarfile.open(tfile, tarMode(tfile, 'r'), encoding='utf-8') as tar:
+            tar.extractall(path=tmpDir)
+        # overwrite json sanbox file in temporary directory
+        for jname in jdict:
+            fname = os.path.join(tmpDir, jname)
+            fstat = os.stat(fname)
+            with open(fname, 'w', encoding='utf-8') as ostream:
+                json.dump(jdict[jname], ostream)
+            if fstat == os.stat(fname):
+                # something wrong as we did not update the file
+                msg = f"File {fname} was not properly updated in {tfile}, file stat is identical"
+                raise Exception(msg)
+        # archive back sandbox
+        with tarfile.open(ofile, tarMode(ofile, 'w'), encoding='utf-8') as tar:
+            tar.add(tmpDir, arcname='')
+        # overwrite existing tarball with new one
+        if dest:
+            os.rename(ofile, dest)
+        else:
+            os.rename(ofile, tfile)
 
 
 class WorkflowUpdaterException(WMException):
@@ -45,6 +197,7 @@ class WorkflowUpdaterPoller(BaseWorkerThread):
         BaseWorkerThread.__init__(self)
 
         myThread = threading.currentThread()
+        self.logger = myThread.logger
         self.daoFactory = DAOFactory(package="WMCore.WMBS",
                                      logger=myThread.logger,
                                      dbinterface=myThread.dbi)
@@ -61,10 +214,16 @@ class WorkflowUpdaterPoller(BaseWorkerThread):
 
         self.userCert = cert()
         self.userKey = ckey()
-        self.rucio = Rucio(acct=self.rucioAcct,
-                           hostUrl=self.rucioUrl,
-                           authUrl=self.rucioAuthUrl)
-                           # configDict={'logger': self.logger})
+        try:
+            self.rucio = Rucio(acct=self.rucioAcct,
+                               hostUrl=self.rucioUrl,
+                               authUrl=self.rucioAuthUrl)
+        except Exception as ex:
+            self.rucio = None
+        # define where to look for sandbox tar balls
+        self.sandboxDir = getattr(self.config.WorkflowUpdater, "sandboxDir")
+        if not os.path.exists(self.sandboxDir):
+            self.sandboxDir = '/data/srv/wmagent/current/install/wmagentpy3/WorkQueueManager/cache'
 
     @timeFunction
     def algorithm(self, parameters=None):
@@ -101,12 +260,85 @@ class WorkflowUpdaterPoller(BaseWorkerThread):
             with CodeTimer("Rucio block resolution", logger=logging):
                 self.findRucioBlocks(uniqueActivePU, msPileupList)
 
-            # TODO in future tickets: find the json files in the spec/sandbox area and tweak them
-
+            self.adjustJSONSpec(puWflows, msPileupList)
         except Exception as ex:
             msg = f"Caught unexpected exception in WorkflowUpdater. Details:\n{str(ex)}"
             logging.exception(msg)
             raise WorkflowUpdaterException(msg) from None
+
+    def adjustJSONSpec(self, puWflows, msPileupList, dest=None):
+        """
+        Main logic of the algorithm:
+        - for every pileup record find out location of tarball
+        - get configuration files within tarball
+        - extract block information
+        - replace pileupconf.json files within tarball
+        :param puWflows: list of active pileup workflows with the following structure:
+            {"name": string with workflow name,
+             "spec": string with spec path,
+             "pileup": list of strings with pileup names}
+        :param msPileupList: list of all pileup records in MSPileup service. It has the following structure:
+            {"pileupName": string with pileup name,
+             "customName": string with custom pileup name - if any,
+             "rses": list of RSE names,
+             "blocks": list of block names}
+        :param dest: optional destination parameter to write final tar ball (use for unit tests)
+        :return: nothing, it performs checks and adjust in place pileupconf.json file(s)
+        """
+        # loop over active pileup workflows
+        for wflow in puWflows:
+            # this logic implies that we have untarred workflow tar ball
+            sdir = os.path.join(self.sandboxDir, wflow['name'])
+            tarName = wflow['name'] + '-Sandbox.tar.bz2'
+            tarFile = os.path.join(sdir, tarName)
+            self.logger.debug("process %s, tarfile %s", wflow, tarFile)
+
+            # json dictionary to write back to our tarball
+            jdict = {}
+
+            # list over pileup workflows in MSPileup service
+            for pileupDoc in msPileupList:
+                # check if active pileup workflow is found in MSPileup one
+                pileupName = pileupDoc['pileupName']
+                if pileupName in wflow["pileup"]:
+                    # find pileup configuration files in sandbox area
+                    self.logger.debug("find pileupconf.json in %s", sdir)
+                    files = findFiles(sdir, "pileupconf.json")
+                    self.logger.debug("found matched pileup %s with conf files %s", pileupName, files)
+
+                    # check config files content if they have the same or different datasets
+                    for fname in files:
+                        # make sure that there is no double slaehes in a file path
+                        fname = fname.replace("//", "/")
+                        self.logger.debug("search %s in %s", pileupName, fname)
+                        pileupConfContent = ""
+                        with open(fname, 'r', encoding='utf-8') as istream:
+                            pileupConfContent = istream.read()
+
+                        # check if our pileup name is present in pileupConf content
+                        if pileupName in pileupConfContent:
+                            self.logger.debug("found matched pileup %s in conf file %s", pileupName, fname)
+
+                            # extract pileupconf.json from full path name which should not have double slashes
+                            pileupConfJson = os.path.join('WMSandbox', fname.split('WMSandbox/')[-1])
+                            self.logger.debug("extract %s", pileupConfJson)
+
+                            # get cotent of pileupconf.json file
+                            jdoc = extractPileupconf(tarFile, pileupConfJson)
+                            bdict = blockLocations(jdoc)
+                            blocks = pileupDoc["blocks"]
+                            rdict = rucioBlockLocations(self.rucio, blocks)
+
+                            # check if rucio block locations are differ from one in pileupconf.json
+                            if checkChanges(rdict, bdict):
+                                self.logger.debug("Update pileup configuration file %s", pileupConfJson)
+                                jdoc = updateBlockInfo(jdoc, rdict)
+                                jdict[pileupConfJson] = jdoc
+
+            # replace pileupconf.json files within tarball if we have an update
+            if jdict:
+                self.logger.info("Write pileup configuration file %s", tarFile)
+                writePileupJson(tarFile, jdict, dest)
 
     def getPileupDocs(self):
         """

--- a/src/python/WMCore/WMRuntime/SandboxCreator.py
+++ b/src/python/WMCore/WMRuntime/SandboxCreator.py
@@ -56,7 +56,8 @@ class SandboxCreator(object):
 
             extracts a sandbox at the given archivePath to the given targetPath
         """
-        os.makedirs(targetPath)
+        if not os.path.exists(targetPath):
+            os.makedirs(targetPath)
         archive = tarfile.TarFile(archivePath)
         archive.extractall(targetPath)
         archive.close()

--- a/test/python/Utils_t/FileTools_t.py
+++ b/test/python/Utils_t/FileTools_t.py
@@ -102,6 +102,15 @@ class testFileTools(unittest.TestCase):
         self.assertEqual(cksum, "3774692924")
         return
 
+    def testTarMode(self):
+        """
+        Test tarMode function
+        """
+        mode = FileTools.tarMode('file.bz2', 'w')
+        self.assertEqual(mode, 'w:bz2')
+        mode = FileTools.tarMode('file.tar', 'r')
+        self.assertEqual(mode, 'r')
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/WMComponent_t/WorkflowUpdater_t/WorkflowUpdaterPoller_t.py
+++ b/test/python/WMComponent_t/WorkflowUpdater_t/WorkflowUpdaterPoller_t.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python
+
+import os
+import json
+import shutil
+import logging
+import tarfile
+import tempfile
+import unittest
+
+from WMComponent.WorkflowUpdater.WorkflowUpdaterPoller import \
+    blockLocations, checkChanges, updateBlockInfo, writePileupJson, \
+    findJsonSandboxFiles, extractPileupconf, WorkflowUpdaterPoller
+from WMCore.MicroService.Tools.Common import getMSLogger
+from WMCore.WMBase import getTestBase
+from WMCore.Configuration import Configuration
+from WMQuality.Emulators.RucioClient.MockRucioApi import MockRucioApi
+from WMQuality.Emulators.EmulatedUnitTestCase import EmulatedUnitTestCase
+from WMQuality.TestInit import TestInit
+
+
+class WorkflowUpdaterPollerTest(EmulatedUnitTestCase):
+    """
+    Test case for the WorkflowUpdaterPoller
+    """
+
+    def setUp(self):
+        """
+        Setup the database and logging connection. Try to create all of the
+        WMBS tables.
+        """
+        self.testInit = TestInit(__file__)
+        self.testInit.setLogging()
+        self.testInit.setDatabaseConnection()
+
+        self.logger = getMSLogger(False)
+        super(WorkflowUpdaterPollerTest, self).setUp()
+
+        testData = os.path.join(getTestBase(), "WMComponent_t/WorkflowUpdater_t")
+        sandbox1 = 'SC_MultiPU_Agent227_Val_240110_215719_7133-Sandbox.tar.bz2'
+        self.sandbox1 = os.path.join(testData, sandbox1)
+        self.jdoc = {"mc": {"block1": {"FileList": [], "NumberOfEvents": 1, "PhEDExNodeNames": ['rse1']},
+                            "block2": {"FileList": [], "NumberOfEvents": 1, "PhEDExNodeNames": ['rse2']},
+                            "block3": {"FileList": [], "NumberOfEvents": 1, "PhEDExNodeNames": ['rse3']}}}
+
+    def testFindJsonSandboxFiles(self):
+        """
+        Test findJsonSandboxFiles function
+        """
+        files = findJsonSandboxFiles(self.sandbox1)
+        self.assertEqual(len(files), 2)
+        self.logger.info(files)
+        expect = ['WMSandbox/GenSimFull/cmsRun1/pileupconf.json', 'WMSandbox/GenSimFull/cmsRun2/pileupconf.json']
+        self.assertEqual(files, expect)
+
+    def testExtractPileupconf(self):
+        """
+        Test extractPileupconf function
+        """
+        self.logger.info(self.sandbox1)
+        files = findJsonSandboxFiles(self.sandbox1)
+        for fname in files:
+            jdoc = extractPileupconf(self.sandbox1, fname)
+            keys = list(jdoc.keys())
+            self.assertEqual(keys, ['mc'])
+            bdict = blockLocations(jdoc)
+            blocks = bdict.keys()
+            self.logger.info("%s found %d block names", fname, len(blocks))
+            if fname == 'WMSandbox/GenSimFull/cmsRun1/pileupconf.json':
+                self.assertEqual(len(blocks), 1)
+            elif fname == 'WMSandbox/GenSimFull/cmsRun2/pileupconf.json':
+                self.assertEqual(len(blocks), 463)
+
+    def testBlockLocations(self):
+        """
+        Test blockLocations function
+        """
+        bdict = blockLocations(dict(self.jdoc))
+        self.assertEqual(list(bdict.keys()), ["block1", "block2", "block3"])
+        self.assertEqual(bdict['block1'], ['rse1'])
+        self.assertEqual(bdict['block2'], ['rse2'])
+        self.assertEqual(bdict['block3'], ['rse3'])
+
+    def testUpdataBlockInfo(self):
+        """
+        Test updateBlockInfo function
+        """
+        jdoc = dict(self.jdoc)
+        rses = ['rse1', 'rse2', 'rse3']
+        rdict = {'block1': rses, 'block2': rses}
+        doc = updateBlockInfo(jdoc, rdict)
+        for rec in doc.values():
+            self.assertEqual(rec['block1']['PhEDExNodeNames'], ['rse1'])
+            # block3 should be discarded by now
+            self.assertEqual(len(rec), 2)
+            self.assertEqual(rec['block2']['PhEDExNodeNames'], ['rse2'])
+
+    def testCheckChanges(self):
+        """
+        Test checkChanges function
+        """
+        rdict = {}
+        bdict = blockLocations(dict(self.jdoc))
+        status = checkChanges(rdict, bdict)
+        self.assertEqual(status, True)
+        status = checkChanges(bdict, bdict)
+        self.assertEqual(status, False)
+
+    def testWritePileupJson(self):
+        """
+        Test writePileupJson function
+        """
+        testDoc = {"test": True, "int": 1, "list": [1, 2, 3]}
+        jdict = {}
+        tmpFile = '/tmp/WMComponent-Sandbox.tar.bz2'
+
+        # write new content to tmpFile
+        files = findJsonSandboxFiles(self.sandbox1)
+        for fname in files:
+            jdoc = extractPileupconf(self.sandbox1, fname)
+            # we skip updating part and write our test doc
+            jdict[fname] = testDoc
+        self.logger.info("Write %s to %s", jdict, tmpFile)
+        writePileupJson(self.sandbox1, jdict, tmpFile)
+
+        # now we extract from tmpFile our pileupconf.json files and make comparison of their content
+        for fname in files:
+            jdoc = extractPileupconf(tmpFile, fname)
+            self.logger.info("Extracted %s from %s (%s)", jdoc, tmpFile, fname)
+            self.assertEqual(jdoc, testDoc)
+
+        # remove tmpFile
+        os.remove(tmpFile)
+
+    def testAdjustJSONSpec(self):
+        """
+        Test adjustJSONSpec function
+        """
+        # setup WorkflowUpdater
+        config = Configuration()
+        config.component_('WorkflowUpdater')
+        config.WorkflowUpdater.rucioAccount = 'wmcore_pileup'
+        config.WorkflowUpdater.rucioUrl = 'http://cms-rucio-int.cern.ch'
+        config.WorkflowUpdater.rucioAuthUrl = 'https://cms-rucio-auth-int.cern.ch'
+        config.WorkflowUpdater.rucioCustomScope = 'group.wmcore'
+        config.WorkflowUpdater.msPileupUrl = 'https://cmsweb-testbed.cern.ch/mspileup'
+        config.WorkflowUpdater.sandboxDir = '/tmp'
+        obj = WorkflowUpdaterPoller(config)
+        obj.rucio = MockRucioApi(config.WorkflowUpdater.rucioAccount,
+                                 config.WorkflowUpdater.rucioUrl,
+                                 config.WorkflowUpdater.rucioAuthUrl)
+        self.logger = logging.getLogger()
+        obj.logger = self.logger
+        obj.logger.setLevel(logging.DEBUG)
+
+        # extract workflow name from our test tar.bz2
+        fname = os.path.basename(self.sandbox1)
+        wflowName = fname.replace(".tar.bz2", "").replace("-Sandbox", "")
+
+        # copy our test tar.bz2 file to test area
+        dstDir = os.path.join('/tmp', wflowName)
+        self.logger.debug("### create %s", dstDir)
+        if not os.path.exists(dstDir):
+            os.makedirs(dstDir)
+        tarFileName = os.path.join(dstDir, fname)
+        self.logger.debug("### copy %s to %s", self.sandbox1, dstDir)
+        shutil.copyfile(self.sandbox1, tarFileName)
+
+        # untar our sandbox file and adjust pileup blocks
+        with tarfile.open(tarFileName, 'r:bz2') as tar:
+            tar.extractall(path=dstDir)
+            self.logger.debug("### files in %s: %s", dstDir, os.listdir(dstDir))
+
+            # we got spec and pileup name from self.sandbox1
+            wflowSpec = "GenSimFull"
+            pileup = "/RelValMinBias_14TeV/CMSSW_11_2_0_pre8-112X_mcRun3_2024_realistic_v10_forTrk-v1/GEN-SIM"
+            # here we pass fake blocks name, therefore new content should be empty
+            blocks = ["block#123"]
+
+            # our new pileup workflow list
+            puWflows = [{'name': wflowName, 'spec': wflowSpec, 'pileup': pileup}]
+
+            # let's fake MSPlieup list with fake rses and blocks
+            msPileupList = [{'pileupName': pileup, 'rses': ["rse1"], "blocks": blocks}]
+            self.logger.debug("### run adjustJSONSpec puWflows=%s msPileupList=%s", puWflows, msPileupList)
+
+            # perform adjustment of JSON files in sandbox tarball
+            obj.adjustJSONSpec(puWflows, msPileupList)
+
+        # at this point we should updated one of our configuration files and it should have empty content
+        with tarfile.open(tarFileName, 'r:bz2') as tar:
+            with tempfile.TemporaryDirectory() as tmpDir:
+                tar.extractall(path=tmpDir)
+                confName = os.path.join(tmpDir, 'WMSandbox/GenSimFull/cmsRun1/pileupconf.json')
+                with open(confName, 'r', encoding='utf-8') as istream:
+                    content = json.load(istream)
+                    self.logger.debug("new content %s", content)
+                    # since we passed fake blocks the new content should be empty
+                    self.assertEqual(content, {"mc": {}})
+
+        # reset logger back to original
+        obj.logger.setLevel(logging.WARNING)
+        self.logger.setLevel(logging.WARNING)
+
+        # clean-up destination area
+        shutil.rmtree(dstDir)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/python/WMComponent_t/WorkflowUpdater_t/WorkflowUpdater_t.py
+++ b/test/python/WMComponent_t/WorkflowUpdater_t/WorkflowUpdater_t.py
@@ -96,6 +96,7 @@ class WorkflowUpdaterTest(EmulatedUnitTestCase):
         config.WorkflowUpdater.rucioUrl = "http://cms-rucio-int.cern.ch"
         config.WorkflowUpdater.rucioAuthUrl = "https://cms-rucio-auth-int.cern.ch"
         config.WorkflowUpdater.msPileupUrl = "https://cmsweb-testbed.cern.ch/ms-pileup/data/pileup"
+        config.WorkflowUpdater.sandboxDir = "/tmp"
 
         return config
 


### PR DESCRIPTION
Just a logic update (3rd commit) based on Valentin's PR (1st and 2nd commits): https://github.com/dmwm/WMCore/pull/11884

In short, for each active workflow with pileup, perform the following:
1. Find all pileupconf.json files inside the workflow sandbox (not the tarball)
2. For each pileup JSON found:
2.a. load its content
2.b. figure out the dataset name
2.c. iterate over the pileup documents from MSPileup and find the correct pileup document
2.d. compare the block and their location between the JSON and MSPileup. If there are no changes, jump to step 2.
2.e. if there are changes, update the json content with addition/removal of blocks and update of their locations
2.f. finally, update the tarball with that content against that specific pileupconf.json file (writePileupJson() method)
2.g. go back to step 2

The only difference between this and what we previously discussed is that here I start iterating over the pileupconf.json first, to avoid multiple load/dump from the filesystem.

NOTE though that the performance is very sub-optimal, as we might be untarring + tarring the same spec N times, where N is the number of pileupconf.json files in the tarball (which can either belong to the same dataset or to different ones).