### PR TITLE
Avoid writing empty dict and provide dbsUrl for DBSConcurrency module

### DIFF
--- a/bin/wmagent-mod-config
+++ b/bin/wmagent-mod-config
@@ -150,6 +150,9 @@ def modifyConfiguration(config, **args):
     if hasattr(config, "DBS3Upload"):
         config.DBS3Upload.dbsUrl = args["dbs3_url"]
 
+    if hasattr(config, "WorkflowUpdater"):
+        config.WorkflowUpdater.dbsUrl = args["dbs3_reader_url"]
+
     if hasattr(config, "AsyncTransfer"):
         config.CoreDatabase.connectUrl = '%s/asynctransfer_agent' % args["couch_url"]
         config.AsyncTransfer.couch_instance = args["couch_url"]
@@ -319,7 +322,7 @@ def main(argv=None):
                                          "sb_hostname=", "sb_port=", "sb_basepath=", "ufc_hostname=", "ufc_port=",
                                          "ufc_service_url=", "ufc_cachedir=", "client_mapping=",
                                          "workload_summary_url=", "coredb_url=", "wmstats_url=", "ops_proxy=",
-                                         "reqmgr2_url=", "acdc_url=", "amq_auth_file=", "dbs3_url=",
+                                         "reqmgr2_url=", "acdc_url=", "amq_auth_file=", "dbs3_url=", "dbs3_reader_url=",
                                          "dqm_url=", "grafana_token=", "requestcouch_url=", "central_logdb_url=",
                                          "wmarchive_url=", "amq_credentials=",
                                          "rucio_account=", "rucio_host=", "rucio_auth=", "mspileup_url="])
@@ -343,7 +346,7 @@ def main(argv=None):
                           '--ufc_port', '--ufc_service_url', '--ufc_cachedir',
                           '--client_mapping', '--workload_summary_url',
                           '--wmstats_url', '--ops_proxy', '--reqmgr2_url', '--acdc_url',
-                          '--amq_auth_file', '--dbs3_url', '--dqm_url',
+                          '--amq_auth_file', '--dbs3_url', 'dbs3_reader_url', '--dqm_url',
                           '--grafana_token', '--requestcouch_url', '--central_logdb_url',
                           '--wmarchive_url', '--amq_credentials',
                           '--rucio_account', '--rucio_host', '--rucio_auth', '--mspileup_url'):

--- a/deploy/WMAgent.production
+++ b/deploy/WMAgent.production
@@ -15,6 +15,7 @@ WMSTATS_URL=https://cmsweb.cern.ch/couchdb/wmstats
 ACDC_URL=https://cmsweb.cern.ch/couchdb/acdcserver
 WORKLOAD_SUMMARY_URL=https://cmsweb.cern.ch/couchdb/workloadsummary
 DBS3_URL=https://cmsweb-prod.cern.ch/dbs/prod/global/DBSWriter
+DBS3_READER_URL=https://cmsweb-prod.cern.ch/dbs/prod/global/DBSReader
 DQM_URL=https://cmsweb.cern.ch/dqm/offline
 REQUESTCOUCH_URL=https://cmsweb.cern.ch/couchdb/reqmgr_workload_cache
 REQMGR2_URL=https://cmsweb.cern.ch/reqmgr2

--- a/deploy/WMAgent.testbed
+++ b/deploy/WMAgent.testbed
@@ -15,6 +15,7 @@ WMSTATS_URL=https://cmsweb-testbed.cern.ch/couchdb/wmstats
 ACDC_URL=https://cmsweb-testbed.cern.ch/couchdb/acdcserver
 WORKLOAD_SUMMARY_URL=https://cmsweb-testbed.cern.ch/couchdb/workloadsummary
 DBS3_URL=https://cmsweb-testbed.cern.ch/dbs/int/global/DBSWriter
+DBS3_READER_URL=https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader
 DQM_URL=https://cmsweb-testbed.cern.ch/dqm/dev
 REQUESTCOUCH_URL=https://cmsweb-testbed.cern.ch/couchdb/reqmgr_workload_cache
 REQMGR2_URL=https://cmsweb-testbed.cern.ch/reqmgr2

--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -391,6 +391,7 @@ config.WorkflowUpdater.namespace = "WMComponent.WorkflowUpdater.WorkflowUpdater"
 config.WorkflowUpdater.componentDir = config.General.workDir + "/WorkflowUpdater"
 config.WorkflowUpdater.logLevel = globalLogLevel
 config.WorkflowUpdater.pollInterval = 8 * 60 * 60  # every 8 hours
+config.WorkflowUpdater.dbsUrl = "OVER_WRITE_BY_SECRETS"
 config.WorkflowUpdater.rucioAccount = "wmcore_pileup"
 config.WorkflowUpdater.rucioUrl = "OVER_WRITE_BY_SECRETS"
 config.WorkflowUpdater.rucioAuthUrl = "OVER_WRITE_BY_SECRETS"

--- a/src/python/WMComponent/WorkflowUpdater/WorkflowUpdaterPoller.py
+++ b/src/python/WMComponent/WorkflowUpdater/WorkflowUpdaterPoller.py
@@ -397,7 +397,7 @@ class WorkflowUpdaterPoller(BaseWorkerThread):
                                 self.logger.info("Mark %s to be updated in tarball %s with a fresh pileup content",
                                                  puConfJson, tarFile)
                             else:
-                                self.logger.warning("updateBlockInfo did not return any results, will skip update of pileup json content")
+                                self.logger.warning("updateBlockInfo did not return any results for %s, will skip update of pileup json content", pileupName)
                         else:
                             msg = "### There are no differences between JSON and MSPileup content "
                             msg += f"for pileup name {pileupName}. Not updating anything!"

--- a/src/python/WMComponent/WorkflowUpdater/WorkflowUpdaterPoller.py
+++ b/src/python/WMComponent/WorkflowUpdater/WorkflowUpdaterPoller.py
@@ -394,8 +394,10 @@ class WorkflowUpdaterPoller(BaseWorkerThread):
                             if puNewJsonContent:
                                 # we update json file if we get new pileup content
                                 jdict[puConfJson] = puNewJsonContent
-                            self.logger.info("Mark %s to be updated in tarball %s with a fresh pileup content",
-                                             puConfJson, tarFile)
+                                self.logger.info("Mark %s to be updated in tarball %s with a fresh pileup content",
+                                                 puConfJson, tarFile)
+                            else:
+                                self.logger.info("updateBlockInfo did not return any results, will skipp update of pileup jsoon content")
                         else:
                             msg = "### There are no differences between JSON and MSPileup content "
                             msg += f"for pileup name {pileupName}. Not updating anything!"

--- a/src/python/WMComponent/WorkflowUpdater/WorkflowUpdaterPoller.py
+++ b/src/python/WMComponent/WorkflowUpdater/WorkflowUpdaterPoller.py
@@ -397,7 +397,7 @@ class WorkflowUpdaterPoller(BaseWorkerThread):
                                 self.logger.info("Mark %s to be updated in tarball %s with a fresh pileup content",
                                                  puConfJson, tarFile)
                             else:
-                                self.logger.info("updateBlockInfo did not return any results, will skipp update of pileup jsoon content")
+                                self.logger.warning("updateBlockInfo did not return any results, will skip update of pileup json content")
                         else:
                             msg = "### There are no differences between JSON and MSPileup content "
                             msg += f"for pileup name {pileupName}. Not updating anything!"

--- a/src/python/WMCore/Services/DBS/DBSConcurrency.py
+++ b/src/python/WMCore/Services/DBS/DBSConcurrency.py
@@ -11,20 +11,23 @@ import urllib
 from WMCore.Services.pycurl_manager import getdata as multi_getdata
 
 
-def getBlockInfo4PU(blockNames, ckey, cert):
+def getBlockInfo4PU(blockNames, dbsUrl, ckey, cert):
     """
     Fetch block information details, file list and number of events, from DBS
     server. Here we use concrete set of parameters for DBS to use in this case, i.e.
     we must look-up only valid files and get full details from the DBS API (in order
     to get number of events).
     :param blockNames: list of block names
+    :param dbsUrl: dbs URL
+    :param ckey: user keyfile
+    :param cert: user certificate
     :return: dictionary of {block: {"FileList": list of strings, "NumberOfEvents": integer}, ...}
     """
     urls = []
     for blk in blockNames:
         # need to encode block name properly
         block = urllib.parse.quote_plus(blk)
-        url = f"https://cmsweb-prod.cern.ch/dbs/prod/global/DBSReader/files?detail=true&validFileOnly=1&block_name={block}"
+        url = f"{dbsUrl}/files?detail=true&validFileOnly=1&block_name={block}"
         urls.append(url)
     # place concurrent calls to DBS, please note that multi_getdata is generator, therefore
     # it does not put DBS results into the memory until this generator is iterated

--- a/test/python/WMComponent_t/WorkflowUpdater_t/WorkflowUpdaterPoller_t.py
+++ b/test/python/WMComponent_t/WorkflowUpdater_t/WorkflowUpdaterPoller_t.py
@@ -38,7 +38,8 @@ class WorkflowUpdaterPollerTest(EmulatedUnitTestCase):
         # setup WorkflowUpdater
         config = Configuration()
         config.component_('WorkflowUpdater')
-        config.WorkflowUpdater.dbsUrl = 'https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader'
+        self.dbsUrl = 'https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader'
+        config.WorkflowUpdater.dbsUrl = self.dbsUrl
         config.WorkflowUpdater.rucioAccount = 'wma_test'
         config.WorkflowUpdater.rucioUrl = 'http://cms-rucio-int.cern.ch'
         config.WorkflowUpdater.rucioAuthUrl = 'https://cms-rucio-auth-int.cern.ch'
@@ -101,7 +102,7 @@ class WorkflowUpdaterPollerTest(EmulatedUnitTestCase):
         rses = ['rse1', 'rse2', 'rse3']
         binfo = {'PhEDExNodeNames': rses, 'files': [], 'events': 0}
         msPUBlockLoc = {'block1': binfo, 'block2': binfo}
-        doc = updateBlockInfo(jdoc, msPUBlockLoc, self.logger)
+        doc = updateBlockInfo(jdoc, msPUBlockLoc, self.dbsUrl, self.logger)
         for rec in doc.values():
             # for block1 and block2 we expect new list of rses from blockInfo
             # block3 should be discarded by now

--- a/test/python/WMComponent_t/WorkflowUpdater_t/WorkflowUpdaterPoller_t.py
+++ b/test/python/WMComponent_t/WorkflowUpdater_t/WorkflowUpdaterPoller_t.py
@@ -38,6 +38,7 @@ class WorkflowUpdaterPollerTest(EmulatedUnitTestCase):
         # setup WorkflowUpdater
         config = Configuration()
         config.component_('WorkflowUpdater')
+        config.WorkflowUpdater.dbsUrl = 'https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader'
         config.WorkflowUpdater.rucioAccount = 'wma_test'
         config.WorkflowUpdater.rucioUrl = 'http://cms-rucio-int.cern.ch'
         config.WorkflowUpdater.rucioAuthUrl = 'https://cms-rucio-auth-int.cern.ch'

--- a/test/python/WMCore_t/Services_t/DBS_t/DBSConcurrency_t.py
+++ b/test/python/WMCore_t/Services_t/DBS_t/DBSConcurrency_t.py
@@ -54,7 +54,7 @@ class DBSConcurrencyTest(EmulatedUnitTestCase):
         self.assertTrue(elapsedTime < 3)
 
         time0 = time.time()
-        blockInfoList = getBlockInfo4PU(blocks, self.ckey, self.cert)
+        blockInfoList = getBlockInfo4PU(blocks, self.dbs, self.ckey, self.cert)
         for blk, row in blockInfoList.items():
             self.logger.debug("block %s, nfiles=%d, nevents=%d", blk, len(row['FileList']), row['NumberOfEvents'])
         elapsedTime = time.time() - time0


### PR DESCRIPTION
Fixes #11736 

#### Status
ready

#### Description
During integration tests we found that written JSON contains empty structure like `{'mc': {}}`. During debugging process we found two issues:
- `updateBlockInfo` may provide empty json dict which is passed to json config file
- `getBlockInfo4PU` from `WMCore/Services/DBS/DBSConcurrency.py` module contains hard-coded cmsweb production dbs URL which may not provide correct content when we perform tests on testbed due to different databases used in production and testbed DBS.

This PR fixes both issues. In addition, it adds proper configuration to
1. WMAgent.production, and WMAgent.testbed files
2. update the default config WMAgentConfig.py file


#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Here are additional changes applied to other repositories which should be applied together with this PR:
1. to eployment repo: https://github.com/dmwm/deployment/pull/1313
2. to CMSKubernetes repo: https://github.com/dmwm/CMSKubernetes/pull/1465

#### External dependencies / deployment changes
