### PR TITLE
Fixes 12112: Replace os.rename with shutil.move

### DIFF
--- a/src/python/WMComponent/WorkflowUpdater/WorkflowUpdaterPoller.py
+++ b/src/python/WMComponent/WorkflowUpdater/WorkflowUpdaterPoller.py
@@ -12,9 +12,10 @@ Among the actions performed by this component, we can list:
 * update this json in the workflow sandbox
 """
 
-import os
 import json
 import logging
+import os
+import shutil
 import tarfile
 import tempfile
 import threading
@@ -220,9 +221,9 @@ def writePileupJson(tfile, jdict, logger, dest=None):
             tar.add(tmpDir, arcname='')
         # overwrite existing tarball with new one
         if dest:
-            os.rename(ofile, dest)
+            shutil.move(ofile, dest)
         else:
-            os.rename(ofile, tfile)
+            shutil.move(ofile, tfile)
 
 
 class WorkflowUpdaterException(WMException):


### PR DESCRIPTION
Fixes #12112 , part of #11978

#### Status
In development

#### Description
Replaces os.rename in WorkflowUpdaterPoller in favor of shutil.move

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
N/A

#### External dependencies / deployment changes
N/A
