### PR TITLE
BROKEN - Implementation of the token-safe retry logic for gfal

### DIFF
--- a/etc/submit_py3.sh
+++ b/etc/submit_py3.sh
@@ -192,6 +192,31 @@ else
 fi
 echo -e "======== WMAgent Python bootstrap finished at $(TZ=GMT date) ========\n"
 
+echo -e "======= WMAgent token verification at $(TZ=GMT date) ========\n"
+echo "Content under _CONDOR_CREDS: ${_CONDOR_CREDS}"
+ls -l ${_CONDOR_CREDS}
+
+if [ -f "${_CONDOR_CREDS}/cms.use" ]
+then
+    echo "CMS token found, setting BEARER_TOKEN_FILE=${_CONDOR_CREDS}/cms.use"
+    export BEARER_TOKEN_FILE=${_CONDOR_CREDS}/cms.use
+
+    # Show token information
+    # This tool requires htgettoken package in the cmssw runtime apptainer image
+    if command -v httokendecode ls 2>&1 > /dev/null
+    then
+        httokendecode -H ${BEARER_TOKEN_FILE}
+    else
+        echo "Warning: [WMAgent Token verification] httokendecode tool could not be found."
+        echo "Warning: Token exists and can be used, but details will not be displayed."
+    fi
+else
+    echo "[WMAgent token verification]: The bearer token file could not be found."
+    # Do not fail, we still support x509 proxies
+    # if we fail here in the future, we need to define an exit code number
+    # exit 1106
+fi
+
 
 echo "======== WMAgent Unpack the job starting at $(TZ=GMT date) ========"
 # Should be ready to unpack and run this

--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -520,8 +520,11 @@ class SimpleCondorPlugin(BasePlugin):
                 ad['Requirements'] = self.reqStr
 
             #ad['My.x509userproxy'] = classad.quote(self.x509userproxy)
+<<<<<<< HEAD
             # Allow oauth based token authentication
             ad['use_oauth_services'] = "cms"
+=======
+>>>>>>> 5f13933e5 (Disabling x509 -- TO REVERT)
             sites = ','.join(sorted(job.get('possibleSites')))
             ad['My.DESIRED_Sites'] = classad.quote(str(sites))
             sites = ','.join(sorted(job.get('potentialSites')))

--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -520,6 +520,8 @@ class SimpleCondorPlugin(BasePlugin):
                 ad['Requirements'] = self.reqStr
 
             #ad['My.x509userproxy'] = classad.quote(self.x509userproxy)
+            # Allow oauth based token authentication
+            ad['use_oauth_services'] = "cms"
             sites = ','.join(sorted(job.get('possibleSites')))
             ad['My.DESIRED_Sites'] = classad.quote(str(sites))
             sites = ','.join(sorted(job.get('potentialSites')))

--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -520,11 +520,8 @@ class SimpleCondorPlugin(BasePlugin):
                 ad['Requirements'] = self.reqStr
 
             #ad['My.x509userproxy'] = classad.quote(self.x509userproxy)
-<<<<<<< HEAD
             # Allow oauth based token authentication
             ad['use_oauth_services'] = "cms"
-=======
->>>>>>> 5f13933e5 (Disabling x509 -- TO REVERT)
             sites = ','.join(sorted(job.get('possibleSites')))
             ad['My.DESIRED_Sites'] = classad.quote(str(sites))
             sites = ','.join(sorted(job.get('potentialSites')))

--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -132,8 +132,8 @@ class SimpleCondorPlugin(BasePlugin):
             self.reqStr = None
 
         # x509 proxy handling
-        proxy = Proxy({'logger': myThread.logger})
-        self.x509userproxy = proxy.getProxyFilename()
+        ##proxy = Proxy({'logger': myThread.logger})
+        ##self.x509userproxy = proxy.getProxyFilename()
 
         # These are added now by the condor client
         #self.x509userproxysubject = proxy.getSubject()
@@ -519,7 +519,7 @@ class SimpleCondorPlugin(BasePlugin):
             if self.reqStr is not None:
                 ad['Requirements'] = self.reqStr
 
-            ad['My.x509userproxy'] = classad.quote(self.x509userproxy)
+            #ad['My.x509userproxy'] = classad.quote(self.x509userproxy)
             sites = ','.join(sorted(job.get('possibleSites')))
             ad['My.DESIRED_Sites'] = classad.quote(str(sites))
             sites = ','.join(sorted(job.get('potentialSites')))

--- a/src/python/WMCore/Storage/Backends/GFAL2Impl.py
+++ b/src/python/WMCore/Storage/Backends/GFAL2Impl.py
@@ -5,6 +5,7 @@ Implementation of StageOutImpl interface for gfal-copy
 """
 import argparse
 import os
+import logging
 
 from WMCore.Storage.Registry import registerStageOutImpl
 from WMCore.Storage.StageOutImpl import StageOutImpl

--- a/src/python/WMCore/Storage/Backends/GFAL2Impl.py
+++ b/src/python/WMCore/Storage/Backends/GFAL2Impl.py
@@ -160,7 +160,7 @@ class GFAL2Impl(StageOutImpl):
             # Special case: for _CONDOR_CREDS, log its subpath if defined
             if var == "_CONDOR_CREDS" and value != "Not defined":
                 subpath = os.path.join(value, "cms.use")
-                logger.info(f"{var}/cms.use: {subpath}")
+                logging.info(f"{var}/cms.use: {subpath}")
 
                 if os.path.exists(subpath):
                     try:
@@ -168,15 +168,15 @@ class GFAL2Impl(StageOutImpl):
                             ["htdecodetoken", "-H", subpath], stderr=subprocess.STDOUT, text=True
                         )
                         if decoded_output.strip():
-                            logger.info(f"Decoded token for {var}/cms.use:\n{decoded_output.strip()}")
+                            logging.info(f"Decoded token for {var}/cms.use:\n{decoded_output.strip()}")
                         else:
-                            logger.warning(f"No output from htdecodetoken for {var}/cms.use.")
+                            logging.warning(f"No output from htdecodetoken for {var}/cms.use.")
                     except subprocess.CalledProcessError as e:
-                        logger.error(f"Error decoding token for {var}/cms.use: {e.output.strip()}")
+                        logging.error(f"Error decoding token for {var}/cms.use: {e.output.strip()}")
                     except FileNotFoundError:
-                        logger.error(f"htdecodetoken command not found. Ensure it is installed and in the PATH.")
+                        logging.error(f"htdecodetoken command not found. Ensure it is installed and in the PATH.")
                 else:
-                    logger.warning(f"Subpath does not exist: {subpath}")
+                    logging.warning(f"Subpath does not exist: {subpath}")
 
 
         if _CheckExitCodeOption:

--- a/src/python/WMCore/Storage/Backends/GFAL2Impl.py
+++ b/src/python/WMCore/Storage/Backends/GFAL2Impl.py
@@ -153,21 +153,21 @@ class GFAL2Impl(StageOutImpl):
             result += """
             EXIT_STATUS=$?
             echo "gfal-copy exit status: $EXIT_STATUS"
-            echo "BEARER_TOKEN" $BEARER_TOKEN
-            htdecodetoken -H $BEARER_TOKEN
-            echo "BEARER_TOKEN_FILE" $BEARER_TOKEN_FILE
-            htdecodetoken -H $BEARER_TOKEN_FILE
-            echo "X509_USER_PROXY" $X509_USER_PROXY
-            echo "_CONDOR_CREDS" ${_CONDOR_CREDS}
-            echo ${_CONDOR_CREDS}/cms.use
-            htdecodetoken -H 
+            echo "BEARER_TOKEN: $BEARER_TOKEN"
+            htdecodetoken -H "$BEARER_TOKEN"
+            echo "BEARER_TOKEN_FILE: $BEARER_TOKEN_FILE"
+            htdecodetoken -H "$BEARER_TOKEN_FILE"
+            echo "X509_USER_PROXY: $X509_USER_PROXY"
+            echo "_CONDOR_CREDS: $_CONDOR_CREDS"
+            echo "${_CONDOR_CREDS}/cms.use"
+            htdecodetoken -H "$_CONDOR_CREDS/cms.use"
             if [[ $EXIT_STATUS != 0 ]]; then
                 echo "ERROR: gfal-copy exited with $EXIT_STATUS"
                 echo "Cleaning up failed file:"
                 {remove_command}
             fi
             exit $EXIT_STATUS
-            """.format(remove_command=self.createRemoveFileCommand(targetPFN))  
+            """.format(remove_command=self.createRemoveFileCommand(targetPFN))
 
         return result
 

--- a/src/python/WMCore/Storage/Backends/GFAL2Impl.py
+++ b/src/python/WMCore/Storage/Backends/GFAL2Impl.py
@@ -25,10 +25,10 @@ class GFAL2Impl(StageOutImpl):
         # Next commands after separation are executed without env -i and this leads us with
         # mixed environment with COMP and system python.
         # GFAL2 is not build under COMP environment and it had failures with mixed environment.
-        self.setups = "env -i JOBSTARTDIR=$JOBSTARTDIR bash -c '{}'"  # Default initialization, it is tweaked in createStageOutCommand depending on the authentication method
-        self.removeCommand = self.setups.format('. $JOBSTARTDIR/startup_environment.sh; date; gfal-rm -t 600 {}')
-        self.copyOpts = '-t 2400 -T 2400 -p -v --abort-on-failure {checksum} {options} {source} {destination}'
-        self.copyCommand = self.setups.format('. $JOBSTARTDIR/startup_environment.sh; date; gfal-copy ' + self.copyOpts)
+        ##self.setups = "env -i JOBSTARTDIR=$JOBSTARTDIR bash -c '{}'"  # Default initialization, it is tweaked in createStageOutCommand depending on the authentication method
+        ##self.removeCommand = self.setups.format('. $JOBSTARTDIR/startup_environment.sh; date; gfal-rm -t 600 {}')
+        ##self.copyOpts = '-t 2400 -T 2400 -p -v --abort-on-failure {checksum} {options} {source} {destination}'
+        ##self.copyCommand = self.setups.format('. $JOBSTARTDIR/startup_environment.sh; date; gfal-copy ' + self.copyOpts)
 
     def createFinalPFN(self, pfn):
         """
@@ -172,6 +172,10 @@ class GFAL2Impl(StageOutImpl):
             self.setups = "env -i BEARER_TOKEN=$(cat $BEARER_TOKEN_FILE) JOBSTARTDIR=$JOBSTARTDIR bash -c '{}'"
         else:
             self.setups = "env -i JOBSTARTDIR=$JOBSTARTDIR bash -c '{}'"
+        #Need to define this variables here, otherwise the self.setups update is not propagated
+        self.removeCommand = self.setups.format('. $JOBSTARTDIR/startup_environment.sh; date; gfal-rm -t 600 {}')
+        self.copyOpts = '-t 2400 -T 2400 -p -v --abort-on-failure {checksum} {options} {source} {destination}'
+        self.copyCommand = self.setups.format('. $JOBSTARTDIR/startup_environment.sh; date; gfal-copy ' + self.copyOpts)
 
         copyCommandDict = self.buildCopyCommandDict(sourcePFN, targetPFN, options, checksums)
         copyCommand = self.copyCommand.format_map(copyCommandDict)

--- a/src/python/WMCore/Storage/Backends/GFAL2Impl.py
+++ b/src/python/WMCore/Storage/Backends/GFAL2Impl.py
@@ -154,10 +154,13 @@ class GFAL2Impl(StageOutImpl):
             EXIT_STATUS=$?
             echo "gfal-copy exit status: $EXIT_STATUS"
             echo "BEARER_TOKEN" $BEARER_TOKEN
+            htdecodetoken -H $BEARER_TOKEN
             echo "BEARER_TOKEN_FILE" $BEARER_TOKEN_FILE
+            htdecodetoken -H $BEARER_TOKEN_FILE
             echo "X509_USER_PROXY" $X509_USER_PROXY
             echo "_CONDOR_CREDS" ${_CONDOR_CREDS}
             echo ${_CONDOR_CREDS}/cms.use
+            htdecodetoken -H 
             if [[ $EXIT_STATUS != 0 ]]; then
                 echo "ERROR: gfal-copy exited with $EXIT_STATUS"
                 echo "Cleaning up failed file:"

--- a/src/python/WMCore/Storage/Backends/GFAL2Impl.py
+++ b/src/python/WMCore/Storage/Backends/GFAL2Impl.py
@@ -25,10 +25,10 @@ class GFAL2Impl(StageOutImpl):
         # Next commands after separation are executed without env -i and this leads us with
         # mixed environment with COMP and system python.
         # GFAL2 is not build under COMP environment and it had failures with mixed environment.
-        ##self.setups = "env -i JOBSTARTDIR=$JOBSTARTDIR bash -c '{}'"  # Default initialization, it is tweaked in createStageOutCommand depending on the authentication method
-        ##self.removeCommand = self.setups.format('. $JOBSTARTDIR/startup_environment.sh; date; gfal-rm -t 600 {}')
-        ##self.copyOpts = '-t 2400 -T 2400 -p -v --abort-on-failure {checksum} {options} {source} {destination}'
-        ##self.copyCommand = self.setups.format('. $JOBSTARTDIR/startup_environment.sh; date; gfal-copy ' + self.copyOpts)
+        self.setups = "env -i JOBSTARTDIR=$JOBSTARTDIR bash -c '{}'"  # Default initialization, it is tweaked in createStageOutCommand depending on the authentication method
+        self.removeCommand = self.setups.format('. $JOBSTARTDIR/startup_environment.sh; date; gfal-rm -t 600 {}')
+        self.copyOpts = '-t 2400 -T 2400 -p -v --abort-on-failure {checksum} {options} {source} {destination}'
+        self.copyCommand = self.setups.format('. $JOBSTARTDIR/startup_environment.sh; date; gfal-copy ' + self.copyOpts)
 
     def createFinalPFN(self, pfn):
         """
@@ -133,6 +133,11 @@ class GFAL2Impl(StageOutImpl):
         else:
             logging.info("Warning! Running gfal without either a X509 certificate or a token!")
             self.setups = "env -i JOBSTARTDIR=$JOBSTARTDIR bash -c '{}'"
+
+        #Need to define this variables here, otherwise the self.setups update is not propagated
+        self.removeCommand = self.setups.format('. $JOBSTARTDIR/startup_environment.sh; date; gfal-rm -t 600 {}')
+        self.copyOpts = '-t 2400 -T 2400 -p -v --abort-on-failure {checksum} {options} {source} {destination}'
+        self.copyCommand = self.setups.format('. $JOBSTARTDIR/startup_environment.sh; date; gfal-copy ' + self.copyOpts)
 
         # Construct the gfal-cp command
         copyCommandDict = self.buildCopyCommandDict(sourcePFN, targetPFN, options, checksums)

--- a/src/python/WMCore/Storage/Backends/GFAL2Impl.py
+++ b/src/python/WMCore/Storage/Backends/GFAL2Impl.py
@@ -153,6 +153,11 @@ class GFAL2Impl(StageOutImpl):
             result += """
             EXIT_STATUS=$?
             echo "gfal-copy exit status: $EXIT_STATUS"
+            echo "BEARER_TOKEN" $BEARER_TOKEN
+            echo "BEARER_TOKEN_FILE" $BEARER_TOKEN_FILE
+            echo "X509_USER_PROXY" $X509_USER_PROXY
+            echo "_CONDOR_CREDS" ${_CONDOR_CREDS}
+            echo ${_CONDOR_CREDS}/cms.use
             if [[ $EXIT_STATUS != 0 ]]; then
                 echo "ERROR: gfal-copy exited with $EXIT_STATUS"
                 echo "Cleaning up failed file:"

--- a/src/python/WMCore/Storage/StageOutImpl.py
+++ b/src/python/WMCore/Storage/StageOutImpl.py
@@ -214,7 +214,8 @@ class StageOutImpl:
         # //
         try:
             command = self.createStageOutCommand(sourcePFN, targetPFN, options, checksums, auth_method="TOKEN")
-        except:
+        except TypeError as ex:
+            logging.warning("Falling back to default createStageOutCommand due to: %s", str(ex))
             command = self.createStageOutCommand(sourcePFN, targetPFN, options, checksums)
         # //
         # // Run the command

--- a/src/python/WMCore/Storage/StageOutImpl.py
+++ b/src/python/WMCore/Storage/StageOutImpl.py
@@ -236,7 +236,7 @@ class StageOutImpl:
                 if os.getenv("X509_USER_PROXY"):
                     logging.info("Retrying with X509_USER_PROXY after unsetting BEARER_TOKEN...")
                     os.system("unset BEARER_TOKEN; unset BEARER_TOKEN_FILE")
-                    command = self.createStageOutCommand(sourcePFN, targetPFN, options, checksums, "X509")
+                    command = self.createStageOutCommand(sourcePFN, targetPFN, options, checksums, auth_method="X509")
                     try:
                         self.executeCommand(command)
                         logging.info("Stage-out succeeded with X509 after unsetting BEARER_TOKEN.")
@@ -247,7 +247,7 @@ class StageOutImpl:
                 if os.getenv("BEARER_TOKEN") or os.getenv("BEARER_TOKEN_FILE"):
                     logging.info("Retrying with BEARER_TOKEN after unsetting X509_USER_PROXY...")
                     os.system("unset X509_USER_PROXY")
-                    command = self.createStageOutCommand(sourcePFN, targetPFN, options, checksums, "TOKEN")
+                    command = self.createStageOutCommand(sourcePFN, targetPFN, options, checksums, auth_method="TOKEN")
                     try:
                         self.executeCommand(command)
                         logging.info("Stage-out succeeded with TOKEN after unsetting X509_USER_PROXY.")
@@ -265,6 +265,6 @@ class StageOutImpl:
         # This block will now always be executed after retries are exhausted
         if stageOutEx is not None:
             logging.error("Maximum number of retries exhausted. Further details on the failed command reported below.")
-            command = self.createDebuggingCommand(sourcePFN, targetPFN, options, checksums)
+            command = self.createDebuggingCommand(sourcePFN, targetPFN, options, checksums, auth_method="TOKEN")
             self.executeCommand(command)
             raise stageOutEx from None

--- a/src/python/WMCore/Storage/StageOutImpl.py
+++ b/src/python/WMCore/Storage/StageOutImpl.py
@@ -212,7 +212,10 @@ class StageOutImpl:
         # //
         # // Create the command to be used.
         # //
-        command = self.createStageOutCommand(sourcePFN, targetPFN, options, checksums, auth_method="TOKEN")
+        try:
+            command = self.createStageOutCommand(sourcePFN, targetPFN, options, checksums, auth_method="TOKEN")
+        except:
+            command = self.createStageOutCommand(sourcePFN, targetPFN, options, checksums)
         # //
         # // Run the command
         # //

--- a/src/python/WMCore/Storage/StageOutImpl.py
+++ b/src/python/WMCore/Storage/StageOutImpl.py
@@ -142,7 +142,7 @@ class StageOutImpl:
         """
         raise NotImplementedError("StageOutImpl.createStageOutCommand")
 
-    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None, auth_method=None):
         """
         Build a shell command that will report in the logs the details about
         failing stageOut commands
@@ -254,7 +254,7 @@ class StageOutImpl:
                         return
                     except StageOutError as fallbackEx:
                         logging.warning("Fallback with BEARER_TOKEN failed:\n%s", str(fallbackEx))
-    
+
                 if retryCount == self.numRetries:
                     # Last retry, propagate the information outside of the for loop
                     stageOutEx = ex

--- a/src/python/WMCore/Storage/StageOutImpl.py
+++ b/src/python/WMCore/Storage/StageOutImpl.py
@@ -212,7 +212,7 @@ class StageOutImpl:
         # //
         # // Create the command to be used.
         # //
-        command = self.createStageOutCommand(sourcePFN, targetPFN, options, checksums)
+        command = self.createStageOutCommand(sourcePFN, targetPFN, options, checksums, auth_method="TOKEN")
         # //
         # // Run the command
         # //
@@ -220,8 +220,9 @@ class StageOutImpl:
         stageOutEx = None  # variable to store the possible StageOutError
         for retryCount in range(self.numRetries + 1):
             try:
-                logging.info("Running the stage out (attempt %d)...", retryCount + 1)
+                logging.info("Running the stage out with tokens (attempt %d)...", retryCount + 1)
                 self.executeCommand(command)
+                logging.info(f"{command}")
                 logging.info("Stage-out succeeded with the current environment.")
                 break
 

--- a/src/python/WMCore/Storage/StageOutImpl.py
+++ b/src/python/WMCore/Storage/StageOutImpl.py
@@ -222,7 +222,7 @@ class StageOutImpl:
             try:
                 logging.info("Running the stage out with tokens (attempt %d)...", retryCount + 1)
                 self.executeCommand(command)
-                logging.info(f"{command}")
+                logging.info("Command to run: %s", command)
                 logging.info("Stage-out succeeded with the current environment.")
                 break
 

--- a/src/python/WMCore/Storage/StageOutImpl.py
+++ b/src/python/WMCore/Storage/StageOutImpl.py
@@ -132,7 +132,7 @@ class StageOutImpl:
         If no directory is required, do not implement this method
         """
 
-    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None, auth_method=None):
         """
         _createStageOutCommand_
 
@@ -220,7 +220,7 @@ class StageOutImpl:
         stageOutEx = None  # variable to store the possible StageOutError
         for retryCount in range(self.numRetries + 1):
             try:
-                logging.info(f"Running the stage out (attempt {retryCount + 1})...")
+                logging.info("Running the stage out (attempt %d)...", retryCount + 1)
                 self.executeCommand(command)
                 logging.info("Stage-out succeeded with the current environment.")
                 break
@@ -242,7 +242,7 @@ class StageOutImpl:
                         logging.info("Stage-out succeeded with X509 after unsetting BEARER_TOKEN.")
                         return
                     except StageOutError as fallbackEx:
-                        logging.warning(f"Fallback with X509_USER_PROXY failed: \n{fallbackEx}")
+                        logging.warning("Fallback with X509_USER_PROXY failed:\n%s", str(fallbackEx))
 
                 if os.getenv("BEARER_TOKEN") or os.getenv("BEARER_TOKEN_FILE"):
                     logging.info("Retrying with BEARER_TOKEN after unsetting X509_USER_PROXY...")
@@ -253,9 +253,8 @@ class StageOutImpl:
                         logging.info("Stage-out succeeded with TOKEN after unsetting X509_USER_PROXY.")
                         return
                     except StageOutError as fallbackEx:
-                        logging.warning(f"Fallback with BEARER_TOKEN failed: \n{fallbackEx}")
-
-
+                        logging.warning("Fallback with BEARER_TOKEN failed:\n%s", str(fallbackEx))
+    
                 if retryCount == self.numRetries:
                     # Last retry, propagate the information outside of the for loop
                     stageOutEx = ex

--- a/test/python/WMCore_t/Storage_t/Backends_t/GFAL2Impl_t.py
+++ b/test/python/WMCore_t/Storage_t/Backends_t/GFAL2Impl_t.py
@@ -14,9 +14,9 @@ class GFAL2ImplTest(unittest.TestCase):
 
     def testInit(self):
         testGFAL2Impl = GFAL2Impl()
-        removeCommand = "env -i X509_USER_PROXY=$X509_USER_PROXY JOBSTARTDIR=$JOBSTARTDIR bash -c " \
+        removeCommand = "env -i JOBSTARTDIR=$JOBSTARTDIR bash -c " \
                 "'. $JOBSTARTDIR/startup_environment.sh; date; gfal-rm -t 600 {}'"
-        copyCommand = "env -i X509_USER_PROXY=$X509_USER_PROXY JOBSTARTDIR=$JOBSTARTDIR bash -c '" \
+        copyCommand = "env -i JOBSTARTDIR=$JOBSTARTDIR bash -c '" \
               ". $JOBSTARTDIR/startup_environment.sh; date; gfal-copy -t 2400 -T 2400 -p " \
               "-v --abort-on-failure {checksum} {options} {source} {destination}'"
         self.assertEqual(removeCommand, testGFAL2Impl.removeCommand)

--- a/test/python/WMCore_t/Storage_t/Backends_t/GFAL2Impl_t.py
+++ b/test/python/WMCore_t/Storage_t/Backends_t/GFAL2Impl_t.py
@@ -14,11 +14,12 @@ class GFAL2ImplTest(unittest.TestCase):
 
     def testInit(self):
         testGFAL2Impl = GFAL2Impl()
+        # The default setup without a token
         removeCommand = "env -i JOBSTARTDIR=$JOBSTARTDIR bash -c " \
-                "'. $JOBSTARTDIR/startup_environment.sh; date; gfal-rm -t 600 {}'"
+                        "'. $JOBSTARTDIR/startup_environment.sh; date; gfal-rm -t 600 {}'"
         copyCommand = "env -i JOBSTARTDIR=$JOBSTARTDIR bash -c '" \
-              ". $JOBSTARTDIR/startup_environment.sh; date; gfal-copy -t 2400 -T 2400 -p " \
-              "-v --abort-on-failure {checksum} {options} {source} {destination}'"
+                    ". $JOBSTARTDIR/startup_environment.sh; date; gfal-copy -t 2400 -T 2400 -p " \
+                    "-v --abort-on-failure {checksum} {options} {source} {destination}'"
         self.assertEqual(removeCommand, testGFAL2Impl.removeCommand)
         self.assertEqual(copyCommand, testGFAL2Impl.copyCommand)
 
@@ -79,10 +80,23 @@ class GFAL2ImplTest(unittest.TestCase):
     def testCreateStageOutCommand_stageIn(self, mock_createRemoveFileCommand):
         self.GFAL2Impl.stageIn = True
         mock_createRemoveFileCommand.return_value = "targetPFN2"
-        result = self.GFAL2Impl.createStageOutCommand("sourcePFN", "targetPFN")
+
+        # Call createStageOutCommand with auth_method='TOKEN'
+        result = self.GFAL2Impl.createStageOutCommand(
+            "sourcePFN", "targetPFN", auth_method='TOKEN'
+        )
+
+        # Generate the expected result with auth_method='TOKEN'
         expectedResult = self.getStageOutCommandResult(
-            self.getCopyCommandDict("-K adler32", "", "sourcePFN", "targetPFN"), "targetPFN2")
+            self.getCopyCommandDict("-K adler32", "", "sourcePFN", "targetPFN"),
+            "targetPFN2",
+            auth_method="TOKEN"
+        )
+
+        # Assert that the removeFileCommand was called correctly
         mock_createRemoveFileCommand.assert_called_with("targetPFN")
+
+        # Compare the expected and actual result
         self.assertEqual(expectedResult, result)
 
     @mock.patch('WMCore.Storage.Backends.GFAL2Impl.GFAL2Impl.createRemoveFileCommand')
@@ -94,20 +108,37 @@ class GFAL2ImplTest(unittest.TestCase):
         mock_createRemoveFileCommand.assert_called_with("file:targetPFN")
         self.assertEqual(expectedResult, result)
 
-    def getCopyCommandDict(self, checksum, options, source, destination):
-        copyCommandDict = {'checksum': '', 'options': '', 'source': '', 'destination': ''}
-        copyCommandDict['checksum'] = checksum
-        copyCommandDict['options'] = options
-        copyCommandDict['source'] = source
-        copyCommandDict['destination'] = destination
+    def getCopyCommandDict(self, checksum, options, source, destination, auth_method=None):
+        """
+        Generate a dictionary for the gfal-copy command, dynamically adjusting for auth_method.
+        """
+        copyCommandDict = {
+            'checksum': checksum,
+            'options': options,
+            'source': source,
+            'destination': destination
+        }
         return copyCommandDict
 
-    def getStageOutCommandResult(self, copyCommandDict, createRemoveFileCommandResult):
+    def getStageOutCommandResult(self, copyCommandDict, createRemoveFileCommandResult, auth_method=None):
+        """
+        Generate the expected result for the gfal-copy command, including dynamic adjustments for auth_method.
+        """
+        # Adjust the setup based on auth_method
+        if auth_method == "X509":
+            setups = "env -i X509_USER_PROXY=$X509_USER_PROXY JOBSTARTDIR=$JOBSTARTDIR bash -c '{}'"
+        elif auth_method == "TOKEN":
+            setups = "env -i BEARER_TOKEN=$(cat $BEARER_TOKEN_FILE) JOBSTARTDIR=$JOBSTARTDIR bash -c '{}'"
+        else:
+            setups = "env -i JOBSTARTDIR=$JOBSTARTDIR bash -c '{}'"
+
+        # Build the copy command dynamically
+        copyOpts = '-t 2400 -T 2400 -p -v --abort-on-failure {checksum} {options} {source} {destination}'
+        copyCommand = setups.format('. $JOBSTARTDIR/startup_environment.sh; date; gfal-copy ' + copyOpts)
+
+        # Construct the full result
         result = "#!/bin/bash\n"
-
-        copyCommand = self.copyCommand.format_map(copyCommandDict)
-        result += copyCommand
-
+        result += copyCommand.format_map(copyCommandDict)
         result += """
             EXIT_STATUS=$?
             echo "gfal-copy exit status: $EXIT_STATUS"
@@ -118,7 +149,7 @@ class GFAL2ImplTest(unittest.TestCase):
             fi
             exit $EXIT_STATUS
             """.format(remove_command=createRemoveFileCommandResult)
-        
+
         return result
     
     @mock.patch('WMCore.Storage.Backends.GFAL2Impl.os.path')

--- a/test/python/WMCore_t/Storage_t/StageOutImpl_t.py
+++ b/test/python/WMCore_t/Storage_t/StageOutImpl_t.py
@@ -91,7 +91,7 @@ class StageOutImplTest(unittest.TestCase):
         mock_createSourceName.assert_called_with("protocol", "inputPFN")
         mock_createTargetName.assert_called_with("protocol", "targetPFN")
         mock_createOutputDirectory.assert_called_with("targetPFN")
-        mock_createStageOutCommand.assert_called_with("sourcePFN", "targetPFN", None, None)
+        mock_createStageOutCommand.assert_called_with("sourcePFN", "targetPFN", None, None, auth_method='TOKEN')
         mock_executeCommand.assert_called_with("command")
 
     @mock.patch('WMCore.Storage.StageOutImpl.StageOutImpl.createSourceName')
@@ -111,7 +111,7 @@ class StageOutImplTest(unittest.TestCase):
         mock_createSourceName.assert_called_with("protocol", "inputPFN")
         mock_createTargetName.assert_called_with("protocol", "targetPFN")
         mock_createOutputDirectory.assert_called_with("targetPFN")
-        mock_createStageOutCommand.assert_called_with("sourcePFN", "targetPFN", None, None)
+        mock_createStageOutCommand.assert_called_with("sourcePFN", "targetPFN", None, None, auth_method='TOKEN')
         mock_executeCommand.assert_called_with("command")
         calls = [call(600), call(600), call(600), call(600)]
         mock_time.sleep.assert_has_calls(calls)


### PR DESCRIPTION
Fixes #12144 

#### Status
not-tested

#### Description
This PR introduces the retry logic proposed by @stlammel for handling the possible failures with token authentication when used with `gfal-cp`. To be extended to the `xrootd` protocol.
More details in the issue description

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
