### PR TITLE
Replace xquery with query, due to deprecation of the former since HTCondor 10.7.0

### DIFF
--- a/bin/adhoc-scripts/drainAgent.py
+++ b/bin/adhoc-scripts/drainAgent.py
@@ -202,7 +202,7 @@ def getCondorJobs():
     """
     jobDict = {}
     schedd = condor.Schedd()
-    jobs = schedd.xquery('WMAgent_AgentName == "WMAgent"', ['WMAgent_RequestName', 'JobStatus'])
+    jobs = schedd.query('WMAgent_AgentName == "WMAgent"', ['WMAgent_RequestName', 'JobStatus'])
     for job in jobs:
         jobStatus = job['JobStatus']
         jobDict.setdefault(jobStatus, {})

--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -207,11 +207,11 @@ class SimpleCondorPlugin(BasePlugin):
 
         schedd = htcondor.Schedd()
 
-        logging.debug("Start: Retrieving classAds using Condor Python XQuery")
+        logging.debug("Start: Retrieving classAds using Condor Python query")
         try:
-            itobj = schedd.xquery("WMAgent_AgentName == %s" % classad.quote(self.agent),
+            jobAds = schedd.query("WMAgent_AgentName == %s" % classad.quote(self.agent),
                                   ['ClusterId', 'ProcId', 'JobStatus', 'MachineAttrGLIDEIN_CMSSite0'])
-            for jobAd in itobj:
+            for jobAd in jobAds:
                 gridId = "%s.%s" % (jobAd['ClusterId'], jobAd['ProcId'])
                 jobStatus = SimpleCondorPlugin.exitCodeMap().get(jobAd.get('JobStatus'), 'Unknown')
                 location = jobAd.get('MachineAttrGLIDEIN_CMSSite0', None)
@@ -372,10 +372,10 @@ class SimpleCondorPlugin(BasePlugin):
         origSiteLists = set()
 
         try:
-            itobj = sd.xquery('WMAgent_AgentName =?= %s && JobStatus =?= 1' % classad.quote(self.agent),
+            jobAds = sd.query('WMAgent_AgentName =?= %s && JobStatus =?= 1' % classad.quote(self.agent),
                               ['WMAgent_JobID', 'DESIRED_Sites', 'ExtDESIRED_Sites'])
 
-            for jobAd in itobj:
+            for jobAd in jobAds:
                 jobAdId = jobAd.get('WMAgent_JobID')
                 desiredSites = jobAd.get('DESIRED_Sites')
                 extDesiredSites = jobAd.get('ExtDESIRED_Sites')

--- a/src/python/WMCore/Services/PyCondor/PyCondorAPI.py
+++ b/src/python/WMCore/Services/PyCondor/PyCondorAPI.py
@@ -37,7 +37,6 @@ class PyCondorAPI(object):
         Retrieves a job summary from the HTCondor Schedd object
         :return: a list of classads representing the matching jobs, or None if failed
         """
-        ### NOTE: SummaryOnly does not work with xquery method
         jobs = None  # return None to signalize the query failed
         queryOpts = htcondor.htcondor.QueryOpts.SummaryOnly
         try:
@@ -68,12 +67,12 @@ class PyCondorAPI(object):
         msg = "Querying condor schedd with params: constraint=%s, attrList=%s, limit=%s, opts=%s"
         logging.info(msg, constraint, attrList, limit, opts)
         try:
-            return self.schedd.xquery(constraint, attrList, limit, opts=opts)
+            return self.schedd.query(constraint, attrList, limit, opts=opts)
         except Exception:
             self.recreateSchedd()
 
         # if we hit another exception, let it be raised up in the chain
-        return self.schedd.xquery(constraint, attrList, limit, opts=opts)
+        return self.schedd.query(constraint, attrList, limit, opts=opts)
 
     def editCondorJobs(self, job_spec, attr, value):
         """


### PR DESCRIPTION
Fixes #12027

#### Status
READY

#### Description
Replaces xquery with query. Arguments do not change.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
HTcondor python bindings