### PR TITLE
Add python 3.9 suport for Watchdog.isAlive()

### DIFF
--- a/src/python/WMCore/WMRuntime/Watchdog.py
+++ b/src/python/WMCore/WMRuntime/Watchdog.py
@@ -327,3 +327,16 @@ class Watchdog(threading.Thread):
         # self._MonMgr.loadMonitors()
         # self._MonMgr.loadUpdators()
         return
+
+    def isAlive(self):
+        """
+        :return whether this class thread is alive or not.
+        """
+        try:
+            # For python 3.8 and below
+            value = super(Watchdog, self).isAlive()
+        except AttributeError:
+            # For python 3.9 and above
+            value = self.is_alive()
+
+        return value


### PR DESCRIPTION
Fixes #12109

#### Status
ready

#### Description
Define Watchdog.isAlive() so it supports python 3.7 and 3.9

#### Is it backward compatible (if not, which system it affects?)
<YES | NO | MAYBE>

Related issue:
https://github.com/dmwm/WMCore/issues/11978