### PR TITLE
Cross-check status of elements retrieved from workRestrictions list function

### DIFF
--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -484,10 +484,14 @@ class WorkQueue(WorkQueueBase):
             ele['WMBSUrl'] = self.params["WMBSUrl"]
             workByRequest.setdefault(ele['RequestName'], 0)
             workByRequest[ele['RequestName']] += 1
-        work = self.parent_queue.saveElements(*elements)
-        self.logger.info("Assigned work to the child queue for:")
-        for reqName, numElem in viewitems(workByRequest):
+        self.logger.info("Setting GQE status to 'Negotiating' and assigning to this child queue for:")
+        for reqName, numElem in workByRequest.items():
             self.logger.info("    %d elements for: %s", numElem, reqName)
+
+        work = self.parent_queue.saveElements(*elements)
+        self.logger.info("GQE successfully saved for:")
+        for ele in work:
+            self.logger.info("    %s under GQE id: %s", ele['RequestName'], ele.id)
         return work
 
     def doneWork(self, elementIDs=None, SubscriptionId=None, WorkflowName=None):

--- a/src/python/WMCore/WorkQueue/WorkQueueBackend.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueBackend.py
@@ -521,6 +521,10 @@ class WorkQueueBackend(object):
             if element['RequestName'] in excludeWorkflows:
                 msg = "Skipping aborted/force-completed workflow: %s, work id: %s"
                 self.logger.info(msg, element['RequestName'], element._id)
+            elif element['Status'] != 'Available':
+                # Extra safety mechanism, see https://github.com/dmwm/WMCore/pull/12050
+                msg = "Skipping element in unwanted status: %s, work id: %s"
+                self.logger.warning(msg, element['Status'], element._id)
             else:
                 sortedElements.append(element)
         sortAvailableElements(sortedElements)


### PR DESCRIPTION
Fixes #12041 

#### Status
ready

#### Description
Summary of changes are:
* provide a more clear log for the "saveElements" action, printing what was actually successfully saved;
* when evaluating available work pulled from workqueue `workRestriction` list function, make sure the actual element document status is `Available`, if not, skip it from work acquisition

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
