### PR TITLE
Consider AAA flags when adding input data to WMBS

### DIFF
--- a/src/python/WMCore/WorkQueue/WMBSHelper.py
+++ b/src/python/WMCore/WorkQueue/WMBSHelper.py
@@ -451,7 +451,16 @@ class WMBSHelper(WMConnectionBase):
                 self._addACDCFileToWMBSFile(acdcFile)
         else:
             self.isDBS = True
-            blockPNNs = block['PhEDExNodeNames']
+            # Location to be used in WMBS follows the order of: first use Rucio, otherwise use LQE
+            if block['PhEDExNodeNames']:
+                # See https://github.com/dmwm/WMCore/blob/d0b6d7d/src/python/WMCore/WorkQueue/WorkQueue.py#L415
+                logging.info("Using actual Rucio data locality for data: %s", self.block)
+                blockPNNs = block['PhEDExNodeNames']
+            else:
+                # See https://github.com/dmwm/WMCore/blob/d0b6d7d/src/python/WMCore/WorkQueue/WorkQueue.py#L454
+                # In other words, it could be that data is not available in this list and will be read through AAA
+                logging.info("Using workqueue element location (including AAA flags) for data: %s", self.block)
+                blockPNNs = self.commonLocation
             logging.info('Adding files into WMBS for %s with PNNs: %s', self.wmSpec.name(), blockPNNs)
             for dbsFile in self.validFiles(block['Files']):
                 self._addDBSFileToWMBSFile(dbsFile, blockPNNs)


### PR DESCRIPTION
Fixes #11501 

#### Status
not-tested

#### Description
To avoid workqueue elements failing to be acquired from LQE to WMBS in WorkQueueManager, fallback data location to the output of `possibleSites()` from https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/WorkQueue/DataStructs/WorkQueueElement.py#L18 whenever a Rucio rule is not fully satisfied (and AAA has been enabled for the workflow).

Without this change, LQE will keep failing to be acquired by WMBS until data converges to the destination (likely after someone identifies it, discuss with the DM team and actions are taken...).

This development may have one potential drawback though, in case data is not available anywhere on Disk, jobs will likely fail to read the input data. Hopefully data will converge before job retries are exhausted. Otherwise, ACDC documents will be created reporting data location as the expected location for that file (usually a logical OR used of RSEs).

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
