### PR TITLE
MSOutput: stop output placement for relval workflows by default

### DIFF
--- a/src/python/WMCore/MicroService/MSOutput/MSOutput.py
+++ b/src/python/WMCore/MicroService/MSOutput/MSOutput.py
@@ -81,7 +81,10 @@ class MSOutput(MSCore):
         self.mode = mode
         self.msConfig.setdefault("limitRequestsPerCycle", 500)
         self.msConfig.setdefault("enableDataPlacement", False)
+        # Enable relval workflows to go to tape
         self.msConfig.setdefault("enableRelValCustodial", False)
+        # Enable relval workflows to go to disk
+        self.msConfig.setdefault("enableRelValDisk", False)
         self.msConfig.setdefault("excludeDataTier", [])
         self.msConfig.setdefault("rucioAccount", 'wmcore_transferor')
         self.msConfig.setdefault("rucioRSEAttribute", 'dm_weight')
@@ -737,8 +740,10 @@ class MSOutput(MSCore):
         :return: True if the dataset is allowed to pass, False otherwise
         """
         # Bypass every configuration for RelVals, keep everything on disk
+        # unless the disk option for this workflow is not enabled.
         if isRelVal:
-            return True
+            return self.msConfig['enableRelValDisk']
+
         dataTier = dataItem['Dataset'].split('/')[-1]
         if dataTier in self.msConfig['excludeDataTier']:
             self.logger.warning("Skipping dataset: %s because it's excluded in the MS configuration",


### PR DESCRIPTION
Fixes #12069

#### Status
 not-tested

#### Description
As requested by P&R, add configuration to stop output placement for relval workflows

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Documentation: https://gitlab.cern.ch/dmwm/wmcore-docs/-/merge_requests/50/diffs

#### External dependencies / deployment changes
Service configuration changes:
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/307
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/308
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/309
