### PR TITLE
Bugfix part pu block level information missing fix 11736

### DIFF
--- a/src/python/WMComponent/WorkflowUpdater/WorkflowUpdaterPoller.py
+++ b/src/python/WMComponent/WorkflowUpdater/WorkflowUpdaterPoller.py
@@ -170,7 +170,8 @@ def updateBlockInfo(jdoc, msPUBlockLoc, dbsUrl, logger):
                 newDict[blockName] = record
                 # keep track of blocks we need to update with DBS information
                 blocksToUpdate.append(blockName)
-        returnDict[puType] = newDict
+        if newDict:
+            returnDict[puType] = newDict
 
     # Update block records with DBS information.
     # Optimization note: this step is done outside of main loop above since
@@ -293,7 +294,7 @@ class WorkflowUpdaterPoller(BaseWorkerThread):
                 logging.info("Agent has no active workflows with pileup at the moment")
                 return
             # resolve unique active pileup dataset names
-            uniqueActivePU = flattenList([item['pileup'] for item in puWflows])
+            uniqueActivePU = set(flattenList([item['pileup'] for item in puWflows]))
 
             # otherwise, move on retrieving pileups
             msPileupList = self.getPileupDocs()
@@ -463,7 +464,9 @@ class WorkflowUpdaterPoller(BaseWorkerThread):
                 workloadHelper.load(wflowSpec['spec'])
                 pileupSpecs = workloadHelper.listPileupDatasets()
                 if pileupSpecs:
-                    wflowSpec['pileup'] = pileupSpecs.values()
+                    wflowSpec['pileup'] = set()
+                    for pileupN in pileupSpecs.values():
+                        wflowSpec['pileup'] =  wflowSpec['pileup'] | pileupN
                     logging.info("Workflow: %s requires pileup dataset(s): %s",
                                  wflowSpec['name'], wflowSpec['pileup'])
                     wflowsWithPU.append(wflowSpec)


### PR DESCRIPTION
Fixes #11736

#### Status
 ready

#### Description
Previously we were having issues obtaining block level information from DBS, which was fixed  by correctly configuring the dbsUrl inside the `WorflowUpdater` component. This relieved two more issues :
* We were wrongly checking for empty records returned from `updateBlockInfo` we were getting an object like this `{'mc':{}}`, which is not an empty dictionary and was misleading us. 
* We were always getting the above returned by `updateBlockInfo`, because we were always sending an empty list of blocs `msPUBlockLoc:{}` to be searched for. And we were always sending this list empty, because we were failing to resolve block level information from Rucio here: https://github.com/dmwm/WMCore/blob/9e20b58bf71dfa25ff0a5ba670bc3577e20310cf/src/python/WMComponent/WorkflowUpdater/WorkflowUpdaterPoller.py#L493 , due to a bad data structure flattening in the main algorithm here: https://github.com/dmwm/WMCore/blob/9e20b58bf71dfa25ff0a5ba670bc3577e20310cf/src/python/WMComponent/WorkflowUpdater/WorkflowUpdaterPoller.py#L296 and the main reason for that faulty flattening of the data structure was this exact line here: https://github.com/dmwm/WMCore/blob/9e20b58bf71dfa25ff0a5ba670bc3577e20310cf/src/python/WMComponent/WorkflowUpdater/WorkflowUpdaterPoller.py#L466  where we populate the block level information as dictionary views, instead of direct sets. The resultant data structure (upon flattening) was not a pure list of strings, but rather a list of sets: 
* What were getting:
```
In [111]: uniqueActivePU
Out[111]: 
[{'/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL16_106X_mcRun2_asymptotic_v13-v1/PREMIX',
  '/RelValMinBias_14TeV/CMSSW_11_2_0_pre8-112X_mcRun3_2024_realistic_v10_forTrk-v1/GEN-SIM'},
 {'/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL16_106X_mcRun2_asymptotic_v13-v1/PREMIX',
  '/RelValMinBias_14TeV/CMSSW_11_2_0_pre8-112X_mcRun3_2024_realistic_v10_forTrk-v1/GEN-SIM'},
 {'/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL16_106X_mcRun2_asymptotic_v13-v1/PREMIX',
  '/RelValMinBias_14TeV/CMSSW_11_2_0_pre8-112X_mcRun3_2024_realistic_v10_forTrk-v1/GEN-SIM'},
 {'/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL16_106X_mcRun2_asymptotic_v13-v1/PREMIX',
  '/RelValMinBias_14TeV/CMSSW_11_2_0_pre8-112X_mcRun3_2024_realistic_v10_forTrk-v1/GEN-SIM'},
 {'/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL16_106X_mcRun2_asymptotic_v13-v1/PREMIX',
  '/RelValMinBias_14TeV/CMSSW_11_2_0_pre8-112X_mcRun3_2024_realistic_v10_forTrk-v1/GEN-SIM'}]
```
* What we were expecting:
``` 
In [112]: uniqueActivePU2
Out[112]: 
['/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL16_106X_mcRun2_asymptotic_v13-v1/PREMIX',
 '/RelValMinBias_14TeV/CMSSW_11_2_0_pre8-112X_mcRun3_2024_realistic_v10_forTrk-v1/GEN-SIM',
 '/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL16_106X_mcRun2_asymptotic_v13-v1/PREMIX',
 '/RelValMinBias_14TeV/CMSSW_11_2_0_pre8-112X_mcRun3_2024_realistic_v10_forTrk-v1/GEN-SIM',
 '/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL16_106X_mcRun2_asymptotic_v13-v1/PREMIX',
 '/RelValMinBias_14TeV/CMSSW_11_2_0_pre8-112X_mcRun3_2024_realistic_v10_forTrk-v1/GEN-SIM',
 '/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL16_106X_mcRun2_asymptotic_v13-v1/PREMIX',
 '/RelValMinBias_14TeV/CMSSW_11_2_0_pre8-112X_mcRun3_2024_realistic_v10_forTrk-v1/GEN-SIM',
 '/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL16_106X_mcRun2_asymptotic_v13-v1/PREMIX',
 '/RelValMinBias_14TeV/CMSSW_11_2_0_pre8-112X_mcRun3_2024_realistic_v10_forTrk-v1/GEN-SIM']
```

### With the current Fix:
I've fetched the changes from @vkuznet who has provided the first part of the fix
* We force any faulty call to `updateBlockInfo` to return an empty `{}` 
* We iterate through the sets of PU datasets returned from `WMBSHelper.listPileupDatasets` for every workflow and add them not as a view in the returned `workflowSpec` but rather as a pure set. This way later  the structure is flattened properly 
* We convert the already flattened data structure `uniqueActivePU` to a set, in order to avoid null or repeated cycles later in the code.  

#### Is it backward compatible (if not, which system it affects?)
NO NEED BE 

#### Related PRs
None

#### External dependencies / deployment changes
None
