### PR TITLE
Fix T1 site cores ResourceControl logic

### DIFF
--- a/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
+++ b/src/python/WMComponent/AgentStatusWatcher/ResourceControlUpdater.py
@@ -214,8 +214,8 @@ class ResourceControlUpdater(BaseWorkerThread):
         for site in set(infoRC).intersection(set(infoSSB)):
             if self.tier0Mode and site.startswith('T1_'):
                 # T1 cores utilization for Tier0
-                infoSSB[site]['slotsCPU'] *= self.t1SitesCores // 100
-                infoSSB[site]['slotsIO'] *= self.t1SitesCores // 100
+                infoSSB[site]['slotsCPU'] = int(infoSSB[site]['slotsCPU'] * self.t1SitesCores / 100)
+                infoSSB[site]['slotsIO'] = int(infoSSB[site]['slotsIO'] * self.t1SitesCores / 100)
             else:
                 # round very small sites to the bare minimum
                 infoSSB[site]['slotsCPU'] = max(infoSSB[site]['slotsCPU'], self.minCPUSlots)


### PR DESCRIPTION
Fixes #12121 

#### Status
not-tested

#### Description
Given that Tier0 configuration sets this value <=100% (e.g. 12.5), the integer division would always return 0, hence not changing any of the default thresholds.

With the current change, we can now properly calculate a percentage of the site slots (e.g. 1250 for CNAF).

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
It has to go together with this T0 PR: https://github.com/dmwm/T0/pull/5007

#### External dependencies / deployment changes
None