### PR TITLE
Add new Merge Repack special cases to AccountantWorker

### DIFF
--- a/src/python/WMComponent/JobAccountant/AccountantWorker.py
+++ b/src/python/WMComponent/JobAccountant/AccountantWorker.py
@@ -455,8 +455,10 @@ class AccountantWorker(WMConnectionBase):
         if jobSuccess:
             fileList = fwkJobReport.getAllFiles()
 
-            # consistency check comparing outputMap to fileList
-            # they should match except for some limited special cases
+            # Consistency check comparing outputMap to fileList
+            # they should match except for some limited special cases related to Tier-0:
+            #     Repack Merge: May not produce Error output modules
+            #     Express Merge: May not write RAW output
             # as of #7998, workflow output identifier is made of output module name and datatier
             outputModules = set([])
             for fwjrFile in fileList:
@@ -466,11 +468,7 @@ class AccountantWorker(WMConnectionBase):
                 pass
             elif jobType == "LogCollect" and not outputMap and outputModules == {'LogCollect'}:
                 pass
-            elif jobType == "Merge" and set(outputMap) == {'MergedRAW', 'MergedErrorRAW', 'logArchive'} \
-                    and outputModules == {'MergedRAW', 'logArchive'}:
-                pass
-            elif jobType == "Merge" and set(outputMap) == {'MergedRAW', 'MergedErrorRAW', 'logArchive'} \
-                    and outputModules == {'MergedErrorRAW', 'logArchive'}:
+            elif jobType == "Merge" and (set(outputMap) & {'MergedErrorRAW', 'MergedErrorL1SCOUT', 'MergedErrorHLTSCOUT'}):
                 pass
             elif jobType == "Express" and set(outputMap).difference(outputModules) == {'write_RAWRAW'}:
                 pass


### PR DESCRIPTION
Fixes #11950 

#### Status
ready

Tested with T0 Replay

#### Description
AccountantWorker verifies that each job produces all the pre-stablished output modules. Tier-0 Repack and Express workflows do now follow this rule, as each job may or may not produce an Error module, depending on the size of the output, which cannot be predicted during workflow creation. This PR refactors these exceptions to output module verification in AccountantWorker, and adds exceptions for the new Repack data tiers `HLTSCOUT` and `L1SCOUT`.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
PR allowing for use of alphanumerical data tiers:#11951 #11951 

#### External dependencies / deployment changes
