### PR TITLE
Add wheel package to install WMCore wheels

### DIFF
--- a/.github/workflows/build_and_install_locally.yaml
+++ b/.github/workflows/build_and_install_locally.yaml
@@ -48,7 +48,11 @@ jobs:
           awk "/(${{ matrix.target }}$)|(${{ matrix.target }},)/ {print \$1}" requirements.${{ matrix.target }}.txt > requirements.txt
 
       - name: Build sdist and wheels
-        run: python3 setup.py clean sdist bdist_wheel
+        run: |
+          echo "install wheel package from pip to build wheels"
+          pip install wheel
+          echo "build WMCore sdist and wheels"
+          python3 setup.py clean sdist bdist_wheel
 
       - name: Verify built package
         run: ls -lh dist/


### PR DESCRIPTION
Fixes #12256 

#### Status
ready but not tested due to CI/CD pipeline in GitHub

#### Description
Added wheel python package to allow installing python tar-balls and wheels

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
- https://github.com/dmwm/WMCore/pull/12259
- https://github.com/dmwm/WMCore/pull/12273
- https://github.com/dmwm/WMCore/pull/12274
 
#### External dependencies / deployment changes
