### PR TITLE
Revert "Additional Unit test Fix for 12107"

### DIFF
--- a/src/python/WMCore/ReqMgr/DataStructs/RequestStatus.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/RequestStatus.py
@@ -197,6 +197,8 @@ def get_modifiable_properties(status=None):
     """
     if status:
         allowedKeys = ALLOWED_ACTIONS_FOR_STATUS.get(status, 'all_attributes')
+        # if not allowedKeys == 'all_attributes':
+        #     allowedKeys.extend(ALLOWED_ACTIONS_ALL_STATUS)
         return allowedKeys
     else:
         return ALLOWED_ACTIONS_FOR_STATUS

--- a/test/python/WMCore_t/ReqMgr_t/Utils_t/Validation_t.py
+++ b/test/python/WMCore_t/ReqMgr_t/Utils_t/Validation_t.py
@@ -93,7 +93,6 @@ class ValidationTests(unittest.TestCase):
             defReqArgs["RequestStatus"] = status
             expectedReqArgs = {key: None for key in get_modifiable_properties(status)}
             reqArgsDiff = _validate_request_allowed_args(defReqArgs, newReqArgs)
-            reqArgsDiff.pop("RequestStatus")
             print(f"reqArgsDiff: {reqArgsDiff}")
             print(f"expectedReqArgs: {expectedReqArgs}")
             self.assertDictEqual(reqArgsDiff, expectedReqArgs)


### PR DESCRIPTION
Reverts dmwm/WMCore#12111

In order to move forward with central validation (after cutting yet another release candidate - likely 2.3.6rc8)