### PR TITLE
Add WorkQueue.DataStructs.CouchWorkQueueElement as a dependency to reqmgr2

### DIFF
--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -104,6 +104,7 @@ dependencies = {
                      'Utils'],
         'modules': ['WMCore.WorkQueue.__init__',
                     'WMCore.WorkQueue.DataStructs.__init__',
+                    'WMCore.WorkQueue.DataStructs.CouchWorkQueueElement',
                     'WMCore.WorkQueue.DataStructs.WorkQueueElement'],
         'systems': ['wmc-rest', 'wmc-runtime', 'wmc-database'],
         'statics': ['src/couchapps/ReqMgr+',


### PR DESCRIPTION
Fixes #12244 (see [comment](https://github.com/dmwm/WMCore/issues/12244#issuecomment-2702171530))
Complement to https://github.com/dmwm/WMCore/pull/12245

#### Status
ready

#### Description
Fix a missing dependency for `reqmgr2` [1], which is required during build time.

Note that these dependencies are hard to test, so the best is to get this in and then verify the reqmgr2 package, once a new release is made.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Resolve issue introduced with https://github.com/dmwm/WMCore/pull/12245

#### External dependencies / deployment changes
[1]
```
  File "/usr/local/lib/python3.8/site-packages/WMCore/Services/WorkQueue/WorkQueue.py", line 9, in <module>
    from WMCore.WorkQueue.DataStructs.CouchWorkQueueElement import CouchWorkQueueElement
ModuleNotFoundError: No module named 'WMCore.WorkQueue.DataStructs.CouchWorkQueueElement'
```