### PR TITLE
Add token authentication support

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -221,6 +221,7 @@ config.JobSubmitter.skipRefreshCount = 20  # (If above the threshold meet, cache
 config.JobSubmitter.submitScript = os.path.join(os.environ["WMCORE_ROOT"], submitScript)
 config.JobSubmitter.extraMemoryPerCore = 500  # in MB
 config.JobSubmitter.drainGraceTime = 2 * 24 * 60 * 60  # in seconds
+config.JobSubmitter.useOauthToken = False
 
 config.component_("JobTracker")
 config.JobTracker.namespace = "WMComponent.JobTracker.JobTracker"

--- a/etc/submit_py3.sh
+++ b/etc/submit_py3.sh
@@ -192,6 +192,34 @@ else
 fi
 echo -e "======== WMAgent Python bootstrap finished at $(TZ=GMT date) ========\n"
 
+echo -e "======= WMAgent token verification at $(TZ=GMT date) ========\n"
+if [ -n "${_CONDOR_CREDS}" ]; then
+    echo "Content under _CONDOR_CREDS: ${_CONDOR_CREDS}"
+    ls -l ${_CONDOR_CREDS}
+    # Now, check specifically for cms token
+    if [ -f "${_CONDOR_CREDS}/cms.use" ]
+    then
+        echo "CMS token found, setting BEARER_TOKEN_FILE=${_CONDOR_CREDS}/cms.use"
+        export BEARER_TOKEN_FILE=${_CONDOR_CREDS}/cms.use
+    
+        # Show token information
+        # This tool requires htgettoken package in the cmssw runtime apptainer image
+        if command -v httokendecode ls 2>&1 > /dev/null
+        then
+            httokendecode -H ${BEARER_TOKEN_FILE}
+        else
+            echo "Warning: [WMAgent Token verification] httokendecode tool could not be found."
+            echo "Warning: Token exists and can be used, but details will not be displayed."
+        fi
+    else
+        echo "[WMAgent token verification]: The bearer token file could not be found."
+        # Do not fail, we still support x509 proxies
+        # if we fail here in the future, we need to define an exit code number
+        # exit 1106
+    fi
+else
+    echo "Variable _CONDOR_CREDS is not defined, condor auth/token credentials directory not found."
+fi
 
 echo "======== WMAgent Unpack the job starting at $(TZ=GMT date) ========"
 # Should be ready to unpack and run this

--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -139,6 +139,8 @@ class SimpleCondorPlugin(BasePlugin):
         #self.x509userproxysubject = proxy.getSubject()
         #self.x509userproxyfqan = proxy.getAttributeFromProxy(self.x509userproxy)
 
+        self.useCMSToken = getattr(config.JobSubmitter, 'useOauthToken', False)
+
         return
 
     def submit(self, jobs, info=None):
@@ -520,6 +522,11 @@ class SimpleCondorPlugin(BasePlugin):
                 ad['Requirements'] = self.reqStr
 
             ad['My.x509userproxy'] = classad.quote(self.x509userproxy)
+
+            # Allow oauth based token authentication
+            if self.useCMSToken:
+                ad['use_oauth_services'] = "cms"
+
             sites = ','.join(sorted(job.get('possibleSites')))
             ad['My.DESIRED_Sites'] = classad.quote(str(sites))
             sites = ','.join(sorted(job.get('potentialSites')))


### PR DESCRIPTION
Fixes #12199

Needed for #12144

#### Status
tested and working
But external dependency is not completed (condor). Therefore, this functionality is disabled by default.

#### Description
This does not completely fixes #12144
This is needed to enable token authentication in WMAgent.
Stage-in should be functional with this fix
Stage-out will require changes in the stageout commands
Functionality is disabled by default (until condor setup of tokens is uniform in all schedds)

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
HTCondor token setup
htgettoken (optional) in the CMS runtime image.
Note: The HTCondor token setup is not deployed in all schedds yet.

### Additional notes

1)
There is a variable called $BEARER_TOKEN_FILE that if set, HTCondor will write the token there.
This would need to be setup in the host, not the WMAgent container.
This step is however, not critical because this is the reference token.
The actual token that HTCondor transfers comes from

```
condor_config_val SEC_CREDENTIAL_DIRECTORY_OAUTH
```
which is in a private system area.
This can be changed in the condor configuration to directly write to `/data/certs` in the future.

2) Python bindings
When jobs are submitted via the condor python bindings, inside the WMAgent container, the job is submitted, but /usr/bin/condor_vault_storer does not seem to be triggered.
I am currently working that around by:

Executing a condor_submit with a test job once from the host
Token seems to stay and refresh afterwards 
If cms_readonly scope is used, this does not happen and we need a manual refresh, but for production, we don't need any scope.