### PR TITLE
Switch updateSiteList to updateElementsByWorkflow API

### DIFF
--- a/src/python/WMComponent/WorkflowUpdater/SiteListPoller.py
+++ b/src/python/WMComponent/WorkflowUpdater/SiteListPoller.py
@@ -127,7 +127,8 @@ class SiteListPoller(BaseWorkerThread):
                 self.logger.info("  siteBlackList %s => %s", wmaBlackList, siteBlackList)
                 try:
                     # update local WorkQueue first
-                    self.localWQ.updateSiteLists(wflow, siteWhiteList, siteBlackList)
+                    params = {'SiteWhitelist': siteWhiteList, 'SiteBlacklist': siteBlackList}
+                    self.localWQ.updateElementsByWorkflow(wHelper, params, status=['Available'])
                     self.logger.info("successfully updated workqueue elements for workflow %s", wflow)
                 except Exception as ex:
                     logging.exception("Unexpected exception while updating elements in local workqueue Details:\n%s", str(ex))


### PR DESCRIPTION
Fixes #12040 

#### Status
ready

#### Description
replace `updateSiteLists` API in favor of `updateElementsByWorkflow` one

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
#12155 , #12123 

#### External dependencies / deployment changes
