### PR TITLE
Correctly pass dbsUrl to the locationsFromMSPileup method

### DIFF
--- a/src/python/WMCore/WorkQueue/DataLocationMapper.py
+++ b/src/python/WMCore/WorkQueue/DataLocationMapper.py
@@ -77,7 +77,7 @@ class DataLocationMapper(object):
         for dbs, dataItems in viewitems(dataByDbs):
             # if global use Rucio, else use dbs
             if "pileup" in rucioAcct:
-                output = self.locationsFromMSPileup(dataItems, dbs)
+                output = self.locationsFromMSPileup(dataItems, dbs.dbsURL)
             elif isGlobalDBS(dbs):
                 output = self.locationsFromRucio(dataItems, rucioAcct)
             else:


### PR DESCRIPTION
Fixes #11903 

#### Status
READY

#### Description
We were wrongly passing the whole `dbs` object to the `locationsFromMSPileup` method in `WMCore.WorkQueue.DataLocationMapper` and later trying to parse it as a string in order to find out whether it was a testbed instance or not. This is used later as a marker to the actual MSPileup instance we are currently configured  against. 

With this fix we are now refering to the `dbs.dbsURL` attribute in this parsing procedure which should fix the issue. But the question, whether using the `dbsURL` in order to find out the `MSPileup` instance is the optimal way, still remains.     

#### Is it backward compatible (if not, which system it affects?)
YES 

#### Related PRs
None

#### External dependencies / deployment changes
None