### PR TITLE
Fix WorkQueue broken reference to rejectedWork and badWork

### DIFF
--- a/src/python/WMCore/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/WorkQueue/WorkQueue.py
@@ -1060,7 +1060,7 @@ class WorkQueue(WorkQueueBase):
         if not rucioObj:
             rucioObj = self.rucio
 
-        totalUnits = []
+        totalUnits, rejectedWork, badWork = [], [], []
         # split each top level task into constituent work elements
         # get the acdc server and db name
         for topLevelTask in wmspec.taskIterator():


### PR DESCRIPTION
Fixes #11681 

#### Status
not-tested

#### Description
Because this is supposed to be a very simple (bug-)fix, so we better fix it sooner than later.

Ensure that `rejectedWork` and `badWork` are a known symbol before accessing them, such that we avoid errors like:
```
Error: local variable 'rejectedWork' referenced before assignment
```

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
