### PR TITLE
Replace ddm_quota with dm_weight

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -379,7 +379,7 @@ config.RucioInjector.cacheExpiration = 2 * 24 * 60 * 60  # two days
 config.RucioInjector.createBlockRules = True
 config.RucioInjector.RSEPostfix = False  # enable it to append _Test to the RSE names
 config.RucioInjector.metaDIDProject = "Production"
-config.RucioInjector.containerDiskRuleParams = {"weight": "ddm_quota", "copies": 2, "grouping": "DATASET"}
+config.RucioInjector.containerDiskRuleParams = {"weight": "dm_weight", "copies": 2, "grouping": "DATASET"}
 config.RucioInjector.blockRuleParams = {}
 # this RSEExpr below might be updated by wmagent-mod-config script
 config.RucioInjector.containerDiskRuleRSEExpr = "(tier=2|tier=1)&cms_type=real&rse_type=DISK"

--- a/src/python/WMCore/MicroService/MSOutput/MSOutput.py
+++ b/src/python/WMCore/MicroService/MSOutput/MSOutput.py
@@ -88,7 +88,7 @@ class MSOutput(MSCore):
         self.msConfig.setdefault("excludeDataTier", [])
         self.msConfig.setdefault("rucioAccount", 'wmcore_transferor')
         self.msConfig.setdefault("rucioRSEAttribute", 'dm_weight')
-        self.msConfig.setdefault("rucioDiskRuleWeight", 'ddm_quota')
+        self.msConfig.setdefault("rucioDiskRuleWeight", 'dm_weight')
         self.msConfig.setdefault("rucioTapeExpression", 'rse_type=TAPE\cms_type=test')
         # This Disk expression wil target all real DISK T1 and T2 RSEs
         self.msConfig.setdefault("rucioDiskExpression", '(tier=2|tier=1)&cms_type=real&rse_type=DISK')
@@ -462,8 +462,7 @@ class MSOutput(MSCore):
         """
         # This API returns a tuple with the RSE name and whether it requires approval
         return self.rucio.pickRSE(rseExpression=self.msConfig["rucioTapeExpression"],
-                                  rseAttribute=self.msConfig["rucioRSEAttribute"],
-                                  minNeeded=dataSize)
+                                  rseAttribute=self.msConfig["rucioRSEAttribute"])
 
     def getRequestRecords(self, reqStatus):
         """

--- a/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
+++ b/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
@@ -91,7 +91,7 @@ class MSTransferor(MSCore):
         # Set to negative to ignore.
         self.msConfig.setdefault("warningTransferThreshold", 100. * (1000 ** 4))  # 100TB
         # weight expression for the input replication rules
-        self.msConfig.setdefault("rucioRuleWeight", 'ddm_quota')
+        self.msConfig.setdefault("rucioRuleWeight", 'dm_weight')
         # Workflows with open running timeout are used for growing input dataset, thus
         # make a container level rule for the whole container whenever the open running
         # timeout is larger than what is configured (or the default of 7 days below)

--- a/src/python/WMCore/Services/Rucio/Rucio.py
+++ b/src/python/WMCore/Services/Rucio/Rucio.py
@@ -10,9 +10,10 @@ from __future__ import division, print_function, absolute_import
 from builtins import str, object
 from future.utils import viewitems, viewvalues
 
+from copy import deepcopy
 import json
 import logging
-from copy import deepcopy
+
 from rucio.client import Client
 from rucio.common.exception import (AccountNotFound, DataIdentifierNotFound, AccessDenied, DuplicateRule,
                                     DataIdentifierAlreadyExists, DuplicateContent, InvalidRSEExpression,
@@ -764,7 +765,7 @@ class Rucio(object):
             return matchingRSEs
         return dropTapeRSEs(matchingRSEs)
 
-    def pickRSE(self, rseExpression='rse_type=TAPE\cms_type=test', rseAttribute='ddm_quota', minNeeded=0):
+    def pickRSE(self, rseExpression='rse_type=TAPE\cms_type=test', rseAttribute='dm_weight'):
         """
         _pickRSE_
 
@@ -772,7 +773,6 @@ class Rucio(object):
         The attribute should correlate to space available.
         :param rseExpression: Rucio RSE expression to pick RSEs (defaults to production Tape RSEs)
         :param rseAttribute: The RSE attribute to use as a weight. Must be a number
-        :param minNeeded: If the RSE attribute is less than this number, the RSE will not be considered.
 
         Returns: A tuple of the chosen RSE and if the chosen RSE requires approval to write (rule property)
         """
@@ -790,12 +790,8 @@ class Rucio(object):
             else:
                 attrValue = 1
             requiresApproval = rseAttrs.get('requires_approval', False)
-            if rseAttribute == "ddm_quota" and attrValue > minNeeded:
-                rsesWithApproval.append((rse, requiresApproval))
-                rsesWeight.append(attrValue)
-            elif rseAttribute != "ddm_quota":  # e.g. dm_weight
-                rsesWithApproval.append((rse, requiresApproval))
-                rsesWeight.append(attrValue)
+            rsesWithApproval.append((rse, requiresApproval))
+            rsesWeight.append(attrValue)
 
         return weightedChoice(rsesWithApproval, rsesWeight)
 

--- a/test/python/WMComponent_t/RucioInjector_t/RucioInjectorPoller_t.py
+++ b/test/python/WMComponent_t/RucioInjector_t/RucioInjectorPoller_t.py
@@ -76,7 +76,7 @@ class RucioInjectorPollerTest(EmulatedUnitTestCase):
         config.RucioInjector.createBlockRules = True
         config.RucioInjector.RSEPostfix = False  # enable it to append _Test to the RSE names
         config.RucioInjector.metaDIDProject = "Production"
-        config.RucioInjector.containerDiskRuleParams = {"weight": "ddm_quota", "copies": 2, "grouping": "DATASET"}
+        config.RucioInjector.containerDiskRuleParams = {"weight": "dm_weight", "copies": 2, "grouping": "DATASET"}
         config.RucioInjector.blockRuleParams = {}
         config.RucioInjector.containerDiskRuleRSEExpr = "(tier=2|tier=1)&cms_type=real&rse_type=DISK"
         config.RucioInjector.rucioAccount = "wma_test"

--- a/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
+++ b/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
@@ -400,7 +400,7 @@ class RucioTest(EmulatedUnitTestCase):
         Test the `pickRSE` method
         """
         print(self.myRucio.cli.list_rse_attributes("T1_US_FNAL_Disk"))
-        resp = self.myRucio.pickRSE(rseExpression="ddm_quota>0", rseAttribute="ddm_quota")
+        resp = self.myRucio.pickRSE(rseExpression="dm_weight>0", rseAttribute="dm_weight")
         self.assertTrue(len(resp) == 2)
         self.assertTrue(resp[1] is True or resp[1] is False)
 


### PR DESCRIPTION
Also added a deprecation warning

Fixes #12055 

#### Status
In development

#### Description
Changes the rseAttribute used for RSE quota from ddm_quota to dm_weight

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
[Merge Request in services_config](https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/350)

#### External dependencies / deployment changes
N/A