### PR TITLE
Check WMArchive doc size and cut off big docs

### DIFF
--- a/src/python/WMComponent/ArchiveDataReporter/ArchiveDataPoller.py
+++ b/src/python/WMComponent/ArchiveDataReporter/ArchiveDataPoller.py
@@ -26,7 +26,7 @@ class ArchiveDataPoller(BaseWorkerThread):
         BaseWorkerThread.__init__(self)
         self.config = config
         # setup size threshold to fit CMSWEB nginx/frontend, i.e. 8MB
-        self.sizeThreshold = self.config.get('sizeThredhold', 8*1024*1024)
+        self.sizeThreshold = getattr(config.ArchiveDataReporter, "sizeThreshold", 8*1024*1024)
 
     def setup(self, parameters):
         """


### PR DESCRIPTION
Fixes #11960 

#### Status
In development

#### Description
Provide check for newly created WMArchive document before sending them to WMArchive service. The size threshold can be configured and by default equal to 8MB (current threshold on CMSWEB nginx). To avoid flooding log with very large docs a short version of the WMArchive document (a slice) is provided and printed out to the logger together with full size of the document and used threshold.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs

#### External dependencies / deployment changes
