### PR TITLE
Added pycurl dev library which provides curl-config required for pycurl

### DIFF
--- a/.github/workflows/build_and_install_locally.yaml
+++ b/.github/workflows/build_and_install_locally.yaml
@@ -33,6 +33,12 @@ jobs:
         with:
           python-version: "3.8"
 
+      - name: Update system packages to include pycurl
+        run: |
+          echo "update system packages to include pycurl dev librarty (required for pycurl)"
+          sudo apt update
+          sudo apt install -y curl libcurl4-openssl-dev
+
       - name: Upgrade pip3
         run: |
           python3 -m pip install --upgrade pip
@@ -47,10 +53,12 @@ jobs:
           cat requirements.txt | egrep -v "gfal" > requirements.${{ matrix.target }}.txt
           awk "/(${{ matrix.target }}$)|(${{ matrix.target }},)/ {print \$1}" requirements.${{ matrix.target }}.txt > requirements.txt
 
-      - name: Build sdist
+      - name: Build sdist and bdist_wheel
         run: |
+          echo "install wheel package from pip to build wheels"
+          pip install wheel
           echo "build WMCore sdist and wheels"
-          python3 setup.py clean sdist
+          python3 setup.py clean sdist bdist_wheel
 
       - name: Verify built package
         run: ls -lh dist/


### PR DESCRIPTION
Fixes #12256 

#### Status
ready but not tested due to GitHub Actions CI/CD pipeline

#### Description
Added curl dev library to CI/CD pipeline which suppose to provide `curl-config` which is required for `pycurl` installation on a system

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
- [dmwm/WMCore#12273](https://github.com/dmwm/WMCore/pull/12273)
- [dmwm/WMCore#12274](https://github.com/dmwm/WMCore/pull/12274), simple typo in redirect
- [dmwm/WMCore#12275](https://github.com/dmwm/WMCore/pull/12275), added wheel python package to build wheels
- [dmwm/WMCore#12276](https://github.com/dmwm/WMCore/pull/12276) disable wheels builds

Turns out the actual issue is missing `curl-config` on Ubuntu system rather the wheel build package.

#### External dependencies / deployment changes
