### PR TITLE
Update CD pipeline to used trusted publishers

### DIFF
--- a/.github/workflows/pypi_build_and_images.yaml
+++ b/.github/workflows/pypi_build_and_images.yaml
@@ -31,8 +31,6 @@ jobs:
     uses: ./.github/workflows/pypi_build_publish_template.yaml
     with:
       wmcore_component: ${{ matrix.target }}
-    secrets:
-      pypy_token: ${{ secrets.PYPY_PRODUCTION }}
 
   # second job, depends on build_and_publish_services, builds and upload
   # docker images to CERN registry

--- a/.github/workflows/pypi_build_publish_template.yaml
+++ b/.github/workflows/pypi_build_publish_template.yaml
@@ -6,17 +6,18 @@ on:
       wmcore_component:
         required: true
         type: string
-    secrets:
-      pypy_token:
-        required: true
 
 jobs:
   build_and_publish_from_template:
     runs-on: ubuntu-latest
+    environment:
+      name: production
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup python 3.8
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.8"
       - name: Upgrade pip3
@@ -30,9 +31,6 @@ jobs:
           cp requirements.txt requirements.wmcore.txt
           awk "/(${{ inputs.wmcore_component }}$)|(${{ inputs.wmcore_component }},)/ {print \$1}" requirements.wmcore.txt > requirements.txt
       - name: Build sdist
-        run: python setup.py clean sdist
-      - name: Publish component
+        run: python3 setup.py clean sdist
+      - name: Upload package distribution to PyPi
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.pypy_token }}


### PR DESCRIPTION
Fixes #11727 

#### Status
ready

#### Description
With this PR, we move away from PyPi user/token authentication in our CD pipeline. Finally adopting (actually enabling) PyPI 2FA together with trusted publisher registration in the PyPi projects.

In addition, I have updated the version of a couple of GitHub actions.
 
#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
It does depend on configuring trusted publisher in all of the WMCore PyPi projects (under the account we use for publishing packages to PyPi).

Some references are:
https://docs.pypi.org/trusted-publishers/
and
https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/