### PR TITLE
Bundle of patches for WM central services 2.3.5

### DIFF
--- a/src/python/WMCore/MicroService/MSOutput/MSOutput.py
+++ b/src/python/WMCore/MicroService/MSOutput/MSOutput.py
@@ -81,7 +81,10 @@ class MSOutput(MSCore):
         self.mode = mode
         self.msConfig.setdefault("limitRequestsPerCycle", 500)
         self.msConfig.setdefault("enableDataPlacement", False)
+        # Enable relval workflows to go to tape
         self.msConfig.setdefault("enableRelValCustodial", False)
+        # Enable relval workflows to go to disk
+        self.msConfig.setdefault("enableRelValDisk", False)
         self.msConfig.setdefault("excludeDataTier", [])
         self.msConfig.setdefault("rucioAccount", 'wmcore_transferor')
         self.msConfig.setdefault("rucioRSEAttribute", 'dm_weight')
@@ -737,8 +740,10 @@ class MSOutput(MSCore):
         :return: True if the dataset is allowed to pass, False otherwise
         """
         # Bypass every configuration for RelVals, keep everything on disk
+        # unless the disk option for this workflow is not enabled.
         if isRelVal:
-            return True
+            return self.msConfig['enableRelValDisk']
+
         dataTier = dataItem['Dataset'].split('/')[-1]
         if dataTier in self.msConfig['excludeDataTier']:
             self.logger.warning("Skipping dataset: %s because it's excluded in the MS configuration",

--- a/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
+++ b/src/python/WMCore/WorkQueue/Policy/Start/StartPolicyInterface.py
@@ -294,7 +294,7 @@ class StartPolicyInterface(PolicyInterface):
                     self.logger.debug(f'Retrieved MSPileup document: {doc}')
                     if len(currentRSEs) == 0:
                         self.logger.warning(f'No RSE has a copy of the desired pileup dataset. Expected RSEs: {doc["expectedRSEs"]}')  
-                    result[dataset] = doc['currentRSEs']
+                    result[dataset] = currentRSEs
                 except IndexError:
                     self.logger.warning('Did not find any pileup document for query: %s', queryDict['query'])
                     result[dataset] = []


### PR DESCRIPTION
Backporting to the `2.3.5_cmsweb` branch the following changes/fixes:
* https://github.com/dmwm/WMCore/pull/12094
* https://github.com/dmwm/WMCore/pull/12090

Note that CI pipeline only runs against the master branch, so I am merging this right away.