### PR TITLE
Fix delayed $WMA_DEPLOY_DIR env virable

### DIFF
--- a/deploy/deploy-wmagent-venv.sh
+++ b/deploy/deploy-wmagent-venv.sh
@@ -514,9 +514,9 @@ wmaInstall() {
     _addWMCoreVenvVar  WMA_INSTALL_DIR $WMA_CURRENT_DIR/install
     _addWMCoreVenvVar  WMA_CONFIG_DIR $WMA_CURRENT_DIR/config
     _addWMCoreVenvVar  WMA_CONFIG_FILE $WMA_CONFIG_DIR/config.py
-    _addWMCoreVenvVar  WMA_MANAGE_DIR $WMA_DEPLOY_DIR/bin
     _addWMCoreVenvVar  WMA_LOG_DIR $WMA_CURRENT_DIR/logs
     _addWMCoreVenvVar  WMA_DEPLOY_DIR $venvPath
+    _addWMCoreVenvVar  WMA_MANAGE_DIR $WMA_DEPLOY_DIR/bin
     _addWMCoreVenvVar  WMA_ENV_FILE $WMA_DEPLOY_DIR/deploy/env.sh
     _addWMCoreVenvVar  WMA_SECRETS_FILE $WMA_ADMIN_DIR/WMAgent.secrets
 


### PR DESCRIPTION
Fixes #12166 

#### Status
not-tested

#### Description
Once we've fixed the broken `set_cronjob` function for the virtual environment  here: https://github.com/dmwm/CMSKubernetes/pull/1564 , we  immediately started  getting e-mail warnings for broken cronjobs of the sort: 

```
/bin/sh: line 1: /bin/manage: No such file or directory
```
And the reason was that we  have used the `$WMA_DEPLOY_DIR` env. variable in the construction of `$WMA_MANAGE_DIR`, but we have the initialization of the former delayed, so it ends up as an empty string in the later.
This was resulting in generating the following crontab record: 
```
55 */12 * * * date -Im >> /data/WMAgent.venv3/srv/wmagent/2.3.4/logs/renew-proxy.log && /bin/manage renew-proxy 2>&1 >> /data/WMAgent.venv3/srv/wmagent/2.3.4/logs/renew-proxy.log
```  

With the current PR  we fix the delayed initialization of `$WMA_DEPLOY_DIR` variable. Which fixes the issue and the correctly generated crontab record is as follows: 
```
55 */12 * * * date -Im >> /data/WMAgent.venv3/srv/wmagent/2.3.4/logs/renew-proxy.log && /data/WMAgent.venv3/bin/manage renew-proxy 2>&1 >> /data/WMAgent.venv3/srv/wmagent/2.3.4/logs/renew-proxy.log

```

#### Is it backward compatible (if not, which system it affects?)
YES 

#### Related PRs
https://github.com/dmwm/CMSKubernetes/pull/1564

#### External dependencies / deployment changes
No