### PR TITLE
Set memory for ignored tasks (Express Merge)

### DIFF
--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -625,7 +625,7 @@ class WMTaskHelper(TreeHelper):
         if memoryReq or getattr(performanceParams, "memoryRequirement", None):
             performanceParams.memoryRequirement = memoryReq or getattr(performanceParams, "memoryRequirement")
             # if we change memory requirements, then we must change MaxPSS as well
-            self.setMaxPSS(performanceParams.memoryRequirement)
+            self.setMaxPSS(performanceParams.memoryRequirement, taskType)
 
         return
 

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -596,7 +596,7 @@ class WMTaskHelper(TreeHelper):
 
         return splittingParams
 
-    def setJobResourceInformation(self, timePerEvent=None, sizePerEvent=None, memoryReq=None):
+    def setJobResourceInformation(self, timePerEvent=None, sizePerEvent=None, memoryReq=None, taskType=None):
         """
         _setJobResourceInformation_
 
@@ -604,7 +604,11 @@ class WMTaskHelper(TreeHelper):
         the three key values are main memory usage, time per processing unit (e.g. time per event) and
         disk usage per processing unit (e.g. size per event).
         """
-        if self.taskType() in ["Merge", "Cleanup", "LogCollect"]:
+
+        # If task type is specified, it may be that we dont want "Merge" tasks to be ignored, 
+        # or that the task type is not one of the three to ignore
+
+        if self.taskType() in ["Merge", "Cleanup", "LogCollect"] and taskType is None:
             # don't touch job requirements for these task types
             return
 
@@ -1215,14 +1219,17 @@ class WMTaskHelper(TreeHelper):
             self.monitoring.section_("PerformanceMonitor")
         return
 
-    def setMaxPSS(self, maxPSS):
+    def setMaxPSS(self, maxPSS, taskType=None):
         """
         _setMaxPSS_
 
         Set MaxPSS performance monitoring for this task.
         :param maxPSS: maximum Proportional Set Size (PSS) memory consumption in MiB
         """
-        if self.taskType() in ["Merge", "Cleanup", "LogCollect"]:
+        # If task type is specified, it may be that we dont want "Merge" tasks to be ignored, 
+        # or that the task type is not one of the three to ignore
+        
+        if self.taskType() in ["Merge", "Cleanup", "LogCollect"] and taskType is None:
             # keep the default settings (from StdBase) for these task types
             return
 

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -893,9 +893,13 @@ class WMWorkloadHelper(PersistencyHelper):
 
         for task in taskIterator:
             if isinstance(memory, dict):
-                mem = memory.get(task.name())
+                if task.name() in memory:
+                    mem = memory.get(task.name())
+                else:
+                    mem = memory.get("default")
             else:
                 mem = memory
+            
             task.setJobResourceInformation(memoryReq=mem)
             self.setMemory(memory, task)
 

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -896,7 +896,14 @@ class WMWorkloadHelper(PersistencyHelper):
                 mem = memory.get(task.name())
             else:
                 mem = memory
-            task.setJobResourceInformation(memoryReq=mem)
+            
+            # If a task is specified, the ResourceInformation should take into account that
+            # it may not want to be ignored, regardless of the task 
+            if initialTask is not None:
+                task.setJobResourceInformation(memoryReq=mem, taskType=task.taskType()) # Or taskType=initialTask.taskType() ?
+            else:
+                task.setJobResourceInformation(memoryReq=mem)
+
             self.setMemory(memory, task)
 
         return
@@ -2002,6 +2009,10 @@ class WMWorkloadHelper(PersistencyHelper):
 
         if kwargs.get("Memory") is not None:
             self.setMemory(kwargs.get("Memory"))
+        if kwargs.get("TaskMemory") is not None:
+            for taskName in kwargs.get("TaskMemory"):
+                task = self.getTaskByName(taskName)
+                self.setMemory(memory=kwargs.get("TaskMemory"), initialTask=task)
         if kwargs.get("Multicore") is not None:
             self.setCoresAndStreams(kwargs.get("Multicore"), kwargs.get("EventStreams"))
 

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -896,7 +896,6 @@ class WMWorkloadHelper(PersistencyHelper):
                 mem = memory.get(task.name())
             else:
                 mem = memory
-                
             task.setJobResourceInformation(memoryReq=mem)
             self.setMemory(memory, task)
 

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -893,13 +893,10 @@ class WMWorkloadHelper(PersistencyHelper):
 
         for task in taskIterator:
             if isinstance(memory, dict):
-                if task.name() in memory:
-                    mem = memory.get(task.name())
-                else:
-                    mem = memory.get("default")
+                mem = memory.get(task.name())
             else:
                 mem = memory
-            
+                
             task.setJobResourceInformation(memoryReq=mem)
             self.setMemory(memory, task)
 


### PR DESCRIPTION
Fixes #12086

#### Status
In development

#### Description

Currently, "Merge" tasks, among others, have their job resource information hardcoded in [setRuntimeMonitors](https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/WMSpec/StdSpecs/StdBase.py#L252). For these tasks, the functions that set a different memory value do not work, as they are set to ignore such tasks:

* [setJobResourceInformation](https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/WMSpec/WMTask.py#L599)
* [setMaxPSS](https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/WMSpec/WMTask.py#L1218)

The problem with this is that Express Merge jobs in particular have shown to need more memory than the default value of 2.3 GiB. Since the memory setting functions ignore merge tasks, these jobs cant be given more memory without changing the current code.

This patch allows to avoid the tasks from being ignored in case a task is specified
Adds support for setting the memory of specified taskNames, and if such taskName is of a "Merge" task it would not be ignored. 

#### Is it backward compatible (if not, which system it affects?)
MAYBE

#### Related PRs
NONE

#### External dependencies / deployment changes
NONE
