### PR TITLE
Fix empty userDN for MSPileupTask update of transition record

### DIFF
--- a/src/python/WMCore/MicroService/MSPileup/MSPileupTasks.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupTasks.py
@@ -99,7 +99,8 @@ class MSPileupTasks():
                 pileupSize = datasetSizes.get(pileupName, 0)
                 if pileupSize:
                     doc['pileupSize'] = pileupSize
-                self.mgr.updatePileup(doc, validate=False)
+                # here we update our new document in database with document validation
+                self.mgr.updatePileupDocumentInDatabase(doc)
         except Exception as exp:
             msg = f"MSPileup pileup size task failed with error {exp}"
             self.logger.exception(msg)
@@ -262,7 +263,8 @@ class MSPileupTasks():
                     self.logger.info("Finally, updating the pileup document for pileup name: %s", doc['pileupName'])
 
                     # update MSPileup document in MongoDB
-                    self.mgr.updatePileup(doc, rseList=doc['currentRSEs'])
+                    # here we update our new document in database with document validation
+                    self.mgr.updatePileupDocumentInDatabase(doc, rseList=doc['currentRSEs'])
                     self.logger.info("Pileup name %s had its fraction updated in the partialPileupTask function", doc['pileupName'])
                 except Exception as exp:
                     msg = f"Failed to update MSPileup document, {exp}"
@@ -516,7 +518,9 @@ def monitoringTask(doc, spec):
     # persist an up-to-date version of the pileup data structure in MongoDB
     if modify:
         logger.info(f"monitoring task {uuid}, update {pname}")
-        mgr.updatePileup(doc, validate=False)
+        # here we update our new document in database without validation since
+        # we only updated rule ids and rses
+        mgr.updatePileupDocumentInDatabase(doc, validate=False)
         msg = f"update pileup {pname}"
         report.addEntry('monitoring', uuid, msg)
     else:
@@ -582,7 +586,9 @@ def inactiveTask(doc, spec):
     # persist an up-to-date version of the pileup data structure in MongoDB
     if modify:
         logger.info(f"inactive task {uuid}, update {pname}")
-        mgr.updatePileup(doc, validate=False)
+        # here we update our new document in database without validation since
+        # we only updated rule ids and rses
+        mgr.updatePileupDocumentInDatabase(doc, validate=False)
         msg = f"update pileup {pname}"
         report.addEntry('inactive', uuid, msg)
 
@@ -703,7 +709,9 @@ def activeTask(doc, spec):
     # persist an up-to-date version of the pileup data structure in MongoDB
     if modify:
         logger.info(f"active task {uuid} update {pname}")
-        mgr.updatePileup(doc, validate=False)
+        # here we update our new document in database without validation since
+        # we only updated rule ids and rses
+        mgr.updatePileupDocumentInDatabase(doc, validate=False)
         msg = f"update pileup {pname}"
         report.addEntry('active', uuid, msg)
     else:

--- a/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupData_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupData_t.py
@@ -9,8 +9,10 @@ import time
 import unittest
 
 # WMCore modules
-from WMCore.MicroService.MSPileup.MSPileupData import MSPileupData, stripKeys, getNewTimestamp, customDID
+from WMCore.MicroService.MSPileup.MSPileupData import MSPileupData, stripKeys, getNewTimestamp, \
+    customDID, addTransitionRecord
 from WMCore.MicroService.MSPileup.MSPileupError import MSPILEUP_SCHEMA_ERROR
+from WMCore.MicroService.Tools.Common import getMSLogger
 from Utils.Timers import encodeTimestamp, decodeTimestamp, gmtimeSeconds
 
 
@@ -19,6 +21,7 @@ class MSPileupTest(unittest.TestCase):
 
     def setUp(self):
         """setup unit test class"""
+        self.logger = getMSLogger(False)
         self.validRSEs = ['rse1']
         msConfig = {'reqmgr2Url': 'http://localhost',
                     'rucioAccount': 'wmcore_test',
@@ -34,6 +37,42 @@ class MSPileupTest(unittest.TestCase):
                     'mockMongoDB': True}
         self.mgr = MSPileupData(msConfig, skipRucio=True)
 
+        pname = '/skldjflksdjf/skldfjslkdjf/PREMIX'
+        now = int(time.mktime(time.gmtime()))
+        expectedRSEs = self.validRSEs
+        fullReplicas = 1
+        pileupSize = 1
+        ruleIds = []
+        campaigns = []
+        containerFraction = 1.0
+        replicationGrouping = "ALL"
+
+        pdict = {
+            'pileupName': pname,
+            'pileupType': 'classic',
+            'insertTime': now,
+            'lastUpdateTime': now,
+            'expectedRSEs': expectedRSEs,
+            'currentRSEs': expectedRSEs,
+            'fullReplicas': fullReplicas,
+            'campaigns': campaigns,
+            'containerFraction': containerFraction,
+            'replicationGrouping': replicationGrouping,
+            'activatedOn': now,
+            'deactivatedOn': now,
+            'active': True,
+            'pileupSize': pileupSize,
+            'customName': '',
+            'transition': [],
+            'ruleIds': ruleIds}
+        self.doc = pdict
+        self.pname = pname
+        self.userDN = 'test-dn'
+        self.tranRecord = {'containerFraction': 1.0,
+                           'customDID': self.pname,
+                           'DN': self.userDN,
+                           'updateTime': gmtimeSeconds()}
+
     def testCustomDID(self):
         """Test the customDID function"""
         pname = "/abc/xyz/MINIAOD"
@@ -47,6 +86,65 @@ class MSPileupTest(unittest.TestCase):
         did = customDID(pname)
         expect = "/abc/xyz/MINIAOD-V124"
         self.assertTrue(did == expect)
+
+    def testUpdateTransitionRecord(self):
+        """Test the addTransitionRecord function"""
+        self.logger.info("test addTransitionRecord function")
+        doc = dict(self.doc)
+        userDN = ''
+        doc['transition'] = [self.tranRecord]
+        addTransitionRecord(doc, userDN, self.logger)
+        self.logger.info("1st test (empty DN) %s", doc)
+        self.assertTrue(len(doc['transition']), 1)
+        trec = doc['transition'][0]
+        self.logger.info("trec %s", trec)
+        self.assertTrue(trec['DN'], self.userDN)
+
+        # test when our document contains smaller fraction
+        fraction = 0.5
+        doc['containerFraction'] = fraction
+        doc['transition'] = [self.tranRecord]
+        addTransitionRecord(doc, userDN, self.logger)
+        self.logger.info("2nd test (container fraction) %s", doc)
+        self.assertTrue(len(doc['transition']), 2)
+        # check that all transition record have the same DN
+        for trec in doc['transition']:
+            self.assertTrue(trec['DN'], self.userDN)
+        # check container fraction of last record
+        trec = doc['transition'][-1]
+        self.logger.info("trec %s", trec)
+        self.assertTrue(trec['containerFraction'], fraction)
+
+
+        # test use-case when we supply the same container fraction
+        addTransitionRecord(doc, self.userDN, self.logger)
+        self.logger.info("2nd test (same container fraction) %s", doc)
+        self.assertTrue(len(doc['transition']), 2)
+
+        # test when our document contains smaller fraction and we add new transition record with custom DN
+        userDN = 'bla'
+        addTransitionRecord(doc, userDN, self.logger)
+        self.logger.info("3rd test (custom DN) %s", doc)
+        self.assertTrue(len(doc['transition']), 3)
+        # check that last transition record will have custom DN
+        trec = doc['transition'][-1]
+        self.assertTrue(trec['DN'], userDN)
+        # and first and second transition record should have original userDN
+        trec = doc['transition'][0]
+        self.assertTrue(trec['DN'], self.userDN)
+        trec = doc['transition'][1]
+        self.assertTrue(trec['DN'], self.userDN)
+
+        # test daemon use-case, i.e. when we update pileup record attribute w/o transition
+        doc = dict(self.doc)
+        doc['transition'] = [self.tranRecord]
+        doc['pileupSize'] = 100
+        userDN = ''
+        addTransitionRecord(doc, userDN, self.logger)
+        self.logger.info("4th test (daemon test) %s", doc)
+        self.assertTrue(len(doc['transition']), 1)
+        trec = doc['transition'][0]
+        self.assertTrue(trec['DN'], self.userDN)
 
     def testStripKeys(self):
         """
@@ -88,40 +186,13 @@ class MSPileupTest(unittest.TestCase):
         Unit test to test document creation and storage in MongoDB
         """
         skeys = ['_id']
-        pname = '/skldjflksdjf/skldfjslkdjf/PREMIX'
-        now = int(time.mktime(time.gmtime()))
-        expectedRSEs = self.validRSEs
-        fullReplicas = 1
-        pileupSize = 1
-        ruleIds = []
-        campaigns = []
-        containerFraction = 1.0
-        replicationGrouping = "ALL"
-
-        pdict = {
-            'pileupName': pname,
-            'pileupType': 'classic',
-            'insertTime': now,
-            'lastUpdateTime': now,
-            'expectedRSEs': expectedRSEs,
-            'currentRSEs': expectedRSEs,
-            'fullReplicas': fullReplicas,
-            'campaigns': campaigns,
-            'containerFraction': containerFraction,
-            'replicationGrouping': replicationGrouping,
-            'activatedOn': now,
-            'deactivatedOn': now,
-            'active': True,
-            'pileupSize': pileupSize,
-            'customName': '',
-            'transition': [],
-            'ruleIds': ruleIds}
-
-        out = self.mgr.createPileup(pdict, self.validRSEs)
+        pdict = dict(self.doc)
+        pname = self.pname
+        out = self.mgr.createPileup(pdict, self.validRSEs, userDN=self.userDN)
         self.assertEqual(len(out), 0)
 
         # now fail the RSE validation
-        out = self.mgr.createPileup(pdict, ['rse2'])[0]
+        out = self.mgr.createPileup(pdict, ['rse2'], userDN=self.userDN)[0]
         self.assertEqual(out['error'], "MSPileupError")
         self.assertEqual(out['code'], 7)
         expect = "Failed to create MSPileupObj, MSPileup input is invalid, expectedRSEs value ['rse1'] is not in validRSEs ['rse2']"

--- a/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupTasks_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupTasks_t.py
@@ -98,6 +98,7 @@ class MSPileupTasksTest(EmulatedUnitTestCase):
         """
         # we will define log stream to capture everything that goes to the log stream
         self.logger = logging.getLogger()
+        self.userDN = 'test-dn'
 
         # setup rucio client
         self.rucioAccount = 'wmcore_pileup'
@@ -148,13 +149,13 @@ class MSPileupTasksTest(EmulatedUnitTestCase):
             'ruleIds': ['rse1']}
         self.data = data
 
-        self.mgr.createPileup(data, self.validRSEs)
+        self.mgr.createPileup(data, self.validRSEs, userDN=self.userDN)
 
         # add more docs similar in nature but with different size
         data['pileupName'] = pname.replace('processed', 'processed-2')
-        self.mgr.createPileup(data, self.validRSEs)
+        self.mgr.createPileup(data, self.validRSEs, userDN=self.userDN)
         data['pileupName'] = pname.replace('processed', 'processed-3')
-        self.mgr.createPileup(data, self.validRSEs)
+        self.mgr.createPileup(data, self.validRSEs, userDN=self.userDN)
 
     def testMSPileupTasks(self):
         """
@@ -230,7 +231,7 @@ class MSPileupTasksTest(EmulatedUnitTestCase):
         trec = {'DN': 'localhost-test', 'containerFraction': 1, 'customDID': 'customDID', 'updateTime': gmtimeSeconds()}
         data.update({'transition': [trec]})
 
-        self.mgr.createPileup(data, self.validRSEs)
+        self.mgr.createPileup(data, self.validRSEs, userDN=self.userDN)
 
         # now create mock rucio client
         rucioClient = MockRucioApi(self.rucioAccount, hostUrl=self.hostUrl, authUrl=self.authUrl)
@@ -272,7 +273,7 @@ class MSPileupTasksTest(EmulatedUnitTestCase):
         trec = {'DN': 'localhost-test', 'containerFraction': 1, 'customDID': 'customDID', 'updateTime': gmtimeSeconds()}
         data.update({'transition': [trec]})
 
-        self.mgr.createPileup(data, self.validRSEs)
+        self.mgr.createPileup(data, self.validRSEs, userDN=self.userDN)
 
         # now create mock rucio client
         rucioClient = MockRucioApi(self.rucioAccount, hostUrl=self.hostUrl, authUrl=self.authUrl)
@@ -317,7 +318,7 @@ class MSPileupTasksTest(EmulatedUnitTestCase):
         self.logger.info("### step 1: create partial pileup document %s", pname)
         data = dict(self.data)
         data['pileupName'] = pname
-        self.mgr.createPileup(data, self.validRSEs)
+        self.mgr.createPileup(data, self.validRSEs, userDN=self.userDN)
 
         # sleep a little bit between creation and updated document
         time.sleep(1)
@@ -355,7 +356,7 @@ class MSPileupTasksTest(EmulatedUnitTestCase):
         # step 4 of https://gist.github.com/amaltaro/b4f9bafc0b58c10092a0735c635538b5
         # add new spec with transition change
         spec = {'pileupName': pname, 'containerFraction': 0.5}
-        res = self.mgr.updatePileup(spec)
+        res = self.mgr.updatePileup(spec, rseList=self.validRSEs)
         self.logger.info("### step 4: updatePileup %s", res)
         self.assertEqual(len(res), 0)
 
@@ -401,7 +402,7 @@ class MSPileupTasksTest(EmulatedUnitTestCase):
 
         # step 8 of https://gist.github.com/amaltaro/b4f9bafc0b58c10092a0735c635538b5
         spec = {'pileupName': pname, 'containerFraction': 0.75}
-        res = self.mgr.updatePileup(spec)
+        res = self.mgr.updatePileup(spec, rseList=self.validRSEs)
         self.logger.info("### step 8: updatePileup %s", res)
         self.assertEqual(len(res), 0)
 


### PR DESCRIPTION
Fixes #11920 

#### Status
ready

#### Description
Fix issue with empty userDN during MSPileupTask cycle of updating MSPileup record. The code has been refactored to provide new `updateTransitionRecord` function. With new stand-alone function I added separate unit test to test its functionality.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs

#### External dependencies / deployment changes
