### PR TITLE
Fix bug from #11765

### DIFF
--- a/src/python/WMCore/MicroService/MSPileup/MSPileupData.py
+++ b/src/python/WMCore/MicroService/MSPileup/MSPileupData.py
@@ -371,7 +371,7 @@ class MSPileupData():
         """
         try:
             self.dbColl.delete_one(spec)
-            self.logger.info("Pileup object '%s' (custom name '%s') successfully deleted", spec.get("pileupName"), spec.get('cusomName'))
+            self.logger.info("Pileup object '%s' (custom name '%s') successfully deleted", spec.get("pileupName"), spec.get('customName'))
         except Exception as exp:
             msg = f"Unable to delete with spec {spec}, error {exp}"
             self.logger.exception(msg)


### PR DESCRIPTION
Fixes #12051 

#### Status
not-tested 

#### Description
Fixes leftover misspelled keyword from #11765 , noted in https://github.com/dmwm/WMCore/pull/11765#discussion_r1369296362

#### Is it backward compatible (if not, which system it affects?)
MAYBE

#### Related PRs


#### External dependencies / deployment changes

