### PR TITLE
Integrate package attestations in the CI/CD pipeline

### DIFF
--- a/.github/workflows/pypi_build_publish_template.yaml
+++ b/.github/workflows/pypi_build_publish_template.yaml
@@ -32,5 +32,13 @@ jobs:
           awk "/(${{ inputs.wmcore_component }}$)|(${{ inputs.wmcore_component }},)/ {print \$1}" requirements.wmcore.txt > requirements.txt
       - name: Build sdist
         run: python3 setup.py clean sdist
+      - name: List contents before attestation
+        run: |
+          ls ${{ github.workspace }}
+          ls ${{ github.workspace }}/dist
+      - name: Attest package
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: '${{ github.workspace }}/dist/${{ inputs.wmcore_component }}-*'
       - name: Upload package distribution to PyPi
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Fixes #12179 

#### Status
not-tested

#### Description
This is a second attempt to try to fix package upload to PyPi, with the integration of "Attestations" into our pipeline.

First error happened in this tag: https://github.com/dmwm/WMCore/actions/runs/11956233634

which we tried to fix by adding another Trusted Publisher in PyPi.

#### Is it backward compatible (if not, which system it affects?)
MAYBE

#### Related PRs
None

#### External dependencies / deployment changes
None
