### PR TITLE
Add check for creating updateBlockInfo return dictionary

### DIFF
--- a/src/python/WMComponent/WorkflowUpdater/WorkflowUpdaterPoller.py
+++ b/src/python/WMComponent/WorkflowUpdater/WorkflowUpdaterPoller.py
@@ -170,7 +170,8 @@ def updateBlockInfo(jdoc, msPUBlockLoc, dbsUrl, logger):
                 newDict[blockName] = record
                 # keep track of blocks we need to update with DBS information
                 blocksToUpdate.append(blockName)
-        returnDict[puType] = newDict
+        if newDict:
+            returnDict[puType] = newDict
 
     # Update block records with DBS information.
     # Optimization note: this step is done outside of main loop above since


### PR DESCRIPTION
Fixes #11736 

#### Status
ready

#### Description
Add extra check for updateBlockInfo return dictionary which should protect us from creation of `{'mc': {}}` structures returned by this funcion.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs

#### External dependencies / deployment changes
