### PR TITLE
Fix redirect command to create new requirements.<pkg>.txt

### DIFF
--- a/.github/workflows/build_and_install_locally.yaml
+++ b/.github/workflows/build_and_install_locally.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Create requirements file
         run: |
           echo "create new requirements.txt without gfal dependencies for CI/CD"
-          cat requirements.txt | egrep -v "gfal" requirements.${{ matrix.target }}.txt
+          cat requirements.txt | egrep -v "gfal" > requirements.${{ matrix.target }}.txt
           awk "/(${{ matrix.target }}$)|(${{ matrix.target }},)/ {print \$1}" requirements.${{ matrix.target }}.txt > requirements.txt
 
       - name: Build sdist and wheels


### PR DESCRIPTION
Fixes #12256 

#### Status
ready but not tested due to new CI/CD pipeline which can only be tested within GitHub Actions

#### Description
Fix bug to create new requirements file

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
- https://github.com/dmwm/WMCore/pull/12273
- https://github.com/dmwm/WMCore/pull/12259

#### External dependencies / deployment changes
