### PR TITLE
dbs3-client - fix specific version in requirements.txt with ==

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ CMSCouchapp~=1.3.4            # wmcore,wmagent
 CMSMonitoring~=0.6.10         # wmcore,wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-pileup,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner
 coverage~=5.4                 # wmcore,wmagent,wmagent-devtools
 cx-Oracle~=8.3.0              # wmcore,wmagent
-dbs3-client~=4.0.19           # wmcore,wmagent,reqmgr2,reqmon,global-workqueue
+dbs3-client==4.0.19           # wmcore,wmagent,wmagent-devtools,reqmgr2,reqmon,global-workqueue,reqmgr2ms-output,reqmgr2ms-pileup,reqmgr2ms-rulecleaner,reqmgr2ms-transferor
 future~=0.18.2                # wmcore,wmagent,wmagent-devtools,reqmgr2,reqmon,acdcserver,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-pileup,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner
 gfal2-python~=1.11.0.post3    # wmcore,reqmgr2ms-unmerged
 httplib2~=0.20.4              # wmcore,wmagent,reqmgr2,reqmon,acdcserver,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-pileup,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ CMSCouchapp~=1.3.4            # wmcore,wmagent
 CMSMonitoring~=0.6.10         # wmcore,wmagent,reqmgr2,reqmon,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-pileup,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner
 coverage~=5.4                 # wmcore,wmagent,wmagent-devtools
 cx-Oracle~=8.3.0              # wmcore,wmagent
-dbs3-client==4.0.19           # wmcore,wmagent,wmagent-devtools,reqmgr2,reqmon,global-workqueue,reqmgr2ms-output,reqmgr2ms-pileup,reqmgr2ms-rulecleaner,reqmgr2ms-transferor
+dbs3-client==4.0.19           # wmcore,wmagent,wmagent-devtools,reqmgr2,reqmon,global-workqueue,reqmgr2ms-output,reqmgr2ms-transferor
 future~=0.18.2                # wmcore,wmagent,wmagent-devtools,reqmgr2,reqmon,acdcserver,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-pileup,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner
 gfal2-python~=1.11.0.post3    # wmcore,reqmgr2ms-unmerged
 httplib2~=0.20.4              # wmcore,wmagent,reqmgr2,reqmon,acdcserver,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-pileup,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner

--- a/src/python/WMCore/MicroService/Tools/Common.py
+++ b/src/python/WMCore/MicroService/Tools/Common.py
@@ -25,10 +25,6 @@ from Utils.CertTools import ckey, cert
 from WMCore.Services.pycurl_manager import RequestHandler
 from WMCore.Services.pycurl_manager import getdata as multi_getdata
 
-# DBS agregators
-from dbs.apis.dbsClient import aggRuns, aggFileLumis
-
-
 # static variables
 STEP_PAT = re.compile(r'Step[0-9]')
 TASK_PAT = re.compile(r'Task[0-9]')
@@ -279,6 +275,11 @@ def getFileLumisInBlock(blocks, dbsUrl, validFileOnly=1):
     :param validFileOnly: integer flag for valid files only or not
     :return: a dict of blocks with list of file/run/lumi info
     """
+    # importing dbs3-client only in the functions where it is used so that 
+    # we do not need to add it to the docker images of microservices that do
+    # not use it.
+    from dbs.apis.dbsClient import aggFileLumis
+
     runLumisByBlock = {}
     urls = ['%s/filelumis?validFileOnly=%d&block_name=%s' % (dbsUrl, validFileOnly, quote(b)) for b in blocks]
     # limit it to 10 concurrent calls not to overload DBS
@@ -343,6 +344,11 @@ def getRunsInBlock(blocks, dbsUrl):
     :param dbsUrl: string with the DBS URL
     :return: a dictionary of block names and a list of run numbers
     """
+    # importing dbs3-client only in the functions where it is used so that 
+    # we do not need to add it to the docker images of microservices that do
+    # not use it.
+    from dbs.apis.dbsClient import aggRuns
+
     runsByBlock = {}
     urls = ['%s/runs?block_name=%s' % (dbsUrl, quote(b)) for b in blocks]
     logging.info("Executing %d requests against DBS 'runs' API", len(urls))


### PR DESCRIPTION
Related to #12100 

#### Status
not tested. 

I am not sure how to build docker images manually without having a new wmcore tag. is it even possible? I tried to read some documentation [1] and skimmed through the scripts in github actions and dockerfiles in dmwm/cmskubernetes/docker/pypi directory but I did not find anything.

#### Description
Fix the version of the dbs3-client with `==` operator instead of `~=`.

moreover, i did not find any indication of the dbsclient being used in msunmerged and msmonitor. am I wrong?

#### Is it backward compatible (if not, which system it affects?)
Yes

#### Related PRs
https://github.com/dmwm/CMSKubernetes/pull/1550
and
https://github.com/dmwm/CMSKubernetes/pull/1551

#### External dependencies / deployment changes
no change

---

[1] 

- https://cms-wmcore.docs.cern.ch/wmcore/WMCore-Kubernetes-101/#building-docker-images
- https://cms-wmcore.docs.cern.ch/wmcore/WMAgent-in-Docker/#build-the-wmagent-docker-image