### PR TITLE
Replace couchdb/wmstats uri at WorkflowUpdater config section

### DIFF
--- a/bin/wmagent-mod-config
+++ b/bin/wmagent-mod-config
@@ -293,7 +293,8 @@ def modifyConfiguration(config, **args):
         config.WorkflowUpdater.dbsUrl = args.get("dbs3_reader_url", None)
         config.WorkflowUpdater.rucioUrl = args["rucio_host"]
         config.WorkflowUpdater.rucioAuthUrl = args["rucio_auth"]
-        config.WorkflowUpdater.wmstatsUrl = args["wmstats_url"]
+        if args.get("wmstats_url", None):
+            config.WorkflowUpdater.wmstatsUrl = args["wmstats_url"].replace("couchdb/wmstats", "wmstatsserver")
         if args.get("mspileup_url", None):
             config.WorkflowUpdater.msPileupUrl = args["mspileup_url"]
 


### PR DESCRIPTION
Fixes #12231 

#### Status
ready

#### Description

This is a followup on Alan's request from here: https://github.com/dmwm/WMCore/issues/12231#issuecomment-2599692029 to change the WMStats url for the WorkflowUpdater component to point to the backend WMstats service instead of the couchdb database.   

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
this is a correction to this PR: https://github.com/dmwm/WMCore/pull/12232

#### External dependencies / deployment changes
None
