### PR TITLE
Fix unit test threading monitor

### DIFF
--- a/test/python/WMCore_t/Misc_t/Runtime_t.py
+++ b/test/python/WMCore_t/Misc_t/Runtime_t.py
@@ -73,7 +73,7 @@ def miniStartup(thisDir=os.getcwd()):
     task.completeTask(jobLocation=os.path.join(thisDir, 'WMTaskSpace'),
                       reportName="Report.0.pkl")
 
-    if monitor.isAlive():
+    if monitor.is_alive():
         monitor.shutdown()
 
     return


### PR DESCRIPTION
Fixes #12109
#### Status
ready

#### Description
Change `threading.Thread().isAlive` method to `threading.Thread().is_alive`, which is compatible with python 3.6.8->3.9.

#### Is it backward compatible (if not, which system it affects?)
YES
