### PR TITLE
Fix interval for WMStats DataCacheUpdate CherryPy thread

### DIFF
--- a/src/python/WMCore/WMStats/CherryPyThreads/DataCacheUpdate.py
+++ b/src/python/WMCore/WMStats/CherryPyThreads/DataCacheUpdate.py
@@ -6,6 +6,7 @@ from WMCore.WMStats.DataStructs.DataCache import DataCache
 from WMCore.Services.WMStats.WMStatsReader import WMStatsReader
 from WMCore.ReqMgr.DataStructs.RequestStatus import WMSTATS_JOB_INFO, WMSTATS_NO_JOB_INFO
 
+
 class DataCacheUpdate(CherryPyPeriodicTask):
 
     def __init__(self, rest, config):
@@ -17,7 +18,8 @@ class DataCacheUpdate(CherryPyPeriodicTask):
         """
         sets the list of functions which
         """
-        self.concurrentTasks = [{'func': self.gatherActiveDataStats, 'duration': 300}]
+        self.concurrentTasks = [{'func': self.gatherActiveDataStats,
+                                 'duration': config.dataCacheUpdateDuration}]
 
     def gatherActiveDataStats(self, config):
         """


### PR DESCRIPTION
Fixes #11571 

#### Status
ready

#### Description
It does not really fix the ticket #11571, but it's just another misbehavior and/or easy improvement identified while having a deep investigation of the WMStats service.

This PR fixes a bug in the DataCacheUpdate cherrypy thread, which is hard-coded to update the cache every 300 seconds, without taking into consideration the configurable interval via:
```
dataCacheTasks.dataCacheUpdateDuration = 60 * 5 # every 5 min
```

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
