### PR TITLE
Check status of attachDIDs API and act upon it

### DIFF
--- a/src/python/Utils/IteratorTools.py
+++ b/src/python/Utils/IteratorTools.py
@@ -18,6 +18,18 @@ def grouper(iterable, n):
     return iter(lambda: list(islice(iterable, n)), [])
 
 
+def getChunk(arr, step):
+    """
+    Return chunk of entries from given array and step, it is similar in behavior to grouper
+    function but instead of returning new list it provides a generator iterable object.
+    :param arr: input array of data
+    :param step: step to iterate
+    :return: generator, set of slices with number of entries equal to step of iteration
+    """
+    for i in range(0, len(arr), step):
+        yield arr[i:i + step]
+
+
 def flattenList(doubleList):
     """
     Make flat a list of lists.

--- a/src/python/WMCore/MicroService/MSPileup/MSPileupTasks.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupTasks.py
@@ -267,7 +267,7 @@ class MSPileupTasks():
 
                     # update MSPileup document in MongoDB
                     # here we update our new document in database with document validation
-                    self.mgr.updatePileupDocumentInDatabase(doc, rseList=doc['currentRSEs'])
+                    self.mgr.updatePileupDocumentInDatabase(doc, rseList=doc['expectedRSEs'])
                     self.logger.info("Pileup name %s had its fraction updated in the partialPileupTask function", doc['pileupName'])
                 except Exception as exp:
                     msg = f"Failed to update MSPileup document, {exp}"

--- a/src/python/WMCore/MicroService/MSPileup/MSPileupTasks.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupTasks.py
@@ -220,7 +220,10 @@ class MSPileupTasks():
             newRules = []
             self.logger.info("Attaching %d blocks to custom pileup name: %s", len(customBlocks), cname)
             if len(customBlocks):
-                self.rucioClient.attachDIDs(None, cname, customBlocks, scope=self.customRucioScope)
+                status = self.rucioClient.attachDIDs(None, cname, customBlocks, scope=self.customRucioScope)
+                if not status:
+                    self.logger.error("Failed to attach DIDs to custom container %s with scope %s", cname, self.customRucioScope)
+                    continue
             for rse in doc['expectedRSEs']:
                 # create new rule for custom DID using pileup document rse
                 ruleIds = self.rucioClient.createReplicationRule(cname, rse, scope=self.customRucioScope)

--- a/test/python/Utils_t/IteratorTools_t.py
+++ b/test/python/Utils_t/IteratorTools_t.py
@@ -7,7 +7,7 @@ from builtins import range
 import itertools
 import unittest
 
-from Utils.IteratorTools import grouper, flattenList, makeListElementsUnique
+from Utils.IteratorTools import grouper, flattenList, makeListElementsUnique, getChunk
 
 
 class IteratorToolsTest(unittest.TestCase):
@@ -73,6 +73,13 @@ class IteratorToolsTest(unittest.TestCase):
         data = [(1, 2), (1, 3), (2, 4), (2, 5), (1, 3), (2, 5)]
         self.assertListEqual([(1, 2), (1, 3), (2, 4), (2, 5)], makeListElementsUnique(data))
 
+    def testGetChunk(self):
+        """
+        Test the `getChunk` function.
+        """
+        arr = range(10)
+        for chunk in getChunk(arr, 2):
+            self.assertTrue(len(chunk) == 2)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #11994 

#### Status
ready

#### Description
Check status of `rucioClient.attachDIDs` and skip MSPileup workflow if it fails

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs

#### External dependencies / deployment changes
