### PR TITLE
Register MSTransferor endpoint in REST layer

### DIFF
--- a/src/python/WMCore/MicroService/Service/Data.py
+++ b/src/python/WMCore/MicroService/Service/Data.py
@@ -155,8 +155,6 @@ class Data(with_metaclass(Singleton, RESTEntity, object)):
 
         NOTE: the usage of this method requires further thought
         """
-        msg = 'expect "request" attribute in your request'
-        result = {'status': 'Not supported, %s' % msg, 'request': None}
         try:
             data = json.load(cherrypy.request.body)
             if 'ms-pileup' in self.mount:
@@ -164,12 +162,12 @@ class Data(with_metaclass(Singleton, RESTEntity, object)):
                 for doc in self.mgr.post(data):
                     mspileupError(doc)
                     yield doc
-            elif 'request' in data:
-                # all other MS services
-                reqName = data['request']
-                result = self.mgr.info(reqName)
-                for doc in results(result):
+            elif 'ms-transferor' in self.mount:
+                for doc in self.mgr.post(data):
                     yield doc
+            else:
+                msg = f"End point {self.mount} does not support POST request JSON payload"
+                raise cherrypy.HTTPError(status=400, message=msg) from None
         except cherrypy.HTTPError:
             raise
         except:

--- a/test/python/WMCore_t/MicroService_t/MicroService_t.py
+++ b/test/python/WMCore_t/MicroService_t/MicroService_t.py
@@ -10,6 +10,7 @@ import unittest
 import cherrypy
 import gzip
 import json
+import http.client
 from WMCore_t.MicroService_t import TestConfig
 from WMCore.MicroService.Service.RestApiHub import RestApiHub
 from WMCore.MicroService.Tools.Common import cert, ckey
@@ -153,9 +154,9 @@ class MicroServiceTest(unittest.TestCase):
         url = self.url + "/%s" % api
         params = {"request": "fake_request_name"}
         headers = {'Content-Type': 'application/json'}
-        data = self.mgr.getdata(url, params=params, headers=headers, verb='POST',
-                                cert=cert(), ckey=ckey(), encode=True, decode=True)
-        self.assertDictEqual(data['result'][0], {'status': 'OK', 'api': 'info'})
+        with self.assertRaises(http.client.HTTPException):
+            self.mgr.getdata(url, params=params, headers=headers, verb='POST',
+                             cert=cert(), ckey=ckey(), encode=True, decode=True)
 
     def testPostCallGZipped(self):
         "Test function for getting state of the MicroService"
@@ -163,9 +164,9 @@ class MicroServiceTest(unittest.TestCase):
         url = self.url + "/%s" % api
         params = {"request": "fake_request_name"}
         headers = {'Content-Type': 'application/json', 'Accept-Encoding': 'gzip'}
-        data = self.mgr.getdata(url, params=params, headers=headers, verb='POST',
-                                cert=cert(), ckey=ckey(), encode=True, decode=True)
-        self.assertDictEqual(data['result'][0], {'status': 'OK', 'api': 'info'})
+        with self.assertRaises(http.client.HTTPException):
+            self.mgr.getdata(url, params=params, headers=headers, verb='POST',
+                             cert=cert(), ckey=ckey(), encode=True, decode=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #12040 

#### Status
ready

#### Description
During integration tests I experimentally found that REST end-points are served by `Data.py` module and delegate logic of API call to `MSManager.py`. Therefore, I added proper handling of REST end-point in `Data.py` which calls MSManager post API.

To better clarify HTTP request flow I provide full details how REST layer works in WM web framework.

The REST MicroService layer works in the following way:
- client can send HTTP request (GET/POST/PUT/DELETE) to WM web service, e.g. MicroService
- the request is captured and served by WMCore/MicroService/Service/Data.py
- this module has `def get`, `def post` functions which are used to handle HTTP method of the request
- the WMCore/MicroService/Service/RestApiHub.py hub is used to register service end-point with appropriate Data instance, e.g. `/data/ms-transferor/transferor` end-point where `/data/ms-transferor` is FE redirect and `/transferor` is MS end-point is bound to instance of `Data` class
- the appropriate function, e.g. `def post` of Data class will handle HTTP request and call `self.mgr.post` method of `MSManager` (here `self.mgr` is `MSManager` instance)
- the `def post` of `MSManager` will check the payload and route it to appropriate service API.

Therefore WM REST web framework has three parts:
- end-point registration with `Data` instance
- the HTTP method handler function, e.g. `def post` in `Data` class which calls
- MSManager POST api, e.g. `self.mgr.post` to handle business logic of HTTP request.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
https://github.com/dmwm/WMCore/pull/12155

#### External dependencies / deployment changes
