### PR TITLE
Improve patchComponent && Add patchCluster scripts

### DIFF
--- a/bin/patchCluster.sh
+++ b/bin/patchCluster.sh
@@ -1,0 +1,259 @@
+#!/bin/bash
+
+usage()
+{
+    echo -e "\nA simple script to be used for patching all Running backends in"
+    echo -e "a WMCore central services K8 cluster with a patch based on:"
+    echo -e "  * A list of upstream PRs (the order of applying them matters) or "
+    echo -e "  * A patch file provided or"
+    echo -e "  * A patch created from StdIn"
+    echo -e ""
+    echo -e "Usage: ./patchCluster.sh [-n] [-z] [-f <patchFile>] [-p <\"SpaceSepListOfPods\">] [-s <serviceName>] 12077 12120 ..."
+    echo -e ""
+    echo -e "       -p - Space separated list of pods to be patched (Mind the quotation marks)"
+    echo -e "       -s - Service name whose pods to be patched (if found)"
+    echo -e "       -d - Deployment name whose pods to be patched (if found)"
+    echo -e "       -z - Only zero the code base to the currently deployed tag for the files changed in the patch - no actual patches will be applied"
+    echo -e "       -f - Apply the specified patch file. No multiple files supported. If opt is repeated only the last one will be considered."
+    echo -e "       -n - Do not zero the code base neither from TAG nor from Master branch, just apply the patch"
+    echo -e "       -o - One go - Apply the patch only through a single attempt starting from the tag deployed at the destination and avoid the second attempt upon syncing to master."
+    echo -e ""
+    echo -e "NOTE: We do not support patching from file and patching from command line simultaneously"
+    echo -e "       If both provided at the command line patching from command line takes precedence"
+    echo -e ""
+    echo -e "Examples: \n"
+    echo -e "       ./patchCluster.sh -s reqmgr2 11270 12120 \n"
+    echo -e "       ./patchCluster.sh -p pod/reqmgr2-bcdccd8c6-hsmlj -f /tmp/11270.patch \n"
+    echo -e "       git diff --no-color | ./patchCluster.sh -s reqmgr2 -n \n"
+    echo -e "       curl https://patch-diff.githubusercontent.com/raw/dmwm/WMCore/pull/11270.patch | ./patchCluster.sh -s reqmgr2 \n"
+
+}
+
+# Set defaults
+currPods=""
+currService=""
+currDeployment=""
+zeroOnly=false
+zeroCodeBase=true
+oneGo=false
+extPatchFile=""
+while getopts ":f:p:s:d:znh" opt; do
+    case ${opt} in
+        p)
+            currPods=$OPTARG
+            ;;
+        s)
+            currService=$OPTARG
+            ;;
+        d)
+            currDeployment=$OPTARG
+            ;;
+        f)
+            extPatchFile=$OPTARG
+            ;;
+        z)
+            zeroOnly=true
+            ;;
+        n)
+            zeroCodeBase=false
+            ;;
+        o)
+            oneGo=true
+            ;;
+        h)
+            usage
+            exit 0 ;;
+        \? )
+            echo -e "\nERROR: Invalid Option: -$OPTARG\n"
+            usage
+            exit 1 ;;
+        : )
+            echo -e "\nERROR: Invalid Option: -$OPTARG requires an argument\n"
+            usage
+            exit 1 ;;
+    esac
+done
+
+# shift to the last  parsed option, so we can consume the patchList with a regular shift
+shift $(expr $OPTIND - 1 )
+
+
+# if fd 0 (stdin) is open and refers to a terminal - then we are running the script directly, without a pipe
+# if fd 0 (stdin) is open but does not refer to the terminal - then we are running the script through a pipe
+if [ -t 0 ] ; then pipe=false; else pipe=true ; fi
+
+patchList=$*
+
+which kubectl || { echo "ERROR: Missing 'kubectl'. Cannot continue! EXIT!"; exit 1 ;}
+
+currCluster=`kubectl config get-clusters |grep -v NAME`
+nameSpace=dmwm
+
+echo
+echo
+echo
+echo ========================================================
+echo "INFO: CLUSTER: $currCluster"
+echo --------------------------------------------------------
+
+if $zeroOnly; then
+    echo "INFO: Only Zeroing the code base No patches will be applied"
+    echo "INFO: Source files affected to be taken from patches: $patchList"
+elif $pipe ;then
+    echo "INFO: Patching from StdIn"
+elif [[ -n $extPatchFile ]]; then
+    echo "INFO: Patching from file: $extPatchFile"
+elif [[ -z $patchList ]] ; then
+    echo "ERROR: Neither patchList provided nor patchFile nor patching from StdIn"
+    exit
+else
+    echo "INFO: Applying patches: $patchList"
+fi
+
+
+# -----------------------------------------------------------
+# Build patchComponent.sh script command to be executed at the pod:
+
+# NOTE: We do not support patching from file and patching from command line simultaneously
+#       If both provided at the command line patching from command line takes precedence
+
+podCmdActions="sudo -v && /data/manage help && which curl && curl https://raw.githubusercontent.com/dmwm/WMCore/master/bin/patchComponent.sh -o /data/patchComponent.sh && chmod 755 /data/patchComponent.sh "
+podCmdOpts=""
+patchFile=""
+$zeroOnly && podCmdOpts="$podCmdOpts -z"
+$oneGo && podCmdOpts="$podCmdOpts -o"
+$zeroCodeBase || podCmdOpts="$podCmdOpts -n"
+
+[[ -n $extPatchFile ]] && { patchFile="/tmp/`basename $extPatchFile`"
+                            podCmdOpts="$podCmdOpts -f $patchFile" ;}
+
+# NOTE: We are about to create the pipeTmp_****.patch file from stdIn here
+#       And we are about to call `patchComponent.sh` through -f option, but we must
+#       explicitly break the redirection from the pipe command, because otherwise
+#       it will be kept through out the call to `patchComponent.sh` and will cause
+#       the $pipe flag to take precedence over the -f flag inside `patchComponent.sh`
+#       Then the so sent file will be ignored. What we need to do here is, once we create
+#       the temporary patch file from stdin (currently redirected through the pipe)
+#       to open again fd 0 (stdin) and redirect it to a tty terminal.
+$pipe && { patchFile="/tmp/pipeTmp_$(id -u).patch"
+           extPatchFile=$patchFile
+           podCmdOpts="$podCmdOpts -f $patchFile"
+           echo "INFO: Creating a temporary patchFile from stdin at: $patchFile"
+           cat <&0 > $patchFile
+           exec 0<>/dev/tty
+           # The flag bellow is just for debugging purposes, never used after the printout
+           [[ -t 0 ]] && newPipeFlag=false || newPipeFlag=true
+           echo
+           echo "DEBUG: newPipeFlag=$newPipeFlag"
+           }
+
+podCmd="$podCmdActions && sudo /data/patchComponent.sh $podCmdOpts $patchList "
+restartCmd="/data/manage restart && sleep 1 && /data/manage status"
+
+echo
+echo "DEBUG: podCmd: $podCmd"
+echo
+# -----------------------------------------------------------
+
+echo --------------------------------------------------------
+# First try to find any pod from the service name provided and then extend the list in currPods:
+if [[ -n $currService ]]; then
+    servicePods=`kubectl -n $nameSpace  get ep $currService -o=jsonpath='{.subsets[*].addresses[*].ip}' | tr ' ' '\n' | xargs -I % kubectl -n $nameSpace get pods  -o=name --field-selector=status.podIP=%`
+    [[ $? -eq 0 ]] || { echo "WARNING: could not find service: $currService at cluster: $currCluster"; exit ;}
+
+    # We need to trim the `pod/` prefix from every pod's name produced with the above command
+    if [[ -n $servicePods ]] ; then
+        for pod in $servicePods; do
+            currPods="$currPods ${pod#pod/}"
+        done
+        echo "INFO: Found the following pods for SERVICE: $currService: "
+        echo "$servicePods "
+    else
+        echo "WARNING: No pods found for SERVICE: $currService"
+        exit
+    fi
+fi
+
+# Second try to find any pod from the deployment name provided and then extend the list in currPods:
+if [[ -n $currDeployment ]]; then
+    deploymentPods=`kubectl get --raw "/apis/apps/v1/namespaces/dmwm/deployments/$currDeployment/scale"|jq -r .status.selector | xargs -I % kubectl -n $nameSpace get pods  -o=name --selector=%`
+    [[ $? -eq 0 ]] || { echo "WARNING: could not find deployment: $currDeployment at cluster: $currCluster"; exit ;}
+
+    # We need to trim the `pod/` prefix from every pod's name produced with the above command
+    if [[ -n $deploymentPods ]] ; then
+        for pod in $deploymentPods; do
+            currPods="$currPods ${pod#pod/}"
+        done
+        echo "INFO: Found the following pods for DEPLOYMENT: $currDeployment: "
+        echo "$deploymentPods "
+    else
+        echo "WARNING: No pods found for DEPLOYMENT: $currDeployment"
+        exit
+    fi
+fi
+
+
+
+if [[ -n $currPods ]] ; then
+    echo ========================================================
+    echo WARNING: We are about to patch backend pods: $currPods
+    echo WARNING: at k8 CLUSTER: $currCluster !!!!
+else
+    echo ========================================================
+    echo WARNING: We are about to patch ANY running backend pod
+    echo WARNING: at k8 CLUSTER: $currCluster !!!!
+fi
+
+echo WARNING: Are you sure you want to continue?
+echo -n "[y/n](Default n): "
+read x && [[ $x =~ (y|yes|Yes|YES) ]] || { echo WARNING: Exit on user request!; exit 101 ;}
+echo ========================================================
+
+
+if [[ -n $currPods ]] ; then
+    runningPods=$currPods
+else
+    # # check if any service name was actually provided at the command line and if not only then search for all running pods for the whole cluster:
+    # if [[ -n $currService ]] ; then
+    #     echo "WARNING: Requested to patch: $currService at: $currCluster but NO pods were found."
+    #     echo "WARNING: Will not patch the whole cluster. Nothing to do here, giving up now."
+    #     exit
+    # else
+    runningPods=`kubectl get pods --no-headers -o custom-columns=":metadata.name" -n $nameSpace  --field-selector=status.phase=Running`
+    # fi
+fi
+
+for pod in $runningPods
+do
+    echo
+    echo --------------------------------------------------------
+    echo INFO: $pod:
+
+    if $pipe || [[ -n $extPatchFile ]]; then
+        echo INFO: Copying any external patchFiles provided: $extPatchFile
+        echo INFO: Executing: kubectl -n $nameSpace  cp $extPatchFile $pod:$patchFile
+        kubectl -n $nameSpace  cp $extPatchFile $pod:$patchFile || {
+            echo ERROR: While copying patch files to pod:$pod
+            echo ERROR: Skipping it!
+            continue
+        }
+    fi
+    echo
+    echo --------------------------------------------------------
+    echo INFO: Patching the services at pod: $pod:
+    echo INFO: Executing: kubectl exec -it $pod -n $nameSpace -- /bin/bash -c \"$podCmd\"
+    kubectl exec -it $pod -n $nameSpace -- /bin/bash -c "$podCmd" || {
+        echo ERROR: While patching the pod:$pod
+        echo ERROR: Skipping it!
+        continue
+    }
+    echo
+    echo --------------------------------------------------------
+    echo INFO: Restarting the services at pod: $pod:
+    echo INFO: Executing: kubectl exec $pod -n $nameSpace -- /bin/bash -c \"$restartCmd\"
+    kubectl exec $pod -n $nameSpace -- /bin/bash -c "$restartCmd" || {
+        echo ERROR: While restarting the service at pod:$pod
+        echo ERROR: Skipping it!
+        continue
+    }
+done

--- a/bin/patchComponent.sh
+++ b/bin/patchComponent.sh
@@ -2,28 +2,80 @@
 
 usage()
 {
-    echo -ne "\nA simple script to facilitate component patching\n"
-    echo -ne "and to decrease the development && testing turnaround time.\n"
-    echo -ne "Usage: \n"
-    echo -ne "\t sudo ./patchComponent.sh 11270\n"
-    echo -ne "\t git diff --no-color | sudo ./patchComponent.sh \n or:\n"
-    echo -ne "\t curl https://patch-diff.githubusercontent.com/raw/dmwm/WMCore/pull/11270.patch | sudo ./patchComponent.sh \n"
-    exit 1
+    echo -e "\nA simple script to facilitate component patching"
+    echo -e "and to decrease the development && testing turnaround time."
+    echo -e "  * A list of upstream PRs (the order of applying them matters) or "
+    echo -e "  * A patch file provided or"
+    echo -e "  * A patch created from StdIn"
+    echo -e ""
+    echo -e "Usage: ./patchComponent [-n] [-z] [-f <patchFile>] <patchNum> <patchNum> ..."
+    echo -e "       -z - Only zero the code base to the currently deployed tag for the files changed in the patch - no actual patches will be applied"
+    echo -e "       -f - Apply the specified patch file. No multiple files supported. If opt is repeated only the last one will be considered."
+    echo -e "       -n - Do not zero the code base neither from TAG nor from Master branch, just apply the patch"
+    echo -e "       -o - One go - Apply the patch only through a single attempt starting from the tag deployed at the destination and avoid the second attempt upon syncing to master."
+    echo -e ""
+    echo -e "NOTE: We do not support patching from file and patching from command line simultaneously"
+    echo -e "       If both provided at the command line patching from command line takes precedence"
+    echo -e ""
+    echo -e "Examples: \n"
+    echo -e "       sudo ./patchComponent.sh 11270 12120"
+    echo -e "       sudo ./patchComponent.sh -f /tmp/11270.patch"
+    echo -e "       git diff --no-color | sudo ./patchComponent.sh"
+    echo -e "       curl https://patch-diff.githubusercontent.com/raw/dmwm/WMCore/pull/11270.patch | sudo ./patchComponent.sh \n"
 }
+
+
+
+# Add default value for zeroOnly option
+zeroOnly=false
+zeroCodeBase=true
+oneGo=false
+extPatchFile=""
+while getopts ":f:znoh" opt; do
+    case ${opt} in
+        f)
+            extPatchFile=$OPTARG
+            ;;
+        z)
+            zeroOnly=true
+            ;;
+        n)
+            zeroCodeBase=false
+            ;;
+        o)
+            oneGo=true
+            ;;
+        h)
+            usage
+            exit 0 ;;
+        \? )
+            echo -e "\nERROR: Invalid Option: -$OPTARG\n"
+            usage
+            exit 1 ;;
+        : )
+            echo -e "\nERROR: Invalid Option: -$OPTARG requires an argument\n"
+            usage
+            exit 1 ;;
+    esac
+done
+# shift to the last  parsed option, so we can consume the patchNum with a regular shift
+shift $(expr $OPTIND - 1 )
+
 
 # if fd 0 (stdin) is open and refers to a terminal - then we are running the script directly, without a pipe
 # if fd 0 (stdin) is open but does not refer to the terminal - then we are running the script through a pipe
 if [ -t 0 ] ; then pipe=false; else pipe=true ; fi
 
-patchNum=$1
-shift
-
-[[ -z $patchNum ]] && patchNum=temp
-echo "Patching WMCore code with PR: $patchNum"
+patchList=$*
+# [[ -z $patchList ]] && patchList="temp"
 
 currTag=$(python -c "from WMCore import __version__ as WMCoreVersion; print(WMCoreVersion)")
-echo "Current WMCoreTag: $currTag"
 
+echo
+echo
+echo
+echo ========================================================
+echo "INFO: Current WMCoreTag: $currTag"
 
 # Find all possible locations for the component source
 # NOTE: We always consider PYTHONPATH first
@@ -32,43 +84,283 @@ pythonLibPaths="$pythonLibPaths $(python -c "from distutils.sysconfig import get
 
 for path in $pythonLibPaths
 do
-    [[ -d $path/WMCore ]] && { pythonLibPath=$path; echo "Source code found at: $path"; break ;}
+    [[ -d $path/WMCore ]] && { pythonLibPath=$path; echo "INFO: Source code found at: $path"; break ;}
 done
 
 [[ -z $pythonLibPath  ]] && { echo "ERROR: Could not find WMCore source to patch"; exit  1 ;}
-echo "Current PythonLibPath: $pythonLibPath"
+echo "INFO: Current PythonLibPath: $pythonLibPath"
+echo --------------------------------------------------------
+echo
 
+# Set patch command parameters
 stripLevel=3
-patchFile=/tmp/$patchNum.patch
-
 patchCmd="patch -t --verbose -b --version-control=numbered -d $pythonLibPath -p$stripLevel"
 
+# Define Auxiliary functions
+_createTestFilesDst() {
+    # A simple function to create test files destination for not breaking the patches
+    # because of a missing destination:
+    # :param $1:   The source branch to be used for checking the files: could be TAG or Master
+    # :param $2-*: The list of files to be checked out
+    local srcBranch=$1
+    shift
+    local testFileList=$*
+    for file in $testFileList
+    do
+        # file=${file#a\/test\/python\/}
+        fileName=`basename $file`
+        fileDir=`dirname $file`
+        # Create the file path if missing
+        mkdir -p $pythonLibPath/$fileDir
+        echo INFO: orig: https://raw.githubusercontent.com/dmwm/WMCore/$srcBranch/test/python/$file
+        echo INFO: dest: $pythonLibPath/$file
+        curl -f https://raw.githubusercontent.com/dmwm/WMCore/$srcBranch/test/python/$file  -o $pythonLibPath/$file || {
+            echo INFO: file: $file missing at the origin.
+            echo INFO: Seems to be a new file for the curren patch.
+            echo INFO: Removing it from the destination as well!
+            rm -f $pythonLibPath/$file
+        }
+    done
+}
 
-if $pipe
-then
-    # if we run through a pipeline create the temporary patch file for later parsing
-    echo "Creating a temporary patchFile at: $patchFile"
-    cat <&0 > $patchFile
+_zeroCodeBase() {
+    # A simple function to zero the code base for a set of files starting from
+    # a given tag or branch at the origin
+    # :param $1:   The source branch to be used for checking the files: could be TAG or Master
+    # :param $2-*: The list of files to be checked out
+    local srcBranch=$1
+    shift
+    local srcFileList=$*
+    for file in $srcFileList
+    do
+        # file=${file#a\/src\/python\/}
+        fileName=`basename $file`
+        fileDir=`dirname $file`
+        # Create the file path if missing
+        mkdir -p $pythonLibPath/$fileDir
+        echo INFO: orig: https://raw.githubusercontent.com/dmwm/WMCore/$srcBranch/src/python/$file
+        echo INFO: dest: $pythonLibPath/$file
+        curl -f https://raw.githubusercontent.com/dmwm/WMCore/$srcBranch/src/python/$file  -o $pythonLibPath/$file || {
+            echo INFO: file: $file missing at the origin.
+            echo INFO: Seems to be a new file for the curren patch.
+            echo INFO: Removing it from the destination as well!
+            rm -f $pythonLibPath/$file
+        }
+    done
+}
+
+
+# DONE: ....HERE TO START ITERATING THROUGH THE PATCH LIST
+
+# Create the full list of patch files to be applied - keeping the order
+# from the original patch list as provided at the command line
+patchFileList=""
+_createPatchFiles(){
+    local patchFile
+
+    # Check if we are running from a pipe
+    $pipe && {
+        if $zeroOnly ;then
+            echo "INFO: Zeroing WMCore code base from StdIn"
+        else
+            echo "INFO: Patching WMCore code from StdIn"
+        fi
+        patchFile="/tmp/pipeTmp_$(id -u).patch"
+        patchFileList=$patchFile
+        echo "INFO: Creating a temporary patchFile from stdin at: $patchFile"
+        cat <&0 > $patchFile
+        return
+    }
+
+    # Check if we were sent a file to patch from
+    [[ -n $extPatchFile ]] && {
+        if $zeroOnly ;then
+            echo "INFO: Zeroing WMCore code base with file: $extPatchFile"
+        else
+            echo "INFO: Patching WMCore code with file: $extPatchFile"
+        fi
+        patchFile=$extPatchFile
+        patchFileList=$patchFile
+        echo "INFO: Using command line provided patch file: $patchFile"
+        return
+    }
+
+    # Finally, if none of the above, build the list of patch files to be applied from the patchNums provided at the command line
+    if $zeroOnly ; then
+        echo "INFO: Zeroing WMCore code base with PRs: $patchList"
+    else
+        echo "INFO: Patching WMCore code with PRs: $patchList"
+    fi
+    for patchNum in $patchList
+    do
+        patchFile=/tmp/$patchNum.patch
+        patchFileList="$patchFileList $patchFile"
+        echo "INFO: Downloading a temporary patchFile at: $patchFile"
+        curl https://patch-diff.githubusercontent.com/raw/dmwm/WMCore/pull/$patchNum.patch -o $patchFile
+    done
+}
+
+_warnFilelist(){
+    echo WARNING: Please consider checking the follwoing list of files for eventual code conflicts:
+    for file in $srcFileList $testFileList
+    do
+        echo WARNING: $pythonLibPath/$file
+    done
+}
+
+_createPatchFiles
+
+echo "DEBUG: patchFileList: $patchFileList"
+
+# Build full lists of files altered by the given set of patch files to be applied
+srcFileList=""
+testFileList=""
+for patchFile in $patchFileList
+do
+    # Parse a list of files changed only by the current patch
+    srcFileListTemp=`grep diff $patchFile |grep "a/src/python" |awk '{print $3}' |sort |uniq`
+    testFileListTemp=`grep diff $patchFile |grep "a/test/python" |awk '{print $3}' |sort |uniq`
+
+    # Reduce paths for both src and test file lists to the path depth known to
+    # the WMCore modules/packages and add them to the global scope file lists
+    for file in $srcFileListTemp
+    do
+        file=${file#a\/src\/python\/} && srcFileList="$srcFileList $file"
+    done
+
+    for file in $testFileListTemp
+    do
+        file=${file#a\/test\/python\/} && testFileList="$testFileList $file"
+    done
+done
+
+
+$zeroCodeBase && {
+    echo
+    echo --------------------------------------------------------
+    echo "INFO: Refreshing all files which are to be patched from the origin and TAG: $currTag"
+    echo
+
+    # First create destination for test files from currTag if missing
+    _createTestFilesDst $currTag $testFileList
+
+
+    # Then zero code base for source files from currTag
+    _zeroCodeBase $currTag $srcFileList
+}
+
+# exit if the user has requested to only zero the code base
+$zeroOnly && {  _warnFilelist; exit ;}
+
+err=0
+echo
+echo
+echo --------------------------------------------------------
+echo "INFO: Patching all files starting from the $($zeroCodeBase && echo original version of TAG: $currTag || echo current version of files)"
+for patchFile  in $patchFileList
+do
+    echo
+    echo
+    echo --------------------------------------------------------
+    echo "INFO: ----------------- Currently applying patch: $patchNum -----------------"
+    echo "INFO: cat $patchFile | $patchCmd"
+    cat $patchFile | $patchCmd
+    let err+=$?
+done
+
+echo
+echo +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+echo
+if [[ $err -eq 0 ]]; then
+    echo INFO: First patch attempt exit status: $err
+    echo INFO: ALL GOOD
+    echo +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    exit
 else
-    echo "Downloading a temporary patchFile at: $patchFile"
-    curl https://patch-diff.githubusercontent.com/raw/dmwm/WMCore/pull/$patchNum.patch -o $patchFile
+    echo WARNING: First patch attempt exit status: $err
+    echo
+    echo
+    echo WARNING: There were errors while patching from TAG: $currTag
+    echo WARNING: Most probably some of the files from the current patch were having changes
+    echo WARNING: between the current PR and the tag deployed at the host/container.
+    echo
+    echo
+
+    # exit at this stage if the user has requested to patch without zeroing the code base
+    $zeroCodeBase || { _warnFilelist ; exit 1 ;}
+
+    # exit at this stage if the user has requested to do the patch only in one go
+    # without a second attempt from master. Restore files to their version at TAG
+    $oneGo && {
+        echo WARNING: Restoring all files to their original version at TAG: $currTag
+        echo
+        echo
+        _createTestFilesDst $currTag $testFileList
+        _zeroCodeBase $currTag $srcFileList
+        echo
+        echo
+        echo WARNING: All files have been rolled back to their original version at TAG: $currTag
+        _warnFilelist
+        exit 1
+    }
+    echo WARNING: TRYING TO START FROM ORIGIN/MASTER BRANCH INSTEAD:
+    echo
+    echo
 fi
 
 
-echo "Refreshing all files which are to be patched from the origin"
-for file in `grep diff $patchFile |grep "a/src/python" |awk '{print $3}' |sort |uniq`
+# If we are here it means something went wrong while patching some of the files.
+# Most probably some of the files are having changes between the current PR and the tag deployed.
+# What we can do in such cases is to try to fetch and zero the code base for those files
+# to be patched from master and hope there are no conflicts in the PR.
+
+echo
+echo --------------------------------------------------------
+echo "WARNING: Refreshing all files which are to be patched from origin/master branch:"
+echo
+
+# First create destination for test files from master if missing
+_createTestFilesDst "master" $testFileList
+
+# Then zero code base for source files from master
+_zeroCodeBase "master" $srcFileList
+
+err=0
+echo
+echo
+echo --------------------------------------------------------
+echo "WARNING: Patching all files starting from origin/master branch"
+for patchFile in $patchFileList
 do
-    file=${file#a\/src\/python\/}
-    echo orig: https://raw.githubusercontent.com/dmwm/WMCore/$currTag/src/python/$file
-    echo dest: $pythonLibPath/$file
-    curl -f https://raw.githubusercontent.com/dmwm/WMCore/$currTag/src/python/$file  -o $pythonLibPath/$file || { \
-        echo file: $file missing at the origin.
-        echo Seems to be a new file for the current patch.
-        echo Removing it from the destination as well!
-        rm -f $pythonLibPath/$file
-    }
+    echo
+    echo
+    echo "WARNING: --------------- Currently applying patch: $patchNum ---------------"
+    echo "WARNING: cat $patchFile | $patchCmd"
+    cat $patchFile | $patchCmd
+    let err+=$?
 done
 
-echo "Patching all files starting from the original version"
-echo "cat $patchFile | $patchCmd"
-cat $patchFile | $patchCmd
+
+echo
+echo +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+echo WARNING: Second patch attempt exit status: $err
+echo
+echo
+
+[[ $err -eq 0 ]] || {
+
+    _createTestFilesDst $currTag $testFileList
+    _zeroCodeBase $currTag $srcFileList
+
+    echo
+    echo +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    echo WARNING: There were errors while patching from master branch as well
+    echo WARNING: All files have been rolled back to their original version at TAG: $currTag
+    echo
+    echo
+}
+echo +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+_warnFilelist
+
+exit $err


### PR DESCRIPTION
Fixes #11685

#### Status
ready

#### Description
With the current PR we improve the functionality of `patchComponent.sh` script adding the following functionalities:

* The ability to find the correct WMCore codebase destination - regardless if running from pypi or from Source
* The ability to recognize the WMCore version currently deployed at the destination
* The ability to parse the patch file to find the full list of files prepared for altering
* The ability to  "zero" the codeBase of all the files which are about to be patched to the state as they are at the WMCore version currently deployed at the destination
* The ability to perform a second patch attempt starting from latest version of the files from the list of files to be altered (by fetching them from `upstream/master`) if the first attempt to patch from the currently deployed version fails. It is a feature quite needed in the case of completely broken history and/or intermediate developments that might have happened between the moment of forking to a new branch for creating the patch and the actually applying and/or when the origin branch on top of which the patch has been created is behind the branch currently deployed at destination.
* Automatically  detecting any code conflicts (failed patch steps) and  reverting the whole code to the baseline it started  from if found any
* The ability to patch from local tree (through `git *` commands) without going through officially creating a PR in the upstream repository
* The ability to chose if to skip any of the above actions
* The ability to manually revert (only zeroing)  the whole code base to the version deployed at the destination
* The ability to apply multiple patches in a row (preserving their order)

We also introduce the script `patchClustetr.sh`, which is capable of applying all those step on a Kuberenetes  cluster. The granularity could be:
* A whole cluster
* A Pod
* A Service
* A Deployment

This way those two scripts become a well coupled pair, which boosts the development and testing/validation process tremendously!!!  

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
