### PR TITLE
_check_ustr() not defined, was merged into _check_str()

### DIFF
--- a/src/python/WMCore/REST/Validation.py
+++ b/src/python/WMCore/REST/Validation.py
@@ -231,7 +231,7 @@ def validate_ustrlist(argname, param, safe, rx, custom_err = None):
 
     Note that an array of zero length is accepted, meaning there were no
     `argname` parameters at all in `param.kwargs`."""
-    _validate_all(argname, param, safe, _check_ustr, rx, custom_err)
+    _validate_all(argname, param, safe, _check_str, rx, custom_err)
 
 def validate_numlist(argname, param, safe, bare=False, minval=None, maxval=None, custom_err = None):
     """Validates that an argument is an array of integers, as checked by


### PR DESCRIPTION
Fixes #10719 

#### Status
 not-tested

#### Description
This function _check_ustr() was removed and combined with _check_str() in #10757 , but the call was fixed only for validate_ustr() , not validate_ustrlist(). This validation function may not be used anymore, I see only calls in dmwm/sitedb (7 years old) and issue discussions in CRABServer(https://github.com/dmwm/CRABServer/issues/6624#issuecomment-855966958) from before #10757.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
#10757 

#### External dependencies / deployment changes
No
