### PR TITLE
skip possible JVM msg in voms-proxy-info output. Fix #12075

### DIFF
--- a/src/python/WMCore/Credential/Proxy.py
+++ b/src/python/WMCore/Credential/Proxy.py
@@ -728,7 +728,7 @@ class Proxy(Credential):
         if not proxy:
             proxy = self.getProxyFilename()
 
-        timeLeftCmd = 'voms-proxy-info -file ' + proxy + ' -timeleft'
+        timeLeftCmd = 'voms-proxy-info -file ' + proxy + ' -timeleft | tail -1'
         timeLeftLocal, _, self.retcode = execute_command(self.setEnv(timeLeftCmd), self.logger, self.commandTimeout)
 
         if self.retcode != 0:


### PR DESCRIPTION
Fixes #12075

#### Status
ready

#### Description
add ` tail -1 ` to make sure to only parse the last line of voms-proxy-info output

#### Is it backward compatible (if not, which system it affects?)
YES

