### PR TITLE
wmstats - consistent reporting of wmagent disk use

### DIFF
--- a/src/couchapps/WMStats/_attachments/js/Views/HTMLList/WMStats.AgentDetailList.js
+++ b/src/couchapps/WMStats/_attachments/js/Views/HTMLList/WMStats.AgentDetailList.js
@@ -21,7 +21,7 @@ WMStats.namespace("AgentDetailList");
     var diskFullFormat = function(diskList) {
         var formatStr = "<details> <summary> disk list</summary> <ul>";
         for (var i in diskList) {
-            formatStr += "<li><b>" + diskList[i].mounted +"</b>:" + diskList[i].percent +"</li>";
+            formatStr += "<li><b>" + diskList[i].filesystem +"</b>:" + diskList[i].percent +"</li>";
         }
         formatStr += "</ul></details>";
         return formatStr;

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t0.min.js
@@ -2808,7 +2808,7 @@ WMStats.namespace("AgentDetailList");
     var diskFullFormat = function(diskList) {
         var formatStr = "<details> <summary> disk list</summary> <ul>";
         for (var i in diskList) {
-            formatStr += "<li><b>" + diskList[i].mounted +"</b>:" + diskList[i].percent +"</li>";
+            formatStr += "<li><b>" + diskList[i].filesystem +"</b>:" + diskList[i].percent +"</li>";
         }
         formatStr += "</ul></details>";
         return formatStr;

--- a/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
+++ b/src/couchapps/WMStats/_attachments/js/minified/import-all-t1.min.js
@@ -2951,7 +2951,7 @@ WMStats.namespace("AgentDetailList");
     var diskFullFormat = function(diskList) {
         var formatStr = "<details> <summary> disk list</summary> <ul>";
         for (var i in diskList) {
-            formatStr += "<li><b>" + diskList[i].mounted +"</b>:" + diskList[i].percent +"</li>";
+            formatStr += "<li><b>" + diskList[i].filesystem +"</b>:" + diskList[i].percent +"</li>";
         }
         formatStr += "</ul></details>";
         return formatStr;

--- a/src/python/Utils/Utilities.py
+++ b/src/python/Utils/Utilities.py
@@ -99,7 +99,9 @@ def diskUse():
     for x in output:
         split = x.split()
         if split != [] and split[0] != 'Filesystem':
-            diskPercent.append({'mounted': split[5], 'percent': split[4]})
+            diskPercent.append({'filesystem': split[0],
+                                'mounted':    split[5], 
+                                'percent':    split[4]})
 
     return diskPercent
 


### PR DESCRIPTION
Fixes #12139 

#### Status

Tested. I run this code inside a wmagent docker container and i got the expected output [1].

#### Description

the output of df is

```plaitnext
(WMAgent-2.3.5) [cmst1@vocms0262:~]$ df -klP
Filesystem     1024-blocks    Used Available Capacity Mounted on
/dev/vdb         257837508 3991660 240722264       2% /etc/group
```

At the moment in WMStats we show the value of the latest column "mounted on", which is not meaningful nor consistent across agents. The first column "filesystem" contains the name of the partition that we care about and is consistent both between the docker container and the host and across different hosts.

This PR adds the parsing of the first column and shows that string in wmstats

#### Is it backward compatible (if not, which system it affects?)

YES: I did not remove the "mounted on" column, so existing code will continue to work as is

#### Related PRs

none

#### External dependencies / deployment changes

none

---

[1]

<details>

```plaintext
(WMAgent-2.3.5) [cmst1@vocms0262:~]$ vim Utilities.py
(WMAgent-2.3.5) [cmst1@vocms0262:~]$ python
Python 3.8.16 (default, May 23 2023, 14:26:40)
[GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import Utilities
>>> Utilities.diskUse()
[{'filesystem': 'overlay', 'mounted': '/', 'percent': '22%'}, {'filesystem': 'tmpfs', 'mounted': '/dev', 'percent': '0%'}, {'filesystem': 'shm', 'mounted': '/dev/shm', 'percent': '0%'}, {'filesystem': '/dev/vda1', 'mounted': '/tmp', 'percent': '22%'}, {'filesystem': '/dev/vdb', 'mounted': '/etc/group', 'percent': '2%'}, {'filesystem': 'tmpfs', 'mounted': '/proc/acpi', 'percent': '0%'}, {'filesystem': 'tmpfs', 'mounted': '/proc/scsi', 'percent': '0%'}, {'filesystem': 'tmpfs', 'mounted': '/sys/firmware', 'percent': '0%'}]
```

</details>