### PR TITLE
T0 to produce skimmed RAW data through Repack Workflow

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/Repack.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Repack.py
@@ -50,8 +50,9 @@ class RepackWorkloadFactory(StdBase):
 
         # complete output configuration
         for output in self.outputs:
-            output['moduleLabel'] = "write_%s_%s" % (output['primaryDataset'],
-                                                     output['dataTier'])
+            moduleLabel = "write_%s_%s" % (output['primaryDataset'],
+                                           output['dataTier'])
+            output['moduleLabel'] = moduleLabel.replace("-", "_")  # For T0 Raw Skims, PDs will contain a "-", so here we replace for "_" for the moduleLabel
 
         # finalize splitting parameters
         mySplitArgs = self.repackSplitArgs.copy()
@@ -61,7 +62,8 @@ class RepackWorkloadFactory(StdBase):
         repackOutMods = self.setupProcessingTask(repackTask, taskType,
                                                  scenarioName=self.procScenario,
                                                  scenarioFunc="repack",
-                                                 scenarioArgs={'outputs': self.outputs},
+                                                 scenarioArgs={'outputs': self.outputs,
+                                                               'globalTag': self.globalTag},
                                                  splitAlgo="Repack",
                                                  splitArgs=mySplitArgs,
                                                  stepType=cmsswStepType)
@@ -139,12 +141,14 @@ class RepackWorkloadFactory(StdBase):
                              primaryDataset=getattr(parentOutputModule, "primaryDataset"),
                              dataTier=getattr(parentOutputModule, "dataTier"),
                              filterName=getattr(parentOutputModule, "filterName"),
+                             rawSkim=getattr(parentOutputModule, "rawSkim", None),
                              forceMerged=True)
 
         self.addOutputModule(mergeTask, "MergedError",
                              primaryDataset=getattr(parentOutputModule, "primaryDataset") + "-Error",
                              dataTier=getattr(parentOutputModule, "dataTier"),
                              filterName=getattr(parentOutputModule, "filterName"),
+                             rawSkim=getattr(parentOutputModule, "rawSkim", None),
                              forceMerged=True)
 
         self.addCleanupTask(parentTask, parentOutputModuleName, dataTier=getattr(parentOutputModule, "dataTier"))
@@ -186,7 +190,7 @@ class RepackWorkloadFactory(StdBase):
         specArgs = {"RequestType": {"default": "Repack"},
                     "ConfigCacheID": {"optional": True, "null": True},
                     "Scenario": {"default": "fake", "attr": "procScenario"},
-                    "GlobalTag": {"default": "fake"},
+                    "GlobalTag": {"default": "fake", "attr": "globalTag"},
                     "ProcessingString": {"default": "", "validate": procstringT0},
                     "Outputs": {"type": makeList, "optional": False},
                     "MaxSizeSingleLumi": {"type": int, "optional": False},

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -223,6 +223,8 @@ class StdBase(object):
                     outputModules[moduleLabel] = {'dataTier': output['dataTier']}
                     if 'primaryDataset' in output:
                         outputModules[moduleLabel]['primaryDataset'] = output['primaryDataset']
+                    if 'rawSkim' in output:
+                        outputModules[moduleLabel]['rawSkim'] = output['rawSkim']
                     if 'filterName' in output:
                         outputModules[moduleLabel]['filterName'] = output['filterName']
 
@@ -467,6 +469,7 @@ class StdBase(object):
                                                                                    self.inputPrimaryDataset),
                                                 configOutput[outputModuleName]['dataTier'],
                                                 configOutput[outputModuleName].get('filterName', None),
+                                                configOutput[outputModuleName].get('rawSkim', None),
                                                 forceMerged=forceMerged, forceUnmerged=forceUnmerged, taskConf=taskConf)
             outputModules[outputModuleName] = outputModule
 
@@ -507,6 +510,7 @@ class StdBase(object):
 
     def addOutputModule(self, parentTask, outputModuleName,
                         primaryDataset, dataTier, filterName,
+                        rawSkim=None,
                         stepName="cmsRun1", forceMerged=False,
                         forceUnmerged=False, taskConf=None):
         """
@@ -583,6 +587,7 @@ class StdBase(object):
                                         processedDataset=processedDataset,
                                         dataTier=dataTier,
                                         filterName=filterName,
+                                        rawSkim=rawSkim,
                                         lfnBase=unmergedLFN,
                                         mergedLFNBase=mergedLFN,
                                         transient=isTransient)
@@ -590,7 +595,8 @@ class StdBase(object):
         return {"primaryDataset": primaryDataset,
                 "dataTier": dataTier,
                 "processedDataset": processedDataset,
-                "filterName": filterName}
+                "filterName": filterName,
+                "rawSkim": rawSkim}
 
     def addLogCollectTask(self, parentTask, taskName="LogCollect", filesPerJob=500,
                           cmsswVersion=None, scramArch=None):

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Repack_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Repack_t.py
@@ -40,12 +40,24 @@ REQUEST = {
     'Outputs': [{'dataTier': "RAW",
                  'eventContent': "All",
                  'selectEvents': ["Path1:HLT,Path2:HLT"],
-                 'primaryDataset': "PrimaryDataset1"},
+                 'primaryDataset': "PrimaryDataset1",
+                 'rawSkim': None},
+                {'dataTier': "RAW",
+                 'eventContent': "All",
+                 'selectEvents': ["Path1:HLT,Path2:HLT"],
+                 'primaryDataset': "PrimaryDataset2",
+                 'rawSkim': None},
+                {'dataTier': "RAW",
+                 'eventContent': "All",
+                 'selectEvents': ["Path1:HLT,Path2:HLT"],
+                 'primaryDataset': "PrimaryDataset1-rawSkim1",
+                 'rawSkim': "rawSkim1"},
                 {'dataTier': "RAW",
                  'eventContent': "All",
                  'selectEvents': ["Path3:HLT,Path4:HLT"],
-                 'primaryDataset': "PrimaryDataset2"}]
-}
+                 'primaryDataset': "PrimaryDataset2-rawSkim2",
+                 'rawSkim': "rawSkim2"}]
+    }
 
 
 class RepackTests(unittest.TestCase):
@@ -242,7 +254,7 @@ class RepackTests(unittest.TestCase):
     def testMemCoresSettings(self):
         """
         _testMemCoresSettings_
-        
+
         Make sure the multicore and memory setings are properly propagated to
         all tasks and steps.
         """
@@ -299,15 +311,23 @@ class RepackTests(unittest.TestCase):
         # expected tasks, filesets, subscriptions, etc
         expOutTasks = ['/TestWorkload/Repack',
                        '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset1_RAW',
-                       '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset2_RAW']
+                       '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset2_RAW',
+                       '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset1_rawSkim1_RAW',
+                       '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset2_rawSkim2_RAW']
         expWfTasks = ['/TestWorkload/Repack',
                       '/TestWorkload/Repack/LogCollect',
                       '/TestWorkload/Repack/RepackCleanupUnmergedwrite_PrimaryDataset1_RAW',
                       '/TestWorkload/Repack/RepackCleanupUnmergedwrite_PrimaryDataset2_RAW',
+                      '/TestWorkload/Repack/RepackCleanupUnmergedwrite_PrimaryDataset1_rawSkim1_RAW',
+                      '/TestWorkload/Repack/RepackCleanupUnmergedwrite_PrimaryDataset2_rawSkim2_RAW',
                       '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset1_RAW',
                       '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset1_RAW/Repackwrite_PrimaryDataset1_RAWMergeLogCollect',
                       '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset2_RAW',
-                      '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset2_RAW/Repackwrite_PrimaryDataset2_RAWMergeLogCollect']
+                      '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset2_RAW/Repackwrite_PrimaryDataset2_RAWMergeLogCollect',
+                      '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset1_rawSkim1_RAW',
+                      '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset1_rawSkim1_RAW/Repackwrite_PrimaryDataset1_rawSkim1_RAWMergeLogCollect',
+                      '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset2_rawSkim2_RAW',
+                      '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset2_rawSkim2_RAW/Repackwrite_PrimaryDataset2_rawSkim2_RAWMergeLogCollect']
         expFsets = ['TestWorkload-Repack-StreamerFiles',
                     '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset1_RAW/merged-logArchive',
                     '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset1_RAW/merged-MergedRAW',
@@ -315,20 +335,38 @@ class RepackTests(unittest.TestCase):
                     '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset2_RAW/merged-logArchive',
                     '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset2_RAW/merged-MergedRAW',
                     '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset2_RAW/merged-MergedErrorRAW',
+                    '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset1_rawSkim1_RAW/merged-logArchive',
+                    '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset1_rawSkim1_RAW/merged-MergedRAW',
+                    '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset1_rawSkim1_RAW/merged-MergedErrorRAW',
+                    '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset2_rawSkim2_RAW/merged-logArchive',
+                    '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset2_rawSkim2_RAW/merged-MergedRAW',
+                    '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset2_rawSkim2_RAW/merged-MergedErrorRAW',
                     '/TestWorkload/Repack/unmerged-write_PrimaryDataset1_RAWRAW',
                     '/TestWorkload/Repack/unmerged-write_PrimaryDataset2_RAWRAW',
+                    '/TestWorkload/Repack/unmerged-write_PrimaryDataset1_rawSkim1_RAWRAW',
+                    '/TestWorkload/Repack/unmerged-write_PrimaryDataset2_rawSkim2_RAWRAW',
                     '/TestWorkload/Repack/unmerged-logArchive']
         subMaps = [(4,
                     '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset1_RAW/merged-logArchive',
                     '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset1_RAW/Repackwrite_PrimaryDataset1_RAWMergeLogCollect',
                     'MinFileBased',
                     'LogCollect'),
-                   (7,
+                   (10,
                     '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset2_RAW/merged-logArchive',
                     '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset2_RAW/Repackwrite_PrimaryDataset2_RAWMergeLogCollect',
                     'MinFileBased',
                     'LogCollect'),
-                   (8,
+                   (7,
+                    '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset1_rawSkim1_RAW/merged-logArchive',
+                    '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset1_rawSkim1_RAW/Repackwrite_PrimaryDataset1_rawSkim1_RAWMergeLogCollect',
+                    'MinFileBased',
+                    'LogCollect'),
+                   (13,
+                    '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset2_rawSkim2_RAW/merged-logArchive',
+                    '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset2_rawSkim2_RAW/Repackwrite_PrimaryDataset2_rawSkim2_RAWMergeLogCollect',
+                    'MinFileBased',
+                    'LogCollect'),
+                   (14,
                     '/TestWorkload/Repack/unmerged-logArchive',
                     '/TestWorkload/Repack/LogCollect',
                     'MinFileBased',
@@ -343,14 +381,34 @@ class RepackTests(unittest.TestCase):
                     '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset1_RAW',
                     'RepackMerge',
                     'Merge'),
-                   (5,
+                   (8,
                     '/TestWorkload/Repack/unmerged-write_PrimaryDataset2_RAWRAW',
                     '/TestWorkload/Repack/RepackCleanupUnmergedwrite_PrimaryDataset2_RAW',
                     'SiblingProcessingBased',
                     'Cleanup'),
-                   (6,
+                   (9,
                     '/TestWorkload/Repack/unmerged-write_PrimaryDataset2_RAWRAW',
                     '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset2_RAW',
+                    'RepackMerge',
+                    'Merge'),
+                   (5,
+                    '/TestWorkload/Repack/unmerged-write_PrimaryDataset1_rawSkim1_RAWRAW',
+                    '/TestWorkload/Repack/RepackCleanupUnmergedwrite_PrimaryDataset1_rawSkim1_RAW',
+                    'SiblingProcessingBased',
+                    'Cleanup'),
+                   (6,
+                    '/TestWorkload/Repack/unmerged-write_PrimaryDataset1_rawSkim1_RAWRAW',
+                    '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset1_rawSkim1_RAW',
+                    'RepackMerge',
+                    'Merge'),
+                   (11, 
+                    '/TestWorkload/Repack/unmerged-write_PrimaryDataset2_rawSkim2_RAWRAW',
+                    '/TestWorkload/Repack/RepackCleanupUnmergedwrite_PrimaryDataset2_rawSkim2_RAW',
+                    'SiblingProcessingBased',
+                    'Cleanup'),
+                   (12,
+                    '/TestWorkload/Repack/unmerged-write_PrimaryDataset2_rawSkim2_RAWRAW',
+                    '/TestWorkload/Repack/RepackMergewrite_PrimaryDataset2_rawSkim2_RAW',
                     'RepackMerge',
                     'Merge'),
                    (1,
@@ -358,6 +416,8 @@ class RepackTests(unittest.TestCase):
                     '/TestWorkload/Repack',
                     'Repack',
                     'Repack')]
+
+        self.maxDiff = None
 
         testArguments = RepackWorkloadFactory.getTestArguments()
         testArguments.update(deepcopy(REQUEST))


### PR DESCRIPTION
Fixes #12297 

#### Status
Ready

#### Description
In order to support the new `raw skim` datasets, we need to allow two things:
* The `moduleLabel` in [Repack.py](https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/WMSpec/StdSpecs/Repack.py#L53) can't have `-` in its name, so we introduce the parameter `parentDataset` in `Outputs`. This way we can create a legal name for `moduleLabel`:
```
output['moduleLabel'] = "write_%s_RawSkim_%s_%s" % (output['parentDataset'],
                                                                                             output['rawSkim'],
                                                                                             output['dataTier'])
``` 
We then delete the new attribute similarly to what is done in [setupProcessingTask](https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/WMSpec/StdSpecs/StdBase.py#L480).

* The repack workflow needs to pass a global tag to CMSSW in order to use the desired trigger paths.
* 
#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
T0 PR: https://github.com/dmwm/T0/pull/5041
CMSSW PR: 

#### External dependencies / deployment changes
NO
