### PR TITLE
11891 create mock classdata for mspileup

### DIFF
--- a/src/python/WMQuality/Emulators/EmulatedUnitTestCase.py
+++ b/src/python/WMQuality/Emulators/EmulatedUnitTestCase.py
@@ -16,6 +16,7 @@ from WMQuality.Emulators.LogDB.MockLogDB import MockLogDB
 from WMQuality.Emulators.PyCondorAPI.MockPyCondorAPI import MockPyCondorAPI
 from WMQuality.Emulators.ReqMgrAux.MockReqMgrAux import MockReqMgrAux
 from WMQuality.Emulators.RucioClient.MockRucioApi import MockRucioApi
+from WMQuality.Emulators.MSPileup.MockMSPileupAPI import getPileupDocs as mockPileupDocs
 
 
 class EmulatedUnitTestCase(unittest.TestCase):
@@ -27,7 +28,7 @@ class EmulatedUnitTestCase(unittest.TestCase):
     def __init__(self, methodName='runTest', mockDBS=True,
                  mockReqMgrAux=True, mockLogDB=True,
                  mockMemoryCache=True, mockPyCondor=True,
-                 mockCRIC=True, mockRucio=True):
+                 mockCRIC=True, mockRucio=True, mockMSPileup=True):
         self.mockDBS = mockDBS
         self.mockReqMgrAux = mockReqMgrAux
         self.mockLogDB = mockLogDB
@@ -35,7 +36,8 @@ class EmulatedUnitTestCase(unittest.TestCase):
         self.mockPyCondor = mockPyCondor
         self.mockCRIC = mockCRIC
         self.mockRucio = mockRucio
-        super(EmulatedUnitTestCase, self).__init__(methodName)
+        self.mockMSPileup = mockMSPileup
+        super().__init__(methodName)
 
     def setUp(self):
         """
@@ -45,7 +47,7 @@ class EmulatedUnitTestCase(unittest.TestCase):
 
         TODO: parameters to turn off emulators individually
         """
-        print(f"Running setUp with emulated services. ")
+        print("Running setUp with emulated services.")
         if self.mockDBS:
             self.dbsPatchers = []
             patchDBSAt = ["dbs.apis.dbsClient.DbsApi",
@@ -110,4 +112,14 @@ class EmulatedUnitTestCase(unittest.TestCase):
                 self.cricPatchers[-1].start()
                 self.addCleanup(self.cricPatchers[-1].stop)
 
-        return
+        if self.mockMSPileup:
+            self.msPileupPatchers = []
+            patchMSPileupAt = ['WMCore.MicroService.MSTransferor.MSTransferor.getPileupDocs', # TODO: Need to use Services.MSPileupUtils
+                               'WMCore.WorkQueue.Policy.Start.StartPolicyInterface.getPileupDocs',
+                               'WMCore.WorkQueue.DataLocationMapper.getPileupDocs',
+                               # 'WMComponent.WorkflowUpdator.WorkflowUpdaterPoller.getPileupDocs', TODO: Need to use Services.MSPileupUtils
+                               'WMCore_t.Services_t.MSPileup_t.MSPileupUtils_t.getPileupDocs']
+            for module in patchMSPileupAt:
+                self.msPileupPatchers.append(mock.patch(module, new=mockPileupDocs))
+                self.msPileupPatchers[-1].start()
+                self.addCleanup(self.msPileupPatchers[-1].stop)

--- a/src/python/WMQuality/Emulators/MSPileup/MockMSPileupAPI.py
+++ b/src/python/WMQuality/Emulators/MSPileup/MockMSPileupAPI.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+"""
+Version of WMCore/Services/MSPileup intended to be used with mock or unittest.mock
+"""
+
+
+def getPileupDocs(mspileupUrl, queryDict=None, method='GET'):
+    """
+    Returns list of Pileup Documents.
+    """
+    print(f"Mocking MSPileup getPileupDocs: \
+          url: {mspileupUrl}, query: {queryDict}, method: {method}")
+
+    queryDict = queryDict or {}
+
+    pdict = {
+        # "pileupName": "/MinBias_TuneCP5_14TeV-pythia8/PhaseIITDRSpring19GS-106X_upgrade2023_realistic_v2_ext1-v1/GEN-SIM",
+        "pileupName": "/GammaGammaToEE_Elastic_Pt15_8TeV-lpair/Summer12-START53_V7C-v1/GEN-SIM",
+        "pileupType": "classic",
+        "insertTime": 1680873642,
+        "lastUpdateTime": 1706216047,
+        "expectedRSEs": [
+            "T2_XX_SiteA",
+            "T2_XX_SiteB",
+            "T2_XX_SiteC"
+            ],
+        "currentRSEs": [
+            "T2_XX_SiteA",
+            "T2_XX_SiteB",
+            "T2_XX_SiteC"
+            ],
+        "fullReplicas": 1,
+        "campaigns": [
+            "Apr2023_Val"
+            ],
+        "containerFraction": 1.0,
+        "replicationGrouping": "ALL",
+        "activatedOn": 1706216047,
+        "deactivatedOn": 1680873642,
+        "active": True,
+        "pileupSize": 1233099715874,
+        "ruleIds": [
+            "55e5a21aecb5445c8aa40581a7bf18d2",
+            "67a3fa7252f54507ba1c45f271beb754"
+            ],
+        "customName": "",
+        "transition": []}
+
+    if 'filters' in queryDict.keys():
+        return [{k: v for k, v in pdict.items() if k in queryDict['filters']}]
+
+    return [pdict]

--- a/test/python/WMCore_t/Services_t/MSPileup_t/MSPileupUtils_t.py
+++ b/test/python/WMCore_t/Services_t/MSPileup_t/MSPileupUtils_t.py
@@ -7,10 +7,12 @@ import unittest
 
 from nose.plugins.attrib import attr
 
+from WMQuality.Emulators.EmulatedUnitTestCase import EmulatedUnitTestCase
+from WMCore.MicroService.MSPileup.DataStructs.MSPileupObj import schema
 from WMCore.Services.MSPileup.MSPileupUtils import getPileupDocs
 
 
-class MSPileupUtilsTest(unittest.TestCase):
+class MSPileupUtilsTest(EmulatedUnitTestCase):
     """
     Test class for the RucioUtils module
     """
@@ -20,6 +22,7 @@ class MSPileupUtilsTest(unittest.TestCase):
         Setup for unit tests
         """
         self.logger = logging.getLogger()
+        super().setUp()
 
     def tearDown(self):
         """
@@ -31,43 +34,14 @@ class MSPileupUtilsTest(unittest.TestCase):
         """
         Test getting pileup docs from testbed.
         """
-        pdict = {
-            "pileupName": "/MinBias_TuneCP5_14TeV-pythia8/PhaseIITDRSpring19GS-106X_upgrade2023_realistic_v2_ext1-v1/GEN-SIM",
-            "pileupType": "classic",
-            "insertTime": 1680873642,
-            "lastUpdateTime": 1706216047,
-            "expectedRSEs": [
-                "T1_US_FNAL_Disk",
-                "T2_CH_CERN"
-                ],
-            "currentRSEs": [
-                "T1_US_FNAL_Disk",
-                "T2_CH_CERN"
-                ],
-            "fullReplicas": 1,
-            "campaigns": [
-                "Apr2023_Val"
-                ],
-            "containerFraction": 1.0,
-            "replicationGrouping": "ALL",
-            "activatedOn": 1706216047,
-            "deactivatedOn": 1680873642,
-            "active": True,
-            "pileupSize": 1233099715874,
-            "ruleIds": [
-                "55e5a21aecb5445c8aa40581a7bf18d2",
-                "67a3fa7252f54507ba1c45f271beb754"
-                ],
-            "customName": "",
-            "transition": []
-            }
+        pdict = schema()
 
         dataItem = '/MinBias_TuneCP5_14TeV-pythia8/PhaseIITDRSpring19GS-106X_upgrade2023_realistic_v2_ext1-v1/GEN-SIM'
         msPileupUrl = 'https://cmsweb-testbed.cern.ch/ms-pileup/data/pileup'
 
         # test without filter
         queryDict = {'query': {'pileupName': dataItem}}
-        result = getPileupDocs(msPileupUrl, queryDict)
+        result = getPileupDocs(msPileupUrl, queryDict, method='POST')
 
         self.logger.info('GetPileupDocs Result: %s', result)
 
@@ -81,7 +55,7 @@ class MSPileupUtilsTest(unittest.TestCase):
         filterKeys = ['currentRSEs', 'pileupName', 'containerFraction', 'ruleIds']
         queryDict = {'query': {'pileupName': dataItem},
                      'filters': filterKeys}
-        result = getPileupDocs(msPileupUrl, queryDict)
+        result = getPileupDocs(msPileupUrl, queryDict, method='POST')
 
         self.assertGreater(len(result), 0)
 

--- a/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Block_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/Policy_t/Start_t/Block_t.py
@@ -32,25 +32,6 @@ parentProcArgs["SplittingAlgo"] = "LumiBased"
 parentProcArgs["LumisPerJob"] = 8
 
 
-# A mock class for WMCore.WorkQueue.Policy.Start.Block
-class ThisBlock(Block):
-    def __init__(self, **args):
-        super().__init__(**args)
-
-    def getDatasetLocationsFromMSPileup(self, datasetsWithDbsURL):
-        """
-        Override StartPolicyInterface.getDatasetLocationsFromMSPileup
-        for unit test purposes
-        """
-        print("Mocked ThisBlock.getDatasetLocationsFromMSPileup ")
-        expectedLocations = ['T2_XX_SiteA', 'T2_XX_SiteB', 'T2_XX_SiteC']
-        result = {}
-        for dbsUrl, datasets in datasetsWithDbsURL.items():
-            for dataset in datasets:
-                result[dataset] = expectedLocations
-        return result
-
-
 def rerecoWorkload(workloadName, arguments, assignArgs=None):
     factory = ReRecoWorkloadFactory()
     wmspec = factory.factoryWorkloadConstruction(workloadName, arguments)
@@ -453,8 +434,7 @@ class BlockTestCase(EmulatedUnitTestCase):
         if it is present in the workload.
         """
         for task in MultiTaskProcessingWorkload.taskIterator():
-            # units, _, _ = Block(**self.splitArgs)(MultiTaskProcessingWorkload, task)
-            units, _, _ = ThisBlock(**self.splitArgs)(MultiTaskProcessingWorkload, task)
+            units, _, _ = Block(**self.splitArgs)(MultiTaskProcessingWorkload, task)
             self.assertEqual(58, len(units))
             for unit in units:
                 pileupData = unit["PileupData"]


### PR DESCRIPTION
Fixes #11891

#### Status
In development

#### Description
Mocks the MSPileupUtils.py getPileupDocs call for testing via an MSPileup Emulator

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
#11870
#11879

#### External dependencies / deployment changes
No
