### PR TITLE
Add setter methods map to WMWorkload and call it for all reqArg parameters

### DIFF
--- a/src/python/WMCore/Services/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/Services/WorkQueue/WorkQueue.py
@@ -284,6 +284,41 @@ class WorkQueue(object):
             wmspec.saveCouch(self.hostWithAuth, self.db.name, dummy_values)
         return
 
+    def updateElementsByWorkflow(self, workload, updateParams, status=None):
+        """
+        Update all available WorkQueue elements of a given workflow  with a set
+        of arguments provided through the `updateParams` dictionary
+        :param workload:     A workflow spec
+        :param updateParams: A dictionary with parameters  to be updated
+        :param status:       A list of allowed WorkQueue elements statuses to be considered for updating
+                             Default: None - do not filter by status
+        :return:             No value, raises exceptions from internal methods in case of errors.
+        """
+        # Fetch the whole view with Workqueue elements per given workflow
+        wfName = workload.name()
+        data = self.db.loadView('WorkQueue', 'elementsDetailByWorkflowAndStatus',
+                                {'startkey': [wfName], 'endkey': [wfName, {}],
+                                 'reduce': False})
+
+        # Fetch only a list of WorkQueue element Ids && Filter them by allowed status
+        if status:
+            elementsToUpdate = [x['id'] for x in data.get('rows', []) if x['value']['Status'] in status]
+        else:
+            elementsToUpdate = [x['id'] for x in data.get('rows', [])]
+
+        # Update all WorkQueue elements with the parameters provided in a single push
+        if elementsToUpdate:
+            self.updateElements(*elementsToUpdate, **updateParams)
+
+        # Update the spec, if it exists
+        if self.db.documentExists(wfName):
+            # Update all workload parameters based on the full reqArgs dictionary
+            workload.updateWorkloadArgs(updateParams)
+            # Commit the changes of the current workload object to the database:
+            workload.saveCouchUrl(workload.specUrl())
+        return
+
+
     def getWorkflowNames(self, inboxFlag=False):
         """Get workflow names from workqueue db"""
         if inboxFlag:

--- a/src/python/WMCore/WMSpec/WMWorkloadTools.py
+++ b/src/python/WMCore/WMSpec/WMWorkloadTools.py
@@ -279,7 +279,7 @@ def validateArgumentsCreate(arguments, argumentDefinition, checkInputDset=True):
     return
 
 
-def validateArgumentsUpdate(arguments, argumentDefinition):
+def validateArgumentsUpdate(arguments, argumentDefinition, optionKey="assign_optional"):
     """
     _validateArgumentsUpdate_
 
@@ -290,7 +290,7 @@ def validateArgumentsUpdate(arguments, argumentDefinition):
     otherwise returns None.
     """
     validateUnknownArgs(arguments, argumentDefinition)
-    _validateArgumentOptions(arguments, argumentDefinition, "assign_optional")
+    _validateArgumentOptions(arguments, argumentDefinition, optionKey)
     validateSiteLists(arguments)
 
     return


### PR DESCRIPTION
Fixes #12038

#### Status
Ready

#### Description
With the current PR we add the new functionality to call all needed WMWorkload  setter methods based on a full `reqArgs` dictionary passed from the upper level caller and try to set all of parameters at once, rather than calling every single setter method one by one. This is achieved by creating a proper map between methods and possible request arguments. And later validating if the set of arguments passed with `reqArgs` dictionary would properly match the signature of the setter method which is to be called. In the current implementation only a small set of methods is mapped to request parameters :
* setSiteWhiteList
* setSiteBlacklist
* setPriority
(Mostly single argument parametrized methods, but that's  ok for the time being, because those cover perfectly the functionality we need to plug in here)

With this change a path for updating all possible workqueue elements in a single go was opened. In the `WorkQueue` service an additional method was  developed for fetching all possible workqueue elements and update them all with the full set of arguments provided through the `reqArgs` dictionary with the cost of a single database action per WorkQuee element, rather than 3 (or more) separate calls to the database for updating every single element parameter separately. Upon updating all workqueue elements with the new parameters  the WMSpec copy of the given workflow at the workqueue is also updated in a single push using the same logic from above.   

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
