### PR TITLE
Logging typos fixed, maybe one error code definition too

### DIFF
--- a/src/python/WMComponent/AnalyticsDataCollector/Plugins/Tier0Plugin.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/Plugins/Tier0Plugin.py
@@ -187,7 +187,7 @@ class Tier0Plugin(PluginInterface):
                     centralRequestCouchDB.updateRequestStatus(workflowName, workflowStatus)
             except Tier0PluginError as t0ex:
                 # More specific exception, just log it anyway
-                self.logger.error('Error ocurred while processing a doc:\n%s' % str(t0ex))
+                self.logger.error('Error occurred while processing a doc:\n%s' % str(t0ex))
             except Exception as ex:
                 # Plugins are meant to be not-critical
                 # If something fails then just keep going

--- a/src/python/WMComponent/JobCreator/JobCreatorPoller.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorPoller.py
@@ -466,7 +466,7 @@ class JobCreatorPoller(BaseWorkerThread):
             except Exception as ex:
                 msg = "Had failure loading generators for subscription %i\n" % (subscriptionID)
                 msg += "Exception: %s\n" % str(ex)
-                msg += "Passing over this error.  It will reoccur next interation!\n"
+                msg += "Passing over this error.  It will reoccur next iteration!\n"
                 msg += "Please check or remove this subscription!\n"
                 logging.error(msg)
                 continue

--- a/src/python/WMCore/Agent/Flow/Generate.py
+++ b/src/python/WMCore/Agent/Flow/Generate.py
@@ -61,7 +61,7 @@ Inheritance is preferred.
                 str(self.config.General.srcDir))
             os.makedirs(self.config.General.srcDir)
         except:
-            print('ERROR: Make sure directory does not exists')
+            print('ERROR: Make sure directory does not exist already')
             sys.exit(0)
         self.parse()
         print('Starting generation')

--- a/src/python/WMCore/Credential/SimpleMyProxy.py
+++ b/src/python/WMCore/Credential/SimpleMyProxy.py
@@ -170,7 +170,7 @@ def myproxy_client(sslctx, op, username, logger, lifetime=43200, host="myproxy.c
         pem_certs = deserialize_certs(d)
         if len(pem_certs) != numcerts:
             raise MyProxyException("%d certs expected, %d received" % (numcerts, len(pem_certs)))
-        logger.debug("debug: certs deserialized successfuly")
+        logger.debug("debug: certs deserialized successfully")
 
         # return proxy, the corresponding privkey, and then the rest of cert chain
         data = pem_certs[0] + privkey

--- a/src/python/WMCore/Database/CMSCouch.py
+++ b/src/python/WMCore/Database/CMSCouch.py
@@ -1027,7 +1027,7 @@ class CouchServer(CouchDBRequests):
         check_name(dbname)
         dbname = urllib.parse.quote_plus(dbname)
         if "cmsweb" in self.url:
-            msg = f"You can't be serious that you want to delete a PROODUCTION database!!! "
+            msg = f"You can't be serious that you want to delete a PRODUCTION database!!! "
             msg += f"At url: {self.url}, for database name: {dbname}. Bailing out!"
             raise RuntimeError(msg)
         return self.delete("/%s" % dbname)

--- a/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
+++ b/src/python/WMCore/JobSplitting/EventAwareLumiBased.py
@@ -261,7 +261,7 @@ class EventAwareLumiBased(JobFactory):
                             msg = None
                             if failNextJob:
                                 msg = "File %s has a single lumi %s, in run %s " % (f['lfn'], lumi, run.run)
-                                msg += "with too many events %d and it woud take %d sec to run" \
+                                msg += "with too many events %d and it would take %d sec to run" \
                                        % (f['events'], timePerLumi)
                             self.lumiChecker.closeJob(self.currentJob)
                             self.newJob(name=self.getJobName(), failedJob=failNextJob, failedReason=msg, failedErrCode=99305)

--- a/src/python/WMCore/JobSplitting/EventAwareLumiByWork.py
+++ b/src/python/WMCore/JobSplitting/EventAwareLumiByWork.py
@@ -152,7 +152,7 @@ class EventAwareLumiByWork(JobFactory):
                     if timePerLumi > jobTimeLimit and len(lumisByFile[lfn].getLumis()):
                         # This lumi has too many events. Output this job and a new one with just that lumi
                         failReason = "File %s has a single lumi %s, in run %s " % (lfn, lumi, run)
-                        failReason += "with too many events %d and it woud take %d sec to run" \
+                        failReason += "with too many events %d and it would take %d sec to run" \
                                       % (self.eventsInLumi, timePerLumi)
                         self.stopAndMakeJob(reason='Lumi too big', runLumi=(run, lumi),
                                             failNextJob=True, failReason=failReason)

--- a/src/python/WMCore/MicroService/MSOutput/MSOutput.py
+++ b/src/python/WMCore/MicroService/MSOutput/MSOutput.py
@@ -30,7 +30,7 @@ class MSOutputException(WMException):
     General Exception Class for MSOutput Module in WMCore MicroServices
     """
     def __init__(self, message):
-        self.myMessage = "MSOtputException: %s" % message
+        self.myMessage = "MSOutputException: %s" % message
         super(MSOutputException, self).__init__(self.myMessage)
 
 

--- a/src/python/WMCore/ProcessPool/ProcessPool.py
+++ b/src/python/WMCore/ProcessPool/ProcessPool.py
@@ -304,7 +304,7 @@ class ProcessPool(object):
                 self.runningWork -= 1
                 totalItems -= 1
             except Exception as ex:
-                msg = "Exception while getting slave outputin ProcessPool.\n"
+                msg = "Exception while getting slave output in ProcessPool.\n"
                 msg += str(ex)
                 logging.error(msg)
                 break

--- a/src/python/WMCore/Services/ReqMgrAux/ReqMgrAux.py
+++ b/src/python/WMCore/Services/ReqMgrAux/ReqMgrAux.py
@@ -104,7 +104,7 @@ class ReqMgrAux(Service):
         resp = self["requests"].put('cmsswversions', cmsswVersions)[0]['result']
 
         if resp and resp[0].get("ok", False):
-            self["logger"].info("CMSSW document successfuly updated.")
+            self["logger"].info("CMSSW document successfully updated.")
             return True
 
         msg = "Failed to update CMSSW document. Response: %s" % resp

--- a/src/python/WMCore/Services/Requests.py
+++ b/src/python/WMCore/Services/Requests.py
@@ -500,7 +500,7 @@ class Requests(dict):
         elif verb == 'PUT':
             c.setopt(pycurl.CUSTOMREQUEST, 'PUT')
         else:
-            raise HTTPException("Verb %s not sopported for upload." % verb)
+            raise HTTPException("Verb %s not supported for upload." % verb)
         c.setopt(c.URL, url)
         fullParams = [(fieldName, (c.FORM_FILE, fileName))]
         fullParams.extend(params)

--- a/src/python/WMCore/Services/WMArchive/DataMap.py
+++ b/src/python/WMCore/Services/WMArchive/DataMap.py
@@ -304,7 +304,7 @@ def convertStepValue(stepValue):
             stepValue['input'] = convertInput(stepValue['input'][list(stepValue['input'])[0]])
 
         else:
-            raise Exception("Unknow iput key %s" % list(stepValue['input']))
+            raise Exception("Unknown input key %s" % list(stepValue['input']))
 
     if "output" in stepValue:
         # remove output module name layer

--- a/src/python/WMCore/WMRuntime/Bootstrap.py
+++ b/src/python/WMCore/WMRuntime/Bootstrap.py
@@ -61,7 +61,7 @@ def getSyncCE():
             host = host.split(":")[0]
             result = host
         except Exception:
-            logging.warning("Failed to extract SynCE from globus")
+            logging.warning("Failed to extract SyncCE from globus")
         return result
 
     if 'NORDUGRID_CE' in os.environ:

--- a/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
@@ -171,7 +171,7 @@ class CMSSW(Executor):
             architecture=scramArch,
         )
 
-        logging.info("Runing SCRAM")
+        logging.info("Running SCRAM")
         try:
             projectOutcome = scram.project()
         except Exception as ex:

--- a/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/DQMUpload.py
@@ -179,7 +179,7 @@ class DQMUpload(Executor):
                     logException = False
                     raise Exception(msg)
                 else:
-                    msg = 'HTTP upload finished succesfully with response:\n' + msg
+                    msg = 'HTTP upload finished successfully with response:\n' + msg
                     logging.info(msg)
         except HTTPError as ex:
             msg = 'HTTP upload failed with response:\n'

--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -594,7 +594,7 @@ class WorkQueue(WorkQueueBase):
             if self.params.get('cancelGraceTime', -1) > 0 and elements:
                 last_update = max([float(x.updatetime) for x in elements])
                 if (time.time() - last_update) > self.params['cancelGraceTime']:
-                    self.logger.info("%s cancelation has stalled, mark as finished", elements[0]['RequestName'])
+                    self.logger.info("%s cancellation has stalled, mark as finished", elements[0]['RequestName'])
                     # Don't update as fails sometimes due to conflicts (#3856)
                     for x in elements:
                         if not x.inEndState():

--- a/test/python/WMCore_t/JobSplitting_t/EventAwareLumiBased_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/EventAwareLumiBased_t.py
@@ -518,7 +518,7 @@ class EventAwareLumiBasedTest(unittest.TestCase):
         failedJobs = [job for job in jobs if job.get('failedOnCreation', False)]
         self.assertEqual(len(failedJobs), 1)
         self.assertEqual(failedJobs[0]['failedReason'],
-                         'File /this/is/file2 has a single lumi 1, in run 1 with too many events 1000 and it woud take 12000 sec to run')
+                         'File /this/is/file2 has a single lumi 1, in run 1 with too many events 1000 and it would take 12000 sec to run')
 
         return
 
@@ -572,7 +572,7 @@ class EventAwareLumiBasedTest(unittest.TestCase):
             self.assertEqual(len(finalLumi), 1)
 
             self.assertEqual(jobs[i]['failedReason'],
-                             "File /this/is/file%d has a single lumi %s, in run %s with too many events 1000 and it woud take 12000 sec to run" % (
+                             "File /this/is/file%d has a single lumi %s, in run %s with too many events 1000 and it would take 12000 sec to run" % (
                              i + 1, finalLumi[0], runNums[0]))
 
         return

--- a/test/python/WMCore_t/JobSplitting_t/EventAwareLumiByWork_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/EventAwareLumiByWork_t.py
@@ -409,7 +409,7 @@ class EventAwareLumiByWorkTest(unittest.TestCase):
         for jobNum in (0, 1, 3, 4):
             self.assertFalse(jobs[jobNum].get('failedOnCreation'))
         self.assertTrue(jobs[2]['failedOnCreation'])
-        self.assertEqual(jobs[2]['failedReason'], 'File /this/is/file2 has a single lumi 1, in run 1 with too many events 1000 and it woud take 12000 sec to run')
+        self.assertEqual(jobs[2]['failedReason'], 'File /this/is/file2 has a single lumi 1, in run 1 with too many events 1000 and it would take 12000 sec to run')
 
         return
 
@@ -444,7 +444,7 @@ class EventAwareLumiByWorkTest(unittest.TestCase):
         self.assertEqual(len(jobs), 3)
         for job in jobs:
             self.assertTrue(job['failedOnCreation'])
-            self.assertIn(' with too many events 1000 and it woud take 12000 sec to run', job['failedReason'])
+            self.assertIn(' with too many events 1000 and it would take 12000 sec to run', job['failedReason'])
 
         return
 

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/EventAwareLumiBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/EventAwareLumiBased_t.py
@@ -418,7 +418,7 @@ class EventAwareLumiBasedTest(unittest.TestCase):
         self.assertEqual(len(jobs), 6, "Six jobs must be in the jobgroup")
         self.assertTrue(jobs[3]['failedOnCreation'], "The job processing the second file should me marked for failure")
         self.assertEqual(jobs[3]['failedReason'],
-                         'File /this/is/file2 has a single lumi 1, in run 1 with too many events 1000 and it woud take 12000 sec to run')
+                         'File /this/is/file2 has a single lumi 1, in run 1 with too many events 1000 and it would take 12000 sec to run')
 
     def testD_HardLimitSplittingOnly(self):
         """
@@ -462,7 +462,7 @@ class EventAwareLumiBasedTest(unittest.TestCase):
             self.assertTrue(jobs[i - 1]['failedOnCreation'],
                             "The job processing the second file should me marked for failure")
             error = 'File /this/is/file%s has a single lumi %d, in run %s' % (i, i - 1, i - 1)
-            error += ' with too many events 1000 and it woud take 12000 sec to run'
+            error += ' with too many events 1000 and it would take 12000 sec to run'
             self.assertEqual(jobs[i - 1]['failedReason'], error)
 
         return

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/EventAwareLumiByWork_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/EventAwareLumiByWork_t.py
@@ -526,7 +526,7 @@ class EventAwareLumiByWorkTest(unittest.TestCase):
             self.assertFalse(jobs[jobNum].get('failedOnCreation'))
         self.assertTrue(jobs[2]['failedOnCreation'])
         self.assertEqual(jobs[2]['failedReason'],
-                         'File /this/is/file2 has a single lumi 1, in run 1 with too many events 1000 and it woud take 12000 sec to run')
+                         'File /this/is/file2 has a single lumi 1, in run 1 with too many events 1000 and it would take 12000 sec to run')
 
         return
 
@@ -565,7 +565,7 @@ class EventAwareLumiByWorkTest(unittest.TestCase):
             num = list(jobs[i]['mask']['runAndLumis'])[0]
             self.assertTrue(jobs[i]['failedOnCreation'])
             error = 'File /this/is/file%s has a single lumi %s, in run %s' % (num, num, num)
-            error += ' with too many events 1000 and it woud take 12000 sec to run'
+            error += ' with too many events 1000 and it would take 12000 sec to run'
             self.assertEqual(jobs[i]['failedReason'], error)
 
         return


### PR DESCRIPTION
Fixes #12051 

#### Status
not-tested 

#### Description
Fixes some logging output typos, that seem not have been hardcoded into parsing code elsewhere on github (except for the second commit with 'woud's ).
Is WMCore/Agent/Flow/DefaultFlow.py used at all? I only saw it in a help output from the flow generation as a default file to modify to your own needs, not run as is? If you want, I could cherry-pick the commits from https://github.com/dmwm/WMCore/compare/master...oljemark:WMCore:twiki-codes to this PR - the error code typo fix would also need simultaneous fix in the TWiki.

#### Is it backward compatible (if not, which system it affects?)
MAYBE 

#### Related PRs

#### External dependencies / deployment changes
