### PR TITLE
Remove unused mod-config CRABInterface section (followup to #8926)

### DIFF
--- a/bin/wmagent-mod-config
+++ b/bin/wmagent-mod-config
@@ -191,19 +191,6 @@ def modifyConfiguration(config, **args):
         if "ops_proxy" in args:
             config.RetryManager.opsProxy = args["ops_proxy"]
 
-    if hasattr(config, "CRABInterface"):
-        config.CRABInterface.Webtools.host = args["cs_hostname"]
-        config.CRABInterface.Webtools.port = int(args["cs_port"])
-        config.CRABInterface.serverDN = args["host_dn"]
-        config.CRABInterface.views.active.crab.model.couchUrl = args["couch_url"]
-        config.CRABInterface.views.active.crab.jsmCacheCouchURL = args["couch_url"]
-        config.CRABInterface.ACDCCouchURL = args["couch_url"]
-        config.CRABInterface.configCacheCouchURL = args["couch_url"]
-        config.CRABInterface.sandBoxCacheHost = args["sb_hostname"]
-        config.CRABInterface.sandBoxCachePort = int(args["sb_port"])
-        config.CRABInterface.sandBoxCacheBasepath = 'userfilecache/userfilecache'
-        config.CRABInterface.clientMapping = args["client_mapping"]
-
     if hasattr(config, "UserFileCache"):
         config.UserFileCache.Webtools.host = args["ufc_hostname"]
         config.UserFileCache.Webtools.port = int(args["ufc_port"])


### PR DESCRIPTION
Fixes #12299 

#### Status
not-tested 

#### Description
This section was maybe used by AsyncStageout in 2018 (archived since 2022), let's see if any tests fail.
In addition to the two variables I noted in the issue #12299 , at least sandboxCacheBasepath is also unused anywhere on Github.

#### Is it backward compatible (if not, which system it affects?)
MAYBE

#### Related PRs
#8926 

#### External dependencies / deployment changes
If no config has this section defined, then removing this should cause no changes in deployment
