### PR TITLE
Use POST method for getting pileup documents in MSTransferor

### DIFF
--- a/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
+++ b/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
@@ -128,7 +128,10 @@ class MSTransferor(MSCore):
         self.logger.info("Updating all local caches...")
         self.dsetCounter = 0
         self.blockCounter = 0
-        self.pileupDocs = getPileupDocs(self.msConfig['mspileupUrl'], self.pileupQuery)
+        self.pileupDocs = getPileupDocs(self.msConfig['mspileupUrl'],
+                                        self.pileupQuery, method='POST')
+        self.logger.info("Found %s pileup documents matching the query: %s",
+                         len(self.pileupDocs), self.pileupQuery)
         campaigns = self.reqmgrAux.getCampaignConfig("ALL_DOCS")
         self.psn2pnnMap = self.cric.PSNtoPNNMap()
         self.pnn2psnMap = self.cric.PNNtoPSNMap()


### PR DESCRIPTION
Fixes #11935 
Complement to https://github.com/dmwm/WMCore/pull/11910

#### Status
ready

#### Description
The title says it all, use the POST instead of GET method for retrieving pileup documents with a specific query string.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None