### PR TITLE
Add WMCore.ReqMgr.Tools dependency for wmagent pypi package.

### DIFF
--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -186,6 +186,7 @@ dependencies = {
                      'WMCore.BossAir+', 'WMCore.Credential',
                      'WMCore.JobSplitting+', 'WMCore.ProcessPool',
                      'WMCore.Services+', 'WMCore.WMSpec+',
+                     'WMCore.ReqMgr.DataStructs+', 'WMCore.ReqMgr.Tools+',
                      'WMCore.WMBS+', 'WMCore.ResourceControl+'],
         'systems': ['wmc-web', 'wmc-database', 'global-workqueue', 'wmc-runtime'],
         'statics': ['bin+',


### PR DESCRIPTION
Fixes #11981 

#### Status
ready

#### Description
For deploying wmagent for T0 we  need to have the `WMCore.ReqMgr.Tools` module. Since we do not install `t0-agent` as for the rpm based deployment but we deploy directly `wmagent` package we are planning to dd the needed dependencies to the main package and once we  deprecate the rpm deployment we plan to deprecate the `t0-agent` package as well. 

The alternative would be to start us building and uploading to Pypi the `t0-agent` package as well. In addition to that we will have to change  few  other places  in the deployment scripts at `CMSKubernetes`, that's  why we prefer to take the simpler approach here and just add the dependency to the `wmagent` pypi package.   

 
#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
We need  to create  a patch tag: 2.3.3.1

