### PR TITLE
Ignore list order in SiteLists comparison

### DIFF
--- a/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
+++ b/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py
@@ -1378,8 +1378,8 @@ class WMWorkloadTest(unittest.TestCase):
         # NOTE: Should not raise any exception
         reqArgs = {'SiteWhitelist': ["T2_CH_CERN", "T0_CH_CERN"], 'SiteBlacklist': ["T1_US_FNAL"]}
         testWorkload.updateWorkloadArgs(reqArgs)
-        self.assertListEqual(testWorkload.getSiteWhitelist(), reqArgs['SiteWhitelist'])
-        self.assertListEqual(testWorkload.getSiteBlacklist(), reqArgs['SiteBlacklist'])
+        self.assertCountEqual(testWorkload.getSiteWhitelist(), reqArgs['SiteWhitelist'])
+        self.assertCountEqual(testWorkload.getSiteBlacklist(), reqArgs['SiteBlacklist'])
 
         # Validate unknown arguments exception (using stat update arguments for the test)
         from WMCore.WMSpec.WMWorkload import WMWorkloadUnhandledException


### PR DESCRIPTION
Fixes #12038 

#### Status
ready

#### Description
When closing the original issue, I have overlooked a failure of one of the newly added Unit Tests. The test was failing because the `assertListEqual` test actually accounts for list elements order as well resulting in the following error: [2]. 
Upon fixing it the resultant test run looks like: [1]


[1]
```
 746 │In [190]: wmwTest.testUpdateWorkloadArgs()                                      |                                                                                                                                                                                                                                                                                                     
 747 │wmwTest.testUpdateWorkloadArgs())                                               |          
```

[2]
```
 700 │In [188]: wmwTest.testUpdateWorkloadArgs()                                      |                                                                                                                                                                                                                                                                                                     
 701 │wmwTest.testUpdateWorkloadArgs())                                               |                                                                                                                                                                                                                                                                                                     
 702 │---------------------------------------------------------------------------     |                                                                                                                                                                                                                                                                                                     
 703 │AssertionError                            Traceback (most recent call last)     |                                                                                                                                                                                                                                                                                                     
 704 │Cell In[188], line 1                                                            |                                                                                                                                                                                                                                                                                                     
 705 │----> 1 wmwTest.testUpdateWorkloadArgs()                                        |                                                                                                                                                                                                                                                                                                     
 706 │                                                                                |                                                                                                                                                                                                                                                                                                     
 707 │File /data/WMAgent.venv3/srv/WMCore/test/python/WMCore_t/WMSpec_t/WMWorkload_t.py:1381, in WMWorkloadTest.testUpdateWorkloadArgs(self)                                                                                                                                                                                                                                                
 708 │   1379 reqArgs = {'SiteWhitelist': ["T2_CH_CERN", "T0_CH_CERN"], 'SiteBlacklist': ["T1_US_FNAL"]}                                                                                                                                                                                                                                                                                    
 709 │   1380 testWorkload.updateWorkloadArgs(reqArgs)                                |                                                                                                                                                                                                                                                                                                     
 710 │-> 1381 self.assertListEqual(testWorkload.getSiteWhitelist(), reqArgs['SiteWhitelist'])                                                                                                                                                                                                                                                                                               
 711 │   1382 self.assertListEqual(testWorkload.getSiteBlacklist(), reqArgs['SiteBlacklist'])                                                                                                                                                                                                                                                                                               
 712 │   1384 # Validate unknown arguments exception (using stat update arguments for the test)                                                                                                                                                                                                                                                                                             
 713 │                                                                                |                                                                                                                                                                                                                                                                                                     
 714 │File /usr/lib64/python3.9/unittest/case.py:1043, in TestCase.assertListEqual(self, list1, list2, msg)                                                                                                                                                                                                                                                                                 
 715 │   1033 def assertListEqual(self, list1, list2, msg=None):                      |                                                                                                                                                                                                                                                                                                     
 716 │   1034     """A list-specific equality assertion.                              |                                                                                                                                                                                                                                                                                                     
 717 │   1035                                                                         |                                                                                                                                                                                                                                                                                                     
 718 │   1036     Args:                                                               |                                                                                                                                                                                                                                                                                                     
 719 │   (...)                                                                        |                                                                                                                                                                                                                                                                                                     
 720 │   1041                                                                         |                                                                                                                                                                                                                                                                                                     
 721 │   1042     """                                                                 |                                                                                                                                                                                                                                                                                                     
 722 │-> 1043     self.assertSequenceEqual(list1, list2, msg, seq_type=list)          |                                                                                                                                                                                                                                                                                                     
 723 │                                                                                |                                                                                                                                                                                                                                                                                                     
 724 │File /usr/lib64/python3.9/unittest/case.py:1025, in TestCase.assertSequenceEqual(self, seq1, seq2, msg, seq_type)                                                                                                                                                                                                                                                                     
 725 │   1023 standardMsg = self._truncateMessage(standardMsg, diffMsg)               |                                                                                                                                                                                                                                                                                                     
 726 │   1024 msg = self._formatMessage(msg, standardMsg)                             |                                                                                                                                                                                                                                                                                                     
 727 │-> 1025 self.fail(msg)                                                          |                                                                                                                                                                                                                                                                                                     
 728 │                                                                                |                                                                                                                                                                                                                                                                                                     
 729 │File /usr/lib64/python3.9/unittest/case.py:676, in TestCase.fail(self, msg)     |                                                                                                                                                                                                                                                                                                     
 730 │    674 def fail(self, msg=None):                                               |                                                                                                                                                                                                                                                                                                     
 731 │    675     """Fail immediately, with the given message."""                     |                                                                                                                                                                                                                                                                                                     
 732 │--> 676     raise self.failureException(msg)                                    |                                                                                                                                                                                                                                                                                                     
 733 │                                                                                |                                                                                                                                                                                                                                                                                                     
 734 │AssertionError: Lists differ: ['T0_CH_CERN', 'T2_CH_CERN'] != ['T2_CH_CERN', 'T0_CH_CERN']                                                                                                                                                                                                                                                                                            
 735 │                                                                                |                                                                                                                                                                                                                                                                                                     
 736 │First differing element 0:                                                      |                                                                                                                                                                                                                                                                                                     
 737 │'T0_CH_CERN'                                                                    |                                                                                                                                                                                                                                                                                                     
 738 │'T2_CH_CERN'                                                                    |                                                                                                                                                                                                                                                                                                     
 739 │                                                                                |                                                                                                                                                                                                                                                                                                     
 740 │- ['T0_CH_CERN', 'T2_CH_CERN']                                                  |                                                                                                                                                                                                                                                                                                     
 741 │+ ['T2_CH_CERN', 'T0_CH_CERN']                                                  |                                                                                                                                                                                                                                                                                                     
 742 │                                     
```

#### Is it backward compatible (if not, which system it affects?)
NO

#### Related PRs
None

#### External dependencies / deployment changes
None