### PR TITLE
python 3.11 - inspect.getargspec moved to inspect.getfullargspec

### DIFF
--- a/src/python/WMCore/REST/Server.py
+++ b/src/python/WMCore/REST/Server.py
@@ -680,7 +680,7 @@ class MiniRESTApi(object):
         :arg callable callable: The handler; see class documentation for signature.
         :arg list args: List of valid positional and keyword argument names.
           These will be copied to the API object which will be passed to the
-          validation methods. Normally you'd get these with inspect.getargspec().
+          validation methods. Normally you'd get these with inspect.getfullargspec().
         :arg callable validation: The validator; see class documentation for the
           signature and behavioural requirements. If `args` is non-empty,
           `validation` is mandatory; if `args` is empty, `callable` does not
@@ -2358,7 +2358,7 @@ def restcall(func=None, args=None, generate="result", **kwargs):
 
     The `args` should be the parameter names accepted by the decorated
     function. If `args` is the default None, the possible arguments are
-    extracted with :func:`inspect.getargspec`.
+    extracted with :func:`inspect.getfullargspec`.
 
     The `generate` argument sets the label used by output formatters to
     surround the output. The default is "result", yielding for example
@@ -2395,7 +2395,7 @@ def restcall(func=None, args=None, generate="result", **kwargs):
         if not func:
             raise ValueError("'restcall' must be applied to a function")
         if args == None:
-            args = [a for a in inspect.getargspec(func).args if a != 'self']
+            args = [a for a in inspect.getfullargspec(func).args if a != 'self']
         if args == None or not isinstance(args, list):
             raise ValueError("'args' must be defined")
         kwargs.update(generate=generate)


### PR DESCRIPTION
Related #12208 

#### Status

manual tests in my shell, unittests look good

#### Description

in python 3.11 the function `inspect.getargspec()` has been removed, [1]. `inspect.getfullargspec()` is intended to be a drop-in replacement [2].

these changes are compatible with python 3.8 [3] and are necessary to run our code in py>=3.11. 


#### Is it backward compatible (if not, which system it affects?)

yes

#### Related PRs

none

#### External dependencies / deployment changes

none

---

[1] https://docs.python.org/dev/whatsnew/3.11.html#removed
[2] https://docs.python.org/3.8/library/inspect.html#inspect.getfullargspec

> Deprecated since version 3.0: Use [getfullargspec()](https://docs.python.org/3.8/library/inspect.html#inspect.getfullargspec) for an updated API that is usually a drop-in replacement, but also correctly handles function annotations and keyword-only parameters.

[3]

<details><summary> tests </summary>

```python
# cat insp.py
import inspect

def test(a, b=None, c=10, *args, **kwargs):
    print("args")
    print(f" \\- {a}")
    print(f" \\- {b}")
    print(f" \\- {c}")
    print(f" \\- {args}")
    print(f" \\- {kwargs}")
    return

insp1 = inspect.getargspec(test)
print(insp1)
insp1 = inspect.getfullargspec(test)
print(insp1)
insp1 = inspect.signature(test)
print(insp1)

class MyClass:
    def test1(self, a):
        print(f"ciao {a}")
        return

insp2 = inspect.getargspec(MyClass.test1)
print(insp2)
insp2 = inspect.getfullargspec(MyClass.test1)
print(insp2)
insp2 = inspect.signature(MyClass.test1)
print(insp2)
```

notice that the new object `FullArgSpec` contains all the arguments that were present in `ArgSpec`

```plaintext
> python3
Python 3.8.20 (default, Feb 13 2025, 00:00:00)
[GCC 14.2.1 20250110 (Red Hat 14.2.1-7)] on linux
Type "help", "copyright", "credits" or "license" for more information.

> python3 insp.py
insp.py:13: DeprecationWarning: inspect.getargspec() is deprecated since Python 3.0, use inspect.signature() or inspect.getfullargspec()
  insp1 = inspect.getargspec(test)
ArgSpec(args=['a', 'b', 'c'], varargs='args', keywords='kwargs', defaults=(None, 10))
FullArgSpec(args=['a', 'b', 'c'], varargs='args', varkw='kwargs', defaults=(None, 10), kwonlyargs=[], kwonlydefaults=None, annotations={})
(a, b=None, c=10, *args, **kwargs)
insp.py:25: DeprecationWarning: inspect.getargspec() is deprecated since Python 3.0, use inspect.signature() or inspect.getfullargspec()
  insp2 = inspect.getargspec(MyClass.test1)
ArgSpec(args=['self', 'a'], varargs=None, keywords=None, defaults=None)
FullArgSpec(args=['self', 'a'], varargs=None, varkw=None, defaults=None, kwonlyargs=[], kwonlydefaults=None, annotations={})
(self, a)
```
</details>