### PR TITLE
Introducing createDebuggingCommand in all the stageout submodules

### DIFF
--- a/src/python/WMCore/Storage/Backends/AWSS3Impl.py
+++ b/src/python/WMCore/Storage/Backends/AWSS3Impl.py
@@ -56,6 +56,26 @@ class AWSS3Impl(StageOutImpl):
             """ % self.createRemoveFileCommand(targetPFN)
 
         return result
+    
+    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+        """
+        Debug a failed aws s3 copy command for stageOut, without re-running it,
+        providing information on the environment and the certifications
+
+        :sourcePFN: str, PFN of the source file
+        :targetPFN: str, destination PFN
+        :options: str, additional options for copy command
+        :checksums: dict, collect checksums according to the algorithms saved as keys
+        """
+        # Build the command for debugging purposes
+        copyCommand = "aws s3 cp"
+        if options != None:
+            copyCommand += " %s " % options
+        copyCommand += " %s " % sourcePFN
+        copyCommand += " %s \n" % targetPFN
+
+        result = self.debuggingTemplate.format(copy_command=copyCommand, source=sourcePFN, destination=targetPFN)
+        return result
 
     def removeFile(self, pfnToRemove):
         """

--- a/src/python/WMCore/Storage/Backends/CPImpl.py
+++ b/src/python/WMCore/Storage/Backends/CPImpl.py
@@ -82,6 +82,35 @@ class CPImpl(StageOutImpl):
 
         return copyCommand
 
+    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+        """
+        Debug a failed cp command for stageOut, without re-running it,
+        providing information on the environment and the certifications
+
+        :sourcePFN: str, PFN of the source file
+        :targetPFN: str, destination PFN
+        :options: str, additional options for copy command
+        :checksums: dict, collect checksums according to the algorithms saved as keys
+        """
+        # Build the command for debugging purposes
+        copyCommand = ""
+
+        if self.stageIn:
+            remotePFN, localPFN = sourcePFN, targetPFN
+        else:
+            remotePFN, localPFN = targetPFN, sourcePFN
+            copyCommand += "LOCAL_SIZE=`stat -c%%s %s`\n" % localPFN
+            copyCommand += "echo \"Local File Size is: $LOCAL_SIZE\"\n"
+
+        copyCommand += "cp %s %s\n" % (sourcePFN, targetPFN)
+
+        if self.stageIn:
+            copyCommand += "LOCAL_SIZE=`stat -c%%s %s`\n" % localPFN
+            copyCommand += "echo \"Local File Size is: $LOCAL_SIZE\"\n"
+
+        result = self.debuggingTemplate.format(copy_command=copyCommand, source=sourcePFN, destination=remotePFN)
+        return result
+
     def removeFile(self, pfnToRemove):
         """
         _removeFile_

--- a/src/python/WMCore/Storage/Backends/GFAL2Impl.py
+++ b/src/python/WMCore/Storage/Backends/GFAL2Impl.py
@@ -182,13 +182,6 @@ class GFAL2Impl(StageOutImpl):
         echo "Source PFN: {source}"
         echo "Target PFN: {destination}"
         echo
-        echo
-        echo "Information for credentials in the environment"
-        echo "Bearer token content: $BEARER_TOKEN"
-        echo "Bearer token file: $BEARER_TOKEN_FILE"
-        echo "httokendecode path: $(which httokendecode)"
-        echo "httokendecode: $httokendecode"
-        echo
         echo "VOMS proxy info:"
         voms-proxy-info -all
         echo "==========================================================="

--- a/src/python/WMCore/Storage/Backends/LCGImpl.py
+++ b/src/python/WMCore/Storage/Backends/LCGImpl.py
@@ -199,6 +199,26 @@ class LCGImpl(StageOutImpl):
 
         return result
 
+    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+        """
+        Debug a failed lcg-via smrv copy command for stageOut, without re-running it,
+        providing information on the environment and the certifications
+
+        :sourcePFN: str, PFN of the source file
+        :targetPFN: str, destination PFN
+        :options: str, additional options for copy command
+        :checksums: dict, collect checksums according to the algorithms saved as keys
+        """
+        # Build the command for debugging purposes
+        copyCommand = "lcg-cp -b -D srmv2 --vo cms --srm-timeout 2400 --sendreceive-timeout 2400 --connect-timeout 300 --verbose"
+        if options != None:
+            copyCommand += " %s " % options
+        copyCommand += " %s " % sourcePFN
+        copyCommand += " %s 2> stageout.log" % targetPFN
+
+        result = self.debuggingTemplate.format(copy_command=copyCommand, source=sourcePFN, destination=targetPFN)
+        return result
+
     def removeFile(self, pfnToRemove):
         """
         _removeFile_

--- a/src/python/WMCore/Storage/Backends/TestFallbackToOldBackend.py
+++ b/src/python/WMCore/Storage/Backends/TestFallbackToOldBackend.py
@@ -96,6 +96,26 @@ class TestFallbackToOldBackendImpl(StageOutImpl):
         print(result)
         return result
 
+    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+        """
+        Debug a failed copy command for stageOut, without re-running it,
+        providing information on the environment and the certifications
+
+        :sourcePFN: str, PFN of the source file
+        :targetPFN: str, destination PFN
+        :options: str, additional options for copy command
+        :checksums: dict, collect checksums according to the algorithms saved as keys
+        """
+        # Build the command for debugging purposes
+        copyCommand = " /bin/cp "
+        if options != None:
+            copyCommand += " %s " % options
+        copyCommand += " %s " % sourcePFN
+        copyCommand += " %s " % targetPFN
+
+        result = self.debuggingTemplate.format(copy_command=copyCommand, source=sourcePFN, destination=targetPFN)
+        return result
+
     def removeFile(self, pfnToRemove):
         """
         _removeFile_

--- a/src/python/WMCore/Storage/Backends/UnittestImpl.py
+++ b/src/python/WMCore/Storage/Backends/UnittestImpl.py
@@ -21,13 +21,58 @@ class WinImpl(StageOutImpl):
     Test plugin that always returns success
 
     """
-    def createSourceName(self, protocol, lfn):
+    def createSourceName(self, protocol, pfn):
         return "WIN!!!"
 
 
     def createStageOutCommand(self, sourcePFN, targetPFN, options = None, checksums = None):
         print("WinImpl.createStageOutCommand(%s, %s, %s, %s)" % (sourcePFN, targetPFN, options, checksums))
         return "WIN!!!"
+
+
+    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+        """
+        Debug a failed unittest cp command for stageOut, without re-running it,
+        providing information on the environment and the certifications
+
+        :sourcePFN: str, PFN of the source file
+        :targetPFN: str, destination PFN
+        :options: str, additional options for copy command
+        :checksums: dict, collect checksums according to the algorithms saved as keys
+        """
+        # Build the command for debugging purposes
+        copyCommand = "WinImpl.createStageOutCommand(%s, %s, %s, %s)" % (sourcePFN, targetPFN, options, checksums)
+
+        result = "#!/bin/bash\n"
+        result += """
+        echo
+        echo
+        echo "-----------------------------------------------------------"
+        echo "==========================================================="
+        echo
+        echo "Debugging information on failing copy command"
+        echo
+        echo "Current date and time: $(date +"%Y-%m-%d %H:%M:%S")"
+        echo "copy command which failed: {copy_command}"
+        echo "Hostname:   $(hostname -f)"
+        echo "OS:  $(uname -r -s)"
+        echo
+        echo "PYTHON environment variables:"
+        env | grep ^PYTHON
+        echo
+        echo "LD_* environment variables:"
+        env | grep ^LD_
+        echo
+        echo "Source PFN: {source}"
+        echo "Target PFN: {destination}"
+        echo
+        echo "VOMS proxy info:"
+        voms-proxy-info -all
+        echo "==========================================================="
+        echo "-----------------------------------------------------------"
+        echo
+        """.format(copy_command=copyCommand, source=sourcePFN, destination=targetPFN)
+        return result
 
 
     def removeFile(self, pfnToRemove):
@@ -48,7 +93,7 @@ class FailImpl(StageOutImpl):
 
     """
 
-    def createSourceName(self, protocol, lfn):
+    def createSourceName(self, protocol, pfn):
         return "FAIL!!!"
 
 
@@ -56,6 +101,22 @@ class FailImpl(StageOutImpl):
         print("FailImpl.createStageOutCommand(%s, %s, %s, %s)" % (sourcePFN, targetPFN, options, checksums))
         return "FAIL!!!"
 
+
+    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+        """
+        Debug a failed unittest cp command for stageOut, without re-running it,
+        providing information on the environment and the certifications
+
+        :sourcePFN: str, PFN of the source file
+        :targetPFN: str, destination PFN
+        :options: str, additional options for copy command
+        :checksums: dict, collect checksums according to the algorithms saved as keys
+        """
+        # Build the command for debugging purposes
+        copyCommand = "FailImpl.createStageOutCommand(%s, %s, %s, %s)" % (sourcePFN, targetPFN, options, checksums)
+
+        result = self.debuggingTemplate.format(copy_command=copyCommand, source=sourcePFN, destination=targetPFN)
+        return result
 
     def removeFile(self, pfnToRemove):
         print("FailImpl.removeFile(%s)" % pfnToRemove)
@@ -100,6 +161,21 @@ class LocalCopyImpl(StageOutImpl):
         command = "cp %s %s" %(sourcePFN, sourcePFN+'2')
         return command
 
+    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+        """
+        Debug a failed unittest cp command for stageOut, without re-running it,
+        providing information on the environment and the certifications
+
+        :sourcePFN: str, PFN of the source file
+        :targetPFN: str, destination PFN
+        :options: str, additional options for copy command
+        :checksums: dict, collect checksums according to the algorithms saved as keys
+        """
+        # Build the command for debugging purposes
+        copyCommand = "cp %s %s" %(sourcePFN, sourcePFN+'2')
+
+        result = self.debuggingTemplate.format(copy_command=copyCommand, source=sourcePFN, destination=sourcePFN+'2')
+        return result
 
     def removeFile(self, pfnToRemove):
         command = "rm  %s" %pfnToRemove

--- a/src/python/WMCore/Storage/Backends/VandyImpl.py
+++ b/src/python/WMCore/Storage/Backends/VandyImpl.py
@@ -69,6 +69,26 @@ class VandyImpl(StageOutImpl):
             return "%s %s %s" % (self._downloadScript, sourcePFN, targetPFN)
         else:
             return "%s %s %s" % (self._cpScript, sourcePFN, targetPFN)
+        
+    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+        """
+        Debug a failed vandy copy command for stageOut, without re-running it,
+        providing information on the environment and the certifications
+
+        :sourcePFN: str, PFN of the source file
+        :targetPFN: str, destination PFN
+        :options: str, additional options for copy command
+        :checksums: dict, collect checksums according to the algorithms saved as keys
+        """
+        # Build the command for debugging purposes
+        copyCommand = ""
+        if self.stageIn:
+            copyCommand += "%s %s %s" % (self._downloadScript, sourcePFN, targetPFN)
+        else:
+            copyCommand += "%s %s %s" % (self._cpScript, sourcePFN, targetPFN)
+
+        result = self.debuggingTemplate.format(copy_command=copyCommand, source=sourcePFN, destination=targetPFN)
+        return result
 
     def removeFile(self, pfnToRemove):
 

--- a/src/python/WMCore/Storage/Backends/XRDCPImpl.py
+++ b/src/python/WMCore/Storage/Backends/XRDCPImpl.py
@@ -159,6 +159,23 @@ class XRDCPImpl(StageOutImpl):
             copyCommand += "else echo \"ERROR: XRootD file transfer return code is $RC. Size or Checksum Mismatch between local and SE\"; %s exit 60311 ; fi" % removeCommand
 
         return copyCommand
+    
+    def createDebuggingCommand(self, sourcePFN, targetPFN, options=None, checksums=None):
+        """
+        Debug a failed xrdcp command for stageOut, without re-running it,
+        providing information on the environment and the certifications
+
+        :sourcePFN: str, PFN of the source file
+        :targetPFN: str, destination PFN
+        :options: str, additional options for copy command
+        :checksums: dict, collect checksums according to the algorithms saved as keys
+        """
+        # Build the command for debugging purposes
+        copyCommandDict = self.buildCopyCommandDict(sourcePFN, targetPFN, options, checksums)
+        copyCommand = self.copyCommand.format_map(copyCommandDict)
+
+        result = self.debuggingTemplate.format(copy_command=copyCommand, source=copyCommandDict['source'], destination=copyCommandDict['destination'])
+        return result
 
     def removeFile(self, pfnToRemove):
         """

--- a/src/python/WMCore/Storage/StageOutImpl.py
+++ b/src/python/WMCore/Storage/StageOutImpl.py
@@ -37,6 +37,35 @@ class StageOutImpl:
         self.numRetries = 3
         self.retryPause = 600
         self.stageIn = stagein
+        self.debuggingTemplate =  "#!/bin/bash\n"
+        self.debuggingTemplate += """
+        echo
+        echo
+        echo "-----------------------------------------------------------"
+        echo "==========================================================="
+        echo
+        echo "Debugging information on failing copy command"
+        echo
+        echo "Current date and time: $(date +"%Y-%m-%d %H:%M:%S")"
+        echo "copy command which failed: {copy_command}"
+        echo "Hostname:   $(hostname -f)"
+        echo "OS:  $(uname -r -s)"
+        echo
+        echo "PYTHON environment variables:"
+        env | grep ^PYTHON
+        echo
+        echo "LD_* environment variables:"
+        env | grep ^LD_
+        echo
+        echo "Source PFN: {source}"
+        echo "Target PFN: {destination}"
+        echo
+        echo "VOMS proxy info:"
+        voms-proxy-info -all
+        echo "==========================================================="
+        echo "-----------------------------------------------------------"
+        echo
+        """
 
     @staticmethod
     def splitPFN(pfn):
@@ -148,7 +177,7 @@ class StageOutImpl:
         failing stageOut commands
         """
         raise NotImplementedError("StageOutImpl.createDebuggingCommand")
-
+    
     def removeFile(self, pfnToRemove):
         """
         _removeFile_


### PR DESCRIPTION
Fixes #12283 

#### Status
ready

#### Description
It introduces the `createDebuggingCommand` for all the stage-out submodules to avoid failures due to missing overriding of the StageOutImpl method with the same name.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
I suppose it doesn't
