### PR TITLE
debugging open express workflows

### DIFF
--- a/src/python/WMCore/JobSplitting/SiblingProcessingBased.py
+++ b/src/python/WMCore/JobSplitting/SiblingProcessingBased.py
@@ -41,6 +41,7 @@ class SiblingProcessingBased(JobFactory):
         if self.subscription["fileset"].open == True:
             filesetClosed = False
         else:
+            a = Adding_Bug_For_Testing_Purposes
             fileFailed = daoFactory(classname = "Subscriptions.SiblingSubscriptionsFailed")
             fileFailed.execute(self.subscription["id"],
                                self.subscription["fileset"].id,

--- a/src/python/WMCore/WMSpec/StdSpecs/DQMHarvest.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/DQMHarvest.py
@@ -83,7 +83,11 @@ class DQMHarvestWorkloadFactory(DataProcessing):
 
         harvestTask = self.workload.newTask("%sDQMHarvest" % harvestType)
 
-        self.addRuntimeMonitors(harvestTask)
+        if periodic_harvest_sibling:
+            self.addRuntimeMonitors(harvestTask, mem=0.1)
+        else:
+            self.addRuntimeMonitors(harvestTask)
+        
         harvestTaskCmssw = harvestTask.makeStep("cmsRun1")
         harvestTaskCmssw.setStepType("CMSSW")
 

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -249,7 +249,7 @@ class StdBase(object):
 
         return outputModules
 
-    def addRuntimeMonitors(self, task):
+    def addRuntimeMonitors(self, task, mem=2.3):
         """
         _addRuntimeMonitors_
 
@@ -257,7 +257,8 @@ class StdBase(object):
         Memory settings are defined in Megabytes and timing in seconds.
         """
         # Default settings defined by CMS policy
-        maxpss = 2.3 * 1024  # 2.3 GiB, but in MiB
+        logging.info("+++ Setting memory to {} for task type {}".format(mem, task.taskType()))
+        maxpss = mem * 1024  # 2.3 GiB, but in MiB
         softTimeout = 47 * 3600  # 47h
         hardTimeout = 47 * 3600 + 5 * 60  # 47h + 5 minutes
 


### PR DESCRIPTION
Fixes #12272

#### Status
For debugging purposes, not for merging

#### Description
We suspect there is an error in the logic of sibling harvesting jobs. Every time a sibling harvesting job is failed, the files remain in acquired state, and never make it to failed state. This means that the fileset and subscription are never closed and the workflow remains open until manual intervention in the database. The investigation so far is documented in https://gitlab.cern.ch/dmwm/wmcore-docs/-/issues/3

#### Is it backward compatible (if not, which system it affects?)
Not Applicable 
#### Related PRs
None 

#### External dependencies / deployment changes
None
