### PR TITLE
Change the way to estimate running components

### DIFF
--- a/deploy/restartComponent.sh
+++ b/deploy/restartComponent.sh
@@ -13,8 +13,8 @@ DEST_NAME=cms-wmcore-team
 [[ -z $WMA_INSTALL_DIR ]] && { echo "ERROR: Trying to run without having the full WMAgent environment set!";  exit 1 ;}
 
 echo -e "\n###Checking agent logs at: $(date)"
-comps=$(ls $WMA_INSTALL_DIR)
-for comp in $comps; do
+compsRunning=$(manage execute-agent wmcoreD --status |grep -E "Running:[0-9]+" |awk '{print $1}' |awk -F \: '{print $2}')
+for comp in $compsRunning; do
   COMPLOG=$WMA_INSTALL_DIR/$comp/ComponentLog
   if [ ! -f $COMPLOG ]; then
     echo "Not a component or $COMPLOG does not exist"


### PR DESCRIPTION
Fixes #12184 

#### Status
ready

#### Description
With the current PR we address the issue reported by T0 team in the following comment:  https://github.com/dmwm/WMCore/issues/12184#issuecomment-2505440898

Here we change the way we  estimate the set of running components.  Instead of just listing the log directories here we rely on the returned value from the actual `manage` command and  the `execute-agent` call to the underlying daemon to run the agent.   

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
https://github.com/dmwm/WMCore/pull/12185

#### External dependencies / deployment changes
None