### PR TITLE
Add WorkQueueTest:testProductionMultiQueue to the unstable unit tests

### DIFF
--- a/test/etc/UnstableTests.txt
+++ b/test/etc/UnstableTests.txt
@@ -31,3 +31,4 @@ WMCore_t.Services_t.Rucio_t.RucioUtils_t.RucioUtilsTest:testWeightedChoice
 WMCore_t.WMBS_t.JobSplitting_t.RunBased_t.EventBasedTest:testMultipleRunsCombine
 WMCore_t.WorkQueue_t.Policy_t.Start_t.Block_t.BlockTestCase:testPileupData
 WMCore_t.WorkQueue_t.WorkQueue_t.WorkQueueTest:testThrottling
+WMCore_t.WorkQueue_t.WorkQueue_t.WorkQueueTest:testProductionMultiQueue


### PR DESCRIPTION
Fixes  (no issue created, but it's been reported in https://github.com/dmwm/WMCore/pull/12241#issuecomment-2619744115)

#### Status
ready

#### Description
Add `WMCore_t.WorkQueue_t.WorkQueue_t.WorkQueueTest:testProductionMultiQueue` to the list of unstable unit tests.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None