### PR TITLE
Fix variable name in log record; complement to #11879

### DIFF
--- a/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
@@ -284,7 +284,7 @@ class StartPolicyInterface(PolicyInterface):
         for dbsUrl, datasets in datasetsWithDbsURL.items():
             pileUpinstance = '-testbed' if 'cmsweb-testbed' in dbsUrl else '-prod'
             msPileupUrl = f'https://cmsweb{pileUpinstance}.cern.ch/ms-pileup/data/pileup'
-            self.logger.info(f'Will fetch {len(datasets)} from MSPileup url: {dbsUrl}')
+            self.logger.info(f'Will fetch {len(datasets)} from MSPileup url: {msPileupUrl}')
             for dataset in datasets:
                 queryDict = {'query': {'pileupName': dataset},
                             'filters': ['expectedRSEs', 'currentRSEs', 'pileupName', 'containerFraction', 'ruleIds']}


### PR DESCRIPTION
Fixes #11620
Complement to https://github.com/dmwm/WMCore/pull/11879

#### Status
ready

#### Description
Dennis fixed this issue in this PR: https://github.com/dmwm/WMCore/pull/11905
but I would like to deploy it in production in the upgraded scheduled for today, so here goes a simple fix to the variable name being referenced in an important log record of the WorkQueue.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Bug fix for https://github.com/dmwm/WMCore/pull/11879

#### External dependencies / deployment changes
None