### PR TITLE
Have default memory be 3.0 GiB

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/Express.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Express.py
@@ -265,7 +265,9 @@ class ExpressWorkloadFactory(StdBase):
         dataTier = getattr(parentOutputModule, "dataTier")
         mergeTask.setInputReference(parentTaskCmssw, outputModule=parentOutputModuleName, dataTier=dataTier)
 
-        self.addRuntimeMonitors(mergeTask)
+        expressMergeMaxPSS = mySplitArgs['mergeTaskMemory']
+        self.addRuntimeMonitors(mergeTask, maxpss=expressMergeMaxPSS)
+
         mergeTaskCmssw = mergeTask.makeStep("cmsRun1")
         mergeTaskCmssw.setStepType("CMSSW")
 
@@ -457,6 +459,7 @@ class ExpressWorkloadFactory(StdBase):
         self.expressSplitArgs['maxInputRate'] = arguments['MaxInputRate']
         self.expressSplitArgs['maxInputEvents'] = arguments['MaxInputEvents']
         self.expressMergeSplitArgs = {}
+        self.expressMergeSplitArgs['mergeTaskMemory'] = arguments['MergeTaskMemory']
         self.expressMergeSplitArgs['maxInputSize'] = arguments['MaxInputSize']
         self.expressMergeSplitArgs['maxInputFiles'] = arguments['MaxInputFiles']
         self.expressMergeSplitArgs['maxLatency'] = arguments['MaxLatency']

--- a/src/python/WMCore/WMSpec/StdSpecs/Express.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Express.py
@@ -495,6 +495,7 @@ class ExpressWorkloadFactory(StdBase):
                     "MaxInputSize": {"type": int, "optional": False},
                     "MaxInputFiles": {"type": int, "optional": False},
                     "MaxLatency": {"type": int, "optional": False},
+                    "MergeTaskMemory": {"default": 3000.0, "type": float, "validate": lambda x: x > 0},
 
                     }
         baseArgs.update(specArgs)

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -264,7 +264,7 @@ class StdBase(object):
         monitoring.interval = 300
         monitoring.monitors = ["PerformanceMonitor"]
         monitoring.section_("PerformanceMonitor")
-        monitoring.PerformanceMonitor.maxPSS = maxpss * 1024 # in MiB
+        monitoring.PerformanceMonitor.maxPSS = maxpss * 1024  # in MiB
         monitoring.PerformanceMonitor.softTimeout = softTimeout
         monitoring.PerformanceMonitor.hardTimeout = hardTimeout
         return task

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -1091,6 +1091,7 @@ class StdBase(object):
                      "ProcessingString": {"validate": procstring, "optional": False},
                      "ProcessingVersion": {"default": 1, "type": int, "validate": procversion},
                      "Memory": {"default": 2300.0, "type": float, "validate": lambda x: x > 0},
+                     "MergeTaskMemory": {"default": 3000.0, "type": float, "validate": lambda x: x > 0},
                      "Multicore": {"default": 1, "type": int, "validate": lambda x: x > 0},
                      "EventStreams": {"type": int, "default": 0, "validate": lambda x: x >= 0, "null": True},
                      "MergedLFNBase": {"default": "/store/data"},

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -257,7 +257,7 @@ class StdBase(object):
         Memory settings are defined in Megabytes and timing in seconds.
         """
         # Default settings defined by CMS policy
-        maxpss = 2.3 * 1024  # 2.3 GiB, but in MiB
+        maxpss = 3.0 * 1024  # 3.0 GiB, but in MiB
         softTimeout = 47 * 3600  # 47h
         hardTimeout = 47 * 3600 + 5 * 60  # 47h + 5 minutes
 

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -249,7 +249,7 @@ class StdBase(object):
 
         return outputModules
 
-    def addRuntimeMonitors(self, task, maxpss=2.3):
+    def addRuntimeMonitors(self, task, maxpss=2.3 * 1024):
         """
         _addRuntimeMonitors_
 
@@ -264,7 +264,7 @@ class StdBase(object):
         monitoring.interval = 300
         monitoring.monitors = ["PerformanceMonitor"]
         monitoring.section_("PerformanceMonitor")
-        monitoring.PerformanceMonitor.maxPSS = maxpss * 1024  # in MiB
+        monitoring.PerformanceMonitor.maxPSS = maxpss  # value is propagated in MiB
         monitoring.PerformanceMonitor.softTimeout = softTimeout
         monitoring.PerformanceMonitor.hardTimeout = hardTimeout
         return task
@@ -1091,7 +1091,6 @@ class StdBase(object):
                      "ProcessingString": {"validate": procstring, "optional": False},
                      "ProcessingVersion": {"default": 1, "type": int, "validate": procversion},
                      "Memory": {"default": 2300.0, "type": float, "validate": lambda x: x > 0},
-                     "MergeTaskMemory": {"default": 3000.0, "type": float, "validate": lambda x: x > 0},
                      "Multicore": {"default": 1, "type": int, "validate": lambda x: x > 0},
                      "EventStreams": {"type": int, "default": 0, "validate": lambda x: x >= 0, "null": True},
                      "MergedLFNBase": {"default": "/store/data"},

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -249,7 +249,7 @@ class StdBase(object):
 
         return outputModules
 
-    def addRuntimeMonitors(self, task):
+    def addRuntimeMonitors(self, task, maxpss=2.3):
         """
         _addRuntimeMonitors_
 
@@ -257,7 +257,6 @@ class StdBase(object):
         Memory settings are defined in Megabytes and timing in seconds.
         """
         # Default settings defined by CMS policy
-        maxpss = 3.0 * 1024  # 3.0 GiB, but in MiB
         softTimeout = 47 * 3600  # 47h
         hardTimeout = 47 * 3600 + 5 * 60  # 47h + 5 minutes
 
@@ -265,7 +264,7 @@ class StdBase(object):
         monitoring.interval = 300
         monitoring.monitors = ["PerformanceMonitor"]
         monitoring.section_("PerformanceMonitor")
-        monitoring.PerformanceMonitor.maxPSS = maxpss
+        monitoring.PerformanceMonitor.maxPSS = maxpss * 1024 # in MiB
         monitoring.PerformanceMonitor.softTimeout = softTimeout
         monitoring.PerformanceMonitor.hardTimeout = hardTimeout
         return task

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Express_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Express_t.py
@@ -53,7 +53,8 @@ REQUEST = {
     "ScramArch": "slc6_amd64_gcc530",
     "Scenario": "test_scenario",
     "SpecialDataset": "StreamExpress",
-    "StreamName": "Express"
+    "StreamName": "Express",
+    "MergeTaskMemory": 3000
 }
 
 


### PR DESCRIPTION
Fixes #12086

#### Status
Ready

#### Description
Express merge tasks now require 3.0 GiB 

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
https://github.com/dmwm/WMCore/pull/12085

12085 is closed now.

#### External dependencies / deployment changes
NO
