### PR TITLE
Disable wheels package installation due to broken pycurl

### DIFF
--- a/.github/workflows/build_and_install_locally.yaml
+++ b/.github/workflows/build_and_install_locally.yaml
@@ -47,12 +47,10 @@ jobs:
           cat requirements.txt | egrep -v "gfal" > requirements.${{ matrix.target }}.txt
           awk "/(${{ matrix.target }}$)|(${{ matrix.target }},)/ {print \$1}" requirements.${{ matrix.target }}.txt > requirements.txt
 
-      - name: Build sdist and wheels
+      - name: Build sdist
         run: |
-          echo "install wheel package from pip to build wheels"
-          pip install wheel
           echo "build WMCore sdist and wheels"
-          python3 setup.py clean sdist bdist_wheel
+          python3 setup.py clean sdist
 
       - name: Verify built package
         run: ls -lh dist/


### PR DESCRIPTION
Fixes #12256 

#### Status
ready but not tested due to CI/CD run in GitHub Action

#### Description
Found that new CI/CD pipeline can't build wheel package due to broken pycurl build, see details in here
https://github.com/dmwm/WMCore/actions/runs/13526049894/job/37796756053

Therefore, disable build of wheels packages (usually those are available in pypi for python packages).

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Here is list of PRs fixing new CI/CD pipeline:
- [dmwm/WMCore#12273](https://github.com/dmwm/WMCore/pull/12273)
- [dmwm/WMCore#12274](https://github.com/dmwm/WMCore/pull/12274), simple typo in redirect
- [dmwm/WMCore#12275](https://github.com/dmwm/WMCore/pull/12275), added wheel python package to build wheels

#### External dependencies / deployment changes
