### PR TITLE
(Safe) Implementation of the token-safe retry logic for gfal

### DIFF
--- a/src/python/WMCore/Storage/Backends/AWSS3Impl.py
+++ b/src/python/WMCore/Storage/Backends/AWSS3Impl.py
@@ -9,6 +9,7 @@ from __future__ import print_function
 from __future__ import division
 
 import os
+import logging
 from WMCore.Storage.StageOutImpl import StageOutImpl
 from WMCore.Storage.Registry import registerStageOutImpl
 
@@ -28,11 +29,13 @@ class AWSS3Impl(StageOutImpl):
         """
         return "%s" % pfn
 
-    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None, authMethod=None, forceMethod=False):
         """
         _createStageOutCommand_
         Build an aws s3 copy command
         """
+        logging.warning("Warning! AWSS3Impl does not support authMethod handling")
+
         result = "#!/bin/sh\n"
 
         copyCommand = "aws s3 cp"
@@ -57,7 +60,7 @@ class AWSS3Impl(StageOutImpl):
 
         return result
     
-    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None, authMethod=None, forceMethod=False):
         """
         Debug a failed aws s3 copy command for stageOut, without re-running it,
         providing information on the environment and the certifications

--- a/src/python/WMCore/Storage/Backends/CPImpl.py
+++ b/src/python/WMCore/Storage/Backends/CPImpl.py
@@ -10,6 +10,7 @@ from __future__ import division
 
 import os
 import errno
+import logging
 
 from WMCore.Storage.Registry import registerStageOutImpl
 from WMCore.Storage.StageOutImpl import StageOutImpl
@@ -49,13 +50,15 @@ class CPImpl(StageOutImpl):
                     raise
         return
 
-    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None, authMethod=None, forceMethod=False):
         """
         _createStageOutCommand_
 
         Build the actual cp stageout command
 
         """
+        logging.warning("Warning! CPImpl does not support authMethod handling")
+
         copyCommand = ""
 
         if self.stageIn:
@@ -82,7 +85,7 @@ class CPImpl(StageOutImpl):
 
         return copyCommand
 
-    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None, authMethod=None, forceMethod=False):
         """
         Debug a failed cp command for stageOut, without re-running it,
         providing information on the environment and the certifications

--- a/src/python/WMCore/Storage/Backends/FNALImpl.py
+++ b/src/python/WMCore/Storage/Backends/FNALImpl.py
@@ -8,6 +8,7 @@ Implementation of StageOutImpl interface for FNAL
 from __future__ import print_function
 
 import os
+import logging
 
 from WMCore.Storage.Backends.LCGImpl import LCGImpl
 from WMCore.Storage.Registry import registerStageOutImpl
@@ -84,12 +85,13 @@ class FNALImpl(StageOutImpl):
             return self.srmImpl.createSourceName(protocol, pfn)
         return pfn
 
-    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None, authMethod=None, forceMethod=False):
         """
         _createStageOutCommand_
 
         Build a mkdir to generate the directory
         """
+        logging.warning("Warning! FNALImpl does not support authMethod handling")
 
         if getattr(self, 'stageIn', False):
             return self.buildStageInCommand(sourcePFN, targetPFN, options)
@@ -137,7 +139,7 @@ class FNALImpl(StageOutImpl):
             """
             return result
 
-    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None, authMethod=None, forceMethod=False):
         """
         Debug a failed fnal-flavor copy command for stageOut, without re-running it,
         providing information on the environment and the certifications

--- a/src/python/WMCore/Storage/Backends/GFAL2Impl.py
+++ b/src/python/WMCore/Storage/Backends/GFAL2Impl.py
@@ -9,8 +9,6 @@ import os
 from WMCore.Storage.Registry import registerStageOutImpl
 from WMCore.Storage.StageOutImpl import StageOutImpl
 
-_CheckExitCodeOption = True
-
 
 class GFAL2Impl(StageOutImpl):
     """
@@ -24,10 +22,20 @@ class GFAL2Impl(StageOutImpl):
         # Next commands after separation are executed without env -i and this leads us with
         # mixed environment with COMP and system python.
         # GFAL2 is not build under COMP environment and it had failures with mixed environment.
-        self.setups = "env -i X509_USER_PROXY=$X509_USER_PROXY JOBSTARTDIR=$JOBSTARTDIR bash -c '{}'"
-        self.removeCommand = self.setups.format('. $JOBSTARTDIR/startup_environment.sh; date; gfal-rm -t 600 {}')
+
+        self.setAuthX509 = "X509_USER_PROXY=$X509_USER_PROXY"
+        self.setAuthToken = "BEARER_TOKEN_FILE=$BEARER_TOKEN_FILE BEARER_TOKEN=$(cat $BEARER_TOKEN_FILE)"
+        self.unsetX509 = "unset X509_USER_PROXY;"
+        self.unsetToken = "unset BEARER_TOKEN;"
+
+        # These commands are parameterized according to:
+        # 1. authentication method (set_auth)
+        # 2. forced authentication method (unset_auth)
+        # 3. finally, debug mode or not (dry_run)
+        self.setups = "env -i {{set_auth}} JOBSTARTDIR=$JOBSTARTDIR bash -c '{}'"
         self.copyOpts = '-t 2400 -T 2400 -p -v --abort-on-failure {checksum} {options} {source} {destination}'
-        self.copyCommand = self.setups.format('. $JOBSTARTDIR/startup_environment.sh; date; gfal-copy ' + self.copyOpts)
+        self.copyCommand = self.setups.format('. $JOBSTARTDIR/startup_environment.sh; {unset_auth} date; {dry_run} gfal-copy ' + self.copyOpts)
+        self.removeCommand = self.setups.format('. $JOBSTARTDIR/startup_environment.sh; {unset_auth} date; {dry_run} gfal-rm -t 600 {}')
 
     def createFinalPFN(self, pfn):
         """
@@ -64,32 +72,52 @@ class GFAL2Impl(StageOutImpl):
         """
         return
 
-    def createRemoveFileCommand(self, pfn):
+    def createRemoveFileCommand(self, pfn, authMethod=None, forceMethod=False, dryRun=False):
         """
-        _createRemoveFileCommand_
         handle file remove using gfal-rm
 
         gfal-rm options used:
           -t   global timeout for the execution of the command.
                Command is interrupted if time expires before it finishes
+        :pfn: str, destination PFN
+        :authMethod: string with the authentication method to use (either 'X509' or 'TOKEN')
+        :forceMethod: bool to isolate and force a given authentication method
+        :dryRun: bool, dry run mode (to enable debug mode)
         """
+        if authMethod is None:
+            set_auth = self.setAuthToken + " " + self.setAuthX509
+            unset_auth = ""
+        elif authMethod == 'X509':
+            set_auth = self.setAuthX509
+            unset_auth = self.unsetToken if forceMethod else ""
+        elif authMethod == 'TOKEN':
+            set_auth = self.setAuthToken
+            unset_auth = self.unsetToken if forceMethod else ""
+        
+        dryRun = 'echo ' if dryRun else ''
+
         if os.path.isfile(pfn):
-            return "/bin/rm -f {}".format(os.path.abspath(pfn))
+            return "{} /bin/rm -f {}".format(dryRun, os.path.abspath(pfn))
         else:
-            return self.removeCommand.format(self.createFinalPFN(pfn))
+            return self.removeCommand.format(self.createFinalPFN(pfn), set_auth=set_auth, unset_auth=unset_auth, dry_run=dryRun)
 
-
-    def buildCopyCommandDict(self, sourcePFN, targetPFN, options=None, checksums=None):
+    def buildCopyCommandDict(self, sourcePFN, targetPFN, options=None, checksums=None,
+                             authMethod='X509', forceMethod=False, dryRun=False):
         """
-        Build the gfal-cp command for stageOut
+        Build the gfal-copy command for stageOut
 
         :sourcePFN: str, PFN of the source file
         :targetPFN: str, destination PFN
         :options: str, additional options for gfal-cp
         :checksums: dict, collect checksums according to the algorithms saved as keys
+        :authMethod: string with the authentication method to use (either 'X509' or 'TOKEN')
+        :forceMethod: bool to isolate and force a given authentication method
+        :dryRun: bool, dry run mode (to enable debug mode)
+        :returns: a dictionary with specific parameters to be formatted in the commands
         """
 
-        copyCommandDict = {'checksum': '', 'options': '', 'source': '', 'destination': ''}
+        copyCommandDict = {'checksum': '', 'options': '', 'source': '', 'destination': '',
+                           'set_auth': '', 'unset_auth': '', 'dry_run': ''}
 
         useChecksum = (checksums is not None and 'adler32' in checksums and not self.stageIn)
 
@@ -111,9 +139,22 @@ class GFAL2Impl(StageOutImpl):
         copyCommandDict['source'] = self.createFinalPFN(sourcePFN)
         copyCommandDict['destination'] = self.createFinalPFN(targetPFN)
 
+        if authMethod is None:
+            copyCommandDict['set_auth'] = ""
+            copyCommandDict['unset_auth'] = ""
+        elif authMethod.upper() == 'X509':
+            copyCommandDict['set_auth'] = self.setAuthX509
+            copyCommandDict['unset_auth'] = self.unsetToken if forceMethod else ""
+        elif authMethod.upper() == 'TOKEN':
+            copyCommandDict['set_auth'] = self.setAuthToken
+            copyCommandDict['unset_auth'] = self.unsetToken if forceMethod else ""
+
+        copyCommandDict['dry_run'] = 'echo ' if dryRun else ''
+
         return copyCommandDict
 
-    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None, 
+                              authMethod=None, forceMethod=False):
         """
         Create gfal-cp command for stageOut
 
@@ -121,27 +162,35 @@ class GFAL2Impl(StageOutImpl):
         :targetPFN: str, destination PFN
         :options: str, additional options for gfal-cp
         :checksums: dict, collect checksums according to the algorithms saved as keys
+        :authMethod: string with the authentication method to use (either 'X509' or 'TOKEN')
+        :forceMethod: bool to isolate and force a given authentication method
+        returns: a string with the full stage out script
         """
-
-        copyCommandDict = self.buildCopyCommandDict(sourcePFN, targetPFN, options, checksums)
+        copyCommandDict = self.buildCopyCommandDict(sourcePFN, targetPFN, options, checksums,
+                                                    authMethod, forceMethod)
         copyCommand = self.copyCommand.format_map(copyCommandDict)
+        if authMethod is None:
+            # add more verbosity for reporting which authentication method GFAL uses when it is not specified
+            copyCommand = copyCommand.replace('-p -v', '-p -vvv')
+        
         result = "#!/bin/bash\n" + copyCommand
 
-        if _CheckExitCodeOption:
-            result += """
-            EXIT_STATUS=$?
-            echo "gfal-copy exit status: $EXIT_STATUS"
-            if [[ $EXIT_STATUS != 0 ]]; then
-                echo "ERROR: gfal-copy exited with $EXIT_STATUS"
-                echo "Cleaning up failed file:"
-                {remove_command}
-            fi
-            exit $EXIT_STATUS
-            """.format(remove_command=self.createRemoveFileCommand(targetPFN))
+        # add check for exit code
+        result += """
+        EXIT_STATUS=$?
+        echo "gfal-copy exit status: $EXIT_STATUS"
+        if [[ $EXIT_STATUS != 0 ]]; then
+            echo "ERROR: gfal-copy exited with $EXIT_STATUS"
+            echo "Cleaning up failed file:"
+            {remove_command}
+        fi
+        exit $EXIT_STATUS
+        """.format(remove_command=self.createRemoveFileCommand(targetPFN, authMethod=authMethod, forceMethod=forceMethod))
 
         return result
 
-    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None,
+                               authMethod=None, forceMethod=False):
         """
         Debug a failed gfal-cp command for stageOut, without re-running it,
         providing information on the environment and the certifications
@@ -152,8 +201,13 @@ class GFAL2Impl(StageOutImpl):
         :checksums: dict, collect checksums according to the algorithms saved as keys
         """
 
-        copyCommandDict = self.buildCopyCommandDict(sourcePFN, targetPFN, options, checksums)
+        copyCommandDict = self.buildCopyCommandDict(sourcePFN, targetPFN, options, checksums,
+                                                    authMethod, forceMethod, dryRun=True)
+
         copyCommand = self.copyCommand.format_map(copyCommandDict)
+        if authMethod is None:
+            # add more verbosity for reporting which authentication method GFAL uses when it is not specified
+            copyCommand = copyCommand.replace('-p -v', '-p -vvv')
 
         result = "#!/bin/bash\n"
         result += """
@@ -182,6 +236,10 @@ class GFAL2Impl(StageOutImpl):
         echo "Source PFN: {source}"
         echo "Target PFN: {destination}"
         echo
+        echo "Information for credentials in the environment"
+        echo "Bearer token content: $BEARER_TOKEN"
+        echo "Bearer token file: $BEARER_TOKEN_FILE"
+        echo
         echo "VOMS proxy info:"
         voms-proxy-info -all
         echo "==========================================================="
@@ -195,10 +253,7 @@ class GFAL2Impl(StageOutImpl):
         _removeFile_
         CleanUp pfn provided
         """
-        if os.path.isfile(pfnToRemove):
-            command = "/bin/rm -f {}".format(os.path.abspath(pfnToRemove))
-        else:
-            command = self.removeCommand.format(self.createFinalPFN(pfnToRemove))
+        command = self.createRemoveFileCommand(pfnToRemove)
         self.executeCommand(command)
 
 

--- a/src/python/WMCore/Storage/Backends/LCGImpl.py
+++ b/src/python/WMCore/Storage/Backends/LCGImpl.py
@@ -6,6 +6,7 @@ Implementation of StageOutImpl interface for lcg-cp
 
 """
 import os
+import logging
 
 from future.utils import viewitems
 
@@ -89,13 +90,15 @@ class LCGImpl(StageOutImpl):
         else:
             return StageOutImpl.createRemoveFileCommand(self, pfn)
 
-    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None, authMethod=None, forceMethod=False):
         """
         _createStageOutCommand_
 
         Build an srmcp command
 
         """
+        logging.warning("Warning! LCGImpl does not support authMethod handling")
+
         result = "#!/bin/sh\n"
 
         # check if we should use the grid UI from CVMFS
@@ -199,7 +202,7 @@ class LCGImpl(StageOutImpl):
 
         return result
 
-    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None, authMethod=None, forceMethod=False):
         """
         Debug a failed lcg-via smrv copy command for stageOut, without re-running it,
         providing information on the environment and the certifications

--- a/src/python/WMCore/Storage/Backends/SRMV2Impl.py
+++ b/src/python/WMCore/Storage/Backends/SRMV2Impl.py
@@ -11,6 +11,7 @@ from builtins import zip, range
 
 import os
 import re
+import logging
 
 from WMCore.Storage.Execute import runCommandWithOutput
 from WMCore.Storage.Registry import registerStageOutImpl
@@ -113,7 +114,7 @@ class SRMV2Impl(StageOutImpl):
         else:
             return StageOutImpl.createRemoveFileCommand(self, pfn)
 
-    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None, authMethod=None, forceMethod=False):
         """
         _createStageOutCommand_
 
@@ -125,6 +126,8 @@ class SRMV2Impl(StageOutImpl):
           -retry_num        number of retries before before client gives up
           -request_lifetime request lifetime in seconds
         """
+        logging.warning("Warning! SRMV2Impl does not support authMethod handling")
+        
         result = "#!/bin/sh\n"
         result += "REPORT_FILE=`pwd`/srm.report.$$\n"
         result += "srmcp -2 -report=$REPORT_FILE -retry_num=0 -request_lifetime=2400"
@@ -191,7 +194,7 @@ class SRMV2Impl(StageOutImpl):
 
         return result
     
-    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None, authMethod=None, forceMethod=False):
         """
         Debug a failed smrv2 copy command for stageOut, without re-running it,
         providing information on the environment and the certifications

--- a/src/python/WMCore/Storage/Backends/TestFallbackToOldBackend.py
+++ b/src/python/WMCore/Storage/Backends/TestFallbackToOldBackend.py
@@ -70,7 +70,7 @@ class TestFallbackToOldBackendImpl(StageOutImpl):
         else:
             print("=> dir already exists... do nothing.")
 
-    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None, authMethod=None, forceMethod=False):
         """
         _createStageOutCommand_
 
@@ -96,7 +96,7 @@ class TestFallbackToOldBackendImpl(StageOutImpl):
         print(result)
         return result
 
-    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None, authMethod=None, forceMethod=False):
         """
         Debug a failed copy command for stageOut, without re-running it,
         providing information on the environment and the certifications

--- a/src/python/WMCore/Storage/Backends/UnittestImpl.py
+++ b/src/python/WMCore/Storage/Backends/UnittestImpl.py
@@ -25,12 +25,12 @@ class WinImpl(StageOutImpl):
         return "WIN!!!"
 
 
-    def createStageOutCommand(self, sourcePFN, targetPFN, options = None, checksums = None):
+    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None, authMethod=False, forceMethod=False):
         print("WinImpl.createStageOutCommand(%s, %s, %s, %s)" % (sourcePFN, targetPFN, options, checksums))
         return "WIN!!!"
 
 
-    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None, authMethod=None, forceMethod=False):
         """
         Debug a failed unittest cp command for stageOut, without re-running it,
         providing information on the environment and the certifications
@@ -97,12 +97,12 @@ class FailImpl(StageOutImpl):
         return "FAIL!!!"
 
 
-    def createStageOutCommand(self, sourcePFN, targetPFN, options = None, checksums = None):
+    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None, authMethod=None, forceMethod=False):
         print("FailImpl.createStageOutCommand(%s, %s, %s, %s)" % (sourcePFN, targetPFN, options, checksums))
         return "FAIL!!!"
 
 
-    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None, authMethod=None, forceMethod=False):
         """
         Debug a failed unittest cp command for stageOut, without re-running it,
         providing information on the environment and the certifications
@@ -157,11 +157,11 @@ class LocalCopyImpl(StageOutImpl):
         return pfn
 
 
-    def createStageOutCommand(self, sourcePFN, targetPFN, options = None, checksums = None):
+    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None, authMethod=None, forceMethod=False):
         command = "cp %s %s" %(sourcePFN, sourcePFN+'2')
         return command
 
-    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None, authMethod=None, forceMethod=False):
         """
         Debug a failed unittest cp command for stageOut, without re-running it,
         providing information on the environment and the certifications

--- a/src/python/WMCore/Storage/Backends/VandyImpl.py
+++ b/src/python/WMCore/Storage/Backends/VandyImpl.py
@@ -7,6 +7,7 @@ Implementation of StageOutImpl interface for Vanderbilt
 """
 
 import os.path
+import logging
 
 from WMCore.Storage.Registry import registerStageOutImpl
 from WMCore.Storage.StageOutImpl import StageOutImpl
@@ -56,7 +57,7 @@ class VandyImpl(StageOutImpl):
         # throw a stage out error
         self.executeCommand(command)
 
-    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None, authMethod=None, forceMethod=False):
 
         """
         _createStageOutCommand_
@@ -65,12 +66,14 @@ class VandyImpl(StageOutImpl):
         targetPFN.
 
         """
+        logging.warning("Warning! VandyImpl does not support authMethod handling")
+
         if self.stageIn:
             return "%s %s %s" % (self._downloadScript, sourcePFN, targetPFN)
         else:
             return "%s %s %s" % (self._cpScript, sourcePFN, targetPFN)
         
-    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None, authMethod=None, forceMethod=False):
         """
         Debug a failed vandy copy command for stageOut, without re-running it,
         providing information on the environment and the certifications

--- a/src/python/WMCore/Storage/Backends/XRDCPImpl.py
+++ b/src/python/WMCore/Storage/Backends/XRDCPImpl.py
@@ -15,7 +15,7 @@ import os
 
 from WMCore.Storage.Registry import registerStageOutImpl
 from WMCore.Storage.StageOutImpl import StageOutImpl
-
+from WMCore.Storage.StageOutError import StageOutError
 
 class XRDCPImpl(StageOutImpl):
     """
@@ -28,7 +28,49 @@ class XRDCPImpl(StageOutImpl):
         self.numRetries = 5
         self.retryPause = 300
         self.xrdfsCmd = "xrdfs"
-
+        self.setAuthX509 = "env X509_USER_PROXY=$X509_USER_PROXY "
+        self.setAuthToken = "env BEARER_TOKEN_FILE=$BEARER_TOKEN_FILE BEARER_TOKEN=$(cat $BEARER_TOKEN_FILE) "
+        self.unsetX509 = "X509_USER_PROXY= "
+        self.unsetToken = "BEARER_TOKEN_FILE= BEARER_TOKEN= "
+        self.debuggingTemplate = "#!/bin/bash\n"
+        self.debuggingTemplate += """
+        echo
+        echo
+        echo "-----------------------------------------------------------"
+        echo "==========================================================="
+        echo
+        echo "Debugging information on failing xrdcp/xrdfs command"
+        echo
+        echo "Current date and time: $(date +"%Y-%m-%d %H:%M:%S")"
+        echo "XRootD command which failed: {copy_command}"
+        echo "Hostname:   $(hostname -f)"
+        echo "OS:  $(uname -r -s)"
+        echo
+        echo "XRD environment variables (if any):"
+        env | grep ^XRD_
+        echo
+        echo "PYTHON environment variables:"
+        env | grep ^PYTHON
+        echo
+        echo "LD_* environment variables:"
+        env | grep ^LD_
+        echo
+        echo "xrdcp location: $(which xrdcp)"
+        echo "xrdfs location: $(which xrdfs)"
+        echo "Source PFN: {source}"
+        echo "Target PFN: {destination}"
+        echo
+        echo
+        echo "Information for credentials in the environment"
+        echo "Bearer token content: $BEARER_TOKEN"
+        echo "Bearer token file: $BEARER_TOKEN_FILE"
+        echo
+        echo "VOMS proxy info:"
+        voms-proxy-info -all
+        echo "==========================================================="
+        echo "-----------------------------------------------------------"
+        echo
+        """
     def createSourceName(self, protocol, pfn):
         """
         _createSourceName_
@@ -44,7 +86,7 @@ class XRDCPImpl(StageOutImpl):
         """
         return
 
-    def _checkXRDUtilsExist(self):
+    def checkXRDUtilsExist(self):
         """
         Verifies whether xrdcp and xrdfs utils exist in the job path.
 
@@ -59,17 +101,44 @@ class XRDCPImpl(StageOutImpl):
 
         return foundXrdcp & foundXrdfs
 
-    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+    def _getAuthEnv(self, authMethod=None, forceMethod=False):
         """
-        _createStageOutCommand_
+        Get environment variables for stageout command based on the selected authentication method.
+        :authMethod: str, the authentication method to be used ("X509", "TOKEN", or None)
+        :forceMethod: bool, cleans non-chosen auth methods from environment.
+        :return: str
+        """
+        authEnv = ""
+        if authMethod is None:
+            return authEnv
+        elif authMethod.upper() == 'X509':
+            authEnv = self.setAuthX509
+            if forceMethod:
+                authEnv += self.unsetToken
+        elif authMethod.upper() == 'TOKEN':
+            authEnv = self.setAuthToken
+            if forceMethod:
+                authEnv += self.unsetX509
+        else:
+            logging.warning("Warning! Running without either a X509 certificate or a token specified!")
 
-        Build the actual xrdcp stageout command
+        return authEnv
 
+    def getFormattedCopyCommand(self, sourcePFN, targetPFN, options=None, checksums=None, authMethod=None, forceMethod=False, dryRun=False):
+        """
+        Construct xrdcp/xrdfs stageout command.
         If adler32 checksum is provided, use it for the transfer
         xrdcp options used:
           --force : re-creates a file if it's already present
           --nopbar : does not display the progress bar
 
+        :sourcePFN: str, the source PFN.
+        :targetPFN: str, the target PFN.
+        :options: str, additional options for gfal-copy.
+        :checksums: dict, checksum values.
+        :authMethod: str, preferred authentication method.
+        :forceMethod: bool, whether to force the preferred authentication method.
+        :dryRun: bool, dry run mode (to enable debug mode)
         """
         if not options:
             options = ''
@@ -100,7 +169,7 @@ class XRDCPImpl(StageOutImpl):
         # If not, check whether OSG cvmfs repo is available.
         # This likely only works on RHEL7 x86-64 (and compatible) OS, but this
         # represents most of our resources and it's a fallback mechanism anyways
-        if not self._checkXRDUtilsExist():
+        if not self.checkXRDUtilsExist():
             logging.warning("Failed to find XRootD in the path. Trying fallback to OSG CVMFS...")
             initFile = "/cvmfs/oasis.opensciencegrid.org/osg-software/osg-wn-client/current/el7-x86_64/setup.sh"
             if os.path.isfile(initFile):
@@ -116,8 +185,12 @@ class XRDCPImpl(StageOutImpl):
             xrdcpCmd = "xrdcp"
             self.xrdfsCmd = "xrdfs"
 
+        # Check for auth-related environment to prepend
+        authEnv = self._getAuthEnv(authMethod, forceMethod)
+        if authEnv:
+            copyCommand += authEnv
+            self.xrdfsCmd = "%s %s" % (authEnv, self.xrdfsCmd)
         copyCommand += "%s --force --nopbar " % xrdcpCmd
-        
         
         if copyCommandOptions:
             copyCommand += "%s " % copyCommandOptions
@@ -158,9 +231,30 @@ class XRDCPImpl(StageOutImpl):
             copyCommand += "if [ $RC == 0 ] && [ $REMOTE_SIZE ] && [ $LOCAL_SIZE == $REMOTE_SIZE ]; then exit 0; "
             copyCommand += "else echo \"ERROR: XRootD file transfer return code is $RC. Size or Checksum Mismatch between local and SE\"; %s exit 60311 ; fi" % removeCommand
 
+        if dryRun:
+            return self.debuggingTemplate.format(copy_command=copyCommand, source=sourcePFN, destination=targetPFN)
+
         return copyCommand
+
+    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None, authMethod=None, forceMethod=False):
+        """
+        _createStageOutCommand_
+
+        Build the actual xrdcp stageout command
+
+        :sourcePFN: str, the source PFN.
+        :targetPFN: str, the target PFN.
+        :options: str, additional options for gfal-copy.
+        :checksums: dict, checksum values.
+        :authMethod: str, preferred authentication method.
+        :forceMethod: bool, whether to force the preferred authentication method.
+        :dryRun: bool, dry run mode (to enable debug mode).
+
+        """
+        # Construct xrdcp stageout command and return it
+        return self.getFormattedCopyCommand(sourcePFN, targetPFN, options, checksums, authMethod, forceMethod)
     
-    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None, authMethod=None, forceMethod=False):
         """
         Debug a failed xrdcp command for stageOut, without re-running it,
         providing information on the environment and the certifications
@@ -169,22 +263,52 @@ class XRDCPImpl(StageOutImpl):
         :targetPFN: str, destination PFN
         :options: str, additional options for copy command
         :checksums: dict, collect checksums according to the algorithms saved as keys
+        :authMethod: str, the authentication method to be preferentially used ("X509", "TOKEN", or None)
+        :forceMethod: bool, whether to force the use of the preferred authentication method, disabling the other 
         """
-        # Build the command for debugging purposes
-        copyCommandDict = self.buildCopyCommandDict(sourcePFN, targetPFN, options, checksums)
-        copyCommand = self.copyCommand.format_map(copyCommandDict)
-
-        result = self.debuggingTemplate.format(copy_command=copyCommand, source=copyCommandDict['source'], destination=copyCommandDict['destination'])
-        return result
+        # Construct xrdcp/xrdfs commands, but returning the debugging information instead of running it
+        return self.getFormattedCopyCommand(sourcePFN, targetPFN, options, checksums, authMethod, forceMethod, dryRun=True)
 
     def removeFile(self, pfnToRemove):
         """
-        _removeFile_
-
+        Remove a file
+        :pfnToRemove: str, PFN of the source file
         """
         (_, host, path, _) = self.splitPFN(pfnToRemove)
-        command = "%s %s rm %s" % (self.xrdfsCmd, host, path)
-        self.executeCommand(command)
+
+        # Try TOKEN authentication first, follow with safe-logic auth methods otherwise
+        authEnv = self._getAuthEnv(authMethod="TOKEN")
+        command = "%s %s %s rm %s" % (authEnv, self.xrdfsCmd, host, path)
+
+        try:
+            self.executeCommand(command)
+            logging.info("Removing file with TOKEN authentication succeeded (X509 still enabled).")
+        except StageOutError as ex:
+            logging.error("Removing file with TOKEN authentication failed. Command: %s", command)
+            logging.error("Error: %s", str(ex))
+            logging.info("Attempting to remove file with authentication safe-logic")
+            if os.getenv("X509_USER_PROXY"):
+                logging.info("Retrying with X509_USER_PROXY with BEARER_TOKEN unset...")
+                authEnv = self._getAuthEnv(authMethod="X509", forceMethod=True)
+                command = "%s %s %s rm %s" % (authEnv, self.xrdfsCmd, host, path)
+                try:
+                    self.executeCommand(command)
+                    logging.info("removefile succeeded with X509 with BEARER_TOKEN unset.")
+                    return
+                except StageOutError as fallbackEx:
+                    logging.error("Fallback with X509_USER_PROXY failed:\n%s", str(fallbackEx))
+
+            if os.getenv("BEARER_TOKEN") or os.getenv("BEARER_TOKEN_FILE"):
+                logging.info("Retrying with BEARER_TOKEN with X509_USER_PROXY unset...")
+                authEnv = self._getAuthEnv(authMethod="TOKEN", forceMethod=True)
+                command = "%s %s %s rm %s" % (authEnv, self.xrdfsCmd, host, path)
+                try:
+                    self.executeCommand(command)
+                    logging.info("Removing file succeeded with TOKEN with X509_USER_PROXY unset.")
+                    return
+                except StageOutError as fallbackEx:
+                    logging.error("Fallback with BEARER_TOKEN failed:\n%s", str(fallbackEx))
+              
         return
 
 registerStageOutImpl("xrdcp", XRDCPImpl)

--- a/src/python/WMCore/Storage/StageOutImpl.py
+++ b/src/python/WMCore/Storage/StageOutImpl.py
@@ -57,6 +57,10 @@ class StageOutImpl:
         echo "LD_* environment variables:"
         env | grep ^LD_
         echo
+        echo "Information for credentials in the environment"
+        echo "Bearer token content: $BEARER_TOKEN"
+        echo "Bearer token file: $BEARER_TOKEN_FILE"
+        echo
         echo "Source PFN: {source}"
         echo "Target PFN: {destination}"
         echo
@@ -161,7 +165,7 @@ class StageOutImpl:
         If no directory is required, do not implement this method
         """
 
-    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+    def createStageOutCommand(self, sourcePFN, targetPFN, options=None, checksums=None, authMethod=None, forceMethod=False):
         """
         _createStageOutCommand_
 
@@ -171,7 +175,7 @@ class StageOutImpl:
         """
         raise NotImplementedError("StageOutImpl.createStageOutCommand")
 
-    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None, authMethod=None, forceMethod=False):
         """
         Build a shell command that will report in the logs the details about
         failing stageOut commands
@@ -207,10 +211,9 @@ class StageOutImpl:
 
         This operator does the actual stage out by invoking the overridden
         plugin methods of the derived object.
-
-
         """
-        #  //
+
+        # //
         # // Generate the source PFN from the plain PFN if needed
         # //
         sourcePFN = self.createSourceName(protocol, inputPFN)
@@ -218,7 +221,7 @@ class StageOutImpl:
         # destination may also need PFN changed
         # i.e. if we are staging in a file from an SE
         targetPFN = self.createTargetName(protocol, targetPFN)
-        #  //
+        # //
         # // Create the output directory if implemented
         # //
         for retryCount in range(self.numRetries + 1):
@@ -232,30 +235,60 @@ class StageOutImpl:
                 msg += "Error details:\n{}\n".format(str(ex))
                 logging.error(msg)
                 if retryCount == self.numRetries:
-                    #  //
+                    # //
                     # // last retry, propagate exception
                     # //
+                    logging.error("Maximum retries exhausted when trying to create the output directory")
                     raise ex
                 time.sleep(self.retryPause)
 
         # //
         # // Create the command to be used.
         # //
-        command = self.createStageOutCommand(sourcePFN, targetPFN, options, checksums)
-        #  //
+        # // This will actually only enforce the definition of the bearer token variables, still x509 auth activated as a backup
+        command = self.createStageOutCommand(sourcePFN, targetPFN, options, checksums, authMethod="TOKEN")
+        # //
         # // Run the command
         # //
 
         stageOutEx = None  # variable to store the possible StageOutError
         for retryCount in range(self.numRetries + 1):
             try:
-                logging.info("Running the stage out...")
+                logging.info("Running the stage out with the available auth method (attempt %d)...", retryCount + 1)
+                logging.info("Command to run: %s", command)
                 self.executeCommand(command)
+                logging.info("\nStage-out succeeded with the current environment.")
                 break
+
             except StageOutError as ex:
-                msg = "Attempt {} to stage out failed.\n".format(retryCount)
+                msg = "Attempt {} to stage out failed with default setup.\n".format(retryCount)
                 msg += "Error details:\n{}\n".format(str(ex))
                 logging.error(msg)
+                logging.info("Retrying with authentication-safe logic...")
+
+                # Authentication-safe fallback logic
+                if os.getenv("X509_USER_PROXY"):
+                    logging.info("Retrying with X509_USER_PROXY with BEARER_TOKEN unset...")
+                    command = self.createStageOutCommand(sourcePFN, targetPFN, options, checksums, authMethod="X509", forceMethod=True)
+                    try:
+                        logging.info("Command to run: %s", command)
+                        self.executeCommand(command)
+                        logging.info("Stage-out succeeded with X509 with BEARER_TOKEN unset.")
+                        return
+                    except StageOutError as fallbackEx:
+                        logging.warning("Fallback with X509_USER_PROXY failed:\n%s", str(fallbackEx))
+
+                if os.getenv("BEARER_TOKEN") or os.getenv("BEARER_TOKEN_FILE"):
+                    logging.info("Retrying with BEARER_TOKEN with X509_USER_PROXY unset...")
+                    command = self.createStageOutCommand(sourcePFN, targetPFN, options, checksums, authMethod="TOKEN", forceMethod=True)
+                    try:
+                        logging.info("Command to run: %s", command)
+                        self.executeCommand(command)
+                        logging.info("Stage-out succeeded with TOKEN with X509_USER_PROXY unset.")
+                        return
+                    except StageOutError as fallbackEx:
+                        logging.warning("Fallback with BEARER_TOKEN failed:\n%s", str(fallbackEx))
+
                 if retryCount == self.numRetries:
                     # Last retry, propagate the information outside of the for loop
                     stageOutEx = ex
@@ -265,6 +298,6 @@ class StageOutImpl:
         # This block will now always be executed after retries are exhausted
         if stageOutEx is not None:
             logging.error("Maximum number of retries exhausted. Further details on the failed command reported below.")
-            command = self.createDebuggingCommand(sourcePFN, targetPFN, options, checksums)
+            command = self.createDebuggingCommand(sourcePFN, targetPFN, options, checksums, authMethod="TOKEN")
             self.executeCommand(command)
             raise stageOutEx from None

--- a/test/python/WMCore_t/Storage_t/Backends_t/XRDCPImpl_t.py
+++ b/test/python/WMCore_t/Storage_t/Backends_t/XRDCPImpl_t.py
@@ -88,7 +88,7 @@ class XRDCPImplTest(unittest.TestCase):
             if copyCommandOptions:
                 targetPFN += "?svcClass=t0cms"
         initFile = "/cvmfs/oasis.opensciencegrid.org/osg-software/osg-wn-client/current/el7-x86_64/setup.sh"
-        if not self.XRDCPImpl._checkXRDUtilsExist() and os.path.isfile(initFile):
+        if not self.XRDCPImpl.checkXRDUtilsExist() and os.path.isfile(initFile):
             copyCommand += "source {}\n".format(initFile)
         copyCommand += "xrdcp --force --nopbar "
         if unknow:
@@ -125,4 +125,4 @@ class XRDCPImplTest(unittest.TestCase):
     @mock.patch('WMCore.Storage.Backends.XRDCPImpl.XRDCPImpl.executeCommand')
     def testRemoveFile(self, mock_executeCommand):
         self.XRDCPImpl.removeFile("gsiftp://site.com/inputs/f.a")
-        mock_executeCommand.assert_called_with("xrdfs site.com rm inputs/f.a")
+        mock_executeCommand.assert_called_with("env BEARER_TOKEN_FILE=$BEARER_TOKEN_FILE BEARER_TOKEN=$(cat $BEARER_TOKEN_FILE)  xrdfs site.com rm inputs/f.a")

--- a/test/python/WMCore_t/Storage_t/StageOutImpl_t.py
+++ b/test/python/WMCore_t/Storage_t/StageOutImpl_t.py
@@ -81,38 +81,69 @@ class StageOutImplTest(unittest.TestCase):
     @mock.patch('WMCore.Storage.StageOutImpl.StageOutImpl.createTargetName')
     @mock.patch('WMCore.Storage.StageOutImpl.StageOutImpl.createOutputDirectory')
     @mock.patch('WMCore.Storage.StageOutImpl.StageOutImpl.createStageOutCommand')
+    @mock.patch('WMCore.Storage.StageOutImpl.StageOutImpl.createDebuggingCommand')
     @mock.patch('WMCore.Storage.StageOutImpl.StageOutImpl.executeCommand')
-    def testCallable(self, mock_executeCommand, mock_createStageOutCommand, mock_createOutputDirectory,
-                     mock_createTargetName, mock_createSourceName):
+    def testCallable(self, 
+                    mock_executeCommand,          # from the last decorator
+                    mock_createDebuggingCommand,  # from the second-to-last decorator
+                    mock_createStageOutCommand,   # then this one
+                    mock_createOutputDirectory, 
+                    mock_createTargetName, 
+                    mock_createSourceName):
         mock_createSourceName.return_value = "sourcePFN"
         mock_createTargetName.return_value = "targetPFN"
         mock_createStageOutCommand.return_value = "command"
+        # Even if set, createDebuggingCommand should not be called on success.
+        mock_createDebuggingCommand.return_value = "command"
+        
         self.StageOutImpl("protocol", "inputPFN", "targetPFN")
+        
         mock_createSourceName.assert_called_with("protocol", "inputPFN")
         mock_createTargetName.assert_called_with("protocol", "targetPFN")
         mock_createOutputDirectory.assert_called_with("targetPFN")
-        mock_createStageOutCommand.assert_called_with("sourcePFN", "targetPFN", None, None)
+        mock_createStageOutCommand.assert_called_with("sourcePFN", "targetPFN", None, None, authmethod='TOKEN')
+        # Verify that createDebuggingCommand was not called during a successful stage-out.
+        mock_createDebuggingCommand.assert_not_called()
         mock_executeCommand.assert_called_with("command")
 
     @mock.patch('WMCore.Storage.StageOutImpl.StageOutImpl.createSourceName')
     @mock.patch('WMCore.Storage.StageOutImpl.StageOutImpl.createTargetName')
     @mock.patch('WMCore.Storage.StageOutImpl.StageOutImpl.createOutputDirectory')
     @mock.patch('WMCore.Storage.StageOutImpl.StageOutImpl.createStageOutCommand')
+    @mock.patch('WMCore.Storage.StageOutImpl.StageOutImpl.createDebuggingCommand')
     @mock.patch('WMCore.Storage.StageOutImpl.StageOutImpl.executeCommand')
     @mock.patch('WMCore.Storage.StageOutImpl.time')
-    def testCallable_StageOutError(self, mock_time, mock_executeCommand, mock_createStageOutCommand,
-                                   mock_createOutputDirectory, mock_createTargetName, mock_createSourceName):
+    def testCallable_StageOutError(self, mock_time, mock_executeCommand, mock_createStageOutCommand, 
+                                mock_createDebuggingCommand, mock_createOutputDirectory, 
+                                mock_createTargetName, mock_createSourceName):
         mock_createSourceName.return_value = "sourcePFN"
         mock_createTargetName.return_value = "targetPFN"
         mock_createStageOutCommand.return_value = "command"
+        mock_createDebuggingCommand.return_value = "command"
+        
+        # Force createOutputDirectory to fail twice, then succeed.
         mock_createOutputDirectory.side_effect = [StageOutError("error"), StageOutError("error"), None]
-        mock_executeCommand.side_effect = [StageOutError("error"), StageOutError("error"), None]
-        self.StageOutImpl("protocol", "inputPFN", "targetPFN")
+        
+        # Force executeCommand to fail on all 4 attempts, then succeed for the debugging command.
+        mock_executeCommand.side_effect = [
+            StageOutError("error"),
+            StageOutError("error"),
+            StageOutError("error"),
+            StageOutError("error"),
+            None  # This call is for executing the debugging command.
+        ]
+    
+        with self.assertRaises(StageOutError):
+            self.StageOutImpl("protocol", "inputPFN", "targetPFN")
+        
         mock_createSourceName.assert_called_with("protocol", "inputPFN")
         mock_createTargetName.assert_called_with("protocol", "targetPFN")
         mock_createOutputDirectory.assert_called_with("targetPFN")
-        mock_createStageOutCommand.assert_called_with("sourcePFN", "targetPFN", None, None)
-        mock_executeCommand.assert_called_with("command")
+        # The stage-out command is generated with authmethod='TOKEN'
+        mock_createStageOutCommand.assert_called_with("sourcePFN", "targetPFN", None, None, authmethod='TOKEN')
+        # After retries are exhausted, the debugging command should be generated.
+        mock_createDebuggingCommand.assert_called_with("sourcePFN", "targetPFN", None, None, authmethod='TOKEN')
+        # Assert that time.sleep was called 4 times (once for each failed stage-out attempt).
         calls = [call(600), call(600), call(600), call(600)]
         mock_time.sleep.assert_has_calls(calls)
 

--- a/test/python/WMCore_t/Storage_t/StageOutImpl_t.py
+++ b/test/python/WMCore_t/Storage_t/StageOutImpl_t.py
@@ -101,7 +101,7 @@ class StageOutImplTest(unittest.TestCase):
         mock_createSourceName.assert_called_with("protocol", "inputPFN")
         mock_createTargetName.assert_called_with("protocol", "targetPFN")
         mock_createOutputDirectory.assert_called_with("targetPFN")
-        mock_createStageOutCommand.assert_called_with("sourcePFN", "targetPFN", None, None, authmethod='TOKEN')
+        mock_createStageOutCommand.assert_called_with("sourcePFN", "targetPFN", None, None, authMethod='TOKEN')
         # Verify that createDebuggingCommand was not called during a successful stage-out.
         mock_createDebuggingCommand.assert_not_called()
         mock_executeCommand.assert_called_with("command")
@@ -139,10 +139,10 @@ class StageOutImplTest(unittest.TestCase):
         mock_createSourceName.assert_called_with("protocol", "inputPFN")
         mock_createTargetName.assert_called_with("protocol", "targetPFN")
         mock_createOutputDirectory.assert_called_with("targetPFN")
-        # The stage-out command is generated with authmethod='TOKEN'
-        mock_createStageOutCommand.assert_called_with("sourcePFN", "targetPFN", None, None, authmethod='TOKEN')
+        # The stage-out command is generated with authMethod='TOKEN'
+        mock_createStageOutCommand.assert_called_with("sourcePFN", "targetPFN", None, None, authMethod='TOKEN')
         # After retries are exhausted, the debugging command should be generated.
-        mock_createDebuggingCommand.assert_called_with("sourcePFN", "targetPFN", None, None, authmethod='TOKEN')
+        mock_createDebuggingCommand.assert_called_with("sourcePFN", "targetPFN", None, None, authMethod='TOKEN')
         # Assert that time.sleep was called 4 times (once for each failed stage-out attempt).
         calls = [call(600), call(600), call(600), call(600)]
         mock_time.sleep.assert_has_calls(calls)


### PR DESCRIPTION
Fixes #12144 

#### Status
Tested

#### Description
This PR introduces the retry logic proposed by @stlammel for handling the possible failures with token authentication when used with `gfal-cp` and `xrootd` protocols.

Both the copy and remove commands are preceded by setting the proper env variables to enforcing the desired authentication method, specified via the `authMethod` method argument. In addition, given that these protocols will try to use every authentication method before failing, an additional `forceMethod` argument is added to unset the env variables needed to enable the undesired protocol.

For instance:
`authMethod=TOKEN, forceMethod=True` set the `BEARER_TOKEN*` env variables and clearly unset the `X509_` ones.

These variables are introduced also for all other subclasses for the other protocols, but their usage in not implemented for now. The retry logic is delegated to `StageOutImpl`

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
#12199 for implementing the token authentication in the stage-in step
This PR overrides #12191 

#### External dependencies / deployment changes
None
