### PR TITLE
Make exit code for the xrdcp command part of script exit code

### DIFF
--- a/test/python/WMCore_t/Storage_t/Backends_t/XRDCPImpl_t.py
+++ b/test/python/WMCore_t/Storage_t/Backends_t/XRDCPImpl_t.py
@@ -97,6 +97,8 @@ class XRDCPImplTest(unittest.TestCase):
             copyCommand += "--cksum adler32:%s " % checksums
         copyCommand += " \"%s\" " % sourcePFN
         copyCommand += " \"%s\" \n" % targetPFN
+        copyCommand += "RC=$? \n"
+        copyCommand += "echo \"xrdcp exit code: $RC\" \n"
         if stageIn:
             copyCommand += "LOCAL_SIZE=`stat -c%%s \"%s\"`\n" % localPFN
             copyCommand += "echo \"Local File Size is: $LOCAL_SIZE\"\n"
@@ -112,12 +114,12 @@ class XRDCPImplTest(unittest.TestCase):
                 host, path)
             copyCommand += "echo \"Remote File Checksum is: $REMOTE_XS\"\n"
 
-            copyCommand += "if [ $REMOTE_SIZE ] && [ $REMOTE_XS ] && [ $LOCAL_SIZE == $REMOTE_SIZE ] && [ '%s' == $REMOTE_XS ]; then exit 0; " % \
-                           checksums
-            copyCommand += "else echo \"ERROR: Size or Checksum Mismatch between local and SE\"; %s exit 60311 ; fi" % removeCommand
+            copyCommand += "if [ $RC == 0 ] && [ $REMOTE_SIZE ] && [ $REMOTE_XS ] && [ $LOCAL_SIZE == $REMOTE_SIZE ] && [ '%s' == $REMOTE_XS ]; then exit 0; " % checksums
+            copyCommand += "else echo \"ERROR: XRootD file transfer return code is $RC. Size or Checksum Mismatch between local and SE\"; %s exit 60311 ; fi" % removeCommand
         else:
-            copyCommand += "if [ $REMOTE_SIZE ] && [ $LOCAL_SIZE == $REMOTE_SIZE ]; then exit 0; "
-            copyCommand += "else echo \"ERROR: Size Mismatch between local and SE\"; %s exit 60311 ; fi" % removeCommand
+
+            copyCommand += "if [ $RC == 0 ] && [ $REMOTE_SIZE ] && [ $LOCAL_SIZE == $REMOTE_SIZE ]; then exit 0; "
+            copyCommand += "else echo \"ERROR: XRootD file transfer return code is $RC. Size or Checksum Mismatch between local and SE\"; %s exit 60311 ; fi" % removeCommand
         return copyCommand
 
     @mock.patch('WMCore.Storage.Backends.XRDCPImpl.XRDCPImpl.executeCommand')


### PR DESCRIPTION
Fixes #11998

#### Status
to test with a dummy workflow

#### Description
Save the `xrdcp` exit code in a env variable, and use it to determine the script's exit code. In this way, if the `xrdcp` command fails but the other checks are passed, the scripts return a non-0 exit code.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
This would override https://github.com/dmwm/WMCore/pull/12035

#### External dependencies / deployment changes
No