### PR TITLE
WorkQueue: convert PNN to PSN for pileup location

### DIFF
--- a/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
@@ -290,7 +290,7 @@ class StartPolicyInterface(PolicyInterface):
                             'filters': ['expectedRSEs', 'currentRSEs', 'pileupName', 'containerFraction', 'ruleIds']}
                 try:
                     doc = getPileupDocs(msPileupUrl, queryDict, method='POST')[0]
-                    currentRSEs = doc['currentRSEs']
+                    currentRSEs = self.cric.PNNstoPSNs(doc['currentRSEs'])
                     self.logger.debug(f'Retrieved MSPileup document: {doc}')
                     if len(currentRSEs) == 0:
                         self.logger.warning(f'No RSE has a copy of the desired pileup dataset. Expected RSEs: {doc["expectedRSEs"]}')  


### PR DESCRIPTION
Fixes #12012 
Superseeds https://github.com/dmwm/WMCore/pull/12015

#### Status
ready

#### Description
This PR will map the PNNs/RSEs retrieved from MSPileup to their actual PSNs, before persisting those locations in:
* fresh new workqueue elements
* and pileup location update thread

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None