### PR TITLE
Add code to insert transition record; code re-factoring

### DIFF
--- a/bin/adhoc-scripts/adjustMongoDocs.py
+++ b/bin/adhoc-scripts/adjustMongoDocs.py
@@ -16,6 +16,9 @@ EOF
 # a json structure presented in /tmp/schema.json file
 adjustMongoDocs.py --fin=/tmp/schema.json --dburi=localhost:8230 --dbname=test --dbcoll=test --verbose 1
 
+# run script to add new transition record to all MSPileup records if they do not have it
+adjustMongoDocs.py --add-tran-record --dburi=localhost:8230 --dbname=test --dbcoll=test --verbose 1
+
 NOTE: the script can run from any location assuming it has proper db uri with
 credentials and availability of mongo db outside of its own cluster, but most
 likely it will be run on mongo db k8s cluster
@@ -24,6 +27,9 @@ likely it will be run on mongo db k8s cluster
 import argparse
 import json
 from pymongo import MongoClient
+
+# WMCore services
+from Utils.Timers import gmtimeSeconds
 
 
 class OptionParser(object):
@@ -40,34 +46,79 @@ class OptionParser(object):
                                  dest="dbname", default="", help="MongoDB database")
         self.parser.add_argument("--dbcoll", action="store",
                                  dest="dbcoll", default="", help="MongoDB collection")
+        self.parser.add_argument("--userdn", action="store",
+                                 dest="userDN", default='', help="user DN")
+        self.parser.add_argument("--add-tran-record", action="store_true",
+                                 dest="transition", help="add transaction record")
         self.parser.add_argument("--verbose", action="store",
                                  dest="verbose", default=0, help="verbosity level")
 
 
-def adjust():
+def addTransitionRecord(dburi, dbname, dbcoll, userDN, verbose):
+    """
+    Helper function to add and update in place transition record for existing MSPileup records
+    :param dburi: database URI (string)
+    :param dbname: database name (string)
+    :param dbcoll: database collection name (string)
+    :param userDN: string representing user DN
+    :param verbose: verbose flag (boolean)
+    :return: nothing
+    """
+    if not userDN:
+        raise Exception("No userDN provided")
+    conn = MongoClient(host=dburi)
+    records = [r for r in conn[dbname][dbcoll].find()]
+    for rec in records:
+        if not rec.get("transition"):
+            tranRecord = {'containerFraction': 1.0,
+                          'customDID': rec['pileupName'],
+                          'updateTime': gmtimeSeconds(),
+                          'DN': userDN}
+            rec['transition'] = [tranRecord]
+            if verbose:
+                print(f"update rec={rec} with new transition record={tranRecord}")
+            spec = {'pileupName': rec['pileupName'], 'customName': rec.get('customName', '')}
+            # perform update of the record
+            conn[dbname][dbcoll].update_one(spec, {'$set': {'transition': [tranRecord]}}, upsert=True)
+
+
+def adjust(dburi, dbname, dbcoll, fin, verbose):
     """
     helper script to update documents in MongoDB with given db name/collection
     and schema file (which should contain new addition, in form of JSON, to the
     db documents)
+    :param dburi: database URI (string)
+    :param dbname: database name (string)
+    :param dbcoll: database collection name (string)
+    :param fin: input file with schema content
+    :param verbose: verbose flag (boolean)
+    :return: nothing
     """
-    optmgr = OptionParser()
-    opts = optmgr.parser.parse_args()
-    conn = MongoClient(host=opts.dburi)
-    dbname = opts.dbname
-    dbcoll = opts.dbcoll
-    verbose = opts.verbose
+    conn = MongoClient(host=dburi)
     schema = {}
-    with open(opts.fin, 'r', encoding='utf-8') as istream:
+    with open(fin, 'r', encoding='utf-8') as istream:
         schema = json.load(istream)
     if schema:
         if verbose:
-            print("read data from '%s', %s/%s" % (opts.dburi, dbname, dbcoll))
+            print(f"read data from '{dburi}', {dbname}/{dbcoll}")
         records = [r for r in conn[dbname][dbcoll].find()]
         for doc in records:
             if verbose:
-                print("update doc=%s with schema=%s" % (doc, schema))
+                print(f"update doc={doc} with schema={schema}")
             conn[dbname][dbcoll].update_one(doc, {'$set': schema}, upsert=True)
 
 
+def main():
+    """
+    Main function
+    """
+    optmgr = OptionParser()
+    opts = optmgr.parser.parse_args()
+    if opts.transition:
+        addTransitionRecord(opts.dburi, opts.dbname, opts.dbcoll, opts.userDN, opts.verbose)
+    else:
+        adjust(opts.dburi, opts.dbname, opts.dbcoll, opts.fin, opts.verbose)
+
+
 if __name__ == '__main__':
-    adjust()
+    main()


### PR DESCRIPTION
Fixes #11914, supersede #11915 

#### Status
ready

#### Description
Update ad-hoc scripts to create initial transition record for MSPileup records. There are two scripts:
- `adjustMongoDocs.py` to communicate with MongoDB directly
- `updatePileupObjects.py` to communicate with MongoDB backend via MSPileup REST API

Here is how each script can be called:
```
# adjust port, dbname and dbcoll appropriately
adjustMongoDocs.py --add-tran-record --dburi=localhost:8230 --dbname=test --dbcoll=test --verbose 1

# use update script to rely on MSPileup REST API
updatePileupObjects.py --add-tran-record -url=https://cmsweb.cern.ch --userDN=<user-dn>
```


#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
part of meta https://github.com/dmwm/WMCore/issues/11537

#### External dependencies / deployment changes
pymongo client