### PR TITLE
Allow override for Rucio storag.json using env variable

### DIFF
--- a/src/python/WMCore/Storage/RucioFileCatalog.py
+++ b/src/python/WMCore/Storage/RucioFileCatalog.py
@@ -132,6 +132,12 @@ def storageJsonPath(currentSite, currentSubsite, storageSite):
     :para storageSite: str, name of storage site for a stage-out
     :return: str, a path to storage.json (/pathToStorageJson/storage.json)
     """
+
+    # return path override if it is defined and exists
+    siteConfigPathOverride = os.getenv('WMAGENT_RUCIO_CATALOG_OVERRIDE', None)
+    if siteConfigPathOverride and os.path.exists(siteConfigPathOverride):
+        return siteConfigPathOverride    
+
     # get site config
     siteConfigPath = os.getenv('SITECONFIG_PATH', None)
     if not siteConfigPath:


### PR DESCRIPTION
Fixes #12004

#### Status
Ready - tested successfully in Tier-0

#### Description
Adds the ability to override the site catalog path based on one additional environment variable. This mechanism is to be used only for the T0 agents and is not about to affect the production ones.
 
#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
There is a bigger change required on the Tier0 side which is covered by this PR:  
https://github.com/dmwm/T0/commit/1add230a634b33f949837f218b72da1c1bacd836


#### External dependencies / deployment changes
