### PR TITLE
Grant attestation write access - CI/CD pipeline

### DIFF
--- a/.github/workflows/pypi_build_publish_template.yaml
+++ b/.github/workflows/pypi_build_publish_template.yaml
@@ -14,6 +14,7 @@ jobs:
       name: production
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+      attestations: write  # IMPORTANT: necessary to persist the attestation
     steps:
       - uses: actions/checkout@v4
       - name: Setup python 3.8


### PR DESCRIPTION
Fixes #12179 

#### Status
not-tested

#### Description
One more change for supporting attestations in GitHub workflows CI/CD pipeline.
Complement to https://github.com/dmwm/WMCore/pull/12177

#### Is it backward compatible (if not, which system it affects?)
MAYBE

#### Related PRs
Complement to https://github.com/dmwm/WMCore/pull/12177

#### External dependencies / deployment changes
None
