### PR TITLE
Use PNN to PSN conversion in WQE mapping

### DIFF
--- a/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
@@ -294,7 +294,7 @@ class StartPolicyInterface(PolicyInterface):
                     self.logger.debug(f'Retrieved MSPileup document: {doc}')
                     if len(currentRSEs) == 0:
                         self.logger.warning(f'No RSE has a copy of the desired pileup dataset. Expected RSEs: {doc["expectedRSEs"]}')  
-                    result[dataset] = doc['currentRSEs']
+                    result[dataset] = currentRSEs
                 except IndexError:
                     self.logger.warning('Did not find any pileup document for query: %s', queryDict['query'])
                     result[dataset] = []


### PR DESCRIPTION
Fixes #12012

#### Status
ready

#### Description
Fixes a bug in the WQE mapping that was not using the new PNN->PSN conversion that WQ uses.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Complement bug-fix provided by: https://github.com/dmwm/WMCore/pull/12066