### PR TITLE
Renaming RequestPriority during WorQueue.updateElements call

### DIFF
--- a/src/python/WMCore/Services/WorkQueue/WorkQueue.py
+++ b/src/python/WMCore/Services/WorkQueue/WorkQueue.py
@@ -200,6 +200,8 @@ class WorkQueue(object):
         if not elementIds:
             return
         eleParams = {}
+        if 'RequestPriority' in updatedParams:
+            updatedParams['Priority'] = updatedParams.pop('RequestPriority')
         eleParams[self.eleKey] = updatedParams
         conflictIDs = self.db.updateBulkDocumentsWithConflictHandle(elementIds, eleParams, maxConflictLimit=20)
         if conflictIDs:


### PR DESCRIPTION
Fixes #12247 

#### Status
ready && tested

#### Description
With the current PR we rename the `RequestPriority` parameter that comes with the dictionary of arguments during the call of `WorkQueue.updateElements` method. By that we mitigate the consequences of the  fact that the priority parameter name differs between the WorkQueueelement and the Workflow descriptions.  

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
N/A
