### PR TITLE
Fix patchComponent logic to find the correct python lib path && Zero the codebase

### DIFF
--- a/bin/patchComponent.sh
+++ b/bin/patchComponent.sh
@@ -5,24 +5,70 @@ usage()
     echo -ne "\nA simple script to facilitate component patching\n"
     echo -ne "and to decrease the development && testing turnaround time.\n"
     echo -ne "Usage: \n"
-    echo -ne "\t git diff --no-color | sudo ./patchComponent.sh (wmagent | reqmon | reqmgr2 | reqmgr2ms...)\n or:\n"
-    echo -ne "\t curl https://patch-diff.githubusercontent.com/raw/dmwm/WMCore/pull/11270.patch | sudo ./patchComponent.sh (wmagent | reqmon | reqmgr2 | reqmgr2ms...)\n"
+    echo -ne "\t sudo ./patchComponent.sh 11270\n"
+    echo -ne "\t git diff --no-color | sudo ./patchComponent.sh \n or:\n"
+    echo -ne "\t curl https://patch-diff.githubusercontent.com/raw/dmwm/WMCore/pull/11270.patch | sudo ./patchComponent.sh \n"
     exit 1
 }
 
-# TODO: To check against a list of components
-component=$1
-[[ -z $component ]] && usage
+# if fd 0 (stdin) is open and refers to a terminal - then we are running the script directly, without a pipe
+# if fd 0 (stdin) is open but does not refer to the terminal - then we are running the script through a pipe
+if [ -t 0 ] ; then pipe=false; else pipe=true ; fi
 
-echo "Patching component: $component"
+patchNum=$1
+shift
 
-if [[ $component == "wmagent" ]]
-then
-    rootDir=/data/srv/$component/current/apps.sw/$component/lib/python*/site-packages
-else
-    rootDir=/data/srv/current/apps.sw/$component/lib/python*/site-packages/
-fi
+[[ -z $patchNum ]] && patchNum=temp
+echo "Patching WMCore code with PR: $pathcNum"
+
+currTag=$(python -c "from WMCore import __version__ as WMCoreVersion; print(WMCoreVersion)")
+echo "Current WMCoreTag: $currTag"
+
+
+# Find all possible locations for the component source
+# NOTE: We always consider PYTHONPATH first
+pythonLibPaths=$(echo $PYTHONPATH |sed -e "s/\:/ /g")
+pythonLibPaths="$pythonLibPaths $(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")"
+
+for path in $pythonLibPaths
+do
+    [[ -d $path/WMCore ]] && { pythonLibPath=$path; echo "Source code found at: $path"; break ;}
+done
+
+[[ -z $pythonLibPath  ]] && { echo "ERROR: Could not find WMCore source to patch"; exit  1 ;}
+echo "Current PythonLibPath: $pythonLibPath"
 
 stripLevel=3
+patchFile=/tmp/$patchNum.patch
 
-patch --verbose -b --version-control=numbered -d $rootDir -p$stripLevel
+patchCmd="patch -t --verbose -b --version-control=numbered -d $pythonLibPath -p$stripLevel"
+
+
+if $pipe
+then
+    # if we run through a pipeline create the temporary patch file for later parsing
+    echo "Creating a temporary patchFile at: $patchFile"
+    cat <&0 > $patchFile
+else
+    echo "Downloading a temporary patchFile at: $patchFile"
+    curl https://patch-diff.githubusercontent.com/raw/dmwm/WMCore/pull/$patchNum.patch -o $patchFile
+fi
+
+
+echo "Refreshing all files which are to be patched from the origin"
+for file in `grep diff $patchFile |grep "a/src/python" |awk '{print $3}' |sort |uniq`
+do
+    file=${file#a\/src\/python\/}
+    echo orig: https://raw.githubusercontent.com/dmwm/WMCore/$currTag/src/python/$file
+    echo dest: $pythonLibPath/$file
+    curl -f https://raw.githubusercontent.com/dmwm/WMCore/$currTag/src/python/$file  -o $pythonLibPath/$file || { \
+        echo file: $file missing at the origin.
+        echo Seems to be a new file for the curren patch.
+        echo Removing it from the destination as well!
+        rm -f $pythonLibPath/$file
+    }
+done
+
+echo "Patching all files starting from the original version"
+echo "cat $patchFile | $patchCmd"
+cat $patchFile | $patchCmd


### PR DESCRIPTION
#### Status
ready

#### Description
This is a PR to add some more logic to `bin/patchComponent.sh`, such that we make it cover the new deployment models, both docker and virtual env. With this change  during execution, the script makes an attempt to:
 * Find the proper pythonLib path independently of the deployment method or the deployment destination
 * Find the WMCore tag currently deployed at the host/container and zero the code base (only the list of files affected by the current patch) to the tag discovered. This way it avoids any eventual code conflicts during repeated patching or eventual  leftovers from newly added files during the process of reverting and re applying the patch. 

With the current PR  we also increase the functionality of the script to be called by 3 methods:
* Pointing just the PR number from upstream 
```
./patchComponent.sh 11270
```

* Creating and appling a patch directly from a current local source tree:
```
git diff --no-color | ./patchComponent.sh
```

* Fetch a patch from upstream github (could be based only on a file diff or on a full PR) and apply it:
```
curl https://patch-diff.githubusercontent.com/raw/dmwm/WMCore/pull/11270.patch | ./patchComponent.sh 
``` 

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None