### PR TITLE
Use getTimeRotatingLogger for WMCore REST

### DIFF
--- a/src/python/WMCore/WMLogging.py
+++ b/src/python/WMCore/WMLogging.py
@@ -4,16 +4,23 @@ _WMLogging_
 
 Logging facilities used in WMCore.
 """
+from datetime import datetime, date
 import logging
-from datetime import date, timedelta
-from logging.handlers import HTTPHandler, RotatingFileHandler, TimedRotatingFileHandler
+from logging.handlers import (HTTPHandler,
+                              RotatingFileHandler,
+                              TimedRotatingFileHandler,
+                              QueueHandler,
+                              QueueListener)
+from pathlib import Path
+
 
 # a new log level which is lower than debug
 # to prevent a tsunami of log messages in debug
 # mode but to have the possibility to see all
 # database queries if necessary.
 logging.SQLDEBUG = 5
-logging.addLevelName(logging.SQLDEBUG,"SQLDEBUG")
+logging.addLevelName(logging.SQLDEBUG, "SQLDEBUG")
+
 
 def sqldebug(msg):
     """
@@ -22,7 +29,34 @@ def sqldebug(msg):
     """
     logging.log(logging.SQLDEBUG, msg)
 
-def setupRotatingHandler(fileName, maxBytes = 200000000, backupCount = 3):
+
+def log_listener(queue, name, logFile):
+    """
+    Listener process for process to fetch logs from a queue and log to the
+    root logger. The root logger is set to a TimeRotatingLogger
+
+    From
+    https://docs.python.org/3/howto/logging-cookbook.html#logging-to-a-single-file-from-multiple-processes
+
+    :param queue: The queue to listen to
+    :param name: The logger name
+    :param logFile: The TimeRotatingLogger filename
+    """
+    getTimeRotatingLogger(name, logFile)
+    while True:
+        try:
+            record = queue.get()
+            if record is None:
+                break
+            logger = logger.getLogger(record.name)
+            logger.handle(record)
+        except Exception:
+            import sys, traceback
+            print('Problem with log listener:', file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
+
+
+def setupRotatingHandler(fileName, maxBytes=200000000, backupCount=3):
     """
     _setupRotatingHandler_
 
@@ -30,55 +64,75 @@ def setupRotatingHandler(fileName, maxBytes = 200000000, backupCount = 3):
     """
     handler = RotatingFileHandler(fileName, "a", maxBytes, backupCount)
     logging.getLogger().addHandler(handler)
-    return
 
 
-def getTimeRotatingLogger(name, logFile, duration = 'midnight'):
-    """ Set the logger for time based lotaing.
+def getTimeRotatingLogger(name, logFile, duration='midnight'):
+    """
+    Set the logger for time based rotating.
     """
     logger = logging.getLogger(name)
     if duration == 'midnight':
-        handler = MyTimedRotatingFileHandler(logFile, duration, backupCount = 10)
+        handler = WMTimedRotatingFileHandler(logFile, when=duration, backupCount=10)
     else:
-        handler = TimedRotatingFileHandler(logFile, duration, backupCount = 10)
+        handler = TimedRotatingFileHandler(logFile, when=duration, backupCount=10)
     formatter = logging.Formatter("%(asctime)s:%(levelname)s:%(module)s:%(message)s")
     handler.setFormatter(formatter)
     logger.addHandler(handler)
-    logger.setLevel(logging.INFO)
+    # logger.setLevel(logging.INFO)
 
     return logger
 
 
-class MyTimedRotatingFileHandler(TimedRotatingFileHandler):
+class WMTimedRotatingFileHandler(TimedRotatingFileHandler):
     """
-    _MyTimedRotatingFileHandler_
+    _WMTimedRotatingFileHandler_
 
     Overwrite the standard filename functionality from
-    logging.handlers.MyTimedRotatingFileHandler
+    logging.handlers.TimedRotatingFileHandler
     such that it mimics the same behaviour as rotatelogs tool.
 
-    Source code from:
-    https://stackoverflow.com/questions/338450/timedrotatingfilehandler-changing-file-name
+    More information here:
+    https://docs.python.org/3/library/logging.handlers.html#baserotatinghandler
     """
-    def __init__(self, logName, interval, backupCount):
-        super(MyTimedRotatingFileHandler, self).__init__(logName, when=interval,
-                                                         backupCount=backupCount)
-
-    def doRollover(self):
+    def __init__(self, filename, when='midnight', backupCount=10, **kwargs):
         """
-        _doRollover_
-
-        Rotate the log file and add the date between the log name
-        and its extension, e.g.:
-        reqmgr2.log becomes reqmgr2-20170815.log
+        Initializes WMTimedRotatingFileHandler
         """
-        self.stream.close()
-        # replace yesterday's date by today
-        yesterdayStr = (date.today() - timedelta(1)).strftime("%Y%m%d")
-        todayStr = date.today().strftime("%Y%m%d")
-        self.baseFilename = self.baseFilename.replace(yesterdayStr, todayStr)
-        self.stream = open(self.baseFilename, 'w', encoding='utf-8')
-        self.rolloverAt = self.rolloverAt + self.interval
+        super().__init__(filename, when=when, backupCount=backupCount,
+                         delay=True, **kwargs)
+
+        today = datetime.now().strftime(self.suffix).replace('-', '')
+        # store our filename and set the filename to be used
+        self.loggerBaseName = self.baseFilename
+        filepath = Path(self.baseFilename)
+        self.baseFilename = f"{filepath.parent}/{filepath.stem}-{today}{filepath.suffix}"
+
+        self.stream = self._open()
+
+    def namer(self, default_name):
+        """
+        namer called by rotation_filename in TimedRotatingFileHandler.doRollover
+
+        For us to replicate rotatelogs, we need to add the time_str to the
+        filename before the .log suffix
+        """
+        # get the time from default_name
+        today = datetime.now().strftime(self.suffix).replace('-', '')
+        time_str = today.replace('-', '')
+        log_path = Path(self.loggerBaseName)
+        logPath = f"{log_path.parent}/{log_path.stem}-{time_str}{log_path.suffix}"
+        return logPath
+
+    def rotator(self, src, dest):
+        """
+        rotator is called by the self.rotate
+
+        Gets the new date, then sets the proper self.baseFilename
+        We don't use the default behavior of the current file being renamed
+        """
+        today = datetime.now().strftime(self.suffix).replace('-', '')
+        filepath = Path(self.loggerBaseName)
+        self.baseFilename = f"{filepath.parent}/{filepath.stem}-{today}{filepath.suffix}"
 
 
 class CouchHandler(logging.handlers.HTTPHandler):

--- a/test/python/WMCore_t/WMLogging_t.py
+++ b/test/python/WMCore_t/WMLogging_t.py
@@ -1,19 +1,30 @@
 #!/usr/bin/env python
 # encoding: utf-8
+"""
+Test case for WMLogging module
+"""
 from builtins import range
+from datetime import date
 import logging
-import unittest
 import os
-from WMCore.WMLogging import CouchHandler
+from pathlib import Path
+import unittest
+import time
+
+from WMCore.WMLogging import CouchHandler, WMTimedRotatingFileHandler
 from WMCore.Database.CMSCouch import CouchServer
 
+
 class WMLoggingTest(unittest.TestCase):
+    """
+    Unit tests for WMLogging module.
+    """
     def setUp(self):
         # Make an instance of the server
         self.server = CouchServer(os.getenv("COUCHURL", 'http://admin:password@localhost:5984'))
         testname = self.id().split('.')[-1]
         # Create a database, drop an existing one first
-        self.dbname = 'cmscouch_unittest_%s' % testname.lower()
+        self.dbname = f'cmscouch_unittest_{testname.lower()}'
 
         if self.dbname in self.server.listDatabases():
             self.server.deleteDatabase(self.dbname)
@@ -25,23 +36,86 @@ class WMLoggingTest(unittest.TestCase):
         # This used to test self._exc_info to only run on success. Broke in 2.7. Removed.
         self.server.deleteDatabase(self.dbname)
 
+        # delete testRotate directory
+        logPath = Path('testRotate')
+        for _, _, filenames in os.walk(logPath):
+            for filename in filenames:
+                os.remove(logPath.joinpath(filename))
+                pass
+
     def testLog(self):
         """
         Write ten log messages to the database at three different levels
         """
-        my_logger = logging.getLogger('MyLogger')
-        my_logger.setLevel(logging.DEBUG)
+        myLogger = logging.getLogger('MyLogger')
+        myLogger.setLevel(logging.DEBUG)
         handler = CouchHandler(self.server.url, self.dbname)
         formatter = logging.Formatter('%(message)s')
         handler.setFormatter(formatter)
-        my_logger.addHandler(handler)
+        myLogger.addHandler(handler)
 
         for _ in range(10):
-            my_logger.debug('This is probably all noise.')
-            my_logger.info('Jackdaws love my big sphinx of quartz.')
-            my_logger.error('HOLLY CRAP!')
+            myLogger.debug('This is probably all noise.')
+            myLogger.info('Jackdaws love my big sphinx of quartz.')
+            myLogger.error('HOLLY CRAP!')
         logs = self.db.allDocs()['rows']
         self.assertEqual(30, len(logs))
+
+    def testWMRotateLogs(self):
+        """
+        Test to make sure a date is in or will be added to the logName
+        """
+        todayStr = date.today().strftime("%Y%m%d")
+        defaultToday = date.today().strftime("%Y-%m-%d")
+
+        myLogger = logging.getLogger('MyLogger2')
+        myLogger.setLevel(logging.DEBUG)
+        logPath = Path('testRotate')
+        logPath.mkdir(parents=True, exist_ok=True)
+        logName = logPath.joinpath("mylog.log")
+        formatter = logging.Formatter('%(message)s')
+        handler = WMTimedRotatingFileHandler(logName,
+                                             when='S',
+                                             interval=1,
+                                             backupCount=10)
+        handler.setFormatter(formatter)
+        myLogger.addHandler(handler)
+        myLogger.info('log 1')
+        time.sleep(2)
+        myLogger.info('log 2')
+
+        p = Path('testRotate')
+        files = list(p.iterdir())
+        self.assertEqual(len(files), 2)
+        for idx, log in enumerate(sorted(files)):
+            with open(log, 'r', encoding='utf-8') as f:
+                lines = f.readlines()
+                if idx == 0:
+                    self.assertEqual(lines[0].strip(), "log 1")
+                else:
+                    self.assertEqual(lines[0].strip(), "log 2")
+                    self.assertNotIn(defaultToday, log.name)
+                    self.assertIn(todayStr, log.name)
+
+        # test backupCount
+        time.sleep(2)
+        for i in range(3, 11):
+            myLogger.info('log %s', i)
+            time.sleep(2)
+        files = list(p.iterdir())
+        self.assertEqual(len(files), 10)
+
+        myLogger.info('log %s', 11)
+        files = list(p.iterdir())
+        self.assertEqual(len(files), 11)
+
+        time.sleep(2)
+        myLogger.info('log %s', 12)
+        time.sleep(2)
+        files = list(p.iterdir())
+        self.assertEqual(len(files), 11)
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes/Is a part of #11922 

#### Status
In development | not-tested

#### Description
Should set up a Python TimedRotatingFileHandler to replace the usage of `rotatelogs`

#### Is it backward compatible (if not, which system it affects?)
MAYBE
Should only be used when `|rotatelogs ...` is not used during deployment

#### Related PRs
https://github.com/dmwm/CMSKubernetes/pull/1452
https://github.com/dmwm/CMSKubernetes/pull/1604

#### External dependencies / deployment changes
Potentially remove the use of `rotatelogs`.
