### PR TITLE
Add support for microarchitecture

### DIFF
--- a/test/python/WMCore_t/Services_t/TagCollector_t/TagCollector_t.py
+++ b/test/python/WMCore_t/Services_t/TagCollector_t/TagCollector_t.py
@@ -26,12 +26,21 @@ class TagCollectorTest(unittest.TestCase):
         releases = self.tagCollecor.releases()
         architectures = self.tagCollecor.architectures()
         realsese_by_arch = self.tagCollecor.releases_by_architecture()
+        microarch_by_release = self.tagCollecor.defaultMicroArchVersionNumberByRelease()
+        microarch_testCMSSW_15 = self.tagCollecor.getGreaterMicroarchVersionNumber("CMSSW_15_0_0_pre3")
+        microarch_testCMSSW_12_15 = self.tagCollecor.getGreaterMicroarchVersionNumber("CMSSW_12_4_0_pre2,CMSSW_15_0_0_pre3")
+        microarch_testCMSSW_7_12 = self.tagCollecor.getGreaterMicroarchVersionNumber("CMSSW_7_1_10_patch2,CMSSW_12_4_0_pre2", rel_microarchs=microarch_by_release)
         self.assertIn('CMSSW_7_1_10_patch2', releases)
         self.assertIn('slc6_amd64_gcc493', architectures)
         self.assertIn('slc7_amd64_gcc620', architectures)
         self.assertEqual(len(architectures), len(realsese_by_arch))
         self.assertEqual(sorted(self.tagCollecor.releases('slc6_amd64_gcc493')),
                          sorted(realsese_by_arch.get('slc6_amd64_gcc493')))
+        self.assertEqual(0, microarch_by_release['CMSSW_7_1_10_patch2'])
+        self.assertEqual(3, microarch_by_release['CMSSW_15_0_0_pre3'])
+        self.assertEqual(3, microarch_testCMSSW_12_15)
+        self.assertEqual(3, microarch_testCMSSW_15)
+        self.assertEqual(0, microarch_testCMSSW_7_12)
 
         return
 


### PR DESCRIPTION
Fixes #12168

#### Status
Ready

#### Description
Adds minimum microarchitecture classad based on Tag Collector information.
For x86 architecture, default to "2" when information not in Tag Collector.
When non-x86 arch in list of required architectures, return "0" instead

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
Tag Collector URL
