### PR TITLE
Pylint and code reformat with ruff for src/python/Utils

### DIFF
--- a/src/python/Utils/CPMetrics.py
+++ b/src/python/Utils/CPMetrics.py
@@ -203,18 +203,19 @@ def promMetrics(data, exporter):
         metrics = json.loads(metrics)
     # the following keys will be skipped
     skip = [
-        'cherrypy_app_enabled',
-        'cherrypy_http_server_bind_address',
-        'cherrypy_app_requests',
-        'cherrypy_app_server_version',
-        'cherrypy_http_server_enabled']
+        "cherrypy_app_enabled",
+        "cherrypy_http_server_bind_address",
+        "cherrypy_app_requests",
+        "cherrypy_app_server_version",
+        "cherrypy_http_server_enabled",
+    ]
     # our prometheus data representation
     pdata = ""
     for key, val in list(metrics.items()):
         if key in skip:
             continue
         # add exporter name as a prefix for each key
-        key = '{}_{}'.format(exporter, key)
+        key = "{}_{}".format(exporter, key)
         mhelp = "# HELP {}\n".format(key)
         if isinstance(val, list):
             mtype = "# TYPE {} histogram\n".format(key)
@@ -224,7 +225,7 @@ def promMetrics(data, exporter):
                 entries = []
                 for kkk, vvv in list(wdict.items()):
                     entries.append('{}="{}"'.format(kkk, vvv))
-                entry = "{%s}" % ','.join(entries)
+                entry = "{%s}" % ",".join(entries)
                 pdata += "{}{} 1\n".format(key, entry)
         elif isinstance(val, (str, tuple)):
             continue
@@ -245,18 +246,23 @@ def flattenStats(cpdata):
         cpdata = json.loads(decodeBytesToUnicode(cpdata))
     data = {}
     for cpKey, cpVal in list(cpdata.items()):
-        if cpKey.lower().find('cherrypy') != -1:
+        if cpKey.lower().find("cherrypy") != -1:
             for cpnKey, cpnVal in list(cpVal.items()):
-                nkey = 'cherrypy_app_%s' % cpnKey
+                nkey = "cherrypy_app_%s" % cpnKey
                 nkey = nkey.lower().replace(" ", "_").replace("/", "_")
                 data[nkey] = cpnVal
-        if cpKey.lower().find('cheroot') != -1:
+        if cpKey.lower().find("cheroot") != -1:
             for cpnKey, cpnVal in list(cpVal.items()):
-                if cpnKey == 'Worker Threads':
+                if cpnKey == "Worker Threads":
                     wdata = []
                     for workerKey, threadValue in list(cpnVal.items()):
-                        workerKey = workerKey.lower().replace(" ", "_").replace("/", "_").replace("-", "_")
-                        threadValue['thread_name'] = workerKey
+                        workerKey = (
+                            workerKey.lower()
+                            .replace(" ", "_")
+                            .replace("/", "_")
+                            .replace("-", "_")
+                        )
+                        threadValue["thread_name"] = workerKey
                         nval = {}
                         for tkey, tval in list(threadValue.items()):
                             tkey = tkey.lower().replace(" ", "_").replace("/", "_")
@@ -264,7 +270,7 @@ def flattenStats(cpdata):
                         wdata.append(nval)
                     data["cherrypy_server_worker_threads"] = wdata
                 else:
-                    nkey = 'cherrypy_http_server_%s' % cpnKey
+                    nkey = "cherrypy_http_server_%s" % cpnKey
                     nkey = nkey.lower().replace(" ", "_").replace("/", "_")
                     data[nkey] = cpnVal
     return data

--- a/src/python/Utils/CertTools.py
+++ b/src/python/Utils/CertTools.py
@@ -22,30 +22,41 @@ def getKeyCertFromEnv():
     First preference to HOST Certificate, This is how it set in Tier0
 
     """
-    envPairs = [('X509_HOST_KEY', 'X509_HOST_CERT'),  # First preference to HOST Certificate,
-                ('X509_USER_PROXY', 'X509_USER_PROXY'),  # Second preference to User Proxy, very common
-                ('X509_USER_KEY', 'X509_USER_CERT')]  # Third preference to User Cert/Proxy combinition
+    envPairs = [
+        ("X509_HOST_KEY", "X509_HOST_CERT"),  # First preference to HOST Certificate,
+        (
+            "X509_USER_PROXY",
+            "X509_USER_PROXY",
+        ),  # Second preference to User Proxy, very common
+        ("X509_USER_KEY", "X509_USER_CERT"),
+    ]  # Third preference to User Cert/Proxy combinition
 
     for keyEnv, certEnv in envPairs:
         localKey = os.environ.get(keyEnv)
         localCert = os.environ.get(certEnv)
-        if localKey and localCert and os.path.exists(localKey) and os.path.exists(localCert):
+        if (
+            localKey
+            and localCert
+            and os.path.exists(localKey)
+            and os.path.exists(localCert)
+        ):
             # if it is found in env return key, cert
             return localKey, localCert
 
     # TODO: only in linux, unix case, add other os case
     # look for proxy at default location /tmp/x509up_u$uid
-    localKey = localCert = '/tmp/x509up_u' + str(os.getuid())
+    localKey = localCert = "/tmp/x509up_u" + str(os.getuid())
     if os.path.exists(localKey):
         return localKey, localCert
 
     # Finary look for globaus location
-    if (os.environ.get('HOME') and
-        os.path.exists(os.environ['HOME'] + '/.globus/usercert.pem')  and
-        os.path.exists(os.environ['HOME'] + '/.globus/userkey.pem')):
-
-        localKey = os.environ['HOME'] + '/.globus/userkey.pem'
-        localCert = os.environ['HOME'] + '/.globus/usercert.pem'
+    if (
+        os.environ.get("HOME")
+        and os.path.exists(os.environ["HOME"] + "/.globus/usercert.pem")
+        and os.path.exists(os.environ["HOME"] + "/.globus/userkey.pem")
+    ):
+        localKey = os.environ["HOME"] + "/.globus/userkey.pem"
+        localCert = os.environ["HOME"] + "/.globus/usercert.pem"
         return localKey, localCert
     # couldn't find the key, cert files
     return None, None

--- a/src/python/Utils/EmailAlert.py
+++ b/src/python/Utils/EmailAlert.py
@@ -6,7 +6,6 @@ This class does not work from kubernetes pods. The AlertManagerAPI class should 
 More details at: https://github.com/dmwm/WMCore/issues/10234
 """
 
-
 from builtins import str, object
 import smtplib
 import logging
@@ -47,4 +46,3 @@ class EmailAlert(object):
         except UnboundLocalError:
             # it means our client failed connecting to the SMTP server
             pass
-

--- a/src/python/Utils/ExtendedUnitTestCase.py
+++ b/src/python/Utils/ExtendedUnitTestCase.py
@@ -44,8 +44,10 @@ class ExtendedUnitTestCase(unittest.TestCase):
             return
 
         if not isinstance(expected_obj, type(actual_obj)):
-            self.fail(msg="The two objects are different type and cannot be compared: %s and %s" % (
-            type(expected_obj), type(actual_obj)))
+            self.fail(
+                msg="The two objects are different type and cannot be compared: %s and %s"
+                % (type(expected_obj), type(actual_obj))
+            )
 
         expected = copy.deepcopy(expected_obj)
         actual = copy.deepcopy(actual_obj)
@@ -57,6 +59,9 @@ class ExtendedUnitTestCase(unittest.TestCase):
             traverse_list(expected)
             traverse_list(actual)
         else:
-            self.fail(msg="The two objects are different type (%s) and cannot be compared." % type(expected_obj))
+            self.fail(
+                msg="The two objects are different type (%s) and cannot be compared."
+                % type(expected_obj)
+            )
 
         return self.assertEqual(expected, actual)

--- a/src/python/Utils/FileTools.py
+++ b/src/python/Utils/FileTools.py
@@ -3,7 +3,6 @@
 Utilities related to file handling
 """
 
-
 import io
 import os
 import glob
@@ -40,9 +39,9 @@ def tarMode(tfile, opMode):
     :return: mode of operation
     """
     ext = tfile.split(".")[-1]
-    if ext == 'tar':
+    if ext == "tar":
         return opMode
-    mode = opMode + ':' + ext
+    mode = opMode + ":" + ext
     return mode
 
 
@@ -62,12 +61,14 @@ def calculateChecksums(filename):
 
     """
     adler32Checksum = 1  # adler32 of an empty string
-    cksumProcess = subprocess.Popen("cksum", stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    cksumProcess = subprocess.Popen(
+        "cksum", stdin=subprocess.PIPE, stdout=subprocess.PIPE
+    )
 
     # the lambda basically creates an iterator function with zero
     # arguments that steps through the file in 4096 byte chunks
-    with open(filename, 'rb') as f:
-        for chunk in iter((lambda: f.read(4096)), b''):
+    with open(filename, "rb") as f:
+        for chunk in iter((lambda: f.read(4096)), b""):
             adler32Checksum = zlib.adler32(chunk, adler32Checksum)
             cksumProcess.stdin.write(chunk)
 
@@ -83,7 +84,7 @@ def calculateChecksums(filename):
         raise RuntimeError("Something went wrong with the cksum calculation !")
 
     cksumStdout[0] = decodeBytesToUnicode(cksumStdout[0])
-    return (format(adler32Checksum & 0xffffffff, '08x'), cksumStdout[0])
+    return (format(adler32Checksum & 0xFFFFFFFF, "08x"), cksumStdout[0])
 
 
 def tail(filename, nLines=20):
@@ -97,7 +98,7 @@ def tail(filename, nLines=20):
     pos, lines = nLines + 1, []
 
     # make sure only valid utf8 encoded chars will be passed along
-    with io.open(filename, 'r', encoding='utf8', errors='ignore') as f:
+    with io.open(filename, "r", encoding="utf8", errors="ignore") as f:
         while len(lines) <= nLines:
             try:
                 f.seek(-pos, 2)
@@ -122,10 +123,16 @@ def getFileInfo(filename):
 
     filestats = os.stat(filename)
 
-    fileInfo = {'Name': filename,
-                'Size': filestats[stat.ST_SIZE],
-                'LastModification': time.strftime("%m/%d/%Y %I:%M:%S %p", time.localtime(filestats[stat.ST_MTIME])),
-                'LastAccess': time.strftime("%m/%d/%Y %I:%M:%S %p", time.localtime(filestats[stat.ST_ATIME]))}
+    fileInfo = {
+        "Name": filename,
+        "Size": filestats[stat.ST_SIZE],
+        "LastModification": time.strftime(
+            "%m/%d/%Y %I:%M:%S %p", time.localtime(filestats[stat.ST_MTIME])
+        ),
+        "LastAccess": time.strftime(
+            "%m/%d/%Y %I:%M:%S %p", time.localtime(filestats[stat.ST_ATIME])
+        ),
+    }
     return fileInfo
 
 
@@ -135,7 +142,7 @@ def findMagicStr(filename, matchString):
 
     Parse a log file looking for a pattern string
     """
-    with io.open(filename, 'r', encoding='utf8', errors='ignore') as logfile:
+    with io.open(filename, "r", encoding="utf8", errors="ignore") as logfile:
         # TODO: can we avoid reading the whole file
         for line in logfile:
             if matchString in line:
@@ -165,8 +172,15 @@ def loadEnvFile(wmaEnvFilePath, logger=None):
     """
     if not logger:
         logger = logging.getLogger()
-    subProc = subprocess.run(['bash', '-c', f'source {wmaEnvFilePath} && python -c "import os; print(repr(os.environ.copy()))" '],
-                                   capture_output=True, check=False)
+    subProc = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f'source {wmaEnvFilePath} && python -c "import os; print(repr(os.environ.copy()))" ',
+        ],
+        capture_output=True,
+        check=False,
+    )
     if subProc.returncode == 0:
         newEnv = eval(subProc.stdout)
         os.environ.update(newEnv)

--- a/src/python/Utils/IteratorTools.py
+++ b/src/python/Utils/IteratorTools.py
@@ -4,6 +4,7 @@ from builtins import str, map
 import collections
 from itertools import islice, chain, groupby
 
+
 def grouper(iterable, n):
     """
     :param iterable: List of other iterable to slice
@@ -27,7 +28,7 @@ def getChunk(arr, step):
     :return: generator, set of slices with number of entries equal to step of iteration
     """
     for i in range(0, len(arr), step):
-        yield arr[i:i + step]
+        yield arr[i : i + step]
 
 
 def flattenList(doubleList):
@@ -50,13 +51,14 @@ def nestedDictUpdate(d, u):
             d[k] = u[k]
     return d
 
+
 def convertFromUnicodeToBytes(data):
     """
     code fram
     http://stackoverflow.com/questions/1254454/fastest-way-to-convert-a-dicts-keys-values-from-unicode-to-str
     """
     if isinstance(data, str):
-        return data.encode('utf-8')
+        return data.encode("utf-8")
     elif isinstance(data, collections.Mapping):
         return dict(list(map(convertFromUnicodeToBytes, list(data.items()))))
     elif isinstance(data, collections.Iterable):

--- a/src/python/Utils/MathUtils.py
+++ b/src/python/Utils/MathUtils.py
@@ -3,7 +3,6 @@
 Module containing mathematical and physics utils
 """
 
-
 from builtins import int, str
 from math import ceil
 

--- a/src/python/Utils/MemoryCache.py
+++ b/src/python/Utils/MemoryCache.py
@@ -12,7 +12,6 @@ data type.
 
 from copy import copy
 
-from builtins import object
 from time import time
 
 
@@ -20,8 +19,8 @@ class MemoryCacheException(Exception):
     def __init__(self, message):
         super(MemoryCacheException, self).__init__(message)
 
-class MemoryCache():
 
+class MemoryCache:
     __slots__ = ["lastUpdate", "expiration", "_cache"]
 
     def __init__(self, expiration, initialData=None):
@@ -51,7 +50,11 @@ class MemoryCache():
         if isinstance(self._cache, dict):
             return copy(self._cache.get(keyName))
         else:
-            raise MemoryCacheException("Cannot retrieve an item from a non-dict MemoryCache object: {}".format(self._cache))
+            raise MemoryCacheException(
+                "Cannot retrieve an item from a non-dict MemoryCache object: {}".format(
+                    self._cache
+                )
+            )
 
     def reset(self):
         """
@@ -62,7 +65,9 @@ class MemoryCache():
         elif isinstance(self._cache, list):
             del self._cache[:]
         else:
-            raise MemoryCacheException("The cache needs to be reset manually, data type unknown")
+            raise MemoryCacheException(
+                "The cache needs to be reset manually, data type unknown"
+            )
 
     def isCacheExpired(self):
         """
@@ -78,7 +83,9 @@ class MemoryCache():
         """
         if self.isCacheExpired():
             expiredSince = int(time()) - (self.lastUpdate + self.expiration)
-            raise MemoryCacheException("Memory cache expired for %d seconds" % expiredSince)
+            raise MemoryCacheException(
+                "Memory cache expired for %d seconds" % expiredSince
+            )
         return self._cache
 
     def setCache(self, inputData):
@@ -88,8 +95,10 @@ class MemoryCache():
         :param inputData: data to store in the cache
         """
         if not isinstance(self._cache, type(inputData)):
-            raise TypeError("Current cache data type: %s, while new value is: %s" %
-                            (type(self._cache), type(inputData)))
+            raise TypeError(
+                "Current cache data type: %s, while new value is: %s"
+                % (type(self._cache), type(inputData))
+            )
         self.reset()
         self.lastUpdate = int(time())
         self._cache = inputData
@@ -115,5 +124,8 @@ class MemoryCache():
         elif isinstance(self._cache, dict) and isinstance(inputItem, dict):
             self._cache.update(inputItem)
         else:
-            msg = "Input item type: %s cannot be added to a cache type: %s" % (type(self._cache), type(inputItem))
+            msg = "Input item type: %s cannot be added to a cache type: %s" % (
+                type(self._cache),
+                type(inputItem),
+            )
             raise TypeError("Cache and input item data type mismatch. %s" % msg)

--- a/src/python/Utils/Patterns.py
+++ b/src/python/Utils/Patterns.py
@@ -5,9 +5,10 @@ Patterns module provides set of CS patterns
 
 class Singleton(type):
     """Implementation of Singleton class"""
+
     _instances = {}
+
     def __call__(cls, *args, **kwargs):
         if cls not in cls._instances:
-            cls._instances[cls] = \
-                    super(Singleton, cls).__call__(*args, **kwargs)
+            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
         return cls._instances[cls]

--- a/src/python/Utils/Pipeline.py
+++ b/src/python/Utils/Pipeline.py
@@ -54,6 +54,7 @@ class Functor(object):
 
 
     """
+
     def __init__(self, func, *args, **kwargs):
         """
         The init method for class Functor
@@ -77,6 +78,7 @@ class Pipeline(object):
     A simple Functional Pipeline Class: applies a set of functions to an object,
     where the output of every previous function is an input to the next one.
     """
+
     # NOTE:
     #    Similar and inspiring approaches but yet some different implementations
     #    are discussed in the following two links [1] & [2]. With a quite good

--- a/src/python/Utils/PortForward.py
+++ b/src/python/Utils/PortForward.py
@@ -7,6 +7,7 @@ A decorator for swapping ports in an url
 
 from builtins import str, bytes
 
+
 def portForward(port):
     """
     Decorator wrapper function for port forwarding of the REST calls of any
@@ -27,6 +28,7 @@ def portForward(port):
 
     param port: The port to which the REST call should be forwarded.
     """
+
     def portForwardDecorator(callFunc):
         """
         The actual decorator
@@ -50,14 +52,14 @@ def portForward(port):
             forwarded = False
             try:
                 if isinstance(url, str):
-                    urlToMangle = 'https://cmsweb'
+                    urlToMangle = "https://cmsweb"
                     if url.startswith(urlToMangle):
-                        newUrl = url.replace('.cern.ch/', '.cern.ch:%d/' % port, 1)
+                        newUrl = url.replace(".cern.ch/", ".cern.ch:%d/" % port, 1)
                         forwarded = True
                 elif isinstance(url, bytes):
-                    urlToMangle = b'https://cmsweb'
+                    urlToMangle = b"https://cmsweb"
                     if url.startswith(urlToMangle):
-                        newUrl = url.replace(b'.cern.ch/', b'.cern.ch:%d/' % port, 1)
+                        newUrl = url.replace(b".cern.ch/", b".cern.ch:%d/" % port, 1)
                         forwarded = True
 
             except Exception:
@@ -66,11 +68,13 @@ def portForward(port):
                 return callFunc(callObj, newUrl, *args, **kwargs)
             else:
                 return callFunc(callObj, url, *args, **kwargs)
+
         return portMangle
+
     return portForwardDecorator
 
 
-class PortForward():
+class PortForward:
     """
     A class with a call method implementing a simple way to use the functionality
     provided by the protForward decorator as a pure functional call:
@@ -81,6 +85,7 @@ class PortForward():
         url = 'https://cmsweb-testbed.cern.ch/couchdb'
         url = portForwarder(url)
     """
+
     def __init__(self, port):
         """
         The init method for the PortForward call class. This one is supposed
@@ -92,6 +97,8 @@ class PortForward():
         """
         The call method for the PortForward class
         """
+
         def dummyCall(self, url):
             return url
+
         return portForward(self.port)(dummyCall)(self, url)

--- a/src/python/Utils/ProcessStats.py
+++ b/src/python/Utils/ProcessStats.py
@@ -39,27 +39,30 @@ try:
 except ImportError:
     pass
 
+
 def _baseProcessStatusFormat(pid=None):
     if not pid:
         pid = os.getpid()
     ttime = time.localtime()
-    tstamp = time.strftime('%d/%b/%Y:%H:%M:%S', ttime)
-    return {'pid': pid, 'timestamp': tstamp, 'time': time.time()}
+    tstamp = time.strftime("%d/%b/%Y:%H:%M:%S", ttime)
+    return {"pid": pid, "timestamp": tstamp, "time": time.time()}
+
 
 def processStatus(pid=None):
     "Return status of the process in a dictionary format"
 
     pdict = _baseProcessStatusFormat(pid)
-    if 'psutil' not in sys.modules:
+    if "psutil" not in sys.modules:
         return pdict
     proc = psutil.Process(pid)
     pdict.update(proc.as_dict())
     return pdict
 
+
 def processStatusDict(pid=None):
     "Return status of the process in a dictionary format"
     pdict = _baseProcessStatusFormat(pid)
-    if 'psutil' not in sys.modules:
+    if "psutil" not in sys.modules:
         return pdict
     proc = psutil.Process(pid)
     pdict.update({"cpu_times": dict(proc.cpu_times()._asdict())})
@@ -68,6 +71,7 @@ def processStatusDict(pid=None):
     pdict.update({"memory_full_info": dict(proc.memory_full_info()._asdict())})
     pdict.update({"memory_percent": proc.memory_percent()})
     return pdict
+
 
 def threadStack():
     """
@@ -89,9 +93,10 @@ def threadStack():
         threads.append(tdict)
     return dict(threads=threads)
 
+
 def main():
     "Main function to use this module as a stand-along script."
-    parser = argparse.ArgumentParser(prog='PROG')
+    parser = argparse.ArgumentParser(prog="PROG")
     parser.add_argument("--pid", action="store", dest="pid", help="process id")
     opts = parser.parse_args()
 
@@ -99,5 +104,6 @@ def main():
     pdict.update(threadStack())
     print(json.dumps(pdict))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/src/python/Utils/PythonVersion.py
+++ b/src/python/Utils/PythonVersion.py
@@ -2,7 +2,7 @@
 Easily get the version of the python interpreter at runtime
 """
 
- # Jenkins CI
+# Jenkins CI
 
 import sys
 import pickle

--- a/src/python/Utils/Signals.py
+++ b/src/python/Utils/Signals.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-#-*- coding: utf-8 -*-
-#pylint: disable=
+# -*- coding: utf-8 -*-
+# pylint: disable=
 """
 File       : Signals.py
 Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
@@ -17,6 +17,7 @@ import signal
 import threading
 import traceback
 
+
 def dumpthreads(isignal, iframe):
     """
     Dump context of all threads upon given signal
@@ -26,11 +27,12 @@ def dumpthreads(isignal, iframe):
     id2name = dict([(th.ident, th.name) for th in threading.enumerate()])
     code = []
     for tid, stack in list(sys._current_frames().items()):
-        code.append("\n# Thread: %s(%d)" % (id2name.get(tid,""), tid))
+        code.append("\n# Thread: %s(%d)" % (id2name.get(tid, ""), tid))
         for filename, lineno, name, line in traceback.extract_stack(stack):
             code.append('File: "%s", line %d, in %s' % (filename, lineno, name))
-            if  line:
+            if line:
                 code.append("  %s" % (line.strip()))
     print("\n".join(code))
+
 
 signal.signal(signal.SIGUSR1, dumpthreads)

--- a/src/python/Utils/Throttled.py
+++ b/src/python/Utils/Throttled.py
@@ -31,7 +31,6 @@ def api():
 
 """
 
-
 # standard modules
 import time
 from builtins import object
@@ -57,21 +56,28 @@ class _ThrottleCounter(object):
     def __enter__(self):
         "Define enter method for `with` context"
         ctr = self.throttle._incUser(self.user)
-        msg = "Entering throttled function with counter %d for user %s" \
-                % (ctr, self.user)
+        msg = "Entering throttled function with counter %d for user %s" % (
+            ctr,
+            self.user,
+        )
         self.throttle.logger.debug(msg)
         if ctr > self.throttle.getLimit():
             msg = "The current number of active operations for this resource"
-            msg += " exceeds the limit of %d for user %s" \
-                   % (self.throttle.getLimit(), self.user)
+            msg += " exceeds the limit of %d for user %s" % (
+                self.throttle.getLimit(),
+                self.user,
+            )
             raise cherrypy.HTTPError("429 Too Many Requests", msg)
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         "Define exit method for `with` context"
         ctr = self.throttle._decUser(self.user)
-        msg = "Exiting throttled function with counter %d for user %s" \
-                % (ctr, self.user)
+        msg = "Exiting throttled function with counter %d for user %s" % (
+            ctr,
+            self.user,
+        )
         self.throttle.logger.debug(msg)
+
 
 class _ThrottleTimeCounter(object):
     """
@@ -89,8 +95,11 @@ class _ThrottleTimeCounter(object):
         if ctr > self.throttle.getLimit():
             self.throttle._decUser(self.user)
             msg = "The current number of active operations for this resource"
-            msg += " exceeds the limit of %d for user %s in last %s sec" \
-                   % (self.throttle.getLimit(), self.user, self.trange)
+            msg += " exceeds the limit of %d for user %s in last %s sec" % (
+                self.throttle.getLimit(),
+                self.user,
+                self.trange,
+            )
             raise cherrypy.HTTPError("429 Too Many Requests", msg)
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
@@ -124,13 +133,19 @@ class UserThrottleTime(object):
 
     def make_throttled(self, trange=60):
         "decorator for throttled context"
+
         def throttled_decorator(fn):
             def throttled_wrapped_function(*args, **kw):
-                username = cherrypy.request.user.get('login', 'Unknown') \
-                        if hasattr(cherrypy.request, 'user') else 'Unknown'
+                username = (
+                    cherrypy.request.user.get("login", "Unknown")
+                    if hasattr(cherrypy.request, "user")
+                    else "Unknown"
+                )
                 with self.throttleContext(username, trange):
                     return fn(*args, **kw)
+
             return throttled_wrapped_function
+
         return throttled_decorator
 
     def reset(self, user):
@@ -144,7 +159,7 @@ class UserThrottleTime(object):
             self.users.setdefault(user, 0)
             last_time = self.users_time.setdefault(user, time.time())
             # increase counter within our trange
-            if abs(time.time()-last_time) < trange:
+            if abs(time.time() - last_time) < trange:
                 self.users[user] += 1
             else:
                 self.reset(user)
@@ -155,14 +170,15 @@ class UserThrottleTime(object):
         with self.lock:
             # decrease counter outside of our trange
             last_time = self.users_time[user]
-            if abs(time.time()-last_time) < trange:
+            if abs(time.time() - last_time) < trange:
                 # gradually decrease user counter based on his/her elapsed time
-                step = int(trange - abs(time.time()-last_time))
+                step = int(trange - abs(time.time() - last_time))
                 self.users[user] -= step
                 if self.users[user] < 0:
                     self.reset(user)
             else:
                 self.reset(user)
+
 
 class UserThrottle(object):
     """
@@ -189,19 +205,26 @@ class UserThrottle(object):
         """
         decorator for throttled context
         """
+
         def throttled_decorator(fn):
             """
             A decorator
             """
+
             def throttled_wrapped_function(*args, **kw):
                 """
                 A wrapped function.
                 """
-                username = cherrypy.request.user.get('login', 'Unknown') \
-                        if hasattr(cherrypy.request, 'user') else 'Unknown'
+                username = (
+                    cherrypy.request.user.get("login", "Unknown")
+                    if hasattr(cherrypy.request, "user")
+                    else "Unknown"
+                )
                 with self.throttleContext(username, debug):
                     return fn(*args, **kw)
+
             return throttled_wrapped_function
+
         return throttled_decorator
 
     def _incUser(self, user):
@@ -209,7 +232,7 @@ class UserThrottle(object):
         retval = 0
         with self.lock:
             retval = self.users[user]
-            if getattr(self.tls, 'count', None) is None:
+            if getattr(self.tls, "count", None) is None:
                 self.tls.count = 0
             self.tls.count += 1
             if self.tls.count == 1:

--- a/src/python/Utils/Timers.py
+++ b/src/python/Utils/Timers.py
@@ -25,7 +25,9 @@ def encodeTimestamp(secs):
     :return: time string in GMT timezone representation
     """
     if not isinstance(secs, (int, float)):
-        raise Exception("Wrong input, should be seconds since epoch either int or float value")
+        raise Exception(
+            "Wrong input, should be seconds since epoch either int or float value"
+        )
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(int(secs)))
 
 
@@ -37,7 +39,9 @@ def decodeTimestamp(timeString):
     :return: seconds since ecouch in GMT timezone
     """
     if not isinstance(timeString, str):
-        raise Exception("Wrong input, should be time string in GMT timezone representation")
+        raise Exception(
+            "Wrong input, should be time string in GMT timezone representation"
+        )
     return calendar.timegm(time.strptime(timeString, "%Y-%m-%dT%H:%M:%SZ"))
 
 
@@ -72,7 +76,7 @@ class CodeTimer(object):
         do_something()
     """
 
-    def __init__(self, label='The function', logger=None):
+    def __init__(self, label="The function", logger=None):
         self.start = time.time()
         self.label = label
         self.logger = logger or logging.getLogger()
@@ -122,9 +126,17 @@ class LocalTimezone(tzinfo):
         return time.tzname[self._isdst(dt)]
 
     def _isdst(self, dt):
-        tt = (dt.year, dt.month, dt.day,
-              dt.hour, dt.minute, dt.second,
-              dt.weekday(), 0, 0)
+        tt = (
+            dt.year,
+            dt.month,
+            dt.day,
+            dt.hour,
+            dt.minute,
+            dt.second,
+            dt.weekday(),
+            0,
+            0,
+        )
         stamp = time.mktime(tt)
         tt = time.localtime(stamp)
         return tt.tm_isdst > 0

--- a/src/python/Utils/Timestamps.py
+++ b/src/python/Utils/Timestamps.py
@@ -19,7 +19,7 @@ import sys
 
 
 # script options
-options = {"reportFile=": "", "wmJobStart=": '', "wmJobEnd=": ''}
+options = {"reportFile=": "", "wmJobStart=": "", "wmJobEnd=": ""}
 
 
 def addTimestampMetrics(config, wmJobStart, wmJobEnd):
@@ -30,7 +30,7 @@ def addTimestampMetrics(config, wmJobStart, wmJobEnd):
     :param wmJobStart: start time of WM job in seconds
     :param wmJobEnd: end time of WM job in seconds
     """
-    wmTiming = config.section_('WMTiming')
+    wmTiming = config.section_("WMTiming")
     wmTiming.WMJobStart = wmJobStart
     wmTiming.WMJobEnd = wmJobEnd
     wmTiming.WMTotalWallClockTime = wmJobEnd - wmJobStart
@@ -63,7 +63,7 @@ def main():
 
     # read content of given FJR report file
     data = {}
-    with open(reportFile, 'rb') as istream:
+    with open(reportFile, "rb") as istream:
         data = pickle.load(istream)
 
     # adjust FJR data with provided metrics
@@ -72,7 +72,7 @@ def main():
     # write content of FJR back to report file
     reportOutFile = reportFile + ".new"
     msg = f"Adding wmJobTime metric to {reportFile}"
-    with open(reportOutFile, 'wb') as ostream:
+    with open(reportOutFile, "wb") as ostream:
         logging.info(msg)
         pickle.dump(data, ostream)
 
@@ -82,5 +82,5 @@ def main():
         os.rename(reportOutFile, reportFile)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/python/Utils/TokenManager.py
+++ b/src/python/Utils/TokenManager.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#pylint: disable=W0212
+# pylint: disable=W0212
 """
 File       : TokenManager.py
 Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
@@ -41,7 +41,7 @@ def readToken(name=None):
     """
     if name and os.path.exists(name):
         token = None
-        with open(name, 'r', encoding='utf-8') as istream:
+        with open(name, "r", encoding="utf-8") as istream:
             token = istream.read()
         return token
     if name:
@@ -49,7 +49,11 @@ def readToken(name=None):
     return os.environ.get("IAM_TOKEN")
 
 
-def tokenData(token, url="https://cms-auth.web.cern.ch/jwk", audUrl="https://wlcg.cern.ch/jwt/v1/any"):
+def tokenData(
+    token,
+    url="https://cms-auth.web.cern.ch/jwk",
+    audUrl="https://wlcg.cern.ch/jwt/v1/any",
+):
     """
     inspect and extract token data
     :param token: token string
@@ -64,14 +68,14 @@ def tokenData(token, url="https://cms-auth.web.cern.ch/jwk", audUrl="https://wlc
     signingKey = jwksClient.get_signing_key_from_jwt(token)
     key = signingKey.key
     headers = jwt.get_unverified_header(token)
-    alg = headers.get('alg', 'RS256')
+    alg = headers.get("alg", "RS256")
     data = jwt.decode(
         token,
         key,
         algorithms=[alg],
         audience=audUrl,
         options={"verify_exp": True},
-        )
+    )
     return data
 
 
@@ -84,22 +88,24 @@ def isValidToken(token):
     """
     tokenDict = {}
     tokenDict = tokenData(token)
-    exp = tokenDict.get('exp', 0)  # expire, seconds since epoch
+    exp = tokenDict.get("exp", 0)  # expire, seconds since epoch
     if not exp or exp < time.time():
         return False
     return True
 
 
-class TokenManager():
+class TokenManager:
     """
     TokenManager class handles IAM tokens
     """
 
-    def __init__(self,
-                 name=None,
-                 url="https://cms-auth.web.cern.ch/jwk",
-                 audUrl="https://wlcg.cern.ch/jwt/v1/any",
-                 logger=None):
+    def __init__(
+        self,
+        name=None,
+        url="https://cms-auth.web.cern.ch/jwk",
+        audUrl="https://wlcg.cern.ch/jwt/v1/any",
+        logger=None,
+    ):
         """
         Token manager reads IAM tokens either from file or env.
         It caches token along with expiration timestamp.
@@ -133,7 +139,7 @@ class TokenManager():
         except Exception as exc:
             self.logger.exception(str(exc))
             raise
-        self.expire = tokenDict.get('exp', 0)
+        self.expire = tokenDict.get("exp", 0)
         return self.token
 
     def getLifetime(self):

--- a/src/python/Utils/Tracing.py
+++ b/src/python/Utils/Tracing.py
@@ -16,16 +16,15 @@ Use like this:
 
 
 def trace_calls(frame, event, arg, to_be_traced=None):
-    if event != 'call':
+    if event != "call":
         return
     co = frame.f_code
     func_name = co.co_name
-    if func_name == 'write':
+    if func_name == "write":
         return  # Ignore write() calls from printing
     line_no = frame.f_lineno
     filename = co.co_filename
-    print('* Call to {} on line {} of {}'.format(
-        func_name, line_no, filename))
+    print("* Call to {} on line {} of {}".format(func_name, line_no, filename))
     if func_name in to_be_traced:
         # Trace into this function
         return trace_lines
@@ -35,25 +34,25 @@ def trace_calls(frame, event, arg, to_be_traced=None):
 def trace_calls_and_returns(frame, event, arg):
     co = frame.f_code
     func_name = co.co_name
-    if func_name == 'write':
+    if func_name == "write":
         return  # Ignore write() calls from printing
     line_no = frame.f_lineno
     filename = co.co_filename
-    if event == 'call':
-        print('Call to {} on line {} of {}'.format(func_name, line_no, filename))
+    if event == "call":
+        print("Call to {} on line {} of {}".format(func_name, line_no, filename))
         return trace_calls_and_returns
-    elif event == 'return':
-        print(' {} => {} ({})'.format(func_name, arg, filename))
+    elif event == "return":
+        print(" {} => {} ({})".format(func_name, arg, filename))
     return
 
 
 def trace_lines(frame, event, arg):
-    if event != 'line':
+    if event != "line":
         return
     co = frame.f_code
     func_name = co.co_name
     line_no = frame.f_lineno
-    print('*  {} line {}'.format(func_name, line_no))
+    print("*  {} line {}".format(func_name, line_no))
 
 
 def dont_trace(frame, event, arg):

--- a/src/python/Utils/TwPrint.py
+++ b/src/python/Utils/TwPrint.py
@@ -7,16 +7,19 @@ Description:
 A simple textwrap based printer for nested dictionaries.
 
 """
+
 from textwrap import TextWrapper
 from collections import OrderedDict
 
 
-def twClosure(replace_whitespace=False,
-              break_long_words=False,
-              maxWidth=120,
-              maxLength=-1,
-              maxDepth=-1,
-              initial_indent=''):
+def twClosure(
+    replace_whitespace=False,
+    break_long_words=False,
+    maxWidth=120,
+    maxLength=-1,
+    maxDepth=-1,
+    initial_indent="",
+):
     """
     Deals with indentation of dictionaries with very long key, value pairs.
     replace_whitespace: Replace each whitespace character with a single space.
@@ -28,25 +31,27 @@ def twClosure(replace_whitespace=False,
     Uses 4 spaces indentation for both keys and values.
     Nested dictionaries and lists go to next line.
     """
-    twr = TextWrapper(replace_whitespace=replace_whitespace,
-                      break_long_words=break_long_words,
-                      width=maxWidth,
-                      initial_indent=initial_indent)
+    twr = TextWrapper(
+        replace_whitespace=replace_whitespace,
+        break_long_words=break_long_words,
+        width=maxWidth,
+        initial_indent=initial_indent,
+    )
 
-    def twEnclosed(obj, ind='', depthReached=0, reCall=False):
+    def twEnclosed(obj, ind="", depthReached=0, reCall=False):
         """
         The inner function of the closure
         ind: Initial indentation for the single output string
         reCall: Flag to indicate a recursive call (should not be used outside)
         """
-        output = ''
+        output = ""
         if isinstance(obj, dict):
-            obj = OrderedDict(sorted(list(obj.items()),
-                                     key=lambda t: t[0],
-                                     reverse=False))
+            obj = OrderedDict(
+                sorted(list(obj.items()), key=lambda t: t[0], reverse=False)
+            )
             if reCall:
-                output += '\n'
-            ind += '    '
+                output += "\n"
+            ind += "    "
             depthReached += 1
             lengthReached = 0
             for key, value in list(obj.items()):
@@ -55,14 +60,16 @@ def twClosure(replace_whitespace=False,
                     output += "%s...\n" % ind
                     break
                 if depthReached <= maxDepth or maxDepth < 0:
-                    output += "%s%s: %s" % (ind,
-                                            ''.join(twr.wrap(key)),
-                                            twEnclosed(value, ind, depthReached=depthReached, reCall=True))
+                    output += "%s%s: %s" % (
+                        ind,
+                        "".join(twr.wrap(key)),
+                        twEnclosed(value, ind, depthReached=depthReached, reCall=True),
+                    )
 
         elif isinstance(obj, (list, set)):
             if reCall:
-                output += '\n'
-            ind += '    '
+                output += "\n"
+            ind += "    "
             lengthReached = 0
             for value in obj:
                 lengthReached += 1
@@ -70,7 +77,10 @@ def twClosure(replace_whitespace=False,
                     output += "%s...\n" % ind
                     break
                 if depthReached <= maxDepth or maxDepth < 0:
-                    output += "%s%s" % (ind, twEnclosed(value, ind, depthReached=depthReached, reCall=True))
+                    output += "%s%s" % (
+                        ind,
+                        twEnclosed(value, ind, depthReached=depthReached, reCall=True),
+                    )
         else:
             output += "%s\n" % str(obj)  # join(twr.wrap(str(obj)))
         return output
@@ -82,9 +92,7 @@ def twPrint(obj, maxWidth=120, maxLength=-1, maxDepth=-1):
     """
     A simple caller of twClosure (see docstring for twClosure)
     """
-    twPrinter = twClosure(maxWidth=maxWidth,
-                          maxLength=maxLength,
-                          maxDepth=maxDepth)
+    twPrinter = twClosure(maxWidth=maxWidth, maxLength=maxLength, maxDepth=maxDepth)
     print(twPrinter(obj))
 
 
@@ -92,7 +100,5 @@ def twFormat(obj, maxWidth=120, maxLength=-1, maxDepth=-1):
     """
     A simple caller of twClosure (see docstring for twClosure)
     """
-    twFormatter = twClosure(maxWidth=maxWidth,
-                            maxLength=maxLength,
-                            maxDepth=maxDepth)
+    twFormatter = twClosure(maxWidth=maxWidth, maxLength=maxLength, maxDepth=maxDepth)
     return twFormatter(obj)

--- a/src/python/Utils/Utilities.py
+++ b/src/python/Utils/Utilities.py
@@ -11,19 +11,21 @@ import sys
 from types import ModuleType, FunctionType
 from gc import get_referents
 
+
 def lowerCmsHeaders(headers):
     """
     Lower CMS headers in provided header's dict. The WMCore Authentication
     code check only cms headers in lower case, e.g. cms-xxx-yyy.
     """
     lheaders = {}
-    for hkey, hval in list(headers.items()): # perform lower-case
+    for hkey, hval in list(headers.items()):  # perform lower-case
         # lower header keys since we check lower-case in headers
-        if hkey.startswith('Cms-') or hkey.startswith('CMS-'):
+        if hkey.startswith("Cms-") or hkey.startswith("CMS-"):
             lheaders[hkey.lower()] = hval
         else:
             lheaders[hkey] = hval
     return lheaders
+
 
 def makeList(stringList):
     """
@@ -36,10 +38,10 @@ def makeList(stringList):
     if isinstance(stringList, list):
         return stringList
     if isinstance(stringList, str):
-        toks = stringList.lstrip(' [').rstrip(' ]').split(',')
-        if toks == ['']:
+        toks = stringList.lstrip(" [").rstrip(" ]").split(",")
+        if toks == [""]:
             return []
-        return [str(tok.strip(' \'"')) for tok in toks]
+        return [str(tok.strip(" '\"")) for tok in toks]
     raise ValueError("Can't convert to list %s" % stringList)
 
 
@@ -98,10 +100,10 @@ def diskUse():
     output = decodeBytesToUnicode(output).split("\n")
     for x in output:
         split = x.split()
-        if split != [] and split[0] != 'Filesystem':
-            diskPercent.append({'filesystem': split[0],
-                                'mounted':    split[5], 
-                                'percent':    split[4]})
+        if split != [] and split[0] != "Filesystem":
+            diskPercent.append(
+                {"filesystem": split[0], "mounted": split[5], "percent": split[4]}
+            )
 
     return diskPercent
 
@@ -112,7 +114,7 @@ def numberCouchProcess():
     """
     ps = subprocess.Popen(["ps", "-ef"], stdout=subprocess.PIPE)
     process = ps.communicate()[0]
-    process = decodeBytesToUnicode(process).count('couchjs')
+    process = decodeBytesToUnicode(process).count("couchjs")
 
     return process
 
@@ -132,7 +134,9 @@ def rootUrlJoin(base, extend):
     return None
 
 
-def zipEncodeStr(message, maxLen=5120, compressLevel=9, steps=100, truncateIndicator=" (...)"):
+def zipEncodeStr(
+    message, maxLen=5120, compressLevel=9, steps=100, truncateIndicator=" (...)"
+):
     """
     _zipEncodeStr_
     Utility to zip a string and encode it.
@@ -146,7 +150,7 @@ def zipEncodeStr(message, maxLen=5120, compressLevel=9, steps=100, truncateIndic
     if len(encodedStr) < maxLen or maxLen == -1:
         return encodedStr
 
-    compressRate = 1. * len(encodedStr) / len(base64.b64encode(message))
+    compressRate = 1.0 * len(encodedStr) / len(base64.b64encode(message))
 
     # Estimate new length for message zip/encoded version
     # to be less than maxLen.
@@ -160,7 +164,7 @@ def zipEncodeStr(message, maxLen=5120, compressLevel=9, steps=100, truncateIndic
     # If new length is not short enough, truncate
     # recursively by steps
     while len(encodedStr) > maxLen:
-        message = message[:-steps - len(truncateIndicator)] + truncateIndicator
+        message = message[: -steps - len(truncateIndicator)] + truncateIndicator
         encodedStr = zipEncodeStr(message, maxLen=-1)
 
     return encodedStr
@@ -183,7 +187,7 @@ def getSize(obj):
     BLACKLIST = type, ModuleType, FunctionType
 
     if isinstance(obj, BLACKLIST):
-        raise TypeError('getSize() does not take argument of type: '+ str(type(obj)))
+        raise TypeError("getSize() does not take argument of type: " + str(type(obj)))
     seen_ids = set()
     size = 0
     objects = [obj]
@@ -229,11 +233,12 @@ def decodeBytesToUnicode(value, errors="strict"):
         return value.decode("utf-8", errors)
     return value
 
+
 def decodeBytesToUnicodeConditional(value, errors="ignore", condition=True):
     """
     if *condition*, then call decodeBytesToUnicode(*value*, *errors*),
     else return *value*
-    
+
     This may be useful when we want to conditionally apply decodeBytesToUnicode,
     maintaining brevity.
 
@@ -249,6 +254,7 @@ def decodeBytesToUnicodeConditional(value, errors="ignore", condition=True):
     if condition:
         return decodeBytesToUnicode(value, errors)
     return value
+
 
 def encodeUnicodeToBytes(value, errors="strict"):
     """
@@ -269,7 +275,7 @@ def encodeUnicodeToBytes(value, errors="strict"):
     - "errors" can be: "strict", "ignore", "replace", "xmlcharrefreplace"
     - ref: https://docs.python.org/2/howto/unicode.html#the-unicode-type
     py3:
-    - "errors" can be: "strict", "ignore", "replace", "backslashreplace", 
+    - "errors" can be: "strict", "ignore", "replace", "backslashreplace",
       "xmlcharrefreplace", "namereplace"
     - ref: https://docs.python.org/3/howto/unicode.html#the-string-type
     """
@@ -277,11 +283,12 @@ def encodeUnicodeToBytes(value, errors="strict"):
         return value.encode("utf-8", errors)
     return value
 
+
 def encodeUnicodeToBytesConditional(value, errors="ignore", condition=True):
     """
     if *condition*, then call encodeUnicodeToBytes(*value*, *errors*),
     else return *value*
-    
+
     This may be useful when we want to conditionally apply encodeUnicodeToBytes,
     maintaining brevity.
 


### PR DESCRIPTION
Fixes # (no issue created)

#### Status
In development

#### Description
Just playing around with the `ruff` library and checking the outcome of its auto-reformat for coding style and many of the pylint issues. I have used the following 2 commands:
```
ruff format src/python/Utils/
ruff check --fix src/python/Utils/
```

but from a different virtual environment that uses python 3.10.13 (so results might be slightly different than expected).

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
