### PR TITLE
Fix 11909 Uses MSPileupUtils getPileupDocs in all Instances

### DIFF
--- a/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
+++ b/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
@@ -24,11 +24,12 @@ from copy import deepcopy
 from Utils.IteratorTools import grouper
 from WMCore.MicroService.DataStructs.DefaultStructs import TRANSFEROR_REPORT,\
     TRANSFER_RECORD, TRANSFER_COUCH_DOC
-from WMCore.MicroService.Tools.Common import (teraBytes, isRelVal, getPileupDocs)
+from WMCore.MicroService.Tools.Common import (teraBytes, isRelVal)
 from WMCore.MicroService.MSCore.MSCore import MSCore
 from WMCore.MicroService.MSTransferor.RequestInfo import RequestInfo
 from WMCore.MicroService.MSTransferor.DataStructs.RSEQuotas import RSEQuotas
 from WMCore.Services.CRIC.CRIC import CRIC
+from WMCore.Services.MSPileup.MSPileupUtils import getPileupDocs
 from WMCore.Services.Rucio.RucioUtils import GROUPING_ALL
 
 

--- a/src/python/WMCore/MicroService/Tools/Common.py
+++ b/src/python/WMCore/MicroService/Tools/Common.py
@@ -106,26 +106,6 @@ def dbsInfo(datasets, dbsUrl):
     return datasetBlocks, datasetSizes, datasetTransfers
 
 
-def getPileupDocs(mspileupUrl, queryDict):
-    """
-    Fetch documents from MSPileup according to the query passed in.
-    :param mspileupUrl: string with the MSPileup url
-    :param queryDict: dictionary with the MongoDB query to run
-    :return: returns a list with all the pileup objects, or raises
-        an exception in case of failure
-    """
-    mgr = RequestHandler()
-    headers = {'Content-Type': 'application/json'}
-    data = mgr.getdata(mspileupUrl, queryDict, headers, verb='POST',
-                       ckey=ckey(), cert=cert(), encode=True, decode=True)
-    if data and data.get("result", []):
-        if "error" in data["result"][0]:
-            msg = f"Failed to retrieve MSPileup documents with query: {queryDict}"
-            msg += f" and error message: {data}"
-            raise RuntimeError(msg)
-    return data["result"]
-
-
 def getPileupDatasetSizes(datasets, phedexUrl):
     """
     Given a list of datasets, find all their blocks with replicas

--- a/src/python/WMCore/Services/MSPileup/MSPileupUtils.py
+++ b/src/python/WMCore/Services/MSPileup/MSPileupUtils.py
@@ -21,7 +21,6 @@ def getPileupDocs(mspileupUrl, queryDict=None, method='GET'):
     queryDict = queryDict or {}
     mgr = RequestHandler()
     headers = {'Content-Type': 'application/json'}
-    # TODO: Use GET instead?
     data = mgr.getdata(mspileupUrl, queryDict, headers, verb=method,
                        ckey=ckey(), cert=cert(), encode=True, decode=True)
     if data and data.get("result", []):

--- a/src/python/WMQuality/Emulators/EmulatedUnitTestCase.py
+++ b/src/python/WMQuality/Emulators/EmulatedUnitTestCase.py
@@ -114,10 +114,10 @@ class EmulatedUnitTestCase(unittest.TestCase):
 
         if self.mockMSPileup:
             self.msPileupPatchers = []
-            patchMSPileupAt = ['WMCore.MicroService.MSTransferor.MSTransferor.getPileupDocs', # TODO: Need to use Services.MSPileupUtils
+            patchMSPileupAt = ['WMCore.MicroService.MSTransferor.MSTransferor.getPileupDocs',
                                'WMCore.WorkQueue.Policy.Start.StartPolicyInterface.getPileupDocs',
                                'WMCore.WorkQueue.DataLocationMapper.getPileupDocs',
-                               # 'WMComponent.WorkflowUpdator.WorkflowUpdaterPoller.getPileupDocs', TODO: Need to use Services.MSPileupUtils
+                               'WMComponent.WorkflowUpdater.WorkflowUpdaterPoller.getPileupDocs',
                                'WMCore_t.Services_t.MSPileup_t.MSPileupUtils_t.getPileupDocs']
             for module in patchMSPileupAt:
                 self.msPileupPatchers.append(mock.patch(module, new=mockPileupDocs))


### PR DESCRIPTION
Fixes #11909 

#### Status
Not tested

#### Description
Replaces `getPileupDocs` in `MSTransferor` and `WorkflowUpdatorPoller` with `MSPileupUtils.getPileupDocs`

#### Is it backward compatible (if not, which system it affects?)
MAYBE

#### Related PRs
https://github.com/dmwm/WMCore/pull/11905

#### External dependencies / deployment changes
N/A
