### PR TITLE
Migrate to from queue_with_itemdata() to Schedd.submit()

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -165,9 +165,8 @@ class SimpleCondorPlugin(BasePlugin):
 
             logging.debug("Start: Submitting %d jobs using Condor Python Submit", len(jobParams))
             try:
-                with schedd.transaction() as txn:
-                    submitRes = sub.queue_with_itemdata(txn, 1, iter(jobParams))
-                    clusterId = submitRes.cluster()
+                submitRes = schedd.submit(sub, itemdata=iter(jobParams))
+                clusterId = submitRes.cluster()
             except Exception as ex:
                 logging.error("SimpleCondorPlugin job submission failed.")
                 logging.exception(str(ex))


### PR DESCRIPTION
Fixes #12238

#### Status
Ready

#### Description
Replace schedd.Transaction and queue_with_itemdata() with Schedd.submitt(), since the former has been deprecated since 10.7.0

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
HTCondor python bindings