### PR TITLE
Fix possibleSites to convert Storage elements name

### DIFF
--- a/src/python/WMCore/WorkQueue/DataStructs/WorkQueueElement.py
+++ b/src/python/WMCore/WorkQueue/DataStructs/WorkQueueElement.py
@@ -10,6 +10,7 @@ from hashlib import md5
 
 from Utils.Utilities import encodeUnicodeToBytesConditional
 from Utils.PythonVersion import PY3
+from WMCore.Services.CRIC.CRIC import CRIC
 
 STATES = ('Available', 'Negotiating', 'Acquired', 'Running',
           'Done', 'Failed', 'CancelRequested', 'Canceled')
@@ -29,13 +30,14 @@ def possibleSites(element):
         return elem['SiteWhitelist']
 
     commonSites = set(elem['SiteWhitelist']) - set(elem['SiteBlacklist'])
+    cric = CRIC()    
 
     if elem['Inputs'] and elem['NoInputUpdate'] is False:
-        commonSites = commonSites.intersection(set([y for x in viewvalues(elem['Inputs']) for y in x]))
+        commonSites = commonSites.intersection(set([y for x in viewvalues(elem['Inputs']) for y in cric.PNNstoPSNs(x)]))
     if elem['ParentFlag'] and elem['NoInputUpdate'] is False:
-        commonSites = commonSites.intersection(set([y for x in viewvalues(elem['ParentData']) for y in x]))
+        commonSites = commonSites.intersection(set([y for x in viewvalues(elem['ParentData']) for y in cric.PNNstoPSNs(x)]))
     if elem['PileupData'] and elem['NoPileupUpdate'] is False:
-        commonSites = commonSites.intersection(set([y for x in viewvalues(elem['PileupData']) for y in x]))
+        commonSites = commonSites.intersection(set([y for x in viewvalues(elem['PileupData']) for y in cric.PNNstoPSNs(x)]))
 
     return list(commonSites)
 


### PR DESCRIPTION
Fixes #12012

#### Status
not-tested

#### Description
Fix `possibleSites` method in WorkQueue to properly calculate the intersection of sites between `SiteWhitelist` and `PileupData` site locations.

I convert the Storage Element names to Site names for cases such as `T1_US_FNAL_Disk` using CRIC.

#### Is it backward compatible (if not, which system it affects?)
MAYBE, WMAgent WorkQueue

#### Related PRs
None

#### External dependencies / deployment changes
Not Sure
