### PR TITLE
Update Tape RSE attribute from ddm_quota to dm_weight in MSOutput

### DIFF
--- a/src/python/WMCore/MicroService/MSOutput/MSOutput.py
+++ b/src/python/WMCore/MicroService/MSOutput/MSOutput.py
@@ -1,13 +1,9 @@
 """
-File       : MSOtput.py
+File       : MSOutput.py
 
 Description: MSOutput.py class provides the whole logic behind
 the Output data placement in WMCore MicroServices.
 """
-
-# futures
-from __future__ import division, print_function
-from future.utils import viewitems
 
 # system modules
 import time
@@ -88,7 +84,7 @@ class MSOutput(MSCore):
         self.msConfig.setdefault("enableRelValCustodial", False)
         self.msConfig.setdefault("excludeDataTier", [])
         self.msConfig.setdefault("rucioAccount", 'wmcore_transferor')
-        self.msConfig.setdefault("rucioRSEAttribute", 'ddm_quota')
+        self.msConfig.setdefault("rucioRSEAttribute", 'dm_weight')
         self.msConfig.setdefault("rucioDiskRuleWeight", 'ddm_quota')
         self.msConfig.setdefault("rucioTapeExpression", 'rse_type=TAPE\cms_type=test')
         # This Disk expression wil target all real DISK T1 and T2 RSEs
@@ -240,7 +236,7 @@ class MSOutput(MSCore):
 
         # filter out documents already produced
         finalRequests = []
-        for reqName, reqData in viewitems(requestRecords):
+        for reqName, reqData in requestRecords.items():
             if reqName in mongoDocNames:
                 self.logger.info("Mongo document already created for %s, skipping it.", reqName)
             else:
@@ -634,7 +630,7 @@ class MSOutput(MSCore):
         A function used to update one or few particular fields in a document
         :**kwargs: The keys/value pairs to be updated (will be tested against MSOutputTemplate)
         """
-        for key, value in viewitems(kwargs):
+        for key, value in kwargs.items():
             try:
                 msOutDoc.setKey(key, value)
                 msOutDoc.updateTime()


### PR DESCRIPTION
Fixes #11939 

#### Status
ready

#### Description
Adopt a dynamic new attribute for Tape RSEs, named `dm_weight`. This attribute will be used by MSOutput to decide which Tape RSE will get the output datasets of a given workflow.

#### Is it backward compatible (if not, which system it affects?)
YES (from the WM perspective)

#### Related PRs
None

#### External dependencies / deployment changes
Services configuration PR coming up soon
Preprod (to be tested): https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/242
Prod: https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/244