### PR TITLE
Add code to insert transition record; code re-factoring

### DIFF
--- a/bin/adhoc-scripts/adjustMongoDocs.py
+++ b/bin/adhoc-scripts/adjustMongoDocs.py
@@ -16,6 +16,9 @@ EOF
 # a json structure presented in /tmp/schema.json file
 adjustMongoDocs.py --fin=/tmp/schema.json --dburi=localhost:8230 --dbname=test --dbcoll=test --verbose 1
 
+# run script to add new transition record to all MSPileup records if they do not have it
+adjustMongoDocs.py --add-tran-record --dburi=localhost:8230 --dbname=test --dbcoll=test --verbose 1
+
 NOTE: the script can run from any location assuming it has proper db uri with
 credentials and availability of mongo db outside of its own cluster, but most
 likely it will be run on mongo db k8s cluster
@@ -25,12 +28,16 @@ import argparse
 import json
 from pymongo import MongoClient
 
+# WMCore services
+from Utils.Timers import gmtimeSeconds
+
 
 class OptionParser(object):
     "Helper class to handle script options"
 
     def __init__(self):
         "User based option parser"
+        defaultDN = '/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=msunmer/CN=852819/CN=Robot: WmCore Service Account'
         self.parser = argparse.ArgumentParser(prog='PROG')
         self.parser.add_argument("--fin", action="store",
                                  dest="fin", default="", help="Input file with update fields")
@@ -40,34 +47,79 @@ class OptionParser(object):
                                  dest="dbname", default="", help="MongoDB database")
         self.parser.add_argument("--dbcoll", action="store",
                                  dest="dbcoll", default="", help="MongoDB collection")
+        self.parser.add_argument("--userdn", action="store",
+                                 dest="userDN", default=defaultDN, help="user DN")
+        self.parser.add_argument("--add-tran-record", action="store_true",
+                                 dest="transition", help="add transaction record")
         self.parser.add_argument("--verbose", action="store",
                                  dest="verbose", default=0, help="verbosity level")
 
 
-def adjust():
+def addTransitionRecord(dburi, dbname, dbcoll, userDN, verbose):
+    """
+    Helper function to add and update in place transition record for existing MSPileup records
+    :param dburi: database URI (string)
+    :param dbname: database name (string)
+    :param dbcoll: database collection name (string)
+    :param userDN: string representing user DN
+    :param verbose: verbose flag (boolean)
+    :return: nothing
+    """
+    conn = MongoClient(host=dburi)
+    records = [r for r in conn[dbname][dbcoll].find()]
+    for rec in records:
+        if 'pileupName' not in rec:
+            continue
+        if ('transition' in rec and len(rec['transition']) == 0) or 'transition' not in rec:
+            tranRecord = {'containerFraction': 1.0,
+                          'customDID': rec['pileupName'],
+                          'updateTime': gmtimeSeconds(),
+                          'DN': userDN}
+            rec['transition'] = [tranRecord]
+            if verbose:
+                print(f"update rec={rec} with new transition record={tranRecord}")
+            spec = {'pileupName': rec['pileupName'], 'customName': rec.get('customName', '')}
+            # perform update of the record
+            conn[dbname][dbcoll].update_one(spec, {'$set': {'transition': [tranRecord]}}, upsert=True)
+
+
+def adjust(dburi, dbname, dbcoll, fin, verbose):
     """
     helper script to update documents in MongoDB with given db name/collection
     and schema file (which should contain new addition, in form of JSON, to the
     db documents)
+    :param dburi: database URI (string)
+    :param dbname: database name (string)
+    :param dbcoll: database collection name (string)
+    :param fin: input file with schema content
+    :param verbose: verbose flag (boolean)
+    :return: nothing
     """
-    optmgr = OptionParser()
-    opts = optmgr.parser.parse_args()
-    conn = MongoClient(host=opts.dburi)
-    dbname = opts.dbname
-    dbcoll = opts.dbcoll
-    verbose = opts.verbose
+    conn = MongoClient(host=dburi)
     schema = {}
-    with open(opts.fin, 'r', encoding='utf-8') as istream:
+    with open(fin, 'r', encoding='utf-8') as istream:
         schema = json.load(istream)
     if schema:
         if verbose:
-            print("read data from '%s', %s/%s" % (opts.dburi, dbname, dbcoll))
+            print(f"read data from '{dburi}', {dbname}/{dbcoll}")
         records = [r for r in conn[dbname][dbcoll].find()]
         for doc in records:
             if verbose:
-                print("update doc=%s with schema=%s" % (doc, schema))
+                print(f"update doc={doc} with schema={schema}")
             conn[dbname][dbcoll].update_one(doc, {'$set': schema}, upsert=True)
 
 
+def main():
+    """
+    Main function
+    """
+    optmgr = OptionParser()
+    opts = optmgr.parser.parse_args()
+    if opts.transition:
+        addTransitionRecord(opts.dburi, opts.dbname, opts.dbcoll, opts.userDN, opts.verbose)
+    else:
+        adjust(opts.dburi, opts.dbname, opts.dbcoll, opts.fin, opts.verbose)
+
+
 if __name__ == '__main__':
-    adjust()
+    main()

--- a/bin/adhoc-scripts/adjustMongoDocs.py
+++ b/bin/adhoc-scripts/adjustMongoDocs.py
@@ -68,9 +68,7 @@ def addTransitionRecord(dburi, dbname, dbcoll, userDN, verbose):
     conn = MongoClient(host=dburi)
     records = [r for r in conn[dbname][dbcoll].find()]
     for rec in records:
-        if 'pileupName' not in rec:
-            continue
-        if ('transition' in rec and len(rec['transition']) == 0) or 'transition' not in rec:
+        if not rec.get("transition"):
             tranRecord = {'containerFraction': 1.0,
                           'customDID': rec['pileupName'],
                           'updateTime': gmtimeSeconds(),

--- a/bin/adhoc-scripts/adjustMongoDocs.py
+++ b/bin/adhoc-scripts/adjustMongoDocs.py
@@ -37,7 +37,6 @@ class OptionParser(object):
 
     def __init__(self):
         "User based option parser"
-        defaultDN = '/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=msunmer/CN=852819/CN=Robot: WmCore Service Account'
         self.parser = argparse.ArgumentParser(prog='PROG')
         self.parser.add_argument("--fin", action="store",
                                  dest="fin", default="", help="Input file with update fields")
@@ -48,7 +47,7 @@ class OptionParser(object):
         self.parser.add_argument("--dbcoll", action="store",
                                  dest="dbcoll", default="", help="MongoDB collection")
         self.parser.add_argument("--userdn", action="store",
-                                 dest="userDN", default=defaultDN, help="user DN")
+                                 dest="userDN", default='', help="user DN")
         self.parser.add_argument("--add-tran-record", action="store_true",
                                  dest="transition", help="add transaction record")
         self.parser.add_argument("--verbose", action="store",
@@ -65,6 +64,8 @@ def addTransitionRecord(dburi, dbname, dbcoll, userDN, verbose):
     :param verbose: verbose flag (boolean)
     :return: nothing
     """
+    if not userDN:
+        raise Exception("No userDN provided")
     conn = MongoClient(host=dburi)
     records = [r for r in conn[dbname][dbcoll].find()]
     for rec in records:

--- a/bin/adhoc-scripts/updatePileupObjects.py
+++ b/bin/adhoc-scripts/updatePileupObjects.py
@@ -31,7 +31,6 @@ class OptionParser():
 
     def __init__(self):
         "User based option parser"
-        defaultDN = '/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=msunmer/CN=852819/CN=Robot: WmCore Service Account'
         self.parser = argparse.ArgumentParser(prog='PROG')
         self.parser.add_argument("--fin", action="store",
                                  dest="fin", default="", help="Input file with update fields (optional)")
@@ -41,7 +40,7 @@ class OptionParser():
                                  dest="url", default="https://cmsweb-testbed.cern.ch",
                                  help="URL for the MSPileup service")
         self.parser.add_argument("--userdn", action="store",
-                                 dest="userDN", default=defaultDN, help="user DN")
+                                 dest="userDN", default='', help="user DN")
         self.parser.add_argument("--add-tran-record", action="store_true",
                                  dest="transition", help="add transition record")
 
@@ -168,6 +167,8 @@ def addTransitionRecords(handler, url, userDN, logger, dryrun):
     :param dryrun: option to run dry-run mode (boolean)
     :return: nothing
     """
+    if not userDN:
+        raise Exception("No userDN provided")
     puDocs = getPileupDocs(url, handler, logger)
     logger.info("Found %d documents in MSPileup", len(puDocs))
     recordsToUpdate = []

--- a/bin/adhoc-scripts/updatePileupObjects.py
+++ b/bin/adhoc-scripts/updatePileupObjects.py
@@ -34,7 +34,7 @@ class OptionParser():
         defaultDN = '/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=msunmer/CN=852819/CN=Robot: WmCore Service Account'
         self.parser = argparse.ArgumentParser(prog='PROG')
         self.parser.add_argument("--fin", action="store",
-                                 dest="fin", default="", help="Input JSON file (optional)")
+                                 dest="fin", default="", help="Input file with update fields (optional)")
         self.parser.add_argument("--dry-run", action="store_true",
                                  dest="dryrun", help="Fetch docs but do not update")
         self.parser.add_argument("--url", action="store",

--- a/bin/adhoc-scripts/updatePileupObjects.py
+++ b/bin/adhoc-scripts/updatePileupObjects.py
@@ -170,6 +170,7 @@ def addTransitionRecords(handler, url, userDN, logger, dryrun):
     """
     puDocs = getPileupDocs(url, handler, logger)
     logger.info("Found %d documents in MSPileup", len(puDocs))
+    recordsToUpdate = []
     for rec in puDocs:
         if not rec.get("transition"):
             tranRecord = {'containerFraction': 1.0,
@@ -178,13 +179,14 @@ def addTransitionRecords(handler, url, userDN, logger, dryrun):
                           'DN': userDN}
             rec['transition'] = [tranRecord]
             logger.info("New pileup document is: %s", rec)
+            recordsToUpdate.append(rec)
 
     if dryrun:
-        logger.info("documents are not written due to --dry-run option\n")
+        logger.info("%s documents needs to be updated but are not written due to --dry-run option\n", len(recordsToUpdate))
     else:
         # finally, update the pileup documents in the database
-        writePileupDocs(url, puDocs, handler, logger)
-        logger.info("documents are uploaded to MSPileup\n")
+        writePileupDocs(url, recordsToUpdate, handler, logger)
+        logger.info("%s documents are uploaded to MSPileup\n", len(recordsToUpdate))
 
 
 def updatePileupRecords(handler, url, logger, dryrun, fin=""):
@@ -206,8 +208,11 @@ def updatePileupRecords(handler, url, logger, dryrun, fin=""):
             logger.error("Provided %s file does not exist", fin)
             os.exit(1)
     else:
-        puDocs = getPileupDocs(url, handler, logger)
-        logger.info("Found %d documents in MSPileup", len(puDocs))
+        logger.info("No input file is provided to update pileup records")
+        os.exit(1)
+
+    puDocs = getPileupDocs(url, handler, logger)
+    logger.info("Found %d documents in MSPileup", len(puDocs))
 
     # update the documents with the override content
     for doc in puDocs:

--- a/bin/adhoc-scripts/updatePileupObjects.py
+++ b/bin/adhoc-scripts/updatePileupObjects.py
@@ -9,6 +9,9 @@ used to update every single pileup document that it fetches from MSPileup.
 
 Example usage is:
 python3 updatePileupObjects.py --url=https://cmsweb.cern.ch --fin=override_data.json
+
+# run script to add new transition record to all MSPileup records if they do not have it
+python3 updatePileupObjects.py --add-tran-record -url=https://cmsweb.cern.ch --userDN=<user-dn>
 """
 import argparse
 import json
@@ -19,20 +22,28 @@ import urllib.request
 import ssl
 from http.client import HTTPSConnection
 
+# WMCore services
+from Utils.Timers import gmtimeSeconds
+
 
 class OptionParser():
     """Class to parse the command line arguments"""
 
     def __init__(self):
         "User based option parser"
+        defaultDN = '/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=msunmer/CN=852819/CN=Robot: WmCore Service Account'
         self.parser = argparse.ArgumentParser(prog='PROG')
-        self.parser.add_argument("--fin", required=True,
-                                 dest="fin", help="Input JSON file")
+        self.parser.add_argument("--fin", action="store",
+                                 dest="fin", default="", help="Input JSON file (optional)")
         self.parser.add_argument("--dry-run", action="store_true",
                                  dest="dryrun", help="Fetch docs but do not update")
         self.parser.add_argument("--url", action="store",
                                  dest="url", default="https://cmsweb-testbed.cern.ch",
                                  help="URL for the MSPileup service")
+        self.parser.add_argument("--userdn", action="store",
+                                 dest="userDN", default=defaultDN, help="user DN")
+        self.parser.add_argument("--add-tran-record", action="store_true",
+                                 dest="transition", help="add transition record")
 
 
 class HTTPSClientAuthHandler(urllib.request.HTTPSHandler):
@@ -147,6 +158,72 @@ def writePileupDocs(mspileupUrl, puDocs, handler, logger):
                 logger.critical(msg)
 
 
+def addTransitionRecords(handler, url, userDN, logger, dryrun):
+    """
+    Helper function to add and update in place transition record for existing MSPileup records
+    :param handler: HTTP handler to use
+    :param url: url to use (string)
+    :param userDN: string representing user DN
+    :param logger: logger to use
+    :param dryrun: option to run dry-run mode (boolean)
+    :return: nothing
+    """
+    puDocs = getPileupDocs(url, handler, logger)
+    logger.info("Found %d documents in MSPileup", len(puDocs))
+    for rec in puDocs:
+        if not rec.get("transition"):
+            tranRecord = {'containerFraction': 1.0,
+                          'customDID': rec['pileupName'],
+                          'updateTime': gmtimeSeconds(),
+                          'DN': userDN}
+            rec['transition'] = [tranRecord]
+            logger.info("New pileup document is: %s", rec)
+
+    if dryrun:
+        logger.info("documents are not written due to --dry-run option\n")
+    else:
+        # finally, update the pileup documents in the database
+        writePileupDocs(url, puDocs, handler, logger)
+        logger.info("documents are uploaded to MSPileup\n")
+
+
+def updatePileupRecords(handler, url, logger, dryrun, fin=""):
+    """
+    helper function to update pileup records
+    :param handler: HTTP handler to use
+    :param url: url to use (string)
+    :param logger: logger object to use
+    :param dryrun: option to run dry-run mode (boolean)
+    :param fin: input file name to read from (optional, string)
+    :return: nothing
+    """
+    if fin:
+        if os.path.exists(fin):
+            with open(fin, 'r', encoding='utf-8') as istream:
+                puOverride = json.load(istream)
+            logger.info("Pileup override file: %s has the following content: %s", fin, puOverride)
+        else:
+            logger.error("Provided %s file does not exist", fin)
+            os.exit(1)
+    else:
+        puDocs = getPileupDocs(url, handler, logger)
+        logger.info("Found %d documents in MSPileup", len(puDocs))
+
+    # update the documents with the override content
+    for doc in puDocs:
+        doc.update(puOverride)
+        logger.info("New pileup document is: %s", doc)
+
+    if dryrun:
+        logger.info("Updated documents (dry-run option):")
+        for doc in puDocs:
+            logger.info(doc)
+    else:
+        # finally, update the pileup documents in the database
+        writePileupDocs(url, puDocs, handler, logger)
+        logger.info("documents are uploaded to MSPileup\n")
+
+
 def main():
     """Executes everything"""
     optmgr = OptionParser()
@@ -179,24 +256,10 @@ def main():
     # initialize HTTPS client handler
     handler = HTTPSClientAuthHandler(key, cert)
 
-    with open(opts.fin, 'r', encoding='utf-8') as istream:
-        puOverride = json.load(istream)
-    logger.info("Pileup override file: %s has the following content: %s", opts.fin, puOverride)
-
-    puDocs = getPileupDocs(opts.url, handler, logger)
-    logger.info("Found %d documents in MSPileup", len(puDocs))
-
-    # update the documents with the override content
-    for doc in puDocs:
-        doc.update(puOverride)
-        logger.info("New pileup document is: %s", doc)
-
-    if opts.dryrun:
-        logger.info("documents are not written due to --dry-run option\n")
+    if opts.transition:
+        addTransitionRecords(handler, opts.url, opts.userDN, logger, opts.dryrun)
     else:
-        # finally, update the pileup documents in the database
-        writePileupDocs(opts.url, puDocs, handler, logger)
-        logger.info("documents are uploaded to MSPileup\n")
+        updatePileupRecords(handler, opts.url, logger, opts.dryrun, opts.fin)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #11914 

#### Status
ready

#### Description
Update ad-hoc scripts to create initial transition record for MSPileup records. There are two scripts:
- `adjustMongoDocs.py` to communicate with MongoDB directly
- `updatePileupObjects.py` to communicate with MongoDB backend via MSPileup REST API

Here is how each script can be called:
```
# adjust port, dbname and dbcoll appropriately
adjustMongoDocs.py --add-tran-record --dburi=localhost:8230 --dbname=test --dbcoll=test --verbose 1

# use update script to rely on MSPileup REST API
updatePileupObjects.py --add-tran-record -url=https://cmsweb.cern.ch --userDN=<user-dn>
```


#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
part of meta https://github.com/dmwm/WMCore/issues/11537

#### External dependencies / deployment changes
pymongo client