### PR TITLE
Properly run restartComponent.sh avoiding hardwired paths

### DIFF
--- a/deploy/restartComponent.sh
+++ b/deploy/restartComponent.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 ### Script to check the tail of each WMAgent component and evaluate
 # whether they are running or not, based on file meta-data (stat).
 # Component is automatically restarted if deemed down.
@@ -10,15 +10,12 @@ HOST=$(hostname)
 DATENOW=$(date +%s)
 DEST_NAME=cms-wmcore-team
 
-# Figure whether it's a python2 or python3 agent
-if [ ! -d "$install" ]; then
-  install="/data/srv/wmagent/current/install/"
-fi
+[[ -z $WMA_INSTALL_DIR ]] && { echo "ERROR: Trying to run without having the full WMAgent environment set!";  exit 1 ;}
 
 echo -e "\n###Checking agent logs at: $(date)"
-comps=$(ls $install)
+comps=$(ls $WMA_INSTALL_DIR)
 for comp in $comps; do
-  COMPLOG=$install/$comp/ComponentLog
+  COMPLOG=$WMA_INSTALL_DIR/$comp/ComponentLog
   if [ ! -f $COMPLOG ]; then
     echo "Not a component or $COMPLOG does not exist"
     continue
@@ -34,7 +31,8 @@ for comp in $comps; do
     fi
 
     TAIL_LOG=$(tail -n100 $COMPLOG)
-    $manage execute-agent wmcoreD --restart --components=$comp
+    echo -e "Restarting component: $comp"
+    manage execute-agent wmcoreD --restart --components=$comp
     echo -e "ComponentLog quiet for $INTERVAL secs\n\nTail of the log is:\n$TAIL_LOG" |
       mail -s "$HOST : $comp restarted" $DEST_NAME@cern.ch
   fi


### PR DESCRIPTION
Fixes #12184 

#### Status
ready

#### Description
With the current change we avoid hardwired paths inside the `restartComponent.sh` script, and instead we properly tie  those as relative paths to the proper environment `$WMA_*` variables. 

In addition we add the executable flag to the script and change its shell from `sh` to `bash`, in order to be correctly run and later quit in case of errors from the cronjobs of the agents, instead of being sourced and the errors silently ignored if the script just quits (`exit $errCode` inside a sourced script will just close the shell sourcing the script leaving no trace of the error code returned).  

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
This PR  goes hand in hand with: https://github.com/dmwm/CMSKubernetes/pull/1569

#### External dependencies / deployment changes
The WMAgent packages uploaded to Pypi. 
Since the `restartComponent.sh` script is always run by our cronjobs  from `$WMA_DEPLOY_DIR/deploy/` it will always be the version of the script coming from the WMAgent pypi package which is to be executed, regardless if one runs the service from source or from the pypi packages. So even if the fix is applied and patched the change won't take effect until the newly built python package is redeployed at the destination or eventually the script substituted manually. 