### PR TITLE
Fix last digit wrap in customDID sequence

### DIFF
--- a/src/python/WMCore/MicroService/MSPileup/MSPileupData.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupData.py
@@ -71,9 +71,9 @@ def customDID(pname):
     if re.match(pat, pname):
         arr = pname.split("-")
         lastSuffix = arr[-1]
-        ver = int(lastSuffix[-1])
+        ver = int(lastSuffix.replace('V', ''))
         suffix = f"{ver + 1}"
-        pname = ''.join(pname[:-1]) + suffix
+        pname = ''.join(pname.split('-V')[0]) + '-V' + suffix
     else:
         pname += "-V1"
     return pname

--- a/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupData_t.py
+++ b/test/python/WMCore_t/MicroService_t/MSPileup_t/MSPileupData_t.py
@@ -87,6 +87,18 @@ class MSPileupTest(unittest.TestCase):
         expect = "/abc/xyz/MINIAOD-V124"
         self.assertTrue(did == expect)
 
+        # test last digit wrap
+        pname = "/abc/xyz/MINIAOD-V19"
+        did = customDID(pname)
+        expect = "/abc/xyz/MINIAOD-V20"
+        self.assertTrue(did == expect)
+
+        # test last digit wrap
+        pname = "/abc/xyz/MINIAOD-V99"
+        did = customDID(pname)
+        expect = "/abc/xyz/MINIAOD-V100"
+        self.assertTrue(did == expect)
+
     def testUpdateTransitionRecord(self):
         """Test the addTransitionRecord function"""
         self.logger.info("test addTransitionRecord function")


### PR DESCRIPTION
Fixes #11736 

#### Status
ready

#### Description
I found that current algorithm in `customDID` function creates wrong sequence number when last digit is more than 10 and lasts with number 9, i.e. 19, 1119, 29, etc. This leads to non-sequential sequence number wraps, e.g. (taken from cmsweb-testbed):
```
    {
      "containerFraction": 1.0,
      "customDID": "/hasan-test10-Neutrino_E-10_gun/Run3Summer21PrePremix-120X_mcRun3_2021_realistic_v6-v2/PREMIX-V19",
      "updateTime": 1709642777,
      "DN": ""
    },
    {
      "containerFraction": 1.0,
      "customDID": "/hasan-test10-Neutrino_E-10_gun/Run3Summer21PrePremix-120X_mcRun3_2021_realistic_v6-v2/PREMIX-V110",
      "updateTime": 1709643280,
      "DN": "xxx"
    },
``` 
Please see that transition record went from `-V19` to `-V110`. This PR fixes this issue.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs

#### External dependencies / deployment changes
