### PR TITLE
Add couchApp cron support

### DIFF
--- a/bin/wmagent-couchapp-init
+++ b/bin/wmagent-couchapp-init
@@ -118,7 +118,7 @@ def installWorkQueueCouchApp(couchUrl, couchDBName):
         shutil.rmtree(tempDir, ignore_errors=True)
 
 
-def createCronEntries(crontabLines):
+def createCrontabEntries(crontabLines):
     tempDir = tempfile.mkdtemp()
     cname = '%s/crontab' % tempDir
     os.system("crontab -l > %s" % cname)
@@ -131,6 +131,18 @@ def createCronEntries(crontabLines):
     os.system("crontab %s" % cname)
     os.remove(cname)
     os.rmdir(tempDir)
+
+
+def createCronEntries(crontabLines, useCrontab=False):
+    if useCrontab:
+        createCronEntries(crontabLines)
+    else:
+        cname = wmagentConfig.General.cronFile
+        with open(cname, 'a') as astream:
+            for line in crontabLines:
+                line = line.strip()
+                if  line not in entries:
+                    astream.write(line + '\n')
 
 
 def setupCron(couchUrl, couchDBName):

--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -93,6 +93,7 @@ config.General.ReqMgr2ServiceURL = "ReqMgr2 rest service"
 config.General.centralWMStatsURL = "Central WMStats URL"
 # ReqMgrAux disk cache duration (in hours), set to 5 minutes: 5 / 60 = 0.083
 config.General.ReqMgrAuxCacheDuration = 0.083
+config.General.cronFile = "/etc/cron.d/wmagent"
 
 config.section_("JobStateMachine")
 config.JobStateMachine.couchurl = couchURL


### PR DESCRIPTION
Fixes #12000 

#### Status
In development | not-tested

#### Description
Modifies cron method, so that it appends couchApp related cron lines accordingly. 

#### Is it backward compatible (if not, which system it affects?)
NO
It requires a backport in order to deploy WMAgent via docker (CMSKubernete)

#### Related PRs
https://github.com/dmwm/CMSKubernetes/pull/1534

#### External dependencies / deployment changes
<Does it require deployment changes? Does it rely on third-party libraries?>
