### PR TITLE
Adjust AlertManagerAPI to avoid using multiple spaces in various attibutes of alert

### DIFF
--- a/src/python/Utils/Utilities.py
+++ b/src/python/Utils/Utilities.py
@@ -297,3 +297,12 @@ def encodeUnicodeToBytesConditional(value, errors="ignore", condition=True):
     if condition:
         return encodeUnicodeToBytes(value, errors)
     return value
+
+def normalize_spaces(text):
+    """
+    Helper function to remove any number of empty spaces within given text and replace
+    then with single space.
+    :param text: string
+    :return: normalized string
+    """
+    return re.sub(r'\s+', ' ', text).strip()

--- a/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
+++ b/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
@@ -605,7 +605,7 @@ class MSTransferor(MSCore):
                                                                          workflowName)
         alertSeverity = "high"
         alertSummary = "[MSTransferor] Transfer document could not be created in CouchDB."
-        alertDescription = "Workflow: {}, failed request  due to error posting to CouchDB".format(workflowName)
+        alertDescription = "Workflow: {}, failed request due to error posting to CouchDB".format(workflowName)
         tag = self.alertDestinationMap.get("alertTransferCouchDBError", "")
         self.sendAlert(alertName, alertSeverity, alertSummary, alertDescription,
                        self.alertServiceName, tag=tag)

--- a/test/python/Utils_t/Utilities_t.py
+++ b/test/python/Utils_t/Utilities_t.py
@@ -8,7 +8,7 @@ import unittest
 
 from Utils.Utilities import makeList, makeNonEmptyList, strToBool, \
     safeStr, rootUrlJoin, zipEncodeStr, lowerCmsHeaders, getSize, \
-    encodeUnicodeToBytes, diskUse, numberCouchProcess
+    encodeUnicodeToBytes, diskUse, numberCouchProcess, normalize_spaces
 
 
 class UtilitiesTests(unittest.TestCase):
@@ -219,6 +219,13 @@ cms::Exception caught in CMS.EventProcessor and rethrown
 
         self.assertTrue(filesystem_is_dev > 0)
 
+    def testNormalizeSpaces(self):
+        """
+        Test the `normalize_spaces` function.
+        """
+        data = normalize_spaces("bla bla     bla    ")
+        expect = "bla bla bla"
+        self.assertEqual(data, expect)
 
     def testNumberCouchProcess(self):
         """


### PR DESCRIPTION
Fixes #11911 

#### Status
ready

#### Description
This PR provides the following set of changes:
- Add new `normalize_spaces` function in AlertManagerAPI and use it for all alert attributes
  - this will strip out all empty spaces with more then 2 space characters
- Add UUID attribute to alert to make it traceable in WM logs
- Add logger printout of alert (including UUID) with `ALERT` prefix when we send it over to Prometheus/AM URL
  - this message will then show in any WM log and become traceable via UUID

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
I modified AlertManager configuration where I performed the following changes:
- https://gitlab.cern.ch/cmsmonitoring/cmsmon-configs/-/merge_requests/69
  - remove personal emails in some routes and instead use either e-group email or another route, e.g. change `wmagent-slack` receiver route to `dmwm-admins`
- https://gitlab.cern.ch/dmwm/wmcore-docs/-/merge_requests/73
  - provides additional documentation

#### External dependencies / deployment changes
