### PR TITLE
collections.(Mapping|Iterable) moved to collections.abc.(Mapping|Iterable)

### DIFF
--- a/src/python/Utils/IteratorTools.py
+++ b/src/python/Utils/IteratorTools.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
 from builtins import str, map
-import collections
+import collections.abc
 from itertools import islice, chain, groupby
 
 def grouper(iterable, n):
@@ -43,7 +43,7 @@ def nestedDictUpdate(d, u):
     http://stackoverflow.com/questions/3232943/update-value-of-a-nested-dictionary-of-varying-depth
     """
     for k, v in u.items():
-        if isinstance(v, collections.Mapping):
+        if isinstance(v, collections.abc.Mapping):
             r = nestedDictUpdate(d.get(k, {}), v)
             d[k] = r
         else:
@@ -57,9 +57,9 @@ def convertFromUnicodeToBytes(data):
     """
     if isinstance(data, str):
         return data.encode('utf-8')
-    elif isinstance(data, collections.Mapping):
+    elif isinstance(data, collections.abc.Mapping):
         return dict(list(map(convertFromUnicodeToBytes, list(data.items()))))
-    elif isinstance(data, collections.Iterable):
+    elif isinstance(data, collections.abc.Iterable):
         return type(data)(list(map(convertFromUnicodeToBytes, data)))
     else:
         return data

--- a/src/python/WMCore/ReqMgr/Web/ReqMgrService.py
+++ b/src/python/WMCore/ReqMgr/Web/ReqMgrService.py
@@ -11,7 +11,7 @@ from builtins import str as newstr, bytes, map
 from future.utils import viewitems, viewvalues
 
 # system modules
-import collections
+import collections.abc
 import json
 import os
 import pprint
@@ -276,9 +276,9 @@ def priority_transition(docs):
 def toString(data):
     if isinstance(data, (newstr, bytes)):
         return str(data)
-    elif isinstance(data, collections.Mapping):
+    elif isinstance(data, collections.abc.Mapping):
         return dict(list(map(toString, viewitems(data))))
-    elif isinstance(data, collections.Iterable):
+    elif isinstance(data, collections.abc.Iterable):
         return type(data)(list(map(toString, data)))
     else:
         return data


### PR DESCRIPTION
Related #12208 

#### Status

manual tests in local shell, unittests look good

#### Description

as described here [1]:

> Remove deprecated aliases to [Collections Abstract Base Classes](https://docs.python.org/dev/library/collections.abc.html#collections-abstract-base-classes) from the [collections](https://docs.python.org/dev/library/collections.html#module-collections) module. (Contributed by Victor Stinner in [bpo-37324](https://bugs.python.org/issue?@action=redirect&bpo=37324).)

Now these classes work as follows [2]:

```plaintext
> python3
Python 3.8.20 (default, Feb 13 2025, 00:00:00)
[GCC 14.2.1 20250110 (Red Hat 14.2.1-7)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import collections
>>> collections.Mapping
<stdin>:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
<class 'collections.abc.Mapping'>
>>> collections.abc.Mapping
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib64/python3.8/collections/__init__.py", line 55, in __getattr__
    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
AttributeError: module 'collections' has no attribute 'abc'
>>> import collections.abc
>>> collections.abc.Mapping
<class 'collections.abc.Mapping'>
```

notice that the followings have not been moved [3]:

- `collections.defaultdict`
- `collections.Counter`
- `collections.deque`
- `collections.namedtuple`

#### Is it backward compatible (if not, which system it affects?)

YES.

The changes from this PR are compatible with py3.8 and py3.9. Moreover, they are necessary if we want to run py >=3.10

#### Related PRs

none

#### External dependencies / deployment changes

none

---

[1] https://docs.python.org/dev/whatsnew/3.10.html#removed
[2] https://docs.python.org/3/library/collections.abc.html#collections-abstract-base-classes
[3] https://docs.python.org/3/library/collections.html