### PR TITLE
Add SiteList actions to active statuses in ReqMgr2

### DIFF
--- a/src/python/WMCore/ReqMgr/DataStructs/RequestStatus.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/RequestStatus.py
@@ -128,10 +128,10 @@ ALLOWED_ACTIONS_FOR_STATUS = {
                             "NonCustodialSites", "Override",
                             "SubscriptionPriority"],
     "assigned": ["RequestPriority"],
-    "staging": ["RequestPriority"],
+    "staging": ["RequestPriority", "SiteWhitelist", "SiteBlacklist"],
     "staged": ["RequestPriority"],
-    "acquired": ["RequestPriority"],
-    "running-open": ["RequestPriority"],
+    "acquired": ["RequestPriority", "SiteWhitelist", "SiteBlacklist"],
+    "running-open": ["RequestPriority", "SiteWhitelist", "SiteBlacklist"],
     "running-closed": ["RequestPriority"],
     "failed": [],
     "force-complete": [],
@@ -145,6 +145,18 @@ ALLOWED_ACTIONS_FOR_STATUS = {
     "aborted-archived": [],
     "rejected-archived": [],
 }
+
+# NOTE: We need to Explicitly add RequestStatus to reqArgsDiff, since it is
+#       missing from the ALLOWED_ACTIONS_FOR_STATUS mapping. The alternative
+#       would be to add it as allowed action to every state.
+#       The same applies to few more, such as all the keys needed for the
+#       workqueue_stat_validation() calls, but we do this only during
+#       request parameters validation.
+ALLOWED_ACTIONS_ALL_STATUS = ["RequestStatus"]
+
+# NOTE: We need to explicitly add all stat keys during validation
+#       They are needed for the workqueue_stat_validation() calls
+ALLOWED_STAT_KEYS = ['total_jobs', 'input_lumis', 'input_events', 'input_num_files']
 
 # Workflow state transition automatically controlled by ReqMgr2
 ### NOTE: order of this list matters and it's used for status transition
@@ -184,7 +196,10 @@ def get_modifiable_properties(status=None):
     TODO: Currently gets the result from hardcoded list. change to get from configuration or db
     """
     if status:
-        return ALLOWED_ACTIONS_FOR_STATUS.get(status, 'all_attributes')
+        allowedKeys = ALLOWED_ACTIONS_FOR_STATUS.get(status, 'all_attributes')
+        if not allowedKeys == 'all_attributes':
+            allowedKeys.extend(ALLOWED_ACTIONS_ALL_STATUS)
+        return allowedKeys
     else:
         return ALLOWED_ACTIONS_FOR_STATUS
 

--- a/src/python/WMCore/ReqMgr/DataStructs/RequestStatus.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/RequestStatus.py
@@ -197,8 +197,6 @@ def get_modifiable_properties(status=None):
     """
     if status:
         allowedKeys = ALLOWED_ACTIONS_FOR_STATUS.get(status, 'all_attributes')
-        # if not allowedKeys == 'all_attributes':
-        #     allowedKeys.extend(ALLOWED_ACTIONS_ALL_STATUS)
         return allowedKeys
     else:
         return ALLOWED_ACTIONS_FOR_STATUS

--- a/src/python/WMCore/ReqMgr/DataStructs/RequestStatus.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/RequestStatus.py
@@ -197,8 +197,8 @@ def get_modifiable_properties(status=None):
     """
     if status:
         allowedKeys = ALLOWED_ACTIONS_FOR_STATUS.get(status, 'all_attributes')
-        if not allowedKeys == 'all_attributes':
-            allowedKeys.extend(ALLOWED_ACTIONS_ALL_STATUS)
+        # if not allowedKeys == 'all_attributes':
+        #     allowedKeys.extend(ALLOWED_ACTIONS_ALL_STATUS)
         return allowedKeys
     else:
         return ALLOWED_ACTIONS_FOR_STATUS

--- a/src/python/WMCore/ReqMgr/Utils/Validation.py
+++ b/src/python/WMCore/ReqMgr/Utils/Validation.py
@@ -14,7 +14,7 @@ from WMCore.Lexicon import procdataset
 from WMCore.REST.Auth import authz_match
 from WMCore.ReqMgr.DataStructs.Request import initialize_request_args, initialize_clone
 from WMCore.ReqMgr.DataStructs.RequestError import InvalidStateTransition, InvalidSpecParameterValue
-from WMCore.ReqMgr.DataStructs.RequestStatus import check_allowed_transition, get_modifiable_properties, STATES_ALLOW_ONLY_STATE_TRANSITION, ALLOWED_STAT_KEYS
+from WMCore.ReqMgr.DataStructs.RequestStatus import check_allowed_transition, get_modifiable_properties, STATES_ALLOW_ONLY_STATE_TRANSITION, ALLOWED_STAT_KEYS, ALLOWED_ACTIONS_ALL_STATUS
 from WMCore.ReqMgr.Tools.cms import releases, architectures, dashboardActivities
 from WMCore.Services.DBS.DBS3Reader import getDataTiers
 from WMCore.WMFactory import WMFactory
@@ -56,6 +56,7 @@ def _validate_request_allowed_args(reqArgs, newReqArgs):
 
     allowedKeys = deepcopy(get_modifiable_properties(status))
     allowedKeys.extend(ALLOWED_STAT_KEYS)
+    allowedKeys.extend(ALLOWED_ACTIONS_ALL_STATUS)
 
     # Filter out all fields which are not allowed for the given source status:
     for key in reqArgsDiffKeys:

--- a/test/python/WMCore_t/ReqMgr_t/Utils_t/Validation_t.py
+++ b/test/python/WMCore_t/ReqMgr_t/Utils_t/Validation_t.py
@@ -93,6 +93,7 @@ class ValidationTests(unittest.TestCase):
             defReqArgs["RequestStatus"] = status
             expectedReqArgs = {key: None for key in get_modifiable_properties(status)}
             reqArgsDiff = _validate_request_allowed_args(defReqArgs, newReqArgs)
+            reqArgsDiff.pop("RequestStatus")
             print(f"reqArgsDiff: {reqArgsDiff}")
             print(f"expectedReqArgs: {expectedReqArgs}")
             self.assertDictEqual(reqArgsDiff, expectedReqArgs)


### PR DESCRIPTION
Fixes #12037 

#### Status

**SUPERSEEDED BY: https://github.com/dmwm/WMCore/pull/12148**

#### Description
With the current change we allow SiteLists related actions for statuses: staging, acquired, running-open in ReqMgr2

Before making a call to central services for changing any of the request parameters, an additional step is executed to
to check which are the allowed parameter modifications for the given status and if the so provided new values fromthe rest call actually differ from the workflow parameters already defined in central couchdb.

With the current change we no longer ignore all the rest of the request arguments provided with the REST call in the cases of a change of the Request priority. See: https://github.com/dmwm/WMCore/issues/8457#issuecomment-366195086

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
This PR provides a cherry-pick of 3 pull requests that have been recently reverted. Changes have been originally provided by:
https://github.com/dmwm/WMCore/pull/12077
https://github.com/dmwm/WMCore/pull/12108
https://github.com/dmwm/WMCore/pull/12111

#### External dependencies / deployment changes
None
