### PR TITLE
Add appropriate tags and destination for alert routing

### DIFF
--- a/deploy/WMAgent.production
+++ b/deploy/WMAgent.production
@@ -10,6 +10,7 @@ COUCH_PORT=5984
 COUCH_HOST=127.0.0.1
 COUCH_CERT_FILE=/data/certs/servicecert.pem
 COUCH_KEY_FILE=/data/certs/servicekey.pem
+ALERT_EMAILS=
 GLOBAL_WORKQUEUE_URL=https://cmsweb.cern.ch/couchdb/workqueue
 WMSTATS_URL=https://cmsweb.cern.ch/couchdb/wmstats
 ACDC_URL=https://cmsweb.cern.ch/couchdb/acdcserver

--- a/deploy/WMAgent.testbed
+++ b/deploy/WMAgent.testbed
@@ -10,6 +10,7 @@ COUCH_PORT=5984
 COUCH_HOST=127.0.0.1
 COUCH_CERT_FILE=/data/certs/servicecert.pem
 COUCH_KEY_FILE=/data/certs/servicekey.pem
+ALERT_EMAILS=
 GLOBAL_WORKQUEUE_URL=https://cmsweb-testbed.cern.ch/couchdb/workqueue
 WMSTATS_URL=https://cmsweb-testbed.cern.ch/couchdb/wmstats
 ACDC_URL=https://cmsweb-testbed.cern.ch/couchdb/acdcserver

--- a/deploy/restartComponent.sh
+++ b/deploy/restartComponent.sh
@@ -8,7 +8,11 @@
 
 HOST=$(hostname)
 DATENOW=$(date +%s)
-DEST_NAME=cms-wmcore-team
+# look-up alert emails from WMA secret file where ALERT_EMAILS may contains multiple emails and spaces, e.g.
+# ALERT_EMAILS="user1@domain.com user2@domain.com" or ALERT_EMAILS = "user1@domain.com user2@domain.com"
+ALERT_EMAILS=`sed -E 's/^[[:space:]]*ALERT_EMAILS[[:space:]]*=[[:space:]]*"([^"]*)".*/\1/' $WMA_SECRETS_FILE`
+
+[[ -z $ALERT_EMAILS ]] && {echo "ERROR: unable to find ALERT_EMAILS in $WMA_SECRETS_FILE"; exit 1;}
 
 [[ -z $WMA_INSTALL_DIR ]] && { echo "ERROR: Trying to run without having the full WMAgent environment set!";  exit 1 ;}
 
@@ -34,7 +38,7 @@ for comp in $comps; do
     echo -e "Restarting component: $comp"
     manage execute-agent wmcoreD --restart --components=$comp
     echo -e "ComponentLog quiet for $INTERVAL secs\n\nTail of the log is:\n$TAIL_LOG" |
-      mail -s "$HOST : $comp restarted" $DEST_NAME@cern.ch
+      mail -s "$HOST : $comp restarted" $ALERT_EMAILS
   fi
 done
 

--- a/src/python/WMCore/MicroService/MSCore/MSCore.py
+++ b/src/python/WMCore/MicroService/MSCore/MSCore.py
@@ -50,6 +50,8 @@ class MSCore(object):
                                configDict={"logger": self.logger, "user_agent": "wmcore-microservices"})
         self.alertManagerUrl = self.msConfig.get("alertManagerUrl", None)
         self.alertManagerApi = AlertManagerAPI(self.alertManagerUrl, logger=self.logger)
+        # alertDestinationMap is used to define alert routes
+        self.alertDestinationMap = self.msConfig.get("alertDestinationMap", {})
 
     def unifiedConfig(self):
         """
@@ -92,7 +94,7 @@ class MSCore(object):
             reportDict[keyName] = value
         return reportDict
 
-    def sendAlert(self, alertName, severity, summary, description, service, endSecs=1 * 60 * 60):
+    def sendAlert(self, alertName, severity, summary, description, service, tag=None, endSecs=1 * 60 * 60):
         """
         Sends an alert to Prometheus.
         :param alertName: string with unique alert name
@@ -100,11 +102,12 @@ class MSCore(object):
         :param summary: string with a short summary of the alert
         :param description: string with a longer description of the alert
         :param service: string with the service name generating this alert
+        :param tag: string representing desired alert's tag, it can use commas to assign multiple tags, e.g. tag1,tag2
         :param endSecs: integer with an expiration time
         :return: none
         """
         try:
             self.alertManagerApi.sendAlert(alertName, severity, summary, description,
-                                           service, endSecs=endSecs)
+                                           service, tag=tag, endSecs=endSecs)
         except Exception as ex:
             self.logger.exception("Failed to send alert to %s. Error: %s", self.alertManagerUrl, str(ex))

--- a/src/python/WMCore/MicroService/MSOutput/MSOutput.py
+++ b/src/python/WMCore/MicroService/MSOutput/MSOutput.py
@@ -1011,7 +1011,9 @@ class MSOutput(MSCore):
         alertDescription += " In order to get output data placement working, add it ASAP please."
         self.logger.critical(alertDescription)
         if self.msConfig["sendNotification"]:
-            self.sendAlert(alertName, alertSeverity, alertSummary, alertDescription, self.alertServiceName)
+            tag = self.alertDestinationMap.get("alertCampaignNotFound", "")
+            self.sendAlert(alertName, alertSeverity, alertSummary, alertDescription,
+                           self.alertServiceName, tag=tag)
 
     def alertDatatierNotFound(self, datatierName, containerName, isRelVal):
         """
@@ -1029,7 +1031,9 @@ class MSOutput(MSCore):
         alertDescription += "Please add it ASAP. Letting it pass for now..."
         self.logger.critical(alertDescription)
         if self.msConfig["sendNotification"] and not isRelVal:
-            self.sendAlert(alertName, alertSeverity, alertSummary, alertDescription, self.alertServiceName)
+            tag = self.alertDestinationMap.get("alertDatatierNotFound", "")
+            self.sendAlert(alertName, alertSeverity, alertSummary, alertDescription,
+                           self.alertServiceName, tag=tag)
 
     def alertGenericError(self, caller, workflowname, msg, exMsg, document):
         """
@@ -1048,6 +1052,8 @@ class MSOutput(MSCore):
         alertDescription = "wf: {}\n\nmsg: {}\n\nex: {}\n\n{}".format(workflowname, msg, exMsg, document)
         self.logger.error("%s\n%s\n%s", alertName, alertSummary, alertDescription)
         if self.msConfig["sendNotification"]:
-            self.sendAlert(alertName, alertSeverity, alertSummary, alertDescription, self.alertServiceName)
+            tag = self.alertDestinationMap.get("alertGenericError", "")
+            self.sendAlert(alertName, alertSeverity, alertSummary, alertDescription,
+                           self.alertServiceName, tag=tag)
 
 

--- a/src/python/WMCore/MicroService/MSRuleCleaner/MSRuleCleaner.py
+++ b/src/python/WMCore/MicroService/MSRuleCleaner/MSRuleCleaner.py
@@ -806,6 +806,7 @@ class MSRuleCleaner(MSCore):
         # Check if alarms are enabled for this service
         # Alert expiration time defaults to 2 days
         if self.msConfig["sendNotification"]:
+            tag = self.alertDestinationMap.get("alertStatusAdvanceExpired", "")
             self.sendAlert(alertName, alertSeverity, alertSummary, alertDescription,
-                           service=self.alertServiceName, endSecs=self.alertExpiration)
+                           service=self.alertServiceName, endSecs=self.alertExpiration, tag=tag)
         self.logger.critical(alertDescription)

--- a/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
+++ b/src/python/WMCore/MicroService/MSTransferor/MSTransferor.py
@@ -579,8 +579,9 @@ class MSTransferor(MSCore):
         alertSummary = "[MSTransferor] Workflow cannot proceed due to some PU misconfiguration."
         alertDescription = "Workflow: {} could not proceed due to some PU misconfiguration,".format(workflowName)
         alertDescription += "so it will be skipped."
+        tag = self.alertDestinationMap.get("alertPUMisconfig", "")
         self.sendAlert(alertName, alertSeverity, alertSummary, alertDescription,
-                       self.alertServiceName)
+                       self.alertServiceName, tag=tag)
         self.logger.critical(alertDescription)
 
     def alertUnknownTransferError(self, workflowName):
@@ -592,8 +593,9 @@ class MSTransferor(MSCore):
         alertSeverity = "high"
         alertSummary = "[MSTransferor] Unknown exception while making transfer request."
         alertDescription = "Unknown exception while making Transfer request for workflow: {}".format(workflowName)
+        tag = self.alertDestinationMap.get("alertUnknownTransferError", "")
         self.sendAlert(alertName, alertSeverity, alertSummary, alertDescription,
-                       self.alertServiceName)
+                       self.alertServiceName, tag=tag)
 
     def alertTransferCouchDBError(self, workflowName):
         """
@@ -604,8 +606,9 @@ class MSTransferor(MSCore):
         alertSeverity = "high"
         alertSummary = "[MSTransferor] Transfer document could not be created in CouchDB."
         alertDescription = "Workflow: {}, failed request  due to error posting to CouchDB".format(workflowName)
+        tag = self.alertDestinationMap.get("alertTransferCouchDBError", "")
         self.sendAlert(alertName, alertSeverity, alertSummary, alertDescription,
-                       self.alertServiceName)
+                       self.alertServiceName, tag=tag)
         self.logger.warning(alertDescription)
 
 
@@ -628,9 +631,9 @@ class MSTransferor(MSCore):
             alertDescription = "Workflow: {} has a large amount of ".format(wflowName)
             alertDescription += "data subscribed: {} TB, ".format(teraBytes(dataSize))
             alertDescription += "for {} data: {}.""".format(dataIn['type'], dataIn['name'])
-
+            tag = self.alertDestinationMap.get("alertLargeInputData", "")
             self.sendAlert(alertName, alertSeverity, alertSummary, alertDescription,
-                           self.alertServiceName)
+                           self.alertServiceName, tag=tag)
             self.logger.warning(alertDescription)
 
     def _getValidSites(self, wflow, dataIn):


### PR DESCRIPTION
Fixes #11911 

#### Status
ready

#### Description
Add necessary tags to sendAlert method to allow matching them with appropriate CMS Monitoring AlertManager, see https://its.cern.ch/jira/browse/CMSMONIT-632. The proposed changes include the following:
- add `tag` parameter to sendAlert of MSCore class (as it is passed to AlertManagerAPI)
- provide different tag values based on discussion presented in this [spreadsheet](https://docs.google.com/spreadsheets/d/1KJ_EuD1k-RY2mnqhjpCLLwg6lTVkKma_4aLGFZ1JoLk/edit?usp=sharing)
- adjust `deploy/restartComponent.sh` script to include various destination including WM, PNR, Tier0 groups

With proposed changes a `tag="email-dmdm,email-pnr,alerts-pnr"` will allow various matching in AlertManager configuration which will look at a specific pattern, e.g. `email-pnr` and route this alert to assigned e-group email. The tag comma separated values is appropriate syntax to specify list of tags we want to use for matching alert in AM configuration.

To make alerts routes configurable we propose to use the following map in MS service configuration files, e.g.
```
data.alertDestinationMap = {
    "alertCampaignNotFound": "alerts-pnr",
    "alertDatatierNotFound": "alerts-pnr",
    "alertGenericError": "alerts-dmwm,alerts-pnr,email-dmwm,email-pnr",
    "alertStatusAdvanceExpired": "alerts-pnr",
    "alertPUMisconfig": "email-pnr,alerts-pnr",
    "alertUnknownTransferError": "email-dmdm,email-pnr,alerts-pnr",
    "alertTransferCouchDBError": "email-dmdm,email-pnr,alerts-pnr",
    "alertLargeInputData": "alerts-pnr"
}
```
where each map entry defines function is used in WM codebase and corresponding alert tag(s). This will allow to properly configure services with different alert destination map. For instance, for production cluster we can add email alerts while for preprod we can use only MM alerts and we may have empty map for dev cluster (in this case alert will not be routed since no tags will be provided, but the code will still send the alert to CMS Monitoring, i.e. the alert can be found but there would be no routes/notifications).

**NOTE:** If we merge this PR we'll need to update relative configuration files to introduce `data.alertDestinationMap` for MSOutput, MSRuleCleaner and MSTransferor services.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
- https://gitlab.cern.ch/dmwm/wmcore-docs/-/merge_requests/73 for documentation update
- https://github.com/dmwm/WMCore/pull/12237, adjusting AlertManagerAPI, spaces, etc.
- https://its.cern.ch/jira/browse/CMSMONIT-632, request for different routes in AlertManager configuration
- configuration change for
   - production branch: https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/360
   - preprod branch: https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/361
#### External dependencies / deployment changes
