### PR TITLE
Adding wmstatsUrl to WorkflowUpdater configuration

### DIFF
--- a/bin/wmagent-mod-config
+++ b/bin/wmagent-mod-config
@@ -293,6 +293,7 @@ def modifyConfiguration(config, **args):
         config.WorkflowUpdater.dbsUrl = args.get("dbs3_reader_url", None)
         config.WorkflowUpdater.rucioUrl = args["rucio_host"]
         config.WorkflowUpdater.rucioAuthUrl = args["rucio_auth"]
+        config.WorkflowUpdater.wmstatsUrl = args["wmstats_url"]
         if args.get("mspileup_url", None):
             config.WorkflowUpdater.msPileupUrl = args["mspileup_url"]
 

--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -392,6 +392,7 @@ config.WorkflowUpdater.componentDir = config.General.workDir + "/WorkflowUpdater
 config.WorkflowUpdater.logLevel = globalLogLevel
 config.WorkflowUpdater.pollInterval = 8 * 60 * 60  # every 8 hours
 config.WorkflowUpdater.dbsUrl = "OVER_WRITE_BY_SECRETS"
+config.WorkflowUpdater.wmstatsUrl = "OVER_WRITE_BY_SECRETS"
 config.WorkflowUpdater.rucioAccount = "wmcore_pileup"
 config.WorkflowUpdater.rucioUrl = "OVER_WRITE_BY_SECRETS"
 config.WorkflowUpdater.rucioAuthUrl = "OVER_WRITE_BY_SECRETS"


### PR DESCRIPTION
Fixes #12231 

#### Status
ready

#### Description
With the current PR we  are adding the so missing configuration parameter `wmstatsUrl` for the WMAgent `WorkflowUpadter` component.

#### Is it backward compatible (if not, which system it affects?)
YES 

#### Related PRs
https://github.com/dmwm/WMCore/pull/12123 

#### External dependencies / deployment changes
Requires 
* A new  WMAgent  TAG/
* Package upload to Pypi  and 
* redeployment of the agent in order 
for the changes to take effect. It won't work through just patching the agent.  
