### PR TITLE
Adapting the references to config files and install folder for containers

### DIFF
--- a/bin/adhoc-scripts/checkStuckLQE.py
+++ b/bin/adhoc-scripts/checkStuckLQE.py
@@ -72,10 +72,8 @@ def commonDataLocation(element):
     return commonLoc
 
 def main():
-    if 'WMAGENT_CONFIG' not in os.environ:
-        os.environ['WMAGENT_CONFIG'] = '/data/srv/wmagent/current/config/wmagent/config.py'
-    config = loadConfigurationFile(os.environ["WMAGENT_CONFIG"])
-
+    config = loadConfigurationFile(os.environ.get('WMA_CONFIG_FILE', '/data/srv/wmagent/current/config/config.py')) 
+    
     if len(sys.argv) != 2:
         print("You must provide a request name")
         sys.exit(1)

--- a/bin/adhoc-scripts/drainAgent.py
+++ b/bin/adhoc-scripts/drainAgent.py
@@ -366,8 +366,7 @@ def main():
     twiki = ('<pre>', '</pre>') if args.twiki else ('', '')
     print(twiki[0])
 
-    os.environ['WMAGENT_CONFIG'] = '/data/srv/wmagent/current/config/wmagent/config.py'
-    config = loadConfigurationFile(os.environ["WMAGENT_CONFIG"])
+    config = loadConfigurationFile(os.environ.get('WMA_CONFIG_FILE', '/data/srv/wmagent/current/config/config.py')) 
 
     gmtTimeNow = strftime("%a, %d %b %Y %H:%M:%S +0000", gmtime())
     print("Drain check time: %s\n" % gmtTimeNow)

--- a/bin/adhoc-scripts/getWQStatusByWorkflow.py
+++ b/bin/adhoc-scripts/getWQStatusByWorkflow.py
@@ -37,9 +37,7 @@ def createElementsSummary(reqName, elements, queueUrl):
 
 
 def main():
-    if 'WMAGENT_CONFIG' not in os.environ:
-        os.environ['WMAGENT_CONFIG'] = '/data/srv/wmagent/current/config/wmagent/config.py'
-    config = loadConfigurationFile(os.environ["WMAGENT_CONFIG"])
+    config = loadConfigurationFile(os.environ.get('WMA_CONFIG_FILE', '/data/srv/wmagent/current/config/config.py'))
 
     if len(sys.argv) != 2:
         print("You must provide a request name")

--- a/bin/dbsbuffer-file-fix.py
+++ b/bin/dbsbuffer-file-fix.py
@@ -9,7 +9,7 @@ from WMCore.Database.DBFormatter import DBFormatter
 from WMCore.WMInit import connectToDB
 
 def fixDBSmissingFileAssoc():
-    os.environ['WMAGENT_CONFIG'] = '/data/srv/wmagent/current/config/wmagent/config.py'
+    os.environ['WMA_CONFIG_FILE'] = '/data/srv/wmagent/current/config/config.py'
     connectToDB()
     myThread = threading.currentThread()
     formatter = DBFormatter(logging, myThread.dbi)

--- a/bin/kill-workflow-in-agent
+++ b/bin/kill-workflow-in-agent
@@ -16,12 +16,8 @@ def killWorkflowAgent(WorkflowName):
     """
     Cancel work for a given workflow - delete in wmbs, delete from workqueue db, set canceled in inbox
     """    
-    # get configuration file path
-    if "WMAGENT_CONFIG" not in os.environ:
-        os.environ['WMAGENT_CONFIG'] = '/data/srv/wmagent/current/config/wmagent/config.py'
-    
-    # load config
-    wmConfig = loadConfigurationFile(os.environ['WMAGENT_CONFIG'])
+    # get configuration file path and load it
+    wmConfig = loadConfigurationFile(os.environ.get('WMA_CONFIG_FILE', '/data/srv/wmagent/current/config/config.py'))
     wqManager = wmConfig.section_('WorkQueueManager')
     
     couchUrl = wqManager.couchurl

--- a/bin/kill-workflow-in-global
+++ b/bin/kill-workflow-in-global
@@ -25,12 +25,8 @@ def main():
         sys.exit(0)
     wflowName = args[0]
 
-    # get configuration file path
-    if "WMAGENT_CONFIG" not in os.environ:
-        os.environ['WMAGENT_CONFIG'] = '/data/srv/wmagent/current/config/wmagent/config.py'
-
-    # load config
-    wmConfig = loadConfigurationFile(os.environ['WMAGENT_CONFIG'])
+    # get configuration file path and load it
+    wmConfig = loadConfigurationFile(os.environ.get('WMA_CONFIG_FILE', '/data/srv/wmagent/current/config/config.py'))
 
     gqService = WorkQueue(wmConfig.WorkloadSummary.couchurl,
                           wmConfig.WorkQueueManager.dbname)


### PR DESCRIPTION
Fixes #11993

#### Status
Ready

#### Description
It corrects the references to the WMAgent config file and the component paths in the additional scripts stored in `bin`. It relies on the `WMA_CONFIG_FILE` and `WMA_INSTALL` env variables that are introduced in the WMAgent.secrets schema for the containers.

NOTE: we acknowledge this is not backward compatible with the RPM deployment model.

#### Is it backward compatible (if not, which system it affects?)
No

#### External dependencies / deployment changes
No
