### PR TITLE
Populate WMCMSSWSubprocess section for failed jobs too

### DIFF
--- a/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
@@ -303,6 +303,12 @@ class CMSSW(Executor):
         envOverride['PYTHONPATH'] = pythonPath
         os.environ.update(envOverride)
 
+        try:
+            # Update the job report with the relevant WMCMSSWSubprocess metrics
+            self.report.updateSubprocessInfo(sysTime, userTime, startTime, endTime)
+        except Exception as ex:
+            logging.error("Error updating job report with WMCMSSWSubprocess metrics: %s", str(ex))
+
         if returnCode != 0:
             argsDump = {'arguments': args}
             msg = "Error running cmsRun\n%s\n" % argsDump
@@ -322,9 +328,6 @@ class CMSSW(Executor):
             self._setStatus(returnCode, returnMessage)
 
         try:
-            # update FJR report info with subprocess info
-            self.report.updateSubprocessInfo(sysTime, userTime, startTime, endTime)
-
             # parse job report XML
             self.report.parse(jobReportXML, stepName=self.stepName)
         except Exception as ex:


### PR DESCRIPTION
Fixes #12216 

#### Status
ready

#### Description
Update WMCMSSWSubprocess metrics before deciding the actual outcome of the job, such that these metrics are also available for jobs that failed and persisted the FJR.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None