### PR TITLE
Job Retry Project: Modifiers and MemoryModifier

### DIFF
--- a/src/python/WMComponent/ErrorHandler/ErrorHandlerPoller.py
+++ b/src/python/WMComponent/ErrorHandler/ErrorHandlerPoller.py
@@ -10,7 +10,7 @@ config.ErrorHandler.maxRetries
 
 If the max retries value should be set by exitCode:
 
-config.ErrorHandler.
+config.ErrorHandler.exitCodesRetry = {50660: 10}
 
 However, it can also be used to handle jobs based on properties in the FWJR.
 In order to engage any of this behavior you have to set the config option:

--- a/src/python/WMComponent/JobCreator/JobCreatorPoller.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorPoller.py
@@ -412,13 +412,15 @@ class JobCreatorPoller(BaseWorkerThread):
         """
         logging.info("Beginning JobCreator.pollSubscriptions() cycle.")
         myThread = threading.currentThread()
-
+        logging.info('TEST: jobCreator.pollSubscriptions 1')
         # First, get list of Subscriptions
         subscriptions = self.subscriptionList.execute()
-
+        logging.info('TEST: jobCreator.pollSubscriptions 2')
         # Okay, now we have a list of subscriptions
         for subscriptionID in subscriptions:
+            logging.info('TEST: jobCreator.pollSubscriptions 3. subscriptionID is {}'.format(subscriptionID))
             wmbsSubscription = Subscription(id=subscriptionID)
+            logging.info('TEST: jobCreator.pollSubscriptions 4. Subscription is {}'.format(wmbsSubscription))
             try:
                 wmbsSubscription.load()
             except IndexError:
@@ -431,8 +433,10 @@ class JobCreatorPoller(BaseWorkerThread):
                 continue
 
             workflow = Workflow(id=wmbsSubscription["workflow"].id)
+            logging.info('TEST: jobCreator.pollSubscriptions 5. workflow is {}'.format(workflow))
             workflow.load()
             wmbsSubscription['workflow'] = workflow
+            logging.info('TEST: jobCreator.pollSubscriptions 6. wmbsSubscription is {}'.format(wmbsSubscription))
             wmWorkload = retrieveWMSpec(workflow=workflow)
 
             if not workflow.task or not wmWorkload:

--- a/src/python/WMComponent/RetryManager/Modifier/BaseModifier.py
+++ b/src/python/WMComponent/RetryManager/Modifier/BaseModifier.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+
+"""
+_BaseModifier_
+
+
+"""
+
+import pickle, os
+import logging
+import tarfile
+import sys
+import shutil
+from tempfile import TemporaryDirectory
+import datetime
+from WMCore.WMRuntime.SandboxCreator import SandboxCreator
+import pickle
+
+
+class BaseModifier(object):
+
+    def __init__(self, config):
+        object.__init__(self)
+        self.backupPath = "./oldSandboxes"
+        self.tempFolder 
+        self.sandboxPath = None
+        self.config = config
+
+    def loadPKL(pklFile):
+        with open(pklFile, 'rb') as file:
+            data = pickle.load(file)
+        return data
+
+    def savePKL(pklFile, data):
+        with open(pklFile, 'wb') as file:
+            pickle.dump(data, file)
+
+    def loadJobPKL(self, pklFile):
+        if self.data is None:
+            self.job = load
+
+
+    def updateSandbox(self, jobPKL, workload):
+        date = datetime.datetime.now().strftime("%y%m%d%H%M%S")
+        backupFile = f"{self.backupPath}/{jobPKL['workflow']}_{date}.tar.bz2"
+
+        shutil.copyfile(jobPKL['sandbox'], backupFile)
+
+        tempDir = TemporaryDirectory()
+        tFile = tarfile.open(jobPKL['sandbox'], "r")
+        tFile.extractall(tempDir)
+        
+        shutil.copyfile(jobPKL['spec'], tempDir+'/WMSandbox/WMWorkload.pkl')
+
+
+    def getWorkload(self, jobPKL):
+        """
+        _getWorkload_
+
+        
+        """
+        pklPath = jobPKL['spec']
+
+        configHandle = open(pklPath, "rb")
+        workload = pickle.load(configHandle)
+        configHandle.close()
+
+        return workload
+
+    def setWorkload(self, workload, jobPKL):
+        """
+        _setWorkload_
+
+        
+        """
+        pklPath = jobPKL['spec']
+
+        #Pkl the modified object
+        with open(pklPath, 'wb') as pf:
+            pickle.dump(workload, pf)
+        
+        self.updateSandbox()
+
+        return
+
+    def getModifierParam(self, jobType, param, defaultReturn = {}):
+        """
+        _getAlgoParam_
+
+        Get a parameter from the config for the current algorithm and given
+        job type
+        """
+        modName = self.__class__.__name__
+        modArgs = getattr(self.config.RetryManager, modName)
+
+        if hasattr(modArgs, jobType):
+            algoParams = getattr(modArgs, jobType)
+        else:
+            algoParams = modArgs.default
+
+        if hasattr(algoParams, param):
+            return getattr(algoParams, param)
+        else:
+            logging.error("No %s for %s algorithm and %s job type" % (param, modName, jobType))
+            return defaultReturn
+    
+    def modifyJob(self, job):
+        """
+        Executes the functions to modify the job
+        """
+        pass

--- a/src/python/WMComponent/RetryManager/Modifier/BaseModifier.py
+++ b/src/python/WMComponent/RetryManager/Modifier/BaseModifier.py
@@ -26,12 +26,12 @@ class BaseModifier(object):
         self.sandboxPath = None
         self.config = config
 
-    def loadPKL(pklFile):
+    def loadPKL(self, pklFile):
         with open(pklFile, 'rb') as file:
             data = pickle.load(file)
         return data
 
-    def savePKL(pklFile, data):
+    def savePKL(self, pklFile, data):
         with open(pklFile, 'wb') as file:
             pickle.dump(data, file)
 

--- a/src/python/WMComponent/RetryManager/Modifier/BaseModifier.py
+++ b/src/python/WMComponent/RetryManager/Modifier/BaseModifier.py
@@ -93,13 +93,13 @@ class BaseModifier(object):
         modName = self.__class__.__name__
         modArgs = getattr(self.config.RetryManager, modName)
 
-        if hasattr(modArgs, jobType):
-            algoParams = getattr(modArgs, jobType)
+        if hasattr(modArgs, jobType): #config.RetryManager.MemoryModifier.Processing = modifierParams
+            modifierParams = getattr(modArgs, jobType)
         else:
-            algoParams = modArgs.default
+            modifierParams = modArgs.default #config.RetryManager.MemoryModifier.default = modifierParams
 
-        if hasattr(algoParams, param):
-            return getattr(algoParams, param)
+        if hasattr(modifierParams, param):
+            return getattr(modifierParams, param)
         else:
             logging.error("No %s for %s algorithm and %s job type" % (param, modName, jobType))
             return defaultReturn

--- a/src/python/WMComponent/RetryManager/Modifier/BaseModifier.py
+++ b/src/python/WMComponent/RetryManager/Modifier/BaseModifier.py
@@ -22,7 +22,7 @@ class BaseModifier(object):
     def __init__(self, config):
         object.__init__(self)
         self.backupPath = "./oldSandboxes"
-        self.tempFolder 
+        #self.tempFolder --> not being used? Initialized as what?
         self.sandboxPath = None
         self.config = config
 

--- a/src/python/WMComponent/RetryManager/Modifier/BaseModifier.py
+++ b/src/python/WMComponent/RetryManager/Modifier/BaseModifier.py
@@ -40,7 +40,7 @@ class BaseModifier(object):
             self.job = load
 
 
-    def updateSandbox(self, jobPKL, workload):
+    def updateSandbox(self, jobPKL, workload): # Not using workload?
         date = datetime.datetime.now().strftime("%y%m%d%H%M%S")
         backupFile = f"{self.backupPath}/{jobPKL['workflow']}_{date}.tar.bz2"
 
@@ -79,7 +79,7 @@ class BaseModifier(object):
         with open(pklPath, 'wb') as pf:
             pickle.dump(workload, pf)
         
-        self.updateSandbox()
+        self.updateSandbox(jobPKL, workload) # Not using workload in this function updateSandbox
 
         return
 

--- a/src/python/WMComponent/RetryManager/Modifier/BaseModifier.py
+++ b/src/python/WMComponent/RetryManager/Modifier/BaseModifier.py
@@ -24,6 +24,7 @@ class BaseModifier(object):
         self.backupPath = "oldSandboxes/"
         self.sandboxPath = None
         self.config = config
+        self.dataDict = {}
 
     def loadPKL(self, pklFile):
         with open(pklFile, 'rb') as file:
@@ -33,11 +34,12 @@ class BaseModifier(object):
     def savePKL(self, pklFile, data):
         with open(pklFile, 'wb') as file:
             pickle.dump(data, file)
-
-    def loadJobPKL(self, pklFile):
-        if self.data is None:
-            self.job = load
-
+            
+    def getDataDict(self):
+        return self.dataDict
+    
+    def updateDataDict(self, key, value):
+        self.dataDict[key] = value
 
     def updateSandbox(self, jobPKL, workload): # Not using workload?
         date = datetime.datetime.now().strftime("%y%m%d%H%M%S")

--- a/src/python/WMComponent/RetryManager/Modifier/BaseModifier.py
+++ b/src/python/WMComponent/RetryManager/Modifier/BaseModifier.py
@@ -25,39 +25,65 @@ class BaseModifier(object):
         self.backupPath = "oldSandboxes/"
         self.sandboxPath = None
         self.config = config
-        self.dataDictJson = '/data/tier0/WMAgent.venv3/dataDict.json'
+        #self.dataDictJson = '/data/tier0/WMAgent.venv3/dataDict.json' # How to save it in $WMA_INSTALL_DIR/RetryManager ?
 
-        if os.path.exists('{}'.format(self.dataDictJson)):
+        self.logDir = getattr(config.RetryManager, 'componentDir')
+        self.dataDictJson = "%s/%s" % (self.logDir, 'dataDict.json')
+
+
+        if os.path.exists(self.dataDictJson):
             self.dataDict = self.readDataDict(self.dataDictJson)
         else:
             self.dataDict = {}
             self.writeDataDict(self.dataDictJson, self.dataDict)
 
     def loadPKL(self, pklFile):
+        """
+        __loadPKL__
+
+        Loads data from pickle file
+        Used for job.pkl
+        """
         with open(pklFile, 'rb') as file:
             data = pickle.load(file)
         return data
 
     def savePKL(self, pklFile, data):
+        """
+        __savePKL__
+
+        Saves new job data into pickle file
+        Used for job.pkl
+        """
         with open(pklFile, 'wb') as file:
             pickle.dump(data, file)
             
-    def getDataDict(self):
-        return self.dataDict
-    
-    def updateDataDict(self, key, value):
-        self.dataDict[key] = value
-
     def writeDataDict(self, jsonPath, jsonData):
+        """
+        __writeDataDict__
+
+        Writes updates dataDict into json file in the component directory
+        Json file serves as record keeping of job modifications that have taken place by a modifier
+        """
         with open(jsonPath, 'w') as jsonDataDict:
             json.dump(jsonData, jsonDataDict, indent=4)
 
     def readDataDict(self, jsonPath):
+        """
+        __readDataDict__
+
+        Retreives dataDict from json file
+        """
         with open(jsonPath, 'r') as jsonDataDict:
             data = json.load(dataJson)
         return data
 
-    def updateSandbox(self, jobPKL, workload): # Not using workload?
+    def updateSandbox(self, jobPKL): 
+        """
+        __updateSandbox__
+
+
+        """
         date = datetime.datetime.now().strftime("%y%m%d%H%M%S")
         os.makedirs(os.path.dirname(self.backupPath), exist_ok=True)
         backupFile = f"{self.backupPath}/{jobPKL['workflow']}_{date}.tar.bz2"
@@ -114,7 +140,7 @@ class BaseModifier(object):
         with open(pklPath, 'wb') as pf:
             pickle.dump(workload, pf)
         
-        self.updateSandbox(jobPKL, workload) # Not using workload in this function updateSandbox
+        self.updateSandbox(jobPKL)
 
         return
 
@@ -122,8 +148,7 @@ class BaseModifier(object):
         """
         _getAlgoParam_
 
-        Get a parameter from the config for the current algorithm and given
-        job type
+        Get a parameter from the config for the current algorithm and given job type
         """
         modName = self.__class__.__name__
         modArgs = getattr(self.config.RetryManager, modName)
@@ -144,3 +169,16 @@ class BaseModifier(object):
         Executes the functions to modify the job
         """
         pass
+
+#    def getDataDict(self):
+#        """
+#        __getDataDict__
+#        """
+#        return self.dataDict
+    
+#    def updateDataDict(self, key, value):
+#        """
+#        __updateDataDict__
+
+#        """
+#        self.dataDict[key] = value

--- a/src/python/WMComponent/RetryManager/Modifier/BaseModifier.py
+++ b/src/python/WMComponent/RetryManager/Modifier/BaseModifier.py
@@ -7,6 +7,7 @@ _BaseModifier_
 """
 
 import pickle, os
+import json
 import logging
 import tarfile
 import sys
@@ -24,7 +25,13 @@ class BaseModifier(object):
         self.backupPath = "oldSandboxes/"
         self.sandboxPath = None
         self.config = config
-        self.dataDict = {}
+        self.dataDictJson = '/data/tier0/WMAgent.venv3/dataDict.json'
+
+        if os.path.exists('{}'.format(self.dataDictJson)):
+            self.dataDict = self.readDataDict(self.dataDictJson)
+        else:
+            self.dataDict = {}
+            self.writeDataDict(self.dataDictJson)
 
     def loadPKL(self, pklFile):
         with open(pklFile, 'rb') as file:
@@ -40,6 +47,15 @@ class BaseModifier(object):
     
     def updateDataDict(self, key, value):
         self.dataDict[key] = value
+
+    def writeDataDict(self, jsonPath, jsonData):
+        with open(jsonPath, 'w') as jsonDataDict:
+            json.dump(jsonData, jsonDataDict, indent=4)
+
+    def readDataDict(self, jsonPath):
+        with open(jsonPath, 'r') as jsonDataDict:
+            data = json.load(dataJson)
+        return data
 
     def updateSandbox(self, jobPKL, workload): # Not using workload?
         date = datetime.datetime.now().strftime("%y%m%d%H%M%S")

--- a/src/python/WMComponent/RetryManager/Modifier/BaseModifier.py
+++ b/src/python/WMComponent/RetryManager/Modifier/BaseModifier.py
@@ -62,12 +62,19 @@ class BaseModifier(object):
         tempDir.cleanup()
         return
         
+    def getTask(self, jobPKL):
+        """
+        _getTask_
 
+        """
+        task = jobPKL['task']
+        return task
+    
     def getWorkload(self, jobPKL):
         """
         _getWorkload_
 
-        
+
         """
         pklPath = jobPKL['spec']
 

--- a/src/python/WMComponent/RetryManager/Modifier/BaseModifier.py
+++ b/src/python/WMComponent/RetryManager/Modifier/BaseModifier.py
@@ -31,7 +31,7 @@ class BaseModifier(object):
             self.dataDict = self.readDataDict(self.dataDictJson)
         else:
             self.dataDict = {}
-            self.writeDataDict(self.dataDictJson)
+            self.writeDataDict(self.dataDictJson, self.dataDict)
 
     def loadPKL(self, pklFile):
         with open(pklFile, 'rb') as file:

--- a/src/python/WMComponent/RetryManager/Modifier/BaseModifier.py
+++ b/src/python/WMComponent/RetryManager/Modifier/BaseModifier.py
@@ -75,7 +75,7 @@ class BaseModifier(object):
         Retreives dataDict from json file
         """
         with open(jsonPath, 'r') as jsonDataDict:
-            data = json.load(dataJson)
+            data = json.load(jsonDataDict)
         return data
 
     def updateSandbox(self, jobPKL): 

--- a/src/python/WMComponent/RetryManager/Modifier/BaseModifier.py
+++ b/src/python/WMComponent/RetryManager/Modifier/BaseModifier.py
@@ -62,13 +62,13 @@ class BaseModifier(object):
         tempDir.cleanup()
         return
         
-    def getTask(self, jobPKL):
+    def getTaskPath(self, jobPKL):
         """
         _getTask_
 
         """
-        task = jobPKL['task']
-        return task
+        taskPath = jobPKL['task']
+        return taskPath
     
     def getWorkload(self, jobPKL):
         """

--- a/src/python/WMComponent/RetryManager/Modifier/MemoryModifier.py
+++ b/src/python/WMComponent/RetryManager/Modifier/MemoryModifier.py
@@ -72,11 +72,6 @@ class MemoryModifier(BaseModifier):
         The "main" function in charge of modifying the memory before a retry. 
         It needs to modify the job.pkl file and the workflow sandbox
         """
-        settings = self.getModifierParam(job['jobType'], 'settings')
-        if not settings['requiresModify']:
-            logging.info('requiresModify set to False or not specified')
-            logging.info('Not performing any modifications')
-            return
         
         pklFile = '{}/job.pkl'.format(job['cache_dir']) 
         jobPKL = self.loadPKL(pklFile)
@@ -87,5 +82,21 @@ class MemoryModifier(BaseModifier):
         self.changeSandbox(jobPKL, newMemory)
 
     def modifyJob(self, job):
+        try:
+            settings = self.getModifierParam(job['jobType'], 'settings')
+        except:
+            logging.exception('Error while getting the MemoryModifier settings parameter. Not modifying memory')
+            return
+        
+        if not 'requiresModify' in settings:
+            logging.info('requiresModify not specified')
+            logging.info('Not performing any modifications')
+            return 
 
-        self.changeMemory(job)
+        elif not settings['requiresModify']:
+            logging.info('requiresModify set to False')
+            logging.info('Not performing any modifications')
+            return
+        
+        else:
+            self.changeMemory(job)

--- a/src/python/WMComponent/RetryManager/Modifier/MemoryModifier.py
+++ b/src/python/WMComponent/RetryManager/Modifier/MemoryModifier.py
@@ -49,15 +49,14 @@ class MemoryModifier(BaseModifier):
         print (data['estimatedMemoryUsage'])
 
     def getNewMemory(self, jobPKL, settings):
-        maxMemPerCore = settings['maxMemory']
-        #Finds job.pkl file
-
+        maxMemPerCore = settings['maxMemory']/jobPKL['numberOfCores']
         currentMem = jobPKL['estimatedMemoryUsage']
         currentMemPerCore = currentMem/jobPKL['numberOfCores']
+
         if 'multiplyMemory' in settings:
             newMemPerCore = currentMemPerCore * settings['multiplyMemory']
         elif 'addMemory' in settings:
-            newMemPerCore = currentMemPerCore + settings['addMemory']
+            newMemPerCore = currentMemPerCore + (settings['addMemory']/jobPKL['numberOfCores'])
         else:
             newMemPerCore = currentMemPerCore
             logging.info('No increment values were given in the MemoryModifier parameter')
@@ -67,7 +66,7 @@ class MemoryModifier(BaseModifier):
             newMemPerCore = maxMemPerCore
         return newMemPerCore * jobPKL['numberOfCores']
     
-    def changeMemory(self, job):
+    def changeMemory(self, job, settings):
         """
         The "main" function in charge of modifying the memory before a retry. 
         It needs to modify the job.pkl file and the workflow sandbox
@@ -99,4 +98,4 @@ class MemoryModifier(BaseModifier):
             return
         
         else:
-            self.changeMemory(job)
+            self.changeMemory(job, settings)

--- a/src/python/WMComponent/RetryManager/Modifier/MemoryModifier.py
+++ b/src/python/WMComponent/RetryManager/Modifier/MemoryModifier.py
@@ -31,7 +31,7 @@ class MemoryModifier(BaseModifier):
         for task in workHelper.getAllTasks():
             task.setMaxPSS(newMemory)
 
-        self.setWorkload(workload)
+        self.setWorkload(workload, jobPKL)
 
         return
 
@@ -40,6 +40,7 @@ class MemoryModifier(BaseModifier):
         Modifies the pklFile job.pkl by changing the estimatedMemoryUsage to a new_memory value
 
         """
+        logging.info('MemoryModifier.changeJobPkl: Modifying {} job memory. Previous value: {}. New value: {}'.format(jobPKL['jobType'], jobPKL['estimatedMemoryUsage'], newMemory))
         jobPKL['estimatedMemoryUsage'] = newMemory 
         self.savePKL(pklFile, jobPKL)
 
@@ -98,4 +99,5 @@ class MemoryModifier(BaseModifier):
             return
         
         else:
+            logging.info('MemoryModifier.changeMemory called successfully')
             self.changeMemory(job, settings)

--- a/src/python/WMComponent/RetryManager/Modifier/MemoryModifier.py
+++ b/src/python/WMComponent/RetryManager/Modifier/MemoryModifier.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+
+"""
+_MemoryModifier_
+
+config.RetryManager.section_('MemoryModifier')
+config.RetryManager.MemoryModifier.section_('default')
+config.RetryManager.MemoryModifier.default.maxMemory = 2000 # Memory/cpu in MB
+config.RetryManager.MemoryModifier.section_('merge')
+config.RetryManager.MemoryModifier.merge.maxMemory = 3000 # Memory/cpu in MB
+"""
+
+import pickle
+from WMCore.WMSpec.WMWorkload import WMWorkloadHelper
+from WMComponent.RetryManager.Modifier.BaseModifier import BaseModifier
+import pickle
+
+
+class MemoryModifier(BaseModifier):
+
+    def changeSandbox(self, jobPKL, newMemory):
+        """
+        _changeSandbox_
+
+        Modifies the parameter maxPSS in the sandbox. This is a change that applies for all jobs in that workflow that remain to be submitted 
+        """
+
+        workload = self.getWorkload(jobPKL)
+        workHelper = WMWorkloadHelper(workload)
+
+        for task in workHelper.getAllTasks():
+            task.setMaxPSS(newMemory)
+
+        self.setWorkload(workload)
+
+        return
+
+    def changeJobPkl(self, jobPKL, newMemory):
+        """
+        Modifies the pklFile job.pkl by changing the estimatedMemoryUsage to a new_memory value
+
+        """
+        jobPKL['estimatedMemoryUsage'] = newMemory
+        pklFile = '{}/job.pkl'.format(jobPKL['cache_dir']) 
+        self.savePKL(pklFile,data)
+
+
+    def checkNewJobPkl(pklFile):
+        with open(pklFile, 'rb') as file:
+            data = pickle.load(file)
+        print (data['estimatedMemoryUsage'])
+
+    def getNewMemory(self, jobPKL):
+        maxMemPerCore = self.getModifierParam(job['jobType'], 'maxMemory')
+        #Finds job.pkl file
+
+        currentMem = jobPKL['estimatedMemoryUsage']
+        currentMemPerCore = currentMem/jobPKL['numberOfCores']
+        newMemPerCore = currentMemPerCore * 1.5
+        if newMemPerCore > maxMemPerCore:
+            newMemPerCore = maxMemPerCore
+        return maxMemPerCore * jobPKL['numberOfCores']
+
+    def changeMemory(self, job):
+        """
+        The "main" function in charge of modifying the memory before a retry. 
+        It needs to modify the job.pkl file and the workflow sandbox
+        """
+        pklFile = '{}/job.pkl'.format(job['cache_dir']) 
+        jobPKL = self.loadPKL(pklFile)
+        newMemory = self.getNewMemory(jobPKL)
+
+        self.changeJobPkl(jobPKL, newMemory)
+        self.changeSandbox(jobPKL, newMemory)
+
+    def modifyJob(self, job):
+        self.changeMemory(job)

--- a/src/python/WMComponent/RetryManager/Modifier/MemoryModifier.py
+++ b/src/python/WMComponent/RetryManager/Modifier/MemoryModifier.py
@@ -3,14 +3,83 @@
 """
 _MemoryModifier_
 
+This particular modifier is in charge of incrementing memory to jobs that require it before resuming them.
+Note: It does not resume the job.
+
+It takes a failed job with exit code 50660 and it proceeds to modify the estimatedMemoryUsage in job.pkl and the maxPSS in the task
+The MemoryModifier will only proceed to modify the memory if its properly enabled for the job type of the job in question.
+
+Example: 
+# To enable MemoryModifier:
+config.RetryManager.modifiers = {50660: 'MemoryModifier'}
+config.RetryManager.section_('MemoryModifier')
+
+# To configure the setup for a specific job type: 
+config.RetryManager.MemoryModifier.section_('Processing')
+config.RetryManager.MemoryModifier.Processing.settings = {'requiresModify': True, 'multiplyMemoryPerCore': 1.5, 'maxMemoryPerCore': 2000}
+
+# To configure default job type:
+config.RetryManager.MemoryModifier.section_('default')
+config.RetryManager.MemoryModifier.default.settings = {'requiresModify': True, 'multiplyMemoryPerCore': 1.5, 'maxMemoryPerCore': 2000}
+
+# All together usage:
+
 config.RetryManager.modifiers = {50660: 'MemoryModifier'}
 config.RetryManager.section_('MemoryModifier')
 config.RetryManager.MemoryModifier.section_('default')
-config.RetryManager.MemoryModifier.default.settings = {'requiresModify': False, 'addMemoryPerCore': 200, 'maxMemoryPerCore': 2000}
+config.RetryManager.MemoryModifier.default.settings = {'requiresModify': False, 'multiplyMemoryPerCore': 1.5, 'maxMemoryPerCore': 2000}
 config.RetryManager.MemoryModifier.section_('Processing')
-config.RetryManager.MemoryModifier.Processing.settings = {'requiresModify': True, 'addMemoryPerCore': 200, 'maxMemoryPerCore': 2500}
+config.RetryManager.MemoryModifier.Processing.settings = {'requiresModify': False, 'multiplyMemoryPerCore': 1.2, 'maxMemoryPerCore': 2000}
 config.RetryManager.MemoryModifier.section_('merge')
-config.RetryManager.MemoryModifier.merge.settings = {'requiresModify': True, 'multiplyMemoryPerCore': 1.2, 'maxMemoryPerCore': 3000}
+config.RetryManager.MemoryModifier.merge.settings = {'requiresModify': False, 'multiplyMemoryPerCore': 1.2, 'maxMemoryPerCore': 2000}
+
+dataDict = {'someTask': {
+                         'maxPSS': [firstMaxPSS, secondMaxPSS, ...], 
+                         'jobs': {
+                                  'someJobId': [firstEstimatedMemoryUsage, secondEstimatedMemoryUsage, ...],
+                                  'anotherJobId': [...]
+                                  }
+                         'jobIDs': [firstJobId, secondJobId ...]
+                         } 
+            }
+sample dataDict:
+{
+    "/Repack_Run382810_StreamALCAPHISYM_Tier0_REPLAY_2024_ID240708022442_v8022442/Repack": {
+        "maxPSS": [
+            250.0,
+            500.0,
+            1000.0,
+            2000.0
+        ],
+        "jobs": {
+            "102": [
+                250.0, 
+                500.0, 
+                1000.0, 
+                2000.0
+            ],
+            "103": [
+                250.0, 
+                500.0
+            ],
+            "1547": [
+                250.0, 
+                500.0, 
+                1000.0
+            ]
+        },
+        "jobIDs": [
+            102,
+            103,
+            1547,
+            102,
+            1547,
+            102
+        ]
+    },
+    ...
+}
+
 """
 import time
 import os
@@ -29,7 +98,6 @@ class MemoryModifier(BaseModifier):
 
         Modifies the parameter maxPSS in the sandbox. This is a change that applies for all jobs in that workflow that remain to be submitted 
         """
-
         workload = self.getWorkload(jobPKL)
         workHelper = WMWorkloadHelper(workload)
 
@@ -44,7 +112,10 @@ class MemoryModifier(BaseModifier):
     
     def changeMemoryForTask(self, taskPath, jobPKL, newMemory):
         """
-        Approach to modify memory per task, rather than continuously changing the whole workflow
+        __changeMemoryForTask__
+
+        Gets workload to get access to job task
+        Sets new maxPSS at task level
         """
         workload = self.getWorkload(jobPKL)
         workHelper = WMWorkloadHelper(workload)
@@ -54,23 +125,22 @@ class MemoryModifier(BaseModifier):
 
     def changeJobPkl(self, pklFile, jobPKL, newMemory):
         """
-        Modifies the pklFile job.pkl by changing the estimatedMemoryUsage to a new_memory value
+        __changeJobPkl__
 
+        Modifies the pklFile job.pkl by changing the estimatedMemoryUsage to a new_memory value
         """
-        current_time = time.localtime()
-        formatted_time = time.strftime("%Y-%m-%d %H:%M:%S", current_time)
         logging.info('MemoryModifier modifying %s job pkl file. Previous value: %d. New value: %d', jobPKL['jobType'], jobPKL['estimatedMemoryUsage'], newMemory)
-        os.system('echo "time: {}; job: {}; job type: {}; job old memory: {}; job new memory: {}" >> /data/tier0/WMAgent.venv3/memoryLogsChangeJobPkl.txt'.format(formatted_time, jobPKL['id'], jobPKL['jobType'], jobPKL['estimatedMemoryUsage'], newMemory))
         jobPKL['estimatedMemoryUsage'] = newMemory 
         self.savePKL(pklFile, jobPKL)
 
-    def checkNewJobPkl(pklFile):
-        with open(pklFile, 'rb') as file:
-            data = pickle.load(file)
-        print (data['estimatedMemoryUsage'])
-
     def getNewMemory(self, taskPath, currentMemory, numberOfCores, settings):
+        """
+        __getNewMemory__
 
+        Determines the new memory for the retry
+        New memory should not be greater than max memory in settings parameter
+        New memory should be greater than or equal to current memory in task (i.e maxPSS)
+        """
         maxMemPerCore = settings['maxMemoryPerCore']
         currentMemPerCore = currentMemory/numberOfCores
 
@@ -93,84 +163,57 @@ class MemoryModifier(BaseModifier):
     
     def changeMemory(self, job, settings):
         """
+        __changeMemory__
+
         The "main" function in charge of modifying the memory before a retry. 
-        It needs to modify the job.pkl file and the maxPSS value for the respective task
+        Modifies job.pkl first
+        Modifies task maxPSS second, if newMemory exceeds current maxPSS
         """
-        current_time = time.localtime()
-        formatted_time = time.strftime("%Y-%m-%d %H:%M:%S", current_time)
+
         pklFile = '{}/job.pkl'.format(job['cache_dir']) 
         jobPKL = self.loadPKL(pklFile)
 
         currentMemory = jobPKL['estimatedMemoryUsage']
         numberOfCores = jobPKL['numberOfCores']
-        currentJob = jobPKL['id']
-        taskPath = self.getTaskPath(jobPKL)
+        currentJob    = jobPKL['id']
+        taskPath      = self.getTaskPath(jobPKL)
 
         if not taskPath in self.dataDict:
             taskData = {'maxPSS': [currentMemory], 'jobs': {}, 'jobIDs': []}
             self.dataDict[taskPath] = taskData
-            #self.updateDataDict(key=taskPath, value=taskData)
 
         newMemory = self.getNewMemory(taskPath, currentMemory, numberOfCores, settings)
         
+        ### TESTING ###
+        logging.info('TEST: current task is {}'.format(taskPath))
+        logging.info('TEST: Pre-Mod dataDict: {}'.format(self.dataDict))
+        ### TESTING ###
 
-
-        ###
-        logging.info('CURRENT TASK is {}'.format(taskPath))
-        logging.info('Pre-Mod dataDict: {}'.format(self.dataDict))
-        ###
-
-        os.system('echo "{}; {}; {}; {} " >> /data/tier0/WMAgent.venv3/srv/wmagent/2.3.4rc11/logs/jobs/{}_job_{}.txt'.format(formatted_time, jobPKL['id'], jobPKL['estimatedMemoryUsage'], newMemory, jobPKL['jobType'] ,jobPKL['id']))
-        os.system('echo "{}; {}; {}; {}; {} " >> /data/tier0/WMAgent.venv3/srv/wmagent/2.3.4rc11/logs/jobs/all.txt'.format(formatted_time, jobPKL['jobType'], jobPKL['id'], jobPKL['estimatedMemoryUsage'], newMemory))
-
+        # Changing job.pkl estimatedMemoryUsage
         self.changeJobPkl(pklFile, jobPKL, newMemory)
-        
-        oldMemory = currentMemory
+        oldMemory     = currentMemory
         currentMemory = jobPKL['estimatedMemoryUsage'] #i.e. newMemory
-
+        
         if not currentJob in self.dataDict[taskPath]['jobs']:
             self.dataDict[taskPath]['jobs'][currentJob] = [oldMemory, currentMemory]
         else:
             self.dataDict[taskPath]['jobs'][currentJob].append(currentMemory)
 
         self.dataDict[taskPath]['jobIDs'].append(currentJob)
-        ###
-        logging.info('Post-Mod dataDict: {}'.format(self.dataDict))
-        ###
 
-        ###
-        taskMod = False
-        ###
+        ### TESTING ###
+        logging.info('TEST: Post-Mod dataDict: {}'.format(self.dataDict))
+        ### TESTING ###
 
         if self.dataDict[taskPath]['maxPSS'][-1] < newMemory:
-
-            ###
-            os.system('echo "{}; {}; {}" >> /data/tier0/WMAgent.venv3/srv/wmagent/2.3.4rc11/logs/workflows/{}.txt'.format(formatted_time, taskPath, self.dataDict[taskPath]['maxPSS'][-1], jobPKL['workflow']))
-            ###
-
             self.changeMemoryForTask(taskPath, jobPKL, newMemory)
             self.dataDict[taskPath]['maxPSS'].append(newMemory)
 
-            ###
-            os.system('echo "{}; {}; {}" >> /data/tier0/WMAgent.venv3/srv/wmagent/2.3.4rc11/logs/workflows/{}.txt'.format(formatted_time, taskPath, self.dataDict[taskPath]['maxPSS'][-1], jobPKL['workflow']))
-            os.system('echo "\n" >> /data/tier0/WMAgent.venv3/srv/wmagent/2.3.4rc11/logs/workflows/{}.txt'.format(jobPKL['workflow']))
-            ###
-
-            ###
-            taskMod = True
-            ###
-        
-        ###
-        if taskMod:
-            os.system('echo "{}; {}; {}; {}; {}; {}; {}" >> /data/tier0/WMAgent.venv3/srv/wmagent/2.3.4rc11/logs/jobs/all.txt'.format(formatted_time, jobPKL['jobType'], jobPKL['id'], jobPKL['estimatedMemoryUsage'], newMemory, taskPath, self.dataDict[taskPath]['maxPSS'][-1]))
-        ###
-
         self.writeDataDict(self.dataDictJson, self.dataDict)
-        logging.info('Old maxPSS: %d. New maxPSS: %d', jobPKL['estimatedMemoryUsage'], newMemory)
+        logging.info('Old maxPSS: %d. New maxPSS: %d', self.dataDict[taskPath]['maxPSS'][-2], self.dataDict[taskPath]['maxPSS'][-1])
 
     def modifyJob(self, job):
-        current_time = time.localtime()
-        formatted_time = time.strftime("%Y-%m-%d %H:%M:%S", current_time)
+
         try:
             settings = self.getModifierParam(job['jobType'], 'settings')
         except:
@@ -178,14 +221,13 @@ class MemoryModifier(BaseModifier):
             return
 
         if not 'requiresModify' in settings:
-            logging.debug('MemoryModifer for job type %s does not specify requiresModify. Not modifying memory',job['jobType'])
+            logging.debug('MemoryModifer for job type %s does not specify requiresModify. Not modifying memory for job %d', job['jobType'], job['id'])
             return 
 
         elif not settings['requiresModify']:
-            logging.debug('MemoryModifyer for job type %s has requiresModify set to False. Not modifying memory', job['jobType'])
+            logging.debug('MemoryModifier for job type %s has requiresModify set to False. Not modifying memory for job %d', job['jobType'], job['id'])
             return
         
         else:
             logging.info('MemoryModifier modifying memory for job %d of job type %s', job['id'], job['jobType'])
-            os.system('echo "time: {}; job: {}; job type: {}" >> /data/tier0/WMAgent.venv3/memoryLogsModifyJob.txt'.format(formatted_time, job['id'], job['jobType']))
             self.changeMemory(job, settings)

--- a/src/python/WMComponent/RetryManager/Modifier/MemoryModifier.py
+++ b/src/python/WMComponent/RetryManager/Modifier/MemoryModifier.py
@@ -50,14 +50,14 @@ class MemoryModifier(BaseModifier):
         print (data['estimatedMemoryUsage'])
 
     def getNewMemory(self, jobPKL, settings):
-        maxMemPerCore = settings['maxMemory']/jobPKL['numberOfCores']
+        maxMemPerCore = settings['maxMemory']
         currentMem = jobPKL['estimatedMemoryUsage']
         currentMemPerCore = currentMem/jobPKL['numberOfCores']
 
         if 'multiplyMemory' in settings:
             newMemPerCore = currentMemPerCore * settings['multiplyMemory']
         elif 'addMemory' in settings:
-            newMemPerCore = currentMemPerCore + (settings['addMemory']/jobPKL['numberOfCores'])
+            newMemPerCore = currentMemPerCore + settings['addMemory']
         else:
             newMemPerCore = currentMemPerCore
             logging.info('No increment values were given in the MemoryModifier parameter')
@@ -80,6 +80,7 @@ class MemoryModifier(BaseModifier):
 
         self.changeJobPkl(pklFile, jobPKL, newMemory)
         self.changeSandbox(jobPKL, newMemory)
+        logging.info('Old maxPSS: %d. New maxPSS: %d', job['estimatedMemoryUsage'], newMemory)
 
     def modifyJob(self, job):
         try:
@@ -87,7 +88,7 @@ class MemoryModifier(BaseModifier):
         except:
             logging.exception('Error while getting the MemoryModifier settings parameter. Not modifying memory')
             return
-        
+
         if not 'requiresModify' in settings:
             logging.info('requiresModify not specified')
             logging.info('Not performing any modifications')
@@ -99,5 +100,5 @@ class MemoryModifier(BaseModifier):
             return
         
         else:
-            logging.info('MemoryModifier.changeMemory called successfully')
+            logging.info('Modifying memory for job %d', job['id'])
             self.changeMemory(job, settings)

--- a/src/python/WMComponent/RetryManager/Modifier/MemoryModifier.py
+++ b/src/python/WMComponent/RetryManager/Modifier/MemoryModifier.py
@@ -21,8 +21,7 @@ from WMComponent.RetryManager.Modifier.BaseModifier import BaseModifier
 
 
 class MemoryModifier(BaseModifier):
-    def __init__(self):
-        self.taskMemory = {}
+
     def changeSandbox(self, jobPKL, newMemory):
         """
         _changeSandbox_
@@ -93,16 +92,19 @@ class MemoryModifier(BaseModifier):
 
         newMemory = self.getNewMemory(jobPKL, settings)
         taskPath = self.getTaskPath(jobPKL)
+        taskMemory = self.getDataDict()
+        logging.info('CURRENT TASK is {}'.format(taskPath))
+        logging.info('1. DICTIONARY is {}'.format(taskMemory))
 
-        if not taskPath in self.taskMemory:
-            self.taskMemory[taskPath] = job['estimatedMemoryUsage']
+        if not taskPath in taskMemory:
+            self.updateDataDict(key=taskPath, value=job['estimatedMemoryUsage'])
 
         self.changeJobPkl(pklFile, jobPKL, newMemory)
 
-        if self.taskMemory[taskPath] < newMemory:
+        logging.info('2. DICTIONARY is {}'.format(taskMemory))
+        if taskMemory[taskPath] < newMemory:
             self.changeMemoryForTask(taskPath, jobPKL, newMemory)
-            self.taskMemory[taskPath] = newMemory
-        
+            taskMemory[taskPath] = newMemory
         logging.info('Old maxPSS: %d. New maxPSS: %d', job['estimatedMemoryUsage'], newMemory)
 
     def modifyJob(self, job):

--- a/src/python/WMComponent/RetryManager/Modifier/MemoryModifier.py
+++ b/src/python/WMComponent/RetryManager/Modifier/MemoryModifier.py
@@ -15,6 +15,7 @@ config.RetryManager.MemoryModifier.merge.settings = {'requiresModify': True, 'mu
 
 import pickle
 import logging
+from WMCore.WMSpec.WMTask import WMTaskHelper
 from WMCore.WMSpec.WMWorkload import WMWorkloadHelper
 from WMComponent.RetryManager.Modifier.BaseModifier import BaseModifier
 
@@ -32,6 +33,7 @@ class MemoryModifier(BaseModifier):
         workHelper = WMWorkloadHelper(workload)
 
         for task in workHelper.getAllTasks():
+            
             task.setMaxPSS(newMemory)
             
 
@@ -43,8 +45,12 @@ class MemoryModifier(BaseModifier):
         """
         Approach to modify memory per task, rather than continuously changing the whole workflow
         """
-        task = self.getTask(jobPKL)
+        workload = self.getWorkload(jobPKL)
+        workHelper = WMWorkloadHelper(workload)
+        taskPath = self.getTaskPath(jobPKL)
+        task = workHelper.getTaskByPath(taskPath)
         task.setMaxPSS(newMemory)
+        self.setWorkload(workload, jobPKL)
 
     def changeJobPkl(self, pklFile, jobPKL, newMemory):
         """

--- a/src/python/WMComponent/RetryManager/Modifier/MemoryModifier.py
+++ b/src/python/WMComponent/RetryManager/Modifier/MemoryModifier.py
@@ -33,10 +33,18 @@ class MemoryModifier(BaseModifier):
 
         for task in workHelper.getAllTasks():
             task.setMaxPSS(newMemory)
+            
 
         self.setWorkload(workload, jobPKL)
 
         return
+    
+    def changeMemoryForTask(self, jobPKL, newMemory):
+        """
+        Approach to modify memory per task, rather than continuously changing the whole workflow
+        """
+        task = self.getTask(jobPKL)
+        task.setMaxPSS(newMemory)
 
     def changeJobPkl(self, pklFile, jobPKL, newMemory):
         """
@@ -80,7 +88,7 @@ class MemoryModifier(BaseModifier):
         newMemory = self.getNewMemory(jobPKL, settings)
 
         self.changeJobPkl(pklFile, jobPKL, newMemory)
-        self.changeSandbox(jobPKL, newMemory)
+        self.changeMemoryForTask(jobPKL, newMemory)
         logging.info('Old maxPSS: %d. New maxPSS: %d', job['estimatedMemoryUsage'], newMemory)
 
     def modifyJob(self, job):

--- a/src/python/WMComponent/RetryManager/RetryManagerPoller.py
+++ b/src/python/WMComponent/RetryManager/RetryManagerPoller.py
@@ -227,6 +227,7 @@ class RetryManagerPoller(BaseWorkerThread):
 
         # Now we should have the jobs
         propList = self.selectRetryAlgo(jobList, cooloffType)
+        logging.info('Now calling selectJobModifier')
         propList = self.selectJobModifier(propList) #this propList has the modified jobs
         
 

--- a/src/python/WMComponent/RetryManager/RetryManagerPoller.py
+++ b/src/python/WMComponent/RetryManager/RetryManagerPoller.py
@@ -149,7 +149,7 @@ class RetryManagerPoller(BaseWorkerThread):
         self.modifiers = {}
 
         self.typeModifierAssoc = getattr(self.config.RetryManager, 'modifiers', {})
-        self.typeModifierAssoc.setdefault('default', None)
+        #self.typeModifierAssoc.setdefault('default', None)
 
         for modifierName in viewvalues(self.typeModifierAssoc):
             try:

--- a/src/python/WMComponent/RetryManager/RetryManagerPoller.py
+++ b/src/python/WMComponent/RetryManager/RetryManagerPoller.py
@@ -324,18 +324,18 @@ class RetryManagerPoller(BaseWorkerThread):
         if len(jobList) == 0:
             return result
         
-        for job in jobList:
-            exitCode = self.getJobExitCode(job) #Can and should this be setup differently? Something similar to such function may exist already
+        for job in jobList: 
             try:
+                exitCode = self.getJobExitCode(job)
                 if exitCode in self.typeModifierAssoc:
                     modifierName = self.typeModifierAssoc[exitCode]
                     modifier = self.modifiers[modifierName]
                     modifier.modifyJob(job=job)
-                    
+                    logging.debug('job %d of job type %s was modified with the %s. Job %d now proceeds to retry', job['id'], job['jobType'], modifierName, job['id'])  
                 result.append(job)
 
             except Exception as ex:
-                msg = "Exception while checking the failure type for job %i\n" % job['id']
+                msg = "Exception while checking the exit code for job %i\n" % job['id']
                 msg += str(ex)
                 logging.error(msg)
                 logging.debug("Job: %s\n", job)


### PR DESCRIPTION
Fixes #[11881](https://github.com/dmwm/WMCore/issues/11881)

#### Status
In development

#### Description
Introducing Modifiers, which is a feature of the RetryManager. The setup is analog to the Plugins. After a plugin has been selected with [selectRetryAlgo](https://github.com/LinaresToine/WMCore/blob/9658b9cb711aa8a6c2e83b7b3c2049277dc491f6/src/python/WMComponent/RetryManager/RetryManagerPoller.py#L229), the RetryManagerPoller uses [selectJobModifier](https://github.com/LinaresToine/WMCore/blob/9658b9cb711aa8a6c2e83b7b3c2049277dc491f6/src/python/WMComponent/RetryManager/RetryManagerPoller.py#L231), where the jobs with specific exit codes will get modified. 

As for the Modifiers themselves, this PR only introduces the MemoryModifier, whose functions work towards modifying the job pkl file and the sandbox maxPSS parameter. To use it, the config file must be modified in a way similar to this:

config.RetryManager.modifiers={50660: 'MemoryModifier'}
config.RetryManager.section_('MemoryModifier')
config.RetryManager.MemoryModifier.section_(<jobType>)
config.RetryManager.MemoryModifier.<jobType>.settings = {'requiresModify': True, 'multiplyMemoryPerCore': 200, 'maxMemoryPerCore': 2000}

#### Is it backward compatible (if not, which system it affects?)
Maybe. I believe it is, since the modifications only imply that the list of jobs to retry will go through an extra step before actually being retried. This patch should work on previous versions without issues.

#### Related PRs
This is a formal PR to the development that was being worked on by @germanfgv and me in https://github.com/LinaresToine/WMCore/pull/3

#### External dependencies / deployment changes
None
