### PR TITLE
fix usage of requirements.<pkg>.txt as part of the matrix.target

### DIFF
--- a/.github/workflows/build_and_install_locally.yaml
+++ b/.github/workflows/build_and_install_locally.yaml
@@ -44,8 +44,8 @@ jobs:
       - name: Create requirements file
         run: |
           echo "create new requirements.txt without gfal dependencies for CI/CD"
-          cat requirements.txt | egrep -v "gfal" requirements.$pkg.txt
-          awk "/(${{ matrix.target }}$)|(${{ matrix.target }},)/ {print \$1}" requirements.$pkg.txt > requirements.txt
+          cat requirements.txt | egrep -v "gfal" requirements.${{ matrix.target }}.txt
+          awk "/(${{ matrix.target }}$)|(${{ matrix.target }},)/ {print \$1}" requirements.${{ matrix.target }}.txt > requirements.txt
 
       - name: Build sdist and wheels
         run: python3 setup.py clean sdist bdist_wheel


### PR DESCRIPTION
Fixes #12256 

#### Status
ready but not-tested until GitHub Action will be run

#### Description
Bug fix in new CI/CD pipeline to properly use `requirements.<pkg>.txt` as part of the matrix.target

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
https://github.com/dmwm/WMCore/pull/12259

#### External dependencies / deployment changes
