### PR TITLE
Support nano flavours in prompt reco workflows

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/PromptReco.py
@@ -61,6 +61,7 @@ class PromptRecoWorkloadFactory(DataProcessing):
                         'skims': self.alcaSkims,
                         'PhysicsSkims': self.physicsSkims,
                         'dqmSeq': self.dqmSequences,
+                        'nanoFlavours': self.nanoFlavours,
                         'outputs': recoOutputs}
         if self.globalTagConnect:
             scenarioArgs['globalTagConnect'] = self.globalTagConnect
@@ -179,6 +180,7 @@ class PromptRecoWorkloadFactory(DataProcessing):
                                   "type": makeList, "optional": False, "null": False},
                     "PhysicsSkims": {"default": [], "type": makeList,
                                      "optional": True, "null": False},
+                    "NanoFlavours": {"default": [], "type": makeList, "attr": "nanoFlavours"},
                     "InitCommand": {"default": None, "optional": True, "null": True},
                     "EnvPath": {"default": None, "optional": True, "null": True},
                     "BinPath": {"default": None, "optional": True, "null": True},


### PR DESCRIPTION
Fixes #12234

#### Status
Tested, waiting for review of the produced nanoaod files.
#### Description
The prompt reco workflow will now take a new argument named `NanoFlavours` from T0, and send the `nanoFlavours` argument to the CMSSW helper of the promptReco workflow.


#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
The corresponding T0 PR is: https://github.com/dmwm/T0/pull/5031

#### External dependencies / deployment changes
This development needs to be tested with a CMSSW version that supports the nano flavours