### PR TITLE
Replace WorkQueue replication filter by selector function

### DIFF
--- a/src/python/WMComponent/AgentStatusWatcher/replication_selector.json
+++ b/src/python/WMComponent/AgentStatusWatcher/replication_selector.json
@@ -1,0 +1,18 @@
+
+{
+    "_comment": "This corresponds to a set of selector filter functions for CouchDB database replication",
+    "WMStatsAgent/repfilter": {
+        "_deleted": {"$exists": false},
+        "_id": {"$regex": "^(?!_design/)"}
+    },
+    "T0Request/repfilter": {
+        "_id": {"$regex": "^(?!_design/)"}
+    },
+    "WorkQueue/queueFilter": {
+        "_deleted": {"$exists": false},
+        "type": "WMCore.WorkQueue.DataStructs.WorkQueueElement.WorkQueueElement",
+        "WMCore\\.WorkQueue\\.DataStructs\\.WorkQueueElement\\.WorkQueueElement":
+            {"ParentQueueUrl": "config.WorkQueueManager.queueParams['ParentQueueCouchUrl']",
+            "ChildQueueUrl": "config.WorkQueueManager.queueParams['QueueURL']"}
+    }
+}

--- a/src/python/WMCore/Database/CMSCouch.py
+++ b/src/python/WMCore/Database/CMSCouch.py
@@ -1016,7 +1016,7 @@ class CouchServer(CouchDBRequests):
 
     def replicate(self, source, destination, continuous=False,
                   create_target=False, cancel=False, doc_ids=False,
-                  filter=False, query_params=False, sleepSecs=0):
+                  filter=False, query_params=False, sleepSecs=0, selector=False):
         """
         Trigger replication between source and destination. CouchDB options are
         defined in: https://docs.couchdb.org/en/3.1.2/api/server/common.html#replicate
@@ -1039,6 +1039,7 @@ class CouchServer(CouchDBRequests):
                        this filter is expected to have been defined in the design doc.
         :param query_params: dictionary of parameters to pass over to the filter function
         :param sleepSecs: amount of seconds to sleep after the replication job is created
+        :param selector: a new'ish feature for filter functions in Erlang
         :return: status of the replication creation
         """
         listDbs = self.listDatabases()
@@ -1064,6 +1065,8 @@ class CouchServer(CouchDBRequests):
             data["filter"] = filter
             if query_params:
                 data["query_params"] = query_params
+        if selector: data["selector"] = selector
+
         resp = self.post('/_replicator', data)
         # Sleep required for CouchDB 3.x unit tests
         time.sleep(sleepSecs)


### PR DESCRIPTION
Fixes #11192 

#### Status
ready

#### Description
As the title says, stop using a JavaScript filter in favor of a native Erlang selector function, for database replication between (T0)WMAgent and central services.
A new JSON file has been provided with the relevant selector configuration, using the same name as the filter javascript file in the `couchapps` package.

Note that string field with dot separators has to be escaped, otherwise it gets expanded in the selector to a nested JSON, failing to match any documents.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
Both vocms0255 and submit11 have been running with an old [first commit](https://github.com/dmwm/WMCore/pull/12143/commits/aa994d78b3eb3614d2f281f82cd7e9c0bbd68ef8).
