### PR TITLE
wmagent - htcondor bindings bumped to v24.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ dbs3-client==4.0.19           # wmcore,wmagent,wmagent-devtools,reqmgr2,reqmon,g
 future~=0.18.2                # wmcore,wmagent,wmagent-devtools,reqmgr2,reqmon,acdcserver,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-pileup,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner
 gfal2-python~=1.11.0.post3    # wmcore,reqmgr2ms-unmerged
 httplib2~=0.20.4              # wmcore,wmagent,reqmgr2,reqmon,acdcserver,global-workqueue,reqmgr2ms-unmerged,reqmgr2ms-output,reqmgr2ms-pileup,reqmgr2ms-monitor,reqmgr2ms-transferor,reqmgr2ms-rulecleaner
-htcondor~=10.9.0              # wmcore,wmagent
+htcondor~=24.3.0              # wmcore,wmagent
 Jinja2~=3.1.2                 # wmcore,wmagent
 memory-profiler~=0.60.0       # wmcore,wmagent-devtools
 mock~=4.0.3                   # wmcore,wmagent,wmagent-devtools


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/12031

#### Status

not tested. 

I need to deploy a new release candidate in my test environment to test these chagnes

#### Description

I can not find any quick way to just change the htcondor bindings in my venv setup, the quickest way seems to be to bump the htcondor version in the requirements, create a new release candidate tag, deploy in my VM, test it there.

Then, if something breaks, we will deal with it in new PRs.

#### Is it backward compatible (if not, which system it affects?)

I hope so!

#### Related PRs

none

#### External dependencies / deployment changes

New htcondor pythhon bindings version!
