### PR TITLE
python 3.13 - deprecate cgi module

### DIFF
--- a/src/python/WMCore/ReqMgr/Web/tools.py
+++ b/src/python/WMCore/ReqMgr/Web/tools.py
@@ -11,7 +11,6 @@ import json
 import logging
 import os
 import sys
-import cgi
 import types
 from datetime import datetime, timedelta
 from json import JSONEncoder
@@ -32,24 +31,6 @@ try:
 except:
     pass
 
-
-def quote(data):
-    """
-    Sanitize the data using cgi.escape.
-    """
-    if isinstance(data, (int, float, dict, list)):
-        res = data
-    else:
-        try:
-            if data:
-                res = cgi.escape(data, quote=True)
-            else:
-                res = ""
-        except Exception as exc:
-            print("Unable to cgi.escape(%s, quote=True)" % data)
-            print(exc)
-            res = ""
-    return res
 
 class Page(object):
     """
@@ -139,7 +120,6 @@ class TemplatedPage(Page):
         env = jinja2.Environment(loader=jinja2.FileSystemLoader(self.templatedir))
         for arg in args:
             kwargs.update(**arg)
-        kwargs.update(**{"quote":quote})
         tmpl = os.path.join(self.templatedir, ifile + '.tmpl')
         if  os.path.exists(tmpl):
             template = env.get_template(ifile + '.tmpl')

--- a/src/python/WMCore/ReqMgr/Web/utils.py
+++ b/src/python/WMCore/ReqMgr/Web/utils.py
@@ -17,7 +17,6 @@ from Utils.PythonVersion import PY3
 standard_library.install_aliases()
 
 # system modules
-import cgi
 import json
 import time
 import hashlib
@@ -38,23 +37,6 @@ def gen_color(val):
     keyhash.update(encodeUnicodeToBytesConditional(val, condition=PY3))
     col = '#%s' % keyhash.hexdigest()[:6]
     return col
-
-def quote(data):
-    """
-    Sanitize the data using cgi.escape.
-    """
-    if  isinstance(data, (int, float, dict, list)):
-        res = data
-    else:
-        try:
-            if  data:
-                res = cgi.escape(data, quote=True)
-            else:
-                res = ""
-        except Exception as exc:
-            print("Unable to cgi.escape(%s, quote=True)" % data)
-            res = ""
-    return res
 
 def json2form(jsondata, indent=2, keep_first_value=True):
     "Convert input json dict into one used by HTML form"

--- a/src/python/WMCore/WebTools/RESTApi.py
+++ b/src/python/WMCore/WebTools/RESTApi.py
@@ -19,7 +19,6 @@ active.rest.formatter.templates = '/templates/WMCore/WebTools/'
 
 """
 
-import cgi
 import traceback
 
 from cherrypy import expose, request, response, HTTPError
@@ -108,9 +107,6 @@ class RESTApi(WebAPI):
             # If something raises an HTTPError assume it's something that should
             # go to the client
             response.status = h.args[0]
-            for kwarg in kwargs:
-                if isinstance(kwargs[kwarg], cgi.FieldStorage):
-                    kwargs[kwarg] = 'FieldStorage class, not printed.'
             self.debug('call to %s with args: %s kwargs: %s resulted in %s' % (request.method, args, kwargs, h.args[1]))
             return self._formatResponse({'exception': h.args[0],
                                         'type': 'HTTPError',
@@ -120,9 +116,6 @@ class RESTApi(WebAPI):
             # If something raises a generic exception assume the details are private
             # and should not go to the client
             response.status = 500
-            for kwarg in kwargs:
-                if isinstance(kwargs[kwarg], cgi.FieldStorage):
-                    kwargs[kwarg] = 'FieldStorage class, not printed.'
             debugMsg = replaceToSantizeURL("""call to %s with args: %s kwargs: %s resulted in %s \n
                                               stack trace: %s""" % (request.method, args,
                                                      kwargs, e.__str__(), traceback.format_exc()))

--- a/test/python/WMCore_t/Services_t/PyCurlRESTModel.py
+++ b/test/python/WMCore_t/Services_t/PyCurlRESTModel.py
@@ -4,13 +4,8 @@ from WMQuality.WebTools.RESTServerSetup import DefaultConfig
 import WMCore
 
 import logging
-import unittest
 import threading
 import cherrypy
-import os
-import uuid
-import tempfile
-from cgi import FieldStorage
 
 def noBodyProcess():
     """Sets cherrypy.request.process_request_body = False, giving


### PR DESCRIPTION
Related to #12208 

#### Status

 - [x] manual tests
 - [x] unittests
 - [x] external reviews

#### Description

the module `cgi` has been considered a "dead battery" and removed from python standard library from python 3.13 [1].

List of the proposed changes:

- `src/python/WMCore/WebTools/RESTApi.py`: Removed mentions `cgi.FieldStorage`. It is not used anywhere else in the code, I do not see how these lines are still relevant.
- `src/python/WMCore/ReqMgr/Web/utils.py`: the function `quote()` does not seem to be used in this file, I removed it, so that i could remove the import of `cgi`.
- `src/python/WMCore/ReqMgr/Web/tools.py`: `cgi.escape()` has been removed since python 3.8 [2] and they suggest to use `html.escape()` instead. Since we have proper try/except clauses around `cgi.escape()`, this would not crash our service but emptying some data. Migrating to `html.escape()` is straightfoward so i just did it. Apparently, we use the function `quote` for jinja templates https://github.com/dmwm/WMCore/blob/d335ef6bdea7da49164da68a4ed3c5a464662842/src/python/WMCore/ReqMgr/Web/tools.py#L142 So I did not remove it just yet. However, I can not find any reference to that in these jinja templates [3], but maybe I am missing something. Since I would still prefer not to have functionality that we do not use,  @vkuznet, do you know or remember if we really-really-really need to revive this `tools.py:quote()` function? Do you think it's needed in any template? . Or can we remove it in the same way I did for `utils.py` and forget about `html.escape()`?

#### Is it backward compatible (if not, which system it affects?)

yes

#### Related PRs

none

#### External dependencies / deployment changes

none

---

[1] https://docs.python.org/dev/whatsnew/3.13.html#removed-modules-and-apis

[2] 

- python 3.8: `cgi.escape()` has been removed https://docs.python.org/dev/whatsnew/3.8.html#api-and-feature-removals
- python 3.7: `cgi.escape()` signature https://docs.python.org/3.7/library/cgi.html?highlight=cgi#module-cgi 
- python 3.13: `html.escape()` signature https://docs.python.org/3/library/html.html - identical to `cgi.escape()`
- python3.8: `cgi.escape()` is no longer there https://docs.python.org/3.8/library/cgi.html?highlight=cgi#functions

[3] https://github.com/dmwm/WMCore/tree/master/src/html/ReqMgr/jinja_templates