### PR TITLE
Fix regex for Spec generation with alphanumerical data tiers

### DIFF
--- a/src/python/WMCore/Lexicon.py
+++ b/src/python/WMCore/Lexicon.py
@@ -437,7 +437,7 @@ def lfnBase(candidate):
     As lfn above, but for doing the lfnBase
     i.e., for use in spec generation and parsing
     """
-    regexp1 = '/([a-z]+)/([a-z0-9]+)/([a-zA-Z0-9\-_]+)/([a-zA-Z0-9\-_]+)/([A-Z\-_]+)/([a-zA-Z0-9\-_]+)'
+    regexp1 = '/([a-z]+)/([a-z0-9]+)/([a-zA-Z0-9\-_]+)/([a-zA-Z0-9\-_]+)/([A-Z0-9\-_]+)/([a-zA-Z0-9\-_]+)'
     regexp2 = '/([a-z]+)/([a-z0-9]+)/([a-z0-9]+)/([a-zA-Z0-9\-_]+)/([a-zA-Z0-9\-_]+)/([A-Z\-_]+)/([a-zA-Z0-9\-_]+)((/[0-9]+){3}){0,1}'
     regexp3 = '/(store)/(temp/)*(user|group)/(%(hnName)s|%(physics_group)s)/%(primDS)s/%(procDS)s/%(version)s' % lfnParts
 


### PR DESCRIPTION
Fixes #11930 

#### Status
ready

#### Description
While the previous changes merged in #11931 where enough to accept the final datasets and lfn of files with numbers in their data tier, it turns out workflow creation fails in the process , as the intermediate regexp of lexicon weren't updated. This fixes that.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
#11931 

#### External dependencies / deployment changes
No
