### PR TITLE
Remove dependency on deprecated method xml..getchildren

### DIFF
--- a/src/python/WMCore/Services/TagCollector/XMLUtils.py
+++ b/src/python/WMCore/Services/TagCollector/XMLUtils.py
@@ -71,7 +71,7 @@ def get_children(elem, event, row, key):
     row for given key. The change of notations can be applied during
     parsing step by using provided notations dictionary.
     """
-    for child in elem.getchildren():
+    for child in list(elem):
         child_key = child.tag
         child_data = child.attrib
         if not child_data:
@@ -79,7 +79,7 @@ def get_children(elem, event, row, key):
         else:
             child_dict = child_data
 
-        if child.getchildren():  # we got grand-children
+        if list(child):  # we got grand-children
             if child_dict:
                 row[key][child_key] = child_dict
             else:


### PR DESCRIPTION
Fixes #11982

#### Status
ready

#### Description
With this PR we get rid of  the deprecated method `getchildren` for the `xml` package

 
#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
We need to create a patch tag: 2.3.3.2