### PR TITLE
Add WMCore.BossAir package to crabtaskwork

### DIFF
--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -223,7 +223,8 @@ dependencies = {
         'packages': ['WMCore.Credential', 'WMCore.Algorithms+', 'WMCore.WMSpec+',
                      'WMCore.JobSplitting', 'WMCore.Services+', 'Utils+'],
         'systems': ['wmc-database', 'wmc-runtime'],
-        'modules': ['WMCore.WMBS.File', 'WMCore.WMBS.WMBSBase', 'WMCore.WMBS.__init__'],
+        'modules': ['WMCore.WMBS.File', 'WMCore.WMBS.WMBSBase', 'WMCore.WMBS.__init__',
+                    'WMCore.BossAir.Plugins.BasePlugin', 'WMCore.BossAir.Plugins.__init__'],
     },
     'wmclient': {
         'systems': ['wmc-runtime', 'wmc-database']


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/11912

#### Status
Ready

#### Description
Add `WMCore.BossAir` to `crabtaskwork`. It is required by `WMCore.WMRuntime.Bootstrap` module.
This is only affects CRAB.

#### Is it backward compatible (if not, which system it affects?)
YES 

#### Related PRs
None

#### External dependencies / deployment changes
None
